### PR TITLE
WebGPU updates: header, WGPU_WHOLE_SIZE, map offset size handling

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -91,7 +91,7 @@
     // Must be in sync with webgpu.h.
     COPY_STRIDE_UNDEFINED: 0xFFFFFFFF,
     LIMIT_U32_UNDEFINED: 0xFFFFFFFF,
-    WHOLE_MAP_SIZE: -1, // indicate 32-bit uint max
+    WHOLE_MAP_SIZE: 0xFFFFFFFF, // use 32-bit uint max
     AdapterType: {
       Unknown: 3,
     },
@@ -1815,7 +1815,7 @@ var LibraryWebGPU = {
     var bufferWrapper = WebGPU.mgrBuffer.objects[bufferId];
     {{{ gpu.makeCheckDefined('bufferWrapper') }}}
 
-    if (size === {{{ gpu.WHOLE_MAP_SIZE }}}) size = undefined;
+    if ((size >>> 0) === {{{ gpu.WHOLE_MAP_SIZE }}}) size = undefined;
 
     var mapped;
     try {
@@ -1842,7 +1842,7 @@ var LibraryWebGPU = {
     var bufferWrapper = WebGPU.mgrBuffer.objects[bufferId];
     {{{ gpu.makeCheckDefined('bufferWrapper') }}}
 
-    if (size === {{{ gpu.WHOLE_MAP_SIZE }}}) size = undefined;
+    if ((size >>> 0) === {{{ gpu.WHOLE_MAP_SIZE }}}) size = undefined;
 
     if (bufferWrapper.mapMode !== {{{ gpu.MapMode.Write }}}) {
 #if ASSERTIONS
@@ -1887,7 +1887,7 @@ var LibraryWebGPU = {
     bufferWrapper.onUnmap = [];
     var buffer = bufferWrapper.object;
 
-    if (size === {{{ gpu.WHOLE_MAP_SIZE }}}) size = undefined;
+    if ((size >>> 0) === {{{ gpu.WHOLE_MAP_SIZE }}}) size = undefined;
 
     // `callback` takes (WGPUBufferMapAsyncStatus status, void * userdata)
 

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -729,7 +729,7 @@ var LibraryWebGPU = {
     return queueId;
   },
 
-  wgpuDeviceHasFeatures: function(deviceId, feature) {
+  wgpuDeviceHasFeature: function(deviceId, feature) {
     abort('TODO: wgpuDeviceHasFeatures unimplemented');
   },
 

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -672,7 +672,13 @@ var LibraryWebGPU = {
   // wgpuDevice
 
   wgpuDeviceEnumerateFeatures: function(deviceId, featuresOutPtr) {
-    abort('TODO: wgpuDeviceEnumerateFeatures unimplemented');
+    var device = WebGPU.mgrDevice.get(deviceId);
+    var offset = 0;
+    for (var feature of device.features) {
+      var featureEnumValue = WebGPU.FeatureNameString2Enum[feature];
+      {{{ makeSetValue('featuresOutPtr', 'offset', 'featureEnumValue', 'i32') }}};
+      offset += 4;
+    }
   },
 
   wgpuDeviceDestroy: function(deviceId) { WebGPU.mgrDevice.get(deviceId)["destroy"](); },
@@ -729,8 +735,9 @@ var LibraryWebGPU = {
     return queueId;
   },
 
-  wgpuDeviceHasFeature: function(deviceId, feature) {
-    abort('TODO: wgpuDeviceHasFeatures unimplemented');
+  wgpuDeviceHasFeature: function(deviceId, featureEnumValue) {
+    var device = WebGPU.mgrDevice.get(deviceId);
+    return device.features.has(WebGPU.FeatureName[featureEnumValue]);
   },
 
   wgpuDevicePushErrorScope: function(deviceId, filter) {
@@ -2398,7 +2405,13 @@ var LibraryWebGPU = {
   // WGPUAdapter
 
   wgpuAdapterEnumerateFeatures: function(adapterId, featuresOutPtr) {
-    abort('TODO: wgpuAdapterEnumerateFeatures unimplemented');
+    var adapter = WebGPU.mgrAdapter.get(adapterId);
+    var offset = 0;
+    for (var feature of adapter.features) {
+      var featureEnumValue = WebGPU.FeatureNameString2Enum[feature];
+      {{{ makeSetValue('featuresOutPtr', 'offset', 'featureEnumValue', 'i32') }}};
+      offset += 4;
+    }
   },
 
   wgpuAdapterGetProperties: function(adapterId, properties) {
@@ -2415,8 +2428,9 @@ var LibraryWebGPU = {
     abort('TODO: wgpuAdapterGetLimits unimplemented');
   },
 
-  wgpuAdapterHasFeature: function(adapterId, feature) {
-    abort('TODO: wgpuAdapterHasFeature unimplemented');
+  wgpuAdapterHasFeature: function(adapterId, featureEnumValue) {
+    var adapter = WebGPU.mgrAdapter.get(adapterId);
+    return adapter.features.has(WebGPU.FeatureName[featureEnumValue]);
   },
 
   wgpuAdapterRequestDevice__deps: [
@@ -2584,6 +2598,12 @@ var LibraryWebGPU = {
     return 0;
   },
 };
+
+// Inverted index used by EnumerateFeatures/HasFeature
+LibraryWebGPU.$WebGPU.FeatureNameString2Enum = {};
+for (var value in LibraryWebGPU.$WebGPU.FeatureName) {
+  LibraryWebGPU.$WebGPU.FeatureNameString2Enum[LibraryWebGPU.$WebGPU.FeatureName[value]] = value;
+}
 
 autoAddDeps(LibraryWebGPU, '$WebGPU');
 mergeInto(LibraryManager.library, LibraryWebGPU);

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1449,6 +1449,13 @@ var LibraryWebGPU = {
     return WebGPU.mgrShaderModule.create(device["createShaderModule"](desc));
   },
 
+  // wgpuQuerySet
+
+  wgpuQuerySetSetLabel: function(querySetId, labelPtr) {
+    var querySet = WebGPU.mgrQuerySet.get(querySetId);
+    querySet.label = UTF8ToString(labelPtr);
+  },
+
   // wgpuQueue
 
   wgpuQueueSetLabel: function(queueId, labelPtr) {

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -401,6 +401,11 @@ var LibraryWebGPU = {
       'uint16',
       'uint32',
     ],
+    LoadOp: [
+      undefined,
+      'clear',
+      'load',
+    ],
     PipelineStatisticName: [
       'vertex-shader-invocations',
       'clipper-invocations',

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1185,9 +1185,10 @@
                 "offset",
                 "length"
             ],
-            "WGPUComputePassDescriptor": [
-                "nextInChain",
-                "label"
+            "WGPUComputePassTimestampWrite": [
+                "querySet",
+                "queryIndex",
+                "location"
             ],
             "WGPUConstantEntry": [
                 "nextInChain",
@@ -1270,6 +1271,10 @@
                 "pipelineStatistics",
                 "pipelineStatisticsCount"
             ],
+            "WGPUQueueDescriptor": [
+                "nextInChain",
+                "label"
+            ],
             "WGPURenderBundleDescriptor": [
                 "nextInChain",
                 "label"
@@ -1294,6 +1299,11 @@
                 "stencilStoreOp",
                 "stencilClearValue",
                 "stencilReadOnly"
+            ],
+            "WGPURenderPassTimestampWrite": [
+                "querySet",
+                "queryIndex",
+                "location"
             ],
             "WGPURequestAdapterOptions": [
                 "nextInChain",
@@ -1414,6 +1424,12 @@
                 "messageCount",
                 "messages"
             ],
+            "WGPUComputePassDescriptor": [
+                "nextInChain",
+                "label",
+                "timestampWriteCount",
+                "timestampWrites"
+            ],
             "WGPUDepthStencilState": [
                 "nextInChain",
                 "format",
@@ -1469,7 +1485,9 @@
                 "size",
                 "format",
                 "mipLevelCount",
-                "sampleCount"
+                "sampleCount",
+                "viewFormatCount",
+                "viewFormats"
             ],
             "WGPUVertexBufferLayout": [
                 "arrayStride",
@@ -1500,7 +1518,8 @@
                 "label",
                 "requiredFeaturesCount",
                 "requiredFeatures",
-                "requiredLimits"
+                "requiredLimits",
+                "defaultQueue"
             ],
             "WGPURenderPassDescriptor": [
                 "nextInChain",
@@ -1508,7 +1527,9 @@
                 "colorAttachmentCount",
                 "colorAttachments",
                 "depthStencilAttachment",
-                "occlusionQuerySet"
+                "occlusionQuerySet",
+                "timestampWriteCount",
+                "timestampWrites"
             ],
             "WGPUVertexState": [
                 "nextInChain",

--- a/system/include/webgpu/webgpu_cpp.h
+++ b/system/include/webgpu/webgpu_cpp.h
@@ -225,6 +225,11 @@ namespace wgpu {
         Info = 0x00000002,
     };
 
+    enum class ComputePassTimestampLocation : uint32_t {
+        Beginning = 0x00000000,
+        End = 0x00000001,
+    };
+
     enum class CreatePipelineAsyncStatus : uint32_t {
         Success = 0x00000000,
         Error = 0x00000001,
@@ -337,6 +342,11 @@ namespace wgpu {
         Error = 0x00000001,
         Unknown = 0x00000002,
         DeviceLost = 0x00000003,
+    };
+
+    enum class RenderPassTimestampLocation : uint32_t {
+        Beginning = 0x00000000,
+        End = 0x00000001,
     };
 
     enum class RequestAdapterStatus : uint32_t {
@@ -657,7 +667,7 @@ namespace wgpu {
     struct CommandBufferDescriptor;
     struct CommandEncoderDescriptor;
     struct CompilationMessage;
-    struct ComputePassDescriptor;
+    struct ComputePassTimestampWrite;
     struct ConstantEntry;
     struct Extent3D;
     struct InstanceDescriptor;
@@ -669,9 +679,11 @@ namespace wgpu {
     struct PrimitiveDepthClipControl;
     struct PrimitiveState;
     struct QuerySetDescriptor;
+    struct QueueDescriptor;
     struct RenderBundleDescriptor;
     struct RenderBundleEncoderDescriptor;
     struct RenderPassDepthStencilAttachment;
+    struct RenderPassTimestampWrite;
     struct RequestAdapterOptions;
     struct SamplerBindingLayout;
     struct SamplerDescriptor;
@@ -691,6 +703,7 @@ namespace wgpu {
     struct BindGroupLayoutEntry;
     struct BlendState;
     struct CompilationInfo;
+    struct ComputePassDescriptor;
     struct DepthStencilState;
     struct ImageCopyBuffer;
     struct ImageCopyTexture;
@@ -791,6 +804,7 @@ namespace wgpu {
         using ObjectBase::ObjectBase;
         using ObjectBase::operator=;
 
+        size_t EnumerateFeatures(FeatureName * features) const;
         bool GetLimits(SupportedLimits * limits) const;
         void GetProperties(AdapterProperties * properties) const;
         bool HasFeature(FeatureName feature) const;
@@ -807,6 +821,7 @@ namespace wgpu {
         using ObjectBase::ObjectBase;
         using ObjectBase::operator=;
 
+        void SetLabel(char const * label) const;
 
       private:
         friend ObjectBase<BindGroup, WGPUBindGroup>;
@@ -819,6 +834,7 @@ namespace wgpu {
         using ObjectBase::ObjectBase;
         using ObjectBase::operator=;
 
+        void SetLabel(char const * label) const;
 
       private:
         friend ObjectBase<BindGroupLayout, WGPUBindGroupLayout>;
@@ -832,9 +848,10 @@ namespace wgpu {
         using ObjectBase::operator=;
 
         void Destroy() const;
-        void const * GetConstMappedRange(size_t offset = 0, size_t size = 0) const;
-        void * GetMappedRange(size_t offset = 0, size_t size = 0) const;
+        void const * GetConstMappedRange(size_t offset = 0, size_t size = WGPU_WHOLE_MAP_SIZE) const;
+        void * GetMappedRange(size_t offset = 0, size_t size = WGPU_WHOLE_MAP_SIZE) const;
         void MapAsync(MapMode mode, size_t offset, size_t size, BufferMapCallback callback, void * userdata) const;
+        void SetLabel(char const * label) const;
         void Unmap() const;
 
       private:
@@ -848,6 +865,7 @@ namespace wgpu {
         using ObjectBase::ObjectBase;
         using ObjectBase::operator=;
 
+        void SetLabel(char const * label) const;
 
       private:
         friend ObjectBase<CommandBuffer, WGPUCommandBuffer>;
@@ -872,6 +890,7 @@ namespace wgpu {
         void PopDebugGroup() const;
         void PushDebugGroup(char const * groupLabel) const;
         void ResolveQuerySet(QuerySet const& querySet, uint32_t firstQuery, uint32_t queryCount, Buffer const& destination, uint64_t destinationOffset) const;
+        void SetLabel(char const * label) const;
         void WriteTimestamp(QuerySet const& querySet, uint32_t queryIndex) const;
 
       private:
@@ -886,14 +905,15 @@ namespace wgpu {
         using ObjectBase::operator=;
 
         void BeginPipelineStatisticsQuery(QuerySet const& querySet, uint32_t queryIndex) const;
-        void Dispatch(uint32_t workgroupCountX, uint32_t workgroupCountY = 1, uint32_t workgroupCountZ = 1) const;
-        void DispatchIndirect(Buffer const& indirectBuffer, uint64_t indirectOffset) const;
+        void DispatchWorkgroups(uint32_t workgroupCountX, uint32_t workgroupCountY = 1, uint32_t workgroupCountZ = 1) const;
+        void DispatchWorkgroupsIndirect(Buffer const& indirectBuffer, uint64_t indirectOffset) const;
         void End() const;
         void EndPipelineStatisticsQuery() const;
         void InsertDebugMarker(char const * markerLabel) const;
         void PopDebugGroup() const;
         void PushDebugGroup(char const * groupLabel) const;
         void SetBindGroup(uint32_t groupIndex, BindGroup const& group, uint32_t dynamicOffsetCount = 0, uint32_t const * dynamicOffsets = nullptr) const;
+        void SetLabel(char const * label) const;
         void SetPipeline(ComputePipeline const& pipeline) const;
         void WriteTimestamp(QuerySet const& querySet, uint32_t queryIndex) const;
 
@@ -938,11 +958,14 @@ namespace wgpu {
         SwapChain CreateSwapChain(Surface const& surface, SwapChainDescriptor const * descriptor) const;
         Texture CreateTexture(TextureDescriptor const * descriptor) const;
         void Destroy() const;
+        size_t EnumerateFeatures(FeatureName * features) const;
         bool GetLimits(SupportedLimits * limits) const;
         Queue GetQueue() const;
+        bool HasFeature(FeatureName feature) const;
         bool PopErrorScope(ErrorCallback callback, void * userdata) const;
         void PushErrorScope(ErrorFilter filter) const;
         void SetDeviceLostCallback(DeviceLostCallback callback, void * userdata) const;
+        void SetLabel(char const * label) const;
         void SetUncapturedErrorCallback(ErrorCallback callback, void * userdata) const;
 
       private:
@@ -971,6 +994,7 @@ namespace wgpu {
         using ObjectBase::ObjectBase;
         using ObjectBase::operator=;
 
+        void SetLabel(char const * label) const;
 
       private:
         friend ObjectBase<PipelineLayout, WGPUPipelineLayout>;
@@ -984,6 +1008,7 @@ namespace wgpu {
         using ObjectBase::operator=;
 
         void Destroy() const;
+        void SetLabel(char const * label) const;
 
       private:
         friend ObjectBase<QuerySet, WGPUQuerySet>;
@@ -997,6 +1022,7 @@ namespace wgpu {
         using ObjectBase::operator=;
 
         void OnSubmittedWorkDone(uint64_t signalValue, QueueWorkDoneCallback callback, void * userdata) const;
+        void SetLabel(char const * label) const;
         void Submit(uint32_t commandCount, CommandBuffer const * commands) const;
         void WriteBuffer(Buffer const& buffer, uint64_t bufferOffset, void const * data, size_t size) const;
         void WriteTexture(ImageCopyTexture const * destination, void const * data, size_t dataSize, TextureDataLayout const * dataLayout, Extent3D const * writeSize) const;
@@ -1034,6 +1060,7 @@ namespace wgpu {
         void PushDebugGroup(char const * groupLabel) const;
         void SetBindGroup(uint32_t groupIndex, BindGroup const& group, uint32_t dynamicOffsetCount = 0, uint32_t const * dynamicOffsets = nullptr) const;
         void SetIndexBuffer(Buffer const& buffer, IndexFormat format, uint64_t offset = 0, uint64_t size = WGPU_WHOLE_SIZE) const;
+        void SetLabel(char const * label) const;
         void SetPipeline(RenderPipeline const& pipeline) const;
         void SetVertexBuffer(uint32_t slot, Buffer const& buffer, uint64_t offset = 0, uint64_t size = WGPU_WHOLE_SIZE) const;
 
@@ -1064,6 +1091,7 @@ namespace wgpu {
         void SetBindGroup(uint32_t groupIndex, BindGroup const& group, uint32_t dynamicOffsetCount = 0, uint32_t const * dynamicOffsets = nullptr) const;
         void SetBlendConstant(Color const * color) const;
         void SetIndexBuffer(Buffer const& buffer, IndexFormat format, uint64_t offset = 0, uint64_t size = WGPU_WHOLE_SIZE) const;
+        void SetLabel(char const * label) const;
         void SetPipeline(RenderPipeline const& pipeline) const;
         void SetScissorRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height) const;
         void SetStencilReference(uint32_t reference) const;
@@ -1096,6 +1124,7 @@ namespace wgpu {
         using ObjectBase::ObjectBase;
         using ObjectBase::operator=;
 
+        void SetLabel(char const * label) const;
 
       private:
         friend ObjectBase<Sampler, WGPUSampler>;
@@ -1151,6 +1180,7 @@ namespace wgpu {
 
         TextureView CreateView(TextureViewDescriptor const * descriptor = nullptr) const;
         void Destroy() const;
+        void SetLabel(char const * label) const;
 
       private:
         friend ObjectBase<Texture, WGPUTexture>;
@@ -1163,6 +1193,7 @@ namespace wgpu {
         using ObjectBase::ObjectBase;
         using ObjectBase::operator=;
 
+        void SetLabel(char const * label) const;
 
       private:
         friend ObjectBase<TextureView, WGPUTextureView>;
@@ -1252,9 +1283,10 @@ namespace wgpu {
         uint64_t length;
     };
 
-    struct ComputePassDescriptor {
-        ChainedStruct const * nextInChain = nullptr;
-        char const * label = nullptr;
+    struct ComputePassTimestampWrite {
+        QuerySet querySet;
+        uint32_t queryIndex;
+        ComputePassTimestampLocation location;
     };
 
     struct ConstantEntry {
@@ -1353,6 +1385,11 @@ namespace wgpu {
         uint32_t pipelineStatisticsCount = 0;
     };
 
+    struct QueueDescriptor {
+        ChainedStruct const * nextInChain = nullptr;
+        char const * label = nullptr;
+    };
+
     struct RenderBundleDescriptor {
         ChainedStruct const * nextInChain = nullptr;
         char const * label = nullptr;
@@ -1379,6 +1416,12 @@ namespace wgpu {
         StoreOp stencilStoreOp = StoreOp::Undefined;
         uint32_t stencilClearValue = 0;
         bool stencilReadOnly = false;
+    };
+
+    struct RenderPassTimestampWrite {
+        QuerySet querySet;
+        uint32_t queryIndex;
+        RenderPassTimestampLocation location;
     };
 
     struct RequestAdapterOptions {
@@ -1525,6 +1568,13 @@ namespace wgpu {
         CompilationMessage const * messages;
     };
 
+    struct ComputePassDescriptor {
+        ChainedStruct const * nextInChain = nullptr;
+        char const * label = nullptr;
+        uint32_t timestampWriteCount = 0;
+        ComputePassTimestampWrite const * timestampWrites;
+    };
+
     struct DepthStencilState {
         ChainedStruct const * nextInChain = nullptr;
         TextureFormat format;
@@ -1562,7 +1612,7 @@ namespace wgpu {
     };
 
     struct RenderPassColorAttachment {
-        TextureView view;
+        TextureView view = nullptr;
         TextureView resolveTarget = nullptr;
         LoadOp loadOp;
         StoreOp storeOp;
@@ -1588,6 +1638,8 @@ namespace wgpu {
         TextureFormat format;
         uint32_t mipLevelCount = 1;
         uint32_t sampleCount = 1;
+        uint32_t viewFormatCount = 0;
+        TextureFormat const * viewFormats;
     };
 
     struct VertexBufferLayout {
@@ -1624,6 +1676,7 @@ namespace wgpu {
         uint32_t requiredFeaturesCount = 0;
         FeatureName const * requiredFeatures = nullptr;
         RequiredLimits const * requiredLimits = nullptr;
+        QueueDescriptor defaultQueue;
     };
 
     struct RenderPassDescriptor {
@@ -1633,6 +1686,8 @@ namespace wgpu {
         RenderPassColorAttachment const * colorAttachments;
         RenderPassDepthStencilAttachment const * depthStencilAttachment = nullptr;
         QuerySet occlusionQuerySet = nullptr;
+        uint32_t timestampWriteCount = 0;
+        RenderPassTimestampWrite const * timestampWrites;
     };
 
     struct VertexState {

--- a/system/lib/webgpu/webgpu_cpp.cpp
+++ b/system/lib/webgpu/webgpu_cpp.cpp
@@ -121,6 +121,14 @@ namespace wgpu {
     static_assert(static_cast<uint32_t>(CompilationMessageType::Warning) == WGPUCompilationMessageType_Warning, "value mismatch for CompilationMessageType::Warning");
     static_assert(static_cast<uint32_t>(CompilationMessageType::Info) == WGPUCompilationMessageType_Info, "value mismatch for CompilationMessageType::Info");
 
+    // ComputePassTimestampLocation
+
+    static_assert(sizeof(ComputePassTimestampLocation) == sizeof(WGPUComputePassTimestampLocation), "sizeof mismatch for ComputePassTimestampLocation");
+    static_assert(alignof(ComputePassTimestampLocation) == alignof(WGPUComputePassTimestampLocation), "alignof mismatch for ComputePassTimestampLocation");
+
+    static_assert(static_cast<uint32_t>(ComputePassTimestampLocation::Beginning) == WGPUComputePassTimestampLocation_Beginning, "value mismatch for ComputePassTimestampLocation::Beginning");
+    static_assert(static_cast<uint32_t>(ComputePassTimestampLocation::End) == WGPUComputePassTimestampLocation_End, "value mismatch for ComputePassTimestampLocation::End");
+
     // CreatePipelineAsyncStatus
 
     static_assert(sizeof(CreatePipelineAsyncStatus) == sizeof(WGPUCreatePipelineAsyncStatus), "sizeof mismatch for CreatePipelineAsyncStatus");
@@ -285,6 +293,14 @@ namespace wgpu {
     static_assert(static_cast<uint32_t>(QueueWorkDoneStatus::Error) == WGPUQueueWorkDoneStatus_Error, "value mismatch for QueueWorkDoneStatus::Error");
     static_assert(static_cast<uint32_t>(QueueWorkDoneStatus::Unknown) == WGPUQueueWorkDoneStatus_Unknown, "value mismatch for QueueWorkDoneStatus::Unknown");
     static_assert(static_cast<uint32_t>(QueueWorkDoneStatus::DeviceLost) == WGPUQueueWorkDoneStatus_DeviceLost, "value mismatch for QueueWorkDoneStatus::DeviceLost");
+
+    // RenderPassTimestampLocation
+
+    static_assert(sizeof(RenderPassTimestampLocation) == sizeof(WGPURenderPassTimestampLocation), "sizeof mismatch for RenderPassTimestampLocation");
+    static_assert(alignof(RenderPassTimestampLocation) == alignof(WGPURenderPassTimestampLocation), "alignof mismatch for RenderPassTimestampLocation");
+
+    static_assert(static_cast<uint32_t>(RenderPassTimestampLocation::Beginning) == WGPURenderPassTimestampLocation_Beginning, "value mismatch for RenderPassTimestampLocation::Beginning");
+    static_assert(static_cast<uint32_t>(RenderPassTimestampLocation::End) == WGPURenderPassTimestampLocation_End, "value mismatch for RenderPassTimestampLocation::End");
 
     // RequestAdapterStatus
 
@@ -765,15 +781,17 @@ namespace wgpu {
     static_assert(offsetof(CompilationMessage, length) == offsetof(WGPUCompilationMessage, length),
             "offsetof mismatch for CompilationMessage::length");
 
-    // ComputePassDescriptor
+    // ComputePassTimestampWrite
 
-    static_assert(sizeof(ComputePassDescriptor) == sizeof(WGPUComputePassDescriptor), "sizeof mismatch for ComputePassDescriptor");
-    static_assert(alignof(ComputePassDescriptor) == alignof(WGPUComputePassDescriptor), "alignof mismatch for ComputePassDescriptor");
+    static_assert(sizeof(ComputePassTimestampWrite) == sizeof(WGPUComputePassTimestampWrite), "sizeof mismatch for ComputePassTimestampWrite");
+    static_assert(alignof(ComputePassTimestampWrite) == alignof(WGPUComputePassTimestampWrite), "alignof mismatch for ComputePassTimestampWrite");
 
-    static_assert(offsetof(ComputePassDescriptor, nextInChain) == offsetof(WGPUComputePassDescriptor, nextInChain),
-            "offsetof mismatch for ComputePassDescriptor::nextInChain");
-    static_assert(offsetof(ComputePassDescriptor, label) == offsetof(WGPUComputePassDescriptor, label),
-            "offsetof mismatch for ComputePassDescriptor::label");
+    static_assert(offsetof(ComputePassTimestampWrite, querySet) == offsetof(WGPUComputePassTimestampWrite, querySet),
+            "offsetof mismatch for ComputePassTimestampWrite::querySet");
+    static_assert(offsetof(ComputePassTimestampWrite, queryIndex) == offsetof(WGPUComputePassTimestampWrite, queryIndex),
+            "offsetof mismatch for ComputePassTimestampWrite::queryIndex");
+    static_assert(offsetof(ComputePassTimestampWrite, location) == offsetof(WGPUComputePassTimestampWrite, location),
+            "offsetof mismatch for ComputePassTimestampWrite::location");
 
     // ConstantEntry
 
@@ -955,6 +973,16 @@ namespace wgpu {
     static_assert(offsetof(QuerySetDescriptor, pipelineStatisticsCount) == offsetof(WGPUQuerySetDescriptor, pipelineStatisticsCount),
             "offsetof mismatch for QuerySetDescriptor::pipelineStatisticsCount");
 
+    // QueueDescriptor
+
+    static_assert(sizeof(QueueDescriptor) == sizeof(WGPUQueueDescriptor), "sizeof mismatch for QueueDescriptor");
+    static_assert(alignof(QueueDescriptor) == alignof(WGPUQueueDescriptor), "alignof mismatch for QueueDescriptor");
+
+    static_assert(offsetof(QueueDescriptor, nextInChain) == offsetof(WGPUQueueDescriptor, nextInChain),
+            "offsetof mismatch for QueueDescriptor::nextInChain");
+    static_assert(offsetof(QueueDescriptor, label) == offsetof(WGPUQueueDescriptor, label),
+            "offsetof mismatch for QueueDescriptor::label");
+
     // RenderBundleDescriptor
 
     static_assert(sizeof(RenderBundleDescriptor) == sizeof(WGPURenderBundleDescriptor), "sizeof mismatch for RenderBundleDescriptor");
@@ -1010,6 +1038,18 @@ namespace wgpu {
             "offsetof mismatch for RenderPassDepthStencilAttachment::stencilClearValue");
     static_assert(offsetof(RenderPassDepthStencilAttachment, stencilReadOnly) == offsetof(WGPURenderPassDepthStencilAttachment, stencilReadOnly),
             "offsetof mismatch for RenderPassDepthStencilAttachment::stencilReadOnly");
+
+    // RenderPassTimestampWrite
+
+    static_assert(sizeof(RenderPassTimestampWrite) == sizeof(WGPURenderPassTimestampWrite), "sizeof mismatch for RenderPassTimestampWrite");
+    static_assert(alignof(RenderPassTimestampWrite) == alignof(WGPURenderPassTimestampWrite), "alignof mismatch for RenderPassTimestampWrite");
+
+    static_assert(offsetof(RenderPassTimestampWrite, querySet) == offsetof(WGPURenderPassTimestampWrite, querySet),
+            "offsetof mismatch for RenderPassTimestampWrite::querySet");
+    static_assert(offsetof(RenderPassTimestampWrite, queryIndex) == offsetof(WGPURenderPassTimestampWrite, queryIndex),
+            "offsetof mismatch for RenderPassTimestampWrite::queryIndex");
+    static_assert(offsetof(RenderPassTimestampWrite, location) == offsetof(WGPURenderPassTimestampWrite, location),
+            "offsetof mismatch for RenderPassTimestampWrite::location");
 
     // RequestAdapterOptions
 
@@ -1281,6 +1321,20 @@ namespace wgpu {
     static_assert(offsetof(CompilationInfo, messages) == offsetof(WGPUCompilationInfo, messages),
             "offsetof mismatch for CompilationInfo::messages");
 
+    // ComputePassDescriptor
+
+    static_assert(sizeof(ComputePassDescriptor) == sizeof(WGPUComputePassDescriptor), "sizeof mismatch for ComputePassDescriptor");
+    static_assert(alignof(ComputePassDescriptor) == alignof(WGPUComputePassDescriptor), "alignof mismatch for ComputePassDescriptor");
+
+    static_assert(offsetof(ComputePassDescriptor, nextInChain) == offsetof(WGPUComputePassDescriptor, nextInChain),
+            "offsetof mismatch for ComputePassDescriptor::nextInChain");
+    static_assert(offsetof(ComputePassDescriptor, label) == offsetof(WGPUComputePassDescriptor, label),
+            "offsetof mismatch for ComputePassDescriptor::label");
+    static_assert(offsetof(ComputePassDescriptor, timestampWriteCount) == offsetof(WGPUComputePassDescriptor, timestampWriteCount),
+            "offsetof mismatch for ComputePassDescriptor::timestampWriteCount");
+    static_assert(offsetof(ComputePassDescriptor, timestampWrites) == offsetof(WGPUComputePassDescriptor, timestampWrites),
+            "offsetof mismatch for ComputePassDescriptor::timestampWrites");
+
     // DepthStencilState
 
     static_assert(sizeof(DepthStencilState) == sizeof(WGPUDepthStencilState), "sizeof mismatch for DepthStencilState");
@@ -1410,6 +1464,10 @@ namespace wgpu {
             "offsetof mismatch for TextureDescriptor::mipLevelCount");
     static_assert(offsetof(TextureDescriptor, sampleCount) == offsetof(WGPUTextureDescriptor, sampleCount),
             "offsetof mismatch for TextureDescriptor::sampleCount");
+    static_assert(offsetof(TextureDescriptor, viewFormatCount) == offsetof(WGPUTextureDescriptor, viewFormatCount),
+            "offsetof mismatch for TextureDescriptor::viewFormatCount");
+    static_assert(offsetof(TextureDescriptor, viewFormats) == offsetof(WGPUTextureDescriptor, viewFormats),
+            "offsetof mismatch for TextureDescriptor::viewFormats");
 
     // VertexBufferLayout
 
@@ -1482,6 +1540,8 @@ namespace wgpu {
             "offsetof mismatch for DeviceDescriptor::requiredFeatures");
     static_assert(offsetof(DeviceDescriptor, requiredLimits) == offsetof(WGPUDeviceDescriptor, requiredLimits),
             "offsetof mismatch for DeviceDescriptor::requiredLimits");
+    static_assert(offsetof(DeviceDescriptor, defaultQueue) == offsetof(WGPUDeviceDescriptor, defaultQueue),
+            "offsetof mismatch for DeviceDescriptor::defaultQueue");
 
     // RenderPassDescriptor
 
@@ -1500,6 +1560,10 @@ namespace wgpu {
             "offsetof mismatch for RenderPassDescriptor::depthStencilAttachment");
     static_assert(offsetof(RenderPassDescriptor, occlusionQuerySet) == offsetof(WGPURenderPassDescriptor, occlusionQuerySet),
             "offsetof mismatch for RenderPassDescriptor::occlusionQuerySet");
+    static_assert(offsetof(RenderPassDescriptor, timestampWriteCount) == offsetof(WGPURenderPassDescriptor, timestampWriteCount),
+            "offsetof mismatch for RenderPassDescriptor::timestampWriteCount");
+    static_assert(offsetof(RenderPassDescriptor, timestampWrites) == offsetof(WGPURenderPassDescriptor, timestampWrites),
+            "offsetof mismatch for RenderPassDescriptor::timestampWrites");
 
     // VertexState
 
@@ -1568,6 +1632,10 @@ namespace wgpu {
     static_assert(sizeof(Adapter) == sizeof(WGPUAdapter), "sizeof mismatch for Adapter");
     static_assert(alignof(Adapter) == alignof(WGPUAdapter), "alignof mismatch for Adapter");
 
+    size_t Adapter::EnumerateFeatures(FeatureName * features) const {
+        auto result = wgpuAdapterEnumerateFeatures(Get(), reinterpret_cast<WGPUFeatureName * >(features));
+        return result;
+    }
     bool Adapter::GetLimits(SupportedLimits * limits) const {
         auto result = wgpuAdapterGetLimits(Get(), reinterpret_cast<WGPUSupportedLimits * >(limits));
         return result;
@@ -1598,6 +1666,9 @@ namespace wgpu {
     static_assert(sizeof(BindGroup) == sizeof(WGPUBindGroup), "sizeof mismatch for BindGroup");
     static_assert(alignof(BindGroup) == alignof(WGPUBindGroup), "alignof mismatch for BindGroup");
 
+    void BindGroup::SetLabel(char const * label) const {
+        wgpuBindGroupSetLabel(Get(), reinterpret_cast<char const * >(label));
+    }
     void BindGroup::WGPUReference(WGPUBindGroup handle) {
         if (handle != nullptr) {
             wgpuBindGroupReference(handle);
@@ -1614,6 +1685,9 @@ namespace wgpu {
     static_assert(sizeof(BindGroupLayout) == sizeof(WGPUBindGroupLayout), "sizeof mismatch for BindGroupLayout");
     static_assert(alignof(BindGroupLayout) == alignof(WGPUBindGroupLayout), "alignof mismatch for BindGroupLayout");
 
+    void BindGroupLayout::SetLabel(char const * label) const {
+        wgpuBindGroupLayoutSetLabel(Get(), reinterpret_cast<char const * >(label));
+    }
     void BindGroupLayout::WGPUReference(WGPUBindGroupLayout handle) {
         if (handle != nullptr) {
             wgpuBindGroupLayoutReference(handle);
@@ -1644,6 +1718,9 @@ namespace wgpu {
     void Buffer::MapAsync(MapMode mode, size_t offset, size_t size, BufferMapCallback callback, void * userdata) const {
         wgpuBufferMapAsync(Get(), static_cast<WGPUMapMode>(mode), offset, size, callback, reinterpret_cast<void * >(userdata));
     }
+    void Buffer::SetLabel(char const * label) const {
+        wgpuBufferSetLabel(Get(), reinterpret_cast<char const * >(label));
+    }
     void Buffer::Unmap() const {
         wgpuBufferUnmap(Get());
     }
@@ -1663,6 +1740,9 @@ namespace wgpu {
     static_assert(sizeof(CommandBuffer) == sizeof(WGPUCommandBuffer), "sizeof mismatch for CommandBuffer");
     static_assert(alignof(CommandBuffer) == alignof(WGPUCommandBuffer), "alignof mismatch for CommandBuffer");
 
+    void CommandBuffer::SetLabel(char const * label) const {
+        wgpuCommandBufferSetLabel(Get(), reinterpret_cast<char const * >(label));
+    }
     void CommandBuffer::WGPUReference(WGPUCommandBuffer handle) {
         if (handle != nullptr) {
             wgpuCommandBufferReference(handle);
@@ -1718,6 +1798,9 @@ namespace wgpu {
     void CommandEncoder::ResolveQuerySet(QuerySet const& querySet, uint32_t firstQuery, uint32_t queryCount, Buffer const& destination, uint64_t destinationOffset) const {
         wgpuCommandEncoderResolveQuerySet(Get(), querySet.Get(), firstQuery, queryCount, destination.Get(), destinationOffset);
     }
+    void CommandEncoder::SetLabel(char const * label) const {
+        wgpuCommandEncoderSetLabel(Get(), reinterpret_cast<char const * >(label));
+    }
     void CommandEncoder::WriteTimestamp(QuerySet const& querySet, uint32_t queryIndex) const {
         wgpuCommandEncoderWriteTimestamp(Get(), querySet.Get(), queryIndex);
     }
@@ -1740,11 +1823,11 @@ namespace wgpu {
     void ComputePassEncoder::BeginPipelineStatisticsQuery(QuerySet const& querySet, uint32_t queryIndex) const {
         wgpuComputePassEncoderBeginPipelineStatisticsQuery(Get(), querySet.Get(), queryIndex);
     }
-    void ComputePassEncoder::Dispatch(uint32_t workgroupCountX, uint32_t workgroupCountY, uint32_t workgroupCountZ) const {
-        wgpuComputePassEncoderDispatch(Get(), workgroupCountX, workgroupCountY, workgroupCountZ);
+    void ComputePassEncoder::DispatchWorkgroups(uint32_t workgroupCountX, uint32_t workgroupCountY, uint32_t workgroupCountZ) const {
+        wgpuComputePassEncoderDispatchWorkgroups(Get(), workgroupCountX, workgroupCountY, workgroupCountZ);
     }
-    void ComputePassEncoder::DispatchIndirect(Buffer const& indirectBuffer, uint64_t indirectOffset) const {
-        wgpuComputePassEncoderDispatchIndirect(Get(), indirectBuffer.Get(), indirectOffset);
+    void ComputePassEncoder::DispatchWorkgroupsIndirect(Buffer const& indirectBuffer, uint64_t indirectOffset) const {
+        wgpuComputePassEncoderDispatchWorkgroupsIndirect(Get(), indirectBuffer.Get(), indirectOffset);
     }
     void ComputePassEncoder::End() const {
         wgpuComputePassEncoderEnd(Get());
@@ -1763,6 +1846,9 @@ namespace wgpu {
     }
     void ComputePassEncoder::SetBindGroup(uint32_t groupIndex, BindGroup const& group, uint32_t dynamicOffsetCount, uint32_t const * dynamicOffsets) const {
         wgpuComputePassEncoderSetBindGroup(Get(), groupIndex, group.Get(), dynamicOffsetCount, reinterpret_cast<uint32_t const * >(dynamicOffsets));
+    }
+    void ComputePassEncoder::SetLabel(char const * label) const {
+        wgpuComputePassEncoderSetLabel(Get(), reinterpret_cast<char const * >(label));
     }
     void ComputePassEncoder::SetPipeline(ComputePipeline const& pipeline) const {
         wgpuComputePassEncoderSetPipeline(Get(), pipeline.Get());
@@ -1870,6 +1956,10 @@ namespace wgpu {
     void Device::Destroy() const {
         wgpuDeviceDestroy(Get());
     }
+    size_t Device::EnumerateFeatures(FeatureName * features) const {
+        auto result = wgpuDeviceEnumerateFeatures(Get(), reinterpret_cast<WGPUFeatureName * >(features));
+        return result;
+    }
     bool Device::GetLimits(SupportedLimits * limits) const {
         auto result = wgpuDeviceGetLimits(Get(), reinterpret_cast<WGPUSupportedLimits * >(limits));
         return result;
@@ -1877,6 +1967,10 @@ namespace wgpu {
     Queue Device::GetQueue() const {
         auto result = wgpuDeviceGetQueue(Get());
         return Queue::Acquire(result);
+    }
+    bool Device::HasFeature(FeatureName feature) const {
+        auto result = wgpuDeviceHasFeature(Get(), static_cast<WGPUFeatureName>(feature));
+        return result;
     }
     bool Device::PopErrorScope(ErrorCallback callback, void * userdata) const {
         auto result = wgpuDevicePopErrorScope(Get(), callback, reinterpret_cast<void * >(userdata));
@@ -1887,6 +1981,9 @@ namespace wgpu {
     }
     void Device::SetDeviceLostCallback(DeviceLostCallback callback, void * userdata) const {
         wgpuDeviceSetDeviceLostCallback(Get(), callback, reinterpret_cast<void * >(userdata));
+    }
+    void Device::SetLabel(char const * label) const {
+        wgpuDeviceSetLabel(Get(), reinterpret_cast<char const * >(label));
     }
     void Device::SetUncapturedErrorCallback(ErrorCallback callback, void * userdata) const {
         wgpuDeviceSetUncapturedErrorCallback(Get(), callback, reinterpret_cast<void * >(userdata));
@@ -1933,6 +2030,9 @@ namespace wgpu {
     static_assert(sizeof(PipelineLayout) == sizeof(WGPUPipelineLayout), "sizeof mismatch for PipelineLayout");
     static_assert(alignof(PipelineLayout) == alignof(WGPUPipelineLayout), "alignof mismatch for PipelineLayout");
 
+    void PipelineLayout::SetLabel(char const * label) const {
+        wgpuPipelineLayoutSetLabel(Get(), reinterpret_cast<char const * >(label));
+    }
     void PipelineLayout::WGPUReference(WGPUPipelineLayout handle) {
         if (handle != nullptr) {
             wgpuPipelineLayoutReference(handle);
@@ -1952,6 +2052,9 @@ namespace wgpu {
     void QuerySet::Destroy() const {
         wgpuQuerySetDestroy(Get());
     }
+    void QuerySet::SetLabel(char const * label) const {
+        wgpuQuerySetSetLabel(Get(), reinterpret_cast<char const * >(label));
+    }
     void QuerySet::WGPUReference(WGPUQuerySet handle) {
         if (handle != nullptr) {
             wgpuQuerySetReference(handle);
@@ -1970,6 +2073,9 @@ namespace wgpu {
 
     void Queue::OnSubmittedWorkDone(uint64_t signalValue, QueueWorkDoneCallback callback, void * userdata) const {
         wgpuQueueOnSubmittedWorkDone(Get(), signalValue, callback, reinterpret_cast<void * >(userdata));
+    }
+    void Queue::SetLabel(char const * label) const {
+        wgpuQueueSetLabel(Get(), reinterpret_cast<char const * >(label));
     }
     void Queue::Submit(uint32_t commandCount, CommandBuffer const * commands) const {
         wgpuQueueSubmit(Get(), commandCount, reinterpret_cast<WGPUCommandBuffer const * >(commands));
@@ -2043,6 +2149,9 @@ namespace wgpu {
     void RenderBundleEncoder::SetIndexBuffer(Buffer const& buffer, IndexFormat format, uint64_t offset, uint64_t size) const {
         wgpuRenderBundleEncoderSetIndexBuffer(Get(), buffer.Get(), static_cast<WGPUIndexFormat>(format), offset, size);
     }
+    void RenderBundleEncoder::SetLabel(char const * label) const {
+        wgpuRenderBundleEncoderSetLabel(Get(), reinterpret_cast<char const * >(label));
+    }
     void RenderBundleEncoder::SetPipeline(RenderPipeline const& pipeline) const {
         wgpuRenderBundleEncoderSetPipeline(Get(), pipeline.Get());
     }
@@ -2113,6 +2222,9 @@ namespace wgpu {
     void RenderPassEncoder::SetIndexBuffer(Buffer const& buffer, IndexFormat format, uint64_t offset, uint64_t size) const {
         wgpuRenderPassEncoderSetIndexBuffer(Get(), buffer.Get(), static_cast<WGPUIndexFormat>(format), offset, size);
     }
+    void RenderPassEncoder::SetLabel(char const * label) const {
+        wgpuRenderPassEncoderSetLabel(Get(), reinterpret_cast<char const * >(label));
+    }
     void RenderPassEncoder::SetPipeline(RenderPipeline const& pipeline) const {
         wgpuRenderPassEncoderSetPipeline(Get(), pipeline.Get());
     }
@@ -2170,6 +2282,9 @@ namespace wgpu {
     static_assert(sizeof(Sampler) == sizeof(WGPUSampler), "sizeof mismatch for Sampler");
     static_assert(alignof(Sampler) == alignof(WGPUSampler), "alignof mismatch for Sampler");
 
+    void Sampler::SetLabel(char const * label) const {
+        wgpuSamplerSetLabel(Get(), reinterpret_cast<char const * >(label));
+    }
     void Sampler::WGPUReference(WGPUSampler handle) {
         if (handle != nullptr) {
             wgpuSamplerReference(handle);
@@ -2258,6 +2373,9 @@ namespace wgpu {
     void Texture::Destroy() const {
         wgpuTextureDestroy(Get());
     }
+    void Texture::SetLabel(char const * label) const {
+        wgpuTextureSetLabel(Get(), reinterpret_cast<char const * >(label));
+    }
     void Texture::WGPUReference(WGPUTexture handle) {
         if (handle != nullptr) {
             wgpuTextureReference(handle);
@@ -2274,6 +2392,9 @@ namespace wgpu {
     static_assert(sizeof(TextureView) == sizeof(WGPUTextureView), "sizeof mismatch for TextureView");
     static_assert(alignof(TextureView) == alignof(WGPUTextureView), "alignof mismatch for TextureView");
 
+    void TextureView::SetLabel(char const * label) const {
+        wgpuTextureViewSetLabel(Get(), reinterpret_cast<char const * >(label));
+    }
     void TextureView::WGPUReference(WGPUTextureView handle) {
         if (handle != nullptr) {
             wgpuTextureViewReference(handle);

--- a/tests/reference_struct_info.json
+++ b/tests/reference_struct_info.json
@@ -847,9 +847,17 @@
             "type": 8
         },
         "WGPUComputePassDescriptor": {
-            "__size__": 8,
+            "__size__": 16,
             "label": 4,
-            "nextInChain": 0
+            "nextInChain": 0,
+            "timestampWriteCount": 8,
+            "timestampWrites": 12
+        },
+        "WGPUComputePassTimestampWrite": {
+            "__size__": 12,
+            "location": 8,
+            "queryIndex": 4,
+            "querySet": 0
         },
         "WGPUComputePipelineDescriptor": {
             "__size__": 32,
@@ -879,7 +887,8 @@
             "stencilWriteMask": 52
         },
         "WGPUDeviceDescriptor": {
-            "__size__": 20,
+            "__size__": 28,
+            "defaultQueue": 20,
             "label": 4,
             "nextInChain": 0,
             "requiredFeatures": 12,
@@ -1004,6 +1013,11 @@
             "pipelineStatisticsCount": 20,
             "type": 8
         },
+        "WGPUQueueDescriptor": {
+            "__size__": 8,
+            "label": 4,
+            "nextInChain": 0
+        },
         "WGPURenderBundleDescriptor": {
             "__size__": 8,
             "label": 4,
@@ -1041,13 +1055,21 @@
             "view": 0
         },
         "WGPURenderPassDescriptor": {
-            "__size__": 24,
+            "__size__": 32,
             "colorAttachmentCount": 8,
             "colorAttachments": 12,
             "depthStencilAttachment": 16,
             "label": 4,
             "nextInChain": 0,
-            "occlusionQuerySet": 20
+            "occlusionQuerySet": 20,
+            "timestampWriteCount": 24,
+            "timestampWrites": 28
+        },
+        "WGPURenderPassTimestampWrite": {
+            "__size__": 12,
+            "location": 8,
+            "queryIndex": 4,
+            "querySet": 0
         },
         "WGPURenderPipelineDescriptor": {
             "__size__": 84,
@@ -1162,7 +1184,7 @@
             "rowsPerImage": 20
         },
         "WGPUTextureDescriptor": {
-            "__size__": 40,
+            "__size__": 48,
             "dimension": 12,
             "format": 28,
             "label": 4,
@@ -1170,7 +1192,9 @@
             "nextInChain": 0,
             "sampleCount": 36,
             "size": 16,
-            "usage": 8
+            "usage": 8,
+            "viewFormatCount": 40,
+            "viewFormats": 44
         },
         "WGPUTextureViewDescriptor": {
             "__size__": 36,


### PR DESCRIPTION
Update WebGPU gen headers and the following implementations:
* Handling of WGPU_WHOLE_SIZE based on https://github.com/emscripten-core/emscripten/pull/15244
* Bunch of `SetLabel` funcs
* `TimestampWrite` update of `Compute/RenderPassDescriptor`
* `EnumerateFeatures`, `HasFeature`
* `dispatch(Indirect)` -> `dispatchWorkgroups(Indirect)` rename (with deprecate workaround)
* Handling of `mapAsync`/`get(Const)MappedRange` `offset`/`size` implementation