### PR TITLE
Add note on emscripten_set_main_loop with Wasm EH

### DIFF
--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -361,6 +361,8 @@ Functions
 
   .. note:: Calling this function overrides the effect of any previous calls to :c:func:`emscripten_set_main_loop_timing` in the calling thread by applying the timing mode specified by the parameter ``fps``. To specify a different timing mode for the current thread, call the function :c:func:`emscripten_set_main_loop_timing` after setting up the main loop.
 
+  .. note:: Currently, ``simulate_infinite_loop`` == true does not work yet with `the new Wasm exception handling <https://emscripten.org/docs/porting/exceptions.html#webassembly-exception-handling-proposal>`_; your program may crash with memory errors.
+
   :param em_callback_func func: C function to set as main event loop for the calling thread.
   :param int fps: Number of frames per second that the JavaScript will call the function. Setting ``int <=0`` (recommended) uses the browser’s ``requestAnimationFrame`` mechanism to call the function.
   :param int simulate_infinite_loop: If true, this function will throw an exception in order to stop execution of the caller.

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -361,7 +361,7 @@ Functions
 
   .. note:: Calling this function overrides the effect of any previous calls to :c:func:`emscripten_set_main_loop_timing` in the calling thread by applying the timing mode specified by the parameter ``fps``. To specify a different timing mode for the current thread, call the function :c:func:`emscripten_set_main_loop_timing` after setting up the main loop.
 
-  .. note:: Currently, ``simulate_infinite_loop`` == true does not work yet with `the new Wasm exception handling <https://emscripten.org/docs/porting/exceptions.html#webassembly-exception-handling-proposal>`_; your program may crash with memory errors.
+  .. note:: Currently, using `the new Wasm exception handling <https://emscripten.org/docs/porting/exceptions.html#webassembly-exception-handling-proposal>`_ and ``simulate_infinite_loop`` == true at the same time does not work yet in C++ projects that have objects with destructors on the stack at the time of the call.
 
   :param em_callback_func func: C function to set as main event loop for the calling thread.
   :param int fps: Number of frames per second that the JavaScript will call the function. Setting ``int <=0`` (recommended) uses the browser’s ``requestAnimationFrame`` mechanism to call the function.


### PR DESCRIPTION
When `simulate_infinite_loop` is true, `emscripten_set_main_loop` does
not work with [the new Wasm EH](https://emscripten.org/docs/porting/exceptions.html#webassembly-exception-handling-proposal)
because throwing a JS exception will cause destructors in the Wasm stack
frames to run. This can be fixed in future by either by fixing the LLVM
compilation by adding an additional `catch` to every `catch_all` so that
we can rethrow JS exceptions of this kind, or possibly using [the new
stack switching proposal](https://github.com/WebAssembly/stack-switching).

This PR adds a note that this features currently doesn't work with Wasm
EH.