### PR TITLE
[CI] Switch to the previous Chrome download URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,10 @@ commands:
           name: download chrome
           command: |
             # Using stable rather than beta until we can fix
-            # Currently downloading form our own buckets due to:
-            # https://github.com/emscripten-core/emscripten/issues/14987
-            #wget -O ~/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-            wget -O ~/chrome.deb https://storage.googleapis.com/webassembly/chrome/google-chrome-stable_current_amd64.deb
+            # https://github.com/emscripten-core/emscripten/issues/14369
+            wget -O ~/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            # If that download link breaks, temporarily use this URL instead:
+            # wget -O ~/chrome.deb https://storage.googleapis.com/webassembly/chrome/google-chrome-stable_current_amd64.deb
             dpkg -i ~/chrome.deb
   emsdk-env:
     description: "emsdk_env.sh"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ commands:
             # Currently downloading form our own buckets due to:
             # https://github.com/emscripten-core/emscripten/issues/14987
             #wget -O ~/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-            wget -O ~/chrome.deb https://storage.googleapis.com/webassembly/chrome/google-chrome-stable_current_amd64_new.deb
+            wget -O ~/chrome.deb https://storage.googleapis.com/webassembly/chrome/google-chrome-stable_current_amd64.deb
             dpkg -i ~/chrome.deb
   emsdk-env:
     description: "emsdk_env.sh"


### PR DESCRIPTION
In a824211356 we added a "_new" suffix to the URL we use to download Chrome on
CI to switch to a newer version hosted in our cloud storage bucket. Now that
that new version has proven to work, switch back to the normal URL that now
points to the new version as well.