### PR TITLE
Use unsigned types for POINTER_TYPE

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3524,13 +3524,13 @@ LibraryManager.library = {
   // mode are created here and imported by the module.
   // Mark with `__import` so these are usable from native code.  This is needed
   // because, by default, only functions can be be imported.
-  __stack_pointer: "new WebAssembly.Global({'value': '{{{ POINTER_TYPE }}}', 'mutable': true}, {{{ to64(STACK_BASE) }}})",
+  __stack_pointer: "new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': true}, {{{ to64(STACK_BASE) }}})",
   __stack_pointer__import: true,
   // tell the memory segments where to place themselves
-  __memory_base: "new WebAssembly.Global({'value': '{{{ POINTER_TYPE }}}', 'mutable': false}, {{{ to64(GLOBAL_BASE) }}})",
+  __memory_base: "new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': false}, {{{ to64(GLOBAL_BASE) }}})",
   __memory_base__import: true,
   // the wasm backend reserves slot 0 for the NULL function pointer
-  __table_base: "new WebAssembly.Global({'value': '{{{ POINTER_TYPE }}}', 'mutable': false}, {{{ to64(1) }}})",
+  __table_base: "new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': false}, {{{ to64(1) }}})",
   __table_base__import: true,
 #if MEMORY64
   __table_base32: 1,
@@ -3544,11 +3544,11 @@ LibraryManager.library = {
   __heap_base__import: true,
 #if EXCEPTION_HANDLING
   // In dynamic linking we define tags here and feed them to each module
-  __cpp_exception: "new WebAssembly.Tag({'parameters': ['{{{ POINTER_TYPE }}}']})",
+  __cpp_exception: "new WebAssembly.Tag({'parameters': ['{{{ POINTER_WASM_TYPE }}}']})",
   __cpp_exception__import: true,
 #endif
 #if SUPPORT_LONGJMP == 'wasm'
-  __c_longjmp: "new WebAssembly.Tag({'parameters': ['{{{ POINTER_TYPE }}}']})",
+  __c_longjmp: "new WebAssembly.Tag({'parameters': ['{{{ POINTER_WASM_TYPE }}}']})",
   __c_longjmp_import: true,
 #endif
 #endif

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -52,7 +52,7 @@ var LibraryDylink = {
   $GOTHandler: {
     'get': function(obj, symName) {
       if (!GOT[symName]) {
-        GOT[symName] = new WebAssembly.Global({'value': '{{{ POINTER_TYPE }}}', 'mutable': true});
+        GOT[symName] = new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': true});
 #if DYLINK_DEBUG
         err("new GOT entry: " + symName);
 #endif

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -676,7 +676,7 @@ var LibraryPThread = {
     // Proxied canvases string pointer -1 is used as a special token to fetch
     // whatever canvases were passed to build in -s
     // OFFSCREENCANVASES_TO_PTHREAD= command line.
-    if (transferredCanvasNames == -1) transferredCanvasNames = '{{{ OFFSCREENCANVASES_TO_PTHREAD }}}';
+    if (transferredCanvasNames == (-1 >>> 0)) transferredCanvasNames = '{{{ OFFSCREENCANVASES_TO_PTHREAD }}}';
     else
 #endif
     if (transferredCanvasNames) transferredCanvasNames = UTF8ToString(transferredCanvasNames).trim();

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 12888,
-  "a.html.gz": 6990,
-  "total": 12888,
-  "total_gz": 6990
+  "a.html": 12866,
+  "a.html.gz": 6978,
+  "total": 12866,
+  "total_gz": 6978
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17413,
-  "a.html.gz": 7530,
-  "total": 17413,
-  "total_gz": 7530
+  "a.html": 17393,
+  "a.html.gz": 7522,
+  "total": 17393,
+  "total_gz": 7522
 }


### PR DESCRIPTION
This seems to be slight codesize win because the generated code for
makeGetValue/makeSetValue I guess is slightly smaller for unsigned
types.