### PR TITLE
[wasm64] convert BigInt<->Number based on library function `__sig` attributes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,7 +380,7 @@ jobs:
     executor: bionic
     steps:
       - run-tests-linux:
-          test_targets: "wasm64.test_hello_world wasm64l.test_hello_world wasm64l.test_unistd_truncate wasm64l.test_mmap"
+          test_targets: "wasm64.test_hello_world wasm64l.test_hello_world wasm64l.test_mmap wasm64l.test_unistd_* skip:wasm64l.test_unistd_sysconf"
   test-other:
     executor: bionic
     steps:

--- a/src/library.js
+++ b/src/library.js
@@ -87,6 +87,8 @@ LibraryManager.library = {
   },
 #endif
 
+  // Returns a pointer ('p'), which means an i32 on wasm32 and an i64 wasm64
+  emscripten_get_heap_max__sig: 'p',
   emscripten_get_heap_max: function() {
 #if ALLOW_MEMORY_GROWTH
     // Stay one Wasm page short of 4GB: while e.g. Chrome is able to allocate
@@ -357,6 +359,7 @@ LibraryManager.library = {
   // the wasm file standalone.
 #if SHRINK_LEVEL < 2 && !STANDALONE_WASM
 
+  emscripten_memcpy_big__sig: 'vppp',
 #if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 100101
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin lists browsers that support TypedArray.prototype.copyWithin, but it
   // has outdated information for Safari, saying it would not support it.
@@ -3304,7 +3307,7 @@ LibraryManager.library = {
   #endif
   },
 
-  emscripten_console_log__sig: 'vi',
+  emscripten_console_log__sig: 'vp',
   emscripten_console_log: function(str) {
 #if ASSERTIONS
     assert(typeof str == 'number');
@@ -3312,7 +3315,7 @@ LibraryManager.library = {
     console.log(UTF8ToString(str));
   },
 
-  emscripten_console_warn__sig: 'vi',
+  emscripten_console_warn__sig: 'vp',
   emscripten_console_warn: function(str) {
 #if ASSERTIONS
     assert(typeof str == 'number');
@@ -3320,7 +3323,7 @@ LibraryManager.library = {
     console.warn(UTF8ToString(str));
   },
 
-  emscripten_console_error__sig: 'vi',
+  emscripten_console_error__sig: 'vp',
   emscripten_console_error: function(str) {
 #if ASSERTIONS
     assert(typeof str == 'number');

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -54,7 +54,7 @@ var WasiLibrary = {
 
   environ_sizes_get__deps: ['$getEnvStrings'],
   environ_sizes_get__nothrow: true,
-  environ_sizes_get__sig: 'iii',
+  environ_sizes_get__sig: 'ipp',
   environ_sizes_get: function(penviron_count, penviron_buf_size) {
     var strings = getEnvStrings();
     {{{ makeSetValue('penviron_count', 0, 'strings.length', 'i32') }}};
@@ -72,7 +72,7 @@ var WasiLibrary = {
 #endif
   ],
   environ_get__nothrow: true,
-  environ_get__sig: 'iii',
+  environ_get__sig: 'ipp',
   environ_get: function(__environ, environ_buf) {
     var bufSize = 0;
     getEnvStrings().forEach(function(string, i) {
@@ -88,7 +88,7 @@ var WasiLibrary = {
   // to main, and the `mainArgs` global does not exist.
 #if STANDALONE_WASM
   args_sizes_get__nothrow: true,
-  args_sizes_get__sig: 'iii',
+  args_sizes_get__sig: 'ipp',
   args_sizes_get: function(pargc, pargv_buf_size) {
     {{{ from64(['pargc', 'pargv_buf_size']) }}};
 #if MAIN_READS_PARAMS
@@ -105,7 +105,7 @@ var WasiLibrary = {
   },
 
   args_get__nothrow: true,
-  args_get__sig: 'iii',
+  args_get__sig: 'ipp',
 #if MINIMAL_RUNTIME && MAIN_READS_PARAMS
   args_get__deps: ['$writeAsciiToMemory'],
 #endif
@@ -136,7 +136,7 @@ var WasiLibrary = {
   // this is needed. To get this code to be usable as a JS shim we need to
   // either wait for BigInt support or to legalize on the client.
   clock_time_get__nothrow: true,
-  clock_time_get__sig: 'iiiii',
+  clock_time_get__sig: 'iijp',
   clock_time_get__deps: ['emscripten_get_now', '$nowIsMonotonic', '$checkWasiClock'],
   clock_time_get: function(clk_id, {{{ defineI64Param('precision') }}}, ptime) {
     {{{ receiveI64ParamAsI32s('precision') }}}
@@ -160,7 +160,7 @@ var WasiLibrary = {
   },
 
   clock_res_get__nothrow: true,
-  clock_res_get__sig: 'iii',
+  clock_res_get__sig: 'iip',
   clock_res_get__deps: ['emscripten_get_now', 'emscripten_get_now_res', '$nowIsMonotonic', '$checkWasiClock'],
   clock_res_get: function(clk_id, pres) {
     if (!checkWasiClock(clk_id)) {
@@ -247,7 +247,7 @@ var WasiLibrary = {
 #else
   fd_write__deps: ['$printChar'],
 #endif
-  fd_write__sig: 'iiiii',
+  fd_write__sig: 'iippp',
   fd_write: function(fd, iov, iovcnt, pnum) {
     {{{ from64(['iov', 'iovcnt', 'pnum']) }}};
 #if SYSCALLS_REQUIRE_FILESYSTEM
@@ -310,7 +310,7 @@ var WasiLibrary = {
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },
 
-  fd_read__sig: 'iiiii',
+  fd_read__sig: 'iippp',
 #if SYSCALLS_REQUIRE_FILESYSTEM
   fd_read__deps: ['$doReadv'],
 #endif
@@ -330,6 +330,7 @@ var WasiLibrary = {
 #if SYSCALLS_REQUIRE_FILESYSTEM
   fd_pread__deps: ['$doReadv'],
 #endif
+  fd_pread__sig: 'iippjp',
   fd_pread: function(fd, iov, iovcnt, {{{ defineI64Param('offset') }}}, pnum) {
 #if SYSCALLS_REQUIRE_FILESYSTEM
     {{{ receiveI64ParamAsI32s('offset') }}}
@@ -347,6 +348,7 @@ var WasiLibrary = {
 #endif
   },
 
+  fd_seek__sig: 'iijip',
   fd_seek: function(fd, {{{ defineI64Param('offset') }}}, whence, newOffset) {
 #if SYSCALLS_REQUIRE_FILESYSTEM
     {{{ receiveI64ParamAsI32s('offset') }}}
@@ -370,7 +372,7 @@ var WasiLibrary = {
 #endif
   },
 
-  fd_fdstat_get__sig: 'iii',
+  fd_fdstat_get__sig: 'iip',
   fd_fdstat_get: function(fd, pbuf) {
 #if SYSCALLS_REQUIRE_FILESYSTEM
     var stream = SYSCALLS.getStreamFromFD(fd);

--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -32,13 +32,21 @@ function convertJsFunctionToWasm(func, sig) {
       'i': 'i32',
       'j': 'i64',
       'f': 'f32',
-      'd': 'f64'
+      'd': 'f64',
+#if MEMORY64
+      'p': 'i64',
+#else
+      'p': 'i32',
+#endif
     };
     var type = {
       parameters: [],
       results: sig[0] == 'v' ? [] : [typeNames[sig[0]]]
     };
     for (var i = 1; i < sig.length; ++i) {
+#if ASSERTIONS
+      assert(sig[i] in typeNames, 'invalid signature char: ' + sig[i]);
+#endif
       type.parameters.push(typeNames[sig[i]]);
     }
     return new WebAssembly.Function(type, func);
@@ -54,6 +62,11 @@ function convertJsFunctionToWasm(func, sig) {
   var sigParam = sig.slice(1);
   var typeCodes = {
     'i': 0x7f, // i32
+#if MEMORY64
+    'p': 0x7e, // i64
+#else
+    'p': 0x7f, // i32
+#endif
     'j': 0x7e, // i64
     'f': 0x7d, // f32
     'd': 0x7c, // f64
@@ -62,6 +75,9 @@ function convertJsFunctionToWasm(func, sig) {
   // Parameters, length + signatures
   typeSection = typeSection.concat(uleb128Encode(sigParam.length));
   for (var i = 0; i < sigParam.length; ++i) {
+#if ASSERTIONS
+    assert(sigParam[i] in typeCodes, 'invalid signature char: ' + sigParam[i]);
+#endif
     typeSection.push(typeCodes[sigParam[i]]);
   }
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9256,6 +9256,12 @@ def make_run(name, emcc_args, settings=None, env=None, node_args=None, require_v
   return TT
 
 
+# Note: We add --profiling-funcs to many of these modes (especially
+# modes under active development) since it makes debugging test
+# failures easier.  The downside of this approach is that we are not
+# testing the default mode (i.e. without `--profiling-funcs`).  See:
+# https://github.com/emscripten-core/emscripten/pull/15480
+
 # Main wasm test modes
 core0 = make_run('core0', emcc_args=['-O0'])
 core0g = make_run('core0g', emcc_args=['-O0', '-g'])
@@ -9267,10 +9273,10 @@ cores = make_run('cores', emcc_args=['-Os'])
 corez = make_run('corez', emcc_args=['-Oz'])
 
 # MEMORY64=1
-wasm64 = make_run('wasm64', emcc_args=[], settings={'MEMORY64': 1},
+wasm64 = make_run('wasm64', emcc_args=['--profiling-funcs'], settings={'MEMORY64': 1},
                   require_v8=True, v8_args=['--experimental-wasm-memory64'])
 # MEMORY64=2, or "lowered"
-wasm64l = make_run('wasm64l', emcc_args=[], settings={'MEMORY64': 2},
+wasm64l = make_run('wasm64l', emcc_args=['--profiling-funcs'], settings={'MEMORY64': 2},
                    node_args=['--experimental-wasm-bigint'])
 
 lto0 = make_run('lto0', emcc_args=['-flto', '-O0'])

--- a/tools/wasm2c.py
+++ b/tools/wasm2c.py
@@ -20,6 +20,11 @@ def s_to_c(s):
     return 'u32'
   elif s == 'j':
     return 'u64'
+  elif s == 'p':
+    if settings.MEMORY64:
+      return 'u64'
+    else:
+      return 'u32'
   elif s == 'f':
     return 'f32'
   elif s == 'd':


### PR DESCRIPTION
This change introduces and type to the `__sig` scheme that we using for
library functions: 'p'.  This letter signifies that the paramater or
return value is the width of a pointer which means it will differ
between wasm32 and wasm64.

We use this whenever a JS function receives or returns pointer type or a
size_t type.

For wasm32, we don't need to do anything since the incoming value is and
i32.  For wasm64 we covert the incoming BigInt value to an int53/double
at the JS/Wasm boundary.  At the moment no checking is done on the
values, which means values that don't pricely convert to JS double can
be currupted/truncated.  As a followup, we could consider using the
checking coversion functions, or asserting in debug builds if the values
don't fit within this range.