### PR TITLE
Switch to using Chrome beta on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ commands:
           command: |
             # Using stable rather than beta until we can fix
             # https://github.com/emscripten-core/emscripten/issues/14369
-            wget -O ~/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            wget -O ~/chrome.deb https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
             # If that download link breaks, temporarily use this URL instead:
             # wget -O ~/chrome.deb https://storage.googleapis.com/webassembly/chrome/google-chrome-stable_current_amd64.deb
             dpkg -i ~/chrome.deb


### PR DESCRIPTION
Rather than Chrome stable. We had originally switched from beta to stable to
work around CI failures, but those have gone away.