### PR TITLE
tests: Honor test emcc_args in self.emcc helper functions

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -935,7 +935,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         self.fail(f'subprocess exited with non-zero return code({e.returncode}): `{shared.shlex_join(cmd)}`')
 
   def emcc(self, filename, args=[], output_filename=None, **kwargs):
-    cmd = [compiler_for(filename), filename] + args
+    cmd = [compiler_for(filename), filename] + self.get_emcc_args(ldflags='-c' not in args) + args
     if output_filename:
       cmd += ['-o', output_filename]
     self.run_process(cmd, **kwargs)

--- a/tests/module/test_stdin.c
+++ b/tests/module/test_stdin.c
@@ -28,7 +28,7 @@ void main_loop() {
       if (ret != EOF) putc(ret, stdout);
       if (ret == '\n') line++;
     } else if (line > 0) {
-      ret = scanf("%10s", str);
+      ret = scanf("%9s", str);
       if (ret > 0) puts(str);
     }
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -868,7 +868,7 @@ class TestCoreBase(RunnerCore):
 
     building.link_to_object(['main.o', 'liba.a', 'libb.a'], 'all.o')
 
-    self.emcc('all.o', self.get_emcc_args(), 'all.js')
+    self.emcc('all.o', output_filename='all.js')
     self.do_run('all.js', 'result: 1', no_build=True)
 
   def test_if(self):
@@ -7485,7 +7485,7 @@ void* operator new(size_t size) {
     no_maps_filename = 'no-maps.out.js'
 
     assert '-gsource-map' not in self.emcc_args
-    self.emcc('src.cpp', self.get_emcc_args(), out_filename)
+    self.emcc('src.cpp', output_filename=out_filename)
     # the file name may find its way into the generated code, so make sure we
     # can do an apples-to-apples comparison by compiling with the same file name
     shutil.move(out_filename, no_maps_filename)
@@ -7538,7 +7538,7 @@ void* operator new(size_t size) {
     wasm_filename = 'a.out.wasm'
     shutil.copyfile(test_file('core/test_dwarf.c'), 'test_dwarf.c')
 
-    self.emcc('test_dwarf.c', self.get_emcc_args(), js_filename)
+    self.emcc('test_dwarf.c', output_filename=js_filename)
 
     out = self.run_process([shared.LLVM_DWARFDUMP, wasm_filename, '-all'], stdout=PIPE).stdout
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1011,6 +1011,7 @@ int main() {
       }
     ''')
 
+    self.emcc_args.remove('-Werror')
     self.emcc('libA.c', ['-shared'], output_filename='libA.so')
 
     self.emcc('a2.c', ['-r', '-L.', '-lA', '-o', 'a2.o'])
@@ -1158,6 +1159,8 @@ int f() {
         return 0;
       }
     ''')
+
+    self.emcc_args.remove('-Werror')
     self.emcc('libA.c', ['-shared'], output_filename='libA.so')
     self.emcc('main.c', ['libA.so', 'libA.so'], output_filename='a.out.js')
     self.assertContained('result: 1', self.run_js('a.out.js'))
@@ -1846,6 +1849,8 @@ int f() {
     self.assertContained('ALL OK', self.run_process(config.JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).stdout)
 
   def test_bzip2(self):
+    self.emcc_args.remove('-Werror')
+    self.emcc_args.append('-Wno-pointer-sign')
     self.emcc(test_file('bzip2_test.c'), ['-sUSE_BZIP2=1'], output_filename='a.out.js')
     self.assertContained("usage: unzcrash filename", self.run_process(config.JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).stdout)
 


### PR DESCRIPTION
These means that object files compiled with this helper will
have the correct flags set by default.

I noticed that issue while working on the memory64 test suite.