### PR TITLE
Simplify internal mmap API. NFC.

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1224,10 +1224,7 @@ FS.staticInit();` +
       }
       stream.stream_ops.allocate(stream, offset, length);
     },
-    mmap: (stream, address, length, position, prot, flags) => {
-#if CAN_ADDRESS_2GB
-      address >>>= 0;
-#endif
+    mmap: (stream, length, position, prot, flags) => {
       // User requests writing to file (prot & PROT_WRITE != 0).
       // Checking if we have permissions to write to the file unless
       // MAP_PRIVATE flag is set. According to POSIX spec it is possible
@@ -1245,7 +1242,7 @@ FS.staticInit();` +
       if (!stream.stream_ops.mmap) {
         throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
       }
-      return stream.stream_ops.mmap(stream, address, length, position, prot, flags);
+      return stream.stream_ops.mmap(stream, length, position, prot, flags);
     },
     msync: (stream, buffer, offset, length, mmapFlags) => {
 #if CAN_ADDRESS_2GB

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -333,11 +333,7 @@ mergeInto(LibraryManager.library, {
         MEMFS.expandFileStorage(stream.node, offset + length);
         stream.node.usedBytes = Math.max(stream.node.usedBytes, offset + length);
       },
-      mmap: function(stream, address, length, position, prot, flags) {
-        if (address !== 0) {
-          // We don't currently support location hints for the address of the mapping
-          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
-        }
+      mmap: function(stream, length, position, prot, flags) {
         if (!FS.isFile(stream.node.mode)) {
           throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
         }

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -298,11 +298,7 @@ mergeInto(LibraryManager.library, {
 
         return position;
       },
-      mmap: (stream, address, length, position, prot, flags) => {
-        if (address !== 0) {
-          // We don't currently support location hints for the address of the mapping
-          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
-        }
+      mmap: (stream, length, position, prot, flags) => {
         if (!FS.isFile(stream.node.mode)) {
           throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
         }

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -174,14 +174,10 @@ mergeInto(LibraryManager.library, {
     allocate: function() {
       throw new FS.ErrnoError({{{ cDefine('EOPNOTSUPP') }}});
     },
-    mmap: function(stream, address, length, position, prot, flags) {
+    mmap: function(stream, length, position, prot, flags) {
       if (stream.stream_ops) {
         // this stream is created by in-memory filesystem
-        return VFS.mmap(stream, address, length, position, prot, flags);
-      }
-      if (address !== 0) {
-        // We don't currently support location hints for the address of the mapping
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        return VFS.mmap(stream, length, position, prot, flags);
       }
 
       var ptr = mmapAlloc(length);

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -121,9 +121,13 @@ var SyscallsLibrary = {
   ],
   _mmap_js: function(addr, len, prot, flags, fd, off, allocated) {
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
-    var info = FS.getStream(fd);
-    if (!info) return -{{{ cDefine('EBADF') }}};
-    var res = FS.mmap(info, addr, len, off, prot, flags);
+    if (addr !== 0) {
+      // We don't currently support location hints for the address of the mapping
+      return -{{{ cDefine('EINVAL') }}};
+    }
+    var stream = FS.getStream(fd);
+    if (!stream) return -{{{ cDefine('EBADF') }}};
+    var res = FS.mmap(stream, len, off, prot, flags);
     var ptr = res.ptr;
     {{{ makeSetValue('allocated', 0, 'res.allocated', 'i32') }}};
 #if CAN_ADDRESS_2GB


### PR DESCRIPTION
We don't support address hints ever, so do the check up front
and skip passing this extra param.  Minor code size and complexity
saving.