### PR TITLE
[WasmFS] Allow backends to have short reads and writes

### DIFF
--- a/src/library_wasmfs_js_file.js
+++ b/src/library_wasmfs_js_file.js
@@ -17,33 +17,25 @@ mergeInto(LibraryManager.library, {
         wasmFS$JSMemoryFiles[file] = undefined;
       },
       write: (file, buffer, length, offset) => {
-        try {
-          if (!wasmFS$JSMemoryFiles[file]) {
-            // Initialize typed array on first write operation.
-            wasmFS$JSMemoryFiles[file] = new Uint8Array(offset + length);
-          }
-
-          if (offset + length > wasmFS$JSMemoryFiles[file].length) {
-            // Resize the typed array if the length of the write buffer exceeds its capacity.
-            var oldContents = wasmFS$JSMemoryFiles[file];
-            var newContents = new Uint8Array(offset + length);
-            newContents.set(oldContents);
-            wasmFS$JSMemoryFiles[file] = newContents;
-          }
-
-          wasmFS$JSMemoryFiles[file].set(HEAPU8.subarray(buffer, buffer + length), offset);
-          return 0;
-        } catch (err) {
-          return {{{ cDefine('EIO') }}};
+        if (!wasmFS$JSMemoryFiles[file]) {
+          // Initialize typed array on first write operation.
+          wasmFS$JSMemoryFiles[file] = new Uint8Array(offset + length);
         }
+        if (offset + length > wasmFS$JSMemoryFiles[file].length) {
+          // Resize the typed array if the length of the write buffer exceeds its capacity.
+          var oldContents = wasmFS$JSMemoryFiles[file];
+          var newContents = new Uint8Array(offset + length);
+          newContents.set(oldContents);
+          wasmFS$JSMemoryFiles[file] = newContents;
+        }
+        wasmFS$JSMemoryFiles[file].set(HEAPU8.subarray(buffer, buffer + length), offset);
+        return length;
       },
       read: (file, buffer, length, offset) => {
-        try {
-          HEAPU8.set(wasmFS$JSMemoryFiles[file].subarray(offset, offset + length), buffer);
-          return 0;
-        } catch (err) {
-          return {{{ cDefine('EIO') }}};
-        }
+        var fileData = wasmFS$JSMemoryFiles[file];
+        length = Math.max(0, fileData.length - offset);
+        HEAPU8.set(fileData.subarray(offset, offset + length), buffer);
+        return length;
       },
       getSize: (file) => {
         return wasmFS$JSMemoryFiles[file] ? wasmFS$JSMemoryFiles[file].length : 0;

--- a/src/library_wasmfs_jsimpl.js
+++ b/src/library_wasmfs_jsimpl.js
@@ -84,7 +84,7 @@ mergeInto(LibraryManager.library, {
     assert(wasmFS$backends[backend]);
 #endif
     var result = await wasmFS$backends[backend].write(file, buffer, length, offset);
-    {{{ makeSetValue('result_p', 0, 'result', 'i64') }}};
+    {{{ makeSetValue('result_p', 0, 'result', 'i32') }}}; // TODO: wasm64
     _emscripten_proxy_finish(ctx);
   },
 
@@ -95,7 +95,7 @@ mergeInto(LibraryManager.library, {
     assert(wasmFS$backends[backend]);
 #endif
     var result = await wasmFS$backends[backend].read(file, buffer, length, offset);
-    {{{ makeSetValue('result_p', 0, 'result', 'i32') }}};
+    {{{ makeSetValue('result_p', 0, 'result', 'i32') }}}; // TODO: wasm64
     _emscripten_proxy_finish(ctx);
   },
 

--- a/src/library_wasmfs_jsimpl.js
+++ b/src/library_wasmfs_jsimpl.js
@@ -84,7 +84,7 @@ mergeInto(LibraryManager.library, {
     assert(wasmFS$backends[backend]);
 #endif
     var result = await wasmFS$backends[backend].write(file, buffer, length, offset);
-    {{{ makeSetValue('result_p', 0, 'result', 'i32') }}}; // TODO: wasm64
+    {{{ makeSetValue('result_p', 0, 'result', SIZE_TYPE) }}};
     _emscripten_proxy_finish(ctx);
   },
 
@@ -95,7 +95,7 @@ mergeInto(LibraryManager.library, {
     assert(wasmFS$backends[backend]);
 #endif
     var result = await wasmFS$backends[backend].read(file, buffer, length, offset);
-    {{{ makeSetValue('result_p', 0, 'result', 'i32') }}}; // TODO: wasm64
+    {{{ makeSetValue('result_p', 0, 'result', SIZE_TYPE) }}};
     _emscripten_proxy_finish(ctx);
   },
 

--- a/system/lib/wasmfs/backends/memory_backend.cpp
+++ b/system/lib/wasmfs/backends/memory_backend.cpp
@@ -13,22 +13,22 @@
 
 namespace wasmfs {
 
-__wasi_errno_t MemoryFile::write(const uint8_t* buf, size_t len, off_t offset) {
+ssize_t MemoryFile::write(const uint8_t* buf, size_t len, off_t offset) {
   if (offset + len > buffer.size()) {
     buffer.resize(offset + len);
   }
   std::memcpy(&buffer[offset], buf, len);
-
-  return __WASI_ERRNO_SUCCESS;
+  return len;
 }
 
-__wasi_errno_t MemoryFile::read(uint8_t* buf, size_t len, off_t offset) {
-  // The caller should have already checked that the offset + len does
-  // not exceed the file's size.
-  assert(offset + len <= buffer.size());
+ssize_t MemoryFile::read(uint8_t* buf, size_t len, off_t offset) {
+  if (offset >= buffer.size()) {
+    len = 0;
+  } else if (offset + len >= buffer.size()) {
+    len = buffer.size() - offset;
+  }
   std::memcpy(buf, &buffer[offset], len);
-
-  return __WASI_ERRNO_SUCCESS;
+  return len;
 }
 
 std::vector<MemoryDirectory::ChildEntry>::iterator

--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -163,25 +163,21 @@ private:
 
   void close() override { state.close(); }
 
-  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override {
+  ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
     uint32_t nread;
     if (auto err = _wasmfs_node_read(state.getFD(), buf, len, offset, &nread)) {
-      return err;
+      return -err;
     }
-    // TODO: Add a way to report the actual bytes read. We currently assume the
-    // available bytes can't change under us.
-    return __WASI_ERRNO_SUCCESS;
+    return nread;
   }
 
-  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override {
+  ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
     uint32_t nwritten;
     if (auto err =
           _wasmfs_node_write(state.getFD(), buf, len, offset, &nwritten)) {
-      return err;
+      return -err;
     }
-    // TODO: Add a way to report the actual bytes written. We currently assume
-    // the write cannot be short.
-    return __WASI_ERRNO_SUCCESS;
+    return nwritten;
   }
 
   void flush() override {

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -131,20 +131,16 @@ private:
     }
   }
 
-  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override {
+  ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
     uint32_t nread;
     proxy([&]() { nread = _wasmfs_opfs_read(accessID, buf, len, offset); });
-    // TODO: Add a way to report the actual bytes read. We currently assume the
-    // available bytes can't change under us.
-    return __WASI_ERRNO_SUCCESS;
+    return nread;
   }
 
-  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override {
+  ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
     uint32_t nwritten;
     proxy([&]() { nwritten = _wasmfs_opfs_write(accessID, buf, len, offset); });
-    // TODO: Add a way to report the actual bytes written. We currently assume
-    // the write cannot be short.
-    return __WASI_ERRNO_SUCCESS;
+    return nwritten;
   }
 
   void flush() override {

--- a/system/lib/wasmfs/backends/proxied_file_backend.cpp
+++ b/system/lib/wasmfs/backends/proxied_file_backend.cpp
@@ -31,14 +31,14 @@ class ProxiedFile : public DataFile {
   }
 
   // Read and write operations are forwarded via the proxying mechanism.
-  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override {
-    __wasi_errno_t result;
+  ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
+    ssize_t result;
     proxy([&]() { result = baseFile->locked().write(buf, len, offset); });
     return result;
   }
 
-  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override {
-    __wasi_errno_t result;
+  ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
+    ssize_t result;
     proxy([&]() { result = baseFile->locked().read(buf, len, offset); });
     return result;
   }

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -130,8 +130,10 @@ protected:
   virtual void open(oflags_t flags) = 0;
   virtual void close() = 0;
 
-  // TODO: Allow backends to override the version of read with multiple iovecs
-  // to make it possible to implement pipes. See #16269.
+  // Return the accessed length or a negative error code. It is not an error to
+  // access fewer bytes than requested.
+  // TODO: Allow backends to override the version of read with
+  // multiple iovecs to make it possible to implement pipes. See #16269.
   virtual ssize_t read(uint8_t* buf, size_t len, off_t offset) = 0;
   virtual ssize_t write(const uint8_t* buf, size_t len, off_t offset) = 0;
 

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -132,9 +132,8 @@ protected:
 
   // TODO: Allow backends to override the version of read with multiple iovecs
   // to make it possible to implement pipes. See #16269.
-  virtual __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) = 0;
-  virtual __wasi_errno_t
-  write(const uint8_t* buf, size_t len, off_t offset) = 0;
+  virtual ssize_t read(uint8_t* buf, size_t len, off_t offset) = 0;
+  virtual ssize_t write(const uint8_t* buf, size_t len, off_t offset) = 0;
 
   // Sets the size of the file to a specific size. If new space is allocated, it
   // should be zero-initialized (often backends have an efficient way to do this
@@ -283,10 +282,10 @@ public:
   void open(oflags_t flags) { getFile()->open(flags); }
   void close() { getFile()->close(); }
 
-  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) {
+  ssize_t read(uint8_t* buf, size_t len, off_t offset) {
     return getFile()->read(buf, len, offset);
   }
-  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) {
+  ssize_t write(const uint8_t* buf, size_t len, off_t offset) {
     return getFile()->write(buf, len, offset);
   }
 

--- a/system/lib/wasmfs/js_impl_backend.h
+++ b/system/lib/wasmfs/js_impl_backend.h
@@ -80,15 +80,12 @@ class JSImplFile : public DataFile {
   void open(oflags_t) override {}
   void close() override {}
 
-  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override {
+  ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
     return _wasmfs_jsimpl_write(
       getBackendIndex(), getFileIndex(), buf, len, offset);
   }
 
-  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override {
-    // The caller should have already checked that the offset + len does
-    // not exceed the file's size.
-    assert(offset + len <= getSize());
+  ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
     return _wasmfs_jsimpl_read(
       getBackendIndex(), getFileIndex(), buf, len, offset);
   }

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -21,8 +21,8 @@ class MemoryFile : public DataFile {
 
   void open(oflags_t) override {}
   void close() override {}
-  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override;
-  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override;
+  ssize_t write(const uint8_t* buf, size_t len, off_t offset) override;
+  ssize_t read(uint8_t* buf, size_t len, off_t offset) override;
   void flush() override {}
   size_t getSize() override { return buffer.size(); }
   void setSize(size_t size) override { return buffer.resize(size); }

--- a/system/lib/wasmfs/pipe_backend.h
+++ b/system/lib/wasmfs/pipe_backend.h
@@ -26,22 +26,22 @@ class PipeFile : public DataFile {
   void open(oflags_t) override {}
   void close() override {}
 
-  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override {
+  ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
     for (size_t i = 0; i < len; i++) {
       data->push(buf[i]);
     }
-    return __WASI_ERRNO_SUCCESS;
+    return len;
   }
 
-  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override {
+  ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
     for (size_t i = 0; i < len; i++) {
       if (data->empty()) {
-        return __WASI_ERRNO_INVAL;
+        return i;
       }
       buf[i] = data->front();
       data->pop();
     }
-    return __WASI_ERRNO_SUCCESS;
+    return len;
   }
 
   void flush() override {}

--- a/system/lib/wasmfs/proxied_async_js_impl_backend.h
+++ b/system/lib/wasmfs/proxied_async_js_impl_backend.h
@@ -55,14 +55,14 @@ void _wasmfs_jsimpl_async_write(em_proxying_ctx* ctx,
                                 const uint8_t* buffer,
                                 size_t length,
                                 off_t offset,
-                                __wasi_errno_t* result);
+                                ssize_t* result);
 void _wasmfs_jsimpl_async_read(em_proxying_ctx* ctx,
                                js_index_t backend,
                                js_index_t index,
                                const uint8_t* buffer,
                                size_t length,
                                off_t offset,
-                               __wasi_errno_t* result);
+                               ssize_t* result);
 void _wasmfs_jsimpl_async_get_size(em_proxying_ctx* ctx,
                                    js_index_t backend,
                                    js_index_t index,
@@ -88,27 +88,21 @@ class ProxiedAsyncJSImplFile : public DataFile {
   void open(oflags_t) override {}
   void close() override {}
 
-  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override {
-    __wasi_errno_t result;
+  ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
+    ssize_t result;
     proxy([&](auto ctx) {
       _wasmfs_jsimpl_async_write(
         ctx.ctx, getBackendIndex(), getFileIndex(), buf, len, offset, &result);
     });
-
     return result;
   }
 
-  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override {
-    // The caller should have already checked that the offset + len does
-    // not exceed the file's size.
-    assert(offset + len <= getSize());
-
-    __wasi_errno_t result;
+  ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
+    ssize_t result;
     proxy([&](auto ctx) {
       _wasmfs_jsimpl_async_read(
         ctx.ctx, getBackendIndex(), getFileIndex(), buf, len, offset, &result);
     });
-
     return result;
   }
 

--- a/system/lib/wasmfs/special_files.cpp
+++ b/system/lib/wasmfs/special_files.cpp
@@ -20,11 +20,11 @@ class StdinFile : public DataFile {
   void open(oflags_t) override {}
   void close() override {}
 
-  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override {
-    return __WASI_ERRNO_INVAL;
+  ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
+    return -__WASI_ERRNO_INVAL;
   }
 
-  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override {
+  ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
     // TODO: Implement reading from stdin.
     abort();
   };
@@ -45,8 +45,8 @@ protected:
   void open(oflags_t) override {}
   void close() override {}
 
-  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override {
-    return __WASI_ERRNO_INVAL;
+  ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
+    return -__WASI_ERRNO_INVAL;
   };
 
   void flush() override {
@@ -60,10 +60,10 @@ protected:
   size_t getSize() override { return 0; }
   void setSize(size_t size) override {}
 
-  __wasi_errno_t writeToJS(const uint8_t* buf,
-                           size_t len,
-                           void (*console_write)(const char*),
-                           std::vector<char>& fd_write_buffer) {
+  ssize_t writeToJS(const uint8_t* buf,
+                    size_t len,
+                    void (*console_write)(const char*),
+                    std::vector<char>& fd_write_buffer) {
     for (size_t j = 0; j < len; j++) {
       uint8_t current = buf[j];
       // Flush on either a null or a newline.
@@ -75,7 +75,7 @@ protected:
         fd_write_buffer.push_back(current);
       }
     }
-    return __WASI_ERRNO_SUCCESS;
+    return len;
   }
 
 public:
@@ -85,7 +85,7 @@ public:
 };
 
 class StdoutFile : public WritingStdFile {
-  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override {
+  ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
     // Node and worker threads issue in Emscripten:
     // https://github.com/emscripten-core/emscripten/issues/14804.
     // Issue filed in Node: https://github.com/nodejs/node/issues/40961
@@ -100,7 +100,7 @@ public:
 };
 
 class StderrFile : public WritingStdFile {
-  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override {
+  ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
     // Similar issue with Node and worker threads as emscripten_out.
     // TODO: May not want to proxy stderr (fd == 2) to the main thread, as
     //       emscripten_err does.


### PR DESCRIPTION
We previously tried to prevent reads and writes beyond the ends of files by
calling `getSize` on files in the backend-independent implementations of `read`
and `write` and adjusting the length we passed to the backend accordingly. This
works fine when files have meaningful lengths, reads and writes are guaranteed
not to be shortened by the underlying APIs, and files cannot change size
concurrently with the syscall execution, but those requirements are not always
met.

Instead, change the backend API to match the `pread` and `pwrite` syscall APIs,
which allow accesses to be shorter than requested. Specifically, change the
return types to be `ssize_t` so that the accessed lengths can be returned. Error
codes are now returned as negative values, just like in the syscalls themselves.

This change will also have performance benefits, especially for the OPFS
backend, in which getting the size of a file is an asynchronous operation that
is much slower than a small read or write.