### PR TITLE
browser_tests: Report exceptions as test results. NFC

### DIFF
--- a/tests/browser/async_bad_list.cpp
+++ b/tests/browser/async_bad_list.cpp
@@ -8,6 +8,7 @@
 
 int main() {
   int x = EM_ASM_INT({
+    window.disableErrorReporting = true;
     window.onerror = function(e) {
       var message = e.toString();
       var success = message.indexOf("unreachable") >= 0 || // firefox

--- a/tests/browser/async_returnvalue.cpp
+++ b/tests/browser/async_returnvalue.cpp
@@ -32,6 +32,7 @@ extern "C" int sync_tunnel_bool(bool);
 int main() {
 #ifdef BAD
   EM_ASM({
+    window.disableErrorReporting = true;
     window.onerror = function(e) {
       var success = e.toString().indexOf("import sync_tunnel was not in ASYNCIFY_IMPORTS, but changed the state") > 0;
       if (success && !Module.reported) {

--- a/tests/common.py
+++ b/tests/common.py
@@ -1330,7 +1330,7 @@ def harness_server_func(in_queue, out_queue, port):
         self.end_headers()
         self.wfile.write(b'OK')
 
-      elif 'stdout=' in self.path or 'stderr=' in self.path or 'exception=' in self.path:
+      elif 'stdout=' in self.path or 'stderr=' in self.path:
         '''
           To get logging to the console from browser tests, add this to
           print/printErr/the exception handler in src/shell.html:

--- a/tests/emscripten_throw_number_pre.js
+++ b/tests/emscripten_throw_number_pre.js
@@ -1,6 +1,5 @@
 addEventListener('error', function(event) {
-  event.preventDefault();
-  event.stopPropagation();
+  window.disableErrorReporting = true;
   var result = event.error === 42 ? 0 : 1;
   var xhr = new XMLHttpRequest();
   xhr.open('GET', 'http://localhost:8888/report_result?' + result, true);

--- a/tests/emscripten_throw_string_pre.js
+++ b/tests/emscripten_throw_string_pre.js
@@ -1,6 +1,5 @@
 addEventListener('error', function(event) {
-  event.preventDefault();
-  event.stopPropagation();
+  window.disableErrorReporting = true;
   var result = event.error === 'Hello!' ? 0 : 1;
   var xhr = new XMLHttpRequest();
   xhr.open('GET', 'http://localhost:8888/report_result?' + result, true);

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -659,6 +659,7 @@ If manually bisecting:
           <hr><div id='output'></div><hr>
           <script type='text/javascript'>
             window.onerror = function(error) {
+              window.disableErrorReporting = true;
               window.onerror = null;
               var result = error.indexOf("test.data") >= 0 ? 1 : 0;
               var xhr = new XMLHttpRequest();
@@ -2587,6 +2588,18 @@ Module["preRun"].push(function () {
   })
   @requires_threads
   def test_html5_core(self, opts):
+    if '-sHTML5_SUPPORT_DEFERRING_USER_SENSITIVE_REQUESTS=0' in opts:
+      # In this mode an exception can be thrown by the browser, and we don't
+      # want the test to fail in that case so we override the error handling.
+      create_file('pre.js', '''
+      window.disableErrorReporting = true;
+      window.addEventListener('error', (event) => {
+        if (!event.message.includes('exception:fullscreen error')) {
+          report_error(event);
+        }
+      });
+      ''')
+      self.emcc_args.append('--pre-js=pre.js')
     self.btest(test_file('test_html5_core.c'), args=opts, expected='0')
 
   @requires_threads


### PR DESCRIPTION
I noticed that exceptions in browser tests were not being reported
as test failure, but showing up as `[no http server activity]`.

With this change, exceptions are treated as results and will cause
synchronous test failure with more meaningful errors.