### PR TITLE
Rename EM_BUILD_VERBOSE -> EMTEST_BUILD_VERBOSE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,11 @@ executors:
       - image: emscripten/emscripten-ci
     environment:
       LANG: "C.UTF-8"
-      EMTEST_DETECT_TEMPFILE_LEAKS: "1"
       EMCC_CORES: "4"
       EMSDK_NOTTY: "1"
       EMTEST_WASI_SYSROOT: "~/wasi-sdk/wasi-sysroot"
+      EMTEST_BUILD_VERBOSE: "2"
+      EMTEST_DETECT_TEMPFILE_LEAKS: "1"
   mac:
     environment:
       EMSDK_NOTTY: "1"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,10 +20,12 @@ See docs/process.md for more on how version tagging works.
 
 3.1.11
 ------
-- Bug fixes
+- The `EM_BUILD_VERBOSE` environment variable only effects test code these days
+  and therefore was renamed to `EMTEST_BUILD_VERBOSE`.
 
 3.1.10 - 05/02/2022
 -------------------
+- Bug fixes
 
 3.1.9 - 04/21/2022
 ------------------

--- a/tests/common.py
+++ b/tests/common.py
@@ -31,9 +31,8 @@ import clang_native
 import jsrun
 from tools.shared import TEMP_DIR, EMCC, EMXX, DEBUG, EMCONFIGURE, EMCMAKE
 from tools.shared import EMSCRIPTEN_TEMP_DIR
-from tools.shared import EM_BUILD_VERBOSE
 from tools.shared import get_canonical_temp_dir, try_delete, path_from_root
-from tools.utils import MACOS, WINDOWS, read_file, read_binary, write_file, write_binary
+from tools.utils import MACOS, WINDOWS, read_file, read_binary, write_file, write_binary, exit_with_error
 from tools import shared, line_endings, building, config
 
 logger = logging.getLogger('common')
@@ -59,6 +58,15 @@ EMTEST_LACKS_NATIVE_CLANG = None
 EMTEST_VERBOSE = None
 EMTEST_REBASELINE = None
 EMTEST_FORCE64 = None
+
+# Verbosity level control for subprocess calls to configure + make.
+# 0: disabled.
+# 1: Log stderr of configure/make.
+# 2: Log stdout and stderr configure/make. Print out subprocess commands that were executed.
+# 3: Log stdout and stderr, and pass VERBOSE=1 to CMake/configure/make steps.
+EMTEST_BUILD_VERBOSE = int(os.getenv('EMTEST_BUILD_VERBOSE', '0'))
+if 'EM_BUILD_VERBOSE' in os.environ:
+  exit_with_error('EM_BUILD_VERBOSE has been renamed to EMTEST_BUILD_VERBOSE')
 
 # Special value for passing to assert_returncode which means we expect that program
 # to fail with non-zero return code, but we don't care about specifically which one.
@@ -1757,8 +1765,8 @@ def build_library(name,
     try:
       with open(os.path.join(project_dir, 'configure_out'), 'w') as out:
         with open(os.path.join(project_dir, 'configure_err'), 'w') as err:
-          stdout = out if EM_BUILD_VERBOSE < 2 else None
-          stderr = err if EM_BUILD_VERBOSE < 1 else None
+          stdout = out if EMTEST_BUILD_VERBOSE < 2 else None
+          stderr = err if EMTEST_BUILD_VERBOSE < 1 else None
           shared.run_process(configure, env=env, stdout=stdout, stderr=stderr,
                              cwd=project_dir)
     except subprocess.CalledProcessError:
@@ -1779,14 +1787,14 @@ def build_library(name,
   def open_make_err(mode='r'):
     return open(os.path.join(project_dir, 'make.err'), mode)
 
-  if EM_BUILD_VERBOSE >= 3:
+  if EMTEST_BUILD_VERBOSE >= 3:
     make_args += ['VERBOSE=1']
 
   try:
     with open_make_out('w') as make_out:
       with open_make_err('w') as make_err:
-        stdout = make_out if EM_BUILD_VERBOSE < 2 else None
-        stderr = make_err if EM_BUILD_VERBOSE < 1 else None
+        stdout = make_out if EMTEST_BUILD_VERBOSE < 2 else None
+        stderr = make_err if EMTEST_BUILD_VERBOSE < 1 else None
         shared.run_process(make + make_args, stdout=stdout, stderr=stderr, env=env,
                            cwd=project_dir)
   except subprocess.CalledProcessError:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -29,13 +29,13 @@ if __name__ == '__main__':
   raise Exception('do not run this file directly; do something like: tests/runner other')
 
 from tools.shared import try_delete, config
-from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, PYTHON, FILE_PACKAGER, WINDOWS, EM_BUILD_VERBOSE
+from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, PYTHON, FILE_PACKAGER, WINDOWS
 from tools.shared import CLANG_CC, CLANG_CXX, LLVM_AR, LLVM_DWARFDUMP, LLVM_DWP, EMCMAKE, EMCONFIGURE
 from common import RunnerCore, path_from_root, is_slow_test, ensure_dir, disabled, make_executable
 from common import env_modify, no_mac, no_windows, requires_native_clang, with_env_modify
 from common import create_file, parameterized, NON_ZERO, node_pthreads, TEST_ROOT, test_file
 from common import compiler_for, read_file, read_binary, EMBUILDER, require_v8, require_node
-from common import also_with_minimal_runtime, also_with_wasm_bigint
+from common import also_with_minimal_runtime, also_with_wasm_bigint, EMTEST_BUILD_VERBOSE
 from tools import shared, building, utils, deps_info, response_file
 import common
 import jsrun
@@ -655,13 +655,13 @@ f.close()
         if test_dir == 'target_html':
           env['EMCC_SKIP_SANITY_CHECK'] = '1'
         print(str(cmd))
-        self.run_process(cmd, env=env, stdout=None if EM_BUILD_VERBOSE >= 2 else PIPE, stderr=None if EM_BUILD_VERBOSE >= 1 else PIPE)
+        self.run_process(cmd, env=env, stdout=None if EMTEST_BUILD_VERBOSE >= 2 else PIPE, stderr=None if EMTEST_BUILD_VERBOSE >= 1 else PIPE)
 
         # Build
         cmd = conf['build']
-        if EM_BUILD_VERBOSE >= 3 and 'Ninja' not in generator:
+        if EMTEST_BUILD_VERBOSE >= 3 and 'Ninja' not in generator:
           cmd += ['VERBOSE=1']
-        self.run_process(cmd, stdout=None if EM_BUILD_VERBOSE >= 2 else PIPE)
+        self.run_process(cmd, stdout=None if EMTEST_BUILD_VERBOSE >= 2 else PIPE)
         self.assertExists(tempdirname + '/' + output_file, 'building a cmake-generated Makefile failed to produce an output file %s!' % tempdirname + '/' + output_file)
 
         # Run through node, if CMake produced a .js file.

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -675,14 +675,6 @@ def get_llvm_target():
 # file.  TODO(sbc): We should try to reduce that amount we do here and instead
 # have consumers explicitly call initialization functions.
 
-# Verbosity level control for any intermediate subprocess spawns from the compiler. Useful for internal debugging.
-# 0: disabled.
-# 1: Log stderr of subprocess spawns.
-# 2: Log stdout and stderr of subprocess spawns. Print out subprocess commands that were executed.
-# 3: Log stdout and stderr, and pass VERBOSE=1 to CMake configure steps.
-EM_BUILD_VERBOSE = int(os.getenv('EM_BUILD_VERBOSE', '0'))
-TRACK_PROCESS_SPAWNS = EM_BUILD_VERBOSE >= 3
-
 set_version_globals()
 
 CLANG_CC = os.path.expanduser(build_clang_tool_path(exe_suffix('clang')))


### PR DESCRIPTION
This environment variable is now only used by test code so I've
moved it into tests/common.py and renamed it.

Also, set EMTEST_BUILD_VERBOSE=2 in CI to get more information output.