### PR TITLE
Temporarily set -Wno-pointer-sign for zlib build

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1229,9 +1229,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
   def get_zlib_library(self):
     return self.get_library(os.path.join('third_party', 'zlib'), os.path.join('libz.a'),
-                              configure=['cmake', '.'],
-                              make=['cmake', '--build', '.'],
-                              make_args=[])
+                            configure=['cmake', '.'],
+                            make=['cmake', '--build', '.'],
+                            make_args=[])
 
 
 # Run a server and a web page. When a test runs, we tell the server about it,

--- a/tests/common.py
+++ b/tests/common.py
@@ -1227,7 +1227,6 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
     return poppler + freetype
 
-
   def get_zlib_library(self, cmake):
     assert cmake or not WINDOWS, 'on windows, get_zlib_library only supports cmake'
 
@@ -1248,7 +1247,6 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       rtn = self.get_library(os.path.join('third_party', 'zlib'), os.path.join('libz.a'), make_args=['libz.a'])
     self.emcc_args = old_args
     return rtn
-
 
 
 # Run a server and a web page. When a test runs, we tell the server about it,

--- a/tests/common.py
+++ b/tests/common.py
@@ -1228,14 +1228,10 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     return poppler + freetype
 
   def get_zlib_library(self):
-    # TODO: remove -Wno-unknown-warning-option when clang rev 11da1b53 rolls into emscripten
-    self.emcc_args += ['-Wno-deprecated-non-prototype', '-Wno-unknown-warning-option']
-    if WINDOWS:
-      return self.get_library(os.path.join('third_party', 'zlib'), os.path.join('libz.a'),
+    return self.get_library(os.path.join('third_party', 'zlib'), os.path.join('libz.a'),
                               configure=['cmake', '.'],
                               make=['cmake', '--build', '.'],
                               make_args=[])
-    return self.get_library(os.path.join('third_party', 'zlib'), os.path.join('libz.a'), make_args=['libz.a'])
 
 
 # Run a server and a web page. When a test runs, we tell the server about it,


### PR DESCRIPTION
zlib's configure script assumes that test compiles failed if there is any output on stderr (rather than being based on exit status). Sometimes emscripten prints "building libc" or similar if it needs to build a library. This causes flaky failures in running the tests. See #16908 for details.
This PR works around the problem by disabling the warning, but doesn't fix the underlying problem.