### PR TITLE
Fix use of `waitAsync` and closure compiler warnings in WASM_WORKERS mode

### DIFF
--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -212,7 +212,7 @@ mergeInto(LibraryManager.library, {
   // see https://bugs.chromium.org/p/chromium/issues/detail?id=1167541
   // https://github.com/tc39/proposal-atomics-wait-async/blob/master/PROPOSAL.md
   // This polyfill performs polling with setTimeout() to observe a change in the target memory location.
-  emscripten_atomic_wait_async__postset: "if (!Atomics['waitAsync'] || parseInt((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91) { \n"+
+  emscripten_atomic_wait_async__postset: "if (!Atomics['waitAsync'] || jstoi_q((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91) { \n"+
 "let __Atomics_waitAsyncAddresses = [/*[i32a, index, value, maxWaitMilliseconds, promiseResolve]*/];\n"+
 "function __Atomics_pollWaitAsyncAddresses() {\n"+
 "  let now = performance.now();\n"+
@@ -259,7 +259,7 @@ mergeInto(LibraryManager.library, {
   _emscripten_atomic_live_wait_asyncs: '{}',
   _emscripten_atomic_live_wait_asyncs_counter: '0',
 
-  emscripten_atomic_wait_async__deps: ['_emscripten_atomic_wait_states', '_emscripten_atomic_live_wait_asyncs', '_emscripten_atomic_live_wait_asyncs_counter'],
+  emscripten_atomic_wait_async__deps: ['_emscripten_atomic_wait_states', '_emscripten_atomic_live_wait_asyncs', '_emscripten_atomic_live_wait_asyncs_counter', '$jstoi_q'],
   emscripten_atomic_wait_async: function(addr, val, asyncWaitFinished, userData, maxWaitMilliseconds) {
     let wait = Atomics['waitAsync'](HEAP32, addr >> 2, val, maxWaitMilliseconds);
     if (!wait.async) return __emscripten_atomic_wait_states.indexOf(wait.value);
@@ -340,9 +340,9 @@ mergeInto(LibraryManager.library, {
     };
     let tryAcquireLock = () => {
       do {
-        let val = Atomics.compareExchange(HEAPU32, lock >> 2, 0/*zero represents lock being free*/, 1/*one represents lock being acquired*/);
+        var val = Atomics.compareExchange(HEAP32, lock >> 2, 0/*zero represents lock being free*/, 1/*one represents lock being acquired*/);
         if (!val) return dispatch(0, 0/*'ok'*/);
-        var wait = Atomics['waitAsync'](HEAPU32, lock >> 2, val, maxWaitMilliseconds);
+        var wait = Atomics['waitAsync'](HEAP32, lock >> 2, val, maxWaitMilliseconds);
       } while(wait.value === 'not-equal');
 #if ASSERTIONS
       assert(wait.async || wait.value === 'timed-out');
@@ -362,12 +362,12 @@ mergeInto(LibraryManager.library, {
     let tryAcquireSemaphore = () => {
       let val = num;
       do {
-        let ret = Atomics.compareExchange(HEAPU32, sem >> 2,
+        let ret = Atomics.compareExchange(HEAP32, sem >> 2,
                                           val, /* We expect this many semaphore resoures to be available*/
                                           val - num /* Acquire 'num' of them */);
         if (ret == val) return dispatch(ret/*index of resource acquired*/, 0/*'ok'*/);
         val = ret;
-        let wait = Atomics['waitAsync'](HEAPU32, sem >> 2, ret, maxWaitMilliseconds);
+        let wait = Atomics['waitAsync'](HEAP32, sem >> 2, ret, maxWaitMilliseconds);
       } while(wait.value === 'not-equal');
 #if ASSERTIONS
       assert(wait.async || wait.value === 'timed-out');

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5223,7 +5223,7 @@ window.close = function() {
   # Tests emscripten_lock_async_acquire() function.
   @also_with_minimal_runtime
   def test_wasm_worker_lock_async_acquire(self):
-    self.btest(test_file('wasm_worker/lock_async_acquire.c'), expected='0', args=['-sWASM_WORKERS'])
+    self.btest(test_file('wasm_worker/lock_async_acquire.c'), expected='0', args=['--closure=1', '-sWASM_WORKERS'])
 
   # Tests emscripten_lock_busyspin_wait_acquire() in Worker and main thread.
   @also_with_minimal_runtime

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11901,6 +11901,10 @@ Module['postRun'] = function() {
   def test_wasm_worker_preprocessor_flags(self):
     self.run_process([EMCC, '-c', test_file('wasm_worker/wasm_worker_preprocessor_flags.c'), '-sWASM_WORKERS'])
 
+  @also_with_minimal_runtime
+  def test_wasm_worker_closure(self):
+    self.run_process([EMCC, test_file('wasm_worker/lock_async_acquire.c'), '-O2', '-sWASM_WORKERS', '--closure=1'])
+
   def test_debug_opt_warning(self):
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '-O2', '-g', '-Werror'])
     self.assertContained('error: running limited binaryen optimizations because DWARF info requested (or indirectly required) [-Wlimited-postlink-optimizations]', err)


### PR DESCRIPTION
`waitAsync` seems to require an int32 rather than uint32 view.  Without
this change I get bunch of errors run from when running
`browser.test_wasm_worker_lock_async_acquire`:

`TypeError: [object Uint32Array] is not an int32 or BigInt64 typed array`