### PR TITLE
Make `do_run` test functions consistent

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1100,7 +1100,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     banned = [b[0] for b in self.banned_js_engines if b]
     return [engine for engine in js_engines if engine and engine[0] not in banned]
 
-  def do_run(self, src, expected_output, force_c=False, **kwargs):
+  def do_run(self, src, expected_output=None, force_c=False, **kwargs):
     if 'no_build' in kwargs:
       filename = src
     else:
@@ -1109,21 +1109,21 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       else:
         filename = 'src.cpp'
       write_file(filename, src)
-    self._build_and_run(filename, expected_output, **kwargs)
+    return self._build_and_run(filename, expected_output, **kwargs)
 
   def do_runf(self, filename, expected_output=None, **kwargs):
     return self._build_and_run(filename, expected_output, **kwargs)
 
   ## Just like `do_run` but with filename of expected output
   def do_run_from_file(self, filename, expected_output_filename, **kwargs):
-    self._build_and_run(filename, read_file(expected_output_filename), **kwargs)
+    return self._build_and_run(filename, read_file(expected_output_filename), **kwargs)
 
   def do_run_in_out_file_test(self, *path, **kwargs):
     srcfile = test_file(*path)
     out_suffix = kwargs.pop('out_suffix', '')
     outfile = shared.unsuffixed(srcfile) + out_suffix + '.out'
     expected = read_file(outfile)
-    self._build_and_run(srcfile, expected, **kwargs)
+    return self._build_and_run(srcfile, expected, **kwargs)
 
   ## Does a complete test - builds, runs, checks output, etc.
   def _build_and_run(self, filename, expected_output, args=[], output_nicerizer=None,


### PR DESCRIPTION
- `do_run` also sets `expected_output=None`, like `do_runf`.
- `do_run`, `do_run_from_file`, and `do_run_in_out_file_test` now return
  the stdout+stderr output, like `do_runf`.