### PR TITLE
Fix MAX_TEXTURES calculation

### DIFF
--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -2881,7 +2881,7 @@ var LibraryGLEmulation = {
       // User can override the maximum number of texture units that we emulate. Using fewer texture units increases runtime performance
       // slightly, so it is advantageous to choose as small value as needed.
       // Limit to a maximum of 28 to not overflow the state bits used for renderer caching (31 bits = 3 attributes + 28 texture units).
-      GLImmediate.MAX_TEXTURES = Math.max(Module['GL_MAX_TEXTURE_IMAGE_UNITS'] || GLctx.getParameter(GLctx.MAX_TEXTURE_IMAGE_UNITS), 28);
+      GLImmediate.MAX_TEXTURES = Math.min(Module['GL_MAX_TEXTURE_IMAGE_UNITS'] || GLctx.getParameter(GLctx.MAX_TEXTURE_IMAGE_UNITS), 28);
 
       GLImmediate.TexEnvJIT.init(GLctx, GLImmediate.MAX_TEXTURES);
 


### PR DESCRIPTION
Using `Math.max` is incorrect in the calculation because there is no actual way to reduce the `MAX_TEXTURES` value, as it was the original intention behind adding this calculation. 
Also, as the value `28` is usually bigger than the most common value of `MAX_TEXTURE_IMAGE_UNITS` and it produces some warnings because on some calls we try to use an index bigger than `MAX_TEXTURE_IMAGE_UNITS`, e.g:
```
WebGL: INVALID_VALUE: vertexAttrib4f: index out of range
```