### PR TITLE
Fixes #16913: Don't use fetch() in Node.js environment

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1234,6 +1234,15 @@ function createWasm() {
         // Don't use streaming for file:// delivered objects in a webview, fetch them synchronously.
         !isFileURI(wasmBinaryFile) &&
 #endif
+#if ENVIRONMENT_MAY_BE_NODE
+        // Avoid instantiateStreaming() on Node.js environment for now, as while
+        // Node.js v18.1.0 implements it, it does not have a full fetch()
+        // implementation yet.
+        //
+        // Reference:
+        //   https://github.com/emscripten-core/emscripten/pull/16917
+        !ENVIRONMENT_IS_NODE &&
+#endif
         typeof fetch == 'function') {
       return fetch(wasmBinaryFile, {{{ makeModuleReceiveExpr('fetchSettings', "{ credentials: 'same-origin' }") }}}).then(function(response) {
         // Suppress closure warning here since the upstream definition for


### PR DESCRIPTION
Node.js v18.1.0 has implemented `WebAssembly.instantiateStreaming` API, and it broked all emscriptened js codes since emscripten is using `WebAssembly.instantiateStreaming` as a criterion to distinguish whether it is Node.js environment or a browser environment.

The issue will be fixed if we use `ENVIRONMENT_IS_NODE` as a proper criterion to distinguish Node.js environment.

Fixes #16913, https://github.com/antelle/argon2-browser/issues/81.

###### References
- https://github.com/nodejs/node/pull/42701
- https://github.com/antelle/argon2-browser/issues/81
- https://github.com/simnalamburt/argon2-browser-error-repro
- https://github.com/emscripten-core/emscripten/issues/16913