### PR TITLE
[EH] Make std::terminate() work with EH

### DIFF
--- a/system/lib/libcxx/include/exception
+++ b/system/lib/libcxx/include/exception
@@ -45,7 +45,11 @@ unexpected_handler get_unexpected() noexcept;
 typedef void (*terminate_handler)();
 terminate_handler set_terminate(terminate_handler  f ) noexcept;
 terminate_handler get_terminate() noexcept;
+#ifdef __USING_WASM_EXCEPTIONS__
+[[noreturn]] void terminate();
+#else
 [[noreturn]] void terminate() noexcept;
+#endif
 
 bool uncaught_exception()  noexcept;
 int  uncaught_exceptions() noexcept;  // C++17
@@ -128,7 +132,11 @@ _LIBCPP_NORETURN _LIBCPP_FUNC_VIS void unexpected();
 typedef void (*terminate_handler)();
 _LIBCPP_FUNC_VIS terminate_handler set_terminate(terminate_handler) _NOEXCEPT;
 _LIBCPP_FUNC_VIS terminate_handler get_terminate() _NOEXCEPT;
+#ifdef __USING_WASM_EXCEPTIONS__
+_LIBCPP_NORETURN _LIBCPP_FUNC_VIS void terminate();
+#else
 _LIBCPP_NORETURN _LIBCPP_FUNC_VIS void terminate() _NOEXCEPT;
+#endif
 
 _LIBCPP_FUNC_VIS bool uncaught_exception() _NOEXCEPT;
 _LIBCPP_FUNC_VIS _LIBCPP_AVAILABILITY_UNCAUGHT_EXCEPTIONS int uncaught_exceptions() _NOEXCEPT;

--- a/system/lib/libcxx/include/exception
+++ b/system/lib/libcxx/include/exception
@@ -46,6 +46,8 @@ typedef void (*terminate_handler)();
 terminate_handler set_terminate(terminate_handler  f ) noexcept;
 terminate_handler get_terminate() noexcept;
 #ifdef __USING_WASM_EXCEPTIONS__
+// In Wasm EH, a JS exception thrown by abort() is caught by 'noexcept' cleanup
+// // from which std::__terminate is called again, causing an infinite loop
 [[noreturn]] void terminate();
 #else
 [[noreturn]] void terminate() noexcept;
@@ -133,6 +135,8 @@ typedef void (*terminate_handler)();
 _LIBCPP_FUNC_VIS terminate_handler set_terminate(terminate_handler) _NOEXCEPT;
 _LIBCPP_FUNC_VIS terminate_handler get_terminate() _NOEXCEPT;
 #ifdef __USING_WASM_EXCEPTIONS__
+// In Wasm EH, a JS exception thrown by abort() is caught by 'noexcept' cleanup
+// // from which std::__terminate is called again, causing an infinite loop
 _LIBCPP_NORETURN _LIBCPP_FUNC_VIS void terminate();
 #else
 _LIBCPP_NORETURN _LIBCPP_FUNC_VIS void terminate() _NOEXCEPT;

--- a/system/lib/libcxxabi/src/cxa_handlers.cpp
+++ b/system/lib/libcxxabi/src/cxa_handlers.cpp
@@ -50,7 +50,13 @@ get_terminate() noexcept
 }
 
 void
+#ifdef __USING_WASM_EXCEPTIONS__
+// In Wasm EH, a JS exception thrown by abort() is caught by 'noexcept' cleanup
+// from which std::__terminate is called again, causing an infinite loop
+__terminate(terminate_handler func)
+#else
 __terminate(terminate_handler func) noexcept
+#endif
 {
 #ifndef _LIBCXXABI_NO_EXCEPTIONS
     try
@@ -71,7 +77,13 @@ __terminate(terminate_handler func) noexcept
 
 __attribute__((noreturn))
 void
+#ifdef __USING_WASM_EXCEPTIONS__
+// In Wasm EH, a JS exception thrown by abort() is caught by 'noexcept' cleanup
+// from which std::terminate is called again, causing an infinite loop
+terminate()
+#else
 terminate() noexcept
+#endif
 {
 #if !defined(_LIBCXXABI_NO_EXCEPTIONS) && !defined(__USING_EMSCRIPTEN_EXCEPTIONS__)
     // If there might be an uncaught exception

--- a/system/lib/libcxxabi/src/cxa_handlers.h
+++ b/system/lib/libcxxabi/src/cxa_handlers.h
@@ -25,7 +25,11 @@ __unexpected(unexpected_handler func);
 
 _LIBCXXABI_HIDDEN _LIBCXXABI_NORETURN
 void
+#ifdef __USING_WASM_EXCEPTIONS__
 __terminate(terminate_handler func);
+#else
+__terminate(terminate_handler func) noexcept;
+#endif
 
 }  // std
 

--- a/system/lib/libcxxabi/src/cxa_handlers.h
+++ b/system/lib/libcxxabi/src/cxa_handlers.h
@@ -26,6 +26,8 @@ __unexpected(unexpected_handler func);
 _LIBCXXABI_HIDDEN _LIBCXXABI_NORETURN
 void
 #ifdef __USING_WASM_EXCEPTIONS__
+// In Wasm EH, a JS exception thrown by abort() is caught by 'noexcept' cleanup
+// // from which std::__terminate is called again, causing an infinite loop
 __terminate(terminate_handler func);
 #else
 __terminate(terminate_handler func) noexcept;

--- a/system/lib/libcxxabi/src/cxa_handlers.h
+++ b/system/lib/libcxxabi/src/cxa_handlers.h
@@ -25,7 +25,7 @@ __unexpected(unexpected_handler func);
 
 _LIBCXXABI_HIDDEN _LIBCXXABI_NORETURN
 void
-__terminate(terminate_handler func) noexcept;
+__terminate(terminate_handler func);
 
 }  // std
 


### PR DESCRIPTION
`noexcept` function shouldn't throw, so `noexcept` function code
generation is to `invoke` every function call in those functions and in
case they throw, call `std::terminate`. This codegen comes from clang
and native platforms do this too. So in wasm, they become something like
```wasm
try
  function body
catch_all
  call std::terminate
end
```

`std::terminate` calls `std::__terminate`. Both of `std::terminate` and
`std::__terminate` are `noexcept` now. So that means their code is
structured like that, which sounds like self-calling, but normally no
function calls in those functions should ever throw, so that's fine. But
in our case, `abort` ends up throwing, which is a problem.

The function body of `__terminate` eventually calls JS `abort`, and ends
up here:
https://github.com/emscripten-core/emscripten/blob/970998b2670a9bcf39d31e2b01db571089955add/src/preamble.js#L605-L623

This ends up throwing a JS exception. This is basically just a foreign
exception from the wasm perspective, and is caught by `catch_all`, and
calls `std::terminate` again. And the whole process continues until the
call stack is exhausted.

What #9730 tried to do was throwing a trap, because Wasm
`catch`/`catch_all` don't catch traps. Traps become `RuntimeError`s
after they hit a JS frame. To be consistent, we decided
`catch`/`catch_all` shouldn't catch them after they become
`RuntimeError`s. That's the reason #9730 changed the code to throw not
just any random thing but `RuntimeError`. But somehow we decided that we
make that trap distinction not based on `RuntimeError` class but some
hidden field
(https://github.com/WebAssembly/exception-handling/issues/89#issuecomment-559533953).

This PR removes `noexcept` from `std::terminate` and
`std::__terminate`'s signatures so that the cleanup that contains
`catch_all` is not generated for those two functions. So now the JS
exception thrown by `abort()` will unwind the stack, which is different
from native, but that can be considered OK because I don't think users
expect `abort` to preserve the stack intact?

Fixes #16407.