### PR TITLE
Exclude `__cxa_atexit` definition from LTO

### DIFF
--- a/tests/other/test_lto_atexit.c
+++ b/tests/other/test_lto_atexit.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+
+// In Wasm destructors get lowered to constructors that call `__cxa_atexit`.
+//
+// Because this lowering happens during compilation this symbol cannot itself be
+// compiled as LTO (since generated new references to LTO symbols at LTO time
+// results int link failure).  We had a bug where this symbol was itself LTO
+// which can cause link failures.
+//
+// See: https://github.com/emscripten-core/emscripten/issues/16836
+void my_dtor() __attribute__((destructor));
+
+void my_dtor() {
+  printf("my_dtor\n");
+}
+
+int main() {
+  printf("main done\n");
+  return 0;
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11963,3 +11963,14 @@ Module['postRun'] = function() {
   @also_with_wasm_bigint
   def test_parseTools(self):
     self.do_other_test('test_parseTools.c', emcc_args=['--js-library', test_file('other/test_parseTools.js')])
+
+  def test_lto_atexit(self):
+    self.emcc_args.append('-flto')
+
+    # Without EXIT_RUNTIME we don't expect the dtor to run at all
+    output = self.do_runf(test_file('other/test_lto_atexit.c'), 'main done')
+    self.assertNotContained('my_dtor', output)
+
+    # With EXIT_RUNTIME we expect to see the dtor running.
+    self.set_setting('EXIT_RUNTIME')
+    self.do_runf(test_file('other/test_lto_atexit.c'), 'main done\nmy_dtor\n')

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -714,6 +714,9 @@ class libcompiler_rt(MTLibrary, SjLjLibrary):
 
 class libnoexit(Library):
   name = 'libnoexit'
+  # __cxa_atexit calls can be generated during LTO the implemenation cannot
+  # itself be LTO.  See `get_libcall_files` below for more details.
+  force_object_files = True
   src_dir = 'system/lib/libc'
   src_files = ['atexit_dummy.c']
 
@@ -780,6 +783,10 @@ class libc(MuslInternalLibrary,
     ]
     math_files = files_in_path(path='system/lib/libc/musl/src/math', filenames=math_files)
 
+    exit_files = files_in_path(
+        path='system/lib/libc/musl/src/exit',
+        filenames=['atexit.c'])
+
     other_files = files_in_path(
       path='system/lib/libc',
       filenames=['emscripten_memcpy.c', 'emscripten_memset.c',
@@ -802,7 +809,7 @@ class libc(MuslInternalLibrary,
     iprintf_files += files_in_path(
       path='system/lib/libc/musl/src/string',
       filenames=['strlen.c'])
-    return math_files + other_files + iprintf_files
+    return math_files + exit_files + other_files + iprintf_files
 
   def get_files(self):
     libc_files = []


### PR DESCRIPTION
Without this change the test fails with:

```
wasm-ld: error: ...sysroot/lib/wasm32-emscripten/lto/libnoexit.a(atexit_dummy.o): attempt to add bitcode file after LTO.
```

See #16836