### PR TITLE
Fix websocket_to_posix_proxy API call error checks

### DIFF
--- a/tools/websocket_to_posix_proxy/src/posix_sockets.h
+++ b/tools/websocket_to_posix_proxy/src/posix_sockets.h
@@ -20,6 +20,8 @@
 #define SEND_FORMATTING_SPECIFIER "%ld"
 #define CLOSE_SOCKET(x) close(x)
 
+#define CREATE_SOCKET_CALL_RETURNS_AN_ERROR(x) ((x) < 0)
+#define SOCKET_API_CALL_RETURNS_AN_ERROR(x) ((x) < 0)
 #define GET_SOCKET_ERROR() (errno)
 
 #define PRINT_SOCKET_ERROR(errorCode) do { \
@@ -39,6 +41,15 @@
 #define SEND_RET_TYPE int
 #define SEND_FORMATTING_SPECIFIER "%d"
 #define CLOSE_SOCKET(x) closesocket(x)
+
+// Winsock documentation states that the "BSD style of error checking "will not work on Windows":
+// https://docs.microsoft.com/en-us/windows/win32/winsock/return-values-on-function-failure-2
+// but instead must check against SOCKET_ERROR or INVALID_SOCKET
+
+// On Windows, API calls that return a socket should test against INVALID_SOCKET:
+// https://docs.microsoft.com/en-us/windows/win32/winsock/handling-winsock-errors
+#define CREATE_SOCKET_CALL_RETURNS_AN_ERROR(x) ((x) == INVALID_SOCKET)
+#define SOCKET_API_CALL_RETURNS_AN_ERROR(x) ((x) == SOCKET_ERROR)
 
 #define GET_SOCKET_ERROR() (WSAGetLastError())
 

--- a/tools/websocket_to_posix_proxy/src/posix_sockets.h
+++ b/tools/websocket_to_posix_proxy/src/posix_sockets.h
@@ -20,8 +20,8 @@
 #define SEND_FORMATTING_SPECIFIER "%ld"
 #define CLOSE_SOCKET(x) close(x)
 
-#define CREATE_SOCKET_CALL_RETURNS_AN_ERROR(x) ((x) < 0)
-#define SOCKET_API_CALL_RETURNS_AN_ERROR(x) ((x) < 0)
+#define IS_CREATE_SOCKET_ERROR(x) ((x) < 0)
+#define IS_SOCKET_API_ERROR(x) ((x) < 0)
 #define GET_SOCKET_ERROR() (errno)
 
 #define PRINT_SOCKET_ERROR(errorCode) do { \
@@ -48,8 +48,8 @@
 
 // On Windows, API calls that return a socket should test against INVALID_SOCKET:
 // https://docs.microsoft.com/en-us/windows/win32/winsock/handling-winsock-errors
-#define CREATE_SOCKET_CALL_RETURNS_AN_ERROR(x) ((x) == INVALID_SOCKET)
-#define SOCKET_API_CALL_RETURNS_AN_ERROR(x) ((x) == SOCKET_ERROR)
+#define IS_CREATE_SOCKET_ERROR(x) ((x) == INVALID_SOCKET)
+#define IS_SOCKET_API_ERROR(x) ((x) == SOCKET_ERROR)
 
 #define GET_SOCKET_ERROR() (WSAGetLastError())
 

--- a/tools/websocket_to_posix_proxy/src/websocket_to_posix_proxy.c
+++ b/tools/websocket_to_posix_proxy/src/websocket_to_posix_proxy.c
@@ -719,7 +719,7 @@ void Socket(int client_fd, uint8_t *data, uint64_t numBytes) {
   d->type = Translate_Socket_Type(d->type);
   d->protocol = Translate_Socket_Protocol(d->protocol);
   SOCKET_T ret = socket(d->domain, d->type, d->protocol);
-  int errorCode = (ret < 0) ? GET_SOCKET_ERROR() : 0;
+  int errorCode = CREATE_SOCKET_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 
 #ifdef POSIX_SOCKET_DEBUG
   printf("socket(domain=%d,type=%d,protocol=%d)->%d\n", d->domain, d->type, d->protocol, ret);
@@ -765,7 +765,7 @@ void Socketpair(int client_fd, uint8_t *data, uint64_t numBytes) {
   d->type = Translate_Socket_Type(d->type);
   d->protocol = Translate_Socket_Protocol(d->protocol);
   int ret = socketpair(d->domain, d->type, d->protocol, socket_vector);
-  int errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+  int errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 #endif
 
 #ifdef POSIX_SOCKET_DEBUG
@@ -825,7 +825,7 @@ void Shutdown(int client_fd, uint8_t *data, uint64_t numBytes) {
 
   if (IsSocketPartOfConnection(client_fd, d->socket)) {
     ret = shutdown(d->socket, d->how);
-    errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+    errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 #ifdef POSIX_SOCKET_DEBUG
     printf("shutdown(socket=%d,how=%d)->%d\n", d->socket, d->how, ret);
     if (errorCode) PRINT_SOCKET_ERROR(errorCode);
@@ -865,7 +865,7 @@ void Bind(int client_fd, uint8_t *data, uint64_t numBytes) {
 
   if (IsSocketPartOfConnection(client_fd, d->socket)) {
     ret = bind(d->socket, (struct sockaddr*)d->address, d->address_len);
-    errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+    errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 #ifdef POSIX_SOCKET_DEBUG
     printf("bind(socket=%d,address=%p,address_len=%d, address=\"%s\")->%d\n", d->socket, d->address, d->address_len, BufferToString(d->address, d->address_len), ret);
     if (errorCode) PRINT_SOCKET_ERROR(errorCode);
@@ -902,7 +902,7 @@ void Connect(int client_fd, uint8_t *data, uint64_t numBytes) {
 
   if (IsSocketPartOfConnection(client_fd, d->socket)) {
     ret = connect(d->socket, (struct sockaddr*)d->address, actualAddressLen);
-    errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+    errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 #ifdef POSIX_SOCKET_DEBUG
     printf("connect(socket=%d,address=%p,address_len=%d, address=\"%s\")->%d\n", d->socket, d->address, d->address_len, BufferToString(d->address, actualAddressLen), ret);
     if (errorCode) PRINT_SOCKET_ERROR(errorCode);
@@ -936,7 +936,7 @@ void Listen(int client_fd, uint8_t *data, uint64_t numBytes) {
 
   if (IsSocketPartOfConnection(client_fd, d->socket)) {
     ret = listen(d->socket, d->backlog);
-    errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+    errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 #ifdef POSIX_SOCKET_DEBUG
     printf("listen(socket=%d,backlog=%d)->%d\n", d->socket, d->backlog, ret);
     if (errorCode) PRINT_SOCKET_ERROR(errorCode);
@@ -977,7 +977,7 @@ void Accept(int client_fd, uint8_t *data, uint64_t numBytes) {
     printf("accept(socket=%d,address=%p,address_len=%u, address=\"%s\")\n", d->socket, address, d->address_len, BufferToString(address, addressLen));
 #endif
     ret = accept(d->socket, d->address_len ? (struct sockaddr*)address : 0, d->address_len ? &addressLen : 0);
-    errorCode = (ret < 0) ? GET_SOCKET_ERROR() : 0;
+    errorCode = CREATE_SOCKET_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 
 #ifdef POSIX_SOCKET_DEBUG
     printf("accept returned %d (address=\"%s\")\n", ret, BufferToString(address, addressLen));
@@ -1031,7 +1031,7 @@ void Getsockname(int client_fd, uint8_t *data, uint64_t numBytes) {
 
   if (IsSocketPartOfConnection(client_fd, d->socket)) {
     ret = getsockname(d->socket, (struct sockaddr*)address, &addressLen);
-    errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+    errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 
 #ifdef POSIX_SOCKET_DEBUG
     printf("getsockname(socket=%d,address=%p,address_len=%u)->%d (ret address: \"%s\")\n", d->socket, address, d->address_len, ret, BufferToString(address, addressLen));
@@ -1079,7 +1079,7 @@ void Getpeername(int client_fd, uint8_t *data, uint64_t numBytes)
 
   if (IsSocketPartOfConnection(client_fd, d->socket)) {
     ret = getpeername(d->socket, (struct sockaddr*)address, &addressLen);
-    errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+    errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 
 #ifdef POSIX_SOCKET_DEBUG
     printf("getpeername(socket=%d,address=%p,address_len=%u, address=\"%s\")->%d\n", d->socket, address, d->address_len, BufferToString(address, addressLen), ret);
@@ -1127,7 +1127,7 @@ void Send(int client_fd, uint8_t *data, uint64_t numBytes) {
 
   if (IsSocketPartOfConnection(client_fd, d->socket)) {
     ret = send(d->socket, (const char *)d->message, actualBytes, d->flags);
-    errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+    errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 
 #ifdef POSIX_SOCKET_DEBUG
     printf("send(socket=%d,message=%p,length=%zd,flags=%d, data=\"%s\")->" SEND_FORMATTING_SPECIFIER "\n", d->socket, d->message, d->length, d->flags, BufferToString(d->message, d->length), ret);
@@ -1166,7 +1166,7 @@ void Recv(int client_fd, uint8_t *data, uint64_t numBytes) {
 
   if (IsSocketPartOfConnection(client_fd, d->socket)) {
     ret = recv(d->socket, (char *)buffer, d->length, d->flags);
-    errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+    errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
     receivedBytes = MAX(ret, 0);
 
 #ifdef POSIX_SOCKET_DEBUG
@@ -1214,7 +1214,7 @@ void Sendto(int client_fd, uint8_t *data, uint64_t numBytes) {
 
   if (IsSocketPartOfConnection(client_fd, d->socket)) {
     ret = sendto(d->socket, (const char *)d->message, d->length, d->flags, (struct sockaddr*)d->dest_addr, d->dest_len);
-    errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+    errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 
 #ifdef POSIX_SOCKET_DEBUG
     printf("sendto(socket=%d,message=%p,length=%zd,flags=%d,dest_addr=%p,dest_len=%d)->" SEND_FORMATTING_SPECIFIER "\n", d->socket, d->message, d->length, d->flags, d->dest_addr, d->dest_len, ret);
@@ -1256,7 +1256,7 @@ void Recvfrom(int client_fd, uint8_t *data, uint64_t numBytes) {
 
   if (IsSocketPartOfConnection(client_fd, d->socket)) {
     ret = recvfrom(d->socket, (char *)buffer, d->length, d->flags, (struct sockaddr*)address, &address_len);
-    errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+    errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 #ifdef POSIX_SOCKET_DEBUG
     printf("recvfrom(socket=%d,buffer=%p,length=%zd,flags=%d,address=%p,address_len=%u, address=\"%s\")->%d\n", d->socket, buffer, d->length, d->flags, address, d->address_len, BufferToString(address, address_len), ret);
     if (errorCode) PRINT_SOCKET_ERROR(errorCode);
@@ -1332,7 +1332,7 @@ void Getsockopt(int client_fd, uint8_t *data, uint64_t numBytes) {
 
   if (IsSocketPartOfConnection(client_fd, d->socket)) {
     ret = getsockopt(d->socket, d->level, d->option_name, (char*)option_value, &option_len);
-    errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+    errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 
 #ifdef POSIX_SOCKET_DEBUG
     printf("getsockopt(socket=%d,level=%d,option_name=%d,option_value=%p,option_len=%u, optionData=\"%s\")->%d\n", d->socket, d->level, d->option_name, option_value, d->option_len, BufferToString(option_value, option_len), ret);
@@ -1390,7 +1390,7 @@ void Setsockopt(int client_fd, uint8_t *data, uint64_t numBytes) {
 
   if (IsSocketPartOfConnection(client_fd, d->socket)) {
     ret = setsockopt(d->socket, d->level, d->option_name, (const char *)d->option_value, actualOptionLen);
-    errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+    errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 
 #ifdef POSIX_SOCKET_DEBUG
     printf("setsockopt(socket=%d,level=%d,option_name=%d,option_value=%p,option_len=%d, optionData=\"%s\")->%d\n", d->socket, d->level, d->option_name, d->option_value, d->option_len, BufferToString(d->option_value, actualOptionLen), ret);
@@ -1438,7 +1438,7 @@ void Getaddrinfo(int client_fd, uint8_t *data, uint64_t numBytes) {
 
   struct addrinfo *res = 0;
   int ret = getaddrinfo(d->node, d->service, d->hasHints ? &hints : 0, &res);
-  int errorCode = (ret != 0) ? GET_SOCKET_ERROR() : 0;
+  int errorCode = SOCKET_API_CALL_RETURNS_AN_ERROR(ret) ? GET_SOCKET_ERROR() : 0;
 
 #ifdef POSIX_SOCKET_DEBUG
   printf("getaddrinfo(node=%s,service=%s,hasHints=%d,ai_flags=%d,ai_family=%d,ai_socktype=%d,ai_protocol=%d)->%d\n", d->node, d->service, d->hasHints, d->ai_flags, d->ai_family, d->ai_socktype, d->ai_protocol, ret);


### PR DESCRIPTION
On Linux/BSD/macOS, socket API calls return -1 on failure (typically tested against via if (ret < 0)). On Windows, Win32 API docs ask to check against SOCKET_ERROR(-1) and/or INVALID_SOCKET(0xffff) values, depending on API call in question. Fix bad error checks against value of zero and instead use checks that reflect the best practices on both platforms. Fixes #16897.