### PR TITLE
Remove `js_engines` argument in test running functions

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1089,16 +1089,14 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     ''' % locals(),
            'a: loaded\na: b (prev: (null))\na: c (prev: b)\n')
 
-  def filtered_js_engines(self, js_engines=None):
-    if js_engines is None:
-      js_engines = self.js_engines
-    for engine in js_engines:
+  def filtered_js_engines(self):
+    for engine in self.js_engines:
       assert engine in config.JS_ENGINES, "js engine does not exist in config.JS_ENGINES"
       assert type(engine) == list
     for engine in self.banned_js_engines:
       assert type(engine) in (list, type(None))
     banned = [b[0] for b in self.banned_js_engines if b]
-    return [engine for engine in js_engines if engine and engine[0] not in banned]
+    return [engine for engine in self.js_engines if engine and engine[0] not in banned]
 
   def do_run(self, src, expected_output=None, force_c=False, **kwargs):
     if 'no_build' in kwargs:
@@ -1128,7 +1126,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   ## Does a complete test - builds, runs, checks output, etc.
   def _build_and_run(self, filename, expected_output, args=[], output_nicerizer=None,
                      no_build=False,
-                     js_engines=None, libraries=[],
+                     libraries=[],
                      includes=[],
                      assert_returncode=0, assert_identical=False, assert_all=False,
                      check_for_error=True, force_c=False, emcc_args=[],
@@ -1145,7 +1143,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
                            output_basename=output_basename)
     self.assertExists(js_file)
 
-    engines = self.filtered_js_engines(js_engines)
+    engines = self.filtered_js_engines()
     if len(engines) > 1 and not self.use_all_engines:
       engines = engines[:1]
     # In standalone mode, also add wasm vms as we should be able to run there too.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -518,11 +518,12 @@ class TestCoreBase(RunnerCore):
     self.do_core_test('test_i64_varargs.c', args='waka fleefl asdfasdfasdfasdf'.split())
 
   @no_wasm2js('wasm_bigint')
+  @require_node
   def test_i64_invoke_bigint(self):
     self.set_setting('WASM_BIGINT')
     self.emcc_args += ['-fexceptions']
     self.node_args += ['--experimental-wasm-bigint']
-    self.do_core_test('test_i64_invoke_bigint.cpp', js_engines=[config.NODE_JS])
+    self.do_core_test('test_i64_invoke_bigint.cpp')
 
   def test_vararg_copy(self):
     self.do_run_in_out_file_test('va_arg/test_va_copy.c')
@@ -5386,15 +5387,17 @@ Module = {
   def test_fwrite_0(self):
     self.do_core_test('test_fwrite_0.c')
 
-  def test_fgetc_ungetc(self):
+  @parameterized({
+    '': (['MEMFS']),
+    'nodefs': (['NODEFS'])
+  })
+  def test_fgetc_ungetc(self, fs):
     print('TODO: update this test once the musl ungetc-on-EOF-stream bug is fixed upstream and reaches us')
-    orig_compiler_opts = self.emcc_args.copy()
-    for fs in ['MEMFS', 'NODEFS']:
-      print(fs)
-      self.emcc_args = orig_compiler_opts + ['-D' + fs]
-      if fs == 'NODEFS':
-        self.emcc_args += ['-lnodefs.js']
-      self.do_runf(test_file('stdio/test_fgetc_ungetc.c'), 'success', js_engines=[config.NODE_JS])
+    self.emcc_args += ['-D' + fs]
+    if fs == 'NODEFS':
+      self.require_node()
+      self.emcc_args += ['-lnodefs.js']
+    self.do_runf(test_file('stdio/test_fgetc_ungetc.c'), 'success')
 
   def test_fgetc_unsigned(self):
     src = r'''
@@ -5793,6 +5796,7 @@ Module['onRuntimeInitialized'] = function() {
     self.do_core_test(test_file('test_signals.c'))
 
   @no_windows('https://github.com/emscripten-core/emscripten/issues/8882')
+  @require_node
   def test_unistd_access(self):
     self.uses_es6 = True
     orig_compiler_opts = self.emcc_args.copy()
@@ -5805,13 +5809,13 @@ Module['onRuntimeInitialized'] = function() {
         self.emcc_args += ['-sFORCE_FILESYSTEM']
       if fs == 'NODEFS':
         self.emcc_args += ['-lnodefs.js']
-      self.do_run_in_out_file_test('unistd/access.c', js_engines=[config.NODE_JS])
+      self.do_run_in_out_file_test('unistd/access.c')
     # Node.js fs.chmod is nearly no-op on Windows
     # TODO: NODERAWFS in WasmFS
     if not WINDOWS and not self.get_setting('WASMFS'):
       self.emcc_args = orig_compiler_opts
       self.set_setting('NODERAWFS')
-      self.do_run_in_out_file_test('unistd/access.c', js_engines=[config.NODE_JS])
+      self.do_run_in_out_file_test('unistd/access.c')
 
   def test_unistd_curdir(self):
     self.uses_es6 = True
@@ -5829,19 +5833,22 @@ Module['onRuntimeInitialized'] = function() {
   def test_unistd_dup(self):
     self.do_run_in_out_file_test('unistd/dup.c')
 
-  def test_unistd_truncate(self):
+  @parameterized({
+    '': (['MEMFS']),
+    'nodefs': (['NODEFS'])
+  })
+  def test_unistd_truncate(self, fs):
     self.uses_es6 = True
     orig_compiler_opts = self.emcc_args.copy()
-    for fs in ['MEMFS', 'NODEFS']:
-      self.emcc_args = orig_compiler_opts + ['-D' + fs]
-      if self.get_setting('WASMFS'):
-        if fs == 'NODEFS':
-          # TODO: NODEFS in WasmFS
-          continue
-        self.emcc_args += ['-sFORCE_FILESYSTEM']
+    self.emcc_args = orig_compiler_opts + ['-D' + fs]
+    if self.get_setting('WASMFS'):
       if fs == 'NODEFS':
-        self.emcc_args += ['-lnodefs.js']
-      self.do_run_in_out_file_test('unistd/truncate.c', js_engines=[config.NODE_JS])
+        self.skipTest('TODO: NODEFS in WasmFS')
+      self.emcc_args += ['-sFORCE_FILESYSTEM']
+    if fs == 'NODEFS':
+      self.emcc_args += ['-lnodefs.js']
+      self.require_node()
+    self.do_run_in_out_file_test('unistd/truncate.c')
 
   @no_windows("Windows throws EPERM rather than EACCES or EINVAL")
   @unittest.skipIf(WINDOWS or os.geteuid() == 0, "Root access invalidates this test by being able to write on readonly files")
@@ -5866,33 +5873,36 @@ Module['onRuntimeInitialized'] = function() {
     self.do_runf(filename, str(expected) + ', errno: 0')
 
   @no_windows('https://github.com/emscripten-core/emscripten/issues/8882')
-  def test_unistd_unlink(self):
-    self.clear()
-    orig_compiler_opts = self.emcc_args.copy()
-    for fs in ['MEMFS', 'NODEFS']:
-      if fs == 'NODEFS' and self.get_setting('WASMFS'):
-        # TODO: NODEFS in WasmFS
-        continue
-      self.emcc_args = orig_compiler_opts + ['-D' + fs]
-      # symlinks on node.js on non-linux behave differently (e.g. on Windows they require administrative privileges)
-      # so skip testing those bits on that combination.
-      if fs == 'NODEFS':
-        self.emcc_args += ['-lnodefs.js']
-        if WINDOWS:
-          self.emcc_args += ['-DNO_SYMLINK=1']
-        if MACOS:
-          continue
-      self.do_runf(test_file('unistd/unlink.c'), 'success', js_engines=[config.NODE_JS])
+  @parameterized({
+    '': (['MEMFS']),
+    'nodefs': (['NODEFS']),
+    'noderawfs': (['NODERAWFS']),
+  })
+  def test_unistd_unlink(self, fs):
+    if fs in ('NODEFS', 'NODERAWFS'):
+      self.require_node()
+      if self.get_setting('WASMFS'):
+        self.skipTest('NODEFS in WasmFS')
+
+    self.emcc_args += ['-D' + fs]
+    # symlinks on node.js on non-linux behave differently (e.g. on Windows they require administrative privileges)
+    # so skip testing those bits on that combination.
+    if fs == 'NODEFS':
+      self.emcc_args += ['-lnodefs.js']
+      if WINDOWS:
+        self.emcc_args += ['-DNO_SYMLINK=1']
+      if MACOS:
+        self.skipTest()
 
     # Several differences/bugs on non-linux including https://github.com/nodejs/node/issues/18014
     # TODO: NODERAWFS in WasmFS
-    if not WINDOWS and not MACOS and not self.get_setting('WASMFS'):
-      self.emcc_args = orig_compiler_opts + ['-DNODERAWFS']
+    if fs == 'NODERAWFS':
+      self.set_setting('NODERAWFS')
       # 0 if root user
       if os.geteuid() == 0:
         self.emcc_args += ['-DSKIP_ACCESS_TESTS']
-      self.set_setting('NODERAWFS')
-      self.do_runf(test_file('unistd/unlink.c'), 'success', js_engines=[config.NODE_JS])
+
+    self.do_runf(test_file('unistd/unlink.c'), 'success')
 
   @parameterized({
     'memfs': (['-DMEMFS'], False),
@@ -5942,14 +5952,18 @@ Module['onRuntimeInitialized'] = function() {
       self.do_run_in_out_file_test('unistd/io.c')
 
   @no_windows('https://github.com/emscripten-core/emscripten/issues/8882')
-  def test_unistd_misc(self):
+  @parameterized({
+    '': (['MEMFS']),
+    'nodefs': (['NODEFS']),
+  })
+  def test_unistd_misc(self, fs):
     self.set_setting('LLD_REPORT_UNDEFINED')
     orig_compiler_opts = self.emcc_args.copy()
-    for fs in ['MEMFS', 'NODEFS']:
-      self.emcc_args = orig_compiler_opts + ['-D' + fs]
-      if fs == 'NODEFS':
-        self.emcc_args += ['-lnodefs.js']
-      self.do_run_in_out_file_test('unistd/misc.c', js_engines=[config.NODE_JS], interleaved_output=False)
+    self.emcc_args = orig_compiler_opts + ['-D' + fs]
+    if fs == 'NODEFS':
+      self.require_node()
+      self.emcc_args += ['-lnodefs.js']
+    self.do_run_in_out_file_test('unistd/misc.c', interleaved_output=False)
 
   # i64s in the API, which we'd need to legalize for JS, so in standalone mode
   # all we can test is wasm VMs

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11649,7 +11649,7 @@ Module['postRun'] = function() {
 }
 ''')
     self.emcc_args += ['--pre-js', 'pre.js']
-    self.do_run_in_out_file_test('unistd/close.c', js_engines=[config.NODE_JS])
+    self.do_run_in_out_file_test('unistd/close.c')
 
   # WASMFS tests
 


### PR DESCRIPTION
There were very few callers that used this argument and they were all
better served by calling `self.require_node` or `self.require_v8` which
fail in a more descriptive way.

Some of these tests already have `@require_node`.  Others could be
parameterized allowing the MEMFS version to run on any VM and only the
nodefs flavor to be limited to node.