### PR TITLE
[wasm64] Fix emscripten_get_compiler_setting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,7 @@ jobs:
     executor: bionic
     steps:
       - run-tests-linux:
-          test_targets: "wasm64.test_hello_world wasm64.test_ccall wasm64l.test_hello_world wasm64l.test_mmap wasm64l.test_unistd_* skip:wasm64l.test_unistd_sysconf wasm64l.test_mmap_file wasm64l.test_ccall wasm64l.test_signals"
+          test_targets: "wasm64.test_hello_world wasm64.test_ccall wasm64l.test_hello_world wasm64l.test_mmap wasm64l.test_unistd_* skip:wasm64l.test_unistd_sysconf wasm64l.test_mmap_file wasm64l.test_ccall wasm64l.test_signals wasm64l.test_emscripten_get_compiler_setting"
   test-other:
     executor: bionic
     steps:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,8 +20,12 @@ See docs/process.md for more on how version tagging works.
 
 3.1.11
 ------
+- The return value of `emscripten_get_compiler_setting` was changed from `int`
+  to `long` so that it is compatible with `MEMORY64`.  The return value of this
+  function sometimes contains a pointer value so `int` is not sufficiently
+  wide under `wasm64`. (#16938)
 - The `EM_BUILD_VERBOSE` environment variable only effects test code these days
-  and therefore was renamed to `EMTEST_BUILD_VERBOSE`.
+  and therefore was renamed to `EMTEST_BUILD_VERBOSE`. (#16904)
 
 3.1.10 - 05/02/2022
 -------------------

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -1042,7 +1042,7 @@ Defines
 Functions
 ---------
 
-.. c:function:: int emscripten_get_compiler_setting(const char *name)
+.. c:function:: long emscripten_get_compiler_setting(const char *name)
 
   Returns the value of a compiler setting.
 
@@ -1050,7 +1050,7 @@ Functions
 
     emscripten_get_compiler_setting("INITIAL_MEMORY")
 
-  For values containing anything other than an integer, a string is returned (you will need to cast the ``int`` return value to a ``char*``).
+  For values containing anything other than an integer, a string is returned (you will need to cast the ``long`` return value to a ``char*``).
 
   Some useful things this can do is provide the version of Emscripten (“EMSCRIPTEN_VERSION”), the optimization level (“OPT_LEVEL”), debug level (“DEBUG_LEVEL”), etc.
 

--- a/src/library.js
+++ b/src/library.js
@@ -2572,6 +2572,7 @@ LibraryManager.library = {
   // We never free the return values of this function so we need to allocate
   // using builtin_malloc to avoid LSan reporting these as leaks.
   emscripten_get_compiler_setting__deps: ['emscripten_builtin_malloc'],
+  emscripten_get_compiler_setting__sig: 'pp',
   emscripten_get_compiler_setting: function(name) {
 #if RETAIN_COMPILER_SETTINGS
     name = UTF8ToString(name);

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -785,7 +785,7 @@ function instrumentWasmExportsForMemory64(exports) {
     (function(name) {
       var original = exports[name];
       var replacement = original;
-      if (name === 'stackAlloc' || name === 'malloc') {
+      if (name === 'stackAlloc' || name === 'malloc' || name === 'emscripten_builtin_malloc') {
         // get one i64, return an i64
         replacement = (x) => {
           var r = Number(original(BigInt(x)));

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -136,7 +136,7 @@ int emscripten_get_worker_queue_size(worker_handle worker);
 
 // misc.
 
-int emscripten_get_compiler_setting(const char *name);
+long emscripten_get_compiler_setting(const char *name);
 int emscripten_has_asyncify(void);
 
 void emscripten_debugger(void);

--- a/tests/core/emscripten_get_compiler_setting.c
+++ b/tests/core/emscripten_get_compiler_setting.c
@@ -10,7 +10,7 @@
 #include <emscripten.h>
 
 int main() {
-  printf("INVOKE_RUN: %d\n", emscripten_get_compiler_setting("INVOKE_RUN"));
+  printf("INVOKE_RUN: %ld\n", emscripten_get_compiler_setting("INVOKE_RUN"));
   assert((unsigned)emscripten_get_compiler_setting("OPT_LEVEL") <= 3);
   assert((unsigned)emscripten_get_compiler_setting("DEBUG_LEVEL") <= 4);
   printf("EMSCRIPTEN_VERSION: %s\n", (char*)emscripten_get_compiler_setting("EMSCRIPTEN_VERSION"));

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9445,7 +9445,7 @@ int main () {
     #include <emscripten.h>
 
     int main() {
-      printf("%d %d\n",
+      printf("%ld %ld\n",
         emscripten_get_compiler_setting("BINARYEN_ASYNC_COMPILATION"),
         emscripten_get_compiler_setting("WASM_ASYNC_COMPILATION"));
       return 0;


### PR DESCRIPTION
Although this changes the return type of
`emscripten_get_compiler_setting` from `int` to `long` I don't think
this will break many existing users (this API I also imagine has very
few users).  The test here needed an update because it tried to directly
use the return value in a printf statement but most users will likely
be assigning to an `int` which will continue to work.

I thought about using `intptr_t` as the return type but that would
mean adding `#include <inttypes.h>` to `emscripten.h` which seems like
a slightly bigger change.