### PR TITLE
[wasm64] Fix return type of builtin float comparisons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,7 @@ jobs:
     executor: bionic
     steps:
       - run-tests-linux:
-          test_targets: "wasm64.test_hello_world wasm64.test_ccall wasm64l.test_hello_world wasm64l.test_mmap wasm64l.test_unistd_* skip:wasm64l.test_unistd_sysconf wasm64l.test_mmap_file wasm64l.test_ccall wasm64l.test_signals wasm64l.test_emscripten_get_compiler_setting"
+          test_targets: "wasm64.test_hello_world wasm64.test_ccall wasm64l.test_hello_world wasm64l.test_mmap wasm64l.test_unistd_* skip:wasm64l.test_unistd_sysconf wasm64l.test_mmap_file wasm64l.test_ccall wasm64l.test_signals wasm64l.test_emscripten_get_compiler_setting wasm64l.test_float_builtins"
   test-other:
     executor: bionic
     steps:

--- a/system/lib/compiler-rt/lib/builtins/fp_compare_impl.inc
+++ b/system/lib/compiler-rt/lib/builtins/fp_compare_impl.inc
@@ -12,7 +12,7 @@
 // functions. We need to ensure that the return value is sign-extended in the
 // same way as GCC expects (since otherwise GCC-generated __builtin_isinf
 // returns true for finite 128-bit floating-point numbers).
-#ifdef __aarch64__
+#if defined(__aarch64__) || defined(__wasm__)
 // AArch64 GCC overrides libgcc_cmp_return to use int instead of long.
 typedef int CMP_RESULT;
 #elif __SIZEOF_POINTER__ == 8 && __SIZEOF_LONG__ == 4


### PR DESCRIPTION
The llvm-generated calls always use i32 as the return type for float
comparisons such as `__getf2`, but `compiler-rt` was being built with
`long` as the return type resulting in linker warning and runtime
errors:

```
wasm-ld: warning: function signature mismatch: __eqtf2
>>> defined as (i64, i64, i64, i64) -> i32 in /usr/local/google/home/sbc/dev/wasm/emscripten/cache/sysroot/lib/wasm64-emscripten/libc-debug.a(fmodl.o)
>>> defined as (i64, i64, i64, i64) -> i64 in /usr/local/google/home/sbc/dev/wasm/emscripten/cache/sysroot/lib/wasm64-emscripten/libcompiler_rt.a(comparetf2.o)
```