### PR TITLE
Fix test suite regression from #16932

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5910,7 +5910,7 @@ Module['onRuntimeInitialized'] = function() {
       if WINDOWS:
         self.emcc_args += ['-DNO_SYMLINK=1']
       if MACOS:
-        self.skipTest()
+        self.skipTest('only tested on linux')
 
     # Several differences/bugs on non-linux including https://github.com/nodejs/node/issues/18014
     # TODO: NODERAWFS in WasmFS


### PR DESCRIPTION
The tiny bug here was missed on github CI as we don't run that test on Mac
here.