### PR TITLE
Stop unexportedRuntimeFunction('foo__user', false); from reaching generated builds

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -114,6 +114,7 @@ function isJsLibraryConfigIdentifier(ident) {
     '__nothrow',
     '__noleakcheck',
     '__internal',
+    '__user',
   ];
   return suffixes.some((suffix) => ident.endsWith(suffix));
 }


### PR DESCRIPTION
Clean up the stray `__user` directives from getting generated in ASSERTIONS builds:

![image](https://user-images.githubusercontent.com/225351/168049455-8499b3f0-3d66-4b5a-aedc-894633686b09.png)
