### PR TITLE
Bump binaryen to the current release of 108

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -39,7 +39,7 @@ logger = logging.getLogger('building')
 #  Building
 binaryen_checked = False
 
-EXPECTED_BINARYEN_VERSION = 107
+EXPECTED_BINARYEN_VERSION = 108
 # cache results of nm - it can be slow to run
 nm_cache = {}
 _is_ar_cache = {}


### PR DESCRIPTION
I've gotten into a bad habit of bumping this right before a release, which is the
last moment in time before releasing on binaryen would break a roll. But it's
better to update after a release, then do the bump here in emscripten at our
leisure, rather than block the binaryen release on it. Also, it is nicer to point to
the current release rather than one back.