### PR TITLE
[wasm64] Fix wasm64 + MINIMAL_RUNTIME

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,7 @@ jobs:
     executor: bionic
     steps:
       - run-tests-linux:
-          test_targets: "wasm64.test_hello_world wasm64.test_ccall wasm64l.test_hello_world wasm64l.test_mmap wasm64l.test_unistd_* skip:wasm64l.test_unistd_sysconf wasm64l.test_mmap_file wasm64l.test_ccall wasm64l.test_signals wasm64l.test_emscripten_get_compiler_setting wasm64l.test_float_builtins wasm64l.test_getopt wasm64l.test_em_asm*"
+          test_targets: "wasm64.test_hello_world wasm64.test_ccall wasm64l.test_hello_world wasm64l.test_mmap wasm64l.test_unistd_* skip:wasm64l.test_unistd_sysconf wasm64l.test_mmap_file wasm64l.test_ccall wasm64l.test_signals wasm64l.test_emscripten_get_compiler_setting wasm64l.test_float_builtins wasm64l.test_getopt wasm64l.test_em_asm* wasm64l.test_minimal_runtime_utf8_invalid"
   test-other:
     executor: bionic
     steps:

--- a/embuilder.py
+++ b/embuilder.py
@@ -40,6 +40,7 @@ MINIMAL_TASKS = [
     'libc++-noexcept',
     'libal',
     'libdlmalloc',
+    'libdlmalloc-noerrno',
     'libdlmalloc-debug',
     'libemmalloc',
     'libemmalloc-debug',

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -199,6 +199,10 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
   asm = output.instance.exports;
 #endif
 
+#if MEMORY64
+  asm = instrumentWasmExportsForMemory64(asm);
+#endif
+
 #if USE_OFFSET_CONVERTER
 #if USE_PTHREADS
   if (!ENVIRONMENT_IS_PTHREAD)

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -12,6 +12,10 @@
 #include "runtime_asan.js"
 #endif
 
+#if MEMORY64
+#include "runtime_wasm64.js"
+#endif
+
 #if ASSERTIONS || SAFE_HEAP
 /** @type {function(*, string=)} */
 function assert(condition, text) {

--- a/src/runtime_wasm64.js
+++ b/src/runtime_wasm64.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2022 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+#if !MEMORY64
+#error "should only be inclded in MEMORY64 mode"
+#endif
+
+// In memory64 mode wasm pointers are 64-bit.  In JS these show up as BigInts.
+// For now, we keep JS as much the same as it always was, that is, stackAlloc()
+// receives and returns a Number from the JS point of view - we translate
+// BigInts automatically for that.
+// TODO: support minified export names, so we can turn
+// MINIFY_WASM_IMPORTS_AND_EXPORTS back on for MEMORY64.
+// TODO: Remove this hacky mechanism and replace with something more like the
+// `__sig` attributes we have in JS library code.
+function instrumentWasmExportsForMemory64(exports) {
+  var instExports = {};
+  for (var name in exports) {
+    (function(name) {
+      var original = exports[name];
+      var replacement = original;
+      if (['stackAlloc', 'emscripten_builtin_malloc', 'malloc', '__getTypeName'].includes(name)) {
+        // get one i64, return an i64.
+        replacement = (x) => {
+          var r = Number(original(BigInt(x)));
+          return r;
+        };
+      } else if (['setThrew', 'free', 'stackRestore', '__cxa_is_pointer_type'].includes(name)) {
+        // get one i64
+        replacement = (x) => {
+          original(BigInt(x));
+        };
+      } else if (['stackSave', 'emscripten_stack_get_end',
+                  'emscripten_stack_get_base', 'pthread_self',
+                  'emscripten_stack_get_current',
+                  '__errno_location'].includes(name)) {
+        // return an i64
+        replacement = () => {
+          var r = Number(original());
+          return r;
+        };
+      } else if (name === 'emscripten_builtin_memalign') {
+        // get two i64, return an i64
+        replacement = (x, y) => {
+          var r = Number(original(BigInt(x), BigInt(y)));
+          return r;
+        };
+      } else if (name === 'main') {
+        // Special case for main.  Use `function` here rather than arrow
+        // function to avoid implicit `strict`.
+        replacement = function(x, y) {
+          // Pass an extra 0 in case its a 3-argument form of main.  Sadly we
+          // can't just omit that argument like we can for wasm32 because the
+          // missing third argument will generate:
+          // `TypeError: Cannot convert undefined to a BigInt`.
+          // See https://github.com/WebAssembly/JS-BigInt-integration/issues/12
+          return original(x, BigInt(y ? y : 0), BigInt(0));
+        };
+      }
+      instExports[name] = replacement;
+    })(name);
+  }
+  return instExports;
+}


### PR DESCRIPTION
Move the instrumentWasmExportsForMemory64 helper out into its own file
so we have be used under MINIMAL_RUNTIME too.  In the long run this
function should be replaced with something more data driven but for now
this works.

Split out from #16922