### PR TITLE
Use empty object as initial JS library. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -20,7 +20,7 @@
 // object. For convenience, the short name appears here. Note that if you add a
 // new function with an '_', it will not be found.
 
-LibraryManager.library = {
+mergeInto(LibraryManager.library, {
   // ==========================================================================
   // getTempRet0/setTempRet0: scratch space handling i64 return
   //
@@ -3587,7 +3587,7 @@ LibraryManager.library = {
   __c_longjmp_import: true,
 #endif
 #endif
-};
+});
 
 function autoAddDeps(object, name) {
   for (var item in object) {

--- a/src/library_bootstrap.js
+++ b/src/library_bootstrap.js
@@ -11,8 +11,8 @@
 assert(false, "library_bootstrap.js only designed for use with BOOTSTRAPPING_STRUCT_INFO")
 #endif
 
-assert(!LibraryManager.library);
-LibraryManager.library = {
+assert(Object.keys(LibraryManager.library).length === 0);
+mergeInto(LibraryManager.library, {
   $callRuntimeCallbacks: function() {},
   $handleException: function(e) { if (!e instanceof ExitStatus && !e == 'unwind') throw e; },
-};
+});

--- a/src/modules.js
+++ b/src/modules.js
@@ -21,7 +21,7 @@ function genArgSequence(n) {
 global.libraryFunctions = [];
 
 global.LibraryManager = {
-  library: null,
+  library: {},
   structs: {},
   loaded: false,
   libraries: [],
@@ -31,7 +31,8 @@ global.LibraryManager = {
   },
 
   load: function() {
-    if (this.library) return;
+    assert(!this.loaded);
+    this.loaded = true;
 
     // Core system libraries (always linked against)
     let libraries = [
@@ -302,8 +303,6 @@ global.LibraryManager = {
         }
       }
     }
-
-    this.loaded = true;
   },
 };
 


### PR DESCRIPTION
This minior refactoring mans that library.js and library_bootstrap.js
are less special and allows libraries other than `library.js` to be
processed first (something I wanted to try in another PR).