### PR TITLE
Move JS version of printf/puts to library_bootstrap

### DIFF
--- a/src/library_bootstrap.js
+++ b/src/library_bootstrap.js
@@ -14,5 +14,34 @@ assert(false, "library_bootstrap.js only designed for use with BOOTSTRAPPING_STR
 assert(Object.keys(LibraryManager.library).length === 0);
 mergeInto(LibraryManager.library, {
   $callRuntimeCallbacks: function() {},
-  $handleException: function(e) { if (!e instanceof ExitStatus && !e == 'unwind') throw e; },
+
+  $handleException: function(e) {
+    if (!(e instanceof ExitStatus) && e !== 'unwind') {
+      throw e;
+    }
+  },
+
+  // printf/puts implementations for when musl is not pulled in - very
+  // partial, but enough for bootstrapping structInfo
+
+  printf__deps: ['$formatString'],
+  printf: function(format, varargs) {
+    // int printf(const char *restrict format, ...);
+    // http://pubs.opengroup.org/onlinepubs/000095399/functions/printf.html
+    // extra effort to support printf, even without a filesystem. very partial, very hackish
+    var result = formatString(format, varargs);
+    var string = intArrayToString(result);
+    if (string[string.length-1] === '\n') string = string.substr(0, string.length-1); // remove a final \n, as Module.print will do that
+    out(string);
+    return result.length;
+  },
+
+  puts: function(s) {
+    // extra effort to support puts, even without a filesystem. very partial, very hackish
+    var result = UTF8ToString(s);
+    var string = result.substr(0);
+    if (string[string.length-1] === '\n') string = string.substr(0, string.length-1); // remove a final \n, as Module.print will do that
+    out(string);
+    return result.length;
+  },
 });

--- a/src/library_formatString.js
+++ b/src/library_formatString.js
@@ -21,6 +21,12 @@ mergeInto(LibraryManager.library, {
                       : Math.pow(2, bits)         + value;
   },
 
+  $strLen: function(ptr) {
+    var end = ptr;
+    while (HEAPU8[end]) ++end;
+    return end - ptr;
+  },
+
   // Converts a value we have as unsigned, into a signed value. For
   // example, 200 in a uint8 would be a negative number.
   $reSign: function(value, bits) {
@@ -46,7 +52,7 @@ mergeInto(LibraryManager.library, {
   //   varargs: A pointer to the start of the arguments list.
   // Returns the resulting string string as a character array.
   $formatString__deps: ['$reallyNegative', '$convertI32PairToI53', '$convertU32PairToI53',
-                        '$reSign', '$unSign', 'strlen'
+                        '$reSign', '$unSign', '$strLen',
 #if MINIMAL_RUNTIME
     , '$intArrayFromString'
 #endif
@@ -409,7 +415,7 @@ mergeInto(LibraryManager.library, {
           case 's': {
             // String.
             var arg = getNextArg('i8*');
-            var argLength = arg ? _strlen(arg) : '(null)'.length;
+            var argLength = arg ? strLen(arg) : '(null)'.length;
             if (precisionSet) argLength = Math.min(argLength, precision);
             if (!flagLeftAlign) {
               while (argLength < width--) {
@@ -466,38 +472,6 @@ mergeInto(LibraryManager.library, {
       }
     }
     return ret;
-  },
-
-  // printf/puts/strlen implementations for when musl is not pulled in - very
-  // partial. useful for tests, and when bootstrapping structInfo
-  strlen: function(ptr) {
-    {{{ from64('ptr') }}};
-    var end = ptr;
-    while (HEAPU8[end]) ++end;
-    return end - ptr;
-  },
-  printf__deps: ['$formatString'
-#if MINIMAL_RUNTIME
-    , '$intArrayToString'
-#endif
-    ],
-  printf: function(format, varargs) {
-    // int printf(const char *restrict format, ...);
-    // http://pubs.opengroup.org/onlinepubs/000095399/functions/printf.html
-    // extra effort to support printf, even without a filesystem. very partial, very hackish
-    var result = formatString(format, varargs);
-    var string = intArrayToString(result);
-    if (string[string.length-1] === '\n') string = string.substr(0, string.length-1); // remove a final \n, as Module.print will do that
-    out(string);
-    return result.length;
-  },
-  puts: function(s) {
-    // extra effort to support puts, even without a filesystem. very partial, very hackish
-    var result = UTF8ToString(s);
-    var string = result.substr(0);
-    if (string[string.length-1] === '\n') string = string.substr(0, string.length-1); // remove a final \n, as Module.print will do that
-    out(string);
-    return result.length;
   },
 });
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3298,7 +3298,10 @@ mergeInto(LibraryManager.library, {
     '<' : 0,
     'white space' : 1
   },
-  printf__deps: ['__internal_data', 'fprintf']
+  foo__deps: ['__internal_data'],
+  foo: function() {
+    return 0;
+  }
 });
 ''')
 

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -94,7 +94,6 @@ _deps_info = {
   'emscripten_idb_async_load': ['malloc', 'free'],
   'emscripten_idb_load': ['malloc', 'free'],
   'emscripten_init_websocket_to_posix_socket_bridge': ['malloc', 'free'],
-  'emscripten_log': ['strlen'],
   # This list is the same as setjmp's dependencies. In non-LTO builds, setjmp
   # does not exist in the object files; it is converted into a code sequence
   # that includes several functions, one of which is emscripten_longjmp. This is


### PR DESCRIPTION
These functions are only needed/used when generating struct info.
Contrary to the comment we have no tests that use these functions.