### PR TITLE
Avoid extra JS var in defineI64Param/receiveI64ParamAsI53. NFC

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1126,7 +1126,7 @@ function hasExportedFunction(func) {
 // it is a BigInt. Otherwise, we legalize into pairs of i32s.
 function defineI64Param(name) {
   if (WASM_BIGINT) {
-    return `/** @type {!BigInt} */ ${name}_bigint`;
+    return `/** @type {!BigInt} */ ${name}`;
   }
   return `${name}_low, ${name}_high`;
 }
@@ -1138,7 +1138,7 @@ function receiveI64ParamAsI32s(name) {
     //    https://github.com/google/closure-compiler/issues/3167
     //  * acorn needs to be upgraded, and to set ecmascript version >= 11
     //  * terser needs to be upgraded
-    return `var ${name}_low = Number(${name}_bigint & BigInt(0xffffffff)) | 0, ${name}_high = Number(${name}_bigint >> BigInt(32)) | 0;`;
+    return `var ${name}_low = Number(${name} & BigInt(0xffffffff)) | 0, ${name}_high = Number(${name} >> BigInt(32)) | 0;`;
   }
   return '';
 }
@@ -1146,7 +1146,7 @@ function receiveI64ParamAsI32s(name) {
 function receiveI64ParamAsI53(name, onError) {
   if (WASM_BIGINT) {
     // Just convert the bigint into a double.
-    return `var ${name} = bigintToI53Checked(${name}_bigint); if (isNaN(${name})) return ${onError};`;
+    return `${name} = bigintToI53Checked(${name}); if (isNaN(${name})) return ${onError};`;
   }
   // Covert the high/low pair to a Number, checking for
   // overflow of the I53 range and returning onError in that case.

--- a/src/parseTools_legacy.js
+++ b/src/parseTools_legacy.js
@@ -17,7 +17,7 @@ function makeStructuralReturn(values) {
 function receiveI64ParamAsDouble(name) {
   if (WASM_BIGINT) {
     // Just convert the bigint into a double.
-    return `var ${name} = Number(${name}_bigint);`;
+    return `${name} = Number(${name});`;
   }
   // Combine the i32 params. Use an unsigned operator on low and shift high by
   // 32 bits.


### PR DESCRIPTION
Declare bigint param without any mangling, and then simply overwrite
with Number form if/when needed.

Split out from #16922.

As well as saving a little on codesize this helps for cases there
`defineI64Param` is used but that reciever wants to deal with the
bigint param directly.