### PR TITLE
emsize: accept single and double-dashed flavors of the format flag

### DIFF
--- a/emsize.py
+++ b/emsize.py
@@ -38,7 +38,7 @@ def error(text):
 
 def parse_args(argv):
   parser = argparse.ArgumentParser(description=__doc__)
-  parser.add_argument('-format')
+  parser.add_argument('-format', '--format')
   parser.add_argument('file')
   args = parser.parse_args(argv)
   return args.file

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -605,7 +605,7 @@ f.close()
     #   emcc tests/hello_world.c -Oz --closure 1 -o tests/other/test_emsize.js
     expected = read_file(test_file('other/test_emsize.out'))
     cmd = [emsize, test_file('other/test_emsize.js')]
-    for command in [cmd, cmd + ['-format=sysv']]:
+    for command in [cmd, cmd + ['--format=sysv']]:
       output = self.run_process(cmd, stdout=PIPE).stdout
       self.assertContained(expected, output)
 


### PR DESCRIPTION
The flag is still ignored as before.