### PR TITLE
[wasm64] Use `int` over `long` for time_t, etc. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,7 @@ jobs:
     executor: bionic
     steps:
       - run-tests-linux:
-          test_targets: "wasm64.test_hello_world wasm64.test_ccall wasm64l.test_hello_world wasm64l.test_mmap wasm64l.test_unistd_* skip:wasm64l.test_unistd_sysconf wasm64l.test_mmap_file wasm64l.test_ccall wasm64l.test_signals wasm64l.test_emscripten_get_compiler_setting wasm64l.test_float_builtins wasm64l.test_getopt wasm64l.test_em_asm* wasm64l.test_minimal_runtime_utf8_invalid"
+          test_targets: "wasm64.test_hello_world wasm64.test_ccall wasm64l.test_hello_world wasm64l.test_mmap wasm64l.test_unistd_* skip:wasm64l.test_unistd_sysconf wasm64l.test_mmap_file wasm64l.test_ccall wasm64l.test_signals wasm64l.test_emscripten_get_compiler_setting wasm64l.test_float_builtins wasm64l.test_getopt wasm64l.test_em_asm* wasm64l.test_minimal_runtime_utf8_invalid wasm64l.test_strftime wasm64l.test_utime"
   test-other:
     executor: bionic
     steps:

--- a/src/library.js
+++ b/src/library.js
@@ -445,7 +445,7 @@ mergeInto(LibraryManager.library, {
     return (date.getTime() / 1000)|0;
   },
 
-  _gmtime_js__sig: 'iii',
+  _gmtime_js__sig: 'ipp',
   _gmtime_js: function(time, tmPtr) {
     var date = new Date({{{ makeGetValue('time', 0, 'i32') }}}*1000);
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_sec, 'date.getUTCSeconds()', 'i32') }}};
@@ -460,7 +460,7 @@ mergeInto(LibraryManager.library, {
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_yday, 'yday', 'i32') }}};
   },
 
-  _timegm_js__sig: 'ii',
+  _timegm_js__sig: 'ip',
   _timegm_js: function(tmPtr) {
     var time = Date.UTC({{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_year, 'i32') }}} + 1900,
                         {{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_mon, 'i32') }}},
@@ -479,7 +479,7 @@ mergeInto(LibraryManager.library, {
     return (date.getTime() / 1000)|0;
   },
 
-  _localtime_js__sig: 'iii',
+  _localtime_js__sig: 'ipp',
   _localtime_js: function(time, tmPtr) {
     var date = new Date({{{ makeGetValue('time', 0, 'i32') }}}*1000);
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_sec, 'date.getSeconds()', 'i32') }}};
@@ -543,7 +543,7 @@ mergeInto(LibraryManager.library, {
   // TODO: Initialize these to defaults on startup from system settings.
   // Note: glibc has one fewer underscore for all of these. Also used in other related functions (timegm)
   _tzset_js__deps: ['tzset_impl'],
-  _tzset_js__sig: 'viii',
+  _tzset_js__sig: 'vppp',
   _tzset_js: function(timezone, daylight, tzname) {
     // TODO: Use (malleable) environment variables instead of system settings.
     if (__tzset_js.called) return;
@@ -654,7 +654,7 @@ mergeInto(LibraryManager.library, {
     , '$intArrayFromString', '$writeArrayToMemory'
 #endif
   ],
-  strftime__sig: 'iiiii',
+  strftime__sig: 'ppppp',
   strftime: function(s, maxsize, format, tm) {
     // size_t strftime(char *restrict s, size_t maxsize, const char *restrict format, const struct tm *restrict timeptr);
     // http://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html

--- a/system/lib/libc/musl/arch/emscripten/bits/alltypes.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/alltypes.h
@@ -41,7 +41,7 @@ typedef __WCHAR_TYPE__ wchar_t;
 
 #else
 #if defined(__NEED_wchar_t) && !defined(__DEFINED_wchar_t)
-typedef long wchar_t;
+typedef int wchar_t;
 #define __DEFINED_wchar_t
 #endif
 
@@ -78,12 +78,12 @@ typedef long double double_t;
 #endif
 
 #if defined(__NEED_time_t) && !defined(__DEFINED_time_t)
-typedef long time_t;
+typedef int time_t; /* XXX EMSCRIPTEN: ensure it's always 32-bits even in wasm64 */
 #define __DEFINED_time_t
 #endif
 
 #if defined(__NEED_suseconds_t) && !defined(__DEFINED_suseconds_t)
-typedef long suseconds_t;
+typedef int suseconds_t; /* XXX EMSCRIPTEN: ensure it's always 32-bits even in wasm64 */
 #define __DEFINED_suseconds_t
 #endif
 
@@ -253,7 +253,7 @@ typedef unsigned int dev_t;
 #endif
 
 #if defined(__NEED_blksize_t) && !defined(__DEFINED_blksize_t)
-typedef long blksize_t;
+typedef int blksize_t; /* XXX EMSCRIPTEN: ensure it's always 32-bits even in wasm64 */
 #define __DEFINED_blksize_t
 #endif
 
@@ -278,7 +278,7 @@ typedef unsigned wint_t;
 #endif
 
 #if defined(__NEED_wctype_t) && !defined(__DEFINED_wctype_t)
-typedef unsigned long wctype_t;
+typedef unsigned int wctype_t; /* XXX EMSCRIPTEN: ensure it's always 32-bits even in wasm64 */
 #define __DEFINED_wctype_t
 #endif
 

--- a/system/lib/libc/musl/src/time/clock.c
+++ b/system/lib/libc/musl/src/time/clock.c
@@ -1,6 +1,12 @@
 #include <time.h>
 #include <limits.h>
 
+#ifdef __EMSCRIPTEN__
+#define TIME_T_MAX INT_MAX
+#else
+#define TIME_T_MAX LONG_MAX
+#endif
+
 clock_t clock()
 {
 	struct timespec ts;
@@ -8,7 +14,7 @@ clock_t clock()
 	if (__clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts))
 		return -1;
 
-	if (ts.tv_sec > LONG_MAX/1000000
+	if (ts.tv_sec > TIME_T_MAX/1000000
 	 || ts.tv_nsec/1000 > LONG_MAX-1000000*ts.tv_sec)
 		return -1;
 

--- a/tests/utime/test_utime.c
+++ b/tests/utime/test_utime.c
@@ -44,15 +44,15 @@ void test() {
   assert(s.st_mtime == t.modtime);
 
   // NULL sets atime and mtime to current time.
-  long now = time(NULL);
+  time_t now = time(NULL);
   rv = utime("writeable", NULL);
   assert(rv == 0);
   memset(&s, 0, sizeof s);
   stat("writeable", &s);
   assert(s.st_atime == s.st_mtime);
-  long diff = s.st_atime - now;
+  time_t diff = s.st_atime - now;
   if (abs(diff) > 5) {
-    fprintf(stderr, "st_atime: %li, now: %li, diff: %li\n ", s.st_atime, now, diff);
+    fprintf(stderr, "st_atime: %i, now: %i, diff: %i\n ", s.st_atime, now, diff);
     assert(abs(diff) <= 5);
   }
 


### PR DESCRIPTION
This doesn't change the size of the type for wasm32 but helps with
wasm64 since it makes these types consistent between the two.

Split out from #16922