### PR TITLE
[WasmFS] Do not change the type bits in the mode

### DIFF
--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -258,7 +258,11 @@ public:
     : file(file), lock(file->mutex, std::defer_lock) {}
   size_t getSize() { return file->getSize(); }
   mode_t getMode() { return file->mode; }
-  void setMode(mode_t mode) { file->mode = mode; }
+  void setMode(mode_t mode) {
+    // The type bits can never be changed (whether something is a file or a
+    // directory, for example).
+    file->mode = (file->mode & S_IFMT) | (mode & ~S_IFMT);
+  }
   time_t getCTime() { return file->ctime; }
   void setCTime(time_t time) { file->ctime = time; }
   time_t getMTime() { return file->mtime; }


### PR DESCRIPTION
The mode has permission bits, like read/write, which can be changed, but the
type bits like "is file" or "is directory" can never be changed in POSIX. Or at
least so the docs I can find seem to say, and I confirmed it on Linux. It is also
how the old FS works.

This is a necessary fix for a future PR's test to pass, so a test is not included
in this PR.