### PR TITLE
[WasmFS] Update ctime in chmod

### DIFF
--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1041,7 +1041,10 @@ int __syscall_fchmodat(int dirfd, intptr_t path, int mode, ...) {
   if (auto err = parsed.getError()) {
     return err;
   }
-  parsed.getFile()->locked().setMode(mode);
+  auto lockedFile = parsed.getFile()->locked();
+  lockedFile.setMode(mode);
+  // On POSIX, ctime is updated on metadata changes, like chmod.
+  lockedFile.setCTime(time(NULL));
   return 0;
 }
 


### PR DESCRIPTION
Any metadata update should update ctime according to the docs, and we
have a test that verifies it. (The test is not enabled yet as it depends on 2
other PRs before I can do that.)