### PR TITLE
[wasm64] Remove unneeded usage of `from64`

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -403,7 +403,6 @@ var LibraryEmbind = {
   },
 
   $heap32VectorToArray: function(count, firstElement) {
-    {{{ from64('firstElement') }}}
     var array = [];
     for (var i = 0; i < count; i++) {
         array.push(HEAP32[(firstElement >> 2) + i]);
@@ -475,7 +474,6 @@ var LibraryEmbind = {
 
   $getShiftFromSize__deps: [],
   $getShiftFromSize: function(size) {
-    {{{ from64('size') }}}
     switch (size) {
         case 1: return 0;
         case 2: return 1;

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -166,6 +166,7 @@ var SyscallsLibrary = {
     FS.chdir(path);
     return 0;
   },
+  __syscall_chmod__sig: 'ipi',
   __syscall_chmod: function(path, mode) {
     path = SYSCALLS.getStr(path);
     FS.chmod(path, mode);
@@ -261,6 +262,7 @@ var SyscallsLibrary = {
     }
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },
+  __syscall_symlink__sig: 'ipp',
   __syscall_symlink: function(target, linkpath) {
     target = SYSCALLS.getStr(target);
     linkpath = SYSCALLS.getStr(linkpath);
@@ -640,12 +642,12 @@ var SyscallsLibrary = {
     FS.ftruncate(fd, length);
     return 0;
   },
-  __syscall_stat64__sig: 'iip',
+  __syscall_stat64__sig: 'ipp',
   __syscall_stat64: function(path, buf) {
     path = SYSCALLS.getStr(path);
     return SYSCALLS.doStat(FS.stat, path, buf);
   },
-  __syscall_lstat64__sig: 'iip',
+  __syscall_lstat64__sig: 'ipp',
   __syscall_lstat64: function(path, buf) {
     path = SYSCALLS.getStr(path);
     return SYSCALLS.doStat(FS.lstat, path, buf);
@@ -821,6 +823,7 @@ var SyscallsLibrary = {
     FS.mkdir(path, mode, 0);
     return 0;
   },
+  __syscall_mknodat__sig: 'iipii',
   __syscall_mknodat: function(dirfd, path, mode, dev) {
 #if SYSCALL_DEBUG
     err('warning: untested syscall');
@@ -880,6 +883,7 @@ var SyscallsLibrary = {
     }
     return 0;
   },
+  __syscall_renameat__sig: 'iipip',
   __syscall_renameat: function(olddirfd, oldpath, newdirfd, newpath) {
     oldpath = SYSCALLS.getStr(oldpath);
     newpath = SYSCALLS.getStr(newpath);
@@ -916,6 +920,7 @@ var SyscallsLibrary = {
     HEAP8[buf+len] = endChar;
     return len;
   },
+  __syscall_fchmodat__sig: 'iipip',
   __syscall_fchmodat: function(dirfd, path, mode, varargs) {
 #if SYSCALL_DEBUG
     err('warning: untested syscall');
@@ -925,6 +930,7 @@ var SyscallsLibrary = {
     FS.chmod(path, mode);
     return 0;
   },
+  __syscall_faccessat__sig: 'iipii',
   __syscall_faccessat: function(dirfd, path, amode, flags) {
 #if SYSCALL_DEBUG
     err('warning: untested syscall');

--- a/src/library_trace.js
+++ b/src/library_trace.js
@@ -180,6 +180,7 @@ var LibraryTracing = {
     }
   },
 
+  emscripten_trace_log_message__sig: 'vpp',
   emscripten_trace_log_message: function(channel, message) {
     if (EmscriptenTrace.postEnabled) {
       var now = EmscriptenTrace.now();
@@ -200,6 +201,7 @@ var LibraryTracing = {
     }
   },
 
+  emscripten_trace_mark__sig: 'vp',
   emscripten_trace_mark: function(message) {
     if (EmscriptenTrace.postEnabled) {
       var now = EmscriptenTrace.now();
@@ -309,6 +311,7 @@ var LibraryTracing = {
     }
   },
 
+  emscripten_trace_enter_context__sig: 'vp',
   emscripten_trace_enter_context: function(name) {
     if (EmscriptenTrace.postEnabled) {
       var now = EmscriptenTrace.now();
@@ -330,6 +333,7 @@ var LibraryTracing = {
     }
   },
 
+  emscripten_trace_task_start__sig: 'vip',
   emscripten_trace_task_start: function(task_id, name) {
     if (EmscriptenTrace.postEnabled) {
       var now = EmscriptenTrace.now();

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -762,7 +762,6 @@ function instrumentWasmTableWithAbort() {
   var realGet = wasmTable.get;
   var wrapperCache = {};
   wasmTable.get = (i) => {
-    {{{ from64('i') }}}
     var func = realGet.call(wasmTable, i);
     var cached = wrapperCache[i];
     if (!cached || cached.func !== func) {

--- a/src/runtime_strings.js
+++ b/src/runtime_strings.js
@@ -101,7 +101,6 @@ function UTF8ArrayToString(heapOrArray, idx, maxBytesToRead) {
  * @return {string}
  */
 function UTF8ToString(ptr, maxBytesToRead) {
-  {{{ from64('ptr') }}};
 #if CAN_ADDRESS_2GB
   ptr >>>= 0;
 #endif

--- a/tests/core/test_em_js.cpp
+++ b/tests/core/test_em_js.cpp
@@ -19,6 +19,10 @@ EM_JS(double, noarg_double, (void), {
 EM_JS(void, intarg, (int x), { out("  takes ints: " + x);});
 EM_JS(void, doublearg, (double d), { out("  takes doubles: " + d);});
 EM_JS(double, stringarg, (const char* str), {
+  // Convert pointers (which can be BigInt under wasm64), to Number, which
+  // internal function expect.
+  // FIXME(https://github.com/emscripten-core/emscripten/issues/16975)
+  str = Number(str);
   out("  takes strings: " + UTF8ToString(str));
   return 7.75;
 });
@@ -27,6 +31,10 @@ EM_JS(int, multi_intarg, (int x, int y), {
   return 6;
 });
 EM_JS(double, multi_mixedarg, (int x, const char* str, double d), {
+  // Convert pointers (which can be BigInt under wasm64), to Number, which
+  // internal function expect.
+  // FIXME(https://github.com/emscripten-core/emscripten/issues/16975)
+  str = Number(str);
   out("  mixed arg types: " + x + ", " + UTF8ToString(str) + ", " + d);
   return 8.125;
 });
@@ -60,6 +68,7 @@ EM_JS(char*, return_utf8_str, (void), {
     var lengthBytes = lengthBytesUTF8(jsString)+1;
     var stringOnWasmHeap = _malloc(lengthBytes);
     stringToUTF8(jsString, stringOnWasmHeap, lengthBytes);
+    // FIXME(https://github.com/emscripten-core/emscripten/issues/16975)
 #if __wasm64__
     return BigInt(stringOnWasmHeap);
 #else
@@ -72,6 +81,7 @@ EM_JS(char*, return_str, (void), {
   var lengthBytes = jsString.length+1;
   var stringOnWasmHeap = _malloc(lengthBytes);
   stringToUTF8(jsString, stringOnWasmHeap, lengthBytes);
+    // FIXME(https://github.com/emscripten-core/emscripten/issues/16975)
 #if __wasm64__
   return BigInt(stringOnWasmHeap);
 #else

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -661,7 +661,7 @@ def generate_js(data_target, data_files, metadata):
         code += '''\
           var start64 = Module['___emscripten_embedded_file_data'] >> 3;
           do {
-            var name_addr = HEAPU64[start64++];
+            var name_addr = Number(HEAPU64[start64++]);
             var len = HEAPU32[start64 << 1];
             start64++;
             var content = Number(HEAPU64[start64++]);


### PR DESCRIPTION
Followup to #16922.

The goal here is to do any BigInt/Number conversions for int53 at the
JS/Wasm boundary.  Some of the internal usage of `from64` predates the
`__sig` machanism for annotating functions and no longer necessary.