### PR TITLE
[WasmFS] Fix URL support in fetch backend

### DIFF
--- a/src/library_wasmfs_fetch.js
+++ b/src/library_wasmfs_fetch.js
@@ -14,7 +14,7 @@ mergeInto(LibraryManager.library, {
     '$wasmFS$JSMemoryFiles',
     '_wasmfs_create_js_file_backend_js',
   ],
-  _wasmfs_create_fetch_backend_js: async function (backend) {
+  _wasmfs_create_fetch_backend_js: async function(backend) {
     // Get a promise that fetches the data and stores it in JS memory (if it has
     // not already been fetched).
     async function getFile(file) {
@@ -70,7 +70,7 @@ mergeInto(LibraryManager.library, {
         await getFile(file);
         return jsFileOps.read(file, buffer, length, offset);
       },
-      getSize: async (file) => {
+      getSize: async(file) => {
         await getFile(file);
         return jsFileOps.getSize(file);
       },

--- a/src/library_wasmfs_jsimpl.js
+++ b/src/library_wasmfs_jsimpl.js
@@ -9,6 +9,8 @@ mergeInto(LibraryManager.library, {
   // the JS code that implements them. This is the JS side of the JSImpl* class
   // in C++, together with the js_impl calls defined right after it.
   $wasmFS$backends: {},
+  // Contains a mapping of backend files to their file names.
+  $wasmFS$backendFileNames: {},
 
   _wasmfs_jsimpl_alloc_file: function(backend, file) {
 #if ASSERTIONS
@@ -107,5 +109,12 @@ mergeInto(LibraryManager.library, {
     var size = await wasmFS$backends[backend].getSize(file);
     {{{ makeSetValue('size_p', 0, 'size', 'i64') }}};
     _emscripten_proxy_finish(ctx);
+  },
+
+  _wasmfs_jsimpl_set_backend_name: function(backend, file, name) {
+#if ASSERTIONS
+    assert(wasmFS$backends[backend]);
+#endif
+    wasmFS$backendFileNames[file] = name ? UTF8ToString(name) : undefined;
   },
 });

--- a/src/library_wasmfs_jsimpl.js
+++ b/src/library_wasmfs_jsimpl.js
@@ -9,8 +9,6 @@ mergeInto(LibraryManager.library, {
   // the JS code that implements them. This is the JS side of the JSImpl* class
   // in C++, together with the js_impl calls defined right after it.
   $wasmFS$backends: {},
-  // Contains a mapping of backend files to their file names.
-  $wasmFS$backendFileNames: {},
 
   _wasmfs_jsimpl_alloc_file: function(backend, file) {
 #if ASSERTIONS
@@ -109,12 +107,5 @@ mergeInto(LibraryManager.library, {
     var size = await wasmFS$backends[backend].getSize(file);
     {{{ makeSetValue('size_p', 0, 'size', 'i64') }}};
     _emscripten_proxy_finish(ctx);
-  },
-
-  _wasmfs_jsimpl_set_backend_name: function(backend, file, name) {
-#if ASSERTIONS
-    assert(wasmFS$backends[backend]);
-#endif
-    wasmFS$backendFileNames[file] = name ? UTF8ToString(name) : undefined;
   },
 });

--- a/system/lib/wasmfs/backends/fetch_backend.cpp
+++ b/system/lib/wasmfs/backends/fetch_backend.cpp
@@ -13,13 +13,12 @@
 // See library_wasmfs_fetch.js
 
 extern "C" {
-void _wasmfs_create_fetch_backend_js(wasmfs::backend_t, char*);
+void _wasmfs_create_fetch_backend_js(wasmfs::backend_t, const char*);
 }
 
 namespace wasmfs {
 
-extern "C" backend_t wasmfs_create_fetch_backend(char* base_url) {
-  // TODO: use base url, cache on JS side
+extern "C" backend_t wasmfs_create_fetch_backend(const char* base_url) {
   return wasmFS.addBackend(
     std::make_unique<ProxiedAsyncJSBackend>([base_url](backend_t backend) {
       _wasmfs_create_fetch_backend_js(backend, base_url);

--- a/system/lib/wasmfs/backends/fetch_backend.cpp
+++ b/system/lib/wasmfs/backends/fetch_backend.cpp
@@ -13,15 +13,17 @@
 // See library_wasmfs_fetch.js
 
 extern "C" {
-void _wasmfs_create_fetch_backend_js(wasmfs::backend_t);
+void _wasmfs_create_fetch_backend_js(wasmfs::backend_t, char*);
 }
 
 namespace wasmfs {
 
 extern "C" backend_t wasmfs_create_fetch_backend(char* base_url) {
   // TODO: use base url, cache on JS side
-  return wasmFS.addBackend(std::make_unique<ProxiedAsyncJSBackend>(
-    [](backend_t backend) { _wasmfs_create_fetch_backend_js(backend); }));
+  return wasmFS.addBackend(
+    std::make_unique<ProxiedAsyncJSBackend>([base_url](backend_t backend) {
+      _wasmfs_create_fetch_backend_js(backend, base_url);
+    }));
 }
 
 } // namespace wasmfs

--- a/system/lib/wasmfs/backends/fetch_backend.cpp
+++ b/system/lib/wasmfs/backends/fetch_backend.cpp
@@ -13,16 +13,86 @@
 // See library_wasmfs_fetch.js
 
 extern "C" {
-void _wasmfs_create_fetch_backend_js(wasmfs::backend_t, const char*);
+void _wasmfs_create_fetch_backend_js(wasmfs::backend_t);
 }
 
 namespace wasmfs {
 
-extern "C" backend_t wasmfs_create_fetch_backend(const char* base_url) {
-  return wasmFS.addBackend(
-    std::make_unique<ProxiedAsyncJSBackend>([base_url](backend_t backend) {
-      _wasmfs_create_fetch_backend_js(backend, base_url);
-    }));
+class FetchFile : public ProxiedAsyncJSImplFile {
+  std::string filePath;
+
+public:
+  FetchFile(const std::string& path,
+            mode_t mode,
+            backend_t backend,
+            emscripten::ProxyWorker& proxy)
+    : ProxiedAsyncJSImplFile(mode, backend, proxy), filePath(path) {}
+
+  const std::string& getPath() const { return filePath; }
+};
+
+class FetchDirectory : public MemoryDirectory {
+  std::string dirPath;
+  emscripten::ProxyWorker& proxy;
+
+public:
+  FetchDirectory(const std::string& path,
+                 mode_t mode,
+                 backend_t backend,
+                 emscripten::ProxyWorker& proxy)
+    : MemoryDirectory(mode, backend), dirPath(path), proxy(proxy) {}
+
+  std::shared_ptr<DataFile> insertDataFile(const std::string& name,
+                                           mode_t mode) override {
+    auto childPath = getChildPath(name);
+    auto child =
+      std::make_shared<FetchFile>(childPath, mode, getBackend(), proxy);
+    insertChild(name, child);
+    return child;
+  }
+
+  std::shared_ptr<Directory> insertDirectory(const std::string& name,
+                                             mode_t mode) override {
+    auto childPath = getChildPath(name);
+    auto childDir =
+      std::make_shared<FetchDirectory>(childPath, mode, getBackend(), proxy);
+    insertChild(name, childDir);
+    return childDir;
+  }
+
+  std::string getChildPath(const std::string& name) const {
+    return dirPath + '/' + name;
+  }
+};
+
+class FetchBackend : public ProxiedAsyncJSBackend {
+  std::string baseUrl;
+
+public:
+  FetchBackend(const std::string& baseUrl,
+               std::function<void(backend_t)> setupOnThread)
+    : ProxiedAsyncJSBackend(setupOnThread), baseUrl(baseUrl) {}
+
+  std::shared_ptr<DataFile> createFile(mode_t mode) override {
+    return std::make_shared<FetchFile>(baseUrl, mode, this, proxy);
+  }
+
+  std::shared_ptr<Directory> createDirectory(mode_t mode) override {
+    return std::make_shared<FetchDirectory>(baseUrl, mode, this, proxy);
+  }
+};
+
+extern "C" {
+backend_t wasmfs_create_fetch_backend(const char* base_url) {
+  return wasmFS.addBackend(std::make_unique<FetchBackend>(
+    base_url ? base_url : "",
+    [](backend_t backend) { _wasmfs_create_fetch_backend_js(backend); }));
+}
+
+const char* EMSCRIPTEN_KEEPALIVE _wasmfs_fetch_get_file_path(void* ptr) {
+  auto* file = reinterpret_cast<wasmfs::FetchFile*>(ptr);
+  return file ? file->getPath().data() : nullptr;
+}
 }
 
 } // namespace wasmfs

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -52,6 +52,7 @@ class MemoryDirectory : public Directory {
 
   std::vector<ChildEntry>::iterator findEntry(const std::string& name);
 
+protected:
   void insertChild(const std::string& name, std::shared_ptr<File> child) {
     assert(findEntry(name) == entries.end());
     entries.push_back({name, child});

--- a/system/lib/wasmfs/proxied_async_js_impl_backend.h
+++ b/system/lib/wasmfs/proxied_async_js_impl_backend.h
@@ -67,6 +67,9 @@ void _wasmfs_jsimpl_async_get_size(em_proxying_ctx* ctx,
                                    js_index_t backend,
                                    js_index_t index,
                                    size_t* result);
+void _wasmfs_jsimpl_set_backend_name(js_index_t backend,
+                                     js_index_t index,
+                                     const char* name);
 }
 
 namespace wasmfs {
@@ -85,8 +88,20 @@ class ProxiedAsyncJSImplFile : public DataFile {
   }
 
   // TODO: Notify the JS about open and close events?
-  void open(oflags_t) override {}
-  void close() override {}
+  void open(oflags_t) override {
+    const std::string name = getRelativeFileName();
+    proxy([&]() {
+      _wasmfs_jsimpl_set_backend_name(
+        getBackendIndex(), getFileIndex(), name.data());
+    });
+  }
+
+  void close() override {
+    proxy([&]() {
+      _wasmfs_jsimpl_set_backend_name(
+        getBackendIndex(), getFileIndex(), nullptr);
+    });
+  }
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
     ssize_t result;
@@ -107,6 +122,22 @@ class ProxiedAsyncJSImplFile : public DataFile {
   }
 
   void flush() override {}
+
+  std::string getRelativeFileName() {
+    std::string name;
+    auto parent = locked().getParent();
+    auto child = shared_from_this();
+    while (parent) {
+      if (!name.empty())
+        name.insert(0, "/");
+      name.insert(0, parent->locked().getName(child));
+      if (parent->getBackend() != backend)
+        break;
+      child = parent;
+      parent = parent->locked().getParent();
+    }
+    return name;
+  }
 
   size_t getSize() override {
     size_t result;

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5302,7 +5302,7 @@ window.close = function() {
   @parameterized({
     # the fetch backend works even on the main thread: we proxy to a background
     # thread and busy-wait
-    'main_thread': (['-sPTHREAD_POOL_SIZE=1'],),
+    'main_thread': (['-sPTHREAD_POOL_SIZE=4'],),
     # using proxy_to_pthread also works, of course
     'proxy_to_pthread': (['-sPROXY_TO_PTHREAD', '-sINITIAL_MEMORY=32MB', '-DPROXYING'],),
   })

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5304,13 +5304,18 @@ window.close = function() {
     # thread and busy-wait
     'main_thread': (['-sPTHREAD_POOL_SIZE=1'],),
     # using proxy_to_pthread also works, of course
-    'proxy_to_pthread': (['-sPROXY_TO_PTHREAD'],),
+    'proxy_to_pthread': (['-sPROXY_TO_PTHREAD', '-sINITIAL_MEMORY=32MB', '-DPROXYING'],),
   })
   @requires_threads
   def test_wasmfs_fetch_backend(self, args):
     if is_firefox() and '-sPROXY_TO_PTHREAD' not in args:
       return self.skipTest('ff hangs on the main_thread version. browser bug?')
     create_file('data.dat', 'hello, fetch')
+    create_file('test.txt', 'fetch 2')
+    try_delete('subdir')
+    ensure_dir('subdir')
+    create_file('subdir/backendfile', 'file 1')
+    create_file('subdir/backendfile2', 'file 2')
     self.btest_exit(test_file('wasmfs/wasmfs_fetch.c'),
                     args=['-sWASMFS', '-sUSE_PTHREADS'] + args)
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5317,7 +5317,7 @@ window.close = function() {
     create_file('subdir/backendfile', 'file 1')
     create_file('subdir/backendfile2', 'file 2')
     self.btest_exit(test_file('wasmfs/wasmfs_fetch.c'),
-                    args=['-sWASMFS', '-sUSE_PTHREADS'] + args)
+                    args=['-sWASMFS', '-sUSE_PTHREADS', '--js-library', test_file('wasmfs/wasmfs_fetch.js')] + args)
 
   @requires_threads
   @no_firefox('no OPFS support yet')

--- a/tests/wasmfs/wasmfs_fetch.c
+++ b/tests/wasmfs/wasmfs_fetch.c
@@ -16,6 +16,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+// NOTE: Each fetch backend runs in a separate thread.
+
 void getUrlOrigin(char* ptr, int len);
 char url_orig[256] = {};
 
@@ -127,13 +129,9 @@ void test_default() {
 int main() {
   getUrlOrigin(url_orig, sizeof(url_orig));
   test_default();
-
-  // NOTE: Each fetch backend runs in a separate thread.
-#ifdef PROXYING
   test_url_relative();
   test_url_absolute();
   test_directory_abs();
-#endif
 
   return 0;
 }

--- a/tests/wasmfs/wasmfs_fetch.c
+++ b/tests/wasmfs/wasmfs_fetch.c
@@ -17,7 +17,7 @@
 #include <unistd.h>
 
 void getUrlOrigin(char* ptr, int len);
-char url_orig[1024] = {};
+char url_orig[256] = {};
 
 void check_file(int fd, const char* content) {
   assert(fd >= 0);
@@ -47,15 +47,24 @@ void test_url_absolute() {
   printf("Running %s...\n", __FUNCTION__);
 
   assert(strlen(url_orig) != 0);
-  backend_t backend = wasmfs_create_fetch_backend(url_orig);
-  int fd = wasmfs_create_file("/test.txt", 0777, backend);
+  const char* file_name = "/test.txt";
+  char url[200];
+  snprintf(url, sizeof(url), "%s%s", url_orig, file_name);
+
+  backend_t backend = wasmfs_create_fetch_backend(url);
+  int fd = wasmfs_create_file(file_name, 0777, backend);
   check_file(fd, "fetch 2");
   assert(close(fd) == 0);
 }
 
 void test_directory_abs() {
-  backend_t backend = wasmfs_create_fetch_backend(url_orig);
+  printf("Running %s...\n", __FUNCTION__);
+
   const char* dir_path = "/subdir";
+  char url[200];
+  snprintf(url, sizeof(url), "%s%s", url_orig, dir_path);
+
+  backend_t backend = wasmfs_create_fetch_backend(url);
   int res = wasmfs_create_directory(dir_path, 0777, backend);
   if (errno)
     perror("wasmfs_create_directory");

--- a/tests/wasmfs/wasmfs_fetch.js
+++ b/tests/wasmfs/wasmfs_fetch.js
@@ -1,0 +1,12 @@
+mergeInto(LibraryManager.library, {
+  getUrlOrigin: function (ptr, len) {
+    try {
+      var orig = self.location.origin;
+      var nb = lengthBytesUTF8(orig) + 1;
+      if (nb <= len)
+        stringToUTF8(orig, ptr, len);
+    } catch (e) {
+      console.warn(e);
+    }
+  }
+});


### PR DESCRIPTION
Use the relative file path as a part of fetch URL.
But do so only in case the base URL is absolute.
This allows fetching several different files using the same backend.

Fix #16954