### PR TITLE
Fix cache repopulation within `emconfigure`

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5517,6 +5517,12 @@ print(os.environ.get('NM'))
 ''')
     check(EMCONFIGURE, [PYTHON, 'test.py'], expect=shared.LLVM_NM, fail=False)
 
+    create_file('test.c', 'int main() { return 0; }')
+    cache_dir = tempfile.mkdtemp(prefix='emscripten_test_cache_')
+    with env_modify({'EM_CACHE': cache_dir}):
+      check(EMCONFIGURE, [EMCC, 'test.c'], fail=False)
+    shutil.rmtree(cache_dir)
+
   def test_emmake_python(self):
     # simulates a configure/make script that looks for things like CC, AR, etc., and which we should
     # not confuse by setting those vars to something containing `python X` as the script checks for

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5518,8 +5518,8 @@ print(os.environ.get('NM'))
     check(EMCONFIGURE, [PYTHON, 'test.py'], expect=shared.LLVM_NM, fail=False)
 
     create_file('test.c', 'int main() { return 0; }')
-    cache_dir = tempfile.mkdtemp(prefix='emscripten_test_cache_')
-    with env_modify({'EM_CACHE': cache_dir}):
+    os.mkdir('test_cache')
+    with env_modify({'EM_CACHE': os.path.join(os.getcwd(), 'test_cache')}):
       check(EMCONFIGURE, [EMCC, 'test.c'], fail=False)
     shutil.rmtree(cache_dir)
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5519,7 +5519,7 @@ print(os.environ.get('NM'))
 
     create_file('test.c', 'int main() { return 0; }')
     os.mkdir('test_cache')
-    with env_modify({'EM_CACHE': os.path.join(os.getcwd(), 'test_cache')}):
+    with env_modify({'EM_CACHE': os.path.abspath('test_cache')}):
       check(EMCONFIGURE, [EMCC, 'test.c'], fail=False)
 
   def test_emmake_python(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5521,7 +5521,6 @@ print(os.environ.get('NM'))
     os.mkdir('test_cache')
     with env_modify({'EM_CACHE': os.path.join(os.getcwd(), 'test_cache')}):
       check(EMCONFIGURE, [EMCC, 'test.c'], fail=False)
-    shutil.rmtree(cache_dir)
 
   def test_emmake_python(self):
     # simulates a configure/make script that looks for things like CC, AR, etc., and which we should

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -62,7 +62,8 @@ def clean_env():
   for opt in ['CFLAGS', 'CXXFLAGS', 'LDFLAGS',
               'EMCC_CFLAGS',
               'EMCC_FORCE_STDLIBS',
-              'EMCC_ONLY_FORCED_STDLIBS']:
+              'EMCC_ONLY_FORCED_STDLIBS',
+              'EMMAKEN_JUST_CONFIGURE']:
     if opt in safe_env:
       del safe_env[opt]
   return safe_env


### PR DESCRIPTION
When `emcc` is called within `emconfigure` and also needs to build a cache from scratch, it incorrectly retains the `EMMAKEN_JUST_CONFIGURE` variable for the cache build, causing errors.