### PR TITLE
Experiment with CircleCI "resource_class"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: emscripten/emscripten-ci
     environment:
       LANG: "C.UTF-8"
-      EMCC_CORES: "4"
+      EMCC_CORES: "8"
       EMSDK_NOTTY: "1"
       EMTEST_WASI_SYSROOT: "~/wasi-sdk/wasi-sysroot"
       EMTEST_BUILD_VERBOSE: "2"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: emscripten/emscripten-ci
     environment:
       LANG: "C.UTF-8"
-      EMCC_CORES: "8"
+      EMCC_CORES: "16"
       EMSDK_NOTTY: "1"
       EMTEST_WASI_SYSROOT: "~/wasi-sdk/wasi-sysroot"
       EMTEST_BUILD_VERBOSE: "2"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,7 @@ jobs:
     # Use the largest resource class we can to make this job as fast as
     # possible, since it blocks almost all other jobs.
     # https://circleci.com/docs/2.0/configuration-reference/#resourceclass
-    resource_class: xlarge
+    resource_class: xlarge # no faster :(
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ executors:
       - image: emscripten/emscripten-ci
     environment:
       LANG: "C.UTF-8"
+      EMCC_CORES: "4"
       EMSDK_NOTTY: "1"
       EMTEST_WASI_SYSROOT: "~/wasi-sdk/wasi-sysroot"
       EMTEST_BUILD_VERBOSE: "2"
@@ -307,6 +308,10 @@ jobs:
     # cost for the same work), but given this blocks almost all the other jobs
     # we want it to finish asap
     resource_class: xlarge
+    environment:
+      # undefine the number of cores, so that we pick up the default for xlarge
+      # (which is more future proof)
+      EMCC_CORES: ""
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,6 +303,10 @@ jobs:
           test_targets: "sanity"
   build-linux:
     executor: bionic
+    # Use the largest resource class we can to make this job as fast as
+    # possible, since it blocks almost all other jobs.
+    # https://circleci.com/docs/2.0/configuration-reference/#resourceclass
+    resource_class: xlarge
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,13 +297,13 @@ jobs:
       - run: npm run lint
   test-sanity:
     executor: bionic
-    resource_class: xlarge
+    resource_class: large
     steps:
       - run-tests-linux:
           test_targets: "sanity"
   build-linux:
     executor: bionic
-    resource_class: xlarge
+    resource_class: large
     steps:
       - checkout
       - run:
@@ -344,13 +344,13 @@ jobs:
   # Perhaps we don't need to run this suite with every commit. Consider moving this to FYI bot.
   test-posixtest:
     executor: bionic
-    resource_class: xlarge
+    resource_class: large
     steps:
       - run-tests-linux:
           test_targets: "posixtest"
   test-core0:
     executor: bionic
-    resource_class: xlarge
+    resource_class: large
     # Temporarily set EMCC_READ_METADATA to compare to ensure that the python
     # can marches precisely the output wasm-emscripten-finalize.
     environment:
@@ -362,7 +362,7 @@ jobs:
           test_targets: "core0 skip:core0.test_em_js_pthreads"
   test-core2:
     executor: bionic
-    resource_class: xlarge
+    resource_class: large
     environment:
       EMTEST_BROWSER: "node"
     steps:
@@ -371,7 +371,7 @@ jobs:
           test_targets: "core2 asan.test_stat asan.test_float_builtins asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime asan.test_async_hello lsan.test_stdio_locking lsan.test_pthread_create browser.test_pthread_join"
   test-core3:
     executor: bionic
-    resource_class: xlarge
+    resource_class: large
     steps:
       - run-tests-linux:
           # also add a little select testing for wasm2js in -O3
@@ -379,19 +379,19 @@ jobs:
           test_targets: "core3 wasm2js3.test_memorygrowth_2 wasmfs.test_hello_world wasmfs.test_hello_world_standalone wasmfs.test_unistd_links* wasmfs.test_atexit_standalone wasmfs.test_emscripten_get_now wasmfs.test_dyncall_specific_minimal_runtime core2ss.test_pthread_dylink wasmfs.test_utime wasmfs.test_unistd_unlink wasmfs.test_unistd_access wasmfs.test_unistd_close wasmfs.test_unistd_truncate wasmfs.test_readdir wasmfs.test_unistd_pipe wasmfs.test_dlfcn_self wasmfs.test_dlfcn_unique_sig wasmfs.test_dylink_basics wasmfs.test_exit_status wasmfs.test_minimal_runtime_memorygrowth wasmfs.test_getcwd_with_non_ascii_name other.test_unistd_fstatfs_wasmfs"
   test-wasm2js1:
     executor: bionic
-    resource_class: xlarge
+    resource_class: large
     steps:
       - run-tests-linux:
           test_targets: "wasm2js1"
   test-wasm64:
     executor: bionic
-    resource_class: xlarge
+    resource_class: large
     steps:
       - run-tests-linux:
           test_targets: "wasm64.test_hello_world wasm64.test_ccall wasm64l"
   test-other:
     executor: bionic
-    resource_class: xlarge
+    resource_class: large
     steps:
       - run-tests-linux:
           # some native-dependent tests fail because of the lack of native
@@ -399,17 +399,17 @@ jobs:
           test_targets: "other skip:other.test_native_link_error_message"
   test-browser-chrome:
     executor: bionic
-    resource_class: xlarge
+    resource_class: large
     steps:
       - test-chrome
   test-browser-firefox:
     executor: bionic
-    resource_class: xlarge
+    resource_class: large
     steps:
       - test-firefox
   test-sockets-chrome:
     executor: bionic
-    resource_class: xlarge
+    resource_class: large
     steps:
       - test-sockets-chrome
   # windows and mac do not have separate build and test jobs, as they only run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,9 +309,7 @@ jobs:
     # we want it to finish asap
     resource_class: xlarge
     environment:
-      # undefine the number of cores, so that we pick up the default for xlarge
-      # (which is more future proof)
-      EMCC_CORES: null
+      EMCC_CORES: 16
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,15 +298,13 @@ jobs:
       - run: npm run lint
   test-sanity:
     executor: bionic
+    resource_class: xlarge
     steps:
       - run-tests-linux:
           test_targets: "sanity"
   build-linux:
     executor: bionic
-    # Use the largest resource class we can to make this job as fast as
-    # possible, since it blocks almost all other jobs.
-    # https://circleci.com/docs/2.0/configuration-reference/#resourceclass
-    resource_class: xlarge # no faster :(
+    resource_class: xlarge
     steps:
       - checkout
       - run:
@@ -347,11 +345,13 @@ jobs:
   # Perhaps we don't need to run this suite with every commit. Consider moving this to FYI bot.
   test-posixtest:
     executor: bionic
+    resource_class: xlarge
     steps:
       - run-tests-linux:
           test_targets: "posixtest"
   test-core0:
     executor: bionic
+    resource_class: xlarge
     # Temporarily set EMCC_READ_METADATA to compare to ensure that the python
     # can marches precisely the output wasm-emscripten-finalize.
     environment:
@@ -363,6 +363,7 @@ jobs:
           test_targets: "core0 skip:core0.test_em_js_pthreads"
   test-core2:
     executor: bionic
+    resource_class: xlarge
     environment:
       EMTEST_BROWSER: "node"
     steps:
@@ -371,6 +372,7 @@ jobs:
           test_targets: "core2 asan.test_stat asan.test_float_builtins asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime asan.test_async_hello lsan.test_stdio_locking lsan.test_pthread_create browser.test_pthread_join"
   test-core3:
     executor: bionic
+    resource_class: xlarge
     steps:
       - run-tests-linux:
           # also add a little select testing for wasm2js in -O3
@@ -378,16 +380,19 @@ jobs:
           test_targets: "core3 wasm2js3.test_memorygrowth_2 wasmfs.test_hello_world wasmfs.test_hello_world_standalone wasmfs.test_unistd_links* wasmfs.test_atexit_standalone wasmfs.test_emscripten_get_now wasmfs.test_dyncall_specific_minimal_runtime core2ss.test_pthread_dylink wasmfs.test_utime wasmfs.test_unistd_unlink wasmfs.test_unistd_access wasmfs.test_unistd_close wasmfs.test_unistd_truncate wasmfs.test_readdir wasmfs.test_unistd_pipe wasmfs.test_dlfcn_self wasmfs.test_dlfcn_unique_sig wasmfs.test_dylink_basics wasmfs.test_exit_status wasmfs.test_minimal_runtime_memorygrowth wasmfs.test_getcwd_with_non_ascii_name other.test_unistd_fstatfs_wasmfs"
   test-wasm2js1:
     executor: bionic
+    resource_class: xlarge
     steps:
       - run-tests-linux:
           test_targets: "wasm2js1"
   test-wasm64:
     executor: bionic
+    resource_class: xlarge
     steps:
       - run-tests-linux:
           test_targets: "wasm64.test_hello_world wasm64.test_ccall wasm64l"
   test-other:
     executor: bionic
+    resource_class: xlarge
     steps:
       - run-tests-linux:
           # some native-dependent tests fail because of the lack of native
@@ -395,14 +400,17 @@ jobs:
           test_targets: "other skip:other.test_native_link_error_message"
   test-browser-chrome:
     executor: bionic
+    resource_class: xlarge
     steps:
       - test-chrome
   test-browser-firefox:
     executor: bionic
+    resource_class: xlarge
     steps:
       - test-firefox
   test-sockets-chrome:
     executor: bionic
+    resource_class: xlarge
     steps:
       - test-sockets-chrome
   # windows and mac do not have separate build and test jobs, as they only run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,12 +297,15 @@ jobs:
       - run: npm run lint
   test-sanity:
     executor: bionic
-    resource_class: xlarge
     steps:
       - run-tests-linux:
           test_targets: "sanity"
   build-linux:
     executor: bionic
+    # xlarge has 4x the cores of the default medium, costs 4x as much, and runs
+    # in about 1/2 the time, so it is not cost-effective (overall it is 2x the
+    # cost for the same work), but given this blocks almost all the other jobs
+    # we want it to finish asap
     resource_class: xlarge
     steps:
       - checkout
@@ -344,13 +347,11 @@ jobs:
   # Perhaps we don't need to run this suite with every commit. Consider moving this to FYI bot.
   test-posixtest:
     executor: bionic
-    resource_class: xlarge
     steps:
       - run-tests-linux:
           test_targets: "posixtest"
   test-core0:
     executor: bionic
-    resource_class: xlarge
     # Temporarily set EMCC_READ_METADATA to compare to ensure that the python
     # can marches precisely the output wasm-emscripten-finalize.
     environment:
@@ -362,7 +363,6 @@ jobs:
           test_targets: "core0 skip:core0.test_em_js_pthreads"
   test-core2:
     executor: bionic
-    resource_class: xlarge
     environment:
       EMTEST_BROWSER: "node"
     steps:
@@ -371,7 +371,6 @@ jobs:
           test_targets: "core2 asan.test_stat asan.test_float_builtins asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime asan.test_async_hello lsan.test_stdio_locking lsan.test_pthread_create browser.test_pthread_join"
   test-core3:
     executor: bionic
-    resource_class: xlarge
     steps:
       - run-tests-linux:
           # also add a little select testing for wasm2js in -O3
@@ -379,19 +378,16 @@ jobs:
           test_targets: "core3 wasm2js3.test_memorygrowth_2 wasmfs.test_hello_world wasmfs.test_hello_world_standalone wasmfs.test_unistd_links* wasmfs.test_atexit_standalone wasmfs.test_emscripten_get_now wasmfs.test_dyncall_specific_minimal_runtime core2ss.test_pthread_dylink wasmfs.test_utime wasmfs.test_unistd_unlink wasmfs.test_unistd_access wasmfs.test_unistd_close wasmfs.test_unistd_truncate wasmfs.test_readdir wasmfs.test_unistd_pipe wasmfs.test_dlfcn_self wasmfs.test_dlfcn_unique_sig wasmfs.test_dylink_basics wasmfs.test_exit_status wasmfs.test_minimal_runtime_memorygrowth wasmfs.test_getcwd_with_non_ascii_name other.test_unistd_fstatfs_wasmfs"
   test-wasm2js1:
     executor: bionic
-    resource_class: xlarge
     steps:
       - run-tests-linux:
           test_targets: "wasm2js1"
   test-wasm64:
     executor: bionic
-    resource_class: xlarge
     steps:
       - run-tests-linux:
           test_targets: "wasm64.test_hello_world wasm64.test_ccall wasm64l"
   test-other:
     executor: bionic
-    resource_class: xlarge
     steps:
       - run-tests-linux:
           # some native-dependent tests fail because of the lack of native
@@ -399,17 +395,14 @@ jobs:
           test_targets: "other skip:other.test_native_link_error_message"
   test-browser-chrome:
     executor: bionic
-    resource_class: xlarge
     steps:
       - test-chrome
   test-browser-firefox:
     executor: bionic
-    resource_class: xlarge
     steps:
       - test-firefox
   test-sockets-chrome:
     executor: bionic
-    resource_class: xlarge
     steps:
       - test-sockets-chrome
   # windows and mac do not have separate build and test jobs, as they only run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,7 @@ jobs:
     environment:
       # undefine the number of cores, so that we pick up the default for xlarge
       # (which is more future proof)
-      EMCC_CORES: ""
+      EMCC_CORES: null
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,13 +297,13 @@ jobs:
       - run: npm run lint
   test-sanity:
     executor: bionic
-    resource_class: large
+    resource_class: xlarge
     steps:
       - run-tests-linux:
           test_targets: "sanity"
   build-linux:
     executor: bionic
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - run:
@@ -344,13 +344,13 @@ jobs:
   # Perhaps we don't need to run this suite with every commit. Consider moving this to FYI bot.
   test-posixtest:
     executor: bionic
-    resource_class: large
+    resource_class: xlarge
     steps:
       - run-tests-linux:
           test_targets: "posixtest"
   test-core0:
     executor: bionic
-    resource_class: large
+    resource_class: xlarge
     # Temporarily set EMCC_READ_METADATA to compare to ensure that the python
     # can marches precisely the output wasm-emscripten-finalize.
     environment:
@@ -362,7 +362,7 @@ jobs:
           test_targets: "core0 skip:core0.test_em_js_pthreads"
   test-core2:
     executor: bionic
-    resource_class: large
+    resource_class: xlarge
     environment:
       EMTEST_BROWSER: "node"
     steps:
@@ -371,7 +371,7 @@ jobs:
           test_targets: "core2 asan.test_stat asan.test_float_builtins asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime asan.test_async_hello lsan.test_stdio_locking lsan.test_pthread_create browser.test_pthread_join"
   test-core3:
     executor: bionic
-    resource_class: large
+    resource_class: xlarge
     steps:
       - run-tests-linux:
           # also add a little select testing for wasm2js in -O3
@@ -379,19 +379,19 @@ jobs:
           test_targets: "core3 wasm2js3.test_memorygrowth_2 wasmfs.test_hello_world wasmfs.test_hello_world_standalone wasmfs.test_unistd_links* wasmfs.test_atexit_standalone wasmfs.test_emscripten_get_now wasmfs.test_dyncall_specific_minimal_runtime core2ss.test_pthread_dylink wasmfs.test_utime wasmfs.test_unistd_unlink wasmfs.test_unistd_access wasmfs.test_unistd_close wasmfs.test_unistd_truncate wasmfs.test_readdir wasmfs.test_unistd_pipe wasmfs.test_dlfcn_self wasmfs.test_dlfcn_unique_sig wasmfs.test_dylink_basics wasmfs.test_exit_status wasmfs.test_minimal_runtime_memorygrowth wasmfs.test_getcwd_with_non_ascii_name other.test_unistd_fstatfs_wasmfs"
   test-wasm2js1:
     executor: bionic
-    resource_class: large
+    resource_class: xlarge
     steps:
       - run-tests-linux:
           test_targets: "wasm2js1"
   test-wasm64:
     executor: bionic
-    resource_class: large
+    resource_class: xlarge
     steps:
       - run-tests-linux:
           test_targets: "wasm64.test_hello_world wasm64.test_ccall wasm64l"
   test-other:
     executor: bionic
-    resource_class: large
+    resource_class: xlarge
     steps:
       - run-tests-linux:
           # some native-dependent tests fail because of the lack of native
@@ -399,17 +399,17 @@ jobs:
           test_targets: "other skip:other.test_native_link_error_message"
   test-browser-chrome:
     executor: bionic
-    resource_class: large
+    resource_class: xlarge
     steps:
       - test-chrome
   test-browser-firefox:
     executor: bionic
-    resource_class: large
+    resource_class: xlarge
     steps:
       - test-firefox
   test-sockets-chrome:
     executor: bionic
-    resource_class: large
+    resource_class: xlarge
     steps:
       - test-sockets-chrome
   # windows and mac do not have separate build and test jobs, as they only run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ executors:
       - image: emscripten/emscripten-ci
     environment:
       LANG: "C.UTF-8"
-      EMCC_CORES: "16"
       EMSDK_NOTTY: "1"
       EMTEST_WASI_SYSROOT: "~/wasi-sdk/wasi-sysroot"
       EMTEST_BUILD_VERBOSE: "2"


### PR DESCRIPTION
This sees what happens if we use "extra large" - the biggest CircleCI has - compared
to the default "medium" we've been using. This should bump us from 2 virtual cores to
8 and likewise increase memory by a similar ratio.

Sadly this does not help on `build-linux` that I can see, which is the most critical one.
But it does help on `core*` and `other`, but only by around 30% or so, which is slightly
disappointing given how parallelizable our tests are (and even inside each test, in
binaryen). Perhaps disk I/O or something else is just significant there?

I can't find any docs on the cost of this switch, but I guess their pricing may not be
fully public? Overall, given the modest improvement here, I'm not sure it's worth it,
but if the cost is not an issue maybe we should do it.