### PR TITLE
Fix TextDecoder exception on decoding SharedArrayBuffer

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1253,5 +1253,7 @@ function getUnsharedTextDecoderView(heap, start, end) {
 
   // Otherwise, generate a runtime type check: must do a .slice() if looking at a SAB,
   // or can use .subarray() otherwise.
-  return `${heap}.buffer instanceof SharedArrayBuffer ? ${shared} : ${unshared}`;
+  // In some cases, `instanceof SharedArrayBuffer` returns false even though buffer is an SAB.
+  // See: https://github.com/emscripten-core/emscripten/issues/15217
+  return `Object.prototype.toString.call(${heap}.buffer) === "[object SharedArrayBuffer]" ? ${shared} : ${unshared}`;
 }


### PR DESCRIPTION
Fixes #15217

This patch is used in our product to fix a problem described in #15217.

I haven't run a full browser compatibility tests other than Chrome.  But I see this pattern (type checking based on `Symbol.toStringTag`) [already being used][1] so I guess it is acceptable.

As for performance, benchmark shows `Object.prototype.toString.call` is slightly faster than `instanceof`.

[1]: https://github.com/emscripten-core/emscripten/blob/d5ef6937fe395488e23a82c1e582a7ea5c2dab83/third_party/socket.io.js#L374-L376