### PR TITLE
[EH] Tidy up format_exception.cpp (NFC)

### DIFF
--- a/system/lib/libcxxabi/src/format_exception.cpp
+++ b/system/lib/libcxxabi/src/format_exception.cpp
@@ -1,39 +1,46 @@
 #include "cxa_exception.h"
-#include "cxxabi.h"
+#include "private_typeinfo.h"
 #include <stdio.h>
-#include <typeinfo>
 
 #ifdef __USING_EMSCRIPTEN_EXCEPTIONS__
 
+using namespace __cxxabiv1;
+
+//  Utility routines copied from cxa_exception.cpp
+static inline __cxa_exception*
+cxa_exception_from_thrown_object(void* thrown_object) {
+  return static_cast<__cxa_exception*>(thrown_object) - 1;
+}
+
 extern "C" {
 
-int __cxa_can_catch(const std::type_info* catchType,
-                    const std::type_info* excpType,
-                    void** thrown);
-
-char* emscripten_format_exception(void* exc_ptr) {
-  __cxxabiv1::__cxa_exception* exc_info =
-    (__cxxabiv1::__cxa_exception*)exc_ptr - 1;
-  std::type_info* exc_type = exc_info->exceptionType;
-  const char* exc_name = exc_type->name();
+char* emscripten_format_exception(void* thrown_object) {
+  __cxa_exception* exception_header =
+    cxa_exception_from_thrown_object(thrown_object);
+  const __shim_type_info* thrown_type =
+    static_cast<const __shim_type_info*>(exception_header->exceptionType);
+  const char* type_name = thrown_type->name();
 
   int status = 0;
-  char* demangled_buf = __cxxabiv1::__cxa_demangle(exc_name, 0, 0, &status);
+  char* demangled_buf = __cxa_demangle(type_name, 0, 0, &status);
   if (status == 0 && demangled_buf) {
-    exc_name = demangled_buf;
+    type_name = demangled_buf;
   }
 
-  int can_catch = __cxa_can_catch(&typeid(std::exception), exc_type, &exc_ptr);
+  const __shim_type_info* catch_type =
+    static_cast<const __shim_type_info*>(&typeid(std::exception));
+  int can_catch = catch_type->can_catch(thrown_type, thrown_object);
   char* result = NULL;
   if (can_catch) {
-    const char* exc_what = ((std::exception*)exc_ptr)->what();
-    asprintf(&result, "Cpp Exception %s: %s", exc_name, exc_what);
+    const char* what =
+      static_cast<const std::exception*>(thrown_object)->what();
+    asprintf(&result, "Cpp Exception %s: %s", type_name, what);
   } else {
     asprintf(&result,
              "Cpp Exception: The exception is an object of type '%s' at "
              "address %p which does not inherit from std::exception",
-             exc_name,
-             exc_ptr);
+             type_name,
+             thrown_object);
   }
 
   if (demangled_buf) {


### PR DESCRIPTION
This makes small cosmetic changes that do not affect the functionality.
- Use `using namespace __cxxabiv1`. This namespace is used many times
  and I think it's OK to put this at the top. Other libc++abi cpp files
  also do this.
- Use `static_cast` instead of the old cast. This is also in line with
  the rest of libc++abi.
- Change some variable names. This tries to make variable names in line
  with libc++abi's other files; personally I don't particularly like
  their long names such as `exception_header`, but I think keeping them
  in line with the rest of the code is generally good and possibly 
  helpful when we upstream the changes.
- Add `cxa_exception_from_thrown_object` and use it. The reason I copied
  this function from cxa_exception.cpp is I'm planning to use all these
  three when I add Wasm EH support for this function, and it will be
  easier to read if we use these than just doing the arthmetic
  ourselves.
  https://github.com/emscripten-core/emscripten/blob/d5ef6937fe395488e23a82c1e582a7ea5c2dab83/system/lib/libcxxabi/src/cxa_exception.cpp#L39-L67
  The reason I copied them is they are static functions in
  cxa_exception.cpp. We possibly can move them to a header file and
  include it both places, but that means further changes to libc++abi
  codebase, which I think will make this harder to upstream.
- Use `__shim_type_info::can_catch` directly instead of `__cxa_catch`,
  which is a wrapper created to be called from JS. This removes the need
  to include the declaration of `__cxa_catch` in this file.