### PR TITLE
[EH] Simplify exception format message

### DIFF
--- a/system/lib/libcxxabi/src/format_exception.cpp
+++ b/system/lib/libcxxabi/src/format_exception.cpp
@@ -34,13 +34,13 @@ char* emscripten_format_exception(void* thrown_object) {
   if (can_catch) {
     const char* what =
       static_cast<const std::exception*>(thrown_object)->what();
-    asprintf(&result, "Cpp Exception %s: %s", type_name, what);
-  } else {
     asprintf(&result,
-             "Cpp Exception: The exception is an object of type '%s' at "
-             "address %p which does not inherit from std::exception",
+             "terminating with uncaught exception of type %s: %s",
              type_name,
-             thrown_object);
+             what);
+  } else {
+    asprintf(
+      &result, "terminating with uncaught exception of type %s", type_name);
   }
 
   if (demangled_buf) {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1657,11 +1657,11 @@ int main(int argc, char **argv)
       }
     '''
     expected = '''\
-Cpp Exception: The exception is an object of type 'int' at address xxx which does not inherit from std::exception
-Cpp Exception: The exception is an object of type 'char' at address xxx which does not inherit from std::exception
-Cpp Exception std::runtime_error: abc
-Cpp Exception myexception: My exception happened
-Cpp Exception: The exception is an object of type 'char const*' at address xxx which does not inherit from std::exception
+terminating with uncaught exception of type int
+terminating with uncaught exception of type char
+terminating with uncaught exception of type std::runtime_error: abc
+terminating with uncaught exception of type myexception: My exception happened
+terminating with uncaught exception of type char const*
 '''
 
     self.do_run(src, expected)


### PR DESCRIPTION
This makes exception format message format the same as that of
`demangling_terminate_handler`, which is called when an uncaught
exception terminates the program:
https://github.com/emscripten-core/emscripten/blob/d5ef6937fe395488e23a82c1e582a7ea5c2dab83/system/lib/libcxxabi/src/cxa_default_handlers.cpp#L62-L72

This removes 'address' from the message when an exception does not
inherit from `std::exception`, but I guess it's fine; we didn't print
the address in case of `std::exception` anyway.