### PR TITLE
Temporarily disable test_exceptions_longjmp3_wasm under LSan. NFC

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1735,6 +1735,8 @@ int main() {
 
   @with_both_eh_sjlj
   def test_exceptions_longjmp3(self):
+    if '-fwasm-exceptions' in self.emcc_args:
+      self.skipTest('https://github.com/emscripten-core/emscripten/issues/17004')
     self.do_core_test('test_exceptions_longjmp3.cpp')
 
   @with_both_eh_sjlj


### PR DESCRIPTION
This test currently has a leak: #17004.