### PR TITLE
Remove now-unneeded check in library_pthread.js. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -487,23 +487,10 @@ var LibraryPThread = {
     assert(pthread_ptr, 'Internal Error! Null pthread_ptr in cleanupThread!');
 #endif
     var pthread = PThread.pthreads[pthread_ptr];
-    // If pthread has been removed from this map this also means that pthread_ptr points
-    // to already freed data. Such situation may occur in following circumstance:
-    // Joining thread from non-main browser thread (this also includes thread running main()
-    // when compiled with `PROXY_TO_PTHREAD`) - in such situation it may happen that following
-    // code flow occur (MB - Main Browser Thread, S1, S2 - Worker Threads):
-    // S2: thread ends, 'exit' message is sent to MB
-    // S1: calls pthread_join(S2), this causes:
-    //     a. S2 is marked as detached,
-    //     b. 'cleanupThread' message is sent to MB.
-    // MB: handles 'exit' message, as thread is detached, so returnWorkerToPool()
-    //     is called and all thread related structs are freed/released.
-    // MB: handles 'cleanupThread' message which calls this function.
-    if (pthread) {
-      {{{ makeSetValue('pthread_ptr', C_STRUCTS.pthread.self, 0, 'i32') }}};
-      var worker = pthread.worker;
-      PThread.returnWorkerToPool(worker);
-    }
+    assert(pthread);
+    {{{ makeSetValue('pthread_ptr', C_STRUCTS.pthread.self, 0, 'i32') }}};
+    var worker = pthread.worker;
+    PThread.returnWorkerToPool(worker);
   },
 
 #if MAIN_MODULE


### PR DESCRIPTION
The race condition decribed in this comment is no longer possible
because the very fist statement `S2: thread ends, 'exit' message is sent
to MB` is no longer true.

When a non-detached thread exits it no longer sends any kind of message
back to the main thread. It simply sets it own `detach_state` to
`DT_EXITED`.