### PR TITLE
Minor library_pthread.js cleanup. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -612,9 +612,6 @@ var LibraryPThread = {
       /*start_profiling=*/true
 #endif
     );
-#if ASSERTIONS
-    PThread.mainRuntimeThread = true;
-#endif
     PThread.threadInit();
   },
 


### PR DESCRIPTION
Remove unused `PThread.mainRuntimeThread`. NFC
    
The last usage was removed in #17017.