### PR TITLE
[WasmFS] Fix OPFS `getSize` when file is not opened

### DIFF
--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -236,10 +236,18 @@ mergeInto(LibraryManager.library, {
     return accessHandle.write(data, {at: pos});
   },
 
-  _wasmfs_opfs_get_size__deps: ['$wasmfsOPFSAccesses'],
-  _wasmfs_opfs_get_size: async function(ctx, accessID, sizePtr) {
+  _wasmfs_opfs_get_size_access__deps: ['$wasmfsOPFSAccesses'],
+  _wasmfs_opfs_get_size_access: async function(ctx, accessID, sizePtr) {
     let accessHandle = wasmfsOPFSAccesses.get(accessID);
     let size = await accessHandle.getSize();
+    {{{ makeSetValue('sizePtr', 0, 'size', 'i32') }}};
+    _emscripten_proxy_finish(ctx);
+  },
+
+  _wasmfs_opfs_get_size_blob__deps: ['$wasmfsOPFSFiles'],
+  _wasmfs_opfs_get_size_blob: async function(ctx, fileID, sizePtr) {
+    let fileHandle = wasmfsOPFSFiles.get(fileID);
+    let size = (await fileHandle.getFile()).size;
     {{{ makeSetValue('sizePtr', 0, 'size', 'i32') }}};
     _emscripten_proxy_finish(ctx);
   },

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -69,7 +69,15 @@ int _wasmfs_opfs_write(int access_id,
                        uint32_t len,
                        uint32_t pos);
 
-void _wasmfs_opfs_get_size(em_proxying_ctx* ctx, int access_id, uint32_t* size);
+// Get the size via an AccessHandle.
+void _wasmfs_opfs_get_size_access(em_proxying_ctx* ctx,
+                                  int access_id,
+                                  uint32_t* size);
+
+// Get the size via a File Blob.
+void _wasmfs_opfs_get_size_blob(em_proxying_ctx* ctx,
+                                int access_id,
+                                uint32_t* size);
 
 void _wasmfs_opfs_set_size(em_proxying_ctx* ctx, int access_id, uint32_t size);
 
@@ -106,7 +114,14 @@ public:
 private:
   size_t getSize() override {
     uint32_t size;
-    proxy([&](auto ctx) { _wasmfs_opfs_get_size(ctx.ctx, accessID, &size); });
+    if (accessID == -1) {
+      proxy(
+        [&](auto ctx) { _wasmfs_opfs_get_size_blob(ctx.ctx, fileID, &size); });
+    } else {
+      proxy([&](auto ctx) {
+        _wasmfs_opfs_get_size_access(ctx.ctx, accessID, &size);
+      });
+    }
     return size_t(size);
   }
 

--- a/tests/wasmfs/wasmfs_opfs.c
+++ b/tests/wasmfs/wasmfs_opfs.c
@@ -69,26 +69,26 @@ int main(int argc, char* argv[]) {
   fdatasync(fd);
   emscripten_console_log("flushed");
 
-  struct stat stat;
-  err = fstat(fd, &stat);
+  struct stat stat_buf;
+  err = fstat(fd, &stat_buf);
   assert(err == 0);
-  assert(stat.st_size == strlen(msg));
+  assert(stat_buf.st_size == strlen(msg));
   emscripten_console_log("statted");
 
 #ifndef WASMFS_SETUP
 
   err = ftruncate(fd, 100);
   assert(err == 0);
-  err = fstat(fd, &stat);
+  err = fstat(fd, &stat_buf);
   assert(err == 0);
-  assert(stat.st_size == 100);
+  assert(stat_buf.st_size == 100);
   emscripten_console_log("truncated to 100");
 
   err = ftruncate(fd, 0);
   assert(err == 0);
-  err = fstat(fd, &stat);
+  err = fstat(fd, &stat_buf);
   assert(err == 0);
-  assert(stat.st_size == 0);
+  assert(stat_buf.st_size == 0);
   emscripten_console_log("truncated to 0");
 
   struct dirent** entries;
@@ -118,6 +118,11 @@ int main(int argc, char* argv[]) {
   assert(err == 0);
   emscripten_console_log("closed file");
 
+  err = stat("/opfs/working/foo.txt", &stat_buf);
+  assert(err == 0);
+  assert(stat_buf.st_size == 0);
+  emscripten_console_log("statted");
+
   err = rename("/opfs/working/foo.txt", "/opfs/foo.txt");
   assert(err == 0);
   err = access("/opfs/working/foo.txt", F_OK);
@@ -144,7 +149,13 @@ int main(int argc, char* argv[]) {
 }
 
 void cleanup(void) {
+  printf("cleaning up\n");
+
   unlink("/opfs/working/foo.txt");
   rmdir("/opfs/working");
   unlink("/opfs/foo.txt");
+
+  assert(access("/opfs/working/foo.txt", F_OK) != 0);
+  assert(access("/opfs/working", F_OK) != 0);
+  assert(access("/opfs/foo.txt", F_OK) != 0);
 }

--- a/tests/wasmfs/wasmfs_opfs.c
+++ b/tests/wasmfs/wasmfs_opfs.c
@@ -84,12 +84,12 @@ int main(int argc, char* argv[]) {
   assert(stat_buf.st_size == 100);
   emscripten_console_log("truncated to 100");
 
-  err = ftruncate(fd, 0);
+  err = ftruncate(fd, 1);
   assert(err == 0);
   err = fstat(fd, &stat_buf);
   assert(err == 0);
-  assert(stat_buf.st_size == 0);
-  emscripten_console_log("truncated to 0");
+  assert(stat_buf.st_size == 1);
+  emscripten_console_log("truncated to 1");
 
   struct dirent** entries;
   int nentries = scandir("/opfs/working", &entries, NULL, alphasort);
@@ -120,7 +120,7 @@ int main(int argc, char* argv[]) {
 
   err = stat("/opfs/working/foo.txt", &stat_buf);
   assert(err == 0);
-  assert(stat_buf.st_size == 0);
+  assert(stat_buf.st_size == 1);
   emscripten_console_log("statted");
 
   err = rename("/opfs/working/foo.txt", "/opfs/foo.txt");


### PR DESCRIPTION
The `getSize` implementation in the OPFS backend previously depended on having
an AccessHandle to the corresponding file, but that's only the case for open
files. `getSize` can also be called on files that have not been opened, for
example in the implementation of the `stat` syscall. Fix the bug in this case by
using an alternative code path that gets the size of the file using the Blob
API, which does not require having an AccessHandle.