### PR TITLE
Use BigInt literals in JS sources

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -609,7 +609,7 @@ var LibraryEmbind = {
     // maxRange comes through as -1 for uint64_t (see issue 13902). Work around that temporarily
     if (isUnsignedType) {
         // Use string because acorn does recognize bigint literals
-        maxRange = (BigInt(1) << BigInt(64)) - BigInt(1);
+        maxRange = (1n << 64n) - 1n;
     }
 
     registerType(primitiveType, {

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -900,11 +900,11 @@ var LibraryPThread = {
 #if WASM_BIGINT
         if (typeof arg == 'bigint') {
           // The prefix is non-zero to indicate a bigint.
-          HEAP64[b + 2*i] = BigInt(1);
+          HEAP64[b + 2*i] = 1n;
           HEAP64[b + 2*i + 1] = arg;
         } else {
           // The prefix is zero to indicate a JS Number.
-          HEAP64[b + 2*i] = BigInt(0);
+          HEAP64[b + 2*i] = 0n;
           HEAPF64[b + 2*i + 1] = arg;
         }
 #else

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1133,12 +1133,7 @@ function defineI64Param(name) {
 
 function receiveI64ParamAsI32s(name) {
   if (WASM_BIGINT) {
-    // TODO: use Xn notation when JS parsers support it (as of April 6 2020,
-    //  * closure compiler is missing support
-    //    https://github.com/google/closure-compiler/issues/3167
-    //  * acorn needs to be upgraded, and to set ecmascript version >= 11
-    //  * terser needs to be upgraded
-    return `var ${name}_low = Number(${name} & BigInt(0xffffffff)) | 0, ${name}_high = Number(${name} >> BigInt(32)) | 0;`;
+    return `var ${name}_low = Number(${name} & 0xffffffffn) | 0, ${name}_high = Number(${name} >> 32n) | 0;`;
   }
   return '';
 }
@@ -1155,7 +1150,7 @@ function receiveI64ParamAsI53(name, onError) {
 
 function sendI64Argument(low, high) {
   if (WASM_BIGINT) {
-    return 'BigInt(low) | (BigInt(high) << BigInt(32))';
+    return 'BigInt(low) | (BigInt(high) << 32n)';
   }
   return low + ', ' + high;
 }

--- a/src/runtime_wasm64.js
+++ b/src/runtime_wasm64.js
@@ -57,7 +57,7 @@ function instrumentWasmExportsForMemory64(exports) {
           // missing third argument will generate:
           // `TypeError: Cannot convert undefined to a BigInt`.
           // See https://github.com/WebAssembly/JS-BigInt-integration/issues/12
-          return original(x, BigInt(y ? y : 0), BigInt(0));
+          return original(x, BigInt(y ? y : 0), 0n);
         };
       } else if (['emscripten_stack_set_limits', '__set_stack_limits'].includes(name)) {
         // get 2 i64 arguments

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -640,7 +640,7 @@ module({
 
         test("passing Symbol or BigInt as floats always throws", function() {
             assert.throws(TypeError, function() { cm.const_ref_adder(Symbol('0'), 1); });
-            assert.throws(TypeError, function() { cm.const_ref_adder(BigInt(0), 1); });
+            assert.throws(TypeError, function() { cm.const_ref_adder(0n, 1); });
         });
 
         if (cm['ASSERTIONS']) {

--- a/tests/return64bit/testbind_bigint.js
+++ b/tests/return64bit/testbind_bigint.js
@@ -11,15 +11,15 @@ Module['runtest'] = function() {
   // Use eval to create BigInt, as no support for Xn notation yet in JS
   // optimizer.
   var bigint = _test_return64(eval('0xaabbccdd11223344n'));
-  var low = Number(bigint & BigInt(0xffffffff));
-  var high = Number(bigint >> BigInt(32));
+  var low = Number(bigint & 0xffffffffn);
+  var high = Number(bigint >> 32n);
   console.log("low = " + low);
   console.log("high = " + high);
 
   var ptr = _get_func_ptr();
   bigint = dynCall('jj', ptr, [eval('0xabcdef1912345678n')]);
-  low = Number(bigint & BigInt(0xffffffff));
-  high = Number(bigint >> BigInt(32));
+  low = Number(bigint & 0xffffffffn);
+  high = Number(bigint >> 32n);
   console.log("low = " + low);
   console.log("high = " + high);
 };

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1811,7 +1811,7 @@ int main() {
 
         EM_JS(Classey*, get_null, (), {
         #if __wasm64__
-          return BigInt(0);
+          return 0n;
         #else
           return 0;
         #endif

--- a/tools/js_manipulation.py
+++ b/tools/js_manipulation.py
@@ -118,7 +118,7 @@ def make_invoke(sig):
   # For function that needs to return a genuine i64 (i.e. if legal_sig[0] is 'j')
   # we need to return an actual BigInt, even in the exceptional case because
   # wasm won't implicitly convert undefined to 0 in this case.
-  exceptional_ret = '\n    return BigInt(0);' if legal_sig[0] == 'j' else ''
+  exceptional_ret = '\n    return 0n;' if legal_sig[0] == 'j' else ''
   body = '%s%s;' % (ret, make_dynCall(sig, args))
   # Exceptions thrown from C++ exception will be integer numbers.
   # longjmp will throw the number Infinity.


### PR DESCRIPTION
Now that terser is patched and upgraded we no longer have to
avoid the use of BitInt literals in the source.

Depends on #17035 