### PR TITLE
parseTools.js: Remove used checkSafeHeap. NFC

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -281,10 +281,6 @@ function indentify(text, indent) {
 
 // Correction tools
 
-function checkSafeHeap() {
-  return SAFE_HEAP === 1;
-}
-
 function getHeapOffset(offset, type) {
   if (!WASM_BIGINT && Runtime.getNativeFieldSize(type) > 4 && type == 'i64') {
     // we emulate 64-bit integer values as 32 in asmjs-unknown-emscripten, but not double


### PR DESCRIPTION
The last usage of this function was removed in 2015: 66bd874d9bcc3a0ef2b9892253ee8359525ce48d