### PR TITLE
Remove SAFE_HEAP handling makeGet/SetValue. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1825,7 +1825,9 @@ def phase_linker_setup(options, state, newargs, user_settings):
   if not settings.BOOTSTRAPPING_STRUCT_INFO:
     # Include the internal library function since they are used by runtime functions.
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$getWasmTableEntry', '$setWasmTableEntry']
-    if settings.SAFE_HEAP or not settings.MINIMAL_RUNTIME:
+    if settings.SAFE_HEAP:
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$getValue_safe', '$setValue_safe']
+    if not settings.MINIMAL_RUNTIME:
       settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$getValue', '$setValue']
 
   if settings.MAIN_MODULE:

--- a/src/library_getvalue.js
+++ b/src/library_getvalue.js
@@ -6,27 +6,13 @@
 
 var LibraryMemOps = {
   $setValue__docs: `
-  /** @param {number} ptr
-      @param {number} value
-      @param {string} type
-      @param {number|boolean=} noSafe */`,
-  $setValue: function(ptr, value, type = 'i8', noSafe) {
+  /**
+   * @param {number} ptr
+   * @param {number} value
+   * @param {string} type
+   */`,
+  $setValue: function(ptr, value, type = 'i8') {
     if (type.endsWith('*')) type = '{{{ POINTER_WASM_TYPE }}}';
-#if SAFE_HEAP
-    if (noSafe) {
-      switch (type) {
-        case 'i1': {{{ makeSetValue('ptr', '0', 'value', 'i1', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
-        case 'i8': {{{ makeSetValue('ptr', '0', 'value', 'i8', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
-        case 'i16': {{{ makeSetValue('ptr', '0', 'value', 'i16', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
-        case 'i32': {{{ makeSetValue('ptr', '0', 'value', 'i32', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
-        case 'i64': {{{ makeSetValue('ptr', '0', 'value', 'i64', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
-        case 'float': {{{ makeSetValue('ptr', '0', 'value', 'float', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
-        case 'double': {{{ makeSetValue('ptr', '0', 'value', 'double', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
-        default: abort('invalid type for setValue: ' + type);
-      }
-      return;
-    }
-#endif
     switch (type) {
       case 'i1': {{{ makeSetValue('ptr', '0', 'value', 'i1') }}}; break;
       case 'i8': {{{ makeSetValue('ptr', '0', 'value', 'i8') }}}; break;
@@ -40,26 +26,12 @@ var LibraryMemOps = {
   },
 
   $getValue__docs: `
-  /** @param {number} ptr
-      @param {string} type
-      @param {number|boolean=} noSafe */`,
-  $getValue: function(ptr, type = 'i8', noSafe) {
+  /**
+   * @param {number} ptr
+   * @param {string} type
+   */`,
+  $getValue: function(ptr, type = 'i8') {
     if (type.endsWith('*')) type = '{{{ POINTER_WASM_TYPE }}}';
-#if SAFE_HEAP
-    if (noSafe) {
-      switch (type) {
-        case 'i1': return {{{ makeGetValue('ptr', '0', 'i1', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
-        case 'i8': return {{{ makeGetValue('ptr', '0', 'i8', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
-        case 'i16': return {{{ makeGetValue('ptr', '0', 'i16', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
-        case 'i32': return {{{ makeGetValue('ptr', '0', 'i32', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
-        case 'i64': return {{{ makeGetValue('ptr', '0', 'i64', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
-        case 'float': return {{{ makeGetValue('ptr', '0', 'float', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
-        case 'double': return {{{ makeGetValue('ptr', '0', 'double', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
-        default: abort('invalid type for getValue: ' + type);
-      }
-      return;
-    }
-#endif
     switch (type) {
       case 'i1': return {{{ makeGetValue('ptr', '0', 'i1') }}};
       case 'i8': return {{{ makeGetValue('ptr', '0', 'i8') }}};
@@ -72,6 +44,39 @@ var LibraryMemOps = {
     }
     return null;
   },
+
+#if SAFE_HEAP
+  // Identical to above two functions, but known to the safeHeap pass
+  // in tools/acorn-optimizer.js.  The heap accesses here in these two
+  // functions will not get re-written.
+  $setValue_safe__internal: true,
+  $setValue_safe: function(ptr, value, type) {
+    switch (type) {
+      case 'i1': {{{ makeSetValue('ptr', '0', 'value', 'i1') }}}; break;
+      case 'i8': {{{ makeSetValue('ptr', '0', 'value', 'i8') }}}; break;
+      case 'i16': {{{ makeSetValue('ptr', '0', 'value', 'i16') }}}; break;
+      case 'i32': {{{ makeSetValue('ptr', '0', 'value', 'i32') }}}; break;
+      case 'i64': {{{ makeSetValue('ptr', '0', 'value', 'i64') }}}; break;
+      case 'float': {{{ makeSetValue('ptr', '0', 'value', 'float') }}}; break;
+      case 'double': {{{ makeSetValue('ptr', '0', 'value', 'double') }}}; break;
+      default: abort('invalid type for setValue: ' + type);
+    }
+  },
+
+  $getValue_safe__internal: true,
+  $getValue_safe: function(ptr, type) {
+    switch (type) {
+      case 'i1': return {{{ makeGetValue('ptr', '0', 'i1') }}};
+      case 'i8': return {{{ makeGetValue('ptr', '0', 'i8') }}};
+      case 'i16': return {{{ makeGetValue('ptr', '0', 'i16') }}};
+      case 'i32': return {{{ makeGetValue('ptr', '0', 'i32') }}};
+      case 'i64': return {{{ makeGetValue('ptr', '0', 'i64') }}};
+      case 'float': return {{{ makeGetValue('ptr', '0', 'float') }}};
+      case 'double': return {{{ makeGetValue('ptr', '0', 'double') }}};
+      default: abort('invalid type for getValue: ' + type);
+    }
+  },
+#endif
 };
 
 mergeInto(LibraryManager.library, LibraryMemOps);

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -376,7 +376,7 @@ function makeSetTempDouble(i, type, value) {
 }
 
 // See makeSetValue
-function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align, noSafe) {
+function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align) {
   if (typeof unsigned !== 'undefined') {
     // TODO(sbc): make this into an error at some point.
     printErr('makeGetValue: Please use u8/u16/u32/u64 unsigned types in favor of additional argument');
@@ -389,8 +389,8 @@ function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align, noSa
   }
 
   if (type == 'double' && (align < 8)) {
-    const setdouble1 = makeSetTempDouble(0, 'i32', makeGetValue(ptr, pos, 'i32', noNeedFirst, unsigned, ignore, align, noSafe));
-    const setdouble2 = makeSetTempDouble(1, 'i32', makeGetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), 'i32', noNeedFirst, unsigned, ignore, align, noSafe));
+    const setdouble1 = makeSetTempDouble(0, 'i32', makeGetValue(ptr, pos, 'i32', noNeedFirst, unsigned, ignore, align));
+    const setdouble2 = makeSetTempDouble(1, 'i32', makeGetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), 'i32', noNeedFirst, unsigned, ignore, align));
     return '(' + setdouble1 + ',' + setdouble2 + ',' + makeGetTempDouble(0, 'double') + ')';
   }
 
@@ -402,12 +402,12 @@ function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align, noSa
       if (isIntImplemented(type)) {
         if (bytes == 4 && align == 2) {
           // Special case that we can optimize
-          ret += makeGetValue(ptr, pos, 'i16', noNeedFirst, 2, ignore, 2, noSafe) + '|' +
-                 '(' + makeGetValue(ptr, getFastValue(pos, '+', 2), 'i16', noNeedFirst, 2, ignore, 2, noSafe) + '<<16)';
+          ret += makeGetValue(ptr, pos, 'i16', noNeedFirst, 2, ignore, 2) + '|' +
+                 '(' + makeGetValue(ptr, getFastValue(pos, '+', 2), 'i16', noNeedFirst, 2, ignore, 2) + '<<16)';
         } else { // XXX we cannot truly handle > 4... (in x86)
           ret = '';
           for (let i = 0; i < bytes; i++) {
-            ret += '(' + makeGetValue(ptr, getFastValue(pos, '+', i), 'i8', noNeedFirst, 1, ignore, 1, noSafe) + (i > 0 ? '<<' + (8 * i) : '') + ')';
+            ret += '(' + makeGetValue(ptr, getFastValue(pos, '+', i), 'i8', noNeedFirst, 1, ignore, 1) + (i > 0 ? '<<' + (8 * i) : '') + ')';
             if (i < bytes - 1) ret += '|';
           }
           ret = '(' + makeSignOp(ret, type, unsigned ? 'un' : 're', true);
@@ -425,11 +425,6 @@ function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align, noSa
   }
 
   const offset = calcFastOffset(ptr, pos, noNeedFirst);
-  if (SAFE_HEAP && !noSafe) {
-    if (!ignore) {
-      return asmCoercion('SAFE_HEAP_LOAD' + (FLOAT_TYPES.has(type) ? '_D' : '') + '(' + asmCoercion(offset, 'i32') + ', ' + Runtime.getNativeTypeSize(type) + ', ' + (!!unsigned + 0) + ')', type, unsigned ? 'u' : undefined);
-    }
-  }
 
   const slab = getHeapForType(type);
   let ret = slab + '[' + getHeapOffset(offset, type) + ']';
@@ -447,24 +442,22 @@ function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align, noSa
  * @param {nunber} pos The position in that slab - the offset. Added to any offset in the pointer itself.
  * @param {number} value The value to set.
  * @param {string} type A string defining the type. Used to find the slab (HEAPU8, HEAP16, HEAPU32, etc.).
- *             'null' means, in the context of SAFE_HEAP, that we should accept all types;
  *             which means we should write to all slabs, ignore type differences if any on reads, etc.
  * @param {bool} noNeedFirst Whether to ignore the offset in the pointer itself.
  * @param {bool} ignore: legacy, ignored.
  * @param {number} align: TODO
- * @param {bool} noSafe: TODO
  * @param {string} sep: TODO
  * @return {TODO}
  */
-function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe, sep = ';') {
+function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, sep = ';') {
   if (type == 'double' && (align < 8)) {
     return '(' + makeSetTempDouble(0, 'double', value) + ',' +
-            makeSetValue(ptr, pos, makeGetTempDouble(0, 'i32'), 'i32', noNeedFirst, ignore, align, noSafe, ',') + ',' +
-            makeSetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), makeGetTempDouble(1, 'i32'), 'i32', noNeedFirst, ignore, align, noSafe, ',') + ')';
+            makeSetValue(ptr, pos, makeGetTempDouble(0, 'i32'), 'i32', noNeedFirst, ignore, align, ',') + ',' +
+            makeSetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), makeGetTempDouble(1, 'i32'), 'i32', noNeedFirst, ignore, align, ',') + ')';
   } else if (!WASM_BIGINT && type == 'i64') {
     return '(tempI64 = [' + splitI64(value) + '],' +
-            makeSetValue(ptr, pos, 'tempI64[0]', 'i32', noNeedFirst, ignore, align, noSafe, ',') + ',' +
-            makeSetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), 'tempI64[1]', 'i32', noNeedFirst, ignore, align, noSafe, ',') + ')';
+            makeSetValue(ptr, pos, 'tempI64[0]', 'i32', noNeedFirst, ignore, align, ',') + ',' +
+            makeSetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), 'tempI64[1]', 'i32', noNeedFirst, ignore, align, ',') + ')';
   }
 
   const bits = getBits(type);
@@ -478,17 +471,17 @@ function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe,
         if (bytes == 4 && align == 2) {
           // Special case that we can optimize
           ret += 'tempBigInt=' + value + sep;
-          ret += makeSetValue(ptr, pos, 'tempBigInt&0xffff', 'i16', noNeedFirst, ignore, 2, noSafe) + sep;
-          ret += makeSetValue(ptr, getFastValue(pos, '+', 2), 'tempBigInt>>16', 'i16', noNeedFirst, ignore, 2, noSafe);
+          ret += makeSetValue(ptr, pos, 'tempBigInt&0xffff', 'i16', noNeedFirst, ignore, 2) + sep;
+          ret += makeSetValue(ptr, getFastValue(pos, '+', 2), 'tempBigInt>>16', 'i16', noNeedFirst, ignore, 2);
         } else {
           ret += 'tempBigInt=' + value + sep;
           for (let i = 0; i < bytes; i++) {
-            ret += makeSetValue(ptr, getFastValue(pos, '+', i), 'tempBigInt&0xff', 'i8', noNeedFirst, ignore, 1, noSafe);
+            ret += makeSetValue(ptr, getFastValue(pos, '+', i), 'tempBigInt&0xff', 'i8', noNeedFirst, ignore, 1);
             if (i < bytes - 1) ret += sep + 'tempBigInt = tempBigInt>>8' + sep;
           }
         }
       } else {
-        ret += makeSetValue('tempDoublePtr', 0, value, type, noNeedFirst, ignore, 8, noSafe, null, true) + sep;
+        ret += makeSetValue('tempDoublePtr', 0, value, type, noNeedFirst, ignore, 8) + sep;
         ret += makeCopyValues(getFastValue(ptr, '+', pos), 'tempDoublePtr', Runtime.getNativeTypeSize(type), type, null, align, sep);
       }
       return ret;
@@ -496,11 +489,6 @@ function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe,
   }
 
   const offset = calcFastOffset(ptr, pos, noNeedFirst);
-  if (SAFE_HEAP && !noSafe) {
-    if (!ignore) {
-      return 'SAFE_HEAP_STORE' + (FLOAT_TYPES.has(type) ? '_D' : '') + '(' + asmCoercion(offset, 'i32') + ', ' + asmCoercion(value, type) + ', ' + Runtime.getNativeTypeSize(type) + ')';
-    }
-  }
 
   const slab = getHeapForType(type);
   if (slab == 'HEAPU64' || slab == 'HEAP64') {

--- a/src/runtime_safe_heap.js
+++ b/src/runtime_safe_heap.js
@@ -47,7 +47,7 @@ function SAFE_HEAP_STORE(dest, value, bytes, isFloat) {
     assert(brk >= _emscripten_stack_get_base()); // sbrk-managed memory must be above the stack
     assert(brk <= HEAP8.length);
   }
-  setValue(dest, value, getSafeHeapType(bytes, isFloat), 1);
+  setValue_safe(dest, value, getSafeHeapType(bytes, isFloat));
   return value;
 }
 function SAFE_HEAP_STORE_D(dest, value, bytes) {
@@ -76,7 +76,7 @@ function SAFE_HEAP_LOAD(dest, bytes, unsigned, isFloat) {
     assert(brk <= HEAP8.length);
   }
   var type = getSafeHeapType(bytes, isFloat);
-  var ret = getValue(dest, type, 1);
+  var ret = getValue_safe(dest, type);
   if (unsigned) ret = unSign(ret, parseInt(type.substr(1), 10));
 #if SAFE_HEAP_LOG
   out('SAFE_HEAP load: ' + [dest, ret, bytes, isFloat, unsigned, SAFE_HEAP_COUNTER++]);

--- a/tests/optimizer/test-safeHeap-output.js
+++ b/tests/optimizer/test-safeHeap-output.js
@@ -40,11 +40,11 @@ function SAFE_HEAP_FOO(ptr) {
  return HEAP8[ptr];
 }
 
-function setValue(ptr) {
+function setValue_safe(ptr) {
  return HEAP8[ptr];
 }
 
-function getValue(ptr) {
+function getValue_safe(ptr) {
  return HEAP8[ptr];
 }
 

--- a/tests/optimizer/test-safeHeap.js
+++ b/tests/optimizer/test-safeHeap.js
@@ -36,10 +36,10 @@ HEAPF32[x] = HEAP32[y];
 function SAFE_HEAP_FOO(ptr) {
   return HEAP8[ptr];
 }
-function setValue(ptr) {
+function setValue_safe(ptr) {
   return HEAP8[ptr];
 }
-function getValue(ptr) {
+function getValue_safe(ptr) {
   return HEAP8[ptr];
 }
 

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -1374,8 +1374,8 @@ function safeHeap(ast) {
     FunctionDeclaration(node, c) {
       if (node.id.type === 'Identifier' &&
           (node.id.name.startsWith('SAFE_HEAP') ||
-           node.id.name === 'setValue' ||
-           node.id.name === 'getValue')) {
+           node.id.name === 'setValue_safe' ||
+           node.id.name === 'getValue_safe')) {
         // do not recurse into this js impl function, which we use during
         // startup before the wasm is ready
       } else {


### PR DESCRIPTION
Converting heap accessed to SAFE_HEAP is these days
handled by a pass in tools/acorn-optimizer.js so that
use of SAFE_HEAP here was redundant.