### PR TITLE
Remove redundant clearing of pthread struct internals. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -441,7 +441,6 @@ var LibraryPThread = {
     assert(!ENVIRONMENT_IS_PTHREAD, 'Internal Error! killThread() can only ever be called from main application thread!');
     assert(pthread_ptr, 'Internal Error! Null pthread_ptr in killThread!');
 #endif
-    {{{ makeSetValue('pthread_ptr', C_STRUCTS.pthread.self, 0, 'i32') }}};
     var pthread = PThread.pthreads[pthread_ptr];
     delete PThread.pthreads[pthread_ptr];
     pthread.worker.terminate();
@@ -469,7 +468,6 @@ var LibraryPThread = {
 #endif
     var pthread = PThread.pthreads[pthread_ptr];
     assert(pthread);
-    {{{ makeSetValue('pthread_ptr', C_STRUCTS.pthread.self, 0, 'i32') }}};
     var worker = pthread.worker;
     PThread.returnWorkerToPool(worker);
   },

--- a/src/struct_info_internal.json
+++ b/src/struct_info_internal.json
@@ -7,7 +7,6 @@
         "structs": {
             "pthread": [
               "profilerBlock",
-              "self",
               "tsd",
               "stack",
               "stack_size",

--- a/tests/reference_struct_info.json
+++ b/tests/reference_struct_info.json
@@ -1372,7 +1372,6 @@
             "profilerBlock": 104,
             "result": 56,
             "robust_list": 68,
-            "self": 0,
             "stack": 44,
             "stack_owned": 108,
             "stack_size": 48,


### PR DESCRIPTION
Both these locations end up calling `_emscripten_thread_free_data` which
already clears the entire struct:

```
  // To aid in debugging set all fields to zero
  memset(t, 0, sizeof(*t));
```