### PR TITLE
Remove unused entries from struct_info.json. NFC

### DIFF
--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -15,21 +15,6 @@
         }
     },
     {
-        "file": "limits.h",
-        "defines": [
-            "INT_MAX"
-        ]
-    },
-    {
-        "file": "utime.h",
-        "structs": {
-            "utimbuf": [
-                "actime",
-                "modtime"
-            ]
-        }
-    },
-    {
         "file": "sys/stat.h",
         "defines": [
             "S_IFDIR",
@@ -147,20 +132,9 @@
         }
     },
     {
-        "file": "sys/time.h",
-        "structs": {
-            "timeval": [
-                "tv_sec",
-                "tv_usec"
-            ]
-        }
-    },
-    {
         "file": "time.h",
         "defines": [
-            "CLOCK_REALTIME",
-            "CLOCK_MONOTONIC",
-            "CLOCK_MONOTONIC_RAW"
+            "CLOCK_REALTIME"
         ],
         "structs": {
             "tm": [
@@ -179,17 +153,6 @@
             "timespec": [
                 "tv_sec",
                 "tv_nsec"
-            ]
-        }
-    },
-    {
-        "file": "compat/sys/timeb.h",
-        "structs": {
-            "timeb": [
-                "time",
-                "millitm",
-                "timezone",
-                "dstflag"
             ]
         }
     },

--- a/tests/reference_struct_info.json
+++ b/tests/reference_struct_info.json
@@ -17,8 +17,6 @@
         "AUDIO_F32": 33056,
         "AUDIO_S16LSB": 32784,
         "AUDIO_U8": 8,
-        "CLOCK_MONOTONIC": 1,
-        "CLOCK_MONOTONIC_RAW": 4,
         "CLOCK_REALTIME": 0,
         "E2BIG": 1,
         "EACCES": 2,
@@ -279,7 +277,6 @@
         "File::SymlinkKind": 3,
         "File::UnknownKind": 0,
         "INADDR_LOOPBACK": 2130706433,
-        "INT_MAX": 2147483647,
         "IPPROTO_TCP": 6,
         "IPPROTO_UDP": 17,
         "MAP_ANONYMOUS": 32,
@@ -1465,22 +1462,10 @@
             "threadStatus": 0,
             "timeSpentInStatus": 16
         },
-        "timeb": {
-            "__size__": 12,
-            "dstflag": 8,
-            "millitm": 4,
-            "time": 0,
-            "timezone": 6
-        },
         "timespec": {
             "__size__": 8,
             "tv_nsec": 4,
             "tv_sec": 0
-        },
-        "timeval": {
-            "__size__": 8,
-            "tv_sec": 0,
-            "tv_usec": 4
         },
         "tm": {
             "__size__": 44,
@@ -1495,11 +1480,6 @@
             "tm_yday": 28,
             "tm_year": 20,
             "tm_zone": 40
-        },
-        "utimbuf": {
-            "__size__": 8,
-            "actime": 0,
-            "modtime": 4
         }
     }
 }


### PR DESCRIPTION
A bunch of time-related code was recently moved into native
making these redundant.