### PR TITLE
Don't call `__stdio_exit` when we want to keep the runtime alive

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,8 @@ See docs/process.md for more on how version tagging works.
 ------
 - Fix crash, introduced in 3.1.11, which occurred when using pointer types
   (types ending in `*`) with getValue/setValue library functions. (#17028)
+- Fix possible deadlock in multi-threaded builds that use EXIT_RUNTIME=0 with
+  ASSERTIONS enabled. This was introduced in 3.1.3 as part of #16130. (#17044)
 
 3.1.11 - 05/21/2022
 -------------------

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -371,11 +371,11 @@ function checkUnflushedContent() {
     has = true;
   }
   try { // it doesn't matter if it fails
-#if SYSCALLS_REQUIRE_FILESYSTEM == 0
-    var flush = {{{ '$flush_NO_FILESYSTEM' in addedLibraryItems ? 'flush_NO_FILESYSTEM' : 'null' }}};
-    if (flush) flush();
-#elif hasExportedFunction('___stdio_exit')
-    ___stdio_exit();
+#if SYSCALLS_REQUIRE_FILESYSTEM == 0 && '$stdio_flush_NO_FILESYSTEM' in addedLibraryItems
+    stdio_flush_NO_FILESYSTEM();
+#elif hasExportedFunction('_fflush')
+    // fflush(NULL) flushes all streams.
+    _fflush(0);
 #endif
 #if '$FS' in addedLibraryItems && '$TTY' in addedLibraryItems
     // also flush in the JS FS layer


### PR DESCRIPTION
`__stdio_exit` should only be used in cases where the runtime is no
longer going to be used but `checkUnflushedContent` is only used in the
cases where `EXIT_RUNTIME=0` (i.e. the runtime stays alive forever).

This was a bug introduced in #16130, which manifested in deadlocks when
other threads attempted to use the stdio streams since `__stdio_exit`
called `FFINALLOCK` which leaving them in a forever-locked state.