### PR TITLE
[EH] Rename format_exception.cpp

### DIFF
--- a/system/lib/libcxxabi/src/cxa_emscripten.cpp
+++ b/system/lib/libcxxabi/src/cxa_emscripten.cpp
@@ -1,3 +1,13 @@
+//===------------------------- cxa_emscripten.cpp -------------------------===//
+//
+// This code contains Emscripten specific code for exception handling.
+// Emscripten has two modes of exception handling: Emscripten EH, which uses JS
+// glue code, and Wasm EH, which uses the new Wasm exception handling proposal
+// and meant to be faster. Code for different modes is demarcated with
+// '__USING_EMSCRIPTEN_EXCEPTIONS__' and '__USING_WASM_EXCEPTIONS__'.
+//
+//===----------------------------------------------------------------------===//
+
 #include "cxa_exception.h"
 #include "private_typeinfo.h"
 #include <stdio.h>

--- a/system/lib/libcxxabi/src/cxa_exception_emscripten.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception_emscripten.cpp
@@ -1,4 +1,4 @@
-//===------------------------- cxa_emscripten.cpp -------------------------===//
+//===------------------- cxa_exception_emscripten.cpp ---------------------===//
 //
 // This code contains Emscripten specific code for exception handling.
 // Emscripten has two modes of exception handling: Emscripten EH, which uses JS

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1203,7 +1203,7 @@ class libcxxabi(NoExceptLibrary, MTLibrary):
       'stdlib_stdexcept.cpp',
       'stdlib_typeinfo.cpp',
       'private_typeinfo.cpp',
-      'format_exception.cpp',
+      'cxa_emscripten.cpp',
     ]
     if self.eh_mode == Exceptions.NONE:
       filenames += ['cxa_noexception.cpp']

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1203,7 +1203,7 @@ class libcxxabi(NoExceptLibrary, MTLibrary):
       'stdlib_stdexcept.cpp',
       'stdlib_typeinfo.cpp',
       'private_typeinfo.cpp',
-      'cxa_emscripten.cpp',
+      'cxa_exception_emscripten.cpp',
     ]
     if self.eh_mode == Exceptions.NONE:
       filenames += ['cxa_noexception.cpp']


### PR DESCRIPTION
I think we need a separate file in libc++abi for 'our' EH, meaning both
Emscripten EH and Wasm EH. (I think they can be in the same file, as
long as we have `ifdef`s) This also adds a file header.

I think this method can be in that file, rather than having a separate
file for this. I named this `cxa_emscripten.cpp` because it's the name
 #16627 used and I hope we can put all Emscripten specific stuff there,
but maybe @sbc100 had another thought; if so let me know.