### PR TITLE
Process wasm exports in-place. NFC

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -107,12 +107,11 @@ mergeInto(LibraryManager.library, {
 #endif
 
     instrumentWasmExports: function(exports) {
-      var ret = {};
       for (var x in exports) {
         (function(x) {
           var original = exports[x];
           if (typeof original == 'function') {
-            ret[x] = function() {
+            exports[x] = function() {
 #if ASYNCIFY_DEBUG >= 2
               err('ASYNCIFY: ' + '  '.repeat(Asyncify.exportCallStack.length) + ' try ' + x);
 #endif
@@ -130,12 +129,9 @@ mergeInto(LibraryManager.library, {
                 }
               }
             };
-          } else {
-            ret[x] = original;
           }
         })(x);
       }
-      return ret;
     },
 
     maybeStopUnwind: function() {

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -141,14 +141,12 @@ var LibraryDylink = {
   $relocateExports__deps: ['$updateGOT'],
   $relocateExports__docs: '/** @param {boolean=} replace */',
   $relocateExports: function(exports, memoryBase, replace) {
-    var relocated = {};
-
     for (var e in exports) {
       var value = exports[e];
 #if SPLIT_MODULE
       // Do not modify exports synthesized by wasm-split
       if (e.startsWith('%')) {
-        relocated[e] = value
+        exports[e] = value
         continue;
       }
 #endif
@@ -160,10 +158,9 @@ var LibraryDylink = {
       if (typeof value == 'number') {
         value += memoryBase;
       }
-      relocated[e] = value;
+      exports[e] = value;
     }
-    updateGOT(relocated, replace);
-    return relocated;
+    updateGOT(exports, replace);
   },
 
   $reportUndefinedSymbols__internal: true,
@@ -582,7 +579,8 @@ var LibraryDylink = {
 #endif
         // add new entries to functionsInTableMap
         updateTableMap(tableBase, metadata.tableSize);
-        moduleExports = relocateExports(instance.exports, memoryBase);
+        moduleExports = Object.assign({}, instance.exports);
+        relocateExports(moduleExports, memoryBase);
         if (!flags.allowUndefined) {
           reportUndefinedSymbols();
         }

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -200,7 +200,11 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
 #endif
 
 #if MEMORY64
-  asm = instrumentWasmExportsForMemory64(asm);
+  // instrumentWasmExportsForMemory64 modified the exports in-place but we
+  // need to first make a copy since engines do not allow direct manipulation
+  // of exports.
+  asm = Object.assign({}, asm);
+  instrumentWasmExportsForMemory64(asm);
 #endif
 
 #if USE_OFFSET_CONVERTER

--- a/src/runtime_wasm64.js
+++ b/src/runtime_wasm64.js
@@ -17,7 +17,6 @@
 // TODO: Remove this hacky mechanism and replace with something more like the
 // `__sig` attributes we have in JS library code.
 function instrumentWasmExportsForMemory64(exports) {
-  var instExports = {};
   for (var name in exports) {
     (function(name) {
       var original = exports[name];
@@ -72,8 +71,7 @@ function instrumentWasmExportsForMemory64(exports) {
           return r;
         };
       }
-      instExports[name] = replacement;
+      exports[name] = replacement;
     })(name);
   }
-  return instExports;
 }


### PR DESCRIPTION
Rather than making a new copy the entire exports object.