### PR TITLE
Remove `--no-gc-sections` from `-sLINKABLE` builds.

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -587,7 +587,9 @@ var LibraryDylink = {
           reportUndefinedSymbols();
         }
 #if STACK_OVERFLOW_CHECK >= 2
-        moduleExports['__set_stack_limits'](_emscripten_stack_get_base(), _emscripten_stack_get_end())
+        if (moduleExports['__set_stack_limits']) {
+          moduleExports['__set_stack_limits'](_emscripten_stack_get_base(), _emscripten_stack_get_end())
+        }
 #endif
 
         // initialize the module
@@ -651,7 +653,9 @@ var LibraryDylink = {
       err('setDylinkStackLimits[' + name + ']');
 #endif
       var lib = LDSO.loadedLibsByName[name];
-      lib.module['__set_stack_limits'](stackTop, stackMax);
+      if (lib.module['__set_stack_limits']) {
+        lib.module['__set_stack_limits'](stackTop, stackMax);
+      }
     }
   },
 #endif

--- a/tools/building.py
+++ b/tools/building.py
@@ -292,7 +292,6 @@ def lld_flags_for_executable(external_symbols):
 
   if settings.LINKABLE:
     cmd.append('--export-dynamic')
-    cmd.append('--no-gc-sections')
 
   c_exports = [e for e in settings.EXPORTED_FUNCTIONS if is_c_symbol(e)]
   # Strip the leading underscores


### PR DESCRIPTION
Any symbols that have default visibility should be kept around because
we already pass `--export-dynamic`.  Passing `--no-gc-sections` causes
a lot more stuff that we don't even export to be kept around at link
time.

This change also makes `__set_stack_limits` options in shared libraries
which it technically always has been.  Binaryen doesn't generate this
function at all if it can't find a stack pointer at all in the side
module.

See: #16926