### PR TITLE
circleci: Remove unnecessary installation on python3.8 on windows. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -430,10 +430,9 @@ jobs:
           name: Install packages
           command: |
             choco install cmake.portable ninja
-            choco install python --version 3.8.0
       - run:
           name: Add python to bash path
-          command: echo "export PATH=\"$PATH:/c/python38/:/c/python38/Scripts/\"" >> $BASH_ENV
+          command: echo "export PATH=\"$PATH:/c/Python27amd64/\"" >> $BASH_ENV
       - build
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand


### PR DESCRIPTION
We can use the version of python that is installed by default to
bootstrap the emsdk install and from there we get our modern python.

This speeds up the windows bot start time by about a minute.