### PR TITLE
Avoid calling writeStackCookie to early in worker.js

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -656,7 +656,7 @@ var LibraryDylink = {
   // therefore before we have a stack.  Instead we delay calling
   // `__set_stack_limits` until we start running a thread.  We also need to call
   // this again for each new thread that the runs on a worker (since each thread
-  // has is own sperate stack region).
+  // has its own separate stack region).
   $setDylinkStackLimits: function(stackTop, stackMax) {
     for (var name in LDSO.loadedLibsByName) {
 #if DYLINK_DEBUG

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -214,12 +214,16 @@ function stackCheckInit() {
   // This is normally called automatically during __wasm_call_ctors but need to
   // get these values before even running any of the ctors so we call it redundantly
   // here.
-  // TODO(sbc): Move writeStackCookie to native to to avoid this.
+#if ASSERTIONS && USE_PTHREADS
+  // See $establishStackSpace for the equivelent code that runs on a thread
+  assert(!ENVIRONMENT_IS_PTHREAD);
+#endif
 #if RELOCATABLE
   _emscripten_stack_set_limits({{{ STACK_BASE }}} , {{{ STACK_MAX }}});
 #else
   _emscripten_stack_init();
 #endif
+  // TODO(sbc): Move writeStackCookie to native to to avoid this.
   writeStackCookie();
 }
 #endif
@@ -240,7 +244,10 @@ function run(args) {
   }
 
 #if STACK_OVERFLOW_CHECK
-  stackCheckInit();
+#if USE_PTHREADS
+  if (!ENVIRONMENT_IS_PTHREAD)
+#endif
+    stackCheckInit();
 #endif
 
 #if RELOCATABLE

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -375,9 +375,6 @@ function preRun() {
 }
 
 function initRuntime() {
-#if STACK_OVERFLOW_CHECK
-  checkStackCookie();
-#endif
 #if ASSERTIONS
   assert(!runtimeInitialized);
 #endif
@@ -389,6 +386,10 @@ function initRuntime() {
 
 #if USE_PTHREADS
   if (ENVIRONMENT_IS_PTHREAD) return;
+#endif
+
+#if STACK_OVERFLOW_CHECK
+  checkStackCookie();
 #endif
 
 #if STACK_OVERFLOW_CHECK >= 2

--- a/src/runtime_stack_check.js
+++ b/src/runtime_stack_check.js
@@ -8,6 +8,9 @@
 // Initializes the stack cookie. Called at the startup of main and at the startup of each thread in pthreads mode.
 function writeStackCookie() {
   var max = _emscripten_stack_get_end();
+#if RUNTIME_DEBUG
+  err('writeStackCookie: ' + max.toString(16));
+#endif
 #if ASSERTIONS
   assert((max & 3) == 0);
 #endif


### PR DESCRIPTION
When running a worker we don't want to write the stack cookie until the
worker is actually running a pthread.  This is done in
`establishStackSpace`.

For this reason we don't want to run `writeStackCookie` during
`run` (which is used only to initiialize the worker, before its
running a thread).

The extra call to `writeStackCookie` was not harmfull but its writing
the default stack location (the one used by the main thread!).