### PR TITLE
[EH] Change Wasm EH setting's name

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -844,7 +844,7 @@ def get_cflags(user_args):
 
   # if exception catching is disabled, we can prevent that code from being
   # generated in the frontend
-  if settings.DISABLE_EXCEPTION_CATCHING and not settings.EXCEPTION_HANDLING:
+  if settings.DISABLE_EXCEPTION_CATCHING and not settings.WASM_EXCEPTIONS:
     cflags.append('-fignore-exceptions')
 
   if settings.INLINING_LIMIT:
@@ -2570,12 +2570,12 @@ def phase_linker_setup(options, state, newargs, user_settings):
   # Export tag objects which are likely needed by the native code, but which are
   # currently not reported in the metadata of wasm-emscripten-finalize
   if settings.RELOCATABLE:
-    if settings.EXCEPTION_HANDLING:
+    if settings.WASM_EXCEPTIONS:
       settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.append('__cpp_exception')
     if settings.SUPPORT_LONGJMP == 'wasm':
       settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.append('__c_longjmp')
 
-  if settings.EXCEPTION_HANDLING:
+  if settings.WASM_EXCEPTIONS:
     settings.REQUIRED_EXPORTS += ['__trap']
 
   return target, wasm_target
@@ -3220,7 +3220,7 @@ def parse_args(newargs):
     elif arg == '-fno-exceptions':
       settings.DISABLE_EXCEPTION_CATCHING = 1
       settings.DISABLE_EXCEPTION_THROWING = 1
-      settings.EXCEPTION_HANDLING = 0
+      settings.WASM_EXCEPTIONS = 0
     elif arg == '-fexceptions':
       eh_enabled = True
     elif arg == '-fwasm-exceptions':
@@ -3283,11 +3283,11 @@ def parse_args(newargs):
   # exception handling by default when -fexceptions is given when wasm
   # exception handling becomes stable.
   if wasm_eh_enabled:
-    settings.EXCEPTION_HANDLING = 1
+    settings.WASM_EXCEPTIONS = 1
     settings.DISABLE_EXCEPTION_THROWING = 1
     settings.DISABLE_EXCEPTION_CATCHING = 1
   elif eh_enabled:
-    settings.EXCEPTION_HANDLING = 0
+    settings.WASM_EXCEPTIONS = 0
     settings.DISABLE_EXCEPTION_THROWING = 0
     settings.DISABLE_EXCEPTION_CATCHING = 0
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -635,7 +635,7 @@ def add_standard_wasm_imports(send_items_map):
 
   if settings.RELOCATABLE:
     send_items_map['__indirect_function_table'] = 'wasmTable'
-    if settings.EXCEPTION_HANDLING:
+    if settings.WASM_EXCEPTIONS:
       send_items_map['__cpp_exception'] = '___cpp_exception'
     if settings.SUPPORT_LONGJMP == 'wasm':
       send_items_map['__c_longjmp'] = '___c_longjmp'

--- a/src/library.js
+++ b/src/library.js
@@ -3604,7 +3604,7 @@ mergeInto(LibraryManager.library, {
   // global, basically).
   __heap_base: '{{{ to64(HEAP_BASE) }}}',
   __heap_base__import: true,
-#if EXCEPTION_HANDLING
+#if WASM_EXCEPTIONS
   // In dynamic linking we define tags here and feed them to each module
   __cpp_exception: "new WebAssembly.Tag({'parameters': ['{{{ POINTER_WASM_TYPE }}}']})",
   __cpp_exception__import: true,

--- a/src/modules.js
+++ b/src/modules.js
@@ -50,7 +50,7 @@ global.LibraryManager = {
       'library_eventloop.js',
     ];
 
-    if (LINK_AS_CXX && !EXCEPTION_HANDLING) {
+    if (LINK_AS_CXX && !WASM_EXCEPTIONS) {
       if (DISABLE_EXCEPTION_THROWING) {
         libraries.push('library_exceptions_stub.js');
       } else {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -628,7 +628,7 @@ function abort(what) {
   // defintion for WebAssembly.RuntimeError claims it takes no arguments even
   // though it can.
   // TODO(https://github.com/google/closure-compiler/pull/3913): Remove if/when upstream closure gets fixed.
-#if EXCEPTION_HANDLING == 1
+#if WASM_EXCEPTIONS == 1
   // See above, in the meantime, we resort to wasm code for trapping.
   ___trap();
 #else

--- a/src/settings.js
+++ b/src/settings.js
@@ -659,7 +659,7 @@ var LZ4 = false;
 // The three options below (DISABLE_EXCEPTION_CATCHING,
 // EXCEPTION_CATCHING_ALLOWED, and DISABLE_EXCEPTION_THROWING) only pertain to
 // Emscripten exception handling and do not control the experimental native wasm
-// exception handling option (EXCEPTION_HANDLING).
+// exception handling option (WASM_EXCEPTIONS).
 
 // Disables generating code to actually catch exceptions. This disabling is on
 // by default as the overhead of exceptions is quite high in size and speed

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -177,8 +177,8 @@ var CAN_ADDRESS_2GB = false;
 // This has no effect if DWARF is not being emitted.
 var SEPARATE_DWARF = false;
 
-// New WebAssembly exception handling (experimental)
-var EXCEPTION_HANDLING = false;
+// New WebAssembly exception handling
+var WASM_EXCEPTIONS = false;
 
 // Used internally when running the JS compiler simply to generate list of all
 // JS symbols. This is used by LLD_REPORT_UNDEFINED to generate a list of all

--- a/tools/building.py
+++ b/tools/building.py
@@ -371,9 +371,9 @@ def link_lld(args, target, external_symbols=None):
   for a in llvm_backend_args():
     cmd += ['-mllvm', a]
 
-  if settings.EXCEPTION_HANDLING:
+  if settings.WASM_EXCEPTIONS:
     cmd += ['-mllvm', '-wasm-enable-eh']
-  if settings.EXCEPTION_HANDLING or settings.SUPPORT_LONGJMP == 'wasm':
+  if settings.WASM_EXCEPTIONS or settings.SUPPORT_LONGJMP == 'wasm':
     cmd += ['-mllvm', '-exception-model=wasm']
 
   if settings.MEMORY64:

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -193,7 +193,7 @@ _deps_info = {
 
 
 def get_deps_info():
-  if not settings.EXCEPTION_HANDLING and settings.LINK_AS_CXX:
+  if not settings.WASM_EXCEPTIONS and settings.LINK_AS_CXX:
     _deps_info['__cxa_begin_catch'] = ['__cxa_is_pointer_type']
     _deps_info['__cxa_throw'] = ['__cxa_is_pointer_type']
     _deps_info['__cxa_find_matching_catch'] = ['__cxa_can_catch']

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -70,7 +70,7 @@ COMPILE_TIME_SETTINGS = {
 
     # Internal settings used during compilation
     'EXCEPTION_CATCHING_ALLOWED',
-    'EXCEPTION_HANDLING',
+    'WASM_EXCEPTIONS',
     'LTO',
     'OPT_LEVEL',
     'DEBUG_LEVEL',

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -607,7 +607,7 @@ class NoExceptLibrary(Library):
 
   @classmethod
   def get_default_variation(cls, **kwargs):
-    if settings.EXCEPTION_HANDLING:
+    if settings.WASM_EXCEPTIONS:
       eh_mode = Exceptions.WASM
     elif settings.DISABLE_EXCEPTION_CATCHING == 1:
       eh_mode = Exceptions.NONE
@@ -1853,7 +1853,7 @@ def get_libs_to_link(args, forced, only_forced):
     add_library('libc++')
   if settings.LINK_AS_CXX or sanitize:
     add_library('libc++abi')
-    if settings.EXCEPTION_HANDLING:
+    if settings.WASM_EXCEPTIONS:
       add_library('libunwind')
 
   if settings.USE_ASAN:


### PR DESCRIPTION
I named it EXCEPTION_HANDLING thinking we will eventually remove
Emscripten EH and this will be the only mode of EH, but maybe that won't
happen for a while, and code is confusing because if you write
`if !EXCEPTION_HANDLING` it sounds like all exception handling should be
disabled.