### PR TITLE
Allow RUNTIME_DEBUG to be explicitly controlled

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1592,6 +1592,11 @@ def phase_linker_setup(options, state, newargs, user_settings):
   if options.cpu_profiler:
     options.post_js.append(utils.path_from_root('src/cpuprofiler.js'))
 
+  default_setting(user_settings, 'RUNTIME_DEBUG', settings.LIBRARY_DEBUG or
+                  settings.GL_DEBUG or
+                  settings.DYLINK_DEBUG or
+                  settings.PTHREADS_DEBUG)
+
   if options.memory_profiler:
     settings.MEMORYPROFILER = 1
 

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -53,8 +53,6 @@ WASM_EXPORTS = new Set(WASM_EXPORTS);
 SIDE_MODULE_EXPORTS = new Set(SIDE_MODULE_EXPORTS);
 INCOMING_MODULE_JS_API = new Set(INCOMING_MODULE_JS_API);
 
-RUNTIME_DEBUG = LIBRARY_DEBUG || GL_DEBUG || DYLINK_DEBUG || PTHREADS_DEBUG;
-
 // Side modules are pure wasm and have no JS
 assert(!SIDE_MODULE, 'JS compiler should not run on side modules');
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1999,6 +1999,16 @@ var TRUSTED_TYPES = false;
 // settings is *only* needed when also explicitly targeting older browsers.
 var POLYFILL = true;
 
+// If true, add tracing to core runtime functions.
+// This settings is enabled by default is any of the other debugging settings
+// are enabled:
+// - PTHREADS_DEBUG
+// - DYLINK_DEBUG
+// - LIBRARY_DEBUG
+// - GL_DEBUG
+// [link]
+var RUNTIME_DEBUG = false;
+
 //===========================================
 // Internal, used for testing only, from here
 //===========================================


### PR DESCRIPTION
Previously this setting was hidden and automatically enabled based
on others, but I've found it useful to enable it independently.