### PR TITLE
Don't apply --whole-archive linker option when -sLINKABLE is set

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -358,12 +358,6 @@ def link_lld(args, target, external_symbols=None):
   # grouping.
   args = [a for a in args if a not in ('--start-group', '--end-group')]
 
-  # Emscripten currently expects linkable output (SIDE_MODULE/MAIN_MODULE) to
-  # include all archive contents.
-  if settings.LINKABLE:
-    args.insert(0, '--whole-archive')
-    args.append('--no-whole-archive')
-
   if settings.STRICT:
     args.append('--fatal-warnings')
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1905,12 +1905,6 @@ def calculate(input_files, args, forced):
 
   libs_to_link = get_libs_to_link(args, forced, only_forced)
 
-  # When LINKABLE is set the entire link command line is wrapped in --whole-archive by
-  # building.link_ldd.  And since --whole-archive/--no-whole-archive processing does not nest we
-  # shouldn't add any extra `--no-whole-archive` or we will undo the intent of building.link_ldd.
-  if settings.LINKABLE or settings.SIDE_MODULE:
-    return [l[0] for l in libs_to_link]
-
   # Wrap libraries in --whole-archive, as needed.  We need to do this last
   # since otherwise the abort sorting won't make sense.
   ret = []


### PR DESCRIPTION
This setting causes trouble when compiling Rust because Rust archives contain an extra `lib.rmeta` index file. See discussion in #17109.