### PR TITLE
Don't set PYTHONUTF8 during CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,9 +416,6 @@ jobs:
       shell: bash.exe -eo pipefail
     environment:
       PYTHONUNBUFFERED: "1"
-      # Override the default locale to use UTF-8 encoding for all files and stdio 
-      # streams (see PEP540), since oure test files are encoded with UTF-8.
-      PYTHONUTF8: "1"
       EMSDK_NOTTY: "1"
       # clang can compile but not link in the current setup, see
       # https://github.com/emscripten-core/emscripten/pull/11382#pullrequestreview-428902638


### PR DESCRIPTION
By setting this we were masking possible bugs related to the encodings
(especially on windows).

See https://docs.python.org/3/library/os.html#utf8-mode

See #16981 and #17108