### PR TITLE
[WasmFS] Fix wasmfs.test_openjpeg

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6841,7 +6841,7 @@ void* operator new(size_t size) {
       create_file('pre.js', """
         Module.preRun = function() { FS.createDataFile('/', 'image.j2k', %s, true, false, false); };
         Module.postRun = function() {
-          out('Data: ' + JSON.stringify(Array.from(MEMFS.getFileDataAsTypedArray(FS.analyzePath('image.raw').object))));
+          out('Data: ' + JSON.stringify(Array.from(FS.readFile('image.raw'))));
         };
         """ % line_splitter(str(image_bytes)))
 


### PR DESCRIPTION
The test used an internal MEMFS method unnecessarily. Using a generic method
makes it work in WasmFS too, and it's simpler.