### PR TITLE
Allow `-M` to be passed to the linker

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -84,7 +84,6 @@ SUPPORTED_LINKER_FLAGS = (
 UNSUPPORTED_LLD_FLAGS = {
     # macOS-specific linker flag that libtool (ltmain.sh) will if macOS is detected.
     '-bind_at_load': False,
-    '-M': False,
     # wasm-ld doesn't support soname or other dynamic linking flags (yet).   Ignore them
     # in order to aid build systems that want to pass these flags.
     '-soname': True,

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -12078,3 +12078,10 @@ Module['postRun'] = function() {{
   def test_xlocale(self):
     # Test for xlocale.h compatibility header
     self.do_other_test('test_xlocale.c')
+
+  def test_print_map(self):
+    self.run_process([EMCC, '-c', test_file('hello_world.c')])
+    out = self.run_process([EMCC, 'hello_world.o', '-Wl,--print-map'], stdout=PIPE).stdout
+    self.assertContained('hello_world.o:(__original_main)', out)
+    out2 = self.run_process([EMCC, 'hello_world.o', '-Wl,-M'], stdout=PIPE).stdout
+    self.assertEqual(out, out2)


### PR DESCRIPTION
We implemented `--print-map` and enabled it in #12697 but overlooked
that `-M` is just shorthand for this.