### PR TITLE
Fix signature generation in RELOCATABLE

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -382,12 +382,12 @@ function ${name}(${args}) {
       if ((EXPORT_ALL || EXPORTED_FUNCTIONS.has(finalName)) && !noExport) {
         contentText += `\nModule["${finalName}"] = ${finalName};`;
       }
-      // Main modules need signatures to create proper wrappers. Stack switching
-      // need signatures so we can create a proper WebAssembly.Function with the
-      // signature for the Promise API.
+      // Relocatable code needs signatures to create proper wrappers. Stack
+      // switching needs signatures so we can create a proper
+      // WebAssembly.Function with the signature for the Promise API.
       // TODO: For asyncify we could only add the signatures we actually need,
       //       of async imports/exports.
-      if (sig && (MAIN_MODULE || ASYNCIFY == 2)) {
+      if (sig && (RELOCATABLE || ASYNCIFY == 2)) {
         contentText += `\n${finalName}.sig = '${sig}';`;
       }
 

--- a/tests/core/test_relocatable_void_function.c
+++ b/tests/core/test_relocatable_void_function.c
@@ -5,6 +5,7 @@
  * found in the LICENSE file.
  */
 
+#include <emscripten/console.h>
 #include <stdio.h>
 
 void hi_world() {
@@ -13,5 +14,13 @@ void hi_world() {
 
 int main() {
   hi_world();
+
+  // Also test an indirect call. Taking the function by reference makes us go
+  // through more code paths that could have bugs, like relocatable code needing
+  // to make wrapper functions for function pointers, which need signatures for
+  // an imported function from JS.
+  void (*func)(const char*) = &emscripten_console_log;
+  func("indirect import");
+
   return 0;
 }

--- a/tests/core/test_relocatable_void_function.out
+++ b/tests/core/test_relocatable_void_function.out
@@ -1,1 +1,2 @@
 hi world
+indirect import


### PR DESCRIPTION
This fixes `wasmfs.test_relocatable_void_function` but the problem is not
specific to WasmFS. The bug was that we checked `MAIN_MODULE` where
we should check `RELOCATABLE` (really, we don't have much use case for
`RELOCATABLE`-with-JS-but-not-`MAIN_MODULE`, but that's a separate
issue). This was not noticeable before because the few tests we have for
`RELOCATABLE` by itself did not happen to have imports that actually need
a signature. But in WasmFS we have more imports, specifically we add the
`__emscripten_out` import to print to stdout, and that ends up crashing on
not having a signature.