### PR TITLE
Add support for noexcept keyword to embind. 

### DIFF
--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -637,22 +637,8 @@ struct GetterPolicy<GetterReturnType (GetterThisType::*)() const> {
 
 #ifdef __cpp_noexcept_function_type
 template<typename GetterReturnType, typename GetterThisType>
-struct GetterPolicy<GetterReturnType (GetterThisType::*)() const noexcept> {
-    typedef GetterReturnType ReturnType;
-    typedef GetterReturnType (GetterThisType::*Context)() const noexcept;
-
-    typedef internal::BindingType<ReturnType> Binding;
-    typedef typename Binding::WireType WireType;
-
-    template<typename ClassType>
-    static WireType get(const Context& context, const ClassType& ptr) {
-        return Binding::toWireType((ptr.*context)());
-    }
-
-    static void* getContext(Context context) {
-        return internal::getContext(context);
-    }
-};
+struct GetterPolicy<GetterReturnType (GetterThisType::*)() const noexcept>
+     : GetterPolicy<GetterReturnType (GetterThisType::*)() const> {};
 #endif
 
 template<typename GetterReturnType, typename GetterThisType>
@@ -732,22 +718,8 @@ struct SetterPolicy<SetterReturnType (SetterThisType::*)(SetterArgumentType)> {
 
 #ifdef __cpp_noexcept_function_type
 template<typename SetterReturnType, typename SetterThisType, typename SetterArgumentType>
-struct SetterPolicy<SetterReturnType (SetterThisType::*)(SetterArgumentType) noexcept> {
-    typedef SetterArgumentType ArgumentType;
-    typedef SetterReturnType (SetterThisType::*Context)(SetterArgumentType) noexcept;
-
-    typedef internal::BindingType<SetterArgumentType> Binding;
-    typedef typename Binding::WireType WireType;
-
-    template<typename ClassType>
-    static void set(const Context& context, ClassType& ptr, WireType wt) {
-        (ptr.*context)(Binding::fromWireType(wt));
-    }
-
-    static void* getContext(Context context) {
-        return internal::getContext(context);
-    }
-};
+struct SetterPolicy<SetterReturnType (SetterThisType::*)(SetterArgumentType) noexcept>
+     : SetterPolicy<SetterReturnType (SetterThisType::*)(SetterArgumentType)> {};
 #endif
 
 template<typename SetterReturnType, typename SetterThisType, typename SetterArgumentType>
@@ -1389,46 +1361,12 @@ struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) const> {
 
 #ifdef __cpp_noexcept_function_type
 template<typename ClassType, typename ReturnType, typename... Args>
-struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) noexcept> {
-
-    template <typename CT, typename... Policies>
-    static void invoke(const char* methodName,
-                        ReturnType (ClassType::*memberFunction)(Args...) noexcept)  {
-        auto invoker = &MethodInvoker<decltype(memberFunction), ReturnType, ClassType*, Args...>::invoke;
-
-        typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, AllowedRawPointer<ClassType>, Args...> args;
-        _embind_register_class_function(
-            TypeID<ClassType>::get(),
-            methodName,
-            args.getCount(),
-            args.getTypes(),
-            getSignature(invoker),
-            reinterpret_cast<GenericFunction>(invoker),
-            getContext(memberFunction),
-            isPureVirtual<Policies...>::value);
-    }
-};
+struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) noexcept>
+     : RegisterClassMethod<ReturnType (ClassType::*)(Args...)> {};
 
 template<typename ClassType, typename ReturnType, typename... Args>
-struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) const noexcept> {
-
-    template <typename CT, typename... Policies>
-    static void invoke(const char* methodName,
-                        ReturnType (ClassType::*memberFunction)(Args...) const noexcept)  {
-        auto invoker = &MethodInvoker<decltype(memberFunction), ReturnType, const ClassType*, Args...>::invoke;
-
-        typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, AllowedRawPointer<const ClassType>, Args...> args;
-        _embind_register_class_function(
-            TypeID<ClassType>::get(),
-            methodName,
-            args.getCount(),
-            args.getTypes(),
-            getSignature(invoker),
-            reinterpret_cast<GenericFunction>(invoker),
-            getContext(memberFunction),
-            isPureVirtual<Policies...>::value);
-    }
-};
+struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) const noexcept>
+     : RegisterClassMethod<ReturnType (ClassType::*)(Args...) const> {};
 #endif
 
 template<typename ReturnType, typename ThisType, typename... Args>

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -1338,6 +1338,12 @@ struct RegisterClassMethod<ReturnType (ClassType::*)(Args...)> {
     }
 };
 
+#ifdef __cpp_noexcept_function_type
+template<typename ClassType, typename ReturnType, typename... Args>
+struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) noexcept>
+     : RegisterClassMethod<ReturnType (ClassType::*)(Args...)> {};
+#endif
+
 template<typename ClassType, typename ReturnType, typename... Args>
 struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) const> {
 
@@ -1360,10 +1366,6 @@ struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) const> {
 };
 
 #ifdef __cpp_noexcept_function_type
-template<typename ClassType, typename ReturnType, typename... Args>
-struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) noexcept>
-     : RegisterClassMethod<ReturnType (ClassType::*)(Args...)> {};
-
 template<typename ClassType, typename ReturnType, typename... Args>
 struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) const noexcept>
      : RegisterClassMethod<ReturnType (ClassType::*)(Args...) const> {};
@@ -1388,6 +1390,12 @@ struct RegisterClassMethod<ReturnType (*)(ThisType, Args...)> {
             false);
     }
 };
+
+#ifdef __cpp_noexcept_function_type
+template<typename ReturnType, typename ThisType, typename... Args>
+struct RegisterClassMethod<ReturnType (*)(ThisType, Args...) noexcept>
+     : RegisterClassMethod<ReturnType (*)(ThisType, Args...)> {};
+#endif
 
 template<typename ReturnType, typename ThisType, typename... Args>
 struct RegisterClassMethod<std::function<ReturnType (ThisType, Args...)>> {

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -635,6 +635,26 @@ struct GetterPolicy<GetterReturnType (GetterThisType::*)() const> {
     }
 };
 
+#ifdef __cpp_noexcept_function_type
+template<typename GetterReturnType, typename GetterThisType>
+struct GetterPolicy<GetterReturnType (GetterThisType::*)() const noexcept> {
+    typedef GetterReturnType ReturnType;
+    typedef GetterReturnType (GetterThisType::*Context)() const noexcept;
+
+    typedef internal::BindingType<ReturnType> Binding;
+    typedef typename Binding::WireType WireType;
+
+    template<typename ClassType>
+    static WireType get(const Context& context, const ClassType& ptr) {
+        return Binding::toWireType((ptr.*context)());
+    }
+
+    static void* getContext(Context context) {
+        return internal::getContext(context);
+    }
+};
+#endif
+
 template<typename GetterReturnType, typename GetterThisType>
 struct GetterPolicy<GetterReturnType (*)(const GetterThisType&)> {
     typedef GetterReturnType ReturnType;
@@ -709,6 +729,26 @@ struct SetterPolicy<SetterReturnType (SetterThisType::*)(SetterArgumentType)> {
         return internal::getContext(context);
     }
 };
+
+#ifdef __cpp_noexcept_function_type
+template<typename SetterReturnType, typename SetterThisType, typename SetterArgumentType>
+struct SetterPolicy<SetterReturnType (SetterThisType::*)(SetterArgumentType) noexcept> {
+    typedef SetterArgumentType ArgumentType;
+    typedef SetterReturnType (SetterThisType::*Context)(SetterArgumentType) noexcept;
+
+    typedef internal::BindingType<SetterArgumentType> Binding;
+    typedef typename Binding::WireType WireType;
+
+    template<typename ClassType>
+    static void set(const Context& context, ClassType& ptr, WireType wt) {
+        (ptr.*context)(Binding::fromWireType(wt));
+    }
+
+    static void* getContext(Context context) {
+        return internal::getContext(context);
+    }
+};
+#endif
 
 template<typename SetterReturnType, typename SetterThisType, typename SetterArgumentType>
 struct SetterPolicy<SetterReturnType (*)(SetterThisType&, SetterArgumentType)> {
@@ -1346,6 +1386,50 @@ struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) const> {
             isPureVirtual<Policies...>::value);
     }
 };
+
+#ifdef __cpp_noexcept_function_type
+template<typename ClassType, typename ReturnType, typename... Args>
+struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) noexcept> {
+
+    template <typename CT, typename... Policies>
+    static void invoke(const char* methodName,
+                        ReturnType (ClassType::*memberFunction)(Args...) noexcept)  {
+        auto invoker = &MethodInvoker<decltype(memberFunction), ReturnType, ClassType*, Args...>::invoke;
+
+        typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, AllowedRawPointer<ClassType>, Args...> args;
+        _embind_register_class_function(
+            TypeID<ClassType>::get(),
+            methodName,
+            args.getCount(),
+            args.getTypes(),
+            getSignature(invoker),
+            reinterpret_cast<GenericFunction>(invoker),
+            getContext(memberFunction),
+            isPureVirtual<Policies...>::value);
+    }
+};
+
+template<typename ClassType, typename ReturnType, typename... Args>
+struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) const noexcept> {
+
+    template <typename CT, typename... Policies>
+    static void invoke(const char* methodName,
+                        ReturnType (ClassType::*memberFunction)(Args...) const noexcept)  {
+        auto invoker = &MethodInvoker<decltype(memberFunction), ReturnType, const ClassType*, Args...>::invoke;
+
+        typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, AllowedRawPointer<const ClassType>, Args...> args;
+        _embind_register_class_function(
+            TypeID<ClassType>::get(),
+            methodName,
+            args.getCount(),
+            args.getTypes(),
+            getSignature(invoker),
+            reinterpret_cast<GenericFunction>(invoker),
+            getContext(memberFunction),
+            isPureVirtual<Policies...>::value);
+    }
+};
+#endif
 
 template<typename ReturnType, typename ThisType, typename... Args>
 struct RegisterClassMethod<ReturnType (*)(ThisType, Args...)> {

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -386,6 +386,22 @@ public:
     }
 };
 
+class NoExceptClass {
+public:
+    int getValue() noexcept {
+        return 42;
+    }
+    int getValueConst() const noexcept {
+        return 43;
+    }
+    int getX() const noexcept { return x; }
+    void setX(int x_) noexcept { x = x_; }
+private:
+    int x;
+};
+
+void embind_test_no_except_function(NoExceptClass&) noexcept {}
+
 class ParentClass {
 public:
     ParentClass(): bigClass() {};
@@ -1969,6 +1985,12 @@ EMSCRIPTEN_BINDINGS(tests) {
         .constructor<int, int, int>()
         .function("getMember", &TemplateClass<int>::getMember)
         ;
+
+    class_<NoExceptClass>("NoExceptClass")
+        .function("embind_test_no_except_function", &embind_test_no_except_function)
+        .function("getValue", &NoExceptClass::getValue)
+        .function("getValueConst", &NoExceptClass::getValueConst)
+        .property("x", &NoExceptClass::getX, &NoExceptClass::setX);
 
     class_<ContainsTemplatedMemberClass>("ContainsTemplatedMemberClass")
         .constructor<>()

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2499,6 +2499,8 @@ int f() {
   def test_embind(self, extra_args):
     test_cases = [
       (['-lembind']),
+      # Ensure embind compiles under C++17 where "noexcept" became part of the function signature.
+      (['-lembind', '-std=c++17']),
       (['-lembind', '-O1']),
       (['-lembind', '-O2']),
       (['-lembind', '-O2', '-sALLOW_MEMORY_GROWTH', test_file('embind/isMemoryGrowthEnabled=true.cpp')]),


### PR DESCRIPTION
This continues the work from #15273 and #10613 which supports the noexcept
keyword by ignoring it on c++17 compilers. I've also added a missing
template for class methods and tests for each possible use of noexcept.