### PR TITLE
Avoid filesystem syscall in test_syscall_intercept

### DIFF
--- a/tests/core/test_syscall_intercept.c
+++ b/tests/core/test_syscall_intercept.c
@@ -3,8 +3,8 @@
 #include <stdio.h>
 
 // Import the syscall under a separate name
-__attribute__((import_module("env"), import_name("emscripten_get_now")))
-double __orig_emscripten_get_now(void);
+__attribute__((import_module("env"), import_name("emscripten_get_now"))) double
+__orig_emscripten_get_now(void);
 
 double emscripten_get_now(void) {
   printf("emscripten_get_now intercepted\n");

--- a/tests/core/test_syscall_intercept.c
+++ b/tests/core/test_syscall_intercept.c
@@ -1,21 +1,18 @@
 #include <assert.h>
-#include <string.h>
+#include <emscripten.h>
 #include <stdio.h>
 
 // Import the syscall under a separate name
-__attribute__((import_module("env"), import_name("__syscall_getcwd")))
-int __orig_getcwd(intptr_t buf, size_t size);
+__attribute__((import_module("env"), import_name("emscripten_get_now")))
+double __orig_emscripten_get_now(void);
 
-
-int __syscall_getcwd(intptr_t buf, size_t size) {
-  printf("__syscall_getcwd intercepted\n");
-  return __orig_getcwd(buf, size);
+double emscripten_get_now(void) {
+  printf("emscripten_get_now intercepted\n");
+  return __orig_emscripten_get_now();
 }
 
 int main() {
-  char cwd[1024];
-  int rtn = __syscall_getcwd((intptr_t)cwd, sizeof(cwd));
-  assert(rtn > 0);
-  printf("cwd = %s\n", cwd);
+  double now = emscripten_get_now();
+  assert(now > 0); // any non-negative time is valid
   return 0;
 }

--- a/tests/core/test_syscall_intercept.out
+++ b/tests/core/test_syscall_intercept.out
@@ -1,2 +1,1 @@
-__syscall_getcwd intercepted
-cwd = /
+emscripten_get_now intercepted

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9390,7 +9390,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args += ['-mreference-types']
     self.do_core_test('test_externref.c', libraries=['asm.o'])
 
-  @no_wasmfs('syscalls are not JS imports, and cannot be intercepted as such')
   def test_syscall_intercept(self):
     self.do_core_test('test_syscall_intercept.c')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9390,6 +9390,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args += ['-mreference-types']
     self.do_core_test('test_externref.c', libraries=['asm.o'])
 
+  @no_wasmfs('syscalls are not JS imports, and cannot be intercepted as such')
   def test_syscall_intercept(self):
     self.do_core_test('test_syscall_intercept.c')
 


### PR DESCRIPTION
The test checks that we can intercept an imported syscall from JS. In WasmFS,
however, filesystem syscalls are not JS imports. Instead, move the test to use a
function that is definitely an import.