### PR TITLE
Rebaseline to fix code size test breakage

### DIFF
--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 12866,
-  "a.html.gz": 6979,
-  "total": 12866,
-  "total_gz": 6979
+  "a.html": 12854,
+  "a.html.gz": 6948,
+  "total": 12854,
+  "total_gz": 6948
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17393,
-  "a.html.gz": 7524,
-  "total": 17393,
-  "total_gz": 7524
+  "a.html": 17360,
+  "a.html.gz": 7495,
+  "total": 17360,
+  "total_gz": 7495
 }


### PR DESCRIPTION
Some minor improvements, likely from the LLVM side, made things better
enough to break some expectations.