### PR TITLE
Add missing function dependency for embind class constructor.

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -2075,7 +2075,8 @@ var LibraryEmbind = {
 
   _embind_register_class_constructor__deps: [
     '$heap32VectorToArray', '$embind__requireFunction', '$runDestructors',
-    '$throwBindingError', '$whenDependentTypesAreResolved', '$registeredTypes'],
+    '$throwBindingError', '$whenDependentTypesAreResolved', '$registeredTypes',
+    '$craftInvokerFunction'],
   _embind_register_class_constructor: function(
     rawClassType,
     argCount,

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2488,8 +2488,7 @@ int f() {
               .property("x", &MyClass::getX, &MyClass::setX);
       }
     ''')
-    self.run_process([EMXX, 'main.cpp', '-lembind', '-sASYNCIFY', '--post-js', 'post.js'])
-    self.assertContained('42', self.run_js('a.out.js'))
+    self.do_runf('main.cpp', '42', emcc_args=['-lembind', '--post-js', 'post.js'])
 
   def test_embind_closure_no_dynamic_execution(self):
     create_file('post.js', '''


### PR DESCRIPTION
The `craftInvokerFunction` was not being generated if embind was used for a
class binding without ever using a `function` binding.

Fixes #17143