### PR TITLE
[EH] Make getCppExceptionThrownValue return thrown value

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -398,29 +398,32 @@ var LibraryExceptions = {
     return Module['asm']['__cpp_exception'];
   },
 
-  $getCppExceptionThrownValue__deps: ['$getCppExceptionTag'],
+  $getCppExceptionThrownValue__deps: ['$getCppExceptionTag', '__thrown_object_from_unwind_exception'],
   $getCppExceptionThrownValue: function(ex) {
-    return ex.getArg(getCppExceptionTag(), 0);
+    // In Wasm EH, the value extracted from WebAssembly.Exception is a pointer
+    // to the unwind header. Convert it to the actual thrown value.
+    var unwind_ex = ex.getArg(getCppExceptionTag(), 0);
+    return ___thrown_object_from_unwind_exception(unwind_ex);
   },
 
-  $incrementExceptionRefcount__deps: ['__increment_wasm_exception_refcount', '$getCppExceptionThrownValue'],
+  $incrementExceptionRefcount__deps: ['__cxa_increment_exception_refcount', '$getCppExceptionThrownValue'],
   $incrementExceptionRefcount: function(obj) {
     var ptr = getCppExceptionThrownValue(obj);
-    ___increment_wasm_exception_refcount(ptr);
+    ___cxa_increment_exception_refcount(ptr);
   },
 
-  $decrementExceptionRefcount__deps: ['__decrement_wasm_exception_refcount', '$getCppExceptionThrownValue'],
+  $decrementExceptionRefcount__deps: ['__cxa_decrement_exception_refcount', '$getCppExceptionThrownValue'],
   $decrementExceptionRefcount: function(obj) {
     var ptr = getCppExceptionThrownValue(obj);
-    ___decrement_wasm_exception_refcount(ptr);
+    ___cxa_decrement_exception_refcount(ptr);
   },
 
   $getExceptionMessage__deps: ['__get_exception_message', 'free', '$getCppExceptionThrownValue'],
-  $getExceptionMessage: function(ptr) {
+  $getExceptionMessage: function(obj) {
     // In Wasm EH, the thrown object is a WebAssembly.Exception. Extract the
     // thrown value from it.
-    var obj = getCppExceptionThrownValue(ptr);
-    var utf8_addr = ___get_exception_message(obj);
+    var ptr = getCppExceptionThrownValue(obj);
+    var utf8_addr = ___get_exception_message(ptr);
     var result = UTF8ToString(utf8_addr);
     _free(utf8_addr);
     return result;

--- a/system/lib/libcxxabi/src/cxa_exception_emscripten.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception_emscripten.cpp
@@ -33,27 +33,26 @@ thrown_object_from_cxa_exception(__cxa_exception* exception_header) {
 //  Get the exception object from the unwind pointer.
 //  Relies on the structure layout, where the unwind pointer is right in
 //  front of the user's exception object
-static inline __cxa_exception* cxa_exception_from_exception_unwind_exception(
+static inline __cxa_exception* cxa_exception_from_unwind_exception(
   _Unwind_Exception* unwind_exception) {
   return cxa_exception_from_thrown_object(unwind_exception + 1);
 }
 
-static inline void* thrown_object_from_exception_unwind_exception(
+static inline void* thrown_object_from_unwind_exception(
   _Unwind_Exception* unwind_exception) {
   __cxa_exception* exception_header =
-    cxa_exception_from_exception_unwind_exception(unwind_exception);
+    cxa_exception_from_unwind_exception(unwind_exception);
   return thrown_object_from_cxa_exception(exception_header);
 }
 
 extern "C" {
 
+void* __thrown_object_from_unwind_exception(
+  _Unwind_Exception* unwind_exception) {
+  return thrown_object_from_unwind_exception(unwind_exception);
+}
+
 char* __get_exception_message(void* thrown_object, bool terminate=false) {
-#if __USING_WASM_EXCEPTIONS__
-  // In Wasm EH, the thrown value is 'unwindHeader' field of __cxa_exception. So
-  // we need to get the real pointer thrown by user.
-  thrown_object = thrown_object_from_exception_unwind_exception(
-    static_cast<_Unwind_Exception*>(thrown_object));
-#endif
   __cxa_exception* exception_header =
     cxa_exception_from_thrown_object(thrown_object);
   const __shim_type_info* thrown_type =
@@ -95,34 +94,6 @@ char* __get_exception_terminate_message(void *thrown_object) {
   return __get_exception_message(thrown_object, true);
 }
 
-#if __USING_WASM_EXCEPTIONS__
-void __cxa_increment_exception_refcount(void* thrown_object) _NOEXCEPT;
-void __cxa_decrement_exception_refcount(void* thrown_object) _NOEXCEPT;
-
-// These are wrappers for __cxa_increment_exception_refcount and
-// __cxa_decrement_exception_refcount so that these can be called from JS. When
-// you catch a Wasm exception from JS and do not rethrow it, its refcount is
-// still greater than 0 so memory is leaked; users call JS library functions
-// that call these to fix it.
-
-void __increment_wasm_exception_refcount(
-  void* unwind_exception) _NOEXCEPT {
-  // In Wasm EH, the thrown value is 'unwindHeader' field of __cxa_exception. So
-  // we need to get the real pointer thrown by user.
-  void* thrown_object = thrown_object_from_exception_unwind_exception(
-    static_cast<_Unwind_Exception*>(unwind_exception));
-  __cxa_increment_exception_refcount(thrown_object);
-}
-
-void __decrement_wasm_exception_refcount(
-  void* unwind_exception) _NOEXCEPT {
-  // In Wasm EH, the thrown value is 'unwindHeader' field of __cxa_exception. So
-  // we need to get the real pointer thrown by user.
-  void* thrown_object = thrown_object_from_exception_unwind_exception(
-    static_cast<_Unwind_Exception*>(unwind_exception));
-  __cxa_decrement_exception_refcount(thrown_object);
-}
-#endif // __USING_WASM_EXCEPTIONS__
 }
 
 #endif // __USING_EMSCRIPTEN_EXCEPTIONS__ || __USING_WASM_EXCEPTIONS__

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1640,7 +1640,7 @@ int main(int argc, char **argv)
     self.set_setting('EXPORTED_FUNCTIONS', ['_main', 'getExceptionMessage', '___get_exception_message'])
     if '-fwasm-exceptions' in self.emcc_args:
       exports = self.get_setting('EXPORTED_FUNCTIONS')
-      self.set_setting('EXPORTED_FUNCTIONS', exports + ['___cpp_exception', '___increment_wasm_exception_refcount', '___decrement_wasm_exception_refcount'])
+      self.set_setting('EXPORTED_FUNCTIONS', exports + ['___cpp_exception', '___cxa_increment_exception_refcount', '___cxa_decrement_exception_refcount', '___thrown_object_from_unwind_exception'])
 
     # FIXME Temporary workaround. See 'FIXME' in the test source code below for
     # details.


### PR DESCRIPTION
In Emscripten EH, the thrown value by the JS library is the original
user-thrown value itself.

But in Wasm EH, what we throw is an [`WebAssembly.Exception`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) object. You
can use getArg method to get the value thrown. But even this value is
not the actual user-thrown value; in libc++abi, which Wasm EH uses, what
we actually throw is a pointer to something called unwind header,
represented by `_Unwind_Exception`:
https://github.com/emscripten-core/emscripten/blob/1f6b136d75c9a6a89d07ed069b9cede80b39cebd/system/lib/libcxxabi/src/cxa_exception.cpp#L284

The current `getCppExceptionThrownValue` in our JS exception library
returns the `_Unwind_Exception` pointer, which is the value actually
thrown by libc++abi, and not the original user-thrown value. This is
confusing in the first place, and I got requests from users who want to
access the original user-thrown value.

Because of `WebAssembly.Exception` object, we still have some
discrepancy between Emscripten EH and Wasm EH, but I think this is more
intuitive, and it actually simplifies libc++abi code as well.

So the current state:
- Emscripten EH: Throws original user-thrown value
- Wasm EH: Throws `WebAssembly.Exception` object, which contains the
           pointer to the unwind header

After this PR:
- Emscripten EH: Throws original user-thrown value
-  Wasm EH: Throws `WebAssembly.Exception` object, which contains the
          original user-thrown value

Addresses #16033.