### PR TITLE
Export runtime keepalive API to native code. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3446,6 +3446,14 @@ mergeInto(LibraryManager.library, {
 #endif
   },
 
+  emscripten_runtime_keepalive_push: '$runtimeKeepalivePush',
+  emscripten_runtime_keepalive_pop: '$runtimeKeepalivePop',
+  emscripten_runtime_keepalive_check: function() {
+    // keepRuntimeAlive is a runtime function rather than a library function,
+    // so we can't use an alias like we do for the two functions above.
+    return keepRuntimeAlive();
+  },
+
   // Used to call user callbacks from the embedder / event loop.  For example
   // setTimeout or any other kind of event handler that calls into user case
   // needs to use this wrapper.

--- a/src/modules.js
+++ b/src/modules.js
@@ -296,7 +296,8 @@ global.LibraryManager = {
           }
           const ret = sig == 'v' ? '' : 'return ';
           const args = genArgSequence(argCount).join(',');
-          lib[x] = new Function(args, `${ret}_${target}(${args});`);
+          const mangledName = mangleCSymbolName(target);
+          lib[x] = new Function(args, `${ret}${mangledName}(${args});`);
 
           if (!lib[x + '__deps']) lib[x + '__deps'] = [];
           lib[x + '__deps'].push(target);

--- a/system/include/emscripten/eventloop.h
+++ b/system/include/emscripten/eventloop.h
@@ -26,6 +26,10 @@ void emscripten_set_immediate_loop(EM_BOOL (*cb)(void *userData), void *userData
 long emscripten_set_interval(void (*cb)(void *userData), double intervalMsecs, void *userData);
 void emscripten_clear_interval(long setIntervalId);
 
+void emscripten_runtime_keepalive_push();
+void emscripten_runtime_keepalive_pop();
+EM_BOOL emscripten_runtime_keepalive_check();
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/pthread/test_pthread_proxying_cpp.cpp
+++ b/tests/pthread/test_pthread_proxying_cpp.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <condition_variable>
 #include <emscripten/proxying.h>
+#include <emscripten/eventloop.h>
 #include <iostream>
 #include <sched.h>
 
@@ -26,7 +27,7 @@ void looper_main() {
 }
 
 void returner_main() {
-  emscripten_exit_with_live_runtime();
+  emscripten_runtime_keepalive_push();
 }
 
 void test_proxy_async() {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2749,8 +2749,6 @@ The current type of b is: 9
                                  interleaved_output=False, emcc_args=args)
 
   @node_pthreads
-  @no_lsan('https://github.com/emscripten-core/emscripten/issues/17091')
-  @no_asan('https://github.com/emscripten-core/emscripten/issues/17091')
   @no_wasm2js('occasionally hangs in wasm2js (#16569)')
   def test_pthread_proxying_cpp(self):
     self.set_setting('EXIT_RUNTIME')


### PR DESCRIPTION
Sometimes it is useful to be able to make the runtime as alive without
also unwinding.  See test_pthread_proxying_cpp.cpp for an example of
this.

I also have use case for emscripten_runtime_keepalive_check() in #17153