### PR TITLE
Use regular allocator for pthread data. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -610,14 +610,6 @@ var LibraryPThread = {
     return ___pthread_create_js(pthread_ptr, attr, start_routine, arg);
   },
 
-  // ASan wraps the emscripten_builtin_pthread_create call in
-  // __lsan::ScopedInterceptorDisabler.  Unfortunately, that only disables it on
-  // the thread that made the call.  __pthread_create_js gets proxied to the
-  // main thread, where LSan is not disabled. This makes it necessary for us to
-  // disable LSan here (using __noleakcheck), so that it does not detect
-  // pthread's internal allocations as leaks.  If/when we remove all the
-  // allocations from __pthread_create_js we could also remove this.
-  __pthread_create_js__noleakcheck: true,
   __pthread_create_js__sig: 'iiiii',
   __pthread_create_js__deps: ['$spawnThread', 'pthread_self', '$pthreadCreateProxied'],
   __pthread_create_js: function(pthread_ptr, attr, start_routine, arg) {

--- a/system/lib/compiler-rt/lib/lsan/lsan_interceptors.cpp
+++ b/system/lib/compiler-rt/lib/lsan/lsan_interceptors.cpp
@@ -450,7 +450,7 @@ extern "C" void *__lsan_thread_start_func(void *arg) {
     internal_sched_yield();
   ThreadStart(tid, GetTid());
 #if SANITIZER_EMSCRIPTEN
-  emscripten_builtin_free(p);
+  free(p);
 #else
   atomic_store(&p->tid, 0, memory_order_release);
 #endif
@@ -470,7 +470,7 @@ INTERCEPTOR(int, pthread_create, void *th, void *attr,
   int detached = 0;
   pthread_attr_getdetachstate(attr, &detached);
 #if SANITIZER_EMSCRIPTEN
-  ThreadParam *p = (ThreadParam *) emscripten_builtin_malloc(sizeof(ThreadParam));
+  ThreadParam *p = (ThreadParam *) malloc(sizeof(ThreadParam));
   p->callback = callback;
   p->param = param;
   atomic_store(&p->tid, 0, memory_order_relaxed);

--- a/system/lib/pthread/pthread_create.c
+++ b/system/lib/pthread/pthread_create.c
@@ -14,7 +14,6 @@
 #include <string.h>
 #include <threads.h>
 #include <unistd.h>
-#include <emscripten/heap.h>
 
 #define STACK_ALIGN 16
 
@@ -123,7 +122,7 @@ int __pthread_create(pthread_t* restrict res,
   size += __pthread_tsd_size;
 
   // Allocate all the data for the new thread and zero-initialize.
-  unsigned char* block = emscripten_builtin_malloc(size);
+  unsigned char* block = malloc(size);
   memset(block, 0, size);
 
   struct pthread *new = (struct pthread*)block;
@@ -217,7 +216,7 @@ void _emscripten_thread_free_data(pthread_t t) {
   assert(t != pthread_self());
 #ifndef NDEBUG
   if (t->profilerBlock) {
-    emscripten_builtin_free(t->profilerBlock);
+    free(t->profilerBlock);
   }
 #endif
 
@@ -230,7 +229,7 @@ void _emscripten_thread_free_data(pthread_t t) {
 #endif
   // To aid in debugging, set the entire region to zero.
   memset(block, 0, sizeof(struct pthread));
-  emscripten_builtin_free(block);
+  free(block);
 }
 
 void _emscripten_thread_exit(void* result) {

--- a/system/lib/pthread/thread_profiler.c
+++ b/system/lib/pthread/thread_profiler.c
@@ -10,7 +10,6 @@
 #include <stdbool.h>
 #include "pthread_impl.h"
 #include <emscripten/threading.h>
-#include <emscripten/heap.h>
 
 static bool enabled = false;
 
@@ -21,7 +20,7 @@ void _emscripten_thread_profiler_init(pthread_t thread) {
   if (!enabled) {
     return;
   }
-  thread->profilerBlock = emscripten_builtin_malloc(sizeof(thread_profiler_block));
+  thread->profilerBlock = malloc(sizeof(thread_profiler_block));
   memset(thread->profilerBlock, 0, sizeof(thread_profiler_block));
   thread->profilerBlock->currentStatusStartTime = emscripten_get_now();
 }


### PR DESCRIPTION
These days I don't see why we wouldn't want to track leaks within
pthread_create itself.