### PR TITLE
Fix unaligned TSD region in thread info struct

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -394,6 +394,7 @@ jobs:
           test_targets: "
             core3
             core2ss.test_pthread_dylink
+            core2ss.test_pthread_thread_local_storage
             wasm2js3.test_memorygrowth_2
             other.test_unistd_fstatfs_wasmfs
             wasmfs.test_hello_world


### PR DESCRIPTION
In #17090 the TSD region (a set of thread-specific pointers) was
not being aligned.  This change uses a consistent allocation scheme
for each of the sections of thread data, but otherwise is NFC.