### PR TITLE
Fix some test failures resulting `main` mangling llvm change

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -221,7 +221,7 @@ def report_missing_symbols(js_library_funcs):
     # maximum compatibility.
     return
 
-  if settings.EXPECT_MAIN and 'main' not in settings.WASM_EXPORTS:
+  if settings.EXPECT_MAIN and 'main' not in settings.WASM_EXPORTS and '__main_argc_argv' not in settings.WASM_EXPORTS:
     # For compatibility with the output of wasm-ld we use the same wording here in our
     # error message as if wasm-ld had failed (i.e. in LLD_REPORT_UNDEFINED mode).
     exit_with_error('entry symbol not defined (pass --no-entry to suppress): main')

--- a/tests/hello_libcxx.cpp
+++ b/tests/hello_libcxx.cpp
@@ -5,9 +5,7 @@
 
 #include <iostream>
 
-int main()
-{
+int main(int argc, char* argv[]) {
   std::cout << "hello, world!" << std::endl;
   return 0;
 }
-

--- a/tests/hello_world.c
+++ b/tests/hello_world.c
@@ -11,4 +11,3 @@ int main() {
   printf("hello, world!\n");
   return 0;
 }
-


### PR DESCRIPTION
It seems that in `-sSTRICT` mode we were getting link failures because
`--entry=main` doesn't work anymore if that entry point takes arguments
(because it gets mangled to `__main_argc_argv`).

The reason we didn't pick this up earlier is that I guess we don't
do enough testing of `-sSTRICT` mode and it was only some browser tests
that was failing (e.g. `browser.test_openal_error`).