### PR TITLE
Add pthread + dylink test for side-module-defined C++ comat info. NFC

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1770,8 +1770,8 @@ int f() {
       emcc_args=[
         '-pthread', '-Wno-experimental',
         '-sPROXY_TO_PTHREAD',
-        '-sEXIT_RUNTIME=1',
-        '-sMAIN_MODULE=1',
+        '-sEXIT_RUNTIME',
+        '-sMAIN_MODULE=2',
         'side.wasm',
       ])
 
@@ -1794,6 +1794,55 @@ int f() {
     self.set_setting('WASM_BIGINT')
     self.emcc_args += ['-Wno-experimental']
     self.do_runf(test_file('core/test_em_js.cpp'))
+
+  @node_pthreads
+  def test_dylink_pthread_comdat(self):
+    # Test that the comdat info for `Foo`, which is defined in the side module,
+    # is visible to the main module.
+    create_file('foo.h', r'''
+    struct Foo {
+      // Making this method virtual causes the comdat group for the
+      // class to only be defined in the side module.
+      virtual void method() const;
+    };
+    ''')
+    create_file('main.cpp', r'''
+      #include "foo.h"
+      #include <typeinfo>
+      #include <emscripten/console.h>
+
+      int main() {
+        _emscripten_outf("main: Foo typeid: %s", typeid(Foo).name());
+
+        Foo().method();
+        return 0;
+      }
+    ''')
+    create_file('side.cpp', r'''
+      #include "foo.h"
+      #include <typeinfo>
+      #include <emscripten/console.h>
+
+      void Foo::method() const {
+        _emscripten_outf("side: Foo typeid: %s", typeid(Foo).name());
+      }
+      ''')
+    self.run_process([
+      EMCC,
+      '-o', 'libside.wasm',
+      'side.cpp',
+      '-pthread', '-Wno-experimental',
+      '-sSIDE_MODULE=1'])
+    self.do_runf(
+      'main.cpp',
+      'main: Foo typeid: 3Foo\nside: Foo typeid: 3Foo\n',
+      emcc_args=[
+        '-pthread', '-Wno-experimental',
+        '-sPROXY_TO_PTHREAD',
+        '-sEXIT_RUNTIME',
+        '-sMAIN_MODULE=2',
+        'libside.wasm',
+      ])
 
   def test_dylink_no_autoload(self):
     create_file('main.c', r'''


### PR DESCRIPTION
This test will only pass once that corresponding llvm fix lands:
https://reviews.llvm.org/D127333

See #17150