### PR TITLE
Add ChangeLog entries

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,8 +18,19 @@ to browse the changes between the tags.
 
 See docs/process.md for more on how version tagging works.
 
-3.1.14
-------
+3.2.0
+-----
+- Weak undefined symbols fixed in dynamic linking. (#17164)
+- Internally, the name of `main` function now gets mangled (by clang) in the
+  same way as with other wasm targets.  This means that within the wasm module
+  the name of the main function can now be `__main_argc_argv`, but, since we
+  still export this to JS as `_main`, this should not be a user-visible change.
+- Use of pkg-config from cmake not longer causes the C++ include path to be
+  broken. (#17137)
+- `emscripten_runtime_keeplive_push()` and `emscripten_runtime_keeplive_push()`
+  are now exposed to native code and can be used to keep the runtime alive
+  without immediately unwinding the event loop (as
+  `emscripten_exit_with_live_runtime()` does). (#17160)
 
 3.1.13 - 06/02/2022
 -------------------


### PR DESCRIPTION
Also, bump the minor emscripten version, mostly arbitrarily, but also
because the `main` mangling change is fairly significant and could
arguably be an ABI change (at least for the wasm module itself).