### PR TITLE
Fix binding of dynamically initialized globals.

### DIFF
--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -1885,9 +1885,19 @@ void constant(const char* name, const ConstantType& v) {
         static_cast<double>(asGenericValue(BT::toWireType(v))));
 }
 
-// EMSCRIPTEN_BINDINGS simple creates a static constructor function which
+
+
+
+// EMSCRIPTEN_BINDINGS creates a static struct to initialize the binding which
 // will get included in the program if the translation unit in which it is
-// define gets linked into the program.
-#define EMSCRIPTEN_BINDINGS(name) __attribute__((constructor)) static void __embind_init_##name(void)
+// defined gets linked into the program. Using a C++ constructor here ensures it
+// occurs after any other C++ constructors in this file, which is not true for
+// __attribute__((constructor)) (they run before C++ constructors in the same
+// file).
+#define EMSCRIPTEN_BINDINGS(name)                                              \
+  static struct EmBindInit_##name {                                            \
+    EmBindInit_##name();                                                       \
+  } EmBindInit_##name##_instance;                                              \
+  EmBindInit_##name::EmBindInit_##name()
 
 } // end namespace emscripten

--- a/tests/embind/test_dynamic_initialization.cpp
+++ b/tests/embind/test_dynamic_initialization.cpp
@@ -1,0 +1,20 @@
+// Copyright 2018 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <string>
+#include <emscripten/bind.h>
+#include <emscripten/emscripten.h>
+
+const std::string global_string = "global string";
+
+EMSCRIPTEN_BINDINGS(constants) {
+  emscripten::constant("global_string", global_string);
+}
+
+int main() {
+    EM_ASM(
+        console.log("global_string = " + Module['global_string']);
+    );
+}

--- a/tests/embind/test_dynamic_initialization.out
+++ b/tests/embind/test_dynamic_initialization.out
@@ -1,0 +1,1 @@
+global_string = global string

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7482,6 +7482,11 @@ void* operator new(size_t size) {
     err = self.expect_fail([EMCC, test_file('embind/test_val_assignment.cpp'), '-lembind', '-c'])
     self.assertContained('candidate function not viable: expects an lvalue for object argument', err)
 
+  @no_wasm64('embind does not yet support MEMORY64')
+  def test_embind_dynamic_initialization(self):
+    self.emcc_args += ['-lembind']
+    self.do_run_in_out_file_test('embind/test_dynamic_initialization.cpp')
+
   @no_wasm2js('wasm_bigint')
   @no_wasm64('embind does not yet support MEMORY64')
   def test_embind_i64_val(self):


### PR DESCRIPTION
Embind bindings were being initialized before dynamically initialized
static globals, making it impossible to bind them. This moves the
initialization back into a static struct so the bindings work as expected.

Fixes #16275