### PR TITLE
[EH] Rename EH library functions in JS

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -398,31 +398,36 @@ var LibraryExceptions = {
     return Module['asm']['__cpp_exception'];
   },
 
-  $getCppExceptionThrownValue__deps: ['$getCppExceptionTag', '__thrown_object_from_unwind_exception'],
-  $getCppExceptionThrownValue: function(ex) {
+  // Given an WebAssembly.Exception object, returns the actual user-thrown
+  // C++ object address in the Wasm memory.
+  // WebAssembly.Exception is a JS object representing a Wasm exception,
+  // provided by Wasm JS API:
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception
+  $getCppExceptionThrownObjectFromWebAssemblyException__deps: ['$getCppExceptionTag', '__thrown_object_from_unwind_exception'],
+  $getCppExceptionThrownObjectFromWebAssemblyException: function(ex) {
     // In Wasm EH, the value extracted from WebAssembly.Exception is a pointer
     // to the unwind header. Convert it to the actual thrown value.
-    var unwind_ex = ex.getArg(getCppExceptionTag(), 0);
-    return ___thrown_object_from_unwind_exception(unwind_ex);
+    var unwind_header = ex.getArg(getCppExceptionTag(), 0);
+    return ___thrown_object_from_unwind_exception(unwind_header);
   },
 
-  $incrementExceptionRefcount__deps: ['__cxa_increment_exception_refcount', '$getCppExceptionThrownValue'],
-  $incrementExceptionRefcount: function(obj) {
-    var ptr = getCppExceptionThrownValue(obj);
+  $incrementExceptionRefcount__deps: ['__cxa_increment_exception_refcount', '$getCppExceptionThrownObjectFromWebAssemblyException'],
+  $incrementExceptionRefcount: function(ex) {
+    var ptr = getCppExceptionThrownObjectFromWebAssemblyException(ex);
     ___cxa_increment_exception_refcount(ptr);
   },
 
-  $decrementExceptionRefcount__deps: ['__cxa_decrement_exception_refcount', '$getCppExceptionThrownValue'],
-  $decrementExceptionRefcount: function(obj) {
-    var ptr = getCppExceptionThrownValue(obj);
+  $decrementExceptionRefcount__deps: ['__cxa_decrement_exception_refcount', '$getCppExceptionThrownObjectFromWebAssemblyException'],
+  $decrementExceptionRefcount: function(ex) {
+    var ptr = getCppExceptionThrownObjectFromWebAssemblyException(ex);
     ___cxa_decrement_exception_refcount(ptr);
   },
 
-  $getExceptionMessage__deps: ['__get_exception_message', 'free', '$getCppExceptionThrownValue'],
-  $getExceptionMessage: function(obj) {
+  $getExceptionMessage__deps: ['__get_exception_message', 'free', '$getCppExceptionThrownObjectFromWebAssemblyException'],
+  $getExceptionMessage: function(ex) {
     // In Wasm EH, the thrown object is a WebAssembly.Exception. Extract the
     // thrown value from it.
-    var ptr = getCppExceptionThrownValue(obj);
+    var ptr = getCppExceptionThrownObjectFromWebAssemblyException(ex);
     var utf8_addr = ___get_exception_message(ptr);
     var result = UTF8ToString(utf8_addr);
     _free(utf8_addr);


### PR DESCRIPTION
Terms like 'object' and 'value' were used interchangeably and
inconsistently, causing confusion. This tries to make it more
consistent.

- Thrown object: A user-thrown value in C++, which is a C++ pointer.
  When you do `throw 3;`, libc++abi allocates a storage to store an
  exception and store that value '3' within that storage. This is the
  pointer to that location. This is consistent with the term used by
  libc++abi; which also calls the pointer 'thrown object'. Emscripten EH
  throws this directly, so you get this value right away when you catch
  an exception with JS `catch`. In Wasm EH, which uses libc++abi, this
  is not the value libc++abi actually throws. See below.

- Unwind header: The pointer that actually gets thrown in libc++abi.
  This pointer preceeds the thrown object:
  https://github.com/emscripten-core/emscripten/blob/24f765dc3545e89f232c9f8503f6426055271628/system/lib/libcxxabi/src/cxa_exception.cpp#L26-L28
  This is an internal detail of libc++abi so we don't want to expose
  this to users. Emscripten EH doesn't use this concept.

- WebAssembly exception: A native Wasm exception, represented by
  `WebAssembly.Exception` JS object. This is what is actually gets
  thrown from Wasm `throw` instruction. libunwind receives the unwind
  header pointer (see above) from libc++abi, and create an
  `WebAssembly.Exception` object and package the received value with the
  C++ exception tag, and throws it. So this is what you get when you
  catch a Wasm exception with JS `catch`.

Relevant previous discussion: https://github.com/emscripten-core/emscripten/pull/17157#pullrequestreview-1000439362