### PR TITLE
Add Val Helper

### DIFF
--- a/system/include/emscripten/val_helper.h
+++ b/system/include/emscripten/val_helper.h
@@ -273,6 +273,10 @@ class ValHelper {
   void add(std::array<T, SIZE>&& a) {
     internal::AddArraySpan(a.data(), a.size(), this, true);
   }
+  template <typename T, size_t SIZE>
+  void add(const T(&a)[SIZE]) {
+    internal::AddArraySpan(a, SIZE, this, false);
+  }
 
   void concat_array(const void* a, uint16_t n, TYPE t = TYPE::INT32) {
     cursor_->type = TYPE::ARRAY;
@@ -299,6 +303,10 @@ class ValHelper {
   template <typename T, size_t SIZE>
   void concat(std::array<T, SIZE>&& a) {
     internal::ConcatArraySpan(a.data(), a.size(), this, true);
+  }
+  template <typename T, size_t SIZE>
+  void concat(const T(&a)[SIZE]) {
+    internal::ConcatArraySpan(a, SIZE, this, false);
   }
 
   void finalize() {

--- a/system/include/emscripten/val_helper.h
+++ b/system/include/emscripten/val_helper.h
@@ -1,0 +1,398 @@
+/*
+ * Copyright 2022 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#pragma once
+
+#include <emscripten/val.h>
+
+#include <array>
+#include <assert.h>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+extern "C" {
+void ValHelper_JS(emscripten::EM_VAL h, const void* ptr, int size);
+#ifdef __PERF_VAL_HELPER
+void ValHelperPerf_AuditBufFull(int c, int n, emscripten::EM_VAL h);
+#endif
+}
+
+// ValHelper caches changes and commit them bulkly to the binding val.
+//
+// Why is fast?
+//  1) saving context switches
+//  2) good locality
+//  3) no extra copies
+//
+// Usage:
+//          ValHelper vh(OBJECT);
+//          vh.set("k1", 1);
+//          vh.set("k3", "hello");
+//          vh.set("k2", std::vector<float>{1,2,3,4,5,6,7,8,9});
+//          vh.finalize();
+//
+// Caveats:
+//  1) For sub-scoped objects set/added, preferring finalize inside, or use
+//     std::move if only few ones(1 or 2).
+//          ValHelper vh(ARRAY);
+//          if (condition) {
+//              std::string temp;
+//              generate_string(&temp);
+//              vh.add(std::move(temp));
+//          }
+//  2) When you passed ValHelper as argument, always do finalize() before
+//     leaving the scope as cached pointers may be stale immediately.
+//
+namespace Val {
+
+enum class TYPE : uint8_t {
+    NONE = 0,
+    INT32,
+    UINT32,
+    FLOAT32,
+    FLOAT64,
+    BOOL,
+    STRING,
+    U8STRING,
+    EMVAL,
+    ARRAY,
+    MAX
+};
+
+enum EmValType {
+    OBJECT = 0,  // Default
+    ARRAY,
+};
+
+template<typename T>
+struct map { static constexpr TYPE type = TYPE::NONE; };
+template<> struct map<int> { static constexpr TYPE type = TYPE::INT32; };
+template<> struct map<uint32_t> { static constexpr TYPE type = TYPE::UINT32; };
+template<> struct map<float> { static constexpr TYPE type = TYPE::FLOAT32; };
+template<> struct map<double> { static constexpr TYPE type = TYPE::FLOAT64; };
+template<> struct map<bool> { static constexpr TYPE type = TYPE::BOOL; };
+
+constexpr bool is_supported_array_type(TYPE t) {
+  return (t == TYPE::INT32 || t == TYPE::UINT32 || t == TYPE::FLOAT32 ||
+          t == TYPE::FLOAT64 || t == TYPE::BOOL);
+}
+
+template<typename>
+struct is_std_vector : std::false_type {};
+
+template<typename T, typename... TS>
+struct is_std_vector<std::vector<T, TS...>> : std::true_type {};
+
+template<typename>
+struct is_std_array : std::false_type {};
+
+template<typename T, size_t N>
+struct is_std_array<std::array<T, N>> : std::true_type {};
+
+template <typename T>
+constexpr bool is_supported_rvalue_type() {
+  return std::is_same<T, std::string>::value ||
+         std::is_same<T, emscripten::val>::value ||
+         is_std_vector<T>::value ||
+         is_std_array<T>::value;
+}
+
+// We expect lvalue reference or literals.  For rvalues other than explicitly
+// supported (which is cached or commited instantly), it fails the compiling.
+template <typename V>
+static constexpr bool check_arg_pointer_wont_dangle() {
+  static_assert(
+      (is_supported_rvalue_type<typename std::remove_cv<
+           typename std::remove_reference<V>::type>::type>() ||
+       std::is_lvalue_reference<V>::value || !std::is_class<V>::value),
+      "Expect lvalue or literal, but NO rvalue.");
+  return true;
+}
+
+namespace internal {
+
+template<typename T, typename VH>
+void AddArraySpan(const T* start, size_t n, VH* h, bool commit_now) {
+  if constexpr (is_supported_array_type(map<T>::type)) {
+    // much more efficient way.
+    h->add_array(start, n, map<T>::type);
+    if (commit_now)
+      h->finalize();
+  } else {
+    VH tp(ARRAY);
+    tp.add(start, start + n);
+    h->add(tp);  // always commit
+  }
+}
+
+template<typename T, typename VH>
+void ConcatArraySpan(const T* start, size_t n, VH* h, bool commit_now) {
+  if constexpr (is_supported_array_type(map<T>::type)) {
+    // much more efficient way.
+    h->concat_array(start, n, map<T>::type);
+  } else {
+    h->add(start, start + n);
+  }
+  if (commit_now) h->finalize();
+}
+
+}  // namespace internal
+
+using emscripten::val;
+template <size_t N = 20 /*BUFF_SIZE*/ >
+class ValHelper {
+ public:
+  ValHelper() : ValHelper(OBJECT) {}
+  ~ValHelper() = default;
+
+  // disallow copy & move operations.
+  ValHelper(const ValHelper&) = delete;
+  ValHelper& operator=(const ValHelper&) = delete;
+
+  explicit ValHelper(const val& v) : val_(v) {}
+  explicit ValHelper(EmValType t)
+    : val_(t == ARRAY ? val::array() : val::object()) {}
+
+  template <typename V>
+  void set(const val& k, V&& v) {
+    if constexpr (check_arg_pointer_wont_dangle<V>()) {}
+
+    cursor_->key = (const char*)k.as_handle();
+    cursor_->key_flag = FLAG_VAL_KEY;
+    add(std::forward<V>(v));
+  }
+
+  template <typename V>
+  void set(const char* k, V&& v) {
+    if constexpr (check_arg_pointer_wont_dangle<V>()) {}
+
+    cursor_->key = k;
+    cursor_->key_flag = 0;
+    add(std::forward<V>(v));
+  }
+
+  void add(int v) {
+    cursor_->type = TYPE::INT32;
+    cursor_->value.w[0].i = v;
+    advance_and_may_finalize();
+  }
+  void add(size_t v) {
+    return add(static_cast<unsigned int>(v));
+  }
+  void add(unsigned int v) {
+    cursor_->type = TYPE::UINT32;
+    cursor_->value.w[0].u = v;
+    advance_and_may_finalize();
+  }
+  void add(float v) {
+    cursor_->type = TYPE::FLOAT32;
+    cursor_->value.w[0].f = v;
+    advance_and_may_finalize();
+  }
+  void add(double v) {
+    cursor_->type = TYPE::FLOAT64;
+    cursor_->value.d = v;
+    advance_and_may_finalize();
+  }
+  void add(bool v) {
+    cursor_->type = TYPE::BOOL;
+    cursor_->value.b = v;
+    advance_and_may_finalize();
+  }
+
+  void add(const char* v) {
+    cursor_->type = TYPE::STRING;
+    cursor_->value.w[0].s = v;
+    advance_and_may_finalize();
+  }
+  void add_u8(const char* v) {
+    cursor_->type = TYPE::U8STRING;
+    cursor_->value.w[0].s = v;
+    advance_and_may_finalize();
+  }
+  void add(const std::string& v) {
+    add_u8(v.c_str());
+  }
+  void add(std::string&& v) {
+    auto cached = std::make_unique<std::string>(std::move(v));
+    add_u8(cached->data());
+    if (!cached_strings_.capacity()) cached_strings_.reserve(4);
+    cached_strings_.push_back(std::move(cached));
+  }
+
+  // accept |ValHelper| but only lvalue reference
+  template<size_t SZ>
+  void add(ValHelper<SZ>& vh) {
+    add(vh.toval());
+  }
+  void add(const val& v) {
+    cursor_->type = TYPE::EMVAL;
+    cursor_->value.w[0].v = v.as_handle();
+    advance_and_may_finalize();
+  }
+  void add(val&& v) {
+    if (!cached_vals_.capacity()) cached_vals_.reserve(4);
+    cached_vals_.push_back(std::move(v));  // efficient op
+    add(cached_vals_.back());
+  }
+
+  template <typename Iter>
+  void add(Iter begin, Iter end) {
+    for (auto it = begin; it != end; ++it)
+      add(*it);
+  }
+
+  // Using explicit type
+  void add_array(const void* a, uint16_t n, TYPE t = TYPE::INT32) {
+    cursor_->type = TYPE::ARRAY;
+    cursor_->value.w[0].addr = a;
+    cursor_->value.w[1].item.t = (uint8_t)t;
+    cursor_->value.w[1].item.f = 0;
+    cursor_->value.w[1].item.n = n;
+    advance_and_may_finalize();
+  }
+
+  template <typename T>
+  void add(const std::vector<T>& v) {
+    internal::AddArraySpan(v.data(), v.size(), this, false);
+  }
+  template <typename T>
+  void add(std::vector<T>&& v) {
+    internal::AddArraySpan(v.data(), v.size(), this, true);
+  }
+  template <typename T, size_t SIZE>
+  void add(const std::array<T, SIZE>& a) {
+    internal::AddArraySpan(a.data(), a.size(), this, false);
+  }
+  template <typename T, size_t SIZE>
+  void add(std::array<T, SIZE>&& a) {
+    internal::AddArraySpan(a.data(), a.size(), this, true);
+  }
+
+  void concat_array(const void* a, uint16_t n, TYPE t = TYPE::INT32) {
+    cursor_->type = TYPE::ARRAY;
+    cursor_->value.w[0].addr = a;
+    cursor_->value.w[1].item.t = (uint8_t)t;
+    cursor_->value.w[1].item.f = FLAG_CONCAT;
+    cursor_->value.w[1].item.n = n;
+    advance_and_may_finalize();
+  }
+
+  // Use only for ARRAY type
+  template <typename T>
+  void concat(const std::vector<T>& v) {
+    internal::ConcatArraySpan(v.data(), v.size(), this, false);
+  }
+  template <typename T>
+  void concat(std::vector<T>&& v) {
+    internal::ConcatArraySpan(v.data(), v.size(), this, true);
+  }
+  template <typename T, size_t SIZE>
+  void concat(const std::array<T, SIZE>& a) {
+    internal::ConcatArraySpan(a.data(), a.size(), this, false);
+  }
+  template <typename T, size_t SIZE>
+  void concat(std::array<T, SIZE>&& a) {
+    internal::ConcatArraySpan(a.data(), a.size(), this, true);
+  }
+
+  void finalize() {
+    ValHelper_JS(val_.as_handle(), buffer(), size());
+    reset();
+  }
+
+  size_t size() const { return cursor_ - items_.data(); }
+  bool empty() const { return cursor_ == items_.data(); }
+
+  const val& get_val() const { return val_; }
+
+  val toval() {
+    if (!empty()) finalize();
+    return val_;
+  }
+
+  void reset_val() {
+    assert(empty());
+    val_ = val_.isArray() ? val::array() : val::object();
+  }
+
+  void attach(const val& v) {
+    assert(empty());
+    val_ = v;
+  }
+
+ private:
+  const void* buffer() const { return items_.data(); }
+
+  void reset() {
+    cursor_ = items_.data();
+    cached_vals_.clear();
+    cached_strings_.clear();
+  }
+
+  void advance_and_may_finalize() {
+    cursor_++;
+    if (size() >= N) {
+      finalize();
+
+#ifdef __PERF_VAL_HELPER
+      static uint32_t count = 0;
+      ValHelperPerf_AuditBufFull(++count, N, val_.as_handle());
+#endif
+    }
+  }
+
+  enum { FLAG_CONCAT = 1, FLAG_VAL_KEY = 2 };
+
+  // |Entry| is 16B in length, keep it a POD.
+  struct Entry {
+    TYPE type;  // uint8_t
+    uint8_t key_flag;  // key is emscripten::val
+
+    const char* key;  // key string for OBJECT
+    union {
+      union {
+        int32_t i;
+        uint32_t u;
+        float f;
+        const char* s;
+        emscripten::EM_VAL v;
+        const void* addr;
+        struct {
+          uint8_t t;  // TYPE still
+          uint8_t f;  // FLAG_CONCAT
+          uint16_t n;
+        } item;
+      } w[2];
+      double d;
+      uint64_t u;  // not now
+      bool b;
+    } value;
+  };
+
+  static_assert(alignof(Entry) == 8, "Entry must be 8B aligned");
+  static_assert(sizeof(Entry) == 16, "Entry must be 16B in length");
+
+  // Use fixed-length array instead of vector, as it's used as a buffer.
+  // We will `flush` the buffer on the fly when it got full.
+  std::array<Entry, N> items_;
+
+  // Current slot to use
+  Entry* cursor_ = items_.data();
+
+  // Binding val
+  val val_ = val::null();
+
+  // Transient storage for passed temporary/rvalue arguments.
+  std::vector<val> cached_vals_;
+
+  // In most case we don't use cached buffer, so std::array seems not worthy.
+  std::vector<std::unique_ptr<std::string>> cached_strings_;
+};
+
+}  // namespace Val

--- a/system/lib/embind/val_helper.cpp
+++ b/system/lib/embind/val_helper.cpp
@@ -1,0 +1,75 @@
+#include <emscripten.h>
+#include <emscripten/val.h>
+
+// We use EM_JS to push all the data to val in oneshot.
+EM_JS(void, ValHelper_JS, (emscripten::EM_VAL o, const void* ptr, int size), {
+    o = Emval.toValue(o);
+    var is_array = (o instanceof Array);
+    for (var i = 0; i < size; i++) {
+        var t = HEAPU8[ptr];
+        var val_k = !!HEAPU8[(ptr + 1)];
+        var k = HEAP32[(ptr >> 2) + 1];
+        ptr += 8;
+        var v;
+        var skip = false;
+        switch (t) {
+            case 1:  // INT32
+                v = HEAP32[(ptr >> 2)]; break;
+            case 2:  // UINT32
+                v = HEAPU32[(ptr >> 2)]; break;
+            case 3:  // FLOAT32
+                v = HEAPF32[(ptr >> 2)]; break;
+            case 4:  // FLOAT64
+                v = HEAPF64[(ptr >> 3)]; break;
+            case 5:  // BOOL
+                v = !!HEAPU8[ptr]; break;
+            case 6:  // STRING
+                v = readLatin1String(HEAP32[(ptr >> 2)]); break;
+            case 7:  // U8STRING
+                v = UTF8ToString(HEAP32[(ptr >> 2)]); break;
+            case 8:  // EMVAL
+                v = Emval.toValue(HEAP32[(ptr >> 2)]); break;
+            case 9: {  // ARRAY
+                var ad = HEAP32[(ptr >> 2)];
+                var ty = HEAPU8[(ptr + 4)];
+                var con = !!HEAPU8[(ptr + 5)];
+                var n = HEAPU16[(ptr >> 1) + 3];
+                var heap;
+                switch (ty) {
+                    case 1: ad >>= 2; heap = HEAP32;  break;  // INT32
+                    case 2: ad >>= 2; heap = HEAPU32; break;  // UINT32
+                    case 3: ad >>= 2; heap = HEAPF32; break;  // FLOAT32
+                    case 4: ad >>= 3; heap = HEAPF64; break;  // FLOAT64
+                    case 5:           heap = HEAPU8;  break;  // BOOL
+                    default: skip = true; break;
+                }
+                if (!skip) {
+                    v = [];
+                    if (ty == 5) {  // BOOL(Byte)
+                        for (var j = 0; j < n; j++) v[j] = !!heap[ad+j];
+                    } else {
+                        for (var j = 0; j < n; j++) v[j] = heap[ad+j];
+                    }
+                    if (con) {
+                        o.push(...v);
+                        skip = true;
+                    }
+                }
+                break;
+            }
+            default: skip = true; break;
+        }
+        ptr += 8;  // Always advance the ptr
+        if (skip) continue;
+        if (is_array) {
+            o.push(v);
+        } else {
+            k = val_k ? Emval.toValue(k) : readLatin1String(k);
+            o[k] = v;
+        }
+    }
+});
+
+EM_JS(void, ValHelperPerf_AuditBufFull, (int c, int n, emscripten::EM_VAL o), {
+    console.log("valhelper buffer full times: " + c, n);
+});

--- a/tests/embind/test_val_helper.cpp
+++ b/tests/embind/test_val_helper.cpp
@@ -1,0 +1,391 @@
+
+#include <array>
+#include <emscripten.h>
+#include <emscripten/val.h>
+#include <emscripten/val_helper.h>
+#include <malloc.h>
+#include <iostream>
+#include <stdio.h>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+using namespace emscripten;
+
+namespace Val {
+using VH = ValHelper<32>;
+}
+
+namespace {
+
+unsigned int get_used_memory() {
+  struct mallinfo i = ::mallinfo();
+  unsigned int dynamicTop = (unsigned int)sbrk(0);
+  return dynamicTop - i.fordblks;
+}
+
+}  // namespace
+
+namespace std {
+
+template <class T, std::size_t N>
+constexpr std::size_t size(const T (&array)[N]) noexcept
+{
+    return N;
+}
+
+}
+
+void fail() { std::cout << "fail\n"; }
+
+void pass() { std::cout << "pass\n"; }
+
+void test(std::string message) { std::cout << "test:\n" << message << "\n"; }
+
+void ensure(bool value) {
+  if (value)
+    pass();
+  else
+    fail();
+}
+
+void ensure_not(bool value) { ensure(!value); }
+
+void ensure_js(std::string js_code) {
+  ensure(emscripten_run_script_int(js_code.c_str()));
+}
+
+void ensure_js_not(std::string js_code) {
+  js_code.insert(0, "!( ");
+  js_code.append(" )");
+  ensure_js(js_code);
+}
+
+namespace tests {
+
+const char LONG_S[] =
+    "Class Template Argument Deduction (CTAD) is a C++17 Core Language feature "
+    "that reduces code verbosity. C++17’s Standard Library also supports CTAD, "
+    "so after upgrading your toolset, you can take advantage of this new "
+    "feature when using STL types like std::pair and std::vector. Class "
+    "templates in other libraries and your own code will partially benefit "
+    "from CTAD automatically, but sometimes they’ll need a bit of new code "
+    "(deduction guides) to fully benefit. Fortunately, both using CTAD and "
+    "providing deduction guides is pretty easy, despite template "
+    "metaprogramming’s fearsome reputation!";
+
+const int BIG_A[] = {
+    0x01, 0x61, 0x01, 0x63, 0x00, 0x07, 0x01, 0x61, 0x01, 0x64, 0x00, 0x01,
+    0x01, 0x61, 0x01, 0x65, 0x00, 0x01, 0x01, 0x61, 0x01, 0x66, 0x00, 0x0C,
+    0x01, 0x61, 0x01, 0x67, 0x00, 0x02, 0x01, 0x61, 0x01, 0x68, 0x00, 0x04,
+    0x01, 0x61, 0x01, 0x69, 0x00, 0x01, 0x01, 0x61, 0x01, 0x6A, 0x00, 0x01,
+    0x01, 0x61, 0x06, 0x6D, 0x65, 0x6D, 0x6F, 0x72, 0x79, 0x02, 0x01, 0x80,
+    0x02, 0x80, 0x80, 0x02, 0x01, 0x61, 0x05, 0x74, 0x61, 0x62, 0x6C, 0x65,
+    0x01, 0x70, 0x00, 0xF7, 0x02, 0x03, 0xBF, 0x06, 0xBD, 0x06, 0x00, 0x08,
+    0x06, 0x06, 0x04, 0x06, 0x06, 0x58, 0x0B, 0x00, 0x1F, 0x16, 0x5A, 0x02,
+    0x13, 0x02, 0x0F, 0x02, 0x02, 0x01, 0x16, 0x04, 0x02, 0x0B, 0x3C, 0x14,
+    0x02, 0x29, 0x02, 0x54, 0x0C, 0x06, 0x18, 0x1C, 0x02, 0x04, 0x2F, 0x14,
+    0x28, 0x01, 0x21, 0x00, 0x2C, 0x0C, 0x16, 0x2C, 0x0C, 0x02, 0x15, 0x04,
+    0x06, 0x2F, 0x0C, 0x00, 0x06, 0x32, 0x02, 0x01, 0x02, 0x06, 0x1B, 0x22,
+    0x0F, 0x28, 0x04, 0x49, 0x18, 0x1C, 0x06, 0x10, 0x42, 0x14, 0x02, 0x11,
+    0x00, 0x01, 0x02, 0x01, 0x0F, 0x04, 0x23, 0x29, 0x53, 0x00, 0x01, 0x14,
+    0x04, 0x01, 0x0F, 0x13, 0x09, 0x17, 0x0B, 0x2D, 0x3F, 0x06, 0x02, 0x00,
+    0x56, 0x11, 0x02, 0x14, 0x35, 0x06, 0x04, 0x06, 0x40, 0x0C, 0x55, 0x20,
+    0x06, 0x09, 0x09, 0x04, 0x02, 0x2B, 0x11, 0x2B, 0x19, 0x05, 0x18, 0x19,
+    0x22, 0x27, 0x04, 0x50, 0x04, 0x0F, 0x01, 0x01, 0x13, 0x3A, 0x18, 0x10,
+    0x28, 0x00, 0x31, 0x07, 0x22, 0x01, 0x00, 0x02, 0x02, 0x05, 0x00, 0x03,
+    0x02, 0x01, 0x07, 0x36, 0x1A, 0x1B, 0x0C, 0x01, 0x04, 0x04, 0x19, 0x0C,
+    0x00, 0x18, 0x00, 0x13, 0x47, 0x19, 0x52, 0x3D, 0x02, 0x18, 0x5C, 0x15,
+    0x0D, 0x08, 0x00, 0x00, 0x07, 0x04, 0x02, 0x23, 0x01, 0x01, 0x16, 0x06,
+    0x04, 0x02, 0x02, 0x24, 0x24, 0x0D, 0x01, 0x00, 0x34, 0x14, 0x0B, 0x19,
+    0x21, 0x02, 0x05, 0x01, 0x45, 0x00, 0x00, 0x03, 0x06, 0x02, 0x1A, 0x07,
+    0x07, 0x51, 0x1C, 0x01, 0x04, 0x06, 0x23, 0x13, 0x04, 0x46, 0x06, 0x01,
+    0x01, 0x0C, 0x02, 0x23, 0x0C, 0x02, 0x04, 0x03, 0x00, 0x0C, 0x02, 0x01,
+    0x01, 0x13, 0x09, 0x01, 0x0C, 0x0C, 0x01, 0x02, 0x48, 0x11, 0x4C, 0x1E,
+    0x0A, 0x19, 0x00, 0x44, 0x57, 0x03, 0x33, 0x01, 0x25, 0x2D, 0x33, 0x24,
+    0x03, 0x43, 0x15, 0x0F, 0x18, 0x1B, 0x13, 0x09, 0x04, 0x00, 0x1C, 0x1A,
+};
+
+const std::vector<int> veci{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20};
+
+void test_val() {
+  val v = val::object();
+  v.set("key1", 1);
+  v.set("key2", 2);
+  v.set("key3", "333333333333333333333333");
+  v.set("key4", 6.69884350);
+  v.set("key5", true);
+  std::string s("hello world!!");
+  v.set("key6", s);
+  val v1 = val(1000.1);
+  v.set("key7", v1);
+  v.set("key8", val::array(std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+                                            12, 13, 14, 15}));
+  v.set("key9", val::array(std::vector<float>{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7,
+                                              8.8, 9.9}));
+  v.set("key11", "jjk");
+  auto ls =
+      std::string("a long long long long long long long long string!!!!!");
+  v.set("key12", ls);
+  v.set("long_value", LONG_S);
+  std::vector<int> biga(BIG_A, BIG_A + std::size(BIG_A));
+  v.set("big_array", val::array(biga));
+
+  // embed an array
+  val ar = val::array();
+  ar.call<void>("push", std::string("string1"));
+  ar.call<void>("push", std::string("string2"));
+  ar.call<void>("push", std::string("string3"));
+  ar.call<void>("push", std::string("string4"));
+  ar.call<void>("push", ls);
+  for (auto i : veci)
+    ar.call<void>("push", i);
+  v.set("key_array", ar);
+
+  // embed an object
+  val ob = val::object();
+  ob.set("subkey1", 1);
+  ob.set("subkey2", 1.0f);
+  ob.set("subkey3", 9.9);
+  ob.set("subkey4", "substring1");
+  ob.set("subkey5", std::string("substring2"));
+  v.set("key_object", ob);
+
+  // EM_ASM({console.log(Emval.toValue($0));}, v.as_handle());
+}
+
+void test_valhelper() {
+  Val::VH v;
+  v.set("key1", 1);
+  v.set("key2", 2);
+  v.set("key3", "333333333333333333333333");
+  v.set("key4", 6.69884350);
+  v.set("key5", true);
+  std::string s("hello world!!");
+  v.set("key6", s);
+  v.set("key7", 1000.1);
+  auto vec =
+      std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+  v.set("key8", vec);
+  auto vecf = std::vector<float>{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9};
+  v.set("key9", vecf);
+  v.set("key11", "jjk");
+  std::string ls("a long long long long long long long long string!!!!!");
+  v.set("key12", ls);
+  v.set("long_value", LONG_S);
+  std::vector<int> biga(BIG_A, BIG_A + std::size(BIG_A));
+  v.set("big_array", biga);
+
+  // embed an array
+  Val::VH ar(Val::ARRAY);
+  std::vector<std::string> vs{"string1", "string2", "string3", "string4", ls};
+  ar.concat(vs);
+  ar.concat(veci);
+  v.set("key_array", ar.toval());
+
+  // embed an object
+  Val::VH ob;
+  ob.set("subkey1", 1);
+  ob.set("subkey2", 1.0f);
+  ob.set("subkey3", 9.9);
+  std::string ss1("substring1");
+  ob.set("subkey4", ss1);
+  std::string ss2("substring2");
+  ob.set("subkey5", ss2);
+  v.set("key_object", ob.toval());
+
+  v.finalize();
+  // EM_ASM({console.log(Emval.toValue($0));}, v.toval().as_handle());
+}
+
+// test_val loop 100000 cost: 1340.400000
+// test_valhelper loop 100000 cost: 609.800000
+
+// WITH LONG_S & BIG_A
+// test_val loop 100000 cost: 5737.500000
+// test_valhelper loop 100000 cost: 1155.300000
+
+void test_time_perf() {
+  const size_t LoopTimes = 100000;
+  double start = emscripten_get_now();
+  for (size_t i = 0; i < LoopTimes; i++) {
+    test_val();
+  }
+  printf("test_val loop %zu cost: %f\n", LoopTimes, emscripten_get_now() - start);
+
+  start = emscripten_get_now();
+  for (size_t i = 0; i < LoopTimes; i++) {
+    test_valhelper();
+  }
+  printf("test_valhelper loop %zu cost: %f\n", LoopTimes, emscripten_get_now() - start);
+}
+
+void test_cases() {
+  printf("start\n");
+
+  test("add() overloads");
+  EM_ASM(
+    a = [];
+  );
+  Val::VH va(val::global("a"));
+  va.add(1);
+  va.add(1.1);
+  va.add((char)3);
+  va.add((uint8_t)4);
+  va.add((uint32_t)-1);
+  va.add(1.0f);
+  va.add((float)1.1);
+  va.finalize();
+  ensure_js("a[0] == 1");
+  ensure_js("a[1] == 1.1");
+  ensure_js("a[2] == 3");
+  ensure_js("a[3] == 4");
+  ensure_js("a[4] == 4294967295");  // (unsigned)-1
+  ensure_js("a[5] == 1.0");
+  ensure_js("parseFloat(a[6]).toFixed(1) == 1.1");
+
+  va.add("hello");
+  va.add(std::string("world"));
+  va.add(val::array());
+  va.finalize();
+  ensure_js("a[7] == 'hello'");
+  ensure_js("a[8] == 'world'");
+  ensure_js("Array.isArray(a[9]) && a[9].length == 0");
+
+  test("add(array)");
+  EM_ASM(
+    a = [];
+  );
+  va.attach(val::global("a"));
+  std::vector<int> vec{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  va.add(vec);
+  va.add(std::vector<int>{5, 6, 7, 8, 9});
+  va.add(std::vector<std::string>{"1", "2", "3"});
+  std::vector<std::string> vs{"1", "2", "3"};
+  va.add(vs);
+  std::array<int, 5> ar{1, 2, 3, 4, 5};
+  va.add(ar);
+  std::array<std::string, 5> ar1{"4", "5", "6", "99"};
+  va.add(ar1);
+  va.finalize();
+  ensure_js("a[0].length == 16 && a[0][0] == 1 && a[0][2] == 3 && a[0][15] == 16");
+  ensure_js("a[1].length == 5 && a[1][0] == 5 && a[1][1] == 6 && a[1][5] == undefined");
+  ensure_js("a[2].length == 3 && a[2][0] == '1' && a[2][1] == '2' && a[2][2] == '3' ");
+  ensure_js("a[3].length == 3 && a[3][0] == '1' && a[3][1] == '2' && a[3][2] == '3' ");
+  ensure_js("a[4].length == 5 && a[4][0] == 1 && a[4][1] == 2 && a[4][4] == 5");
+  ensure_js("a[5].length == 5 && a[5][0] == '4' && a[5][1] == '5' && a[5][2] == '6' && a[5][3] == '99' && a[5][4] == ''");
+
+  test("concat(array&)");
+  EM_ASM(
+    a = [];
+
+  );
+  va.attach(val::global("a"));
+  va.add(0);
+  va.concat(vec);
+  va.finalize();
+  ensure_js("a[0] == 0");
+  ensure_js("a[1] == 1 && a[2] == 2 && a[3] == 3 && a[16] == 16");
+  ensure_js("a[17] === undefined");
+
+  va.concat(std::vector<std::string>{"1", "2", "3", "4", "5", "6"});                                                                                                                                                                                                                                                                         
+  va.concat(std::vector<float>{1.1,1.2,1.3});
+  va.concat(std::vector<short>{1,2,3});                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+  va.finalize();
+  ensure_js("a[17] == '1' && a[18] == '2' && a[19] == '3' && a[20] == '4'");
+  // Floating number is not accurate
+  ensure_js("parseFloat(a[23]).toFixed(1) == '1.1' ");
+  ensure_js("parseFloat(a[24]).toFixed(1) == '1.2' ");
+  ensure_js("parseFloat(a[25]).toFixed(1) == '1.3' ");
+  ensure_js("a[26] == 1 && a[27] == 2 && a[28] == 3");
+
+  test("set(k,v)");
+  EM_ASM(
+    a = {};
+  );
+  Val::VH vo(val::global("a"));
+  vo.set("k1", 1);
+  vo.set("k2", 1.1);
+  vo.set("k3", "hi");
+  vo.set("k4", std::string("world"));
+  vo.set("k5", (uint16_t)5);
+  val a("ka");
+  vo.set(a, "value_a");
+  vo.finalize();
+  ensure_js("a.k1 == 1");
+  ensure_js("a.k2 == 1.1");
+  ensure_js("a.k3 == 'hi'");
+  ensure_js("a.k4 == 'world'");
+  ensure_js("a.k5 == 5");
+  ensure_js("a.ka == 'value_a'");
+
+  test("set(k, array)");
+  vo.set("k6", vec);
+  vo.set("k7", std::vector<float>{1, 2, 3, 4, 5, 6});
+  vo.finalize();
+  ensure_js("a.k6 instanceof Array && a.k6.length == 16");
+  ensure_js("a.k6[0] == 1 && a.k6[1] == 2 && a.k6[9] == 10 && a.k6[15] == 16");
+  ensure_js("a.k7 instanceof Array && a.k7.length == 6");
+  ensure_js("a.k7[0] == 1 && a.k7[1] == 2 && a.k7[2] == 3 && a.k7[5] == 6");
+
+  test("set(k, VH)");
+  Val::VH vha(Val::ARRAY);
+  vha.add(1);
+  vo.set("k8", vha);
+  vo.finalize();
+  ensure_js("a['k8'] instanceof Array && a['k8'][0] == 1");
+
+  Val::VH vho(Val::OBJECT);
+  vho.set("k1", 2);
+  vho.set("k2", "v2");
+  vo.set("k9", vho);
+  vo.finalize();
+  ensure_js("a['k9'] instanceof Object");
+  ensure_js("a['k9']['k1'] == 2");
+  ensure_js("a['k9']['k2'] == 'v2'");
+
+  test("use local scope values");
+  {
+    std::string s1;
+    vo.set("ks1", std::move(s1));
+    std::string s2("abc");
+    vo.set("ks2", std::move(s2));
+    std::string s3("def");
+    vo.set("ks3", std::move(s3));
+  }
+  vo.finalize();
+  ensure_js("a.ks1 == ''");
+  ensure_js("a.ks2 == 'abc'");
+  ensure_js("a.ks3 == 'def'");
+
+  test("use local emscripten::val");
+  {
+    val o = val::object();
+    o.set("k1", 1);
+    o.set("k2", "a");
+    val a = val::array();
+    a.call<void>("push", 1);
+    a.call<void>("push", 2);
+    vo.set("o", std::move(o));
+    vo.set("a", std::move(a));
+  }
+  vo.finalize();
+  ensure_js("a.o.k1 == 1");
+  ensure_js("a.o.k2 == 'a'");
+  ensure_js("a.a[0]== 1 && a.a[1] == 2");
+
+  printf("end\n");
+}
+
+}  // namespace tests
+
+int main() {
+  auto m1 = get_used_memory();
+  tests::test_cases();
+  auto m2 = get_used_memory();
+  assert(m1 == m2);
+
+  // tests::test_time_perf();
+  return 0;
+}

--- a/tests/embind/test_val_helper.cpp
+++ b/tests/embind/test_val_helper.cpp
@@ -206,7 +206,7 @@ void test_valhelper() {
 // test_val loop 100000 cost: 5737.500000
 // test_valhelper loop 100000 cost: 1155.300000
 
-void test_time_perf() {
+void test_perf() {
   const size_t LoopTimes = 100000;
   double start = emscripten_get_now();
   for (size_t i = 0; i < LoopTimes; i++) {
@@ -219,6 +219,26 @@ void test_time_perf() {
     test_valhelper();
   }
   printf("test_valhelper loop %zu cost: %f\n", LoopTimes, emscripten_get_now() - start);
+}
+
+// loop 100000 val biga cost: 4519.156967
+// loop 100000 VH biga cost: 214.419598
+void test_perf_biga() {
+  const size_t LoopTimes = 100000;
+  double start = emscripten_get_now();
+  for (size_t i = 0; i < LoopTimes; i++) {
+    val vo = val::object();
+    vo.set("k", val::array(BIG_A, BIG_A+std::size(BIG_A)));
+  }
+  printf("loop %zu val biga cost: %f\n", LoopTimes, emscripten_get_now() - start);
+
+  start = emscripten_get_now();
+  for (size_t i = 0; i < LoopTimes; i++) {
+    Val::VH vo;
+    vo.set("k", BIG_A);
+    vo.finalize();
+  }
+  printf("loop %zu VH biga cost: %f\n", LoopTimes, emscripten_get_now() - start);
 }
 
 void test_cases() {
@@ -386,6 +406,7 @@ int main() {
   auto m2 = get_used_memory();
   assert(m1 == m2);
 
-  // tests::test_time_perf();
+  // tests::test_perf();
+  // tests::test_perf_biga();
   return 0;
 }

--- a/tests/embind/test_val_helper.out
+++ b/tests/embind/test_val_helper.out
@@ -1,0 +1,62 @@
+start
+test:
+add() overloads
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+test:
+add(array)
+pass
+pass
+pass
+pass
+pass
+pass
+test:
+concat(array&)
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+test:
+set(k,v)
+pass
+pass
+pass
+pass
+pass
+pass
+test:
+set(k, array)
+pass
+pass
+pass
+pass
+test:
+set(k, VH)
+pass
+pass
+pass
+pass
+test:
+use local scope values
+pass
+pass
+pass
+test:
+use local emscripten::val
+pass
+pass
+pass
+end

--- a/tests/embind/test_val_helper.out
+++ b/tests/embind/test_val_helper.out
@@ -11,8 +11,10 @@ pass
 pass
 pass
 pass
+pass
 test:
 add(array)
+pass
 pass
 pass
 pass
@@ -37,8 +39,11 @@ pass
 pass
 pass
 pass
+pass
 test:
 set(k, array)
+pass
+pass
 pass
 pass
 pass

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7478,6 +7478,11 @@ void* operator new(size_t size) {
     self.do_run_in_out_file_test('embind/test_val.cpp')
 
   @no_wasm64('embind does not yet support MEMORY64')
+  def test_embind_val_helper(self):
+    self.emcc_args += ['-lembind']
+    self.do_run_in_out_file_test('embind/test_val_helper.cpp')
+
+  @no_wasm64('embind does not yet support MEMORY64')
   def test_embind_val_assignment(self):
     err = self.expect_fail([EMCC, test_file('embind/test_val_assignment.cpp'), '-lembind', '-c'])
     self.assertContained('candidate function not viable: expects an lvalue for object argument', err)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1473,7 +1473,9 @@ class libembind(Library):
     return name
 
   def get_files(self):
-    return [utils.path_from_root('system/lib/embind/bind.cpp')]
+    return files_in_path(
+        path='system/lib/embind',
+        filenames=['bind.cpp', 'val_helper.cpp'])
 
   @classmethod
   def get_default_variation(cls, **kwargs):


### PR DESCRIPTION
val is great to operate with Javascript objects on C++ side.  While if there is a large
number of data need set to the JS object behind the val, or make changes to val
very frequently, val doesn’t offer best performance. 

The val_helper is designed for this scenario specially by caching multiple operations
and commit them in bulk. Moreover, for arrays or strings (or any continuous memory
structs), memory address/pointer is used directly in JS side to avoid serializing the
contents.

Benchmarking tests show that val_helper is much faster in some cases, and is a bit
simpler comparing val.
