### PR TITLE
[WasmFS] Move O_TRUNC handling to avoid crash

### DIFF
--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -465,6 +465,8 @@ static __wasi_fd_t doOpen(path::ParsedParent parsed,
     return -EEXIST;
   }
 
+  // Note that we open the file before truncating it because some backends may
+  // depend on that (e.g. OPFS).
   auto openFile = std::make_shared<OpenFileState>(0, flags, child);
 
   // If O_TRUNC, truncate the file if possible.

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -465,6 +465,8 @@ static __wasi_fd_t doOpen(path::ParsedParent parsed,
     return -EEXIST;
   }
 
+  auto openFile = std::make_shared<OpenFileState>(0, flags, child);
+
   // If O_TRUNC, truncate the file if possible.
   if ((flags & O_TRUNC) && child->is<DataFile>()) {
     if (fileMode & WASMFS_PERM_WRITE) {
@@ -474,7 +476,6 @@ static __wasi_fd_t doOpen(path::ParsedParent parsed,
     }
   }
 
-  auto openFile = std::make_shared<OpenFileState>(0, flags, child);
   return wasmFS.getFileTable().locked().addEntry(openFile);
 }
 

--- a/tests/wasmfs/wasmfs_opfs.c
+++ b/tests/wasmfs/wasmfs_opfs.c
@@ -123,6 +123,16 @@ int main(int argc, char* argv[]) {
   assert(stat_buf.st_size == 1);
   emscripten_console_log("statted");
 
+  fd = open("/opfs/working/foo.txt", O_RDONLY | O_TRUNC);
+  assert(fd > 0);
+  emscripten_console_log("truncated while opening");
+  close(fd);
+
+  err = stat("/opfs/working/foo.txt", &stat_buf);
+  assert(err == 0);
+  assert(stat_buf.st_size == 0);
+  emscripten_console_log("statted");
+
   err = rename("/opfs/working/foo.txt", "/opfs/foo.txt");
   assert(err == 0);
   err = access("/opfs/working/foo.txt", F_OK);

--- a/tests/wasmfs/wasmfs_opfs.c
+++ b/tests/wasmfs/wasmfs_opfs.c
@@ -121,7 +121,7 @@ int main(int argc, char* argv[]) {
   err = stat("/opfs/working/foo.txt", &stat_buf);
   assert(err == 0);
   assert(stat_buf.st_size == 1);
-  emscripten_console_log("statted");
+  emscripten_console_log("statted while closed");
 
   fd = open("/opfs/working/foo.txt", O_RDONLY | O_TRUNC);
   assert(fd > 0);
@@ -131,7 +131,7 @@ int main(int argc, char* argv[]) {
   err = stat("/opfs/working/foo.txt", &stat_buf);
   assert(err == 0);
   assert(stat_buf.st_size == 0);
-  emscripten_console_log("statted");
+  emscripten_console_log("statted after truncation");
 
   err = rename("/opfs/working/foo.txt", "/opfs/foo.txt");
   assert(err == 0);


### PR DESCRIPTION
WasmFS backends like OPFS may reasonably expect that files will only be modified
while open and may be unprepared to modify unopened files. However, when
handling O_TRUNC, we truncated files before opening them in the backend. For the
OPFS backend in particular, this caused a crash because the backend did not yet
have an AccessHandle for the file. Fix the problem by deferring O_TRUNC handling
until after we have asked the backend to open the file.