### PR TITLE
Remove shared.PYTHON. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1104,7 +1104,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     args = [x for x in args if x != '--cflags']
     with misc_temp_files.get_file(suffix='.o') as temp_target:
       input_file = 'hello_world.c'
-      cmd = [shared.PYTHON, "-E", sys.argv[0], utils.path_from_root('tests', input_file), '-v', '-c', '-o', temp_target] + args
+      compiler = shared.EMCC
+      if run_via_emxx:
+        compiler = shared.EMXX
+      cmd = [compiler, utils.path_from_root('tests', input_file), '-v', '-c', '-o', temp_target] + args
       proc = run_process(cmd, stderr=PIPE, check=False)
       if proc.returncode != 0:
         print(proc.stderr)

--- a/tests/benchmark_sse.py
+++ b/tests/benchmark_sse.py
@@ -15,14 +15,16 @@ from subprocess import Popen
 __rootpath__ = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(__rootpath__)
 
-from tools.shared import PYTHON, WINDOWS, CLANG_CXX, EMCC, PIPE, V8_ENGINE
-from tools.shared import path_from_root, run_process, test_file
+from tools.shared import WINDOWS, CLANG_CXX, EMCC, PIPE
+from tools.shared import run_process
+from tools.config import V8_ENGINE
+from tests.common import EMRUN, test_file
 import clang_native
 
 temp_dir = tempfile.mkdtemp()
 
 # System info
-system_info = Popen([PYTHON, path_from_root('emrun'), '--system_info'], stdout=PIPE, stderr=PIPE).communicate()
+system_info = Popen([EMRUN, '--system_info'], stdout=PIPE, stderr=PIPE).communicate()
 
 # Native info
 native_info = Popen(['clang', '-v'], stdout=PIPE, stderr=PIPE).communicate()

--- a/tests/common.py
+++ b/tests/common.py
@@ -78,8 +78,10 @@ WEBIDL_BINDER = shared.bat_suffix(path_from_root('tools/webidl_binder'))
 
 EMBUILDER = shared.bat_suffix(path_from_root('embuilder'))
 EMMAKE = shared.bat_suffix(path_from_root('emmake'))
+EMRUN = shared.bat_suffix(shared.path_from_root('emrun'))
 WASM_DIS = Path(building.get_binaryen_bin(), 'wasm-dis')
 LLVM_OBJDUMP = os.path.expanduser(shared.build_llvm_tool_path(shared.exe_suffix('llvm-objdump')))
+PYTHON = sys.executable
 
 
 def delete_contents(pathname):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -22,7 +22,7 @@ from urllib.request import urlopen
 
 from common import BrowserCore, RunnerCore, path_from_root, has_browser, EMTEST_BROWSER, Reporting
 from common import create_file, parameterized, ensure_dir, disabled, test_file, WEBIDL_BINDER
-from common import read_file, requires_v8, also_with_minimal_runtime
+from common import read_file, requires_v8, also_with_minimal_runtime, EMRUN
 from tools import shared
 from tools import ports
 from tools.shared import EMCC, WINDOWS, FILE_PACKAGER, PIPE
@@ -5402,9 +5402,6 @@ window.close = function() {
 
   def test_full_js_library_strict(self):
     self.btest_exit(test_file('hello_world.c'), args=['-sINCLUDE_FULL_LIBRARY', '-sSTRICT_JS'])
-
-
-EMRUN = path_from_root('emrun')
 
 
 class emrun(RunnerCore):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
   raise Exception('do not run this file directly; do something like: tests/runner')
 
 from tools.shared import try_delete, PIPE
-from tools.shared import PYTHON, EMCC, EMAR
+from tools.shared import EMCC, EMAR
 from tools.utils import WINDOWS, MACOS, write_file
 from tools import shared, building, config, webassembly
 import common
@@ -28,7 +28,7 @@ from common import RunnerCore, path_from_root, requires_native_clang, test_file,
 from common import skip_if, needs_dylink, no_windows, no_mac, is_slow_test, parameterized
 from common import env_modify, with_env_modify, disabled, node_pthreads, also_with_wasm_bigint
 from common import read_file, read_binary, requires_v8, requires_node
-from common import NON_ZERO, WEBIDL_BINDER, EMBUILDER
+from common import NON_ZERO, WEBIDL_BINDER, EMBUILDER, PYTHON
 import clang_native
 
 # decorators for limiting which modes a test can run in

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -29,13 +29,13 @@ if __name__ == '__main__':
   raise Exception('do not run this file directly; do something like: tests/runner other')
 
 from tools.shared import try_delete, config
-from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, PYTHON, FILE_PACKAGER, WINDOWS
+from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, FILE_PACKAGER, WINDOWS
 from tools.shared import CLANG_CC, CLANG_CXX, LLVM_AR, LLVM_DWARFDUMP, LLVM_DWP, EMCMAKE, EMCONFIGURE
 from common import RunnerCore, path_from_root, is_slow_test, ensure_dir, disabled, make_executable
 from common import env_modify, no_mac, no_windows, requires_native_clang, with_env_modify
 from common import create_file, parameterized, NON_ZERO, node_pthreads, TEST_ROOT, test_file
 from common import compiler_for, read_file, read_binary, EMBUILDER, requires_v8, requires_node
-from common import also_with_minimal_runtime, also_with_wasm_bigint, EMTEST_BUILD_VERBOSE
+from common import also_with_minimal_runtime, also_with_wasm_bigint, EMTEST_BUILD_VERBOSE, PYTHON
 from tools import shared, building, utils, deps_info, response_file
 import common
 import jsrun

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -17,9 +17,9 @@ if __name__ == '__main__':
 import clang_native
 import common
 from common import BrowserCore, no_windows, create_file, test_file, read_file
-from common import parameterized, requires_native_clang
+from common import parameterized, requires_native_clang, PYTHON
 from tools import shared, config, utils
-from tools.shared import PYTHON, EMCC, path_from_root, run_process, CLANG_CC
+from tools.shared import EMCC, path_from_root, run_process, CLANG_CC
 
 npm_checked = False
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -22,7 +22,7 @@ from . import shared
 from . import webassembly
 from . import config
 from . import utils
-from .shared import CLANG_CC, CLANG_CXX, PYTHON
+from .shared import CLANG_CC, CLANG_CXX
 from .shared import LLVM_NM, EMCC, EMAR, EMXX, EMRANLIB, WASM_LD, LLVM_AR
 from .shared import LLVM_LINK, LLVM_OBJCOPY
 from .shared import try_delete, run_process, check_call, exit_with_error
@@ -1432,7 +1432,7 @@ def emit_wasm_source_map(wasm_file, map_file, final_wasm):
   # source file paths must be relative to the location of the map (which is
   # emitted alongside the wasm)
   base_path = os.path.dirname(os.path.abspath(final_wasm))
-  sourcemap_cmd = [PYTHON, "-E", path_from_root('tools/wasm-sourcemap.py'),
+  sourcemap_cmd = [sys.executable, '-E', path_from_root('tools/wasm-sourcemap.py'),
                    wasm_file,
                    '--dwarfdump=' + LLVM_DWARFDUMP,
                    '-o',  map_file,

--- a/tools/emcoverage.py
+++ b/tools/emcoverage.py
@@ -42,13 +42,12 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def main():
-  # We hack sys.executable to point to this file, which is executable via #! line.
-  # Emscripten uses sys.executable to populate shared.PYTHON, which is used to
-  # invoke all python subprocesses. By making this script run all python subprocesses,
-  # all of them will execute under the watchful eye of emcoverage.py, and resulting
-  # in their code coverage being tracked.
-  sys.executable = os.path.abspath(__file__)
-  os.environ['EMSDK_PYTHON'] = sys.executable
+  # We set EMSDK_PYTHON to point to this file, which is executable via #! line.
+  # Emscripten uses EMSDK_PYTHON to invoke all python subprocesses. By making this
+  # script run all python subprocesses, all of them will execute under the
+  # watchful eye of emcoverage.py, and resulting in their code coverage being
+  # tracked.
+  os.environ['EMSDK_PYTHON'] = os.path.abspath(__file__)
 
   store = os.path.join(SCRIPT_DIR, 'coverage')
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -47,7 +47,6 @@ from .settings import settings
 DEBUG_SAVE = DEBUG or int(os.environ.get('EMCC_DEBUG_SAVE', '0'))
 MINIMUM_NODE_VERSION = (4, 1, 1)
 EXPECTED_LLVM_VERSION = "15.0"
-PYTHON = sys.executable
 
 # Used only when EM_PYTHON_MULTIPROCESSING=1 env. var is set.
 multiprocessing_pool = None
@@ -705,6 +704,7 @@ EMCMAKE = bat_suffix(path_from_root('emcmake'))
 EMCONFIGURE = bat_suffix(path_from_root('emconfigure'))
 EM_NM = bat_suffix(path_from_root('emnm'))
 FILE_PACKAGER = bat_suffix(path_from_root('tools/file_packager'))
+WASM_SOURCEMAP = bat_suffix(path_from_root('tools/wasm-sourcemap'))
 
 setup_temp_dirs()
 


### PR DESCRIPTION
This was nothing more than an alias for sys.executable.  While this
is used a fair amount in testing, emscripten itself should not be
forking python subprocesses itself, but instead using the launcher
scripts.