### PR TITLE
[WasmFS] Support resizing unopened files in the OPFS backend

### DIFF
--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -252,8 +252,8 @@ mergeInto(LibraryManager.library, {
     _emscripten_proxy_finish(ctx);
   },
 
-  _wasmfs_opfs_get_size_blob__deps: ['$wasmfsOPFSFileHandles'],
-  _wasmfs_opfs_get_size_blob: async function(ctx, fileID, sizePtr) {
+  _wasmfs_opfs_get_size_file__deps: ['$wasmfsOPFSFileHandles'],
+  _wasmfs_opfs_get_size_file: async function(ctx, fileID, sizePtr) {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     let size = (await fileHandle.getFile()).size;
     {{{ makeSetValue('sizePtr', 0, 'size', 'i32') }}};
@@ -264,6 +264,20 @@ mergeInto(LibraryManager.library, {
   _wasmfs_opfs_set_size_access: async function(ctx, accessID, size) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     await accessHandle.truncate(size);
+    _emscripten_proxy_finish(ctx);
+  },
+
+  _wasmfs_opfs_set_size_file__deps: ['$wasmfsOPFSFileHandles'],
+  _wasmfs_opfs_set_size_file: async function(ctx, fileID, size, errPtr) {
+    let fileHandle = wasmfsOPFSFileHandles.get(fileID);
+    try {
+      let writable = await fileHandle.createWritable();
+      await writable.truncate(size);
+      await writable.close();
+      {{{ makeSetValue('errPtr', 0, '0', 'i32') }}};
+    } catch {
+      {{{ makeSetValue('errPtr', 0, '1', 'i32') }}};
+    }
     _emscripten_proxy_finish(ctx);
   },
 

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -466,7 +466,7 @@ static __wasi_fd_t doOpen(path::ParsedParent parsed,
   }
 
   // Note that we open the file before truncating it because some backends may
-  // depend on that (e.g. OPFS).
+  // truncate opened files more efficiently (e.g. OPFS).
   auto openFile = std::make_shared<OpenFileState>(0, flags, child);
 
   // If O_TRUNC, truncate the file if possible.

--- a/tests/wasmfs/wasmfs_opfs.c
+++ b/tests/wasmfs/wasmfs_opfs.c
@@ -123,6 +123,15 @@ int main(int argc, char* argv[]) {
   assert(stat_buf.st_size == 1);
   emscripten_console_log("statted while closed");
 
+  err = truncate("/opfs/working/foo.txt", 42);
+  assert(err == 0);
+  emscripten_console_log("resized while closed");
+
+  err = stat("/opfs/working/foo.txt", &stat_buf);
+  assert(err == 0);
+  assert(stat_buf.st_size == 42);
+  emscripten_console_log("statted while closed again");
+
   fd = open("/opfs/working/foo.txt", O_RDONLY | O_TRUNC);
   assert(fd > 0);
   emscripten_console_log("truncated while opening");


### PR DESCRIPTION
In #17192 we updated WasmFS to open files before truncating them since the OPFS
backend did not support truncating unopened files. However, `truncate` can be
called on unopened files so the OPFS backend needs to support these truncations
anyway. Implement truncation of unopened files using the older, async
WritableStream Blob API.