### PR TITLE
Allow tests to append to settings

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -565,6 +565,24 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       value = int(value)
     self.settings_mods[key] = value
 
+  def append_setting(self, key, value):
+    if value is None:
+      return
+    if key not in self.settings_mods or self.settings_mods[key] is None:
+      self.settings_mods[key] = [value]
+      return
+    assert isinstance(self.settings_mods[key], list)
+    self.settings_mods[key].append(value)
+
+  def extend_setting(self, key, iterable):
+    if iterable is None:
+      return
+    assert isinstance(iterable, list)
+    if key not in self.settings_mods or self.settings_mods[key] is None:
+      self.settings_mods[key] = iterable
+    assert isinstance(self.settings_mods[key], list)
+    self.settings_mods[key] += iterable
+
   def has_changed_setting(self, key):
     return key in self.settings_mods
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1639,8 +1639,7 @@ int main(int argc, char **argv)
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$getExceptionMessage', '$incrementExceptionRefcount', '$decrementExceptionRefcount'])
     self.set_setting('EXPORTED_FUNCTIONS', ['_main', 'getExceptionMessage', '___get_exception_message'])
     if '-fwasm-exceptions' in self.emcc_args:
-      exports = self.get_setting('EXPORTED_FUNCTIONS')
-      self.set_setting('EXPORTED_FUNCTIONS', exports + ['___cpp_exception', '___cxa_increment_exception_refcount', '___cxa_decrement_exception_refcount', '___thrown_object_from_unwind_exception'])
+      self.extend_setting('EXPORTED_FUNCTIONS', ['___cpp_exception', '___cxa_increment_exception_refcount', '___cxa_decrement_exception_refcount', '___thrown_object_from_unwind_exception'])
 
     # FIXME Temporary workaround. See 'FIXME' in the test source code below for
     # details.


### PR DESCRIPTION
This adds `append_setting` and `extend_setting` function that can be
used in tests. This can be handy when you set some settings that
modifies other list settings, and you want to append something on top of
those list settings. For example, you set a setting `SOME_SETTING`,
which adds some functions to `EXPORTED_FUNCTIONS`. And you also want to
export `_main` in a test. But this won't work:
```py
self.set_setting('SOME_SETTING')
self.set_setting('EXPORTED_FUNCTIONS', ['_main'])
```

I think, for some settings like `EXPORTED_FUNCTIONS` or
`DEFAULT_LIBRARY_FUNCTION_TO_INCLUDE`, ths can be useful.