### PR TITLE
Explicitly use utf-8 in `create_file` during tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -301,7 +301,7 @@ def create_file(name, contents, binary=False):
   if binary:
     name.write_bytes(contents)
   else:
-    name.write_text(contents)
+    name.write_text(contents, encoding='utf-8')
 
 
 def make_executable(name):


### PR DESCRIPTION
This may help solve the current breakage on the Windows roller, which appears to
be defaulting to the "charmap" codec that cannot encode a character used in the
other.test_prejs_unicode test.