### PR TITLE
Fix function signature for emscripten_memcpy_big

### DIFF
--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -118,7 +118,7 @@ int getentropy(void* buffer, size_t length) {
 extern void emscripten_notify_memory_growth(size_t memory_index);
 
 // Should never be called in standalone mode
-void *emscripten_memcpy_big(void *restrict dest, const void *restrict src, size_t n) {
+void emscripten_memcpy_big(void *restrict dest, const void *restrict src, size_t n) {
   __builtin_unreachable();
 }
 


### PR DESCRIPTION
Change it in standalone.c to match emscripten_memcpy.c, as it was changed there in [#16604](https://github.com/emscripten-core/emscripten/pull/16604). Fixes #17208.