### PR TITLE
file_packager: Cleanup file embedding

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 3.2.0
 -----
+- `tools/file_packager` no longer generates (or requires) any "pre-js" code when
+  running in `--embed-file` mode.  Instead the embedded files are loaded at
+  static constructor time.
 - Emscripten now knows what minimum browser versions the `WASM_BIGINT` feature
   requires and will automatically set the defaults accordingly. (#17163)
 - Weak undefined symbols fixed in dynamic linking. (#17164)

--- a/emcc.py
+++ b/emcc.py
@@ -1014,9 +1014,14 @@ def package_files(options, target):
     rtn.append(object_file)
 
   cmd = [shared.FILE_PACKAGER, shared.replace_suffix(target, '.data')] + file_args
-  file_code = shared.check_call(cmd, stdout=PIPE).stdout
-
-  options.pre_js = js_manipulation.add_files_pre_js(options.pre_js, file_code)
+  if options.preload_files:
+    # Preloading files uses --pre-js code that runs before the module is loaded.
+    file_code = shared.check_call(cmd, stdout=PIPE).stdout
+    options.pre_js = js_manipulation.add_files_pre_js(options.pre_js, file_code)
+  else:
+    # Otherwise, we are embedding files, which does not require --pre-js code,
+    # and instead relies on a static constrcutor to populate the filesystem.
+    shared.check_call(cmd)
 
   return rtn
 

--- a/src/library.js
+++ b/src/library.js
@@ -3626,30 +3626,29 @@ mergeInto(LibraryManager.library, {
 #endif
 #endif
 
-  _emscripten_fs_load_embedded_files__deps: ['$FS'],
+  _emscripten_fs_load_embedded_files__deps: ['$FS', '$PATH'],
   _emscripten_fs_load_embedded_files__sig: 'vp',
   _emscripten_fs_load_embedded_files: function(ptr) {
-#if MEMORY64
-    var start64 = ptr >> 3;
+#if RUNTIME_DEBUG
+    err('preloading data files');
+#endif
     do {
-      var name_addr = Number(HEAPU64[start64++]);
-      var len = HEAPU32[start64 << 1];
-      start64++;
-      var content = Number(HEAPU64[start64++]);
+      var name_addr = {{{ makeGetValue('ptr', '0', '*') }}};
+      ptr += {{{ POINTER_SIZE }}};
+      var len = {{{ makeGetValue('ptr', '0', '*') }}};
+      ptr += {{{ POINTER_SIZE }}};
+      var content = {{{ makeGetValue('ptr', '0', '*') }}};
+      ptr += {{{ POINTER_SIZE }}};
       var name = UTF8ToString(name_addr)
+#if RUNTIME_DEBUG
+      err('preloading files: ' + name);
+#endif
+      FS.createPath('/', PATH.dirname(name), true, true);
       // canOwn this data in the filesystem, it is a slice of wasm memory that will never change
       FS.createDataFile(name, null, HEAP8.subarray(content, content + len), true, true, true);
-    } while (HEAPU64[start64]);
-#else
-    var start32 = ptr >> 2;
-    do {
-      var name_addr = HEAPU32[start32++];
-      var len = HEAPU32[start32++];
-      var content = HEAPU32[start32++];
-      var name = UTF8ToString(name_addr)
-      // canOwn this data in the filesystem, it is a slice of wasm memory that will never change
-      FS.createDataFile(name, null, HEAP8.subarray(content, content + len), true, true, true);
-    } while (HEAPU32[start32]);
+    } while ({{{ makeGetValue('ptr', '0', '*') }}});
+#if RUNTIME_DEBUG
+    err('done preloading data files');
 #endif
   },
 });

--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -15,6 +15,7 @@ mergeInto(LibraryManager.library, {
     '$wasmFSPreloadedFiles',
     '$wasmFSPreloadedDirs',
     '$asyncLoad',
+    '$PATH',
   ],
   $FS : {
     // TODO: Clean up the following functions - currently copied from library_fs.js directly.
@@ -64,7 +65,15 @@ mergeInto(LibraryManager.library, {
     },
     createPath: (parent, path, canRead, canWrite) => {
       // Cache file path directory names.
-      wasmFSPreloadedDirs.push({parentPath: parent, childName: path});
+      var parts = path.split('/').reverse();
+      while (parts.length) {
+        var part = parts.pop();
+        if (!part) continue;
+        var current = PATH.join2(parent, part);
+        wasmFSPreloadedDirs.push({parentPath: parent, childName: part});
+        parent = current;
+      }
+      return current;
     },
     readFile: (path, opts) => {
       opts = opts || {};

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -537,6 +537,8 @@ def main():
       err('--obj-output is only applicable when embedding files')
       return 1
     generate_object_file(data_files)
+    if not options.has_preloaded:
+      return 0
 
   ret = generate_js(data_target, data_files, metadata)
 
@@ -680,13 +682,12 @@ def generate_js(data_target, data_files, metadata):
     dirname = os.path.dirname(filename)
     basename = os.path.basename(filename)
     if file_.mode == 'embed':
-      if not options.obj_output:
-        # Embed
-        data = base64_encode(utils.read_binary(file_.srcpath))
-        code += "      var fileData%d = '%s';\n" % (counter, data)
-        # canOwn this data in the filesystem (i.e. there is no need to create a copy in the FS layer).
-        code += ("      Module['FS_createDataFile']('%s', '%s', decodeBase64(fileData%d), true, true, true);\n"
-                 % (dirname, basename, counter))
+      # Embed
+      data = base64_encode(utils.read_binary(file_.srcpath))
+      code += "      var fileData%d = '%s';\n" % (counter, data)
+      # canOwn this data in the filesystem (i.e. there is no need to create a copy in the FS layer).
+      code += ("      Module['FS_createDataFile']('%s', '%s', decodeBase64(fileData%d), true, true, true);\n"
+               % (dirname, basename, counter))
     elif file_.mode == 'preload':
       # Preload
       metadata_el = {


### PR DESCRIPTION
- Simplify library helper code
- Avoid `--pre-js` completely where possible (its still needed for --preload-file, but not for --embed-file)