### PR TITLE
Fix rust linking by wrapping some_file.rlib with --no-whole-archive

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9403,6 +9403,9 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   def test_linking_rust_library(self):
     """Rust libraries have an extra lib.rmeta file which can't be linked with --whole-archive."""
+    if self.get_setting('MEMORY64'):
+      self.skipTest('MEMORY64 does not yet support SJLJ')
+
     create_file('a.c', 'int f() { return 1; }')
     create_file('main.c', r'''
       #include <stdio.h>

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1940,7 +1940,7 @@ def calculate(input_files, args, forced):
   # When LINKABLE is set the entire link command line is wrapped in --whole-archive by
   # building.link_ldd.  And since --whole-archive/--no-whole-archive processing does not nest we
   # shouldn't add any extra `--no-whole-archive` or we will undo the intent of building.link_ldd.
-  if settings.LINKABLE or settings.SIDE_MODULE:
+  if settings.LINKABLE:
     return [l[0] for l in libs_to_link]
 
   # Wrap libraries in --whole-archive, as needed.  We need to do this last


### PR DESCRIPTION
Another attempt to fix #17109.