### PR TITLE
[WasmFS] Implement /tmp

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4900,6 +4900,7 @@ int main()
   def test_strptime_symmetry(self):
     self.do_runf(test_file('strptime_symmetry.cpp'), 'TEST PASSED')
 
+  @also_with_wasmfs
   def test_truncate_from_0(self):
     create_file('src.cpp', r'''
 #include <cerrno>


### PR DESCRIPTION
Also refactor the setup of /dev/* to use the newer backend API since we're
touching that code anyway. For testing, add a WasmFS configuration to an
arbitrary test that depends on /tmp.

Fixes #17127.