### PR TITLE
Fix libc_optz in EMCC_FORCE_STDLIBS builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,6 +372,7 @@ jobs:
     steps:
       - run-tests-linux:
           # also add a few asan tests and a single test of EMTEST_BROWSER=node
+          # also add a corez test of dynamic linking + forced syslibs
           test_targets: "
             core2
             asan.test_stat
@@ -384,7 +385,8 @@ jobs:
             asan.test_async_hello
             lsan.test_stdio_locking
             lsan.test_pthread_create
-            browser.test_pthread_join"
+            browser.test_pthread_join
+            corez.test_dylink_syslibs_all"
   test-core3:
     executor: bionic
     steps:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1867,7 +1867,9 @@ def get_libs_to_link(args, forced, only_forced):
   # C libraries that override libc must come before it
   if settings.PRINTF_LONG_DOUBLE:
     add_library('libprintf_long_double')
-  if settings.SHRINK_LEVEL >= 2:
+  # See comment in libc_optz itself
+  if settings.SHRINK_LEVEL >= 2 and not settings.LINKABLE and \
+     not os.environ.get('EMCC_FORCE_STDLIBS'):
     add_library('libc_optz')
 
   if settings.STANDALONE_WASM:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1060,7 +1060,13 @@ class libc_optz(libc):
     return cmd
 
   def can_use(self):
-    return super(libc_optz, self).can_use() and settings.SHRINK_LEVEL >= 2
+    # Because libc_optz overrides parts of libc, it is not compatible with
+    # dynamic linking which uses --whole-archive. In addition,
+    # EMCC_FORCE_STDLIBS can have a similar effect of forcing all libraries.
+    # In both cases, the build is not one that is hyper-focused on code size,
+    # and so optz is not that important.
+    return super(libc_optz, self).can_use() and settings.SHRINK_LEVEL >= 2 and \
+           not settings.LINKABLE and not os.environ.get('EMCC_FORCE_STDLIBS')
 
 
 class libprintf_long_double(libc):
@@ -1861,13 +1867,7 @@ def get_libs_to_link(args, forced, only_forced):
   # C libraries that override libc must come before it
   if settings.PRINTF_LONG_DOUBLE:
     add_library('libprintf_long_double')
-  # Becuase libc_optz overrides parts of libc, it is not compatible with `LINKABLE`
-  # (used in `MAIN_MODULE=1`) because with that setting we use `--whole-archive` to
-  # include all system libraries.
-  # However, because libc_optz is a size optimization it is not really important
-  # when used with `MAIN_MODULE=1` (which links in all system libraries, leading
-  # to overheads far bigger than any savings from libc_optz)
-  if settings.SHRINK_LEVEL >= 2 and not settings.LINKABLE:
+  if settings.SHRINK_LEVEL >= 2:
     add_library('libc_optz')
 
   if settings.STANDALONE_WASM:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1066,7 +1066,7 @@ class libc_optz(libc):
     # In both cases, the build is not one that is hyper-focused on code size,
     # and so optz is not that important.
     return super(libc_optz, self).can_use() and settings.SHRINK_LEVEL >= 2 and \
-           not settings.LINKABLE and not os.environ.get('EMCC_FORCE_STDLIBS')
+        not settings.LINKABLE and not os.environ.get('EMCC_FORCE_STDLIBS')
 
 
 class libprintf_long_double(libc):


### PR DESCRIPTION
Aside from `MAIN_MODULE=1`, if the user uses `EMCC_FORCE_STDLIBS` then
all system libraries will be linked in, and potentially cause problems.
Fixes `corez.test_dylink_syslibs_all` as well as `ltoz` and `thinltoz`, see
https://github.com/emscripten-core/emscripten/pull/17179#issuecomment-1158226153

Second part of the diff moves the disabling check into the library, to avoid redundancy
(which would require fixing this in 2 places).