### PR TITLE
[WasmFS] Follow symlinks and fix fstatat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,7 @@ jobs:
             wasmfs.test_mmap_anon*
             wasmfs.test_getcwd_with_non_ascii_name
             wasmfs.test_stat
-            wasmfs.test_statat
+            wasmfs.test_fstatat
             wasmfs.test_unistd_links_memfs"
   test-wasm2js1:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,7 +420,9 @@ jobs:
             wasmfs.test_minimal_runtime_memorygrowth
             wasmfs.test_mmap_anon*
             wasmfs.test_getcwd_with_non_ascii_name
-            wasmfs.test_stat"
+            wasmfs.test_stat
+            wasmfs.test_statat
+            wasmfs.test_unistd_links_memfs"
   test-wasm2js1:
     executor: bionic
     steps:

--- a/system/lib/wasmfs/paths.cpp
+++ b/system/lib/wasmfs/paths.cpp
@@ -20,7 +20,7 @@ ParsedFile doParseFile(std::string_view path,
                        LinkBehavior links,
                        size_t& recursions);
 
-ParsedFile getBase(__wasi_fd_t basefd) {
+ParsedFile getBaseDir(__wasi_fd_t basefd) {
   if (basefd == AT_FDCWD) {
     return {wasmFS.getCWD()};
   }
@@ -129,7 +129,7 @@ ParsedFile doParseFile(std::string_view path,
 } // anonymous namespace
 
 ParsedParent parseParent(std::string_view path, __wasi_fd_t basefd) {
-  auto base = getBase(basefd);
+  auto base = getBaseDir(basefd);
   if (auto err = base.getError()) {
     return err;
   }
@@ -140,7 +140,7 @@ ParsedParent parseParent(std::string_view path, __wasi_fd_t basefd) {
 
 ParsedFile
 parseFile(std::string_view path, __wasi_fd_t basefd, LinkBehavior links) {
-  auto base = getBase(basefd);
+  auto base = getBaseDir(basefd);
   if (auto err = base.getError()) {
     return err;
   }

--- a/system/lib/wasmfs/paths.h
+++ b/system/lib/wasmfs/paths.h
@@ -23,7 +23,9 @@ using Error = long;
 // or is a view into a static string.
 using ParentChild = std::pair<std::shared_ptr<Directory>, std::string_view>;
 
-enum LinkBehavior { FollowLinks, FollowParentLinks, NoFollowLinks };
+// If the path refers to a link, whether we should follow that link. Links among
+// the parent directories in the path are always followed.
+enum LinkBehavior { FollowLinks, NoFollowLinks };
 
 struct ParsedParent {
 private:
@@ -48,9 +50,7 @@ public:
   }
 };
 
-ParsedParent parseParent(std::string_view path,
-                         __wasi_fd_t basefd = AT_FDCWD,
-                         LinkBehavior links = FollowLinks);
+ParsedParent parseParent(std::string_view path, __wasi_fd_t basefd = AT_FDCWD);
 
 struct ParsedFile {
 private:

--- a/system/lib/wasmfs/paths.h
+++ b/system/lib/wasmfs/paths.h
@@ -23,6 +23,8 @@ using Error = long;
 // or is a view into a static string.
 using ParentChild = std::pair<std::shared_ptr<Directory>, std::string_view>;
 
+enum LinkBehavior { FollowLinks, FollowParentLinks, NoFollowLinks };
+
 struct ParsedParent {
 private:
   std::variant<Error, ParentChild> val;
@@ -46,7 +48,9 @@ public:
   }
 };
 
-ParsedParent parseParent(std::string_view path, __wasi_fd_t basefd = AT_FDCWD);
+ParsedParent parseParent(std::string_view path,
+                         __wasi_fd_t basefd = AT_FDCWD,
+                         LinkBehavior links = FollowLinks);
 
 struct ParsedFile {
 private:
@@ -71,7 +75,9 @@ public:
   }
 };
 
-ParsedFile parseFile(std::string_view path, __wasi_fd_t basefd = AT_FDCWD);
+ParsedFile parseFile(std::string_view path,
+                     __wasi_fd_t basefd = AT_FDCWD,
+                     LinkBehavior links = FollowLinks);
 
 // Like `parseFile`, but handle the case where `flags & AT_EMPTY_PATH`. Does not
 // validate the flags since different callers have different allowed flags.

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -316,7 +316,7 @@ backend_t wasmfs_get_backend_by_path(const char* path) {
   return parsed.getFile()->getBackend();
 }
 
-int __syscall_fstatat64(int dirfd, intptr_t path, intptr_t buf, int flags) {
+int __syscall_newfstatat(int dirfd, intptr_t path, intptr_t buf, int flags) {
   // Only accept valid flags.
   if (flags & ~(AT_EMPTY_PATH | AT_NO_AUTOMOUNT | AT_SYMLINK_NOFOLLOW)) {
     // TODO: Test this case.
@@ -359,15 +359,15 @@ int __syscall_fstatat64(int dirfd, intptr_t path, intptr_t buf, int flags) {
 }
 
 int __syscall_stat64(intptr_t path, intptr_t buf) {
-  return __syscall_fstatat64(AT_FDCWD, path, buf, 0);
+  return __syscall_newfstatat(AT_FDCWD, path, buf, 0);
 }
 
 int __syscall_lstat64(intptr_t path, intptr_t buf) {
-  return __syscall_fstatat64(AT_FDCWD, path, buf, AT_SYMLINK_NOFOLLOW);
+  return __syscall_newfstatat(AT_FDCWD, path, buf, AT_SYMLINK_NOFOLLOW);
 }
 
 int __syscall_fstat64(int fd, intptr_t buf) {
-  return __syscall_fstatat64(fd, (intptr_t)"", buf, AT_EMPTY_PATH);
+  return __syscall_newfstatat(fd, (intptr_t) "", buf, AT_EMPTY_PATH);
 }
 
 // When calling doOpen(), we may request an FD be returned, or we may not need
@@ -982,8 +982,10 @@ int __syscall_symlink(intptr_t target, intptr_t linkpath) {
 }
 
 // TODO: Test this with non-AT_FDCWD values.
+// TODO: Test that FollowParentLinks is not the same as NoFollowLinks
 int __syscall_readlinkat(int dirfd, intptr_t path, intptr_t buf, size_t bufsize) {
-  auto parsed = path::parseFile((char*)path, dirfd);
+  // TODO: Handle empty paths.
+  auto parsed = path::parseFile((char*)path, dirfd, path::FollowParentLinks);
   if (auto err = parsed.getError()) {
     return err;
   }
@@ -1448,17 +1450,6 @@ int __syscall_fstatfs64(int fd, size_t size, intptr_t buf) {
     return -EBADF;
   }
   return doStatFS(openFile->locked().getFile(), size, (struct statfs*)buf);
-}
-
-int __syscall_newfstatat(int dirfd, intptr_t path, intptr_t buf, int flags) {
-  if (flags & ~(AT_EMPTY_PATH | AT_NO_AUTOMOUNT | AT_SYMLINK_NOFOLLOW)) {
-    return -EINVAL;
-  }
-  auto parsed = path::getFileAt(dirfd, (char*)path, flags);
-  if (auto err = parsed.getError()) {
-    return err;
-  }
-  return doStatFS(parsed.getFile(), sizeof(struct statfs), (struct statfs*)buf);
 }
 
 intptr_t _mmap_js(

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -982,10 +982,9 @@ int __syscall_symlink(intptr_t target, intptr_t linkpath) {
 }
 
 // TODO: Test this with non-AT_FDCWD values.
-// TODO: Test that FollowParentLinks is not the same as NoFollowLinks
 int __syscall_readlinkat(int dirfd, intptr_t path, intptr_t buf, size_t bufsize) {
   // TODO: Handle empty paths.
-  auto parsed = path::parseFile((char*)path, dirfd, path::FollowParentLinks);
+  auto parsed = path::parseFile((char*)path, dirfd, path::NoFollowLinks);
   if (auto err = parsed.getError()) {
     return err;
   }

--- a/tests/stat/test_fstatat.c
+++ b/tests/stat/test_fstatat.c
@@ -58,7 +58,11 @@ void test() {
   assert(s.st_ctime);
 #ifdef __EMSCRIPTEN__
   assert(s.st_blksize == 4096);
+#ifdef WASMFS
+  assert(s.st_blocks == 8);
+#else
   assert(s.st_blocks == 1);
+#endif
 #endif
 
   // stat a file
@@ -110,7 +114,11 @@ void test() {
   assert(s.st_ctime);
 #ifdef __EMSCRIPTEN__
   assert(s.st_blksize == 4096);
+#ifdef WASMFS
+  assert(s.st_blocks == 8);
+#else
   assert(s.st_blocks == 1);
+#endif
 #endif
 
   close(fd);
@@ -135,7 +143,7 @@ void test() {
 #endif
 
   close(fd);
-  
+
   // lstat a link - with AT_FDCWD and AT_SYMLINK_NOFOLLOW.
   memset(&s, 0, sizeof(s));
   err = fstatat(AT_FDCWD, "folder/file-link", &s, AT_SYMLINK_NOFOLLOW);

--- a/tests/stat/test_fstatat.c
+++ b/tests/stat/test_fstatat.c
@@ -58,6 +58,7 @@ void test() {
   assert(s.st_ctime);
 #ifdef __EMSCRIPTEN__
   assert(s.st_blksize == 4096);
+  // WasmFS correctly counts 512B blocks, but MEMFS counts 4kb blocks.
 #ifdef WASMFS
   assert(s.st_blocks == 8);
 #else

--- a/tests/stat/test_stat.c
+++ b/tests/stat/test_stat.c
@@ -142,8 +142,6 @@ void test() {
   assert(s.st_blocks == 0);
 #endif
 
-  // WasmFS does not follow symlinks yet.
-#ifndef WASMFS
   // stat a link (should match the file stat from above)
   memset(&s, 0, sizeof(s));
   err = stat("folder/file-link", &s);
@@ -160,7 +158,6 @@ void test() {
 #ifdef __EMSCRIPTEN__
   assert(s.st_blksize == 4096);
   assert(s.st_blocks == 1);
-#endif
 #endif
 
   // lstat a link (should NOT match the file stat from above)

--- a/tests/unistd/links.c
+++ b/tests/unistd/links.c
@@ -82,7 +82,6 @@ int main() {
 #endif
   errno = 0;
 
-#ifndef WASMFS
   // FS.lookupPath should notice the symlink loop and return ELOOP, not go into
   // an infinite recurse.
   //
@@ -94,7 +93,6 @@ int main() {
   printf("errno: %d\n", errno);
   assert(errno == ELOOP);
   errno = 0;
-#endif
 
   return 0;
 }


### PR DESCRIPTION
Update path parsing to follow symlinks by default, but add configuration options
necessary for some system calls to opt out of following symlinks at the leaf of
paths.

As a drive-by to get test_fstatat.c working, also rename __syscall_fstatat64 to
its expected name, __syscall_newfstatat, and delete our incorrect previous
version of __syscall_newfstatat, which was performing a statfs operation.

Fixes #15948.