### PR TITLE
Fix corez.test_dylink_iostream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,6 +395,7 @@ jobs:
           # also add a little select wasmfs testing
           test_targets: "
             core3
+            corez.test_dylink_iostream
             core2ss.test_pthread_dylink
             core2ss.test_pthread_thread_local_storage
             wasm2js3.test_memorygrowth_2

--- a/src/library.js
+++ b/src/library.js
@@ -364,11 +364,11 @@ mergeInto(LibraryManager.library, {
 
   // In -Oz builds, we replace memcpy() altogether with a non-unrolled wasm
   // variant, so we should never emit emscripten_memcpy_big() in the build.
-  // (However, in MAIN_MODULE=1 mode we link in all system libraries, which does
-  // end up adding code that refers to this.)
   // In STANDALONE_WASM we avoid the emscripten_memcpy_big dependency so keep
   // the wasm file standalone.
-#if (SHRINK_LEVEL < 2 || LINKABLE) && !STANDALONE_WASM
+  // In MAIN_MODULE=1 or EMCC_FORCE_STDLIBS mode all of libc is force included
+  // so we cannot override parts of it, and therefore cannot use libc_optz.
+#if (SHRINK_LEVEL < 2 || LINKABLE || process.env.EMCC_FORCE_STDLIBS) && !STANDALONE_WASM
 
   emscripten_memcpy_big__sig: 'vppp',
 #if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 100101


### PR DESCRIPTION
More fallout from the libc_optz optimization.  I think it would be great
it we could get rid of EMCC_FORCE_STDLIBS since it causes a lot of odd
issues like this.