### PR TITLE
Strip code section from separate-dwarf file

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3404,7 +3404,7 @@ def phase_binaryen(target, options, wasm_target):
     # we are not running wasm-opt. if we need to strip certain sections
     # then do so using llvm-objcopy which is fast and does not rewrite the
     # code (which is better for debug info)
-    sections = ['producers'] if strip_prodcuers else []
+    sections = ['producers'] if strip_producers else []
     building.strip(wasm_target, wasm_target, debug=strip_debug, sections=sections)
     building.save_intermediate(wasm_target, 'strip.wasm')
 

--- a/emcc.py
+++ b/emcc.py
@@ -3404,7 +3404,8 @@ def phase_binaryen(target, options, wasm_target):
     # we are not running wasm-opt. if we need to strip certain sections
     # then do so using llvm-objcopy which is fast and does not rewrite the
     # code (which is better for debug info)
-    building.strip(wasm_target, wasm_target, debug=strip_debug, producers=strip_producers)
+    sections = ['producers'] if strip_prodcuers else []
+    building.strip(wasm_target, wasm_target, debug=strip_debug, sections=sections)
     building.save_intermediate(wasm_target, 'strip.wasm')
 
   if settings.EVAL_CTORS:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8615,9 +8615,10 @@ int main() {
     if not debug_wasm.has_name_section():
       self.fail('name section not found in separate dwarf file')
     for sec in debug_wasm.sections():
-      # TODO: check for absence of code section (see
-      # https://github.com/emscripten-core/emscripten/issues/13084)
-      if sec.name and sec.name != 'name' and not sec.name.startswith('.debug'):
+      if (sec.type == webassembly.SecType.CODE or
+          sec.type == webassembly.SecType.DATA):
+        self.fail(f'section of type "{sec.type}" found in separate dwarf file')
+      if sec.name and sec.name != 'name':
         self.fail(f'non-debug section "{sec.name}" found in separate dwarf file')
 
     # Check that dwarfdump can dump the debug info

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8615,10 +8615,9 @@ int main() {
     if not debug_wasm.has_name_section():
       self.fail('name section not found in separate dwarf file')
     for sec in debug_wasm.sections():
-      if (sec.type == webassembly.SecType.CODE or
-          sec.type == webassembly.SecType.DATA):
+      if sec.type == webassembly.SecType.CODE:
         self.fail(f'section of type "{sec.type}" found in separate dwarf file')
-      if sec.name and sec.name != 'name':
+      if sec.name and sec.name != 'name' and not sec.name.startswith('.debug') :
         self.fail(f'non-debug section "{sec.name}" found in separate dwarf file')
 
     # Check that dwarfdump can dump the debug info

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8617,7 +8617,7 @@ int main() {
     for sec in debug_wasm.sections():
       if sec.type == webassembly.SecType.CODE:
         self.fail(f'section of type "{sec.type}" found in separate dwarf file')
-      if sec.name and sec.name != 'name' and not sec.name.startswith('.debug') :
+      if sec.name and sec.name != 'name' and not sec.name.startswith('.debug'):
         self.fail(f'non-debug section "{sec.name}" found in separate dwarf file')
 
     # Check that dwarfdump can dump the debug info

--- a/tools/building.py
+++ b/tools/building.py
@@ -1219,19 +1219,18 @@ def wasm2js(js_file, wasm_file, opt_level, minify_whitespace, use_closure_compil
   return js_file
 
 
-def strip(infile, outfile, debug=False, producers=False):
+def strip(infile, outfile, debug=False, sections=None):
   cmd = [LLVM_OBJCOPY, infile, outfile]
   if debug:
     cmd += ['--remove-section=.debug*']
-  if producers:
-    cmd += ['--remove-section=producers']
+  if sections:
+    cmd += ['--remove-section=' + section for section in sections]
+  print(cmd)
   check_call(cmd)
 
 
 # extract the DWARF info from the main file, and leave the wasm with
 # debug into as a file on the side
-# TODO: emit only debug sections in the side file, and not the entire
-#       wasm as well
 def emit_debug_on_side(wasm_file):
   # if the dwarf filename wasn't provided, use the default target + a suffix
   wasm_file_with_dwarf = settings.SEPARATE_DWARF
@@ -1247,6 +1246,10 @@ def emit_debug_on_side(wasm_file):
 
   shutil.move(wasm_file, wasm_file_with_dwarf)
   strip(wasm_file_with_dwarf, wasm_file, debug=True)
+
+  # Strip code and data from the debug file to limit its size. The other known
+  # sections are still required to correctly interpret the DWARF info.
+  strip(wasm_file_with_dwarf, wasm_file_with_dwarf, section=['CODE', 'DATA'])
 
   # embed a section in the main wasm to point to the file with external DWARF,
   # see https://yurydelendik.github.io/webassembly-dwarf/#external-DWARF

--- a/tools/building.py
+++ b/tools/building.py
@@ -1225,7 +1225,6 @@ def strip(infile, outfile, debug=False, sections=None):
     cmd += ['--remove-section=.debug*']
   if sections:
     cmd += ['--remove-section=' + section for section in sections]
-  print(cmd)
   check_call(cmd)
 
 
@@ -1249,7 +1248,10 @@ def emit_debug_on_side(wasm_file):
 
   # Strip code and data from the debug file to limit its size. The other known
   # sections are still required to correctly interpret the DWARF info.
-  strip(wasm_file_with_dwarf, wasm_file_with_dwarf, section=['CODE', 'DATA'])
+  # TODO(dschuff): Also strip the DATA section? To make this work we'd need to
+  # either allow "invalid" data segment name entries, or maybe convert the DATA
+  # to a DATACOUNT section.
+  strip(wasm_file_with_dwarf, wasm_file_with_dwarf, sections=['CODE'])
 
   # embed a section in the main wasm to point to the file with external DWARF,
   # see https://yurydelendik.github.io/webassembly-dwarf/#external-DWARF


### PR DESCRIPTION
Other custom sections need to stay in the file so that the DWARF data can be interpreted by tools such as llvm-dwarfdump.

Fixes #13084
