### PR TITLE
Fix test_emcc_print_search_dirs on win32. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,6 +507,7 @@ jobs:
             other.test_realpath
             other.test_embed_file_dup
             other.test_dot_a_all_contents_invalid
+            other.test_emcc_print_search_dirs
             other.test_pkg_config*"
       # Run a single websockify-based test to ensure it works on windows.
       - run-tests:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -617,7 +617,11 @@ f.close()
     output = self.run_process([EMCC, '-print-search-dirs'], stdout=PIPE).stdout
     self.assertContained('programs: =', output)
     self.assertContained('libraries: =', output)
-    self.assertContained(str(shared.Cache.get_lib_dir(absolute=True)), output)
+    libpath = output.split('libraries: =', 1)[1].strip()
+    libpath = libpath.split(os.pathsep)
+    libpath = [Path(p) for p in libpath]
+    print(libpath)
+    self.assertIn(shared.Cache.get_lib_dir(absolute=True), libpath)
 
   def test_emcc_print_file_name(self):
     self.run_process([EMBUILDER, 'build', 'libc'])


### PR DESCRIPTION
Also, print the search dirs for easier debugging.