### PR TITLE
Fix python metadata extraction with pthreads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,9 +365,7 @@ jobs:
       EMCC_READ_METADATA: "compare"
     steps:
       - run-tests-linux:
-          # test_em_js_pthreads current triggers a bug in python metadata
-          # extraction: https://github.com/emscripten-core/emscripten/issues/16573
-          test_targets: "core0 skip:core0.test_em_js_pthreads"
+          test_targets: "core0"
   test-core2:
     executor: bionic
     environment:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2230,12 +2230,13 @@ int main(int argc, char **argv) {
   @parameterized({
     '': ([], False),
     'pthreads': (['-sUSE_PTHREADS', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'], False),
+    'pthreads_dylink': (['-sUSE_PTHREADS', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME', '-sMAIN_MODULE=2', '-Wno-experimental'], False),
     'c': ([], True),
-    'linked': (['-sMAIN_MODULE'], False),
-    'linked_c': (['-sMAIN_MODULE'], True),
+    'dylink': (['-sMAIN_MODULE=2'], False),
+    'dylink_c': (['-sMAIN_MODULE=2'], True),
   })
   def test_em_js(self, args, force_c):
-    if '-sMAIN_MODULE' in args:
+    if '-sMAIN_MODULE=2' in args:
       self.check_dylink()
     else:
       self.emcc_args += ['-sEXPORTED_FUNCTIONS=_main,_malloc']


### PR DESCRIPTION
We have to jump through a lot more hoops to find the EM_JS segment
data when the segments are passive.  In this case the address of each
segment is not in the segment information, but embedded in the
`__wasm_init_memory` code which gets called from `_start`.  We have to
do more work here partially decode this function, but its still less
than binaryen is doing.

Fixes: #16573