### PR TITLE
Avoid keeping module file open in tools/webassembly.py API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -485,6 +485,7 @@ jobs:
             core2.test_em_asm_unicode
             core2.test_em_js
             core2.test_em_js_pthreads
+            other.test_c_preprocessor
             other.test_prejs_unicode
             other.test_em_js_side_module
             other.test_es5_transpile


### PR DESCRIPTION
These was a bug in my imlemenation of `@cache` that I added in #17255
where it was keeping the underlying wasm file open and never actually
closing it.  This is because I was using the incoming arguments as the
hash key instead of their hash value.

The bug only manifested on windows where open files are locked in some
way prevented futher actions from modifying them and resulting is a
strange error:

```llvm-objcopy.exe: error: permission denied```