### PR TITLE
Remove string-to-function eval from named function factory

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -199,21 +199,11 @@ var LibraryEmbind = {
   $createNamedFunction__deps: ['$makeLegalFunctionName'],
   $createNamedFunction: function(name, body) {
     name = makeLegalFunctionName(name);
-#if DYNAMIC_EXECUTION == 0
-    return function() {
-      "use strict";
-      return body.apply(this, arguments);
-    };
-#else
-    /*jshint evil:true*/
-    return new Function(
-        "body",
-        "return function " + name + "() {\n" +
-        "    \"use strict\";" +
-        "    return body.apply(this, arguments);\n" +
-        "};\n"
-    )(body);
-#endif
+      return {
+      [name]: function () {
+        return body.apply(body, arguments);
+      }
+    }[name];
   },
 
   embind_repr: function(v) {


### PR DESCRIPTION
return the object key [name] as caller.name of the new function