### PR TITLE
Optimize val::array for numeric types

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -127,6 +127,7 @@ var LibraryEmVal = {
     return Emval.toHandle([]);
   },
 
+  _emval_new_array_from_memory_view__sig: 'ip',
   _emval_new_array_from_memory_view__deps: ['$Emval'],
   _emval_new_array_from_memory_view: function(view) {
     view = Emval.toValue(view);

--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -130,8 +130,8 @@ var LibraryEmVal = {
   _emval_new_array_from_memory_view__deps: ['$Emval'],
   _emval_new_array_from_memory_view: function(view) {
     view = Emval.toValue(view);
-    var a = [];
     // using for..loop is faster than Array.from
+    var a = new Array(view.length);
     for (i = 0; i < view.length; i++) a[i] = view[i];
     return Emval.toHandle(a);
   },

--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -127,7 +127,7 @@ var LibraryEmVal = {
     return Emval.toHandle([]);
   },
 
-  _emval_new_array_from_memory_view__sig: 'ip',
+  _emval_new_array_from_memory_view__sig: 'pp',
   _emval_new_array_from_memory_view__deps: ['$Emval'],
   _emval_new_array_from_memory_view: function(view) {
     view = Emval.toValue(view);

--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -127,6 +127,15 @@ var LibraryEmVal = {
     return Emval.toHandle([]);
   },
 
+  _emval_new_array_from_memory_view__deps: ['$Emval'],
+  _emval_new_array_from_memory_view: function(view) {
+    view = Emval.toValue(view);
+    var a = [];
+    // using for..loop is faster than Array.from
+    for (i = 0; i < view.length; i++) a[i] = view[i];
+    return Emval.toHandle(a);
+  },
+
   _emval_new_object__sig: 'p',
   _emval_new_object__deps: ['$Emval'],
   _emval_new_object: function() {

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -337,7 +337,7 @@ public:
 
     template<typename T>
     static val array(const std::vector<T>& vec) {
-      if constexpr (std::is_arithmetic<T>::value && !std::is_same<T, bool>::value) {
+      if constexpr (internal::typeSupportsMemoryView<T>()) {
           // for numeric types, pass memory view and copy in JS side one-off
           val view{ typed_memory_view(vec.size(), vec.data()) };
           return val(internal::_emval_new_array_from_memory_view(view.as_handle()));

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -336,13 +336,13 @@ public:
 
     template<typename T>
     static val array(const std::vector<T>& vec) {
-      if constexpr (internal::typeSupportsMemoryView<T>()) {
-          // for numeric types, pass memory view and copy in JS side one-off
-          val view{ typed_memory_view(vec.size(), vec.data()) };
-          return val(internal::_emval_new_array_from_memory_view(view.as_handle()));
-      } else {
-          return array(vec.begin(), vec.end());
-      }
+        if constexpr (internal::typeSupportsMemoryView<T>()) {
+            // for numeric types, pass memory view and copy in JS side one-off
+            val view{ typed_memory_view(vec.size(), vec.data()) };
+            return val(internal::_emval_new_array_from_memory_view(view.as_handle()));
+        } else {
+            return array(vec.begin(), vec.end());
+        }
     }
 
     static val object() {

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -16,7 +16,6 @@
 #include <climits>
 #include <emscripten/wire.h>
 #include <stdint.h> // uintptr_t
-#include <type_traits>
 #include <vector>
 
 

--- a/tests/embind/embind_benchmark.cpp
+++ b/tests/embind/embind_benchmark.cpp
@@ -462,6 +462,33 @@ void __attribute__((noinline)) pass_gameobject_ptr_benchmark()
     printf("C++ pass_gameobject_ptr %d iters: %f msecs.\n", N, (t2-t));
 }
 
+void __attribute__((noinline)) numeric_val_array_benchmark() {
+  using emscripten::val;
+
+  std::vector<int> vec = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                          13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+                          26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
+                          39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
+                          52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63};
+
+  const int kLoopTimes = 100000;
+  double t = emscripten_get_now();
+  for (int i = 0; i < kLoopTimes; i++) {
+    val v = val::array(vec.begin(), vec.end());
+  }
+  printf("val::array: %lf\n", emscripten_get_now() - t);
+
+  t = emscripten_get_now();
+  for (int i = 0; i < kLoopTimes; i++) {
+    val v = val::array(vec);
+  }
+  printf("val::array opt numeric types: %lf\n", emscripten_get_now() - t);
+
+  // It's about 20x times faster.
+  // val::array: 1021.525756
+  // val::array opt numeric types: 50.600682
+}
+
 int EMSCRIPTEN_KEEPALIVE main()
 {
     for(int i = 1000; i <= 100000; i *= 10)
@@ -506,4 +533,5 @@ int EMSCRIPTEN_KEEPALIVE main()
     call_through_interface1();
     call_through_interface2();
     returns_val_benchmark();
+    numeric_val_array_benchmark();
 }

--- a/tests/embind/test_val.cpp
+++ b/tests/embind/test_val.cpp
@@ -39,7 +39,33 @@ EMSCRIPTEN_BINDINGS(test_bindings) {
   emscripten::function("makeDummy", &makeDummy, emscripten::allow_raw_pointers());
 }
 
+void __attribute__((noinline)) val_array_benchmark() {
+  std::vector<int> vec = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                          13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+                          26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
+                          39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
+                          52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63};
+
+  const int kLoopTimes = 100000;
+  double t = emscripten_get_now();
+  for (int i = 0; i < kLoopTimes; i++) {
+    val v = val::array(vec.begin(), vec.end());
+  }
+  printf("val::array: %lf\n", emscripten_get_now() - t);
+
+  t = emscripten_get_now();
+  for (int i = 0; i < kLoopTimes; i++) {
+    val v = val::array(vec);
+  }
+  printf("val::array opt numeric types: %lf\n", emscripten_get_now() - t);
+
+  // It's about 20x times faster.
+  // val::array: 1021.525756
+  // val::array opt numeric types: 50.600682
+}
+
 int main() {
+  // val_array_benchmark();
   printf("start\n");
 
   test("val array()");

--- a/tests/embind/test_val.cpp
+++ b/tests/embind/test_val.cpp
@@ -39,33 +39,7 @@ EMSCRIPTEN_BINDINGS(test_bindings) {
   emscripten::function("makeDummy", &makeDummy, emscripten::allow_raw_pointers());
 }
 
-void __attribute__((noinline)) val_array_benchmark() {
-  std::vector<int> vec = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
-                          13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
-                          26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
-                          39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
-                          52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63};
-
-  const int kLoopTimes = 100000;
-  double t = emscripten_get_now();
-  for (int i = 0; i < kLoopTimes; i++) {
-    val v = val::array(vec.begin(), vec.end());
-  }
-  printf("val::array: %lf\n", emscripten_get_now() - t);
-
-  t = emscripten_get_now();
-  for (int i = 0; i < kLoopTimes; i++) {
-    val v = val::array(vec);
-  }
-  printf("val::array opt numeric types: %lf\n", emscripten_get_now() - t);
-
-  // It's about 20x times faster.
-  // val::array: 1021.525756
-  // val::array opt numeric types: 50.600682
-}
-
 int main() {
-  // val_array_benchmark();
   printf("start\n");
 
   test("val array()");


### PR DESCRIPTION
The val::array(const std::vector<T>&) is implemented by pushing items one
by one to val and is pretty slow for numeric types.

A new library function is added, which accepts memory_view and then copy
the typed array in JS side one-off. It's about 20x times faster.

Fixes: #17291