### PR TITLE
Fix compiler error on webidl tutorial.

### DIFF
--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -81,6 +81,7 @@ mid_js = []
 
 pre_c += [r'''
 #include <emscripten.h>
+#include <stddef.h>
 ''']
 
 mid_c += [r'''


### PR DESCRIPTION
The current steps for the tutorial leads to the following compiler error:

```
Error:
./glue.cpp:8:40: error: unknown type name 'size_t'
EM_JS(void, array_bounds_check_error, (size_t idx, size_t size), {
```

Fixes: #16876