### PR TITLE
[Wasm64] Fix pointer types used embind's craftInvokerFunction

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -43,6 +43,7 @@ MINIMAL_TASKS = [
     'libdlmalloc-noerrno',
     'libdlmalloc-tracing',
     'libdlmalloc-debug',
+    'libembind',
     'libembind-rtti',
     'libemmalloc',
     'libemmalloc-debug',

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -1165,7 +1165,7 @@ var LibraryEmbind = {
   },
 
   $embind__requireFunction__deps: ['$readLatin1String', '$throwBindingError'
-#if DYNCALLS || !WASM_BIGINT
+#if DYNCALLS || !WASM_BIGINT || MEMORY64
     , '$getDynCaller'
 #endif
   ],
@@ -1178,6 +1178,10 @@ var LibraryEmbind = {
 #else
 #if !WASM_BIGINT
       if (signature.includes('j')) {
+        return getDynCaller(signature, rawFunction);
+      }
+#elif MEMORY64
+      if (signature.includes('p')) {
         return getDynCaller(signature, rawFunction);
       }
 #endif

--- a/src/library.js
+++ b/src/library.js
@@ -3201,11 +3201,12 @@ mergeInto(LibraryManager.library, {
 #if MINIMAL_RUNTIME
     var f = dynCalls[sig];
 #else
-    var f = Module["dynCall_" + sig];
+    var f = Module['dynCall_' + sig];
 #endif
     return args && args.length ? f.apply(null, [ptr].concat(args)) : f.call(null, ptr);
   },
   $dynCall__deps: ['$dynCallLegacy', '$getWasmTableEntry'],
+#endif
 
   // Used in library code to get JS function from wasm function pointer.
   // All callers should use direct table access where possible and only fall
@@ -3213,7 +3214,7 @@ mergeInto(LibraryManager.library, {
   $getDynCaller__deps: ['$dynCall'],
   $getDynCaller: function(sig, ptr) {
 #if ASSERTIONS && !DYNCALLS
-    assert(sig.includes('j'), 'getDynCaller should only be called with i64 sigs')
+    assert(sig.includes('j') || sig.includes('p'), 'getDynCaller should only be called with i64 sigs')
 #endif
     var argCache = [];
     return function() {
@@ -3222,7 +3223,6 @@ mergeInto(LibraryManager.library, {
       return dynCall(sig, ptr, argCache);
     };
   },
-#endif
 
   $dynCall__docs: '/** @param {Object=} args */',
   $dynCall: function(sig, ptr, args) {
@@ -3239,6 +3239,21 @@ mergeInto(LibraryManager.library, {
 #endif
 #if ASSERTIONS
     assert(getWasmTableEntry(ptr), 'missing table entry in dynCall: ' + ptr);
+#endif
+#if MEMORY64
+    // With MEMORY64 we have an additional step to covert `p` arguments to
+    // bigint. This is the runtime equivalent of the wrappers we create for wasm
+    // exports in `emscripten.py:create_wasm64_wrappers`.
+    if (sig.includes('p')) {
+      var new_args = [];
+      args.forEach((arg, index) => {
+        if (sig[index + 1] == 'p') {
+          arg = BigInt(arg);
+        }
+        new_args.push(arg);
+      });
+      args = new_args;
+    }
 #endif
     return getWasmTableEntry(ptr).apply(null, args)
 #endif

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -432,6 +432,17 @@ struct SignatureCode<double> {
     }
 };
 
+#ifdef __wasm64__
+// With wasm32 we can fallback to 'i' for pointer types but we need special
+// handling with wasm64.
+template<>
+struct SignatureCode<void*> {
+    static constexpr char get() {
+        return 'p';
+    }
+};
+#endif
+
 template<typename... Args>
 const char* getGenericSignature() {
     static constexpr char signature[] = { SignatureCode<Args>::get()..., 0 };
@@ -442,6 +453,12 @@ template<typename T> struct SignatureTranslator { using type = int; };
 template<> struct SignatureTranslator<void> { using type = void; };
 template<> struct SignatureTranslator<float> { using type = float; };
 template<> struct SignatureTranslator<double> { using type = double; };
+#ifdef __wasm64__
+template<typename PtrType>
+struct SignatureTranslator<PtrType*> { using type = void*; };
+template<typename ReturnType, typename... Args>
+struct SignatureTranslator<ReturnType (*)(Args...)> { using type = void*; };
+#endif
 
 template<typename... Args>
 EMSCRIPTEN_ALWAYS_INLINE const char* getSpecificSignature() {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7334,12 +7334,11 @@ void* operator new(size_t size) {
       ''')
       self.do_runf('test_embind.cpp', 'abs(-10): 10\nabs(-11): 11', emcc_args=args)
 
-  @no_wasm64('embind does not yet support MEMORY64')
   def test_embind_2(self):
     self.emcc_args += ['-lembind', '--post-js', 'post.js']
     create_file('post.js', '''
       function printLerp() {
-          out('lerp ' + Module.lerp(100, 200, 66) + '.');
+        out('lerp ' + Module.lerp(100, 200, 66) + '.');
       }
     ''')
     create_file('test_embind_2.cpp', r'''
@@ -7348,14 +7347,14 @@ void* operator new(size_t size) {
       #include <emscripten/bind.h>
       using namespace emscripten;
       int lerp(int a, int b, int t) {
-          return (100 - t) * a + t * b;
+        return (100 - t) * a + t * b;
       }
       EMSCRIPTEN_BINDINGS(my_module) {
-          function("lerp", &lerp);
+        function("lerp", &lerp);
       }
       int main(int argc, char **argv) {
-          EM_ASM(printLerp());
-          return 0;
+        EM_ASM(printLerp());
+        return 0;
       }
     ''')
     self.do_runf('test_embind_2.cpp', 'lerp 166')
@@ -7388,7 +7387,6 @@ void* operator new(size_t size) {
     ''')
     self.do_runf('test_embind_3.cpp', 'UnboundTypeError: Cannot call compute due to unbound types: Pi')
 
-  @no_wasm64('embind does not yet support MEMORY64')
   def test_embind_4(self):
     self.emcc_args += ['-lembind', '--post-js', 'post.js']
     create_file('post.js', '''
@@ -7440,7 +7438,6 @@ void* operator new(size_t size) {
     self.do_run_in_out_file_test('embind/test_negative_constants.cpp')
 
   @also_with_wasm_bigint
-  @no_wasm64('embind does not yet support MEMORY64')
   def test_embind_unsigned(self):
     self.emcc_args += ['-lembind']
     self.do_run_in_out_file_test('embind/test_unsigned.cpp')
@@ -7474,7 +7471,6 @@ void* operator new(size_t size) {
     self.node_args += ['--experimental-wasm-bigint']
     self.do_run_in_out_file_test('embind/test_i64_binding.cpp', assert_identical=True)
 
-  @no_wasm64('embind does not yet support MEMORY64')
   def test_embind_no_rtti(self):
     create_file('main.cpp', r'''
       #include <emscripten.h>
@@ -7508,7 +7504,6 @@ void* operator new(size_t size) {
     self.emcc_args += ['-lembind', '-fno-rtti', '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0']
     self.do_core_test('test_embind_polymorphic_class_no_rtti.cpp')
 
-  @no_wasm64('embind does not yet support MEMORY64')
   def test_embind_no_rtti_followed_by_rtti(self):
     src = r'''
       #include <emscripten.h>


### PR DESCRIPTION
There are still some remaining failures but this fixes a whole class
of failures with wasm64 and embind.