### PR TITLE
Remove duplicated function signatures from embind.js. NFC

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -443,7 +443,6 @@ var LibraryEmbind = {
   _embind_register_bool__sig: 'vpppii',
   _embind_register_bool__deps: [
     '$getShiftFromSize', '$readLatin1String', '$registerType'],
-  _embind_register_bool__sig: 'vpppii',
   _embind_register_bool: function(rawType, name, size, trueValue, falseValue) {
     var shift = getShiftFromSize(size);
 
@@ -552,7 +551,6 @@ var LibraryEmbind = {
   _embind_register_integer__deps: [
     'embind_repr', '$getShiftFromSize', '$integerReadValueFromPointer',
     '$readLatin1String', '$registerType'],
-  _embind_register_integer__sig: 'vpppii',
   _embind_register_integer: function(primitiveType, name, size, minRange, maxRange) {
     name = readLatin1String(name);
     // LLVM doesn't have signed and unsigned 32-bit types, so u32 literals come
@@ -609,7 +607,6 @@ var LibraryEmbind = {
   _embind_register_bigint__sig: 'vpppjj',
   _embind_register_bigint__deps: [
     'embind_repr', '$readLatin1String', '$registerType', '$integerReadValueFromPointer'],
-  _embind_register_bigint__sig: 'vpppjj',
   _embind_register_bigint: function(primitiveType, name, size, minRange, maxRange) {
     name = readLatin1String(name);
 
@@ -651,7 +648,6 @@ var LibraryEmbind = {
   _embind_register_float__deps: [
     'embind_repr', '$floatReadValueFromPointer', '$getShiftFromSize',
     '$readLatin1String', '$registerType'],
-  _embind_register_float__sig: 'vppp',
   _embind_register_float: function(rawType, name, size) {
     var shift = getShiftFromSize(size);
     name = readLatin1String(name);


### PR DESCRIPTION
Found using:
```bash
$ sort src/embind/*.js | uniq -d | grep '__sig:'
```