### PR TITLE
[WasmFS] Use the same system library inheritance order as libc

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1538,7 +1538,7 @@ class libstb_image(Library):
     return [utils.path_from_root('system/lib/stb_image.c')]
 
 
-class libwasmfs(MTLibrary, DebugLibrary, AsanInstrumentedLibrary):
+class libwasmfs(DebugLibrary, AsanInstrumentedLibrary, MTLibrary):
   name = 'libwasmfs'
 
   cflags = ['-fno-exceptions', '-std=c++17']


### PR DESCRIPTION
To ensure that the `MTLibrary` base names have a higher priority
as `DebugLibrary` and `AsanInstrumentedLibrary`.

This changes the `libwasmfs` system libraries from:
```bash
$ ls cache/sysroot/lib/wasm32-emscripten | grep libwasmfs
libwasmfs.a
libwasmfs-asan.a
libwasmfs-asan-debug.a
libwasmfs-asan-debug-mt.a
libwasmfs-asan-debug-ww.a
libwasmfs-asan-mt.a
libwasmfs-asan-ww.a
libwasmfs-debug.a
libwasmfs-debug-mt.a
libwasmfs-debug-ww.a
libwasmfs-mt.a
libwasmfs-ww.a
```

To:
```bash
$ ls cache/sysroot/lib/wasm32-emscripten | grep libwasmfs
libwasmfs.a
libwasmfs-asan.a
libwasmfs-asan-debug.a
libwasmfs-debug.a
libwasmfs-mt.a
libwasmfs-mt-asan.a
libwasmfs-mt-asan-debug.a
libwasmfs-mt-debug.a
libwasmfs-ww.a
libwasmfs-ww-asan.a
libwasmfs-ww-asan-debug.a
libwasmfs-ww-debug.a
```

And allows one to use (for example):
```bash
$ embuilder.py build libc-mt{,-debug} libwasmfs-mt{,-debug}
```

Without getting this error message:
```
embuilder:INFO: building libwasmfs-mt-debug
embuilder:ERROR: unfamiliar build target: libwasmfs-mt-debug
```