### PR TITLE
shell.js: Handle if location object does not exist

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -139,7 +139,7 @@ var _scriptDir = import.meta.url;
 var _scriptDir = (typeof document != 'undefined' && document.currentScript) ? document.currentScript.src : undefined;
 
 if (ENVIRONMENT_IS_WORKER) {
-  _scriptDir = self.location == null ? '' : self.location.href;
+  _scriptDir = self.location ? self.location.href : '';
 }
 #if ENVIRONMENT_MAY_BE_NODE
 else if (ENVIRONMENT_IS_NODE) {
@@ -362,7 +362,7 @@ if (ENVIRONMENT_IS_SHELL) {
 #if ENVIRONMENT_MAY_BE_WEB || ENVIRONMENT_MAY_BE_WORKER
 if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
   if (ENVIRONMENT_IS_WORKER) { // Check worker, not web, since window could be polyfilled
-    scriptDirectory = self.location == null ? '' : self.location.href;
+    scriptDirectory = self.location ? self.location.href : '';
   } else if (typeof document != 'undefined' && document.currentScript) { // web
     scriptDirectory = document.currentScript.src;
   }

--- a/src/shell.js
+++ b/src/shell.js
@@ -139,7 +139,7 @@ var _scriptDir = import.meta.url;
 var _scriptDir = (typeof document != 'undefined' && document.currentScript) ? document.currentScript.src : undefined;
 
 if (ENVIRONMENT_IS_WORKER) {
-  _scriptDir = self.location.href;
+  _scriptDir = self.location == null ? '' : self.location.href;
 }
 #if ENVIRONMENT_MAY_BE_NODE
 else if (ENVIRONMENT_IS_NODE) {
@@ -362,7 +362,7 @@ if (ENVIRONMENT_IS_SHELL) {
 #if ENVIRONMENT_MAY_BE_WEB || ENVIRONMENT_MAY_BE_WORKER
 if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
   if (ENVIRONMENT_IS_WORKER) { // Check worker, not web, since window could be polyfilled
-    scriptDirectory = self.location.href;
+    scriptDirectory = self.location == null ? '' : self.location.href;
   } else if (typeof document != 'undefined' && document.currentScript) { // web
     scriptDirectory = document.currentScript.src;
   }


### PR DESCRIPTION
When compiling with the options introduced in [this comment](https://github.com/emscripten-core/emscripten/issues/13190#issuecomment-1159204680), the `ENVIRONMENT_IS_WORKER` value is set to `true`.
In Deno, the value of `self.location` is `undefined` when the `deno run` command is executed without the `--location` CLI argument.
In the scenario of creating the Deno library, it is difficult to tell the library user to input the `--location` CLI argument, so I modified it to handle fallback at this level.