### PR TITLE
Don't print a newline every time output is flushed in node

### DIFF
--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -150,6 +150,14 @@ mergeInto(LibraryManager.library, {
       },
       put_char: function(tty, val) {
         if (val === null || val === {{{ charCode('\n') }}}) {
+#if ENVIRONMENT_MAY_BE_NODE
+          if (ENVIRONMENT_IS_NODE) {
+            if(val === {{{ charCode('\n') }}}){
+              tty.output.push({{{ charCode('\n') }}});
+            }
+            process.stdout.write(Buffer.from(tty.output));
+          } else
+#endif
           out(UTF8ArrayToString(tty.output, 0));
           tty.output = [];
         } else {
@@ -171,6 +179,14 @@ mergeInto(LibraryManager.library, {
     default_tty1_ops: {
       put_char: function(tty, val) {
         if (val === null || val === {{{ charCode('\n') }}}) {
+#if ENVIRONMENT_MAY_BE_NODE
+          if (ENVIRONMENT_IS_NODE) {
+            if(val === {{{ charCode('\n') }}}){
+              tty.output.push({{{ charCode('\n') }}});
+            }
+            process.stderr.write(Buffer.from(tty.output));
+          } else
+#endif
           err(UTF8ArrayToString(tty.output, 0));
           tty.output = [];
         } else {

--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -158,6 +158,11 @@ mergeInto(LibraryManager.library, {
       },
       flush: function(tty) {
         if (tty.output && tty.output.length > 0) {
+#if ENVIRONMENT_MAY_BE_NODE
+          if (ENVIRONMENT_IS_NODE) {
+            process.stdout.write(Buffer.from(tty.output));
+          } else
+#endif
           out(UTF8ArrayToString(tty.output, 0));
           tty.output = [];
         }
@@ -174,6 +179,11 @@ mergeInto(LibraryManager.library, {
       },
       flush: function(tty) {
         if (tty.output && tty.output.length > 0) {
+#if ENVIRONMENT_MAY_BE_NODE
+          if (ENVIRONMENT_IS_NODE) {
+            process.stderr.write(Buffer.from(tty.output));
+          } else
+#endif
           err(UTF8ArrayToString(tty.output, 0));
           tty.output = [];
         }

--- a/tests/core/pthread/test_pthread_dylink_longjmp.c
+++ b/tests/core/pthread/test_pthread_dylink_longjmp.c
@@ -32,6 +32,6 @@ int main() {
   rc = pthread_join(t, NULL);
   assert(!rc);
 
-  printf("Done");
+  printf("Done\n");
   return 0;
 }

--- a/tests/cstdio/test_remove.cpp
+++ b/tests/cstdio/test_remove.cpp
@@ -57,7 +57,7 @@ void test() {
   err = std::remove("dir");
   assert(!err);
 
-  std::cout << "success";
+  std::cout << "success\n";
 }
 
 int main() {

--- a/tests/fs_after_main.cpp
+++ b/tests/fs_after_main.cpp
@@ -14,6 +14,7 @@
 EMSCRIPTEN_KEEPALIVE
 extern "C" void finish(void*) {
   EM_ASM({
+    console.log(" Module['extraSecretBuffer']",  Module['extraSecretBuffer']);
     var printed = Module['extraSecretBuffer'].split('Iteration').length - 1;
     console.log(printed);
     assert(printed == 5, 'should have printed 5 iterations');

--- a/tests/pthread/test_pthread_cleanup.cpp
+++ b/tests/pthread/test_pthread_cleanup.cpp
@@ -83,7 +83,7 @@ int main() {
 //   s = pthread_cancel(thr[3]);
 //   assert(s == 0);
   pthread_cleanup_pop(1);
-  printf("Cleanup state variable: %ld", cleanupState);
+  printf("Cleanup state variable: %ld\n", cleanupState);
   assert(cleanupState == 907640832);
 
   pthread_cleanup_pop(1);

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1536,9 +1536,9 @@ int main(int argc, char **argv)
         }
 
         if (std::uncaught_exception())
-          std::cout << "ERROR: uncaught_exception still set.";
+          std::cout << "ERROR: uncaught_exception still set.\n";
         else
-          std::cout << "OK";
+          std::cout << "OK\n";
       }
     '''
     self.do_run(src, 'OK\n')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8375,6 +8375,7 @@ end
     # fflush with the full filesystem will flush from libc, but not the JS logging, which awaits a newline
     self.do_other_test('test_fflush_fs.cpp', emcc_args=['-sFORCE_FILESYSTEM'])
 
+  @requires_v8
   def test_fflush_fs_exit(self):
     # on exit, we can send out a newline as no more code will run
     self.do_other_test('test_fflush_fs_exit.cpp', emcc_args=['-sFORCE_FILESYSTEM', '-sEXIT_RUNTIME'])


### PR DESCRIPTION
When printing to the browser console, it's not possible to print a partial line. When printing in node, it is. This fixes `flush` when in node to behave like expected of a terminal application.

Ideally, if we're in node we ought to default to preserving `isatty` for the standard streams.