### PR TITLE
Fix core2g.test_externref. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,6 +396,7 @@ jobs:
           # also add a little select wasmfs testing
           test_targets: "
             core3
+            core2g.test_externref
             corez.test_dylink_iostream
             core2ss.test_pthread_dylink
             core2ss.test_pthread_thread_local_storage

--- a/tests/core/test_externref.s
+++ b/tests/core/test_externref.s
@@ -1,5 +1,6 @@
 # Define a global of type `externref`
 
+.section .data.my_global,"",@
 .globaltype my_global, externref
 my_global:
 
@@ -9,6 +10,7 @@ my_global:
 .functype log_externref_js (externref) -> ()
 
 .globl log_externref
+.section .text.log_externref,"",@
 log_externref:
   .functype log_externref () -> ()
   global.get my_global


### PR DESCRIPTION
Building this test in debug mode (e.g. core2g or core0g) was
causing a crash in the llvm object writer.

Putting the wasm global in a non-text section fixes it.  We should
probably be getting a better error message, but thats an upstream
llvm issue.