### PR TITLE
emmalloc: Use a union within the Region struct. NFC

### DIFF
--- a/test/code_size/hello_wasm_worker_wasm.json
+++ b/test/code_size/hello_wasm_worker_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 433,
   "a.js": 733,
   "a.js.gz": 463,
-  "a.wasm": 1800,
-  "a.wasm.gz": 994,
-  "total": 3270,
-  "total_gz": 1890
+  "a.wasm": 1823,
+  "a.wasm.gz": 991,
+  "total": 3293,
+  "total_gz": 1887
 }

--- a/test/code_size/hello_webgl2_wasm.json
+++ b/test/code_size/hello_webgl2_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 379,
   "a.js": 4968,
   "a.js.gz": 2427,
-  "a.wasm": 10421,
-  "a.wasm.gz": 6673,
-  "total": 15958,
-  "total_gz": 9479
+  "a.wasm": 10444,
+  "a.wasm.gz": 6677,
+  "total": 15981,
+  "total_gz": 9483
 }

--- a/test/code_size/hello_webgl2_wasm2js.json
+++ b/test/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 18039,
-  "a.js.gz": 7986,
+  "a.js": 18072,
+  "a.js.gz": 7982,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 21777,
-  "total_gz": 11079
+  "total": 21810,
+  "total_gz": 11075
 }

--- a/test/code_size/hello_webgl_wasm.json
+++ b/test/code_size/hello_webgl_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 379,
   "a.js": 4447,
   "a.js.gz": 2247,
-  "a.wasm": 10421,
-  "a.wasm.gz": 6673,
-  "total": 15437,
-  "total_gz": 9299
+  "a.wasm": 10444,
+  "a.wasm.gz": 6677,
+  "total": 15460,
+  "total_gz": 9303
 }

--- a/test/code_size/hello_webgl_wasm2js.json
+++ b/test/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 17511,
-  "a.js.gz": 7821,
+  "a.js": 17544,
+  "a.js.gz": 7831,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 21249,
-  "total_gz": 10914
+  "total": 21282,
+  "total_gz": 10924
 }


### PR DESCRIPTION
The allows to typed/readable accesses to the root regions as well as the
free regions.  I went for the term root here since `sentinal` was
already used for the sentinals that top of each of the free buckets.

The minor codesize changes seem to relate to the way the llvm codegen       
handles accessing data in unions.  It seems to fold the offset into the  
load less often.  Perhaps its something that we could improve in the     
backend, but its really a minor difference and don't think we should be  
tuning our C code to avoid unions (or otherwise pander the minutia of    
codegen issues).   