### PR TITLE
Replace hasExportedFunction with hasExportedSymbol. NFC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,7 +21,7 @@ See docs/process.md for more on how version tagging works.
 3.1.15
 ------
 - The JS library helper function `hasExportedFunction` has been replaced with
-  `hasExportedSymbol`, which takes and unmangled (no leading underscore) symbol
+  `hasExportedSymbol`, which takes an unmangled (no leading underscore) symbol
   name.
 - Post-link metadata extraction switched from wasm-emscripten-finalize
   (binaryen) to python code within emscripten.  This change should have no

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 3.1.15
 ------
+- The JS library helper function `hasExportedFunction` has been replaced with
+  `hasExportedSymbol`, which takes and unmangled (no leading underscore) symbol
+  name.
 - Post-link metadata extraction switched from wasm-emscripten-finalize
   (binaryen) to python code within emscripten.  This change should have no
   semantic effect, but can temporarily be reverted by setting

--- a/src/library.js
+++ b/src/library.js
@@ -3577,7 +3577,7 @@ mergeInto(LibraryManager.library, {
   // page-aligned size, and clears the allocated space.
   $mmapAlloc__deps: ['$zeroMemory', '$alignMemory'],
   $mmapAlloc: function(size) {
-#if hasExportedFunction('_emscripten_builtin_memalign')
+#if hasExportedSymbol('emscripten_builtin_memalign')
     size = alignMemory(size, {{{ WASM_PAGE_SIZE }}});
     var ptr = _emscripten_builtin_memalign({{{ WASM_PAGE_SIZE }}}, size);
     if (!ptr) return 0;

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -479,7 +479,7 @@ var LibraryDylink = {
       if (!Module.hasOwnProperty(module_sym)) {
         Module[module_sym] = exports[sym];
       }
-#if !hasExportedFunction('_main')
+#if !hasExportedSymbol('main')
       // If the main module doesn't define main it could be defined in one of
       // the side modules, and we need to handle the mangled named.
       if (sym == '__main_argc_argv') {

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1500,7 +1500,7 @@ FS.staticInit();` +
     quit: () => {
       FS.init.initialized = false;
       // force-flush all streams, so we get musl std streams printed out
-#if hasExportedFunction('_fflush')
+#if hasExportedSymbol('fflush')
       _fflush(0);
 #endif
       // close all of our streams

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -231,7 +231,7 @@ var WasiLibrary = {
   $flush_NO_FILESYSTEM__deps: ['$printChar', '$printCharBuffers'],
   $flush_NO_FILESYSTEM: function() {
     // flush anything remaining in the buffers during shutdown
-#if hasExportedFunction('_fflush')
+#if hasExportedSymbol('fflush')
     _fflush(0);
 #endif
     if (printCharBuffers[1].length) printChar(1, {{{ charCode("\n") }}});

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -832,7 +832,7 @@ New syntax is {{{ makeDynCall("${sig}", "funcPtr") }}}(arg1, arg2, ...). \
 Please update to new syntax.`);
 
     if (DYNCALLS) {
-      if (!hasExportedFunction(`dynCall_${sig}`)) {
+      if (!hasExportedSymbol(`dynCall_${sig}`)) {
         if (ASSERTIONS) {
           return `(function(${args}) { throw 'Internal Error! Attempted to invoke wasm function pointer with signature "${sig}", but no such functions have gotten exported!'; })`;
         } else {
@@ -846,7 +846,7 @@ Please update to new syntax.`);
   }
 
   if (DYNCALLS) {
-    if (!hasExportedFunction(`dynCall_${sig}`)) {
+    if (!hasExportedSymbol(`dynCall_${sig}`)) {
       if (ASSERTIONS) {
         return `(function(${args}) { throw 'Internal Error! Attempted to invoke wasm function pointer with signature "${sig}", but no such functions have gotten exported!'; })`;
       } else {
@@ -1085,12 +1085,18 @@ function _asmjsDemangle(symbol) {
     return symbol;
   }
   // Strip leading "_"
-  assert(symbol.startsWith('_'));
+  assert(symbol.startsWith('_'), 'expected mangled symbol: ' + symbol);
   return symbol.substr(1);
 }
 
+// TODO(sbc): Remove this function along with _asmjsDemangle.
 function hasExportedFunction(func) {
+  warnOnce('hasExportedFunction has been replaced with hasExportedSymbol, which takes and unmangled (no leading underscore) symbol name');
   return WASM_EXPORTS.has(_asmjsDemangle(func));
+}
+
+function hasExportedSymbol(sym) {
+  return WASM_EXPORTS.has(sym);
 }
 
 // JS API I64 param handling: if we have BigInt support, the ABI is simple,
@@ -1170,7 +1176,7 @@ function addReadyPromiseAssertions(promise) {
 }
 
 function makeMalloc(source, param) {
-  if (hasExportedFunction('_malloc')) {
+  if (hasExportedSymbol('malloc')) {
     return `_malloc(${param})`;
   }
   // It should be impossible to call some functions without malloc being

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -380,7 +380,7 @@ function checkUnflushedContent() {
   try { // it doesn't matter if it fails
 #if SYSCALLS_REQUIRE_FILESYSTEM == 0 && '$flush_NO_FILESYSTEM' in addedLibraryItems
     flush_NO_FILESYSTEM();
-#elif hasExportedFunction('_fflush')
+#elif hasExportedSymbol('fflush')
     _fflush(0);
 #endif
 #if '$FS' in addedLibraryItems && '$TTY' in addedLibraryItems

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -32,7 +32,7 @@ function run() {
 
 #endif
 
-#if IN_TEST_HARNESS && hasExportedFunction('_flush')
+#if IN_TEST_HARNESS && hasExportedSymbol('flush')
   // flush any stdio streams for test harness, since there are existing
   // tests that depend on this behavior.
   // For production use, instead print full lines to avoid this kind of lazy
@@ -88,7 +88,7 @@ function initRuntime(asm) {
   PThread.tlsInitFunctions.push(asm['_emscripten_tls_init']);
 #endif
 
-#if hasExportedFunction('___wasm_call_ctors')
+#if hasExportedSymbol('__wasm_call_ctors')
   asm['__wasm_call_ctors']();
 #endif
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -220,12 +220,12 @@ function cwrap(ident, returnType, argTypes, opts) {
 #if ASSERTIONS
 // We used to include malloc/free by default in the past. Show a helpful error in
 // builds with assertions.
-#if !hasExportedFunction('_malloc')
+#if !hasExportedSymbol('malloc')
 function _malloc() {
   abort("malloc() called but not included in the build - add '_malloc' to EXPORTED_FUNCTIONS");
 }
 #endif // malloc
-#if !hasExportedFunction('_free')
+#if !hasExportedSymbol('free')
 function _free() {
   // Show a helpful error since we used to include free by default in the past.
   abort("free() called but not included in the build - add '_free' to EXPORTED_FUNCTIONS");
@@ -1054,11 +1054,11 @@ function createWasm() {
 #endif
 #endif
 
-#if hasExportedFunction('___wasm_call_ctors')
+#if hasExportedSymbol('__wasm_call_ctors')
     addOnInit(Module['asm']['__wasm_call_ctors']);
 #endif
 
-#if hasExportedFunction('___wasm_apply_data_relocs')
+#if hasExportedSymbol('__wasm_apply_data_relocs')
     __RELOC_FUNCS__.push(Module['asm']['__wasm_apply_data_relocs']);
 #endif
 


### PR DESCRIPTION
Leave the old helper in place for JS library authors who might still
be using it.

This should allow us to one day remove the `_asmjsDemangle` helper of
which this is the only caller, moving slowly towards not using mangled
names at all.