### PR TITLE
remove a redundant .resolve() for getting library cache paths

### DIFF
--- a/tools/cache.py
+++ b/tools/cache.py
@@ -142,7 +142,7 @@ class Cache:
   # Request a cached file. If it isn't in the cache, it will be created with
   # the given creator function
   def get(self, shortname, creator, what=None, force=False):
-    cachename = Path(self.dirname, shortname).resolve()
+    cachename = Path(self.dirname, shortname)
     # Check for existence before taking the lock in case we can avoid the
     # lock completely.
     if cachename.exists() and not force:


### PR DESCRIPTION
Without this, symlinks for system libs are followed and resolved. For bazel, this means a file named `libFoo.a` might be resolved as `e58957f1cab91f52c0125960ca9dc918860122a36a7c295387ad22371102068c_01009924`, which then fails an assert at https://github.com/emscripten-core/emscripten/blob/main/tools/shared.py#L609. 

This is not the only way to resolve this issue. Instead, we could change https://github.com/emscripten-core/emscripten/blob/main/tools/system_libs.py#L378 to actually read the extension on the file itself, which would return an empty string in the example above, which would cause this return to be hit: https://github.com/emscripten-core/emscripten/blob/main/tools/system_libs.py#L260, which would be the assert is never reached in the first place.

I would be happy with either of these solutions.