### PR TITLE
Remove 'exception of type' prefix when the exception has a message

### DIFF
--- a/system/lib/libcxxabi/src/cxa_exception_emscripten.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception_emscripten.cpp
@@ -92,8 +92,8 @@ char* __get_exception_message(void* thrown_object, bool terminate=false) {
     const char* what =
       static_cast<const std::exception*>(thrown_object)->what();
     asprintf(&result,
-             (terminate ? "terminating with uncaught exception of type %s: %s"
-                        : "exception of type %s: %s"),
+             (terminate ? "terminating with uncaught exception %s: %s"
+                        : "%s: %s"),
              type_name,
              what);
   } else {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1685,8 +1685,8 @@ int main(int argc, char **argv)
     expected = '''\
 exception of type int
 exception of type char
-exception of type std::runtime_error: abc
-exception of type myexception: My exception happened
+std::runtime_error: abc
+myexception: My exception happened
 exception of type char const*
 '''
 


### PR DESCRIPTION
I think this makes the message a bit more readable. @aheejin 