### PR TITLE
SIDE_MODULE DCE according to another SIDE_MODULE

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1230,7 +1230,7 @@ def phase_calculate_linker_inputs(options, state, linker_inputs):
   else:
     linker_args = filter_out_duplicate_dynamic_libs(linker_args)
 
-  if settings.MAIN_MODULE:
+  if settings.MAIN_MODULE or settings.SIDE_MODULE:
     dylibs = [a for a in linker_args if building.is_wasm_dylib(a)]
     process_dynamic_libs(dylibs, state.lib_dirs)
 


### PR DESCRIPTION
SIDE_MODULE can DCE normally according to another SIDE_MODULE.

> sideModule DCE all symbols, instead of keepalive symbols needed by cModule.

[#17354](https://github.com/emscripten-core/emscripten/issues/17354#issuecomment-1173658915)

I'm not very familiar with `process_dynamic_libs` and may need to check further if such changes are correct.

Self test: https://github.com/Keillion/emsdk-cheatlist/tree/b9a4bd64c51659a7a5d3230de9b47ae2376844bd