### PR TITLE
Fix unexpected runtime exit with `EXIT_RUNTIME`while calling glfwSetWindowSize

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -598,7 +598,7 @@ var LibraryGLFW = {
 #if USE_GLFW == 3
         {{{ makeDynCall('viii', 'GLFW.active.windowSizeFunc') }}}(GLFW.active.id, GLFW.active.width, GLFW.active.height);
 #endif
-      });
+      }, true);
     },
 
     onFramebufferSizeChanged: function() {
@@ -610,7 +610,7 @@ var LibraryGLFW = {
 #if USE_GLFW == 3
         {{{ makeDynCall('viii', 'GLFW.active.framebufferSizeFunc') }}}(GLFW.active.id, GLFW.active.width, GLFW.active.height);
 #endif
-      });
+      }, true);
     },
 
     getTime: function() {

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -590,7 +590,6 @@ var LibraryGLFW = {
 
       if (!GLFW.active.windowSizeFunc) return;
 
-      {{{ runtimeKeepalivePush() }}}
       callUserCallback(function() {
 #if USE_GLFW == 2
         {{{ makeDynCall('vii', 'GLFW.active.windowSizeFunc') }}}(GLFW.active.width, GLFW.active.height);
@@ -600,7 +599,6 @@ var LibraryGLFW = {
         {{{ makeDynCall('viii', 'GLFW.active.windowSizeFunc') }}}(GLFW.active.id, GLFW.active.width, GLFW.active.height);
 #endif
       });
-      {{{ runtimeKeepalivePop() }}}
     },
 
     onFramebufferSizeChanged: function() {
@@ -608,13 +606,11 @@ var LibraryGLFW = {
 
       if (!GLFW.active.framebufferSizeFunc) return;
 
-      {{{ runtimeKeepalivePush() }}}
       callUserCallback(function() {
 #if USE_GLFW == 3
         {{{ makeDynCall('viii', 'GLFW.active.framebufferSizeFunc') }}}(GLFW.active.id, GLFW.active.width, GLFW.active.height);
 #endif
       });
-      {{{ runtimeKeepalivePop() }}}
     },
 
     getTime: function() {
@@ -963,6 +959,7 @@ var LibraryGLFW = {
       if (!win) return;
 
       if (GLFW.active.id == win.id) {
+        {{{ runtimeKeepalivePush() }}}
         if (width == screen.width && height == screen.height) {
           Browser.requestFullscreen();
         } else {
@@ -971,6 +968,7 @@ var LibraryGLFW = {
           win.width = width;
           win.height = height;
         }
+        {{{ runtimeKeepalivePop() }}}
       }
 
       if (!win.windowSizeFunc) return;

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -590,6 +590,7 @@ var LibraryGLFW = {
 
       if (!GLFW.active.windowSizeFunc) return;
 
+      {{{ runtimeKeepalivePush() }}}
       callUserCallback(function() {
 #if USE_GLFW == 2
         {{{ makeDynCall('vii', 'GLFW.active.windowSizeFunc') }}}(GLFW.active.width, GLFW.active.height);
@@ -598,7 +599,8 @@ var LibraryGLFW = {
 #if USE_GLFW == 3
         {{{ makeDynCall('viii', 'GLFW.active.windowSizeFunc') }}}(GLFW.active.id, GLFW.active.width, GLFW.active.height);
 #endif
-      }, true);
+      });
+      {{{ runtimeKeepalivePop() }}}
     },
 
     onFramebufferSizeChanged: function() {
@@ -606,11 +608,13 @@ var LibraryGLFW = {
 
       if (!GLFW.active.framebufferSizeFunc) return;
 
+      {{{ runtimeKeepalivePush() }}}
       callUserCallback(function() {
 #if USE_GLFW == 3
         {{{ makeDynCall('viii', 'GLFW.active.framebufferSizeFunc') }}}(GLFW.active.id, GLFW.active.width, GLFW.active.height);
 #endif
-      }, true);
+      });
+      {{{ runtimeKeepalivePop() }}}
     },
 
     getTime: function() {

--- a/tests/glfw3.c
+++ b/tests/glfw3.c
@@ -124,7 +124,6 @@ int main()
         glfwGetWindowPos(window, &x, &y); // stub
         glfwGetWindowSize(window, &w, &h);
         assert(w == 640 && h == 480);
-        assert(exited == 0);
 
         glfwSetWindowSize(window, 1, 1);
         glfwGetWindowSize(window, &w, &h);
@@ -133,6 +132,7 @@ int main()
 
         glfwSetWindowSize(window, 640, 480);
         glfwGetFramebufferSize(window, &w, &h);
+        assert(exited == 0);
 
         // XXX: not implemented
         // glfwIconifyWindow(window);

--- a/tests/glfw3.c
+++ b/tests/glfw3.c
@@ -41,6 +41,13 @@ assert(glfwSet##Function(Value) == Value); /* The previously set callback */
 assert(glfwSet##Function(Window, Value) == NULL);  /* Default value (no callback was set) */ \
 assert(glfwSet##Function(Window, Value) == Value); /* The previously set callback */
 
+static int exited = 0;
+
+__attribute__((destructor))
+void onExit() {
+    exited = 1;
+}
+
 int main()
 {
     GLFWwindow *window;
@@ -117,10 +124,12 @@ int main()
         glfwGetWindowPos(window, &x, &y); // stub
         glfwGetWindowSize(window, &w, &h);
         assert(w == 640 && h == 480);
+        assert(exited == 0);
 
         glfwSetWindowSize(window, 1, 1);
         glfwGetWindowSize(window, &w, &h);
         assert(w == 1 && h == 1);
+        assert(exited == 0);
 
         glfwSetWindowSize(window, 640, 480);
         glfwGetFramebufferSize(window, &w, &h);

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2864,7 +2864,7 @@ Module["preRun"].push(function () {
     'gl_es': (['-DCLIENT_API=GLFW_OPENGL_ES_API'],)
   })
   def test_glfw3(self, args):
-    for opts in [[], ['-sLEGACY_GL_EMULATION'], ['-Os', '--closure=1']]:
+    for opts in [[], ['-sEXIT_RUNTIME=1'], ['-sLEGACY_GL_EMULATION'], ['-Os', '--closure=1']]:
       print(opts)
       self.btest(test_file('glfw3.c'), args=['-sUSE_GLFW=3', '-lglfw', '-lGL'] + args + opts, expected='1')
 


### PR DESCRIPTION
When called `glfwSetWindowSize`, emscripten runtime will exit unintentionally.