### PR TITLE
Remove needless internal use of Module object. NFC

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -210,7 +210,7 @@ mergeInto(LibraryManager.library, {
         Asyncify.state = Asyncify.State.Normal;
         // Keep the runtime alive so that a re-wind can be done later.
 #if ASYNCIFY == 1
-        runAndAbortIfError(Module['_asyncify_stop_unwind']);
+        runAndAbortIfError(_asyncify_stop_unwind);
 #endif
         if (typeof Fibers != 'undefined') {
           Fibers.trampoline();
@@ -331,7 +331,7 @@ mergeInto(LibraryManager.library, {
 #endif
           Asyncify.state = Asyncify.State.Rewinding;
 #if ASYNCIFY == 1
-          runAndAbortIfError(() => Module['_asyncify_start_rewind'](Asyncify.currData));
+          runAndAbortIfError(() => _asyncify_start_rewind(Asyncify.currData));
 #endif
           if (typeof Browser != 'undefined' && Browser.mainLoop.func) {
             Browser.mainLoop.resume();
@@ -392,7 +392,7 @@ mergeInto(LibraryManager.library, {
             // TODO: handle rejection
           });
 #else
-          runAndAbortIfError(() => Module['_asyncify_start_unwind'](Asyncify.currData));
+          runAndAbortIfError(() => _asyncify_start_unwind(Asyncify.currData));
 #endif
         }
       } else if (Asyncify.state === Asyncify.State.Rewinding) {
@@ -402,7 +402,7 @@ mergeInto(LibraryManager.library, {
 #endif
         Asyncify.state = Asyncify.State.Normal;
 #if ASYNCIFY == 1
-        runAndAbortIfError(Module['_asyncify_stop_rewind']);
+        runAndAbortIfError(_asyncify_stop_rewind);
 #endif
         _free(Asyncify.currData);
         Asyncify.currData = null;
@@ -534,7 +534,7 @@ mergeInto(LibraryManager.library, {
       _emscripten_stack_set_limits(stack_base, stack_max);
 
 #if STACK_OVERFLOW_CHECK >= 2
-      Module['___set_stack_limits'](stack_base, stack_max);
+      ___set_stack_limits(stack_base, stack_max);
 #endif
 
       stackRestore({{{ makeGetValue('newFiber', C_STRUCTS.emscripten_fiber_s.stack_ptr,   'i32') }}});
@@ -561,7 +561,7 @@ mergeInto(LibraryManager.library, {
         err('ASYNCIFY/FIBER: start rewind', asyncifyData, '(resuming fiber', newFiber, ')');
 #endif
         Asyncify.state = Asyncify.State.Rewinding;
-        Module['_asyncify_start_rewind'](asyncifyData);
+        _asyncify_start_rewind(asyncifyData);
         Asyncify.doRewind(asyncifyData);
       }
     },
@@ -610,7 +610,7 @@ mergeInto(LibraryManager.library, {
 #if ASYNCIFY_DEBUG
       err('ASYNCIFY/FIBER: start unwind', asyncifyData);
 #endif
-      Module['_asyncify_start_unwind'](asyncifyData);
+      _asyncify_start_unwind(asyncifyData);
 
       var stackTop = stackSave();
       {{{ makeSetValue('oldFiber', C_STRUCTS.emscripten_fiber_s.stack_ptr, 'stackTop', 'i32') }}};
@@ -624,7 +624,7 @@ mergeInto(LibraryManager.library, {
       err('ASYNCIFY/FIBER: stop rewind');
 #endif
       Asyncify.state = Asyncify.State.Normal;
-      Module['_asyncify_stop_rewind']();
+      _asyncify_stop_rewind();
       Asyncify.currData = null;
     }
   },

--- a/src/library_stack_trace.js
+++ b/src/library_stack_trace.js
@@ -12,8 +12,7 @@ var LibraryStackTrace = {
     // This avoids an infinite recursion with malloc()->abort()->stackTrace()->demangle()->malloc()->...
     demangle.recursionGuard = (demangle.recursionGuard|0)+1;
     if (demangle.recursionGuard > 1) return func;
-    var __cxa_demangle_func = Module['___cxa_demangle'] || Module['__cxa_demangle'];
-    assert(__cxa_demangle_func);
+    assert(___cxa_demangle);
     return withStackSave(function() {
       try {
         var s = func;
@@ -23,7 +22,7 @@ var LibraryStackTrace = {
         var buf = stackAlloc(len);
         stringToUTF8(s, buf, len);
         var status = stackAlloc(4);
-        var ret = __cxa_demangle_func(buf, 0, 0, status);
+        var ret = ___cxa_demangle(buf, 0, 0, status);
         if ({{{ makeGetValue('status', '0', 'i32') }}} === 0 && ret) {
           return UTF8ToString(ret);
         }

--- a/src/library_stack_trace.js
+++ b/src/library_stack_trace.js
@@ -12,7 +12,9 @@ var LibraryStackTrace = {
     // This avoids an infinite recursion with malloc()->abort()->stackTrace()->demangle()->malloc()->...
     demangle.recursionGuard = (demangle.recursionGuard|0)+1;
     if (demangle.recursionGuard > 1) return func;
+#ASSERTIONS 
     assert(___cxa_demangle);
+#endif
     return withStackSave(function() {
       try {
         var s = func;


### PR DESCRIPTION
This are normal native functions and we can call them by their internal
name (I'm working on a change that avoids exporting them at all).