### PR TITLE
[RFC] Writable WORKERFS

### DIFF
--- a/src/library_workerfs.js
+++ b/src/library_workerfs.js
@@ -46,6 +46,9 @@ mergeInto(LibraryManager.library, {
       (mount.opts["blobs"] || []).forEach(function(obj) {
         WORKERFS.createNode(ensureParent(obj["name"]), base(obj["name"]), WORKERFS.FILE_MODE, 0, obj["data"]);
       });
+      (mount.opts["writables"] || []).forEach(function(obj) {
+        WORKERFS.createNode(ensureParent(obj["name"]), base(obj["name"]), WORKERFS.FILE_MODE, 0, obj);
+      });
       (mount.opts["packages"] || []).forEach(function(pack) {
         pack['metadata'].files.forEach(function(file) {
           var name = file.filename.substr(1); // remove initial slash
@@ -140,7 +143,14 @@ mergeInto(LibraryManager.library, {
         return chunk.size;
       },
       write: function (stream, buffer, offset, length, position) {
-        throw new FS.ErrnoError({{{ cDefine('EIO') }}});
+        postMessage({
+          type: "write",
+          file: stream.node.name,
+          position,
+          buffer: buffer.slice(offset, offset + length),
+          length: length,
+        });
+        return length;
       },
       llseek: function (stream, offset, whence) {
         var position = offset;


### PR DESCRIPTION
Hello,

From wasm currently there is no easy way to generate large output files. MEMFS based approaches are all limited to the size of available memory.

This small patch adds a postMessage to WORKERFS' stream_ops.write callback, on predefined entries passed in at mount time, called "writables", alongside the existing "files" and "blobs" arguments, which semantically are writeonly files that can be persisted or streamed in browswer context in the onmessage handler.

While the patch is apparently not intended for merging, I'm looking for feedback on how this can be taken forward.

I've looked at @connorjclark 's fsfs PR and that is also depending on MEMFS so it cannot solve the problem.

This patch is verified to work as intended in handling large output files in my ffmpeg wasm app.

Thanks,