### PR TITLE
Remove special handling of stackSave/stackRestore/stackAlloc

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -446,6 +446,11 @@ function exportRuntime() {
     'abort',
     'keepRuntimeAlive',
     'wasmMemory',
+    // These last three are actually native wasm functions these days but we
+    // allow exporting them via EXPORTED_RUNTIME_METHODS for backwards compat.
+    'stackSave',
+    'stackRestore',
+    'stackAlloc',
   ];
 
   if (USE_PTHREADS && ALLOW_MEMORY_GROWTH) {
@@ -473,9 +478,6 @@ function exportRuntime() {
     runtimeElements = runtimeElements.concat([
       'run',
       'warnOnce',
-      'stackSave',
-      'stackRestore',
-      'stackAlloc',
       'AsciiToString',
       'stringToAscii',
       'UTF16ToString',


### PR DESCRIPTION
There is no different between how these symbols are handled under the
standard an minimal runtime (unlike the other symbols that are added
separately there).

I'm working changes to remove all the different in the library vs
runtime split that exist between minimal runtime and regular runtime.
For most symbols this means moving them to JS library functions but for
these three they are already handled the same in both runtimes.