### PR TITLE
jsifier: Rename libraryFunction -> librarySymbols

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -461,7 +461,7 @@ def get_all_js_syms():
     glue, forwarded_data = emscripten.compile_settings()
     forwarded_json = json.loads(forwarded_data)
     library_syms = set()
-    for name in forwarded_json['libraryFunctions']:
+    for name in forwarded_json['librarySymbols']:
       if shared.is_c_symbol(name):
         name = shared.demangle_c_symbol_name(name)
         library_syms.add(name)

--- a/emscripten.py
+++ b/emscripten.py
@@ -375,7 +375,7 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile):
   if settings.ASYNCIFY:
     exports += ['asyncify_start_unwind', 'asyncify_stop_unwind', 'asyncify_start_rewind', 'asyncify_stop_rewind']
 
-  report_missing_symbols(forwarded_json['libraryFunctions'])
+  report_missing_symbols(forwarded_json['librarySymbols'])
 
   if not outfile_js:
     logger.debug('emscript: skipping remaining js glue generation')

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -317,11 +317,6 @@ function ${name}(${args}) {
             deps.push(snippet);
             snippet = mangleCSymbolName(snippet);
           }
-          // In asm, we need to know about library functions. If there is a target, though, then no
-          // need to consider this a library function - we will call directly to it anyhow
-          if (!redirectedIdent && (typeof target == 'function')) {
-            libraryFunctions.push(finalName);
-          }
         }
       } else if (typeof snippet == 'object') {
         snippet = stringifyWithFunctions(snippet);
@@ -330,14 +325,9 @@ function ${name}(${args}) {
         isFunction = true;
         snippet = processLibraryFunction(snippet, ident, finalName, deps);
         addImplicitDeps(snippet, deps);
-        libraryFunctions.push(finalName);
       }
 
-      // If a JS library item specifies xxx_import: true, then explicitly mark that symbol to be exported
-      // to wasm module.
-      if (LibraryManager.library[ident + '__import']) {
-        libraryFunctions.push(finalName);
-      }
+      librarySymbols.push(finalName);
 
       if (ONLY_CALC_JS_SYMBOLS) {
         return '';
@@ -555,7 +545,7 @@ function ${name}(${args}) {
     print(processMacros(preprocess(shellParts[1], shellFile)));
 
     print('\n//FORWARDED_DATA:' + JSON.stringify({
-      libraryFunctions: libraryFunctions,
+      librarySymbols: librarySymbols,
       warnings: warnings,
       ATINITS: ATINITS.join('\n'),
       ATMAINS: ATMAINS.join('\n'),

--- a/src/library.js
+++ b/src/library.js
@@ -385,7 +385,6 @@ mergeInto(LibraryManager.library, {
   //   AppleWebKit/605.1.15 Safari/604.1 Version/13.0.4 iPhone OS 13_3 on iPhone 6s with iOS 13.3
   //   AppleWebKit/605.1.15 Version/13.0.3 Intel Mac OS X 10_15_1 on Safari 13.0.3 (15608.3.10.1.4) on macOS Catalina 10.15.1
   // Hence the support status of .copyWithin() for Safari version range [10.0.0, 10.1.0] is unknown.
-  emscripten_memcpy_big__import: true,
   emscripten_memcpy_big: '= Uint8Array.prototype.copyWithin\n' +
     '  ? function(dest, src, num) { HEAPU8.copyWithin(dest, src, src + num); }\n' +
     '  : function(dest, src, num) { HEAPU8.set(HEAPU8.subarray(src, src+num), dest); }\n',
@@ -2293,7 +2292,6 @@ mergeInto(LibraryManager.library, {
     return Math.random();
   },
 
-  emscripten_get_now__import: true,
   emscripten_get_now__sig: 'd',
   emscripten_get_now: ';' +
 #if ENVIRONMENT_MAY_BE_NODE
@@ -3591,16 +3589,11 @@ mergeInto(LibraryManager.library, {
 #if RELOCATABLE
   // Globals that are normally exported from the wasm module but in relocatable
   // mode are created here and imported by the module.
-  // Mark with `__import` so these are usable from native code.  This is needed
-  // because, by default, only functions can be be imported.
   __stack_pointer: "new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': true}, {{{ to64(STACK_BASE) }}})",
-  __stack_pointer__import: true,
   // tell the memory segments where to place themselves
   __memory_base: "new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': false}, {{{ to64(GLOBAL_BASE) }}})",
-  __memory_base__import: true,
   // the wasm backend reserves slot 0 for the NULL function pointer
   __table_base: "new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': false}, {{{ to64(1) }}})",
-  __table_base__import: true,
 #if MEMORY64
   __table_base32: 1,
 #endif
@@ -3610,11 +3603,9 @@ mergeInto(LibraryManager.library, {
   // have __heap_base hardcoded into it - it receives it from JS as an extern
   // global, basically).
   __heap_base: '{{{ to64(HEAP_BASE) }}}',
-  __heap_base__import: true,
 #if WASM_EXCEPTIONS
   // In dynamic linking we define tags here and feed them to each module
   __cpp_exception: "new WebAssembly.Tag({'parameters': ['{{{ POINTER_WASM_TYPE }}}']})",
-  __cpp_exception__import: true,
 #endif
 #if SUPPORT_LONGJMP == 'wasm'
   __c_longjmp: "new WebAssembly.Tag({'parameters': ['{{{ POINTER_WASM_TYPE }}}']})",

--- a/src/modules.js
+++ b/src/modules.js
@@ -17,8 +17,8 @@ function genArgSequence(n) {
   return args;
 }
 
-// List of functions that were added from the library.
-global.libraryFunctions = [];
+// List of symbols that were added from the library.
+global.librarySymbols = [];
 
 global.LibraryManager = {
   library: {},
@@ -362,7 +362,7 @@ function isInternalSymbol(ident) {
 function addMissingLibraryStubs() {
   if (!ASSERTIONS) return '';
   let rtn = '';
-  const librarySymbolSet = new Set(libraryFunctions);
+  const librarySymbolSet = new Set(librarySymbols);
   for (const ident in LibraryManager.library) {
     if (typeof LibraryManager.library[ident] === 'function') {
       if (ident[0] === '$' && !isJsLibraryConfigIdentifier(ident) && !isInternalSymbol(ident)) {

--- a/src/utility.js
+++ b/src/utility.js
@@ -113,7 +113,6 @@ function isJsLibraryConfigIdentifier(ident) {
     '__deps',
     '__postset',
     '__docs',
-    '__import',
     '__nothrow',
     '__noleakcheck',
     '__internal',


### PR DESCRIPTION
Also, include all library symbols, not just functions, in the list which allows things
like wasm globals, numbers, and other elements to be linked into native code
and/or exported via `DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.`

This allows us to remove the special `__import` decorator.