### PR TITLE
Simplify + optimize lengthBytesUTF8. Don't fully decode surrogates

### DIFF
--- a/src/runtime_strings.js
+++ b/src/runtime_strings.js
@@ -187,6 +187,7 @@ function stringToUTF8(str, outPtr, maxBytesToWrite) {
 
 // Returns the number of bytes the given Javascript string takes if encoded as a UTF8 byte array, EXCLUDING the null terminator byte.
 function lengthBytesUTF8(str) {
+  var len = 0;
   for (var i = 0, l = str.length; i < l; ++i) {
     // Gotcha: charCodeAt returns a 16-bit word that is a UTF-16 encoded code unit, not a Unicode code point of the character! So decode UTF16->UTF32->UTF8.
     // See http://unicode.org/faq/utf_bom.html#utf16-3

--- a/src/runtime_strings.js
+++ b/src/runtime_strings.js
@@ -187,16 +187,19 @@ function stringToUTF8(str, outPtr, maxBytesToWrite) {
 
 // Returns the number of bytes the given Javascript string takes if encoded as a UTF8 byte array, EXCLUDING the null terminator byte.
 function lengthBytesUTF8(str) {
-  var len = 0;
-  for (var i = 0; i < str.length; ++i) {
+  for (var i = 0, l = str.length; i < l; ++i) {
     // Gotcha: charCodeAt returns a 16-bit word that is a UTF-16 encoded code unit, not a Unicode code point of the character! So decode UTF16->UTF32->UTF8.
     // See http://unicode.org/faq/utf_bom.html#utf16-3
-    var u = str.charCodeAt(i); // possibly a lead surrogate
-    if (u >= 0xD800 && u <= 0xDFFF) u = 0x10000 + ((u & 0x3FF) << 10) | (str.charCodeAt(++i) & 0x3FF);
-    if (u <= 0x7F) ++len;
-    else if (u <= 0x7FF) len += 2;
-    else if (u <= 0xFFFF) len += 3;
-    else len += 4;
+    let c = str.charCodeAt(i); // possibly a lead surrogate
+    if (c <= 0x7F) {
+      len++;
+    } else if (c <= 0x7FF) {
+      len += 2;
+    } else if (c >= 0xD800 && c <= 0xDFFF) { // high surrogate occurred
+      len += 4; ++i;
+    } else {
+      len += 3;
+    }
   }
   return len;
 }

--- a/src/runtime_strings.js
+++ b/src/runtime_strings.js
@@ -196,7 +196,7 @@ function lengthBytesUTF8(str) {
       len++;
     } else if (c <= 0x7FF) {
       len += 2;
-    } else if (c >= 0xD800 && c <= 0xDFFF) { // high surrogate occurred
+    } else if (c >= 0xD800 && c <= 0xDFFF) {
       len += 4; ++i;
     } else {
       len += 3;

--- a/src/runtime_strings.js
+++ b/src/runtime_strings.js
@@ -191,7 +191,7 @@ function lengthBytesUTF8(str) {
   for (var i = 0; i < str.length; ++i) {
     // Gotcha: charCodeAt returns a 16-bit word that is a UTF-16 encoded code unit, not a Unicode code point of the character! So decode UTF16->UTF32->UTF8.
     // See http://unicode.org/faq/utf_bom.html#utf16-3
-    let c = str.charCodeAt(i); // possibly a lead surrogate
+    var c = str.charCodeAt(i); // possibly a lead surrogate
     if (c <= 0x7F) {
       len++;
     } else if (c <= 0x7FF) {

--- a/src/runtime_strings.js
+++ b/src/runtime_strings.js
@@ -188,7 +188,7 @@ function stringToUTF8(str, outPtr, maxBytesToWrite) {
 // Returns the number of bytes the given Javascript string takes if encoded as a UTF8 byte array, EXCLUDING the null terminator byte.
 function lengthBytesUTF8(str) {
   var len = 0;
-  for (var i = 0, l = str.length; i < l; ++i) {
+  for (var i = 0; i < str.length; ++i) {
     // Gotcha: charCodeAt returns a 16-bit word that is a UTF-16 encoded code unit, not a Unicode code point of the character! So decode UTF16->UTF32->UTF8.
     // See http://unicode.org/faq/utf_bom.html#utf16-3
     let c = str.charCodeAt(i); // possibly a lead surrogate


### PR DESCRIPTION
`lengthBytesUTF8` can be simplified and don't fully decode code point to low & high surrogates for UTF8 length calculation.