### PR TITLE
Remove redundant alias handling in JS compiler. NFC

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -290,7 +290,6 @@ function ${name}(${args}) {
 
       const original = LibraryManager.library[ident];
       let snippet = original;
-      let redirectedIdent = null;
       const deps = LibraryManager.library[ident + '__deps'] || [];
       if (!Array.isArray(deps)) {
         error(`JS library directive ${ident}__deps=${deps.toString()} is of type ${typeof deps}, but it should be an array!`);
@@ -307,18 +306,7 @@ function ${name}(${args}) {
       });
       let isFunction = false;
 
-      if (typeof snippet == 'string') {
-        if (snippet[0] != '=') {
-          const target = LibraryManager.library[snippet];
-          if (target) {
-            // Redirection for aliases. We include the parent, and at runtime make ourselves equal to it.
-            // This avoid having duplicate functions with identical content.
-            redirectedIdent = snippet;
-            deps.push(snippet);
-            snippet = mangleCSymbolName(snippet);
-          }
-        }
-      } else if (typeof snippet == 'object') {
+      if (typeof snippet == 'object') {
         snippet = stringifyWithFunctions(snippet);
         addImplicitDeps(snippet, deps);
       } else if (typeof snippet == 'function') {
@@ -349,9 +337,6 @@ function ${name}(${args}) {
         }
       }
 
-      if (redirectedIdent) {
-        deps = deps.concat(LibraryManager.library[redirectedIdent + '__deps'] || []);
-      }
       if (VERBOSE) {
         printErr(`adding ${finalName} and deps ${deps} : ` + (snippet + '').substr(0, 40));
       }


### PR DESCRIPTION
This alias handling code was not active.  You can see this from the
fact that the `deps` variable is declared const and then re-assigned
in the case of an alias, which would have been a runtime error if it
ever happended.

Aliased are instead handed in modules.js.  See `apply synonyms` in that
file.