### PR TITLE
Fix webgpu warning when configuring swapchain on canvas

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -2582,11 +2582,11 @@ var LibraryWebGPU = {
     ];
 
     if (canvasSize[0] !== 0) {
-        context.canvas.width = canvasSize[0];
+        context["canvas"]["width"] = canvasSize[0];
     }
 
     if (canvasSize[1] !== 0) {
-        context.canvas.height = canvasSize[1];
+        context["canvas"]["height"] = canvasSize[1];
     }
 
     var configuration = {

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -2575,20 +2575,16 @@ var LibraryWebGPU = {
     assert({{{ gpu.PresentMode.Fifo }}} ===
       {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.presentMode) }}});
 #endif
-    var configurationSize = [
-      {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.width) }}},
-      {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.height) }}},
-    ];
+
+    context.canvas.width = {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.width) }}};
+    context.canvas.height = {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.height) }}};
 
     var configuration = {
       "device": device,
       "format": WebGPU.TextureFormat[
         {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.format) }}}],
       "usage": {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.usage) }}},
-      "size": configurationSize[0] !== 0 && configurationSize[1] !== 0
-        ? configurationSize
-        : undefined,
-        "alphaMode": "opaque",
+      "alphaMode": "opaque",
     };
     context["configure"](configuration);
 

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -2576,8 +2576,18 @@ var LibraryWebGPU = {
       {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.presentMode) }}});
 #endif
 
-    context.canvas.width = {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.width) }}};
-    context.canvas.height = {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.height) }}};
+    var canvasSize = [
+        {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.width) }}},
+        {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.height) }}}
+    ];
+
+    if (canvasSize[0] !== 0) {
+        context.canvas.width = canvasSize[0];
+    }
+
+    if (canvasSize[1] !== 0) {
+        context.canvas.height = canvasSize[1];
+    }
 
     var configuration = {
       "device": device,

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -2575,16 +2575,20 @@ var LibraryWebGPU = {
     assert({{{ gpu.PresentMode.Fifo }}} ===
       {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.presentMode) }}});
 #endif
+    var configurationSize = [
+      {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.width) }}},
+      {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.height) }}},
+    ];
 
     var configuration = {
       "device": device,
       "format": WebGPU.TextureFormat[
         {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.format) }}}],
       "usage": {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.usage) }}},
-      "size": [
-        {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.width) }}},
-        {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUSwapChainDescriptor.height) }}},
-      ],
+      "size": configurationSize[0] !== 0 && configurationSize[1] !== 0
+        ? configurationSize
+        : undefined,
+        "alphaMode": "opaque",
     };
     context["configure"](configuration);
 


### PR DESCRIPTION
Fixes #17416

Set `size` to `undefined` when no size is specified when creating a context. Won't break current behavior when users still specify the canvas size and will emit a warning.

When the size is specified to be zero by zero, we send no size as the [webgpu specification states](https://www.w3.org/TR/webgpu/#context-sizing) and the context will take `canvas.width` and `canvas.height`.

In my toy project, I automatically set and resize the canvas using the following code:
```js
const canvas = document.querySelector("canvas");
const { width, height } = canvas.getBoundingClientRect();
canvas.width = width * window.devicePixelRatio;
canvas.height = height * window.devicePixelRatio;
const resizeObserver = new ResizeObserver(entries => {
    for (const entry of entries) {
        if (entry.target !== canvas) { continue; }
        canvas.width = entry.devicePixelContentBoxSize[0].inlineSize;
        canvas.height = entry.devicePixelContentBoxSize[0].blockSize;
    }
});
resizeObserver.observe(canvas);
```

cc @shrekshao