### PR TITLE
Remove use of OrderedDict. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -18,7 +18,6 @@ import time
 import logging
 import pprint
 import shutil
-from collections import OrderedDict
 
 from tools import building
 from tools import diagnostics
@@ -771,7 +770,7 @@ def add_standard_wasm_imports(send_items_map):
 
 def create_sending(invoke_funcs, metadata):
   # Map of wasm imports to mangled/external/JS names
-  send_items_map = OrderedDict()
+  send_items_map = {}
 
   def add_send_items(name, mangled_name, ignore_dups=False):
     # Sanity check that the names of emJsFuncs, declares, and globalImports don't overlap

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -11,7 +11,6 @@ sections from a wasm file.
 """
 
 import argparse
-from collections import OrderedDict
 import json
 import logging
 from math import floor, log
@@ -311,11 +310,11 @@ def build_sourcemap(entries, code_section_offset, prefixes, collect_sources, bas
     last_source_id = source_id
     last_line = line
     last_column = column
-  return OrderedDict([('version', 3),
-                      ('names', []),
-                      ('sources', sources),
-                      ('sourcesContent', sources_content),
-                      ('mappings', ','.join(mappings))])
+  return {'version': 3,
+          'names': [],
+          'sources': sources,
+          'sourcesContent': sources_content,
+          'mappings': ','.join(mappings)}
 
 
 def main():


### PR DESCRIPTION
We require python3.6 which guarantees ordering of all dicts:
https://docs.python.org/3.6/whatsnew/3.6.html#new-dict-implementation
https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6