### PR TITLE
Allow `run` in EXPORTED_RUNTIME_METHODS, even under MINIMAL_RUNTIME

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -344,6 +344,7 @@ function exportRuntime() {
 
   // All possible runtime elements that can be exported
   let runtimeElements = [
+    'run',
     'ccall',
     'cwrap',
     'UTF8ArrayToString',
@@ -408,11 +409,8 @@ function exportRuntime() {
   }
 
   if (!MINIMAL_RUNTIME) {
-    // MINIMAL_RUNTIME has moved these functions to library_strings.js
-    runtimeElements = runtimeElements.concat([
-      'run',
-      'ExitStatus',
-    ]);
+    // Symbols that only exist in the regular runtime.
+    runtimeElements.push('ExitStatus');
   }
 
   if (STACK_OVERFLOW_CHECK) {


### PR DESCRIPTION
The `run` symbol exists in both runtimes, this change means we only have
a single MINIMAL_RUNTIME-only symbol left in this list, which I'm hoping
to remove as a followup.