### PR TITLE
Enable compilation on BE host machines

### DIFF
--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -635,6 +635,8 @@ Environment variables
 
    * "EMCC_SKIP_SANITY_CHECK" [general]
 
+   * "EMCC_SUPPORT_BIG_ENDIAN" [general]
+
    * "EM_IGNORE_SANITY" [general]
 
    * "EM_CONFIG" [general]

--- a/src/settings.js
+++ b/src/settings.js
@@ -293,12 +293,6 @@ var DECLARE_ASM_MODULE_EXPORTS = true;
 // [compile]
 var INLINING_LIMIT = false;
 
-// If set to 1, perform acorn pass that converts each HEAP access into a
-// function call that uses DataView to enforce LE byte order for HEAP buffer;
-// This makes generated JavaScript run on BE as well as LE machines. (If 0, only
-// LE systems are supported). Does not affect generated wasm.
-var SUPPORT_BIG_ENDIAN = false;
-
 // Check each write to the heap, for example, this will give a clear
 // error on what would be segfaults in a native build (like dereferencing
 // 0). See runtime_safe_heap.js for the actual checks performed.

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -122,6 +122,15 @@ class SettingsManager:
     if 'EMCC_STRICT' in os.environ:
       self.attrs['STRICT'] = int(os.environ.get('EMCC_STRICT'))
 
+    # If set, perform acorn pass that converts each HEAP access into a function
+    # call that uses DataView to enforce LE byte order for HEAP buffer; This
+    # makes generated JavaScript run on BE as well as LE machines. (If 0, only
+    # LE systems are supported). Does not affect generated wasm.
+    if 'EMCC_SUPPORT_BIG_ENDIAN' in os.environ:
+      self.attrs['SUPPORT_BIG_ENDIAN'] = int(os.environ.get('EMCC_SUPPORT_BIG_ENDIAN'))
+    else:
+      self.attrs['SUPPORT_BIG_ENDIAN'] = 0
+
     # Special handling for LEGACY_SETTINGS.  See src/setting.js for more
     # details
     for legacy in self.attrs['LEGACY_SETTINGS']:


### PR DESCRIPTION
Issue: https://github.com/emscripten-core/emscripten/issues/12387
Earlier pr https://github.com/emscripten-core/emscripten/pull/13413 enabled compiling for Big-Endian *target* machine, but not support to compile on Big-Endian *host*.

Enable compilation on BE host machines by changing `-sSUPPORT_BIG_ENDIAN` command-line flag to `EMCC_SUPPORT_BIG_ENDIAN` env variable. This avoids cross-cutting changes needed to propagate `-sSUPPORT_BIG_ENDIAN` flag into all nested `emcc` & `em++` calls.

Usage:
```
export EMCC_SUPPORT_BIG_ENDIAN=1
./emcc ...
```

Achieves: Emcc works on Big-Endian *host* and *target* if EMCC_SUPPORT_BIG_ENDIAN is set to 1.
Since `self.attrs` is shared across `*py` scripts, no individual changes in every script are needed.