### PR TITLE
Start using JS `let` in JS library code. NFC

### DIFF
--- a/src/arrayUtils.js
+++ b/src/arrayUtils.js
@@ -15,7 +15,7 @@ function intArrayFromString(stringy, dontAddNull, length) {
 
 function intArrayToString(array) {
   var ret = [];
-  for (var i = 0; i < array.length; i++) {
+  for (let i = 0; i < array.length; i++) {
     var chr = array[i];
     if (chr > 0xFF) {
       if (ASSERTIONS) {

--- a/src/base64Utils.js
+++ b/src/base64Utils.js
@@ -52,7 +52,7 @@ function intArrayFromBase64(s) {
   try {
     var decoded = decodeBase64(s);
     var bytes = new Uint8Array(decoded.length);
-    for (var i = 0 ; i < decoded.length ; ++i) {
+    for (let i = 0 ; i < decoded.length ; ++i) {
       bytes[i] = decoded.charCodeAt(i);
     }
     return bytes;

--- a/src/cpuprofiler.js
+++ b/src/cpuprofiler.js
@@ -76,7 +76,7 @@ var emscriptenCpuProfiler = {
     var now = performance.realNow();
     if (this.fpsCounterTicks.length < this.fpsCounterNumMostRecentFrames) this.fpsCounterTicks.push(now);
     else {
-      for (var i = 0; i < this.fpsCounterTicks.length-1; ++i) this.fpsCounterTicks[i] = this.fpsCounterTicks[i+1];
+      for (let i = 0; i < this.fpsCounterTicks.length-1; ++i) this.fpsCounterTicks[i] = this.fpsCounterTicks[i+1];
       this.fpsCounterTicks[this.fpsCounterTicks.length-1] = now;
     }
   
@@ -90,7 +90,7 @@ var emscriptenCpuProfiler = {
 
       var numSamplesToAccount = Math.min(this.timeSpentInMainloop.length, 120);
       var startX = (this.currentHistogramX - numSamplesToAccount + this.canvas.width) % this.canvas.width;
-      for (var i = 0; i < numSamplesToAccount; ++i) {
+      for (let i = 0; i < numSamplesToAccount; ++i) {
         var x = (startX + i) % this.canvas.width;
         var dt = this.timeSpentInMainloop[x] + this.timeSpentOutsideMainloop[x];
         totalRAFDt += this.timeSpentInMainloop[x];
@@ -102,7 +102,7 @@ var emscriptenCpuProfiler = {
       var avgDt = totalDt / nSamples;
       var avgFps = 1000.0 / avgDt;
       var dtVariance = 0;
-      for (var i = 1; i < numSamplesToAccount; ++i) {
+      for (let i = 1; i < numSamplesToAccount; ++i) {
         var x = (startX + i) % this.canvas.width;
         var dt = this.timeSpentInMainloop[x] + this.timeSpentOutsideMainloop[x];
         var d = dt - avgDt;
@@ -162,7 +162,7 @@ var emscriptenCpuProfiler = {
         accumulatedFrameTimeInsideMainLoop: function(startX, numSamples) {
           var total = 0;
           numSamples = Math.min(numSamples, this.frametimesInsideMainLoop.length);
-          for (var i = 0; i < numSamples; ++i) {
+          for (let i = 0; i < numSamples; ++i) {
             var x = (startX + i) % this.frametimesInsideMainLoop.length;
             if (this.frametimesInsideMainLoop[x]) total += this.frametimesInsideMainLoop[x];
           }
@@ -171,7 +171,7 @@ var emscriptenCpuProfiler = {
         accumulatedFrameTimeOutsideMainLoop: function(startX, numSamples) {
           var total = 0;
           numSamples = Math.min(numSamples, this.frametimesInsideMainLoop.length);
-          for (var i = 0; i < numSamples; ++i) {
+          for (let i = 0; i < numSamples; ++i) {
             var x = (startX + i) % this.frametimesInsideMainLoop.length;
             if (this.frametimesOutsideMainLoop[x]) total += this.frametimesOutsideMainLoop[x];
           }
@@ -201,7 +201,7 @@ var emscriptenCpuProfiler = {
       if (sect.traceable && timeInSection > this.logWebGLCallsSlowerThan) {
         var funcs = new Error().stack.toString().split('\n');
         var cs = '';
-        for (var i = 2; i < 5 && i < funcs.length; ++i) {
+        for (let i = 2; i < 5 && i < funcs.length; ++i) {
           if (i != 2) cs += ' <- ';
           var fn = funcs[i];
           var at = fn.indexOf('@');
@@ -232,7 +232,7 @@ var emscriptenCpuProfiler = {
     if (this.insideMainLoopRecursionCounter != 0) return;
 
     // Aggregate total times spent in each section to memory store to wait until the next stats UI redraw period.
-    for (var i = 0; i < this.sections.length; ++i) {
+    for (let i = 0; i < this.sections.length; ++i) {
       var sect = this.sections[i];
       if (!sect) continue;
       sect.frametimesInsideMainLoop[this.currentHistogramX] = sect.accumulatedTimeInsideMainLoop;
@@ -420,7 +420,7 @@ var emscriptenCpuProfiler = {
 
   drawBar: function drawBar(x) {
     var timeSpentInSectionsInsideMainLoop = 0;
-    for (var i = 0; i < this.sections.length; ++i) {
+    for (let i = 0; i < this.sections.length; ++i) {
       var sect = this.sections[i];
       if (!sect) continue;
       timeSpentInSectionsInsideMainLoop += sect.frametimesInsideMainLoop[x];
@@ -431,7 +431,7 @@ var emscriptenCpuProfiler = {
     y -= h;
     this.drawContext.fillStyle = this.colorCpuTimeSpentInUserCode;
     this.drawContext.fillRect(x, y, 1, h);
-    for (var i = 0; i < this.sections.length; ++i) {
+    for (let i = 0; i < this.sections.length; ++i) {
       var sect = this.sections[i];
       if (!sect) continue;
       h = (sect.frametimesInsideMainLoop[x] + sect.frametimesOutsideMainLoop[x]) * scale;
@@ -496,10 +496,10 @@ var emscriptenCpuProfiler = {
     }
 
     if (endX < startX) {
-      for (var x = startX; x < this.canvas.width; ++x) this.drawBar(x);
+      for (let x = startX; x < this.canvas.width; ++x) this.drawBar(x);
       startX = 0;
     }
-    for (var x = startX; x < endX; ++x) this.drawBar(x);
+    for (let x = startX; x < endX; ++x) this.drawBar(x);
   },
 
   // Work around Microsoft Edge bug where webGLContext.function.length always returns 0.

--- a/src/deterministic.js
+++ b/src/deterministic.js
@@ -20,7 +20,7 @@ Module['thisProgram'] = 'thisProgram'; // for consistency between different buil
 function hashMemory(id) {
   var ret = 0;
   var len = _sbrk();
-  for (var i = 0; i < len; i++) {
+  for (let i = 0; i < len; i++) {
     ret = (ret*17 + HEAPU8[i])|0;
   }
   return id + ':' + ret;
@@ -28,7 +28,7 @@ function hashMemory(id) {
 
 function hashString(s) {
   var ret = 0;
-  for (var i = 0; i < s.length; i++) {
+  for (let i = 0; i < s.length; i++) {
     ret = (ret*17 + s.charCodeAt(i))|0;
   }
   return ret;

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -343,7 +343,7 @@ var LibraryEmbind = {
         if (myTypeConverters.length !== myTypes.length) {
             throwInternalError('Mismatched type converter count');
         }
-        for (var i = 0; i < myTypes.length; ++i) {
+        for (let i = 0; i < myTypes.length; ++i) {
             registerType(myTypes[i], myTypeConverters[i]);
         }
     }
@@ -378,7 +378,7 @@ var LibraryEmbind = {
   $embind_charCodes: undefined,
   $embind_init_charCodes: function() {
     var codes = new Array(256);
-    for (var i = 0; i < 256; ++i) {
+    for (let i = 0; i < 256; ++i) {
         codes[i] = String.fromCharCode(i);
     }
     embind_charCodes = codes;
@@ -404,7 +404,7 @@ var LibraryEmbind = {
 
   $heap32VectorToArray: function(count, firstElement) {
     var array = [];
-    for (var i = 0; i < count; i++) {
+    for (let i = 0; i < count; i++) {
         // TODO(https://github.com/emscripten-core/emscripten/issues/17310):
         // Find a way to hoist the `>> 2` or `>> 3` out of this loop.
         array.push({{{ makeGetValue('firstElement', 'i * ' + POINTER_SIZE, '*') }}});
@@ -701,7 +701,7 @@ var LibraryEmbind = {
         if (stdStringIsUTF8) {
           var decodeStartPtr = payload;
           // Looping here to support possible embedded '0' bytes
-          for (var i = 0; i <= length; ++i) {
+          for (let i = 0; i <= length; ++i) {
             var currentBytePtr = payload + i;
             if (i == length || HEAPU8[currentBytePtr] == 0) {
               var maxRead = currentBytePtr - decodeStartPtr;
@@ -755,7 +755,7 @@ var LibraryEmbind = {
           stringToUTF8(value, ptr, length + 1);
         } else {
           if (valueIsOfTypeString) {
-            for (var i = 0; i < length; ++i) {
+            for (let i = 0; i < length; ++i) {
               var charCode = value.charCodeAt(i);
               if (charCode > 255) {
                 _free(ptr);
@@ -813,7 +813,7 @@ var LibraryEmbind = {
 
         var decodeStartPtr = value + 4;
         // Looping here to support possible embedded '0' bytes
-        for (var i = 0; i <= length; ++i) {
+        for (let i = 0; i <= length; ++i) {
           var currentBytePtr = value + 4 + i * charSize;
           if (i == length || HEAP[currentBytePtr >> shift] == 0) {
             var maxReadBytes = currentBytePtr - decodeStartPtr;
@@ -999,7 +999,7 @@ var LibraryEmbind = {
     // TODO: Remove this completely once all function invokers are being dynamically generated.
     var needsDestructorStack = false;
 
-    for (var i = 1; i < argTypes.length; ++i) { // Skip return value at index 0 - it's not deleted here.
+    for (let i = 1; i < argTypes.length; ++i) { // Skip return value at index 0 - it's not deleted here.
       if (argTypes[i] !== null && argTypes[i].destructorFunction === undefined) { // The type does not define a destructor function - must use dynamic stack
         needsDestructorStack = true;
         break;
@@ -1030,7 +1030,7 @@ var LibraryEmbind = {
         thisWired = argTypes[1]['toWireType'](destructors, this);
         invokerFuncArgs[1] = thisWired;
       }
-      for (var i = 0; i < expectedArgCount; ++i) {
+      for (let i = 0; i < expectedArgCount; ++i) {
         argsWired[i] = argTypes[i + 2]['toWireType'](destructors, arguments[i]);
         invokerFuncArgs.push(argsWired[i]);
       }
@@ -1041,7 +1041,7 @@ var LibraryEmbind = {
         if (needsDestructorStack) {
           runDestructors(destructors);
         } else {
-          for (var i = isClassMethodFunc ? 1 : 2; i < argTypes.length; i++) {
+          for (let i = isClassMethodFunc ? 1 : 2; i < argTypes.length; i++) {
             var param = i === 1 ? thisWired : argsWired[i - 2];
             if (argTypes[i].destructorFunction !== null) {
               argTypes[i].destructorFunction(param);
@@ -1069,7 +1069,7 @@ var LibraryEmbind = {
 #else
     var argsList = "";
     var argsListWired = "";
-    for (var i = 0; i < argCount - 2; ++i) {
+    for (let i = 0; i < argCount - 2; ++i) {
       argsList += (i!==0?", ":"")+"arg"+i;
       argsListWired += (i!==0?", ":"")+"arg"+i+"Wired";
     }
@@ -1101,7 +1101,7 @@ var LibraryEmbind = {
       invokerFnBody += "var thisWired = classParam.toWireType("+dtorStack+", this);\n";
     }
 
-    for (var i = 0; i < argCount - 2; ++i) {
+    for (let i = 0; i < argCount - 2; ++i) {
       invokerFnBody += "var arg"+i+"Wired = argType"+i+".toWireType("+dtorStack+", arg"+i+"); // "+argTypes[i+2].name+"\n";
       args1.push("argType"+i);
       args2.push(argTypes[i+2]);
@@ -1123,7 +1123,7 @@ var LibraryEmbind = {
     if (needsDestructorStack) {
       invokerFnBody += "runDestructors(destructors);\n";
     } else {
-      for (var i = isClassMethodFunc?1:2; i < argTypes.length; ++i) { // Skip return value at index 0 - it's not deleted here. Also skip class type if not a method.
+      for (let i = isClassMethodFunc?1:2; i < argTypes.length; ++i) { // Skip return value at index 0 - it's not deleted here. Also skip class type if not a method.
         var paramName = (i === 1 ? "thisWired" : ("arg"+(i - 2)+"Wired"));
         if (argTypes[i].destructorFunction !== null) {
           invokerFnBody += paramName+"_dtor("+paramName+"); // "+argTypes[i].name+"\n";
@@ -1295,7 +1295,7 @@ var LibraryEmbind = {
         name: reg.name,
         'fromWireType': function(ptr) {
           var rv = new Array(elementsLength);
-          for (var i = 0; i < elementsLength; ++i) {
+          for (let i = 0; i < elementsLength; ++i) {
             rv[i] = elements[i].read(ptr);
           }
           rawDestructor(ptr);
@@ -1306,7 +1306,7 @@ var LibraryEmbind = {
             throw new TypeError("Incorrect number of tuple elements for " + reg.name + ": expected=" + elementsLength + ", actual=" + o.length);
           }
           var ptr = rawConstructor();
-          for (var i = 0; i < elementsLength; ++i) {
+          for (let i = 0; i < elementsLength; ++i) {
             elements[i].write(ptr, o[i]);
           }
           if (destructors !== null) {

--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -37,7 +37,7 @@ var LibraryEmVal = {
   $count_emval_handles__deps: ['$emval_handle_array'],
   $count_emval_handles: function() {
     var count = 0;
-    for (var i = 5; i < emval_handle_array.length; ++i) {
+    for (let i = 5; i < emval_handle_array.length; ++i) {
       if (emval_handle_array[i] !== undefined) {
         ++count;
       }
@@ -47,7 +47,7 @@ var LibraryEmVal = {
 
   $get_first_emval__deps: ['$emval_handle_array'],
   $get_first_emval: function() {
-    for (var i = 5; i < emval_handle_array.length; ++i) {
+    for (let i = 5; i < emval_handle_array.length; ++i) {
       if (emval_handle_array[i] !== undefined) {
         return emval_handle_array[i];
       }
@@ -187,7 +187,7 @@ var LibraryEmVal = {
     var argsList = new Array(argCount + 1);
     return function(constructor, argTypes, args) {
       argsList[0] = constructor;
-      for (var i = 0; i < argCount; ++i) {
+      for (let i = 0; i < argCount; ++i) {
         var argType = requireRegisteredType({{{ makeGetValue('argTypes', 'i * POINTER_SIZE', '*') }}}, 'parameter ' + i);
         argsList[i + 1] = argType['readValueFromPointer'](args);
         args += argType['argPackAdvance'];
@@ -197,14 +197,14 @@ var LibraryEmVal = {
     };
 #else
     var argsList = "";
-    for (var i = 0; i < argCount; ++i) {
+    for (let i = 0; i < argCount; ++i) {
       argsList += (i!==0?", ":"")+"arg"+i; // 'arg0, arg1, ..., argn'
     }
 
     var functionBody =
         "return function emval_allocator_"+argCount+"(constructor, argTypes, args) {\n";
 
-    for (var i = 0; i < argCount; ++i) {
+    for (let i = 0; i < argCount; ++i) {
         functionBody +=
             "var argType"+i+" = requireRegisteredType({{{ makeGetValue('argTypes', '0', '*') }}}, 'parameter "+i+"');\n" +
             "var arg"+i+" = argType"+i+".readValueFromPointer(args);\n" +
@@ -381,7 +381,7 @@ var LibraryEmVal = {
     var types = emval_lookupTypes(argCount, argTypes);
 
     var args = new Array(argCount);
-    for (var i = 0; i < argCount; ++i) {
+    for (let i = 0; i < argCount; ++i) {
       var type = types[i];
       args[i] = type['readValueFromPointer'](argv);
       argv += type['argPackAdvance'];
@@ -394,7 +394,7 @@ var LibraryEmVal = {
   $emval_lookupTypes__deps: ['$requireRegisteredType'],
   $emval_lookupTypes: function(argCount, argTypes) {
     var a = new Array(argCount);
-    for (var i = 0; i < argCount; ++i) {
+    for (let i = 0; i < argCount; ++i) {
       a[i] = requireRegisteredType({{{ makeGetValue('argTypes', 'i * POINTER_SIZE', '*') }}},
                                    "parameter " + i);
     }
@@ -435,12 +435,12 @@ var LibraryEmVal = {
     var argN = new Array(argCount - 1);
     var invokerFunction = (handle, name, destructors, args) => {
       var offset = 0;
-      for (var i = 0; i < argCount - 1; ++i) {
+      for (let i = 0; i < argCount - 1; ++i) {
         argN[i] = types[i + 1]['readValueFromPointer'](args + offset);
         offset += types[i + 1]['argPackAdvance'];
       }
       var rv = handle[name].apply(handle, argN);
-      for (var i = 0; i < argCount - 1; ++i) {
+      for (let i = 0; i < argCount - 1; ++i) {
         if (types[i + 1].deleteObject) {
           types[i + 1].deleteObject(argN[i]);
         }
@@ -454,7 +454,7 @@ var LibraryEmVal = {
     var args = [retType];
 
     var argsList = ""; // 'arg0, arg1, arg2, ... , argN'
-    for (var i = 0; i < argCount - 1; ++i) {
+    for (let i = 0; i < argCount - 1; ++i) {
       argsList += (i !== 0 ? ", " : "") + "arg" + i;
       params.push("argType" + i);
       args.push(types[1 + i]);
@@ -465,14 +465,14 @@ var LibraryEmVal = {
         "return function " + functionName + "(handle, name, destructors, args) {\n";
 
     var offset = 0;
-    for (var i = 0; i < argCount - 1; ++i) {
+    for (let i = 0; i < argCount - 1; ++i) {
         functionBody +=
         "    var arg" + i + " = argType" + i + ".readValueFromPointer(args" + (offset ? ("+"+offset) : "") + ");\n";
         offset += types[i + 1]['argPackAdvance'];
     }
     functionBody +=
         "    var rv = handle[name](" + argsList + ");\n";
-    for (var i = 0; i < argCount - 1; ++i) {
+    for (let i = 0; i < argCount - 1; ++i) {
         if (types[i + 1]['deleteObject']) {
             functionBody +=
             "    argType" + i + ".deleteObject(arg" + i + ");\n";

--- a/src/headless.js
+++ b/src/headless.js
@@ -60,7 +60,7 @@ var window = {
       // rafs
       var currRafs = window.rafs;
       window.rafs = [];
-      for (var i = 0; i < currRafs.length; i++) {
+      for (let i = 0; i < currRafs.length; i++) {
         var raf = currRafs[i];
         headlessPrint('calling raf: ' + raf.uid);// + ': ' + raf.toString().substring(0, 50));
         raf();
@@ -90,7 +90,7 @@ var window = {
   removeEventListener: function(id, func) {
     var listeners = this.eventListeners[id];
     if (!listeners) return;
-    for (var i = 0; i < listeners.length; i++) {
+    for (let i = 0; i < listeners.length; i++) {
       if (listeners[i] === func) {
         listeners.splice(i, 1);
         return;
@@ -194,7 +194,7 @@ var performance = {
 };
 function fixPath(path) {
   if (path[0] == '/') path = path.substring(1);
-  for (var i = 0; i < window.dirsToDrop; i++) {
+  for (let i = 0; i < window.dirsToDrop; i++) {
     path = '../' + path;
   }
   return path

--- a/src/library.js
+++ b/src/library.js
@@ -45,7 +45,7 @@ mergeInto(LibraryManager.library, {
   $zeroMemory: function(address, size) {
 #if LEGACY_VM_SUPPORT
     if (!HEAPU8.fill) {
-      for (var i = 0; i < size; i++) {
+      for (let i = 0; i < size; i++) {
         HEAPU8[address + i] = 0;
       }
       return;
@@ -283,7 +283,7 @@ mergeInto(LibraryManager.library, {
     // Loop through potential heap size increases. If we attempt a too eager
     // reservation that fails, cut down on the attempted size and reserve a
     // smaller bump instead. (max 3 times, chosen somewhat arbitrarily)
-    for (var cutDown = 1; cutDown <= 4; cutDown *= 2) {
+    for (let cutDown = 1; cutDown <= 4; cutDown *= 2) {
 #if MEMORY_GROWTH_LINEAR_STEP == -1
       var overGrownHeapSize = oldSize * (1 + {{{ MEMORY_GROWTH_GEOMETRIC_STEP }}} / cutDown); // ensure geometric growth
 #if MEMORY_GROWTH_GEOMETRIC_CAP
@@ -411,7 +411,7 @@ mergeInto(LibraryManager.library, {
     // http://linux.die.net/man/3/getloadavg
     var limit = Math.min(nelem, 3);
     var doubleSize = {{{ Runtime.getNativeTypeSize('double') }}};
-    for (var i = 0; i < limit; i++) {
+    for (let i = 0; i < limit; i++) {
       {{{ makeSetValue('loadavg', 'i * doubleSize', '0.1', 'double') }}};
     }
     return limit;
@@ -668,7 +668,7 @@ mergeInto(LibraryManager.library, {
 
   _arraySum: function(array, index) {
     var sum = 0;
-    for (var i = 0; i <= index; sum += array[i++]) {
+    for (let i = 0; i <= index; sum += array[i++]) {
       // no-op
     }
     return sum;
@@ -1009,7 +1009,7 @@ mergeInto(LibraryManager.library, {
     // escape special characters
     // TODO: not sure we really need to escape all of these in JS regexps
     var SPECIAL_CHARS = '\\!@#$^&*()+=-[]/{}|:<>?,.';
-    for (var i=0, ii=SPECIAL_CHARS.length; i<ii; ++i) {
+    for (let i=0, ii=SPECIAL_CHARS.length; i<ii; ++i) {
       pattern = pattern.replace(new RegExp('\\'+SPECIAL_CHARS[i], 'g'), '\\'+SPECIAL_CHARS[i]);
     }
 
@@ -1066,7 +1066,7 @@ mergeInto(LibraryManager.library, {
 
     // take care of capturing groups
     var capture = [];
-    for (var i=pattern.indexOf('%'); i>=0; i=pattern.indexOf('%')) {
+    for (let i=pattern.indexOf('%'); i>=0; i=pattern.indexOf('%')) {
       capture.push(pattern[i+1]);
       pattern = pattern.replace(new RegExp('\\%'+pattern[i+1], 'g'), '');
     }
@@ -1160,7 +1160,7 @@ mergeInto(LibraryManager.library, {
         // get day of month from day of year ...
         var day = jstoi_q(value);
         var leapYear = __isLeapYear(date.year);
-        for (var month=0; month<12; ++month) {
+        for (let month=0; month<12; ++month) {
           var daysUntilMonth = __arraySum(leapYear ? __MONTH_DAYS_LEAP : __MONTH_DAYS_REGULAR, month-1);
           if (day<=daysUntilMonth+(leapYear ? __MONTH_DAYS_LEAP : __MONTH_DAYS_REGULAR)[month]) {
             date.day = day-daysUntilMonth;
@@ -1558,7 +1558,7 @@ mergeInto(LibraryManager.library, {
 
   $inetPton4: function(str) {
     var b = str.split('.');
-    for (var i = 0; i < 4; i++) {
+    for (let i = 0; i < 4; i++) {
       var tmp = Number(b[i]);
       if (isNaN(tmp)) return null;
       b[i] = tmp;
@@ -2135,7 +2135,7 @@ mergeInto(LibraryManager.library, {
       var length = aliases.length;
       var aliasListBuf = _malloc((length + 1) * 4); // Use length + 1 so we have space for the terminating NULL ptr.
 
-      for (var i = 0; i < length; i++, j += 4) {
+      for (let i = 0; i < length; i++, j += 4) {
         var alias = aliases[i];
         var aliasBuf = _malloc(alias.length + 1);
         writeAsciiToMemory(alias, aliasBuf);
@@ -2254,7 +2254,7 @@ mergeInto(LibraryManager.library, {
 #endif // ENVIRONMENT_MAY_BE_NODE
     // we couldn't find a proper implementation, as Math.random() is not suitable for /dev/random, see emscripten-core/emscripten/pull/7096
 #if ASSERTIONS
-    return () => abort("no cryptographic support found for randomDevice. consider polyfilling it if you want to use something insecure like Math.random(), e.g. put this in a --pre-js: var crypto = { getRandomValues: function(array) { for (var i = 0; i < array.length; i++) array[i] = (Math.random()*256)|0 } };");
+    return () => abort("no cryptographic support found for randomDevice. consider polyfilling it if you want to use something insecure like Math.random(), e.g. put this in a --pre-js: var crypto = { getRandomValues: function(array) { for (let i = 0; i < array.length; i++) array[i] = (Math.random()*256)|0 } };");
 #else
     return () => abort("randomDevice");
 #endif
@@ -2266,7 +2266,7 @@ mergeInto(LibraryManager.library, {
     if (!_getentropy.randomDevice) {
       _getentropy.randomDevice = getRandomDevice();
     }
-    for (var i = 0; i < size; i++) {
+    for (let i = 0; i < size; i++) {
       {{{ makeSetValue('buffer', 'i', '_getentropy.randomDevice()', 'i8') }}};
     }
     return 0;
@@ -3094,7 +3094,7 @@ mergeInto(LibraryManager.library, {
   _Unwind_Backtrace: function(func, arg) {
     var trace = _emscripten_get_callstack_js();
     var parts = trace.split('\n');
-    for (var i = 0; i < parts.length; i++) {
+    for (let i = 0; i < parts.length; i++) {
       var ret = {{{ makeDynCall('iii', 'func') }}}(0, arg);
       if (ret !== 0) return;
     }

--- a/src/library_addfunction.js
+++ b/src/library_addfunction.js
@@ -36,7 +36,7 @@ mergeInto(LibraryManager.library, {
       parameters: [],
       results: sig[0] == 'v' ? [] : [typeNames[sig[0]]]
     };
-    for (var i = 1; i < sig.length; ++i) {
+    for (let i = 1; i < sig.length; ++i) {
 #if ASSERTIONS
       assert(sig[i] in typeNames, 'invalid signature char: ' + sig[i]);
 #endif
@@ -82,7 +82,7 @@ mergeInto(LibraryManager.library, {
 
     // Parameters, length + signatures
     uleb128Encode(sigParam.length, typeSectionBody);
-    for (var i = 0; i < sigParam.length; ++i) {
+    for (let i = 0; i < sigParam.length; ++i) {
 #if ASSERTIONS
       assert(sigParam[i] in typeCodes, 'invalid signature char: ' + sigParam[i]);
 #endif
@@ -152,7 +152,7 @@ mergeInto(LibraryManager.library, {
   $updateTableMap__deps: ['$getWasmTableEntry'],
   $updateTableMap: function(offset, count) {
     if (functionsInTableMap) {
-      for (var i = offset; i < offset + count; i++) {
+      for (let i = offset; i < offset + count; i++) {
         var item = getWasmTableEntry(i);
         // Ignore null values.
         if (item) {
@@ -191,7 +191,7 @@ mergeInto(LibraryManager.library, {
     // Make sure functionsInTableMap is actually up to date, that is, that this
     // function is not actually in the wasm Table despite not being tracked in
     // functionsInTableMap.
-    for (var i = 0; i < wasmTable.length; i++) {
+    for (let i = 0; i < wasmTable.length; i++) {
       assert(getWasmTableEntry(i) != func, 'function in Table but not functionsInTableMap');
     }
   #endif

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -211,7 +211,7 @@ var LibraryBrowser = {
               var ret = '';
               var leftchar = 0;
               var leftbits = 0;
-              for (var i = 0; i < data.length; i++) {
+              for (let i = 0; i < data.length; i++) {
                 leftchar = (leftchar << 8) | data[i];
                 leftbits += 8;
                 while (leftbits >= 6) {
@@ -1201,7 +1201,7 @@ var LibraryBrowser = {
   emscripten_hide_mouse: function() {
     var styleSheet = document.styleSheets[0];
     var rules = styleSheet.cssRules;
-    for (var i = 0; i < rules.length; i++) {
+    for (let i = 0; i < rules.length; i++) {
       if (rules[i].cssText.substr(0, 6) == 'canvas') {
         styleSheet.deleteRule(i);
         i--;

--- a/src/library_ccall.js
+++ b/src/library_ccall.js
@@ -65,7 +65,7 @@ mergeInto(LibraryManager.library, {
     assert(returnType !== 'array', 'Return type should not be "array".');
 #endif
     if (args) {
-      for (var i = 0; i < args.length; i++) {
+      for (let i = 0; i < args.length; i++) {
         var converter = toC[argTypes[i]];
         if (converter) {
           if (stack === 0) stack = stackSave();

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -376,7 +376,7 @@ var LibraryDylink = {
       // current module could resolve its imports. (see tools/shared.py
       // WebAssembly.make_shared_library() for "dylink" section extension format)
       var neededDynlibsCount = getLEB();
-      for (var i = 0; i < neededDynlibsCount; ++i) {
+      for (let i = 0; i < neededDynlibsCount; ++i) {
         var libname = getString();
         customSection.neededDynlibs.push(libname);
       }
@@ -399,7 +399,7 @@ var LibraryDylink = {
           customSection.tableAlign = getLEB();
         } else if (subsectionType === WASM_DYLINK_NEEDED) {
           var neededDynlibsCount = getLEB();
-          for (var i = 0; i < neededDynlibsCount; ++i) {
+          for (let i = 0; i < neededDynlibsCount; ++i) {
             libname = getString();
             customSection.neededDynlibs.push(libname);
           }
@@ -490,7 +490,7 @@ var LibraryDylink = {
 
 #if DYLINK_DEBUG
   $dumpTable: function() {
-    for (var i = 0; i < wasmTable.length; i++)
+    for (let i = 0; i < wasmTable.length; i++)
       err('table: ' + i + ' : ' + wasmTable.get(i));
   },
 #endif

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -363,7 +363,7 @@ var LibraryExceptions = {
     // Due to inheritance, those types may not precisely match the
     // type of the thrown object. Find one which matches, and
     // return the type of the catch block which should be called.
-    for (var i = 0; i < typeArray.length; i++) {
+    for (let i = 0; i < typeArray.length; i++) {
       var caughtType = typeArray[i];
       if (caughtType === 0 || caughtType === thrownType) {
         // Catch all clause matched or exactly the same type is caught

--- a/src/library_formatString.js
+++ b/src/library_formatString.js
@@ -254,7 +254,7 @@ mergeInto(LibraryManager.library, {
                 currArg = -currArg;
                 argText = (currAbsArg - 1).toString(16);
                 var buffer = [];
-                for (var i = 0; i < argText.length; i++) {
+                for (let i = 0; i < argText.length; i++) {
                   buffer.push((0xF - parseInt(argText[i], 16)).toString(16));
                 }
                 argText = buffer.join('');
@@ -419,7 +419,7 @@ mergeInto(LibraryManager.library, {
               }
             }
             if (arg) {
-              for (var i = 0; i < argLength; i++) {
+              for (let i = 0; i < argLength; i++) {
                 ret.push({{{ makeGetValue('arg++', 0, 'u8') }}});
               }
             } else {
@@ -454,7 +454,7 @@ mergeInto(LibraryManager.library, {
           }
           default: {
             // Unknown specifiers remain untouched.
-            for (var i = startTextIndex; i < textIndex + 2; i++) {
+            for (let i = startTextIndex; i < textIndex + 2; i++) {
               ret.push({{{ makeGetValue(0, 'i', 'i8') }}});
             }
           }

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -137,7 +137,7 @@ FS.staticInit();` +
       var current = FS.root;
       var current_path = '/';
 
-      for (var i = 0; i < parts.length; i++) {
+      for (let i = 0; i < parts.length; i++) {
         var islast = (i === parts.length-1);
         if (islast && opts.parent) {
           // stop resolving
@@ -197,7 +197,7 @@ FS.staticInit();` +
       name = name.toLowerCase();
 #endif
 
-      for (var i = 0; i < name.length; i++) {
+      for (let i = 0; i < name.length; i++) {
         hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
       }
       return ((parentid + hash) >>> 0) % FS.nameTable.length;
@@ -387,7 +387,7 @@ FS.staticInit();` +
     //
     MAX_OPEN_FDS: 4096,
     nextfd: (fd_start = 0, fd_end = FS.MAX_OPEN_FDS) => {
-      for (var fd = fd_start; fd <= fd_end; fd++) {
+      for (let fd = fd_start; fd <= fd_end; fd++) {
         if (!FS.streams[fd]) {
           return fd;
         }
@@ -673,7 +673,7 @@ FS.staticInit();` +
     mkdirTree: (path, mode) => {
       var dirs = path.split('/');
       var d = '';
-      for (var i = 0; i < dirs.length; ++i) {
+      for (let i = 0; i < dirs.length; ++i) {
         if (!dirs[i]) continue;
         d += '/' + dirs[i];
         try {
@@ -1504,7 +1504,7 @@ FS.staticInit();` +
       _fflush(0);
 #endif
       // close all of our streams
-      for (var i = 0; i < FS.streams.length; i++) {
+      for (let i = 0; i < FS.streams.length; i++) {
         var stream = FS.streams[i];
         if (!stream) {
           continue;
@@ -1589,7 +1589,7 @@ FS.staticInit();` +
       if (data) {
         if (typeof data == 'string') {
           var arr = new Array(data.length);
-          for (var i = 0, len = data.length; i < len; ++i) arr[i] = data.charCodeAt(i);
+          for (let i = 0, len = data.length; i < len; ++i) arr[i] = data.charCodeAt(i);
           data = arr;
         }
         // make sure we can write to the file
@@ -1620,7 +1620,7 @@ FS.staticInit();` +
         },
         read: (stream, buffer, offset, length, pos /* ignored */) => {
           var bytesRead = 0;
-          for (var i = 0; i < length; i++) {
+          for (let i = 0; i < length; i++) {
             var result;
             try {
               result = input();
@@ -1824,11 +1824,11 @@ FS.staticInit();` +
         assert(size >= 0);
 #endif
         if (contents.slice) { // normal array
-          for (var i = 0; i < size; i++) {
+          for (let i = 0; i < size; i++) {
             buffer[offset + i] = contents[position + i];
           }
         } else {
-          for (var i = 0; i < size; i++) { // LazyUint8Array from sync binary XHR
+          for (let i = 0; i < size; i++) { // LazyUint8Array from sync binary XHR
             buffer[offset + i] = contents.get(position + i);
           }
         }

--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -139,7 +139,7 @@ var LibraryGLEmulation = {
 
       GLEmulation.fogColor = new Float32Array(4);
 
-      for (var clipPlaneId = 0; clipPlaneId < GLEmulation.MAX_CLIP_PLANES; clipPlaneId++) {
+      for (let clipPlaneId = 0; clipPlaneId < GLEmulation.MAX_CLIP_PLANES; clipPlaneId++) {
         GLEmulation.clipPlaneEquation[clipPlaneId] = new Float32Array(4);
       }
 
@@ -151,7 +151,7 @@ var LibraryGLEmulation = {
       GLEmulation.materialShininess = new Float32Array([0.0]);
       GLEmulation.materialEmission = new Float32Array([0.0, 0.0, 0.0, 1.0]);
 
-      for (var lightId = 0; lightId < GLEmulation.MAX_LIGHTS; lightId++) {
+      for (let lightId = 0; lightId < GLEmulation.MAX_LIGHTS; lightId++) {
         GLEmulation.lightAmbient[lightId] = new Float32Array([0.0, 0.0, 0.0, 1.0]);
         GLEmulation.lightDiffuse[lightId] = lightId ? new Float32Array([0.0, 0.0, 0.0, 1.0]) : new Float32Array([1.0, 1.0, 1.0, 1.0]);
         GLEmulation.lightSpecular[lightId] = lightId ? new Float32Array([0.0, 0.0, 0.0, 1.0]) : new Float32Array([1.0, 1.0, 1.0, 1.0]);
@@ -487,7 +487,7 @@ var LibraryGLEmulation = {
           if (need_mm && !has_mm) source = 'uniform mat4 u_modelView; \n' + source;
           if (need_pm && !has_pm) source = 'uniform mat4 u_projection; \n' + source;
           GL.shaderInfos[shader].ftransform = need_pm || need_mm || need_pv; // we will need to provide the fixed function stuff as attributes and uniforms
-          for (var i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
+          for (let i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
             // XXX To handle both regular texture mapping and cube mapping, we use vec4 for tex coordinates.
             old = source;
             var need_vtc = source.search('v_texCoord' + i) == -1;
@@ -1590,7 +1590,7 @@ var LibraryGLEmulation = {
           assert(maxTexUnits > 0);
 #endif
           s_texUnits = [];
-          for (var i = 0; i < maxTexUnits; i++) {
+          for (let i = 0; i < maxTexUnits; i++) {
             s_texUnits.push(new CTexUnit());
           }
         },
@@ -1606,7 +1606,7 @@ var LibraryGLEmulation = {
           s_requiredTexUnitsForPass.length = 0; // Clear the list.
           var lines = [];
           var lastPassVar = PRIM_COLOR_VARYING;
-          for (var i = 0; i < s_texUnits.length; i++) {
+          for (let i = 0; i < s_texUnits.length; i++) {
             if (!s_texUnits[i].enabled()) continue;
 
             s_requiredTexUnitsForPass.push(i);
@@ -1622,7 +1622,7 @@ var LibraryGLEmulation = {
           lines.push(resultDest + " = " + lastPassVar + ";");
 
           var indent = "";
-          for (var i = 0; i < indentSize; i++) indent += " ";
+          for (let i = 0; i < indentSize; i++) indent += " ";
 
           var output = indent + lines.join("\n" + indent);
 
@@ -1638,7 +1638,7 @@ var LibraryGLEmulation = {
         },
 
         traverseState: function(keyView) {
-          for (var i = 0; i < s_texUnits.length; i++) {
+          for (let i = 0; i < s_texUnits.length; i++) {
             s_texUnits[i].traverseState(keyView);
           }
         },
@@ -1879,7 +1879,7 @@ var LibraryGLEmulation = {
           var env = getCurTexUnit().env;
           switch (pname) {
             case GL_TEXTURE_ENV_COLOR: {
-              for (var i = 0; i < 4; i++) {
+              for (let i = 0; i < 4; i++) {
                 var param = {{{ makeGetValue('params', 'i*4', 'float') }}};
                 if (env.envColor[i] != param) {
                   env.invalidateKey(); // We changed FFP emulation renderer state.
@@ -2042,7 +2042,7 @@ var LibraryGLEmulation = {
     setClientAttribute: function setClientAttribute(name, size, type, stride, pointer) {
       var attrib = GLImmediate.clientAttributes[name];
       if (!attrib) {
-        for (var i = 0; i <= name; i++) { // keep flat
+        for (let i = 0; i <= name; i++) { // keep flat
           if (!GLImmediate.clientAttributes[i]) {
             GLImmediate.clientAttributes[i] = {
               name: name,
@@ -2088,7 +2088,7 @@ var LibraryGLEmulation = {
     },
 
     disableBeginEndClientAttributes: function disableBeginEndClientAttributes() {
-      for (var i = 0; i < GLImmediate.NUM_ATTRIBUTES; i++) {
+      for (let i = 0; i < GLImmediate.NUM_ATTRIBUTES; i++) {
         if (GLImmediate.rendererComponents[i]) GLImmediate.enabledClientAttributes[i] = false;
       }
     },
@@ -2107,7 +2107,7 @@ var LibraryGLEmulation = {
 
       // By attrib state:
       var enabledAttributesKey = 0;
-      for (var i = 0; i < attributes.length; i++) {
+      for (let i = 0; i < attributes.length; i++) {
         enabledAttributesKey |= 1 << attributes[i].name;
       }
 
@@ -2134,13 +2134,13 @@ var LibraryGLEmulation = {
       enabledAttributesKey = (enabledAttributesKey << 2) | fogParam;
 
       // By clip plane mode
-      for (var clipPlaneId = 0; clipPlaneId < GLEmulation.MAX_CLIP_PLANES; clipPlaneId++) {
+      for (let clipPlaneId = 0; clipPlaneId < GLEmulation.MAX_CLIP_PLANES; clipPlaneId++) {
         enabledAttributesKey = (enabledAttributesKey << 1) | GLEmulation.clipPlaneEnabled[clipPlaneId];
       }
 
       // By lighting mode and enabled lights
       enabledAttributesKey = (enabledAttributesKey << 1) | GLEmulation.lightingEnabled;
-      for (var lightId = 0; lightId < GLEmulation.MAX_LIGHTS; lightId++) {
+      for (let lightId = 0; lightId < GLEmulation.MAX_LIGHTS; lightId++) {
         enabledAttributesKey = (enabledAttributesKey << 1) | (GLEmulation.lightingEnabled ? GLEmulation.lightEnabled[lightId] : 0);
       }
 
@@ -2180,7 +2180,7 @@ var LibraryGLEmulation = {
     createRenderer: function createRenderer(renderer) {
       var useCurrProgram = !!GL.currProgram;
       var hasTextures = false;
-      for (var i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
+      for (let i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
         var texAttribName = GLImmediate.TEXTURE0 + i;
         if (!GLImmediate.enabledClientAttributes[texAttribName])
           continue;
@@ -2246,7 +2246,7 @@ var LibraryGLEmulation = {
             var texUnitUniformList = '';
             var vsTexCoordInits = '';
             this.usedTexUnitList = GLImmediate.TexEnvJIT.getUsedTexUnitList();
-            for (var i = 0; i < this.usedTexUnitList.length; i++) {
+            for (let i = 0; i < this.usedTexUnitList.length; i++) {
               var texUnit = this.usedTexUnitList[i];
               texUnitAttribList += 'attribute vec4 ' + aTexCoordPrefix + texUnit + ';\n';
               texUnitVaryingList += 'varying vec4 ' + vTexCoordPrefix + texUnit + ';\n';
@@ -2274,7 +2274,7 @@ var LibraryGLEmulation = {
             var vsClipPlaneInit = '';
             var fsClipPlaneDefs = '';
             var fsClipPlanePass = '';
-            for (var clipPlaneId = 0; clipPlaneId < GLEmulation.MAX_CLIP_PLANES; clipPlaneId++) {
+            for (let clipPlaneId = 0; clipPlaneId < GLEmulation.MAX_CLIP_PLANES; clipPlaneId++) {
               if (GLEmulation.clipPlaneEnabled[clipPlaneId]) {
                 vsClipPlaneDefs += 'uniform vec4 u_clipPlaneEquation' + clipPlaneId + ';';
                 vsClipPlaneDefs += 'varying float v_clipDistance' + clipPlaneId + ';';
@@ -2301,7 +2301,7 @@ var LibraryGLEmulation = {
               vsLightingPass += '  v_color.xyz = u_materialEmission.xyz;';
               vsLightingPass += '  v_color.xyz += u_lightModelAmbient.xyz * u_materialAmbient.xyz;';
 
-              for (var lightId = 0; lightId < GLEmulation.MAX_LIGHTS; lightId++) {
+              for (let lightId = 0; lightId < GLEmulation.MAX_LIGHTS; lightId++) {
                 if (GLEmulation.lightEnabled[lightId]) {
                   vsLightingDefs += 'uniform vec4 u_lightAmbient' + lightId + ';';
                   vsLightingDefs += 'uniform vec4 u_lightDiffuse' + lightId + ';';
@@ -2443,7 +2443,7 @@ var LibraryGLEmulation = {
             GLctx.bindAttribLocation(this.program, GLImmediate.COLOR, 'a_color');
             GLctx.bindAttribLocation(this.program, GLImmediate.NORMAL, 'a_normal');
             var maxVertexAttribs = GLctx.getParameter(GLctx.MAX_VERTEX_ATTRIBS);
-            for (var i = 0; i < GLImmediate.MAX_TEXTURES && GLImmediate.TEXTURE0 + i < maxVertexAttribs; i++) {
+            for (let i = 0; i < GLImmediate.MAX_TEXTURES && GLImmediate.TEXTURE0 + i < maxVertexAttribs; i++) {
               GLctx.bindAttribLocation(this.program, GLImmediate.TEXTURE0 + i, 'a_texCoord'+i);
               GLctx.bindAttribLocation(this.program, GLImmediate.TEXTURE0 + i, aTexCoordPrefix+i);
             }
@@ -2458,7 +2458,7 @@ var LibraryGLEmulation = {
 
           this.texCoordLocations = [];
 
-          for (var i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
+          for (let i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
             if (!GLImmediate.enabledClientAttributes[GLImmediate.TEXTURE0 + i]) {
               this.texCoordLocations[i] = -1;
               continue;
@@ -2476,7 +2476,7 @@ var LibraryGLEmulation = {
             var prevBoundProg = GLctx.getParameter(GLctx.CURRENT_PROGRAM);
             GLctx.useProgram(this.program);
             {
-              for (var i = 0; i < this.usedTexUnitList.length; i++) {
+              for (let i = 0; i < this.usedTexUnitList.length; i++) {
                 var texUnitID = this.usedTexUnitList[i];
                 var texSamplerLoc = GLctx.getUniformLocation(this.program, uTexUnitPrefix + texUnitID);
                 GLctx.uniform1i(texSamplerLoc, texUnitID);
@@ -2489,7 +2489,7 @@ var LibraryGLEmulation = {
           }
 
           this.textureMatrixLocations = [];
-          for (var i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
+          for (let i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
             this.textureMatrixLocations[i] = GLctx.getUniformLocation(this.program, 'u_textureMatrix' + i);
           }
           this.normalLocation = GLctx.getAttribLocation(this.program, 'a_normal');
@@ -2517,7 +2517,7 @@ var LibraryGLEmulation = {
 
           this.hasClipPlane = false;
           this.clipPlaneEquationLocation = [];
-          for (var clipPlaneId = 0; clipPlaneId < GLEmulation.MAX_CLIP_PLANES; clipPlaneId++) {
+          for (let clipPlaneId = 0; clipPlaneId < GLEmulation.MAX_CLIP_PLANES; clipPlaneId++) {
             this.clipPlaneEquationLocation[clipPlaneId] = GLctx.getUniformLocation(this.program, 'u_clipPlaneEquation' + clipPlaneId);
             this.hasClipPlane = (this.hasClipPlane || this.clipPlaneEquationLocation[clipPlaneId]);
           }
@@ -2533,7 +2533,7 @@ var LibraryGLEmulation = {
           this.lightDiffuseLocation = []
           this.lightSpecularLocation = []
           this.lightPositionLocation = []
-          for (var lightId = 0; lightId < GLEmulation.MAX_LIGHTS; lightId++) {
+          for (let lightId = 0; lightId < GLEmulation.MAX_LIGHTS; lightId++) {
             this.lightAmbientLocation[lightId] = GLctx.getUniformLocation(this.program, 'u_lightAmbient' + lightId);
             this.lightDiffuseLocation[lightId] = GLctx.getUniformLocation(this.program, 'u_lightDiffuse' + lightId);
             this.lightSpecularLocation[lightId] = GLctx.getUniformLocation(this.program, 'u_lightSpecular' + lightId);
@@ -2642,7 +2642,7 @@ var LibraryGLEmulation = {
           }
 #endif
           if (this.hasTextures) {
-            for (var i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
+            for (let i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
 #if GL_FFP_ONLY
               if (!GLctx.currentArrayBufferBinding) {
                 var attribLoc = GLImmediate.TEXTURE0+i;
@@ -2706,7 +2706,7 @@ var LibraryGLEmulation = {
           }
 
           if (this.hasClipPlane) {
-            for (var clipPlaneId = 0; clipPlaneId < GLEmulation.MAX_CLIP_PLANES; clipPlaneId++) {
+            for (let clipPlaneId = 0; clipPlaneId < GLEmulation.MAX_CLIP_PLANES; clipPlaneId++) {
               if (this.clipPlaneEquationLocation[clipPlaneId]) GLctx.uniform4fv(this.clipPlaneEquationLocation[clipPlaneId], GLEmulation.clipPlaneEquation[clipPlaneId]);
             }
           }
@@ -2718,7 +2718,7 @@ var LibraryGLEmulation = {
             if (this.materialSpecularLocation) GLctx.uniform4fv(this.materialSpecularLocation, GLEmulation.materialSpecular);
             if (this.materialShininessLocation) GLctx.uniform1f(this.materialShininessLocation, GLEmulation.materialShininess[0]);
             if (this.materialEmissionLocation) GLctx.uniform4fv(this.materialEmissionLocation, GLEmulation.materialEmission);
-            for (var lightId = 0; lightId < GLEmulation.MAX_LIGHTS; lightId++) {
+            for (let lightId = 0; lightId < GLEmulation.MAX_LIGHTS; lightId++) {
               if (this.lightAmbientLocation[lightId]) GLctx.uniform4fv(this.lightAmbientLocation[lightId], GLEmulation.lightAmbient[lightId]);
               if (this.lightDiffuseLocation[lightId]) GLctx.uniform4fv(this.lightDiffuseLocation[lightId], GLEmulation.lightDiffuse[lightId]);
               if (this.lightSpecularLocation[lightId]) GLctx.uniform4fv(this.lightSpecularLocation[lightId], GLEmulation.lightSpecular[lightId]);
@@ -2741,7 +2741,7 @@ var LibraryGLEmulation = {
 #if !GL_FFP_ONLY
           GLctx.disableVertexAttribArray(this.positionLocation);
           if (this.hasTextures) {
-            for (var i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
+            for (let i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
               if (GLImmediate.enabledClientAttributes[GLImmediate.TEXTURE0+i] && this.texCoordLocations[i] >= 0) {
                 GLctx.disableVertexAttribArray(this.texCoordLocations[i]);
               }
@@ -2888,7 +2888,7 @@ var LibraryGLEmulation = {
       GLImmediate.NUM_ATTRIBUTES = 3 /*pos+normal+color attributes*/ + GLImmediate.MAX_TEXTURES;
       GLImmediate.clientAttributes = [];
       GLEmulation.enabledClientAttribIndices = [];
-      for (var i = 0; i < GLImmediate.NUM_ATTRIBUTES; i++) {
+      for (let i = 0; i < GLImmediate.NUM_ATTRIBUTES; i++) {
         GLImmediate.clientAttributes.push({});
         GLEmulation.enabledClientAttribIndices.push(false);
       }
@@ -2899,7 +2899,7 @@ var LibraryGLEmulation = {
       GLImmediate.matrix = [];
       GLImmediate.matrixStack = [];
       GLImmediate.matrixVersion = [];
-      for (var i = 0; i < 2 + GLImmediate.MAX_TEXTURES; i++) { // Modelview, Projection, plus one matrix for each texture coordinate.
+      for (let i = 0; i < 2 + GLImmediate.MAX_TEXTURES; i++) { // Modelview, Projection, plus one matrix for each texture coordinate.
         GLImmediate.matrixStack.push([]);
         GLImmediate.matrixVersion.push(0);
         GLImmediate.matrix.push(GLImmediate.matrixLib.mat4.create());
@@ -2960,7 +2960,7 @@ var LibraryGLEmulation = {
       var maxStride = 0;
       var attributes = GLImmediate.liveClientAttributes;
       attributes.length = 0;
-      for (var i = 0; i < 3+GLImmediate.MAX_TEXTURES; i++) {
+      for (let i = 0; i < 3+GLImmediate.MAX_TEXTURES; i++) {
         if (GLImmediate.enabledClientAttributes[i]) {
           var attr = GLImmediate.clientAttributes[i];
           attributes.push(attr);
@@ -2983,7 +2983,7 @@ var LibraryGLEmulation = {
         var start = GLImmediate.restrideBuffer;
         bytes = 0;
         // calculate restrided offsets and total size
-        for (var i = 0; i < attributes.length; i++) {
+        for (let i = 0; i < attributes.length; i++) {
           var attr = attributes[i];
           var size = attr.sizeBytes;
           if (size % 4 != 0) size += 4 - (size % 4); // align everything
@@ -2991,20 +2991,20 @@ var LibraryGLEmulation = {
           bytes += size;
         }
         // copy out the data (we need to know the stride for that, and define attr.pointer)
-        for (var i = 0; i < attributes.length; i++) {
+        for (let i = 0; i < attributes.length; i++) {
           var attr = attributes[i];
           var srcStride = Math.max(attr.sizeBytes, attr.stride);
           if ((srcStride & 3) == 0 && (attr.sizeBytes & 3) == 0) {
             var size4 = attr.sizeBytes>>2;
             var srcStride4 = Math.max(attr.sizeBytes, attr.stride)>>2;
-            for (var j = 0; j < count; j++) {
-              for (var k = 0; k < size4; k++) { // copy in chunks of 4 bytes, our alignment makes this possible
+            for (let j = 0; j < count; j++) {
+              for (let k = 0; k < size4; k++) { // copy in chunks of 4 bytes, our alignment makes this possible
                 HEAP32[((start + attr.offset + bytes*j)>>2) + k] = HEAP32[(attr.pointer>>2) + j*srcStride4 + k];
               }
             }
           } else {
-            for (var j = 0; j < count; j++) {
-              for (var k = 0; k < attr.sizeBytes; k++) { // source data was not aligned to multiples of 4, must copy byte by byte.
+            for (let j = 0; j < count; j++) {
+              for (let k = 0; k < attr.sizeBytes; k++) { // source data was not aligned to multiples of 4, must copy byte by byte.
                 HEAP8[start + attr.offset + bytes*j + k] = HEAP8[attr.pointer + j*srcStride + k];
               }
             }
@@ -3020,7 +3020,7 @@ var LibraryGLEmulation = {
         } else {
           GLImmediate.vertexPointer = clientStartPointer;
         }
-        for (var i = 0; i < attributes.length; i++) {
+        for (let i = 0; i < attributes.length; i++) {
           var attr = attributes[i];
           attr.offset = attr.pointer - GLImmediate.vertexPointer; // Compute what will be the offset of this attribute in the VBO after we upload.
         }
@@ -3064,7 +3064,7 @@ var LibraryGLEmulation = {
           // an element array buffer. But best is to use both buffers!
           assert(!GLctx.currentElementArrayBufferBinding);
 #endif
-          for (var i = 0; i < numProvidedIndexes; i++) {
+          for (let i = 0; i < numProvidedIndexes; i++) {
             var currIndex = {{{ makeGetValue('ptr', 'i*2', 'u16') }}};
             GLImmediate.firstVertex = Math.min(GLImmediate.firstVertex, currIndex);
             GLImmediate.lastVertex = Math.max(GLImmediate.lastVertex, currIndex+1);
@@ -3131,14 +3131,14 @@ var LibraryGLEmulation = {
 
     GLImmediate.clientAttributes_preBegin = GLImmediate.clientAttributes;
     GLImmediate.clientAttributes = []
-    for (var i = 0; i < GLImmediate.clientAttributes_preBegin.length; i++) {
+    for (let i = 0; i < GLImmediate.clientAttributes_preBegin.length; i++) {
       GLImmediate.clientAttributes.push({});
     }
 
     GLImmediate.mode = mode;
     GLImmediate.vertexCounter = 0;
     var components = GLImmediate.rendererComponents = [];
-    for (var i = 0; i < GLImmediate.NUM_ATTRIBUTES; i++) {
+    for (let i = 0; i < GLImmediate.NUM_ATTRIBUTES; i++) {
       components[i] = 0;
     }
     GLImmediate.rendererComponentPointer = 0;
@@ -3570,7 +3570,7 @@ var LibraryGLEmulation = {
   emulGlGenVertexArrays__deps: ['$GLEmulation'],
   emulGlGenVertexArrays__sig: 'vii',
   emulGlGenVertexArrays: function(n, vaos) {
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       var id = GL.getNewId(GLEmulation.vaos);
       GLEmulation.vaos[id] = {
         id: id,
@@ -3585,7 +3585,7 @@ var LibraryGLEmulation = {
   },
   emulGlDeleteVertexArrays__sig: 'vii',
   emulGlDeleteVertexArrays: function(n, vaos) {
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       var id = {{{ makeGetValue('vaos', 'i*4', 'i32') }}};
       GLEmulation.vaos[id] = null;
       if (GLEmulation.currentVao && GLEmulation.currentVao.id == id) GLEmulation.currentVao = null;

--- a/src/library_glew.js
+++ b/src/library_glew.js
@@ -116,7 +116,7 @@ var LibraryGLEW = {
 
   glewIsSupported: function(name) {
     var exts = UTF8ToString(name).split(' ');
-    for (var i = 0; i < exts.length; ++i) {
+    for (let i = 0; i < exts.length; ++i) {
       if (!GLEW.extensionIsSupported(exts[i]))
         return 0;
     }

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -420,7 +420,7 @@ var LibraryGLFW = {
     onBlur: function(event) {
       if (!GLFW.active) return;
 
-      for (var i = 0; i < GLFW.active.domKeys.length; ++i) {
+      for (let i = 0; i < GLFW.active.domKeys.length; ++i) {
         if (GLFW.active.domKeys[i]) {
           GLFW.onKeyChanged(i, 0); // GLFW_RELEASE
         }
@@ -645,7 +645,7 @@ var LibraryGLFW = {
         GLFW.lastGamepadState = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads : []);
         GLFW.lastGamepadStateFrame = Browser.mainLoop.currentFrameNumber;
 
-        for (var joy = 0; joy < GLFW.lastGamepadState.length; ++joy) {
+        for (let joy = 0; joy < GLFW.lastGamepadState.length; ++joy) {
           var gamepad = GLFW.lastGamepadState[joy];
 
           if (gamepad) {
@@ -666,11 +666,11 @@ var LibraryGLFW = {
 
             var data = GLFW.joys[joy];
 
-            for (var i = 0; i < gamepad.buttons.length;  ++i) {
+            for (let i = 0; i < gamepad.buttons.length;  ++i) {
               {{{ makeSetValue('data.buttons + i', '0', 'gamepad.buttons[i].pressed', 'i8') }}};
             }
 
-            for (var i = 0; i < gamepad.axes.length; ++i) {
+            for (let i = 0; i < gamepad.axes.length; ++i) {
               {{{ makeSetValue('data.axes + i*4', '0', 'gamepad.axes[i]', 'float') }}};
             }
           } else {
@@ -771,7 +771,7 @@ var LibraryGLFW = {
           if (++written === count) {
             {{{ makeDynCall('viii', 'GLFW.active.dropFunc') }}}(GLFW.active.id, count, filenames);
 
-            for (var i = 0; i < filenamesArray.length; ++i) {
+            for (let i = 0; i < filenamesArray.length; ++i) {
               _free(filenamesArray[i]);
             }
             _free(filenames);
@@ -781,10 +781,10 @@ var LibraryGLFW = {
 
         var filename = allocateUTF8(path);
         filenamesArray.push(filename);
-        {{{ makeSetValue('filenames + i*4', '0', 'filename', POINTER_TYPE) }}};
+        {{{ makeSetValue('filenames', 'filenamesArray.length*4', 'filename', POINTER_TYPE) }}};
       }
 
-      for (var i = 0; i < count; ++i) {
+      for (let i = 0; i < count; ++i) {
         save(event.dataTransfer.files[i]);
       }
 #endif // FILESYSTEM
@@ -1054,7 +1054,7 @@ var LibraryGLFW = {
         GLFW.active = null;
 
       // Destroy context when no alive windows
-      for (var i = 0; i < GLFW.windows.length; i++)
+      for (let i = 0; i < GLFW.windows.length; i++)
         if (GLFW.windows[i] !== null) return;
 
       Module.ctx = Browser.destroyContext(Module['canvas'], true, true);

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -50,7 +50,7 @@ var LibraryHTML5 = {
     inEventHandler: 0,
 
     removeAllEventListeners: function() {
-      for (var i = JSEvents.eventHandlers.length-1; i >= 0; --i) {
+      for (let i = JSEvents.eventHandlers.length-1; i >= 0; --i) {
         JSEvents._removeHandler(i);
       }
       JSEvents.eventHandlers = [];
@@ -103,7 +103,7 @@ var LibraryHTML5 = {
     
     // Erases all deferred calls to the given target function from the queue list.
     removeDeferredCalls: function(targetFunction) {
-      for (var i = 0; i < JSEvents.deferredCalls.length; ++i) {
+      for (let i = 0; i < JSEvents.deferredCalls.length; ++i) {
         if (JSEvents.deferredCalls[i].targetFunction == targetFunction) {
           JSEvents.deferredCalls.splice(i, 1);
           --i;
@@ -119,7 +119,7 @@ var LibraryHTML5 = {
       if (!JSEvents.canPerformEventHandlerRequests()) {
         return;
       }
-      for (var i = 0; i < JSEvents.deferredCalls.length; ++i) {
+      for (let i = 0; i < JSEvents.deferredCalls.length; ++i) {
         var call = JSEvents.deferredCalls[i];
         JSEvents.deferredCalls.splice(i, 1);
         --i;
@@ -137,7 +137,7 @@ var LibraryHTML5 = {
 
     // Removes all event handlers on the given DOM element of the given type. Pass in eventTypeString == undefined/null to remove all event handlers regardless of the type.
     removeAllHandlersOnTarget: function(target, eventTypeString) {
-      for (var i = 0; i < JSEvents.eventHandlers.length; ++i) {
+      for (let i = 0; i < JSEvents.eventHandlers.length; ++i) {
         if (JSEvents.eventHandlers[i].target == target && 
           (!eventTypeString || eventTypeString == JSEvents.eventHandlers[i].eventTypeString)) {
            JSEvents._removeHandler(i--);
@@ -178,7 +178,7 @@ var LibraryHTML5 = {
         JSEvents.registerRemoveEventListeners();
 #endif
       } else {
-        for (var i = 0; i < JSEvents.eventHandlers.length; ++i) {
+        for (let i = 0; i < JSEvents.eventHandlers.length; ++i) {
           if (JSEvents.eventHandlers[i].target == eventHandler.target
            && JSEvents.eventHandlers[i].eventTypeString == eventHandler.eventTypeString) {
              JSEvents._removeHandler(i--);
@@ -1427,7 +1427,7 @@ var LibraryHTML5 = {
     var hiddenElements = [];
     while (child != document.body) {
       var children = parent.children;
-      for (var i = 0; i < children.length; ++i) {
+      for (let i = 0; i < children.length; ++i) {
         if (children[i] != child) {
           hiddenElements.push({ node: children[i], displayState: children[i].style.display });
           children[i].style.display = 'none';
@@ -1441,7 +1441,7 @@ var LibraryHTML5 = {
 
   // Applies old visibility states, given a list of changes returned by hideEverythingExceptGivenElement().
   $restoreHiddenElements: function(hiddenElements) {
-    for (var i = 0; i < hiddenElements.length; ++i) {
+    for (let i = 0; i < hiddenElements.length; ++i) {
       hiddenElements[i].node.style.display = hiddenElements[i].displayState;
     }
   },
@@ -1964,7 +1964,7 @@ var LibraryHTML5 = {
     if (!navigator.vibrate) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
 
     var vibrateList = [];
-    for (var i = 0; i < numEntries; ++i) {
+    for (let i = 0; i < numEntries; ++i) {
       var msecs = {{{ makeGetValue('msecsArray', 'i*4', 'i32') }}};
       vibrateList.push(msecs);
     }
@@ -2061,7 +2061,7 @@ var LibraryHTML5 = {
       // only changed touches in e.changedTouches, and touches on target at a.targetTouches), mark a boolean in
       // each Touch object so that we can later loop only once over all touches we see to marshall over to Wasm.
 
-      for (var i = 0; i < et.length; ++i) {
+      for (let i = 0; i < et.length; ++i) {
         t = et[i];
         // Browser might recycle the generated Touch objects between each frame (Firefox on Android), so reset any
         // changed/target states we may have set from previous frame.
@@ -2069,13 +2069,13 @@ var LibraryHTML5 = {
         touches[t.identifier] = t;
       }
       // Mark which touches are part of the changedTouches list.
-      for (var i = 0; i < e.changedTouches.length; ++i) {
+      for (let i = 0; i < e.changedTouches.length; ++i) {
         t = e.changedTouches[i];
         t.isChanged = 1;
         touches[t.identifier] = t;
       }
       // Mark which touches are part of the targetTouches list.
-      for (var i = 0; i < e.targetTouches.length; ++i) {
+      for (let i = 0; i < e.targetTouches.length; ++i) {
         touches[e.targetTouches[i].identifier].onTarget = 1;
       }
 
@@ -2176,17 +2176,17 @@ var LibraryHTML5 = {
 
   $fillGamepadEventData: function(eventStruct, e) {
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenGamepadEvent.timestamp, 'e.timestamp', 'double') }}};
-    for (var i = 0; i < e.axes.length; ++i) {
+    for (let i = 0; i < e.axes.length; ++i) {
       {{{ makeSetValue('eventStruct+i*8', C_STRUCTS.EmscriptenGamepadEvent.axis, 'e.axes[i]', 'double') }}};
     }
-    for (var i = 0; i < e.buttons.length; ++i) {
+    for (let i = 0; i < e.buttons.length; ++i) {
       if (typeof e.buttons[i] == 'object') {
         {{{ makeSetValue('eventStruct+i*8', C_STRUCTS.EmscriptenGamepadEvent.analogButton, 'e.buttons[i].value', 'double') }}};
       } else {
         {{{ makeSetValue('eventStruct+i*8', C_STRUCTS.EmscriptenGamepadEvent.analogButton, 'e.buttons[i]', 'double') }}};
       }
     }
-    for (var i = 0; i < e.buttons.length; ++i) {
+    for (let i = 0; i < e.buttons.length; ++i) {
       if (typeof e.buttons[i] == 'object') {
         {{{ makeSetValue('eventStruct+i*4', C_STRUCTS.EmscriptenGamepadEvent.digitalButton, 'e.buttons[i].pressed', 'i32') }}};
       } else {

--- a/src/library_html5_webgl.js
+++ b/src/library_html5_webgl.js
@@ -14,7 +14,7 @@ var LibraryHtml5WebGL = {
     var len = arr.length;
     var writeLength = dstLength < len ? dstLength : len;
     var heap = heapType ? HEAPF32 : HEAP32;
-    for (var i = 0; i < writeLength; ++i) {
+    for (let i = 0; i < writeLength; ++i) {
       heap[(dst >> 2) + i] = arr[i];
     }
     return len;
@@ -26,7 +26,7 @@ var LibraryHtml5WebGL = {
     assert(attributes);
 #endif
     var a = attributes >> 2;
-    for (var i = 0; i < ({{{ C_STRUCTS.EmscriptenWebGLContextAttributes.__size__ }}}>>2); ++i) {
+    for (let i = 0; i < ({{{ C_STRUCTS.EmscriptenWebGLContextAttributes.__size__ }}}>>2); ++i) {
       HEAP32[a+i] = 0;
     }
 
@@ -578,7 +578,7 @@ function handleWebGLProxying(funcs) {
 
   function listOfNFunctionArgs(func) {
     var args = [];
-    for (var i = 0; i < func.length; ++i) {
+    for (let i = 0; i < func.length; ++i) {
       args.push('p' + i);
     }
     return args;

--- a/src/library_lz4.js
+++ b/src/library_lz4.js
@@ -25,7 +25,7 @@ mergeInto(LibraryManager.library, {
       var compressedData = pack['compressedData'];
       if (!compressedData) compressedData = LZ4.codec.compressPackage(pack['data']);
       assert(compressedData['cachedIndexes'].length === compressedData['cachedChunks'].length);
-      for (var i = 0; i < compressedData['cachedIndexes'].length; i++) {
+      for (let i = 0; i < compressedData['cachedIndexes'].length; i++) {
         compressedData['cachedIndexes'][i] = -1;
         compressedData['cachedChunks'][i] = compressedData['data'].subarray(compressedData['cachedOffset'] + i*LZ4.CHUNK_SIZE,
                                                                       compressedData['cachedOffset'] + (i+1)*LZ4.CHUNK_SIZE);

--- a/src/library_math.js
+++ b/src/library_math.js
@@ -68,7 +68,7 @@ mergeInto(LibraryManager.library, {
   emscripten_math_hypot__sig: 'iip',
   emscripten_math_hypot: function(count, varargs) {
     var args = [];
-    for (var i = 0; i < count; ++i) args.push(HEAPF64[(varargs>>3) + i]);
+    for (let i = 0; i < count; ++i) args.push(HEAPF64[(varargs>>3) + i]);
     return Math.hypot.apply(null, args);
   },
   emscripten_math_sin: function(x) {

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -253,7 +253,7 @@ mergeInto(LibraryManager.library, {
         if (size > 8 && contents.subarray) { // non-trivial, and typed array
           buffer.set(contents.subarray(position, position + size), offset);
         } else {
-          for (var i = 0; i < size; i++) buffer[offset + i] = contents[position + i];
+          for (let i = 0; i < size; i++) buffer[offset + i] = contents[position + i];
         }
         return size;
       },
@@ -307,7 +307,7 @@ mergeInto(LibraryManager.library, {
           // Use typed array write which is available.
           node.contents.set(buffer.subarray(offset, offset + length), position);
         } else {
-          for (var i = 0; i < length; i++) {
+          for (let i = 0; i < length; i++) {
            node.contents[position + i] = buffer[offset + i]; // Or fall back to manual write if not.
           }
         }

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -46,7 +46,7 @@ mergeInto(LibraryManager.library, {
     },
     createStandardStreams: function() {
       FS.streams[0] = FS.createStream({ nfd: 0, position: 0, path: '', flags: 0, tty: true, seekable: false }, 0, 0);
-      for (var i = 1; i < 3; i++) {
+      for (let i = 1; i < 3; i++) {
         FS.streams[i] = FS.createStream({ nfd: i, position: 0, path: '', flags: 577, tty: true, seekable: false }, i, i);
       }
     },

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -121,7 +121,7 @@ var LibraryOpenAL = {
       var bufCursor = src.bufsProcessed;
 
       // Advance past any audio that is already scheduled
-      for (var i = 0; i < src.audioQueue.length; i++) {
+      for (let i = 0; i < src.audioQueue.length; i++) {
         var audioSrc = src.audioQueue[i];
         startTime = audioSrc._startTime + audioSrc._duration;
         startOffset = 0.0;
@@ -288,7 +288,7 @@ var LibraryOpenAL = {
         // Since we've already skipped any full-queue loops if there were any, we just need to find
         // out where in the queue the remaining time puts us, which won't require stepping through the
         // entire queue more than once.
-        for (var i = 0; i < src.bufQueue.length; i++) {
+        for (let i = 0; i < src.bufQueue.length; i++) {
           if (src.bufsProcessed >= src.bufQueue.length) {
             if (src.looping) {
               src.bufsProcessed %= src.bufQueue.length;
@@ -321,7 +321,7 @@ var LibraryOpenAL = {
     cancelPendingSourceAudio: function(src) {
       AL.updateSourceTime(src);
 
-      for (var i = 1; i < src.audioQueue.length; i++) {
+      for (let i = 1; i < src.audioQueue.length; i++) {
         var audioSrc = src.audioQueue[i];
         audioSrc.stop();
       }
@@ -332,7 +332,7 @@ var LibraryOpenAL = {
     },
 
     stopSourceAudio: function(src) {
-      for (var i = 0; i < src.audioQueue.length; i++) {
+      for (let i = 0; i < src.audioQueue.length; i++) {
         src.audioQueue[i].stop();
       }
       src.audioQueue.length = 0;
@@ -400,7 +400,7 @@ var LibraryOpenAL = {
 
       // Find the first non-zero buffer in the queue to determine the proper format
       var templateBuf = AL.buffers[0];
-      for (var i = 0; i < src.bufQueue.length; i++) {
+      for (let i = 0; i < src.bufQueue.length; i++) {
         if (src.bufQueue[i].id !== 0) {
           templateBuf = src.bufQueue[i];
           break;
@@ -698,7 +698,7 @@ var LibraryOpenAL = {
 
     sourceDuration: function(src) {
       var length = 0.0;
-      for (var i = 0; i < src.bufQueue.length; i++) {
+      for (let i = 0; i < src.bufQueue.length; i++) {
         var audioBuf = src.bufQueue[i].audioBuf;
         length += audioBuf ? audioBuf.duration : 0.0;
       }
@@ -709,7 +709,7 @@ var LibraryOpenAL = {
       AL.updateSourceTime(src);
 
       var offset = 0.0;
-      for (var i = 0; i < src.bufsProcessed; i++) {
+      for (let i = 0; i < src.bufsProcessed; i++) {
         if (src.bufQueue[i].audioBuf) {
           offset += src.bufQueue[i].audioBuf.duration;
         }
@@ -1132,7 +1132,7 @@ var LibraryOpenAL = {
       case 0x2009 /* AL_BYTE_LENGTH_SOFT */: 
         var length = 0;
         var bytesPerFrame = 0;
-        for (var i = 0; i < src.bufQueue.length; i++) {
+        for (let i = 0; i < src.bufQueue.length; i++) {
           length += src.bufQueue[i].length;
           if (src.bufQueue[i].id !== 0) {
             bytesPerFrame = src.bufQueue[i].bytesPerSample * src.bufQueue[i].channels;
@@ -1141,7 +1141,7 @@ var LibraryOpenAL = {
         return length * bytesPerFrame;
       case 0x200A /* AL_SAMPLE_LENGTH_SOFT */:
         var length = 0;
-        for (var i = 0; i < src.bufQueue.length; i++) {
+        for (let i = 0; i < src.bufQueue.length; i++) {
           length += src.bufQueue[i].length;
         }
         return length;
@@ -1726,7 +1726,7 @@ var LibraryOpenAL = {
 
     var buffers = [];
     try {
-      for (var chan=0; chan < outputChannelCount; ++chan) {
+      for (let chan=0; chan < outputChannelCount; ++chan) {
         buffers[chan] = newSampleArray(bufferFrameCapacity);
       }
     } catch(e) {
@@ -1834,7 +1834,7 @@ var LibraryOpenAL = {
         switch (format) {
         case 0x10010: /* AL_FORMAT_MONO_FLOAT32 */
           var channel0 = srcBuf.getChannelData(0);
-          for (var i = 0 ; i < srcBuf.length; ++i) {
+          for (let i = 0 ; i < srcBuf.length; ++i) {
             var wi = (c.capturePlayhead + i) % c.bufferFrameCapacity;
             c.buffers[0][wi] = channel0[i];
           }
@@ -1842,7 +1842,7 @@ var LibraryOpenAL = {
         case 0x10011: /* AL_FORMAT_STEREO_FLOAT32 */
           var channel0 = srcBuf.getChannelData(0);
           var channel1 = srcBuf.getChannelData(1);
-          for (var i = 0 ; i < srcBuf.length; ++i) {
+          for (let i = 0 ; i < srcBuf.length; ++i) {
             var wi = (c.capturePlayhead + i) % c.bufferFrameCapacity;
             c.buffers[0][wi] = channel0[i];
             c.buffers[1][wi] = channel1[i];
@@ -1850,7 +1850,7 @@ var LibraryOpenAL = {
           break;
         case 0x1101:  /* AL_FORMAT_MONO16 */
           var channel0 = srcBuf.getChannelData(0);
-          for (var i = 0 ; i < srcBuf.length; ++i) {
+          for (let i = 0 ; i < srcBuf.length; ++i) {
             var wi = (c.capturePlayhead + i) % c.bufferFrameCapacity;
             c.buffers[0][wi] = channel0[i] * 32767;
           }
@@ -1858,7 +1858,7 @@ var LibraryOpenAL = {
         case 0x1103:  /* AL_FORMAT_STEREO16 */
           var channel0 = srcBuf.getChannelData(0);
           var channel1 = srcBuf.getChannelData(1);
-          for (var i = 0 ; i < srcBuf.length; ++i) {
+          for (let i = 0 ; i < srcBuf.length; ++i) {
             var wi = (c.capturePlayhead + i) % c.bufferFrameCapacity;
             c.buffers[0][wi] = channel0[i] * 32767;
             c.buffers[1][wi] = channel1[i] * 32767;
@@ -1866,7 +1866,7 @@ var LibraryOpenAL = {
           break;
         case 0x1100:  /* AL_FORMAT_MONO8 */
           var channel0 = srcBuf.getChannelData(0);
-          for (var i = 0 ; i < srcBuf.length; ++i) {
+          for (let i = 0 ; i < srcBuf.length; ++i) {
             var wi = (c.capturePlayhead + i) % c.bufferFrameCapacity;
             c.buffers[0][wi] = (channel0[i] + 1.0) * 127;
           }
@@ -1874,7 +1874,7 @@ var LibraryOpenAL = {
         case 0x1102:  /* AL_FORMAT_STEREO8 */
           var channel0 = srcBuf.getChannelData(0);
           var channel1 = srcBuf.getChannelData(1);
-          for (var i = 0 ; i < srcBuf.length; ++i) {
+          for (let i = 0 ; i < srcBuf.length; ++i) {
             var wi = (c.capturePlayhead + i) % c.bufferFrameCapacity;
             c.buffers[0][wi] = (channel0[i] + 1.0) * 127;
             c.buffers[1][wi] = (channel1[i] + 1.0) * 127;
@@ -2028,8 +2028,8 @@ var LibraryOpenAL = {
     
     // If fratio is an integer we don't need linear resampling, just skip samples
     if (Math.floor(fratio) == fratio) {
-      for (var i = 0, frame_i = 0; frame_i < requestedFrameCount; ++frame_i) {
-        for (var chan = 0; chan < c.buffers.length; ++chan, ++i) {
+      for (let i = 0, frame_i = 0; frame_i < requestedFrameCount; ++frame_i) {
+        for (let chan = 0; chan < c.buffers.length; ++chan, ++i) {
           setSample(i, c.buffers[chan][c.captureReadhead]);
         }
         c.captureReadhead = (fratio + c.captureReadhead) % c.bufferFrameCapacity;
@@ -2041,11 +2041,11 @@ var LibraryOpenAL = {
       // We don't use OfflineAudioContexts for this: See the discussion at
       // https://github.com/jpernst/emscripten/issues/2#issuecomment-312729735
       // if you're curious about why.
-      for (var i = 0, frame_i = 0; frame_i < requestedFrameCount; ++frame_i) {
+      for (let i = 0, frame_i = 0; frame_i < requestedFrameCount; ++frame_i) {
         var lefti = Math.floor(c.captureReadhead);
         var righti = Math.ceil(c.captureReadhead);
         var d = c.captureReadhead - lefti;
-        for (var chan = 0; chan < c.buffers.length; ++chan, ++i) {
+        for (let chan = 0; chan < c.buffers.length; ++chan, ++i) {
           var lefts = c.buffers[chan][lefti];
           var rights = c.buffers[chan][righti];
           setSample(i, (1 - d) * lefts + d * rights);
@@ -2510,7 +2510,7 @@ var LibraryOpenAL = {
         return;
       }
 
-      for (var i = 0; i < AL.currentCtx.attrs.length; i++) {
+      for (let i = 0; i < AL.currentCtx.attrs.length; i++) {
         {{{ makeSetValue('pValues', 'i*4', 'AL.currentCtx.attrs[i]', 'i32') }}};
       }
       break;
@@ -2760,7 +2760,7 @@ var LibraryOpenAL = {
       return;
     }
 
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       var buf = {
         deviceId: AL.currentCtx.deviceId,
         id: AL.newId(),
@@ -2787,7 +2787,7 @@ var LibraryOpenAL = {
       return;
     }
 
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       var bufId = {{{ makeGetValue('pBufferIds', 'i*4', 'i32') }}};
       /// Deleting the zero buffer is a legal NOP, so ignore it
       if (bufId === 0) {
@@ -2813,7 +2813,7 @@ var LibraryOpenAL = {
       }
     }
 
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       var bufId = {{{ makeGetValue('pBufferIds', 'i*4', 'i32') }}};
       if (bufId === 0) {
         continue;
@@ -2834,7 +2834,7 @@ var LibraryOpenAL = {
 #endif
       return;
     }
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       var gain = AL.currentCtx.audioCtx.createGain();
       gain.connect(AL.currentCtx.gain);
       var src = {
@@ -2887,7 +2887,7 @@ var LibraryOpenAL = {
       return;
     }
 
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       var srcId = {{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}};
       if (!AL.currentCtx.sources[srcId]) {
 #if OPENAL_DEBUG
@@ -2898,7 +2898,7 @@ var LibraryOpenAL = {
       }
     }
 
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       var srcId = {{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}};
       AL.setSourceState(AL.currentCtx.sources[srcId], 0x1014 /* AL_STOPPED */);
       _alSourcei(srcId, 0x1009 /* AL_BUFFER */, 0);
@@ -3770,7 +3770,7 @@ var LibraryOpenAL = {
         if (size > 0) {
           audioBuf = AL.currentCtx.audioCtx.createBuffer(1, size, freq);
           var channel0 = audioBuf.getChannelData(0);
-          for (var i = 0; i < size; ++i) {
+          for (let i = 0; i < size; ++i) {
             channel0[i] = HEAPU8[pData++] * 0.0078125 /* 1/128 */ - 1.0;
           }
         }
@@ -3783,7 +3783,7 @@ var LibraryOpenAL = {
           audioBuf = AL.currentCtx.audioCtx.createBuffer(1, size >> 1, freq);
           var channel0 = audioBuf.getChannelData(0);
           pData >>= 1;
-          for (var i = 0; i < size >> 1; ++i) {
+          for (let i = 0; i < size >> 1; ++i) {
             channel0[i] = HEAP16[pData++] * 0.000030517578125 /* 1/32768 */;
           }
         }
@@ -3796,7 +3796,7 @@ var LibraryOpenAL = {
           audioBuf = AL.currentCtx.audioCtx.createBuffer(2, size >> 1, freq);
           var channel0 = audioBuf.getChannelData(0);
           var channel1 = audioBuf.getChannelData(1);
-          for (var i = 0; i < size >> 1; ++i) {
+          for (let i = 0; i < size >> 1; ++i) {
             channel0[i] = HEAPU8[pData++] * 0.0078125 /* 1/128 */ - 1.0;
             channel1[i] = HEAPU8[pData++] * 0.0078125 /* 1/128 */ - 1.0;
           }
@@ -3811,7 +3811,7 @@ var LibraryOpenAL = {
           var channel0 = audioBuf.getChannelData(0);
           var channel1 = audioBuf.getChannelData(1);
           pData >>= 1;
-          for (var i = 0; i < size >> 2; ++i) {
+          for (let i = 0; i < size >> 2; ++i) {
             channel0[i] = HEAP16[pData++] * 0.000030517578125 /* 1/32768 */;
             channel1[i] = HEAP16[pData++] * 0.000030517578125 /* 1/32768 */;
           }
@@ -3825,7 +3825,7 @@ var LibraryOpenAL = {
           audioBuf = AL.currentCtx.audioCtx.createBuffer(1, size >> 2, freq);
           var channel0 = audioBuf.getChannelData(0);
           pData >>= 2;
-          for (var i = 0; i < size >> 2; ++i) {
+          for (let i = 0; i < size >> 2; ++i) {
             channel0[i] = HEAPF32[pData++];
           }
         }
@@ -3839,7 +3839,7 @@ var LibraryOpenAL = {
           var channel0 = audioBuf.getChannelData(0);
           var channel1 = audioBuf.getChannelData(1);
           pData >>= 2;
-          for (var i = 0; i < size >> 3; ++i) {
+          for (let i = 0; i < size >> 3; ++i) {
             channel0[i] = HEAPF32[pData++];
             channel1[i] = HEAPF32[pData++];
           }
@@ -4141,14 +4141,14 @@ var LibraryOpenAL = {
 
     // Find the first non-zero buffer in the queue to determine the proper format
     var templateBuf = AL.buffers[0];
-    for (var i = 0; i < src.bufQueue.length; i++) {
+    for (let i = 0; i < src.bufQueue.length; i++) {
       if (src.bufQueue[i].id !== 0) {
         templateBuf = src.bufQueue[i];
         break;
       }
     }
 
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       var bufId = {{{ makeGetValue('pBufferIds', 'i*4', 'i32') }}};
       var buf = AL.buffers[bufId];
       if (!buf) {
@@ -4178,7 +4178,7 @@ var LibraryOpenAL = {
     }
 
     src.type = 0x1029 /* AL_STREAMING */;
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       var bufId = {{{ makeGetValue('pBufferIds', 'i*4', 'i32') }}};
       var buf = AL.buffers[bufId];
       buf.refCount++;
@@ -4220,7 +4220,7 @@ var LibraryOpenAL = {
       return;
     }
 
-    for (var i = 0; i < count; i++) {
+    for (let i = 0; i < count; i++) {
       var buf = src.bufQueue.shift();
       buf.refCount--;
       // Write the buffers index out to the return list.
@@ -4272,7 +4272,7 @@ var LibraryOpenAL = {
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
     }
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       if (!AL.currentCtx.sources[{{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}]) {
 #if OPENAL_DEBUG
         err('alSourcePlayv() called with an invalid source');
@@ -4282,7 +4282,7 @@ var LibraryOpenAL = {
       }
     }
 
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       var srcId = {{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}};
       AL.setSourceState(AL.currentCtx.sources[srcId], 0x1012 /* AL_PLAYING */);
     }
@@ -4323,7 +4323,7 @@ var LibraryOpenAL = {
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
     }
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       if (!AL.currentCtx.sources[{{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}]) {
 #if OPENAL_DEBUG
         err('alSourceStopv() called with an invalid source');
@@ -4333,7 +4333,7 @@ var LibraryOpenAL = {
       }
     }
 
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       var srcId = {{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}};
       AL.setSourceState(AL.currentCtx.sources[srcId], 0x1014 /* AL_STOPPED */);
     }
@@ -4377,7 +4377,7 @@ var LibraryOpenAL = {
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
     }
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       if (!AL.currentCtx.sources[{{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}]) {
 #if OPENAL_DEBUG
         err('alSourceRewindv() called with an invalid source');
@@ -4387,7 +4387,7 @@ var LibraryOpenAL = {
       }
     }
 
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       var srcId = {{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}};
       AL.setSourceState(AL.currentCtx.sources[srcId], 0x1011 /* AL_INITIAL */);
     }
@@ -4428,7 +4428,7 @@ var LibraryOpenAL = {
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
     }
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       if (!AL.currentCtx.sources[{{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}]) {
 #if OPENAL_DEBUG
         err('alSourcePausev() called with an invalid source');
@@ -4438,7 +4438,7 @@ var LibraryOpenAL = {
       }
     }
 
-    for (var i = 0; i < count; ++i) {
+    for (let i = 0; i < count; ++i) {
       var srcId = {{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}};
       AL.setSourceState(AL.currentCtx.sources[srcId], 0x1013 /* AL_PAUSED */);
     }

--- a/src/library_path.js
+++ b/src/library_path.js
@@ -16,7 +16,7 @@ mergeInto(LibraryManager.library, {
     normalizeArray: (parts, allowAboveRoot) => {
       // if the path tries to go above the root, `up` ends up > 0
       var up = 0;
-      for (var i = parts.length - 1; i >= 0; i--) {
+      for (let i = parts.length - 1; i >= 0; i--) {
         var last = parts[i];
         if (last === '.') {
           parts.splice(i, 1);
@@ -122,14 +122,14 @@ mergeInto(LibraryManager.library, {
       var toParts = trim(to.split('/'));
       var length = Math.min(fromParts.length, toParts.length);
       var samePartsLength = length;
-      for (var i = 0; i < length; i++) {
+      for (let i = 0; i < length; i++) {
         if (fromParts[i] !== toParts[i]) {
           samePartsLength = i;
           break;
         }
       }
       var outputParts = [];
-      for (var i = samePartsLength; i < fromParts.length; i++) {
+      for (let i = samePartsLength; i < fromParts.length; i++) {
         outputParts.push('..');
       }
       outputParts = outputParts.concat(toParts.slice(samePartsLength));

--- a/src/library_pipefs.js
+++ b/src/library_pipefs.js
@@ -69,7 +69,7 @@ mergeInto(LibraryManager.library, {
           return ({{{ cDefine('POLLWRNORM') }}} | {{{ cDefine('POLLOUT') }}});
         }
         if (pipe.buckets.length > 0) {
-          for (var i = 0; i < pipe.buckets.length; i++) {
+          for (let i = 0; i < pipe.buckets.length; i++) {
             var bucket = pipe.buckets[i];
             if (bucket.offset - bucket.roffset > 0) {
               return ({{{ cDefine('POLLRDNORM') }}} | {{{ cDefine('POLLIN') }}});
@@ -89,7 +89,7 @@ mergeInto(LibraryManager.library, {
         var pipe = stream.node.pipe;
         var currentLength = 0;
 
-        for (var i = 0; i < pipe.buckets.length; i++) {
+        for (let i = 0; i < pipe.buckets.length; i++) {
           var bucket = pipe.buckets[i];
           currentLength += bucket.offset - bucket.roffset;
         }
@@ -113,7 +113,7 @@ mergeInto(LibraryManager.library, {
         var totalRead = toRead;
         var toRemove = 0;
 
-        for (var i = 0; i < pipe.buckets.length; i++) {
+        for (let i = 0; i < pipe.buckets.length; i++) {
           var currBucket = pipe.buckets[i];
           var bucketSize = currBucket.offset - currBucket.roffset;
 
@@ -192,7 +192,7 @@ mergeInto(LibraryManager.library, {
         var numBuckets = (data.byteLength / PIPEFS.BUCKET_BUFFER_SIZE) | 0;
         var remElements = data.byteLength % PIPEFS.BUCKET_BUFFER_SIZE;
 
-        for (var i = 0; i < numBuckets; i++) {
+        for (let i = 0; i < numBuckets; i++) {
           var newBucket = {
             buffer: new Uint8Array(PIPEFS.BUCKET_BUFFER_SIZE),
             offset: PIPEFS.BUCKET_BUFFER_SIZE,

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -86,7 +86,7 @@ var LibraryPThread = {
 #if PTHREAD_POOL_SIZE
       var pthreadPoolSize = {{{ PTHREAD_POOL_SIZE }}};
       // Start loading up the Worker pool, if requested.
-      for (var i = 0; i < pthreadPoolSize; ++i) {
+      for (let i = 0; i < pthreadPoolSize; ++i) {
         PThread.allocateUnusedWorker();
       }
 #endif
@@ -171,7 +171,7 @@ var LibraryPThread = {
       assert(PThread.runningWorkers.length === 0);
 #endif
 
-      for (var i = 0; i < PThread.unusedWorkers.length; ++i) {
+      for (let i = 0; i < PThread.unusedWorkers.length; ++i) {
         var worker = PThread.unusedWorkers[i];
 #if ASSERTIONS
         // This Worker should not be hosting a pthread at this time.
@@ -854,7 +854,7 @@ var LibraryPThread = {
       var serializedNumCallArgs = numCallArgs {{{ WASM_BIGINT ? "* 2" : "" }}};
       var args = stackAlloc(serializedNumCallArgs * 8);
       var b = args >> 3;
-      for (var i = 0; i < numCallArgs; i++) {
+      for (let i = 0; i < numCallArgs; i++) {
         var arg = outerArgs[2 + i];
 #if WASM_BIGINT
         if (typeof arg == 'bigint') {
@@ -885,7 +885,7 @@ var LibraryPThread = {
 #endif
     _emscripten_receive_on_main_thread_js_callArgs.length = numCallArgs;
     var b = args >> 3;
-    for (var i = 0; i < numCallArgs; i++) {
+    for (let i = 0; i < numCallArgs; i++) {
 #if WASM_BIGINT
       if (HEAP64[b + 2*i]) {
         // It's a BigInt.

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -464,9 +464,9 @@ var LibrarySDL = {
 
       var colors32 = surfData.colors32;
 
-      for (var y = startY; y < endY; ++y) {
+      for (let y = startY; y < endY; ++y) {
         var base = y * fullWidth;
-        for (var x = startX; x < endX; ++x) {
+        for (let x = startX; x < endX; ++x) {
           data32[base + x] = colors32[{{{ makeGetValue('buffer + base + x', '0', 'u8') }}}];
         }
       }
@@ -568,7 +568,7 @@ var LibrarySDL = {
 
           // Clear out any touchstart events that we've already processed
           if (event.type === 'touchstart') {
-            for (var i = 0; i < event.touches.length; i++) {
+            for (let i = 0; i < event.touches.length; i++) {
               var touch = event.touches[i];
               if (SDL.downFingers[touch.identifier] != true) {
                 SDL.downFingers[touch.identifier] = true;
@@ -598,7 +598,7 @@ var LibrarySDL = {
             SDL.events.push(mouseEvent);
           }
 
-          for (var i = 0; i < touches.length; i++) {
+          for (let i = 0; i < touches.length; i++) {
             var touch = touches[i];
             SDL.events.push({
               type: event.type,
@@ -612,7 +612,7 @@ var LibrarySDL = {
 
           // Remove the entry in the SDL.downFingers hash
           // because the finger is no longer down.
-          for (var i = 0; i < event.changedTouches.length; i++) {
+          for (let i = 0; i < event.changedTouches.length; i++) {
             var touch = event.changedTouches[i];
             if (SDL.downFingers[touch.identifier] === true) {
               delete SDL.downFingers[touch.identifier];
@@ -628,7 +628,7 @@ var LibrarySDL = {
           SDL.DOMButtons[0] = 0;
           SDL.events.push(mouseEvent);
 
-          for (var i = 0; i < event.changedTouches.length; i++) {
+          for (let i = 0; i < event.changedTouches.length; i++) {
             var touch = event.changedTouches[i];
             SDL.events.push({
               type: 'touchend',
@@ -752,7 +752,7 @@ var LibrarySDL = {
           break;
         case 'mouseout':
           // Un-press all pressed mouse buttons, because we might miss the release outside of the canvas
-          for (var i = 0; i < 3; i++) {
+          for (let i = 0; i < 3; i++) {
             if (SDL.DOMButtons[i]) {
               SDL.events.push({
                 type: 'mouseup',
@@ -935,7 +935,7 @@ var LibrarySDL = {
           {{{ makeSetValue('ptr', C_STRUCTS.SDL_TextInputEvent.type, 'SDL.DOMEventToSDLEvent[event.type]', 'i32') }}};
           // Not filling in windowID for now
           var cStr = intArrayFromString(String.fromCharCode(event.charCode));
-          for (var i = 0; i < cStr.length; ++i) {
+          for (let i = 0; i < cStr.length; ++i) {
             {{{ makeSetValue('ptr', C_STRUCTS.SDL_TextInputEvent.text + ' + i', 'cStr[i]', 'i8') }}};
           }
           break;
@@ -1082,7 +1082,7 @@ var LibrarySDL = {
       if (SDL.numChannels && SDL.numChannels >= num && num != 0) return;
       SDL.numChannels = num;
       SDL.channels = [];
-      for (var i = 0; i < num; i++) {
+      for (let i = 0; i < num; i++) {
         SDL.channels[i] = {
           audio: null,
           volume: 1.0
@@ -1193,22 +1193,22 @@ var LibrarySDL = {
       // so perform a buffer conversion for the data.
       var audio = SDL_audio();
       var numChannels = audio.channels;
-      for (var c = 0; c < numChannels; ++c) {
+      for (let c = 0; c < numChannels; ++c) {
         var channelData = dstAudioBuffer['getChannelData'](c);
         if (channelData.length != sizeSamplesPerChannel) {
           throw 'Web Audio output buffer length mismatch! Destination size: ' + channelData.length + ' samples vs expected ' + sizeSamplesPerChannel + ' samples!';
         }
         if (audio.format == {{{ cDefine('AUDIO_S16LSB') }}}) {
-          for (var j = 0; j < sizeSamplesPerChannel; ++j) {
+          for (let j = 0; j < sizeSamplesPerChannel; ++j) {
             channelData[j] = ({{{ makeGetValue('heapPtr', '(j*numChannels + c)*2', 'i16') }}}) / 0x8000;
           }
         } else if (audio.format == {{{ cDefine('AUDIO_U8') }}}) {
-          for (var j = 0; j < sizeSamplesPerChannel; ++j) {
+          for (let j = 0; j < sizeSamplesPerChannel; ++j) {
             var v = ({{{ makeGetValue('heapPtr', 'j*numChannels + c', 'i8') }}});
             channelData[j] = ((v >= 0) ? v-128 : v+128) /128;
           }
         } else if (audio.format == {{{ cDefine('AUDIO_F32') }}}) {
-          for (var j = 0; j < sizeSamplesPerChannel; ++j) {
+          for (let j = 0; j < sizeSamplesPerChannel; ++j) {
             channelData[j] = ({{{ makeGetValue('heapPtr', '(j*numChannels + c)*4', 'float') }}});
           }
         } else {
@@ -1224,7 +1224,7 @@ var LibrarySDL = {
       var image = surfData.ctx.getImageData(0, 0, surfData.width, surfData.height);
       var data = image.data;
       var num = Math.min(surfData.width, surfData.height);
-      for (var i = 0; i < num; i++) {
+      for (let i = 0; i < num; i++) {
         out('   diagonal ' + i + ':' + [data[i*surfData.width*4 + i*4 + 0], data[i*surfData.width*4 + i*4 + 1], data[i*surfData.width*4 + i*4 + 2], data[i*surfData.width*4 + i*4 + 3]]);
       }
     },
@@ -1239,7 +1239,7 @@ var LibrarySDL = {
     recordJoystickState: function(joystick, state) {
       // Standardize button state.
       var buttons = new Array(state.buttons.length);
-      for (var i = 0; i < state.buttons.length; i++) {
+      for (let i = 0; i < state.buttons.length; i++) {
         buttons[i] = SDL.getJoystickButtonState(state.buttons[i]);
       }
 
@@ -1515,7 +1515,7 @@ var LibrarySDL = {
   SDL_AudioQuit__proxy: 'sync',
   SDL_AudioQuit__sig: 'v',
   SDL_AudioQuit: function() {
-    for (var i = 0; i < SDL.numChannels; ++i) {
+    for (let i = 0; i < SDL.numChannels; ++i) {
       var chan = /** @type {{ audio: (HTMLMediaElement|undefined) }} */ (SDL.channels[i]);
       if (chan.audio) {
         chan.audio.pause();
@@ -1577,7 +1577,7 @@ var LibrarySDL = {
     if (surf == SDL.screen && SDL.defaults.opaqueFrontBuffer) {
       var data = surfData.image.data;
       var num = data.length;
-      for (var i = 0; i < num/4; i++) {
+      for (let i = 0; i < num/4; i++) {
         data[i*4+3] = 255; // opacity, as canvases blend alpha
       }
     }
@@ -1593,7 +1593,7 @@ var LibrarySDL = {
         //
         // var size = surfData.width * surfData.height;
         // var data = '';
-        // for (var i = 0; i<size; i++) {
+        // for (let i = 0; i<size; i++) {
         //   var color = SDL.translateRGBAToColor(
         //     surfData.image.data[i*4   ],
         //     surfData.image.data[i*4 +1],
@@ -1701,9 +1701,9 @@ var LibrarySDL = {
       var s = surfData.buffer;
       var data = surfData.image.data;
       var colors = surfData.colors; // TODO: optimize using colors32
-      for (var y = 0; y < height; y++) {
+      for (let y = 0; y < height; y++) {
         var base = y*width*4;
-        for (var x = 0; x < width; x++) {
+        for (let x = 0; x < width; x++) {
           // See comment above about signs
           var val = {{{ makeGetValue('s++', '0', 'u8') }}} * 4;
           var start = base + x*4;
@@ -1878,11 +1878,11 @@ var LibrarySDL = {
     var image = data.ctx.createImageData(width, height);
     var pitchOfDst = width * 4;
 
-    for (var row = 0; row < height; ++row) {
+    for (let row = 0; row < height; ++row) {
       var baseOfSrc = row * pitch;
       var baseOfDst = row * pitchOfDst;
 
-      for (var col = 0; col < width * 4; ++col) {
+      for (let col = 0; col < width * 4; ++col) {
         image.data[baseOfDst + col] = {{{ makeGetValue('pixels', 'baseOfDst + col', 'u8') }}};
       }
     }
@@ -2142,7 +2142,7 @@ var LibrarySDL = {
       surfData.colors32 = new Uint32Array(buffer);
     }
 
-    for (var i = 0; i < nColors; ++i) {
+    for (let i = 0; i < nColors; ++i) {
       var index = (firstColor + i) * 4;
       surfData.colors[index] = {{{ makeGetValue('colors', 'i*4', 'u8') }}};
       surfData.colors[index + 1] = {{{ makeGetValue('colors', 'i*4 + 1', 'u8') }}};
@@ -2341,7 +2341,7 @@ var LibrarySDL = {
           var data = imageData.data;
           var sourcePtr = raw.data;
           var destPtr = 0;
-          for (var i = 0; i < pixels; i++) {
+          for (let i = 0; i < pixels; i++) {
             data[destPtr++] = {{{ makeGetValue('sourcePtr++', 0, 'u8') }}};
             data[destPtr++] = {{{ makeGetValue('sourcePtr++', 0, 'u8') }}};
             data[destPtr++] = {{{ makeGetValue('sourcePtr++', 0, 'u8') }}};
@@ -2353,7 +2353,7 @@ var LibrarySDL = {
           var data = imageData.data;
           var sourcePtr = raw.data;
           var destPtr = 0;
-          for (var i = 0; i < pixels; i++) {
+          for (let i = 0; i < pixels; i++) {
             var gray = {{{ makeGetValue('sourcePtr++', 0, 'u8') }}};
             var alpha = {{{ makeGetValue('sourcePtr++', 0, 'u8') }}};
             data[destPtr++] = gray;
@@ -2367,7 +2367,7 @@ var LibrarySDL = {
           var data = imageData.data;
           var sourcePtr = raw.data;
           var destPtr = 0;
-          for (var i = 0; i < pixels; i++) {
+          for (let i = 0; i < pixels; i++) {
             var value = {{{ makeGetValue('sourcePtr++', 0, 'u8') }}};
             data[destPtr++] = value;
             data[destPtr++] = value;
@@ -2495,7 +2495,7 @@ var LibrarySDL = {
       SDL.audio.queueNewAudioData = function SDL_queueNewAudioData() {
         if (!SDL.audio) return;
 
-        for (var i = 0; i < SDL.audio.numSimultaneouslyQueuedBuffers; ++i) {
+        for (let i = 0; i < SDL.audio.numSimultaneouslyQueuedBuffers; ++i) {
           // Only queue new data if we don't have enough audio data already in queue. Otherwise skip this time slot
           // and wait to queue more in the next time the callback is run.
           var secsUntilNextPlayStart = SDL.audio.nextPlayTime - SDL.audioContext['currentTime'];
@@ -2742,7 +2742,7 @@ var LibrarySDL = {
   Mix_Volume__sig: 'iii',
   Mix_Volume: function(channel, volume) {
     if (channel == -1) {
-      for (var i = 0; i < SDL.numChannels-1; i++) {
+      for (let i = 0; i < SDL.numChannels-1; i++) {
         _Mix_Volume(i, volume);
       }
       return _Mix_Volume(SDL.numChannels-1, volume);
@@ -2891,7 +2891,7 @@ var LibrarySDL = {
 
     var numSamples = len >> 1; // len is the length in bytes, and the array contains 16-bit PCM values
     var buffer = new Float32Array(numSamples);
-    for (var i = 0; i < numSamples; ++i) {
+    for (let i = 0; i < numSamples; ++i) {
       buffer[i] = ({{{ makeGetValue('mem', 'i*2', 'i16') }}}) / 0x8000; // hardcoded 16-bit audio, signed (TODO: reSign if not ta2?)
     }
 
@@ -2940,7 +2940,7 @@ var LibrarySDL = {
     // If the user asks us to allocate a channel automatically, get the first
     // free one.
     if (channel == -1) {
-      for (var i = SDL.channelMinimumNumber; i < SDL.numChannels; i++) {
+      for (let i = SDL.channelMinimumNumber; i < SDL.numChannels; i++) {
         if (!SDL.channels[i].audio) {
           channel = i;
           break;
@@ -3002,7 +3002,7 @@ var LibrarySDL = {
     if (channel != -1) {
       halt(channel);
     } else {
-      for (var i = 0; i < SDL.channels.length; ++i) halt(i);
+      for (let i = 0; i < SDL.channels.length; ++i) halt(i);
     }
     return 0;
   },
@@ -3115,7 +3115,7 @@ var LibrarySDL = {
   Mix_Playing: function(channel) {
     if (channel === -1) {
       var count = 0;
-      for (var i = 0; i < SDL.channels.length; i++) {
+      for (let i = 0; i < SDL.channels.length; i++) {
         count += _Mix_Playing(i);
       }
       return count;
@@ -3131,7 +3131,7 @@ var LibrarySDL = {
   Mix_Pause__sig: 'vi',
   Mix_Pause: function(channel) {
     if (channel === -1) {
-      for (var i = 0; i<SDL.channels.length;i++) {
+      for (let i = 0; i<SDL.channels.length;i++) {
         _Mix_Pause(i);
       }
       return;
@@ -3151,7 +3151,7 @@ var LibrarySDL = {
   Mix_Paused: function(channel) {
     if (channel === -1) {
       var pausedCount = 0;
-      for (var i = 0; i<SDL.channels.length;i++) {
+      for (let i = 0; i<SDL.channels.length;i++) {
         pausedCount += _Mix_Paused(i);
       }
       return pausedCount;
@@ -3174,7 +3174,7 @@ var LibrarySDL = {
   Mix_Resume__sig: 'vi',
   Mix_Resume: function(channel) {
     if (channel === -1) {
-      for (var i = 0; i<SDL.channels.length;i++) {
+      for (let i = 0; i<SDL.channels.length;i++) {
         _Mix_Resume(i);
       }
       return;
@@ -3559,7 +3559,7 @@ var LibrarySDL = {
     var count = 0;
     var gamepads = SDL.getGamepads();
     // The length is not the number of gamepads; check which ones are defined.
-    for (var i = 0; i < gamepads.length; i++) {
+    for (let i = 0; i < gamepads.length; i++) {
       if (gamepads[i] !== undefined) count++;
     }
     return count;

--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -431,7 +431,7 @@ mergeInto(LibraryManager.library, {
         }
         // close any peer connections
         var peers = Object.keys(sock.peers);
-        for (var i = 0; i < peers.length; i++) {
+        for (let i = 0; i < peers.length; i++) {
           var peer = sock.peers[peers[i]];
           try {
             peer.socket.close();

--- a/src/library_strings.js
+++ b/src/library_strings.js
@@ -73,7 +73,7 @@ mergeInto(LibraryManager.library, {
 
       // If maxBytesToRead is not passed explicitly, it will be undefined, and the for-loop's condition
       // will always evaluate to true. The loop is then terminated on the first null char.
-      for (var i = 0; !(i >= maxBytesToRead / 2); ++i) {
+      for (let i = 0; !(i >= maxBytesToRead / 2); ++i) {
         var codeUnit = {{{ makeGetValue('ptr', 'i*2', 'i16') }}};
         if (codeUnit == 0) break;
         // fromCharCode constructs a character from a UTF-16 code unit, so we can pass the UTF16 string right through.
@@ -116,7 +116,7 @@ mergeInto(LibraryManager.library, {
     maxBytesToWrite -= 2; // Null terminator.
     var startPtr = outPtr;
     var numCharsToWrite = (maxBytesToWrite < str.length*2) ? (maxBytesToWrite / 2) : str.length;
-    for (var i = 0; i < numCharsToWrite; ++i) {
+    for (let i = 0; i < numCharsToWrite; ++i) {
       // charCodeAt returns a UTF-16 encoded code unit, so it can be directly written to the HEAP.
       var codeUnit = str.charCodeAt(i); // possibly a lead surrogate
       {{{ makeSetValue('outPtr', 0, 'codeUnit', 'i16') }}};
@@ -190,7 +190,7 @@ mergeInto(LibraryManager.library, {
     if (maxBytesToWrite < 4) return 0;
     var startPtr = outPtr;
     var endPtr = startPtr + maxBytesToWrite - 4;
-    for (var i = 0; i < str.length; ++i) {
+    for (let i = 0; i < str.length; ++i) {
       // Gotcha: charCodeAt returns a 16-bit word that is a UTF-16 encoded code unit, not a Unicode code point of the character! We must decode the string to UTF-32 to the heap.
       // See http://unicode.org/faq/utf_bom.html#utf16-3
       var codeUnit = str.charCodeAt(i); // possibly a lead surrogate
@@ -211,7 +211,7 @@ mergeInto(LibraryManager.library, {
   // a UTF16 byte array, EXCLUDING the null terminator byte.
   $lengthBytesUTF32: function(str) {
     var len = 0;
-    for (var i = 0; i < str.length; ++i) {
+    for (let i = 0; i < str.length; ++i) {
       // Gotcha: charCodeAt returns a 16-bit word that is a UTF-16 encoded code unit, not a Unicode code point of the character! We must decode the string to UTF-32 to the heap.
       // See http://unicode.org/faq/utf_bom.html#utf16-3
       var codeUnit = str.charCodeAt(i);
@@ -269,7 +269,7 @@ mergeInto(LibraryManager.library, {
 
   $writeAsciiToMemory__docs: '/** @param {boolean=} dontAddNull */',
   $writeAsciiToMemory: function(str, buffer, dontAddNull) {
-    for (var i = 0; i < str.length; ++i) {
+    for (let i = 0; i < str.length; ++i) {
 #if ASSERTIONS
       assert(str.charCodeAt(i) === (str.charCodeAt(i) & 0xff));
 #endif

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -421,15 +421,15 @@ var SyscallsLibrary = {
     }
     // concatenate scatter-gather arrays into one message buffer
     var total = 0;
-    for (var i = 0; i < num; i++) {
+    for (let i = 0; i < num; i++) {
       total += {{{ makeGetValue('iov', '(' + C_STRUCTS.iovec.__size__ + ' * i) + ' + C_STRUCTS.iovec.iov_len, 'i32') }}};
     }
     var view = new Uint8Array(total);
     var offset = 0;
-    for (var i = 0; i < num; i++) {
+    for (let i = 0; i < num; i++) {
       var iovbase = {{{ makeGetValue('iov', '(' + C_STRUCTS.iovec.__size__ + ' * i) + ' + C_STRUCTS.iovec.iov_base, POINTER_TYPE) }}};
       var iovlen = {{{ makeGetValue('iov', '(' + C_STRUCTS.iovec.__size__ + ' * i) + ' + C_STRUCTS.iovec.iov_len, 'i32') }}};
-      for (var j = 0; j < iovlen; j++) {  
+      for (let j = 0; j < iovlen; j++) {
         view[offset++] = {{{ makeGetValue('iovbase', 'j', 'i8') }}};
       }
     }
@@ -443,7 +443,7 @@ var SyscallsLibrary = {
     var num = {{{ makeGetValue('message', C_STRUCTS.msghdr.msg_iovlen, 'i32') }}};
     // get the total amount of data we can read across all arrays
     var total = 0;
-    for (var i = 0; i < num; i++) {
+    for (let i = 0; i < num; i++) {
       total += {{{ makeGetValue('iov', '(' + C_STRUCTS.iovec.__size__ + ' * i) + ' + C_STRUCTS.iovec.iov_len, 'i32') }}};
     }
     // try to read total data
@@ -469,7 +469,7 @@ var SyscallsLibrary = {
     // write the buffer out to the scatter-gather arrays
     var bytesRead = 0;
     var bytesRemaining = msg.buffer.byteLength;
-    for (var i = 0; bytesRemaining > 0 && i < num; i++) {
+    for (let i = 0; bytesRemaining > 0 && i < num; i++) {
       var iovbase = {{{ makeGetValue('iov', '(' + C_STRUCTS.iovec.__size__ + ' * i) + ' + C_STRUCTS.iovec.iov_base, POINTER_TYPE) }}};
       var iovlen = {{{ makeGetValue('iov', '(' + C_STRUCTS.iovec.__size__ + ' * i) + ' + C_STRUCTS.iovec.iov_len, 'i32') }}};
       if (!iovlen) {
@@ -536,7 +536,7 @@ var SyscallsLibrary = {
       return (fd < 32 ? (low & val) : (high & val));
     };
 
-    for (var fd = 0; fd < nfds; fd++) {
+    for (let fd = 0; fd < nfds; fd++) {
       var mask = 1 << (fd % 32);
       if (!(check(fd, allLow, allHigh, mask))) {
         continue;  // index isn't in the set
@@ -595,7 +595,7 @@ var SyscallsLibrary = {
   __syscall_poll__sig: 'ipii',
   __syscall_poll: function(fds, nfds, timeout) {
     var nonzero = 0;
-    for (var i = 0; i < nfds; i++) {
+    for (let i = 0; i < nfds; i++) {
       var pollfd = fds + {{{ C_STRUCTS.pollfd.__size__ }}} * i;
       var fd = {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.fd, 'i32') }}};
       var events = {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.events, 'i16') }}};

--- a/src/library_trace.js
+++ b/src/library_trace.js
@@ -285,7 +285,7 @@ var LibraryTracing = {
       var totalMemory = 0;
       for (var i in AL.currentContext.buf) {
         var buffer = AL.currentContext.buf[i];
-        for (var channel = 0; channel < buffer.numberOfChannels; ++channel) {
+        for (let channel = 0; channel < buffer.numberOfChannels; ++channel) {
           totalMemory += buffer.getChannelData(channel).length * 4;
         }
       }

--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -60,7 +60,7 @@ mergeInto(LibraryManager.library, {
           throw new FS.ErrnoError({{{ cDefine('ENXIO') }}});
         }
         var bytesRead = 0;
-        for (var i = 0; i < length; i++) {
+        for (let i = 0; i < length; i++) {
           var result;
           try {
             result = stream.tty.ops.get_char(stream.tty);

--- a/src/library_uuid.js
+++ b/src/library_uuid.js
@@ -56,7 +56,7 @@ mergeInto(LibraryManager.library, {
     if (!uuid) {
       uuid = new Array(16);
       var d = new Date().getTime();
-      for (var i = 0; i < 16; i++) {
+      for (let i = 0; i < 16; i++) {
         var r = ((d + Math.random() * 256) % 256)|0;
         d = (d / 256)|0;
         uuid[i] = r;
@@ -73,7 +73,7 @@ mergeInto(LibraryManager.library, {
   // If the value is equal to the NULL UUID, 1 is returned, otherwise 0 is returned.
   uuid_is_null: function(uu) {
     // int uuid_is_null(const uuid_t uu);
-    for (var i = 0; i < 4; i++, uu = (uu+4)|0) {
+    for (let i = 0; i < 4; i++, uu = (uu+4)|0) {
       var val = {{{ makeGetValue('uu', 0, 'i32') }}};
       if (val) {
         return 0;

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -198,7 +198,7 @@ var WasiLibrary = {
   $doReadv__docs: '/** @param {number=} offset */',
   $doReadv: function(stream, iov, iovcnt, offset) {
     var ret = 0;
-    for (var i = 0; i < iovcnt; i++) {
+    for (let i = 0; i < iovcnt; i++) {
       var ptr = {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_base, '*') }}};
       var len = {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_len, '*') }}};
       iov += {{{ C_STRUCTS.iovec.__size__ }}};
@@ -212,7 +212,7 @@ var WasiLibrary = {
   $doWritev__docs: '/** @param {number=} offset */',
   $doWritev: function(stream, iov, iovcnt, offset) {
     var ret = 0;
-    for (var i = 0; i < iovcnt; i++) {
+    for (let i = 0; i < iovcnt; i++) {
       var ptr = {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_base, '*') }}};
       var len = {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_len, '*') }}};
       iov += {{{ C_STRUCTS.iovec.__size__ }}};
@@ -273,7 +273,7 @@ var WasiLibrary = {
       var ptr = {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_base, '*') }}};
       var len = {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_len, '*') }}};
       iov += {{{ C_STRUCTS.iovec.__size__ }}};
-      for (var j = 0; j < len; j++) {
+      for (let j = 0; j < len; j++) {
         printChar(fd, HEAPU8[ptr+j]);
       }
       num += len;

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -20,7 +20,7 @@ var LibraryGL = {
 
   // For functions such as glDrawBuffers, glInvalidateFramebuffer and glInvalidateSubFramebuffer that need to pass a short array to the WebGL API,
   // create a set of short fixed-length arrays to avoid having to generate any garbage when calling those functions.
-  $tempFixedLengthArray__postset: 'for (var i = 0; i < 32; ++i) tempFixedLengthArray.push(new Array(i));',
+  $tempFixedLengthArray__postset: 'for (let i = 0; i < 32; ++i) tempFixedLengthArray.push(new Array(i));',
   $tempFixedLengthArray: [],
 
   $miniTempWebGLFloatBuffers: [],
@@ -240,7 +240,7 @@ var LibraryGL = {
     // Get a new ID for a texture/buffer/etc., while keeping the table dense and fast. Creation is fairly rare so it is worth optimizing lookups later.
     getNewId: function(table) {
       var ret = GL.counter++;
-      for (var i = table.length; i < ret; i++) {
+      for (let i = table.length; i < ret; i++) {
         table[i] = null;
       }
       return ret;
@@ -275,7 +275,7 @@ var LibraryGL = {
       context.tempVertexBuffers1.length = context.tempVertexBuffers2.length = largestIndex+1;
       context.tempIndexBuffers = [];
       context.tempIndexBuffers.length = largestIndex+1;
-      for (var i = 0; i <= largestIndex; ++i) {
+      for (let i = 0; i <= largestIndex; ++i) {
         context.tempIndexBuffers[i] = null; // Created on-demand
         context.tempVertexBufferCounters1[i] = context.tempVertexBufferCounters2[i] = 0;
         var ringbufferLength = GL.numTempVertexBuffersPerSize;
@@ -284,7 +284,7 @@ var LibraryGL = {
         var ringbuffer1 = context.tempVertexBuffers1[i];
         var ringbuffer2 = context.tempVertexBuffers2[i];
         ringbuffer1.length = ringbuffer2.length = ringbufferLength;
-        for (var j = 0; j < ringbufferLength; ++j) {
+        for (let j = 0; j < ringbufferLength; ++j) {
           ringbuffer1[j] = ringbuffer2[j] = null; // Created on-demand
         }
       }
@@ -361,7 +361,7 @@ var LibraryGL = {
       GL.currentContext.tempVertexBufferCounters1 = GL.currentContext.tempVertexBufferCounters2;
       GL.currentContext.tempVertexBufferCounters2 = vb;
       var largestIndex = GL.log2ceilLookup(GL.MAX_TEMP_BUFFER_SIZE);
-      for (var i = 0; i <= largestIndex; ++i) {
+      for (let i = 0; i <= largestIndex; ++i) {
         GL.currentContext.tempVertexBufferCounters1[i] = 0;
       }
     },
@@ -369,7 +369,7 @@ var LibraryGL = {
 
     getSource: function(shader, count, string, length) {
       var source = '';
-      for (var i = 0; i < count; ++i) {
+      for (let i = 0; i < count; ++i) {
         var len = length ? {{{ makeGetValue('length', 'i*4', 'i32') }}} : -1;
         source += UTF8ToString({{{ makeGetValue('string', 'i*4', 'i32') }}}, len < 0 ? undefined : len);
       }
@@ -424,7 +424,7 @@ var LibraryGL = {
       GL.resetBufferBinding = false;
 
       // TODO: initial pass to detect ranges we need to upload, might not need an upload per attrib
-      for (var i = 0; i < GL.currentContext.maxVertexAttribs; ++i) {
+      for (let i = 0; i < GL.currentContext.maxVertexAttribs; ++i) {
         var cb = GL.currentContext.clientBuffers[i];
         if (!cb.clientside || !cb.enabled) continue;
 
@@ -692,7 +692,7 @@ var LibraryGL = {
       const disableHalfFloatExtensionIfBroken = (ctx) => {
         var t = ctx.createTexture();
         ctx.bindTexture(0xDE1/*GL_TEXTURE_2D*/, t);
-        for (var i = 0; i < 8 && ctx.getError(); ++i) /*no-op*/;
+        for (let i = 0; i < 8 && ctx.getError(); ++i) /*no-op*/;
         var ext = ctx.getExtension('OES_texture_half_float');
         if (!ext) return; // no half-float extension - nothing needed to fix.
         // Bug on Safari on iOS and macOS: texImage2D() and texSubImage2D() do not allow uploading pixel data to half float textures,
@@ -918,7 +918,7 @@ var LibraryGL = {
           };
           var maxVertexAttribs = gl.getParameter(0x8869 /*GL_MAX_VERTEX_ATTRIBS*/);
           var prevVertexAttribEnables = [];
-          for (var i = 0; i < maxVertexAttribs; ++i) {
+          for (let i = 0; i < maxVertexAttribs; ++i) {
             var prevEnabled = gl.getVertexAttrib(i, 0x8622 /*GL_VERTEX_ATTRIB_ARRAY_ENABLED*/);
             var wantEnabled = i == context.blitPosLoc;
             if (prevEnabled && !wantEnabled) {
@@ -932,7 +932,7 @@ var LibraryGL = {
 
           draw();
 
-          for (var i = 0; i < maxVertexAttribs; ++i) {
+          for (let i = 0; i < maxVertexAttribs; ++i) {
             var prevEnabled = prevVertexAttribEnables[i];
             var nowEnabled = i == context.blitPosLoc;
             if (prevEnabled && !nowEnabled) {
@@ -1024,7 +1024,7 @@ var LibraryGL = {
 #if FULL_ES2
       context.maxVertexAttribs = context.GLctx.getParameter(0x8869 /*GL_MAX_VERTEX_ATTRIBS*/);
       context.clientBuffers = [];
-      for (var i = 0; i < context.maxVertexAttribs; i++) {
+      for (let i = 0; i < context.maxVertexAttribs; i++) {
         context.clientBuffers[i] = { enabled: false, clientside: false, size: 0, type: 0, normalized: 0, stride: 0, ptr: 0, vertexAttribPointerAdaptor: null };
       }
 
@@ -1350,7 +1350,7 @@ var LibraryGL = {
                      result instanceof Uint32Array ||
                      result instanceof Int32Array ||
                      result instanceof Array) {
-            for (var i = 0; i < result.length; ++i) {
+            for (let i = 0; i < result.length; ++i) {
               switch (type) {
                 case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('p', 'i*4', 'result[i]', 'i32') }}}; break;
                 case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('p', 'i*4', 'result[i]', 'float') }}}; break;
@@ -1415,7 +1415,7 @@ var LibraryGL = {
 
   glDeleteTextures__sig: 'vii',
   glDeleteTextures: function(n, textures) {
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       var id = {{{ makeGetValue('textures', 'i*4', 'i32') }}};
       var texture = GL.textures[id];
       if (!texture) continue; // GL spec: "glDeleteTextures silently ignores 0s and names that do not correspond to existing textures".
@@ -1685,7 +1685,7 @@ var LibraryGL = {
     , functionName
 #endif
     ) {
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       var buffer = GLctx[createFunction]();
       var id = buffer && GL.getNewId(objectTable);
       if (buffer) {
@@ -1723,7 +1723,7 @@ var LibraryGL = {
 
   glDeleteBuffers__sig: 'vii',
   glDeleteBuffers: function(n, buffers) {
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       var id = {{{ makeGetValue('buffers', 'i*4', 'i32') }}};
       var buffer = GL.buffers[id];
 
@@ -1813,7 +1813,7 @@ var LibraryGL = {
   // Queries EXT
   glGenQueriesEXT__sig: 'vii',
   glGenQueriesEXT: function(n, ids) {
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       var query = GLctx.disjointTimerQueryExt['createQueryEXT']();
       if (!query) {
         GL.recordError(0x502 /* GL_INVALID_OPERATION */);
@@ -1832,7 +1832,7 @@ var LibraryGL = {
 
   glDeleteQueriesEXT__sig: 'vii',
   glDeleteQueriesEXT: function(n, ids) {
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       var id = {{{ makeGetValue('ids', 'i*4', 'i32') }}};
       var query = GL.queries[id];
       if (!query) continue; // GL spec: "unused names in ids are ignored, as is the name zero."
@@ -1969,7 +1969,7 @@ var LibraryGL = {
 
   glDeleteRenderbuffers__sig: 'vii',
   glDeleteRenderbuffers: function(n, renderbuffers) {
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       var id = {{{ makeGetValue('renderbuffers', 'i*4', 'i32') }}};
       var renderbuffer = GL.renderbuffers[id];
       if (!renderbuffer) continue; // GL spec: "glDeleteRenderbuffers silently ignores 0s and names that do not correspond to existing renderbuffer objects".
@@ -2036,7 +2036,7 @@ var LibraryGL = {
 #endif
       }
     } else {
-      for (var i = 0; i < data.length; i++) {
+      for (let i = 0; i < data.length; i++) {
         switch (type) {
           case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'i32') }}}; break;
           case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'float') }}}; break;
@@ -2232,7 +2232,7 @@ var LibraryGL = {
 #endif
       }
     } else {
-      for (var i = 0; i < data.length; i++) {
+      for (let i = 0; i < data.length; i++) {
         switch (type) {
           case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'i32') }}}; break;
           case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'float') }}}; break;
@@ -2382,7 +2382,7 @@ var LibraryGL = {
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}}) {
       // avoid allocation when uploading few enough uniforms
       var view = __miniTempWebGLIntBuffers[count-1];
-      for (var i = 0; i < count; ++i) {
+      for (let i = 0; i < count; ++i) {
         view[i] = {{{ makeGetValue('value', '4*i', 'i32') }}};
       }
     } else
@@ -2427,7 +2427,7 @@ var LibraryGL = {
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE / 2 }}}) {
       // avoid allocation when uploading few enough uniforms
       var view = __miniTempWebGLIntBuffers[2*count-1];
-      for (var i = 0; i < 2*count; i += 2) {
+      for (let i = 0; i < 2*count; i += 2) {
         view[i] = {{{ makeGetValue('value', '4*i', 'i32') }}};
         view[i+1] = {{{ makeGetValue('value', '4*i+4', 'i32') }}};
       }
@@ -2473,7 +2473,7 @@ var LibraryGL = {
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE / 3 }}}) {
       // avoid allocation when uploading few enough uniforms
       var view = __miniTempWebGLIntBuffers[3*count-1];
-      for (var i = 0; i < 3*count; i += 3) {
+      for (let i = 0; i < 3*count; i += 3) {
         view[i] = {{{ makeGetValue('value', '4*i', 'i32') }}};
         view[i+1] = {{{ makeGetValue('value', '4*i+4', 'i32') }}};
         view[i+2] = {{{ makeGetValue('value', '4*i+8', 'i32') }}};
@@ -2520,7 +2520,7 @@ var LibraryGL = {
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE / 4 }}}) {
       // avoid allocation when uploading few enough uniforms
       var view = __miniTempWebGLIntBuffers[4*count-1];
-      for (var i = 0; i < 4*count; i += 4) {
+      for (let i = 0; i < 4*count; i += 4) {
         view[i] = {{{ makeGetValue('value', '4*i', 'i32') }}};
         view[i+1] = {{{ makeGetValue('value', '4*i+4', 'i32') }}};
         view[i+2] = {{{ makeGetValue('value', '4*i+8', 'i32') }}};
@@ -2568,7 +2568,7 @@ var LibraryGL = {
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}}) {
       // avoid allocation when uploading few enough uniforms
       var view = miniTempWebGLFloatBuffers[count-1];
-      for (var i = 0; i < count; ++i) {
+      for (let i = 0; i < count; ++i) {
         view[i] = {{{ makeGetValue('value', '4*i', 'float') }}};
       }
     } else
@@ -2613,7 +2613,7 @@ var LibraryGL = {
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE / 2 }}}) {
       // avoid allocation when uploading few enough uniforms
       var view = miniTempWebGLFloatBuffers[2*count-1];
-      for (var i = 0; i < 2*count; i += 2) {
+      for (let i = 0; i < 2*count; i += 2) {
         view[i] = {{{ makeGetValue('value', '4*i', 'float') }}};
         view[i+1] = {{{ makeGetValue('value', '4*i+4', 'float') }}};
       }
@@ -2659,7 +2659,7 @@ var LibraryGL = {
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE / 3 }}}) {
       // avoid allocation when uploading few enough uniforms
       var view = miniTempWebGLFloatBuffers[3*count-1];
-      for (var i = 0; i < 3*count; i += 3) {
+      for (let i = 0; i < 3*count; i += 3) {
         view[i] = {{{ makeGetValue('value', '4*i', 'float') }}};
         view[i+1] = {{{ makeGetValue('value', '4*i+4', 'float') }}};
         view[i+2] = {{{ makeGetValue('value', '4*i+8', 'float') }}};
@@ -2709,7 +2709,7 @@ var LibraryGL = {
       // hoist the heap out of the loop for size and for pthreads+growth.
       var heap = HEAPF32;
       value >>= 2;
-      for (var i = 0; i < 4 * count; i += 4) {
+      for (let i = 0; i < 4 * count; i += 4) {
         var dst = value + i;
         view[i] = heap[dst];
         view[i + 1] = heap[dst + 1];
@@ -2758,7 +2758,7 @@ var LibraryGL = {
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE / 4 }}}) {
       // avoid allocation when uploading few enough uniforms
       var view = miniTempWebGLFloatBuffers[4*count-1];
-      for (var i = 0; i < 4*count; i += 4) {
+      for (let i = 0; i < 4*count; i += 4) {
         view[i] = {{{ makeGetValue('value', '4*i', 'float') }}};
         view[i+1] = {{{ makeGetValue('value', '4*i+4', 'float') }}};
         view[i+2] = {{{ makeGetValue('value', '4*i+8', 'float') }}};
@@ -2806,7 +2806,7 @@ var LibraryGL = {
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE / 9 }}}) {
       // avoid allocation when uploading few enough uniforms
       var view = miniTempWebGLFloatBuffers[9*count-1];
-      for (var i = 0; i < 9*count; i += 9) {
+      for (let i = 0; i < 9*count; i += 9) {
         view[i] = {{{ makeGetValue('value', '4*i', 'float') }}};
         view[i+1] = {{{ makeGetValue('value', '4*i+4', 'float') }}};
         view[i+2] = {{{ makeGetValue('value', '4*i+8', 'float') }}};
@@ -2862,7 +2862,7 @@ var LibraryGL = {
       // hoist the heap out of the loop for size and for pthreads+growth.
       var heap = HEAPF32;
       value >>= 2;
-      for (var i = 0; i < 16 * count; i += 16) {
+      for (let i = 0; i < 16 * count; i += 16) {
         var dst = value + i;
         view[i] = heap[dst];
         view[i + 1] = heap[dst + 1];
@@ -3034,7 +3034,7 @@ var LibraryGL = {
       len = maxCount;
     }
     {{{ makeSetValue('count', '0', 'len', 'i32') }}};
-    for (var i = 0; i < len; ++i) {
+    for (let i = 0; i < len; ++i) {
       var id = GL.shaders.indexOf(result[i]);
 #if GL_ASSERTIONS
       assert(id !== -1, 'shader not bound to local id');
@@ -3313,21 +3313,21 @@ var LibraryGL = {
       {{{ makeSetValue('p', '0', 'log.length + 1', 'i32') }}};
     } else if (pname == 0x8B87 /* GL_ACTIVE_UNIFORM_MAX_LENGTH */) {
       if (!program.maxUniformLength) {
-        for (var i = 0; i < GLctx.getProgramParameter(program, 0x8B86/*GL_ACTIVE_UNIFORMS*/); ++i) {
+        for (let i = 0; i < GLctx.getProgramParameter(program, 0x8B86/*GL_ACTIVE_UNIFORMS*/); ++i) {
           program.maxUniformLength = Math.max(program.maxUniformLength, GLctx.getActiveUniform(program, i).name.length+1);
         }
       }
       {{{ makeSetValue('p', '0', 'program.maxUniformLength', 'i32') }}};
     } else if (pname == 0x8B8A /* GL_ACTIVE_ATTRIBUTE_MAX_LENGTH */) {
       if (!program.maxAttributeLength) {
-        for (var i = 0; i < GLctx.getProgramParameter(program, 0x8B89/*GL_ACTIVE_ATTRIBUTES*/); ++i) {
+        for (let i = 0; i < GLctx.getProgramParameter(program, 0x8B89/*GL_ACTIVE_ATTRIBUTES*/); ++i) {
           program.maxAttributeLength = Math.max(program.maxAttributeLength, GLctx.getActiveAttrib(program, i).name.length+1);
         }
       }
       {{{ makeSetValue('p', '0', 'program.maxAttributeLength', 'i32') }}};
     } else if (pname == 0x8A35 /* GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH */) {
       if (!program.maxUniformBlockNameLength) {
-        for (var i = 0; i < GLctx.getProgramParameter(program, 0x8A36/*GL_ACTIVE_UNIFORM_BLOCKS*/); ++i) {
+        for (let i = 0; i < GLctx.getProgramParameter(program, 0x8A36/*GL_ACTIVE_UNIFORM_BLOCKS*/); ++i) {
           program.maxUniformBlockNameLength = Math.max(program.maxUniformBlockNameLength, GLctx.getActiveUniformBlockName(program, i).length+1);
         }
       }
@@ -3582,7 +3582,7 @@ var LibraryGL = {
 
   glDeleteFramebuffers__sig: 'vii',
   glDeleteFramebuffers: function(n, framebuffers) {
-    for (var i = 0; i < n; ++i) {
+    for (let i = 0; i < n; ++i) {
       var id = {{{ makeGetValue('framebuffers', 'i*4', 'i32') }}};
       var framebuffer = GL.framebuffers[id];
       if (!framebuffer) continue; // GL spec: "glDeleteFramebuffers silently ignores 0s and names that do not correspond to existing framebuffer objects".
@@ -3659,7 +3659,7 @@ var LibraryGL = {
 #if GL_ASSERTIONS
     assert(GLctx['deleteVertexArray'], 'Must have WebGL2 or OES_vertex_array_object to use vao');
 #endif
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       var id = {{{ makeGetValue('vaos', 'i*4', 'i32') }}};
       GLctx['deleteVertexArray'](GL.vaos[id]);
       GL.vaos[id] = null;
@@ -3896,7 +3896,7 @@ var LibraryGL = {
 #endif
 
     var bufArray = tempFixedLengthArray[n];
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       bufArray[i] = {{{ makeGetValue('bufs', 'i*4', 'i32') }}};
     }
 

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -77,7 +77,7 @@ var LibraryWebGL2 = {
 #endif
     var ret = GLctx['getInternalformatParameter'](target, internalformat, pname);
     if (ret === null) return;
-    for (var i = 0; i < ret.length && i < bufSize; ++i) {
+    for (let i = 0; i < ret.length && i < bufSize; ++i) {
       {{{ makeSetValue('params', 'i*4', 'ret[i]', 'i32') }}};
     }
   },
@@ -139,7 +139,7 @@ var LibraryWebGL2 = {
     assert(numAttachments < tempFixedLengthArray.length, 'Invalid count of numAttachments=' + numAttachments + ' passed to glInvalidateFramebuffer (that many attachment points do not exist in GL)');
 #endif
     var list = tempFixedLengthArray[numAttachments];
-    for (var i = 0; i < numAttachments; i++) {
+    for (let i = 0; i < numAttachments; i++) {
       list[i] = {{{ makeGetValue('attachments', 'i*4', 'i32') }}};
     }
 
@@ -153,7 +153,7 @@ var LibraryWebGL2 = {
     assert(numAttachments < tempFixedLengthArray.length, 'Invalid count of numAttachments=' + numAttachments + ' passed to glInvalidateSubFramebuffer (that many attachment points do not exist in GL)');
 #endif
     var list = tempFixedLengthArray[numAttachments];
-    for (var i = 0; i < numAttachments; i++) {
+    for (let i = 0; i < numAttachments; i++) {
       list[i] = {{{ makeGetValue('attachments', 'i*4', 'i32') }}};
     }
 
@@ -199,7 +199,7 @@ var LibraryWebGL2 = {
 
   glDeleteQueries__sig: 'vii',
   glDeleteQueries: function(n, ids) {
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       var id = {{{ makeGetValue('ids', 'i*4', 'i32') }}};
       var query = GL.queries[id];
       if (!query) continue; // GL spec: "unused names in ids are ignored, as is the name zero."
@@ -279,7 +279,7 @@ var LibraryWebGL2 = {
 
   glDeleteSamplers__sig: 'vii',
   glDeleteSamplers: function(n, samplers) {
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       var id = {{{ makeGetValue('samplers', 'i*4', 'i32') }}};
       var sampler = GL.samplers[id];
       if (!sampler) continue;
@@ -383,7 +383,7 @@ var LibraryWebGL2 = {
 
   glDeleteTransformFeedbacks__sig: 'vii',
   glDeleteTransformFeedbacks: function(n, ids) {
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       var id = {{{ makeGetValue('ids', 'i*4', 'i32') }}};
       var transformFeedback = GL.transformFeedbacks[id];
       if (!transformFeedback) continue; // GL spec: "unused names in ids are ignored, as is the name zero."
@@ -413,7 +413,7 @@ var LibraryWebGL2 = {
 #endif
     program = GL.programs[program];
     var vars = [];
-    for (var i = 0; i < count; i++)
+    for (let i = 0; i < count; i++)
       vars.push(UTF8ToString({{{ makeGetValue('varyings', 'i*4', 'i32') }}}));
 
     GLctx['transformFeedbackVaryings'](program, vars, bufferMode);
@@ -554,14 +554,14 @@ var LibraryWebGL2 = {
 #endif
     program = GL.programs[program];
     var names = [];
-    for (var i = 0; i < uniformCount; i++)
+    for (let i = 0; i < uniformCount; i++)
       names.push(UTF8ToString({{{ makeGetValue('uniformNames', 'i*4', 'i32') }}}));
 
     var result = GLctx['getUniformIndices'](program, names);
     if (!result) return; // GL spec: If an error is generated, nothing is written out to uniformIndices.
 
     var len = result.length;
-    for (var i = 0; i < len; i++) {
+    for (let i = 0; i < len; i++) {
       {{{ makeSetValue('uniformIndices', 'i*4', 'result[i]', 'i32') }}};
     }
   },
@@ -588,7 +588,7 @@ var LibraryWebGL2 = {
 #endif
     program = GL.programs[program];
     var ids = [];
-    for (var i = 0; i < uniformCount; i++) {
+    for (let i = 0; i < uniformCount; i++) {
       ids.push({{{ makeGetValue('uniformIndices', 'i*4', 'i32') }}});
     }
 
@@ -596,7 +596,7 @@ var LibraryWebGL2 = {
     if (!result) return; // GL spec: If an error is generated, nothing is written out to params.
 
     var len = result.length;
-    for (var i = 0; i < len; i++) {
+    for (let i = 0; i < len; i++) {
       {{{ makeSetValue('params', 'i*4', 'result[i]', 'i32') }}};
     }
   },
@@ -636,7 +636,7 @@ var LibraryWebGL2 = {
     var result = GLctx['getActiveUniformBlockParameter'](program, uniformBlockIndex, pname);
     if (result === null) return; // If an error occurs, nothing should be written to params.
     if (pname == 0x8A43 /*GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES*/) {
-      for (var i = 0; i < result.length; i++) {
+      for (let i = 0; i < result.length; i++) {
         {{{ makeSetValue('params', 'i*4', 'result[i]', 'i32') }}};
       }
     } else {

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -284,7 +284,7 @@ var LibraryWebGPU = {
     makePipelineConstants: function(constantCount, constantsPtr) {
       if (!constantCount) return;
       var constants = {};
-      for (var i = 0; i < constantCount; ++i) {
+      for (let i = 0; i < constantCount; ++i) {
         var entryPtr = constantsPtr + {{{ C_STRUCTS.WGPUConstantEntry.__size__ }}} * i;
         var key = UTF8ToString({{{ makeGetValue('entryPtr', C_STRUCTS.WGPUConstantEntry.key, '*') }}});
         constants[key] = {{{ makeGetValue('entryPtr', C_STRUCTS.WGPUConstantEntry.value, 'double') }}};
@@ -1014,7 +1014,7 @@ var LibraryWebGPU = {
 
     function makeEntries(count, entriesPtrs) {
       var entries = [];
-      for (var i = 0; i < count; ++i) {
+      for (let i = 0; i < count; ++i) {
         entries.push(makeEntry(entriesPtrs +
             {{{ C_STRUCTS.WGPUBindGroupLayoutEntry.__size__ }}} * i));
       }
@@ -1077,7 +1077,7 @@ var LibraryWebGPU = {
 
     function makeEntries(count, entriesPtrs) {
       var entries = [];
-      for (var i = 0; i < count; ++i) {
+      for (let i = 0; i < count; ++i) {
         entries.push(makeEntry(entriesPtrs +
             {{{C_STRUCTS.WGPUBindGroupEntry.__size__}}} * i));
       }
@@ -1105,7 +1105,7 @@ var LibraryWebGPU = {
     var bglCount = {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUPipelineLayoutDescriptor.bindGroupLayoutCount) }}};
     var bglPtr = {{{ makeGetValue('descriptor', C_STRUCTS.WGPUPipelineLayoutDescriptor.bindGroupLayouts, '*') }}};
     var bgls = [];
-    for (var i = 0; i < bglCount; ++i) {
+    for (let i = 0; i < bglCount; ++i) {
       bgls.push(WebGPU.mgrBindGroupLayout.get(
         {{{ makeGetValue('bglPtr', '4 * i', '*') }}}));
     }
@@ -1130,7 +1130,7 @@ var LibraryWebGPU = {
       var pipelineStatisticsPtr =
         {{{ makeGetValue('descriptor', C_STRUCTS.WGPUQuerySetDescriptor.pipelineStatistics, '*') }}};
       pipelineStatistics = [];
-      for (var i = 0; i < pipelineStatisticsCount; ++i) {
+      for (let i = 0; i < pipelineStatisticsCount; ++i) {
         pipelineStatistics.push(WebGPU.PipelineStatisticName[
           {{{ gpu.makeGetU32('pipelineStatisticsPtr', '4 * i') }}}]);
       }
@@ -1155,7 +1155,7 @@ var LibraryWebGPU = {
 
       function makeColorFormats(count, formatsPtr) {
         var formats = [];
-        for (var i = 0; i < count; ++i, formatsPtr += 4) {
+        for (let i = 0; i < count; ++i, formatsPtr += 4) {
           // format could be undefined
           formats.push(WebGPU.TextureFormat[{{{ gpu.makeGetU32('formatsPtr', 0) }}}]);
         }
@@ -1254,7 +1254,7 @@ var LibraryWebGPU = {
 
     function makeColorStates(count, csArrayPtr) {
       var states = [];
-      for (var i = 0; i < count; ++i) {
+      for (let i = 0; i < count; ++i) {
         states.push(makeColorState(csArrayPtr + {{{ C_STRUCTS.WGPUColorTargetState.__size__ }}} * i));
       }
       return states;
@@ -1306,7 +1306,7 @@ var LibraryWebGPU = {
 
     function makeVertexAttributes(count, vaArrayPtr) {
       var vas = [];
-      for (var i = 0; i < count; ++i) {
+      for (let i = 0; i < count; ++i) {
         vas.push(makeVertexAttribute(vaArrayPtr + i * {{{ C_STRUCTS.WGPUVertexAttribute.__size__ }}}));
       }
       return vas;
@@ -1329,7 +1329,7 @@ var LibraryWebGPU = {
       if (!count) return undefined;
 
       var vbs = [];
-      for (var i = 0; i < count; ++i) {
+      for (let i = 0; i < count; ++i) {
         vbs.push(makeVertexBuffer(vbArrayPtr + i * {{{ C_STRUCTS.WGPUVertexBufferLayout.__size__ }}}));
       }
       return vbs;
@@ -1536,7 +1536,7 @@ var LibraryWebGPU = {
 
     function makeComputePassTimestampWrites(count, twPtr) {
       var timestampWrites = [];
-      for (var i = 0; i < count; ++i) {
+      for (let i = 0; i < count; ++i) {
         timestampWrites.push(makeComputePassTimestampWrite(twPtr + {{{ C_STRUCTS.WGPUComputePassTimestampWrite.__size__ }}} * i));
       }
       return timestampWrites;
@@ -1593,7 +1593,7 @@ var LibraryWebGPU = {
 
     function makeColorAttachments(count, caPtr) {
       var attachments = [];
-      for (var i = 0; i < count; ++i) {
+      for (let i = 0; i < count; ++i) {
         attachments.push(makeColorAttachment(caPtr + {{{ C_STRUCTS.WGPURenderPassColorAttachment.__size__ }}} * i));
       }
       return attachments;
@@ -1632,7 +1632,7 @@ var LibraryWebGPU = {
 
     function makeRenderPassTimestampWrites(count, twPtr) {
       var timestampWrites = [];
-      for (var i = 0; i < count; ++i) {
+      for (let i = 0; i < count; ++i) {
         timestampWrites.push(makeRenderPassTimestampWrite(twPtr + {{{ C_STRUCTS.WGPURenderPassTimestampWrite.__size__ }}} * i));
       }
       return timestampWrites;
@@ -1931,7 +1931,7 @@ var LibraryWebGPU = {
       return;
     }
 
-    for (var i = 0; i < bufferWrapper.onUnmap.length; ++i) {
+    for (let i = 0; i < bufferWrapper.onUnmap.length; ++i) {
       bufferWrapper.onUnmap[i]();
     }
     bufferWrapper.onUnmap = undefined;
@@ -1988,7 +1988,7 @@ var LibraryWebGPU = {
       pass["setBindGroup"](groupIndex, group);
     } else {
       var offsets = [];
-      for (var i = 0; i < dynamicOffsetCount; i++, dynamicOffsetsPtr += 4) {
+      for (let i = 0; i < dynamicOffsetCount; i++, dynamicOffsetsPtr += 4) {
         offsets.push({{{ gpu.makeGetU32('dynamicOffsetsPtr', 0) }}});
       }
       pass["setBindGroup"](groupIndex, group, offsets);
@@ -2074,7 +2074,7 @@ var LibraryWebGPU = {
       pass["setBindGroup"](groupIndex, group);
     } else {
       var offsets = [];
-      for (var i = 0; i < dynamicOffsetCount; i++, dynamicOffsetsPtr += 4) {
+      for (let i = 0; i < dynamicOffsetCount; i++, dynamicOffsetsPtr += 4) {
         offsets.push({{{ gpu.makeGetU32('dynamicOffsetsPtr', 0) }}});
       }
       pass["setBindGroup"](groupIndex, group, offsets);
@@ -2213,7 +2213,7 @@ var LibraryWebGPU = {
       pass["setBindGroup"](groupIndex, group);
     } else {
       var offsets = [];
-      for (var i = 0; i < dynamicOffsetCount; i++, dynamicOffsetsPtr += 4) {
+      for (let i = 0; i < dynamicOffsetCount; i++, dynamicOffsetsPtr += 4) {
         offsets.push({{{ gpu.makeGetU32('dynamicOffsetsPtr', 0) }}});
       }
       pass["setBindGroup"](groupIndex, group, offsets);

--- a/src/library_websocket.js
+++ b/src/library_websocket.js
@@ -263,9 +263,9 @@ var LibraryWebSocket = {
         HEAP8.set(new Uint8Array(e.data), buf);
 #if WEBSOCKET_DEBUG
         var s = 'WebSocket onmessage, received data: ' + len + ' bytes of binary:';
-        for (var i = 0; i < Math.min(len, 256); ++i) s += ' ' + HEAPU8[buf+i].toString(16);
+        for (let i = 0; i < Math.min(len, 256); ++i) s += ' ' + HEAPU8[buf+i].toString(16);
         s += ', "';
-        for (var i = 0; i < Math.min(len, 256); ++i) s += (HEAPU8[buf+i] >= 32 && HEAPU8[buf+i] <= 127) ? String.fromCharCode(HEAPU8[buf+i]) : '\uFFFD';
+        for (let i = 0; i < Math.min(len, 256); ++i) s += (HEAPU8[buf+i] >= 32 && HEAPU8[buf+i] <= 127) ? String.fromCharCode(HEAPU8[buf+i]) : '\uFFFD';
         s += '"';
         if (len > 256) s + ' ... (' + (len - 256) + ' more bytes)';
 
@@ -355,9 +355,9 @@ var LibraryWebSocket = {
 
 #if WEBSOCKET_DEBUG
     var s = 'data: ' + dataLength + ' bytes of binary:';
-    for (var i = 0; i < Math.min(dataLength, 256); ++i) s += ' '+ HEAPU8[binaryData+i].toString(16);
+    for (let i = 0; i < Math.min(dataLength, 256); ++i) s += ' '+ HEAPU8[binaryData+i].toString(16);
     s += ', "';
-    for (var i = 0; i < Math.min(dataLength, 256); ++i) s += (HEAPU8[binaryData+i] >= 32 && HEAPU8[binaryData+i] <= 127) ? String.fromCharCode(HEAPU8[binaryData+i]) : '\uFFFD';
+    for (let i = 0; i < Math.min(dataLength, 256); ++i) s += (HEAPU8[binaryData+i] >= 32 && HEAPU8[binaryData+i] <= 127) ? String.fromCharCode(HEAPU8[binaryData+i]) : '\uFFFD';
     s += '"';
     if (dataLength > 256) s + ' ... (' + (dataLength - 256) + ' more bytes)';
 

--- a/src/library_workerfs.js
+++ b/src/library_workerfs.js
@@ -19,7 +19,7 @@ mergeInto(LibraryManager.library, {
         // return the parent node, creating subdirs as necessary
         var parts = path.split('/');
         var parent = root;
-        for (var i = 0; i < parts.length-1; i++) {
+        for (let i = 0; i < parts.length-1; i++) {
           var curr = parts.slice(0, i+1).join('/');
           // Issue 4254: Using curr as a node name will prevent the node
           // from being found in FS.nameTable when FS.open is called on

--- a/src/memoryprofiler.js
+++ b/src/memoryprofiler.js
@@ -374,7 +374,7 @@ var emscriptenMemoryProfiler = {
 
     for (var i in AL.currentContext.buf) {
       var buffer = AL.currentContext.buf[i];
-      for (var channel = 0; channel < buffer.numberOfChannels; ++channel) totalMemory += buffer.getChannelData(channel).length * 4;
+      for (let channel = 0; channel < buffer.numberOfChannels; ++channel) totalMemory += buffer.getChannelData(channel).length * 4;
     }
     return totalMemory;
   },
@@ -437,7 +437,7 @@ var emscriptenMemoryProfiler = {
   printHeapResizeLog: function(heapResizes) {
     var demangler = typeof demangleAll != 'undefined' ? demangleAll : function(x) { return x; };
     var html = '';
-    for (var i = 0; i < heapResizes.length; ++i) {
+    for (let i = 0; i < heapResizes.length; ++i) {
       var j = i+1;
       while(j < heapResizes.length) {
         if ((heapResizes[j].filteredStack || heapResizes[j].stack) == (heapResizes[i].filteredStack || heapResizes[i].stack)) {

--- a/src/polyfill/bigint64array.js
+++ b/src/polyfill/bigint64array.js
@@ -50,7 +50,7 @@ if (typeof globalThis.BigInt64Array === "undefined") {
             return createBigInt64Array(new_buf);
           },
           [Symbol.iterator]: function* () {
-            for (var i = 0; i < array.length / 2; i++) {
+            for (let i = 0; i < array.length / 2; i++) {
               yield partsToBigInt(array[2 * i], array[2 * i + 1]);
             }
           },
@@ -72,7 +72,7 @@ if (typeof globalThis.BigInt64Array === "undefined") {
               // Firefox: "invalid or out-of-range index"
               throw new RangeError("offset is out of bounds");
             }
-            for (var i = 0; i < source.length; i++) {
+            for (let i = 0; i < source.length; i++) {
               var value = source[i];
               var pair = bigIntToParts(value);
               array.set(pair, 2 * (targetOffset + i));

--- a/src/polyfill/objassign.js
+++ b/src/polyfill/objassign.js
@@ -22,7 +22,7 @@ if (typeof Object.assign == 'undefined') {
    * @suppress {visibility, duplicate, checkTypes}
    */
   Object.assign = function(target, source) {
-    for (var i = 1; i < arguments.length; i++) {
+    for (let i = 1; i < arguments.length; i++) {
       var source = arguments[i];
       if (!source) continue;
       for (var key in source) {

--- a/src/polyfill/promise.js
+++ b/src/polyfill/promise.js
@@ -128,7 +128,7 @@ var Promise = (function() {
       });
     }
 
-    for (var i = 0, len = self._deferreds.length; i < len; i++) {
+    for (let i = 0, len = self._deferreds.length; i < len; i++) {
       handle(self, self._deferreds[i]);
     }
     self._deferreds = null;
@@ -217,7 +217,7 @@ var Promise = (function() {
         }
       }
 
-      for (var i = 0; i < args.length; i++) {
+      for (let i = 0; i < args.length; i++) {
         res(i, args[i]);
       }
     });
@@ -245,7 +245,7 @@ var Promise = (function() {
         return reject(new TypeError('Promise.race accepts an array'));
       }
 
-      for (var i = 0, len = arr.length; i < len; i++) {
+      for (let i = 0, len = arr.length; i < len; i++) {
         Promise.resolve(arr[i]).then(resolve, reject);
       }
     });

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -26,7 +26,7 @@ function runMemoryInitializer() {
     var applyMemoryInitializer = (data) => {
       if (data.byteLength) data = new Uint8Array(data);
 #if ASSERTIONS
-      for (var i = 0; i < data.length; i++) {
+      for (let i = 0; i < data.length; i++) {
         assert(HEAPU8[{{{ GLOBAL_BASE }}} + i] === 0, "area for memory initializer should not have been touched before it's loaded");
       }
 #endif

--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -71,7 +71,7 @@ function renderFrame() {
   if (dst.set) {
     dst.set(renderFrameData);
   } else {
-    for (var i = 0; i < renderFrameData.length; i++) {
+    for (let i = 0; i < renderFrameData.length; i++) {
       dst[i] = renderFrameData[i];
     }
   }

--- a/src/source_map_support.js
+++ b/src/source_map_support.js
@@ -24,7 +24,7 @@ function WasmSourceMap(sourceMap) {
     var shift = 0;
     var value = 0;
 
-    for (var i = 0; i < string.length; ++i) {
+    for (let i = 0; i < string.length; ++i) {
       var integer = vlqMap[string[i]];
       if (integer === undefined) {
         throw new Error('Invalid character (' + string[i] + ')');

--- a/src/threadprofiler.js
+++ b/src/threadprofiler.js
@@ -37,7 +37,7 @@ var emscriptenThreadProfiler = {
     for (var i in PThread.pthreads) {
       threads.push(PThread.pthreads[i].threadInfoStruct);
     }
-    for (var i = 0; i < threads.length; ++i) {
+    for (let i = 0; i < threads.length; ++i) {
       var threadPtr = threads[i];
       var profilerBlock = Atomics.load(HEAPU32, (threadPtr + 8 /* {{{ C_STRUCTS.pthread.profilerBlock }}}*/) >> 2);
       var threadName = PThread.getThreadName(threadPtr);
@@ -65,7 +65,7 @@ var emscriptenThreadProfiler = {
       threads.push(PThread.pthreads[i].threadInfoStruct);
     }
 
-    for (var i = 0; i < threads.length; ++i) {
+    for (let i = 0; i < threads.length; ++i) {
       var threadPtr = threads[i];
       var profilerBlock = Atomics.load(HEAPU32, (threadPtr + 8 /* {{{ C_STRUCTS.pthread.profilerBlock }}}*/) >> 2);
       var threadName = PThread.getThreadName(threadPtr);
@@ -79,7 +79,7 @@ var emscriptenThreadProfiler = {
 
       var threadTimesInStatus = [];
       var totalTime = 0;
-      for (var j = 0; j < 7/*EM_THREAD_STATUS_NUMFIELDS*/; ++j) {
+      for (let j = 0; j < 7/*EM_THREAD_STATUS_NUMFIELDS*/; ++j) {
         threadTimesInStatus.push(HEAPF64[((profilerBlock + 16/*C_STRUCTS.thread_profiler_block.timeSpentInStatus*/) >> 3) + j]);
         totalTime += threadTimesInStatus[j];
         HEAPF64[((profilerBlock + 16/*C_STRUCTS.thread_profiler_block.timeSpentInStatus*/) >> 3) + j] = 0;

--- a/src/wasm_offset_converter.js
+++ b/src/wasm_offset_converter.js
@@ -117,7 +117,7 @@ function WasmOffsetConverter(wasmBytes, wasmModule) {
   }
 
   var sections = WebAssembly.Module.customSections(wasmModule, "name");
-  for (var i = 0; i < sections.length; ++i) {
+  for (let i = 0; i < sections.length; ++i) {
     buffer = new Uint8Array(sections[i]);
     if (buffer[0] != 1) // not a function name section
       continue;

--- a/src/webGLClient.js
+++ b/src/webGLClient.js
@@ -294,7 +294,7 @@ function WebGLClient() {
   function renderAllCommands() {
     // we can skip parts of the frames before the last, as we just need their side effects
     skippable = true;
-    for (var i = 0; i < commandBuffers.length-1; i++) {
+    for (let i = 0; i < commandBuffers.length-1; i++) {
       renderCommands(commandBuffers[i]);
     }
     skippable = false;


### PR DESCRIPTION
I've started with just the loop variables in `for` loops, and for now
I'm still avoiding `const` simply because it take 2 extra characters.

This gets transpiled down to var when targeting ES5 and we already
have a test for that in the form of other.test_es5_transpile.

See #11984