### PR TITLE
Fix build failures when any parent directory is {"type": "module"}

### DIFF
--- a/commonjs-loader.mjs
+++ b/commonjs-loader.mjs
@@ -1,0 +1,1 @@
+export async function getFormat() { return { format: "commonjs" } }

--- a/emcc.py
+++ b/emcc.py
@@ -620,6 +620,12 @@ def make_js_executable(script):
   cmd = config.JS_ENGINE
   if settings.WASM_BIGINT:
     cmd.append('--experimental-wasm-bigint')
+
+  # Force commonjs mode. This prevents build failures when any parent
+  # directory happen to contain package.json with {"type": "module"}.
+  # See https://github.com/emscripten-core/emscripten/issues/17431
+  cmd.extend(['--experimental-loader', os.path.join(os.path.dirname(__file__), 'commonjs-loader.mjs')])
+
   cmd = shared.shlex_join(cmd)
   if not os.path.isabs(config.JS_ENGINE[0]):
     # TODO: use whereis etc. And how about non-*NIX?


### PR DESCRIPTION
This fixes hard-to-debug failures when any parent directory has `package.json` with `{"type": "module"}` in it.

Before this fix `emconfigure` / `conftest` would fail with the error in `config.log`:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ""
```

The fix forces common.js mode for generated Node scripts.

fixes #13551
fixes #17431