### PR TITLE
Fix closer error in wasm2s.core2s.test_dylink_syslibs_missing_assertions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,6 +400,7 @@ jobs:
             corez.test_dylink_iostream
             core2ss.test_pthread_dylink
             core2ss.test_pthread_thread_local_storage
+            core2s.test_dylink_syslibs_missing_assertions
             wasm2js3.test_memorygrowth_2
             other.test_unistd_fstatfs_wasmfs
             wasmfs.test_hello_world

--- a/src/library_eventloop.js
+++ b/src/library_eventloop.js
@@ -44,7 +44,8 @@ LibraryJSEventLoop = {
       'var __setImmediate_id_counter = 0;\n' +
       'var __setImmediate_queue = [];\n' +
       'var __setImmediate_message_id = "_si";\n' +
-      'var __setImmediate_cb = (/** @type {Event} */e) => {\n' +
+      '/** @param {Event} e */\n' +
+      'var __setImmediate_cb = (e) => {\n' +
         'if (e.data === __setImmediate_message_id) {\n' +
           'e.stopPropagation();\n' +
           '__setImmediate_queue.shift()();\n' +


### PR DESCRIPTION
This was broken by #17446 but we don't run wasm2s are part of our github
CI.