### PR TITLE
Convert all sdl tests to btest_exit. NFC

### DIFF
--- a/tests/sdl2_audio_beep.cpp
+++ b/tests/sdl2_audio_beep.cpp
@@ -177,9 +177,6 @@ void nextTest(void *unused = 0) {
         printf("All tests done. Quit.\n");
 #ifdef __EMSCRIPTEN__
         emscripten_cancel_main_loop();
-#ifdef REPORT_RESULT
-        REPORT_RESULT(1);
-#endif
 #endif
         return;
       }
@@ -236,7 +233,10 @@ int main(int argc, char** argv) {
   SDL_Init(SDL_INIT_AUDIO);
 
   nextTest();
-   
+
+  if (!beep)
+    return 1;
+
 #ifdef __EMSCRIPTEN__
   emscripten_set_main_loop(update, 60, 0);
 #else

--- a/tests/sdl2_canvas_size.c
+++ b/tests/sdl2_canvas_size.c
@@ -52,7 +52,6 @@ int main(int argc, char *argv[])
 
     SDL_DestroyWindow(window);
     SDL_Quit();
-    REPORT_RESULT(1);
 
     return 0;
 }

--- a/tests/sdl2_canvas_write.cpp
+++ b/tests/sdl2_canvas_write.cpp
@@ -3,6 +3,7 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
+#include <assert.h>
 #include <SDL.h>
 #include <emscripten.h>
 
@@ -32,7 +33,7 @@ void draw(SDL_Window *window, SDL_Surface *surface) {
         sdlError("SDL_UpdateWindowSurface");
 }
 
-int verify(void) {
+void verify(void) {
     int res = EM_ASM_INT({
         var ctx = Module['canvas'].getContext('2d');
         var data = ctx.getImageData(0, 0, 256, 256).data;
@@ -52,7 +53,7 @@ int verify(void) {
     });
 
     printf("%s\n", res ? "FAIL" : "PASS");
-    return res;
+    assert(res == 0);
 }
 
 int main(void) {
@@ -71,7 +72,6 @@ int main(void) {
 
     draw(window, surface);
 
-    int result = verify();
-    REPORT_RESULT(result);
+    verify();
+    return 0;
 }
-

--- a/tests/sdl2_custom_cursor.c
+++ b/tests/sdl2_custom_cursor.c
@@ -50,7 +50,6 @@ int main(int argc, char *argv[])
 
     SDL_DestroyWindow(window);
     SDL_Quit();
-    REPORT_RESULT(1);
 
     return 0;
 }

--- a/tests/sdl2_gl_read.c
+++ b/tests/sdl2_gl_read.c
@@ -141,8 +141,8 @@ void Verify() {
     ok = ok && (data[x*4+0] == 0);
     ok = ok && (data[x*4+1] == 0);
   }
-  int result = seen && ok;
-  REPORT_RESULT(result);
+  assert(seen);
+  assert(ok);
 }
 
 int main(int argc, char *argv[])

--- a/tests/sdl2_image.c
+++ b/tests/sdl2_image.c
@@ -63,7 +63,7 @@ int main() {
 
   int result = 0;
 
-  result |= testImage(renderer, SCREENSHOT_DIRNAME "/" SCREENSHOT_BASENAME); // absolute path
+  result = testImage(renderer, SCREENSHOT_DIRNAME "/" SCREENSHOT_BASENAME); // absolute path
   assert(result != 0);
 
   chdir(SCREENSHOT_DIRNAME);
@@ -76,8 +76,6 @@ int main() {
 
   SDL_Quit();
 
-  REPORT_RESULT(result);
-
-  return 0;
+  return result;
 }
 

--- a/tests/sdl2_key.c
+++ b/tests/sdl2_key.c
@@ -13,7 +13,7 @@ int result = 1;
 
 int EventHandler(void *userdata, SDL_Event *event) {
   int mod;
-  
+
   switch(event->type) {
     case SDL_KEYUP:
       break;
@@ -29,9 +29,8 @@ int EventHandler(void *userdata, SDL_Event *event) {
             printf("b scancode\n"); result *= 23; break;
           }
           printf("unknown key: sym %d scancode %d\n", event->key.keysym.sym, event->key.keysym.scancode);
-          REPORT_RESULT(result);
-          emscripten_run_script("throw 'done'"); // comment this out to leave event handling active. Use the following to log DOM keys:
-                                                 // addEventListener('keyup', function(event) { console.log(event->keyCode) }, true)
+          emscripten_force_exit(result); // comment this out to leave event handling active. Use the following to log DOM keys:
+                                         // addEventListener('keyup', function(event) { console.log(event->keyCode) }, true)
         }
       }
       break;
@@ -78,6 +77,7 @@ int main(int argc, char **argv) {
   emscripten_run_script("keydown(66);keyup(66);"); // b
   emscripten_run_script("keydown(100);keyup(100);"); // trigger the end
 
-  return 0;
+  emscripten_exit_with_live_runtime();
+  return 99;
 }
 

--- a/tests/sdl2_misc.c
+++ b/tests/sdl2_misc.c
@@ -13,8 +13,6 @@
 
 #include <emscripten.h>
 
-#include "report_result.h"
-
 int main(int argc, char *argv[])
 {
     SDL_Window *window;

--- a/tests/sdl2_mixer_music.c
+++ b/tests/sdl2_mixer_music.c
@@ -14,9 +14,7 @@ void main2()
 	emscripten_cancel_main_loop();
 	Mix_FreeMusic(music);
 	Mix_CloseAudio();
-#ifdef REPORT_RESULT
-	REPORT_RESULT(1);
-#endif
+	emscripten_force_exit(0);
 }
 
 int main(int argc, char* argv[])

--- a/tests/sdl2_mouse.c
+++ b/tests/sdl2_mouse.c
@@ -10,7 +10,6 @@
 #include <assert.h>
 #include <emscripten.h>
 
-int result = 1;
 int mouse_motions = 0;
 
 #define abs(x) ((x) < 0 ? -(x) : (x))
@@ -45,8 +44,7 @@ void one() {
       case SDL_MOUSEBUTTONDOWN: {
         SDL_MouseButtonEvent *m = (SDL_MouseButtonEvent*)&event;
         if (m->button == 2) {
-          REPORT_RESULT(result);
-          emscripten_run_script("throw 'done'");
+          emscripten_force_exit(0);
         }
         printf("button down : %d,%d  %d,%d\n", m->button, m->state, m->x, m->y);
 #ifdef TEST_SDL_MOUSE_OFFSETS
@@ -88,7 +86,7 @@ int main() {
 
   emscripten_async_call(main_2, NULL, 3000); // avoid startup delays and intermittent errors
 
-  return 0;
+  return 99;
 }
 
 void main_2(void* arg) {

--- a/tests/sdl2_pumpevents.c
+++ b/tests/sdl2_pumpevents.c
@@ -5,6 +5,7 @@
  * found in the LICENSE file.
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <SDL2/SDL.h>
@@ -14,56 +15,39 @@
 // SDL_GetKeyState instead
 #define SDL_GetKeyState SDL_GetKeyboardState
 
-int result = 0;
-
-int loop1()
-{
+void loop1() {
   printf("loop1\n");
   unsigned i;
-  int r = 0;
 
   // method 1: SDL_PollEvent loop
   SDL_Event e;
   while (SDL_PollEvent(&e));
 
   const Uint8 *keys = SDL_GetKeyState(NULL);
-  if (keys[SDL_SCANCODE_LEFT])
-    r = 1;
-
-  return r;
+  assert(keys[SDL_SCANCODE_LEFT]);
 }
 
-int loop2()
-{
+void loop2() {
   printf("loop2\n");
-  
+
   unsigned i;
-  int r = 0;
-   
+
   // method 2: SDL_PumpEvents
   SDL_PumpEvents();
 
   const Uint8 *keys = SDL_GetKeyState(NULL);
-  if (keys[SDL_SCANCODE_RIGHT])
-    r = 2;
-
-  return r;
+  assert(keys[SDL_SCANCODE_RIGHT]);
 }
 
-int alphakey()
-{
+void alphakey() {
   printf("alpha\n");
-  
+
   unsigned i;
-  int r = 0;
 
   SDL_PumpEvents();
 
   const Uint8 *keys = SDL_GetKeyState(NULL);
-  if (keys[SDL_SCANCODE_A])
-    r = 4;
-
-  return r;
+  assert(keys[SDL_SCANCODE_A]);
 }
 
 int main(int argc, char *argv[])
@@ -71,13 +55,12 @@ int main(int argc, char *argv[])
   SDL_Init(SDL_INIT_VIDEO);
   SDL_Window *window;
   SDL_CreateWindow("window", 0, 0, 600, 450, 0);
-    
+
   emscripten_run_script("keydown(37);"); // left
-  result += loop1();
+  loop1();
   emscripten_run_script("keydown(39);"); // right
-  result += loop2();
+  loop2();
   emscripten_run_script("keydown(65);"); // A
-  result += alphakey();
-  REPORT_RESULT(result);
+  alphakey();
   return 0;
 }

--- a/tests/sdl2_swsurface.c
+++ b/tests/sdl2_swsurface.c
@@ -25,10 +25,6 @@ int main(int argc, char** argv) {
 
   SDL_Quit();
 
-#ifdef __EMSCRIPTEN__
-  REPORT_RESULT(1);
-#endif
-
   return 0;
 }
 

--- a/tests/sdl2_text.c
+++ b/tests/sdl2_text.c
@@ -23,8 +23,8 @@ void one() {
         if (!strcmp("a", event.text.text)) {
           result = 1;
         } else if (!strcmp("A", event.text.text)) {
-          REPORT_RESULT(result);
-          emscripten_run_script("throw 'done'");
+          assert(result);
+          emscripten_force_exit(0);
         }
         break;
     }

--- a/tests/sdl2_threads.c
+++ b/tests/sdl2_threads.c
@@ -16,15 +16,9 @@ int main()
 	int result;
 
 	thread = SDL_CreateThread(test_thread, "Test Thread", (void *)NULL);
+	assert(thread);
 
-	if (NULL == thread) {
-		return 1;
-	} else {
-		SDL_WaitThread(thread, &result);
-	}
-
-#ifdef REPORT_RESULT
-	REPORT_RESULT(result);
-#endif
+	SDL_WaitThread(thread, &result);
+	assert(result == 4);
 	return 0;
 }

--- a/tests/sdl2_timer.c
+++ b/tests/sdl2_timer.c
@@ -16,9 +16,8 @@ Uint32 SDLCALL report_result(Uint32 interval, void *param) {
   reported = 1;
   SDL_Quit();
   int result = *(int *)param;
-  printf("%p %d\n", param, result);
-  REPORT_RESULT(result);
-  return 0;
+  printf("report_result: %p %d\n", param, result);
+  emscripten_force_exit(0);
 }
 
 void nop(void) {}
@@ -29,11 +28,8 @@ int main(int argc, char** argv) {
   Uint32 ticks1 = SDL_GetTicks();
   SDL_Delay(5); // busy-wait
   Uint32 ticks2 = SDL_GetTicks();
-  if (ticks2 < ticks1 + 4) {
-    printf("not enough ticks from busy-wait\n");
-    REPORT_RESULT(9);
-    return 0;
-  }
+  // not enough ticks from busy-wait
+  assert(ticks2 >= ticks1 + 4);
 
   int badret = 4;
   int goodret = 5;
@@ -43,6 +39,5 @@ int main(int argc, char** argv) {
   SDL_RemoveTimer(badtimer);
 
   emscripten_set_main_loop(nop, 0, 0);
-
-  return 0;
+  return 99;
 }

--- a/tests/sdl2_unwasteful.cpp
+++ b/tests/sdl2_unwasteful.cpp
@@ -47,8 +47,7 @@ static void main_loop(void)
 
     runs++;
     if (runs >= TOTAL_RUNS) {
-        emscripten_cancel_main_loop();
-        REPORT_RESULT(1);
+        emscripten_force_exit(0);
     }
 }
 
@@ -66,4 +65,3 @@ int main(void)
 
     emscripten_set_main_loop(main_loop, 0, 1);
 }
-

--- a/tests/sdl_alloctext.c
+++ b/tests/sdl_alloctext.c
@@ -30,8 +30,5 @@ int main()
         SDL_FreeSurface(text);
     }
 
-#ifdef __EMSCRIPTEN__
-    REPORT_RESULT(1);
-#endif
+    return 0;
 }
-

--- a/tests/sdl_audio_beep.cpp
+++ b/tests/sdl_audio_beep.cpp
@@ -183,10 +183,7 @@ void nextTest(void *unused = 0) {
       if (s >= NUM_ELEMS(sdlAudioFormats)) {
         printf("All tests done. Quit.\n");
 #ifdef __EMSCRIPTEN__
-        emscripten_cancel_main_loop();
-#ifdef REPORT_RESULT
-        REPORT_RESULT(1);
-#endif
+        emscripten_force_exit(0);
 #endif
         return;
       }
@@ -247,7 +244,7 @@ int main(int argc, char** argv) {
   SDL_Init(SDL_INIT_AUDIO);
 
   nextTest();
-   
+
 #ifdef __EMSCRIPTEN__
   emscripten_set_main_loop(update, 60, 0);
 #else

--- a/tests/sdl_audio_beep_sleep.cpp
+++ b/tests/sdl_audio_beep_sleep.cpp
@@ -180,10 +180,7 @@ void nextTest(void *unused = 0) {
       if (s >= NUM_ELEMS(sdlAudioFormats)) {
         printf("All tests done. Quit.\n");
 #ifdef __EMSCRIPTEN__
-        emscripten_cancel_main_loop();
-#ifdef REPORT_RESULT
-        REPORT_RESULT(1);
-#endif
+        emscripten_force_exit(0);
 #endif
         return;
       }
@@ -241,7 +238,7 @@ int main(int argc, char** argv) {
   SDL_Init(SDL_INIT_AUDIO);
 
   nextTest();
-   
+
 #ifdef __EMSCRIPTEN__
   emscripten_set_main_loop(update, 60, 0);
 #else

--- a/tests/sdl_audio_mix.c
+++ b/tests/sdl_audio_mix.c
@@ -18,11 +18,10 @@ static Mix_Music *music = NULL;
 static int soundChannel = 0;
 static int noiseLoopChannel = 0;
 
-void one_iter();
 void one_iter() {
   static int frames = 0;
   frames++;
-  
+
   switch( frames ) {
     case 1:
       soundChannel = Mix_PlayChannel(-1, sound, 0);
@@ -64,9 +63,7 @@ void one_iter() {
     case 120:
       Mix_HaltChannel(soundChannel);
       Mix_HaltMusic();
-#ifdef REPORT_RESULT
-      REPORT_RESULT(1);
-#endif
+      emscripten_force_exit(0);
       break;
   };
 }
@@ -75,12 +72,12 @@ void one_iter() {
 int main(int argc, char **argv) {
   SDL_Init(SDL_INIT_AUDIO);
   Mix_Init(MIX_INIT_OGG);
-  
+
   // This reserves channel 0 for other purposes.
   // We are just going to verify that we are not
   // allocated channel 0 when we call Mix_PlayChannel(-1, ...)
   Mix_ReserveChannels(1);
-  
+
   int ret = Mix_OpenAudio(0, 0, 0, 0); // we ignore all these..
   assert(ret == 0);
 
@@ -98,6 +95,6 @@ int main(int argc, char **argv) {
     Mix_Quit();
   Mix_CloseAudio();
 
-  return 0;
+  return 99;
 }
 

--- a/tests/sdl_audio_mix_channels.c
+++ b/tests/sdl_audio_mix_channels.c
@@ -20,8 +20,7 @@ static int noiseLoopChannel = 0;
 
 static const int kNumChannels = 40;
 
-static int loadAndPlay()
-{
+static int loadAndPlay() {
   return Mix_PlayChannel(-1, sound, -1);
 }
 
@@ -37,23 +36,12 @@ int main(int argc, char **argv) {
   sound = Mix_LoadWAV("sound.ogg");
 
   // allocate all the channels
-  for ( int i = 0; i < kNumChannels; i++ )
-  {
+  for (int i = 0; i < kNumChannels; i++) {
     assert(loadAndPlay() != -1);
   }
 
-    // This point, we should have exhausted our channels
-
-
-
-
+  // This point, we should have exhausted our channels
   int lastChannel = loadAndPlay();
-
-#ifdef __EMSCRIPTEN__
-  int result = (lastChannel == -1);
-  REPORT_RESULT(result);
-#endif
-
   assert(lastChannel == -1);
 
   // force a quit

--- a/tests/sdl_audio_panning.c
+++ b/tests/sdl_audio_panning.c
@@ -17,7 +17,7 @@
 Mix_Chunk *sound;
 
 void done() {
-  REPORT_RESULT(1);
+  emscripten_force_exit(0);
 }
 
 void pan() {
@@ -85,5 +85,5 @@ int main(int argc, char **argv) {
 
   printf("you should hear the sound moving from left to right. press the button to replay!\n");
 
-  return 0;
+  return 99;
 }

--- a/tests/sdl_gl_mapbuffers.c
+++ b/tests/sdl_gl_mapbuffers.c
@@ -24,7 +24,7 @@ GLuint LoadShader ( GLenum type, const char *shaderSrc )
 {
    GLuint shader;
    GLint compiled;
-   
+
    shader = glCreateShader ( type );
    if ( shader == 0 )
    	return 0;
@@ -32,7 +32,7 @@ GLuint LoadShader ( GLenum type, const char *shaderSrc )
    glShaderSource ( shader, 1, &shaderSrc, NULL );
    glCompileShader ( shader );
    glGetShaderiv ( shader, GL_COMPILE_STATUS, &compiled );
-   if ( !compiled ) 
+   if ( !compiled )
    {
       GLint infoLen = 0;
       glGetShaderiv ( shader, GL_INFO_LOG_LENGTH, &infoLen );
@@ -40,7 +40,7 @@ GLuint LoadShader ( GLenum type, const char *shaderSrc )
       {
          char* infoLog = malloc (sizeof(char) * infoLen );
          glGetShaderInfoLog ( shader, infoLen, NULL, infoLog );
-         printf ( "Error compiling shader:\n%s\n", infoLog );            
+         printf ( "Error compiling shader:\n%s\n", infoLog );
          free ( infoLog );
       }
       glDeleteShader ( shader );
@@ -51,14 +51,14 @@ GLuint LoadShader ( GLenum type, const char *shaderSrc )
 
 int Init ()
 {
-   GLbyte vShaderStr[] =  
+   GLbyte vShaderStr[] =
       "attribute vec4 vPosition;    \n"
       "void main()                  \n"
       "{                            \n"
       "   gl_Position = vPosition;  \n"
       "}                            \n";
-   
-   GLbyte fShaderStr[] =  
+
+   GLbyte fShaderStr[] =
       "precision mediump float;\n"\
       "void main()                                  \n"
       "{                                            \n"
@@ -81,7 +81,7 @@ int Init ()
    glBindAttribLocation ( programObject, 0, "vPosition" );
    glLinkProgram ( programObject );
    glGetProgramiv ( programObject, GL_LINK_STATUS, &linked );
-   if ( !linked ) 
+   if ( !linked )
    {
       GLint infoLen = 0;
       glGetProgramiv ( programObject, GL_INFO_LOG_LENGTH, &infoLen );
@@ -89,7 +89,7 @@ int Init ()
       {
          char* infoLog = malloc (sizeof(char) * infoLen );
          glGetProgramInfoLog ( programObject, infoLen, NULL, infoLog );
-         printf ( "Error linking program:\n%s\n", infoLog );            
+         printf ( "Error linking program:\n%s\n", infoLog );
          free ( infoLog );
       }
       glDeleteProgram ( programObject );
@@ -106,7 +106,7 @@ int Init ()
 void Draw ()
 {
    void *buffer;
-   GLfloat vVertices[] = {  0.0f,  0.5f, 0.0f, 
+   GLfloat vVertices[] = {  0.0f,  0.5f, 0.0f,
                            -0.5f, -0.5f, 0.0f,
                             0.5f, -0.5f, 0.0f };
 
@@ -128,7 +128,7 @@ void Draw ()
    memcpy(buffer, vVertices, sizeof(vVertices));
    glFlushMappedBufferRange(GL_ARRAY_BUFFER, 0, sizeof(vVertices));
    glUnmapBuffer(GL_ARRAY_BUFFER);
-   
+
    glViewport ( 0, 0, width, height );
    glClear ( GL_COLOR_BUFFER_BIT );
    glUseProgram ( programObject );
@@ -157,8 +157,8 @@ void Verify() {
     ok = ok && (data[x*4+0] == 0);
     ok = ok && (data[x*4+1] == 0);
   }
-  int result = seen && ok;
-  REPORT_RESULT(result);
+  assert(seen);
+  assert(ok);
 }
 
 int main(int argc, char *argv[])

--- a/tests/sdl_gl_read.c
+++ b/tests/sdl_gl_read.c
@@ -142,8 +142,8 @@ void Verify() {
     ok = ok && (data[x*4+0] == 0);
     ok = ok && (data[x*4+1] == 0);
   }
-  int result = seen && ok;
-  REPORT_RESULT(result);
+  assert(seen);
+  assert(ok);
 }
 
 int main(int argc, char *argv[])

--- a/tests/sdl_key_proxy.c
+++ b/tests/sdl_key_proxy.c
@@ -8,10 +8,11 @@
 #include <stdio.h>
 #include <SDL/SDL.h>
 #include <emscripten.h>
+#include <emscripten/eventloop.h>
 
 int result = 1;
 
-void one() {
+EMSCRIPTEN_KEEPALIVE void one() {
   SDL_Event event;
   while (SDL_PollEvent(&event)) {
     printf("got event %d\n", event.type);
@@ -45,8 +46,7 @@ void one() {
               printf("b scancode\n"); result *= 23; break;
             }
             printf("unknown key: sym %d scancode %d\n", event.key.keysym.sym, event.key.keysym.scancode);
-            REPORT_RESULT(result);
-            emscripten_run_script("throw 'done'"); // comment this out to leave event handling active. Use the following to log DOM keys:
+            emscripten_force_exit(result); // comment this out to leave event handling active. Use the following to log DOM keys:
                                                    // addEventListener('keyup', function(event) { console.log(event.keyCode) }, true)
           }
         }
@@ -61,9 +61,7 @@ int main(int argc, char **argv) {
   printf("main\n");
   SDL_Init(SDL_INIT_VIDEO);
   SDL_Surface *screen = SDL_SetVideoMode(600, 450, 32, SDL_HWSURFACE);
-
-  if (argc == 1337) one(); // keep it alive
-
+  emscripten_runtime_keepalive_push();
   return 0;
 }
 

--- a/tests/sdl_mouse.c
+++ b/tests/sdl_mouse.c
@@ -10,8 +10,6 @@
 #include <assert.h>
 #include <emscripten.h>
 
-int result = 1;
-
 #define abs(x) ((x) < 0 ? -(x) : (x))
 void one() {
   SDL_Event event;
@@ -36,8 +34,7 @@ void one() {
       case SDL_MOUSEBUTTONDOWN: {
         SDL_MouseButtonEvent *m = (SDL_MouseButtonEvent*)&event;
         if (m->button == 2) {
-          REPORT_RESULT(result);
-          emscripten_run_script("throw 'done'");
+          emscripten_force_exit(0);
         }
         printf("button down: %d,%d  %d,%d\n", m->button, m->state, m->x, m->y);
 #ifdef TEST_SDL_MOUSE_OFFSETS
@@ -75,7 +72,7 @@ int main() {
 
   emscripten_async_call(main_2, NULL, 3000); // avoid startup delays and intermittent errors
 
-  return 0;
+  return 99;
 }
 
 void main_2(void* arg) {

--- a/tests/sdl_resize.c
+++ b/tests/sdl_resize.c
@@ -30,7 +30,7 @@ void loop() {
           case 1:
             assert(r->w == 123);
             assert(r->h == 246);
-            REPORT_RESULT(1);
+            emscripten_force_exit(0);
             break;
         }
       }

--- a/tests/sdl_surface_refcount.c
+++ b/tests/sdl_surface_refcount.c
@@ -6,6 +6,7 @@
  */
 
 #include <emscripten.h>
+#include <assert.h>
 #include <SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -30,6 +31,6 @@ int main(int argc, char *argv[])
     SDL_FreeSurface(surface);
     SDL_FreeSurface(reference);
     int result = is_surface_freed(surface);
-    REPORT_RESULT(result);
+    assert(result);
     return 0;
 }

--- a/tests/sdl_text.c
+++ b/tests/sdl_text.c
@@ -13,7 +13,7 @@
 
 int result = 0;
 
-void one() {
+EMSCRIPTEN_KEEPALIVE void one() {
   SDL_Event event;
   while (SDL_PollEvent(&event)) {
     switch (event.type) {
@@ -23,8 +23,8 @@ void one() {
         if (!strcmp("a", event.text.text)) {
           result = 1;
         } else if (!strcmp("A", event.text.text)) {
-          REPORT_RESULT(result);
-          emscripten_run_script("throw 'done'");
+          assert(result);
+          emscripten_force_exit(0);
         }
         break;
       default: /* Report an unhandled event */
@@ -40,8 +40,6 @@ int main() {
 
   emscripten_run_script("simulateKeyEvent('a'.charCodeAt(0))"); // a
   emscripten_run_script("simulateKeyEvent('A'.charCodeAt(0))"); // A
-
-  one();
-
-  return 0;
+                                                                //
+  emscripten_exit_with_live_runtime();
 }

--- a/tests/sdl_touch.c
+++ b/tests/sdl_touch.c
@@ -30,9 +30,7 @@ void progress() {
   else if (!got_up) printf("Release a finger to generate a touch up event.\n");
   else
   {
-#ifdef REPORT_RESULT
-    REPORT_RESULT(0);
-#endif
+    emscripten_force_exit(0);
   }
 }
 

--- a/tests/sdl_wm_togglefullscreen.c
+++ b/tests/sdl_wm_togglefullscreen.c
@@ -20,8 +20,6 @@ int inFullscreen = 0;
 
 int wasFullscreen = 0;
 
-int finished = 0;
-
 void render() {
   int width, height;
   emscripten_get_canvas_element_size("#canvas", &width, &height);
@@ -32,22 +30,16 @@ void render() {
 void mainloop() {
   render();
 
-  if (finished) return;
-
   SDL_Event event;
   int isInFullscreen = EM_ASM_INT(return !!(document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement || document.msFullscreenElement));
   if (isInFullscreen && !wasFullscreen) {
     printf("Successfully transitioned to fullscreen mode!\n");
     wasFullscreen = isInFullscreen;
   }
-  
+
   if (wasFullscreen && !isInFullscreen) {
     printf("Exited fullscreen. Test succeeded.\n");
-#ifdef REPORT_RESULT
-    REPORT_RESULT(1);
-#endif
-    wasFullscreen = isInFullscreen;
-    finished = 1;
+    emscripten_force_exit(0);
     return;
   }
 
@@ -64,11 +56,8 @@ void mainloop() {
           } else {
             printf("Exited fullscreen. Test failed, fullscreen transition did not happen!\n");
           }
-#ifdef REPORT_RESULT
-          REPORT_RESULT(result);
-#endif
-          finished = 1;
-          return;
+          assert(result);
+          emscripten_force_exit(result ? 0 : 1);
         } else {
           printf("Entering fullscreen...\n");
         }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -888,8 +888,7 @@ window.close = function() {
              %s
             }
           ''' % ('setTimeout(function() {' if delay else '', '}, 1);' if delay else '', 'setTimeout(function() {' if delay else '', '}, 1);' if delay else ''))
-          self.compile_btest([test_file('sdl_key.c'), '-o', 'page.html'] + defines + async_ + ['--pre-js', 'pre.js', '-sEXPORTED_FUNCTIONS=_main', '-lSDL', '-lGL', '-sEXIT_RUNTIME'])
-          self.run_browser('page.html', '', '/report_result?exit:223092870')
+          self.btest_exit(test_file('sdl_key.c'), 223092870, args=defines + async_ + ['--pre-js=pre.js', '-lSDL', '-lGL'])
 
   def test_sdl_key_proxy(self):
     create_file('pre.js', '''
@@ -929,7 +928,7 @@ keydown(100);keyup(100); // trigger the end
 </body>''')
       create_file('test.html', html)
 
-    self.btest('sdl_key_proxy.c', '223092870', args=['--proxy-to-worker', '--pre-js', 'pre.js', '-sEXPORTED_FUNCTIONS=_main,_one', '-lSDL', '-lGL'], post_build=post)
+    self.btest_exit('sdl_key_proxy.c', 223092870, args=['--proxy-to-worker', '--pre-js', 'pre.js', '-sEXPORTED_FUNCTIONS=_main,_one', '-lSDL', '-lGL'], post_build=post)
 
   def test_canvas_focus(self):
     self.btest_exit('canvas_focus.c')
@@ -997,8 +996,7 @@ keydown(100);keyup(100); // trigger the end
       }
     ''')
 
-    self.compile_btest([test_file('sdl_text.c'), '-o', 'page.html', '--pre-js', 'pre.js', '-sEXPORTED_FUNCTIONS=_main,_one', '-lSDL', '-lGL'])
-    self.run_browser('page.html', '', '/report_result?1')
+    self.btest_exit('sdl_text.c', args=['--pre-js', 'pre.js', '-lSDL', '-lGL'])
 
   def test_sdl_mouse(self):
     create_file('pre.js', '''
@@ -1029,8 +1027,7 @@ keydown(100);keyup(100); // trigger the end
       window['simulateMouseEvent'] = simulateMouseEvent;
     ''')
 
-    self.compile_btest([test_file('sdl_mouse.c'), '-O2', '--minify=0', '-o', 'page.html', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
-    self.run_browser('page.html', '', '/report_result?1')
+    self.btest_exit(test_file('sdl_mouse.c'), args=['-O2', '--minify=0', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
 
   def test_sdl_mouse_offsets(self):
     create_file('pre.js', '''
@@ -1106,8 +1103,8 @@ keydown(100);keyup(100); // trigger the end
       </html>
     ''')
 
-    self.compile_btest([test_file('sdl_mouse.c'), '-DTEST_SDL_MOUSE_OFFSETS', '-O2', '--minify=0', '-o', 'sdl_mouse.js', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
-    self.run_browser('page.html', '', '/report_result?1')
+    self.compile_btest([test_file('sdl_mouse.c'), '-DTEST_SDL_MOUSE_OFFSETS', '-O2', '--minify=0', '-o', 'sdl_mouse.js', '--pre-js', 'pre.js', '-lSDL', '-lGL', '-sEXIT_RUNTIME'])
+    self.run_browser('page.html', '', '/report_result?exit:0')
 
   def test_glut_touchevents(self):
     self.btest_exit('glut_touchevents.c', args=['-lglut'])
@@ -1500,13 +1497,12 @@ keydown(100);keyup(100); // trigger the end
   @requires_graphics_hardware
   def test_sdl_gl_read(self):
     # SDL, OpenGL, readPixels
-    self.compile_btest([test_file('sdl_gl_read.c'), '-o', 'something.html', '-lSDL', '-lGL'])
-    self.run_browser('something.html', '.', '/report_result?1')
+    self.btest_exit('sdl_gl_read.c', args=['-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_gl_mapbuffers(self):
-    self.btest('sdl_gl_mapbuffers.c', expected='1', args=['-sFULL_ES3=1', '-lSDL', '-lGL'],
-               message='You should see a blue triangle.')
+    self.btest_exit('sdl_gl_mapbuffers.c', args=['-sFULL_ES3=1', '-lSDL', '-lGL'],
+                    message='You should see a blue triangle.')
 
   @requires_graphics_hardware
   def test_sdl_ogl(self):
@@ -1932,7 +1928,7 @@ keydown(100);keyup(100); // trigger the end
   def test_sdl_resize(self):
     # FIXME(https://github.com/emscripten-core/emscripten/issues/12978)
     self.emcc_args.append('-Wno-deprecated-declarations')
-    self.btest('sdl_resize.c', '1', args=['-lSDL', '-lGL'])
+    self.btest_exit('sdl_resize.c', args=['-lSDL', '-lGL'])
 
   def test_glshaderinfo(self):
     self.btest('glshaderinfo.cpp', '1', args=['-lGL', '-lglut'])
@@ -2215,10 +2211,10 @@ void *getBindBuffer() {
     self.btest('sdl_ttf_render_text_solid.c', reference='sdl_ttf_render_text_solid.png', args=['-O2', '-sINITIAL_MEMORY=16MB', '-lSDL', '-lGL'])
 
   def test_sdl_alloctext(self):
-    self.btest('sdl_alloctext.c', expected='1', args=['-sINITIAL_MEMORY=16MB', '-lSDL', '-lGL'])
+    self.btest_exit('sdl_alloctext.c', args=['-sINITIAL_MEMORY=16MB', '-lSDL', '-lGL'])
 
   def test_sdl_surface_refcount(self):
-    self.btest('sdl_surface_refcount.c', args=['-lSDL'], expected='1')
+    self.btest_exit('sdl_surface_refcount.c', args=['-lSDL'])
 
   def test_sdl_free_screen(self):
     self.btest('sdl_free_screen.cpp', args=['-lSDL', '-lGL'], reference='htmltest.png')
@@ -2773,7 +2769,7 @@ Module["preRun"].push(function () {
   def test_sdl_touch(self):
     for opts in [[], ['-O2', '-g1', '--closure=1']]:
       print(opts)
-      self.btest(test_file('sdl_touch.c'), args=opts + ['-DAUTOMATE_SUCCESS=1', '-lSDL', '-lGL'], expected='0')
+      self.btest_exit('sdl_touch.c', args=opts + ['-DAUTOMATE_SUCCESS=1', '-lSDL', '-lGL'])
 
   def test_html5_mouse(self):
     for opts in [[], ['-O2', '-g1', '--closure=1']]:
@@ -2896,29 +2892,37 @@ Module["preRun"].push(function () {
     for mem in [0, 1]:
       for dest, dirname, basename in [('screenshot.jpg', '/', 'screenshot.jpg'),
                                       ('screenshot.jpg@/assets/screenshot.jpg', '/assets', 'screenshot.jpg')]:
-        self.compile_btest([
-          test_file('sdl2_image.c'), '-o', 'page.html', '-O2', '--memory-init-file', str(mem),
-          '--preload-file', dest, '-DSCREENSHOT_DIRNAME="' + dirname + '"', '-DSCREENSHOT_BASENAME="' + basename + '"', '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--use-preload-plugins'
+        self.btest_exit('sdl2_image.c', 600, args=[
+          '-O2', '--memory-init-file', str(mem),
+          '--preload-file', dest,
+          '-DSCREENSHOT_DIRNAME="' + dirname + '"',
+          '-DSCREENSHOT_BASENAME="' + basename + '"',
+          '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--use-preload-plugins'
         ])
-        self.run_browser('page.html', '', '/report_result?600')
 
   @requires_graphics_hardware
   def test_sdl2_image_jpeg(self):
     shutil.copyfile(test_file('screenshot.jpg'), 'screenshot.jpeg')
-    self.compile_btest([
-      test_file('sdl2_image.c'), '-o', 'page.html',
-      '--preload-file', 'screenshot.jpeg', '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.jpeg"', '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--use-preload-plugins'
+    self.btest_exit('sdl2_image.c', 600, args=[
+      '--preload-file', 'screenshot.jpeg',
+      '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.jpeg"',
+      '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--use-preload-plugins'
     ])
-    self.run_browser('page.html', '', '/report_result?600')
 
   @requires_graphics_hardware
   def test_sdl2_image_formats(self):
     shutil.copyfile(test_file('screenshot.png'), 'screenshot.png')
     shutil.copyfile(test_file('screenshot.jpg'), 'screenshot.jpg')
-    self.btest('sdl2_image.c', expected='512', args=['--preload-file', 'screenshot.png', '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.png"',
-                                                     '-DNO_PRELOADED', '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '-sSDL2_IMAGE_FORMATS=["png"]'])
-    self.btest('sdl2_image.c', expected='600', args=['--preload-file', 'screenshot.jpg', '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.jpg"',
-                                                     '-DBITSPERPIXEL=24', '-DNO_PRELOADED', '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '-sSDL2_IMAGE_FORMATS=["jpg"]'])
+    self.btest_exit('sdl2_image.c', 512, args=[
+      '--preload-file', 'screenshot.png',
+      '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.png"', '-DNO_PRELOADED',
+      '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '-sSDL2_IMAGE_FORMATS=["png"]'
+    ])
+    self.btest_exit('sdl2_image.c', 600, args=[
+      '--preload-file', 'screenshot.jpg',
+      '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.jpg"', '-DBITSPERPIXEL=24', '-DNO_PRELOADED',
+      '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '-sSDL2_IMAGE_FORMATS=["jpg"]'
+    ])
 
   def test_sdl2_key(self):
     create_file('pre.js', '''
@@ -2947,8 +2951,7 @@ Module["preRun"].push(function () {
       }
     ''')
 
-    self.compile_btest([test_file('sdl2_key.c'), '-o', 'page.html', '-sUSE_SDL=2', '--pre-js', 'pre.js', '-sEXPORTED_FUNCTIONS=_main,_one'])
-    self.run_browser('page.html', '', '/report_result?37182145')
+    self.btest_exit('sdl2_key.c', 37182145, args=['-sUSE_SDL=2', '--pre-js', 'pre.js', '-sEXPORTED_FUNCTIONS=_main,_one'])
 
   def test_sdl2_text(self):
     create_file('pre.js', '''
@@ -2966,8 +2969,7 @@ Module["preRun"].push(function () {
       }
     ''')
 
-    self.compile_btest([test_file('sdl2_text.c'), '-o', 'page.html', '--pre-js', 'pre.js', '-sEXPORTED_FUNCTIONS=_main,_one', '-sUSE_SDL=2'])
-    self.run_browser('page.html', '', '/report_result?1')
+    self.btest_exit(test_file('sdl2_text.c'), args=['--pre-js', 'pre.js', '-sEXPORTED_FUNCTIONS=_main,_one', '-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_mouse(self):
@@ -2999,8 +3001,7 @@ Module["preRun"].push(function () {
       window['simulateMouseEvent'] = simulateMouseEvent;
     ''')
 
-    self.compile_btest([test_file('sdl2_mouse.c'), '-O2', '--minify=0', '-o', 'page.html', '--pre-js', 'pre.js', '-sUSE_SDL=2'])
-    self.run_browser('page.html', '', '/report_result?1')
+    self.btest_exit(test_file('sdl2_mouse.c'), args=['-O2', '--minify=0', '-o', 'page.html', '--pre-js', 'pre.js', '-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_mouse_offsets(self):
@@ -3077,12 +3078,12 @@ Module["preRun"].push(function () {
       </html>
     ''')
 
-    self.compile_btest([test_file('sdl2_mouse.c'), '-DTEST_SDL_MOUSE_OFFSETS=1', '-O2', '--minify=0', '-o', 'sdl2_mouse.js', '--pre-js', 'pre.js', '-sUSE_SDL=2'])
-    self.run_browser('page.html', '', '/report_result?1')
+    self.compile_btest([test_file('sdl2_mouse.c'), '-DTEST_SDL_MOUSE_OFFSETS=1', '-O2', '--minify=0', '-o', 'sdl2_mouse.js', '--pre-js', 'pre.js', '-sUSE_SDL=2', '-sEXIT_RUNTIME'])
+    self.run_browser('page.html', '', '/report_result?exit:0')
 
   @requires_threads
   def test_sdl2_threads(self):
-      self.btest('sdl2_threads.c', expected='4', args=['-sUSE_PTHREADS', '-sUSE_SDL=2', '-sPROXY_TO_PTHREAD'])
+      self.btest_exit('sdl2_threads.c', args=['-sUSE_PTHREADS', '-sUSE_SDL=2', '-sPROXY_TO_PTHREAD'])
 
   @requires_graphics_hardware
   def test_sdl2glshader(self):
@@ -3124,7 +3125,7 @@ Module["preRun"].push(function () {
     self.btest('sdl2_canvas_palette_2.c', reference='sdl_canvas_palette_b.png', args=['-sUSE_SDL=2', '--pre-js', 'args-b.js'])
 
   def test_sdl2_swsurface(self):
-    self.btest('sdl2_swsurface.c', expected='1', args=['-sUSE_SDL=2', '-sINITIAL_MEMORY=64MB'])
+    self.btest_exit('sdl2_swsurface.c', args=['-sUSE_SDL=2', '-sINITIAL_MEMORY=64MB'])
 
   @requires_graphics_hardware
   def test_sdl2_image_prepare(self):
@@ -3172,19 +3173,18 @@ window.close = function() {
         document.dispatchEvent(event);
       }
     ''')
-    self.btest('sdl2_pumpevents.c', expected='7', args=['--pre-js', 'pre.js', '-sUSE_SDL=2'])
+    self.btest_exit('sdl2_pumpevents.c', args=['--pre-js', 'pre.js', '-sUSE_SDL=2'])
 
   def test_sdl2_timer(self):
-    self.btest('sdl2_timer.c', expected='5', args=['-sUSE_SDL=2'])
+    self.btest_exit('sdl2_timer.c', args=['-sUSE_SDL=2'])
 
   def test_sdl2_canvas_size(self):
-    self.btest('sdl2_canvas_size.c', expected='1', args=['-sUSE_SDL=2'])
+    self.btest_exit('sdl2_canvas_size.c', args=['-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_gl_read(self):
     # SDL, OpenGL, readPixels
-    self.compile_btest([test_file('sdl2_gl_read.c'), '-o', 'something.html', '-sUSE_SDL=2'])
-    self.run_browser('something.html', '.', '/report_result?1')
+    self.btest_exit(test_file('sdl2_gl_read.c'), args=['-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_glmatrixmode_texture(self):
@@ -3246,10 +3246,10 @@ window.close = function() {
                message='You should see an image with fog.')
 
   def test_sdl2_unwasteful(self):
-    self.btest('sdl2_unwasteful.cpp', expected='1', args=['-sUSE_SDL=2', '-O1'])
+    self.btest_exit('sdl2_unwasteful.cpp', args=['-sUSE_SDL=2', '-O1'])
 
   def test_sdl2_canvas_write(self):
-    self.btest('sdl2_canvas_write.cpp', expected='0', args=['-sUSE_SDL=2'])
+    self.btest_exit('sdl2_canvas_write.cpp', args=['-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_gl_frames_swap(self):
@@ -3277,7 +3277,7 @@ window.close = function() {
 
   def test_sdl2_custom_cursor(self):
     shutil.copyfile(test_file('cursor.bmp'), 'cursor.bmp')
-    self.btest('sdl2_custom_cursor.c', expected='1', args=['--preload-file', 'cursor.bmp', '-sUSE_SDL=2'])
+    self.btest_exit('sdl2_custom_cursor.c', args=['--preload-file', 'cursor.bmp', '-sUSE_SDL=2'])
 
   def test_sdl2_misc(self):
     self.btest_exit('sdl2_misc.c', args=['-sUSE_SDL=2'])
@@ -3310,7 +3310,7 @@ window.close = function() {
   @requires_sound_hardware
   def test_sdl2_mixer_music(self, formats, flags, music_name):
     shutil.copyfile(test_file('sounds', music_name), music_name)
-    self.btest('sdl2_mixer_music.c', expected='1', args=[
+    self.btest_exit('sdl2_mixer_music.c', args=[
       '--preload-file', music_name,
       '-DSOUND_PATH=' + json.dumps(music_name),
       '-DFLAGS=' + flags,
@@ -3377,7 +3377,7 @@ window.close = function() {
 
   @requires_sound_hardware
   def test_sdl_audio_beep_sleep(self):
-    self.btest('sdl_audio_beep_sleep.cpp', '1', args=['-Os', '-sASSERTIONS', '-sDISABLE_EXCEPTION_CATCHING=0', '-profiling', '-sSAFE_HEAP', '-lSDL', '-sASYNCIFY'], timeout=90)
+    self.btest_exit('sdl_audio_beep_sleep.cpp', args=['-Os', '-sASSERTIONS', '-sDISABLE_EXCEPTION_CATCHING=0', '-profiling', '-sSAFE_HEAP', '-lSDL', '-sASYNCIFY'], timeout=90)
 
   def test_mainloop_reschedule(self):
     self.btest('mainloop_reschedule.cpp', '1', args=['-Os', '-sASYNCIFY'])

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -47,13 +47,13 @@ class interactive(BrowserCore):
     self.btest(test_file('sdl_touch.c'), args=['-O2', '-g1', '--closure=1'], expected='0')
 
   def test_sdl_wm_togglefullscreen(self):
-    self.btest('sdl_wm_togglefullscreen.c', expected='1')
+    self.btest_exit('sdl_wm_togglefullscreen.c')
 
   def test_sdl_fullscreen_samecanvassize(self):
     self.btest_exit('sdl_fullscreen_samecanvassize.c')
 
   def test_sdl2_togglefullscreen(self):
-    self.btest('sdl_togglefullscreen.c', expected='1', args=['-sUSE_SDL=2'])
+    self.btest_exit('sdl_togglefullscreen.c', args=['-sUSE_SDL=2'])
 
   def test_sdl_audio(self):
     shutil.copyfile(test_file('sounds', 'alarmvictory_1.ogg'), os.path.join(self.get_dir(), 'sound.ogg'))
@@ -63,8 +63,7 @@ class interactive(BrowserCore):
     open(os.path.join(self.get_dir(), 'bad.ogg'), 'w').write('I claim to be audio, but am lying')
 
     # use closure to check for a possible bug with closure minifying away newer Audio() attributes
-    self.compile_btest(['-O2', '--closure=1', '--minify=0', test_file('sdl_audio.c'), '--preload-file', 'sound.ogg', '--preload-file', 'sound2.wav', '--embed-file', 'the_entertainer.ogg', '--preload-file', 'noise.ogg', '--preload-file', 'bad.ogg', '-o', 'page.html', '-sEXPORTED_FUNCTIONS=_main,_play,_play2'])
-    self.run_browser('page.html', '', '/report_result?1')
+    self.btest_exit(test_file('sdl_audio.c'), args=['--preload-file', 'sound.ogg', '--preload-file', 'sound2.wav', '--embed-file', 'the_entertainer.ogg', '--preload-file', 'noise.ogg', '--preload-file', 'bad.ogg'])
 
     # print('SDL2')
     # check sdl2 as well
@@ -82,8 +81,7 @@ class interactive(BrowserCore):
   def test_sdl_audio_mix_channels(self, args):
     shutil.copyfile(test_file('sounds', 'noise.ogg'), os.path.join(self.get_dir(), 'sound.ogg'))
 
-    self.compile_btest(['-O2', '--minify=0', test_file('sdl_audio_mix_channels.c'), '--preload-file', 'sound.ogg', '-o', 'page.html'] + args)
-    self.run_browser('page.html', '', '/report_result?1')
+    self.btest_exit('sdl_audio_mix_channels.c', args=['-O2', '--minify=0', '--preload-file', 'sound.ogg'] + args)
 
   @parameterized({
     '': ([],),
@@ -94,20 +92,17 @@ class interactive(BrowserCore):
     shutil.copyfile(test_file('sounds', 'the_entertainer.ogg'), os.path.join(self.get_dir(), 'music.ogg'))
     shutil.copyfile(test_file('sounds', 'noise.ogg'), os.path.join(self.get_dir(), 'noise.ogg'))
 
-    self.compile_btest(['-O2', '--minify=0', test_file('sdl_audio_mix.c'), '--preload-file', 'sound.ogg', '--preload-file', 'music.ogg', '--preload-file', 'noise.ogg', '-o', 'page.html'] + args)
-    self.run_browser('page.html', '', '/report_result?1')
+    self.btest_exit('sdl_audio_mix.c', args=['-O2', '--minify=0', '--preload-file', 'sound.ogg', '--preload-file', 'music.ogg', '--preload-file', 'noise.ogg'] + args)
 
   def test_sdl_audio_panning(self):
     shutil.copyfile(test_file('sounds', 'the_entertainer.wav'), os.path.join(self.get_dir(), 'the_entertainer.wav'))
 
     # use closure to check for a possible bug with closure minifying away newer Audio() attributes
-    self.compile_btest(['-O2', '--closure=1', '--minify=0', test_file('sdl_audio_panning.c'), '--preload-file', 'the_entertainer.wav', '-o', 'page.html', '-sEXPORTED_FUNCTIONS=_main,_play'])
-    self.run_browser('page.html', '', '/report_result?1')
+    self.btest_exit('sdl_audio_panning.c', args=['-O2', '--closure=1', '--minify=0', '--preload-file', 'the_entertainer.wav', '-sEXPORTED_FUNCTIONS=_main,_play'])
 
   def test_sdl_audio_beeps(self):
     # use closure to check for a possible bug with closure minifying away newer Audio() attributes
-    self.compile_btest([test_file('sdl_audio_beep.cpp'), '-O2', '--closure=1', '--minify=0', '-sDISABLE_EXCEPTION_CATCHING=0', '-o', 'page.html'])
-    self.run_browser('page.html', '', '/report_result?1')
+    self.btest_exit(test_file('sdl_audio_beep.cpp'), args=['-O2', '--closure=1', '--minify=0', '-sDISABLE_EXCEPTION_CATCHING=0', '-o', 'page.html'])
 
   def test_sdl2_mixer_wav(self):
     shutil.copyfile(test_file('sounds', 'the_entertainer.wav'), 'sound.wav')
@@ -138,10 +133,9 @@ class interactive(BrowserCore):
       '-sINITIAL_MEMORY=33554432'
     ])
 
-  def zzztest_sdl2_audio_beeps(self):
+  def test_sdl2_audio_beeps(self):
     # use closure to check for a possible bug with closure minifying away newer Audio() attributes
-    self.compile_btest(['-O2', '--closure=1', '--minify=0', test_file('sdl2_audio_beep.cpp'), '-sDISABLE_EXCEPTION_CATCHING=0', '-sUSE_SDL=2', '-o', 'page.html'])
-    self.run_browser('page.html', '', '/report_result?1')
+    self.btest_exit(test_file('sdl2_audio_beep.cpp'), args=['-O2', '--closure=1', '--minify=0', '-sDISABLE_EXCEPTION_CATCHING=0', '-sUSE_SDL=2'])
 
   def test_openal_playback(self):
     shutil.copyfile(test_file('sounds', 'audio.wav'), os.path.join(self.get_dir(), 'audio.wav'))


### PR DESCRIPTION
Most of these change are converting the checks in the test code from `REPORT_RESULT` to `assert` and using `btest_exit` rather than `btest` to run the tests.

I did make make some more substantial changes to the interactive `sdl_audio.c` test to make it easier to run and verify that it was working as expected.