### PR TITLE
Use regular `-I` include flag for SDL paths

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -59,6 +59,7 @@ logger = logging.getLogger('emcc')
 C_ENDINGS = ('.c', '.i')
 CXX_ENDINGS = ('.cpp', '.cxx', '.cc', '.c++', '.CPP', '.CXX', '.C', '.CC', '.C++', '.ii')
 OBJC_ENDINGS = ('.m', '.mi')
+PREPROCESSED_ENDINGS = ('.i', '.ii')
 OBJCXX_ENDINGS = ('.mm', '.mii')
 SPECIAL_ENDINGLESS_FILENAMES = (os.devnull,)
 
@@ -822,8 +823,48 @@ def emsdk_cflags(user_args):
   return cflags + ['-Xclang', '-iwithsysroot' + os.path.join('/include', 'compat')]
 
 
-def get_clang_flags():
+def get_target_flags():
   return ['-target', shared.get_llvm_target()]
+
+
+def get_clang_flags(user_args):
+  flags = get_target_flags()
+
+  # if exception catching is disabled, we can prevent that code from being
+  # generated in the frontend
+  if settings.DISABLE_EXCEPTION_CATCHING and not settings.WASM_EXCEPTIONS:
+    flags.append('-fignore-exceptions')
+
+  if settings.INLINING_LIMIT:
+    flags.append('-fno-inline-functions')
+
+  if settings.RELOCATABLE and '-fPIC' not in user_args:
+    flags.append('-fPIC')
+
+  # We use default visiibilty=default in emscripten even though the upstream
+  # backend defaults visibility=hidden.  This matched the expectations of C/C++
+  # code in the wild which expects undecorated symbols to be exported to other
+  # DSO's by default.
+  if not any(a.startswith('-fvisibility') for a in user_args):
+    flags.append('-fvisibility=default')
+
+  if settings.LTO:
+    if not any(a.startswith('-flto') for a in user_args):
+      flags.append('-flto=' + settings.LTO)
+    # setjmp/longjmp handling using Wasm EH
+    # For non-LTO, '-mllvm -wasm-enable-eh' added in
+    # building.llvm_backend_args() sets this feature in clang. But in LTO, the
+    # argument is added to wasm-ld instead, so clang needs to know that EH is
+    # enabled so that it can be added to the attributes in LLVM IR.
+    if settings.SUPPORT_LONGJMP == 'wasm':
+      flags.append('-mexception-handling')
+
+  else:
+    # In LTO mode these args get passed instead at link time when the backend runs.
+    for a in building.llvm_backend_args():
+      flags += ['-mllvm', a]
+
+  return flags
 
 
 cflags = None
@@ -836,7 +877,7 @@ def get_cflags(user_args):
 
   # Flags we pass to the compiler when building C/C++ code
   # We add these to the user's flags (newargs), but not when building .s or .S assembly files
-  cflags = get_clang_flags()
+  cflags = get_clang_flags(user_args)
 
   if settings.EMSCRIPTEN_TRACING:
     cflags.append('-D__EMSCRIPTEN_TRACING__=1')
@@ -857,40 +898,6 @@ def get_cflags(user_args):
     cflags += ['-D__EMSCRIPTEN_major__=' + str(shared.EMSCRIPTEN_VERSION_MAJOR),
                '-D__EMSCRIPTEN_minor__=' + str(shared.EMSCRIPTEN_VERSION_MINOR),
                '-D__EMSCRIPTEN_tiny__=' + str(shared.EMSCRIPTEN_VERSION_TINY)]
-
-  # if exception catching is disabled, we can prevent that code from being
-  # generated in the frontend
-  if settings.DISABLE_EXCEPTION_CATCHING and not settings.WASM_EXCEPTIONS:
-    cflags.append('-fignore-exceptions')
-
-  if settings.INLINING_LIMIT:
-    cflags.append('-fno-inline-functions')
-
-  if settings.RELOCATABLE and '-fPIC' not in user_args:
-    cflags.append('-fPIC')
-
-  # We use default visiibilty=default in emscripten even though the upstream
-  # backend defaults visibility=hidden.  This matched the expectations of C/C++
-  # code in the wild which expects undecorated symbols to be exported to other
-  # DSO's by default.
-  if not any(a.startswith('-fvisibility') for a in user_args):
-    cflags.append('-fvisibility=default')
-
-  if settings.LTO:
-    if not any(a.startswith('-flto') for a in user_args):
-      cflags.append('-flto=' + settings.LTO)
-    # setjmp/longjmp handling using Wasm EH
-    # For non-LTO, '-mllvm -wasm-enable-eh' added in
-    # building.llvm_backend_args() sets this feature in clang. But in LTO, the
-    # argument is added to wasm-ld instead, so clang needs to know that EH is
-    # enabled so that it can be added to the attributes in LLVM IR.
-    if settings.SUPPORT_LONGJMP == 'wasm':
-      cflags.append('-mexception-handling')
-
-  else:
-    # In LTO mode these args get passed instead at link time when the backend runs.
-    for a in building.llvm_backend_args():
-      cflags += ['-mllvm', a]
 
   # Changes to default clang behavior
 
@@ -1045,7 +1052,7 @@ def run(args):
   if len(args) == 2 and args[1] == '-v':
     # autoconf likes to see 'GNU' in the output to enable shared object support
     print(version_string(), file=sys.stderr)
-    return shared.check_call([clang, '-v'] + get_clang_flags(), check=False).returncode
+    return shared.check_call([clang, '-v'] + get_target_flags(), check=False).returncode
 
   # Additional compiler flags that we treat as if they were passed to us on the
   # commandline
@@ -2709,8 +2716,11 @@ def phase_compile_inputs(options, state, newargs, input_files):
   def get_clang_command(src_file):
     return get_compiler(src_file) + get_cflags(state.orig_args) + compile_args + [src_file]
 
+  def get_clang_command_preprocessed(src_file):
+    return get_compiler(src_file) + get_clang_flags(state.orig_args) + compile_args + [src_file]
+
   def get_clang_command_asm(src_file):
-    return get_compiler(src_file) + get_clang_flags() + compile_args + [src_file]
+    return get_compiler(src_file) + get_target_flags() + compile_args + [src_file]
 
   # preprocessor-only (-E) support
   if state.mode == Mode.PREPROCESS_ONLY:
@@ -2765,6 +2775,8 @@ def phase_compile_inputs(options, state, newargs, input_files):
       linker_inputs.append((i, output_file))
     if get_file_suffix(input_file) in ASSEMBLY_ENDINGS:
       cmd = get_clang_command_asm(input_file)
+    elif get_file_suffix(input_file) in PREPROCESSED_ENDINGS:
+      cmd = get_clang_command_preprocessed(input_file)
     else:
       cmd = get_clang_command(input_file)
     if not state.has_dash_c:

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -355,7 +355,7 @@ def add_cflags(args, settings): # noqa: U100
 
   # Legacy SDL1 port is not actually a port at all but builtin
   if settings.USE_SDL == 1:
-    args += ['-Xclang', '-iwithsysroot/include/SDL']
+    args += ['-I' + Ports.get_include_dir('SDL')]
 
   needed = get_needed_ports(settings)
 

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -69,6 +69,7 @@ def get(ports, settings, shared):
       o = os.path.join(ports.get_build_dir(), 'sdl2', 'src', src + '.o')
       shared.safe_ensure_dirs(os.path.dirname(o))
       command = [shared.EMCC,
+                 '-sUSE_SDL=0',
                  '-c', os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'src', src),
                  '-o', o, '-I' + ports.get_include_dir('SDL2'),
                  '-O2', '-w']
@@ -91,8 +92,7 @@ def linker_setup(ports, settings):
 
 
 def process_args(ports):
-  # TODO(sbc): remove this
-  return ['-Xclang', '-isystem' + ports.get_include_dir('SDL2')]
+  return ['-I' + ports.get_include_dir('SDL2')]
 
 
 def show():


### PR DESCRIPTION
When SDL it used on the desktop the SDL include paths are injected
in this way:

```
$ sdl-config  --cflags
-I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT
$ sdl2-config  --cflags
-I/usr/include/SDL2 -D_REENTRANT
```

Its also the way to add include paths for all the other ports.