### PR TITLE
Highlight `warnOnce` warnings under node

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2416,6 +2416,9 @@ mergeInto(LibraryManager.library, {
     if (!warnOnce.shown) warnOnce.shown = {};
     if (!warnOnce.shown[text]) {
       warnOnce.shown[text] = 1;
+#if ENVIRONMENT_MAY_BE_NODE
+      if (ENVIRONMENT_IS_NODE) text = 'warning: ' + text;
+#endif
       err(text);
     }
   },

--- a/tests/other/test_fflush.out
+++ b/tests/other/test_fflush.out
@@ -1,3 +1,3 @@
 Hey1
-stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1 (see the FAQ), or make sure to emit a newline when you printf etc.
+warning: stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1 (see the FAQ), or make sure to emit a newline when you printf etc.
 (this may also be due to not including full filesystem support - try building with -sFORCE_FILESYSTEM)

--- a/tests/other/test_fflush_fs.out
+++ b/tests/other/test_fflush_fs.out
@@ -1,2 +1,2 @@
 Hey1
-stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1 (see the FAQ), or make sure to emit a newline when you printf etc.
+warning: stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1 (see the FAQ), or make sure to emit a newline when you printf etc.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3773,7 +3773,7 @@ int main() {
 #endif
 }
 ''')
-    warning = 'stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1'
+    warning = 'warning: stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1'
 
     def test(cxx, no_exit, assertions, flush=0, keepalive=0, filesystem=1):
       if cxx:
@@ -12298,3 +12298,20 @@ Module['postRun'] = function() {{
 
     for m, [v1, v2] in output['assertEquals']:
       self.assertEqual(v1, v2, msg=m)
+
+  def test_warn_once(self):
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$warnOnce'])
+    create_file('main.c', r'''\
+      #include <stdio.h>
+      #include <emscripten.h>
+
+      int main() {
+        EM_ASM({
+          warnOnce("foo");
+          // Second call should not output anything
+          warnOnce("foo");
+        });
+        printf("done\n");
+      }
+    ''')
+    self.do_runf('main.c', 'warning: foo\ndone\n')


### PR DESCRIPTION
On the web we don't need do this since console.warn are already
shown as warnings.  However, under node its nice if the warnings stand
out from other stuff being written to stderr.