### PR TITLE
Add test for ABORT_ON_WASM_EXCEPTIONS + exception during main

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -158,7 +158,7 @@ function callMain(args) {
 
 #if ABORT_ON_WASM_EXCEPTIONS
     // See abortWrapperDepth in preamble.js!
-    abortWrapperDepth += 2;
+    abortWrapperDepth += 1;
 #endif
 
 #if STANDALONE_WASM
@@ -192,7 +192,7 @@ function callMain(args) {
 #if ABORT_ON_WASM_EXCEPTIONS
   finally {
     // See abortWrapperDepth in preamble.js!
-    abortWrapperDepth -= 2;
+    abortWrapperDepth -= 1;
   }
 #endif
 }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -564,7 +564,6 @@ function createExportWrapper(name, fixedasm) {
 #endif
 
 #if ABORT_ON_WASM_EXCEPTIONS
-// When exception catching is enabled (!DISABLE_EXCEPTION_CATCHING)
 // `abortWrapperDepth` counts the recursion level of the wrapper function so
 // that we only handle exceptions at the top level letting the exception
 // mechanics work uninterrupted at the inner level.  Additionally,
@@ -580,13 +579,10 @@ function makeAbortWrapper(original) {
       throw "program has already aborted!";
     }
 
-#if !DISABLE_EXCEPTION_CATCHING
     abortWrapperDepth += 1;
-#endif
     try {
       return original.apply(null, arguments);
-    }
-    catch (e) {
+    } catch (e) {
       if (
         ABORT // rethrow exception if abort() was called in the original function call above
         || abortWrapperDepth > 1 // rethrow exceptions not caught at the top level if exception catching is enabled; rethrow from exceptions from within callMain
@@ -599,12 +595,10 @@ function makeAbortWrapper(original) {
 
       abort("unhandled exception: " + [e, e.stack]);
     }
-#if !DISABLE_EXCEPTION_CATCHING
     finally {
       abortWrapperDepth -= 1;
     }
-#endif
-    }
+  }
 }
 
 // Instrument all the exported functions to:

--- a/src/settings.js
+++ b/src/settings.js
@@ -1947,18 +1947,20 @@ var SEPARATE_DWARF_URL = '';
 // [link]
 var ERROR_ON_WASM_CHANGES_AFTER_LINK = false;
 
-// Whether the program should abort when an unhandled WASM exception is encountered.
-// This makes the Emscripten program behave more like a native program where the OS
-// would terminate the process and no further code can be executed when an unhandled
-// exception (e.g. out-of-bounds memory access) happens.
+// Abort on unhandled excptions that occur when calling exported WebAssembly
+// functions. This makes the program behave more like a native program where the
+// OS would terminate the process and no further code can be executed when an
+// unhandled exception (e.g. out-of-bounds memory access) happens.
 // This will instrument all exported functions to catch thrown exceptions and
-// call abort() when they happen. Once the program aborts any exported function calls
-// will fail with a "program has already aborted" exception to prevent calls into
-// code with a potentially corrupted program state.
-// This adds a small fixed amount to code size in optimized builds and a slight overhead
-// for the extra instrumented function indirection.
-// Enable this if you want Emscripten to handle unhandled exceptions nicely at the
-// cost of a few bytes extra.
+// call abort() when they happen. Once the program aborts any exported function
+// calls will fail with a "program has already aborted" exception to prevent
+// calls into code with a potentially corrupted program state.
+// This adds a small fixed amount to code size in optimized builds and a slight
+// overhead for the extra instrumented function indirection.  Enable this if you
+// want Emscripten to handle unhandled exceptions nicely at the cost of a few
+// bytes extra.
+// Exceptions that occur within the `main` function are already handled via an
+// alternative mechanimsm.
 // [link]
 var ABORT_ON_WASM_EXCEPTIONS = false;
 

--- a/tests/core/test_abort_on_exceptions.cpp
+++ b/tests/core/test_abort_on_exceptions.cpp
@@ -28,4 +28,4 @@ EMSCRIPTEN_BINDINGS(test_abort_on_exception) {
 
 int main() {
   return 0;
-} 
+}

--- a/tests/core/test_abort_on_exceptions.out
+++ b/tests/core/test_abort_on_exceptions.out
@@ -1,5 +1,5 @@
 crashing
-true
+exception caught; runtime should be dead
 again
 program has already aborted!
 ccall

--- a/tests/core/test_abort_on_exceptions_main.c
+++ b/tests/core/test_abort_on_exceptions_main.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <stdio.h>
+#include <emscripten.h>
+
+EM_JS(void, throwException, (void), {
+  throw new Error("crash");
+});
+
+int main() {
+  printf("crashing during main\n");
+  throwException();
+  return 0;
+}

--- a/tests/core/test_abort_on_exceptions_post.js
+++ b/tests/core/test_abort_on_exceptions_post.js
@@ -5,7 +5,7 @@ addOnPostRun(function() {
   }
   catch(e) {
     // Catch the abort
-    out(true);
+    out("exception caught; runtime should be dead");
   }
   out("again");
   try {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9341,8 +9341,19 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('ALLOW_TABLE_GROWTH')
     self.set_setting('EXPORTED_RUNTIME_METHODS', ['ccall', 'cwrap'])
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$addFunction'])
-    self.emcc_args += ['-lembind', '--post-js', test_file('core/test_abort_on_exception_post.js')]
-    self.do_core_test('test_abort_on_exception.cpp', interleaved_output=False)
+    self.emcc_args += ['-lembind', '--post-js', test_file('core/test_abort_on_exceptions_post.js')]
+    self.do_core_test('test_abort_on_exceptions.cpp', interleaved_output=False)
+
+  def test_abort_on_exceptions_main(self):
+    # The unhandled exception wrappers should not kick in for exceptions thrown during main
+    self.set_setting('ABORT_ON_WASM_EXCEPTIONS')
+    self.emcc_args.append('--minify=0')
+    output = self.do_runf(test_file('core/test_abort_on_exceptions_main.c'), assert_returncode=NON_ZERO)
+    # The exception should make it all the way out
+    self.assertContained('Error: crash', output)
+    # And not be translated into abort by makeAbortWrapper
+    self.assertNotContained('unhandled exception', output)
+    self.assertNotContained('Aborted', output)
 
   @needs_dylink
   def test_gl_main_module(self):


### PR DESCRIPTION
The special handling of abortWrapperDepth if callMain was previsouly
untested.