### PR TITLE
[WasmFS] Fix stack leak in JS API

### DIFF
--- a/system/lib/wasmfs/js_api.cpp
+++ b/system/lib/wasmfs/js_api.cpp
@@ -100,8 +100,8 @@ int _wasmfs_mkdir(char* path, int mode) {
 
 int _wasmfs_chdir(char* path) { return __syscall_chdir((intptr_t)path); }
 
-void _wasmfs_symlink(char* old_path, char* new_path) {
-  __syscall_symlink((intptr_t)old_path, (intptr_t)new_path);
+int _wasmfs_symlink(char* old_path, char* new_path) {
+  return __syscall_symlink((intptr_t)old_path, (intptr_t)new_path);
 }
 
 int _wasmfs_chmod(char* path, mode_t mode) {


### PR DESCRIPTION
The JS API uses `allocateUTF8OnStack` to convert JS strings to C++ strings, but
that function decrements the stack pointer and the JS API implementation never
reset the stack pointer afterwards. Using the JS functions would leak stack
space and could break programs that held references to stack data in frames
above the JS functions. Fix the bug by using `withStackSave` in the JS API
implementations.