### PR TITLE
Add SDL_config file for emscripten

### DIFF
--- a/system/include/SDL/SDL_config.h
+++ b/system/include/SDL/SDL_config.h
@@ -41,6 +41,8 @@
 #include "SDL_config_android.h"
 #elif defined(__NINTENDODS__)
 #include "SDL_config_nintendods.h"
+#elif defined(__EMSCRIPTEN__)
+#include "SDL_config_emscripten.h"
 #else
 #include "SDL_config_minimal.h"
 #endif /* platform config */

--- a/system/include/SDL/SDL_config_emscripten.h
+++ b/system/include/SDL/SDL_config_emscripten.h
@@ -1,0 +1,76 @@
+#ifndef _SDL_config_emscripten_h
+#define _SDL_config_emscripten_h
+
+#include "SDL_platform.h"
+#include "SDL_config_minimal.h"
+
+#define HAVE_GCC_ATOMICS	1
+
+#define HAVE_ALLOCA_H		1
+#define HAVE_SYS_TYPES_H	1
+#define HAVE_STDIO_H	1
+#define STDC_HEADERS	1
+#define HAVE_STRING_H	1
+#define HAVE_INTTYPES_H	1
+#define HAVE_STDINT_H	1
+#define HAVE_CTYPE_H	1
+#define HAVE_MATH_H	1
+#define HAVE_SIGNAL_H	1
+
+/* C library functions */
+#define HAVE_MALLOC	1
+#define HAVE_CALLOC	1
+#define HAVE_REALLOC	1
+#define HAVE_FREE	1
+#define HAVE_ALLOCA	1
+#define HAVE_GETENV	1
+#define HAVE_SETENV	1
+#define HAVE_PUTENV	1
+#define HAVE_SETENV	1
+#define HAVE_UNSETENV	1
+#define HAVE_QSORT	1
+#define HAVE_ABS	1
+#define HAVE_BCOPY	1
+#define HAVE_MEMSET	1
+#define HAVE_MEMCPY	1
+#define HAVE_MEMMOVE	1
+#define HAVE_MEMCMP	1
+#define HAVE_STRLEN	1
+#define HAVE_STRLCPY	1
+#define HAVE_STRLCAT	1
+#define HAVE_STRDUP	1
+#define HAVE_STRCHR	1
+#define HAVE_STRRCHR	1
+#define HAVE_STRSTR	1
+#define HAVE_STRTOL	1
+#define HAVE_STRTOUL	1
+#define HAVE_STRTOLL	1
+#define HAVE_STRTOULL	1
+#define HAVE_STRTOD	1
+#define HAVE_ATOI	1
+#define HAVE_ATOF	1
+#define HAVE_STRCMP	1
+#define HAVE_STRNCMP	1
+#define HAVE_STRCASECMP	1
+#define HAVE_STRNCASECMP 1
+#define HAVE_SSCANF	1
+#define HAVE_SNPRINTF	1
+#define HAVE_VSNPRINTF	1
+#define HAVE_M_PI	1
+#define HAVE_ATAN	1
+#define HAVE_ATAN2	1
+#define HAVE_CEIL	1
+#define HAVE_COPYSIGN	1
+#define HAVE_COS	1
+#define HAVE_COSF	1
+#define HAVE_FABS	1
+#define HAVE_FLOOR	1
+#define HAVE_LOG	1
+#define HAVE_POW	1
+#define HAVE_SCALBN	1
+#define HAVE_SIN	1
+#define HAVE_SINF	1
+#define HAVE_SQRT	1
+#define HAVE_NANOSLEEP	1
+
+#endif /* _SDL_config_emscripten_h */


### PR DESCRIPTION
I noticed that we lacked such a thing while working on #17475.  It turns
out that system header are technically allowed to redefine macros
without generating a warning, but when I made the SDL header tree into a
normal `-I` path I noticed that `M_PI` was being duplicately defined
because we were not defining `HAVE_M_PI`.

This list of defines is taked from `SDL_config_iphoneos.h` and a visual
inspection seems to confirm that we do indeed support all the specified
features.

See https://gcc.gnu.org/onlinedocs/cpp/System-Headers.html: 
"Macros defined in a system header are immune to a few warnings wherever they are expanded. This immunity is granted on an ad-hoc basis, when we find that a warning generates lots of false positives because of code in macros defined in system headers."