### PR TITLE
emcc.py: Avoid mutating `user_args` in `get_cflags`. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -220,7 +220,8 @@ class Mode(Enum):
 class EmccState:
   def __init__(self, args):
     self.mode = Mode.COMPILE_AND_LINK
-    self.orig_args = args
+    # Using tuple here to prevent accidental mutation
+    self.orig_args = tuple(args)
     self.has_dash_c = False
     self.has_dash_E = False
     self.has_dash_S = False
@@ -791,13 +792,9 @@ def emsdk_cflags(user_args):
       if n in hay:
         return True
 
-  # relaxed-simd implies simd128.
-  if '-mrelaxed-simd' in user_args:
-    user_args += ['-msimd128']
-
   if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER) or array_contains_any_of(user_args, SIMD_NEON_FLAGS):
-    if '-msimd128' not in user_args:
-      exit_with_error('Passing any of ' + ', '.join(SIMD_INTEL_FEATURE_TOWER + SIMD_NEON_FLAGS) + ' flags also requires passing -msimd128!')
+    if '-msimd128' not in user_args and '-mrelaxed-simd' not in user_args:
+      exit_with_error('Passing any of ' + ', '.join(SIMD_INTEL_FEATURE_TOWER + SIMD_NEON_FLAGS) + ' flags also requires passing -msimd128 (or -mrelaxed-simd)!')
     cflags += ['-D__SSE__=1']
 
   if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[1:]):
@@ -1255,7 +1252,7 @@ def phase_parse_arguments(state):
   """The first phase of the compiler.  Parse command line argument and
   populate settings.
   """
-  newargs = state.orig_args.copy()
+  newargs = list(state.orig_args)
 
   # Scan and strip emscripten specific cmdline warning flags.
   # This needs to run before other cmdline flags have been parsed, so that


### PR DESCRIPTION
The addition of `-msimd128` to `user_args` here only effects the lines
below within this function, since `user_args` is not what we pass to
clang.