### PR TITLE
tests: Avoid duplicating/inlining browser_reporting.js within reftest.js

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1553,7 +1553,6 @@ class BrowserCore(RunnerCore):
     #   pngcrush -rem gAMA -rem cHRM -rem iCCP -rem sRGB infile outfile
     basename = os.path.basename(expected)
     shutil.copyfile(expected, self.in_dir(basename))
-    reporting = read_file(test_file('browser_reporting.js'))
     write_file('reftest.js', '''
       function doReftest() {
         if (doReftest.done) return;
@@ -1599,15 +1598,8 @@ class BrowserCore(RunnerCore):
               }
             }
             var wrong = Math.floor(total / (img.width*img.height*3)); // floor, to allow some margin of error for antialiasing
-            // If the main JS file is in a worker, or modularize, then we need to supply our own reporting logic.
-            if (typeof reportResultToServer === 'undefined') {
-              (function() {
-                %s
-                reportResultToServer(wrong);
-              })();
-            } else {
-              reportResultToServer(wrong);
-            }
+            assert(reportResultToServer);
+            reportResultToServer(wrong);
           };
           actualImage.src = actualUrl;
         }
@@ -1656,7 +1648,7 @@ class BrowserCore(RunnerCore):
       }
 
       setupRefTest();
-''' % (reporting, basename, int(manually_trigger)))
+''' % (basename, int(manually_trigger)))
 
   def compile_btest(self, args, reporting=Reporting.FULL):
     # Inject support code for reporting results. This adds an include a header so testcases can

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -821,11 +821,14 @@ If manually bisecting:
 
   def post_manual_reftest(self):
     assert os.path.exists('reftest.js')
+    shutil.copyfile(test_file('browser_reporting.js'), self.in_dir('browser_reporting.js'))
+
     html = read_file('test.html')
     html = html.replace('</body>', '''
+<script src="browser_reporting.js"></script>
+<script src="reftest.js"></script>
 <script>
 function assert(x, y) { if (!x) throw 'assertion failed ' + y }
-%s
 
 var windowClose = window.close;
 window.close = function() {
@@ -836,7 +839,7 @@ window.close = function() {
   }, 1000);
 };
 </script>
-</body>''' % read_file('reftest.js'))
+</body>''')
     create_file('test.html', html)
 
   def test_sdl_canvas_proxy(self):
@@ -3209,10 +3212,10 @@ Module["preRun"].push(function () {
   def test_sdl2_gl_frames_swap(self):
     def post_build():
       self.post_manual_reftest()
-      html = read_file('test.html')
-      html2 = html.replace('''Module['postRun'] = doReftest;''', '') # we don't want the very first frame
-      assert html != html2
-      create_file('test.html', html2)
+      js = read_file('reftest.js')
+      js2 = js.replace('''Module['postRun'] = doReftest;''', '') # we don't want the very first frame
+      assert js != js2
+      create_file('reftest.js', js2)
     self.btest('browser/test_sdl2_gl_frames_swap.c', reference='browser/test_sdl2_gl_frames_swap.png', args=['--proxy-to-worker', '-sGL_TESTING', '-sUSE_SDL=2'], manual_reference=True, post_build=post_build)
 
   @requires_graphics_hardware


### PR DESCRIPTION
This file was duplicated/inlined into reftest.js for the case where
the module is running on worker (e.g. proxy-to-worker) and therefore
the copy that gets included via `--pre-js` is not accessible

However, we can simplify this by simply directly including
`browser_reporting.js` when we use it in this way.