### PR TITLE
Improve release process documentation

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -55,10 +55,10 @@ How:
 
 1. Pick a version for a release and make sure it meets the requirements above.
    Let this version SHA be <non-LTO-sha>.
-1. If we want to do an LTO release as well, create a CL that copies [DEPS][DEPS] from <non-lto-sha>
-   to [DEPS.tagged-release][DEPS.tagged-release] in
-   [emscripten-releases][releases_repo] repo. When this CL is committed, let the resulting SHA be
-   <LTO-sha>. An example of this CL can be
+1. If we want to do an LTO release as well, create a CL that copies [DEPS][DEPS]
+   from <non-lto-sha> to [DEPS.tagged-release][DEPS.tagged-release] in
+   [emscripten-releases][releases_repo] repo. When this CL is committed, let the
+   resulting SHA be <LTO-sha>. An example of this CL can be
    https://chromium-review.googlesource.com/c/emscripten-releases/+/3781978.
 1. Run [`./scripts/create_release.py`][create_release] in the emsdk repository.
    When we do both an LTO and a non-LTO release, run:
@@ -83,11 +83,11 @@ How:
 1. [Tag][emsdk_tags] the `emsdk` repo with the new version number, on the commit
    that does the update, after it lands on main.
 1. [Tag][emscripten_tags] the `emscripten` repo with the new version number, on
-   the commit referred to in the [DEPS][DEPS] (or DEPS.tagged-release) file above.
+   the commit referred to in the [DEPS][DEPS] (or DEPS.tagged-release) file
+   above.
 1. Update [`emscripten-version.txt`][emscripten_version] and
    [`ChangeLog.md`][changelog] in the emscripten repo to refer the next,
-   upcoming, version. An example of this PR is
-   emscripten-core/emscripten#17439.
+   upcoming, version. An example of this PR is emscripten-core/emscripten#17439.
 
 Major version update (1.X.Y to 1.(X+1).0)
 -----------------------------------------

--- a/docs/process.md
+++ b/docs/process.md
@@ -86,7 +86,8 @@ How:
    the commit referred to in the [DEPS][DEPS] file above.
 1. Update [`emscripten-version.txt`][emscripten_version] and
    [`ChangeLog.md`][changelog] in the emscripten repo to refer the next,
-   upcoming, version. An example of this PR can be #17439.
+   upcoming, version. An example of this PR can be
+   emscripten-core/emscripten#17439.
 
 Major version update (1.X.Y to 1.(X+1).0)
 -----------------------------------------

--- a/docs/process.md
+++ b/docs/process.md
@@ -80,9 +80,9 @@ How:
    script will update [emscripten-releases-tags.json][emscripten_releases_tags],
    adding a new version. The script will create a new git branch that can be
    uploaded as a PR. An example of this PR can be emscripten-core/emsdk#1071.
-1. [Tag](emsdk_tags) the `emsdk` repo with the new version number, on the commit
+1. [Tag][emsdk_tags] the `emsdk` repo with the new version number, on the commit
    that does the update, after it lands on main.
-1. [Tag](emscripten_tags) the `emscripten` repo with the new version number, on
+1. [Tag][emscripten_tags] the `emscripten` repo with the new version number, on
    the commit referred to in the [DEPS][DEPS] file above.
 1. Update [`emscripten-version.txt`][emscripten_version] and
    [`ChangeLog.md`][changelog] in the emscripten repo to refer the next,
@@ -155,5 +155,5 @@ See notes above on installing sphinx.
 [emscripten_releases_tags]: https://github.com/emscripten-core/emsdk/blob/main/emscripten-releases-tags.json
 [DEPS]: https://chromium.googlesource.com/emscripten-releases/+/refs/heads/main/DEPS
 [DEPS.tagged-release]: https://chromium.googlesource.com/emscripten-releases/+/refs/heads/main/DEPS.tagged-release
-[emscripten_tags]: https://github.com/emscripten-core/emscripten/tags
 [emsdk_tags]: https://github.com/emscripten-core/emsdk/tags
+[emscripten_tags]: https://github.com/emscripten-core/emscripten/tags

--- a/docs/process.md
+++ b/docs/process.md
@@ -55,9 +55,9 @@ How:
 
 1. Pick a version for a release and make sure it meets the requirements above.
    Let this version SHA be <non-LTO-sha>.
-1. If we want to do a LTO release as well, create a PR that copies [DEPS][DEPS]
+1. If we want to do an LTO release as well, create a CL that copies [DEPS][DEPS] from <non-lto-sha>
    to [DEPS.tagged-release][DEPS.tagged-release] in
-   [emscripten-releases][releases_repo] repo. Let this LTO version SHA be
+   [emscripten-releases][releases_repo] repo. When this CL is committed, let the resulting SHA be
    <LTO-sha>. An example of this PR can be
    https://chromium-review.googlesource.com/c/emscripten-releases/+/3781978.
 1. Run [`./scripts/create_release.py`][create_release] in the emsdk repository.
@@ -67,7 +67,7 @@ How:
    ```
    This will make the <LTO-sha> point to the versioned name release (e.g.
    `3.1.7`) and the <non-LTO-sha> point to the assert build release (e.g.
-   `3.1.7-assert`). When we do only a non-LTO release, run:
+   `3.1.7-asserts`). When we do only a non-LTO release, run:
    ```
    ./scripts/create_release.py <non-LTO-sha>
    ```
@@ -79,14 +79,14 @@ How:
    name release. Running this [`./scripts/create_release.py`][create_release]
    script will update [emscripten-releases-tags.json][emscripten_releases_tags],
    adding a new version. The script will create a new git branch that can be
-   uploaded as a PR. An example of this PR can be emscripten-core/emsdk#1071.
+   uploaded as a PR. An example of this PR is emscripten-core/emsdk#1071.
 1. [Tag][emsdk_tags] the `emsdk` repo with the new version number, on the commit
    that does the update, after it lands on main.
 1. [Tag][emscripten_tags] the `emscripten` repo with the new version number, on
-   the commit referred to in the [DEPS][DEPS] file above.
+   the commit referred to in the [DEPS][DEPS] (or DEPS.tagged-release) file above.
 1. Update [`emscripten-version.txt`][emscripten_version] and
    [`ChangeLog.md`][changelog] in the emscripten repo to refer the next,
-   upcoming, version. An example of this PR can be
+   upcoming, version. An example of this PR is
    emscripten-core/emscripten#17439.
 
 Major version update (1.X.Y to 1.(X+1).0)

--- a/docs/process.md
+++ b/docs/process.md
@@ -58,7 +58,7 @@ How:
 1. If we want to do an LTO release as well, create a CL that copies [DEPS][DEPS] from <non-lto-sha>
    to [DEPS.tagged-release][DEPS.tagged-release] in
    [emscripten-releases][releases_repo] repo. When this CL is committed, let the resulting SHA be
-   <LTO-sha>. An example of this PR can be
+   <LTO-sha>. An example of this CL can be
    https://chromium-review.googlesource.com/c/emscripten-releases/+/3781978.
 1. Run [`./scripts/create_release.py`][create_release] in the emsdk repository.
    When we do both an LTO and a non-LTO release, run:

--- a/docs/process.md
+++ b/docs/process.md
@@ -49,22 +49,44 @@ Requirements:
    [emscripten-releases][releases_repo] repo, which then specifies through
    [DEPS][DEPS] exactly which revisions to use in all other repos).
  * [GitHub CI](https://github.com/emscripten-core/emscripten/branches) is green
-   on the `main` branch.
+   on the `main` branch for the emscripten commit referred to in [DEPS][DEPS].
 
 How:
 
+1. Pick a version for a release and make sure it meets the requirements above.
+   Let this version SHA be <non-LTO-sha>.
+1. If we want to do a LTO release as well, create a PR that copies [DEPS][DEPS]
+   to [DEPS.tagged-release][DEPS.tagged-release] in
+   [emscripten-releases][releases_repo] repo. Let this LTO version SHA be
+   <LTO-sha>. An example of this PR can be
+   https://chromium-review.googlesource.com/c/emscripten-releases/+/3781978.
 1. Run [`./scripts/create_release.py`][create_release] in the emsdk repository.
-   This script will update [emscripten-releases-tags.json][emscripten_releases_tags],
-   adding a new version.  You can either specify the desired hash, or let the
-   script pick the current tot build.  The script will create a new git branch
-   that can be uploaded as a PR.
-3. Tag the `emsdk` repo with the new version number, on the commit that does the
-   update, after it lands on main.
-4. Tag the `emscripten` repo with the new version number, on the commit referred
-   to in the [DEPS][DEPS] file above.
-5. Update [`emscripten-version.txt`][emscripten_version] and
+   When we do both an LTO and a non-LTO release, run:
+   ```
+   ./scripts/create_release.py <LTO-sha> <non-LTO-sha>
+   ```
+   This will make the <LTO-sha> point to the versioned name release (e.g.
+   `3.1.7`) and the <non-LTO-sha> point to the assert build release (e.g.
+   `3.1.7-assert`). When we do only a non-LTO release, run:
+   ```
+   ./scripts/create_release.py <non-LTO-sha>
+   ```
+   This will make the <non-LTO-sha> point directly to the versioned name release
+   (e.g. `3.1.7`) and there will be no assert build release. If we run
+   [`./scripts/create_release.py`][create_release] without any arguments, it
+   will automatically pick a tot version from
+   [emscripten-releases][releases_repo] repo and make it point to the versioned
+   name release. Running this [`./scripts/create_release.py`][create_release]
+   script will update [emscripten-releases-tags.json][emscripten_releases_tags],
+   adding a new version. The script will create a new git branch that can be
+   uploaded as a PR. An example of this PR can be emscripten-core/emsdk#1071.
+1. [Tag](emsdk_tags) the `emsdk` repo with the new version number, on the commit
+   that does the update, after it lands on main.
+1. [Tag](emscripten_tags) the `emscripten` repo with the new version number, on
+   the commit referred to in the [DEPS][DEPS] file above.
+1. Update [`emscripten-version.txt`][emscripten_version] and
    [`ChangeLog.md`][changelog] in the emscripten repo to refer the next,
-   upcoming, version.
+   upcoming, version. An example of this PR can be #17439.
 
 Major version update (1.X.Y to 1.(X+1).0)
 -----------------------------------------
@@ -130,4 +152,7 @@ See notes above on installing sphinx.
 [changelog]: https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md
 [create_release]: https://github.com/emscripten-core/emsdk/blob/main/scripts/create_release.py
 [emscripten_releases_tags]: https://github.com/emscripten-core/emsdk/blob/main/emscripten-releases-tags.json
-[DEPS]: https://chromium.googlesource.com/emscripten-releases/+/refs/heads/master/DEPS
+[DEPS]: https://chromium.googlesource.com/emscripten-releases/+/refs/heads/main/DEPS
+[DEPS.tagged-release]: https://chromium.googlesource.com/emscripten-releases/+/refs/heads/main/DEPS.tagged-release
+[emscripten_tags]: https://github.com/emscripten-core/emscripten/tags
+[emsdk_tags]: https://github.com/emscripten-core/emsdk/tags


### PR DESCRIPTION
I've created my first release and this PR contains the info I would have
liked. This adds info on how to create both a LTO and non-LTO release
and adds example PRs for each of the steps.