### PR TITLE
Update WebGPU to dawn @98f18d

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -151,11 +151,6 @@
     TextureFormat: {
       Undefined: 0,
     },
-    VertexStepMode: {
-      Vertex: 0,
-      Instance: 1,
-      VertexBufferNotUsed: 2,
-    },
   };
   return null;
 })(); }}}
@@ -1317,9 +1312,10 @@ var LibraryWebGPU = {
 
     function makeVertexBuffer(vbPtr) {
       if (!vbPtr) return undefined;
-      return {
+      var stepModeValue = WebGPU.VertexStepMode[{{{ gpu.makeGetU32('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.stepMode) }}}];
+      return stepModeValue === undefined ? undefined :{
         "arrayStride": {{{ gpu.makeGetU64('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.arrayStride) }}},
-        "stepMode": WebGPU.VertexStepMode[{{{ gpu.makeGetU32('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.stepMode) }}}],
+        "stepMode": stepModeValue,
         "attributes": makeVertexAttributes(
           {{{ gpu.makeGetU32('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.attributeCount) }}},
           {{{ makeGetValue('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.attributes, '*') }}}),

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -151,6 +151,11 @@
     TextureFormat: {
       Undefined: 0,
     },
+    VertexStepMode: {
+      Vertex: 0,
+      Instance: 1,
+      VertexBufferNotUsed: 2,
+    },
   };
   return null;
 })(); }}}
@@ -1312,10 +1317,10 @@ var LibraryWebGPU = {
 
     function makeVertexBuffer(vbPtr) {
       if (!vbPtr) return undefined;
-      var stepModeValue = WebGPU.VertexStepMode[{{{ gpu.makeGetU32('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.stepMode) }}}];
-      return stepModeValue === undefined ? undefined :{
+      var stepModeInt = {{{ gpu.makeGetU32('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.stepMode) }}};
+      return stepModeInt === {{{ gpu.VertexStepMode.VertexBufferNotUsed }}} ? null : {
         "arrayStride": {{{ gpu.makeGetU64('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.arrayStride) }}},
-        "stepMode": stepModeValue,
+        "stepMode": WebGPU.VertexStepMode[stepModeInt],
         "attributes": makeVertexAttributes(
           {{{ gpu.makeGetU32('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.attributeCount) }}},
           {{{ makeGetValue('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.attributes, '*') }}}),

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1675,6 +1675,7 @@ var LibraryWebGPU = {
           {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPassDescriptor.depthStencilAttachment, '*') }}}),
         "occlusionQuerySet": WebGPU.mgrQuerySet.get(
           {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPassDescriptor.occlusionQuerySet, '*') }}}),
+        "maxDrawCount": maxDrawCount,
       };
       var labelPtr = {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPassDescriptor.label, '*') }}};
       if (labelPtr) desc["label"] = UTF8ToString(labelPtr);
@@ -1686,9 +1687,6 @@ var LibraryWebGPU = {
           {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPassDescriptor.timestampWrites, '*') }}});
       }
 
-      if (maxDrawCount) {
-        desc["maxDrawCount"] = maxDrawCount;
-      }
       return desc;
     }
 

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1632,10 +1632,6 @@ var LibraryWebGPU = {
       };
     }
 
-    function makeRenderPassDescriptorMaxDrawCount(mdcPtr) {
-        return  {{{ gpu.makeGetU64('mdcPtr', C_STRUCTS.WGPURenderPassDescriptorMaxDrawCount.maxDrawCount) }}};
-    }
-
     function makeRenderPassTimestampWrite(twPtr) {
       return {
         "querySet": WebGPU.mgrQuerySet.get(
@@ -1666,8 +1662,7 @@ var LibraryWebGPU = {
 #endif
         var renderPassDescriptorMaxDrawCount = nextInChainPtr;
         {{{ gpu.makeCheckDescriptor('renderPassDescriptorMaxDrawCount') }}}
-        maxDrawCount = makeRenderPassDescriptorMaxDrawCount(
-          {{{ makeGetValue('renderPassDescriptorMaxDrawCount', C_STRUCTS.WGPUSurfaceDescriptorFromCanvasHTMLSelector.selector, '*') }}});
+        maxDrawCount = {{{ gpu.makeGetU64('renderPassDescriptorMaxDrawCount', C_STRUCTS.WGPURenderPassDescriptorMaxDrawCount.maxDrawCount) }}};
       }
 
       var desc = {

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -151,6 +151,11 @@
     TextureFormat: {
       Undefined: 0,
     },
+    VertexStepMode: {
+      Vertex: 0,
+      Instance: 1,
+      VertexBufferNotUsed: 2,
+    },
   };
   return null;
 })(); }}}
@@ -1312,11 +1317,10 @@ var LibraryWebGPU = {
 
     function makeVertexBuffer(vbPtr) {
       if (!vbPtr) return undefined;
-
+      var stepModeInt = {{{ gpu.makeGetU32('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.stepMode) }}};
       return {
         "arrayStride": {{{ gpu.makeGetU64('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.arrayStride) }}},
-        "stepMode": WebGPU.VertexStepMode[
-          {{{ gpu.makeGetU32('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.stepMode) }}}],
+        "stepMode": stepModeInt === {{{ gpu.VertexStepMode.VertexBufferNotUsed }}} ? undefined : WebGPU.VertexStepMode[stepModeInt],
         "attributes": makeVertexAttributes(
           {{{ gpu.makeGetU32('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.attributeCount) }}},
           {{{ makeGetValue('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.attributes, '*') }}}),

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1457,7 +1457,7 @@ var LibraryWebGPU = {
     return querySet.count;
   },
 
-  wgpuQuerySetSetGetType: function(querySetId, labelPtr) {
+  wgpuQuerySetGetType: function(querySetId, labelPtr) {
     var querySet = WebGPU.mgrQuerySet.get(querySetId);
     return querySet.type;
   },

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -635,7 +635,7 @@ var LibraryWebGPU = {
     VertexStepMode: [
       'vertex',
       'instance',
-      'vertex-buffer-not-used',
+      undefined,
     ],
   },
 
@@ -1317,10 +1317,9 @@ var LibraryWebGPU = {
 
     function makeVertexBuffer(vbPtr) {
       if (!vbPtr) return undefined;
-      var stepModeInt = {{{ gpu.makeGetU32('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.stepMode) }}};
       return {
         "arrayStride": {{{ gpu.makeGetU64('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.arrayStride) }}},
-        "stepMode": stepModeInt === {{{ gpu.VertexStepMode.VertexBufferNotUsed }}} ? undefined : WebGPU.VertexStepMode[stepModeInt],
+        "stepMode": WebGPU.VertexStepMode[{{{ gpu.makeGetU32('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.stepMode) }}}],
         "attributes": makeVertexAttributes(
           {{{ gpu.makeGetU32('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.attributeCount) }}},
           {{{ makeGetValue('vbPtr', C_STRUCTS.WGPUVertexBufferLayout.attributes, '*') }}}),
@@ -1659,6 +1658,7 @@ var LibraryWebGPU = {
         var sType = {{{ gpu.makeGetU32('nextInChainPtr', C_STRUCTS.WGPUChainedStruct.sType) }}};
 #if ASSERTIONS
         assert(sType === {{{ gpu.SType.RenderPassDescriptorMaxDrawCount }}});
+        assert(0 === {{{ makeGetValue('nextInChainPtr', C_STRUCTS.WGPUChainedStruct.next, '*') }}});
 #endif
         var renderPassDescriptorMaxDrawCount = nextInChainPtr;
         {{{ gpu.makeCheckDescriptor('renderPassDescriptorMaxDrawCount') }}}

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -141,6 +141,8 @@
       SurfaceDescriptorFromCanvasHTMLSelector: 4,
       ShaderModuleSPIRVDescriptor: 5,
       ShaderModuleWGSLDescriptor: 6,
+      PrimitiveDepthClipControl: 7,
+      RenderPassDescriptorMaxDrawCount: 15,
     },
     QueueWorkDoneStatus: {
       Success: 0,
@@ -380,19 +382,17 @@ var LibraryWebGPU = {
       'validation',
       'out-of-memory',
     ],
-    FeatureName: {
-      0: undefined,
-      1: 'depth-clip-control',
-      2: 'depth24unorm-stencil8',
-      3: 'depth32float-stencil8',
-      4: 'timestamp-query',
-      5: 'pipeline-statistics-query',
-      6: 'texture-compression-bc',
-      7: 'texture-compression-etc2',
-      8: 'texture-compression-astc',
-      9: 'indirect-first-instance',
-      1000: 'depth-clamping',
-    },
+    FeatureName: [
+      undefined,
+      'depth-clip-control',
+      'depth32float-stencil8',
+      'timestamp-query',
+      'pipeline-statistics-query',
+      'texture-compression-bc',
+      'texture-compression-etc2',
+      'texture-compression-astc',
+      'indirect-first-instance',
+    ],
     FilterMode: [
       'nearest',
       'linear',
@@ -422,10 +422,6 @@ var LibraryWebGPU = {
       undefined,
       'low-power',
       'high-performance',
-    ],
-    PredefinedColorSpace: [
-      undefined,
-      'srgb',
     ],
     PrimitiveTopology: [
       'point-list',
@@ -526,7 +522,6 @@ var LibraryWebGPU = {
       'depth16unorm',
       'depth24plus',
       'depth24plus-stencil8',
-      'depth24unorm-stencil8',
       'depth32float',
       'depth32float-stencil8',
       'bc1-rgba-unorm',
@@ -635,6 +630,7 @@ var LibraryWebGPU = {
     VertexStepMode: [
       'vertex',
       'instance',
+      'vertex-buffer-not-used',
     ],
   },
 
@@ -725,6 +721,8 @@ var LibraryWebGPU = {
     setLimitValueU32('maxVertexAttributes', {{{ C_STRUCTS.WGPULimits.maxVertexAttributes }}});
     setLimitValueU32('maxVertexBufferArrayStride', {{{ C_STRUCTS.WGPULimits.maxVertexBufferArrayStride }}});
     setLimitValueU32('maxInterStageShaderComponents', {{{ C_STRUCTS.WGPULimits.maxInterStageShaderComponents }}});
+    setLimitValueU32('maxInterStageShaderVariables', {{{ C_STRUCTS.WGPULimits.maxInterStageShaderVariables }}});
+    setLimitValueU32('maxColorAttachments', {{{ C_STRUCTS.WGPULimits.maxColorAttachments }}});
     setLimitValueU32('maxComputeWorkgroupStorageSize', {{{ C_STRUCTS.WGPULimits.maxComputeWorkgroupStorageSize }}});
     setLimitValueU32('maxComputeInvocationsPerWorkgroup', {{{ C_STRUCTS.WGPULimits.maxComputeInvocationsPerWorkgroup }}});
     setLimitValueU32('maxComputeWorkgroupSizeX', {{{ C_STRUCTS.WGPULimits.maxComputeWorkgroupSizeX }}});
@@ -1450,6 +1448,16 @@ var LibraryWebGPU = {
 
   // wgpuQuerySet
 
+  wgpuQuerySetGetCount: function(querySetId) {
+    var querySet = WebGPU.mgrQuerySet.get(querySetId);
+    return querySet.count;
+  },
+
+  wgpuQuerySetSetGetType: function(querySetId, labelPtr) {
+    var querySet = WebGPU.mgrQuerySet.get(querySetId);
+    return querySet.type;
+  },
+
   wgpuQuerySetSetLabel: function(querySetId, labelPtr) {
     var querySet = WebGPU.mgrQuerySet.get(querySetId);
     querySet.label = UTF8ToString(labelPtr);
@@ -1620,6 +1628,10 @@ var LibraryWebGPU = {
       };
     }
 
+    function makeRenderPassDescriptorMaxDrawCount(mdcPtr) {
+        return  {{{ gpu.makeGetU64('mdcPtr', C_STRUCTS.WGPURenderPassDescriptorMaxDrawCount.maxDrawCount) }}};
+    }
+
     function makeRenderPassTimestampWrite(twPtr) {
       return {
         "querySet": WebGPU.mgrQuerySet.get(
@@ -1639,7 +1651,21 @@ var LibraryWebGPU = {
     }
 
     function makeRenderPassDescriptor(descriptor) {
-      {{{ gpu.makeCheckDescriptor('descriptor') }}}
+      {{{ gpu.makeCheck('descriptor') }}}
+      var nextInChainPtr = {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPassDescriptor.nextInChain, '*') }}};
+      
+      var maxDrawCount = undefined;
+      if (nextInChainPtr !== 0) {
+        var sType = {{{ gpu.makeGetU32('nextInChainPtr', C_STRUCTS.WGPUChainedStruct.sType) }}};
+#if ASSERTIONS
+        assert(sType === {{{ gpu.SType.RenderPassDescriptorMaxDrawCount }}});
+#endif
+        var renderPassDescriptorMaxDrawCount = nextInChainPtr;
+        {{{ gpu.makeCheckDescriptor('renderPassDescriptorMaxDrawCount') }}}
+        maxDrawCount = makeRenderPassDescriptorMaxDrawCount(
+          {{{ makeGetValue('renderPassDescriptorMaxDrawCount', C_STRUCTS.WGPUSurfaceDescriptorFromCanvasHTMLSelector.selector, '*') }}});
+      }
+
       var desc = {
         "label": undefined,
         "colorAttachments": makeColorAttachments(
@@ -1658,6 +1684,10 @@ var LibraryWebGPU = {
         desc["timestampWrites"] = makeRenderPassTimestampWrites(
           timestampWriteCount,
           {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPassDescriptor.timestampWrites, '*') }}});
+      }
+
+      if (maxDrawCount) {
+        desc["maxDrawCount"] = maxDrawCount;
       }
       return desc;
     }
@@ -1917,6 +1947,17 @@ var LibraryWebGPU = {
     });
   },
 
+  wgpuBufferGetSize: function(bufferId) {
+    var buffer = WebGPU.mgrBuffer.get(bufferId);
+    // 64-bit
+    return buffer.size;
+  },
+
+  wgpuBufferGetUsage: function(bufferId) {
+    var buffer = WebGPU.mgrBuffer.get(bufferId);
+    return buffer.usage;
+  },
+
   wgpuBufferSetLabel: function(bufferId, labelPtr) {
     var buffer = WebGPU.mgrBuffer.get(bufferId);
     buffer.label = UTF8ToString(labelPtr);
@@ -1940,6 +1981,46 @@ var LibraryWebGPU = {
   },
 
   // wgpuTexture
+
+  wgpuTextureGetDepthOrArrayLayers: function(textureId) {
+    var texture = WebGPU.mgrTexture.get(textureId);
+    return texture.depthOrArrayLayers;
+  },
+
+  wgpuTextureGetDimension: function(textureId) {
+    var texture = WebGPU.mgrTexture.get(textureId);
+    return texture.dimension;
+  },
+
+  wgpuTextureGetFormat: function(textureId) {
+    var texture = WebGPU.mgrTexture.get(textureId);
+    return texture.format;
+  },
+
+  wgpuTextureGetHeight: function(textureId) {
+    var texture = WebGPU.mgrTexture.get(textureId);
+    return texture.height;
+  },
+
+  wgpuTextureGetMipLevelCount: function(textureId) {
+    var texture = WebGPU.mgrTexture.get(textureId);
+    return texture.mipLevelCount;
+  },
+
+  wgpuTextureGetSampleCount: function(textureId) {
+    var texture = WebGPU.mgrTexture.get(textureId);
+    return texture.sampleCount;
+  },
+
+  wgpuTextureGetUsage: function(textureId) {
+    var texture = WebGPU.mgrTexture.get(textureId);
+    return texture.usage;
+  },
+
+  wgpuTextureGetWidth: function(textureId) {
+    var texture = WebGPU.mgrTexture.get(textureId);
+    return texture.width;
+  },
 
   wgpuTextureSetLabel: function(textureId, labelPtr) {
     var texture = WebGPU.mgrTexture.get(textureId);
@@ -2412,6 +2493,8 @@ var LibraryWebGPU = {
   wgpuAdapterGetProperties: function(adapterId, properties) {
     {{{ gpu.makeCheckDescriptor('properties') }}}
     {{{ makeSetValue('properties', C_STRUCTS.WGPUAdapterProperties.vendorID, '0', 'i32') }}};
+    {{{ makeSetValue('properties', C_STRUCTS.WGPUAdapterProperties.vendorName, '0', 'i32') }}};
+    {{{ makeSetValue('properties', C_STRUCTS.WGPUAdapterProperties.architecture, '0', 'i32') }}};
     {{{ makeSetValue('properties', C_STRUCTS.WGPUAdapterProperties.deviceID, '0', 'i32') }}};
     {{{ makeSetValue('properties', C_STRUCTS.WGPUAdapterProperties.name, '0', 'i32') }}};
     {{{ makeSetValue('properties', C_STRUCTS.WGPUAdapterProperties.driverDescription, '0', 'i32') }}};
@@ -2483,6 +2566,8 @@ var LibraryWebGPU = {
         setLimitU32IfDefined("maxVertexAttributes", {{{ C_STRUCTS.WGPULimits.maxVertexAttributes }}});
         setLimitU32IfDefined("maxVertexBufferArrayStride", {{{ C_STRUCTS.WGPULimits.maxVertexBufferArrayStride }}});
         setLimitU32IfDefined("maxInterStageShaderComponents", {{{ C_STRUCTS.WGPULimits.maxInterStageShaderComponents }}});
+        setLimitU32IfDefined("maxInterStageShaderVariables", {{{ C_STRUCTS.WGPULimits.maxInterStageShaderVariables }}});
+        setLimitU32IfDefined("maxColorAttachments", {{{ C_STRUCTS.WGPULimits.maxColorAttachments }}});
         setLimitU32IfDefined("maxComputeWorkgroupStorageSize", {{{ C_STRUCTS.WGPULimits.maxComputeWorkgroupStorageSize }}});
         setLimitU32IfDefined("maxComputeInvocationsPerWorkgroup", {{{ C_STRUCTS.WGPULimits.maxComputeInvocationsPerWorkgroup }}});
         setLimitU32IfDefined("maxComputeWorkgroupSizeX", {{{ C_STRUCTS.WGPULimits.maxComputeWorkgroupSizeX }}});

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1041,6 +1041,8 @@
             "WGPUAdapterProperties": [
                 "nextInChain",
                 "vendorID",
+                "vendorName",
+                "architecture",
                 "deviceID",
                 "name",
                 "driverDescription",
@@ -1136,6 +1138,8 @@
                 "maxVertexAttributes",
                 "maxVertexBufferArrayStride",
                 "maxInterStageShaderComponents",
+                "maxInterStageShaderVariables",
+                "maxColorAttachments",
                 "maxComputeWorkgroupStorageSize",
                 "maxComputeInvocationsPerWorkgroup",
                 "maxComputeWorkgroupSizeX",
@@ -1159,10 +1163,6 @@
                 "label",
                 "bindGroupLayoutCount",
                 "bindGroupLayouts"
-            ],
-            "WGPUPrimitiveDepthClampingState": [
-                "chain",
-                "clampDepth"
             ],
             "WGPUPrimitiveDepthClipControl": [
                 "chain",
@@ -1211,6 +1211,10 @@
                 "stencilStoreOp",
                 "stencilClearValue",
                 "stencilReadOnly"
+            ],
+            "WGPURenderPassDescriptorMaxDrawCount": [
+                "chain",
+                "maxDrawCount"
             ],
             "WGPURenderPassTimestampWrite": [
                 "querySet",

--- a/system/include/webgpu/webgpu.h
+++ b/system/include/webgpu/webgpu.h
@@ -231,15 +231,13 @@ typedef enum WGPUErrorType {
 typedef enum WGPUFeatureName {
     WGPUFeatureName_Undefined = 0x00000000,
     WGPUFeatureName_DepthClipControl = 0x00000001,
-    WGPUFeatureName_Depth24UnormStencil8 = 0x00000002,
-    WGPUFeatureName_Depth32FloatStencil8 = 0x00000003,
-    WGPUFeatureName_TimestampQuery = 0x00000004,
-    WGPUFeatureName_PipelineStatisticsQuery = 0x00000005,
-    WGPUFeatureName_TextureCompressionBC = 0x00000006,
-    WGPUFeatureName_TextureCompressionETC2 = 0x00000007,
-    WGPUFeatureName_TextureCompressionASTC = 0x00000008,
-    WGPUFeatureName_IndirectFirstInstance = 0x00000009,
-    WGPUFeatureName_DepthClamping = 0x000003E8,
+    WGPUFeatureName_Depth32FloatStencil8 = 0x00000002,
+    WGPUFeatureName_TimestampQuery = 0x00000003,
+    WGPUFeatureName_PipelineStatisticsQuery = 0x00000004,
+    WGPUFeatureName_TextureCompressionBC = 0x00000005,
+    WGPUFeatureName_TextureCompressionETC2 = 0x00000006,
+    WGPUFeatureName_TextureCompressionASTC = 0x00000007,
+    WGPUFeatureName_IndirectFirstInstance = 0x00000008,
     WGPUFeatureName_Force32 = 0x7FFFFFFF
 } WGPUFeatureName;
 
@@ -284,12 +282,6 @@ typedef enum WGPUPowerPreference {
     WGPUPowerPreference_HighPerformance = 0x00000002,
     WGPUPowerPreference_Force32 = 0x7FFFFFFF
 } WGPUPowerPreference;
-
-typedef enum WGPUPredefinedColorSpace {
-    WGPUPredefinedColorSpace_Undefined = 0x00000000,
-    WGPUPredefinedColorSpace_Srgb = 0x00000001,
-    WGPUPredefinedColorSpace_Force32 = 0x7FFFFFFF
-} WGPUPredefinedColorSpace;
 
 typedef enum WGPUPresentMode {
     WGPUPresentMode_Immediate = 0x00000000,
@@ -349,7 +341,7 @@ typedef enum WGPUSType {
     WGPUSType_ShaderModuleSPIRVDescriptor = 0x00000005,
     WGPUSType_ShaderModuleWGSLDescriptor = 0x00000006,
     WGPUSType_PrimitiveDepthClipControl = 0x00000007,
-    WGPUSType_PrimitiveDepthClampingState = 0x000003E9,
+    WGPUSType_RenderPassDescriptorMaxDrawCount = 0x0000000F,
     WGPUSType_Force32 = 0x7FFFFFFF
 } WGPUSType;
 
@@ -450,61 +442,60 @@ typedef enum WGPUTextureFormat {
     WGPUTextureFormat_Depth16Unorm = 0x00000026,
     WGPUTextureFormat_Depth24Plus = 0x00000027,
     WGPUTextureFormat_Depth24PlusStencil8 = 0x00000028,
-    WGPUTextureFormat_Depth24UnormStencil8 = 0x00000029,
-    WGPUTextureFormat_Depth32Float = 0x0000002A,
-    WGPUTextureFormat_Depth32FloatStencil8 = 0x0000002B,
-    WGPUTextureFormat_BC1RGBAUnorm = 0x0000002C,
-    WGPUTextureFormat_BC1RGBAUnormSrgb = 0x0000002D,
-    WGPUTextureFormat_BC2RGBAUnorm = 0x0000002E,
-    WGPUTextureFormat_BC2RGBAUnormSrgb = 0x0000002F,
-    WGPUTextureFormat_BC3RGBAUnorm = 0x00000030,
-    WGPUTextureFormat_BC3RGBAUnormSrgb = 0x00000031,
-    WGPUTextureFormat_BC4RUnorm = 0x00000032,
-    WGPUTextureFormat_BC4RSnorm = 0x00000033,
-    WGPUTextureFormat_BC5RGUnorm = 0x00000034,
-    WGPUTextureFormat_BC5RGSnorm = 0x00000035,
-    WGPUTextureFormat_BC6HRGBUfloat = 0x00000036,
-    WGPUTextureFormat_BC6HRGBFloat = 0x00000037,
-    WGPUTextureFormat_BC7RGBAUnorm = 0x00000038,
-    WGPUTextureFormat_BC7RGBAUnormSrgb = 0x00000039,
-    WGPUTextureFormat_ETC2RGB8Unorm = 0x0000003A,
-    WGPUTextureFormat_ETC2RGB8UnormSrgb = 0x0000003B,
-    WGPUTextureFormat_ETC2RGB8A1Unorm = 0x0000003C,
-    WGPUTextureFormat_ETC2RGB8A1UnormSrgb = 0x0000003D,
-    WGPUTextureFormat_ETC2RGBA8Unorm = 0x0000003E,
-    WGPUTextureFormat_ETC2RGBA8UnormSrgb = 0x0000003F,
-    WGPUTextureFormat_EACR11Unorm = 0x00000040,
-    WGPUTextureFormat_EACR11Snorm = 0x00000041,
-    WGPUTextureFormat_EACRG11Unorm = 0x00000042,
-    WGPUTextureFormat_EACRG11Snorm = 0x00000043,
-    WGPUTextureFormat_ASTC4x4Unorm = 0x00000044,
-    WGPUTextureFormat_ASTC4x4UnormSrgb = 0x00000045,
-    WGPUTextureFormat_ASTC5x4Unorm = 0x00000046,
-    WGPUTextureFormat_ASTC5x4UnormSrgb = 0x00000047,
-    WGPUTextureFormat_ASTC5x5Unorm = 0x00000048,
-    WGPUTextureFormat_ASTC5x5UnormSrgb = 0x00000049,
-    WGPUTextureFormat_ASTC6x5Unorm = 0x0000004A,
-    WGPUTextureFormat_ASTC6x5UnormSrgb = 0x0000004B,
-    WGPUTextureFormat_ASTC6x6Unorm = 0x0000004C,
-    WGPUTextureFormat_ASTC6x6UnormSrgb = 0x0000004D,
-    WGPUTextureFormat_ASTC8x5Unorm = 0x0000004E,
-    WGPUTextureFormat_ASTC8x5UnormSrgb = 0x0000004F,
-    WGPUTextureFormat_ASTC8x6Unorm = 0x00000050,
-    WGPUTextureFormat_ASTC8x6UnormSrgb = 0x00000051,
-    WGPUTextureFormat_ASTC8x8Unorm = 0x00000052,
-    WGPUTextureFormat_ASTC8x8UnormSrgb = 0x00000053,
-    WGPUTextureFormat_ASTC10x5Unorm = 0x00000054,
-    WGPUTextureFormat_ASTC10x5UnormSrgb = 0x00000055,
-    WGPUTextureFormat_ASTC10x6Unorm = 0x00000056,
-    WGPUTextureFormat_ASTC10x6UnormSrgb = 0x00000057,
-    WGPUTextureFormat_ASTC10x8Unorm = 0x00000058,
-    WGPUTextureFormat_ASTC10x8UnormSrgb = 0x00000059,
-    WGPUTextureFormat_ASTC10x10Unorm = 0x0000005A,
-    WGPUTextureFormat_ASTC10x10UnormSrgb = 0x0000005B,
-    WGPUTextureFormat_ASTC12x10Unorm = 0x0000005C,
-    WGPUTextureFormat_ASTC12x10UnormSrgb = 0x0000005D,
-    WGPUTextureFormat_ASTC12x12Unorm = 0x0000005E,
-    WGPUTextureFormat_ASTC12x12UnormSrgb = 0x0000005F,
+    WGPUTextureFormat_Depth32Float = 0x00000029,
+    WGPUTextureFormat_Depth32FloatStencil8 = 0x0000002A,
+    WGPUTextureFormat_BC1RGBAUnorm = 0x0000002B,
+    WGPUTextureFormat_BC1RGBAUnormSrgb = 0x0000002C,
+    WGPUTextureFormat_BC2RGBAUnorm = 0x0000002D,
+    WGPUTextureFormat_BC2RGBAUnormSrgb = 0x0000002E,
+    WGPUTextureFormat_BC3RGBAUnorm = 0x0000002F,
+    WGPUTextureFormat_BC3RGBAUnormSrgb = 0x00000030,
+    WGPUTextureFormat_BC4RUnorm = 0x00000031,
+    WGPUTextureFormat_BC4RSnorm = 0x00000032,
+    WGPUTextureFormat_BC5RGUnorm = 0x00000033,
+    WGPUTextureFormat_BC5RGSnorm = 0x00000034,
+    WGPUTextureFormat_BC6HRGBUfloat = 0x00000035,
+    WGPUTextureFormat_BC6HRGBFloat = 0x00000036,
+    WGPUTextureFormat_BC7RGBAUnorm = 0x00000037,
+    WGPUTextureFormat_BC7RGBAUnormSrgb = 0x00000038,
+    WGPUTextureFormat_ETC2RGB8Unorm = 0x00000039,
+    WGPUTextureFormat_ETC2RGB8UnormSrgb = 0x0000003A,
+    WGPUTextureFormat_ETC2RGB8A1Unorm = 0x0000003B,
+    WGPUTextureFormat_ETC2RGB8A1UnormSrgb = 0x0000003C,
+    WGPUTextureFormat_ETC2RGBA8Unorm = 0x0000003D,
+    WGPUTextureFormat_ETC2RGBA8UnormSrgb = 0x0000003E,
+    WGPUTextureFormat_EACR11Unorm = 0x0000003F,
+    WGPUTextureFormat_EACR11Snorm = 0x00000040,
+    WGPUTextureFormat_EACRG11Unorm = 0x00000041,
+    WGPUTextureFormat_EACRG11Snorm = 0x00000042,
+    WGPUTextureFormat_ASTC4x4Unorm = 0x00000043,
+    WGPUTextureFormat_ASTC4x4UnormSrgb = 0x00000044,
+    WGPUTextureFormat_ASTC5x4Unorm = 0x00000045,
+    WGPUTextureFormat_ASTC5x4UnormSrgb = 0x00000046,
+    WGPUTextureFormat_ASTC5x5Unorm = 0x00000047,
+    WGPUTextureFormat_ASTC5x5UnormSrgb = 0x00000048,
+    WGPUTextureFormat_ASTC6x5Unorm = 0x00000049,
+    WGPUTextureFormat_ASTC6x5UnormSrgb = 0x0000004A,
+    WGPUTextureFormat_ASTC6x6Unorm = 0x0000004B,
+    WGPUTextureFormat_ASTC6x6UnormSrgb = 0x0000004C,
+    WGPUTextureFormat_ASTC8x5Unorm = 0x0000004D,
+    WGPUTextureFormat_ASTC8x5UnormSrgb = 0x0000004E,
+    WGPUTextureFormat_ASTC8x6Unorm = 0x0000004F,
+    WGPUTextureFormat_ASTC8x6UnormSrgb = 0x00000050,
+    WGPUTextureFormat_ASTC8x8Unorm = 0x00000051,
+    WGPUTextureFormat_ASTC8x8UnormSrgb = 0x00000052,
+    WGPUTextureFormat_ASTC10x5Unorm = 0x00000053,
+    WGPUTextureFormat_ASTC10x5UnormSrgb = 0x00000054,
+    WGPUTextureFormat_ASTC10x6Unorm = 0x00000055,
+    WGPUTextureFormat_ASTC10x6UnormSrgb = 0x00000056,
+    WGPUTextureFormat_ASTC10x8Unorm = 0x00000057,
+    WGPUTextureFormat_ASTC10x8UnormSrgb = 0x00000058,
+    WGPUTextureFormat_ASTC10x10Unorm = 0x00000059,
+    WGPUTextureFormat_ASTC10x10UnormSrgb = 0x0000005A,
+    WGPUTextureFormat_ASTC12x10Unorm = 0x0000005B,
+    WGPUTextureFormat_ASTC12x10UnormSrgb = 0x0000005C,
+    WGPUTextureFormat_ASTC12x12Unorm = 0x0000005D,
+    WGPUTextureFormat_ASTC12x12UnormSrgb = 0x0000005E,
     WGPUTextureFormat_Force32 = 0x7FFFFFFF
 } WGPUTextureFormat;
 
@@ -567,6 +558,7 @@ typedef enum WGPUVertexFormat {
 typedef enum WGPUVertexStepMode {
     WGPUVertexStepMode_Vertex = 0x00000000,
     WGPUVertexStepMode_Instance = 0x00000001,
+    WGPUVertexStepMode_VertexBufferNotUsed = 0x00000002,
     WGPUVertexStepMode_Force32 = 0x7FFFFFFF
 } WGPUVertexStepMode;
 
@@ -638,6 +630,8 @@ typedef struct WGPUChainedStructOut {
 typedef struct WGPUAdapterProperties {
     WGPUChainedStructOut * nextInChain;
     uint32_t vendorID;
+    char const * vendorName;
+    char const * architecture;
     uint32_t deviceID;
     char const * name;
     char const * driverDescription;
@@ -648,11 +642,11 @@ typedef struct WGPUAdapterProperties {
 typedef struct WGPUBindGroupEntry {
     WGPUChainedStruct const * nextInChain;
     uint32_t binding;
-    WGPUBuffer buffer;
+    WGPUBuffer buffer; // nullable
     uint64_t offset;
     uint64_t size;
-    WGPUSampler sampler;
-    WGPUTextureView textureView;
+    WGPUSampler sampler; // nullable
+    WGPUTextureView textureView; // nullable
 } WGPUBindGroupEntry;
 
 typedef struct WGPUBlendComponent {
@@ -670,7 +664,7 @@ typedef struct WGPUBufferBindingLayout {
 
 typedef struct WGPUBufferDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
     WGPUBufferUsageFlags usage;
     uint64_t size;
     bool mappedAtCreation;
@@ -685,17 +679,17 @@ typedef struct WGPUColor {
 
 typedef struct WGPUCommandBufferDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
 } WGPUCommandBufferDescriptor;
 
 typedef struct WGPUCommandEncoderDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
 } WGPUCommandEncoderDescriptor;
 
 typedef struct WGPUCompilationMessage {
     WGPUChainedStruct const * nextInChain;
-    char const * message;
+    char const * message; // nullable
     WGPUCompilationMessageType type;
     uint64_t lineNum;
     uint64_t linePos;
@@ -746,6 +740,8 @@ typedef struct WGPULimits {
     uint32_t maxVertexAttributes;
     uint32_t maxVertexBufferArrayStride;
     uint32_t maxInterStageShaderComponents;
+    uint32_t maxInterStageShaderVariables;
+    uint32_t maxColorAttachments;
     uint32_t maxComputeWorkgroupStorageSize;
     uint32_t maxComputeInvocationsPerWorkgroup;
     uint32_t maxComputeWorkgroupSizeX;
@@ -769,16 +765,12 @@ typedef struct WGPUOrigin3D {
 
 typedef struct WGPUPipelineLayoutDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
     uint32_t bindGroupLayoutCount;
     WGPUBindGroupLayout const * bindGroupLayouts;
 } WGPUPipelineLayoutDescriptor;
 
-typedef struct WGPUPrimitiveDepthClampingState {
-    WGPUChainedStruct chain;
-    bool clampDepth;
-} WGPUPrimitiveDepthClampingState;
-
+// Can be chained in WGPUPrimitiveState
 typedef struct WGPUPrimitiveDepthClipControl {
     WGPUChainedStruct chain;
     bool unclippedDepth;
@@ -794,7 +786,7 @@ typedef struct WGPUPrimitiveState {
 
 typedef struct WGPUQuerySetDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
     WGPUQueryType type;
     uint32_t count;
     WGPUPipelineStatisticName const * pipelineStatistics;
@@ -803,17 +795,17 @@ typedef struct WGPUQuerySetDescriptor {
 
 typedef struct WGPUQueueDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
 } WGPUQueueDescriptor;
 
 typedef struct WGPURenderBundleDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
 } WGPURenderBundleDescriptor;
 
 typedef struct WGPURenderBundleEncoderDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
     uint32_t colorFormatsCount;
     WGPUTextureFormat const * colorFormats;
     WGPUTextureFormat depthStencilFormat;
@@ -834,6 +826,12 @@ typedef struct WGPURenderPassDepthStencilAttachment {
     bool stencilReadOnly;
 } WGPURenderPassDepthStencilAttachment;
 
+// Can be chained in WGPURenderPassDescriptor
+typedef struct WGPURenderPassDescriptorMaxDrawCount {
+    WGPUChainedStruct chain;
+    uint64_t maxDrawCount;
+} WGPURenderPassDescriptorMaxDrawCount;
+
 typedef struct WGPURenderPassTimestampWrite {
     WGPUQuerySet querySet;
     uint32_t queryIndex;
@@ -842,7 +840,7 @@ typedef struct WGPURenderPassTimestampWrite {
 
 typedef struct WGPURequestAdapterOptions {
     WGPUChainedStruct const * nextInChain;
-    WGPUSurface compatibleSurface;
+    WGPUSurface compatibleSurface; // nullable
     WGPUPowerPreference powerPreference;
     bool forceFallbackAdapter;
 } WGPURequestAdapterOptions;
@@ -854,7 +852,7 @@ typedef struct WGPUSamplerBindingLayout {
 
 typedef struct WGPUSamplerDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
     WGPUAddressMode addressModeU;
     WGPUAddressMode addressModeV;
     WGPUAddressMode addressModeW;
@@ -869,15 +867,17 @@ typedef struct WGPUSamplerDescriptor {
 
 typedef struct WGPUShaderModuleDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
 } WGPUShaderModuleDescriptor;
 
+// Can be chained in WGPUShaderModuleDescriptor
 typedef struct WGPUShaderModuleSPIRVDescriptor {
     WGPUChainedStruct chain;
     uint32_t codeSize;
     uint32_t const * code;
 } WGPUShaderModuleSPIRVDescriptor;
 
+// Can be chained in WGPUShaderModuleDescriptor
 typedef struct WGPUShaderModuleWGSLDescriptor {
     WGPUChainedStruct chain;
     char const * source;
@@ -899,9 +899,10 @@ typedef struct WGPUStorageTextureBindingLayout {
 
 typedef struct WGPUSurfaceDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
 } WGPUSurfaceDescriptor;
 
+// Can be chained in WGPUSurfaceDescriptor
 typedef struct WGPUSurfaceDescriptorFromCanvasHTMLSelector {
     WGPUChainedStruct chain;
     char const * selector;
@@ -909,7 +910,7 @@ typedef struct WGPUSurfaceDescriptorFromCanvasHTMLSelector {
 
 typedef struct WGPUSwapChainDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
     WGPUTextureUsageFlags usage;
     WGPUTextureFormat format;
     uint32_t width;
@@ -933,7 +934,7 @@ typedef struct WGPUTextureDataLayout {
 
 typedef struct WGPUTextureViewDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
     WGPUTextureFormat format;
     WGPUTextureViewDimension dimension;
     uint32_t baseMipLevel;
@@ -951,7 +952,7 @@ typedef struct WGPUVertexAttribute {
 
 typedef struct WGPUBindGroupDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
     WGPUBindGroupLayout layout;
     uint32_t entryCount;
     WGPUBindGroupEntry const * entries;
@@ -980,7 +981,7 @@ typedef struct WGPUCompilationInfo {
 
 typedef struct WGPUComputePassDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
     uint32_t timestampWriteCount;
     WGPUComputePassTimestampWrite const * timestampWrites;
 } WGPUComputePassDescriptor;
@@ -1022,8 +1023,8 @@ typedef struct WGPUProgrammableStageDescriptor {
 } WGPUProgrammableStageDescriptor;
 
 typedef struct WGPURenderPassColorAttachment {
-    WGPUTextureView view;
-    WGPUTextureView resolveTarget;
+    WGPUTextureView view; // nullable
+    WGPUTextureView resolveTarget; // nullable
     WGPULoadOp loadOp;
     WGPUStoreOp storeOp;
     WGPUColor clearValue;
@@ -1041,7 +1042,7 @@ typedef struct WGPUSupportedLimits {
 
 typedef struct WGPUTextureDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
     WGPUTextureUsageFlags usage;
     WGPUTextureDimension dimension;
     WGPUExtent3D size;
@@ -1061,7 +1062,7 @@ typedef struct WGPUVertexBufferLayout {
 
 typedef struct WGPUBindGroupLayoutDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
     uint32_t entryCount;
     WGPUBindGroupLayoutEntry const * entries;
 } WGPUBindGroupLayoutDescriptor;
@@ -1069,33 +1070,33 @@ typedef struct WGPUBindGroupLayoutDescriptor {
 typedef struct WGPUColorTargetState {
     WGPUChainedStruct const * nextInChain;
     WGPUTextureFormat format;
-    WGPUBlendState const * blend;
+    WGPUBlendState const * blend; // nullable
     WGPUColorWriteMaskFlags writeMask;
 } WGPUColorTargetState;
 
 typedef struct WGPUComputePipelineDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
-    WGPUPipelineLayout layout;
+    char const * label; // nullable
+    WGPUPipelineLayout layout; // nullable
     WGPUProgrammableStageDescriptor compute;
 } WGPUComputePipelineDescriptor;
 
 typedef struct WGPUDeviceDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
     uint32_t requiredFeaturesCount;
     WGPUFeatureName const * requiredFeatures;
-    WGPURequiredLimits const * requiredLimits;
+    WGPURequiredLimits const * requiredLimits; // nullable
     WGPUQueueDescriptor defaultQueue;
 } WGPUDeviceDescriptor;
 
 typedef struct WGPURenderPassDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
+    char const * label; // nullable
     uint32_t colorAttachmentCount;
     WGPURenderPassColorAttachment const * colorAttachments;
-    WGPURenderPassDepthStencilAttachment const * depthStencilAttachment;
-    WGPUQuerySet occlusionQuerySet;
+    WGPURenderPassDepthStencilAttachment const * depthStencilAttachment; // nullable
+    WGPUQuerySet occlusionQuerySet; // nullable
     uint32_t timestampWriteCount;
     WGPURenderPassTimestampWrite const * timestampWrites;
 } WGPURenderPassDescriptor;
@@ -1122,13 +1123,13 @@ typedef struct WGPUFragmentState {
 
 typedef struct WGPURenderPipelineDescriptor {
     WGPUChainedStruct const * nextInChain;
-    char const * label;
-    WGPUPipelineLayout layout;
+    char const * label; // nullable
+    WGPUPipelineLayout layout; // nullable
     WGPUVertexState vertex;
     WGPUPrimitiveState primitive;
-    WGPUDepthStencilState const * depthStencil;
+    WGPUDepthStencilState const * depthStencil; // nullable
     WGPUMultisampleState multisample;
-    WGPUFragmentState const * fragment;
+    WGPUFragmentState const * fragment; // nullable
 } WGPURenderPipelineDescriptor;
 
 #ifdef __cplusplus
@@ -1174,6 +1175,8 @@ typedef void (*WGPUProcBindGroupLayoutRelease)(WGPUBindGroupLayout bindGroupLayo
 typedef void (*WGPUProcBufferDestroy)(WGPUBuffer buffer);
 typedef void const * (*WGPUProcBufferGetConstMappedRange)(WGPUBuffer buffer, size_t offset, size_t size);
 typedef void * (*WGPUProcBufferGetMappedRange)(WGPUBuffer buffer, size_t offset, size_t size);
+typedef uint64_t (*WGPUProcBufferGetSize)(WGPUBuffer buffer);
+typedef WGPUBufferUsage (*WGPUProcBufferGetUsage)(WGPUBuffer buffer);
 typedef void (*WGPUProcBufferMapAsync)(WGPUBuffer buffer, WGPUMapModeFlags mode, size_t offset, size_t size, WGPUBufferMapCallback callback, void * userdata);
 typedef void (*WGPUProcBufferSetLabel)(WGPUBuffer buffer, char const * label);
 typedef void (*WGPUProcBufferUnmap)(WGPUBuffer buffer);
@@ -1186,14 +1189,14 @@ typedef void (*WGPUProcCommandBufferReference)(WGPUCommandBuffer commandBuffer);
 typedef void (*WGPUProcCommandBufferRelease)(WGPUCommandBuffer commandBuffer);
 
 // Procs of CommandEncoder
-typedef WGPUComputePassEncoder (*WGPUProcCommandEncoderBeginComputePass)(WGPUCommandEncoder commandEncoder, WGPUComputePassDescriptor const * descriptor);
+typedef WGPUComputePassEncoder (*WGPUProcCommandEncoderBeginComputePass)(WGPUCommandEncoder commandEncoder, WGPUComputePassDescriptor const * descriptor /* nullable */);
 typedef WGPURenderPassEncoder (*WGPUProcCommandEncoderBeginRenderPass)(WGPUCommandEncoder commandEncoder, WGPURenderPassDescriptor const * descriptor);
 typedef void (*WGPUProcCommandEncoderClearBuffer)(WGPUCommandEncoder commandEncoder, WGPUBuffer buffer, uint64_t offset, uint64_t size);
 typedef void (*WGPUProcCommandEncoderCopyBufferToBuffer)(WGPUCommandEncoder commandEncoder, WGPUBuffer source, uint64_t sourceOffset, WGPUBuffer destination, uint64_t destinationOffset, uint64_t size);
 typedef void (*WGPUProcCommandEncoderCopyBufferToTexture)(WGPUCommandEncoder commandEncoder, WGPUImageCopyBuffer const * source, WGPUImageCopyTexture const * destination, WGPUExtent3D const * copySize);
 typedef void (*WGPUProcCommandEncoderCopyTextureToBuffer)(WGPUCommandEncoder commandEncoder, WGPUImageCopyTexture const * source, WGPUImageCopyBuffer const * destination, WGPUExtent3D const * copySize);
 typedef void (*WGPUProcCommandEncoderCopyTextureToTexture)(WGPUCommandEncoder commandEncoder, WGPUImageCopyTexture const * source, WGPUImageCopyTexture const * destination, WGPUExtent3D const * copySize);
-typedef WGPUCommandBuffer (*WGPUProcCommandEncoderFinish)(WGPUCommandEncoder commandEncoder, WGPUCommandBufferDescriptor const * descriptor);
+typedef WGPUCommandBuffer (*WGPUProcCommandEncoderFinish)(WGPUCommandEncoder commandEncoder, WGPUCommandBufferDescriptor const * descriptor /* nullable */);
 typedef void (*WGPUProcCommandEncoderInsertDebugMarker)(WGPUCommandEncoder commandEncoder, char const * markerLabel);
 typedef void (*WGPUProcCommandEncoderPopDebugGroup)(WGPUCommandEncoder commandEncoder);
 typedef void (*WGPUProcCommandEncoderPushDebugGroup)(WGPUCommandEncoder commandEncoder, char const * groupLabel);
@@ -1229,7 +1232,7 @@ typedef void (*WGPUProcComputePipelineRelease)(WGPUComputePipeline computePipeli
 typedef WGPUBindGroup (*WGPUProcDeviceCreateBindGroup)(WGPUDevice device, WGPUBindGroupDescriptor const * descriptor);
 typedef WGPUBindGroupLayout (*WGPUProcDeviceCreateBindGroupLayout)(WGPUDevice device, WGPUBindGroupLayoutDescriptor const * descriptor);
 typedef WGPUBuffer (*WGPUProcDeviceCreateBuffer)(WGPUDevice device, WGPUBufferDescriptor const * descriptor);
-typedef WGPUCommandEncoder (*WGPUProcDeviceCreateCommandEncoder)(WGPUDevice device, WGPUCommandEncoderDescriptor const * descriptor);
+typedef WGPUCommandEncoder (*WGPUProcDeviceCreateCommandEncoder)(WGPUDevice device, WGPUCommandEncoderDescriptor const * descriptor /* nullable */);
 typedef WGPUComputePipeline (*WGPUProcDeviceCreateComputePipeline)(WGPUDevice device, WGPUComputePipelineDescriptor const * descriptor);
 typedef void (*WGPUProcDeviceCreateComputePipelineAsync)(WGPUDevice device, WGPUComputePipelineDescriptor const * descriptor, WGPUCreateComputePipelineAsyncCallback callback, void * userdata);
 typedef WGPUPipelineLayout (*WGPUProcDeviceCreatePipelineLayout)(WGPUDevice device, WGPUPipelineLayoutDescriptor const * descriptor);
@@ -1237,7 +1240,7 @@ typedef WGPUQuerySet (*WGPUProcDeviceCreateQuerySet)(WGPUDevice device, WGPUQuer
 typedef WGPURenderBundleEncoder (*WGPUProcDeviceCreateRenderBundleEncoder)(WGPUDevice device, WGPURenderBundleEncoderDescriptor const * descriptor);
 typedef WGPURenderPipeline (*WGPUProcDeviceCreateRenderPipeline)(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor);
 typedef void (*WGPUProcDeviceCreateRenderPipelineAsync)(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor, WGPUCreateRenderPipelineAsyncCallback callback, void * userdata);
-typedef WGPUSampler (*WGPUProcDeviceCreateSampler)(WGPUDevice device, WGPUSamplerDescriptor const * descriptor);
+typedef WGPUSampler (*WGPUProcDeviceCreateSampler)(WGPUDevice device, WGPUSamplerDescriptor const * descriptor /* nullable */);
 typedef WGPUShaderModule (*WGPUProcDeviceCreateShaderModule)(WGPUDevice device, WGPUShaderModuleDescriptor const * descriptor);
 typedef WGPUSwapChain (*WGPUProcDeviceCreateSwapChain)(WGPUDevice device, WGPUSurface surface, WGPUSwapChainDescriptor const * descriptor);
 typedef WGPUTexture (*WGPUProcDeviceCreateTexture)(WGPUDevice device, WGPUTextureDescriptor const * descriptor);
@@ -1268,6 +1271,8 @@ typedef void (*WGPUProcPipelineLayoutRelease)(WGPUPipelineLayout pipelineLayout)
 
 // Procs of QuerySet
 typedef void (*WGPUProcQuerySetDestroy)(WGPUQuerySet querySet);
+typedef uint32_t (*WGPUProcQuerySetGetCount)(WGPUQuerySet querySet);
+typedef WGPUQueryType (*WGPUProcQuerySetGetType)(WGPUQuerySet querySet);
 typedef void (*WGPUProcQuerySetSetLabel)(WGPUQuerySet querySet, char const * label);
 typedef void (*WGPUProcQuerySetReference)(WGPUQuerySet querySet);
 typedef void (*WGPUProcQuerySetRelease)(WGPUQuerySet querySet);
@@ -1290,7 +1295,7 @@ typedef void (*WGPUProcRenderBundleEncoderDraw)(WGPURenderBundleEncoder renderBu
 typedef void (*WGPUProcRenderBundleEncoderDrawIndexed)(WGPURenderBundleEncoder renderBundleEncoder, uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance);
 typedef void (*WGPUProcRenderBundleEncoderDrawIndexedIndirect)(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset);
 typedef void (*WGPUProcRenderBundleEncoderDrawIndirect)(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset);
-typedef WGPURenderBundle (*WGPUProcRenderBundleEncoderFinish)(WGPURenderBundleEncoder renderBundleEncoder, WGPURenderBundleDescriptor const * descriptor);
+typedef WGPURenderBundle (*WGPUProcRenderBundleEncoderFinish)(WGPURenderBundleEncoder renderBundleEncoder, WGPURenderBundleDescriptor const * descriptor /* nullable */);
 typedef void (*WGPUProcRenderBundleEncoderInsertDebugMarker)(WGPURenderBundleEncoder renderBundleEncoder, char const * markerLabel);
 typedef void (*WGPUProcRenderBundleEncoderPopDebugGroup)(WGPURenderBundleEncoder renderBundleEncoder);
 typedef void (*WGPUProcRenderBundleEncoderPushDebugGroup)(WGPURenderBundleEncoder renderBundleEncoder, char const * groupLabel);
@@ -1358,8 +1363,16 @@ typedef void (*WGPUProcSwapChainReference)(WGPUSwapChain swapChain);
 typedef void (*WGPUProcSwapChainRelease)(WGPUSwapChain swapChain);
 
 // Procs of Texture
-typedef WGPUTextureView (*WGPUProcTextureCreateView)(WGPUTexture texture, WGPUTextureViewDescriptor const * descriptor);
+typedef WGPUTextureView (*WGPUProcTextureCreateView)(WGPUTexture texture, WGPUTextureViewDescriptor const * descriptor /* nullable */);
 typedef void (*WGPUProcTextureDestroy)(WGPUTexture texture);
+typedef uint32_t (*WGPUProcTextureGetDepthOrArrayLayers)(WGPUTexture texture);
+typedef WGPUTextureDimension (*WGPUProcTextureGetDimension)(WGPUTexture texture);
+typedef WGPUTextureFormat (*WGPUProcTextureGetFormat)(WGPUTexture texture);
+typedef uint32_t (*WGPUProcTextureGetHeight)(WGPUTexture texture);
+typedef uint32_t (*WGPUProcTextureGetMipLevelCount)(WGPUTexture texture);
+typedef uint32_t (*WGPUProcTextureGetSampleCount)(WGPUTexture texture);
+typedef WGPUTextureUsage (*WGPUProcTextureGetUsage)(WGPUTexture texture);
+typedef uint32_t (*WGPUProcTextureGetWidth)(WGPUTexture texture);
 typedef void (*WGPUProcTextureSetLabel)(WGPUTexture texture, char const * label);
 typedef void (*WGPUProcTextureReference)(WGPUTexture texture);
 typedef void (*WGPUProcTextureRelease)(WGPUTexture texture);
@@ -1399,6 +1412,8 @@ WGPU_EXPORT void wgpuBindGroupLayoutRelease(WGPUBindGroupLayout bindGroupLayout)
 WGPU_EXPORT void wgpuBufferDestroy(WGPUBuffer buffer);
 WGPU_EXPORT void const * wgpuBufferGetConstMappedRange(WGPUBuffer buffer, size_t offset, size_t size);
 WGPU_EXPORT void * wgpuBufferGetMappedRange(WGPUBuffer buffer, size_t offset, size_t size);
+WGPU_EXPORT uint64_t wgpuBufferGetSize(WGPUBuffer buffer);
+WGPU_EXPORT WGPUBufferUsage wgpuBufferGetUsage(WGPUBuffer buffer);
 WGPU_EXPORT void wgpuBufferMapAsync(WGPUBuffer buffer, WGPUMapModeFlags mode, size_t offset, size_t size, WGPUBufferMapCallback callback, void * userdata);
 WGPU_EXPORT void wgpuBufferSetLabel(WGPUBuffer buffer, char const * label);
 WGPU_EXPORT void wgpuBufferUnmap(WGPUBuffer buffer);
@@ -1411,14 +1426,14 @@ WGPU_EXPORT void wgpuCommandBufferReference(WGPUCommandBuffer commandBuffer);
 WGPU_EXPORT void wgpuCommandBufferRelease(WGPUCommandBuffer commandBuffer);
 
 // Methods of CommandEncoder
-WGPU_EXPORT WGPUComputePassEncoder wgpuCommandEncoderBeginComputePass(WGPUCommandEncoder commandEncoder, WGPUComputePassDescriptor const * descriptor);
+WGPU_EXPORT WGPUComputePassEncoder wgpuCommandEncoderBeginComputePass(WGPUCommandEncoder commandEncoder, WGPUComputePassDescriptor const * descriptor /* nullable */);
 WGPU_EXPORT WGPURenderPassEncoder wgpuCommandEncoderBeginRenderPass(WGPUCommandEncoder commandEncoder, WGPURenderPassDescriptor const * descriptor);
 WGPU_EXPORT void wgpuCommandEncoderClearBuffer(WGPUCommandEncoder commandEncoder, WGPUBuffer buffer, uint64_t offset, uint64_t size);
 WGPU_EXPORT void wgpuCommandEncoderCopyBufferToBuffer(WGPUCommandEncoder commandEncoder, WGPUBuffer source, uint64_t sourceOffset, WGPUBuffer destination, uint64_t destinationOffset, uint64_t size);
 WGPU_EXPORT void wgpuCommandEncoderCopyBufferToTexture(WGPUCommandEncoder commandEncoder, WGPUImageCopyBuffer const * source, WGPUImageCopyTexture const * destination, WGPUExtent3D const * copySize);
 WGPU_EXPORT void wgpuCommandEncoderCopyTextureToBuffer(WGPUCommandEncoder commandEncoder, WGPUImageCopyTexture const * source, WGPUImageCopyBuffer const * destination, WGPUExtent3D const * copySize);
 WGPU_EXPORT void wgpuCommandEncoderCopyTextureToTexture(WGPUCommandEncoder commandEncoder, WGPUImageCopyTexture const * source, WGPUImageCopyTexture const * destination, WGPUExtent3D const * copySize);
-WGPU_EXPORT WGPUCommandBuffer wgpuCommandEncoderFinish(WGPUCommandEncoder commandEncoder, WGPUCommandBufferDescriptor const * descriptor);
+WGPU_EXPORT WGPUCommandBuffer wgpuCommandEncoderFinish(WGPUCommandEncoder commandEncoder, WGPUCommandBufferDescriptor const * descriptor /* nullable */);
 WGPU_EXPORT void wgpuCommandEncoderInsertDebugMarker(WGPUCommandEncoder commandEncoder, char const * markerLabel);
 WGPU_EXPORT void wgpuCommandEncoderPopDebugGroup(WGPUCommandEncoder commandEncoder);
 WGPU_EXPORT void wgpuCommandEncoderPushDebugGroup(WGPUCommandEncoder commandEncoder, char const * groupLabel);
@@ -1454,7 +1469,7 @@ WGPU_EXPORT void wgpuComputePipelineRelease(WGPUComputePipeline computePipeline)
 WGPU_EXPORT WGPUBindGroup wgpuDeviceCreateBindGroup(WGPUDevice device, WGPUBindGroupDescriptor const * descriptor);
 WGPU_EXPORT WGPUBindGroupLayout wgpuDeviceCreateBindGroupLayout(WGPUDevice device, WGPUBindGroupLayoutDescriptor const * descriptor);
 WGPU_EXPORT WGPUBuffer wgpuDeviceCreateBuffer(WGPUDevice device, WGPUBufferDescriptor const * descriptor);
-WGPU_EXPORT WGPUCommandEncoder wgpuDeviceCreateCommandEncoder(WGPUDevice device, WGPUCommandEncoderDescriptor const * descriptor);
+WGPU_EXPORT WGPUCommandEncoder wgpuDeviceCreateCommandEncoder(WGPUDevice device, WGPUCommandEncoderDescriptor const * descriptor /* nullable */);
 WGPU_EXPORT WGPUComputePipeline wgpuDeviceCreateComputePipeline(WGPUDevice device, WGPUComputePipelineDescriptor const * descriptor);
 WGPU_EXPORT void wgpuDeviceCreateComputePipelineAsync(WGPUDevice device, WGPUComputePipelineDescriptor const * descriptor, WGPUCreateComputePipelineAsyncCallback callback, void * userdata);
 WGPU_EXPORT WGPUPipelineLayout wgpuDeviceCreatePipelineLayout(WGPUDevice device, WGPUPipelineLayoutDescriptor const * descriptor);
@@ -1462,7 +1477,7 @@ WGPU_EXPORT WGPUQuerySet wgpuDeviceCreateQuerySet(WGPUDevice device, WGPUQuerySe
 WGPU_EXPORT WGPURenderBundleEncoder wgpuDeviceCreateRenderBundleEncoder(WGPUDevice device, WGPURenderBundleEncoderDescriptor const * descriptor);
 WGPU_EXPORT WGPURenderPipeline wgpuDeviceCreateRenderPipeline(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor);
 WGPU_EXPORT void wgpuDeviceCreateRenderPipelineAsync(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor, WGPUCreateRenderPipelineAsyncCallback callback, void * userdata);
-WGPU_EXPORT WGPUSampler wgpuDeviceCreateSampler(WGPUDevice device, WGPUSamplerDescriptor const * descriptor);
+WGPU_EXPORT WGPUSampler wgpuDeviceCreateSampler(WGPUDevice device, WGPUSamplerDescriptor const * descriptor /* nullable */);
 WGPU_EXPORT WGPUShaderModule wgpuDeviceCreateShaderModule(WGPUDevice device, WGPUShaderModuleDescriptor const * descriptor);
 WGPU_EXPORT WGPUSwapChain wgpuDeviceCreateSwapChain(WGPUDevice device, WGPUSurface surface, WGPUSwapChainDescriptor const * descriptor);
 WGPU_EXPORT WGPUTexture wgpuDeviceCreateTexture(WGPUDevice device, WGPUTextureDescriptor const * descriptor);
@@ -1493,6 +1508,8 @@ WGPU_EXPORT void wgpuPipelineLayoutRelease(WGPUPipelineLayout pipelineLayout);
 
 // Methods of QuerySet
 WGPU_EXPORT void wgpuQuerySetDestroy(WGPUQuerySet querySet);
+WGPU_EXPORT uint32_t wgpuQuerySetGetCount(WGPUQuerySet querySet);
+WGPU_EXPORT WGPUQueryType wgpuQuerySetGetType(WGPUQuerySet querySet);
 WGPU_EXPORT void wgpuQuerySetSetLabel(WGPUQuerySet querySet, char const * label);
 WGPU_EXPORT void wgpuQuerySetReference(WGPUQuerySet querySet);
 WGPU_EXPORT void wgpuQuerySetRelease(WGPUQuerySet querySet);
@@ -1515,7 +1532,7 @@ WGPU_EXPORT void wgpuRenderBundleEncoderDraw(WGPURenderBundleEncoder renderBundl
 WGPU_EXPORT void wgpuRenderBundleEncoderDrawIndexed(WGPURenderBundleEncoder renderBundleEncoder, uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance);
 WGPU_EXPORT void wgpuRenderBundleEncoderDrawIndexedIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset);
 WGPU_EXPORT void wgpuRenderBundleEncoderDrawIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset);
-WGPU_EXPORT WGPURenderBundle wgpuRenderBundleEncoderFinish(WGPURenderBundleEncoder renderBundleEncoder, WGPURenderBundleDescriptor const * descriptor);
+WGPU_EXPORT WGPURenderBundle wgpuRenderBundleEncoderFinish(WGPURenderBundleEncoder renderBundleEncoder, WGPURenderBundleDescriptor const * descriptor /* nullable */);
 WGPU_EXPORT void wgpuRenderBundleEncoderInsertDebugMarker(WGPURenderBundleEncoder renderBundleEncoder, char const * markerLabel);
 WGPU_EXPORT void wgpuRenderBundleEncoderPopDebugGroup(WGPURenderBundleEncoder renderBundleEncoder);
 WGPU_EXPORT void wgpuRenderBundleEncoderPushDebugGroup(WGPURenderBundleEncoder renderBundleEncoder, char const * groupLabel);
@@ -1583,8 +1600,16 @@ WGPU_EXPORT void wgpuSwapChainReference(WGPUSwapChain swapChain);
 WGPU_EXPORT void wgpuSwapChainRelease(WGPUSwapChain swapChain);
 
 // Methods of Texture
-WGPU_EXPORT WGPUTextureView wgpuTextureCreateView(WGPUTexture texture, WGPUTextureViewDescriptor const * descriptor);
+WGPU_EXPORT WGPUTextureView wgpuTextureCreateView(WGPUTexture texture, WGPUTextureViewDescriptor const * descriptor /* nullable */);
 WGPU_EXPORT void wgpuTextureDestroy(WGPUTexture texture);
+WGPU_EXPORT uint32_t wgpuTextureGetDepthOrArrayLayers(WGPUTexture texture);
+WGPU_EXPORT WGPUTextureDimension wgpuTextureGetDimension(WGPUTexture texture);
+WGPU_EXPORT WGPUTextureFormat wgpuTextureGetFormat(WGPUTexture texture);
+WGPU_EXPORT uint32_t wgpuTextureGetHeight(WGPUTexture texture);
+WGPU_EXPORT uint32_t wgpuTextureGetMipLevelCount(WGPUTexture texture);
+WGPU_EXPORT uint32_t wgpuTextureGetSampleCount(WGPUTexture texture);
+WGPU_EXPORT WGPUTextureUsage wgpuTextureGetUsage(WGPUTexture texture);
+WGPU_EXPORT uint32_t wgpuTextureGetWidth(WGPUTexture texture);
 WGPU_EXPORT void wgpuTextureSetLabel(WGPUTexture texture, char const * label);
 WGPU_EXPORT void wgpuTextureReference(WGPUTexture texture);
 WGPU_EXPORT void wgpuTextureRelease(WGPUTexture texture);

--- a/system/include/webgpu/webgpu_cpp.h
+++ b/system/include/webgpu/webgpu_cpp.h
@@ -128,6 +128,12 @@ namespace wgpu {
         return (static_cast<Integral>(value) & (static_cast<Integral>(value) - 1)) == 0;
     }
 
+    namespace detail {
+        constexpr size_t ConstexprMax(size_t a, size_t b) {
+            return a > b ? a : b;
+        }
+    }  // namespace detail
+
     static constexpr uint32_t kArrayLayerCountUndefined = WGPU_ARRAY_LAYER_COUNT_UNDEFINED;
     static constexpr uint32_t kCopyStrideUndefined = WGPU_COPY_STRIDE_UNDEFINED;
     static constexpr uint32_t kLimitU32Undefined = WGPU_LIMIT_U32_UNDEFINED;
@@ -265,15 +271,13 @@ namespace wgpu {
     enum class FeatureName : uint32_t {
         Undefined = 0x00000000,
         DepthClipControl = 0x00000001,
-        Depth24UnormStencil8 = 0x00000002,
-        Depth32FloatStencil8 = 0x00000003,
-        TimestampQuery = 0x00000004,
-        PipelineStatisticsQuery = 0x00000005,
-        TextureCompressionBC = 0x00000006,
-        TextureCompressionETC2 = 0x00000007,
-        TextureCompressionASTC = 0x00000008,
-        IndirectFirstInstance = 0x00000009,
-        DepthClamping = 0x000003E8,
+        Depth32FloatStencil8 = 0x00000002,
+        TimestampQuery = 0x00000003,
+        PipelineStatisticsQuery = 0x00000004,
+        TextureCompressionBC = 0x00000005,
+        TextureCompressionETC2 = 0x00000006,
+        TextureCompressionASTC = 0x00000007,
+        IndirectFirstInstance = 0x00000008,
     };
 
     enum class FilterMode : uint32_t {
@@ -310,11 +314,6 @@ namespace wgpu {
         Undefined = 0x00000000,
         LowPower = 0x00000001,
         HighPerformance = 0x00000002,
-    };
-
-    enum class PredefinedColorSpace : uint32_t {
-        Undefined = 0x00000000,
-        Srgb = 0x00000001,
     };
 
     enum class PresentMode : uint32_t {
@@ -368,7 +367,7 @@ namespace wgpu {
         ShaderModuleSPIRVDescriptor = 0x00000005,
         ShaderModuleWGSLDescriptor = 0x00000006,
         PrimitiveDepthClipControl = 0x00000007,
-        PrimitiveDepthClampingState = 0x000003E9,
+        RenderPassDescriptorMaxDrawCount = 0x0000000F,
     };
 
     enum class SamplerBindingType : uint32_t {
@@ -461,61 +460,60 @@ namespace wgpu {
         Depth16Unorm = 0x00000026,
         Depth24Plus = 0x00000027,
         Depth24PlusStencil8 = 0x00000028,
-        Depth24UnormStencil8 = 0x00000029,
-        Depth32Float = 0x0000002A,
-        Depth32FloatStencil8 = 0x0000002B,
-        BC1RGBAUnorm = 0x0000002C,
-        BC1RGBAUnormSrgb = 0x0000002D,
-        BC2RGBAUnorm = 0x0000002E,
-        BC2RGBAUnormSrgb = 0x0000002F,
-        BC3RGBAUnorm = 0x00000030,
-        BC3RGBAUnormSrgb = 0x00000031,
-        BC4RUnorm = 0x00000032,
-        BC4RSnorm = 0x00000033,
-        BC5RGUnorm = 0x00000034,
-        BC5RGSnorm = 0x00000035,
-        BC6HRGBUfloat = 0x00000036,
-        BC6HRGBFloat = 0x00000037,
-        BC7RGBAUnorm = 0x00000038,
-        BC7RGBAUnormSrgb = 0x00000039,
-        ETC2RGB8Unorm = 0x0000003A,
-        ETC2RGB8UnormSrgb = 0x0000003B,
-        ETC2RGB8A1Unorm = 0x0000003C,
-        ETC2RGB8A1UnormSrgb = 0x0000003D,
-        ETC2RGBA8Unorm = 0x0000003E,
-        ETC2RGBA8UnormSrgb = 0x0000003F,
-        EACR11Unorm = 0x00000040,
-        EACR11Snorm = 0x00000041,
-        EACRG11Unorm = 0x00000042,
-        EACRG11Snorm = 0x00000043,
-        ASTC4x4Unorm = 0x00000044,
-        ASTC4x4UnormSrgb = 0x00000045,
-        ASTC5x4Unorm = 0x00000046,
-        ASTC5x4UnormSrgb = 0x00000047,
-        ASTC5x5Unorm = 0x00000048,
-        ASTC5x5UnormSrgb = 0x00000049,
-        ASTC6x5Unorm = 0x0000004A,
-        ASTC6x5UnormSrgb = 0x0000004B,
-        ASTC6x6Unorm = 0x0000004C,
-        ASTC6x6UnormSrgb = 0x0000004D,
-        ASTC8x5Unorm = 0x0000004E,
-        ASTC8x5UnormSrgb = 0x0000004F,
-        ASTC8x6Unorm = 0x00000050,
-        ASTC8x6UnormSrgb = 0x00000051,
-        ASTC8x8Unorm = 0x00000052,
-        ASTC8x8UnormSrgb = 0x00000053,
-        ASTC10x5Unorm = 0x00000054,
-        ASTC10x5UnormSrgb = 0x00000055,
-        ASTC10x6Unorm = 0x00000056,
-        ASTC10x6UnormSrgb = 0x00000057,
-        ASTC10x8Unorm = 0x00000058,
-        ASTC10x8UnormSrgb = 0x00000059,
-        ASTC10x10Unorm = 0x0000005A,
-        ASTC10x10UnormSrgb = 0x0000005B,
-        ASTC12x10Unorm = 0x0000005C,
-        ASTC12x10UnormSrgb = 0x0000005D,
-        ASTC12x12Unorm = 0x0000005E,
-        ASTC12x12UnormSrgb = 0x0000005F,
+        Depth32Float = 0x00000029,
+        Depth32FloatStencil8 = 0x0000002A,
+        BC1RGBAUnorm = 0x0000002B,
+        BC1RGBAUnormSrgb = 0x0000002C,
+        BC2RGBAUnorm = 0x0000002D,
+        BC2RGBAUnormSrgb = 0x0000002E,
+        BC3RGBAUnorm = 0x0000002F,
+        BC3RGBAUnormSrgb = 0x00000030,
+        BC4RUnorm = 0x00000031,
+        BC4RSnorm = 0x00000032,
+        BC5RGUnorm = 0x00000033,
+        BC5RGSnorm = 0x00000034,
+        BC6HRGBUfloat = 0x00000035,
+        BC6HRGBFloat = 0x00000036,
+        BC7RGBAUnorm = 0x00000037,
+        BC7RGBAUnormSrgb = 0x00000038,
+        ETC2RGB8Unorm = 0x00000039,
+        ETC2RGB8UnormSrgb = 0x0000003A,
+        ETC2RGB8A1Unorm = 0x0000003B,
+        ETC2RGB8A1UnormSrgb = 0x0000003C,
+        ETC2RGBA8Unorm = 0x0000003D,
+        ETC2RGBA8UnormSrgb = 0x0000003E,
+        EACR11Unorm = 0x0000003F,
+        EACR11Snorm = 0x00000040,
+        EACRG11Unorm = 0x00000041,
+        EACRG11Snorm = 0x00000042,
+        ASTC4x4Unorm = 0x00000043,
+        ASTC4x4UnormSrgb = 0x00000044,
+        ASTC5x4Unorm = 0x00000045,
+        ASTC5x4UnormSrgb = 0x00000046,
+        ASTC5x5Unorm = 0x00000047,
+        ASTC5x5UnormSrgb = 0x00000048,
+        ASTC6x5Unorm = 0x00000049,
+        ASTC6x5UnormSrgb = 0x0000004A,
+        ASTC6x6Unorm = 0x0000004B,
+        ASTC6x6UnormSrgb = 0x0000004C,
+        ASTC8x5Unorm = 0x0000004D,
+        ASTC8x5UnormSrgb = 0x0000004E,
+        ASTC8x6Unorm = 0x0000004F,
+        ASTC8x6UnormSrgb = 0x00000050,
+        ASTC8x8Unorm = 0x00000051,
+        ASTC8x8UnormSrgb = 0x00000052,
+        ASTC10x5Unorm = 0x00000053,
+        ASTC10x5UnormSrgb = 0x00000054,
+        ASTC10x6Unorm = 0x00000055,
+        ASTC10x6UnormSrgb = 0x00000056,
+        ASTC10x8Unorm = 0x00000057,
+        ASTC10x8UnormSrgb = 0x00000058,
+        ASTC10x10Unorm = 0x00000059,
+        ASTC10x10UnormSrgb = 0x0000005A,
+        ASTC12x10Unorm = 0x0000005B,
+        ASTC12x10UnormSrgb = 0x0000005C,
+        ASTC12x12Unorm = 0x0000005D,
+        ASTC12x12UnormSrgb = 0x0000005E,
     };
 
     enum class TextureSampleType : uint32_t {
@@ -574,6 +572,7 @@ namespace wgpu {
     enum class VertexStepMode : uint32_t {
         Vertex = 0x00000000,
         Instance = 0x00000001,
+        VertexBufferNotUsed = 0x00000002,
     };
 
 
@@ -675,7 +674,6 @@ namespace wgpu {
     struct MultisampleState;
     struct Origin3D;
     struct PipelineLayoutDescriptor;
-    struct PrimitiveDepthClampingState;
     struct PrimitiveDepthClipControl;
     struct PrimitiveState;
     struct QuerySetDescriptor;
@@ -683,6 +681,7 @@ namespace wgpu {
     struct RenderBundleDescriptor;
     struct RenderBundleEncoderDescriptor;
     struct RenderPassDepthStencilAttachment;
+    struct RenderPassDescriptorMaxDrawCount;
     struct RenderPassTimestampWrite;
     struct RequestAdapterOptions;
     struct SamplerBindingLayout;
@@ -850,6 +849,8 @@ namespace wgpu {
         void Destroy() const;
         void const * GetConstMappedRange(size_t offset = 0, size_t size = WGPU_WHOLE_MAP_SIZE) const;
         void * GetMappedRange(size_t offset = 0, size_t size = WGPU_WHOLE_MAP_SIZE) const;
+        uint64_t GetSize() const;
+        BufferUsage GetUsage() const;
         void MapAsync(MapMode mode, size_t offset, size_t size, BufferMapCallback callback, void * userdata) const;
         void SetLabel(char const * label) const;
         void Unmap() const;
@@ -1008,6 +1009,8 @@ namespace wgpu {
         using ObjectBase::operator=;
 
         void Destroy() const;
+        uint32_t GetCount() const;
+        QueryType GetType() const;
         void SetLabel(char const * label) const;
 
       private:
@@ -1180,6 +1183,14 @@ namespace wgpu {
 
         TextureView CreateView(TextureViewDescriptor const * descriptor = nullptr) const;
         void Destroy() const;
+        uint32_t GetDepthOrArrayLayers() const;
+        TextureDimension GetDimension() const;
+        TextureFormat GetFormat() const;
+        uint32_t GetHeight() const;
+        uint32_t GetMipLevelCount() const;
+        uint32_t GetSampleCount() const;
+        TextureUsage GetUsage() const;
+        uint32_t GetWidth() const;
         void SetLabel(char const * label) const;
 
       private:
@@ -1218,6 +1229,8 @@ namespace wgpu {
     struct AdapterProperties {
         ChainedStructOut  * nextInChain = nullptr;
         uint32_t vendorID;
+        char const * vendorName;
+        char const * architecture;
         uint32_t deviceID;
         char const * name;
         char const * driverDescription;
@@ -1326,6 +1339,8 @@ namespace wgpu {
         uint32_t maxVertexAttributes = WGPU_LIMIT_U32_UNDEFINED;
         uint32_t maxVertexBufferArrayStride = WGPU_LIMIT_U32_UNDEFINED;
         uint32_t maxInterStageShaderComponents = WGPU_LIMIT_U32_UNDEFINED;
+        uint32_t maxInterStageShaderVariables = WGPU_LIMIT_U32_UNDEFINED;
+        uint32_t maxColorAttachments = WGPU_LIMIT_U32_UNDEFINED;
         uint32_t maxComputeWorkgroupStorageSize = WGPU_LIMIT_U32_UNDEFINED;
         uint32_t maxComputeInvocationsPerWorkgroup = WGPU_LIMIT_U32_UNDEFINED;
         uint32_t maxComputeWorkgroupSizeX = WGPU_LIMIT_U32_UNDEFINED;
@@ -1354,18 +1369,13 @@ namespace wgpu {
         BindGroupLayout const * bindGroupLayouts;
     };
 
-    struct PrimitiveDepthClampingState : ChainedStruct {
-        PrimitiveDepthClampingState() {
-            sType = SType::PrimitiveDepthClampingState;
-        }
-        alignas(ChainedStruct) bool clampDepth = false;
-    };
-
+    // Can be chained in PrimitiveState
     struct PrimitiveDepthClipControl : ChainedStruct {
         PrimitiveDepthClipControl() {
             sType = SType::PrimitiveDepthClipControl;
         }
-        alignas(ChainedStruct) bool unclippedDepth = false;
+        static constexpr size_t kFirstMemberAlignment = detail::ConstexprMax(alignof(ChainedStruct), alignof(bool ));
+        alignas(kFirstMemberAlignment) bool unclippedDepth = false;
     };
 
     struct PrimitiveState {
@@ -1418,6 +1428,15 @@ namespace wgpu {
         bool stencilReadOnly = false;
     };
 
+    // Can be chained in RenderPassDescriptor
+    struct RenderPassDescriptorMaxDrawCount : ChainedStruct {
+        RenderPassDescriptorMaxDrawCount() {
+            sType = SType::RenderPassDescriptorMaxDrawCount;
+        }
+        static constexpr size_t kFirstMemberAlignment = detail::ConstexprMax(alignof(ChainedStruct), alignof(uint64_t ));
+        alignas(kFirstMemberAlignment) uint64_t maxDrawCount = 50000000;
+    };
+
     struct RenderPassTimestampWrite {
         QuerySet querySet;
         uint32_t queryIndex;
@@ -1456,19 +1475,23 @@ namespace wgpu {
         char const * label = nullptr;
     };
 
+    // Can be chained in ShaderModuleDescriptor
     struct ShaderModuleSPIRVDescriptor : ChainedStruct {
         ShaderModuleSPIRVDescriptor() {
             sType = SType::ShaderModuleSPIRVDescriptor;
         }
-        alignas(ChainedStruct) uint32_t codeSize;
+        static constexpr size_t kFirstMemberAlignment = detail::ConstexprMax(alignof(ChainedStruct), alignof(uint32_t ));
+        alignas(kFirstMemberAlignment) uint32_t codeSize;
         uint32_t const * code;
     };
 
+    // Can be chained in ShaderModuleDescriptor
     struct ShaderModuleWGSLDescriptor : ChainedStruct {
         ShaderModuleWGSLDescriptor() {
             sType = SType::ShaderModuleWGSLDescriptor;
         }
-        alignas(ChainedStruct) char const * source;
+        static constexpr size_t kFirstMemberAlignment = detail::ConstexprMax(alignof(ChainedStruct), alignof(char const * ));
+        alignas(kFirstMemberAlignment) char const * source;
     };
 
     struct StencilFaceState {
@@ -1490,11 +1513,13 @@ namespace wgpu {
         char const * label = nullptr;
     };
 
+    // Can be chained in SurfaceDescriptor
     struct SurfaceDescriptorFromCanvasHTMLSelector : ChainedStruct {
         SurfaceDescriptorFromCanvasHTMLSelector() {
             sType = SType::SurfaceDescriptorFromCanvasHTMLSelector;
         }
-        alignas(ChainedStruct) char const * selector;
+        static constexpr size_t kFirstMemberAlignment = detail::ConstexprMax(alignof(ChainedStruct), alignof(char const * ));
+        alignas(kFirstMemberAlignment) char const * selector;
     };
 
     struct SwapChainDescriptor {

--- a/system/lib/webgpu/webgpu_cpp.cpp
+++ b/system/lib/webgpu/webgpu_cpp.cpp
@@ -183,7 +183,6 @@ namespace wgpu {
 
     static_assert(static_cast<uint32_t>(FeatureName::Undefined) == WGPUFeatureName_Undefined, "value mismatch for FeatureName::Undefined");
     static_assert(static_cast<uint32_t>(FeatureName::DepthClipControl) == WGPUFeatureName_DepthClipControl, "value mismatch for FeatureName::DepthClipControl");
-    static_assert(static_cast<uint32_t>(FeatureName::Depth24UnormStencil8) == WGPUFeatureName_Depth24UnormStencil8, "value mismatch for FeatureName::Depth24UnormStencil8");
     static_assert(static_cast<uint32_t>(FeatureName::Depth32FloatStencil8) == WGPUFeatureName_Depth32FloatStencil8, "value mismatch for FeatureName::Depth32FloatStencil8");
     static_assert(static_cast<uint32_t>(FeatureName::TimestampQuery) == WGPUFeatureName_TimestampQuery, "value mismatch for FeatureName::TimestampQuery");
     static_assert(static_cast<uint32_t>(FeatureName::PipelineStatisticsQuery) == WGPUFeatureName_PipelineStatisticsQuery, "value mismatch for FeatureName::PipelineStatisticsQuery");
@@ -191,7 +190,6 @@ namespace wgpu {
     static_assert(static_cast<uint32_t>(FeatureName::TextureCompressionETC2) == WGPUFeatureName_TextureCompressionETC2, "value mismatch for FeatureName::TextureCompressionETC2");
     static_assert(static_cast<uint32_t>(FeatureName::TextureCompressionASTC) == WGPUFeatureName_TextureCompressionASTC, "value mismatch for FeatureName::TextureCompressionASTC");
     static_assert(static_cast<uint32_t>(FeatureName::IndirectFirstInstance) == WGPUFeatureName_IndirectFirstInstance, "value mismatch for FeatureName::IndirectFirstInstance");
-    static_assert(static_cast<uint32_t>(FeatureName::DepthClamping) == WGPUFeatureName_DepthClamping, "value mismatch for FeatureName::DepthClamping");
 
     // FilterMode
 
@@ -246,14 +244,6 @@ namespace wgpu {
     static_assert(static_cast<uint32_t>(PowerPreference::Undefined) == WGPUPowerPreference_Undefined, "value mismatch for PowerPreference::Undefined");
     static_assert(static_cast<uint32_t>(PowerPreference::LowPower) == WGPUPowerPreference_LowPower, "value mismatch for PowerPreference::LowPower");
     static_assert(static_cast<uint32_t>(PowerPreference::HighPerformance) == WGPUPowerPreference_HighPerformance, "value mismatch for PowerPreference::HighPerformance");
-
-    // PredefinedColorSpace
-
-    static_assert(sizeof(PredefinedColorSpace) == sizeof(WGPUPredefinedColorSpace), "sizeof mismatch for PredefinedColorSpace");
-    static_assert(alignof(PredefinedColorSpace) == alignof(WGPUPredefinedColorSpace), "alignof mismatch for PredefinedColorSpace");
-
-    static_assert(static_cast<uint32_t>(PredefinedColorSpace::Undefined) == WGPUPredefinedColorSpace_Undefined, "value mismatch for PredefinedColorSpace::Undefined");
-    static_assert(static_cast<uint32_t>(PredefinedColorSpace::Srgb) == WGPUPredefinedColorSpace_Srgb, "value mismatch for PredefinedColorSpace::Srgb");
 
     // PresentMode
 
@@ -331,7 +321,7 @@ namespace wgpu {
     static_assert(static_cast<uint32_t>(SType::ShaderModuleSPIRVDescriptor) == WGPUSType_ShaderModuleSPIRVDescriptor, "value mismatch for SType::ShaderModuleSPIRVDescriptor");
     static_assert(static_cast<uint32_t>(SType::ShaderModuleWGSLDescriptor) == WGPUSType_ShaderModuleWGSLDescriptor, "value mismatch for SType::ShaderModuleWGSLDescriptor");
     static_assert(static_cast<uint32_t>(SType::PrimitiveDepthClipControl) == WGPUSType_PrimitiveDepthClipControl, "value mismatch for SType::PrimitiveDepthClipControl");
-    static_assert(static_cast<uint32_t>(SType::PrimitiveDepthClampingState) == WGPUSType_PrimitiveDepthClampingState, "value mismatch for SType::PrimitiveDepthClampingState");
+    static_assert(static_cast<uint32_t>(SType::RenderPassDescriptorMaxDrawCount) == WGPUSType_RenderPassDescriptorMaxDrawCount, "value mismatch for SType::RenderPassDescriptorMaxDrawCount");
 
     // SamplerBindingType
 
@@ -448,7 +438,6 @@ namespace wgpu {
     static_assert(static_cast<uint32_t>(TextureFormat::Depth16Unorm) == WGPUTextureFormat_Depth16Unorm, "value mismatch for TextureFormat::Depth16Unorm");
     static_assert(static_cast<uint32_t>(TextureFormat::Depth24Plus) == WGPUTextureFormat_Depth24Plus, "value mismatch for TextureFormat::Depth24Plus");
     static_assert(static_cast<uint32_t>(TextureFormat::Depth24PlusStencil8) == WGPUTextureFormat_Depth24PlusStencil8, "value mismatch for TextureFormat::Depth24PlusStencil8");
-    static_assert(static_cast<uint32_t>(TextureFormat::Depth24UnormStencil8) == WGPUTextureFormat_Depth24UnormStencil8, "value mismatch for TextureFormat::Depth24UnormStencil8");
     static_assert(static_cast<uint32_t>(TextureFormat::Depth32Float) == WGPUTextureFormat_Depth32Float, "value mismatch for TextureFormat::Depth32Float");
     static_assert(static_cast<uint32_t>(TextureFormat::Depth32FloatStencil8) == WGPUTextureFormat_Depth32FloatStencil8, "value mismatch for TextureFormat::Depth32FloatStencil8");
     static_assert(static_cast<uint32_t>(TextureFormat::BC1RGBAUnorm) == WGPUTextureFormat_BC1RGBAUnorm, "value mismatch for TextureFormat::BC1RGBAUnorm");
@@ -573,6 +562,7 @@ namespace wgpu {
 
     static_assert(static_cast<uint32_t>(VertexStepMode::Vertex) == WGPUVertexStepMode_Vertex, "value mismatch for VertexStepMode::Vertex");
     static_assert(static_cast<uint32_t>(VertexStepMode::Instance) == WGPUVertexStepMode_Instance, "value mismatch for VertexStepMode::Instance");
+    static_assert(static_cast<uint32_t>(VertexStepMode::VertexBufferNotUsed) == WGPUVertexStepMode_VertexBufferNotUsed, "value mismatch for VertexStepMode::VertexBufferNotUsed");
 
     // BufferUsage
 
@@ -654,6 +644,10 @@ namespace wgpu {
             "offsetof mismatch for AdapterProperties::nextInChain");
     static_assert(offsetof(AdapterProperties, vendorID) == offsetof(WGPUAdapterProperties, vendorID),
             "offsetof mismatch for AdapterProperties::vendorID");
+    static_assert(offsetof(AdapterProperties, vendorName) == offsetof(WGPUAdapterProperties, vendorName),
+            "offsetof mismatch for AdapterProperties::vendorName");
+    static_assert(offsetof(AdapterProperties, architecture) == offsetof(WGPUAdapterProperties, architecture),
+            "offsetof mismatch for AdapterProperties::architecture");
     static_assert(offsetof(AdapterProperties, deviceID) == offsetof(WGPUAdapterProperties, deviceID),
             "offsetof mismatch for AdapterProperties::deviceID");
     static_assert(offsetof(AdapterProperties, name) == offsetof(WGPUAdapterProperties, name),
@@ -870,6 +864,10 @@ namespace wgpu {
             "offsetof mismatch for Limits::maxVertexBufferArrayStride");
     static_assert(offsetof(Limits, maxInterStageShaderComponents) == offsetof(WGPULimits, maxInterStageShaderComponents),
             "offsetof mismatch for Limits::maxInterStageShaderComponents");
+    static_assert(offsetof(Limits, maxInterStageShaderVariables) == offsetof(WGPULimits, maxInterStageShaderVariables),
+            "offsetof mismatch for Limits::maxInterStageShaderVariables");
+    static_assert(offsetof(Limits, maxColorAttachments) == offsetof(WGPULimits, maxColorAttachments),
+            "offsetof mismatch for Limits::maxColorAttachments");
     static_assert(offsetof(Limits, maxComputeWorkgroupStorageSize) == offsetof(WGPULimits, maxComputeWorkgroupStorageSize),
             "offsetof mismatch for Limits::maxComputeWorkgroupStorageSize");
     static_assert(offsetof(Limits, maxComputeInvocationsPerWorkgroup) == offsetof(WGPULimits, maxComputeInvocationsPerWorkgroup),
@@ -922,14 +920,6 @@ namespace wgpu {
             "offsetof mismatch for PipelineLayoutDescriptor::bindGroupLayoutCount");
     static_assert(offsetof(PipelineLayoutDescriptor, bindGroupLayouts) == offsetof(WGPUPipelineLayoutDescriptor, bindGroupLayouts),
             "offsetof mismatch for PipelineLayoutDescriptor::bindGroupLayouts");
-
-    // PrimitiveDepthClampingState
-
-    static_assert(sizeof(PrimitiveDepthClampingState) == sizeof(WGPUPrimitiveDepthClampingState), "sizeof mismatch for PrimitiveDepthClampingState");
-    static_assert(alignof(PrimitiveDepthClampingState) == alignof(WGPUPrimitiveDepthClampingState), "alignof mismatch for PrimitiveDepthClampingState");
-
-    static_assert(offsetof(PrimitiveDepthClampingState, clampDepth) == offsetof(WGPUPrimitiveDepthClampingState, clampDepth),
-            "offsetof mismatch for PrimitiveDepthClampingState::clampDepth");
 
     // PrimitiveDepthClipControl
 
@@ -1038,6 +1028,14 @@ namespace wgpu {
             "offsetof mismatch for RenderPassDepthStencilAttachment::stencilClearValue");
     static_assert(offsetof(RenderPassDepthStencilAttachment, stencilReadOnly) == offsetof(WGPURenderPassDepthStencilAttachment, stencilReadOnly),
             "offsetof mismatch for RenderPassDepthStencilAttachment::stencilReadOnly");
+
+    // RenderPassDescriptorMaxDrawCount
+
+    static_assert(sizeof(RenderPassDescriptorMaxDrawCount) == sizeof(WGPURenderPassDescriptorMaxDrawCount), "sizeof mismatch for RenderPassDescriptorMaxDrawCount");
+    static_assert(alignof(RenderPassDescriptorMaxDrawCount) == alignof(WGPURenderPassDescriptorMaxDrawCount), "alignof mismatch for RenderPassDescriptorMaxDrawCount");
+
+    static_assert(offsetof(RenderPassDescriptorMaxDrawCount, maxDrawCount) == offsetof(WGPURenderPassDescriptorMaxDrawCount, maxDrawCount),
+            "offsetof mismatch for RenderPassDescriptorMaxDrawCount::maxDrawCount");
 
     // RenderPassTimestampWrite
 
@@ -1715,6 +1713,14 @@ namespace wgpu {
         auto result = wgpuBufferGetMappedRange(Get(), offset, size);
         return result;
     }
+    uint64_t Buffer::GetSize() const {
+        auto result = wgpuBufferGetSize(Get());
+        return result;
+    }
+    BufferUsage Buffer::GetUsage() const {
+        auto result = wgpuBufferGetUsage(Get());
+        return static_cast<BufferUsage>(result);
+    }
     void Buffer::MapAsync(MapMode mode, size_t offset, size_t size, BufferMapCallback callback, void * userdata) const {
         wgpuBufferMapAsync(Get(), static_cast<WGPUMapMode>(mode), offset, size, callback, reinterpret_cast<void * >(userdata));
     }
@@ -2052,6 +2058,14 @@ namespace wgpu {
     void QuerySet::Destroy() const {
         wgpuQuerySetDestroy(Get());
     }
+    uint32_t QuerySet::GetCount() const {
+        auto result = wgpuQuerySetGetCount(Get());
+        return result;
+    }
+    QueryType QuerySet::GetType() const {
+        auto result = wgpuQuerySetGetType(Get());
+        return static_cast<QueryType>(result);
+    }
     void QuerySet::SetLabel(char const * label) const {
         wgpuQuerySetSetLabel(Get(), reinterpret_cast<char const * >(label));
     }
@@ -2372,6 +2386,38 @@ namespace wgpu {
     }
     void Texture::Destroy() const {
         wgpuTextureDestroy(Get());
+    }
+    uint32_t Texture::GetDepthOrArrayLayers() const {
+        auto result = wgpuTextureGetDepthOrArrayLayers(Get());
+        return result;
+    }
+    TextureDimension Texture::GetDimension() const {
+        auto result = wgpuTextureGetDimension(Get());
+        return static_cast<TextureDimension>(result);
+    }
+    TextureFormat Texture::GetFormat() const {
+        auto result = wgpuTextureGetFormat(Get());
+        return static_cast<TextureFormat>(result);
+    }
+    uint32_t Texture::GetHeight() const {
+        auto result = wgpuTextureGetHeight(Get());
+        return result;
+    }
+    uint32_t Texture::GetMipLevelCount() const {
+        auto result = wgpuTextureGetMipLevelCount(Get());
+        return result;
+    }
+    uint32_t Texture::GetSampleCount() const {
+        auto result = wgpuTextureGetSampleCount(Get());
+        return result;
+    }
+    TextureUsage Texture::GetUsage() const {
+        auto result = wgpuTextureGetUsage(Get());
+        return static_cast<TextureUsage>(result);
+    }
+    uint32_t Texture::GetWidth() const {
+        auto result = wgpuTextureGetWidth(Get());
+        return result;
     }
     void Texture::SetLabel(char const * label) const {
         wgpuTextureSetLabel(Get(), reinterpret_cast<char const * >(label));

--- a/test/reference_struct_info.json
+++ b/test/reference_struct_info.json
@@ -688,14 +688,16 @@
             "patch": 2
         },
         "WGPUAdapterProperties": {
-            "__size__": 28,
-            "adapterType": 20,
-            "backendType": 24,
-            "deviceID": 8,
-            "driverDescription": 16,
-            "name": 12,
+            "__size__": 36,
+            "adapterType": 28,
+            "architecture": 12,
+            "backendType": 32,
+            "deviceID": 16,
+            "driverDescription": 24,
+            "name": 20,
             "nextInChain": 0,
-            "vendorID": 4
+            "vendorID": 4,
+            "vendorName": 8
         },
         "WGPUBindGroupDescriptor": {
             "__size__": 20,
@@ -887,17 +889,19 @@
             "nextInChain": 0
         },
         "WGPULimits": {
-            "__size__": 112,
+            "__size__": 120,
             "maxBindGroups": 16,
-            "maxComputeInvocationsPerWorkgroup": 92,
-            "maxComputeWorkgroupSizeX": 96,
-            "maxComputeWorkgroupSizeY": 100,
-            "maxComputeWorkgroupSizeZ": 104,
-            "maxComputeWorkgroupStorageSize": 88,
-            "maxComputeWorkgroupsPerDimension": 108,
+            "maxColorAttachments": 92,
+            "maxComputeInvocationsPerWorkgroup": 100,
+            "maxComputeWorkgroupSizeX": 104,
+            "maxComputeWorkgroupSizeY": 108,
+            "maxComputeWorkgroupSizeZ": 112,
+            "maxComputeWorkgroupStorageSize": 96,
+            "maxComputeWorkgroupsPerDimension": 116,
             "maxDynamicStorageBuffersPerPipelineLayout": 24,
             "maxDynamicUniformBuffersPerPipelineLayout": 20,
             "maxInterStageShaderComponents": 84,
+            "maxInterStageShaderVariables": 88,
             "maxSampledTexturesPerShaderStage": 28,
             "maxSamplersPerShaderStage": 32,
             "maxStorageBufferBindingSize": 56,
@@ -934,11 +938,6 @@
             "bindGroupLayouts": 12,
             "label": 4,
             "nextInChain": 0
-        },
-        "WGPUPrimitiveDepthClampingState": {
-            "__size__": 12,
-            "chain": 0,
-            "clampDepth": 8
         },
         "WGPUPrimitiveDepthClipControl": {
             "__size__": 12,
@@ -1022,6 +1021,11 @@
             "timestampWriteCount": 24,
             "timestampWrites": 28
         },
+        "WGPURenderPassDescriptorMaxDrawCount": {
+            "__size__": 16,
+            "chain": 0,
+            "maxDrawCount": 8
+        },
         "WGPURenderPassTimestampWrite": {
             "__size__": 12,
             "location": 8,
@@ -1047,7 +1051,7 @@
             "powerPreference": 8
         },
         "WGPURequiredLimits": {
-            "__size__": 120,
+            "__size__": 128,
             "limits": 8,
             "nextInChain": 0
         },
@@ -1102,7 +1106,7 @@
             "viewDimension": 12
         },
         "WGPUSupportedLimits": {
-            "__size__": 120,
+            "__size__": 128,
             "limits": 8,
             "nextInChain": 0
         },


### PR DESCRIPTION
- Remove predefined color space
- Remove DepthClampingState
- Remove depth24unorm-stencil8 format (causing enum value shift, might cause some regression)
- Add adapter properties `vendorName` and `architecture`
- Add limits `maxInterStageShaderVariables` and `maxColorAttachments`
- Add vertex step mode enum `'vertex-buffer-not-used'` (set to undefined)
- Add `WGPURenderPassDescriptorMaxDrawCount` as an extension descriptor to set maxDrawCount
- Add various reflection methods.