### PR TITLE
Remove some code duplication between the ports. NFC

### DIFF
--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -266,7 +266,9 @@ class Ports:
   def clear_project_build(name):
     port = ports_by_name[name]
     port.clear(Ports, settings, shared)
-    shared.try_delete(os.path.join(Ports.get_build_dir(), name))
+    build_dir = os.path.join(Ports.get_build_dir(), name)
+    shared.try_delete(build_dir)
+    return build_dir
 
 
 def dependency_order(port_list):

--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -5,7 +5,6 @@
 
 import logging
 import os
-import shutil
 
 TAG = '1.75.0'
 HASH = '8c38be1ebef1b8ada358ad6b7c9ec17f5e0a300e8085db3473a13e19712c95eeb3c3defacd3c53482eb96368987c4b022efa8da2aac2431a154e40153d3c3dcd'
@@ -21,17 +20,15 @@ def get(ports, settings, shared):
 
   def create(final):
     logging.info('building port: boost_headers')
-    ports.clear_project_build('boost_headers')
+    build_dir = ports.clear_project_build('boost_headers')
 
     # includes
     source_path_include = os.path.join(ports.get_dir(), 'boost_headers', 'boost')
-    dest_path_include = ports.get_include_dir('boost')
-    shared.try_delete(dest_path_include)
-    shutil.copytree(source_path_include, dest_path_include)
+    ports.install_header_dir(source_path_include, 'boost')
 
     # write out a dummy cpp file, to create an empty library
     # this is needed as emscripted ports expect this, even if it is not used
-    dummy_file = os.path.join(ports.get_build_dir(), 'boost_headers', 'dummy.cpp')
+    dummy_file = os.path.join(build_dir, 'dummy.cpp')
     shared.safe_ensure_dirs(os.path.dirname(dummy_file))
     with open(dummy_file, 'w') as f:
       f.write('static void dummy() {}')

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -22,9 +22,7 @@ def get(ports, settings, shared):
     logging.info('building port: bullet')
 
     source_path = os.path.join(ports.get_dir(), 'bullet', 'Bullet-' + TAG)
-    dest_path = os.path.join(ports.get_build_dir(), 'bullet')
-
-    shutil.rmtree(dest_path, ignore_errors=True)
+    dest_path = ports.clear_project_build('bullet')
     shutil.copytree(source_path, dest_path)
     src_path = os.path.join(dest_path, 'bullet', 'src')
     src_path = os.path.join(dest_path, 'bullet', 'src')

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -18,13 +18,8 @@ def get(ports, settings, shared):
   ports.fetch_project('bzip2', 'https://github.com/emscripten-ports/bzip2/archive/' + VERSION + '.zip', 'bzip2-' + VERSION, sha512hash=HASH)
 
   def create(final):
-    ports.clear_project_build('bzip2')
-
+    dest_path = ports.clear_project_build('bzip2')
     source_path = os.path.join(ports.get_dir(), 'bzip2', 'bzip2-' + VERSION)
-    dest_path = os.path.join(ports.get_build_dir(), 'bzip2')
-    shared.try_delete(dest_path)
-    os.makedirs(dest_path)
-    shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
 
     # build
@@ -35,7 +30,7 @@ def get(ports, settings, shared):
     commands = []
     o_s = []
     for src in srcs:
-      o = os.path.join(ports.get_build_dir(), 'bzip2', src + '.o')
+      o = os.path.join(dest_path, shared.replace_suffix(src, '.o'))
       shared.safe_ensure_dirs(os.path.dirname(o))
       commands.append([shared.EMCC, '-c', os.path.join(dest_path, src), '-O2', '-o', o, '-I' + dest_path, '-w', ])
       o_s.append(o)

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -31,8 +31,7 @@ def get(ports, settings, shared):
     cocos2dx_src = make_source_list(cocos2d_root, cocos2dx_root)
     cocos2dx_includes = make_includes(cocos2d_root)
 
-    cocos2d_build = os.path.join(ports.get_build_dir(), 'cocos2d')
-    shared.try_delete(os.path.join(cocos2d_build, 'samples'))
+    cocos2d_build = ports.clear_project_build('cocos2d')
     shutil.copytree(os.path.join(cocos2d_root, 'samples', 'Cpp'),
                     os.path.join(cocos2d_build, 'samples'))
 

--- a/tools/ports/giflib.py
+++ b/tools/ports/giflib.py
@@ -22,9 +22,7 @@ def get(ports, settings, shared):
     logging.info('building port: giflib')
 
     source_path = os.path.join(ports.get_dir(), 'giflib', f'giflib-{VERSION}')
-    dest_path = os.path.join(ports.get_build_dir(), 'giflib')
-
-    shutil.rmtree(dest_path, ignore_errors=True)
+    dest_path = ports.clear_project_build('giflib')
     shutil.copytree(source_path, dest_path)
 
     ports.install_headers(dest_path)

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -86,10 +86,9 @@ def get(ports, settings, shared):
 
   def create(final):
     logging.info('building port: harfbuzz')
-    ports.clear_project_build('harfbuzz')
+    build_path = ports.clear_project_build('harfbuzz')
 
     source_path = os.path.join(ports.get_dir(), 'harfbuzz', 'harfbuzz-' + VERSION)
-    build_path = os.path.join(ports.get_build_dir(), 'harfbuzz')
     freetype_include = ports.get_include_dir('freetype2/freetype')
     ports.install_headers(os.path.join(source_path, 'src'), target='harfbuzz')
 

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -31,9 +31,8 @@ def get(ports, settings, shared):
 
   def prepare_build():
     source_path = os.path.join(ports.get_dir(), 'icu', 'icu') # downloaded icu4c path
-    dest_path = os.path.join(ports.get_build_dir(), 'icu') # icu build path
+    dest_path = ports.clear_project_build('icu') # icu build path
     logging.debug(f'preparing for icu build: {source_path} -> {dest_path}')
-    shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
 
   def build_lib(lib_output, lib_src, other_includes, build_flags):

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -26,9 +26,7 @@ def get(ports, settings, shared):
     logging.info('building port: libjpeg')
 
     source_path = os.path.join(ports.get_dir(), 'libjpeg', 'jpeg-9c')
-    dest_path = os.path.join(ports.get_build_dir(), 'libjpeg')
-
-    shutil.rmtree(dest_path, ignore_errors=True)
+    dest_path = ports.clear_project_build('libjpeg')
     shutil.copytree(source_path, dest_path)
 
     Path(dest_path, 'jconfig.h').write_text(jconfig_h)

--- a/tools/ports/libmodplug.py
+++ b/tools/ports/libmodplug.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 import logging
 from pathlib import Path
 
@@ -21,14 +20,12 @@ def get(ports, settings, shared):
 
   def create(output_path):
     logging.info('building port: libmodplug')
-    ports.clear_project_build('libmodplug')
 
     source_path = os.path.join(ports.get_dir(), 'libmodplug', 'libmodplug-' + TAG)
     src_dir = os.path.join(source_path, 'src')
     libmodplug_path = os.path.join(src_dir, 'libmodplug')
 
-    build_dir = os.path.join(ports.get_build_dir(), 'libmodplug')
-    shutil.rmtree(build_dir, ignore_errors=True)
+    build_dir = ports.clear_project_build('libmodplug')
     shared.safe_ensure_dirs(build_dir)
     Path(build_dir, 'config.h').write_text(config_h)
 

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -30,9 +30,7 @@ def get(ports, settings, shared):
     logging.info('building port: libpng')
 
     source_path = os.path.join(ports.get_dir(), 'libpng', 'libpng-' + TAG)
-    dest_path = os.path.join(ports.get_build_dir(), 'libpng')
-
-    shutil.rmtree(dest_path, ignore_errors=True)
+    dest_path = ports.clear_project_build('libpng')
     shutil.copytree(source_path, dest_path)
 
     Path(dest_path, 'pnglibconf.h').write_text(pnglibconf_h)

--- a/tools/ports/mpg123.py
+++ b/tools/ports/mpg123.py
@@ -23,13 +23,12 @@ def get(ports, settings, shared):
     logging.info('building port: mpg123')
 
     source_path = os.path.join(ports.get_dir(), 'mpg123', 'mpg123-' + TAG)
-    dest_path = os.path.join(ports.get_build_dir(), 'mpg123')
+    dest_path = ports.clear_project_build('mpg123')
 
     sauce_path = os.path.join(dest_path, 'src')
     libmpg123_path = os.path.join(sauce_path, 'libmpg123')
     compat_path = os.path.join(sauce_path, 'compat')
 
-    shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
     Path(sauce_path, 'config.h').write_text(config_h)
     Path(libmpg123_path, 'mpg123.h').write_text(mpg123_h)

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -21,20 +21,14 @@ def get(ports, settings, shared):
 
   def create(final):
     logging.info('building port: ogg')
-    ports.clear_project_build('vorbis')
 
     source_path = os.path.join(ports.get_dir(), 'ogg', 'Ogg-' + TAG)
-    dest_path = os.path.join(ports.get_build_dir(), 'ogg')
-
-    shutil.rmtree(dest_path, ignore_errors=True)
+    dest_path = ports.clear_project_build('ogg')
     shutil.copytree(source_path, dest_path)
 
     Path(dest_path, 'include', 'ogg', 'config_types.h').write_text(config_types_h)
 
-    header_dir = ports.get_include_dir('ogg')
-    shutil.rmtree(header_dir, ignore_errors=True)
-    shutil.copytree(os.path.join(dest_path, 'include', 'ogg'), header_dir)
-
+    ports.install_header_dir(os.path.join(dest_path, 'include', 'ogg'), 'ogg')
     ports.build_port(os.path.join(dest_path, 'src'), final)
 
   return [shared.Cache.get_lib('libogg.a', create)]

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -25,12 +25,12 @@ def get(ports, settings, shared):
 
   def create(final):
     logging.info('building port: regal')
-    ports.clear_project_build('regal')
+    dest_path = ports.clear_project_build('regal')
 
     # copy sources
     # only what is needed is copied: regal, boost, lookup3
     source_path_src = os.path.join(ports.get_dir(), 'regal', 'regal-' + TAG, 'src')
-    dest_path_src = os.path.join(ports.get_build_dir(), 'regal', 'src')
+    dest_path_src = os.path.join(dest_path, 'src')
 
     source_path_regal = os.path.join(source_path_src, 'regal')
     source_path_boost = os.path.join(source_path_src, 'boost')
@@ -39,7 +39,6 @@ def get(ports, settings, shared):
     dest_path_boost = os.path.join(dest_path_src, 'boost')
     dest_path_lookup3 = os.path.join(dest_path_src, 'lookup3')
 
-    shutil.rmtree(dest_path_src, ignore_errors=True)
     shutil.copytree(source_path_regal, dest_path_regal)
     shutil.copytree(source_path_boost, dest_path_boost)
     shutil.copytree(source_path_lookup3, dest_path_lookup3)

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -65,8 +65,9 @@ def get(ports, settings, shared):
 
     commands = []
     o_s = []
+    build_dir = ports.clear_project_build('sdl2')
     for src in srcs:
-      o = os.path.join(ports.get_build_dir(), 'sdl2', 'src', src + '.o')
+      o = os.path.join(build_dir, 'src', shared.replace_suffix(src, '.o'))
       shared.safe_ensure_dirs(os.path.dirname(o))
       command = [shared.EMCC,
                  '-sUSE_SDL=0',

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -26,9 +26,8 @@ def get(ports, settings, shared):
     logging.info('building port: sdl2_gfx')
 
     source_path = os.path.join(ports.get_dir(), 'sdl2_gfx', 'sdl2_gfx-' + TAG)
-    dest_path = os.path.join(ports.get_build_dir(), 'sdl2_gfx')
+    dest_path = ports.clear_project_build('sdl2_gfx')
 
-    shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
     ports.build_port(dest_path, final, [dest_path], exclude_dirs=['test'], flags=['-sUSE_SDL=2'])
 

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -46,8 +46,9 @@ def get(ports, settings, shared):
     if 'jpg' in settings.SDL2_IMAGE_FORMATS:
       defs += ['-sUSE_LIBJPEG=1']
 
+    build_dir = ports.clear_project_build('sdl2_image')
     for src in srcs:
-      o = os.path.join(ports.get_build_dir(), 'sdl2_image', src + '.o')
+      o = os.path.join(build_dir, shared.replace_suffix(src, '.o'))
       commands.append([shared.EMCC, '-c', os.path.join(src_dir, src),
                        '-O2', '-sUSE_SDL=2', '-o', o, '-w'] + defs)
       o_s.append(o)

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -39,9 +39,8 @@ def get(ports, settings, shared):
     logging.info('building port: sdl2_mixer')
 
     source_path = os.path.join(ports.get_dir(), 'sdl2_mixer', 'SDL_mixer-' + TAG)
-    dest_path = os.path.join(ports.get_build_dir(), 'sdl2_mixer')
+    dest_path = ports.clear_project_build('sdl2_mixer')
 
-    shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
 
     flags = [

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -28,12 +28,13 @@ def get(ports, settings, shared):
     srcs = 'SDLnet.c SDLnetselect.c SDLnetTCP.c SDLnetUDP.c'.split()
     commands = []
     o_s = []
+    build_dir = ports.clear_project_build('sdl2_net')
+    shared.safe_ensure_dirs(build_dir)
     for src in srcs:
-      o = os.path.join(ports.get_build_dir(), 'sdl2_net', src + '.o')
+      o = os.path.join(build_dir, shared.replace_suffix(src, '.o'))
       commands.append([shared.EMCC, '-c', os.path.join(src_dir, src),
                        '-O2', '-sUSE_SDL=2', '-o', o, '-w'])
       o_s.append(o)
-    shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)
     ports.create_lib(final, o_s)
 

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -26,8 +26,9 @@ def get(ports, settings, shared):
     commands = []
     o_s = []
 
+    build_dir = ports.clear_project_build('sdl2_ttf')
     for src in srcs:
-      o = os.path.join(ports.get_build_dir(), 'sdl2_ttf', src + '.o')
+      o = os.path.join(build_dir, shared.replace_suffix(src, '.o'))
       command = [shared.EMCC,
                  '-c', os.path.join(src_root, src),
                  '-O2', '-DTTF_USE_HARFBUZZ=1', '-sUSE_SDL=2', '-sUSE_FREETYPE=1', '-sUSE_HARFBUZZ=1', '-o', o, '-w']

--- a/tools/ports/sqlite3.py
+++ b/tools/ports/sqlite3.py
@@ -33,9 +33,8 @@ def get(ports, settings, shared):
     logging.info('building port: libsqlite3')
 
     source_path = os.path.join(ports.get_dir(), 'sqlite3', release)
-    dest_path = os.path.join(ports.get_build_dir(), 'sqlite3')
+    dest_path = ports.clear_project_build('sqlite3')
 
-    shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
 
     ports.install_headers(dest_path)

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -24,9 +24,7 @@ def get(ports, settings, shared):
     logging.info('building port: vorbis')
 
     source_path = os.path.join(ports.get_dir(), 'vorbis', 'Vorbis-' + TAG)
-    dest_path = os.path.join(ports.get_build_dir(), 'vorbis')
-
-    shutil.rmtree(dest_path, ignore_errors=True)
+    dest_path = ports.clear_project_build('vorbis')
     shutil.copytree(source_path, dest_path)
 
     ports.build_port(os.path.join(dest_path, 'lib'), final, [os.path.join(dest_path, 'include')],

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -19,13 +19,8 @@ def get(ports, settings, shared):
   ports.fetch_project('zlib', f'https://storage.googleapis.com/webassembly/emscripten-ports/zlib-{VERSION}.zip', 'zlib-' + VERSION, sha512hash=HASH)
 
   def create(final):
-    ports.clear_project_build('zlib')
-
     source_path = os.path.join(ports.get_dir(), 'zlib', 'zlib-' + VERSION)
-    dest_path = os.path.join(ports.get_build_dir(), 'zlib')
-    shared.try_delete(dest_path)
-    os.makedirs(dest_path)
-    shutil.rmtree(dest_path, ignore_errors=True)
+    dest_path = ports.clear_project_build('zlib')
     shutil.copytree(source_path, dest_path)
     Path(dest_path, 'zconf.h').write_text(zconf_h)
     ports.install_headers(dest_path)


### PR DESCRIPTION
There was a bunch of redundant calls to `try_delete` and by having
`clear_project_build()` return the build directory we can avoid
recalculating the build directory.

Split out from #17512