### PR TITLE
Mention emnapi in documentation

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -17,7 +17,6 @@ JavaScript and compiled C or C++:
   created with:
 
   - :ref:`Embind or WebIDL-Binder<interacting-with-code-binding-cpp>`
-  - :ref:`Emnapi (Node-API)<interacting-with-code-emnapi>`
 
 - Call JavaScript functions from **C/C++**:
 

--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -801,13 +801,13 @@ for defining the binding:
 
 .. _interacting-with-code-emnapi:
 
-Binding C/C++ and JavaScript - Emnapi
+Binding C/C++ and JavaScript - Node-API
 ===============================================================
 
 `Emnapi`_ is an unofficial `Node-API`_ implementation which can be used
-in Emscripten. If you would like to port existing Node-API addon
-to WebAssembly, you can give it a try. See
-`Emnapi documentation`_ for more details.
+on Emscripten. If you would like to port existing Node-API addon to WebAssembly
+or compile the same binding code to both Node.js native addon and WebAssembly,
+you can give it a try. See `Emnapi documentation`_ for more details.
 
 .. _library.js: https://github.com/emscripten-core/emscripten/blob/main/src/library.js
 .. _test_js_libraries: https://github.com/emscripten-core/emscripten/blob/1.29.12/tests/test_core.py#L5043

--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -801,12 +801,12 @@ for defining the binding:
 
 .. _interacting-with-code-emnapi:
 
-Binding C/C++ and JavaScript — Emnapi (Node-API for Emscripten)
+Binding C/C++ and JavaScript - Emnapi
 ===============================================================
 
-`Emnapi`_ is an unofficial `Node-API`_ implementation for Emscripten.
-If you prefer Node-API, or you would like to port your Node.js addon
-written in Node-API to WebAssembly, you can give it a try. See
+`Emnapi`_ is an unofficial `Node-API`_ implementation which can be used
+in Emscripten. If you would like to port existing Node-API addon
+to WebAssembly, you can give it a try. See
 `Emnapi documentation`_ for more details.
 
 .. _library.js: https://github.com/emscripten-core/emscripten/blob/main/src/library.js
@@ -820,5 +820,5 @@ written in Node-API to WebAssembly, you can give it a try. See
 .. _Box2D: https://github.com/kripken/box2d.js/#box2djs
 .. _Bullet: https://github.com/kripken/ammo.js/#ammojs
 .. _Emnapi: https://github.com/toyobayashi/emnapi
-.. _Node-API: https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html
+.. _Node-API: https://nodejs.org/dist/latest/docs/api/n-api.html
 .. _Emnapi documentation: https://emnapi-docs.vercel.app/guide/getting-started.html

--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -17,6 +17,7 @@ JavaScript and compiled C or C++:
   created with:
 
   - :ref:`Embind or WebIDL-Binder<interacting-with-code-binding-cpp>`
+  - :ref:`Emnapi (Node-API)<interacting-with-code-emnapi>`
 
 - Call JavaScript functions from **C/C++**:
 
@@ -798,6 +799,16 @@ for defining the binding:
    of one tool over the other will usually be based on which is the most
    natural fit for the project and its build system.
 
+.. _interacting-with-code-emnapi:
+
+Binding C/C++ and JavaScript — Emnapi (Node-API for Emscripten)
+===============================================================
+
+`Emnapi`_ is an unofficial `Node-API`_ implementation for Emscripten.
+If you prefer Node-API, or you would like to port your Node.js addon
+written in Node-API to WebAssembly, you can give it a try. See
+`Emnapi documentation`_ for more details.
+
 .. _library.js: https://github.com/emscripten-core/emscripten/blob/main/src/library.js
 .. _test_js_libraries: https://github.com/emscripten-core/emscripten/blob/1.29.12/tests/test_core.py#L5043
 .. _src/deps_info.json: https://github.com/emscripten-core/emscripten/blob/main/src/deps_info.json
@@ -808,3 +819,6 @@ for defining the binding:
 .. _tests/test_core.py: https://github.com/emscripten-core/emscripten/blob/1.29.12/tests/test_core.py#L4597
 .. _Box2D: https://github.com/kripken/box2d.js/#box2djs
 .. _Bullet: https://github.com/kripken/ammo.js/#ammojs
+.. _Emnapi: https://github.com/toyobayashi/emnapi
+.. _Node-API: https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html
+.. _Emnapi documentation: https://emnapi-docs.vercel.app/guide/getting-started.html


### PR DESCRIPTION
Would you mind mentioning [emnapi](https://github.com/toyobayashi/emnapi) in documentation?

emnapi gives Emscripten users another way to write binding code, and also gives users the ability to port Node.js addons written in Node-API to WebAssembly.

Currently emnapi has a [documentation site](https://emnapi-docs.vercel.app/) and has successfully ported most of the official examples in [node-addon-examples](https://github.com/toyobayashi/node-addon-examples) repository.

I think it is time to let more developers know emnapi. The community can help make it better.

Sorry for my bad English, great appreciate if you approve this.