### PR TITLE
Make test_emsymbolizer more robust

### DIFF
--- a/test/core/test_dwarf.c
+++ b/test/core/test_dwarf.c
@@ -6,8 +6,6 @@ void __attribute__((noinline)) foo() {
   out_to_js(0); // line 6
   out_to_js(1); // line 7
   out_to_js(2); // line 8
-  // A silly possible recursion to avoid binaryen doing any inlining.
-  if (out_to_js(3)) foo();
 }
 
 void __attribute__((always_inline)) bar() {

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8650,8 +8650,8 @@ int main() {
     # as described by the DWARF.
     # TODO: consider also checking the function names once the output format
     # stabilizes more
-    self.assertRegex(get_addr('0x124').replace('\n', ''),
-                     'test_dwarf.c:15:3.*test_dwarf.c:20:3')
+    self.assertRegex(get_addr('0x118').replace('\n', ''),
+                     'test_dwarf.c:13:3.*test_dwarf.c:18:3')
 
   def test_separate_dwarf(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-g'])


### PR DESCRIPTION
test_dwarf.c contained a recursion to prevent Binaryen from inlining foo().
But that wasn't necessary since it doesn't do inlining at O1 anyway. Instead,
an LLVM change converted the recursive call into a loop and broke the hardcoded
addresses in the test. This PR removes the recursion, and works both before
and after the aforementioned LLVM change.