### PR TITLE
Create utils.delete_file and utils.delete_dir in place of tempfiles.try_delete.  NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -51,7 +51,7 @@ from tools import wasm2c
 from tools import webassembly
 from tools import config
 from tools.settings import settings, MEM_SIZE_SETTINGS, COMPILE_TIME_SETTINGS
-from tools.utils import read_file, write_file, read_binary
+from tools.utils import read_file, write_file, read_binary, delete_file
 
 logger = logging.getLogger('emcc')
 
@@ -3044,7 +3044,7 @@ def phase_final_emitting(options, state, target, wasm_target, memfile):
     generate_worker_js(target, js_target, target_basename)
 
   if embed_memfile() and memfile:
-    shared.try_delete(memfile)
+    delete_file(memfile)
 
   if settings.SPLIT_MODULE:
     diagnostics.warning('experimental', 'The SPLIT_MODULE setting is experimental and subject to change')
@@ -3532,7 +3532,7 @@ def phase_binaryen(target, options, wasm_target):
     if settings.WASM != 2:
       final_js = wasm2js
       # if we only target JS, we don't need the wasm any more
-      shared.try_delete(wasm_target)
+      delete_file(wasm_target)
 
     save_intermediate('wasm2js')
 
@@ -3570,7 +3570,7 @@ def phase_binaryen(target, options, wasm_target):
       js = do_replace(js, '<<< WASM_BINARY_DATA >>>', base64_encode(read_binary(wasm_target)))
     else:
       js = do_replace(js, '<<< WASM_BINARY_FILE >>>', get_subresource_location(wasm_target))
-    shared.try_delete(wasm_target)
+    delete_file(wasm_target)
     write_file(final_js, js)
 
 
@@ -3768,7 +3768,7 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
     js_contents = script.inline or ''
     if script.src:
       js_contents += read_file(js_target)
-    shared.try_delete(js_target)
+    delete_file(js_target)
     script.src = None
     script.inline = js_contents
 

--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -10,7 +10,8 @@ import tempfile
 import time
 import queue
 
-from tools.tempfiles import try_delete
+import common
+
 
 NUM_CORES = None
 
@@ -95,7 +96,7 @@ class ParallelTestSuite(unittest.BaseTestSuite):
       else:
         self.clear_finished_processes()
     for temp_dir in self.dedicated_temp_dirs:
-      try_delete(temp_dir)
+      common.force_delete_dir(temp_dir)
     return buffered_results
 
   def clear_finished_processes(self):

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -21,8 +21,8 @@ import jsrun
 import common
 from tools.shared import CLANG_CC, CLANG_CXX
 from common import TEST_ROOT, test_file, read_file, read_binary
-from tools.shared import run_process, PIPE, try_delete, EMCC, config
-from tools import building
+from tools.shared import run_process, PIPE, EMCC, config
+from tools import building, utils
 
 # standard arguments for timing:
 # 0: no runtime, just startup
@@ -197,7 +197,7 @@ class EmscriptenBenchmarker(Benchmarker):
       emcc_args += lib_builder('js_' + llvm_root, native=False, env_init=env_init)
     final = os.path.dirname(filename) + os.path.sep + self.name + ('_' if self.name else '') + os.path.basename(filename) + '.js'
     final = final.replace('.cpp', '')
-    try_delete(final)
+    utils.delete_file(final)
     cmd = [
       EMCC, filename,
       OPTIMIZATIONS,
@@ -317,7 +317,7 @@ class CheerpBenchmarker(Benchmarker):
       cheerp_args += ['-cheerp-pretty-code'] # get function names, like emcc --profiling
     final = os.path.dirname(filename) + os.path.sep + self.name + ('_' if self.name else '') + os.path.basename(filename) + '.js'
     final = final.replace('.cpp', '')
-    try_delete(final)
+    utils.delete_file(final)
     dirs_to_delete = []
     cheerp_args += ['-cheerp-preexecute']
     try:
@@ -339,7 +339,7 @@ class CheerpBenchmarker(Benchmarker):
         run_binaryen_opts(final.replace('.js', '.wasm'), self.binaryen_opts)
     finally:
       for dir_ in dirs_to_delete:
-        try_delete(dir_)
+        utils.delete_dir(dir_)
 
   def run(self, args):
     return jsrun.run_js(self.filename, engine=self.engine, args=args, stderr=PIPE)

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -26,7 +26,7 @@ from common import read_file, requires_v8, also_with_minimal_runtime, EMRUN
 from tools import shared
 from tools import ports
 from tools.shared import EMCC, WINDOWS, FILE_PACKAGER, PIPE
-from tools.shared import try_delete
+from tools.utils import delete_file, delete_dir
 
 
 def test_chunked_synchronous_xhr_server(support_byte_ranges, chunkSize, data, checksum, port):
@@ -245,8 +245,8 @@ class browser(BrowserCore):
       ''')
     # use relative paths when calling emcc, because file:// URIs can only load
     # sourceContent when the maps are relative paths
-    try_delete(html_file)
-    try_delete(html_file + '.map')
+    delete_file(html_file)
+    delete_file(html_file + '.map')
     self.compile_btest(['src.cpp', '-o', 'src.html', '-gsource-map'])
     self.assertExists(html_file)
     self.assertExists('src.wasm.map')
@@ -339,7 +339,7 @@ If manually bisecting:
     self.btest_exit('main.cpp', args=['--preload-file', absolute_src_path])
 
     # Test subdirectory handling with asset packaging.
-    try_delete('assets')
+    delete_dir('assets')
     ensure_dir('assets/sub/asset1/'.replace('\\', '/'))
     ensure_dir('assets/sub/asset1/.git'.replace('\\', '/')) # Test adding directory that shouldn't exist.
     ensure_dir('assets/sub/asset2/'.replace('\\', '/'))
@@ -2560,8 +2560,8 @@ void *getBindBuffer() {
     print(out)
 
     # Tidy up files that might have been created by this test.
-    try_delete(test_file('uuid/test.js'))
-    try_delete(test_file('uuid/test.js.map'))
+    delete_file(test_file('uuid/test.js'))
+    delete_file(test_file('uuid/test.js.map'))
 
     # Now run test in browser
     self.btest_exit(test_file('uuid/test.c'), args=['-luuid'])
@@ -4040,7 +4040,7 @@ Module["preRun"].push(function () {
     # Test that it is possible to define "Module.locateFile(foo)" function to locate where worker.js will be loaded from.
     create_file('shell2.html', read_file(path_from_root('src/shell.html')).replace('var Module = {', 'var Module = { locateFile: function(filename) { if (filename == "test.worker.js") return "cdn/test.worker.js"; else return filename; }, '))
     self.compile_btest(['main.cpp', '--shell-file', 'shell2.html', '-sWASM=0', '-sIN_TEST_HARNESS', '-sUSE_PTHREADS', '-sPTHREAD_POOL_SIZE', '-o', 'test2.html'], reporting=Reporting.JS_ONLY)
-    try_delete('test.worker.js')
+    delete_file('test.worker.js')
     self.run_browser('test2.html', '/report_result?exit:0')
 
   # Test that if the main thread is performing a futex wait while a pthread needs it to do a proxied operation (before that pthread would wake up the main thread), that it's not a deadlock.
@@ -5295,7 +5295,7 @@ Module["preRun"].push(function () {
       return self.skipTest('ff hangs on the main_thread version. browser bug?')
     create_file('data.dat', 'hello, fetch')
     create_file('test.txt', 'fetch 2')
-    try_delete('subdir')
+    delete_dir('subdir')
     ensure_dir('subdir')
     create_file('subdir/backendfile', 'file 1')
     create_file('subdir/backendfile2', 'file 2')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -19,9 +19,9 @@ from functools import wraps
 if __name__ == '__main__':
   raise Exception('do not run this file directly; do something like: test/runner')
 
-from tools.shared import try_delete, PIPE
+from tools.shared import PIPE
 from tools.shared import EMCC, EMAR
-from tools.utils import WINDOWS, MACOS, write_file
+from tools.utils import WINDOWS, MACOS, write_file, delete_file
 from tools import shared, building, config, webassembly
 import common
 from common import RunnerCore, path_from_root, requires_native_clang, test_file, create_file
@@ -4064,7 +4064,7 @@ ok
 
     if isinstance(main, list):
       # main is just a library
-      try_delete('main.js')
+      delete_file('main.js')
       self.run_process([EMCC] + main + self.get_emcc_args() + ['-o', 'main.js'])
       self.do_run('main.js', expected, no_build=True, **kwargs)
     else:
@@ -6380,7 +6380,7 @@ int main(void) {
     if self.emcc_args == []:
       # emcc should build in dlmalloc automatically, and do all the sign correction etc. for it
 
-      try_delete('src.js')
+      delete_file('src.js')
       self.run_process([EMCC, test_file('dlmalloc_test.c'), '-sINITIAL_MEMORY=128MB', '-o', 'src.js'], stdout=PIPE, stderr=self.stderr_redirect)
 
       self.do_run(None, '*1,0*', ['200', '1'], no_build=True)

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -18,8 +18,9 @@ from common import parameterized, EMBUILDER
 from tools.config import EM_CONFIG
 from tools.shared import EMCC
 from tools.shared import CANONICAL_TEMP_DIR
-from tools.shared import try_delete, config
+from tools.shared import config
 from tools.shared import EXPECTED_LLVM_VERSION, Cache
+from tools.utils import delete_file, delete_dir
 from tools import shared, utils
 from tools import response_file
 from tools import ports
@@ -44,8 +45,8 @@ def restore_and_set_up():
 
 # wipe the config and sanity files, creating a blank slate
 def wipe():
-  try_delete(EM_CONFIG)
-  try_delete(SANITY_FILE)
+  delete_file(EM_CONFIG)
+  delete_file(SANITY_FILE)
 
 
 def add_to_config(content):
@@ -212,7 +213,7 @@ class sanity(RunnerCore):
 
     # The guessed config should be ok
     # XXX This depends on your local system! it is possible `which` guesses wrong
-    # try_delete('a.out.js')
+    # delete_file('a.out.js')
     # output = self.run_process([EMCC, test_file('hello_world.c')], stdout=PIPE, stderr=PIPE).output
     # self.assertContained('hello, world!', self.run_js('a.out.js'), output)
 
@@ -229,7 +230,7 @@ class sanity(RunnerCore):
           elif 'runner' not in ' '.join(command):
             self.assertContained('error: NODE_JS is set to empty value', output) # sanity check should fail
         finally:
-          try_delete(default_config)
+          delete_file(default_config)
 
   def test_llvm(self):
     LLVM_WARNING = 'LLVM version for clang executable'
@@ -252,7 +253,7 @@ class sanity(RunnerCore):
 
     for inc_x in range(-2, 3):
       for inc_y in range(-2, 3):
-        try_delete(SANITY_FILE)
+        delete_file(SANITY_FILE)
         expected_x = real_version_x + inc_x
         expected_y = real_version_y + inc_y
         if expected_x < 0 or expected_y < 0:
@@ -303,7 +304,7 @@ class sanity(RunnerCore):
                              ('v4.2.3-pre', True),
                              ('cheez', False)]:
       print(version, succeed)
-      try_delete(SANITY_FILE)
+      delete_file(SANITY_FILE)
       f = open(self.in_dir('fake', 'nodejs'), 'w')
       f.write('#!/bin/sh\n')
       f.write('''if [ $1 = "--version" ]; then
@@ -354,7 +355,7 @@ fi
     # but with EMCC_DEBUG=1 we should check
     with env_modify({'EMCC_DEBUG': '1'}):
       output = self.check_working(EMCC)
-    try_delete(CANONICAL_TEMP_DIR)
+    delete_dir(CANONICAL_TEMP_DIR)
 
     self.assertContained(SANITY_MESSAGE, output)
     output = self.check_working(EMCC)
@@ -568,7 +569,7 @@ fi
       self.do([EMCC, '--clear-cache'])
       print(i)
       if i == 0:
-        try_delete(PORTS_DIR)
+        delete_dir(PORTS_DIR)
       else:
         self.do([EMCC, '--clear-ports'])
       self.assertNotExists(PORTS_DIR)
@@ -619,7 +620,7 @@ fi
                  ('node',   config.NODE_JS),
                  ('nodejs', config.NODE_JS)]
     for filename, engine in jsengines:
-      try_delete(SANITY_FILE)
+      delete_file(SANITY_FILE)
       if type(engine) is list:
         engine = engine[0]
       if not engine:
@@ -682,7 +683,7 @@ fi
         self.check_working([EMCC] + MINIMAL_HELLO_WORLD + ['-c'], expected)
 
     test_with_fake('got js backend! JavaScript (asm.js, emscripten) backend', 'LLVM has not been built with the WebAssembly backend')
-    try_delete(CANONICAL_TEMP_DIR)
+    delete_dir(CANONICAL_TEMP_DIR)
 
   def test_required_config_settings(self):
     # with no binaryen root, an error is shown

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -18,7 +18,7 @@ import clang_native
 import common
 from common import BrowserCore, no_windows, create_file, test_file, read_file
 from common import parameterized, requires_native_clang, PYTHON
-from tools import shared, config, utils
+from tools import config, utils
 from tools.shared import EMCC, path_from_root, run_process, CLANG_CC
 
 npm_checked = False
@@ -267,7 +267,6 @@ class sockets(BrowserCore):
   @no_windows('This test uses Unix-specific build architecture.')
   def test_enet(self):
     # this is also a good test of raw usage of emconfigure and emmake
-    shared.try_delete('enet')
     shutil.copytree(test_file('third_party', 'enet'), 'enet')
     with utils.chdir('enet'):
       self.run_process([path_from_root('emconfigure'), './configure', '--disable-shared'])

--- a/tools/building.py
+++ b/tools/building.py
@@ -25,7 +25,7 @@ from . import utils
 from .shared import CLANG_CC, CLANG_CXX
 from .shared import LLVM_NM, EMCC, EMAR, EMXX, EMRANLIB, WASM_LD, LLVM_AR
 from .shared import LLVM_LINK, LLVM_OBJCOPY
-from .shared import try_delete, run_process, check_call, exit_with_error
+from .shared import run_process, check_call, exit_with_error
 from .shared import path_from_root
 from .shared import asmjs_mangle, DEBUG
 from .shared import TEMP_DIR
@@ -71,7 +71,7 @@ def extract_archive_contents(archive_files):
   unpack_temp_dir = tempfile.mkdtemp('_archive_contents', 'emscripten_temp_')
 
   def clean_at_exit():
-    try_delete(unpack_temp_dir)
+    utils.delete_dir(unpack_temp_dir)
   shared.atexit.register(clean_at_exit)
 
   archive_contents = []
@@ -521,7 +521,7 @@ def link_bitcode(args, target, force_archive_contents=False):
     scan_archive_group(current_archive_group)
     current_archive_group = None
 
-  try_delete(target)
+  utils.delete_file(target)
 
   # Finish link
   # tolerate people trying to link a.so a.so etc.
@@ -595,7 +595,7 @@ def parse_llvm_nm_symbols(output):
 
 
 def emar(action, output_filename, filenames, stdout=None, stderr=None, env=None):
-  try_delete(output_filename)
+  utils.delete_file(output_filename)
   cmd = [EMAR, action, output_filename] + filenames
   cmd = get_command_with_possible_response_file(cmd)
   run_process(cmd, stdout=stdout, stderr=stderr, env=env)
@@ -913,7 +913,7 @@ def run_closure_cmd(cmd, filename, env, pretty):
   # But it looks like it creates such files on Linux(?) even without setting that command line
   # flag (and currently we don't), so delete the produced source map file to not leak files in
   # temp directory.
-  try_delete(outfile + '.map')
+  utils.delete_file(outfile + '.map')
 
   # Print Closure diagnostics result up front.
   if proc.returncode != 0:

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -8,7 +8,7 @@ import logging
 import os
 from pathlib import Path
 
-from . import tempfiles, filelock, config, utils
+from . import filelock, config, utils
 from .settings import settings
 
 logger = logging.getLogger('cache')
@@ -83,9 +83,8 @@ class Cache:
 
   def erase(self):
     with self.lock():
-      if self.dirname.exists():
-        for f in os.listdir(self.dirname):
-          tempfiles.try_delete(Path(self.dirname, f))
+      # Delete everything except the lockfile itself
+      utils.delete_contents(self.dirname, exclude=[os.path.basename(self.filelock_name)])
 
   def get_path(self, name):
     return Path(self.dirname, name)
@@ -133,7 +132,7 @@ class Cache:
       name = Path(self.dirname, shortname)
       if name.exists():
         logger.info(f'deleting cached file: {name}')
-        tempfiles.try_delete(name)
+        utils.delete_file(name)
 
   def get_lib(self, libname, *args, **kwargs):
     name = self.get_lib_name(libname)

--- a/tools/minimal_runtime_shell.py
+++ b/tools/minimal_runtime_shell.py
@@ -206,7 +206,7 @@ def generate_minimal_runtime_html(target, options, js_target, target_basename):
   # In SINGLE_FILE build, embed the main .js file into the .html output
   if settings.SINGLE_FILE:
     js_contents = utils.read_file(js_target)
-    shared.try_delete(js_target)
+    utils.delete_file(js_target)
   else:
     js_contents = ''
   shell = shell.replace('{{{ JS_CONTENTS_IN_SINGLE_FILE_BUILD }}}', js_contents)

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -77,7 +77,7 @@ class Ports:
     if not target:
       target = os.path.basename(src_dir)
     dest = Ports.get_include_dir(target)
-    shared.try_delete(dest)
+    utils.delete_dir(dest)
     logger.debug(f'installing headers: {dest}')
     shutil.copytree(src_dir, dest)
 
@@ -144,9 +144,7 @@ class Ports:
   @staticmethod
   def erase():
     dirname = Ports.get_dir()
-    shared.try_delete(dirname)
-    if os.path.exists(dirname):
-      logger.warning('could not delete ports dir %s - try to delete it manually' % dirname)
+    utils.delete_dir(dirname)
 
   @staticmethod
   def get_build_dir():
@@ -192,7 +190,7 @@ class Ports:
               logger.warning(f'not grabbing local port: {name} from {path} to {fullname} (subdir: {subdir}) as the destination {target} is newer (run emcc --clear-ports if that is incorrect)')
             else:
               logger.warning(f'grabbing local port: {name} from {path} to {fullname} (subdir: {subdir})')
-              shared.try_delete(fullname)
+              utils.delete_file(fullname)
               shutil.copytree(path, target)
               Ports.clear_project_build(name)
             return
@@ -253,8 +251,8 @@ class Ports:
           return
         # file exists but tag is bad
         logger.warning('local copy of port is not correct, retrieving from remote server')
-        shared.try_delete(fullname)
-        shared.try_delete(fullpath)
+        utils.delete_dir(fullname)
+        utils.delete_file(fullpath)
 
       retrieve()
       unpack()
@@ -267,7 +265,7 @@ class Ports:
     port = ports_by_name[name]
     port.clear(Ports, settings, shared)
     build_dir = os.path.join(Ports.get_build_dir(), name)
-    shared.try_delete(build_dir)
+    utils.delete_dir(build_dir)
     return build_dir
 
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -34,7 +34,6 @@ logging.basicConfig(format='%(name)s:%(levelname)s: %(message)s',
                     level=logging.DEBUG if DEBUG else logging.INFO)
 colored_logger.enable()
 
-from .tempfiles import try_delete
 from .utils import path_from_root, exit_with_error, safe_ensure_dirs, WINDOWS
 from . import cache, tempfiles
 from . import diagnostics
@@ -482,7 +481,7 @@ def get_emscripten_temp_dir():
     if not DEBUG_SAVE:
       def prepare_to_clean_temp(d):
         def clean_temp():
-          try_delete(d)
+          utils.delete_dir(d)
 
         atexit.register(clean_temp)
       # this global var might change later

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -14,7 +14,7 @@ from enum import IntEnum, auto
 from glob import iglob
 
 from . import shared, building, utils
-from . import deps_info, tempfiles
+from . import deps_info
 from . import diagnostics
 from tools.shared import demangle_c_symbol_name
 from tools.settings import settings
@@ -334,7 +334,7 @@ class Library:
     utils.safe_ensure_dirs(build_dir)
     create_lib(out_filename, self.build_objects(build_dir))
     if not shared.DEBUG:
-      tempfiles.try_delete(build_dir)
+      utils.delete_dir(build_dir)
 
   @classmethod
   def _inherit_list(cls, attr):

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -5,6 +5,7 @@
 
 import contextlib
 import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -93,3 +94,32 @@ def write_binary(file_path, contents):
   """Write to a file opened in binary mode"""
   with open(file_path, 'wb') as fh:
     fh.write(contents)
+
+
+def delete_file(filename):
+  """Delete a file (if it exists)."""
+  if not os.path.exists(filename):
+    return
+  os.remove(filename)
+
+
+def delete_dir(dirname):
+  """Delete a directory (if it exists)."""
+  if not os.path.exists(dirname):
+    return
+  shutil.rmtree(dirname)
+
+
+def delete_contents(dirname, exclude=None):
+  """Delete the contents of a directory without removing
+  the directory itself."""
+  if not os.path.exists(dirname):
+    return
+  for entry in os.listdir(dirname):
+    if exclude and entry in exclude:
+      continue
+    entry = os.path.join(dirname, entry)
+    if os.path.isdir(entry):
+      delete_dir(entry)
+    else:
+      delete_file(entry)

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -15,7 +15,7 @@ __scriptdir__ = os.path.dirname(os.path.abspath(__file__))
 __rootdir__ = os.path.dirname(__scriptdir__)
 sys.path.append(__rootdir__)
 
-from tools import shared, utils
+from tools import utils
 
 sys.path.append(utils.path_from_root('third_party'))
 sys.path.append(utils.path_from_root('third_party/ply'))
@@ -50,8 +50,8 @@ class Dummy:
 input_file = sys.argv[1]
 output_base = sys.argv[2]
 
-shared.try_delete(output_base + '.cpp')
-shared.try_delete(output_base + '.js')
+utils.delete_file(output_base + '.cpp')
+utils.delete_file(output_base + '.js')
 
 p = WebIDL.Parser()
 p.parse(r'''


### PR DESCRIPTION


The code in `tempfiles.try_delete` went to great length to never fail
and change the permission bits of the things it was trying to delete.

However, in most cases is undesirable and overkill.  We don't want to
silently fail if the delete fails, and we don't want to delete read only
files in most cases.

The exception is in the test suite were we do sometimes create read only
and we want to be able to clean them up.  So I created a test-only
helper called `force_delete_dir`, but even then we don't want to
silently fail so the try/catch was removed here.