### PR TITLE
Send unhandledrejection events to the main thread

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,8 @@ See docs/process.md for more on how version tagging works.
   emscripten (llvm, wabt, binaryen).  This should not effect any users of
   emscripten, only developers. (#17502)
 - The llvm version that emscripten uses was updated to 16.0.0 (#17534)
+- worker.js now propagates unhandled promise rejections to the main thread the
+  same way it propagates uncaught exceptions.
 
 3.1.17 - 07/22/2022
 ------

--- a/src/worker.js
+++ b/src/worker.js
@@ -105,6 +105,14 @@ Module['instantiateWasm'] = (info, receiveInstance) => {
 }
 #endif
 
+// Turn unhandled rejected promises into errors so that the main thread will be
+// notified about them.
+self.onunhandledrejection = (e) => {
+  if (typeof(e.reason) !== 'undefined') {
+    throw e.reason;
+  }
+};
+
 self.onmessage = (e) => {
   try {
     if (e.data.cmd === 'load') { // Preload command that is called once per worker to parse and load the Emscripten code.

--- a/src/worker.js
+++ b/src/worker.js
@@ -108,7 +108,7 @@ Module['instantiateWasm'] = (info, receiveInstance) => {
 // Turn unhandled rejected promises into errors so that the main thread will be
 // notified about them.
 self.onunhandledrejection = (e) => {
-  if (typeof(e.reason) !== 'undefined') {
+  if (typeof e.reason !== 'undefined') {
     throw e.reason;
   }
 };

--- a/src/worker.js
+++ b/src/worker.js
@@ -111,6 +111,7 @@ self.onunhandledrejection = (e) => {
   if (typeof e.reason !== 'undefined') {
     throw e.reason;
   }
+  throw e;
 };
 
 self.onmessage = (e) => {

--- a/src/worker.js
+++ b/src/worker.js
@@ -108,10 +108,7 @@ Module['instantiateWasm'] = (info, receiveInstance) => {
 // Turn unhandled rejected promises into errors so that the main thread will be
 // notified about them.
 self.onunhandledrejection = (e) => {
-  if (typeof e.reason !== 'undefined') {
-    throw e.reason;
-  }
-  throw e;
+  throw e.reason ?? e;
 };
 
 self.onmessage = (e) => {

--- a/test/common.py
+++ b/test/common.py
@@ -1532,7 +1532,7 @@ class BrowserCore(RunnerCore):
             if extra_tries > 0:
               print('[test error (see below), automatically retrying]')
               print(e)
-              return self.run_browser(html_file, message, expected, timeout, extra_tries - 1)
+              return self.run_browser(html_file, expected, message, timeout, extra_tries - 1)
             else:
               raise e
       finally:

--- a/test/pthread/test_pthread_unhandledrejection.c
+++ b/test/pthread/test_pthread_unhandledrejection.c
@@ -1,0 +1,5 @@
+#include <emscripten/emscripten.h>
+
+int main() {
+  EM_ASM({ Promise.reject("rejected!"); });
+}

--- a/test/pthread/test_pthread_unhandledrejection.c
+++ b/test/pthread/test_pthread_unhandledrejection.c
@@ -2,4 +2,5 @@
 
 int main() {
   EM_ASM({ Promise.reject("rejected!"); });
+  emscripten_exit_with_live_runtime();
 }

--- a/test/pthread/test_pthread_unhandledrejection.post.js
+++ b/test/pthread/test_pthread_unhandledrejection.post.js
@@ -1,0 +1,15 @@
+if (!ENVIRONMENT_IS_PTHREAD) {
+  if (ENVIRONMENT_IS_NODE) {
+    process.on('error', (e) => {
+      if (e === 'rejected!') {
+        console.log('passed');
+      }
+    });
+  } else {
+    addEventListener('error', (e) => {
+      if (e.message === 'Uncaught rejected!') {
+        console.log('passed');
+      }
+    });
+  }
+}

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5377,6 +5377,14 @@ Module["preRun"].push(function () {
   def test_assert_failure(self):
     self.btest(test_file('browser/test_assert_failure.c'), 'abort:Assertion failed: false && "this is a test"')
 
+  def test_pthread_unhandledrejection(self):
+    # Check that an unhandled promise rejection is propagated to the main thread
+    # as an error. This test is failing if it hangs!
+    self.btest(test_file('pthread/test_pthread_unhandledrejection.c'),
+               args=['-pthread', '-sPROXY_TO_PTHREAD', '--post-js',
+                     test_file('pthread/test_pthread_unhandledrejection.post.js')],
+               expected='exception:Uncaught [object ErrorEvent] / undefined')
+
   def test_full_js_library_strict(self):
     self.btest_exit(test_file('hello_world.c'), args=['-sINCLUDE_FULL_LIBRARY', '-sSTRICT_JS'])
 

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5377,6 +5377,7 @@ Module["preRun"].push(function () {
   def test_assert_failure(self):
     self.btest(test_file('browser/test_assert_failure.c'), 'abort:Assertion failed: false && "this is a test"')
 
+  @no_firefox('output slightly different in FireFox')
   def test_pthread_unhandledrejection(self):
     # Check that an unhandled promise rejection is propagated to the main thread
     # as an error. This test is failing if it hangs!

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9066,6 +9066,14 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_run_in_out_file_test('core/pthread/test_pthread_exit_main.c')
 
   @node_pthreads
+  def test_pthread_unhandledrejection(self):
+    # Check that an unhandled promise rejection is propagated to the main thread
+    # as an error.
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.emcc_args += ['--post-js', test_file('pthread/test_pthread_unhandledrejection.post.js')]
+    self.do_runf(test_file('pthread/test_pthread_unhandledrejection.c'), 'passed')
+
+  @node_pthreads
   @no_wasm2js('wasm2js does not support PROXY_TO_PTHREAD (custom section support)')
   def test_pthread_offset_converter(self):
     self.set_setting('PROXY_TO_PTHREAD')


### PR DESCRIPTION
We send uncaught exceptions to the main thread where they can be handled in a
central location, but we did not previously send unhandledrejection events that
are created when a promise is rejected with no handler. Add a handler in
worker.js that intercepts unhandledrejection events and throws them as errors so
they are propagated to the main thread in the usual manner.

The way this works varies slightly between Node and the browser, so add tests
for both cases.