### PR TITLE
[WasmFS] Support errors in `open`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,8 @@ See docs/process.md for more on how version tagging works.
   emscripten (llvm, wabt, binaryen).  This should not effect any users of
   emscripten, only developers. (#17502)
 - The llvm version that emscripten uses was updated to 16.0.0 (#17534)
+- worker.js now propagates unhandled promise rejections to the main thread the
+  same way it propagates uncaught exceptions.
 
 3.1.17 - 07/22/2022
 ------

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -232,7 +232,9 @@ mergeInto(LibraryManager.library, {
       }
       accessID = wasmfsOPFSAllocate(wasmfsOPFSAccessHandles, accessHandle);
     } catch (e) {
-      if (e.name === "InvalidStateError") {
+      // TODO: Presumably only one of these will appear in the final API?
+      if (e.name === "InvalidStateError" ||
+          e.name === "NoModificationAllowedError") {
         accessID = -1;
       } else {
         throw e;

--- a/src/worker.js
+++ b/src/worker.js
@@ -105,6 +105,14 @@ Module['instantiateWasm'] = (info, receiveInstance) => {
 }
 #endif
 
+// Turn unhandled rejected promises into errors so that the main thread will be
+// notified about them.
+self.onunhandledrejection = (e) => {
+  if (typeof(e.reason) !== 'undefined') {
+    throw e.reason;
+  }
+};
+
 self.onmessage = (e) => {
   try {
     if (e.data.cmd === 'load') { // Preload command that is called once per worker to parse and load the Emscripten code.

--- a/src/worker.js
+++ b/src/worker.js
@@ -108,7 +108,7 @@ Module['instantiateWasm'] = (info, receiveInstance) => {
 // Turn unhandled rejected promises into errors so that the main thread will be
 // notified about them.
 self.onunhandledrejection = (e) => {
-  if (typeof(e.reason) !== 'undefined') {
+  if (typeof e.reason !== 'undefined') {
     throw e.reason;
   }
 };

--- a/src/worker.js
+++ b/src/worker.js
@@ -111,6 +111,7 @@ self.onunhandledrejection = (e) => {
   if (typeof e.reason !== 'undefined') {
     throw e.reason;
   }
+  throw e;
 };
 
 self.onmessage = (e) => {

--- a/src/worker.js
+++ b/src/worker.js
@@ -108,10 +108,7 @@ Module['instantiateWasm'] = (info, receiveInstance) => {
 // Turn unhandled rejected promises into errors so that the main thread will be
 // notified about them.
 self.onunhandledrejection = (e) => {
-  if (typeof e.reason !== 'undefined') {
-    throw e.reason;
-  }
-  throw e;
+  throw e.reason ?? e;
 };
 
 self.onmessage = (e) => {

--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -156,10 +156,7 @@ private:
     WASMFS_UNREACHABLE("TODO: implement NodeFile::setSize");
   }
 
-  void open(oflags_t flags) override {
-    // TODO: Properly report errors.
-    state.open(flags);
-  }
+  int open(oflags_t flags) override { return state.open(flags); }
 
   void close() override { state.close(); }
 

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -272,12 +272,7 @@ private:
     }
   }
 
-  void open(oflags_t flags) override {
-    if (auto err = state.open(proxy, fileID, flags); err < 0) {
-      // TODO: Proper error reporting.
-      assert(false && "error during open");
-    }
-  }
+  int open(oflags_t flags) override { return state.open(proxy, fileID, flags); }
 
   void close() override { state.close(proxy); }
 

--- a/system/lib/wasmfs/backends/proxied_file_backend.cpp
+++ b/system/lib/wasmfs/backends/proxied_file_backend.cpp
@@ -22,8 +22,10 @@ class ProxiedFile : public DataFile {
   emscripten::ProxyWorker& proxy;
   std::shared_ptr<DataFile> baseFile;
 
-  void open(oflags_t flags) override {
-    proxy([&]() { baseFile->locked().open(flags); });
+  int open(oflags_t flags) override {
+    int err;
+    proxy([&]() { err = baseFile->locked().open(flags); });
+    return err;
   }
 
   void close() override {

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -129,9 +129,8 @@ class DataFile : public File {
 protected:
   // Notify the backend when this file is opened or closed. The backend is
   // responsible for keeping files accessible as long as they are open, even if
-  // they are unlinked.
-  // TODO: Report errors.
-  virtual void open(oflags_t flags) = 0;
+  // they are unlinked. Returns 0 on success or a negative error code.
+  virtual int open(oflags_t flags) = 0;
   virtual void close() = 0;
 
   // Return the accessed length or a negative error code. It is not an error to
@@ -289,7 +288,7 @@ public:
   Handle(std::shared_ptr<File> dataFile) : File::Handle(dataFile) {}
   Handle(Handle&&) = default;
 
-  void open(oflags_t flags) { getFile()->open(flags); }
+  [[nodiscard]] int open(oflags_t flags) { return getFile()->open(flags); }
   void close() { getFile()->close(); }
 
   ssize_t read(uint8_t* buf, size_t len, off_t offset) {

--- a/system/lib/wasmfs/file_table.cpp
+++ b/system/lib/wasmfs/file_table.cpp
@@ -12,12 +12,15 @@
 namespace wasmfs {
 
 FileTable::FileTable() {
-  entries.push_back(
-    std::make_shared<OpenFileState>(0, O_RDONLY, SpecialFiles::getStdin()));
-  entries.push_back(
-    std::make_shared<OpenFileState>(0, O_WRONLY, SpecialFiles::getStdout()));
-  entries.push_back(
-    std::make_shared<OpenFileState>(0, O_WRONLY, SpecialFiles::getStderr()));
+  entries.emplace_back();
+  (void)OpenFileState::create(
+    SpecialFiles::getStdin(), O_RDONLY, entries.back());
+  entries.emplace_back();
+  (void)OpenFileState::create(
+    SpecialFiles::getStdout(), O_WRONLY, entries.back());
+  entries.emplace_back();
+  (void)OpenFileState::create(
+    SpecialFiles::getStderr(), O_WRONLY, entries.back());
 }
 
 std::shared_ptr<OpenFileState> FileTable::Handle::getEntry(__wasi_fd_t fd) {

--- a/system/lib/wasmfs/js_impl_backend.h
+++ b/system/lib/wasmfs/js_impl_backend.h
@@ -77,7 +77,7 @@ class JSImplFile : public DataFile {
   }
 
   // TODO: Notify the JS about open and close events?
-  void open(oflags_t) override {}
+  int open(oflags_t) override { return 0; }
   void close() override {}
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -19,7 +19,7 @@ namespace wasmfs {
 class MemoryFile : public DataFile {
   std::vector<uint8_t> buffer;
 
-  void open(oflags_t) override {}
+  int open(oflags_t) override { return 0; }
   void close() override {}
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override;
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override;

--- a/system/lib/wasmfs/pipe_backend.h
+++ b/system/lib/wasmfs/pipe_backend.h
@@ -23,7 +23,7 @@ using PipeData = std::queue<uint8_t>;
 class PipeFile : public DataFile {
   std::shared_ptr<PipeData> data;
 
-  void open(oflags_t) override {}
+  int open(oflags_t) override { return 0; }
   void close() override {}
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {

--- a/system/lib/wasmfs/proxied_async_js_impl_backend.h
+++ b/system/lib/wasmfs/proxied_async_js_impl_backend.h
@@ -85,7 +85,7 @@ class ProxiedAsyncJSImplFile : public DataFile {
   }
 
   // TODO: Notify the JS about open and close events?
-  void open(oflags_t) override {}
+  int open(oflags_t) override { return 0; }
   void close() override {}
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {

--- a/system/lib/wasmfs/special_files.cpp
+++ b/system/lib/wasmfs/special_files.cpp
@@ -19,7 +19,7 @@ namespace {
 
 // No-op reads and writes: /dev/null
 class NullFile : public DataFile {
-  void open(oflags_t) override {}
+  int open(oflags_t) override { return 0; }
   void close() override {}
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
@@ -37,7 +37,7 @@ public:
 };
 
 class StdinFile : public DataFile {
-  void open(oflags_t) override {}
+  int open(oflags_t) override { return 0; }
   void close() override {}
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
@@ -62,7 +62,7 @@ class WritingStdFile : public DataFile {
 protected:
   std::vector<char> writeBuffer;
 
-  void open(oflags_t) override {}
+  int open(oflags_t) override { return 0; }
   void close() override {}
 
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
@@ -134,7 +134,7 @@ public:
 };
 
 class RandomFile : public DataFile {
-  void open(oflags_t) override {}
+  int open(oflags_t) override { return 0; }
   void close() override {}
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {

--- a/test/common.py
+++ b/test/common.py
@@ -1532,7 +1532,7 @@ class BrowserCore(RunnerCore):
             if extra_tries > 0:
               print('[test error (see below), automatically retrying]')
               print(e)
-              return self.run_browser(html_file, message, expected, timeout, extra_tries - 1)
+              return self.run_browser(html_file, expected, message, timeout, extra_tries - 1)
             else:
               raise e
       finally:

--- a/test/pthread/test_pthread_unhandledrejection.c
+++ b/test/pthread/test_pthread_unhandledrejection.c
@@ -1,0 +1,5 @@
+#include <emscripten/emscripten.h>
+
+int main() {
+  EM_ASM({ Promise.reject("rejected!"); });
+}

--- a/test/pthread/test_pthread_unhandledrejection.c
+++ b/test/pthread/test_pthread_unhandledrejection.c
@@ -2,4 +2,5 @@
 
 int main() {
   EM_ASM({ Promise.reject("rejected!"); });
+  emscripten_exit_with_live_runtime();
 }

--- a/test/pthread/test_pthread_unhandledrejection.post.js
+++ b/test/pthread/test_pthread_unhandledrejection.post.js
@@ -1,0 +1,15 @@
+if (!ENVIRONMENT_IS_PTHREAD) {
+  if (ENVIRONMENT_IS_NODE) {
+    process.on('error', (e) => {
+      if (e === 'rejected!') {
+        console.log('passed');
+      }
+    });
+  } else {
+    addEventListener('error', (e) => {
+      if (e.message === 'Uncaught rejected!') {
+        console.log('passed');
+      }
+    });
+  }
+}

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5377,6 +5377,14 @@ Module["preRun"].push(function () {
   def test_assert_failure(self):
     self.btest(test_file('browser/test_assert_failure.c'), 'abort:Assertion failed: false && "this is a test"')
 
+  def test_pthread_unhandledrejection(self):
+    # Check that an unhandled promise rejection is propagated to the main thread
+    # as an error. This test is failing if it hangs!
+    self.btest(test_file('pthread/test_pthread_unhandledrejection.c'),
+               args=['-pthread', '-sPROXY_TO_PTHREAD', '--post-js',
+                     test_file('pthread/test_pthread_unhandledrejection.post.js')],
+               expected='exception:Uncaught [object ErrorEvent] / undefined')
+
   def test_full_js_library_strict(self):
     self.btest_exit(test_file('hello_world.c'), args=['-sINCLUDE_FULL_LIBRARY', '-sSTRICT_JS'])
 

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5310,6 +5310,14 @@ Module["preRun"].push(function () {
     self.btest_exit(test, args=args + ['-DWASMFS_SETUP'])
     self.btest_exit(test, args=args + ['-DWASMFS_RESUME'])
 
+  @requires_threads
+  @no_firefox('no OPFS support yet')
+  def test_wasmfs_opfs_errors(self):
+    test = test_file('wasmfs/wasmfs_opfs_errors.c')
+    postjs = test_file('wasmfs/wasmfs_opfs_errors_post.js')
+    args = ['-sWASMFS', '-pthread', '-sPROXY_TO_PTHREAD', '--post-js', postjs]
+    self.btest(test, args=args, expected="0")
+
   @no_firefox('no 4GB support yet')
   def test_zzz_zzz_emmalloc_memgrowth(self, *args):
     self.btest(test_file('browser/emmalloc_memgrowth.cpp'), expected='0', args=['-sMALLOC=emmalloc', '-sALLOW_MEMORY_GROWTH=1', '-sABORTING_MALLOC=0', '-sASSERTIONS=2', '-sMINIMAL_RUNTIME=1', '-sMAXIMUM_MEMORY=4GB'])

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5377,6 +5377,7 @@ Module["preRun"].push(function () {
   def test_assert_failure(self):
     self.btest(test_file('browser/test_assert_failure.c'), 'abort:Assertion failed: false && "this is a test"')
 
+  @no_firefox('output slightly different in FireFox')
   def test_pthread_unhandledrejection(self):
     # Check that an unhandled promise rejection is propagated to the main thread
     # as an error. This test is failing if it hangs!

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9066,6 +9066,14 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_run_in_out_file_test('core/pthread/test_pthread_exit_main.c')
 
   @node_pthreads
+  def test_pthread_unhandledrejection(self):
+    # Check that an unhandled promise rejection is propagated to the main thread
+    # as an error.
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.emcc_args += ['--post-js', test_file('pthread/test_pthread_unhandledrejection.post.js')]
+    self.do_runf(test_file('pthread/test_pthread_unhandledrejection.c'), 'passed')
+
+  @node_pthreads
   @no_wasm2js('wasm2js does not support PROXY_TO_PTHREAD (custom section support)')
   def test_pthread_offset_converter(self):
     self.set_setting('PROXY_TO_PTHREAD')

--- a/test/wasmfs/wasmfs_opfs_errors.c
+++ b/test/wasmfs/wasmfs_opfs_errors.c
@@ -1,0 +1,62 @@
+#include <emscripten/emscripten.h>
+#include <emscripten/wasmfs.h>
+#include <emscripten/console.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+
+int main() {
+  wasmfs_create_directory("/opfs", 0777, wasmfs_create_opfs_backend());
+  EM_ASM({ run_test(); });
+  emscripten_exit_with_live_runtime();
+}
+
+const char* file = "/opfs/data";
+
+// Each of these functions returns:
+//   0: failure with EACCES
+//   1: success
+//   2: other error
+
+static int try_open(int flags) {
+  int fd = open(file, flags);
+  if (fd >= 0) {
+    close(fd);
+    return 1;
+  }
+  if (errno == EACCES) {
+    return 0;
+  }
+  emscripten_console_error(strerror(errno));
+  return 2;
+}
+
+
+EMSCRIPTEN_KEEPALIVE
+int try_open_wronly(void) {
+  return try_open(O_WRONLY);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int try_open_rdwr(void) {
+  return try_open(O_RDWR);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int try_open_rdonly(void) {
+  return try_open(O_RDONLY);
+}
+
+EMSCRIPTEN_KEEPALIVE
+void report_result(int result) {
+  EM_ASM({ console.log(new Error().stack); });
+#ifdef REPORT_RESULT
+  REPORT_RESULT(result);
+#else
+  if (result != 0) {
+    abort();
+  }
+#endif
+}

--- a/test/wasmfs/wasmfs_opfs_errors_post.js
+++ b/test/wasmfs/wasmfs_opfs_errors_post.js
@@ -1,0 +1,45 @@
+async function run_test() {
+  let access;
+  try {
+    let root = await navigator.storage.getDirectory();
+    let child = await root.getFileHandle("data", {create: true});
+    access = await child.createSyncAccessHandle();
+  } catch (e) {
+    console.log("test setup failed");
+    throw e;
+  }
+
+  // We won't be able to open the file for writing since there is already a
+  // file handle for it.
+
+  if (Module._try_open_wronly() != 0) {
+    throw "Did not get expected EACCES opening file for writing";
+  }
+
+  if (Module._try_open_rdwr() != 0) {
+    throw "Did not get expected EACCES opening file for reading and writing";
+  }
+
+  if (Module._try_open_rdonly() != 1) {
+    throw "Unexpected failure opening file for reading only";
+  }
+
+  await access.close();
+
+  // We can open the file in any mode now that there is no open access
+  // handle for it.
+
+  if (Module._try_open_wronly() != 1) {
+    throw "Unexpected failure opening file for writing";
+  }
+
+  if (Module._try_open_rdwr() != 1) {
+    throw "Unexpected failure opening file for reading and writing";
+  }
+
+  if (Module._try_open_rdonly() != 1) {
+    throw "Unexpected failure opening file for reading";
+  }
+
+  Module._report_result(0);
+}


### PR DESCRIPTION
Change the signature of the `open` method in the backend API to support
returning error codes. Also refactor how this method is called since it was
previously called in the `OpenFileState` constructor, but constructors are not
fallible.