### PR TITLE
Fix Fetch API problems

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -589,3 +589,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Márton Marczell <mmarczell.graphisoft@gmail.com> (copyright owned by GRAPHISOFT SE)
 * Alexander Vestin <alex.vestin@gmail.com>
 * Xiaobing Yang <yangxiaobing@jwzg.com>
+* Alexandra Cherdantseva <neluhus.vagus@gmail.com>

--- a/site/source/docs/api_reference/fetch.rst
+++ b/site/source/docs/api_reference/fetch.rst
@@ -262,8 +262,7 @@ state of the request.
 The emscripten_fetch_attr_t object has a timeoutMSecs field which allows
 specifying a timeout duration for the transfer. Additionally,
 emscripten_fetch_close() can be called at any time for asynchronous and waitable
-fetches to abort the download (this is currently broken, see `#8234
-<https://github.com/emscripten-core/emscripten/issues/8234>`_).
+fetches to abort the download.
 The following example illustrates these fields
 and the onprogress handler.
 

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -376,9 +376,8 @@ function fetchXHR(fetch, onsuccess, onerror, onprogress, onreadystatechange) {
     if (!(id in Fetch.xhrs)) { 
       return;
     }
-    var status = xhr.status; // XXX TODO: Overwriting xhr.status doesn't work here, so don't override anywhere else either.
 #if FETCH_DEBUG
-    console.error('fetch: xhr of URL "' + xhr.url_ + '" / responseURL "' + xhr.responseURL + '" finished with error, readyState ' + xhr.readyState + ' and status ' + status);
+    console.error('fetch: xhr of URL "' + xhr.url_ + '" / responseURL "' + xhr.responseURL + '" finished with error, readyState ' + xhr.readyState + ' and status ' + xhr.status);
 #endif
     saveResponseAndStatus();
     if (onerror) onerror(fetch, xhr, e);
@@ -601,7 +600,7 @@ function fetchFree(id) {
     console.log("fetch: Deleting id:" + id + " of " + Fetch.xhrs);
 #endif
     var xhr = Fetch.xhrs[id];
-    if (xhr !== undefined) {
+    if (xhr) {
         delete Fetch.xhrs[id];
         // check if fetch is still in progress and should be aborted
         if (xhr.readyState > 0 && xhr.readyState < 4) {

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -427,7 +427,8 @@ function fetchXHR(fetch, onsuccess, onerror, onprogress, onreadystatechange) {
   };
   xhr.onreadystatechange = (e) => {
     // check if xhr was aborted by user and don't try to call back
-    if (!(id in Fetch.xhrs)) { 
+    if (!(id in Fetch.xhrs)) {
+      {{{ runtimeKeepalivePop() }}}
       return;
     }
     HEAPU16[fetch + {{{ C_STRUCTS.emscripten_fetch_t.readyState }}} >> 1] = xhr.readyState;
@@ -603,8 +604,8 @@ function fetchFree(id) {
     if (xhr !== undefined) {
         delete Fetch.xhrs[id];
         // check if fetch is still in progress and should be aborted
-        if (xhr.readyState > 0 && xhr.readyState < 4) { 
-            xhr.abort(); 
+        if (xhr.readyState > 0 && xhr.readyState < 4) {
+            xhr.abort();
         }
     }
 }

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -5,6 +5,7 @@
  */
 
 var Fetch = {
+  // Map of integer fetch id to XHR request object
   xhrs: {},
 
   // The web worker that runs proxied file I/O requests. (this field is populated on demand, start as undefined to save code size)

--- a/test/fetch/xhr_abort.cpp
+++ b/test/fetch/xhr_abort.cpp
@@ -8,51 +8,41 @@
 #include <assert.h>
 #include <emscripten/fetch.h>
 
-void handleSuccess(emscripten_fetch_t *fetch)
-{
+void handleSuccess(emscripten_fetch_t *fetch) {
   assert(false && "Should not succeed");
   emscripten_fetch_close(fetch);
 }
 
-void handleError(emscripten_fetch_t *fetch)
-{
+void handleError(emscripten_fetch_t *fetch) {
   printf("handleError: %d %s\n", fetch->status, fetch->statusText);
   bool isAbortedStatus = fetch->status == (unsigned short) -1;
   assert(isAbortedStatus); // should have aborted status
-  if (isAbortedStatus)
-  {
-    EM_ASM({
-      const xhr = Fetch.xhrs[$0];
-      const oldReadyStateChangeHandler = xhr.onreadystatechange;
-      // Overriding xhr handlers to check if xhr.abort() was called
-      xhr.onreadystatechange = (e) => {
-        console.log("fetch: xhr.readyState: " + xhr.readyState + ', status: ' + xhr.status);
-        assert(xhr.readyState === 0 || xhr.status === 0, "readyState should be equal to UNSENT(0) or status should be equal to 0 when calling xhr.abort()");
-        oldReadyStateChangeHandler(e);
-      };
-      xhr.onload = () => {
-        assert(false && "xhr.onload should not be called after xhr.abort()");
-      };
-      xhr.onerror = () => {
-        assert(false && "xhr.onerror should not be called after xhr.abort()");
-      };
-      xhr.onprogress = () => {
-        assert(false && "xhr.onprogress should not be called after xhr.abort()");
-      };
-    }, fetch->id);
-  } else
-  {
-    emscripten_fetch_close(fetch); // free fetch
-  }
+  EM_ASM({
+    const xhr = Fetch.xhrs[$0];
+    const oldReadyStateChangeHandler = xhr.onreadystatechange;
+    // Overriding xhr handlers to check if xhr.abort() was called
+    xhr.onreadystatechange = (e) => {
+      console.log("fetch: xhr.readyState: " + xhr.readyState + ', status: ' + xhr.status);
+      assert(xhr.readyState === 0 || xhr.status === 0, "readyState should be equal to UNSENT(0) or status should be equal to 0 when calling xhr.abort()");
+      oldReadyStateChangeHandler(e);
+    };
+    xhr.onload = () => {
+      assert(false, "xhr.onload should not be called after xhr.abort()");
+    };
+    xhr.onerror = () => {
+      assert(false, "xhr.onerror should not be called after xhr.abort()");
+    };
+    xhr.onprogress = () => {
+      assert(false, "xhr.onprogress should not be called after xhr.abort()");
+    };
+  }, fetch->id);
 }
 
-void handleStateChange(emscripten_fetch_t *fetch)
-{
+void handleStateChange(emscripten_fetch_t *fetch) {
   emscripten_fetch_close(fetch); // Abort the fetch
 }
 
-int main()
-{
+int main() {
   emscripten_fetch_attr_t attr;
   emscripten_fetch_attr_init(&attr);
   strcpy(attr.requestMethod, "GET");

--- a/test/fetch/xhr_abort.cpp
+++ b/test/fetch/xhr_abort.cpp
@@ -1,0 +1,65 @@
+// Copyright 2022 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <emscripten/fetch.h>
+
+void handleSuccess(emscripten_fetch_t *fetch)
+{
+  assert(false && "Should not succeed");
+  emscripten_fetch_close(fetch);
+}
+
+void handleError(emscripten_fetch_t *fetch)
+{
+  printf("handleError: %d %s\n", fetch->status, fetch->statusText);
+  bool isAbortedStatus = fetch->status == (unsigned short) -1;
+  assert(isAbortedStatus); // should have aborted status
+  if (isAbortedStatus)
+  {
+    EM_ASM({
+      const xhr = Fetch.xhrs[$0];
+      const oldReadyStateChangeHandler = xhr.onreadystatechange;
+      // Overriding xhr handlers to check if xhr.abort() was called
+      xhr.onreadystatechange = (e) => {
+        console.log("fetch: xhr.readyState: " + xhr.readyState + ', status: ' + xhr.status);
+        assert(xhr.readyState === 0 || xhr.status === 0, "readyState should be equal to UNSENT(0) or status should be equal to 0 when calling xhr.abort()");
+        oldReadyStateChangeHandler(e);
+      };
+      xhr.onload = () => {
+        assert(false && "xhr.onload should not be called after xhr.abort()");
+      };
+      xhr.onerror = () => {
+        assert(false && "xhr.onerror should not be called after xhr.abort()");
+      };
+      xhr.onprogress = () => {
+        assert(false && "xhr.onprogress should not be called after xhr.abort()");
+      };
+    }, fetch->id);
+  } else
+  {
+    emscripten_fetch_close(fetch); // free fetch
+  }
+}
+
+void handleStateChange(emscripten_fetch_t *fetch)
+{
+  emscripten_fetch_close(fetch); // Abort the fetch
+}
+
+int main()
+{
+  emscripten_fetch_attr_t attr;
+  emscripten_fetch_attr_init(&attr);
+  strcpy(attr.requestMethod, "GET");
+  attr.attributes = EMSCRIPTEN_FETCH_REPLACE;
+  attr.onsuccess = handleSuccess;
+  attr.onerror = handleError;
+  attr.onreadystatechange = handleStateChange;
+  auto fetch = emscripten_fetch(&attr, "gears.png");
+  return 0;
+}

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4597,6 +4597,11 @@ Module["preRun"].push(function () {
   def test_fetch_headers_received(self):
     self.btest_exit('fetch/headers_received.cpp', args=['-sFETCH_DEBUG', '-sFETCH'])
 
+  @also_with_wasm64
+  def test_fetch_xhr_abort(self):
+    shutil.copyfile(test_file('gears.png'), 'gears.png')
+    self.btest_exit('fetch/xhr_abort.cpp', args=['-sFETCH_DEBUG', '-sFETCH'])
+
   # Tests emscripten_fetch() usage in synchronous mode when used from the main
   # thread proxied to a Worker with -sPROXY_TO_PTHREAD option.
   @no_firefox('https://github.com/emscripten-core/emscripten/issues/16868')


### PR DESCRIPTION
- Fix emscripten_fetch_close to abort active xhrs
  - use dict for active xhrs instead of list to store id generated with globalFetchIdCounter in C
  - calling xhr.abort() will callback, so we add checks to not callback on destroyed emscripten_fetch_t instances
- Don't allocate memory for zero ptrLen (somehow zero-size allocation creates a new memory address, looks like a bug)
- Save response data in xhr.onload if it was not saved in xhr.onprogress