### PR TITLE
Temporarily disable stripping the code section from separate-dwarf files

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8689,8 +8689,11 @@ int main() {
       if not debug_wasm.has_name_section():
         self.fail('name section not found in separate dwarf file')
       for sec in debug_wasm.sections():
-        if sec.type == webassembly.SecType.CODE:
-          self.fail(f'section of type "{sec.type}" found in separate dwarf file')
+        # TODO(https://github.com/emscripten-core/emscripten/issues/13084):
+        # Re-enable this code once the debugger extension can handle wasm files
+        # with name sections but no code sections.
+        # if sec.type == webassembly.SecType.CODE:
+        #   self.fail(f'section of type "{sec.type}" found in separate dwarf file')
         if sec.name and sec.name != 'name' and not sec.name.startswith('.debug'):
           self.fail(f'non-debug section "{sec.name}" found in separate dwarf file')
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -1251,7 +1251,10 @@ def emit_debug_on_side(wasm_file):
   # TODO(dschuff): Also strip the DATA section? To make this work we'd need to
   # either allow "invalid" data segment name entries, or maybe convert the DATA
   # to a DATACOUNT section.
-  strip(wasm_file_with_dwarf, wasm_file_with_dwarf, sections=['CODE'])
+  # TODO(https://github.com/emscripten-core/emscripten/issues/13084): Re-enable
+  # this code once the debugger extension can handle wasm files with name
+  # sections but no code sections.
+  # strip(wasm_file_with_dwarf, wasm_file_with_dwarf, sections=['CODE'])
 
   # embed a section in the main wasm to point to the file with external DWARF,
   # see https://yurydelendik.github.io/webassembly-dwarf/#external-DWARF


### PR DESCRIPTION
The current version of the devtools debugger is based on a version of LLVM from before https://github.com/llvm/llvm-project/commit/5a082d9c1c14df5cee5a45683aee524e9b57a662 and so can't handle wasm files with name sections but no code section.
Once it's updated we can revert this change.