### PR TITLE
Update stack switching API to match V8

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7963,8 +7963,6 @@ void* operator new(size_t size) {
   @no_wasm64('TODO: asyncify for wasm64')
   @with_asyncify_and_stack_switching
   def test_async_hello(self):
-    if self.get_setting('ASYNCIFY') == 2:
-      self.skipTest('https://github.com/emscripten-core/emscripten/issues/17532')
     # needs to flush stdio streams
     self.set_setting('EXIT_RUNTIME')
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12234,7 +12234,6 @@ Module['postRun'] = function() {{
     self.assertNotIn(b'.debug', read_binary('hello_world.o'))
 
   @requires_v8
-  @disabled('https://github.com/emscripten-core/emscripten/issues/17532')
   def test_stack_switching_size(self):
     # use iostream code here to purposefully get a fairly large wasm file, so
     # that our size comparisons later are meaningful


### PR DESCRIPTION
Per
https://github.com/v8/v8/commit/ff44012623e97727c917e1c5bb018b5602873113,
this moves `returnPromiseOnSuspend` and `suspendOnReturnedPromise` from
`Suspender` to `WebAssembly`, and removes the uses of
`Asyncify.suspender` from the code.

@fgmccabe @thibaudmichaud