### PR TITLE
Use window.self instead of self

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -139,7 +139,7 @@ var _scriptDir = import.meta.url;
 var _scriptDir = (typeof document != 'undefined' && document.currentScript) ? document.currentScript.src : undefined;
 
 if (ENVIRONMENT_IS_WORKER) {
-  _scriptDir = self.location.href;
+  _scriptDir = window.self.location.href;
 }
 #if ENVIRONMENT_MAY_BE_NODE
 else if (ENVIRONMENT_IS_NODE) {
@@ -362,7 +362,7 @@ if (ENVIRONMENT_IS_SHELL) {
 #if ENVIRONMENT_MAY_BE_WEB || ENVIRONMENT_MAY_BE_WORKER
 if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
   if (ENVIRONMENT_IS_WORKER) { // Check worker, not web, since window could be polyfilled
-    scriptDirectory = self.location.href;
+    scriptDirectory = window.self.location.href;
   } else if (typeof document != 'undefined' && document.currentScript) { // web
     scriptDirectory = document.currentScript.src;
   }


### PR DESCRIPTION
Hi,

Here is a patch i had to apply manually while i was following a recipe from the web.

`self` is not defined. I don*t think it is a reserved word.

Feel free to close the PR if it's pointless, i have no skills around.