### PR TITLE
deterministically sort files in file packager

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -520,6 +520,10 @@ def main():
     seen.add(name)
     return False
 
+  # The files are sorted by the dstpath to make the order of files reproducible
+  # across file systems / operating systems (os.walk does not produce the same
+  # file order on different file systems / operating systems)
+  data_files = sorted(data_files, key=lambda file_: file_.dstpath)
   data_files = [file_ for file_ in data_files if not was_seen(file_.dstpath)]
 
   if AV_WORKAROUND:


### PR DESCRIPTION
we have warnings where WASM cannot be instantiated because of one C file marking some struct as "extern" which is part of another C file. 

If the one that marks the struct as "extern" comes first, there is a warning that reads something like: 

```
pyjs_main.js:9 Couldn't instantiate wasm: /home/derthorsten/micromamba/envs/pyjs-build-wasm2/lib/python3.10/site-packages/scipy/sparse/linalg/_propack/_cpropack.cpython-310.so 'Error: bad export type for `bbcom_`: undefined'
(anonymous) @ pyjs_main.js:9
pyjs_main.js:9 Couldn't instantiate wasm: /home/derthorsten/micromamba/envs/pyjs-build-wasm2/lib/python3.10/site-packages/scipy/sparse/linalg/_propack/_dpropack.cpython-310.so 'Error: bad export type for `bbcom_`: undefined'
(anonymous) @ pyjs_main.js:9
```

However, `bbcom_` is defined in `_zpropack` whcih comes later. With a deterministic order we can put the `extern` in the correct place.