### PR TITLE
test: Don't implicitly add `-I.` when building test code. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -688,11 +688,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       cmd += emcc_args
     if libraries:
       cmd += libraries
-    if shared.suffix(filename) not in ('.i', '.ii'):
-      # Add the location of the test file to include path.
-      cmd += ['-I.']
-      if includes:
-        cmd += ['-I' + str(include) for include in includes]
+    if includes:
+      cmd += ['-I' + str(include) for include in includes]
 
     self.run_process(cmd, stderr=self.stderr_redirect if not DEBUG else None)
     self.assertExists(output)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7581,7 +7581,7 @@ void* operator new(size_t size) {
 
   @no_wasm64('webidl not compatible with MEMORY64 yet')
   @parameterized({
-    '': (None, False),
+    '': ('DEFAULT', False),
     'all': ('ALL', False),
     'fast': ('FAST', False),
     'default': ('DEFAULT', False),
@@ -7626,10 +7626,8 @@ void* operator new(size_t size) {
     if allow_memory_growth:
       self.set_setting('ALLOW_MEMORY_GROWTH')
 
-    if not mode:
-      mode = 'DEFAULT'
     expected = test_file('webidl/output_%s.txt' % mode)
-    self.do_run_from_file(test_file('webidl/test.cpp'), expected)
+    self.do_run_from_file(test_file('webidl/test.cpp'), expected, includes=['.'])
 
   ### Tests for tools
 


### PR DESCRIPTION
Turns out there was only a single test that was relying on this behavior
so its better to keep the default build command simpler/smaller.