### PR TITLE
Add missing dependency to embind's getTypeName. NFC

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -10,7 +10,6 @@
 /*global FUNCTION_TABLE, HEAP8, HEAPU8, HEAP16, HEAPU16, HEAP32, HEAPU32, HEAPF32, HEAPF64*/
 /*global readLatin1String*/
 /*global Emval, emval_handle_array, __emval_decref*/
-/*global ___getTypeName*/
 /*jslint sub:true*/ /* The symbols 'fromWireType' and 'toWireType' must be accessed via array notation to be closure-safe since craftInvokerFunction crafts functions as strings that can't be closured. */
 
 // -- jshint doesn't understand library syntax, so we need to specifically tell it about the symbols we define
@@ -394,7 +393,7 @@ var LibraryEmbind = {
     return ret;
   },
 
-  $getTypeName__deps: ['$readLatin1String'],
+  $getTypeName__deps: ['$readLatin1String', '__getTypeName'],
   $getTypeName: function(type) {
     var ptr = ___getTypeName(type);
     var rv = readLatin1String(ptr);


### PR DESCRIPTION
We have had reports of `__getTypeName` being undefined at runtime which
should not be possible.  Add this explicit dependency so that we fail
at link time if this symbol (defined in `bind.cpp`) is missing.