### PR TITLE
Remove calls to __set_stack_limits.

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -969,7 +969,6 @@ def create_wasm64_wrappers(metadata):
     'main': '__PP',
     '__main_argc_argv': '__PP',
     'emscripten_stack_set_limits': '_pp',
-    '__set_stack_limits': '_pp',
     '__cxa_can_catch': '_ppp',
   }
 

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -546,10 +546,6 @@ mergeInto(LibraryManager.library, {
       var stack_max =  {{{ makeGetValue('newFiber', C_STRUCTS.emscripten_fiber_s.stack_limit, 'i32') }}};
       _emscripten_stack_set_limits(stack_base, stack_max);
 
-#if STACK_OVERFLOW_CHECK >= 2
-      ___set_stack_limits(stack_base, stack_max);
-#endif
-
       stackRestore({{{ makeGetValue('newFiber', C_STRUCTS.emscripten_fiber_s.stack_ptr,   'i32') }}});
 
       var entryPoint = {{{ makeGetValue('newFiber', C_STRUCTS.emscripten_fiber_s.entry, 'i32') }}};

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -908,9 +908,6 @@ var LibraryPThread = {
     return {{{ DEFAULT_PTHREAD_STACK_SIZE }}};
   },
 
-#if STACK_OVERFLOW_CHECK >= 2 && MAIN_MODULE
-  $establishStackSpace__deps: ['$setDylinkStackLimits'],
-#endif
   $establishStackSpace__internal: true,
   $establishStackSpace: function() {
     var pthread_ptr = _pthread_self();
@@ -928,16 +925,6 @@ var LibraryPThread = {
     // Set stack limits used by `emscripten/stack.h` function.  These limits are
     // cached in wasm-side globals to make checks as fast as possible.
     _emscripten_stack_set_limits(stackTop, stackMax);
-#if STACK_OVERFLOW_CHECK >= 2
-    // Set stack limits used by binaryen's `StackCheck` pass.
-    // TODO(sbc): Can this be combined with the above.
-    ___set_stack_limits(stackTop, stackMax);
-#if MAIN_MODULE
-    // With dynamic linking we could have any number of pre-loaded libraries
-    // that each need to have their stack limits set.
-    setDylinkStackLimits(stackTop, stackMax);
-#endif
-#endif
 
     // Call inside wasm module to set up the stack frame for this pthread in wasm module scope
     stackRestore(stackTop);

--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -55,24 +55,8 @@ mergeInto(LibraryManager.library, {
     assert(m['sz'] % 16 == 0);
 #endif
 
-#if STACK_OVERFLOW_CHECK >= 2
-    // _emscripten_wasm_worker_initialize() initializes the stack for this Worker,
-    // but it cannot call to extern __set_stack_limits() function, or Binaryen breaks
-    // with "Fatal: Module::addFunction: __set_stack_limits already exists".
-    // So for now, invoke this function from JS side. TODO: remove this in the future.
-    // Note that this call is not exactly correct, since this limit will include
-    // the TLS slot, that will be part of the region between m['sb'] and m['sz'],
-    // so we need to fix up the call below.
-    ___set_stack_limits(m['sb'] + m['sz'], m['sb']);
-#endif
     // Run the C side Worker initialization for stack and TLS.
     _emscripten_wasm_worker_initialize(m['sb'], m['sz']);
-#if STACK_OVERFLOW_CHECK >= 2
-    // Fix up stack base. (TLS frame is created at the bottom address end of the stack)
-    // See https://github.com/emscripten-core/emscripten/issues/16496
-    ___set_stack_limits(_emscripten_stack_get_base(), _emscripten_stack_get_end());
-#endif
-
     // The Wasm Worker runtime is now up, so we can start processing
     // any postMessage function calls that have been received. Drop the temp
     // message handler that queued any pending incoming postMessage function calls ...

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -79,9 +79,6 @@ function initRuntime(asm) {
 #if STACK_OVERFLOW_CHECK
   _emscripten_stack_init();
   writeStackCookie();
-#if STACK_OVERFLOW_CHECK >= 2
-  ___set_stack_limits(_emscripten_stack_get_base(), _emscripten_stack_get_end());
-#endif
 #endif
 
 #if USE_PTHREADS

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -257,12 +257,6 @@ function initRuntime() {
   checkStackCookie();
 #endif
 
-#if STACK_OVERFLOW_CHECK >= 2
-#if RUNTIME_LOGGING
-  err('__set_stack_limits: ' + _emscripten_stack_get_base() + ', ' + _emscripten_stack_get_end());
-#endif
-  ___set_stack_limits(_emscripten_stack_get_base(), _emscripten_stack_get_end());
-#endif
 #if RELOCATABLE
   callRuntimeCallbacks(__RELOC_FUNCS__);
 #endif

--- a/system/lib/compiler-rt/stack_limits.S
+++ b/system/lib/compiler-rt/stack_limits.S
@@ -107,14 +107,6 @@ emscripten_wasm_worker_initialize:
   PTR.add
   global.set __stack_base
 
-// TODO: We'd like to do this here to avoid JS side calls to __set_stack_limits.
-//       (or even better, we'd like to avoid duplicate versions of the stack variables)
-// See https://github.com/emscripten-core/emscripten/issues/16496
-//  global.get __stack_base
-//  global.get __stack_end
-//  .functype __set_stack_limits (PTR, PTR) -> ()
-//  call __set_stack_limits
-
   // __wasm_init_tls(stackLowestAddress);
   local.get 0
   .functype __wasm_init_tls (PTR) -> ()


### PR DESCRIPTION
Binaryen now uses __stack_base and __stack_end directly now.