### PR TITLE
Export `__start_em_js` and `__stop_em_js` so binaryen can use them. NFC

### DIFF
--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -29,8 +29,16 @@ var SIDE_MODULE_EXPORTS = [];
 // module (or other side modules) will need to provide.
 var SIDE_MODULE_IMPORTS = [];
 
-// Like EXPORTED_FUNCTIONS, but will not error if symbol is missing
-var EXPORT_IF_DEFINED = ['__start_em_asm', '__stop_em_asm'];
+// Like EXPORTED_FUNCTIONS, but will not error if symbol is missing.
+// The start/stop symbols are included by default so that then can be extracted
+// from the binary and embedded into the generated JS.  The PostEmscripten pass
+// in binaryen will then strip these exports so they will not appear in the
+// final shipping binary.
+// They are included here rather than in REQUIRED_EXPORTS because not all
+// programs contains EM_JS or EM_ASM data section, in which case these symbols
+// won't exist.
+var EXPORT_IF_DEFINED = ['__start_em_asm', '__stop_em_asm',
+                         '__start_em_js', '__stop_em_js'];
 
 // Like EXPORTED_FUNCTIONS, but symbol is required to exist in native code.
 // This means wasm-ld will fail if these symbols are missing.

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8645,12 +8645,14 @@ int main() {
           [emsymbolizer, 'test_dwarf.wasm', address], stdout=PIPE).stdout
 
     # Check a location in foo(), not inlined.
-    self.assertIn('test_dwarf.c:6:3', get_addr('0x101'))
+    # If the output binary size changes use `wasm-objdump -d` on the binary
+    # look for the offset of the first call to `out_to_js`.
+    self.assertIn('test_dwarf.c:6:3', get_addr('0x10d'))
     # Check that both bar (inlined) and main (inlinee) are in the output,
     # as described by the DWARF.
     # TODO: consider also checking the function names once the output format
     # stabilizes more
-    self.assertRegex(get_addr('0x118').replace('\n', ''),
+    self.assertRegex(get_addr('0x124').replace('\n', ''),
                      'test_dwarf.c:13:3.*test_dwarf.c:18:3')
 
   def test_separate_dwarf(self):


### PR DESCRIPTION
See https://github.com/WebAssembly/binaryen/pull/4870 which makes sure
they get stripped and https://github.com/WebAssembly/binaryen/pull/4871
which actually depends on them.