### PR TITLE
Change release_notes.rst to link to the GitHub markdown file

### DIFF
--- a/site/source/docs/introducing_emscripten/release_notes.rst
+++ b/site/source/docs/introducing_emscripten/release_notes.rst
@@ -4,20 +4,11 @@
 Release Notes
 =============
 
-Changes between tagged Emscripten versions are recorded in the :ref:`ChangeLog`
+Changes between tagged Emscripten versions are recorded in the 
+`ChangeLog <https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md>`_
 (``ChangeLog.md`` in the source repo).
 This log includes high-level information about new features, user-oriented
 fixes, options, command-line parameters, usage changes, deprecations,
 significant internal modifications, optimizations, etc. The log for each version
 links to a detailed diff report, which lists all the incremental changes since
 the previous release.
-
-.. _ChangeLog:
-
-ChangeLog
-=========
-
-The ChangeLog for Emscripten |release| (|today|) is listed below.
-
-.. include::   ../../../../ChangeLog.md
-   :literal:


### PR DESCRIPTION
This prevents having stale content, and with GH's auto rendering, 
the markdown is quite readable on its own.