### PR TITLE
Make test_emsymbolizer robust

### DIFF
--- a/test/core/test_dwarf.c
+++ b/test/core/test_dwarf.c
@@ -4,13 +4,13 @@ EM_JS(int, out_to_js, (int x), {})
 
 void __attribute__((noinline)) foo() {
   out_to_js(0); // line 6
-  out_to_js(1); // line 7
-  out_to_js(2); // line 8
+  out_to_js(1);
+  out_to_js(2);
 }
 
 void __attribute__((always_inline)) bar() {
   out_to_js(3);
-  __builtin_trap();
+  __builtin_trap(); // line 13
 }
 
 int main() {


### PR DESCRIPTION
Currently the addresses are hardcoded, but we have seen them change
multiple times in the last few weeks now. I think it's worthwhile to
make them computed automatically at this point. It'd been easier to use
`wasm-objdump` from wabt, but it is not a dependency of emscripten, so
this uses `llvm-objdump`.