### PR TITLE
Fix uname() machine on wasm64

### DIFF
--- a/system/lib/libc/emscripten_syscall_stubs.c
+++ b/system/lib/libc/emscripten_syscall_stubs.c
@@ -60,7 +60,7 @@ int __syscall_uname(intptr_t buf) {
   strcpy(utsname->nodename, "emscripten");
   strcpy(utsname->release, full_version);
   strcpy(utsname->version, "#1");
-#ifdef __wams64__
+#ifdef __wasm64__
   strcpy(utsname->machine, "wasm64");
 #else
   strcpy(utsname->machine, "wasm32");

--- a/test/core/test_uname.c
+++ b/test/core/test_uname.c
@@ -5,7 +5,9 @@
  * found in the LICENSE file.
  */
 
+#include <assert.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/utsname.h>
 
 int main() {
@@ -16,6 +18,12 @@ int main() {
   printf("release: %s\n", u.release);
   printf("version: %s\n", u.version);
   printf("machine: %s\n", u.machine);
+#ifdef __wasm64__
+  assert(strcmp(u.machine, "wasm64") == 0);
+#else
+  assert(strcmp(u.machine, "wasm32") == 0);
+#endif
   printf("invalid: %d\n", uname(0));
+
   return 0;
 }

--- a/test/core/test_uname.out
+++ b/test/core/test_uname.out
@@ -3,4 +3,4 @@ sysname: Emscripten
 nodename: emscripten
 release: \d+.\d+.\d+
 version: #1
-machine: wasm32
+machine: wasm(32|64)


### PR DESCRIPTION
Correct a typo in `__syscall_uname` code. wasm64 builds now correctly
report `utsname->machine` as `"wasm64"`.