### PR TITLE
Improve error messages in file_packager.py.

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2723,13 +2723,13 @@ int f() {
           if empty_lines > 1:
             self.fail('output contains more then one empty line in row')
 
-    # relative path to below the current dir is invalid
+    # relative path must be within/below the current dir
     stderr = self.expect_fail([FILE_PACKAGER, 'test.data', '--preload', '../data1.txt'])
-    self.assertContained('below the current directory', stderr)
+    self.assertContained('which is not contained within the current directory', stderr)
 
     # relative path that ends up under us is cool
     proc = self.run_process([FILE_PACKAGER, 'test.data', '--preload', '../subdir/data2.txt'], stderr=PIPE, stdout=PIPE)
-    self.assertNotContained('below the current directory', proc.stderr)
+    self.assertNotContained('which is not contained within the current directory', proc.stderr)
     check(proc.stdout)
 
     # direct path leads to the same code being generated - relative path does not make us do anything different

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -477,8 +477,8 @@ def main():
   if not file_.explicit_dst_path:
     for file_ in data_files:
       # This file was not defined with src@dst, so we inferred the destination
-      # from the source. In that case, we require that the destination not be
-      # under the current location
+      # from the source. In that case, we require that the destination be
+      # within the current working directory.
       path = file_.dstpath
       # Use os.path.realpath to resolve any symbolic links to hard paths,
       # to match the structure in curr_abspath.
@@ -486,18 +486,19 @@ def main():
       if DEBUG:
         err(path, abspath, curr_abspath)
       if not abspath.startswith(curr_abspath):
-        err('Error: Embedding "%s" which is below the current directory '
-            '"%s". This is invalid since the current directory becomes the '
-            'root that the generated code will see' % (path, curr_abspath))
+        err('Error: Embedding "%s" which is not contained within the current directory '
+            '"%s".  This is invalid since the current directory becomes the '
+            'root that the generated code will see.  To include files outside of the current '
+            'working directoty you can use the `--preload-file srcpath@dstpath` syntax to '
+            'explicitly specify the target location.' % (path, curr_abspath))
         sys.exit(1)
       file_.dstpath = abspath[len(curr_abspath) + 1:]
       if os.path.isabs(path):
         err('Warning: Embedding an absolute file/directory name "%s" to the '
             'virtual filesystem. The file will be made available in the '
-            'relative path "%s". You can use the explicit syntax '
-            '--preload-file srcpath@dstpath to explicitly specify the target '
-            'location the absolute source path should be directed to.'
-            % (path, file_.dstpath))
+            'relative path "%s". You can use the `--preload-file srcpath@dstpath` '
+            'syntax to explicitly specify the target location the absolute source '
+            'path should be directed to.' % (path, file_.dstpath))
 
   for file_ in data_files:
     # name in the filesystem, native and emulated


### PR DESCRIPTION
The terms `not be under` and `is below` here were confusing/wrong I
hink.  This error is generated when files are "not contained within"
the current working directory which in my mind is the same as "not below".
However the error message was using the term "below" to been "outside
of" which seems wrong to me.

Fixes: #2656