### PR TITLE
Export `__stack_base` and `__stack_end` for the StackCheck binaryen pass

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1997,6 +1997,17 @@ def phase_linker_setup(options, state, newargs, user_settings):
       'emscripten_stack_get_base'
     ]
 
+    if settings.STACK_OVERFLOW_CHECK >= 2 and not settings.SIDE_MODULE:
+      # STACK_OVERFLOW_CHECK=2 runs a binaryen pass that uses __stack_base
+      # and __stack_end, so we export them from to ensure the binaryen pass
+      # can find them.
+      # For SIDE_MODULES, we don't add the exports. This is because the
+      # binaryen pass will add these as imports if it needs them.
+      settings.REQUIRED_EXPORTS += [
+        '__stack_base',
+        '__stack_end'
+      ]
+
     # We call one of these two functions during startup which caches the stack limits
     # in wasm globals allowing get_base/get_free to be super fast.
     # See compiler-rt/stack_limits.S.

--- a/emcc.py
+++ b/emcc.py
@@ -1458,6 +1458,8 @@ def phase_setup(options, state, newargs, user_settings):
   if settings.USE_PTHREADS or settings.WASM_WORKERS:
     settings.SHARED_MEMORY = 1
 
+  newargs += ['-mmutable-globals']
+
   if settings.USE_PTHREADS and '-pthread' not in newargs:
     newargs += ['-pthread']
   elif settings.SHARED_MEMORY:

--- a/system/lib/compiler-rt/stack_limits.S
+++ b/system/lib/compiler-rt/stack_limits.S
@@ -19,8 +19,10 @@
 # TODO(sbc): It would be nice if these we initialized directly
 # using PTR.const rather than using the `emscripten_stack_init`
 .globaltype __stack_end, PTR
+.globl __stack_end
 __stack_end:
 .globaltype __stack_base, PTR
+.globl __stack_base
 __stack_base:
 
 emscripten_stack_get_base:

--- a/system/lib/compiler-rt/stack_limits.S
+++ b/system/lib/compiler-rt/stack_limits.S
@@ -19,10 +19,10 @@
 # TODO(sbc): It would be nice if these we initialized directly
 # using PTR.const rather than using the `emscripten_stack_init`
 .globaltype __stack_end, PTR
-.globl __stack_end
+.hidden __stack_end
 __stack_end:
 .globaltype __stack_base, PTR
-.globl __stack_base
+.hidden __stack_base
 __stack_base:
 
 emscripten_stack_get_base:

--- a/system/lib/compiler-rt/stack_limits.S
+++ b/system/lib/compiler-rt/stack_limits.S
@@ -19,10 +19,10 @@
 # TODO(sbc): It would be nice if these we initialized directly
 # using PTR.const rather than using the `emscripten_stack_init`
 .globaltype __stack_end, PTR
-.hidden __stack_end
+.globl __stack_end
 __stack_end:
 .globaltype __stack_base, PTR
-.hidden __stack_base
+.globl __stack_base
 __stack_base:
 
 emscripten_stack_get_base:

--- a/test/core/test_dlfcn_self.exports
+++ b/test/core/test_dlfcn_self.exports
@@ -8,6 +8,8 @@ __progname_full
 __sig_actions
 __sig_pending
 __signgam
+__stack_base
+__stack_end
 __threwValue
 _environ
 _ns_flagdata

--- a/tools/building.py
+++ b/tools/building.py
@@ -326,7 +326,7 @@ def lld_flags_for_executable(external_symbols):
   if not settings.SIDE_MODULE:
     if settings.STACK_OVERFLOW_CHECK >= 2:
       cmd.append('-Wl,--no-check-features')
-    
+
     # Export these two section start symbols so that we can extact the string
     # data that they contain.
     cmd += [

--- a/tools/building.py
+++ b/tools/building.py
@@ -383,7 +383,6 @@ def link_lld(args, target, external_symbols=None):
   if settings.MEMORY64:
     cmd.append('-mwasm64')
 
-
   if not settings.SIDE_MODULE:
     if settings.STACK_OVERFLOW_CHECK >= 2:
       cmd.append('--no-check-features')

--- a/tools/building.py
+++ b/tools/building.py
@@ -323,10 +323,6 @@ def lld_flags_for_executable(external_symbols):
     if settings.ALLOW_TABLE_GROWTH:
       cmd.append('--growable-table')
 
-  if not settings.SIDE_MODULE:
-    if settings.STACK_OVERFLOW_CHECK >= 2:
-      cmd.append('--no-check-features')
-
     # Export these two section start symbols so that we can extact the string
     # data that they contain.
     cmd += [
@@ -386,6 +382,11 @@ def link_lld(args, target, external_symbols=None):
 
   if settings.MEMORY64:
     cmd.append('-mwasm64')
+
+
+  if not settings.SIDE_MODULE:
+    if settings.STACK_OVERFLOW_CHECK >= 2:
+      cmd.append('--no-check-features')
 
   # For relocatable output (generating an object file) we don't pass any of the
   # normal linker flags that are used when building and exectuable

--- a/tools/building.py
+++ b/tools/building.py
@@ -325,7 +325,7 @@ def lld_flags_for_executable(external_symbols):
 
   if not settings.SIDE_MODULE:
     if settings.STACK_OVERFLOW_CHECK >= 2:
-      cmd += [ '-Wl,--no-check-features' ]
+      cmd.append('-Wl,--no-check-features')
     
     # Export these two section start symbols so that we can extact the string
     # data that they contain.

--- a/tools/building.py
+++ b/tools/building.py
@@ -323,7 +323,8 @@ def lld_flags_for_executable(external_symbols):
     if settings.ALLOW_TABLE_GROWTH:
       cmd.append('--growable-table')
 
-    # Export these two section start symbols so that we can extact the string
+  if not settings.SIDE_MODULE:
+    # Export these two section start symbols so that we can extract the string
     # data that they contain.
     cmd += [
       '-z', 'stack-size=%s' % settings.TOTAL_STACK,
@@ -382,10 +383,6 @@ def link_lld(args, target, external_symbols=None):
 
   if settings.MEMORY64:
     cmd.append('-mwasm64')
-
-  if not settings.SIDE_MODULE:
-    if settings.STACK_OVERFLOW_CHECK >= 2:
-      cmd.append('--no-check-features')
 
   # For relocatable output (generating an object file) we don't pass any of the
   # normal linker flags that are used when building and exectuable

--- a/tools/building.py
+++ b/tools/building.py
@@ -325,7 +325,7 @@ def lld_flags_for_executable(external_symbols):
 
   if not settings.SIDE_MODULE:
     if settings.STACK_OVERFLOW_CHECK >= 2:
-      cmd.append('-Wl,--no-check-features')
+      cmd.append('--no-check-features')
 
     # Export these two section start symbols so that we can extact the string
     # data that they contain.

--- a/tools/building.py
+++ b/tools/building.py
@@ -324,6 +324,9 @@ def lld_flags_for_executable(external_symbols):
       cmd.append('--growable-table')
 
   if not settings.SIDE_MODULE:
+    if settings.STACK_OVERFLOW_CHECK >= 2:
+      cmd += [ '-Wl,--no-check-features' ]
+    
     # Export these two section start symbols so that we can extact the string
     # data that they contain.
     cmd += [


### PR DESCRIPTION
This is part of a fix for https://github.com/emscripten-core/emscripten/issues/16496