### PR TITLE
Fix return size of fd_read, fd_pread, and fd_pwrite

### DIFF
--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -293,7 +293,7 @@ var WasiLibrary = {
     {{{ receiveI64ParamAsI53('offset', cDefine('EOVERFLOW')) }}}
     var stream = SYSCALLS.getStreamFromFD(fd)
     var num = doWritev(stream, iov, iovcnt, offset);
-    {{{ makeSetValue('pnum', 0, 'num', 'i32') }}};
+    {{{ makeSetValue('pnum', 0, 'num', SIZE_TYPE) }}};
     return 0;
 #elif ASSERTIONS
     abort('fd_pwrite called without SYSCALLS_REQUIRE_FILESYSTEM');
@@ -330,7 +330,7 @@ var WasiLibrary = {
 #if SYSCALLS_REQUIRE_FILESYSTEM
     var stream = SYSCALLS.getStreamFromFD(fd);
     var num = doReadv(stream, iov, iovcnt);
-    {{{ makeSetValue('pnum', 0, 'num', 'i32') }}};
+    {{{ makeSetValue('pnum', 0, 'num', SIZE_TYPE) }}};
     return 0;
 #elif ASSERTIONS
     abort('fd_read called without SYSCALLS_REQUIRE_FILESYSTEM');
@@ -350,7 +350,7 @@ var WasiLibrary = {
     {{{ receiveI64ParamAsI53('offset', cDefine('EOVERFLOW')) }}}
     var stream = SYSCALLS.getStreamFromFD(fd)
     var num = doReadv(stream, iov, iovcnt, offset);
-    {{{ makeSetValue('pnum', 0, 'num', 'i32') }}};
+    {{{ makeSetValue('pnum', 0, 'num', SIZE_TYPE) }}};
     return 0;
 #elif ASSERTIONS
     abort('fd_pread called without SYSCALLS_REQUIRE_FILESYSTEM');


### PR DESCRIPTION
The three functions declared the return size pointer as `i32`, which is
incorrect on WASM64. It is a `SIZE_TYPE`.

Closes: #17607