### PR TITLE
Revert "Create utils.delete_file and utils.delete_dir in place of tempfiles.try_delete.  NFC (#17512)"

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -51,7 +51,7 @@ from tools import wasm2c
 from tools import webassembly
 from tools import config
 from tools.settings import settings, MEM_SIZE_SETTINGS, COMPILE_TIME_SETTINGS
-from tools.utils import read_file, write_file, read_binary, delete_file
+from tools.utils import read_file, write_file, read_binary
 
 logger = logging.getLogger('emcc')
 
@@ -3050,7 +3050,7 @@ def phase_final_emitting(options, state, target, wasm_target, memfile):
     generate_worker_js(target, js_target, target_basename)
 
   if embed_memfile() and memfile:
-    delete_file(memfile)
+    shared.try_delete(memfile)
 
   if settings.SPLIT_MODULE:
     diagnostics.warning('experimental', 'The SPLIT_MODULE setting is experimental and subject to change')
@@ -3541,7 +3541,7 @@ def phase_binaryen(target, options, wasm_target):
     if settings.WASM != 2:
       final_js = wasm2js
       # if we only target JS, we don't need the wasm any more
-      delete_file(wasm_target)
+      shared.try_delete(wasm_target)
 
     save_intermediate('wasm2js')
 
@@ -3579,7 +3579,7 @@ def phase_binaryen(target, options, wasm_target):
       js = do_replace(js, '<<< WASM_BINARY_DATA >>>', base64_encode(read_binary(wasm_target)))
     else:
       js = do_replace(js, '<<< WASM_BINARY_FILE >>>', get_subresource_location(wasm_target))
-    delete_file(wasm_target)
+    shared.try_delete(wasm_target)
     write_file(final_js, js)
 
 
@@ -3777,7 +3777,7 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
     js_contents = script.inline or ''
     if script.src:
       js_contents += read_file(js_target)
-    delete_file(js_target)
+    shared.try_delete(js_target)
     script.src = None
     script.inline = js_contents
 

--- a/test/common.py
+++ b/test/common.py
@@ -31,9 +31,9 @@ import clang_native
 import jsrun
 from tools.shared import TEMP_DIR, EMCC, EMXX, DEBUG, EMCONFIGURE, EMCMAKE
 from tools.shared import EMSCRIPTEN_TEMP_DIR
-from tools.shared import get_canonical_temp_dir, path_from_root
+from tools.shared import get_canonical_temp_dir, try_delete, path_from_root
 from tools.utils import MACOS, WINDOWS, read_file, read_binary, write_file, write_binary, exit_with_error
-from tools import shared, line_endings, building, config, utils
+from tools import shared, line_endings, building, config
 
 logger = logging.getLogger('common')
 
@@ -82,6 +82,13 @@ EMRUN = shared.bat_suffix(shared.path_from_root('emrun'))
 WASM_DIS = Path(building.get_binaryen_bin(), 'wasm-dis')
 LLVM_OBJDUMP = os.path.expanduser(shared.build_llvm_tool_path(shared.exe_suffix('llvm-objdump')))
 PYTHON = sys.executable
+
+
+def delete_contents(pathname):
+  for entry in os.listdir(pathname):
+    try_delete(os.path.join(pathname, entry))
+    # TODO(sbc): Should we make try_delete have a stronger guarantee?
+    assert not os.path.exists(os.path.join(pathname, entry))
 
 
 def test_file(*path_components):
@@ -301,35 +308,6 @@ def make_executable(name):
   Path(name).chmod(stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC)
 
 
-def make_dir_writeable(dirname):
-  # Ensure all files are readable and writable by the current user.
-  permission_bits = stat.S_IWRITE | stat.S_IREAD
-
-  def is_writable(path):
-    return (os.stat(path).st_mode & permission_bits) != permission_bits
-
-  def make_writable(path):
-    new_mode = os.stat(path).st_mode | permission_bits
-    os.chmod(path, new_mode)
-
-  # Some tests make files and subdirectories read-only, so rmtree/unlink will not delete
-  # them. Force-make everything writable in the subdirectory to make it
-  # removable and re-attempt.
-  if not is_writable(dirname):
-    make_writable(dirname)
-
-  for directory, subdirs, files in os.walk(dirname):
-    for item in files + subdirs:
-      i = os.path.join(directory, item)
-      if not os.path.islink(i):
-        make_writable(i)
-
-
-def force_delete_dir(dirname):
-  make_dir_writeable(dirname)
-  utils.delete_dir(dirname)
-
-
 def parameterized(parameters):
   """
   Mark a test as parameterized.
@@ -531,7 +509,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
           # expect this.  --no-clean can be used to keep the old contents for the new test
           # run. This can be useful when iterating on a given test with extra files you want to keep
           # around in the output directory.
-          utils.delete_contents(self.working_dir)
+          delete_contents(self.working_dir)
       else:
         print('Creating new test output directory')
         ensure_dir(self.working_dir)
@@ -549,7 +527,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     if not EMTEST_SAVE_DIR:
       # rmtree() fails on Windows if the current working directory is inside the tree.
       os.chdir(os.path.dirname(self.get_dir()))
-      force_delete_dir(self.get_dir())
+      try_delete(self.get_dir())
 
       if EMTEST_DETECT_TEMPFILE_LEAKS and not DEBUG:
         temp_files_after_run = []
@@ -973,9 +951,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
                          cache_name, env_init=env_init, native=native)
 
   def clear(self):
-    utils.delete_contents(self.get_dir())
+    delete_contents(self.get_dir())
     if EMSCRIPTEN_TEMP_DIR:
-      utils.delete_contents(EMSCRIPTEN_TEMP_DIR)
+      delete_contents(EMSCRIPTEN_TEMP_DIR)
 
   def run_process(self, cmd, check=True, **args):
     # Wrapper around shared.run_process.  This is desirable so that the tests
@@ -1741,7 +1719,7 @@ class BrowserCore(RunnerCore):
     outfile = 'test.html'
     args += [filename, '-o', outfile]
     # print('all args:', args)
-    utils.delete_file(outfile)
+    try_delete(outfile)
     self.compile_btest(args, reporting=reporting)
     self.assertExists(outfile)
     if post_build:

--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -10,8 +10,7 @@ import tempfile
 import time
 import queue
 
-import common
-
+from tools.tempfiles import try_delete
 
 NUM_CORES = None
 
@@ -96,7 +95,7 @@ class ParallelTestSuite(unittest.BaseTestSuite):
       else:
         self.clear_finished_processes()
     for temp_dir in self.dedicated_temp_dirs:
-      common.force_delete_dir(temp_dir)
+      try_delete(temp_dir)
     return buffered_results
 
   def clear_finished_processes(self):

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -21,8 +21,8 @@ import jsrun
 import common
 from tools.shared import CLANG_CC, CLANG_CXX
 from common import TEST_ROOT, test_file, read_file, read_binary
-from tools.shared import run_process, PIPE, EMCC, config
-from tools import building, utils
+from tools.shared import run_process, PIPE, try_delete, EMCC, config
+from tools import building
 
 # standard arguments for timing:
 # 0: no runtime, just startup
@@ -197,7 +197,7 @@ class EmscriptenBenchmarker(Benchmarker):
       emcc_args += lib_builder('js_' + llvm_root, native=False, env_init=env_init)
     final = os.path.dirname(filename) + os.path.sep + self.name + ('_' if self.name else '') + os.path.basename(filename) + '.js'
     final = final.replace('.cpp', '')
-    utils.delete_file(final)
+    try_delete(final)
     cmd = [
       EMCC, filename,
       OPTIMIZATIONS,
@@ -317,7 +317,7 @@ class CheerpBenchmarker(Benchmarker):
       cheerp_args += ['-cheerp-pretty-code'] # get function names, like emcc --profiling
     final = os.path.dirname(filename) + os.path.sep + self.name + ('_' if self.name else '') + os.path.basename(filename) + '.js'
     final = final.replace('.cpp', '')
-    utils.delete_file(final)
+    try_delete(final)
     dirs_to_delete = []
     cheerp_args += ['-cheerp-preexecute']
     try:
@@ -339,7 +339,7 @@ class CheerpBenchmarker(Benchmarker):
         run_binaryen_opts(final.replace('.js', '.wasm'), self.binaryen_opts)
     finally:
       for dir_ in dirs_to_delete:
-        utils.delete_dir(dir_)
+        try_delete(dir_)
 
   def run(self, args):
     return jsrun.run_js(self.filename, engine=self.engine, args=args, stderr=PIPE)

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -26,7 +26,7 @@ from common import read_file, requires_v8, also_with_minimal_runtime, EMRUN
 from tools import shared
 from tools import ports
 from tools.shared import EMCC, WINDOWS, FILE_PACKAGER, PIPE
-from tools.utils import delete_file, delete_dir
+from tools.shared import try_delete
 
 
 def test_chunked_synchronous_xhr_server(support_byte_ranges, chunkSize, data, checksum, port):
@@ -245,8 +245,8 @@ class browser(BrowserCore):
       ''')
     # use relative paths when calling emcc, because file:// URIs can only load
     # sourceContent when the maps are relative paths
-    delete_file(html_file)
-    delete_file(html_file + '.map')
+    try_delete(html_file)
+    try_delete(html_file + '.map')
     self.compile_btest(['src.cpp', '-o', 'src.html', '-gsource-map'])
     self.assertExists(html_file)
     self.assertExists('src.wasm.map')
@@ -339,7 +339,7 @@ If manually bisecting:
     self.btest_exit('main.cpp', args=['--preload-file', absolute_src_path])
 
     # Test subdirectory handling with asset packaging.
-    delete_dir('assets')
+    try_delete('assets')
     ensure_dir('assets/sub/asset1/'.replace('\\', '/'))
     ensure_dir('assets/sub/asset1/.git'.replace('\\', '/')) # Test adding directory that shouldn't exist.
     ensure_dir('assets/sub/asset2/'.replace('\\', '/'))
@@ -2560,8 +2560,8 @@ void *getBindBuffer() {
     print(out)
 
     # Tidy up files that might have been created by this test.
-    delete_file(test_file('uuid/test.js'))
-    delete_file(test_file('uuid/test.js.map'))
+    try_delete(test_file('uuid/test.js'))
+    try_delete(test_file('uuid/test.js.map'))
 
     # Now run test in browser
     self.btest_exit(test_file('uuid/test.c'), args=['-luuid'])
@@ -4040,7 +4040,7 @@ Module["preRun"].push(function () {
     # Test that it is possible to define "Module.locateFile(foo)" function to locate where worker.js will be loaded from.
     create_file('shell2.html', read_file(path_from_root('src/shell.html')).replace('var Module = {', 'var Module = { locateFile: function(filename) { if (filename == "test.worker.js") return "cdn/test.worker.js"; else return filename; }, '))
     self.compile_btest(['main.cpp', '--shell-file', 'shell2.html', '-sWASM=0', '-sIN_TEST_HARNESS', '-sUSE_PTHREADS', '-sPTHREAD_POOL_SIZE', '-o', 'test2.html'], reporting=Reporting.JS_ONLY)
-    delete_file('test.worker.js')
+    try_delete('test.worker.js')
     self.run_browser('test2.html', '/report_result?exit:0')
 
   # Test that if the main thread is performing a futex wait while a pthread needs it to do a proxied operation (before that pthread would wake up the main thread), that it's not a deadlock.
@@ -5298,7 +5298,7 @@ Module["preRun"].push(function () {
     create_file('data.dat', 'hello, fetch')
     create_file('small.dat', 'hello')
     create_file('test.txt', 'fetch 2')
-    delete_dir('subdir')
+    try_delete('subdir')
     ensure_dir('subdir')
     create_file('subdir/backendfile', 'file 1')
     create_file('subdir/backendfile2', 'file 2')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -19,9 +19,9 @@ from functools import wraps
 if __name__ == '__main__':
   raise Exception('do not run this file directly; do something like: test/runner')
 
-from tools.shared import PIPE
+from tools.shared import try_delete, PIPE
 from tools.shared import EMCC, EMAR
-from tools.utils import WINDOWS, MACOS, write_file, delete_file
+from tools.utils import WINDOWS, MACOS, write_file
 from tools import shared, building, config, webassembly
 import common
 from common import RunnerCore, path_from_root, requires_native_clang, test_file, create_file
@@ -4064,7 +4064,7 @@ ok
 
     if isinstance(main, list):
       # main is just a library
-      delete_file('main.js')
+      try_delete('main.js')
       self.run_process([EMCC] + main + self.get_emcc_args() + ['-o', 'main.js'])
       self.do_run('main.js', expected, no_build=True, **kwargs)
     else:
@@ -6383,7 +6383,7 @@ int main(void) {
     if self.emcc_args == []:
       # emcc should build in dlmalloc automatically, and do all the sign correction etc. for it
 
-      delete_file('src.js')
+      try_delete('src.js')
       self.run_process([EMCC, test_file('dlmalloc_test.c'), '-sINITIAL_MEMORY=128MB', '-o', 'src.js'], stdout=PIPE, stderr=self.stderr_redirect)
 
       self.do_run(None, '*1,0*', ['200', '1'], no_build=True)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -27,7 +27,7 @@ from subprocess import PIPE, STDOUT
 if __name__ == '__main__':
   raise Exception('do not run this file directly; do something like: test/runner other')
 
-from tools.shared import config
+from tools.shared import try_delete, config
 from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, FILE_PACKAGER, WINDOWS
 from tools.shared import CLANG_CC, CLANG_CXX, LLVM_AR, LLVM_DWARFDUMP, LLVM_DWP, EMCMAKE, EMCONFIGURE
 from common import RunnerCore, path_from_root, is_slow_test, ensure_dir, disabled, make_executable
@@ -36,7 +36,7 @@ from common import create_file, parameterized, NON_ZERO, node_pthreads, TEST_ROO
 from common import compiler_for, EMBUILDER, requires_v8, requires_node
 from common import also_with_minimal_runtime, also_with_wasm_bigint, EMTEST_BUILD_VERBOSE, PYTHON
 from tools import shared, building, utils, deps_info, response_file
-from tools.utils import read_file, write_file, delete_file, read_binary
+from tools.utils import read_file, write_file, read_binary
 import common
 import jsrun
 import clang_native
@@ -392,7 +392,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       os.chdir(os.path.dirname(path))
       self.assertContained('hello, world!', self.run_js(os.path.basename(path)))
       os.chdir(last)
-      delete_file(path)
+      try_delete(path)
 
   @is_slow_test
   @parameterized({
@@ -1302,7 +1302,7 @@ int f() {
         print(engine, file=sys.stderr)
         # work around a bug in python's subprocess module
         # (we'd use self.run_js() normally)
-        delete_file('out.txt')
+        try_delete('out.txt')
         cmd = jsrun.make_command(os.path.normpath('out.js'), engine)
         cmd = shared.shlex_join(cmd)
         if WINDOWS:
@@ -1408,7 +1408,7 @@ int f() {
     self.assertContained('hello there', self.run_js('a.out.js'))
 
     # ditto with first creating .o files
-    delete_file('a.out.js')
+    try_delete('a.out.js')
     self.run_process([EMXX, '-c', Path('foo/main.cpp'), '-o', Path('foo/main.o')])
     self.run_process([EMXX, '-c', Path('bar/main.cpp'), '-o', Path('bar/main.o')])
     self.run_process([EMCC, Path('foo/main.o'), Path('bar/main.o')])
@@ -1447,7 +1447,7 @@ int f() {
       }
     ''')
     self.run_process([EMCC, 'common.c', '-c', '-o', 'common.o'])
-    delete_file('liba.a')
+    try_delete('liba.a')
     self.run_process([EMAR, 'rc', 'liba.a', 'common.o'])
 
     create_file('common.c', r'''
@@ -1457,7 +1457,7 @@ int f() {
       }
     ''')
     self.run_process([EMCC, 'common.c', '-c', '-o', 'common.o'])
-    delete_file('libb.a')
+    try_delete('libb.a')
     self.run_process([EMAR, 'rc', 'libb.a', 'common.o'])
 
     create_file('main.c', r'''
@@ -1491,7 +1491,7 @@ int f() {
     ''')
     self.run_process([EMCC, Path('b/common.c'), '-c', '-o', Path('b/common.o')])
 
-    delete_file('liba.a')
+    try_delete('liba.a')
     self.run_process([EMAR, 'rc', 'liba.a', Path('a/common.o'), Path('b/common.o')])
 
     # Verify that archive contains basenames with hashes to avoid duplication
@@ -1514,7 +1514,7 @@ int f() {
     self.assertContained('a\nb...\n', self.run_js('a.out.js'))
 
     # Using llvm-ar directly should cause duplicate basenames
-    delete_file('libdup.a')
+    try_delete('libdup.a')
     self.run_process([LLVM_AR, 'rc', 'libdup.a', Path('a/common.o'), Path('b/common.o')])
     text = self.run_process([EMAR, 't', 'libdup.a'], stdout=PIPE).stdout
     self.assertEqual(text.count('common.o'), 2)
@@ -2112,7 +2112,7 @@ int f() {
 
     for args in ([], ['-O1'], ['-sMAX_WEBGL_VERSION=2']):
       for value in ([0, 1]):
-        delete_file('a.out.js')
+        try_delete('a.out.js')
         print('checking "%s" %s' % (args, value))
         extra = ['-s', action + '_ON_UNDEFINED_SYMBOLS=%d' % value] if action else []
         proc = self.run_process([EMXX, 'main.cpp'] + extra + args, stderr=PIPE, check=False)
@@ -2466,13 +2466,13 @@ int f() {
     self.emcc(test_file(source_file), ['-g'], js_file)
     self.verify_dwarf_exists(wasm_file)
     self.assertFalse(os.path.isfile(map_file))
-    self.clear()
+    try_delete([wasm_file, map_file, js_file])
 
     # Generate only source map
     self.emcc(test_file(source_file), ['-gsource-map'], js_file)
     self.verify_dwarf_does_not_exist(wasm_file)
     self.verify_source_map_exists(map_file)
-    self.clear()
+    try_delete([wasm_file, map_file, js_file])
 
     # Generate DWARF with source map
     self.emcc(test_file(source_file), ['-g', '-gsource-map'], js_file)
@@ -2992,7 +2992,7 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
     self.assertContained('bufferTest finished', self.run_js('main.js'))
 
     # Delete test.js again and check it's gone.
-    delete_file('test.js')
+    try_delete('test.js')
     self.assertNotExists('test.js')
 
     # compile with -O2 --closure 1
@@ -3663,12 +3663,12 @@ return 0;
     err = self.run_process([EMXX, 'src.cpp', '-include', 'header.h', '-Xclang', '-print-stats'], stderr=PIPE).stderr
     self.assertTextDataContained('*** PCH/Modules Loaded:\nModule: header.h.' + suffix, err)
     # and sanity check it is not mentioned when not
-    delete_file('header.h.' + suffix)
+    try_delete('header.h.' + suffix)
     err = self.run_process([EMXX, 'src.cpp', '-include', 'header.h', '-Xclang', '-print-stats'], stderr=PIPE).stderr
     self.assertNotContained('*** PCH/Modules Loaded:\nModule: header.h.' + suffix, err.replace('\r\n', '\n'))
 
     # with specified target via -o
-    delete_file('header.h.' + suffix)
+    try_delete('header.h.' + suffix)
     self.run_process([EMCC, '-xc++-header', 'header.h', '-o', 'my.' + suffix])
     self.assertExists('my.' + suffix)
 
@@ -4007,7 +4007,7 @@ int main()
       (['-Wno-implicit-function-declaration'], ['hello '], []),
     ]:
       print(opts, expected)
-      delete_file('a.out.js')
+      try_delete('a.out.js')
       stderr = self.run_process([EMCC, 'src.c'] + opts, stderr=PIPE, check=False).stderr
       for ce in compile_expected + [INCOMPATIBLE_WARNINGS]:
         self.assertContained(ce, stderr)
@@ -4263,7 +4263,7 @@ int main() {
     self.assertNotContained('eval(', src)
     self.assertNotContained('eval.', src)
     self.assertNotContained('new Function', src)
-    delete_file('a.out.js')
+    try_delete('a.out.js')
 
     # Test that --preload-file doesn't add an use of eval().
     create_file('temp.txt', "foo\n")
@@ -4273,12 +4273,12 @@ int main() {
     self.assertNotContained('eval(', src)
     self.assertNotContained('eval.', src)
     self.assertNotContained('new Function', src)
-    delete_file('a.out.js')
+    try_delete('a.out.js')
 
     # Test that -sDYNAMIC_EXECUTION and -sRELOCATABLE are not allowed together.
     self.expect_fail([EMCC, test_file('hello_world.c'), '-O1',
                       '-sDYNAMIC_EXECUTION=0', '-sRELOCATABLE'])
-    delete_file('a.out.js')
+    try_delete('a.out.js')
 
     create_file('test.c', r'''
       #include <emscripten/emscripten.h>
@@ -4291,13 +4291,13 @@ int main() {
     # Test that emscripten_run_script() aborts when -sDYNAMIC_EXECUTION=0
     self.run_process([EMCC, 'test.c', '-O1', '-sDYNAMIC_EXECUTION=0'])
     self.assertContained('DYNAMIC_EXECUTION=0 was set, cannot eval', self.run_js('a.out.js', assert_returncode=NON_ZERO))
-    delete_file('a.out.js')
+    try_delete('a.out.js')
 
     # Test that emscripten_run_script() posts a warning when -sDYNAMIC_EXECUTION=2
     self.run_process([EMCC, 'test.c', '-O1', '-sDYNAMIC_EXECUTION=2'])
     self.assertContained('Warning: DYNAMIC_EXECUTION=2 was set, but calling eval in the following location:', self.run_js('a.out.js'))
     self.assertContained('hello from script', self.run_js('a.out.js'))
-    delete_file('a.out.js')
+    try_delete('a.out.js')
 
   def test_init_file_at_offset(self):
     create_file('src.cpp', r'''
@@ -5556,7 +5556,7 @@ int main(void) {
     self.run_process([EMCC, '-c', 'x.c', '-o', 'x.o'])
     self.run_process([EMCC, '-c', 'y.c', '-o', 'y.o'])
     self.run_process([EMCC, '-c', 'z.c', '-o', 'z.o'])
-    delete_file('libtest.a')
+    try_delete('libtest.a')
     self.run_process([EMAR, 'rc', 'libtest.a', 'y.o'])
     self.run_process([EMAR, 'rc', 'libtest.a', 'x.o'])
     self.run_process([EMRANLIB, 'libtest.a'])
@@ -7224,7 +7224,7 @@ int main() {
             assert ret == 0
 
           for f in files:
-            delete_file(f)
+            try_delete(f)
 
   def test_binaryen_names(self):
     sizes = {}
@@ -7240,7 +7240,7 @@ int main() {
         (['-O2', '--profiling-funcs'], True),
       ]:
       print(args, expect_names)
-      delete_file('a.out.js')
+      try_delete('a.out.js')
       # we use dlmalloc here, as emmalloc has a bunch of asserts that contain the text "malloc" in
       # them, which makes counting harder
       self.run_process([EMXX, test_file('hello_world.cpp')] + args + ['-sMALLOC="dlmalloc"', '-sEXPORTED_FUNCTIONS=_main,_malloc'])
@@ -7370,7 +7370,7 @@ int main() {
         (['-O2', '--closure=1', '-g1'],  False, False, True, True,  True),
       ]:
       print(args, expect_dash_g, expect_emit_text)
-      delete_file('a.out.wat')
+      try_delete('a.out.wat')
       cmd = [EMXX, test_file('hello_world.cpp')] + args
       print(' '.join(cmd))
       self.run_process(cmd)
@@ -7655,7 +7655,7 @@ int main() {
       if '-sSIDE_MODULE' in args:
         continue
       print(args)
-      delete_file('a.out.wasm')
+      try_delete('a.out.wasm')
       cmd = [EMCC, test_file('other/ffi.c'), '-g', '-o', 'a.out.wasm'] + args
       print(' '.join(cmd))
       self.run_process(cmd)
@@ -7695,7 +7695,7 @@ int main() {
   def test_no_legalize_js_ffi(self):
     # test minimal JS FFI legalization for invoke and dyncalls
     args = ['-sLEGALIZE_JS_FFI=0', '-sMAIN_MODULE=2', '-O3', '-sDISABLE_EXCEPTION_CATCHING=0']
-    delete_file('a.out.wasm')
+    try_delete('a.out.wasm')
     with env_modify({'EMCC_FORCE_STDLIBS': 'libc++'}):
       cmd = [EMXX, test_file('other/noffi.cpp'), '-g', '-o', 'a.out.js'] + args
     print(' '.join(cmd))
@@ -9370,7 +9370,7 @@ int main () {
         return # Nonexistent file passes in this check
       obtained_size = os.path.getsize(f)
       print('size of generated ' + f + ': ' + str(obtained_size))
-      delete_file(f)
+      try_delete(f)
       self.assertLess(obtained_size, expected_size)
 
     self.run_process([PYTHON, test_file('gen_many_js_functions.py'), 'library_long.js', 'main_long.c'])
@@ -9440,7 +9440,7 @@ int main () {
       self.run_process(args)
 
       output = read_file('a.js')
-      delete_file('a.js')
+      try_delete('a.js')
       self.assertNotContained('asm["_thisIsAFunctionExportedFromAsmJsOrWasmWithVeryLongFunction"]', output)
 
       # TODO: Add stricter testing when Wasm side is also optimized: (currently Wasm does still need
@@ -9553,7 +9553,7 @@ int main () {
       with gzip.open(f_gz, 'wb') as gzf:
         gzf.write(read_binary(f))
       size = os.path.getsize(f_gz)
-      delete_file(f_gz)
+      try_delete(f_gz)
       return size
 
     # For certain tests, don't just check the output size but check

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -18,9 +18,8 @@ from common import parameterized, EMBUILDER
 from tools.config import EM_CONFIG
 from tools.shared import EMCC
 from tools.shared import CANONICAL_TEMP_DIR
-from tools.shared import config
+from tools.shared import try_delete, config
 from tools.shared import EXPECTED_LLVM_VERSION, Cache
-from tools.utils import delete_file, delete_dir
 from tools import shared, utils
 from tools import response_file
 from tools import ports
@@ -45,8 +44,8 @@ def restore_and_set_up():
 
 # wipe the config and sanity files, creating a blank slate
 def wipe():
-  delete_file(EM_CONFIG)
-  delete_file(SANITY_FILE)
+  try_delete(EM_CONFIG)
+  try_delete(SANITY_FILE)
 
 
 def add_to_config(content):
@@ -213,7 +212,7 @@ class sanity(RunnerCore):
 
     # The guessed config should be ok
     # XXX This depends on your local system! it is possible `which` guesses wrong
-    # delete_file('a.out.js')
+    # try_delete('a.out.js')
     # output = self.run_process([EMCC, test_file('hello_world.c')], stdout=PIPE, stderr=PIPE).output
     # self.assertContained('hello, world!', self.run_js('a.out.js'), output)
 
@@ -230,7 +229,7 @@ class sanity(RunnerCore):
           elif 'runner' not in ' '.join(command):
             self.assertContained('error: NODE_JS is set to empty value', output) # sanity check should fail
         finally:
-          delete_file(default_config)
+          try_delete(default_config)
 
   def test_llvm(self):
     LLVM_WARNING = 'LLVM version for clang executable'
@@ -253,7 +252,7 @@ class sanity(RunnerCore):
 
     for inc_x in range(-2, 3):
       for inc_y in range(-2, 3):
-        delete_file(SANITY_FILE)
+        try_delete(SANITY_FILE)
         expected_x = real_version_x + inc_x
         expected_y = real_version_y + inc_y
         if expected_x < 0 or expected_y < 0:
@@ -304,7 +303,7 @@ class sanity(RunnerCore):
                              ('v4.2.3-pre', True),
                              ('cheez', False)]:
       print(version, succeed)
-      delete_file(SANITY_FILE)
+      try_delete(SANITY_FILE)
       f = open(self.in_dir('fake', 'nodejs'), 'w')
       f.write('#!/bin/sh\n')
       f.write('''if [ $1 = "--version" ]; then
@@ -355,7 +354,7 @@ fi
     # but with EMCC_DEBUG=1 we should check
     with env_modify({'EMCC_DEBUG': '1'}):
       output = self.check_working(EMCC)
-    delete_dir(CANONICAL_TEMP_DIR)
+    try_delete(CANONICAL_TEMP_DIR)
 
     self.assertContained(SANITY_MESSAGE, output)
     output = self.check_working(EMCC)
@@ -569,7 +568,7 @@ fi
       self.do([EMCC, '--clear-cache'])
       print(i)
       if i == 0:
-        delete_dir(PORTS_DIR)
+        try_delete(PORTS_DIR)
       else:
         self.do([EMCC, '--clear-ports'])
       self.assertNotExists(PORTS_DIR)
@@ -620,7 +619,7 @@ fi
                  ('node',   config.NODE_JS),
                  ('nodejs', config.NODE_JS)]
     for filename, engine in jsengines:
-      delete_file(SANITY_FILE)
+      try_delete(SANITY_FILE)
       if type(engine) is list:
         engine = engine[0]
       if not engine:
@@ -683,7 +682,7 @@ fi
         self.check_working([EMCC] + MINIMAL_HELLO_WORLD + ['-c'], expected)
 
     test_with_fake('got js backend! JavaScript (asm.js, emscripten) backend', 'LLVM has not been built with the WebAssembly backend')
-    delete_dir(CANONICAL_TEMP_DIR)
+    try_delete(CANONICAL_TEMP_DIR)
 
   def test_required_config_settings(self):
     # with no binaryen root, an error is shown

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -18,7 +18,7 @@ import clang_native
 import common
 from common import BrowserCore, no_windows, create_file, test_file, read_file
 from common import parameterized, requires_native_clang, PYTHON
-from tools import config, utils
+from tools import shared, config, utils
 from tools.shared import EMCC, path_from_root, run_process, CLANG_CC
 
 npm_checked = False
@@ -267,6 +267,7 @@ class sockets(BrowserCore):
   @no_windows('This test uses Unix-specific build architecture.')
   def test_enet(self):
     # this is also a good test of raw usage of emconfigure and emmake
+    shared.try_delete('enet')
     shutil.copytree(test_file('third_party', 'enet'), 'enet')
     with utils.chdir('enet'):
       self.run_process([path_from_root('emconfigure'), './configure', '--disable-shared'])

--- a/tools/building.py
+++ b/tools/building.py
@@ -25,7 +25,7 @@ from . import utils
 from .shared import CLANG_CC, CLANG_CXX
 from .shared import LLVM_NM, EMCC, EMAR, EMXX, EMRANLIB, WASM_LD, LLVM_AR
 from .shared import LLVM_LINK, LLVM_OBJCOPY
-from .shared import run_process, check_call, exit_with_error
+from .shared import try_delete, run_process, check_call, exit_with_error
 from .shared import path_from_root
 from .shared import asmjs_mangle, DEBUG
 from .shared import TEMP_DIR
@@ -71,7 +71,7 @@ def extract_archive_contents(archive_files):
   unpack_temp_dir = tempfile.mkdtemp('_archive_contents', 'emscripten_temp_')
 
   def clean_at_exit():
-    utils.delete_dir(unpack_temp_dir)
+    try_delete(unpack_temp_dir)
   shared.atexit.register(clean_at_exit)
 
   archive_contents = []
@@ -521,7 +521,7 @@ def link_bitcode(args, target, force_archive_contents=False):
     scan_archive_group(current_archive_group)
     current_archive_group = None
 
-  utils.delete_file(target)
+  try_delete(target)
 
   # Finish link
   # tolerate people trying to link a.so a.so etc.
@@ -595,7 +595,7 @@ def parse_llvm_nm_symbols(output):
 
 
 def emar(action, output_filename, filenames, stdout=None, stderr=None, env=None):
-  utils.delete_file(output_filename)
+  try_delete(output_filename)
   cmd = [EMAR, action, output_filename] + filenames
   cmd = get_command_with_possible_response_file(cmd)
   run_process(cmd, stdout=stdout, stderr=stderr, env=env)
@@ -913,7 +913,7 @@ def run_closure_cmd(cmd, filename, env, pretty):
   # But it looks like it creates such files on Linux(?) even without setting that command line
   # flag (and currently we don't), so delete the produced source map file to not leak files in
   # temp directory.
-  utils.delete_file(outfile + '.map')
+  try_delete(outfile + '.map')
 
   # Print Closure diagnostics result up front.
   if proc.returncode != 0:

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -8,7 +8,7 @@ import logging
 import os
 from pathlib import Path
 
-from . import filelock, config, utils
+from . import tempfiles, filelock, config, utils
 from .settings import settings
 
 logger = logging.getLogger('cache')
@@ -70,8 +70,9 @@ class Cache:
 
   def erase(self):
     with self.lock('erase'):
-      # Delete everything except the lockfile itself
-      utils.delete_contents(self.dirname, exclude=[os.path.basename(self.filelock_name)])
+      if self.dirname.exists():
+        for f in os.listdir(self.dirname):
+          tempfiles.try_delete(Path(self.dirname, f))
 
   def get_path(self, name):
     return Path(self.dirname, name)
@@ -119,7 +120,7 @@ class Cache:
       name = Path(self.dirname, shortname)
       if name.exists():
         logger.info(f'deleting cached file: {name}')
-        utils.delete_file(name)
+        tempfiles.try_delete(name)
 
   def get_lib(self, libname, *args, **kwargs):
     name = self.get_lib_name(libname)

--- a/tools/minimal_runtime_shell.py
+++ b/tools/minimal_runtime_shell.py
@@ -206,7 +206,7 @@ def generate_minimal_runtime_html(target, options, js_target, target_basename):
   # In SINGLE_FILE build, embed the main .js file into the .html output
   if settings.SINGLE_FILE:
     js_contents = utils.read_file(js_target)
-    utils.delete_file(js_target)
+    shared.try_delete(js_target)
   else:
     js_contents = ''
   shell = shell.replace('{{{ JS_CONTENTS_IN_SINGLE_FILE_BUILD }}}', js_contents)

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -77,7 +77,7 @@ class Ports:
     if not target:
       target = os.path.basename(src_dir)
     dest = Ports.get_include_dir(target)
-    utils.delete_dir(dest)
+    shared.try_delete(dest)
     logger.debug(f'installing headers: {dest}')
     shutil.copytree(src_dir, dest)
 
@@ -144,7 +144,9 @@ class Ports:
   @staticmethod
   def erase():
     dirname = Ports.get_dir()
-    utils.delete_dir(dirname)
+    shared.try_delete(dirname)
+    if os.path.exists(dirname):
+      logger.warning('could not delete ports dir %s - try to delete it manually' % dirname)
 
   @staticmethod
   def get_build_dir():
@@ -190,7 +192,7 @@ class Ports:
               logger.warning(f'not grabbing local port: {name} from {path} to {fullname} (subdir: {subdir}) as the destination {target} is newer (run emcc --clear-ports if that is incorrect)')
             else:
               logger.warning(f'grabbing local port: {name} from {path} to {fullname} (subdir: {subdir})')
-              utils.delete_file(fullname)
+              shared.try_delete(fullname)
               shutil.copytree(path, target)
               Ports.clear_project_build(name)
             return
@@ -251,8 +253,8 @@ class Ports:
           return
         # file exists but tag is bad
         logger.warning('local copy of port is not correct, retrieving from remote server')
-        utils.delete_dir(fullname)
-        utils.delete_file(fullpath)
+        shared.try_delete(fullname)
+        shared.try_delete(fullpath)
 
       retrieve()
       unpack()
@@ -265,7 +267,7 @@ class Ports:
     port = ports_by_name[name]
     port.clear(Ports, settings, shared)
     build_dir = os.path.join(Ports.get_build_dir(), name)
-    utils.delete_dir(build_dir)
+    shared.try_delete(build_dir)
     return build_dir
 
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -34,6 +34,7 @@ logging.basicConfig(format='%(name)s:%(levelname)s: %(message)s',
                     level=logging.DEBUG if DEBUG else logging.INFO)
 colored_logger.enable()
 
+from .tempfiles import try_delete
 from .utils import path_from_root, exit_with_error, safe_ensure_dirs, WINDOWS
 from . import cache, tempfiles
 from . import diagnostics
@@ -491,7 +492,7 @@ def get_emscripten_temp_dir():
     if not DEBUG_SAVE:
       def prepare_to_clean_temp(d):
         def clean_temp():
-          utils.delete_dir(d)
+          try_delete(d)
 
         atexit.register(clean_temp)
       # this global var might change later

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -14,7 +14,7 @@ from enum import IntEnum, auto
 from glob import iglob
 
 from . import shared, building, utils
-from . import deps_info
+from . import deps_info, tempfiles
 from . import diagnostics
 from tools.shared import demangle_c_symbol_name
 from tools.settings import settings
@@ -334,7 +334,7 @@ class Library:
     utils.safe_ensure_dirs(build_dir)
     create_lib(out_filename, self.build_objects(build_dir))
     if not shared.DEBUG:
-      utils.delete_dir(build_dir)
+      tempfiles.try_delete(build_dir)
 
   @classmethod
   def _inherit_list(cls, attr):

--- a/tools/tempfiles.py
+++ b/tools/tempfiles.py
@@ -3,11 +3,63 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
+import os
+import shutil
 import tempfile
 import atexit
+import stat
 import sys
 
-from . import utils
+
+def try_delete(pathnames):
+  if isinstance(pathnames, list):
+    for pathname in pathnames:
+      try_delete_one(pathname)
+  else:
+    try_delete_one(pathnames)
+
+
+# Attempts to delete given possibly nonexisting or read-only directory tree or filename.
+# If any failures occur, the function silently returns without throwing an error.
+def try_delete_one(pathname):
+  try:
+    os.unlink(pathname)
+  except OSError:
+    pass
+  if not os.path.exists(pathname):
+    return
+  try:
+    shutil.rmtree(pathname, ignore_errors=True)
+  except IOError:
+    pass
+  if not os.path.exists(pathname):
+    return
+
+  # Ensure all files are readable and writable by the current user.
+  permission_bits = stat.S_IWRITE | stat.S_IREAD
+
+  def is_writable(path):
+    return (os.stat(path).st_mode & permission_bits) != permission_bits
+
+  def make_writable(path):
+    os.chmod(path, os.stat(path).st_mode | permission_bits)
+
+  # Some tests make files and subdirectories read-only, so rmtree/unlink will not delete
+  # them. Force-make everything writable in the subdirectory to make it
+  # removable and re-attempt.
+  if not is_writable(pathname):
+    make_writable(pathname)
+
+  if os.path.isdir(pathname):
+    for directory, subdirs, files in os.walk(pathname):
+      for item in files + subdirs:
+        i = os.path.join(directory, item)
+        make_writable(i)
+
+  try:
+    shutil.rmtree(pathname, ignore_errors=True)
+  except IOError:
+    pass
 
 
 class TempFiles:
@@ -41,7 +93,7 @@ class TempFiles:
 
       def __exit__(self_, type, value, traceback):
         if not self.save_debug_files:
-          utils.delete_file(self_.file.name)
+          try_delete(self_.file.name)
     return TempFileObject()
 
   def get_dir(self):
@@ -55,5 +107,5 @@ class TempFiles:
       print(f'not cleaning up temp files since in debug-save mode, see them in {self.tmpdir}', file=sys.stderr)
       return
     for filename in self.to_clean:
-      utils.delete_file(filename)
+      try_delete(filename)
     self.to_clean = []

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -5,7 +5,6 @@
 
 import contextlib
 import os
-import shutil
 import sys
 from pathlib import Path
 
@@ -94,32 +93,3 @@ def write_binary(file_path, contents):
   """Write to a file opened in binary mode"""
   with open(file_path, 'wb') as fh:
     fh.write(contents)
-
-
-def delete_file(filename):
-  """Delete a file (if it exists)."""
-  if not os.path.exists(filename):
-    return
-  os.remove(filename)
-
-
-def delete_dir(dirname):
-  """Delete a directory (if it exists)."""
-  if not os.path.exists(dirname):
-    return
-  shutil.rmtree(dirname)
-
-
-def delete_contents(dirname, exclude=None):
-  """Delete the contents of a directory without removing
-  the directory itself."""
-  if not os.path.exists(dirname):
-    return
-  for entry in os.listdir(dirname):
-    if exclude and entry in exclude:
-      continue
-    entry = os.path.join(dirname, entry)
-    if os.path.isdir(entry):
-      delete_dir(entry)
-    else:
-      delete_file(entry)

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -15,7 +15,7 @@ __scriptdir__ = os.path.dirname(os.path.abspath(__file__))
 __rootdir__ = os.path.dirname(__scriptdir__)
 sys.path.append(__rootdir__)
 
-from tools import utils
+from tools import shared, utils
 
 sys.path.append(utils.path_from_root('third_party'))
 sys.path.append(utils.path_from_root('third_party/ply'))
@@ -50,8 +50,8 @@ class Dummy:
 input_file = sys.argv[1]
 output_base = sys.argv[2]
 
-utils.delete_file(output_base + '.cpp')
-utils.delete_file(output_base + '.js')
+shared.try_delete(output_base + '.cpp')
+shared.try_delete(output_base + '.js')
 
 p = WebIDL.Parser()
 p.parse(r'''


### PR DESCRIPTION
This reverts commit 028241f329cfbbe66bfb0103363bdd40c3b536d2.

It seems to be causing consistent failures, when paired with new LLVM updates (e.g. 
https://ci.chromium.org/ui/p/emscripten-releases/builders/try/win/b8806276352238048897/overview)
It's not clear exactly why yet, but I'd like to let the LLVM update roll into emsdk and then it may be 
easier to test.