### PR TITLE
[Wasm64] Fix makeSetValue of i64s with WASM_BIGINT

### DIFF
--- a/test/other/test_parseTools.c
+++ b/test/other/test_parseTools.c
@@ -5,6 +5,7 @@
 void test_makeGetValue(int32_t* ptr);
 int  test_receiveI64ParamAsI53(int64_t arg1, int64_t arg2);
 int  test_receiveI64ParamAsDouble(int64_t arg1, int64_t arg2);
+void test_makeSetValue_i64(int64_t* ptr);
 
 #define MAX_SAFE_INTEGER (1ll << 53)
 #define MIN_SAFE_INTEGER (-MAX_SAFE_INTEGER)
@@ -41,6 +42,18 @@ int main() {
   rtn = test_receiveI64ParamAsDouble(MIN_SAFE_INTEGER - 1, 0);
   printf("rtn = %d\n", rtn);
 
-  printf("done\n");
+  printf("\ntest_makeSetValue_i64\n");
+  // Test an unaligned read of an i64 in JS. To do that, get an unaligned
+  // pointer. i64s are only 32-bit aligned, but we can't rely on the address to
+  // happen to be unaligned here, so actually force an unaligned address (one
+  // of the iterations will be unaligned).
+  char buffer[16];
+  for (size_t i = 0; i < 8; i += 4) {
+    int64_t* unaligned_i64 = (int64_t*)(buffer + i);
+    test_makeSetValue_i64(unaligned_i64);
+    printf("i64 = 0x%llx\n", *unaligned_i64);
+  }
+
+  printf("\ndone\n");
   return 0;
 }

--- a/test/other/test_parseTools.js
+++ b/test/other/test_parseTools.js
@@ -81,5 +81,9 @@ mergeInto(LibraryManager.library, {
     val = {{{ makeGetValue('ptr', '0', 'i32*') }}};
     out('ptr: ' + val.toString(16))
     assert(val == 0xedcba988);
-  }
+  },
+
+  test_makeSetValue_i64: function(ptr) {
+    {{{ makeSetValue('ptr', '0', 0x12345678AB, 'i64') }}};
+  },
 });

--- a/test/other/test_parseTools.out
+++ b/test/other/test_parseTools.out
@@ -49,4 +49,9 @@ test_receiveI64ParamAsDouble:
 arg1: -9007199254740992
 arg2: 0
 rtn = 0
+
+test_makeSetValue_i64
+i64 = 0x12345678ab
+i64 = 0x12345678ab
+
 done

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5290,6 +5290,9 @@ Module["preRun"].push(function () {
     'main_thread': (['-sPTHREAD_POOL_SIZE=5'],),
     # using proxy_to_pthread also works, of course
     'proxy_to_pthread': (['-sPROXY_TO_PTHREAD', '-sINITIAL_MEMORY=32MB', '-DPROXYING'],),
+    # using BigInt support affects the ABI, and should not break things. (this
+    # could be tested on either thread; do the main thread for simplicity)
+    'bigint': (['-sPTHREAD_POOL_SIZE=5', '-sWASM_BIGINT'],),
   })
   @requires_threads
   def test_wasmfs_fetch_backend(self, args):


### PR DESCRIPTION
The code here assumed that we can write `HEAP64[ptr>>3]` to read an
i64 value. That assumes the pointer has 64-bit alignment, which is not the
case with wasm32+WASM_BIGINT.

This fixes a WasmFS issue where we'd pass a pointer to a file size, a
64-bit number, and write it from JS in the fetch backend (specifically the
async jsimpl code that it uses), but this is a much more general issue.

Fixes #17614. The test added here fails before the fix, but perhaps we
should add a specific test for makeSetValue as well? (do we have unit
tests for that @sbc100 ?)