### PR TITLE
Update test_implicit_func for LLVM 16

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -870,7 +870,7 @@ def get_clang_flags(user_args):
 cflags = None
 
 
-def get_cflags(user_args):
+def get_cflags(user_args, is_cxx):
   global cflags
   if cflags:
     return cflags
@@ -906,7 +906,9 @@ def get_cflags(user_args):
   #   -Wno-error=implicit-function-declaration
   # or disable even a warning about it with
   #   -Wno-implicit-function-declaration
-  cflags += ['-Werror=implicit-function-declaration']
+  # This is already an error in C++ so we don't need to inject extra flags.
+  if not is_cxx:
+    cflags += ['-Werror=implicit-function-declaration']
 
   ports.add_cflags(cflags, settings)
 
@@ -2728,7 +2730,7 @@ def phase_compile_inputs(options, state, newargs, input_files):
     return CC
 
   def get_clang_command(src_file):
-    return get_compiler(src_file) + get_cflags(state.orig_args) + compile_args + [src_file]
+    return get_compiler(src_file) + get_cflags(state.orig_args, use_cxx(src_file)) + compile_args + [src_file]
 
   def get_clang_command_preprocessed(src_file):
     return get_compiler(src_file) + get_clang_flags(state.orig_args) + compile_args + [src_file]

--- a/emcc.py
+++ b/emcc.py
@@ -1135,7 +1135,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   passthrough_flags = ['-print-search-dirs', '-print-libgcc-file-name']
   if any(a in args for a in passthrough_flags) or any(a.startswith('-print-file-name=') for a in args):
-    return run_process([clang] + args + get_cflags(args), check=False).returncode
+    return run_process([clang] + args + get_cflags(args, run_via_emxx), check=False).returncode
 
   ## Process argument and setup the compiler
   state = EmccState(args)

--- a/test/implicit_func.c
+++ b/test/implicit_func.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+int main()
+{
+    printf("hello %d\n", strnlen("waka", 2)); // Implicit declaration, no header, for strnlen
+    int (*my_strnlen)(char*, ...) = strnlen;
+    printf("hello %d\n", my_strnlen("shaka", 2));
+    return 0;
+}

--- a/test/other/test_implicit_func.c
+++ b/test/other/test_implicit_func.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
-int main()
-{
+int main() {
     printf("hello %d\n", strnlen("waka", 2)); // Implicit declaration, no header, for strnlen
     int (*my_strnlen)(char*, ...) = strnlen;
     printf("hello %d\n", my_strnlen("shaka", 2));

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3987,7 +3987,7 @@ Waste<3> *getMore() {
     try_delete('implicit_func.o')
     result = self.run_process(
         [EMCC, path_from_root('test/other/test_implicit_func.c'), '-c', '-o', 'implicit_func.o', '-std=gnu89'],
-          stderr=PIPE, check=False)
+        stderr=PIPE, check=False)
     self.assertContained(IMPLICIT_C89, result.stderr)
     self.assertContained(INCOMPATIBLE, result.stderr)
     self.assertTrue(result.returncode != 0, 'Expected compile to fail')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3981,16 +3981,14 @@ Waste<3> *getMore() {
     # EMCC makes -Wimplict-function-declaration an error by default in all modes. Upstream LLVM
     # emits a warning in gnu89 mode, but otherwise emcc's behavior is identical to upstream.
     IMPLICIT_C89 = "error: implicit declaration of function 'strnlen'"
-    # Also ensure that -Wincompatible-function-pointer-types is an error
-    INCOMPATIBLE = 'error: incompatible function pointer types'
+    # Also check for -Wincompatible-function-pointer-types (it became an error in LLVM 16)
+    INCOMPATIBLE = ': incompatible function pointer types'
 
     try_delete('implicit_func.o')
-    result = self.run_process(
-        [EMCC, path_from_root('test/other/test_implicit_func.c'), '-c', '-o', 'implicit_func.o', '-std=gnu89'],
-        stderr=PIPE, check=False)
-    self.assertContained(IMPLICIT_C89, result.stderr)
-    self.assertContained(INCOMPATIBLE, result.stderr)
-    self.assertTrue(result.returncode != 0, 'Expected compile to fail')
+    stderr = self.expect_fail(
+        [EMCC, path_from_root('test/other/test_implicit_func.c'), '-c', '-o', 'implicit_func.o', '-std=gnu89'])
+    self.assertContained(IMPLICIT_C89, stderr)
+    self.assertContained(INCOMPATIBLE, stderr)
 
   @requires_native_clang
   def test_bad_triple(self):

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3986,6 +3986,7 @@ Waste<3> *getMore() {
 
     def warning(text):
       return 'warning: ' + text
+
     def error(text):
       return 'error: ' + text
 
@@ -4012,7 +4013,6 @@ Waste<3> *getMore() {
         self.assertTrue(result.returncode == 0, 'Expected compile to succeed')
       else:
         self.assertTrue(result.returncode != 0, 'Expected compile to fail')
-
 
   @requires_native_clang
   def test_bad_triple(self):

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3977,6 +3977,7 @@ Waste<3> *getMore() {
       self.assertContained('argc: 1\n16\n17\n10\n', self.run_js('a.out.js'))
       self.assertContainedIf('globalCtors', src, has_global)
 
+  @disabled('Re-enable when LLVM 16.0 rolls into emsdk')
   def test_implicit_func(self):
     IMPLICIT_C89 = "implicit declaration of function 'strnlen'"
     IMPLICIT_C99 = "call to undeclared function 'strnlen'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]"


### PR DESCRIPTION
After the branch to LLVM 16, -Wincompatible-function-pointer types has been upgraded to an error
by default. The functional change in this PR is to update test_implicit_func
to incorporate this.
I also refactored the test and captured more precisely the differences between
the messages in C89 vs other modes. The test also no longer links or runs the
result; it didn't seem useful to test for a behavior that is known to be
incorrect, and it speeds up the test.