### PR TITLE
Disable bitfield constant conversion warnings in Bullet

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6760,7 +6760,8 @@ void* operator new(size_t size) {
         '-Wno-deprecated-register',
         '-Wno-writable-strings',
         '-Wno-shift-negative-value',
-        '-Wno-format'
+        '-Wno-format',
+        '-Wno-bitfield-constant-conversion',
     ]
 
     # extra testing for ASSERTIONS == 2

--- a/test/third_party/bullet/src/BulletSoftBody/btSoftBody.cpp
+++ b/test/third_party/bullet/src/BulletSoftBody/btSoftBody.cpp
@@ -1,5 +1,3 @@
-// There are several bitfield conversion warnings in this file.
-#pragma clang diagnostic ignored "-Wbitfield-constant-conversion"
 /*
 Bullet Continuous Collision Detection and Physics Library
 Copyright (c) 2003-2006 Erwin Coumans  http://continuousphysics.com/Bullet/

--- a/test/third_party/bullet/src/BulletSoftBody/btSoftBody.cpp
+++ b/test/third_party/bullet/src/BulletSoftBody/btSoftBody.cpp
@@ -1,3 +1,5 @@
+// There are several bitfield conversion warnings in this file.
+#pragma clang diagnostic ignored "-Wbitfield-constant-conversion"
 /*
 Bullet Continuous Collision Detection and Physics Library
 Copyright (c) 2003-2006 Erwin Coumans  http://continuousphysics.com/Bullet/


### PR DESCRIPTION
After https://reviews.llvm.org/D131255 clang warns about
signed bitfield conversions in Bullet. Disable the warning to
allow Bullet to continue building.