### PR TITLE
Default to ERROR_ON_UNDEFINED_SYMBOLS, even when SIDE_MODULE is set. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2146,12 +2146,6 @@ def phase_linker_setup(options, state, newargs, user_settings):
   if settings.SIDE_MODULE and 'GLOBAL_BASE' in user_settings:
     exit_with_error('Cannot set GLOBAL_BASE when building SIDE_MODULE')
 
-  # When building a side module we currently have to assume that any undefined
-  # symbols that exist at link time will be satisfied by the main module or JS.
-  if settings.SIDE_MODULE:
-    default_setting(user_settings, 'ERROR_ON_UNDEFINED_SYMBOLS', 0)
-    default_setting(user_settings, 'WARN_ON_UNDEFINED_SYMBOLS', 0)
-
   if options.use_preload_plugins or len(options.preload_files) or len(options.embed_files):
     if settings.NODERAWFS:
       exit_with_error('--preload-file and --embed-file cannot be used with NODERAWFS which disables virtual filesystem')
@@ -2683,6 +2677,16 @@ def phase_linker_setup(options, state, newargs, user_settings):
 
   apply_min_browser_versions(user_settings)
 
+  if settings.SIDE_MODULE:
+    # For side modules, we ignore all REQUIRED_EXPORTS that might have been added above.
+    # They all come from either libc or compiler-rt.  The exception is __wasm_call_ctors
+    # which is a per-module export.
+    settings.REQUIRED_EXPORTS.clear()
+
+  if not settings.STANDALONE_WASM:
+    # in standalone mode, crt1 will call the constructors from inside the wasm
+    settings.REQUIRED_EXPORTS.append('__wasm_call_ctors')
+
   return target, wasm_target
 
 
@@ -2876,7 +2880,7 @@ def phase_link(linker_arguments, wasm_target):
   # fastcomp deferred linking opts.
   # TODO: we could check if this is a fastcomp build, and still speed things up here
   js_syms = None
-  if settings.LLD_REPORT_UNDEFINED and settings.ERROR_ON_UNDEFINED_SYMBOLS:
+  if settings.LLD_REPORT_UNDEFINED and settings.ERROR_ON_UNDEFINED_SYMBOLS and not settings.SIDE_MODULE:
     js_syms = get_all_js_syms()
   building.link_lld(linker_arguments, wasm_target, external_symbols=js_syms)
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1759,7 +1759,7 @@ def warn_on_unexported_main(symbolses):
 
 
 def handle_reverse_deps(input_files):
-  if settings.REVERSE_DEPS == 'none':
+  if settings.REVERSE_DEPS == 'none' or settings.SIDE_MODULE:
     return
   elif settings.REVERSE_DEPS == 'all':
     # When not optimzing we add all possible reverse dependencies rather


### PR DESCRIPTION
This change removes the defaulting of ERROR_ON_UNDEFINED_SYMBOLS when
building a side module.

In order handle that I removed from REQUIRED_EXPORTS all of the symbols
that are not relevant when building a side module.

This change is basically NFC.  The main thing it fixes a lot of
incorrect "undefined symbol" errors when building a side module with
`ERROR_ON_UNDEFINED_SYMBOLS`.

Fixes: #17605