### PR TITLE
Fix sdl2_mixer_mp3 build after recent LLVM change

### DIFF
--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -57,6 +57,7 @@ def get(ports, settings, shared):
 
     if "mp3" in settings.SDL2_MIXER_FORMATS:
       flags += [
+        '-Wno-incompatible-function-pointer-types',
         '-sUSE_MPG123=1',
         '-DMUSIC_MP3_MPG123',
       ]


### PR DESCRIPTION
This doesn't get caught by the rollers because I guess we don't do
`./embuilder build ALL` there, and we don't have test for this
particular flavor of sdl2_mixer.