### PR TITLE
Define _cmake_record_install_prefix so that Platform/Unix.cmake will not error for cmake version 3.24

### DIFF
--- a/cmake/Modules/CMakeSystemSpecificInformation.cmake
+++ b/cmake/Modules/CMakeSystemSpecificInformation.cmake
@@ -80,6 +80,16 @@ set(UNIX   )
 set(CYGWIN )
 set(WIN32  )
 
+function(_cmake_record_install_prefix )
+  set(_CMAKE_SYSTEM_PREFIX_PATH_INSTALL_PREFIX_VALUE "${CMAKE_INSTALL_PREFIX}" PARENT_SCOPE)
+  set(count 0)
+  foreach(value IN LISTS CMAKE_SYSTEM_PREFIX_PATH)
+    if(value STREQUAL CMAKE_INSTALL_PREFIX)
+      math(EXPR count "${count}+1")
+    endif()
+  endforeach()
+  set(_CMAKE_SYSTEM_PREFIX_PATH_INSTALL_PREFIX_COUNT "${count}" PARENT_SCOPE)
+endfunction()
 
 # include Generic system information
 include(CMakeGenericSystem)


### PR DESCRIPTION
In CMake verison 3.24, they add "Support per call disabling of CMAKE_INSTALL_PREFIX" in commit [42f7e397894c5132b4706f478e62ce5d648119c1](https://github.com/Kitware/CMake/commit/42f7e397894c5132b4706f478e62ce5d648119c1). As a part of this, they introduce the `_cmake_record_install_prefix` function that gets used in [Modules/Platform/WindowsPaths.cmake](https://github.com/Kitware/CMake/blob/bcd98b5f9846d7b9d2a6518501eb7ac56139665e/Modules/Platform/WindowsPaths.cmake#L70), [Modules/Platform/UnixPaths.cmake](https://github.com/Kitware/CMake/blob/bcd98b5f9846d7b9d2a6518501eb7ac56139665e/Modules/Platform/UnixPaths.cmake#L47), and [Modules/Platform/CrayLinuxEnvironment.cmake](https://github.com/Kitware/CMake/blob/bcd98b5f9846d7b9d2a6518501eb7ac56139665e/Modules/Platform/CrayLinuxEnvironment.cmake#L71). CMake defines `_cmake_record_install_prefix` in [Modules/CMakeSystemSpecificInformation.cmake](https://github.com/Kitware/CMake/blob/bcd98b5f9846d7b9d2a6518501eb7ac56139665e/Modules/CMakeSystemSpecificInformation.cmake). Building LLVM calls [Platform/${CMAKE_HOST_SYSTEM_NAME}](https://github.com/llvm/llvm-project/blob/main/llvm/cmake/config-ix.cmake#L749) where, on my builder, `CMAKE_HOST_SYSTEM_NAME=Linux`, then Platform/Linux calls Platform/Unix which tries to call `_cmake_record_install_prefix`, but `_cmake_record_install_prefix` is not defined because Emscripten does not define it in [CMakeSystemSpecificInformation.cmake](https://github.com/emscripten-core/emscripten/blob/main/cmake/Modules/CMakeSystemSpecificInformation.cmake). It seems like the solutons are either to have emcmake set `CMAKE_HOST_SYSTEM_NAME=Emscripten` ( which I have not tried ), or to define `_cmake_record_install_prefix` in CMakeSystemSpecificInformation.cmake ( which is what this pull request does ).