### PR TITLE
Remove emrun html output restriction

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1855,8 +1855,6 @@ def phase_linker_setup(options, state, newargs, user_settings):
   if options.emrun:
     if settings.MINIMAL_RUNTIME:
       exit_with_error('--emrun is not compatible with MINIMAL_RUNTIME')
-    if options.oformat != OFormat.HTML:
-      exit_with_error('--emrun is only compatible with html output')
 
   if options.use_closure_compiler:
     settings.USE_CLOSURE_COMPILER = 1


### PR DESCRIPTION
.js is more or less the established output format for emcc and changing it to html seems a bit too unconvenient just for enabling emrun support. emrun always takes the html filename as an argument, so emcc doesn't strictly speaking need to enforce that the output is html. This is useful in cases where there exists a custom html file that will be run with emrun.