### PR TITLE
Replaced typeof require check with process.release.name to run .mjs in node with -sASSERTIONS

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -194,7 +194,7 @@ var requireNodeFS;
 if (ENVIRONMENT_IS_NODE) {
 #if ENVIRONMENT
 #if ASSERTIONS
-  if (process.release.name !== 'node') throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
+  if (!global.process || !process.release || process.release.name !== 'node') throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
 #endif
 #endif
   if (ENVIRONMENT_IS_WORKER) {

--- a/src/shell.js
+++ b/src/shell.js
@@ -194,7 +194,7 @@ var requireNodeFS;
 if (ENVIRONMENT_IS_NODE) {
 #if ENVIRONMENT
 #if ASSERTIONS
-  if (!(typeof process == 'object' && typeof Buffer == 'function')) throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
+  if (process.release.name !== 'node') throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
 #endif
 #endif
   if (ENVIRONMENT_IS_WORKER) {

--- a/src/shell.js
+++ b/src/shell.js
@@ -194,7 +194,7 @@ var requireNodeFS;
 if (ENVIRONMENT_IS_NODE) {
 #if ENVIRONMENT
 #if ASSERTIONS
-  if (!(typeof process == 'object' && typeof require == 'function')) throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
+  if (!(typeof process == 'object' && typeof Buffer == 'function')) throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
 #endif
 #endif
   if (ENVIRONMENT_IS_WORKER) {


### PR DESCRIPTION
Implementing the changes detailed in #17465 to fix the faulty assertion on .mjs files (since `require` will be undefined in modules).