### PR TITLE
asyncify: Fix possible infinite recursion in maybeStopUnwind

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -206,11 +206,15 @@ mergeInto(LibraryManager.library, {
           Asyncify.state === Asyncify.State.Unwinding &&
           Asyncify.exportCallStack.length === 0) {
         // We just finished unwinding.
+        // Be sure to set the state before calling any other functions to avoid
+        // possible infinite recursion here (For example in debug pthread builds
+        // the err() function itself can call back into WebAssembly to get the
+        // current pthread_self() pointer).
+        Asyncify.state = Asyncify.State.Normal;
 #if ASYNCIFY_DEBUG
         err('ASYNCIFY: stop unwind');
 #endif
         {{{ runtimeKeepalivePush(); }}}
-        Asyncify.state = Asyncify.State.Normal;
         // Keep the runtime alive so that a re-wind can be done later.
 #if ASYNCIFY == 1
         runAndAbortIfError(_asyncify_stop_unwind);

--- a/test/other/test_pthread_asyncify.c
+++ b/test/other/test_pthread_asyncify.c
@@ -1,0 +1,29 @@
+// Copyright 2019 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <assert.h>
+#include <emscripten.h>
+#include <emscripten/console.h>
+
+void* thread_main(void* arg) {
+  printf("thread main\n");
+  emscripten_sleep(10);
+  printf("done sleep\n");
+  return NULL;
+}
+
+int main() {
+  printf("main\n");
+  pthread_t thread;
+  int rc = pthread_create(&thread, NULL, thread_main, NULL);
+  assert(rc == 0);
+  rc = pthread_join(thread, NULL);
+  assert(rc == 0);
+  printf("done pthread_join\n");
+  return 0;
+}

--- a/test/other/test_pthread_asyncify.out
+++ b/test/other/test_pthread_asyncify.out
@@ -1,0 +1,1 @@
+done sleep

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10529,6 +10529,16 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
     self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test('other/test_pthread_self_join_detach.c')
 
+  @node_pthreads
+  def test_pthread_asyncify(self):
+    # We had a infinite recursion bug when enabling PTHREADS_DEBUG + ASYNCIFY.
+    # This was because PTHREADS_DEBUG calls back into WebAssembly for each call to `err()`.
+    self.set_setting('PTHREADS_DEBUG')
+    self.set_setting('ASYNCIFY')
+    self.set_setting('PTHREAD_POOL_SIZE', 2)
+    self.set_setting('EXIT_RUNTIME')
+    self.do_run_in_out_file_test('other/test_pthread_asyncify.c')
+
   def test_stdin_preprocess(self):
     create_file('temp.h', '#include <string>')
     outputStdin = self.run_process([EMCC, '-x', 'c++', '-dM', '-E', '-'], input="#include <string>", stdout=PIPE).stdout


### PR DESCRIPTION
I noticed this while trying to enable PTHREADS_DEBUG in an ASYNCIFY
build.