### PR TITLE
Fix error handling in instantiateWasm hook

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1143,7 +1143,12 @@ function createWasm() {
       return exports;
     } catch(e) {
       err('Module.instantiateWasm callback failed with error: ' + e);
-      return false;
+      #if MODULARIZE
+        // If instantiation fails, reject the module ready promise.
+        readyPromiseReject(e);
+      #else
+        return false;
+      #endif
     }
   }
 


### PR DESCRIPTION
If you specify the Module property `instantiateWasm`, and override it with your own function, and an error is thrown in that function, this does not reject the ready promise that is used with MODULARIZE. Instead, the promise never gets rejected, and the loading hangs forever. There are some ways to work around this that are quite awkward and involve various levels of nested promises, and the best solution is just to fix the error handling when MODULARIZE is on.

CC @sbc100 @dschuff 