### PR TITLE
Fix core0.test_dylink_basics on windows. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,6 +478,7 @@ jobs:
           python: "$EMSDK_PYTHON"
       - run-tests:
           test_targets: "
+            core0.test_dylink_basics
             core2.test_sse1
             core2.test_ccall
             core2.test_utf16

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -412,8 +412,7 @@ class TestCoreBase(RunnerCore):
   def verify_in_strict_mode(self, filename):
     js = read_file(filename)
     filename += '.strict.js'
-    with open(filename, 'w') as outfile:
-      outfile.write('"use strict";\n' + js)
+    write_file(filename, '"use strict";\n' + js)
     self.run_js(filename)
 
   def do_core_test(self, testname, **kwargs):


### PR DESCRIPTION
This is test-only change where we forgot to use an explicitly encoding
when writing a file.

See #17677