### PR TITLE
[Wasm64] Implement emmalloc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,6 +448,7 @@ jobs:
     executor: bionic
     steps:
       - run-tests-linux:
+          frozen_cache: false
           test_targets: "wasm64.test_hello_world wasm64.test_ccall wasm64l"
   test-other:
     executor: bionic

--- a/system/lib/sbrk.c
+++ b/system/lib/sbrk.c
@@ -47,11 +47,13 @@ uintptr_t* emscripten_get_sbrk_ptr() {
   return &sbrk_val;
 }
 
+// Enforce preserving a minimal alignof(maxalign_t) alignment for sbrk.
+#define SBRK_ALIGNMENT (__alignof__(max_align_t))
+
 void *sbrk(intptr_t increment_) {
   uintptr_t old_size;
-  // Enforce preserving a minimal 4-byte alignment for sbrk.
   uintptr_t increment = (uintptr_t)increment_;
-  increment = (increment + 3) & ~3;
+  increment = (increment + (SBRK_ALIGNMENT-1)) & ~(SBRK_ALIGNMENT-1);
 #if __EMSCRIPTEN_PTHREADS__
   // Our default dlmalloc uses locks around each malloc/free, so no additional
   // work is necessary to keep things threadsafe, but we also make sure sbrk

--- a/test/core/test_emmalloc_memory_statistics.cpp
+++ b/test/core/test_emmalloc_memory_statistics.cpp
@@ -2,29 +2,30 @@
 #include <emscripten/emmalloc.h>
 
 template<typename T>
-T round_to_4k(T val){
-	return (T)(((size_t)val + 4095) & ~4095);
+T round_to_4k(T val) {
+  return (T)(((size_t)val + 4095) & ~4095);
 }
 
-int main()
-{
-	void *ptr = malloc(32*1024*1024);
-	void *ptr2 = malloc(4*1024*1024);
-	void *ptr3 = malloc(64*1024*1024);
-	void *ptr4 = malloc(16*1024);
-	void *ptr5 = malloc(2*1024*1024);
-	printf("%ld\n", (long)(ptr && ptr2 && ptr3 && ptr4 && ptr5));
-	free(ptr2);
-	free(ptr4);
-	printf("%d\n", emmalloc_validate_memory_regions());
-	printf("%zu\n", emmalloc_dynamic_heap_size());
-	printf("%zu\n", emmalloc_free_dynamic_memory());
-	size_t numFreeMemoryRegions = 0;
-	size_t freeMemorySizeMap[32];
-	numFreeMemoryRegions = emmalloc_compute_free_dynamic_memory_fragmentation_map(freeMemorySizeMap);
-	printf("%zu\n", numFreeMemoryRegions);
-	for(int i = 0; i < 32; ++i)
-		printf("%zu ", freeMemorySizeMap[i]);
-	printf("\n");
-	printf("%zu\n", round_to_4k(emmalloc_unclaimed_heap_memory()));
+int main() {
+  void *ptr = malloc(32*1024*1024);
+  void *ptr2 = malloc(4*1024*1024);
+  void *ptr3 = malloc(64*1024*1024);
+  void *ptr4 = malloc(16*1024);
+  void *ptr5 = malloc(2*1024*1024);
+  printf("%ld\n", (long)(ptr && ptr2 && ptr3 && ptr4 && ptr5));
+  free(ptr2);
+  free(ptr4);
+  printf("validate_memory_regions: %d\n", emmalloc_validate_memory_regions());
+  printf("dynamic_heap_size: %zu\n", emmalloc_dynamic_heap_size());
+  printf("free_dynamic_memory: %zu\n", emmalloc_free_dynamic_memory());
+  size_t numFreeMemoryRegions = 0;
+  size_t freeMemorySizeMap[32];
+  numFreeMemoryRegions = emmalloc_compute_free_dynamic_memory_fragmentation_map(freeMemorySizeMap);
+  printf("numFreeMemoryRegions: %zu\n", numFreeMemoryRegions);
+  for (int i = 0; i < 32; ++i) {
+    printf("%zu ", freeMemorySizeMap[i]);
+  }
+  printf("\n");
+  printf("unclaimed_heap_memory: %zu\n", round_to_4k(emmalloc_unclaimed_heap_memory()));
+  return 0;
 }

--- a/test/core/test_emmalloc_memory_statistics.out
+++ b/test/core/test_emmalloc_memory_statistics.out
@@ -1,7 +1,7 @@
 1
-0
-106971424
-4210892
-3
+validate_memory_regions: 0
+dynamic_heap_size: 106971424
+free_dynamic_memory: 4210892
+numFreeMemoryRegions: 3
 0 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 
-21999616
+unclaimed_heap_memory: 21999616

--- a/test/core/test_emmalloc_memory_statistics64.out
+++ b/test/core/test_emmalloc_memory_statistics64.out
@@ -1,0 +1,7 @@
+1
+validate_memory_regions: 0
+dynamic_heap_size: 106971712
+free_dynamic_memory: 4211104
+numFreeMemoryRegions: 3
+0 0 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 
+unclaimed_heap_memory: 21999616

--- a/test/core/test_malloc_usable_size.c
+++ b/test/core/test_malloc_usable_size.c
@@ -1,4 +1,5 @@
-#include <emscripten/emmalloc.h>
+#include <assert.h>
+#include <malloc.h>
 #include <stdio.h>
 
 // Mark as used to defeat LTO which can otherwise completely elimate the
@@ -7,7 +8,11 @@ void* ptr __attribute__((used));
 
 int main()
 {
+  // Usable size should always be at least the size of 2 pointers
+  // (See SMALLEST_ALLOCATION_SIZE in emmalloc.c)
   ptr = malloc(1);
-  printf("%zu\n", malloc_usable_size(ptr));
+  size_t usable = malloc_usable_size(ptr);
+  printf("malloc_usable_size: %zu\n", usable);
+  assert(usable == 2 * sizeof(void*));
   return 0;
 }

--- a/test/core/test_malloc_usable_size.out
+++ b/test/core/test_malloc_usable_size.out
@@ -1,1 +1,1 @@
-8
+malloc_usable_size: (8|16)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1013,7 +1013,6 @@ base align: 0, 0, 0, 0'''])
 
   @no_asan('ASan does not support custom memory allocators')
   @no_lsan('LSan does not support custom memory allocators')
-  @no_wasm64('emmalloc does not yet support MEMORY64')
   @parameterized({
     'normal': [],
     'memvalidate': ['-DEMMALLOC_MEMVALIDATE'],
@@ -1034,29 +1033,28 @@ base align: 0, 0, 0, 0'''])
 
   @no_asan('ASan does not support custom memory allocators')
   @no_lsan('LSan does not support custom memory allocators')
-  @no_wasm64('emmalloc does not yet support MEMORY64')
   def test_emmalloc_usable_size(self, *args):
     self.set_setting('MALLOC', 'emmalloc')
-    self.emcc_args += list(args)
-
-    self.do_core_test('test_malloc_usable_size.c')
+    self.do_core_test('test_malloc_usable_size.c', regex=True)
 
   @no_optimize('output is sensitive to optimization flags, so only test unoptimized builds')
   @no_asan('ASan does not support custom memory allocators')
   @no_lsan('LSan does not support custom memory allocators')
   @no_ubsan('UBSan changes memory consumption')
-  @no_wasm64('emmalloc does not yet support MEMORY64')
   def test_emmalloc_memory_statistics(self, *args):
+    if self.is_wasm64():
+      out_suffix = '64'
+    else:
+      out_suffix = ''
 
     self.set_setting('MALLOC', 'emmalloc')
     self.emcc_args += ['-sINITIAL_MEMORY=128MB', '-g'] + list(args)
 
-    self.do_core_test('test_emmalloc_memory_statistics.cpp')
+    self.do_core_test('test_emmalloc_memory_statistics.cpp', out_suffix=out_suffix)
 
   @no_optimize('output is sensitive to optimization flags, so only test unoptimized builds')
   @no_asan('ASan does not support custom memory allocators')
   @no_lsan('LSan does not support custom memory allocators')
-  @no_wasm64('emmalloc does not yet support MEMORY64')
   def test_emmalloc_trim(self, *args):
     self.set_setting('MALLOC', 'emmalloc')
     self.emcc_args += ['-sINITIAL_MEMORY=128MB', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=2147418112'] + list(args)
@@ -1064,7 +1062,6 @@ base align: 0, 0, 0, 0'''])
     self.do_core_test('test_emmalloc_trim.cpp')
 
   # Test case against https://github.com/emscripten-core/emscripten/issues/10363
-  @no_wasm64('emmalloc does not yet support MEMORY64')
   def test_emmalloc_memalign_corruption(self, *args):
     self.set_setting('MALLOC', 'emmalloc')
     self.do_core_test('emmalloc_memalign_corruption.cpp')
@@ -2821,7 +2818,6 @@ The current type of b is: 9
 
   @no_asan('ASan does not support custom memory allocators')
   @no_lsan('LSan does not support custom memory allocators')
-  @no_wasm64('emmalloc does not yet support MEMORY64')
   @node_pthreads
   def test_pthread_emmalloc(self):
     self.emcc_args += ['-fno-builtin']

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1387,11 +1387,6 @@ class libmalloc(MTLibrary):
   def can_use(self):
     return super().can_use() and settings.MALLOC != 'none'
 
-  def can_build(self):
-    # emmalloc is not currently compatible with 64-bit pointers.  See
-    # the comment at the top of emmalloc.c.
-    return not self.malloc.startswith('emmalloc') or not settings.MEMORY64
-
   @classmethod
   def vary_on(cls):
     return super().vary_on() + ['is_debug', 'use_errno', 'is_tracing', 'memvalidate', 'verbose']


### PR DESCRIPTION
The primary change here is to use `size_t` in a bunch of places that
previously used `uint32_t`.

This change also increases the alignment of `sbrk()` from 4 to
`alignof(maxalign_t)` (8).

As part of this change I also converted all the tracing/logging in
emmalloc form EM_ASM to `_emscripten_out`/`_emscripten_err`.  The latter
two are disigned for low level tracing an should never allocate heap
memory themselves.  The motivation for this is that `EM_ASM` arguments
that are 64-bit are not yet well supported.  At best the arguments would
come through as BigInts and the EM_ASM code would become more complex,
having to handle both cases.