### PR TITLE
Add sign-ext lowering pass when target browser doesn't support it

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,7 +28,10 @@ See docs/process.md for more on how version tagging works.
   support these older engines you can use these settings
   (`-sMIN_SAFARI_VERSION=120000` and/or `-sMIN_EDGE_VERSION=44`) to revert to
   the previous defaults, which will result in the new proposals being disabled.
-  (#17690)
+  Note that in order to avoid support for the sign-extension emscripten uses
+  a binaryen pass, so targeting older browsers requires the running of wasm-opt
+  and is therefore incompatible with `ERROR_ON_WASM_CHANGES_AFTER_LINK` (i.e.
+  fast linking). (#17690)
 - Added `--reproduce` command line flag (or equivalently `EMCC_REPRODUCE`
   environment variable).  This options specifies the name of a tar file into
   which emscripten will copy all of the input files along with a response file

--- a/src/settings.js
+++ b/src/settings.js
@@ -1968,7 +1968,9 @@ var SEPARATE_DWARF_URL = '';
 // not in others like split-dwarf).
 // When this flag is turned on, we error at link time if the build requires any
 // changes to the wasm after link. This can be useful in testing, for example.
-// [link]
+// Some example of features that require post-link wasm changes are:
+// - Lowering i64 to i32 pairs at the JS boundary (See WASM_BIGINT)
+// - Lowering sign-extnesion operation when targeting older browsers.
 var ERROR_ON_WASM_CHANGES_AFTER_LINK = false;
 
 // Abort on unhandled excptions that occur when calling exported WebAssembly

--- a/test/other/test_signext_lowering.c
+++ b/test/other/test_signext_lowering.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include <stdint.h>
+
+int main(int argc, char* argv[]) {
+  printf("%lld\n", (int64_t)argc);
+}

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -1,0 +1,88 @@
+# Copyright 2022 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+"""Utilities for mapping browser versions to webassembly features."""
+
+import logging
+from enum import IntEnum, auto
+
+from .settings import settings, user_settings
+
+logger = logging.getLogger('feature_matrix')
+
+
+class Feature(IntEnum):
+  NON_TRAPPING_FPTOINT = auto()
+  SIGN_EXT = auto()
+  BULK_MEMORY = auto()
+  MUTABLE_GLOBALS = auto()
+  JS_BIGINT_INTEGRATION = auto()
+
+
+default_features = {Feature.SIGN_EXT, Feature.MUTABLE_GLOBALS}
+
+min_browser_versions = {
+  Feature.NON_TRAPPING_FPTOINT: {
+    'chrome': 75,
+    'firefox': 65,
+    'safari': 150000,
+  },
+  Feature.SIGN_EXT: {
+    'chrome': 74,
+    'firefox': 62,
+    'safari': 140100,
+  },
+  Feature.BULK_MEMORY: {
+    'chrome': 75,
+    'firefox': 79,
+    'safari': 150000,
+  },
+  Feature.MUTABLE_GLOBALS: {
+    'chrome': 74,
+    'firefox': 61,
+    'safari': 120000,
+  },
+  Feature.JS_BIGINT_INTEGRATION: {
+    'chrome': 67,
+    'firefox': 68,
+    'safari': 150000,
+  },
+}
+
+
+def caniuse(feature):
+  min_versions = min_browser_versions[feature]
+  if settings.MIN_CHROME_VERSION < min_versions['chrome']:
+    return False
+  # For edge we just use the same version requirements as chrome since,
+  # at least for modern versions of edge, they share version numbers.
+  if settings.MIN_EDGE_VERSION < min_versions['chrome']:
+    return False
+  if settings.MIN_FIREFOX_VERSION < min_versions['firefox']:
+    return False
+  if settings.MIN_SAFARI_VERSION < min_versions['safari']:
+    return False
+  # IE don't support any non-MVP features
+  if settings.MIN_IE_VERSION != 0x7FFFFFFF:
+    return False
+  return True
+
+
+def enable_feature(feature):
+  """Updates default settings for browser versions such that the given
+  feature is available everywhere.
+  """
+  for name, min_version in min_browser_versions[feature].items():
+    name = f'MIN_{name.upper()}_VERSION'
+    if settings[name] < min_version and name not in user_settings:
+      setattr(settings, name, min_version)
+
+
+# apply minimum browser version defaults based on user settings. if
+# a user requests a feature that we know is only supported in browsers
+# from a specific version and above, we can assume that browser version.
+def apply_min_browser_versions():
+  if settings.WASM_BIGINT:
+    enable_feature(Feature.JS_BIGINT_INTEGRATION)


### PR DESCRIPTION
llvm and binaryen now default to enabling sign-ext and mutable-globals   
by default. See https://reviews.llvm.org/D125728.                        
                                                                         
In order to allow users to continue to target older browsers we will        
now lower sign-ext operations in a binaryen pass if the target browsers  
don't support it.   