### PR TITLE
Bump min browser versions such they all support llvm default features

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,15 @@ See docs/process.md for more on how version tagging works.
 
 3.1.26 (in development)
 -----------------------
+- Inline with the recent changes to llvm and binaryen, emscripten will now, by
+  default, enable the sign-extension and mutable-globals WebAssembly proposals.
+  In order to do so the default minimum safari version (`MIN_SAFARI_VERSION`)
+  was updated from 12.0 to 14.1, and support for the old EdgeHTML engine
+  (`MIN_EDGE_VERSION`) was removed by default.  If you want to continue to
+  support these older engines you can use these settings
+  (`-sMIN_SAFARI_VERSION=120000` and/or `-sMIN_EDGE_VERSION=44`) to revert to
+  the previous defaults, which will result in the new proposals being disabled.
+  (#17690)
 - Added `--reproduce` command line flag (or equivalently `EMCC_REPRODUCE`
   environment variable).  This options specifies the name of a tar file into
   which emscripten will copy all of the input files along with a response file

--- a/src/settings.js
+++ b/src/settings.js
@@ -1749,14 +1749,16 @@ var MIN_FIREFOX_VERSION = 65;
 
 // Specifies the oldest version of desktop Safari to target. Version is encoded
 // in MMmmVV, e.g. 70101 denotes Safari 7.1.1.
-// Safari 12.0.0 was released on September 17, 2018, bundled with macOS 10.14.0
-// Mojave.
+// Safari 14.1.0 was released on April 26, 2021, bundled with macOS 11.0 Big
+// Sur and iOS 14.5.
+// The previous default, Safari 12.0.0 was released on September 17, 2018,
+// bundled with macOS 10.14.0 Mojave.
 // NOTE: Emscripten is unable to produce code that would work in iOS 9.3.5 and
 // older, i.e. iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 and older,
 // see https://github.com/emscripten-core/emscripten/pull/7191.
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
 // [link]
-var MIN_SAFARI_VERSION = 120000;
+var MIN_SAFARI_VERSION = 140100;
 
 // Specifies the oldest version of Internet Explorer to target. E.g. pass -s
 // MIN_IE_VERSION = 11 to drop support for IE 10 and older.
@@ -1768,10 +1770,17 @@ var MIN_IE_VERSION = 0x7FFFFFFF;
 // Specifies the oldest version of Edge (EdgeHTML, the non-Chromium based
 // flavor) to target. E.g. pass -sMIN_EDGE_VERSION=40 to drop support for
 // EdgeHTML 39 and older.
-// Edge 44.17763 was released on November 13, 2018
+// EdgeHTML 44.17763 was released on November 13, 2018
+// EdgeHTML was completely in April 2021 and replaced by the current
+// Chromium-based Edge.
+// Since version 79, Edge version numbers have mirrored chromium version
+// numbers, so it no longer makes sense specify MIN_EDGE_VERSION independenly.
+// If Chromium and Edge ever start to diverage this setting may be revived with
+// more modern post-chromium default value.
+// See https://en.wikipedia.org/wiki/Microsoft_Edge#New_Edge_release_history
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
 // [link]
-var MIN_EDGE_VERSION = 44;
+var MIN_EDGE_VERSION = 0x7FFFFFFF;
 
 // Specifies the oldest version of Chrome. E.g. pass -sMIN_CHROME_VERSION=58 to
 // drop support for Chrome 57 and older.


### PR DESCRIPTION
LLVM and binaryen updated their defaults to include sign extension and mutable globals: https://reviews.llvm.org/D125728.

According to https://webassembly.org/roadmap/ the min versions required for sign extension are:

- firefox: 62
- safai: 14.1
- chrome: 71

And for mutable globals:

- firefox: 61
- safai: ??
- chrome: 72

Since the minimum firefox and chrome versions are already 65 and 74, the only version we need to bump is the safari
version which needs to go from 12.0 to 14.1.