### PR TITLE
Fix assertion message on missing dynCall. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3198,9 +3198,9 @@ mergeInto(LibraryManager.library, {
 #if ASSERTIONS
 #if MINIMAL_RUNTIME
     assert(typeof dynCalls != 'undefined', 'Global dynCalls dictionary was not generated in the build! Pass -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$dynCall linker flag to include it!');
-    assert(sig in dynCalls, 'bad function pointer type - no table for sig \'' + sig + '\'');
+    assert(sig in dynCalls, 'bad function pointer type - sig is not in dynCalls: \'' + sig + '\'');
 #else
-    assert(('dynCall_' + sig) in Module, 'bad function pointer type - no table for sig \'' + sig + '\'');
+    assert(('dynCall_' + sig) in Module, 'bad function pointer type - dynCall function not found for sig \'' + sig + '\'');
 #endif
     if (args && args.length) {
       // j (64-bit integer) must be passed in as two numbers [low 32, high 32].


### PR DESCRIPTION
The 'no table for sig' dates back to the fastcomp era I believe.

See: #17707