### PR TITLE
Always check llvm version and allow warning to be suppressed

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1137,8 +1137,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       print(shared.shlex_join(parts[1:]))
     return 0
 
-  shared.check_sanity()
-
   passthrough_flags = ['-print-search-dirs', '-print-libgcc-file-name']
   if any(a in args for a in passthrough_flags) or any(a.startswith('-print-file-name=') for a in args):
     return run_process([clang] + args + get_cflags(args, run_via_emxx), check=False).returncode
@@ -1146,6 +1144,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   ## Process argument and setup the compiler
   state = EmccState(args)
   options, newargs, user_settings = phase_parse_arguments(state)
+
+  shared.check_sanity()
 
   if 'EMMAKEN_NO_SDK' in os.environ:
     exit_with_error('EMMAKEN_NO_SDK is no longer supported.  The standard -nostdlib and -nostdinc flags should be used instead')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -413,8 +413,14 @@ def check_sanity(force=False):
       sanity_data = utils.read_file(sanity_file)
       if sanity_data == expected:
         logger.debug(f'sanity file up-to-date: {sanity_file}')
+        # Even if the sanity file is up-to-date we still need to at least
+        # check the llvm version. This comes at no extra performance cost
+        # since the version was already extracted and cached by the
+        # generate_sanity() call above.
         if force:
           perform_sanity_checks()
+        else:
+          check_llvm_version()
         return True # all is well
     return False
 


### PR DESCRIPTION
Previously we would only check the llvm version if the sanity file was
out-of-date.  However, we want this warning to be shown every time the
compiler is run, and the version information is already retrieved from
clang as part of check_sanity so it doesn't cost anything extra to do it
each time.

I also notices the `-Wno-version-check` flag was not working to suppress
this warning since the check was being done before argument parsing.