### PR TITLE
[WasmFS] Fix and test FS.writeFile

### DIFF
--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -140,7 +140,13 @@ mergeInto(LibraryManager.library, {
     writeFile: (path, data) => {
       return withStackSave(() => {
         var pathBuffer = allocateUTF8OnStack(path);
-        var dataBuffer = _malloc(data);
+        var dataBuffer = _malloc(data.length);
+#if ASSERTIONS
+        assert(dataBuffer);
+#endif
+        for (var i = 0; i < data.length; i++) {
+          {{{ makeSetValue('dataBuffer', 'i', 'data[i]', 'i8') }}};
+        }
         var ret = __wasmfs_write_file(pathBuffer, dataBuffer, data.length);
         _free(dataBuffer);
         return ret;

--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -140,6 +140,11 @@ mergeInto(LibraryManager.library, {
     writeFile: (path, data) => {
       return withStackSave(() => {
         var pathBuffer = allocateUTF8OnStack(path);
+        if (typeof data == 'string') {
+          var buf = new Uint8Array(lengthBytesUTF8(data) + 1);
+          var actualNumBytes = stringToUTF8Array(data, buf, 0, buf.length);
+          data = buf.slice(0, actualNumBytes);
+        }
         var dataBuffer = _malloc(data.length);
 #if ASSERTIONS
         assert(dataBuffer);

--- a/system/lib/wasmfs/js_api.cpp
+++ b/system/lib/wasmfs/js_api.cpp
@@ -58,7 +58,7 @@ void* _wasmfs_read_file(char* path) {
 }
 
 // Writes to a file, possibly creating it, and returns the number of bytes
-// written successfully.
+// written successfully. If the file already exists, appends to it.
 int _wasmfs_write_file(char* pathname, char* data, size_t data_size) {
   auto parsedParent = path::parseParent(pathname);
   if (parsedParent.getError()) {
@@ -87,7 +87,9 @@ int _wasmfs_write_file(char* pathname, char* data, size_t data_size) {
     return 0;
   }
 
-  auto result = dataFile->locked().write((uint8_t*)data, data_size, 0);
+  auto lockedFile = dataFile->locked();
+  auto offset = lockedFile.getSize();
+  auto result = lockedFile.write((uint8_t*)data, data_size, offset);
   if (result != __WASI_ERRNO_SUCCESS) {
     return 0;
   }

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5843,6 +5843,11 @@ main( int argv, char ** argc ) {
   def test_fs_writeFile(self):
     self.do_run_in_out_file_test('fs/test_writeFile.cpp')
 
+  def test_fs_writeFile_wasmfs(self):
+    self.emcc_args += ['-sWASMFS']
+    self.emcc_args += ['-sFORCE_FILESYSTEM']
+    self.do_run_in_out_file_test('fs/test_writeFile.cpp')
+
   def test_fs_write(self):
     self.do_run_in_out_file_test('fs/test_write.cpp')
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5843,6 +5843,7 @@ main( int argv, char ** argc ) {
   def test_fs_writeFile(self):
     self.do_run_in_out_file_test('fs/test_writeFile.cpp')
 
+  @no_wasm64('MEMORY64 does not yet support WasmFS')
   def test_fs_writeFile_wasmfs(self):
     self.emcc_args += ['-sWASMFS']
     self.emcc_args += ['-sFORCE_FILESYSTEM']


### PR DESCRIPTION
Fixes #17230

* This function appends to the existing file, if it exists.
* Handle a string input, not just a typed array.
* Fix the heap allocation logic (we malloced but were missing the copy).