### PR TITLE
Add support for the new JavaScript promise integration API.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -600,6 +600,8 @@ def get_binaryen_passes():
     if settings.ASYNCIFY_ONLY:
       check_human_readable_list(settings.ASYNCIFY_ONLY)
       passes += ['--pass-arg=asyncify-onlylist@%s' % ','.join(settings.ASYNCIFY_ONLY)]
+  elif settings.ASYNCIFY == 2:
+    passes += ['--jspi']
   if settings.BINARYEN_IGNORE_IMPLICIT_TRAPS:
     passes += ['--ignore-implicit-traps']
   # normally we can assume the memory, if imported, has not been modified

--- a/emscripten.py
+++ b/emscripten.py
@@ -141,6 +141,9 @@ def update_settings_glue(wasm_file, metadata):
 
   # start with the MVP features, and add any detected features.
   settings.BINARYEN_FEATURES = ['--mvp-features'] + metadata['features']
+  if settings.ASYNCIFY == 2:
+    settings.BINARYEN_FEATURES += ['--enable-reference-types']
+
   if settings.USE_PTHREADS:
     assert '--enable-threads' in settings.BINARYEN_FEATURES
   if settings.MEMORY64:

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -181,8 +181,19 @@ function callMain(args) {
     assert(ret == 0, '_emscripten_proxy_main failed to start proxy thread: ' + ret);
 #endif
 #else
+#if ASYNCIFY == 2
+    // The current spec of JSPI returns a promise only if the function suspends
+    // and a plain value otherwise. This will likely change:
+    // https://github.com/WebAssembly/js-promise-integration/issues/11
+    Promise.resolve(ret).then((result) => {
+      exitJS(result, /* implicit = */ true);
+    }).catch((e) => {
+      handleException(e);
+    });
+#else
     // if we're not running an evented main loop, it's time to exit
     exitJS(ret, /* implicit = */ true);
+#endif // ASYNCIFY == 2
     return ret;
   }
   catch (e) {

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7987,8 +7987,6 @@ void* operator new(size_t size) {
   @no_wasm64('TODO: asyncify for wasm64')
   @with_asyncify_and_stack_switching
   def test_async_hello(self):
-    if self.get_setting('ASYNCIFY') == 2:
-      self.skipTest('https://github.com/emscripten-core/emscripten/issues/17532')
     # needs to flush stdio streams
     self.set_setting('EXIT_RUNTIME')
 


### PR DESCRIPTION
- Enables the new "jspi" pass in binaryen.
- Wraps all imports/exports in a suspending/promising. WebAssembly.Function.


This currently wraps everything, but we could make it only wrap async
functions as needed.