### PR TITLE
Fix assertion in file_packager for Jest

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -996,7 +996,7 @@ def generate_js(data_target, data_files, metadata):
     code += '''
       function processPackageData(arrayBuffer) {
         assert(arrayBuffer, 'Loading data file failed.');
-        assert(arrayBuffer instanceof ArrayBuffer, 'bad input to processPackageData');
+        assert(arrayBuffer.constructor.name === ArrayBuffer.name, 'bad input to processPackageData');
         var byteArray = new Uint8Array(arrayBuffer);
         var curr;
         %s


### PR DESCRIPTION
`instanceof` doesn't always behave as expected:
https://stackoverflow.com/questions/6473273/why-are-myarray-instanceof-array-and-myarray-constructor-array-both-false-wh

We see this problem in https://github.com/pyodide/pyodide/issues/2764. People downstream of Pyodide are using sed to remove this assertion from `pyodide.asm.js` because it is failing.