### PR TITLE
[WasmFS] Avoid using pointers as JS handles

### DIFF
--- a/src/library_wasmfs_jsimpl.js
+++ b/src/library_wasmfs_jsimpl.js
@@ -12,14 +12,14 @@ mergeInto(LibraryManager.library, {
 
   _wasmfs_jsimpl_alloc_file: function(backend, file) {
 #if ASSERTIONS
-    assert(wasmFS$backends[backend]);
+    assert(wasmFS$backends[backend], 'wasmfs backend not found: ' + backend);
 #endif
     return wasmFS$backends[backend].allocFile(file);
   },
 
   _wasmfs_jsimpl_free_file: function(backend, file) {
 #if ASSERTIONS
-    assert(wasmFS$backends[backend]);
+    assert(wasmFS$backends[backend], 'wasmfs backend not found: ' + backend);
 #endif
     return wasmFS$backends[backend].freeFile(file);
   },

--- a/system/lib/wasmfs/backends/js_file_backend.cpp
+++ b/system/lib/wasmfs/backends/js_file_backend.cpp
@@ -13,14 +13,15 @@
 // See library_wasmfs_js_file.js
 
 extern "C" {
-void _wasmfs_create_js_file_backend_js(wasmfs::backend_t);
+void _wasmfs_create_js_file_backend_js(js_index_t backend);
 }
 
 namespace wasmfs {
 
 extern "C" backend_t wasmfs_create_js_file_backend() {
   backend_t backend = wasmFS.addBackend(std::make_unique<JSImplBackend>());
-  _wasmfs_create_js_file_backend_js(backend);
+  _wasmfs_create_js_file_backend_js(
+    static_cast<JSImplBackend*>(backend)->getIndex());
   return backend;
 }
 

--- a/system/lib/wasmfs/js_impl_backend.cpp
+++ b/system/lib/wasmfs/js_impl_backend.cpp
@@ -1,0 +1,14 @@
+#include "js_impl_backend.h"
+
+namespace wasmfs {
+
+std::atomic<js_index_t> JSImplFile::next_index;
+
+std::atomic<js_index_t> JSImplBackend::next_index;
+
+js_index_t JSImplFile::getBackendIndex() {
+  JSImplBackend* jsbackend = static_cast<JSImplBackend*>(getBackend());
+  return jsbackend->getIndex();
+}
+
+} // namespace wasmfs

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1557,6 +1557,7 @@ class libwasmfs(DebugLibrary, AsanInstrumentedLibrary, MTLibrary):
         path='system/lib/wasmfs',
         filenames=['file.cpp',
                    'file_table.cpp',
+                   'js_impl_backend.cpp',
                    'js_api.cpp',
                    'paths.cpp',
                    'special_files.cpp',


### PR DESCRIPTION
This makes porting to wasm64 easier, but at the cost of an extra member
on the C/C++ side for each JS file and JS backend.

It also obviously means that handles on the JS side are not easily
mapped to pointers on the C/C++ side.

Split out from #17731