### PR TITLE
Rename runOnMainThread -> runIfMainThread

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -880,7 +880,7 @@ function modifyFunction(text, func) {
   return func(name, args, rest.substring(bodyStart + 1, bodyEnd), async_);
 }
 
-function runOnMainThread(text) {
+function runIfMainThread(text) {
   if (WASM_WORKERS && USE_PTHREADS) {
     return 'if (!ENVIRONMENT_IS_WASM_WORKER && !ENVIRONMENT_IS_PTHREAD) { ' + text + ' }';
   } else if (WASM_WORKERS) {
@@ -891,6 +891,10 @@ function runOnMainThread(text) {
     return text;
   }
 }
+
+// Legacy name for runIfMainThread.
+// TODO(remove).
+const runOnMainThread = runIfMainThread;
 
 function expectToReceiveOnModule(name) {
   return INCOMING_MODULE_JS_API.has(name);

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -752,7 +752,7 @@ var splitModuleProxyHandler = {
 #if LOAD_SOURCE_MAP
 function receiveSourceMapJSON(sourceMap) {
   wasmSourceMap = new WasmSourceMap(sourceMap);
-  {{{ runOnMainThread("removeRunDependency('source-map');") }}}
+  {{{ runIfMainThread("removeRunDependency('source-map');") }}}
 }
 #endif
 
@@ -966,10 +966,10 @@ function createWasm() {
 
   }
   // we can't run yet (except in a pthread, where we have a custom sync instantiator)
-  {{{ runOnMainThread("addRunDependency('wasm-instantiate');") }}}
+  {{{ runIfMainThread("addRunDependency('wasm-instantiate');") }}}
 
 #if LOAD_SOURCE_MAP
-  {{{ runOnMainThread("addRunDependency('source-map');") }}}
+  {{{ runIfMainThread("addRunDependency('source-map');") }}}
 #endif
 
   // Prefer streaming instantiation if available.

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -120,7 +120,7 @@ function ready() {
   readyPromiseResolve(Module);
 #endif // MODULARIZE
 #if INVOKE_RUN && HAS_MAIN
-  {{{ runOnMainThread("run();") }}}
+  {{{ runIfMainThread("run();") }}}
 #elif ASSERTIONS
   console.log('ready() called, and INVOKE_RUN=0. The runtime is now ready for you to call run() to invoke application _main(). You can also override ready() in a --pre-js file to get this signal as a callback')
 #endif


### PR DESCRIPTION
When ready code `runOnMainThread` sounds like its going to proxy the
work to the main thread, but that is not what this function does.  Its
really about conditional execution.