### PR TITLE
fix: failed to overwrite previous downloaded file on next wget

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -470,8 +470,14 @@ mergeInto(LibraryManager.library, {
         wakeUp,
         false, // dontCreateFile
         false, // canOwn
-        // preFinish: if the destination directory does not yet exist, create it
-        () => FS.mkdirTree(destinationDirectory)
+        function() { // preFinish
+          // if a file exists there, we overwrite it
+          try {
+            FS.unlink(_file);
+          } catch (e) {}
+          // if the destination directory does not yet exist, create it
+          FS.mkdirTree(destinationDirectory);
+        }
       );
     });
   },

--- a/test/test_wget.c
+++ b/test/test_wget.c
@@ -20,6 +20,10 @@ int main() {
   emscripten_wget(file , file);
   printf("back from wget\n");
 
+  printf("calling wget again to overwrite previous file\n");
+  emscripten_wget(file , file);
+  printf("back from wget\n");
+
   FILE * f = fopen(file, "r");
   assert(f);
 


### PR DESCRIPTION
According to [emscripten_wget api](https://emscripten.org/docs/api_reference/emscripten.h.html?highlight=emscripten_wget#c.emscripten_wget), at 'file' parameter description:

> If the file already exists it will be overwritten.

The actual implementation in `emscripten_wget` does not meet the expected behavior, while `emscripten_async_wget` does, because in `emscripten_async_wget`, it tried to unlink previous file before saving a new one:

```javascript
// src/library_wget.js:51:7
function() { // preFinish
  // if a file exists there, we overwrite it
  try {
    FS.unlink(_file);
  } catch (e) {}
  // if the destination directory does not yet exist, create it
  FS.mkdirTree(destinationDirectory);
}
```

In this pull request, I try to unlink before saving the file in src/library_async.js:470:9 just like what `emscripten_async_wget` did.