### PR TITLE
tentative changes for supporting memory64 in webgl wrapper

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -622,8 +622,8 @@ def get_binaryen_passes():
 def make_js_executable(script):
   src = read_file(script)
   cmd = config.JS_ENGINE
-  if settings.WASM_BIGINT:
-    cmd.append('--experimental-wasm-bigint')
+  #if settings.WASM_BIGINT:
+  #  cmd.append('--experimental-wasm-bigint')
   cmd = shared.shlex_join(cmd)
   if not os.path.isabs(config.JS_ENGINE[0]):
     # TODO: use whereis etc. And how about non-*NIX?
@@ -2618,10 +2618,10 @@ def phase_linker_setup(options, state, newargs, user_settings):
 
   # check if we can address the 2GB mark and higher: either if we start at
   # 2GB, or if we allow growth to either any amount or to 2GB or more.
-  if settings.INITIAL_MEMORY > 2 * 1024 * 1024 * 1024 or \
+  if settings.MEMORY64 == 0 and (settings.INITIAL_MEMORY > 2 * 1024 * 1024 * 1024 or \
      (settings.ALLOW_MEMORY_GROWTH and
       (settings.MAXIMUM_MEMORY < 0 or
-       settings.MAXIMUM_MEMORY > 2 * 1024 * 1024 * 1024)):
+       settings.MAXIMUM_MEMORY > 2 * 1024 * 1024 * 1024))):
     settings.CAN_ADDRESS_2GB = 1
 
   settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
@@ -3466,6 +3466,7 @@ def phase_binaryen(target, options, wasm_target):
     # >=2GB heap support requires pointers in JS to be unsigned. rather than
     # require all pointers to be unsigned by default, which increases code size
     # a little, keep them signed, and just unsign them here if we need that.
+    # BELOW DOES NOT WORK IN COMBINATION WITH BigInt and wasm64 support
     if settings.CAN_ADDRESS_2GB:
       final_js = building.use_unsigned_pointers_in_js(final_js)
 

--- a/src/library.js
+++ b/src/library.js
@@ -162,7 +162,7 @@ mergeInto(LibraryManager.library, {
     // full 4GB Wasm memories, the size will wrap back to 0 bytes in Wasm side
     // for any code that deals with heap sizes, which would require special
     // casing all heap size related code to treat 0 specially.
-    return {{{ Math.min(MAXIMUM_MEMORY, FOUR_GB - WASM_PAGE_SIZE) }}};
+    return {{{ MAXIMUM_MEMORY }}};
 #else // no growth
     return HEAPU8.length;
 #endif
@@ -1270,7 +1270,7 @@ mergeInto(LibraryManager.library, {
   // These are in order to print helpful error messages when either longjmp of
   // setjmp is used.
   longjmp__deps: [function() {
-    error('longjmp support was disabled (SUPPORT_LONGJMP=0), but it is required by the code (either set SUPPORT_LONGJMP=1, or remove uses of it in the project)');
+    //error('longjmp support was disabled (SUPPORT_LONGJMP=0), but it is required by the code (either set SUPPORT_LONGJMP=1, or remove uses of it in the project)');
   }],
   get setjmp__deps() {
     return this.longjmp__deps;
@@ -3325,6 +3325,7 @@ mergeInto(LibraryManager.library, {
   $getWasmTableEntry__internal: true,
   $getWasmTableEntry__deps: ['$wasmTableMirror'],
   $getWasmTableEntry: function(funcPtr) {
+    funcPtr = Number(funcPtr);
     var func = wasmTableMirror[funcPtr];
     if (!func) {
       if (funcPtr >= wasmTableMirror.length) wasmTableMirror.length = funcPtr + 1;

--- a/src/library_egl.js
+++ b/src/library_egl.js
@@ -69,7 +69,7 @@ var LibraryEGL = {
           } else if (param == 0x3038 /*EGL_NONE*/) {
               break;
           }
-          attribList += 8;
+          attribList += 8n;
         }
       }
 
@@ -102,7 +102,7 @@ var LibraryEGL = {
     // Therefore, be lax and allow anything to be passed in, and return the magic handle to our default EGLDisplay object.
 
 //    if (nativeDisplayType == 0 /* EGL_DEFAULT_DISPLAY */) {
-        return 62000; // Magic ID for Emscripten 'default display'
+        return 62000n; // Magic ID for Emscripten 'default display'
 //    }
 //    else
 //      return 0; // EGL_NO_DISPLAY
@@ -292,7 +292,7 @@ var LibraryEGL = {
     // - EGL_VG_COLORSPACE (can't be set)
     // - EGL_VG_ALPHA_FORMAT (can't be set)
     EGL.setErrorCode(0x3000 /* EGL_SUCCESS */);
-    return 62006; /* Magic ID for Emscripten 'default surface' */
+    return 62006n; /* Magic ID for Emscripten 'default surface' */
   },
 
   // EGLAPI EGLBoolean EGLAPIENTRY eglDestroySurface(EGLDisplay display, EGLSurface surface);
@@ -342,7 +342,7 @@ var LibraryEGL = {
         EGL.setErrorCode(0x3004 /*EGL_BAD_ATTRIBUTE*/);
         return 0;
       }
-      contextAttribs += 8;
+      contextAttribs += 8n;
     }
 #if MAX_WEBGL_VERSION >= 2
     if (glesContextVersion < 2 || glesContextVersion > 3) {
@@ -375,7 +375,7 @@ var LibraryEGL = {
 
       // Note: This function only creates a context, but it shall not make it active.
       GL.makeContextCurrent(null);
-      return 62004; // Magic ID for Emscripten EGLContext
+      return 62004n; // Magic ID for Emscripten EGLContext
     } else {
       EGL.setErrorCode(0x3009 /* EGL_BAD_MATCH */); // By the EGL 1.4 spec, an implementation that does not support GLES2 (WebGL in this case), this error code is set.
       return 0; /* EGL_NO_CONTEXT */

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -527,7 +527,7 @@ var LibraryHTML5 = {
         JSEvents.queueEventHandlerOnThread_iiii(targetThread, callbackfunc, eventTypeId, mouseEventData, userData);
       } else
 #endif
-      if ({{{ makeDynCall('iiii', 'callbackfunc') }}}(eventTypeId, JSEvents.mouseEvent, userData)) e.preventDefault();
+      if ({{{ makeDynCall('iipp', 'callbackfunc') }}}(eventTypeId, JSEvents.mouseEvent, userData)) e.preventDefault();
     };
 
     var eventHandler = {

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -285,7 +285,7 @@ function getHeapOffset(offset, type) {
 
   const sz = Runtime.getNativeTypeSize(type);
   const shifts = Math.log(sz) / Math.LN2;
-  return `((${offset})>>${shifts})`;
+  return `Number((${offset})>>${shifts}n)`;
 }
 
 function ensureDot(value) {
@@ -596,8 +596,11 @@ function getFastValue(a, op, b, type) {
 
 function calcFastOffset(ptr, pos, noNeedFirst) {
   assert(!noNeedFirst);
-  if (typeof ptr == 'bigint') ptr = Number(ptr);
-  if (typeof pos == 'bigint') pos = Number(pos);
+  if (typeof ptr == 'number') ptr = 'BigInt('+ptr+')';
+  if (typeof pos == 'number') pos = 'BigInt('+pos+')';
+  if (typeof ptr == 'string') ptr = 'BigInt('+ptr+')';
+  if (typeof pos == 'string') pos = 'BigInt('+pos+')';
+
   return getFastValue(ptr, '+', pos, 'i32');
 }
 

--- a/src/runtime_strings.js
+++ b/src/runtime_strings.js
@@ -21,10 +21,11 @@ var UTF8Decoder = typeof TextDecoder != 'undefined' ? new TextDecoder('utf8') : 
  * @return {string}
  */
 function UTF8ArrayToString(heapOrArray, idx, maxBytesToRead) {
+  idx = Number(idx);
 #if CAN_ADDRESS_2GB
   idx >>>= 0;
 #endif
-  var endIdx = idx + maxBytesToRead;
+  var endIdx = idx + Number(maxBytesToRead);
 #if TEXTDECODER
   var endPtr = idx;
   // TextDecoder needs to know the byte length in advance, it doesn't stop on null terminator by itself.

--- a/system/lib/sbrk.c
+++ b/system/lib/sbrk.c
@@ -52,6 +52,7 @@ void *sbrk(intptr_t increment_) {
   // Enforce preserving a minimal 4-byte alignment for sbrk.
   uintptr_t increment = (uintptr_t)increment_;
   increment = (increment + 3) & ~3;
+  
 #if __EMSCRIPTEN_PTHREADS__
   // Our default dlmalloc uses locks around each malloc/free, so no additional
   // work is necessary to keep things threadsafe, but we also make sure sbrk
@@ -69,7 +70,7 @@ void *sbrk(intptr_t increment_) {
     uintptr_t new_brk = old_brk + increment;
     // Check for a 32-bit overflow, which would indicate that we are trying to
     // allocate over 4GB, which is never possible in wasm32.
-    if (increment > 0 && (uint32_t)new_brk <= (uint32_t)old_brk) {
+    if (increment > 0 && (uint64_t)new_brk <= (uint64_t)old_brk) {
       goto Error;
     }
     old_size = emscripten_get_heap_size();

--- a/test/common.py
+++ b/test/common.py
@@ -267,7 +267,7 @@ def also_with_wasm_bigint(f):
         self.skipTest('redundant in bigint test config')
       self.set_setting('WASM_BIGINT')
       self.require_node()
-      self.node_args.append('--experimental-wasm-bigint')
+      #self.node_args.append('--experimental-wasm-bigint')
       f(self)
     else:
       f(self)

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -300,8 +300,8 @@ def inspect_headers(headers, cflags):
   # Run the compiled program.
   show('Calling generated program... ' + js_file[1])
   args = []
-  if settings.MEMORY64:
-    args += ['--experimental-wasm-bigint']
+  #if settings.MEMORY64:
+  #  args += ['--experimental-wasm-bigint']
   info = shared.run_js_tool(js_file[1], node_args=args, stdout=shared.PIPE).splitlines()
 
   if not DEBUG:


### PR DESCRIPTION
These changes are in no way production ready (most if this is hacked together in order to get a prototype build working). They have allowed me to generate a wasm64 compile of an opengl based rendering engine. These changes also provide the capability to use more than 4GB of heap memory when using the OpenGL api.