### PR TITLE
Do not inject path manipulation utils when compiling to JS only

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -186,7 +186,7 @@ function logExceptionOnExit(e) {
 }
 #endif
 
-#if ENVIRONMENT_MAY_BE_NODE
+#if ENVIRONMENT_MAY_BE_NODE && WASM
 var fs;
 var nodePath;
 var requireNodeFS;
@@ -268,7 +268,7 @@ if (ENVIRONMENT_IS_NODE) {
 #endif
 
 } else
-#endif // ENVIRONMENT_MAY_BE_NODE
+#endif // ENVIRONMENT_MAY_BE_NODE && WASM
 #if ENVIRONMENT_MAY_BE_SHELL || ASSERTIONS
 if (ENVIRONMENT_IS_SHELL) {
 


### PR DESCRIPTION
This save a bunch of bytes from the dist file, and also avoid having bundlers freake out when they see Node.js specific code when they target browsers only.