### PR TITLE
[WasmFS] Add a way to opt out of using the dcache

### DIFF
--- a/system/lib/wasmfs/backends/memory_backend.cpp
+++ b/system/lib/wasmfs/backends/memory_backend.cpp
@@ -38,9 +38,17 @@ MemoryDirectory::findEntry(const std::string& name) {
   });
 }
 
+std::shared_ptr<File> MemoryDirectory::getChild(const std::string& name) {
+  if (auto entry = findEntry(name); entry != entries.end()) {
+    return entry->child;
+  }
+  return nullptr;
+}
+
 bool MemoryDirectory::removeChild(const std::string& name) {
   auto entry = findEntry(name);
   if (entry != entries.end()) {
+    entry->child->locked().setParent(nullptr);
     entries.erase(entry);
   }
   return true;
@@ -69,6 +77,17 @@ bool MemoryDirectory::insertMove(const std::string& name,
   removeChild(name);
   insertChild(name, file);
   return true;
+}
+
+std::string MemoryDirectory::getName(std::shared_ptr<File> file) {
+  auto it =
+    std::find_if(entries.begin(), entries.end(), [&](const auto& entry) {
+      return entry.child == file;
+    });
+  if (it != entries.end()) {
+    return it->name;
+  }
+  return "";
 }
 
 class MemoryFileBackend : public Backend {

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -43,7 +43,9 @@ void DataFile::Handle::preloadFromJS(int index) {
 void Directory::Handle::cacheChild(const std::string& name,
                                    std::shared_ptr<File> child,
                                    DCacheKind kind) {
-  // Update the dcache if the backend hasn't opted out of using the dcache.
+  // Update the dcache if the backend hasn't opted out of using the dcache or if
+  // this is a mount point, in which case it is not under the control of the
+  // backend.
   if (kind == DCacheKind::Mount || !getDir()->maintainsFileIdentity()) {
     auto& dcache = getDir()->dcache;
     auto [_, inserted] = dcache.insert({name, {kind, child}});

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -58,9 +58,7 @@ protected:
     entries.push_back({name, child});
   }
 
-  std::shared_ptr<File> getChild(const std::string& name) override {
-    return nullptr;
-  }
+  std::shared_ptr<File> getChild(const std::string& name) override;
 
   bool removeChild(const std::string& name) override;
 
@@ -89,6 +87,12 @@ protected:
 
   size_t getNumEntries() override { return entries.size(); }
   std::vector<Directory::Entry> getEntries() override;
+
+  std::string getName(std::shared_ptr<File> file) override;
+
+  // Since we internally track files with `File` objects, we don't need the
+  // dcache as well.
+  bool maintainsFileIdentity() override { return true; }
 
 public:
   MemoryDirectory(mode_t mode, backend_t backend) : Directory(mode, backend) {}

--- a/system/lib/wasmfs/support.h
+++ b/system/lib/wasmfs/support.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <stdnoreturn.h>
-
 #include <cstdlib>
 
 #ifndef NDEBUG

--- a/system/lib/wasmfs/support.h
+++ b/system/lib/wasmfs/support.h
@@ -12,7 +12,7 @@
 #ifndef NDEBUG
 // In debug builds show a message.
 namespace wasmfs {
-noreturn void
+[[noreturn]] void
 handle_unreachable(const char* msg, const char* file, unsigned line);
 }
 #define WASMFS_UNREACHABLE(msg)                                                \


### PR DESCRIPTION
Besides acting as a cache for relatively slow WasmFS backends, the dcache also
serves the critical purpose of ensuring that file identities are stable, i.e.
that each `File` object corresponds 1:1 to an underlying file. Maintaining this
property is critical because a large number of subtle bugs pop up without it.
For example, if a single file is represented by two `File` objects, then
removing it will only clear the parent pointer of one of the objects, leaving
the other in an inconsistent state.

However, sometimes the dcache can introduce more problems than it solves. For
example, in a hypothetical case-insensitive backend, the dcache would
incorrectly accumulate multiple entries with different capitalizations
corresponding to the same underlying file. In other cases, such as for the
in-memory backend, the dcache is superfluous because the backend already ensures
that files correspond 1:1 to `File` objects.

For these exceptional cases, provide a new virtual directory method,
`maintainsFileIdentity`, that allows backends to opt out of using the dcache and
handle all directory lookups themselves. Opting out comes with a few additional
responsibilities that are documented in file.h.