### PR TITLE
Add dynCall_sig adaptor for MAIN_MODULE == 2

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2392,7 +2392,7 @@ def phase_linker_setup(options, state, newargs, user_settings):
       settings.LINKABLE or
       settings.INCLUDE_FULL_LIBRARY or
       not settings.DISABLE_EXCEPTION_CATCHING or
-      (settings.MAIN_MODULE == 1 and (settings.DYNCALLS or not settings.WASM_BIGINT))
+      (settings.MAIN_MODULE and (settings.DYNCALLS or not settings.WASM_BIGINT))
   ):
       settings.REQUIRED_EXPORTS += ["getTempRet0", "setTempRet0"]
 

--- a/src/library.js
+++ b/src/library.js
@@ -3194,7 +3194,7 @@ mergeInto(LibraryManager.library, {
   },
 
 #if DYNCALLS || !WASM_BIGINT
-#if MAIN_MODULE == 1
+#if MAIN_MODULE
   $dynCallLegacy__deps: ['$createDyncallWrapper'],
 #endif
   $dynCallLegacy: function(sig, ptr, args) {
@@ -3202,8 +3202,6 @@ mergeInto(LibraryManager.library, {
 #if MINIMAL_RUNTIME
     assert(typeof dynCalls != 'undefined', 'Global dynCalls dictionary was not generated in the build! Pass -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$dynCall linker flag to include it!');
     assert(sig in dynCalls, 'bad function pointer type - sig is not in dynCalls: \'' + sig + '\'');
-#else
-    assert(('dynCall_' + sig) in Module, 'bad function pointer type - dynCall function not found for sig \'' + sig + '\'');
 #endif
     if (args && args.length) {
       // j (64-bit integer) must be passed in as two numbers [low 32, high 32].
@@ -3215,7 +3213,7 @@ mergeInto(LibraryManager.library, {
 #if MINIMAL_RUNTIME
     var f = dynCalls[sig];
 #else
-#if MAIN_MODULE == 1
+#if MAIN_MODULE
     if (!('dynCall_' + sig in Module)) {
       Module['dynCall_' + sig] = createDyncallWrapper(sig);
     }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12457,7 +12457,8 @@ Module['postRun'] = function() {{
   def test_dyncallwrapper(self):
     self.set_setting('MAIN_MODULE', 1)
     expected = "2 7\ni: 2 j: 8589934599 f: 3.120000 d: 77.120000"
-    self.do_runf(test_file('test_runtime_dyncall_wrapper.c'), expected)
+    self.do_runf(test_file('test_runtime_dyncall_wrapper.c'), expected, emcc_args=['-sMAIN_MODULE=1'])
+    self.do_runf(test_file('test_runtime_dyncall_wrapper.c'), expected, emcc_args=['-sMAIN_MODULE=2'])
 
   def test_compile_with_cache_lock(self):
     # Verify that, after warming the cache, running emcc does not require the cache lock.


### PR DESCRIPTION
Fixes #17707.

Follow up on PR #17328.

- Create the wasm adaptor also for MAIN_MODULE == 2
- Remove obsolete assert (triggers for all cases were we create the wrapper)