### PR TITLE
[WasmFS] Handle 404 error in fetch backend

### DIFF
--- a/src/library_wasmfs_fetch.js
+++ b/src/library_wasmfs_fetch.js
@@ -42,7 +42,7 @@ mergeInto(LibraryManager.library, {
         var buffer = await response['arrayBuffer']();
         wasmFS$JSMemoryFiles[file] = new Uint8Array(buffer);
       } else {
-        throw (response.status);
+        throw response;
       }
     }
 
@@ -73,15 +73,15 @@ mergeInto(LibraryManager.library, {
       read: async (file, buffer, length, offset) => {
         try {
           await getFile(file);
-        } catch (status) {
-          return status === 404 ? -{{{ cDefine('ENOENT') }}} : -{{{ cDefine('EBADF') }}};
+        } catch (response) {
+          return response.status === 404 ? -{{{ cDefine('ENOENT') }}} : -{{{ cDefine('EBADF') }}};
         }
         return jsFileOps.read(file, buffer, length, offset);
       },
       getSize: async (file) => {
         try {
           await getFile(file);
-        } catch (e) {}
+        } catch (response) {}
         return jsFileOps.getSize(file);
       },
     };

--- a/src/library_wasmfs_fetch.js
+++ b/src/library_wasmfs_fetch.js
@@ -38,13 +38,10 @@ mergeInto(LibraryManager.library, {
         }
       }
       var response = await fetch(url);
-      if (response.ok) 
-      {
+      if (response.ok) {
         var buffer = await response['arrayBuffer']();
         wasmFS$JSMemoryFiles[file] = new Uint8Array(buffer);
-      }
-      else 
-      {
+      } else {
         throw (response.status);
       }
     }
@@ -74,14 +71,18 @@ mergeInto(LibraryManager.library, {
 
       // read/getSize fetch the data, then forward to the parent class.
       read: async (file, buffer, length, offset) => {
-        return getFile(file)
-        .then(() => jsFileOps.read(file, buffer, length, offset))
-        .catch((status) => status === 404 ? -{{{ cDefine('ENOENT') }}} : -{{{ cDefine('EBADF') }}});
+        try {
+          await getFile(file);
+        } catch (status) {
+          return status === 404 ? -{{{ cDefine('ENOENT') }}} : -{{{ cDefine('EBADF') }}};
+        }
+        return jsFileOps.read(file, buffer, length, offset);
       },
-      getSize: async(file) => {
-        return getFile(file)
-        .then(() => jsFileOps.getSize(file))
-        .catch((status) => jsFileOps.getSize(file));
+      getSize: async (file) => {
+        try {
+          await getFile(file);
+        } catch (e) {}
+        return jsFileOps.getSize(file);
       },
     };
   },

--- a/test/wasmfs/wasmfs_fetch.c
+++ b/test/wasmfs/wasmfs_fetch.c
@@ -150,6 +150,34 @@ void test_small_reads() {
   assert(close(fd) == 0);
 }
 
+void test_nonexistent() {
+  printf("Running %s...\n", __FUNCTION__);
+
+  const char* dir_path = "/subdir";
+  char url[200];
+  snprintf(url, sizeof(url), "%s%s", url_orig, dir_path);
+
+  backend_t backend = wasmfs_get_backend_by_path(url);
+
+  const char* file_name = "/subdir/nonexistent.txt";
+  int fd = wasmfs_create_file(file_name, 0777, backend);
+
+  struct stat file;
+  assert(fstat(fd, &file) != -1);
+  printf("file size: %lld\n", file.st_size);
+  assert(file.st_size == 0);
+
+  errno = 0;
+  char buf[1];
+  int bytes_read = read(fd, buf, sizeof(buf));
+  printf("Bytes read: %d\n", bytes_read);
+  assert(bytes_read == -1);
+  printf("Errno: %s\n", strerror(errno));
+  assert(errno == ENOENT);
+
+  assert(close(fd) == 0);
+}
+
 int main() {
   getUrlOrigin(url_orig, sizeof(url_orig));
   test_default();
@@ -157,6 +185,7 @@ int main() {
   test_url_absolute();
   test_directory_abs();
   test_small_reads();
+  test_nonexistent();
 
   return 0;
 }


### PR DESCRIPTION
Fixes #17234.

- Added a check for successful fetch
- Return ENOENT in case of 404 error while reading
- Added a new test case