### PR TITLE
Fix src@dst bug in file_packager.py

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -474,8 +474,8 @@ def main():
   # even if we cd'd into a symbolic link.
   curr_abspath = os.path.abspath(os.getcwd())
 
-  if not file_.explicit_dst_path:
-    for file_ in data_files:
+  for file_ in data_files:
+    if not file_.explicit_dst_path:
       # This file was not defined with src@dst, so we inferred the destination
       # from the source. In that case, we require that the destination be
       # within the current working directory.


### PR DESCRIPTION
As mentioned is issue #17753, these two lines of code were swapped, which caused a bug that overwrote all the custom `src@dst` destinations when the last file to be passed as an argument did not have an explicit destination.