### PR TITLE
[WasmFS] Allow backends to report errors in `close`

### DIFF
--- a/src/library_wasmfs_node.js
+++ b/src/library_wasmfs_node.js
@@ -166,7 +166,12 @@ mergeInto(LibraryManager.library, {
 
   _wasmfs_node_close__deps: [],
   _wasmfs_node_close: function(fd) {
-    fs.closeSync(fd);
+    try {
+      fs.closeSync(fd);
+    } catch (e) {
+      if (!e.code) throw e;
+      return wasmfsNodeConvertNodeCode(e);
+    }
   },
 
   _wasmfs_node_read__deps: ['$wasmfsNodeConvertNodeCode'],

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -266,12 +266,13 @@ mergeInto(LibraryManager.library, {
 
   _wasmfs_opfs_close_access__deps: ['$wasmfsOPFSFree',
                                     '$wasmfsOPFSAccessHandles'],
-  _wasmfs_opfs_close_access: function(accessID) {
+  _wasmfs_opfs_close_access: async function(ctx, accessID) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
+    // Wait for the close to finish to ensure that subsequent opens succeed. The
+    // close cannot fail, so we don't need any kind of error handling.
+    await accessHandle.close();
     wasmfsOPFSFree(wasmfsOPFSAccessHandles, accessID);
-    // This is an async API, but we don't actually need to wait for it. It also
-    // cannot fail, so we don't need any kind of error handling.
-    accessHandle.close();
+    _emscripten_proxy_finish(ctx);
   },
 
   _wasmfs_opfs_close_blob__deps: ['$wasmfsOPFSFree',

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -266,11 +266,12 @@ mergeInto(LibraryManager.library, {
 
   _wasmfs_opfs_close_access__deps: ['$wasmfsOPFSFree',
                                     '$wasmfsOPFSAccessHandles'],
-  _wasmfs_opfs_close_access: async function(ctx, accessID) {
+  _wasmfs_opfs_close_access: function(accessID) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
-    await accessHandle.close();
     wasmfsOPFSFree(wasmfsOPFSAccessHandles, accessID);
-    _emscripten_proxy_finish(ctx);
+    // This is an async API, but we don't actually need to wait for it. It also
+    // cannot fail, so we don't need any kind of error handling.
+    accessHandle.close();
   },
 
   _wasmfs_opfs_close_blob__deps: ['$wasmfsOPFSFree',

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -58,7 +58,7 @@ void _wasmfs_opfs_open_access(em_proxying_ctx* ctx,
 
 void _wasmfs_opfs_open_blob(em_proxying_ctx* ctx, int file_id, int* blob_id);
 
-void _wasmfs_opfs_close_access(em_proxying_ctx* ctx, int access_id);
+void _wasmfs_opfs_close_access(int access_id);
 
 void _wasmfs_opfs_close_blob(int blob_id);
 
@@ -178,7 +178,7 @@ public:
     if (--openCount == 0) {
       switch (kind) {
         case Access:
-          proxy([&](auto ctx) { _wasmfs_opfs_close_access(ctx.ctx, id); });
+          proxy([&]() { _wasmfs_opfs_close_access(id); });
           break;
         case Blob:
           proxy([&]() { _wasmfs_opfs_close_blob(id); });
@@ -274,7 +274,10 @@ private:
 
   int open(oflags_t flags) override { return state.open(proxy, fileID, flags); }
 
-  void close() override { state.close(proxy); }
+  int close() override {
+    state.close(proxy);
+    return 0;
+  }
 
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
     uint32_t nread;

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -58,7 +58,7 @@ void _wasmfs_opfs_open_access(em_proxying_ctx* ctx,
 
 void _wasmfs_opfs_open_blob(em_proxying_ctx* ctx, int file_id, int* blob_id);
 
-void _wasmfs_opfs_close_access(int access_id);
+void _wasmfs_opfs_close_access(em_proxying_ctx* ctx, int access_id);
 
 void _wasmfs_opfs_close_blob(int blob_id);
 
@@ -178,7 +178,7 @@ public:
     if (--openCount == 0) {
       switch (kind) {
         case Access:
-          proxy([&]() { _wasmfs_opfs_close_access(id); });
+          proxy([&](auto ctx) { _wasmfs_opfs_close_access(ctx.ctx, id); });
           break;
         case Blob:
           proxy([&]() { _wasmfs_opfs_close_blob(id); });

--- a/system/lib/wasmfs/backends/proxied_file_backend.cpp
+++ b/system/lib/wasmfs/backends/proxied_file_backend.cpp
@@ -28,8 +28,10 @@ class ProxiedFile : public DataFile {
     return err;
   }
 
-  void close() override {
-    proxy([&]() { baseFile->locked().close(); });
+  int close() override {
+    int err = 0;
+    proxy([&]() { err = baseFile->locked().close(); });
+    return err;
   }
 
   // Read and write operations are forwarded via the proxying mechanism.

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -132,7 +132,7 @@ protected:
   // responsible for keeping files accessible as long as they are open, even if
   // they are unlinked. Returns 0 on success or a negative error code.
   virtual int open(oflags_t flags) = 0;
-  virtual void close() = 0;
+  virtual int close() = 0;
 
   // Return the accessed length or a negative error code. It is not an error to
   // access fewer bytes than requested. Will only be called on opened files.
@@ -314,7 +314,7 @@ public:
   Handle(Handle&&) = default;
 
   [[nodiscard]] int open(oflags_t flags) { return getFile()->open(flags); }
-  void close() { getFile()->close(); }
+  [[nodiscard]] int close() { return getFile()->close(); }
 
   ssize_t read(uint8_t* buf, size_t len, off_t offset) {
     return getFile()->read(buf, len, offset);

--- a/system/lib/wasmfs/js_impl_backend.h
+++ b/system/lib/wasmfs/js_impl_backend.h
@@ -82,7 +82,7 @@ class JSImplFile : public DataFile {
 
   // TODO: Notify the JS about open and close events?
   int open(oflags_t) override { return 0; }
-  void close() override {}
+  int close() override { return 0; }
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
     return _wasmfs_jsimpl_write(

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -20,7 +20,7 @@ class MemoryFile : public DataFile {
   std::vector<uint8_t> buffer;
 
   int open(oflags_t) override { return 0; }
-  void close() override {}
+  int close() override { return 0; }
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override;
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override;
   void flush() override {}

--- a/system/lib/wasmfs/pipe_backend.h
+++ b/system/lib/wasmfs/pipe_backend.h
@@ -24,7 +24,7 @@ class PipeFile : public DataFile {
   std::shared_ptr<PipeData> data;
 
   int open(oflags_t) override { return 0; }
-  void close() override {}
+  int close() override { return 0; }
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
     for (size_t i = 0; i < len; i++) {

--- a/system/lib/wasmfs/proxied_async_js_impl_backend.h
+++ b/system/lib/wasmfs/proxied_async_js_impl_backend.h
@@ -86,7 +86,7 @@ class ProxiedAsyncJSImplFile : public DataFile {
 
   // TODO: Notify the JS about open and close events?
   int open(oflags_t) override { return 0; }
-  void close() override {}
+  int close() override { return 0; }
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
     ssize_t result;

--- a/system/lib/wasmfs/special_files.cpp
+++ b/system/lib/wasmfs/special_files.cpp
@@ -20,7 +20,7 @@ namespace {
 // No-op reads and writes: /dev/null
 class NullFile : public DataFile {
   int open(oflags_t) override { return 0; }
-  void close() override {}
+  int close() override { return 0; }
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
     return len;
@@ -38,7 +38,7 @@ public:
 
 class StdinFile : public DataFile {
   int open(oflags_t) override { return 0; }
-  void close() override {}
+  int close() override { return 0; }
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
     return -__WASI_ERRNO_INVAL;
@@ -63,7 +63,7 @@ protected:
   std::vector<char> writeBuffer;
 
   int open(oflags_t) override { return 0; }
-  void close() override {}
+  int close() override { return 0; }
 
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
     return -__WASI_ERRNO_INVAL;
@@ -135,7 +135,7 @@ public:
 
 class RandomFile : public DataFile {
   int open(oflags_t) override { return 0; }
-  void close() override {}
+  int close() override { return 0; }
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
     return -__WASI_ERRNO_INVAL;

--- a/test/wasmfs/wasmfs_opfs.c
+++ b/test/wasmfs/wasmfs_opfs.c
@@ -157,13 +157,17 @@ int main(int argc, char* argv[]) {
   assert(strcmp(buf3, msg2) == 0);
   emscripten_console_logf("read message: %s (%d)", buf3, nread);
 
-  close(fd);
-  close(fd2);
+  err = close(fd);
+  assert(err == 0);
+
+  err = close(fd2);
+  assert(err == 0);
 
   fd = open("/opfs/working/foo.txt", O_RDONLY | O_TRUNC);
   assert(fd > 0);
   emscripten_console_log("truncated while opening read-only");
-  close(fd);
+  err = close(fd);
+  assert(err == 0);
 
   err = stat("/opfs/working/foo.txt", &stat_buf);
   assert(err == 0);
@@ -173,7 +177,8 @@ int main(int argc, char* argv[]) {
   fd = open("/opfs/working/foo.txt", O_WRONLY | O_TRUNC);
   assert(fd > 0);
   emscripten_console_log("truncated while opening write-only");
-  close(fd);
+  err = close(fd);
+  assert(err == 0);
 
   err = stat("/opfs/working/foo.txt", &stat_buf);
   assert(err == 0);

--- a/test/wasmfs/wasmfs_opfs_errors.c
+++ b/test/wasmfs/wasmfs_opfs_errors.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <emscripten/emscripten.h>
 #include <emscripten/wasmfs.h>
 #include <emscripten/console.h>

--- a/test/wasmfs/wasmfs_opfs_errors.c
+++ b/test/wasmfs/wasmfs_opfs_errors.c
@@ -23,7 +23,8 @@ const char* file = "/opfs/data";
 static int try_open(int flags) {
   int fd = open(file, flags);
   if (fd >= 0) {
-    close(fd);
+    int err = close(fd);
+    assert(err == 0);
     return 1;
   }
   if (errno == EACCES) {

--- a/test/wasmfs/wasmfs_opfs_errors.c
+++ b/test/wasmfs/wasmfs_opfs_errors.c
@@ -1,12 +1,12 @@
 #include <assert.h>
+#include <emscripten/console.h>
 #include <emscripten/emscripten.h>
 #include <emscripten/wasmfs.h>
-#include <emscripten/console.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <stdlib.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 int main() {
   wasmfs_create_directory("/opfs", 0777, wasmfs_create_opfs_backend());


### PR DESCRIPTION
This is hard to test because we don't have a way of deterministically making a
close fail in any of our existing backends, although in principle failure can
happen in the node backend. I manually tested that this worked correctly by
synthetically injecting an error on close into the OPFS backend and checking
that it did not cause the program to crash or hang and that errno was correctly
set afterward.

However, the close method on SyncAccessHandle is infallible, so we don't
actually need any error handling. As an additional change, simplify
`wasmfs_opfs_close_access` to not wait for the file to be asynchronously closed.