### PR TITLE
embuilder: Move settings and defaults into ports

### DIFF
--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -23,13 +23,16 @@ ports_by_name = {}
 # {variant_name: (port_name, extra_settings)}
 port_variants = {}
 
+# {setting name: default}
+port_settings = {}
+
 ports_dir = os.path.dirname(os.path.abspath(__file__))
 
 logger = logging.getLogger('ports')
 
 
 def read_ports():
-  expected_attrs = ['get', 'clear', 'process_args', 'show', 'needed']
+  expected_attrs = ['get', 'clear', 'process_args', 'show', 'needed', 'settings']
   for filename in os.listdir(ports_dir):
     if not filename.endswith('.py') or filename == '__init__.py':
       continue
@@ -55,9 +58,16 @@ def read_ports():
         utils.exit_with_error('duplicate port variant: %s' % variant)
       port_variants[variant] = (port.name, extra_settings)
 
+    for key, default in port.settings.items():
+      if key in port_settings:
+        utils.exit_with_error('duplicate setting: %s' % key)
+      port_settings[key] = default
+
   for dep in port.deps:
     if dep not in ports_by_name:
       utils.exit_with_error('unknown dependency in port: %s' % dep)
+
+  settings.update_port_settings(port_settings)
 
 
 def get_all_files_under(dirname):

--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -9,6 +9,8 @@ import os
 TAG = '1.75.0'
 HASH = '8c38be1ebef1b8ada358ad6b7c9ec17f5e0a300e8085db3473a13e19712c95eeb3c3defacd3c53482eb96368987c4b022efa8da2aac2431a154e40153d3c3dcd'
 
+settings = {'USE_BOOST_HEADERS': False}
+
 
 def needed(settings):
   return settings.USE_BOOST_HEADERS == 1

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -10,6 +10,8 @@ import shutil
 TAG = 'version_1'
 HASH = '3922486816cf7d99ee02c3c1ef63d94290e8ed304016dd9927137d04206e7674d9df8773a4abb7bb57783d0a5107ad0f893aa87acfb34f7b316eec22ca55a536'
 
+settings = {'USE_BULLET': False}
+
 
 def needed(settings):
   return settings.USE_BULLET == 1

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -9,6 +9,8 @@ import shutil
 VERSION = '1.0.6'
 HASH = '512cbfde5144067f677496452f3335e9368fd5d7564899cb49e77847b9ae7dca598218276637cbf5ec524523be1e8ace4ad36a148ef7f4badf3f6d5a002a4bb2'
 
+settings = {'USE_BZIP2': False}
+
 
 def needed(settings):
   return settings.USE_BZIP2

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -12,6 +12,10 @@ TAG = 'version_3_3'
 HASH = 'd7b22660036c684f09754fcbbc7562984f02aa955eef2b76555270c63a717e6672c4fe695afb16280822e8b7c75d4b99ae21975a01a4ed51cad957f7783722cd'
 
 deps = ['libpng', 'zlib']
+settings = {
+  # 3 = use cocos2d v3 from emscripten-ports
+  'USE_COCOS2D': 0,
+}
 
 
 def needed(settings):

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -10,6 +10,8 @@ from pathlib import Path
 TAG = 'version_1'
 HASH = '0d0b1280ba0501ad0a23cf1daa1f86821c722218b59432734d3087a89acd22aabd5c3e5e1269700dcd41e87073046e906060f167c032eb91a3ac8c5808a02783'
 
+settings = {'USE_FREETYPE': False}
+
 
 def needed(settings):
   return settings.USE_FREETYPE

--- a/tools/ports/giflib.py
+++ b/tools/ports/giflib.py
@@ -10,6 +10,8 @@ import logging
 VERSION = '5.2.1'
 HASH = '4550e53c21cb1191a4581e363fc9d0610da53f7898ca8320f0d3ef6711e76bdda2609c2df15dc94c45e28bff8de441f1227ec2da7ea827cb3c0405af4faa4736'
 
+settings = {'USE_GIFLIB': False}
+
 
 def needed(settings):
   return settings.USE_GIFLIB

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -10,6 +10,7 @@ VERSION = '3.2.0'
 HASH = '2e5ab5ad83a0d8801abd3f82a276f776a0ad330edc0ab843f879dd7ad3fd2e0dc0e9a3efbb6c5f2e67d14c0e37f0d9abdb40c5e25d8231a357c0025669f219c3'
 
 deps = ['freetype']
+settings = {'USE_HARFBUZZ': False}
 variants = {'harfbuzz-mt': {'USE_PTHREADS': 1}}
 
 srcs = '''

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -11,6 +11,7 @@ TAG = 'release-68-2'
 VERSION = '68_2'
 HASH = '12c3db5966c234c94e7918fb8acc8bd0838edc36a620f3faa788e7ff27b06f1aa431eb117401026e3963622b9323212f444b735d5c9dd3d0b82d772a4834b993'
 
+settings = {'USE_ICU': False}
 variants = {'icu-mt': {'USE_PTHREADS': 1}}
 
 libname_libicu_common = 'libicu_common'

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -11,6 +11,8 @@ from pathlib import Path
 VERSION = '9c'
 HASH = 'b2affe9a1688bd49fc033f4682c4a242d4ee612f1affaef532f5adcb4602efc4433c4a52a4b3d69e7440ff1f6413b1b041b419bc90efd6d697999961a9a6afb7'
 
+settings = {'USE_LIBJPEG': False}
+
 
 def needed(settings):
   return settings.USE_LIBJPEG

--- a/tools/ports/libmodplug.py
+++ b/tools/ports/libmodplug.py
@@ -10,6 +10,8 @@ from pathlib import Path
 TAG = '11022021'
 HASH = 'f770031ad6c2152cbed8c8eab8edf2be1d27f9e74bc255a9930c17019944ee5fdda5308ea992c66a78af9fe1d8dca090f6c956910ce323f8728247c10e44036b'
 
+settings = {'USE_MODPLUG': False}
+
 
 def needed(settings):
   return settings.USE_MODPLUG

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -12,6 +12,7 @@ TAG = '1.6.37'
 HASH = '2ce2b855af307ca92a6e053f521f5d262c36eb836b4810cb53c809aa3ea2dcc08f834aee0ffd66137768a54397e28e92804534a74abb6fc9f6f3127f14c9c338'
 
 deps = ['zlib']
+settings = {'USE_LIBPNG': False}
 variants = {'libpng-mt': {'USE_PTHREADS': 1}}
 
 

--- a/tools/ports/mpg123.py
+++ b/tools/ports/mpg123.py
@@ -11,6 +11,8 @@ from pathlib import Path
 TAG = '1.26.2'
 HASH = 'aa63fcb08b243a1e09f7701b3d84a19d7412a87253d54d49f014fdb9e75bbc81d152a41ed750fccde901453929b2a001585a7645351b41845ad205c17a73dcc9'
 
+settings = {'USE_MPG123': False}
+
 
 def needed(settings):
   return settings.USE_MPG123

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -11,6 +11,8 @@ from pathlib import Path
 TAG = 'version_1'
 HASH = '929e8d6003c06ae09593021b83323c8f1f54532b67b8ba189f4aedce52c25dc182bac474de5392c46ad5b0dea5a24928e4ede1492d52f4dd5cd58eea9be4dba7'
 
+settings = {'USE_OGG': False}
+
 
 def needed(settings):
   return settings.USE_OGG

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -10,6 +10,7 @@ import shutil
 TAG = 'version_7'
 HASH = 'a921dab254f21cf5d397581c5efe58faf147c31527228b4fb34aed75164c736af4b3347092a8d9ec1249160230fa163309a87a20c2b9ceef8554566cc215de9d'
 
+settings = {'USE_REGAL': False}
 variants = {'regal-mt': {'USE_PTHREADS': 1}}
 
 

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -9,6 +9,14 @@ TAG = 'release-2.24.0'
 HASH = '33ea357de1c137b4ce101349b119105d090ef2e05224fd3f05074b65579e53b068fa94aba6a37ac44c21f246e14ed15f0045dcdd1ddf7357a35aa7e8f2db2d3b'
 SUBDIR = 'SDL-' + TAG
 
+settings = {
+  # Specify the SDL version that is being linked against.
+  # 1, the default, is 1.3, which is implemented in JS
+  # 2 is a port of the SDL C code on emscripten-ports
+  # When AUTO_JS_LIBRARIES is set to 0 this defaults to 0 and SDL
+  # is not linked in.
+  'USE_SDL': 1
+}
 variants = {'sdl2-mt': {'USE_PTHREADS': 1}}
 
 

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -12,6 +12,12 @@ HASH = 'f39f1f50a039a1667fe92b87d28548d32adcf0eb8526008656de5315039aa21f29d23070
 
 deps = ['sdl2']
 
+settings = {
+  # Specify the SDL_gfx version that is being linked against.
+  # Must match USE_SDL
+  'USE_SDL_GFX': False,
+}
+
 
 def needed(settings):
   return settings.USE_SDL_GFX == 2

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -9,6 +9,14 @@ TAG = 'version_4'
 HASH = '30a7b04652239bccff3cb1fa7cd8ae602791b5f502a96df39585c13ebc4bb2b64ba1598c0d1f5382028d94e04a5ca02185ea06bf7f4b3520f6df4cc253f9dd24'
 
 deps = ['sdl2']
+settings = {
+  # Specify the SDL_image version that is being linked against.
+  # Must match USE_SDL
+  'USE_SDL_IMAGE': 1,
+  # Formats to support in SDL2_image.
+  # Valid values: bmp, gif, lbm, pcx, png, pnm, tga, xcf, xpm, xv
+  'SDL2_IMAGE_FORMATS': [],
+}
 variants = {
   'sdl2_image_jpg':  {'SDL2_IMAGE_FORMATS': ["jpg"]},
   'sdl2_image_png': {'SDL2_IMAGE_FORMATS': ["png"]},

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -11,6 +11,13 @@ TAG = 'release-2.0.4'
 HASH = '5ba387f997219a1deda868f380bf7ee8bc0842261dd54772ad2d560f5282fcbe7bc130e8d16dccc259eeb8cda993a0f34cd3be103fc38f8c6a68428a10e5db4c'
 
 deps = ['sdl2']
+settings = {
+  # Specify the SDL_mixer version that is being linked against.
+  # Doesn't *have* to match USE_SDL, but a good idea.
+  'USE_SDL_MIXER': 1,
+  # Formats to support in SDL2_mixer. Valid values: ogg, mp3, mod, mid
+  'SDL2_MIXER_FORMATS': ['ogg'],
+}
 variants = {
   'sdl2_mixer_mp3': {'SDL2_MIXER_FORMATS': ["mp3"]},
   'sdl2_mixer_none': {'SDL2_MIXER_FORMATS': []},

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -10,6 +10,11 @@ TAG = 'version_2'
 HASH = '317b22ad9b6b2f7b40fac7b7c426da2fa2da1803bbe58d480631f1e5b190d730763f2768c77c72affa806c69a1e703f401b15a1be3ec611cd259950d5ebc3711'
 
 deps = ['sdl2']
+settings = {
+  # Specify the SDL_ttf version that is being linked against.
+  # Must match USE_SDL
+  'USE_SDL_NET': 1,
+}
 
 
 def needed(settings):

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -9,6 +9,7 @@ TAG = '38fcb695276ed794f879d5d9c5ef4e5286a5200d' # Latest as of 24 November 2020
 HASH = '4c1ac5d27439d28c6d84593dd15dd80c825d68c6bf1020ab4317f2bce1efe16401b5b3280a181047c8317c38a19bbeeae8d52862e6b2c9776d5809758ee7aaa6'
 
 deps = ['freetype', 'sdl2', 'harfbuzz']
+settings = {'USE_SDL_TTF': 1}
 
 
 def needed(settings):

--- a/tools/ports/sqlite3.py
+++ b/tools/ports/sqlite3.py
@@ -14,6 +14,7 @@ VERSION_YEAR = 2022
 HASH = 'cbaf4adb3e404d9aa403b34f133c5beca5f641ae1e23f84dbb021da1fb9efdc7c56b5922eb533ae5cb6d26410ac60cb3f026085591bc83ebc1c225aed0cf37ca'
 
 deps = []
+settings = {'USE_SQLITE3': False}
 variants = {'sqlite3-mt': {'USE_PTHREADS': 1}}
 
 

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -11,6 +11,7 @@ TAG = 'version_1'
 HASH = '99bee75beb662f8520bbb18ad6dbf8590d30eb3a7360899f0ac4764ca72fe8013da37c9df21e525f9d2dc5632827d4b4cea558cbc938e7fbed0c41a29a7a2dc5'
 
 deps = ['ogg']
+settings = {'USE_VORBIS': False}
 
 
 def needed(settings):

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -10,6 +10,8 @@ from pathlib import Path
 VERSION = '1.2.12'
 HASH = 'cc2366fa45d5dfee1f983c8c51515e0cff959b61471e2e8d24350dea22d3f6fcc50723615a911b046ffc95f51ba337d39ae402131a55e6d1541d3b095d6c0a14'
 
+settings = {'USE_ZLIB': False}
+
 
 def needed(settings):
   return settings.USE_ZLIB

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -21,34 +21,7 @@ MEM_SIZE_SETTINGS = {
     'DEFAULT_PTHREAD_STACK_SIZE'
 }
 
-PORTS_SETTINGS = {
-    # All port-related settings are valid at compile time
-    'USE_SDL',
-    'USE_LIBPNG',
-    'USE_BULLET',
-    'USE_ZLIB',
-    'USE_BZIP2',
-    'USE_VORBIS',
-    'USE_COCOS2D',
-    'USE_ICU',
-    'USE_MODPLUG',
-    'USE_SDL_MIXER',
-    'USE_SDL_IMAGE',
-    'USE_SDL_TTF',
-    'USE_SDL_NET',
-    'USE_SDL_GFX',
-    'USE_LIBJPEG',
-    'USE_OGG',
-    'USE_REGAL',
-    'USE_BOOST_HEADERS',
-    'USE_HARFBUZZ',
-    'USE_MPG123',
-    'USE_GIFLIB',
-    'USE_FREETYPE',
-    'SDL2_MIXER_FORMATS',
-    'SDL2_IMAGE_FORMATS',
-    'USE_SQLITE3',
-}
+# PORTS_SETTINGS are now provided by each individual port.
 
 # Subset of settings that apply at compile time.
 # (Keep in sync with [compile] comments in settings.js)
@@ -81,7 +54,7 @@ COMPILE_TIME_SETTINGS = {
     # TODO: should not be here
     'AUTO_ARCHIVE_INDEXES',
     'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE',
-}.union(PORTS_SETTINGS)
+}
 
 
 class SettingsManager:
@@ -155,6 +128,16 @@ class SettingsManager:
     self.allowed_settings.clear()
     if allowed:
       self.allowed_settings.update(allowed)
+
+  def update_port_settings(self, port_setting):
+    for key, value in port_setting.items():
+      default = self.attrs.setdefault(key, value)
+      if value != default:
+        raise ValueError(
+          f"port setting {key!r}: '{value!r}' != default '{default!r}'."
+        )
+    # All port-related settings are valid at compile time
+    COMPILE_TIME_SETTINGS.update(set(port_setting))
 
   def __getattr__(self, attr):
     if self.allowed_settings:


### PR DESCRIPTION
Port settings and default values for port settings are now provided by
port modules. Port modules can register new settings without adding them
to `settings.js`.

See: #17729