### PR TITLE
[WasmFS] Allow backends to report errors on `setSize`

### DIFF
--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -343,9 +343,13 @@ mergeInto(LibraryManager.library, {
   },
 
   _wasmfs_opfs_set_size_access__deps: ['$wasmfsOPFSAccessHandles'],
-  _wasmfs_opfs_set_size_access: async function(ctx, accessID, size) {
+  _wasmfs_opfs_set_size_access: async function(ctx, accessID, size, errPtr) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
-    await accessHandle.truncate(size);
+    try {
+      await accessHandle.truncate(size);
+    } catch {
+      {{{ makeSetValue('errPtr', 0, '1', 'i32') }}};
+    }
     _emscripten_proxy_finish(ctx);
   },
 
@@ -356,7 +360,6 @@ mergeInto(LibraryManager.library, {
       let writable = await fileHandle.createWritable({keepExistingData: true});
       await writable.truncate(size);
       await writable.close();
-      {{{ makeSetValue('errPtr', 0, '0', 'i32') }}};
     } catch {
       {{{ makeSetValue('errPtr', 0, '1', 'i32') }}};
     }

--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -154,7 +154,7 @@ private:
     return size_t(size);
   }
 
-  void setSize(size_t size) override {
+  int setSize(size_t size) override {
     WASMFS_UNREACHABLE("TODO: implement NodeFile::setSize");
   }
 

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -258,8 +258,8 @@ private:
         // We don't support `truncate` in blob mode because the blob would
         // become invalidated and refreshing it while ensuring other in-flight
         // operations on the same file do not observe the invalidated blob would
-        // be extermely complicated.
-        WASMFS_UNREACHABLE("TODO: proper setSize error handling");
+        // be extremely complicated.
+        return -EIO;
       case OpenState::None: {
         proxy([&](auto ctx) {
           _wasmfs_opfs_set_size_file(ctx.ctx, fileID, size, &err);

--- a/system/lib/wasmfs/backends/proxied_file_backend.cpp
+++ b/system/lib/wasmfs/backends/proxied_file_backend.cpp
@@ -57,7 +57,7 @@ class ProxiedFile : public DataFile {
     return result;
   }
 
-  void setSize(size_t size) override {
+  int setSize(size_t size) override {
     WASMFS_UNREACHABLE("TODO: ProxiedFS setSize");
   }
 

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -143,8 +143,8 @@ protected:
 
   // Sets the size of the file to a specific size. If new space is allocated, it
   // should be zero-initialized. May be called on files that have not been
-  // opened.
-  virtual void setSize(size_t size) = 0;
+  // opened. Returns 0 on success or a negative error code.
+  virtual int setSize(size_t size) = 0;
 
   // TODO: Design a proper API for flushing files.
   virtual void flush() = 0;
@@ -323,7 +323,7 @@ public:
     return getFile()->write(buf, len, offset);
   }
 
-  void setSize(size_t size) { return getFile()->setSize(size); }
+  [[nodiscard]] int setSize(size_t size) { return getFile()->setSize(size); }
 
   // TODO: Design a proper API for flushing files.
   void flush() { getFile()->flush(); }

--- a/system/lib/wasmfs/js_impl_backend.h
+++ b/system/lib/wasmfs/js_impl_backend.h
@@ -100,7 +100,7 @@ class JSImplFile : public DataFile {
     return _wasmfs_jsimpl_get_size(getBackendIndex(), getFileIndex());
   }
 
-  void setSize(size_t size) override {
+  int setSize(size_t size) override {
     WASMFS_UNREACHABLE("TODO: JSImpl setSize");
   }
 

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -25,7 +25,10 @@ class MemoryFile : public DataFile {
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override;
   void flush() override {}
   size_t getSize() override { return buffer.size(); }
-  void setSize(size_t size) override { return buffer.resize(size); }
+  int setSize(size_t size) override {
+    buffer.resize(size);
+    return 0;
+  }
 
 public:
   MemoryFile(mode_t mode, backend_t backend) : DataFile(mode, backend) {}

--- a/system/lib/wasmfs/pipe_backend.h
+++ b/system/lib/wasmfs/pipe_backend.h
@@ -48,9 +48,8 @@ class PipeFile : public DataFile {
 
   size_t getSize() override { return data->size(); }
 
-  void setSize(size_t size) override {
-    // no-op
-  }
+  // TODO: Should this return an error?
+  int setSize(size_t size) override { return 0; }
 
 public:
   // PipeFiles do not have or need a backend. Pass NullBackend to the parent for

--- a/system/lib/wasmfs/proxied_async_js_impl_backend.h
+++ b/system/lib/wasmfs/proxied_async_js_impl_backend.h
@@ -117,7 +117,7 @@ class ProxiedAsyncJSImplFile : public DataFile {
     return result;
   }
 
-  void setSize(size_t size) override {
+  int setSize(size_t size) override {
     WASMFS_UNREACHABLE("TODO: ProxiedAsyncJSImplFile setSize");
   }
 

--- a/system/lib/wasmfs/special_files.cpp
+++ b/system/lib/wasmfs/special_files.cpp
@@ -30,7 +30,7 @@ class NullFile : public DataFile {
 
   void flush() override {}
   size_t getSize() override { return 0; }
-  void setSize(size_t size) override {}
+  int setSize(size_t size) override { return -EPERM; }
 
 public:
   NullFile() : DataFile(S_IRUGO | S_IWUGO, NullBackend, S_IFCHR) {}
@@ -51,7 +51,7 @@ class StdinFile : public DataFile {
 
   void flush() override {}
   size_t getSize() override { return 0; }
-  void setSize(size_t size) override {}
+  int setSize(size_t size) override { return -EPERM; }
 
 public:
   StdinFile() : DataFile(S_IRUGO, NullBackend, S_IFCHR) { seekable = false; }
@@ -78,7 +78,7 @@ protected:
   }
 
   size_t getSize() override { return 0; }
-  void setSize(size_t size) override {}
+  int setSize(size_t size) override { return -EPERM; }
 
   ssize_t writeToJS(const uint8_t* buf,
                     size_t len,
@@ -152,7 +152,7 @@ class RandomFile : public DataFile {
 
   void flush() override {}
   size_t getSize() override { return 0; }
-  void setSize(size_t size) override {}
+  int setSize(size_t size) override { return -EPERM; }
 
 public:
   RandomFile() : DataFile(S_IRUGO, NullBackend, S_IFCHR) { seekable = false; }

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -502,22 +502,14 @@ static __wasi_fd_t doOpen(path::ParsedParent parsed,
 
   // If O_TRUNC, truncate the file if possible.
   if (flags & O_TRUNC) {
-    if (child->is<DataFile>()) {
-      if (fileMode & WASMFS_PERM_WRITE) {
-        // TODO: Linux still truncates the file when it's opened only for
-        // reading, so we should too. But until we get proper error reporting
-        // from setSize (which we can then ignore here), the OPFS backend will
-        // crash in this case because it does not support truncating files open
-        // only for reading.
-        if (accessMode != O_RDONLY) {
-          child->cast<DataFile>()->locked().setSize(0);
-        }
-      } else {
-        return -EACCES;
-      }
-    } else {
+    if (!child->is<DataFile>()) {
       return -EISDIR;
     }
+    if ((fileMode & WASMFS_PERM_WRITE) == 0) {
+      return -EACCES;
+    }
+    // Try to truncate the file, continuing silently if we cannot.
+    (void)child->cast<DataFile>()->locked().setSize(0);
   }
 
   return wasmFS.getFileTable().locked().addEntry(openFile);
@@ -1171,9 +1163,9 @@ int __syscall_faccessat(int dirfd, intptr_t path, int amode, int flags) {
 
 static int doTruncate(std::shared_ptr<File>& file, off_t size) {
   auto dataFile = file->dynCast<DataFile>();
-  // TODO: support for symlinks.
+
   if (!dataFile) {
-    return __WASI_ERRNO_ISDIR;
+    return -EISDIR;
   }
 
   auto locked = dataFile->locked();
@@ -1185,11 +1177,7 @@ static int doTruncate(std::shared_ptr<File>& file, off_t size) {
     return -EINVAL;
   }
 
-  // TODO: error handling for allocation errors. atm with exceptions disabled,
-  //       however, C++ backends using std::vector for storage have no way to
-  //       report that, and will abort in malloc.
-  locked.setSize(size);
-  return 0;
+  return locked.setSize(size);
 }
 
 int __syscall_truncate64(intptr_t path, uint64_t size) {
@@ -1348,14 +1336,14 @@ int __syscall_fallocate(int fd, int mode, uint64_t off, uint64_t len) {
     return -EINVAL;
   }
 
-  // TODO: We silently do nothing if the stream does not support allocation, but
-  //       in principle we should return EOPNOTSUPP.
   // TODO: We could only fill zeros for regions that were completely unused
   //       before, which for a backend with sparse data storage could make a
   //       difference. For that we'd need a new backend API.
   auto newNeededSize = off + len;
   if (newNeededSize > locked.getSize()) {
-    locked.setSize(newNeededSize);
+    if (auto err = locked.setSize(newNeededSize)) {
+      return err;
+    }
   }
 
   return 0;

--- a/test/wasmfs/wasmfs_opfs_errors.c
+++ b/test/wasmfs/wasmfs_opfs_errors.c
@@ -52,6 +52,20 @@ int try_open_rdonly(void) {
 }
 
 EMSCRIPTEN_KEEPALIVE
+int try_truncate(void) {
+  emscripten_console_log("in try_truncate");
+  int err = truncate(file, 42);
+  if (err == 0) {
+    return 1;
+  }
+  if (errno == EIO) {
+    return 0;
+  }
+  emscripten_console_error(strerror(errno));
+  return 2;
+}
+
+EMSCRIPTEN_KEEPALIVE
 void report_result(int result) {
   EM_ASM({ console.log(new Error().stack); });
 #ifdef REPORT_RESULT

--- a/test/wasmfs/wasmfs_opfs_errors.c
+++ b/test/wasmfs/wasmfs_opfs_errors.c
@@ -53,7 +53,6 @@ int try_open_rdonly(void) {
 
 EMSCRIPTEN_KEEPALIVE
 int try_truncate(void) {
-  emscripten_console_log("in try_truncate");
   int err = truncate(file, 42);
   if (err == 0) {
     return 1;

--- a/test/wasmfs/wasmfs_opfs_errors_post.js
+++ b/test/wasmfs/wasmfs_opfs_errors_post.js
@@ -24,6 +24,10 @@ async function run_test() {
     throw "Unexpected failure opening file for reading only";
   }
 
+  if (Module._try_truncate() != 0) {
+    throw "Did not get expected EIO when resizing file";
+  }
+
   await access.close();
 
   // We can open the file in any mode now that there is no open access

--- a/test/wasmfs/wasmfs_opfs_errors_post.js
+++ b/test/wasmfs/wasmfs_opfs_errors_post.js
@@ -45,5 +45,9 @@ async function run_test() {
     throw "Unexpected failure opening file for reading";
   }
 
+  if (Module._try_truncate() != 1) {
+    throw "Unexpected failure when resizing file";
+  }
+
   Module._report_result(0);
 }


### PR DESCRIPTION
Add a test that exercises the `set_size_file` path in the OPFS backend since it
should not be possible to get an error on the `set_size_access`
codepath. (Although I wouldn't be surprised if it is possible in a way I haven't
thought of.) Also, as a drive-by, fix an error code in `doTruncate` to be
properly negative.