### PR TITLE
[WasmFS] Report an optional error from insertDataFile

### DIFF
--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -175,7 +175,7 @@ mergeInto(LibraryManager.library, {
       let childID = await wasmfsOPFSGetOrCreateFile(parent, name, true);
     } catch(e) {
       _emscripten_proxy_finish(ctx);
-      // TODO: Return a specific error code depending on the error. 
+      // TODO: Return a specific error code depending on the error.
       return 1;
     }
     {{{ makeSetValue('childIDPtr', 0, 'childID', 'i32') }}};

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -171,9 +171,16 @@ mergeInto(LibraryManager.library, {
   _wasmfs_opfs_insert_file__deps: ['$wasmfsOPFSGetOrCreateFile'],
   _wasmfs_opfs_insert_file: async function(ctx, parent, namePtr, childIDPtr) {
     let name = UTF8ToString(namePtr);
-    let childID = await wasmfsOPFSGetOrCreateFile(parent, name, true);
+    try {
+      let childID = await wasmfsOPFSGetOrCreateFile(parent, name, true);
+    } catch(e) {
+      _emscripten_proxy_finish(ctx);
+      // TODO: Return a specific error code depending on the error. 
+      return 1;
+    }
     {{{ makeSetValue('childIDPtr', 0, 'childID', 'i32') }}};
     _emscripten_proxy_finish(ctx);
+    return 0;
   },
 
   _wasmfs_opfs_insert_directory__deps: ['$wasmfsOPFSGetOrCreateDir'],

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -169,7 +169,7 @@ mergeInto(LibraryManager.library, {
   },
 
   _wasmfs_opfs_insert_file__deps: ['$wasmfsOPFSGetOrCreateFile'],
-  _wasmfs_opfs_insert_file: async function(ctx, parent, namePtr, childIDPtr) {
+  _wasmfs_opfs_insert_file: async function(ctx, parent, namePtr, childIDPtr, errPtr) {
     let name = UTF8ToString(namePtr);
     let childID;
     try {
@@ -177,11 +177,11 @@ mergeInto(LibraryManager.library, {
     } catch(e) {
       _emscripten_proxy_finish(ctx);
       // TODO: Return a specific error code depending on the error.
-      return 1;
+      {{{ makeSetValue('errPtr', 0, '1', 'i32') }}};
+      return;
     }
     {{{ makeSetValue('childIDPtr', 0, 'childID', 'i32') }}};
     _emscripten_proxy_finish(ctx);
-    return 0;
   },
 
   _wasmfs_opfs_insert_directory__deps: ['$wasmfsOPFSGetOrCreateDir'],

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -171,8 +171,9 @@ mergeInto(LibraryManager.library, {
   _wasmfs_opfs_insert_file__deps: ['$wasmfsOPFSGetOrCreateFile'],
   _wasmfs_opfs_insert_file: async function(ctx, parent, namePtr, childIDPtr) {
     let name = UTF8ToString(namePtr);
+    let childID;
     try {
-      let childID = await wasmfsOPFSGetOrCreateFile(parent, name, true);
+      childID = await wasmfsOPFSGetOrCreateFile(parent, name, true);
     } catch(e) {
       _emscripten_proxy_finish(ctx);
       // TODO: Return a specific error code depending on the error.

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -175,9 +175,9 @@ mergeInto(LibraryManager.library, {
     try {
       childID = await wasmfsOPFSGetOrCreateFile(parent, name, true);
     } catch(e) {
-      _emscripten_proxy_finish(ctx);
       // TODO: Return a specific error code depending on the error.
       {{{ makeSetValue('errPtr', 0, '1', 'i32') }}};
+      _emscripten_proxy_finish(ctx);
       return;
     }
     {{{ makeSetValue('childIDPtr', 0, 'childID', 'i32') }}};

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -28,11 +28,11 @@ void _wasmfs_opfs_get_child(em_proxying_ctx* ctx,
                             int* child_id);
 
 // Create a file under `parent` with `name` and store its ID in `child_id`.
-// Returns 0 on success, or a negative error code.
-int _wasmfs_opfs_insert_file(em_proxying_ctx* ctx,
-                             int parent,
-                             const char* name,
-                             int* child_id);
+void _wasmfs_opfs_insert_file(em_proxying_ctx* ctx,
+                              int parent,
+                              const char* name,
+                              int* child_id,
+                              int* err);
 
 // Create a directory under `parent` with `name` and store its ID in `child_id`.
 void _wasmfs_opfs_insert_directory(em_proxying_ctx* ctx,
@@ -259,7 +259,7 @@ private:
         // be extermely complicated.
         WASMFS_UNREACHABLE("TODO: proper setSize error handling");
       case OpenState::None: {
-        int err = 1;
+        int err = 0;
         proxy([&](auto ctx) {
           _wasmfs_opfs_set_size_file(ctx.ctx, fileID, size, &err);
         });
@@ -368,9 +368,9 @@ private:
     int childID = 0;
     int err = 0;
     proxy([&](auto ctx) {
-      err = _wasmfs_opfs_insert_file(ctx.ctx, dirID, name.c_str(), &childID);
+      _wasmfs_opfs_insert_file(ctx.ctx, dirID, name.c_str(), &childID, &err);
     });
-    if (err != 0) {
+    if (err) {
       return {};
     }
     assert(childID >= 0);

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -28,7 +28,7 @@ void _wasmfs_opfs_get_child(em_proxying_ctx* ctx,
                             int* child_id);
 
 // Create a file under `parent` with `name` and store its ID in `child_id`.
-// Returns 0 on success, or an error code.
+// Returns 0 on success, or a negative error code.
 int _wasmfs_opfs_insert_file(em_proxying_ctx* ctx,
                              int parent,
                              const char* name,

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -259,7 +259,7 @@ private:
         // be extermely complicated.
         WASMFS_UNREACHABLE("TODO: proper setSize error handling");
       case OpenState::None: {
-        int err = 0;
+        int err = 1;
         proxy([&](auto ctx) {
           _wasmfs_opfs_set_size_file(ctx.ctx, fileID, size, &err);
         });

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -28,11 +28,8 @@ void _wasmfs_opfs_get_child(em_proxying_ctx* ctx,
                             int* child_id);
 
 // Create a file under `parent` with `name` and store its ID in `child_id`.
-void _wasmfs_opfs_insert_file(em_proxying_ctx* ctx,
-                              int parent,
-                              const char* name,
-                              int* child_id,
-                              int* err);
+void _wasmfs_opfs_insert_file(
+  em_proxying_ctx* ctx, int parent, const char* name, int* child_id, int* err);
 
 // Create a directory under `parent` with `name` and store its ID in `child_id`.
 void _wasmfs_opfs_insert_directory(em_proxying_ctx* ctx,

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -190,6 +190,7 @@ protected:
   // Inserts a file with the given name, kind, and mode. Returns a `File` object
   // corresponding to the newly created file or nullptr if the new file could
   // not be created. Assumes a child with this name does not already exist.
+  // If the operation failed, returns nullptr.
   virtual std::shared_ptr<DataFile> insertDataFile(const std::string& name,
                                                    mode_t mode) = 0;
   virtual std::shared_ptr<Directory> insertDirectory(const std::string& name,
@@ -357,6 +358,7 @@ public:
   // Insert a child of the given name, kind, and mode in the underlying backend,
   // which will allocate and return a corresponding `File` on success or return
   // nullptr otherwise. Assumes a child with this name does not already exist.
+  // If the operation failed, returns nullptr.
   std::shared_ptr<DataFile> insertDataFile(const std::string& name,
                                            mode_t mode);
   std::shared_ptr<Directory> insertDirectory(const std::string& name,

--- a/system/lib/wasmfs/file_table.h
+++ b/system/lib/wasmfs/file_table.h
@@ -59,6 +59,7 @@ public:
   [[nodiscard]] static int create(std::shared_ptr<File> file,
                                   oflags_t flags,
                                   std::shared_ptr<OpenFileState>& out) {
+    assert(file);
     if (auto f = file->dynCast<DataFile>()) {
       if (int err = f->locked().open(flags & O_ACCMODE)) {
         return err;

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -437,7 +437,7 @@ static __wasi_fd_t doOpen(path::ParsedParent parsed,
         if (!created) {
           // TODO Receive a specific error code, and report it here. For now,
           //      report a generic error.
-          return -EINVAL;
+          return -EIO;
         }
       } else {
         created = backend->createFile(mode);

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -434,6 +434,11 @@ static __wasi_fd_t doOpen(path::ParsedParent parsed,
       std::shared_ptr<File> created;
       if (backend == parent->getBackend()) {
         created = lockedParent.insertDataFile(std::string(childName), mode);
+        if (!created) {
+          // TODO Receive a specific error code, and report it here. For now,
+          //      report a generic error.
+          return -EINVAL;
+        }
       } else {
         created = backend->createFile(mode);
         bool mounted = lockedParent.mountChild(std::string(childName), created);


### PR DESCRIPTION
This seems difficult to test. We'd need maybe a mock environment that
fakes the OPFS API..?