### PR TITLE
[WasmFS] Catch and report read and write errors in OPFS

### DIFF
--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -293,7 +293,11 @@ mergeInto(LibraryManager.library, {
   _wasmfs_opfs_read_access: function(accessID, bufPtr, len, pos) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     let data = HEAPU8.subarray(bufPtr, bufPtr + len);
-    return accessHandle.read(data, {at: pos});
+    try {
+      return accessHandle.read(data, {at: pos});
+    } catch (e) {
+      return -1;
+    }
   },
 
   _wasmfs_opfs_read_blob__deps: ['$wasmfsOPFSBlobs'],
@@ -326,7 +330,11 @@ mergeInto(LibraryManager.library, {
   _wasmfs_opfs_write_access: function(accessID, bufPtr, len, pos, nwrittenPtr) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     let data = HEAPU8.subarray(bufPtr, bufPtr + len);
-    return accessHandle.write(data, {at: pos});
+    try {
+      return accessHandle.write(data, {at: pos});
+    } catch (e) {
+      return -1;
+    }
   },
 
   _wasmfs_opfs_get_size_access__deps: ['$wasmfsOPFSAccessHandles'],

--- a/test/wasmfs/wasmfs_opfs_errors_post.js
+++ b/test/wasmfs/wasmfs_opfs_errors_post.js
@@ -49,5 +49,13 @@ async function run_test() {
     throw "Unexpected failure when resizing file";
   }
 
+  if (Module._try_oob_read() != 0) {
+    throw "Did not get expected EINVAL doing out of bounds read";
+  }
+
+  if (Module._try_oob_write() != 0) {
+    throw "Did not get expected EINVAL doing out of bounds write";
+  }
+
   Module._report_result(0);
 }


### PR DESCRIPTION
Reading and writing with invalid offsets was the most convenient error to test
and produces an EINVAL error. In principle other kinds of errors are also
possible, but for now they produce EINVAL as well.