### PR TITLE
[WasmFS] Make OPFS error handling more robust and regular

### DIFF
--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -98,7 +98,9 @@ mergeInto(LibraryManager.library, {
       if (e.name === "TypeMismatchError") {
         return -{{{ cDefine('EISDIR') }}};
       }
+#ifdef ASSERTIONS
       err('unexpected error:', e, e.stack);
+#endif
       return -{{{ cDefine('EIO') }}};
     }
     return wasmfsOPFSAllocate(wasmfsOPFSFileHandles, fileHandle);
@@ -122,7 +124,9 @@ mergeInto(LibraryManager.library, {
       if (e.name === "TypeMismatchError") {
         return -{{{ cDefine('ENOTDIR') }}};
       }
+#ifdef ASSERTIONS
       err('unexpected error:', e, e.stack);
+#endif
       return -{{{ cDefine('EIO') }}};
     }
     return wasmfsOPFSAllocate(wasmfsOPFSDirectoryHandles, childHandle);
@@ -234,7 +238,9 @@ mergeInto(LibraryManager.library, {
           e.name === "NoModificationAllowedError") {
         accessID = -{{{ cDefine('EACCES') }}};
       } else {
+#ifdef ASSERTIONS
         err('unexpected error:', e, e.stack);
+#endif
         accessID = -{{{ cDefine('EIO') }}};
       }
     }
@@ -255,7 +261,9 @@ mergeInto(LibraryManager.library, {
       if (e.name === "NotAllowedError") {
         blobID = -{{{ cDefine('EACCES') }}};
       } else {
+#ifdef ASSERTIONS
         err('unexpected error:', e, e.stack);
+#endif
         blobID = -{{{ cDefine('EIO') }}};
       }
     }
@@ -290,7 +298,9 @@ mergeInto(LibraryManager.library, {
       if (e.name == "TypeError") {
         return -{{{ cDefine('EINVAL') }}};
       }
+#ifdef ASSERTIONS
       err('unexpected error:', e, e.stack);
+#endif
       return -{{{ cDefine('EIO') }}};
     }
   },
@@ -313,7 +323,9 @@ mergeInto(LibraryManager.library, {
       if (e instanceof RangeError) {
         nread = -{{{ cDefine('EFAULT') }}};
       } else {
+#ifdef ASSERTIONS
         err('unexpected error:', e, e.stack);
+#endif
         nread = -{{{ cDefine('EIO') }}};
       }
     }
@@ -332,7 +344,9 @@ mergeInto(LibraryManager.library, {
       if (e.name == "TypeError") {
         return -{{{ cDefine('EINVAL') }}};
       }
+#ifdef ASSERTIONS
       err('unexpected error:', e, e.stack);
+#endif
       return -{{{ cDefine('EIO') }}};
     }
   },

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -98,7 +98,7 @@ mergeInto(LibraryManager.library, {
       if (e.name === "TypeMismatchError") {
         return -{{{ cDefine('EISDIR') }}};
       }
-#ifdef ASSERTIONS
+#if ASSERTIONS
       err('unexpected error:', e, e.stack);
 #endif
       return -{{{ cDefine('EIO') }}};
@@ -124,7 +124,7 @@ mergeInto(LibraryManager.library, {
       if (e.name === "TypeMismatchError") {
         return -{{{ cDefine('ENOTDIR') }}};
       }
-#ifdef ASSERTIONS
+#if ASSERTIONS
       err('unexpected error:', e, e.stack);
 #endif
       return -{{{ cDefine('EIO') }}};
@@ -238,7 +238,7 @@ mergeInto(LibraryManager.library, {
           e.name === "NoModificationAllowedError") {
         accessID = -{{{ cDefine('EACCES') }}};
       } else {
-#ifdef ASSERTIONS
+#if ASSERTIONS
         err('unexpected error:', e, e.stack);
 #endif
         accessID = -{{{ cDefine('EIO') }}};
@@ -261,7 +261,7 @@ mergeInto(LibraryManager.library, {
       if (e.name === "NotAllowedError") {
         blobID = -{{{ cDefine('EACCES') }}};
       } else {
-#ifdef ASSERTIONS
+#if ASSERTIONS
         err('unexpected error:', e, e.stack);
 #endif
         blobID = -{{{ cDefine('EIO') }}};
@@ -298,7 +298,7 @@ mergeInto(LibraryManager.library, {
       if (e.name == "TypeError") {
         return -{{{ cDefine('EINVAL') }}};
       }
-#ifdef ASSERTIONS
+#if ASSERTIONS
       err('unexpected error:', e, e.stack);
 #endif
       return -{{{ cDefine('EIO') }}};
@@ -323,7 +323,7 @@ mergeInto(LibraryManager.library, {
       if (e instanceof RangeError) {
         nread = -{{{ cDefine('EFAULT') }}};
       } else {
-#ifdef ASSERTIONS
+#if ASSERTIONS
         err('unexpected error:', e, e.stack);
 #endif
         nread = -{{{ cDefine('EIO') }}};
@@ -344,7 +344,7 @@ mergeInto(LibraryManager.library, {
       if (e.name == "TypeError") {
         return -{{{ cDefine('EINVAL') }}};
       }
-#ifdef ASSERTIONS
+#if ASSERTIONS
       err('unexpected error:', e, e.stack);
 #endif
       return -{{{ cDefine('EIO') }}};

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -81,12 +81,8 @@ mergeInto(LibraryManager.library, {
   },
 
   // Return the file ID for the file with `name` under `parent`, creating it if
-  // it doesn't exist and `create` or otherwise return one of the following
-  // error codes:
-  //
-  // -1: file does not exist.
-  // -2: file exists but it is actually a directory.
-  // -3: file exists but an access handle cannot be created for it.
+  // it doesn't exist and `create` or otherwise return a negative error code
+  // corresponding to the error.
   $wasmfsOPFSGetOrCreateFile__deps: ['$wasmfsOPFSAllocate',
                                      '$wasmfsOPFSDirectoryHandles',
                                      '$wasmfsOPFSFileHandles'],
@@ -97,22 +93,20 @@ mergeInto(LibraryManager.library, {
       fileHandle = await parentHandle.getFileHandle(name, {create: create});
     } catch (e) {
       if (e.name === "NotFoundError") {
-        return -1;
+        return -{{{ cDefine('EEXIST') }}};
       }
       if (e.name === "TypeMismatchError") {
-        return -2;
+        return -{{{ cDefine('EISDIR') }}};
       }
-      throw e;
+      err('unexpected error:', e, e.stack);
+      return -{{{ cDefine('EIO') }}};
     }
     return wasmfsOPFSAllocate(wasmfsOPFSFileHandles, fileHandle);
   },
 
   // Return the file ID for the directory with `name` under `parent`, creating
-  // it if it doesn't exist and `create` or otherwise one of the following error
-  // codes:
-  //
-  // -1: directory does not exist.
-  // -2: directory exists but is actually a data file.
+  // it if it doesn't exist and `create` or otherwise return a negative error
+  // code corresponding to the error.
   $wasmfsOPFSGetOrCreateDir__deps: ['$wasmfsOPFSAllocate',
                                     '$wasmfsOPFSDirectoryHandles'],
   $wasmfsOPFSGetOrCreateDir: async function(parent, name, create) {
@@ -123,12 +117,13 @@ mergeInto(LibraryManager.library, {
           await parentHandle.getDirectoryHandle(name, {create: create});
     } catch (e) {
       if (e.name === "NotFoundError") {
-        return -1;
+        return -{{{ cDefine('EEXIST') }}};
       }
       if (e.name === "TypeMismatchError") {
-        return -2;
+        return -{{{ cDefine('ENOTDIR') }}};
       }
-      throw e;
+      err('unexpected error:', e, e.stack);
+      return -{{{ cDefine('EIO') }}};
     }
     return wasmfsOPFSAllocate(wasmfsOPFSDirectoryHandles, childHandle);
   },
@@ -140,7 +135,7 @@ mergeInto(LibraryManager.library, {
     let name = UTF8ToString(namePtr);
     let childType = 1;
     let childID = await wasmfsOPFSGetOrCreateFile(parent, name, false);
-    if (childID == -2) {
+    if (childID == -{{{ cDefine('EISDIR') }}}) {
       childType = 2;
       childID = await wasmfsOPFSGetOrCreateDir(parent, name, false);
     }
@@ -154,6 +149,7 @@ mergeInto(LibraryManager.library, {
     let dirHandle = wasmfsOPFSDirectoryHandles.get(dirID);
 
     // TODO: Use 'for await' once Acorn supports that.
+    // TODO: Error handling.
     let iter = dirHandle.entries();
     for (let entry; entry = await iter.next(), !entry.done;) {
       let [name, child] = entry.value;
@@ -169,17 +165,9 @@ mergeInto(LibraryManager.library, {
   },
 
   _wasmfs_opfs_insert_file__deps: ['$wasmfsOPFSGetOrCreateFile'],
-  _wasmfs_opfs_insert_file: async function(ctx, parent, namePtr, childIDPtr, errPtr) {
+  _wasmfs_opfs_insert_file: async function(ctx, parent, namePtr, childIDPtr) {
     let name = UTF8ToString(namePtr);
-    let childID;
-    try {
-      childID = await wasmfsOPFSGetOrCreateFile(parent, name, true);
-    } catch(e) {
-      // TODO: Return a specific error code depending on the error.
-      {{{ makeSetValue('errPtr', 0, '1', 'i32') }}};
-      _emscripten_proxy_finish(ctx);
-      return;
-    }
+    let childID = await wasmfsOPFSGetOrCreateFile(parent, name, true);
     {{{ makeSetValue('childIDPtr', 0, 'childID', 'i32') }}};
     _emscripten_proxy_finish(ctx);
   },
@@ -199,6 +187,7 @@ mergeInto(LibraryManager.library, {
     let name = UTF8ToString(namePtr);
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     let newDirHandle = wasmfsOPFSDirectoryHandles.get(newDirID);
+    // TODO: error handling
     await fileHandle.move(newDirHandle, name);
     _emscripten_proxy_finish(ctx);
   },
@@ -243,9 +232,10 @@ mergeInto(LibraryManager.library, {
       // TODO: Presumably only one of these will appear in the final API?
       if (e.name === "InvalidStateError" ||
           e.name === "NoModificationAllowedError") {
-        accessID = -1;
+        accessID = -{{{ cDefine('EACCES') }}};
       } else {
-        throw e;
+        err('unexpected error:', e, e.stack);
+        accessID = -{{{ cDefine('EIO') }}};
       }
     }
     {{{ makeSetValue('accessIDPtr', 0, 'accessID', 'i32') }}};
@@ -263,9 +253,10 @@ mergeInto(LibraryManager.library, {
       blobID = wasmfsOPFSAllocate(wasmfsOPFSBlobs, blob);
     } catch (e) {
       if (e.name === "NotAllowedError") {
-        blobID = -1;
+        blobID = -{{{ cDefine('EACCES') }}};
       } else {
-        throw e;
+        err('unexpected error:', e, e.stack);
+        blobID = -{{{ cDefine('EIO') }}};
       }
     }
     {{{ makeSetValue('blobIDPtr', 0, 'blobID', 'i32') }}};
@@ -296,7 +287,11 @@ mergeInto(LibraryManager.library, {
     try {
       return accessHandle.read(data, {at: pos});
     } catch (e) {
-      return -1;
+      if (e.name == "TypeError") {
+        return -{{{ cDefine('EINVAL') }}};
+      }
+      err('unexpected error:', e, e.stack);
+      return -{{{ cDefine('EIO') }}};
     }
   },
 
@@ -316,9 +311,10 @@ mergeInto(LibraryManager.library, {
       nread += data.length;
     } catch (e) {
       if (e instanceof RangeError) {
-        nread = -1;
+        nread = -{{{ cDefine('EFAULT') }}};
       } else {
-        throw e;
+        err('unexpected error:', e, e.stack);
+        nread = -{{{ cDefine('EIO') }}};
       }
     }
 
@@ -327,19 +323,24 @@ mergeInto(LibraryManager.library, {
   },
 
   _wasmfs_opfs_write_access__deps: ['$wasmfsOPFSAccessHandles'],
-  _wasmfs_opfs_write_access: function(accessID, bufPtr, len, pos, nwrittenPtr) {
+  _wasmfs_opfs_write_access: function(accessID, bufPtr, len, pos) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     let data = HEAPU8.subarray(bufPtr, bufPtr + len);
     try {
       return accessHandle.write(data, {at: pos});
     } catch (e) {
-      return -1;
+      if (e.name == "TypeError") {
+        return -{{{ cDefine('EINVAL') }}};
+      }
+      err('unexpected error:', e, e.stack);
+      return -{{{ cDefine('EIO') }}};
     }
   },
 
   _wasmfs_opfs_get_size_access__deps: ['$wasmfsOPFSAccessHandles'],
   _wasmfs_opfs_get_size_access: async function(ctx, accessID, sizePtr) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
+    // TODO: Error handling
     let size = await accessHandle.getSize();
     {{{ makeSetValue('sizePtr', 0, 'size', 'i32') }}};
     _emscripten_proxy_finish(ctx);
@@ -347,12 +348,14 @@ mergeInto(LibraryManager.library, {
 
   _wasmfs_opfs_get_size_blob__deps: ['$wasmfsOPFSBlobs'],
   _wasmfs_opfs_get_size_blob: function(blobID) {
+    // This cannot fail.
     return wasmfsOPFSBlobs.get(blobID).size;
   },
 
   _wasmfs_opfs_get_size_file__deps: ['$wasmfsOPFSFileHandles'],
   _wasmfs_opfs_get_size_file: async function(ctx, fileID, sizePtr) {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
+    // TODO: Error handling
     let size = (await fileHandle.getFile()).size;
     {{{ makeSetValue('sizePtr', 0, 'size', 'i32') }}};
     _emscripten_proxy_finish(ctx);
@@ -364,7 +367,8 @@ mergeInto(LibraryManager.library, {
     try {
       await accessHandle.truncate(size);
     } catch {
-      {{{ makeSetValue('errPtr', 0, '1', 'i32') }}};
+      let err = -{{{ cDefine('EIO') }}};
+      {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
     _emscripten_proxy_finish(ctx);
   },
@@ -377,7 +381,8 @@ mergeInto(LibraryManager.library, {
       await writable.truncate(size);
       await writable.close();
     } catch {
-      {{{ makeSetValue('errPtr', 0, '1', 'i32') }}};
+      let err = -{{{ cDefine('EIO') }}};
+      {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
     _emscripten_proxy_finish(ctx);
   },
@@ -385,6 +390,7 @@ mergeInto(LibraryManager.library, {
   _wasmfs_opfs_flush_access__deps: ['$wasmfsOPFSAccessHandles'],
   _wasmfs_opfs_flush_access: async function(ctx, accessID) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
+    // TODO: Error handling
     await accessHandle.flush();
     _emscripten_proxy_finish(ctx);
   }

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -149,7 +149,7 @@ public:
           proxy(
             [&](auto ctx) { _wasmfs_opfs_open_blob(ctx.ctx, fileID, &id); });
           if (id < 0) {
-            return -id;
+            return id;
           }
           kind = Blob;
           break;

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -28,8 +28,10 @@ void _wasmfs_opfs_get_child(em_proxying_ctx* ctx,
                             int* child_id);
 
 // Create a file under `parent` with `name` and store its ID in `child_id`.
-void _wasmfs_opfs_insert_file(
-  em_proxying_ctx* ctx, int parent, const char* name, int* child_id, int* err);
+void _wasmfs_opfs_insert_file(em_proxying_ctx* ctx,
+                              int parent,
+                              const char* name,
+                              int* child_id);
 
 // Create a directory under `parent` with `name` and store its ID in `child_id`.
 void _wasmfs_opfs_insert_directory(em_proxying_ctx* ctx,
@@ -138,7 +140,7 @@ public:
             [&](auto ctx) { _wasmfs_opfs_open_access(ctx.ctx, fileID, &id); });
           // TODO: Fall back to open as a blob instead.
           if (id < 0) {
-            return -EACCES;
+            return id;
           }
           kind = Access;
           break;
@@ -147,7 +149,7 @@ public:
           proxy(
             [&](auto ctx) { _wasmfs_opfs_open_blob(ctx.ctx, fileID, &id); });
           if (id < 0) {
-            return -EACCES;
+            return -id;
           }
           kind = Blob;
           break;
@@ -160,7 +162,7 @@ public:
       proxy(
         [&](auto ctx) { _wasmfs_opfs_open_access(ctx.ctx, fileID, &newID); });
       if (newID < 0) {
-        return -EACCES;
+        return newID;
       }
       // We have an AccessHandle, so close the blob.
       proxy([&]() { _wasmfs_opfs_close_blob(getBlobID()); });
@@ -267,7 +269,7 @@ private:
       default:
         WASMFS_UNREACHABLE("Unexpected open state");
     }
-    return err ? -EIO : 0;
+    return err;
   }
 
   int open(oflags_t flags) override { return state.open(proxy, fileID, flags); }
@@ -297,9 +299,7 @@ private:
       default:
         WASMFS_UNREACHABLE("Unexpected open state");
     }
-    // TODO: This is the correct error code for negative read positions, but we
-    // should handle other errors correctly as well.
-    return nread < 0 ? -EINVAL : nread;
+    return nread;
   }
 
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
@@ -310,9 +310,7 @@ private:
       nwritten =
         _wasmfs_opfs_write_access(state.getAccessID(), buf, len, offset);
     });
-    // TODO: This is the correct error code for negative write positions, but we
-    // should handle other errors correctly as well.
-    return nwritten < 0 ? -EINVAL : nwritten;
+    return nwritten;
   }
 
   void flush() override {
@@ -371,14 +369,13 @@ private:
   std::shared_ptr<DataFile> insertDataFile(const std::string& name,
                                            mode_t mode) override {
     int childID = 0;
-    int err = 0;
     proxy([&](auto ctx) {
-      _wasmfs_opfs_insert_file(ctx.ctx, dirID, name.c_str(), &childID, &err);
+      _wasmfs_opfs_insert_file(ctx.ctx, dirID, name.c_str(), &childID);
     });
-    if (err) {
-      return {};
+    if (childID < 0) {
+      // TODO: Propagate specific errors.
+      return nullptr;
     }
-    assert(childID >= 0);
     return std::make_shared<OPFSFile>(mode, getBackend(), childID, proxy);
   }
 
@@ -388,14 +385,17 @@ private:
     proxy([&](auto ctx) {
       _wasmfs_opfs_insert_directory(ctx.ctx, dirID, name.c_str(), &childID);
     });
-    // TODO: Handle errors gracefully.
-    assert(childID >= 0);
+    if (childID < 0) {
+      // TODO: Propagate specific errors.
+      return nullptr;
+    }
     return std::make_shared<OPFSDirectory>(mode, getBackend(), childID, proxy);
   }
 
   std::shared_ptr<Symlink> insertSymlink(const std::string& name,
                                          const std::string& target) override {
     // Symlinks not supported.
+    // TODO: Propagate EPERM specifically.
     return nullptr;
   }
 


### PR DESCRIPTION
Refactor the existing error handling in the OPFS backend according to these
principles:

 1. Determine error codes where errors occur. This simplifies the code by
    eliminating ad hoc magic error constants and improves the code by making
    errors more specific.

 2. Return errors in existing return channels where possible, rather than adding
    new out-params for errors. This reduces code size and makes the code more
    robust by reducing the space of meaningless return values.

 3. Do not allow any exceptions to escape. Unknown exceptions are reported to
    the console and converted to catch-all EIO error codes. Exceptions escaping
    the async OFPS code cause deadlocks, so they must be rigorously avoided.