### PR TITLE
[WasmFS] Allow backends to report errors from `flush`

### DIFF
--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -402,10 +402,14 @@ mergeInto(LibraryManager.library, {
   },
 
   _wasmfs_opfs_flush_access__deps: ['$wasmfsOPFSAccessHandles'],
-  _wasmfs_opfs_flush_access: async function(ctx, accessID) {
+  _wasmfs_opfs_flush_access: async function(ctx, accessID, errPtr) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
-    // TODO: Error handling
-    await accessHandle.flush();
+    try {
+      await accessHandle.flush();
+    } catch {
+      let err = -{{{ cDefine('EIO') }}};
+      {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
+    }
     _emscripten_proxy_finish(ctx);
   }
 });

--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -137,7 +137,7 @@ public:
     : DataFile(mode, backend), state(path) {}
 
 private:
-  off_t getSize() override {
+  size_t getSize() override {
     // TODO: This should really be using a 64-bit file size type.
     uint32_t size;
     if (state.isOpen()) {
@@ -151,10 +151,10 @@ private:
         return 0;
       }
     }
-    return off_t(size);
+    return size_t(size);
   }
 
-  int setSize(off_t size) override {
+  int setSize(size_t size) override {
     WASMFS_UNREACHABLE("TODO: implement NodeFile::setSize");
   }
 

--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -137,7 +137,7 @@ public:
     : DataFile(mode, backend), state(path) {}
 
 private:
-  size_t getSize() override {
+  off_t getSize() override {
     // TODO: This should really be using a 64-bit file size type.
     uint32_t size;
     if (state.isOpen()) {
@@ -151,10 +151,10 @@ private:
         return 0;
       }
     }
-    return size_t(size);
+    return off_t(size);
   }
 
-  int setSize(size_t size) override {
+  int setSize(off_t size) override {
     WASMFS_UNREACHABLE("TODO: implement NodeFile::setSize");
   }
 
@@ -179,7 +179,7 @@ private:
     return nwritten;
   }
 
-  void flush() override {
+  int flush() override {
     WASMFS_UNREACHABLE("TODO: implement NodeFile::flush");
   }
 };

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -88,22 +88,23 @@ int _wasmfs_opfs_write_access(int access_id,
 // Get the size via an AccessHandle.
 void _wasmfs_opfs_get_size_access(em_proxying_ctx* ctx,
                                   int access_id,
-                                  off_t* size);
+                                  uint32_t* size);
 
-// TODO: return 64-byte off_t.
 uint32_t _wasmfs_opfs_get_size_blob(int blob_id);
 
 // Get the size of a file handle via a File Blob.
-void _wasmfs_opfs_get_size_file(em_proxying_ctx* ctx, int file_id, off_t* size);
+void _wasmfs_opfs_get_size_file(em_proxying_ctx* ctx,
+                                int file_id,
+                                uint32_t* size);
 
 void _wasmfs_opfs_set_size_access(em_proxying_ctx* ctx,
                                   int access_id,
-                                  off_t size,
+                                  uint32_t size,
                                   int* err);
 
 void _wasmfs_opfs_set_size_file(em_proxying_ctx* ctx,
                                 int file_id,
-                                off_t size,
+                                uint32_t size,
                                 int* err);
 
 void _wasmfs_opfs_flush_access(em_proxying_ctx* ctx, int access_id, int* err);
@@ -221,8 +222,9 @@ public:
   }
 
 private:
-  off_t getSize() override {
-    off_t size;
+  size_t getSize() override {
+    // TODO: 64-bit sizes.
+    uint32_t size;
     switch (state.getKind()) {
       case OpenState::None:
         proxy([&](auto ctx) {
@@ -240,10 +242,10 @@ private:
       default:
         WASMFS_UNREACHABLE("Unexpected open state");
     }
-    return size;
+    return size_t(size);
   }
 
-  int setSize(off_t size) override {
+  int setSize(size_t size) override {
     int err = 0;
     switch (state.getKind()) {
       case OpenState::Access:
@@ -257,8 +259,6 @@ private:
         // become invalidated and refreshing it while ensuring other in-flight
         // operations on the same file do not observe the invalidated blob would
         // be extremely complicated.
-        // TODO: Can we assume there are no other in-flight operations on this
-        // file and do something better here?
         return -EIO;
       case OpenState::None: {
         proxy([&](auto ctx) {

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -88,26 +88,25 @@ int _wasmfs_opfs_write_access(int access_id,
 // Get the size via an AccessHandle.
 void _wasmfs_opfs_get_size_access(em_proxying_ctx* ctx,
                                   int access_id,
-                                  uint32_t* size);
+                                  off_t* size);
 
+// TODO: return 64-byte off_t.
 uint32_t _wasmfs_opfs_get_size_blob(int blob_id);
 
 // Get the size of a file handle via a File Blob.
-void _wasmfs_opfs_get_size_file(em_proxying_ctx* ctx,
-                                int file_id,
-                                uint32_t* size);
+void _wasmfs_opfs_get_size_file(em_proxying_ctx* ctx, int file_id, off_t* size);
 
 void _wasmfs_opfs_set_size_access(em_proxying_ctx* ctx,
                                   int access_id,
-                                  uint32_t size,
+                                  off_t size,
                                   int* err);
 
 void _wasmfs_opfs_set_size_file(em_proxying_ctx* ctx,
                                 int file_id,
-                                uint32_t size,
+                                off_t size,
                                 int* err);
 
-void _wasmfs_opfs_flush_access(em_proxying_ctx* ctx, int access_id);
+void _wasmfs_opfs_flush_access(em_proxying_ctx* ctx, int access_id, int* err);
 
 } // extern "C"
 
@@ -222,9 +221,8 @@ public:
   }
 
 private:
-  size_t getSize() override {
-    // TODO: 64-bit sizes.
-    uint32_t size;
+  off_t getSize() override {
+    off_t size;
     switch (state.getKind()) {
       case OpenState::None:
         proxy([&](auto ctx) {
@@ -242,10 +240,10 @@ private:
       default:
         WASMFS_UNREACHABLE("Unexpected open state");
     }
-    return size_t(size);
+    return size;
   }
 
-  int setSize(size_t size) override {
+  int setSize(off_t size) override {
     int err = 0;
     switch (state.getKind()) {
       case OpenState::Access:
@@ -259,6 +257,8 @@ private:
         // become invalidated and refreshing it while ensuring other in-flight
         // operations on the same file do not observe the invalidated blob would
         // be extremely complicated.
+        // TODO: Can we assume there are no other in-flight operations on this
+        // file and do something better here?
         return -EIO;
       case OpenState::None: {
         proxy([&](auto ctx) {
@@ -313,11 +313,12 @@ private:
     return nwritten;
   }
 
-  void flush() override {
+  int flush() override {
+    int err = 0;
     switch (state.getKind()) {
       case OpenState::Access:
         proxy([&](auto ctx) {
-          _wasmfs_opfs_flush_access(ctx.ctx, state.getAccessID());
+          _wasmfs_opfs_flush_access(ctx.ctx, state.getAccessID(), &err);
         });
         break;
       case OpenState::Blob:
@@ -325,6 +326,7 @@ private:
       default:
         break;
     }
+    return err;
   }
 };
 

--- a/system/lib/wasmfs/backends/proxied_file_backend.cpp
+++ b/system/lib/wasmfs/backends/proxied_file_backend.cpp
@@ -47,17 +47,17 @@ class ProxiedFile : public DataFile {
     return result;
   }
 
-  void flush() override {}
+  int flush() override { return 0; }
 
   // Querying the size of the Proxied File returns the size of the underlying
   // file given by the proxying mechanism.
-  size_t getSize() override {
-    size_t result;
+  off_t getSize() override {
+    off_t result;
     proxy([&]() { result = baseFile->locked().getSize(); });
     return result;
   }
 
-  int setSize(size_t size) override {
+  int setSize(off_t size) override {
     WASMFS_UNREACHABLE("TODO: ProxiedFS setSize");
   }
 

--- a/system/lib/wasmfs/backends/proxied_file_backend.cpp
+++ b/system/lib/wasmfs/backends/proxied_file_backend.cpp
@@ -51,13 +51,13 @@ class ProxiedFile : public DataFile {
 
   // Querying the size of the Proxied File returns the size of the underlying
   // file given by the proxying mechanism.
-  off_t getSize() override {
-    off_t result;
+  size_t getSize() override {
+    size_t result;
     proxy([&]() { result = baseFile->locked().getSize(); });
     return result;
   }
 
-  int setSize(off_t size) override {
+  int setSize(size_t size) override {
     WASMFS_UNREACHABLE("TODO: ProxiedFS setSize");
   }
 

--- a/system/lib/wasmfs/js_impl_backend.h
+++ b/system/lib/wasmfs/js_impl_backend.h
@@ -96,11 +96,11 @@ class JSImplFile : public DataFile {
 
   int flush() override { return 0; }
 
-  off_t getSize() override {
+  size_t getSize() override {
     return _wasmfs_jsimpl_get_size(getBackendIndex(), getFileIndex());
   }
 
-  int setSize(off_t size) override {
+  int setSize(size_t size) override {
     WASMFS_UNREACHABLE("TODO: JSImpl setSize");
   }
 

--- a/system/lib/wasmfs/js_impl_backend.h
+++ b/system/lib/wasmfs/js_impl_backend.h
@@ -94,13 +94,13 @@ class JSImplFile : public DataFile {
       getBackendIndex(), getFileIndex(), buf, len, offset);
   }
 
-  void flush() override {}
+  int flush() override { return 0; }
 
-  size_t getSize() override {
+  off_t getSize() override {
     return _wasmfs_jsimpl_get_size(getBackendIndex(), getFileIndex());
   }
 
-  int setSize(size_t size) override {
+  int setSize(off_t size) override {
     WASMFS_UNREACHABLE("TODO: JSImpl setSize");
   }
 

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -23,9 +23,9 @@ class MemoryFile : public DataFile {
   int close() override { return 0; }
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override;
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override;
-  void flush() override {}
-  size_t getSize() override { return buffer.size(); }
-  int setSize(size_t size) override {
+  int flush() override { return 0; }
+  off_t getSize() override { return buffer.size(); }
+  int setSize(off_t size) override {
     buffer.resize(size);
     return 0;
   }

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -24,8 +24,8 @@ class MemoryFile : public DataFile {
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override;
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override;
   int flush() override { return 0; }
-  off_t getSize() override { return buffer.size(); }
-  int setSize(off_t size) override {
+  size_t getSize() override { return buffer.size(); }
+  int setSize(size_t size) override {
     buffer.resize(size);
     return 0;
   }

--- a/system/lib/wasmfs/pipe_backend.h
+++ b/system/lib/wasmfs/pipe_backend.h
@@ -46,10 +46,10 @@ class PipeFile : public DataFile {
 
   int flush() override { return 0; }
 
-  off_t getSize() override { return data->size(); }
+  size_t getSize() override { return data->size(); }
 
   // TODO: Should this return an error?
-  int setSize(off_t size) override { return 0; }
+  int setSize(size_t size) override { return 0; }
 
 public:
   // PipeFiles do not have or need a backend. Pass NullBackend to the parent for

--- a/system/lib/wasmfs/pipe_backend.h
+++ b/system/lib/wasmfs/pipe_backend.h
@@ -44,12 +44,12 @@ class PipeFile : public DataFile {
     return len;
   }
 
-  void flush() override {}
+  int flush() override { return 0; }
 
-  size_t getSize() override { return data->size(); }
+  off_t getSize() override { return data->size(); }
 
   // TODO: Should this return an error?
-  int setSize(size_t size) override { return 0; }
+  int setSize(off_t size) override { return 0; }
 
 public:
   // PipeFiles do not have or need a backend. Pass NullBackend to the parent for

--- a/system/lib/wasmfs/proxied_async_js_impl_backend.h
+++ b/system/lib/wasmfs/proxied_async_js_impl_backend.h
@@ -66,7 +66,7 @@ void _wasmfs_jsimpl_async_read(em_proxying_ctx* ctx,
 void _wasmfs_jsimpl_async_get_size(em_proxying_ctx* ctx,
                                    js_index_t backend,
                                    js_index_t index,
-                                   off_t* result);
+                                   size_t* result);
 }
 
 namespace wasmfs {
@@ -108,8 +108,8 @@ class ProxiedAsyncJSImplFile : public DataFile {
 
   int flush() override { return 0; }
 
-  off_t getSize() override {
-    off_t result;
+  size_t getSize() override {
+    size_t result;
     proxy([&](auto ctx) {
       _wasmfs_jsimpl_async_get_size(
         ctx.ctx, getBackendIndex(), getFileIndex(), &result);
@@ -117,7 +117,7 @@ class ProxiedAsyncJSImplFile : public DataFile {
     return result;
   }
 
-  int setSize(off_t size) override {
+  int setSize(size_t size) override {
     WASMFS_UNREACHABLE("TODO: ProxiedAsyncJSImplFile setSize");
   }
 

--- a/system/lib/wasmfs/proxied_async_js_impl_backend.h
+++ b/system/lib/wasmfs/proxied_async_js_impl_backend.h
@@ -66,7 +66,7 @@ void _wasmfs_jsimpl_async_read(em_proxying_ctx* ctx,
 void _wasmfs_jsimpl_async_get_size(em_proxying_ctx* ctx,
                                    js_index_t backend,
                                    js_index_t index,
-                                   size_t* result);
+                                   off_t* result);
 }
 
 namespace wasmfs {
@@ -106,10 +106,10 @@ class ProxiedAsyncJSImplFile : public DataFile {
     return result;
   }
 
-  void flush() override {}
+  int flush() override { return 0; }
 
-  size_t getSize() override {
-    size_t result;
+  off_t getSize() override {
+    off_t result;
     proxy([&](auto ctx) {
       _wasmfs_jsimpl_async_get_size(
         ctx.ctx, getBackendIndex(), getFileIndex(), &result);
@@ -117,7 +117,7 @@ class ProxiedAsyncJSImplFile : public DataFile {
     return result;
   }
 
-  int setSize(size_t size) override {
+  int setSize(off_t size) override {
     WASMFS_UNREACHABLE("TODO: ProxiedAsyncJSImplFile setSize");
   }
 

--- a/system/lib/wasmfs/special_files.cpp
+++ b/system/lib/wasmfs/special_files.cpp
@@ -29,8 +29,8 @@ class NullFile : public DataFile {
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override { return 0; }
 
   int flush() override { return 0; }
-  off_t getSize() override { return 0; }
-  int setSize(off_t size) override { return -EPERM; }
+  size_t getSize() override { return 0; }
+  int setSize(size_t size) override { return -EPERM; }
 
 public:
   NullFile() : DataFile(S_IRUGO | S_IWUGO, NullBackend, S_IFCHR) {}
@@ -50,8 +50,8 @@ class StdinFile : public DataFile {
   };
 
   int flush() override { return 0; }
-  off_t getSize() override { return 0; }
-  int setSize(off_t size) override { return -EPERM; }
+  size_t getSize() override { return 0; }
+  int setSize(size_t size) override { return -EPERM; }
 
 public:
   StdinFile() : DataFile(S_IRUGO, NullBackend, S_IFCHR) { seekable = false; }
@@ -78,8 +78,8 @@ protected:
     return 0;
   }
 
-  off_t getSize() override { return 0; }
-  int setSize(off_t size) override { return -EPERM; }
+  size_t getSize() override { return 0; }
+  int setSize(size_t size) override { return -EPERM; }
 
   ssize_t writeToJS(const uint8_t* buf,
                     size_t len,
@@ -152,8 +152,8 @@ class RandomFile : public DataFile {
   };
 
   int flush() override { return 0; }
-  off_t getSize() override { return 0; }
-  int setSize(off_t size) override { return -EPERM; }
+  size_t getSize() override { return 0; }
+  int setSize(size_t size) override { return -EPERM; }
 
 public:
   RandomFile() : DataFile(S_IRUGO, NullBackend, S_IFCHR) { seekable = false; }

--- a/system/lib/wasmfs/special_files.cpp
+++ b/system/lib/wasmfs/special_files.cpp
@@ -28,9 +28,9 @@ class NullFile : public DataFile {
 
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override { return 0; }
 
-  void flush() override {}
-  size_t getSize() override { return 0; }
-  int setSize(size_t size) override { return -EPERM; }
+  int flush() override { return 0; }
+  off_t getSize() override { return 0; }
+  int setSize(off_t size) override { return -EPERM; }
 
 public:
   NullFile() : DataFile(S_IRUGO | S_IWUGO, NullBackend, S_IFCHR) {}
@@ -49,9 +49,9 @@ class StdinFile : public DataFile {
     abort();
   };
 
-  void flush() override {}
-  size_t getSize() override { return 0; }
-  int setSize(size_t size) override { return -EPERM; }
+  int flush() override { return 0; }
+  off_t getSize() override { return 0; }
+  int setSize(off_t size) override { return -EPERM; }
 
 public:
   StdinFile() : DataFile(S_IRUGO, NullBackend, S_IFCHR) { seekable = false; }
@@ -69,16 +69,17 @@ protected:
     return -__WASI_ERRNO_INVAL;
   };
 
-  void flush() override {
+  int flush() override {
     // Write a null to flush the output if we have content.
     if (!writeBuffer.empty()) {
       const uint8_t nothing = '\0';
       write(&nothing, 1, 0);
     }
+    return 0;
   }
 
-  size_t getSize() override { return 0; }
-  int setSize(size_t size) override { return -EPERM; }
+  off_t getSize() override { return 0; }
+  int setSize(off_t size) override { return -EPERM; }
 
   ssize_t writeToJS(const uint8_t* buf,
                     size_t len,
@@ -150,9 +151,9 @@ class RandomFile : public DataFile {
     return len;
   };
 
-  void flush() override {}
-  size_t getSize() override { return 0; }
-  int setSize(size_t size) override { return -EPERM; }
+  int flush() override { return 0; }
+  off_t getSize() override { return 0; }
+  int setSize(off_t size) override { return -EPERM; }
 
 public:
   RandomFile() : DataFile(S_IRUGO, NullBackend, S_IFCHR) { seekable = false; }

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -292,7 +292,8 @@ __wasi_errno_t __wasi_fd_sync(__wasi_fd_t fd) {
   // way. TODO: in the future we may want syncing of directories.
   auto dataFile = openFile->locked().getFile()->dynCast<DataFile>();
   if (dataFile) {
-    dataFile->locked().flush();
+    // Translate to WASI standard of positive return codes.
+    return -dataFile->locked().flush();
   }
 
   return __WASI_ERRNO_SUCCESS;

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -58,8 +58,8 @@ WasmFS::~WasmFS() {
   // Note that we lock here, although strictly speaking it is unnecessary given
   // that we are in the destructor of WasmFS: nothing can possibly be running
   // on files at this time.
-  SpecialFiles::getStdout()->locked().flush();
-  SpecialFiles::getStderr()->locked().flush();
+  (void)SpecialFiles::getStdout()->locked().flush();
+  (void)SpecialFiles::getStderr()->locked().flush();
 
   // Break the reference cycle caused by the root directory being its own
   // parent.


### PR DESCRIPTION
And catch and report such errors in the OPFS backend to prevent errors from
causing the async task to hang and create deadlocks.