### PR TITLE
Remove redundant _emscripten_date_now and fix signature

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -448,11 +448,6 @@ mergeInto(LibraryManager.library, {
   // time.h
   // ==========================================================================
 
-  _emscripten_date_now__sig: 'j',
-  _emscripten_date_now: function() {
-    return Date.now();
-  },
-
   _mktime_js__sig: 'ip',
   _mktime_js: function(tmPtr) {
     var date = new Date({{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_year, 'i32') }}} + 1900,

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2705,6 +2705,7 @@ var LibraryHTML5 = {
     return requestAnimationFrame(tick);
   },
 
+  emscripten_date_now__sig: 'd',
   emscripten_date_now: function() {
     return Date.now();
   },

--- a/system/lib/libc/emscripten_time.c
+++ b/system/lib/libc/emscripten_time.c
@@ -6,6 +6,7 @@
  */
 
 #include <emscripten/emscripten.h>
+#include <emscripten/html5.h>
 #include <time.h>
 #include <stdbool.h>
 #include <sys/time.h>
@@ -27,7 +28,6 @@ int _timegm_js(struct tm *tm);
 int _mktime_js(struct tm *tm);
 void _localtime_js(const time_t *restrict t, struct tm *restrict tm);
 void _gmtime_js(const time_t *restrict t, struct tm *restrict tm);
-double _emscripten_date_now();
 double emscripten_get_now_res();
 
 __attribute__((__weak__))
@@ -70,14 +70,14 @@ __attribute__((__weak__))
 clock_t __clock() {
   static thread_local double start = 0;
   if (!start) {
-    start = _emscripten_date_now();
+    start = emscripten_date_now();
   }
-  return (_emscripten_date_now() - start) * (CLOCKS_PER_SEC / 1000);
+  return (emscripten_date_now() - start) * (CLOCKS_PER_SEC / 1000);
 }
 
 __attribute__((__weak__))
 time_t __time(time_t *t) {
-  double ret = _emscripten_date_now() / 1000;
+  double ret = emscripten_date_now() / 1000;
   if (t) {
     *t = ret;
   }
@@ -97,7 +97,7 @@ int __clock_gettime(clockid_t clk, struct timespec *ts) {
 
   double now_ms;
   if (clk == CLOCK_REALTIME) {
-    now_ms = _emscripten_date_now();
+    now_ms = emscripten_date_now();
   } else if ((clk == CLOCK_MONOTONIC || clk == CLOCK_MONOTONIC_RAW) && is_monotonic) {
     now_ms = emscripten_get_now();
   } else {
@@ -134,7 +134,7 @@ int __clock_getres(clockid_t clk, struct timespec *ts) {
 
 __attribute__((__weak__))
 int __gettimeofday(struct timeval *restrict tv, void *restrict tz) {
-  double now_ms = _emscripten_date_now();
+  double now_ms = emscripten_date_now();
   long long now_s = now_ms / 1000;
   tv->tv_sec = now_s; // seconds
   tv->tv_usec = (now_ms - (now_s * 1000)) * 1000; // nicroseconds


### PR DESCRIPTION
For some reason we had both a public API and a private one for this, but
they are identical.

The prefixed version also had the wrong signature - it returns double.