### PR TITLE
[WasmFS] Report errors from `getSize`

### DIFF
--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -137,7 +137,7 @@ public:
     : DataFile(mode, backend), state(path) {}
 
 private:
-  size_t getSize() override {
+  off_t getSize() override {
     // TODO: This should really be using a 64-bit file size type.
     uint32_t size;
     if (state.isOpen()) {
@@ -151,10 +151,10 @@ private:
         return 0;
       }
     }
-    return size_t(size);
+    return off_t(size);
   }
 
-  int setSize(size_t size) override {
+  int setSize(off_t size) override {
     WASMFS_UNREACHABLE("TODO: implement NodeFile::setSize");
   }
 

--- a/system/lib/wasmfs/backends/proxied_file_backend.cpp
+++ b/system/lib/wasmfs/backends/proxied_file_backend.cpp
@@ -51,13 +51,13 @@ class ProxiedFile : public DataFile {
 
   // Querying the size of the Proxied File returns the size of the underlying
   // file given by the proxying mechanism.
-  size_t getSize() override {
-    size_t result;
+  off_t getSize() override {
+    off_t result;
     proxy([&]() { result = baseFile->locked().getSize(); });
     return result;
   }
 
-  int setSize(size_t size) override {
+  int setSize(off_t size) override {
     WASMFS_UNREACHABLE("TODO: ProxiedFS setSize");
   }
 

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -101,8 +101,9 @@ protected:
   // A mutex is needed for multiple accesses to the same file.
   std::recursive_mutex mutex;
 
-  // May be called on files that have not been opened.
-  virtual size_t getSize() = 0;
+  // The the size in bytes of a file or return a negative error code. May be
+  // called on files that have not been opened.
+  virtual off_t getSize() = 0;
 
   mode_t mode = 0; // User and group mode bits for access permission.
 
@@ -144,7 +145,7 @@ protected:
   // Sets the size of the file to a specific size. If new space is allocated, it
   // should be zero-initialized. May be called on files that have not been
   // opened. Returns 0 on success or a negative error code.
-  virtual int setSize(size_t size) = 0;
+  virtual int setSize(off_t size) = 0;
 
   // Sync the file data to the underlying persistent storage, if any. Returns 0
   // on success or a negative error code.
@@ -254,7 +255,7 @@ public:
 protected:
   // 4096 bytes is the size of a block in ext4.
   // This value was also copied from the JS file system.
-  size_t getSize() override { return 4096; }
+  off_t getSize() override { return 4096; }
 };
 
 class Symlink : public File {
@@ -270,7 +271,7 @@ public:
   virtual std::string getTarget() const = 0;
 
 protected:
-  size_t getSize() override { return getTarget().size(); }
+  off_t getSize() override { return getTarget().size(); }
 };
 
 class File::Handle {
@@ -286,7 +287,7 @@ public:
   Handle(std::shared_ptr<File> file) : file(file), lock(file->mutex) {}
   Handle(std::shared_ptr<File> file, std::defer_lock_t)
     : file(file), lock(file->mutex, std::defer_lock) {}
-  size_t getSize() { return file->getSize(); }
+  off_t getSize() { return file->getSize(); }
   mode_t getMode() { return file->mode; }
   void setMode(mode_t mode) {
     // The type bits can never be changed (whether something is a file or a
@@ -325,7 +326,7 @@ public:
     return getFile()->write(buf, len, offset);
   }
 
-  [[nodiscard]] int setSize(size_t size) { return getFile()->setSize(size); }
+  [[nodiscard]] int setSize(off_t size) { return getFile()->setSize(size); }
 
   // TODO: Design a proper API for flushing files.
   [[nodiscard]] int flush() { return getFile()->flush(); }

--- a/system/lib/wasmfs/js_impl_backend.h
+++ b/system/lib/wasmfs/js_impl_backend.h
@@ -96,11 +96,11 @@ class JSImplFile : public DataFile {
 
   int flush() override { return 0; }
 
-  size_t getSize() override {
+  off_t getSize() override {
     return _wasmfs_jsimpl_get_size(getBackendIndex(), getFileIndex());
   }
 
-  int setSize(size_t size) override {
+  int setSize(off_t size) override {
     WASMFS_UNREACHABLE("TODO: JSImpl setSize");
   }
 

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -24,8 +24,8 @@ class MemoryFile : public DataFile {
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override;
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override;
   int flush() override { return 0; }
-  size_t getSize() override { return buffer.size(); }
-  int setSize(size_t size) override {
+  off_t getSize() override { return buffer.size(); }
+  int setSize(off_t size) override {
     buffer.resize(size);
     return 0;
   }

--- a/system/lib/wasmfs/pipe_backend.h
+++ b/system/lib/wasmfs/pipe_backend.h
@@ -46,10 +46,10 @@ class PipeFile : public DataFile {
 
   int flush() override { return 0; }
 
-  size_t getSize() override { return data->size(); }
+  off_t getSize() override { return data->size(); }
 
   // TODO: Should this return an error?
-  int setSize(size_t size) override { return 0; }
+  int setSize(off_t size) override { return 0; }
 
 public:
   // PipeFiles do not have or need a backend. Pass NullBackend to the parent for

--- a/system/lib/wasmfs/proxied_async_js_impl_backend.h
+++ b/system/lib/wasmfs/proxied_async_js_impl_backend.h
@@ -66,7 +66,7 @@ void _wasmfs_jsimpl_async_read(em_proxying_ctx* ctx,
 void _wasmfs_jsimpl_async_get_size(em_proxying_ctx* ctx,
                                    js_index_t backend,
                                    js_index_t index,
-                                   size_t* result);
+                                   off_t* result);
 }
 
 namespace wasmfs {
@@ -108,8 +108,8 @@ class ProxiedAsyncJSImplFile : public DataFile {
 
   int flush() override { return 0; }
 
-  size_t getSize() override {
-    size_t result;
+  off_t getSize() override {
+    off_t result;
     proxy([&](auto ctx) {
       _wasmfs_jsimpl_async_get_size(
         ctx.ctx, getBackendIndex(), getFileIndex(), &result);
@@ -117,7 +117,7 @@ class ProxiedAsyncJSImplFile : public DataFile {
     return result;
   }
 
-  int setSize(size_t size) override {
+  int setSize(off_t size) override {
     WASMFS_UNREACHABLE("TODO: ProxiedAsyncJSImplFile setSize");
   }
 

--- a/system/lib/wasmfs/special_files.cpp
+++ b/system/lib/wasmfs/special_files.cpp
@@ -29,8 +29,8 @@ class NullFile : public DataFile {
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override { return 0; }
 
   int flush() override { return 0; }
-  size_t getSize() override { return 0; }
-  int setSize(size_t size) override { return -EPERM; }
+  off_t getSize() override { return 0; }
+  int setSize(off_t size) override { return -EPERM; }
 
 public:
   NullFile() : DataFile(S_IRUGO | S_IWUGO, NullBackend, S_IFCHR) {}
@@ -50,8 +50,8 @@ class StdinFile : public DataFile {
   };
 
   int flush() override { return 0; }
-  size_t getSize() override { return 0; }
-  int setSize(size_t size) override { return -EPERM; }
+  off_t getSize() override { return 0; }
+  int setSize(off_t size) override { return -EPERM; }
 
 public:
   StdinFile() : DataFile(S_IRUGO, NullBackend, S_IFCHR) { seekable = false; }
@@ -78,8 +78,8 @@ protected:
     return 0;
   }
 
-  size_t getSize() override { return 0; }
-  int setSize(size_t size) override { return -EPERM; }
+  off_t getSize() override { return 0; }
+  int setSize(off_t size) override { return -EPERM; }
 
   ssize_t writeToJS(const uint8_t* buf,
                     size_t len,
@@ -152,8 +152,8 @@ class RandomFile : public DataFile {
   };
 
   int flush() override { return 0; }
-  size_t getSize() override { return 0; }
-  int setSize(size_t size) override { return -EPERM; }
+  off_t getSize() override { return 0; }
+  int setSize(off_t size) override { return -EPERM; }
 
 public:
   RandomFile() : DataFile(S_IRUGO, NullBackend, S_IFCHR) { seekable = false; }


### PR DESCRIPTION
Update the return type of `getSize` from `size_t` to `off_t`, which allows for
negative error codes. `off_t` is more correct anyway, since in 32-bit mode
it is possible for a file size to be greater than the max value of `size_t`.
Also update the argument to `getSize` from `size_t` to `off_t` to match.

I manually verified that this error handling works with an injected error, but I
was not able to create a test that could trigger the error naturally.