### PR TITLE
[WasmFS] Allow `move` to return specific error codes

### DIFF
--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -187,12 +187,16 @@ mergeInto(LibraryManager.library, {
 
   _wasmfs_opfs_move__deps: ['$wasmfsOPFSFileHandles',
                             '$wasmfsOPFSDirectoryHandles'],
-  _wasmfs_opfs_move: async function(ctx, fileID, newDirID, namePtr) {
+  _wasmfs_opfs_move: async function(ctx, fileID, newDirID, namePtr, errPtr) {
     let name = UTF8ToString(namePtr);
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     let newDirHandle = wasmfsOPFSDirectoryHandles.get(newDirID);
-    // TODO: error handling
-    await fileHandle.move(newDirHandle, name);
+    try {
+      await fileHandle.move(newDirHandle, name);
+    } catch {
+      let err = -{{{ cDefine('EIO') }}};
+      {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
+    }
     _emscripten_proxy_finish(ctx);
   },
 

--- a/system/lib/wasmfs/backends/memory_backend.cpp
+++ b/system/lib/wasmfs/backends/memory_backend.cpp
@@ -63,8 +63,8 @@ std::vector<Directory::Entry> MemoryDirectory::getEntries() {
   return result;
 }
 
-bool MemoryDirectory::insertMove(const std::string& name,
-                                 std::shared_ptr<File> file) {
+int MemoryDirectory::insertMove(const std::string& name,
+                                std::shared_ptr<File> file) {
   auto& oldEntries =
     std::static_pointer_cast<MemoryDirectory>(file->locked().getParent())
       ->entries;
@@ -76,7 +76,7 @@ bool MemoryDirectory::insertMove(const std::string& name,
   }
   removeChild(name);
   insertChild(name, file);
-  return true;
+  return 0;
 }
 
 std::string MemoryDirectory::getName(std::shared_ptr<File> file) {

--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -256,8 +256,7 @@ private:
     abort();
   }
 
-  bool insertMove(const std::string& name,
-                  std::shared_ptr<File> file) override {
+  int insertMove(const std::string& name, std::shared_ptr<File> file) override {
     // TODO
     abort();
   }

--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -137,7 +137,7 @@ public:
     : DataFile(mode, backend), state(path) {}
 
 private:
-  size_t getSize() override {
+  off_t getSize() override {
     // TODO: This should really be using a 64-bit file size type.
     uint32_t size;
     if (state.isOpen()) {
@@ -151,10 +151,10 @@ private:
         return 0;
       }
     }
-    return size_t(size);
+    return off_t(size);
   }
 
-  int setSize(size_t size) override {
+  int setSize(off_t size) override {
     WASMFS_UNREACHABLE("TODO: implement NodeFile::setSize");
   }
 

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -42,7 +42,8 @@ void _wasmfs_opfs_insert_directory(em_proxying_ctx* ctx,
 void _wasmfs_opfs_move(em_proxying_ctx* ctx,
                        int file_id,
                        int new_dir_id,
-                       const char* name);
+                       const char* name,
+                       int* err);
 
 void _wasmfs_opfs_remove_child(em_proxying_ctx* ctx,
                                int dir_id,
@@ -401,14 +402,13 @@ private:
     return nullptr;
   }
 
-  bool insertMove(const std::string& name,
-                  std::shared_ptr<File> file) override {
+  int insertMove(const std::string& name, std::shared_ptr<File> file) override {
     auto old_file = std::static_pointer_cast<OPFSFile>(file);
+    int err = 0;
     proxy([&](auto ctx) {
-      _wasmfs_opfs_move(ctx.ctx, old_file->fileID, dirID, name.c_str());
+      _wasmfs_opfs_move(ctx.ctx, old_file->fileID, dirID, name.c_str(), &err);
     });
-    // TODO: Handle errors.
-    return true;
+    return err;
   }
 
   bool removeChild(const std::string& name) override {

--- a/system/lib/wasmfs/backends/proxied_file_backend.cpp
+++ b/system/lib/wasmfs/backends/proxied_file_backend.cpp
@@ -51,13 +51,13 @@ class ProxiedFile : public DataFile {
 
   // Querying the size of the Proxied File returns the size of the underlying
   // file given by the proxying mechanism.
-  size_t getSize() override {
-    size_t result;
+  off_t getSize() override {
+    off_t result;
     proxy([&]() { result = baseFile->locked().getSize(); });
     return result;
   }
 
-  int setSize(size_t size) override {
+  int setSize(off_t size) override {
     WASMFS_UNREACHABLE("TODO: ProxiedFS setSize");
   }
 

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -143,11 +143,11 @@ Directory::Handle::insertSymlink(const std::string& name,
 // TODO: consider moving this to be `Backend::move` to avoid asymmetry between
 // the source and destination directories and/or taking `Directory::Handle`
 // arguments to prove that the directories have already been locked.
-bool Directory::Handle::insertMove(const std::string& name,
-                                   std::shared_ptr<File> file) {
+int Directory::Handle::insertMove(const std::string& name,
+                                  std::shared_ptr<File> file) {
   // Cannot insert into an unlinked directory.
   if (!getParent()) {
-    return false;
+    return -EPERM;
   }
 
   // Look up the file in its old parent's cache.
@@ -161,8 +161,8 @@ bool Directory::Handle::insertMove(const std::string& name,
   // involving the backend.
 
   // Attempt the move.
-  if (!getDir()->insertMove(name, file)) {
-    return false;
+  if (auto err = getDir()->insertMove(name, file)) {
+    return err;
   }
 
   if (oldIt != oldCache.end()) {
@@ -189,7 +189,7 @@ bool Directory::Handle::insertMove(const std::string& name,
   oldParent->locked().setMTime(now);
   setMTime(now);
 
-  return true;
+  return 0;
 }
 
 bool Directory::Handle::removeChild(const std::string& name) {

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -101,8 +101,9 @@ protected:
   // A mutex is needed for multiple accesses to the same file.
   std::recursive_mutex mutex;
 
-  // May be called on files that have not been opened.
-  virtual size_t getSize() = 0;
+  // The the size in bytes of a file or return a negative error code. May be
+  // called on files that have not been opened.
+  virtual off_t getSize() = 0;
 
   mode_t mode = 0; // User and group mode bits for access permission.
 
@@ -144,7 +145,7 @@ protected:
   // Sets the size of the file to a specific size. If new space is allocated, it
   // should be zero-initialized. May be called on files that have not been
   // opened. Returns 0 on success or a negative error code.
-  virtual int setSize(size_t size) = 0;
+  virtual int setSize(off_t size) = 0;
 
   // Sync the file data to the underlying persistent storage, if any. Returns 0
   // on success or a negative error code.
@@ -254,7 +255,7 @@ public:
 protected:
   // 4096 bytes is the size of a block in ext4.
   // This value was also copied from the JS file system.
-  size_t getSize() override { return 4096; }
+  off_t getSize() override { return 4096; }
 };
 
 class Symlink : public File {
@@ -270,7 +271,7 @@ public:
   virtual std::string getTarget() const = 0;
 
 protected:
-  size_t getSize() override { return getTarget().size(); }
+  off_t getSize() override { return getTarget().size(); }
 };
 
 class File::Handle {
@@ -286,7 +287,7 @@ public:
   Handle(std::shared_ptr<File> file) : file(file), lock(file->mutex) {}
   Handle(std::shared_ptr<File> file, std::defer_lock_t)
     : file(file), lock(file->mutex, std::defer_lock) {}
-  size_t getSize() { return file->getSize(); }
+  off_t getSize() { return file->getSize(); }
   mode_t getMode() { return file->mode; }
   void setMode(mode_t mode) {
     // The type bits can never be changed (whether something is a file or a
@@ -325,7 +326,7 @@ public:
     return getFile()->write(buf, len, offset);
   }
 
-  [[nodiscard]] int setSize(size_t size) { return getFile()->setSize(size); }
+  [[nodiscard]] int setSize(off_t size) { return getFile()->setSize(size); }
 
   // TODO: Design a proper API for flushing files.
   [[nodiscard]] int flush() { return getFile()->flush(); }

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -203,10 +203,10 @@ protected:
   // Move the file represented by `file` from its current directory to this
   // directory with the new `name`, possibly overwriting another file that
   // already exists with that name. The old directory may be the same as this
-  // directory. On success, return `true`. Otherwise return `false` without
-  // changing any underlying state.
-  virtual bool insertMove(const std::string& name,
-                          std::shared_ptr<File> file) = 0;
+  // directory. On success return 0 and otherwise return a negative error code
+  // without changing any underlying state.
+  virtual int insertMove(const std::string& name,
+                         std::shared_ptr<File> file) = 0;
 
   // Remove the file with the given name, returning `true` on success or if the
   // child has already been removed or returning `false` if the child cannot be
@@ -371,10 +371,11 @@ public:
   // Move the file represented by `file` from its current directory to this
   // directory with the new `name`, possibly overwriting another file that
   // already exists with that name. The old directory may be the same as this
-  // directory. On success, return `true`. Otherwise return `false` without
-  // changing any underlying state. This should only be called from renameat
-  // with the locks on the old and new parents already held.
-  bool insertMove(const std::string& name, std::shared_ptr<File> file);
+  // directory. On success return 0 and otherwise return a negative error code
+  // without changing any underlying state. This should only be called from
+  // renameat with the locks on the old and new parents already held.
+  [[nodiscard]] int insertMove(const std::string& name,
+                               std::shared_ptr<File> file);
 
   // Remove the file with the given name, returning `true` on success or if the
   // vhild has already been removed or returning `false` if the child cannot be

--- a/system/lib/wasmfs/js_impl_backend.h
+++ b/system/lib/wasmfs/js_impl_backend.h
@@ -96,11 +96,11 @@ class JSImplFile : public DataFile {
 
   int flush() override { return 0; }
 
-  size_t getSize() override {
+  off_t getSize() override {
     return _wasmfs_jsimpl_get_size(getBackendIndex(), getFileIndex());
   }
 
-  int setSize(size_t size) override {
+  int setSize(off_t size) override {
     WASMFS_UNREACHABLE("TODO: JSImpl setSize");
   }
 

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -24,8 +24,8 @@ class MemoryFile : public DataFile {
   ssize_t write(const uint8_t* buf, size_t len, off_t offset) override;
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override;
   int flush() override { return 0; }
-  size_t getSize() override { return buffer.size(); }
-  int setSize(size_t size) override {
+  off_t getSize() override { return buffer.size(); }
+  int setSize(off_t size) override {
     buffer.resize(size);
     return 0;
   }

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -86,7 +86,7 @@ protected:
     return child;
   }
 
-  bool insertMove(const std::string& name, std::shared_ptr<File> file) override;
+  int insertMove(const std::string& name, std::shared_ptr<File> file) override;
 
   size_t getNumEntries() override { return entries.size(); }
   std::vector<Directory::Entry> getEntries() override;

--- a/system/lib/wasmfs/pipe_backend.h
+++ b/system/lib/wasmfs/pipe_backend.h
@@ -46,10 +46,10 @@ class PipeFile : public DataFile {
 
   int flush() override { return 0; }
 
-  size_t getSize() override { return data->size(); }
+  off_t getSize() override { return data->size(); }
 
   // TODO: Should this return an error?
-  int setSize(size_t size) override { return 0; }
+  int setSize(off_t size) override { return 0; }
 
 public:
   // PipeFiles do not have or need a backend. Pass NullBackend to the parent for

--- a/system/lib/wasmfs/proxied_async_js_impl_backend.h
+++ b/system/lib/wasmfs/proxied_async_js_impl_backend.h
@@ -66,7 +66,7 @@ void _wasmfs_jsimpl_async_read(em_proxying_ctx* ctx,
 void _wasmfs_jsimpl_async_get_size(em_proxying_ctx* ctx,
                                    js_index_t backend,
                                    js_index_t index,
-                                   size_t* result);
+                                   off_t* result);
 }
 
 namespace wasmfs {
@@ -108,8 +108,8 @@ class ProxiedAsyncJSImplFile : public DataFile {
 
   int flush() override { return 0; }
 
-  size_t getSize() override {
-    size_t result;
+  off_t getSize() override {
+    off_t result;
     proxy([&](auto ctx) {
       _wasmfs_jsimpl_async_get_size(
         ctx.ctx, getBackendIndex(), getFileIndex(), &result);
@@ -117,7 +117,7 @@ class ProxiedAsyncJSImplFile : public DataFile {
     return result;
   }
 
-  int setSize(size_t size) override {
+  int setSize(off_t size) override {
     WASMFS_UNREACHABLE("TODO: ProxiedAsyncJSImplFile setSize");
   }
 

--- a/system/lib/wasmfs/special_files.cpp
+++ b/system/lib/wasmfs/special_files.cpp
@@ -29,8 +29,8 @@ class NullFile : public DataFile {
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override { return 0; }
 
   int flush() override { return 0; }
-  size_t getSize() override { return 0; }
-  int setSize(size_t size) override { return -EPERM; }
+  off_t getSize() override { return 0; }
+  int setSize(off_t size) override { return -EPERM; }
 
 public:
   NullFile() : DataFile(S_IRUGO | S_IWUGO, NullBackend, S_IFCHR) {}
@@ -50,8 +50,8 @@ class StdinFile : public DataFile {
   };
 
   int flush() override { return 0; }
-  size_t getSize() override { return 0; }
-  int setSize(size_t size) override { return -EPERM; }
+  off_t getSize() override { return 0; }
+  int setSize(off_t size) override { return -EPERM; }
 
 public:
   StdinFile() : DataFile(S_IRUGO, NullBackend, S_IFCHR) { seekable = false; }
@@ -78,8 +78,8 @@ protected:
     return 0;
   }
 
-  size_t getSize() override { return 0; }
-  int setSize(size_t size) override { return -EPERM; }
+  off_t getSize() override { return 0; }
+  int setSize(off_t size) override { return -EPERM; }
 
   ssize_t writeToJS(const uint8_t* buf,
                     size_t len,
@@ -152,8 +152,8 @@ class RandomFile : public DataFile {
   };
 
   int flush() override { return 0; }
-  size_t getSize() override { return 0; }
-  int setSize(size_t size) override { return -EPERM; }
+  off_t getSize() override { return 0; }
+  int setSize(off_t size) override { return -EPERM; }
 
 public:
   RandomFile() : DataFile(S_IRUGO, NullBackend, S_IFCHR) { seekable = false; }

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -604,16 +604,14 @@ doMkdir(path::ParsedParent parsed, int mode, backend_t backend = NullBackend) {
     backend = parent->getBackend();
   }
 
-  std::shared_ptr<File> created;
   if (backend == parent->getBackend()) {
-    created = lockedParent.insertDirectory(childName, mode);
-    if (!created) {
+    if (!lockedParent.insertDirectory(childName, mode)) {
       // TODO Receive a specific error code, and report it here. For now, report
       //      a generic error.
       return -EIO;
     }
   } else {
-    created = backend->createDirectory(mode);
+    auto created = backend->createDirectory(mode);
     if (!created) {
       // TODO Receive a specific error code, and report it here. For now, report
       //      a generic error.

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1014,8 +1014,8 @@ int __syscall_renameat(int olddirfd,
   }
 
   // Perform the move.
-  if (!lockedNewParent.insertMove(newFileName, oldFile)) {
-    return -EPERM;
+  if (auto err = lockedNewParent.insertMove(newFileName, oldFile)) {
+    return err;
   }
   return 0;
 }


### PR DESCRIPTION
It already supporting returning errors via a `bool`, but it is better to be able
to return precise errors. Also catch and return errors in the OPFS backend,
which did not previously do any error handling for moves.

Tested manually via an error injected into the OPFS backend since I don't know a
way to get the `move` method on the FileSystemFileHandle to reliably fail in a
way that wouldn't cause the syscall implementation to bail out earlier.