### PR TITLE
[WasmFS][NFC] Assert that error codes are negative

### DIFF
--- a/system/lib/wasmfs/file_table.cpp
+++ b/system/lib/wasmfs/file_table.cpp
@@ -41,6 +41,7 @@ int FileTable::Handle::setEntry(__wasi_fd_t fd,
     auto file = fileTable.entries[fd]->locked().getFile();
     if (auto f = file->dynCast<DataFile>()) {
       ret = f->locked().close();
+      assert(ret <= 0);
     }
   }
   fileTable.entries[fd] = openFile;


### PR DESCRIPTION
To catch mistakes in backend implementations, assert where possible that error
codes are negative.