### PR TITLE
fixed pthread_create crash introduced in commit ba4c5f1455e508d298b7bbf49790ad3c02a1…

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -648,7 +648,7 @@ var LibraryPThread = {
 
     var offscreenCanvases = {}; // Dictionary of OffscreenCanvas objects we'll transfer to the created thread to own
     var moduleCanvasId = Module['canvas'] ? Module['canvas'].id : '';
-    for (var name of transferredCanvasNames) {
+    if (transferredCanvasNames) for (var name of transferredCanvasNames) {
       name = name.trim();
       var offscreenCanvasInfo;
       try {


### PR DESCRIPTION
When thread is created while app is already running `transferredCanvasNames` variable equals zero and this loop
`for (var name of transferredCanvasNames)` causes exception:
```
TypeError: transferredCanvasNames is not iterable
    at ___pthread_create_js
```
Previous old-style `for (var i in transferredCanvasNames)` loop does not cause exception if transferredCanvasNames equals zero