### PR TITLE
Revert "GitHub Workflows security hardening"

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -8,9 +8,6 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
-
 jobs:
   archive:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts emscripten-core/emscripten#17764

Browser CI has gotten very flakey since this landed. Perhaps that's a coincidence, but
let's see if a reversion makes a difference. If so perhaps we should land this.