### PR TITLE
Fix generateDyncall when there is more than one 64 bit argument

### DIFF
--- a/src/library_makeDynCall.js
+++ b/src/library_makeDynCall.js
@@ -19,7 +19,7 @@ mergeInto(LibraryManager.library, {
       "i", // The first argument is the function pointer to call
       // in the rest of the argument list, one 64 bit integer is legalized into
       // two 32 bit integers.
-      sig.slice(1).replace("j", "ii"),
+      sig.slice(1).split("").map(x => x === "j" ? "ii" : x).join("")
     ].join("");
 
     var typeSectionBody = [

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12454,9 +12454,14 @@ Module['postRun'] = function() {{
     self.do_runf('main.c', 'warning: foo\ndone\n')
 
   def test_dyncallwrapper(self):
-    self.set_setting('MAIN_MODULE', 1)
-    expected = "2 7\ni: 2 j: 8589934599 f: 3.120000 d: 77.120000"
-    self.do_runf(test_file('test_runtime_dyncall_wrapper.c'), expected)
+    self.set_setting("MAIN_MODULE", 1)
+    expected = """\
+2 7
+i: 2 j: 8589934599 f: 3.120000 d: 77.120000
+j1: 8589934599, j2: 30064771074, j3: 12884901891
+"""
+    self.do_runf(test_file("test_runtime_dyncall_wrapper.c"), expected)
+
 
   def test_compile_with_cache_lock(self):
     # Verify that, after warming the cache, running emcc does not require the cache lock.

--- a/test/test_runtime_dyncall_wrapper.c
+++ b/test/test_runtime_dyncall_wrapper.c
@@ -10,6 +10,10 @@ void f2(int i, uint64_t j, float f, double d){
     printf("i: %d j: %lld f: %f d: %lf\n", i, j, f, d);
 }
 
+void f3(uint64_t j1, uint64_t j2, uint64_t j3){
+    printf("j1: %lld, j2: %lld, j3: %lld\n", j1, j2, j3);
+}
+
 
 int main(){
     EM_ASM({
@@ -21,4 +25,9 @@ int main(){
         var w = createDyncallWrapper("vijfd");
         w($0, 2, 7, 2, 3.12, 77.12);
     }, f2);
+
+    EM_ASM({
+        var w = createDyncallWrapper("vjjj");
+        w($0, 7, 2, 2, 7, 3, 3);
+    }, f3);
 }


### PR DESCRIPTION
`replace("j", "ii")` only replaces the first "j". For some reason node has no `replaceAll` so I used split + map. So the original code broke when there is more than one 64 bit argument.