### PR TITLE
wasm2js: Pass info object directly to wasm2js-generated code. NFC

### DIFF
--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -63,10 +63,10 @@ WebAssembly = {
 
   /** @constructor */
   Instance: function(module, info) {
-    // TODO: use the module and info somehow - right now the wasm2js output is embedded in
+    // TODO: use the module somehow - right now the wasm2js output is embedded in
     // the main JS
     // This will be replaced by the actual wasm2js code.
-    this.exports = Module['__wasm2jsInstantiate__'](asmLibraryArg);
+    this.exports = Module['__wasm2jsInstantiate__'](info);
   },
 
   instantiate: /** @suppress{checkTypes} */ function(binary, info) {
@@ -77,7 +77,7 @@ WebAssembly = {
 #if SHARED_MEMORY
           'module': module,
 #endif
-          'instance': new WebAssembly.Instance(module)
+          'instance': new WebAssembly.Instance(module, info)
         });
 #if ASSERTIONS || WASM == 2 // see postamble_minimal.js which uses .catch
         // Emulate a simple WebAssembly.instantiate(..).then(()=>{}).catch(()=>{}) syntax.

--- a/test/code_size/hello_webgl2_wasm2js.json
+++ b/test/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 18076,
-  "a.js.gz": 7984,
+  "a.js": 18179,
+  "a.js.gz": 8064,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 21814,
-  "total_gz": 11077
+  "total": 21917,
+  "total_gz": 11157
 }

--- a/test/code_size/hello_webgl_wasm2js.json
+++ b/test/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 17547,
-  "a.js.gz": 7834,
+  "a.js": 17651,
+  "a.js.gz": 7888,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 21285,
-  "total_gz": 10927
+  "total": 21389,
+  "total_gz": 10981
 }

--- a/test/code_size/hello_world_wasm2js.json
+++ b/test/code_size/hello_world_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 671,
   "a.html.gz": 430,
-  "a.js": 613,
-  "a.js.gz": 389,
+  "a.js": 710,
+  "a.js.gz": 435,
   "a.mem": 6,
   "a.mem.gz": 32,
-  "total": 1290,
-  "total_gz": 851
+  "total": 1387,
+  "total_gz": 897
 }

--- a/test/code_size/random_printf_wasm2js.json
+++ b/test/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17337,
-  "a.html.gz": 7512,
-  "total": 17337,
-  "total_gz": 7512
+  "a.html": 17444,
+  "a.html.gz": 7564,
+  "total": 17444,
+  "total_gz": 7564
 }


### PR DESCRIPTION
Depends on https://github.com/WebAssembly/binaryen/pull/5018

See #17737