### PR TITLE
[WasmFS] Return errors from `getEntries` and `getNumEntries`

### DIFF
--- a/system/lib/wasmfs/backends/memory_backend.cpp
+++ b/system/lib/wasmfs/backends/memory_backend.cpp
@@ -54,13 +54,13 @@ int MemoryDirectory::removeChild(const std::string& name) {
   return 0;
 }
 
-std::vector<Directory::Entry> MemoryDirectory::getEntries() {
+Directory::MaybeEntries MemoryDirectory::getEntries() {
   std::vector<Directory::Entry> result;
   result.reserve(entries.size());
   for (auto& [name, child] : entries) {
     result.push_back({name, child->kind, child->getIno()});
   }
-  return result;
+  return {result};
 }
 
 int MemoryDirectory::insertMove(const std::string& name,

--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -258,21 +258,22 @@ private:
     abort();
   }
 
-  size_t getNumEntries() override {
+  ssize_t getNumEntries() override {
     // TODO: optimize this?
-    return getEntries().size();
+    auto entries = getEntries();
+    if (int err = entries.getError()) {
+      return err;
+    }
+    return entries->size();
   }
 
-  std::vector<Directory::Entry> getEntries() override {
+  Directory::MaybeEntries getEntries() override {
     std::vector<Directory::Entry> entries;
     int err = _wasmfs_node_readdir(state.path.c_str(), &entries);
-    // TODO: Make this fallible. We actually depend on suppressing the error
-    //       here to pass test_unlink_wasmfs_node because the File stored in the
-    //       file table is not the same File that had its parent pointer reset
-    //       during the unlink. Fixing this may require caching Files at some
-    //       layer to ensure they are the same.
-    (void)err;
-    return entries;
+    if (err) {
+      return {-err};
+    }
+    return {entries};
   }
 };
 

--- a/system/lib/wasmfs/file_table.cpp
+++ b/system/lib/wasmfs/file_table.cpp
@@ -41,6 +41,7 @@ int FileTable::Handle::setEntry(__wasi_fd_t fd,
     auto file = fileTable.entries[fd]->locked().getFile();
     if (auto f = file->dynCast<DataFile>()) {
       ret = f->locked().close();
+      assert(ret <= 0);
     }
   }
   fileTable.entries[fd] = openFile;

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -88,8 +88,8 @@ protected:
 
   int insertMove(const std::string& name, std::shared_ptr<File> file) override;
 
-  size_t getNumEntries() override { return entries.size(); }
-  std::vector<Directory::Entry> getEntries() override;
+  ssize_t getNumEntries() override { return entries.size(); }
+  Directory::MaybeEntries getEntries() override;
 
   std::string getName(std::shared_ptr<File> file) override;
 

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -879,7 +879,10 @@ int __syscall_getdents64(int fd, intptr_t dirp, size_t count) {
     {".", File::DirectoryKind, dir->getIno()},
     {"..", File::DirectoryKind, parent->getIno()}};
   auto dirEntries = lockedDir.getEntries();
-  entries.insert(entries.end(), dirEntries.begin(), dirEntries.end());
+  if (int err = dirEntries.getError()) {
+    return err;
+  }
+  entries.insert(entries.end(), dirEntries->begin(), dirEntries->end());
 
   off_t bytesRead = 0;
   for (; index < entries.size() && bytesRead + sizeof(dirent) <= count;


### PR DESCRIPTION
Make the return type of `getEntries` a variant that can be either a vector of
entries as before or a negative error code. Update the return type of
`getNumEntries` to be a ssize_t so it can return negative error codes as well.
This caps the number of directory entries that can be reported at around two
billion, but that should be sufficient.

I have manually tested via an injected error that the error handling works
correctly for the OPFS backend, although I was not able to construct a test case
for this.