### PR TITLE
[WasmFS] Update file mtime on write

### DIFF
--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -166,6 +166,9 @@ static __wasi_errno_t writeAtOffset(OffsetHandling setOffset,
       lockedOpenFile.getFile()->isSeekable()) {
     lockedOpenFile.setPosition(offset + bytesWritten);
   }
+  if (bytesWritten) {
+    lockedFile.setMTime(time(NULL));
+  }
   return __WASI_ERRNO_SUCCESS;
 }
 


### PR DESCRIPTION
 - Fixes #17247.
 -  Set file mtime if any bytes were written.
 -  Add a test.