### PR TITLE
Explicitly set the C++ standard for several ports/libraries

### DIFF
--- a/tools/ports/libmodplug.py
+++ b/tools/ports/libmodplug.py
@@ -34,6 +34,7 @@ def get(ports, settings, shared):
       '-DREAL_IS_FLOAT',
       '-DHAVE_CONFIG_H',
       '-DSYM_VISIBILITY',
+      '-std=gnu++14',
       '-O2',
       '-fno-exceptions',
       '-ffast-math',

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -113,10 +113,11 @@ def get(ports, settings, shared):
       o = os.path.join(dest_path_src, src + '.o')
       shared.safe_ensure_dirs(os.path.dirname(o))
 
-      command = [shared.EMCC, '-c', c,
+      command = [shared.EMXX, '-c', c,
                  '-DNDEBUG',
                  '-DREGAL_LOG=0',  # Set to 1 if you need to have some logging info
                  '-DREGAL_MISSING=0',  # Set to 1 if you don't want to crash in case of missing GL implementation
+                 '-std=gnu++14',
                  '-fno-rtti',
                  '-fno-exceptions', # Disable exceptions (in STL containers mostly), as they are not used at all
                  '-O3',

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1214,6 +1214,7 @@ class libcxxabi(NoExceptLibrary, MTLibrary):
       '-Oz',
       '-D_LIBCXXABI_BUILDING_LIBRARY',
       '-DLIBCXXABI_NON_DEMANGLING_TERMINATE',
+      '-std=c++14',
     ]
   includes = ['system/lib/libcxx/src']
 


### PR DESCRIPTION
Specifically libc++abi, regal, and libmodplug
clang has updated its default C++ standard to C++17 and these libraries don't build with that standard. This explicitly sets the builds to C++14. Then we can let the change roll in, and update the libraries as desired.