### PR TITLE
Convert all ports to use `build_port`. NFC

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3285,8 +3285,8 @@ Module["preRun"].push(function () {
   def test_cocos2d_hello(self):
     # cocos2d build contains a bunch of warnings about tiff symbols being missing at link time:
     # e.g. warning: undefined symbol: TIFFClientOpen
-    cocos2d_root = os.path.join(ports.Ports.get_build_dir(), 'cocos2d')
-    preload_file = os.path.join(cocos2d_root, 'samples', 'HelloCpp', 'Resources') + '@'
+    cocos2d_root = os.path.join(ports.Ports.get_dir(), 'cocos2d', 'Cocos2d-version_3_3')
+    preload_file = os.path.join(cocos2d_root, 'samples', 'Cpp', 'HelloCpp', 'Resources') + '@'
     self.btest('cocos2d_hello.cpp', reference='cocos2d_hello.png', reference_slack=1,
                args=['-sUSE_COCOS2D=3', '-sERROR_ON_UNDEFINED_SYMBOLS=0',
                      '-Wno-js-compiler',

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -108,44 +108,38 @@ class Ports:
       shutil.copyfile(f, os.path.join(dest, os.path.basename(f)))
 
   @staticmethod
-  def build_port(src_path, output_path, includes=[], flags=[], exclude_files=[], exclude_dirs=[]):  # noqa
-    srcs = []
-    for root, _, files in os.walk(src_path, topdown=False):
-      if any((excluded in root) for excluded in exclude_dirs):
-        continue
-      for f in files:
-        ext = shared.suffix(f)
-        if ext in ('.c', '.cpp') and not any((excluded in f) for excluded in exclude_files):
-          srcs.append(os.path.join(root, f))
-    include_commands = ['-I' + src_path]
-    for include in includes:
-      include_commands.append('-I' + include)
+  def build_port(src_dir, output_path, build_dir, includes=[], flags=[], exclude_files=[], exclude_dirs=[], srcs=[]):  # noqa
+    if srcs:
+      srcs = [os.path.join(src_dir, s) for s in srcs]
+    else:
+      srcs = []
+      for root, _, files in os.walk(src_dir, topdown=False):
+        if any((excluded in root) for excluded in exclude_dirs):
+          continue
+        for f in files:
+          ext = shared.suffix(f)
+          if ext in ('.c', '.cpp') and not any((excluded in f) for excluded in exclude_files):
+            srcs.append(os.path.join(root, f))
 
+    cflags = system_libs.get_base_cflags() + ['-O2', '-w', '-I' + src_dir] + flags
+    for include in includes:
+      cflags.append('-I' + include)
+
+    if build_dir:
+      if not os.path.exists(build_dir):
+        os.makedirs(build_dir)
+      build_dir = src_dir
     commands = []
     objects = []
     for src in srcs:
-      obj = src + '.o'
-      commands.append([shared.EMCC, '-c', src, '-O2', '-o', obj, '-w'] + include_commands + flags)
+      relpath = os.path.relpath(src, src_dir)
+      obj = os.path.join(build_dir, relpath) + '.o'
+      commands.append([shared.EMCC, '-c', src, '-o', obj] + cflags)
       objects.append(obj)
 
-    Ports.run_commands(commands)
+    system_libs.run_build_commands(commands)
     system_libs.create_lib(output_path, objects)
     return output_path
-
-  @staticmethod
-  def run_commands(commands):
-    # Runs a sequence of compiler commands, adding importand cflags as defined by get_cflags() so
-    # that the ports are built in the correct configuration.
-    def add_args(cmd):
-      # this must only be called on a standard build command
-      assert cmd[0] in (shared.EMCC, shared.EMXX)
-      # add standard cflags, but also allow the cmd to override them
-      return cmd[:1] + system_libs.get_base_cflags() + cmd[1:]
-    system_libs.run_build_commands([add_args(c) for c in commands])
-
-  @staticmethod
-  def create_lib(libname, inputs): # make easily available for port objects
-    system_libs.create_lib(libname, inputs)
 
   @staticmethod
   def get_dir():

--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+from pathlib import Path
 
 TAG = '1.75.0'
 HASH = '8c38be1ebef1b8ada358ad6b7c9ec17f5e0a300e8085db3473a13e19712c95eeb3c3defacd3c53482eb96368987c4b022efa8da2aac2431a154e40153d3c3dcd'
@@ -20,7 +21,6 @@ def get(ports, settings, shared):
 
   def create(final):
     logging.info('building port: boost_headers')
-    build_dir = ports.clear_project_build('boost_headers')
 
     # includes
     source_path_include = os.path.join(ports.get_dir(), 'boost_headers', 'boost')
@@ -28,19 +28,12 @@ def get(ports, settings, shared):
 
     # write out a dummy cpp file, to create an empty library
     # this is needed as emscripted ports expect this, even if it is not used
+    build_dir = ports.clear_project_build('boost_headers')
     dummy_file = os.path.join(build_dir, 'dummy.cpp')
     shared.safe_ensure_dirs(os.path.dirname(dummy_file))
-    with open(dummy_file, 'w') as f:
-      f.write('static void dummy() {}')
+    Path(dummy_file).write_text('static void dummy() {}')
 
-    commands = []
-    o_s = []
-    obj = dummy_file + '.o'
-    command = [shared.EMCC, '-c', dummy_file, '-o', obj]
-    commands.append(command)
-    ports.run_commands(commands)
-    o_s.append(obj)
-    ports.create_lib(final, o_s)
+    ports.build_port(build_dir, final, build_dir)
 
   return [shared.Cache.get_lib('libboost_headers.a', create, what='port')]
 

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -23,8 +23,7 @@ def get(ports, settings, shared):
 
     source_path = os.path.join(ports.get_dir(), 'bullet', 'Bullet-' + TAG)
     dest_path = ports.clear_project_build('bullet')
-    shutil.copytree(source_path, dest_path)
-    src_path = os.path.join(dest_path, 'bullet', 'src')
+    src_path = os.path.join(source_path, 'bullet', 'src')
 
     dest_include_path = ports.get_include_dir('bullet')
     for base, _, files in os.walk(src_path):
@@ -42,8 +41,7 @@ def get(ports, settings, shared):
       for dir in dirs:
         includes.append(os.path.join(base, dir))
 
-    ports.build_port(src_path, final, includes=includes, exclude_dirs=['MiniCL'],
-                     flags=['-std=gnu++14'])
+    ports.build_port(src_path, final, dest_path, includes=includes, exclude_dirs=['MiniCL'], flags=['-std=gnu++14'])
 
   return [shared.Cache.get_lib('libbullet.a', create)]
 

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 
 VERSION = '1.0.6'
 HASH = '512cbfde5144067f677496452f3335e9368fd5d7564899cb49e77847b9ae7dca598218276637cbf5ec524523be1e8ace4ad36a148ef7f4badf3f6d5a002a4bb2'
@@ -18,26 +17,16 @@ def get(ports, settings, shared):
   ports.fetch_project('bzip2', 'https://github.com/emscripten-ports/bzip2/archive/' + VERSION + '.zip', 'bzip2-' + VERSION, sha512hash=HASH)
 
   def create(final):
-    dest_path = ports.clear_project_build('bzip2')
     source_path = os.path.join(ports.get_dir(), 'bzip2', 'bzip2-' + VERSION)
-    shutil.copytree(source_path, dest_path)
+    ports.install_headers(source_path)
 
     # build
     srcs = [
       'blocksort.c', 'compress.c', 'decompress.c', 'huffman.c',
       'randtable.c', 'bzlib.c', 'crctable.c',
     ]
-    commands = []
-    o_s = []
-    for src in srcs:
-      o = os.path.join(dest_path, shared.replace_suffix(src, '.o'))
-      shared.safe_ensure_dirs(os.path.dirname(o))
-      commands.append([shared.EMCC, '-c', os.path.join(dest_path, src), '-O2', '-o', o, '-I' + dest_path, '-w', ])
-      o_s.append(o)
-    ports.run_commands(commands)
-
-    ports.create_lib(final, o_s)
-    ports.install_headers(source_path)
+    dest_path = ports.clear_project_build('bzip2')
+    ports.build_port(source_path, final, dest_path, srcs=srcs)
 
   return [shared.Cache.get_lib('libbz2.a', create, what='port')]
 

--- a/tools/ports/giflib.py
+++ b/tools/ports/giflib.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 import logging
 
 VERSION = '5.2.1'
@@ -20,14 +19,10 @@ def get(ports, settings, shared):
 
   def create(final):
     logging.info('building port: giflib')
-
     source_path = os.path.join(ports.get_dir(), 'giflib', f'giflib-{VERSION}')
     dest_path = ports.clear_project_build('giflib')
-    shutil.copytree(source_path, dest_path)
-
-    ports.install_headers(dest_path)
-
-    ports.build_port(dest_path, final)
+    ports.install_headers(source_path)
+    ports.build_port(source_path, final, dest_path)
 
   return [shared.Cache.get_lib('libgif.a', create, what='port')]
 

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -87,7 +87,6 @@ def get(ports, settings, shared):
 
   def create(final):
     logging.info('building port: harfbuzz')
-    build_path = ports.clear_project_build('harfbuzz')
 
     source_path = os.path.join(ports.get_dir(), 'harfbuzz', 'harfbuzz-' + VERSION)
     freetype_include = ports.get_include_dir('freetype2')
@@ -131,15 +130,8 @@ def get(ports, settings, shared):
     else:
       cflags.append('-DHB_NO_MT')
 
-    commands = []
-    o_s = []
-    for src in srcs:
-      o = os.path.join(build_path, src + '.o')
-      shared.safe_ensure_dirs(os.path.dirname(o))
-      commands.append([shared.EMCC, '-c', os.path.join(source_path, 'src', src), '-o', o] + cflags)
-      o_s.append(o)
-    ports.run_commands(commands)
-    ports.create_lib(final, o_s)
+    build_dir = ports.clear_project_build('harfbuzz')
+    ports.build_port(os.path.join(source_path, 'src'), final, build_dir, flags=cflags, srcs=srcs)
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -5,7 +5,6 @@
 
 import logging
 import os
-import shutil
 
 TAG = 'release-68-2'
 VERSION = '68_2'
@@ -29,13 +28,14 @@ def get_lib_name(base_name, settings):
 def get(ports, settings, shared):
   url = 'https://github.com/unicode-org/icu/releases/download/%s/icu4c-%s-src.zip' % (TAG, VERSION)
   ports.fetch_project('icu', url, 'icu', sha512hash=HASH)
-  icu_source_path = os.path.join(ports.get_build_dir(), 'icu', 'source')
+  icu_source_path = None
+  dest_path = None
 
   def prepare_build():
+    nonlocal icu_source_path, dest_path
     source_path = os.path.join(ports.get_dir(), 'icu', 'icu') # downloaded icu4c path
     dest_path = ports.clear_project_build('icu') # icu build path
-    logging.debug(f'preparing for icu build: {source_path} -> {dest_path}')
-    shutil.copytree(source_path, dest_path)
+    icu_source_path = os.path.join(source_path, 'source')
 
   def build_lib(lib_output, lib_src, other_includes, build_flags):
     logging.debug('building port: icu- ' + lib_output)
@@ -56,7 +56,7 @@ def get(ports, settings, shared):
     if settings.USE_PTHREADS:
       additional_build_flags.append('-pthread')
 
-    ports.build_port(lib_src, lib_output, other_includes, build_flags + additional_build_flags)
+    ports.build_port(lib_src, lib_output, dest_path, includes=other_includes, flags=build_flags + additional_build_flags)
 
   # creator for libicu_common
   def create_libicu_common(lib_output):

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 import logging
 from pathlib import Path
 
@@ -24,22 +23,16 @@ def get(ports, settings, shared):
 
   def create(final):
     logging.info('building port: libjpeg')
-
     source_path = os.path.join(ports.get_dir(), 'libjpeg', 'jpeg-9c')
     dest_path = ports.clear_project_build('libjpeg')
-    shutil.copytree(source_path, dest_path)
-
-    Path(dest_path, 'jconfig.h').write_text(jconfig_h)
-    ports.install_headers(dest_path)
-
-    ports.build_port(
-      dest_path, final,
-      exclude_files=[
-        'ansi2knr.c', 'cjpeg.c', 'ckconfig.c', 'djpeg.c', 'example.c',
-        'jmemansi.c', 'jmemdos.c', 'jmemmac.c', 'jmemname.c',
-        'jpegtran.c', 'rdjpgcom.c', 'wrjpgcom.c',
-      ]
-    )
+    Path(source_path, 'jconfig.h').write_text(jconfig_h)
+    ports.install_headers(source_path)
+    excludes = [
+      'ansi2knr.c', 'cjpeg.c', 'ckconfig.c', 'djpeg.c', 'example.c',
+      'jmemansi.c', 'jmemdos.c', 'jmemmac.c', 'jmemname.c',
+      'jpegtran.c', 'rdjpgcom.c', 'wrjpgcom.c',
+    ]
+    ports.build_port(source_path, final, dest_path, exclude_files=excludes)
 
   return [shared.Cache.get_lib('libjpeg.a', create, what='port')]
 

--- a/tools/ports/libmodplug.py
+++ b/tools/ports/libmodplug.py
@@ -18,16 +18,14 @@ def needed(settings):
 def get(ports, settings, shared):
   ports.fetch_project('libmodplug', 'https://github.com/jancc/libmodplug/archive/v' + TAG + '.zip', 'libmodplug-' + TAG, sha512hash=HASH)
 
-  def create(output_path):
+  def create(final):
     logging.info('building port: libmodplug')
 
     source_path = os.path.join(ports.get_dir(), 'libmodplug', 'libmodplug-' + TAG)
     src_dir = os.path.join(source_path, 'src')
     libmodplug_path = os.path.join(src_dir, 'libmodplug')
 
-    build_dir = ports.clear_project_build('libmodplug')
-    shared.safe_ensure_dirs(build_dir)
-    Path(build_dir, 'config.h').write_text(config_h)
+    Path(source_path, 'config.h').write_text(config_h)
 
     flags = [
       '-DOPT_GENERIC',
@@ -40,10 +38,9 @@ def get(ports, settings, shared):
       '-ffast-math',
       '-fno-common',
       '-fvisibility=hidden',
-      '-I' + build_dir,
+      '-I' + source_path,
       '-I' + libmodplug_path,
     ]
-
     srcs = [
       os.path.join(src_dir, 'fastmix.cpp'),
       os.path.join(src_dir, 'load_669.cpp'),
@@ -81,16 +78,8 @@ def get(ports, settings, shared):
       os.path.join(src_dir, 'sndmix.cpp'),
     ]
 
-    commands = []
-    objects = []
-
-    for src in srcs:
-      obj = os.path.join(build_dir, os.path.basename(src) + '.o')
-      commands.append([shared.EMCC, '-c', src, '-O2', '-o', obj, '-w'] + flags)
-      objects.append(obj)
-
-    ports.run_commands(commands)
-    ports.create_lib(output_path, objects)
+    build_dir = ports.clear_project_build('libmodplug')
+    ports.build_port(source_path, final, build_dir, flags=flags, srcs=srcs)
 
     ports.install_headers(libmodplug_path, pattern="*.h", target='libmodplug')
     ports.install_headers(src_dir, pattern="modplug.h", target='libmodplug')

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 import logging
 from pathlib import Path
 
@@ -31,17 +30,15 @@ def get(ports, settings, shared):
     logging.info('building port: libpng')
 
     source_path = os.path.join(ports.get_dir(), 'libpng', 'libpng-' + TAG)
-    dest_path = ports.clear_project_build('libpng')
-    shutil.copytree(source_path, dest_path)
-
-    Path(dest_path, 'pnglibconf.h').write_text(pnglibconf_h)
-    ports.install_headers(dest_path)
+    Path(source_path, 'pnglibconf.h').write_text(pnglibconf_h)
+    ports.install_headers(source_path)
 
     flags = ['-sUSE_ZLIB=1']
     if settings.USE_PTHREADS:
       flags += ['-sUSE_PTHREADS=1']
 
-    ports.build_port(dest_path, final, flags=flags, exclude_files=['pngtest'], exclude_dirs=['scripts', 'contrib'])
+    build_dir = ports.clear_project_build('libpng')
+    ports.build_port(source_path, final, build_dir, flags=flags, exclude_files=['pngtest'], exclude_dirs=['scripts', 'contrib'])
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/mpg123.py
+++ b/tools/ports/mpg123.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 import logging
 from pathlib import Path
 
@@ -19,19 +18,20 @@ def needed(settings):
 def get(ports, settings, shared):
   ports.fetch_project('mpg123', 'https://www.mpg123.de/download/mpg123-1.26.2.tar.bz2', 'mpg123-' + TAG, sha512hash=HASH)
 
-  def create(output_path):
+  def create(final):
     logging.info('building port: mpg123')
 
     source_path = os.path.join(ports.get_dir(), 'mpg123', 'mpg123-' + TAG)
-    dest_path = ports.clear_project_build('mpg123')
 
-    sauce_path = os.path.join(dest_path, 'src')
-    libmpg123_path = os.path.join(sauce_path, 'libmpg123')
-    compat_path = os.path.join(sauce_path, 'compat')
+    src_path = os.path.join(source_path, 'src')
+    libmpg123_path = os.path.join(src_path, 'libmpg123')
+    compat_path = os.path.join(src_path, 'compat')
 
-    shutil.copytree(source_path, dest_path)
-    Path(sauce_path, 'config.h').write_text(config_h)
+    Path(src_path, 'config.h').write_text(config_h)
     Path(libmpg123_path, 'mpg123.h').write_text(mpg123_h)
+
+    # copy header to a location so it can be used as 'MPG123/'
+    ports.install_headers(libmpg123_path, pattern="*123.h", target='')
 
     flags = [
       '-DOPT_GENERIC',
@@ -41,7 +41,7 @@ def get(ports, settings, shared):
       '-funroll-all-loops',
       '-finline-functions',
       '-ffast-math',
-      '-I' + sauce_path,
+      '-I' + src_path,
       '-I' + compat_path,
       '-I' + libmpg123_path,
     ]
@@ -76,19 +76,8 @@ def get(ports, settings, shared):
       os.path.join(compat_path, 'compat_str.c'),
     ]
 
-    commands = []
-    objects = []
-
-    for src in srcs:
-      obj = src + '.o'
-      commands.append([shared.EMCC, '-c', src, '-O2', '-o', obj, '-w'] + flags)
-      objects.append(obj)
-
-    ports.run_commands(commands)
-    ports.create_lib(output_path, objects)
-
-    # copy header to a location so it can be used as 'MPG123/'
-    ports.install_headers(libmpg123_path, pattern="*123.h", target='')
+    dest_path = ports.clear_project_build('mpg123')
+    ports.build_port(source_path, final, dest_path, flags=flags, srcs=srcs)
 
   return [shared.Cache.get_lib('libmpg123.a', create, what='port')]
 

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -5,7 +5,6 @@
 
 import logging
 import os
-import shutil
 from pathlib import Path
 
 TAG = 'version_1'
@@ -23,13 +22,10 @@ def get(ports, settings, shared):
     logging.info('building port: ogg')
 
     source_path = os.path.join(ports.get_dir(), 'ogg', 'Ogg-' + TAG)
+    Path(source_path, 'include', 'ogg', 'config_types.h').write_text(config_types_h)
+    ports.install_header_dir(os.path.join(source_path, 'include', 'ogg'), 'ogg')
     dest_path = ports.clear_project_build('ogg')
-    shutil.copytree(source_path, dest_path)
-
-    Path(dest_path, 'include', 'ogg', 'config_types.h').write_text(config_types_h)
-
-    ports.install_header_dir(os.path.join(dest_path, 'include', 'ogg'), 'ogg')
-    ports.build_port(os.path.join(dest_path, 'src'), final)
+    ports.build_port(os.path.join(source_path, 'src'), final, dest_path)
 
   return [shared.Cache.get_lib('libogg.a', create)]
 

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -5,7 +5,6 @@
 
 import logging
 import os
-import shutil
 
 TAG = 'version_7'
 HASH = 'a921dab254f21cf5d397581c5efe58faf147c31527228b4fb34aed75164c736af4b3347092a8d9ec1249160230fa163309a87a20c2b9ceef8554566cc215de9d'
@@ -27,26 +26,18 @@ def get(ports, settings, shared):
 
   def create(final):
     logging.info('building port: regal')
-    dest_path = ports.clear_project_build('regal')
+    source_path = os.path.join(ports.get_dir(), 'regal', 'regal-' + TAG)
 
     # copy sources
     # only what is needed is copied: regal, boost, lookup3
-    source_path_src = os.path.join(ports.get_dir(), 'regal', 'regal-' + TAG, 'src')
-    dest_path_src = os.path.join(dest_path, 'src')
+    source_path_src = os.path.join(source_path, 'src')
 
     source_path_regal = os.path.join(source_path_src, 'regal')
     source_path_boost = os.path.join(source_path_src, 'boost')
     source_path_lookup3 = os.path.join(source_path_src, 'lookup3')
-    dest_path_regal = os.path.join(dest_path_src, 'regal')
-    dest_path_boost = os.path.join(dest_path_src, 'boost')
-    dest_path_lookup3 = os.path.join(dest_path_src, 'lookup3')
-
-    shutil.copytree(source_path_regal, dest_path_regal)
-    shutil.copytree(source_path_boost, dest_path_boost)
-    shutil.copytree(source_path_lookup3, dest_path_lookup3)
 
     # includes
-    source_path_include = os.path.join(ports.get_dir(), 'regal', 'regal-' + TAG, 'include', 'GL')
+    source_path_include = os.path.join(source_path, 'include', 'GL')
     ports.install_headers(source_path_include, target='GL')
 
     # build
@@ -105,38 +96,29 @@ def get(ports, settings, shared):
                   'regal/RegalX11.cpp',
                   'regal/RegalDllMain.cpp']
 
-    commands = []
-    o_s = []
+    srcs_regal = [os.path.join(source_path_src, s) for s in srcs_regal]
 
-    for src in srcs_regal:
-      c = os.path.join(dest_path_src, src)
-      o = os.path.join(dest_path_src, src + '.o')
-      shared.safe_ensure_dirs(os.path.dirname(o))
+    flags = [
+      '-DNDEBUG',
+      '-DREGAL_LOG=0',  # Set to 1 if you need to have some logging info
+      '-DREGAL_MISSING=0',  # Set to 1 if you don't want to crash in case of missing GL implementation
+      '-std=gnu++14',
+      '-fno-rtti',
+      '-fno-exceptions', # Disable exceptions (in STL containers mostly), as they are not used at all
+      '-O3',
+      '-I' + source_path_regal,
+      '-I' + source_path_lookup3,
+      '-I' + source_path_boost,
+      '-Wall',
+      '-Werror',
+      '-Wno-deprecated-register',
+      '-Wno-unused-parameter'
+    ]
+    if settings.USE_PTHREADS:
+      flags += ['-pthread']
 
-      command = [shared.EMXX, '-c', c,
-                 '-DNDEBUG',
-                 '-DREGAL_LOG=0',  # Set to 1 if you need to have some logging info
-                 '-DREGAL_MISSING=0',  # Set to 1 if you don't want to crash in case of missing GL implementation
-                 '-std=gnu++14',
-                 '-fno-rtti',
-                 '-fno-exceptions', # Disable exceptions (in STL containers mostly), as they are not used at all
-                 '-O3',
-                 '-o', o,
-                 '-I' + dest_path_regal,
-                 '-I' + dest_path_lookup3,
-                 '-I' + dest_path_boost,
-                 '-Wall',
-                 '-Werror',
-                 '-Wno-deprecated-register',
-                 '-Wno-unused-parameter']
-      if settings.USE_PTHREADS:
-        command += ['-pthread']
-      commands.append(command)
-
-      o_s.append(o)
-
-    ports.run_commands(commands)
-    ports.create_lib(final, o_s)
+    build_dir = ports.clear_project_build('regal')
+    ports.build_port(source_path_src, final, build_dir, srcs=srcs_regal, flags=flags)
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -26,7 +26,8 @@ def get(ports, settings, shared):
 
   def create(final):
     # copy includes to a location so they can be used as 'SDL2/'
-    source_include_path = os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'include')
+    src_dir = os.path.join(ports.get_dir(), 'sdl2', SUBDIR)
+    source_include_path = os.path.join(src_dir, 'include')
     ports.install_headers(source_include_path, target='SDL2')
 
     # build
@@ -65,23 +66,13 @@ def get(ports, settings, shared):
     thread_backend = 'generic' if not settings.USE_PTHREADS else 'pthread'
     srcs += ['thread/%s/%s' % (thread_backend, s) for s in thread_srcs]
 
-    commands = []
-    o_s = []
+    srcs = [os.path.join(src_dir, 'src', s) for s in srcs]
+    flags = ['-sUSE_SDL=0']
+    includes = [ports.get_include_dir('SDL2')]
+    if settings.USE_PTHREADS:
+      flags += ['-sUSE_PTHREADS']
     build_dir = ports.clear_project_build('sdl2')
-    for src in srcs:
-      o = os.path.join(build_dir, 'src', shared.replace_suffix(src, '.o'))
-      shared.safe_ensure_dirs(os.path.dirname(o))
-      command = [shared.EMCC,
-                 '-sUSE_SDL=0',
-                 '-c', os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'src', src),
-                 '-o', o, '-I' + ports.get_include_dir('SDL2'),
-                 '-O2', '-w']
-      if settings.USE_PTHREADS:
-        command += ['-sUSE_PTHREADS']
-      commands.append(command)
-      o_s.append(o)
-    ports.run_commands(commands)
-    ports.create_lib(final, o_s)
+    ports.build_port(src_dir, final, build_dir, srcs=srcs, includes=includes, flags=flags)
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 import logging
 
 TAG = '2b147ffef10ec541d3eace326eafe11a54e635f8'
@@ -24,13 +23,9 @@ def get(ports, settings, shared):
 
   def create(final):
     logging.info('building port: sdl2_gfx')
-
     source_path = os.path.join(ports.get_dir(), 'sdl2_gfx', 'sdl2_gfx-' + TAG)
     dest_path = ports.clear_project_build('sdl2_gfx')
-
-    shutil.copytree(source_path, dest_path)
-    ports.build_port(dest_path, final, [dest_path], exclude_dirs=['test'], flags=['-sUSE_SDL=2'])
-
+    ports.build_port(source_path, final, dest_path, includes=[dest_path], exclude_dirs=['test'], flags=['-sUSE_SDL=2'])
     ports.install_headers(source_path, target='SDL2')
 
   return [shared.Cache.get_lib('libSDL2_gfx.a', create)]

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -19,27 +19,29 @@ def needed(settings):
   return settings.USE_SDL_IMAGE == 2
 
 
-def get(ports, settings, shared):
-  sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
-  assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_image'
-  ports.fetch_project('sdl2_image', 'https://github.com/emscripten-ports/SDL2_image/archive/' + TAG + '.zip', 'SDL2_image-' + TAG, sha512hash=HASH)
-
+def get_lib_name(settings):
   settings.SDL2_IMAGE_FORMATS.sort()
   formats = '-'.join(settings.SDL2_IMAGE_FORMATS)
 
   libname = 'libSDL2_image'
   if formats != '':
     libname += '_' + formats
-  libname += '.a'
+  return libname + '.a'
+
+
+def get(ports, settings, shared):
+  sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
+  assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_image'
+  ports.fetch_project('sdl2_image', 'https://github.com/emscripten-ports/SDL2_image/archive/' + TAG + '.zip', 'SDL2_image-' + TAG, sha512hash=HASH)
+  libname = get_lib_name(settings)
 
   def create(final):
     src_dir = os.path.join(ports.get_dir(), 'sdl2_image', 'SDL2_image-' + TAG)
     ports.install_headers(src_dir, target='SDL2')
     srcs = '''IMG.c IMG_bmp.c IMG_gif.c IMG_jpg.c IMG_lbm.c IMG_pcx.c IMG_png.c IMG_pnm.c IMG_tga.c
               IMG_tif.c IMG_xcf.c IMG_xpm.c IMG_xv.c IMG_webp.c IMG_ImageIO.m'''.split()
-    commands = []
-    o_s = []
-    defs = []
+
+    defs = ['-O2', '-sUSE_SDL=2']
 
     for fmt in settings.SDL2_IMAGE_FORMATS:
       defs.append('-DLOAD_' + fmt.upper())
@@ -51,20 +53,13 @@ def get(ports, settings, shared):
       defs += ['-sUSE_LIBJPEG=1']
 
     build_dir = ports.clear_project_build('sdl2_image')
-    for src in srcs:
-      o = os.path.join(build_dir, shared.replace_suffix(src, '.o'))
-      commands.append([shared.EMCC, '-c', os.path.join(src_dir, src),
-                       '-O2', '-sUSE_SDL=2', '-o', o, '-w'] + defs)
-      o_s.append(o)
-    shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
-    ports.run_commands(commands)
-    ports.create_lib(final, o_s)
+    ports.build_port(src_dir, final, build_dir, flags=defs, srcs=srcs)
 
   return [shared.Cache.get_lib(libname, create, what='port')]
 
 
 def clear(ports, settings, shared):
-  shared.Cache.get_path('libSDL2_image.a')
+  shared.Cache.erase_lib(get_lib_name(settings))
 
 
 def process_dependencies(settings):

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 import logging
 
 TAG = 'release-2.0.4'
@@ -45,8 +44,6 @@ def get(ports, settings, shared):
     source_path = os.path.join(ports.get_dir(), 'sdl2_mixer', 'SDL_mixer-' + TAG)
     dest_path = ports.clear_project_build('sdl2_mixer')
 
-    shutil.copytree(source_path, dest_path)
-
     flags = [
       '-sUSE_SDL=2',
       '-O2',
@@ -78,9 +75,9 @@ def get(ports, settings, shared):
       ]
 
     ports.build_port(
-      dest_path,
+      source_path,
       final,
-      includes=[],
+      dest_path,
       flags=flags,
       exclude_files=[
         'playmus.c',

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -25,18 +25,9 @@ def get(ports, settings, shared):
     logging.info('building port: sdl2_net')
     src_dir = os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG)
     ports.install_headers(src_dir, target='SDL2')
-    srcs = 'SDLnet.c SDLnetselect.c SDLnetTCP.c SDLnetUDP.c'.split()
-    commands = []
-    o_s = []
     build_dir = ports.clear_project_build('sdl2_net')
-    shared.safe_ensure_dirs(build_dir)
-    for src in srcs:
-      o = os.path.join(build_dir, shared.replace_suffix(src, '.o'))
-      commands.append([shared.EMCC, '-c', os.path.join(src_dir, src),
-                       '-O2', '-sUSE_SDL=2', '-o', o, '-w'])
-      o_s.append(o)
-    ports.run_commands(commands)
-    ports.create_lib(final, o_s)
+    excludes = ['chatd.c', 'chat.cpp', 'showinterfaces.c']
+    ports.build_port(src_dir, final, build_dir, exclude_files=excludes)
 
   return [shared.Cache.get_lib('libSDL2_net.a', create, what='port')]
 

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -21,23 +21,9 @@ def get(ports, settings, shared):
   def create(final):
     src_root = os.path.join(ports.get_dir(), 'sdl2_ttf', 'SDL_ttf-' + TAG)
     ports.install_headers(src_root, target='SDL2')
-
-    srcs = ['SDL_ttf.c']
-    commands = []
-    o_s = []
-
+    flags = ['-DTTF_USE_HARFBUZZ=1', '-sUSE_SDL=2', '-sUSE_FREETYPE=1', '-sUSE_HARFBUZZ=1']
     build_dir = ports.clear_project_build('sdl2_ttf')
-    for src in srcs:
-      o = os.path.join(build_dir, shared.replace_suffix(src, '.o'))
-      command = [shared.EMCC,
-                 '-c', os.path.join(src_root, src),
-                 '-O2', '-DTTF_USE_HARFBUZZ=1', '-sUSE_SDL=2', '-sUSE_FREETYPE=1', '-sUSE_HARFBUZZ=1', '-o', o, '-w']
-      commands.append(command)
-      o_s.append(o)
-
-    shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
-    ports.run_commands(commands)
-    ports.create_lib(final, o_s)
+    ports.build_port(src_root, final, build_dir, flags=flags, srcs=['SDL_ttf.c'])
 
   return [shared.Cache.get_lib('libSDL2_ttf.a', create, what='port')]
 

--- a/tools/ports/sqlite3.py
+++ b/tools/ports/sqlite3.py
@@ -76,7 +76,7 @@ def get(ports, settings, shared):
     else:
       flags += ['-DSQLITE_THREADSAFE=0']
 
-    ports.build_port(dest_path, final, flags=flags, exclude_files=['shell.c'])
+    ports.build_port(source_path, final, dest_path, flags=flags, exclude_files=['shell.c'])
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -5,7 +5,6 @@
 
 import logging
 import os
-import shutil
 
 TAG = 'version_1'
 HASH = '99bee75beb662f8520bbb18ad6dbf8590d30eb3a7360899f0ac4764ca72fe8013da37c9df21e525f9d2dc5632827d4b4cea558cbc938e7fbed0c41a29a7a2dc5'
@@ -22,14 +21,13 @@ def get(ports, settings, shared):
 
   def create(final):
     logging.info('building port: vorbis')
-
     source_path = os.path.join(ports.get_dir(), 'vorbis', 'Vorbis-' + TAG)
-    dest_path = ports.clear_project_build('vorbis')
-    shutil.copytree(source_path, dest_path)
-
-    ports.build_port(os.path.join(dest_path, 'lib'), final, [os.path.join(dest_path, 'include')],
-                     ['-sUSE_OGG=1'], ['psytune', 'barkmel', 'tone', 'misc'])
     ports.install_header_dir(os.path.join(source_path, 'include', 'vorbis'))
+    dest_path = ports.clear_project_build('vorbis')
+    ports.build_port(os.path.join(source_path, 'lib'), final, dest_path,
+                     includes=[os.path.join(dest_path, 'include')],
+                     flags=['-sUSE_OGG=1'],
+                     exclude_files=['psytune', 'barkmel', 'tone', 'misc'])
 
   return [shared.Cache.get_lib('libvorbis.a', create)]
 

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 from pathlib import Path
 
 VERSION = '1.2.12'
@@ -20,23 +19,13 @@ def get(ports, settings, shared):
 
   def create(final):
     source_path = os.path.join(ports.get_dir(), 'zlib', 'zlib-' + VERSION)
-    dest_path = ports.clear_project_build('zlib')
-    shutil.copytree(source_path, dest_path)
-    Path(dest_path, 'zconf.h').write_text(zconf_h)
-    ports.install_headers(dest_path)
+    Path(source_path, 'zconf.h').write_text(zconf_h)
+    ports.install_headers(source_path)
 
     # build
     srcs = 'adler32.c compress.c crc32.c deflate.c gzclose.c gzlib.c gzread.c gzwrite.c infback.c inffast.c inflate.c inftrees.c trees.c uncompr.c zutil.c'.split()
-    commands = []
-    o_s = []
-    for src in srcs:
-      o = os.path.join(dest_path, src + '.o')
-      shared.safe_ensure_dirs(os.path.dirname(o))
-      commands.append([shared.EMCC, os.path.join(dest_path, src), '-O2', '-o', o, '-I' + dest_path, '-w', '-c'])
-      o_s.append(o)
-    ports.run_commands(commands)
-
-    ports.create_lib(final, o_s)
+    dest_path = ports.clear_project_build('zlib')
+    ports.build_port(source_path, final, dest_path, srcs=srcs)
 
   return [shared.Cache.get_lib('libz.a', create, what='port')]
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -75,6 +75,7 @@ def run_build_commands(commands):
   # to setup the sysroot itself.
   ensure_sysroot()
   shared.run_multiple_processes(commands, env=clean_env())
+  logger.info('compiled %d inputs' % len(commands))
 
 
 def create_lib(libname, inputs):


### PR DESCRIPTION
This will allow more easy transition to alternative build systems such as ninja (See #17809).

Also, update build_port to allow separate source and build directories. This avoids copying the entire source code of each port from the extracts archive into the build directory.