### PR TITLE
Build bullet lib in C++14 mode

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -417,7 +417,8 @@ class TestCoreBase(RunnerCore):
   def get_bullet_library(self, use_cmake):
     if use_cmake:
       configure_commands = ['cmake', '.']
-      configure_args = ['-DBUILD_DEMOS=OFF', '-DBUILD_EXTRAS=OFF', '-DUSE_GLUT=OFF']
+      configure_args = ['-DBUILD_DEMOS=OFF', '-DBUILD_EXTRAS=OFF', '-DUSE_GLUT=OFF',
+                        '-DCMAKE_CXX_STANDARD=14']
       # Depending on whether 'configure' or 'cmake' is used to build, Bullet
       # places output files in different directory structures.
       generated_libs = [Path('src/BulletDynamics/libBulletDynamics.a'),

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -25,7 +25,6 @@ def get(ports, settings, shared):
     dest_path = ports.clear_project_build('bullet')
     shutil.copytree(source_path, dest_path)
     src_path = os.path.join(dest_path, 'bullet', 'src')
-    src_path = os.path.join(dest_path, 'bullet', 'src')
 
     dest_include_path = ports.get_include_dir('bullet')
     for base, _, files in os.walk(src_path):
@@ -43,7 +42,8 @@ def get(ports, settings, shared):
       for dir in dirs:
         includes.append(os.path.join(base, dir))
 
-    ports.build_port(src_path, final, includes=includes, exclude_dirs=['MiniCL'])
+    ports.build_port(src_path, final, includes=includes, exclude_dirs=['MiniCL'],
+                     flags=['-std=gnu++14'])
 
   return [shared.Cache.get_lib('libbullet.a', create)]
 


### PR DESCRIPTION
It was not intended to be built in C++17 and issues warnings in that mode.