### PR TITLE
[WasmFS] Catch errors in _wasmfs_opfs_close_access

### DIFF
--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -286,11 +286,14 @@ mergeInto(LibraryManager.library, {
 
   _wasmfs_opfs_close_access__deps: ['$wasmfsOPFSFree',
                                     '$wasmfsOPFSAccessHandles'],
-  _wasmfs_opfs_close_access: async function(ctx, accessID) {
+  _wasmfs_opfs_close_access: async function(ctx, accessID, errPtr) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
-    // Wait for the close to finish to ensure that subsequent opens succeed. The
-    // close cannot fail, so we don't need any kind of error handling.
-    await accessHandle.close();
+    try {
+      await accessHandle.close();
+    } catch {
+      let err = -{{{ cDefine('EIO') }}};
+      {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
+    }
     wasmfsOPFSFree(wasmfsOPFSAccessHandles, accessID);
     _emscripten_proxy_finish(ctx);
   },

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -61,7 +61,7 @@ void _wasmfs_opfs_open_access(em_proxying_ctx* ctx,
 
 void _wasmfs_opfs_open_blob(em_proxying_ctx* ctx, int file_id, int* blob_id);
 
-void _wasmfs_opfs_close_access(em_proxying_ctx* ctx, int access_id);
+void _wasmfs_opfs_close_access(em_proxying_ctx* ctx, int access_id, int* err);
 
 void _wasmfs_opfs_close_blob(int blob_id);
 
@@ -175,13 +175,15 @@ public:
     return 0;
   }
 
-  void close(ProxyWorker& proxy) {
+  int close(ProxyWorker& proxy) {
     // TODO: Downgrade to Blob access once the last writable file descriptor has
     // been closed.
+    int err = 0;
     if (--openCount == 0) {
       switch (kind) {
         case Access:
-          proxy([&](auto ctx) { _wasmfs_opfs_close_access(ctx.ctx, id); });
+          proxy(
+            [&](auto ctx) { _wasmfs_opfs_close_access(ctx.ctx, id, &err); });
           break;
         case Blob:
           proxy([&]() { _wasmfs_opfs_close_blob(id); });
@@ -192,6 +194,7 @@ public:
       kind = None;
       id = -1;
     }
+    return err;
   }
 
   int getAccessID() {
@@ -277,10 +280,7 @@ private:
 
   int open(oflags_t flags) override { return state.open(proxy, fileID, flags); }
 
-  int close() override {
-    state.close(proxy);
-    return 0;
-  }
+  int close() override { return state.close(proxy); }
 
   ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
     // TODO: use an i64 here.


### PR DESCRIPTION
Apparently `close` on `AccessHandles` can fail after all, so we have to be
prepared to catch and recover from errors there. Tested manually since I don't
know how to deterministically cause close to fail.