### PR TITLE
WebGL bindings: Fix shifts for >=2GB heaps

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -82,7 +82,7 @@ var LibraryGL = {
     return HEAPU16;
   },
 
-  // Returns the appropriate amount of times for a heap (based on the element
+  // Returns the appropriate amount of shifts for a heap (based on the element
   // size in the heap).
   $heapAccessShiftForWebGLHeap: function(heap) {
     return 31 - Math.clz32(heap.BYTES_PER_ELEMENT);

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -82,8 +82,22 @@ var LibraryGL = {
     return HEAPU16;
   },
 
+  // Returns the appropriate amount of times for a heap (based on the element
+  // size in the heap).
   $heapAccessShiftForWebGLHeap: function(heap) {
     return 31 - Math.clz32(heap.BYTES_PER_ELEMENT);
+  },
+
+  // Receives a pointer and a heap, and shifts the pointer the appropriate
+  // amount of times for that heap (based on the element size in the heap).
+  $getShiftedPtrForWebGLHeap__deps: ['$heapAccessShiftForWebGLHeap'],
+  $getShiftedPtrForWebGLHeap: function(ptr, heap) {
+    var shifts = heapAccessShiftForWebGLHeap(heap);
+#if CAN_ADDRESS_2GB
+    return ptr >>> shifts;
+#else
+    return ptr >> shifts;
+#endif
   },
 
 #if MIN_WEBGL_VERSION == 1
@@ -1518,7 +1532,7 @@ var LibraryGL = {
   glTexImage2D__sig: 'viiiiiiiii',
   glTexImage2D__deps: ['$emscriptenWebGLGetTexPixelData'
 #if MAX_WEBGL_VERSION >= 2
-                       , '$heapObjectForWebGLType', '$heapAccessShiftForWebGLHeap'
+                       , '$heapObjectForWebGLType', '$getShiftedPtrForWebGLHeap'
 #endif
   ],
   glTexImage2D: function(target, level, internalFormat, width, height, border, format, type, pixels) {
@@ -1547,7 +1561,7 @@ var LibraryGL = {
         GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, pixels);
       } else if (pixels) {
         var heap = heapObjectForWebGLType(type);
-        GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, heap, pixels >> heapAccessShiftForWebGLHeap(heap));
+        GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, heap, getShiftedPtrForWebGLHeap(pixels, heap));
       } else {
         GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, null);
       }
@@ -1560,7 +1574,7 @@ var LibraryGL = {
   glTexSubImage2D__sig: 'viiiiiiiii',
   glTexSubImage2D__deps: ['$emscriptenWebGLGetTexPixelData'
 #if MAX_WEBGL_VERSION >= 2
-                          , '$heapObjectForWebGLType', '$heapAccessShiftForWebGLHeap'
+                          , '$heapObjectForWebGLType', '$getShiftedPtrForWebGLHeap'
 #endif
   ],
   glTexSubImage2D: function(target, level, xoffset, yoffset, width, height, format, type, pixels) {
@@ -1579,7 +1593,7 @@ var LibraryGL = {
         GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
       } else if (pixels) {
         var heap = heapObjectForWebGLType(type);
-        GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, heap, pixels >> heapAccessShiftForWebGLHeap(heap));
+        GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, heap, getShiftedPtrForWebGLHeap(pixels, heap));
       } else {
         GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, null);
       }
@@ -1594,7 +1608,7 @@ var LibraryGL = {
   glReadPixels__sig: 'viiiiiii',
   glReadPixels__deps: ['$emscriptenWebGLGetTexPixelData'
 #if MAX_WEBGL_VERSION >= 2
-                       , '$heapObjectForWebGLType', '$heapAccessShiftForWebGLHeap'
+                       , '$heapObjectForWebGLType', '$getShiftedPtrForWebGLHeap'
 #endif
   ],
   glReadPixels: function(x, y, width, height, format, type, pixels) {
@@ -1604,7 +1618,7 @@ var LibraryGL = {
         GLctx.readPixels(x, y, width, height, format, type, pixels);
       } else {
         var heap = heapObjectForWebGLType(type);
-        GLctx.readPixels(x, y, width, height, format, type, heap, pixels >> heapAccessShiftForWebGLHeap(heap));
+        GLctx.readPixels(x, y, width, height, format, type, heap, getShiftedPtrForWebGLHeap(pixels, heap));
       }
       return;
     }

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -161,26 +161,26 @@ var LibraryWebGL2 = {
   },
 
   glTexImage3D__sig: 'viiiiiiiiii',
-  glTexImage3D__deps: ['$heapObjectForWebGLType', '$heapAccessShiftForWebGLHeap'],
+  glTexImage3D__deps: ['$heapObjectForWebGLType', '$getShiftedPtrForWebGLHeap'],
   glTexImage3D: function(target, level, internalFormat, width, height, depth, border, format, type, pixels) {
     if (GLctx.currentPixelUnpackBufferBinding) {
       GLctx['texImage3D'](target, level, internalFormat, width, height, depth, border, format, type, pixels);
     } else if (pixels) {
       var heap = heapObjectForWebGLType(type);
-      GLctx['texImage3D'](target, level, internalFormat, width, height, depth, border, format, type, heap, pixels >> heapAccessShiftForWebGLHeap(heap));
+      GLctx['texImage3D'](target, level, internalFormat, width, height, depth, border, format, type, heap, getShiftedPtrForWebGLHeap(pixels, heap));
     } else {
       GLctx['texImage3D'](target, level, internalFormat, width, height, depth, border, format, type, null);
     }
   },
 
   glTexSubImage3D__sig: 'viiiiiiiiiii',
-  glTexSubImage3D__deps: ['$heapObjectForWebGLType', '$heapAccessShiftForWebGLHeap'],
+  glTexSubImage3D__deps: ['$heapObjectForWebGLType', '$getShiftedPtrForWebGLHeap'],
   glTexSubImage3D: function(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels) {
     if (GLctx.currentPixelUnpackBufferBinding) {
       GLctx['texSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
     } else if (pixels) {
       var heap = heapObjectForWebGLType(type);
-      GLctx['texSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, heap, pixels >> heapAccessShiftForWebGLHeap(heap));
+      GLctx['texSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, heap, getShiftedPtrForWebGLHeap(pixels, heap));
     } else {
       GLctx['texSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, null);
     }

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1951,6 +1951,13 @@ keydown(100);keyup(100); // trigger the end
   def test_gl_glteximage(self):
     self.btest('gl_teximage.c', '1', args=['-lGL', '-lSDL'])
 
+  @unittest.skip("can only work in chrome canary atm (Sep 2022)")
+  @requires_graphics_hardware
+  def test_gl_glteximage_gl2_4gb(self):
+    # test glTexImage2D in WebGL2, where using >2GB of memory may be tricky: we
+    # have a pointer there that is shifted, and we must shift it as unsigned.
+    self.btest('gl_teximage.c', '1', args=['-lGL', '-lSDL', '-sINITIAL_MEMORY=3GB', '-sMAX_WEBGL_VERSION=2', '-DTEST_WEBGL2_2GB'])
+
   @parameterized({
     '': ([],),
     'pthreads': (['-sUSE_PTHREADS', '-sPROXY_TO_PTHREAD', '-sOFFSCREEN_FRAMEBUFFER'],),


### PR DESCRIPTION
Fixes #17539