### PR TITLE
[WasmFS][NFC] Do not eagerly execute queue in ProxyWorker

### DIFF
--- a/system/lib/wasmfs/thread_utils.h
+++ b/system/lib/wasmfs/thread_utils.h
@@ -25,9 +25,7 @@ public:
   // Spawn the worker thread.
   ProxyWorker()
     : queue(), thread([&]() {
-        // Process the queue in case any work came in while we were starting up,
-        // then sit in the event loop performing work as it comes in.
-        queue.execute();
+        // Sit in the event loop performing work as it comes in.
         emscripten_exit_with_live_runtime();
       }) {}
 


### PR DESCRIPTION
Eagerly executing the queue is no longer necessary since #16771 made it
impossible to miss work on thread startup.