### PR TITLE
Assign wasmMemory from Module['wasmMemory'] in minimal runtime

### DIFF
--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -99,6 +99,11 @@ if (!ENVIRONMENT_IS_PTHREAD) {
   updateGlobalBufferAndViews(wasmMemory.buffer);
 #if USE_PTHREADS
 } else {
+#if MODULARIZE
+  if (Module['wasmMemory']) {
+    wasmMemory = Module['wasmMemory'];
+  }
+#endif // MODULARIZE
   updateGlobalBufferAndViews({{{ MODULARIZE ? 'Module.buffer' : 'wasmMemory.buffer' }}});
 }
 #endif // USE_PTHREADS

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4769,6 +4769,7 @@ Module["preRun"].push(function () {
     run([])
     run(['-sASSERTIONS'])
     run(['-sPROXY_TO_PTHREAD'])
+    run(['-sMINIMAL_RUNTIME', '-sMODULARIZE', '-sEXPORT_NAME=MyModule'])
 
   # Tests that time in a pthread is relative to the main thread, so measurements
   # on different threads are still monotonic, as if checking a single central


### PR DESCRIPTION
## Issue

When building with:

* `MINIMAL_RUNTIME=2`
* `MODULARIZE=1`
* `-pthread`
* `ALLOW_MEMORY_GROWTH`

workers do not assign the shared `wasmModule` coming from the `Module` object. Then, any call in the memory growth code will basically fail because the reference to `wasmMemory` will be `undefined`.

## Fix

Assign the `wasmMemory` variable the same way it's done in non-minimal runtime