### PR TITLE
Avoid using built-in function in _mm_madd_epi16. NFC

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -557,7 +557,7 @@ The following table highlights the availability and expected performance of diff
    * - _mm_loadu_si16
      - ❌ emulated with const+scalar load+replace lane
    * - _mm_madd_epi16
-     - ✅ wasm_dot_s_i32x4_i16x8
+     - ✅ wasm_i32x4_dot_i16x8
    * - _mm_maskmoveu_si128
      - ❌ scalarized
    * - _mm_max_epi16

--- a/system/include/compat/emmintrin.h
+++ b/system/include/compat/emmintrin.h
@@ -648,7 +648,7 @@ _mm_avg_epu16(__m128i __a, __m128i __b)
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_madd_epi16(__m128i __a, __m128i __b)
 {
-  return (__m128i)__builtin_wasm_dot_s_i32x4_i16x8((__i16x8)__a, (__i16x8)__b);
+  return (__m128i)wasm_i32x4_dot_i16x8((v128_t)__a, (v128_t)__b);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))


### PR DESCRIPTION
Commit llvm/llvm-project@502f540 finalized the `wasm_simd128.h` intrinsics header, so using the built-in equivalent of `wasm_i32x4_dot_i16x8` is not needed here.