### PR TITLE
ports: Consistent use of `build_dir` name. NFC

### DIFF
--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -125,15 +125,14 @@ class Ports:
     for include in includes:
       cflags.append('-I' + include)
 
-    if build_dir:
-      if not os.path.exists(build_dir):
-        os.makedirs(build_dir)
-      build_dir = src_dir
     commands = []
     objects = []
     for src in srcs:
       relpath = os.path.relpath(src, src_dir)
       obj = os.path.join(build_dir, relpath) + '.o'
+      dirname = os.path.dirname(obj)
+      if not os.path.exists(dirname):
+        os.makedirs(dirname)
       commands.append([shared.EMCC, '-c', src, '-o', obj] + cflags)
       objects.append(obj)
 

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -22,7 +22,6 @@ def get(ports, settings, shared):
     logging.info('building port: bullet')
 
     source_path = os.path.join(ports.get_dir(), 'bullet', 'Bullet-' + TAG)
-    dest_path = ports.clear_project_build('bullet')
     src_path = os.path.join(source_path, 'bullet', 'src')
 
     dest_include_path = ports.get_include_dir('bullet')
@@ -46,7 +45,8 @@ def get(ports, settings, shared):
       '-std=gnu++14'
     ]
 
-    ports.build_port(src_path, final, dest_path, includes=includes, flags=flags, exclude_dirs=['MiniCL'])
+    build_dir = ports.clear_project_build('bullet')
+    ports.build_port(src_path, final, build_dir, includes=includes, flags=flags, exclude_dirs=['MiniCL'])
 
   return [shared.Cache.get_lib('libbullet.a', create)]
 

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -25,8 +25,8 @@ def get(ports, settings, shared):
       'blocksort.c', 'compress.c', 'decompress.c', 'huffman.c',
       'randtable.c', 'bzlib.c', 'crctable.c',
     ]
-    dest_path = ports.clear_project_build('bzip2')
-    ports.build_port(source_path, final, dest_path, srcs=srcs)
+    build_dir = ports.clear_project_build('bzip2')
+    ports.build_port(source_path, final, build_dir, srcs=srcs)
 
   return [shared.Cache.get_lib('libbz2.a', create, what='port')]
 

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -91,8 +91,8 @@ def get(ports, settings, shared):
       '-pthread'
     ]
 
-    dest_path = ports.clear_project_build('freetype')
-    ports.build_port(source_path, final, dest_path, flags=flags, srcs=srcs)
+    build_dir = ports.clear_project_build('freetype')
+    ports.build_port(source_path, final, build_dir, flags=flags, srcs=srcs)
 
   return [shared.Cache.get_lib('libfreetype.a', create, what='port')]
 

--- a/tools/ports/giflib.py
+++ b/tools/ports/giflib.py
@@ -20,9 +20,9 @@ def get(ports, settings, shared):
   def create(final):
     logging.info('building port: giflib')
     source_path = os.path.join(ports.get_dir(), 'giflib', f'giflib-{VERSION}')
-    dest_path = ports.clear_project_build('giflib')
     ports.install_headers(source_path)
-    ports.build_port(source_path, final, dest_path)
+    build_dir = ports.clear_project_build('giflib')
+    ports.build_port(source_path, final, build_dir)
 
   return [shared.Cache.get_lib('libgif.a', create, what='port')]
 

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -29,12 +29,12 @@ def get(ports, settings, shared):
   url = 'https://github.com/unicode-org/icu/releases/download/%s/icu4c-%s-src.zip' % (TAG, VERSION)
   ports.fetch_project('icu', url, 'icu', sha512hash=HASH)
   icu_source_path = None
-  dest_path = None
+  build_dir = None
 
   def prepare_build():
-    nonlocal icu_source_path, dest_path
+    nonlocal icu_source_path, build_dir
     source_path = os.path.join(ports.get_dir(), 'icu', 'icu') # downloaded icu4c path
-    dest_path = ports.clear_project_build('icu') # icu build path
+    build_dir = ports.clear_project_build('icu') # icu build path
     icu_source_path = os.path.join(source_path, 'source')
 
   def build_lib(lib_output, lib_src, other_includes, build_flags):
@@ -59,7 +59,7 @@ def get(ports, settings, shared):
     if settings.USE_PTHREADS:
       additional_build_flags.append('-pthread')
 
-    ports.build_port(lib_src, lib_output, dest_path, includes=other_includes, flags=build_flags + additional_build_flags)
+    ports.build_port(lib_src, lib_output, build_dir, includes=other_includes, flags=build_flags + additional_build_flags)
 
   # creator for libicu_common
   def create_libicu_common(lib_output):

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -24,7 +24,6 @@ def get(ports, settings, shared):
   def create(final):
     logging.info('building port: libjpeg')
     source_path = os.path.join(ports.get_dir(), 'libjpeg', 'jpeg-9c')
-    dest_path = ports.clear_project_build('libjpeg')
     Path(source_path, 'jconfig.h').write_text(jconfig_h)
     ports.install_headers(source_path)
     excludes = [
@@ -32,7 +31,8 @@ def get(ports, settings, shared):
       'jmemansi.c', 'jmemdos.c', 'jmemmac.c', 'jmemname.c',
       'jpegtran.c', 'rdjpgcom.c', 'wrjpgcom.c',
     ]
-    ports.build_port(source_path, final, dest_path, exclude_files=excludes)
+    build_dir = ports.clear_project_build('libjpeg')
+    ports.build_port(source_path, final, build_dir, exclude_files=excludes)
 
   return [shared.Cache.get_lib('libjpeg.a', create, what='port')]
 

--- a/tools/ports/mpg123.py
+++ b/tools/ports/mpg123.py
@@ -75,8 +75,8 @@ def get(ports, settings, shared):
       os.path.join(compat_path, 'compat_str.c'),
     ]
 
-    dest_path = ports.clear_project_build('mpg123')
-    ports.build_port(source_path, final, dest_path, flags=flags, srcs=srcs)
+    build_dir = ports.clear_project_build('mpg123')
+    ports.build_port(source_path, final, build_dir, flags=flags, srcs=srcs)
 
   return [shared.Cache.get_lib('libmpg123.a', create, what='port')]
 

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -24,8 +24,8 @@ def get(ports, settings, shared):
     source_path = os.path.join(ports.get_dir(), 'ogg', 'Ogg-' + TAG)
     Path(source_path, 'include', 'ogg', 'config_types.h').write_text(config_types_h)
     ports.install_header_dir(os.path.join(source_path, 'include', 'ogg'), 'ogg')
-    dest_path = ports.clear_project_build('ogg')
-    ports.build_port(os.path.join(source_path, 'src'), final, dest_path)
+    build_dir = ports.clear_project_build('ogg')
+    ports.build_port(os.path.join(source_path, 'src'), final, build_dir)
 
   return [shared.Cache.get_lib('libogg.a', create)]
 

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -24,8 +24,8 @@ def get(ports, settings, shared):
   def create(final):
     logging.info('building port: sdl2_gfx')
     source_path = os.path.join(ports.get_dir(), 'sdl2_gfx', 'sdl2_gfx-' + TAG)
-    dest_path = ports.clear_project_build('sdl2_gfx')
-    ports.build_port(source_path, final, dest_path, includes=[dest_path], exclude_dirs=['test'], flags=['-sUSE_SDL=2'])
+    build_dir = ports.clear_project_build('sdl2_gfx')
+    ports.build_port(source_path, final, build_dir, exclude_dirs=['test'], flags=['-sUSE_SDL=2'])
     ports.install_headers(source_path, target='SDL2')
 
   return [shared.Cache.get_lib('libSDL2_gfx.a', create)]

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -42,8 +42,6 @@ def get(ports, settings, shared):
     logging.info('building port: sdl2_mixer')
 
     source_path = os.path.join(ports.get_dir(), 'sdl2_mixer', 'SDL_mixer-' + TAG)
-    dest_path = ports.clear_project_build('sdl2_mixer')
-
     flags = [
       '-sUSE_SDL=2',
       '-O2',
@@ -74,10 +72,11 @@ def get(ports, settings, shared):
         '-DMUSIC_MID_TIMIDITY',
       ]
 
+    build_dir = ports.clear_project_build('sdl2_mixer')
     ports.build_port(
       source_path,
       final,
-      dest_path,
+      build_dir,
       flags=flags,
       exclude_files=[
         'playmus.c',

--- a/tools/ports/sqlite3.py
+++ b/tools/ports/sqlite3.py
@@ -72,8 +72,8 @@ def get(ports, settings, shared):
     else:
       flags += ['-DSQLITE_THREADSAFE=0']
 
-    dest_path = ports.clear_project_build('sqlite3')
-    ports.build_port(source_path, final, dest_path, flags=flags, exclude_files=['shell.c'])
+    build_dir = ports.clear_project_build('sqlite3')
+    ports.build_port(source_path, final, build_dir, flags=flags, exclude_files=['shell.c'])
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -23,9 +23,8 @@ def get(ports, settings, shared):
     logging.info('building port: vorbis')
     source_path = os.path.join(ports.get_dir(), 'vorbis', 'Vorbis-' + TAG)
     ports.install_header_dir(os.path.join(source_path, 'include', 'vorbis'))
-    dest_path = ports.clear_project_build('vorbis')
-    ports.build_port(os.path.join(source_path, 'lib'), final, dest_path,
-                     includes=[os.path.join(dest_path, 'include')],
+    build_dir = ports.clear_project_build('vorbis')
+    ports.build_port(os.path.join(source_path, 'lib'), final, build_dir,
                      flags=['-sUSE_OGG=1'],
                      exclude_files=['psytune', 'barkmel', 'tone', 'misc'])
 

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -24,9 +24,9 @@ def get(ports, settings, shared):
 
     # build
     srcs = 'adler32.c compress.c crc32.c deflate.c gzclose.c gzlib.c gzread.c gzwrite.c infback.c inffast.c inflate.c inftrees.c trees.c uncompr.c zutil.c'.split()
-    dest_path = ports.clear_project_build('zlib')
+    build_dir = ports.clear_project_build('zlib')
     flags = ['-Wno-deprecated-non-prototype']
-    ports.build_port(source_path, final, dest_path, srcs=srcs, flags=flags)
+    ports.build_port(source_path, final, build_dir, srcs=srcs, flags=flags)
 
   return [shared.Cache.get_lib('libz.a', create, what='port')]
 


### PR DESCRIPTION
This used to represent a location where the source was copied to but these days its just a build directory.

I'm planning some followups to avoid cleaning out this directory more often than we need to.