### PR TITLE
ports: Skip cleaning of build directory at start of each build. NFC

### DIFF
--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -108,7 +108,8 @@ class Ports:
       shutil.copyfile(f, os.path.join(dest, os.path.basename(f)))
 
   @staticmethod
-  def build_port(src_dir, output_path, build_dir, includes=[], flags=[], exclude_files=[], exclude_dirs=[], srcs=[]):  # noqa
+  def build_port(src_dir, output_path, port_name, includes=[], flags=[], exclude_files=[], exclude_dirs=[], srcs=[]):  # noqa
+    build_dir = os.path.join(Ports.get_build_dir(), port_name)
     if srcs:
       srcs = [os.path.join(src_dir, s) for s in srcs]
     else:

--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -23,17 +23,17 @@ def get(ports, settings, shared):
     logging.info('building port: boost_headers')
 
     # includes
-    source_path_include = os.path.join(ports.get_dir(), 'boost_headers', 'boost')
+    source_path = os.path.join(ports.get_dir(), 'boost_headers')
+    source_path_include = os.path.join(source_path, 'boost')
     ports.install_header_dir(source_path_include, 'boost')
 
     # write out a dummy cpp file, to create an empty library
     # this is needed as emscripted ports expect this, even if it is not used
-    build_dir = ports.clear_project_build('boost_headers')
-    dummy_file = os.path.join(build_dir, 'dummy.cpp')
+    dummy_file = os.path.join(source_path, 'dummy.cpp')
     shared.safe_ensure_dirs(os.path.dirname(dummy_file))
     Path(dummy_file).write_text('static void dummy() {}')
 
-    ports.build_port(build_dir, final, build_dir)
+    ports.build_port(source_path, final, 'boost_headers', srcs=['dummy.cpp'])
 
   return [shared.Cache.get_lib('libboost_headers.a', create, what='port')]
 

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -45,8 +45,7 @@ def get(ports, settings, shared):
       '-std=gnu++14'
     ]
 
-    build_dir = ports.clear_project_build('bullet')
-    ports.build_port(src_path, final, build_dir, includes=includes, flags=flags, exclude_dirs=['MiniCL'])
+    ports.build_port(src_path, final, 'bullet', includes=includes, flags=flags, exclude_dirs=['MiniCL'])
 
   return [shared.Cache.get_lib('libbullet.a', create)]
 

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -25,8 +25,7 @@ def get(ports, settings, shared):
       'blocksort.c', 'compress.c', 'decompress.c', 'huffman.c',
       'randtable.c', 'bzlib.c', 'crctable.c',
     ]
-    build_dir = ports.clear_project_build('bzip2')
-    ports.build_port(source_path, final, build_dir, srcs=srcs)
+    ports.build_port(source_path, final, 'bzip2', srcs=srcs)
 
   return [shared.Cache.get_lib('libbz2.a', create, what='port')]
 

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -44,13 +44,12 @@ def get(ports, settings, shared):
       '-sUSE_ZLIB=1',
       '-sUSE_LIBPNG=1',
     ]
-    build_dir = ports.clear_project_build('cocos2d')
 
     for dirname in includes:
       target = os.path.join('cocos2d', os.path.relpath(dirname, cocos2d_root))
       ports.install_header_dir(dirname, target=target)
 
-    ports.build_port(cocos2d_src, final, build_dir,
+    ports.build_port(cocos2d_src, final, 'cocos2d',
                      flags=flags,
                      includes=includes,
                      srcs=srcs)

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -91,8 +91,7 @@ def get(ports, settings, shared):
       '-pthread'
     ]
 
-    build_dir = ports.clear_project_build('freetype')
-    ports.build_port(source_path, final, build_dir, flags=flags, srcs=srcs)
+    ports.build_port(source_path, final, 'freetype', flags=flags, srcs=srcs)
 
   return [shared.Cache.get_lib('libfreetype.a', create, what='port')]
 

--- a/tools/ports/giflib.py
+++ b/tools/ports/giflib.py
@@ -21,8 +21,7 @@ def get(ports, settings, shared):
     logging.info('building port: giflib')
     source_path = os.path.join(ports.get_dir(), 'giflib', f'giflib-{VERSION}')
     ports.install_headers(source_path)
-    build_dir = ports.clear_project_build('giflib')
-    ports.build_port(source_path, final, build_dir)
+    ports.build_port(source_path, final, 'giflib')
 
   return [shared.Cache.get_lib('libgif.a', create, what='port')]
 

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -130,8 +130,7 @@ def get(ports, settings, shared):
     else:
       cflags.append('-DHB_NO_MT')
 
-    build_dir = ports.clear_project_build('harfbuzz')
-    ports.build_port(os.path.join(source_path, 'src'), final, build_dir, flags=cflags, srcs=srcs)
+    ports.build_port(os.path.join(source_path, 'src'), final, 'harfbuzz', flags=cflags, srcs=srcs)
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -29,12 +29,10 @@ def get(ports, settings, shared):
   url = 'https://github.com/unicode-org/icu/releases/download/%s/icu4c-%s-src.zip' % (TAG, VERSION)
   ports.fetch_project('icu', url, 'icu', sha512hash=HASH)
   icu_source_path = None
-  build_dir = None
 
   def prepare_build():
-    nonlocal icu_source_path, build_dir
+    nonlocal icu_source_path
     source_path = os.path.join(ports.get_dir(), 'icu', 'icu') # downloaded icu4c path
-    build_dir = ports.clear_project_build('icu') # icu build path
     icu_source_path = os.path.join(source_path, 'source')
 
   def build_lib(lib_output, lib_src, other_includes, build_flags):
@@ -59,7 +57,7 @@ def get(ports, settings, shared):
     if settings.USE_PTHREADS:
       additional_build_flags.append('-pthread')
 
-    ports.build_port(lib_src, lib_output, build_dir, includes=other_includes, flags=build_flags + additional_build_flags)
+    ports.build_port(lib_src, lib_output, 'icu', includes=other_includes, flags=build_flags + additional_build_flags)
 
   # creator for libicu_common
   def create_libicu_common(lib_output):

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -31,8 +31,7 @@ def get(ports, settings, shared):
       'jmemansi.c', 'jmemdos.c', 'jmemmac.c', 'jmemname.c',
       'jpegtran.c', 'rdjpgcom.c', 'wrjpgcom.c',
     ]
-    build_dir = ports.clear_project_build('libjpeg')
-    ports.build_port(source_path, final, build_dir, exclude_files=excludes)
+    ports.build_port(source_path, final, 'libjpeg', exclude_files=excludes)
 
   return [shared.Cache.get_lib('libjpeg.a', create, what='port')]
 

--- a/tools/ports/libmodplug.py
+++ b/tools/ports/libmodplug.py
@@ -79,8 +79,7 @@ def get(ports, settings, shared):
       os.path.join(src_dir, 'sndmix.cpp'),
     ]
 
-    build_dir = ports.clear_project_build('libmodplug')
-    ports.build_port(source_path, final, build_dir, flags=flags, srcs=srcs)
+    ports.build_port(source_path, final, 'libmodplug', flags=flags, srcs=srcs)
 
     ports.install_headers(libmodplug_path, pattern="*.h", target='libmodplug')
     ports.install_headers(src_dir, pattern="modplug.h", target='libmodplug')

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -37,8 +37,7 @@ def get(ports, settings, shared):
     if settings.USE_PTHREADS:
       flags += ['-sUSE_PTHREADS=1']
 
-    build_dir = ports.clear_project_build('libpng')
-    ports.build_port(source_path, final, build_dir, flags=flags, exclude_files=['pngtest'], exclude_dirs=['scripts', 'contrib'])
+    ports.build_port(source_path, final, 'libpng', flags=flags, exclude_files=['pngtest'], exclude_dirs=['scripts', 'contrib'])
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/mpg123.py
+++ b/tools/ports/mpg123.py
@@ -75,8 +75,7 @@ def get(ports, settings, shared):
       os.path.join(compat_path, 'compat_str.c'),
     ]
 
-    build_dir = ports.clear_project_build('mpg123')
-    ports.build_port(source_path, final, build_dir, flags=flags, srcs=srcs)
+    ports.build_port(source_path, final, 'mpg123', flags=flags, srcs=srcs)
 
   return [shared.Cache.get_lib('libmpg123.a', create, what='port')]
 

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -24,8 +24,7 @@ def get(ports, settings, shared):
     source_path = os.path.join(ports.get_dir(), 'ogg', 'Ogg-' + TAG)
     Path(source_path, 'include', 'ogg', 'config_types.h').write_text(config_types_h)
     ports.install_header_dir(os.path.join(source_path, 'include', 'ogg'), 'ogg')
-    build_dir = ports.clear_project_build('ogg')
-    ports.build_port(os.path.join(source_path, 'src'), final, build_dir)
+    ports.build_port(os.path.join(source_path, 'src'), final, 'ogg')
 
   return [shared.Cache.get_lib('libogg.a', create)]
 

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -117,8 +117,7 @@ def get(ports, settings, shared):
     if settings.USE_PTHREADS:
       flags += ['-pthread']
 
-    build_dir = ports.clear_project_build('regal')
-    ports.build_port(source_path_src, final, build_dir, srcs=srcs_regal, flags=flags)
+    ports.build_port(source_path_src, final, 'regal', srcs=srcs_regal, flags=flags)
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -71,8 +71,7 @@ def get(ports, settings, shared):
     includes = [ports.get_include_dir('SDL2')]
     if settings.USE_PTHREADS:
       flags += ['-sUSE_PTHREADS']
-    build_dir = ports.clear_project_build('sdl2')
-    ports.build_port(src_dir, final, build_dir, srcs=srcs, includes=includes, flags=flags)
+    ports.build_port(src_dir, final, 'sdl2', srcs=srcs, includes=includes, flags=flags)
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -24,8 +24,7 @@ def get(ports, settings, shared):
   def create(final):
     logging.info('building port: sdl2_gfx')
     source_path = os.path.join(ports.get_dir(), 'sdl2_gfx', 'sdl2_gfx-' + TAG)
-    build_dir = ports.clear_project_build('sdl2_gfx')
-    ports.build_port(source_path, final, build_dir, exclude_dirs=['test'], flags=['-sUSE_SDL=2'])
+    ports.build_port(source_path, final, 'sdl2_gfx', exclude_dirs=['test'], flags=['-sUSE_SDL=2'])
     ports.install_headers(source_path, target='SDL2')
 
   return [shared.Cache.get_lib('libSDL2_gfx.a', create)]

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -52,8 +52,7 @@ def get(ports, settings, shared):
     if 'jpg' in settings.SDL2_IMAGE_FORMATS:
       defs += ['-sUSE_LIBJPEG=1']
 
-    build_dir = ports.clear_project_build('sdl2_image')
-    ports.build_port(src_dir, final, build_dir, flags=defs, srcs=srcs)
+    ports.build_port(src_dir, final, 'sdl2_image', flags=defs, srcs=srcs)
 
   return [shared.Cache.get_lib(libname, create, what='port')]
 

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -25,9 +25,8 @@ def get(ports, settings, shared):
     logging.info('building port: sdl2_net')
     src_dir = os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG)
     ports.install_headers(src_dir, target='SDL2')
-    build_dir = ports.clear_project_build('sdl2_net')
     excludes = ['chatd.c', 'chat.cpp', 'showinterfaces.c']
-    ports.build_port(src_dir, final, build_dir, exclude_files=excludes)
+    ports.build_port(src_dir, final, 'sdl2_net', exclude_files=excludes)
 
   return [shared.Cache.get_lib('libSDL2_net.a', create, what='port')]
 

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -22,8 +22,7 @@ def get(ports, settings, shared):
     src_root = os.path.join(ports.get_dir(), 'sdl2_ttf', 'SDL_ttf-' + TAG)
     ports.install_headers(src_root, target='SDL2')
     flags = ['-DTTF_USE_HARFBUZZ=1', '-sUSE_SDL=2', '-sUSE_FREETYPE=1', '-sUSE_HARFBUZZ=1']
-    build_dir = ports.clear_project_build('sdl2_ttf')
-    ports.build_port(src_root, final, build_dir, flags=flags, srcs=['SDL_ttf.c'])
+    ports.build_port(src_root, final, 'sdl2_ttf', flags=flags, srcs=['SDL_ttf.c'])
 
   return [shared.Cache.get_lib('libSDL2_ttf.a', create, what='port')]
 

--- a/tools/ports/sqlite3.py
+++ b/tools/ports/sqlite3.py
@@ -72,8 +72,7 @@ def get(ports, settings, shared):
     else:
       flags += ['-DSQLITE_THREADSAFE=0']
 
-    build_dir = ports.clear_project_build('sqlite3')
-    ports.build_port(source_path, final, build_dir, flags=flags, exclude_files=['shell.c'])
+    ports.build_port(source_path, final, 'sqlite3', flags=flags, exclude_files=['shell.c'])
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -23,8 +23,7 @@ def get(ports, settings, shared):
     logging.info('building port: vorbis')
     source_path = os.path.join(ports.get_dir(), 'vorbis', 'Vorbis-' + TAG)
     ports.install_header_dir(os.path.join(source_path, 'include', 'vorbis'))
-    build_dir = ports.clear_project_build('vorbis')
-    ports.build_port(os.path.join(source_path, 'lib'), final, build_dir,
+    ports.build_port(os.path.join(source_path, 'lib'), final, 'vorbis',
                      flags=['-sUSE_OGG=1'],
                      exclude_files=['psytune', 'barkmel', 'tone', 'misc'])
 

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -24,9 +24,8 @@ def get(ports, settings, shared):
 
     # build
     srcs = 'adler32.c compress.c crc32.c deflate.c gzclose.c gzlib.c gzread.c gzwrite.c infback.c inffast.c inflate.c inftrees.c trees.c uncompr.c zutil.c'.split()
-    build_dir = ports.clear_project_build('zlib')
     flags = ['-Wno-deprecated-non-prototype']
-    ports.build_port(source_path, final, build_dir, srcs=srcs, flags=flags)
+    ports.build_port(source_path, final, 'zlib', srcs=srcs, flags=flags)
 
   return [shared.Cache.get_lib('libz.a', create, what='port')]
 


### PR DESCRIPTION
`clear_project_build` is already called each time a new vesion of a port is extracted.  There is no reason to also clear the build directory during the `create` call.

This helps with #17809 and also simplifies the code in each port.