### PR TITLE
Simplify `remove_trailing_zeros`. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -430,10 +430,8 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile):
 
 def remove_trailing_zeros(memfile):
   mem_data = utils.read_binary(memfile)
-  end = len(mem_data)
-  while end > 0 and (mem_data[end - 1] == b'\0' or mem_data[end - 1] == 0):
-    end -= 1
-  utils.write_binary(memfile, mem_data[:end])
+  mem_data = mem_data.rstrip(b'\0')
+  utils.write_binary(memfile, mem_data)
 
 
 @ToolchainProfiler.profile()


### PR DESCRIPTION
I'm not sure why this wasn't written this way to begin with but I verified that we have test coverage for this function, if it fails to strip the trailing white space correctly.