### PR TITLE
Align the length passed to __syscall_mmap2() so the struct map* struc…

### DIFF
--- a/system/lib/libc/emscripten_mmap.c
+++ b/system/lib/libc/emscripten_mmap.c
@@ -28,6 +28,8 @@ struct map {
   struct map* next;
 } __attribute__((aligned (1)));
 
+#define ALIGN_TO(value,alignment) (((value) + ((alignment) - 1)) & ~((alignment) - 1))
+
 // Linked list of all mapping, guarded by a musl-style lock (LOCK/UNLOCK)
 static volatile int lock[1];
 static struct map* mappings;
@@ -126,13 +128,14 @@ intptr_t __syscall_mmap2(intptr_t addr, size_t len, int prot, int flags, int fd,
   // but it is widely used way to allocate memory pages on Linux, BSD and Mac.
   // In this case fd argument is ignored.
   if (flags & MAP_ANONYMOUS) {
+    size_t alloc_len = ALIGN_TO(len, 16);
     // For anonymous maps, allocate that mapping at the end of the region.
-    void* ptr = emscripten_builtin_memalign(WASM_PAGE_SIZE, len + sizeof(struct map));
+    void* ptr = emscripten_builtin_memalign(WASM_PAGE_SIZE, alloc_len + sizeof(struct map));
     if (!ptr) {
       return -ENOMEM;
     }
-    memset(ptr, 0, len);
-    new_map = (struct map*)((char*)ptr + len);
+    memset(ptr, 0, alloc_len);
+    new_map = (struct map*)((char*)ptr + alloc_len);
     new_map->addr = ptr;
     new_map->fd = -1;
     new_map->allocated = true;


### PR DESCRIPTION
…ture is aligned properly.