### PR TITLE
[WasmFS] Add a hack to work around deadlocks

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1560,6 +1560,9 @@ def setup_pthreads(target):
   # All proxying async backends will need this.
   if settings.WASMFS:
     settings.REQUIRED_EXPORTS += ['emscripten_proxy_finish']
+    # TODO: Remove this once we no longer need the heartbeat hack in
+    # wasmfs/thread_utils.h
+    settings.REQUIRED_EXPORTS += ['emscripten_proxy_execute_queue']
 
   # pthread stack setup and other necessary utilities
   def include_and_export(name):

--- a/system/include/emscripten/proxying.h
+++ b/system/include/emscripten/proxying.h
@@ -88,8 +88,6 @@ namespace emscripten {
 
 // A thin C++ wrapper around the underlying C API.
 class ProxyingQueue {
-  em_proxying_queue* queue = em_proxying_queue_create();
-
   static void runAndFree(void* arg) {
     auto* f = (std::function<void()>*)arg;
     (*f)();
@@ -107,6 +105,8 @@ class ProxyingQueue {
   }
 
 public:
+  em_proxying_queue* queue = em_proxying_queue_create();
+
   // ProxyingQueue can be moved but not copied. It is not valid to call any
   // methods on ProxyingQueues that have been moved out of.
   ProxyingQueue() = default;

--- a/system/lib/wasmfs/thread_utils.h
+++ b/system/lib/wasmfs/thread_utils.h
@@ -25,6 +25,24 @@ public:
   // Spawn the worker thread.
   ProxyWorker()
     : queue(), thread([&]() {
+
+      // Sometimes the main thread is spinning, waiting on a WasmFS lock held by
+      // a thread trying to proxy work to this dedicated worker. In that case,
+      // the proxying message won't be relayed by the main thread and the system
+      // will deadlock. This heartbeat ensures that proxying work eventually
+      // gets done so the thread holding the lock can make forward progress even
+      // if the main thread is blocked.
+      //
+      // Note that this requires adding _emscripten_proxy_execute_queue to
+      // EXPORTED_FUNCTIONS.
+      EM_ASM({
+          var heartbeat = () => {
+            _emscripten_proxy_execute_queue($0);
+            setTimeout(heartbeat, 50);
+          };
+          heartbeat();
+        }, queue.queue);
+
         // Sit in the event loop performing work as it comes in.
         emscripten_exit_with_live_runtime();
       }) {}

--- a/system/lib/wasmfs/thread_utils.h
+++ b/system/lib/wasmfs/thread_utils.h
@@ -25,28 +25,28 @@ public:
   // Spawn the worker thread.
   ProxyWorker()
     : queue(), thread([&]() {
-
-      // Sometimes the main thread is spinning, waiting on a WasmFS lock held by
-      // a thread trying to proxy work to this dedicated worker. In that case,
-      // the proxying message won't be relayed by the main thread and the system
-      // will deadlock. This heartbeat ensures that proxying work eventually
-      // gets done so the thread holding the lock can make forward progress even
-      // if the main thread is blocked.
-      //
-      // TODO: Remove this once we can postMessage directly between workers
-      // without involving the main thread.
-      //
-      // Note that this requires adding _emscripten_proxy_execute_queue to
-      // EXPORTED_FUNCTIONS.
-      EM_ASM({
-        var intervalID = setInterval(() => {
-          if (ABORT) {
-            clearInterval(intervalID);
-          } else {
-            _emscripten_proxy_execute_queue($0);
-          }
-        }, 50);
-      }, queue.queue);
+        // Sometimes the main thread is spinning, waiting on a WasmFS lock held
+        // by a thread trying to proxy work to this dedicated worker. In that
+        // case, the proxying message won't be relayed by the main thread and
+        // the system will deadlock. This heartbeat ensures that proxying work
+        // eventually gets done so the thread holding the lock can make forward
+        // progress even if the main thread is blocked.
+        //
+        // TODO: Remove this once we can postMessage directly between workers
+        // without involving the main thread.
+        //
+        // Note that this requires adding _emscripten_proxy_execute_queue to
+        // EXPORTED_FUNCTIONS.
+        EM_ASM({
+          var intervalID =
+            setInterval(() => {
+              if (ABORT) {
+                clearInterval(intervalID);
+              } else {
+                _emscripten_proxy_execute_queue($0);
+              }
+            }, 50);
+          }, queue.queue);
 
         // Sit in the event loop performing work as it comes in.
         emscripten_exit_with_live_runtime();

--- a/system/lib/wasmfs/thread_utils.h
+++ b/system/lib/wasmfs/thread_utils.h
@@ -33,15 +33,20 @@ public:
       // gets done so the thread holding the lock can make forward progress even
       // if the main thread is blocked.
       //
+      // TODO: Remove this once we can postMessage directly between workers
+      // without involving the main thread.
+      //
       // Note that this requires adding _emscripten_proxy_execute_queue to
       // EXPORTED_FUNCTIONS.
       EM_ASM({
-          var heartbeat = () => {
+        var intervalID = setInterval(() => {
+          if (ABORT) {
+            clearInterval(intervalID);
+          } else {
             _emscripten_proxy_execute_queue($0);
-            setTimeout(heartbeat, 50);
-          };
-          heartbeat();
-        }, queue.queue);
+          }
+        }, 50);
+      }, queue.queue);
 
         // Sit in the event loop performing work as it comes in.
         emscripten_exit_with_live_runtime();


### PR DESCRIPTION
When the main thread tries to perform a WasmFS operation that tries to acquire a
lock that is already held by another thread that is trying to proxy a backend
operation, deadlock can occur. Proxying depends on passing a message to a worker
thread and that message has to be relayed through the main thread. When the main
thread is spinning on a lock, the proxying message is not relayed and neither
thread makes forward progress.

Work around the issue by adding a heartbeat event on the dedicated worker thread
to make it execute the queue periodically even without receiving a message from
the main thread. This allows the proxying thread holding the lock to make
forward progress and resolves the deadlock.