### PR TITLE
[WasmFS] Fix a bug and reduce contention on `close`

### DIFF
--- a/system/lib/wasmfs/file_table.cpp
+++ b/system/lib/wasmfs/file_table.cpp
@@ -30,19 +30,19 @@ std::shared_ptr<OpenFileState> FileTable::Handle::getEntry(__wasi_fd_t fd) {
   return fileTable.entries[fd];
 }
 
-int FileTable::Handle::setEntry(__wasi_fd_t fd,
-                                std::shared_ptr<OpenFileState> openFile) {
+std::shared_ptr<DataFile>
+FileTable::Handle::setEntry(__wasi_fd_t fd,
+                            std::shared_ptr<OpenFileState> openFile) {
   assert(fd >= 0);
   if (fd >= fileTable.entries.size()) {
     fileTable.entries.resize(fd + 1);
   }
-  int ret = 0;
-  if (fileTable.entries[fd]) {
-    auto file = fileTable.entries[fd]->locked().getFile();
-    if (auto f = file->dynCast<DataFile>()) {
-      ret = f->locked().close();
-      assert(ret <= 0);
-    }
+  if (openFile) {
+    ++openFile->uses;
+  }
+  std::shared_ptr<DataFile> ret;
+  if (fileTable.entries[fd] && --fileTable.entries[fd]->uses == 0) {
+    ret = fileTable.entries[fd]->locked().getFile()->dynCast<DataFile>();
   }
   fileTable.entries[fd] = openFile;
   return ret;

--- a/system/lib/wasmfs/file_table.h
+++ b/system/lib/wasmfs/file_table.h
@@ -30,6 +30,8 @@ template<typename T> bool addWillOverFlow(T a, T b) {
   return false;
 }
 
+class FileTable;
+
 class OpenFileState : public std::enable_shared_from_this<OpenFileState> {
   std::shared_ptr<File> file;
   off_t position = 0;
@@ -40,11 +42,20 @@ class OpenFileState : public std::enable_shared_from_this<OpenFileState> {
   // open file descriptor.
   std::recursive_mutex mutex;
 
+  // The number of times this OpenFileState appears in the table. Use this
+  // instead of shared_ptr::use_count to avoid accidentally counting temporary
+  // objects.
+  int uses = 0;
+
   // We can't make the constructor private because std::make_shared needs to be
   // able to call it, but we can make it unusable publicly.
   struct private_key {
     explicit private_key(int) {}
   };
+
+  // `uses` is protected by the FileTable lock and can be accessed directly by
+  // `FileTable::Handle.
+  friend FileTable;
 
 public:
   OpenFileState(private_key, oflags_t flags, std::shared_ptr<File> file)
@@ -104,11 +115,13 @@ public:
 
     std::shared_ptr<OpenFileState> getEntry(__wasi_fd_t fd);
 
-    // Set the table slot at `fd` to the given file. Return the result of
-    // closing the file that was previously in that entry or 0 if there was no
-    // previous file.
-    [[nodiscard]] int setEntry(__wasi_fd_t fd,
-                               std::shared_ptr<OpenFileState> openFile);
+    // Set the table slot at `fd` to the given file. If this overwrites the last
+    // reference to an OpenFileState for a data file in the table, return the
+    // file so it can be closed by the caller. Do not close the file directly in
+    // this method so it can be closed later while the FileTable lock is not
+    // held.
+    [[nodiscard]] std::shared_ptr<DataFile>
+    setEntry(__wasi_fd_t fd, std::shared_ptr<OpenFileState> openFile);
     __wasi_fd_t addEntry(std::shared_ptr<OpenFileState> openFileState);
   };
 

--- a/test/wasmfs/wasmfs_opfs.c
+++ b/test/wasmfs/wasmfs_opfs.c
@@ -61,6 +61,15 @@ int main(int argc, char* argv[]) {
 
 #endif // !WASMFS_RESUME
 
+  int newfd1 = dup(fd);
+  assert(newfd1 != -1);
+  int newfd2 = dup(newfd1);
+  assert(newfd2 != -1);
+  err = close(newfd1);
+  assert(err != -1);
+  err = close(newfd2);
+  assert(err != -1);
+
   char buf[100] = {};
   int nread = read(fd, buf, 100);
   assert(nread == strlen(msg));


### PR DESCRIPTION
We were previously calling the backend close method on files every time one of
their fds was closed, but we should have only been calling close on the files
when the last reference to one of their file descriptors was removed from the
file file table. Since the `dup` family of system calls copies fds by reference
rather than by value, these are not the same thing. Due to this bug, it was
possible for `close` to be called on a file more than `open` had been called on
it, which could put backends into invalid states and cause crashes. Fix the
problem by maintaining an explicit reference count on open file descriptors. Do
not just reuse the existing shared_ptr use_count to avoid accidentally
overcounting due to temporary copies of the shared_ptr that are not in the
table.

While fixing that bug, also take the opportunity to reduce lock contention due
to `close` by releasing the file table lock before calling into the backend to
close a file. `close` can be an expensive operation in the backend and the file
table has to be locked frequently, so this was previously a major source of
contention.