### PR TITLE
Deprecate -sCLOSURE_WARNINGS in favor or normal -W flags

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,12 +27,17 @@ See docs/process.md for more on how version tagging works.
 - C++17 is now the default version of the C++ standard used by the compiler.
   This is due to an upstream change in llvm.  Use `-std=c++14` (or technically
   `-std=gnu++14`) to revert to the previous default.
+- Closure warnings are now controlled via the standard `-Wclosure` warning flags
+  rather than via a specific/custom `CLOSURE_WARNINGS` setting.  The old
+  setting continues to work but will issue a deprecation warning.
+  If you link with `-Werror` but you don't want closure warnings to be errors
+  you can add `-Wno-error=closure` or `-Wno-closure`.
 
 3.1.21 - 09/09/2022
 -------------------
 - Update SDL2 port to 2.24.0 (#17748)
 - The `LEGACY_RUNTIME` setting is no longer enabled by default.  If you use any
-  of these legacy runtime functions (except in library code with explict
+  of these legacy runtime functions (except in library code with explicit
   dependencies) then you would need to set `LEGACY_RUNTIME` on the command line
   or add the ones you need to `DEFAULT_LIBRARY_FUNCS_TO_INCLUDE`:
    - addFunction

--- a/emcc.py
+++ b/emcc.py
@@ -1866,8 +1866,21 @@ def phase_linker_setup(options, state, newargs, user_settings):
   if options.use_closure_compiler:
     settings.USE_CLOSURE_COMPILER = 1
 
-  if settings.CLOSURE_WARNINGS not in ['quiet', 'warn', 'error']:
-    exit_with_error('Invalid option -sCLOSURE_WARNINGS=%s specified! Allowed values are "quiet", "warn" or "error".' % settings.CLOSURE_WARNINGS)
+  if settings.CLOSURE_WARNINGS:
+    if settings.CLOSURE_WARNINGS not in ['quiet', 'warn', 'error']:
+      exit_with_error('Invalid option -sCLOSURE_WARNINGS=%s specified! Allowed values are "quiet", "warn" or "error".' % settings.CLOSURE_WARNINGS)
+
+    diagnostics.warning('deprecated', 'CLOSURE_WARNINGS is deprecated, use -Wclosure/-Wno-closure instread')
+    closure_warnings = diagnostics.manager.warnings['closure']
+    if settings.CLOSURE_WARNINGS == 'error':
+      closure_warnings['error'] = True
+      closure_warnings['enabled'] = True
+    elif settings.CLOSURE_WARNINGS == 'warn':
+      closure_warnings['error'] = False
+      closure_warnings['enabled'] = True
+    elif settings.CLOSURE_WARNINGS == 'quiet':
+      closure_warnings['error'] = False
+      closure_warnings['enabled'] = False
 
   if not settings.MINIMAL_RUNTIME:
     if not settings.BOOTSTRAPPING_STRUCT_INFO:

--- a/src/settings.js
+++ b/src/settings.js
@@ -265,12 +265,13 @@ var GLOBAL_BASE = 1024;
 // [link]
 var USE_CLOSURE_COMPILER = false;
 
-// Specifies how warnings emitted by Closure are treated. Possible
-// options: 'quiet', 'warn', 'error'. If set to 'warn', Closure warnings are printed
-// out to console. If set to 'error', Closure warnings are treated like errors,
-// similar to -Werror compiler flag.
+// Deprecated: Use the standard warnings flags instead. e.g. `-Wclosure`,
+// `-Wno-closure`, `-Werror=closure`.
+// options: 'quiet', 'warn', 'error'. If set to 'warn', Closure warnings are
+// printed out to console. If set to 'error', Closure warnings are treated like
+// errors, similar to -Werror compiler flag.
 // [link]
-var CLOSURE_WARNINGS = 'quiet';
+var CLOSURE_WARNINGS = '';
 
 // Ignore closure warnings and errors (like on duplicate definitions)
 // [link]

--- a/test/common.py
+++ b/test/common.py
@@ -496,10 +496,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     super().setUp()
     self.settings_mods = {}
     self.emcc_args = ['-Werror', '-Wno-limited-postlink-optimizations']
-    # We want to be strict about closure warnings in our test code.
-    # TODO(sbc): Remove this if we make it the default for `-Werror`:
-    # https://github.com/emscripten-core/emscripten/issues/16205):
-    self.ldflags = ['-sCLOSURE_WARNINGS=error']
+    self.ldflags = []
     self.node_args = [
       # Increate stack trace limit to maximise usefulness of test failure reports
       '--stack-trace-limit=50',

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1447,7 +1447,9 @@ keydown(100);keyup(100); // trigger the end
     print('    opts')
     self.btest_exit(test_file('fs/test_lz4fs.cpp'), 1, args=['-DLOAD_MANUALLY', '-sLZ4=1', '-sFORCE_FILESYSTEM', '-O2'])
     print('    opts+closure')
-    self.btest_exit(test_file('fs/test_lz4fs.cpp'), 1, args=['-DLOAD_MANUALLY', '-sLZ4=1', '-sFORCE_FILESYSTEM', '-O2', '--closure=1', '-g1', '-sCLOSURE_WARNINGS=quiet'])
+    self.btest_exit(test_file('fs/test_lz4fs.cpp'), 1, args=['-DLOAD_MANUALLY', '-sLZ4=1',
+                                                             '-sFORCE_FILESYSTEM', '-O2',
+                                                             '--closure=1', '-g1', '-Wno-closure'])
 
     '''# non-lz4 for comparison
     try:
@@ -3474,7 +3476,7 @@ Module["preRun"].push(function () {
   def test_modularize_and_preload_files(self):
     self.set_setting('EXIT_RUNTIME')
     # TODO(sbc): Fix closure warnings with MODULARIZE + WASM=0
-    self.ldflags.remove('-sCLOSURE_WARNINGS=error')
+    self.ldflags.append('-Wno-error=closure')
     # amount of memory different from the default one that will be allocated for the emscripten heap
     totalMemory = 33554432
     for opts in [[], ['-O1'], ['-O2', '-profiling'], ['-O2'], ['-O2', '--closure=1']]:
@@ -5032,7 +5034,7 @@ Module["preRun"].push(function () {
 
   def test_no_declare_asm_module_exports_asmjs(self):
     # TODO(sbc): Fix closure warnings with MODULARIZE + WASM=0
-    self.ldflags.remove('-sCLOSURE_WARNINGS=error')
+    self.ldflags.append('-Wno-error=closure')
     for minimal_runtime in [[], ['-sMINIMAL_RUNTIME']]:
       self.btest(test_file('declare_asm_module_exports.cpp'), '1', args=['-sDECLARE_ASM_MODULE_EXPORTS=0', '-sENVIRONMENT=web', '-O3', '--closure=1', '-sWASM=0'] + minimal_runtime)
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5450,7 +5450,7 @@ Pass: 0.000012 0.000012''')
       self.emcc_args += ['--closure', '2'] # Use closure 2 here for some additional coverage
       # Sadly --closure=2 is not yet free of closure warnings
       # FIXME(https://github.com/emscripten-core/emscripten/issues/17080)
-      self.ldflags.remove('-sCLOSURE_WARNINGS=error')
+      self.ldflags.append('-Wno-error=closure')
     elif self.maybe_closure():
       # closure can generate variables called 'gc', which pick up js shell stuff
       self.banned_js_engines = [config.SPIDERMONKEY_ENGINE]
@@ -7639,7 +7639,7 @@ void* operator new(size_t size) {
   def test_webidl(self, mode, allow_memory_growth):
     self.uses_es6 = True
     # TODO(): Remove once we make webidl output closure-warning free.
-    self.ldflags.remove('-sCLOSURE_WARNINGS=error')
+    self.ldflags.append('-Wno-error=closure')
     self.set_setting('WASM_ASYNC_COMPILATION', 0)
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$intArrayFromString'])
     if self.maybe_closure():
@@ -7905,7 +7905,7 @@ void* operator new(size_t size) {
     create_file('post.js', 'var TheModule = Module();\n')
     if not self.is_wasm():
       # TODO(sbc): Fix closure warnings with MODULARIZE + WASM=0
-      self.ldflags.remove('-sCLOSURE_WARNINGS=error')
+      self.ldflags.append('-Wno-error=closure')
 
     self.emcc_args += [
       '--pre-js', test_file('core/modularize_closure_pre.js'),

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8232,7 +8232,7 @@ end
     # Test for closure errors and warnings in the entire JS library.
     self.build(test_file('hello_world.c'), emcc_args=[
       '--closure=1',
-      '-sCLOSURE_WARNINGS=error',
+      '-Werror=closure',
       '-sINCLUDE_FULL_LIBRARY',
       # Enable as many features as possible in order to maximise
       # tha amount of library code we inculde here.
@@ -8246,7 +8246,7 @@ end
     # This test can be removed if USE_WEBGPU is later included in INCLUDE_FULL_LIBRARY.
     self.build(test_file('hello_world.c'), emcc_args=[
       '--closure=1',
-      '-sCLOSURE_WARNINGS=error',
+      '-Werror=closure',
       '-sINCLUDE_FULL_LIBRARY',
       '-sUSE_WEBGPU'
     ])
@@ -8318,7 +8318,7 @@ end
       '-sINCLUDE_FULL_LIBRARY',
       '-sFETCH',
       '-sFETCH_SUPPORT_INDEXEDDB',
-      '-sCLOSURE_WARNINGS=error',
+      '-Werror=closure',
       '--pre-js=pre.js'
     ])
     code = read_file('hello_world.js')
@@ -9450,7 +9450,7 @@ int main () {
 
     for closure in [[], ['--closure=1']]:
       for opt in [['-O2'], ['-O3'], ['-Os']]:
-        test(['-sWASM=0'], closure, opt)
+        test(['-sWASM=0', '-Wno-closure'], closure, opt)
         test(['-sWASM_ASYNC_COMPILATION=0'], closure, opt)
 
   @parameterized({
@@ -10724,13 +10724,22 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
 
   # Verifies that warning messages that Closure outputs are recorded to console
   def test_closure_warnings(self):
-    proc = self.run_process([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-sCLOSURE_WARNINGS=quiet'], stderr=PIPE)
+    proc = self.run_process([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-Wno-closure'], stderr=PIPE)
     self.assertNotContained('WARNING', proc.stderr)
 
-    proc = self.run_process([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-sCLOSURE_WARNINGS=warn'], stderr=PIPE)
+    proc = self.run_process([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-Wno-error=closure'], stderr=PIPE)
     self.assertContained('WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration', proc.stderr)
 
-    self.expect_fail([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-sCLOSURE_WARNINGS=error'])
+    self.expect_fail([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-Werror=closure'])
+
+    # Run the same tests again with deprecated `-sCLOSURE_WARNINGS` setting instead
+    proc = self.run_process([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-sCLOSURE_WARNINGS=quiet', '-Wno-deprecated'], stderr=PIPE)
+    self.assertNotContained('WARNING', proc.stderr)
+
+    proc = self.run_process([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-sCLOSURE_WARNINGS=warn', '-Wno-deprecated'], stderr=PIPE)
+    self.assertContained('WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration', proc.stderr)
+
+    self.expect_fail([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-sCLOSURE_WARNINGS=error', '-Wno-deprecated'])
 
   def test_bitcode_input(self):
     # Verify that bitcode files are accepted as input
@@ -11214,17 +11223,17 @@ exec "$@"
 
   # Make sure that --cpuprofiler compiles with --closure 1
   def test_cpuprofiler_closure(self):
-    # TODO: Enable '-sCLOSURE_WARNINGS=error' in the following, but that has currently regressed.
+    # TODO: Enable '-Werror=closure' in the following, but that has currently regressed.
     self.run_process([EMCC, test_file('hello_world.c'), '-O2', '--closure=1', '--cpuprofiler'])
 
   # Make sure that --memoryprofiler compiles with --closure 1
   def test_memoryprofiler_closure(self):
-    # TODO: Enable '-sCLOSURE_WARNINGS=error' in the following, but that has currently regressed.
+    # TODO: Enable '-Werror=closure' in the following, but that has currently regressed.
     self.run_process([EMCC, test_file('hello_world.c'), '-O2', '--closure=1', '--memoryprofiler'])
 
   # Make sure that --threadprofiler compiles with --closure 1
   def test_threadprofiler_closure(self):
-    # TODO: Enable '-sCLOSURE_WARNINGS=error' in the following, but that has currently regressed.
+    # TODO: Enable '-Werror=closure' in the following, but that has currently regressed.
     self.run_process([EMCC, test_file('hello_world.c'), '-O2', '-sUSE_PTHREADS', '--closure=1', '--threadprofiler', '-sASSERTIONS'])
 
   @node_pthreads

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -74,6 +74,7 @@ diagnostics.add_warning('transpile')
 diagnostics.add_warning('limited-postlink-optimizations')
 diagnostics.add_warning('em-js-i64')
 diagnostics.add_warning('js-compiler')
+diagnostics.add_warning('closure')
 
 
 # TODO(sbc): Investigate switching to shlex.quote


### PR DESCRIPTION
One noticable effect of this change is that closure users who link with `-Werror` will now have thier closure warnings treated as errors. `-Wno-error=closure` can disabled these just like any other warning.

Fixes: #16205