### PR TITLE
Remove __EMSCRIPTEN_major/minor/tiny__ from command line flags.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 3.1.23 (in development)
 -----------------------
+- The `__EMSCRIPTEN_major__/minor__/tiny__` macros are no longer defined on the
+  command line but require `<emscripten.h/>` (or just `<emscripten/version.h>`
+  to be included. (#17883)
 
 3.1.22 - 09/19/22
 -----------------

--- a/emcc.py
+++ b/emcc.py
@@ -900,12 +900,6 @@ def get_cflags(user_args, is_cxx):
     # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code
     # in strict mode. Code should use the define __EMSCRIPTEN__ instead.
     cflags.append('-DEMSCRIPTEN')
-    # The __EMSCRIPTEN_major__/__EMSCRIPTEN_minor__/__EMSCRIPTEN_tiny__ macros
-    # are now defined in emscripten/version.h but in non-strict mode, we continue
-    # to define them here (for now) for backwards compatibility.
-    cflags += ['-D__EMSCRIPTEN_major__=' + str(shared.EMSCRIPTEN_VERSION_MAJOR),
-               '-D__EMSCRIPTEN_minor__=' + str(shared.EMSCRIPTEN_VERSION_MINOR),
-               '-D__EMSCRIPTEN_tiny__=' + str(shared.EMSCRIPTEN_VERSION_TINY)]
 
   # Changes to default clang behavior
 


### PR DESCRIPTION
There were already not present in STRICT mode, this change completely removes them.

These macros are defined in `<emscripten/version.h>` (which is included by `<emscripten.h>`).  Removing the redundant definition from the command line simplifies the underlying clang commands that emcc generates and brings us closer the vanilla clang.