### PR TITLE
Check for invalid symbol names in llvm-nm output.

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -576,7 +576,7 @@ def parse_llvm_nm_symbols(output):
 
     filename = line[:filename_pos]
     if entry_pos + 13 >= len(line):
-      exit_with_error('error parsing output of llvm-nm: `%s`\nIf the symbol name here contains a colon, and starts with __invoke_, then the object file was likely built with and old version of llvm.' % line)
+      exit_with_error('error parsing output of llvm-nm: `%s`\nIf the symbol name here contains a colon, and starts with __invoke_, then the object file was likely built with an old version of llvm (please rebuild it).' % line)
 
     status = line[entry_pos + 11] # Skip address, which is always fixed-length 8 chars.
     symbol = line[entry_pos + 13:]

--- a/tools/building.py
+++ b/tools/building.py
@@ -575,6 +575,9 @@ def parse_llvm_nm_symbols(output):
       filename_pos = entry_pos
 
     filename = line[:filename_pos]
+    if entry_pos + 13 >= len(line):
+      exit_with_error('error parsing output of llvm-nm: `%s`\nIf the symbol name here contains a colon, and starts with __invoke_, then the object file was likely built with and old version of llvm.' % line)
+
     status = line[entry_pos + 11] # Skip address, which is always fixed-length 8 chars.
     symbol = line[entry_pos + 13:]
 


### PR DESCRIPTION
See https://github.com/emscripten-core/emscripten/issues/12551 and:
https://github.com/emscripten-core/emscripten/issues/17826

Older versions of llvm didn't used to mangle these __invoke symbols.