### PR TITLE
Fix timeout in run_multiple_processes

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -219,7 +219,7 @@ def run_multiple_processes(commands,
           # All processes still running; wait a short while for the first (oldest) process to finish,
           # then look again if any process has completed.
           try:
-            out, err = processes[0][1].communicate(0.2)
+            out, err = processes[0][1].communicate(timeout=0.2)
             return (0, out.decode('UTF-8') if out else '', err.decode('UTF-8') if err else '')
           except subprocess.TimeoutExpired:
             pass


### PR DESCRIPTION
The first argument to `communicate` is `stdin` so this parameter wasn't doing what it was intended to do.  This means that when the max number of processes was met we could always block until the first of them was finished, instead of checking the entire list ever 200 milliseconds.

For things like building libcxx (where each object file can take a while to build) this can slow down the build but reducing the parallelism.