### PR TITLE
Revert part of #17878

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1860,7 +1860,7 @@ def phase_linker_setup(options, state, newargs, user_settings):
   if options.use_closure_compiler:
     settings.USE_CLOSURE_COMPILER = 1
 
-  if settings.CLOSURE_WARNINGS:
+  if 'CLOSURE_WARNINGS' in user_settings:
     if settings.CLOSURE_WARNINGS not in ['quiet', 'warn', 'error']:
       exit_with_error('Invalid option -sCLOSURE_WARNINGS=%s specified! Allowed values are "quiet", "warn" or "error".' % settings.CLOSURE_WARNINGS)
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -271,7 +271,7 @@ var USE_CLOSURE_COMPILER = false;
 // printed out to console. If set to 'error', Closure warnings are treated like
 // errors, similar to -Werror compiler flag.
 // [link]
-var CLOSURE_WARNINGS = '';
+var CLOSURE_WARNINGS = 'quiet';
 
 // Ignore closure warnings and errors (like on duplicate definitions)
 // [link]

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10725,15 +10725,20 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
 
   # Verifies that warning messages that Closure outputs are recorded to console
   def test_closure_warnings(self):
+    # Default should be no warnings
+    proc = self.run_process([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1'], stderr=PIPE)
+    self.assertNotContained('WARNING', proc.stderr)
     proc = self.run_process([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-Wno-closure'], stderr=PIPE)
     self.assertNotContained('WARNING', proc.stderr)
 
-    proc = self.run_process([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-Wno-error=closure'], stderr=PIPE)
+    proc = self.run_process([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-Wclosure'], stderr=PIPE)
     self.assertContained('WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration', proc.stderr)
 
     self.expect_fail([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-Werror=closure'])
 
     # Run the same tests again with deprecated `-sCLOSURE_WARNINGS` setting instead
+    proc = self.run_process([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-Wno-deprecated'], stderr=PIPE)
+    self.assertNotContained('WARNING', proc.stderr)
     proc = self.run_process([EMCC, test_file('test_closure_warning.c'), '-O3', '--closure=1', '-sCLOSURE_WARNINGS=quiet', '-Wno-deprecated'], stderr=PIPE)
     self.assertNotContained('WARNING', proc.stderr)
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -74,7 +74,8 @@ diagnostics.add_warning('transpile')
 diagnostics.add_warning('limited-postlink-optimizations')
 diagnostics.add_warning('em-js-i64')
 diagnostics.add_warning('js-compiler')
-diagnostics.add_warning('closure')
+# Closure warning are not (yet) enabled by default
+diagnostics.add_warning('closure', enabled=False)
 
 
 # TODO(sbc): Investigate switching to shlex.quote


### PR DESCRIPTION
In #17878 I mistakenly changed the default for closure warnings from "quiet" (disabled) to "warn" (enabled).

While we might want to do that change I want to make that change explicit and separate from the change to use the `-W` flag system.