### PR TITLE
[WasmFS] Barebones MAP_SHARED support

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -585,8 +585,8 @@ var SyscallsLibrary = {
 
     return total;
   },
-  _msync_js__sig: 'ippii',
-  _msync_js: function(addr, len, flags, fd) {
+  _msync_js__sig: 'ippiiip',
+  _msync_js: function(addr, len, prot, flags, fd, offset) {
     SYSCALLS.doMsync(addr, SYSCALLS.getStreamFromFD(fd), len, flags, 0);
     return 0;
   },

--- a/system/lib/libc/emscripten_mmap.c
+++ b/system/lib/libc/emscripten_mmap.c
@@ -43,7 +43,8 @@ int _mmap_js(size_t length,
              int* allocated,
              void** addr);
 int _munmap_js(intptr_t addr, size_t length, int prot, int flags, int fd, size_t offset);
-int _msync_js(intptr_t addr, size_t length, int flags, int fd);
+int _msync_js(
+  intptr_t addr, size_t length, int prot, int flags, int fd, size_t offset);
 
 static struct map* find_mapping(intptr_t addr, struct map** prev) {
   struct map* map = mappings;
@@ -112,7 +113,7 @@ int __syscall_msync(intptr_t addr, size_t len, int flags) {
   if (map->flags & MAP_ANONYMOUS) {
     return 0;
   }
-  return _msync_js(addr, len, map->flags, map->fd);
+  return _msync_js(addr, len, map->prot, map->flags, map->fd, map->offset);
 }
 
 intptr_t __syscall_mmap2(intptr_t addr, size_t len, int prot, int flags, int fd, size_t off) {

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1544,6 +1544,23 @@ int _mmap_js(size_t length,
              size_t offset,
              int* allocated,
              void** addr) {
+  // PROT_EXEC is not supported (although we pretend to support the absence of
+  // PROT_READ or PROT_WRITE).
+  if ((prot & PROT_EXEC)) {
+    return -EPERM;
+  }
+
+  // One of MAP_PRIVATE, MAP_SHARED, or MAP_SHARED_VALIDATE must be used.
+  int mapType = flags & MAP_TYPE;
+  if (mapType != MAP_PRIVATE && mapType != MAP_SHARED &&
+      mapType != MAP_SHARED_VALIDATE) {
+    return -EINVAL;
+  }
+
+  if (mapType == MAP_SHARED_VALIDATE) {
+    WASMFS_UNREACHABLE("TODO: MAP_SHARED_VALIDATE");
+  }
+
   auto openFile = wasmFS.getFileTable().locked().getEntry(fd);
   if (!openFile) {
     return -EBADF;
@@ -1564,7 +1581,7 @@ int _mmap_js(size_t length,
     // According to the POSIX spec it is possible to write to a file opened in
     // read-only mode with MAP_PRIVATE flag, as all modifications will be
     // visible only in the memory of the current process.
-    if ((prot & PROT_WRITE) != 0 && (flags & MAP_PRIVATE) == 0 &&
+    if ((prot & PROT_WRITE) != 0 && mapType != MAP_PRIVATE &&
         (lockedOpenFile.getFlags() & O_ACCMODE) != O_RDWR) {
       return -EACCES;
     }
@@ -1576,11 +1593,10 @@ int _mmap_js(size_t length,
     return -ENODEV;
   }
 
-  // TODO: handle non-private mmaps. Those can be optimized in interesting ways
-  //       like avoiding an allocation and a copy as we do below (whereas a
-  //       private mmap is always a copy into a new, private region not shared
-  //       with anything else).
-  assert(flags & MAP_PRIVATE);
+  // TODO: On MAP_SHARED, install the mapping on the DataFile object itself so
+  // that reads and writes can be redirected to the mapped region and so that
+  // the mapping can correctly outlive the file being closed. This will require
+  // changes to emscripten_mmap.c as well.
 
   // Align to a wasm page size, as we expect in the future to get wasm
   // primitives to do this work, and those would presumably be aligned to a page
@@ -1609,6 +1625,31 @@ int _mmap_js(size_t length,
   memset(ptr + nread, 0, length - nread);
 
   return 0;
+}
+
+int _msync_js(
+  intptr_t addr, size_t length, int prot, int flags, int fd, size_t offset) {
+  // TOOD: This is not correct! Mappings should be associated with files, not
+  // fds. Only need to sync if shared and writes are allowed.
+  int mapType = flags & MAP_TYPE;
+  if (mapType == MAP_SHARED && (prot & PROT_WRITE)) {
+    __wasi_ciovec_t iovec;
+    iovec.buf = (uint8_t*)addr;
+    iovec.buf_len = length;
+    __wasi_size_t nwritten;
+    // Translate from WASI positive error codes to negative error codes.
+    auto ret = -__wasi_fd_pwrite(fd, &iovec, 1, offset, &nwritten);
+    return ret;
+  }
+  return 0;
+}
+
+int _munmap_js(
+  intptr_t addr, size_t length, int prot, int flags, int fd, size_t offset) {
+  // TOOD: This is not correct! Mappings should be associated with files, not
+  // fds.
+  // TODO: Syncing should probably be handled in __syscall_munmap instead.
+  return _msync_js(addr, length, prot, flags, fd, offset);
 }
 
 // Stubs (at least for now)

--- a/test/fs/test_mmap.c
+++ b/test/fs/test_mmap.c
@@ -223,7 +223,7 @@ void test_mmap_hint() {
  * operation.
  */
 void test_mmap_overallocate() {
-#if !defined(NODEFS) && !defined(NODERAWFS)
+#if !defined(NODEFS) && !defined(NODERAWFS) && !defined(WASMFS)
   int fd = open("yolo/overallocatedfile.txt", O_RDWR | O_CREAT, (mode_t)0600);
   assert(fd != -1);
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5876,6 +5876,7 @@ main( int argv, char ** argc ) {
     'memfs': ['MEMFS'],
     'nodefs': ['NODEFS'],
     'noderaswfs': ['NODERAWFS'],
+    'wasmfs': ['WASMFS']
   })
   def test_fs_mmap(self, fs):
     self.uses_es6 = True
@@ -5885,6 +5886,9 @@ main( int argv, char ** argc ) {
     if fs == 'NODERAWFS':
       self.require_node()
       self.emcc_args += ['-lnodefs.js', '-lnoderawfs.js']
+    if fs == 'WASMFS':
+      print("HELLO")
+      self.emcc_args += ['-sWASMFS', '-sFORCE_FILESYSTEM']
     self.do_run_in_out_file_test('fs/test_mmap.c', emcc_args=['-D' + fs])
 
   @parameterized({


### PR DESCRIPTION
Support MAP_SHARED to the extent that the legacy FS supports MAP_SHARED. In
particular, implement it so that mysnc and munmap will write the memory contents
back to the mapped file as long as the file is still open with the same file
descriptor.

Associating mappings with file descriptors is not correct behavior and `read`
may not be consistent with the contents of the mapping, but at least this will
make MAP_SHARED work for WasmFS in cases where it worked with the legacy FS.