### PR TITLE
Added support for utf8 strings using std::u8string

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -685,9 +685,9 @@ var LibraryEmbind = {
     var stdStringIsUTF8
 #if EMBIND_STD_STRING_IS_UTF8
     //process only std::string bindings with UTF8 support, in contrast to e.g. std::basic_string<unsigned char>
-    = (name === "std::string");
+    = (name === "std::string" || name == "std::u8string");
 #else
-    = false;
+    = (name === "std::u8string");
 #endif
 
     registerType(rawType, {

--- a/system/lib/embind/bind.cpp
+++ b/system/lib/embind/bind.cpp
@@ -143,6 +143,7 @@ EMSCRIPTEN_BINDINGS(builtin) {
   register_float<double>("double");
 
   _embind_register_std_string(TypeID<std::string>::get(), "std::string");
+  _embind_register_std_string(TypeID<std::u8string>::get(), "std::u8string");
   _embind_register_std_string(
     TypeID<std::basic_string<unsigned char>>::get(), "std::basic_string<unsigned char>");
   _embind_register_std_wstring(TypeID<std::wstring>::get(), sizeof(wchar_t), "std::wstring");

--- a/test/embind/embind.test.js
+++ b/test/embind/embind.test.js
@@ -470,6 +470,11 @@ module({
             var e = cm.emval_test_take_and_return_std_string(string);
             assert.equal(string, e);
         });
+
+        var utf8TestString = String.fromCharCode(10) +
+            String.fromCharCode(1234) +
+            String.fromCharCode(2345) +
+            String.fromCharCode(65535);
         
         var utf16TestString = String.fromCharCode(10) +
             String.fromCharCode(1234) +
@@ -487,6 +492,10 @@ module({
             assert.equal(utf16TestString, cm.get_non_ascii_wstring());
         });
 
+        test("non-ascii u8strings", function() {
+            assert.equal(utf8TestString, cm.get_non_ascii_u8string());
+        });
+
         test("non-ascii u16strings", function() {
             assert.equal(utf16TestString, cm.get_non_ascii_u16string());
         });
@@ -497,6 +506,10 @@ module({
 
         test("passing unicode (wide) string into C++", function() {
             assert.equal(utf16TestString, cm.take_and_return_std_wstring(utf16TestString));
+        });
+
+        test("passing unicode (utf-8) string into C++", function() {
+            assert.equal(utf8TestString, cm.take_and_return_std_u8string(utf8TestString));
         });
 
         test("passing unicode (utf-16) string into C++", function() {
@@ -511,6 +524,11 @@ module({
             test("can access a literal wstring after a memory growth", function() {
                 cm.force_memory_growth();
                 assert.equal("get_literal_wstring", cm.get_literal_wstring());
+            });
+
+            test("can access a literal u8string after a memory growth", function() {
+                cm.force_memory_growth();
+                assert.equal("get_literal_u8string", cm.get_literal_u8string());
             });
             
             test("can access a literal u16string after a memory growth", function() {

--- a/test/embind/embind_test.cpp
+++ b/test/embind/embind_test.cpp
@@ -161,6 +161,25 @@ std::wstring get_non_ascii_wstring() {
     return ws;
 }
 
+std::u8string get_non_ascii_u8string() {
+  std::u8string u8s(14, 0);
+  u8s[0] = 0xa;
+  u8s[1] = 0xd3;
+  u8s[2] = 0x92;
+  u8s[3] = 0xe0;
+  u8s[4] = 0xa4;
+  u8s[5] = 0xa9;
+  u8s[6] = 0xf0;
+  u8s[7] = 0x9f;
+  u8s[8] = 0x98;
+  u8s[9] = 0x81;
+  u8s[10] = 0xf0;
+  u8s[11] = 0x9f;
+  u8s[12] = 0x9a;
+  u8s[13] = 0x80;
+  return u8s;
+}
+
 std::u16string get_non_ascii_u16string() {
     std::u16string u16s(4, 0);
     u16s[0] = 10;
@@ -182,6 +201,10 @@ std::u32string get_non_ascii_u32string() {
 
 std::wstring get_literal_wstring() {
     return L"get_literal_wstring";
+}
+
+std::u8string get_literal_u8string() {
+    return u8"get_literal_u8string";
 }
 
 std::u16string get_literal_u16string() {
@@ -221,6 +244,10 @@ std::basic_string<unsigned char> emval_test_take_and_return_std_basic_string_uns
 }
 
 std::wstring take_and_return_std_wstring(std::wstring str) {
+    return str;
+}
+
+std::u8string take_and_return_std_u8string(std::u8string str) {
     return str;
 }
 
@@ -1833,10 +1860,13 @@ EMSCRIPTEN_BINDINGS(tests) {
     function("emval_test_take_and_return_std_string_const_ref", &emval_test_take_and_return_std_string_const_ref);
     function("emval_test_take_and_return_std_basic_string_unsigned_char", &emval_test_take_and_return_std_basic_string_unsigned_char);
     function("take_and_return_std_wstring", &take_and_return_std_wstring);
+    function("take_and_return_std_u8string", &take_and_return_std_u8string);
     function("take_and_return_std_u16string", &take_and_return_std_u16string);
     function("take_and_return_std_u32string", &take_and_return_std_u32string);
+    function("get_non_ascii_u8string", &get_non_ascii_u8string);
     function("get_non_ascii_u16string", &get_non_ascii_u16string);
     function("get_non_ascii_u32string", &get_non_ascii_u32string);
+    function("get_literal_u8string", &get_literal_u8string);
     function("get_literal_u16string", &get_literal_u16string);
     function("get_literal_u32string", &get_literal_u32string);
 


### PR DESCRIPTION
This merge request add support for the `std::u8string` type, a string type that is unambiguously utf8 encoded.

C++20 added the type `char8_t` alongside with `std::u8string`. Embind still didn't knew how to pass that string type around despite knowing how to pass `std::string` assuming utf8.

This allow using a more robust interface between c++ and javascript when using multiple encoding types withing a C++ code.