### PR TITLE
Fix get_library() to work with native mode

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -972,7 +972,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     # get_library() is used to compile libraries, and not link executables,
     # so we don't want to pass linker flags here (emscripten warns if you
     # try to pass linker settings when compiling).
-    emcc_args = self.get_emcc_args(ldflags=False)
+    emcc_args = []
+    if not native:
+      emcc_args = self.get_emcc_args(ldflags=False)
 
     hash_input = (str(emcc_args) + ' $ ' + str(env_init)).encode('utf-8')
     cache_name = name + ','.join([opt for opt in emcc_args if len(opt) < 7]) + '_' + hashlib.md5(hash_input).hexdigest() + cache_name_extra


### PR DESCRIPTION
When `get_library`'s `native` parameter is `True`, `emcc_args` should not be used, because they can be emcc-only args and not clang args. For example, currently we have
https://github.com/emscripten-core/emscripten/blob/929a6d5810908065bf23aa2af492da32ab572d57/test/common.py#L489 And `-Wno-limited-postlink-optimizations` only exists in emscripten, so it errors out when directly fed to clang.

So all `NativeBenchmarker` tests fail when calling `lib_builder`, https://github.com/emscripten-core/emscripten/blob/929a6d5810908065bf23aa2af492da32ab572d57/test/test_benchmark.py#L141 which calls `get_library`, e.g.
https://github.com/emscripten-core/emscripten/blob/929a6d5810908065bf23aa2af492da32ab572d57/test/test_benchmark.py#L994 with the clang error message
```
error: unknown warning option '-Wno-limited-postlink-optimizations'; did
you mean '-Wno-invalid-partial-specialization'?
[-Werror,-Wunknown-warning-option]
```

This uses `emcc_arg` only in the case of non-native builds. Currently `test_zzz_box2d`, `test_zzz_bullet`, `test_zzz_coremark`, and `_test_zzz_zlib` are failing and run OK with this PR.