### PR TITLE
Don't modify emcc_args in EmscriptenBenchmarker::build

### DIFF
--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -194,7 +194,7 @@ class EmscriptenBenchmarker(Benchmarker):
       # systems (like zlib) if they see a CFLAGS it will override all their
       # default flags, including optimizations.
       env_init['CFLAGS'] = ' '.join(LLVM_FEATURE_FLAGS + [OPTIMIZATIONS] + self.extra_args)
-      emcc_args += lib_builder('js_' + llvm_root, native=False, env_init=env_init)
+      emcc_args = emcc_args + lib_builder('js_' + llvm_root, native=False, env_init=env_init)
     final = os.path.dirname(filename) + os.path.sep + self.name + ('_' if self.name else '') + os.path.basename(filename) + '.js'
     final = final.replace('.cpp', '')
     utils.delete_file(final)

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -194,6 +194,8 @@ class EmscriptenBenchmarker(Benchmarker):
       # systems (like zlib) if they see a CFLAGS it will override all their
       # default flags, including optimizations.
       env_init['CFLAGS'] = ' '.join(LLVM_FEATURE_FLAGS + [OPTIMIZATIONS] + self.extra_args)
+      # This shouldn't be 'emcc_args += ...', because emcc_args is passed in as
+      # a parameter and changes will be visible to the caller.
       emcc_args = emcc_args + lib_builder('js_' + llvm_root, native=False, env_init=env_init)
     final = os.path.dirname(filename) + os.path.sep + self.name + ('_' if self.name else '') + os.path.basename(filename) + '.js'
     final = final.replace('.cpp', '')


### PR DESCRIPTION
`Benchmarker::do_benchmark` calls `Benchmarker::build` and pass `emcc_args` list to it.
https://github.com/emscripten-core/emscripten/blob/929a6d5810908065bf23aa2af492da32ab572d57/test/test_benchmark.py#L469

But `EmscriptenBenchmarker::build` adds to that list, modifying the the argument passed in.
https://github.com/emscripten-core/emscripten/blob/929a6d5810908065bf23aa2af492da32ab572d57/test/test_benchmark.py#L197

So when `EmscriptenBenchmarker::build` is called multiple times within `do_benchmark` because there are multiple `EmscriptenBenchmarker`s, https://github.com/emscripten-core/emscripten/blob/929a6d5810908065bf23aa2af492da32ab572d57/test/test_benchmark.py#L372-L377

the modified `emcc_args` in an earlier iteration gets passed in to the `EmscriptenBenchmarker::build` call in the next iteration, causing duplicated file names in the arguments and failing with duplicate symbol errors.

This PR changes `emcc_args += ...` to `emcc_args = emcc_args + ...` in order to make a copy. It looks this code used to be the latter form but somehow changed to the former in #17173.

`test_zzz_lua_binarytrees` and `test_zzz_lua_scimark` are affected by this and run OK with this PR.