### PR TITLE
Revert "Temporarily modify wasm2js expectations to allow binaryen change to roll"

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9456,8 +9456,7 @@ int main () {
 
   @parameterized({
     'hello_world_wasm': ('hello_world', False, True),
-    # Temporarily disabled compare_js_output here while https://github.com/WebAssembly/binaryen/pull/5018 rolls in
-    'hello_world_wasm2js': ('hello_world', True, False),
+    'hello_world_wasm2js': ('hello_world', True, True),
     'random_printf_wasm': ('random_printf', False),
     'random_printf_wasm2js': ('random_printf', True),
     'hello_webgl_wasm': ('hello_webgl', False),

--- a/tools/maybe_wasm2js.py
+++ b/tools/maybe_wasm2js.py
@@ -45,12 +45,8 @@ cmd = [os.path.join(building.get_binaryen_bin(), 'wasm2js'), '--emscripten', was
 cmd += opts
 js = shared.run_process(cmd, stdout=subprocess.PIPE).stdout
 # assign the instantiate function to where it will be used
-if 'instantiate(asmLibraryArg)' in js:
-  js = shared.do_replace(js, 'function instantiate(asmLibraryArg) {',
-                         "Module['__wasm2jsInstantiate__'] = function(asmLibraryArg) {")
-else:
-  js = shared.do_replace(js, 'function instantiate(info) {',
-                         "Module['__wasm2jsInstantiate__'] = function(info) {")
+js = shared.do_replace(js, 'function instantiate(asmLibraryArg) {',
+                       "Module['__wasm2jsInstantiate__'] = function(asmLibraryArg) {")
 
 # create the combined js to run in wasm2js mode
 print('var Module = { doWasm2JS: true };\n')


### PR DESCRIPTION
Reverts emscripten-core/emscripten#17860, as the binaryen PR it was waiting for to land has landed
(https://github.com/WebAssembly/binaryen/pull/5018).