### PR TITLE
Don't use -std=c99 in test_life

### DIFF
--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -857,7 +857,7 @@ class benchmark(common.RunnerCore):
   @non_core
   def test_life(self):
     src = read_file(test_file('life.c'))
-    self.do_benchmark('life', src, '''--------------------------------''', shared_args=['-std=c99'], force_c=True)
+    self.do_benchmark('life', src, '''--------------------------------''', force_c=True)
 
   def test_zzz_linpack(self):
     def output_parser(output):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1996,7 +1996,6 @@ int main() {
     self.do_core_test('test_stack_void.c')
 
   def test_life(self):
-    self.emcc_args += ['-std=c99']
     self.do_run_in_out_file_test('life.c', args=['2'])
 
   def test_array2(self):


### PR DESCRIPTION
Not sure why it's there in the first place, but with this `benchmark.test_life` fails with:
```
life.c:71:7: error: call to undeclared function 'usleep'; ISO C99 and later do not
support implicit function declarations [-Wimplicit-function-declaration]
      usleep(20000);
```

Without this I don't see any errors. Also removed it in `test_core.py` because why not.