### PR TITLE
Make benchmarks using library_browser.js work

### DIFF
--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -870,21 +870,33 @@ class benchmark(common.RunnerCore):
   def test_native_functions(self):
     def output_parser(output):
       return float(re.search(r'Total time: ([\d\.]+)', output).group(1))
-    self.do_benchmark('native_functions', read_file(test_file('benchmark_ffis.cpp')), 'Total time:', output_parser=output_parser, shared_args=['-DBUILD_FOR_SHELL', '-I' + TEST_ROOT])
+    self.do_benchmark('native_functions', read_file(test_file('benchmark_ffis.cpp')), 'Total time:',
+                      output_parser=output_parser,
+                      # Not minimal because this uses functions in library_browsers.js
+                      emcc_args=['-sMINIMAL_RUNTIME=0'],
+                      shared_args=['-DBUILD_FOR_SHELL', '-I' + TEST_ROOT])
 
   # Benchmarks the synthetic performance of calling function pointers.
   @non_core
   def test_native_function_pointers(self):
     def output_parser(output):
       return float(re.search(r'Total time: ([\d\.]+)', output).group(1))
-    self.do_benchmark('native_functions', read_file(test_file('benchmark_ffis.cpp')), 'Total time:', output_parser=output_parser, shared_args=['-DBENCHMARK_FUNCTION_POINTER=1', '-DBUILD_FOR_SHELL', '-I' + TEST_ROOT])
+    self.do_benchmark('native_functions', read_file(test_file('benchmark_ffis.cpp')), 'Total time:',
+                      output_parser=output_parser,
+                      # Not minimal because this uses functions in library_browsers.js
+                      emcc_args=['-sMINIMAL_RUNTIME=0'],
+                      shared_args=['-DBENCHMARK_FUNCTION_POINTER=1', '-DBUILD_FOR_SHELL', '-I' + TEST_ROOT])
 
   # Benchmarks the synthetic performance of calling "foreign" JavaScript functions.
   @non_core
   def test_foreign_functions(self):
     def output_parser(output):
       return float(re.search(r'Total time: ([\d\.]+)', output).group(1))
-    self.do_benchmark('foreign_functions', read_file(test_file('benchmark_ffis.cpp')), 'Total time:', output_parser=output_parser, emcc_args=['--js-library', test_file('benchmark_ffis.js')], shared_args=['-DBENCHMARK_FOREIGN_FUNCTION=1', '-DBUILD_FOR_SHELL', '-I' + TEST_ROOT])
+    self.do_benchmark('foreign_functions', read_file(test_file('benchmark_ffis.cpp')), 'Total time:',
+                      output_parser=output_parser,
+                      # Not minimal because this uses functions in library_browsers.js
+                      emcc_args=['--js-library', test_file('benchmark_ffis.js'), '-sMINIMAL_RUNTIME=0'],
+                      shared_args=['-DBENCHMARK_FOREIGN_FUNCTION=1', '-DBUILD_FOR_SHELL', '-I' + TEST_ROOT])
 
   @non_core
   def test_memcpy_128b(self):


### PR DESCRIPTION
`test_foreign_functions`, `test_native_functions`, and `test_native_function_pointers` use
https://github.com/emscripten-core/emscripten/blob/main/test/benchmark_ffis.cpp, which uses `emscripten_set_main_loop` and `emscripten_cancel_main_loop`: https://github.com/emscripten-core/emscripten/blob/b8ad2b5b1dfefd4b18f705427f2954623d5f4672/test/benchmark_ffis.cpp#L93-L95 https://github.com/emscripten-core/emscripten/blob/b8ad2b5b1dfefd4b18f705427f2954623d5f4672/test/benchmark_ffis.cpp#L105-L107

This requires `MINIMAL_RUNTIME=0`, but `EmscriptenBenchmarker::build` sets it by default:
https://github.com/emscripten-core/emscripten/blob/b8ad2b5b1dfefd4b18f705427f2954623d5f4672/test/test_benchmark.py#L216

So they generate this error:
```
error: undefined symbol: emscripten_cancel_main_loop (referenced by top-level compiled C/C++ code)
```

This PR overrides `MINIMAL_RUNTIME` to 0 for those three benchmarks.