### PR TITLE
JSPI - Support EM_*JS functions.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2587,12 +2587,6 @@ def phase_linker_setup(options, state, newargs, user_settings):
 
     if settings.ASYNCIFY == 2:
       diagnostics.warning('experimental', 'ASYNCIFY with stack switching is experimental')
-      if not settings.EXIT_RUNTIME:
-        # FIXME: investigate d8 issues without EXIT_RUNTIME (quit exits too
-        #        early, not leaving async work a chance to run; only
-        #        EXIT_RUNTIME tracks whether such work exists and should stop us
-        #        from exiting).
-        exit_with_error('ASYNCIFY with stack switching requires EXIT_RUNTIME for now')
 
   if settings.WASM2JS:
     if settings.GENERATE_SOURCE_MAP:

--- a/emscripten.py
+++ b/emscripten.py
@@ -572,6 +572,22 @@ def create_asm_consts(metadata):
   return asm_consts
 
 
+def type_to_sig(type):
+  # These should match the conversion in $sigToWasmTypes.
+  return {
+    webassembly.Type.I32: 'i',
+    webassembly.Type.I64: 'j',
+    webassembly.Type.F32: 'f',
+    webassembly.Type.F64: 'd',
+    webassembly.Type.VOID: 'v'
+  }[type]
+
+
+def func_type_to_sig(type):
+  parameters = [type_to_sig(param) for param in type.params]
+  return type_to_sig(type.returns[0]) + ''.join(parameters)
+
+
 def create_em_js(metadata):
   em_js_funcs = []
   separator = '<::>'
@@ -586,6 +602,9 @@ def create_em_js(metadata):
     arg_names = [arg.split()[-1].replace("*", "") for arg in args if arg]
     args = ','.join(arg_names)
     func = f'function {name}({args}) {body}'
+    if settings.ASYNCIFY == 2 and name in metadata['emJsFuncTypes']:
+      sig = func_type_to_sig(metadata['emJsFuncTypes'][name])
+      func = func + f'\n{name}.sig = \'{sig}\';'
     em_js_funcs.append(func)
 
   return em_js_funcs

--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -116,6 +116,39 @@ WebAssembly.Memory.prototype.buffer;
 WebAssembly.Table.prototype.length;
 
 /**
+ * @record
+ */
+function FunctionType() {}
+/**
+ * @type {Array<string>}
+ */
+FunctionType.prototype.parameters;
+/**
+ * @type {Array<string>}
+ */
+FunctionType.prototype.results;
+/**
+ * @record
+ */
+ function FunctionUsage() {}
+ /**
+  * @type {string}
+  */
+FunctionUsage.prototype.promising;
+ /**
+  * @type {string}
+  */
+FunctionUsage.prototype.suspending;
+
+/**
+ * @constructor
+ * @param {!FunctionType} type
+ * @param {!Function} func
+ * @param {FunctionUsage=} usage
+ */
+WebAssembly.Function = function(type, func, usage) {};
+
+/**
  * @suppress {undefinedVars}
  */
 var wakaUnknownAfter;

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9494,9 +9494,11 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @no_asan('asyncify stack operations confuse asan')
   @no_wasm64('TODO: asyncify for wasm64')
+  @with_asyncify_and_stack_switching
   def test_em_async_js(self):
     self.uses_es6 = True
-    self.set_setting('ASYNCIFY')
+    if not self.get_setting('ASYNCIFY'):
+      self.set_setting('ASYNCIFY')
     self.set_setting('EXPORTED_RUNTIME_METHODS', 'ccall')
     self.maybe_closure()
     self.do_core_test('test_em_async_js.c')

--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -265,6 +265,7 @@ def extract_metadata(filename):
   invoke_funcs = []
   global_imports = []
   em_js_funcs = {}
+  em_js_func_types = {}
 
   with webassembly.Module(filename) as module:
     exports = module.get_exports()
@@ -286,7 +287,10 @@ def extract_metadata(filename):
       if i.kind == webassembly.ExternType.FUNC:
         if i.field.startswith('invoke_'):
           invoke_funcs.append(i.field)
-        elif i.field not in em_js_funcs:
+        elif i.field in em_js_funcs:
+          types = module.get_types()
+          em_js_func_types[i.field] = types[i.type]
+        else:
           declares.append(i.field)
 
     export_names = [e.name for e in exports if e.kind in [webassembly.ExternType.FUNC, webassembly.ExternType.TAG]]
@@ -303,6 +307,7 @@ def extract_metadata(filename):
     metadata['asmConsts'] = get_asm_strings(module, export_map)
     metadata['declares'] = declares
     metadata['emJsFuncs'] = em_js_funcs
+    metadata['emJsFuncTypes'] = em_js_func_types
     metadata['exports'] = export_names
     metadata['features'] = features
     metadata['globalImports'] = global_imports


### PR DESCRIPTION
Generate the needed type signatures to create wrapper WebAssembly Functions.

Fixes #17890