### PR TITLE
Use @memoize for get_temp_files. NFC

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -501,6 +501,7 @@ def replace_or_append_suffix(filename, new_suffix):
 
 # Temp dir. Create a random one, unless EMCC_DEBUG is set, in which case use the canonical
 # temp directory (TEMP_DIR/emscripten_temp).
+@memoize
 def get_emscripten_temp_dir():
   """Returns a path to EMSCRIPTEN_TEMP_DIR, creating one if it didn't exist."""
   global EMSCRIPTEN_TEMP_DIR
@@ -555,6 +556,7 @@ def setup_temp_dirs():
       atexit.register(lock.release)
 
 
+@memoize
 def get_temp_files():
   if DEBUG_SAVE:
     # In debug mode store all temp files in the emscripten-specific temp dir


### PR DESCRIPTION
This avoids creating a new TempFiles object each time this function is classed.  Instead we now have just a single TempFiles object for the life of the program and single atexit handler registered.

Prior to this we would create a new object on each call which would result in many exit handlers running and output like this when running with EMCC_DEBUG:

```
profiler:DEBUG: block "main" raised an exception after 6.069 seconds
not cleaning up temp files since in debug-save mode, see them in /tmp/emscripten_temp
not cleaning up temp files since in debug-save mode, see them in /tmp/emscripten_temp
not cleaning up temp files since in debug-save mode, see them in /tmp/emscripten_temp
not cleaning up temp files since in debug-save mode, see them in /tmp/emscripten_temp
not cleaning up temp files since in debug-save mode, see them in /tmp/emscripten_temp
not cleaning up temp files since in debug-save mode, see them in /tmp/emscripten_temp
not cleaning up temp files since in debug-save mode, see them in /tmp/emscripten_temp
not cleaning up temp files since in debug-save mode, see them in /tmp/emscripten_temp
not cleaning up temp files since in debug-save mode, see them in /tmp/emscripten_temp
not cleaning up temp files since in debug-save mode, see them in /tmp/emscripten_temp
not cleaning up temp files since in debug-save mode, see them in /tmp/emscripten_temp
tools.filelock:DEBUG: Attempting to release lock 140457333353168 on /tmp/emscripten_temp/emscripten.lock
tools.filelock:DEBUG: Lock 140457333353168 released on /tmp/emscripten_temp/emscripten.lock
```