### PR TITLE
Cleanup tempfile naming for JS optimization passes. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2310,8 +2310,7 @@ int f() {
     if common.EMTEST_REBASELINE:
       write_file(expected_file, js)
     else:
-      expected = read_file(expected_file)
-      self.assertIdentical(expected, js)
+      self.assertFileContents(expected_file, js)
 
   @parameterized({
     'wasm2js': ('wasm2js', ['minifyNames', 'last']),

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -1799,11 +1799,11 @@ function reattachComments(ast, comments) {
 
 let suffix = '';
 
-const argv = process['argv'].slice(2);
+const argv = process.argv.slice(2);
 // If enabled, output retains parentheses and comments so that the
 // output can further be passed out to Closure.
 let closureFriendly = argv.indexOf('--closureFriendly');
-if (closureFriendly > -1) {
+if (closureFriendly != -1) {
   argv.splice(closureFriendly, 1);
   closureFriendly = true;
 } else {
@@ -1811,11 +1811,18 @@ if (closureFriendly > -1) {
 }
 
 let exportES6 = argv.indexOf('--exportES6');
-if (exportES6 > -1) {
+if (exportES6 != -1) {
   argv.splice(exportES6, 1);
   exportES6 = true;
 } else {
   exportES6 = false;
+}
+
+let outfile;
+const outfileIndex = argv.indexOf('-o');
+if (outfileIndex != -1) {
+  outfile = argv[outfileIndex + 1];
+  argv.splice(outfileIndex, 2);
 }
 
 const infile = argv[0];
@@ -1899,8 +1906,13 @@ if (!noPrint) {
     keep_quoted_props: true, // for closure
     comments: true, // for closure as well
   });
-  print(output);
+
+  let fd = process.stdout.fd;
+  if (outfile) {
+    fd = fs.openSync(outfile, 'w');
+  }
+  fs.writeSync(fd, output + '\n');
   if (suffix) {
-    print(suffix);
+    fs.writeSync(fd, suffix + '\n');
   }
 }

--- a/tools/building.py
+++ b/tools/building.py
@@ -387,15 +387,22 @@ def acorn_optimizer(filename, passes, extra_info=None, return_output=False):
     cmd += ['--exportES6']
   if settings.VERBOSE:
     cmd += ['verbose']
-  if not return_output:
-    next = original_filename + '.jso.js'
-    shared.get_temp_files().note(next)
-    check_call(cmd, stdout=open(next, 'w'))
-    save_intermediate(next, '%s.js' % passes[0])
-    return next
-  output = check_call(cmd, stdout=PIPE).stdout
-  return output
+  if return_output:
+    return check_call(cmd, stdout=PIPE).stdout
 
+  acorn_optimizer.counter += 1
+  basename = shared.unsuffixed(original_filename)
+  if '.jso' in basename:
+    basename = shared.unsuffixed(basename)
+  output_file = basename + '.jso%d.js' % acorn_optimizer.counter
+  shared.get_temp_files().note(output_file)
+  cmd += ['-o', output_file]
+  check_call(cmd)
+  save_intermediate(output_file, '%s.js' % passes[0])
+  return output_file
+
+
+acorn_optimizer.counter = 0
 
 WASM_CALL_CTORS = '__wasm_call_ctors'
 
@@ -1296,17 +1303,16 @@ def run_wasm_opt(infile, outfile=None, args=[], **kwargs):  # noqa
   return run_binaryen_command('wasm-opt', infile, outfile, args=args, **kwargs)
 
 
-save_intermediate_counter = 0
-
-
 def save_intermediate(src, dst):
   if DEBUG:
-    global save_intermediate_counter
-    dst = 'emcc-%d-%s' % (save_intermediate_counter, dst)
-    save_intermediate_counter += 1
+    dst = 'emcc-%d-%s' % (save_intermediate.counter, dst)
+    save_intermediate.counter += 1
     dst = os.path.join(CANONICAL_TEMP_DIR, dst)
     logger.debug('saving debug copy %s' % dst)
     shutil.copyfile(src, dst)
+
+
+save_intermediate.counter = 0
 
 
 def js_legalization_pass_flags():


### PR DESCRIPTION
Add `-o filename` to acorn-optimizer.js and use it rather than opening the file on the python side.  This makes the debug logs easier to read since you can see both the output filename and the input filename in each command.

Also, simplify the names of the temp files so we don't end up with crazy long filenames like `tmp.js.jso.js.jso.js.jso.js.jso.js`.