### PR TITLE
file corruption when using emscripten_run_preload_plugins

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -789,7 +789,7 @@ var LibraryBrowser = {
     FS.createPreloadedFile(
       PATH.dirname(_file),
       PATH.basename(_file),
-      new Uint8Array(data.object.contents), true, true,
+      FS.readFile(_file), true, true,
       () => {
         {{{ runtimeKeepalivePop() }}}
         if (onload) {{{ makeDynCall('vi', 'onload') }}}(file);


### PR DESCRIPTION
valid library binary files (.so) coming from MEMFS are not well decoded. eg `Couldn't instantiate wasm: /tmp/wasabigeom.cpython-311-wasm32-emscripten.so 'CompileError: wasm validation error: at offset 542165: failed to start custom section' ` on firefox  or v8 `main.js:1 Couldn't instantiate wasm: /tmp/wasabigeom.cpython-311-wasm32-emscripten.so 'CompileError: WebAssembly.instantiate(): expected  length: @+542164'`

maybe related https://github.com/emscripten-core/emscripten/issues/16740 https://github.com/emscripten-core/emscripten/issues/16742