### PR TITLE
Don't build libwasm_workers_stubs with -pthread. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,9 +406,11 @@ jobs:
     executor: bionic
     steps:
       - run-tests-linux:
+          frozen_cache: false
           # also add a little select testing for wasm2js in -O3
           # also add a little select wasmfs testing
           test_targets: "
+            lto2.test_dylink_syslibs_all
             core3
             core2g.test_externref
             corez.test_dylink_iostream

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1236,11 +1236,11 @@ class libwasm_workers(MTLibrary):
   name = 'libwasm_workers'
 
   def get_cflags(self):
-    cflags = get_base_cflags() + ['-pthread', '-D_DEBUG' if self.debug else '-Oz']
+    cflags = get_base_cflags() + ['-D_DEBUG' if self.debug else '-Oz']
     if not self.debug:
       cflags += ['-DNDEBUG']
     if self.is_ww or self.is_mt:
-      cflags += ['-sWASM_WORKERS']
+      cflags += ['-pthread', '-sWASM_WORKERS']
     if settings.MAIN_MODULE:
       cflags += ['-fPIC']
     return cflags


### PR DESCRIPTION
With #17914, libwasm_workers was built with `-flto` in LTO mode (just like most other standard libraries).  However doing seemed to trigger a bug which was that libwasm_workers was being built with `-pthread` even when pthreads were not enabled.  Somehow this didn't matter before but once it was also built with LTO it caused a failure on one of our bots:

```
FAIL: test_dylink_syslibs_all (test_core.lto2)
CompileError: WebAssembly.instantiate(): Compiling function #923:"emscripten_atomic_cas_u32" failed: Invalid opcode (enable with --experimental-wasm-threads) @+640479
Aborted(CompileError: WebAssembly.instantiate(): Compiling function #923:"emscripten_atomic_cas_u32" failed: Invalid opcode (enable with --experimental-wasm-threads) @+640479)
```