### PR TITLE
Fix acorn-optimizer.js when writing large files to stdout

### DIFF
--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -1900,19 +1900,24 @@ if (!noPrint) {
     reattachComments(terserAst, sourceComments);
   }
 
-  const output = terserAst.print_to_string({
+  let output = terserAst.print_to_string({
     beautify: !minifyWhitespace,
     indent_level: minifyWhitespace ? 0 : 1,
     keep_quoted_props: true, // for closure
     comments: true, // for closure as well
   });
 
-  let fd = process.stdout.fd;
-  if (outfile) {
-    fd = fs.openSync(outfile, 'w');
-  }
-  fs.writeSync(fd, output + '\n');
+  output += '\n';
   if (suffix) {
-    fs.writeSync(fd, suffix + '\n');
+    output += suffix + '\n';
+  }
+
+  if (outfile) {
+    fs.writeFileSync(outfile, output);
+  } else {
+    // Simply using `fs.writeFileSync` on `process.stdout` has issues with
+    // large amount of data. It can cause:
+    //   Error: EAGAIN: resource temporarily unavailable, write
+    process.stdout.write(output);
   }
 }


### PR DESCRIPTION
This was broken in #17948 but it only showed up in binaryen because we don't have enough large tests to trigger the issue.

The problem seem to be when using `fs.writeSync` in combination with `process.stdout.fd`.  In this case we can get partial writes, but even adding a loop can fail with EAGAIN.

Work around the issue by calling process.stdout.write directly like we do in print (like we used to do before #17948).

Fixes: #17960