### PR TITLE
Remove getExceptionMessage from EXPORTED_FUNCTIONS

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2660,7 +2660,7 @@ def phase_linker_setup(options, state, newargs, user_settings):
     # What you need to do is different depending on the kind of EH you use
     # (https://github.com/emscripten-core/emscripten/issues/17115).
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$getExceptionMessage', '$incrementExceptionRefcount', '$decrementExceptionRefcount']
-    settings.EXPORTED_FUNCTIONS += ['getExceptionMessage', '___get_exception_message']
+    settings.EXPORTED_FUNCTIONS += ['___get_exception_message']
     if settings.WASM_EXCEPTIONS:
       settings.EXPORTED_FUNCTIONS += ['___cpp_exception', '___cxa_increment_exception_refcount', '___cxa_decrement_exception_refcount', '___thrown_object_from_unwind_exception']
 


### PR DESCRIPTION
Not sure why it was added there in the first place. It is a JS function and doesn't need to be there.