### PR TITLE
Disable test_em_async_js_stack_switching

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9499,6 +9499,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_wasm64('TODO: asyncify for wasm64')
   @with_asyncify_and_stack_switching
   def test_em_async_js(self):
+    if self.get_setting('ASYNCIFY') == 2:
+      self.skipTest('https://github.com/emscripten-core/emscripten/issues/17977')
     self.uses_es6 = True
     if not self.get_setting('ASYNCIFY'):
       self.set_setting('ASYNCIFY')


### PR DESCRIPTION
`core2.test_em_async_js_stack_switching` is [failing](https://app.circleci.com/pipelines/github/emscripten-core/emscripten/23787/workflows/5b3dcf53-9b82-44e2-8767-d06a03a94d6e/jobs/570810) the CI (#17977), so temporarily disables it.