### PR TITLE
[EH] Support stack traces for Wasm exceptions

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -35,6 +35,7 @@ MINIMAL_TASKS = [
     'libc_optz-debug',
     'libc++abi',
     'libc++abi-except',
+    'libc++abi-debug-except',
     'libc++abi-noexcept',
     'libc++',
     'libc++-except',

--- a/emcc.py
+++ b/emcc.py
@@ -2652,6 +2652,11 @@ def phase_linker_setup(options, state, newargs, user_settings):
   if settings.WASM_EXCEPTIONS:
     settings.REQUIRED_EXPORTS += ['__trap']
 
+  # When ASSERTIONS is set, we include stack traces in Wasm exception objects
+  # using the JS API, which needs this C++ tag exported.
+  if settings.ASSERTIONS and settings.WASM_EXCEPTIONS:
+    settings.EXPORTED_FUNCTIONS += ['___cpp_exception']
+
   # Make `getExceptionMessage` and other necessary functions available for use.
   if settings.EXPORT_EXCEPTION_HANDLING_HELPERS:
     # We also export refcount increasing and decreasing functions because if you

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -417,11 +417,18 @@ var LibraryExceptions = {
     return Module['asm']['__cpp_exception'];
   },
 
-  // Given an WebAssembly.Exception object, returns the actual user-thrown
-  // C++ object address in the Wasm memory.
+  // Throw a WebAssembly.Exception object with the C++ tag. If traceStack is
+  // true, includes the stack traces within the exception object.
   // WebAssembly.Exception is a JS object representing a Wasm exception,
   // provided by Wasm JS API:
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception
+  __throwCppWebAssemblyException__deps: ['$getCppExceptionTag'],
+  __throwCppWebAssemblyException: function(ex, traceStack) {
+    throw new WebAssembly.Exception(getCppExceptionTag(), [ex], {traceStack: traceStack});
+  },
+
+  // Given an WebAssembly.Exception object, returns the actual user-thrown
+  // C++ object address in the Wasm memory.
   $getCppExceptionThrownObjectFromWebAssemblyException__deps: ['$getCppExceptionTag', '__thrown_object_from_unwind_exception'],
   $getCppExceptionThrownObjectFromWebAssemblyException: function(ex) {
     // In Wasm EH, the value extracted from WebAssembly.Exception is a pointer

--- a/system/lib/libcxxabi/src/cxa_exception.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception.cpp
@@ -253,6 +253,13 @@ handler, _Unwind_RaiseException may return. In that case, __cxa_throw
 will call terminate, assuming that there was no handler for the
 exception.
 */
+
+#if defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
+extern "C" {
+void __throwCppWebAssemblyException(_Unwind_Exception*, bool);
+} // extern "C"
+#endif
+
 void
 #ifdef __USING_WASM_EXCEPTIONS__
 // In wasm, destructors return their argument
@@ -280,6 +287,14 @@ __cxa_throw(void *thrown_object, std::type_info *tinfo, void (*dest)(void *)) {
 
 #ifdef __USING_SJLJ_EXCEPTIONS__
     _Unwind_SjLj_RaiseException(&exception_header->unwindHeader);
+#elif __USING_WASM_EXCEPTIONS__
+#ifdef NDEBUG
+    _Unwind_RaiseException(&exception_header->unwindHeader);
+#else
+    // In debug mode, call a JS library function to use WebAssembly.Exception JS
+    // API, which enables us to include stack traces
+    __throwCppWebAssemblyException(&exception_header->unwindHeader, true);
+#endif
 #else
     _Unwind_RaiseException(&exception_header->unwindHeader);
 #endif

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7904,6 +7904,47 @@ int main() {
       out = self.run_js('a.out.js', assert_returncode=NON_ZERO)
       self.assertContained('no native wasm support detected', out)
 
+  @requires_v8
+  def test_wasm_exceptions_stack_trace(self):
+    src = r'''
+      void bar() {
+        throw 3;
+      }
+      void foo() {
+        bar();
+      }
+      int main() {
+        foo();
+        return 0;
+      }
+    '''
+    emcc_args = ['-g', '-fwasm-exceptions']
+    self.v8_args.append('--experimental-wasm-eh')
+
+    # Stack trace example for this example code:
+    # exiting due to exception: [object WebAssembly.Exception],Error
+    #     at ___throwCppWebAssemblyException (test.js:1139:13)
+    #     at __cxa_throw (wasm://wasm/009a7c9a:wasm-function[1551]:0x24367)
+    #     at bar() (wasm://wasm/009a7c9a:wasm-function[12]:0xf53)
+    #     at foo() (wasm://wasm/009a7c9a:wasm-function[19]:0x154e)
+    #     at __original_main (wasm://wasm/009a7c9a:wasm-function[20]:0x15a6)
+    #     at main (wasm://wasm/009a7c9a:wasm-function[56]:0x25be)
+    #     at test.js:833:22
+    #     at callMain (test.js:4567:15)
+    #     at doRun (test.js:4621:23)
+    #     at run (test.js:4636:5)
+    stack_trace_checks = ['at __cxa_throw', 'at bar', 'at foo', 'at main']
+
+    # We attach stack traces to exception objects only when ASSERTIONS is set
+    self.set_setting('ASSERTIONS')
+    self.do_run(src, emcc_args=emcc_args, assert_all=True,
+                assert_returncode=NON_ZERO, expected_output=stack_trace_checks)
+
+    self.set_setting('ASSERTIONS', 0)
+    err = self.do_run(src, emcc_args=emcc_args, assert_returncode=NON_ZERO)
+    for check in stack_trace_checks:
+      self.assertNotContained(check, err)
+
   @requires_node
   def test_jsrun(self):
     print(config.NODE_JS)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1350,7 +1350,7 @@ class crtbegin(MuslInternalLibrary):
     return super().can_use() and settings.SHARED_MEMORY
 
 
-class libcxxabi(NoExceptLibrary, MTLibrary):
+class libcxxabi(NoExceptLibrary, MTLibrary, DebugLibrary):
   name = 'libc++abi'
   cflags = [
       '-Oz',
@@ -1363,7 +1363,6 @@ class libcxxabi(NoExceptLibrary, MTLibrary):
 
   def get_cflags(self):
     cflags = super().get_cflags()
-    cflags.append('-DNDEBUG')
     if not self.is_mt and not self.is_ww:
       cflags.append('-D_LIBCXXABI_HAS_NO_THREADS')
     if self.eh_mode == Exceptions.NONE:


### PR DESCRIPTION
This embeds stack traces into `WebAssembly.Exception` objects when `ASSERTION` is set. To do this, we now have a separate debug version of libc++abi, whose `__cxa_throw` doesn't call libunwind's `_Unwind_RaiseException`, which uses Wasm's `throw` instruction directly to throw exceptions, but rather calls out to a helper JS function that creates and throws `WebAssembly.Exception`. That JS function uses the optional `stack` property of `WebAssembly.Exception` constructor to attach stack traces to objects.

Without `ASSERTION` set, when an exception is thrown and uncaught, we only see something like
```console
exiting due to exception: [object WebAssembly.Exception]
```
And this is what we've seen so far as well.

With this patch, when `ASSERTION` is set, we see stack traces like
```console
exiting due to exception: [object WebAssembly.Exception],Error
    at ___throwCppWebAssemblyException (test.js:1139:13)
    at __cxa_throw (wasm://wasm/009a7c9a:wasm-function[1551]:0x24367)
    at bar() (wasm://wasm/009a7c9a:wasm-function[12]:0xf53)
    at foo() (wasm://wasm/009a7c9a:wasm-function[19]:0x154e)
    at __original_main (wasm://wasm/009a7c9a:wasm-function[20]:0x15a6)
    at main (wasm://wasm/009a7c9a:wasm-function[56]:0x25be)
    at test.js:833:22
    at callMain (test.js:4567:15)
    at doRun (test.js:4621:23)
    at run (test.js:4636:5)
```

Fixes #17466.