### PR TITLE
Fix closure warnings when compiling with ASYNCIFY=2.

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -132,11 +132,11 @@ FunctionType.prototype.results;
  */
  function FunctionUsage() {}
  /**
-  * @type {string}
+  * @type {string|undefined}
   */
 FunctionUsage.prototype.promising;
  /**
-  * @type {string}
+  * @type {string|undefined}
   */
 FunctionUsage.prototype.suspending;
 
@@ -147,6 +147,11 @@ FunctionUsage.prototype.suspending;
  * @param {FunctionUsage=} usage
  */
 WebAssembly.Function = function(type, func, usage) {};
+/**
+ * @param {Function} func
+ * @return {FunctionType}
+ */
+WebAssembly.Function.type = function(func) {};
 
 /**
  * @suppress {undefinedVars}

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -91,7 +91,7 @@ mergeInto(LibraryManager.library, {
 #if ASSERTIONS
             assert(sig, 'Missing __sig for ' + x);
 #endif
-            var type = sigToWasmTypes(sig, original);
+            var type = sigToWasmTypes(sig);
 #if ASYNCIFY_DEBUG
             err('asyncify: suspendOnReturnedPromise for', x, original);
 #endif


### PR DESCRIPTION
Fixes the warnings seen in https://app.circleci.com/pipelines/github/emscripten-core/emscripten/23787/workflows/5b3dcf53-9b82-44e2-8767-d06a03a94d6e/jobs/570810