### PR TITLE
JSPI - Enable test_stack_switching_size.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -977,7 +977,8 @@ mergeInto(LibraryManager.library, {
     return bytes.length-1;
   },
   strftime_l__deps: ['strftime'],
-  strftime_l: function(s, maxsize, format, tm) {
+  strftime_l__sig: 'pppppp',
+  strftime_l: function(s, maxsize, format, tm, loc) {
     return _strftime(s, maxsize, format, tm); // no locale support yet
   },
 

--- a/src/library_addfunction.js
+++ b/src/library_addfunction.js
@@ -23,7 +23,12 @@ mergeInto(LibraryManager.library, {
   $sigToWasmTypes: function(sig) {
     var typeNames = {
       'i': 'i32',
+#if MEMORY64
       'j': 'i64',
+#else
+      // i64 values will be split into two i32s.
+      'j': 'i32',
+#endif
       'f': 'f32',
       'd': 'f64',
 #if MEMORY64
@@ -41,6 +46,11 @@ mergeInto(LibraryManager.library, {
       assert(sig[i] in typeNames, 'invalid signature char: ' + sig[i]);
 #endif
       type.parameters.push(typeNames[sig[i]]);
+#if !MEMORY64
+      if (sig[i] === 'j') {
+        type.parameters.push('i32');
+      }
+#endif
     }
     return type;
   },

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12316,7 +12316,6 @@ Module['postRun'] = function() {{
     self.assertNotIn(b'.debug', read_binary('hello_world.o'))
 
   @requires_v8
-  @disabled('https://github.com/emscripten-core/emscripten/issues/17532')
   def test_stack_switching_size(self):
     # use iostream code here to purposefully get a fairly large wasm file, so
     # that our size comparisons later are meaningful


### PR DESCRIPTION
Fixes required for the test:
- Add missing signature for strftime_l.
- Fix signature conversion for i64.

Fixes: #17724