### PR TITLE
[EH] Use _UA_SEARCH_PHASE in personality function (NFC)

### DIFF
--- a/system/lib/libcxxabi/src/cxa_personality.cpp
+++ b/system/lib/libcxxabi/src/cxa_personality.cpp
@@ -967,6 +967,8 @@ __gxx_personality_v0
             exc->catchTemp = reinterpret_cast<void*>(results.landingPad);
             exc->adjustedPtr = results.adjustedPtr;
 #ifdef __USING_WASM_EXCEPTIONS__
+            // Wasm only uses a single phase (_UA_SEARCH_PHASE), so save the
+            // results here.
             set_registers(unwind_exception, context, results);
 #endif
         }

--- a/system/lib/libunwind/src/Unwind-wasm.c
+++ b/system/lib/libunwind/src/Unwind-wasm.c
@@ -42,7 +42,7 @@ _Unwind_Reason_Code _Unwind_CallPersonality(void *exception_ptr) {
   // Call personality function. Wasm does not have two-phase unwinding, so we
   // only do the cleanup phase.
   _Unwind_Reason_Code ret = __gxx_personality_wasm0(
-      1, _UA_CLEANUP_PHASE, exception_object->exception_class, exception_object,
+      1, _UA_SEARCH_PHASE, exception_object->exception_class, exception_object,
       (struct _Unwind_Context *)&__wasm_lpad_context);
   return ret;
 }


### PR DESCRIPTION
In two-phase unwinding, the first phase is the search phase (`_UA_SEARCH_PHASE`) and the second one is the cleanup phase (`_UA_CLEANUP_PHASE`). The search phase searches up the stack to see if there is a matching catch handler, and if it finds one, it caches the result. And in the second cleanup phase, it retrieves the cached result (to avoid doing same work twice) and unwinds the stack.

Wasm does not do the two-phase unwinding; it only has a single phase. We used `_UA_CLEANUP_PHASE` for this single phase, so in Wasm the cleanup phase is supposed to the search. So we several many custom `#ifdef`s to use the code guarded by `_UA_SEARCH_PHASE`, for example: https://github.com/aheejin/emscripten/blob/d57db5bea1719319a680699c50b91fa3d88fa0ec/system/lib/libcxxabi/src/cxa_personality.cpp#L771-L776 https://github.com/aheejin/emscripten/blob/d57db5bea1719319a680699c50b91fa3d88fa0ec/system/lib/libcxxabi/src/cxa_personality.cpp#L850-L855

These are apparently gone in #14288, which replaced many `if`s with `assert`s. This in effect removed our special handling for `_UA_CLEANUP_PHASE`; there are several `assert`s that asserts the current phase is `_UA_SEARCH_PHASE`, while Wasm is in `_UA_CLEANUP_PHASE`. But this has not caused problems so far because we have built libc++abi with `-NDEBUG`, so all assertions were no-op. https://github.com/emscripten-core/emscripten/blob/40fb7d2071e439f1de614898b88518df582faa94/tools/system_libs.py#L1366 But this is now a problem because #17979 adds a debug build of libc++abi, which enables assertions.

Come to think of it, I'm not sure why I decided to use `_UA_CLEANUP_PHASE` for our single phase in the first place. If we use `_UA_SEARCH_PHASE`, we can remove more our custom code and reduce the difference between our port and the upstream library.