### PR TITLE
Fix ABORT_ON_WASM_EXCEPTIONS + PROXY_TO_PTHREAD

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -180,6 +180,9 @@ function callMain(args) {
 #if ASSERTIONS
     assert(ret == 0, '_emscripten_proxy_main failed to start proxy thread: ' + ret);
 #endif
+#if ABORT_ON_WASM_EXCEPTIONS
+  }
+#endif
 #else
 #if ASYNCIFY == 2
     // The current spec of JSPI returns a promise only if the function suspends

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9460,6 +9460,13 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.assertNotContained('unhandled exception', output)
     self.assertNotContained('Aborted', output)
 
+  @node_pthreads
+  def test_abort_on_exceptions_pthreads(self):
+    self.set_setting('ABORT_ON_WASM_EXCEPTIONS')
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('EXIT_RUNTIME')
+    self.do_core_test('test_hello_world.c')
+
   @needs_dylink
   def test_gl_main_module(self):
     self.set_setting('MAIN_MODULE')


### PR DESCRIPTION
This was broken in #17486 but we were not testing this configuration.

Fixes: #17994