### PR TITLE
cmake: Unconditionally set CMAKE_AR/CMAKE_RANLIB etc

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -87,33 +87,14 @@ else()
 endif()
 
 # Specify the compilers to use for C and C++
-if ("${CMAKE_C_COMPILER}" STREQUAL "")
-  set(CMAKE_C_COMPILER "${EMSCRIPTEN_ROOT_PATH}/emcc${EMCC_SUFFIX}" CACHE FILEPATH "Emscripten emcc")
-endif()
-if ("${CMAKE_CXX_COMPILER}" STREQUAL "")
-  set(CMAKE_CXX_COMPILER "${EMSCRIPTEN_ROOT_PATH}/em++${EMCC_SUFFIX}" CACHE FILEPATH "Emscripten em++")
-endif()
-
-if ("${CMAKE_AR}" STREQUAL "")
-  set(CMAKE_AR "${EMSCRIPTEN_ROOT_PATH}/emar${EMCC_SUFFIX}" CACHE FILEPATH "Emscripten ar")
-endif()
-
-if ("${CMAKE_RANLIB}" STREQUAL "")
-  set(CMAKE_RANLIB "${EMSCRIPTEN_ROOT_PATH}/emranlib${EMCC_SUFFIX}" CACHE FILEPATH "Emscripten ranlib")
-endif()
-
-if ("${CMAKE_C_COMPILER_AR}" STREQUAL "")
-  set(CMAKE_C_COMPILER_AR "${CMAKE_AR}" CACHE FILEPATH "Emscripten ar")
-endif()
-if ("${CMAKE_CXX_COMPILER_AR}" STREQUAL "")
-  set(CMAKE_CXX_COMPILER_AR "${CMAKE_AR}" CACHE FILEPATH "Emscripten ar")
-endif()
-if ("${CMAKE_C_COMPILER_RANLIB}" STREQUAL "")
-  set(CMAKE_C_COMPILER_RANLIB "${CMAKE_RANLIB}" CACHE FILEPATH "Emscripten ranlib")
-endif()
-if ("${CMAKE_CXX_COMPILER_RANLIB}" STREQUAL "")
-  set(CMAKE_CXX_COMPILER_RANLIB "${CMAKE_RANLIB}" CACHE FILEPATH "Emscripten ranlib")
-endif()
+set(CMAKE_C_COMPILER "${EMSCRIPTEN_ROOT_PATH}/emcc${EMCC_SUFFIX}" CACHE FILEPATH "Emscripten emcc")
+set(CMAKE_CXX_COMPILER "${EMSCRIPTEN_ROOT_PATH}/em++${EMCC_SUFFIX}" CACHE FILEPATH "Emscripten em++")
+set(CMAKE_AR "${EMSCRIPTEN_ROOT_PATH}/emar${EMCC_SUFFIX}" CACHE FILEPATH "Emscripten ar")
+set(CMAKE_RANLIB "${EMSCRIPTEN_ROOT_PATH}/emranlib${EMCC_SUFFIX}" CACHE FILEPATH "Emscripten ranlib")
+set(CMAKE_C_COMPILER_AR "${CMAKE_AR}" CACHE FILEPATH "Emscripten ar")
+set(CMAKE_CXX_COMPILER_AR "${CMAKE_AR}" CACHE FILEPATH "Emscripten ar")
+set(CMAKE_C_COMPILER_RANLIB "${CMAKE_RANLIB}" CACHE FILEPATH "Emscripten ranlib")
+set(CMAKE_CXX_COMPILER_RANLIB "${CMAKE_RANLIB}" CACHE FILEPATH "Emscripten ranlib")
 
 # Don't allow CMake to autodetect the compiler, since it does not understand
 # Emscripten.


### PR DESCRIPTION
These were made conditional a long time ago in 9de7165f9 but it not clear to me exactly what purpose it serves.

Other toolchain files out there dont seem to do this: https://android.googlesource.com/platform/ndk/+/refs/heads/master/build/cmake/android-legacy.toolchain.cmake#549

And its causing problems for some of our users (See #17992)

I verified that `CMAKE_AR` can still be overridden from both the            
command line and from the `CMakeLists.txt` file in the project being        
built. 

Fixes: #17992