### PR TITLE
JSPI - Fix multiple async calls exiting early.

### DIFF
--- a/src/library_ccall.js
+++ b/src/library_ccall.js
@@ -75,19 +75,19 @@ mergeInto(LibraryManager.library, {
         }
       }
     }
-#if ASYNCIFY
+#if ASYNCIFY == 1
     // Data for a previous async operation that was in flight before us.
     var previousAsync = Asyncify.currData;
 #endif
     var ret = func.apply(null, cArgs);
     function onDone(ret) {
-#if ASYNCIFY
+#if ASYNCIFY == 1
       runtimeKeepalivePop();
 #endif
       if (stack !== 0) stackRestore(stack);
       return convertReturnValue(ret);
     }
-#if ASYNCIFY
+#if ASYNCIFY == 1
     // Keep the runtime alive through all calls. Note that this call might not be
     // async, but for simplicity we push and pop in all calls.
     runtimeKeepalivePush();
@@ -114,7 +114,7 @@ mergeInto(LibraryManager.library, {
 #endif
 
     ret = onDone(ret);
-#if ASYNCIFY
+#if ASYNCIFY == 1
     // If this is an async ccall, ensure we return a promise
     if (asyncMode) return Promise.resolve(ret);
 #endif

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -288,7 +288,7 @@ function exitRuntime() {
 #if RUNTIME_DEBUG
   err('exitRuntime');
 #endif
-#if ASYNCIFY && ASSERTIONS
+#if ASYNCIFY == 1 && ASSERTIONS
   // ASYNCIFY cannot be used once the runtime starts shutting down.
   Asyncify.state = Asyncify.State.Disabled;
 #endif

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8061,6 +8061,25 @@ int main() {
 
     self.do_runf('main.c', 'HelloWorld!99')
 
+  @no_wasm64('TODO: asyncify for wasm64')
+  @with_asyncify_and_stack_switching
+  def test_async_loop(self):
+    # needs to flush stdio streams
+    self.set_setting('EXIT_RUNTIME')
+
+    create_file('main.c',  r'''
+#include <stdio.h>
+#include <emscripten.h>
+int main() {
+  for (int i = 0; i < 5; i++) {
+    emscripten_sleep(1);
+    printf("hello %d\n", i);
+  }
+}
+''')
+
+    self.do_runf('main.c', 'hello 0\nhello 1\nhello 2\nhello 3\nhello 4\n')
+
   @requires_v8
   @no_wasm64('TODO: asyncify for wasm64')
   def test_async_hello_v8(self):


### PR DESCRIPTION
When multiple async calls happened in a row the asyncify code was getting in a bad state because of the differences in how JSPI/ASYNCIFY=1 handle rewinding (JSPI doesn't re-call the supsended function).

This separates out the implementations for ASYNCIFY=1 and JSPI so they have some shared code and then their own implementations for `handleSleep` and `handleAsync`.

Originally we'd hoped to keep most of the code and assertions the same for the two asyncify implementations, but I think they're different enough that they should be separated out.
1) ASYNCIFY=1 and JSPI handle rewind differently on how they resume.
2) With JSPI the engine handles some of the assertions.
3) The JSPI code can be much smaller.