### PR TITLE
Support parsing extended const in tools/webassembly.py

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12320,7 +12320,7 @@ Module['postRun'] = function() {{
   @requires_v8
   def test_extended_const(self):
     self.v8_args = ['--experimental-wasm-extended-const']
-    # Export at least one global so that we excersie the parsing of global section.
+    # Export at least one global so that we exercise the parsing of the global section.
     self.do_runf(test_file('hello_world.c'), emcc_args=['-sEXPORTED_FUNCTIONS=_main,___stdout_used', '-mextended-const', '-sMAIN_MODULE=2'])
     wat = self.get_wasm_text('hello_world.wasm')
     # Test that extended-const expressions are used in the data segments.

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12320,7 +12320,8 @@ Module['postRun'] = function() {{
   @requires_v8
   def test_extended_const(self):
     self.v8_args = ['--experimental-wasm-extended-const']
-    self.do_runf(test_file('hello_world.c'), emcc_args=['-mextended-const', '-sMAIN_MODULE=2'])
+    # Export at least one global so that we excersie the parsing of global section.
+    self.do_runf(test_file('hello_world.c'), emcc_args=['-sEXPORTED_FUNCTIONS=_main,___stdout_used', '-mextended-const', '-sMAIN_MODULE=2'])
     wat = self.get_wasm_text('hello_world.wasm')
     # Test that extended-const expressions are used in the data segments.
     self.assertTrue(re.search(r'\(data \(i32.add\s+\(global.get \$\S+\)\s+\(i32.const \d+\)', wat))

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -109,6 +109,7 @@ class OpCode(IntEnum):
   F32_CONST = 0x43
   F64_CONST = 0x44
   I32_ADD = 0x6a
+  I64_ADD = 0x6b
   REF_NULL = 0xd0
   ATOMIC_PREFIX = 0xfe
   MEMORY_PREFIX = 0xfc
@@ -239,7 +240,7 @@ class Module:
         args.append(self.read_uleb())
       elif opcode in (OpCode.REF_NULL,):
         args.append(self.read_type())
-      elif opcode in (OpCode.END,):
+      elif opcode in (OpCode.END, OpCode.I32_ADD, OpCode.I64_ADD):
         pass
       else:
         raise Exception('unexpected opcode %s' % opcode)


### PR DESCRIPTION
By forcing the export of a global we force our metadata parsing code to parse the global section which contains that extended const init expressions.