### PR TITLE
Set EM_CONFIG rather then running emsdk_env.sh.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,11 @@ commands:
     steps:
       - run:
           name: emsdk_env.sh
-          command: echo "EMSDK_QUIET=1 source ~/emsdk/emsdk_env.sh" >> $BASH_ENV
+          command: |
+            echo "EMSDK_QUIET=1 source ~/emsdk/emsdk_env.sh" >> $BASH_ENV
+            # In order make our external version of emscripten use the emsdk
+            # config we need to explictly set EM_CONFIG here.
+            echo "export EM_CONFIG=~/emsdk/.emscripten" >> $BASH_ENV
   npm-install:
     description: "npm ci"
     steps:


### PR DESCRIPTION
Since https://github.com/emscripten-core/emsdk/pull/1110 landed emsdk no longer set `EM_CONFIG` so we need to do that (in order to make our local version of emscripten use the config from emsdk).