### PR TITLE
Reduce timeout in run_multiple_processes from 200ms to 50ms

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -203,7 +203,7 @@ def run_multiple_processes(commands,
           # All processes still running; wait a short while for the first (oldest) process to finish,
           # then look again if any process has completed.
           try:
-            processes[0][1].communicate(timeout=0.2)
+            processes[0][1].communicate(timeout=0.05)
             return 0
           except subprocess.TimeoutExpired:
             pass


### PR DESCRIPTION
This seems to speed up build libc, at least on my machine:

200ms NUM_CORES=20:
7.48s
7.18s
7.58s
7.71s

50ms NUM_CORES=20:
7.14s
7.13s
7.07s
7.49s

10ms NUM_CORES=20:
7.06s
7.05s
7.20s
7.46s

10ms NUM_CORES=5:
12.90s
12.97s
12.87

100ms NUM_CORES=5:
13.65s
13.51s
13.82s