### PR TITLE
Reduce the max sleep time in run_multiple_processes

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -186,7 +186,7 @@ def run_multiple_processes(commands,
       # (oldest) process to finish, then look again if any process has completed.
       idx, proc = next(iter(processes.items()))
       try:
-        proc.communicate(timeout=0.2)
+        proc.communicate(timeout=0.01)
         return idx
       except subprocess.TimeoutExpired:
         pass


### PR DESCRIPTION
When we are running max number of processes we wait for process zero to finish before calling poll() on the entire list.  The amount of time we wait here has an effect on parallelism.  Especially when we have long running sub-processes.

I benchmarked using `./embuilder build libc++ --force` because, unlike with libc, each subprocess can take quite a while (more than 1s).

200ms timeout NUM_CORES=20:
7.48s
7.18s
7.58s
7.71s

50ms timeout NUM_CORES=20:
7.14s
7.13s
7.07s
7.49s

10ms timeout NUM_CORES=20:
7.06s
7.05s
7.20s
7.46s

The difference is more pronounced the fewer cores we have:

10ms timeout NUM_CORES=5:
12.90s
12.97s
12.87

200ms timeout NUM_CORES=5:
13.65s
13.51s
13.82s