### PR TITLE
WasmFS: Preserve name case with CASE_INSENSITIVE_FS

### DIFF
--- a/system/lib/wasmfs/backends/memory_backend.cpp
+++ b/system/lib/wasmfs/backends/memory_backend.cpp
@@ -65,15 +65,10 @@ Directory::MaybeEntries MemoryDirectory::getEntries() {
 
 int MemoryDirectory::insertMove(const std::string& name,
                                 std::shared_ptr<File> file) {
-  auto& oldEntries =
-    std::static_pointer_cast<MemoryDirectory>(file->locked().getParent())
-      ->entries;
-  for (auto it = oldEntries.begin(); it != oldEntries.end(); ++it) {
-    if (it->child == file) {
-      oldEntries.erase(it);
-      break;
-    }
-  }
+  auto oldParentLocked = file->locked().getParent()->locked();
+  auto oldName = oldParentLocked.getName(file);
+  if (int err = oldParentLocked.removeChild(oldName))
+    return err;
   (void)removeChild(name);
   insertChild(name, file);
   return 0;

--- a/test/other/test_fs_icase.cpp
+++ b/test/other/test_fs_icase.cpp
@@ -94,13 +94,8 @@ int main() {
   assert(contents.size() == 2);
   assert(std::find(contents.begin(), contents.end(), "test2.txt") !=
          contents.end());
-#ifdef WASMFS
-  assert(std::find(contents.begin(), contents.end(), "subdir") !=
-         contents.end());
-#else
   assert(std::find(contents.begin(), contents.end(), "Subdir") !=
          contents.end());
-#endif
 
   // Create a file in the directory.
   write_file("SubDir/Test.txt");
@@ -110,13 +105,8 @@ int main() {
   // Check child directory contents and entries name.
   contents = readdir("subdir");
   assert(contents.size() == 1);
-#ifdef WASMFS
-  assert(std::find(contents.begin(), contents.end(), "test.txt") !=
-         contents.end());
-#else
   assert(std::find(contents.begin(), contents.end(), "Test.txt") !=
          contents.end());
-#endif
 
   // Delete a file from a directory.
 #ifdef WASMFS
@@ -132,8 +122,12 @@ int main() {
   assert(chdir("subdir") == 0);
   char buffer[256];
   printf("getcwd: %s\n", getcwd(buffer, sizeof(buffer)));
-  assert(
-    std::string(buffer).ends_with("subdir")); // original case is not preserved
+#ifdef WASMFS
+  assert(std::string(buffer).ends_with("Subdir"));
+#else
+  // Bug in FS.chdir().
+  assert(std::string(buffer).ends_with("subdir"));
+#endif
   assert(chdir("..") == 0);
 
   // Rename a directory.
@@ -155,13 +149,8 @@ int main() {
   assert(contents.size() == 4);
   assert(std::find(contents.begin(), contents.end(), "test2.txt.lnk") !=
          contents.end());
-#ifdef WASMFS
-  assert(std::find(contents.begin(), contents.end(), "subdir2.lnk") !=
-         contents.end());
-#else
   assert(std::find(contents.begin(), contents.end(), "SUBDIR2.LNK") !=
          contents.end());
-#endif
 
   // Delete symlinks.
   assert(unlink("Test2.txt.lnk") == 0);


### PR DESCRIPTION
Don't inherit `IgnoreCaseDirectory` from `MemoryDirectory`. Implement `Directory` interface directly instead.
Save original name in `ChildEntry`.
Correct `MemoryDirectory::insertMove` to avoid assumption that old parent is a `MemoryDirectory`.

Fix #17993