### PR TITLE
cmake: Always check for EMSCRIPTEN_VERSION

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -96,7 +96,21 @@ set(CMAKE_CXX_COMPILER_AR "${CMAKE_AR}" CACHE FILEPATH "Emscripten ar")
 set(CMAKE_C_COMPILER_RANLIB "${CMAKE_RANLIB}" CACHE FILEPATH "Emscripten ranlib")
 set(CMAKE_CXX_COMPILER_RANLIB "${CMAKE_RANLIB}" CACHE FILEPATH "Emscripten ranlib")
 
-# Don't allow CMake to autodetect the compiler, since it does not understand
+# Capture the Emscripten version to EMSCRIPTEN_VERSION variable.
+if (NOT EMSCRIPTEN_VERSION)
+  execute_process(COMMAND "${CMAKE_C_COMPILER}" "-v" RESULT_VARIABLE _cmake_compiler_result ERROR_VARIABLE _cmake_compiler_output OUTPUT_QUIET)
+  if (NOT _cmake_compiler_result EQUAL 0)
+    message(FATAL_ERROR "Failed to fetch Emscripten version information with command \"'${CMAKE_C_COMPILER}' -v\"! Process returned with error code ${_cmake_compiler_result}.")
+  endif()
+  string(REGEX MATCH "emcc \\(.*\\) ([0-9\\.]+)" _dummy_unused "${_cmake_compiler_output}")
+  if (NOT CMAKE_MATCH_1)
+    message(FATAL_ERROR "Failed to regex parse Emscripten compiler version from version string: ${_cmake_compiler_output}")
+  endif()
+
+  set(EMSCRIPTEN_VERSION "${CMAKE_MATCH_1}")
+endif()
+
+# Don't allow CMake to autodetect the compiler, since this is quite slow with
 # Emscripten.
 # Pass -DEMSCRIPTEN_FORCE_COMPILERS=OFF to disable (sensible mostly only for
 # testing/debugging purposes).
@@ -126,20 +140,6 @@ if (EMSCRIPTEN_FORCE_COMPILERS)
     if (${CMAKE_C_COMPILER_VERSION} VERSION_LESS 3.9.0)
       message(WARNING "CMAKE_C_COMPILER version looks too old. Was ${CMAKE_C_COMPILER_VERSION}, should be at least 3.9.0.")
     endif()
-  endif()
-
-  # Capture the Emscripten version to EMSCRIPTEN_VERSION variable.
-  if (NOT EMSCRIPTEN_VERSION)
-    execute_process(COMMAND "${CMAKE_C_COMPILER}" "-v" RESULT_VARIABLE _cmake_compiler_result ERROR_VARIABLE _cmake_compiler_output OUTPUT_QUIET)
-    if (NOT _cmake_compiler_result EQUAL 0)
-      message(FATAL_ERROR "Failed to fetch Emscripten version information with command \"'${CMAKE_C_COMPILER}' -v\"! Process returned with error code ${_cmake_compiler_result}.")
-    endif()
-    string(REGEX MATCH "emcc \\(.*\\) ([0-9\\.]+)" _dummy_unused "${_cmake_compiler_output}")
-    if (NOT CMAKE_MATCH_1)
-      message(FATAL_ERROR "Failed to regex parse Emscripten compiler version from version string: ${_cmake_compiler_output}")
-    endif()
-
-    set(EMSCRIPTEN_VERSION "${CMAKE_MATCH_1}")
   endif()
 
   set(CMAKE_C_COMPILER_ID_RUN TRUE)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -798,6 +798,8 @@ f.close()
   # Tests that the CMake variable EMSCRIPTEN_VERSION is properly provided to user CMake scripts
   def test_cmake_emscripten_version(self):
     self.run_process([EMCMAKE, 'cmake', test_file('cmake/emscripten_version')])
+    self.clear()
+    self.run_process([EMCMAKE, 'cmake', test_file('cmake/emscripten_version'), '-DEMSCRIPTEN_FORCE_COMPILERS=OFF'])
 
   def test_cmake_emscripten_system_processor(self):
     cmake_dir = test_file('cmake/emscripten_system_processor')


### PR DESCRIPTION
Even when running with EMSCRIPTEN_FORCE_COMPILERS it can be useful
to have access to EMSCRIPTEN_VERSION.

