### PR TITLE
Rename test_libpng_with_pthreads

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1956,7 +1956,7 @@ int f() {
     self.assertContained('libpng passes test', output)
 
   @node_pthreads
-  def test_pthread_libpng(self):
+  def test_zzz_libpng_with_pthreads(self):
     shutil.copyfile(test_file('third_party/libpng/pngtest.png'), 'pngtest.png')
     self.emcc(test_file('third_party/libpng/pngtest.c'), ['--embed-file', 'pngtest.png', '-sUSE_LIBPNG', '-sUSE_PTHREADS'], output_filename='a.out.js')
     output = self.run_js('a.out.js')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1956,7 +1956,7 @@ int f() {
     self.assertContained('libpng passes test', output)
 
   @node_pthreads
-  def test_libpng_with_pthreads(self):
+  def test_pthread_libpng(self):
     shutil.copyfile(test_file('third_party/libpng/pngtest.png'), 'pngtest.png')
     self.emcc(test_file('third_party/libpng/pngtest.c'), ['--embed-file', 'pngtest.png', '-sUSE_LIBPNG', '-sUSE_PTHREADS'], output_filename='a.out.js')
     output = self.run_js('a.out.js')


### PR DESCRIPTION
This is a crazy experiment to diagnose flake on the windows builder (by trying to ensure that this test doesn't run simultaneously with test_libpng)