### PR TITLE
Fix the handling of runtimeKeepalivePush() and runtimeKeepalivePop() in emscripten_set_immediate_loop()

### DIFF
--- a/src/library_eventloop.js
+++ b/src/library_eventloop.js
@@ -95,11 +95,11 @@ LibraryJSEventLoop = {
   emscripten_set_immediate_loop: function(cb, userData) {
     polyfillSetImmediate();
     function tick() {
-      {{{ runtimeKeepalivePop(); }}}
       callUserCallback(function() {
         if ({{{ makeDynCall('ip', 'cb') }}}(userData)) {
-          {{{ runtimeKeepalivePush(); }}}
           emSetImmediate(tick);
+        } else {
+          {{{ runtimeKeepalivePop(); }}}
         }
       });
     }


### PR DESCRIPTION
Fix the handling of runtimeKeepalivePush() and runtimeKeepalivePop() in emscripten_set_immediate_loop() to be watertight.