### PR TITLE
Use explicit linker generated high/low symbols to determine stack bounds. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -209,8 +209,8 @@ def compile_settings():
 def set_memory(static_bump):
   stack_low = align_memory(settings.GLOBAL_BASE + static_bump)
   stack_high = align_memory(stack_low + settings.TOTAL_STACK)
-  settings.STACK_BASE = stack_high
-  settings.STACK_MAX = stack_low
+  settings.STACK_HIGH = stack_high
+  settings.STACK_LOW = stack_low
   settings.HEAP_BASE = align_memory(stack_high)
 
 
@@ -353,7 +353,7 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile):
     dylink_sec = webassembly.parse_dylink_section(in_wasm)
     static_bump = align_memory(dylink_sec.mem_size)
     set_memory(static_bump)
-    logger.debug('stack_base: %d, stack_max: %d, heap_base: %d', settings.STACK_BASE, settings.STACK_MAX, settings.HEAP_BASE)
+    logger.debug('stack_low: %d, stack_high: %d, heap_base: %d', settings.STACK_LOW, settings.STACK_HIGH, settings.HEAP_BASE)
 
     # When building relocatable output (e.g. MAIN_MODULE) the reported table
     # size does not include the reserved slot at zero for the null pointer.

--- a/src/library.js
+++ b/src/library.js
@@ -3600,7 +3600,7 @@ mergeInto(LibraryManager.library, {
 #if RELOCATABLE
   // Globals that are normally exported from the wasm module but in relocatable
   // mode are created here and imported by the module.
-  __stack_pointer: "new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': true}, {{{ to64(STACK_BASE) }}})",
+  __stack_pointer: "new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': true}, {{{ to64(STACK_HIGH) }}})",
   // tell the memory segments where to place themselves
   __memory_base: "new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': false}, {{{ to64(GLOBAL_BASE) }}})",
   // the wasm backend reserves slot 0 for the NULL function pointer
@@ -3617,6 +3617,8 @@ mergeInto(LibraryManager.library, {
   // have __heap_base hardcoded into it - it receives it from JS as an extern
   // global, basically).
   __heap_base: '{{{ HEAP_BASE }}}',
+  __stack_high: '{{{ STACK_HIGH }}}',
+  __stack_low: '{{{ STACK_LOW }}}',
   __global_base: '{{{ GLOBAL_BASE }}}',
 #if WASM_EXCEPTIONS
   // In dynamic linking we define tags here and feed them to each module

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -222,7 +222,7 @@ function stackCheckInit() {
   assert(!ENVIRONMENT_IS_PTHREAD);
 #endif
 #if RELOCATABLE
-  _emscripten_stack_set_limits({{{ STACK_BASE }}} , {{{ STACK_MAX }}});
+  _emscripten_stack_set_limits({{{ STACK_HIGH }}} , {{{ STACK_LOW }}});
 #else
   _emscripten_stack_init();
 #endif

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -215,8 +215,8 @@ var GENERATE_DWARF = false;
 
 // Memory layout.  These are only used/set in RELOCATABLE builds.  Otherwise
 // memory layout is fixed in the wasm binary at link time.
-var STACK_BASE = 0;
-var STACK_MAX = 0;
+var STACK_HIGH = 0;
+var STACK_LOW = 0;
 var HEAP_BASE = 0;
 
 // Used internally. set when there is a main() function.

--- a/system/lib/compiler-rt/stack_limits.S
+++ b/system/lib/compiler-rt/stack_limits.S
@@ -39,19 +39,20 @@ emscripten_stack_init:
   # emscripten_stack_get_base, or emscripten_stack_get_free are called
   .functype emscripten_stack_init () -> ()
 
-  # The heap base is where the stack grown down from.
+  # What llvm calls __stack_high is the high address from where is grows
+  # downwards.  We call this the stack base here in emscripten.
 #ifdef __PIC__
-  global.get __heap_base@GOT
+  global.get __stack_high@GOT
 #else
-  PTR.const __heap_base
+  PTR.const __stack_high
 #endif
   global.set __stack_base
 
-  # The end of stack data is the limit of the stack growth
+  # What llvm calls __stack_low is that end of the stack
 #ifdef __PIC__
-  global.get __data_end@GOT
+  global.get __stack_low@GOT
 #else
-  PTR.const __data_end
+  PTR.const __stack_low
 #endif
   # Align up to 16 bytes
   PTR.const 0xf


### PR DESCRIPTION
See https://reviews.llvm.org/D135910