### PR TITLE
Add implementation of SDL_GetScancodeFromKey

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -3711,7 +3711,9 @@ var LibrarySDL = {
   SDL_GetCurrentAudioDriver: function() {
     return allocateUTF8('Emscripten Audio');
   },
-
+  SDL_GetScancodeFromKey: function (key) {
+    return SDL.scanCodes[key]; 
+  },
   SDL_GetAudioDriver__deps: ['SDL_GetCurrentAudioDriver'],
   SDL_GetAudioDriver: function(index) { return _SDL_GetCurrentAudioDriver() },
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1939,6 +1939,20 @@ int f() {
     self.run_process([EMXX, 'main.cpp'])
     self.assertContained('1234, 1234, 4321\n', self.run_js('a.out.js'))
 
+
+  def test_sdl_scan_code_from_key(self):
+    create_file('main.cpp', r'''
+      #include <stdio.h>
+      #include <SDL/SDL_keyboard.h>
+
+      int main() {
+        printf("%d\n", SDL_GetScancodeFromKey(35));
+        return 0;
+      }
+    ''')
+    self.run_process([EMXX, 'main.cpp'])
+    self.assertEqual("204\n", self.run_js('a.out.js'))
+
   def test_sdl2_mixer_wav(self):
     self.emcc(test_file('browser/test_sdl2_mixer_wav.c'), ['-sUSE_SDL_MIXER=2'], output_filename='a.out.js')
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1939,7 +1939,6 @@ int f() {
     self.run_process([EMXX, 'main.cpp'])
     self.assertContained('1234, 1234, 4321\n', self.run_js('a.out.js'))
 
-
   def test_sdl_scan_code_from_key(self):
     create_file('main.cpp', r'''
       #include <stdio.h>
@@ -1950,8 +1949,7 @@ int f() {
         return 0;
       }
     ''')
-    self.run_process([EMXX, 'main.cpp'])
-    self.assertEqual("204\n", self.run_js('a.out.js'))
+    self.do_runf('main.cpp', '204\n')
 
   def test_sdl2_mixer_wav(self):
     self.emcc(test_file('browser/test_sdl2_mixer_wav.c'), ['-sUSE_SDL_MIXER=2'], output_filename='a.out.js')


### PR DESCRIPTION
Added the `SDL_GetScancodeFromKey` function in the `emscripten/src/library_sdl.js` that is called in `system/include/SDL/SDL_keyboard.h` that returns a scan code according to the key provided. Also Added a test in `test/test_other.py`, the test creates a file emulating the C file, the test calls the new function with a key and prints the matching/expected scan code, the test passed everytime.

Fixes: #17711