### PR TITLE
Use a debug-prefix-map for system libs

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -242,7 +242,7 @@ def main():
       if do_clear:
         library.erase()
       if do_build:
-        library.build()
+        library.build(deterministic_paths=True)
     elif what == 'sysroot':
       if do_clear:
         shared.Cache.erase_file('sysroot_install.stamp')

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -410,7 +410,7 @@ class Library:
     cflags = self.get_cflags()
     if self.deterministic_paths:
       source_dir = utils.path_from_root()
-      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten']
+      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten', f'-fdebug-compilation-dir=/emsdk/emscripten']
     asflags = get_base_cflags()
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -429,7 +429,7 @@ class Library:
     cflags = self.get_cflags()
     if self.deterministic_paths:
       source_dir = utils.path_from_root()
-      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten']
+      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten', f'-fdebug-compilation-dir=/emsdk/emscripten']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       object_basename = shared.unsuffixed_basename(src)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -424,7 +424,6 @@ class Library:
     commands = []
     objects = []
     source_dir = utils.path_from_root()
-    print(source_dir)
     cflags = self.get_cflags() + [f'-fdebug-prefix-map={source_dir}=/buildbot']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -410,7 +410,7 @@ class Library:
     cflags = self.get_cflags()
     if self.deterministic_paths:
       source_dir = utils.path_from_root()
-      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten', f'-fdebug-compilation-dir=/emsdk/emscripten']
+      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten', '-fdebug-compilation-dir=/emsdk/emscripten']
     asflags = get_base_cflags()
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -429,7 +429,7 @@ class Library:
     cflags = self.get_cflags()
     if self.deterministic_paths:
       source_dir = utils.path_from_root()
-      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten', f'-fdebug-compilation-dir=/emsdk/emscripten']
+      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten', '-fdebug-compilation-dir=/emsdk/emscripten']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       object_basename = shared.unsuffixed_basename(src)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -407,7 +407,7 @@ class Library:
     utils.safe_ensure_dirs(build_dir)
 
     source_dir = utils.path_from_root()
-    cflags = self.get_cflags() + [f'-fdebug-prefix-map={source_dir}=/buildbot']
+    cflags = self.get_cflags() + [f'-fdebug-prefix-map={source_dir}=/emsdk/emscripten']
     asflags = get_base_cflags()
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -424,7 +424,7 @@ class Library:
     commands = []
     objects = []
     source_dir = utils.path_from_root()
-    cflags = self.get_cflags() + [f'-fdebug-prefix-map={source_dir}=/buildbot']
+    cflags = self.get_cflags() + [f'-fdebug-prefix-map={source_dir}=/emsdk/emscripten']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       object_basename = shared.unsuffixed_basename(src)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -103,7 +103,7 @@ def create_lib(libname, inputs):
 
 def run_ninja(build_dir):
   diagnostics.warning('experimental', 'ninja support is experimental')
-  cmd = ['ninja', '-C', build_dir]
+  cmd = ['ninja', '-C', build_dir, f'-j {shared.get_num_cores()}']
   if shared.PRINT_STAGES:
     cmd.append('-v')
   shared.check_call(cmd, env=clean_env())
@@ -406,7 +406,8 @@ class Library:
     ensure_sysroot()
     utils.safe_ensure_dirs(build_dir)
 
-    cflags = self.get_cflags()
+    source_dir = utils.__rootpath__
+    cflags = self.get_cflags() + [f'-fdebug-prefix-map={source_dir}=buildbot']
     asflags = get_base_cflags()
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -422,7 +423,8 @@ class Library:
     """
     commands = []
     objects = []
-    cflags = self.get_cflags()
+    source_dir = utils.__rootpath__
+    cflags = self.get_cflags() + [f'-fdebug-prefix-map={source_dir}=buildbot']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       object_basename = shared.unsuffixed_basename(src)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -362,12 +362,13 @@ class Library:
   def get_path(self, absolute=False):
     return shared.Cache.get_lib_name(self.get_filename(), absolute=absolute)
 
-  def build(self):
+  def build(self, deterministic_paths=False):
     """
     Gets the cached path of this library.
 
     This will trigger a build if this library is not in the cache.
     """
+    self.deterministic_paths = deterministic_paths
     return shared.Cache.get(self.get_path(), self.do_build, force=USE_NINJA == 2, quiet=USE_NINJA)
 
   def get_link_flag(self):
@@ -407,7 +408,8 @@ class Library:
     utils.safe_ensure_dirs(build_dir)
 
     source_dir = utils.path_from_root()
-    cflags = self.get_cflags() + [f'-fdebug-prefix-map={source_dir}=/emsdk/emscripten']
+    if self.deterministic_paths:
+      cflags = self.get_cflags() + [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten']
     asflags = get_base_cflags()
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -424,7 +426,8 @@ class Library:
     commands = []
     objects = []
     source_dir = utils.path_from_root()
-    cflags = self.get_cflags() + [f'-fdebug-prefix-map={source_dir}=/emsdk/emscripten']
+    if self.deterministic_paths:
+      cflags = self.get_cflags() + [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       object_basename = shared.unsuffixed_basename(src)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -103,7 +103,7 @@ def create_lib(libname, inputs):
 
 def run_ninja(build_dir):
   diagnostics.warning('experimental', 'ninja support is experimental')
-  cmd = ['ninja', '-C', build_dir, f'-j {shared.get_num_cores()}']
+  cmd = ['ninja', '-C', build_dir]
   if shared.PRINT_STAGES:
     cmd.append('-v')
   shared.check_call(cmd, env=clean_env())
@@ -406,8 +406,8 @@ class Library:
     ensure_sysroot()
     utils.safe_ensure_dirs(build_dir)
 
-    source_dir = utils.__rootpath__
-    cflags = self.get_cflags() + [f'-fdebug-prefix-map={source_dir}=buildbot']
+    source_dir = utils.path_from_root()
+    cflags = self.get_cflags() + [f'-fdebug-prefix-map={source_dir}=/buildbot']
     asflags = get_base_cflags()
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -423,8 +423,9 @@ class Library:
     """
     commands = []
     objects = []
-    source_dir = utils.__rootpath__
-    cflags = self.get_cflags() + [f'-fdebug-prefix-map={source_dir}=buildbot']
+    source_dir = utils.path_from_root()
+    print(source_dir)
+    cflags = self.get_cflags() + [f'-fdebug-prefix-map={source_dir}=/buildbot']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       object_basename = shared.unsuffixed_basename(src)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -407,9 +407,10 @@ class Library:
     ensure_sysroot()
     utils.safe_ensure_dirs(build_dir)
 
-    source_dir = utils.path_from_root()
+    cflags = self.get_cflags()
     if self.deterministic_paths:
-      cflags = self.get_cflags() + [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten']
+      source_dir = utils.path_from_root()
+      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten']
     asflags = get_base_cflags()
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -425,9 +426,10 @@ class Library:
     """
     commands = []
     objects = []
-    source_dir = utils.path_from_root()
+    cflags = self.get_cflags()
     if self.deterministic_paths:
-      cflags = self.get_cflags() + [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten']
+      source_dir = utils.path_from_root()
+      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       object_basename = shared.unsuffixed_basename(src)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -410,7 +410,8 @@ class Library:
     cflags = self.get_cflags()
     if self.deterministic_paths:
       source_dir = utils.path_from_root()
-      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten', '-fdebug-compilation-dir=/emsdk/emscripten']
+      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten',
+                 '-fdebug-compilation-dir=/emsdk/emscripten']
     asflags = get_base_cflags()
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -429,7 +430,8 @@ class Library:
     cflags = self.get_cflags()
     if self.deterministic_paths:
       source_dir = utils.path_from_root()
-      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten', '-fdebug-compilation-dir=/emsdk/emscripten']
+      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten',
+                 '-fdebug-compilation-dir=/emsdk/emscripten']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       object_basename = shared.unsuffixed_basename(src)


### PR DESCRIPTION
Currently the system libs are built with full absolute paths in their debug info. (So for emcc, binaries will just get paths from the Chromium buildbot). This isn't useful for debugging and it makes compiler output nondeterministic across platforms. Fix this by substituting out the buildbot paths.