### PR TITLE
Improve library_c_preprocessor.js to allow using 'defined' function/macro in a operator keyword style, plus other fixes

### DIFF
--- a/src/library_c_preprocessor.js
+++ b/src/library_c_preprocessor.js
@@ -45,8 +45,9 @@ mergeInto(LibraryManager.library, {
     defs['defined'] = (args) => { // built-in "#if defined(x)"" macro.
 #if ASSERTIONS
       assert(args.length == 1);
+      assert(/^[A-Za-z0-9_$]+$/.test(args[0].trim())); // Test that a C preprocessor identifier contains only valid characters (we likely parsed wrong if this fails)
 #endif
-      return defs[args[0]] ? 1 : 0;
+      return defs[args[0].trim()] ? 1 : 0;
     };
 
     // Returns true if str[i] is whitespace.
@@ -122,12 +123,17 @@ mergeInto(LibraryManager.library, {
               var pp = defs[symbol];
               if (pp) {
                 var expanded = str.substring(lineStart, i);
-                if (pp.length && str[j] == '(') { // Expanding a macro? (#define FOO(X) ...)
-                  var closeParens = find_closing_parens_index(str, j);
-#if ASSERTIONS
-                  assert(str[closeParens] == ')');
-#endif
-                  expanded += pp(str.substring(j+1, closeParens).split(',')) + str.substring(closeParens+1, lineEnd);
+                if (pp.length) { // Expanding a macro? (#define FOO(X) ...)
+                  while (isWhitespace(str, j)) ++j;
+                  if (str[j] == '(') {
+                    var closeParens = find_closing_parens_index(str, j);
+                    // N.b. this has a limitation that multiparameter macros cannot nest with other multiparameter macros
+                    // e.g. FOO(a, BAR(b, c)) is not supported.
+                    expanded += pp(str.substring(j+1, closeParens).split(',')) + str.substring(closeParens+1, lineEnd);
+                  } else {
+                    var j2 = nextWhitespace(str, j);
+                    expanded += pp([str.substring(j, j2)]) + str.substring(j2, lineEnd);
+                  }
                 } else { // Expanding a non-macro (#define FOO BAR)
                   expanded += pp() + str.substring(j, lineEnd);
                 }
@@ -272,7 +278,7 @@ mergeInto(LibraryManager.library, {
         break;
       case 'undef': if (thisLineIsInActivePreprocessingBlock) delete defs[expression]; break;
       default:
-        if (directive != 'version' && directive != 'pragma' && directive != 'extension') { // GLSL shader compiler specific #directives.
+        if (directive != 'version' && directive != 'pragma' && directive != 'extension' && directive != 'line') { // GLSL shader compiler specific #directives.
 #if ASSERTIONS
           err('Unrecognized preprocessor directive #' + directive + '!');
 #endif

--- a/src/library_c_preprocessor.js
+++ b/src/library_c_preprocessor.js
@@ -249,7 +249,7 @@ mergeInto(LibraryManager.library, {
         break;
       case 'ifdef': stack.push(!!defs[expression] * stack[stack.length-1]); break;
       case 'ifndef': stack.push(!defs[expression] * stack[stack.length-1]); break;
-      case 'else': stack[stack.length-1] = 1-stack[stack.length-1]; break;
+      case 'else': stack[stack.length-1] = (1-stack[stack.length-1]) * stack[stack.length-2]; break;
       case 'endif': stack.pop(); break;
       case 'define':
         if (thisLineIsInActivePreprocessingBlock) {

--- a/test/test_c_preprocessor.c
+++ b/test/test_c_preprocessor.c
@@ -139,9 +139,9 @@ EM_JS(void, test_c_preprocessor, (void), {
 	test('#define FOO 42\nFOO\n', '42\n'); // Test expanding a preprocessor symbol
 
 	test('#define FOO 42\n#define BAR FOO\nBAR\n', '42\n'); // Test chained expanding a preprocessor symbol
-	test('#define MACRO(x) x\nMACRO(42)\n', '42\n'); // Test simple preprocessor macro
-	test('#define MACRO(x,y) x\nMACRO(42, 53)\n', '42\n'); // Test simple preprocessor macro
-	test('#define MACRO(  \t  x   ,   y   )    \t x    \t\nMACRO(42, 53)\n', '42\n'); // Test simple preprocessor macro
+	test('#define MACRO(x) x\nMACRO(42)\n', '42\n'); // Test one-parameter preprocessor macro
+	test('#define MACRO(x,y) x\nMACRO(42, 53)\n', '42\n'); // Test a two-parameter preprocessor macro
+	test('#define MACRO(  \t  x   ,   y   )    \t x    \t\nMACRO(42, 53)\n', '42\n'); // Test a macro with odd whitescape in it
 
 	test('#define MACRO(x,y,z) x+y<=z\nMACRO(42,15,30)\n', '42+15<=30\n'); // Test three-arg macro
 
@@ -163,7 +163,14 @@ EM_JS(void, test_c_preprocessor, (void), {
 
 	test('#if defined(FOO)\nA\n#endif', "");  // Test defined() macro
 	test('#define FOO 0\n#if defined(FOO)\nA\n#endif', "A\n");  // Test defined() macro
+	test('#define FOO 0\n#if !defined(FOO)\nA\n#endif', "");  // Test that !defined() works
+	test('#define FOO 0\n#if defined FOO \nA\n#endif', "A\n");  // Test defined without using parens
+	test('#define FOO 0\n#if ! defined FOO \nA\n#endif', "");  // Test that ! defined works, with odd whitespace
+	test('#define FOO 0\n#if defined   FOO  \nA\n#endif', "A\n");  // Test defined without using parens, with odd whitespace
+	test('#define FOO 0\n#if defined (FOO) \nA\n#endif', "A\n");  // Test defined with parens and whitespace
+	test('#define FOO 0\n#if defined ( FOO ) \nA\n#endif', "A\n");  // Test defined with parens and whitespace
 	test('#define FOO 0\n#undef FOO\n#if defined(FOO)\nA\n#endif', "");  // Test defined() macro after #undef
+	test('#define FOO 0\n#if defined FOO && BAR \nA\n#endif', "");  // Test that defined operator binds tighter than &&
 
 	test('#define SAMPLE_TEXTURE_2D texture \nvec4 c = SAMPLE_TEXTURE_2D(tex, texCoord);\n', 'vec4 c = texture(tex, texCoord);\n'); // Test expanding a non-macro to a macro-like call site
 
@@ -176,6 +183,8 @@ EM_JS(void, test_c_preprocessor, (void), {
 	test('#define FOO 1\n#if FOO\n#define BAR this_is_right\n#else\n#define BAR this_is_wrong\n#endif\nBAR', 'this_is_right\n'); // Test nested #defines in both sides of an #if-#else block.
 
 	test('\n#define FOO 1\nFOO\n', '\n1\n'); // Test that preprocessor is not confused by an input that starts with a \n
+
+	test('#line 162 "foo.glsl"\n', '#line 162 "foo.glsl"\n'); // Test that #line directives are retained in the output
 
 	if (numFailed) throw numFailed + ' tests failed!';
 });

--- a/test/test_c_preprocessor.c
+++ b/test/test_c_preprocessor.c
@@ -100,6 +100,11 @@ EM_JS(void, test_c_preprocessor, (void), {
 	test('#define FOO 1\n#if FOO >= 1\nB\n#endif', 'B\n'); // Test >=
 	test('#define FOO 1\n#if FOO >= 2\nB\n#endif', "");    // Test >=
 
+	test('#define FOO 0\n#define BAR 0\n#if FOO\n#if BAR\n1\n#else\n2\n#endif\n#else\n#if BAR\n3\n#else\n4\n#endif\n#endif', '4\n'); // Test nested #if-#elses
+	test('#define FOO 0\n#define BAR 1\n#if FOO\n#if BAR\n1\n#else\n2\n#endif\n#else\n#if BAR\n3\n#else\n4\n#endif\n#endif', '3\n'); // Test nested #if-#elses
+	test('#define FOO 1\n#define BAR 0\n#if FOO\n#if BAR\n1\n#else\n2\n#endif\n#else\n#if BAR\n3\n#else\n4\n#endif\n#endif', '2\n'); // Test nested #if-#elses
+	test('#define FOO 1\n#define BAR 1\n#if FOO\n#if BAR\n1\n#else\n2\n#endif\n#else\n#if BAR\n3\n#else\n4\n#endif\n#endif', '1\n'); // Test nested #if-#elses
+
 	test('#define FOO 1\n#define BAR 2\n#if FOO < 3 && BAR < 4\nB\n#endif', 'B\n'); // Test evaluation of && and <
 	test('#define FOO 1\n#define BAR 2\n#if FOO < 3 && BAR < 2\nB\n#endif', "");    // Test evaluation of && and <
 


### PR DESCRIPTION
Improve library_c_preprocessor.js to allow using 'defined' function/macro in a operator keyword style, i.e. '#if defined FOO'. Also fix nested #if-#else handling, stop complaining about #line preprocessor directive being unrecognized, and add a test that #line preprocessor directives are passed through to the output.