### PR TITLE
Remove checks for Module object. NFC

### DIFF
--- a/src/cpuprofiler.js
+++ b/src/cpuprofiler.js
@@ -671,4 +671,6 @@ setTimeout = (fn, delay) => {
 // Backwards compatibility with previously compiled code. Don't call this anymore!
 function cpuprofiler_add_hooks() { emscriptenCpuProfiler.initialize(); }
 
-if (typeof Module != 'undefined' && typeof document != 'undefined') emscriptenCpuProfiler.initialize();
+if (typeof document != 'undefined') {
+  emscriptenCpuProfiler.initialize();
+}

--- a/src/deterministic.js
+++ b/src/deterministic.js
@@ -14,7 +14,6 @@ Date.now = () => TIME++;
 if (typeof performance == 'object') performance.now = Date.now;
 if (ENVIRONMENT_IS_NODE) process['hrtime'] = Date.now;
 
-if (!Module) Module = {};
 Module['thisProgram'] = 'thisProgram'; // for consistency between different builds than between runs of the same build
 
 function hashMemory(id) {

--- a/src/emrun_postjs.js
+++ b/src/emrun_postjs.js
@@ -89,7 +89,7 @@ if (typeof window == "object" && (typeof ENVIRONMENT_IS_PTHREAD == 'undefined' |
     http.send(data); // XXX  this does not work in workers, for some odd reason (issue #2681)
   };
 
-  if (typeof Module != 'undefined' && typeof document != 'undefined') {
+  if (typeof document != 'undefined') {
     emrun_register_handlers();
   }
 }

--- a/src/memoryprofiler.js
+++ b/src/memoryprofiler.js
@@ -632,6 +632,8 @@ var emscriptenMemoryProfiler = {
 // anymore!
 function memoryprofiler_add_hooks() { emscriptenMemoryProfiler.initialize(); }
 
-if (typeof Module != 'undefined' && typeof document != 'undefined' && typeof window != 'undefined' && typeof process == 'undefined') emscriptenMemoryProfiler.initialize();
+if (typeof document != 'undefined' && typeof window != 'undefined' && typeof process == 'undefined') {
+  emscriptenMemoryProfiler.initialize();
+}
 
 #endif

--- a/src/threadprofiler.js
+++ b/src/threadprofiler.js
@@ -97,10 +97,8 @@ var emscriptenThreadProfiler = {
   }
 };
 
-if (typeof Module != 'undefined') {
-  if (typeof document != 'undefined') {
-    emscriptenThreadProfiler.initialize();
-  } else if (!ENVIRONMENT_IS_PTHREAD && typeof process != 'undefined') {
-    emscriptenThreadProfiler.initializeNode();
-  }
+if (typeof document != 'undefined') {
+  emscriptenThreadProfiler.initialize();
+} else if (!ENVIRONMENT_IS_PTHREAD && typeof process != 'undefined') {
+  emscriptenThreadProfiler.initializeNode();
 }

--- a/test/asan-no-leak.js
+++ b/test/asan-no-leak.js
@@ -1,5 +1,1 @@
-if (Module != undefined) {
-  Module.ASAN_OPTIONS = 'detect_leaks=0';
-} else {
-  Module = {ASAN_OPTIONS: 'detect_leaks=0'};
-}
+Module['ASAN_OPTIONS'] = 'detect_leaks=0';

--- a/test/canvas_style_proxy_pre.js
+++ b/test/canvas_style_proxy_pre.js
@@ -1,4 +1,3 @@
-var Module = Module || {};
 Module.postRun = Module.postRun || [];
 Module.postRun.push(function () {
   postMessage({ target: 'window', method: 'verifyCanvasStyle' });

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3252,7 +3252,6 @@ m0.ccall('myreadSeekEnd', 'number', [], []);
 ''')
 
     create_file('proxyfs_pre.js', r'''
-if (typeof Module === 'undefined') Module = {};
 Module["noInitialRun"]=true;
 Module["noExitRuntime"]=true;
 ''')


### PR DESCRIPTION
These scripts are all included after Module object is created in at the to of shell.js.

`--pre-js` and `--post-js` files can/should all assuming the existence of the Module object.  The existance of code like this can add to the confusions, leading folks like me to believe the cannot rely on the existence of `Module`.