### PR TITLE
Fix asan.test_async_hello_stack_switching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,6 +403,7 @@ jobs:
             asan.test_dyncall_specific_minimal_runtime
             asan.test_async_hello
             asan.test_dlfcn_basic
+            asan.test_async_hello_stack_switching
             lsan.test_stdio_locking
             lsan.test_dlfcn_basic
             lsan.test_pthread_create"

--- a/src/library.js
+++ b/src/library.js
@@ -2389,6 +2389,7 @@ mergeInto(LibraryManager.library, {
   $nowIsMonotonic: 'true;',
 #endif
 
+  _emscripten_get_now_is_monotonic__sig: 'i',
   _emscripten_get_now_is_monotonic__internal: true,
   _emscripten_get_now_is_monotonic__deps: ['$nowIsMonotonic'],
   _emscripten_get_now_is_monotonic: function() {
@@ -2984,7 +2985,11 @@ mergeInto(LibraryManager.library, {
     return ASM_CONSTS[code].apply(null, args);
 #endif
   },
-  emscripten_asm_const_double: 'emscripten_asm_const_int',
+  emscripten_asm_const_double__sig: 'dppp',
+  emscripten_asm_const_double__deps: ['emscripten_asm_const_int'],
+  emscripten_asm_const_double: function(code, sigPtr, argbuf) {
+    return _emscripten_asm_const_int(code, sigPtr, argbuf);
+  },
 
 #if MEMORY64
   emscripten_asm_const_ptr__sig: 'pppp',


### PR DESCRIPTION
This required add a missing `__sig` and avoiding using an alias for
emscripten_asm_const_double.   We can't use an alias in this case
because ASYNCIFY=2 requires the signature to match the wasm signature
precisely.