### PR TITLE
Support different node flags for different versions of node.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ executors:
   linux-node:
     docker:
       - image: circleci/node:stretch
+  linux-python:
+    docker:
+      - image: cimg/python:3.10.7
   bionic:
     docker:
       - image: emscripten/emscripten-ci
@@ -44,7 +47,7 @@ commands:
       - run:
           name: emsdk_env.sh
           command: |
-            echo "EMSDK_QUIET=1 source ~/emsdk/emsdk_env.sh" >> $BASH_ENV
+            EMSDK_BASH=1 ~/emsdk/emsdk construct_env >> $BASH_ENV
             # In order make our external version of emscripten use the emsdk
             # config we need to explictly set EM_CONFIG here.
             echo "export EM_CONFIG=~/emsdk/.emscripten" >> $BASH_ENV
@@ -469,6 +472,28 @@ jobs:
           test_targets: "wasm64"
       - run-tests:
           test_targets: "wasm64l"
+  test-latest-node:
+    executor: linux-python
+    steps:
+      - checkout
+      - run:
+          name: submodule update
+          command: git submodule update --init
+      - pip-install
+      - build
+      - run:
+          name: get node
+          command: |
+            cd $HOME
+            wget https://nodejs.org/dist/v19.0.0/node-v19.0.0-linux-x64.tar.xz
+            tar xf node-v19.0.0-linux-x64.tar.xz
+            echo "export EM_JS_ENGINES=$HOME/node-v19.0.0-linux-x64/bin/node" >> $BASH_ENV
+            echo "export EM_NODE_JS=$HOME/node-v19.0.0-linux-x64/bin/node" >> $BASH_ENV
+            echo "export PATH=\"$HOME/node-v19.0.0-linux-x64/bin:\$PATH\"" >> $BASH_ENV
+      - run-tests:
+          # Run tests that on older versions of node would require flags, but
+          # those flags should not be injected on newer versions.
+          test_targets: "-v core2.test_pthread_create core2.test_i64_invoke_bigint"
   test-other:
     executor: bionic
     steps:
@@ -628,5 +653,6 @@ workflows:
       - test-sockets-chrome:
           requires:
             - build-linux
+      - test-latest-node
       - test-windows
       - test-mac

--- a/emcc.py
+++ b/emcc.py
@@ -631,7 +631,7 @@ def make_js_executable(script):
   src = read_file(script)
   cmd = config.JS_ENGINES[0]
   if settings.WASM_BIGINT:
-    cmd.append('--experimental-wasm-bigint')
+    cmd += shared.node_bigint_flags()
   cmd = shared.shlex_join(cmd)
   if not os.path.isabs(cmd[0]):
     # TODO: use whereis etc. And how about non-*NIX?

--- a/emcmake.py
+++ b/emcmake.py
@@ -35,11 +35,13 @@ variables so that emcc etc. are used. Typical usage:
     args.append('-DCMAKE_TOOLCHAIN_FILE=' + utils.path_from_root('cmake/Modules/Platform/Emscripten.cmake'))
 
   if not has_substr(args, '-DCMAKE_CROSSCOMPILING_EMULATOR'):
-    node_js = config.NODE_JS[0]
-    # In order to allow cmake to run code built with pthreads we need to pass some extra flags to node.
-    # Note that we also need --experimental-wasm-bulk-memory which is true by default and hence not added here
+    node_js = [config.NODE_JS[0]]
+    # In order to allow cmake to run code built with pthreads we need to pass
+    # some extra flags to node.
+    node_js += shared.node_pthread_flags()
+    node_js = ';'.join(node_js)
     # See https://github.com/emscripten-core/emscripten/issues/15522
-    args.append(f'-DCMAKE_CROSSCOMPILING_EMULATOR={node_js};--experimental-wasm-threads')
+    args.append(f'-DCMAKE_CROSSCOMPILING_EMULATOR={node_js}')
 
   # On Windows specify MinGW Makefiles or ninja if we have them and no other
   # toolchain was specified, to keep CMake from pulling in a native Visual

--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -43,7 +43,7 @@ if (ENVIRONMENT_IS_PTHREAD) {
     if (!(wasmMemory.buffer instanceof SharedArrayBuffer)) {
       err('requested a shared WebAssembly.Memory but the returned buffer is not a SharedArrayBuffer, indicating that while the browser has SharedArrayBuffer it does not have WebAssembly threads support - you may need to set a flag');
       if (ENVIRONMENT_IS_NODE) {
-        err('(on node you may need: --experimental-wasm-threads --experimental-wasm-bulk-memory and also use a recent version)');
+        err('(on node you may need: --experimental-wasm-threads --experimental-wasm-bulk-memory and/or recent version)');
       }
       throw Error('bad memory');
     }

--- a/test/common.py
+++ b/test/common.py
@@ -260,7 +260,7 @@ def also_with_wasm_bigint(f):
         self.skipTest('redundant in bigint test config')
       self.set_setting('WASM_BIGINT')
       self.require_node()
-      self.node_args.append('--experimental-wasm-bigint')
+      self.node_args += shared.node_bigint_flags()
       f(self)
     else:
       f(self)
@@ -457,7 +457,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     if self.get_setting('MINIMAL_RUNTIME'):
       self.skipTest('node pthreads not yet supported with MINIMAL_RUNTIME')
     self.js_engines = [config.NODE_JS]
-    self.node_args += ['--experimental-wasm-threads', '--experimental-wasm-bulk-memory']
+    self.node_args += shared.node_pthread_flags()
 
   def uses_memory_init_file(self):
     if self.get_setting('SIDE_MODULE') or (self.is_wasm() and not self.get_setting('WASM2JS')):
@@ -1799,7 +1799,7 @@ class BrowserCore(RunnerCore):
       expected = [expected]
     if EMTEST_BROWSER == 'node':
       self.js_engines = [config.NODE_JS]
-      self.node_args += ['--experimental-wasm-threads', '--experimental-wasm-bulk-memory']
+      self.node_args += shared.node_pthread_flags()
       output = self.run_js('test.js')
       self.assertContained('RESULT: ' + expected[0], output)
     else:

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -240,7 +240,7 @@ def also_with_standalone_wasm(wasm2c=False, impure=False):
         if impure:
           self.wasm_engines = []
         self.js_engines = [config.NODE_JS]
-        self.node_args.append('--experimental-wasm-bigint')
+        self.node_args += shared.node_bigint_flags()
         func(self)
         if wasm2c:
           print('wasm2c')
@@ -576,7 +576,7 @@ class TestCoreBase(RunnerCore):
   def test_i64_invoke_bigint(self):
     self.set_setting('WASM_BIGINT')
     self.emcc_args += ['-fexceptions']
-    self.node_args += ['--experimental-wasm-bigint']
+    self.node_args += shared.node_bigint_flags()
     self.do_core_test('test_i64_invoke_bigint.cpp')
 
   def test_vararg_copy(self):
@@ -2277,7 +2277,7 @@ int main(int argc, char **argv) {
     self.assertContained('emcc: error: using 64-bit arguments in EM_JS function without WASM_BIGINT is not yet fully supported: `foo`', err)
 
     self.set_setting('WASM_BIGINT')
-    self.node_args += ['--experimental-wasm-bigint']
+    self.node_args += shared.node_bigint_flags()
     self.do_core_test('test_em_js_i64.c')
 
   def test_runtime_stacksave(self):
@@ -7006,7 +7006,7 @@ void* operator new(size_t size) {
       # mode. this happens to work without wasmfs, but with wasmfs we get the
       # time when we create/update a file, which uses clock_time_get that has an
       # i64 param. For such an import to work we need wasm-bigint support.
-      self.node_args.append('--experimental-wasm-bigint')
+      self.node_args += shared.node_bigint_flags()
     if not can_do_standalone(self):
       return self.skipTest('standalone mode not supported')
     self.set_setting('STANDALONE_WASM')
@@ -7580,14 +7580,14 @@ void* operator new(size_t size) {
   def test_embind_i64_val(self):
     self.set_setting('WASM_BIGINT')
     self.emcc_args += ['-lembind']
-    self.node_args += ['--experimental-wasm-bigint']
+    self.node_args += shared.node_bigint_flags()
     self.do_run_in_out_file_test('embind/test_i64_val.cpp', assert_identical=True)
 
   @no_wasm2js('wasm_bigint')
   def test_embind_i64_binding(self):
     self.set_setting('WASM_BIGINT')
     self.emcc_args += ['-lembind']
-    self.node_args += ['--experimental-wasm-bigint']
+    self.node_args += shared.node_bigint_flags()
     self.do_run_in_out_file_test('embind/test_i64_binding.cpp', assert_identical=True)
 
   def test_embind_no_rtti(self):
@@ -9637,7 +9637,7 @@ wasm64 = make_run('wasm64', emcc_args=['-Wno-experimental', '--profiling-funcs']
 # MEMORY64=2, or "lowered"
 wasm64l = make_run('wasm64l', emcc_args=['-Wno-experimental', '--profiling-funcs'],
                    settings={'MEMORY64': 2},
-                   node_args=['--experimental-wasm-bigint'])
+                   node_args=shared.node_bigint_flags())
 
 lto0 = make_run('lto0', emcc_args=['-flto', '-O0'])
 lto1 = make_run('lto1', emcc_args=['-flto', '-O1'])
@@ -9674,7 +9674,7 @@ core2s = make_run('core2s', emcc_args=['-O2'], settings={'SAFE_HEAP': 1})
 core2ss = make_run('core2ss', emcc_args=['-O2'], settings={'STACK_OVERFLOW_CHECK': 2})
 
 bigint = make_run('bigint', emcc_args=['--profiling-funcs'], settings={'WASM_BIGINT': 1},
-                  node_args=['--experimental-wasm-bigint'])
+                  node_args=shared.node_bigint_flags())
 
 # Add DEFAULT_TO_CXX=0
 strict = make_run('strict', emcc_args=[], settings={'STRICT': 1})

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6844,7 +6844,7 @@ Resolved: "/" => "/"
     ''')
 
     # Run the test and confirm the output is as expected.
-    out = self.run_js('testrun.js', engine=config.NODE_JS + ['--experimental-wasm-bigint'])
+    out = self.run_js('testrun.js', engine=config.NODE_JS + shared.node_bigint_flags())
     self.assertContained('''\
 input = 0xaabbccdd11223344
 low = 5678
@@ -12106,7 +12106,7 @@ Module['postRun'] = function() {{
   @wasmfs_all_backends
   def test_wasmfs_readfile_bigint(self):
     self.set_setting('WASM_BIGINT')
-    self.node_args += ['--experimental-wasm-bigint']
+    self.node_args += shared.node_bigint_flags()
     self.do_run_in_out_file_test(test_file('wasmfs/wasmfs_readfile.c'))
 
   def test_wasmfs_jsfile(self):
@@ -12319,7 +12319,7 @@ Module['postRun'] = function() {{
   @also_with_minimal_runtime
   def test_shared_memory(self):
     self.do_runf(test_file('wasm_worker/shared_memory.c'), '0', emcc_args=[])
-    self.node_args += ['--experimental-wasm-threads', '--experimental-wasm-bulk-memory']
+    self.node_args += shared.node_pthread_flags()
     self.do_runf(test_file('wasm_worker/shared_memory.c'), '1', emcc_args=['-sSHARED_MEMORY'])
     self.do_runf(test_file('wasm_worker/shared_memory.c'), '1', emcc_args=['-sWASM_WORKERS'])
     self.do_runf(test_file('wasm_worker/shared_memory.c'), '1', emcc_args=['-pthread'])

--- a/tools/config.py
+++ b/tools/config.py
@@ -135,6 +135,9 @@ def parse_config_file():
     if env_value is not None:
       if env_value in ('', '0'):
         env_value = None
+      # Unlike the other keys these two should always be lists.
+      if key in ('JS_ENGINES', 'WASM_ENGINES'):
+        env_value = env_value.split(',')
       globals()[key] = env_value
     elif key in config:
       globals()[key] = config[key]

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -301,7 +301,7 @@ def inspect_headers(headers, cflags):
   show('Calling generated program... ' + js_file[1])
   args = []
   if settings.MEMORY64:
-    args += ['--experimental-wasm-bigint']
+    args += shared.node_bigint_flags()
   info = shared.run_js_tool(js_file[1], node_args=args, stdout=shared.PIPE).splitlines()
 
   if not DEBUG:


### PR DESCRIPTION
This is mostly about what flags to pass to node during testing, but also applies to `CMAKE_CROSSCOMPILING_EMULATOR` and to the #! used in autoconf tests.