### PR TITLE
Remove unused JS_ENGINE from emscripten config. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -629,11 +629,11 @@ def get_binaryen_passes():
 
 def make_js_executable(script):
   src = read_file(script)
-  cmd = config.JS_ENGINE
+  cmd = config.JS_ENGINES[0]
   if settings.WASM_BIGINT:
     cmd.append('--experimental-wasm-bigint')
   cmd = shared.shlex_join(cmd)
-  if not os.path.isabs(config.JS_ENGINE[0]):
+  if not os.path.isabs(cmd[0]):
     # TODO: use whereis etc. And how about non-*NIX?
     cmd = '/usr/bin/env -S ' + cmd
   logger.debug('adding `#!` to JavaScript file: %s' % cmd)

--- a/tools/config.py
+++ b/tools/config.py
@@ -27,7 +27,6 @@ LLVM_ADD_VERSION = None
 CLANG_ADD_VERSION = None
 CLOSURE_COMPILER = None
 JAVA = None
-JS_ENGINE = None
 JS_ENGINES = None
 WASMER = None
 WASMTIME = None
@@ -58,13 +57,11 @@ def root_is_writable():
 
 def normalize_config_settings():
   global CACHE, PORTS, LLVM_ADD_VERSION, CLANG_ADD_VERSION, CLOSURE_COMPILER
-  global NODE_JS, V8_ENGINE, JS_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, WASM_ENGINES
+  global NODE_JS, V8_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, WASM_ENGINES
 
   # EM_CONFIG stuff
   if not JS_ENGINES:
     JS_ENGINES = [NODE_JS]
-  if not JS_ENGINE:
-    JS_ENGINE = JS_ENGINES[0]
 
   # Engine tweaks
   if SPIDERMONKEY_ENGINE:
@@ -74,7 +71,6 @@ def normalize_config_settings():
     SPIDERMONKEY_ENGINE = fix_js_engine(SPIDERMONKEY_ENGINE, new_spidermonkey)
   NODE_JS = fix_js_engine(NODE_JS, listify(NODE_JS))
   V8_ENGINE = fix_js_engine(V8_ENGINE, listify(V8_ENGINE))
-  JS_ENGINE = fix_js_engine(JS_ENGINE, listify(JS_ENGINE))
   JS_ENGINES = [listify(engine) for engine in JS_ENGINES]
   WASM_ENGINES = [listify(engine) for engine in WASM_ENGINES]
   CLOSURE_COMPILER = listify(CLOSURE_COMPILER)
@@ -122,7 +118,6 @@ def parse_config_file():
     'CLANG_ADD_VERSION',
     'CLOSURE_COMPILER',
     'JAVA',
-    'JS_ENGINE',
     'JS_ENGINES',
     'WASMER',
     'WASMTIME',


### PR DESCRIPTION
We use `JS_ENGINES` (the plural) version when running tests.  There was one useage of the singular version which was in generating the #! line when building autoconf tests.