### PR TITLE
Avoid calling resetPrototype on missing object

### DIFF
--- a/test/manual_wasm_instantiate.html
+++ b/test/manual_wasm_instantiate.html
@@ -172,6 +172,11 @@
         wasm.then(function(wasmBinary) {
           console.log('wasm download finished, begin instantiating');
           var wasmInstantiate = WebAssembly.instantiate(new Uint8Array(wasmBinary), imports).then(function(output) {
+            // When overriding instantiateWasm, in asan builds, we also need
+            // to take case of creating the WasmOffsetConverter
+            if (typeof WasmOffsetConverter != "undefined") {
+              wasmOffsetConverter = new WasmOffsetConverter(wasmBinary, output.module);
+            }
             console.log('wasm instantiation succeeded');
             Module.testWasmInstantiationSucceeded = 1;
             successCallback(output.instance);

--- a/test/manual_wasm_instantiate.html
+++ b/test/manual_wasm_instantiate.html
@@ -173,7 +173,7 @@
           console.log('wasm download finished, begin instantiating');
           var wasmInstantiate = WebAssembly.instantiate(new Uint8Array(wasmBinary), imports).then(function(output) {
             // When overriding instantiateWasm, in asan builds, we also need
-            // to take case of creating the WasmOffsetConverter
+            // to take care of creating the WasmOffsetConverter
             if (typeof WasmOffsetConverter != "undefined") {
               wasmOffsetConverter = new WasmOffsetConverter(wasmBinary, output.module);
             }


### PR DESCRIPTION
`wasmSourceMapData` and `wasmOffestData` are used to communicate data to new
pthreads and cannot/should not be used in general just because `instantatiateWasm`
is overridden.

Folks who want to override `instantatiateWasm` and still want asan (and the offset
converter in general) to work would need to create the `WasmOffsetConverter` as
part of `instantatiateWasm`.


Fixes: #17472