### PR TITLE
Reuse device handle in emscripten_webgpu_get_device

### DIFF
--- a/src/library_html5_webgpu.js
+++ b/src/library_html5_webgpu.js
@@ -60,9 +60,13 @@ var LibraryHTML5WebGPU = {
 #if ASSERTIONS
     assert(Module['preinitializedWebGPUDevice']);
 #endif
-    var device = Module['preinitializedWebGPUDevice'];
-    var deviceWrapper = { queueId: WebGPU.mgrQueue.create(device["queue"]) };
-    return WebGPU.mgrDevice.create(device, deviceWrapper);
+    if (WebGPU.preinitializedDeviceId === undefined) {
+      var device = Module['preinitializedWebGPUDevice'];
+      var deviceWrapper = { queueId: WebGPU.mgrQueue.create(device["queue"]) };
+      WebGPU.preinitializedDeviceId = WebGPU.mgrDevice.create(device, deviceWrapper);
+    }
+    WebGPU.mgrDevice.reference(WebGPU.preinitializedDeviceId);
+    return WebGPU.preinitializedDeviceId;
   },
 };
 


### PR DESCRIPTION
Currently, this function creates a new wrapper each time it's called. As a result, what is a single device in JavaScript looks like different devices in C (the handles are different), and there is a new entry in WebGPU.mgrDevice for each call.

With this change, the same handle is returned each time.

Note that each new device wrapper currently also leaks a queue wrapper (see the comment at
<https://github.com/emscripten-core/emscripten/blob/0c4fba0371abc8c7219dc481a02ea4a464b14641/src/library_webgpu.js#L190>), so this change also reduces the impact of that issue.