### PR TITLE
Use Linux-built cache/sysroot for Mac CI tester 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -568,13 +568,15 @@ jobs:
             brew list ninja || brew install ninja
             brew list python3 || brew install python3
             brew list pkg-config || brew install pkg-config
-      - checkout
-      - build
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
       - pip-install:
           python: "$EMSDK_PYTHON"
-      - run-tests-linux:
+      - attach_workspace:
+          at: ~/
+      - checkout
+      - build
+      - run-tests:
           # skip other.test_stack_switching_size as we do not currently install
           # d8 on mac
           test_targets: "

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,6 +577,9 @@ jobs:
             ls -l ~/cache/sysroot
             ls -l ~/cache/sysroot/lib/wasm32-emscripten
       - checkout
+      - run:
+          command: |
+            rm -rf ~/emsdk
       - build
       - run:
           name: ls cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,27 +111,27 @@ commands:
       - run:
           name: embuilder build ALL
           command: |
-            ./embuilder build SYSTEM
+            ./embuilder build ALL
             ./test/runner test_hello_world
-      #- run:
-      #    name: embuilder (LTO)
-      #    command: |
-      #      ./embuilder build MINIMAL --lto
-      #      ./test/runner test_hello_world
-      #- run:
-      #    name: embuilder (WASM64)
-      #    command: |
-      #      ./embuilder build MINIMAL --wasm64
-      #- run:
-      #    name: embuilder (PIC)
-      #    command: |
-      #      ./embuilder build MINIMAL_PIC --pic
-      #      ./test/runner test_hello_world
-      #- run:
-      #    name: embuilder (PIC+LTO)
-      #    command: |
-      #      ./embuilder build MINIMAL --pic --lto
-      #      ./test/runner test_hello_world
+      - run:
+          name: embuilder (LTO)
+          command: |
+            ./embuilder build MINIMAL --lto
+            ./test/runner test_hello_world
+      - run:
+          name: embuilder (WASM64)
+          command: |
+            ./embuilder build MINIMAL --wasm64
+      - run:
+          name: embuilder (PIC)
+          command: |
+            ./embuilder build MINIMAL_PIC --pic
+            ./test/runner test_hello_world
+      - run:
+          name: embuilder (PIC+LTO)
+          command: |
+            ./embuilder build MINIMAL --pic --lto
+            ./test/runner test_hello_world
   persist:
     description: "Persist the emsdk, libraries, and engines"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -573,7 +573,7 @@ jobs:
           at: ~/
       - checkout
       - run:
-          name: Remove native binaries
+          name: Remove Linux binaries
           command: |
             rm -rf ~/emsdk ~/vms
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,8 +574,7 @@ jobs:
       - emsdk-env
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
-      - pip-install:
-          python: "$EMSDK_PYTHON"
+      - pip-install
 
       - npm-install
       - run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,27 +111,27 @@ commands:
       - run:
           name: embuilder build ALL
           command: |
-            ./embuilder build ALL
+            ./embuilder build SYSTEM
             ./test/runner test_hello_world
-      - run:
-          name: embuilder (LTO)
-          command: |
-            ./embuilder build MINIMAL --lto
-            ./test/runner test_hello_world
-      - run:
-          name: embuilder (WASM64)
-          command: |
-            ./embuilder build MINIMAL --wasm64
-      - run:
-          name: embuilder (PIC)
-          command: |
-            ./embuilder build MINIMAL_PIC --pic
-            ./test/runner test_hello_world
-      - run:
-          name: embuilder (PIC+LTO)
-          command: |
-            ./embuilder build MINIMAL --pic --lto
-            ./test/runner test_hello_world
+      #- run:
+      #    name: embuilder (LTO)
+      #    command: |
+      #      ./embuilder build MINIMAL --lto
+      #      ./test/runner test_hello_world
+      #- run:
+      #    name: embuilder (WASM64)
+      #    command: |
+      #      ./embuilder build MINIMAL --wasm64
+      #- run:
+      #    name: embuilder (PIC)
+      #    command: |
+      #      ./embuilder build MINIMAL_PIC --pic
+      #      ./test/runner test_hello_world
+      #- run:
+      #    name: embuilder (PIC+LTO)
+      #    command: |
+      #      ./embuilder build MINIMAL --pic --lto
+      #      ./test/runner test_hello_world
   persist:
     description: "Persist the emsdk, libraries, and engines"
     steps:
@@ -573,17 +573,17 @@ jobs:
       - run:
           name: ls cache
           command: |
-            ls -l cache
-            ls -l cache/sysroot
-            ls -l cache/sysroot/lib/wasm32-emscripten
+            ls -l ~/cache
+            ls -l ~/cache/sysroot
+            ls -l ~/cache/sysroot/lib/wasm32-emscripten
       - checkout
       - build
       - run:
           name: ls cache
           command: |
-            ls -l cache
-            ls -l cache/sysroot
-            ls -l cache/sysroot/lib/wasm32-emscripten
+            ls -l ~/cache
+            ls -l ~/cache/sysroot
+            ls -l ~/cache/sysroot/lib/wasm32-emscripten
       #- emsdk-env
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,13 +100,13 @@ commands:
             cat ~/emsdk/.emscripten
       - emsdk-env
       - npm-install
+  build-libs:
+    description: "Build all libraries, and freeze the cache"
+    steps:
       - run:
           name: clear cache
           command: |
             ./emcc --clear-cache
-  build-libs:
-    description: "Build all libraries, and freeze the cache"
-    steps:
       - pip-install
       - run:
           name: embuilder build ALL
@@ -574,7 +574,7 @@ jobs:
       # only limited tests here, it's more efficient to build on demand
       - pip-install:
           python: "$EMSDK_PYTHON"
-      - run-tests:
+      - run-tests-linux:
           # skip other.test_stack_switching_size as we do not currently install
           # d8 on mac
           test_targets: "
@@ -628,4 +628,6 @@ workflows:
           requires:
             - build-linux
       - test-windows
-      - test-mac
+      - test-mac:
+          requires:
+            - build-linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -570,13 +570,26 @@ jobs:
             brew list pkg-config || brew install pkg-config
       - attach_workspace:
           at: ~/
+      - run:
+          name: ls cache
+          command: |
+            ls -l cache
+            ls -l cache/sysroot
+            ls -l cache/sysroot/lib/wasm32-emscripten
       - checkout
-      - emsdk-env
+      - build
+      - run:
+          name: ls cache
+          command: |
+            ls -l cache
+            ls -l cache/sysroot
+            ls -l cache/sysroot/lib/wasm32-emscripten
+      #- emsdk-env
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
-      - pip-install
-
-      - npm-install
+      - pip-install:
+          python: "$EMSDK_PYTHON"
+      #- npm-install
       - run-tests:
           # skip other.test_stack_switching_size as we do not currently install
           # d8 on mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,6 +558,7 @@ jobs:
     executor: mac
     environment:
       EMTEST_SKIP_V8: "1"
+      EMCC_SKIP_SANITY_CHECK: "1"
     steps:
       - run:
           name: Install brew package dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -568,14 +568,16 @@ jobs:
             brew list ninja || brew install ninja
             brew list python3 || brew install python3
             brew list pkg-config || brew install pkg-config
+      - attach_workspace:
+          at: ~/
+      - checkout
+      - emsdk-env
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
       - pip-install:
           python: "$EMSDK_PYTHON"
-      - attach_workspace:
-          at: ~/
-      - checkout
-      - build
+
+      - npm-install
       - run-tests:
           # skip other.test_stack_switching_size as we do not currently install
           # d8 on mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ commands:
       - emsdk-env
       - npm-install
   build-libs:
-    description: "Build all libraries, and freeze the cache"
+    description: "Build all libraries"
     steps:
       - run:
           name: clear cache
@@ -636,5 +636,8 @@ workflows:
             - build-linux
       - test-windows
       - test-mac:
+          # The mac tester also uses the libraries built on the linux builder to
+          # save total build time (this is fine because the libraries are wasm
+          # and do not depend on the underlying build platform)
           requires:
             - build-linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ commands:
             echo "WASM_ENGINES = []" >> .emscripten
             test -f ~/vms/wasmtime && echo "WASMTIME = os.path.expanduser(os.path.join('~', 'vms', 'wasmtime')) ; WASM_ENGINES.append(WASMTIME)" >> .emscripten || true
             test -f ~/vms/wasmer && echo "WASMER = os.path.expanduser(os.path.join('~', 'vms', 'wasmer')) ; WASM_ENGINES.append(WASMER)" >> .emscripten || true
-            test -d ~/wasi-sdk && cp -ar ~/wasi-sdk/lib/ ~/emsdk/upstream/lib/clang/16.0.0/
+            test -d ~/wasi-sdk && cp -a ~/wasi-sdk/lib/ ~/emsdk/upstream/lib/clang/16.0.0/
             cd -
             echo "final .emscripten:"
             cat ~/emsdk/.emscripten

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,29 +571,16 @@ jobs:
             brew list pkg-config || brew install pkg-config
       - attach_workspace:
           at: ~/
-      - run:
-          name: ls cache
-          command: |
-            ls -l ~/cache
-            ls -l ~/cache/sysroot
-            ls -l ~/cache/sysroot/lib/wasm32-emscripten
       - checkout
       - run:
+          name: Remove native binaries
           command: |
-            rm -rf ~/emsdk
+            rm -rf ~/emsdk ~/vms
       - build
-      - run:
-          name: ls cache
-          command: |
-            ls -l ~/cache
-            ls -l ~/cache/sysroot
-            ls -l ~/cache/sysroot/lib/wasm32-emscripten
-      #- emsdk-env
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
       - pip-install:
           python: "$EMSDK_PYTHON"
-      #- npm-install
       - run-tests:
           # skip other.test_stack_switching_size as we do not currently install
           # d8 on mac

--- a/test/runner.py
+++ b/test/runner.py
@@ -93,6 +93,47 @@ misc_test_modes = [
 ]
 
 
+cross_platform_tests = [
+    'core0.test_dylink_basics',
+    'core2.test_sse1',
+    'core2.test_ccall',
+    'core2.test_utf16',
+    'core2.test_em_asm_unicode',
+    'core2.test_em_js',
+    'core2.test_em_js_pthreads',
+    'core2.test_unicode_js_library',
+    'other.test_dlmalloc_modes',
+    'other.test_c_preprocessor',
+    'other.test_prejs_unicode',
+    'other.test_em_js_side_module',
+    'other.test_es5_transpile',
+    'other.test_emcc_cflags',
+    'other.test_stdin',
+    'other.test_bad_triple',
+    'other.test_closure_externs',
+    'other.test_binaryen_debug',
+    'other.test_js_optimizer*',
+    'other.test_output_to_nowhere',
+    'other.test_emcc_dev_null',
+    'other.test_cmake*',
+    'other.test_system_include_paths',
+    'other.test_emar_response_file',
+    'other.test_special_chars_in_arguments',
+    'other.test_toolchain_profiler',
+    'other.test_realpath_nodefs',
+    'other.test_response_file_encoding',
+    'other.test_libc_progname',
+    'other.test_realpath',
+    'other.test_embed_file_dup',
+    'other.test_dot_a_all_contents_invalid',
+    'other.test_emcc_print_search_dirs',
+    'other.test_emcc_print_file_name',
+    'other.test_pkg_config*',
+    'sockets.test_nodejs_sockets_echo*',
+    'core0.test_lua',
+    'core0.test_longjmp_standalone',
+]
+
 def check_js_engines():
   working_engines = [e for e in config.JS_ENGINES if jsrun.check_engine(e)]
   if len(working_engines) < len(config.JS_ENGINES):

--- a/test/runner.py
+++ b/test/runner.py
@@ -93,47 +93,6 @@ misc_test_modes = [
 ]
 
 
-cross_platform_tests = [
-    'core0.test_dylink_basics',
-    'core2.test_sse1',
-    'core2.test_ccall',
-    'core2.test_utf16',
-    'core2.test_em_asm_unicode',
-    'core2.test_em_js',
-    'core2.test_em_js_pthreads',
-    'core2.test_unicode_js_library',
-    'other.test_dlmalloc_modes',
-    'other.test_c_preprocessor',
-    'other.test_prejs_unicode',
-    'other.test_em_js_side_module',
-    'other.test_es5_transpile',
-    'other.test_emcc_cflags',
-    'other.test_stdin',
-    'other.test_bad_triple',
-    'other.test_closure_externs',
-    'other.test_binaryen_debug',
-    'other.test_js_optimizer*',
-    'other.test_output_to_nowhere',
-    'other.test_emcc_dev_null',
-    'other.test_cmake*',
-    'other.test_system_include_paths',
-    'other.test_emar_response_file',
-    'other.test_special_chars_in_arguments',
-    'other.test_toolchain_profiler',
-    'other.test_realpath_nodefs',
-    'other.test_response_file_encoding',
-    'other.test_libc_progname',
-    'other.test_realpath',
-    'other.test_embed_file_dup',
-    'other.test_dot_a_all_contents_invalid',
-    'other.test_emcc_print_search_dirs',
-    'other.test_emcc_print_file_name',
-    'other.test_pkg_config*',
-    'sockets.test_nodejs_sockets_echo*',
-    'core0.test_lua',
-    'core0.test_longjmp_standalone',
-]
-
 def check_js_engines():
   working_engines = [e for e in config.JS_ENGINES if jsrun.check_engine(e)]
   if len(working_engines) < len(config.JS_ENGINES):


### PR DESCRIPTION
This PR makes the CircleCI builders use the sysroot built by the Linux builder on the mac bot, instead of having the mac bot rebuild all the libraries. It does this by attaching the same workspace that the linux testers do, and then removing the Linux-specific binaries and emsdk, and using the mac EMSDK instead.