### PR TITLE
Fix comment in gen_struct_info.py

### DIFF
--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -261,7 +261,7 @@ def inspect_headers(headers, cflags):
   else:
     compiler = shared.EMCC
 
-  # -Oz optimizes enough to avoid warnings on code size/num locals
+  # -O1+ produces calls to iprintf, which libcompiler_rt doesn't support
   cmd = [compiler] + cflags + ['-o', js_file[1], src_file[1],
                                '-O0',
                                '-Werror',


### PR DESCRIPTION
The optimization option was changed from `-Oz` to `-O0` due to `iprintf` calls in #8348.