### PR TITLE
Restore the musl pthread circular thread list, in order to fix the pthread key recreation zero-initialization issue

### DIFF
--- a/system/lib/libc/musl/src/internal/pthread_impl.h
+++ b/system/lib/libc/musl/src/internal/pthread_impl.h
@@ -26,8 +26,7 @@ struct pthread {
 #ifndef TLS_ABOVE_TP
 	uintptr_t *dtv;
 #endif
-	// TODO(sbc): Implement circular list of threads
-	//struct pthread *prev, *next; /* non-ABI */
+	struct pthread *prev, *next; /* non-ABI */
 	uintptr_t sysinfo;
 #ifndef TLS_ABOVE_TP
 #ifdef CANARY_PAD

--- a/system/lib/libc/musl/src/thread/pthread_key_create.c
+++ b/system/lib/libc/musl/src/thread/pthread_key_create.c
@@ -26,7 +26,7 @@ weak_alias(dummy_0, __tl_unlock);
 
 int __pthread_key_create(pthread_key_t *k, void (*dtor)(void *))
 {
-        pthread_t self = __pthread_self(), td=self;
+        pthread_t self = __pthread_self();
 
 	/* This can only happen in the main thread before
 	 * pthread_create has been called. */

--- a/system/lib/libc/musl/src/thread/pthread_key_create.c
+++ b/system/lib/libc/musl/src/thread/pthread_key_create.c
@@ -26,7 +26,7 @@ weak_alias(dummy_0, __tl_unlock);
 
 int __pthread_key_create(pthread_key_t *k, void (*dtor)(void *))
 {
-	pthread_t self = __pthread_self();
+        pthread_t self = __pthread_self(), td=self;
 
 	/* This can only happen in the main thread before
 	 * pthread_create has been called. */
@@ -57,13 +57,10 @@ int __pthread_key_delete(pthread_key_t k)
 	__block_app_sigs(&set);
 	__pthread_rwlock_wrlock(&key_lock);
 
-  // TODO(sbc): Implement circular list of threads
-  /*
 	__tl_lock();
 	do td->tsd[k] = 0;
 	while ((td=td->next)!=self);
 	__tl_unlock();
-  */
 
 	keys[k] = 0;
 

--- a/system/lib/libc/musl/src/thread/pthread_key_create.c
+++ b/system/lib/libc/musl/src/thread/pthread_key_create.c
@@ -26,7 +26,7 @@ weak_alias(dummy_0, __tl_unlock);
 
 int __pthread_key_create(pthread_key_t *k, void (*dtor)(void *))
 {
-        pthread_t self = __pthread_self();
+	pthread_t self = __pthread_self();
 
 	/* This can only happen in the main thread before
 	 * pthread_create has been called. */

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -681,7 +681,8 @@ void __emscripten_init_main_thread(void) {
   // tid is always non-zero.
   __main_pthread.tid = getpid();
   __main_pthread.locale = &libc.global_locale;
-  // TODO(sbc): Implement circular list of threads
-  //__main_pthread.next = __main_pthread.prev = &__main_pthread;
+  // pthread struct prev and next should initially point to itself (see __init_tp),
+  // this is used by pthread_key_delete for deleting thread-specific data.
+  __main_pthread.next = __main_pthread.prev = &__main_pthread;
   __main_pthread.tsd = (void **)__pthread_tsd_main;
 }

--- a/system/lib/pthread/pthread_create.c
+++ b/system/lib/pthread/pthread_create.c
@@ -274,13 +274,6 @@ void _emscripten_thread_free_data(pthread_t t) {
   }
 #endif
 
-  __tl_lock();
-
-  t->next->prev = t->prev;
-  t->prev->next = t->next;
-
-  __tl_unlock();
-
   // Free all the enture thread block (called map_base because
   // musl normally allocates this using mmap).  This region
   // includes the pthread structure itself.

--- a/test/other/metadce/test_metadce_minimal_pthreads.funcs
+++ b/test/other/metadce/test_metadce_minimal_pthreads.funcs
@@ -10,6 +10,9 @@ $__pthread_setcancelstate
 $__set_thread_state
 $__stdio_write
 $__timedwait
+$__tl_lock
+$__tl_unlock
+$__wait
 $__wake
 $__wasi_syscall_ret
 $__wasm_call_ctors
@@ -30,6 +33,7 @@ $a_cas_p.1
 $a_dec
 $a_fetch_add
 $a_inc
+$a_store
 $a_swap
 $add
 $dispose_chunk

--- a/test/pthread/test_pthread_key_recreation.cpp
+++ b/test/pthread/test_pthread_key_recreation.cpp
@@ -1,0 +1,95 @@
+// Copyright 2019 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <iostream>
+#include <cassert>
+#include <condition_variable>
+#include <pthread.h>
+#include <emscripten.h>
+
+// tests, in the following sequence
+//  pthread_key_create with key k
+//  pthread_key_delete of key k
+//  pthread_key_create returning the same key k
+// , that the thread local slot is correctly initialized to 0 in all threads
+
+// overall structure based on test_pthread_reltime.cpp
+
+static pthread_key_t key;
+
+static std::mutex mutex;
+static std::condition_variable cond_var;
+static bool thread_sync = false;
+
+void *thread_main(void *arg) {
+    assert(pthread_getspecific(key) == 0);
+
+    pthread_setspecific(key, (void*)123);
+    assert(pthread_getspecific(key) == (void*)123);
+
+    // wait for slot to be recreated
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+	thread_sync = true;
+        cond_var.notify_one();
+    }
+
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        while (thread_sync)
+            cond_var.wait(lock);
+    }
+
+    assert(pthread_getspecific(key) == 0);
+
+    return NULL;
+}
+
+int main() {
+    // create tls slot and set the value
+    pthread_key_create(&key, NULL);
+    assert(pthread_getspecific(key) == 0);
+
+    pthread_setspecific(key, (void*)456);
+    assert(pthread_getspecific(key) == (void*)456);
+    
+    // launch worker thread that also sets and queries the same slot
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+
+    pthread_t thread;
+    int error = pthread_create(&thread, &attr, thread_main, NULL);
+    assert(!error);
+
+    // wait for worker thread to finish initial setting of the slot
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+	while (!thread_sync)
+	  cond_var.wait(lock);
+    }
+
+    // recreate
+    pthread_key_delete(key);
+    pthread_key_t oldkey = key;
+
+    pthread_key_create(&key, NULL);
+    assert(pthread_getspecific(key) == 0);
+
+    // this assertion holds in the current musl implementation,
+    // so we can skip having to loop over pthread_key_create's
+    // until we recover the same key
+    assert(oldkey == key);
+
+    // notify worker thread to check the slot again
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+	thread_sync = false;
+        cond_var.notify_one();
+    }
+
+    pthread_join(thread, nullptr);
+
+    return 0;
+}

--- a/test/pthread/test_pthread_key_recreation.cpp
+++ b/test/pthread/test_pthread_key_recreation.cpp
@@ -85,7 +85,7 @@ int main() {
     // notify worker thread to check the slot again
     {
         assert(pthread_mutex_lock(&mutex) == 0);
-	    thread_sync = false;
+        thread_sync = false;
         assert(pthread_cond_signal(&cond_var) == 0);
         assert(pthread_mutex_unlock(&mutex) == 0);
     }

--- a/test/reference_struct_info.json
+++ b/test/reference_struct_info.json
@@ -1346,10 +1346,10 @@
             "p_proto": 8
         },
         "pthread": {
-            "__size__": 112,
-            "profilerBlock": 104,
-            "stack": 44,
-            "stack_size": 48
+            "__size__": 120,
+            "profilerBlock": 112,
+            "stack": 52,
+            "stack_size": 56
         },
         "pthread_attr_t": {
             "__size__": 44,

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5434,6 +5434,10 @@ Module["preRun"].push(function () {
                      test_file('pthread/test_pthread_unhandledrejection.post.js')],
                expected='exception:Uncaught [object ErrorEvent] / undefined')
 
+  @requires_threads
+  def test_pthread_key_recreation(self):
+    self.btest_exit(test_file('pthread/test_pthread_key_recreation.cpp'), args=['-sUSE_PTHREADS', '-sPTHREAD_POOL_SIZE'])
+
   def test_full_js_library_strict(self):
     self.btest_exit(test_file('hello_world.c'), args=['-sINCLUDE_FULL_LIBRARY', '-sSTRICT_JS'])
 

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5436,7 +5436,7 @@ Module["preRun"].push(function () {
 
   @requires_threads
   def test_pthread_key_recreation(self):
-    self.btest_exit(test_file('pthread/test_pthread_key_recreation.cpp'), args=['-sUSE_PTHREADS', '-sPTHREAD_POOL_SIZE'])
+    self.btest_exit(test_file('pthread/test_pthread_key_recreation.cpp'), args=['-sUSE_PTHREADS', '-sPTHREAD_POOL_SIZE=1'])
 
   def test_full_js_library_strict(self):
     self.btest_exit(test_file('hello_world.c'), args=['-sINCLUDE_FULL_LIBRARY', '-sSTRICT_JS'])


### PR DESCRIPTION
Restored the musl circular thread list, and added a test case.

One notably adjustment needed for emscripten is, in pthread_create, to add the new thread to the list *prior* to handing off to a worker using __pthread_create_js, as there is a race condition otherwise since the new thread can potentially run and exit via _emscripten_thread_exit, before the call returns to pthread_create.

On top of that, there is one code path specific to emscripten (and not musl) - when workers are returned to the pool (returnWorkerToPool), _emscripten_thread_free_data is called to free the associated __pthread structure. It's possible for this to happen without the _emscripten_thread_exit cleanup code (removal from the list) having been called. So I also modified _emscripten_thread_free_data to perform the necessary adjustments to the thread list pointers.

Fixes: #8740