### PR TITLE
Add option to force rebuilding libraries

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -956,7 +956,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
   def get_library(self, name, generated_libs, configure=['sh', './configure'],  # noqa
                   configure_args=None, make=None, make_args=None,
-                  env_init=None, cache_name_extra='', native=False):
+                  env_init=None, cache_name_extra='', native=False,
+                  force_rebuild=False):
     if make is None:
       make = ['make']
     if env_init is None:
@@ -980,7 +981,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     valid_chars = "_%s%s" % (string.ascii_letters, string.digits)
     cache_name = ''.join([(c if c in valid_chars else '_') for c in cache_name])
 
-    if self.library_cache.get(cache_name):
+    if not force_rebuild and self.library_cache.get(cache_name):
       print('<load %s from cache> ' % cache_name, file=sys.stderr)
       generated_libs = []
       for basename, contents in self.library_cache[cache_name]:

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -969,7 +969,9 @@ class benchmark(common.RunnerCore):
     shutil.copyfile(test_file(f'third_party/lua/{benchmark}.lua'), benchmark + '.lua')
 
     def lib_builder(name, native, env_init):
-      ret = self.get_library(os.path.join('third_party', 'lua_native' if native else 'lua'), [os.path.join('src', 'lua.o'), os.path.join('src', 'liblua.a')], make=['make', 'generic'], configure=None, native=native, cache_name_extra=name, env_init=env_init)
+      # We force recomputation for the native benchmarker because this benchmark
+      # uses native_exec=True, so we need to copy the native executable
+      ret = self.get_library(os.path.join('third_party', 'lua_native' if native else 'lua'), [os.path.join('src', 'lua.o'), os.path.join('src', 'liblua.a')], make=['make', 'generic'], configure=None, native=native, cache_name_extra=name, env_init=env_init, force_rebuild=native)
       if native:
         return ret
       shutil.copyfile(ret[0], ret[0] + '.bc')


### PR DESCRIPTION
Most big benchmarks (the ones with `_zzz_`) in `test_benchmark.py` has a separate directory in `test/third_party`, and a test source file with `main` that we build as an executable.
https://github.com/emscripten-core/emscripten/blob/857bdf9cb9ae37812dbdeb107f2e65b508d8b484/test/test_benchmark.py#L142-L148

[`RunnerCore::get_library`](https://github.com/emscripten-core/emscripten/blob/857bdf9cb9ae37812dbdeb107f2e65b508d8b484/test/common.py#L957-L1003) copies `test/third_party/[LIBRARY]` into `building` dir within a temp dir, builds the library if it's not built and cached already, and returns the paths of the library files. https://github.com/emscripten-core/emscripten/blob/857bdf9cb9ae37812dbdeb107f2e65b508d8b484/test/common.py#L983-L990


But when [`native_exec`](https://github.com/emscripten-core/emscripten/blob/857bdf9cb9ae37812dbdeb107f2e65b508d8b484/test/test_benchmark.py#L134) parameter of `Benchmarker::build` is true, In [`NativeBenchmarker`](https://github.com/emscripten-core/emscripten/blob/857bdf9cb9ae37812dbdeb107f2e65b508d8b484/test/test_benchmark.py#L127-L174), we don't have a separate test file that becomes an executable. After building a library, the library directory contains a native executable ready to be used, so we just copy them to `LIBRARY.native` file.                                                   
https://github.com/emscripten-core/emscripten/blob/857bdf9cb9ae37812dbdeb107f2e65b508d8b484/test/test_benchmark.py#L151-L153 

Only `lua` (which is used by `test_zzz_lua_binarytrees` and `test_zzz_lua_scimark`) is using this `native_exec` option: https://github.com/emscripten-core/emscripten/blob/857bdf9cb9ae37812dbdeb107f2e65b508d8b484/test/test_benchmark.py#L982

This makes running more than one `lua` benchmarks in series error out. For example, suppose you run `NativeBenchmarker` on `test_zzz_lua_binarytrees` and then `test_zzz_lua_scimark`, by running
```console
./test/runner benchmark.test_zzz_lua_binarytrees benchmark.test_zzz_lua_scimark
```
When you run `lua_binarytrees`, you run `lua`s `lib_builder`, which calls `get_library`, which copies `test/third_party/lua` into `building` within the temp directory and builds the native executable. And then when you run `lua_scimark`, it doesn't rebuild `lua` library but just retrieves the cached build. But cached builds are for generated libraries and not executables, which `native_exec` uses.

We can possibly rewrite `get_library` so that it can nicely handle both libraries and native executables, but currently this becomes a problem only when we run two `lua_*` benchmarks with `NativeBenchmarker`, so doing something big seems like overkill.

This adds `force_rebuild` option, which defaults to false, to `RunnerCore::get_library`, which is set only when `native_exec` is true in `test_benchmark.py` (Currently only `lua`).

To reproduce the bug this PR fixes, currently you should actually run one more benchmarks whose name comes before `lua` in alphabetical order, as in:
```console
./test/runner benchmark.test_zzz_coremark benchmark.test_zzz_lua_binarytrees benchmark.test_zzz_lua_scimark
```
Because this line alters the environment when `build_library` (which is called by `get_library`) is first run:
https://github.com/emscripten-core/emscripten/blob/857bdf9cb9ae37812dbdeb107f2e65b508d8b484/test/common.py#L1863 So if we run only the two `lua_*` benchmarks, the second run will have a different set of environment variables, which makes the [hashes](https://github.com/emscripten-core/emscripten/blob/857bdf9cb9ae37812dbdeb107f2e65b508d8b484/test/common.py#L977) different, making `get_library` rebuild, not load, the library.