### PR TITLE
Fix `Module.print` always overridden in `PROXY_TO_WORKER`

### DIFF
--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -16,13 +16,13 @@ if (typeof Module == 'undefined') {
   };
 }
 
-if (!Object.hasOwnProperty(Module, 'print')) {
+if (!Module.hasOwnProperty('print')) {
   Module['print'] = function(x) {
     console.log(x);
   };
 }
 
-if (!Object.hasOwnProperty(Module, 'printErr')) {
+if (!Module.hasOwnProperty('printErr')) {
   Module['printErr'] = function(x) {
     console.error(x);
   };


### PR DESCRIPTION
With #16478 default values were introduced for `print` and `printErr` for `PROXY_TO_WORKER`, but a typo means that the values are _always_ overridden with the defaults.