### PR TITLE
Disable `-Wcast-function-type-strict` in HarfBuzz port

### DIFF
--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -130,6 +130,9 @@ def get(ports, settings, shared):
     else:
       cflags.append('-DHB_NO_MT')
 
+    # https://github.com/harfbuzz/harfbuzz/commit/60c6b7786d9f4651ae2803bfc4ff4435b38a5bc6
+    cflags.append('-Wno-error=cast-function-type-strict')
+
     ports.build_port(os.path.join(source_path, 'src'), final, 'harfbuzz', flags=cflags, srcs=srcs)
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -132,6 +132,8 @@ def get(ports, settings, shared):
 
     # https://github.com/harfbuzz/harfbuzz/commit/60c6b7786d9f4651ae2803bfc4ff4435b38a5bc6
     cflags.append('-Wno-error=cast-function-type-strict')
+    # TODO(kleisauke): Remove when LLVM rolls in
+    cflags.append('-Wno-unknown-warning-option')
 
     ports.build_port(os.path.join(source_path, 'src'), final, 'harfbuzz', flags=cflags, srcs=srcs)
 

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -131,7 +131,7 @@ def get(ports, settings, shared):
       cflags.append('-DHB_NO_MT')
 
     # https://github.com/harfbuzz/harfbuzz/commit/60c6b7786d9f4651ae2803bfc4ff4435b38a5bc6
-    cflags.append('-Wno-error=cast-function-type-strict')
+    cflags.append('-Wno-cast-function-type-strict')
     # TODO(kleisauke): Remove when LLVM rolls in
     cflags.append('-Wno-unknown-warning-option')
 


### PR DESCRIPTION
Corresponds to the fix introduced in commit https://github.com/harfbuzz/harfbuzz/commit/60c6b7786d9f4651ae2803bfc4ff4435b38a5bc6. This should fix the LLVM autoroller.

Context: https://github.com/emscripten-core/emscripten/issues/16126#issuecomment-1295914949.