### PR TITLE
Fix setting of tm_yday in localtime and mktime for issue #17635

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -448,6 +448,7 @@ mergeInto(LibraryManager.library, {
   // time.h
   // ==========================================================================
 
+  _mktime_js__deps: ['_yday_from_date'],
   _mktime_js__sig: 'ip',
   _mktime_js: function(tmPtr) {
     var date = new Date({{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_year, 'i32') }}} + 1900,
@@ -478,7 +479,7 @@ mergeInto(LibraryManager.library, {
     }
 
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_wday, 'date.getDay()', 'i32') }}};
-    var yday = ((date.getTime() - start.getTime()) / (1000 * 60 * 60 * 24))|0;
+    var yday = __yday_from_date(date);
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_yday, 'yday', 'i32') }}};
     // To match expected behavior, update fields from date
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_sec, 'date.getSeconds()', 'i32') }}};
@@ -526,7 +527,7 @@ mergeInto(LibraryManager.library, {
     return (date.getTime() / 1000)|0;
   },
 
-  _localtime_js__deps: ['$readI53FromI64'],
+  _localtime_js__deps: ['$readI53FromI64', '_yday_from_date'],
   _localtime_js__sig: 'ipp',
   _localtime_js: function(time, tmPtr) {
     var date = new Date({{{ makeGetValue('time', 0, 'i53') }}}*1000);
@@ -538,12 +539,12 @@ mergeInto(LibraryManager.library, {
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_year, 'date.getFullYear()-1900', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_wday, 'date.getDay()', 'i32') }}};
 
-    var start = new Date(date.getFullYear(), 0, 1);
-    var yday = ((date.getTime() - start.getTime()) / (1000 * 60 * 60 * 24))|0;
+    var yday = __yday_from_date(date);
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_yday, 'yday', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_gmtoff, '-(date.getTimezoneOffset() * 60)', 'i32') }}};
 
     // Attention: DST is in December in South, and some regions don't have DST at all.
+    var start = new Date(date.getFullYear(), 0, 1);
     var summerOffset = new Date(date.getFullYear(), 6, 1).getTimezoneOffset();
     var winterOffset = start.getTimezoneOffset();
     var dst = (summerOffset != winterOffset && date.getTimezoneOffset() == Math.min(winterOffset, summerOffset))|0;
@@ -635,9 +636,20 @@ mergeInto(LibraryManager.library, {
 
   _MONTH_DAYS_REGULAR: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
   _MONTH_DAYS_LEAP: [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
-
+  _MONTH_DAYS_REGULAR_CUMULATIVE: [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
+  _MONTH_DAYS_LEAP_CUMULATIVE: [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335],
+    
   _isLeapYear: function(year) {
       return year%4 === 0 && (year%100 !== 0 || year%400 === 0);
+  },
+
+  _yday_from_date__deps: ['_isLeapYear', '_MONTH_DAYS_LEAP_CUMULATIVE', '_MONTH_DAYS_REGULAR_CUMULATIVE'],
+  _yday_from_date: function(date) {
+    var isLeapYear = __isLeapYear(date.getFullYear());
+    var monthDaysCumulative = (isLeapYear ? __MONTH_DAYS_LEAP_CUMULATIVE : __MONTH_DAYS_REGULAR_CUMULATIVE);
+    var yday = monthDaysCumulative[date.getMonth()] + date.getDate() - 1; // -1 since it's days since Jan 1
+
+    return yday;
   },
 
   _arraySum: function(array, index) {

--- a/src/library.js
+++ b/src/library.js
@@ -638,7 +638,7 @@ mergeInto(LibraryManager.library, {
   _MONTH_DAYS_LEAP: [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
   _MONTH_DAYS_REGULAR_CUMULATIVE: [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
   _MONTH_DAYS_LEAP_CUMULATIVE: [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335],
-    
+
   _isLeapYear: function(year) {
       return year%4 === 0 && (year%100 !== 0 || year%400 === 0);
   },

--- a/src/library.js
+++ b/src/library.js
@@ -479,7 +479,7 @@ mergeInto(LibraryManager.library, {
     }
 
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_wday, 'date.getDay()', 'i32') }}};
-    var yday = __yday_from_date(date);
+    var yday = __yday_from_date(date)|0;
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_yday, 'yday', 'i32') }}};
     // To match expected behavior, update fields from date
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_sec, 'date.getSeconds()', 'i32') }}};
@@ -539,7 +539,7 @@ mergeInto(LibraryManager.library, {
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_year, 'date.getFullYear()-1900', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_wday, 'date.getDay()', 'i32') }}};
 
-    var yday = __yday_from_date(date);
+    var yday = __yday_from_date(date)|0;
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_yday, 'yday', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_gmtoff, '-(date.getTimezoneOffset() * 60)', 'i32') }}};
 

--- a/src/library.js
+++ b/src/library.js
@@ -612,7 +612,7 @@ mergeInto(LibraryManager.library, {
     // Coordinated Universal Time (UTC) and local standard time."), the same
     // as returned by stdTimezoneOffset.
     // See http://pubs.opengroup.org/onlinepubs/009695399/functions/tzset.html
-    {{{ makeSetValue('timezone', '0', 'stdTimezoneOffset * 60', 'i32') }}};
+    {{{ makeSetValue('timezone', '0', 'stdTimezoneOffset * 60', POINTER_TYPE) }}};
 
     {{{ makeSetValue('daylight', '0', 'Number(winterOffset != summerOffset)', 'i32') }}};
 

--- a/test/core/test_time.cpp
+++ b/test/core/test_time.cpp
@@ -257,13 +257,13 @@ int main() {
     struct tm prev_tm;
     time_t test = xmas2002;
     localtime_r(&test, &prev_tm);
-    
+
     for (int i = 1; i < 2*24*366; ++i) {
       struct tm this_tm;
       test = xmas2002 + 30*60*i;
       localtime_r(&test, &this_tm);
 
-      if(this_tm.tm_year != prev_tm.tm_year) {
+      if (this_tm.tm_year != prev_tm.tm_year) {
         assert(this_tm.tm_yday == 0 && prev_tm.tm_yday == 364); //flipped over to 2003, 2002 was non-leap
       } else if(this_tm.tm_mday != prev_tm.tm_mday) {
         assert(this_tm.tm_yday == prev_tm.tm_yday + 1);

--- a/test/core/test_time.cpp
+++ b/test/core/test_time.cpp
@@ -250,6 +250,29 @@ int main() {
   check_gmtime_localtime(253402300799); // end of year 9999
   check_gmtime_localtime(-62135596800); // beginning of year 1
 
+  // check that localtime sets tm_yday correctly whenever the day rolls over (issue #17635)
+  // prior to being fixed, tm_yday did not increment correctly at epoch time 1049061599 (2003-03-31 00:00:00) in CET time
+  // assumes other tests already verified other aspects of localtime
+  {
+    struct tm prev_tm;
+    time_t test = xmas2002;
+    localtime_r(&test, &prev_tm);
+    
+    for (int i = 1; i < 2*24*366; ++i) {
+      struct tm this_tm;
+      test = xmas2002 + 30*60*i;
+      localtime_r(&test, &this_tm);
+
+      if(this_tm.tm_year != prev_tm.tm_year) {
+        assert(this_tm.tm_yday == 0 && prev_tm.tm_yday == 364); //flipped over to 2003, 2002 was non-leap
+      } else if(this_tm.tm_mday != prev_tm.tm_mday) {
+        assert(this_tm.tm_yday == prev_tm.tm_yday + 1);
+      }
+
+      prev_tm = this_tm;
+    }
+  }
+
   puts("success");
   return 0;
 }

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2858,7 +2858,7 @@ The current type of b is: 9
 
   def test_time(self):
     self.do_core_test('test_time.cpp')
-    for tz in ['EST+05EDT', 'UTC+0']:
+    for tz in ['EST+05EDT', 'UTC+0', 'CET']:
       print('extra tz test:', tz)
       with env_modify({'TZ': tz}):
         # Run the test with different time zone settings if


### PR DESCRIPTION
Changed to use a simple calculation where we look up a table of cumulative sum of days up to the start of that month, and then add the offset of days into the month on top of that.

Added a new sub test to the test_time test case.

Also verified manually: used a program that steps thru every second in a one year period, and compared the yday value of a gcc build vs an emscripten build.

While working on this, found a bug in tzset_impl: timezone is a long, but it's being set as int by makeSetValue (i32). This causes a break on the wasm64 test. So I also put in a fix for that - but I have a further comment on that line.

Fixes: #17635 