### PR TITLE
Disable warning pragmas in HarfBuzz port

### DIFF
--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -130,10 +130,15 @@ def get(ports, settings, shared):
     else:
       cflags.append('-DHB_NO_MT')
 
-    # https://github.com/harfbuzz/harfbuzz/commit/60c6b7786d9f4651ae2803bfc4ff4435b38a5bc6
-    cflags.append('-Wno-cast-function-type-strict')
-    # TODO(kleisauke): Remove when LLVM rolls in
-    cflags.append('-Wno-unknown-warning-option')
+    # Letting HarfBuzz enable warnings through pragmas can block compiler
+    # upgrades in situations where say a ToT compiler build adds a new
+    # stricter warning under -Wfoowarning-subgroup. HarfBuzz pragma-enables
+    # -Wfoowarning which default-enables -Wfoowarning-subgroup implicitly but
+    # HarfBuzz upstream is not yet clean of warnings produced for
+    # -Wfoowarning-subgroup. Hence disabling pragma warning control here.
+    # See also: https://github.com/emscripten-core/emscripten/pull/18119
+    cflags.append('-DHB_NO_PRAGMA_GCC_DIAGNOSTIC_ERROR')
+    cflags.append('-DHB_NO_PRAGMA_GCC_DIAGNOSTIC_WARNING')
 
     ports.build_port(os.path.join(source_path, 'src'), final, 'harfbuzz', flags=cflags, srcs=srcs)
 


### PR DESCRIPTION
Disabling `-Wcast-function-type-strict` didn't work since Harfbuzz enables `-Wcast-function-type` (which has `-Wcast-function-type-strict` as a subgroup) via pragmas. Ensure we define both `HB_NO_PRAGMA_GCC_DIAGNOSTIC_ERROR` and `HB_NO_PRAGMA_GCC_DIAGNOSTIC_WARNING` to disable this behavior.

This corresponds to commit chromium/chromium@3699066 in Chromium.