### PR TITLE
glMapBufferRange:  Support INVALIDATE_RANGE access bit.

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -4021,17 +4021,17 @@ var LibraryGL = {
   glMapBufferRange__sig: 'iiiii',
   glMapBufferRange__deps: ['$emscriptenWebGLGetBufferBinding', '$emscriptenWebGLValidateMapBufferTarget'],
   glMapBufferRange: function(target, offset, length, access) {
-    if ((access & (0x1 | 0x20)) != 0) {
+    if ((access & (0x1/*GL_MAP_READ_BIT*/ | 0x20/*GL_MAP_UNSYNCHRONIZED_BIT*/)) != 0) {
       err("glMapBufferRange access does not support MAP_READ or MAP_UNSYNCHRONIZED");
       return 0;
     }
 
-    if ((access & 0x2) == 0) {
+    if ((access & 0x2/*GL_MAP_WRITE_BIT*/) == 0) {
       err("glMapBufferRange access must include MAP_WRITE");
       return 0;
     }
 
-    if ((access & (0x4 | 0x8)) == 0) {
+    if ((access & (0x4/*GL_MAP_INVALIDATE_BUFFER_BIT*/ | 0x8/*GL_MAP_INVALIDATE_RANGE_BIT*/)) == 0) {
       err("glMapBufferRange access must include INVALIDATE_BUFFER or INVALIDATE_RANGE");
       return 0;
     }

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -4021,8 +4021,18 @@ var LibraryGL = {
   glMapBufferRange__sig: 'iiiii',
   glMapBufferRange__deps: ['$emscriptenWebGLGetBufferBinding', '$emscriptenWebGLValidateMapBufferTarget'],
   glMapBufferRange: function(target, offset, length, access) {
-    if (access != 0x1A && access != 0xA) {
-      err("glMapBufferRange is only supported when access is MAP_WRITE|INVALIDATE_BUFFER");
+    if ((access & (0x1 | 0x20)) != 0) {
+      err("glMapBufferRange access does not support MAP_READ or MAP_UNSYNCHRONIZED");
+      return 0;
+    }
+
+    if ((access & 0x2) == 0) {
+      err("glMapBufferRange access must include MAP_WRITE");
+      return 0;
+    }
+
+    if ((access & (0x4 | 0x8)) == 0) {
+      err("glMapBufferRange access must include INVALIDATE_BUFFER or INVALIDATE_RANGE");
       return 0;
     }
 


### PR DESCRIPTION
Since glMapBufferRange allocates a buffer for the user-specified range and then a later unmap operation uses bufferSubData() to update just that range, the behavior is already consistent with INVALIDATE_RANGE in addition to INVALIDATE_BUFFER.  Therefore, this commit adds support for INVALIDATE_RANGE by changing the access mode error logic.  This commit also adds INVALIDATE_RANGE coverage to test_sdl_gl_mapbuffers.c and adds both positive and negative cases.