### PR TITLE
Fix false positive overflow detection in sbrk in wasm64 mode

### DIFF
--- a/system/lib/sbrk.c
+++ b/system/lib/sbrk.c
@@ -69,9 +69,9 @@ void *sbrk(intptr_t increment_) {
     uintptr_t old_brk = *sbrk_ptr;
 #endif
     uintptr_t new_brk = old_brk + increment;
-    // Check for a 32-bit overflow, which would indicate that we are trying to
-    // allocate over 4GB, which is never possible in wasm32.
-    if (increment > 0 && (uint32_t)new_brk <= (uint32_t)old_brk) {
+    // Check for an overflow, which would indicate that we are trying to
+    // allocate over maximum addressable memory.
+    if (increment > 0 && new_brk <= old_brk) {
       goto Error;
     }
     old_size = emscripten_get_heap_size();


### PR DESCRIPTION
In some cases  `sbrk()` would fail due to a false positive overflow in wasm64.
Example:
```C
// wasm64
uintptr_t old_brk = (uintptr_t)0xFFFF0000; // < 2^32
uintptr_t new_brk = old_brk + 0xFFFF + 1; // > 2^32
if((uint32_t)new_brk <= (uint32_t)old_brk) {
    // Condition IS met even if new_brk is valid
}
```