### PR TITLE
Add support for -Og flag

### DIFF
--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -74,6 +74,10 @@ Options that are modified or new in *emcc* are listed below:
 
      This is a good setting for a release build.
 
+"-Og"
+   [compile+link] Like "-O1". In future versions, this option might
+   disable different optimizations in order to improve debuggability.
+
 "-Os"
    [compile+link] Like "-O3", but focuses more on code size (and may
    make tradeoffs with speed). This can affect both wasm and

--- a/emcc.py
+++ b/emcc.py
@@ -3137,16 +3137,20 @@ def parse_args(newargs):
 
     if arg.startswith('-O'):
       # Let -O default to -O2, which is what gcc does.
-      options.requested_level = strip_prefix(arg, '-O') or '2'
-      if options.requested_level == 's':
-        options.requested_level = 2
+      requested_level = strip_prefix(arg, '-O') or '2'
+      if requested_level == 's':
+        requested_level = 2
         settings.SHRINK_LEVEL = 1
-      elif options.requested_level == 'z':
-        options.requested_level = 2
+      elif requested_level == 'z':
+        requested_level = 2
         settings.SHRINK_LEVEL = 2
+      elif requested_level == 'g':
+        requested_level = 1
+        settings.SHRINK_LEVEL = 0
+        settings.DEBUG_LEVEL = max(settings.DEBUG_LEVEL, 1)
       else:
         settings.SHRINK_LEVEL = 0
-      settings.OPT_LEVEL = validate_arg_level(options.requested_level, 3, 'invalid optimization level: ' + arg, clamp=True)
+      settings.OPT_LEVEL = validate_arg_level(requested_level, 3, 'invalid optimization level: ' + arg, clamp=True)
     elif check_arg('--js-opts'):
       logger.warning('--js-opts ignored when using llvm backend')
       consume_arg()

--- a/site/source/docs/optimizing/Optimizing-Code.rst
+++ b/site/source/docs/optimizing/Optimizing-Code.rst
@@ -9,7 +9,7 @@ Generally you should first compile and run your code without optimizations (the 
 How to optimize code
 ====================
 
-Code is optimized by specifying :ref:`optimization flags <emcc-compiler-optimization-options>` when running :ref:`emcc <emccdoc>`. The levels include: :ref:`-O0 <emcc-O0>` (no optimization), :ref:`-O1 <emcc-O1>`, :ref:`-O2 <emcc-O2>`, :ref:`-Os <emcc-Os>`, :ref:`-Oz <emcc-Oz>`, and :ref:`-O3 <emcc-O3>`.
+Code is optimized by specifying :ref:`optimization flags <emcc-compiler-optimization-options>` when running :ref:`emcc <emccdoc>`. The levels include: :ref:`-O0 <emcc-O0>` (no optimization), :ref:`-O1 <emcc-O1>`, :ref:`-O2 <emcc-O2>`, :ref:`-Os <emcc-Os>`, :ref:`-Oz <emcc-Oz>`, :ref:`-Og <emcc-Og>`, and :ref:`-O3 <emcc-O3>`.
 
 For example, to compile with optimization level ``-O2``:
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -72,6 +72,13 @@ Options that are modified or new in *emcc* are listed below:
 
   .. note:: This is a good setting for a release build.
 
+.. _emcc-Og:
+
+``-Og``
+  [compile+link]
+  Like ``-O1``. In future versions, this option might disable different
+  optimizations in order to improve debuggability.
+
 .. _emcc-Os:
 
 ``-Os``

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3909,7 +3909,7 @@ int main() {
       self.assertContained('Test passed.', self.run_js('a.out.js'))
 
   def test_os_oz(self):
-    for opt in ['-O1', '-O2', '-Os', '-Oz', '-O3']:
+    for opt in ['-O1', '-O2', '-Os', '-Oz', '-O3', '-Og']:
       print(opt)
       proc = self.run_process([EMXX, '-v', test_file('hello_world.cpp'), opt], stderr=PIPE)
       self.assertContained(opt, proc.stderr)
@@ -3924,14 +3924,15 @@ int main() {
         ('s', ['-Os']),
         ('z', ['-Oz']),
         ('3', ['-O3']),
+        ('g', ['-Og']),
       ]:
       print(name, args)
       self.clear()
       self.run_process([EMCC, '-c', path_from_root('system/lib/dlmalloc.c')] + args)
       sizes[name] = os.path.getsize('dlmalloc.o')
     print(sizes)
-    opt_min = min(sizes['1'], sizes['2'], sizes['3'], sizes['s'], sizes['z'])
-    opt_max = max(sizes['1'], sizes['2'], sizes['3'], sizes['s'], sizes['z'])
+    opt_min = min(sizes['1'], sizes['2'], sizes['3'], sizes['s'], sizes['z'], sizes['g'])
+    opt_max = max(sizes['1'], sizes['2'], sizes['3'], sizes['s'], sizes['z'], sizes['g'])
     # 'opt builds are all fairly close'
     self.assertLess(opt_min - opt_max, opt_max * 0.1)
     # unopt build is quite larger'


### PR DESCRIPTION
Currently we treat this like `-O1` (which is what clang does) plus we set `DEBUG_LEVEL=1` which disables minification.

See https://clang.llvm.org/docs/CommandGuide/clang.html#cmdoption-o0

See #18123