### PR TITLE
Fix EMPROFILE=2 when using em++ rather than emcc

### DIFF
--- a/em++.py
+++ b/em++.py
@@ -11,7 +11,7 @@ emcc.run_via_emxx = True
 
 if __name__ == '__main__':
   try:
-    sys.exit(emcc.run(sys.argv))
+    sys.exit(emcc.main(sys.argv))
   except KeyboardInterrupt:
     emcc.logger.warning('KeyboardInterrupt')
     sys.exit(1)


### PR DESCRIPTION
We were not getting top level timing information when running via em++.

Before:

```
$ EMPROFILE=2 ./em++ test/hello_world.cpp  -c
profiler:INFO: start block "parse arguments"
profiler:INFO: block "parse arguments" took 0.000 seconds
profiler:INFO: start block "check_sanity"
profiler:INFO: block "check_sanity" took 0.050 seconds
profiler:INFO: start block "setup"
profiler:INFO: block "setup" took 0.000 seconds
profiler:INFO: start block "compile inputs"
profiler:INFO:   start block "ensure_sysroot"
profiler:INFO:   block "ensure_sysroot" took 0.000 seconds
profiler:INFO: block "compile inputs" took 0.065 seconds
```

After:

```
$ EMPROFILE=2 ./em++ test/hello_world.cpp  -c
profiler:INFO: start block "main"
profiler:INFO:   start block "parse arguments"
profiler:INFO:   block "parse arguments" took 0.000 seconds
profiler:INFO:   start block "check_sanity"
profiler:INFO:   block "check_sanity" took 0.040 seconds
profiler:INFO:   start block "setup"
profiler:INFO:   block "setup" took 0.000 seconds
profiler:INFO:   start block "compile inputs"
profiler:INFO:     start block "ensure_sysroot"
profiler:INFO:     block "ensure_sysroot" took 0.000 seconds
profiler:INFO:   block "compile inputs" took 0.069 seconds
profiler:INFO: block "main" took 0.111 seconds
```

See #18129