### PR TITLE
Make `nm` output parsing robust against symbols containing `:`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,6 +407,7 @@ jobs:
             asan.test_async_hello
             asan.test_dlfcn_basic
             asan.test_async_hello_stack_switching
+            asan.test_cubescript
             lsan.test_stdio_locking
             lsan.test_dlfcn_basic
             lsan.test_pthread_create"

--- a/tools/building.py
+++ b/tools/building.py
@@ -300,24 +300,25 @@ def parse_llvm_nm_symbols(output):
 
   for line in output.split('\n'):
     # Line format: "[archive filename:]object filename: address status name"
-    entry_pos = line.rfind(':')
+    entry_pos = line.rfind(': ')
     if entry_pos < 0:
       continue
 
-    filename_pos = line.rfind(':', 0, entry_pos)
+    filename_end = line.rfind(':', 0, entry_pos)
     # Disambiguate between
     #   C:\bar.o: T main
     # and
     #   /foo.a:bar.o: T main
     # (both of these have same number of ':'s, but in the first, the file name on disk is "C:\bar.o", in second, it is "/foo.a")
-    if filename_pos < 0 or line[filename_pos + 1] in '/\\':
-      filename_pos = entry_pos
+    if filename_end < 0 or line[filename_end + 1] in '/\\':
+      filename_end = entry_pos
 
-    filename = line[:filename_pos]
+    filename = line[:filename_end]
     if entry_pos + 13 >= len(line):
       exit_with_error('error parsing output of llvm-nm: `%s`\nIf the symbol name here contains a colon, and starts with __invoke_, then the object file was likely built with an old version of llvm (please rebuild it).' % line)
 
-    status = line[entry_pos + 11] # Skip address, which is always fixed-length 8 chars.
+    # Skip address, which is always fixed-length 8 chars (plus 2 leading chars `: ` and one trailing space)
+    status = line[entry_pos + 11]
     symbol = line[entry_pos + 13:]
 
     if filename not in symbols:


### PR DESCRIPTION
A recent llvm change introduces symbol with colons in them for the
first time: https://reviews.llvm.org/D137227