### PR TITLE
When using WASM_WORKERS: make sure sbrk ptr is aligned properly for tls space, and malloc needs to be thread safe

### DIFF
--- a/system/lib/dlmalloc.c
+++ b/system/lib/dlmalloc.c
@@ -21,6 +21,10 @@
 /* XXX Emscripten Tracing API. This defines away the code if tracing is disabled. */
 #include <emscripten/trace.h>
 
+#ifdef __EMSCRIPTEN_WASM_WORKERS__
+#define USE_LOCKS 1
+#endif
+
 /* Make malloc() and free() threadsafe by securing the memory allocations with pthread mutexes. */
 #if __EMSCRIPTEN_PTHREADS__
 #define USE_LOCKS 1

--- a/system/lib/wasm_worker/library_wasm_worker.c
+++ b/system/lib/wasm_worker/library_wasm_worker.c
@@ -4,7 +4,6 @@
 #include <emscripten/heap.h>
 #include <emscripten/stack.h>
 #include <malloc.h>
-#include <stddef.h>
 
 #ifndef __EMSCRIPTEN_WASM_WORKERS__
 #error __EMSCRIPTEN_WASM_WORKERS__ should be defined when building this file!
@@ -22,18 +21,10 @@ void __wasm_init_tls(void *memory);
 __attribute__((constructor(48)))
 static void emscripten_wasm_worker_main_thread_initialize() {
 	uintptr_t* sbrk_ptr = emscripten_get_sbrk_ptr();
-	uintptr_t sbrk_addr = *sbrk_ptr;
-
-	if(__builtin_wasm_tls_align() != 0)
-	{
-		sbrk_addr = (sbrk_addr + __builtin_wasm_tls_align() - 1) & (-__builtin_wasm_tls_align());
-	}
-	__wasm_init_tls((void*)sbrk_addr);
-
-	sbrk_addr += __builtin_wasm_tls_size();
-	sbrk_addr = (sbrk_addr + __alignof__(max_align_t) - 1) & (-__alignof__(max_align_t));
-
-	*sbrk_ptr = sbrk_addr;
+	assert((*sbrk_ptr & 15) == 0);
+	assert(__builtin_wasm_tls_align() <= 16);
+	__wasm_init_tls((void*)*sbrk_ptr);
+	*sbrk_ptr += (__builtin_wasm_tls_size() + 15) & -16;
 }
 
 emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackLowestAddress, uint32_t stackSize)

--- a/system/lib/wasm_worker/library_wasm_worker.c
+++ b/system/lib/wasm_worker/library_wasm_worker.c
@@ -20,9 +20,12 @@ void __wasm_init_tls(void *memory);
 
 __attribute__((constructor(48)))
 static void emscripten_wasm_worker_main_thread_initialize() {
+	//  __alignof__(max_align_t) should be sufficient,
+	// but using 16 to match emscripten_wasm_worker_initialize
+	const size_t NeedAlign = 16;
 	uintptr_t* sbrk_ptr = emscripten_get_sbrk_ptr();
 	__wasm_init_tls((void*)*sbrk_ptr);
-	*sbrk_ptr += __builtin_wasm_tls_size();
+	*sbrk_ptr += ((__builtin_wasm_tls_size() + (NeedAlign - 1)) & ~(NeedAlign - 1));
 }
 
 emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackLowestAddress, uint32_t stackSize)


### PR DESCRIPTION
Fixes: #18096 

Two issues:
i) alignment fault
Instrumenting SAFE_HEAP_STORE_i32_4_4 revealed that the misaligned address was a multiple of *2*, but not 4.

I compiled two versions of the reproducing code, one with and one without the emscripten_lock_t functions, and compared the two resulting wasm files (in WAT format, using wasm2wat). The version that does not using the lock_t functions, does not throw the same alignment fault.

The critical difference - the emscripten_lock_t function-using version invokes emscripten_wasm_worker_main_thread_initialize during __wasm_call_ctors. 

emscripten_wasm_worker_main_thread_initialize adjusts the sbrk_ptr by __tls_size, which is *2*. That matches the misalignment seen in SAFE_HEAP_STORE_i32_4_4 above.
 (global $__tls_size i32 (i32.const 2))
*sbrk_ptr += __builtin_wasm_tls_size();

This PR changes emscripten_wasm_worker_main_thread_initialize to adjust sbrk_ptr by a properly aligned offset. This is in line with emscripten_wasm_worker_initialize, which aligns the stack end after the same tls_size adjustment.

Would like to point out one thing - it's a bit of a surprise for me that dlmalloc is not handling a misaligned sbrk, since sbrk is not documented to return an aligned pointer. If it's the case that dlmalloc assumes an aligned sbrk, it might be worth reexamining that assumption? Or maybe it's some strange interaction with SAFE_HEAP and sanitized=undefined that causes the misalignment to manifest?

ii) segmentation fault
It looks like thread safety doesn't get turned on automatically when using WASM_WORKERS! USE_LOCKS should be defined, so that malloc is thread safe.


