### PR TITLE
Add EMCC_REPRODUCE/--reproduce

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,12 @@ See docs/process.md for more on how version tagging works.
 
 3.1.26 (in development)
 -----------------------
+- Added `--reproduce` command line flag (or equivalently `EMCC_REPRODUCE`
+  environment variable).  This options specifies the name of a tar file into
+  which emscripten will copy all of the input files along with a response file
+  that will allow the command to be replicated.  This can be useful for sharing
+  reproduction cases with others (inspired by the lld option of the same name).
+  (#18160)
 
 3.1.25 - 11/08/22
 -----------------

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -209,6 +209,12 @@ Options that are modified or new in *emcc* are listed below:
 "--tracing"
    [link] Enable the Emscripten Tracing API.
 
+"--reproduce=<file.tar>"
+   [compile+link] Write tar file containing inputs and command to
+   reproduce invocation.  When sharing this file be aware that it will
+   any object files, source files and libraries that that were passed
+   to the compiler.
+
 "--emit-symbol-map"
    [link] Save a map file between function indexes in the wasm and
    function names. By storing the names on a file on the side, you can

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -205,6 +205,12 @@ Options that are modified or new in *emcc* are listed below:
   [link]
   Enable the :ref:`Emscripten Tracing API <trace-h>`.
 
+``--reproduce=<file.tar>``
+  [compile+link]
+  Write tar file containing inputs and command to reproduce invocation.  When
+  sharing this file be aware that it will any object files, source files and
+  libraries that that were passed to the compiler.
+
 .. _emcc-emit-symbol-map:
 
 ``--emit-symbol-map``


### PR DESCRIPTION
This works just like the corresponding feature of ldd: It creates a tar archive the contains all the input files used along with a response file that makes it easy to recreate a given command.

Fixes: #18146