### PR TITLE
Fix badly placed _emscripten_thread_supports_atomics_wait() check

### DIFF
--- a/system/lib/pthread/emscripten_futex_wake.c
+++ b/system/lib/pthread/emscripten_futex_wake.c
@@ -11,8 +11,6 @@
 #include <atomic.h>
 #include <emscripten/threading.h>
 
-int _emscripten_thread_supports_atomics_wait(void);
-
 // Stores the memory address that the main thread is waiting on, if any. If
 // the main thread is waiting, we wake it up before waking up any workers.
 void* _emscripten_main_thread_futex;
@@ -32,13 +30,9 @@ int emscripten_futex_wake(volatile void *addr, int count) {
   // this scheme does not adhere to real queue-based waiting.
   int main_thread_woken = 0;
   if (a_cas_p(&_emscripten_main_thread_futex, (void*)addr, 0) == addr) {
-    // We only use __emscripten_main_thread_futex on the main browser thread,
-    // where we cannot block while we wait. Therefore we should only see it set
-    // from other threads (that should always support waiting), and not on the
-    // main thread itself. In other words, the main thread must never try to
-    // wake itself up!
-    assert(_emscripten_thread_supports_atomics_wait());
-    --count;
+    // The main browser thread must never try to wake itself up!
+    assert(!emscripten_is_main_browser_thread());
+    if (count != INT_MAX) --count;
     main_thread_woken = 1;
     if (count <= 0) {
       return 1;

--- a/system/lib/pthread/emscripten_futex_wake.c
+++ b/system/lib/pthread/emscripten_futex_wake.c
@@ -32,10 +32,13 @@ int emscripten_futex_wake(volatile void *addr, int count) {
   if (a_cas_p(&_emscripten_main_thread_futex, (void*)addr, 0) == addr) {
     // The main browser thread must never try to wake itself up!
     assert(!emscripten_is_main_browser_thread());
-    if (count != INT_MAX) --count;
-    main_thread_woken = 1;
-    if (count <= 0) {
-      return 1;
+    if (count != INT_MAX)
+    {
+      --count;
+      main_thread_woken = 1;
+      if (count <= 0) {
+        return 1;
+      }
     }
   }
 


### PR DESCRIPTION
Fix badly placed _emscripten_thread_supports_atomics_wait() check in emscripten_futex_wake(). Also in case the implementations of Atomics.notify() might be using a special optimized implementation for count==INT_MAX to wake all waiters, avoid subtracting one from INT_MAX that would notify 'INT_MAX-1' waiters. (i.e. Infinity-1==Infinity still)