### PR TITLE
Fix Wasm Workers + proxied JS functions to emit a proper runtime error message

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -374,14 +374,19 @@ function ${name}(${args}) {
     return _emscripten_proxy_to_main_thread_js(${proxiedFunctionTable.length}, ${+sync}${args ? ', ' : ''}${args});
   ${body}
 }\n`);
-          } else if (WASM_WORKERS && ASSERTIONS) {
-            // In ASSERTIONS builds add runtime checks that proxied functions are not attempted to be called in Wasm Workers
-            // (since there is no automatic proxying architecture available)
-            contentText = modifyFunction(snippet, (name, args, body) => `
-function ${name}(${args}) {
-  assert(!ENVIRONMENT_IS_WASM_WORKER, "Attempted to call proxied function '${name}' in a Wasm Worker, but in Wasm Worker enabled builds, proxied function architecture is not available!");
-  ${body}
-}\n`);
+          } else if (WASM_WORKERS) {
+            if (ASSERTIONS) {
+              // In ASSERTIONS builds add runtime checks that proxied functions are not attempted to be called in Wasm Workers
+              // (since there is no automatic proxying architecture available)
+              contentText = modifyFunction(snippet, (name, args, body) => `
+  function ${name}(${args}) {
+    assert(!ENVIRONMENT_IS_WASM_WORKER, "Attempted to call proxied function '${name}' in a Wasm Worker, but in Wasm Worker enabled builds, proxied function architecture is not available!");
+    ${body}
+  }\n`);
+            } else {
+              // In non-ASSERTIONS builds directly emit the original function.
+              contentText = snippet;
+            }
           }
           proxiedFunctionTable.push(finalName);
         } else if ((USE_ASAN || USE_LSAN || UBSAN_RUNTIME) && LibraryManager.library[ident + '__noleakcheck']) {

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5281,6 +5281,14 @@ Module["preRun"].push(function () {
   def test_wasm_worker_semaphore_try_acquire(self):
     self.btest(test_file('wasm_worker/semaphore_try_acquire.c'), expected='0', args=['-sWASM_WORKERS'])
 
+  # Tests that calling any proxied function in a Wasm Worker will abort at runtime when ASSERTIONS are enabled.
+  def test_wasm_worker_proxied_function(self):
+    error_msg = "abort:Assertion failed: Attempted to call proxied function '_proxied_js_function' in a Wasm Worker, but in Wasm Worker enabled builds, proxied function architecture is not available!"
+    # Test that program aborts in ASSERTIONS-enabled builds
+    self.btest(test_file('wasm_worker/proxied_function.c'), expected=error_msg, args=['--js-library', test_file('wasm_worker/proxied_function.js'), '-sWASM_WORKERS', '-sASSERTIONS'])
+    # Test that code does not crash in ASSERTIONS-disabled builds
+    self.btest(test_file('wasm_worker/proxied_function.c'), expected='0', args=['--js-library', test_file('wasm_worker/proxied_function.js'), '-sWASM_WORKERS', '-sASSERTIONS=0'])
+
   @no_firefox('no 4GB support yet')
   @requires_v8
   def test_zzz_zzz_4gb(self):

--- a/test/wasm_worker/proxied_function.c
+++ b/test/wasm_worker/proxied_function.c
@@ -1,0 +1,35 @@
+// This test checks whether attempting to call a proxied JS function (one with __proxy signature) will throw
+// an exception.
+
+#include <emscripten.h>
+#include <emscripten/wasm_worker.h>
+
+void proxied_js_function(void);
+
+void test_finished()
+{
+  REPORT_RESULT(0);
+}
+
+void run_in_worker()
+{
+  int threw = EM_ASM_INT({
+    try {
+      _proxied_js_function();
+    } catch(e) {
+      console.error(e);
+      return 1;
+    }
+    return 0;
+  });
+
+  if (!threw) {
+    emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, test_finished);
+  }
+}
+
+int main()
+{
+  emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(1024), run_in_worker);
+  proxied_js_function(); // Pin a dependency from C code to the JS function to avoid needing to mess with cmdline export directives
+}

--- a/test/wasm_worker/proxied_function.js
+++ b/test/wasm_worker/proxied_function.js
@@ -1,0 +1,7 @@
+mergeInto(LibraryManager.library, {
+  proxied_js_function__proxy: 'sync',
+  proxied_js_function__sig: 'v',
+  proxied_js_function: function() {
+  	console.log('In proxied_js_function');
+  }
+});


### PR DESCRIPTION
Fix Wasm Workers + proxied JS functions to emit a proper runtime error message, instead of failing at parse error at compile time, and add a test. Fixes #18162.