### PR TITLE
Change HEAP8.length assert in SAFE_HEAP_LOAD/_STORE() to instead asse…

### DIFF
--- a/src/runtime_safe_heap.js
+++ b/src/runtime_safe_heap.js
@@ -15,7 +15,7 @@ function getSafeHeapType(bytes, isFloat) {
     case 2: return 'i16';
     case 4: return isFloat ? 'float' : 'i32';
     case 8: return isFloat ? 'double' : 'i64';
-    default: assert(0);
+    default: assert(0, 'getSafeHeapType() invalid bytes=' + bytes);
   }
 }
 
@@ -44,8 +44,8 @@ function SAFE_HEAP_STORE(dest, value, bytes, isFloat) {
 #endif
     var brk = _sbrk() >>> 0;
     if (dest + bytes > brk) abort('segmentation fault, exceeded the top of the available dynamic heap when storing ' + bytes + ' bytes to address ' + dest + '. DYNAMICTOP=' + brk);
-    assert(brk >= _emscripten_stack_get_base()); // sbrk-managed memory must be above the stack
-    assert(brk <= HEAP8.length);
+    assert(brk >= _emscripten_stack_get_base(), "brk >= _emscripten_stack_get_base() (brk=" + brk + ", _emscripten_stack_get_base()=" + _emscripten_stack_get_base() + ')'); // sbrk-managed memory must be above the stack
+    assert(brk <= wasmMemory.buffer.byteLength, "brk <= wasmMemory.buffer.byteLength (brk=" + brk + ', wasmMemory.buffer.byteLength=' + wasmMemory.buffer.byteLength + ')');
   }
   setValue_safe(dest, value, getSafeHeapType(bytes, isFloat));
   return value;
@@ -72,8 +72,8 @@ function SAFE_HEAP_LOAD(dest, bytes, unsigned, isFloat) {
 #endif
     var brk = _sbrk() >>> 0;
     if (dest + bytes > brk) abort('segmentation fault, exceeded the top of the available dynamic heap when loading ' + bytes + ' bytes from address ' + dest + '. DYNAMICTOP=' + brk);
-    assert(brk >= _emscripten_stack_get_base()); // sbrk-managed memory must be above the stack
-    assert(brk <= HEAP8.length);
+    assert(brk >= _emscripten_stack_get_base(), "brk >= _emscripten_stack_get_base() (brk=" + brk + ", _emscripten_stack_get_base()=" + _emscripten_stack_get_base() + ')'); // sbrk-managed memory must be above the stack
+    assert(brk <= wasmMemory.buffer.byteLength, "brk <= wasmMemory.buffer.byteLength (brk=" + brk + ', wasmMemory.buffer.byteLength=' + wasmMemory.buffer.byteLength + ')');
   }
   var type = getSafeHeapType(bytes, isFloat);
   var ret = getValue_safe(dest, type);


### PR DESCRIPTION
Change HEAP8.length assert in SAFE_HEAP_LOAD/_STORE() to instead assert against wasmMemory.buffer.byteLength, because HEAP8.length may be out of date if another thread races to sbrk(). Related to test case in [#18096](https://github.com/emscripten-core/emscripten/issues/18096#issuecomment-1309041621).

Also improve the assert() tests to give a more meaningful assert failure.