### PR TITLE
Wasm workers sbrk race

### DIFF
--- a/test/wasm_worker/sbrk_race.cpp
+++ b/test/wasm_worker/sbrk_race.cpp
@@ -1,0 +1,28 @@
+/* Build with e.g.
+
+  em++ -O3 -g3 -sWASM_WORKERS=1 -sASSERTIONS=1 -sINITIAL_MEMORY=64KB -sALLOW_MEMORY_GROWTH=1 -sSAFE_HEAP=2
+    -sDISABLE_EXCEPTION_CATCHING=0 -sNO_FILESYSTEM -sEXIT_RUNTIME=0 -sMALLOC=emmalloc-verbose
+    -sSTACK_SIZE=16KB -sMEMORY_GROWTH_LINEAR_STEP=64KB
+    test/wasm_worker/sbrk_race.cpp -o a.html
+*/
+
+#include <emscripten/emscripten.h>
+#include <emscripten/wasm_worker.h>
+
+#include <stdlib.h>
+
+void done()
+{
+  EM_ASM(document.body.innerHTML = 'Test finished without crashing');
+}
+
+void worker() {
+  for(int i = 0; i < 60000; ++i)
+    EM_ASM({}, malloc(i)); // Allocate 60k*(60k-1)/2 == 1.8 GB of memory
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, done);
+}
+
+int main() {
+  emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(1024), &worker);
+  emscripten_set_main_loop([](){}, 0, 1);
+}


### PR DESCRIPTION
This PR is an issue report in the form of a PR.

Contained is a test case that uncovers some kind of race condition in Wasm Workers + sbrk() memory growth usage.

The test case is the same crash as the test case from https://github.com/emscripten-core/emscripten/issues/18096#issuecomment-1309041621 (thanks @debevv for providing this!), but minified to bare bones elements.

The test case initially crashes to an assert in #18170 , but fixing that assert does not fully fix the test, hence posting two different PRs, since #18170 is not enough to fix this test case.

The crash aborts on segfault in WASM_HEAP_STORE_i32_4_4() where the memory store address is above the sbrk end address. This is really peculiar since there is only one Worker that is performing any memory/malloc/sbrk operations in the whole test. Tried to use Chrome's DWARF debugger to figure out what is going wrong in the test case, but unfortunately it is not able to show the interesting information - have to dig deeper with manual prints.

What is most peculiar about the test case, is that it has a strong amount of nondeterminism in it, even though there is really no apparent source of what would cause it. The whole test case is sequential, as there is only one Worker doing linear work, and the main thread is asleep. Still, the Worker crashes always after a seemingly random number of calls to sbrk(), every time on a different count.

Sometimes it crashes immediately, other times it crashes e.g. after ~10 seconds of malloc()ing.

The crash occurs independently of using emmalloc or dlmalloc as the allocator, so probably easier to utilize emmalloc as it is smaller than dlmalloc. But the crash is not about the allocator, but something about sbrk/wasm heap size interaction.

The crash is not an OOM, the segfault occurs well before reaching the 2GB heap growth limit. Sometimes the test does pass without reaching the limit at all.

Printing stuff to console does not disrupt the crash frequency, i.e. it does not seem to be timing sensitive. Hence one can compile with `-sMALLOC=emmalloc-verbose` or `-sMALLOC=emmalloc` to observe the issue.

Likewise the crash occurs with -O1 ... -O3. But haven't observed it happening with -O0.

And finally, here is the kicker: the crash never happens if one comments out the line `emscripten_set_main_loop([](){}, 0, 1);` on line 27 of the test case, which is odd. The crash should not be about EXIT_RUNTIME at least, since removing `emscripten_set_main_loop()` but building with `-sEXIT_RUNTIME=0` and calling `emscripten_exit_with_live_runtime();` does not observe the crash - so the issue should not be that the main thread would be quitting the runtime on the Worker.

![image](https://user-images.githubusercontent.com/225351/200918117-cf39fc06-7c0e-48be-a67a-9a7baa28b992.png)

~PR #18170 would be good to land already now. I'll splice that commit off of this PR afterwards, and land this PR when the test case here is figured out to pass.~