### PR TITLE
enable thread safety for sbrk and emmalloc, when using WASM_WORKERS

### DIFF
--- a/system/lib/emmalloc.c
+++ b/system/lib/emmalloc.c
@@ -107,7 +107,7 @@ typedef struct RootRegion
   uint8_t* endPtr;
 } RootRegion;
 
-#if defined(__EMSCRIPTEN_PTHREADS__) || defined(__EMSCRIPTEN_WASM_WORKERS__)
+#ifdef __EMSCRIPTEN_SHARED_MEMORY__
 // In multithreaded builds, use a simple global spinlock strategy to acquire/release access to the memory allocator.
 static volatile uint8_t multithreadingLock = 0;
 #define MALLOC_ACQUIRE() while(__sync_lock_test_and_set(&multithreadingLock, 1)) { while(multithreadingLock) { /*nop*/ } }

--- a/system/lib/emmalloc.c
+++ b/system/lib/emmalloc.c
@@ -107,7 +107,7 @@ typedef struct RootRegion
   uint8_t* endPtr;
 } RootRegion;
 
-#if defined(__EMSCRIPTEN_PTHREADS__)
+#if defined(__EMSCRIPTEN_PTHREADS__) || defined(__EMSCRIPTEN_WASM_WORKERS__)
 // In multithreaded builds, use a simple global spinlock strategy to acquire/release access to the memory allocator.
 static volatile uint8_t multithreadingLock = 0;
 #define MALLOC_ACQUIRE() while(__sync_lock_test_and_set(&multithreadingLock, 1)) { while(multithreadingLock) { /*nop*/ } }

--- a/system/lib/sbrk.c
+++ b/system/lib/sbrk.c
@@ -6,11 +6,7 @@
  *
 */
 
-#if __EMSCRIPTEN_PTHREADS__
-#define RETRY_SBRK 1
-#endif
-
-#ifdef __EMSCRIPTEN_WASM_WORKERS__
+#ifdef __EMSCRIPTEN_SHARED_MEMORY__
 #define RETRY_SBRK 1
 #endif
 

--- a/test/code_size/hello_wasm_worker_wasm.json
+++ b/test/code_size/hello_wasm_worker_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 433,
   "a.js": 733,
   "a.js.gz": 463,
-  "a.wasm": 1805,
-  "a.wasm.gz": 1002,
+  "a.wasm": 1861,
+  "a.wasm.gz": 1031,
   "total": 3275,
   "total_gz": 1898
 }


### PR DESCRIPTION
This is a fix for the issue reported in PR #18171 .

More details in my comment on that PR:
https://github.com/emscripten-core/emscripten/pull/18171#issuecomment-1310110560