### PR TITLE
Print error output when failing to fetch emcc.bat version information.

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -100,7 +100,9 @@ set(CMAKE_CXX_COMPILER_RANLIB "${CMAKE_RANLIB}" CACHE FILEPATH "Emscripten ranli
 if (NOT EMSCRIPTEN_VERSION)
   execute_process(COMMAND "${CMAKE_C_COMPILER}" "-v" RESULT_VARIABLE _cmake_compiler_result ERROR_VARIABLE _cmake_compiler_output OUTPUT_QUIET)
   if (NOT _cmake_compiler_result EQUAL 0)
-    message(FATAL_ERROR "Failed to fetch Emscripten version information with command \"'${CMAKE_C_COMPILER}' -v\"! Process returned with error code ${_cmake_compiler_result}.")
+    message(FATAL_ERROR "Failed to fetch Emscripten version information with command \"'${CMAKE_C_COMPILER}' -v\"!\n"
+                        "Process returned with error code ${_cmake_compiler_result}.\n"
+                        "Output:\n${_cmake_compiler_output}")
   endif()
   string(REGEX MATCH "emcc \\(.*\\) ([0-9\\.]+)" _dummy_unused "${_cmake_compiler_output}")
   if (NOT CMAKE_MATCH_1)


### PR DESCRIPTION
Before:
```
CMake Error at C:/Users/nathan/Source/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake:103 (message):
  Failed to fetch Emscripten version information with command
  "'C:/Users/nathan/Source/emsdk/upstream/emscripten/emcc.bat' -v"! Process
  returned with error code 9009.
```
After:
```
CMake Error at C:/Users/nathan/Source/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake:103 (message):
  Failed to fetch Emscripten version information with command
  "'C:/Users/nathan/Source/emsdk/upstream/emscripten/emcc.bat' -v"!

  Process returned with error code 9009.

  Output:

  Python was not found; run without arguments to install from the Microsoft
  Store, or disable this shortcut from Settings > Manage App Execution
  Aliases.

```

Process 9009 doesn't really indicate what the error is, so in this PR, we print the actual error output when there is an error. This should help in diagnosising issues such as #12537 and microsoft/vcpkg/issues/24406.