### PR TITLE
Fix WebGL2 build with -sWASM_BIGINT build mode

### DIFF
--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -723,10 +723,8 @@ var LibraryWebGL2 = {
     GL.syncs[id] = null;
   },
 
-#if WASM_BIGINT
-  glClientWaitSync__sig: 'iiii',
-#else
-  glClientWaitSync__sig: 'iiiii',
+  glClientWaitSync__sig: 'iiij',
+#if !WASM_BIGINT
   glClientWaitSync__deps: ['$convertI32PairToI53'],
 #endif
   glClientWaitSync: function(sync, flags, {{{ defineI64Param('timeout') }}}) {
@@ -743,10 +741,8 @@ var LibraryWebGL2 = {
     );
   },
 
-#if WASM_BIGINT
-  glWaitSync__sig: 'viii',
-#else
-  glWaitSync__sig: 'viiii',
+  glWaitSync__sig: 'viij',
+#if !WASM_BIGINT
   glWaitSync__deps: ['$convertI32PairToI53'],
 #endif
   glWaitSync: function(sync, flags, {{{ defineI64Param('timeout') }}}) {

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -725,37 +725,40 @@ var LibraryWebGL2 = {
 
 #if WASM_BIGINT
   glClientWaitSync__sig: 'iiii',
-  glClientWaitSync: function(sync, flags, timeout) {
-    // WebGL2 vs GLES3 differences: in GLES3, the timeout parameter is a uint64, where 0xFFFFFFFFFFFFFFFFULL means GL_TIMEOUT_IGNORED.
-    // In JS, there's no 64-bit value types, so instead timeout is taken to be signed, and GL_TIMEOUT_IGNORED is given value -1.
-    // Inherently the value accepted in the timeout is lossy, and can't take in arbitrary u64 bit pattern (but most likely doesn't matter)
-    // See https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.15
-    return GLctx.clientWaitSync(GL.syncs[sync], flags, Number(timeout));
-  },
-
-  glWaitSync__sig: 'viii',
-  glWaitSync: function(sync, flags, timeout) {
-    // See WebGL2 vs GLES3 difference on GL_TIMEOUT_IGNORED above (https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.15)
-    GLctx.waitSync(GL.syncs[sync], flags, Number(timeout));
-  },
 #else
   glClientWaitSync__sig: 'iiiii',
   glClientWaitSync__deps: ['$convertI32PairToI53'],
-  glClientWaitSync: function(sync, flags, timeoutLo, timeoutHi) {
+#endif
+  glClientWaitSync: function(sync, flags, {{{ defineI64Param('timeout') }}}) {
     // WebGL2 vs GLES3 differences: in GLES3, the timeout parameter is a uint64, where 0xFFFFFFFFFFFFFFFFULL means GL_TIMEOUT_IGNORED.
     // In JS, there's no 64-bit value types, so instead timeout is taken to be signed, and GL_TIMEOUT_IGNORED is given value -1.
     // Inherently the value accepted in the timeout is lossy, and can't take in arbitrary u64 bit pattern (but most likely doesn't matter)
     // See https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.15
-    return GLctx.clientWaitSync(GL.syncs[sync], flags, convertI32PairToI53(timeoutLo, timeoutHi));
+    return GLctx.clientWaitSync(GL.syncs[sync], flags,
+#if WASM_BIGINT
+      Number(timeout)
+#else
+      convertI32PairToI53(timeout_low, timeout_high)
+#endif
+    );
   },
 
+#if WASM_BIGINT
+  glWaitSync__sig: 'viii',
+#else
   glWaitSync__sig: 'viiii',
   glWaitSync__deps: ['$convertI32PairToI53'],
-  glWaitSync: function(sync, flags, timeoutLo, timeoutHi) {
-    // See WebGL2 vs GLES3 difference on GL_TIMEOUT_IGNORED above (https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.15)
-    GLctx.waitSync(GL.syncs[sync], flags, convertI32PairToI53(timeoutLo, timeoutHi));
-  },
 #endif
+  glWaitSync: function(sync, flags, {{{ defineI64Param('timeout') }}}) {
+    // See WebGL2 vs GLES3 difference on GL_TIMEOUT_IGNORED above (https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.15)
+    GLctx.waitSync(GL.syncs[sync], flags,
+#if WASM_BIGINT
+      Number(timeout)
+#else
+      convertI32PairToI53(timeout_low, timeout_high)
+#endif
+    );
+  },
 
   glGetSynciv__sig: 'viiiii',
   glGetSynciv: function(sync, pname, bufSize, length, values) {

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -732,13 +732,8 @@ var LibraryWebGL2 = {
     // In JS, there's no 64-bit value types, so instead timeout is taken to be signed, and GL_TIMEOUT_IGNORED is given value -1.
     // Inherently the value accepted in the timeout is lossy, and can't take in arbitrary u64 bit pattern (but most likely doesn't matter)
     // See https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.15
-    return GLctx.clientWaitSync(GL.syncs[sync], flags,
-#if WASM_BIGINT
-      Number(timeout)
-#else
-      convertI32PairToI53(timeout_low, timeout_high)
-#endif
-    );
+    {{{ receiveI64ParamAsI53Unchecked('timeout'); }}}
+    return GLctx.clientWaitSync(GL.syncs[sync], flags, timeout);
   },
 
   glWaitSync__sig: 'viij',

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -742,13 +742,8 @@ var LibraryWebGL2 = {
 #endif
   glWaitSync: function(sync, flags, {{{ defineI64Param('timeout') }}}) {
     // See WebGL2 vs GLES3 difference on GL_TIMEOUT_IGNORED above (https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.15)
-    GLctx.waitSync(GL.syncs[sync], flags,
-#if WASM_BIGINT
-      Number(timeout)
-#else
-      convertI32PairToI53(timeout_low, timeout_high)
-#endif
-    );
+    {{{ receiveI64ParamAsI53Unchecked('timeout'); }}}
+    GLctx.waitSync(GL.syncs[sync], flags, timeout);
   },
 
   glGetSynciv__sig: 'viiiii',

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -996,9 +996,14 @@ function receiveI64ParamAsI53(name, onError) {
     // Just convert the bigint into a double.
     return `${name} = bigintToI53Checked(${name}); if (isNaN(${name})) return ${onError};`;
   }
-  // Covert the high/low pair to a Number, checking for
+  // Convert the high/low pair to a Number, checking for
   // overflow of the I53 range and returning onError in that case.
   return `var ${name} = convertI32PairToI53Checked(${name}_low, ${name}_high); if (isNaN(${name})) return ${onError};`;
+}
+
+function receiveI64ParamAsI53Unchecked(name) {
+  if (WASM_BIGINT) return `${name} = Number(${name});`;
+  return `var ${name} = convertI32PairToI53(${name}_low, ${name}_high);`;
 }
 
 function sendI64Argument(low, high) {


### PR DESCRIPTION
Fix WebGL2 build with -sWASM_BIGINT build mode, where glClientWaitSync() and glWaitSync() will not take a low,high i32 pair as argument