### PR TITLE
[Docs] Add doc on setjmp-longjmp support

### DIFF
--- a/site/source/docs/porting/exceptions.rst
+++ b/site/source/docs/porting/exceptions.rst
@@ -1,4 +1,4 @@
-.. Exceptions support:
+.. _exceptions:
 
 ==============================
 C++ exceptions support
@@ -74,3 +74,8 @@ throwing and catching exceptions to WebAssembly.
 As a result, it can reduce code size and performance overhead compared
 to the JavaScript-based implementation. However, it's still brand-new
 and `not yet supported by default in most engines <https://webassembly.org/roadmap/>`_.
+
+Using exceptions and setjmp-longjmp together
+############################################
+
+See :ref:`using-exceptions-and-setjmp-longjmp-together`.

--- a/site/source/docs/porting/index.rst
+++ b/site/source/docs/porting/index.rst
@@ -20,6 +20,7 @@ The topics in this section cover the main integration points that you need to co
   networking
   simd
   exceptions
+  setjmp-longjmp
   asyncify
   ../compiling/Building-Projects
 

--- a/site/source/docs/porting/setjmp-longjmp.rst
+++ b/site/source/docs/porting/setjmp-longjmp.rst
@@ -89,7 +89,8 @@ To use the WebAssembly EH and setjmp-longjmp support together:
 
 There is one specific restriction for using WebAssembly EH-based support for
 exceptions and setjmp-longjmp at the same time. You cannot call ``setjmp``
-within a C++ ``catch`` clause. For example, the following will not work:
+within a C++ ``catch`` clause. For example, the following will error out during
+compile time:
 
 .. code-block:: cpp
 

--- a/site/source/docs/porting/setjmp-longjmp.rst
+++ b/site/source/docs/porting/setjmp-longjmp.rst
@@ -7,10 +7,10 @@ C setjmp-longjmp Support
 setjmp-longjmp support is enabled by default in Emscripten. This is controlled
 by the ``SUPPORT_LONGJMP`` setting, which can take these values:
 
-- ``emscripten``: JavaScript-based support
-- ``wasm``: WebAssembly exception handling-based support
-- 0: No support
-- 1: Default support (currently ``emscripten``) (default)
+* ``emscripten``: JavaScript-based support
+* ``wasm``: WebAssembly exception handling-based support
+* 0: No support
+* 1: Default support (currently ``emscripten``) (default)
 
 Currently ``-sSUPPORT_LONGJMP=1`` is the same as
 ``-sSUPPORT_LONGJMP=emscripten``, and turned on by default. This default will

--- a/site/source/docs/porting/setjmp-longjmp.rst
+++ b/site/source/docs/porting/setjmp-longjmp.rst
@@ -5,7 +5,7 @@ C setjmp-longjmp Support
 ========================
 
 setjmp-longjmp support is enabled by default in Emscripten. This is controlled
-by ``SUPPORT_LONGJMP`` setting, which can take these values:
+by the ``SUPPORT_LONGJMP`` setting, which can take these values:
 
 - ``emscripten``: JavaScript-based support
 - ``wasm``: WebAssembly exception handling-based support
@@ -13,7 +13,7 @@ by ``SUPPORT_LONGJMP`` setting, which can take these values:
 - 1: Default support (currently ``emscripten``) (default)
 
 Currently ``-sSUPPORT_LONGJMP=1`` is the same as
-``-sSUPPORT_LONGJMP=emscripten``, and turned on by default. This will later be
+``-sSUPPORT_LONGJMP=emscripten``, and turned on by default. This default will eventually be
 the new ``wasm`` when most browsers support it.
 
 ``setjmp`` saves information about the calling environment into a buffer, and
@@ -87,7 +87,7 @@ To use the WebAssembly EH and setjmp-longjmp support together:
 
   em++ -fwasm-exceptions -sSUPPORT_LONGJMP=wasm test.cpp -o test.js
 
-There is one restriction for using WebAssembly EH-based support for exceptions
+There is one specific restriction for using WebAssembly EH-based support for exceptions
 and setjmp-longjmp at the same time. You cannot call ``setjmp`` within a C++
 ``catch`` clause. For example, the following will not work:
 

--- a/site/source/docs/porting/setjmp-longjmp.rst
+++ b/site/source/docs/porting/setjmp-longjmp.rst
@@ -1,0 +1,117 @@
+.. _setjmp-longjmp:
+
+========================
+C setjmp-longjmp Support
+========================
+
+setjmp-longjmp support is enabled by default in Emscripten. This is controlled
+by ``SUPPORT_LONGJMP`` setting, which can take these values:
+
+- ``emscripten``: JavaScript-based support
+- ``wasm``: WebAssembly exception handling-based support
+- 0: No support
+- 1: Default support (currently ``emscripten``) (default)
+
+Currently ``-sSUPPORT_LONGJMP=1`` is the same as
+``-sSUPPORT_LONGJMP=emscripten``, and turned on by default. This will later be
+the new ``wasm`` when most browsers support it.
+
+``setjmp`` saves information about the calling environment into a buffer, and
+``longjmp`` transfers the control back to the point where ``setjmp`` was called
+by using the buffer. ``longjmp``'s call stack should contain the function from
+which ``setjmp`` was called.
+
+Emscripten's support has a restriction that indirect calls to ``setjmp`` are not
+supported. For example, the below does not work:
+
+.. code-block:: c
+
+  jmp_buf env;
+  int (*fp)(jmp_buf) = setjmp;
+  fp(env); // Doesn't work
+
+
+JavaScript-based setjmp-longjmp Support
+=======================================
+
+In this mode, Emscripten emulates setjmp-longjmp using JavaScript. This option
+is set by adding ``-sSUPPORT_LONGJMP=emscripten`` to the command line, but this
+is currently enabled by default.
+
+Note that this option can have relatively high overhead in terms of code size,
+but it will work on all JavaScript engines with WebAssembly support, even if
+they do not yet support the `new WebAssembly exception handling proposal
+<https://github.com/WebAssembly/exception-handling/blob/master/proposals/exception-handling/Exceptions.md>`_.
+
+
+WebAssembly Exception Handling-based setjmp-longjmp Support
+===========================================================
+
+Alternatively, you can opt-in to the new support using the `WebAssembly
+exception handling
+<https://github.com/WebAssembly/exception-handling/blob/master/proposals/exception-handling/Exceptions.md>`_
+proposal. To enable it, pass ``-sSUPPORT_LONGJMP=wasm`` at both compile time and
+link time.
+
+This option leverages a new feature that brings built-in instructions for
+throwing and catching exceptions to WebAssembly. As a result, it can reduce code
+size and performance overhead compared to the JavaScript-based implementation.
+This option is currently supported in several major web browsers, but `may not
+be supported in all WebAssembly engines yet
+<https://webassembly.org/roadmap/>`_.
+
+
+.. _using-exceptions-and-setjmp-longjmp-together:
+
+Using Exceptions and setjmp-longjmp Together
+============================================
+
+We also have two kinds of :ref:`exception handling support <exceptions>`:
+JavaScript-based support and the new WebAssembly EH-based support. Our
+setjmp-longjmp support use the same mechanisms. Because of that, you should use
+the same kind of EH and setjmp-longjmp support when using exceptions and
+setjmp-longjmp together.
+
+For example, to use the JavaScript-based EH and setjmp-longjmp support together:
+
+.. code-block:: bash
+
+  em++ -fexceptions test.cpp -o test.js
+
+``-sSUPPORT_LONGJMP=1``, which defaults to ``emscripten``, is enabled by
+default, so you don't need to pass it explicitly.
+
+To use the WebAssembly EH and setjmp-longjmp support together:
+
+.. code-block:: bash
+
+  em++ -fwasm-exceptions -sSUPPORT_LONGJMP=wasm test.cpp -o test.js
+
+There is one restriction for using WebAssembly EH-based support for exceptions
+and setjmp-longjmp at the same time. You cannot call ``setjmp`` within a C++
+``catch`` clause. For example, the following will not work:
+
+.. code-block:: cpp
+
+  try {
+    ...
+  catch (int n) {
+    setjmp(buf); // Doesn't work
+  }
+
+Calling ``setjmp`` within a ``try`` clause is fine. Calling another user
+function that calls ``setjmp`` within a ``catch`` clause is also fine.
+
+.. code-block:: cpp
+
+  try {
+    setjmp(buf); // Works
+  catch (int n) {
+    ...
+  }
+
+  try {
+    ...
+  } catch (int n) {
+    function_that_calls_setjmp(); // Works
+  }

--- a/site/source/docs/porting/setjmp-longjmp.rst
+++ b/site/source/docs/porting/setjmp-longjmp.rst
@@ -13,8 +13,8 @@ by the ``SUPPORT_LONGJMP`` setting, which can take these values:
 - 1: Default support (currently ``emscripten``) (default)
 
 Currently ``-sSUPPORT_LONGJMP=1`` is the same as
-``-sSUPPORT_LONGJMP=emscripten``, and turned on by default. This default will eventually be
-the new ``wasm`` when most browsers support it.
+``-sSUPPORT_LONGJMP=emscripten``, and turned on by default. This default will
+eventually be the new ``wasm`` when most browsers support it.
 
 ``setjmp`` saves information about the calling environment into a buffer, and
 ``longjmp`` transfers the control back to the point where ``setjmp`` was called
@@ -87,9 +87,9 @@ To use the WebAssembly EH and setjmp-longjmp support together:
 
   em++ -fwasm-exceptions -sSUPPORT_LONGJMP=wasm test.cpp -o test.js
 
-There is one specific restriction for using WebAssembly EH-based support for exceptions
-and setjmp-longjmp at the same time. You cannot call ``setjmp`` within a C++
-``catch`` clause. For example, the following will not work:
+There is one specific restriction for using WebAssembly EH-based support for
+exceptions and setjmp-longjmp at the same time. You cannot call ``setjmp``
+within a C++ ``catch`` clause. For example, the following will not work:
 
 .. code-block:: cpp
 


### PR DESCRIPTION
This adds a doc on setjmp-longjmp support. This also describes how to use exceptions and setjmp-longjmp together and restrictions that apply.

While we have been allowing Wasm EH + Emscripten SjLj combination as an interim solution while Wasm SjLj support was not implemented yet, this only documents Emscripten EH + Emscripten SjLj and Wasm EH + Wasm SjLj combinations, to reduce confusion. (Emscripten EH is what we call "JavaScript-based support" in the docs) Wasm EH + Emscripten SjLj has a lot more restrictions, including you cannot even use `setjmp` in the same function that uses `try`-`catch` or stack allocated objects that have destructors, and we don't intend to maintain support for that combination anyway.