### PR TITLE
Improve error locations in Workers on Node.js

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -35,7 +35,7 @@ if (ENVIRONMENT_IS_NODE) {
     },
     Worker: nodeWorkerThreads.Worker,
     importScripts: function(f) {
-      (0, eval)(fs.readFileSync(f, 'utf8'));
+      (0, eval)(fs.readFileSync(f, 'utf8') + '//# sourceURL=' + f);
     },
     postMessage: function(msg) {
       parentPort.postMessage(msg);


### PR DESCRIPTION
This uses the `//# sourceURL=...` annotation from the source map spec that is natively supported by V8/Node. It allows to associate dynamically evaluated code with a given filename / URL.

Example before:

```
calling join
thread_start
Aborted(native code called abort())
worker.js onmessage() captured an uncaught exception: RuntimeError: Aborted(native code called abort())
RuntimeError: Aborted(native code called abort())
    at abort (eval at importScripts (/tmp/emscripten_test/test_pthread_abort_interrupt.worker.js:37:16), <anonymous>:1089:11)
    at _abort (eval at importScripts (/tmp/emscripten_test/test_pthread_abort_interrupt.worker.js:37:16), <anonymous>:1969:7)
    at <anonymous>:wasm-function[21]:0x832
    at Object.invokeEntryPoint (eval at importScripts (/tmp/emscripten_test/test_pthread_abort_interrupt.worker.js:37:16), <anonymous>:1796:42)
    at self.onmessage (/tmp/emscripten_test/test_pthread_abort_interrupt.worker.js:164:35)
    at MessagePort.<anonymous> (/tmp/emscripten_test/test_pthread_abort_interrupt.worker.js:24:38)
    at MessagePort.[nodejs.internal.kHybridDispatch] (internal/event_target.js:399:24)
    at MessagePort.exports.emitMessage (internal/per_context/messageport.js:18:26)
```

After:

```
calling join
thread_start
Aborted(native code called abort())
worker.js onmessage() captured an uncaught exception: RuntimeError: Aborted(native code called abort())
RuntimeError: Aborted(native code called abort())
    at abort (/tmp/emscripten_test/test_pthread_abort_interrupt.js:1089:11)
    at _abort (/tmp/emscripten_test/test_pthread_abort_interrupt.js:1969:7)
    at <anonymous>:wasm-function[21]:0x832
    at Object.invokeEntryPoint (/tmp/emscripten_test/test_pthread_abort_interrupt.js:1796:42)
    at self.onmessage (/tmp/emscripten_test/test_pthread_abort_interrupt.worker.js:164:35)
    at MessagePort.<anonymous> (/tmp/emscripten_test/test_pthread_abort_interrupt.worker.js:24:38)
    at MessagePort.[nodejs.internal.kHybridDispatch] (internal/event_target.js:399:24)
    at MessagePort.exports.emitMessage (internal/per_context/messageport.js:18:26)
```