### PR TITLE
Improve wasm-split docs

### DIFF
--- a/site/source/docs/optimizing/Module-Splitting.rst
+++ b/site/source/docs/optimizing/Module-Splitting.rst
@@ -55,8 +55,9 @@ further changes to the JS produced by the initial compilation.
 Basic Example
 -------------
 
-Let’s run through a basic example of using SPLIT_MODULE with Node. Later we will
-adapt the example to run on the Web as well.
+Let’s run through a basic example of using SPLIT_MODULE with Node. Later in the
+"Running on the Web" section we will discuss how to adapt the example to run on
+the Web as well.
 
 Here’s our application code::
 


### PR DESCRIPTION
More explicitly call out that the example program will need to be adapted to run
on the Web and point to the later section on how that works.