### PR TITLE
Fix variable name typo. NFC

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -854,7 +854,7 @@ function modifyFunction(text, func) {
   // Match a function with a name.
   let match = text.match(/^\s*(async\s+)?function\s+([^(]*)?\s*\(([^)]*)\)/);
   let async_;
-  let names;
+  let name;
   let args;
   let rest;
   if (match) {


### PR DESCRIPTION
Because of a typo, the `names` variable was unused, and instead all assignments to `name` were changing the global `name` property.

Ideally all these preprocessor scripts should use `'use strict';` so that these and other errors would be quicker to catch, but I'm leaving that to others :)