### PR TITLE
fix: node read needs to check filename if url.

### DIFF
--- a/src/node_shell_read.js
+++ b/src/node_shell_read.js
@@ -48,7 +48,7 @@ readAsync = (filename, onload, onerror) => {
     onload(ret);
   }
 #endif
-  filename = nodePath['normalize'](filename);
+  filename = filename.startsWith('file://') ? new URL(filename, import.meta.url) : nodePath['normalize'](filename);
   fs.readFile(filename, function(err, data) {
     if (err) onerror(err);
     else onload(data.buffer);


### PR DESCRIPTION
The original code ``filename = nodePath['normalize'](filename);`` is buggy when using it used with electron package.
fs.readFile will take this to a wrong path on electron packaged.
For exmaple:
I have a packaged file path "'file:///C:/**/resources/app/dist/demo.wasm", fs.readFile will throw a error like: 
"Error: ENOENT: no such file or directory, open 'C:\**:\C:\**\resources\app\dist\demo.wasm"

So add the new URL wrap did the trick.

