### PR TITLE
Prevent idle Workers from keeping Node.js app alive

### DIFF
--- a/src/closure-externs/node-externs.js
+++ b/src/closure-externs/node-externs.js
@@ -111,3 +111,6 @@ Buffer.prototype.slice = function(start, end) {};
  * @nosideeffects
  */
 Buffer.prototype.toString = function(encoding, start, end) {};
+
+Worker.prototype.ref = function() {};
+Worker.prototype.unref = function() {};

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -273,12 +273,12 @@ var LibraryPThread = {
           cancelThread(d['thread']);
         } else if (cmd === 'loaded') {
           worker.loaded = true;
-          if (onFinishedLoading) onFinishedLoading(worker);
 #if ENVIRONMENT_MAY_BE_NODE
           if (ENVIRONMENT_IS_NODE) {
             worker.unref();
           }
 #endif
+          if (onFinishedLoading) onFinishedLoading(worker);
           // If this Worker is already pending to start running a thread, launch the thread now
           if (worker.runPthread) {
             worker.runPthread();

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -274,13 +274,13 @@ var LibraryPThread = {
         } else if (cmd === 'loaded') {
           worker.loaded = true;
           if (onFinishedLoading) onFinishedLoading(worker);
-#if ENVIRONMENT_MAY_BE_NODE
-          if (ENVIRONMENT_IS_NODE) worker.unref();
-#endif
           // If this Worker is already pending to start running a thread, launch the thread now
           if (worker.runPthread) {
             worker.runPthread();
           }
+#if ENVIRONMENT_MAY_BE_NODE
+          else if (ENVIRONMENT_IS_NODE) worker.unref();
+#endif
         } else if (cmd === 'print') {
           out('Thread ' + d['threadId'] + ': ' + d['text']);
         } else if (cmd === 'printErr') {

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -274,7 +274,11 @@ var LibraryPThread = {
         } else if (cmd === 'loaded') {
           worker.loaded = true;
           if (onFinishedLoading) onFinishedLoading(worker);
-          worker.unref();
+#if ENVIRONMENT_MAY_BE_NODE
+          if (ENVIRONMENT_IS_NODE) {
+            worker.unref();
+          }
+#endif
           // If this Worker is already pending to start running a thread, launch the thread now
           if (worker.runPthread) {
             worker.runPthread();

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -274,10 +274,12 @@ var LibraryPThread = {
         } else if (cmd === 'loaded') {
           worker.loaded = true;
           if (onFinishedLoading) onFinishedLoading(worker);
+#if ENVIRONMENT_MAY_BE_NODE
+          if (ENVIRONMENT_IS_NODE) worker.unref();
+#endif
           // If this Worker is already pending to start running a thread, launch the thread now
           if (worker.runPthread) {
             worker.runPthread();
-            delete worker.runPthread;
           }
         } else if (cmd === 'print') {
           out('Thread ' + d['threadId'] + ': ' + d['text']);
@@ -323,7 +325,6 @@ var LibraryPThread = {
           // TODO: update the worker queue?
           // See: https://github.com/emscripten-core/emscripten/issues/9763
         });
-        worker.unref();
       }
 #endif
 
@@ -599,10 +600,10 @@ var LibraryPThread = {
       // Ask the worker to start executing its pthread entry point function.
       msg.time = performance.now();
       worker.postMessage(msg, threadParams.transferList);
+      delete worker.runPthread;
     };
     if (worker.loaded) {
       worker.runPthread();
-      delete worker.runPthread;
     }
     return 0;
   },

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -207,6 +207,9 @@ var LibraryPThread = {
 
 #if ENVIRONMENT_MAY_BE_NODE
       if (ENVIRONMENT_IS_NODE) {
+        // Once a pthread has finished and the worker becomes idle, mark it
+        // as weakly referenced so that its existence does not prevent Node.js
+        // from exiting.
         worker.unref();
       }
 #endif
@@ -275,6 +278,9 @@ var LibraryPThread = {
           worker.loaded = true;
 #if ENVIRONMENT_MAY_BE_NODE
           if (ENVIRONMENT_IS_NODE) {
+            // Once worker is loaded & idle, mark it as weakly referenced,
+            // so that mere existence of a Worker in the pool does not prevent
+            // Node.js from exiting the app.
             worker.unref();
           }
 #endif
@@ -596,6 +602,8 @@ var LibraryPThread = {
       // Ask the worker to start executing its pthread entry point function.
 #if ENVIRONMENT_MAY_BE_NODE
       if (ENVIRONMENT_IS_NODE) {
+        // Mark worker as strongly referenced once we start executing a pthread,
+        // so that Node.js doesn't exit while the pthread is running.
         worker.ref();
       }
 #endif

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9084,6 +9084,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @node_pthreads
   def test_pthread_create(self):
+    self.set_setting('EXIT_RUNTIME')
     # test that the node environment can be specified by itself, and that still
     # works with pthreads (even though we did not specify 'node,worker')
     self.set_setting('ENVIRONMENT', 'node')
@@ -9120,6 +9121,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_pthread_create_pool(self):
     # with a pool, we can synchronously depend on workers being available
     self.set_setting('PTHREAD_POOL_SIZE', 2)
+    self.set_setting('EXIT_RUNTIME')
     self.emcc_args += ['-DALLOW_SYNC']
     self.do_run_in_out_file_test('core/pthread/create.cpp')
 
@@ -9135,12 +9137,14 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_pthread_create_embind_stack_check(self):
     # embind should work with stack overflow checks (see #12356)
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
+    self.set_setting('EXIT_RUNTIME')
     self.emcc_args += ['-lembind']
     self.do_run_in_out_file_test('core/pthread/create.cpp')
 
   @node_pthreads
   def test_pthread_exceptions(self):
     self.set_setting('PTHREAD_POOL_SIZE', 2)
+    self.set_setting('EXIT_RUNTIME')
     self.emcc_args += ['-fexceptions']
     self.do_run_in_out_file_test('core/pthread/exceptions.cpp')
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2806,11 +2806,11 @@ The current type of b is: 9
 
   @node_pthreads
   def test_pthread_setspecific_mainthread(self):
-    logger.debug('.. return')
+    print('.. return')
     self.do_runf(test_file('pthread/test_pthread_setspecific_mainthread.c'), 'done!', emcc_args=['-DRETURN'])
-    logger.debug('.. exit')
+    print('.. exit')
     self.do_runf(test_file('pthread/test_pthread_setspecific_mainthread.c'), 'done!', emcc_args=['-DEXIT'])
-    logger.debug('.. pthread_exit')
+    print('.. pthread_exit')
     self.do_run_in_out_file_test('pthread/test_pthread_setspecific_mainthread.c')
 
   @node_pthreads

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2829,6 +2829,8 @@ The current type of b is: 9
 
   @node_pthreads
   def test_pthread_abort_interrupt(self):
+    # TODO: investigate. This should work even w/o EXIT_RUNTIME and it does locally, but fails on CI.
+    self.set_setting('EXIT_RUNTIME')
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     expected = ['Aborted(). Build with -sASSERTIONS for more info', 'Aborted(native code called abort())']
     self.do_runf(test_file('pthread/test_pthread_abort_interrupt.c'), expected, assert_returncode=NON_ZERO)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2766,20 +2766,17 @@ The current type of b is: 9
 
   @node_pthreads
   def test_pthread_proxying_dropped_work(self):
-    self.set_setting('EXIT_RUNTIME')
     self.set_setting('PTHREAD_POOL_SIZE=2')
     self.do_run_in_out_file_test('pthread/test_pthread_proxying_dropped_work.c')
 
   @node_pthreads
   def test_pthread_proxying_refcount(self):
-    self.set_setting('EXIT_RUNTIME')
     self.set_setting('PTHREAD_POOL_SIZE=1')
     self.set_setting('ASSERTIONS=0')
     self.do_run_in_out_file_test('pthread/test_pthread_proxying_refcount.c')
 
   @node_pthreads
   def test_pthread_dispatch_after_exit(self):
-    self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test('pthread/test_pthread_dispatch_after_exit.c', interleaved_output=False)
 
   @node_pthreads
@@ -2791,7 +2788,6 @@ The current type of b is: 9
 
   @node_pthreads
   def test_pthread_nested_work_queue(self):
-    self.set_setting('EXIT_RUNTIME')
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     self.do_run_in_out_file_test('pthread/test_pthread_nested_work_queue.c')
 
@@ -2804,23 +2800,20 @@ The current type of b is: 9
 
   @node_pthreads
   def test_pthread_cleanup(self):
-    self.set_setting('EXIT_RUNTIME')
     self.set_setting('PTHREAD_POOL_SIZE', 4)
     self.do_run_in_out_file_test('pthread/test_pthread_cleanup.cpp')
 
   @node_pthreads
   def test_pthread_setspecific_mainthread(self):
-    self.set_setting('EXIT_RUNTIME')
-    print('.. return')
+    logger.debug('.. return')
     self.do_runf(test_file('pthread/test_pthread_setspecific_mainthread.c'), 'done!', emcc_args=['-DRETURN'])
-    print('.. exit')
+    logger.debug('.. exit')
     self.do_runf(test_file('pthread/test_pthread_setspecific_mainthread.c'), 'done!', emcc_args=['-DEXIT'])
-    print('.. pthread_exit')
+    logger.debug('.. pthread_exit')
     self.do_run_in_out_file_test('pthread/test_pthread_setspecific_mainthread.c')
 
   @node_pthreads
   def test_pthread_attr_getstack(self):
-    self.set_setting('EXIT_RUNTIME')
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     self.do_run_in_out_file_test('pthread/test_pthread_attr_getstack.c')
 
@@ -2836,7 +2829,6 @@ The current type of b is: 9
 
   @node_pthreads
   def test_pthread_abort_interrupt(self):
-    self.set_setting('EXIT_RUNTIME')
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     expected = ['Aborted(). Build with -sASSERTIONS for more info', 'Aborted(native code called abort())']
     self.do_runf(test_file('pthread/test_pthread_abort_interrupt.c'), expected, assert_returncode=NON_ZERO)
@@ -9092,7 +9084,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @node_pthreads
   def test_pthread_create(self):
-    self.set_setting('EXIT_RUNTIME')
     # test that the node environment can be specified by itself, and that still
     # works with pthreads (even though we did not specify 'node,worker')
     self.set_setting('ENVIRONMENT', 'node')
@@ -9112,13 +9103,11 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @node_pthreads
   def test_pthread_cxx_threads(self):
     self.set_setting('PTHREAD_POOL_SIZE', 1)
-    self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test('pthread/test_pthread_cxx_threads.cpp')
 
   @node_pthreads
   def test_pthread_busy_wait(self):
     self.set_setting('PTHREAD_POOL_SIZE', 1)
-    self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test('pthread/test_pthread_busy_wait.cpp')
 
   @node_pthreads
@@ -9131,7 +9120,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_pthread_create_pool(self):
     # with a pool, we can synchronously depend on workers being available
     self.set_setting('PTHREAD_POOL_SIZE', 2)
-    self.set_setting('EXIT_RUNTIME')
     self.emcc_args += ['-DALLOW_SYNC']
     self.do_run_in_out_file_test('core/pthread/create.cpp')
 
@@ -9147,14 +9135,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_pthread_create_embind_stack_check(self):
     # embind should work with stack overflow checks (see #12356)
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
-    self.set_setting('EXIT_RUNTIME')
     self.emcc_args += ['-lembind']
     self.do_run_in_out_file_test('core/pthread/create.cpp')
 
   @node_pthreads
   def test_pthread_exceptions(self):
     self.set_setting('PTHREAD_POOL_SIZE', 2)
-    self.set_setting('EXIT_RUNTIME')
     self.emcc_args += ['-fexceptions']
     self.do_run_in_out_file_test('core/pthread/exceptions.cpp')
 
@@ -9167,11 +9153,9 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @node_pthreads
   def test_pthread_exit_main(self):
-    self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test('core/pthread/test_pthread_exit_main.c')
 
   def test_pthread_exit_main_stub(self):
-    self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test('core/pthread/test_pthread_exit_main.c')
 
   @node_pthreads
@@ -9223,7 +9207,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @node_pthreads
   def test_stdio_locking(self):
     self.set_setting('PTHREAD_POOL_SIZE', '2')
-    self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test('core/test_stdio_locking.c')
 
   @needs_dylink
@@ -9238,7 +9221,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @node_pthreads
   def test_pthread_dylink(self):
     self.emcc_args.append('-Wno-experimental')
-    self.set_setting('EXIT_RUNTIME')
     self.set_setting('USE_PTHREADS')
     self.set_setting('PTHREAD_POOL_SIZE', 2)
     main = test_file('core/pthread/test_pthread_dylink.c')
@@ -9259,7 +9241,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @node_pthreads
   def test_pthread_dylink_entry_point(self, args):
     self.emcc_args.append('-Wno-experimental')
-    self.set_setting('EXIT_RUNTIME')
     self.set_setting('USE_PTHREADS')
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     main = test_file('core/pthread/test_pthread_dylink_entry_point.c')
@@ -9269,7 +9250,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @node_pthreads
   def test_pthread_dylink_exceptions(self):
     self.emcc_args.append('-Wno-experimental')
-    self.set_setting('EXIT_RUNTIME')
     self.set_setting('USE_PTHREADS')
     self.emcc_args.append('-fexceptions')
     self.dylink_testf(test_file('core/pthread/test_pthread_dylink_exceptions.cpp'))
@@ -9312,7 +9292,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @node_pthreads
   def test_pthread_dylink_tls(self):
     self.emcc_args.append('-Wno-experimental')
-    self.set_setting('EXIT_RUNTIME')
     self.set_setting('USE_PTHREADS')
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     main = test_file('core/pthread/test_pthread_dylink_tls.c')
@@ -9322,7 +9301,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @node_pthreads
   def test_pthread_dylink_longjmp(self):
     self.emcc_args.append('-Wno-experimental')
-    self.set_setting('EXIT_RUNTIME')
     self.set_setting('USE_PTHREADS')
     self.set_setting('PTHREAD_POOL_SIZE=1')
     main = test_file('core/pthread/test_pthread_dylink_longjmp.c')
@@ -9332,7 +9310,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @node_pthreads
   def test_pthread_dylink_main_module_1(self):
     self.emcc_args.append('-Wno-experimental')
-    self.set_setting('EXIT_RUNTIME')
     self.set_setting('USE_PTHREADS')
     self.set_setting('MAIN_MODULE')
     self.do_runf(test_file('hello_world.c'))

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2771,6 +2771,7 @@ The current type of b is: 9
 
   @node_pthreads
   def test_pthread_proxying_refcount(self):
+    self.set_setting('EXIT_RUNTIME')
     self.set_setting('PTHREAD_POOL_SIZE=1')
     self.set_setting('ASSERTIONS=0')
     self.do_run_in_out_file_test('pthread/test_pthread_proxying_refcount.c')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2829,8 +2829,6 @@ The current type of b is: 9
 
   @node_pthreads
   def test_pthread_abort_interrupt(self):
-    # TODO: investigate. This should work even w/o EXIT_RUNTIME and it does locally, but fails on CI.
-    self.set_setting('EXIT_RUNTIME')
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     expected = ['Aborted(). Build with -sASSERTIONS for more info', 'Aborted(native code called abort())']
     self.do_runf(test_file('pthread/test_pthread_abort_interrupt.c'), expected, assert_returncode=NON_ZERO)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9101,7 +9101,6 @@ T6:(else) !ASSERTIONS""", output)
 const test_module = require("./module");
 test_module().then((test_module_instance) => {
   test_module_instance._main();
-  process.exit(0);
 });
 '''
     ensure_dir('subdir')


### PR DESCRIPTION
Fixes #12801 for majority of cases.

This is a relatively simple change, but it took embarrassingly many attempts to get it in the right places for all obscure tests to pass + to figure out which tests can make use of it instead of doing manual exit + to debug some apparent differences in Node Worker GC behaviour between Windows/Linux as a bonus.

I tried two approaches in parallel, a conservative one in this PR and one that brings Emscripten behaviour closer to native in a separate branch.

In ideal scenario, I wanted to make Node.js apps behave just like native, where background threads themselves don't keep an app open, and instead app lives as long as it explicitly blocks on `pthread_join` or other blocking APIs. However, it's a more disruptive change that still requires more work and testing, as some Emscripten use-cases implicitly depend on the app running despite not having any more foreground work to do - one notable example is `PROXY_TO_PTHREAD` that spawns a detached thread, but obviously wants the app to continue running. All those cases are fixable, but, as said above, requires more work so I'm keeping it aside for now.

Instead, in this PR I'm adding a .ref/.unref "dance" (h/t @d3lm for the original idea) that keeps the app alive as long as _any_ pthreads are running, whether joinable or detached, and whether you have explicit blocking on them or not. It works as following:

- Upon creation, all pool workers are strongly referenced as we need to wait for them to be properly loaded.
- Once worker is loaded, it's marked as weakly referenced, as we don't want idle workers to prevent app from exiting.
- Once worker is associated with & starts running a pthread, it's marked as strongly referenced so that the app stays alive as long as it's doing some work.
- Once worker is done and returned to the idle worker pool, it's weakly referenced again.

This ensures maximum compatibility, while fixing majority of common cases.

One usecase it doesn't fix is when a C/C++ app itself has an internal singletone threadpool (like one created by glib) - in this case there's no way for Emscripten to know that those "running" threads are actually semantically idle. This would be fixed by the more rigorous alternative implementation mentioned above, but, for now, such usecases can be relatively easily worked around with a bit of custom `--pre-js` that goes over all `PThread.runningWorkers` and marks them as `.unref`d. That's what I did in an app I'm currently working on, and it works pretty well. To avoid reaching into JS internals, we might consider adding an `emscripten_`-prefixed API to allow referencing/unreferencing Worker via a `pthread_t` instance from the C code, but for now I'm leaving it out of scope of this PR.

Let me know if you have any questions.
