### PR TITLE
Allow commit ce4c405 to roll in

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -256,6 +256,7 @@ class other(RunnerCore):
     'node': (['-sENVIRONMENT=node'],),
   })
   @node_pthreads
+  @no_mac("Temporally disabled see: https://github.com/emscripten-core/emscripten/pull/17915#issuecomment-1319195397")
   def test_emcc_output_worker_mjs(self, args):
     create_file('extern-post.js', 'await Module();')
     os.mkdir('subdir')


### PR DESCRIPTION
Somehow that commit caused a runtime assertion failure on macOS with Node v14.15.5 (whose active support ended a year ago) when testing `other.test_emcc_output_worker_mjs`.

This seems to happen only for the multi-environment build, which could indicate that it fails on the `await import` statement.

---
Note that I'm not sure why the auto-roller doesn't test this with Node v14.18.2 (which was landed via commit https://github.com/emscripten-core/emsdk/commit/24e78812e06995ffcf48982bedb46d7de5fdd493).