### PR TITLE
Move changelog note to the correct place. NFC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@ See docs/process.md for more on how version tagging works.
 
 3.1.27 (in development)
 -----------------------
+- Add support for `-sEXPORT_ES6`/`*.mjs` on Node.js. (#17915)
 
 3.1.26 - 11/17/22
 -----------------
@@ -46,7 +47,6 @@ See docs/process.md for more on how version tagging works.
   overflow will trap rather corrupting global data first).  This should not
   be a user-visible change (unless your program does something very odd such
   depending on the specific location of stack data in memory). (#18154)
-- Add support for `-sEXPORT_ES6`/`*.mjs` on Node.js. (#17915)
 
 3.1.25 - 11/08/22
 -----------------


### PR DESCRIPTION
3.1.26 was tagged on commit 8eaf19f, so it did not contain the changes made in commit ce4c405.