### PR TITLE
Remove outdated code referencing wasm-emscripten-finalize

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -470,13 +470,6 @@ def finalize_wasm(infile, outfile, memfile):
     # wasm2js requires full legalization (and will do extra wasm binary
     # later processing later anyhow)
     modify_wasm = True
-  if settings.USE_PTHREADS and settings.RELOCATABLE:
-    # HACK: When settings.USE_PTHREADS and settings.RELOCATABLE are set finalize needs to scan
-    # more than just the start function for memory.init instructions.  This means it can't run
-    # with setSkipFunctionBodies() enabled.  Currently the only way to force this is to set an
-    # output file.
-    # TODO(sbc): Find a better way to do this.
-    modify_wasm = True
   if settings.GENERATE_SOURCE_MAP:
     building.emit_wasm_source_map(infile, infile + '.map', outfile)
     building.save_intermediate(infile + '.map', 'base_wasm.map')


### PR DESCRIPTION
We no longer need to run wasm-emscripten-finalize to extract metadata.