### PR TITLE
Add helper functions for obtaining the global data section and the dynamic heap addresses.

### DIFF
--- a/system/include/emscripten/heap.h
+++ b/system/include/emscripten/heap.h
@@ -21,7 +21,8 @@ extern "C" {
 #endif
 
 // Returns a pointer to a memory location that contains the heap DYNAMICTOP
-// variable (the end of the dynamic memory region)
+// variable (the end of the dynamic memory region). This address stays the same
+// throughout program lifetime.
 uintptr_t *emscripten_get_sbrk_ptr(void);
 
 // Attempts to geometrically or linearly increase the heap so that it
@@ -31,10 +32,36 @@ uintptr_t *emscripten_get_sbrk_ptr(void);
 // cannot be used to shrink the size of the heap.
 int emscripten_resize_heap(size_t requested_size) EM_IMPORT(emscripten_resize_heap);
 
-// Returns the current size of the WebAssembly heap.
+// Returns the base address of the global data section. The global data section
+// contains the constant global and static function local data, either zero- or
+// non-zero initialized. This address stays constant throughout program lifetime.
+uintptr_t emscripten_get_global_base(void);
+
+// Returns the end address of the global data section. N.b. the memory location
+// pointed to by this end value is not part of the global data section itself, i.e.
+// the global data section consists of the half-open range [global_base,
+// global_end[ in the usual begin-end pointer span style. This address stays
+// constant throughout program lifetime.
+uintptr_t emscripten_get_global_end(void);
+
+// Returns the starting address of the dynamic memory heap. This value corresponds
+// to the the sbrk value at program startup, when no dynamic memory allocations
+// have yet been made. This address stays constant throughout program lifetime.
+uintptr_t emscripten_get_dyn_heap_base(void);
+
+// Returns the end address of the dynamic memory heap (same as the sbrk() point)
+// This value can change during program execution, as the WebAssembly heap is
+// grown by calling sbrk().
+#define emscripten_get_dyn_heap_end() (*emscripten_get_sbrk_ptr())
+
+// Returns the current size of the WebAssembly heap (the WebAssembly.Memory object).
+// This value can change during program execution, as the WebAssembly heap is
+// grown by calling emscripten_resize_heap().
 size_t emscripten_get_heap_size(void);
 
-// Returns the max size of the WebAssembly heap.
+// Returns the max size of the WebAssembly heap (the WebAssembly.Memory object).
+// This is the largest size that the memory is allowed to grow up to, set at
+// compile time. This value is a constant throughout program lifetime.
 size_t emscripten_get_heap_max(void);
 
 // Direct access to the system allocator.  Use these to access that underlying

--- a/system/lib/sbrk.c
+++ b/system/lib/sbrk.c
@@ -47,6 +47,24 @@ uintptr_t* emscripten_get_sbrk_ptr() {
   return &sbrk_val;
 }
 
+extern uint32_t __global_base;
+extern uint32_t __data_end;
+
+uintptr_t emscripten_get_global_base()
+{
+  return (uintptr_t)&__global_base;
+}
+
+uintptr_t emscripten_get_global_end()
+{
+  return (uintptr_t)&__data_end;
+}
+
+uintptr_t emscripten_get_dyn_heap_base()
+{
+  return (uintptr_t)&__heap_base;
+}
+
 // Enforce preserving a minimal alignof(maxalign_t) alignment for sbrk.
 #define SBRK_ALIGNMENT (__alignof__(max_align_t))
 


### PR DESCRIPTION
Add helper functions for obtaining the global data section start and end addresses, and the dynamic heap start and end addresses. These are required for implementing support for the Boehm GC.

Didn't do any tests yet, but posting first for comments.