### PR TITLE
[WasmFS] Add virtual backend utilities

### DIFF
--- a/system/lib/wasmfs/backends/ignore_case_backend.cpp
+++ b/system/lib/wasmfs/backends/ignore_case_backend.cpp
@@ -8,7 +8,7 @@
 
 #include "backend.h"
 #include "file.h"
-#include "memory_backend.h"
+#include "virtual.h"
 #include "wasmfs.h"
 
 namespace {
@@ -20,105 +20,171 @@ std::string normalize(const std::string& name) {
   }
   return result;
 }
-} // namespace
+
+} // anonymous namespace
 
 namespace wasmfs {
 
-// Problem: Child entries are stored both in IgnoreCaseDirectory and in baseDirectory.
-//
-// Original name case preservation could be possible if MemoryDirectory::entries
-// were accesible. Then, we would store the original case there but search
-// ignoring case.
-//
-class IgnoreCaseDirectory : public MemoryDirectory {
-  using BaseClass = MemoryDirectory;
-  std::shared_ptr<Directory> baseDirectory;
+class IgnoreCaseDirectory : public VirtualDirectory {
+
+  struct ChildInfo {
+    std::string originalName;
+    std::shared_ptr<File> child;
+  };
+
+  // Map normalized names to virtual files and their non-normalized names.
+  std::map<std::string, ChildInfo> children;
 
 public:
-  IgnoreCaseDirectory(std::shared_ptr<Directory> base, backend_t proxyBackend)
-    : BaseClass(base->locked().getMode(), proxyBackend), baseDirectory(base) {}
+  IgnoreCaseDirectory(std::shared_ptr<Directory> real, backend_t backend)
+    : VirtualDirectory(real, backend) {}
 
-  std::shared_ptr<File> getChild(const std::string& name) override {
-    return BaseClass::getChild(normalize(name));
-  }
-
+  std::shared_ptr<File> getChild(const std::string& name) override;
   std::shared_ptr<DataFile> insertDataFile(const std::string& name,
-                                           mode_t mode) override {
-    auto name2 = normalize(name);
-    auto baseDirLocked = baseDirectory->locked();
-    auto child = baseDirLocked.insertDataFile(name2, mode);
-    if (child) {
-      insertChild(name2, child);
-      // Directory::Hanlde needs a parent
-      child->locked().setParent(cast<Directory>());
-    }
-    return child;
-  }
-
+                                           mode_t mode) override;
   std::shared_ptr<Directory> insertDirectory(const std::string& name,
-                                             mode_t mode) override {
-    auto name2 = normalize(name);
-    auto baseDirLocked = baseDirectory->locked();
-    if (!baseDirLocked.getParent())
-      baseDirLocked.setParent(parent.lock()); // Directory::Hanlde needs a parent
-    auto baseChild = baseDirLocked.insertDirectory(name2, mode);
-    auto child = std::make_shared<IgnoreCaseDirectory>(baseChild, getBackend());
-    insertChild(name2, child);
-    return child;
-  }
-
+                                             mode_t mode) override;
   std::shared_ptr<Symlink> insertSymlink(const std::string& name,
-                                         const std::string& target) override {
-    auto name2 = normalize(name);
-    auto child = baseDirectory->locked().insertSymlink(name2, target);
-    if (child) {
-      insertChild(name2, child);
-      // Directory::Hanlde needs a parent
-      child->locked().setParent(cast<Directory>());
-    }
-    return child;
-  }
-
-  int insertMove(const std::string& name, std::shared_ptr<File> file) override {
-    auto newName = normalize(name);
-    // Remove entry with the new name (if any) from this directory.
-    if (auto err = removeChild(newName))
-      return err;
-    auto oldParent = file->locked().getParent()->locked();
-    auto oldName = normalize(oldParent.getName(file));
-    // Move in underlying directory.
-    if (auto err = baseDirectory->locked().insertMove(newName, file))
-      return err;
-    // Ensure old file was removed.
-    if (auto err = oldParent.removeChild(oldName))
-      return err;
-    // Cache file with the new name in this directory.
-    insertChild(newName, file);
-    file->locked().setParent(cast<Directory>());
-    return 0;
-  }
-
-  int removeChild(const std::string& name) override {
-    auto name2 = normalize(name);
-    if (auto err = BaseClass::removeChild(name2))
-      return err;
-    return baseDirectory->locked().removeChild(name2);
-  }
-
-  ssize_t getNumEntries() override { return baseDirectory->locked().getNumEntries(); }
-
-  // TODO: preserve original name, denormalize, and use it here
-  Directory::MaybeEntries getEntries() override {
-    return baseDirectory->locked().getEntries();
-  }
-
-  // TODO: preserve original name, denormalize, and use it here
-  std::string getName(std::shared_ptr<File> file) override {
-    return BaseClass::getName(file);
-  }
-
+                                         const std::string& target) override;
+  int insertMove(const std::string& name, std::shared_ptr<File> file) override;
+  int removeChild(const std::string& name) override;
+  ssize_t getNumEntries() override { return real->locked().getNumEntries(); }
+  Directory::MaybeEntries getEntries() override;
+  std::string getName(std::shared_ptr<File> file) override;
   bool maintainsFileIdentity() override { return true; }
 };
+
+// Wrap a real file in an IgnoreCase virtual file of the same kind.
+std::shared_ptr<DataFile> virtualize(std::shared_ptr<DataFile> data,
+                                     backend_t backend) {
+  return std::make_shared<VirtualDataFile>(data, backend);
+}
+
+std::shared_ptr<Directory> virtualize(std::shared_ptr<Directory> dir,
+                                      backend_t backend) {
+  return std::make_shared<IgnoreCaseDirectory>(dir, backend);
+}
+
+std::shared_ptr<Symlink> virtualize(std::shared_ptr<Symlink> link,
+                                    backend_t backend) {
+  return std::make_shared<VirtualSymlink>(link, backend);
+}
+
+std::shared_ptr<File> virtualize(std::shared_ptr<File> file,
+                                 backend_t backend) {
+  if (auto data = file->dynCast<DataFile>()) {
+    return virtualize(data, backend);
+  } else if (auto dir = file->dynCast<Directory>()) {
+    return virtualize(dir, backend);
+  } else if (auto link = file->dynCast<Symlink>()) {
+    return virtualize(link, backend);
+  }
+  WASMFS_UNREACHABLE("unexpected file kind");
+}
+
+std::shared_ptr<File> IgnoreCaseDirectory::getChild(const std::string& name) {
+  auto normalized = normalize(name);
+  if (auto it = children.find(normalized); it != children.end()) {
+    return it->second.child;
+  }
+  auto child = real->locked().getChild(normalized);
+  if (!child) {
+    return nullptr;
+  }
+  child = virtualize(child, getBackend());
+  children[normalized] = {name, child};
+  return child;
+}
+
+std::shared_ptr<DataFile>
+IgnoreCaseDirectory::insertDataFile(const std::string& name, mode_t mode) {
+  auto normalized = normalize(name);
+  auto file = real->locked().insertDataFile(normalized, mode);
+  if (!file) {
+    return nullptr;
+  }
+  file = virtualize(file, getBackend());
+  children[normalized] = {name, file};
+  return file;
+}
+
+std::shared_ptr<Directory>
+IgnoreCaseDirectory::insertDirectory(const std::string& name, mode_t mode) {
+  auto normalized = normalize(name);
+  auto dir = real->locked().insertDirectory(normalized, mode);
+  if (!dir) {
+    return nullptr;
+  }
+  dir = virtualize(dir, getBackend());
+  children[normalized] = {name, dir};
+  return dir;
+}
+
+std::shared_ptr<Symlink>
+IgnoreCaseDirectory::insertSymlink(const std::string& name,
+                                   const std::string& target) {
+  auto normalized = normalize(name);
+  auto link = real->locked().insertSymlink(normalized, target);
+  if (!link) {
+    return nullptr;
+  }
+  link = virtualize(link, getBackend());
+  children[normalized] = {name, link};
+  return link;
+}
+
+int IgnoreCaseDirectory::insertMove(const std::string& name,
+                                    std::shared_ptr<File> file) {
+  auto normalized = normalize(name);
+  if (auto err = real->locked().insertMove(normalized, devirtualize(file))) {
+    return err;
+  }
+  auto oldParent =
+    std::static_pointer_cast<IgnoreCaseDirectory>(file->locked().getParent());
+  auto& oldChildren = oldParent->children;
+  for (auto it = oldChildren.begin(); it != oldChildren.end(); ++it) {
+    if (it->second.child == file) {
+      oldChildren.erase(it);
+      break;
+    }
+  }
+  children[normalized] = {name, file};
+  return 0;
+}
+
+int IgnoreCaseDirectory::removeChild(const std::string& name) {
+  auto normalized = normalize(name);
+  if (auto err = real->locked().removeChild(normalized)) {
+    return err;
+  }
+  auto it = children.find(normalized);
+  assert(it != children.end());
+  it->second.child->locked().setParent(nullptr);
+  children.erase(it);
+  return 0;
+}
+
+Directory::MaybeEntries IgnoreCaseDirectory::getEntries() {
+  auto entries = real->locked().getEntries();
+  if (auto err = entries.getError()) {
+    return entries;
+  }
+  for (auto& entry : *entries) {
+    if (auto it = children.find(entry.name); it != children.end()) {
+      entry.name = it->second.originalName;
+    }
+  }
+  return entries;
+}
+
+std::string IgnoreCaseDirectory::getName(std::shared_ptr<File> file) {
+  for (auto& [_, info] : children) {
+    if (info.child == file) {
+      return info.originalName;
+    }
+  }
+  return "";
+}
 
 class IgnoreCaseBackend : public Backend {
   backend_t backend;
@@ -129,16 +195,21 @@ public:
   }
 
   std::shared_ptr<DataFile> createFile(mode_t mode) override {
-    return backend->createFile(mode);
+    return virtualize(backend->createFile(mode), this);
   }
 
   std::shared_ptr<Directory> createDirectory(mode_t mode) override {
-    return std::make_shared<IgnoreCaseDirectory>(backend->createDirectory(mode),
-                                                 this);
+    auto real = backend->createDirectory(mode);
+    // Inserts into the real backing directory won't work if it doesn't appear
+    // to be linked, so give it a parent.
+    // TODO: Break this reference cycle in a destructor somewhere.
+    real->locked().setParent(real);
+    auto ret = virtualize(real, this);
+    return ret;
   }
 
   std::shared_ptr<Symlink> createSymlink(std::string target) override {
-    return backend->createSymlink(normalize(target));
+    return virtualize(backend->createSymlink(target), this);
   }
 };
 
@@ -148,12 +219,14 @@ backend_t createIgnoreCaseBackend(std::function<backend_t()> createBackend) {
 }
 
 extern "C" {
+
 // C API for creating ignore case backend.
 backend_t wasmfs_create_icase_backend(backend_constructor_t create_backend,
                                       void* arg) {
   return createIgnoreCaseBackend(
     [create_backend, arg]() { return create_backend(arg); });
 }
-}
+
+} // extern "C"
 
 } // namespace wasmfs

--- a/system/lib/wasmfs/backends/ignore_case_backend.cpp
+++ b/system/lib/wasmfs/backends/ignore_case_backend.cpp
@@ -159,13 +159,20 @@ int IgnoreCaseDirectory::insertMove(const std::string& name,
   auto oldParent =
     std::static_pointer_cast<IgnoreCaseDirectory>(file->locked().getParent());
   auto& oldChildren = oldParent->children;
+  // Delete the entry in the old parent.
   for (auto it = oldChildren.begin(); it != oldChildren.end(); ++it) {
     if (it->second.child == file) {
       oldChildren.erase(it);
       break;
     }
   }
-  children[normalized] = {name, file};
+  // Unlink the overwritten entry if it exists.
+  auto [it, inserted] = children.insert({normalized, {name, file}});
+  if (!inserted) {
+    it->second.child->locked().setParent(nullptr);
+    it->second = {name, file};
+  }
+
   return 0;
 }
 

--- a/system/lib/wasmfs/backends/ignore_case_backend.cpp
+++ b/system/lib/wasmfs/backends/ignore_case_backend.cpp
@@ -10,18 +10,8 @@
 // internally so they can be returned later, giving the appearance of a
 // case-insensitive but case-preserving file system.
 //
-// DataFiles and Symlinks are also wrapped, although their wrappers pass
-// operations through to the underlying files with not modifications. These
-// wrappers are important to maintain the clear distinction between the virtual
-// backend, which is visible to the rest of WasmFS, and the underlying "real"
-// backend, which does not know it is being virtualized. In particular, if we
-// did not wrap these files, the WasmFS dcache system would expect the virtual
-// directories to be the parents of the "real" unwrapped files. But the "real"
-// backend may expect that its directories are the parents of those files and
-// may not work correctly otherwise. Introducing the no-op wrappers solves this
-// problem: WasmFS sees a consistent view of virtual directories being the
-// parent of their virtual children, and the "real" underlying backend sees its
-// "real" directories being the parents of their "real" children.
+// See the comment in virtual.h for an explanation of why DataFiles and Symlinks
+// must have no-op wrappers.
 
 #include "backend.h"
 #include "file.h"

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -178,11 +178,12 @@ int Directory::Handle::insertMove(const std::string& name,
       it->second.file->locked().setParent(nullptr);
       it->second = entry;
     }
-    file->locked().setParent(getDir());
   } else {
     // This backend doesn't use the dcache.
     assert(getDir()->maintainsFileIdentity());
   }
+
+  file->locked().setParent(getDir());
 
   // TODO: Moving mount points probably shouldn't update the mtime.
   auto now = time(NULL);

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -257,7 +257,7 @@ protected:
   //  1. Ensuring that all insert* and getChild calls returning a particular
   //     file return the same File object.
   //
-  //  2. Clearing the File's parent field in `removeChild`.
+  //  2. Clearing unlinked Files' parents in `removeChild` and `insertMove`.
   //
   //  3. Implementing `getName`, since it cannot be implemented in terms of the
   //     dcache.

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -181,6 +181,10 @@ public:
       return 0;
     }
 
+    std::vector<Entry>& operator*() {
+      return *std::get_if<std::vector<Entry>>(this);
+    }
+
     std::vector<Entry>* operator->() {
       return std::get_if<std::vector<Entry>>(this);
     }

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -15,6 +15,7 @@
 #include <emscripten/threading.h>
 
 namespace wasmfs {
+
 // This class describes a file that lives in Wasm Memory.
 class MemoryFile : public DataFile {
   std::vector<uint8_t> buffer;

--- a/system/lib/wasmfs/virtual.h
+++ b/system/lib/wasmfs/virtual.h
@@ -1,0 +1,116 @@
+// Copyright 2022 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+// Utilities for creating virtual backends that forward operations to underlying
+// "real" files.
+
+#pragma once
+
+#include "file.h"
+
+namespace wasmfs {
+
+static inline std::shared_ptr<File> devirtualize(std::shared_ptr<File>);
+
+class VirtualDataFile : public DataFile {
+protected:
+  std::shared_ptr<DataFile> real;
+
+public:
+  VirtualDataFile(std::shared_ptr<DataFile> real, backend_t backend)
+    : DataFile(real->locked().getMode(), backend), real(real) {}
+
+protected:
+  virtual off_t getSize() override { return real->locked().getSize(); }
+  virtual int open(oflags_t flags) override {
+    return real->locked().open(flags);
+  }
+  virtual int close() override { return real->locked().close(); }
+  virtual ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
+    return real->locked().read(buf, len, offset);
+  }
+  virtual ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
+    return real->locked().write(buf, len, offset);
+  }
+  virtual int setSize(off_t size) override {
+    return real->locked().setSize(size);
+  }
+  virtual int flush() override { return real->locked().flush(); }
+
+  friend std::shared_ptr<File> devirtualize(std::shared_ptr<File>);
+};
+
+// Forward operations through Directory::Handle to get the proper dcache logic.
+class VirtualDirectory : public Directory {
+protected:
+  std::shared_ptr<Directory> real;
+
+public:
+  VirtualDirectory(std::shared_ptr<Directory> real, backend_t backend)
+    : Directory(real->locked().getMode(), backend), real(real) {}
+
+protected:
+  virtual std::shared_ptr<File> getChild(const std::string& name) override {
+    return real->locked().getChild(name);
+  }
+  virtual std::shared_ptr<DataFile> insertDataFile(const std::string& name,
+                                                   mode_t mode) override {
+    return real->locked().insertDataFile(name, mode);
+  }
+  virtual std::shared_ptr<Directory> insertDirectory(const std::string& name,
+                                                     mode_t mode) override {
+    return real->locked().insertDirectory(name, mode);
+  }
+  virtual std::shared_ptr<Symlink>
+  insertSymlink(const std::string& name, const std::string& target) override {
+    return real->locked().insertSymlink(name, target);
+  }
+  virtual int insertMove(const std::string& name,
+                         std::shared_ptr<File> file) override {
+    return real->locked().insertMove(name, file);
+  }
+  virtual int removeChild(const std::string& name) override {
+    return real->locked().removeChild(name);
+  }
+  virtual ssize_t getNumEntries() override {
+    return real->locked().getNumEntries();
+  }
+  virtual MaybeEntries getEntries() override {
+    return real->locked().getEntries();
+  }
+  virtual std::string getName(std::shared_ptr<File> file) override {
+    return real->locked().getName(file);
+  }
+
+  friend std::shared_ptr<File> devirtualize(std::shared_ptr<File>);
+};
+
+class VirtualSymlink : public Symlink {
+protected:
+  std::shared_ptr<Symlink> real;
+
+public:
+  VirtualSymlink(std::shared_ptr<Symlink> real, backend_t backend)
+    : Symlink(backend), real(real) {}
+
+protected:
+  virtual std::string getTarget() const override { return real->getTarget(); }
+
+  friend std::shared_ptr<File> devirtualize(std::shared_ptr<File>);
+};
+
+// Unwrap a virtual file and get the underlying real file of the same kind.
+inline std::shared_ptr<File> devirtualize(std::shared_ptr<File> file) {
+  if (file->is<DataFile>()) {
+    return std::static_pointer_cast<VirtualDataFile>(file)->real;
+  } else if (auto dir = file->is<Directory>()) {
+    return std::static_pointer_cast<VirtualDirectory>(file)->real;
+  } else if (auto link = file->is<Symlink>()) {
+    return std::static_pointer_cast<VirtualDirectory>(file)->real;
+  }
+  WASMFS_UNREACHABLE("unexpected file kind");
+}
+
+} // namespace wasmfs

--- a/system/lib/wasmfs/virtual.h
+++ b/system/lib/wasmfs/virtual.h
@@ -4,7 +4,14 @@
 // found in the LICENSE file.
 
 // Utilities for creating virtual backends that forward operations to underlying
-// "real" files.
+// "real" files. Virtual backends must wrap all underlying files, even if the
+// wrapper is a no-op, so that no part of the system observes mixed backends. To
+// the backend-independent code, the root directory of the virtual backend and
+// all of its descendants must appear to have the same virtual backend. To the
+// underlying "real" backend, all of its files must appear to have parents of
+// the same real backend. Without these invariants, renames would not work
+// correctly and without wrapping all files, these invariants would not be
+// upheld.
 
 #pragma once
 

--- a/test/other/test_fs_icase.cpp
+++ b/test/other/test_fs_icase.cpp
@@ -94,13 +94,8 @@ int main() {
   assert(contents.size() == 2);
   assert(std::find(contents.begin(), contents.end(), "test2.txt") !=
          contents.end());
-#ifdef WASMFS
-  assert(std::find(contents.begin(), contents.end(), "subdir") !=
-         contents.end());
-#else
   assert(std::find(contents.begin(), contents.end(), "Subdir") !=
          contents.end());
-#endif
 
   // Create a file in the directory.
   write_file("SubDir/Test.txt");
@@ -110,13 +105,8 @@ int main() {
   // Check child directory contents and entries name.
   contents = readdir("subdir");
   assert(contents.size() == 1);
-#ifdef WASMFS
-  assert(std::find(contents.begin(), contents.end(), "test.txt") !=
-         contents.end());
-#else
   assert(std::find(contents.begin(), contents.end(), "Test.txt") !=
          contents.end());
-#endif
 
   // Delete a file from a directory.
 #ifdef WASMFS
@@ -132,8 +122,12 @@ int main() {
   assert(chdir("subdir") == 0);
   char buffer[256];
   printf("getcwd: %s\n", getcwd(buffer, sizeof(buffer)));
-  assert(
-    std::string(buffer).ends_with("subdir")); // original case is not preserved
+#ifdef WASMFS
+  assert(std::string(buffer).ends_with("Subdir"));
+#else
+  // original case is not preserved
+  assert(std::string(buffer).ends_with("subdir"));
+#endif
   assert(chdir("..") == 0);
 
   // Rename a directory.
@@ -155,13 +149,8 @@ int main() {
   assert(contents.size() == 4);
   assert(std::find(contents.begin(), contents.end(), "test2.txt.lnk") !=
          contents.end());
-#ifdef WASMFS
-  assert(std::find(contents.begin(), contents.end(), "subdir2.lnk") !=
-         contents.end());
-#else
   assert(std::find(contents.begin(), contents.end(), "SUBDIR2.LNK") !=
          contents.end());
-#endif
 
   // Delete symlinks.
   assert(unlink("Test2.txt.lnk") == 0);

--- a/test/other/test_fs_icase.cpp
+++ b/test/other/test_fs_icase.cpp
@@ -132,16 +132,19 @@ int main() {
 #endif
   assert(chdir("..") == 0);
 
+#ifdef WASMFS
   // Create a directory to be overwritten by the subsequent rename.
   assert(mkdir("SUBDIR2", S_IRWXUGO) == 0);
   int overwritten_dir = open("subdir2", O_RDONLY | O_DIRECTORY);
   assert(overwritten_dir != -1);
+#endif
 
   // Rename a directory.
   assert(rename("subdir", "Subdir2") == 0);
   assert(!exists("subdir"));
   assert(exists("subdir2"));
 
+#ifdef WASMFS
   // Check that the overwritten dir was properly unlinked.
   int cwd = open(".", O_DIRECTORY | O_RDONLY);
   assert(cwd != 0);
@@ -149,7 +152,10 @@ int main() {
   assert(getcwd(buffer, sizeof(buffer)) == NULL);
   assert(errno == ENOENT);
   assert(fchdir(cwd) == 0);
+#endif
 
+#ifdef WASMFS
+  // bug in legacy FS
   // Check that the parent of a moved directory is set correctly.
   assert(mkdir("subdir2/subsubdir", S_IRWXUGO) == 0);
   assert(rename("SubDir2/SubSubDir", "SUBSUBDIR") == 0);
@@ -160,6 +166,7 @@ int main() {
   assert(strcmp(buffer, "/SUBSUBDIR") == 0);
   assert(fchdir(cwd) == 0);
   assert(rmdir("subsubdir") == 0);
+#endif
 
   // Create a file symlink.
   assert(symlink("test2.txt", "test2.txt.lnk") == 0);


### PR DESCRIPTION
Add generic subclasses of DataFile, Directory, and Symlink that wrap other files
and pass operations through to them. Use the new utilities in a rewrite of the
ignore-case virtual backend that cleanly separates the underlying "real" file
system from the virtual file system. This also fixes outstanding issues with the
ignore case backend in which the original, non-normalized file names were not
preserved.

Fixes #17993.