### PR TITLE
Move printing of emmalloc dynamic memory fragmentation map into emmalloc

### DIFF
--- a/system/include/emscripten/emmalloc.h
+++ b/system/include/emscripten/emmalloc.h
@@ -118,6 +118,10 @@ size_t emmalloc_unclaimed_heap_memory(void);
 // iterates through all free memory blocks.
 size_t emmalloc_compute_free_dynamic_memory_fragmentation_map(size_t freeMemorySizeMap[32]);
 
+// Same as above, but instead of returning the information in an array, prints it directly
+// to stdout.
+void emmalloc_dump_free_dynamic_memory_fragmentation_map(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/system/lib/emmalloc.c
+++ b/system/lib/emmalloc.c
@@ -47,6 +47,7 @@
 #include <memory.h>
 #include <assert.h>
 #include <malloc.h>
+#include <stdio.h>
 #include <emscripten/heap.h>
 #include <emscripten/threading.h>
 
@@ -1426,6 +1427,15 @@ size_t emmalloc_compute_free_dynamic_memory_fragmentation_map(size_t freeMemoryS
   }
   MALLOC_RELEASE();
   return numFreeMemoryRegions;
+}
+
+void emmalloc_dump_free_dynamic_memory_fragmentation_map()
+{
+  size_t freeMemorySizeMap[32];
+  size_t numFreeMemoryRegions = emmalloc_compute_free_dynamic_memory_fragmentation_map(freeMemorySizeMap);
+  printf("numFreeMemoryRegions: %zu\n", numFreeMemoryRegions);
+  for(int i = 0; i < 32; ++i)
+    printf("Free memory regions of size [%llu,%llu[ bytes: %zu regions\n", 1ull<<i, 1ull<<(i+1), freeMemorySizeMap[i]);
 }
 
 size_t emmalloc_unclaimed_heap_memory(void) {

--- a/test/core/test_emmalloc_memory_statistics.cpp
+++ b/test/core/test_emmalloc_memory_statistics.cpp
@@ -19,12 +19,6 @@ int main()
 	printf("emmalloc_validate_memory_regions: %d\n", emmalloc_validate_memory_regions());
 	printf("emmalloc_dynamic_heap_size      : %zu\n", emmalloc_dynamic_heap_size());
 	printf("emmalloc_free_dynamic_memory    : %zu\n", emmalloc_free_dynamic_memory());
-	size_t numFreeMemoryRegions = 0;
-	size_t freeMemorySizeMap[32];
-	numFreeMemoryRegions = emmalloc_compute_free_dynamic_memory_fragmentation_map(freeMemorySizeMap);
-	printf("numFreeMemoryRegions: %zu\n", numFreeMemoryRegions);
-	for(int i = 0; i < 32; ++i)
-		printf("%zu ", freeMemorySizeMap[i]);
-	printf("\n");
+  emmalloc_dump_free_dynamic_memory_fragmentation_map();
 	printf("emmalloc_unclaimed_heap_memory  : %zu\n", round_to_4k(emmalloc_unclaimed_heap_memory()));
 }

--- a/test/core/test_emmalloc_memory_statistics.out
+++ b/test/core/test_emmalloc_memory_statistics.out
@@ -3,5 +3,36 @@ emmalloc_validate_memory_regions: 0
 emmalloc_dynamic_heap_size      : 106971424
 emmalloc_free_dynamic_memory    : 4210892
 numFreeMemoryRegions: 3
-0 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 
+Free memory regions of size [1,2[ bytes: 0 regions
+Free memory regions of size [2,4[ bytes: 0 regions
+Free memory regions of size [4,8[ bytes: 0 regions
+Free memory regions of size [8,16[ bytes: 0 regions
+Free memory regions of size [16,32[ bytes: 0 regions
+Free memory regions of size [32,64[ bytes: 0 regions
+Free memory regions of size [64,128[ bytes: 0 regions
+Free memory regions of size [128,256[ bytes: 1 regions
+Free memory regions of size [256,512[ bytes: 0 regions
+Free memory regions of size [512,1024[ bytes: 0 regions
+Free memory regions of size [1024,2048[ bytes: 0 regions
+Free memory regions of size [2048,4096[ bytes: 0 regions
+Free memory regions of size [4096,8192[ bytes: 0 regions
+Free memory regions of size [8192,16384[ bytes: 0 regions
+Free memory regions of size [16384,32768[ bytes: 1 regions
+Free memory regions of size [32768,65536[ bytes: 0 regions
+Free memory regions of size [65536,131072[ bytes: 0 regions
+Free memory regions of size [131072,262144[ bytes: 0 regions
+Free memory regions of size [262144,524288[ bytes: 0 regions
+Free memory regions of size [524288,1048576[ bytes: 0 regions
+Free memory regions of size [1048576,2097152[ bytes: 0 regions
+Free memory regions of size [2097152,4194304[ bytes: 0 regions
+Free memory regions of size [4194304,8388608[ bytes: 1 regions
+Free memory regions of size [8388608,16777216[ bytes: 0 regions
+Free memory regions of size [16777216,33554432[ bytes: 0 regions
+Free memory regions of size [33554432,67108864[ bytes: 0 regions
+Free memory regions of size [67108864,134217728[ bytes: 0 regions
+Free memory regions of size [134217728,268435456[ bytes: 0 regions
+Free memory regions of size [268435456,536870912[ bytes: 0 regions
+Free memory regions of size [536870912,1073741824[ bytes: 0 regions
+Free memory regions of size [1073741824,2147483648[ bytes: 0 regions
+Free memory regions of size [2147483648,4294967296[ bytes: 0 regions
 emmalloc_unclaimed_heap_memory  : 27176960

--- a/test/core/test_emmalloc_memory_statistics64.out
+++ b/test/core/test_emmalloc_memory_statistics64.out
@@ -3,5 +3,36 @@ emmalloc_validate_memory_regions: 0
 emmalloc_dynamic_heap_size      : 106971712
 emmalloc_free_dynamic_memory    : 4211104
 numFreeMemoryRegions: 3
-0 0 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 
+Free memory regions of size [1,2[ bytes: 0 regions
+Free memory regions of size [2,4[ bytes: 0 regions
+Free memory regions of size [4,8[ bytes: 0 regions
+Free memory regions of size [8,16[ bytes: 0 regions
+Free memory regions of size [16,32[ bytes: 0 regions
+Free memory regions of size [32,64[ bytes: 0 regions
+Free memory regions of size [64,128[ bytes: 0 regions
+Free memory regions of size [128,256[ bytes: 0 regions
+Free memory regions of size [256,512[ bytes: 1 regions
+Free memory regions of size [512,1024[ bytes: 0 regions
+Free memory regions of size [1024,2048[ bytes: 0 regions
+Free memory regions of size [2048,4096[ bytes: 0 regions
+Free memory regions of size [4096,8192[ bytes: 0 regions
+Free memory regions of size [8192,16384[ bytes: 0 regions
+Free memory regions of size [16384,32768[ bytes: 1 regions
+Free memory regions of size [32768,65536[ bytes: 0 regions
+Free memory regions of size [65536,131072[ bytes: 0 regions
+Free memory regions of size [131072,262144[ bytes: 0 regions
+Free memory regions of size [262144,524288[ bytes: 0 regions
+Free memory regions of size [524288,1048576[ bytes: 0 regions
+Free memory regions of size [1048576,2097152[ bytes: 0 regions
+Free memory regions of size [2097152,4194304[ bytes: 0 regions
+Free memory regions of size [4194304,8388608[ bytes: 1 regions
+Free memory regions of size [8388608,16777216[ bytes: 0 regions
+Free memory regions of size [16777216,33554432[ bytes: 0 regions
+Free memory regions of size [33554432,67108864[ bytes: 0 regions
+Free memory regions of size [67108864,134217728[ bytes: 0 regions
+Free memory regions of size [134217728,268435456[ bytes: 0 regions
+Free memory regions of size [268435456,536870912[ bytes: 0 regions
+Free memory regions of size [536870912,1073741824[ bytes: 0 regions
+Free memory regions of size [1073741824,2147483648[ bytes: 0 regions
+Free memory regions of size [2147483648,4294967296[ bytes: 0 regions
 emmalloc_unclaimed_heap_memory  : 27176960


### PR DESCRIPTION
Move printing of emmalloc dynamic memory fragmentation map into emmalloc itself, so it can be reused in different test files.