### PR TITLE
Fix "test/runner benchmark" to work

### DIFF
--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -399,7 +399,7 @@ if config.NODE_JS and config.NODE_JS in config.JS_ENGINES:
     ]
   else:
     benchmarkers += [
-      # EmscriptenBenchmarker('Node.js', config.NODE_JS),
+      EmscriptenBenchmarker('Node.js', config.NODE_JS),
     ]
 
 


### PR DESCRIPTION
For some reason JS benchmarking was disabled in the benchmark suite, restore it so that test/runner benchmark works again.