### PR TITLE
Improve error messages from jsifier

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,7 @@ See docs/process.md for more on how version tagging works.
   state normally stored on the stack is hidden within the runtime and does not
   occupy linear memory at all.  The default for `DEFAULT_PTHREAD_STACK_SIZE` was
   also reduced from 2MB to 64KB to match.
+- Improved error messages from custom JS libraries. (#18266)
 
 3.1.26 - 11/17/22
 -----------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,7 +33,7 @@ See docs/process.md for more on how version tagging works.
   state normally stored on the stack is hidden within the runtime and does not
   occupy linear memory at all.  The default for `DEFAULT_PTHREAD_STACK_SIZE` was
   also reduced from 2MB to 64KB to match.
-- Improved error messages from custom JS libraries. (#18266)
+- Improved error messages for writing custom JS libraries. (#18266)
 
 3.1.26 - 11/17/22
 -----------------

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -8,6 +8,7 @@
 // LLVM => JavaScript compiler, main entry point
 
 const fs = require('fs');
+global.vm = require('vm');
 global.assert = require('assert');
 global.nodePath = require('path');
 
@@ -36,7 +37,7 @@ global.read = (filename) => {
 };
 
 function load(f) {
-  eval.call(null, read(f));
+  (0, eval)(read(f) + '//# sourceURL=' + find(f));
 };
 
 // Basic utilities
@@ -92,7 +93,7 @@ try {
     // Compiler failed on internal compiler error!
     printErr('Internal compiler error in src/compiler.js!');
     printErr('Please create a bug report at https://github.com/emscripten-core/emscripten/issues/');
-    printErr('with a log of the build and the input files used to run. Exception message: "' + err + '" | ' + err.stack);
+    printErr('with a log of the build and the input files used to run. Exception message: "' + (err.stack || err));
   }
 
   // Work around a node.js bug where stdout buffer is not flushed at process exit:

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -526,7 +526,7 @@ function ${name}(${args}) {
     const post = processMacros(preprocess(read(postFile), postFile));
     print(post);
 
-    print(processMacros(preprocess(shellParts[1], shellFile)));
+    print(processMacros(preprocess(shellParts[1], shellFile, shellParts[0].match(/\n/g).length)));
 
     print('\n//FORWARDED_DATA:' + JSON.stringify({
       librarySymbols: librarySymbols,

--- a/src/modules.js
+++ b/src/modules.js
@@ -212,26 +212,17 @@ global.LibraryManager = {
       }
       try {
         processed = processMacros(preprocess(src, filename));
-        eval(processed);
+        vm.runInThisContext(processed, { filename: filename.replace(/\.\w+$/, '.preprocessed$&') });
       } catch (e) {
-        const details = [e, e.lineNumber ? `line number: ${e.lineNumber}` : ''];
+        error(`failure to execute js library "${filename}":`);
         if (VERBOSE) {
-          details.push((e.stack || '').toString().replace('Object.<anonymous>', filename));
-        }
-        if (processed) {
-          error(`failure to execute js library "${filename}": ${details}`);
-          if (VERBOSE) {
+          if (processed) {
             error(`preprocessed source (you can run a js engine on this to get a clearer error message sometimes):\n=============\n${processed}\n=============`);
           } else {
-            error('use -sVERBOSE to see more details');
+            error(`original source:\n=============\n${src}\n=============`);
           }
         } else {
-          error(`failure to process js library "${filename}": ${details}`);
-          if (VERBOSE) {
-            error(`original source:\n=============\n${src}\n=============`);
-          } else {
-            error('use -sVERBOSE to see more details');
-          }
+          error('use -sVERBOSE to see more details');
         }
         throw e;
       } finally {

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -8,7 +8,7 @@
  * Tests live in test/other/test_parseTools.js.
  */
 
-const FOUR_GB = 4 * 1024 * 1024 * 1024;
+globalThis.FOUR_GB = 4 * 1024 * 1024 * 1024;
 const FLOAT_TYPES = new Set(['float', 'double']);
 
 let currentlyParsedFilename = '';

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -34,7 +34,7 @@ function processMacros(text) {
 // Also handles #include x.js (similar to C #include <file>)
 // Param filenameHint can be passed as a description to identify the file that is being processed, used
 // to locate errors for reporting and for html files to stop expansion between <style> and </style>.
-function preprocess(text, filenameHint) {
+function preprocess(text, filenameHint, lineOffset = 0) {
   if (EXPORT_ES6 && USE_ES6_IMPORT_META) {
     // `eval`, Terser and Closure don't support module syntax; to allow it,
     // we need to temporarily replace `import.meta` and `await import` usages
@@ -63,97 +63,92 @@ function preprocess(text, filenameHint) {
   let emptyLine = false;
 
   try {
-    for (let i = 0; i < lines.length; i++) {
-      let line = lines[i];
-      try {
-        if (line[line.length - 1] === '\r') {
-          line = line.substr(0, line.length - 1); // Windows will have '\r' left over from splitting over '\r\n'
-        }
-        if (isHtml && line.includes('<style') && !inStyle) {
-          inStyle = true;
-        }
-        if (isHtml && line.includes('</style') && inStyle) {
-          inStyle = false;
-        }
+    for (let [i, line] of lines.entries()) {
+      i += lineOffset; // adjust line number in case this is e.g. 2nd part of shell.js
+      if (line[line.length - 1] === '\r') {
+        line = line.substr(0, line.length - 1); // Windows will have '\r' left over from splitting over '\r\n'
+      }
+      if (isHtml && line.includes('<style') && !inStyle) {
+        inStyle = true;
+      }
+      if (isHtml && line.includes('</style') && inStyle) {
+        inStyle = false;
+      }
 
-        if (!inStyle) {
-          const trimmed = line.trim();
-          if (trimmed.startsWith('#')) {
-            const first = trimmed.split(' ', 1)[0];
-            if (first == '#if' || first == '#ifdef' || first == '#elif') {
-              if (first == '#ifdef') {
-                warn('use of #ifdef in js library.  Use #if instead.');
-              }
-              if (first == '#elif') {
-                const curr = showStack.pop();
-                if (curr == SHOW || curr == IGNORE_ALL) {
-                  // If we showed to previous block we enter the IGNORE_ALL state
-                  // and stay there until endif is seen
-                  showStack.push(IGNORE_ALL);
-                  continue;
-                }
-              }
-              const after = trimmed.substring(trimmed.indexOf(' '));
-              const truthy = !!eval(after);
-              showStack.push(truthy ? SHOW : IGNORE);
-            } else if (first === '#include') {
-              if (showCurrentLine()) {
-                let filename = line.substr(line.indexOf(' ') + 1);
-                if (filename.startsWith('"')) {
-                  filename = filename.substr(1, filename.length - 2);
-                }
-                const included = read(filename);
-                const result = preprocess(included, filename);
-                if (result) {
-                  ret += `// include: ${filename}\n`;
-                  ret += result;
-                  ret += `// end include: ${filename}\n`;
-                }
-              }
-            } else if (first === '#else') {
-              assert(showStack.length > 0);
-              const curr = showStack.pop();
-              if (curr == IGNORE) {
-                showStack.push(SHOW);
-              } else {
-                showStack.push(IGNORE);
-              }
-            } else if (first === '#endif') {
-              assert(showStack.length > 0);
-              showStack.pop();
-            } else if (first === '#warning') {
-              if (showCurrentLine()) {
-                printErr(`${filenameHint}:${i + 1}: #warning ${trimmed.substring(trimmed.indexOf(' ')).trim()}`);
-              }
-            } else if (first === '#error') {
-              if (showCurrentLine()) {
-                error(`${filenameHint}:${i + 1}: #error ${trimmed.substring(trimmed.indexOf(' ')).trim()}`);
-              }
-            } else {
-              throw new Error(`Unknown preprocessor directive on line ${i}: ``${line}```);
+      if (!inStyle) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('#')) {
+          const first = trimmed.split(' ', 1)[0];
+          if (first == '#if' || first == '#ifdef' || first == '#elif') {
+            if (first == '#ifdef') {
+              warn('use of #ifdef in js library.  Use #if instead.');
             }
-          } else {
-            if (showCurrentLine()) {
-              // Never emit more than one empty line at a time.
-              if (emptyLine && !line) {
+            if (first == '#elif') {
+              const curr = showStack.pop();
+              if (curr == SHOW || curr == IGNORE_ALL) {
+                // If we showed to previous block we enter the IGNORE_ALL state
+                // and stay there until endif is seen
+                showStack.push(IGNORE_ALL);
                 continue;
               }
-              ret += line + '\n';
-              if (!line) {
-                emptyLine = true;
-              } else {
-                emptyLine = false;
+            }
+            const after = trimmed.substring(trimmed.indexOf(' '));
+            const truthy = !!vm.runInThisContext(after, { filename: filenameHint, lineOffset: i, columnOffset: line.indexOf(after) });
+            showStack.push(truthy ? SHOW : IGNORE);
+          } else if (first === '#include') {
+            if (showCurrentLine()) {
+              let filename = line.substr(line.indexOf(' ') + 1);
+              if (filename.startsWith('"')) {
+                filename = filename.substr(1, filename.length - 2);
+              }
+              const included = read(filename);
+              const result = preprocess(included, filename);
+              if (result) {
+                ret += `// include: ${filename}\n`;
+                ret += result;
+                ret += `// end include: ${filename}\n`;
               }
             }
+          } else if (first === '#else') {
+            assert(showStack.length > 0);
+            const curr = showStack.pop();
+            if (curr == IGNORE) {
+              showStack.push(SHOW);
+            } else {
+              showStack.push(IGNORE);
+            }
+          } else if (first === '#endif') {
+            assert(showStack.length > 0);
+            showStack.pop();
+          } else if (first === '#warning') {
+            if (showCurrentLine()) {
+              printErr(`${filenameHint}:${i + 1}: #warning ${trimmed.substring(trimmed.indexOf(' ')).trim()}`);
+            }
+          } else if (first === '#error') {
+            if (showCurrentLine()) {
+              error(`${filenameHint}:${i + 1}: #error ${trimmed.substring(trimmed.indexOf(' ')).trim()}`);
+            }
+          } else {
+            throw new Error(`${filenameHint}:${i + 1}: Unknown preprocessor directive ${first}`);
           }
-        } else { // !inStyle
+        } else {
           if (showCurrentLine()) {
+            // Never emit more than one empty line at a time.
+            if (emptyLine && !line) {
+              continue;
+            }
             ret += line + '\n';
+            if (!line) {
+              emptyLine = true;
+            } else {
+              emptyLine = false;
+            }
           }
         }
-      } catch (e) {
-        printErr('parseTools.js preprocessor error in ' + filenameHint + ':' + (i + 1) + ': \"' + line + '\"!');
-        throw e;
+      } else { // !inStyle
+        if (showCurrentLine()) {
+          ret += line + '\n';
+        }
       }
     }
     assert(showStack.length == 0, `preprocessing error in file ${filenameHint}, \

--- a/tools/preprocessor.js
+++ b/tools/preprocessor.js
@@ -16,6 +16,7 @@
 
 const fs = require('fs');
 const path = require('path');
+global.vm = require('vm');
 
 const arguments_ = process['argv'].slice(2);
 const debug = false;
@@ -46,7 +47,7 @@ global.read = function(filename) {
 };
 
 global.load = function(f) {
-  eval.call(null, read(f));
+  (0, eval)(read(f) + '//# sourceURL=' + find(f));
 };
 
 const settingsFile = arguments_[0];


### PR DESCRIPTION
Got a bit tired of opaque error messages coming from JS library processing when I accidentally introduce a syntax error, so here's a simple but effective improvement made possible by replacing `eval` with `vm.runScriptInContext`.

I'm actually not sure why Node.js doesn't just use the same error output for eval as well, but at least this helps 🤷‍♂️

While at it, also added filenames to `load` functions used by compiler.js itself, so the stacktrace contains actual filenames instead of nested evals and did few other minor cleanups to avoid error message duplication.

Example post-processed JS error message before:

```
error: failure to execute js library "library_pthread.js":
error: use -sVERBOSE to see more details
Internal compiler error in src/compiler.js!
Please create a bug report at https://github.com/emscripten-core/emscripten/issues/
with a log of the build and the input files used to run. Exception message: "SyntaxError: Unexpected token 'function'" | SyntaxError: Unexpected token 'function'
    at Object.load (eval at load (C:\Users\me\Documents\emscripten\src\compiler.js:39:8), <anonymous>:215:14)
    at runJSify (eval at load (C:\Users\me\Documents\emscripten\src\compiler.js:39:8), <anonymous>:78:18)
    ...
```

After:

```
error: failure to execute js library "library_pthread.js":
error: use -sVERBOSE to see more details
Internal compiler error in src/compiler.js!
Please create a bug report at https://github.com/emscripten-core/emscripten/issues/
with a log of the build and the input files used to run. Exception message: "library_pthread.preprocessed.js:330
  $spawnThread function(threadParams) {
               ^^^^^^^^

SyntaxError: Unexpected token 'function'
    at new Script (vm.js:102:7)
    at createScript (vm.js:262:10)
    at Object.runInThisContext (vm.js:310:10)
    at Object.load (C:\Users\me\Documents\emscripten\src\modules.js:215:12)
    at runJSify (C:\Users\me\Documents\emscripten\src\jsifier.js:78:18)
    ...
```



Example preprocessor error message before:

```
parseTools.js preprocessor error in shell_minimal.js:126: "#if MIN_CHROME_VERSION < 45 || MINEDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 90000"!
Internal compiler error in src/compiler.js!
Please create a bug report at https://github.com/emscripten-core/emscripten/issues/
with a log of the build and the input files used to run. Exception message: "ReferenceError: MINEDGE_VERSION is not defined" | ReferenceError: MINEDGE_VERSION is not defined
    at eval (eval at preprocess (eval at load (C:\Users\me\Documents\emscripten\src\compiler.js:39:8)), <anonymous>:1:29)        
    at preprocess (eval at load (C:\Users\me\Documents\emscripten\src\compiler.js:39:8), <anonymous>:97:32)
    at finalCombiner (eval at load (C:\Users\me\Documents\emscripten\src\compiler.js:39:8), <anonymous>:475:25)
    at runJSify (eval at load (C:\Users\me\Documents\emscripten\src\compiler.js:39:8), <anonymous>:543:3)
    ...
```

After:

```
Internal compiler error in src/compiler.js!
Please create a bug report at https://github.com/emscripten-core/emscripten/issues/
with a log of the build and the input files used to run. Exception message: "shell_minimal.js:126
 MIN_CHROME_VERSION < 45 || MINEDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 90000
                            ^

ReferenceError: MINEDGE_VERSION is not defined
    at shell_minimal.js:126:32
    at Script.runInThisContext (vm.js:134:12)
    at Object.runInThisContext (vm.js:310:38)
    at preprocess (C:\Users\me\Documents\emscripten\src\parseTools.js:96:33)
    at finalCombiner (C:\Users\me\Documents\emscripten\src\jsifier.js:475:25)
    at runJSify (C:\Users\me\Documents\emscripten\src\jsifier.js:543:3)
    ...
```