### PR TITLE
Remove declaration of undefined function __getDynamicPointerType. NFC

### DIFF
--- a/site/source/docs/api_reference/bind.h.rst
+++ b/site/source/docs/api_reference/bind.h.rst
@@ -134,13 +134,7 @@ select_overload and select_const
 
 
 Functions
-=============
-
-.. cpp:function:: void* __getDynamicPointerType(void* p)
-
-
-   :param void* p
-
+=========
 
 .. cpp:function:: void function()
 

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -502,8 +502,6 @@ EMSCRIPTEN_ALWAYS_INLINE const char* getSignature(Return (*)(Args...)) {
 // FUNCTIONS
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" void* __getDynamicPointerType(void* p);
-
 template<typename ReturnType, typename... Args, typename... Policies>
 void function(const char* name, ReturnType (*fn)(Args...), Policies...) {
     using namespace internal;


### PR DESCRIPTION
I believe this function was removed from the codebase in 78568fe4c2ba8fd014fd8af23453ac8b2d0728f5.