### PR TITLE
[emsymbolizer] Restrict choices of source

### DIFF
--- a/emsymbolizer.py
+++ b/emsymbolizer.py
@@ -230,8 +230,8 @@ def main(args):
 
 def get_args():
   parser = argparse.ArgumentParser()
-  parser.add_argument('-s', '--source', help='Force debug info source type',
-                      default=())
+  parser.add_argument('-s', '--source', choices=['dwarf', 'sourcemap'],
+                      help='Force debug info source type', default=())
   parser.add_argument('-f', '--file', action='store',
                       help='Force debug info source file')
   parser.add_argument('-t', '--addrtype', choices=['code', 'file'],


### PR DESCRIPTION
Currently `-s`/`--source` option can take any string, but only `dwarf` and `sourcemap` are meaningful values for that. This restricts the choices to those two values in `argparse`. This also has a benefit of showing the possible values in the help message, so you can know what to add after `-s` without checking the source code.