### PR TITLE
Remove EMSCRIPTEN_ROOT from config file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,11 @@ See docs/process.md for more on how version tagging works.
 3.1.28 (in development)
 -----------------------
 - musl libc updated from v1.2.2 to v1.2.3. (#18270)
+- The default emscripten config file no longer contains `EMSCRIPTEN_ROOT`.  This
+  setting has long been completely ignored by emscripten itself. For
+  applications that wish to know where emscripten is installed looking for
+  `emcc` in the `PATH` has long been the recommended method (i.e. `which emcc`).
+  (#18279)
 
 3.1.27 - 11/29/22
 -----------------

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -234,7 +234,6 @@ class other(RunnerCore):
         self.run_process([compiler, '--generate-config'])
         self.assertExists(config_path)
         config_contents = read_file(config_path)
-        self.assertContained('EMSCRIPTEN_ROOT', config_contents)
         self.assertContained('LLVM_ROOT', config_contents)
         os.remove(config_path)
 

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -208,7 +208,7 @@ class sanity(RunnerCore):
     self.assertNotContained('}}}', config_data)
     self.assertContained('{{{', template_data)
     self.assertContained('}}}', template_data)
-    for content in ['EMSCRIPTEN_ROOT', 'LLVM_ROOT', 'NODE_JS', 'JS_ENGINES']:
+    for content in ['LLVM_ROOT', 'NODE_JS', 'JS_ENGINES']:
       self.assertContained(content, config_data)
 
     # The guessed config should be ok
@@ -268,17 +268,6 @@ class sanity(RunnerCore):
         else:
           output = self.check_working(EMCC)
           self.assertNotContained(LLVM_WARNING, output)
-
-  def test_emscripten_root(self):
-    # The correct path
-    restore_and_set_up()
-    add_to_config("EMSCRIPTEN_ROOT = '%s'" % path_from_root())
-    self.check_working(EMCC)
-
-    # The correct path with extra stuff
-    restore_and_set_up()
-    add_to_config("EMSCRIPTEN_ROOT = '%s'" % (path_from_root() + os.path.sep))
-    self.check_working(EMCC)
 
   def test_node(self):
     NODE_WARNING = 'node version appears too old'

--- a/tools/config.py
+++ b/tools/config.py
@@ -176,7 +176,6 @@ def generate_config(path):
   config_data = config_data.splitlines()[3:] # remove the initial comment
   config_data = '\n'.join(config_data)
   # autodetect some default paths
-  config_data = config_data.replace('\'{{{ EMSCRIPTEN_ROOT }}}\'', repr(__rootpath__))
   llvm_root = os.path.dirname(which('llvm-dis') or '/usr/bin/llvm-dis')
   config_data = config_data.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
 
@@ -199,10 +198,9 @@ It contains our best guesses for the important paths, which are:
   LLVM_ROOT       = %s
   BINARYEN_ROOT   = %s
   NODE_JS         = %s
-  EMSCRIPTEN_ROOT = %s
 
 Please edit the file if any of those are incorrect.\
-''' % (path, llvm_root, binaryen_root, node, __rootpath__), file=sys.stderr)
+''' % (path, llvm_root, binaryen_root, node), file=sys.stderr)
 
 
 # Emscripten configuration is done through the --em-config command line option

--- a/tools/config_template.py
+++ b/tools/config_template.py
@@ -12,10 +12,6 @@
 # is not valid, but LLVM='c:\\llvm\\' and LLVM='c:/llvm/'
 # are.
 
-# This is used by external projects in order to find emscripten.  It is not used
-# by emscripten itself.
-EMSCRIPTEN_ROOT = '{{{ EMSCRIPTEN_ROOT }}}' # directory
-
 LLVM_ROOT = '{{{ LLVM_ROOT }}}' # directory
 BINARYEN_ROOT = '{{{ BINARYEN_ROOT }}}' # directory
 


### PR DESCRIPTION
I tried to do this once before back in #7254 and then that got temporarily revert in #7411.

The specific issue with godot was addressed in
7998745237bee472ec7d899424a0f4357dfbf9c0

Folks who want to find out where emscripten is still have two different choices that don't involve parsing the config file by hand:

1. `which emcc`
2. `em-config EMSCRIPTEN_ROOT`