### PR TITLE
Handle Ctrl+C in the test runner on Windows. NFC

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -19,7 +19,8 @@ NUM_CORES = None
 def init_worker():
   # Prevent the "Terminate batch job (Y/N)?" dialog from intercepting Ctrl+C
   # on Windows.
-  os.close(0)
+  devnull = os.open(os.devnull, os.O_RDONLY)
+  os.dup2(devnull, sys.stdin.fileno())
 
 
 def run_test(test):

--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -15,11 +15,12 @@ import common
 
 NUM_CORES = None
 
-
-def run_test(test):
+def init_worker():
   # Prevent the "Terminate batch job (Y/N)?" dialog from intercepting Ctrl+C
   # on Windows.
   os.close(0)
+
+def run_test(test):
   olddir = os.getcwd()
   result = BufferedParallelTestResult()
   temp_dir = tempfile.mkdtemp(prefix='emtest_')
@@ -57,7 +58,7 @@ class ParallelTestSuite(unittest.BaseTestSuite):
     tests = list(self.reversed_tests())
     use_cores = min(self.max_cores, len(tests), num_cores())
     print('Using %s parallel test processes' % use_cores)
-    pool = multiprocessing.Pool(use_cores)
+    pool = multiprocessing.Pool(use_cores, init_worker)
     results = [pool.apply_async(run_test, (t,)) for t in tests]
     results = [r.get() for r in results]
     pool.close()

--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -17,6 +17,9 @@ NUM_CORES = None
 
 
 def run_test(test):
+  # Prevent the "Terminate batch job (Y/N)?" dialog from intercepting Ctrl+C
+  # on Windows.
+  os.close(0)
   olddir = os.getcwd()
   result = BufferedParallelTestResult()
   temp_dir = tempfile.mkdtemp(prefix='emtest_')

--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -15,10 +15,12 @@ import common
 
 NUM_CORES = None
 
+
 def init_worker():
   # Prevent the "Terminate batch job (Y/N)?" dialog from intercepting Ctrl+C
   # on Windows.
   os.close(0)
+
 
 def run_test(test):
   olddir = os.getcwd()


### PR DESCRIPTION
After some trial and error, it appears that closing stdin via os.close in the worker is enough for the cmd.exe not to wait with the "Terminate batch job (Y/N)" dialog in background, so the tests finally exit as expected.

Fixes #18213.