### PR TITLE
Search for binaryen/node/llvm in path if config values not specified.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,6 +37,10 @@ See docs/process.md for more on how version tagging works.
   affect correct usages as the function has always returned different values on
   different platforms, and is clearly documented as "only meaningful in
   comparison to other calls to this function". (#18267)
+- Emscripten will now search your PATH for binaryen, llvm, and node if the
+  corresponding config file settings (`BINARYEN_ROOT`, `LLVM_ROOT`, `NODE_JS`)
+  are not set.  In theory this allows emscripten to run with an empty config
+  file.
 
 3.1.27 - 11/29/22
 -----------------

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -671,7 +671,17 @@ fi
     self.check_working([EMCC, test_file('hello_world.c')], 'BINARYEN_ROOT is set to empty value in %s' % EM_CONFIG)
 
     open(EM_CONFIG, 'a').write('\ndel BINARYEN_ROOT\n')
-    self.check_working([EMCC, test_file('hello_world.c')], 'BINARYEN_ROOT is not defined in %s' % EM_CONFIG)
+    self.check_working([EMCC, test_file('hello_world.c')], 'BINARYEN_ROOT not set in config (%s), and `wasm-opt` not found in PATH' % EM_CONFIG)
+
+  def test_empty_config(self):
+    restore_and_set_up()
+    make_fake_tool(self.in_dir('fake', 'wasm-opt'), 'foo')
+    make_fake_clang(self.in_dir('fake', 'clang'), EXPECTED_LLVM_VERSION)
+    make_fake_tool(self.in_dir('fake', 'llvm-ar'), EXPECTED_LLVM_VERSION)
+    make_fake_tool(self.in_dir('fake', 'llvm-nm'), EXPECTED_LLVM_VERSION)
+    open(EM_CONFIG, 'w').close()
+    with env_modify({'PATH': self.in_dir('fake') + os.pathsep + os.environ['PATH']}):
+      self.check_working([EMCC])
 
   def test_embuilder_force(self):
     restore_and_set_up()


### PR DESCRIPTION
This allows for maintainers to emscripten packages to simply configure that right tools in the PATH, and can completely avoid the need for a config file.