### PR TITLE
Avoid exporting malloc/free in all pthreads builds. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2618,7 +2618,6 @@ def phase_linker_setup(options, state, newargs):
   if settings.RELOCATABLE or \
      settings.BUILD_AS_WORKER or \
      settings.USE_WEBGPU or \
-     settings.USE_PTHREADS or \
      settings.OFFSCREENCANVAS_SUPPORT or \
      settings.LEGACY_GL_EMULATION or \
      not settings.DISABLE_EXCEPTION_CATCHING or \

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -663,7 +663,11 @@ var LibraryPThread = {
   // allocations from __pthread_create_js we could also remove this.
   __pthread_create_js__noleakcheck: true,
   __pthread_create_js__sig: 'iiiii',
-  __pthread_create_js__deps: ['$spawnThread', 'pthread_self', '$pthreadCreateProxied'],
+  __pthread_create_js__deps: ['$spawnThread', 'pthread_self', '$pthreadCreateProxied',
+#if OFFSCREENCANVAS_SUPPORT
+    'malloc',
+#endif
+  ],
   __pthread_create_js: function(pthread_ptr, attr, startRoutine, arg) {
     if (typeof SharedArrayBuffer == 'undefined') {
       err('Current environment does not support SharedArrayBuffer, pthreads are not available!');
@@ -773,7 +777,7 @@ var LibraryPThread = {
         return {{{ cDefine('EINVAL') }}}; // Hitting this might indicate an implementation bug or some other internal error
       }
     }
-#endif
+#endif // OFFSCREENCANVAS_SUPPORT
 
     // Synchronously proxy the thread creation to main thread if possible. If we
     // need to transfer ownership of objects, then proxy asynchronously via

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -149,6 +149,9 @@ var LibraryGL = {
 #if GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS
   // If GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS is enabled, GL.initExtensions() will call to initialize these.
   $GL__deps: [
+#if USE_PTHREADS
+    'malloc', // Needed by registerContext
+#endif
 #if MIN_WEBGL_VERSION == 1
     '_webgl_enable_ANGLE_instanced_arrays',
     '_webgl_enable_OES_vertex_array_object',

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4098,9 +4098,10 @@ Module["preRun"].push(function () {
   # Test that it is possible to synchronously call a JavaScript function on the main thread and get a return value back.
   @requires_threads
   def test_pthread_call_sync_on_main_thread(self):
+    self.set_setting('EXPORTED_FUNCTIONS', '_main,_malloc')
     self.btest_exit(test_file('pthread/call_sync_on_main_thread.c'), args=['-O3', '-sUSE_PTHREADS', '-sPROXY_TO_PTHREAD', '-DPROXY_TO_PTHREAD=1', '--js-library', test_file('pthread/call_sync_on_main_thread.js')])
     self.btest_exit(test_file('pthread/call_sync_on_main_thread.c'), args=['-O3', '-sUSE_PTHREADS', '-DPROXY_TO_PTHREAD=0', '--js-library', test_file('pthread/call_sync_on_main_thread.js')])
-    self.btest_exit(test_file('pthread/call_sync_on_main_thread.c'), args=['-Oz', '-DPROXY_TO_PTHREAD=0', '--js-library', test_file('pthread/call_sync_on_main_thread.js'), '-sEXPORTED_FUNCTIONS=_main,_malloc'])
+    self.btest_exit(test_file('pthread/call_sync_on_main_thread.c'), args=['-Oz', '-DPROXY_TO_PTHREAD=0', '--js-library', test_file('pthread/call_sync_on_main_thread.js')])
 
   # Test that it is possible to asynchronously call a JavaScript function on the main thread.
   @requires_threads

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11595,6 +11595,7 @@ exec "$@"
         cmd.append('-sASYNCIFY')
       if function.startswith('emscripten_webgl_') or 'offscreencanvas' in function:
         cmd.append('-sOFFSCREENCANVAS_SUPPORT')
+        cmd.append('-sUSE_PTHREADS')
       if function.startswith('wgpu'):
         cmd.append('-sUSE_WEBGPU')
       if function.startswith('__cxa_'):

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -137,7 +137,6 @@ _deps_info = {
   'emscripten_set_touchstart_callback_on_thread': ['malloc'],
   'emscripten_set_visibilitychange_callback_on_thread': ['malloc'],
   'emscripten_set_wheel_callback_on_thread': ['malloc'],
-  'emscripten_webgl_create_context': ['malloc'],
   'emscripten_webgl_get_parameter_utf8': ['malloc'],
   'emscripten_webgl_get_program_info_log_utf8': ['malloc'],
   'emscripten_webgl_get_shader_info_log_utf8': ['malloc'],
@@ -206,16 +205,21 @@ def get_deps_info():
     _deps_info['__cxa_find_matching_catch_7'] = ['__cxa_can_catch', 'setTempRet0']
     _deps_info['__cxa_find_matching_catch_8'] = ['__cxa_can_catch', 'setTempRet0']
     _deps_info['__cxa_find_matching_catch_9'] = ['__cxa_can_catch', 'setTempRet0']
+  if settings.USE_PTHREADS and settings.OFFSCREENCANVAS_SUPPORT:
+    _deps_info['pthread_create'] = ['malloc']
   if settings.FILESYSTEM and settings.SYSCALLS_REQUIRE_FILESYSTEM:
     _deps_info['mmap'] = ['emscripten_builtin_memalign']
-  if settings.USE_PTHREADS and settings.OFFSCREEN_FRAMEBUFFER:
-    # When OFFSCREEN_FRAMEBUFFER is defined these functions are defined in native code,
-    # otherwise they are defined in src/library_html5_webgl.js.
-    _deps_info['emscripten_webgl_destroy_context'] = ['emscripten_webgl_make_context_current', 'emscripten_webgl_get_current_context']
-  if settings.USE_PTHREADS and settings.OFFSCREENCANVAS_SUPPORT:
-    _deps_info['emscripten_set_offscreencanvas_size_on_target_thread'] = ['emscripten_dispatch_to_thread_', 'malloc', 'free']
-    _deps_info['emscripten_set_offscreencanvas_size_on_target_thread_js'] = ['malloc']
   if settings.USE_PTHREADS:
+    _deps_info['glutCreateWindow'] = ['malloc']
+    _deps_info['emscripten_webgl_create_context'] = ['malloc']
+    _deps_info['emscripten_webgl_destroy_context'] = ['free']
     _deps_info['emscripten_set_canvas_element_size_calling_thread'] = ['emscripten_dispatch_to_thread_']
+    if settings.OFFSCREEN_FRAMEBUFFER:
+      # When OFFSCREEN_FRAMEBUFFER is defined these functions are defined in native code,
+      # otherwise they are defined in src/library_html5_webgl.js.
+      _deps_info['emscripten_webgl_destroy_context'] += ['emscripten_webgl_make_context_current', 'emscripten_webgl_get_current_context']
+    if settings.OFFSCREENCANVAS_SUPPORT:
+      _deps_info['emscripten_set_offscreencanvas_size_on_target_thread'] = ['emscripten_dispatch_to_thread_', 'malloc', 'free']
+      _deps_info['emscripten_set_offscreencanvas_size_on_target_thread_js'] = ['malloc']
 
   return _deps_info


### PR DESCRIPTION
The JS code for pthread_create does actually depend on malloc or free except in the case of OFFSCREENCANVASES_TO_PTHREAD.