### PR TITLE
Extract a loadWasmModuleToAllWorkers helper. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -406,13 +406,15 @@ var LibraryPThread = {
 #if !PTHREAD_POOL_SIZE
       onMaybeReady();
 #else
-      // Instantiation is synchronous in pthreads and we assert on run dependencies.
+      // Instantiation is synchronous in pthreads.
       if (
         ENVIRONMENT_IS_PTHREAD
 #if WASM_WORKERS
         || ENVIRONMENT_IS_WASM_WORKER
 #endif
-      ) return onMaybeReady();
+      ) {
+        return onMaybeReady();
+      }
       let promises = PThread.unusedWorkers.map(PThread.loadWasmModuleToWorker);
 #if PTHREAD_POOL_DELAY_LOAD
       // PTHREAD_POOL_DELAY_LOAD means we want to proceed synchronously without


### PR DESCRIPTION
This is a small refactor designed to make initialization of the PThread pool cleaner and to handle various conditions for sync vs async Worker initialization from a single place that can be reused between shells.

Mostly extracted from #18281 by @kripken's request.