### PR TITLE
Update/fix CheckSizeType cmake check

### DIFF
--- a/cmake/Modules/CheckTypeSize.c.in
+++ b/cmake/Modules/CheckTypeSize.c.in
@@ -9,6 +9,12 @@
 # define KEY '_','_','p','p','c','_','_'
 #elif defined(__ppc64__)
 # define KEY '_','_','p','p','c','6','4','_','_'
+#elif defined(__aarch64__)
+# define KEY '_','_','a','a','r','c','h','6','4','_','_'
+#elif defined(__ARM_ARCH_7A__)
+# define KEY '_','_','A','R','M','_','A','R','C','H','_','7','A','_','_'
+#elif defined(__ARM_ARCH_7S__)
+# define KEY '_','_','A','R','M','_','A','R','C','H','_','7','S','_','_'
 #endif
 
 #define SIZE (sizeof(@type@))
@@ -33,5 +39,5 @@ int main(int argc, char *argv[])
   int require = 0;
   require += info_size[argc];
   (void)argv;
-  return SIZE;
+  return require;
 }

--- a/test/cmake/check_type_size/CMakeLists.txt
+++ b/test/cmake/check_type_size/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(test_cmake)
+
+include(CheckTypeSize)
+
+check_type_size("int" int_size)
+if (NOT "${int_size}" EQUAL "4")
+  message(FATAL_ERROR "CHECK_TYPE_SIZE with int did not return 4! (${int_size})")
+endif()
+message(STATUS "CHECK_TYPE_SIZE int -> ${int_size}")
+
+check_type_size("int[256+1]" big_size)
+if (NOT "${big_size}" EQUAL "1028")
+  message(FATAL_ERROR "CHECK_TYPE_SIZE with int[256+1] did not return 1028! (${big_size})")
+endif()
+message(STATUS "CHECK_TYPE_SIZE int -> ${big_size}")

--- a/test/cmake/target_js/CMakeLists.txt
+++ b/test/cmake/target_js/CMakeLists.txt
@@ -79,16 +79,7 @@ endif()
 include(TestBigEndian)
 test_big_endian(endian_result)
 if (NOT ${endian_result} EQUAL 0)
-        message(FATAL_ERROR "TEST_BIG_ENDIAN did not return 0!")
-endif()
-
-# Requires CMAKE_CROSSCOMPILING_EMULATOR support.
-if (${CMAKE_VERSION} VERSION_GREATER 3.2.20150502)
-  include(CheckTypeSize)
-  check_type_size("int" int_size)
-  if (NOT ${int_size} EQUAL 4)
-    message(FATAL_ERROR "CHECK_TYPE_SIZE with int did not return 4!")
-  endif()
+  message(FATAL_ERROR "TEST_BIG_ENDIAN did not return 0!")
 endif()
 
 add_executable(test_cmake ${sourceFiles})

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -890,6 +890,13 @@ f.close()
         out = self.run_process([emmake, 'pkg-config', '--modversion', package], stdout=PIPE).stdout
         self.assertContained(version, out)
 
+  def test_cmake_check_type_size(self):
+    self.run_process([EMCMAKE, 'cmake', test_file('cmake/check_type_size')])
+
+    # Verify that this test works without needing to run node.  We do this by breaking node
+    # execution.
+    self.run_process([EMCMAKE, 'cmake', '-DCMAKE_CROSSCOMPILING_EMULATOR=/missing_binary', test_file('cmake/check_type_size')])
+
   def test_system_include_paths(self):
     # Verify that all default include paths are within `emscripten/system`
 


### PR DESCRIPTION
Update the CheckTypeSize files to v3.10.2 (mostly arbitrary version).

Local patch to CheckTypeSize is not much smaller.  Instead of executing the program and using the return value (doesn't work for return values greater than 255), we simply inject `-oformat=wasm` onto the link command, and then we can use `strings` on the binary just like the upstream check.  This is basically a single line patch against upstream now.

Fixes: #18278 #18238 #17268 #17811