### PR TITLE
Replace use of llvm-dis as the guessed location for LLVM root

### DIFF
--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -172,7 +172,7 @@ class sanity(RunnerCore):
         open(os.path.join(temp_bin, name), 'w').close()
         make_executable(os.path.join(temp_bin, name))
 
-      make_new_executable('llvm-dis')
+      make_new_executable('wasm-ld')
       make_new_executable('node')
 
       with env_modify({'PATH': temp_bin + os.pathsep + os.environ['PATH']}):

--- a/tools/config.py
+++ b/tools/config.py
@@ -176,7 +176,7 @@ def generate_config(path):
   config_data = config_data.splitlines()[3:] # remove the initial comment
   config_data = '\n'.join(config_data)
   # autodetect some default paths
-  llvm_root = os.path.dirname(which('llvm-dis') or '/usr/bin/llvm-dis')
+  llvm_root = os.path.dirname(which('wasm-ld') or '/usr/bin/wasm-ld')
   config_data = config_data.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
 
   binaryen_root = os.path.dirname(os.path.dirname(which('wasm-opt') or '/usr/local/bin/wasm-opt'))


### PR DESCRIPTION
generate_config tries to find the location of an LLVM installation based on the presence of llvm-dis. This will likely work to locate a toolchain-developer-focused or self-built version of LLVM, but not one that is part of a Linux system package or mac SDK, because those don't include llvm-dis. This could fail in 2 ways: if there were a wasm-supporting clang and lld (which are all that's needed from LLVM for many purposes) but no llvm-dis (which is not included in emsdk); or if there were an LLVM without wasm support.
We could use wasm-ld instead, which is one truly reuquired component (and the presence of which would likely indicate a wasm-supporting clang to go with it). This could still fail in some cases (e.g. sometimes a tool like objcopy is needed and might not be present) but no cases I'm aware of that are not already failure modes of the existing code.