### PR TITLE
Fix for running of side module static constructors

### DIFF
--- a/system/lib/pthread/proxying.c
+++ b/system/lib/pthread/proxying.c
@@ -210,6 +210,12 @@ static em_task_queue* get_or_add_tasks_for_thread(em_proxying_queue* q,
 // Exported for use in worker.js, but otherwise an internal function.
 EMSCRIPTEN_KEEPALIVE
 void _emscripten_proxy_execute_task_queue(em_task_queue* tasks) {
+  // Before we attempt to execute a request from another thread make sure we
+  // are in sync with all the loaded code.
+  // For example, in PROXY_TO_PTHREAD the atexit functions are called via
+  // a proxied call, and without this call to syncronize we would crash if
+  // any atexit functions were registered from a side module.
+  _emscripten_thread_sync_code();
   em_task_queue_execute(tasks);
 }
 

--- a/test/core/pthread/test_pthread_dlopen_side.c
+++ b/test/core/pthread/test_pthread_dlopen_side.c
@@ -1,6 +1,12 @@
+#include <stdio.h>
+
 typedef int (*myfunc_type)();
 
 static int mydata[10] = { 44 };
+
+__attribute__((constructor)) static void ctor() {
+  puts("side module ctor");
+}
 
 static int myfunc() {
   return 43;

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -3100,7 +3100,14 @@ The current type of b is: 9
     self.do_run(src, expected)
 
   @needs_dylink
-  def test_dlfcn_basic(self):
+  @parameterized({
+    '': ([],),
+    'pthreads': (['-pthread', '-sEXIT_RUNTIME', '-sPROXY_TO_PTHREAD', '-Wno-experimental'],),
+  })
+  def test_dlfcn_basic(self, args):
+    if args:
+      self.setup_node_pthreads()
+    self.emcc_args += args
     create_file('liblib.cpp', '''
       #include <cstdio>
 
@@ -9299,7 +9306,9 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('PROXY_TO_PTHREAD')
     if do_yield:
       self.emcc_args.append('-DYIELD')
-      self.do_runf(test_file('core/pthread/test_pthread_dlopen.c'), 'done join')
+      self.do_runf(test_file('core/pthread/test_pthread_dlopen.c'),
+                   ['side module ctor', 'done join'],
+                   assert_all=True)
     else:
       self.do_runf(test_file('core/pthread/test_pthread_dlopen.c'),
                    'invalid index into function table',


### PR DESCRIPTION
This bug only only applied when a non-main thread was the first one to `dlopen` a given side module.