### PR TITLE
Extract startWorker helper. NFC

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -18,6 +18,12 @@ var EMSCRIPTEN$AWAIT$IMPORT;
 // Don't minify createRequire
 var createRequire;
 
+// Don't minify startWorker which we use to start workers once the runtime is ready.
+/**
+ * @param {Object} Module
+ */
+var startWorker = function(Module) {};
+
 // Closure externs used by library_sockfs.js
 
 /**

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -292,7 +292,7 @@ function run(args) {
     readyPromiseResolve(Module);
 #endif // MODULARIZE
     initRuntime();
-    postMessage({ 'cmd': 'loaded' });
+    startWorker(Module);
     return;
   }
 #endif

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -246,13 +246,6 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
 #else
   ready();
 #endif
-
-#if USE_PTHREADS
-  // This Worker is now ready to host pthreads, tell the main thread we can proceed.
-  if (ENVIRONMENT_IS_PTHREAD) {
-    postMessage({ 'cmd': 'loaded' });
-  }
-#endif
 }
 
 #if ASSERTIONS || WASM == 2

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -119,6 +119,12 @@ function ready() {
 #elif ASSERTIONS
   out('ready() called, and INVOKE_RUN=0. The runtime is now ready for you to call run() to invoke application _main(). You can also override ready() in a --pre-js file to get this signal as a callback')
 #endif
+#if USE_PTHREADS
+  // This Worker is now ready to host pthreads, tell the main thread we can proceed.
+  if (ENVIRONMENT_IS_PTHREAD) {
+    startWorker(Module);
+  }
+#endif
 }
 
 #if POLYFILL


### PR DESCRIPTION
Extracted some changes out of https://github.com/emscripten-core/emscripten/pull/18305 that report Worker as ready only once runtime is initialized *and* `Module` variable is assigned.