### PR TITLE
Speed up running of JS compiler in LLD_REPORT_UNDEFINED mode. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -508,23 +508,14 @@ def get_all_js_syms():
   # TODO(sbc): Find a way to optimize this.  Potentially we could add a super-set
   # mode of the js compiler that would generate a list of all possible symbols
   # that could be checked in.
-  old_full = settings.INCLUDE_FULL_LIBRARY
-  try:
-    # Temporarily define INCLUDE_FULL_LIBRARY since we want a full list
-    # of all available JS library functions.
-    settings.INCLUDE_FULL_LIBRARY = True
-    settings.ONLY_CALC_JS_SYMBOLS = True
-    emscripten.generate_struct_info()
-    glue, forwarded_data = emscripten.compile_settings()
-    forwarded_json = json.loads(forwarded_data)
-    library_syms = set()
-    for name in forwarded_json['librarySymbols']:
-      if shared.is_c_symbol(name):
-        name = shared.demangle_c_symbol_name(name)
-        library_syms.add(name)
-  finally:
-    settings.ONLY_CALC_JS_SYMBOLS = False
-    settings.INCLUDE_FULL_LIBRARY = old_full
+  emscripten.generate_struct_info()
+  glue, forwarded_data = emscripten.compile_javascript(symbols_only=True)
+  forwarded_json = json.loads(forwarded_data)
+  library_syms = set()
+  for name in forwarded_json:
+    if shared.is_c_symbol(name):
+      name = shared.demangle_c_symbol_name(name)
+      library_syms.add(name)
 
   return library_syms
 

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -43,8 +43,17 @@ function load(f) {
 // Basic utilities
 load('utility.js');
 
+
+const argv = process.argv.slice(2);
+const symbolsOnly = argv.indexOf('--symbols-only');
+if (symbolsOnly != -1) {
+  argv.splice(symbolsOnly, 1);
+}
+
+global.ONLY_CALC_JS_SYMBOLS = symbolsOnly != -1;
+
 // Load settings from JSON passed on the command line
-const settingsFile = process.argv[2];
+const settingsFile = argv[0];
 assert(settingsFile);
 
 const settings = JSON.parse(read(settingsFile));
@@ -55,6 +64,9 @@ WASM_EXPORTS = new Set(WASM_EXPORTS);
 SIDE_MODULE_EXPORTS = new Set(SIDE_MODULE_EXPORTS);
 INCOMING_MODULE_JS_API = new Set(INCOMING_MODULE_JS_API);
 WEAK_IMPORTS = new Set(WEAK_IMPORTS);
+if (ONLY_CALC_JS_SYMBOLS) {
+  INCLUDE_FULL_LIBRARY = 1;
+}
 
 // Side modules are pure wasm and have no JS
 assert(!SIDE_MODULE, 'JS compiler should not run on side modules');

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -540,5 +540,10 @@ function ${name}(${args}) {
   // Data
   functionStubs.forEach(functionStubHandler);
 
+  if (ONLY_CALC_JS_SYMBOLS) {
+    print(JSON.stringify(librarySymbols));
+    return;
+  }
+
   finalCombiner();
 }

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -189,11 +189,6 @@ var SEPARATE_DWARF = false;
 // New WebAssembly exception handling
 var WASM_EXCEPTIONS = false;
 
-// Used internally when running the JS compiler simply to generate list of all
-// JS symbols. This is used by LLD_REPORT_UNDEFINED to generate a list of all
-// JS library symbols.
-var ONLY_CALC_JS_SYMBOLS = false;
-
 // Set to true if the program has a main function.  By default this is
 // enabled, but if `--no-entry` is passed, or if `_main` is not part of
 // EXPORTED_FUNCTIONS then this gets set to 0.


### PR DESCRIPTION
Avoid generating the full JS output, only generate the metadata.  This saves about 10% of the cost.

See: #16003