### PR TITLE
Make test_dash_s_list_parsing more robust

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9208,8 +9208,7 @@ _d
       proc = self.run_process([EMCC, 'src.c', '-s', export_arg], stdout=PIPE, stderr=PIPE, check=not expected)
       print(proc.stderr)
       if not expected:
-        self.assertFalse(proc.stderr)
-        js = open('a.out.js').read()
+        js = read_file('a.out.js')
         for sym in ('_a', '_b', '_c', '_d'):
           self.assertContained(f'var {sym} = ', js)
       else:


### PR DESCRIPTION
Don't try to assert that the emcc stderr is empty.  The compiler can generate message on stderr under certain circumstances.  For example the `cache:INFO: generating system library: ...` messages.

Without this change this test fails if the cache is cleared right before running it.