### PR TITLE
Don't define posix macros that we don't support

### DIFF
--- a/system/lib/libc/README.md
+++ b/system/lib/libc/README.md
@@ -11,7 +11,7 @@ Some changes have been made to the version that was taken from upstream, includi
  * Backporting an operator-precedence warning fix from 6e76e1540fc58a418494bf5eb832b556f9c5763e in the upstream version.
  * Switch to using the wasi `fd_write` syscall instead of `writev`.
  * Simplify stdout stream handling: do not support seeking, terminal handling, etc., as it just increases code size and Emscripten doesn't have those features anyhow.
- * Setting `_POSIX_REALTIME_SIGNALS` and `_POSIX_SPAWN` macros to -1, to exclude unsupported functions.
+ * Don't define `_POSIX_REALTIME_SIGNALS` and `_POSIX_SPAWN` macros, to exclude unsupported functions.
 
 Copy log.c and log2.c from ealier version of musl which result in smaller
 binary size since they do not rely data tables in log_data.c and log2_data.c.

--- a/system/lib/libc/musl/include/unistd.h
+++ b/system/lib/libc/musl/include/unistd.h
@@ -242,8 +242,6 @@ pid_t gettid(void);
 
 #ifndef __EMSCRIPTEN__
 #define _POSIX_REALTIME_SIGNALS _POSIX_VERSION
-#else
-#define _POSIX_REALTIME_SIGNALS -1
 #endif
 
 #define _POSIX_REGEXP           1
@@ -252,8 +250,6 @@ pid_t gettid(void);
 
 #ifndef __EMSCRIPTEN__
 #define _POSIX_SPAWN            _POSIX_VERSION
-#else
-#define _POSIX_SPAWN            -1
 #endif
 
 #define _POSIX_VDISABLE         0
@@ -264,9 +260,7 @@ pid_t gettid(void);
 #define _POSIX_THREAD_ATTR_STACKADDR _POSIX_VERSION
 #define _POSIX_THREAD_ATTR_STACKSIZE _POSIX_VERSION
 #define _POSIX_THREAD_PRIORITY_SCHEDULING _POSIX_VERSION
-#ifdef __EMSCRIPTEN__
-#define _POSIX_THREAD_CPUTIME   -1
-#else
+#ifndef __EMSCRIPTEN__
 #define _POSIX_THREAD_CPUTIME   _POSIX_VERSION
 #endif
 #define _POSIX_TIMERS           _POSIX_VERSION


### PR DESCRIPTION
While -1 is valid value for these, simply not defining them is perfectly acceptable and has the same meaning AFAICT.  This makes the patch smaller, and also works for codebased that use `#ifdef`

This change was original made in #9452.