### PR TITLE
Improve longjmp stubs. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1241,9 +1241,7 @@ mergeInto(LibraryManager.library, {
 #if SUPPORT_LONGJMP == 'emscripten'
   _emscripten_throw_longjmp__sig: 'v',
   _emscripten_throw_longjmp: function() { throw Infinity; },
-#endif
-
-#if !SUPPORT_LONGJMP
+#elif !SUPPORT_LONGJMP
 #if !INCLUDE_FULL_LIBRARY
   // These are in order to print helpful error messages when either longjmp of
   // setjmp is used.
@@ -1258,17 +1256,19 @@ mergeInto(LibraryManager.library, {
   // built with SUPPORT_LONGJMP=1, the object file contains references of not
   // longjmp but _emscripten_throw_longjmp, which is called from
   // emscripten_longjmp.
-  _emscripten_throw_longjmp: function() { error('longjmp support was disabled (SUPPORT_LONGJMP=0), but it is required by the code (either set SUPPORT_LONGJMP=1, or remove uses of it in the project)'); },
   get _emscripten_throw_longjmp__deps() {
     return this.longjmp__deps;
   },
 #endif
+  _emscripten_throw_longjmp: function() {
+    error('longjmp support was disabled (SUPPORT_LONGJMP=0), but it is required by the code (either set SUPPORT_LONGJMP=1, or remove uses of it in the project)');
+  },
   // will never be emitted, as the dep errors at compile time
   longjmp: function(env, value) {
-    abort('longjmp not supported');
+    abort('longjmp not supported (build with -s SUPPORT_LONGJMP)');
   },
-  setjmp: function(env, value) {
-    abort('setjmp not supported');
+  setjmp: function(env) {
+    abort('setjmp not supported (build with -s SUPPORT_LONGJMP)');
   },
 #endif
 


### PR DESCRIPTION
- Use `elif` here so its clear that we either include one block or the next, but never both.
- Fix signature of setjmp.
- Include the `_emscripten_throw_longjmp` stub regardless of `INCLUDE_FULL_LIBRARY` settings.  

This final fix is a prerequisite for #16003.  Without this change LLD_REPORT_UNDEFINED results in the following different error message:

```
-error: longjmp support was disabled (SUPPORT_LONGJMP=0), but it is required by the code (either set SUPPORT_LONGJMP=1, or remove uses of it in the project)
+wasm-ld: error: /usr/local/google/home/sbc/dev/wasm/emscripten/cache/sysroot/lib/wasm32-emscripten/libcompiler_rt.a(emscripten_setjmp.o): undefined symbol: _emscripten_throw_longjmp
```

