### PR TITLE
Detect GL version for custom preinitialized contexts

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -626,7 +626,7 @@ var LibraryGL = {
       if (Module['preinitializedWebGLContext']) {
         var ctx = Module['preinitializedWebGLContext'];
 #if MAX_WEBGL_VERSION >= 2
-        // The ctx object may not be of a known class (e.g. it may be a debug wrapper), so we ask it for its version instead.
+        // The ctx object may not be of a known class (e.g. it may be a debug wrapper), so we ask it for its version rather than use instanceof.
         webGLContextAttributes.majorVersion = Number(ctx.getParameter(ctx.VERSION).match(/^WebGL (\d+).\d+/)[1]);
 #else
         webGLContextAttributes.majorVersion = 1;

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -626,7 +626,8 @@ var LibraryGL = {
       if (Module['preinitializedWebGLContext']) {
         var ctx = Module['preinitializedWebGLContext'];
 #if MAX_WEBGL_VERSION >= 2
-        webGLContextAttributes.majorVersion = (typeof WebGL2RenderingContext != 'undefined' && ctx instanceof WebGL2RenderingContext) ? 2 : 1;
+        // The ctx object may not be of a known class (e.g. it may be a debug wrapper), so we ask it for its version instead.
+        webGLContextAttributes.majorVersion = Number(ctx.getParameter(ctx.VERSION).match(/^WebGL (\d+).\d+/)[1]);
 #else
         webGLContextAttributes.majorVersion = 1;
 #endif
@@ -653,7 +654,7 @@ var LibraryGL = {
 #if MIN_WEBGL_VERSION >= 2
       var ctx = canvas.getContext("webgl2", webGLContextAttributes);
 #else
-      var ctx = 
+      var ctx =
 #if MAX_WEBGL_VERSION >= 2
         (webGLContextAttributes.majorVersion > 1)
         ?
@@ -3153,7 +3154,7 @@ var LibraryGL = {
     while(bindingMatch = bindingRegex.exec(source)) {
       // We have a layout(binding=x) enabled uniform. Parse the array length of that uniform, if it is an array, i.e. a
       //    layout(binding = 3) uniform sampler2D mainTexture[arrayLength];
-      // or 
+      // or
       //    layout(binding = 1, std140) uniform MainBlock { ... } name[arrayLength];
       var arrayLength = 1;
       for(var i = bindingMatch.index; i < source.length && source[i] != ';'; ++i) {


### PR DESCRIPTION
For debugging purposes, it can be useful to wrap a WebGL context into a custom object presenting the same interface (e.g. using <https://github.com/KhronosGroup/WebGLDeveloperTools>). This can be passed to Emscripten using preinitializedWebGLContext. However, currently checks for an instance of WebGL2RenderingContext, and so it will assume that a custom context wrapper only supports WebGL 1, even if it is in fact a WebGL 2 context.

To address that, we can parse the VERSION parameter instead, which is guaranteed to start with "WebGL 1.0 " or "WebGL 2.0 " depending on which API the context supports. This way, the version of a wrapped context is correctly detected.