### PR TITLE
URI decode emrun arguments

### DIFF
--- a/src/emrun_prejs.js
+++ b/src/emrun_prejs.js
@@ -10,6 +10,9 @@
 // Route URL GET parameters to argc+argv
 if (typeof window == 'object') {
   Module['arguments'] = window.location.search.substr(1).trim().split('&');
+  for (let i = 0; i < Module['arguments'].length; ++i) {
+    Module['arguments'][i] = decodeURI(Module['arguments'][i]);
+  }
   // If no args were passed arguments = [''], in which case kill the single empty string.
   if (!Module['arguments'][0]) {
     Module['arguments'] = [];


### PR DESCRIPTION

This (https://github.com/emscripten-core/emscripten/issues/5369) issue seems to have never been resolved.

Here I unescape the arguments from the window.location.search so that spaces are correctly passed to the application