### PR TITLE
Remove LLD_REPORT_UNDEFINED setting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,8 @@ See docs/process.md for more on how version tagging works.
 3.1.33 (in development)
 -----------------------
 - Update SDL2_ttf port to 2.20.2 (#18804)
+- The `LLD_REPORT_UNDEFINED` setting has been removed.  It's now essentially
+  always enabled. (#18342)
 
 3.1.32 - 02/17/23
 -----------------

--- a/emcc.py
+++ b/emcc.py
@@ -3075,7 +3075,7 @@ def phase_link(linker_arguments, wasm_target):
   # fastcomp deferred linking opts.
   # TODO: we could check if this is a fastcomp build, and still speed things up here
   js_syms = None
-  if settings.LLD_REPORT_UNDEFINED and settings.ERROR_ON_UNDEFINED_SYMBOLS and not settings.SIDE_MODULE:
+  if settings.ERROR_ON_UNDEFINED_SYMBOLS and not settings.SIDE_MODULE:
     js_syms = get_all_js_syms()
   building.link_lld(linker_arguments, wasm_target, external_symbols=js_syms)
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -239,7 +239,7 @@ def report_missing_symbols(js_symbols):
 
   if settings.EXPECT_MAIN and 'main' not in settings.WASM_EXPORTS and '__main_argc_argv' not in settings.WASM_EXPORTS:
     # For compatibility with the output of wasm-ld we use the same wording here in our
-    # error message as if wasm-ld had failed (i.e. in LLD_REPORT_UNDEFINED mode).
+    # error message as if wasm-ld had failed.
     exit_with_error('entry symbol not defined (pass --no-entry to suppress): main')
 
 

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -278,9 +278,6 @@ function ${name}(${args}) {
           if (dependent) msg += ` (referenced by ${dependent})`;
           if (ERROR_ON_UNDEFINED_SYMBOLS) {
             error(msg);
-            if (dependent == TOP_LEVEL && !LLD_REPORT_UNDEFINED) {
-              warnOnce('Link with `-sLLD_REPORT_UNDEFINED` to get more information on undefined symbols');
-            }
             warnOnce('To disable errors for undefined symbols use `-sERROR_ON_UNDEFINED_SYMBOLS=0`');
             warnOnce(mangled + ' may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library');
           } else if (VERBOSE || WARN_ON_UNDEFINED_SYMBOLS) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1935,14 +1935,6 @@ var USE_OFFSET_CONVERTER = false;
 // This is enabled automatically when using -gsource-map with sanitizers.
 var LOAD_SOURCE_MAP = false;
 
-// If set to 0, delay undefined symbol report until after wasm-ld runs.  This
-// avoids running the JS compiler prior to wasm-ld, but reduces the amount
-// of information in the undefined symbol message (Since JS compiler cannot
-// report the name of the object file that contains the reference to the
-// undefined symbol).
-// [link]
-var LLD_REPORT_UNDEFINED = true;
-
 // Default to c++ mode even when run as `emcc` rather then `emc++`.
 // When this is disabled `em++` is required when compiling and linking C++
 // programs. This which matches the behaviour of gcc/g++ and clang/clang++.
@@ -2188,4 +2180,5 @@ var LEGACY_SETTINGS = [
   ['LIBRARY_DEPS_TO_AUTOEXPORT', [[]], 'No longer needed'],
   ['EMIT_EMSCRIPTEN_METADATA', [0], 'No longer supported'],
   ['SHELL_FILE', [''], 'No longer supported'],
+  ['LLD_REPORT_UNDEFINED', [1], 'No longer supported'],
 ];

--- a/src/settings.js
+++ b/src/settings.js
@@ -2180,5 +2180,5 @@ var LEGACY_SETTINGS = [
   ['LIBRARY_DEPS_TO_AUTOEXPORT', [[]], 'No longer needed'],
   ['EMIT_EMSCRIPTEN_METADATA', [0], 'No longer supported'],
   ['SHELL_FILE', [''], 'No longer supported'],
-  ['LLD_REPORT_UNDEFINED', [1], 'No longer supported'],
+  ['LLD_REPORT_UNDEFINED', [1], 'Disabling is no longer supported'],
 ];

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -4224,11 +4224,6 @@ ok
     self.do_basic_dylink_test()
 
   @needs_dylink
-  def test_dylink_basics_no_lld_report_undefined(self):
-    self.set_setting('LLD_REPORT_UNDEFINED', 0)
-    self.do_basic_dylink_test()
-
-  @needs_dylink
   def test_dylink_no_export(self):
     self.set_setting('NO_DECLARE_ASM_MODULE_EXPORTS')
     self.do_basic_dylink_test()

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11037,21 +11037,6 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
     self.expect_fail([EMCC, '-Wl,--fatal-warnings', 'a.c', 'b.c'])
     self.expect_fail([EMCC, '-sSTRICT', 'a.c', 'b.c'])
 
-  # TODO(sbc): Remove these tests once we remove the LLD_REPORT_UNDEFINED
-  def test_lld_report_undefined(self):
-    create_file('main.c', 'void foo(); int main() { foo(); return 0; }')
-    stderr = self.expect_fail([EMCC, '-sLLD_REPORT_UNDEFINED=0', 'main.c'])
-    self.assertContained('error: undefined symbol: foo (referenced by top-level compiled C/C++ code)', stderr)
-
-  def test_lld_report_undefined_reverse_deps(self):
-    self.run_process([EMCC, '-sLLD_REPORT_UNDEFINED=0', '-sREVERSE_DEPS=all', test_file('hello_world.c')])
-
-  def test_lld_report_undefined_exceptions(self):
-    self.run_process([EMXX, '-sLLD_REPORT_UNDEFINED=0', '-fwasm-exceptions', test_file('hello_libcxx.cpp')])
-
-  def test_lld_report_undefined_main_module(self):
-    self.run_process([EMCC, '-sLLD_REPORT_UNDEFINED=0', '-sMAIN_MODULE=2', test_file('hello_world.c')])
-
   # Verifies that warning messages that Closure outputs are recorded to console
   def test_closure_warnings(self):
     # Default should be no warnings


### PR DESCRIPTION
This setting became the default in #16003.  There is no reason to keep
it around anymore and we have has no issues reported in the last 3
months (4 releases).