### PR TITLE
Allow emscripten to be run without a config file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,8 +39,8 @@ See docs/process.md for more on how version tagging works.
   comparison to other calls to this function". (#18267)
 - Emscripten will now search your PATH for binaryen, llvm, and node if the
   corresponding config file settings (`BINARYEN_ROOT`, `LLVM_ROOT`, `NODE_JS`)
-  are not set.  In theory this allows emscripten to run with an empty config
-  file.
+  are not set.  Allows emscripten to run with an empty config file given the
+  right tools in the PATH. (#18289)
 
 3.1.27 - 11/29/22
 -----------------

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -163,7 +163,7 @@ class sanity(RunnerCore):
   def test_firstrun(self):
     default_config = config.embedded_config
     output = self.do([EMCC, '-v'])
-    self.assertContained('emcc: error: config file not found: %s.  Please create one by hand or run `emcc --generate-config`' % default_config, output)
+    self.assertContained('emcc: warning: config file not found: %s.  You can create one by hand or run `emcc --generate-config`' % default_config, output)
 
     try:
       temp_bin = tempfile.mkdtemp()
@@ -680,6 +680,16 @@ fi
     make_fake_tool(self.in_dir('fake', 'llvm-ar'), EXPECTED_LLVM_VERSION)
     make_fake_tool(self.in_dir('fake', 'llvm-nm'), EXPECTED_LLVM_VERSION)
     open(EM_CONFIG, 'w').close()
+    with env_modify({'PATH': self.in_dir('fake') + os.pathsep + os.environ['PATH']}):
+      self.check_working([EMCC])
+
+  def test_missing_config(self):
+    restore_and_set_up()
+    make_fake_tool(self.in_dir('fake', 'wasm-opt'), 'foo')
+    make_fake_clang(self.in_dir('fake', 'clang'), EXPECTED_LLVM_VERSION)
+    make_fake_tool(self.in_dir('fake', 'llvm-ar'), EXPECTED_LLVM_VERSION)
+    make_fake_tool(self.in_dir('fake', 'llvm-nm'), EXPECTED_LLVM_VERSION)
+    delete_file(EM_CONFIG)
     with env_modify({'PATH': self.in_dir('fake') + os.pathsep + os.environ['PATH']}):
       self.check_working([EMCC])
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -383,7 +383,10 @@ def set_version_globals():
 
 def generate_sanity():
   sanity_file_content = f'{EMSCRIPTEN_VERSION}|{config.LLVM_ROOT}|{get_clang_version()}'
-  config_data = utils.read_file(config.EM_CONFIG)
+  if os.path.exists(config.EM_CONFIG):
+    config_data = utils.read_file(config.EM_CONFIG)
+  else:
+    config_data = ''
   checksum = binascii.crc32(config_data.encode())
   sanity_file_content += '|%#x\n' % checksum
   return sanity_file_content


### PR DESCRIPTION
Followup to #18289 which allowed the file to be empty.