### PR TITLE
Minor optimizations for `compiler.js --symbols-only`. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -222,10 +222,10 @@ def set_memory(static_bump):
   settings.HEAP_BASE = align_memory(stack_high)
 
 
-def report_missing_symbols(js_library_funcs):
+def report_missing_symbols(js_symbols):
   # Report any symbol that was explicitly exported but is present neither
   # as a native function nor as a JS library function.
-  defined_symbols = set(asmjs_mangle(e) for e in settings.WASM_EXPORTS).union(js_library_funcs)
+  defined_symbols = set(asmjs_mangle(e) for e in settings.WASM_EXPORTS).union(js_symbols)
   missing = set(settings.USER_EXPORTED_FUNCTIONS) - defined_symbols
   for symbol in sorted(missing):
     diagnostics.warning('undefined', f'undefined exported symbol: "{symbol}"')

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -45,12 +45,12 @@ load('utility.js');
 
 
 const argv = process.argv.slice(2);
-const symbolsOnly = argv.indexOf('--symbols-only');
-if (symbolsOnly != -1) {
-  argv.splice(symbolsOnly, 1);
+const symbolsOnlyArg = argv.indexOf('--symbols-only');
+if (symbolsOnlyArg != -1) {
+  argv.splice(symbolsOnlyArg, 1);
 }
 
-global.ONLY_CALC_JS_SYMBOLS = symbolsOnly != -1;
+const symbolsOnly = symbolsOnlyArg != -1;
 
 // Load settings from JSON passed on the command line
 const settingsFile = argv[0];
@@ -64,7 +64,7 @@ WASM_EXPORTS = new Set(WASM_EXPORTS);
 SIDE_MODULE_EXPORTS = new Set(SIDE_MODULE_EXPORTS);
 INCOMING_MODULE_JS_API = new Set(INCOMING_MODULE_JS_API);
 WEAK_IMPORTS = new Set(WEAK_IMPORTS);
-if (ONLY_CALC_JS_SYMBOLS) {
+if (symbolsOnly) {
   INCLUDE_FULL_LIBRARY = 1;
 }
 
@@ -94,7 +94,7 @@ load('runtime.js');
 B = new Benchmarker();
 
 try {
-  runJSify();
+  runJSify(symbolsOnly);
 
   B.print('glue');
 } catch (err) {


### PR DESCRIPTION
- Pass `symbolsOnly` as an argument rather than a flag.
- Do less work in symbolsOnly mode.