### PR TITLE
[Proxying] Add `emscripten_proxy_async_with_callback`

### DIFF
--- a/site/source/docs/api_reference/proxying.h.rst
+++ b/site/source/docs/api_reference/proxying.h.rst
@@ -78,6 +78,13 @@ Functions
   thread then return immediately without waiting for ``func`` to be executed.
   Returns 1 if the work was successfully enqueued or 0 otherwise.
 
+.. c:function:: int emscripten_proxy_async_with_callback(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void* arg, void (*callback)(void*), void* callback_arg)
+
+  Enqueue `func` on the given queue and thread. Once it finishes executing, it
+  will proxy `callback` back to the current thread on the same queue. Returns 1
+  if the work was successfully enqueued and the target thread notified or 0
+  otherwise.
+
 .. c:function:: int emscripten_proxy_sync(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void* arg)
 
   Enqueue ``func`` to be called with argument ``arg`` on the given queue and
@@ -122,6 +129,12 @@ defined within namespace ``emscripten``.
 
     Calls ``emscripten_proxy_async`` to execute ``func``, returning ``true`` if the
     function was successfully enqueued and ``false`` otherwise.
+
+  .. cpp:member:: bool proxyAsyncWithCallback(pthread_t target, std::function<void()>&& func, std::function<void()>&& callback)
+
+    Calls ``emscripten_proxy_async_with_callback`` to execute ``func`` and
+    schedule ``callback``, returning ``true`` if the function was successfully
+    enqueued and ``false`` otherwise.
 
   .. cpp:member:: bool proxySync(const pthread_t target, const std::function<void()>& func)
 

--- a/test/pthread/test_pthread_proxying.out
+++ b/test/pthread/test_pthread_proxying.out
@@ -8,6 +8,10 @@ running widget 5 on returner
 Testing sync_with_ctx proxying
 running widget 6 on looper
 running widget 7 on returner
+Testing async_with_callback proxying
+running widget 8 on main
+running widget 9 on looper
+running widget 10 on returner
 Testing tasks queue growth
 Testing proxying queue growth
 work

--- a/test/pthread/test_pthread_proxying_cpp.out
+++ b/test/pthread/test_pthread_proxying_cpp.out
@@ -1,4 +1,5 @@
 Testing async proxying
 Testing sync proxying
-Testing sync proxying
+Testing sync_with_ctx proxying
+Testing async_with_callback proxying
 done


### PR DESCRIPTION
Add a public function for asynchronously proxying work and receiving a callback
on the proxying thread once that work has finished. In principle we could also
add `emscripten_proxy_async_with_callback_and_ctx` in case the asynchronously
proxied work is itself asynchronous, but leave that as future work.

Another issue is that the tests for the new API must busy wait for the callback
to be enqueued, since there is no way of blocking until work is available in the
queue. Adding such a capability is also left as future work.