### PR TITLE
Use `fetch` when `XMLHttpRequest` is unavailable in `file_packager.py`

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -943,6 +943,14 @@ def generate_js(data_target, data_files, metadata):
     ret += '''
       function fetchRemotePackage(packageName, packageSize, callback, errback) {
         %(node_support_code)s
+        if (typeof XMLHttpRequest === 'undefined') {
+          fetch(packageName).then(function(response) {
+            return response.arrayBuffer();
+          }).then(function(data) {
+            callback(data);
+          });
+          return;
+        }
         var xhr = new XMLHttpRequest();
         xhr.open('GET', packageName, true);
         xhr.responseType = 'arraybuffer';
@@ -980,7 +988,7 @@ def generate_js(data_target, data_files, metadata):
           throw new Error("NetworkError for: " + packageName);
         }
         xhr.onload = function(event) {
-          if (xhr.status == 200 || xhr.status == 304 || xhr.status == 206 || (xhr.status == 0 && xhr.response)) { // file URLs can return 0
+          if ((xhr.status >= 200 && xhr.status < 300) || xhr.status == 304 || (xhr.status == 0 && xhr.response)) { // file URLs can return 0
             var packageData = xhr.response;
             callback(packageData);
           } else {
@@ -1088,9 +1096,17 @@ def generate_js(data_target, data_files, metadata):
   function runMetaWithFS() {
     Module['addRunDependency']('%(metadata_file)s');
     var REMOTE_METADATA_NAME = Module['locateFile'] ? Module['locateFile']('%(metadata_file)s', '') : '%(metadata_file)s';
+    if (typeof XMLHttpRequest === 'undefined') {
+      fetch(REMOTE_METADATA_NAME).then(function(response) {
+        return response.json();
+      }).then(function(data) {
+        loadPackage(data);
+      });
+      return;
+    }
     var xhr = new XMLHttpRequest();
     xhr.onreadystatechange = function() {
-     if (xhr.readyState === 4 && xhr.status === 200) {
+     if (xhr.readyState === 4 && xhr.status >= 200 && xhr.status < 300) {
        loadPackage(JSON.parse(xhr.responseText));
      }
     }


### PR DESCRIPTION
Service workers can't use `XMLHttpRequest`, but they can use `fetch`. This allows service workers to load packaged data.

Also updated the valid HTTP status codes to include the entire 200 range.