### PR TITLE
Don't error on STANDALONE_WASM + USE_PTHREADS

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -25,9 +25,6 @@
 #if EVAL_CTORS
 #error "EVAL_CTORS is not compatible with pthreads yet (passive segments)"
 #endif
-#if STANDALONE_WASM
-#error "STANDALONE_WASM does not support shared memories yet"
-#endif
 
 var LibraryPThread = {
   $PThread__postset: 'PThread.init();',

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9120,9 +9120,13 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args.append('-fPIC')
     self.do_core_test('test_hello_world.c')
 
+  # Marked as impure since we don't have a wasi-threads is still
+  # a WIP.
+  @also_with_standalone_wasm(impure=True)
   @node_pthreads
   def test_pthread_create(self):
-    self.set_setting('EXIT_RUNTIME')
+    if not self.get_setting('STANDALONE_WASM'):
+      self.set_setting('EXIT_RUNTIME')
     # test that the node environment can be specified by itself, and that still
     # works with pthreads (even though we did not specify 'node,worker')
     self.set_setting('ENVIRONMENT', 'node')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -890,12 +890,17 @@ f.close()
         out = self.run_process([emmake, 'pkg-config', '--modversion', package], stdout=PIPE).stdout
         self.assertContained(version, out)
 
-  def test_cmake_check_type_size(self):
-    self.run_process([EMCMAKE, 'cmake', test_file('cmake/check_type_size')])
+  @parameterized({
+    '': [[]],
+    'pthreads': [['-DCMAKE_CXX_FLAGS=-pthread', '-DCMAKE_C_FLAGS=-pthread']],
+  })
+  def test_cmake_check_type_size(self, flags):
+    cmd = [EMCMAKE, 'cmake', test_file('cmake/check_type_size')] + flags
+    self.run_process(cmd)
 
     # Verify that this test works without needing to run node.  We do this by breaking node
     # execution.
-    self.run_process([EMCMAKE, 'cmake', '-DCMAKE_CROSSCOMPILING_EMULATOR=/missing_binary', test_file('cmake/check_type_size')])
+    self.run_process(cmd + ['-DCMAKE_CROSSCOMPILING_EMULATOR=/missing_binary'])
 
   def test_system_include_paths(self):
     # Verify that all default include paths are within `emscripten/system`


### PR DESCRIPTION
Using these two options together will most likely result in some non-standard JS imports (e.g. `_pthread_create_js`), but the point of `STANDALONE_WASM` is not to completely eliminate those, only to avoid them where possible.

Fixes: #18354