### PR TITLE
Fix infinite wait bug in test_pthread_proxying_cpp.cpp

### DIFF
--- a/test/pthread/test_pthread_proxying_cpp.cpp
+++ b/test/pthread/test_pthread_proxying_cpp.cpp
@@ -56,7 +56,10 @@ void test_proxy_async() {
   // Proxy to looper.
   {
     queue.proxyAsync(looper.native_handle(), [&]() {
-      i = 2;
+      {
+        std::unique_lock<std::mutex> lock(mutex);
+        i = 2;
+      }
       executor = std::this_thread::get_id();
       cond.notify_one();
     });
@@ -68,7 +71,10 @@ void test_proxy_async() {
   // Proxy to returner.
   {
     queue.proxyAsync(returner.native_handle(), [&]() {
-      i = 3;
+      {
+        std::unique_lock<std::mutex> lock(mutex);
+        i = 3;
+      }
       executor = std::this_thread::get_id();
       cond.notify_one();
     });
@@ -164,7 +170,10 @@ void test_proxy_async_with_callback(void) {
     queue.proxyAsyncWithCallback(
       looper.native_handle(),
       [&]() {
-        i = 2;
+        {
+          std::unique_lock<std::mutex> lock(mutex);
+          i = 2;
+        }
         executor = std::this_thread::get_id();
         cond.notify_one();
       },
@@ -184,7 +193,10 @@ void test_proxy_async_with_callback(void) {
     queue.proxyAsyncWithCallback(
       returner.native_handle(),
       [&]() {
-        i = 3;
+        {
+          std::unique_lock<std::mutex> lock(mutex);
+          i = 3;
+        }
         executor = std::this_thread::get_id();
         cond.notify_one();
       },


### PR DESCRIPTION
The tests in test_pthread_proxying_cpp proxy functions that increment local
variables. For the async proxying functions, the proxying is followed by a wait
on a condition variable so the test can assert that the proxied work was
completed. However, the incrementing of the local variables was not protected by
the lock used with the condition variable, so it was possible for the variable
to be incremented and the condition variable notified after checking the wait
condition but before waiting. Since the condition variable would not be notified
again, the test would wait on the condition variable forever.

Fix the bug by taking the lock before incrementing the variable in tests where
this could cause problems.

Fixes #18353.