### PR TITLE
[Proxying][Docs] Improve the docs for proxying with callback

### DIFF
--- a/site/source/docs/api_reference/proxying.h.rst
+++ b/site/source/docs/api_reference/proxying.h.rst
@@ -80,10 +80,10 @@ Functions
 
 .. c:function:: int emscripten_proxy_async_with_callback(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void* arg, void (*callback)(void*), void* callback_arg)
 
-  Enqueue `func` on the given queue and thread. Once it finishes executing, it
-  will proxy `callback` back to the current thread on the same queue. Returns 1
-  if the work was successfully enqueued and the target thread notified or 0
-  otherwise.
+  Enqueue `func` on the given queue and thread. Once (and if) it finishes
+  executing, it will asynchronously proxy `callback` back to the current thread
+  on the same queue. Returns 1 if the initial work was successfully enqueued and
+  the target thread notified or 0 otherwise.
 
 .. c:function:: int emscripten_proxy_sync(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void* arg)
 

--- a/system/include/emscripten/proxying.h
+++ b/system/include/emscripten/proxying.h
@@ -54,10 +54,10 @@ int emscripten_proxy_async(em_proxying_queue* q,
                            void (*func)(void*),
                            void* arg);
 
-// Enqueue `func` on the given queue and thread. Once it finishes executing, it
-// will proxy `callback` back to the current thread on the same queue. Returns 1
-// if the work was successfully enqueued and the target thread notified or 0
-// otherwise.
+// Enqueue `func` on the given queue and thread. Once (and if) it finishes
+// executing, it will asynchronously proxy `callback` back to the current thread
+// on the same queue. Returns 1 if the initial work was successfully enqueued
+// and the target thread notified or 0 otherwise.
 int emscripten_proxy_async_with_callback(em_proxying_queue* q,
                                          pthread_t target_thread,
                                          void (*func)(void*),


### PR DESCRIPTION
Make it clear that work is asynchronously proxied in both directions and that
the return code is determined only by whether the initial work is proxied.