### PR TITLE
Enable test_pthread_proxying_cpp on wasm2js

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2770,7 +2770,6 @@ The current type of b is: 9
                                  interleaved_output=False, emcc_args=args)
 
   @node_pthreads
-  @no_wasm2js('occasionally hangs in wasm2js (#16569)')
   def test_pthread_proxying_cpp(self):
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('PROXY_TO_PTHREAD')


### PR DESCRIPTION
It had previously been disabled because of flakes on wasm2js, but those flakes
are probably fixed by #18358.