### PR TITLE
Separate dlopen_async callback data from dso struct. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -22,6 +22,9 @@
 
 mergeInto(LibraryManager.library, {
   $ptrToString: function(ptr) {
+#if ASSERTIONS
+    assert(typeof ptr === 'number');
+#endif
     return '0x' + ptr.toString(16).padStart(8, '0');
   },
 

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -239,7 +239,7 @@ var LibraryDylink = {
   _dlopen_js: function(filename, flag) {
     abort(dlopenMissingError);
   },
-  _emscripten_dlopen_js: function(filename, flags, user_data, onsuccess, onerror) {
+  _emscripten_dlopen_js: function(handle, onsuccess, onerror, user_data) {
     abort(dlopenMissingError);
   },
   _dlsym_js: function(handle, symbol) {
@@ -1023,17 +1023,17 @@ var LibraryDylink = {
   // Async version of dlopen.
   _emscripten_dlopen_js__deps: ['$dlopenInternal', '$callUserCallback', '$dlSetError'],
   _emscripten_dlopen_js__sig: 'vppp',
-  _emscripten_dlopen_js: function(handle, onsuccess, onerror) {
+  _emscripten_dlopen_js: function(handle, onsuccess, onerror, user_data) {
     /** @param {Object=} e */
     function errorCallback(e) {
       var filename = UTF8ToString({{{ makeGetValue('handle', C_STRUCTS.dso.name, '*') }}});
       dlSetError('Could not load dynamic lib: ' + filename + '\n' + e);
       {{{ runtimeKeepalivePop() }}}
-      callUserCallback(function () { {{{ makeDynCall('vi', 'onerror') }}}(handle); });
+      callUserCallback(function () { {{{ makeDynCall('vii', 'onerror') }}}(handle, user_data); });
     }
     function successCallback() {
       {{{ runtimeKeepalivePop() }}}
-      callUserCallback(function () { {{{ makeDynCall('vii', 'onsuccess') }}}(handle); });
+      callUserCallback(function () { {{{ makeDynCall('vii', 'onsuccess') }}}(handle, user_data); });
     }
 
     {{{ runtimeKeepalivePush() }}}

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -914,7 +914,10 @@ var LibraryPThread = {
     var numCallArgs = arguments.length - 2;
     var outerArgs = arguments;
 #if ASSERTIONS
-    if (numCallArgs > {{{ cDefine('EM_QUEUED_JS_CALL_MAX_ARGS') }}}-1) throw 'emscripten_proxy_to_main_thread_js: Too many arguments ' + numCallArgs + ' to proxied function idx=' + index + ', maximum supported is ' + ({{{ cDefine('EM_QUEUED_JS_CALL_MAX_ARGS') }}}-1) + '!';
+    var maxArgs = {{{ cDefine('EM_QUEUED_JS_CALL_MAX_ARGS') - 1 }}};
+    if (numCallArgs > maxArgs) {
+      throw 'emscripten_proxy_to_main_thread_js: Too many arguments ' + numCallArgs + ' to proxied function idx=' + index + ', maximum supported is ' + maxArgs;
+    }
 #endif
     // Allocate a buffer, which will be copied by the C code.
     return withStackSave(() => {

--- a/system/lib/libc/musl/src/internal/dynlink.h
+++ b/system/lib/libc/musl/src/internal/dynlink.h
@@ -15,11 +15,6 @@
 struct dso {
   struct dso *next, *prev;
 
-  // For async mode
-  em_dlopen_callback onsuccess;
-  em_arg_callback_func onerror;
-  void* user_data;
-
   // Flags used to open the library.  We need to cache these so that other
   // threads can mirror the open library state.
   int flags;

--- a/test/reference_struct_info.json
+++ b/test/reference_struct_info.json
@@ -1258,14 +1258,14 @@
             "d_type": 18
         },
         "dso": {
-            "__size__": 44,
-            "flags": 20,
-            "mem_addr": 28,
-            "mem_allocated": 24,
-            "mem_size": 32,
-            "name": 44,
-            "table_addr": 36,
-            "table_size": 40
+            "__size__": 32,
+            "flags": 8,
+            "mem_addr": 16,
+            "mem_allocated": 12,
+            "mem_size": 20,
+            "name": 32,
+            "table_addr": 24,
+            "table_size": 28
         },
         "emscripten_fetch_attr_t": {
             "__size__": 92,


### PR DESCRIPTION
Using fields embedded in the DSO struct (which is shared between threads) is not thread safe.

This is needed as part of my fix for #18345