### PR TITLE
[Proxying] Abort if a callback cannot be scheduled

### DIFF
--- a/site/source/docs/api_reference/proxying.h.rst
+++ b/site/source/docs/api_reference/proxying.h.rst
@@ -83,7 +83,8 @@ Functions
   Enqueue `func` on the given queue and thread. Once (and if) it finishes
   executing, it will asynchronously proxy `callback` back to the current thread
   on the same queue. Returns 1 if the initial work was successfully enqueued and
-  the target thread notified or 0 otherwise.
+  the target thread notified or 0 otherwise. If the callback cannot be scheduled
+  (for example due to OOM), the program is aborted.
 
 .. c:function:: int emscripten_proxy_sync(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void* arg)
 

--- a/system/include/emscripten/proxying.h
+++ b/system/include/emscripten/proxying.h
@@ -57,7 +57,8 @@ int emscripten_proxy_async(em_proxying_queue* q,
 // Enqueue `func` on the given queue and thread. Once (and if) it finishes
 // executing, it will asynchronously proxy `callback` back to the current thread
 // on the same queue. Returns 1 if the initial work was successfully enqueued
-// and the target thread notified or 0 otherwise.
+// and the target thread notified or 0 otherwise. If the callback cannot be
+// scheduled (for example due to OOM), the program is aborted.
 int emscripten_proxy_async_with_callback(em_proxying_queue* q,
                                          pthread_t target_thread,
                                          void (*func)(void*),

--- a/system/lib/pthread/proxying.c
+++ b/system/lib/pthread/proxying.c
@@ -379,8 +379,12 @@ static void call_callback_then_free(void* arg) {
 static void call_then_schedule_callback(void* arg) {
   struct callback* info = (struct callback*)arg;
   info->func(info->arg);
-  emscripten_proxy_async(
-    info->q, info->caller_thread, call_callback_then_free, arg);
+  if (!emscripten_proxy_async(
+        info->q, info->caller_thread, call_callback_then_free, arg)) {
+    // No way to gracefully report that we failed to schedule the callback, so
+    // abort.
+    abort();
+  }
 }
 
 int emscripten_proxy_async_with_callback(em_proxying_queue* q,


### PR DESCRIPTION
The only way a callback can fail to be scheduled is on OOM, and at the point
where it is scheduled there is no way to gracefully report an error. Since
programs may hang or otherwise behave arbitrarily poorly if the callback is not
run, eagerly abort the program in this case instead.