### PR TITLE
More minor optimization to `compiler.js --symbols-only`. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -510,21 +510,16 @@ def generate_js_symbols():
   # mode of the js compiler that would generate a list of all possible symbols
   # that could be checked in.
   emscripten.generate_struct_info()
-  glue, forwarded_data = emscripten.compile_javascript(symbols_only=True)
-  forwarded_json = json.loads(forwarded_data)
-  library_syms = set()
-  for name in forwarded_json:
-    if shared.is_c_symbol(name):
-      name = shared.demangle_c_symbol_name(name)
-      library_syms.add(name)
-  return library_syms
+  _, forwarded_data = emscripten.compile_javascript(symbols_only=True)
+  # When running in symbols_only mode compiler.js outputs a flat list of C symbols.
+  return json.loads(forwarded_data)
 
 
 @ToolchainProfiler.profile_block('JS symbol generation')
 def get_all_js_syms():
   # Avoiding using the cache when generating struct info since
   # this step is performed while the cache is locked.
-  if settings.BOOTSTRAPPING_STRUCT_INFO or config.FROZEN_CACHE:
+  if DEBUG or settings.BOOTSTRAPPING_STRUCT_INFO or config.FROZEN_CACHE:
     return generate_js_symbols()
 
   # We define a cache hit as when the settings and `--js-library` contents are

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -230,6 +230,13 @@ function ${name}(${args}) {
         return;
       }
 
+      if (symbolsOnly) {
+        if (!isJsOnlyIdentifier(ident) && LibraryManager.library.hasOwnProperty(ident)) {
+          librarySymbols.push(ident);
+        }
+        return;
+      }
+
       // if the function was implemented in compiled code, there is no need to
       // include the js version
       if (WASM_EXPORTS.has(ident)) {
@@ -242,9 +249,6 @@ function ${name}(${args}) {
       let isStub = false;
 
       if (!LibraryManager.library.hasOwnProperty(ident)) {
-        if (symbolsOnly) {
-          return;
-        }
         const isWeakImport = WEAK_IMPORTS.has(ident);
         if (!isDefined(ident) && !isWeakImport) {
           if (PROXY_TO_PTHREAD && !MAIN_MODULE && ident == '__main_argc_argv') {
@@ -291,10 +295,6 @@ function ${name}(${args}) {
       }
 
       librarySymbols.push(finalName);
-
-      if (symbolsOnly) {
-        return;
-      }
 
       const original = LibraryManager.library[ident];
       let snippet = original;


### PR DESCRIPTION
In this mode, output only native C symbols, and in the unmangled form that the linker expects. This means we can avoiding filtering them and demangling them when they arrive in python.