### PR TITLE
Don't implicitly exit the main thread in PROXY_TO_PTHREAD mode

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 3.1.29 (in development)
 -----------------------
+- Fixed bug in `PROXY_TO_PTHREAD` whereby certain async operations on the main
+  thread would cause the whole program to exit, even when the proxied main
+  function was still running. (#18372)
 - Added `Module.pthreadPoolReady` promise for the `PTHREAD_POOL_DELAY_LOAD`
   mode that allows to safely join spawned threads. (#18281)
 - PThreads can now be safely spawned on-demand in Node.js even without a PThread

--- a/src/library.js
+++ b/src/library.js
@@ -3543,6 +3543,11 @@ mergeInto(LibraryManager.library, {
   ],
   $maybeExit: function() {
 #if EXIT_RUNTIME
+#if PROXY_TO_PTHREAD
+    // In PROXY_TO_PTHREAD mode the main thread never implicitly exits, but
+    // waits for the proxied main function to exit.
+    if (!ENVIRONMENT_IS_PTHREAD) return;
+#endif
 #if RUNTIME_DEBUG
     dbg('maybeExit: user callback done: runtimeKeepaliveCounter=' + runtimeKeepaliveCounter);
 #endif

--- a/test/pthread/test_pthread_proxy_to_pthread.c
+++ b/test/pthread/test_pthread_proxy_to_pthread.c
@@ -5,14 +5,43 @@
  * found in the LICENSE file.
  */
 
-#include <stdio.h>
-#include <emscripten.h>
 #include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
 
-int main()
-{
-	int ENVIRONMENT_IS_WORKER = EM_ASM_INT(return ENVIRONMENT_IS_WORKER);
-	printf("ENVIRONMENT_IS_WORKER: %d\n", ENVIRONMENT_IS_WORKER);
-	assert(ENVIRONMENT_IS_WORKER);
-	return 0;
+#include <emscripten/em_asm.h>
+#include <emscripten/eventloop.h>
+#include <emscripten/threading.h>
+
+_Atomic bool done_callback = false;
+
+void main_thread_callback(void* user_data) {
+  printf("main_thread_callback called\n");
+  done_callback = true;
+}
+
+void set_timeout_on_main() {
+  int is_worker = EM_ASM_INT(return ENVIRONMENT_IS_WORKER);
+  printf("main: ENVIRONMENT_IS_WORKER: %d\n", is_worker);
+  // Verify that we can do async work here on the main thread
+  // without causing the runtime to exit.
+  emscripten_set_immediate(main_thread_callback, NULL);
+}
+
+int main() {
+  int is_worker = EM_ASM_INT(return ENVIRONMENT_IS_WORKER);
+  printf("ENVIRONMENT_IS_WORKER: %d\n", is_worker);
+  assert(is_worker);
+
+  emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_V, set_timeout_on_main);
+  while (!done_callback) {}
+
+  // Repeat the same process to ensure the main thread is still responsive.
+  done_callback = false;
+
+  emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_V, set_timeout_on_main);
+  while (!done_callback) {}
+
+  printf("main done\n");
+  return 0;
 }

--- a/test/pthread/test_pthread_proxy_to_pthread.out
+++ b/test/pthread/test_pthread_proxy_to_pthread.out
@@ -1,0 +1,6 @@
+ENVIRONMENT_IS_WORKER: 1
+main: ENVIRONMENT_IS_WORKER: 0
+main_thread_callback called
+main: ENVIRONMENT_IS_WORKER: 0
+main_thread_callback called
+main done

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2860,6 +2860,12 @@ The current type of b is: 9
     # streams were locked when the main thread returned.
     self.do_runf(test_file('pthread/test_pthread_stdout_after_main.c'))
 
+  @node_pthreads
+  def test_pthread_proxy_to_pthread(self):
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('EXIT_RUNTIME')
+    self.do_run_in_out_file_test(test_file('pthread/test_pthread_proxy_to_pthread.c'))
+
   def test_tcgetattr(self):
     self.do_runf(test_file('termios/test_tcgetattr.c'), 'success')
 


### PR DESCRIPTION
maybeExit should never exit when its run from the main thread in PROXY_TO_PTHREAD mode.  In this mode we always wait for the proxied main thread to signal the exit of the program.

Without this change the last three lines of the test output are never printed because the whole program exits after running the callback.