### PR TITLE
Only define `maybeExit` helper if EXIT_RUNTIME is set. NFC

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -953,7 +953,7 @@ var LibraryBrowser = {
 #if OFFSCREEN_FRAMEBUFFER
     'emscripten_webgl_commit_frame',
 #endif
-#if !MINIMAL_RUNTIME
+#if EXIT_RUNTIME && !MINIMAL_RUNTIME
     '$maybeExit',
 #endif
   ],
@@ -988,7 +988,7 @@ var LibraryBrowser = {
         dbg('main loop exiting..');
 #endif
         {{{ runtimeKeepalivePop() }}}
-#if !MINIMAL_RUNTIME
+#if EXIT_RUNTIME && !MINIMAL_RUNTIME
         maybeExit();
 #endif
         return false;


### PR DESCRIPTION
Previously it was being defined but with an empty body.  This change make it more obvious to the reader that this function exists only when EXIT_RUNTIME is set.

Depends on #18372 .. and this PR is on top of that one.. 