### PR TITLE
dylink: avoid adding strong imports to JS library elements

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -836,7 +836,6 @@ def process_dynamic_libs(dylibs, lib_dirs):
     settings.SIDE_MODULE_IMPORTS.extend(mangled_imports)
     settings.EXPORTED_FUNCTIONS.extend(mangled_strong_imports)
     settings.EXPORT_IF_DEFINED.extend(weak_imports)
-    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.extend(strong_imports)
     building.user_requested_exports.update(mangled_strong_imports)
 
 


### PR DESCRIPTION
This PR resolves a build failure in wasm-vips when building with Emscripten 3.1.28 (which could be related to DCE and/or the `LLD_REPORT_UNDEFINED` change). The build failure was related to symbols that might(?) appear in the side module compiled/linked with `-sSIDE_MODULE=2` and occurred while linking the final binary (compiled/linked with `-sMAIN_MODULE=2`).
```
error: undefined symbol: _ZN3jxl17PassesSharedStateUt_C1Ev (referenced by top-level compiled C/C++ code)
warning: To disable errors for undefined symbols use `-sERROR_ON_UNDEFINED_SYMBOLS=0`
warning: __ZN3jxl17PassesSharedStateUt_C1Ev may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
error: undefined symbol: _ZNSt3__26vectorIaNS_9allocatorIaEEEC1B6v15006Ev (referenced by top-level compiled C/C++ code)
warning: __ZNSt3__26vectorIaNS_9allocatorIaEEEC1B6v15006Ev may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
```

Demangling these C++ symbols results in:
```
jxl::PassesSharedState::{unnamed type#1}::PassesSharedState()
std::__2::vector<signed char, std::__2::allocator<signed char> >::vector[abi:v15006]()
```

During my investigation, I noticed that the exact same symbols are erroneously(?) listed in the `DEFAULT_LIBRARY_FUNCS_TO_INCLUDE` array in the resulting JSON dump (when building with `EMCC_DEBUG=1`). This led me to this one-line change in this PR.

Specifically for wasm-vips, this PR would result in the following symbols being removed from the `DEFAULT_LIBRARY_FUNCS_TO_INCLUDE` array.
<details>
  <summary>Consolidated diff</summary>

```diff
@@ -129,13 +129,6 @@
     "$relocateExports",
     "$reportUndefinedSymbols",
     "$setValue",
-    "_ZN3jxl17PassesSharedStateUt_C1Ev",
-    "_ZNSt3__25ctypeIcE2idE",
-    "_ZNSt3__26vectorIaNS_9allocatorIaEEEC1B6v15006Ev",
-    "_ZSt7nothrow",
-    "_ZTTNSt3__219basic_ostringstreamIcNS_11char_traitsIcEENS_9allocatorIcEEEE",
-    "_ZTVNSt3__215basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEE",
-    "_ZTVNSt3__219basic_ostringstreamIcNS_11char_traitsIcEENS_9allocatorIcEEEE",
     "__assert_fail",
     "__call_sighandler",
     "__emscripten_init_main_thread_js",
@@ -234,11 +227,8 @@
     "fd_seek",
     "fd_write",
     "proc_exit",
-    "stderr",
-    "stdout",
     "strftime",
     "strftime_l",
-    "system",
     "$exitJS",
     "$handleException",
     "$allocateUTF8OnStack",
```
</details>

(note that there were also some unrelated changes to other arrays, but I think this is due to non-determinism, [which I still need to investigate](https://github.com/kleisauke/wasm-vips/blob/9f6cc94a2a2d116cc6c75aaedc7f57793d74eb00/build.sh#L432-L433))

To reproduce, I pushed the changes to the [`emscripten-3.1.28`](https://github.com/kleisauke/wasm-vips/tree/emscripten-3.1.28) branch in wasm-vips, where commit https://github.com/kleisauke/wasm-vips/commit/73af6d87d70c2b039493353b405d6c569fb5128a causes a build failure and commit https://github.com/kleisauke/wasm-vips/commit/cc4382ba5532edc11bd09f835ad0874d84418dcf fixes this.

This PR was deliberately opened as a draft because it causes failures on the wasm-vips testsuite related to this line:
https://github.com/emscripten-core/emscripten/blob/09335067f09c0251a4fe0906751a34995c606a85/src/library_dylink.js#L626
(somehow it tries to make a stub function out of the `system` and the above mentioned C++ symbols)

I also did _not_ test this change locally on the Emscripten testsuite, hopefully the CI will catch this.