### PR TITLE
Add API for creating promises based on native wasm functions

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3696,6 +3696,36 @@ mergeInto(LibraryManager.library, {
     dbg('done preloading data files');
 #endif
   },
+
+  $handleAllocator__docs: '/** @constructor */',
+  $handleAllocator: function() {
+    this.allocated = [];
+    this.freelist = [];
+    this.get = function(id) {
+#if ASSERTIONS
+      assert(this.allocated[id] !== undefined);
+#endif
+      return this.allocated[id];
+    };
+    this.allocate = function(handle) {
+      let id;
+      if (this.freelist.length > 0) {
+        id = this.freelist.pop();
+        this.allocated[id] = handle;
+      } else {
+        id = this.allocated.length;
+        this.allocated.push(handle);
+      }
+      return id;
+    };
+    this.free = function(id) {
+#if ASSERTIONS
+      assert(this.allocated[id] !== undefined);
+#endif
+      delete this.allocated[id];
+      this.freelist.push(id);
+    };
+  },
 });
 
 function autoAddDeps(object, name) {

--- a/src/library_eventloop.js
+++ b/src/library_eventloop.js
@@ -90,7 +90,7 @@ LibraryJSEventLoop = {
     emClearImmediate(id);
   },
 
-  emscripten_set_immediate_loop__sig: 'vpp' ,
+  emscripten_set_immediate_loop__sig: 'ipp' ,
   emscripten_set_immediate_loop__deps: ['$polyfillSetImmediate', '$callUserCallback'],
   emscripten_set_immediate_loop: function(cb, userData) {
     polyfillSetImmediate();
@@ -154,6 +154,62 @@ LibraryJSEventLoop = {
   emscripten_clear_interval: function(id) {
     {{{ runtimeKeepalivePop() }}}
     clearInterval(id);
+  },
+
+  $promiseMap__deps: ['$handleAllocator'],
+  $promiseMap: "new handleAllocator();",
+
+  // Create a new promise that can be resolved or rejected by passing a unique
+  // ID to emscripten_promise_resolve/emscripten_promise_reject.  Returns a JS
+  // object containing the promise, its unique ID, and the associated
+  // reject/resolve functions.
+  $newNativePromise__deps: ['$promiseMap'],
+  $newNativePromise: function(nativeFunc, userData) {
+    var nativePromise = {};
+    var promiseId;
+    var promise = new Promise((resolve, reject) => {
+      nativePromise.reject = reject;
+      nativePromise.resolve = resolve;
+      nativePromise.id = promiseMap.allocate(nativePromise);
+#if RUNTIME_DEBUG
+      dbg('newNativePromise: ' + nativePromise.id);
+#endif
+      nativeFunc(userData, nativePromise.id);
+    });
+    nativePromise.promise = promise;
+    return nativePromise;
+  },
+
+  $getPromise__deps: ['$promiseMap'],
+  $getPromise: function(id) {
+    return promiseMap.get(id).promise;
+  },
+
+  emscripten_promise_create__sig: 'ipp',
+  emscripten_promise_create__deps: ['$newNativePromise'],
+  emscripten_promise_create: function(funcPtr, userData) {
+    return newNativePromise({{{ makeDynCall('vpi', 'funcPtr') }}}, userData).id;
+  },
+
+  emscripten_promise_resolve__deps: ['$promiseMap'],
+  emscripten_promise_resolve__sig: 'vip',
+  emscripten_promise_resolve: function(id, value) {
+#if RUNTIME_DEBUG
+    err('emscripten_resolve_promise: ' + id);
+#endif
+    promiseMap.get(id).resolve(value);
+    promiseMap.free(id);
+  },
+
+  emscripten_promise_reject__deps: ['$promiseMap'],
+  emscripten_promise_reject__sig: 'vi',
+  emscripten_promise_reject: function(id) {
+#if RUNTIME_DEBUG
+    dbg('emscripten_promise_reject: ' + id);
+#endif
+    assert(promiseMap.has(id));
+    promiseMap.get(id).reject();
+    promiseMap.free(id);
   },
 };
 

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -5,36 +5,6 @@
  */
 
 mergeInto(LibraryManager.library, {
-  $handleAllocator__docs: '/** @constructor */',
-  $handleAllocator: function() {
-    this.allocated = [];
-    this.freelist = [];
-    this.get = function(id) {
-#if ASSERTIONS
-      assert(this.allocated[id] !== undefined);
-#endif
-      return this.allocated[id];
-    };
-    this.allocate = function(handle) {
-      let id;
-      if (this.freelist.length > 0) {
-        id = this.freelist.pop();
-        this.allocated[id] = handle;
-      } else {
-        id = this.allocated.length;
-        this.allocated.push(handle);
-      }
-      return id;
-    };
-    this.free = function(id) {
-#if ASSERTIONS
-      assert(this.allocated[id] !== undefined);
-#endif
-      delete this.allocated[id];
-      this.freelist.push(id);
-    };
-  },
-
   $wasmfsOPFSDirectoryHandles__deps: ['$handleAllocator'],
   $wasmfsOPFSDirectoryHandles: "new handleAllocator()",
   $wasmfsOPFSFileHandles__deps: ['$handleAllocator'],

--- a/system/include/emscripten/em_js.h
+++ b/system/include/emscripten/em_js.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <emscripten/em_macros.h>
+
 #ifdef __cplusplus
 #define _EM_JS_CPP_BEGIN extern "C" {
 #define _EM_JS_CPP_END   }

--- a/system/include/emscripten/eventloop.h
+++ b/system/include/emscripten/eventloop.h
@@ -30,6 +30,10 @@ void emscripten_runtime_keepalive_push();
 void emscripten_runtime_keepalive_pop();
 EM_BOOL emscripten_runtime_keepalive_check();
 
+int emscripten_promise_create(void (*start_async)(void* user_data, int promise_id), void* user_data);
+void emscripten_promise_resolve(int promise_id, void* value);
+void emscripten_promise_reject(int promise_id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/core/test_native_promise.c
+++ b/test/core/test_native_promise.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <emscripten/eventloop.h>
+#include <emscripten/em_js.h>
+
+void timer_expired(void* user_data) {
+  int promise_id = (intptr_t)user_data;
+  printf("timer_expired promise_id=%d\n", promise_id);
+  emscripten_promise_resolve(promise_id, (void*)100);
+}
+
+void async_work(void* user_data, int promise_id) {
+  printf("async_work started: user_data=%ld promise_id=%d\n",
+         (intptr_t)user_data,
+         promise_id);
+  emscripten_set_timeout(timer_expired, 1000, (void*)(intptr_t)promise_id);
+}
+
+EM_JS_DEPS(deps, "$getPromise,$runtimeKeepalivePush,$runtimeKeepalivePop");
+
+EM_JS(void, exit_after_promises, (int id1, int id2), {
+  err(`exit_after_promises: ${id1} ${id2}`);
+  runtimeKeepalivePush();
+  getPromise(id1).then((value) => {
+    getPromise(id2).then((value2) => {
+      err(`promises resolved (${value}, ${value2}); exiting`);
+      runtimeKeepalivePop();
+    });
+  });
+});
+
+int main() {
+  int id1 = emscripten_promise_create(async_work, (void*)42);
+  int id2 = emscripten_promise_create(async_work, (void*)99);
+  exit_after_promises(id1, id2);
+  printf("main done\n");
+  return 0;
+}

--- a/test/core/test_native_promise.out
+++ b/test/core/test_native_promise.out
@@ -1,0 +1,7 @@
+async_work started: user_data=42 promise_id=0
+async_work started: user_data=99 promise_id=1
+exit_after_promises: 0 1
+main done
+timer_expired promise_id=0
+timer_expired promise_id=1
+promises resolved (100, 100); exiting

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9633,6 +9633,10 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.run_process([EMCC, '-c', test_file('core/test_main_reads_args_real.c'), '-o', 'real.o'] + self.get_emcc_args(ldflags=False))
     self.do_core_test('test_main_reads_args.c', emcc_args=['real.o', '-sEXIT_RUNTIME'], regex=True)
 
+  @requires_node
+  def test_native_promise(self):
+    self.do_core_test('test_native_promise.c')
+
 
 # Generate tests for everything
 def make_run(name, emcc_args, settings=None, env=None, node_args=None, require_v8=False, v8_args=None):


### PR DESCRIPTION
This API allows JS promises to be created with a unique integer handle and a native function pointer workload.  The native code can than later resolve or reject the promise using `emscripten_promise_resolve` or `emscripten_promise_reject`.

This change uses the handle allocator from library_wasmfs_opfs.js and moves it into generic code.

Split out from #18376 