### PR TITLE
[Wasm64] Fix emscripten_set_timeout and friends

### DIFF
--- a/src/library_eventloop.js
+++ b/src/library_eventloop.js
@@ -78,7 +78,7 @@ LibraryJSEventLoop = {
     return emSetImmediate(function() {
       {{{ runtimeKeepalivePop(); }}}
       callUserCallback(function() {
-        {{{ makeDynCall('vi', 'cb') }}}(userData);
+        {{{ makeDynCall('vp', 'cb') }}}(userData);
       });
     });
   },
@@ -97,20 +97,20 @@ LibraryJSEventLoop = {
     function tick() {
       {{{ runtimeKeepalivePop(); }}}
       callUserCallback(function() {
-        if ({{{ makeDynCall('ii', 'cb') }}}(userData)) {
+        if ({{{ makeDynCall('ip', 'cb') }}}(userData)) {
           {{{ runtimeKeepalivePush(); }}}
           emSetImmediate(tick);
         }
       });
     }
     {{{ runtimeKeepalivePush(); }}}
-    return emSetImmediate(tick);
+    emSetImmediate(tick);
   },
 
   emscripten_set_timeout__sig: 'ipdp',
   emscripten_set_timeout__deps: ['$safeSetTimeout'],
   emscripten_set_timeout: function(cb, msecs, userData) {
-    return safeSetTimeout(() => {{{ makeDynCall('vi', 'cb') }}}(userData), msecs);
+    return safeSetTimeout(() => {{{ makeDynCall('vp', 'cb') }}}(userData), msecs);
   },
 
   emscripten_clear_timeout__sig: 'vi',

--- a/system/include/emscripten/eventloop.h
+++ b/system/include/emscripten/eventloop.h
@@ -15,16 +15,16 @@ extern "C" {
 
 void emscripten_unwind_to_js_event_loop(void) __attribute__((__noreturn__));
 
-long emscripten_set_timeout(void (*cb)(void *userData), double msecs, void *userData);
-void emscripten_clear_timeout(long setTimeoutId);
-void emscripten_set_timeout_loop(EM_BOOL (*cb)(double time, void *userData), double intervalMsecs, void *userData);
+int emscripten_set_timeout(void (*cb)(void *user_data), double msecs, void *user_data);
+void emscripten_clear_timeout(int id);
+void emscripten_set_timeout_loop(EM_BOOL (*cb)(double time, void *user_data), double interval_ms, void *user_data);
 
-long emscripten_set_immediate(void (*cb)(void *userData), void *userData);
-void emscripten_clear_immediate(long setImmediateId);
-void emscripten_set_immediate_loop(EM_BOOL (*cb)(void *userData), void *userData);
+int emscripten_set_immediate(void (*cb)(void *user_data), void *user_data);
+void emscripten_clear_immediate(int id);
+void emscripten_set_immediate_loop(EM_BOOL (*cb)(void *user_data), void *user_data);
 
-long emscripten_set_interval(void (*cb)(void *userData), double intervalMsecs, void *userData);
-void emscripten_clear_interval(long setIntervalId);
+int emscripten_set_interval(void (*cb)(void *user_data), double interval_ms, void *user_data);
+void emscripten_clear_interval(int id);
 
 void emscripten_runtime_keepalive_push();
 void emscripten_runtime_keepalive_pop();


### PR DESCRIPTION
Timeout IDs are all numbers and not bigint so we should use `int` to represent them in C and `i` to represent in signatures.

Testing this stuff is tricky right now because use an older version node in our CI tests and functions like clearTimeout and setInterval are not available under d8.

Split out from #18392