### PR TITLE
Ensure settings, and in particular serialized settings are stable. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -186,15 +186,10 @@ def compile_javascript(symbols_only=False):
     logger.info('logging stderr in js compiler phase into %s' % stderr_file)
     stderr_file = open(stderr_file, 'w')
 
-  # Only the names of the legacy settings are used by the JS compiler
-  # so we can reduce the size of serialized json by simplifying this
-  # otherwise complex value.
-  settings['LEGACY_SETTINGS'] = [l[0] for l in settings['LEGACY_SETTINGS']]
-
   # Save settings to a file to work around v8 issue 1579
   with shared.get_temp_files().get_file('.json') as settings_file:
     with open(settings_file, 'w') as s:
-      json.dump(settings.dict(), s, sort_keys=True, indent=2)
+      json.dump(settings.external_dict(), s, sort_keys=True, indent=2)
 
     # Call js compiler
     env = os.environ.copy()

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -83,6 +83,12 @@ COMPILE_TIME_SETTINGS = {
 }.union(PORTS_SETTINGS)
 
 
+# Settings that don't need to be externalized when serializing to json because they
+# are not used by the JS compiler.
+INTERNAL_SETTINGS = {
+    'SIDE_MODULE_IMPORTS',
+}
+
 user_settings: Dict[str, str] = {}
 
 
@@ -149,6 +155,14 @@ class SettingsManager:
 
   def dict(self):
     return self.attrs
+
+  def external_dict(self):
+    external_settings = {k: v for k, v in self.dict().items() if k not in INTERNAL_SETTINGS}
+    # Only the names of the legacy settings are used by the JS compiler
+    # so we can reduce the size of serialized json by simplifying this
+    # otherwise complex value.
+    external_settings['LEGACY_SETTINGS'] = [l[0] for l in external_settings['LEGACY_SETTINGS']]
+    return external_settings
 
   def keys(self):
     return self.attrs.keys()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -694,7 +694,7 @@ def read_and_preprocess(filename, expand_macros=False):
   # Create a settings file with the current settings to pass to the JS preprocessor
 
   settings_str = ''
-  for key, value in settings.dict().items():
+  for key, value in settings.external_dict().items():
     assert key == key.upper()  # should only ever be uppercase keys in settings
     jsoned = json.dumps(value, sort_keys=True)
     settings_str += f'var {key} = {jsoned};\n'


### PR DESCRIPTION
I noticed that the symbol list cache was changing each time I linked with side modules because the ordering symbols in some of the settings was not stable.

See: #18388