### PR TITLE
Extend autoconf condition with 'conftest.cpp'

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1699,7 +1699,7 @@ def setup_pthreads(target):
 
 @ToolchainProfiler.profile_block('linker_setup')
 def phase_linker_setup(options, state, newargs):
-  autoconf = os.environ.get('EMMAKEN_JUST_CONFIGURE') or 'conftest.c' in state.orig_args
+  autoconf = os.environ.get('EMMAKEN_JUST_CONFIGURE') or 'conftest.c' in state.orig_args or 'conftest.cpp' in state.orig_args
   if autoconf:
     # configure tests want a more shell-like style, where we emit return codes on exit()
     settings.EXIT_RUNTIME = 1


### PR DESCRIPTION
Without this change emcc calls `make_js_executable` during 'configure' and em++ does not, that makes C++ checks to fail, for example in ICU build.
https://github.com/emscripten-core/emscripten/issues/8401