### PR TITLE
Remove redundant `{{BODY}}` mark logic. NFC

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -478,9 +478,8 @@ function ${name}(${args}) {
     itemsDict.globalVariablePostSet = itemsDict.globalVariablePostSet.concat(orderedPostSets);
 
     const shellFile = MINIMAL_RUNTIME ? 'shell_minimal.js' : 'shell.js';
+    print(processMacros(preprocess(read(shellFile), shellFile)));
 
-    const shellParts = read(shellFile).split('{{BODY}}');
-    print(processMacros(preprocess(shellParts[0], shellFile)));
     let pre;
     if (MINIMAL_RUNTIME) {
       pre = processMacros(preprocess(read('preamble_minimal.js'), 'preamble_minimal.js'));
@@ -533,8 +532,6 @@ function ${name}(${args}) {
     const postFile = MINIMAL_RUNTIME ? 'postamble_minimal.js' : 'postamble.js';
     const post = processMacros(preprocess(read(postFile), postFile));
     print(post);
-
-    print(processMacros(preprocess(shellParts[1], shellFile, shellParts[0].match(/\n/g).length)));
 
     print('\n//FORWARDED_DATA:' + JSON.stringify({
       librarySymbols: librarySymbols,

--- a/src/shell.js
+++ b/src/shell.js
@@ -510,5 +510,3 @@ assert(!ENVIRONMENT_IS_SHELL, "shell environment detected but not enabled at bui
 #endif
 
 #endif // ASSERTIONS
-
-{{BODY}}

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -158,5 +158,3 @@ var ENVIRONMENT_IS_WORKER = ENVIRONMENT_IS_PTHREAD = typeof importScripts == 'fu
 
 var currentScriptUrl = typeof _scriptDir != 'undefined' ? _scriptDir : ((typeof document != 'undefined' && document.currentScript) ? document.currentScript.src : undefined);
 #endif // USE_PTHREADS
-
-{{BODY}}


### PR DESCRIPTION
The shell file was split on this. Everything before this mark was emitted before `preamble{,_minimal}.js`, and everything after this mark was emitted after `postamble{,_minimal}.js`. However, this whole logic is considered redundant, since there is no code after this marker (in both `shell.js` and `shell_minimal.js`).

_Split out from #18317._