### PR TITLE
Prefer use of `val::module_property`. NFC

### DIFF
--- a/test/embind/embind_test.cpp
+++ b/test/embind/embind_test.cpp
@@ -193,14 +193,13 @@ std::u32string get_literal_u32string() {
 }
 
 void force_memory_growth() {
-    val module = val::global("Module");
     std::size_t old_size = emscripten_get_heap_size();
     EM_ASM({"globalThis.oldheap = HEAPU8;"});
     assert(val::global("oldheap")["byteLength"].as<size_t>() == old_size);
     emscripten_resize_heap(old_size + EMSCRIPTEN_PAGE_SIZE);
     assert(emscripten_get_heap_size() > old_size);
-    // global HEAPU8 should now be rebound, and our oldheap should be detached
-    assert(module["HEAPU8"]["byteLength"].as<size_t>() > old_size);
+    // HEAPU8 on the module should now be rebound, and our oldheap should be detached
+    assert(val::module_property("HEAPU8")["byteLength"].as<size_t>() > old_size);
     assert(val::global("oldheap")["byteLength"].as<size_t>() == 0);
 }
 


### PR DESCRIPTION
In favor of `val::global("Module")`.

_Split out from #18317._