### PR TITLE
Import xmlrunner only when needed

### DIFF
--- a/test/runner.py
+++ b/test/runner.py
@@ -28,7 +28,6 @@ import os
 import random
 import sys
 import unittest
-import xmlrunner # type: ignore
 
 # Setup
 
@@ -300,6 +299,7 @@ def run_tests(options, suites):
     os.makedirs('out', exist_ok=True)
     # output fd must remain open until after testRunner.run() below
     output = open('out/test-results.xml', 'wb')
+    import xmlrunner # type: ignore
     testRunner = xmlrunner.XMLTestRunner(output=output, verbosity=2,
                                          failfast=options.failfast)
     print('Writing XML test output to ' + os.path.abspath(output.name))


### PR DESCRIPTION
This should unbreak chromium CI. It will also allow running locally without
doing `pip install requirements-dev.txt`.

We could also add that `pip install` on chromium CI I suppose, but as it
seems this new package is the only thing actually requiring it, it is less
surprising for new contributors running tests on the commandline for us
to only import it when needed.