### PR TITLE
[Proxying] Pass a result to the callback

### DIFF
--- a/site/source/docs/api_reference/proxying.h.rst
+++ b/site/source/docs/api_reference/proxying.h.rst
@@ -78,13 +78,14 @@ Functions
   thread then return immediately without waiting for ``func`` to be executed.
   Returns 1 if the work was successfully enqueued or 0 otherwise.
 
-.. c:function:: int emscripten_proxy_async_with_callback(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void* arg, void (*callback)(void*), void* callback_arg)
+.. c:function:: int emscripten_proxy_async_with_callback(em_proxying_queue* q, pthread_t target_thread, void* (*func)(void*), void* arg, void (*callback)(void* arg, void* result), void* callback_arg)
 
   Enqueue `func` on the given queue and thread. Once (and if) it finishes
   executing, it will asynchronously proxy `callback` back to the current thread
-  on the same queue. Returns 1 if the initial work was successfully enqueued and
-  the target thread notified or 0 otherwise. If the callback cannot be scheduled
-  (for example due to OOM), the program is aborted.
+  on the same queue. The result of the proxied function will be passed as the
+  second argument to the callback. Returns 1 if the initial work was
+  successfully enqueued and the target thread notified or 0 otherwise. If the
+  callback cannot be scheduled (for example due to OOM), the program is aborted.
 
 .. c:function:: int emscripten_proxy_sync(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void* arg)
 

--- a/test/pthread/test_pthread_proxying.c
+++ b/test/pthread/test_pthread_proxying.c
@@ -95,6 +95,11 @@ void await_widget(widget* w) {
 
 void do_run_widget(void* arg) { run_widget((widget*)arg); }
 
+void* do_run_widget_42(void* arg) {
+  run_widget((widget*)arg);
+  return (void*)42;
+}
+
 void finish_running_widget(void* arg) {
   widget* w = (widget*)arg;
   run_widget(w);
@@ -199,7 +204,8 @@ void test_proxy_sync_with_ctx(void) {
   destroy_widget(&w7);
 }
 
-void add_one(void* arg) {
+void add_one(void* arg, void* result) {
+  assert((intptr_t)result == 42);
   int* j = (int*)arg;
   *j = *j + 1;
 }
@@ -217,7 +223,7 @@ void test_proxy_async_with_callback(void) {
 
   // Proxy to ourselves.
   emscripten_proxy_async_with_callback(
-    proxy_queue, pthread_self(), do_run_widget, &w8, add_one, &j);
+    proxy_queue, pthread_self(), do_run_widget_42, &w8, add_one, &j);
   assert(!w8.done);
   assert(j == 0);
   emscripten_proxy_execute_queue(proxy_queue);
@@ -228,7 +234,7 @@ void test_proxy_async_with_callback(void) {
 
   // Proxy to looper.
   emscripten_proxy_async_with_callback(
-    proxy_queue, looper, do_run_widget, &w9, add_one, &j);
+    proxy_queue, looper, do_run_widget_42, &w9, add_one, &j);
   await_widget(&w9);
   assert(i == 9);
   assert(w9.done);
@@ -242,7 +248,7 @@ void test_proxy_async_with_callback(void) {
 
   // Proxy to returner.
   emscripten_proxy_async_with_callback(
-    proxy_queue, returner, do_run_widget, &w10, add_one, &j);
+    proxy_queue, returner, do_run_widget_42, &w10, add_one, &j);
   await_widget(&w10);
   assert(i == 10);
   assert(w10.done);

--- a/test/pthread/test_pthread_proxying_cpp.cpp
+++ b/test/pthread/test_pthread_proxying_cpp.cpp
@@ -157,8 +157,12 @@ void test_proxy_async_with_callback(void) {
     [&]() {
       i = 1;
       executor = std::this_thread::get_id();
+      return (void*)42;
     },
-    [&]() { j++; });
+    [&](void* result) {
+      assert((intptr_t)result == 42);
+      j++;
+    });
   assert(i == 0);
   queue.execute();
   assert(i == 1);
@@ -176,8 +180,12 @@ void test_proxy_async_with_callback(void) {
         }
         executor = std::this_thread::get_id();
         cond.notify_one();
+        return (void*)1337;
       },
-      [&]() { j++; });
+      [&](void* result) {
+        assert((intptr_t)result == 1337);
+        j++;
+      });
     std::unique_lock<std::mutex> lock(mutex);
     cond.wait(lock, [&]() { return i == 2; });
     assert(executor == looper.get_id());
@@ -199,8 +207,12 @@ void test_proxy_async_with_callback(void) {
         }
         executor = std::this_thread::get_id();
         cond.notify_one();
+        return nullptr;
       },
-      [&]() { j++; });
+      [&](void* result) {
+        assert(result == nullptr);
+        j++;
+      });
     std::unique_lock<std::mutex> lock(mutex);
     cond.wait(lock, [&]() { return i == 3; });
     assert(executor == returner.get_id());


### PR DESCRIPTION
Allow the function proxied by `emscripten_proxy_async_with_callback` to return a
`void*` result that will be passed as an argument to the callback. Previously
this could be accomplished by allocating space for the result value on the
context argument passed to the proxied function and the callback, but providing
the ability to pass the value directly in the API is more convenient and can
save a separate allocation.

Fixes #18378.