### PR TITLE
Replace FS/closure/preloading hack with typeof

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1877,7 +1877,8 @@ FS.staticInit();` +
           if (onload) onload();
           removeRunDependency(dep);
         }
-        if (Browser.handledByPreloadPlugin(byteArray, fullname, finish, () => {
+        if (typeof Browser != 'undefined' &&
+            Browser.handledByPreloadPlugin(byteArray, fullname, finish, () => {
           if (onerror) onerror();
           removeRunDependency(dep);
         })) {

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -86,10 +86,6 @@ Object.defineProperties(FSNode.prototype, {
 });
 FS.FSNode = FSNode;
 FS.staticInit();` +
-#if USE_CLOSURE_COMPILER
-           // Declare variable for Closure, FS.createPreloadedFile() below calls Browser.handledByPreloadPlugin()
-           '/**@suppress {duplicate, undefinedVars}*/var Browser;' +
-#endif
            // Get module methods from settings
            '{{{ EXPORTED_RUNTIME_METHODS.filter(function(func) { return func.substr(0, 3) === 'FS_' }).map(function(func){return 'Module["' + func + '"] = FS.' + func.substr(3) + ";"}).reduce(function(str, func){return str + func;}, '') }}}';
   },

--- a/src/library_lz4.js
+++ b/src/library_lz4.js
@@ -47,7 +47,7 @@ mergeInto(LibraryManager.library, {
       // is that we only decompress the file if it can be preloaded.
       // Abstracting out the common parts seems to be more effort than it is
       // worth.
-      if (preloadPlugin) {
+      if (preloadPlugin && typeof Browser !== 'undefined') {
         Browser.init();
         pack['metadata'].files.forEach(function(file) {
           var handled = false;

--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -7,10 +7,6 @@
 mergeInto(LibraryManager.library, {
   $wasmFSPreloadedFiles: [],
   $wasmFSPreloadedDirs: [],
-#if USE_CLOSURE_COMPILER
-  // Declare variable for Closure, FS.createPreloadedFile() below calls Browser.handledByPreloadPlugin()
-  $FS__postset: '/**@suppress {duplicate, undefinedVars}*/var Browser;',
-#endif
   $FS__deps: [
     '$wasmFSPreloadedFiles',
     '$wasmFSPreloadedDirs',

--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -33,7 +33,8 @@ mergeInto(LibraryManager.library, {
           removeRunDependency(dep);
         }
 #if !MINIMAL_RUNTIME
-        if (Browser.handledByPreloadPlugin(byteArray, fullname, finish, () => {
+        if (typeof Browser != 'undefined' &&
+            Browser.handledByPreloadPlugin(byteArray, fullname, finish, () => {
           if (onerror) onerror();
           removeRunDependency(dep);
         })) {


### PR DESCRIPTION
Rather than hack in a closure exception for Browser, which may or may not be
included in the build, use `typeof Browser` to check at runtime.

This adds a few bytes, but only in projects using filesystem emulation. And it has
several benefits:

1. Removes the weird hack.
2. Running a minifier on the output later works (right now it will error as it also needs that closure exception - but we hack it in, so it just helps our own minifier internally, and another minifier will fail). This is how I noticed this issue.
3. The closure exception can mask other, real issues. In fact there was one, see the LZ4 change here, which this also fixes to not error. The exception hid a use of Browser that was unguarded and incorrect, and only went unnoticed because all our LZ4 tests are in the browser.

I considered some other options here, but didn't find a better alternative, such as
refactoring the preload-plugin code out of Browser, or adding a hack in postamble to
see if Browser was linked in (like we do for fflush), but those either add new hacks or
they add to code size.