### PR TITLE
Simplify `dynamicLibraries` + `-pthread` testcase. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9409,7 +9409,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_Module_dynamicLibraries_pthreads(self):
     # test that Module.dynamicLibraries works with pthreads
     self.emcc_args += ['-pthread', '-Wno-experimental']
-    self.emcc_args += ['--extern-pre-js', 'pre.js']
+    self.emcc_args += ['--pre-js', 'pre.js']
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
     # This test is for setting dynamicLibraries at runtime so we don't
@@ -9418,15 +9418,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('NO_AUTOLOAD_DYLIBS')
 
     create_file('pre.js', '''
-      if (!global.Module) {
-        // This is the initial load (not a worker)
-        // Define the initial state of Module as we would
-        // in the html shell file.
-        // Use var to escape the scope of the if statement
-        var Module = {
-          dynamicLibraries: ['liblib.so']
-        };
-      }
+      // Load liblib.so by default
+      Module['dynamicLibraries'] = ['liblib.so'];
     ''')
 
     self.dylink_test(

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9418,13 +9418,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('NO_AUTOLOAD_DYLIBS')
 
     create_file('pre.js', '''
-      const sideModule = 'liblib.so';
       if (typeof importScripts == 'undefined') { // !ENVIRONMENT_IS_WORKER
         // Load liblib.so by default on non-workers
-        Module['dynamicLibraries'] = [sideModule];
+        Module['dynamicLibraries'] = ['liblib.so'];
       } else {
         // Verify whether the main thread passes Module.dynamicLibraries to the worker
-        assert(Module['dynamicLibraries'].includes(sideModule));
+        assert(Module['dynamicLibraries'].includes('liblib.so'));
       }
     ''')
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9418,8 +9418,14 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('NO_AUTOLOAD_DYLIBS')
 
     create_file('pre.js', '''
-      // Load liblib.so by default
-      Module['dynamicLibraries'] = ['liblib.so'];
+      const sideModule = 'liblib.so';
+      if (typeof importScripts == 'undefined') { // !ENVIRONMENT_IS_WORKER
+        // Load liblib.so by default on non-workers
+        Module['dynamicLibraries'] = [sideModule];
+      } else {
+        // Verify whether the main thread passes Module.dynamicLibraries to the worker
+        assert(Module['dynamicLibraries'].includes(sideModule));
+      }
     ''')
 
     self.dylink_test(


### PR DESCRIPTION
The guard that checks whether this is the main thread isn't needed.

---

Perhaps this testcase was added before pthreads + dynamic linking was implemented?:
https://github.com/emscripten-core/emscripten/blob/7a865192de93599ec2429fa0bb465eab7e94a14b/emcc.py#L1616-L1623