### PR TITLE
Reorder the browser tests in Chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,9 +279,9 @@ commands:
             # that are not included by "./embuilder build ALL".  For example the
             # PIC version of libSDL which is used by test_sdl2_misc_main_module
             export EM_FROZEN_CACHE=""
-            # skip test_zzz_zzz_4gb_fail as it OOMs on the current bot
-            test/runner browser posixtest_browser.test_pthread_create_1_1 skip:browser.test_zzz_zzz_4gb_fail
             test/runner emrun
+            # skip test_zzz_zzz_4gb_fail as it OOMs on the current bot
+            test/runner posixtest_browser.test_pthread_create_1_1 browser skip:browser.test_zzz_zzz_4gb_fail
       - upload-test-results
   test-sockets-chrome:
     description: "Runs emscripten sockets tests under chrome"


### PR DESCRIPTION
Results are uploaded after this step, and only the last results are uploaded because earlier ones are overwritten (this also seems to be the case when specifying multiple tests com the test/runner command line). It didn't seem worthwhile to add multiple test and upload steps because there are only a few tests in emrun and posixtest.browser currently.