### PR TITLE
Restore previous behaviour of not mangling EM_JS functions

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -611,11 +611,10 @@ def create_em_js(metadata):
       args = args.split(',')
     arg_names = [arg.split()[-1].replace("*", "") for arg in args if arg]
     args = ','.join(arg_names)
-    mangled = asmjs_mangle(name)
-    func = f'function {mangled}({args}) {body}'
+    func = f'function {name}({args}) {body}'
     if (settings.MAIN_MODULE or settings.ASYNCIFY == 2) and name in metadata.emJsFuncTypes:
       sig = func_type_to_sig(metadata.emJsFuncTypes[name])
-      func = func + f'\n{mangled}.sig = \'{sig}\';'
+      func = func + f'\n{name}.sig = \'{sig}\';'
     em_js_funcs.append(func)
 
   return em_js_funcs
@@ -675,7 +674,7 @@ def create_sending(invoke_funcs, metadata):
   send_items_map = {}
 
   for name in metadata.emJsFuncs:
-    send_items_map[name] = asmjs_mangle(name)
+    send_items_map[name] = name
   for name in invoke_funcs:
     send_items_map[name] = name
   for name in metadata.imports:

--- a/test/core/test_em_js.cpp
+++ b/test/core/test_em_js.cpp
@@ -93,6 +93,12 @@ EM_JS(int, _prefixed, (void), {
   return 1;
 });
 
+EM_JS(int, transitive, (void), {
+  // Verify that EM_JS functions can call other EM_JS functions by thier
+  // unmangled name.
+  return noarg_int();
+});
+
 int main() {
   printf("BEGIN\n");
   noarg();
@@ -118,6 +124,7 @@ int main() {
   free(s2);
 
   printf("    _prefixed: %d\n", _prefixed());
+  printf("    transitive: %d\n", transitive());
 
   printf("END\n");
   return 0;

--- a/test/core/test_em_js.out
+++ b/test/core/test_em_js.out
@@ -25,4 +25,6 @@ no args returning double
     return_str returned: hello from js
     return_utf8_str returned: こんにちは
     _prefixed: 1
+no args returning int
+    transitive: 12
 END


### PR DESCRIPTION
As part of #18391 (as yet unreleased) I changed the behaviour of EM_JS functions such that ther were underscore mangled like native functions. However this change in naming can break existing code and is not needed for the fix after all.