### PR TITLE
Report errors early when min browser versions are not compatible

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12763,31 +12763,25 @@ foo/version.txt
     response = response.replace(root, '<root>')
     self.assertTextDataIdentical(expected, response)
 
+  def test_min_browser_version(self):
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Werror', '-sWASM_BIGINT', '-sMIN_SAFARI_VERSION=120000'])
+    self.assertContained('emcc: error: MIN_SAFARI_VERSION=120000 is not compatible with WASM_BIGINT (150000 or above required)', err)
+
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Werror', '-pthread', '-sMIN_CHROME_VERSION=73'])
+    self.assertContained('emcc: error: MIN_CHROME_VERSION=73 is not compatible with pthreads (74 or above required)', err)
+
   def test_signext_lowering(self):
-    cmd = [EMCC, test_file('other/test_signext_lowering.c'), '-sWASM_BIGINT']
+    # Use `-v` to show the sub-commands being run by emcc.
+    cmd = [EMCC, test_file('other/test_signext_lowering.c'), '-v']
 
-    # We expect ERROR_ON_WASM_CHANGES_AFTER_LINK to fail due lowering of sign-ext being
-    # required for safari 12.
-    output = self.expect_fail(cmd + ['-sERROR_ON_WASM_CHANGES_AFTER_LINK', '-sMIN_SAFARI_VERSION=120000'])
-    self.assertContained('error: changes to the wasm are required after link, but disallowed by ERROR_ON_WASM_CHANGES_AFTER_LINK', output)
-    self.assertContained('--signext-lowering', output)
+    # By default we don't expect the lowering pass to be run.
+    err = self.run_process(cmd, stderr=subprocess.PIPE).stderr
+    self.assertNotContained('--signext-lowering', err)
 
-    # Same for firefox
-    output = self.expect_fail(cmd + ['-sERROR_ON_WASM_CHANGES_AFTER_LINK', '-sMIN_FIREFOX_VERSION=61'])
-    self.assertContained('error: changes to the wasm are required after link, but disallowed by ERROR_ON_WASM_CHANGES_AFTER_LINK', output)
-    self.assertContained('--signext-lowering', output)
-
-    # Same for chrome
-    output = self.expect_fail(cmd + ['-sERROR_ON_WASM_CHANGES_AFTER_LINK', '-sMIN_CHROME_VERSION=73'])
-    self.assertContained('error: changes to the wasm are required after link, but disallowed by ERROR_ON_WASM_CHANGES_AFTER_LINK', output)
-    self.assertContained('--signext-lowering', output)
-
-    # Running the same command with safari 14.1 should succeed because no lowering
-    # is required.
-    self.run_process(cmd + ['-sERROR_ON_WASM_CHANGES_AFTER_LINK', '-sMIN_SAFARI_VERSION=140100'])
-    self.assertEqual('1\n', self.run_js('a.out.js'))
-
-    # Running without ERROR_ON_WASM_CHANGES_AFTER_LINK but with safari 12
-    # should successfully lower sign-ext.
-    self.run_process(cmd + ['-sMIN_SAFARI_VERSION=120000', '-o', 'lowered.js'])
-    self.assertEqual('1\n', self.run_js('lowered.js'))
+    # Specifying an older browser version should trigger the lowering pass
+    err = self.run_process(cmd + ['-sMIN_SAFARI_VERSION=120000'], stderr=subprocess.PIPE).stderr
+    self.assertContained('--signext-lowering', err)
+    err = self.run_process(cmd + ['-sMIN_FIREFOX_VERSION=61'], stderr=subprocess.PIPE).stderr
+    self.assertContained('--signext-lowering', err)
+    err = self.run_process(cmd + ['-sMIN_CHROME_VERSION=73'], stderr=subprocess.PIPE).stderr
+    self.assertContained('--signext-lowering', err)

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -9,6 +9,7 @@ import logging
 from enum import IntEnum, auto
 
 from .settings import settings, user_settings
+from . import diagnostics
 
 logger = logging.getLogger('feature_matrix')
 
@@ -19,6 +20,7 @@ class Feature(IntEnum):
   BULK_MEMORY = auto()
   MUTABLE_GLOBALS = auto()
   JS_BIGINT_INTEGRATION = auto()
+  THREADS = auto()
 
 
 default_features = {Feature.SIGN_EXT, Feature.MUTABLE_GLOBALS}
@@ -49,6 +51,11 @@ min_browser_versions = {
     'firefox': 68,
     'safari': 150000,
   },
+  Feature.THREADS: {
+    'chrome': 74,
+    'firefox': 79,
+    'safari': 140100,
+  },
 }
 
 
@@ -70,14 +77,22 @@ def caniuse(feature):
   return True
 
 
-def enable_feature(feature):
+def enable_feature(feature, reason):
   """Updates default settings for browser versions such that the given
   feature is available everywhere.
   """
   for name, min_version in min_browser_versions[feature].items():
     name = f'MIN_{name.upper()}_VERSION'
-    if settings[name] < min_version and name not in user_settings:
-      setattr(settings, name, min_version)
+    if settings[name] < min_version:
+      if name in user_settings:
+        # If the user explicitly chose an older version we issue a warning.
+        diagnostics.warning(
+            'compatibility',
+            f'{name}={user_settings[name]} is not compatible with {reason} '
+            f'({min_version} or above required)')
+      else:
+        # Otherwise we bump the minimum version to accommodate the feature.
+        setattr(settings, name, min_version)
 
 
 # apply minimum browser version defaults based on user settings. if
@@ -85,4 +100,7 @@ def enable_feature(feature):
 # from a specific version and above, we can assume that browser version.
 def apply_min_browser_versions():
   if settings.WASM_BIGINT:
-    enable_feature(Feature.JS_BIGINT_INTEGRATION)
+    enable_feature(Feature.JS_BIGINT_INTEGRATION, 'WASM_BIGINT')
+  if settings.USE_PTHREADS:
+    enable_feature(Feature.THREADS, 'pthreads')
+    enable_feature(Feature.BULK_MEMORY, 'pthreads')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -74,6 +74,7 @@ diagnostics.add_warning('transpile')
 diagnostics.add_warning('limited-postlink-optimizations')
 diagnostics.add_warning('em-js-i64')
 diagnostics.add_warning('js-compiler')
+diagnostics.add_warning('compatibility')
 # Closure warning are not (yet) enabled by default
 diagnostics.add_warning('closure', enabled=False)
 


### PR DESCRIPTION
This caused the test_signext_lowering test to having to be re-written in a different way since it was depending on simultaneously settings WASM_BIGINT and targeting older browser versions (which is now an error).

See #18437