### PR TITLE
Don't default to SDLv1 for un-versioned SDL includes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,11 @@ See docs/process.md for more on how version tagging works.
 
 3.1.30 (in development)
 -----------------------
+- The SDLv1 header directory is no longer added to the include path by default.
+  This means if you include SDL headers without the explicit version in them
+  (e.g. `SDL_events.h`) you will now need to add `-sUSE_SDL` explicitly at
+  compile time.  If you include the SDL headers with the directory name included
+  (e.g. `SDL/SDL_events.h`) you will not be affected by this change. (#18443)
 
 3.1.29 - 01/03/23
 -----------------

--- a/emcc.py
+++ b/emcc.py
@@ -917,6 +917,9 @@ def emsdk_cflags(user_args):
   if array_contains_any_of(user_args, SIMD_NEON_FLAGS):
     cflags += ['-D__ARM_NEON__=1']
 
+  if not settings.USE_SDL:
+    cflags += ['-Xclang', '-iwithsysroot' + os.path.join('/include', 'fakesdl')]
+
   return cflags + ['-Xclang', '-iwithsysroot' + os.path.join('/include', 'compat')]
 
 
@@ -1915,9 +1918,6 @@ def phase_linker_setup(options, state, newargs):
     default_setting('AUTO_ARCHIVE_INDEXES', 0)
     default_setting('IGNORE_MISSING_MAIN', 0)
     default_setting('ALLOW_UNIMPLEMENTED_SYSCALLS', 0)
-
-  if not settings.AUTO_JS_LIBRARIES:
-    default_setting('USE_SDL', 0)
 
   if 'GLOBAL_BASE' not in user_settings and not settings.SHRINK_LEVEL and not settings.OPT_LEVEL:
     # When optimizing for size it helps to put static data first before

--- a/src/settings.js
+++ b/src/settings.js
@@ -1406,7 +1406,7 @@ var LEGALIZE_JS_FFI = true;
 // When AUTO_JS_LIBRARIES is set to 0 this defaults to 0 and SDL
 // is not linked in.
 // [compile+link]
-var USE_SDL = 1;
+var USE_SDL = 0;
 
 // Specify the SDL_gfx version that is being linked against. Must match USE_SDL
 // [compile+link]

--- a/system/include/fakesdl/SDL.h
+++ b/system/include/fakesdl/SDL.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_assert.h
+++ b/system/include/fakesdl/SDL_assert.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_atomic.h
+++ b/system/include/fakesdl/SDL_atomic.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_audio.h
+++ b/system/include/fakesdl/SDL_audio.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_blendmode.h
+++ b/system/include/fakesdl/SDL_blendmode.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_clipboard.h
+++ b/system/include/fakesdl/SDL_clipboard.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_compat.h
+++ b/system/include/fakesdl/SDL_compat.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_config.h
+++ b/system/include/fakesdl/SDL_config.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_copying.h
+++ b/system/include/fakesdl/SDL_copying.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_cpuinfo.h
+++ b/system/include/fakesdl/SDL_cpuinfo.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_endian.h
+++ b/system/include/fakesdl/SDL_endian.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_error.h
+++ b/system/include/fakesdl/SDL_error.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_events.h
+++ b/system/include/fakesdl/SDL_events.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_gesture.h
+++ b/system/include/fakesdl/SDL_gesture.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_gfxPrimitives.h
+++ b/system/include/fakesdl/SDL_gfxPrimitives.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_haptic.h
+++ b/system/include/fakesdl/SDL_haptic.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_hints.h
+++ b/system/include/fakesdl/SDL_hints.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_image.h
+++ b/system/include/fakesdl/SDL_image.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_input.h
+++ b/system/include/fakesdl/SDL_input.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_joystick.h
+++ b/system/include/fakesdl/SDL_joystick.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_keyboard.h
+++ b/system/include/fakesdl/SDL_keyboard.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_keycode.h
+++ b/system/include/fakesdl/SDL_keycode.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_loadso.h
+++ b/system/include/fakesdl/SDL_loadso.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_log.h
+++ b/system/include/fakesdl/SDL_log.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_main.h
+++ b/system/include/fakesdl/SDL_main.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_mixer.h
+++ b/system/include/fakesdl/SDL_mixer.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_mouse.h
+++ b/system/include/fakesdl/SDL_mouse.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_mutex.h
+++ b/system/include/fakesdl/SDL_mutex.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_name.h
+++ b/system/include/fakesdl/SDL_name.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_opengl.h
+++ b/system/include/fakesdl/SDL_opengl.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_opengles.h
+++ b/system/include/fakesdl/SDL_opengles.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_opengles2.h
+++ b/system/include/fakesdl/SDL_opengles2.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_pixels.h
+++ b/system/include/fakesdl/SDL_pixels.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_platform.h
+++ b/system/include/fakesdl/SDL_platform.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_power.h
+++ b/system/include/fakesdl/SDL_power.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_quit.h
+++ b/system/include/fakesdl/SDL_quit.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_rect.h
+++ b/system/include/fakesdl/SDL_rect.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_render.h
+++ b/system/include/fakesdl/SDL_render.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_revision.h
+++ b/system/include/fakesdl/SDL_revision.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_rotozoom.h
+++ b/system/include/fakesdl/SDL_rotozoom.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_rwops.h
+++ b/system/include/fakesdl/SDL_rwops.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_scancode.h
+++ b/system/include/fakesdl/SDL_scancode.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_shape.h
+++ b/system/include/fakesdl/SDL_shape.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_stdinc.h
+++ b/system/include/fakesdl/SDL_stdinc.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_surface.h
+++ b/system/include/fakesdl/SDL_surface.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_syswm.h
+++ b/system/include/fakesdl/SDL_syswm.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_thread.h
+++ b/system/include/fakesdl/SDL_thread.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_timer.h
+++ b/system/include/fakesdl/SDL_timer.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_touch.h
+++ b/system/include/fakesdl/SDL_touch.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_ttf.h
+++ b/system/include/fakesdl/SDL_ttf.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_types.h
+++ b/system/include/fakesdl/SDL_types.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_version.h
+++ b/system/include/fakesdl/SDL_version.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/system/include/fakesdl/SDL_video.h
+++ b/system/include/fakesdl/SDL_video.h
@@ -1,0 +1,1 @@
+#error "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"

--- a/test/browser/test_sdl_alloctext.c
+++ b/test/browser/test_sdl_alloctext.c
@@ -6,8 +6,8 @@
  */
 
 #include <stdio.h>
-#include <SDL.h>
-#include <SDL_ttf.h>
+#include <SDL/SDL.h>
+#include <SDL/SDL_ttf.h>
 
 int main()
 {

--- a/test/browser/test_sdl_surface_refcount.c
+++ b/test/browser/test_sdl_surface_refcount.c
@@ -7,7 +7,7 @@
 
 #include <emscripten.h>
 #include <assert.h>
-#include <SDL.h>
+#include <SDL/SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/test/browser/test_sdl_ttf_render_text_solid.c
+++ b/test/browser/test_sdl_ttf_render_text_solid.c
@@ -6,8 +6,8 @@
  */
 
 #include <stdio.h>
-#include <SDL.h>
-#include <SDL_ttf.h>
+#include <SDL/SDL.h>
+#include <SDL/SDL_ttf.h>
 
 int main()
 {

--- a/test/emscripten_api_browser.c
+++ b/test/emscripten_api_browser.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>
-#include <SDL.h>
+#include <SDL/SDL.h>
 #include <emscripten.h>
 #include <assert.h>
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2483,6 +2483,7 @@ int main(int argc, char **argv) {
 
   @no_wasm2js('massive switches can break js engines')
   def test_bigswitch(self):
+    self.set_setting('USE_SDL')
     self.do_runf(test_file('bigswitch.cpp'), '''34962: GL_ARRAY_BUFFER (0x8892)
 26214: what?
 35040: GL_STREAM_DRAW (0x88E0)

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -26,7 +26,7 @@ def get(ports, settings, shared):
     src_dir = os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG)
     ports.install_headers(src_dir, target='SDL2')
     excludes = ['chatd.c', 'chat.cpp', 'showinterfaces.c']
-    ports.build_port(src_dir, final, 'sdl2_net', exclude_files=excludes)
+    ports.build_port(src_dir, final, 'sdl2_net', exclude_files=excludes, flags=['-sUSE_SDL=2'])
 
   return [shared.cache.get_lib('libSDL2_net.a', create, what='port')]
 


### PR DESCRIPTION
With SDL you can choose to either include the header files via the          
explictly version prefix (e.g. `<SDL/SDL_audio.h>` or                    
`<SDL2/SDL_audio.h>`.  Or some folks configure the include path such        
that the unversioned includes can be used (`#include <SDL_audio.h>`).  

Emscripten allows the unversioned form by putting the `SDL` or `SDL2`       
directory on the include path based on the USE_SDL settings, but the        
fact that were defaulting to enabling version 1 was causing some issues  
(See #18072 and #184402 for more details).                               
                                                                         
After this change we default to not adding either of these include          
paths.  This means that folks who want to use un-versioned includes will 
now need to opt into one version of the other via `-sUSE_SDL`.           
                                                                         
Note that folks using the explict `<SDL/SDL_audio.h>` includes are not   
effected by this (that will always result in an SDL v1 header being         
included).                                                               
                                                                         
In order to make it more obvious that use of `<SDL_audio.h>` now         
requires an opt in, I created dummy headers that should give effected       
users and clear error message.                                           
                                                                         
We've already been doing this in STRICT module for a while now.          
                                                                         
Fixes: #18072, #18440  