### PR TITLE
[CMake/FindOpenAL] Added the OpenAL_FOUND variable

### DIFF
--- a/cmake/Modules/FindOpenAL.cmake
+++ b/cmake/Modules/FindOpenAL.cmake
@@ -7,7 +7,8 @@
 # The implementation is based on the standard FindOpenAL.cmake provided with CMake,
 # but customized for targeting Emscripten only.
 
-if (NOT OPENAL_FOUND)
+if (NOT OpenAL_FOUND OR NOT OPENAL_FOUND)
+	SET(OpenAL_FOUND TRUE)
 	SET(OPENAL_FOUND TRUE)
 
 	# For Emscripten-compiled apps in the test suite (test_alut), this is expected...


### PR DESCRIPTION
As per [CMake's documentation](https://cmake.org/cmake/help/latest/command/find_package.html#basic-signature), a `find_package()` call is expected to make available a `<PackageName>_FOUND` variable, with its name as-is, uncapitalized:
> ```cmake
> find_package(<PackageName> ...)
> ```
> [...] a `<PackageName>_FOUND` variable will be set to indicate whether the package was found.

As is mentioned in Emscripten's script, it is based on CMake's built-in one, which does [this call](https://gitlab.kitware.com/cmake/cmake/-/blob/927e091949baf4e9627f48444a90191780501cc4/Modules/FindOpenAL.cmake#L100-104):
> ```cmake
> find_package_handle_standard_args(
>  OpenAL
>  REQUIRED_VARS OPENAL_LIBRARY OPENAL_INCLUDE_DIR
>  VERSION_VAR OPENAL_VERSION_STRING
>  )
> ```

The [documentation](https://cmake.org/cmake/help/latest/module/FindPackageHandleStandardArgs.html) specifies that this call produces, along with the historically capitalized found variable, an uncapitalized one:
> It also sets the `<PackageName>_FOUND` variable.

> `FOUND_VAR <result-var>`
> Deprecated since version 3.3.
>
> Specifies either `<PackageName>_FOUND` or `<PACKAGENAME>_FOUND` as the result variable. This exists only for compatibility with older versions of CMake and is now ignored. **Result variables of both names are always set for compatibility.**

> Example for the simple signature:
> ```cmake
>find_package_handle_standard_args(LibXml2 DEFAULT_MSG
>  LIBXML2_LIBRARY LIBXML2_INCLUDE_DIR)
> ```
> The `LibXml2` package is considered to be found if both `LIBXML2_LIBRARY` and `LIBXML2_INCLUDE_DIR` are valid. **Then also `LibXml2_FOUND` is set to `TRUE`.**

This pull request thus adds this uncapitalized variable for consistency.