### PR TITLE
Don't rebuilt the cache every time the config file changes. NFC

### DIFF
--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -346,12 +346,6 @@ fi
     self.assertNotContained(SANITY_MESSAGE, output)
     self.assertNotContained(SANITY_FAIL_MESSAGE, output)
 
-    # emcc should also check sanity if the file is outdated
-    open(EM_CONFIG, 'a').write('# extra stuff\n')
-    output = self.check_working(EMCC)
-    self.assertContained(SANITY_MESSAGE, output)
-    self.assertNotContained(SANITY_FAIL_MESSAGE, output)
-
   def test_em_config_env_var(self):
     # emcc should be configurable directly from EM_CONFIG without any config file
     restore_and_set_up()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -8,7 +8,6 @@ from .toolchain_profiler import ToolchainProfiler
 from functools import wraps
 from subprocess import PIPE
 import atexit
-import binascii
 import json
 import logging
 import os
@@ -382,14 +381,7 @@ def set_version_globals():
 
 
 def generate_sanity():
-  sanity_file_content = f'{EMSCRIPTEN_VERSION}|{config.LLVM_ROOT}|{get_clang_version()}'
-  if os.path.exists(config.EM_CONFIG):
-    config_data = utils.read_file(config.EM_CONFIG)
-  else:
-    config_data = ''
-  checksum = binascii.crc32(config_data.encode())
-  sanity_file_content += '|%#x\n' % checksum
-  return sanity_file_content
+  return f'{EMSCRIPTEN_VERSION}|{config.LLVM_ROOT}|{get_clang_version()}'
 
 
 def perform_sanity_checks():


### PR DESCRIPTION
This effectively reverts #11196.  It turns out this caused a lot of unnecessary rebuilding for developers without much real benefit.

If we include the config hash then ever time the config file is edited (for example, to add or remove something from WASM_ENGINES or JS_ENGINES, which are only used during testing) all the libraries would then get needlessly rebuilt.

Since the sanity file already includes the emscripten version and llvm version that should catch most of he cases where the libraries really do require a rebuild.

Changes to the specific llvm or emscripten GIT revision do not cause the cache to get re-built even if we do include the config file hash so it isn't really providing any usefull benefit.