### PR TITLE
Update MINIMUM_NODE_VERSION to match the emsdk version

### DIFF
--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -280,8 +280,9 @@ class sanity(RunnerCore):
 
     for version, succeed in [('v0.8.0', False),
                              ('v4.1.0', False),
-                             ('v4.1.1', True),
-                             ('v4.2.3-pre', True),
+                             ('v14.18.1', False),
+                             ('v14.18.2', True),
+                             ('v14.18.3-pre', True),
                              ('cheez', False)]:
       print(version, succeed)
       delete_file(SANITY_FILE)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -45,7 +45,11 @@ from .settings import settings
 
 
 DEBUG_SAVE = DEBUG or int(os.environ.get('EMCC_DEBUG_SAVE', '0'))
-MINIMUM_NODE_VERSION = (4, 1, 1)
+# Minimum node version required to run the emscripten compiler.  This is not
+# distict from minimum version of node required to execute the generted code.
+# This is not a strict requirement, but this is version of node we ship with
+# emsdk and the oldest version we use when testing the compiler.
+MINIMUM_NODE_VERSION = (14, 18, 2)
 EXPECTED_LLVM_VERSION = "16.0"
 
 # Used only when EM_PYTHON_MULTIPROCESSING=1 env. var is set.


### PR DESCRIPTION
We don't test emscripten on older version of node than this so it seems reasonable to require at least this version.