### PR TITLE
Stack size error message missing important setting

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3148,7 +3148,7 @@ mergeInto(LibraryManager.library, {
     var end = _emscripten_stack_get_end();
     abort('stack overflow (Attempt to set SP to ' + ptrToString(requested) +
           ', with stack limits [' + ptrToString(end) + ' - ' + ptrToString(base) +
-          ']). If you require more stack space build with -sSTACK_SIZE=<bytes>');
+          ']). If you require more stack space build with -sSTACK_SIZE=<bytes> and -sDEFAULT_PTHREAD_STACK_SIZE=<bytes>');
   },
 #endif
 


### PR DESCRIPTION
Please considering mentioning DEFAULT_PTHREAD_STACK_SIZE alongside STACK_SIZE in the runtime error reporting.  DEFAULT_PTHREAD_STACK_SIZE is not well documented.  Anyone using pthreads will waste a lot of time trying to figure out why their code is failing (I know I did).