### PR TITLE
Set pthread stack size when `-sSTACK_SIZE` is set

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 3.1.30 (in development)
 -----------------------
+- The default pthread stack size will now be set to match `-sSTACK_SIZE` by
+  default.  Set `DEFAULT_PTHREAD_STACK_SIZE` explicitly to override this.
+  (#18479)
 - The `buffer` JavaScript variable was removed.  This underlying buffer is
   still accessible via `wasmMemory.buffer` or `HEAPXX.buffer`.  In debug builds,
   a clear error is shown if you try to use it.  (#18454)

--- a/emcc.py
+++ b/emcc.py
@@ -1627,6 +1627,8 @@ def setup_pthreads(target):
   if settings.ALLOW_MEMORY_GROWTH:
     diagnostics.warning('pthreads-mem-growth', 'USE_PTHREADS + ALLOW_MEMORY_GROWTH may run non-wasm code slowly, see https://github.com/WebAssembly/design/issues/1271')
 
+  default_setting('DEFAULT_PTHREAD_STACK_SIZE', settings.STACK_SIZE)
+
   # Functions needs to be exported from the module since they are used in worker.js
   settings.REQUIRED_EXPORTS += [
     'emscripten_dispatch_to_thread_',

--- a/src/settings.js
+++ b/src/settings.js
@@ -1581,18 +1581,14 @@ var PTHREAD_POOL_SIZE_STRICT = 1;
 // [link] - affects generated JS runtime code at link time
 var PTHREAD_POOL_DELAY_LOAD = false;
 
-// If not explicitly specified, this is the stack size to use for newly created
-// pthreads.  According to
-// http://man7.org/linux/man-pages/man3/pthread_create.3.html, default stack
-// size on Linux/x86-32 for a new thread is 2 megabytes, so follow the same
-// convention. Use pthread_attr_setstacksize() at thread creation time to
-// explicitly specify the stack size, in which case this value is ignored. Note
-// that the wasm function call control flow stack is separate from this
-// stack, and this stack only contains certain function local variables, such as
-// those that have their addresses taken, or ones that are too large to fit as
-// local vars in wasm code.
+// Default stack size to use for newly created pthreads.  When not set, this
+// defaults to STACK_SIZE (which in turn defaults to 64k).  Can also be set at
+// runtime using pthread_attr_setstacksize().  Note that the wasm control flow
+// stack is separate from this stack.  This stack only contains certain function
+// local variables, such as those that have their addresses taken, or ones that
+// are too large to fit as local vars in wasm code.
 // [link]
-var DEFAULT_PTHREAD_STACK_SIZE = 64*1024;
+var DEFAULT_PTHREAD_STACK_SIZE = 0;
 
 // True when building with --threadprofiler
 // [link]


### PR DESCRIPTION
This was always my intention with #18191 but somehow it got left out.  I think it makes sense that user to override `STACK_SIZE` also, by default, override the pthread stack size.  Such users can always explicitly set the pthread stack size if they don't want this behaviour.

See #18472