### PR TITLE
Ensure compatibility with Safari for multi-environment ES6 builds

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3767,9 +3767,10 @@ def modularize():
   if not settings.EXPORT_READY_PROMISE:
     return_value = '{}'
 
+  # FIXME: https://bugs.webkit.org/show_bug.cgi?id=223533
   src = '''
-%(maybe_async)sfunction(%(EXPORT_NAME)s) {
-  %(EXPORT_NAME)s = %(EXPORT_NAME)s || {};
+%(maybe_async)sfunction(_%(EXPORT_NAME)s) {
+  %(EXPORT_NAME)s = _%(EXPORT_NAME)s || {};
 
 %(src)s
 

--- a/emcc.py
+++ b/emcc.py
@@ -3769,8 +3769,8 @@ def modularize():
 
   # FIXME: https://bugs.webkit.org/show_bug.cgi?id=223533
   src = '''
-%(maybe_async)sfunction(_%(EXPORT_NAME)s) {
-  %(EXPORT_NAME)s = _%(EXPORT_NAME)s || {};
+%(maybe_async)sfunction(config) {
+  var %(EXPORT_NAME)s = config || {};
 
 %(src)s
 

--- a/emcc.py
+++ b/emcc.py
@@ -3767,7 +3767,10 @@ def modularize():
   if not settings.EXPORT_READY_PROMISE:
     return_value = '{}'
 
-  # FIXME: https://bugs.webkit.org/show_bug.cgi?id=223533
+  # TODO: Remove when https://bugs.webkit.org/show_bug.cgi?id=223533 is resolved.
+  if async_emit != '' and settings.EXPORT_NAME == 'config':
+    diagnostics.warning('emcc', 'EXPORT_NAME should not be named "config" when targeting Safari')
+
   src = '''
 %(maybe_async)sfunction(config) {
   var %(EXPORT_NAME)s = config || {};


### PR DESCRIPTION
Use a different parameter name to prevent the variable from being incorrectly hoisted in JavaScriptCore-based engines (such as Safari). See: https://bugs.webkit.org/show_bug.cgi?id=223533.

Regressed for multi-environment ES6 builds since commit ce4c405 (Emscripten 3.1.27). `-sENVIRONMENT=web` is not affected, as that would avoid the emit of this async function altogether.

Resolves: #18357.

---

Opened as a draft because I do not have access to macOS devices nor have I tested this locally with JSC.