### PR TITLE
Fix deadlock in dlopen. NFC

### DIFF
--- a/test/core/pthread/test_pthread_dlopen_many.c
+++ b/test/core/pthread/test_pthread_dlopen_many.c
@@ -1,0 +1,72 @@
+#include <assert.h>
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stdio.h>
+
+#ifndef NUM_THREADS
+#define NUM_THREADS 2
+#endif
+
+typedef int* (*sidey_data_type)();
+typedef int (*func_t)();
+typedef func_t (*sidey_func_type)();
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+_Atomic int thread_count = 0;
+
+void* thread_main(void* arg) {
+  int num = (intptr_t)arg;
+  printf("thread_main %d %p\n", num, pthread_self());
+  thread_count++;
+
+  // busy wait until all threads are running
+  while (thread_count != NUM_THREADS) {}
+
+  char filename[255];
+  sprintf(filename, "liblib%d.so", num);
+  printf("loading %s\n", filename);
+  void* handle = dlopen(filename, RTLD_NOW|RTLD_GLOBAL);
+  printf("done loading %s\n", filename);
+  if (!handle) {
+    printf("dlerror: %s\n", dlerror());
+  }
+  assert(handle);
+  /*
+   * TODO(sbc): We have a bug that new functions added to the table via dlsym
+   * are not yet correctly synchronized between threads.
+   * Uncommenting the code below will cause a "table out of sync" error.
+   */
+  /*
+  sidey_data_type p_side_data_address;
+  sidey_func_type p_side_func_address;
+  p_side_data_address = dlsym(handle, "side_data_address");
+  printf("p_side_data_address=%p\n", p_side_data_address);
+  p_side_func_address = dlsym(handle, "side_func_address");
+  printf("p_side_func_address=%p\n", p_side_func_address);
+  */
+
+  printf("done thread_main %d\n", num);
+  return NULL;
+}
+
+int main() {
+  printf("in main: %p\n", pthread_self());
+  pthread_mutex_lock(&mutex);
+
+  // start a bunch of threads while holding the lock
+  pthread_t threads[NUM_THREADS];
+  for (int i = 0; i < NUM_THREADS; i++) {
+    pthread_create(&threads[i], NULL, thread_main, (void*)i);
+  }
+
+  // busy wait until all threads are running
+  while (thread_count != NUM_THREADS) {}
+
+  for (int i = 0; i < NUM_THREADS; i++) {
+    pthread_join(threads[i], NULL);
+  }
+
+  printf("main done\n");
+  return 0;
+}

--- a/test/core/pthread/test_pthread_dlopen_side.c
+++ b/test/core/pthread/test_pthread_dlopen_side.c
@@ -1,11 +1,17 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 typedef int (*myfunc_type)();
 
 static int mydata[10] = { 44 };
 
+static void dtor() {
+  puts("side module atexit ..");
+}
+
 __attribute__((constructor)) static void ctor() {
   puts("side module ctor");
+  atexit(dtor);
 }
 
 static int myfunc() {

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9358,6 +9358,24 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @needs_dylink
   @node_pthreads
+  def test_pthread_dlopen_many(self):
+    nthreads = 10
+    self.set_setting('USE_PTHREADS')
+    self.emcc_args.append('-Wno-experimental')
+    self.build_dlfcn_lib(test_file('core/pthread/test_pthread_dlopen_side.c'))
+    for i in range(nthreads):
+      shutil.copyfile('liblib.so', f'liblib{i}.so')
+
+    self.prep_dlfcn_main()
+    self.set_setting('EXIT_RUNTIME')
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.do_runf(test_file('core/pthread/test_pthread_dlopen_many.c'),
+                 ['side module ctor', 'main done', 'side module atexit'],
+                 emcc_args=[f'-DNUM_THREADS={nthreads}'],
+                 assert_all=True)
+
+  @needs_dylink
+  @node_pthreads
   def test_pthread_dlsym(self):
     self.set_setting('USE_PTHREADS')
     self.emcc_args.append('-Wno-experimental')


### PR DESCRIPTION
When within dlopen itself we hold an exclusive lock so we need to disable the automatic code synchronization during that time.

Split out from #18376