### PR TITLE
Fix undefined EM_JS symbol with dynamic linking

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -673,12 +673,13 @@ def create_sending(invoke_funcs, metadata):
   # Map of wasm imports to mangled/external/JS names
   send_items_map = {}
 
-  for name in metadata.emJsFuncs:
-    send_items_map[name] = name
   for name in invoke_funcs:
     send_items_map[name] = name
   for name in metadata.imports:
-    send_items_map[name] = asmjs_mangle(name)
+    if name in metadata.emJsFuncs:
+      send_items_map[name] = name
+    else:
+      send_items_map[name] = asmjs_mangle(name)
 
   add_standard_wasm_imports(send_items_map)
 

--- a/test/other/test_em_js_main_module_address.c
+++ b/test/other/test_em_js_main_module_address.c
@@ -1,0 +1,19 @@
+#include <emscripten.h>
+#include <stdio.h>
+
+EM_JS(void, foo, (void), {
+  err("hello");
+});
+
+// Take the address of foo and store it in a global.
+void (*f)(void) = &foo;
+
+int main() {
+  printf("main\n");
+  // Calling en EM_JS function by its address, without also importing
+  // as a normal function, doesn't yet work with dynamic linking and this
+  // call will fail with `Missing signature argument to addFunction`.
+  f();
+  printf("done\n");
+  return 0;
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11666,6 +11666,20 @@ exec "$@"
     err = self.expect_fail([EMXX, '-sSIDE_MODULE', test_file('core/test_em_js.cpp')])
     self.assertContained('EM_JS is not supported in side modules', err)
 
+  def test_em_js_main_module(self):
+    self.set_setting('MAIN_MODULE', 2)
+    self.set_setting('EXPORTED_FUNCTIONS', '_main,_malloc')
+    self.do_runf(test_file('core/test_em_js.cpp'))
+
+  def test_em_js_main_module_address(self):
+    # This works under static linking but is known to fail with dynamic linking
+    # See https://github.com/emscripten-core/emscripten/issues/18494
+    self.do_runf(test_file('other/test_em_js_main_module_address.c'))
+
+    self.set_setting('MAIN_MODULE', 2)
+    expected = 'Aborted(Assertion failed: Missing signature argument to addFunction: function foo() { err("hello"); })'
+    self.do_runf(test_file('other/test_em_js_main_module_address.c'), expected, assert_returncode=NON_ZERO)
+
   # On Windows maximum command line length is 32767 characters. Create such a long build line by linking together
   # several .o files to test that emcc internally uses response files properly when calling llvmn-nm and wasm-ld.
   @is_slow_test

--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -254,13 +254,12 @@ def get_export_names(module):
 def update_metadata(filename, metadata):
   imports = []
   invoke_funcs = []
-  em_js_funcs = set(metadata.emJsFuncs)
   with webassembly.Module(filename) as module:
     for i in module.get_imports():
       if i.kind == webassembly.ExternType.FUNC:
         if i.field.startswith('invoke_'):
           invoke_funcs.append(i.field)
-        elif i.field not in em_js_funcs:
+        else:
           imports.append(i.field)
       elif i.kind in (webassembly.ExternType.GLOBAL, webassembly.ExternType.TAG):
         imports.append(i.field)
@@ -316,10 +315,10 @@ def extract_metadata(filename):
       if i.kind == webassembly.ExternType.FUNC:
         if i.field.startswith('invoke_'):
           invoke_funcs.append(i.field)
-        elif i.field in em_js_funcs:
-          types = module.get_types()
-          em_js_func_types[i.field] = types[i.type]
         else:
+          if i.field in em_js_funcs:
+            types = module.get_types()
+            em_js_func_types[i.field] = types[i.type]
           import_names.append(i.field)
       elif i.kind in (webassembly.ExternType.GLOBAL, webassembly.ExternType.TAG):
         import_names.append(i.field)


### PR DESCRIPTION
There are two issues that need fixing to actually fix #18494.  This only fixes one of them.