### PR TITLE
Fix incorrect placement of dependency to malloc from stringToNewUTF8.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -52,7 +52,6 @@ mergeInto(LibraryManager.library, {
   // JavaScript <-> C string interop
   // ==========================================================================
 
-  $stringToNewUTF8__deps: ['malloc'],
   $stringToNewUTF8: function(jsString) {
     var length = lengthBytesUTF8(jsString)+1;
     var cString = _malloc(length);

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -186,6 +186,7 @@ _deps_info = {
   'wgpuBufferGetMappedRange': ['malloc', 'free'],
   'wgpuBufferGetConstMappedRange': ['malloc', 'free'],
   'emscripten_glGetString': ['malloc'],
+  '$stringToNewUTF8': ['malloc']
 }
 
 


### PR DESCRIPTION
Iirc it is still the case that all JS->C dependencies must live in tools\deps_info.py rather than in the __deps directives?

Without this change, I get

```
error: undefined symbol: malloc (referenced by $stringToNewUTF8__deps: ['malloc'], referenced by JSON_stringify__deps: ['$stringToNewUTF8','$JSONS'], referenced by top-level compiled C/C++ code)
warning: To disable errors for undefined symbols use `-sERROR_ON_UNDEFINED_SYMBOLS=0`
warning: _malloc may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
Error: Aborting compilation due to previous errors
em++: error: 'C:/emsdk/node/14.18.2_64bit/bin/node.exe C:\emsdk\emscripten\main\src\compiler.js C:\Users\clb\AppData\Local\Temp\tmpni8h85j7.json' failed (returned 1)
```
after this, I get
```
Aborted(malloc() called but not included in the build - add '_malloc' to EXPORTED_FUNCTIONS)
C:\emsdk\emscripten\main\a.js:144
      throw ex;
      ^

RuntimeError: Aborted(malloc() called but not included in the build - add '_malloc' to EXPORTED_FUNCTIONS)
    at abort (C:\emsdk\emscripten\main\a.js:998:11)
    at _malloc (C:\emsdk\emscripten\main\a.js:495:3)
    at stringToNewUTF8 (C:\emsdk\emscripten\main\a.js:1336:21)
    at _JSON_stringify (C:\emsdk\emscripten\main\a.js:1342:14)
    at <anonymous>:wasm-function[6]:0x322
    at main (<anonymous>:wasm-function[7]:0x369)
    at C:\emsdk\emscripten\main\a.js:1062:22
    at callMain (C:\emsdk\emscripten\main\a.js:1951:15)
    at doRun (C:\emsdk\emscripten\main\a.js:2005:23)
    at run (C:\emsdk\emscripten\main\a.js:2020:5)
```
which I can then fix by manually adding _malloc into EXPORTED_FUNCTIONS.