### PR TITLE
Fix alignof in ioctl.c to not use UB

### DIFF
--- a/system/lib/libc/musl/src/misc/ioctl.c
+++ b/system/lib/libc/musl/src/misc/ioctl.c
@@ -9,7 +9,12 @@
 #include <endian.h>
 #include "syscall.h"
 
-#define alignof(t) offsetof(struct { char c; t x; }, x)
+#ifdef __EMSCRIPTEN__
+// The upstream version below is UB in C2x and rejected by clang.
+#define alignof(t) _Alignof(t)
+#else
+#define alignof(t) offsetof(struct { char c; t x; }, x) */
+#endif
 
 #define W 1
 #define R 2

--- a/system/lib/libc/musl/src/misc/ioctl.c
+++ b/system/lib/libc/musl/src/misc/ioctl.c
@@ -13,7 +13,7 @@
 // The upstream version below is UB in C2x and rejected by clang.
 #define alignof(t) _Alignof(t)
 #else
-#define alignof(t) offsetof(struct { char c; t x; }, x) */
+#define alignof(t) offsetof(struct { char c; t x; }, x)
 #endif
 
 #define W 1


### PR DESCRIPTION
Defining types inside offsetof expressions is explicitly made UB in C2x and is
now rejected by clang. Use _Alignof instead since it is available in the version
of C we use to compile our libc.