### PR TITLE
Avoid overwriting identical files when installing headers

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2026,7 +2026,7 @@ int f() {
                  emcc_args=['--embed-file', 'pngtest.png', '-sUSE_LIBPNG'])
 
   @node_pthreads
-  def test_zzz_libpng_with_pthreads(self):
+  def test_libpng_with_pthreads(self):
     shutil.copyfile(test_file('third_party/libpng/pngtest.png'), 'pngtest.png')
     self.do_runf(test_file('third_party/libpng/pngtest.c'), 'libpng passes test',
                  emcc_args=['--embed-file', 'pngtest.png', '-sUSE_LIBPNG', '-sUSE_PTHREADS'])

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -79,6 +79,22 @@ def dir_is_newer(dir_a, dir_b):
   return newest_a[1] > newest_b[1]
 
 
+def maybe_copy(src, dest):
+  """Just like shutil.copyfile, but will do nothing if the destination already
+  exists and has the same contents as the source.
+
+  In the case where a library is built in multiple different configurations,
+  we want to avoids racing between processes that are reading headers (without
+  holding the cache lock) (e.g. normal compile steps) and a process that is
+  building/installing a new flavor of a given library.  In this case the
+  headers will be "re-installed" but we skip the actual filesystem mods
+  to avoid racing with other processes that might be reading these files.
+  """
+  if os.path.exists(dest) and utils.read_file(src) == utils.read_file(dest):
+    return
+  shutil.copyfile(src, dest)
+
+
 class Ports:
   """emscripten-ports library management (https://github.com/emscripten-ports).
   """
@@ -110,7 +126,7 @@ class Ports:
     assert matches, f'no headers found to install in {src_dir}'
     for f in matches:
       logger.debug('installing: ' + os.path.join(dest, os.path.basename(f)))
-      shutil.copyfile(f, os.path.join(dest, os.path.basename(f)))
+      maybe_copy(f, os.path.join(dest, os.path.basename(f)))
 
   @staticmethod
   def build_port(src_dir, output_path, port_name, includes=[], flags=[], cxxflags=[], exclude_files=[], exclude_dirs=[], srcs=[]):  # noqa


### PR DESCRIPTION
I noticed this suspicious flake on one of the bots and I think this should fix it:

```
In file included from /b/s/w/ir/x/w/install/emscripten/test/sqlite/benchmark.c:11:
/b/s/w/ir/x/w/install/emscripten/cache/sysroot/include/sqlite3.h:10539:2: error: unterminated conditional directive
 ^
1 error generated.
```