### PR TITLE
Remove special case file writing code in tools/minimal_runtime_shell.py

### DIFF
--- a/tools/minimal_runtime_shell.py
+++ b/tools/minimal_runtime_shell.py
@@ -211,6 +211,4 @@ def generate_minimal_runtime_html(target, options, js_target, target_basename):
     js_contents = ''
   shell = shell.replace('{{{ JS_CONTENTS_IN_SINGLE_FILE_BUILD }}}', js_contents)
   shell = line_endings.convert_line_endings(shell, '\n', options.output_eol)
-  # Force UTF-8 output for consistency across platforms and with the web.
-  with open(target, 'wb') as f:
-    f.write(shell.encode('utf-8'))
+  utils.write_file(target, shell)


### PR DESCRIPTION
We already have a `write_file` utility which takes care of writing everything in utf-8.  We use this to write all the other output JS and html files.