### PR TITLE
Don't pass the --export-name argument from file_packager.py

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1090,7 +1090,7 @@ def get_subresource_location(path, data_uri=None):
 def package_files(options, target):
   rtn = []
   logger.debug('setting up files')
-  file_args = ['--from-emcc', '--export-name=' + settings.EXPORT_NAME]
+  file_args = ['--from-emcc']
   if options.preload_files:
     file_args.append('--preload')
     file_args += options.preload_files


### PR DESCRIPTION
The file packager ignore the export name in `--from-emcc` mode so
this argument was not doing anything.