### PR TITLE
Cleanup usage of headless.js. NFC

### DIFF
--- a/src/headless.js
+++ b/src/headless.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-//== HEADLESS ==//
-
 var headlessPrint = (x) => {
   //print(x);
 };
@@ -14,14 +12,17 @@ var window = {
   // adjustable parameters
   location: {
     toString: function() {
-      return '%s';
+      return 'http://emscripten.org';
     },
-    search: '?%s',
-    pathname: '%s',
+    search: '',
+    pathname: null,
   },
-  onIdle: function(){ headlessPrint('triggering click'); document.querySelector('.fullscreen-button.low-res').callEventListeners('click'); window.onIdle = null; },
+  onIdle: function() {
+    headlessPrint('triggering click');
+    document.querySelector('.fullscreen-button.low-res').callEventListeners('click');
+    window.onIdle = null;
+  },
   dirsToDrop: 0, // go back to root dir if first_js is in a subdir
-  //
 
   headless: true,
 
@@ -312,6 +313,3 @@ var MozBlobBuilder = () => {
 if (!Module['canvas']) {
   Module['canvas'] = document.getElementById('canvas');
 }
-
-//== HEADLESS ==//
-

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -509,8 +509,7 @@ function ${name}(${args}) {
     if (HEADLESS) {
       print('if (!ENVIRONMENT_IS_WEB) {');
       includeFile('headlessCanvas.js');
-      print('\n');
-      print(read('headless.js').replace("'%s'", "'http://emscripten.org'").replace("'?%s'", "''").replace("'?%s'", "'/'").replace('%s,', 'null,').replace('%d', '0'));
+      includeFile('headless.js')
       print('}');
     }
     if (PROXY_TO_WORKER) {

--- a/test/other/test_sdl_headless.out
+++ b/test/other/test_sdl_headless.out
@@ -1,0 +1,6 @@
+Init: 0
+Font: 0x1
+Sum: 0
+you should see two lines of text in different colors and a blue rectangle
+SDL_Quit called (and ignored)
+done.

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2906,14 +2906,7 @@ int f() {
 
   def test_sdl_headless(self):
     shutil.copyfile(test_file('screenshot.png'), 'example.png')
-    expected = '''Init: 0
-Font: 0x1
-Sum: 0
-you should see two lines of text in different colors and a blue rectangle
-SDL_Quit called (and ignored)
-done.
-'''
-    self.do_runf(test_file('other/test_sdl_headless.c'), expected,  emcc_args=['-sHEADLESS'])
+    self.do_other_test('test_sdl_headless.c', emcc_args=['-sHEADLESS'])
 
   def test_preprocess(self):
     # Pass -Werror to prevent regressions such as https://github.com/emscripten-core/emscripten/pull/9661


### PR DESCRIPTION
Use `includeFile` (which automatically adds markers and is consistent with all the other files we include).

Update the test to use the standard `do_other_test` method.