### PR TITLE
Fix for new warnings in test/third_party/freetype. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1363,6 +1363,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       '-Wno-unused-but-set-variable',
       '-Wno-pointer-bool-conversion',
       '-Wno-shift-negative-value',
+      '-Wno-gnu-offsetof-extensions',
+      # And becuase gnu-offsetof-extensions is a new warning:
+      '-Wno-unknown-warning-option',
     ]
     return self.get_library(os.path.join('third_party', 'freetype'),
                             os.path.join('objs', '.libs', 'libfreetype.a'),


### PR DESCRIPTION
Seems like clang got more strict and this is causing the rollers to fail:

```
freetype/src/sfnt/ttload.c:983:32: error: using an array subscript expression within 'offsetof' is a Clang extension [-Werror,-Wgnu-offsetof-extensions]
        FT_FRAME_BYTE  ( panose[6] ),
```

See https://reviews.llvm.org/D133574
