### PR TITLE
Always warn at link time on bad EXPORTED_RUNTIME_METHODS

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -421,7 +421,7 @@ function exportRuntime() {
 
   // Add JS library elements such as FS, GL, ENV, etc. These are prefixed with
   // '$ which indicates they are JS methods.
-  const runtimeElementsSet = new Set(runtimeElements);
+  let runtimeElementsSet = new Set(runtimeElements);
   for (const ident in LibraryManager.library) {
     if (ident[0] === '$' && !isJsLibraryConfigIdentifier(ident) && !isInternalSymbol(ident)) {
       const jsname = ident.substr(1);
@@ -430,16 +430,16 @@ function exportRuntime() {
     }
   }
 
+  // check all exported things exist, warn about typos
+  runtimeElementsSet = new Set(runtimeElements);
+  for (const name of EXPORTED_RUNTIME_METHODS_SET) {
+    if (!runtimeElementsSet.has(name)) {
+      warn(`invalid item in EXPORTED_RUNTIME_METHODS: ${name}`);
+    }
+  }
+
   let unexportedStubs = '';
   if (ASSERTIONS) {
-    // check all exported things exist, warn about typos
-    const runtimeElementsSet = new Set(runtimeElements);
-    for (const name of EXPORTED_RUNTIME_METHODS_SET) {
-      if (!runtimeElementsSet.has(name)) {
-        warn(`invalid item in EXPORTED_RUNTIME_METHODS: ${name}`);
-      }
-    }
-
     const unexported = [];
     for (const name of runtimeElements) {
       if (!EXPORTED_RUNTIME_METHODS_SET.has(name)) {

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12414,8 +12414,9 @@ int main() {
     # In strict mode the library function is not even available, so we get a build time error
     self.set_setting('STRICT')
     self.clear_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE')
-    err = self.expect_fail([EMCC, test_file('other/test_legacy_runtime.c')] + self.get_emcc_args())
-    self.assertContained('warning: invalid item in EXPORTED_RUNTIME_METHODS: allocate', err)
+    for opt in ['-O0', '-O3']:
+      err = self.expect_fail([EMCC, test_file('other/test_legacy_runtime.c'), opt] + self.get_emcc_args())
+      self.assertContained('warning: invalid item in EXPORTED_RUNTIME_METHODS: allocate', err)
 
   def test_fetch_settings(self):
     create_file('pre.js', '''


### PR DESCRIPTION
I have no idea why this warning was only present when ASSERTIONS were enabled.