### PR TITLE
Use C symbols directly when calling them from library functions. NFC

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1379,11 +1379,11 @@ var LibraryBrowser = {
     return 0;
   },
 
-  emscripten_get_preloaded_image_data_from_FILE__deps: ['emscripten_get_preloaded_image_data'],
+  emscripten_get_preloaded_image_data_from_FILE__deps: ['emscripten_get_preloaded_image_data', 'fileno'],
   emscripten_get_preloaded_image_data_from_FILE__proxy: 'sync',
   emscripten_get_preloaded_image_data_from_FILE__sig: 'iiii',
   emscripten_get_preloaded_image_data_from_FILE: function(file, w, h) {
-    var fd = Module['_fileno'](file);
+    var fd = _fileno(file);
     var stream = FS.getStream(fd);
     if (stream) {
       return _emscripten_get_preloaded_image_data(stream.path, w, h);

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -2262,13 +2262,13 @@ var LibrarySDL = {
         }
       }
       var callStbImage = function(func, params) {
-        var x = Module['_malloc']({{{ getNativeTypeSize('i32') }}});
-        var y = Module['_malloc']({{{ getNativeTypeSize('i32') }}});
-        var comp = Module['_malloc']({{{ getNativeTypeSize('i32') }}});
+        var x = _malloc({{{ getNativeTypeSize('i32') }}});
+        var y = _malloc({{{ getNativeTypeSize('i32') }}});
+        var comp = _malloc({{{ getNativeTypeSize('i32') }}});
         addCleanup(function() {
-          Module['_free'](x);
-          Module['_free'](y);
-          Module['_free'](comp);
+          _free(x);
+          _free(y);
+          _free(comp);
           if (data) Module['_stbi_image_free'](data);
         });
         var data = Module['_' + func].apply(null, params.concat([x, y, comp, 0]));
@@ -2307,10 +2307,10 @@ var LibrarySDL = {
           if (raw === null) err('Trying to reuse preloaded image, but freePreloadedMediaOnUse is set!');
 #if STB_IMAGE
           var lengthBytes = lengthBytesUTF8(filename)+1;
-          var name = Module['_malloc'](lengthBytes);
+          var name = _malloc(lengthBytes);
           stringToUTF8(filename, name, lengthBytes);
           addCleanup(function() {
-            Module['_free'](name);
+            _free(name);
           });
           raw = callStbImage('stbi_load', [name]);
           if (!raw) return 0;
@@ -2765,7 +2765,7 @@ var LibrarySDL = {
     return 1;
   },
 
-  Mix_LoadWAV_RW__deps: ['$PATH_FS'],
+  Mix_LoadWAV_RW__deps: ['$PATH_FS', 'fileno'],
   Mix_LoadWAV_RW__proxy: 'sync',
   Mix_LoadWAV_RW__sig: 'iii',
   Mix_LoadWAV_RW__docs: '/** @param {number|boolean=} freesrc */',
@@ -2778,7 +2778,7 @@ var LibrarySDL = {
 
       if (type === 2/*SDL_RWOPS_STDFILE*/) {
         var fp = {{{ makeGetValue('rwopsID + ' + 28 /*hidden.stdio.fp*/, '0', 'i32') }}};
-        var fd = Module['_fileno'](fp);
+        var fd = _fileno(fp);
         var stream = FS.getStream(fd);
         if (stream) {
           rwops = { filename: stream.path };


### PR DESCRIPTION
Rather than relying on them being exported on the Module object we can just can these function directly.

The deps here already exist in deps_info.py, but adding them here increases robustness.

This change was split out from #18564 (which disabled the exporting of all symbols by default on the Module object).