### PR TITLE
Remove unused (and unusable) `emscripten_sync_run_in_main_thread` API.

### DIFF
--- a/site/source/docs/api_reference/wasm_workers.rst
+++ b/site/source/docs/api_reference/wasm_workers.rst
@@ -185,9 +185,9 @@ In order to enable flexible synchronous execution of code on other threads, and 
 APIs for example for MEMFS filesystem and Offscreen Framebuffer (WebGL emulated from a Worker) features,
 main browser thread and each pthread have a system-backed "proxy message queue" to receive messages.
 
-This enables user code to call API functions ``emscripten_sync_run_in_main_thread*()``,
-``emscripten_sync_run_in_main_runtime_thread()``, ``emscripten_async_run_in_main_runtime_thread()``,
-``emscripten_dispatch_to_thread()``, etc. from ``emscripten/threading.h`` to perform proxied calls.
+This enables user code to call API functions, ``emscripten_sync_run_in_main_runtime_thread()``,
+``emscripten_async_run_in_main_runtime_thread()``, ``emscripten_dispatch_to_thread()``, etc. from
+``emscripten/threading.h`` to perform proxied calls.
 
 Wasm Workers do not provide this functionality. If needed, such messaging should be implemented manually
 by users via regular multithreaded synchronized programming techniques (mutexes, futexes, semaphores, etc.)

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -915,7 +915,6 @@
         "file": "emscripten/threading.h",
         "defines": [
             "EM_PROXIED_RESIZE_OFFSCREENCANVAS",
-            "EM_QUEUED_JS_CALL_MAX_ARGS",
             "EM_FUNC_SIG_V",
             "EM_FUNC_SIG_VI",
             "EM_FUNC_SIG_VII",

--- a/src/struct_info_internal.json
+++ b/src/struct_info_internal.json
@@ -24,6 +24,12 @@
         ]
     },
     {
+        "file": "threading_internal.h",
+        "defines": [
+            "EM_QUEUED_JS_CALL_MAX_ARGS"
+        ]
+    },
+    {
         "file": "dynlink.h",
         "structs": {
             "dso": [

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -42,18 +42,7 @@ int emscripten_futex_wait(volatile void/*uint32_t*/ *addr, uint32_t val, double 
 // INT_MAX to wake all waiters on that location.
 int emscripten_futex_wake(volatile void/*uint32_t*/ *addr, int count);
 
-// Proxied JS function can support a few more arguments than proxied C/C++
-// functions, because the dispatch is variadic and signature independent.
-#define EM_QUEUED_JS_CALL_MAX_ARGS 20
-
 typedef struct em_queued_call em_queued_call;
-
-void emscripten_sync_run_in_main_thread(em_queued_call *call);
-void *emscripten_sync_run_in_main_thread_0(int function);
-void *emscripten_sync_run_in_main_thread_1(int function, void *arg1);
-void *emscripten_sync_run_in_main_thread_2(int function, void *arg1, void *arg2);
-void *emscripten_sync_run_in_main_thread_3(int function, void *arg1, void *arg2, void *arg3);
-void *emscripten_sync_run_in_main_thread_7(int function, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7);
 
 // Encode function signatures into a single uint32_t integer.
 // N.B. This encoding scheme is internal to the implementation, and can change

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -395,101 +395,11 @@ void emscripten_async_run_in_main_thread(em_queued_call* call) {
   do_dispatch_to_thread(emscripten_main_browser_thread_id(), call);
 }
 
-void emscripten_sync_run_in_main_thread(em_queued_call* call) {
+static void sync_run_in_main_thread(em_queued_call* call) {
   emscripten_async_run_in_main_thread(call);
 
   // Enter to wait for the operation to complete.
   emscripten_wait_for_call_v(call, INFINITY);
-}
-
-void* emscripten_sync_run_in_main_thread_0(int function) {
-  em_queued_call q = {function};
-  q.returnValue.vp = 0;
-  emscripten_sync_run_in_main_thread(&q);
-  return q.returnValue.vp;
-}
-
-void* emscripten_sync_run_in_main_thread_1(int function, void* arg1) {
-  em_queued_call q = {function};
-  q.args[0].vp = arg1;
-  q.returnValue.vp = 0;
-  emscripten_sync_run_in_main_thread(&q);
-  return q.returnValue.vp;
-}
-
-void* emscripten_sync_run_in_main_thread_2(
-  int function, void* arg1, void* arg2) {
-  em_queued_call q = {function};
-  q.args[0].vp = arg1;
-  q.args[1].vp = arg2;
-  q.returnValue.vp = 0;
-  emscripten_sync_run_in_main_thread(&q);
-  return q.returnValue.vp;
-}
-
-void* emscripten_sync_run_in_main_thread_3(
-  int function, void* arg1, void* arg2, void* arg3) {
-  em_queued_call q = {function};
-  q.args[0].vp = arg1;
-  q.args[1].vp = arg2;
-  q.args[2].vp = arg3;
-  q.returnValue.vp = 0;
-  emscripten_sync_run_in_main_thread(&q);
-  return q.returnValue.vp;
-}
-
-void* emscripten_sync_run_in_main_thread_4(
-  int function, void* arg1, void* arg2, void* arg3, void* arg4) {
-  em_queued_call q = {function};
-  q.args[0].vp = arg1;
-  q.args[1].vp = arg2;
-  q.args[2].vp = arg3;
-  q.args[3].vp = arg4;
-  q.returnValue.vp = 0;
-  emscripten_sync_run_in_main_thread(&q);
-  return q.returnValue.vp;
-}
-
-void* emscripten_sync_run_in_main_thread_5(
-  int function, void* arg1, void* arg2, void* arg3, void* arg4, void* arg5) {
-  em_queued_call q = {function};
-  q.args[0].vp = arg1;
-  q.args[1].vp = arg2;
-  q.args[2].vp = arg3;
-  q.args[3].vp = arg4;
-  q.args[4].vp = arg5;
-  q.returnValue.vp = 0;
-  emscripten_sync_run_in_main_thread(&q);
-  return q.returnValue.vp;
-}
-
-void* emscripten_sync_run_in_main_thread_6(
-  int function, void* arg1, void* arg2, void* arg3, void* arg4, void* arg5, void* arg6) {
-  em_queued_call q = {function};
-  q.args[0].vp = arg1;
-  q.args[1].vp = arg2;
-  q.args[2].vp = arg3;
-  q.args[3].vp = arg4;
-  q.args[4].vp = arg5;
-  q.args[5].vp = arg6;
-  q.returnValue.vp = 0;
-  emscripten_sync_run_in_main_thread(&q);
-  return q.returnValue.vp;
-}
-
-void* emscripten_sync_run_in_main_thread_7(int function, void* arg1,
-  void* arg2, void* arg3, void* arg4, void* arg5, void* arg6, void* arg7) {
-  em_queued_call q = {function};
-  q.args[0].vp = arg1;
-  q.args[1].vp = arg2;
-  q.args[2].vp = arg3;
-  q.args[3].vp = arg4;
-  q.args[4].vp = arg5;
-  q.args[5].vp = arg6;
-  q.args[6].vp = arg7;
-  q.returnValue.vp = 0;
-  emscripten_sync_run_in_main_thread(&q);
-  return q.returnValue.vp;
 }
 
 void emscripten_current_thread_process_queued_calls() {
@@ -508,7 +418,7 @@ int emscripten_sync_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void* fun
   va_start(args, func_ptr);
   init_em_queued_call_args(&q, sig, args);
   va_end(args);
-  emscripten_sync_run_in_main_thread(&q);
+  sync_run_in_main_thread(&q);
   return q.returnValue.i;
 }
 
@@ -537,7 +447,7 @@ double emscripten_run_in_main_runtime_thread_js(int index, int num_args, int64_t
   }
 
   if (sync) {
-    emscripten_sync_run_in_main_thread(&q);
+    sync_run_in_main_thread(&q);
     // TODO: support BigInt return values somehow.
     return q.returnValue.d;
   } else {

--- a/system/lib/pthread/threading_internal.h
+++ b/system/lib/pthread/threading_internal.h
@@ -17,9 +17,14 @@ typedef union em_variant_val
   char *cp;
 } em_variant_val;
 
+// Proxied JS function can support a few more arguments than proxied C/C++
+// functions, because the dispatch is variadic and signature independent.
+#define EM_QUEUED_JS_CALL_MAX_ARGS 20
+
 // Proxied C/C++ functions support at most this many arguments. Dispatch is
 // static/strongly typed by signature.
 #define EM_QUEUED_CALL_MAX_ARGS 11
+
 typedef struct em_queued_call
 {
   int functionEnum;


### PR DESCRIPTION
This family of function was not used anywhere and is not currently usable externally.

The core function `emscripten_sync_run_in_main_thread` was not usable since the its first argument is `em_queued_call` which is not struct that is declared externally.

The `emscripten_sync_run_in_main_thread_N` function takes a function enum as arg0 which is not designed to be user facing.

It looks like these function were once used by JS library code but the last remaining use of them was removed in #16405.

See: #15756