### PR TITLE
Remove unneeded exportedAsmFunc helper. NFC

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -121,7 +121,7 @@ var LibraryExceptions = {
     this.get_exception_ptr = function() {
       // Work around a fastcomp bug, this code is still included for some reason in a build without
       // exceptions support.
-      var isPointer = {{{ exportedAsmFunc('___cxa_is_pointer_type') }}}(this.get_type());
+      var isPointer = ___cxa_is_pointer_type(this.get_type());
       if (isPointer) {
         return {{{ makeGetValue('this.excPtr', '0', '*') }}};
       }
@@ -346,7 +346,7 @@ var LibraryExceptions = {
         break;
       }
       var adjusted_ptr_addr = info.ptr + {{{ C_STRUCTS.__cxa_exception.adjustedPtr }}};
-      if ({{{ exportedAsmFunc('___cxa_can_catch') }}}(caughtType, thrownType, adjusted_ptr_addr)) {
+      if (___cxa_can_catch(caughtType, thrownType, adjusted_ptr_addr)) {
 #if EXCEPTION_DEBUG
         dbg("  __cxa_find_matching_catch found " + [ptrToString(info.get_adjusted_ptr()), caughtType]);
 #endif

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -453,15 +453,6 @@ function makeHEAPView(which, start, end) {
   return `HEAP${which}.subarray((${start})${mod}, (${end})${mod})`;
 }
 
-// When dynamically linking, some things like dynCalls may not exist in one module and
-// be provided by a linked module, so they must be accessed indirectly using Module
-function exportedAsmFunc(func) {
-  if (!MAIN_MODULE) {
-    return func;
-  }
-  return `Module['${func}']`;
-}
-
 const TWO_TWENTY = Math.pow(2, 20);
 
 // Given two values and an operation, returns the result of that operation.
@@ -734,7 +725,7 @@ Please update to new syntax.`);
       }
     }
 
-    const dyncall = exportedAsmFunc(`dynCall_${sig}`);
+    const dyncall = `dynCall_${sig}`;
     if (sig.length > 1) {
       return `((${args}) => ${dyncall}.apply(null, [${funcPtr}, ${callArgs}]))`;
     }


### PR DESCRIPTION
It looks like this was originally added back in #8040, but was likely not needed.

At least in each of the of three remaining places this function is used we don't need to go via the `Module` object and these symbols can/should simply be referenced via the current scope.

Split out from #18540