### PR TITLE
Allow EXPECTED_LLVM_VERSION+1 during CI

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -214,7 +214,7 @@ class other(RunnerCore):
       # from clang would be flushed to stderr first.
       self.assertContained('emcc (Emscripten gcc/clang-like replacement', proc.stderr)
       self.assertTrue(proc.stderr.startswith('emcc (Emscripten gcc/clang-like replacement'))
-      self.assertContained('clang version %s' % shared.EXPECTED_LLVM_VERSION, proc.stderr)
+      self.assertContained('clang version ', proc.stderr)
       self.assertContained('GNU', proc.stderr)
       self.assertContained('Target: wasm32-unknown-emscripten', proc.stderr)
       self.assertNotContained('this is dangerous', proc.stderr)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -49,7 +49,7 @@ DEBUG_SAVE = DEBUG or int(os.environ.get('EMCC_DEBUG_SAVE', '0'))
 # exact requirement, but is the oldest version of node that we do any testing with.
 # This version aligns with the current Ubuuntu TLS 20.04 (Focal).
 MINIMUM_NODE_VERSION = (10, 19, 0)
-EXPECTED_LLVM_VERSION = "16.0"
+EXPECTED_LLVM_VERSION = 16
 
 # Used only when EM_PYTHON_MULTIPROCESSING=1 env. var is set.
 multiprocessing_pool = None
@@ -288,8 +288,14 @@ def get_clang_version():
 
 def check_llvm_version():
   actual = get_clang_version()
-  if EXPECTED_LLVM_VERSION in actual:
+  if actual.startswith('%d.' % EXPECTED_LLVM_VERSION):
     return True
+  # When running in CI environment we also silently allow the next major
+  # version of LLVM here so that new versions of LLVM can be rolled in
+  # without disruption.
+  if 'BUILDBOT_BUILDNUMBER' in os.environ:
+    if actual.startswith('%d.' % (EXPECTED_LLVM_VERSION + 1)):
+      return True
   diagnostics.warning('version-check', 'LLVM version for clang executable "%s" appears incorrect (seeing "%s", expected "%s")', CLANG_CC, actual, EXPECTED_LLVM_VERSION)
   return False
 


### PR DESCRIPTION
This means that new LLVM versions can roll in without needing so make preemptive changes to emscripten.

Once this lands it should unlock the llvm roller which is currently failing because LLVM top-of-tree is now 17.