### PR TITLE
Test test_minimal_runtime_export_all_modularize under windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -662,6 +662,7 @@ jobs:
             other.test_dot_a_all_contents_invalid
             other.test_emcc_print_search_dirs
             other.test_emcc_print_file_name
+            other.test_minimal_runtime_export_all_modularize
             other.test_pkg_config*"
       - upload-test-results
       # Run a single websockify-based test to ensure it works on windows.

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1307,6 +1307,7 @@ int f() {
     self.emcc('lib.c', ['-Oz', '-sEXPORT_ALL', '-sLINKABLE', '--pre-js', 'main.js'], output_filename='a.out.js')
     self.assertContained('libf1\nlibf2\n', self.run_js('a.out.js'))
 
+  @no_windows('https://github.com/emscripten-core/emscripten/issues/18596')
   def test_minimal_runtime_export_all_modularize(self):
     """This test ensures that MODULARIZE and EXPORT_ALL work simultaneously.
 


### PR DESCRIPTION
This test was added in #17911 but currently fails on windows.

Once we fix #18596 we can re-enable.