### PR TITLE
Increase size of symbol cache. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -554,7 +554,7 @@ def get_all_js_syms():
     # Limit of the overall size of the cache to 100 files.
     # This code will get test coverage since a full test run of `other` or `core`
     # generates ~1000 unique symbol lists.
-    cache_limit = 100
+    cache_limit = 500
     root = cache.get_path('symbol_lists')
     if len(os.listdir(root)) > cache_limit:
       files = []


### PR DESCRIPTION
I notices that when running the test suite we were hitting a lot of cache contention here.  The core2 test suite run with `--skip-slow` currently generates 472 unique symbol lists.

This improves that speed for the core2 run from 3m to 1m50.