### PR TITLE
[Promise] Integrate with Asyncify and JSPI

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -100,7 +100,7 @@ UNSUPPORTED_LLD_FLAGS = {
 }
 
 DEFAULT_ASYNCIFY_IMPORTS = [
-  'wasi_snapshot_preview1.fd_sync', '__wasi_fd_sync', '__asyncjs__*'
+  'wasi_snapshot_preview1.fd_sync', '__wasi_fd_sync', '__asyncjs__*', 'emscripten_promise_await_sync'
 ]
 
 DEFAULT_ASYNCIFY_EXPORTS = [

--- a/src/library_promise.js
+++ b/src/library_promise.js
@@ -260,5 +260,20 @@ mergeInto(LibraryManager.library, {
     dbg(`create: ${id}`);
 #endif
     return id;
-  }
+  },
+
+#if ASYNCIFY == 2
+  emscripten_promise_await_sync__deps: ['$getPromise'],
+  emscripten_promise_await_sync__sig: 'pp',
+  emscripten_promise_await_sync: function(id) {
+    return getPromise(id);
+  },
+#elif ASYNCIFY == 1
+  emscripten_promise_await_sync__deps: ['$getPromise', '$Asyncify'],
+  emscripten_promise_await_sync__sig: 'pp',
+  emscripten_promise_await_sync: function(id) {
+    return Asyncify.handleSleep((wakeUp) => getPromise(id).then(wakeUp));
+  },
+  #endif
+
 });

--- a/system/include/emscripten/promise.h
+++ b/system/include/emscripten/promise.h
@@ -135,6 +135,20 @@ __attribute__((warn_unused_result)) em_promise_t emscripten_promise_any(
 __attribute__((warn_unused_result)) em_promise_t
 emscripten_promise_race(em_promise_t* promises, size_t num_promises);
 
+// Suspend Wasm execution until the given `promise` is resolved. Once the
+// promise is resolved, this function will return the value it was fulfilled
+// with. Since the stack is not unwound while Wasm execution is suspended, it is
+// safe to pass pointers to the stack to asynchronous work that is waited on
+// with this function. If the promise is rejected instead of fulfilled, the
+// suspended Wasm will never be resumed.
+//
+// When Wasm execution suspends, a JS promise will be returned from the Wasm
+// export that led to this call. That promise will be resolved once Wasm resumes
+// execution and returns normally from the export.
+//
+// This function requires ASYNCIFY=1 or ASYNCIFY=2.
+void* emscripten_promise_await_sync(em_promise_t promise);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/core/test_promise_await_sync.c
+++ b/test/core/test_promise_await_sync.c
@@ -1,0 +1,58 @@
+#include <assert.h>
+#include <emscripten/console.h>
+#include <emscripten/emscripten.h>
+#include <emscripten/promise.h>
+
+em_promise_result_t increment(void** result, void* data, void* value) {
+  emscripten_console_log("incrementing counter in promise callback");
+  int* counter = data;
+  (*counter)++;
+  *result = (void*)42;
+  return EM_PROMISE_FULFILL;
+}
+
+typedef struct counter_and_promise {
+  int* counter;
+  em_promise_t promise;
+} counter_and_promise;
+
+void increment2(void* arg) {
+  emscripten_console_log("incrementing counter in callback");
+  counter_and_promise* data = (counter_and_promise*)arg;
+  (*data->counter)++;
+  emscripten_promise_resolve(data->promise, EM_PROMISE_FULFILL, (void*)123);
+  emscripten_promise_destroy(data->promise);
+}
+
+int main() {
+  int counter = 0;
+
+  // Synchronously await a promise we create.
+  em_promise_t start = emscripten_promise_create();
+  em_promise_t incremented =
+    emscripten_promise_then(start, increment, NULL, &counter);
+
+  emscripten_promise_resolve(start, EM_PROMISE_FULFILL, NULL);
+  emscripten_promise_destroy(start);
+
+  void* result = emscripten_promise_await_sync(incremented);
+  assert(result == (void*)42);
+  emscripten_promise_destroy(incremented);
+
+  emscripten_console_logf("incremented counter: %d", counter);
+  assert(counter == 1);
+
+  // Synchronously await a promise resolved in a callback.
+  counter_and_promise arg = (counter_and_promise){
+    .counter = &counter, .promise = emscripten_promise_create()};
+  emscripten_async_call(increment2, &arg, 0);
+
+  result = emscripten_promise_await_sync(arg.promise);
+  assert(result == (void*)123);
+
+  emscripten_console_logf("incremented again: %d", counter);
+  assert(counter == 2);
+
+  emscripten_console_log("done");
+  return 0;
+}

--- a/test/core/test_promise_await_sync.out
+++ b/test/core/test_promise_await_sync.out
@@ -1,0 +1,5 @@
+incrementing counter in promise callback
+incremented counter: 1
+incrementing counter in callback
+incremented again: 2
+done

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9726,6 +9726,11 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('MIN_CHROME_VERSION', '85')
     self.do_core_test('test_promise.c')
 
+  @no_wasm64('TODO: asyncify for wasm64')
+  @with_asyncify_and_stack_switching
+  def test_promise_await_sync(self):
+    self.do_core_test('test_promise_await_sync.c')
+
   def test_emscripten_async_load_script(self):
     create_file('script1.js', 'Module._set(456);''')
     create_file('file1.txt', 'first')


### PR DESCRIPTION
Add an `emscripten_promise_await_sync` function that appears to synchronously
wait for a promise to be resolved using either Asyncify or JSPI. This allows
users to implement an async-sync boundary wherever they want in their code
rather than just at the Wasm-JS boundary. Another convenience is that
synchronously waiting for a promise makes it safe for that promise to access
stack data that is live at the time of the wait.