### PR TITLE
Limit the use of `use strict` in JS output

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1916,8 +1916,12 @@ def phase_linker_setup(options, state, newargs):
     # Require explicit -lfoo.js flags to link with JS libraries.
     default_setting('AUTO_JS_LIBRARIES', 0)
 
+  if settings.STRICT_JS and (settings.MODULARIZE or settings.EXPORT_ES6):
+    exit_with_error("STRICT_JS doesn't work with MODULARIZE or EXPORT_ES6")
+
   if settings.STRICT:
-    default_setting('STRICT_JS', 1)
+    if not settings.MODULARIZE and not settings.EXPORT_ES6:
+      default_setting('STRICT_JS', 1)
     default_setting('AUTO_JS_LIBRARIES', 0)
     default_setting('AUTO_NATIVE_LIBRARIES', 0)
     default_setting('AUTO_ARCHIVE_INDEXES', 0)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -5685,6 +5685,11 @@ int main(void) {
     self.assertFalse(output.stderr)
     self.assertEqual(output.stdout, 'hello, world!\nhello, world!\n')
 
+  def test_modularize_strict(self):
+    self.run_process([EMCC, test_file('hello_world.c'), '-sMODULARIZE', '-sSTRICT'])
+    stdout = self.run_process(config.NODE_JS + ['-e', 'var m = require("./a.out.js"); m();'], stdout=PIPE, stderr=PIPE).stdout
+    self.assertEqual(stdout, 'hello, world!\n')
+
   @node_pthreads
   def test_pthread_print_override_modularize(self):
     self.set_setting('EXPORT_NAME', 'Test')


### PR DESCRIPTION
`use strict` is not supported in function that take default parameters: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Strict_Non_Simple_Params

This is the case when `MODULARIZE` is set.

`use strict` is redundant when building a ES6 module.

Fixes: #18610