### PR TITLE
Avoid needless string attribute lookups JS tools. NFC

### DIFF
--- a/tools/lz4-compress.js
+++ b/tools/lz4-compress.js
@@ -9,20 +9,20 @@
 const fs = require('fs');
 const path = require('path');
 
-const arguments_ = process['argv'].slice(2);
+const arguments_ = process.argv.slice(2);
 const debug = false;
 
 function print(x) {
-  process['stdout'].write(x + '\n');
+  process.stdout.write(x + '\n');
 }
 
 function printErr(x) {
-  process['stderr'].write(x + '\n');
+  process.stderr.write(x + '\n');
 }
 
 function read(filename, binary) {
-  filename = path['normalize'](filename);
-  let ret = fs['readFileSync'](filename);
+  filename = path.normalize(filename);
+  let ret = fs.readFileSync(filename);
   if (ret && !binary) ret = ret.toString();
   return ret;
 }

--- a/tools/preprocessor.js
+++ b/tools/preprocessor.js
@@ -18,14 +18,14 @@ const fs = require('fs');
 const path = require('path');
 global.vm = require('vm');
 
-const arguments_ = process['argv'].slice(2);
+const arguments_ = process.argv.slice(2);
 const debug = false;
 
 global.print = function(x) {
-  process['stdout'].write(x + '\n');
+  process.stdout.write(x + '\n');
 };
 global.printErr = function(x) {
-  process['stderr'].write(x + '\n');
+  process.stderr.write(x + '\n');
 };
 
 global.assert = require('assert');


### PR DESCRIPTION
Once apon a time maybe this was needed for some kind of closure reason? But even then, I can't imagine why, given the correct node externs.