### PR TITLE
Enable `dbg()` helper function whenever ASSERTIONS are enabled

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -55,7 +55,7 @@ var LibraryPThread = {
     // the reverse mapping, each worker has a `pthread_ptr` when its running a
     // pthread.
     pthreads: {},
-#if PTHREADS_DEBUG
+#if ASSERTIONS
     nextWorkerID: 1,
     debugInit: function() {
       function pthreadLogPrefix() {
@@ -70,16 +70,18 @@ var LibraryPThread = {
         return 'w:' + (Module['workerID'] || 0) + ',t:' + ptrToString(t) + ': ';
       }
 
-      // When PTHREAD_DEBUG is enabled, prefix all err()/dbg() messages with the
-      // calling thread ID.
-      var origErr = err;
-      err = (message) => origErr(pthreadLogPrefix() + message);
+      // Prefix all err()/dbg() messages with the calling thread ID.
       var origDbg = dbg;
       dbg = (message) => origDbg(pthreadLogPrefix() + message);
+#if PTHREADS_DEBUG
+      // With PTHREADS_DEBUG also prefix all err() messages.
+      var origErr = err;
+      err = (message) => origErr(pthreadLogPrefix() + message);
+#endif
     },
 #endif
     init: function() {
-#if PTHREADS_DEBUG
+#if ASSERTIONS
       PThread.debugInit();
 #endif
       if (ENVIRONMENT_IS_PTHREAD) {
@@ -390,7 +392,7 @@ var LibraryPThread = {
 #if MAIN_MODULE
         'dynamicLibraries': Module['dynamicLibraries'],
 #endif
-#if PTHREADS_DEBUG
+#if ASSERTIONS
         'workerID': PThread.nextWorkerID++,
 #endif
       });

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -124,7 +124,9 @@ function prettyPrint(arg) {
   }
   return arg;
 }
+#endif
 
+#if ASSERTIONS || RUNTIME_DEBUG
 // Used by XXXXX_DEBUG settings to output debug messages.
 function dbg(text) {
   // TODO(sbc): Make this configurable somehow.  Its not always convient for

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12857,3 +12857,22 @@ foo/version.txt
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
     self.do_other_test('test_itimer.c')
+
+  @node_pthreads
+  def test_dbg(self):
+    create_file('pre.js', '''
+    dbg('start');
+    Module.onRuntimeInitialized = () => dbg('done init');
+    ''')
+    self.emcc_args.append('--pre-js=pre.js')
+    # Verify that, after initialization, dbg() messages are prefixed with
+    # worker and thread ID.
+    self.do_runf(test_file('hello_world.c'),
+                 'start\nw:0,t:0x[0-9a-fA-F]+: done init\nhello, world!\n',
+                 regex=True)
+
+    # When assertions are disabled `dbg` function is not defined
+    self.do_runf(test_file('hello_world.c'),
+                 'ReferenceError: dbg is not defined',
+                 emcc_args=['-sASSERTIONS=0'],
+                 assert_returncode=NON_ZERO)


### PR DESCRIPTION
The dbg function is useful even when RUNTIME_DEBUG is not enabled.