### PR TITLE
Add native wrapper for `dbg()` JS function

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3411,19 +3411,20 @@ mergeInto(LibraryManager.library, {
 
   _emscripten_out__sig: 'vp',
   _emscripten_out: function(str) {
-#if ASSERTIONS
-    assert(typeof str == 'number');
-#endif
     out(UTF8ToString(str));
   },
 
   _emscripten_err__sig: 'vp',
   _emscripten_err: function(str) {
-#if ASSERTIONS
-    assert(typeof str == 'number');
-#endif
     err(UTF8ToString(str));
   },
+
+#if ASSERTIONS || RUNTIME_DEBUG
+  _emscripten_dbg__sig: 'vp',
+  _emscripten_dbg: function(str) {
+    dbg(UTF8ToString(str));
+  },
+#endif
 
   // Use program_invocation_short_name and program_invocation_name in compiled
   // programs. This function is for implementing them.

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -129,7 +129,14 @@ function prettyPrint(arg) {
 #if ASSERTIONS || RUNTIME_DEBUG
 // Used by XXXXX_DEBUG settings to output debug messages.
 function dbg(text) {
-  // TODO(sbc): Make this configurable somehow.  Its not always convient for
+#if ENVIRONMENT_MAY_BE_NODE && USE_PTHREADS
+  // Avoid using the console for debugging in multi-threaded node applications
+  // See https://github.com/emscripten-core/emscripten/issues/14804
+  if (ENVIRONMENT_IS_NODE) {
+    fs.writeSync(2, text + '\n');
+  } else
+#endif
+  // TODO(sbc): Make this configurable somehow.  Its not always convenient for
   // logging to show up as errors.
   console.error(text);
 }

--- a/src/runtime_strings.js
+++ b/src/runtime_strings.js
@@ -105,6 +105,9 @@ function UTF8ArrayToString(heapOrArray, idx, maxBytesToRead) {
  * @return {string}
  */
 function UTF8ToString(ptr, maxBytesToRead) {
+#if ASSERTIONS
+  assert(typeof ptr == 'number');
+#endif
 #if CAN_ADDRESS_2GB
   ptr >>>= 0;
 #endif

--- a/src/worker.js
+++ b/src/worker.js
@@ -177,7 +177,7 @@ function handleMessage(e) {
 
       {{{ makeAsmImportsAccessInPthread('buffer') }}} = {{{ makeAsmImportsAccessInPthread('wasmMemory') }}}.buffer;
 
-#if PTHREADS_DEBUG
+#if ASSERTIONS
       Module['workerID'] = e.data.workerID;
 #endif
 

--- a/system/include/emscripten/console.h
+++ b/system/include/emscripten/console.h
@@ -25,6 +25,7 @@ void emscripten_console_error(const char *utf8String);
 // See https://github.com/emscripten-core/emscripten/issues/14804
 void _emscripten_out(const char *utf8String);
 void _emscripten_err(const char *utf8String);
+void _emscripten_dbg(const char *utf8String);
 
 // Similar to the above functions but operate with printf-like semantics.
 void emscripten_console_logf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
@@ -32,6 +33,7 @@ void emscripten_console_warnf(const char *utf8String, ...) __attribute__((__form
 void emscripten_console_errorf(const char *utf8String, ...)__attribute__((__format__(printf, 1, 2)));
 void _emscripten_outf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
 void _emscripten_errf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
+void _emscripten_dbgf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
 
 #ifdef __cplusplus
 }

--- a/system/lib/libc/dynlink.c
+++ b/system/lib/libc/dynlink.c
@@ -25,7 +25,7 @@
 //#define DYLINK_DEBUG
 
 #ifdef DYLINK_DEBUG
-#define dbg(fmt, ...) _emscripten_errf("%p: " fmt, pthread_self(), ##__VA_ARGS__)
+#define dbg(fmt, ...) _emscripten_dbgf(fmt, ##__VA_ARGS__)
 #else
 #define dbg(fmt, ...)
 #endif

--- a/system/lib/libc/emscripten_console.c
+++ b/system/lib/libc/emscripten_console.c
@@ -54,3 +54,12 @@ void _emscripten_errf(const char* fmt, ...) {
   vlogf(fmt, ap, &_emscripten_err);
   va_end(ap);
 }
+
+#ifndef NDEBUG
+void _emscripten_dbgf(const char* fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  vlogf(fmt, ap, &_emscripten_dbg);
+  va_end(ap);
+}
+#endif

--- a/test/other/test_dbg.c
+++ b/test/other/test_dbg.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <stdio.h>
+#include <emscripten/console.h>
+
+int main() {
+  printf("hello, world!\n");
+#ifndef NDEBUG
+  // This symbol is only available in debug builds (i.e. -sASSERTIONS)
+  _emscripten_dbg("native dbg message");
+  _emscripten_dbgf("formatted: %d", 42);
+#endif
+  return 0;
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12864,15 +12864,20 @@ foo/version.txt
     dbg('start');
     Module.onRuntimeInitialized = () => dbg('done init');
     ''')
+    expected = '''\
+start
+w:0,t:0x[0-9a-fA-F]+: done init
+hello, world!
+w:0,t:0x[0-9a-fA-F]+: native dbg message
+w:0,t:0x[0-9a-fA-F]+: formatted: 42
+'''
     self.emcc_args.append('--pre-js=pre.js')
     # Verify that, after initialization, dbg() messages are prefixed with
     # worker and thread ID.
-    self.do_runf(test_file('hello_world.c'),
-                 'start\nw:0,t:0x[0-9a-fA-F]+: done init\nhello, world!\n',
-                 regex=True)
+    self.do_runf(test_file('other/test_dbg.c'), expected, regex=True)
 
     # When assertions are disabled `dbg` function is not defined
-    self.do_runf(test_file('hello_world.c'),
+    self.do_runf(test_file('other/test_dbg.c'),
                  'ReferenceError: dbg is not defined',
-                 emcc_args=['-sASSERTIONS=0'],
+                 emcc_args=['-DNDEBUG', '-sASSERTIONS=0'],
                  assert_returncode=NON_ZERO)


### PR DESCRIPTION
This means we can remove some complexity from the debug system in `dynlink.c` and other native callers of this function get, for example, the current thread into prepended to the debug message.

Also, make sure that under node, when threads are enabled we bypass the console and write directly to stderr.