### PR TITLE
Remove use of logging from ports builds

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3321,6 +3321,7 @@ Module["preRun"].push(function () {
     self.btest('cocos2d_hello.cpp', reference='cocos2d_hello.png', reference_slack=1,
                args=['-sUSE_COCOS2D=3', '-sERROR_ON_UNDEFINED_SYMBOLS=0',
                      '-Wno-js-compiler',
+                     '-Wno-experimental',
                      '--preload-file', preload_file, '--use-preload-plugins',
                      '-Wno-inconsistent-missing-override',
                      '-Wno-deprecated-declarations'])

--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-import logging
 import os
 
 TAG = '1.75.0'
@@ -20,8 +19,6 @@ def get(ports, settings, shared):
                       sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: boost_headers')
-
     # includes
     source_path = os.path.join(ports.get_dir(), 'boost_headers')
     source_path_include = os.path.join(source_path, 'boost')

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-import logging
 import os
 import shutil
 
@@ -19,8 +18,6 @@ def get(ports, settings, shared):
   ports.fetch_project('bullet', f'https://github.com/emscripten-ports/bullet/archive/{TAG}.zip', sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: bullet')
-
     source_path = os.path.join(ports.get_dir(), 'bullet', 'Bullet-' + TAG)
     src_path = os.path.join(source_path, 'bullet', 'src')
 

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -4,8 +4,8 @@
 # found in the LICENSE file.
 
 import os
-import logging
 import re
+from tools import diagnostics
 
 TAG = 'version_3_3'
 HASH = 'd7b22660036c684f09754fcbbc7562984f02aa955eef2b76555270c63a717e6672c4fe695afb16280822e8b7c75d4b99ae21975a01a4ed51cad957f7783722cd'
@@ -21,7 +21,7 @@ def get(ports, settings, shared):
   ports.fetch_project('cocos2d', f'https://github.com/emscripten-ports/Cocos2d/archive/{TAG}.zip', sha512hash=HASH)
 
   def create(final):
-    logging.warn('cocos2d: library is experimental, do not expect that it will work out of the box')
+    diagnostics.warning('experimental', 'cocos2d: library is experimental, do not expect that it will work out of the box')
 
     cocos2d_src = os.path.join(ports.get_dir(), 'cocos2d')
     cocos2d_root = os.path.join(cocos2d_src, 'Cocos2d-' + TAG)

--- a/tools/ports/giflib.py
+++ b/tools/ports/giflib.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import logging
 
 VERSION = '5.2.1'
 HASH = '4550e53c21cb1191a4581e363fc9d0610da53f7898ca8320f0d3ef6711e76bdda2609c2df15dc94c45e28bff8de441f1227ec2da7ea827cb3c0405af4faa4736'
@@ -18,7 +17,6 @@ def get(ports, settings, shared):
   ports.fetch_project('giflib', f'https://storage.googleapis.com/webassembly/emscripten-ports/giflib-{VERSION}.tar.gz', sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: giflib')
     source_path = os.path.join(ports.get_dir(), 'giflib', f'giflib-{VERSION}')
     ports.install_headers(source_path)
     exclude_files = [

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import logging
 
 VERSION = '3.2.0'
 HASH = 'c9d88068d8017046842f444f02f31dbae109026ede943aaf265db5508de8b4b2be84203950f274a237f515bf7cbd361629d2032c6e8ee8f50354b430bba3a8ca'
@@ -83,8 +82,6 @@ def get(ports, settings, shared):
   ports.fetch_project('harfbuzz', f'https://github.com/harfbuzz/harfbuzz/releases/download/{VERSION}/harfbuzz-{VERSION}.tar.xz', sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: harfbuzz')
-
     source_path = os.path.join(ports.get_dir(), 'harfbuzz', 'harfbuzz-' + VERSION)
     freetype_include = ports.get_include_dir('freetype2')
     ports.install_headers(os.path.join(source_path, 'src'), target='harfbuzz')

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-import logging
 import os
 
 TAG = 'release-68-2'
@@ -35,8 +34,6 @@ def get(ports, settings, shared):
     icu_source_path = os.path.join(source_path, 'source')
 
   def build_lib(lib_output, lib_src, other_includes, build_flags):
-    logging.debug('building port: icu- ' + lib_output)
-
     additional_build_flags = [
         # TODO: investigate why this is needed and remove
         '-Wno-macro-redefined',

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import logging
 
 VERSION = '9c'
 HASH = 'b2affe9a1688bd49fc033f4682c4a242d4ee612f1affaef532f5adcb4602efc4433c4a52a4b3d69e7440ff1f6413b1b041b419bc90efd6d697999961a9a6afb7'
@@ -21,7 +20,6 @@ def get(ports, settings, shared):
   ports.fetch_project('libjpeg', f'https://storage.googleapis.com/webassembly/emscripten-ports/jpegsrc.v{VERSION}.tar.gz', sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: libjpeg')
     source_path = os.path.join(ports.get_dir(), 'libjpeg', f'jpeg-{VERSION}')
     ports.write_file(os.path.join(source_path, 'jconfig.h'), jconfig_h)
     ports.install_headers(source_path)

--- a/tools/ports/libmodplug.py
+++ b/tools/ports/libmodplug.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import logging
 
 TAG = '11022021'
 HASH = 'f770031ad6c2152cbed8c8eab8edf2be1d27f9e74bc255a9930c17019944ee5fdda5308ea992c66a78af9fe1d8dca090f6c956910ce323f8728247c10e44036b'
@@ -18,8 +17,6 @@ def get(ports, settings, shared):
   ports.fetch_project('libmodplug', f'https://github.com/jancc/libmodplug/archive/v{TAG}.zip', sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: libmodplug')
-
     source_path = os.path.join(ports.get_dir(), 'libmodplug', 'libmodplug-' + TAG)
     src_dir = os.path.join(source_path, 'src')
     libmodplug_path = os.path.join(src_dir, 'libmodplug')

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import logging
 
 TAG = '1.6.37'
 HASH = '2ce2b855af307ca92a6e053f521f5d262c36eb836b4810cb53c809aa3ea2dcc08f834aee0ffd66137768a54397e28e92804534a74abb6fc9f6f3127f14c9c338'
@@ -35,8 +34,6 @@ def get(ports, settings, shared):
   ports.fetch_project('libpng', f'https://storage.googleapis.com/webassembly/emscripten-ports/libpng-{TAG}.tar.gz', sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: libpng')
-
     source_path = os.path.join(ports.get_dir(), 'libpng', 'libpng-' + TAG)
     ports.write_file(os.path.join(source_path, 'pnglibconf.h'), pnglibconf_h)
     ports.install_headers(source_path)

--- a/tools/ports/mpg123.py
+++ b/tools/ports/mpg123.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import logging
 
 TAG = '1.26.2'
 HASH = 'aa63fcb08b243a1e09f7701b3d84a19d7412a87253d54d49f014fdb9e75bbc81d152a41ed750fccde901453929b2a001585a7645351b41845ad205c17a73dcc9'
@@ -18,8 +17,6 @@ def get(ports, settings, shared):
   ports.fetch_project('mpg123', f'https://www.mpg123.de/download/mpg123-{TAG}.tar.bz2', sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: mpg123')
-
     source_path = os.path.join(ports.get_dir(), 'mpg123', 'mpg123-' + TAG)
 
     src_path = os.path.join(source_path, 'src')

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-import logging
 import os
 
 TAG = 'version_1'
@@ -18,8 +17,6 @@ def get(ports, settings, shared):
   ports.fetch_project('ogg', f'https://github.com/emscripten-ports/ogg/archive/{TAG}.zip', sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: ogg')
-
     source_path = os.path.join(ports.get_dir(), 'ogg', 'Ogg-' + TAG)
     ports.write_file(os.path.join(source_path, 'include', 'ogg', 'config_types.h'), config_types_h)
     ports.install_header_dir(os.path.join(source_path, 'include', 'ogg'), 'ogg')

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-import logging
 import os
 
 TAG = 'version_7'
@@ -24,7 +23,6 @@ def get(ports, settings, shared):
   ports.fetch_project('regal', f'https://github.com/emscripten-ports/regal/archive/{TAG}.zip', sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: regal')
     source_path = os.path.join(ports.get_dir(), 'regal', 'regal-' + TAG)
 
     # copy sources

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import logging
 
 TAG = '2b147ffef10ec541d3eace326eafe11a54e635f8'
 HASH = 'f39f1f50a039a1667fe92b87d28548d32adcf0eb8526008656de5315039aa21f29d230707caa47f80f6b3a412a577698cd4bbfb9458bb92ac47e6ba993b8efe6'
@@ -22,7 +21,6 @@ def get(ports, settings, shared):
   ports.fetch_project('sdl2_gfx', f'https://github.com/svn2github/sdl2_gfx/archive/{TAG}.zip', sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: sdl2_gfx')
     source_path = os.path.join(ports.get_dir(), 'sdl2_gfx', 'sdl2_gfx-' + TAG)
     ports.build_port(source_path, final, 'sdl2_gfx', exclude_dirs=['test'], flags=['-sUSE_SDL=2'])
     ports.install_headers(source_path, target='SDL2')

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import logging
 
 TAG = 'release-2.0.4'
 HASH = '5ba387f997219a1deda868f380bf7ee8bc0842261dd54772ad2d560f5282fcbe7bc130e8d16dccc259eeb8cda993a0f34cd3be103fc38f8c6a68428a10e5db4c'
@@ -39,8 +38,6 @@ def get(ports, settings, shared):
   libname = get_lib_name(settings)
 
   def create(final):
-    logging.info('building port: sdl2_mixer')
-
     source_path = os.path.join(ports.get_dir(), 'sdl2_mixer', 'SDL_mixer-' + TAG)
     flags = [
       '-sUSE_SDL=2',

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import logging
 
 TAG = 'version_2'
 HASH = '317b22ad9b6b2f7b40fac7b7c426da2fa2da1803bbe58d480631f1e5b190d730763f2768c77c72affa806c69a1e703f401b15a1be3ec611cd259950d5ebc3711'
@@ -22,7 +21,6 @@ def get(ports, settings, shared):
   ports.fetch_project('sdl2_net', f'https://github.com/emscripten-ports/SDL2_net/archive/{TAG}.zip', sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: sdl2_net')
     src_dir = os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG)
     ports.install_headers(src_dir, target='SDL2')
     excludes = ['chatd.c', 'chat.cpp', 'showinterfaces.c']

--- a/tools/ports/sqlite3.py
+++ b/tools/ports/sqlite3.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import logging
 
 # sqlite amalgamation download URL uses relase year and tag
 # 2022  and (3, 38, 5) -> '/2022/sqlite-amalgamation-3380500.zip'
@@ -29,8 +28,6 @@ def get(ports, settings, shared):
   ports.fetch_project('sqlite3', f'https://www.sqlite.org/{VERSION_YEAR}/{release}.zip', sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: libsqlite3')
-
     source_path = os.path.join(ports.get_dir(), 'sqlite3', release)
 
     ports.install_headers(source_path)

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-import logging
 import os
 
 TAG = 'version_1'
@@ -20,7 +19,6 @@ def get(ports, settings, shared):
   ports.fetch_project('vorbis', f'https://github.com/emscripten-ports/vorbis/archive/{TAG}.zip', sha512hash=HASH)
 
   def create(final):
-    logging.info('building port: vorbis')
     source_path = os.path.join(ports.get_dir(), 'vorbis', 'Vorbis-' + TAG)
     ports.install_header_dir(os.path.join(source_path, 'include', 'vorbis'))
     ports.build_port(os.path.join(source_path, 'lib'), final, 'vorbis',


### PR DESCRIPTION
This was just adding unnessary boilerplate to each individual port. We already print several lines of information when building a given port, and its all don't in generic code. e.g.:

```
ports:INFO: retrieving port: bullet from https://github.com/emscripten-ports/bullet/archive/version_1.zip
ports:INFO: unpacking port: bullet
cache:INFO: generating system library: sysroot/lib/wasm32-emscripten/libbullet.a... (this will be cached in "/usr/local/google/home/sbc/dev/wasm/emscripten/cache/sysroot/lib/wasm32-emscripten/libbullet.a" for subsequent builds)
```

For requests to make these things quieter in general see #18607 and #18622.