### PR TITLE
Add a simple test based on googletest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -696,6 +696,9 @@ jobs:
           at: ~/
       - checkout
       - run:
+          name: submodule update
+          command: git submodule update --init
+      - run:
           name: Remove Linux binaries
           command: |
             rm -rf ~/emsdk ~/vms

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "test/third_party/posixtestsuite"]
 	path = test/third_party/posixtestsuite
 	url = https://github.com/emscripten-core/posixtestsuite
+[submodule "test/third_party/googletest"]
+	path = test/third_party/googletest
+	url = git@github.com:google/googletest.git

--- a/test/other/test_googletest.cc
+++ b/test/other/test_googletest.cc
@@ -1,0 +1,5 @@
+#include "gtest/gtest.h"
+
+TEST(MySuite, MyTest) {
+  ASSERT_EQ(2 + 2, 4);
+}

--- a/test/other/test_googletest.out
+++ b/test/other/test_googletest.out
@@ -1,0 +1,1 @@
+[  PASSED  ] 1 test.

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12934,3 +12934,15 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
 
     err = self.expect_fail(base_cmd + ['-sMEMORY_GROWTH_LINEAR_STEP=1mb'])
     self.assertContained('error: MEMORY_GROWTH_LINEAR_STEP is not compatible with STANDALONE_WASM', err)
+
+  @is_slow_test
+  def test_googletest(self):
+    # TODO(sbc): Should we package gtest as an emscripten "port"?  I guess we should if
+    # we plan on using it in more places.
+    self.emcc_args += [
+      '-I' + test_file('third_party/googletest/googletest'),
+      '-I' + test_file('third_party/googletest/googletest/include'),
+      test_file('third_party/googletest/googletest/src/gtest-all.cc'),
+      test_file('third_party/googletest/googletest/src/gtest_main.cc'),
+    ]
+    self.do_other_test('test_googletest.cc')


### PR DESCRIPTION
We received a bug report where the repro case was a googletest test so is seem like it would be good idea to have an easy way to run googletest test.  We may want to consider using this framework within some of our existing test too?