### PR TITLE
Don't include any of the dlsync code unless we are building in PIC mode

### DIFF
--- a/system/lib/pthread/proxying.c
+++ b/system/lib/pthread/proxying.c
@@ -207,6 +207,12 @@ static em_task_queue* get_or_add_tasks_for_thread(em_proxying_queue* q,
   return tasks;
 }
 
+static void dummy()
+{
+}
+
+weak_alias(dummy, _emscripten_thread_sync_code);
+
 // Exported for use in worker.js, but otherwise an internal function.
 EMSCRIPTEN_KEEPALIVE
 void _emscripten_proxy_execute_task_queue(em_task_queue* tasks) {


### PR DESCRIPTION
Here we use PIC mode as proxy for support for dynamic linking.  In theory the entire `dynlink.c` should not be compiled into libc unless dynamic linking is supported.  I will try to do that as followup.