### PR TITLE
[EH] Add EXCEPTION_STACK_TRACES option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,10 +22,10 @@ See docs/process.md for more on how version tagging works.
 -----------------------
 - In Wasm exception mode (`-fwasm-exceptions`), when
   `EXCEPTION_STACK_TRACES` is enabled, uncaught exceptions will display stack
-  traces. Note that stack traces are enabled when either of `ASSERTIONS` or this
-  `EXCEPTION_STACK_TRACES` is enabled, so this option is mainly for the users
-  who want only exceptions' stack traces without turning `ASSERTIONS` on. This
-  option currently works only for Wasm exceptions (-fwasm-exceptions). (#????)
+  traces. This defaults to true when `ASSERTIONS` is enabled. This option is
+  mainly for the users who want only exceptions' stack traces without turning
+  `ASSERTIONS` on. This option currently works only for Wasm exceptions
+  (-fwasm-exceptions). (#18642)
 
 3.1.31 - 01/26/23
 -----------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,12 @@ See docs/process.md for more on how version tagging works.
 
 3.1.32 (in development)
 -----------------------
+- In Wasm exception mode (`-fwasm-exceptions`), when
+  `EXCEPTION_STACK_TRACES` is enabled, uncaught exceptions will display stack
+  traces. Note that stack traces are enabled when either of `ASSERTIONS` or this
+  `EXCEPTION_STACK_TRACES` is enabled, so this option is mainly for the users
+  who want only exceptions' stack traces without turning `ASSERTIONS` on. This
+  option currently works only for Wasm exceptions (-fwasm-exceptions). (#????)
 
 3.1.31 - 01/26/23
 -----------------

--- a/emcc.py
+++ b/emcc.py
@@ -2788,7 +2788,9 @@ def phase_linker_setup(options, state, newargs):
   # When ASSERTIONS or EXCEPTION_STACK_TRACES is set, we include stack traces in
   # Wasm exception objects using the JS API, which needs this C++ tag exported.
   if settings.ASSERTIONS:
-    settings.EXCEPTION_STACK_TRACES = 1
+    if 'EXCEPTION_STACK_TRACES' in user_settings and not settings.EXCEPTION_STACK_TRACES:
+      exit_with_error('EXCEPTION_STACK_TRACES cannot be disabled when ASSSERTIONS are enabled')
+    default_setting('EXCEPTION_STACK_TRACES', 1)
   if settings.EXCEPTION_STACK_TRACES and settings.WASM_EXCEPTIONS:
     settings.EXPORTED_FUNCTIONS += ['___cpp_exception']
     settings.EXPORT_EXCEPTION_HANDLING_HELPERS = True

--- a/emcc.py
+++ b/emcc.py
@@ -2787,8 +2787,9 @@ def phase_linker_setup(options, state, newargs):
 
   # When ASSERTIONS or EXCEPTION_STACK_TRACES is set, we include stack traces in
   # Wasm exception objects using the JS API, which needs this C++ tag exported.
-  if (settings.ASSERTIONS or settings.EXCEPTION_STACK_TRACES) and \
-     settings.WASM_EXCEPTIONS:
+  if settings.ASSERTIONS:
+    settings.EXCEPTION_STACK_TRACES = 1
+  if settings.EXCEPTION_STACK_TRACES and settings.WASM_EXCEPTIONS:
     settings.EXPORTED_FUNCTIONS += ['___cpp_exception']
     settings.EXPORT_EXCEPTION_HANDLING_HELPERS = True
 

--- a/emcc.py
+++ b/emcc.py
@@ -2789,7 +2789,7 @@ def phase_linker_setup(options, state, newargs):
   # Wasm exception objects using the JS API, which needs this C++ tag exported.
   if settings.ASSERTIONS:
     if 'EXCEPTION_STACK_TRACES' in user_settings and not settings.EXCEPTION_STACK_TRACES:
-      exit_with_error('EXCEPTION_STACK_TRACES cannot be disabled when ASSSERTIONS are enabled')
+      exit_with_error('EXCEPTION_STACK_TRACES cannot be disabled when ASSERTIONS are enabled')
     default_setting('EXCEPTION_STACK_TRACES', 1)
   if settings.EXCEPTION_STACK_TRACES and settings.WASM_EXCEPTIONS:
     settings.EXPORTED_FUNCTIONS += ['___cpp_exception']

--- a/emcc.py
+++ b/emcc.py
@@ -2785,9 +2785,10 @@ def phase_linker_setup(options, state, newargs):
   if settings.WASM_EXCEPTIONS:
     settings.REQUIRED_EXPORTS += ['__trap']
 
-  # When ASSERTIONS is set, we include stack traces in Wasm exception objects
-  # using the JS API, which needs this C++ tag exported.
-  if settings.ASSERTIONS and settings.WASM_EXCEPTIONS:
+  # When ASSERTIONS or EXCEPTION_STACK_TRACES is set, we include stack traces in
+  # Wasm exception objects using the JS API, which needs this C++ tag exported.
+  if (settings.ASSERTIONS or settings.EXCEPTION_STACK_TRACES) and \
+     settings.WASM_EXCEPTIONS:
     settings.EXPORTED_FUNCTIONS += ['___cpp_exception']
     settings.EXPORT_EXCEPTION_HANDLING_HELPERS = True
 

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -401,7 +401,7 @@ var LibraryExceptions = {
 #endif
   },
 
-#if ASSERTIONS || EXCEPTION_STACK_TRACES
+#if EXCEPTION_STACK_TRACES
   // Throw a WebAssembly.Exception object with the C++ tag with a stack trace
   // embedded. WebAssembly.Exception is a JS object representing a Wasm
   // exception, provided by Wasm JS API:

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -401,7 +401,7 @@ var LibraryExceptions = {
 #endif
   },
 
-#if ASSERTIONS
+#if ASSERTIONS || EXCEPTION_STACK_TRACES
   // Throw a WebAssembly.Exception object with the C++ tag with a stack trace
   // embedded. WebAssembly.Exception is a JS object representing a Wasm
   // exception, provided by Wasm JS API:

--- a/src/settings.js
+++ b/src/settings.js
@@ -708,6 +708,14 @@ var EXCEPTION_CATCHING_ALLOWED = [];
 // example usage.
 var EXPORT_EXCEPTION_HANDLING_HELPERS = false;
 
+// When this is enabled, exceptions will contain stack traces and uncaught
+// exceptions will display stack traces upon exiting. Note that stack traces
+// will be shown when either of EXCEPTION_STACK_TRACES or ASSERTIONS is enabled.
+// This option is for users who want exceptions' stack traces but do not want
+// other overheads ASSERTIONS can incur. This currently works only for Wasm
+// exceptions (-fwasm-exceptions).
+var EXCEPTION_STACK_TRACES = false;
+
 // Internal: Tracks whether Emscripten should link in exception throwing (C++
 // 'throw') support library. This does not need to be set directly, but pass
 // -fno-exceptions to the build disable exceptions support. (This is basically

--- a/src/settings.js
+++ b/src/settings.js
@@ -709,11 +709,10 @@ var EXCEPTION_CATCHING_ALLOWED = [];
 var EXPORT_EXCEPTION_HANDLING_HELPERS = false;
 
 // When this is enabled, exceptions will contain stack traces and uncaught
-// exceptions will display stack traces upon exiting. Note that stack traces
-// will be shown when either of EXCEPTION_STACK_TRACES or ASSERTIONS is enabled.
-// This option is for users who want exceptions' stack traces but do not want
-// other overheads ASSERTIONS can incur. This currently works only for Wasm
-// exceptions (-fwasm-exceptions).
+// exceptions will display stack traces upon exiting. This defaults to true when
+// ASSERTIONS is enabled. This option is for users who want exceptions' stack
+// traces but do not want other overheads ASSERTIONS can incur. This currently
+// works only for Wasm exceptions (-fwasm-exceptions).
 var EXCEPTION_STACK_TRACES = false;
 
 // Internal: Tracks whether Emscripten should link in exception throwing (C++

--- a/src/shell.js
+++ b/src/shell.js
@@ -173,7 +173,7 @@ var read_,
 function logExceptionOnExit(e) {
   if (e instanceof ExitStatus) return;
   let toLog = e;
-#if ASSERTIONS
+#if ASSERTIONS || EXCEPTION_STACK_TRACES
   if (e && typeof e == 'object' && e.stack) {
     toLog = [e, e.stack];
   }

--- a/src/shell.js
+++ b/src/shell.js
@@ -173,7 +173,7 @@ var read_,
 function logExceptionOnExit(e) {
   if (e instanceof ExitStatus) return;
   let toLog = e;
-#if ASSERTIONS || EXCEPTION_STACK_TRACES
+#if EXCEPTION_STACK_TRACES
   if (e && typeof e == 'object' && e.stack) {
     toLog = [e, e.stack];
   }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8122,7 +8122,7 @@ int main() {
     # Not allowed
     create_file('src.cpp', src)
     err = self.expect_fail([EMCC, 'src.cpp', '-sASSERTIONS=1', '-sEXCEPTION_STACK_TRACES=0'])
-    self.assertContained('EXCEPTION_STACK_TRACES cannot be disabled when ASSSERTIONS are enabled', err)
+    self.assertContained('EXCEPTION_STACK_TRACES cannot be disabled when ASSERTIONS are enabled', err)
 
     # Doesn't print stack traces
     self.set_setting('ASSERTIONS', 0)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8104,22 +8104,27 @@ int main() {
       'at main']
 
     # Stack traces are enabled when either of ASSERTIONS or
-    # EXCEPTION_STACK_TRACES is enabled.
+    # EXCEPTION_STACK_TRACES is enabled. You can't disable
+    # EXCEPTION_STACK_TRACES when ASSERTIONS is enabled.
+
+    # Prints stack traces
     self.set_setting('ASSERTIONS', 1)
     self.set_setting('EXCEPTION_STACK_TRACES', 1)
     self.do_run(src, emcc_args=emcc_args, assert_all=True,
                 assert_returncode=NON_ZERO, expected_output=stack_trace_checks)
 
+    # Prints stack traces
     self.set_setting('ASSERTIONS', 0)
     self.set_setting('EXCEPTION_STACK_TRACES', 1)
     self.do_run(src, emcc_args=emcc_args, assert_all=True,
                 assert_returncode=NON_ZERO, expected_output=stack_trace_checks)
 
-    self.set_setting('ASSERTIONS', 1)
-    self.set_setting('EXCEPTION_STACK_TRACES', 0)
-    self.do_run(src, emcc_args=emcc_args, assert_all=True,
-                assert_returncode=NON_ZERO, expected_output=stack_trace_checks)
+    # Not allowed
+    create_file('src.cpp', src)
+    err = self.expect_fail([EMCC, 'src.cpp', '-sASSERTIONS=1', '-sEXCEPTION_STACK_TRACES=0'])
+    self.assertContained('EXCEPTION_STACK_TRACES cannot be disabled when ASSSERTIONS are enabled', err)
 
+    # Doesn't print stack traces
     self.set_setting('ASSERTIONS', 0)
     self.set_setting('EXCEPTION_STACK_TRACES', 0)
     err = self.do_run(src, emcc_args=emcc_args, assert_returncode=NON_ZERO)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8062,7 +8062,12 @@ int main() {
       out = self.run_js('a.out.js', assert_returncode=NON_ZERO)
       self.assertContained('no native wasm support detected', out)
 
-  @requires_wasm_eh
+  # FIXME Node v18.13 (LTS as of Jan 2023) has not yet implemented the new
+  # optional 'traceStack' option in WebAssembly.Exception constructor
+  # (https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Exception/Exception)
+  # and embeds stack traces unconditionally. Change this back to
+  # @requires_wasm_eh if this issue is fixed later.
+  @requires_v8
   def test_wasm_exceptions_stack_trace_and_message(self):
     src = r'''
       #include <stdexcept>
@@ -8098,12 +8103,25 @@ int main() {
       'at foo',
       'at main']
 
-    # We attach stack traces to exception objects only when ASSERTIONS is set
-    self.set_setting('ASSERTIONS')
+    # Stack traces are enabled when either of ASSERTIONS or
+    # EXCEPTION_STACK_TRACES is enabled.
+    self.set_setting('ASSERTIONS', 1)
+    self.set_setting('EXCEPTION_STACK_TRACES', 1)
     self.do_run(src, emcc_args=emcc_args, assert_all=True,
                 assert_returncode=NON_ZERO, expected_output=stack_trace_checks)
 
     self.set_setting('ASSERTIONS', 0)
+    self.set_setting('EXCEPTION_STACK_TRACES', 1)
+    self.do_run(src, emcc_args=emcc_args, assert_all=True,
+                assert_returncode=NON_ZERO, expected_output=stack_trace_checks)
+
+    self.set_setting('ASSERTIONS', 1)
+    self.set_setting('EXCEPTION_STACK_TRACES', 0)
+    self.do_run(src, emcc_args=emcc_args, assert_all=True,
+                assert_returncode=NON_ZERO, expected_output=stack_trace_checks)
+
+    self.set_setting('ASSERTIONS', 0)
+    self.set_setting('EXCEPTION_STACK_TRACES', 0)
     err = self.do_run(src, emcc_args=emcc_args, assert_returncode=NON_ZERO)
     for check in stack_trace_checks:
       self.assertNotContained(check, err)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1376,6 +1376,10 @@ class libcxxabi(NoExceptLibrary, MTLibrary, DebugLibrary):
     ]
   includes = ['system/lib/libcxx/src']
 
+  def __init__(self, **kwargs):
+    super().__init__(**kwargs)
+    self.is_debug |= settings.EXCEPTION_STACK_TRACES
+
   def get_cflags(self):
     cflags = super().get_cflags()
     if not self.is_mt and not self.is_ww:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1378,6 +1378,7 @@ class libcxxabi(NoExceptLibrary, MTLibrary, DebugLibrary):
 
   def __init__(self, **kwargs):
     super().__init__(**kwargs)
+    # EXCEPTION_STACK_TRACES currently requires the debug version of libc++abi
     self.is_debug |= settings.EXCEPTION_STACK_TRACES
 
   def get_cflags(self):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1378,7 +1378,11 @@ class libcxxabi(NoExceptLibrary, MTLibrary, DebugLibrary):
 
   def __init__(self, **kwargs):
     super().__init__(**kwargs)
-    # EXCEPTION_STACK_TRACES currently requires the debug version of libc++abi
+    # TODO EXCEPTION_STACK_TRACES currently requires the debug version of
+    # libc++abi, causing the debug version of libc++abi to be linked, which
+    # increases code size. libc++abi is not a big library to begin with, but if
+    # this becomes a problem, consider making EXCEPTION_STACK_TRACES work with
+    # the non-debug version of libc++abi.
     self.is_debug |= settings.EXCEPTION_STACK_TRACES
 
   def get_cflags(self):


### PR DESCRIPTION
This adds `EXCEPTION_STACK_TRACES` option, which embeds stack traces into exception objects even when `ASSERTIONS` is not set. This is for the users who wants exception stack traces but don't want to incur the full overhead of `ASSERTIONS`. Exception stack traces are enabled when either of `ASSERTIONS` or `EXCEPTION_STACK_TRACES` is true.

This currently works only for Wasm EH. The reason this option's name is not `WASM_EXCEPTION_STACK_TRACES` is I think this can work for Emscripten EH later if something like #18535 lands.

Fixes #18533.

cc @ravisumit33 