### PR TITLE
dylink: Remove dynamic linking startup code and allocation

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -140,6 +140,9 @@ function stackCheckInit() {
 
 #if RELOCATABLE
 var dylibsLoaded = false;
+#if '$LDSO' in addedLibraryItems
+LDSO.init();
+#endif
 #endif
 
 /** @type {function(Array=)} */


### PR DESCRIPTION
With this change I completely remove the `ensure_init` function and the associated allocation in favor a static handle for the "main" dso.

I also avoid the initial `_dlinit` call out to JS.

This change relies on the fact that `dlopen(NULL, ..`) return a handle the is equivalent of `RTLD_DEFAULT` when passed to `dlsym`.  See: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlopen.3.html