### PR TITLE
remove readlink functions from worker and lz4 fs nodes

### DIFF
--- a/src/library_lz4.js
+++ b/src/library_lz4.js
@@ -134,9 +134,6 @@ mergeInto(LibraryManager.library, {
       symlink: function(parent, newName, oldPath) {
         throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       },
-      readlink: function(node) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
-      },
     },
     stream_ops: {
       read: function (stream, buffer, offset, length, position) {

--- a/src/library_workerfs.js
+++ b/src/library_workerfs.js
@@ -127,9 +127,6 @@ mergeInto(LibraryManager.library, {
       symlink: function(parent, newName, oldPath) {
         throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       },
-      readlink: function(node) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
-      },
     },
     stream_ops: {
       read: function (stream, buffer, offset, length, position) {

--- a/test/fs/test_lz4fs.cpp
+++ b/test/fs/test_lz4fs.cpp
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <unistd.h>
 
 #include <emscripten.h>
 
@@ -113,6 +114,12 @@ extern "C" void EMSCRIPTEN_KEEPALIVE finish() {
   fclose(f1);
   fclose(f2);
   fclose(f3);
+
+  // attemping to read a lz4 node as a link should be invalid
+  buffer[0] = '\0';
+  assert(readlink("file.txt", buffer, sizeof(buffer)) == -1);
+  assert(buffer[0] == '\0');
+  assert(errno == EINVAL);
 
   // all done
   int result;

--- a/test/fs/test_lz4fs.cpp
+++ b/test/fs/test_lz4fs.cpp
@@ -118,7 +118,10 @@ extern "C" void EMSCRIPTEN_KEEPALIVE finish() {
 
   // attemping to read a lz4 node as a link should be invalid
   buffer[0] = '\0';
-  assert(readlink("file.txt", buffer, sizeof(buffer)) == -1);
+  assert(readlink("file1.txt", buffer, sizeof(buffer)) == -1);
+  assert(buffer[0] == '\0');
+  assert(errno == EINVAL);
+  assert(readlink("subdir/file2.txt", buffer, sizeof(buffer)) == -1);
   assert(buffer[0] == '\0');
   assert(errno == EINVAL);
 

--- a/test/fs/test_lz4fs.cpp
+++ b/test/fs/test_lz4fs.cpp
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include <emscripten.h>
 

--- a/test/fs/test_workerfs_read.c
+++ b/test/fs/test_workerfs_read.c
@@ -72,5 +72,12 @@ int main() {
 
   assert(blobFileExists);
   assert(fileTxtExists);
+
+  // attemping to read a worker node as a link should result in EINVAL
+  buf[0] = '\0';
+  assert(readlink("/work/blob.txt", buf, sizeof(buf)) == -1);
+  assert(buf[0] == '\0');
+  assert(errno == EINVAL);
+
   return 0;
 }


### PR DESCRIPTION
Fixes #18587

As mentioned in the bug this manifests in the realpath function.  How i stumbled on it was the use of `std::filesystem::canonical, std::filesystem::weakly_canonical` which uses realpath.
```c
		ssize_t k = readlink(output, stack, p);
		if (k==p) goto toolong;
		if (!k) {
			errno = ENOENT;
			return 0;
		}
		if (k<0) {
                  if (errno != EINVAL) return 0;
```
[if (errno != EINVAL) return 0;](https://github.com/emscripten-core/emscripten/blob/33a9cf1bceaaf52229285b6e77bf7f5747b18dba/system/lib/libc/musl/src/misc/realpath.c#L102)

