### PR TITLE
Error on MEMORY_GROWTH_LINEAR_STEP/GEOMETRIC_CAP with STANDALONE_WASM

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1891,6 +1891,16 @@ def phase_linker_setup(options, state, newargs):
     if 'EXIT_RUNTIME' in user_settings:
       exit_with_error('Explictly setting EXIT_RUNTIME not compatible with STANDALONE_WASM.  EXIT_RUNTIME will always be True for programs (with a main function) and False for reactors (not main function).')
     settings.EXIT_RUNTIME = settings.EXPECT_MAIN
+    settings.IGNORE_MISSING_MAIN = 0
+    # the wasm must be runnable without the JS, so there cannot be anything that
+    # requires JS legalization
+    settings.LEGALIZE_JS_FFI = 0
+    if 'MEMORY_GROWTH_LINEAR_STEP' in user_settings:
+      exit_with_error('MEMORY_GROWTH_LINEAR_STEP is not compatible with STANDALONE_WASM')
+    if 'MEMORY_GROWTH_GEOMETRIC_CAP' in user_settings:
+      exit_with_error('MEMORY_GROWTH_GEOMETRIC_CAP is not compatible with STANDALONE_WASM')
+    if settings.MINIMAL_RUNTIME:
+      exit_with_error('MINIMAL_RUNTIME reduces JS size, and is incompatible with STANDALONE_WASM which focuses on ignoring JS anyhow and being 100% wasm')
 
   # Note the exports the user requested
   building.user_requested_exports.update(settings.EXPORTED_FUNCTIONS)
@@ -1906,9 +1916,6 @@ def phase_linker_setup(options, state, newargs):
     # in libcompiler-rt.
     if not settings.PURE_WASI and '-nostdlib' not in newargs and '-nodefaultlibs' not in newargs:
       default_setting('STACK_OVERFLOW_CHECK', max(settings.ASSERTIONS, settings.STACK_OVERFLOW_CHECK))
-
-  if settings.STANDALONE_WASM:
-    settings.IGNORE_MISSING_MAIN = 0
 
   # For users that opt out of WARN_ON_UNDEFINED_SYMBOLS we assume they also
   # want to opt out of ERROR_ON_UNDEFINED_SYMBOLS.
@@ -2276,10 +2283,6 @@ def phase_linker_setup(options, state, newargs):
 
   settings.REQUIRED_EXPORTS += ['stackSave', 'stackRestore', 'stackAlloc']
 
-  if not settings.STANDALONE_WASM:
-    # in standalone mode, crt1 will call the constructors from inside the wasm
-    settings.REQUIRED_EXPORTS.append('__wasm_call_ctors')
-
   if settings.RELOCATABLE:
     # TODO(https://reviews.llvm.org/D128515): Make this mandatory once
     # llvm change lands
@@ -2458,13 +2461,6 @@ def phase_linker_setup(options, state, newargs):
      settings.EXPORT_NAME == 'Module' and options.oformat == OFormat.HTML and \
      (options.shell_path == utils.path_from_root('src/shell.html') or options.shell_path == utils.path_from_root('src/shell_minimal.html')):
     exit_with_error(f'Due to collision in variable name "Module", the shell file "{options.shell_path}" is not compatible with build options "-sMODULARIZE -sEXPORT_NAME=Module". Either provide your own shell file, change the name of the export to something else to avoid the name collision. (see https://github.com/emscripten-core/emscripten/issues/7950 for details)')
-
-  if settings.STANDALONE_WASM:
-    if settings.MINIMAL_RUNTIME:
-      exit_with_error('MINIMAL_RUNTIME reduces JS size, and is incompatible with STANDALONE_WASM which focuses on ignoring JS anyhow and being 100% wasm')
-    # the wasm must be runnable without the JS, so there cannot be anything that
-    # requires JS legalization
-    settings.LEGALIZE_JS_FFI = 0
 
   # TODO(sbc): Remove WASM2JS here once the size regression it would introduce has been fixed.
   if settings.SHARED_MEMORY or settings.RELOCATABLE or settings.ASYNCIFY_LAZY_LOAD_CODE or settings.WASM2JS:

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12896,3 +12896,15 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
                  'ReferenceError: dbg is not defined',
                  emcc_args=['-DNDEBUG', '-sASSERTIONS=0'],
                  assert_returncode=NON_ZERO)
+
+  def test_standalone_settings(self):
+    base_cmd = [EMCC, test_file('hello_world.c'), '-sSTANDALONE_WASM']
+
+    err = self.expect_fail(base_cmd + ['-sMINIMAL_RUNTIME'])
+    self.assertContained('error: MINIMAL_RUNTIME reduces JS size, and is incompatible with STANDALONE_WASM which focuses on ignoring JS anyhow and being 100% wasm', err)
+
+    err = self.expect_fail(base_cmd + ['-sMEMORY_GROWTH_GEOMETRIC_CAP=1mb'])
+    self.assertContained('error: MEMORY_GROWTH_GEOMETRIC_CAP is not compatible with STANDALONE_WASM', err)
+
+    err = self.expect_fail(base_cmd + ['-sMEMORY_GROWTH_LINEAR_STEP=1mb'])
+    self.assertContained('error: MEMORY_GROWTH_LINEAR_STEP is not compatible with STANDALONE_WASM', err)


### PR DESCRIPTION
This options only effect the JS version of emscripten_resize_heap, and not the native/standalone one.