### PR TITLE
[Proxying][NFC] Encapsulate task queue notification logic

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1110,7 +1110,6 @@ var LibraryPThread = {
       }
       worker.postMessage({'cmd' : 'processProxyingQueue', 'queue': queue});
     }
-    return 1;
   }
 };
 

--- a/system/lib/pthread/em_task_queue.c
+++ b/system/lib/pthread/em_task_queue.c
@@ -5,6 +5,8 @@
  * found in the LICENSE file.
  */
 
+#include <emscripten/threading.h>
+#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -101,4 +103,28 @@ task em_task_queue_dequeue(em_task_queue* queue) {
   task t = queue->tasks[queue->head];
   queue->head = (queue->head + 1) % queue->capacity;
   return t;
+}
+
+// Send a postMessage notification containing the em_task_queue pointer to the
+// target thread so it will execute the queue when it returns to the event loop.
+// Also pass in the current thread and main thread ids to minimize calls back
+// into Wasm.
+extern void _emscripten_notify_task_queue(pthread_t target_thread,
+                                          pthread_t curr_thread,
+                                          pthread_t main_thread,
+                                          em_task_queue* queue);
+
+void em_task_queue_notify(em_task_queue* queue) {
+  // If there is no pending notification for this queue, create one. If an old
+  // notification is currently being processed, it may or may not execute this
+  // work. In case it does not, the new notification will ensure the work is
+  // still executed.
+  notification_state previous =
+    atomic_exchange(&queue->notification, NOTIFICATION_PENDING);
+  if (previous != NOTIFICATION_PENDING) {
+    _emscripten_notify_task_queue(queue->thread,
+                                  pthread_self(),
+                                  emscripten_main_browser_thread_id(),
+                                  queue);
+  }
 }

--- a/system/lib/pthread/em_task_queue.h
+++ b/system/lib/pthread/em_task_queue.h
@@ -41,15 +41,6 @@ typedef struct em_task_queue {
   int tail;
 } em_task_queue;
 
-// Send a postMessage notification containing the em_task_queue pointer to the
-// target thread so it will execute the queue when it returns to the event loop.
-// Also pass in the current thread and main thread ids to minimize calls back
-// into Wasm.
-extern int _emscripten_notify_task_queue(pthread_t target_thread,
-                                         pthread_t curr_thread,
-                                         pthread_t main_thread,
-                                         em_task_queue* queue);
-
 em_task_queue* em_task_queue_create(pthread_t thread);
 
 void em_task_queue_destroy(em_task_queue* queue);
@@ -72,3 +63,7 @@ int em_task_queue_enqueue(em_task_queue* queue, task t);
 
 // Not thread safe. Assumes the queue is not empty.
 task em_task_queue_dequeue(em_task_queue* queue);
+
+// Schedule the queue to be executed next time its owning thread returns to its
+// event loop.
+void em_task_queue_notify(em_task_queue* queue);

--- a/system/lib/pthread/proxying.c
+++ b/system/lib/pthread/proxying.c
@@ -9,7 +9,6 @@
 #include <emscripten/proxying.h>
 #include <emscripten/threading.h>
 #include <pthread.h>
-#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -268,18 +267,7 @@ int emscripten_proxy_async(em_proxying_queue* q,
     return 0;
   }
 
-  // If there is no pending notification for this queue, create one. If an old
-  // notification is currently being processed, it may or may not execute this
-  // work. In case it does not, the new notification will ensure the work is
-  // still executed.
-  notification_state previous =
-    atomic_exchange(&tasks->notification, NOTIFICATION_PENDING);
-  if (previous != NOTIFICATION_PENDING) {
-    _emscripten_notify_task_queue(target_thread,
-                                  pthread_self(),
-                                  emscripten_main_browser_thread_id(),
-                                  tasks);
-  }
+  em_task_queue_notify(tasks);
   return 1;
 }
 


### PR DESCRIPTION
Rather than exposing the details of how task queues are notified to proxying.c,
move the logic into a new `em_task_queue_notify` function declared in
em_task_queue.h and implemented in em_task_queue.c.