### PR TITLE
[EH] Simplify supported node version logic

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -494,10 +494,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def require_wasm_eh(self):
     if config.NODE_JS and config.NODE_JS in self.js_engines:
       version = shared.check_node_version()
-      if version >= (16, 0, 0):
+      if version >= (17, 0, 0):
         self.js_engines = [config.NODE_JS]
-        if version < (20, 0, 0):
-          self.node_args.append('--experimental-wasm-eh')
         return
 
     if config.V8_ENGINE and config.V8_ENGINE in self.js_engines:


### PR DESCRIPTION
According to https://webassembly.org/roadmap/, Wasm EH is enabled by default, i.e., not behind a flag, as of v17.0.

Also I found v16 has problems even with `--experimenal-wasm-eh`. I think its implementation of `WebAssembly.Exception` JS API has changed in the meantime, and because our library_exception.js uses `WebAssembly.Exception` JS API in some cases:
https://github.com/emscripten-core/emscripten/blob/0481237d73b7de6e41975d3da831ad6899d00b7c/src/library_exceptions.js#L413

This errors out with v16:
```console
aheejin@aheejin:~/test/stack$ ~/apps/node-v16.9.1/node --experimental-wasm-eh ex.js
/usr/local/google/home/aheejin/test/stack/ex.js:137
      throw ex;
      ^

TypeError: WebAssembly.Exception(): Argument 0 must be an exception type with 'parameters'
    at ___throw_exception_with_stack_trace (/usr/local/google/home/aheejin/test/stack/ex.js:1314:15)
    at <anonymous>:wasm-function[1660]:0x23f98
    at <anonymous>:wasm-function[13]:0x1557
    at <anonymous>:wasm-function[19]:0x1884
    at /usr/local/google/home/aheejin/test/stack/ex.js:895:22
    at callMain (/usr/local/google/home/aheejin/test/stack/ex.js:4703:15)
    at doRun (/usr/local/google/home/aheejin/test/stack/ex.js:4756:23)
    at run (/usr/local/google/home/aheejin/test/stack/ex.js:4771:5)
    at runCaller (/usr/local/google/home/aheejin/test/stack/ex.js:4688:19)
    at removeRunDependency (/usr/local/google/home/aheejin/test/stack/ex.js:829:7)
```

I think it is the safest to just enable node after v17.