### PR TITLE
[EH] Make test setting consistent (NFC)

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8120,8 +8120,10 @@ int main() {
                 assert_returncode=NON_ZERO, expected_output=stack_trace_checks)
 
     # Not allowed
+    self.set_setting('ASSERTIONS', 1)
+    self.set_setting('EXCEPTION_STACK_TRACES', 0)
     create_file('src.cpp', src)
-    err = self.expect_fail([EMCC, 'src.cpp', '-sASSERTIONS=1', '-sEXCEPTION_STACK_TRACES=0'])
+    err = self.expect_fail([EMCC, 'src.cpp'] + self.get_emcc_args())
     self.assertContained('EXCEPTION_STACK_TRACES cannot be disabled when ASSERTIONS are enabled', err)
 
     # Doesn't print stack traces

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8124,7 +8124,7 @@ int main() {
     self.set_setting('EXCEPTION_STACK_TRACES', 0)
     create_file('src.cpp', src)
     err = self.expect_fail([EMCC, 'src.cpp'] + self.get_emcc_args())
-    self.assertContained('EXCEPTION_STACK_TRACES cannot be disabled when ASSERTIONS are enabled', err)
+    self.assertContained('error: EXCEPTION_STACK_TRACES cannot be disabled when ASSERTIONS are enabled', err)
 
     # Doesn't print stack traces
     self.set_setting('ASSERTIONS', 0)


### PR DESCRIPTION
I wasn't aware that we can also use `set_setting` to set settings and use `get_emcc_args` when testing with `expect_fail`. Changed to use `set_setting` to be consistent with the tests of other combinations.