### PR TITLE
embind: Add support for `std::nullptr_t`

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -675,6 +675,23 @@ var LibraryEmbind = {
     return this['fromWireType']({{{ makeGetValue('pointer', '0', 'i32') }}});
   },
 
+  _embind_register_std_nullptr_t__sig: 'vpppDn',
+  _embind_register_std_nullptr_t__deps: ['$registerType'],
+  _embind_register_std_nullptr_t: function(rawType, name) {
+
+    registerType(rawType, {
+      name: name,
+      'fromWireType': function (value) {
+        return null;
+      },
+      'toWireType': function (destructors, value) {
+        return null;
+      },
+      'argPackAdvance': 8,
+      destructorFunction: null, // This type does not need a destructor
+    });
+  },
+
   _embind_register_std_string__sig: 'vpp',
   _embind_register_std_string__deps: [
     '$readLatin1String', '$registerType',

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -78,6 +78,10 @@ void _embind_register_float(
     const char* name,
     size_t size);
 
+void _embind_register_std_nullptr_t(
+    TYPEID nullptrType,
+    const char* name);
+
 void _embind_register_std_string(
     TYPEID stringType,
     const char* name);

--- a/system/lib/embind/bind.cpp
+++ b/system/lib/embind/bind.cpp
@@ -9,6 +9,7 @@
 #endif
 #include <algorithm>
 #include <climits>
+#include <cstddef>
 #include <emscripten/emscripten.h>
 #include <emscripten/wire.h>
 #include <limits>
@@ -142,6 +143,7 @@ EMSCRIPTEN_BINDINGS(builtin) {
   register_float<float>("float");
   register_float<double>("double");
 
+  _embind_register_std_nullptr_t(TypeID<std::nullptr_t>::get(), "std::nullptr_t");
   _embind_register_std_string(TypeID<std::string>::get(), "std::string");
   _embind_register_std_string(
     TypeID<std::basic_string<unsigned char>>::get(), "std::basic_string<unsigned char>");

--- a/test/embind/embind.test.js
+++ b/test/embind/embind.test.js
@@ -565,6 +565,10 @@ module({
             assert.equal(undefined, cm.emval_test_return_void());
         });
 
+        test("nullptr_t return converts to null", function() {
+          assert.equal(null, cm.emval_test_return_null());
+        });
+
         test("booleans can be marshalled", function() {
             assert.equal(false, cm.emval_test_not(true));
             assert.equal(true, cm.emval_test_not(false));

--- a/test/embind/embind_test.cpp
+++ b/test/embind/embind_test.cpp
@@ -3,6 +3,7 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
+#include <cstddef>
 #include <string>
 #include <malloc.h>
 #include <functional>
@@ -72,6 +73,10 @@ val emval_test_passthrough(val v) {
 }
 
 void emval_test_return_void() {
+}
+
+std::nullptr_t emval_test_return_nullptr_t() {
+    return nullptr;
 }
 
 bool emval_test_not(bool b) {


### PR DESCRIPTION
As the title says, this adds support for `std::nullptr_t` types to the Embind. This came up when bootstrapping a pre-existing binding generator test suite to work with Embind target.

Used the sig `vpppDn` where `Dn` is the Itanium C++ mangled encoding, but not really sure about the rest of the letters, and couldn't really find any documentation regarding how these signatures mean. Is this documented anywhere?



