### PR TITLE
Add emscripten_dlopen_promise API

### DIFF
--- a/src/library_promise.js
+++ b/src/library_promise.js
@@ -79,6 +79,7 @@ mergeInto(LibraryManager.library, {
 #if RUNTIME_DEBUG
       dbg('emscripten promise callback: ' + value);
 #endif
+      {{{ runtimeKeepalivePop() }}};
       var stack = stackSave();
       // Allocate space for the result value and initialize it to NULL.
       var resultPtr = stackAlloc(POINTER_SIZE);
@@ -137,13 +138,14 @@ mergeInto(LibraryManager.library, {
 #if RUNTIME_DEBUG
     dbg('emscripten_promise_then: ' + id);
 #endif
+    {{{ runtimeKeepalivePush() }}};
     var promise = getPromise(id);
     var newId = promiseMap.allocate({
       promise: promise.then(makePromiseCallback(onFulfilled, userData),
                             makePromiseCallback(onRejected, userData))
     });
 #if RUNTIME_DEBUG
-    dbg('create: ' + newId);
+    dbg('emscripten_promise_then: -> ' + newId);
 #endif
     return newId;
   },

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -24,6 +24,7 @@
 #include "em_macros.h"
 #include "em_types.h"
 #include "em_js.h"
+#include "promise.h"
 #include "wget.h"
 #include "version.h"
 
@@ -173,6 +174,11 @@ void emscripten_scan_stack(em_scan_func func);
 // is asynchronous the normal dlopen function can't be used in all situations.
 typedef void (*em_dlopen_callback)(void* handle, void* user_data);
 void emscripten_dlopen(const char *filename, int flags, void* user_data, em_dlopen_callback onsuccess, em_arg_callback_func onerror);
+
+// Promisified version of emscripten_dlopen
+// The returned promise will resolve once the dso has been loaded.  Its up to
+// the caller to call emscripten_promise_destroy on this promise.
+em_promise_t emscripten_dlopen_promise(const char *filename, int flags);
 
 void emscripten_throw_number(double number);
 void emscripten_throw_string(const char *utf8String);

--- a/system/lib/libc/dynlink.c
+++ b/system/lib/libc/dynlink.c
@@ -529,6 +529,37 @@ void emscripten_dlopen(const char* filename, int flags, void* user_data,
   _emscripten_dlopen_js(p, dlopen_onsuccess, dlopen_onerror, d);
 }
 
+static void promise_onsuccess(void* user_data, void* handle) {
+  em_promise_t p = (em_promise_t)user_data;
+  dbg("promise_onsuccess: %p", p);
+  emscripten_promise_resolve(p, EM_PROMISE_FULFILL, handle);
+  emscripten_promise_destroy(p);
+}
+
+static void promise_onerror(void* user_data) {
+  em_promise_t p = (em_promise_t)user_data;
+  dbg("promise_onerror: %p", p);
+  emscripten_promise_resolve(p, EM_PROMISE_REJECT, NULL);
+  emscripten_promise_destroy(p);
+}
+
+// emscripten_dlopen_promise is currently implemented on top of the callback
+// based API (emscripten_dlopen).
+// TODO(sbc): Consider inverting this and perhaps deprecating/removing
+// the old API.
+em_promise_t emscripten_dlopen_promise(const char* filename, int flags) {
+  // Create a promise that is resolved (and destroyed) once the operation
+  // succeeds.
+  em_promise_t p = emscripten_promise_create();
+  emscripten_dlopen(filename, flags, p, promise_onsuccess, promise_onerror);
+
+  // Create a second promise bound the first one to return the caller.  It's
+  // then up to the caller to destroy this promise.
+  em_promise_t ret = emscripten_promise_create();
+  emscripten_promise_resolve(ret, EM_PROMISE_MATCH, p);
+  return ret;
+}
+
 void* __dlsym(void* restrict p, const char* restrict s, void* restrict ra) {
   dbg("__dlsym dso:%p sym:%s", p, s);
   if (p != RTLD_DEFAULT && p != RTLD_NEXT && __dl_invalid_handle(p)) {

--- a/test/other/test_dlopen_promise.c
+++ b/test/other/test_dlopen_promise.c
@@ -1,0 +1,30 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <stdio.h>
+
+#include <emscripten/emscripten.h>
+#include <emscripten/promise.h>
+
+em_promise_result_t on_fullfilled(void **result, void* data, void *handle) {
+  printf("onsuccess\n");
+  int* foo = (int*)dlsym(handle, "foo");
+  assert(foo);
+  printf("foo = %d\n", *foo);
+  assert(*foo == 42);
+  return EM_PROMISE_FULFILL;
+}
+
+em_promise_result_t on_rejected(void **result, void* data, void *value) {
+  printf("onerror %s\n", dlerror());
+  return EM_PROMISE_FULFILL;
+}
+
+int main() {
+  em_promise_t inner = emscripten_dlopen_promise("libside.so", RTLD_NOW);
+  em_promise_t outer = emscripten_promise_then(outer, on_fullfilled, on_rejected, NULL);
+  emscripten_promise_destroy(outer);
+  emscripten_promise_destroy(inner);
+  printf("returning from main\n");
+  return 0;
+}

--- a/test/other/test_dlopen_promise.out
+++ b/test/other/test_dlopen_promise.out
@@ -1,0 +1,3 @@
+returning from main
+onsuccess
+foo = 42

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6364,6 +6364,13 @@ int main(int argc,char** argv) {
     self.set_setting('EXIT_RUNTIME')
     self.do_other_test('test_dlopen_async.c')
 
+  def test_dlopen_promise(self):
+    create_file('side.c', 'int foo = 42;\n')
+    self.run_process([EMCC, 'side.c', '-o', 'libside.so', '-sSIDE_MODULE'])
+    self.set_setting('MAIN_MODULE', 2)
+    self.set_setting('EXIT_RUNTIME')
+    self.do_other_test('test_dlopen_promise.c')
+
   def test_dlopen_blocking(self):
     self.run_process([EMCC, test_file('other/test_dlopen_blocking_side.c'), '-o', 'libside.so', '-sSIDE_MODULE'])
     self.set_setting('MAIN_MODULE', 2)


### PR DESCRIPTION
This is a new promisified version of the existing emscripten_dlopen API which is callback-based.

The new promise API was added in #18598 and this is good place to start integrating it.