### PR TITLE
Use RuntimeError in abort() before module instantiation

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -494,13 +494,11 @@ function abort(what) {
   // Wasm EH code (because RuntimeError is considered as a foreign exception and
   // caught by 'catch_all'), but in case throwing RuntimeError is fine because
   // the module has not even been instantiated, even less running.
-  if (typeof Module['asm'] !== 'undefined')
+  if (typeof Module['asm'] !== 'undefined') {
     ___trap();
-  else
-    throwError(what);
-#else
-  throwError(what);
+  }
 #endif
+  throwError(what);
 }
 
 #include "memoryprofiler.js"

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -469,7 +469,6 @@ function abort(what) {
   // defintion for WebAssembly.RuntimeError claims it takes no arguments even
   // though it can.
   // TODO(https://github.com/google/closure-compiler/pull/3913): Remove if/when upstream closure gets fixed.
-
 #if WASM_EXCEPTIONS == 1
   // See above, in the meantime, we resort to wasm code for trapping.
   //
@@ -481,7 +480,7 @@ function abort(what) {
   // Wasm EH code (because RuntimeError is considered as a foreign exception and
   // caught by 'catch_all'), but in case throwing RuntimeError is fine because
   // the module has not even been instantiated, even less running.
-  if (typeof Module['asm'] !== 'undefined') {
+  if (runtimeInitialized) {
     ___trap();
   }
 #endif

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -493,7 +493,7 @@ function abort(what) {
   // Throw the error whether or not MODULARIZE is set because abort is used
   // in code paths apart from instantiation where an exception is expected
   // to be thrown when abort is called.
-    throw e;
+  throw e;
 }
 
 #include "memoryprofiler.js"

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -470,19 +470,6 @@ function abort(what) {
   // though it can.
   // TODO(https://github.com/google/closure-compiler/pull/3913): Remove if/when upstream closure gets fixed.
 
-  function throwError(what) {
-    /** @suppress {checkTypes} */
-    var e = new WebAssembly.RuntimeError(what);
-
-#if MODULARIZE
-    readyPromiseReject(e);
-#endif
-    // Throw the error whether or not MODULARIZE is set because abort is used
-    // in code paths apart from instantiation where an exception is expected
-    // to be thrown when abort is called.
-    throw e;
-  }
-
 #if WASM_EXCEPTIONS == 1
   // See above, in the meantime, we resort to wasm code for trapping.
   //
@@ -498,7 +485,16 @@ function abort(what) {
     ___trap();
   }
 #endif
-  throwError(what);
+  /** @suppress {checkTypes} */
+  var e = new WebAssembly.RuntimeError(what);
+
+#if MODULARIZE
+  readyPromiseReject(e);
+#endif
+  // Throw the error whether or not MODULARIZE is set because abort is used
+  // in code paths apart from instantiation where an exception is expected
+  // to be thrown when abort is called.
+    throw e;
 }
 
 #include "memoryprofiler.js"


### PR DESCRIPTION
We decided use a trap for `abort` function in case of Wasm EH in order to prevent infinite-looping (#16910).
https://github.com/emscripten-core/emscripten/blob/44b2c2a1ecad39c534e14179acb49419dfee528b/src/preamble.js#L472-L474

The short reason is, in Wasm EH `RuntimeError` is treated as a foreign exception and caught by `catch_all`, so you try to abort the program and throw a `RuntimeError`, but it is caught by some `catch_all` used in the cleanup (=destructors, etc) code, causing the program to continue to run.

`__trap` is [defined](https://github.com/emscripten-core/emscripten/blob/44b2c2a1ecad39c534e14179acb49419dfee528b/system/lib/compiler-rt/__trap.c#L1-L3) in compiler-rt and [exported](https://github.com/emscripten-core/emscripten/blob/44b2c2a1ecad39c534e14179acb49419dfee528b/emcc.py#L2798-L2799) when Wasm EH is enabled.

This has worked so far, but in case we fail to instantiate a Wasm module and call `abort` because of it, we don't have access to the imported `Module['asm']['__trap']`, because `Module['asm']` has not been set:
https://github.com/emscripten-core/emscripten/blob/44b2c2a1ecad39c534e14179acb49419dfee528b/src/preamble.js#L848

And we haven't had the opportunity to run this code:
https://github.com/emscripten-core/emscripten/blob/44b2c2a1ecad39c534e14179acb49419dfee528b/src/preamble.js#L975

So the `abort` call will end like this:
```console
TypeError: Cannot read properties of undefined (reading '__trap')
    at ___trap (/usr/local/google/home/aheejin/test/gl84/exported_api.js:5152:34)
    at abort (/usr/local/google/home/aheejin/test/gl84/exported_api.js:892:5)
    at /usr/local/google/home/aheejin/test/gl84/exported_api.js:1172:5
```
which may not be the worst thing in the world given that we are crashing anyway, but not the situation we intended.

This PR lets us throw `RuntimeError` in case we don't have the wasm module instantiated and have access to `Module['asm']['__trap']`. This is OK even with Wasm EH because we haven't been running the module, there's no risk of infinite-looping we tried to prevent in #16910.

I'm not sure how to add a test for this, because the test would require a module that fails to instantiate. This was found while I was debugging something else.