### PR TITLE
Use st_size in emrun.py rather than constant

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -650,7 +650,7 @@ class HTTPHandler(SimpleHTTPRequestHandler):
       ctype = 'application/javascript'
     self.send_header('Content-type', ctype)
     fs = os.fstat(f.fileno())
-    self.send_header("Content-Length", str(fs[6]))
+    self.send_header("Content-Length", str(fs.st_size))
     self.send_header("Last-Modified", self.date_time_string(fs.st_mtime))
     self.send_header('Cache-Control', 'no-cache, must-revalidate')
     self.send_header('Connection', 'close')


### PR DESCRIPTION
This seems to date back to the initial commit but I can't see any reason to use the constant here.

I tested in both python2 and python3 that these are the same thing.