### PR TITLE
Add i53 support for `makeSetValue`

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -376,6 +376,10 @@ function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, sep = '
 
   const offset = calcFastOffset(ptr, pos);
 
+  if (type === 'i53') {
+    return `writeI53ToI64(${offset}, ${value})`;
+  }
+
   const slab = getHeapForType(type);
   if (slab == 'HEAPU64' || slab == 'HEAP64') {
     value = `BigInt(${value})`;

--- a/src/runtime_stack_check.js
+++ b/src/runtime_stack_check.js
@@ -23,8 +23,8 @@ function writeStackCookie() {
   // The stack grow downwards towards _emscripten_stack_get_end.
   // We write cookies to the final two words in the stack and detect if they are
   // ever overwritten.
-  {{{ makeSetValue('max', 0, '0x2135467', 'u32' ) }}};
-  {{{ makeSetValue('max', 4, '0x89BACDFE', 'u32' ) }}};
+  {{{ makeSetValue('max', 0, '0x02135467', 'u32') }}};
+  {{{ makeSetValue('max', 4, '0x89BACDFE', 'u32') }}};
 #if !USE_ASAN && !SAFE_HEAP // ASan and SAFE_HEAP check address 0 themselves
   // Also test the global address 0 for integrity.
   HEAPU32[0] = 0x63736d65; /* 'emsc' */
@@ -45,7 +45,7 @@ function checkStackCookie() {
   }
   var cookie1 = {{{ makeGetValue('max', 0, 'u32') }}};
   var cookie2 = {{{ makeGetValue('max', 4, 'u32') }}};
-  if (cookie1 != 0x2135467 || cookie2 != 0x89BACDFE) {
+  if (cookie1 != 0x02135467 || cookie2 != 0x89BACDFE) {
     abort('Stack overflow! Stack cookie has been overwritten at ' + ptrToString(max) + ', expected hex dwords 0x89BACDFE and 0x2135467, but received ' + ptrToString(cookie2) + ' ' + ptrToString(cookie1));
   }
 #if !USE_ASAN && !SAFE_HEAP // ASan and SAFE_HEAP check address 0 themselves

--- a/test/other/test_parseTools.c
+++ b/test/other/test_parseTools.c
@@ -1,22 +1,35 @@
 #include <limits.h>
 #include <stdio.h>
 #include <inttypes.h>
+#include <emscripten/emscripten.h>
 
-void test_makeGetValue(int32_t* ptr);
+void test_makeGetValue(int64_t* ptr);
+void test_makeSetValue(int64_t* ptr);
 int  test_receiveI64ParamAsI53(int64_t arg1, int64_t arg2);
 int  test_receiveI64ParamAsDouble(int64_t arg1, int64_t arg2);
-void test_makeSetValue_i64(int64_t* ptr);
+void test_makeSetValue_unaligned(int64_t* ptr);
 
 #define MAX_SAFE_INTEGER (1ll << 53)
 #define MIN_SAFE_INTEGER (-MAX_SAFE_INTEGER)
+
+EMSCRIPTEN_KEEPALIVE void printI64(int64_t* ptr) {
+  printf("printI64: 0x%llx\n", *ptr);
+}
+
+EMSCRIPTEN_KEEPALIVE void clearI64(int64_t* ptr) {
+  *ptr = 0;
+}
 
 int main() {
   int rtn;
   printf("MAX_SAFE_INTEGER: %lld\n", MAX_SAFE_INTEGER);
   printf("MIN_SAFE_INTEGER: %lld\n", MIN_SAFE_INTEGER);
 
-  int32_t num = -0x12345678;
+  int64_t num = -0x0000aabb12345678ll;
+  printI64(&num);
   test_makeGetValue(&num);
+
+  test_makeSetValue(&num);
 
   rtn = test_receiveI64ParamAsI53(42, -42);
   printf("rtn = %d\n", rtn);
@@ -42,7 +55,7 @@ int main() {
   rtn = test_receiveI64ParamAsDouble(MIN_SAFE_INTEGER - 1, 0);
   printf("rtn = %d\n", rtn);
 
-  printf("\ntest_makeSetValue_i64\n");
+  printf("\ntest_makeSetValue_unaligned\n");
   // Test an unaligned read of an i64 in JS. To do that, get an unaligned
   // pointer. i64s are only 32-bit aligned, but we can't rely on the address to
   // happen to be unaligned here, so actually force an unaligned address (one
@@ -50,7 +63,7 @@ int main() {
   char buffer[16];
   for (size_t i = 0; i < 8; i += 4) {
     int64_t* unaligned_i64 = (int64_t*)(buffer + i);
-    test_makeSetValue_i64(unaligned_i64);
+    test_makeSetValue_unaligned(unaligned_i64);
     printf("i64 = 0x%llx\n", *unaligned_i64);
   }
 

--- a/test/other/test_parseTools.out
+++ b/test/other/test_parseTools.out
@@ -1,7 +1,10 @@
 MAX_SAFE_INTEGER: 9007199254740992
 MIN_SAFE_INTEGER: -9007199254740992
+printI64: 0xffff5544edcba988
 
 test_makeGetValue:
+i53: -aabb12345678
+u53: ffff5544edcba800
 i32: -12345678
 u32: edcba988
 u32 legacy: edcba988
@@ -13,6 +16,14 @@ u8: 88
 u8 legacy: 88
 ptr: edcba988
 ptr: edcba988
+
+test_makeSetValue:
+printI64: 0x12345678ab
+printI64: 0xffffffff66780000
+printI64: 0x12345678ab
+printI64: 0xffffffffffffffff
+printI64: 0xff
+printI64: 0x345678ab
 
 test_receiveI64ParamAsI53:
 arg1: 42
@@ -50,7 +61,7 @@ arg1: -9007199254740992
 arg2: 0
 rtn = 0
 
-test_makeSetValue_i64
+test_makeSetValue_unaligned
 i64 = 0x12345678ab
 i64 = 0x12345678ab
 


### PR DESCRIPTION
My plan is to transition most/all of the current callers of makeSetValue with i64 to i53.

There is already support in `makeGetValue` so this just adds parity.

See #18687