### PR TITLE
[EH/SjLj] Make Wasm EH force Wasm SjLj

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,12 @@ See docs/process.md for more on how version tagging works.
   mainly for the users who want only exceptions' stack traces without turning
   `ASSERTIONS` on. This option currently works only for Wasm exceptions
   (-fwasm-exceptions). (#18642)
+- `SUPPORT_LONGJMP`'s default value now depends on the exception mode. If Wasm
+  EH (`-fwasm-exception`) is used, it defaults to `wasm`, and if Emscripten EH
+  (`-sDISABLE_EXCEPTION_CATCHING=0`) is used or no exception support is used, it
+  defaults to `emscripten`. Previously it always defaulted to `emscripten`, so
+  when a user specified `-fwasm-exceptions`, it resulted in Wasm EH + Emscripten
+  SjLj, the combination we do not intend to support for the long term.
 
 3.1.31 - 01/26/23
 -----------------

--- a/emcc.py
+++ b/emcc.py
@@ -1605,7 +1605,7 @@ def phase_setup(options, state, newargs):
     if user_settings.get('ASYNCIFY') == '1':
       diagnostics.warning('emcc', 'ASYNCIFY=1 is not compatible with -fwasm-exceptions. Parts of the program that mix ASYNCIFY and exceptions will not compile.')
 
-    if user_settings['SUPPORT_LONGJMP'] == 'emscripten':
+    if user_settings.get('SUPPORT_LONGJMP') == 'emscripten':
       exit_with_error('SUPPORT_LONGJMP=emscripten is not compatible with -fwasm-exceptions')
 
   if settings.DISABLE_EXCEPTION_THROWING and not settings.DISABLE_EXCEPTION_CATCHING:

--- a/site/source/docs/porting/setjmp-longjmp.rst
+++ b/site/source/docs/porting/setjmp-longjmp.rst
@@ -10,11 +10,12 @@ by the ``SUPPORT_LONGJMP`` setting, which can take these values:
 * ``emscripten``: JavaScript-based support
 * ``wasm``: WebAssembly exception handling-based support
 * 0: No support
-* 1: Default support (currently ``emscripten``) (default)
+* 1: Default support, depending on the exception mode. ``wasm`` if ``-fwasm-exception`` is used, ``emscripten`` otherwise.
 
-Currently ``-sSUPPORT_LONGJMP=1`` is the same as
-``-sSUPPORT_LONGJMP=emscripten``, and turned on by default. This default will
-eventually be the new ``wasm`` when most browsers support it.
+If :ref:`native Wasm exceptions <webassembly-exception-handling-based-support>`
+are used, ``SUPPORT_LONGJMP`` defaults to ``wasm``, and if :ref:`JavaScipt-based
+exceptions <javascript-based-exception-support>` are used or no exception
+support is used, it defaults to ``emscripten``.
 
 ``setjmp`` saves information about the calling environment into a buffer, and
 ``longjmp`` transfers the control back to the point where ``setjmp`` was called
@@ -78,8 +79,9 @@ For example, to use the JavaScript-based EH and setjmp-longjmp support together:
 
   em++ -fexceptions test.cpp -o test.js
 
-``-sSUPPORT_LONGJMP=1``, which defaults to ``emscripten``, is enabled by
-default, so you don't need to pass it explicitly.
+``-sSUPPORT_LONGJMP``, which defaults to ``emscripten`` or ``wasm`` depending on
+the exception mode, is enabled by default, so you don't need to pass it
+explicitly.
 
 To use the WebAssembly EH and setjmp-longjmp support together:
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1873,7 +1873,8 @@ var USES_DYNAMIC_ALLOC = true;
 // 'emscripten': (default) Emscripten setjmp/longjmp handling using JavaScript
 // 'wasm': setjmp/longjmp handling using Wasm EH instructions (experimental)
 // 0: No setjmp/longjmp handling
-// 1: Default setjmp/longjmp/handling. Currently 'emscripten'.
+// 1: Default setjmp/longjmp/handling, depending on the mode of exceptions.
+//    'wasm' if '-fwasm-exception' is used, 'emscripten' otherwise.
 //
 // [compile+link] - at compile time this enables the transformations needed for
 // longjmp support at codegen time, while at link it allows linking in the

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1816,6 +1816,12 @@ int main() {
     self.assertContained('error: You no longer need to pass DISABLE_EXCEPTION_CATCHING or DISABLE_EXCEPTION_THROWING when using Wasm exceptions', err)
     clear_all_relevant_settings(self)
 
+    # Emscripten SjLj and Wasm EH cannot mix
+    self.set_setting('SUPPORT_LONGJMP', 'emscripten')
+    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_emcc_args())
+    self.assertContained('error: SUPPORT_LONGJMP=emscripten is not compatible with -fwasm-exceptions', err)
+    clear_all_relevant_settings(self)
+
     # Wasm SjLj and Emscripten EH cannot mix
     self.set_setting('SUPPORT_LONGJMP', 'wasm')
     self.set_setting('DISABLE_EXCEPTION_THROWING', 0)


### PR DESCRIPTION
Currently `SUPPORT_LONGJMP` defaults to `emscripten` unless explicitly otherwise. So when a user specified `-fwasm-exceptions`, it resulted in Wasm EH + Emscripten SjLj, which has many restrictions (See https://github.com/emscripten-core/emscripten/discussions/17526#discussioncomment-3265159 for details) and is the combination we do not intend to support for the long term.

This PR makes `SUPPORT_LONGJMP` default value depend on the exception mode. If Wasm EH (`-fwasm-exception`) is used, it defaults to `wasm`, and if Emscripten EH (`-sDISABLE_EXCEPTION_CATCHING=0`) is used or no exception support is used, it defaults to `emscripten`. This way users get to use the same kind of EH + SjLj, which is easier to maintain and has less restrictions.