### PR TITLE
Update references to `tot-upstream` to `tot`. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,8 +118,8 @@ commands:
             mv ~/emsdk-main ~/emsdk
             cd ~/emsdk
             ./emsdk update-tags
-            ./emsdk install tot-upstream
-            ./emsdk activate tot-upstream
+            ./emsdk install tot
+            ./emsdk activate tot
             # Remove the emsdk version of emscripten to save space in the
             # persistent workspace and to avoid any confusion with the version
             # we are trying to test.

--- a/site/source/docs/contributing/developers_guide.rst
+++ b/site/source/docs/contributing/developers_guide.rst
@@ -22,12 +22,13 @@ get using the emsdk:
 
 ::
 
-    emsdk install tot-upstream
-    emsdk activate tot-upstream
+    emsdk install tot
+    emsdk activate tot
 
-That gets a "tip-of-tree" build of the very latest binaries. You can use those
-binaries with a checkout of the core Emscripten repository, simply by calling
-``emcc.py`` from that checkout, and it will use the binaries from the emsdk.
+This with install the latest "tip-of-tree" binaries needed to run Emscripten.
+You can use these emsdk-provided binaries with a git checkout of the Emscripten
+repository.  To do this, you can either edit your local ``.emscripten`` config
+file, or set ``EM_CONFIG=/path/to/emsdk/.emscripten`` in your environment.
 
 If you do want to contribute to LLVM or Binaryen, or to test modifications
 to them, you can


### PR DESCRIPTION
Also update/clarify the instructions for using emsdk binaries with and emscripten git checkout.