### PR TITLE
Mark stubs `weak` to let users implement their own versions

### DIFF
--- a/system/lib/libc/emscripten_libc_stubs.c
+++ b/system/lib/libc/emscripten_libc_stubs.c
@@ -20,11 +20,15 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#ifndef weak
+#define weak __attribute__((__weak__))
+#endif
+
 // ==========================================================================
 // sys/wait.h
 // ==========================================================================
 
-int waitid(idtype_t idtype, id_t id, siginfo_t *infop, int options) {
+weak int waitid(idtype_t idtype, id_t id, siginfo_t *infop, int options) {
   errno = ECHILD;
   return -1;
 }
@@ -50,12 +54,12 @@ struct tm *getdate(const char *string) {
   return 0;
 }
 
-int stime(const time_t *t) {
+weak int stime(const time_t *t) {
   errno = EPERM;
   return -1;
 }
 
-int clock_getcpuclockid(pid_t pid, clockid_t *clockid) {
+weak int clock_getcpuclockid(pid_t pid, clockid_t *clockid) {
   if (pid < 0) {
     return ESRCH;
   }
@@ -81,20 +85,20 @@ struct passwd *getpwuid(uid_t uid) {
   return 0;
 }
 
-int getpwnam_r(const char *name, struct passwd *pwd,
+weak int getpwnam_r(const char *name, struct passwd *pwd,
                char *buf, size_t buflen, struct passwd **result) {
   return ENOENT;
 }
 
-int getpwuid_r(uid_t uid, struct passwd *pwd,
+weak int getpwuid_r(uid_t uid, struct passwd *pwd,
                       char *buf, size_t buflen, struct passwd **result) {
   return ENOENT;
 }
 
-void setpwent(void) {
+weak void setpwent(void) {
 }
 
-void endpwent(void) {
+weak void endpwent(void) {
 }
 
 struct passwd *getpwent(void) {
@@ -104,55 +108,55 @@ struct passwd *getpwent(void) {
 
 // grp.h
 
-struct group *getgrnam(const char *name) {
+weak struct group *getgrnam(const char *name) {
   errno = ENOENT;
   return 0;
 }
 
-struct group *getgrgid(gid_t gid) {
+weak struct group *getgrgid(gid_t gid) {
   errno = ENOENT;
   return 0;
 }
 
-int getgrnam_r(const char *name, struct group *grp,
+weak int getgrnam_r(const char *name, struct group *grp,
                char *buf, size_t buflen, struct group **result) {
   return ENOENT;
 }
 
-int getgrgid_r(gid_t gid, struct group *grp,
+weak int getgrgid_r(gid_t gid, struct group *grp,
                char *buf, size_t buflen, struct group **result) {
   return ENOENT;
 }
 
-struct group *getgrent(void) {
+weak struct group *getgrent(void) {
   errno = EIO;
   return NULL;
 }
 
-void endgrent(void) {
+weak void endgrent(void) {
 }
 
-void setgrent(void) {
+weak void setgrent(void) {
 }
 
 // ==========================================================================
 // sys/file.h
 // ==========================================================================
 
-int flock(int fd, int operation) {
+weak int flock(int fd, int operation) {
   // int flock(int fd, int operation);
   // Pretend to succeed
   return 0;
 }
 
-int chroot(const char *path) {
+weak int chroot(const char *path) {
   // int chroot(const char *path);
   // http://pubs.opengroup.org/onlinepubs/7908799/xsh/chroot.html
   errno = EACCES;
   return -1;
 }
 
-int execve(const char *pathname, char *const argv[],
+weak int execve(const char *pathname, char *const argv[],
            char *const envp[]) {
   // int execve(const char *pathname, char *const argv[],
   //            char *const envp[]);
@@ -162,7 +166,7 @@ int execve(const char *pathname, char *const argv[],
   return -1;
 }
 
-pid_t fork(void) {
+weak pid_t fork(void) {
   // pid_t fork(void);
   // http://pubs.opengroup.org/onlinepubs/000095399/functions/fork.html
   // We don't support multiple processes.
@@ -170,12 +174,12 @@ pid_t fork(void) {
   return -1;
 }
 
-pid_t vfork(void) {
+weak pid_t vfork(void) {
   errno = ENOSYS;
   return -1;
 }
 
-int posix_spawn(pid_t *pid, const char *path,
+weak int posix_spawn(pid_t *pid, const char *path,
                        const posix_spawn_file_actions_t *file_actions,
                        const posix_spawnattr_t *attrp,
                        char *const argv[], char *const envp[]) {
@@ -183,17 +187,17 @@ int posix_spawn(pid_t *pid, const char *path,
   return -1;
 }
 
-FILE *popen(const char *command, const char *type) {
+weak FILE *popen(const char *command, const char *type) {
   errno = ENOSYS;
   return NULL;
 }
 
-int pclose(FILE *stream) {
+weak int pclose(FILE *stream) {
   errno = ENOSYS;
   return -1;
 }
 
-int setgroups(size_t size, const gid_t *list) {
+weak int setgroups(size_t size, const gid_t *list) {
   // int setgroups(int ngroups, const gid_t *gidset);
   // https://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man2/setgroups.2.html
   if (size < 1 || size > sysconf(_SC_NGROUPS_MAX)) {
@@ -205,7 +209,7 @@ int setgroups(size_t size, const gid_t *list) {
   return -1;
 }
 
-int sigaltstack(const stack_t *restrict ss, stack_t *restrict old_ss) {
+weak int sigaltstack(const stack_t *restrict ss, stack_t *restrict old_ss) {
   errno = ENOSYS;
   return -1;
 }

--- a/system/lib/libc/emscripten_syscall_stubs.c
+++ b/system/lib/libc/emscripten_syscall_stubs.c
@@ -46,7 +46,11 @@ static mode_t g_umask = S_IRWXU | S_IRWXG | S_IRWXO;
 #define STRINGIFY(s) #s
 #define STR(s) STRINGIFY(s)
 
-int __syscall_uname(intptr_t buf) {
+#ifndef weak
+#define weak __attribute__((__weak__))
+#endif
+
+weak int __syscall_uname(intptr_t buf) {
   if (!buf) {
     return -EFAULT;
   }
@@ -68,7 +72,7 @@ int __syscall_uname(intptr_t buf) {
   return 0;
 }
 
-int __syscall_setpgid(int pid, int pgid) {
+weak int __syscall_setpgid(int pid, int pgid) {
   if (pid && pid != g_pid) {
     return -ESRCH;
   }
@@ -78,37 +82,37 @@ int __syscall_setpgid(int pid, int pgid) {
   return 0;
 }
 
-int __syscall_sync() {
+weak int __syscall_sync() {
   return 0;
 }
 
-int __syscall_getsid(int pid) {
+weak int __syscall_getsid(int pid) {
   if (pid && pid != g_pid) {
     return -ESRCH;
   }
   return g_sid;
 }
 
-int __syscall_getpgid(int pid) {
+weak int __syscall_getpgid(int pid) {
   if (pid && pid != g_pid) {
     return -ESRCH;
   }
   return g_pgid;
 }
 
-int __syscall_getpid() {
+weak int __syscall_getpid() {
   return g_pid;
 }
 
-int __syscall_getppid() {
+weak int __syscall_getppid() {
   return g_ppid;
 }
 
-int __syscall_link(intptr_t oldpath, intptr_t newpath) {
+weak int __syscall_link(intptr_t oldpath, intptr_t newpath) {
   return -EMLINK; // no hardlinks for us
 }
 
-int __syscall_getgroups32(int size, intptr_t list) {
+weak int __syscall_getgroups32(int size, intptr_t list) {
   if (size < 1) {
     return -EINVAL;
   }
@@ -116,21 +120,21 @@ int __syscall_getgroups32(int size, intptr_t list) {
   return 1;
 }
 
-int __syscall_setsid() {
+weak int __syscall_setsid() {
   return 0; // no-op
 }
 
-int __syscall_umask(int mask) {
+weak int __syscall_umask(int mask) {
   int old = g_umask;
   g_umask = mask;
   return old;
 }
 
-int __syscall_setrlimit(int resource, intptr_t limit) {
+weak int __syscall_setrlimit(int resource, intptr_t limit) {
   return 0; // no-op
 }
 
-int __syscall_getrusage(int who, intptr_t usage) {
+weak int __syscall_getrusage(int who, intptr_t usage) {
   REPORT(getrusage);
   struct rusage *u = (struct rusage *)usage;
   memset(u, 0, sizeof(*u));
@@ -141,42 +145,42 @@ int __syscall_getrusage(int who, intptr_t usage) {
   return 0;
 }
 
-int __syscall_getpriority(int which, int who) {
+weak int __syscall_getpriority(int which, int who) {
   return 0;
 }
 
-int __syscall_setpriority(int which, int who, int prio) {
+weak int __syscall_setpriority(int which, int who, int prio) {
   return -EPERM;
 }
 
-int __syscall_setdomainname(intptr_t name, size_t size) {
+weak int __syscall_setdomainname(intptr_t name, size_t size) {
   return -EPERM;
 }
 
-int __syscall_getuid32(void) {
+weak int __syscall_getuid32(void) {
   return 0;
 }
 
-int __syscall_getgid32(void) {
+weak int __syscall_getgid32(void) {
   return 0;
 }
 
-int __syscall_geteuid32(void) {
+weak int __syscall_geteuid32(void) {
   return 0;
 }
 
-int __syscall_getegid32(void) {
+weak int __syscall_getegid32(void) {
   return 0;
 }
 
-int __syscall_getresuid32(intptr_t ruid, intptr_t euid, intptr_t suid) {
+weak int __syscall_getresuid32(intptr_t ruid, intptr_t euid, intptr_t suid) {
   *((uid_t *)ruid) = 0;
   *((uid_t *)euid) = 0;
   *((uid_t *)suid) = 0;
   return 0;
 }
 
-int __syscall_getresgid32(intptr_t ruid, intptr_t euid, intptr_t suid) {
+weak int __syscall_getresgid32(intptr_t ruid, intptr_t euid, intptr_t suid) {
   REPORT(getresgid32);
   *((uid_t *)ruid) = 0;
   *((uid_t *)euid) = 0;
@@ -184,48 +188,48 @@ int __syscall_getresgid32(intptr_t ruid, intptr_t euid, intptr_t suid) {
   return 0;
 }
 
-int __syscall_pause() {
+weak int __syscall_pause() {
   REPORT(pause);
   return -EINTR; // we can't pause
 }
 
-int __syscall_madvise(intptr_t addr, size_t length, int advice) {
+weak int __syscall_madvise(intptr_t addr, size_t length, int advice) {
   REPORT(madvise);
   // advice is welcome, but ignored
   return 0;
 }
 
-int __syscall_mlock(intptr_t addr, size_t len) {
+weak int __syscall_mlock(intptr_t addr, size_t len) {
   REPORT(mlock);
   return 0;
 }
 
-int __syscall_munlock(intptr_t addr, size_t len) {
+weak int __syscall_munlock(intptr_t addr, size_t len) {
   REPORT(munlock);
   return 0;
 }
 
-int __syscall_mprotect(size_t addr, size_t len, int prot) {
+weak int __syscall_mprotect(size_t addr, size_t len, int prot) {
   REPORT(mprotect);
   return 0; // let's not and say we did
 }
 
-int __syscall_mremap(intptr_t old_addr, size_t old_size, size_t new_size, int flags, intptr_t new_addr) {
+weak int __syscall_mremap(intptr_t old_addr, size_t old_size, size_t new_size, int flags, intptr_t new_addr) {
   REPORT(mremap);
   return -ENOMEM; // never succeed
 }
 
-int __syscall_mlockall(int flags) {
+weak int __syscall_mlockall(int flags) {
   REPORT(mlockall);
   return 0;
 }
 
-int __syscall_munlockall() {
+weak int __syscall_munlockall() {
   REPORT(munlockall);
   return 0;
 }
 
-int __syscall_prlimit64(int pid, int resource, intptr_t new_limit, intptr_t old_limit) {
+weak int __syscall_prlimit64(int pid, int resource, intptr_t new_limit, intptr_t old_limit) {
   REPORT(prlimit64);
   struct rlimit *old = (struct rlimit *)old_limit;
   if (old) { // just report no limits
@@ -235,7 +239,7 @@ int __syscall_prlimit64(int pid, int resource, intptr_t new_limit, intptr_t old_
   return 0;
 }
 
-int __syscall_ugetrlimit(int resource, intptr_t rlim) {
+weak int __syscall_ugetrlimit(int resource, intptr_t rlim) {
   REPORT(ugetrlimit);
   struct rlimit * limits = (struct rlimit *)rlim;
   limits->rlim_cur = RLIM_INFINITY;
@@ -243,7 +247,7 @@ int __syscall_ugetrlimit(int resource, intptr_t rlim) {
   return 0; // just report no limits
 }
 
-int __syscall_setsockopt(int sockfd, int level, int optname, intptr_t optval, size_t optlen, int dummy) {
+weak int __syscall_setsockopt(int sockfd, int level, int optname, intptr_t optval, size_t optlen, int dummy) {
   REPORT(setsockopt);
   return -ENOPROTOOPT; // The option is unknown at the level indicated.
 }

--- a/test/other/test_override_stub.c
+++ b/test/other/test_override_stub.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <emscripten.h>
+
+pid_t fork() {
+  printf("override called\n");
+  return 1;
+}
+
+int main() {
+  printf("%d\n", fork()); // re-implemented call
+  chroot(NULL); // stubbed call
+  return 0;
+}

--- a/test/other/test_override_stub.out
+++ b/test/other/test_override_stub.out
@@ -1,0 +1,2 @@
+override called
+1

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3568,6 +3568,23 @@ EMSCRIPTEN_KEEPALIVE int myreadSeekEnd() {
     err = self.expect_fail([EMCC, 'duplicated_func.c'] + self.get_emcc_args())
     self.assertContained('error: Symbol re-definition in JavaScript library: duplicatedFunc. Do not use noOverride if this is intended', err)
 
+
+  def test_override_stub(self):
+    create_file('override_fork.c', '''
+      int fork() {
+        return 0;
+      }
+
+      int main() {
+        fork();
+        return 0;
+      }
+    ''')
+
+    proc = self.run_process([EMCC, 'override_fork.c', '-sALLOW_UNIMPLEMENTED_SYSCALLS=1'], stderr=PIPE)
+    self.assertEqual(proc.returncode, 0, 'subprocess failed. stderr:\n' + proc.stderr)
+
+
   def test_js_lib_missing_sig(self):
     create_file('some_func.c', '''
       #include <stdio.h>

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3568,22 +3568,8 @@ EMSCRIPTEN_KEEPALIVE int myreadSeekEnd() {
     err = self.expect_fail([EMCC, 'duplicated_func.c'] + self.get_emcc_args())
     self.assertContained('error: Symbol re-definition in JavaScript library: duplicatedFunc. Do not use noOverride if this is intended', err)
 
-
   def test_override_stub(self):
-    create_file('override_fork.c', '''
-      int fork() {
-        return 0;
-      }
-
-      int main() {
-        fork();
-        return 0;
-      }
-    ''')
-
-    proc = self.run_process([EMCC, 'override_fork.c', '-sALLOW_UNIMPLEMENTED_SYSCALLS=1'], stderr=PIPE)
-    self.assertEqual(proc.returncode, 0, 'subprocess failed. stderr:\n' + proc.stderr)
-
+    self.do_run_from_file(test_file('other/test_override_stub.c'), test_file('other/test_override_stub.out'))
 
   def test_js_lib_missing_sig(self):
     create_file('some_func.c', '''


### PR DESCRIPTION
Right now `fork` and other stubbed methods do not work at all.

The program, which is being emscripted, and is calling these methods, may behave weirdly, if they return error or just do nothing. 

I guess, in most cases a program that calls `fork`, and it fails, dies abnormally.

With `weak`, a user may supply their own version of these stubs, such as their own `fork`, that:
- either emulates the environment in an acceptable way, so that the program may still work,
- or just shows a nice message to the user, explaining that the functionality isn't working in browser environment, and dies nicely.



