### PR TITLE
Get node mver without regex

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -255,7 +255,7 @@ if (ENVIRONMENT_IS_NODE) {
   // not be needed with node v15 and about because it is now the default
   // behaviour:
   // See https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
-  var nodeMajor = Number(process.versions.node.split(".")[0]);
+  var nodeMajor = process.versions.node.split(".")[0];
   if (nodeMajor < 15) {
     process['on']('unhandledRejection', function(reason) { throw reason; });
   }

--- a/src/shell.js
+++ b/src/shell.js
@@ -255,7 +255,7 @@ if (ENVIRONMENT_IS_NODE) {
   // not be needed with node v15 and about because it is now the default
   // behaviour:
   // See https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
-  var nodeMajor = process.version.match(/^v(\d+)\./)[1];
+  var nodeMajor = Number(process.versions.node.split(".")[0]);
   if (nodeMajor < 15) {
     process['on']('unhandledRejection', function(reason) { throw reason; });
   }


### PR DESCRIPTION
A quick PR to remove unnecessary regex (and also avoid a comparison between a string and a number) as noted in https://github.com/emscripten-core/emscripten/issues/18723#issuecomment-1428800368