### PR TITLE
Do not catch unhandled rejections or exits under node when MODULARIZE is set

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2203,7 +2203,7 @@ def phase_linker_setup(options, state, newargs):
       exit_with_error('targeting node older than 10.19.00 is not supported')
     if settings.MIN_NODE_VERSION >= 150000:
       default_setting('NODEJS_CATCH_REJECTION', 0)
-  
+
   # Do not catch rejections or exits in modularize mode, as these options
   # are for use when running emscripten modules standalone
   # see https://github.com/emscripten-core/emscripten/issues/18723#issuecomment-1429236996

--- a/emcc.py
+++ b/emcc.py
@@ -2203,6 +2203,15 @@ def phase_linker_setup(options, state, newargs):
       exit_with_error('targeting node older than 10.19.00 is not supported')
     if settings.MIN_NODE_VERSION >= 150000:
       default_setting('NODEJS_CATCH_REJECTION', 0)
+  
+  # Do not catch rejections or exits in modularize mode, as these options
+  # are for use when running emscripten modules standalone
+  # see https://github.com/emscripten-core/emscripten/issues/18723#issuecomment-1429236996
+  if settings.MODULARIZE:
+    default_setting('NODEJS_CATCH_REJECTION', 0)
+    default_setting('NODEJS_CATCH_EXIT', 0)
+    if settings.NODEJS_CATCH_REJECTION or settings.NODEJS_CATCH_EXIT:
+      exit_with_error('Cannot use -sNODEJS_CATCH_REJECTION or -sNODEJS_CATCH_EXIT with -sMODULARIZE')
 
   setup_environment_settings()
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -934,6 +934,18 @@ f.close()
       self.expect_fail([compiler, test_file('hello_world.c'), 'this_file_is_missing.c', '-o', 'out.js'])
       self.assertFalse(os.path.exists('out.js'))
 
+  def test_failure_modularize_and_catch_rejection(self):
+    for compiler in [EMCC, EMXX]:
+      # Test that if sMODULARIZE and sNODEJS_CATCH_REJECTION are both enabled, then emcc shouldn't succeed, and shouldn't produce an output file.
+      self.expect_fail([compiler, test_file('hello_world.c'), '-sMODULARIZE', '-sNODEJS_CATCH_REJECTION', '-o', 'out.js'])
+      self.assertFalse(os.path.exists('out.js'))
+
+  def test_failure_modularize_and_catch_exit(self):
+    for compiler in [EMCC, EMXX]:
+      # Test that if sMODULARIZE and sNODEJS_CATCH_EXIT are both enabled, then emcc shouldn't succeed, and shouldn't produce an output file.
+      self.expect_fail([compiler, test_file('hello_world.c'), '-sMODULARIZE', '-sNODEJS_CATCH_EXIT', '-o', 'out.js'])
+      self.assertFalse(os.path.exists('out.js'))
+
   def test_use_cxx(self):
     create_file('empty_file', ' ')
     dash_xc = self.run_process([EMCC, '-v', '-xc', 'empty_file'], stderr=PIPE).stderr

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10539,6 +10539,28 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
     # the instance you must use .then() to get a callback with the instance.
     create_file('test.js', r'''
       try {
+        Module._main;
+      } catch(e) {
+        console.log(e);
+      }
+      try {
+      } catch(e) {
+        console.log(e);
+      }
+    ''')
+    self.run_process([EMCC, test_file('hello_world.c'), '-sASSERTIONS', '--extern-post-js', 'test.js'])
+    # A return code of 7 is from the unhandled Promise rejection
+    out = self.run_js('a.out.js', assert_returncode=0)
+    self.assertContained('hello, world!', out)
+
+  def test_assertions_on_ready_promise_modularized(self):
+    # check that when assertions are on we give useful error messages for
+    # mistakenly thinking the Promise is an instance. I.e., once you could do
+    # Module()._main to get an instance and the main function, but after
+    # the breaking change in #10697 Module() now returns a promise, and to get
+    # the instance you must use .then() to get a callback with the instance.
+    create_file('test.js', r'''
+      try {
         Module()._main;
       } catch(e) {
         console.log(e);
@@ -10551,9 +10573,22 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
     ''')
     self.run_process([EMCC, test_file('hello_world.c'), '-sMODULARIZE', '-sASSERTIONS', '--extern-post-js', 'test.js'])
     # A return code of 7 is from the unhandled Promise rejection
-    out = self.run_js('a.out.js', assert_returncode=7)
+    out = self.run_js('a.out.js', assert_returncode=1)
     self.assertContained('You are getting _main on the Promise object, instead of the instance. Use .then() to get called back with the instance, see the MODULARIZE docs in src/settings.js', out)
     self.assertContained('You are setting onRuntimeInitialized on the Promise object, instead of the instance. Use .then() to get called back with the instance, see the MODULARIZE docs in src/settings.js', out)
+
+  def test_assertions_on_reject_promise(self):
+    # check that when assertions are on we give useful error messages for
+    # mistakenly thinking the Promise is an instance. I.e., once you could do
+    # Module()._main to get an instance and the main function, but after
+    # the breaking change in #10697 Module() now returns a promise, and to get
+    # the instance you must use .then() to get a callback with the instance.
+    create_file('test.js', r'''
+      Promise.reject();
+    ''')
+    self.run_process([EMCC, test_file('hello_world.c'), '-sMODULARIZE', '-sASSERTIONS', '--extern-post-js', 'test.js'])
+    out = self.run_js('a.out.js', assert_returncode=1)
+    self.assertContained('UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "undefined".', out)
 
   def test_em_asm_duplicate_strings(self):
     # We had a regression where tow different EM_ASM strings from two diffferent

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10543,7 +10543,7 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
 '''
     self.do_runf('src.cpp', expected, emcc_args=['-sASSERTIONS'])
 
-  def test_modularized_assertions_on_ready_promise(self):
+  def test_modularize_assertions_on_ready_promise(self):
     # check that when assertions are on we give useful error messages for
     # mistakenly thinking the Promise is an instance. I.e., once you could do
     # Module()._main to get an instance and the main function, but after


### PR DESCRIPTION
Per https://github.com/emscripten-core/emscripten/issues/18723#issuecomment-1429236996.

In `-sMODULARIZE` mode unhandled promise rejections now result in an exit code of 1 which represents "Uncaught Fatal Exception" rather than 7 which represents "Internal Exception Handler Run-Time Failure" caused by an exception being thrown by the `uncaughtException` handler.

See https://github.com/arzzen/all-exit-error-codes/blob/master/programming-languages/javascript/nodejs.md for the table of nodejs exit codes.