### PR TITLE
add support to bind to port 0 in emrun

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -530,6 +530,7 @@ class HTTPWebServer(socketserver.ThreadingMixIn, HTTPServer):
     global last_message_time, page_exit_code, emrun_not_enabled_nag_printed
     self.is_running = True
     self.timeout = timeout
+    logi('Now listening at http://%s/' % ':'.join(map(str,self.socket.getsockname())))
     logv("Entering web server loop.")
     while self.is_running:
       now = tick()
@@ -1653,6 +1654,9 @@ def run():
       logv('Web server root directory: ' + os.path.abspath('.'))
     else:
       logi('Web server root directory: ' + os.path.abspath('.'))
+    logv('Starting web server: http://%s:%i/' % (options.hostname, options.port))
+    httpd = HTTPWebServer((options.hostname, options.port), HTTPHandler)
+    options.port = httpd.socket.getsockname()[1]
 
   if options.android:
     if options.run_browser or options.browser_info:
@@ -1792,11 +1796,6 @@ def run():
       browser_stderr_handle = browser_stdout_handle
     else:
       browser_stderr_handle = open(options.log_stderr, 'a')
-
-  if options.run_server:
-    logv('Starting web server: http://%s:%i/' % (options.hostname, options.port))
-    httpd = HTTPWebServer((options.hostname, options.port), HTTPHandler)
-
   if options.run_browser:
     logv("Starting browser: %s" % ' '.join(browser))
     # if browser[0] == 'cmd':
@@ -1817,8 +1816,6 @@ def run():
     # represent a browser and no point killing it.
     if options.android:
       browser_process = None
-  elif options.run_server:
-    logi('Now listening at http://%s:%i/' % (options.hostname, options.port))
 
   if browser_process:
     premature_quit_code = browser_process.poll()

--- a/emrun.py
+++ b/emrun.py
@@ -1656,6 +1656,7 @@ def run():
       logi('Web server root directory: ' + os.path.abspath('.'))
     logv('Starting web server: http://%s:%i/' % (options.hostname, options.port))
     httpd = HTTPWebServer((options.hostname, options.port), HTTPHandler)
+    # to support binding to port zero we must allow the server to open to socket then retrieve the final port number
     options.port = httpd.socket.getsockname()[1]
 
   if options.android:

--- a/emrun.py
+++ b/emrun.py
@@ -530,7 +530,7 @@ class HTTPWebServer(socketserver.ThreadingMixIn, HTTPServer):
     global last_message_time, page_exit_code, emrun_not_enabled_nag_printed
     self.is_running = True
     self.timeout = timeout
-    logi('Now listening at http://%s/' % ':'.join(map(str,self.socket.getsockname())))
+    logi('Now listening at http://%s/' % ':'.join(map(str, self.socket.getsockname())))
     logv("Entering web server loop.")
     while self.is_running:
       now = tick()


### PR DESCRIPTION
Allowing port 0 binding will find an available port automatically. 

This is useful in situations where you want run emrun multiple times with something like GNU parallel 

Example output
```bash
# ./emrun --verbose --no_browser a
Web server root directory: /root/arsnyder16-emscripten
Starting web server: http://0.0.0.0:6931/
Now listening at http://0.0.0.0:6931/
Entering web server loop.
^CClosed web server.
emrun quitting with process exit code None
# ./emrun --verbose --no_browser --port 0 a
Web server root directory: /root/arsnyder16-emscripten
Starting web server: http://0.0.0.0:0/
Now listening at http://0.0.0.0:41261/
Entering web server loop.
^CClosed web server.
emrun quitting with process exit code None
```