### PR TITLE
[Proxying] Update proxying with callback to support cancellation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -48,6 +48,9 @@ See docs/process.md for more on how version tagging works.
 - Synchronous proxying functions in emscripten/proxying.h now return errors
   instead of hanging forever when the worker thread dies before the proxied work
   is finished.
+- The `emscripten_proxy_async_with_callback` API was replaced with a simpler
+  `emscripten_proxy_callback` API that takes a second callback to be called if
+  the worker thread dies before completing the proxied work.
 
 3.1.31 - 01/26/23
 -----------------

--- a/site/source/docs/api_reference/proxying.h.rst
+++ b/site/source/docs/api_reference/proxying.h.rst
@@ -78,15 +78,6 @@ Functions
   thread then return immediately without waiting for ``func`` to be executed.
   Returns 1 if the work was successfully enqueued or 0 otherwise.
 
-.. c:function:: int emscripten_proxy_async_with_callback(em_proxying_queue* q, pthread_t target_thread, void* (*func)(void*), void* arg, void (*callback)(void* arg, void* result), void* callback_arg)
-
-  Enqueue `func` on the given queue and thread. Once (and if) it finishes
-  executing, it will asynchronously proxy `callback` back to the current thread
-  on the same queue. The result of the proxied function will be passed as the
-  second argument to the callback. Returns 1 if the initial work was
-  successfully enqueued and the target thread notified or 0 otherwise. If the
-  callback cannot be scheduled (for example due to OOM), the program is aborted.
-
 .. c:function:: int emscripten_proxy_sync(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void* arg)
 
   Enqueue ``func`` to be called with argument ``arg`` on the given queue and
@@ -102,6 +93,15 @@ Functions
   marked finished with ``emscripten_proxying_finish``. ``func`` need not call
   ``emscripten_proxying_finish`` itself; it could instead store the context
   pointer and call ``emscripten_proxying_finish`` at an arbitrary later time.
+
+.. c:function:: int emscripten_proxy_callback(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void (*callback)(void*), void (*cancel)(void*), void* arg)
+
+  Enqueue ``func`` on the given queue and thread. Once (and if) it finishes
+  executing, it will asynchronously proxy ``callback`` back to the current
+  thread on the same queue, or if the target thread dies before the work can be
+  completed, ``cancel`` will be proxied back instead. All three function will
+  receive the same argument, ``arg``. Returns 1 if ``func`` was successfully
+  enqueued and the target thread notified or 0 otherwise.
 
 C++ API
 -------
@@ -134,11 +134,11 @@ defined within namespace ``emscripten``.
     Calls ``emscripten_proxy_async`` to execute ``func``, returning ``true`` if the
     function was successfully enqueued and ``false`` otherwise.
 
-  .. cpp:member:: bool proxyAsyncWithCallback(pthread_t target, std::function<void()>&& func, std::function<void()>&& callback)
+  .. cpp:member:: bool proxyCallback(pthread_t target, std::function<void()>&& func, std::function<void()>&& callback, std::function<void()>&& cancel)
 
-    Calls ``emscripten_proxy_async_with_callback`` to execute ``func`` and
-    schedule ``callback``, returning ``true`` if the function was successfully
-    enqueued and ``false`` otherwise.
+    Calls ``emscripten_proxy_callback`` to execute ``func`` and schedule either
+    ``callback`` or ``cancel``, returning ``true`` if the function was
+    successfully enqueued and ``false`` otherwise.
 
   .. cpp:member:: bool proxySync(const pthread_t target, const std::function<void()>& func)
 

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1085,6 +1085,13 @@ var LibraryPThread = {
 #if PTHREADS_DEBUG
     dbg('invokeEntryPoint: ' + ptrToString(ptr));
 #endif
+#if EXIT_RUNTIME
+    // An old thread on this worker may have been canceled without returning the
+    // `runtimeKeepaliveCounter` to zero. Reset it now so the new thread won't
+    // be affected.
+    runtimeKeepaliveCounter = 0;
+#endif
+
 #if MAIN_MODULE
     // Before we call the thread entry point, make sure any shared libraries
     // have been loaded on this there.  Otherwise our table migth be not be

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1085,7 +1085,7 @@ var LibraryPThread = {
 #if PTHREADS_DEBUG
     dbg('invokeEntryPoint: ' + ptrToString(ptr));
 #endif
-#if EXIT_RUNTIME
+#if EXIT_RUNTIME && !MINIMAL_RUNTIME
     // An old thread on this worker may have been canceled without returning the
     // `runtimeKeepaliveCounter` to zero. Reset it now so the new thread won't
     // be affected.

--- a/test/pthread/test_pthread_proxying.out
+++ b/test/pthread/test_pthread_proxying.out
@@ -8,7 +8,7 @@ running widget 5 on returner
 Testing sync_with_ctx proxying
 running widget 6 on looper
 running widget 7 on returner
-Testing async_with_callback proxying
+Testing callback proxying
 running widget 8 on main
 running widget 9 on looper
 running widget 10 on returner

--- a/test/pthread/test_pthread_proxying_canceled_work.out
+++ b/test/pthread/test_pthread_proxying_canceled_work.out
@@ -2,6 +2,8 @@ testing cancel followed by proxy
 testing exit followed by proxy
 testing proxy followed by cancel
 testing proxy followed by exit
+testing callback proxy followed by cancel
+testing callback proxy followed by exit
 testing cancellation of in-progress work
 checking pattern 0
 finishing task 0

--- a/test/pthread/test_pthread_proxying_cpp.out
+++ b/test/pthread/test_pthread_proxying_cpp.out
@@ -1,5 +1,5 @@
 Testing async proxying
 Testing sync proxying
 Testing sync_with_ctx proxying
-Testing async_with_callback proxying
+Testing callback proxying
 done

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9430,7 +9430,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @needs_dylink
   @node_pthreads
-  @no_asan("Transient memory leaks to be solved by #18776")
   def test_pthread_dlopen_many(self):
     nthreads = 10
     self.set_setting('USE_PTHREADS')


### PR DESCRIPTION
Completely overhaul the interface for proxying with callbacks:

 - Rename `emscripten_proxy_async_with_callback` to the simpler `emscripten_proxy_callback`.

 - Add an optional `cancel` callback argument that will be scheduled on the proxying thread if the worker thread dies before the work is started. A future PR will change this so that the `cancel` callback will be called if a worker thread dies before the work is finished to be more consistent with the `proxy_sync` APIs.

 - Remove the ability to receive the result of the proxied function as an argument to the callback function since the extra expressiveness was not general enough to warrant the added complexity.

 - Use only a single context argument rather than a separate context for the proxied function and the callback. This is just as expressive, but it is simpler avoids the question of what context object should be passed to the cancellation callback.

Also update the only user of the callback API, dynlink.c, to use the new API. A future PR will implement a promise-based proxying API and update dynlink.c to use that instead, so this PR just tries to make the minimal necessary changes to dynlink.c.