### PR TITLE
Use keepalive push/pop in PROXY_TO_PTHREAD mode

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2358,6 +2358,7 @@ def phase_linker_setup(options, state, newargs):
     settings.JS_LIBRARIES.append((0, 'library_pthread.js'))
     if settings.PROXY_TO_PTHREAD:
       settings.PTHREAD_POOL_SIZE_STRICT = 0
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$runtimeKeepalivePush']
   else:
     if settings.PROXY_TO_PTHREAD:
       exit_with_error('-sPROXY_TO_PTHREAD requires -sUSE_PTHREADS to work!')

--- a/src/library.js
+++ b/src/library.js
@@ -3581,11 +3581,6 @@ mergeInto(LibraryManager.library, {
 #endif
   ],
   $maybeExit: function() {
-#if PROXY_TO_PTHREAD
-    // In PROXY_TO_PTHREAD mode the main thread never implicitly exits, but
-    // waits for the proxied main function to exit.
-    if (!ENVIRONMENT_IS_PTHREAD) return;
-#endif
 #if RUNTIME_DEBUG
     dbg('maybeExit: user callback done: runtimeKeepaliveCounter=' + runtimeKeepaliveCounter);
 #endif

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -939,6 +939,9 @@ var LibraryPThread = {
 #if PTHREADS_DEBUG
     dbg('exitOnMainThread');
 #endif
+#if PROXY_TO_PTHREAD
+    {{{ runtimeKeepalivePop() }}};
+#endif
 #if MINIMAL_RUNTIME
     _exit(returnCode);
 #else

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -33,6 +33,12 @@ function callMain() {
 
   var entryFunction = {{{ getEntryFunction() }}};
 
+#if PROXY_TO_PTHREAD
+  // With PROXY_TO_PTHREAD make sure we keep the runtime alive until the
+  // proxied main calls exit (see exitOnMainThread() for where Pop is called).
+  {{{ runtimeKeepalivePush() }}}
+#endif
+
 #if MAIN_MODULE
   // Main modules can't tell if they have main() at compile time, since it may
   // arrive from a dynamic library.
@@ -56,9 +62,7 @@ function callMain() {
   var argv = 0;
 #endif // MAIN_READS_PARAMS
 
-#if ABORT_ON_WASM_EXCEPTIONS || !PROXY_TO_PTHREAD
   try {
-#endif
 #if BENCHMARK
     var start = Date.now();
 #endif
@@ -81,16 +85,6 @@ function callMain() {
     Module.realPrint('main() took ' + (Date.now() - start) + ' milliseconds');
 #endif
 
-    // In PROXY_TO_PTHREAD builds, we should never exit the runtime below, as
-    // execution is asynchronously handed off to a pthread.
-#if PROXY_TO_PTHREAD
-#if ASSERTIONS
-    assert(ret == 0, '_emscripten_proxy_main failed to start proxy thread: ' + ret);
-#endif
-#if ABORT_ON_WASM_EXCEPTIONS
-  }
-#endif
-#else
 #if ASYNCIFY == 2
     // The current spec of JSPI returns a promise only if the function suspends
     // and a plain value otherwise. This will likely change:
@@ -109,7 +103,6 @@ function callMain() {
   catch (e) {
     return handleException(e);
   }
-#endif // !PROXY_TO_PTHREAD
 #if ABORT_ON_WASM_EXCEPTIONS
   finally {
     // See abortWrapperDepth in preamble.js!


### PR DESCRIPTION
This replaces the adhoc mechanism we were using in to prevent the runtime from exiting in maybeExit.

This is less hacky and allows us to remove the complex mod to the `callMain` function.