### PR TITLE
Fix flakiness in test_abort_on_exceptions_pthreads

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -575,6 +575,7 @@ function makeAbortWrapper(original) {
         || e === Infinity // EXCEPTION_STACK_TRACES=0 will throw Infinity
 #endif // EXCEPTION_STACK_TRACES
 #endif
+        || e === 'unwind'
       ) {
         throw e;
       }


### PR DESCRIPTION
This fixes the `program has already aborted!` flake we have been seeing in test_abort_on_exceptions_pthreads.

e.g.: https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket/8788935992040264721/+/u/Emscripten_testsuite__SAFE_HEAP_/stdout

```
worker sent an error! undefined:undefined: Unhandled error. ('program has already aborted!')

/b/s/w/ir/x/t/emtest_ulqr0wsn/emscripten_test_core2s_iev5knwg/test_hello_world.js:1
...
Error [ERR_UNHANDLED_ERROR]: Unhandled error. ('program has already aborted!')
    at new NodeError (internal/errors.js:322:7)
    at process.emit (events.js:389:17)
    at emitUnhandledRejectionOrErr (internal/event_target.js:579:11)
    at MessagePort.[nodejs.internal.kHybridDispatch] (internal/event_target.js:403:9)
    at MessagePort.exports.emitMessage (internal/per_context/messageport.js:18:26)
Emitted 'error' event on process instance at:
    at emitUnhandledRejectionOrErr (internal/event_target.js:579:11)
    at MessagePort.[nodejs.internal.kHybridDispatch] (internal/event_target.js:403:9)
    at MessagePort.exports.emitMessage (internal/per_context/messageport.js:18:26) {
  code: 'ERR_UNHANDLED_ERROR',
  context: 'program has already aborted!'
}
```