### PR TITLE
Add EXPORT_KEEPALIVE to export symbols even in MINIMAL_RUNTIME

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,10 @@ See docs/process.md for more on how version tagging works.
 - Update glfw header to 3.3.8 (#18826)
 - The `LLD_REPORT_UNDEFINED` setting has been removed.  It's now essentially
   always enabled. (#18342)
+- Added `-sEXPORT_KEEPALIVE` to export symbols. When using
+  `MINIMAL_RUNTIME`, the option will be **disabled** by default.
+  This option simply exports the symbols on the module object, i.e.,
+  `Module['X'] = X;`
 
 3.1.32 - 02/17/23
 -----------------

--- a/emcc.py
+++ b/emcc.py
@@ -1959,6 +1959,8 @@ def phase_linker_setup(options, state, newargs):
     default_setting('SUPPORT_ERRNO', 0)
     # Require explicit -lfoo.js flags to link with JS libraries.
     default_setting('AUTO_JS_LIBRARIES', 0)
+    # When using MINIMAL_RUNTIME, symbols should only be exported if requested.
+    default_setting('EXPORT_KEEPALIVE', 0)
 
   if settings.STRICT_JS and (settings.MODULARIZE or settings.EXPORT_ES6):
     exit_with_error("STRICT_JS doesn't work with MODULARIZE or EXPORT_ES6")

--- a/emscripten.py
+++ b/emscripten.py
@@ -740,7 +740,7 @@ def make_export_wrappers(exports, delay_assignment):
     wrapper = '/** @type {function(...*):?} */\nvar %s = ' % mangled
 
     # TODO(sbc): Can we avoid exporting the dynCall_ functions on the module.
-    if mangled in settings.EXPORTED_FUNCTIONS or name.startswith('dynCall_'):
+    if name.startswith('dynCall_') or (settings.EXPORT_KEEPALIVE and mangled in settings.EXPORTED_FUNCTIONS):
       exported = 'Module["%s"] = ' % mangled
     else:
       exported = ''
@@ -793,8 +793,9 @@ def create_receiving(exports):
         mangled = asmjs_mangle(s)
         dynCallAssignment = ('dynCalls["' + s.replace('dynCall_', '') + '"] = ') if generate_dyncall_assignment and mangled.startswith('dynCall_') else ''
         export_assignment = ''
-        if settings.MODULARIZE and settings.EXPORT_ALL:
-          export_assignment = f'Module["{mangled}"] = '
+        if settings.MODULARIZE:
+          if settings.EXPORT_ALL or (settings.EXPORT_KEEPALIVE and mangled in settings.EXPORTED_FUNCTIONS):
+            export_assignment = f'Module["{mangled}"] = '
         receiving += [f'{export_assignment}{dynCallAssignment}{mangled} = asm["{s}"]']
     else:
       receiving += make_export_wrappers(exports, delay_assignment)

--- a/emscripten.py
+++ b/emscripten.py
@@ -740,7 +740,8 @@ def make_export_wrappers(exports, delay_assignment):
     wrapper = '/** @type {function(...*):?} */\nvar %s = ' % mangled
 
     # TODO(sbc): Can we avoid exporting the dynCall_ functions on the module.
-    if name.startswith('dynCall_') or (settings.EXPORT_KEEPALIVE and mangled in settings.EXPORTED_FUNCTIONS):
+    should_export = settings.EXPORT_KEEPALIVE and mangled in settings.EXPORTED_FUNCTIONS
+    if name.startswith('dynCall_') or should_export:
       exported = 'Module["%s"] = ' % mangled
     else:
       exported = ''
@@ -792,10 +793,10 @@ def create_receiving(exports):
       for s in exports_that_are_not_initializers:
         mangled = asmjs_mangle(s)
         dynCallAssignment = ('dynCalls["' + s.replace('dynCall_', '') + '"] = ') if generate_dyncall_assignment and mangled.startswith('dynCall_') else ''
+        should_export = settings.EXPORT_ALL or (settings.EXPORT_KEEPALIVE and mangled in settings.EXPORTED_FUNCTIONS)
         export_assignment = ''
-        if settings.MODULARIZE:
-          if settings.EXPORT_ALL or (settings.EXPORT_KEEPALIVE and mangled in settings.EXPORTED_FUNCTIONS):
-            export_assignment = f'Module["{mangled}"] = '
+        if settings.MODULARIZE and should_export:
+          export_assignment = f'Module["{mangled}"] = '
         receiving += [f'{export_assignment}{dynCallAssignment}{mangled} = asm["{s}"]']
     else:
       receiving += make_export_wrappers(exports, delay_assignment)

--- a/src/settings.js
+++ b/src/settings.js
@@ -1832,7 +1832,10 @@ var SUPPORT_ERRNO = true;
 // MINIMAL_RUNTIME=2 to further enable even more code size optimizations. These
 // opts are quite hacky, and work around limitations in Closure and other parts
 // of the build system, so they may not work in all generated programs (But can
-// be useful for really small programs)
+// be useful for really small programs).
+//
+// By default, no symbols will be exported on the `Module` object. In order
+// to export kept alive symbols, please use `-sEXPORT_KEEPALIVE=1`.
 // [link]
 var MINIMAL_RUNTIME = 0;
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -994,6 +994,14 @@ var EXPORTED_FUNCTIONS = [];
 // [link]
 var EXPORT_ALL = false;
 
+// If true, we export the symbols that are present in JS onto the Module
+// object.
+// It only does Module['X'] = X;
+//
+// This only applies to MINIMAL_RUNTIME, where symbols aren't exported by
+// default.
+var EXPORT_KEEPALIVE = true;
+
 // Remembers the values of these settings, and makes them accessible
 // through getCompilerSetting and emscripten_get_compiler_setting.
 // To see what is retained, look for compilerSettings in the generated code.

--- a/src/settings.js
+++ b/src/settings.js
@@ -997,9 +997,6 @@ var EXPORT_ALL = false;
 // If true, we export the symbols that are present in JS onto the Module
 // object.
 // It only does Module['X'] = X;
-//
-// This only applies to MINIMAL_RUNTIME, where symbols aren't exported by
-// default.
 var EXPORT_KEEPALIVE = true;
 
 // Remembers the values of these settings, and makes them accessible

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1313,23 +1313,18 @@ int f() {
       EMSCRIPTEN_KEEPALIVE int libf1() { return 42; }
     ''')
 
-    create_file('main.js', '''
-      var Module = {
-        onRuntimeInitialized: function() {
-          console.log(Module._libf1 ? Module._libf1() : 'unexported');
-        }
+    create_file('pre.js', '''
+      Module.onRuntimeInitialized = () => {
+        console.log(Module._libf1 ? Module._libf1() : 'unexported');
       };
     ''')
 
     # By default, all kept alive functions should be exported.
-    self.emcc('main.c', ['--pre-js', 'main.js'], output_filename='test.js')
-    self.assertContained('42\n', self.run_js('test.js'))
+    self.do_runf('main.c', '42\n', emcc_args=['--pre-js', 'pre.js'])
 
     # Ensures that EXPORT_KEEPALIVE=0 remove the exports
-    self.emcc('main.c', ['-sEXPORT_KEEPALIVE=0', '--pre-js', 'main.js'], output_filename='test.js')
-    self.assertContained('unexported', self.run_js('test.js'))
+    self.do_runf('main.c', 'unexported\n', emcc_args=['-sEXPORT_KEEPALIVE=0', '--pre-js', 'pre.js'])
 
-  @requires_node
   def test_minimal_modularize_export_keepalive(self):
     create_file('main.c', r'''
       #include <emscripten.h>
@@ -1342,16 +1337,14 @@ int f() {
       write_file('main.js', f'{runtime}\nModule().then((mod) => console.log(mod._libf1()));')
 
     # By default, no symbols should be exported when using MINIMAL_RUNTIME.
-    self.emcc('main.c', ['-sMODULARIZE=1', '-sMINIMAL_RUNTIME=2'], output_filename='test.js')
+    self.emcc('main.c', ['-sMODULARIZE=1', '-sMINIMAL_RUNTIME=2', '-sASSERTIONS=0'], output_filename='test.js')
     write_js_main()
-    output = self.expect_fail(config.NODE_JS + ['main.js'])
-    self.assertContained('TypeError: mod._libf1 is not a function', output)
+    self.assertContained('TypeError: mod._libf1 is not a function', self.run_js('main.js', assert_returncode=NON_ZERO))
 
     # Ensures that EXPORT_KEEPALIVE=1 exports the symbols.
-    self.emcc('main.c', ['-sMODULARIZE=1', '-sMINIMAL_RUNTIME=2', '-sEXPORT_KEEPALIVE=1'], output_filename='test.js')
+    self.emcc('main.c', ['-sMODULARIZE=1', '-sMINIMAL_RUNTIME=2', '-sEXPORT_KEEPALIVE=1', '-sASSERTIONS=0'], output_filename='test.js')
     write_js_main()
-    output = self.run_process(config.NODE_JS + ['main.js'], stdout=PIPE, stderr=PIPE)
-    self.assertContained('42\n', output.stdout)
+    self.assertContained('42\n', self.run_js('main.js'))
 
   def test_minimal_runtime_export_all_modularize(self):
     """This test ensures that MODULARIZE and EXPORT_ALL work simultaneously.


### PR DESCRIPTION
This is the continuity of #17911, and an attempt to fix #18814.