### PR TITLE
Move build time `Runtime` object to `parseTools_legacy.js`. NFC

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -81,11 +81,11 @@ if (VERBOSE) {
 
 load('modules.js');
 load('parseTools.js');
+load('jsifier.js');
+load('runtime.js');
 if (!STRICT) {
   load('parseTools_legacy.js');
 }
-load('jsifier.js');
-load('runtime.js');
 
 // ===============================
 // Main

--- a/src/library.js
+++ b/src/library.js
@@ -392,7 +392,7 @@ mergeInto(LibraryManager.library, {
     // int getloadavg(double loadavg[], int nelem);
     // http://linux.die.net/man/3/getloadavg
     var limit = Math.min(nelem, 3);
-    var doubleSize = {{{ Runtime.getNativeTypeSize('double') }}};
+    var doubleSize = {{{ getNativeTypeSize('double') }}};
     for (var i = 0; i < limit; i++) {
       {{{ makeSetValue('loadavg', 'i * doubleSize', '0.1', 'double') }}};
     }
@@ -624,10 +624,10 @@ mergeInto(LibraryManager.library, {
     if (summerOffset < winterOffset) {
       // Northern hemisphere
       {{{ makeSetValue('tzname', '0', 'winterNamePtr', POINTER_TYPE) }}};
-      {{{ makeSetValue('tzname', Runtime.POINTER_SIZE, 'summerNamePtr', POINTER_TYPE) }}};
+      {{{ makeSetValue('tzname', POINTER_SIZE, 'summerNamePtr', POINTER_TYPE) }}};
     } else {
       {{{ makeSetValue('tzname', '0', 'summerNamePtr', POINTER_TYPE) }}};
-      {{{ makeSetValue('tzname', Runtime.POINTER_SIZE, 'winterNamePtr', POINTER_TYPE) }}};
+      {{{ makeSetValue('tzname', POINTER_SIZE, 'winterNamePtr', POINTER_TYPE) }}};
     }
   },
 

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1240,7 +1240,7 @@ var LibraryGLFW = {
   glfwGetMonitors: function(count) {
     {{{ makeSetValue('count', '0', '1', 'i32') }}};
     if (!GLFW.monitors) {
-      GLFW.monitors = {{{ makeMalloc('glfwGetMonitors', Runtime.POINTER_SIZE) }}};
+      GLFW.monitors = {{{ makeMalloc('glfwGetMonitors', POINTER_SIZE) }}};
       {{{ makeSetValue('GLFW.monitors', '0', '1', 'i32') }}};
     }
     return GLFW.monitors;

--- a/src/library_promise.js
+++ b/src/library_promise.js
@@ -155,7 +155,7 @@ mergeInto(LibraryManager.library, {
   emscripten_promise_all: function(idBuf, resultBuf, size) {
     var promises = [];
     for (var i = 0; i < size; i++) {
-      var id = {{{ makeGetValue('idBuf', `i*${Runtime.POINTER_SIZE}`, 'i32') }}};
+      var id = {{{ makeGetValue('idBuf', `i*${POINTER_SIZE}`, 'i32') }}};
       promises[i] = getPromise(id);
     }
 #if RUNTIME_DEBUG
@@ -166,7 +166,7 @@ mergeInto(LibraryManager.library, {
         if (resultBuf) {
           for (var i = 0; i < size; i++) {
             var result = results[i];
-            {{{ makeSetValue('resultBuf', `i*${Runtime.POINTER_SIZE}`, 'result', '*') }}};
+            {{{ makeSetValue('resultBuf', `i*${POINTER_SIZE}`, 'result', '*') }}};
           }
         }
         return resultBuf;

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -96,7 +96,7 @@ var WasiLibrary = {
     var bufSize = 0;
     getEnvStrings().forEach(function(string, i) {
       var ptr = environ_buf + bufSize;
-      {{{ makeSetValue('__environ', `i*${Runtime.POINTER_SIZE}`, 'ptr', POINTER_TYPE) }}};
+      {{{ makeSetValue('__environ', `i*${POINTER_SIZE}`, 'ptr', POINTER_TYPE) }}};
       writeAsciiToMemory(string, ptr);
       bufSize += string.length + 1;
     });
@@ -130,7 +130,7 @@ var WasiLibrary = {
     var bufSize = 0;
     mainArgs.forEach(function(arg, i) {
       var ptr = argv_buf + bufSize;
-      {{{ makeSetValue('argv', `i*${Runtime.POINTER_SIZE}`, 'ptr', POINTER_TYPE) }}};
+      {{{ makeSetValue('argv', `i*${POINTER_SIZE}`, 'ptr', POINTER_TYPE) }}};
       writeAsciiToMemory(arg, ptr);
       bufSize += arg.length + 1;
     });

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -260,12 +260,12 @@ function indentify(text, indent) {
 // Correction tools
 
 function getHeapOffset(offset, type) {
-  if (!WASM_BIGINT && Runtime.getNativeFieldSize(type) > 4 && type == 'i64') {
+  if (!WASM_BIGINT && getNativeFieldSize(type) > 4 && type == 'i64') {
     // we emulate 64-bit integer values as 32 in asmjs-unknown-emscripten, but not double
     type = 'i32';
   }
 
-  const sz = Runtime.getNativeTypeSize(type);
+  const sz = getNativeTypeSize(type);
   const shifts = Math.log(sz) / Math.LN2;
   return `((${offset})>>${shifts})`;
 }
@@ -371,7 +371,7 @@ function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, sep = '
     // bits, so HEAP64[ptr>>3] might be broken.
     return '(tempI64 = [' + splitI64(value) + '],' +
             makeSetValue(ptr, pos, 'tempI64[0]', 'i32', noNeedFirst, ignore, align, ',') + ',' +
-            makeSetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), 'tempI64[1]', 'i32', noNeedFirst, ignore, align, ',') + ')';
+            makeSetValue(ptr, getFastValue(pos, '+', getNativeTypeSize('i32')), 'tempI64[1]', 'i32', noNeedFirst, ignore, align, ',') + ')';
   }
 
   const offset = calcFastOffset(ptr, pos);

--- a/src/parseTools_legacy.js
+++ b/src/parseTools_legacy.js
@@ -84,3 +84,10 @@ function makeCopyValues(dest, src, num, type, modifier, align, sep = ';') {
   });
   return ret.join(sep);
 }
+
+global.Runtime = {
+  getNativeTypeSize: getNativeTypeSize,
+  getNativeFieldSize: getNativeFieldSize,
+  POINTER_SIZE: POINTER_SIZE,
+  QUANTUM_SIZE: POINTER_SIZE,
+};

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -51,7 +51,7 @@ function callMain() {
   args.unshift(thisProgram);
 
   var argc = args.length;
-  var argv = stackAlloc((argc + 1) * {{{ Runtime.POINTER_SIZE }}});
+  var argv = stackAlloc((argc + 1) * {{{ POINTER_SIZE }}});
   var argv_ptr = argv >> {{{ POINTER_SHIFT }}};
   args.forEach((arg) => {
     {{{ POINTER_HEAP }}}[argv_ptr++] = {{{ to64('allocateUTF8OnStack(arg)') }}};

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -34,16 +34,6 @@ function getNativeTypeSize(type) {
   }
 }
 
-global.Runtime = {
-  getNativeTypeSize: getNativeTypeSize,
-
-  // TODO(sbc): This function is unused by emscripten but we can't be
-  // sure there are not external users.
-  // See: https://github.com/emscripten-core/emscripten/issues/15242
-  getNativeFieldSize: function(type) {
-    return Math.max(getNativeTypeSize(type), Runtime.POINTER_SIZE);
-  },
-
-  POINTER_SIZE: POINTER_SIZE,
-  QUANTUM_SIZE: POINTER_SIZE,
-};
+function getNativeFieldSize(type) {
+  return Math.max(getNativeTypeSize(type), POINTER_SIZE);
+}

--- a/src/settings.js
+++ b/src/settings.js
@@ -333,9 +333,9 @@ var EXCEPTION_DEBUG = false;
 var DEMANGLE_SUPPORT = false;
 
 // Print out when we enter a library call (library*.js). You can also unset
-// Runtime.debug at runtime for logging to cease, and can set it when you want
+// runtimeDebug at runtime for logging to cease, and can set it when you want
 // it back. A simple way to set it in C++ is
-//   emscripten_run_script("Runtime.debug = ...;");
+//   emscripten_run_script("runtimeDebug = ...;");
 // [link]
 var LIBRARY_DEBUG = false;
 
@@ -995,7 +995,7 @@ var EXPORTED_FUNCTIONS = [];
 var EXPORT_ALL = false;
 
 // Remembers the values of these settings, and makes them accessible
-// through Runtime.getCompilerSetting and emscripten_get_compiler_setting.
+// through getCompilerSetting and emscripten_get_compiler_setting.
 // To see what is retained, look for compilerSettings in the generated code.
 // [link]
 var RETAIN_COMPILER_SETTINGS = false;
@@ -1265,7 +1265,7 @@ var EXPORT_NAME = 'Module';
 // in particular the 'unsafe-eval' and 'wasm-unsafe-eval' policies.
 //
 // When this flag is set, the following features (linker flags) are unavailable:
-//  -sRELOCATABLE: the function Runtime.loadDynamicLibrary would need to eval().
+//  -sRELOCATABLE: the function loadDynamicLibrary would need to eval().
 // and some features may fall back to slower code paths when they need to:
 // Embind: uses eval() to jit functions for speed.
 //

--- a/test/return64bit/testbind.js
+++ b/test/return64bit/testbind.js
@@ -1,7 +1,7 @@
 // This code represents a simple native JavaScript binding to a test C function
 // that returns a 64 bit long. Notice that the least significant 32 bits are
 // returned in the normal return value, but the most significant 32 bits are
-// returned via the accessor method Runtime.getTempRet0()
+// returned via the accessor method getTempRet0()
 
 var Module = {
     'noExitRuntime' : true

--- a/test/return64bit/testbind_bigint.js
+++ b/test/return64bit/testbind_bigint.js
@@ -1,7 +1,7 @@
 // This code represents a simple native JavaScript binding to a test C function
 // that returns a 64 bit long. Notice that the least significant 32 bits are
 // returned in the normal return value, but the most significant 32 bits are
-// returned via the accessor method Runtime.getTempRet0()
+// returned via the accessor method getTempRet0()
 
 var Module = {
     'noExitRuntime' : true

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13026,3 +13026,18 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
       test_file('third_party/googletest/googletest/src/gtest_main.cc'),
     ]
     self.do_other_test('test_googletest.cc')
+
+  def test_parseTools_legacy(self):
+    create_file('post.js', '''
+      err(_foo());
+    ''')
+    create_file('lib.js', '''
+      mergeInto(LibraryManager.library, {
+        foo: function() {
+            return {{{ Runtime.POINTER_SIZE }}};
+          }
+      });
+    ''')
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', 'foo')
+    self.do_runf(test_file('hello_world.c'), '4\nhello, world!',
+                 emcc_args=['--post-js=post.js', '--js-library=lib.js'])

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -53,28 +53,6 @@ The JSON input format is as follows:
 
 Please note that the 'f' for 'FLOAT_DEFINE' is just the format passed to printf(), you can put anything printf() understands.
 If you call this script with the flag "-f" and pass a header file, it will create an automated boilerplate for you.
-
-The JSON output format is based on the return value of Runtime.generateStructInfo().
-{
-  'structs': {
-    'struct_name': {
-      '__size__': <the struct's size>,
-      'field1': <field1's offset>,
-      'field2': <field2's offset>,
-      'field3': <field3's offset>,
-      'field4': {
-        '__size__': <field4's size>,
-        'nested1': <nested1's offset>,
-        ...
-      },
-      ...
-    }
-  },
-  'defines': {
-    'DEFINE_1': <DEFINE_1's value>,
-    ...
-  }
-}
 """
 
 import sys


### PR DESCRIPTION
Confusingly this was only available at build time, not at runtime.

Followup to #18803.

As another followup I think we can completely remove runtime.js.