### PR TITLE
[Proxying] Add proxying functions that return promises

### DIFF
--- a/system/include/emscripten/proxying.h
+++ b/system/include/emscripten/proxying.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <emscripten/emscripten.h>
+#include <emscripten/promise.h>
 #include <pthread.h>
 
 #ifdef __cplusplus
@@ -101,6 +102,18 @@ int emscripten_proxy_callback_with_ctx(em_proxying_queue* q,
                                        void (*callback)(void*),
                                        void (*cancel)(void*),
                                        void* arg);
+
+__attribute__((warn_unused_result)) em_promise_t
+emscripten_proxy_promise(em_proxying_queue* q,
+                         pthread_t target_thread,
+                         void (*func)(void*),
+                         void* arg);
+
+__attribute__((warn_unused_result)) em_promise_t
+emscripten_proxy_promise_with_ctx(em_proxying_queue* q,
+                                  pthread_t target_thread,
+                                  void (*func)(em_proxying_ctx*, void*),
+                                  void* arg);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/system/lib/pthread/proxying.c
+++ b/system/lib/pthread/proxying.c
@@ -389,7 +389,7 @@ int emscripten_proxy_sync_with_ctx(em_proxying_queue* q,
 }
 
 // Helper for signaling the end of the task after the user function returns.
-static void call_then_finish_sync(em_proxying_ctx* ctx, void* arg) {
+static void call_then_finish_task(em_proxying_ctx* ctx, void* arg) {
   task* t = arg;
   t->func(t->arg);
   emscripten_proxy_finish(ctx);
@@ -401,7 +401,7 @@ int emscripten_proxy_sync(em_proxying_queue* q,
                           void* arg) {
   task t = {.func = func, .arg = arg};
   return emscripten_proxy_sync_with_ctx(
-    q, target_thread, call_then_finish_sync, &t);
+    q, target_thread, call_then_finish_task, &t);
 }
 
 static int do_proxy_callback(em_proxying_queue* q,
@@ -482,4 +482,99 @@ int emscripten_proxy_callback(em_proxying_queue* q,
                            callback_cancel,
                            &block->cb_ctx,
                            &block->ctx);
+}
+
+typedef struct promise_ctx {
+  void (*func)(em_proxying_ctx*, void*);
+  void* arg;
+  em_promise_t promise;
+} promise_ctx;
+
+static void promise_call(em_proxying_ctx* ctx, void* arg) {
+  promise_ctx* promise_ctx = arg;
+  promise_ctx->func(ctx, promise_ctx->arg);
+}
+
+static void promise_fulfill(void* arg) {
+  promise_ctx* promise_ctx = arg;
+  emscripten_promise_resolve(promise_ctx->promise, EM_PROMISE_FULFILL, NULL);
+  emscripten_promise_destroy(promise_ctx->promise);
+}
+
+static void promise_reject(void* arg) {
+  promise_ctx* promise_ctx = arg;
+  emscripten_promise_resolve(promise_ctx->promise, EM_PROMISE_REJECT, NULL);
+  emscripten_promise_destroy(promise_ctx->promise);
+}
+
+static em_promise_t do_proxy_promise(em_proxying_queue* q,
+                                     pthread_t target_thread,
+                                     void (*func)(em_proxying_ctx*, void*),
+                                     void* arg,
+                                     em_promise_t promise,
+                                     em_proxying_ctx* ctx,
+                                     promise_ctx* promise_ctx) {
+  *promise_ctx = (struct promise_ctx){func, arg, promise};
+  if (!do_proxy_callback(q,
+                         target_thread,
+                         promise_call,
+                         promise_fulfill,
+                         promise_reject,
+                         promise_ctx,
+                         ctx)) {
+    emscripten_promise_resolve(promise, EM_PROMISE_REJECT, NULL);
+    return promise;
+  }
+  // Return a separate promise to ensure that the internal promise will stay
+  // alive until the callbacks are called.
+  em_promise_t ret = emscripten_promise_create();
+  emscripten_promise_resolve(ret, EM_PROMISE_MATCH, promise);
+  return ret;
+}
+
+em_promise_t emscripten_proxy_promise_with_ctx(em_proxying_queue* q,
+                                               pthread_t target_thread,
+                                               void (*func)(em_proxying_ctx*,
+                                                            void*),
+                                               void* arg) {
+  em_promise_t promise = emscripten_promise_create();
+  // Allocate the em_proxying_ctx and promise ctx as a single block.
+  struct block {
+    em_proxying_ctx ctx;
+    promise_ctx promise_ctx;
+  };
+  struct block* block = malloc(sizeof(*block));
+  if (block == NULL) {
+    emscripten_promise_resolve(promise, EM_PROMISE_REJECT, NULL);
+    return promise;
+  }
+  return do_proxy_promise(
+    q, target_thread, func, arg, promise, &block->ctx, &block->promise_ctx);
+}
+
+__attribute__((warn_unused_result)) em_promise_t
+emscripten_proxy_promise(em_proxying_queue* q,
+                         pthread_t target_thread,
+                         void (*func)(void*),
+                         void* arg) {
+  em_promise_t promise = emscripten_promise_create();
+  // Allocate the em_proxying_ctx, promise ctx, and user task as a single block.
+  struct block {
+    em_proxying_ctx ctx;
+    promise_ctx promise_ctx;
+    task task;
+  };
+  struct block* block = malloc(sizeof(*block));
+  if (block == NULL) {
+    emscripten_promise_resolve(promise, EM_PROMISE_REJECT, NULL);
+    return promise;
+  }
+  block->task = (task){.func = func, .arg = arg};
+  return do_proxy_promise(q,
+                          target_thread,
+                          call_then_finish_task,
+                          &block->task,
+                          promise,
+                          &block->ctx,
+                          &block->promise_ctx);
 }

--- a/system/lib/pthread/proxying.c
+++ b/system/lib/pthread/proxying.c
@@ -465,7 +465,8 @@ int emscripten_proxy_callback(em_proxying_queue* q,
                               void (*callback)(void*),
                               void (*cancel)(void*),
                               void* arg) {
-  // Allocate the em_proxying_ctx and the user ctx as a single block.
+  // Allocate the em_proxying_ctx and the user ctx as a single block that will
+  // be freed when the `em_proxying_ctx` is freed.
   struct block {
     em_proxying_ctx ctx;
     callback_ctx cb_ctx;
@@ -538,7 +539,8 @@ em_promise_t emscripten_proxy_promise_with_ctx(em_proxying_queue* q,
                                                             void*),
                                                void* arg) {
   em_promise_t promise = emscripten_promise_create();
-  // Allocate the em_proxying_ctx and promise ctx as a single block.
+  // Allocate the em_proxying_ctx and promise ctx as a single block that will be
+  // freed when the `em_proxying_ctx` is freed.
   struct block {
     em_proxying_ctx ctx;
     promise_ctx promise_ctx;
@@ -552,13 +554,13 @@ em_promise_t emscripten_proxy_promise_with_ctx(em_proxying_queue* q,
     q, target_thread, func, arg, promise, &block->ctx, &block->promise_ctx);
 }
 
-__attribute__((warn_unused_result)) em_promise_t
-emscripten_proxy_promise(em_proxying_queue* q,
-                         pthread_t target_thread,
-                         void (*func)(void*),
-                         void* arg) {
+em_promise_t emscripten_proxy_promise(em_proxying_queue* q,
+                                      pthread_t target_thread,
+                                      void (*func)(void*),
+                                      void* arg) {
   em_promise_t promise = emscripten_promise_create();
-  // Allocate the em_proxying_ctx, promise ctx, and user task as a single block.
+  // Allocate the em_proxying_ctx, promise ctx, and user task as a single block
+  // that will be freed when the `em_proxying_ctx` is freed.
   struct block {
     em_proxying_ctx ctx;
     promise_ctx promise_ctx;

--- a/test/pthread/test_pthread_proxying.out
+++ b/test/pthread/test_pthread_proxying.out
@@ -16,6 +16,14 @@ Testing callback_with_ctx proxying
 running widget 11 on main
 running widget 12 on looper
 running widget 13 on returner
+Testing promise proxying
+running widget 14 on worker
+running widget 15 on looper
+running widget 16 on returner
+Testing promise_with_ctx proxying
+running widget 17 on worker
+running widget 18 on looper
+running widget 19 on returner
 Testing tasks queue growth
 Testing proxying queue growth
 work

--- a/test/pthread/test_pthread_proxying_canceled_work.out
+++ b/test/pthread/test_pthread_proxying_canceled_work.out
@@ -2,8 +2,6 @@ testing cancel followed by proxy
 testing exit followed by proxy
 testing proxy followed by cancel
 testing proxy followed by exit
-testing callback proxy followed by cancel
-testing callback proxy followed by exit
 testing cancellation of in-progress work
 checking pattern 0
 finishing task 0


### PR DESCRIPTION
Add `emscripten_proxy_promise` and `emscripten_proxy_promise_with_ctx` that
return `em_promise_t` handles to promises that are fulfilled when the proxied
work is completed or rejected when the target thread dies before it can complete
the work.

Do not document these new APIs yet since they depend on the promise API in
emscripten/promise.h, which is not yet documented. Similarly, do not add a C++
wrapper yet because emscripten/promise.h does not yet have a C++ API.