### PR TITLE
Add check for not supported webassembly.exception.stack

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -420,7 +420,7 @@ var LibraryExceptions = {
     //     ...
     //
     // Remove this JS function name, which is in the second line, from the stack
-    // trace.
+    // trace. Note that .stack does not yet exist in all browsers (see #18828).
     if (e.stack) {
       var arr = e.stack.split('\n');
       arr.splice(1,1);

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -421,9 +421,11 @@ var LibraryExceptions = {
     //
     // Remove this JS function name, which is in the second line, from the stack
     // trace.
-    var arr = e.stack.split('\n');
-    arr.splice(1,1);
-    e.stack = arr.join('\n');
+    if (e.stack) {
+      var arr = e.stack.split('\n');
+      arr.splice(1,1);
+      e.stack = arr.join('\n');
+    }
     throw e;
   },
 #endif


### PR DESCRIPTION
Webassembly.Exception.stack is still on supported on latest safari browser (16.2). Although [MDN](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Exception) shows supported since 15.2 but its incorrect and I have reported the issue https://github.com/mdn/browser-compat-data/issues/18938. As mentioned in the issue it can be easily verified by running below code:

```js
const tag = new WebAssembly.Tag({ parameters: ["i32"] });

function throw_exception_with_stacktrace(param) {
    return new WebAssembly.Exception(tag, [param], { traceStack: true });
}

const ex = throw_exception_with_stacktrace(42);
console.log(ex.stack);
```
Added a safety check in this PR for cases like this where stack comes undefined.