### PR TITLE
JSPI - Support async embind function bindings.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -112,7 +112,8 @@ DEFAULT_ASYNCIFY_IMPORTS = [
 
 DEFAULT_ASYNCIFY_EXPORTS = [
   'main',
-  '__main_argc_argv'
+  '__main_argc_argv',
+  '_ZN10emscripten8internal5async*' # Embind's async functions.
 ]
 
 # Target options
@@ -2141,7 +2142,7 @@ def phase_linker_setup(options, state, newargs):
   if settings.ASYNCIFY_LAZY_LOAD_CODE:
     settings.ASYNCIFY = 1
 
-  if settings.ASYNCIFY:
+  if settings.ASYNCIFY == 1:
     # See: https://github.com/emscripten-core/emscripten/issues/12065
     # See: https://github.com/emscripten-core/emscripten/issues/12066
     settings.DYNCALLS = 1

--- a/emcc.py
+++ b/emcc.py
@@ -113,9 +113,9 @@ DEFAULT_ASYNCIFY_IMPORTS = [
 DEFAULT_ASYNCIFY_EXPORTS = [
   'main',
   '__main_argc_argv',
-   # Embind's async template wrapper functions. These functions are usually in
-   # the function pointer table and not called from exports, but we need to name
-   # them so the JSPI pass can find and convert them.
+  # Embind's async template wrapper functions. These functions are usually in
+  # the function pointer table and not called from exports, but we need to name
+  # them so the JSPI pass can find and convert them.
   '_ZN10emscripten8internal5async*'
 ]
 

--- a/emcc.py
+++ b/emcc.py
@@ -113,7 +113,10 @@ DEFAULT_ASYNCIFY_IMPORTS = [
 DEFAULT_ASYNCIFY_EXPORTS = [
   'main',
   '__main_argc_argv',
-  '_ZN10emscripten8internal5async*' # Embind's async functions.
+   # Embind's async template wrapper functions. These functions are usually in
+   # the function pointer table and not called from exports, but we need to name
+   # them so the JSPI pass can find and convert them.
+  '_ZN10emscripten8internal5async*'
 ]
 
 # Target options

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -10,6 +10,7 @@
 /*global FUNCTION_TABLE, HEAP8, HEAPU8, HEAP16, HEAPU16, HEAP32, HEAPU32, HEAPF32, HEAPF64*/
 /*global readLatin1String*/
 /*global Emval, emval_handle_array, __emval_decref*/
+
 /*jslint sub:true*/ /* The symbols 'fromWireType' and 'toWireType' must be accessed via array notation to be closure-safe since craftInvokerFunction crafts functions as strings that can't be closured. */
 
 // -- jshint doesn't understand library syntax, so we need to specifically tell it about the symbols we define
@@ -988,9 +989,11 @@ var LibraryEmbind = {
 
     var returns = (argTypes[0].name !== "void");
 
+#if ASYNCIFY
     if (isAsync) {
       cppInvokerFunc = Asyncify.makeAsyncFunction(cppInvokerFunc);
     }
+#endif
 
 #if DYNAMIC_EXECUTION == 0
     var expectedArgCount = argCount - 2;

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -947,7 +947,7 @@ var LibraryEmbind = {
     '$Asyncify',
   #endif
   ],
-  $craftInvokerFunction: function(humanName, argTypes, classType, cppInvokerFunc, cppTargetFunc) {
+  $craftInvokerFunction: function(humanName, argTypes, classType, cppInvokerFunc, cppTargetFunc, isAsync) {
     // humanName: a human-readable string name for the function to be generated.
     // argTypes: An array that contains the embind type objects for all types in the function signature.
     //    argTypes[0] is the type object for the function return value.
@@ -961,6 +961,10 @@ var LibraryEmbind = {
     if (argCount < 2) {
       throwBindingError("argTypes array size mismatch! Must at least get return value and 'this' types!");
     }
+
+#if ASSERTIONS && ASYNCIFY != 2
+    assert(!isAsync, 'Async bindings are only supported with JSPI.');
+#endif
 
     var isClassMethodFunc = (argTypes[1] !== null && classType !== null);
 
@@ -983,6 +987,10 @@ var LibraryEmbind = {
     }
 
     var returns = (argTypes[0].name !== "void");
+
+    if (isAsync) {
+      cppInvokerFunc = Asyncify.makeAsyncFunction(cppInvokerFunc);
+    }
 
 #if DYNAMIC_EXECUTION == 0
     var expectedArgCount = argCount - 2;
@@ -1034,9 +1042,13 @@ var LibraryEmbind = {
         }
       }
 
-#if ASYNCIFY
+#if ASYNCIFY == 1
       if (Asyncify.currData) {
         return Asyncify.whenDone().then(onDone);
+      }
+#elif ASYNCIFY == 2
+      if (isAsync) {
+        return rv.then(onDone);
       }
 #endif
 
@@ -1088,11 +1100,13 @@ var LibraryEmbind = {
     }
 
     invokerFnBody +=
-        (returns?"var rv = ":"") + "invoker(fn"+(argsListWired.length>0?", ":"")+argsListWired+");\n";
+        (returns || isAsync ? "var rv = ":"") + "invoker(fn"+(argsListWired.length>0?", ":"")+argsListWired+");\n";
 
-#if ASYNCIFY
+#if ASYNCIFY == 1
     args1.push("Asyncify");
     args2.push(Asyncify);
+#endif
+#if ASYNCIFY
     invokerFnBody += "function onDone(" + (returns ? "rv" : "") + ") {\n";
 #endif
 
@@ -1121,9 +1135,12 @@ var LibraryEmbind = {
 #endif
     }
 
-#if ASYNCIFY
+#if ASYNCIFY == 1
     invokerFnBody += "}\n";
     invokerFnBody += "return Asyncify.currData ? Asyncify.whenDone().then(onDone) : onDone(" + (returns ? "rv" : "") +");\n"
+#elif ASYNCIFY == 2
+    invokerFnBody += "}\n";
+    invokerFnBody += "return " + (isAsync ? "rv.then(onDone)" : "onDone(rv)") + ";";
 #endif
 
     invokerFnBody += "}\n";
@@ -1167,12 +1184,12 @@ var LibraryEmbind = {
     return fp;
   },
 
-  _embind_register_function__sig: 'vpipppp',
+  _embind_register_function__sig: 'vpippppi',
   _embind_register_function__deps: [
     '$craftInvokerFunction', '$exposePublicSymbol', '$heap32VectorToArray',
     '$readLatin1String', '$replacePublicSymbol', '$embind__requireFunction',
     '$throwUnboundTypeError', '$whenDependentTypesAreResolved'],
-  _embind_register_function: function(name, argCount, rawArgTypesAddr, signature, rawInvoker, fn) {
+  _embind_register_function: function(name, argCount, rawArgTypesAddr, signature, rawInvoker, fn, isAsync) {
     var argTypes = heap32VectorToArray(argCount, rawArgTypesAddr);
     name = readLatin1String(name);
 
@@ -1184,7 +1201,7 @@ var LibraryEmbind = {
 
     whenDependentTypesAreResolved([], argTypes, function(argTypes) {
       var invokerArgsArray = [argTypes[0] /* return value */, null /* no class 'this'*/].concat(argTypes.slice(1) /* actual params */);
-      replacePublicSymbol(name, craftInvokerFunction(name, invokerArgsArray, null /* no class 'this'*/, rawInvoker, fn), argCount - 1);
+      replacePublicSymbol(name, craftInvokerFunction(name, invokerArgsArray, null /* no class 'this'*/, rawInvoker, fn, isAsync), argCount - 1);
       return [];
     });
   },
@@ -2168,7 +2185,7 @@ var LibraryEmbind = {
                          classType.registeredClass);
   },
 
-  _embind_register_class_function__sig: 'vppippppi',
+  _embind_register_class_function__sig: 'vppippppii',
   _embind_register_class_function__deps: [
     '$craftInvokerFunction', '$heap32VectorToArray', '$readLatin1String',
     '$embind__requireFunction', '$throwUnboundTypeError',
@@ -2180,7 +2197,8 @@ var LibraryEmbind = {
                                             invokerSignature,
                                             rawInvoker,
                                             context,
-                                            isPureVirtual) {
+                                            isPureVirtual,
+                                            isAsync) {
     var rawArgTypes = heap32VectorToArray(argCount, rawArgTypesAddr);
     methodName = readLatin1String(methodName);
     rawInvoker = embind__requireFunction(invokerSignature, rawInvoker);
@@ -2217,7 +2235,7 @@ var LibraryEmbind = {
       }
 
       whenDependentTypesAreResolved([], rawArgTypes, function(argTypes) {
-        var memberFunction = craftInvokerFunction(humanName, argTypes, classType, rawInvoker, context);
+        var memberFunction = craftInvokerFunction(humanName, argTypes, classType, rawInvoker, context, isAsync);
 
         // Replace the initial unbound-handler-stub function with the appropriate member function, now that all types
         // are resolved. If multiple overloads are registered for this function, the function goes into an overload table.
@@ -2307,7 +2325,7 @@ var LibraryEmbind = {
     });
   },
 
-  _embind_register_class_class_function__sig: 'vppipppp',
+  _embind_register_class_class_function__sig: 'vppippppi',
   _embind_register_class_class_function__deps: [
     '$craftInvokerFunction', '$ensureOverloadTable', '$heap32VectorToArray',
     '$readLatin1String', '$embind__requireFunction', '$throwUnboundTypeError',
@@ -2318,7 +2336,8 @@ var LibraryEmbind = {
                                                   rawArgTypesAddr,
                                                   invokerSignature,
                                                   rawInvoker,
-                                                  fn) {
+                                                  fn,
+                                                  isAsync) {
     var rawArgTypes = heap32VectorToArray(argCount, rawArgTypesAddr);
     methodName = readLatin1String(methodName);
     rawInvoker = embind__requireFunction(invokerSignature, rawInvoker);
@@ -2351,7 +2370,7 @@ var LibraryEmbind = {
         // function. If multiple overloads are registered, the function handlers
         // go into an overload table.
         var invokerArgsArray = [argTypes[0] /* return value */, null /* no class 'this'*/].concat(argTypes.slice(1) /* actual params */);
-        var func = craftInvokerFunction(humanName, invokerArgsArray, null /* no class 'this'*/, rawInvoker, fn);
+        var func = craftInvokerFunction(humanName, invokerArgsArray, null /* no class 'this'*/, rawInvoker, fn, isAsync);
         if (undefined === proto[methodName].overloadTable) {
           func.argCount = argCount-1;
           proto[methodName] = func;

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -10,7 +10,6 @@
 /*global FUNCTION_TABLE, HEAP8, HEAPU8, HEAP16, HEAPU16, HEAP32, HEAPU32, HEAPF32, HEAPF64*/
 /*global readLatin1String*/
 /*global Emval, emval_handle_array, __emval_decref*/
-
 /*jslint sub:true*/ /* The symbols 'fromWireType' and 'toWireType' must be accessed via array notation to be closure-safe since craftInvokerFunction crafts functions as strings that can't be closured. */
 
 // -- jshint doesn't understand library syntax, so we need to specifically tell it about the symbols we define

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -116,22 +116,7 @@ mergeInto(LibraryManager.library, {
             // Wrap all exports with a promising WebAssembly function.
             var isAsyncifyExport = ASYNCIFY_EXPORTS.indexOf(x) >= 0;
             if (isAsyncifyExport) {
-#if ASYNCIFY_DEBUG
-              dbg('asyncify: returnPromiseOnSuspend for', x, original);
-#endif
-              var type = WebAssembly.Function.type(original);
-              var parameters = type.parameters;
-              var results = type.results;
-#if ASSERTIONS
-              assert(results.length !== 0, 'There must be a return result')
-              assert(parameters[0] === 'externref', 'First param must be externref.');
-#endif
-              // Remove the extern ref.
-              parameters.shift();
-              original = new WebAssembly.Function(
-                { parameters , results: ['externref'] },
-                original,
-                { promising : 'first' });
+              original = Asyncify.makeAsyncFunction(original);
             }
 #endif
             ret[x] = function() {
@@ -443,6 +428,24 @@ mergeInto(LibraryManager.library, {
         // TODO: add error handling as a second param when handleSleep implements it.
         startAsync().then(wakeUp);
       });
+    },
+    makeAsyncFunction: function(original) {
+#if ASYNCIFY_DEBUG
+      dbg('asyncify: returnPromiseOnSuspend for', original);
+#endif
+      var type = WebAssembly.Function.type(original);
+      var parameters = type.parameters;
+      var results = type.results;
+#if ASSERTIONS
+      assert(results.length !== 0, 'There must be a return result')
+      assert(parameters[0] === 'externref', 'First param must be externref.');
+#endif
+      // Remove the extern ref.
+      parameters.shift();
+      return new WebAssembly.Function(
+        { parameters , results: ['externref'] },
+        original,
+        { promising : 'first' });
     },
 #endif
   },

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -428,12 +428,6 @@ struct Wrapper<ReturnType(*)(Args...), f> {
         return f(args...);
     }
 };
-template<typename... Args, void(*f)(Args...)>
-struct Wrapper<void(*)(Args...), f> {
-    EMSCRIPTEN_KEEPALIVE static void invoke(Args... args) {
-        f(args...);
-    }
-};
 
 } // end namespace async
 

--- a/test/embind/embind_jspi_test.cpp
+++ b/test/embind/embind_jspi_test.cpp
@@ -1,0 +1,85 @@
+// Copyright 2023 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <emscripten.h>
+#include <emscripten/bind.h>
+
+using namespace emscripten;
+
+void voidFunc() { emscripten_sleep(0); }
+
+int intFunc(int i) {
+  emscripten_sleep(0);
+  return i + 1;
+}
+
+class MyClass {
+public:
+  MyClass() {}
+
+  void voidMethod() { emscripten_sleep(0); }
+
+  int intMethod(int i) {
+    emscripten_sleep(0);
+    return i + 1;
+  }
+
+  static void voidClass() { emscripten_sleep(0); }
+
+  static int intClass(int i) {
+    emscripten_sleep(0);
+    return i + 1;
+  }
+};
+
+int stdFunction(const MyClass& target, int i) {
+  emscripten_sleep(0);
+  return i + 1;
+}
+
+EMSCRIPTEN_BINDINGS(xxx) {
+  function("voidFunc", &voidFunc, async());
+  function("intFunc", &intFunc, async());
+
+  class_<MyClass>("MyClass")
+    .constructor<>()
+    .function("voidMethod", &MyClass::voidMethod, async())
+    .function("intMethod", &MyClass::intMethod, async())
+    .function("stdMethod",
+              std::function<int(const MyClass&, int)>(&stdFunction),
+              async())
+    .function("lambdaMethod",
+              select_overload<int(MyClass&, int)>([](MyClass& self, int i) {
+                emscripten_sleep(0);
+                return i + 1;
+              }),
+              async())
+    .class_function("voidClass", &MyClass::voidClass, async())
+    .class_function("intClass", &MyClass::intClass, async());
+}
+
+EM_ASYNC_JS(void, test, (), {
+  async function check(promise, expected) {
+    assert(promise instanceof Promise);
+    var actual = await promise;
+    assert(actual === expected);
+  }
+  try {
+    await check(Module.intFunc(1), 2);
+    var myClass = new Module.MyClass();
+    await check(myClass.voidMethod());
+    await check(myClass.intMethod(1), 2);
+    await check(myClass.stdMethod(1), 2);
+    await check(myClass.lambdaMethod(1), 2);
+    await check(Module.MyClass.voidClass());
+    await check(Module.MyClass.intClass(1), 2);
+
+    console.log('done');
+  } catch (e) {
+    console.log('Failed: ' + e.stack);
+  }
+});
+
+int main() { test(); }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2695,6 +2695,18 @@ int f() {
     ''')
     self.do_runf('main.cpp', 'done', emcc_args=['-lembind', '-sASYNCIFY', '--post-js', 'post.js'])
 
+  @parameterized({
+    '': ['-sDYNAMIC_EXECUTION=1'],
+    'no_dynamic': ['-sDYNAMIC_EXECUTION=0'],
+  })
+  def test_embind_jspi(self, extra):
+    self.require_v8()
+    self.v8_args.append('--experimental-wasm-stack-switching')
+    self.emcc_args += ['-lembind', '-g', '-sASYNCIFY=2', '-Wno-experimental']
+    self.emcc_args += [extra]
+
+    self.do_runf(test_file('embind/embind_jspi_test.cpp'), 'done')
+
   def test_embind_no_function(self):
     create_file('post.js', '''
       Module['onRuntimeInitialized'] = function() {


### PR DESCRIPTION
Adds a new `async()` option for function and class method bindings. Functions marked async will use a separate async invoker. The invoker will be exported and transformed in the JSPI binaryen pass. When the binding is initialized on start up, a promising WebAssembly Function will be created to wrap the export and extra code will be generated to handle the promise.

Depends on https://github.com/WebAssembly/binaryen/pull/5519