### PR TITLE
Allow JS -> native dependencies to be specified in __deps. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2111,7 +2111,7 @@ mergeInto(LibraryManager.library, {
     list: [],
     map: {}
   },
-  setprotoent__deps: ['$Protocols', '$writeAsciiToMemory'],
+  setprotoent__deps: ['$Protocols', '$writeAsciiToMemory', 'malloc'],
   setprotoent: function(stayopen) {
     // void setprotoent(int stayopen);
 

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -804,6 +804,7 @@ var LibraryBrowser = {
   },
 
   emscripten_run_preload_plugins_data__proxy: 'sync',
+  emscripten_run_preload_plugins_data__deps: ['malloc'],
   emscripten_run_preload_plugins_data__sig: 'viiiiii',
   emscripten_run_preload_plugins_data: function(data, size, suffix, arg, onload, onerror) {
     {{{ runtimeKeepalivePush() }}}
@@ -1355,7 +1356,7 @@ var LibraryBrowser = {
     return info.awaited;
   },
 
-  emscripten_get_preloaded_image_data__deps: ['$PATH_FS'],
+  emscripten_get_preloaded_image_data__deps: ['$PATH_FS', 'malloc'],
   emscripten_get_preloaded_image_data__proxy: 'sync',
   emscripten_get_preloaded_image_data__sig: 'iiii',
   emscripten_get_preloaded_image_data: function(path, w, h) {

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2325,7 +2325,7 @@ var LibraryHTML5 = {
 
   $battery: function() { return navigator.battery || navigator.mozBattery || navigator.webkitBattery; },
 
-  $registerBatteryEventCallback__deps: ['$JSEvents', '$fillBatteryEventData', '$battery', '$findEventTarget'],
+  $registerBatteryEventCallback__deps: ['$JSEvents', '$fillBatteryEventData', '$battery', '$findEventTarget', 'malloc'],
   $registerBatteryEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -2359,7 +2359,7 @@ var LibraryHTML5 = {
 
   emscripten_set_batterychargingchange_callback_on_thread__proxy: 'sync',
   emscripten_set_batterychargingchange_callback_on_thread__sig: 'iii',
-  emscripten_set_batterychargingchange_callback_on_thread__deps: ['$registerBatteryEventCallback', '$battery'],
+  emscripten_set_batterychargingchange_callback_on_thread__deps: ['$registerBatteryEventCallback', '$battery', 'malloc'],
   emscripten_set_batterychargingchange_callback_on_thread: function(userData, callbackfunc, targetThread) {
     if (!battery()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}}; 
     registerBatteryEventCallback(battery(), userData, true, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_BATTERYCHARGINGCHANGE') }}}, "chargingchange", targetThread);
@@ -2368,7 +2368,7 @@ var LibraryHTML5 = {
 
   emscripten_set_batterylevelchange_callback_on_thread__proxy: 'sync',
   emscripten_set_batterylevelchange_callback_on_thread__sig: 'iii',
-  emscripten_set_batterylevelchange_callback_on_thread__deps: ['$registerBatteryEventCallback', '$battery'],
+  emscripten_set_batterylevelchange_callback_on_thread__deps: ['$registerBatteryEventCallback', '$battery', 'malloc'],
   emscripten_set_batterylevelchange_callback_on_thread: function(userData, callbackfunc, targetThread) {
     if (!battery()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}}; 
     registerBatteryEventCallback(battery(), userData, true, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_BATTERYLEVELCHANGE') }}}, "levelchange", targetThread);

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1348,7 +1348,7 @@ var LibrarySDL = {
     return SDL.version;
   },
 
-  SDL_Init__deps: ['$zeroMemory'],
+  SDL_Init__deps: ['$zeroMemory', 'malloc', 'free', 'memcpy'],
   SDL_Init__proxy: 'sync',
   SDL_Init__sig: 'ii',
   SDL_Init__docs: '/** @param{number=} initFlags */', 
@@ -1846,15 +1846,18 @@ var LibrarySDL = {
   SDL_SetError: function() {},
 
   SDL_malloc__sig: 'ii',
+  SDL_malloc__deps: ['malloc'],
   SDL_malloc: function(size) {
     return _malloc(size);
   },
 
   SDL_free__sig: 'vi',
+  SDL_free__deps: ['free'],
   SDL_free: function(ptr) {
     _free(ptr);
   },
 
+  SDL_CreateRGBSurface__deps: ['malloc', 'free'],
   SDL_CreateRGBSurface__proxy: 'sync',
   SDL_CreateRGBSurface__sig: 'iiiiiiiii',
   SDL_CreateRGBSurface: function(flags, width, height, depth, rmask, gmask, bmask, amask) {
@@ -2067,6 +2070,7 @@ var LibrarySDL = {
 
   SDL_PushEvent__proxy: 'sync',
   SDL_PushEvent__sig: 'ii',
+  SDL_PushEvent__deps: ['malloc'],
   SDL_PushEvent: function(ptr) {
     var copy = _malloc({{{ C_STRUCTS.SDL_KeyboardEvent.__size__ }}});
     _memcpy(copy, ptr, {{{ C_STRUCTS.SDL_KeyboardEvent.__size__ }}});
@@ -2117,6 +2121,7 @@ var LibrarySDL = {
   // An Emscripten-specific extension to SDL: Some browser APIs require that they are called from within an event handler function.
   // Allow recording a callback that will be called for each received event.
   emscripten_SDL_SetEventHandler__proxy: 'sync',
+  emscripten_SDL_SetEventHandler__deps: ['malloc'],
   emscripten_SDL_SetEventHandler__sig: 'vii',
   emscripten_SDL_SetEventHandler: function(handler, userdata) {
     SDL.eventHandler = handler;
@@ -2245,7 +2250,7 @@ var LibrarySDL = {
     return flags; // We support JPG, PNG, TIF because browsers do
   },
 
-  IMG_Load_RW__deps: ['SDL_LockSurface', 'SDL_FreeRW', '$PATH_FS'],
+  IMG_Load_RW__deps: ['SDL_LockSurface', 'SDL_FreeRW', '$PATH_FS', 'malloc'],
   IMG_Load_RW__proxy: 'sync',
   IMG_Load_RW__sig: 'iii',
   IMG_Load_RW: function(rwopsID, freeSrc) {
@@ -2413,7 +2418,7 @@ var LibrarySDL = {
 
   // SDL_Audio
 
-  SDL_OpenAudio__deps: ['$autoResumeAudioContext', '$safeSetTimeout'],
+  SDL_OpenAudio__deps: ['$autoResumeAudioContext', '$safeSetTimeout', 'malloc'],
   SDL_OpenAudio__proxy: 'sync',
   SDL_OpenAudio__sig: 'iii',
   SDL_OpenAudio: function(desired, obtained) {

--- a/src/library_uuid.js
+++ b/src/library_uuid.js
@@ -24,6 +24,7 @@ mergeInto(LibraryManager.library, {
   },
 
   // Copies the 'compact' UUID variable from src to dst.
+  uuid_copy__deps: ['memcpy'],
   uuid_copy: function(dst, src) {
     // void uuid_copy(uuid_t dst, const uuid_t src);
     _memcpy(dst, src, 16);

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1851,7 +1851,7 @@ var LibraryWebGPU = {
 
   // In webgpu.h offset and size are passed in as size_t.
   // And library_webgpu assumes that size_t is always 32bit in emscripten.
-  wgpuBufferGetConstMappedRange__deps: ['$warnOnce'],
+  wgpuBufferGetConstMappedRange__deps: ['$warnOnce', 'malloc', 'free'],
   wgpuBufferGetConstMappedRange: function(bufferId, offset, size) {
     var bufferWrapper = WebGPU.mgrBuffer.objects[bufferId];
     {{{ gpu.makeCheckDefined('bufferWrapper') }}}
@@ -1882,7 +1882,7 @@ var LibraryWebGPU = {
 
   // In webgpu.h offset and size are passed in as size_t.
   // And library_webgpu assumes that size_t is always 32bit in emscripten.
-  wgpuBufferGetMappedRange__deps: ['$warnOnce'],
+  wgpuBufferGetMappedRange__deps: ['$warnOnce', 'malloc', 'free'],
   wgpuBufferGetMappedRange: function(bufferId, offset, size) {
     var bufferWrapper = WebGPU.mgrBuffer.objects[bufferId];
     {{{ gpu.makeCheckDefined('bufferWrapper') }}}

--- a/tools/building.py
+++ b/tools/building.py
@@ -148,7 +148,7 @@ def link_to_object(args, target):
 
 def lld_flags_for_executable(external_symbols):
   cmd = []
-  if external_symbols:
+  if settings.ERROR_ON_UNDEFINED_SYMBOLS:
     undefs = shared.get_temp_files().get('.undefined').name
     utils.write_file(undefs, '\n'.join(external_symbols))
     cmd.append('--allow-undefined-file=%s' % undefs)
@@ -176,9 +176,8 @@ def lld_flags_for_executable(external_symbols):
   # Strip the leading underscores
   c_exports = [demangle_c_symbol_name(e) for e in c_exports]
   c_exports += settings.EXPORT_IF_DEFINED
-  if external_symbols:
-    # Filter out symbols external/JS symbols
-    c_exports = [e for e in c_exports if e not in external_symbols]
+  # Filter out symbols external/JS symbols
+  c_exports = [e for e in c_exports if e not in external_symbols]
   for export in c_exports:
     cmd.append('--export-if-defined=' + export)
 

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -53,15 +53,10 @@ from tools.settings import settings
 _deps_info = {
   'alarm': ['_emscripten_timeout'],
   'setitimer': ['_emscripten_timeout'],
-  'Mix_LoadWAV_RW': ['fileno'],
-  'SDL_CreateRGBSurface': ['malloc', 'free'],
   'SDL_GL_GetProcAddress': ['malloc'],
-  'SDL_Init': ['malloc', 'free', 'memcpy'],
   'SDL_LockSurface': ['malloc', 'free'],
   'SDL_OpenAudio': ['malloc', 'free'],
   'SDL_PushEvent': ['malloc', 'free'],
-  'SDL_free': ['free'],
-  'SDL_malloc': ['malloc', 'free'],
   '_embind_register_class': ['free'],
   '_embind_register_enum_value': ['free'],
   '_embind_register_function': ['free'],
@@ -86,8 +81,6 @@ _deps_info = {
   'emscripten_async_wget_data': ['malloc', 'free'],
   'emscripten_create_worker': ['malloc', 'free'],
   'emscripten_get_compiler_setting': ['malloc'],
-  'emscripten_get_preloaded_image_data': ['malloc'],
-  'emscripten_get_preloaded_image_data_from_FILE': ['fileno'],
   'emscripten_get_window_title': ['malloc'],
   'emscripten_idb_async_load': ['malloc', 'free'],
   'emscripten_idb_load': ['malloc', 'free'],
@@ -100,10 +93,7 @@ _deps_info = {
   'emscripten_longjmp': ['malloc', 'free', 'saveSetjmp', 'setThrew'],
   'emscripten_pc_get_file': ['malloc', 'free'],
   'emscripten_pc_get_function': ['malloc', 'free'],
-  'emscripten_run_preload_plugins_data': ['malloc'],
   'emscripten_run_script_string': ['malloc', 'free'],
-  'emscripten_set_batterychargingchange_callback_on_thread': ['malloc'],
-  'emscripten_set_batterylevelchange_callback_on_thread': ['malloc'],
   'emscripten_set_blur_callback_on_thread': ['malloc'],
   'emscripten_set_click_callback_on_thread': ['malloc'],
   'emscripten_set_dblclick_callback_on_thread': ['malloc'],
@@ -176,17 +166,19 @@ _deps_info = {
   # directly include invokes in deps_info.py, so we list it as a setjmp's
   # dependency.
   'setjmp': ['malloc', 'free', 'saveSetjmp', 'setThrew'],
-  'setprotoent': ['malloc'],
   'syslog': ['malloc', 'ntohs', 'htons'],
   'vsyslog': ['malloc', 'ntohs', 'htons'],
   'timegm': ['malloc'],
   'tzset': ['malloc'],
-  'uuid_compare': ['memcmp'],
-  'uuid_copy': ['memcpy'],
-  'wgpuBufferGetMappedRange': ['malloc', 'free'],
-  'wgpuBufferGetConstMappedRange': ['malloc', 'free'],
   'emscripten_glGetString': ['malloc'],
 }
+
+
+def append_deps_info(js_symbol_deps):
+  for key, value in js_symbol_deps.items():
+    if value:
+      _deps_info.setdefault(key, [])
+      _deps_info[key] += value
 
 
 def get_deps_info():


### PR DESCRIPTION
Now that LLD_REPORT_UNDEFINED is always on, we can depend on JS library processing before link time.  Extend the existing symbol list to be a list of symbols + native dependencies.

This way we can begin to move reverse dependencies out of deps_info.py and potentially one day completely remove that file.  For now it is still needed because indirect dependencies can't be specified in the JS library code yet.

Replaces (and inspired by): #15982