### PR TITLE
Remove IN_TEST_HARNESS setting

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -48,19 +48,6 @@ var LibraryEmbind = {
     Module['getLiveInheritedInstances'] = getLiveInheritedInstances;
     Module['flushPendingDeletes'] = flushPendingDeletes;
     Module['setDelayFunction'] = setDelayFunction;
-#if IN_TEST_HARNESS
-#if ASSERTIONS
-    Module['ASSERTIONS'] = true;
-#endif
-#if DYNAMIC_EXECUTION
-    // Without dynamic execution, dynamically created functions will have no
-    // names. This lets the test suite know that.
-    Module['DYNAMIC_EXECUTION'] = true;
-#endif
-#if EMBIND_STD_STRING_IS_UTF8
-    Module['EMBIND_STD_STRING_IS_UTF8'] = true;
-#endif
-#endif
   },
 
   $throwInternalError__deps: ['$InternalError'],

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -901,7 +901,7 @@ var LibraryPThread = {
 
   emscripten_check_blocking_allowed__deps: ['$warnOnce'],
   emscripten_check_blocking_allowed: function() {
-#if ASSERTIONS || IN_TEST_HARNESS || !MINIMAL_RUNTIME || !ALLOW_BLOCKING_ON_MAIN_THREAD
+#if ASSERTIONS || !MINIMAL_RUNTIME || !ALLOW_BLOCKING_ON_MAIN_THREAD
 #if ENVIRONMENT_MAY_BE_NODE
     if (ENVIRONMENT_IS_NODE) return;
 #endif

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -32,14 +32,6 @@ function run() {
 
 #endif
 
-#if IN_TEST_HARNESS && hasExportedSymbol('flush')
-  // flush any stdio streams for test harness, since there are existing
-  // tests that depend on this behavior.
-  // For production use, instead print full lines to avoid this kind of lazy
-  // behavior.
-  _fflush();
-#endif
-
 #if EXIT_RUNTIME
 
 #if ASSERTIONS

--- a/src/settings.js
+++ b/src/settings.js
@@ -1520,10 +1520,6 @@ var SDL2_MIXER_FORMATS = ["ogg"];
 // [compile+link]
 var USE_SQLITE3 = false;
 
-// If true, the current build is performed for the Emscripten test harness.
-// [other]
-var IN_TEST_HARNESS = false;
-
 // If 1, target compiling a shared Wasm Memory.
 // [compile+link] - affects user code at compile and system libraries at link.
 var SHARED_MEMORY = false;

--- a/test/common.py
+++ b/test/common.py
@@ -1826,7 +1826,6 @@ class BrowserCore(RunnerCore):
     # use REPORT_RESULT, and also adds a cpp file to be compiled alongside the testcase, which
     # contains the implementation of REPORT_RESULT (we can't just include that implementation in
     # the header as there may be multiple files being compiled here).
-    args += ['-sIN_TEST_HARNESS']
     if reporting != Reporting.NONE:
       # For basic reporting we inject JS helper funtions to report result back to server.
       args += ['-DEMTEST_PORT_NUMBER=%d' % self.port,

--- a/test/embind/helpers.js
+++ b/test/embind/helpers.js
@@ -1,0 +1,5 @@
+mergeInto(LibraryManager.library, {
+  $ASSERTIONS: Boolean({{{ ASSERTIONS }}}),
+  $DYNAMIC_EXECUTION: Boolean({{{ DYNAMIC_EXECUTION }}}),
+  $EMBIND_STD_STRING_IS_UTF8: Boolean({{{ EMBIND_STD_STRING_IS_UTF8 }}}),
+});

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4059,7 +4059,7 @@ Module["preRun"].push(function () {
 
     # Test that it is possible to define "Module.locateFile" string to locate where worker.js will be loaded from.
     create_file('shell.html', read_file(path_from_root('src/shell.html')).replace('var Module = {', 'var Module = { locateFile: function (path, prefix) {if (path.endsWith(".wasm")) {return prefix + path;} else {return "cdn/" + path;}}, '))
-    self.compile_btest(['main.cpp', '--shell-file', 'shell.html', '-sWASM=0', '-sIN_TEST_HARNESS', '-sUSE_PTHREADS', '-sPTHREAD_POOL_SIZE', '-o', 'test.html'], reporting=Reporting.JS_ONLY)
+    self.compile_btest(['main.cpp', '--shell-file', 'shell.html', '-sWASM=0', '-sUSE_PTHREADS', '-sPTHREAD_POOL_SIZE', '-o', 'test.html'], reporting=Reporting.JS_ONLY)
     shutil.move('test.worker.js', Path('cdn/test.worker.js'))
     if os.path.exists('test.html.mem'):
       shutil.copyfile('test.html.mem', Path('cdn/test.html.mem'))
@@ -4067,7 +4067,7 @@ Module["preRun"].push(function () {
 
     # Test that it is possible to define "Module.locateFile(foo)" function to locate where worker.js will be loaded from.
     create_file('shell2.html', read_file(path_from_root('src/shell.html')).replace('var Module = {', 'var Module = { locateFile: function(filename) { if (filename == "test.worker.js") return "cdn/test.worker.js"; else return filename; }, '))
-    self.compile_btest(['main.cpp', '--shell-file', 'shell2.html', '-sWASM=0', '-sIN_TEST_HARNESS', '-sUSE_PTHREADS', '-sPTHREAD_POOL_SIZE', '-o', 'test2.html'], reporting=Reporting.JS_ONLY)
+    self.compile_btest(['main.cpp', '--shell-file', 'shell2.html', '-sWASM=0', '-sUSE_PTHREADS', '-sPTHREAD_POOL_SIZE', '-o', 'test2.html'], reporting=Reporting.JS_ONLY)
     delete_file('test.worker.js')
     self.run_browser('test2.html', '/report_result?exit:0')
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2760,11 +2760,13 @@ int f() {
         [EMXX, test_file('embind/embind_test.cpp'),
          '--pre-js', test_file('embind/test.pre.js'),
          '--post-js', test_file('embind/test.post.js'),
+         '--js-library', test_file('embind/helpers.js'),
          '-sWASM_ASYNC_COMPILATION=0',
          # This test uses a `CustomSmartPtr` class which has 1MB of data embedded in
          # it which means we need more stack space than normal.
          '-sSTACK_SIZE=2MB',
-         '-sIN_TEST_HARNESS'] + args)
+         '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$EMBIND_STD_STRING_IS_UTF8,$DYNAMIC_EXECUTION,$ASSERTIONS',
+         '-sEXPORTED_FUNCTIONS=EMBIND_STD_STRING_IS_UTF8,DYNAMIC_EXECUTION,ASSERTIONS'] + args)
 
       if '-sDYNAMIC_EXECUTION=0' in args:
         js_binary_str = read_file('a.out.js')


### PR DESCRIPTION
This was set my some unit tests but not all, and has a set of disparate effects on the generated code.

Better to avoid having the test hardness be able have these kinds of special privileges, and it turns out they could all be implemented in other ways, or were not actually needed.