### PR TITLE
Don't run wasm64_v8 tests suite as part of CI. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -536,9 +536,6 @@ jobs:
       - run: rm -rf $HOME/.jsvu
       - install-v8
       - run-tests:
-          title: "wasm64_v8"
-          test_targets: "wasm64_v8"
-      - run-tests:
           title: "wasm64l"
           test_targets: "wasm64l"
       - install-node-canary


### PR DESCRIPTION
Keep the test suite around in case its useful in the future, but in general I've moved to testing under node canary.