### PR TITLE
Deprecate unused MEM_INIT_METHOD setting

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -389,9 +389,9 @@ def minify_whitespace():
   return settings.OPT_LEVEL >= 2 and settings.DEBUG_LEVEL == 0
 
 
-def embed_memfile():
+def embed_memfile(options):
   return (settings.SINGLE_FILE or
-          (settings.WASM2JS and settings.MEM_INIT_METHOD == 0 and
+          (settings.WASM2JS and not options.memory_init_file and
            (not settings.MAIN_MODULE and
             not settings.SIDE_MODULE and
             not settings.GENERATE_SOURCE_MAP)))
@@ -2569,14 +2569,9 @@ def phase_linker_setup(options, state, newargs):
   if options.use_closure_compiler == 2 and not settings.WASM2JS:
     exit_with_error('closure compiler mode 2 assumes the code is asm.js, so not meaningful for wasm')
 
-  if 'MEM_INIT_METHOD' in user_settings:
-    exit_with_error('MEM_INIT_METHOD is not supported in wasm. Memory will be embedded in the wasm binary if threads are not used, and included in a separate file if threads are used.')
-
   if settings.WASM2JS:
     if options.memory_init_file is None:
       options.memory_init_file = settings.OPT_LEVEL >= 2
-    if options.memory_init_file:
-      settings.MEM_INIT_METHOD = 1
     settings.MAYBE_WASM2JS = 1
     # when using wasm2js, if the memory segments are in the wasm then they
     # end up converted by wasm2js into base64 encoded JS. alternatively, we
@@ -2586,11 +2581,6 @@ def phase_linker_setup(options, state, newargs):
     # shared memory builds we must keep the memory segments in the wasm as
     # they will be passive segments which the .mem format cannot handle.
     settings.MEM_INIT_IN_WASM = not options.memory_init_file or settings.SINGLE_FILE or settings.SHARED_MEMORY
-  else:
-    # wasm includes the mem init in the wasm binary. The exception is
-    # wasm2js, which behaves more like js.
-    # TODO(sbc): Error out here in --memory-init-file used.
-    settings.MEM_INIT_IN_WASM = True
 
   if (
       settings.MAYBE_WASM2JS or
@@ -3115,7 +3105,7 @@ def phase_post_link(options, state, in_wasm, wasm_target, target):
   else:
     memfile = shared.replace_or_append_suffix(target, '.mem')
 
-  phase_emscript(in_wasm, wasm_target, memfile)
+  phase_emscript(options, in_wasm, wasm_target, memfile)
 
   if options.js_transform:
     phase_source_transforms(options)
@@ -3133,11 +3123,11 @@ def phase_post_link(options, state, in_wasm, wasm_target, target):
 
 
 @ToolchainProfiler.profile_block('emscript')
-def phase_emscript(in_wasm, wasm_target, memfile):
+def phase_emscript(options, in_wasm, wasm_target, memfile):
   # Emscripten
   logger.debug('emscript')
 
-  if embed_memfile():
+  if embed_memfile(options):
     settings.SUPPORT_BASE64_EMBEDDING = 1
     # _read in shell.js depends on intArrayToString when SUPPORT_BASE64_EMBEDDING is set
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.append('$intArrayToString')
@@ -3274,7 +3264,7 @@ def phase_final_emitting(options, state, target, wasm_target, memfile):
   elif settings.PROXY_TO_WORKER:
     generate_worker_js(target, js_target, target_basename)
 
-  if embed_memfile() and memfile:
+  if embed_memfile(options) and memfile:
     delete_file(memfile)
 
   if settings.SPLIT_MODULE:
@@ -3527,6 +3517,8 @@ def parse_args(newargs):
       ports.show_ports()
       should_exit = True
     elif check_arg('--memory-init-file'):
+      # This flag is ignored unless targetting wasm2js.
+      # TODO(sbc): Error out if used without wasm2js.
       options.memory_init_file = int(consume_arg())
     elif check_flag('--proxy-to-worker'):
       settings_changes.append('PROXY_TO_WORKER=1')

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -219,7 +219,7 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
   updateMemoryViews();
 #endif
 
-#if MEM_INIT_METHOD == 1 && !MEM_INIT_IN_WASM && !SINGLE_FILE
+#if !MEM_INIT_IN_WASM && !SINGLE_FILE
 #if ASSERTIONS
   if (!Module['mem']) throw 'Must load memory initializer as an ArrayBuffer in to variable Module.mem before adding compiled output .js script to the DOM';
 #endif

--- a/src/settings.js
+++ b/src/settings.js
@@ -91,14 +91,6 @@ var INVOKE_RUN = true;
 // [link]
 var EXIT_RUNTIME = false;
 
-// How to represent the initial memory content.
-// 0: embed a base64 string literal representing the initial memory data
-// 1: create a *.mem file containing the binary data of the initial memory;
-
-//    use the --memory-init-file command line switch to select this method
-// [link]
-var MEM_INIT_METHOD = 0;
-
 // The total stack size. There is no way to enlarge the stack, so this
 // value must be large enough for the program's requirements. If
 // assertions are on, we will assert on not exceeding this, otherwise,
@@ -2185,4 +2177,5 @@ var LEGACY_SETTINGS = [
   ['EMIT_EMSCRIPTEN_METADATA', [0], 'No longer supported'],
   ['SHELL_FILE', [''], 'No longer supported'],
   ['LLD_REPORT_UNDEFINED', [1], 'Disabling is no longer supported'],
+  ['MEM_INIT_METHOD', [0], 'No longer supported'],
 ];

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -143,7 +143,10 @@ var AUDIO_WORKLET_FILE = '';
 // Base URL the source mapfile, if relevant
 var SOURCE_MAP_BASE = '';
 
-var MEM_INIT_IN_WASM = false;
+// When this is false we use an external memory init file
+// See --memory-init-file.  When not using wasm2js this flag is ignored, and
+// this setting will always be true.
+var MEM_INIT_IN_WASM = true;
 
 // If set to 1, src/base64Utils.js will be included in the bundle.
 // This is set internally when needed (SINGLE_FILE)

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -94,7 +94,7 @@ if (ENVIRONMENT_IS_NODE) {
   Module['wasm'] = fs.readFileSync(__dirname + '/{{{ TARGET_BASENAME }}}.wasm');
 #endif
 #endif
-#if MEM_INIT_METHOD == 1 && !MEM_INIT_IN_WASM
+#if !MEM_INIT_IN_WASM
   Module['mem'] = fs.readFileSync(__dirname + '/{{{ TARGET_BASENAME }}}.mem');
 #endif
 }
@@ -110,7 +110,7 @@ if (ENVIRONMENT_IS_SHELL) {
   Module['wasm'] = read('{{{ TARGET_BASENAME }}}.wasm', 'binary');
 #endif
 #endif
-#if MEM_INIT_METHOD == 1 && !MEM_INIT_IN_WASM
+#if !MEM_INIT_IN_WASM
   Module['mem'] = read('{{{ TARGET_BASENAME }}}.mem', 'binary');
 #endif
 }

--- a/tools/minimal_runtime_shell.py
+++ b/tools/minimal_runtime_shell.py
@@ -46,7 +46,7 @@ def generate_minimal_runtime_load_statement(target_basename):
   files_to_load = ["script('%s')" % (target_basename + '.js')] # Main JS file always in first entry
 
   # Download separate memory initializer file .mem
-  if settings.MEM_INIT_METHOD == 1 and not settings.MEM_INIT_IN_WASM:
+  if not settings.MEM_INIT_IN_WASM:
     if settings.MODULARIZE:
       modularize_imports += ['mem: r[%d]' % len(files_to_load)]
     else:


### PR DESCRIPTION
We were already aborting if the user ever specified this on the command line.  Because it was already effectively banned I'm not sure we need to mention this in the changelog.