### PR TITLE
Add utf8proc port

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -1520,6 +1520,10 @@ var SDL2_MIXER_FORMATS = ["ogg"];
 // [compile+link]
 var USE_SQLITE3 = false;
 
+// 1 = use utf8proc from emscripten-ports
+// [compile+link]
+var USE_UTF8PROC = false;
+
 // If 1, target compiling a shared Wasm Memory.
 // [compile+link] - affects user code at compile and system libraries at link.
 var SHARED_MEMORY = false;

--- a/tools/ports/utf8proc.py
+++ b/tools/ports/utf8proc.py
@@ -1,0 +1,49 @@
+# Copyright 2014 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+import os
+import shutil
+import logging
+
+VERSION = '2.8.0'
+HASH    = '10b99739167bbcf3fec55446f0c54b4ddf04ad1403b52aeca26de937f95615d6f1ea880b031a4457559c345ea3c0bcff9af87f27b9f8cea98dc5444e8146962a'
+PROJECT = 'utf8proc'
+
+def needed(settings):
+  return settings.USE_UTF8PROC
+
+
+def get(ports, settings, shared):
+    ports.fetch_project(
+        PROJECT,
+        f'https://github.com/JuliaStrings/utf8proc/archive/refs/tags/v{VERSION}.zip',
+        sha512hash=HASH)
+
+    def create(final):
+        logging.info(f'building port: {PROJECT}')
+        ports.clear_project_build(PROJECT)
+        
+        source_path = os.path.join(ports.get_dir(), PROJECT, f'{PROJECT}-{VERSION}')
+        dest_path = os.path.join(ports.get_build_dir(), PROJECT)
+        
+        shutil.rmtree(dest_path, ignore_errors=True)
+        shutil.copytree(source_path, dest_path)
+        
+        ports.install_headers(dest_path)
+        ports.build_port(dest_path, final, PROJECT, srcs=['utf8proc.c'])
+    
+    return [shared.cache.get_lib(f'lib{PROJECT}.a', create, what='port')]
+
+
+def clear(ports, settings, shared):
+    shared.cache.erase_lib(f'lib{PROJECT}.a')
+
+
+def process_args(ports):
+    return []
+
+
+def show():
+    return f'{PROJECT} (USE_UTF8PROC=1; MIT license)'

--- a/tools/ports/utf8proc.py
+++ b/tools/ports/utf8proc.py
@@ -8,8 +8,9 @@ import shutil
 import logging
 
 VERSION = '2.8.0'
-HASH    = '10b99739167bbcf3fec55446f0c54b4ddf04ad1403b52aeca26de937f95615d6f1ea880b031a4457559c345ea3c0bcff9af87f27b9f8cea98dc5444e8146962a'
+HASH = '10b99739167bbcf3fec55446f0c54b4ddf04ad1403b52aeca26de937f95615d6f1ea880b031a4457559c345ea3c0bcff9af87f27b9f8cea98dc5444e8146962a'
 PROJECT = 'utf8proc'
+
 
 def needed(settings):
   return settings.USE_UTF8PROC
@@ -24,16 +25,16 @@ def get(ports, settings, shared):
     def create(final):
         logging.info(f'building port: {PROJECT}')
         ports.clear_project_build(PROJECT)
-        
+
         source_path = os.path.join(ports.get_dir(), PROJECT, f'{PROJECT}-{VERSION}')
         dest_path = os.path.join(ports.get_build_dir(), PROJECT)
-        
+
         shutil.rmtree(dest_path, ignore_errors=True)
         shutil.copytree(source_path, dest_path)
-        
+
         ports.install_headers(dest_path)
         ports.build_port(dest_path, final, PROJECT, srcs=['utf8proc.c'])
-    
+
     return [shared.cache.get_lib(f'lib{PROJECT}.a', create, what='port')]
 
 

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -50,6 +50,7 @@ PORTS_SETTINGS = {
     'SDL2_MIXER_FORMATS',
     'SDL2_IMAGE_FORMATS',
     'USE_SQLITE3',
+    'USE_UTF8PROC',
 }
 
 # Subset of settings that apply at compile time.


### PR DESCRIPTION
This adds [utf8proc](https://github.com/JuliaStrings/utf8proc), a lightweight MIT-licensed C library for processing Unicode.

Please note that the hash used for the zipped repository file was taken from the "unexpected hash" error message emitted by em++ when I attempted to build a test project using `-s USE_UTF8PROC`. When following the normal directions of piping `curl` to `shasum -a 512`, I get a different result. I'm guessing this is an issue with the hash method used by emscripten (e.g., it's not hashing the bytes in a way that exactly reproduces `shasum`), but let me know if I should be doing something different. (Can others reproduce the included hash in the terminal?)