### PR TITLE
Add dladdr to list of dummy dlfnc symbols

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -247,6 +247,7 @@ var LibraryDylink = {
   dlopen__deps: [function() { error(dlopenMissingError); }],
   _emscripten_dlopen__deps: [function() { error(dlopenMissingError); }],
   __dlsym__deps: [function() { error(dlopenMissingError); }],
+  dladdr__deps: [function() { error(dlopenMissingError); }],
 #else
   $dlopenMissingError: `= ${dlopenMissingError}`,
   _dlopen_js__deps: ['$dlopenMissingError'],
@@ -256,6 +257,7 @@ var LibraryDylink = {
   dlopen__deps: ['$dlopenMissingError'],
   _emscripten_dlopen__deps: ['$dlopenMissingError'],
   __dlsym__deps: ['$dlopenMissingError'],
+  dladdr__deps: ['$dlopenMissingError'],
 #endif
   _dlopen_js: function(handle) {
     abort(dlopenMissingError);
@@ -276,6 +278,9 @@ var LibraryDylink = {
     abort(dlopenMissingError);
   },
   __dlsym: function(handle, symbol) {
+    abort(dlopenMissingError);
+  },
+  dladdr: function() {
     abort(dlopenMissingError);
   },
 #else // MAIN_MODULE != 0

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12081,7 +12081,7 @@ void foo() {}
       self.assertNotContained('warning: unsupported syscall', err)
 
   def test_unimplemented_syscalls_dlopen(self):
-    cmd = [EMCC, test_file('other/test_dlopen_blocking.c'), '-sASSERTIONS']
+    cmd = [EMCC, test_file('other/test_dlopen_blocking.c')]
     self.run_process(cmd)
     err = self.run_js('a.out.js', assert_returncode=NON_ZERO)
     self.assertContained('Aborted(To use dlopen, you need enable dynamic linking, see https://github.com/emscripten-core/emscripten/wiki/Linking)', err)
@@ -12091,6 +12091,20 @@ void foo() {}
     cmd += ['-sALLOW_UNIMPLEMENTED_SYSCALLS=0']
     err = self.expect_fail(cmd)
     self.assertContained('To use dlopen, you need enable dynamic linking, see https://github.com/emscripten-core/emscripten/wiki/Linking', err)
+
+  def test_unimplemented_syscalls_dladdr(self):
+    create_file('main.c', '''
+    #include <dlfcn.h>
+
+    int main() {
+      dladdr(0, 0);
+      return 0;
+    }
+    ''')
+
+    self.run_process([EMCC, 'main.c'])
+    err = self.run_js('a.out.js', assert_returncode=NON_ZERO)
+    self.assertContained('Aborted(To use dlopen, you need enable dynamic linking, see https://github.com/emscripten-core/emscripten/wiki/Linking)', err)
 
   @requires_v8
   def test_missing_shell_support(self):


### PR DESCRIPTION
This is needed as of #18638 since dynlink.c is not longer included in the build when MAIN_MODULE is not set.

Fixes: #1195