### PR TITLE
cmake: Fix references to OSX / OS X. NFC

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -6,7 +6,7 @@
 # line parameters:
 # cmake -DCMAKE_TOOLCHAIN_FILE=<EmscriptenRoot>/cmake/Modules/Platform/Emscripten.cmake
 #       -DCMAKE_BUILD_TYPE=<Debug|RelWithDebInfo|Release|MinSizeRel>
-#       -G "Unix Makefiles" (Linux and OSX)
+#       -G "Unix Makefiles" (Linux and macOS)
 #       -G "MinGW Makefiles" (Windows)
 #       <path/to/CMakeLists.txt> # Note, pass in here ONLY the path to the file, not the filename 'CMakeLists.txt' itself.
 


### PR DESCRIPTION
Use macOS instead.