### PR TITLE
Fix missing _emscripten_timeout deps

### DIFF
--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -137,7 +137,6 @@ _deps_info = {
   'emscripten_websocket_set_onmessage_callback_on_thread': ['malloc', 'free'],
   'emscripten_websocket_set_onopen_callback_on_thread': ['malloc'],
   'emscripten_wget_data': ['malloc', 'free'],
-  'emscripten_yield': ['_emscripten_timeout'],
   'getaddrinfo': ['malloc', 'htonl', 'htons', 'ntohs'],
   'gethostbyaddr': ['malloc', 'htons'],
   'gethostbyname': ['malloc', 'htons'],

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -52,6 +52,7 @@ from tools.settings import settings
 
 _deps_info = {
   'alarm': ['_emscripten_timeout'],
+  'sched_yield': ['_emscripten_timeout'],
   'setitimer': ['_emscripten_timeout'],
   'SDL_GL_GetProcAddress': ['malloc'],
   'SDL_LockSurface': ['malloc', 'free'],
@@ -125,6 +126,7 @@ _deps_info = {
   'emscripten_set_touchstart_callback_on_thread': ['malloc'],
   'emscripten_set_visibilitychange_callback_on_thread': ['malloc'],
   'emscripten_set_wheel_callback_on_thread': ['malloc'],
+  'emscripten_thread_sleep': ['_emscripten_timeout'],
   'emscripten_webgl_get_parameter_utf8': ['malloc'],
   'emscripten_webgl_get_program_info_log_utf8': ['malloc'],
   'emscripten_webgl_get_shader_info_log_utf8': ['malloc'],
@@ -135,6 +137,7 @@ _deps_info = {
   'emscripten_websocket_set_onmessage_callback_on_thread': ['malloc', 'free'],
   'emscripten_websocket_set_onopen_callback_on_thread': ['malloc'],
   'emscripten_wget_data': ['malloc', 'free'],
+  'emscripten_yield': ['_emscripten_timeout'],
   'getaddrinfo': ['malloc', 'htonl', 'htons', 'ntohs'],
   'gethostbyaddr': ['malloc', 'htons'],
   'gethostbyname': ['malloc', 'htons'],


### PR DESCRIPTION
This fixes what I believe to be a regression in aef3f83323bb1e9eed5b6ca9356469419ac30a25 (#18416) as we have been seeing the following error message:
```
error: undefined symbol: _emscripten_timeout (referenced by _setitimer_js__deps: ['$timers','$callUserCallback','_emscripten_timeout','emscripten_get_now'], referenced by top-level compiled C/C++ code)
warning: To disable errors for undefined symbols use `-sERROR_ON_UNDEFINED_SYMBOLS=0`
warning: __emscripten_timeout may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
Error: Aborting compilation due to previous errors
```

