### PR TITLE
More nonnull directives

### DIFF
--- a/system/include/emscripten/console.h
+++ b/system/include/emscripten/console.h
@@ -25,7 +25,7 @@ void emscripten_console_error(const char *utf8String __attribute__((nonnull)));
 // See https://github.com/emscripten-core/emscripten/issues/14804
 void _emscripten_out(const char *utf8String __attribute__((nonnull)));
 void _emscripten_err(const char *utf8String __attribute__((nonnull)));
-void _emscripten_dbg(const char *utf8String);
+void _emscripten_dbg(const char *utf8String __attribute__((nonnull)));
 
 // Similar to the above functions but operate with printf-like semantics.
 void emscripten_console_logf(const char *utf8String __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
@@ -33,7 +33,7 @@ void emscripten_console_warnf(const char *utf8String __attribute__((nonnull)), .
 void emscripten_console_errorf(const char *utf8String __attribute__((nonnull)), ...)__attribute__((__format__(printf, 1, 2)));
 void _emscripten_outf(const char *utf8String __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
 void _emscripten_errf(const char *utf8String __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
-void _emscripten_dbgf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
+void _emscripten_dbgf(const char *utf8String __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -36,7 +36,8 @@ void emscripten_force_num_logical_cores(int cores);
 
 // If the given memory address contains value val, puts the calling thread to
 // sleep waiting for that address to be notified.
-int emscripten_futex_wait(volatile void/*uint32_t*/ *addr __attribute__((nonnull)), uint32_t val, double maxWaitMilliseconds);
+// Returns -EINVAL if addr is null.
+int emscripten_futex_wait(volatile void/*uint32_t*/ * _Nonnull addr, uint32_t val, double maxWaitMilliseconds);
 
 // Wakes the given number of threads waiting on a location. Pass count ==
 // INT_MAX to wake all waiters on that location.

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9361,7 +9361,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @node_pthreads
   def test_emscripten_futexes(self):
     self.set_setting('USE_PTHREADS')
-    self.emcc_args += ['-Wno-nonnull']
+    self.emcc_args += ['-Wno-nonnull'] # This test explicitly checks behavior of passing NULL to emscripten_futex_wake().
     self.do_run_in_out_file_test('core/pthread/emscripten_futexes.c')
 
   @node_pthreads


### PR DESCRIPTION
Address review in the previous landed PR, and add more nonnull directives.

Fix `emscripten_futex_wait` to use the weaker `_Nonnull` instead of `__attribute__((nonnull))`, since the implementation of `emscripten_futex_wait` does actually check if the caller passes a null, and return EINVAL in that case.