### PR TITLE
Fix void in headers

### DIFF
--- a/system/include/AL/alc.h
+++ b/system/include/AL/alc.h
@@ -61,7 +61,7 @@ extern ALCboolean alcCloseDevice(ALCdevice *device);
 extern ALCboolean alcIsExtensionPresent(ALCdevice *device, const ALCchar *extname);
 extern ALCboolean alcMakeContextCurrent(ALCcontext *context);
 extern ALCcontext *alcCreateContext(ALCdevice *device, const ALCint *attrlist);
-extern ALCcontext *alcGetCurrentContext();
+extern ALCcontext *alcGetCurrentContext(void);
 extern ALCdevice *alcCaptureOpenDevice(const ALCchar *devicename, ALCuint frequency, ALCenum format, ALCsizei buffersize);
 extern ALCdevice *alcGetContextsDevice(ALCcontext *context);
 extern ALCdevice *alcOpenDevice(const ALCchar *devicename);

--- a/system/include/emscripten/emmalloc.h
+++ b/system/include/emscripten/emmalloc.h
@@ -84,8 +84,8 @@ void *emmalloc_calloc(size_t num, size_t size);
 
 // mallinfo() returns information about current emmalloc allocation state. This function
 // is very slow, only good for debugging. Avoid calling it for "routine" diagnostics.
-struct mallinfo mallinfo();
-struct mallinfo emmalloc_mallinfo();
+struct mallinfo mallinfo(void);
+struct mallinfo emmalloc_mallinfo(void);
 
 // malloc_trim() returns unused dynamic memory back to the WebAssembly heap. Returns 1 if it
 // actually freed any memory, and 0 if not. Note: this function does not release memory back to

--- a/system/include/emscripten/eventloop.h
+++ b/system/include/emscripten/eventloop.h
@@ -26,9 +26,9 @@ void emscripten_set_immediate_loop(EM_BOOL (*cb)(void *user_data), void *user_da
 int emscripten_set_interval(void (*cb)(void *user_data) __attribute__((nonnull)), double interval_ms, void *user_data);
 void emscripten_clear_interval(int id);
 
-void emscripten_runtime_keepalive_push();
-void emscripten_runtime_keepalive_pop();
-EM_BOOL emscripten_runtime_keepalive_check();
+void emscripten_runtime_keepalive_push(void);
+void emscripten_runtime_keepalive_pop(void);
+EM_BOOL emscripten_runtime_keepalive_check(void);
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/proxying.h
+++ b/system/include/emscripten/proxying.h
@@ -27,13 +27,13 @@ extern "C" {
 typedef struct em_proxying_queue em_proxying_queue;
 
 // Create and destroy proxying queues.
-em_proxying_queue* em_proxying_queue_create();
+em_proxying_queue* em_proxying_queue_create(void);
 void em_proxying_queue_destroy(em_proxying_queue* q);
 
 // Get the queue used for proxying low-level runtime work. Work on this queue
 // may be processed at any time inside system functions, so it must be
 // nonblocking and safe to run at any time, similar to a native signal handler.
-em_proxying_queue* emscripten_proxy_get_system_queue();
+em_proxying_queue* emscripten_proxy_get_system_queue(void);
 
 // Execute all the tasks enqueued for the current thread on the given queue. New
 // tasks that are enqueued concurrently with this execution will be executed as

--- a/system/include/emscripten/trace.h
+++ b/system/include/emscripten/trace.h
@@ -68,31 +68,31 @@ void emscripten_trace_close(void);
 
 #else
 
-#define emscripten_trace_configure(collector_url, application)
-#define emscripten_trace_configure_for_google_wtf()
-#define emscripten_trace_configure_for_test()
-#define emscripten_trace_set_enabled(enabled)
-#define emscripten_trace_set_session_username(username)
-#define emscripten_trace_record_frame_start()
-#define emscripten_trace_record_frame_end()
-#define emscripten_trace_mark(message)
-#define emscripten_trace_log_message(channel, message)
-#define emscripten_trace_report_error(error)
-#define emscripten_trace_record_allocation(address, size)
-#define emscripten_trace_record_reallocation(old_address, new_address, size)
-#define emscripten_trace_record_free(address)
-#define emscripten_trace_annotate_address_type(address, type)
-#define emscripten_trace_associate_storage_size(address, size)
-#define emscripten_trace_report_memory_layout()
-#define emscripten_trace_report_off_heap_data()
-#define emscripten_trace_enter_context(name)
-#define emscripten_trace_exit_context()
-#define emscripten_trace_task_start(task_id, taskname)
-#define emscripten_trace_task_associate_data(key, value);
-#define emscripten_trace_task_suspend(explanation);
-#define emscripten_trace_task_resume(task_id, explanation);
-#define emscripten_trace_task_end();
-#define emscripten_trace_close()
+#define emscripten_trace_configure(collector_url, application) ((void)0)
+#define emscripten_trace_configure_for_google_wtf() ((void)0)
+#define emscripten_trace_configure_for_test() ((void)0)
+#define emscripten_trace_set_enabled(enabled) ((void)0)
+#define emscripten_trace_set_session_username(username) ((void)0)
+#define emscripten_trace_record_frame_start() ((void)0)
+#define emscripten_trace_record_frame_end() ((void)0)
+#define emscripten_trace_mark(message) ((void)0)
+#define emscripten_trace_log_message(channel, message) ((void)0)
+#define emscripten_trace_report_error(error) ((void)0)
+#define emscripten_trace_record_allocation(address, size) ((void)0)
+#define emscripten_trace_record_reallocation(old_address, new_address, size) ((void)0)
+#define emscripten_trace_record_free(address) ((void)0)
+#define emscripten_trace_annotate_address_type(address, type) ((void)0)
+#define emscripten_trace_associate_storage_size(address, size) ((void)0)
+#define emscripten_trace_report_memory_layout() ((void)0)
+#define emscripten_trace_report_off_heap_data() ((void)0)
+#define emscripten_trace_enter_context(name) ((void)0)
+#define emscripten_trace_exit_context() ((void)0)
+#define emscripten_trace_task_start(task_id, taskname) ((void)0)
+#define emscripten_trace_task_associate_data(key, value) ((void)0)
+#define emscripten_trace_task_suspend(explanation) ((void)0)
+#define emscripten_trace_task_resume(task_id, explanation) ((void)0)
+#define emscripten_trace_task_end() ((void)0)
+#define emscripten_trace_close() ((void)0)
 
 #endif
 

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -52,9 +52,9 @@ void _emval_decref(EM_VAL value);
 
 void _emval_run_destructors(EM_DESTRUCTORS handle);
 
-EM_VAL _emval_new_array();
+EM_VAL _emval_new_array(void);
 EM_VAL _emval_new_array_from_memory_view(EM_VAL mv);
-EM_VAL _emval_new_object();
+EM_VAL _emval_new_object(void);
 EM_VAL _emval_new_cstring(const char*);
 EM_VAL _emval_new_u8string(const char*);
 EM_VAL _emval_new_u16string(const char16_t*);


### PR DESCRIPTION
Fix C function declarations to state (void).

Fix emscripten_trace_*() no-op definition macros to behave well as statements in macro expansion.