### PR TITLE
fix: avoid repeating same result in __randname on passing same template pointer

### DIFF
--- a/system/lib/libc/musl/src/temp/__randname.c
+++ b/system/lib/libc/musl/src/temp/__randname.c
@@ -8,9 +8,10 @@ char *__randname(char *template)
 	int i;
 	struct timespec ts;
 	unsigned long r;
+	static unsigned int seed = 0;
 
 	__clock_gettime(CLOCK_REALTIME, &ts);
-	r = ts.tv_nsec*65537 ^ (uintptr_t)&ts / 16 + (uintptr_t)template;
+	r = ts.tv_nsec*65537 ^ (uintptr_t)&ts / 16 + (uintptr_t)template + seed++;
 	for (i=0; i<6; i++, r>>=5)
 		template[i] = 'A'+(r&15)+(r&16)*2;
 

--- a/system/lib/libc/musl/src/temp/__randname.c
+++ b/system/lib/libc/musl/src/temp/__randname.c
@@ -8,10 +8,14 @@ char *__randname(char *template)
 	int i;
 	struct timespec ts;
 	unsigned long r;
-	static unsigned int seed = 0;
 
 	__clock_gettime(CLOCK_REALTIME, &ts);
-	r = ts.tv_nsec*65537 ^ (uintptr_t)&ts / 16 + (uintptr_t)template + seed++;
+	r = ts.tv_nsec*65537 ^ (uintptr_t)&ts / 16 + (uintptr_t)template;
+
+	/* XXX EMSCRIPTEN: avoid repeating the same result when __clock_gettime does not change between calls. */
+	static unsigned int seed = 0;
+	r += seed++;
+
 	for (i=0; i<6; i++, r>>=5)
 		template[i] = 'A'+(r&15)+(r&16)*2;
 

--- a/system/lib/libc/musl/src/temp/__randname.c
+++ b/system/lib/libc/musl/src/temp/__randname.c
@@ -13,8 +13,8 @@ char *__randname(char *template)
 	r = ts.tv_nsec*65537 ^ (uintptr_t)&ts / 16 + (uintptr_t)template;
 
 	/* XXX EMSCRIPTEN: avoid repeating the same result when __clock_gettime does not change between calls. */
-	static unsigned int seed = 0;
-	r += seed++;
+	static unsigned int counter = 0;
+	r += counter++;
 
 	for (i=0; i<6; i++, r>>=5)
 		template[i] = 'A'+(r&15)+(r&16)*2;


### PR DESCRIPTION
Attempted to fix the issue of the same pointer possibly causing the same random path to be returned by adding a static variable to keep count, I am unsure how I could add a test for this 😅

Fixes: https://github.com/emscripten-core/emscripten/issues/18591