### PR TITLE
Do not bootstrap struct_info.json using WasmFS

### DIFF
--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -249,6 +249,12 @@ def inspect_headers(headers, cflags):
                                '-sBOOTSTRAPPING_STRUCT_INFO',
                                '-sSTRICT',
                                '-sASSERTIONS=0',
+                               # We cannot bootstrap in wasmfs mode, as we do so
+                               # using -nostdlib, but it requires malloc/free.
+                               # We don't need a filesystem when bootstrapping
+                               # anyhow, so there is no real reason to get this
+                               # working in that mode.
+                               '-sWASMFS=0',
                                # Use SINGLE_FILE so there is only a single
                                # file to cleanup.
                                '-sSINGLE_FILE']


### PR DESCRIPTION
Atm it doesn't work due to needing malloc/free, but there are
also a few other issues we'd need to fix I think. But bootstrapping
doesn't need a filesystem anyhow, so WasmFS doesn't make
sense there, so let's just disable WasmFS when doing that.

Fixes the issue noticed here:

https://github.com/emscripten-core/emscripten/issues/15976#issuecomment-1457506456