### PR TITLE
Error on `-pthreads` vs `-pthread`

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3579,6 +3579,8 @@ def parse_args(newargs):
     # Record USE_PTHREADS setting because it controls whether --shared-memory is passed to lld
     elif arg == '-pthread':
       settings_changes.append('USE_PTHREADS=1')
+    elif arg == '-pthreads':
+      exit_with_error('unrecognized command-line option ‘-pthreads’; did you mean ‘-pthread’?')
     elif arg in ('-fno-diagnostics-color', '-fdiagnostics-color=never'):
       colored_logger.disable()
       diagnostics.color_enabled = False

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13127,3 +13127,10 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
   def test_cpp_module(self):
     self.run_process([EMXX, '-std=c++20', test_file('other/hello_world.cppm'), '--precompile', '-o', 'hello_world.pcm'])
     self.do_other_test('test_cpp_module.cpp', emcc_args=['-std=c++20', '-fprebuilt-module-path=.', 'hello_world.pcm'])
+
+  def test_pthreads_flag(self):
+    # We support just the singular form of `-pthread`, like gcc
+    # Clang supports the plural form too but I think just due to historical accident:
+    # See https://github.com/llvm/llvm-project/commit/c800391fb974cdaaa62bd74435f76408c2e5ceae
+    err = self.expect_fail([EMCC, '-pthreads', '-c', test_file('hello_world.c')])
+    self.assertContained('emcc: error: unrecognized command-line option ‘-pthreads’; did you mean ‘-pthread’?', err)


### PR DESCRIPTION
This is what gcc does and since we have never supported the former anyway (using the plural version didn't set USE_PTHREADS so would not have worked, at least not at link time) this shouldn't be a breaking change.