### PR TITLE
Make RTLD_LOCAL work correctly for recursively loaded DSOs

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1140,7 +1140,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   #          C
   #
   # this test is used by both test_core and test_browser.
-  # when run under broswer it excercises how dynamic linker handles concurrency
+  # when run under browser it excercises how dynamic linker handles concurrency
   # - because B and C are loaded in parallel.
   def _test_dylink_dso_needed(self, do_run):
     create_file('liba.cpp', r'''

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6411,7 +6411,7 @@ int main() {
 
       int main() {
         void (*check) (void);
-        void* h = dlopen("libside.wasm", RTLD_NOW|RTLD_GLOBAL);
+        void* h = dlopen("libside.wasm", RTLD_NOW);
         assert(h);
         check = dlsym(h, "check_relocations");
         assert(check);


### PR DESCRIPTION
When dlopen is first called with `RTLD_LOCAL` a new local scope is created.  All symbols from the DSO being loaded and any of its transitive dependencies get added to this scrope (instead of the global scope).