### PR TITLE
Remove unused stubs from library_dylink.js. NFC

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -240,41 +240,21 @@ var LibraryDylink = {
 
 #if !MAIN_MODULE
 #if !ALLOW_UNIMPLEMENTED_SYSCALLS
-  _dlopen_js__deps: [function() { error(dlopenMissingError); }],
-  _emscripten_dlopen_js__deps: [function() { error(dlopenMissingError); }],
-  _dlsym_js__deps: [function() { error(dlopenMissingError); }],
-  _dlsym_catchup_js__deps: [function() { error(dlopenMissingError); }],
   dlopen__deps: [function() { error(dlopenMissingError); }],
-  _emscripten_dlopen__deps: [function() { error(dlopenMissingError); }],
+  emscripten_dlopen__deps: [function() { error(dlopenMissingError); }],
   __dlsym__deps: [function() { error(dlopenMissingError); }],
   dladdr__deps: [function() { error(dlopenMissingError); }],
 #else
   $dlopenMissingError: `= ${dlopenMissingError}`,
-  _dlopen_js__deps: ['$dlopenMissingError'],
-  _emscripten_dlopen_js__deps: ['$dlopenMissingError'],
-  _dlsym_js__deps: ['$dlopenMissingError'],
-  _dlsym_catchup_js__deps: ['$dlopenMissingError'],
   dlopen__deps: ['$dlopenMissingError'],
-  _emscripten_dlopen__deps: ['$dlopenMissingError'],
+  emscripten_dlopen__deps: ['$dlopenMissingError'],
   __dlsym__deps: ['$dlopenMissingError'],
   dladdr__deps: ['$dlopenMissingError'],
 #endif
-  _dlopen_js: function(handle) {
-    abort(dlopenMissingError);
-  },
-  _emscripten_dlopen_js: function(handle, onsuccess, onerror, user_data) {
-    abort(dlopenMissingError);
-  },
-  _dlsym_js: function(handle, symbol) {
-    abort(dlopenMissingError);
-  },
-  _dlsym_catchup_js: function(handle, symbolIndex) {
-    abort(dlopenMissingError);
-  },
   dlopen: function(handle) {
     abort(dlopenMissingError);
   },
-  _emscripten_dlopen: function(handle, onsuccess, onerror, user_data) {
+  emscripten_dlopen: function(handle, onsuccess, onerror, user_data) {
     abort(dlopenMissingError);
   },
   __dlsym: function(handle, symbol) {


### PR DESCRIPTION
Since #18638 its no longer possible to generated undefined references to the internal (_js-suffixed) versions of these symbols because the `dynlink.c` file is simply not compiled it.

This should really have been part of #18638.