### PR TITLE
Fix other.test_pthreads_flag on windows. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -684,6 +684,7 @@ jobs:
             other.test_emcc_print_file_name
             other.test_minimal_runtime_export_all_modularize
             other.test_pkg_config*
+            other.test_pthreads_flag
             other.test_sdl2_config"
       - upload-test-results
       # Run a single websockify-based test to ensure it works on windows.

--- a/emcc.py
+++ b/emcc.py
@@ -3594,7 +3594,7 @@ def parse_args(newargs):
       # Also set the legacy setting name, in case use JS code depends on it.
       settings.USE_PTHREADS = 1
     elif arg == '-pthreads':
-      exit_with_error('unrecognized command-line option ‘-pthreads’; did you mean ‘-pthread’?')
+      exit_with_error('unrecognized command-line option `-pthreads`; did you mean `-pthread`?')
     elif arg in ('-fno-diagnostics-color', '-fdiagnostics-color=never'):
       colored_logger.disable()
       diagnostics.color_enabled = False

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13203,4 +13203,4 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     # Clang supports the plural form too but I think just due to historical accident:
     # See https://github.com/llvm/llvm-project/commit/c800391fb974cdaaa62bd74435f76408c2e5ceae
     err = self.expect_fail([EMCC, '-pthreads', '-c', test_file('hello_world.c')])
-    self.assertContained('emcc: error: unrecognized command-line option ‘-pthreads’; did you mean ‘-pthread’?', err)
+    self.assertContained('emcc: error: unrecognized command-line option `-pthreads`; did you mean `-pthread`?', err)


### PR DESCRIPTION
I copied this error message directly from gcc output and I guess there is non-ascii char in that was causing trouble on windows.

This should fix the currently blocked emscripten roller.