### PR TITLE
Fix new clang warning in library_wasm_worker.c. NFC

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1270,7 +1270,11 @@ class libwasm_workers(MTLibrary):
 
   def get_cflags(self):
     cflags = get_base_cflags() + ['-D_DEBUG' if self.debug else '-Oz']
-    if not self.debug:
+    if self.debug:
+      # library_wasm_worker.c contains an assert that a nonnull paramater
+      # is no NULL, which llvm now warns is redundant/tautological.
+      cflags += ['-Wno-tautological-pointer-compare']
+    else:
       cflags += ['-DNDEBUG']
     if self.is_ww or self.is_mt:
       cflags += ['-pthread', '-sWASM_WORKERS']


### PR DESCRIPTION
Clang recently started generating a warning if we assert that a paramater marked as `nonnull` is not null.  The code in question is:

assert(stackLowestAddress != 0);

And the warning is:

library_wasm_worker.c:32:9: warning: comparison of nonnull parameter 'stackLowestAddress' not equal to a null pointer is 'true' on first encounter [-Wtautological-pointer-compare]