### PR TITLE
Simplify MODULARIZE code

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3932,7 +3932,6 @@ var %(EXPORT_NAME)s = (() => {
     f.write(src)
 
     # Export using a UMD style export, or ES6 exports if selected
-
     if settings.EXPORT_ES6:
       f.write('export default %s;' % settings.EXPORT_NAME)
     elif not settings.MINIMAL_RUNTIME:
@@ -3941,8 +3940,6 @@ if (typeof exports === 'object' && typeof module === 'object')
   module.exports = %(EXPORT_NAME)s;
 else if (typeof define === 'function' && define['amd'])
   define([], () => %(EXPORT_NAME)s);
-else if (typeof exports === 'object')
-  exports["%(EXPORT_NAME)s"] = %(EXPORT_NAME)s;
 ''' % {'EXPORT_NAME': settings.EXPORT_NAME})
 
   shared.get_temp_files().note(final_js)


### PR DESCRIPTION
We had a report the use of `exports["Foo"]` rather then `exports.Foo` was causing problems.

Can we just remove this line completely and rely on module.exports to take care of the CommonJS case?