### PR TITLE
Pass `-z` flags directly through the linker

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 3.1.34 (in development)
 -----------------------
+- `-z` arguments are now passed directly to wasm-ld without the need for the
+  `-Wl,` prefix.  This matches the behaviour of both clang and gcc. (#18956)
 - The prefered way to enable pthread is now to just the the standard `-pthread`
   flag.  The `-sUSE_PTHREADS` setting still works but is marked as legacy and
   will generate a warning in `-sSTRICT` mode.

--- a/emcc.py
+++ b/emcc.py
@@ -1482,7 +1482,7 @@ def phase_setup(options, state, newargs):
                '-isysroot', '-imultilib', '-A', '-isystem', '-iquote',
                '-install_name', '-compatibility_version',
                '-current_version', '-I', '-L', '-include-pch',
-               '-Xlinker', '-Xclang'):
+               '-Xlinker', '-Xclang', '-z'):
       skip = True
 
     if not arg.startswith('-'):
@@ -1517,6 +1517,14 @@ def phase_setup(options, state, newargs):
       newargs[i] = ''
     elif arg.startswith('-l'):
       add_link_flag(state, i, arg)
+      newargs[i] = ''
+    elif arg == '-z':
+      add_link_flag(state, i, newargs[i])
+      add_link_flag(state, i + 1, newargs[i + 1])
+      newargs[i] = ''
+      newargs[i + 1] = ''
+    elif arg.startswith('-z'):
+      add_link_flag(state, i, newargs[i])
       newargs[i] = ''
     elif arg.startswith('-Wl,'):
       # Multiple comma separated link flags can be specified. Create fake

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10841,11 +10841,17 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
     self.assertContained('error: unable to find library -lbar', err)
 
   def test_linker_flags_pass_through(self):
-    err = self.expect_fail([EMXX, test_file('hello_world.cpp'), '-Wl,--waka'])
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Wl,--waka'])
     self.assertContained('wasm-ld: error: unknown argument: --waka', err)
 
-    err = self.expect_fail([EMXX, test_file('hello_world.cpp'), '-Xlinker', '--waka'])
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Xlinker', '--waka'])
     self.assertContained('wasm-ld: error: unknown argument: --waka', err)
+
+    err = self.run_process([EMCC, test_file('hello_world.c'), '-z', 'foo'], stderr=PIPE).stderr
+    self.assertContained('wasm-ld: warning: unknown -z value: foo', err)
+
+    err = self.run_process([EMCC, test_file('hello_world.c'), '-zfoo'], stderr=PIPE).stderr
+    self.assertContained('wasm-ld: warning: unknown -z value: foo', err)
 
   def test_linker_flags_unused(self):
     err = self.run_process([EMXX, test_file('hello_world.cpp'), '-c', '-lbar'], stderr=PIPE).stderr


### PR DESCRIPTION
This is what the gcc and clang drivers both do.

Fixes: #18948