### PR TITLE
Use JS names for functions that are JS-only. NFC

### DIFF
--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -205,13 +205,9 @@ def get_deps_info():
     _deps_info['glutCreateWindow'] = ['malloc']
     _deps_info['emscripten_webgl_create_context'] = ['malloc']
     _deps_info['emscripten_webgl_destroy_context'] = ['free']
-    _deps_info['emscripten_set_canvas_element_size_calling_thread'] = ['emscripten_dispatch_to_thread_']
     if settings.OFFSCREEN_FRAMEBUFFER:
       # When OFFSCREEN_FRAMEBUFFER is defined these functions are defined in native code,
       # otherwise they are defined in src/library_html5_webgl.js.
       _deps_info['emscripten_webgl_destroy_context'] += ['emscripten_webgl_make_context_current', 'emscripten_webgl_get_current_context']
-    if settings.OFFSCREENCANVAS_SUPPORT:
-      _deps_info['emscripten_set_offscreencanvas_size_on_target_thread'] = ['emscripten_dispatch_to_thread_', 'malloc', 'free']
-      _deps_info['emscripten_set_offscreencanvas_size_on_target_thread_js'] = ['malloc']
 
   return _deps_info


### PR DESCRIPTION
As JS only functions there can never appear in native code so also have no effect it deps_info.py.