### PR TITLE
Move wasm module preload plugin out of library_browser.js. NFC

### DIFF
--- a/site/source/docs/api_reference/preamble.js.rst
+++ b/site/source/docs/api_reference/preamble.js.rst
@@ -437,8 +437,6 @@ The :ref:`emscripten-memory-model` uses a typed array buffer (``ArrayBuffer``) t
   function SAFE_HEAP_LOAD(dest, bytes, isFloat, unsigned)
   function SAFE_FT_MASK(value, mask)
   function CHECK_OVERFLOW(value, bits, ignore, sig)
-  Module["preloadedImages"]
-  Module["preloadedAudios"]
 
 
 .. PRIVATE NOTES (not rendered) :

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -10,6 +10,38 @@ var dlopenMissingError = "'To use dlopen, you need enable dynamic linking, see h
 
 var LibraryDylink = {
 #if RELOCATABLE
+#if FORCE_FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
+  $registerWasmPlugin: function() {
+    // Use string keys here to avoid minification since the plugin consumer
+    // also uses string keys.
+    var wasmPlugin = {
+      'promiseChainEnd': Promise.resolve(),
+      'canHandle': function(name) {
+        return !Module.noWasmDecoding && name.endsWith('.so')
+      },
+      'handle': function(byteArray, name, onload, onerror) {
+        // loadWebAssemblyModule can not load modules out-of-order, so rather
+        // than just running the promises in parallel, this makes a chain of
+        // promises to run in series.
+        wasmPlugin['promiseChainEnd'] = wasmPlugin['promiseChainEnd'].then(
+          () => loadWebAssemblyModule(byteArray, {loadAsync: true, nodelete: true})).then(
+            (module) => {
+              preloadedWasm[name] = module;
+              onload();
+            },
+            (err) => {
+              console.warn("Couldn't instantiate wasm: " + name + " '" + err + "'");
+              onerror();
+            });
+      }
+    };
+    preloadPlugins.push(wasmPlugin);
+  },
+
+  $preloadedWasm__deps: ['$registerWasmPlugin'],
+  $preloadedWasm__postset: `registerWasmPlugin();`,
+  $preloadedWasm: {},
+#endif
 
   $isSymbolDefined: function(symName) {
     // Ignore 'stub' symbols that are auto-generated as part of the original
@@ -887,7 +919,12 @@ var LibraryDylink = {
   // If a library was already loaded, it is not loaded a second time. However
   // flags.global and flags.nodelete are handled every time a load request is made.
   // Once a library becomes "global" or "nodelete", it cannot be removed or unloaded.
-  $loadDynamicLibrary__deps: ['$LDSO', '$loadWebAssemblyModule', '$isInternalSym', '$mergeLibSymbols', '$newDSO'],
+  $loadDynamicLibrary__deps: ['$LDSO', '$loadWebAssemblyModule',
+                              '$isInternalSym', '$mergeLibSymbols', '$newDSO',
+#if FORCE_FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
+                              '$preloadedWasm'
+#endif
+  ],
   $loadDynamicLibrary__docs: `
     /**
      * @param {number=} handle
@@ -957,11 +994,16 @@ var LibraryDylink = {
 
     // libName -> exports
     function getExports() {
+#if FORCE_FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
       // lookup preloaded cache first
-      if (typeof preloadedWasm != 'undefined' && preloadedWasm[libName]) {
+      if (preloadedWasm[libName]) {
+#if DYLINK_DEBUG
+        err('using preloaded module for: ' + libName);
+#endif
         var libModule = preloadedWasm[libName];
         return flags.loadAsync ? Promise.resolve(libModule) : libModule;
       }
+#endif
 
       // module not preloaded - load lib data and create new module from it
       if (flags.loadAsync) {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -19,6 +19,10 @@ Module.realPrint = out;
 out = err = () => {};
 #endif
 
+#if FORCE_FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
+{{{ makeModuleReceiveWithVar('preloadPlugins', undefined, '[]') }}}
+#endif
+
 #if RELOCATABLE
 {{{ makeModuleReceiveWithVar('dynamicLibraries', undefined, '[]', true) }}}
 #endif


### PR DESCRIPTION
Also test the preload plugin system under node.  It was working previously but not covered by any of the test we run in CI.

I'm hoping to unify this preloading system with the one planned as part of #18552.