### PR TITLE
Fix for-of in acorn optimizer

### DIFF
--- a/test/optimizer/JSDCE-fors-output.js
+++ b/test/optimizer/JSDCE-fors-output.js
@@ -1,3 +1,5 @@
 for (var i in x) {}
 
+for (var i of [ 1, 2, 3 ]) {}
+
 for (var j = 0; ;) {}

--- a/test/optimizer/JSDCE-fors.js
+++ b/test/optimizer/JSDCE-fors.js
@@ -1,4 +1,5 @@
 
 for (var i in x) {}
+for (var i of [1, 2, 3]) {}
 for (var j = 0;;) {}
 

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -209,6 +209,9 @@ function restoreForVars(node) {
     ForInStatement(node) {
       fix(node.left);
     },
+    ForOfStatement(node) {
+      fix(node.left);
+    },
   });
   return restored;
 }


### PR DESCRIPTION
Turns out the JS AST has a separate node type for for-of, like for-in.

Fixes #18967