### PR TITLE
Remove old/unused autodebug functions. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3150,27 +3150,6 @@ mergeInto(LibraryManager.library, {
   },
 #endif
 
-  // autodebugging
-
-  emscripten_autodebug_i64: function(line, valuel, valueh) {
-    out('AD:' + [line, valuel, valueh]);
-  },
-  emscripten_autodebug_i32: function(line, value) {
-    out('AD:' + [line, value]);
-  },
-  emscripten_autodebug_i16: function(line, value) {
-    out('AD:' + [line, value]);
-  },
-  emscripten_autodebug_i8: function(line, value) {
-    out('AD:' + [line, value]);
-  },
-  emscripten_autodebug_float: function(line, value) {
-    out('AD:' + [line, value]);
-  },
-  emscripten_autodebug_double: function(line, value) {
-    out('AD:' + [line, value]);
-  },
-
   // special runtime support
 
 #if STACK_OVERFLOW_CHECK

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -72,6 +72,7 @@ def clean_env():
   safe_env = os.environ.copy()
   for opt in ['CFLAGS', 'CXXFLAGS', 'LDFLAGS',
               'EMCC_CFLAGS',
+              'EMCC_AUTODEBUG',
               'EMCC_FORCE_STDLIBS',
               'EMCC_ONLY_FORCED_STDLIBS',
               'EMMAKEN_JUST_CONFIGURE']:


### PR DESCRIPTION
These days that autodebug functions are found in library_autodebug.js and have names like `set_i64` and `get_i64`.