### PR TITLE
Update mac builder to medium gen2 resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ executors:
       EMSDK_NOTTY: "1"
     macos:
       xcode: "13.4.1"
+    resource_class: macos.x86.medium.gen2
 
 commands:
   download-chrome:


### PR DESCRIPTION
see https://circleci.com/product/features/resource-classes/ The 'medium' class will go away later this year. The gen2 class is more expensive per build minute but according to my test https://app.circleci.com/pipelines/github/emscripten-core/emscripten/26604/workflows/c2acf4d1-1d2d-4556-b148-32278b852d42/jobs/614937 vs
https://app.circleci.com/pipelines/github/emscripten-core/emscripten/26608/workflows/8ecccca3-44b6-493e-a3e8-62e74f931fda/jobs/615017 it's enough faster that it's slightly cheaper overall.