### PR TITLE
Update JS library signatures

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -1318,7 +1318,7 @@ var LibraryEmbind = {
 
   $structRegistrations: {},
 
-  _embind_register_value_object__sig: 'viiiiii',
+  _embind_register_value_object__sig: 'vpppppp',
   _embind_register_value_object__deps: [
     '$structRegistrations', '$readLatin1String', '$embind__requireFunction'],
   _embind_register_value_object: function(
@@ -1337,7 +1337,7 @@ var LibraryEmbind = {
     };
   },
 
-  _embind_register_value_object_field__sig: 'viiiiiiiiii',
+  _embind_register_value_object_field__sig: 'vpppppppppp',
   _embind_register_value_object_field__deps: [
     '$structRegistrations', '$readLatin1String', '$embind__requireFunction'],
   _embind_register_value_object_field: function(
@@ -1363,7 +1363,7 @@ var LibraryEmbind = {
     });
   },
 
-  _embind_finalize_value_object__sig: 'ii',
+  _embind_finalize_value_object__sig: 'vp',
   _embind_finalize_value_object__deps: [
     '$structRegistrations', '$runDestructors',
     '$simpleReadValueFromPointer', '$whenDependentTypesAreResolved'],
@@ -2598,7 +2598,7 @@ var LibraryEmbind = {
     exposePublicSymbol(name, ctor);
   },
 
-  _embind_register_enum_value__sig: 'vppi',
+  _embind_register_enum_value__sig: 'vppp',
   _embind_register_enum_value__deps: ['$createNamedFunction', '$readLatin1String', '$requireRegisteredType'],
   _embind_register_enum_value: function(rawEnumType, name, enumValue) {
     var enumType = requireRegisteredType(rawEnumType, 'enum');

--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -327,7 +327,7 @@ var LibraryEmVal = {
   },
 
   _emval_as_int64__deps: ['$Emval', '$requireRegisteredType'],
-  _emval_as_int64__sig: 'dppp',
+  _emval_as_int64__sig: 'jpp',
   _emval_as_int64: function(handle, returnType, destructorsRef) {
     handle = Emval.toValue(handle);
     returnType = requireRegisteredType(returnType, 'emval::as');
@@ -335,7 +335,7 @@ var LibraryEmVal = {
   },
 
   _emval_as_uint64__deps: ['$Emval', '$requireRegisteredType'],
-  _emval_as_uint64__sig: 'dppp',
+  _emval_as_uint64__sig: 'jpp',
   _emval_as_uint64: function(handle, returnType, destructorsRef) {
     handle = Emval.toValue(handle);
     returnType = requireRegisteredType(returnType, 'emval::as');
@@ -381,7 +381,7 @@ var LibraryEmVal = {
     return !object;
   },
 
-  _emval_call__sig: 'ppppp',
+  _emval_call__sig: 'ppipp',
   _emval_call__deps: ['$emval_lookupTypes', '$Emval'],
   _emval_call: function(handle, argCount, argTypes, argv) {
     handle = Emval.toValue(handle);
@@ -427,7 +427,7 @@ var LibraryEmVal = {
   },
 
   $emval_registeredMethods: [],
-  _emval_get_method_caller__sig: 'ppp',
+  _emval_get_method_caller__sig: 'pip',
   _emval_get_method_caller__deps: ['$emval_addMethodCaller', '$emval_lookupTypes', '$new_', '$makeLegalFunctionName', '$emval_registeredMethods'],
   _emval_get_method_caller: function(argCount, argTypes) {
     var types = emval_lookupTypes(argCount, argTypes);
@@ -564,7 +564,7 @@ var LibraryEmVal = {
   },
 
   _emval_throw__deps: ['$Emval'],
-  _emval_throw__sig: 'vp',
+  _emval_throw__sig: 'ip',
   _emval_throw: function(object) {
     object = Emval.toValue(object);
     throw object;

--- a/src/library.js
+++ b/src/library.js
@@ -490,7 +490,7 @@ mergeInto(LibraryManager.library, {
   },
 
   _gmtime_js__deps: ['$readI53FromI64'],
-  _gmtime_js__sig: 'ipp',
+  _gmtime_js__sig: 'vpp',
   _gmtime_js: function(time, tmPtr) {
     var date = new Date({{{ makeGetValue('time', 0, 'i53') }}}*1000);
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_sec, 'date.getUTCSeconds()', 'i32') }}};
@@ -525,7 +525,7 @@ mergeInto(LibraryManager.library, {
   },
 
   _localtime_js__deps: ['$readI53FromI64', '$ydayFromDate'],
-  _localtime_js__sig: 'ipp',
+  _localtime_js__sig: 'vpp',
   _localtime_js: function(time, tmPtr) {
     var date = new Date({{{ makeGetValue('time', 0, 'i53') }}}*1000);
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_sec, 'date.getSeconds()', 'i32') }}};
@@ -1831,7 +1831,7 @@ mergeInto(LibraryManager.library, {
   // note: lots of leaking here!
   gethostbyaddr__deps: ['$DNS', '$getHostByName', '$inetNtop4', '$setErrNo'],
   gethostbyaddr__proxy: 'sync',
-  gethostbyaddr__sig: 'ipii',
+  gethostbyaddr__sig: 'ppii',
   gethostbyaddr: function (addr, addrlen, type) {
     if (type !== {{{ cDefine('AF_INET') }}}) {
       setErrNo({{{ cDefine('EAFNOSUPPORT') }}});
@@ -1877,7 +1877,7 @@ mergeInto(LibraryManager.library, {
 
   gethostbyname_r__deps: ['gethostbyname', 'memcpy', 'free'],
   gethostbyname_r__proxy: 'sync',
-  gethostbyname_r__sig: 'ipppipp',
+  gethostbyname_r__sig: 'ipppppp',
   gethostbyname_r: function(name, ret, buf, buflen, out, err) {
     var data = _gethostbyname(name);
     _memcpy(ret, data, {{{ C_STRUCTS.hostent.__size__ }}});
@@ -2671,7 +2671,7 @@ mergeInto(LibraryManager.library, {
     debugger;
   },
 
-  emscripten_print_double__sig: 'iipi',
+  emscripten_print_double__sig: 'idpi',
   emscripten_print_double: function(x, to, max) {
     var str = x + '';
     if (to) return stringToUTF8(str, to, max);
@@ -3066,7 +3066,7 @@ mergeInto(LibraryManager.library, {
     return ASM_CONSTS[code].apply(null, args);
   },
   emscripten_asm_const_int_sync_on_main_thread__deps: ['$runMainThreadEmAsm'],
-  emscripten_asm_const_int_sync_on_main_thread__sig: 'iiii',
+  emscripten_asm_const_int_sync_on_main_thread__sig: 'ippp',
   emscripten_asm_const_int_sync_on_main_thread: function(code, sigPtr, argbuf) {
     return runMainThreadEmAsm(code, sigPtr, argbuf, 1);
   },
@@ -3413,7 +3413,7 @@ mergeInto(LibraryManager.library, {
 
   // Use program_invocation_short_name and program_invocation_name in compiled
   // programs. This function is for implementing them.
-  _emscripten_get_progname__sig: 'vpp',
+  _emscripten_get_progname__sig: 'vpi',
   _emscripten_get_progname: function(str, len) {
 #if !MINIMAL_RUNTIME
 #if ASSERTIONS

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -608,7 +608,7 @@ mergeInto(LibraryManager.library, {
     },
   },
 
-  emscripten_fiber_swap__sig: 'vii',
+  emscripten_fiber_swap__sig: 'vpp',
   emscripten_fiber_swap__deps: ["$Asyncify", "$Fibers"],
   emscripten_fiber_swap: function(oldFiber, newFiber) {
     if (ABORT) return;

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -779,7 +779,7 @@ var LibraryBrowser = {
 
   emscripten_run_preload_plugins__deps: ['$PATH'],
   emscripten_run_preload_plugins__proxy: 'sync',
-  emscripten_run_preload_plugins__sig: 'iiii',
+  emscripten_run_preload_plugins__sig: 'ippp',
   emscripten_run_preload_plugins: function(file, onload, onerror) {
     {{{ runtimeKeepalivePush() }}}
 
@@ -805,7 +805,7 @@ var LibraryBrowser = {
 
   emscripten_run_preload_plugins_data__proxy: 'sync',
   emscripten_run_preload_plugins_data__deps: ['malloc'],
-  emscripten_run_preload_plugins_data__sig: 'viiiiii',
+  emscripten_run_preload_plugins_data__sig: 'vpipppp',
   emscripten_run_preload_plugins_data: function(data, size, suffix, arg, onload, onerror) {
     {{{ runtimeKeepalivePush() }}}
 
@@ -875,7 +875,7 @@ var LibraryBrowser = {
   },
 
   // Runs natively in pthread, no __proxy needed.
-  emscripten_get_main_loop_timing__sig: 'vii',
+  emscripten_get_main_loop_timing__sig: 'vpp',
   emscripten_get_main_loop_timing: function(mode, value) {
     if (mode) {{{ makeSetValue('mode', 0, 'Browser.mainLoop.timingMode', 'i32') }}};
     if (value) {{{ makeSetValue('value', 0, 'Browser.mainLoop.timingValue', 'i32') }}};
@@ -942,7 +942,7 @@ var LibraryBrowser = {
   },
 
   emscripten_set_main_loop__deps: ['$setMainLoop'],
-  emscripten_set_main_loop__sig: 'viii',
+  emscripten_set_main_loop__sig: 'vpii',
   emscripten_set_main_loop: function(func, fps, simulateInfiniteLoop) {
     var browserIterationFunc = {{{ makeDynCall('v', 'func') }}};
     setMainLoop(browserIterationFunc, fps, simulateInfiniteLoop);
@@ -1104,7 +1104,7 @@ var LibraryBrowser = {
 
   // Runs natively in pthread, no __proxy needed.
   emscripten_set_main_loop_arg__deps: ['$setMainLoop'],
-  emscripten_set_main_loop_arg__sig: 'viiii',
+  emscripten_set_main_loop_arg__sig: 'vppii',
   emscripten_set_main_loop_arg: function(func, arg, fps, simulateInfiniteLoop) {
     var browserIterationFunc = () => {{{ makeDynCall('vi', 'func') }}}(arg);
     setMainLoop(browserIterationFunc, fps, simulateInfiniteLoop, arg);
@@ -1188,13 +1188,13 @@ var LibraryBrowser = {
   },
 
   emscripten_set_window_title__proxy: 'sync',
-  emscripten_set_window_title__sig: 'vi',
+  emscripten_set_window_title__sig: 'vp',
   emscripten_set_window_title: function(title) {
     setWindowTitle(UTF8ToString(title));
   },
 
   emscripten_get_screen_size__proxy: 'sync',
-  emscripten_get_screen_size__sig: 'vii',
+  emscripten_get_screen_size__sig: 'vpp',
   emscripten_get_screen_size: function(width, height) {
     {{{ makeSetValue('width', '0', 'screen.width', 'i32') }}};
     {{{ makeSetValue('height', '0', 'screen.height', 'i32') }}};
@@ -1221,7 +1221,7 @@ var LibraryBrowser = {
   },
 
   emscripten_get_canvas_size__proxy: 'sync',
-  emscripten_get_canvas_size__sig: 'viii',
+  emscripten_get_canvas_size__sig: 'vppp',
   emscripten_get_canvas_size: function(width, height, isFullscreen) {
     var canvas = Module['canvas'];
     {{{ makeSetValue('width', '0', 'canvas.width', 'i32') }}};
@@ -1231,7 +1231,7 @@ var LibraryBrowser = {
 
   // To avoid creating worker parent->child chains, always proxies to execute on the main thread.
   emscripten_create_worker__proxy: 'sync',
-  emscripten_create_worker__sig: 'ii',
+  emscripten_create_worker__sig: 'ip',
   emscripten_create_worker: function(url) {
     url = UTF8ToString(url);
     var id = Browser.workers.length;
@@ -1283,7 +1283,7 @@ var LibraryBrowser = {
   },
 
   emscripten_call_worker__proxy: 'sync',
-  emscripten_call_worker__sig: 'viiiiii',
+  emscripten_call_worker__sig: 'vippipp',
   emscripten_call_worker: function(id, funcName, data, size, callback, arg) {
     funcName = UTF8ToString(funcName);
     var info = Browser.workers[id];
@@ -1358,7 +1358,7 @@ var LibraryBrowser = {
 
   emscripten_get_preloaded_image_data__deps: ['$PATH_FS', 'malloc'],
   emscripten_get_preloaded_image_data__proxy: 'sync',
-  emscripten_get_preloaded_image_data__sig: 'iiii',
+  emscripten_get_preloaded_image_data__sig: 'pppp',
   emscripten_get_preloaded_image_data: function(path, w, h) {
     if ((path | 0) === path) path = UTF8ToString(path);
 
@@ -1382,7 +1382,7 @@ var LibraryBrowser = {
 
   emscripten_get_preloaded_image_data_from_FILE__deps: ['emscripten_get_preloaded_image_data', 'fileno'],
   emscripten_get_preloaded_image_data_from_FILE__proxy: 'sync',
-  emscripten_get_preloaded_image_data_from_FILE__sig: 'iiii',
+  emscripten_get_preloaded_image_data_from_FILE__sig: 'pppp',
   emscripten_get_preloaded_image_data_from_FILE: function(file, w, h) {
     var fd = _fileno(file);
     var stream = FS.getStream(fd);

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -1132,7 +1132,7 @@ var LibraryDylink = {
     }
   },
 
-  _dlsym_catchup_js__sig: 'ppp',
+  _dlsym_catchup_js__sig: 'ppi',
   _dlsym_catchup_js: function(handle, symbolIndex) {
 #if DYLINK_DEBUG
     dbg("_dlsym_catchup: handle=" + ptrToString(handle) + " symbolIndex=" + symbolIndex);

--- a/src/library_eventloop.js
+++ b/src/library_eventloop.js
@@ -90,7 +90,7 @@ LibraryJSEventLoop = {
     emClearImmediate(id);
   },
 
-  emscripten_set_immediate_loop__sig: 'ipp' ,
+  emscripten_set_immediate_loop__sig: 'vpp',
   emscripten_set_immediate_loop__deps: ['$polyfillSetImmediate', '$callUserCallback'],
   emscripten_set_immediate_loop: function(cb, userData) {
     polyfillSetImmediate();

--- a/src/library_glew.js
+++ b/src/library_glew.js
@@ -127,7 +127,7 @@ var LibraryGLEW = {
     return GLEW.extensionIsSupported(UTF8ToString(name));
   },
 
-  glewGetErrorString__sig: 'ii',
+  glewGetErrorString__sig: 'pi',
   glewGetErrorString: function(error) {
     return GLEW.errorString(error);
   },

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -307,7 +307,7 @@ var LibraryGLUT = {
 
   glutInit__deps: ['$Browser'],
   glutInit__proxy: 'sync',
-  glutInit__sig: 'vii',
+  glutInit__sig: 'vpp',
   glutInit: function(argcp, argv) {
     // Ignore arguments
     GLUT.initTime = Date.now();
@@ -419,7 +419,7 @@ var LibraryGLUT = {
 
   glutIdleFunc__proxy: 'sync',
   glutIdleFunc__deps: ['$safeSetTimeout'],
-  glutIdleFunc__sig: 'vi',
+  glutIdleFunc__sig: 'vp',
   glutIdleFunc: function(func) {
     function callback() {
       if (GLUT.idleFunc) {
@@ -435,61 +435,61 @@ var LibraryGLUT = {
 
   glutTimerFunc__proxy: 'sync',
   glutTimerFunc__deps: ['$safeSetTimeout'],
-  glutTimerFunc__sig: 'viii',
+  glutTimerFunc__sig: 'vipi',
   glutTimerFunc: function(msec, func, value) {
     safeSetTimeout(function() { {{{ makeDynCall('vi', 'func') }}}(value); }, msec);
   },
 
   glutDisplayFunc__proxy: 'sync',
-  glutDisplayFunc__sig: 'vi',
+  glutDisplayFunc__sig: 'vp',
   glutDisplayFunc: function(func) {
     GLUT.displayFunc = func;
   },
 
   glutKeyboardFunc__proxy: 'sync',
-  glutKeyboardFunc__sig: 'vi',
+  glutKeyboardFunc__sig: 'vp',
   glutKeyboardFunc: function(func) {
     GLUT.keyboardFunc = func;
   },
 
   glutKeyboardUpFunc__proxy: 'sync',
-  glutKeyboardUpFunc__sig: 'vi',
+  glutKeyboardUpFunc__sig: 'vp',
   glutKeyboardUpFunc: function(func) {
     GLUT.keyboardUpFunc = func;
   },
 
   glutSpecialFunc__proxy: 'sync',
-  glutSpecialFunc__sig: 'vi',
+  glutSpecialFunc__sig: 'vp',
   glutSpecialFunc: function(func) {
     GLUT.specialFunc = func;
   },
 
   glutSpecialUpFunc__proxy: 'sync',
-  glutSpecialUpFunc__sig: 'vi',
+  glutSpecialUpFunc__sig: 'vp',
   glutSpecialUpFunc: function(func) {
     GLUT.specialUpFunc = func;
   },
 
   glutReshapeFunc__proxy: 'sync',
-  glutReshapeFunc__sig: 'vi',
+  glutReshapeFunc__sig: 'vp',
   glutReshapeFunc: function(func) {
     GLUT.reshapeFunc = func;
   },
 
   glutMotionFunc__proxy: 'sync',
-  glutMotionFunc__sig: 'vi',
+  glutMotionFunc__sig: 'vp',
   glutMotionFunc: function(func) {
     GLUT.motionFunc = func;
   },
 
   glutPassiveMotionFunc__proxy: 'sync',
-  glutPassiveMotionFunc__sig: 'vi',
+  glutPassiveMotionFunc__sig: 'vp',
   glutPassiveMotionFunc: function(func) {
     GLUT.passiveMotionFunc = func;
   },
 
   glutMouseFunc__proxy: 'sync',
-  glutMouseFunc__sig: 'vi',
+  glutMouseFunc__sig: 'vp',
   glutMouseFunc: function(func) {
     GLUT.mouseFunc = func;
   },
@@ -573,7 +573,7 @@ var LibraryGLUT = {
 
   glutCreateWindow__proxy: 'sync',
   glutCreateWindow__deps: ['$Browser'],
-  glutCreateWindow__sig: 'ii',
+  glutCreateWindow__sig: 'ip',
   glutCreateWindow: function(name) {
     var contextAttributes = {
       antialias: ((GLUT.initDisplayMode & 0x0080 /*GLUT_MULTISAMPLE*/) != 0),
@@ -591,7 +591,7 @@ var LibraryGLUT = {
 
   glutDestroyWindow__proxy: 'sync',
   glutDestroyWindow__deps: ['$Browser'],
-  glutDestroyWindow__sig: 'ii',
+  glutDestroyWindow__sig: 'vi',
   glutDestroyWindow: function(name) {
     Module.ctx = Browser.destroyContext(Module['canvas'], true, true);
     return 1;

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -399,7 +399,7 @@ var LibraryHTML5 = {
 #endif
 
   emscripten_set_keypress_callback_on_thread__proxy: 'sync',
-  emscripten_set_keypress_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_keypress_callback_on_thread__sig: 'ippipp',
   emscripten_set_keypress_callback_on_thread__deps: ['$registerKeyEventCallback'],
   emscripten_set_keypress_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerKeyEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_KEYPRESS') }}}, "keypress", targetThread);
@@ -407,7 +407,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_keydown_callback_on_thread__proxy: 'sync',
-  emscripten_set_keydown_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_keydown_callback_on_thread__sig: 'ippipp',
   emscripten_set_keydown_callback_on_thread__deps: ['$registerKeyEventCallback'],
   emscripten_set_keydown_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerKeyEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_KEYDOWN') }}}, "keydown", targetThread);
@@ -415,7 +415,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_keyup_callback_on_thread__proxy: 'sync',
-  emscripten_set_keyup_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_keyup_callback_on_thread__sig: 'ippipp',
   emscripten_set_keyup_callback_on_thread__deps: ['$registerKeyEventCallback'],
   emscripten_set_keyup_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerKeyEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_KEYUP') }}}, "keyup", targetThread);
@@ -546,7 +546,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_click_callback_on_thread__proxy: 'sync',
-  emscripten_set_click_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_click_callback_on_thread__sig: 'ippipp',
   emscripten_set_click_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_click_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_CLICK') }}}, "click", targetThread);
@@ -554,7 +554,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_mousedown_callback_on_thread__proxy: 'sync',
-  emscripten_set_mousedown_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_mousedown_callback_on_thread__sig: 'ippipp',
   emscripten_set_mousedown_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mousedown_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSEDOWN') }}}, "mousedown", targetThread);
@@ -562,7 +562,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_mouseup_callback_on_thread__proxy: 'sync',
-  emscripten_set_mouseup_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_mouseup_callback_on_thread__sig: 'ippipp',
   emscripten_set_mouseup_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mouseup_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSEUP') }}}, "mouseup", targetThread);
@@ -570,7 +570,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_dblclick_callback_on_thread__proxy: 'sync',
-  emscripten_set_dblclick_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_dblclick_callback_on_thread__sig: 'ippipp',
   emscripten_set_dblclick_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_dblclick_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_DBLCLICK') }}}, "dblclick", targetThread);
@@ -578,7 +578,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_mousemove_callback_on_thread__proxy: 'sync',
-  emscripten_set_mousemove_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_mousemove_callback_on_thread__sig: 'ippipp',
   emscripten_set_mousemove_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mousemove_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSEMOVE') }}}, "mousemove", targetThread);
@@ -586,7 +586,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_mouseenter_callback_on_thread__proxy: 'sync',
-  emscripten_set_mouseenter_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_mouseenter_callback_on_thread__sig: 'ippipp',
   emscripten_set_mouseenter_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mouseenter_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSEENTER') }}}, "mouseenter", targetThread);
@@ -594,7 +594,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_mouseleave_callback_on_thread__proxy: 'sync',
-  emscripten_set_mouseleave_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_mouseleave_callback_on_thread__sig: 'ippipp',
   emscripten_set_mouseleave_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mouseleave_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSELEAVE') }}}, "mouseleave", targetThread);
@@ -602,7 +602,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_mouseover_callback_on_thread__proxy: 'sync',
-  emscripten_set_mouseover_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_mouseover_callback_on_thread__sig: 'ippipp',
   emscripten_set_mouseover_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mouseover_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSEOVER') }}}, "mouseover", targetThread);
@@ -610,7 +610,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_mouseout_callback_on_thread__proxy: 'sync',
-  emscripten_set_mouseout_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_mouseout_callback_on_thread__sig: 'ippipp',
   emscripten_set_mouseout_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mouseout_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSEOUT') }}}, "mouseout", targetThread);
@@ -618,7 +618,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_get_mouse_status__proxy: 'sync',
-  emscripten_get_mouse_status__sig: 'ii',
+  emscripten_get_mouse_status__sig: 'ip',
   emscripten_get_mouse_status__deps: ['$JSEvents'],
   emscripten_get_mouse_status: function(mouseState) {
     if (!JSEvents.mouseEvent) return {{{ cDefine('EMSCRIPTEN_RESULT_NO_DATA') }}};
@@ -689,7 +689,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_wheel_callback_on_thread__proxy: 'sync',
-  emscripten_set_wheel_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_wheel_callback_on_thread__sig: 'ippipp',
   emscripten_set_wheel_callback_on_thread__deps: ['$JSEvents', '$registerWheelEventCallback', '$findEventTarget'],
   emscripten_set_wheel_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     target = findEventTarget(target);
@@ -769,7 +769,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_resize_callback_on_thread__proxy: 'sync',
-  emscripten_set_resize_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_resize_callback_on_thread__sig: 'ippipp',
   emscripten_set_resize_callback_on_thread__deps: ['$registerUiEventCallback'],
   emscripten_set_resize_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerUiEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_RESIZE') }}}, "resize", targetThread);
@@ -777,7 +777,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_scroll_callback_on_thread__proxy: 'sync',
-  emscripten_set_scroll_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_scroll_callback_on_thread__sig: 'ippipp',
   emscripten_set_scroll_callback_on_thread__deps: ['$registerUiEventCallback'],
   emscripten_set_scroll_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerUiEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_SCROLL') }}}, "scroll", targetThread);
@@ -821,7 +821,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_blur_callback_on_thread__proxy: 'sync',
-  emscripten_set_blur_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_blur_callback_on_thread__sig: 'ippipp',
   emscripten_set_blur_callback_on_thread__deps: ['$registerFocusEventCallback'],
   emscripten_set_blur_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerFocusEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_BLUR') }}}, "blur", targetThread);
@@ -829,7 +829,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_focus_callback_on_thread__proxy: 'sync',
-  emscripten_set_focus_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_focus_callback_on_thread__sig: 'ippipp',
   emscripten_set_focus_callback_on_thread__deps: ['$registerFocusEventCallback'],
   emscripten_set_focus_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerFocusEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_FOCUS') }}}, "focus", targetThread);
@@ -837,7 +837,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_focusin_callback_on_thread__proxy: 'sync',
-  emscripten_set_focusin_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_focusin_callback_on_thread__sig: 'ippipp',
   emscripten_set_focusin_callback_on_thread__deps: ['$registerFocusEventCallback'],
   emscripten_set_focusin_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerFocusEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_FOCUSIN') }}}, "focusin", targetThread);
@@ -845,7 +845,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_focusout_callback_on_thread__proxy: 'sync',
-  emscripten_set_focusout_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_focusout_callback_on_thread__sig: 'ippipp',
   emscripten_set_focusout_callback_on_thread__deps: ['$registerFocusEventCallback'],
   emscripten_set_focusout_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerFocusEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_FOCUSOUT') }}}, "focusout", targetThread);
@@ -891,7 +891,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_deviceorientation_callback_on_thread__proxy: 'sync',
-  emscripten_set_deviceorientation_callback_on_thread__sig: 'iiiii',
+  emscripten_set_deviceorientation_callback_on_thread__sig: 'ipipp',
   emscripten_set_deviceorientation_callback_on_thread__deps: ['$registerDeviceOrientationEventCallback'],
   emscripten_set_deviceorientation_callback_on_thread: function(userData, useCapture, callbackfunc, targetThread) {
     registerDeviceOrientationEventCallback({{{ cDefine('EMSCRIPTEN_EVENT_TARGET_WINDOW') }}}, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_DEVICEORIENTATION') }}}, "deviceorientation", targetThread);
@@ -899,7 +899,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_get_deviceorientation_status__proxy: 'sync',
-  emscripten_get_deviceorientation_status__sig: 'ii',
+  emscripten_get_deviceorientation_status__sig: 'ip',
   emscripten_get_deviceorientation_status__deps: ['$JSEvents', '$registerDeviceOrientationEventCallback'],
   emscripten_get_deviceorientation_status: function(orientationState) {
     if (!JSEvents.deviceOrientationEvent) return {{{ cDefine('EMSCRIPTEN_RESULT_NO_DATA') }}};
@@ -964,7 +964,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_devicemotion_callback_on_thread__proxy: 'sync',
-  emscripten_set_devicemotion_callback_on_thread__sig: 'iiiii',
+  emscripten_set_devicemotion_callback_on_thread__sig: 'ipipp',
   emscripten_set_devicemotion_callback_on_thread__deps: ['$registerDeviceMotionEventCallback'],
   emscripten_set_devicemotion_callback_on_thread: function(userData, useCapture, callbackfunc, targetThread) {
     registerDeviceMotionEventCallback({{{ cDefine('EMSCRIPTEN_EVENT_TARGET_WINDOW') }}}, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_DEVICEMOTION') }}}, "devicemotion", targetThread);
@@ -972,7 +972,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_get_devicemotion_status__proxy: 'sync',
-  emscripten_get_devicemotion_status__sig: 'ii',
+  emscripten_get_devicemotion_status__sig: 'ip',
   emscripten_get_devicemotion_status__deps: ['$JSEvents'],
   emscripten_get_devicemotion_status: function(motionState) {
     if (!JSEvents.deviceMotionEvent) return {{{ cDefine('EMSCRIPTEN_RESULT_NO_DATA') }}};
@@ -1041,7 +1041,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_orientationchange_callback_on_thread__proxy: 'sync',
-  emscripten_set_orientationchange_callback_on_thread__sig: 'iiiii',
+  emscripten_set_orientationchange_callback_on_thread__sig: 'ipipp',
   emscripten_set_orientationchange_callback_on_thread__deps: ['$registerOrientationChangeEventCallback'],
   emscripten_set_orientationchange_callback_on_thread: function(userData, useCapture, callbackfunc, targetThread) {
     if (!screen || !screen['addEventListener']) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
@@ -1050,7 +1050,7 @@ var LibraryHTML5 = {
   },
   
   emscripten_get_orientation_status__proxy: 'sync',
-  emscripten_get_orientation_status__sig: 'ii',
+  emscripten_get_orientation_status__sig: 'ip',
   emscripten_get_orientation_status__deps: ['$fillOrientationChangeEventData', '$screenOrientation'],
   emscripten_get_orientation_status: function(orientationChangeEvent) {
     if (!screenOrientation() && typeof orientation == 'undefined') return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
@@ -1161,7 +1161,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_fullscreenchange_callback_on_thread__proxy: 'sync',
-  emscripten_set_fullscreenchange_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_fullscreenchange_callback_on_thread__sig: 'ippipp',
   emscripten_set_fullscreenchange_callback_on_thread__deps: ['$JSEvents', '$registerFullscreenChangeEventCallback', '$findEventTarget', '$specialHTMLTargets'],
   emscripten_set_fullscreenchange_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     if (!JSEvents.fullscreenEnabled()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
@@ -1190,7 +1190,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_get_fullscreen_status__proxy: 'sync',
-  emscripten_get_fullscreen_status__sig: 'ii',
+  emscripten_get_fullscreen_status__sig: 'ip',
   emscripten_get_fullscreen_status__deps: ['$JSEvents', '$fillFullscreenChangeEventData'],
   emscripten_get_fullscreen_status: function(fullscreenStatus) {
     if (!JSEvents.fullscreenEnabled()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
@@ -1559,7 +1559,7 @@ var LibraryHTML5 = {
 
   emscripten_request_fullscreen__deps: ['$doRequestFullscreen'],
   emscripten_request_fullscreen__proxy: 'sync',
-  emscripten_request_fullscreen__sig: 'iii',
+  emscripten_request_fullscreen__sig: 'ipi',
   emscripten_request_fullscreen: function(target, deferUntilInEventHandler) {
     var strategy = {
       // These options perform no added logic, but just bare request fullscreen.
@@ -1576,7 +1576,7 @@ var LibraryHTML5 = {
 
   emscripten_request_fullscreen_strategy__deps: ['$doRequestFullscreen', '$currentFullscreenStrategy', '$registerRestoreOldStyle'],
   emscripten_request_fullscreen_strategy__proxy: 'sync',
-  emscripten_request_fullscreen_strategy__sig: 'iiii',
+  emscripten_request_fullscreen_strategy__sig: 'ipip',
   emscripten_request_fullscreen_strategy: function(target, deferUntilInEventHandler, fullscreenStrategy) {
     var strategy = {
       scaleMode: {{{ makeGetValue('fullscreenStrategy', C_STRUCTS.EmscriptenFullscreenStrategy.scaleMode, 'i32') }}},
@@ -1597,7 +1597,7 @@ var LibraryHTML5 = {
 
   emscripten_enter_soft_fullscreen__deps: ['$JSEvents', '$setLetterbox', '$hideEverythingExceptGivenElement', '$restoreOldWindowedStyle', '$registerRestoreOldStyle', '$restoreHiddenElements', '$currentFullscreenStrategy', '$softFullscreenResizeWebGLRenderTarget', '$getCanvasElementSize', '$setCanvasElementSize', '$JSEvents_resizeCanvasForFullscreen', '$findEventTarget'],
   emscripten_enter_soft_fullscreen__proxy: 'sync',
-  emscripten_enter_soft_fullscreen__sig: 'iii',
+  emscripten_enter_soft_fullscreen__sig: 'ipp',
   emscripten_enter_soft_fullscreen: function(target, fullscreenStrategy) {
 #if !DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
     if (!target) target = '#canvas';
@@ -1745,7 +1745,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_pointerlockchange_callback_on_thread__proxy: 'sync',
-  emscripten_set_pointerlockchange_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_pointerlockchange_callback_on_thread__sig: 'ippipp',
   emscripten_set_pointerlockchange_callback_on_thread__deps: ['$JSEvents', '$registerPointerlockChangeEventCallback', '$findEventTarget', '$specialHTMLTargets'],
   emscripten_set_pointerlockchange_callback_on_thread__docs: '/** @suppress {missingProperties} */', // Closure does not see document.body.mozRequestPointerLock etc.
   emscripten_set_pointerlockchange_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
@@ -1792,7 +1792,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_pointerlockerror_callback_on_thread__proxy: 'sync',
-  emscripten_set_pointerlockerror_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_pointerlockerror_callback_on_thread__sig: 'ippipp',
   emscripten_set_pointerlockerror_callback_on_thread__deps: ['$JSEvents', '$registerPointerlockErrorEventCallback', '$findEventTarget', '$specialHTMLTargets'],
   emscripten_set_pointerlockerror_callback_on_thread__docs: '/** @suppress {missingProperties} */', // Closure does not see document.body.mozRequestPointerLock etc.
   emscripten_set_pointerlockerror_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
@@ -1816,7 +1816,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_get_pointerlock_status__proxy: 'sync',
-  emscripten_get_pointerlock_status__sig: 'ii',
+  emscripten_get_pointerlock_status__sig: 'ip',
   emscripten_get_pointerlock_status__deps: ['$fillPointerlockChangeEventData'],
   emscripten_get_pointerlock_status__docs: '/** @suppress {missingProperties} */', // Closure does not see document.body.mozRequestPointerLock etc.
   emscripten_get_pointerlock_status: function(pointerlockStatus) {
@@ -1864,7 +1864,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_request_pointerlock__proxy: 'sync',
-  emscripten_request_pointerlock__sig: 'iii',
+  emscripten_request_pointerlock__sig: 'ipi',
   emscripten_request_pointerlock__deps: ['$JSEvents', '$requestPointerLock', '$findEventTarget'],
   emscripten_request_pointerlock: function(target, deferUntilInEventHandler) {
 #if !DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
@@ -1940,7 +1940,7 @@ var LibraryHTML5 = {
   },
   
   emscripten_vibrate_pattern__proxy: 'sync',
-  emscripten_vibrate_pattern__sig: 'iii',
+  emscripten_vibrate_pattern__sig: 'ipi',
   emscripten_vibrate_pattern: function(msecsArray, numEntries) {
     if (!navigator.vibrate) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
 
@@ -1999,7 +1999,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_visibilitychange_callback_on_thread__proxy: 'sync',
-  emscripten_set_visibilitychange_callback_on_thread__sig: 'iiiii',
+  emscripten_set_visibilitychange_callback_on_thread__sig: 'ipipp',
   emscripten_set_visibilitychange_callback_on_thread__deps: ['$registerVisibilityChangeEventCallback', '$specialHTMLTargets'],
   emscripten_set_visibilitychange_callback_on_thread: function(userData, useCapture, callbackfunc, targetThread) {
 #if ENVIRONMENT_MAY_BE_WORKER || ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL
@@ -2012,7 +2012,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_get_visibility_status__proxy: 'sync',
-  emscripten_get_visibility_status__sig: 'ii',
+  emscripten_get_visibility_status__sig: 'ip',
   emscripten_get_visibility_status__deps: ['$fillVisibilityChangeEventData'],
   emscripten_get_visibility_status: function(visibilityStatus) {
     if (typeof document.visibilityState == 'undefined' && typeof document.hidden == 'undefined') {
@@ -2122,7 +2122,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_touchstart_callback_on_thread__proxy: 'sync',
-  emscripten_set_touchstart_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_touchstart_callback_on_thread__sig: 'ippipp',
   emscripten_set_touchstart_callback_on_thread__deps: ['$registerTouchEventCallback'],
   emscripten_set_touchstart_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerTouchEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_TOUCHSTART') }}}, "touchstart", targetThread);
@@ -2130,7 +2130,7 @@ var LibraryHTML5 = {
   },
   
   emscripten_set_touchend_callback_on_thread__proxy: 'sync',
-  emscripten_set_touchend_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_touchend_callback_on_thread__sig: 'ippipp',
   emscripten_set_touchend_callback_on_thread__deps: ['$registerTouchEventCallback'],
   emscripten_set_touchend_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerTouchEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_TOUCHEND') }}}, "touchend", targetThread);
@@ -2138,7 +2138,7 @@ var LibraryHTML5 = {
   },
   
   emscripten_set_touchmove_callback_on_thread__proxy: 'sync',
-  emscripten_set_touchmove_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_touchmove_callback_on_thread__sig: 'ippipp',
   emscripten_set_touchmove_callback_on_thread__deps: ['$registerTouchEventCallback'],
   emscripten_set_touchmove_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerTouchEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_TOUCHMOVE') }}}, "touchmove", targetThread);
@@ -2146,7 +2146,7 @@ var LibraryHTML5 = {
   },
   
   emscripten_set_touchcancel_callback_on_thread__proxy: 'sync',
-  emscripten_set_touchcancel_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_touchcancel_callback_on_thread__sig: 'ippipp',
   emscripten_set_touchcancel_callback_on_thread__deps: ['$registerTouchEventCallback'],
   emscripten_set_touchcancel_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerTouchEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_TOUCHCANCEL') }}}, "touchcancel", targetThread);
@@ -2220,7 +2220,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_gamepadconnected_callback_on_thread__proxy: 'sync',
-  emscripten_set_gamepadconnected_callback_on_thread__sig: 'iiiii',
+  emscripten_set_gamepadconnected_callback_on_thread__sig: 'ipipp',
   emscripten_set_gamepadconnected_callback_on_thread__deps: ['$registerGamepadEventCallback'],
   emscripten_set_gamepadconnected_callback_on_thread: function(userData, useCapture, callbackfunc, targetThread) {
     if (!navigator.getGamepads && !navigator.webkitGetGamepads) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
@@ -2229,7 +2229,7 @@ var LibraryHTML5 = {
   },
   
   emscripten_set_gamepaddisconnected_callback_on_thread__proxy: 'sync',
-  emscripten_set_gamepaddisconnected_callback_on_thread__sig: 'iiiii',
+  emscripten_set_gamepaddisconnected_callback_on_thread__sig: 'ipipp',
   emscripten_set_gamepaddisconnected_callback_on_thread__deps: ['$registerGamepadEventCallback'],
   emscripten_set_gamepaddisconnected_callback_on_thread: function(userData, useCapture, callbackfunc, targetThread) {
     if (!navigator.getGamepads && !navigator.webkitGetGamepads) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
@@ -2258,7 +2258,7 @@ var LibraryHTML5 = {
   },
   
   emscripten_get_gamepad_status__proxy: 'sync',
-  emscripten_get_gamepad_status__sig: 'iii',
+  emscripten_get_gamepad_status__sig: 'iip',
   emscripten_get_gamepad_status__deps: ['$JSEvents', '$fillGamepadEventData'],
   emscripten_get_gamepad_status: function(index, gamepadState) {
 #if ASSERTIONS
@@ -2376,7 +2376,7 @@ var LibraryHTML5 = {
   },
   
   emscripten_get_battery_status__proxy: 'sync',
-  emscripten_get_battery_status__sig: 'ii',
+  emscripten_get_battery_status__sig: 'ip',
   emscripten_get_battery_status__deps: ['$fillBatteryEventData', '$battery'],
   emscripten_get_battery_status: function(batteryState) {
     if (!battery()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}}; 
@@ -2492,7 +2492,7 @@ var LibraryHTML5 = {
   emscripten_set_canvas_element_size_main_thread: function(target, width, height) { return _emscripten_set_canvas_element_size_calling_thread(target, width, height); },
 
   emscripten_set_canvas_element_size__deps: ['$JSEvents', 'emscripten_set_canvas_element_size_calling_thread', 'emscripten_set_canvas_element_size_main_thread', '$findCanvasEventTarget'],
-  emscripten_set_canvas_element_size__sig: 'iiii',
+  emscripten_set_canvas_element_size__sig: 'ipii',
   emscripten_set_canvas_element_size: function(target, width, height) {
 #if GL_DEBUG
     dbg('emscripten_set_canvas_element_size(target='+target+',width='+width+',height='+height);
@@ -2505,7 +2505,7 @@ var LibraryHTML5 = {
   },
 #else
   emscripten_set_canvas_element_size__deps: ['$JSEvents', '$findCanvasEventTarget'],
-  emscripten_set_canvas_element_size__sig: 'iiii',
+  emscripten_set_canvas_element_size__sig: 'ipii',
   emscripten_set_canvas_element_size: function(target, width, height) {
 #if GL_DEBUG
     dbg('emscripten_set_canvas_element_size(target='+target+',width='+width+',height='+height);
@@ -2577,7 +2577,7 @@ var LibraryHTML5 = {
   emscripten_get_canvas_element_size_main_thread__deps: ['emscripten_get_canvas_element_size_calling_thread'],
   emscripten_get_canvas_element_size_main_thread: function(target, width, height) { return _emscripten_get_canvas_element_size_calling_thread(target, width, height); },
 
-  emscripten_get_canvas_element_size__sig: 'ipii',
+  emscripten_get_canvas_element_size__sig: 'ippp',
   emscripten_get_canvas_element_size__deps: ['$JSEvents', 'emscripten_get_canvas_element_size_calling_thread', 'emscripten_get_canvas_element_size_main_thread', '$findCanvasEventTarget'],
   emscripten_get_canvas_element_size: function(target, width, height) {
     var canvas = findCanvasEventTarget(target);
@@ -2613,7 +2613,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_set_element_css_size__proxy: 'sync',
-  emscripten_set_element_css_size__sig: 'iiii',
+  emscripten_set_element_css_size__sig: 'ipdd',
   emscripten_set_element_css_size__deps: ['$JSEvents', '$findEventTarget'],
   emscripten_set_element_css_size: function(target, width, height) {
 #if DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
@@ -2630,7 +2630,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_get_element_css_size__proxy: 'sync',
-  emscripten_get_element_css_size__sig: 'iiii',
+  emscripten_get_element_css_size__sig: 'ippp',
   emscripten_get_element_css_size__deps: ['$JSEvents', '$findEventTarget', '$getBoundingClientRect'],
   emscripten_get_element_css_size: function(target, width, height) {
 #if DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR

--- a/src/library_html5_webgl.js
+++ b/src/library_html5_webgl.js
@@ -61,7 +61,7 @@ var LibraryHtml5WebGL = {
 #else
   // When not in offscreen framebuffer mode, these functions are implemented
   // in JS and forwarded without any proxying.
-  emscripten_webgl_create_context__sig: 'iii',
+  emscripten_webgl_create_context__sig: 'ipp',
   emscripten_webgl_create_context: 'emscripten_webgl_do_create_context',
 
   emscripten_webgl_get_current_context__sig: 'i',
@@ -84,7 +84,7 @@ var LibraryHtml5WebGL = {
 #endif
   '$JSEvents', '$emscripten_webgl_power_preferences', '$findEventTarget', '$findCanvasEventTarget'],
   // This function performs proxying manually, depending on the style of context that is to be created.
-  emscripten_webgl_do_create_context__sig: 'iii',
+  emscripten_webgl_do_create_context__sig: 'ipp',
   emscripten_webgl_do_create_context: function(target, attributes) {
 #if ASSERTIONS
     assert(attributes);
@@ -243,7 +243,7 @@ var LibraryHtml5WebGL = {
   },
 
   emscripten_webgl_get_drawing_buffer_size__proxy: 'sync_on_webgl_context_handle_thread',
-  emscripten_webgl_get_drawing_buffer_size__sig: 'iiii',
+  emscripten_webgl_get_drawing_buffer_size__sig: 'iipp',
   emscripten_webgl_get_drawing_buffer_size: function(contextHandle, width, height) {
     var GLContext = GL.getContext(contextHandle);
 
@@ -290,7 +290,7 @@ var LibraryHtml5WebGL = {
   },
 
   emscripten_webgl_get_context_attributes__proxy: 'sync_on_webgl_context_handle_thread',
-  emscripten_webgl_get_context_attributes__sig: 'iii',
+  emscripten_webgl_get_context_attributes__sig: 'iip',
   emscripten_webgl_get_context_attributes__deps: ['$emscripten_webgl_power_preferences'],
   emscripten_webgl_get_context_attributes: function(c, a) {
     if (!a) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
@@ -321,7 +321,7 @@ var LibraryHtml5WebGL = {
   },
 
   emscripten_webgl_destroy_context__proxy: 'sync_on_webgl_context_handle_thread',
-  emscripten_webgl_destroy_context__sig: 'vi',
+  emscripten_webgl_destroy_context__sig: 'ii',
   emscripten_webgl_destroy_context: function(contextHandle) {
     if (GL.currentContext == contextHandle) GL.currentContext = 0;
     GL.deleteContext(contextHandle);
@@ -351,7 +351,7 @@ var LibraryHtml5WebGL = {
 #endif
   ],
   emscripten_webgl_enable_extension__proxy: 'sync_on_webgl_context_handle_thread',
-  emscripten_webgl_enable_extension__sig: 'iii',
+  emscripten_webgl_enable_extension__sig: 'iip',
   emscripten_webgl_enable_extension: function(contextHandle, extension) {
     var context = GL.getContext(contextHandle);
     var extString = UTF8ToString(extension);
@@ -436,7 +436,7 @@ var LibraryHtml5WebGL = {
   },
 
   emscripten_set_webglcontextlost_callback_on_thread__proxy: 'sync',
-  emscripten_set_webglcontextlost_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_webglcontextlost_callback_on_thread__sig: 'ippipp',
   emscripten_set_webglcontextlost_callback_on_thread__deps: ['$registerWebGlEventCallback'],
   emscripten_set_webglcontextlost_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerWebGlEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_WEBGLCONTEXTLOST') }}}, "webglcontextlost", targetThread);
@@ -444,7 +444,7 @@ var LibraryHtml5WebGL = {
   },
 
   emscripten_set_webglcontextrestored_callback_on_thread__proxy: 'sync',
-  emscripten_set_webglcontextrestored_callback_on_thread__sig: 'iiiiii',
+  emscripten_set_webglcontextrestored_callback_on_thread__sig: 'ippipp',
   emscripten_set_webglcontextrestored_callback_on_thread__deps: ['$registerWebGlEventCallback'],
   emscripten_set_webglcontextrestored_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     registerWebGlEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_WEBGLCONTEXTRESTORED') }}}, "webglcontextrestored", targetThread);
@@ -457,47 +457,47 @@ var LibraryHtml5WebGL = {
     return !GL.contexts[contextHandle] || GL.contexts[contextHandle].GLctx.isContextLost(); // No context ~> lost context.
   },
 
-  emscripten_webgl_get_supported_extensions__sig: 'i',
+  emscripten_webgl_get_supported_extensions__sig: 'p',
   emscripten_webgl_get_supported_extensions__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_supported_extensions__deps: ['$stringToNewUTF8'],
   emscripten_webgl_get_supported_extensions: function() {
     return stringToNewUTF8(GLctx.getSupportedExtensions().join(' '));
   },
 
-  emscripten_webgl_get_program_parameter_d__sig: 'fii',
+  emscripten_webgl_get_program_parameter_d__sig: 'dii',
   emscripten_webgl_get_program_parameter_d__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_program_parameter_d: function(program, param) {
     return GLctx.getProgramParameter(GL.programs[program], param);
   },
 
-  emscripten_webgl_get_program_info_log_utf8__sig: 'ii',
+  emscripten_webgl_get_program_info_log_utf8__sig: 'pi',
   emscripten_webgl_get_program_info_log_utf8__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_program_info_log_utf8__deps: ['$stringToNewUTF8'],
   emscripten_webgl_get_program_info_log_utf8: function(program) {
     return stringToNewUTF8(GLctx.getProgramInfoLog(GL.programs[program]));
   },
 
-  emscripten_webgl_get_shader_parameter_d__sig: 'fii',
+  emscripten_webgl_get_shader_parameter_d__sig: 'dii',
   emscripten_webgl_get_shader_parameter_d__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_shader_parameter_d: function(shader, param) {
     return GLctx.getShaderParameter(GL.shaders[shader], param);
   },
 
-  emscripten_webgl_get_shader_info_log_utf8__sig: 'ii',
+  emscripten_webgl_get_shader_info_log_utf8__sig: 'pi',
   emscripten_webgl_get_shader_info_log_utf8__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_shader_info_log_utf8__deps: ['$stringToNewUTF8'],
   emscripten_webgl_get_shader_info_log_utf8: function(shader) {
     return stringToNewUTF8(GLctx.getShaderInfoLog(GL.shaders[shader]));
   },
 
-  emscripten_webgl_get_shader_source_utf8__sig: 'ii',
+  emscripten_webgl_get_shader_source_utf8__sig: 'pi',
   emscripten_webgl_get_shader_source_utf8__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_shader_source_utf8__deps: ['$stringToNewUTF8'],
   emscripten_webgl_get_shader_source_utf8: function(shader) {
     return stringToNewUTF8(GLctx.getShaderSource(GL.shaders[shader]));
   },
 
-  emscripten_webgl_get_vertex_attrib_d__sig: 'iii',
+  emscripten_webgl_get_vertex_attrib_d__sig: 'dii',
   emscripten_webgl_get_vertex_attrib_d__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_vertex_attrib_d: function(index, param) {
     return GLctx.getVertexAttrib(index, param);
@@ -510,35 +510,35 @@ var LibraryHtml5WebGL = {
     return obj && obj.name;
   },
 
-  emscripten_webgl_get_vertex_attrib_v__sig: 'iiiiii',
+  emscripten_webgl_get_vertex_attrib_v__sig: 'iiipii',
   emscripten_webgl_get_vertex_attrib_v__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_vertex_attrib_v__deps: ['$writeGLArray'],
   emscripten_webgl_get_vertex_attrib_v: function(index, param, dst, dstLength, dstType) {
     return writeGLArray(GLctx.getVertexAttrib(index, param), dst, dstLength, dstType);
   },
 
-  emscripten_webgl_get_uniform_d__sig: 'fii',
+  emscripten_webgl_get_uniform_d__sig: 'dii',
   emscripten_webgl_get_uniform_d__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_uniform_d__deps: ['$webglGetUniformLocation'],
   emscripten_webgl_get_uniform_d: function(program, location) {
     return GLctx.getUniform(GL.programs[program], webglGetUniformLocation(location));
   },
 
-  emscripten_webgl_get_uniform_v__sig: 'iiiiii',
+  emscripten_webgl_get_uniform_v__sig: 'iiipii',
   emscripten_webgl_get_uniform_v__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_uniform_v__deps: ['$writeGLArray', '$webglGetUniformLocation'],
   emscripten_webgl_get_uniform_v: function(program, location, dst, dstLength, dstType) {
     return writeGLArray(GLctx.getUniform(GL.programs[program], webglGetUniformLocation(location)), dst, dstLength, dstType);
   },
 
-  emscripten_webgl_get_parameter_v__sig: 'iiiii',
+  emscripten_webgl_get_parameter_v__sig: 'iipii',
   emscripten_webgl_get_parameter_v__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_parameter_v__deps: ['$writeGLArray'],
   emscripten_webgl_get_parameter_v: function(param, dst, dstLength, dstType) {
     return writeGLArray(GLctx.getParameter(param), dst, dstLength, dstType);
   },
 
-  emscripten_webgl_get_parameter_d__sig: 'fi',
+  emscripten_webgl_get_parameter_d__sig: 'di',
   emscripten_webgl_get_parameter_d__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_parameter_d: function(param) {
     return GLctx.getParameter(param);
@@ -551,14 +551,14 @@ var LibraryHtml5WebGL = {
     return obj && obj.name;
   },
 
-  emscripten_webgl_get_parameter_utf8__sig: 'ii',
+  emscripten_webgl_get_parameter_utf8__sig: 'pi',
   emscripten_webgl_get_parameter_utf8__deps: ['$stringToNewUTF8'],
   emscripten_webgl_get_parameter_utf8__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_parameter_utf8: function(param) {
     return stringToNewUTF8(GLctx.getParameter(param));
   },
 
-  emscripten_webgl_get_parameter_i64v__sig: 'vii',
+  emscripten_webgl_get_parameter_i64v__sig: 'vip',
   emscripten_webgl_get_parameter_i64v__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_parameter_i64v__deps: ['$writeI53ToI64'],
   emscripten_webgl_get_parameter_i64v: function(param, dst) {

--- a/src/library_math.js
+++ b/src/library_math.js
@@ -65,7 +65,7 @@ mergeInto(LibraryManager.library, {
   emscripten_math_cosh: function(x) {
     return Math.cosh(x);
   },
-  emscripten_math_hypot__sig: 'iip',
+  emscripten_math_hypot__sig: 'dip',
   emscripten_math_hypot: function(count, varargs) {
     var args = [];
     for (var i = 0; i < count; ++i) args.push(HEAPF64[(varargs>>3) + i]);

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1613,7 +1613,7 @@ var LibraryOpenAL = {
   // bufferFrameCapacity here for clarity.
   alcCaptureOpenDevice__deps: ['$autoResumeAudioContext'],
   alcCaptureOpenDevice__proxy: 'sync',
-  alcCaptureOpenDevice__sig: 'iiiii',
+  alcCaptureOpenDevice__sig: 'ppiii',
   alcCaptureOpenDevice: function(pDeviceName, requestedSampleRate, format, bufferFrameCapacity) {
 
     var resolvedDeviceName = AL.CAPTURE_DEVICE_NAME;
@@ -1905,7 +1905,7 @@ var LibraryOpenAL = {
   },
 
   alcCaptureCloseDevice__proxy: 'sync',
-  alcCaptureCloseDevice__sig: 'ii',
+  alcCaptureCloseDevice__sig: 'ip',
   alcCaptureCloseDevice: function(deviceId) {
     var c = AL.requireValidCaptureDevice(deviceId, 'alcCaptureCloseDevice');
     if (!c) return false;
@@ -1938,7 +1938,7 @@ var LibraryOpenAL = {
   },
 
   alcCaptureStart__proxy: 'sync',
-  alcCaptureStart__sig: 'vi',
+  alcCaptureStart__sig: 'vp',
   alcCaptureStart: function(deviceId) {
     var c = AL.requireValidCaptureDevice(deviceId, 'alcCaptureStart');
     if (!c) return;
@@ -1959,7 +1959,7 @@ var LibraryOpenAL = {
   },
 
   alcCaptureStop__proxy: 'sync',
-  alcCaptureStop__sig: 'vi',
+  alcCaptureStop__sig: 'vp',
   alcCaptureStop: function(deviceId) {
     var c = AL.requireValidCaptureDevice(deviceId, 'alcCaptureStop');
     if (!c) return;
@@ -1978,7 +1978,7 @@ var LibraryOpenAL = {
   // The last parameter is actually 'number of sample frames', so was
   // renamed accordingly here
   alcCaptureSamples__proxy: 'sync',
-  alcCaptureSamples__sig: 'viii',
+  alcCaptureSamples__sig: 'vppi',
   alcCaptureSamples: function(deviceId, pFrames, requestedFrameCount) {
     var c = AL.requireValidCaptureDevice(deviceId, 'alcCaptureSamples');
     if (!c) return;
@@ -2066,7 +2066,7 @@ var LibraryOpenAL = {
   // -------------------------------------------------------
 
   alcOpenDevice__proxy: 'sync',
-  alcOpenDevice__sig: 'ii',
+  alcOpenDevice__sig: 'pp',
   alcOpenDevice: function(pDeviceName) {
     if (pDeviceName) {
       var name = UTF8ToString(pDeviceName);
@@ -2084,7 +2084,7 @@ var LibraryOpenAL = {
   },
 
   alcCloseDevice__proxy: 'sync',
-  alcCloseDevice__sig: 'ii',
+  alcCloseDevice__sig: 'ip',
   alcCloseDevice: function(deviceId) {
     if (!(deviceId in AL.deviceRefCounts) || AL.deviceRefCounts[deviceId] > 0) {
       return {{{ cDefine('ALC_FALSE') }}};
@@ -2097,7 +2097,7 @@ var LibraryOpenAL = {
 
   alcCreateContext__deps: ['$autoResumeAudioContext'],
   alcCreateContext__proxy: 'sync',
-  alcCreateContext__sig: 'iii',
+  alcCreateContext__sig: 'ppp',
   alcCreateContext: function(deviceId, pAttrList) {
     if (!(deviceId in AL.deviceRefCounts)) {
 #if OPENAL_DEBUG
@@ -2252,7 +2252,7 @@ var LibraryOpenAL = {
   },
 
   alcDestroyContext__proxy: 'sync',
-  alcDestroyContext__sig: 'vi',
+  alcDestroyContext__sig: 'vp',
   alcDestroyContext: function(contextId) {
     var ctx = AL.contexts[contextId];
     if (AL.currentCtx === ctx) {
@@ -2277,7 +2277,7 @@ var LibraryOpenAL = {
   // -------------------------------------------------------
 
   alcGetError__proxy: 'sync',
-  alcGetError__sig: 'ii',
+  alcGetError__sig: 'ip',
   alcGetError: function(deviceId) {
     var err = AL.alcErr;
     AL.alcErr = {{{ cDefine('ALC_NO_ERROR') }}};
@@ -2285,7 +2285,7 @@ var LibraryOpenAL = {
   },
 
   alcGetCurrentContext__proxy: 'sync',
-  alcGetCurrentContext__sig: 'i',
+  alcGetCurrentContext__sig: 'p',
   alcGetCurrentContext: function() {
     if (AL.currentCtx !== null) {
       return AL.currentCtx.id;
@@ -2294,7 +2294,7 @@ var LibraryOpenAL = {
   },
 
   alcMakeContextCurrent__proxy: 'sync',
-  alcMakeContextCurrent__sig: 'ii',
+  alcMakeContextCurrent__sig: 'ip',
   alcMakeContextCurrent: function(contextId) {
     if (contextId === 0) {
       AL.currentCtx = null;
@@ -2305,7 +2305,7 @@ var LibraryOpenAL = {
   },
 
   alcGetContextsDevice__proxy: 'sync',
-  alcGetContextsDevice__sig: 'ii',
+  alcGetContextsDevice__sig: 'pp',
   alcGetContextsDevice: function(contextId) {
     if (contextId in AL.contexts) {
       return AL.contexts[contextId].deviceId;
@@ -2314,13 +2314,13 @@ var LibraryOpenAL = {
   },
 
   // The spec is vague about what these are actually supposed to do, and NOP is a reasonable implementation
-  alcProcessContext__sig: 'vi',
+  alcProcessContext__sig: 'vp',
   alcProcessContext: function(contextId) {},
-  alcSuspendContext__sig: 'vi',
+  alcSuspendContext__sig: 'vp',
   alcSuspendContext: function(contextId) {},
 
   alcIsExtensionPresent__proxy: 'sync',
-  alcIsExtensionPresent__sig: 'iii',
+  alcIsExtensionPresent__sig: 'ipp',
   alcIsExtensionPresent: function(deviceId, pExtName) {
     var name = UTF8ToString(pExtName);
 
@@ -2328,7 +2328,7 @@ var LibraryOpenAL = {
   },
 
   alcGetEnumValue__proxy: 'sync',
-  alcGetEnumValue__sig: 'iii',
+  alcGetEnumValue__sig: 'ipp',
   alcGetEnumValue: function(deviceId, pEnumName) {
     // Spec says :
     // Using a NULL handle is legal, but only the
@@ -2393,7 +2393,7 @@ var LibraryOpenAL = {
   },
 
   alcGetString__proxy: 'sync',
-  alcGetString__sig: 'iii',
+  alcGetString__sig: 'ppi',
   alcGetString__deps: ['$allocateUTF8'],
   alcGetString: function(deviceId, param) {
     if (AL.alcStringCache[param]) {
@@ -2474,7 +2474,7 @@ var LibraryOpenAL = {
   },
 
   alcGetIntegerv__proxy: 'sync',
-  alcGetIntegerv__sig: 'viiii',
+  alcGetIntegerv__sig: 'vpiip',
   alcGetIntegerv: function(deviceId, param, size, pValues) {
     if (size === 0 || !pValues) {
       // Ignore the query, per the spec
@@ -2751,7 +2751,7 @@ var LibraryOpenAL = {
   // -------------------------------------------------------
 
   alGenBuffers__proxy: 'sync',
-  alGenBuffers__sig: 'vii',
+  alGenBuffers__sig: 'vip',
   alGenBuffers: function(count, pBufferIds) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -2778,7 +2778,7 @@ var LibraryOpenAL = {
   },
 
   alDeleteBuffers__proxy: 'sync',
-  alDeleteBuffers__sig: 'vii',
+  alDeleteBuffers__sig: 'vip',
   alDeleteBuffers: function(count, pBufferIds) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -2826,7 +2826,7 @@ var LibraryOpenAL = {
   },
 
   alGenSources__proxy: 'sync',
-  alGenSources__sig: 'vii',
+  alGenSources__sig: 'vip',
   alGenSources: function(count, pSourceIds) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -2878,7 +2878,7 @@ var LibraryOpenAL = {
 
   alDeleteSources__deps: ['alSourcei'],
   alDeleteSources__proxy: 'sync',
-  alDeleteSources__sig: 'vii',
+  alDeleteSources__sig: 'vip',
   alDeleteSources: function(count, pSourceIds) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -2924,7 +2924,7 @@ var LibraryOpenAL = {
   },
 
   alIsExtensionPresent__proxy: 'sync',
-  alIsExtensionPresent__sig: 'ii',
+  alIsExtensionPresent__sig: 'ip',
   alIsExtensionPresent: function(pExtName) {
     var name = UTF8ToString(pExtName);
 
@@ -2932,7 +2932,7 @@ var LibraryOpenAL = {
   },
 
   alGetEnumValue__proxy: 'sync',
-  alGetEnumValue__sig: 'ii',
+  alGetEnumValue__sig: 'ip',
   alGetEnumValue: function(pEnumName) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -3044,7 +3044,7 @@ var LibraryOpenAL = {
   },
 
   alGetString__proxy: 'sync',
-  alGetString__sig: 'ii',
+  alGetString__sig: 'pi',
   alGetString__deps: ['$allocateUTF8'],
   alGetString: function(param) {
     if (AL.stringCache[param]) {
@@ -3194,7 +3194,7 @@ var LibraryOpenAL = {
   },
 
   alGetDoublev__proxy: 'sync',
-  alGetDoublev__sig: 'vii',
+  alGetDoublev__sig: 'vip',
   alGetDoublev: function(param, pValues) {
     var val = AL.getGlobalParam('alGetDoublev', param);
     // Silently ignore null destinations, as per the spec for global state functions
@@ -3239,7 +3239,7 @@ var LibraryOpenAL = {
   },
 
   alGetFloatv__proxy: 'sync',
-  alGetFloatv__sig: 'vii',
+  alGetFloatv__sig: 'vip',
   alGetFloatv: function(param, pValues) {
     var val = AL.getGlobalParam('alGetFloatv', param);
     // Silently ignore null destinations, as per the spec for global state functions
@@ -3285,7 +3285,7 @@ var LibraryOpenAL = {
   },
 
   alGetIntegerv__proxy: 'sync',
-  alGetIntegerv__sig: 'vii',
+  alGetIntegerv__sig: 'vip',
   alGetIntegerv: function(param, pValues) {
     var val = AL.getGlobalParam('alGetIntegerv', param);
     // Silently ignore null destinations, as per the spec for global state functions
@@ -3331,7 +3331,7 @@ var LibraryOpenAL = {
   },
 
   alGetBooleanv__proxy: 'sync',
-  alGetBooleanv__sig: 'vii',
+  alGetBooleanv__sig: 'vip',
   alGetBooleanv: function(param, pValues) {
     var val = AL.getGlobalParam('alGetBooleanv', param);
     // Silently ignore null destinations, as per the spec for global state functions
@@ -3361,13 +3361,13 @@ var LibraryOpenAL = {
   },
 
   alSpeedOfSound__proxy: 'sync',
-  alSpeedOfSound__sig: 'vi',
+  alSpeedOfSound__sig: 'vf',
   alSpeedOfSound: function(value) {
     AL.setGlobalParam('alSpeedOfSound', {{{ cDefine('AL_SPEED_OF_SOUND') }}}, value);
   },
 
   alDopplerFactor__proxy: 'sync',
-  alDopplerFactor__sig: 'vi',
+  alDopplerFactor__sig: 'vf',
   alDopplerFactor: function(value) {
     AL.setGlobalParam('alDopplerFactor', {{{ cDefine('AL_DOPPLER_FACTOR') }}}, value);
   },
@@ -3377,7 +3377,7 @@ var LibraryOpenAL = {
   // It's deprecated since it's equivalent to directly calling
   // alSpeedOfSound() with an appropriately premultiplied value.
   alDopplerVelocity__proxy: 'sync',
-  alDopplerVelocity__sig: 'vi',
+  alDopplerVelocity__sig: 'vf',
   alDopplerVelocity: function(value) {
     warnOnce('alDopplerVelocity() is deprecated, and only kept for compatibility with OpenAL 1.0. Use alSpeedOfSound() instead.');
     if (!AL.currentCtx) {
@@ -3397,7 +3397,7 @@ var LibraryOpenAL = {
   // -------------------------------------------------------
 
   alGetListenerf__proxy: 'sync',
-  alGetListenerf__sig: 'vii',
+  alGetListenerf__sig: 'vip',
   alGetListenerf: function(param, pValue) {
     var val = AL.getListenerParam('alGetListenerf', param);
     if (val === null) {
@@ -3425,7 +3425,7 @@ var LibraryOpenAL = {
   },
 
   alGetListener3f__proxy: 'sync',
-  alGetListener3f__sig: 'viiii',
+  alGetListener3f__sig: 'vippp',
   alGetListener3f: function(param, pValue0, pValue1, pValue2) {
     var val = AL.getListenerParam('alGetListener3f', param);
     if (val === null) {
@@ -3456,7 +3456,7 @@ var LibraryOpenAL = {
   },
 
   alGetListenerfv__proxy: 'sync',
-  alGetListenerfv__sig: 'vii',
+  alGetListenerfv__sig: 'vip',
   alGetListenerfv: function(param, pValues) {
     var val = AL.getListenerParam('alGetListenerfv', param);
     if (val === null) {
@@ -3495,7 +3495,7 @@ var LibraryOpenAL = {
   },
 
   alGetListeneri__proxy: 'sync',
-  alGetListeneri__sig: 'vii',
+  alGetListeneri__sig: 'vip',
   alGetListeneri: function(param, pValue) {
     var val = AL.getListenerParam('alGetListeneri', param);
     if (val === null) {
@@ -3516,7 +3516,7 @@ var LibraryOpenAL = {
   },
 
   alGetListener3i__proxy: 'sync',
-  alGetListener3i__sig: 'viiii',
+  alGetListener3i__sig: 'vippp',
   alGetListener3i: function(param, pValue0, pValue1, pValue2) {
     var val = AL.getListenerParam('alGetListener3i', param);
     if (val === null) {
@@ -3547,7 +3547,7 @@ var LibraryOpenAL = {
   },
 
   alGetListeneriv__proxy: 'sync',
-  alGetListeneriv__sig: 'vii',
+  alGetListeneriv__sig: 'vip',
   alGetListeneriv: function(param, pValues) {
     var val = AL.getListenerParam('alGetListeneriv', param);
     if (val === null) {
@@ -3616,7 +3616,7 @@ var LibraryOpenAL = {
   },
 
   alListenerfv__proxy: 'sync',
-  alListenerfv__sig: 'vii',
+  alListenerfv__sig: 'vip',
   alListenerfv: function(param, pValues) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -3679,7 +3679,7 @@ var LibraryOpenAL = {
   },
 
   alListeneriv__proxy: 'sync',
-  alListeneriv__sig: 'vii',
+  alListeneriv__sig: 'vip',
   alListeneriv: function(param, pValues) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -3739,7 +3739,7 @@ var LibraryOpenAL = {
   },
 
   alBufferData__proxy: 'sync',
-  alBufferData__sig: 'viiiii',
+  alBufferData__sig: 'viipii',
   alBufferData: function(bufferId, format, pData, size, freq) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -3867,7 +3867,7 @@ var LibraryOpenAL = {
   },
 
   alGetBufferf__proxy: 'sync',
-  alGetBufferf__sig: 'viii',
+  alGetBufferf__sig: 'viip',
   alGetBufferf: function(bufferId, param, pValue) {
     var val = AL.getBufferParam('alGetBufferf', bufferId, param);
     if (val === null) {
@@ -3888,7 +3888,7 @@ var LibraryOpenAL = {
   },
 
   alGetBuffer3f__proxy: 'sync',
-  alGetBuffer3f__sig: 'viiiii',
+  alGetBuffer3f__sig: 'viippp',
   alGetBuffer3f: function(bufferId, param, pValue0, pValue1, pValue2) {
     var val = AL.getBufferParam('alGetBuffer3f', bufferId, param);
     if (val === null) {
@@ -3909,7 +3909,7 @@ var LibraryOpenAL = {
   },
 
   alGetBufferfv__proxy: 'sync',
-  alGetBufferfv__sig: 'viii',
+  alGetBufferfv__sig: 'viip',
   alGetBufferfv: function(bufferId, param, pValues) {
     var val = AL.getBufferParam('alGetBufferfv', bufferId, param);
     if (val === null) {
@@ -3930,7 +3930,7 @@ var LibraryOpenAL = {
   },
 
   alGetBufferi__proxy: 'sync',
-  alGetBufferi__sig: 'viii',
+  alGetBufferi__sig: 'viip',
   alGetBufferi: function(bufferId, param, pValue) {
     var val = AL.getBufferParam('alGetBufferi', bufferId, param);
     if (val === null) {
@@ -3961,7 +3961,7 @@ var LibraryOpenAL = {
   },
 
   alGetBuffer3i__proxy: 'sync',
-  alGetBuffer3i__sig: 'viiiii',
+  alGetBuffer3i__sig: 'viippp',
   alGetBuffer3i: function(bufferId, param, pValue0, pValue1, pValue2) {
     var val = AL.getBufferParam('alGetBuffer3i', bufferId, param);
     if (val === null) {
@@ -3982,7 +3982,7 @@ var LibraryOpenAL = {
   },
 
   alGetBufferiv__proxy: 'sync',
-  alGetBufferiv__sig: 'viii',
+  alGetBufferiv__sig: 'viip',
   alGetBufferiv: function(bufferId, param, pValues) {
     var val = AL.getBufferParam('alGetBufferiv', bufferId, param);
     if (val === null) {
@@ -4033,7 +4033,7 @@ var LibraryOpenAL = {
   },
 
   alBufferfv__proxy: 'sync',
-  alBufferfv__sig: 'viii',
+  alBufferfv__sig: 'viip',
   alBufferfv: function(bufferId, param, pValues) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -4065,7 +4065,7 @@ var LibraryOpenAL = {
   },
 
   alBufferiv__proxy: 'sync',
-  alBufferiv__sig: 'viii',
+  alBufferiv__sig: 'viip',
   alBufferiv: function(bufferId, param, pValues) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -4111,7 +4111,7 @@ var LibraryOpenAL = {
   },
 
   alSourceQueueBuffers__proxy: 'sync',
-  alSourceQueueBuffers__sig: 'viii',
+  alSourceQueueBuffers__sig: 'viip',
   alSourceQueueBuffers: function(sourceId, count, pBufferIds) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -4195,7 +4195,7 @@ var LibraryOpenAL = {
   },
 
   alSourceUnqueueBuffers__proxy: 'sync',
-  alSourceUnqueueBuffers__sig: 'viii',
+  alSourceUnqueueBuffers__sig: 'viip',
   alSourceUnqueueBuffers: function(sourceId, count, pBufferIds) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -4258,7 +4258,7 @@ var LibraryOpenAL = {
   },
 
   alSourcePlayv__proxy: 'sync',
-  alSourcePlayv__sig: 'vii',
+  alSourcePlayv__sig: 'vip',
   alSourcePlayv: function(count, pSourceIds) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -4309,7 +4309,7 @@ var LibraryOpenAL = {
   },
 
   alSourceStopv__proxy: 'sync',
-  alSourceStopv__sig: 'vii',
+  alSourceStopv__sig: 'vip',
   alSourceStopv: function(count, pSourceIds) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -4363,7 +4363,7 @@ var LibraryOpenAL = {
   },
 
   alSourceRewindv__proxy: 'sync',
-  alSourceRewindv__sig: 'vii',
+  alSourceRewindv__sig: 'vip',
   alSourceRewindv: function(count, pSourceIds) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -4414,7 +4414,7 @@ var LibraryOpenAL = {
   },
 
   alSourcePausev__proxy: 'sync',
-  alSourcePausev__sig: 'vii',
+  alSourcePausev__sig: 'vip',
   alSourcePausev: function(count, pSourceIds) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -4445,7 +4445,7 @@ var LibraryOpenAL = {
   },
 
   alGetSourcef__proxy: 'sync',
-  alGetSourcef__sig: 'viii',
+  alGetSourcef__sig: 'viip',
   alGetSourcef: function(sourceId, param, pValue) {
     var val = AL.getSourceParam('alGetSourcef', sourceId, param);
     if (val === null) {
@@ -4486,7 +4486,7 @@ var LibraryOpenAL = {
   },
 
   alGetSource3f__proxy: 'sync',
-  alGetSource3f__sig: 'viiiii',
+  alGetSource3f__sig: 'viippp',
   alGetSource3f: function(sourceId, param, pValue0, pValue1, pValue2) {
     var val = AL.getSourceParam('alGetSource3f', sourceId, param);
     if (val === null) {
@@ -4518,7 +4518,7 @@ var LibraryOpenAL = {
   },
 
   alGetSourcefv__proxy: 'sync',
-  alGetSourcefv__sig: 'viii',
+  alGetSourcefv__sig: 'viip',
   alGetSourcefv: function(sourceId, param, pValues) {
     var val = AL.getSourceParam('alGetSourcefv', sourceId, param);
     if (val === null) {
@@ -4566,7 +4566,7 @@ var LibraryOpenAL = {
   },
 
   alGetSourcei__proxy: 'sync',
-  alGetSourcei__sig: 'viii',
+  alGetSourcei__sig: 'viip',
   alGetSourcei: function(sourceId, param, pValue) {
     var val = AL.getSourceParam('alGetSourcei', sourceId, param);
     if (val === null) {
@@ -4612,7 +4612,7 @@ var LibraryOpenAL = {
   },
 
   alGetSource3i__proxy: 'sync',
-  alGetSource3i__sig: 'viiiii',
+  alGetSource3i__sig: 'viippp',
   alGetSource3i: function(sourceId, param, pValue0, pValue1, pValue2) {
     var val = AL.getSourceParam('alGetSource3i', sourceId, param);
     if (val === null) {
@@ -4644,7 +4644,7 @@ var LibraryOpenAL = {
   },
 
   alGetSourceiv__proxy: 'sync',
-  alGetSourceiv__sig: 'viii',
+  alGetSourceiv__sig: 'viip',
   alGetSourceiv: function(sourceId, param, pValues) {
     var val = AL.getSourceParam('alGetSourceiv', sourceId, param);
     if (val === null) {
@@ -4741,7 +4741,7 @@ var LibraryOpenAL = {
   },
 
   alSourcefv__proxy: 'sync',
-  alSourcefv__sig: 'viii',
+  alSourcefv__sig: 'viip',
   alSourcefv: function(sourceId, param, pValues) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
@@ -4835,7 +4835,7 @@ var LibraryOpenAL = {
   },
 
   alSourceiv__proxy: 'sync',
-  alSourceiv__sig: 'viii',
+  alSourceiv__sig: 'viip',
   alSourceiv: function(sourceId, param, pValues) {
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1337,7 +1337,7 @@ var LibrarySDL = {
   },
 
   SDL_Linked_Version__proxy: 'sync',
-  SDL_Linked_Version__sig: 'i',
+  SDL_Linked_Version__sig: 'p',
   SDL_Linked_Version: function() {
     if (SDL.version === null) {
       SDL.version = _malloc({{{ C_STRUCTS.SDL_version.__size__ }}});
@@ -1408,7 +1408,7 @@ var LibrarySDL = {
 
   SDL_GetVideoInfo__deps: ['$zeroMemory'],
   SDL_GetVideoInfo__proxy: 'sync',
-  SDL_GetVideoInfo__sig: 'i',
+  SDL_GetVideoInfo__sig: 'p',
   SDL_GetVideoInfo: function() {
     var ret = _malloc({{{ C_STRUCTS.SDL_VideoInfo.__size__ }}});
     zeroMemory(ret, {{{ C_STRUCTS.SDL_version.__size__ }}});
@@ -1433,7 +1433,7 @@ var LibrarySDL = {
   },
 
   SDL_VideoDriverName__proxy: 'sync',
-  SDL_VideoDriverName__sig: 'iii',
+  SDL_VideoDriverName__sig: 'ppi',
   SDL_VideoDriverName: function(buf, max_size) {
     if (SDL.startTime === null) {
       return 0; //return NULL
@@ -1461,7 +1461,7 @@ var LibrarySDL = {
 
   SDL_SetVideoMode__deps: ['$GL'],
   SDL_SetVideoMode__proxy: 'sync',
-  SDL_SetVideoMode__sig: 'iiiii',
+  SDL_SetVideoMode__sig: 'piiii',
   SDL_SetVideoMode: function(width, height, depth, flags) {
     ['touchstart', 'touchend', 'touchmove', 'mousedown', 'mouseup', 'mousemove', 'DOMMouseScroll', 'mousewheel', 'wheel', 'mouseout'].forEach(function(event) {
       Module['canvas'].addEventListener(event, SDL.receiveEvent, true);
@@ -1506,7 +1506,7 @@ var LibrarySDL = {
   },
 
   SDL_GetVideoSurface__proxy: 'sync',
-  SDL_GetVideoSurface__sig: 'i',
+  SDL_GetVideoSurface__sig: 'p',
   SDL_GetVideoSurface: function() {
     return SDL.screen;
   },
@@ -1542,7 +1542,7 @@ var LibrarySDL = {
 
   // Copy data from the canvas backing to a C++-accessible storage
   SDL_LockSurface__proxy: 'sync',
-  SDL_LockSurface__sig: 'ii',
+  SDL_LockSurface__sig: 'ip',
   SDL_LockSurface: function(surf) {
     var surfData = SDL.surfaces[surf];
 
@@ -1612,7 +1612,7 @@ var LibrarySDL = {
 
   // Copy data from the C++-accessible storage to the canvas backing
   SDL_UnlockSurface__proxy: 'sync',
-  SDL_UnlockSurface__sig: 'vi',
+  SDL_UnlockSurface__sig: 'vp',
   SDL_UnlockSurface: function(surf) {
     assert(!SDL.GL); // in GL mode we do not keep around 2D canvases and contexts
 
@@ -1746,7 +1746,7 @@ var LibrarySDL = {
 #endif
 
   SDL_WM_SetCaption__proxy: 'sync',
-  SDL_WM_SetCaption__sig: 'vii',
+  SDL_WM_SetCaption__sig: 'vpp',
   SDL_WM_SetCaption: function(title, icon) {
     if (title && typeof setWindowTitle != 'undefined') {
       setWindowTitle(UTF8ToString(title));
@@ -1759,7 +1759,7 @@ var LibrarySDL = {
   },
 
   SDL_GetKeyboardState__proxy: 'sync',
-  SDL_GetKeyboardState__sig: 'ii',
+  SDL_GetKeyboardState__sig: 'pp',
   SDL_GetKeyboardState__docs: '/** @param {number=} numKeys */',
   SDL_GetKeyboardState: function(numKeys) {
     if (numKeys) {
@@ -1774,7 +1774,7 @@ var LibrarySDL = {
   },
 
   SDL_GetKeyName__proxy: 'sync',
-  SDL_GetKeyName__sig: 'ii',
+  SDL_GetKeyName__sig: 'pi',
   SDL_GetKeyName__deps: ['$allocateUTF8'],
   SDL_GetKeyName: function(key) {
     if (!SDL.keyName) {
@@ -1790,7 +1790,7 @@ var LibrarySDL = {
   },
 
   SDL_GetMouseState__proxy: 'sync',
-  SDL_GetMouseState__sig: 'iii',
+  SDL_GetMouseState__sig: 'ipp',
   SDL_GetMouseState: function(x, y) {
     if (x) {{{ makeSetValue('x', '0', 'Browser.mouseX', 'i32') }}};
     if (y) {{{ makeSetValue('y', '0', 'Browser.mouseY', 'i32') }}};
@@ -1834,7 +1834,7 @@ var LibrarySDL = {
   },
 
   SDL_GetError__proxy: 'sync',
-  SDL_GetError__sig: 'i',
+  SDL_GetError__sig: 'p',
   SDL_GetError__deps: ['$allocateUTF8'],
   SDL_GetError: function() {
     if (!SDL.errorMessage) {
@@ -1847,13 +1847,13 @@ var LibrarySDL = {
 
   SDL_CreateRGBSurface__deps: ['malloc', 'free'],
   SDL_CreateRGBSurface__proxy: 'sync',
-  SDL_CreateRGBSurface__sig: 'iiiiiiiii',
+  SDL_CreateRGBSurface__sig: 'piiiiiiii',
   SDL_CreateRGBSurface: function(flags, width, height, depth, rmask, gmask, bmask, amask) {
     return SDL.makeSurface(width, height, flags, false, 'CreateRGBSurface', rmask, gmask, bmask, amask);
   },
 
   SDL_CreateRGBSurfaceFrom__proxy: 'sync',
-  SDL_CreateRGBSurfaceFrom__sig: 'iiiiiiiiii',
+  SDL_CreateRGBSurfaceFrom__sig: 'ppiiiiiiii',
   SDL_CreateRGBSurfaceFrom: function(pixels, width, height, depth, pitch, rmask, gmask, bmask, amask) {
     var surf = SDL.makeSurface(width, height, 0, false, 'CreateRGBSurfaceFrom', rmask, gmask, bmask, amask);
 
@@ -1883,7 +1883,7 @@ var LibrarySDL = {
   },
 
   SDL_ConvertSurface__proxy: 'sync',
-  SDL_ConvertSurface__sig: 'iiii',
+  SDL_ConvertSurface__sig: 'pppi',
   SDL_ConvertSurface__docs: '/** @param {number=} format @param {number=} flags */',
   SDL_ConvertSurface: function(surf, format, flags) {
     if  (format) {
@@ -1906,19 +1906,19 @@ var LibrarySDL = {
   },
 
   SDL_FreeSurface__proxy: 'sync',
-  SDL_FreeSurface__sig: 'vi',
+  SDL_FreeSurface__sig: 'vp',
   SDL_FreeSurface: function(surf) {
     if (surf) SDL.freeSurface(surf);
   },
 
   SDL_UpperBlit__proxy: 'sync',
-  SDL_UpperBlit__sig: 'iiiii',
+  SDL_UpperBlit__sig: 'ipppp',
   SDL_UpperBlit: function(src, srcrect, dst, dstrect) {
     return SDL.blitSurface(src, srcrect, dst, dstrect, false);
   },
 
   SDL_UpperBlitScaled__proxy: 'sync',
-  SDL_UpperBlitScaled__sig: 'iiiii',
+  SDL_UpperBlitScaled__sig: 'ipppp',
   SDL_UpperBlitScaled: function(src, srcrect, dst, dstrect) {
     return SDL.blitSurface(src, srcrect, dst, dstrect, true);
   },
@@ -1927,7 +1927,7 @@ var LibrarySDL = {
   SDL_LowerBlitScaled: 'SDL_UpperBlitScaled',
 
   SDL_GetClipRect__proxy: 'sync',
-  SDL_GetClipRect__sig: 'vii',
+  SDL_GetClipRect__sig: 'vpp',
   SDL_GetClipRect: function(surf, rect) {
     assert(rect);
 
@@ -1937,7 +1937,7 @@ var LibrarySDL = {
   },
 
   SDL_SetClipRect__proxy: 'sync',
-  SDL_SetClipRect__sig: 'iii',
+  SDL_SetClipRect__sig: 'ipp',
   SDL_SetClipRect: function(surf, rect) {
     var surfData = SDL.surfaces[surf];
 
@@ -1949,7 +1949,7 @@ var LibrarySDL = {
   },
 
   SDL_FillRect__proxy: 'sync',
-  SDL_FillRect__sig: 'iiii',
+  SDL_FillRect__sig: 'ippi',
   SDL_FillRect: function(surf, rect, color) {
     var surfData = SDL.surfaces[surf];
     assert(!surfData.locked); // but we could unlock and re-lock if we must..
@@ -2014,7 +2014,7 @@ var LibrarySDL = {
   },
 
   SDL_SetAlpha__proxy: 'sync',
-  SDL_SetAlpha__sig: 'iiii',
+  SDL_SetAlpha__sig: 'ipii',
   SDL_SetAlpha: function(surf, flag, alpha) {
     var surfData = SDL.surfaces[surf];
     surfData.alpha = alpha;
@@ -2039,13 +2039,13 @@ var LibrarySDL = {
   },
 
   SDL_PollEvent__proxy: 'sync',
-  SDL_PollEvent__sig: 'ii',
+  SDL_PollEvent__sig: 'ip',
   SDL_PollEvent: function(ptr) {
     return SDL.pollEvent(ptr);
   },
 
   SDL_PushEvent__proxy: 'sync',
-  SDL_PushEvent__sig: 'ii',
+  SDL_PushEvent__sig: 'ip',
   SDL_PushEvent__deps: ['malloc'],
   SDL_PushEvent: function(ptr) {
     var copy = _malloc({{{ C_STRUCTS.SDL_KeyboardEvent.__size__ }}});
@@ -2055,7 +2055,7 @@ var LibrarySDL = {
   },
 
   SDL_PeepEvents__proxy: 'sync',
-  SDL_PeepEvents__sig: 'iiiiii',
+  SDL_PeepEvents__sig: 'ipiiii',
   SDL_PeepEvents: function(events, requestedEventCount, action, from, to) {
     switch (action) {
       case 2: { // SDL_GETEVENT
@@ -2098,7 +2098,7 @@ var LibrarySDL = {
   // Allow recording a callback that will be called for each received event.
   emscripten_SDL_SetEventHandler__proxy: 'sync',
   emscripten_SDL_SetEventHandler__deps: ['malloc'],
-  emscripten_SDL_SetEventHandler__sig: 'vii',
+  emscripten_SDL_SetEventHandler__sig: 'vpp',
   emscripten_SDL_SetEventHandler: function(handler, userdata) {
     SDL.eventHandler = handler;
     SDL.eventHandlerContext = userdata;
@@ -2108,7 +2108,7 @@ var LibrarySDL = {
   },
 
   SDL_SetColors__proxy: 'sync',
-  SDL_SetColors__sig: 'iiiii',
+  SDL_SetColors__sig: 'ippii',
   SDL_SetColors: function(surf, colors, firstColor, nColors) {
     var surfData = SDL.surfaces[surf];
 
@@ -2139,7 +2139,7 @@ var LibrarySDL = {
   },
 
   SDL_MapRGB__proxy: 'sync',
-  SDL_MapRGB__sig: 'iiiii',
+  SDL_MapRGB__sig: 'ipiii',
   SDL_MapRGB: function(fmt, r, g, b) {
     SDL.checkPixelFormat(fmt);
     // We assume the machine is little-endian.
@@ -2147,7 +2147,7 @@ var LibrarySDL = {
   },
 
   SDL_MapRGBA__proxy: 'sync',
-  SDL_MapRGBA__sig: 'iiiiii',
+  SDL_MapRGBA__sig: 'ipiiii',
   SDL_MapRGBA: function(fmt, r, g, b, a) {
     SDL.checkPixelFormat(fmt);
     // We assume the machine is little-endian.
@@ -2155,7 +2155,7 @@ var LibrarySDL = {
   },
 
   SDL_GetRGB__proxy: 'sync',
-  SDL_GetRGB__sig: 'viiiii',
+  SDL_GetRGB__sig: 'vipppp',
   SDL_GetRGB: function(pixel, fmt, r, g, b) {
     SDL.checkPixelFormat(fmt);
     // We assume the machine is little-endian.
@@ -2171,7 +2171,7 @@ var LibrarySDL = {
   },
 
   SDL_GetRGBA__proxy: 'sync',
-  SDL_GetRGBA__sig: 'viiiiii',
+  SDL_GetRGBA__sig: 'vippppp',
   SDL_GetRGBA: function(pixel, fmt, r, g, b, a) {
     SDL.checkPixelFormat(fmt);
     // We assume the machine is little-endian.
@@ -2208,7 +2208,7 @@ var LibrarySDL = {
   SDL_WM_GrabInput: function() {},
 
   SDL_WM_ToggleFullScreen__proxy: 'sync',
-  SDL_WM_ToggleFullScreen__sig: 'ii',
+  SDL_WM_ToggleFullScreen__sig: 'ip',
   SDL_WM_ToggleFullScreen: function(surf) {
     if (Browser.exitFullscreen()) {
       return 1;
@@ -2228,7 +2228,7 @@ var LibrarySDL = {
 
   IMG_Load_RW__deps: ['SDL_LockSurface', 'SDL_FreeRW', '$PATH_FS', 'malloc'],
   IMG_Load_RW__proxy: 'sync',
-  IMG_Load_RW__sig: 'iii',
+  IMG_Load_RW__sig: 'ppi',
   IMG_Load_RW: function(rwopsID, freeSrc) {
     try {
       // stb_image integration support
@@ -2380,7 +2380,7 @@ var LibrarySDL = {
 
   IMG_Load__deps: ['IMG_Load_RW', 'SDL_RWFromFile'],
   IMG_Load__proxy: 'sync',
-  IMG_Load__sig: 'ii',
+  IMG_Load__sig: 'pp',
   IMG_Load: function(filename){
     var rwops = _SDL_RWFromFile(filename);
     var result = _IMG_Load_RW(rwops, 1);
@@ -2395,7 +2395,7 @@ var LibrarySDL = {
 
   SDL_OpenAudio__deps: ['$autoResumeAudioContext', '$safeSetTimeout', 'malloc'],
   SDL_OpenAudio__proxy: 'sync',
-  SDL_OpenAudio__sig: 'iii',
+  SDL_OpenAudio__sig: 'ipp',
   SDL_OpenAudio: function(desired, obtained) {
     try {
       SDL.audio = {
@@ -2710,7 +2710,7 @@ var LibrarySDL = {
   },
 
   Mix_ChannelFinished__proxy: 'sync',
-  Mix_ChannelFinished__sig: 'vi',
+  Mix_ChannelFinished__sig: 'vp',
   Mix_ChannelFinished: function(func) {
     SDL.channelFinished = func;
   },
@@ -2745,7 +2745,7 @@ var LibrarySDL = {
 
   Mix_LoadWAV_RW__deps: ['$PATH_FS', 'fileno'],
   Mix_LoadWAV_RW__proxy: 'sync',
-  Mix_LoadWAV_RW__sig: 'iii',
+  Mix_LoadWAV_RW__sig: 'ppi',
   Mix_LoadWAV_RW__docs: '/** @param {number|boolean=} freesrc */',
   Mix_LoadWAV_RW: function(rwopsID, freesrc) {
     var rwops = SDL.rwops[rwopsID];
@@ -2852,7 +2852,7 @@ var LibrarySDL = {
 
   Mix_LoadWAV__deps: ['Mix_LoadWAV_RW', 'SDL_RWFromFile', 'SDL_FreeRW'],
   Mix_LoadWAV__proxy: 'sync',
-  Mix_LoadWAV__sig: 'ii',
+  Mix_LoadWAV__sig: 'pp',
   Mix_LoadWAV: function(filename) {
     var rwops = _SDL_RWFromFile(filename);
     var result = _Mix_LoadWAV_RW(rwops);
@@ -2861,7 +2861,7 @@ var LibrarySDL = {
   },
 
   Mix_QuickLoad_RAW__proxy: 'sync',
-  Mix_QuickLoad_RAW__sig: 'iii',
+  Mix_QuickLoad_RAW__sig: 'ppi',
   Mix_QuickLoad_RAW: function(mem, len) {
     var audio;
     var webAudio;
@@ -2895,7 +2895,7 @@ var LibrarySDL = {
   },
 
   Mix_FreeChunk__proxy: 'sync',
-  Mix_FreeChunk__sig: 'vi',
+  Mix_FreeChunk__sig: 'vp',
   Mix_FreeChunk: function(id) {
     SDL.audios[id] = null;
   },
@@ -2905,7 +2905,7 @@ var LibrarySDL = {
     SDL.channelMinimumNumber = num;
   },
   Mix_PlayChannelTimed__proxy: 'sync',
-  Mix_PlayChannelTimed__sig: 'iiiii',
+  Mix_PlayChannelTimed__sig: 'iipii',
   Mix_PlayChannelTimed: function(channel, id, loops, ticks) {
     // TODO: handle fixed amount of N loops. Currently loops either 0 or infinite times.
     assert(ticks == -1);
@@ -2986,7 +2986,7 @@ var LibrarySDL = {
 
   Mix_HookMusicFinished__deps: ['Mix_HaltMusic'],
   Mix_HookMusicFinished__proxy: 'sync',
-  Mix_HookMusicFinished__sig: 'vi',
+  Mix_HookMusicFinished__sig: 'vp',
   Mix_HookMusicFinished: function(func) {
     SDL.hookMusicFinished = func;
     if (SDL.music.audio) { // ensure the callback will be called, if a music is already playing
@@ -3005,7 +3005,7 @@ var LibrarySDL = {
 
   Mix_LoadMUS__deps: ['Mix_LoadMUS_RW', 'SDL_RWFromFile', 'SDL_FreeRW'],
   Mix_LoadMUS__proxy: 'sync',
-  Mix_LoadMUS__sig: 'ii',
+  Mix_LoadMUS__sig: 'pp',
   Mix_LoadMUS: function(filename) {
     var rwops = _SDL_RWFromFile(filename);
     var result = _Mix_LoadMUS_RW(rwops);
@@ -3017,7 +3017,7 @@ var LibrarySDL = {
 
   Mix_PlayMusic__deps: ['Mix_HaltMusic'],
   Mix_PlayMusic__proxy: 'sync',
-  Mix_PlayMusic__sig: 'iii',
+  Mix_PlayMusic__sig: 'ipi',
   Mix_PlayMusic: function(id, loops) {
     // Pause old music if it exists.
     if (SDL.music.audio) {
@@ -3191,7 +3191,7 @@ var LibrarySDL = {
   },
 
   TTF_OpenFont__proxy: 'sync',
-  TTF_OpenFont__sig: 'iii',
+  TTF_OpenFont__sig: 'ppi',
   TTF_OpenFont: function(filename, size) {
     filename = PATH.normalize(UTF8ToString(filename));
     var id = SDL.fonts.length;
@@ -3203,13 +3203,13 @@ var LibrarySDL = {
   },
 
   TTF_CloseFont__proxy: 'sync',
-  TTF_CloseFont__sig: 'vi',
+  TTF_CloseFont__sig: 'vp',
   TTF_CloseFont: function(font) {
     SDL.fonts[font] = null;
   },
 
   TTF_RenderText_Solid__proxy: 'sync',
-  TTF_RenderText_Solid__sig: 'iiii',
+  TTF_RenderText_Solid__sig: 'pppp',
   TTF_RenderText_Solid: function(font, text, color) {
     // XXX the font and color are ignored
     text = UTF8ToString(text) || ' '; // if given an empty string, still return a valid surface
@@ -3237,7 +3237,7 @@ var LibrarySDL = {
   TTF_SizeUTF8: 'TTF_SizeText',
 
   TTF_SizeText__proxy: 'sync',
-  TTF_SizeText__sig: 'iiiii',
+  TTF_SizeText__sig: 'ipppp',
   TTF_SizeText: function(font, text, w, h) {
     var fontData = SDL.fonts[font];
     if (w) {
@@ -3250,7 +3250,7 @@ var LibrarySDL = {
   },
 
   TTF_GlyphMetrics__proxy: 'sync',
-  TTF_GlyphMetrics__sig: 'iiiiiiii',
+  TTF_GlyphMetrics__sig: 'ipippppp',
   TTF_GlyphMetrics: function(font, ch, minx, maxx, miny, maxy, advance) {
     var fontData = SDL.fonts[font];
     var width = SDL.estimateTextWidth(fontData,  String.fromCharCode(ch));
@@ -3273,21 +3273,21 @@ var LibrarySDL = {
   },
 
   TTF_FontAscent__proxy: 'sync',
-  TTF_FontAscent__sig: 'ii',
+  TTF_FontAscent__sig: 'ip',
   TTF_FontAscent: function(font) {
     var fontData = SDL.fonts[font];
     return (fontData.size*0.98)|0; // XXX
   },
 
   TTF_FontDescent__proxy: 'sync',
-  TTF_FontDescent__sig: 'ii',
+  TTF_FontDescent__sig: 'ip',
   TTF_FontDescent: function(font) {
     var fontData = SDL.fonts[font];
     return (fontData.size*0.02)|0; // XXX
   },
 
   TTF_FontHeight__proxy: 'sync',
-  TTF_FontHeight__sig: 'ii',
+  TTF_FontHeight__sig: 'ip',
   TTF_FontHeight: function(font) {
     var fontData = SDL.fonts[font];
     return fontData.size;
@@ -3430,7 +3430,7 @@ var LibrarySDL = {
   },
 
   SDL_GL_GetAttribute__proxy: 'sync',
-  SDL_GL_GetAttribute__sig: 'iii',
+  SDL_GL_GetAttribute__sig: 'iip',
   SDL_GL_GetAttribute: function(attr, value) {
     if (!(attr in SDL.glAttributes)) {
       abort('Unknown SDL GL attribute (' + attr + '). Please check if your SDL version is supported.');
@@ -3450,7 +3450,7 @@ var LibrarySDL = {
   // SDL 2
 
   SDL_GL_ExtensionSupported__proxy: 'sync',
-  SDL_GL_ExtensionSupported__sig: 'ii',
+  SDL_GL_ExtensionSupported__sig: 'ip',
   SDL_GL_ExtensionSupported: function(extension) {
     return Module.ctx.getExtension(extension) | 0;
   },
@@ -3488,13 +3488,13 @@ var LibrarySDL = {
   },
 
   SDL_SetWindowTitle__proxy: 'sync',
-  SDL_SetWindowTitle__sig: 'vii',
+  SDL_SetWindowTitle__sig: 'vpp',
   SDL_SetWindowTitle: function(window, title) {
     if (title) document.title = UTF8ToString(title);
   },
 
   SDL_GetWindowSize__proxy: 'sync',
-  SDL_GetWindowSize__sig: 'viii',
+  SDL_GetWindowSize__sig: 'vppp',
   SDL_GetWindowSize: function(window, width, height){
     var w = Module['canvas'].width;
     var h = Module['canvas'].height;
@@ -3505,7 +3505,7 @@ var LibrarySDL = {
   SDL_LogSetOutputFunction: function(callback, userdata) {},
 
   SDL_SetWindowFullscreen__proxy: 'sync',
-  SDL_SetWindowFullscreen__sig: 'iii',
+  SDL_SetWindowFullscreen__sig: 'ipi',
   SDL_SetWindowFullscreen: function(window, fullscreen) {
     if (Browser.isFullscreen) {
       Module['canvas'].exitFullscreen();
@@ -3541,7 +3541,7 @@ var LibrarySDL = {
   },
 
   SDL_JoystickName__proxy: 'sync',
-  SDL_JoystickName__sig: 'ii',
+  SDL_JoystickName__sig: 'pi',
   SDL_JoystickName__deps: ['$allocateUTF8'],
   SDL_JoystickName: function(deviceIndex) {
     var gamepad = SDL.getGamepad(deviceIndex);
@@ -3556,7 +3556,7 @@ var LibrarySDL = {
   },
 
   SDL_JoystickOpen__proxy: 'sync',
-  SDL_JoystickOpen__sig: 'ii',
+  SDL_JoystickOpen__sig: 'pi',
   SDL_JoystickOpen: function(deviceIndex) {
     var gamepad = SDL.getGamepad(deviceIndex);
     if (gamepad) {
@@ -3580,7 +3580,7 @@ var LibrarySDL = {
   },
 
   SDL_JoystickNumAxes__proxy: 'sync',
-  SDL_JoystickNumAxes__sig: 'ii',
+  SDL_JoystickNumAxes__sig: 'ip',
   SDL_JoystickNumAxes: function(joystick) {
     var gamepad = SDL.getGamepad(joystick - 1);
     if (gamepad) {
@@ -3594,7 +3594,7 @@ var LibrarySDL = {
   SDL_JoystickNumHats: function(joystick) { return 0; },
 
   SDL_JoystickNumButtons__proxy: 'sync',
-  SDL_JoystickNumButtons__sig: 'ii',
+  SDL_JoystickNumButtons__sig: 'ip',
   SDL_JoystickNumButtons: function(joystick) {
     var gamepad = SDL.getGamepad(joystick - 1);
     if (gamepad) {
@@ -3620,7 +3620,7 @@ var LibrarySDL = {
   },
 
   SDL_JoystickGetAxis__proxy: 'sync',
-  SDL_JoystickGetAxis__sig: 'iii',
+  SDL_JoystickGetAxis__sig: 'ipi',
   SDL_JoystickGetAxis: function(joystick, axis) {
     var gamepad = SDL.getGamepad(joystick - 1);
     if (gamepad && gamepad.axes.length > axis) {
@@ -3634,7 +3634,7 @@ var LibrarySDL = {
   SDL_JoystickGetBall: function(joystick, ball, dxptr, dyptr) { return -1; },
 
   SDL_JoystickGetButton__proxy: 'sync',
-  SDL_JoystickGetButton__sig: 'iii',
+  SDL_JoystickGetButton__sig: 'ipi',
   SDL_JoystickGetButton: function(joystick, button) {
     var gamepad = SDL.getGamepad(joystick - 1);
     if (gamepad && gamepad.buttons.length > button) {
@@ -3644,7 +3644,7 @@ var LibrarySDL = {
   },
 
   SDL_JoystickClose__proxy: 'sync',
-  SDL_JoystickClose__sig: 'vi',
+  SDL_JoystickClose__sig: 'vp',
   SDL_JoystickClose: function(joystick) {
     delete SDL.lastJoystickState[joystick];
   },
@@ -3654,7 +3654,7 @@ var LibrarySDL = {
   SDL_InitSubSystem: function(flags) { return 0 },
 
   SDL_RWFromConstMem__proxy: 'sync',
-  SDL_RWFromConstMem__sig: 'iii',
+  SDL_RWFromConstMem__sig: 'ppi',
   SDL_RWFromConstMem: function(mem, size) {
     var id = SDL.rwops.length; // TODO: recycle ids when they are null
     SDL.rwops.push({ bytes: mem, count: size });
@@ -3663,7 +3663,7 @@ var LibrarySDL = {
   SDL_RWFromMem: 'SDL_RWFromConstMem',
 
   SDL_RWFromFile__proxy: 'sync',
-  SDL_RWFromFile__sig: 'iii',
+  SDL_RWFromFile__sig: 'ppp',
   SDL_RWFromFile__docs: '/** @param {number=} mode */',
   SDL_RWFromFile: function(_name, mode) {
     var id = SDL.rwops.length; // TODO: recycle ids when they are null
@@ -3673,7 +3673,7 @@ var LibrarySDL = {
   },
 
   SDL_FreeRW__proxy: 'sync',
-  SDL_FreeRW__sig: 'vi',
+  SDL_FreeRW__sig: 'vp',
   SDL_FreeRW: function(rwopsID) {
     SDL.rwops[rwopsID] = null;
     while (SDL.rwops.length > 0 && SDL.rwops[SDL.rwops.length-1] === null) {
@@ -3702,7 +3702,7 @@ var LibrarySDL = {
 
   SDL_AddTimer__proxy: 'sync',
   SDL_AddTimer__deps: ['$safeSetTimeout'],
-  SDL_AddTimer__sig: 'iiii',
+  SDL_AddTimer__sig: 'iipp',
   SDL_AddTimer: function(interval, callback, param) {
     return safeSetTimeout(
       () => {{{ makeDynCall('iii', 'callback') }}}(interval, param),

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -328,7 +328,7 @@ var SyscallsLibrary = {
     return 0;
   },
   __syscall_connect__deps: ['$getSocketFromFD', '$getSocketAddress'],
-  __syscall_connect__sig: 'iipiiii',
+  __syscall_connect__sig: 'iippiii',
   __syscall_connect: function(fd, addr, addrlen, d1, d2, d3) {
     var sock = getSocketFromFD(fd);
     var info = getSocketAddress(addr, addrlen);
@@ -353,7 +353,7 @@ var SyscallsLibrary = {
     return newsock.stream.fd;
   },
   __syscall_bind__deps: ['$getSocketFromFD', '$getSocketAddress'],
-  __syscall_bind__sig: 'iipiiii',
+  __syscall_bind__sig: 'iippiii',
   __syscall_bind: function(fd, addr, addrlen, d1, d2, d3) {
     var sock = getSocketFromFD(fd);
     var info = getSocketAddress(addr, addrlen);
@@ -381,7 +381,7 @@ var SyscallsLibrary = {
     return msg.buffer.byteLength;
   },
   __syscall_sendto__deps: ['$getSocketFromFD', '$getSocketAddress'],
-  __syscall_sendto__sig: 'iipiipi',
+  __syscall_sendto__sig: 'iippipp',
   __syscall_sendto: function(fd, message, length, flags, addr, addr_len) {
     var sock = getSocketFromFD(fd);
     var dest = getSocketAddress(addr, addr_len, true);
@@ -655,7 +655,7 @@ var SyscallsLibrary = {
     FS.fchown(fd, owner, group);
     return 0;
   },
-  __syscall_getdents64__sig: 'iipi',
+  __syscall_getdents64__sig: 'iipp',
   __syscall_getdents64: function(fd, dirp, count) {
     var stream = SYSCALLS.getStreamFromFD(fd)
     if (!stream.getdents) {
@@ -899,7 +899,7 @@ var SyscallsLibrary = {
     FS.symlink(target, linkpath);
     return 0;
   },
-  __syscall_readlinkat__sig: 'vippp',
+  __syscall_readlinkat__sig: 'iippp',
   __syscall_readlinkat: function(dirfd, path, buf, bufsize) {
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);

--- a/src/library_webaudio.js
+++ b/src/library_webaudio.js
@@ -289,27 +289,51 @@ let LibraryWebAudio = {
     (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : globalThis['messagePort']).postMessage({'_wsc': funcPtr, 'x': [] }); // "WaSm Call"
   },
 
-  emscripten_audio_worklet_post_function_1__sig: 'vipd',
-  emscripten_audio_worklet_post_function_1: function(audioContext, funcPtr, arg0) {
+  $emscripten_audio_worklet_post_function_1: function(audioContext, funcPtr, arg0) {
     (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : globalThis['messagePort']).postMessage({'_wsc': funcPtr, 'x': [arg0] }); // "WaSm Call"
   },
 
-  emscripten_audio_worklet_post_function_vi: 'emscripten_audio_worklet_post_function_1',
-  emscripten_audio_worklet_post_function_vd: 'emscripten_audio_worklet_post_function_1',
+  emscripten_audio_worklet_post_function_vi__sig: 'vipi',
+  emscripten_audio_worklet_post_function_vi__deps: ['$emscripten_audio_worklet_post_function_1'],
+  emscripten_audio_worklet_post_function_vi(audioContext, funcPtr, arg0) {
+    emscripten_audio_worklet_post_function_1(audioContext, funcPtr, arg0)
+  },
 
-  emscripten_audio_worklet_post_function_2__sig: 'vipdd',
-  emscripten_audio_worklet_post_function_2: function(audioContext, funcPtr, arg0, arg1) {
+  emscripten_audio_worklet_post_function_vd__sig: 'vipd',
+  emscripten_audio_worklet_post_function_vd__deps: ['$emscripten_audio_worklet_post_function_1'],
+  emscripten_audio_worklet_post_function_vd(audioContext, funcPtr, arg0) {
+    emscripten_audio_worklet_post_function_1(audioContext, funcPtr, arg0)
+  },
+
+  $emscripten_audio_worklet_post_function_2: function(audioContext, funcPtr, arg0, arg1) {
     (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : globalThis['messagePort']).postMessage({'_wsc': funcPtr, 'x': [arg0, arg1] }); // "WaSm Call"
   },
-  emscripten_audio_worklet_post_function_vii: 'emscripten_audio_worklet_post_function_2',
-  emscripten_audio_worklet_post_function_vdd: 'emscripten_audio_worklet_post_function_2',
 
-  emscripten_audio_worklet_post_function_3__sig: 'vipddd',
-  emscripten_audio_worklet_post_function_3: function(audioContext, funcPtr, arg0, arg1, arg2) {
+  emscripten_audio_worklet_post_function_vii__sig: 'vipii',
+  emscripten_audio_worklet_post_function_vii__deps: ['$emscripten_audio_worklet_post_function_2'],
+  emscripten_audio_worklet_post_function_vii: function(audioContext, funcPtr, arg0, arg1) {
+    emscripten_audio_worklet_post_function_2(audioContext, funcPtr, arg0, arg1);
+  },
+
+  emscripten_audio_worklet_post_function_vdd__sig: 'vipdd',
+  emscripten_audio_worklet_post_function_vdd__deps: ['$emscripten_audio_worklet_post_function_2'],
+  emscripten_audio_worklet_post_function_vdd: function(audioContext, funcPtr, arg0, arg1) {
+    emscripten_audio_worklet_post_function_2(audioContext, funcPtr, arg0, arg1);
+  },
+
+  $emscripten_audio_worklet_post_function_3: function(audioContext, funcPtr, arg0, arg1, arg2) {
     (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : globalThis['messagePort']).postMessage({'_wsc': funcPtr, 'x': [arg0, arg1, arg2] }); // "WaSm Call"
   },
-  emscripten_audio_worklet_post_function_viii: 'emscripten_audio_worklet_post_function_3',
-  emscripten_audio_worklet_post_function_vddd: 'emscripten_audio_worklet_post_function_3',
+  emscripten_audio_worklet_post_function_viii__sig: 'vipiii',
+  emscripten_audio_worklet_post_function_viii__deps: ['$emscripten_audio_worklet_post_function_3'],
+  emscripten_audio_worklet_post_function_viii: function(audioContext, funcPtr, arg0, arg1, arg2) {
+    emscripten_audio_worklet_post_function_3(audioContext, funcPtr, arg0, arg1, arg2);
+  },
+  emscripten_audio_worklet_post_function_vddd__sig: 'vipddd',
+  emscripten_audio_worklet_post_function_vddd__deps: ['$emscripten_audio_worklet_post_function_3'],
+  emscripten_audio_worklet_post_function_vddd: function(audioContext, funcPtr, arg0, arg1, arg2) {
+    emscripten_audio_worklet_post_function_3(audioContext, funcPtr, arg0, arg1, arg2);
+  },
 
   emscripten_audio_worklet_post_function_sig__deps: ['$readAsmConstArgs'],
   emscripten_audio_worklet_post_function_sig__sig: 'vippp',

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1149,7 +1149,7 @@ var LibraryGL = {
     GLctx.pixelStorei(pname, param);
   },
 
-  glGetString__sig: 'ii',
+  glGetString__sig: 'pi',
   glGetString__deps: ['$stringToNewUTF8'],
   glGetString: function(name_) {
     var ret = GL.stringCache[name_];
@@ -1400,25 +1400,25 @@ var LibraryGL = {
     }
   },
 
-  glGetIntegerv__sig: 'vii',
+  glGetIntegerv__sig: 'vip',
   glGetIntegerv__deps: ['$emscriptenWebGLGet'],
   glGetIntegerv: function(name_, p) {
     emscriptenWebGLGet(name_, p, {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}});
   },
 
-  glGetFloatv__sig: 'vii',
+  glGetFloatv__sig: 'vip',
   glGetFloatv__deps: ['$emscriptenWebGLGet'],
   glGetFloatv: function(name_, p) {
     emscriptenWebGLGet(name_, p, {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}});
   },
 
-  glGetBooleanv__sig: 'vii',
+  glGetBooleanv__sig: 'vip',
   glGetBooleanv__deps: ['$emscriptenWebGLGet'],
   glGetBooleanv: function(name_, p) {
     emscriptenWebGLGet(name_, p, {{{ cDefine('EM_FUNC_SIG_PARAM_B') }}});
   },
 
-  glDeleteTextures__sig: 'vii',
+  glDeleteTextures__sig: 'vip',
   glDeleteTextures: function(n, textures) {
     for (var i = 0; i < n; i++) {
       var id = {{{ makeGetValue('textures', 'i*4', 'i32') }}};
@@ -1430,7 +1430,7 @@ var LibraryGL = {
     }
   },
 
-  glCompressedTexImage2D__sig: 'viiiiiiii',
+  glCompressedTexImage2D__sig: 'viiiiiiip',
   glCompressedTexImage2D: function(target, level, internalFormat, width, height, border, imageSize, data) {
 #if MAX_WEBGL_VERSION >= 2
     if ({{{ isCurrentContextWebGL2() }}}) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
@@ -1446,7 +1446,7 @@ var LibraryGL = {
   },
 
 
-  glCompressedTexSubImage2D__sig: 'viiiiiiiii',
+  glCompressedTexSubImage2D__sig: 'viiiiiiiip',
   glCompressedTexSubImage2D: function(target, level, xoffset, yoffset, width, height, format, imageSize, data) {
 #if MAX_WEBGL_VERSION >= 2
     if ({{{ isCurrentContextWebGL2() }}}) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
@@ -1520,7 +1520,7 @@ var LibraryGL = {
     return heap.subarray(pixels >> shift, pixels + bytes >> shift);
   },
 
-  glTexImage2D__sig: 'viiiiiiiii',
+  glTexImage2D__sig: 'viiiiiiiip',
   glTexImage2D__deps: ['$emscriptenWebGLGetTexPixelData'
 #if MAX_WEBGL_VERSION >= 2
                        , '$heapObjectForWebGLType', '$heapAccessShiftForWebGLHeap'
@@ -1562,7 +1562,7 @@ var LibraryGL = {
     GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, pixels ? emscriptenWebGLGetTexPixelData(type, format, width, height, pixels, internalFormat) : null);
   },
 
-  glTexSubImage2D__sig: 'viiiiiiiii',
+  glTexSubImage2D__sig: 'viiiiiiiip',
   glTexSubImage2D__deps: ['$emscriptenWebGLGetTexPixelData'
 #if MAX_WEBGL_VERSION >= 2
                           , '$heapObjectForWebGLType', '$heapAccessShiftForWebGLHeap'
@@ -1596,7 +1596,7 @@ var LibraryGL = {
     GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixelData);
   },
 
-  glReadPixels__sig: 'viiiiiii',
+  glReadPixels__sig: 'viiiiiip',
   glReadPixels__deps: ['$emscriptenWebGLGetTexPixelData'
 #if MAX_WEBGL_VERSION >= 2
                        , '$heapObjectForWebGLType', '$heapAccessShiftForWebGLHeap'
@@ -1633,7 +1633,7 @@ var LibraryGL = {
     GLctx.bindTexture(target, GL.textures[texture]);
   },
 
-  glGetTexParameterfv__sig: 'viii',
+  glGetTexParameterfv__sig: 'viip',
   glGetTexParameterfv: function(target, pname, params) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
@@ -1647,7 +1647,7 @@ var LibraryGL = {
     {{{ makeSetValue('params', '0', 'GLctx.getTexParameter(target, pname)', 'float') }}};
   },
 
-  glGetTexParameteriv__sig: 'viii',
+  glGetTexParameteriv__sig: 'viip',
   glGetTexParameteriv: function(target, pname, params) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
@@ -1661,13 +1661,13 @@ var LibraryGL = {
     {{{ makeSetValue('params', '0', 'GLctx.getTexParameter(target, pname)', 'i32') }}};
   },
 
-  glTexParameterfv__sig: 'viii',
+  glTexParameterfv__sig: 'viip',
   glTexParameterfv: function(target, pname, params) {
     var param = {{{ makeGetValue('params', '0', 'float') }}};
     GLctx.texParameterf(target, pname, param);
   },
 
-  glTexParameteriv__sig: 'viii',
+  glTexParameteriv__sig: 'viip',
   glTexParameteriv: function(target, pname, params) {
     var param = {{{ makeGetValue('params', '0', 'i32') }}};
     GLctx.texParameteri(target, pname, param);
@@ -1707,7 +1707,7 @@ var LibraryGL = {
   },
 
   glGenBuffers__deps: ['$__glGenObject'],
-  glGenBuffers__sig: 'vii',
+  glGenBuffers__sig: 'vip',
   glGenBuffers: function(n, buffers) {
     __glGenObject(n, buffers, 'createBuffer', GL.buffers
 #if GL_ASSERTIONS
@@ -1717,7 +1717,7 @@ var LibraryGL = {
   },
 
   glGenTextures__deps: ['$__glGenObject'],
-  glGenTextures__sig: 'vii',
+  glGenTextures__sig: 'vip',
   glGenTextures: function(n, textures) {
     __glGenObject(n, textures, 'createTexture', GL.textures
 #if GL_ASSERTIONS
@@ -1726,7 +1726,7 @@ var LibraryGL = {
       );
   },
 
-  glDeleteBuffers__sig: 'vii',
+  glDeleteBuffers__sig: 'vip',
   glDeleteBuffers: function(n, buffers) {
     for (var i = 0; i < n; i++) {
       var id = {{{ makeGetValue('buffers', 'i*4', 'i32') }}};
@@ -1751,7 +1751,7 @@ var LibraryGL = {
     }
   },
 
-  glGetBufferParameteriv__sig: 'viii',
+  glGetBufferParameteriv__sig: 'viip',
   glGetBufferParameteriv: function(target, value, data) {
     if (!data) {
       // GLES2 specification does not specify how to behave if data is a null pointer. Since calling this function does not make sense
@@ -1765,7 +1765,7 @@ var LibraryGL = {
     {{{ makeSetValue('data', '0', 'GLctx.getBufferParameter(target, value)', 'i32') }}};
   },
 
-  glBufferData__sig: 'viiii',
+  glBufferData__sig: 'vippi',
   glBufferData: function(target, size, data, usage) {
 #if LEGACY_GL_EMULATION
     switch (usage) { // fix usages, WebGL 1 only has *_DRAW
@@ -1804,7 +1804,7 @@ var LibraryGL = {
 #endif
   },
 
-  glBufferSubData__sig: 'viiii',
+  glBufferSubData__sig: 'vippp',
   glBufferSubData: function(target, offset, size, data) {
 #if MAX_WEBGL_VERSION >= 2
     if ({{{ isCurrentContextWebGL2() }}}) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
@@ -1962,7 +1962,7 @@ var LibraryGL = {
     return GLctx.isBuffer(b);
   },
 
-  glGenRenderbuffers__sig: 'vii',
+  glGenRenderbuffers__sig: 'vip',
   glGenRenderbuffers__deps: ['$__glGenObject'],
   glGenRenderbuffers: function(n, renderbuffers) {
     __glGenObject(n, renderbuffers, 'createRenderbuffer', GL.renderbuffers
@@ -1972,7 +1972,7 @@ var LibraryGL = {
       );
   },
 
-  glDeleteRenderbuffers__sig: 'vii',
+  glDeleteRenderbuffers__sig: 'vip',
   glDeleteRenderbuffers: function(n, renderbuffers) {
     for (var i = 0; i < n; i++) {
       var id = {{{ makeGetValue('renderbuffers', 'i*4', 'i32') }}};
@@ -1992,7 +1992,7 @@ var LibraryGL = {
     GLctx.bindRenderbuffer(target, GL.renderbuffers[renderbuffer]);
   },
 
-  glGetRenderbufferParameteriv__sig: 'viii',
+  glGetRenderbufferParameteriv__sig: 'viip',
   glGetRenderbufferParameteriv: function(target, pname, params) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
@@ -2053,13 +2053,13 @@ var LibraryGL = {
     }
   },
 
-  glGetUniformfv__sig: 'viii',
+  glGetUniformfv__sig: 'viip',
   glGetUniformfv__deps: ['$emscriptenWebGLGetUniform'],
   glGetUniformfv: function(program, location, params) {
     emscriptenWebGLGetUniform(program, location, params, {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}});
   },
 
-  glGetUniformiv__sig: 'viii',
+  glGetUniformiv__sig: 'viip',
   glGetUniformiv__deps: ['$emscriptenWebGLGetUniform'],
   glGetUniformiv: function(program, location, params) {
     emscriptenWebGLGetUniform(program, location, params, {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}});
@@ -2151,7 +2151,7 @@ var LibraryGL = {
     return name.slice(-1) == ']' && name.lastIndexOf('[');
   },
 
-  glGetUniformLocation__sig: 'iii',
+  glGetUniformLocation__sig: 'iip',
   glGetUniformLocation__deps: ['$jstoi_q', '$webglPrepareUniformLocationsBeforeFirstUse', '$webglGetLeftBracePos'],
   glGetUniformLocation: function(program, name) {
 
@@ -2250,7 +2250,7 @@ var LibraryGL = {
     }
   },
 
-  glGetVertexAttribfv__sig: 'viii',
+  glGetVertexAttribfv__sig: 'viip',
   glGetVertexAttribfv__deps: ['$emscriptenWebGLGetVertexAttrib'],
   glGetVertexAttribfv: function(index, pname, params) {
     // N.B. This function may only be called if the vertex attribute was specified using the function glVertexAttrib*f(),
@@ -2258,7 +2258,7 @@ var LibraryGL = {
     emscriptenWebGLGetVertexAttrib(index, pname, params, {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}});
   },
 
-  glGetVertexAttribiv__sig: 'viii',
+  glGetVertexAttribiv__sig: 'viip',
   glGetVertexAttribiv__deps: ['$emscriptenWebGLGetVertexAttrib'],
   glGetVertexAttribiv: function(index, pname, params) {
     // N.B. This function may only be called if the vertex attribute was specified using the function glVertexAttrib*f(),
@@ -2266,7 +2266,7 @@ var LibraryGL = {
     emscriptenWebGLGetVertexAttrib(index, pname, params, {{{ cDefine('EM_FUNC_SIG_PARAM_F2I') }}});
   },
 
-  glGetVertexAttribPointerv__sig: 'viii',
+  glGetVertexAttribPointerv__sig: 'viip',
   glGetVertexAttribPointerv: function(index, pname, pointer) {
     if (!pointer) {
       // GLES2 specification does not specify how to behave if pointer is a null pointer. Since calling this function does not make sense
@@ -2357,7 +2357,7 @@ var LibraryGL = {
     GLctx.uniform4i(webglGetUniformLocation(location), v0, v1, v2, v3);
   },
 
-  glUniform1iv__sig: 'viii',
+  glUniform1iv__sig: 'viip',
   glUniform1iv__deps: ['$webglGetUniformLocation'
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
     , '$miniTempWebGLIntBuffers'
@@ -2402,7 +2402,7 @@ var LibraryGL = {
 #endif // MIN_WEBGL_VERSION >= 2
   },
 
-  glUniform2iv__sig: 'viii',
+  glUniform2iv__sig: 'viip',
   glUniform2iv__deps: ['$webglGetUniformLocation'
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
     , '$miniTempWebGLIntBuffers'
@@ -2448,7 +2448,7 @@ var LibraryGL = {
 #endif // MIN_WEBGL_VERSION >= 2
   },
 
-  glUniform3iv__sig: 'viii',
+  glUniform3iv__sig: 'viip',
   glUniform3iv__deps: ['$webglGetUniformLocation'
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
     , '$miniTempWebGLIntBuffers'
@@ -2495,7 +2495,7 @@ var LibraryGL = {
 #endif // MIN_WEBGL_VERSION >= 2
   },
 
-  glUniform4iv__sig: 'viii',
+  glUniform4iv__sig: 'viip',
   glUniform4iv__deps: ['$webglGetUniformLocation'
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
     , '$miniTempWebGLIntBuffers'
@@ -2543,7 +2543,7 @@ var LibraryGL = {
 #endif // MIN_WEBGL_VERSION >= 2
   },
 
-  glUniform1fv__sig: 'viii',
+  glUniform1fv__sig: 'viip',
   glUniform1fv__deps: ['$webglGetUniformLocation'
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
     , '$miniTempWebGLFloatBuffers'
@@ -2588,7 +2588,7 @@ var LibraryGL = {
 #endif // MIN_WEBGL_VERSION >= 2
   },
 
-  glUniform2fv__sig: 'viii',
+  glUniform2fv__sig: 'viip',
   glUniform2fv__deps: ['$webglGetUniformLocation'
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
     , '$miniTempWebGLFloatBuffers'
@@ -2634,7 +2634,7 @@ var LibraryGL = {
 #endif // MIN_WEBGL_VERSION >= 2
   },
 
-  glUniform3fv__sig: 'viii',
+  glUniform3fv__sig: 'viip',
   glUniform3fv__deps: ['$webglGetUniformLocation'
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
     , '$miniTempWebGLFloatBuffers'
@@ -2681,7 +2681,7 @@ var LibraryGL = {
 #endif // MIN_WEBGL_VERSION >= 2
   },
 
-  glUniform4fv__sig: 'viii',
+  glUniform4fv__sig: 'viip',
   glUniform4fv__deps: ['$webglGetUniformLocation'
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
     , '$miniTempWebGLFloatBuffers'
@@ -2733,7 +2733,7 @@ var LibraryGL = {
 #endif // MIN_WEBGL_VERSION >= 2
   },
 
-  glUniformMatrix2fv__sig: 'viiii',
+  glUniformMatrix2fv__sig: 'viiip',
   glUniformMatrix2fv__deps: ['$webglGetUniformLocation'
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
     , '$miniTempWebGLFloatBuffers'
@@ -2781,7 +2781,7 @@ var LibraryGL = {
 #endif // MIN_WEBGL_VERSION >= 2
   },
 
-  glUniformMatrix3fv__sig: 'viiii',
+  glUniformMatrix3fv__sig: 'viiip',
   glUniformMatrix3fv__deps: ['$webglGetUniformLocation'
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
     , '$miniTempWebGLFloatBuffers'
@@ -2834,7 +2834,7 @@ var LibraryGL = {
 #endif // MIN_WEBGL_VERSION >= 2
   },
 
-  glUniformMatrix4fv__sig: 'viiii',
+  glUniformMatrix4fv__sig: 'viiip',
   glUniformMatrix4fv__deps: ['$webglGetUniformLocation'
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
     , '$miniTempWebGLFloatBuffers'
@@ -2932,7 +2932,7 @@ var LibraryGL = {
     GLctx.bindBuffer(target, GL.buffers[buffer]);
   },
 
-  glVertexAttrib1fv__sig: 'vii',
+  glVertexAttrib1fv__sig: 'vip',
   glVertexAttrib1fv: function(index, v) {
 #if GL_ASSERTIONS
     assert((v & 3) == 0, 'Pointer to float data passed to glVertexAttrib1fv must be aligned to four bytes!');
@@ -2942,7 +2942,7 @@ var LibraryGL = {
     GLctx.vertexAttrib1f(index, HEAPF32[v>>2]);
   },
 
-  glVertexAttrib2fv__sig: 'vii',
+  glVertexAttrib2fv__sig: 'vip',
   glVertexAttrib2fv: function(index, v) {
 #if GL_ASSERTIONS
     assert((v & 3) == 0, 'Pointer to float data passed to glVertexAttrib2fv must be aligned to four bytes!');
@@ -2952,7 +2952,7 @@ var LibraryGL = {
     GLctx.vertexAttrib2f(index, HEAPF32[v>>2], HEAPF32[v+4>>2]);
   },
 
-  glVertexAttrib3fv__sig: 'vii',
+  glVertexAttrib3fv__sig: 'vip',
   glVertexAttrib3fv: function(index, v) {
 #if GL_ASSERTIONS
     assert((v & 3) == 0, 'Pointer to float data passed to glVertexAttrib3fv must be aligned to four bytes!');
@@ -2962,7 +2962,7 @@ var LibraryGL = {
     GLctx.vertexAttrib3f(index, HEAPF32[v>>2], HEAPF32[v+4>>2], HEAPF32[v+8>>2]);
   },
 
-  glVertexAttrib4fv__sig: 'vii',
+  glVertexAttrib4fv__sig: 'vip',
   glVertexAttrib4fv: function(index, v) {
 #if GL_ASSERTIONS
     assert((v & 3) == 0, 'Pointer to float data passed to glVertexAttrib4fv must be aligned to four bytes!');
@@ -2972,7 +2972,7 @@ var LibraryGL = {
     GLctx.vertexAttrib4f(index, HEAPF32[v>>2], HEAPF32[v+4>>2], HEAPF32[v+8>>2], HEAPF32[v+12>>2]);
   },
 
-  glGetAttribLocation__sig: 'iii',
+  glGetAttribLocation__sig: 'iip',
   glGetAttribLocation: function(program, name) {
     return GLctx.getAttribLocation(GL.programs[program], UTF8ToString(name));
   },
@@ -2991,13 +2991,13 @@ var LibraryGL = {
     }
   },
 
-  glGetActiveAttrib__sig: 'viiiiiii',
+  glGetActiveAttrib__sig: 'viiipppp',
   glGetActiveAttrib__deps: ['$__glGetActiveAttribOrUniform'],
   glGetActiveAttrib: function(program, index, bufSize, length, size, type, name) {
     __glGetActiveAttribOrUniform('getActiveAttrib', program, index, bufSize, length, size, type, name);
   },
 
-  glGetActiveUniform__sig: 'viiiiiii',
+  glGetActiveUniform__sig: 'viiipppp',
   glGetActiveUniform__deps: ['$__glGetActiveAttribOrUniform'],
   glGetActiveUniform: function(program, index, bufSize, length, size, type, name) {
     __glGetActiveAttribOrUniform('getActiveUniform', program, index, bufSize, length, size, type, name);
@@ -3028,7 +3028,7 @@ var LibraryGL = {
     GL.shaders[id] = null;
   },
 
-  glGetAttachedShaders__sig: 'viiii',
+  glGetAttachedShaders__sig: 'viipp',
   glGetAttachedShaders: function(program, maxCount, count, shaders) {
 #if GL_ASSERTIONS
     GL.validateGLObjectID(GL.programs, program, 'glGetAttachedShaders', 'program');
@@ -3048,7 +3048,7 @@ var LibraryGL = {
     }
   },
 
-  glShaderSource__sig: 'viiii',
+  glShaderSource__sig: 'viipp',
 #if GL_EXPLICIT_UNIFORM_LOCATION || GL_EXPLICIT_UNIFORM_BINDING
   glShaderSource__deps: ['$preprocess_c_code', '$remove_cpp_comments_in_shaders', '$jstoi_q', '$find_closing_parens_index'],
 #endif
@@ -3213,7 +3213,7 @@ var LibraryGL = {
     GLctx.shaderSource(GL.shaders[shader], source);
   },
 
-  glGetShaderSource__sig: 'viiii',
+  glGetShaderSource__sig: 'viipp',
   glGetShaderSource: function(shader, bufSize, length, source) {
 #if GL_ASSERTIONS
     GL.validateGLObjectID(GL.shaders, shader, 'glGetShaderSource', 'shader');
@@ -3236,7 +3236,7 @@ var LibraryGL = {
 #endif
   },
 
-  glGetShaderInfoLog__sig: 'viiii',
+  glGetShaderInfoLog__sig: 'viipp',
   glGetShaderInfoLog: function(shader, maxLength, length, infoLog) {
 #if GL_ASSERTIONS
     GL.validateGLObjectID(GL.shaders, shader, 'glGetShaderInfoLog', 'shader');
@@ -3249,7 +3249,7 @@ var LibraryGL = {
     if (length) {{{ makeSetValue('length', '0', 'numBytesWrittenExclNull', 'i32') }}};
   },
 
-  glGetShaderiv__sig: 'viii',
+  glGetShaderiv__sig: 'viip',
   glGetShaderiv : function(shader, pname, p) {
     if (!p) {
       // GLES2 specification does not specify how to behave if p is a null pointer. Since calling this function does not make sense
@@ -3285,7 +3285,7 @@ var LibraryGL = {
     }
   },
 
-  glGetProgramiv__sig: 'viii',
+  glGetProgramiv__sig: 'viip',
   glGetProgramiv : function(program, pname, p) {
     if (!p) {
       // GLES2 specification does not specify how to behave if p is a null pointer. Since calling this function does not make sense
@@ -3400,7 +3400,7 @@ var LibraryGL = {
     GLctx.detachShader(GL.programs[program], GL.shaders[shader]);
   },
 
-  glGetShaderPrecisionFormat__sig: 'viiii',
+  glGetShaderPrecisionFormat__sig: 'viipp',
   glGetShaderPrecisionFormat: function(shaderType, precisionType, range, precision) {
     var result = GLctx.getShaderPrecisionFormat(shaderType, precisionType);
     {{{ makeSetValue('range', '0', 'result.rangeMin', 'i32') }}};
@@ -3463,7 +3463,7 @@ var LibraryGL = {
 #endif
   },
 
-  glGetProgramInfoLog__sig: 'viiii',
+  glGetProgramInfoLog__sig: 'viipp',
   glGetProgramInfoLog: function(program, maxLength, length, infoLog) {
 #if GL_ASSERTIONS
     GL.validateGLObjectID(GL.programs, program, 'glGetProgramInfoLog', 'program');
@@ -3550,7 +3550,7 @@ var LibraryGL = {
     return GLctx.isProgram(program);
   },
 
-  glBindAttribLocation__sig: 'viii',
+  glBindAttribLocation__sig: 'viip',
   glBindAttribLocation: function(program, index, name) {
 #if GL_ASSERTIONS
     GL.validateGLObjectID(GL.programs, program, 'glBindAttribLocation', 'program');
@@ -3575,7 +3575,7 @@ var LibraryGL = {
 
   },
 
-  glGenFramebuffers__sig: 'vii',
+  glGenFramebuffers__sig: 'vip',
   glGenFramebuffers__deps: ['$__glGenObject'],
   glGenFramebuffers: function(n, ids) {
     __glGenObject(n, ids, 'createFramebuffer', GL.framebuffers
@@ -3585,7 +3585,7 @@ var LibraryGL = {
       );
   },
 
-  glDeleteFramebuffers__sig: 'vii',
+  glDeleteFramebuffers__sig: 'vip',
   glDeleteFramebuffers: function(n, framebuffers) {
     for (var i = 0; i < n; ++i) {
       var id = {{{ makeGetValue('framebuffers', 'i*4', 'i32') }}};
@@ -3615,7 +3615,7 @@ var LibraryGL = {
                                     GL.textures[texture], level);
   },
 
-  glGetFramebufferAttachmentParameteriv__sig: 'viiii',
+  glGetFramebufferAttachmentParameteriv__sig: 'viiip',
   glGetFramebufferAttachmentParameteriv: function(target, attachment, pname, params) {
     var result = GLctx.getFramebufferAttachmentParameter(target, attachment, pname);
     if (result instanceof WebGLRenderbuffer ||
@@ -3637,7 +3637,7 @@ var LibraryGL = {
   , 'emulGlGenVertexArrays'
 #endif
   ],
-  glGenVertexArrays__sig: 'vii',
+  glGenVertexArrays__sig: 'vip',
   glGenVertexArrays: function (n, arrays) {
 #if LEGACY_GL_EMULATION
     _emulGlGenVertexArrays(n, arrays);
@@ -3656,7 +3656,7 @@ var LibraryGL = {
 #if LEGACY_GL_EMULATION
   glDeleteVertexArrays__deps: ['emulGlDeleteVertexArrays'],
 #endif
-  glDeleteVertexArrays__sig: 'vii',
+  glDeleteVertexArrays__sig: 'vip',
   glDeleteVertexArrays: function(n, vaos) {
 #if LEGACY_GL_EMULATION
     _emulGlDeleteVertexArrays(n, vaos);
@@ -3727,7 +3727,7 @@ var LibraryGL = {
 
   // GLES2 emulation
 
-  glVertexAttribPointer__sig: 'viiiiii',
+  glVertexAttribPointer__sig: 'viiiiip',
   glVertexAttribPointer: function(index, size, type, normalized, stride, ptr) {
 #if FULL_ES2
     var cb = GL.currentContext.clientBuffers[index];
@@ -3793,7 +3793,7 @@ var LibraryGL = {
 #endif
   },
 
-  glDrawElements__sig: 'viiii',
+  glDrawElements__sig: 'viiip',
   glDrawElements: function(mode, count, type, indices) {
 #if FULL_ES2
     var buf;
@@ -3866,7 +3866,7 @@ var LibraryGL = {
     GLctx['drawArraysInstanced'](mode, first, count, primcount);
   },
 
-  glDrawElementsInstanced__sig: 'viiiii',
+  glDrawElementsInstanced__sig: 'viiipi',
   glDrawElementsInstanced: function(mode, count, type, indices, primcount) {
 #if GL_ASSERTIONS
     assert(GLctx['drawElementsInstanced'], 'Must have ANGLE_instanced_arrays extension or WebGL 2 to use WebGL instancing');
@@ -3891,7 +3891,7 @@ var LibraryGL = {
 
 
   glDrawBuffers__deps: ['$tempFixedLengthArray'],
-  glDrawBuffers__sig: 'vii',
+  glDrawBuffers__sig: 'vip',
   glDrawBuffers: function(n, bufs) {
 #if GL_ASSERTIONS
     assert(GLctx['drawBuffers'], 'Must have WebGL2 or WEBGL_draw_buffers extension to use drawBuffers');
@@ -3925,12 +3925,12 @@ var LibraryGL = {
     GLctx.depthMask(!!flag);
   },
 
-  glSampleCoverage__sig: 'vii',
+  glSampleCoverage__sig: 'vfi',
   glSampleCoverage: function(value, invert) {
     GLctx.sampleCoverage(value, !!invert);
   },
 
-  glMultiDrawArraysWEBGL__sig: 'viiii',
+  glMultiDrawArraysWEBGL__sig: 'vippi',
   glMultiDrawArrays: 'glMultiDrawArraysWEBGL',
   glMultiDrawArraysANGLE: 'glMultiDrawArraysWEBGL',
   glMultiDrawArraysWEBGL: function(mode, firsts, counts, drawcount) {
@@ -3957,7 +3957,7 @@ var LibraryGL = {
       drawcount);
   },
 
-  glMultiDrawElementsWEBGL__sig: 'viiiii',
+  glMultiDrawElementsWEBGL__sig: 'vipipi',
   glMultiDrawElements: 'glMultiDrawElementsWEBGL',
   glMultiDrawElementsANGLE: 'glMultiDrawElementsWEBGL',
   glMultiDrawElementsWEBGL: function(mode, counts, type, offsets, drawcount) {
@@ -4023,7 +4023,7 @@ var LibraryGL = {
     }
   },
 
-  glMapBufferRange__sig: 'iiiii',
+  glMapBufferRange__sig: 'pippi',
   glMapBufferRange__deps: ['$emscriptenWebGLGetBufferBinding', '$emscriptenWebGLValidateMapBufferTarget'],
   glMapBufferRange: function(target, offset, length, access) {
     if ((access & (0x1/*GL_MAP_READ_BIT*/ | 0x20/*GL_MAP_UNSYNCHRONIZED_BIT*/)) != 0) {
@@ -4059,7 +4059,7 @@ var LibraryGL = {
     return mem;
   },
 
-  glGetBufferPointerv__sig: 'viii',
+  glGetBufferPointerv__sig: 'viip',
   glGetBufferPointerv__deps: ['$emscriptenWebGLGetBufferBinding'],
   glGetBufferPointerv: function(target, pname, params) {
     if (pname == 0x88BD/*GL_BUFFER_MAP_POINTER*/) {
@@ -4075,7 +4075,7 @@ var LibraryGL = {
     }
   },
 
-  glFlushMappedBufferRange__sig: 'viii',
+  glFlushMappedBufferRange__sig: 'vipp',
   glFlushMappedBufferRange__deps: ['$emscriptenWebGLGetBufferBinding', '$emscriptenWebGLValidateMapBufferTarget'],
   glFlushMappedBufferRange: function(target, offset, length) {
     if (!emscriptenWebGLValidateMapBufferTarget(target)) {

--- a/src/library_websocket.js
+++ b/src/library_websocket.js
@@ -12,7 +12,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_get_ready_state__deps: ['$WS'],
   emscripten_websocket_get_ready_state__proxy: 'sync',
-  emscripten_websocket_get_ready_state__sig: 'iii',
+  emscripten_websocket_get_ready_state__sig: 'iip',
   emscripten_websocket_get_ready_state: function(socketId, readyState) {
     var socket = WS.sockets[socketId];
     if (!socket) {
@@ -28,7 +28,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_get_buffered_amount__deps: ['$WS'],
   emscripten_websocket_get_buffered_amount__proxy: 'sync',
-  emscripten_websocket_get_buffered_amount__sig: 'iii',
+  emscripten_websocket_get_buffered_amount__sig: 'iip',
   emscripten_websocket_get_buffered_amount: function(socketId, bufferedAmount) {
     var socket = WS.sockets[socketId];
     if (!socket) {
@@ -44,7 +44,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_get_extensions__deps: ['$WS'],
   emscripten_websocket_get_extensions__proxy: 'sync',
-  emscripten_websocket_get_extensions__sig: 'iiii',
+  emscripten_websocket_get_extensions__sig: 'iipi',
   emscripten_websocket_get_extensions: function(socketId, extensions, extensionsLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
@@ -60,7 +60,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_get_extensions_length__deps: ['$WS'],
   emscripten_websocket_get_extensions_length__proxy: 'sync',
-  emscripten_websocket_get_extensions_length__sig: 'iii',
+  emscripten_websocket_get_extensions_length__sig: 'iip',
   emscripten_websocket_get_extensions_length: function(socketId, extensionsLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
@@ -76,7 +76,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_get_protocol__deps: ['$WS'],
   emscripten_websocket_get_protocol__proxy: 'sync',
-  emscripten_websocket_get_protocol__sig: 'iiii',
+  emscripten_websocket_get_protocol__sig: 'iipi',
   emscripten_websocket_get_protocol: function(socketId, protocol, protocolLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
@@ -92,7 +92,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_get_protocol_length__deps: ['$WS'],
   emscripten_websocket_get_protocol_length__proxy: 'sync',
-  emscripten_websocket_get_protocol_length__sig: 'iii',
+  emscripten_websocket_get_protocol_length__sig: 'iip',
   emscripten_websocket_get_protocol_length: function(socketId, protocolLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
@@ -108,7 +108,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_get_url__deps: ['$WS'],
   emscripten_websocket_get_url__proxy: 'sync',
-  emscripten_websocket_get_url__sig: 'iiii',
+  emscripten_websocket_get_url__sig: 'iipi',
   emscripten_websocket_get_url: function(socketId, url, urlLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
@@ -124,7 +124,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_get_url_length__deps: ['$WS'],
   emscripten_websocket_get_url_length__proxy: 'sync',
-  emscripten_websocket_get_url_length__sig: 'iii',
+  emscripten_websocket_get_url_length__sig: 'iip',
   emscripten_websocket_get_url_length: function(socketId, urlLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
@@ -140,7 +140,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_set_onopen_callback_on_thread__deps: ['$WS'],
   emscripten_websocket_set_onopen_callback_on_thread__proxy: 'sync',
-  emscripten_websocket_set_onopen_callback_on_thread__sig: 'iiiii',
+  emscripten_websocket_set_onopen_callback_on_thread__sig: 'iippp',
   emscripten_websocket_set_onopen_callback_on_thread: function(socketId, userData, callbackFunc, thread) {
 // TODO:
 //    if (thread == {{{ cDefine('EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD') }}} ||
@@ -171,7 +171,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_set_onerror_callback_on_thread__deps: ['$WS'],
   emscripten_websocket_set_onerror_callback_on_thread__proxy: 'sync',
-  emscripten_websocket_set_onerror_callback_on_thread__sig: 'iiiii',
+  emscripten_websocket_set_onerror_callback_on_thread__sig: 'iippp',
   emscripten_websocket_set_onerror_callback_on_thread: function(socketId, userData, callbackFunc, thread) {
     if (!WS.socketEvent) WS.socketEvent = _malloc(1024); // TODO: sizeof(EmscriptenWebSocketCloseEvent), which is the largest event struct
 
@@ -198,7 +198,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_set_onclose_callback_on_thread__deps: ['$WS'],
   emscripten_websocket_set_onclose_callback_on_thread__proxy: 'sync',
-  emscripten_websocket_set_onclose_callback_on_thread__sig: 'iiiii',
+  emscripten_websocket_set_onclose_callback_on_thread__sig: 'iippp',
   emscripten_websocket_set_onclose_callback_on_thread: function(socketId, userData, callbackFunc, thread) {
     if (!WS.socketEvent) WS.socketEvent = _malloc(1024); // TODO: sizeof(EmscriptenWebSocketCloseEvent), which is the largest event struct
 
@@ -228,7 +228,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_set_onmessage_callback_on_thread__deps: ['$WS'],
   emscripten_websocket_set_onmessage_callback_on_thread__proxy: 'sync',
-  emscripten_websocket_set_onmessage_callback_on_thread__sig: 'iiiii',
+  emscripten_websocket_set_onmessage_callback_on_thread__sig: 'iippp',
   emscripten_websocket_set_onmessage_callback_on_thread: function(socketId, userData, callbackFunc, thread) {
     if (!WS.socketEvent) WS.socketEvent = _malloc(1024); // TODO: sizeof(EmscriptenWebSocketCloseEvent), which is the largest event struct
 
@@ -283,7 +283,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_new__deps: ['$WS'],
   emscripten_websocket_new__proxy: 'sync',
-  emscripten_websocket_new__sig: 'ii',
+  emscripten_websocket_new__sig: 'ip',
   emscripten_websocket_new: function(createAttributes) {
     if (typeof WebSocket == 'undefined') {
 #if WEBSOCKET_DEBUG
@@ -319,7 +319,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_send_utf8_text__deps: ['$WS'],
   emscripten_websocket_send_utf8_text__proxy: 'sync',
-  emscripten_websocket_send_utf8_text__sig: 'iii',
+  emscripten_websocket_send_utf8_text__sig: 'iip',
   emscripten_websocket_send_utf8_text: function(socketId, textData) {
     var socket = WS.sockets[socketId];
     if (!socket) {
@@ -343,7 +343,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_send_binary__deps: ['$WS'],
   emscripten_websocket_send_binary__proxy: 'sync',
-  emscripten_websocket_send_binary__sig: 'iiii',
+  emscripten_websocket_send_binary__sig: 'iipi',
   emscripten_websocket_send_binary: function(socketId, binaryData, dataLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
@@ -375,7 +375,7 @@ var LibraryWebSocket = {
 
   emscripten_websocket_close__deps: ['$WS'],
   emscripten_websocket_close__proxy: 'sync',
-  emscripten_websocket_close__sig: 'iiii',
+  emscripten_websocket_close__sig: 'iiip',
   emscripten_websocket_close: function(socketId, code, reason) {
     var socket = WS.sockets[socketId];
     if (!socket) {

--- a/src/library_wget.js
+++ b/src/library_wget.js
@@ -18,7 +18,7 @@ var LibraryWget = {
 
   emscripten_async_wget__deps: ['$PATH_FS', '$wget', '$callUserCallback', '$Browser', '$withStackSave', '$allocateUTF8OnStack'],
   emscripten_async_wget__proxy: 'sync',
-  emscripten_async_wget__sig: 'viiii',
+  emscripten_async_wget__sig: 'vpppp',
   emscripten_async_wget: function(url, file, onload, onerror) {
     {{{ runtimeKeepalivePush() }}}
 
@@ -61,7 +61,7 @@ var LibraryWget = {
 
   emscripten_async_wget_data__deps: ['$asyncLoad', 'malloc', 'free', '$callUserCallback'],
   emscripten_async_wget_data__proxy: 'sync',
-  emscripten_async_wget_data__sig: 'viiii',
+  emscripten_async_wget_data__sig: 'vpppp',
   emscripten_async_wget_data: function(url, arg, onload, onerror) {
     {{{ runtimeKeepalivePush() }}}
     asyncLoad(UTF8ToString(url), function(byteArray) {
@@ -84,7 +84,7 @@ var LibraryWget = {
 
   emscripten_async_wget2__deps: ['$PATH_FS', '$wget', '$withStackSave', '$allocateUTF8OnStack'],
   emscripten_async_wget2__proxy: 'sync',
-  emscripten_async_wget2__sig: 'iiiiiiiii',
+  emscripten_async_wget2__sig: 'ipppppppp',
   emscripten_async_wget2: function(url, file, request, param, arg, onload, onerror, onprogress) {
     {{{ runtimeKeepalivePush() }}}
 
@@ -163,7 +163,7 @@ var LibraryWget = {
 
   emscripten_async_wget2_data__deps: ['$wget', 'malloc', 'free'],
   emscripten_async_wget2_data__proxy: 'sync',
-  emscripten_async_wget2_data__sig: 'iiiiiiiii',
+  emscripten_async_wget2_data__sig: 'ippppippp',
   emscripten_async_wget2_data: function(url, request, param, arg, free, onload, onerror, onprogress) {
     var _url = UTF8ToString(url);
     var _request = UTF8ToString(request);


### PR DESCRIPTION
This change was almost entirely automatically generated by the tool I'm working on as part of #18979.  Once this change lands, I plan to completely remove these signatures and instead auto-generate them, but in order to make that change into no-op I'd like to first update them all in-place.

The one exception, where I hand edited, are the `emscripten_audio_worklet` where I removed the usage of aliases so that each function could have its own signature.

See #18985