### PR TITLE
Fix a few signature that were using `long` types. NFC

### DIFF
--- a/src/library_websocket.js
+++ b/src/library_websocket.js
@@ -38,7 +38,7 @@ var LibraryWebSocket = {
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
 
-    {{{ makeSetValue('bufferedAmount', '0', 'socket.bufferedAmount', 'i64') }}};
+    {{{ makeSetValue('bufferedAmount', '0', 'socket.bufferedAmount', '*') }}};
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },
 

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -476,8 +476,8 @@ void emscripten_html5_remove_all_event_listeners(void);
 #define emscripten_set_batterylevelchange_callback(userData, callback)                        emscripten_set_batterylevelchange_callback_on_thread(             (userData),               (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
 #define emscripten_set_beforeunload_callback(userData, callback)                              emscripten_set_beforeunload_callback_on_thread(                   (userData),               (callback), EM_CALLBACK_THREAD_CONTEXT_MAIN_RUNTIME_THREAD)
 
-long emscripten_request_animation_frame(EM_BOOL (*cb)(double time, void *userData), void *userData);
-void emscripten_cancel_animation_frame(long requestAnimationFrameId);
+int emscripten_request_animation_frame(EM_BOOL (*cb)(double time, void *userData), void *userData);
+void emscripten_cancel_animation_frame(int requestAnimationFrameId);
 void emscripten_request_animation_frame_loop(EM_BOOL (*cb)(double time, void *userData), void *userData);
 
 double emscripten_date_now(void);

--- a/system/include/emscripten/html5_webgl.h
+++ b/system/include/emscripten/html5_webgl.h
@@ -100,6 +100,7 @@ void *emscripten_webgl_get_proc_address(const char *name __attribute__((nonnull)
 
 #define GLint int
 #define GLenum int
+#define GLint64 long long int
 
 #define EMSCRIPTEN_WEBGL_PARAM_TYPE int
 #define EMSCRIPTEN_WEBGL_PARAM_TYPE_INT   0
@@ -188,12 +189,13 @@ GLint emscripten_webgl_get_parameter_o(GLenum param);
 char *emscripten_webgl_get_parameter_utf8(GLenum param);
 
 // Calls GLctx.getParameter():
-// Returns the given WebGL context state as long long, written to the given heap location.
+// Returns the given WebGL context state as GLint64, written to the given heap location.
 // Call this function only for values of 'param' that return a WebGL Number type.
-void emscripten_webgl_get_parameter_i64v(GLenum param, long long *dst __attribute__((nonnull)));
+void emscripten_webgl_get_parameter_i64v(GLenum param, GLint64 *dst __attribute__((nonnull)));
 
 #undef GLint
 #undef GLenum
+#undef GLint64
 
 #ifdef __cplusplus
 } // ~extern "C"

--- a/system/include/emscripten/websocket.h
+++ b/system/include/emscripten/websocket.h
@@ -23,7 +23,7 @@ extern "C" {
 EMSCRIPTEN_RESULT emscripten_websocket_get_ready_state(EMSCRIPTEN_WEBSOCKET_T socket, unsigned short *readyState __attribute__((nonnull)));
 
 // Returns the WebSocket.bufferedAmount field into bufferedAmount. bufferedAmount must not be a null pointer.
-EMSCRIPTEN_RESULT emscripten_websocket_get_buffered_amount(EMSCRIPTEN_WEBSOCKET_T socket, unsigned long long *bufferedAmount __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_websocket_get_buffered_amount(EMSCRIPTEN_WEBSOCKET_T socket, size_t *bufferedAmount __attribute__((nonnull)));
 
 // Writes the WebSocket.url field as a UTF-8 string to the memory area pointed by url. The memory area must contain at least urlLength bytes of free space. If this memory area cannot
 // fit the url string, it will be truncated. Call emscripten_websocket_get_url_length() to determine how large memory area will be required to store the url.


### PR DESCRIPTION
The `emscripten_request_animation_frame` sig was just wrong since that Web API returns WebIDL `long` defined as i32.

For `emscripten_webgl_get_parameter_i64v` use GLint64 rather than `long long` to me more explicit.

For `emscripten_websocket_get_buffered_amount` using `size_t` since we already include `stdint.h` in this header anyway.

I found all of these while working on #18985 which detectes the use of `long`, `size_t` or pointers and marks tham a `p` in their `__sig` attribute.