### PR TITLE
Only test crossplatform tests on mac

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,17 +695,8 @@ jobs:
       - pip-install:
           python: "$EMSDK_PYTHON"
       - run-tests:
-          # skip other.test_stack_switching_size as we do not currently install
-          # d8 on mac
-          title: "other+extras"
-          test_targets: "
-            other
-            sockets.test_nodejs_sockets_echo*
-            core0.test_lua
-            core0.test_longjmp_standalone
-            core2.test_sse1
-            skip:other.test_native_link_error_message
-            skip:other.test_stack_switching_size"
+          title: "crossplatform tests"
+          test_targets: "--crossplatform-only"
       - upload-test-results
 
 workflows:

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1108,6 +1108,7 @@ base align: 0, 0, 0, 0'''])
   def test_regex(self):
     self.do_core_test('test_regex.c')
 
+  @crossplatform
   @also_with_standalone_wasm(wasm2c=True, impure=True)
   def test_longjmp_standalone(self):
     self.do_core_test('test_longjmp.c')
@@ -6867,6 +6868,7 @@ void* operator new(size_t size) {
     self.do_runf(test_file('third_party/libiberty/cp-demangle.c'), '*d_demangle(char const*, int, unsigned int*)*', args=['_ZL10d_demanglePKciPj'])
 
   @needs_make('make')
+  @crossplatform
   def test_lua(self):
     self.emcc_args.remove('-Werror')
     env_init = {

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
 import clang_native
 import common
 from common import BrowserCore, no_windows, create_file, test_file, read_file
-from common import parameterized, requires_native_clang, PYTHON
+from common import parameterized, requires_native_clang, crossplatform, PYTHON
 from tools import config, utils
 from tools.shared import EMCC, path_from_root, run_process, CLANG_CC
 
@@ -277,6 +277,7 @@ class sockets(BrowserCore):
     with CompiledServerHarness(test_file('sockets/test_enet_server.c'), enet, 49210) as harness:
       self.btest_exit(test_file('sockets/test_enet_client.c'), args=enet + ['-DSOCKK=%d' % harness.listen_port])
 
+  @crossplatform
   @parameterized({
     'native': [WebsockifyServerHarness, 59160, ['-DTEST_DGRAM=0']],
     'tcp': [CompiledServerHarness, 59162, ['-DTEST_DGRAM=0']],


### PR DESCRIPTION
This makes the mac builder run only the tests that are marked as @crossplatform, 
having been explicitly added for Windows or mac. It will be a large reduction
in test coverage for mac, but of course run much faster.