### PR TITLE
Implement mount wasmfs

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2338,6 +2338,7 @@ def phase_linker_setup(options, state, newargs):
         '_wasmfs_readdir_start',
         '_wasmfs_readdir_get',
         '_wasmfs_readdir_finish',
+        '_wasmfs_mount',
       ]
 
   # Explicitly drop linking in a malloc implementation if program is not using any dynamic allocation calls.

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1003,6 +1003,12 @@ var SyscallsLibrary = {
     if (suggest) FS.close(suggest);
     return FS.createStream(old, suggestFD, suggestFD + 1).fd;
   },
+  __syscall_mount__sig:'mou', //REMINDER: change the sig here, I just put anything here
+  __syscall_mount: function(type, opts, path){
+    path = SYSCALLS.getStr(path);
+    FS.mount(type, opts, path);
+    return 0;
+  },
 };
 
 function wrapSyscallFunction(x, library, isWasi) {

--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -212,8 +212,16 @@ mergeInto(LibraryManager.library, {
         __wasmfs_readdir_finish(state);
         return entries;
       });
+    },
+    mount: (type, opts, mountpoint) => {
+      return withStackSave(() => {
+        var mountFlags = FS.optionsToFlags(opts);
+        var mountPointBuffer = allocateUTF8OnStack(mountpoint);
+        var typeBuffer = allocateUTF8OnStack(type)
+        return __wasmfs_mount(typeBuffer, mountFlags, mountPointBuffer)
+
+      })
     }
-    // TODO: mount
     // TODO: unmount
     // TODO: lookup
     // TODO: mknod

--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -213,6 +213,50 @@ mergeInto(LibraryManager.library, {
         return entries;
       });
     },
+    optionsToFlags:(opts) => {
+      let flags = 0;
+      const MountFlags = {
+        RDONLY: 0x1,
+        WRONLY: 0x2,
+        RDWR: 0x4,
+        CREATE: 0x8,
+        EXCL: 0x10,
+        TRUNC: 0x20,
+        APPEND: 0x40,
+        IRUGO: cDefine(S_IRUSR) | cDefine(S_IRGRP) | cDefine(S_IROTH),
+      };
+
+
+      for (let i = 0; i < opts.length; i++) {
+        switch (opts[i]) {
+            case 'r':
+                flags |= MountFlags.RDONLY;
+                break;
+            case 'w':
+                flags |= MountFlags.WRONLY;
+                break;
+            case '+':
+                flags |= MountFlags.RDWR;
+                break;
+            case 'a':
+                flags |= MountFlags.APPEND;
+                break;
+            case 't':
+                flags |= MountFlags.TRUNC;
+                break;
+            case 'c':
+                flags |= MountFlags.CREATE;
+                break;
+            case 'x':
+                flags |= MountFlags.EXCL;
+                break;
+            default:
+                throw new Error(`Unknown mount option: ${opts[i]}`);
+        }
+      }
+    
+      return flags;
+    },
     mount: (type, opts, mountpoint) => {
       return withStackSave(() => {
         var mountFlags = FS.optionsToFlags(opts);

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -118,6 +118,7 @@ int __syscall_sendmsg(int sockfd, intptr_t msg , int flags, intptr_t addr, size_
 int __syscall_recvfrom(int sockfd, intptr_t msg, size_t len, int flags, intptr_t addr, intptr_t alen);
 int __syscall_recvmsg(int sockfd, intptr_t msg, int flags, int dummy, int dummy2, int dummy3);
 int __syscall_shutdown(int sockfd, int how, int dummy, int dummy2, int dummy3, int dummy4);
+int __syscall_mount(char* type, int flag, char* path);
 
 #ifdef __cplusplus
 }

--- a/system/lib/wasmfs/js_api.cpp
+++ b/system/lib/wasmfs/js_api.cpp
@@ -114,6 +114,10 @@ int _wasmfs_chmod(char* path, mode_t mode) {
   return __syscall_chmod((intptr_t)path, mode);
 }
 
+int _wasmfs_mount(char* type, int flag, char* path){
+  return __syscall_mount(type, flag, path);
+}
+
 // Helper method that identifies what a path is:
 //   ENOENT - if nothing exists there
 //   EISDIR - if it is a directory

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -19,6 +19,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
+#include <sys/mount.h>
 #include <syscall_arch.h>
 #include <unistd.h>
 #include <utility>
@@ -1723,6 +1724,14 @@ int __syscall_recvfrom(int sockfd,
 int __syscall_recvmsg(
   int sockfd, intptr_t msg, int flags, int dummy, int dummy2, int dummy3) {
   return -ENOSYS;
+}
+
+int __syscall_mount(char* type, int flag, char* path){
+  const char* target = "/tmp";
+  //REMINDER: change the target path
+
+  mount(path, target, type, flag, NULL);
+  return 0;
 }
 
 } // extern "C"


### PR DESCRIPTION
I have tried to implement wasmfs to the best of my ability, but I'm having trouble importing the 'mount' header file from sys/mount.h. Despite my efforts, the 'mount' I have imported is not being recognized during testing. I am also encountering a similar issue with "ioctl" implementation. What steps can I take to resolve this issue?

```
wasm-ld: error: /home/tylerthe/Desktop/gsoc/emscripten/cache/sysroot/lib/wasm32-emscripten/libwasmfs.a(syscalls.o): undefined symbol: mount
emcc: error: '/home/tylerthe/Desktop/gsoc/llvm-project/build/bin/wasm-ld -o test_readv.wasm /tmp/emtest_ehqy3diw/emscripten_temp_xknepqh5/test_readv_0.o -L/home/tylerthe/Desktop/gsoc/emscripten/cache/sysroot/lib/wasm32-emscripten --whole-archive -lwasmfs --no-whole-archive -lGL -lal -lhtml5 -lstubs -lnoexit -lc -ldlmalloc -lcompiler_rt -lc++-noexcept -lc++abi-noexcept -lsockets -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr --allow-undefined-file=/tmp/emtest_ehqy3diw/tmpm9378ofb.undefined --strip-debug --export-if-defined=main --export-if-defined=__start_em_asm --export-if-defined=__stop_em_asm --export-if-defined=__start_em_lib_deps --export-if-defined=__stop_em_lib_deps --export-if-defined=__start_em_js --export-if-defined=__stop_em_js --export-if-defined=__main_argc_argv --export=_wasmfs_read_file --export=_wasmfs_write_file --export=_wasmfs_mkdir --export=_wasmfs_unlink --export=_wasmfs_chdir --export=_wasmfs_symlink --export=_wasmfs_chmod --export=_wasmfs_identify --export=_wasmfs_readdir_start --export=_wasmfs_readdir_get --export=_wasmfs_readdir_finish --export=_wasmfs_mount --export=stackSave --export=stackRestore --export=stackAlloc --export=__errno_location --export=__get_temp_ret --export=__set_temp_ret --export=malloc --export=free --export=__wasm_call_ctors --export-table -z stack-size=65536 --initial-memory=16777216 --no-entry --max-memory=16777216 --global-base=1024' failed (returned 1)
None
None
```