### PR TITLE
Fix libpng and libfreetype port with wasm exceptions are enabled

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -294,6 +294,30 @@ def also_with_wasm_bigint(f):
   return metafunc
 
 
+# This works just like `with_both_eh_sjlj` above but doesn't enable exceptions.
+# Use this for tests that use setjmp/longjmp but not exceptions handling.
+def with_both_sjlj(f):
+  assert callable(f)
+
+  def metafunc(self, is_native):
+    if is_native:
+      if not self.is_wasm():
+        self.skipTest('wasm2js does not support wasm SjLj')
+      self.require_wasm_eh()
+      # FIXME Temporarily disabled. Enable this later when the bug is fixed.
+      if '-fsanitize=address' in self.emcc_args:
+        self.skipTest('Wasm EH does not work with asan yet')
+      self.set_setting('SUPPORT_LONGJMP', 'wasm')
+      f(self)
+    else:
+      self.set_setting('SUPPORT_LONGJMP', 'emscripten')
+      f(self)
+
+  metafunc._parameterize = {'': (False,),
+                            'wasm_sjlj': (True,)}
+  return metafunc
+
+
 def ensure_dir(dirname):
   dirname = Path(dirname)
   dirname.mkdir(parents=True, exist_ok=True)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -28,6 +28,7 @@ from common import RunnerCore, path_from_root, requires_native_clang, test_file,
 from common import skip_if, needs_dylink, no_windows, no_mac, is_slow_test, parameterized
 from common import env_modify, with_env_modify, disabled, node_pthreads, also_with_wasm_bigint
 from common import read_file, read_binary, requires_v8, requires_node, compiler_for, crossplatform
+from common import with_both_sjlj
 from common import NON_ZERO, WEBIDL_BINDER, EMBUILDER, PYTHON
 import clang_native
 
@@ -117,31 +118,6 @@ def with_both_eh_sjlj(f):
       # error out because libc++abi is not included. See
       # https://github.com/emscripten-core/emscripten/pull/14192 for details.
       self.set_setting('DEFAULT_TO_CXX')
-      f(self)
-
-  metafunc._parameterize = {'': (False,),
-                            'wasm': (True,)}
-  return metafunc
-
-
-# This works just like `with_both_eh_sjlj` above but doesn't enable exceptions.
-# Use this for tests that use setjmp/longjmp but not exceptions handling.
-def with_both_sjlj(f):
-  assert callable(f)
-
-  def metafunc(self, is_native):
-    if is_native:
-      # Wasm SjLj is currently supported only in wasm backend and V8
-      if not self.is_wasm():
-        self.skipTest('wasm2js does not support wasm SjLj')
-      self.require_wasm_eh()
-      # FIXME Temporarily disabled. Enable this later when the bug is fixed.
-      if '-fsanitize=address' in self.emcc_args:
-        self.skipTest('Wasm EH does not work with asan yet')
-      self.set_setting('SUPPORT_LONGJMP', 'wasm')
-      f(self)
-    else:
-      self.set_setting('SUPPORT_LONGJMP', 'emscripten')
       f(self)
 
   metafunc._parameterize = {'': (False,),

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -33,7 +33,7 @@ from common import RunnerCore, path_from_root, is_slow_test, ensure_dir, disable
 from common import env_modify, no_mac, no_windows, requires_native_clang, with_env_modify
 from common import create_file, parameterized, NON_ZERO, node_pthreads, TEST_ROOT, test_file
 from common import compiler_for, EMBUILDER, requires_v8, requires_node, requires_wasm64
-from common import requires_wasm_eh, crossplatform
+from common import requires_wasm_eh, crossplatform, with_both_sjlj
 from common import also_with_minimal_runtime, also_with_wasm_bigint, EMTEST_BUILD_VERBOSE, PYTHON
 from tools import shared, building, utils, deps_info, response_file, cache
 from tools.utils import read_file, write_file, delete_file, read_binary
@@ -2205,6 +2205,7 @@ int f() {
     self.do_runf(test_file('bzip2_test.c'), 'usage: unzcrash filename',
                  emcc_args=['-sUSE_BZIP2', '-Wno-pointer-sign'])
 
+  @with_both_sjlj
   def test_freetype(self):
     # copy the Liberation Sans Bold truetype file located in the
     # <emscripten_root>/test/freetype to the compilation folder

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -8,9 +8,18 @@ import os
 TAG = 'version_1'
 HASH = '0d0b1280ba0501ad0a23cf1daa1f86821c722218b59432734d3087a89acd22aabd5c3e5e1269700dcd41e87073046e906060f167c032eb91a3ac8c5808a02783'
 
+variants = {'freetype-wasm-sjlj': {'SUPPORT_LONGJMP': 'wasm'}}
+
 
 def needed(settings):
   return settings.USE_FREETYPE
+
+
+def get_lib_name(settings):
+  if settings.SUPPORT_LONGJMP == 'wasm':
+    return 'libfreetype-wasm-sjlj.a'
+  else:
+    return 'libfreetype.a'
 
 
 def get(ports, settings, shared):
@@ -90,13 +99,16 @@ def get(ports, settings, shared):
       '-pthread'
     ]
 
+    if settings.SUPPORT_LONGJMP == 'wasm':
+      flags.append('-sSUPPORT_LONGJMP=wasm')
+
     ports.build_port(source_path, final, 'freetype', flags=flags, srcs=srcs)
 
-  return [shared.cache.get_lib('libfreetype.a', create, what='port')]
+  return [shared.cache.get_lib(get_lib_name(settings), create, what='port')]
 
 
 def clear(ports, settings, shared):
-  shared.cache.erase_lib('libfreetype.a')
+  shared.cache.erase_lib(get_lib_name(settings))
 
 
 def process_args(ports):

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -10,7 +10,11 @@ TAG = '1.6.37'
 HASH = '2ce2b855af307ca92a6e053f521f5d262c36eb836b4810cb53c809aa3ea2dcc08f834aee0ffd66137768a54397e28e92804534a74abb6fc9f6f3127f14c9c338'
 
 deps = ['zlib']
-variants = {'libpng-mt': {'PTHREADS': 1}}
+variants = {
+  'libpng-mt': {'PTHREADS': 1},
+  'libpng-wasm-sjlj': {'SUPPORT_LONGJMP': 'wasm'},
+  'libpng-mt-wasm-sjlj': {'PTHREADS': 1, 'SUPPORT_LONGJMP': 'wasm'},
+}
 
 
 def needed(settings):
@@ -18,7 +22,12 @@ def needed(settings):
 
 
 def get_lib_name(settings):
-  return 'libpng' + ('-mt' if settings.PTHREADS else '') + '.a'
+  suffix = ''
+  if settings.PTHREADS:
+    suffix += '-mt'
+  if settings.SUPPORT_LONGJMP == 'wasm':
+    suffix += '-wasm-sjlj'
+  return f'libpng{suffix}.a'
 
 
 def get(ports, settings, shared):
@@ -35,6 +44,8 @@ def get(ports, settings, shared):
     flags = ['-sUSE_ZLIB']
     if settings.PTHREADS:
       flags += ['-pthread']
+    if settings.SUPPORT_LONGJMP == 'wasm':
+      flags.append('-sSUPPORT_LONGJMP=wasm')
 
     ports.build_port(source_path, final, 'libpng', flags=flags, exclude_files=['pngtest'], exclude_dirs=['scripts', 'contrib'])
 


### PR DESCRIPTION
Sadly, even though libpng can be compiled with setjmp/longjmp support       
some libraries such as openjpeg assume that setjmp support is included.

Fixes: #19001