### PR TITLE
Use new cDefs proxy object rather than cDefines function. NFC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,8 @@ See docs/process.md for more on how version tagging works.
   folks who had JS files with lines that start with `#` so can't be run through
   the pre-processor.  If folks want to re-enable this we can looks into ways to
   make it conditional/optional.
+- The `{{{ cDefine('name') }}}` helper macro can now be simplified to just `{{{
+  cDefs.name }}}`.
 
 3.1.34 - 03/14/23
 -----------------

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -253,15 +253,15 @@ function fetchXHR(fetch, onsuccess, onerror, onprogress, onreadystatechange) {
   var dataPtr = HEAPU32[fetch_attr + {{{ C_STRUCTS.emscripten_fetch_attr_t.requestData }}} >> 2];
   var dataLength = HEAPU32[fetch_attr + {{{ C_STRUCTS.emscripten_fetch_attr_t.requestDataSize }}} >> 2];
 
-  var fetchAttrLoadToMemory = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_LOAD_TO_MEMORY') }}});
-  var fetchAttrStreamData = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_STREAM_DATA') }}});
+  var fetchAttrLoadToMemory = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_LOAD_TO_MEMORY }}});
+  var fetchAttrStreamData = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_STREAM_DATA }}});
 #if FETCH_SUPPORT_INDEXEDDB
-  var fetchAttrPersistFile = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_PERSIST_FILE') }}});
+  var fetchAttrPersistFile = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_PERSIST_FILE }}});
 #endif
-  var fetchAttrAppend = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_APPEND') }}});
-  var fetchAttrReplace = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_REPLACE') }}});
-  var fetchAttrSynchronous = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_SYNCHRONOUS') }}});
-  var fetchAttrWaitable = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_WAITABLE') }}});
+  var fetchAttrAppend = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_APPEND }}});
+  var fetchAttrReplace = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_REPLACE }}});
+  var fetchAttrSynchronous = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_SYNCHRONOUS }}});
+  var fetchAttrWaitable = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_WAITABLE }}});
 
   var userNameStr = userName ? UTF8ToString(userName) : undefined;
   var passwordStr = password ? UTF8ToString(password) : undefined;
@@ -449,15 +449,15 @@ function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
   var onprogress = HEAPU32[fetch_attr + {{{ C_STRUCTS.emscripten_fetch_attr_t.onprogress }}} >> 2];
   var onreadystatechange = HEAPU32[fetch_attr + {{{ C_STRUCTS.emscripten_fetch_attr_t.onreadystatechange }}} >> 2];
   var fetchAttributes = HEAPU32[fetch_attr + {{{ C_STRUCTS.emscripten_fetch_attr_t.attributes }}} >> 2];
-  var fetchAttrLoadToMemory = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_LOAD_TO_MEMORY') }}});
-  var fetchAttrStreamData = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_STREAM_DATA') }}});
+  var fetchAttrLoadToMemory = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_LOAD_TO_MEMORY }}});
+  var fetchAttrStreamData = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_STREAM_DATA }}});
 #if FETCH_SUPPORT_INDEXEDDB
-  var fetchAttrPersistFile = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_PERSIST_FILE') }}});
-  var fetchAttrNoDownload = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_NO_DOWNLOAD') }}});
+  var fetchAttrPersistFile = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_PERSIST_FILE }}});
+  var fetchAttrNoDownload = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_NO_DOWNLOAD }}});
 #endif
-  var fetchAttrAppend = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_APPEND') }}});
-  var fetchAttrReplace = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_REPLACE') }}});
-  var fetchAttrSynchronous = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_SYNCHRONOUS') }}});
+  var fetchAttrAppend = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_APPEND }}});
+  var fetchAttrReplace = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_REPLACE }}});
+  var fetchAttrSynchronous = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_SYNCHRONOUS }}});
 
   function doCallback(f) {
     if (fetchAttrSynchronous) {

--- a/src/library.js
+++ b/src/library.js
@@ -362,7 +362,7 @@ mergeInto(LibraryManager.library, {
     // http://pubs.opengroup.org/onlinepubs/000095399/functions/system.html
     // Can't call external programs.
     if (!command) return 0; // no shell available
-    setErrNo({{{ cDefine('ENOSYS') }}});
+    setErrNo({{{ cDefs.ENOSYS }}});
     return -1;
   },
 
@@ -1280,251 +1280,251 @@ mergeInto(LibraryManager.library, {
   // ==========================================================================
 
   $ERRNO_CODES__postset: `ERRNO_CODES = {
-    'EPERM': {{{ cDefine('EPERM') }}},
-    'ENOENT': {{{ cDefine('ENOENT') }}},
-    'ESRCH': {{{ cDefine('ESRCH') }}},
-    'EINTR': {{{ cDefine('EINTR') }}},
-    'EIO': {{{ cDefine('EIO') }}},
-    'ENXIO': {{{ cDefine('ENXIO') }}},
-    'E2BIG': {{{ cDefine('E2BIG') }}},
-    'ENOEXEC': {{{ cDefine('ENOEXEC') }}},
-    'EBADF': {{{ cDefine('EBADF') }}},
-    'ECHILD': {{{ cDefine('ECHILD') }}},
-    'EAGAIN': {{{ cDefine('EAGAIN') }}},
-    'EWOULDBLOCK': {{{ cDefine('EWOULDBLOCK') }}},
-    'ENOMEM': {{{ cDefine('ENOMEM') }}},
-    'EACCES': {{{ cDefine('EACCES') }}},
-    'EFAULT': {{{ cDefine('EFAULT') }}},
-    'ENOTBLK': {{{ cDefine('ENOTBLK') }}},
-    'EBUSY': {{{ cDefine('EBUSY') }}},
-    'EEXIST': {{{ cDefine('EEXIST') }}},
-    'EXDEV': {{{ cDefine('EXDEV') }}},
-    'ENODEV': {{{ cDefine('ENODEV') }}},
-    'ENOTDIR': {{{ cDefine('ENOTDIR') }}},
-    'EISDIR': {{{ cDefine('EISDIR') }}},
-    'EINVAL': {{{ cDefine('EINVAL') }}},
-    'ENFILE': {{{ cDefine('ENFILE') }}},
-    'EMFILE': {{{ cDefine('EMFILE') }}},
-    'ENOTTY': {{{ cDefine('ENOTTY') }}},
-    'ETXTBSY': {{{ cDefine('ETXTBSY') }}},
-    'EFBIG': {{{ cDefine('EFBIG') }}},
-    'ENOSPC': {{{ cDefine('ENOSPC') }}},
-    'ESPIPE': {{{ cDefine('ESPIPE') }}},
-    'EROFS': {{{ cDefine('EROFS') }}},
-    'EMLINK': {{{ cDefine('EMLINK') }}},
-    'EPIPE': {{{ cDefine('EPIPE') }}},
-    'EDOM': {{{ cDefine('EDOM') }}},
-    'ERANGE': {{{ cDefine('ERANGE') }}},
-    'ENOMSG': {{{ cDefine('ENOMSG') }}},
-    'EIDRM': {{{ cDefine('EIDRM') }}},
-    'ECHRNG': {{{ cDefine('ECHRNG') }}},
-    'EL2NSYNC': {{{ cDefine('EL2NSYNC') }}},
-    'EL3HLT': {{{ cDefine('EL3HLT') }}},
-    'EL3RST': {{{ cDefine('EL3RST') }}},
-    'ELNRNG': {{{ cDefine('ELNRNG') }}},
-    'EUNATCH': {{{ cDefine('EUNATCH') }}},
-    'ENOCSI': {{{ cDefine('ENOCSI') }}},
-    'EL2HLT': {{{ cDefine('EL2HLT') }}},
-    'EDEADLK': {{{ cDefine('EDEADLK') }}},
-    'ENOLCK': {{{ cDefine('ENOLCK') }}},
-    'EBADE': {{{ cDefine('EBADE') }}},
-    'EBADR': {{{ cDefine('EBADR') }}},
-    'EXFULL': {{{ cDefine('EXFULL') }}},
-    'ENOANO': {{{ cDefine('ENOANO') }}},
-    'EBADRQC': {{{ cDefine('EBADRQC') }}},
-    'EBADSLT': {{{ cDefine('EBADSLT') }}},
-    'EDEADLOCK': {{{ cDefine('EDEADLOCK') }}},
-    'EBFONT': {{{ cDefine('EBFONT') }}},
-    'ENOSTR': {{{ cDefine('ENOSTR') }}},
-    'ENODATA': {{{ cDefine('ENODATA') }}},
-    'ETIME': {{{ cDefine('ETIME') }}},
-    'ENOSR': {{{ cDefine('ENOSR') }}},
-    'ENONET': {{{ cDefine('ENONET') }}},
-    'ENOPKG': {{{ cDefine('ENOPKG') }}},
-    'EREMOTE': {{{ cDefine('EREMOTE') }}},
-    'ENOLINK': {{{ cDefine('ENOLINK') }}},
-    'EADV': {{{ cDefine('EADV') }}},
-    'ESRMNT': {{{ cDefine('ESRMNT') }}},
-    'ECOMM': {{{ cDefine('ECOMM') }}},
-    'EPROTO': {{{ cDefine('EPROTO') }}},
-    'EMULTIHOP': {{{ cDefine('EMULTIHOP') }}},
-    'EDOTDOT': {{{ cDefine('EDOTDOT') }}},
-    'EBADMSG': {{{ cDefine('EBADMSG') }}},
-    'ENOTUNIQ': {{{ cDefine('ENOTUNIQ') }}},
-    'EBADFD': {{{ cDefine('EBADFD') }}},
-    'EREMCHG': {{{ cDefine('EREMCHG') }}},
-    'ELIBACC': {{{ cDefine('ELIBACC') }}},
-    'ELIBBAD': {{{ cDefine('ELIBBAD') }}},
-    'ELIBSCN': {{{ cDefine('ELIBSCN') }}},
-    'ELIBMAX': {{{ cDefine('ELIBMAX') }}},
-    'ELIBEXEC': {{{ cDefine('ELIBEXEC') }}},
-    'ENOSYS': {{{ cDefine('ENOSYS') }}},
-    'ENOTEMPTY': {{{ cDefine('ENOTEMPTY') }}},
-    'ENAMETOOLONG': {{{ cDefine('ENAMETOOLONG') }}},
-    'ELOOP': {{{ cDefine('ELOOP') }}},
-    'EOPNOTSUPP': {{{ cDefine('EOPNOTSUPP') }}},
-    'EPFNOSUPPORT': {{{ cDefine('EPFNOSUPPORT') }}},
-    'ECONNRESET': {{{ cDefine('ECONNRESET') }}},
-    'ENOBUFS': {{{ cDefine('ENOBUFS') }}},
-    'EAFNOSUPPORT': {{{ cDefine('EAFNOSUPPORT') }}},
-    'EPROTOTYPE': {{{ cDefine('EPROTOTYPE') }}},
-    'ENOTSOCK': {{{ cDefine('ENOTSOCK') }}},
-    'ENOPROTOOPT': {{{ cDefine('ENOPROTOOPT') }}},
-    'ESHUTDOWN': {{{ cDefine('ESHUTDOWN') }}},
-    'ECONNREFUSED': {{{ cDefine('ECONNREFUSED') }}},
-    'EADDRINUSE': {{{ cDefine('EADDRINUSE') }}},
-    'ECONNABORTED': {{{ cDefine('ECONNABORTED') }}},
-    'ENETUNREACH': {{{ cDefine('ENETUNREACH') }}},
-    'ENETDOWN': {{{ cDefine('ENETDOWN') }}},
-    'ETIMEDOUT': {{{ cDefine('ETIMEDOUT') }}},
-    'EHOSTDOWN': {{{ cDefine('EHOSTDOWN') }}},
-    'EHOSTUNREACH': {{{ cDefine('EHOSTUNREACH') }}},
-    'EINPROGRESS': {{{ cDefine('EINPROGRESS') }}},
-    'EALREADY': {{{ cDefine('EALREADY') }}},
-    'EDESTADDRREQ': {{{ cDefine('EDESTADDRREQ') }}},
-    'EMSGSIZE': {{{ cDefine('EMSGSIZE') }}},
-    'EPROTONOSUPPORT': {{{ cDefine('EPROTONOSUPPORT') }}},
-    'ESOCKTNOSUPPORT': {{{ cDefine('ESOCKTNOSUPPORT') }}},
-    'EADDRNOTAVAIL': {{{ cDefine('EADDRNOTAVAIL') }}},
-    'ENETRESET': {{{ cDefine('ENETRESET') }}},
-    'EISCONN': {{{ cDefine('EISCONN') }}},
-    'ENOTCONN': {{{ cDefine('ENOTCONN') }}},
-    'ETOOMANYREFS': {{{ cDefine('ETOOMANYREFS') }}},
-    'EUSERS': {{{ cDefine('EUSERS') }}},
-    'EDQUOT': {{{ cDefine('EDQUOT') }}},
-    'ESTALE': {{{ cDefine('ESTALE') }}},
-    'ENOTSUP': {{{ cDefine('ENOTSUP') }}},
-    'ENOMEDIUM': {{{ cDefine('ENOMEDIUM') }}},
-    'EILSEQ': {{{ cDefine('EILSEQ') }}},
-    'EOVERFLOW': {{{ cDefine('EOVERFLOW') }}},
-    'ECANCELED': {{{ cDefine('ECANCELED') }}},
-    'ENOTRECOVERABLE': {{{ cDefine('ENOTRECOVERABLE') }}},
-    'EOWNERDEAD': {{{ cDefine('EOWNERDEAD') }}},
-    'ESTRPIPE': {{{ cDefine('ESTRPIPE') }}},
+    'EPERM': {{{ cDefs.EPERM }}},
+    'ENOENT': {{{ cDefs.ENOENT }}},
+    'ESRCH': {{{ cDefs.ESRCH }}},
+    'EINTR': {{{ cDefs.EINTR }}},
+    'EIO': {{{ cDefs.EIO }}},
+    'ENXIO': {{{ cDefs.ENXIO }}},
+    'E2BIG': {{{ cDefs.E2BIG }}},
+    'ENOEXEC': {{{ cDefs.ENOEXEC }}},
+    'EBADF': {{{ cDefs.EBADF }}},
+    'ECHILD': {{{ cDefs.ECHILD }}},
+    'EAGAIN': {{{ cDefs.EAGAIN }}},
+    'EWOULDBLOCK': {{{ cDefs.EWOULDBLOCK }}},
+    'ENOMEM': {{{ cDefs.ENOMEM }}},
+    'EACCES': {{{ cDefs.EACCES }}},
+    'EFAULT': {{{ cDefs.EFAULT }}},
+    'ENOTBLK': {{{ cDefs.ENOTBLK }}},
+    'EBUSY': {{{ cDefs.EBUSY }}},
+    'EEXIST': {{{ cDefs.EEXIST }}},
+    'EXDEV': {{{ cDefs.EXDEV }}},
+    'ENODEV': {{{ cDefs.ENODEV }}},
+    'ENOTDIR': {{{ cDefs.ENOTDIR }}},
+    'EISDIR': {{{ cDefs.EISDIR }}},
+    'EINVAL': {{{ cDefs.EINVAL }}},
+    'ENFILE': {{{ cDefs.ENFILE }}},
+    'EMFILE': {{{ cDefs.EMFILE }}},
+    'ENOTTY': {{{ cDefs.ENOTTY }}},
+    'ETXTBSY': {{{ cDefs.ETXTBSY }}},
+    'EFBIG': {{{ cDefs.EFBIG }}},
+    'ENOSPC': {{{ cDefs.ENOSPC }}},
+    'ESPIPE': {{{ cDefs.ESPIPE }}},
+    'EROFS': {{{ cDefs.EROFS }}},
+    'EMLINK': {{{ cDefs.EMLINK }}},
+    'EPIPE': {{{ cDefs.EPIPE }}},
+    'EDOM': {{{ cDefs.EDOM }}},
+    'ERANGE': {{{ cDefs.ERANGE }}},
+    'ENOMSG': {{{ cDefs.ENOMSG }}},
+    'EIDRM': {{{ cDefs.EIDRM }}},
+    'ECHRNG': {{{ cDefs.ECHRNG }}},
+    'EL2NSYNC': {{{ cDefs.EL2NSYNC }}},
+    'EL3HLT': {{{ cDefs.EL3HLT }}},
+    'EL3RST': {{{ cDefs.EL3RST }}},
+    'ELNRNG': {{{ cDefs.ELNRNG }}},
+    'EUNATCH': {{{ cDefs.EUNATCH }}},
+    'ENOCSI': {{{ cDefs.ENOCSI }}},
+    'EL2HLT': {{{ cDefs.EL2HLT }}},
+    'EDEADLK': {{{ cDefs.EDEADLK }}},
+    'ENOLCK': {{{ cDefs.ENOLCK }}},
+    'EBADE': {{{ cDefs.EBADE }}},
+    'EBADR': {{{ cDefs.EBADR }}},
+    'EXFULL': {{{ cDefs.EXFULL }}},
+    'ENOANO': {{{ cDefs.ENOANO }}},
+    'EBADRQC': {{{ cDefs.EBADRQC }}},
+    'EBADSLT': {{{ cDefs.EBADSLT }}},
+    'EDEADLOCK': {{{ cDefs.EDEADLOCK }}},
+    'EBFONT': {{{ cDefs.EBFONT }}},
+    'ENOSTR': {{{ cDefs.ENOSTR }}},
+    'ENODATA': {{{ cDefs.ENODATA }}},
+    'ETIME': {{{ cDefs.ETIME }}},
+    'ENOSR': {{{ cDefs.ENOSR }}},
+    'ENONET': {{{ cDefs.ENONET }}},
+    'ENOPKG': {{{ cDefs.ENOPKG }}},
+    'EREMOTE': {{{ cDefs.EREMOTE }}},
+    'ENOLINK': {{{ cDefs.ENOLINK }}},
+    'EADV': {{{ cDefs.EADV }}},
+    'ESRMNT': {{{ cDefs.ESRMNT }}},
+    'ECOMM': {{{ cDefs.ECOMM }}},
+    'EPROTO': {{{ cDefs.EPROTO }}},
+    'EMULTIHOP': {{{ cDefs.EMULTIHOP }}},
+    'EDOTDOT': {{{ cDefs.EDOTDOT }}},
+    'EBADMSG': {{{ cDefs.EBADMSG }}},
+    'ENOTUNIQ': {{{ cDefs.ENOTUNIQ }}},
+    'EBADFD': {{{ cDefs.EBADFD }}},
+    'EREMCHG': {{{ cDefs.EREMCHG }}},
+    'ELIBACC': {{{ cDefs.ELIBACC }}},
+    'ELIBBAD': {{{ cDefs.ELIBBAD }}},
+    'ELIBSCN': {{{ cDefs.ELIBSCN }}},
+    'ELIBMAX': {{{ cDefs.ELIBMAX }}},
+    'ELIBEXEC': {{{ cDefs.ELIBEXEC }}},
+    'ENOSYS': {{{ cDefs.ENOSYS }}},
+    'ENOTEMPTY': {{{ cDefs.ENOTEMPTY }}},
+    'ENAMETOOLONG': {{{ cDefs.ENAMETOOLONG }}},
+    'ELOOP': {{{ cDefs.ELOOP }}},
+    'EOPNOTSUPP': {{{ cDefs.EOPNOTSUPP }}},
+    'EPFNOSUPPORT': {{{ cDefs.EPFNOSUPPORT }}},
+    'ECONNRESET': {{{ cDefs.ECONNRESET }}},
+    'ENOBUFS': {{{ cDefs.ENOBUFS }}},
+    'EAFNOSUPPORT': {{{ cDefs.EAFNOSUPPORT }}},
+    'EPROTOTYPE': {{{ cDefs.EPROTOTYPE }}},
+    'ENOTSOCK': {{{ cDefs.ENOTSOCK }}},
+    'ENOPROTOOPT': {{{ cDefs.ENOPROTOOPT }}},
+    'ESHUTDOWN': {{{ cDefs.ESHUTDOWN }}},
+    'ECONNREFUSED': {{{ cDefs.ECONNREFUSED }}},
+    'EADDRINUSE': {{{ cDefs.EADDRINUSE }}},
+    'ECONNABORTED': {{{ cDefs.ECONNABORTED }}},
+    'ENETUNREACH': {{{ cDefs.ENETUNREACH }}},
+    'ENETDOWN': {{{ cDefs.ENETDOWN }}},
+    'ETIMEDOUT': {{{ cDefs.ETIMEDOUT }}},
+    'EHOSTDOWN': {{{ cDefs.EHOSTDOWN }}},
+    'EHOSTUNREACH': {{{ cDefs.EHOSTUNREACH }}},
+    'EINPROGRESS': {{{ cDefs.EINPROGRESS }}},
+    'EALREADY': {{{ cDefs.EALREADY }}},
+    'EDESTADDRREQ': {{{ cDefs.EDESTADDRREQ }}},
+    'EMSGSIZE': {{{ cDefs.EMSGSIZE }}},
+    'EPROTONOSUPPORT': {{{ cDefs.EPROTONOSUPPORT }}},
+    'ESOCKTNOSUPPORT': {{{ cDefs.ESOCKTNOSUPPORT }}},
+    'EADDRNOTAVAIL': {{{ cDefs.EADDRNOTAVAIL }}},
+    'ENETRESET': {{{ cDefs.ENETRESET }}},
+    'EISCONN': {{{ cDefs.EISCONN }}},
+    'ENOTCONN': {{{ cDefs.ENOTCONN }}},
+    'ETOOMANYREFS': {{{ cDefs.ETOOMANYREFS }}},
+    'EUSERS': {{{ cDefs.EUSERS }}},
+    'EDQUOT': {{{ cDefs.EDQUOT }}},
+    'ESTALE': {{{ cDefs.ESTALE }}},
+    'ENOTSUP': {{{ cDefs.ENOTSUP }}},
+    'ENOMEDIUM': {{{ cDefs.ENOMEDIUM }}},
+    'EILSEQ': {{{ cDefs.EILSEQ }}},
+    'EOVERFLOW': {{{ cDefs.EOVERFLOW }}},
+    'ECANCELED': {{{ cDefs.ECANCELED }}},
+    'ENOTRECOVERABLE': {{{ cDefs.ENOTRECOVERABLE }}},
+    'EOWNERDEAD': {{{ cDefs.EOWNERDEAD }}},
+    'ESTRPIPE': {{{ cDefs.ESTRPIPE }}},
   };`,
   $ERRNO_CODES: {},
   $ERRNO_MESSAGES: {
     0: 'Success',
-    {{{ cDefine('EPERM') }}}: 'Not super-user',
-    {{{ cDefine('ENOENT') }}}: 'No such file or directory',
-    {{{ cDefine('ESRCH') }}}: 'No such process',
-    {{{ cDefine('EINTR') }}}: 'Interrupted system call',
-    {{{ cDefine('EIO') }}}: 'I/O error',
-    {{{ cDefine('ENXIO') }}}: 'No such device or address',
-    {{{ cDefine('E2BIG') }}}: 'Arg list too long',
-    {{{ cDefine('ENOEXEC') }}}: 'Exec format error',
-    {{{ cDefine('EBADF') }}}: 'Bad file number',
-    {{{ cDefine('ECHILD') }}}: 'No children',
-    {{{ cDefine('EWOULDBLOCK') }}}: 'No more processes',
-    {{{ cDefine('ENOMEM') }}}: 'Not enough core',
-    {{{ cDefine('EACCES') }}}: 'Permission denied',
-    {{{ cDefine('EFAULT') }}}: 'Bad address',
-    {{{ cDefine('ENOTBLK') }}}: 'Block device required',
-    {{{ cDefine('EBUSY') }}}: 'Mount device busy',
-    {{{ cDefine('EEXIST') }}}: 'File exists',
-    {{{ cDefine('EXDEV') }}}: 'Cross-device link',
-    {{{ cDefine('ENODEV') }}}: 'No such device',
-    {{{ cDefine('ENOTDIR') }}}: 'Not a directory',
-    {{{ cDefine('EISDIR') }}}: 'Is a directory',
-    {{{ cDefine('EINVAL') }}}: 'Invalid argument',
-    {{{ cDefine('ENFILE') }}}: 'Too many open files in system',
-    {{{ cDefine('EMFILE') }}}: 'Too many open files',
-    {{{ cDefine('ENOTTY') }}}: 'Not a typewriter',
-    {{{ cDefine('ETXTBSY') }}}: 'Text file busy',
-    {{{ cDefine('EFBIG') }}}: 'File too large',
-    {{{ cDefine('ENOSPC') }}}: 'No space left on device',
-    {{{ cDefine('ESPIPE') }}}: 'Illegal seek',
-    {{{ cDefine('EROFS') }}}: 'Read only file system',
-    {{{ cDefine('EMLINK') }}}: 'Too many links',
-    {{{ cDefine('EPIPE') }}}: 'Broken pipe',
-    {{{ cDefine('EDOM') }}}: 'Math arg out of domain of func',
-    {{{ cDefine('ERANGE') }}}: 'Math result not representable',
-    {{{ cDefine('ENOMSG') }}}: 'No message of desired type',
-    {{{ cDefine('EIDRM') }}}: 'Identifier removed',
-    {{{ cDefine('ECHRNG') }}}: 'Channel number out of range',
-    {{{ cDefine('EL2NSYNC') }}}: 'Level 2 not synchronized',
-    {{{ cDefine('EL3HLT') }}}: 'Level 3 halted',
-    {{{ cDefine('EL3RST') }}}: 'Level 3 reset',
-    {{{ cDefine('ELNRNG') }}}: 'Link number out of range',
-    {{{ cDefine('EUNATCH') }}}: 'Protocol driver not attached',
-    {{{ cDefine('ENOCSI') }}}: 'No CSI structure available',
-    {{{ cDefine('EL2HLT') }}}: 'Level 2 halted',
-    {{{ cDefine('EDEADLK') }}}: 'Deadlock condition',
-    {{{ cDefine('ENOLCK') }}}: 'No record locks available',
-    {{{ cDefine('EBADE') }}}: 'Invalid exchange',
-    {{{ cDefine('EBADR') }}}: 'Invalid request descriptor',
-    {{{ cDefine('EXFULL') }}}: 'Exchange full',
-    {{{ cDefine('ENOANO') }}}: 'No anode',
-    {{{ cDefine('EBADRQC') }}}: 'Invalid request code',
-    {{{ cDefine('EBADSLT') }}}: 'Invalid slot',
-    {{{ cDefine('EDEADLOCK') }}}: 'File locking deadlock error',
-    {{{ cDefine('EBFONT') }}}: 'Bad font file fmt',
-    {{{ cDefine('ENOSTR') }}}: 'Device not a stream',
-    {{{ cDefine('ENODATA') }}}: 'No data (for no delay io)',
-    {{{ cDefine('ETIME') }}}: 'Timer expired',
-    {{{ cDefine('ENOSR') }}}: 'Out of streams resources',
-    {{{ cDefine('ENONET') }}}: 'Machine is not on the network',
-    {{{ cDefine('ENOPKG') }}}: 'Package not installed',
-    {{{ cDefine('EREMOTE') }}}: 'The object is remote',
-    {{{ cDefine('ENOLINK') }}}: 'The link has been severed',
-    {{{ cDefine('EADV') }}}: 'Advertise error',
-    {{{ cDefine('ESRMNT') }}}: 'Srmount error',
-    {{{ cDefine('ECOMM') }}}: 'Communication error on send',
-    {{{ cDefine('EPROTO') }}}: 'Protocol error',
-    {{{ cDefine('EMULTIHOP') }}}: 'Multihop attempted',
-    {{{ cDefine('EDOTDOT') }}}: 'Cross mount point (not really error)',
-    {{{ cDefine('EBADMSG') }}}: 'Trying to read unreadable message',
-    {{{ cDefine('ENOTUNIQ') }}}: 'Given log. name not unique',
-    {{{ cDefine('EBADFD') }}}: 'f.d. invalid for this operation',
-    {{{ cDefine('EREMCHG') }}}: 'Remote address changed',
-    {{{ cDefine('ELIBACC') }}}: 'Can   access a needed shared lib',
-    {{{ cDefine('ELIBBAD') }}}: 'Accessing a corrupted shared lib',
-    {{{ cDefine('ELIBSCN') }}}: '.lib section in a.out corrupted',
-    {{{ cDefine('ELIBMAX') }}}: 'Attempting to link in too many libs',
-    {{{ cDefine('ELIBEXEC') }}}: 'Attempting to exec a shared library',
-    {{{ cDefine('ENOSYS') }}}: 'Function not implemented',
-    {{{ cDefine('ENOTEMPTY') }}}: 'Directory not empty',
-    {{{ cDefine('ENAMETOOLONG') }}}: 'File or path name too long',
-    {{{ cDefine('ELOOP') }}}: 'Too many symbolic links',
-    {{{ cDefine('EOPNOTSUPP') }}}: 'Operation not supported on transport endpoint',
-    {{{ cDefine('EPFNOSUPPORT') }}}: 'Protocol family not supported',
-    {{{ cDefine('ECONNRESET') }}}: 'Connection reset by peer',
-    {{{ cDefine('ENOBUFS') }}}: 'No buffer space available',
-    {{{ cDefine('EAFNOSUPPORT') }}}: 'Address family not supported by protocol family',
-    {{{ cDefine('EPROTOTYPE') }}}: 'Protocol wrong type for socket',
-    {{{ cDefine('ENOTSOCK') }}}: 'Socket operation on non-socket',
-    {{{ cDefine('ENOPROTOOPT') }}}: 'Protocol not available',
-    {{{ cDefine('ESHUTDOWN') }}}: 'Can\'t send after socket shutdown',
-    {{{ cDefine('ECONNREFUSED') }}}: 'Connection refused',
-    {{{ cDefine('EADDRINUSE') }}}: 'Address already in use',
-    {{{ cDefine('ECONNABORTED') }}}: 'Connection aborted',
-    {{{ cDefine('ENETUNREACH') }}}: 'Network is unreachable',
-    {{{ cDefine('ENETDOWN') }}}: 'Network interface is not configured',
-    {{{ cDefine('ETIMEDOUT') }}}: 'Connection timed out',
-    {{{ cDefine('EHOSTDOWN') }}}: 'Host is down',
-    {{{ cDefine('EHOSTUNREACH') }}}: 'Host is unreachable',
-    {{{ cDefine('EINPROGRESS') }}}: 'Connection already in progress',
-    {{{ cDefine('EALREADY') }}}: 'Socket already connected',
-    {{{ cDefine('EDESTADDRREQ') }}}: 'Destination address required',
-    {{{ cDefine('EMSGSIZE') }}}: 'Message too long',
-    {{{ cDefine('EPROTONOSUPPORT') }}}: 'Unknown protocol',
-    {{{ cDefine('ESOCKTNOSUPPORT') }}}: 'Socket type not supported',
-    {{{ cDefine('EADDRNOTAVAIL') }}}: 'Address not available',
-    {{{ cDefine('ENETRESET') }}}: 'Connection reset by network',
-    {{{ cDefine('EISCONN') }}}: 'Socket is already connected',
-    {{{ cDefine('ENOTCONN') }}}: 'Socket is not connected',
-    {{{ cDefine('ETOOMANYREFS') }}}: 'Too many references',
-    {{{ cDefine('EUSERS') }}}: 'Too many users',
-    {{{ cDefine('EDQUOT') }}}: 'Quota exceeded',
-    {{{ cDefine('ESTALE') }}}: 'Stale file handle',
-    {{{ cDefine('ENOTSUP') }}}: 'Not supported',
-    {{{ cDefine('ENOMEDIUM') }}}: 'No medium (in tape drive)',
-    {{{ cDefine('EILSEQ') }}}: 'Illegal byte sequence',
-    {{{ cDefine('EOVERFLOW') }}}: 'Value too large for defined data type',
-    {{{ cDefine('ECANCELED') }}}: 'Operation canceled',
-    {{{ cDefine('ENOTRECOVERABLE') }}}: 'State not recoverable',
-    {{{ cDefine('EOWNERDEAD') }}}: 'Previous owner died',
-    {{{ cDefine('ESTRPIPE') }}}: 'Streams pipe error',
+    {{{ cDefs.EPERM }}}: 'Not super-user',
+    {{{ cDefs.ENOENT }}}: 'No such file or directory',
+    {{{ cDefs.ESRCH }}}: 'No such process',
+    {{{ cDefs.EINTR }}}: 'Interrupted system call',
+    {{{ cDefs.EIO }}}: 'I/O error',
+    {{{ cDefs.ENXIO }}}: 'No such device or address',
+    {{{ cDefs.E2BIG }}}: 'Arg list too long',
+    {{{ cDefs.ENOEXEC }}}: 'Exec format error',
+    {{{ cDefs.EBADF }}}: 'Bad file number',
+    {{{ cDefs.ECHILD }}}: 'No children',
+    {{{ cDefs.EWOULDBLOCK }}}: 'No more processes',
+    {{{ cDefs.ENOMEM }}}: 'Not enough core',
+    {{{ cDefs.EACCES }}}: 'Permission denied',
+    {{{ cDefs.EFAULT }}}: 'Bad address',
+    {{{ cDefs.ENOTBLK }}}: 'Block device required',
+    {{{ cDefs.EBUSY }}}: 'Mount device busy',
+    {{{ cDefs.EEXIST }}}: 'File exists',
+    {{{ cDefs.EXDEV }}}: 'Cross-device link',
+    {{{ cDefs.ENODEV }}}: 'No such device',
+    {{{ cDefs.ENOTDIR }}}: 'Not a directory',
+    {{{ cDefs.EISDIR }}}: 'Is a directory',
+    {{{ cDefs.EINVAL }}}: 'Invalid argument',
+    {{{ cDefs.ENFILE }}}: 'Too many open files in system',
+    {{{ cDefs.EMFILE }}}: 'Too many open files',
+    {{{ cDefs.ENOTTY }}}: 'Not a typewriter',
+    {{{ cDefs.ETXTBSY }}}: 'Text file busy',
+    {{{ cDefs.EFBIG }}}: 'File too large',
+    {{{ cDefs.ENOSPC }}}: 'No space left on device',
+    {{{ cDefs.ESPIPE }}}: 'Illegal seek',
+    {{{ cDefs.EROFS }}}: 'Read only file system',
+    {{{ cDefs.EMLINK }}}: 'Too many links',
+    {{{ cDefs.EPIPE }}}: 'Broken pipe',
+    {{{ cDefs.EDOM }}}: 'Math arg out of domain of func',
+    {{{ cDefs.ERANGE }}}: 'Math result not representable',
+    {{{ cDefs.ENOMSG }}}: 'No message of desired type',
+    {{{ cDefs.EIDRM }}}: 'Identifier removed',
+    {{{ cDefs.ECHRNG }}}: 'Channel number out of range',
+    {{{ cDefs.EL2NSYNC }}}: 'Level 2 not synchronized',
+    {{{ cDefs.EL3HLT }}}: 'Level 3 halted',
+    {{{ cDefs.EL3RST }}}: 'Level 3 reset',
+    {{{ cDefs.ELNRNG }}}: 'Link number out of range',
+    {{{ cDefs.EUNATCH }}}: 'Protocol driver not attached',
+    {{{ cDefs.ENOCSI }}}: 'No CSI structure available',
+    {{{ cDefs.EL2HLT }}}: 'Level 2 halted',
+    {{{ cDefs.EDEADLK }}}: 'Deadlock condition',
+    {{{ cDefs.ENOLCK }}}: 'No record locks available',
+    {{{ cDefs.EBADE }}}: 'Invalid exchange',
+    {{{ cDefs.EBADR }}}: 'Invalid request descriptor',
+    {{{ cDefs.EXFULL }}}: 'Exchange full',
+    {{{ cDefs.ENOANO }}}: 'No anode',
+    {{{ cDefs.EBADRQC }}}: 'Invalid request code',
+    {{{ cDefs.EBADSLT }}}: 'Invalid slot',
+    {{{ cDefs.EDEADLOCK }}}: 'File locking deadlock error',
+    {{{ cDefs.EBFONT }}}: 'Bad font file fmt',
+    {{{ cDefs.ENOSTR }}}: 'Device not a stream',
+    {{{ cDefs.ENODATA }}}: 'No data (for no delay io)',
+    {{{ cDefs.ETIME }}}: 'Timer expired',
+    {{{ cDefs.ENOSR }}}: 'Out of streams resources',
+    {{{ cDefs.ENONET }}}: 'Machine is not on the network',
+    {{{ cDefs.ENOPKG }}}: 'Package not installed',
+    {{{ cDefs.EREMOTE }}}: 'The object is remote',
+    {{{ cDefs.ENOLINK }}}: 'The link has been severed',
+    {{{ cDefs.EADV }}}: 'Advertise error',
+    {{{ cDefs.ESRMNT }}}: 'Srmount error',
+    {{{ cDefs.ECOMM }}}: 'Communication error on send',
+    {{{ cDefs.EPROTO }}}: 'Protocol error',
+    {{{ cDefs.EMULTIHOP }}}: 'Multihop attempted',
+    {{{ cDefs.EDOTDOT }}}: 'Cross mount point (not really error)',
+    {{{ cDefs.EBADMSG }}}: 'Trying to read unreadable message',
+    {{{ cDefs.ENOTUNIQ }}}: 'Given log. name not unique',
+    {{{ cDefs.EBADFD }}}: 'f.d. invalid for this operation',
+    {{{ cDefs.EREMCHG }}}: 'Remote address changed',
+    {{{ cDefs.ELIBACC }}}: 'Can   access a needed shared lib',
+    {{{ cDefs.ELIBBAD }}}: 'Accessing a corrupted shared lib',
+    {{{ cDefs.ELIBSCN }}}: '.lib section in a.out corrupted',
+    {{{ cDefs.ELIBMAX }}}: 'Attempting to link in too many libs',
+    {{{ cDefs.ELIBEXEC }}}: 'Attempting to exec a shared library',
+    {{{ cDefs.ENOSYS }}}: 'Function not implemented',
+    {{{ cDefs.ENOTEMPTY }}}: 'Directory not empty',
+    {{{ cDefs.ENAMETOOLONG }}}: 'File or path name too long',
+    {{{ cDefs.ELOOP }}}: 'Too many symbolic links',
+    {{{ cDefs.EOPNOTSUPP }}}: 'Operation not supported on transport endpoint',
+    {{{ cDefs.EPFNOSUPPORT }}}: 'Protocol family not supported',
+    {{{ cDefs.ECONNRESET }}}: 'Connection reset by peer',
+    {{{ cDefs.ENOBUFS }}}: 'No buffer space available',
+    {{{ cDefs.EAFNOSUPPORT }}}: 'Address family not supported by protocol family',
+    {{{ cDefs.EPROTOTYPE }}}: 'Protocol wrong type for socket',
+    {{{ cDefs.ENOTSOCK }}}: 'Socket operation on non-socket',
+    {{{ cDefs.ENOPROTOOPT }}}: 'Protocol not available',
+    {{{ cDefs.ESHUTDOWN }}}: 'Can\'t send after socket shutdown',
+    {{{ cDefs.ECONNREFUSED }}}: 'Connection refused',
+    {{{ cDefs.EADDRINUSE }}}: 'Address already in use',
+    {{{ cDefs.ECONNABORTED }}}: 'Connection aborted',
+    {{{ cDefs.ENETUNREACH }}}: 'Network is unreachable',
+    {{{ cDefs.ENETDOWN }}}: 'Network interface is not configured',
+    {{{ cDefs.ETIMEDOUT }}}: 'Connection timed out',
+    {{{ cDefs.EHOSTDOWN }}}: 'Host is down',
+    {{{ cDefs.EHOSTUNREACH }}}: 'Host is unreachable',
+    {{{ cDefs.EINPROGRESS }}}: 'Connection already in progress',
+    {{{ cDefs.EALREADY }}}: 'Socket already connected',
+    {{{ cDefs.EDESTADDRREQ }}}: 'Destination address required',
+    {{{ cDefs.EMSGSIZE }}}: 'Message too long',
+    {{{ cDefs.EPROTONOSUPPORT }}}: 'Unknown protocol',
+    {{{ cDefs.ESOCKTNOSUPPORT }}}: 'Socket type not supported',
+    {{{ cDefs.EADDRNOTAVAIL }}}: 'Address not available',
+    {{{ cDefs.ENETRESET }}}: 'Connection reset by network',
+    {{{ cDefs.EISCONN }}}: 'Socket is already connected',
+    {{{ cDefs.ENOTCONN }}}: 'Socket is not connected',
+    {{{ cDefs.ETOOMANYREFS }}}: 'Too many references',
+    {{{ cDefs.EUSERS }}}: 'Too many users',
+    {{{ cDefs.EDQUOT }}}: 'Quota exceeded',
+    {{{ cDefs.ESTALE }}}: 'Stale file handle',
+    {{{ cDefs.ENOTSUP }}}: 'Not supported',
+    {{{ cDefs.ENOMEDIUM }}}: 'No medium (in tape drive)',
+    {{{ cDefs.EILSEQ }}}: 'Illegal byte sequence',
+    {{{ cDefs.EOVERFLOW }}}: 'Value too large for defined data type',
+    {{{ cDefs.ECANCELED }}}: 'Operation canceled',
+    {{{ cDefs.ENOTRECOVERABLE }}}: 'State not recoverable',
+    {{{ cDefs.EOWNERDEAD }}}: 'Previous owner died',
+    {{{ cDefs.ESTRPIPE }}}: 'Streams pipe error',
   },
 #if SUPPORT_ERRNO
   $setErrNo__deps: ['__errno_location'],
@@ -1720,16 +1720,16 @@ mergeInto(LibraryManager.library, {
     var addr;
 
     switch (family) {
-      case {{{ cDefine('AF_INET') }}}:
+      case {{{ cDefs.AF_INET }}}:
         if (salen !== {{{ C_STRUCTS.sockaddr_in.__size__ }}}) {
-          return { errno: {{{ cDefine('EINVAL') }}} };
+          return { errno: {{{ cDefs.EINVAL }}} };
         }
         addr = {{{ makeGetValue('sa', C_STRUCTS.sockaddr_in.sin_addr.s_addr, 'i32') }}};
         addr = inetNtop4(addr);
         break;
-      case {{{ cDefine('AF_INET6') }}}:
+      case {{{ cDefs.AF_INET6 }}}:
         if (salen !== {{{ C_STRUCTS.sockaddr_in6.__size__ }}}) {
-          return { errno: {{{ cDefine('EINVAL') }}} };
+          return { errno: {{{ cDefs.EINVAL }}} };
         }
         addr = [
           {{{ makeGetValue('sa', C_STRUCTS.sockaddr_in6.sin6_addr.__in6_union.__s6_addr+0, 'i32') }}},
@@ -1740,7 +1740,7 @@ mergeInto(LibraryManager.library, {
         addr = inetNtop6(addr);
         break;
       default:
-        return { errno: {{{ cDefine('EAFNOSUPPORT') }}} };
+        return { errno: {{{ cDefs.EAFNOSUPPORT }}} };
     }
 
     return { family: family, addr: addr, port: port };
@@ -1749,7 +1749,7 @@ mergeInto(LibraryManager.library, {
   $writeSockaddr__deps: ['$Sockets', '$inetPton4', '$inetPton6', '$zeroMemory'],
   $writeSockaddr: function (sa, family, addr, port, addrlen) {
     switch (family) {
-      case {{{ cDefine('AF_INET') }}}:
+      case {{{ cDefs.AF_INET }}}:
         addr = inetPton4(addr);
         zeroMemory(sa, {{{ C_STRUCTS.sockaddr_in.__size__ }}});
         if (addrlen) {
@@ -1759,7 +1759,7 @@ mergeInto(LibraryManager.library, {
         {{{ makeSetValue('sa', C_STRUCTS.sockaddr_in.sin_addr.s_addr, 'addr', 'i32') }}};
         {{{ makeSetValue('sa', C_STRUCTS.sockaddr_in.sin_port, '_htons(port)', 'i16') }}};
         break;
-      case {{{ cDefine('AF_INET6') }}}:
+      case {{{ cDefs.AF_INET6 }}}:
         addr = inetPton6(addr);
         zeroMemory(sa, {{{ C_STRUCTS.sockaddr_in6.__size__ }}});
         if (addrlen) {
@@ -1773,7 +1773,7 @@ mergeInto(LibraryManager.library, {
         {{{ makeSetValue('sa', C_STRUCTS.sockaddr_in6.sin6_port, '_htons(port)', 'i16') }}};
         break;
       default:
-        return {{{ cDefine('EAFNOSUPPORT') }}};
+        return {{{ cDefs.EAFNOSUPPORT }}};
     }
     return 0;
   },
@@ -1833,8 +1833,8 @@ mergeInto(LibraryManager.library, {
   gethostbyaddr__proxy: 'sync',
   gethostbyaddr__sig: 'ppii',
   gethostbyaddr: function (addr, addrlen, type) {
-    if (type !== {{{ cDefine('AF_INET') }}}) {
-      setErrNo({{{ cDefine('EAFNOSUPPORT') }}});
+    if (type !== {{{ cDefs.AF_INET }}}) {
+      setErrNo({{{ cDefs.EAFNOSUPPORT }}});
       // TODO: set h_errno
       return null;
     }
@@ -1864,7 +1864,7 @@ mergeInto(LibraryManager.library, {
     var aliasesBuf = _malloc(4);
     {{{ makeSetValue('aliasesBuf', '0', '0', POINTER_TYPE) }}};
     {{{ makeSetValue('ret', C_STRUCTS.hostent.h_aliases, 'aliasesBuf', 'i8**') }}};
-    var afinet = {{{ cDefine('AF_INET') }}};
+    var afinet = {{{ cDefs.AF_INET }}};
     {{{ makeSetValue('ret', C_STRUCTS.hostent.h_addrtype, 'afinet', 'i32') }}};
     {{{ makeSetValue('ret', C_STRUCTS.hostent.h_length, '4', 'i32') }}};
     var addrListBuf = _malloc(12);
@@ -1899,7 +1899,7 @@ mergeInto(LibraryManager.library, {
     var addr = 0;
     var port = 0;
     var flags = 0;
-    var family = {{{ cDefine('AF_UNSPEC') }}};
+    var family = {{{ cDefs.AF_UNSPEC }}};
     var type = 0;
     var proto = 0;
     var ai, last;
@@ -1908,10 +1908,10 @@ mergeInto(LibraryManager.library, {
       var sa, salen, ai;
       var errno;
 
-      salen = family === {{{ cDefine('AF_INET6') }}} ?
+      salen = family === {{{ cDefs.AF_INET6 }}} ?
         {{{ C_STRUCTS.sockaddr_in6.__size__ }}} :
         {{{ C_STRUCTS.sockaddr_in.__size__ }}};
-      addr = family === {{{ cDefine('AF_INET6') }}} ?
+      addr = family === {{{ cDefs.AF_INET6 }}} ?
         inetNtop6(addr) :
         inetNtop4(addr);
       sa = _malloc(salen);
@@ -1924,7 +1924,7 @@ mergeInto(LibraryManager.library, {
       {{{ makeSetValue('ai', C_STRUCTS.addrinfo.ai_protocol, 'proto', 'i32') }}};
       {{{ makeSetValue('ai', C_STRUCTS.addrinfo.ai_canonname, 'canon', 'i32') }}};
       {{{ makeSetValue('ai', C_STRUCTS.addrinfo.ai_addr, 'sa', '*') }}};
-      if (family === {{{ cDefine('AF_INET6') }}}) {
+      if (family === {{{ cDefs.AF_INET6 }}}) {
         {{{ makeSetValue('ai', C_STRUCTS.addrinfo.ai_addrlen, C_STRUCTS.sockaddr_in6.__size__, 'i32') }}};
       } else {
         {{{ makeSetValue('ai', C_STRUCTS.addrinfo.ai_addrlen, C_STRUCTS.sockaddr_in.__size__, 'i32') }}};
@@ -1941,40 +1941,40 @@ mergeInto(LibraryManager.library, {
       proto = {{{ makeGetValue('hint', C_STRUCTS.addrinfo.ai_protocol, 'i32') }}};
     }
     if (type && !proto) {
-      proto = type === {{{ cDefine('SOCK_DGRAM') }}} ? {{{ cDefine('IPPROTO_UDP') }}} : {{{ cDefine('IPPROTO_TCP') }}};
+      proto = type === {{{ cDefs.SOCK_DGRAM }}} ? {{{ cDefs.IPPROTO_UDP }}} : {{{ cDefs.IPPROTO_TCP }}};
     }
     if (!type && proto) {
-      type = proto === {{{ cDefine('IPPROTO_UDP') }}} ? {{{ cDefine('SOCK_DGRAM') }}} : {{{ cDefine('SOCK_STREAM') }}};
+      type = proto === {{{ cDefs.IPPROTO_UDP }}} ? {{{ cDefs.SOCK_DGRAM }}} : {{{ cDefs.SOCK_STREAM }}};
     }
 
     // If type or proto are set to zero in hints we should really be returning multiple addrinfo values, but for
     // now default to a TCP STREAM socket so we can at least return a sensible addrinfo given NULL hints.
     if (proto === 0) {
-      proto = {{{ cDefine('IPPROTO_TCP') }}};
+      proto = {{{ cDefs.IPPROTO_TCP }}};
     }
     if (type === 0) {
-      type = {{{ cDefine('SOCK_STREAM') }}};
+      type = {{{ cDefs.SOCK_STREAM }}};
     }
 
     if (!node && !service) {
-      return {{{ cDefine('EAI_NONAME') }}};
+      return {{{ cDefs.EAI_NONAME }}};
     }
-    if (flags & ~({{{ cDefine('AI_PASSIVE') }}}|{{{ cDefine('AI_CANONNAME') }}}|{{{ cDefine('AI_NUMERICHOST') }}}|
-        {{{ cDefine('AI_NUMERICSERV') }}}|{{{ cDefine('AI_V4MAPPED') }}}|{{{ cDefine('AI_ALL') }}}|{{{ cDefine('AI_ADDRCONFIG') }}})) {
-      return {{{ cDefine('EAI_BADFLAGS') }}};
+    if (flags & ~({{{ cDefs.AI_PASSIVE }}}|{{{ cDefs.AI_CANONNAME }}}|{{{ cDefs.AI_NUMERICHOST }}}|
+        {{{ cDefs.AI_NUMERICSERV }}}|{{{ cDefs.AI_V4MAPPED }}}|{{{ cDefs.AI_ALL }}}|{{{ cDefs.AI_ADDRCONFIG }}})) {
+      return {{{ cDefs.EAI_BADFLAGS }}};
     }
-    if (hint !== 0 && ({{{ makeGetValue('hint', C_STRUCTS.addrinfo.ai_flags, 'i32') }}} & {{{ cDefine('AI_CANONNAME') }}}) && !node) {
-      return {{{ cDefine('EAI_BADFLAGS') }}};
+    if (hint !== 0 && ({{{ makeGetValue('hint', C_STRUCTS.addrinfo.ai_flags, 'i32') }}} & {{{ cDefs.AI_CANONNAME }}}) && !node) {
+      return {{{ cDefs.EAI_BADFLAGS }}};
     }
-    if (flags & {{{ cDefine('AI_ADDRCONFIG') }}}) {
+    if (flags & {{{ cDefs.AI_ADDRCONFIG }}}) {
       // TODO
-      return {{{ cDefine('EAI_NONAME') }}};
+      return {{{ cDefs.EAI_NONAME }}};
     }
-    if (type !== 0 && type !== {{{ cDefine('SOCK_STREAM') }}} && type !== {{{ cDefine('SOCK_DGRAM') }}}) {
-      return {{{ cDefine('EAI_SOCKTYPE') }}};
+    if (type !== 0 && type !== {{{ cDefs.SOCK_STREAM }}} && type !== {{{ cDefs.SOCK_DGRAM }}}) {
+      return {{{ cDefs.EAI_SOCKTYPE }}};
     }
-    if (family !== {{{ cDefine('AF_UNSPEC') }}} && family !== {{{ cDefine('AF_INET') }}} && family !== {{{ cDefine('AF_INET6') }}}) {
-      return {{{ cDefine('EAI_FAMILY') }}};
+    if (family !== {{{ cDefs.AF_UNSPEC }}} && family !== {{{ cDefs.AF_INET }}} && family !== {{{ cDefs.AF_INET6 }}}) {
+      return {{{ cDefs.EAI_FAMILY }}};
     }
 
     if (service) {
@@ -1982,22 +1982,22 @@ mergeInto(LibraryManager.library, {
       port = parseInt(service, 10);
 
       if (isNaN(port)) {
-        if (flags & {{{ cDefine('AI_NUMERICSERV') }}}) {
-          return {{{ cDefine('EAI_NONAME') }}};
+        if (flags & {{{ cDefs.AI_NUMERICSERV }}}) {
+          return {{{ cDefs.EAI_NONAME }}};
         }
         // TODO support resolving well-known service names from:
         // http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt
-        return {{{ cDefine('EAI_SERVICE') }}};
+        return {{{ cDefs.EAI_SERVICE }}};
       }
     }
 
     if (!node) {
-      if (family === {{{ cDefine('AF_UNSPEC') }}}) {
-        family = {{{ cDefine('AF_INET') }}};
+      if (family === {{{ cDefs.AF_UNSPEC }}}) {
+        family = {{{ cDefs.AF_INET }}};
       }
-      if ((flags & {{{ cDefine('AI_PASSIVE') }}}) === 0) {
-        if (family === {{{ cDefine('AF_INET') }}}) {
-          addr = _htonl({{{ cDefine('INADDR_LOOPBACK') }}});
+      if ((flags & {{{ cDefs.AI_PASSIVE }}}) === 0) {
+        if (family === {{{ cDefs.AF_INET }}}) {
+          addr = _htonl({{{ cDefs.INADDR_LOOPBACK }}});
         } else {
           addr = [0, 0, 0, 1];
         }
@@ -2014,23 +2014,23 @@ mergeInto(LibraryManager.library, {
     addr = inetPton4(node);
     if (addr !== null) {
       // incoming node is a valid ipv4 address
-      if (family === {{{ cDefine('AF_UNSPEC') }}} || family === {{{ cDefine('AF_INET') }}}) {
-        family = {{{ cDefine('AF_INET') }}};
+      if (family === {{{ cDefs.AF_UNSPEC }}} || family === {{{ cDefs.AF_INET }}}) {
+        family = {{{ cDefs.AF_INET }}};
       }
-      else if (family === {{{ cDefine('AF_INET6') }}} && (flags & {{{ cDefine('AI_V4MAPPED') }}})) {
+      else if (family === {{{ cDefs.AF_INET6 }}} && (flags & {{{ cDefs.AI_V4MAPPED }}})) {
         addr = [0, 0, _htonl(0xffff), addr];
-        family = {{{ cDefine('AF_INET6') }}};
+        family = {{{ cDefs.AF_INET6 }}};
       } else {
-        return {{{ cDefine('EAI_NONAME') }}};
+        return {{{ cDefs.EAI_NONAME }}};
       }
     } else {
       addr = inetPton6(node);
       if (addr !== null) {
         // incoming node is a valid ipv6 address
-        if (family === {{{ cDefine('AF_UNSPEC') }}} || family === {{{ cDefine('AF_INET6') }}}) {
-          family = {{{ cDefine('AF_INET6') }}};
+        if (family === {{{ cDefs.AF_UNSPEC }}} || family === {{{ cDefs.AF_INET6 }}}) {
+          family = {{{ cDefs.AF_INET6 }}};
         } else {
-          return {{{ cDefine('EAI_NONAME') }}};
+          return {{{ cDefs.EAI_NONAME }}};
         }
       }
     }
@@ -2039,8 +2039,8 @@ mergeInto(LibraryManager.library, {
       {{{ makeSetValue('out', '0', 'ai', '*') }}};
       return 0;
     }
-    if (flags & {{{ cDefine('AI_NUMERICHOST') }}}) {
-      return {{{ cDefine('EAI_NONAME') }}};
+    if (flags & {{{ cDefs.AI_NUMERICHOST }}}) {
+      return {{{ cDefs.EAI_NONAME }}};
     }
 
     //
@@ -2049,9 +2049,9 @@ mergeInto(LibraryManager.library, {
     // resolve the hostname to a temporary fake address
     node = DNS.lookup_name(node);
     addr = inetPton4(node);
-    if (family === {{{ cDefine('AF_UNSPEC') }}}) {
-      family = {{{ cDefine('AF_INET') }}};
-    } else if (family === {{{ cDefine('AF_INET6') }}}) {
+    if (family === {{{ cDefs.AF_UNSPEC }}}) {
+      family = {{{ cDefs.AF_INET }}};
+    } else if (family === {{{ cDefs.AF_INET6 }}}) {
       addr = [0, 0, _htonl(0xffff), addr];
     }
     ai = allocaddrinfo(family, type, proto, null, addr, port);
@@ -2064,7 +2064,7 @@ mergeInto(LibraryManager.library, {
   getnameinfo: function (sa, salen, node, nodelen, serv, servlen, flags) {
     var info = readSockaddr(sa, salen);
     if (info.errno) {
-      return {{{ cDefine('EAI_FAMILY') }}};
+      return {{{ cDefs.EAI_FAMILY }}};
     }
     var port = info.port;
     var addr = info.addr;
@@ -2073,9 +2073,9 @@ mergeInto(LibraryManager.library, {
 
     if (node && nodelen) {
       var lookup;
-      if ((flags & {{{ cDefine('NI_NUMERICHOST') }}}) || !(lookup = DNS.lookup_addr(addr))) {
-        if (flags & {{{ cDefine('NI_NAMEREQD') }}}) {
-          return {{{ cDefine('EAI_NONAME') }}};
+      if ((flags & {{{ cDefs.NI_NUMERICHOST }}}) || !(lookup = DNS.lookup_addr(addr))) {
+        if (flags & {{{ cDefs.NI_NAMEREQD }}}) {
+          return {{{ cDefs.EAI_NONAME }}};
         }
       } else {
         addr = lookup;
@@ -2098,7 +2098,7 @@ mergeInto(LibraryManager.library, {
 
     if (overflowed) {
       // Note: even when we overflow, getnameinfo() is specced to write out the truncated results.
-      return {{{ cDefine('EAI_OVERFLOW') }}};
+      return {{{ cDefs.EAI_OVERFLOW }}};
     }
 
     return 0;
@@ -2488,20 +2488,20 @@ mergeInto(LibraryManager.library, {
     var iNextLine = callstack.indexOf('\n', Math.max(iThisFunc, iThisFunc2))+1;
     callstack = callstack.slice(iNextLine);
 
-    if (flags & {{{ cDefine('EM_LOG_DEMANGLE') }}}) {
+    if (flags & {{{ cDefs.EM_LOG_DEMANGLE }}}) {
       warnOnce('EM_LOG_DEMANGLE is deprecated; ignoring');
     }
 
     // If user requested to see the original source stack, but no source map
     // information is available, just fall back to showing the JS stack.
-    if (flags & {{{ cDefine('EM_LOG_C_STACK') }}} && typeof emscripten_source_map == 'undefined') {
+    if (flags & {{{ cDefs.EM_LOG_C_STACK }}} && typeof emscripten_source_map == 'undefined') {
       warnOnce('Source map information is not available, emscripten_log with EM_LOG_C_STACK will be ignored. Build with "--pre-js $EMSCRIPTEN/src/emscripten-source-map.min.js" linker flag to add source map loading to code.');
-      flags ^= {{{ cDefine('EM_LOG_C_STACK') }}};
-      flags |= {{{ cDefine('EM_LOG_JS_STACK') }}};
+      flags ^= {{{ cDefs.EM_LOG_C_STACK }}};
+      flags |= {{{ cDefs.EM_LOG_JS_STACK }}};
     }
 
     var stack_args = null;
-    if (flags & {{{ cDefine('EM_LOG_FUNC_PARAMS') }}}) {
+    if (flags & {{{ cDefs.EM_LOG_FUNC_PARAMS }}}) {
       // To get the actual parameters to the functions, traverse the stack via
       // the unfortunately deprecated 'arguments.callee' method, if it works:
       stack_args = traverseStack(arguments);
@@ -2556,18 +2556,18 @@ mergeInto(LibraryManager.library, {
 
       var haveSourceMap = false;
 
-      if (flags & {{{ cDefine('EM_LOG_C_STACK') }}}) {
+      if (flags & {{{ cDefs.EM_LOG_C_STACK }}}) {
         var orig = emscripten_source_map.originalPositionFor({line: lineno, column: column});
         haveSourceMap = (orig && orig.source);
         if (haveSourceMap) {
-          if (flags & {{{ cDefine('EM_LOG_NO_PATHS') }}}) {
+          if (flags & {{{ cDefs.EM_LOG_NO_PATHS }}}) {
             orig.source = orig.source.substring(orig.source.replace(/\\/g, "/").lastIndexOf('/')+1);
           }
           callstack += '    at ' + symbolName + ' (' + orig.source + ':' + orig.line + ':' + orig.column + ')\n';
         }
       }
-      if ((flags & {{{ cDefine('EM_LOG_JS_STACK') }}}) || !haveSourceMap) {
-        if (flags & {{{ cDefine('EM_LOG_NO_PATHS') }}}) {
+      if ((flags & {{{ cDefs.EM_LOG_JS_STACK }}}) || !haveSourceMap) {
+        if (flags & {{{ cDefs.EM_LOG_NO_PATHS }}}) {
           file = file.substring(file.replace(/\\/g, "/").lastIndexOf('/')+1);
         }
         callstack += (haveSourceMap ? ('     = ' + symbolName) : ('    at '+ symbolName)) + ' (' + file + ':' + lineno + ':' + column + ')\n';
@@ -2575,7 +2575,7 @@ mergeInto(LibraryManager.library, {
 
       // If we are still keeping track with the callstack by traversing via
       // 'arguments.callee', print the function parameters as well.
-      if (flags & {{{ cDefine('EM_LOG_FUNC_PARAMS') }}} && stack_args[0]) {
+      if (flags & {{{ cDefs.EM_LOG_FUNC_PARAMS }}} && stack_args[0]) {
         if (stack_args[1] == symbolName && stack_args[2].length > 0) {
           callstack = callstack.replace(/\s+$/, '');
           callstack += ' with values: ' + stack_args[1] + stack_args[2] + '\n';
@@ -2608,24 +2608,24 @@ mergeInto(LibraryManager.library, {
 
   $emscriptenLog__deps: ['$getCallstack'],
   $emscriptenLog: function(flags, str) {
-    if (flags & {{{ cDefine('EM_LOG_C_STACK') | cDefine('EM_LOG_JS_STACK') }}}) {
+    if (flags & {{{ cDefs.EM_LOG_C_STACK | cDefs.EM_LOG_JS_STACK }}}) {
       str = str.replace(/\s+$/, ''); // Ensure the message and the callstack are joined cleanly with exactly one newline.
       str += (str.length > 0 ? '\n' : '') + getCallstack(flags);
     }
 
-    if (flags & {{{ cDefine('EM_LOG_CONSOLE') }}}) {
-      if (flags & {{{ cDefine('EM_LOG_ERROR') }}}) {
+    if (flags & {{{ cDefs.EM_LOG_CONSOLE }}}) {
+      if (flags & {{{ cDefs.EM_LOG_ERROR }}}) {
         console.error(str);
-      } else if (flags & {{{ cDefine('EM_LOG_WARN') }}}) {
+      } else if (flags & {{{ cDefs.EM_LOG_WARN }}}) {
         console.warn(str);
-      } else if (flags & {{{ cDefine('EM_LOG_INFO') }}}) {
+      } else if (flags & {{{ cDefs.EM_LOG_INFO }}}) {
         console.info(str);
-      } else if (flags & {{{ cDefine('EM_LOG_DEBUG') }}}) {
+      } else if (flags & {{{ cDefs.EM_LOG_DEBUG }}}) {
         console.debug(str);
       } else {
         console.log(str);
       }
-    } else if (flags & {{{ cDefine('EM_LOG_ERROR') | cDefine('EM_LOG_WARN') }}}) {
+    } else if (flags & {{{ cDefs.EM_LOG_ERROR | cDefs.EM_LOG_WARN }}}) {
       err(str);
     } else {
       out(str);

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -292,7 +292,7 @@ var LibraryDylink = {
     loadedLibsByName: {},
     // handle  -> dso; Used by dlsym
     loadedLibsByHandle: {},
-    init: () => newDSO('__main__', {{{ cDefine('RTLD_DEFAULT') }}}, wasmImports),
+    init: () => newDSO('__main__', {{{ cDefs.RTLD_DEFAULT }}}, wasmImports),
   },
 
   $dlSetError__internal: true,
@@ -1060,13 +1060,13 @@ var LibraryDylink = {
       }
     }
 
-    var global = Boolean(flags & {{{ cDefine('RTLD_GLOBAL') }}});
+    var global = Boolean(flags & {{{ cDefs.RTLD_GLOBAL }}});
     var localScope = global ? null : {};
 
     // We don't care about RTLD_NOW and RTLD_LAZY.
     var combinedFlags = {
       global,
-      nodelete:  Boolean(flags & {{{ cDefine('RTLD_NODELETE') }}}),
+      nodelete:  Boolean(flags & {{{ cDefs.RTLD_NODELETE }}}),
       loadAsync: jsflags.loadAsync,
       fs:        jsflags.fs,
     }

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -54,8 +54,8 @@ var FSNode = /** @constructor */ function(parent, name, mode, rdev) {
   this.stream_ops = {};
   this.rdev = rdev;
 };
-var readMode = 292/*{{{ cDefine("S_IRUGO") }}}*/ | 73/*{{{ cDefine("S_IXUGO") }}}*/;
-var writeMode = 146/*{{{ cDefine("S_IWUGO") }}}*/;
+var readMode = 292/*{{{ cDefs.S_IRUGO }}}*/ | 73/*{{{ cDefs.S_IXUGO }}}*/;
+var writeMode = 146/*{{{ cDefs.S_IWUGO }}}*/;
 Object.defineProperties(FSNode.prototype, {
  read: {
   get: /** @this{FSNode} */function() {
@@ -130,7 +130,7 @@ FS.staticInit();` +
       opts = Object.assign(defaults, opts)
 
       if (opts.recurse_count > 8) {  // max recursive lookup of 8
-        throw new FS.ErrnoError({{{ cDefine('ELOOP') }}});
+        throw new FS.ErrnoError({{{ cDefs.ELOOP }}});
       }
 
       // split the absolute path
@@ -169,7 +169,7 @@ FS.staticInit();` +
             current = lookup.node;
 
             if (count++ > 40) {  // limit max consecutive symlinks to 40 (SYMLOOP_MAX).
-              throw new FS.ErrnoError({{{ cDefine('ELOOP') }}});
+              throw new FS.ErrnoError({{{ cDefs.ELOOP }}});
             }
           }
         }
@@ -266,25 +266,25 @@ FS.staticInit();` +
       return !!node.mounted;
     },
     isFile: (mode) => {
-      return (mode & {{{ cDefine('S_IFMT') }}}) === {{{ cDefine('S_IFREG') }}};
+      return (mode & {{{ cDefs.S_IFMT }}}) === {{{ cDefs.S_IFREG }}};
     },
     isDir: (mode) => {
-      return (mode & {{{ cDefine('S_IFMT') }}}) === {{{ cDefine('S_IFDIR') }}};
+      return (mode & {{{ cDefs.S_IFMT }}}) === {{{ cDefs.S_IFDIR }}};
     },
     isLink: (mode) => {
-      return (mode & {{{ cDefine('S_IFMT') }}}) === {{{ cDefine('S_IFLNK') }}};
+      return (mode & {{{ cDefs.S_IFMT }}}) === {{{ cDefs.S_IFLNK }}};
     },
     isChrdev: (mode) => {
-      return (mode & {{{ cDefine('S_IFMT') }}}) === {{{ cDefine('S_IFCHR') }}};
+      return (mode & {{{ cDefs.S_IFMT }}}) === {{{ cDefs.S_IFCHR }}};
     },
     isBlkdev: (mode) => {
-      return (mode & {{{ cDefine('S_IFMT') }}}) === {{{ cDefine('S_IFBLK') }}};
+      return (mode & {{{ cDefs.S_IFMT }}}) === {{{ cDefs.S_IFBLK }}};
     },
     isFIFO: (mode) => {
-      return (mode & {{{ cDefine('S_IFMT') }}}) === {{{ cDefine('S_IFIFO') }}};
+      return (mode & {{{ cDefs.S_IFMT }}}) === {{{ cDefs.S_IFIFO }}};
     },
     isSocket: (mode) => {
-      return (mode & {{{ cDefine('S_IFSOCK') }}}) === {{{ cDefine('S_IFSOCK') }}};
+      return (mode & {{{ cDefs.S_IFSOCK }}}) === {{{ cDefs.S_IFSOCK }}};
     },
 
     //
@@ -294,12 +294,12 @@ FS.staticInit();` +
       // Extra quotes used here on the keys to this object otherwise jsifier will
       // erase them in the process of reading and then writing the JS library
       // code.
-      '"r"': {{{ cDefine('O_RDONLY') }}},
-      '"r+"': {{{ cDefine('O_RDWR') }}},
-      '"w"': {{{ cDefine('O_TRUNC') }}} | {{{ cDefine('O_CREAT') }}} | {{{ cDefine('O_WRONLY') }}},
-      '"w+"': {{{ cDefine('O_TRUNC') }}} | {{{ cDefine('O_CREAT') }}} | {{{ cDefine('O_RDWR') }}},
-      '"a"': {{{ cDefine('O_APPEND') }}} | {{{ cDefine('O_CREAT') }}} | {{{ cDefine('O_WRONLY') }}},
-      '"a+"': {{{ cDefine('O_APPEND') }}} | {{{ cDefine('O_CREAT') }}} | {{{ cDefine('O_RDWR') }}},
+      '"r"': {{{ cDefs.O_RDONLY }}},
+      '"r+"': {{{ cDefs.O_RDWR }}},
+      '"w"': {{{ cDefs.O_TRUNC }}} | {{{ cDefs.O_CREAT }}} | {{{ cDefs.O_WRONLY }}},
+      '"w+"': {{{ cDefs.O_TRUNC }}} | {{{ cDefs.O_CREAT }}} | {{{ cDefs.O_RDWR }}},
+      '"a"': {{{ cDefs.O_APPEND }}} | {{{ cDefs.O_CREAT }}} | {{{ cDefs.O_WRONLY }}},
+      '"a+"': {{{ cDefs.O_APPEND }}} | {{{ cDefs.O_CREAT }}} | {{{ cDefs.O_RDWR }}},
     },
     // convert the 'r', 'r+', etc. to it's corresponding set of O_* flags
     modeStringToFlags: (str) => {
@@ -312,7 +312,7 @@ FS.staticInit();` +
     // convert O_* bitmask to a string for nodePermissions
     flagsToPermissionString: (flag) => {
       var perms = ['r', 'w', 'rw'][flag & 3];
-      if ((flag & {{{ cDefine('O_TRUNC') }}})) {
+      if ((flag & {{{ cDefs.O_TRUNC }}})) {
         perms += 'w';
       }
       return perms;
@@ -322,25 +322,25 @@ FS.staticInit();` +
         return 0;
       }
       // return 0 if any user, group or owner bits are set.
-      if (perms.includes('r') && !(node.mode & {{{ cDefine('S_IRUGO') }}})) {
-        return {{{ cDefine('EACCES') }}};
-      } else if (perms.includes('w') && !(node.mode & {{{ cDefine('S_IWUGO') }}})) {
-        return {{{ cDefine('EACCES') }}};
-      } else if (perms.includes('x') && !(node.mode & {{{ cDefine('S_IXUGO') }}})) {
-        return {{{ cDefine('EACCES') }}};
+      if (perms.includes('r') && !(node.mode & {{{ cDefs.S_IRUGO }}})) {
+        return {{{ cDefs.EACCES }}};
+      } else if (perms.includes('w') && !(node.mode & {{{ cDefs.S_IWUGO }}})) {
+        return {{{ cDefs.EACCES }}};
+      } else if (perms.includes('x') && !(node.mode & {{{ cDefs.S_IXUGO }}})) {
+        return {{{ cDefs.EACCES }}};
       }
       return 0;
     },
     mayLookup: (dir) => {
       var errCode = FS.nodePermissions(dir, 'x');
       if (errCode) return errCode;
-      if (!dir.node_ops.lookup) return {{{ cDefine('EACCES') }}};
+      if (!dir.node_ops.lookup) return {{{ cDefs.EACCES }}};
       return 0;
     },
     mayCreate: (dir, name) => {
       try {
         var node = FS.lookupNode(dir, name);
-        return {{{ cDefine('EEXIST') }}};
+        return {{{ cDefs.EEXIST }}};
       } catch (e) {
       }
       return FS.nodePermissions(dir, 'wx');
@@ -358,28 +358,28 @@ FS.staticInit();` +
       }
       if (isdir) {
         if (!FS.isDir(node.mode)) {
-          return {{{ cDefine('ENOTDIR') }}};
+          return {{{ cDefs.ENOTDIR }}};
         }
         if (FS.isRoot(node) || FS.getPath(node) === FS.cwd()) {
-          return {{{ cDefine('EBUSY') }}};
+          return {{{ cDefs.EBUSY }}};
         }
       } else {
         if (FS.isDir(node.mode)) {
-          return {{{ cDefine('EISDIR') }}};
+          return {{{ cDefs.EISDIR }}};
         }
       }
       return 0;
     },
     mayOpen: (node, flags) => {
       if (!node) {
-        return {{{ cDefine('ENOENT') }}};
+        return {{{ cDefs.ENOENT }}};
       }
       if (FS.isLink(node.mode)) {
-        return {{{ cDefine('ELOOP') }}};
+        return {{{ cDefs.ELOOP }}};
       } else if (FS.isDir(node.mode)) {
         if (FS.flagsToPermissionString(flags) !== 'r' || // opening for write
-            (flags & {{{ cDefine('O_TRUNC') }}})) { // TODO: check for O_SEARCH? (== search for dir only)
-          return {{{ cDefine('EISDIR') }}};
+            (flags & {{{ cDefs.O_TRUNC }}})) { // TODO: check for O_SEARCH? (== search for dir only)
+          return {{{ cDefs.EISDIR }}};
         }
       }
       return FS.nodePermissions(node, FS.flagsToPermissionString(flags));
@@ -395,7 +395,7 @@ FS.staticInit();` +
           return fd;
         }
       }
-      throw new FS.ErrnoError({{{ cDefine('EMFILE') }}});
+      throw new FS.ErrnoError({{{ cDefs.EMFILE }}});
     },
     getStream: (fd) => FS.streams[fd],
     // TODO parameterize this function such that a stream
@@ -416,15 +416,15 @@ FS.staticInit();` +
           },
           isRead: {
             /** @this {FS.FSStream} */
-            get: function() { return (this.flags & {{{ cDefine('O_ACCMODE') }}}) !== {{{ cDefine('O_WRONLY') }}}; }
+            get: function() { return (this.flags & {{{ cDefs.O_ACCMODE }}}) !== {{{ cDefs.O_WRONLY }}}; }
           },
           isWrite: {
             /** @this {FS.FSStream} */
-            get: function() { return (this.flags & {{{ cDefine('O_ACCMODE') }}}) !== {{{ cDefine('O_RDONLY') }}}; }
+            get: function() { return (this.flags & {{{ cDefs.O_ACCMODE }}}) !== {{{ cDefs.O_RDONLY }}}; }
           },
           isAppend: {
             /** @this {FS.FSStream} */
-            get: function() { return (this.flags & {{{ cDefine('O_APPEND') }}}); }
+            get: function() { return (this.flags & {{{ cDefs.O_APPEND }}}); }
           },
           flags: {
             /** @this {FS.FSStream} */
@@ -471,7 +471,7 @@ FS.staticInit();` +
         }
       },
       llseek: () => {
-        throw new FS.ErrnoError({{{ cDefine('ESPIPE') }}});
+        throw new FS.ErrnoError({{{ cDefs.ESPIPE }}});
       }
     },
     major: (dev) => ((dev) >> 8),
@@ -556,7 +556,7 @@ FS.staticInit();` +
       var node;
 
       if (root && FS.root) {
-        throw new FS.ErrnoError({{{ cDefine('EBUSY') }}});
+        throw new FS.ErrnoError({{{ cDefs.EBUSY }}});
       } else if (!root && !pseudo) {
         var lookup = FS.lookupPath(mountpoint, { follow_mount: false });
 
@@ -564,11 +564,11 @@ FS.staticInit();` +
         node = lookup.node;
 
         if (FS.isMountpoint(node)) {
-          throw new FS.ErrnoError({{{ cDefine('EBUSY') }}});
+          throw new FS.ErrnoError({{{ cDefs.EBUSY }}});
         }
 
         if (!FS.isDir(node.mode)) {
-          throw new FS.ErrnoError({{{ cDefine('ENOTDIR') }}});
+          throw new FS.ErrnoError({{{ cDefs.ENOTDIR }}});
         }
       }
 
@@ -602,7 +602,7 @@ FS.staticInit();` +
       var lookup = FS.lookupPath(mountpoint, { follow_mount: false });
 
       if (!FS.isMountpoint(lookup.node)) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
 
       // destroy the nodes for this mount, and all its child mounts
@@ -643,28 +643,28 @@ FS.staticInit();` +
       var parent = lookup.node;
       var name = PATH.basename(path);
       if (!name || name === '.' || name === '..') {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       var errCode = FS.mayCreate(parent, name);
       if (errCode) {
         throw new FS.ErrnoError(errCode);
       }
       if (!parent.node_ops.mknod) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       }
       return parent.node_ops.mknod(parent, name, mode, dev);
     },
     // helpers to create specific types of nodes
     create: (path, mode) => {
       mode = mode !== undefined ? mode : 438 /* 0666 */;
-      mode &= {{{ cDefine('S_IALLUGO') }}};
-      mode |= {{{ cDefine('S_IFREG') }}};
+      mode &= {{{ cDefs.S_IALLUGO }}};
+      mode |= {{{ cDefs.S_IFREG }}};
       return FS.mknod(path, mode, 0);
     },
     mkdir: (path, mode) => {
       mode = mode !== undefined ? mode : 511 /* 0777 */;
-      mode &= {{{ cDefine('S_IRWXUGO') }}} | {{{ cDefine('S_ISVTX') }}};
-      mode |= {{{ cDefine('S_IFDIR') }}};
+      mode &= {{{ cDefs.S_IRWXUGO }}} | {{{ cDefs.S_ISVTX }}};
+      mode |= {{{ cDefs.S_IFDIR }}};
 #if FS_DEBUG
       if (FS.trackingDelegate['onMakeDirectory']) {
         FS.trackingDelegate['onMakeDirectory'](path, mode);
@@ -682,7 +682,7 @@ FS.staticInit();` +
         try {
           FS.mkdir(d, mode);
         } catch(e) {
-          if (e.errno != {{{ cDefine('EEXIST') }}}) throw e;
+          if (e.errno != {{{ cDefs.EEXIST }}}) throw e;
         }
       }
     },
@@ -691,17 +691,17 @@ FS.staticInit();` +
         dev = mode;
         mode = 438 /* 0666 */;
       }
-      mode |= {{{ cDefine('S_IFCHR') }}};
+      mode |= {{{ cDefs.S_IFCHR }}};
       return FS.mknod(path, mode, dev);
     },
     symlink: (oldpath, newpath) => {
       if (!PATH_FS.resolve(oldpath)) {
-        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOENT }}});
       }
       var lookup = FS.lookupPath(newpath, { parent: true });
       var parent = lookup.node;
       if (!parent) {
-        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOENT }}});
       }
       var newname = PATH.basename(newpath);
       var errCode = FS.mayCreate(parent, newname);
@@ -709,7 +709,7 @@ FS.staticInit();` +
         throw new FS.ErrnoError(errCode);
       }
       if (!parent.node_ops.symlink) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       }
 #if FS_DEBUG
       if (FS.trackingDelegate['onMakeSymlink']) {
@@ -732,22 +732,22 @@ FS.staticInit();` +
       lookup = FS.lookupPath(new_path, { parent: true });
       new_dir = lookup.node;
 
-      if (!old_dir || !new_dir) throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
+      if (!old_dir || !new_dir) throw new FS.ErrnoError({{{ cDefs.ENOENT }}});
       // need to be part of the same mount
       if (old_dir.mount !== new_dir.mount) {
-        throw new FS.ErrnoError({{{ cDefine('EXDEV') }}});
+        throw new FS.ErrnoError({{{ cDefs.EXDEV }}});
       }
       // source must exist
       var old_node = FS.lookupNode(old_dir, old_name);
       // old path should not be an ancestor of the new path
       var relative = PATH_FS.relative(old_path, new_dirname);
       if (relative.charAt(0) !== '.') {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       // new path should not be an ancestor of the old path
       relative = PATH_FS.relative(new_path, old_dirname);
       if (relative.charAt(0) !== '.') {
-        throw new FS.ErrnoError({{{ cDefine('ENOTEMPTY') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOTEMPTY }}});
       }
       // see if the new path already exists
       var new_node;
@@ -775,10 +775,10 @@ FS.staticInit();` +
         throw new FS.ErrnoError(errCode);
       }
       if (!old_dir.node_ops.rename) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       }
       if (FS.isMountpoint(old_node) || (new_node && FS.isMountpoint(new_node))) {
-        throw new FS.ErrnoError({{{ cDefine('EBUSY') }}});
+        throw new FS.ErrnoError({{{ cDefs.EBUSY }}});
       }
       // if we are going to change the parent, check write permissions
       if (new_dir !== old_dir) {
@@ -820,10 +820,10 @@ FS.staticInit();` +
         throw new FS.ErrnoError(errCode);
       }
       if (!parent.node_ops.rmdir) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       }
       if (FS.isMountpoint(node)) {
-        throw new FS.ErrnoError({{{ cDefine('EBUSY') }}});
+        throw new FS.ErrnoError({{{ cDefs.EBUSY }}});
       }
 #if FS_DEBUG
       if (FS.trackingDelegate['willDeletePath']) {
@@ -842,7 +842,7 @@ FS.staticInit();` +
       var lookup = FS.lookupPath(path, { follow: true });
       var node = lookup.node;
       if (!node.node_ops.readdir) {
-        throw new FS.ErrnoError({{{ cDefine('ENOTDIR') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOTDIR }}});
       }
       return node.node_ops.readdir(node);
     },
@@ -850,7 +850,7 @@ FS.staticInit();` +
       var lookup = FS.lookupPath(path, { parent: true });
       var parent = lookup.node;
       if (!parent) {
-        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOENT }}});
       }
       var name = PATH.basename(path);
       var node = FS.lookupNode(parent, name);
@@ -862,10 +862,10 @@ FS.staticInit();` +
         throw new FS.ErrnoError(errCode);
       }
       if (!parent.node_ops.unlink) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       }
       if (FS.isMountpoint(node)) {
-        throw new FS.ErrnoError({{{ cDefine('EBUSY') }}});
+        throw new FS.ErrnoError({{{ cDefs.EBUSY }}});
       }
 #if FS_DEBUG
       if (FS.trackingDelegate['willDeletePath']) {
@@ -884,10 +884,10 @@ FS.staticInit();` +
       var lookup = FS.lookupPath(path);
       var link = lookup.node;
       if (!link) {
-        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOENT }}});
       }
       if (!link.node_ops.readlink) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       return PATH_FS.resolve(FS.getPath(link.parent), link.node_ops.readlink(link));
     },
@@ -895,10 +895,10 @@ FS.staticInit();` +
       var lookup = FS.lookupPath(path, { follow: !dontFollow });
       var node = lookup.node;
       if (!node) {
-        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOENT }}});
       }
       if (!node.node_ops.getattr) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       }
       return node.node_ops.getattr(node);
     },
@@ -914,10 +914,10 @@ FS.staticInit();` +
         node = path;
       }
       if (!node.node_ops.setattr) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       }
       node.node_ops.setattr(node, {
-        mode: (mode & {{{ cDefine('S_IALLUGO') }}}) | (node.mode & ~{{{ cDefine('S_IALLUGO') }}}),
+        mode: (mode & {{{ cDefs.S_IALLUGO }}}) | (node.mode & ~{{{ cDefs.S_IALLUGO }}}),
         timestamp: Date.now()
       });
     },
@@ -927,7 +927,7 @@ FS.staticInit();` +
     fchmod: (fd, mode) => {
       var stream = FS.getStream(fd);
       if (!stream) {
-        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+        throw new FS.ErrnoError({{{ cDefs.EBADF }}});
       }
       FS.chmod(stream.node, mode);
     },
@@ -940,7 +940,7 @@ FS.staticInit();` +
         node = path;
       }
       if (!node.node_ops.setattr) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       }
       node.node_ops.setattr(node, {
         timestamp: Date.now()
@@ -953,13 +953,13 @@ FS.staticInit();` +
     fchown: (fd, uid, gid) => {
       var stream = FS.getStream(fd);
       if (!stream) {
-        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+        throw new FS.ErrnoError({{{ cDefs.EBADF }}});
       }
       FS.chown(stream.node, uid, gid);
     },
     truncate: (path, len) => {
       if (len < 0) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       var node;
       if (typeof path == 'string') {
@@ -969,13 +969,13 @@ FS.staticInit();` +
         node = path;
       }
       if (!node.node_ops.setattr) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       }
       if (FS.isDir(node.mode)) {
-        throw new FS.ErrnoError({{{ cDefine('EISDIR') }}});
+        throw new FS.ErrnoError({{{ cDefs.EISDIR }}});
       }
       if (!FS.isFile(node.mode)) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       var errCode = FS.nodePermissions(node, 'w');
       if (errCode) {
@@ -989,10 +989,10 @@ FS.staticInit();` +
     ftruncate: (fd, len) => {
       var stream = FS.getStream(fd);
       if (!stream) {
-        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+        throw new FS.ErrnoError({{{ cDefs.EBADF }}});
       }
-      if ((stream.flags & {{{ cDefine('O_ACCMODE') }}}) === {{{ cDefine('O_RDONLY')}}}) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+      if ((stream.flags & {{{ cDefs.O_ACCMODE }}}) === {{{ cDefs.O_RDONLY}}}) {
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       FS.truncate(stream.node, len);
     },
@@ -1005,12 +1005,12 @@ FS.staticInit();` +
     },
     open: (path, flags, mode) => {
       if (path === "") {
-        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOENT }}});
       }
       flags = typeof flags == 'string' ? FS.modeStringToFlags(flags) : flags;
       mode = typeof mode == 'undefined' ? 438 /* 0666 */ : mode;
-      if ((flags & {{{ cDefine('O_CREAT') }}})) {
-        mode = (mode & {{{ cDefine('S_IALLUGO') }}}) | {{{ cDefine('S_IFREG') }}};
+      if ((flags & {{{ cDefs.O_CREAT }}})) {
+        mode = (mode & {{{ cDefs.S_IALLUGO }}}) | {{{ cDefs.S_IFREG }}};
       } else {
         mode = 0;
       }
@@ -1021,7 +1021,7 @@ FS.staticInit();` +
         path = PATH.normalize(path);
         try {
           var lookup = FS.lookupPath(path, {
-            follow: !(flags & {{{ cDefine('O_NOFOLLOW') }}})
+            follow: !(flags & {{{ cDefs.O_NOFOLLOW }}})
           });
           node = lookup.node;
         } catch (e) {
@@ -1030,11 +1030,11 @@ FS.staticInit();` +
       }
       // perhaps we need to create the node
       var created = false;
-      if ((flags & {{{ cDefine('O_CREAT') }}})) {
+      if ((flags & {{{ cDefs.O_CREAT }}})) {
         if (node) {
           // if O_CREAT and O_EXCL are set, error out if the node already exists
-          if ((flags & {{{ cDefine('O_EXCL') }}})) {
-            throw new FS.ErrnoError({{{ cDefine('EEXIST') }}});
+          if ((flags & {{{ cDefs.O_EXCL }}})) {
+            throw new FS.ErrnoError({{{ cDefs.EEXIST }}});
           }
         } else {
           // node doesn't exist, try to create it
@@ -1043,15 +1043,15 @@ FS.staticInit();` +
         }
       }
       if (!node) {
-        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOENT }}});
       }
       // can't truncate a device
       if (FS.isChrdev(node.mode)) {
-        flags &= ~{{{ cDefine('O_TRUNC') }}};
+        flags &= ~{{{ cDefs.O_TRUNC }}};
       }
       // if asked only for a directory, then this must be one
-      if ((flags & {{{ cDefine('O_DIRECTORY') }}}) && !FS.isDir(node.mode)) {
-        throw new FS.ErrnoError({{{ cDefine('ENOTDIR') }}});
+      if ((flags & {{{ cDefs.O_DIRECTORY }}}) && !FS.isDir(node.mode)) {
+        throw new FS.ErrnoError({{{ cDefs.ENOTDIR }}});
       }
       // check permissions, if this is not a file we just created now (it is ok to
       // create and write to a file with read-only permissions; it is read-only
@@ -1063,14 +1063,14 @@ FS.staticInit();` +
         }
       }
       // do truncation if necessary
-      if ((flags & {{{ cDefine('O_TRUNC')}}}) && !created) {
+      if ((flags & {{{ cDefs.O_TRUNC}}}) && !created) {
         FS.truncate(node, 0);
       }
 #if FS_DEBUG
       var trackingFlags = flags
 #endif
       // we've already handled these, don't pass down to the underlying vfs
-      flags &= ~({{{ cDefine('O_EXCL') }}} | {{{ cDefine('O_TRUNC') }}} | {{{ cDefine('O_NOFOLLOW') }}});
+      flags &= ~({{{ cDefs.O_EXCL }}} | {{{ cDefs.O_TRUNC }}} | {{{ cDefs.O_NOFOLLOW }}});
 
       // register the stream with the filesystem
       var stream = FS.createStream({
@@ -1088,7 +1088,7 @@ FS.staticInit();` +
       if (stream.stream_ops.open) {
         stream.stream_ops.open(stream);
       }
-      if (Module['logReadFiles'] && !(flags & {{{ cDefine('O_WRONLY')}}})) {
+      if (Module['logReadFiles'] && !(flags & {{{ cDefs.O_WRONLY}}})) {
         if (!FS.readFiles) FS.readFiles = {};
         if (!(path in FS.readFiles)) {
           FS.readFiles[path] = 1;
@@ -1106,7 +1106,7 @@ FS.staticInit();` +
     },
     close: (stream) => {
       if (FS.isClosed(stream)) {
-        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+        throw new FS.ErrnoError({{{ cDefs.EBADF }}});
       }
       if (stream.getdents) stream.getdents = null; // free readdir state
       try {
@@ -1130,13 +1130,13 @@ FS.staticInit();` +
     },
     llseek: (stream, offset, whence) => {
       if (FS.isClosed(stream)) {
-        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+        throw new FS.ErrnoError({{{ cDefs.EBADF }}});
       }
       if (!stream.seekable || !stream.stream_ops.llseek) {
-        throw new FS.ErrnoError({{{ cDefine('ESPIPE') }}});
+        throw new FS.ErrnoError({{{ cDefs.ESPIPE }}});
       }
-      if (whence != {{{ cDefine('SEEK_SET') }}} && whence != {{{ cDefine('SEEK_CUR') }}} && whence != {{{ cDefine('SEEK_END') }}}) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+      if (whence != {{{ cDefs.SEEK_SET }}} && whence != {{{ cDefs.SEEK_CUR }}} && whence != {{{ cDefs.SEEK_END }}}) {
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       stream.position = stream.stream_ops.llseek(stream, offset, whence);
       stream.ungotten = [];
@@ -1152,25 +1152,25 @@ FS.staticInit();` +
       offset >>>= 0;
 #endif
       if (length < 0 || position < 0) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       if (FS.isClosed(stream)) {
-        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+        throw new FS.ErrnoError({{{ cDefs.EBADF }}});
       }
-      if ((stream.flags & {{{ cDefine('O_ACCMODE') }}}) === {{{ cDefine('O_WRONLY')}}}) {
-        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+      if ((stream.flags & {{{ cDefs.O_ACCMODE }}}) === {{{ cDefs.O_WRONLY}}}) {
+        throw new FS.ErrnoError({{{ cDefs.EBADF }}});
       }
       if (FS.isDir(stream.node.mode)) {
-        throw new FS.ErrnoError({{{ cDefine('EISDIR') }}});
+        throw new FS.ErrnoError({{{ cDefs.EISDIR }}});
       }
       if (!stream.stream_ops.read) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       var seeking = typeof position != 'undefined';
       if (!seeking) {
         position = stream.position;
       } else if (!stream.seekable) {
-        throw new FS.ErrnoError({{{ cDefine('ESPIPE') }}});
+        throw new FS.ErrnoError({{{ cDefs.ESPIPE }}});
       }
       var bytesRead = stream.stream_ops.read(stream, buffer, offset, length, position);
       if (!seeking) stream.position += bytesRead;
@@ -1186,29 +1186,29 @@ FS.staticInit();` +
       offset >>>= 0;
 #endif
       if (length < 0 || position < 0) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       if (FS.isClosed(stream)) {
-        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+        throw new FS.ErrnoError({{{ cDefs.EBADF }}});
       }
-      if ((stream.flags & {{{ cDefine('O_ACCMODE') }}}) === {{{ cDefine('O_RDONLY')}}}) {
-        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+      if ((stream.flags & {{{ cDefs.O_ACCMODE }}}) === {{{ cDefs.O_RDONLY}}}) {
+        throw new FS.ErrnoError({{{ cDefs.EBADF }}});
       }
       if (FS.isDir(stream.node.mode)) {
-        throw new FS.ErrnoError({{{ cDefine('EISDIR') }}});
+        throw new FS.ErrnoError({{{ cDefs.EISDIR }}});
       }
       if (!stream.stream_ops.write) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
-      if (stream.seekable && stream.flags & {{{ cDefine('O_APPEND') }}}) {
+      if (stream.seekable && stream.flags & {{{ cDefs.O_APPEND }}}) {
         // seek to the end before writing in append mode
-        FS.llseek(stream, 0, {{{ cDefine('SEEK_END') }}});
+        FS.llseek(stream, 0, {{{ cDefs.SEEK_END }}});
       }
       var seeking = typeof position != 'undefined';
       if (!seeking) {
         position = stream.position;
       } else if (!stream.seekable) {
-        throw new FS.ErrnoError({{{ cDefine('ESPIPE') }}});
+        throw new FS.ErrnoError({{{ cDefs.ESPIPE }}});
       }
       var bytesWritten = stream.stream_ops.write(stream, buffer, offset, length, position, canOwn);
       if (!seeking) stream.position += bytesWritten;
@@ -1221,19 +1221,19 @@ FS.staticInit();` +
     },
     allocate: (stream, offset, length) => {
       if (FS.isClosed(stream)) {
-        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+        throw new FS.ErrnoError({{{ cDefs.EBADF }}});
       }
       if (offset < 0 || length <= 0) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
-      if ((stream.flags & {{{ cDefine('O_ACCMODE') }}}) === {{{ cDefine('O_RDONLY')}}}) {
-        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+      if ((stream.flags & {{{ cDefs.O_ACCMODE }}}) === {{{ cDefs.O_RDONLY}}}) {
+        throw new FS.ErrnoError({{{ cDefs.EBADF }}});
       }
       if (!FS.isFile(stream.node.mode) && !FS.isDir(stream.node.mode)) {
-        throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENODEV }}});
       }
       if (!stream.stream_ops.allocate) {
-        throw new FS.ErrnoError({{{ cDefine('EOPNOTSUPP') }}});
+        throw new FS.ErrnoError({{{ cDefs.EOPNOTSUPP }}});
       }
       stream.stream_ops.allocate(stream, offset, length);
     },
@@ -1244,16 +1244,16 @@ FS.staticInit();` +
       // to write to file opened in read-only mode with MAP_PRIVATE flag,
       // as all modifications will be visible only in the memory of
       // the current process.
-      if ((prot & {{{ cDefine('PROT_WRITE') }}}) !== 0
-          && (flags & {{{ cDefine('MAP_PRIVATE')}}}) === 0
-          && (stream.flags & {{{ cDefine('O_ACCMODE') }}}) !== {{{ cDefine('O_RDWR')}}}) {
-        throw new FS.ErrnoError({{{ cDefine('EACCES') }}});
+      if ((prot & {{{ cDefs.PROT_WRITE }}}) !== 0
+          && (flags & {{{ cDefs.MAP_PRIVATE}}}) === 0
+          && (stream.flags & {{{ cDefs.O_ACCMODE }}}) !== {{{ cDefs.O_RDWR}}}) {
+        throw new FS.ErrnoError({{{ cDefs.EACCES }}});
       }
-      if ((stream.flags & {{{ cDefine('O_ACCMODE') }}}) === {{{ cDefine('O_WRONLY')}}}) {
-        throw new FS.ErrnoError({{{ cDefine('EACCES') }}});
+      if ((stream.flags & {{{ cDefs.O_ACCMODE }}}) === {{{ cDefs.O_WRONLY}}}) {
+        throw new FS.ErrnoError({{{ cDefs.EACCES }}});
       }
       if (!stream.stream_ops.mmap) {
-        throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENODEV }}});
       }
       return stream.stream_ops.mmap(stream, length, position, prot, flags);
     },
@@ -1269,12 +1269,12 @@ FS.staticInit();` +
     munmap: (stream) => 0,
     ioctl: (stream, cmd, arg) => {
       if (!stream.stream_ops.ioctl) {
-        throw new FS.ErrnoError({{{ cDefine('ENOTTY') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOTTY }}});
       }
       return stream.stream_ops.ioctl(stream, cmd, arg);
     },
     readFile: (path, opts = {}) => {
-      opts.flags = opts.flags || {{{ cDefine('O_RDONLY') }}};
+      opts.flags = opts.flags || {{{ cDefs.O_RDONLY }}};
       opts.encoding = opts.encoding || 'binary';
       if (opts.encoding !== 'utf8' && opts.encoding !== 'binary') {
         throw new Error('Invalid encoding type "' + opts.encoding + '"');
@@ -1294,7 +1294,7 @@ FS.staticInit();` +
       return ret;
     },
     writeFile: (path, data, opts = {}) => {
-      opts.flags = opts.flags || {{{ cDefine('O_TRUNC') | cDefine('O_CREAT') | cDefine('O_WRONLY') }}};
+      opts.flags = opts.flags || {{{ cDefs.O_TRUNC | cDefs.O_CREAT | cDefs.O_WRONLY }}};
       var stream = FS.open(path, opts.flags, opts.mode);
       if (typeof data == 'string') {
         var buf = new Uint8Array(lengthBytesUTF8(data)+1);
@@ -1315,10 +1315,10 @@ FS.staticInit();` +
     chdir: (path) => {
       var lookup = FS.lookupPath(path, { follow: true });
       if (lookup.node === null) {
-        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOENT }}});
       }
       if (!FS.isDir(lookup.node.mode)) {
-        throw new FS.ErrnoError({{{ cDefine('ENOTDIR') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOTDIR }}});
       }
       var errCode = FS.nodePermissions(lookup.node, 'x');
       if (errCode) {
@@ -1364,12 +1364,12 @@ FS.staticInit();` +
       FS.mkdir('/proc/self/fd');
       FS.mount({
         mount: () => {
-          var node = FS.createNode(proc_self, 'fd', {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */, {{{ cDefine('S_IXUGO') }}});
+          var node = FS.createNode(proc_self, 'fd', {{{ cDefs.S_IFDIR }}} | 511 /* 0777 */, {{{ cDefs.S_IXUGO }}});
           node.node_ops = {
             lookup: (parent, name) => {
               var fd = +name;
               var stream = FS.getStream(fd);
-              if (!stream) throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+              if (!stream) throw new FS.ErrnoError({{{ cDefs.EBADF }}});
               var ret = {
                 parent: null,
                 mount: { mountpoint: 'fake' },
@@ -1409,9 +1409,9 @@ FS.staticInit();` +
       }
 
       // open default streams for the stdin, stdout and stderr devices
-      var stdin = FS.open('/dev/stdin', {{{ cDefine('O_RDONLY') }}});
-      var stdout = FS.open('/dev/stdout', {{{ cDefine('O_WRONLY') }}});
-      var stderr = FS.open('/dev/stderr', {{{ cDefine('O_WRONLY') }}});
+      var stdin = FS.open('/dev/stdin', {{{ cDefs.O_RDONLY }}});
+      var stdout = FS.open('/dev/stdout', {{{ cDefs.O_WRONLY }}});
+      var stderr = FS.open('/dev/stderr', {{{ cDefs.O_WRONLY }}});
 #if ASSERTIONS
       assert(stdin.fd === 0, 'invalid handle for stdin (' + stdin.fd + ')');
       assert(stdout.fd === 1, 'invalid handle for stdout (' + stdout.fd + ')');
@@ -1460,7 +1460,7 @@ FS.staticInit();` +
       FS.ErrnoError.prototype = new Error();
       FS.ErrnoError.prototype.constructor = FS.ErrnoError;
       // Some errors may happen quite a bit, to avoid overhead we reuse them (and suffer a lack of stack info)
-      [{{{ cDefine('ENOENT') }}}].forEach((code) => {
+      [{{{ cDefs.ENOENT }}}].forEach((code) => {
         FS.genericErrors[code] = new FS.ErrnoError(code);
         FS.genericErrors[code].stack = '<generic error, no stack>';
       });
@@ -1528,8 +1528,8 @@ FS.staticInit();` +
     //
     getMode: (canRead, canWrite) => {
       var mode = 0;
-      if (canRead) mode |= {{{ cDefine('S_IRUGO') }}} | {{{ cDefine('S_IXUGO') }}};
-      if (canWrite) mode |= {{{ cDefine('S_IWUGO') }}};
+      if (canRead) mode |= {{{ cDefs.S_IRUGO }}} | {{{ cDefs.S_IXUGO }}};
+      if (canWrite) mode |= {{{ cDefs.S_IWUGO }}};
       return mode;
     },
     findObject: (path, dontResolveLastLink) => {
@@ -1603,8 +1603,8 @@ FS.staticInit();` +
           data = arr;
         }
         // make sure we can write to the file
-        FS.chmod(node, mode | {{{ cDefine('S_IWUGO') }}});
-        var stream = FS.open(node, {{{ cDefine('O_TRUNC') | cDefine('O_CREAT') | cDefine('O_WRONLY') }}});
+        FS.chmod(node, mode | {{{ cDefs.S_IWUGO }}});
+        var stream = FS.open(node, {{{ cDefs.O_TRUNC | cDefs.O_CREAT | cDefs.O_WRONLY }}});
         FS.write(stream, data, 0, data.length, 0, canOwn);
         FS.close(stream);
         FS.chmod(node, mode);
@@ -1635,10 +1635,10 @@ FS.staticInit();` +
             try {
               result = input();
             } catch (e) {
-              throw new FS.ErrnoError({{{ cDefine('EIO') }}});
+              throw new FS.ErrnoError({{{ cDefs.EIO }}});
             }
             if (result === undefined && bytesRead === 0) {
-              throw new FS.ErrnoError({{{ cDefine('EAGAIN') }}});
+              throw new FS.ErrnoError({{{ cDefs.EAGAIN }}});
             }
             if (result === null || result === undefined) break;
             bytesRead++;
@@ -1654,7 +1654,7 @@ FS.staticInit();` +
             try {
               output(buffer[offset+i]);
             } catch (e) {
-              throw new FS.ErrnoError({{{ cDefine('EIO') }}});
+              throw new FS.ErrnoError({{{ cDefs.EIO }}});
             }
           }
           if (length) {
@@ -1679,7 +1679,7 @@ FS.staticInit();` +
           obj.contents = intArrayFromString(read_(obj.url), true);
           obj.usedBytes = obj.contents.length;
         } catch (e) {
-          throw new FS.ErrnoError({{{ cDefine('EIO') }}});
+          throw new FS.ErrnoError({{{ cDefs.EIO }}});
         }
       } else {
         throw new Error('Cannot load without read() or XMLHttpRequest.');
@@ -1854,7 +1854,7 @@ FS.staticInit();` +
         FS.forceLoadFile(node);
         var ptr = mmapAlloc(length);
         if (!ptr) {
-          throw new FS.ErrnoError({{{ cDefine('ENOMEM') }}});
+          throw new FS.ErrnoError({{{ cDefs.ENOMEM }}});
         }
         writeChunks(stream, HEAP8, ptr, length, position);
         return { ptr: ptr, allocated: true };

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -194,7 +194,7 @@ var LibraryHTML5 = {
         {{{ makeSetValue('varargs', 0, 'eventTypeId', 'i32') }}};
         {{{ makeSetValue('varargs', 4, 'eventData', 'i32') }}};
         {{{ makeSetValue('varargs', 8, 'userData', 'i32') }}};
-        _emscripten_dispatch_to_thread_(targetThread, {{{ cDefine('EM_FUNC_SIG_IIII') }}}, eventHandlerFunc, eventData, varargs);
+        _emscripten_dispatch_to_thread_(targetThread, {{{ cDefs.EM_FUNC_SIG_IIII }}}, eventHandlerFunc, eventData, varargs);
       });
     },
 #endif
@@ -202,8 +202,8 @@ var LibraryHTML5 = {
 #if PTHREADS
     getTargetThreadForEventCallback: function(targetThread) {
       switch (targetThread) {
-        case {{{ cDefine('EM_CALLBACK_THREAD_CONTEXT_MAIN_RUNTIME_THREAD') }}}: return 0; // The event callback for the current event should be called on the main browser thread. (0 == don't proxy)
-        case {{{ cDefine('EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD') }}}: return PThread.currentProxiedOperationCallerThread; // The event callback for the current event should be backproxied to the thread that is registering the event.
+        case {{{ cDefs.EM_CALLBACK_THREAD_CONTEXT_MAIN_RUNTIME_THREAD }}}: return 0; // The event callback for the current event should be called on the main browser thread. (0 == don't proxy)
+        case {{{ cDefs.EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD }}}: return PThread.currentProxiedOperationCallerThread; // The event callback for the current event should be backproxied to the thread that is registering the event.
         default: return targetThread; // The event callback for the current event should be proxied to the given specific thread.
       }
     },
@@ -265,10 +265,10 @@ var LibraryHTML5 = {
       HEAP32[idx + {{{ C_STRUCTS.EmscriptenKeyboardEvent.charCode / 4}}}] = e.charCode;
       HEAP32[idx + {{{ C_STRUCTS.EmscriptenKeyboardEvent.keyCode / 4}}}] = e.keyCode;
       HEAP32[idx + {{{ C_STRUCTS.EmscriptenKeyboardEvent.which / 4}}}] = e.which;
-      stringToUTF8(e.key || '', keyEventData + {{{ C_STRUCTS.EmscriptenKeyboardEvent.key }}}, {{{ cDefine('EM_HTML5_SHORT_STRING_LEN_BYTES') }}});
-      stringToUTF8(e.code || '', keyEventData + {{{ C_STRUCTS.EmscriptenKeyboardEvent.code }}}, {{{ cDefine('EM_HTML5_SHORT_STRING_LEN_BYTES') }}});
-      stringToUTF8(e.char || '', keyEventData + {{{ C_STRUCTS.EmscriptenKeyboardEvent.charValue }}}, {{{ cDefine('EM_HTML5_SHORT_STRING_LEN_BYTES') }}});
-      stringToUTF8(e.locale || '', keyEventData + {{{ C_STRUCTS.EmscriptenKeyboardEvent.locale }}}, {{{ cDefine('EM_HTML5_SHORT_STRING_LEN_BYTES') }}});
+      stringToUTF8(e.key || '', keyEventData + {{{ C_STRUCTS.EmscriptenKeyboardEvent.key }}}, {{{ cDefs.EM_HTML5_SHORT_STRING_LEN_BYTES }}});
+      stringToUTF8(e.code || '', keyEventData + {{{ C_STRUCTS.EmscriptenKeyboardEvent.code }}}, {{{ cDefs.EM_HTML5_SHORT_STRING_LEN_BYTES }}});
+      stringToUTF8(e.char || '', keyEventData + {{{ C_STRUCTS.EmscriptenKeyboardEvent.charValue }}}, {{{ cDefs.EM_HTML5_SHORT_STRING_LEN_BYTES }}});
+      stringToUTF8(e.locale || '', keyEventData + {{{ C_STRUCTS.EmscriptenKeyboardEvent.locale }}}, {{{ cDefs.EM_HTML5_SHORT_STRING_LEN_BYTES }}});
 
 #if PTHREADS
       if (targetThread) JSEvents.queueEventHandlerOnThread_iiii(targetThread, callbackfunc, eventTypeId, keyEventData, userData);
@@ -402,24 +402,24 @@ var LibraryHTML5 = {
   emscripten_set_keypress_callback_on_thread__sig: 'ippipp',
   emscripten_set_keypress_callback_on_thread__deps: ['$registerKeyEventCallback'],
   emscripten_set_keypress_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerKeyEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_KEYPRESS') }}}, "keypress", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerKeyEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_KEYPRESS }}}, "keypress", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_keydown_callback_on_thread__proxy: 'sync',
   emscripten_set_keydown_callback_on_thread__sig: 'ippipp',
   emscripten_set_keydown_callback_on_thread__deps: ['$registerKeyEventCallback'],
   emscripten_set_keydown_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerKeyEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_KEYDOWN') }}}, "keydown", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerKeyEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_KEYDOWN }}}, "keydown", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_keyup_callback_on_thread__proxy: 'sync',
   emscripten_set_keyup_callback_on_thread__sig: 'ippipp',
   emscripten_set_keyup_callback_on_thread__deps: ['$registerKeyEventCallback'],
   emscripten_set_keyup_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerKeyEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_KEYUP') }}}, "keyup", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerKeyEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_KEYUP }}}, "keyup", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   // Outline access to function .getBoundingClientRect() since it is a long string. Closure compiler does not outline access to it by itself, but it can inline access if
@@ -549,84 +549,84 @@ var LibraryHTML5 = {
   emscripten_set_click_callback_on_thread__sig: 'ippipp',
   emscripten_set_click_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_click_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_CLICK') }}}, "click", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_CLICK }}}, "click", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_mousedown_callback_on_thread__proxy: 'sync',
   emscripten_set_mousedown_callback_on_thread__sig: 'ippipp',
   emscripten_set_mousedown_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mousedown_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSEDOWN') }}}, "mousedown", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_MOUSEDOWN }}}, "mousedown", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_mouseup_callback_on_thread__proxy: 'sync',
   emscripten_set_mouseup_callback_on_thread__sig: 'ippipp',
   emscripten_set_mouseup_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mouseup_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSEUP') }}}, "mouseup", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_MOUSEUP }}}, "mouseup", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_dblclick_callback_on_thread__proxy: 'sync',
   emscripten_set_dblclick_callback_on_thread__sig: 'ippipp',
   emscripten_set_dblclick_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_dblclick_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_DBLCLICK') }}}, "dblclick", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_DBLCLICK }}}, "dblclick", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_mousemove_callback_on_thread__proxy: 'sync',
   emscripten_set_mousemove_callback_on_thread__sig: 'ippipp',
   emscripten_set_mousemove_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mousemove_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSEMOVE') }}}, "mousemove", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_MOUSEMOVE }}}, "mousemove", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_mouseenter_callback_on_thread__proxy: 'sync',
   emscripten_set_mouseenter_callback_on_thread__sig: 'ippipp',
   emscripten_set_mouseenter_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mouseenter_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSEENTER') }}}, "mouseenter", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_MOUSEENTER }}}, "mouseenter", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_mouseleave_callback_on_thread__proxy: 'sync',
   emscripten_set_mouseleave_callback_on_thread__sig: 'ippipp',
   emscripten_set_mouseleave_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mouseleave_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSELEAVE') }}}, "mouseleave", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_MOUSELEAVE }}}, "mouseleave", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_mouseover_callback_on_thread__proxy: 'sync',
   emscripten_set_mouseover_callback_on_thread__sig: 'ippipp',
   emscripten_set_mouseover_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mouseover_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSEOVER') }}}, "mouseover", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_MOUSEOVER }}}, "mouseover", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_mouseout_callback_on_thread__proxy: 'sync',
   emscripten_set_mouseout_callback_on_thread__sig: 'ippipp',
   emscripten_set_mouseout_callback_on_thread__deps: ['$registerMouseEventCallback'],
   emscripten_set_mouseout_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_MOUSEOUT') }}}, "mouseout", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerMouseEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_MOUSEOUT }}}, "mouseout", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_get_mouse_status__proxy: 'sync',
   emscripten_get_mouse_status__sig: 'ip',
   emscripten_get_mouse_status__deps: ['$JSEvents'],
   emscripten_get_mouse_status: function(mouseState) {
-    if (!JSEvents.mouseEvent) return {{{ cDefine('EMSCRIPTEN_RESULT_NO_DATA') }}};
+    if (!JSEvents.mouseEvent) return {{{ cDefs.EMSCRIPTEN_RESULT_NO_DATA }}};
     // HTML5 does not really have a polling API for mouse events, so implement one manually by
     // returning the data from the most recently received event. This requires that user has registered
     // at least some no-op function as an event handler to any of the mouse function.
     HEAP8.set(HEAP8.subarray(JSEvents.mouseEvent, JSEvents.mouseEvent + {{{ C_STRUCTS.EmscriptenMouseEvent.__size__ }}}), mouseState);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $registerWheelEventCallback__deps: ['$JSEvents', '$fillMouseEventData', '$findEventTarget'],
@@ -694,15 +694,15 @@ var LibraryHTML5 = {
   emscripten_set_wheel_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     target = findEventTarget(target);
     if (typeof target.onwheel != 'undefined') {
-      registerWheelEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_WHEEL') }}}, "wheel", targetThread);
-      return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+      registerWheelEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_WHEEL }}}, "wheel", targetThread);
+      return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
 #if MIN_IE_VERSION <= 8 || MIN_SAFARI_VERSION < 60100 // Browsers that do not support https://caniuse.com/#feat=mdn-api_wheelevent
     } else if (typeof target.onmousewheel != 'undefined') {
-      registerWheelEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_WHEEL') }}}, "mousewheel", targetThread);
-      return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+      registerWheelEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_WHEEL }}}, "mousewheel", targetThread);
+      return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
 #endif
     } else {
-      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
   },
 
@@ -772,16 +772,16 @@ var LibraryHTML5 = {
   emscripten_set_resize_callback_on_thread__sig: 'ippipp',
   emscripten_set_resize_callback_on_thread__deps: ['$registerUiEventCallback'],
   emscripten_set_resize_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerUiEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_RESIZE') }}}, "resize", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerUiEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_RESIZE }}}, "resize", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_scroll_callback_on_thread__proxy: 'sync',
   emscripten_set_scroll_callback_on_thread__sig: 'ippipp',
   emscripten_set_scroll_callback_on_thread__deps: ['$registerUiEventCallback'],
   emscripten_set_scroll_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerUiEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_SCROLL') }}}, "scroll", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerUiEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_SCROLL }}}, "scroll", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $registerFocusEventCallback__deps: ['$JSEvents', '$findEventTarget'],
@@ -800,8 +800,8 @@ var LibraryHTML5 = {
 #else
       var focusEvent = JSEvents.focusEvent;
 #endif
-      stringToUTF8(nodeName, focusEvent + {{{ C_STRUCTS.EmscriptenFocusEvent.nodeName }}}, {{{ cDefine('EM_HTML5_LONG_STRING_LEN_BYTES') }}});
-      stringToUTF8(id, focusEvent + {{{ C_STRUCTS.EmscriptenFocusEvent.id }}}, {{{ cDefine('EM_HTML5_LONG_STRING_LEN_BYTES') }}});
+      stringToUTF8(nodeName, focusEvent + {{{ C_STRUCTS.EmscriptenFocusEvent.nodeName }}}, {{{ cDefs.EM_HTML5_LONG_STRING_LEN_BYTES }}});
+      stringToUTF8(id, focusEvent + {{{ C_STRUCTS.EmscriptenFocusEvent.id }}}, {{{ cDefs.EM_HTML5_LONG_STRING_LEN_BYTES }}});
 
 #if PTHREADS
       if (targetThread) JSEvents.queueEventHandlerOnThread_iiii(targetThread, callbackfunc, eventTypeId, focusEvent, userData);
@@ -824,32 +824,32 @@ var LibraryHTML5 = {
   emscripten_set_blur_callback_on_thread__sig: 'ippipp',
   emscripten_set_blur_callback_on_thread__deps: ['$registerFocusEventCallback'],
   emscripten_set_blur_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerFocusEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_BLUR') }}}, "blur", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerFocusEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_BLUR }}}, "blur", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_focus_callback_on_thread__proxy: 'sync',
   emscripten_set_focus_callback_on_thread__sig: 'ippipp',
   emscripten_set_focus_callback_on_thread__deps: ['$registerFocusEventCallback'],
   emscripten_set_focus_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerFocusEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_FOCUS') }}}, "focus", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerFocusEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_FOCUS }}}, "focus", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_focusin_callback_on_thread__proxy: 'sync',
   emscripten_set_focusin_callback_on_thread__sig: 'ippipp',
   emscripten_set_focusin_callback_on_thread__deps: ['$registerFocusEventCallback'],
   emscripten_set_focusin_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerFocusEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_FOCUSIN') }}}, "focusin", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerFocusEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_FOCUSIN }}}, "focusin", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_focusout_callback_on_thread__proxy: 'sync',
   emscripten_set_focusout_callback_on_thread__sig: 'ippipp',
   emscripten_set_focusout_callback_on_thread__deps: ['$registerFocusEventCallback'],
   emscripten_set_focusout_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerFocusEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_FOCUSOUT') }}}, "focusout", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerFocusEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_FOCUSOUT }}}, "focusout", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $fillDeviceOrientationEventData__deps: ['$JSEvents'],
@@ -894,31 +894,31 @@ var LibraryHTML5 = {
   emscripten_set_deviceorientation_callback_on_thread__sig: 'ipipp',
   emscripten_set_deviceorientation_callback_on_thread__deps: ['$registerDeviceOrientationEventCallback'],
   emscripten_set_deviceorientation_callback_on_thread: function(userData, useCapture, callbackfunc, targetThread) {
-    registerDeviceOrientationEventCallback({{{ cDefine('EMSCRIPTEN_EVENT_TARGET_WINDOW') }}}, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_DEVICEORIENTATION') }}}, "deviceorientation", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerDeviceOrientationEventCallback({{{ cDefs.EMSCRIPTEN_EVENT_TARGET_WINDOW }}}, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_DEVICEORIENTATION }}}, "deviceorientation", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_get_deviceorientation_status__proxy: 'sync',
   emscripten_get_deviceorientation_status__sig: 'ip',
   emscripten_get_deviceorientation_status__deps: ['$JSEvents', '$registerDeviceOrientationEventCallback'],
   emscripten_get_deviceorientation_status: function(orientationState) {
-    if (!JSEvents.deviceOrientationEvent) return {{{ cDefine('EMSCRIPTEN_RESULT_NO_DATA') }}};
+    if (!JSEvents.deviceOrientationEvent) return {{{ cDefs.EMSCRIPTEN_RESULT_NO_DATA }}};
     // HTML5 does not really have a polling API for device orientation events, so implement one manually by
     // returning the data from the most recently received event. This requires that user has registered
     // at least some no-op function as an event handler.
     HEAP32.set(HEAP32.subarray(JSEvents.deviceOrientationEvent, {{{ C_STRUCTS.EmscriptenDeviceOrientationEvent.__size__ }}}), orientationState);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $fillDeviceMotionEventData__deps: ['$JSEvents'],
   $fillDeviceMotionEventData: function(eventStruct, e, target) {
     var supportedFields = 0;
     var a = e['acceleration'];
-    supportedFields |= a && {{{ cDefine('EMSCRIPTEN_DEVICE_MOTION_EVENT_SUPPORTS_ACCELERATION') }}};
+    supportedFields |= a && {{{ cDefs.EMSCRIPTEN_DEVICE_MOTION_EVENT_SUPPORTS_ACCELERATION }}};
     var ag = e['accelerationIncludingGravity'];
-    supportedFields |= ag && {{{ cDefine('EMSCRIPTEN_DEVICE_MOTION_EVENT_SUPPORTS_ACCELERATION_INCLUDING_GRAVITY') }}};
+    supportedFields |= ag && {{{ cDefs.EMSCRIPTEN_DEVICE_MOTION_EVENT_SUPPORTS_ACCELERATION_INCLUDING_GRAVITY }}};
     var rr = e['rotationRate'];
-    supportedFields |= rr && {{{ cDefine('EMSCRIPTEN_DEVICE_MOTION_EVENT_SUPPORTS_ROTATION_RATE') }}};
+    supportedFields |= rr && {{{ cDefs.EMSCRIPTEN_DEVICE_MOTION_EVENT_SUPPORTS_ROTATION_RATE }}};
     a = a || {};
     ag = ag || {};
     rr = rr || {};
@@ -967,20 +967,20 @@ var LibraryHTML5 = {
   emscripten_set_devicemotion_callback_on_thread__sig: 'ipipp',
   emscripten_set_devicemotion_callback_on_thread__deps: ['$registerDeviceMotionEventCallback'],
   emscripten_set_devicemotion_callback_on_thread: function(userData, useCapture, callbackfunc, targetThread) {
-    registerDeviceMotionEventCallback({{{ cDefine('EMSCRIPTEN_EVENT_TARGET_WINDOW') }}}, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_DEVICEMOTION') }}}, "devicemotion", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerDeviceMotionEventCallback({{{ cDefs.EMSCRIPTEN_EVENT_TARGET_WINDOW }}}, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_DEVICEMOTION }}}, "devicemotion", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_get_devicemotion_status__proxy: 'sync',
   emscripten_get_devicemotion_status__sig: 'ip',
   emscripten_get_devicemotion_status__deps: ['$JSEvents'],
   emscripten_get_devicemotion_status: function(motionState) {
-    if (!JSEvents.deviceMotionEvent) return {{{ cDefine('EMSCRIPTEN_RESULT_NO_DATA') }}};
+    if (!JSEvents.deviceMotionEvent) return {{{ cDefs.EMSCRIPTEN_RESULT_NO_DATA }}};
     // HTML5 does not really have a polling API for device motion events, so implement one manually by
     // returning the data from the most recently received event. This requires that user has registered
     // at least some no-op function as an event handler.
     HEAP32.set(HEAP32.subarray(JSEvents.deviceMotionEvent, {{{ C_STRUCTS.EmscriptenDeviceMotionEvent.__size__ }}}), motionState);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $screenOrientation: function() {
@@ -1044,18 +1044,18 @@ var LibraryHTML5 = {
   emscripten_set_orientationchange_callback_on_thread__sig: 'ipipp',
   emscripten_set_orientationchange_callback_on_thread__deps: ['$registerOrientationChangeEventCallback'],
   emscripten_set_orientationchange_callback_on_thread: function(userData, useCapture, callbackfunc, targetThread) {
-    if (!screen || !screen['addEventListener']) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
-    registerOrientationChangeEventCallback(screen, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_ORIENTATIONCHANGE') }}}, "orientationchange", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    if (!screen || !screen['addEventListener']) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
+    registerOrientationChangeEventCallback(screen, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_ORIENTATIONCHANGE }}}, "orientationchange", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
   
   emscripten_get_orientation_status__proxy: 'sync',
   emscripten_get_orientation_status__sig: 'ip',
   emscripten_get_orientation_status__deps: ['$fillOrientationChangeEventData', '$screenOrientation'],
   emscripten_get_orientation_status: function(orientationChangeEvent) {
-    if (!screenOrientation() && typeof orientation == 'undefined') return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    if (!screenOrientation() && typeof orientation == 'undefined') return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     fillOrientationChangeEventData(orientationChangeEvent);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_lock_orientation__proxy: 'sync',
@@ -1076,12 +1076,12 @@ var LibraryHTML5 = {
     } else if (screen.msLockOrientation) {
       succeeded = screen.msLockOrientation(orientations);
     } else {
-      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
     if (succeeded) {
-      return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
     }
-    return {{{ cDefine('EMSCRIPTEN_RESULT_FAILED') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_FAILED }}};
   },
 
   emscripten_unlock_orientation__proxy: 'sync',
@@ -1096,9 +1096,9 @@ var LibraryHTML5 = {
     } else if (screen.msUnlockOrientation) {
       screen.msUnlockOrientation();
     } else {
-      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $fillFullscreenChangeEventData__deps: ['$JSEvents'],
@@ -1116,8 +1116,8 @@ var LibraryHTML5 = {
     var reportedElement = isFullscreen ? fullscreenElement : JSEvents.previousFullscreenElement;
     var nodeName = JSEvents.getNodeNameForTarget(reportedElement);
     var id = (reportedElement && reportedElement.id) ? reportedElement.id : '';
-    stringToUTF8(nodeName, eventStruct + {{{ C_STRUCTS.EmscriptenFullscreenChangeEvent.nodeName }}}, {{{ cDefine('EM_HTML5_LONG_STRING_LEN_BYTES') }}});
-    stringToUTF8(id, eventStruct + {{{ C_STRUCTS.EmscriptenFullscreenChangeEvent.id }}}, {{{ cDefine('EM_HTML5_LONG_STRING_LEN_BYTES') }}});
+    stringToUTF8(nodeName, eventStruct + {{{ C_STRUCTS.EmscriptenFullscreenChangeEvent.nodeName }}}, {{{ cDefs.EM_HTML5_LONG_STRING_LEN_BYTES }}});
+    stringToUTF8(id, eventStruct + {{{ C_STRUCTS.EmscriptenFullscreenChangeEvent.id }}}, {{{ cDefs.EM_HTML5_LONG_STRING_LEN_BYTES }}});
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenFullscreenChangeEvent.elementWidth, 'reportedElement ? reportedElement.clientWidth : 0', 'i32') }}};
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenFullscreenChangeEvent.elementHeight, 'reportedElement ? reportedElement.clientHeight : 0', 'i32') }}};
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenFullscreenChangeEvent.screenWidth, 'screen.width', 'i32') }}};
@@ -1164,44 +1164,44 @@ var LibraryHTML5 = {
   emscripten_set_fullscreenchange_callback_on_thread__sig: 'ippipp',
   emscripten_set_fullscreenchange_callback_on_thread__deps: ['$JSEvents', '$registerFullscreenChangeEventCallback', '$findEventTarget', '$specialHTMLTargets'],
   emscripten_set_fullscreenchange_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    if (!JSEvents.fullscreenEnabled()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    if (!JSEvents.fullscreenEnabled()) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
 #if DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
     target = findEventTarget(target);
 #else
-    target = target ? findEventTarget(target) : specialHTMLTargets[{{{ cDefine('EMSCRIPTEN_EVENT_TARGET_DOCUMENT') }}}];
+    target = target ? findEventTarget(target) : specialHTMLTargets[{{{ cDefs.EMSCRIPTEN_EVENT_TARGET_DOCUMENT }}}];
 #endif
-    if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
-    registerFullscreenChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_FULLSCREENCHANGE') }}}, "fullscreenchange", targetThread);
+    if (!target) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
+    registerFullscreenChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_FULLSCREENCHANGE }}}, "fullscreenchange", targetThread);
 
 #if MIN_FIREFOX_VERSION <= 63 // https://caniuse.com/#feat=mdn-api_element_fullscreenchange_event
-    registerFullscreenChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_FULLSCREENCHANGE') }}}, "mozfullscreenchange", targetThread);
+    registerFullscreenChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_FULLSCREENCHANGE }}}, "mozfullscreenchange", targetThread);
 #endif
 
 #if MIN_CHROME_VERSION < 71 || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
     // Unprefixed Fullscreen API shipped in Chromium 71 (https://bugs.chromium.org/p/chromium/issues/detail?id=383813)
     // As of Safari 13.0.3 on macOS Catalina 10.15.1 still ships with prefixed webkitfullscreenchange. TODO: revisit this check once Safari ships unprefixed version.
-    registerFullscreenChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_FULLSCREENCHANGE') }}}, "webkitfullscreenchange", targetThread);
+    registerFullscreenChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_FULLSCREENCHANGE }}}, "webkitfullscreenchange", targetThread);
 #endif
 
 #if MIN_IE_VERSION != TARGET_NOT_SUPPORTED // https://caniuse.com/#feat=mdn-api_document_fullscreenchange_event
-    registerFullscreenChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_FULLSCREENCHANGE') }}}, "MSFullscreenChange", targetThread);
+    registerFullscreenChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_FULLSCREENCHANGE }}}, "MSFullscreenChange", targetThread);
 #endif
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_get_fullscreen_status__proxy: 'sync',
   emscripten_get_fullscreen_status__sig: 'ip',
   emscripten_get_fullscreen_status__deps: ['$JSEvents', '$fillFullscreenChangeEventData'],
   emscripten_get_fullscreen_status: function(fullscreenStatus) {
-    if (!JSEvents.fullscreenEnabled()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    if (!JSEvents.fullscreenEnabled()) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     fillFullscreenChangeEventData(fullscreenStatus);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $JSEvents_requestFullscreen__deps: ['$JSEvents', '$JSEvents_resizeCanvasForFullscreen'],
   $JSEvents_requestFullscreen: function(target, strategy) {
     // EMSCRIPTEN_FULLSCREEN_SCALE_DEFAULT + EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_NONE is a mode where no extra logic is performed to the DOM elements.
-    if (strategy.scaleMode != {{{ cDefine('EMSCRIPTEN_FULLSCREEN_SCALE_DEFAULT') }}} || strategy.canvasResolutionScaleMode != {{{ cDefine('EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_NONE') }}}) {
+    if (strategy.scaleMode != {{{ cDefs.EMSCRIPTEN_FULLSCREEN_SCALE_DEFAULT }}} || strategy.canvasResolutionScaleMode != {{{ cDefs.EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_NONE }}}) {
       JSEvents_resizeCanvasForFullscreen(target, strategy);
     }
 
@@ -1222,20 +1222,20 @@ var LibraryHTML5 = {
       target.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
 #endif
     } else {
-      return JSEvents.fullscreenEnabled() ? {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}} : {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      return JSEvents.fullscreenEnabled() ? {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}} : {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
 
     currentFullscreenStrategy = strategy;
 
     if (strategy.canvasResizedCallback) {
 #if PTHREADS
-      if (strategy.canvasResizedCallbackTargetThread) JSEvents.queueEventHandlerOnThread_iiii(strategy.canvasResizedCallbackTargetThread, strategy.canvasResizedCallback, {{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, strategy.canvasResizedCallbackUserData);
+      if (strategy.canvasResizedCallbackTargetThread) JSEvents.queueEventHandlerOnThread_iiii(strategy.canvasResizedCallbackTargetThread, strategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, strategy.canvasResizedCallbackUserData);
       else
 #endif
-      {{{ makeDynCall('iiii', 'strategy.canvasResizedCallback') }}}({{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, strategy.canvasResizedCallbackUserData);
+      {{{ makeDynCall('iiii', 'strategy.canvasResizedCallback') }}}({{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, strategy.canvasResizedCallbackUserData);
     }
 
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $JSEvents_resizeCanvasForFullscreen__deps: ['$registerRestoreOldStyle', '$getCanvasElementSize', '$setLetterbox', '$setCanvasElementSize', '$getBoundingClientRect'],
@@ -1257,11 +1257,11 @@ var LibraryHTML5 = {
     var windowedRttWidth = canvasSize[0];
     var windowedRttHeight = canvasSize[1];
 
-    if (strategy.scaleMode == {{{ cDefine('EMSCRIPTEN_FULLSCREEN_SCALE_CENTER') }}}) {
+    if (strategy.scaleMode == {{{ cDefs.EMSCRIPTEN_FULLSCREEN_SCALE_CENTER }}}) {
       setLetterbox(target, (cssHeight - windowedCssHeight) / 2, (cssWidth - windowedCssWidth) / 2);
       cssWidth = windowedCssWidth;
       cssHeight = windowedCssHeight;
-    } else if (strategy.scaleMode == {{{ cDefine('EMSCRIPTEN_FULLSCREEN_SCALE_ASPECT') }}}) {
+    } else if (strategy.scaleMode == {{{ cDefs.EMSCRIPTEN_FULLSCREEN_SCALE_ASPECT }}}) {
       if (cssWidth*windowedRttHeight < windowedRttWidth*cssHeight) {
         var desiredCssHeight = windowedRttHeight * cssWidth / windowedRttWidth;
         setLetterbox(target, (cssHeight - desiredCssHeight) / 2, 0);
@@ -1283,7 +1283,7 @@ var LibraryHTML5 = {
     target.style.width = cssWidth + 'px';
     target.style.height = cssHeight + 'px';
 
-    if (strategy.filteringMode == {{{ cDefine('EMSCRIPTEN_FULLSCREEN_FILTERING_NEAREST') }}}) {
+    if (strategy.filteringMode == {{{ cDefs.EMSCRIPTEN_FULLSCREEN_FILTERING_NEAREST }}}) {
       target.style.imageRendering = 'optimizeSpeed';
       target.style.imageRendering = '-moz-crisp-edges';
       target.style.imageRendering = '-o-crisp-edges';
@@ -1293,8 +1293,8 @@ var LibraryHTML5 = {
       target.style.imageRendering = 'pixelated';
     }
 
-    var dpiScale = (strategy.canvasResolutionScaleMode == {{{ cDefine('EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_HIDEF') }}}) ? devicePixelRatio : 1;
-    if (strategy.canvasResolutionScaleMode != {{{ cDefine('EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_NONE') }}}) {
+    var dpiScale = (strategy.canvasResolutionScaleMode == {{{ cDefs.EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_HIDEF }}}) ? devicePixelRatio : 1;
+    if (strategy.canvasResolutionScaleMode != {{{ cDefs.EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_NONE }}}) {
       var newWidth = (cssWidth * dpiScale)|0;
       var newHeight = (cssHeight * dpiScale)|0;
       setCanvasElementSize(target, newWidth, newHeight);
@@ -1381,10 +1381,10 @@ var LibraryHTML5 = {
 
         if (currentFullscreenStrategy.canvasResizedCallback) {
 #if PTHREADS
-          if (currentFullscreenStrategy.canvasResizedCallbackTargetThread) JSEvents.queueEventHandlerOnThread_iiii(currentFullscreenStrategy.canvasResizedCallbackTargetThread, currentFullscreenStrategy.canvasResizedCallback, {{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
+          if (currentFullscreenStrategy.canvasResizedCallbackTargetThread) JSEvents.queueEventHandlerOnThread_iiii(currentFullscreenStrategy.canvasResizedCallbackTargetThread, currentFullscreenStrategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
           else
 #endif
-          {{{ makeDynCall('iiii', 'currentFullscreenStrategy.canvasResizedCallback') }}}({{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
+          {{{ makeDynCall('iiii', 'currentFullscreenStrategy.canvasResizedCallback') }}}({{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
         }
       }
     }
@@ -1460,10 +1460,10 @@ var LibraryHTML5 = {
   $softFullscreenResizeWebGLRenderTarget__deps: ['$JSEvents', '$setLetterbox', '$currentFullscreenStrategy', '$getCanvasElementSize', '$setCanvasElementSize', '$jstoi_q'],
   $softFullscreenResizeWebGLRenderTarget: function() {
     var dpr = devicePixelRatio;
-    var inHiDPIFullscreenMode = currentFullscreenStrategy.canvasResolutionScaleMode == {{{ cDefine('EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_HIDEF') }}};
-    var inAspectRatioFixedFullscreenMode = currentFullscreenStrategy.scaleMode == {{{ cDefine('EMSCRIPTEN_FULLSCREEN_SCALE_ASPECT') }}};
-    var inPixelPerfectFullscreenMode = currentFullscreenStrategy.canvasResolutionScaleMode != {{{ cDefine('EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_NONE') }}};
-    var inCenteredWithoutScalingFullscreenMode = currentFullscreenStrategy.scaleMode == {{{ cDefine('EMSCRIPTEN_FULLSCREEN_SCALE_CENTER') }}};
+    var inHiDPIFullscreenMode = currentFullscreenStrategy.canvasResolutionScaleMode == {{{ cDefs.EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_HIDEF }}};
+    var inAspectRatioFixedFullscreenMode = currentFullscreenStrategy.scaleMode == {{{ cDefs.EMSCRIPTEN_FULLSCREEN_SCALE_ASPECT }}};
+    var inPixelPerfectFullscreenMode = currentFullscreenStrategy.canvasResolutionScaleMode != {{{ cDefs.EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_NONE }}};
+    var inCenteredWithoutScalingFullscreenMode = currentFullscreenStrategy.scaleMode == {{{ cDefs.EMSCRIPTEN_FULLSCREEN_SCALE_CENTER }}};
     var screenWidth = inHiDPIFullscreenMode ? Math.round(innerWidth*dpr) : innerWidth;
     var screenHeight = inHiDPIFullscreenMode ? Math.round(innerHeight*dpr) : innerHeight;
     var w = screenWidth;
@@ -1509,22 +1509,22 @@ var LibraryHTML5 = {
 
     if (!inCenteredWithoutScalingFullscreenMode && currentFullscreenStrategy.canvasResizedCallback) {
 #if PTHREADS
-      if (currentFullscreenStrategy.canvasResizedCallbackTargetThread) JSEvents.queueEventHandlerOnThread_iiii(currentFullscreenStrategy.canvasResizedCallbackTargetThread, currentFullscreenStrategy.canvasResizedCallback, {{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
+      if (currentFullscreenStrategy.canvasResizedCallbackTargetThread) JSEvents.queueEventHandlerOnThread_iiii(currentFullscreenStrategy.canvasResizedCallbackTargetThread, currentFullscreenStrategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
       else
 #endif
-      {{{ makeDynCall('iiii', 'currentFullscreenStrategy.canvasResizedCallback') }}}({{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
+      {{{ makeDynCall('iiii', 'currentFullscreenStrategy.canvasResizedCallback') }}}({{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
     }
   },
 
   // https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Using_full_screen_mode  
   $doRequestFullscreen__deps: ['$JSEvents', '$setLetterbox', 'emscripten_set_canvas_element_size', 'emscripten_get_canvas_element_size', '$getCanvasElementSize', '$setCanvasElementSize', '$JSEvents_requestFullscreen', '$findEventTarget'],
   $doRequestFullscreen: function(target, strategy) {
-    if (!JSEvents.fullscreenEnabled()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    if (!JSEvents.fullscreenEnabled()) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
 #if !DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
     if (!target) target = '#canvas';
 #endif
     target = findEventTarget(target);
-    if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+    if (!target) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
 
     if (!target.requestFullscreen
 #if MIN_IE_VERSION != TARGET_NOT_SUPPORTED // https://caniuse.com/#feat=fullscreen
@@ -1538,7 +1538,7 @@ var LibraryHTML5 = {
       && !target.webkitRequestFullscreen
 #endif
       ) {
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
 
 #if HTML5_SUPPORT_DEFERRING_USER_SENSITIVE_REQUESTS
@@ -1548,9 +1548,9 @@ var LibraryHTML5 = {
     if (!canPerformRequests) {
       if (strategy.deferUntilInEventHandler) {
         JSEvents.deferCall(JSEvents_requestFullscreen, 1 /* priority over pointer lock */, [target, strategy]);
-        return {{{ cDefine('EMSCRIPTEN_RESULT_DEFERRED') }}};
+        return {{{ cDefs.EMSCRIPTEN_RESULT_DEFERRED }}};
       }
-      return {{{ cDefine('EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED }}};
     }
 #endif
 
@@ -1563,13 +1563,13 @@ var LibraryHTML5 = {
   emscripten_request_fullscreen: function(target, deferUntilInEventHandler) {
     var strategy = {
       // These options perform no added logic, but just bare request fullscreen.
-      scaleMode: {{{ cDefine('EMSCRIPTEN_FULLSCREEN_SCALE_DEFAULT') }}},
-      canvasResolutionScaleMode: {{{ cDefine('EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_NONE') }}},
-      filteringMode: {{{ cDefine('EMSCRIPTEN_FULLSCREEN_FILTERING_DEFAULT') }}},
+      scaleMode: {{{ cDefs.EMSCRIPTEN_FULLSCREEN_SCALE_DEFAULT }}},
+      canvasResolutionScaleMode: {{{ cDefs.EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_NONE }}},
+      filteringMode: {{{ cDefs.EMSCRIPTEN_FULLSCREEN_FILTERING_DEFAULT }}},
 #if HTML5_SUPPORT_DEFERRING_USER_SENSITIVE_REQUESTS
       deferUntilInEventHandler: deferUntilInEventHandler,
 #endif
-      canvasResizedCallbackTargetThread: {{{ cDefine('EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD') }}}
+      canvasResizedCallbackTargetThread: {{{ cDefs.EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD }}}
     };
     return doRequestFullscreen(target, strategy);
   },
@@ -1603,7 +1603,7 @@ var LibraryHTML5 = {
     if (!target) target = '#canvas';
 #endif
     target = findEventTarget(target);
-    if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+    if (!target) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
 
     var strategy = {
         scaleMode: {{{ makeGetValue('fullscreenStrategy', C_STRUCTS.EmscriptenFullscreenStrategy.scaleMode, 'i32') }}},
@@ -1632,10 +1632,10 @@ var LibraryHTML5 = {
       removeEventListener('resize', softFullscreenResizeWebGLRenderTarget);
       if (strategy.canvasResizedCallback) {
 #if PTHREADS
-        if (strategy.canvasResizedCallbackTargetThread) JSEvents.queueEventHandlerOnThread_iiii(strategy.canvasResizedCallbackTargetThread, strategy.canvasResizedCallback, {{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, strategy.canvasResizedCallbackUserData);
+        if (strategy.canvasResizedCallbackTargetThread) JSEvents.queueEventHandlerOnThread_iiii(strategy.canvasResizedCallbackTargetThread, strategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, strategy.canvasResizedCallbackUserData);
         else
 #endif
-        {{{ makeDynCall('iiii', 'strategy.canvasResizedCallback') }}}({{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, strategy.canvasResizedCallbackUserData);
+        {{{ makeDynCall('iiii', 'strategy.canvasResizedCallback') }}}({{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, strategy.canvasResizedCallbackUserData);
       }
       currentFullscreenStrategy = 0;
     }
@@ -1646,13 +1646,13 @@ var LibraryHTML5 = {
     // Inform the caller that the canvas size has changed.
     if (strategy.canvasResizedCallback) {
 #if PTHREADS
-      if (strategy.canvasResizedCallbackTargetThread) JSEvents.queueEventHandlerOnThread_iiii(strategy.canvasResizedCallbackTargetThread, strategy.canvasResizedCallback, {{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, strategy.canvasResizedCallbackUserData);
+      if (strategy.canvasResizedCallbackTargetThread) JSEvents.queueEventHandlerOnThread_iiii(strategy.canvasResizedCallbackTargetThread, strategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, strategy.canvasResizedCallbackUserData);
       else
 #endif
-      {{{ makeDynCall('iiii', 'strategy.canvasResizedCallback') }}}({{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, strategy.canvasResizedCallbackUserData);
+      {{{ makeDynCall('iiii', 'strategy.canvasResizedCallback') }}}({{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, strategy.canvasResizedCallbackUserData);
     }
 
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_exit_soft_fullscreen__deps: ['$restoreOldWindowedStyle'],
@@ -1662,20 +1662,20 @@ var LibraryHTML5 = {
     if (restoreOldWindowedStyle) restoreOldWindowedStyle();
     restoreOldWindowedStyle = null;
 
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_exit_fullscreen__deps: ['$JSEvents', '$currentFullscreenStrategy', '$JSEvents_requestFullscreen', '$specialHTMLTargets'],
   emscripten_exit_fullscreen__proxy: 'sync',
   emscripten_exit_fullscreen__sig: 'i',
   emscripten_exit_fullscreen: function() {
-    if (!JSEvents.fullscreenEnabled()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    if (!JSEvents.fullscreenEnabled()) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
 #if HTML5_SUPPORT_DEFERRING_USER_SENSITIVE_REQUESTS
     // Make sure no queued up calls will fire after this.
     JSEvents.removeDeferredCalls(JSEvents_requestFullscreen);
 #endif
 
-    var d = specialHTMLTargets[{{{ cDefine('EMSCRIPTEN_EVENT_TARGET_DOCUMENT') }}}];
+    var d = specialHTMLTargets[{{{ cDefs.EMSCRIPTEN_EVENT_TARGET_DOCUMENT }}}];
     if (d.exitFullscreen) {
       d.fullscreenElement && d.exitFullscreen();
 #if MIN_IE_VERSION != TARGET_NOT_SUPPORTED // https://caniuse.com/#feat=mdn-api_document_exitfullscreen
@@ -1691,10 +1691,10 @@ var LibraryHTML5 = {
       d.webkitFullscreenElement && d.webkitExitFullscreen();
 #endif
     } else {
-      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
 
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $fillPointerlockChangeEventData__deps: ['$JSEvents'],
@@ -1708,8 +1708,8 @@ var LibraryHTML5 = {
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenPointerlockChangeEvent.isActive, 'isPointerlocked', 'i32') }}};
     var nodeName = JSEvents.getNodeNameForTarget(pointerLockElement);
     var id = (pointerLockElement && pointerLockElement.id) ? pointerLockElement.id : '';
-    stringToUTF8(nodeName, eventStruct + {{{ C_STRUCTS.EmscriptenPointerlockChangeEvent.nodeName }}}, {{{ cDefine('EM_HTML5_LONG_STRING_LEN_BYTES') }}});
-    stringToUTF8(id, eventStruct + {{{ C_STRUCTS.EmscriptenPointerlockChangeEvent.id }}}, {{{ cDefine('EM_HTML5_LONG_STRING_LEN_BYTES') }}});
+    stringToUTF8(nodeName, eventStruct + {{{ C_STRUCTS.EmscriptenPointerlockChangeEvent.nodeName }}}, {{{ cDefs.EM_HTML5_LONG_STRING_LEN_BYTES }}});
+    stringToUTF8(id, eventStruct + {{{ C_STRUCTS.EmscriptenPointerlockChangeEvent.id }}}, {{{ cDefs.EM_HTML5_LONG_STRING_LEN_BYTES }}});
   },
 
   $registerPointerlockChangeEventCallback__deps: ['$JSEvents', '$fillPointerlockChangeEventData', '$findEventTarget'],
@@ -1751,20 +1751,20 @@ var LibraryHTML5 = {
   emscripten_set_pointerlockchange_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     // TODO: Currently not supported in pthreads or in --proxy-to-worker mode. (In pthreads mode, document object is not defined)
     if (!document || !document.body || (!document.body.requestPointerLock && !document.body.mozRequestPointerLock && !document.body.webkitRequestPointerLock && !document.body.msRequestPointerLock)) {
-      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
 
 #if DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
     target = findEventTarget(target);
 #else
-    target = target ? findEventTarget(target) : specialHTMLTargets[{{{ cDefine('EMSCRIPTEN_EVENT_TARGET_DOCUMENT') }}}]; // Pointer lock change events need to be captured from 'document' by default instead of 'window'
+    target = target ? findEventTarget(target) : specialHTMLTargets[{{{ cDefs.EMSCRIPTEN_EVENT_TARGET_DOCUMENT }}}]; // Pointer lock change events need to be captured from 'document' by default instead of 'window'
 #endif
-    if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
-    registerPointerlockChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_POINTERLOCKCHANGE') }}}, "pointerlockchange", targetThread);
-    registerPointerlockChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_POINTERLOCKCHANGE') }}}, "mozpointerlockchange", targetThread);
-    registerPointerlockChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_POINTERLOCKCHANGE') }}}, "webkitpointerlockchange", targetThread);
-    registerPointerlockChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_POINTERLOCKCHANGE') }}}, "mspointerlockchange", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    if (!target) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
+    registerPointerlockChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKCHANGE }}}, "pointerlockchange", targetThread);
+    registerPointerlockChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKCHANGE }}}, "mozpointerlockchange", targetThread);
+    registerPointerlockChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKCHANGE }}}, "webkitpointerlockchange", targetThread);
+    registerPointerlockChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKCHANGE }}}, "mspointerlockchange", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $registerPointerlockErrorEventCallback__deps: ['$JSEvents', '$findEventTarget', '$specialHTMLTargets'],
@@ -1798,21 +1798,21 @@ var LibraryHTML5 = {
   emscripten_set_pointerlockerror_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     // TODO: Currently not supported in pthreads or in --proxy-to-worker mode. (In pthreads mode, document object is not defined)
     if (!document || !document.body.requestPointerLock && !document.body.mozRequestPointerLock && !document.body.webkitRequestPointerLock && !document.body.msRequestPointerLock) {
-      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
 
 #if DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
     target = findEventTarget(target);
 #else
-    target = target ? findEventTarget(target) : specialHTMLTargets[{{{ cDefine('EMSCRIPTEN_EVENT_TARGET_DOCUMENT') }}}]; // Pointer lock change events need to be captured from 'document' by default instead of 'window'
+    target = target ? findEventTarget(target) : specialHTMLTargets[{{{ cDefs.EMSCRIPTEN_EVENT_TARGET_DOCUMENT }}}]; // Pointer lock change events need to be captured from 'document' by default instead of 'window'
 #endif
 
-    if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
-    registerPointerlockErrorEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_POINTERLOCKERROR') }}}, "pointerlockerror", targetThread);
-    registerPointerlockErrorEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_POINTERLOCKERROR') }}}, "mozpointerlockerror", targetThread);
-    registerPointerlockErrorEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_POINTERLOCKERROR') }}}, "webkitpointerlockerror", targetThread);
-    registerPointerlockErrorEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_POINTERLOCKERROR') }}}, "mspointerlockerror", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    if (!target) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
+    registerPointerlockErrorEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKERROR }}}, "pointerlockerror", targetThread);
+    registerPointerlockErrorEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKERROR }}}, "mozpointerlockerror", targetThread);
+    registerPointerlockErrorEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKERROR }}}, "webkitpointerlockerror", targetThread);
+    registerPointerlockErrorEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKERROR }}}, "mspointerlockerror", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_get_pointerlock_status__proxy: 'sync',
@@ -1822,9 +1822,9 @@ var LibraryHTML5 = {
   emscripten_get_pointerlock_status: function(pointerlockStatus) {
     if (pointerlockStatus) fillPointerlockChangeEventData(pointerlockStatus);
     if (!document.body || (!document.body.requestPointerLock && !document.body.mozRequestPointerLock && !document.body.webkitRequestPointerLock && !document.body.msRequestPointerLock)) {
-      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $requestPointerLock: function(target) {
@@ -1856,11 +1856,11 @@ var LibraryHTML5 = {
         || document.body.msRequestPointerLock
 #endif
         ) {
-        return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+        return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
       }
-      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_request_pointerlock__proxy: 'sync',
@@ -1871,7 +1871,7 @@ var LibraryHTML5 = {
     if (!target) target = '#canvas';
 #endif
     target = findEventTarget(target);
-    if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+    if (!target) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
     if (!target.requestPointerLock
 #if MIN_FIREFOX_VERSION <= 40 // https://caniuse.com/#feat=pointerlock
       && !target.mozRequestPointerLock
@@ -1883,7 +1883,7 @@ var LibraryHTML5 = {
       && !target.msRequestPointerLock
 #endif
       ) {
-      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
 
 #if HTML5_SUPPORT_DEFERRING_USER_SENSITIVE_REQUESTS
@@ -1893,9 +1893,9 @@ var LibraryHTML5 = {
     if (!canPerformRequests) {
       if (deferUntilInEventHandler) {
         JSEvents.deferCall(requestPointerLock, 2 /* priority below fullscreen */, [target]);
-        return {{{ cDefine('EMSCRIPTEN_RESULT_DEFERRED') }}};
+        return {{{ cDefs.EMSCRIPTEN_RESULT_DEFERRED }}};
       }
-      return {{{ cDefine('EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED }}};
     }
 #endif
 
@@ -1926,23 +1926,23 @@ var LibraryHTML5 = {
       document.webkitExitPointerLock();
 #endif
     } else {
-      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
   
   emscripten_vibrate__proxy: 'sync',
   emscripten_vibrate__sig: 'ii',
   emscripten_vibrate: function(msecs) {
-    if (!navigator.vibrate) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};    
+    if (!navigator.vibrate) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};    
     navigator.vibrate(msecs);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
   
   emscripten_vibrate_pattern__proxy: 'sync',
   emscripten_vibrate_pattern__sig: 'ipi',
   emscripten_vibrate_pattern: function(msecsArray, numEntries) {
-    if (!navigator.vibrate) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    if (!navigator.vibrate) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
 
     var vibrateList = [];
     for (var i = 0; i < numEntries; ++i) {
@@ -1950,7 +1950,7 @@ var LibraryHTML5 = {
       vibrateList.push(msecs);
     }
     navigator.vibrate(vibrateList);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $fillVisibilityChangeEventData: function(eventStruct) {
@@ -2003,12 +2003,12 @@ var LibraryHTML5 = {
   emscripten_set_visibilitychange_callback_on_thread__deps: ['$registerVisibilityChangeEventCallback', '$specialHTMLTargets'],
   emscripten_set_visibilitychange_callback_on_thread: function(userData, useCapture, callbackfunc, targetThread) {
 #if ENVIRONMENT_MAY_BE_WORKER || ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL
-  if (!specialHTMLTargets[{{{ cDefine('EMSCRIPTEN_EVENT_TARGET_DOCUMENT') }}}]) {
-    return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+  if (!specialHTMLTargets[{{{ cDefs.EMSCRIPTEN_EVENT_TARGET_DOCUMENT }}}]) {
+    return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
   }
 #endif
-    registerVisibilityChangeEventCallback(specialHTMLTargets[{{{ cDefine('EMSCRIPTEN_EVENT_TARGET_DOCUMENT') }}}], userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_VISIBILITYCHANGE') }}}, "visibilitychange", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerVisibilityChangeEventCallback(specialHTMLTargets[{{{ cDefs.EMSCRIPTEN_EVENT_TARGET_DOCUMENT }}}], userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_VISIBILITYCHANGE }}}, "visibilitychange", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_get_visibility_status__proxy: 'sync',
@@ -2016,10 +2016,10 @@ var LibraryHTML5 = {
   emscripten_get_visibility_status__deps: ['$fillVisibilityChangeEventData'],
   emscripten_get_visibility_status: function(visibilityStatus) {
     if (typeof document.visibilityState == 'undefined' && typeof document.hidden == 'undefined') {
-      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
     fillVisibilityChangeEventData(visibilityStatus);  
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $registerTouchEventCallback__deps: ['$JSEvents', '$findEventTarget', '$getBoundingClientRect'],
@@ -2125,32 +2125,32 @@ var LibraryHTML5 = {
   emscripten_set_touchstart_callback_on_thread__sig: 'ippipp',
   emscripten_set_touchstart_callback_on_thread__deps: ['$registerTouchEventCallback'],
   emscripten_set_touchstart_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerTouchEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_TOUCHSTART') }}}, "touchstart", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerTouchEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_TOUCHSTART }}}, "touchstart", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
   
   emscripten_set_touchend_callback_on_thread__proxy: 'sync',
   emscripten_set_touchend_callback_on_thread__sig: 'ippipp',
   emscripten_set_touchend_callback_on_thread__deps: ['$registerTouchEventCallback'],
   emscripten_set_touchend_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerTouchEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_TOUCHEND') }}}, "touchend", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerTouchEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_TOUCHEND }}}, "touchend", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
   
   emscripten_set_touchmove_callback_on_thread__proxy: 'sync',
   emscripten_set_touchmove_callback_on_thread__sig: 'ippipp',
   emscripten_set_touchmove_callback_on_thread__deps: ['$registerTouchEventCallback'],
   emscripten_set_touchmove_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerTouchEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_TOUCHMOVE') }}}, "touchmove", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerTouchEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_TOUCHMOVE }}}, "touchmove", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
   
   emscripten_set_touchcancel_callback_on_thread__proxy: 'sync',
   emscripten_set_touchcancel_callback_on_thread__sig: 'ippipp',
   emscripten_set_touchcancel_callback_on_thread__deps: ['$registerTouchEventCallback'],
   emscripten_set_touchcancel_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerTouchEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_TOUCHCANCEL') }}}, "touchcancel", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerTouchEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_TOUCHCANCEL }}}, "touchcancel", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $fillGamepadEventData: function(eventStruct, e) {
@@ -2180,8 +2180,8 @@ var LibraryHTML5 = {
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenGamepadEvent.index, 'e.index', 'i32') }}};
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenGamepadEvent.numAxes, 'e.axes.length', 'i32') }}};
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenGamepadEvent.numButtons, 'e.buttons.length', 'i32') }}};
-    stringToUTF8(e.id, eventStruct + {{{ C_STRUCTS.EmscriptenGamepadEvent.id }}}, {{{ cDefine('EM_HTML5_MEDIUM_STRING_LEN_BYTES') }}});
-    stringToUTF8(e.mapping, eventStruct + {{{ C_STRUCTS.EmscriptenGamepadEvent.mapping }}}, {{{ cDefine('EM_HTML5_MEDIUM_STRING_LEN_BYTES') }}});
+    stringToUTF8(e.id, eventStruct + {{{ C_STRUCTS.EmscriptenGamepadEvent.id }}}, {{{ cDefs.EM_HTML5_MEDIUM_STRING_LEN_BYTES }}});
+    stringToUTF8(e.mapping, eventStruct + {{{ C_STRUCTS.EmscriptenGamepadEvent.mapping }}}, {{{ cDefs.EM_HTML5_MEDIUM_STRING_LEN_BYTES }}});
   },
 
   $registerGamepadEventCallback__deps: ['$JSEvents', '$fillGamepadEventData', '$findEventTarget'],
@@ -2223,18 +2223,18 @@ var LibraryHTML5 = {
   emscripten_set_gamepadconnected_callback_on_thread__sig: 'ipipp',
   emscripten_set_gamepadconnected_callback_on_thread__deps: ['$registerGamepadEventCallback'],
   emscripten_set_gamepadconnected_callback_on_thread: function(userData, useCapture, callbackfunc, targetThread) {
-    if (!navigator.getGamepads && !navigator.webkitGetGamepads) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
-    registerGamepadEventCallback({{{ cDefine('EMSCRIPTEN_EVENT_TARGET_WINDOW') }}}, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_GAMEPADCONNECTED') }}}, "gamepadconnected", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    if (!navigator.getGamepads && !navigator.webkitGetGamepads) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
+    registerGamepadEventCallback({{{ cDefs.EMSCRIPTEN_EVENT_TARGET_WINDOW }}}, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_GAMEPADCONNECTED }}}, "gamepadconnected", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
   
   emscripten_set_gamepaddisconnected_callback_on_thread__proxy: 'sync',
   emscripten_set_gamepaddisconnected_callback_on_thread__sig: 'ipipp',
   emscripten_set_gamepaddisconnected_callback_on_thread__deps: ['$registerGamepadEventCallback'],
   emscripten_set_gamepaddisconnected_callback_on_thread: function(userData, useCapture, callbackfunc, targetThread) {
-    if (!navigator.getGamepads && !navigator.webkitGetGamepads) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
-    registerGamepadEventCallback({{{ cDefine('EMSCRIPTEN_EVENT_TARGET_WINDOW') }}}, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_GAMEPADDISCONNECTED') }}}, "gamepaddisconnected", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    if (!navigator.getGamepads && !navigator.webkitGetGamepads) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
+    registerGamepadEventCallback({{{ cDefs.EMSCRIPTEN_EVENT_TARGET_WINDOW }}}, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_GAMEPADDISCONNECTED }}}, "gamepaddisconnected", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
   
   emscripten_sample_gamepad_data__proxy: 'sync',
@@ -2242,7 +2242,7 @@ var LibraryHTML5 = {
   emscripten_sample_gamepad_data__deps: ['$JSEvents'],
   emscripten_sample_gamepad_data: function() {
     return (JSEvents.lastGamepadState = (navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : null)))
-      ? {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}} : {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      ? {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}} : {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
   },
 
   emscripten_get_num_gamepads__proxy: 'sync',
@@ -2266,16 +2266,16 @@ var LibraryHTML5 = {
 #endif
 
     // INVALID_PARAM is returned on a Gamepad index that never was there.
-    if (index < 0 || index >= JSEvents.lastGamepadState.length) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+    if (index < 0 || index >= JSEvents.lastGamepadState.length) return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_PARAM }}};
 
     // NO_DATA is returned on a Gamepad index that was removed.
     // For previously disconnected gamepads there should be an empty slot (null/undefined/false) at the index.
     // This is because gamepads must keep their original position in the array.
     // For example, removing the first of two gamepads produces [null/undefined/false, gamepad].
-    if (!JSEvents.lastGamepadState[index]) return {{{ cDefine('EMSCRIPTEN_RESULT_NO_DATA') }}};
+    if (!JSEvents.lastGamepadState[index]) return {{{ cDefs.EMSCRIPTEN_RESULT_NO_DATA }}};
 
     fillGamepadEventData(gamepadState, JSEvents.lastGamepadState[index]);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
   
   $registerBeforeUnloadEventCallback__deps: ['$JSEvents', '$findEventTarget'],
@@ -2308,12 +2308,12 @@ var LibraryHTML5 = {
   emscripten_set_beforeunload_callback_on_thread__sig: 'ippp',
   emscripten_set_beforeunload_callback_on_thread__deps: ['$registerBeforeUnloadEventCallback'],
   emscripten_set_beforeunload_callback_on_thread: function(userData, callbackfunc, targetThread) {
-    if (typeof onbeforeunload == 'undefined') return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    if (typeof onbeforeunload == 'undefined') return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     // beforeunload callback can only be registered on the main browser thread, because the page will go away immediately after returning from the handler,
     // and there is no time to start proxying it anywhere.
-    if (targetThread !== {{{ cDefine('EM_CALLBACK_THREAD_CONTEXT_MAIN_RUNTIME_THREAD') }}}) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
-    registerBeforeUnloadEventCallback({{{ cDefine('EMSCRIPTEN_EVENT_TARGET_WINDOW') }}}, userData, true, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_BEFOREUNLOAD') }}}, "beforeunload");
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    if (targetThread !== {{{ cDefs.EM_CALLBACK_THREAD_CONTEXT_MAIN_RUNTIME_THREAD }}}) return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_PARAM }}};
+    registerBeforeUnloadEventCallback({{{ cDefs.EMSCRIPTEN_EVENT_TARGET_WINDOW }}}, userData, true, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_BEFOREUNLOAD }}}, "beforeunload");
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   $fillBatteryEventData: function(eventStruct, e) {
@@ -2361,27 +2361,27 @@ var LibraryHTML5 = {
   emscripten_set_batterychargingchange_callback_on_thread__sig: 'ippp',
   emscripten_set_batterychargingchange_callback_on_thread__deps: ['$registerBatteryEventCallback', '$battery', 'malloc'],
   emscripten_set_batterychargingchange_callback_on_thread: function(userData, callbackfunc, targetThread) {
-    if (!battery()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}}; 
-    registerBatteryEventCallback(battery(), userData, true, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_BATTERYCHARGINGCHANGE') }}}, "chargingchange", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    if (!battery()) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}}; 
+    registerBatteryEventCallback(battery(), userData, true, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_BATTERYCHARGINGCHANGE }}}, "chargingchange", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_batterylevelchange_callback_on_thread__proxy: 'sync',
   emscripten_set_batterylevelchange_callback_on_thread__sig: 'ippp',
   emscripten_set_batterylevelchange_callback_on_thread__deps: ['$registerBatteryEventCallback', '$battery', 'malloc'],
   emscripten_set_batterylevelchange_callback_on_thread: function(userData, callbackfunc, targetThread) {
-    if (!battery()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}}; 
-    registerBatteryEventCallback(battery(), userData, true, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_BATTERYLEVELCHANGE') }}}, "levelchange", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    if (!battery()) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}}; 
+    registerBatteryEventCallback(battery(), userData, true, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_BATTERYLEVELCHANGE }}}, "levelchange", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
   
   emscripten_get_battery_status__proxy: 'sync',
   emscripten_get_battery_status__sig: 'ip',
   emscripten_get_battery_status__deps: ['$fillBatteryEventData', '$battery'],
   emscripten_get_battery_status: function(batteryState) {
-    if (!battery()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}}; 
+    if (!battery()) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}}; 
     fillBatteryEventData(batteryState, battery());
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
 #if PTHREADS
@@ -2393,7 +2393,7 @@ var LibraryHTML5 = {
     '$findCanvasEventTarget'],
   emscripten_set_canvas_element_size_calling_thread: function(target, width, height) {
     var canvas = findCanvasEventTarget(target);
-    if (!canvas) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+    if (!canvas) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
 
 #if OFFSCREENCANVAS_SUPPORT
     if (canvas.canvasSharedPtr) {
@@ -2435,18 +2435,18 @@ var LibraryHTML5 = {
     } else if (canvas.canvasSharedPtr) {
       var targetThread = {{{ makeGetValue('canvas.canvasSharedPtr', 8, 'i32') }}};
       _emscripten_set_offscreencanvas_size_on_target_thread(targetThread, target, width, height);
-      return {{{ cDefine('EMSCRIPTEN_RESULT_DEFERRED') }}}; // This will have to be done asynchronously
+      return {{{ cDefs.EMSCRIPTEN_RESULT_DEFERRED }}}; // This will have to be done asynchronously
 #endif
     } else {
 #if GL_DEBUG
       dbg('canvas.controlTransferredOffscreen but we do not own the canvas, and do not know who has (no canvas.canvasSharedPtr present, an internal bug?)!\n');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
     }
 #if OFFSCREEN_FRAMEBUFFER
     if (canvas.GLctxObject) GL.resizeOffscreenFramebuffer(canvas.GLctxObject);
 #endif
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   _emscripten_set_offscreencanvas_size__sig: 'iiii',
@@ -2468,7 +2468,7 @@ var LibraryHTML5 = {
       // these two threads will deadlock. At the moment, we'd like to consider that this kind of deadlock would be an Emscripten runtime bug, although if
       // emscripten_set_canvas_element_size() was documented to require running an event in the queue of thread that owns the OffscreenCanvas, then that might be ok.
       // (safer this way however)
-      _emscripten_dispatch_to_thread_(targetThread, {{{ cDefine('EM_PROXIED_RESIZE_OFFSCREENCANVAS') }}}, 0, targetCanvasPtr /* satellite data */, varargs);
+      _emscripten_dispatch_to_thread_(targetThread, {{{ cDefs.EM_PROXIED_RESIZE_OFFSCREENCANVAS }}}, 0, targetCanvasPtr /* satellite data */, varargs);
     });
   },
 
@@ -2482,7 +2482,7 @@ var LibraryHTML5 = {
 #if ASSERTIONS
     err('emscripten_set_offscreencanvas_size: Build with -sOFFSCREENCANVAS_SUPPORT=1 to enable transferring canvases to pthreads.');
 #endif
-    return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
   },
 #endif
 
@@ -2511,13 +2511,13 @@ var LibraryHTML5 = {
     dbg('emscripten_set_canvas_element_size(target='+target+',width='+width+',height='+height);
 #endif
     var canvas = findCanvasEventTarget(target);
-    if (!canvas) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+    if (!canvas) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
     canvas.width = width;
     canvas.height = height;
 #if OFFSCREEN_FRAMEBUFFER
     if (canvas.GLctxObject) GL.resizeOffscreenFramebuffer(canvas.GLctxObject);
 #endif
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 #endif
 
@@ -2544,7 +2544,7 @@ var LibraryHTML5 = {
   emscripten_get_canvas_element_size_calling_thread__deps: ['$JSEvents', '$findCanvasEventTarget'],
   emscripten_get_canvas_element_size_calling_thread: function(target, width, height) {
     var canvas = findCanvasEventTarget(target);
-    if (!canvas) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+    if (!canvas) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
 
 #if OFFSCREENCANVAS_SUPPORT
     if (canvas.canvasSharedPtr) {
@@ -2567,9 +2567,9 @@ var LibraryHTML5 = {
 #if GL_DEBUG
       dbg('canvas.controlTransferredOffscreen but we do not own the canvas, and do not know who has (no canvas.canvasSharedPtr present, an internal bug?)!\n');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
     }
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_get_canvas_element_size_main_thread__proxy: 'sync',
@@ -2591,7 +2591,7 @@ var LibraryHTML5 = {
   emscripten_get_canvas_element_size__sig: 'ippp',
   emscripten_get_canvas_element_size: function(target, width, height) {
     var canvas = findCanvasEventTarget(target);
-    if (!canvas) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+    if (!canvas) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
     {{{ makeSetValue('width', '0', 'canvas.width', 'i32') }}};
     {{{ makeSetValue('height', '0', 'canvas.height', 'i32') }}};
   },
@@ -2621,12 +2621,12 @@ var LibraryHTML5 = {
 #else
     target = target ? findEventTarget(target) : Module['canvas'];
 #endif
-    if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+    if (!target) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
 
     target.style.width = width + "px";
     target.style.height = height + "px";
 
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_get_element_css_size__proxy: 'sync',
@@ -2638,7 +2638,7 @@ var LibraryHTML5 = {
 #else
     target = target ? findEventTarget(target) : Module['canvas'];
 #endif
-    if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+    if (!target) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
 
     var rect = getBoundingClientRect(target);
 #if MIN_IE_VERSION < 9
@@ -2651,7 +2651,7 @@ var LibraryHTML5 = {
     {{{ makeSetValue('height', '0', 'rect.height', 'double') }}};
 #endif
 
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_html5_remove_all_event_listeners__sig: 'v',

--- a/src/library_html5_webgl.js
+++ b/src/library_html5_webgl.js
@@ -118,14 +118,14 @@ var LibraryHtml5WebGL = {
 #if PTHREADS && OFFSCREEN_FRAMEBUFFER
     // Create a WebGL context that is proxied to main thread if canvas was not found on worker, or if explicitly requested to do so.
     if (ENVIRONMENT_IS_PTHREAD) {
-      if (contextAttributes.proxyContextToMainThread === {{{ cDefine('EMSCRIPTEN_WEBGL_CONTEXT_PROXY_ALWAYS') }}} ||
-         (!canvas && contextAttributes.proxyContextToMainThread === {{{ cDefine('EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK') }}})) {
+      if (contextAttributes.proxyContextToMainThread === {{{ cDefs.EMSCRIPTEN_WEBGL_CONTEXT_PROXY_ALWAYS }}} ||
+         (!canvas && contextAttributes.proxyContextToMainThread === {{{ cDefs.EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK }}})) {
         // When WebGL context is being proxied via the main thread, we must render using an offscreen FBO render target to avoid WebGL's
         // "implicit swap when callback exits" behavior. TODO: If OffscreenCanvas is supported, explicitSwapControl=true and still proxying,
         // then this can be avoided, since OffscreenCanvas enables explicit swap control.
 #if GL_DEBUG
-        if (contextAttributes.proxyContextToMainThread === {{{ cDefine('EMSCRIPTEN_WEBGL_CONTEXT_PROXY_ALWAYS') }}}) dbg('EMSCRIPTEN_WEBGL_CONTEXT_PROXY_ALWAYS enabled, proxying WebGL rendering from pthread to main thread.');
-        if (!canvas && contextAttributes.proxyContextToMainThread === {{{ cDefine('EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK') }}}) dbg('Specified canvas target "' + targetStr + '" is not an OffscreenCanvas in the current pthread, but EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK is set. Proxying WebGL rendering from pthread to main thread.');
+        if (contextAttributes.proxyContextToMainThread === {{{ cDefs.EMSCRIPTEN_WEBGL_CONTEXT_PROXY_ALWAYS }}}) dbg('EMSCRIPTEN_WEBGL_CONTEXT_PROXY_ALWAYS enabled, proxying WebGL rendering from pthread to main thread.');
+        if (!canvas && contextAttributes.proxyContextToMainThread === {{{ cDefs.EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK }}}) dbg('Specified canvas target "' + targetStr + '" is not an OffscreenCanvas in the current pthread, but EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK is set. Proxying WebGL rendering from pthread to main thread.');
         dbg('Performance warning: forcing renderViaOffscreenBackBuffer=true and preserveDrawingBuffer=true since proxying WebGL rendering.');
 #endif
         // We will be proxying - if OffscreenCanvas is supported, we can proxy a bit more efficiently by avoiding having to create an Offscreen FBO.
@@ -220,7 +220,7 @@ var LibraryHtml5WebGL = {
   emscripten_webgl_make_context_current_calling_thread: function(contextHandle) {
     var success = GL.makeContextCurrent(contextHandle);
     if (success) GL.currentContextIsProxied = false; // If succeeded above, we will have a local GL context from this thread (worker or main).
-    return success ? {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}} : {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+    return success ? {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}} : {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_PARAM }}};
   },
   // This function gets called in a pthread, after it has successfully activated (with make_current()) a proxied GL context to itself from the main thread.
   // In this scenario, the pthread does not hold a high-level JS object to the GL context, because it lives on the main thread, in which case we record
@@ -234,7 +234,7 @@ var LibraryHtml5WebGL = {
   emscripten_webgl_make_context_current__sig: 'ii',
   emscripten_webgl_make_context_current: function(contextHandle) {
     var success = GL.makeContextCurrent(contextHandle);
-    return success ? {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}} : {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+    return success ? {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}} : {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_PARAM }}};
   },
 #endif
 
@@ -248,11 +248,11 @@ var LibraryHtml5WebGL = {
     var GLContext = GL.getContext(contextHandle);
 
     if (!GLContext || !GLContext.GLctx || !width || !height) {
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_PARAM }}};
     }
     {{{ makeSetValue('width', '0', 'GLContext.GLctx.drawingBufferWidth', 'i32') }}};
     {{{ makeSetValue('height', '0', 'GLContext.GLctx.drawingBufferHeight', 'i32') }}};
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_webgl_do_commit_frame__sig: 'i',
@@ -265,7 +265,7 @@ var LibraryHtml5WebGL = {
 #if GL_DEBUG
       dbg('emscripten_webgl_commit_frame() failed: no GL context set current via emscripten_webgl_make_context_current()!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
 
 #if OFFSCREEN_FRAMEBUFFER
@@ -274,30 +274,30 @@ var LibraryHtml5WebGL = {
 #if GL_DEBUG && OFFSCREENCANVAS_SUPPORT
       if (GL.currentContext.GLctx.commit) dbg('emscripten_webgl_commit_frame(): Offscreen framebuffer should never have gotten created when canvas is in OffscreenCanvas mode, since it is redundant and not necessary');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
     }
 #endif
     if (!GL.currentContext.attributes.explicitSwapControl) {
 #if GL_DEBUG
       dbg('emscripten_webgl_commit_frame() cannot be called for canvases with implicit swap control mode!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
     // We would do GL.currentContext.GLctx.commit(); here, but the current implementation
     // in browsers has removed it - swap is implicit, so this function is a no-op for now
     // (until/unless the spec changes).
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_webgl_get_context_attributes__proxy: 'sync_on_webgl_context_handle_thread',
   emscripten_webgl_get_context_attributes__sig: 'iip',
   emscripten_webgl_get_context_attributes__deps: ['$emscripten_webgl_power_preferences'],
   emscripten_webgl_get_context_attributes: function(c, a) {
-    if (!a) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+    if (!a) return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_PARAM }}};
     c = GL.contexts[c];
-    if (!c) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    if (!c) return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     var t = c.GLctx;
-    if (!t) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    if (!t) return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     t = t.getContextAttributes();
 
     {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.alpha, 't.alpha', 'i32') }}};
@@ -317,7 +317,7 @@ var LibraryHtml5WebGL = {
 #if GL_SUPPORT_EXPLICIT_SWAP_CONTROL
     {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.explicitSwapControl, 'c.attributes.explicitSwapControl', 'i32') }}};
 #endif
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_webgl_destroy_context__proxy: 'sync_on_webgl_context_handle_thread',
@@ -439,16 +439,16 @@ var LibraryHtml5WebGL = {
   emscripten_set_webglcontextlost_callback_on_thread__sig: 'ippipp',
   emscripten_set_webglcontextlost_callback_on_thread__deps: ['$registerWebGlEventCallback'],
   emscripten_set_webglcontextlost_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerWebGlEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_WEBGLCONTEXTLOST') }}}, "webglcontextlost", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerWebGlEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_WEBGLCONTEXTLOST }}}, "webglcontextlost", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_set_webglcontextrestored_callback_on_thread__proxy: 'sync',
   emscripten_set_webglcontextrestored_callback_on_thread__sig: 'ippipp',
   emscripten_set_webglcontextrestored_callback_on_thread__deps: ['$registerWebGlEventCallback'],
   emscripten_set_webglcontextrestored_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    registerWebGlEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_WEBGLCONTEXTRESTORED') }}}, "webglcontextrestored", targetThread);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    registerWebGlEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_WEBGLCONTEXTRESTORED }}}, "webglcontextrestored", targetThread);
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_is_webgl_context_lost__proxy: 'sync_on_webgl_context_handle_thread',

--- a/src/library_lz4.js
+++ b/src/library_lz4.js
@@ -8,8 +8,8 @@
 mergeInto(LibraryManager.library, {
   $LZ4__deps: ['$FS'],
   $LZ4: {
-    DIR_MODE: {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */,
-    FILE_MODE: {{{ cDefine('S_IFREG') }}} | 511 /* 0777 */,
+    DIR_MODE: {{{ cDefs.S_IFDIR }}} | 511 /* 0777 */,
+    FILE_MODE: {{{ cDefs.S_IFREG }}} | 511 /* 0777 */,
     CHUNK_SIZE: -1,
     codec: null,
     init: function() {
@@ -114,25 +114,25 @@ mergeInto(LibraryManager.library, {
         }
       },
       lookup: function(parent, name) {
-        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOENT }}});
       },
       mknod: function (parent, name, mode, dev) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       },
       rename: function (oldNode, newDir, newName) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       },
       unlink: function(parent, name) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       },
       rmdir: function(parent, name) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       },
       readdir: function(node) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       },
       symlink: function(parent, newName, oldPath) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       },
     },
     stream_ops: {
@@ -184,19 +184,19 @@ mergeInto(LibraryManager.library, {
         return written;
       },
       write: function (stream, buffer, offset, length, position) {
-        throw new FS.ErrnoError({{{ cDefine('EIO') }}});
+        throw new FS.ErrnoError({{{ cDefs.EIO }}});
       },
       llseek: function (stream, offset, whence) {
         var position = offset;
-        if (whence === {{{ cDefine('SEEK_CUR') }}}) {
+        if (whence === {{{ cDefs.SEEK_CUR }}}) {
           position += stream.position;
-        } else if (whence === {{{ cDefine('SEEK_END') }}}) {
+        } else if (whence === {{{ cDefs.SEEK_END }}}) {
           if (FS.isFile(stream.node.mode)) {
             position += stream.node.size;
           }
         }
         if (position < 0) {
-          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+          throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
         }
         return position;
       },

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -9,12 +9,12 @@ mergeInto(LibraryManager.library, {
   $MEMFS: {
     ops_table: null,
     mount: function(mount) {
-      return MEMFS.createNode(null, '/', {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */, 0);
+      return MEMFS.createNode(null, '/', {{{ cDefs.S_IFDIR }}} | 511 /* 0777 */, 0);
     },
     createNode: function(parent, name, mode, dev) {
       if (FS.isBlkdev(mode) || FS.isFIFO(mode)) {
         // no supported
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       }
       if (!MEMFS.ops_table) {
         MEMFS.ops_table = {
@@ -181,7 +181,7 @@ mergeInto(LibraryManager.library, {
         }
       },
       lookup: function(parent, name) {
-        throw FS.genericErrors[{{{ cDefine('ENOENT') }}}];
+        throw FS.genericErrors[{{{ cDefs.ENOENT }}}];
       },
       mknod: function(parent, name, mode, dev) {
         return MEMFS.createNode(parent, name, mode, dev);
@@ -196,7 +196,7 @@ mergeInto(LibraryManager.library, {
           }
           if (new_node) {
             for (var i in new_node.contents) {
-              throw new FS.ErrnoError({{{ cDefine('ENOTEMPTY') }}});
+              throw new FS.ErrnoError({{{ cDefs.ENOTEMPTY }}});
             }
           }
         }
@@ -215,7 +215,7 @@ mergeInto(LibraryManager.library, {
       rmdir: function(parent, name) {
         var node = FS.lookupNode(parent, name);
         for (var i in node.contents) {
-          throw new FS.ErrnoError({{{ cDefine('ENOTEMPTY') }}});
+          throw new FS.ErrnoError({{{ cDefs.ENOTEMPTY }}});
         }
         delete parent.contents[name];
         parent.timestamp = Date.now();
@@ -231,13 +231,13 @@ mergeInto(LibraryManager.library, {
         return entries;
       },
       symlink: function(parent, newname, oldpath) {
-        var node = MEMFS.createNode(parent, newname, 511 /* 0777 */ | {{{ cDefine('S_IFLNK') }}}, 0);
+        var node = MEMFS.createNode(parent, newname, 511 /* 0777 */ | {{{ cDefs.S_IFLNK }}}, 0);
         node.link = oldpath;
         return node;
       },
       readlink: function(node) {
         if (!FS.isLink(node.mode)) {
-          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+          throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
         }
         return node.link;
       },
@@ -317,15 +317,15 @@ mergeInto(LibraryManager.library, {
 
       llseek: function(stream, offset, whence) {
         var position = offset;
-        if (whence === {{{ cDefine('SEEK_CUR') }}}) {
+        if (whence === {{{ cDefs.SEEK_CUR }}}) {
           position += stream.position;
-        } else if (whence === {{{ cDefine('SEEK_END') }}}) {
+        } else if (whence === {{{ cDefs.SEEK_END }}}) {
           if (FS.isFile(stream.node.mode)) {
             position += stream.node.usedBytes;
           }
         }
         if (position < 0) {
-          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+          throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
         }
         return position;
       },
@@ -335,13 +335,13 @@ mergeInto(LibraryManager.library, {
       },
       mmap: function(stream, length, position, prot, flags) {
         if (!FS.isFile(stream.node.mode)) {
-          throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
+          throw new FS.ErrnoError({{{ cDefs.ENODEV }}});
         }
         var ptr;
         var allocated;
         var contents = stream.node.contents;
         // Only make a new copy when MAP_PRIVATE is specified.
-        if (!(flags & {{{ cDefine('MAP_PRIVATE') }}}) && contents.buffer === HEAP8.buffer) {
+        if (!(flags & {{{ cDefs.MAP_PRIVATE }}}) && contents.buffer === HEAP8.buffer) {
           // We can't emulate MAP_SHARED when the file is not backed by the
           // buffer we're mapping to (e.g. the HEAP buffer).
           allocated = false;
@@ -358,7 +358,7 @@ mergeInto(LibraryManager.library, {
           allocated = true;
           ptr = mmapAlloc(length);
           if (!ptr) {
-            throw new FS.ErrnoError({{{ cDefine('ENOMEM') }}});
+            throw new FS.ErrnoError({{{ cDefs.ENOMEM }}});
           }
 #if CAN_ADDRESS_2GB
           ptr >>>= 0;

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -17,16 +17,16 @@ mergeInto(LibraryManager.library, {
         flags = flags["fs"];
       }
       NODEFS.flagsForNodeMap = {
-        "{{{ cDefine('O_APPEND') }}}": flags["O_APPEND"],
-        "{{{ cDefine('O_CREAT') }}}": flags["O_CREAT"],
-        "{{{ cDefine('O_EXCL') }}}": flags["O_EXCL"],
-        "{{{ cDefine('O_NOCTTY') }}}": flags["O_NOCTTY"],
-        "{{{ cDefine('O_RDONLY') }}}": flags["O_RDONLY"],
-        "{{{ cDefine('O_RDWR') }}}": flags["O_RDWR"],
-        "{{{ cDefine('O_DSYNC') }}}": flags["O_SYNC"],
-        "{{{ cDefine('O_TRUNC') }}}": flags["O_TRUNC"],
-        "{{{ cDefine('O_WRONLY') }}}": flags["O_WRONLY"],
-        "{{{ cDefine('O_NOFOLLOW') }}}": flags["O_NOFOLLOW"],
+        "{{{ cDefs.O_APPEND }}}": flags["O_APPEND"],
+        "{{{ cDefs.O_CREAT }}}": flags["O_CREAT"],
+        "{{{ cDefs.O_EXCL }}}": flags["O_EXCL"],
+        "{{{ cDefs.O_NOCTTY }}}": flags["O_NOCTTY"],
+        "{{{ cDefs.O_RDONLY }}}": flags["O_RDONLY"],
+        "{{{ cDefs.O_RDWR }}}": flags["O_RDWR"],
+        "{{{ cDefs.O_DSYNC }}}": flags["O_SYNC"],
+        "{{{ cDefs.O_TRUNC }}}": flags["O_TRUNC"],
+        "{{{ cDefs.O_WRONLY }}}": flags["O_WRONLY"],
+        "{{{ cDefs.O_NOFOLLOW }}}": flags["O_NOFOLLOW"],
       };
 #if ASSERTIONS
       // The 0 define must match on both sides, as otherwise we would not
@@ -49,7 +49,7 @@ mergeInto(LibraryManager.library, {
     },
     createNode: (parent, name, mode, dev) => {
       if (!FS.isDir(mode) && !FS.isFile(mode) && !FS.isLink(mode)) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       var node = FS.createNode(parent, name, mode);
       node.node_ops = NODEFS.node_ops;
@@ -84,11 +84,11 @@ mergeInto(LibraryManager.library, {
     // This maps the integer permission modes from http://linux.die.net/man/3/open
     // to node.js-specific file open permission strings at http://nodejs.org/api/fs.html#fs_fs_open_path_flags_mode_callback
     flagsForNode: (flags) => {
-      flags &= ~{{{ cDefine('O_PATH') }}}; // Ignore this flag from musl, otherwise node.js fails to open the file.
-      flags &= ~{{{ cDefine('O_NONBLOCK') }}}; // Ignore this flag from musl, otherwise node.js fails to open the file.
-      flags &= ~{{{ cDefine('O_LARGEFILE') }}}; // Ignore this flag from musl, otherwise node.js fails to open the file.
-      flags &= ~{{{ cDefine('O_CLOEXEC') }}}; // Some applications may pass it; it makes no sense for a single process.
-      flags &= ~{{{ cDefine('O_DIRECTORY') }}}; // Node.js doesn't need this passed in, it errors.
+      flags &= ~{{{ cDefs.O_PATH }}}; // Ignore this flag from musl, otherwise node.js fails to open the file.
+      flags &= ~{{{ cDefs.O_NONBLOCK }}}; // Ignore this flag from musl, otherwise node.js fails to open the file.
+      flags &= ~{{{ cDefs.O_LARGEFILE }}}; // Ignore this flag from musl, otherwise node.js fails to open the file.
+      flags &= ~{{{ cDefs.O_CLOEXEC }}}; // Some applications may pass it; it makes no sense for a single process.
+      flags &= ~{{{ cDefs.O_DIRECTORY }}}; // Node.js doesn't need this passed in, it errors.
       var newFlags = 0;
       for (var k in NODEFS.flagsForNodeMap) {
         if (flags & k) {
@@ -97,7 +97,7 @@ mergeInto(LibraryManager.library, {
         }
       }
       if (flags) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       return newFlags;
     },
@@ -233,7 +233,7 @@ mergeInto(LibraryManager.library, {
           if (!e.code) throw e;
           // node under windows can return code 'UNKNOWN' here:
           // https://github.com/emscripten-core/emscripten/issues/15468
-          if (e.code === 'UNKNOWN') throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+          if (e.code === 'UNKNOWN') throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
           throw new FS.ErrnoError(NODEFS.convertNodeCode(e));
         }
       },
@@ -278,9 +278,9 @@ mergeInto(LibraryManager.library, {
       },
       llseek: (stream, offset, whence) => {
         var position = offset;
-        if (whence === {{{ cDefine('SEEK_CUR') }}}) {
+        if (whence === {{{ cDefs.SEEK_CUR }}}) {
           position += stream.position;
-        } else if (whence === {{{ cDefine('SEEK_END') }}}) {
+        } else if (whence === {{{ cDefs.SEEK_END }}}) {
           if (FS.isFile(stream.node.mode)) {
             try {
               var stat = fs.fstatSync(stream.nfd);
@@ -292,14 +292,14 @@ mergeInto(LibraryManager.library, {
         }
 
         if (position < 0) {
-          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+          throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
         }
 
         return position;
       },
       mmap: (stream, length, position, prot, flags) => {
         if (!FS.isFile(stream.node.mode)) {
-          throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
+          throw new FS.ErrnoError({{{ cDefs.ENODEV }}});
         }
 
         var ptr = mmapAlloc(length);

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -76,7 +76,7 @@ mergeInto(LibraryManager.library, {
     ftruncate: function(fd, len) {
       // See https://github.com/nodejs/node/issues/35632
       if (len < 0) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       fs.ftruncateSync.apply(void 0, arguments);
     },
@@ -88,7 +88,7 @@ mergeInto(LibraryManager.library, {
       var pathTruncated = path.split('/').map(function(s) { return s.substr(0, 255); }).join('/');
       var nfd = fs.openSync(pathTruncated, NODEFS.flagsForNode(flags), mode);
       var st = fs.fstatSync(nfd);
-      if (flags & {{{ cDefine('O_DIRECTORY') }}} && !st.isDirectory()) {
+      if (flags & {{{ cDefs.O_DIRECTORY }}} && !st.isDirectory()) {
         fs.closeSync(nfd);
         throw new FS.ErrnoError(ERRNO_CODES.ENOTDIR);
       }
@@ -128,16 +128,16 @@ mergeInto(LibraryManager.library, {
         return VFS.llseek(stream, offset, whence);
       }
       var position = offset;
-      if (whence === {{{ cDefine('SEEK_CUR') }}}) {
+      if (whence === {{{ cDefs.SEEK_CUR }}}) {
         position += stream.position;
-      } else if (whence === {{{ cDefine('SEEK_END') }}}) {
+      } else if (whence === {{{ cDefs.SEEK_END }}}) {
         position += fs.fstatSync(stream.nfd).size;
-      } else if (whence !== {{{ cDefine('SEEK_SET') }}}) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+      } else if (whence !== {{{ cDefs.SEEK_SET }}}) {
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
 
       if (position < 0) {
-        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
       stream.position = position;
       return position;
@@ -159,9 +159,9 @@ mergeInto(LibraryManager.library, {
         // this stream is created by in-memory filesystem
         return VFS.write(stream, buffer, offset, length, position);
       }
-      if (stream.flags & +"{{{ cDefine('O_APPEND') }}}") {
+      if (stream.flags & +"{{{ cDefs.O_APPEND }}}") {
         // seek to the end before writing in append mode
-        FS.llseek(stream, 0, +"{{{ cDefine('SEEK_END') }}}");
+        FS.llseek(stream, 0, +"{{{ cDefs.SEEK_END }}}");
       }
       var seeking = typeof position != 'undefined';
       if (!seeking && stream.seekable) position = stream.position;
@@ -171,7 +171,7 @@ mergeInto(LibraryManager.library, {
       return bytesWritten;
     },
     allocate: function() {
-      throw new FS.ErrnoError({{{ cDefine('EOPNOTSUPP') }}});
+      throw new FS.ErrnoError({{{ cDefs.EOPNOTSUPP }}});
     },
     mmap: function(stream, length, position, prot, flags) {
       if (stream.stream_ops) {
@@ -197,7 +197,7 @@ mergeInto(LibraryManager.library, {
       return 0;
     },
     ioctl: function() {
-      throw new FS.ErrnoError({{{ cDefine('ENOTTY') }}});
+      throw new FS.ErrnoError({{{ cDefs.ENOTTY }}});
     }
   }
 });

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -46,7 +46,7 @@ var LibraryOpenAL = {
     },
     set alcErr(val) {
       // Errors should not be overwritten by later errors until they are cleared by a query.
-      if (this._alcErr === {{{ cDefine('ALC_NO_ERROR') }}} || val === {{{ cDefine('ALC_NO_ERROR') }}}) {
+      if (this._alcErr === {{{ cDefs.ALC_NO_ERROR }}} || val === {{{ cDefs.ALC_NO_ERROR }}}) {
         this._alcErr = val;
       }
     },
@@ -407,7 +407,7 @@ var LibraryOpenAL = {
         }
       }
       // Create a panner if AL_SOURCE_SPATIALIZE_SOFT is set to true, or alternatively if it's set to auto and the source is mono
-      if (src.spatialize === {{{ cDefine('AL_TRUE') }}} || (src.spatialize === 2 /* AL_AUTO_SOFT */ && templateBuf.channels === 1)) {
+      if (src.spatialize === {{{ cDefs.AL_TRUE }}} || (src.spatialize === 2 /* AL_AUTO_SOFT */ && templateBuf.channels === 1)) {
         if (src.panner) {
           return;
         }
@@ -452,7 +452,7 @@ var LibraryOpenAL = {
       // Use the source's distance model if AL_SOURCE_DISTANCE_MODEL is enabled
       var distanceModel = src.context.sourceDistanceModel ? src.distanceModel : src.context.distanceModel;
       switch (distanceModel) {
-      case {{{ cDefine('AL_NONE') }}}:
+      case {{{ cDefs.AL_NONE }}}:
         panner.distanceModel = 'inverse';
         panner.refDistance = 3.40282e38 /* FLT_MAX */;
         break;
@@ -753,17 +753,17 @@ var LibraryOpenAL = {
       }
 
       switch (param) {
-      case {{{ cDefine('AL_DOPPLER_FACTOR') }}}:
+      case {{{ cDefs.AL_DOPPLER_FACTOR }}}:
         return AL.currentCtx.dopplerFactor;
-      case {{{ cDefine('AL_SPEED_OF_SOUND') }}}:
+      case {{{ cDefs.AL_SPEED_OF_SOUND }}}:
         return AL.currentCtx.speedOfSound;
-      case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+      case {{{ cDefs.AL_DISTANCE_MODEL }}}:
         return AL.currentCtx.distanceModel;
       default:
 #if OPENAL_DEBUG
         dbg(funcname + '() param ' + ptrToString(param) + ' is unknown or not implemented');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
         return null;
       }
     },
@@ -777,33 +777,33 @@ var LibraryOpenAL = {
       }
 
       switch (param) {
-      case {{{ cDefine('AL_DOPPLER_FACTOR') }}}:
+      case {{{ cDefs.AL_DOPPLER_FACTOR }}}:
         if (!Number.isFinite(value) || value < 0.0) { // Strictly negative values are disallowed
 #if OPENAL_DEBUG
           dbg(funcname + '() value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
         AL.currentCtx.dopplerFactor = value;
         AL.updateListenerSpace(AL.currentCtx);
         break;
-      case {{{ cDefine('AL_SPEED_OF_SOUND') }}}:
+      case {{{ cDefs.AL_SPEED_OF_SOUND }}}:
         if (!Number.isFinite(value) || value <= 0.0) { // Negative or zero values are disallowed
 #if OPENAL_DEBUG
           dbg(funcname + '() value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
         AL.currentCtx.speedOfSound = value;
         AL.updateListenerSpace(AL.currentCtx);
         break;
-      case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+      case {{{ cDefs.AL_DISTANCE_MODEL }}}:
         switch (value) {
-        case {{{ cDefine('AL_NONE') }}}:
+        case {{{ cDefs.AL_NONE }}}:
         case 0xd001 /* AL_INVERSE_DISTANCE */:
         case 0xd002 /* AL_INVERSE_DISTANCE_CLAMPED */:
         case 0xd003 /* AL_LINEAR_DISTANCE */:
@@ -817,7 +817,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
         break;
@@ -825,7 +825,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg(funcname + '() param ' + ptrToString(param) + ' is unknown or not implemented');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
         return;
       }
     },
@@ -839,19 +839,19 @@ var LibraryOpenAL = {
       }
 
       switch (param) {
-      case {{{ cDefine('AL_POSITION') }}}:
+      case {{{ cDefs.AL_POSITION }}}:
         return AL.currentCtx.listener.position;
-      case {{{ cDefine('AL_VELOCITY') }}}:
+      case {{{ cDefs.AL_VELOCITY }}}:
         return AL.currentCtx.listener.velocity;
-      case {{{ cDefine('AL_ORIENTATION') }}}:
+      case {{{ cDefs.AL_ORIENTATION }}}:
         return AL.currentCtx.listener.direction.concat(AL.currentCtx.listener.up);
-      case {{{ cDefine('AL_GAIN') }}}:
+      case {{{ cDefs.AL_GAIN }}}:
         return AL.currentCtx.gain.gain.value;
       default:
 #if OPENAL_DEBUG
         dbg(funcname + '() param ' + ptrToString(param) + ' is unknown or not implemented');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
         return null;
       }
     },
@@ -867,18 +867,18 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg(funcname + '(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
         return;
       }
 
       var listener = AL.currentCtx.listener;
       switch (param) {
-      case {{{ cDefine('AL_POSITION') }}}:
+      case {{{ cDefs.AL_POSITION }}}:
         if (!Number.isFinite(value[0]) || !Number.isFinite(value[1]) || !Number.isFinite(value[2])) {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_POSITION value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
@@ -887,12 +887,12 @@ var LibraryOpenAL = {
         listener.position[2] = value[2];
         AL.updateListenerSpace(AL.currentCtx);
         break;
-      case {{{ cDefine('AL_VELOCITY') }}}:
+      case {{{ cDefs.AL_VELOCITY }}}:
         if (!Number.isFinite(value[0]) || !Number.isFinite(value[1]) || !Number.isFinite(value[2])) {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_VELOCITY value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
@@ -901,25 +901,25 @@ var LibraryOpenAL = {
         listener.velocity[2] = value[2];
         AL.updateListenerSpace(AL.currentCtx);
         break;
-      case {{{ cDefine('AL_GAIN') }}}:
+      case {{{ cDefs.AL_GAIN }}}:
         if (!Number.isFinite(value) || value < 0.0) {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_GAIN value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
         AL.currentCtx.gain.gain.value = value;
         break;
-      case {{{ cDefine('AL_ORIENTATION') }}}:
+      case {{{ cDefs.AL_ORIENTATION }}}:
         if (!Number.isFinite(value[0]) || !Number.isFinite(value[1]) || !Number.isFinite(value[2])
           || !Number.isFinite(value[3]) || !Number.isFinite(value[4]) || !Number.isFinite(value[5])
         ) {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_ORIENTATION value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
@@ -935,7 +935,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg(funcname + '() param ' + ptrToString(param) + ' is unknown or not implemented');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
         return;
       }
     },
@@ -952,7 +952,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg(funcname + '() called with an invalid buffer');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
         return;
       }
 
@@ -977,7 +977,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg(funcname + '() param ' + ptrToString(param) + ' is unknown or not implemented');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
         return null;
       }
     },
@@ -994,14 +994,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg(funcname + '() called with an invalid buffer');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
         return;
       }
       if (value === null) {
 #if OPENAL_DEBUG
         dbg(funcname + '(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
         return;
       }
 
@@ -1011,7 +1011,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_SIZE value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
@@ -1022,14 +1022,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_LOOP_POINTS_SOFT value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
         if (buf.refCount > 0) {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_LOOP_POINTS_SOFT set on bound buffer');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_OPERATION') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_OPERATION }}};
           return;
         }
 
@@ -1042,7 +1042,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg(funcname + '() param ' + ptrToString(param) + ' is unknown or not implemented');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
         return;
       }
     },
@@ -1059,7 +1059,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg(funcname + '() called with an invalid source');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
         return null;
       }
 
@@ -1072,11 +1072,11 @@ var LibraryOpenAL = {
         return src.coneOuterAngle;
       case 0x1003 /* AL_PITCH */:
         return src.pitch;
-      case {{{ cDefine('AL_POSITION') }}}:
+      case {{{ cDefs.AL_POSITION }}}:
         return src.position;
-      case {{{ cDefine('AL_DIRECTION') }}}:
+      case {{{ cDefs.AL_DIRECTION }}}:
         return src.direction;
-      case {{{ cDefine('AL_VELOCITY') }}}:
+      case {{{ cDefs.AL_VELOCITY }}}:
         return src.velocity;
       case 0x1007 /* AL_LOOPING */:
         return src.looping;
@@ -1085,7 +1085,7 @@ var LibraryOpenAL = {
           return src.bufQueue[0].id;
         }
         return 0;
-      case {{{ cDefine('AL_GAIN') }}}:
+      case {{{ cDefs.AL_GAIN }}}:
         return src.gain.gain.value;
        case 0x100D /* AL_MIN_GAIN */:
         return src.minGain;
@@ -1147,13 +1147,13 @@ var LibraryOpenAL = {
         return length;
       case 0x200B /* AL_SEC_LENGTH_SOFT */:
         return AL.sourceDuration(src);
-      case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+      case {{{ cDefs.AL_DISTANCE_MODEL }}}:
         return src.distanceModel;
       default:
 #if OPENAL_DEBUG
         dbg(funcname + '() param ' + ptrToString(param) + ' is unknown or not implemented');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
         return null;
       }
     },
@@ -1170,30 +1170,30 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg('alSourcef() called with an invalid source');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
         return;
       }
       if (value === null) {
 #if OPENAL_DEBUG
         dbg(funcname + '(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
         return;
       }
 
       switch (param) {
       case 0x202 /* AL_SOURCE_RELATIVE */:
-        if (value === {{{ cDefine('AL_TRUE') }}}) {
+        if (value === {{{ cDefs.AL_TRUE }}}) {
           src.relative = true;
           AL.updateSourceSpace(src);
-        } else if (value === {{{ cDefine('AL_FALSE') }}}) {
+        } else if (value === {{{ cDefs.AL_FALSE }}}) {
           src.relative = false;
           AL.updateSourceSpace(src);
         } else {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_SOURCE_RELATIVE value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
         break;
@@ -1202,7 +1202,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_CONE_INNER_ANGLE value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
@@ -1216,7 +1216,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_CONE_OUTER_ANGLE value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
@@ -1230,7 +1230,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_PITCH value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
@@ -1241,12 +1241,12 @@ var LibraryOpenAL = {
         src.pitch = value;
         AL.updateSourceRate(src);
         break;
-      case {{{ cDefine('AL_POSITION') }}}:
+      case {{{ cDefs.AL_POSITION }}}:
         if (!Number.isFinite(value[0]) || !Number.isFinite(value[1]) || !Number.isFinite(value[2])) {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_POSITION value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
@@ -1255,12 +1255,12 @@ var LibraryOpenAL = {
         src.position[2] = value[2];
         AL.updateSourceSpace(src);
         break;
-      case {{{ cDefine('AL_DIRECTION') }}}:
+      case {{{ cDefs.AL_DIRECTION }}}:
         if (!Number.isFinite(value[0]) || !Number.isFinite(value[1]) || !Number.isFinite(value[2])) {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_DIRECTION value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
@@ -1269,12 +1269,12 @@ var LibraryOpenAL = {
         src.direction[2] = value[2];
         AL.updateSourceSpace(src);
         break;
-      case {{{ cDefine('AL_VELOCITY') }}}:
+      case {{{ cDefs.AL_VELOCITY }}}:
         if (!Number.isFinite(value[0]) || !Number.isFinite(value[1]) || !Number.isFinite(value[2])) {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_VELOCITY value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
@@ -1284,7 +1284,7 @@ var LibraryOpenAL = {
         AL.updateSourceSpace(src);
         break;
       case 0x1007 /* AL_LOOPING */:
-        if (value === {{{ cDefine('AL_TRUE') }}}) {
+        if (value === {{{ cDefs.AL_TRUE }}}) {
           src.looping = true;
           AL.updateSourceTime(src);
           if (src.type === 0x1028 /* AL_STATIC */ && src.audioQueue.length > 0) {
@@ -1292,7 +1292,7 @@ var LibraryOpenAL = {
             audioSrc.loop = true;
             audioSrc._duration = Number.POSITIVE_INFINITY;
           }
-        } else if (value === {{{ cDefine('AL_FALSE') }}}) {
+        } else if (value === {{{ cDefs.AL_FALSE }}}) {
           src.looping = false;
           var currentTime = AL.updateSourceTime(src);
           if (src.type === 0x1028 /* AL_STATIC */ && src.audioQueue.length > 0) {
@@ -1305,7 +1305,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_LOOPING value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
         break;
@@ -1314,7 +1314,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '(AL_BUFFER) called while source is playing or paused');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_OPERATION') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_OPERATION }}};
           return;
         }
 
@@ -1333,7 +1333,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
             dbg('alSourcei(AL_BUFFER) called with an invalid buffer');
 #endif
-            AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+            AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
             return;
           }
 
@@ -1351,12 +1351,12 @@ var LibraryOpenAL = {
         AL.initSourcePanner(src);
         AL.scheduleSourceAudio(src);
         break;
-      case {{{ cDefine('AL_GAIN') }}}:
+      case {{{ cDefs.AL_GAIN }}}:
         if (!Number.isFinite(value) || value < 0.0) {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_GAIN value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
         src.gain.gain.value = value;
@@ -1366,7 +1366,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_MIN_GAIN value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 #if OPENAL_DEBUG
@@ -1379,7 +1379,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_MAX_GAIN value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 #if OPENAL_DEBUG
@@ -1392,7 +1392,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_REFERENCE_DISTANCE value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
         src.refDistance = value;
@@ -1405,7 +1405,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_ROLLOFF_FACTOR value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
         src.rolloffFactor = value;
@@ -1418,7 +1418,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_CORE_OUTER_GAIN value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
         src.coneOuterGain = value;
@@ -1431,7 +1431,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_MAX_DISTANCE value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
         src.maxDistance = value;
@@ -1444,7 +1444,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_SEC_OFFSET value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
@@ -1466,7 +1466,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_SAMPLE_OFFSET value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
@@ -1489,18 +1489,18 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_BYTE_OFFSET value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
         AL.sourceSeek(src, value);
         break;
       case 0x1214 /* AL_SOURCE_SPATIALIZE_SOFT */:
-        if (value !== {{{ cDefine('AL_FALSE') }}} && value !== {{{ cDefine('AL_TRUE') }}} && value !== 2 /* AL_AUTO_SOFT */) {
+        if (value !== {{{ cDefs.AL_FALSE }}} && value !== {{{ cDefs.AL_TRUE }}} && value !== 2 /* AL_AUTO_SOFT */) {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_SOURCE_SPATIALIZE_SOFT value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
 
@@ -1513,11 +1513,11 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg(funcname + '() param AL_*_LENGTH_SOFT is read only');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_OPERATION') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_OPERATION }}};
         break;
-      case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+      case {{{ cDefs.AL_DISTANCE_MODEL }}}:
         switch (value) {
-        case {{{ cDefine('AL_NONE') }}}:
+        case {{{ cDefs.AL_NONE }}}:
         case 0xd001 /* AL_INVERSE_DISTANCE */:
         case 0xd002 /* AL_INVERSE_DISTANCE_CLAMPED */:
         case 0xd003 /* AL_LINEAR_DISTANCE */:
@@ -1533,7 +1533,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
           dbg(funcname + '() param AL_DISTANCE_MODEL value ' + value + ' is out of range');
 #endif
-          AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
           return;
         }
         break;
@@ -1541,7 +1541,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg(funcname + '() param ' + ptrToString(param) + ' is unknown or not implemented');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
         return;
       }
     },
@@ -1567,7 +1567,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg(funcname+'() on a NULL device is an error');
 #endif
-        AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+        AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
         return null;
       }
       var c = AL.captures[deviceId];
@@ -1575,7 +1575,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg(funcname+'() on an invalid device');
 #endif
-        AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+        AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
         return null;
       }
       var err = c.mediaStreamError;
@@ -1593,7 +1593,7 @@ var LibraryOpenAL = {
           break;
         }
 #endif
-        AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+        AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
         return null;
       }
       return c;
@@ -1640,7 +1640,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alcCaptureOpenDevice() with negative bufferSize');
 #endif
-      AL.alcErr = {{{ cDefine('ALC_INVALID_VALUE') }}};
+      AL.alcErr = {{{ cDefs.ALC_INVALID_VALUE }}};
       return 0;
     }
 
@@ -1695,7 +1695,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alcCaptureOpenDevice() with unsupported format ' + format);
 #endif
-      AL.alcErr = {{{ cDefine('ALC_INVALID_VALUE') }}};
+      AL.alcErr = {{{ cDefs.ALC_INVALID_VALUE }}};
       return 0;
     }
 
@@ -1999,7 +1999,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alcCaptureSamples() with invalid bufferSize');
 #endif
-      AL.alcErr = {{{ cDefine('ALC_INVALID_VALUE') }}};
+      AL.alcErr = {{{ cDefs.ALC_INVALID_VALUE }}};
       return;
     }
 
@@ -2087,12 +2087,12 @@ var LibraryOpenAL = {
   alcCloseDevice__sig: 'ip',
   alcCloseDevice: function(deviceId) {
     if (!(deviceId in AL.deviceRefCounts) || AL.deviceRefCounts[deviceId] > 0) {
-      return {{{ cDefine('ALC_FALSE') }}};
+      return {{{ cDefs.ALC_FALSE }}};
     }
 
     delete AL.deviceRefCounts[deviceId];
     AL.freeIds.push(deviceId);
-    return {{{ cDefine('ALC_TRUE') }}};
+    return {{{ cDefs.ALC_TRUE }}};
   },
 
   alcCreateContext__deps: ['$autoResumeAudioContext'],
@@ -2137,10 +2137,10 @@ var LibraryOpenAL = {
           break
         case 0x1992 /* ALC_HRTF_SOFT */:
           switch (val) {
-            case {{{ cDefine('ALC_FALSE') }}}:
+            case {{{ cDefs.ALC_FALSE }}}:
               hrtf = false;
               break;
-            case {{{ cDefine('ALC_TRUE') }}}:
+            case {{{ cDefs.ALC_TRUE }}}:
               hrtf = true;
               break;
             case 2 /* ALC_DONT_CARE_SOFT */:
@@ -2149,7 +2149,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
               dbg('Unsupported ALC_HRTF_SOFT mode ' + val);
 #endif
-              AL.alcErr = {{{ cDefine('ALC_INVALID_VALUE') }}};
+              AL.alcErr = {{{ cDefs.ALC_INVALID_VALUE }}};
               return 0;
           }
           break;
@@ -2158,7 +2158,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
             dbg('Invalid ALC_HRTF_ID_SOFT index ' + val);
 #endif
-            AL.alcErr = {{{ cDefine('ALC_INVALID_VALUE') }}};
+            AL.alcErr = {{{ cDefs.ALC_INVALID_VALUE }}};
             return 0;
           }
           break;
@@ -2229,7 +2229,7 @@ var LibraryOpenAL = {
       },
       set err(val) {
         // Errors should not be overwritten by later errors until they are cleared by a query.
-        if (this._err === {{{ cDefine('AL_NO_ERROR') }}} || val === {{{ cDefine('AL_NO_ERROR') }}}) {
+        if (this._err === {{{ cDefs.AL_NO_ERROR }}} || val === {{{ cDefs.AL_NO_ERROR }}}) {
           this._err = val;
         }
       }
@@ -2280,7 +2280,7 @@ var LibraryOpenAL = {
   alcGetError__sig: 'ip',
   alcGetError: function(deviceId) {
     var err = AL.alcErr;
-    AL.alcErr = {{{ cDefine('ALC_NO_ERROR') }}};
+    AL.alcErr = {{{ cDefs.ALC_NO_ERROR }}};
     return err;
   },
 
@@ -2301,7 +2301,7 @@ var LibraryOpenAL = {
     } else {
       AL.currentCtx = AL.contexts[contextId];
     }
-    return {{{ cDefine('ALC_TRUE') }}};
+    return {{{ cDefs.ALC_TRUE }}};
   },
 
   alcGetContextsDevice__proxy: 'sync',
@@ -2341,7 +2341,7 @@ var LibraryOpenAL = {
       // this function, sadly.
       return 0;
     } else if (!pEnumName) {
-      AL.alcErr = {{{ cDefine('ALC_INVALID_VALUE') }}};
+      AL.alcErr = {{{ cDefs.ALC_INVALID_VALUE }}};
       return 0;
     }
     var name = UTF8ToString(pEnumName);
@@ -2387,8 +2387,8 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('No value for `' + pEnumName + '` is known by alcGetEnumValue()');
 #endif
-      AL.alcErr = {{{ cDefine('ALC_INVALID_VALUE') }}};
-      return {{{ cDefine('AL_NONE') }}};
+      AL.alcErr = {{{ cDefs.ALC_INVALID_VALUE }}};
+      return {{{ cDefs.AL_NONE }}};
     }
   },
 
@@ -2402,19 +2402,19 @@ var LibraryOpenAL = {
 
     var ret;
     switch (param) {
-    case {{{ cDefine('ALC_NO_ERROR') }}}:
+    case {{{ cDefs.ALC_NO_ERROR }}}:
       ret = 'No Error';
       break;
-    case {{{ cDefine('ALC_INVALID_DEVICE') }}}:
+    case {{{ cDefs.ALC_INVALID_DEVICE }}}:
       ret = 'Invalid Device';
       break;
     case 0xA002 /* ALC_INVALID_CONTEXT */:
       ret = 'Invalid Context';
       break;
-    case {{{ cDefine('ALC_INVALID_ENUM') }}}:
+    case {{{ cDefs.ALC_INVALID_ENUM }}}:
       ret = 'Invalid Enum';
       break;
-    case {{{ cDefine('ALC_INVALID_VALUE') }}}:
+    case {{{ cDefs.ALC_INVALID_VALUE }}}:
       ret = 'Invalid Value';
       break;
     case 0xA005 /* ALC_OUT_OF_MEMORY */:
@@ -2452,7 +2452,7 @@ var LibraryOpenAL = {
       break;
     case 0x1006 /* ALC_EXTENSIONS */:
       if (!deviceId) {
-        AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+        AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
         return 0;
       }
 
@@ -2464,7 +2464,7 @@ var LibraryOpenAL = {
       ret = ret.trim();
       break;
     default:
-      AL.alcErr = {{{ cDefine('ALC_INVALID_ENUM') }}};
+      AL.alcErr = {{{ cDefs.ALC_INVALID_ENUM }}};
       return 0;
     }
 
@@ -2490,7 +2490,7 @@ var LibraryOpenAL = {
       break;
     case 0x1002 /* ALC_ATTRIBUTES_SIZE */:
       if (!(deviceId in AL.deviceRefCounts)) {
-        AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+        AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
         return;
       }
       if (!AL.currentCtx) {
@@ -2502,7 +2502,7 @@ var LibraryOpenAL = {
       break;
     case 0x1003 /* ALC_ALL_ATTRIBUTES */:
       if (!(deviceId in AL.deviceRefCounts)) {
-        AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+        AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
         return;
       }
       if (!AL.currentCtx) {
@@ -2516,7 +2516,7 @@ var LibraryOpenAL = {
       break;
     case 0x1007 /* ALC_FREQUENCY */:
       if (!(deviceId in AL.deviceRefCounts)) {
-        AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+        AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
         return;
       }
       if (!AL.currentCtx) {
@@ -2529,7 +2529,7 @@ var LibraryOpenAL = {
     case 0x1010 /* ALC_MONO_SOURCES */:
     case 0x1011 /* ALC_STEREO_SOURCES */:
       if (!(deviceId in AL.deviceRefCounts)) {
-        AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+        AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
         return;
       }
       if (!AL.currentCtx) {
@@ -2542,7 +2542,7 @@ var LibraryOpenAL = {
     case 0x1992 /* ALC_HRTF_SOFT */:
     case 0x1993 /* ALC_HRTF_STATUS_SOFT */:
       if (!(deviceId in AL.deviceRefCounts)) {
-        AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+        AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
         return;
       }
 
@@ -2557,14 +2557,14 @@ var LibraryOpenAL = {
       break;
     case 0x1994 /* ALC_NUM_HRTF_SPECIFIERS_SOFT */:
       if (!(deviceId in AL.deviceRefCounts)) {
-        AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+        AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
         return;
       }
       {{{ makeSetValue('pValues', '0', '1', 'i32') }}};
       break;
     case 0x20003 /* ALC_MAX_AUXILIARY_SENDS */:
       if (!(deviceId in AL.deviceRefCounts)) {
-        AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+        AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
         return;
       }
       if (!AL.currentCtx) {
@@ -2588,7 +2588,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alcGetIntegerv() with param ' + ptrToString(param) + ' not implemented yet');
 #endif
-      AL.alcErr = {{{ cDefine('ALC_INVALID_ENUM') }}};
+      AL.alcErr = {{{ cDefs.ALC_INVALID_ENUM }}};
       return;
     }
   },
@@ -2600,7 +2600,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alcDevicePauseSOFT() called with an invalid device');
 #endif
-      AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+      AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
       return;
     }
 
@@ -2628,7 +2628,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alcDeviceResumeSOFT() called with an invalid device');
 #endif
-      AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+      AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
       return;
     }
 
@@ -2656,7 +2656,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alcGetStringiSOFT() called with an invalid device');
 #endif
-      AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
+      AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
       return 0;
     }
 
@@ -2673,7 +2673,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg('alcGetStringiSOFT() with param ALC_HRTF_SPECIFIER_SOFT index ' + index + ' is out of range');
 #endif
-        AL.alcErr = {{{ cDefine('ALC_INVALID_VALUE') }}};
+        AL.alcErr = {{{ cDefs.ALC_INVALID_VALUE }}};
         return 0;
       }
       break;
@@ -2682,7 +2682,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg('alcGetStringiSOFT() with param ' + ptrToString(param) + ' not implemented yet');
 #endif
-        AL.alcErr = {{{ cDefine('ALC_INVALID_ENUM') }}};
+        AL.alcErr = {{{ cDefs.ALC_INVALID_ENUM }}};
         return 0;
       }
       return _alcGetString(deviceId, param);
@@ -2700,8 +2700,8 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alcResetDeviceSOFT() called with an invalid device');
 #endif
-      AL.alcErr = {{{ cDefine('ALC_INVALID_DEVICE') }}};
-      return {{{ cDefine('ALC_FALSE') }}};
+      AL.alcErr = {{{ cDefs.ALC_INVALID_DEVICE }}};
+      return {{{ cDefs.ALC_FALSE }}};
     }
 
     var hrtf = null;
@@ -2718,9 +2718,9 @@ var LibraryOpenAL = {
 
         switch (attr) {
         case 0x1992 /* ALC_HRTF_SOFT */:
-          if (val === {{{ cDefine('ALC_TRUE') }}}) {
+          if (val === {{{ cDefs.ALC_TRUE }}}) {
             hrtf = true;
-          } else if (val === {{{ cDefine('ALC_FALSE') }}}) {
+          } else if (val === {{{ cDefs.ALC_FALSE }}}) {
             hrtf = false;
           }
           break;
@@ -2739,7 +2739,7 @@ var LibraryOpenAL = {
       }
     }
 
-    return {{{ cDefine('ALC_TRUE') }}};
+    return {{{ cDefs.ALC_TRUE }}};
   },
 
   // ***************************************************************************
@@ -2799,7 +2799,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg('alDeleteBuffers() called with an invalid buffer');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
         return;
       }
 
@@ -2808,7 +2808,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg('alDeleteBuffers() called with a used buffer');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_OPERATION') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_OPERATION }}};
         return;
       }
     }
@@ -2893,7 +2893,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg('alDeleteSources() called with an invalid source');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
         return;
       }
     }
@@ -2915,11 +2915,11 @@ var LibraryOpenAL = {
   alGetError__sig: 'i',
   alGetError: function() {
     if (!AL.currentCtx) {
-      return {{{ cDefine('AL_INVALID_OPERATION') }}};
+      return {{{ cDefs.AL_INVALID_OPERATION }}};
     }
     // Reset error on get.
     var err = AL.currentCtx.err;
-    AL.currentCtx.err = {{{ cDefine('AL_NO_ERROR') }}};
+    AL.currentCtx.err = {{{ cDefs.AL_NO_ERROR }}};
     return err;
   },
 
@@ -2945,8 +2945,8 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetEnumValue() called with null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
-      return {{{ cDefine('AL_NONE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
+      return {{{ cDefs.AL_NONE }}};
     }
     var name = UTF8ToString(pEnumName);
 
@@ -3038,7 +3038,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('No value for `' + name + '` is known by alGetEnumValue()');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return 0;
     }
   },
@@ -3053,19 +3053,19 @@ var LibraryOpenAL = {
 
     var ret;
     switch (param) {
-    case {{{ cDefine('AL_NO_ERROR') }}}:
+    case {{{ cDefs.AL_NO_ERROR }}}:
       ret = 'No Error';
       break;
-    case {{{ cDefine('AL_INVALID_NAME') }}}:
+    case {{{ cDefs.AL_INVALID_NAME }}}:
       ret = 'Invalid Name';
       break;
-    case {{{ cDefine('AL_INVALID_ENUM') }}}:
+    case {{{ cDefs.AL_INVALID_ENUM }}}:
       ret = 'Invalid Enum';
       break;
-    case {{{ cDefine('AL_INVALID_VALUE') }}}:
+    case {{{ cDefs.AL_INVALID_VALUE }}}:
       ret = 'Invalid Value';
       break;
-    case {{{ cDefine('AL_INVALID_OPERATION') }}}:
+    case {{{ cDefs.AL_INVALID_OPERATION }}}:
       ret = 'Invalid Operation';
       break;
     case 0xA005 /* AL_OUT_OF_MEMORY */:
@@ -3090,7 +3090,7 @@ var LibraryOpenAL = {
       break;
     default:
       if (AL.currentCtx) {
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       } else {
   #if OPENAL_DEBUG
         dbg('alGetString() called without a valid context');
@@ -3122,7 +3122,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alEnable() with param ' + ptrToString(param) + ' not implemented yet');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -3145,7 +3145,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alDisable() with param ' + ptrToString(param) + ' not implemented yet');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -3161,12 +3161,12 @@ var LibraryOpenAL = {
     }
     switch (param) {
     case 'AL_SOURCE_DISTANCE_MODEL':
-      return AL.currentCtx.sourceDistanceModel ? {{{ cDefine('AL_FALSE') }}} : {{{ cDefine('AL_TRUE') }}};
+      return AL.currentCtx.sourceDistanceModel ? {{{ cDefs.AL_FALSE }}} : {{{ cDefs.AL_TRUE }}};
     default:
 #if OPENAL_DEBUG
       dbg('alIsEnabled() with param ' + ptrToString(param) + ' not implemented yet');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return 0;
     }
   },
@@ -3180,15 +3180,15 @@ var LibraryOpenAL = {
     }
 
     switch (param) {
-    case {{{ cDefine('AL_DOPPLER_FACTOR') }}}:
-    case {{{ cDefine('AL_SPEED_OF_SOUND') }}}:
-    case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+    case {{{ cDefs.AL_DOPPLER_FACTOR }}}:
+    case {{{ cDefs.AL_SPEED_OF_SOUND }}}:
+    case {{{ cDefs.AL_DISTANCE_MODEL }}}:
       return val;
     default:
 #if OPENAL_DEBUG
       dbg('alGetDouble(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return 0.0;
     }
   },
@@ -3203,16 +3203,16 @@ var LibraryOpenAL = {
     }
 
     switch (param) {
-    case {{{ cDefine('AL_DOPPLER_FACTOR') }}}:
-    case {{{ cDefine('AL_SPEED_OF_SOUND') }}}:
-    case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+    case {{{ cDefs.AL_DOPPLER_FACTOR }}}:
+    case {{{ cDefs.AL_SPEED_OF_SOUND }}}:
+    case {{{ cDefs.AL_DISTANCE_MODEL }}}:
       {{{ makeSetValue('pValues', '0', 'val', 'double') }}};
       break;
     default:
 #if OPENAL_DEBUG
       dbg('alGetDoublev(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -3226,9 +3226,9 @@ var LibraryOpenAL = {
     }
 
     switch (param) {
-    case {{{ cDefine('AL_DOPPLER_FACTOR') }}}:
-    case {{{ cDefine('AL_SPEED_OF_SOUND') }}}:
-    case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+    case {{{ cDefs.AL_DOPPLER_FACTOR }}}:
+    case {{{ cDefs.AL_SPEED_OF_SOUND }}}:
+    case {{{ cDefs.AL_DISTANCE_MODEL }}}:
       return val;
     default:
 #if OPENAL_DEBUG
@@ -3248,16 +3248,16 @@ var LibraryOpenAL = {
     }
 
     switch (param) {
-    case {{{ cDefine('AL_DOPPLER_FACTOR') }}}:
-    case {{{ cDefine('AL_SPEED_OF_SOUND') }}}:
-    case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+    case {{{ cDefs.AL_DOPPLER_FACTOR }}}:
+    case {{{ cDefs.AL_SPEED_OF_SOUND }}}:
+    case {{{ cDefs.AL_DISTANCE_MODEL }}}:
       {{{ makeSetValue('pValues', '0', 'val', 'float') }}};
       break;
     default:
 #if OPENAL_DEBUG
       dbg('alGetFloatv(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -3271,15 +3271,15 @@ var LibraryOpenAL = {
     }
 
     switch (param) {
-    case {{{ cDefine('AL_DOPPLER_FACTOR') }}}:
-    case {{{ cDefine('AL_SPEED_OF_SOUND') }}}:
-    case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+    case {{{ cDefs.AL_DOPPLER_FACTOR }}}:
+    case {{{ cDefs.AL_SPEED_OF_SOUND }}}:
+    case {{{ cDefs.AL_DISTANCE_MODEL }}}:
       return val;
     default:
 #if OPENAL_DEBUG
       dbg('alGetInteger(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return 0;
     }
   },
@@ -3294,16 +3294,16 @@ var LibraryOpenAL = {
     }
 
     switch (param) {
-    case {{{ cDefine('AL_DOPPLER_FACTOR') }}}:
-    case {{{ cDefine('AL_SPEED_OF_SOUND') }}}:
-    case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+    case {{{ cDefs.AL_DOPPLER_FACTOR }}}:
+    case {{{ cDefs.AL_SPEED_OF_SOUND }}}:
+    case {{{ cDefs.AL_DISTANCE_MODEL }}}:
       {{{ makeSetValue('pValues', '0', 'val', 'i32') }}};
       break;
     default:
 #if OPENAL_DEBUG
       dbg('alGetIntegerv(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -3313,20 +3313,20 @@ var LibraryOpenAL = {
   alGetBoolean: function(param) {
     var val = AL.getGlobalParam('alGetBoolean', param);
     if (val === null) {
-      return {{{ cDefine('AL_FALSE') }}};
+      return {{{ cDefs.AL_FALSE }}};
     }
 
     switch (param) {
-    case {{{ cDefine('AL_DOPPLER_FACTOR') }}}:
-    case {{{ cDefine('AL_SPEED_OF_SOUND') }}}:
-    case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
-      return val !== 0 ? {{{ cDefine('AL_TRUE') }}} : {{{ cDefine('AL_FALSE') }}};
+    case {{{ cDefs.AL_DOPPLER_FACTOR }}}:
+    case {{{ cDefs.AL_SPEED_OF_SOUND }}}:
+    case {{{ cDefs.AL_DISTANCE_MODEL }}}:
+      return val !== 0 ? {{{ cDefs.AL_TRUE }}} : {{{ cDefs.AL_FALSE }}};
     default:
 #if OPENAL_DEBUG
       dbg('alGetBoolean(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
-      return {{{ cDefine('AL_FALSE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
+      return {{{ cDefs.AL_FALSE }}};
     }
   },
 
@@ -3340,16 +3340,16 @@ var LibraryOpenAL = {
     }
 
     switch (param) {
-    case {{{ cDefine('AL_DOPPLER_FACTOR') }}}:
-    case {{{ cDefine('AL_SPEED_OF_SOUND') }}}:
-    case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+    case {{{ cDefs.AL_DOPPLER_FACTOR }}}:
+    case {{{ cDefs.AL_SPEED_OF_SOUND }}}:
+    case {{{ cDefs.AL_DISTANCE_MODEL }}}:
       {{{ makeSetValue('pValues', '0', 'val', 'i8') }}};
       break;
     default:
 #if OPENAL_DEBUG
       dbg('alGetBooleanv(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -3357,19 +3357,19 @@ var LibraryOpenAL = {
   alDistanceModel__proxy: 'sync',
   alDistanceModel__sig: 'vi',
   alDistanceModel: function(model) {
-    AL.setGlobalParam('alDistanceModel', {{{ cDefine('AL_DISTANCE_MODEL') }}}, model);
+    AL.setGlobalParam('alDistanceModel', {{{ cDefs.AL_DISTANCE_MODEL }}}, model);
   },
 
   alSpeedOfSound__proxy: 'sync',
   alSpeedOfSound__sig: 'vf',
   alSpeedOfSound: function(value) {
-    AL.setGlobalParam('alSpeedOfSound', {{{ cDefine('AL_SPEED_OF_SOUND') }}}, value);
+    AL.setGlobalParam('alSpeedOfSound', {{{ cDefs.AL_SPEED_OF_SOUND }}}, value);
   },
 
   alDopplerFactor__proxy: 'sync',
   alDopplerFactor__sig: 'vf',
   alDopplerFactor: function(value) {
-    AL.setGlobalParam('alDopplerFactor', {{{ cDefine('AL_DOPPLER_FACTOR') }}}, value);
+    AL.setGlobalParam('alDopplerFactor', {{{ cDefs.AL_DOPPLER_FACTOR }}}, value);
   },
 
   // http://openal.996291.n3.nabble.com/alSpeedOfSound-or-alDopperVelocity-tp1960.html
@@ -3387,7 +3387,7 @@ var LibraryOpenAL = {
       return;
     }
     if (value <= 0) { // Negative or zero values are disallowed
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
   },
@@ -3407,19 +3407,19 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetListenerf() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
     switch (param) {
-    case {{{ cDefine('AL_GAIN') }}}:
+    case {{{ cDefs.AL_GAIN }}}:
       {{{ makeSetValue('pValue', '0', 'val', 'float') }}};
       break;
     default:
 #if OPENAL_DEBUG
       dbg('alGetListenerf(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -3435,13 +3435,13 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetListener3f() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
     switch (param) {
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       {{{ makeSetValue('pValue0', '0', 'val[0]', 'float') }}};
       {{{ makeSetValue('pValue1', '0', 'val[1]', 'float') }}};
       {{{ makeSetValue('pValue2', '0', 'val[2]', 'float') }}};
@@ -3450,7 +3450,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetListener3f(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -3466,18 +3466,18 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetListenerfv() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
     switch (param) {
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       {{{ makeSetValue('pValues', '0', 'val[0]', 'float') }}};
       {{{ makeSetValue('pValues', '4', 'val[1]', 'float') }}};
       {{{ makeSetValue('pValues', '8', 'val[2]', 'float') }}};
       break;
-    case {{{ cDefine('AL_ORIENTATION') }}}:
+    case {{{ cDefs.AL_ORIENTATION }}}:
       {{{ makeSetValue('pValues', '0', 'val[0]', 'float') }}};
       {{{ makeSetValue('pValues', '4', 'val[1]', 'float') }}};
       {{{ makeSetValue('pValues', '8', 'val[2]', 'float') }}};
@@ -3489,7 +3489,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetListenerfv(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -3505,14 +3505,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetListeneri() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
 #if OPENAL_DEBUG
     dbg('alGetListeneri(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-    AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+    AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
   },
 
   alGetListener3i__proxy: 'sync',
@@ -3526,13 +3526,13 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetListener3i() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
     switch (param) {
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       {{{ makeSetValue('pValue0', '0', 'val[0]', 'i32') }}};
       {{{ makeSetValue('pValue1', '0', 'val[1]', 'i32') }}};
       {{{ makeSetValue('pValue2', '0', 'val[2]', 'i32') }}};
@@ -3541,7 +3541,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetListener3i(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -3557,18 +3557,18 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetListeneriv() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
     switch (param) {
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       {{{ makeSetValue('pValues', '0', 'val[0]', 'i32') }}};
       {{{ makeSetValue('pValues', '4', 'val[1]', 'i32') }}};
       {{{ makeSetValue('pValues', '8', 'val[2]', 'i32') }}};
       break;
-    case {{{ cDefine('AL_ORIENTATION') }}}:
+    case {{{ cDefs.AL_ORIENTATION }}}:
       {{{ makeSetValue('pValues', '0', 'val[0]', 'i32') }}};
       {{{ makeSetValue('pValues', '4', 'val[1]', 'i32') }}};
       {{{ makeSetValue('pValues', '8', 'val[2]', 'i32') }}};
@@ -3580,7 +3580,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetListeneriv(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -3589,7 +3589,7 @@ var LibraryOpenAL = {
   alListenerf__sig: 'vif',
   alListenerf: function(param, value) {
     switch (param) {
-    case {{{ cDefine('AL_GAIN') }}}:
+    case {{{ cDefs.AL_GAIN }}}:
       AL.setListenerParam('alListenerf', param, value);
       break;
     default:
@@ -3602,8 +3602,8 @@ var LibraryOpenAL = {
   alListener3f__sig: 'vifff',
   alListener3f: function(param, value0, value1, value2) {
     switch (param) {
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       AL.paramArray[0] = value0;
       AL.paramArray[1] = value1;
       AL.paramArray[2] = value2;
@@ -3628,19 +3628,19 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alListenerfv() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
     switch (param) {
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       AL.paramArray[0] = {{{ makeGetValue('pValues', '0', 'float') }}};
       AL.paramArray[1] = {{{ makeGetValue('pValues', '4', 'float') }}};
       AL.paramArray[2] = {{{ makeGetValue('pValues', '8', 'float') }}};
       AL.setListenerParam('alListenerfv', param, AL.paramArray);
       break;
-    case {{{ cDefine('AL_ORIENTATION') }}}:
+    case {{{ cDefs.AL_ORIENTATION }}}:
       AL.paramArray[0] = {{{ makeGetValue('pValues', '0', 'float') }}};
       AL.paramArray[1] = {{{ makeGetValue('pValues', '4', 'float') }}};
       AL.paramArray[2] = {{{ makeGetValue('pValues', '8', 'float') }}};
@@ -3665,8 +3665,8 @@ var LibraryOpenAL = {
   alListener3i__sig: 'viiii',
   alListener3i: function(param, value0, value1, value2) {
     switch (param) {
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       AL.paramArray[0] = value0;
       AL.paramArray[1] = value1;
       AL.paramArray[2] = value2;
@@ -3691,19 +3691,19 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alListeneriv() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
     switch (param) {
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       AL.paramArray[0] = {{{ makeGetValue('pValues', '0', 'i32') }}};
       AL.paramArray[1] = {{{ makeGetValue('pValues', '4', 'i32') }}};
       AL.paramArray[2] = {{{ makeGetValue('pValues', '8', 'i32') }}};
       AL.setListenerParam('alListeneriv', param, AL.paramArray);
       break;
-    case {{{ cDefine('AL_ORIENTATION') }}}:
+    case {{{ cDefs.AL_ORIENTATION }}}:
       AL.paramArray[0] = {{{ makeGetValue('pValues', '0', 'i32') }}};
       AL.paramArray[1] = {{{ makeGetValue('pValues', '4', 'i32') }}};
       AL.paramArray[2] = {{{ makeGetValue('pValues', '8', 'i32') }}};
@@ -3752,14 +3752,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alBufferData() called with an invalid buffer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
     if (freq <= 0) {
 #if OPENAL_DEBUG
       dbg('alBufferData() called with an invalid frequency');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
@@ -3852,7 +3852,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg('alBufferData() called with invalid format ' + format);
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
         return;
       }
       buf.frequency = freq;
@@ -3861,7 +3861,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alBufferData() upload failed with an exception ' + e);
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
   },
@@ -3877,14 +3877,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetBufferf() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
 #if OPENAL_DEBUG
     dbg('alGetBufferf(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-    AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+    AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
   },
 
   alGetBuffer3f__proxy: 'sync',
@@ -3898,14 +3898,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetBuffer3f() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
 #if OPENAL_DEBUG
     dbg('alGetBuffer3f(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-    AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+    AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
   },
 
   alGetBufferfv__proxy: 'sync',
@@ -3919,14 +3919,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetBufferfv() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
 #if OPENAL_DEBUG
     dbg('alGetBufferfv(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-    AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+    AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
   },
 
   alGetBufferi__proxy: 'sync',
@@ -3940,7 +3940,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetBufferi() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
@@ -3955,7 +3955,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetBufferi(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -3971,14 +3971,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetBuffer3i() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
 #if OPENAL_DEBUG
     dbg('alGetBuffer3i(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-    AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+    AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
   },
 
   alGetBufferiv__proxy: 'sync',
@@ -3992,7 +3992,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetBufferiv() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
@@ -4011,7 +4011,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetBufferiv(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -4045,7 +4045,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alBufferfv() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
@@ -4077,7 +4077,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alBufferiv() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
@@ -4124,14 +4124,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alSourceQueueBuffers() called with an invalid source');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
       return;
     }
     if (src.type === 0x1028 /* AL_STATIC */) {
 #if OPENAL_DEBUG
       dbg('alSourceQueueBuffers() called while a static buffer is bound');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_OPERATION') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_OPERATION }}};
       return;
     }
 
@@ -4155,7 +4155,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg('alSourceQueueBuffers() called with an invalid buffer');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
         return;
       }
 
@@ -4168,7 +4168,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
         dbg('alSourceQueueBuffers() called with a buffer of different format');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_OPERATION') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_OPERATION }}};
       }
     }
 
@@ -4208,11 +4208,11 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alSourceUnqueueBuffers() called with an invalid source');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
       return;
     }
     if (count > (src.bufQueue.length === 1 && src.bufQueue[0].id === 0 ? 0 : src.bufsProcessed)) {
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
@@ -4251,7 +4251,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alSourcePlay() called with an invalid source');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
       return;
     }
     AL.setSourceState(src, 0x1012 /* AL_PLAYING */);
@@ -4270,14 +4270,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alSourcePlayv() called with null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
     }
     for (var i = 0; i < count; ++i) {
       if (!AL.currentCtx.sources[{{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}]) {
 #if OPENAL_DEBUG
         dbg('alSourcePlayv() called with an invalid source');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
         return;
       }
     }
@@ -4302,7 +4302,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alSourceStop() called with an invalid source');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
       return;
     }
     AL.setSourceState(src, 0x1014 /* AL_STOPPED */);
@@ -4321,14 +4321,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alSourceStopv() called with null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
     }
     for (var i = 0; i < count; ++i) {
       if (!AL.currentCtx.sources[{{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}]) {
 #if OPENAL_DEBUG
         dbg('alSourceStopv() called with an invalid source');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
         return;
       }
     }
@@ -4353,7 +4353,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alSourceRewind() called with an invalid source');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
       return;
     }
     // Stop the source first to clear the source queue
@@ -4375,14 +4375,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alSourceRewindv() called with null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
     }
     for (var i = 0; i < count; ++i) {
       if (!AL.currentCtx.sources[{{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}]) {
 #if OPENAL_DEBUG
         dbg('alSourceRewindv() called with an invalid source');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
         return;
       }
     }
@@ -4407,7 +4407,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alSourcePause() called with an invalid source');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
       return;
     }
     AL.setSourceState(src, 0x1013 /* AL_PAUSED */);
@@ -4426,14 +4426,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alSourcePausev() called with null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
     }
     for (var i = 0; i < count; ++i) {
       if (!AL.currentCtx.sources[{{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}]) {
 #if OPENAL_DEBUG
         dbg('alSourcePausev() called with an invalid source');
 #endif
-        AL.currentCtx.err = {{{ cDefine('AL_INVALID_NAME') }}};
+        AL.currentCtx.err = {{{ cDefs.AL_INVALID_NAME }}};
         return;
       }
     }
@@ -4455,7 +4455,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetSourcef() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
@@ -4463,7 +4463,7 @@ var LibraryOpenAL = {
     case 0x1001 /* AL_CONE_INNER_ANGLE */:
     case 0x1002 /* AL_CONE_OUTER_ANGLE */:
     case 0x1003 /* AL_PITCH */:
-    case {{{ cDefine('AL_GAIN') }}}:
+    case {{{ cDefs.AL_GAIN }}}:
     case 0x100D /* AL_MIN_GAIN */:
     case 0x100E /* AL_MAX_GAIN */:
     case 0x1020 /* AL_REFERENCE_DISTANCE */:
@@ -4480,7 +4480,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetSourcef(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -4496,14 +4496,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetSource3f() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
     switch (param) {
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_DIRECTION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_DIRECTION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       {{{ makeSetValue('pValue0', '0', 'val[0]', 'float') }}};
       {{{ makeSetValue('pValue1', '0', 'val[1]', 'float') }}};
       {{{ makeSetValue('pValue2', '0', 'val[2]', 'float') }}};
@@ -4512,7 +4512,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetSource3f(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -4528,7 +4528,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetSourcefv() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
@@ -4536,7 +4536,7 @@ var LibraryOpenAL = {
     case 0x1001 /* AL_CONE_INNER_ANGLE */:
     case 0x1002 /* AL_CONE_OUTER_ANGLE */:
     case 0x1003 /* AL_PITCH */:
-    case {{{ cDefine('AL_GAIN') }}}:
+    case {{{ cDefs.AL_GAIN }}}:
     case 0x100D /* AL_MIN_GAIN */:
     case 0x100E /* AL_MAX_GAIN */:
     case 0x1020 /* AL_REFERENCE_DISTANCE */:
@@ -4549,9 +4549,9 @@ var LibraryOpenAL = {
     case 0x200B /* AL_SEC_LENGTH_SOFT */:
       {{{ makeSetValue('pValues', '0', 'val[0]', 'float') }}};
       break;
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_DIRECTION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_DIRECTION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       {{{ makeSetValue('pValues', '0', 'val[0]', 'float') }}};
       {{{ makeSetValue('pValues', '4', 'val[1]', 'float') }}};
       {{{ makeSetValue('pValues', '8', 'val[2]', 'float') }}};
@@ -4560,7 +4560,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetSourcefv(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -4576,7 +4576,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetSourcei() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
@@ -4599,14 +4599,14 @@ var LibraryOpenAL = {
     case 0x1214 /* AL_SOURCE_SPATIALIZE_SOFT */:
     case 0x2009 /* AL_BYTE_LENGTH_SOFT */:
     case 0x200A /* AL_SAMPLE_LENGTH_SOFT */:
-    case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+    case {{{ cDefs.AL_DISTANCE_MODEL }}}:
       {{{ makeSetValue('pValue', '0', 'val', 'i32') }}};
       break;
     default:
 #if OPENAL_DEBUG
       dbg('alGetSourcei(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -4622,14 +4622,14 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetSource3i() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
     switch (param) {
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_DIRECTION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_DIRECTION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       {{{ makeSetValue('pValue0', '0', 'val[0]', 'i32') }}};
       {{{ makeSetValue('pValue1', '0', 'val[1]', 'i32') }}};
       {{{ makeSetValue('pValue2', '0', 'val[2]', 'i32') }}};
@@ -4638,7 +4638,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetSource3i(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -4654,7 +4654,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetSourceiv() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
@@ -4677,12 +4677,12 @@ var LibraryOpenAL = {
     case 0x1214 /* AL_SOURCE_SPATIALIZE_SOFT */:
     case 0x2009 /* AL_BYTE_LENGTH_SOFT */:
     case 0x200A /* AL_SAMPLE_LENGTH_SOFT */:
-    case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+    case {{{ cDefs.AL_DISTANCE_MODEL }}}:
       {{{ makeSetValue('pValues', '0', 'val', 'i32') }}};
       break;
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_DIRECTION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_DIRECTION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       {{{ makeSetValue('pValues', '0', 'val[0]', 'i32') }}};
       {{{ makeSetValue('pValues', '4', 'val[1]', 'i32') }}};
       {{{ makeSetValue('pValues', '8', 'val[2]', 'i32') }}};
@@ -4691,7 +4691,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alGetSourceiv(): param ' + ptrToString(param) + ' has wrong signature');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_ENUM') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_ENUM }}};
       return;
     }
   },
@@ -4703,7 +4703,7 @@ var LibraryOpenAL = {
     case 0x1001 /* AL_CONE_INNER_ANGLE */:
     case 0x1002 /* AL_CONE_OUTER_ANGLE */:
     case 0x1003 /* AL_PITCH */:
-    case {{{ cDefine('AL_GAIN') }}}:
+    case {{{ cDefs.AL_GAIN }}}:
     case 0x100D /* AL_MIN_GAIN */:
     case 0x100E /* AL_MAX_GAIN */:
     case 0x1020 /* AL_REFERENCE_DISTANCE */:
@@ -4726,9 +4726,9 @@ var LibraryOpenAL = {
   alSource3f__sig: 'viifff',
   alSource3f: function(sourceId, param, value0, value1, value2) {
     switch (param) {
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_DIRECTION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_DIRECTION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       AL.paramArray[0] = value0;
       AL.paramArray[1] = value1;
       AL.paramArray[2] = value2;
@@ -4753,7 +4753,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alSourcefv() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
@@ -4761,7 +4761,7 @@ var LibraryOpenAL = {
     case 0x1001 /* AL_CONE_INNER_ANGLE */:
     case 0x1002 /* AL_CONE_OUTER_ANGLE */:
     case 0x1003 /* AL_PITCH */:
-    case {{{ cDefine('AL_GAIN') }}}:
+    case {{{ cDefs.AL_GAIN }}}:
     case 0x100D /* AL_MIN_GAIN */:
     case 0x100E /* AL_MAX_GAIN */:
     case 0x1020 /* AL_REFERENCE_DISTANCE */:
@@ -4775,9 +4775,9 @@ var LibraryOpenAL = {
       var val = {{{ makeGetValue('pValues', '0', 'float') }}};
       AL.setSourceParam('alSourcefv', sourceId, param, val);
       break;
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_DIRECTION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_DIRECTION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       AL.paramArray[0] = {{{ makeGetValue('pValues', '0', 'float') }}};
       AL.paramArray[1] = {{{ makeGetValue('pValues', '4', 'float') }}};
       AL.paramArray[2] = {{{ makeGetValue('pValues', '8', 'float') }}};
@@ -4807,7 +4807,7 @@ var LibraryOpenAL = {
     case 0x1214 /* AL_SOURCE_SPATIALIZE_SOFT */:
     case 0x2009 /* AL_BYTE_LENGTH_SOFT */:
     case 0x200A /* AL_SAMPLE_LENGTH_SOFT */:
-    case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+    case {{{ cDefs.AL_DISTANCE_MODEL }}}:
       AL.setSourceParam('alSourcei', sourceId, param, value);
       break;
     default:
@@ -4820,9 +4820,9 @@ var LibraryOpenAL = {
   alSource3i__sig: 'viiiii',
   alSource3i: function(sourceId, param, value0, value1, value2) {
     switch (param) {
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_DIRECTION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_DIRECTION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       AL.paramArray[0] = value0;
       AL.paramArray[1] = value1;
       AL.paramArray[2] = value2;
@@ -4847,7 +4847,7 @@ var LibraryOpenAL = {
 #if OPENAL_DEBUG
       dbg('alSourceiv() called with a null pointer');
 #endif
-      AL.currentCtx.err = {{{ cDefine('AL_INVALID_VALUE') }}};
+      AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
       return;
     }
 
@@ -4866,13 +4866,13 @@ var LibraryOpenAL = {
     case 0x1214 /* AL_SOURCE_SPATIALIZE_SOFT */:
     case 0x2009 /* AL_BYTE_LENGTH_SOFT */:
     case 0x200A /* AL_SAMPLE_LENGTH_SOFT */:
-    case {{{ cDefine('AL_DISTANCE_MODEL') }}}:
+    case {{{ cDefs.AL_DISTANCE_MODEL }}}:
       var val = {{{ makeGetValue('pValues', '0', 'i32') }}};
       AL.setSourceParam('alSourceiv', sourceId, param, val);
       break;
-    case {{{ cDefine('AL_POSITION') }}}:
-    case {{{ cDefine('AL_DIRECTION') }}}:
-    case {{{ cDefine('AL_VELOCITY') }}}:
+    case {{{ cDefs.AL_POSITION }}}:
+    case {{{ cDefs.AL_DIRECTION }}}:
+    case {{{ cDefs.AL_VELOCITY }}}:
       AL.paramArray[0] = {{{ makeGetValue('pValues', '0', 'i32') }}};
       AL.paramArray[1] = {{{ makeGetValue('pValues', '4', 'i32') }}};
       AL.paramArray[2] = {{{ makeGetValue('pValues', '8', 'i32') }}};

--- a/src/library_pipefs.js
+++ b/src/library_pipefs.js
@@ -14,7 +14,7 @@ mergeInto(LibraryManager.library, {
     mount: function (mount) {
       // Do not pollute the real root directory or its child nodes with pipes
       // Looks like it is OK to create another pseudo-root node not linked to the FS.root hierarchy this way
-      return FS.createNode(null, '/', {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */, 0);
+      return FS.createNode(null, '/', {{{ cDefs.S_IFDIR }}} | 511 /* 0777 */, 0);
     },
     createPipe: function () {
       var pipe = {
@@ -32,8 +32,8 @@ mergeInto(LibraryManager.library, {
 
       var rName = PIPEFS.nextname();
       var wName = PIPEFS.nextname();
-      var rNode = FS.createNode(PIPEFS.root, rName, {{{ cDefine('S_IFIFO') }}}, 0);
-      var wNode = FS.createNode(PIPEFS.root, wName, {{{ cDefine('S_IFIFO') }}}, 0);
+      var rNode = FS.createNode(PIPEFS.root, rName, {{{ cDefs.S_IFIFO }}}, 0);
+      var wNode = FS.createNode(PIPEFS.root, wName, {{{ cDefs.S_IFIFO }}}, 0);
 
       rNode.pipe = pipe;
       wNode.pipe = pipe;
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
       var readableStream = FS.createStream({
         path: rName,
         node: rNode,
-        flags: {{{ cDefine('O_RDONLY') }}},
+        flags: {{{ cDefs.O_RDONLY }}},
         seekable: false,
         stream_ops: PIPEFS.stream_ops
       });
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
       var writableStream = FS.createStream({
         path: wName,
         node: wNode,
-        flags: {{{ cDefine('O_WRONLY') }}},
+        flags: {{{ cDefs.O_WRONLY }}},
         seekable: false,
         stream_ops: PIPEFS.stream_ops
       });
@@ -65,14 +65,14 @@ mergeInto(LibraryManager.library, {
       poll: function (stream) {
         var pipe = stream.node.pipe;
 
-        if ((stream.flags & {{{ cDefine('O_ACCMODE') }}}) === {{{ cDefine('O_WRONLY') }}}) {
-          return ({{{ cDefine('POLLWRNORM') }}} | {{{ cDefine('POLLOUT') }}});
+        if ((stream.flags & {{{ cDefs.O_ACCMODE }}}) === {{{ cDefs.O_WRONLY }}}) {
+          return ({{{ cDefs.POLLWRNORM }}} | {{{ cDefs.POLLOUT }}});
         }
         if (pipe.buckets.length > 0) {
           for (var i = 0; i < pipe.buckets.length; i++) {
             var bucket = pipe.buckets[i];
             if (bucket.offset - bucket.roffset > 0) {
-              return ({{{ cDefine('POLLRDNORM') }}} | {{{ cDefine('POLLIN') }}});
+              return ({{{ cDefs.POLLRDNORM }}} | {{{ cDefs.POLLIN }}});
             }
           }
         }
@@ -80,10 +80,10 @@ mergeInto(LibraryManager.library, {
         return 0;
       },
       ioctl: function (stream, request, varargs) {
-        return {{{ cDefine('EINVAL') }}};
+        return {{{ cDefs.EINVAL }}};
       },
       fsync: function (stream) {
-        return {{{ cDefine('EINVAL') }}};
+        return {{{ cDefs.EINVAL }}};
       },
       read: function (stream, buffer, offset, length, position /* ignored */) {
         var pipe = stream.node.pipe;
@@ -106,7 +106,7 @@ mergeInto(LibraryManager.library, {
         }
         if (currentLength == 0) {
           // Behave as if the read end is always non-blocking
-          throw new FS.ErrnoError({{{ cDefine('EAGAIN') }}});
+          throw new FS.ErrnoError({{{ cDefs.EAGAIN }}});
         }
         var toRead = Math.min(currentLength, length);
 

--- a/src/library_promise.js
+++ b/src/library_promise.js
@@ -52,17 +52,17 @@ mergeInto(LibraryManager.library, {
 #endif
     var info = promiseMap.get(id);
     switch (result) {
-      case {{{ cDefine('EM_PROMISE_FULFILL') }}}:
+      case {{{ cDefs.EM_PROMISE_FULFILL }}}:
         info.resolve(value);
         return;
-      case {{{ cDefine('EM_PROMISE_MATCH') }}}:
+      case {{{ cDefs.EM_PROMISE_MATCH }}}:
         info.resolve(getPromise(value));
         return;
-      case {{{ cDefine('EM_PROMISE_MATCH_RELEASE') }}}:
+      case {{{ cDefs.EM_PROMISE_MATCH_RELEASE }}}:
         info.resolve(getPromise(value));
         _emscripten_promise_destroy(value);
         return;
-      case {{{ cDefine('EM_PROMISE_REJECT') }}}:
+      case {{{ cDefs.EM_PROMISE_REJECT }}}:
         info.reject(value);
         return;
     }
@@ -110,15 +110,15 @@ mergeInto(LibraryManager.library, {
         stackRestore(stack);
       }
       switch (result) {
-        case {{{ cDefine('EM_PROMISE_FULFILL') }}}:
+        case {{{ cDefs.EM_PROMISE_FULFILL }}}:
           return resultVal;
-        case {{{ cDefine('EM_PROMISE_MATCH') }}}:
+        case {{{ cDefs.EM_PROMISE_MATCH }}}:
           return getPromise(resultVal);
-        case {{{ cDefine('EM_PROMISE_MATCH_RELEASE') }}}:
+        case {{{ cDefs.EM_PROMISE_MATCH_RELEASE }}}:
           var ret = getPromise(resultVal);
           _emscripten_promise_destroy(resultVal);
           return ret;
-        case {{{ cDefine('EM_PROMISE_REJECT') }}}:
+        case {{{ cDefs.EM_PROMISE_REJECT }}}:
           throw resultVal;
       }
 #if ASSERTIONS

--- a/src/library_proxyfs.js
+++ b/src/library_proxyfs.js
@@ -196,9 +196,9 @@ mergeInto(LibraryManager.library, {
       },
       llseek: function (stream, offset, whence) {
         var position = offset;
-        if (whence === {{{ cDefine('SEEK_CUR') }}}) {
+        if (whence === {{{ cDefs.SEEK_CUR }}}) {
           position += stream.position;
-        } else if (whence === {{{ cDefine('SEEK_END') }}}) {
+        } else if (whence === {{{ cDefs.SEEK_END }}}) {
           if (FS.isFile(stream.node.mode)) {
             try {
               var stat = stream.node.node_ops.getattr(stream.node);

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -655,7 +655,7 @@ var LibraryPThread = {
     var worker = PThread.getNewWorker();
     if (!worker) {
       // No available workers in the PThread pool.
-      return {{{ cDefine('EAGAIN') }}};
+      return {{{ cDefs.EAGAIN }}};
     }
 #if ASSERTIONS
     assert(!worker.pthread_ptr, 'Internal error!');
@@ -744,7 +744,7 @@ var LibraryPThread = {
   __pthread_create_js: function(pthread_ptr, attr, startRoutine, arg) {
     if (typeof SharedArrayBuffer == 'undefined') {
       err('Current environment does not support SharedArrayBuffer, pthreads are not available!');
-      return {{{ cDefine('EAGAIN') }}};
+      return {{{ cDefs.EAGAIN }}};
     }
 #if PTHREADS_DEBUG
     dbg("createThread: " + ptrToString(pthread_ptr));
@@ -782,7 +782,7 @@ var LibraryPThread = {
         if (name == '#canvas') {
           if (!Module['canvas']) {
             err('pthread_create: could not find canvas with ID "' + name + '" to transfer to thread!');
-            error = {{{ cDefine('EINVAL') }}};
+            error = {{{ cDefs.EINVAL }}};
             break;
           }
           name = Module['canvas'].id;
@@ -798,12 +798,12 @@ var LibraryPThread = {
           var canvas = (Module['canvas'] && Module['canvas'].id === name) ? Module['canvas'] : document.querySelector(name);
           if (!canvas) {
             err('pthread_create: could not find canvas with ID "' + name + '" to transfer to thread!');
-            error = {{{ cDefine('EINVAL') }}};
+            error = {{{ cDefs.EINVAL }}};
             break;
           }
           if (canvas.controlTransferredOffscreen) {
             err('pthread_create: cannot transfer canvas with ID "' + name + '" to thread, since the current thread does not have control over it!');
-            error = {{{ cDefine('EPERM') }}}; // Operation not permitted, some other thread is accessing the canvas.
+            error = {{{ cDefs.EPERM }}}; // Operation not permitted, some other thread is accessing the canvas.
             break;
           }
           if (canvas.transferControlToOffscreen) {
@@ -837,7 +837,7 @@ var LibraryPThread = {
             // proxied from worker to main thread.
 #if !OFFSCREEN_FRAMEBUFFER
             err('pthread_create: Build with -sOFFSCREEN_FRAMEBUFFER to enable fallback proxying of GL commands from pthread to main thread.');
-            return {{{ cDefine('ENOSYS') }}}; // Function not implemented, browser doesn't have support for this.
+            return {{{ cDefs.ENOSYS }}}; // Function not implemented, browser doesn't have support for this.
 #endif
           }
         }
@@ -847,7 +847,7 @@ var LibraryPThread = {
         }
       } catch(e) {
         err('pthread_create: failed to transfer control of canvas "' + name + '" to OffscreenCanvas! Error: ' + e);
-        return {{{ cDefine('EINVAL') }}}; // Hitting this might indicate an implementation bug or some other internal error
+        return {{{ cDefs.EINVAL }}}; // Hitting this might indicate an implementation bug or some other internal error
       }
     }
 #endif // OFFSCREENCANVAS_SUPPORT
@@ -917,7 +917,7 @@ var LibraryPThread = {
   },
 
   __pthread_kill_js: function(thread, signal) {
-    if (signal === {{{ cDefine('SIGCANCEL') }}}) { // Used by pthread_cancel in musl
+    if (signal === {{{ cDefs.SIGCANCEL }}}) { // Used by pthread_cancel in musl
       if (!ENVIRONMENT_IS_PTHREAD) cancelThread(thread);
       else postMessage({ 'cmd': 'cancelThread', 'thread': thread });
     } else {
@@ -958,7 +958,7 @@ var LibraryPThread = {
     var numCallArgs = arguments.length - 2;
     var outerArgs = arguments;
 #if ASSERTIONS
-    var maxArgs = {{{ cDefine('EM_QUEUED_JS_CALL_MAX_ARGS') - 1 }}};
+    var maxArgs = {{{ cDefs.EM_QUEUED_JS_CALL_MAX_ARGS - 1 }}};
     if (numCallArgs > maxArgs) {
       throw 'emscripten_proxy_to_main_thread_js: Too many arguments ' + numCallArgs + ' to proxied function idx=' + index + ', maximum supported is ' + maxArgs;
     }

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -65,7 +65,7 @@ var LibrarySDL = {
       volume: 1.0
     },
     mixerFrequency: 22050,
-    mixerFormat: {{{ cDefine('AUDIO_S16LSB') }}},
+    mixerFormat: {{{ cDefs.AUDIO_S16LSB }}},
     mixerNumChannels: 2,
     mixerChunkSize: 1024,
     channelMinimumNumber: 0,
@@ -317,7 +317,7 @@ var LibrarySDL = {
 #if ASSERTIONS
       // Canvas screens are always RGBA.
       var format = {{{ makeGetValue('fmt', C_STRUCTS.SDL_PixelFormat.format, 'i32') }}};
-      if (format != {{{ cDefine('SDL_PIXELFORMAT_RGBA8888') }}}) {
+      if (format != {{{ cDefs.SDL_PIXELFORMAT_RGBA8888 }}}) {
         warnOnce('Unsupported pixel format!');
       }
 #endif
@@ -377,7 +377,7 @@ var LibrarySDL = {
 
       {{{ makeSetValue('surf', C_STRUCTS.SDL_Surface.refcount, '1', 'i32') }}};
 
-      {{{ makeSetValue('pixelFormat', C_STRUCTS.SDL_PixelFormat.format, cDefine('SDL_PIXELFORMAT_RGBA8888'), 'i32') }}};
+      {{{ makeSetValue('pixelFormat', C_STRUCTS.SDL_PixelFormat.format, cDefs.SDL_PIXELFORMAT_RGBA8888, 'i32') }}};
       {{{ makeSetValue('pixelFormat', C_STRUCTS.SDL_PixelFormat.palette, '0', 'i32') }}};// TODO
       {{{ makeSetValue('pixelFormat', C_STRUCTS.SDL_PixelFormat.BitsPerPixel, 'bpp * 8', 'i8') }}};
       {{{ makeSetValue('pixelFormat', C_STRUCTS.SDL_PixelFormat.BytesPerPixel, 'bpp', 'i8') }}};
@@ -655,7 +655,7 @@ var LibrarySDL = {
               type: 'touchmove',
               touch: {
                 identifier: 0,
-                deviceID: {{{ cDefine('SDL_TOUCH_MOUSEID') }}},
+                deviceID: {{{ cDefs.SDL_TOUCH_MOUSEID }}},
                 pageX: event.pageX,
                 pageY: event.pageY
               }
@@ -691,7 +691,7 @@ var LibrarySDL = {
               type: 'touchstart',
               touch: {
                 identifier: 0,
-                deviceID: {{{ cDefine('SDL_TOUCH_MOUSEID') }}},
+                deviceID: {{{ cDefs.SDL_TOUCH_MOUSEID }}},
                 pageX: event.pageX,
                 pageY: event.pageY
               }
@@ -707,7 +707,7 @@ var LibrarySDL = {
               type: 'touchend',
               touch: {
                 identifier: 0,
-                deviceID: {{{ cDefine('SDL_TOUCH_MOUSEID') }}},
+                deviceID: {{{ cDefs.SDL_TOUCH_MOUSEID }}},
                 pageX: event.pageX,
                 pageY: event.pageY
               }
@@ -1197,16 +1197,16 @@ var LibrarySDL = {
         if (channelData.length != sizeSamplesPerChannel) {
           throw 'Web Audio output buffer length mismatch! Destination size: ' + channelData.length + ' samples vs expected ' + sizeSamplesPerChannel + ' samples!';
         }
-        if (audio.format == {{{ cDefine('AUDIO_S16LSB') }}}) {
+        if (audio.format == {{{ cDefs.AUDIO_S16LSB }}}) {
           for (var j = 0; j < sizeSamplesPerChannel; ++j) {
             channelData[j] = ({{{ makeGetValue('heapPtr', '(j*numChannels + c)*2', 'i16') }}}) / 0x8000;
           }
-        } else if (audio.format == {{{ cDefine('AUDIO_U8') }}}) {
+        } else if (audio.format == {{{ cDefs.AUDIO_U8 }}}) {
           for (var j = 0; j < sizeSamplesPerChannel; ++j) {
             var v = ({{{ makeGetValue('heapPtr', 'j*numChannels + c', 'i8') }}});
             channelData[j] = ((v >= 0) ? v-128 : v+128) /128;
           }
-        } else if (audio.format == {{{ cDefine('AUDIO_F32') }}}) {
+        } else if (audio.format == {{{ cDefs.AUDIO_F32 }}}) {
           for (var j = 0; j < sizeSamplesPerChannel; ++j) {
             channelData[j] = ({{{ makeGetValue('heapPtr', '(j*numChannels + c)*4', 'float') }}});
           }
@@ -2409,11 +2409,11 @@ var LibrarySDL = {
         timer: null
       };
       // The .silence field tells the constant sample value that corresponds to the safe un-skewed silence value for the wave data.
-      if (SDL.audio.format == {{{ cDefine('AUDIO_U8') }}}) {
+      if (SDL.audio.format == {{{ cDefs.AUDIO_U8 }}}) {
         SDL.audio.silence = 128; // Audio ranges in [0, 255], so silence is half-way in between.
-      } else if (SDL.audio.format == {{{ cDefine('AUDIO_S16LSB') }}}) {
+      } else if (SDL.audio.format == {{{ cDefs.AUDIO_S16LSB }}}) {
         SDL.audio.silence = 0; // Signed data in range [-32768, 32767], silence is 0.
-      } else if (SDL.audio.format == {{{ cDefine('AUDIO_F32') }}}) {
+      } else if (SDL.audio.format == {{{ cDefs.AUDIO_F32 }}}) {
         SDL.audio.silence = 0.0; // Float data in range [-1.0, 1.0], silence is 0.0
       } else {
         throw 'Invalid SDL audio format ' + SDL.audio.format + '!';
@@ -2449,11 +2449,11 @@ var LibrarySDL = {
       }
 
       var totalSamples = SDL.audio.samples*SDL.audio.channels;
-      if (SDL.audio.format == {{{ cDefine('AUDIO_U8') }}}) {
+      if (SDL.audio.format == {{{ cDefs.AUDIO_U8 }}}) {
         SDL.audio.bytesPerSample = 1;
-      } else if (SDL.audio.format == {{{ cDefine('AUDIO_S16LSB') }}}) {
+      } else if (SDL.audio.format == {{{ cDefs.AUDIO_S16LSB }}}) {
         SDL.audio.bytesPerSample = 2;
-      } else if (SDL.audio.format == {{{ cDefine('AUDIO_F32') }}}) {
+      } else if (SDL.audio.format == {{{ cDefs.AUDIO_F32 }}}) {
         SDL.audio.bytesPerSample = 4;
       } else {
         throw 'Invalid SDL audio format ' + SDL.audio.format + '!';

--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -43,13 +43,13 @@ mergeInto(LibraryManager.library, {
       Module['websocket']['on']('close', (fd) => dbg('Socket close fd = ' + fd));
 #endif
 
-      return FS.createNode(null, '/', {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */, 0);
+      return FS.createNode(null, '/', {{{ cDefs.S_IFDIR }}} | 511 /* 0777 */, 0);
     },
     createSocket: function(family, type, protocol) {
-      type &= ~{{{ cDefine('SOCK_CLOEXEC') | cDefine('SOCK_NONBLOCK') }}}; // Some applications may pass it; it makes no sense for a single process.
-      var streaming = type == {{{ cDefine('SOCK_STREAM') }}};
-      if (streaming && protocol && protocol != {{{ cDefine('IPPROTO_TCP') }}}) {
-        throw new FS.ErrnoError({{{ cDefine('EPROTONOSUPPORT') }}}); // if SOCK_STREAM, must be tcp or 0.
+      type &= ~{{{ cDefs.SOCK_CLOEXEC | cDefs.SOCK_NONBLOCK }}}; // Some applications may pass it; it makes no sense for a single process.
+      var streaming = type == {{{ cDefs.SOCK_STREAM }}};
+      if (streaming && protocol && protocol != {{{ cDefs.IPPROTO_TCP }}}) {
+        throw new FS.ErrnoError({{{ cDefs.EPROTONOSUPPORT }}}); // if SOCK_STREAM, must be tcp or 0.
       }
 
       // create our internal socket structure
@@ -70,7 +70,7 @@ mergeInto(LibraryManager.library, {
 
       // create the filesystem node to store the socket structure
       var name = SOCKFS.nextname();
-      var node = FS.createNode(SOCKFS.root, name, {{{ cDefine('S_IFSOCK') }}}, 0);
+      var node = FS.createNode(SOCKFS.root, name, {{{ cDefs.S_IFSOCK }}}, 0);
       node.sock = sock;
 
       // and the wrapping stream that enables library functions such
@@ -78,7 +78,7 @@ mergeInto(LibraryManager.library, {
       var stream = FS.createStream({
         path: name,
         node: node,
-        flags: {{{ cDefine('O_RDWR') }}},
+        flags: {{{ cDefs.O_RDWR }}},
         seekable: false,
         stream_ops: SOCKFS.stream_ops
       });
@@ -229,7 +229,7 @@ mergeInto(LibraryManager.library, {
             ws = new WebSocketConstructor(url, opts);
             ws.binaryType = 'arraybuffer';
           } catch (e) {
-            throw new FS.ErrnoError({{{ cDefine('EHOSTUNREACH') }}});
+            throw new FS.ErrnoError({{{ cDefs.EHOSTUNREACH }}});
           }
         }
 
@@ -250,7 +250,7 @@ mergeInto(LibraryManager.library, {
         // if this is a bound dgram socket, send the port number first to allow
         // us to override the ephemeral port reported to us by remotePort on the
         // remote end.
-        if (sock.type === {{{ cDefine('SOCK_DGRAM') }}} && typeof sock.sport != 'undefined') {
+        if (sock.type === {{{ cDefs.SOCK_DGRAM }}} && typeof sock.sport != 'undefined') {
 #if SOCKET_DEBUG
           dbg('websocket queuing port message (port ' + sock.sport + ')');
 #endif
@@ -352,7 +352,7 @@ mergeInto(LibraryManager.library, {
             // ECONNREFUSED they are not necessarily the expected error code e.g.
             // ENOTFOUND on getaddrinfo seems to be node.js specific, so using ECONNREFUSED
             // is still probably the most useful thing to do.
-            sock.error = {{{ cDefine('ECONNREFUSED') }}}; // Used in getsockopt for SOL_SOCKET/SO_ERROR test.
+            sock.error = {{{ cDefs.ECONNREFUSED }}}; // Used in getsockopt for SOL_SOCKET/SO_ERROR test.
             Module['websocket'].emit('error', [sock.stream.fd, sock.error, 'ECONNREFUSED: Connection refused']);
             // don't throw
           });
@@ -367,7 +367,7 @@ mergeInto(LibraryManager.library, {
           peer.socket.onerror = function(error) {
             // The WebSocket spec only allows a 'simple event' to be thrown on error,
             // so we only really know as much as ECONNREFUSED.
-            sock.error = {{{ cDefine('ECONNREFUSED') }}}; // Used in getsockopt for SOL_SOCKET/SO_ERROR test.
+            sock.error = {{{ cDefs.ECONNREFUSED }}}; // Used in getsockopt for SOL_SOCKET/SO_ERROR test.
             Module['websocket'].emit('error', [sock.stream.fd, sock.error, 'ECONNREFUSED: Connection refused']);
           };
         }
@@ -377,14 +377,14 @@ mergeInto(LibraryManager.library, {
       // actual sock ops
       //
       poll: function(sock) {
-        if (sock.type === {{{ cDefine('SOCK_STREAM') }}} && sock.server) {
+        if (sock.type === {{{ cDefs.SOCK_STREAM }}} && sock.server) {
           // listen sockets should only say they're available for reading
           // if there are pending clients.
-          return sock.pending.length ? ({{{ cDefine('POLLRDNORM') }}} | {{{ cDefine('POLLIN') }}}) : 0;
+          return sock.pending.length ? ({{{ cDefs.POLLRDNORM }}} | {{{ cDefs.POLLIN }}}) : 0;
         }
 
         var mask = 0;
-        var dest = sock.type === {{{ cDefine('SOCK_STREAM') }}} ?  // we only care about the socket state for connection-based sockets
+        var dest = sock.type === {{{ cDefs.SOCK_STREAM }}} ?  // we only care about the socket state for connection-based sockets
           SOCKFS.websocket_sock_ops.getPeer(sock, sock.daddr, sock.dport) :
           null;
 
@@ -392,24 +392,24 @@ mergeInto(LibraryManager.library, {
             !dest ||  // connection-less sockets are always ready to read
             (dest && dest.socket.readyState === dest.socket.CLOSING) ||
             (dest && dest.socket.readyState === dest.socket.CLOSED)) {  // let recv return 0 once closed
-          mask |= ({{{ cDefine('POLLRDNORM') }}} | {{{ cDefine('POLLIN') }}});
+          mask |= ({{{ cDefs.POLLRDNORM }}} | {{{ cDefs.POLLIN }}});
         }
 
         if (!dest ||  // connection-less sockets are always ready to write
             (dest && dest.socket.readyState === dest.socket.OPEN)) {
-          mask |= {{{ cDefine('POLLOUT') }}};
+          mask |= {{{ cDefs.POLLOUT }}};
         }
 
         if ((dest && dest.socket.readyState === dest.socket.CLOSING) ||
             (dest && dest.socket.readyState === dest.socket.CLOSED)) {
-          mask |= {{{ cDefine('POLLHUP') }}};
+          mask |= {{{ cDefs.POLLHUP }}};
         }
 
         return mask;
       },
       ioctl: function(sock, request, arg) {
         switch (request) {
-          case {{{ cDefine('FIONREAD') }}}:
+          case {{{ cDefs.FIONREAD }}}:
             var bytes = 0;
             if (sock.recv_queue.length) {
               bytes = sock.recv_queue[0].data.length;
@@ -417,7 +417,7 @@ mergeInto(LibraryManager.library, {
             {{{ makeSetValue('arg', '0', 'bytes', 'i32') }}};
             return 0;
           default:
-            return {{{ cDefine('EINVAL') }}};
+            return {{{ cDefs.EINVAL }}};
         }
       },
       close: function(sock) {
@@ -443,14 +443,14 @@ mergeInto(LibraryManager.library, {
       },
       bind: function(sock, addr, port) {
         if (typeof sock.saddr != 'undefined' || typeof sock.sport != 'undefined') {
-          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});  // already bound
+          throw new FS.ErrnoError({{{ cDefs.EINVAL }}});  // already bound
         }
         sock.saddr = addr;
         sock.sport = port;
         // in order to emulate dgram sockets, we need to launch a listen server when
         // binding on a connection-less socket
         // note: this is only required on the server side
-        if (sock.type === {{{ cDefine('SOCK_DGRAM') }}}) {
+        if (sock.type === {{{ cDefs.SOCK_DGRAM }}}) {
           // close the existing server if it exists
           if (sock.server) {
             sock.server.close();
@@ -462,17 +462,17 @@ mergeInto(LibraryManager.library, {
             sock.sock_ops.listen(sock, 0);
           } catch (e) {
             if (!(e.name === 'ErrnoError')) throw e;
-            if (e.errno !== {{{ cDefine('EOPNOTSUPP') }}}) throw e;
+            if (e.errno !== {{{ cDefs.EOPNOTSUPP }}}) throw e;
           }
         }
       },
       connect: function(sock, addr, port) {
         if (sock.server) {
-          throw new FS.ErrnoError({{{ cDefine('EOPNOTSUPP') }}});
+          throw new FS.ErrnoError({{{ cDefs.EOPNOTSUPP }}});
         }
 
         // TODO autobind
-        // if (!sock.addr && sock.type == {{{ cDefine('SOCK_DGRAM') }}}) {
+        // if (!sock.addr && sock.type == {{{ cDefs.SOCK_DGRAM }}}) {
         // }
 
         // early out if we're already connected / in the middle of connecting
@@ -480,9 +480,9 @@ mergeInto(LibraryManager.library, {
           var dest = SOCKFS.websocket_sock_ops.getPeer(sock, sock.daddr, sock.dport);
           if (dest) {
             if (dest.socket.readyState === dest.socket.CONNECTING) {
-              throw new FS.ErrnoError({{{ cDefine('EALREADY') }}});
+              throw new FS.ErrnoError({{{ cDefs.EALREADY }}});
             } else {
-              throw new FS.ErrnoError({{{ cDefine('EISCONN') }}});
+              throw new FS.ErrnoError({{{ cDefs.EISCONN }}});
             }
           }
         }
@@ -494,15 +494,15 @@ mergeInto(LibraryManager.library, {
         sock.dport = peer.port;
 
         // always "fail" in non-blocking mode
-        throw new FS.ErrnoError({{{ cDefine('EINPROGRESS') }}});
+        throw new FS.ErrnoError({{{ cDefs.EINPROGRESS }}});
       },
       listen: function(sock, backlog) {
         if (!ENVIRONMENT_IS_NODE) {
-          throw new FS.ErrnoError({{{ cDefine('EOPNOTSUPP') }}});
+          throw new FS.ErrnoError({{{ cDefs.EOPNOTSUPP }}});
         }
 #if ENVIRONMENT_MAY_BE_NODE
         if (sock.server) {
-           throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});  // already listening
+           throw new FS.ErrnoError({{{ cDefs.EINVAL }}});  // already listening
         }
         var WebSocketServer = require('ws').Server;
         var host = sock.saddr;
@@ -520,7 +520,7 @@ mergeInto(LibraryManager.library, {
 #if SOCKET_DEBUG
           dbg('received connection from: ' + ws._socket.remoteAddress + ':' + ws._socket.remotePort);
 #endif
-          if (sock.type === {{{ cDefine('SOCK_STREAM') }}}) {
+          if (sock.type === {{{ cDefs.SOCK_STREAM }}}) {
             var newsock = SOCKFS.createSocket(sock.family, sock.type, sock.protocol);
 
             // create a peer on the new socket
@@ -550,7 +550,7 @@ mergeInto(LibraryManager.library, {
           // is still probably the most useful thing to do. This error shouldn't
           // occur in a well written app as errors should get trapped in the compiled
           // app's own getaddrinfo call.
-          sock.error = {{{ cDefine('EHOSTUNREACH') }}}; // Used in getsockopt for SOL_SOCKET/SO_ERROR test.
+          sock.error = {{{ cDefs.EHOSTUNREACH }}}; // Used in getsockopt for SOL_SOCKET/SO_ERROR test.
           Module['websocket'].emit('error', [sock.stream.fd, sock.error, 'EHOSTUNREACH: Host is unreachable']);
           // don't throw
         });
@@ -558,7 +558,7 @@ mergeInto(LibraryManager.library, {
       },
       accept: function(listensock) {
         if (!listensock.server || !listensock.pending.length) {
-          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+          throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
         }
         var newsock = listensock.pending.shift();
         newsock.stream.flags = listensock.stream.flags;
@@ -568,7 +568,7 @@ mergeInto(LibraryManager.library, {
         var addr, port;
         if (peer) {
           if (sock.daddr === undefined || sock.dport === undefined) {
-            throw new FS.ErrnoError({{{ cDefine('ENOTCONN') }}});
+            throw new FS.ErrnoError({{{ cDefs.ENOTCONN }}});
           }
           addr = sock.daddr;
           port = sock.dport;
@@ -581,7 +581,7 @@ mergeInto(LibraryManager.library, {
         return { addr: addr, port: port };
       },
       sendmsg: function(sock, buffer, offset, length, addr, port) {
-        if (sock.type === {{{ cDefine('SOCK_DGRAM') }}}) {
+        if (sock.type === {{{ cDefs.SOCK_DGRAM }}}) {
           // connection-less sockets will honor the message address,
           // and otherwise fall back to the bound destination address
           if (addr === undefined || port === undefined) {
@@ -590,7 +590,7 @@ mergeInto(LibraryManager.library, {
           }
           // if there was no address to fall back to, error out
           if (addr === undefined || port === undefined) {
-            throw new FS.ErrnoError({{{ cDefine('EDESTADDRREQ') }}});
+            throw new FS.ErrnoError({{{ cDefs.EDESTADDRREQ }}});
           }
         } else {
           // connection-based sockets will only use the bound
@@ -602,11 +602,11 @@ mergeInto(LibraryManager.library, {
         var dest = SOCKFS.websocket_sock_ops.getPeer(sock, addr, port);
 
         // early out if not connected with a connection-based socket
-        if (sock.type === {{{ cDefine('SOCK_STREAM') }}}) {
+        if (sock.type === {{{ cDefs.SOCK_STREAM }}}) {
           if (!dest || dest.socket.readyState === dest.socket.CLOSING || dest.socket.readyState === dest.socket.CLOSED) {
-            throw new FS.ErrnoError({{{ cDefine('ENOTCONN') }}});
+            throw new FS.ErrnoError({{{ cDefs.ENOTCONN }}});
           } else if (dest.socket.readyState === dest.socket.CONNECTING) {
-            throw new FS.ErrnoError({{{ cDefine('EAGAIN') }}});
+            throw new FS.ErrnoError({{{ cDefs.EAGAIN }}});
           }
         }
 
@@ -634,7 +634,7 @@ mergeInto(LibraryManager.library, {
         // if we're emulating a connection-less dgram socket and don't have
         // a cached connection, queue the buffer to send upon connect and
         // lie, saying the data was sent now.
-        if (sock.type === {{{ cDefine('SOCK_DGRAM') }}}) {
+        if (sock.type === {{{ cDefs.SOCK_DGRAM }}}) {
           if (!dest || dest.socket.readyState !== dest.socket.OPEN) {
             // if we're not connected, open a new connection
             if (!dest || dest.socket.readyState === dest.socket.CLOSING || dest.socket.readyState === dest.socket.CLOSED) {
@@ -656,33 +656,33 @@ mergeInto(LibraryManager.library, {
           dest.socket.send(data);
           return length;
         } catch (e) {
-          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+          throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
         }
       },
       recvmsg: function(sock, length) {
         // http://pubs.opengroup.org/onlinepubs/7908799/xns/recvmsg.html
-        if (sock.type === {{{ cDefine('SOCK_STREAM') }}} && sock.server) {
+        if (sock.type === {{{ cDefs.SOCK_STREAM }}} && sock.server) {
           // tcp servers should not be recv()'ing on the listen socket
-          throw new FS.ErrnoError({{{ cDefine('ENOTCONN') }}});
+          throw new FS.ErrnoError({{{ cDefs.ENOTCONN }}});
         }
 
         var queued = sock.recv_queue.shift();
         if (!queued) {
-          if (sock.type === {{{ cDefine('SOCK_STREAM') }}}) {
+          if (sock.type === {{{ cDefs.SOCK_STREAM }}}) {
             var dest = SOCKFS.websocket_sock_ops.getPeer(sock, sock.daddr, sock.dport);
 
             if (!dest) {
               // if we have a destination address but are not connected, error out
-              throw new FS.ErrnoError({{{ cDefine('ENOTCONN') }}});
+              throw new FS.ErrnoError({{{ cDefs.ENOTCONN }}});
             }
             if (dest.socket.readyState === dest.socket.CLOSING || dest.socket.readyState === dest.socket.CLOSED) {
               // return null if the socket has closed
               return null;
             }
             // else, our socket is in a valid state but truly has nothing available
-            throw new FS.ErrnoError({{{ cDefine('EAGAIN') }}});
+            throw new FS.ErrnoError({{{ cDefs.EAGAIN }}});
           }
-          throw new FS.ErrnoError({{{ cDefine('EAGAIN') }}});
+          throw new FS.ErrnoError({{{ cDefs.EAGAIN }}});
         }
 
         // queued.data will be an ArrayBuffer if it's unadulterated, but if it's
@@ -702,7 +702,7 @@ mergeInto(LibraryManager.library, {
 #endif
 
         // push back any unread data for TCP connections
-        if (sock.type === {{{ cDefine('SOCK_STREAM') }}} && bytesRead < queuedLength) {
+        if (sock.type === {{{ cDefs.SOCK_STREAM }}} && bytesRead < queuedLength) {
           var bytesRemaining = queuedLength - bytesRead;
 #if SOCKET_DEBUG
           dbg('websocket read: put back ' + bytesRemaining + ' bytes');

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -17,7 +17,7 @@ var SyscallsLibrary = {
   $SYSCALLS: {
 #if SYSCALLS_REQUIRE_FILESYSTEM
     // global constants
-    DEFAULT_POLLMASK: {{{ cDefine('POLLIN') }}} | {{{ cDefine('POLLOUT') }}},
+    DEFAULT_POLLMASK: {{{ cDefs.POLLIN }}} | {{{ cDefs.POLLOUT }}},
 
     // shared utilities
     calculateAt: function(dirfd, path, allowEmpty) {
@@ -26,7 +26,7 @@ var SyscallsLibrary = {
       }
       // relative path
       var dir;
-      if (dirfd === {{{ cDefine('AT_FDCWD') }}}) {
+      if (dirfd === {{{ cDefs.AT_FDCWD }}}) {
         dir = FS.cwd();
       } else {
         var dirstream = SYSCALLS.getStreamFromFD(dirfd);
@@ -34,7 +34,7 @@ var SyscallsLibrary = {
       }
       if (path.length == 0) {
         if (!allowEmpty) {
-          throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});;
+          throw new FS.ErrnoError({{{ cDefs.ENOENT }}});;
         }
         return dir;
       }
@@ -47,7 +47,7 @@ var SyscallsLibrary = {
       } catch (e) {
         if (e && e.node && PATH.normalize(path) !== PATH.normalize(FS.getPath(e.node))) {
           // an error occurred while trying to look up the path; we should just report ENOTDIR
-          return -{{{ cDefine('ENOTDIR') }}};
+          return -{{{ cDefs.ENOTDIR }}};
         }
         throw e;
       }
@@ -75,9 +75,9 @@ var SyscallsLibrary = {
     },
     doMsync: function(addr, stream, len, flags, offset) {
       if (!FS.isFile(stream.node.mode)) {
-        throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENODEV }}});
       }
-      if (flags & {{{ cDefine('MAP_PRIVATE') }}}) {
+      if (flags & {{{ cDefs.MAP_PRIVATE }}}) {
         // MAP_PRIVATE calls need not to be synced back to underlying fs
         return 0;
       }
@@ -115,7 +115,7 @@ var SyscallsLibrary = {
     // Just like `FS.getStream` but will throw EBADF if stream is undefined.
     getStreamFromFD: function(fd) {
       var stream = FS.getStream(fd);
-      if (!stream) throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+      if (!stream) throw new FS.ErrnoError({{{ cDefs.EBADF }}});
 #if SYSCALL_DEBUG
       dbg('    (stream: "' + stream.path + '")');
 #endif
@@ -142,7 +142,7 @@ var SyscallsLibrary = {
     {{{ makeSetValue('addr', 0, 'ptr', '*') }}};
     return 0;
 #else // no filesystem support; report lack of support
-    return -{{{ cDefine('ENOSYS') }}};
+    return -{{{ cDefs.ENOSYS }}};
 #endif
   },
 
@@ -155,7 +155,7 @@ var SyscallsLibrary = {
   _munmap_js: function(addr, len, prot, flags, fd, offset) {
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
     var stream = SYSCALLS.getStreamFromFD(fd);
-    if (prot & {{{ cDefine('PROT_WRITE') }}}) {
+    if (prot & {{{ cDefs.PROT_WRITE }}}) {
       SYSCALLS.doMsync(addr, stream, len, flags, offset);
     }
     FS.munmap(stream);
@@ -190,7 +190,7 @@ var SyscallsLibrary = {
   __syscall_pipe__sig: 'ip',
   __syscall_pipe: function(fdPtr) {
     if (fdPtr == 0) {
-      throw new FS.ErrnoError({{{ cDefine('EFAULT') }}});
+      throw new FS.ErrnoError({{{ cDefs.EFAULT }}});
     }
 
     var res = PIPEFS.createPipe();
@@ -210,51 +210,51 @@ var SyscallsLibrary = {
 #else
     var stream = SYSCALLS.getStreamFromFD(fd);
     switch (op) {
-      case {{{ cDefine('TCGETA') }}}:
-      case {{{ cDefine('TCGETS') }}}: {
-        if (!stream.tty) return -{{{ cDefine('ENOTTY') }}};
+      case {{{ cDefs.TCGETA }}}:
+      case {{{ cDefs.TCGETS }}}: {
+        if (!stream.tty) return -{{{ cDefs.ENOTTY }}};
 #if SYSCALL_DEBUG
         dbg('warning: not filling tio struct');
 #endif
         return 0;
       }
-      case {{{ cDefine('TCSETA') }}}:
-      case {{{ cDefine('TCSETAW') }}}:
-      case {{{ cDefine('TCSETAF') }}}:
-      case {{{ cDefine('TCSETS') }}}:
-      case {{{ cDefine('TCSETSW') }}}:
-      case {{{ cDefine('TCSETSF') }}}: {
-        if (!stream.tty) return -{{{ cDefine('ENOTTY') }}};
+      case {{{ cDefs.TCSETA }}}:
+      case {{{ cDefs.TCSETAW }}}:
+      case {{{ cDefs.TCSETAF }}}:
+      case {{{ cDefs.TCSETS }}}:
+      case {{{ cDefs.TCSETSW }}}:
+      case {{{ cDefs.TCSETSF }}}: {
+        if (!stream.tty) return -{{{ cDefs.ENOTTY }}};
         return 0; // no-op, not actually adjusting terminal settings
       }
-      case {{{ cDefine('TIOCGPGRP') }}}: {
-        if (!stream.tty) return -{{{ cDefine('ENOTTY') }}};
+      case {{{ cDefs.TIOCGPGRP }}}: {
+        if (!stream.tty) return -{{{ cDefs.ENOTTY }}};
         var argp = SYSCALLS.get();
         {{{ makeSetValue('argp', 0, 0, 'i32') }}};
         return 0;
       }
-      case {{{ cDefine('TIOCSPGRP') }}}: {
-        if (!stream.tty) return -{{{ cDefine('ENOTTY') }}};
-        return -{{{ cDefine('EINVAL') }}}; // not supported
+      case {{{ cDefs.TIOCSPGRP }}}: {
+        if (!stream.tty) return -{{{ cDefs.ENOTTY }}};
+        return -{{{ cDefs.EINVAL }}}; // not supported
       }
-      case {{{ cDefine('FIONREAD') }}}: {
+      case {{{ cDefs.FIONREAD }}}: {
         var argp = SYSCALLS.get();
         return FS.ioctl(stream, op, argp);
       }
-      case {{{ cDefine('TIOCGWINSZ') }}}: {
+      case {{{ cDefs.TIOCGWINSZ }}}: {
         // TODO: in theory we should write to the winsize struct that gets
         // passed in, but for now musl doesn't read anything on it
-        if (!stream.tty) return -{{{ cDefine('ENOTTY') }}};
+        if (!stream.tty) return -{{{ cDefs.ENOTTY }}};
         return 0;
       }
-      case {{{ cDefine('TIOCSWINSZ') }}}: {
+      case {{{ cDefs.TIOCSWINSZ }}}: {
         // TODO: technically, this ioctl call should change the window size.
         // but, since emscripten doesn't have any concept of a terminal window
         // yet, we'll just silently throw it away as we do TIOCGWINSZ
-        if (!stream.tty) return -{{{ cDefine('ENOTTY') }}};
+        if (!stream.tty) return -{{{ cDefs.ENOTTY }}};
         return 0;
       }
-      default: return -{{{ cDefine('EINVAL') }}}; // not supported
+      default: return -{{{ cDefs.EINVAL }}}; // not supported
     }
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },
@@ -277,7 +277,7 @@ var SyscallsLibrary = {
   $getSocketFromFD__deps: ['$SOCKFS', '$FS'],
   $getSocketFromFD: function(fd) {
     var socket = SOCKFS.getSocket(fd);
-    if (!socket) throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
+    if (!socket) throw new FS.ErrnoError({{{ cDefs.EBADF }}});
 #if SYSCALL_DEBUG
     dbg('    (socket: "' + socket.path + '")');
 #endif
@@ -319,7 +319,7 @@ var SyscallsLibrary = {
   __syscall_getpeername: function(fd, addr, addrlen) {
     var sock = getSocketFromFD(fd);
     if (!sock.daddr) {
-      return -{{{ cDefine('ENOTCONN') }}}; // The socket is not connected.
+      return -{{{ cDefs.ENOTCONN }}}; // The socket is not connected.
     }
     var errno = writeSockaddr(addr, sock.family, DNS.lookup_name(sock.daddr), sock.dport, addrlen);
 #if ASSERTIONS
@@ -338,7 +338,7 @@ var SyscallsLibrary = {
   __syscall_shutdown__deps: ['$getSocketFromFD'],
   __syscall_shutdown: function(fd, how) {
     getSocketFromFD(fd);
-    return -{{{ cDefine('ENOSYS') }}}; // unsupported feature
+    return -{{{ cDefs.ENOSYS }}}; // unsupported feature
   },
   __syscall_accept4__deps: ['$getSocketFromFD', '$writeSockaddr', '$DNS'],
   __syscall_accept4: function(fd, addr, addrlen, flags) {
@@ -397,15 +397,15 @@ var SyscallsLibrary = {
     var sock = getSocketFromFD(fd);
     // Minimal getsockopt aimed at resolving https://github.com/emscripten-core/emscripten/issues/2211
     // so only supports SOL_SOCKET with SO_ERROR.
-    if (level === {{{ cDefine('SOL_SOCKET') }}}) {
-      if (optname === {{{ cDefine('SO_ERROR') }}}) {
+    if (level === {{{ cDefs.SOL_SOCKET }}}) {
+      if (optname === {{{ cDefs.SO_ERROR }}}) {
         {{{ makeSetValue('optval', 0, 'sock.error', 'i32') }}};
         {{{ makeSetValue('optlen', 0, 4, 'i32') }}};
         sock.error = null; // Clear the error (The SO_ERROR option obtains and then clears this field).
         return 0;
       }
     }
-    return -{{{ cDefine('ENOPROTOOPT') }}}; // The option is unknown at the level indicated.
+    return -{{{ cDefs.ENOPROTOOPT }}}; // The option is unknown at the level indicated.
   },
   __syscall_sendmsg__deps: ['$getSocketFromFD', '$readSockaddr', '$DNS'],
   __syscall_sendmsg: function(fd, message, flags) {
@@ -553,15 +553,15 @@ var SyscallsLibrary = {
         flags = stream.stream_ops.poll(stream);
       }
 
-      if ((flags & {{{ cDefine('POLLIN') }}}) && check(fd, srcReadLow, srcReadHigh, mask)) {
+      if ((flags & {{{ cDefs.POLLIN }}}) && check(fd, srcReadLow, srcReadHigh, mask)) {
         fd < 32 ? (dstReadLow = dstReadLow | mask) : (dstReadHigh = dstReadHigh | mask);
         total++;
       }
-      if ((flags & {{{ cDefine('POLLOUT') }}}) && check(fd, srcWriteLow, srcWriteHigh, mask)) {
+      if ((flags & {{{ cDefs.POLLOUT }}}) && check(fd, srcWriteLow, srcWriteHigh, mask)) {
         fd < 32 ? (dstWriteLow = dstWriteLow | mask) : (dstWriteHigh = dstWriteHigh | mask);
         total++;
       }
-      if ((flags & {{{ cDefine('POLLPRI') }}}) && check(fd, srcExceptLow, srcExceptHigh, mask)) {
+      if ((flags & {{{ cDefs.POLLPRI }}}) && check(fd, srcExceptLow, srcExceptHigh, mask)) {
         fd < 32 ? (dstExceptLow = dstExceptLow | mask) : (dstExceptHigh = dstExceptHigh | mask);
         total++;
       }
@@ -598,7 +598,7 @@ var SyscallsLibrary = {
       var pollfd = fds + {{{ C_STRUCTS.pollfd.__size__ }}} * i;
       var fd = {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.fd, 'i32') }}};
       var events = {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.events, 'i16') }}};
-      var mask = {{{ cDefine('POLLNVAL') }}};
+      var mask = {{{ cDefs.POLLNVAL }}};
       var stream = FS.getStream(fd);
       if (stream) {
         mask = SYSCALLS.DEFAULT_POLLMASK;
@@ -606,7 +606,7 @@ var SyscallsLibrary = {
           mask = stream.stream_ops.poll(stream);
         }
       }
-      mask &= events | {{{ cDefine('POLLERR') }}} | {{{ cDefine('POLLHUP') }}};
+      mask &= events | {{{ cDefs.POLLERR }}} | {{{ cDefs.POLLHUP }}};
       if (mask) nonzero++;
       {{{ makeSetValue('pollfd', C_STRUCTS.pollfd.revents, 'mask', 'i16') }}};
     }
@@ -614,17 +614,17 @@ var SyscallsLibrary = {
   },
   __syscall_getcwd__sig: 'ipp',
   __syscall_getcwd: function(buf, size) {
-    if (size === 0) return -{{{ cDefine('EINVAL') }}};
+    if (size === 0) return -{{{ cDefs.EINVAL }}};
     var cwd = FS.cwd();
     var cwdLengthInBytes = lengthBytesUTF8(cwd) + 1;
-    if (size < cwdLengthInBytes) return -{{{ cDefine('ERANGE') }}};
+    if (size < cwdLengthInBytes) return -{{{ cDefs.ERANGE }}};
     stringToUTF8(cwd, buf, size);
     return cwdLengthInBytes;
   },
   __syscall_truncate64__sig: 'ipj',
   __syscall_truncate64__deps: i53ConversionDeps,
   __syscall_truncate64: function(path, {{{ defineI64Param('length') }}}) {
-    {{{ receiveI64ParamAsI53('length', -cDefine('EOVERFLOW')) }}}
+    {{{ receiveI64ParamAsI53('length', -cDefs.EOVERFLOW) }}}
     path = SYSCALLS.getStr(path);
     FS.truncate(path, length);
     return 0;
@@ -632,7 +632,7 @@ var SyscallsLibrary = {
   __syscall_ftruncate64__sig: 'iij',
   __syscall_ftruncate64__deps: i53ConversionDeps,
   __syscall_ftruncate64: function(fd, {{{ defineI64Param('length') }}}) {
-    {{{ receiveI64ParamAsI53('length', -cDefine('EOVERFLOW')) }}}
+    {{{ receiveI64ParamAsI53('length', -cDefs.EOVERFLOW) }}}
     FS.ftruncate(fd, length);
     return 0;
   },
@@ -664,7 +664,7 @@ var SyscallsLibrary = {
 
     var struct_size = {{{ C_STRUCTS.dirent.__size__ }}};
     var pos = 0;
-    var off = FS.llseek(stream, 0, {{{ cDefine('SEEK_CUR') }}});
+    var off = FS.llseek(stream, 0, {{{ cDefs.SEEK_CUR }}});
 
     var idx = Math.floor(off / struct_size);
 
@@ -700,7 +700,7 @@ var SyscallsLibrary = {
       pos += struct_size;
       idx += 1;
     }
-    FS.llseek(stream, idx * struct_size, {{{ cDefine('SEEK_SET') }}});
+    FS.llseek(stream, idx * struct_size, {{{ cDefs.SEEK_SET }}});
     return pos;
   },
   __syscall_fcntl64__deps: ['$setErrNo'],
@@ -714,53 +714,53 @@ var SyscallsLibrary = {
 #else
     var stream = SYSCALLS.getStreamFromFD(fd);
     switch (cmd) {
-      case {{{ cDefine('F_DUPFD') }}}: {
+      case {{{ cDefs.F_DUPFD }}}: {
         var arg = SYSCALLS.get();
         if (arg < 0) {
-          return -{{{ cDefine('EINVAL') }}};
+          return -{{{ cDefs.EINVAL }}};
         }
         var newStream;
         newStream = FS.createStream(stream, arg);
         return newStream.fd;
       }
-      case {{{ cDefine('F_GETFD') }}}:
-      case {{{ cDefine('F_SETFD') }}}:
+      case {{{ cDefs.F_GETFD }}}:
+      case {{{ cDefs.F_SETFD }}}:
         return 0;  // FD_CLOEXEC makes no sense for a single process.
-      case {{{ cDefine('F_GETFL') }}}:
+      case {{{ cDefs.F_GETFL }}}:
         return stream.flags;
-      case {{{ cDefine('F_SETFL') }}}: {
+      case {{{ cDefs.F_SETFL }}}: {
         var arg = SYSCALLS.get();
         stream.flags |= arg;
         return 0;
       }
-      case {{{ cDefine('F_GETLK') }}}:
-      /* case {{{ cDefine('F_GETLK64') }}}: Currently in musl F_GETLK64 has same value as F_GETLK, so omitted to avoid duplicate case blocks. If that changes, uncomment this */ {
-        {{{ assert(cDefine('F_GETLK') === cDefine('F_GETLK64')), '' }}}
+      case {{{ cDefs.F_GETLK }}}:
+      /* case {{{ cDefs.F_GETLK64 }}}: Currently in musl F_GETLK64 has same value as F_GETLK, so omitted to avoid duplicate case blocks. If that changes, uncomment this */ {
+        {{{ assert(cDefs.F_GETLK === cDefs.F_GETLK64), '' }}}
         var arg = SYSCALLS.get();
         var offset = {{{ C_STRUCTS.flock.l_type }}};
         // We're always unlocked.
-        {{{ makeSetValue('arg', 'offset', cDefine('F_UNLCK'), 'i16') }}};
+        {{{ makeSetValue('arg', 'offset', cDefs.F_UNLCK, 'i16') }}};
         return 0;
       }
-      case {{{ cDefine('F_SETLK') }}}:
-      case {{{ cDefine('F_SETLKW') }}}:
-      /* case {{{ cDefine('F_SETLK64') }}}: Currently in musl F_SETLK64 has same value as F_SETLK, so omitted to avoid duplicate case blocks. If that changes, uncomment this */
-      /* case {{{ cDefine('F_SETLKW64') }}}: Currently in musl F_SETLKW64 has same value as F_SETLKW, so omitted to avoid duplicate case blocks. If that changes, uncomment this */
-        {{{ assert(cDefine('F_SETLK64') === cDefine('F_SETLK')), '' }}}
-        {{{ assert(cDefine('F_SETLKW64') === cDefine('F_SETLKW')), '' }}}
+      case {{{ cDefs.F_SETLK }}}:
+      case {{{ cDefs.F_SETLKW }}}:
+      /* case {{{ cDefs.F_SETLK64 }}}: Currently in musl F_SETLK64 has same value as F_SETLK, so omitted to avoid duplicate case blocks. If that changes, uncomment this */
+      /* case {{{ cDefs.F_SETLKW64 }}}: Currently in musl F_SETLKW64 has same value as F_SETLKW, so omitted to avoid duplicate case blocks. If that changes, uncomment this */
+        {{{ assert(cDefs.F_SETLK64 === cDefs.F_SETLK), '' }}}
+        {{{ assert(cDefs.F_SETLKW64 === cDefs.F_SETLKW), '' }}}
         return 0; // Pretend that the locking is successful.
-      case {{{ cDefine('F_GETOWN_EX') }}}:
-      case {{{ cDefine('F_SETOWN') }}}:
-        return -{{{ cDefine('EINVAL') }}}; // These are for sockets. We don't have them fully implemented yet.
-      case {{{ cDefine('F_GETOWN') }}}:
+      case {{{ cDefs.F_GETOWN_EX }}}:
+      case {{{ cDefs.F_SETOWN }}}:
+        return -{{{ cDefs.EINVAL }}}; // These are for sockets. We don't have them fully implemented yet.
+      case {{{ cDefs.F_GETOWN }}}:
         // musl trusts getown return values, due to a bug where they must be, as they overlap with errors. just return -1 here, so fcntl() returns that, and we set errno ourselves.
-        setErrNo({{{ cDefine('EINVAL') }}});
+        setErrNo({{{ cDefs.EINVAL }}});
         return -1;
       default: {
 #if SYSCALL_DEBUG
         dbg('warning: fcntl unrecognized command ' + cmd);
 #endif
-        return -{{{ cDefine('EINVAL') }}};
+        return -{{{ cDefs.EINVAL }}};
       }
     }
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
@@ -825,14 +825,14 @@ var SyscallsLibrary = {
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);
     // we don't want this in the JS API as it uses mknod to create all nodes.
-    switch (mode & {{{ cDefine('S_IFMT') }}}) {
-      case {{{ cDefine('S_IFREG') }}}:
-      case {{{ cDefine('S_IFCHR') }}}:
-      case {{{ cDefine('S_IFBLK') }}}:
-      case {{{ cDefine('S_IFIFO') }}}:
-      case {{{ cDefine('S_IFSOCK') }}}:
+    switch (mode & {{{ cDefs.S_IFMT }}}) {
+      case {{{ cDefs.S_IFREG }}}:
+      case {{{ cDefs.S_IFCHR }}}:
+      case {{{ cDefs.S_IFBLK }}}:
+      case {{{ cDefs.S_IFIFO }}}:
+      case {{{ cDefs.S_IFSOCK }}}:
         break;
-      default: return -{{{ cDefine('EINVAL') }}};
+      default: return -{{{ cDefs.EINVAL }}};
     }
     FS.mknod(path, mode, dev);
     return 0;
@@ -843,8 +843,8 @@ var SyscallsLibrary = {
     dbg('warning: untested syscall');
 #endif
     path = SYSCALLS.getStr(path);
-    var nofollow = flags & {{{ cDefine('AT_SYMLINK_NOFOLLOW') }}};
-    flags = flags & (~{{{ cDefine('AT_SYMLINK_NOFOLLOW') }}});
+    var nofollow = flags & {{{ cDefs.AT_SYMLINK_NOFOLLOW }}};
+    flags = flags & (~{{{ cDefs.AT_SYMLINK_NOFOLLOW }}});
 #if ASSERTIONS
     assert(flags === 0);
 #endif
@@ -855,9 +855,9 @@ var SyscallsLibrary = {
   __syscall_newfstatat__sig: 'iippi',
   __syscall_newfstatat: function(dirfd, path, buf, flags) {
     path = SYSCALLS.getStr(path);
-    var nofollow = flags & {{{ cDefine('AT_SYMLINK_NOFOLLOW') }}};
-    var allowEmpty = flags & {{{ cDefine('AT_EMPTY_PATH') }}};
-    flags = flags & (~{{{ cDefine('AT_SYMLINK_NOFOLLOW') | cDefine('AT_EMPTY_PATH') | cDefine('AT_NO_AUTOMOUNT') }}});
+    var nofollow = flags & {{{ cDefs.AT_SYMLINK_NOFOLLOW }}};
+    var allowEmpty = flags & {{{ cDefs.AT_EMPTY_PATH }}};
+    flags = flags & (~{{{ cDefs.AT_SYMLINK_NOFOLLOW | cDefs.AT_EMPTY_PATH | cDefs.AT_NO_AUTOMOUNT }}});
 #if ASSERTIONS
     assert(!flags, 'unknown flags in __syscall_newfstatat: ' + flags);
 #endif
@@ -870,7 +870,7 @@ var SyscallsLibrary = {
     path = SYSCALLS.calculateAt(dirfd, path);
     if (flags === 0) {
       FS.unlink(path);
-    } else if (flags === {{{ cDefine('AT_REMOVEDIR') }}}) {
+    } else if (flags === {{{ cDefs.AT_REMOVEDIR }}}) {
       FS.rmdir(path);
     } else {
       abort('Invalid flags passed to unlinkat');
@@ -889,7 +889,7 @@ var SyscallsLibrary = {
   __syscall_linkat__nothrow: true,
   __syscall_linkat__proxy: false,
   __syscall_linkat: function(olddirfd, oldpath, newdirfd, newpath, flags) {
-    return -{{{ cDefine('EMLINK') }}}; // no hardlinks for us
+    return -{{{ cDefs.EMLINK }}}; // no hardlinks for us
   },
   __syscall_symlinkat: function(target, newdirfd, linkpath) {
 #if SYSCALL_DEBUG
@@ -903,7 +903,7 @@ var SyscallsLibrary = {
   __syscall_readlinkat: function(dirfd, path, buf, bufsize) {
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);
-    if (bufsize <= 0) return -{{{ cDefine('EINVAL') }}};
+    if (bufsize <= 0) return -{{{ cDefs.EINVAL }}};
     var ret = FS.readlink(path);
 
     var len = Math.min(bufsize, lengthBytesUTF8(ret));
@@ -934,21 +934,21 @@ var SyscallsLibrary = {
     assert(flags === 0);
 #endif
     path = SYSCALLS.calculateAt(dirfd, path);
-    if (amode & ~{{{ cDefine('S_IRWXO') }}}) {
+    if (amode & ~{{{ cDefs.S_IRWXO }}}) {
       // need a valid mode
-      return -{{{ cDefine('EINVAL') }}};
+      return -{{{ cDefs.EINVAL }}};
     }
     var lookup = FS.lookupPath(path, { follow: true });
     var node = lookup.node;
     if (!node) {
-      return -{{{ cDefine('ENOENT') }}};
+      return -{{{ cDefs.ENOENT }}};
     }
     var perms = '';
-    if (amode & {{{ cDefine('R_OK') }}}) perms += 'r';
-    if (amode & {{{ cDefine('W_OK') }}}) perms += 'w';
-    if (amode & {{{ cDefine('X_OK') }}}) perms += 'x';
+    if (amode & {{{ cDefs.R_OK }}}) perms += 'r';
+    if (amode & {{{ cDefs.W_OK }}}) perms += 'w';
+    if (amode & {{{ cDefs.X_OK }}}) perms += 'x';
     if (perms /* otherwise, they've just passed F_OK */ && FS.nodePermissions(node, perms)) {
-      return -{{{ cDefine('EACCES') }}};
+      return -{{{ cDefs.EACCES }}};
     }
     return 0;
   },
@@ -977,8 +977,8 @@ var SyscallsLibrary = {
   },
   __syscall_fallocate__deps: i53ConversionDeps,
   __syscall_fallocate: function(fd, mode, {{{ defineI64Param('offset') }}}, {{{ defineI64Param('len') }}}) {
-    {{{ receiveI64ParamAsI53('offset', -cDefine('EOVERFLOW')) }}}
-    {{{ receiveI64ParamAsI53('len', -cDefine('EOVERFLOW')) }}}
+    {{{ receiveI64ParamAsI53('offset', -cDefs.EOVERFLOW) }}}
+    {{{ receiveI64ParamAsI53('len', -cDefs.EOVERFLOW) }}}
     var stream = SYSCALLS.getStreamFromFD(fd)
 #if ASSERTIONS
     assert(mode === 0);
@@ -991,7 +991,7 @@ var SyscallsLibrary = {
 #if ASSERTIONS
     assert(!flags);
 #endif
-    if (old.fd === suggestFD) return -{{{ cDefine('EINVAL') }}};
+    if (old.fd === suggestFD) return -{{{ cDefs.EINVAL }}};
     var suggest = FS.getStream(suggestFD);
     if (suggest) FS.close(suggest);
     return FS.createStream(old, suggestFD, suggestFD + 1).fd;

--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -43,7 +43,7 @@ mergeInto(LibraryManager.library, {
       open: function(stream) {
         var tty = TTY.ttys[stream.node.rdev];
         if (!tty) {
-          throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
+          throw new FS.ErrnoError({{{ cDefs.ENODEV }}});
         }
         stream.tty = tty;
         stream.seekable = false;
@@ -57,7 +57,7 @@ mergeInto(LibraryManager.library, {
       },
       read: function(stream, buffer, offset, length, pos /* ignored */) {
         if (!stream.tty || !stream.tty.ops.get_char) {
-          throw new FS.ErrnoError({{{ cDefine('ENXIO') }}});
+          throw new FS.ErrnoError({{{ cDefs.ENXIO }}});
         }
         var bytesRead = 0;
         for (var i = 0; i < length; i++) {
@@ -65,10 +65,10 @@ mergeInto(LibraryManager.library, {
           try {
             result = stream.tty.ops.get_char(stream.tty);
           } catch (e) {
-            throw new FS.ErrnoError({{{ cDefine('EIO') }}});
+            throw new FS.ErrnoError({{{ cDefs.EIO }}});
           }
           if (result === undefined && bytesRead === 0) {
-            throw new FS.ErrnoError({{{ cDefine('EAGAIN') }}});
+            throw new FS.ErrnoError({{{ cDefs.EAGAIN }}});
           }
           if (result === null || result === undefined) break;
           bytesRead++;
@@ -81,14 +81,14 @@ mergeInto(LibraryManager.library, {
       },
       write: function(stream, buffer, offset, length, pos) {
         if (!stream.tty || !stream.tty.ops.put_char) {
-          throw new FS.ErrnoError({{{ cDefine('ENXIO') }}});
+          throw new FS.ErrnoError({{{ cDefs.ENXIO }}});
         }
         try {
           for (var i = 0; i < length; i++) {
             stream.tty.ops.put_char(stream.tty, buffer[offset+i]);
           }
         } catch (e) {
-          throw new FS.ErrnoError({{{ cDefine('EIO') }}});
+          throw new FS.ErrnoError({{{ cDefs.EIO }}});
         }
         if (length) {
           stream.node.timestamp = Date.now();

--- a/src/library_uuid.js
+++ b/src/library_uuid.js
@@ -140,12 +140,12 @@ mergeInto(LibraryManager.library, {
 
   uuid_type: function(uu) {
     // int uuid_type(const uuid_t uu);
-    return {{{ cDefine('UUID_TYPE_DCE_RANDOM') }}};
+    return {{{ cDefs.UUID_TYPE_DCE_RANDOM }}};
   },
 
   uuid_variant: function(uu) {
     // int uuid_variant(const uuid_t uu);
-    return {{{ cDefine('UUID_VARIANT_DCE') }}};
+    return {{{ cDefs.UUID_VARIANT_DCE }}};
   }
 });
 

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -140,10 +140,10 @@ var WasiLibrary = {
 #endif
 
   $checkWasiClock: function(clock_id) {
-    return clock_id == {{{ cDefine('__WASI_CLOCKID_REALTIME') }}} ||
-           clock_id == {{{ cDefine('__WASI_CLOCKID_MONOTONIC') }}} ||
-           clock_id == {{{ cDefine('__WASI_CLOCKID_PROCESS_CPUTIME_ID') }}} ||
-           clock_id == {{{ cDefine('__WASI_CLOCKID_THREAD_CPUTIME_ID') }}};
+    return clock_id == {{{ cDefs.__WASI_CLOCKID_REALTIME }}} ||
+           clock_id == {{{ cDefs.__WASI_CLOCKID_MONOTONIC }}} ||
+           clock_id == {{{ cDefs.__WASI_CLOCKID_PROCESS_CPUTIME_ID }}} ||
+           clock_id == {{{ cDefs.__WASI_CLOCKID_THREAD_CPUTIME_ID }}};
   },
 
   // TODO: the i64 in the API here must be legalized for this JS code to run,
@@ -155,16 +155,16 @@ var WasiLibrary = {
   clock_time_get__deps: ['emscripten_get_now', '$nowIsMonotonic', '$checkWasiClock'],
   clock_time_get: function(clk_id, {{{ defineI64Param('ignored_precision') }}}, ptime) {
     if (!checkWasiClock(clk_id)) {
-      return {{{ cDefine('EINVAL') }}};
+      return {{{ cDefs.EINVAL }}};
     }
     var now;
     // all wasi clocks but realtime are monotonic
-    if (clk_id === {{{ cDefine('__WASI_CLOCKID_REALTIME') }}}) {
+    if (clk_id === {{{ cDefs.__WASI_CLOCKID_REALTIME }}}) {
       now = Date.now();
     } else if (nowIsMonotonic) {
       now = _emscripten_get_now();
     } else {
-      return {{{ cDefine('ENOSYS') }}};
+      return {{{ cDefs.ENOSYS }}};
     }
     // "now" is in ms, and wasi times are in ns.
     var nsec = Math.round(now * 1000 * 1000);
@@ -178,16 +178,16 @@ var WasiLibrary = {
   clock_res_get__deps: ['emscripten_get_now', 'emscripten_get_now_res', '$nowIsMonotonic', '$checkWasiClock'],
   clock_res_get: function(clk_id, pres) {
     if (!checkWasiClock(clk_id)) {
-      return {{{ cDefine('EINVAL') }}};
+      return {{{ cDefs.EINVAL }}};
     }
     var nsec;
     // all wasi clocks but realtime are monotonic
-    if (clk_id === {{{ cDefine('CLOCK_REALTIME') }}}) {
+    if (clk_id === {{{ cDefs.CLOCK_REALTIME }}}) {
       nsec = 1000 * 1000; // educated guess that it's milliseconds
     } else if (nowIsMonotonic) {
       nsec = _emscripten_get_now_res();
     } else {
-      return {{{ cDefine('ENOSYS') }}};
+      return {{{ cDefs.ENOSYS }}};
     }
     {{{ makeSetValue('pres', 0, 'nsec >>> 0', 'i32') }}};
     {{{ makeSetValue('pres', 4, '(nsec / Math.pow(2, 32)) >>> 0', 'i32') }}};
@@ -297,7 +297,7 @@ var WasiLibrary = {
   fd_pwrite__sig: 'iippjp',
   fd_pwrite: function(fd, iov, iovcnt, {{{ defineI64Param('offset') }}}, pnum) {
 #if SYSCALLS_REQUIRE_FILESYSTEM
-    {{{ receiveI64ParamAsI53('offset', cDefine('EOVERFLOW')) }}}
+    {{{ receiveI64ParamAsI53('offset', cDefs.EOVERFLOW) }}}
     var stream = SYSCALLS.getStreamFromFD(fd)
     var num = doWritev(stream, iov, iovcnt, offset);
     {{{ makeSetValue('pnum', 0, 'num', SIZE_TYPE) }}};
@@ -305,7 +305,7 @@ var WasiLibrary = {
 #elif ASSERTIONS
     abort('fd_pwrite called without SYSCALLS_REQUIRE_FILESYSTEM');
 #else
-    return {{{ cDefine('ENOSYS') }}};
+    return {{{ cDefs.ENOSYS }}};
 #endif
   },
 
@@ -325,7 +325,7 @@ var WasiLibrary = {
 #elif ASSERTIONS
     abort('fd_close called without SYSCALLS_REQUIRE_FILESYSTEM');
 #else
-    return {{{ cDefine('ENOSYS') }}};
+    return {{{ cDefs.ENOSYS }}};
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },
 
@@ -342,7 +342,7 @@ var WasiLibrary = {
 #elif ASSERTIONS
     abort('fd_read called without SYSCALLS_REQUIRE_FILESYSTEM');
 #else
-    return {{{ cDefine('ENOSYS') }}};
+    return {{{ cDefs.ENOSYS }}};
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },
 
@@ -354,7 +354,7 @@ var WasiLibrary = {
   fd_pread__sig: 'iippjp',
   fd_pread: function(fd, iov, iovcnt, {{{ defineI64Param('offset') }}}, pnum) {
 #if SYSCALLS_REQUIRE_FILESYSTEM
-    {{{ receiveI64ParamAsI53('offset', cDefine('EOVERFLOW')) }}}
+    {{{ receiveI64ParamAsI53('offset', cDefs.EOVERFLOW) }}}
     var stream = SYSCALLS.getStreamFromFD(fd)
     var num = doReadv(stream, iov, iovcnt, offset);
     {{{ makeSetValue('pnum', 0, 'num', SIZE_TYPE) }}};
@@ -362,7 +362,7 @@ var WasiLibrary = {
 #elif ASSERTIONS
     abort('fd_pread called without SYSCALLS_REQUIRE_FILESYSTEM');
 #else
-    return {{{ cDefine('ENOSYS') }}};
+    return {{{ cDefs.ENOSYS }}};
 #endif
   },
 
@@ -370,14 +370,14 @@ var WasiLibrary = {
   fd_seek__deps: i53ConversionDeps,
   fd_seek: function(fd, {{{ defineI64Param('offset') }}}, whence, newOffset) {
 #if SYSCALLS_REQUIRE_FILESYSTEM
-    {{{ receiveI64ParamAsI53('offset', cDefine('EOVERFLOW')) }}}
+    {{{ receiveI64ParamAsI53('offset', cDefs.EOVERFLOW) }}}
     var stream = SYSCALLS.getStreamFromFD(fd);
     FS.llseek(stream, offset, whence);
     {{{ makeSetValue('newOffset', '0', 'stream.position', 'i64') }}};
-    if (stream.getdents && offset === 0 && whence === {{{ cDefine('SEEK_SET') }}}) stream.getdents = null; // reset readdir state
+    if (stream.getdents && offset === 0 && whence === {{{ cDefs.SEEK_SET }}}) stream.getdents = null; // reset readdir state
     return 0;
 #else
-    return {{{ cDefine('ESPIPE') }}};
+    return {{{ cDefs.ESPIPE }}};
 #endif
   },
 
@@ -387,13 +387,13 @@ var WasiLibrary = {
     var stream = SYSCALLS.getStreamFromFD(fd);
     // All character devices are terminals (other things a Linux system would
     // assume is a character device, like the mouse, we have special APIs for).
-    var type = stream.tty ? {{{ cDefine('__WASI_FILETYPE_CHARACTER_DEVICE') }}} :
-               FS.isDir(stream.mode) ? {{{ cDefine('__WASI_FILETYPE_DIRECTORY') }}} :
-               FS.isLink(stream.mode) ? {{{ cDefine('__WASI_FILETYPE_SYMBOLIC_LINK') }}} :
-               {{{ cDefine('__WASI_FILETYPE_REGULAR_FILE') }}};
+    var type = stream.tty ? {{{ cDefs.__WASI_FILETYPE_CHARACTER_DEVICE }}} :
+               FS.isDir(stream.mode) ? {{{ cDefs.__WASI_FILETYPE_DIRECTORY }}} :
+               FS.isLink(stream.mode) ? {{{ cDefs.__WASI_FILETYPE_SYMBOLIC_LINK }}} :
+               {{{ cDefs.__WASI_FILETYPE_REGULAR_FILE }}};
 #else
     // hack to support printf in SYSCALLS_REQUIRE_FILESYSTEM=0
-    var type = fd == 1 || fd == 2 ? {{{ cDefine('__WASI_FILETYPE_CHARACTER_DEVICE') }}} : abort();
+    var type = fd == 1 || fd == 2 ? {{{ cDefs.__WASI_FILETYPE_CHARACTER_DEVICE }}} : abort();
 #endif
     {{{ makeSetValue('pbuf', C_STRUCTS.__wasi_fdstat_t.fs_filetype, 'type', 'i8') }}};
     // TODO {{{ makeSetValue('pbuf', C_STRUCTS.__wasi_fdstat_t.fs_flags, '?', 'i16') }}};
@@ -416,7 +416,7 @@ var WasiLibrary = {
       }
       mount.type.syncfs(mount, false, function(err) {
         if (err) {
-          wakeUp(function() { return {{{ cDefine('EIO') }}} });
+          wakeUp(function() { return {{{ cDefs.EIO }}} });
           return;
         }
         wakeUp(0);
@@ -431,7 +431,7 @@ var WasiLibrary = {
 #elif ASSERTIONS
     abort('fd_sync called without SYSCALLS_REQUIRE_FILESYSTEM');
 #else
-    return {{{ cDefine('ENOSYS') }}};
+    return {{{ cDefs.ENOSYS }}};
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },
 };

--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -57,8 +57,8 @@ mergeInto(LibraryManager.library, {
     },
     getMode: (canRead, canWrite) => {
       var mode = 0;
-      if (canRead) mode |= {{{ cDefine('S_IRUGO') }}} | {{{ cDefine('S_IXUGO') }}};
-      if (canWrite) mode |= {{{ cDefine('S_IWUGO') }}};
+      if (canRead) mode |= {{{ cDefs.S_IRUGO }}} | {{{ cDefs.S_IXUGO }}};
+      if (canWrite) mode |= {{{ cDefs.S_IWUGO }}};
       return mode;
     },
     modeStringToFlags: (str) => {
@@ -73,12 +73,12 @@ mergeInto(LibraryManager.library, {
       // Extra quotes used here on the keys to this object otherwise jsifier will
       // erase them in the process of reading and then writing the JS library
       // code.
-      '"r"': {{{ cDefine('O_RDONLY') }}},
-      '"r+"': {{{ cDefine('O_RDWR') }}},
-      '"w"': {{{ cDefine('O_TRUNC') }}} | {{{ cDefine('O_CREAT') }}} | {{{ cDefine('O_WRONLY') }}},
-      '"w+"': {{{ cDefine('O_TRUNC') }}} | {{{ cDefine('O_CREAT') }}} | {{{ cDefine('O_RDWR') }}},
-      '"a"': {{{ cDefine('O_APPEND') }}} | {{{ cDefine('O_CREAT') }}} | {{{ cDefine('O_WRONLY') }}},
-      '"a+"': {{{ cDefine('O_APPEND') }}} | {{{ cDefine('O_CREAT') }}} | {{{ cDefine('O_RDWR') }}},
+      '"r"': {{{ cDefs.O_RDONLY }}},
+      '"r+"': {{{ cDefs.O_RDWR }}},
+      '"w"': {{{ cDefs.O_TRUNC }}} | {{{ cDefs.O_CREAT }}} | {{{ cDefs.O_WRONLY }}},
+      '"w+"': {{{ cDefs.O_TRUNC }}} | {{{ cDefs.O_CREAT }}} | {{{ cDefs.O_RDWR }}},
+      '"a"': {{{ cDefs.O_APPEND }}} | {{{ cDefs.O_CREAT }}} | {{{ cDefs.O_WRONLY }}},
+      '"a+"': {{{ cDefs.O_APPEND }}} | {{{ cDefs.O_CREAT }}} | {{{ cDefs.O_RDWR }}},
     },
     createDataFile: (parent, name, data, canRead, canWrite, canOwn) => {
       // Data files must be cached until the file system itself has been initialized.
@@ -215,11 +215,11 @@ mergeInto(LibraryManager.library, {
     // TODO: utime
     findObject: (path) => {
       var result = __wasmfs_identify(path);
-      if (result == {{{ cDefine('ENOENT') }}}) {
+      if (result == {{{ cDefs.ENOENT }}}) {
         return null;
       }
       return {
-        isFolder: result == {{{ cDefine('EISDIR') }}},
+        isFolder: result == {{{ cDefs.EISDIR }}},
         isDevice: false, // TODO: wasmfs support for devices
       };
     },

--- a/src/library_wasmfs_fetch.js
+++ b/src/library_wasmfs_fetch.js
@@ -74,7 +74,7 @@ mergeInto(LibraryManager.library, {
         try {
           await getFile(file);
         } catch (response) {
-          return response.status === 404 ? -{{{ cDefine('ENOENT') }}} : -{{{ cDefine('EBADF') }}};
+          return response.status === 404 ? -{{{ cDefs.ENOENT }}} : -{{{ cDefs.EBADF }}};
         }
         return jsFileOps.read(file, buffer, length, offset);
       },

--- a/src/library_wasmfs_js_file.js
+++ b/src/library_wasmfs_js_file.js
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
           wasmFS$JSMemoryFiles[file].set(HEAPU8.subarray(buffer, buffer + length), offset);
           return length;
         } catch (err) {
-          return -{{{ cDefine('EIO') }}};
+          return -{{{ cDefs.EIO }}};
         }
       },
       read: (file, buffer, length, offset) => {

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -36,15 +36,15 @@ mergeInto(LibraryManager.library, {
       fileHandle = await parentHandle.getFileHandle(name, {create: create});
     } catch (e) {
       if (e.name === "NotFoundError") {
-        return -{{{ cDefine('EEXIST') }}};
+        return -{{{ cDefs.EEXIST }}};
       }
       if (e.name === "TypeMismatchError") {
-        return -{{{ cDefine('EISDIR') }}};
+        return -{{{ cDefs.EISDIR }}};
       }
 #if ASSERTIONS
       err('unexpected error:', e, e.stack);
 #endif
-      return -{{{ cDefine('EIO') }}};
+      return -{{{ cDefs.EIO }}};
     }
     return wasmfsOPFSFileHandles.allocate(fileHandle);
   },
@@ -61,15 +61,15 @@ mergeInto(LibraryManager.library, {
           await parentHandle.getDirectoryHandle(name, {create: create});
     } catch (e) {
       if (e.name === "NotFoundError") {
-        return -{{{ cDefine('EEXIST') }}};
+        return -{{{ cDefs.EEXIST }}};
       }
       if (e.name === "TypeMismatchError") {
-        return -{{{ cDefine('ENOTDIR') }}};
+        return -{{{ cDefs.ENOTDIR }}};
       }
 #if ASSERTIONS
       err('unexpected error:', e, e.stack);
 #endif
-      return -{{{ cDefine('EIO') }}};
+      return -{{{ cDefs.EIO }}};
     }
     return wasmfsOPFSDirectoryHandles.allocate(childHandle);
   },
@@ -81,7 +81,7 @@ mergeInto(LibraryManager.library, {
     let name = UTF8ToString(namePtr);
     let childType = 1;
     let childID = await wasmfsOPFSGetOrCreateFile(parent, name, false);
-    if (childID == -{{{ cDefine('EISDIR') }}}) {
+    if (childID == -{{{ cDefs.EISDIR }}}) {
       childType = 2;
       childID = await wasmfsOPFSGetOrCreateDir(parent, name, false);
     }
@@ -108,7 +108,7 @@ mergeInto(LibraryManager.library, {
         });
       }
     } catch {
-      let err = -{{{ cDefine('EIO') }}};
+      let err = -{{{ cDefs.EIO }}};
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
     _emscripten_proxy_finish(ctx);
@@ -140,7 +140,7 @@ mergeInto(LibraryManager.library, {
     try {
       await fileHandle.move(newDirHandle, name);
     } catch {
-      let err = -{{{ cDefine('EIO') }}};
+      let err = -{{{ cDefs.EIO }}};
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
     _emscripten_proxy_finish(ctx);
@@ -153,7 +153,7 @@ mergeInto(LibraryManager.library, {
     try {
       await dirHandle.removeEntry(name);
     } catch {
-      let err = -{{{ cDefine('EIO') }}};
+      let err = -{{{ cDefs.EIO }}};
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
     _emscripten_proxy_finish(ctx);
@@ -188,12 +188,12 @@ mergeInto(LibraryManager.library, {
       // TODO: Presumably only one of these will appear in the final API?
       if (e.name === "InvalidStateError" ||
           e.name === "NoModificationAllowedError") {
-        accessID = -{{{ cDefine('EACCES') }}};
+        accessID = -{{{ cDefs.EACCES }}};
       } else {
 #if ASSERTIONS
         err('unexpected error:', e, e.stack);
 #endif
-        accessID = -{{{ cDefine('EIO') }}};
+        accessID = -{{{ cDefs.EIO }}};
       }
     }
     {{{ makeSetValue('accessIDPtr', 0, 'accessID', 'i32') }}};
@@ -210,12 +210,12 @@ mergeInto(LibraryManager.library, {
       blobID = wasmfsOPFSBlobs.allocate(blob);
     } catch (e) {
       if (e.name === "NotAllowedError") {
-        blobID = -{{{ cDefine('EACCES') }}};
+        blobID = -{{{ cDefs.EACCES }}};
       } else {
 #if ASSERTIONS
         err('unexpected error:', e, e.stack);
 #endif
-        blobID = -{{{ cDefine('EIO') }}};
+        blobID = -{{{ cDefs.EIO }}};
       }
     }
     {{{ makeSetValue('blobIDPtr', 0, 'blobID', 'i32') }}};
@@ -228,7 +228,7 @@ mergeInto(LibraryManager.library, {
     try {
       await accessHandle.close();
     } catch {
-      let err = -{{{ cDefine('EIO') }}};
+      let err = -{{{ cDefs.EIO }}};
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
     wasmfsOPFSAccessHandles.free(accessID);
@@ -248,12 +248,12 @@ mergeInto(LibraryManager.library, {
       return accessHandle.read(data, {at: pos});
     } catch (e) {
       if (e.name == "TypeError") {
-        return -{{{ cDefine('EINVAL') }}};
+        return -{{{ cDefs.EINVAL }}};
       }
 #if ASSERTIONS
       err('unexpected error:', e, e.stack);
 #endif
-      return -{{{ cDefine('EIO') }}};
+      return -{{{ cDefs.EIO }}};
     }
   },
 
@@ -273,12 +273,12 @@ mergeInto(LibraryManager.library, {
       nread += data.length;
     } catch (e) {
       if (e instanceof RangeError) {
-        nread = -{{{ cDefine('EFAULT') }}};
+        nread = -{{{ cDefs.EFAULT }}};
       } else {
 #if ASSERTIONS
         err('unexpected error:', e, e.stack);
 #endif
-        nread = -{{{ cDefine('EIO') }}};
+        nread = -{{{ cDefs.EIO }}};
       }
     }
 
@@ -294,12 +294,12 @@ mergeInto(LibraryManager.library, {
       return accessHandle.write(data, {at: pos});
     } catch (e) {
       if (e.name == "TypeError") {
-        return -{{{ cDefine('EINVAL') }}};
+        return -{{{ cDefs.EINVAL }}};
       }
 #if ASSERTIONS
       err('unexpected error:', e, e.stack);
 #endif
-      return -{{{ cDefine('EIO') }}};
+      return -{{{ cDefs.EIO }}};
     }
   },
 
@@ -310,7 +310,7 @@ mergeInto(LibraryManager.library, {
     try {
       size = await accessHandle.getSize();
     } catch {
-      size = -{{{ cDefine('EIO') }}};
+      size = -{{{ cDefs.EIO }}};
     }
     {{{ makeSetValue('sizePtr', 0, 'size', 'i64') }}};
     _emscripten_proxy_finish(ctx);
@@ -329,7 +329,7 @@ mergeInto(LibraryManager.library, {
     try {
       size = (await fileHandle.getFile()).size;
     } catch {
-      size = -{{{ cDefine('EIO') }}};
+      size = -{{{ cDefs.EIO }}};
     }
     {{{ makeSetValue('sizePtr', 0, 'size', 'i64') }}};
     _emscripten_proxy_finish(ctx);
@@ -344,7 +344,7 @@ mergeInto(LibraryManager.library, {
     try {
       await accessHandle.truncate(size);
     } catch {
-      let err = -{{{ cDefine('EIO') }}};
+      let err = -{{{ cDefs.EIO }}};
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
     _emscripten_proxy_finish(ctx);
@@ -361,7 +361,7 @@ mergeInto(LibraryManager.library, {
       await writable.truncate(size);
       await writable.close();
     } catch {
-      let err = -{{{ cDefine('EIO') }}};
+      let err = -{{{ cDefs.EIO }}};
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
     _emscripten_proxy_finish(ctx);
@@ -373,7 +373,7 @@ mergeInto(LibraryManager.library, {
     try {
       await accessHandle.flush();
     } catch {
-      let err = -{{{ cDefine('EIO') }}};
+      let err = -{{{ cDefs.EIO }}};
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
     _emscripten_proxy_finish(ctx);

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1241,7 +1241,7 @@ var LibraryGL = {
         break;
       case 0x8DF8: // GL_SHADER_BINARY_FORMATS
 #if GL_TRACK_ERRORS
-        if (type != {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}} && type != {{{ cDefine('EM_FUNC_SIG_PARAM_I64') }}}) {
+        if (type != {{{ cDefs.EM_FUNC_SIG_PARAM_I }}} && type != {{{ cDefs.EM_FUNC_SIG_PARAM_I64 }}}) {
           GL.recordError(0x500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
           err('GL_INVALID_ENUM in glGet' + type + 'v(GL_SHADER_BINARY_FORMATS): Invalid parameter type!');
@@ -1357,9 +1357,9 @@ var LibraryGL = {
                      result instanceof Array) {
             for (var i = 0; i < result.length; ++i) {
               switch (type) {
-                case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('p', 'i*4', 'result[i]', 'i32') }}}; break;
-                case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('p', 'i*4', 'result[i]', 'float') }}}; break;
-                case {{{ cDefine('EM_FUNC_SIG_PARAM_B') }}}: {{{ makeSetValue('p', 'i',   'result[i] ? 1 : 0', 'i8') }}}; break;
+                case {{{ cDefs.EM_FUNC_SIG_PARAM_I }}}: {{{ makeSetValue('p', 'i*4', 'result[i]', 'i32') }}}; break;
+                case {{{ cDefs.EM_FUNC_SIG_PARAM_F }}}: {{{ makeSetValue('p', 'i*4', 'result[i]', 'float') }}}; break;
+                case {{{ cDefs.EM_FUNC_SIG_PARAM_B }}}: {{{ makeSetValue('p', 'i',   'result[i] ? 1 : 0', 'i8') }}}; break;
 #if GL_ASSERTIONS
                 default: throw 'internal glGet error, bad type: ' + type;
 #endif
@@ -1390,10 +1390,10 @@ var LibraryGL = {
     }
 
     switch (type) {
-      case {{{ cDefine('EM_FUNC_SIG_PARAM_I64') }}}: writeI53ToI64(p, ret); break;
-      case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('p', '0', 'ret', 'i32') }}}; break;
-      case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}:   {{{ makeSetValue('p', '0', 'ret', 'float') }}}; break;
-      case {{{ cDefine('EM_FUNC_SIG_PARAM_B') }}}: {{{ makeSetValue('p', '0', 'ret ? 1 : 0', 'i8') }}}; break;
+      case {{{ cDefs.EM_FUNC_SIG_PARAM_I64 }}}: writeI53ToI64(p, ret); break;
+      case {{{ cDefs.EM_FUNC_SIG_PARAM_I }}}: {{{ makeSetValue('p', '0', 'ret', 'i32') }}}; break;
+      case {{{ cDefs.EM_FUNC_SIG_PARAM_F }}}:   {{{ makeSetValue('p', '0', 'ret', 'float') }}}; break;
+      case {{{ cDefs.EM_FUNC_SIG_PARAM_B }}}: {{{ makeSetValue('p', '0', 'ret ? 1 : 0', 'i8') }}}; break;
 #if GL_ASSERTIONS
       default: throw 'internal glGet error, bad type: ' + type;
 #endif
@@ -1403,19 +1403,19 @@ var LibraryGL = {
   glGetIntegerv__sig: 'vip',
   glGetIntegerv__deps: ['$emscriptenWebGLGet'],
   glGetIntegerv: function(name_, p) {
-    emscriptenWebGLGet(name_, p, {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}});
+    emscriptenWebGLGet(name_, p, {{{ cDefs.EM_FUNC_SIG_PARAM_I }}});
   },
 
   glGetFloatv__sig: 'vip',
   glGetFloatv__deps: ['$emscriptenWebGLGet'],
   glGetFloatv: function(name_, p) {
-    emscriptenWebGLGet(name_, p, {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}});
+    emscriptenWebGLGet(name_, p, {{{ cDefs.EM_FUNC_SIG_PARAM_F }}});
   },
 
   glGetBooleanv__sig: 'vip',
   glGetBooleanv__deps: ['$emscriptenWebGLGet'],
   glGetBooleanv: function(name_, p) {
-    emscriptenWebGLGet(name_, p, {{{ cDefine('EM_FUNC_SIG_PARAM_B') }}});
+    emscriptenWebGLGet(name_, p, {{{ cDefs.EM_FUNC_SIG_PARAM_B }}});
   },
 
   glDeleteTextures__sig: 'vip',
@@ -2034,8 +2034,8 @@ var LibraryGL = {
     var data = GLctx.getUniform(program, webglGetUniformLocation(location));
     if (typeof data == 'number' || typeof data == 'boolean') {
       switch (type) {
-        case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('params', '0', 'data', 'i32') }}}; break;
-        case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('params', '0', 'data', 'float') }}}; break;
+        case {{{ cDefs.EM_FUNC_SIG_PARAM_I }}}: {{{ makeSetValue('params', '0', 'data', 'i32') }}}; break;
+        case {{{ cDefs.EM_FUNC_SIG_PARAM_F }}}: {{{ makeSetValue('params', '0', 'data', 'float') }}}; break;
 #if GL_ASSERTIONS
         default: throw 'internal emscriptenWebGLGetUniform() error, bad type: ' + type;
 #endif
@@ -2043,8 +2043,8 @@ var LibraryGL = {
     } else {
       for (var i = 0; i < data.length; i++) {
         switch (type) {
-          case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'i32') }}}; break;
-          case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'float') }}}; break;
+          case {{{ cDefs.EM_FUNC_SIG_PARAM_I }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'i32') }}}; break;
+          case {{{ cDefs.EM_FUNC_SIG_PARAM_F }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'float') }}}; break;
 #if GL_ASSERTIONS
           default: throw 'internal emscriptenWebGLGetUniform() error, bad type: ' + type;
 #endif
@@ -2056,13 +2056,13 @@ var LibraryGL = {
   glGetUniformfv__sig: 'viip',
   glGetUniformfv__deps: ['$emscriptenWebGLGetUniform'],
   glGetUniformfv: function(program, location, params) {
-    emscriptenWebGLGetUniform(program, location, params, {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}});
+    emscriptenWebGLGetUniform(program, location, params, {{{ cDefs.EM_FUNC_SIG_PARAM_F }}});
   },
 
   glGetUniformiv__sig: 'viip',
   glGetUniformiv__deps: ['$emscriptenWebGLGetUniform'],
   glGetUniformiv: function(program, location, params) {
-    emscriptenWebGLGetUniform(program, location, params, {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}});
+    emscriptenWebGLGetUniform(program, location, params, {{{ cDefs.EM_FUNC_SIG_PARAM_I }}});
   },
 
   // Returns the WebGLUniformLocation object corresponding to the location index integer on
@@ -2229,9 +2229,9 @@ var LibraryGL = {
       {{{ makeSetValue('params', '0', 'data && data["name"]', 'i32') }}};
     } else if (typeof data == 'number' || typeof data == 'boolean') {
       switch (type) {
-        case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('params', '0', 'data', 'i32') }}}; break;
-        case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('params', '0', 'data', 'float') }}}; break;
-        case {{{ cDefine('EM_FUNC_SIG_PARAM_F2I') }}}: {{{ makeSetValue('params', '0', 'Math.fround(data)', 'i32') }}}; break;
+        case {{{ cDefs.EM_FUNC_SIG_PARAM_I }}}: {{{ makeSetValue('params', '0', 'data', 'i32') }}}; break;
+        case {{{ cDefs.EM_FUNC_SIG_PARAM_F }}}: {{{ makeSetValue('params', '0', 'data', 'float') }}}; break;
+        case {{{ cDefs.EM_FUNC_SIG_PARAM_F2I }}}: {{{ makeSetValue('params', '0', 'Math.fround(data)', 'i32') }}}; break;
 #if GL_ASSERTIONS
         default: throw 'internal emscriptenWebGLGetVertexAttrib() error, bad type: ' + type;
 #endif
@@ -2239,9 +2239,9 @@ var LibraryGL = {
     } else {
       for (var i = 0; i < data.length; i++) {
         switch (type) {
-          case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'i32') }}}; break;
-          case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'float') }}}; break;
-          case {{{ cDefine('EM_FUNC_SIG_PARAM_F2I') }}}: {{{ makeSetValue('params', 'i*4', 'Math.fround(data[i])', 'i32') }}}; break;
+          case {{{ cDefs.EM_FUNC_SIG_PARAM_I }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'i32') }}}; break;
+          case {{{ cDefs.EM_FUNC_SIG_PARAM_F }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'float') }}}; break;
+          case {{{ cDefs.EM_FUNC_SIG_PARAM_F2I }}}: {{{ makeSetValue('params', 'i*4', 'Math.fround(data[i])', 'i32') }}}; break;
 #if GL_ASSERTIONS
           default: throw 'internal emscriptenWebGLGetVertexAttrib() error, bad type: ' + type;
 #endif
@@ -2255,7 +2255,7 @@ var LibraryGL = {
   glGetVertexAttribfv: function(index, pname, params) {
     // N.B. This function may only be called if the vertex attribute was specified using the function glVertexAttrib*f(),
     // otherwise the results are undefined. (GLES3 spec 6.1.12)
-    emscriptenWebGLGetVertexAttrib(index, pname, params, {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}});
+    emscriptenWebGLGetVertexAttrib(index, pname, params, {{{ cDefs.EM_FUNC_SIG_PARAM_F }}});
   },
 
   glGetVertexAttribiv__sig: 'viip',
@@ -2263,7 +2263,7 @@ var LibraryGL = {
   glGetVertexAttribiv: function(index, pname, params) {
     // N.B. This function may only be called if the vertex attribute was specified using the function glVertexAttrib*f(),
     // otherwise the results are undefined. (GLES3 spec 6.1.12)
-    emscriptenWebGLGetVertexAttrib(index, pname, params, {{{ cDefine('EM_FUNC_SIG_PARAM_F2I') }}});
+    emscriptenWebGLGetVertexAttrib(index, pname, params, {{{ cDefs.EM_FUNC_SIG_PARAM_F2I }}});
   },
 
   glGetVertexAttribPointerv__sig: 'viip',

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -52,7 +52,7 @@ var LibraryWebGL2 = {
   glGetInteger64v__sig: 'vii',
   glGetInteger64v__deps: ['$emscriptenWebGLGet'],
   glGetInteger64v: function(name_, p) {
-    emscriptenWebGLGet(name_, p, {{{ cDefine('EM_FUNC_SIG_PARAM_I64') }}});
+    emscriptenWebGLGet(name_, p, {{{ cDefs.EM_FUNC_SIG_PARAM_I64 }}});
   },
 
   glGetInternalformativ__sig: 'viiiii',
@@ -495,10 +495,10 @@ var LibraryWebGL2 = {
     }
 
     switch (type) {
-      case {{{ cDefine('EM_FUNC_SIG_PARAM_I64') }}}: writeI53ToI64(data, ret); break;
-      case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('data', '0', 'ret', 'i32') }}}; break;
-      case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('data', '0', 'ret', 'float') }}}; break;
-      case {{{ cDefine('EM_FUNC_SIG_PARAM_B') }}}: {{{ makeSetValue('data', '0', 'ret ? 1 : 0', 'i8') }}}; break;
+      case {{{ cDefs.EM_FUNC_SIG_PARAM_I64 }}}: writeI53ToI64(data, ret); break;
+      case {{{ cDefs.EM_FUNC_SIG_PARAM_I }}}: {{{ makeSetValue('data', '0', 'ret', 'i32') }}}; break;
+      case {{{ cDefs.EM_FUNC_SIG_PARAM_F }}}: {{{ makeSetValue('data', '0', 'ret', 'float') }}}; break;
+      case {{{ cDefs.EM_FUNC_SIG_PARAM_B }}}: {{{ makeSetValue('data', '0', 'ret ? 1 : 0', 'i8') }}}; break;
       default: throw 'internal emscriptenWebGLGetIndexed() error, bad type: ' + type;
     }
   },
@@ -506,13 +506,13 @@ var LibraryWebGL2 = {
   glGetIntegeri_v__sig: 'viii',
   glGetIntegeri_v__deps: ['$emscriptenWebGLGetIndexed'],
   glGetIntegeri_v: function(target, index, data) {
-    emscriptenWebGLGetIndexed(target, index, data, {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}});
+    emscriptenWebGLGetIndexed(target, index, data, {{{ cDefs.EM_FUNC_SIG_PARAM_I }}});
   },
 
   glGetInteger64i_v__sig: 'viii',
   glGetInteger64i_v__deps: ['$emscriptenWebGLGetIndexed'],
   glGetInteger64i_v: function(target, index, data) {
-    emscriptenWebGLGetIndexed(target, index, data, {{{ cDefine('EM_FUNC_SIG_PARAM_I64') }}});
+    emscriptenWebGLGetIndexed(target, index, data, {{{ cDefs.EM_FUNC_SIG_PARAM_I64 }}});
   },
 
   // Uniform Buffer objects
@@ -783,7 +783,7 @@ var LibraryWebGL2 = {
   glGetUniformuiv__sig: 'viii',
   glGetUniformuiv__deps: ['$emscriptenWebGLGetUniform'],
   glGetUniformuiv: function(program, location, params) {
-    emscriptenWebGLGetUniform(program, location, params, {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}});
+    emscriptenWebGLGetUniform(program, location, params, {{{ cDefs.EM_FUNC_SIG_PARAM_I }}});
   },
 
   glGetFragDataLocation__sig: 'iii',
@@ -799,7 +799,7 @@ var LibraryWebGL2 = {
   glGetVertexAttribIiv: function(index, pname, params) {
     // N.B. This function may only be called if the vertex attribute was specified using the function glVertexAttribI4iv(),
     // otherwise the results are undefined. (GLES3 spec 6.1.12)
-    emscriptenWebGLGetVertexAttrib(index, pname, params, {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}});
+    emscriptenWebGLGetVertexAttrib(index, pname, params, {{{ cDefs.EM_FUNC_SIG_PARAM_I }}});
   },
 
   // N.B. This function may only be called if the vertex attribute was specified using the function glVertexAttribI4uiv(),

--- a/src/library_websocket.js
+++ b/src/library_websocket.js
@@ -19,11 +19,11 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_get_ready_state(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
 
     {{{ makeSetValue('readyState', '0', 'socket.readyState', 'i16') }}};
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_get_buffered_amount__deps: ['$WS'],
@@ -35,11 +35,11 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_get_buffered_amount(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
 
     {{{ makeSetValue('bufferedAmount', '0', 'socket.bufferedAmount', '*') }}};
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_get_extensions__deps: ['$WS'],
@@ -51,11 +51,11 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_get_extensions(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
-    if (!extensions) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+    if (!extensions) return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_PARAM }}};
     stringToUTF8(socket.extensions, extensions, extensionsLength);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_get_extensions_length__deps: ['$WS'],
@@ -67,11 +67,11 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_get_extensions_length(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
-    if (!extensionsLength) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+    if (!extensionsLength) return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_PARAM }}};
     {{{ makeSetValue('extensionsLength', '0', 'lengthBytesUTF8(socket.extensions)+1', 'i32') }}};
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_get_protocol__deps: ['$WS'],
@@ -83,11 +83,11 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_get_protocol(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
-    if (!protocol) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+    if (!protocol) return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_PARAM }}};
     stringToUTF8(socket.protocol, protocol, protocolLength);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_get_protocol_length__deps: ['$WS'],
@@ -99,11 +99,11 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_get_protocol_length(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
-    if (!protocolLength) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+    if (!protocolLength) return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_PARAM }}};
     {{{ makeSetValue('protocolLength', '0', 'lengthBytesUTF8(socket.protocol)+1', 'i32') }}};
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_get_url__deps: ['$WS'],
@@ -115,11 +115,11 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_get_url(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
-    if (!url) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+    if (!url) return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_PARAM }}};
     stringToUTF8(socket.url, url, urlLength);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_get_url_length__deps: ['$WS'],
@@ -131,11 +131,11 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_get_url_length(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
-    if (!urlLength) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+    if (!urlLength) return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_PARAM }}};
     {{{ makeSetValue('urlLength', '0', 'lengthBytesUTF8(socket.url)+1', 'i32') }}};
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_set_onopen_callback_on_thread__deps: ['$WS'],
@@ -143,7 +143,7 @@ var LibraryWebSocket = {
   emscripten_websocket_set_onopen_callback_on_thread__sig: 'iippp',
   emscripten_websocket_set_onopen_callback_on_thread: function(socketId, userData, callbackFunc, thread) {
 // TODO:
-//    if (thread == {{{ cDefine('EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD') }}} ||
+//    if (thread == {{{ cDefs.EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD }}} ||
 //      (thread == _pthread_self()) return emscripten_websocket_set_onopen_callback_on_calling_thread(socketId, userData, callbackFunc);
 
     if (!WS.socketEvent) WS.socketEvent = _malloc(1024); // TODO: sizeof(EmscriptenWebSocketCloseEvent), which is the largest event struct
@@ -153,7 +153,7 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_set_onopen_callback(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
 
 #if WEBSOCKET_DEBUG
@@ -166,7 +166,7 @@ var LibraryWebSocket = {
       HEAPU32[WS.socketEvent>>2] = socketId;
       {{{ makeDynCall('iiii', 'callbackFunc') }}}(0/*TODO*/, WS.socketEvent, userData);
     }
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_set_onerror_callback_on_thread__deps: ['$WS'],
@@ -180,7 +180,7 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_set_onerror_callback(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
 
 #if WEBSOCKET_DEBUG
@@ -193,7 +193,7 @@ var LibraryWebSocket = {
       HEAPU32[WS.socketEvent>>2] = socketId;
       {{{ makeDynCall('iiii', 'callbackFunc') }}}(0/*TODO*/, WS.socketEvent, userData);
     }
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_set_onclose_callback_on_thread__deps: ['$WS'],
@@ -207,7 +207,7 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_set_onclose_callback(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
 
 #if WEBSOCKET_DEBUG
@@ -223,7 +223,7 @@ var LibraryWebSocket = {
       stringToUTF8(e.reason, WS.socketEvent+10, 512);
       {{{ makeDynCall('iiii', 'callbackFunc') }}}(0/*TODO*/, WS.socketEvent, userData);
     }
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_set_onmessage_callback_on_thread__deps: ['$WS'],
@@ -237,7 +237,7 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_set_onmessage_callback(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
 
 #if WEBSOCKET_DEBUG
@@ -278,7 +278,7 @@ var LibraryWebSocket = {
       {{{ makeDynCall('iiii', 'callbackFunc') }}}(0/*TODO*/, WS.socketEvent, userData);
       _free(buf);
     }
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_new__deps: ['$WS'],
@@ -289,13 +289,13 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_new(): WebSocket API is not supported by current browser)');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
     if (!createAttributes) {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_new(): Missing required "createAttributes" function parameter!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_PARAM }}};
     }
 
     var createAttrs = createAttributes>>2;
@@ -326,7 +326,7 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_send_utf8_text(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
 
     var str = UTF8ToString(textData);
@@ -338,7 +338,7 @@ var LibraryWebSocket = {
 #endif
 #endif
     socket.send(str);
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_send_binary__deps: ['$WS'],
@@ -350,7 +350,7 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_send_binary(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
 
 #if WEBSOCKET_DEBUG
@@ -370,7 +370,7 @@ var LibraryWebSocket = {
 #else
     socket.send({{{ makeHEAPView('U8', 'binaryData', 'binaryData+dataLength') }}});
 #endif
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_close__deps: ['$WS'],
@@ -382,7 +382,7 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_close(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
 
     var reasonStr = reason ? UTF8ToString(reason) : undefined;
@@ -397,7 +397,7 @@ var LibraryWebSocket = {
     if (reason) socket.close(code || undefined, UTF8ToString(reason));
     else if (code) socket.close(code);
     else socket.close();
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_delete__deps: ['$WS'],
@@ -409,7 +409,7 @@ var LibraryWebSocket = {
 #if WEBSOCKET_DEBUG
       dbg('emscripten_websocket_delete(): Invalid socket ID ' + socketId + ' specified!');
 #endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+      return {{{ cDefs.EMSCRIPTEN_RESULT_INVALID_TARGET }}};
     }
 
 #if WEBSOCKET_DEBUG
@@ -417,7 +417,7 @@ var LibraryWebSocket = {
 #endif
     socket.onopen = socket.onerror = socket.onclose = socket.onmessage = null;
     delete WS.sockets[socketId];
-    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
   emscripten_websocket_is_supported__proxy: 'sync',

--- a/src/library_workerfs.js
+++ b/src/library_workerfs.js
@@ -7,8 +7,8 @@
 mergeInto(LibraryManager.library, {
   $WORKERFS__deps: ['$FS'],
   $WORKERFS: {
-    DIR_MODE: {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */,
-    FILE_MODE: {{{ cDefine('S_IFREG') }}} | 511 /* 0777 */,
+    DIR_MODE: {{{ cDefs.S_IFDIR }}} | 511 /* 0777 */,
+    FILE_MODE: {{{ cDefs.S_IFREG }}} | 511 /* 0777 */,
     reader: null,
     mount: function (mount) {
       assert(ENVIRONMENT_IS_WORKER);
@@ -100,19 +100,19 @@ mergeInto(LibraryManager.library, {
         }
       },
       lookup: function(parent, name) {
-        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
+        throw new FS.ErrnoError({{{ cDefs.ENOENT }}});
       },
       mknod: function (parent, name, mode, dev) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       },
       rename: function (oldNode, newDir, newName) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       },
       unlink: function(parent, name) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       },
       rmdir: function(parent, name) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       },
       readdir: function(node) {
         var entries = ['.', '..'];
@@ -125,7 +125,7 @@ mergeInto(LibraryManager.library, {
         return entries;
       },
       symlink: function(parent, newName, oldPath) {
-        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
+        throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       },
     },
     stream_ops: {
@@ -137,19 +137,19 @@ mergeInto(LibraryManager.library, {
         return chunk.size;
       },
       write: function (stream, buffer, offset, length, position) {
-        throw new FS.ErrnoError({{{ cDefine('EIO') }}});
+        throw new FS.ErrnoError({{{ cDefs.EIO }}});
       },
       llseek: function (stream, offset, whence) {
         var position = offset;
-        if (whence === {{{ cDefine('SEEK_CUR') }}}) {
+        if (whence === {{{ cDefs.SEEK_CUR }}}) {
           position += stream.position;
-        } else if (whence === {{{ cDefine('SEEK_END') }}}) {
+        } else if (whence === {{{ cDefs.SEEK_END }}}) {
           if (FS.isFile(stream.node.mode)) {
             position += stream.node.size;
           }
         }
         if (position < 0) {
-          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+          throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
         }
         return position;
       },

--- a/src/modules.js
+++ b/src/modules.js
@@ -255,10 +255,30 @@ if (!BOOTSTRAPPING_STRUCT_INFO) {
   C_DEFINES = {};
 }
 
-// Safe way to access a C define. We check that we don't add library functions with missing defines.
+// Use proxy objects for C_DEFINES and C_STRUCTS so that we can give useful
+// error messages.
+C_STRUCTS = new Proxy(C_STRUCTS, {
+  get(target, prop, receiver) {
+    if (!(prop in target)) {
+      throw new Error(`Missing C struct ${prop}! If you just added it to struct_info.json, you need to ./emcc --clear-cache`);
+    }
+    return target[prop]
+  }
+});
+
+cDefs = C_DEFINES = new Proxy(C_DEFINES, {
+  get(target, prop, receiver) {
+    if (!(prop in target)) {
+      throw new Error(`Missing C define ${prop}! If you just added it to struct_info.json, you need to ./emcc --clear-cache`);
+    }
+    return target[prop]
+  }
+});
+
+// Legacy function that existed solely to give error message.  These are now
+// provided by the cDefs proxy object above.
 function cDefine(key) {
-  if (key in C_DEFINES) return C_DEFINES[key];
-  throw new Error(`Missing C define ${key}! If you just added it to struct_info.json, you need to ./emcc --clear-cache`);
+  return cDefs[key];
 }
 
 function isFSPrefixed(name) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -255,7 +255,7 @@ function handleMessage(e) {
       }
     } else if (e.data.cmd === 'cancel') { // Main thread is asking for a pthread_cancel() on this thread.
       if (Module['_pthread_self']()) {
-        Module['__emscripten_thread_exit']({{{ cDefine('PTHREAD_CANCELED') }}});
+        Module['__emscripten_thread_exit']({{{ cDefs.PTHREAD_CANCELED }}});
       }
     } else if (e.data.target === 'setimmediate') {
       // no-op

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13252,3 +13252,16 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     # See https://github.com/llvm/llvm-project/commit/c800391fb974cdaaa62bd74435f76408c2e5ceae
     err = self.expect_fail([EMCC, '-pthreads', '-c', test_file('hello_world.c')])
     self.assertContained('emcc: error: unrecognized command-line option `-pthreads`; did you mean `-pthread`?', err)
+
+  def test_missing_struct_info(self):
+    create_file('lib.js', '''
+      {{{ C_STRUCTS.Foo }}}
+    ''')
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js'])
+    self.assertContained('Error: Missing C struct Foo! If you just added it to struct_info.json, you need to ./emcc --clear-cache', err)
+
+    create_file('lib.js', '''
+      {{{ C_DEFINES.Foo }}}
+    ''')
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js'])
+    self.assertContained('Error: Missing C define Foo! If you just added it to struct_info.json, you need to ./emcc --clear-cache', err)

--- a/tools/maint/check_struct_info.py
+++ b/tools/maint/check_struct_info.py
@@ -34,7 +34,7 @@ def check_structs(info):
 
 def check_defines(info):
   for define in info['defines'].keys():
-    key = 'cDefine(.' + define + '.)'
+    key = r'cDefs\.' + define + r'\>'
     # grep --quiet ruturns 0 when there is a match
     if subprocess.run(['git', 'grep', '--quiet', key], check=False).returncode != 0:
       print(define)


### PR DESCRIPTION
This allows for less syntax when specifying C defines in JS code.  We still need the ugly triple braces but we can avoid the extra quotation marks and function call braces.

This is how we already use the `cStructs` object.