### PR TITLE
[WebGPU] Fix texture GetFormat to return enum int

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -2008,7 +2008,6 @@ var LibraryWebGPU = {
 
   wgpuTextureGetFormat: function(textureId) {
     var texture = WebGPU.mgrTexture.get(textureId);
-    // TODO(#18962): use reverse-lookup table.
     // Should return the enum integer instead of string.
     return WebGPU.TextureFormat.indexOf(texture.format);
   },

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -2103,24 +2103,14 @@ var LibraryWebGPU = {
 
   wgpuComputePassEncoderDispatchWorkgroups: function(passId, x, y, z) {
     var pass = WebGPU.mgrComputePassEncoder.get(passId);
-    // TODO(shrekshao): Remove deprecated dispatch path
-    if (pass["dispatchWorkgroups"]) {
-      pass["dispatchWorkgroups"](x, y, z);
-    } else {
-      pass["dispatch"](x, y, z);
-    }
+    pass["dispatchWorkgroups"](x, y, z);
   },
   wgpuComputePassEncoderDispatchWorkgroupsIndirect: function(passId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
     {{{ receiveI64ParamAsI32s('indirectOffset') }}}
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
     var indirectOffset = {{{ gpu.makeI32I32ToU53('indirectOffset_low', 'indirectOffset_high') }}};
     var pass = WebGPU.mgrComputePassEncoder.get(passId);
-    // TODO(shrekshao): Remove deprecated dispatchIndirect path
-    if (pass["dispatchWorkgroupsIndirect"]) {
-      pass["dispatchWorkgroupsIndirect"](indirectBuffer, indirectOffset);
-    } else {
-      pass["dispatchIndirect"](indirectBuffer, indirectOffset);
-    }
+    pass["dispatchWorkgroupsIndirect"](indirectBuffer, indirectOffset);
   },
 
   wgpuComputePassEncoderBeginPipelineStatisticsQuery: function(passId, querySetId, queryIndex) {

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -2008,7 +2008,9 @@ var LibraryWebGPU = {
 
   wgpuTextureGetFormat: function(textureId) {
     var texture = WebGPU.mgrTexture.get(textureId);
-    return texture.format;
+    // TODO(#18962): use reverse-lookup table.
+    // Should return the enum integer instead of string.
+    return WebGPU.TextureFormat.indexOf(texture.format);
   },
 
   wgpuTextureGetHeight: function(textureId) {

--- a/test/webgpu_basic_rendering.cpp
+++ b/test/webgpu_basic_rendering.cpp
@@ -45,14 +45,14 @@ void GetDevice(void (*callback)(wgpu::Device)) {
 }
 
 static const char shaderCode[] = R"(
-    @stage(vertex)
+    @vertex
     fn main_v(@builtin(vertex_index) idx: u32) -> @builtin(position) vec4<f32> {
         var pos = array<vec2<f32>, 3>(
             vec2<f32>(0.0, 0.5), vec2<f32>(-0.5, -0.5), vec2<f32>(0.5, -0.5));
         return vec4<f32>(pos[idx], 0.0, 1.0);
     }
 
-    @stage(fragment)
+    @fragment
     fn main_f() -> @location(0) vec4<f32> {
         return vec4<f32>(0.0, 0.502, 1.0, 1.0); // 0x80/0xff ~= 0.502
     }
@@ -308,6 +308,12 @@ void doRenderTest() {
         depthTexture = device.CreateTexture(&descriptor);
     }
     render(readbackTexture.CreateView(), depthTexture.CreateView());
+
+    {
+        // A little texture.GetFormat test
+        assert(wgpu::TextureFormat::BGRA8Unorm == readbackTexture.GetFormat());
+        assert(wgpu::TextureFormat::Depth32Float == depthTexture.GetFormat());
+    }
 
     {
         wgpu::BufferDescriptor descriptor{};


### PR DESCRIPTION
* (#18962) Fix texture GetFormat to return enum int; Add a little GetFormat test in `test/webgpu_basic_rendering.cpp`
* Remove the deprecated `dispatch`/`dispatchIndirect` path by the way.

Intended reviewer: @kainino0x 