### PR TITLE
Avoid GL symbols being added to library as "undefined". NFC

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -28,16 +28,16 @@
 var LibraryEmbind = {
   $InternalError__postset: "InternalError = Module['InternalError'] = extendError(Error, 'InternalError');",
   $InternalError__deps: ['$extendError'],
-  $InternalError:  undefined,
+  $InternalError: null,
   $BindingError__postset: "BindingError = Module['BindingError'] = extendError(Error, 'BindingError');",
   $BindingError__deps: ['$extendError'],
-  $BindingError: undefined,
+  $BindingError: null,
   $UnboundTypeError__postset: "UnboundTypeError = Module['UnboundTypeError'] = extendError(Error, 'UnboundTypeError');",
   $UnboundTypeError__deps: ['$extendError'],
-  $UnboundTypeError: undefined,
+  $UnboundTypeError: null,
   $PureVirtualError__postset: "PureVirtualError = Module['PureVirtualError'] = extendError(Error, 'PureVirtualError');",
   $PureVirtualError__deps: ['$extendError'],
-  $PureVirtualError: undefined,
+  $PureVirtualError: null,
 
   $init_embind__deps: [
     '$getInheritedInstanceCount', '$getLiveInheritedInstances',
@@ -352,7 +352,7 @@ var LibraryEmbind = {
 
   $embind_charCodes__deps: ['$embind_init_charCodes'],
   $embind_charCodes__postset: "embind_init_charCodes()",
-  $embind_charCodes: undefined,
+  $embind_charCodes: null,
   $embind_init_charCodes: function() {
     var codes = new Array(256);
     for (var i = 0; i < 256; ++i) {
@@ -1946,7 +1946,7 @@ var LibraryEmbind = {
     }
   },
 
-  $delayFunction: undefined,
+  $delayFunction: null,
 
   $setDelayFunction__deps: ['$delayFunction', '$deletionQueue', '$flushPendingDeletes'],
   $setDelayFunction: function(fn) {

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -326,6 +326,7 @@ function ${name}(${args}) {
       librarySymbols.push(mangled);
 
       const original = LibraryManager.library[symbol];
+      assert(typeof original != 'undefined', 'undefined symbol in LibraryManager: ' + symbol);
       let snippet = original;
 
       const isUserSymbol = LibraryManager.library[symbol + '__user'];

--- a/src/library_addfunction.js
+++ b/src/library_addfunction.js
@@ -142,7 +142,7 @@ mergeInto(LibraryManager.library, {
   $freeTableIndexes: [],
 
   // Weak map of functions in the table to their indexes, created on first use.
-  $functionsInTableMap: undefined,
+  $functionsInTableMap: null,
 
   $getEmptyTableSlot__deps: ['$freeTableIndexes'],
   $getEmptyTableSlot: function() {

--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -3881,16 +3881,16 @@ var LibraryGLEmulation = {
 
   // Open GLES1.1 compatibility
 
-  glGenFramebuffersOES : 'glGenFramebuffers',
-  glGenRenderbuffersOES : 'glGenRenderbuffers',
-  glBindFramebufferOES : 'glBindFramebuffer',
-  glBindRenderbufferOES : 'glBindRenderbuffer',
-  glGetRenderbufferParameterivOES : 'glGetRenderbufferParameteriv',
-  glFramebufferRenderbufferOES : 'glFramebufferRenderbuffer',
-  glRenderbufferStorageOES : 'glRenderbufferStorage',
-  glCheckFramebufferStatusOES : 'glCheckFramebufferStatus',
-  glDeleteFramebuffersOES : 'glDeleteFramebuffers',
-  glDeleteRenderbuffersOES : 'glDeleteRenderbuffers',
+  glGenFramebuffersOES: 'glGenFramebuffers',
+  glGenRenderbuffersOES: 'glGenRenderbuffers',
+  glBindFramebufferOES: 'glBindFramebuffer',
+  glBindRenderbufferOES: 'glBindRenderbuffer',
+  glGetRenderbufferParameterivOES: 'glGetRenderbufferParameteriv',
+  glFramebufferRenderbufferOES: 'glFramebufferRenderbuffer',
+  glRenderbufferStorageOES: 'glRenderbufferStorage',
+  glCheckFramebufferStatusOES: 'glCheckFramebufferStatus',
+  glDeleteFramebuffersOES: 'glDeleteFramebuffers',
+  glDeleteRenderbuffersOES: 'glDeleteRenderbuffers',
   glFramebufferTexture2DOES: 'glFramebufferTexture2D',
 
   // GLU


### PR DESCRIPTION
The `recordGLProcAddressGet` was processing aliases, but it was assuming the aliases existed within the same library file which in was not the case for `glGenFramebuffersOES` and others in this file that alias symbols in `library_webgl.js`.

This was resulting the jsifier thinking the symbols was defined (since it existed in the library) but generating undefined symbols in the in the final output such as:

```
var glGenFramebuffersOES = undefined;
```

Removing the aliasing resolution from `recordGLProcAddressGet` lets `jsifier.js` handle the alias which results in the following output after this change:

```
var _glGenFramebuffersOES = _glGenFramebuffers;
```

Also add some assertions so these types of error don't get overlooked in the future.