### PR TITLE
Use normal JS library aliases for GL symbols. NFC

### DIFF
--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -3881,16 +3881,16 @@ var LibraryGLEmulation = {
 
   // Open GLES1.1 compatibility
 
-  glGenFramebuffersOES : 'glGenFramebuffers',
-  glGenRenderbuffersOES : 'glGenRenderbuffers',
-  glBindFramebufferOES : 'glBindFramebuffer',
-  glBindRenderbufferOES : 'glBindRenderbuffer',
-  glGetRenderbufferParameterivOES : 'glGetRenderbufferParameteriv',
-  glFramebufferRenderbufferOES : 'glFramebufferRenderbuffer',
-  glRenderbufferStorageOES : 'glRenderbufferStorage',
-  glCheckFramebufferStatusOES : 'glCheckFramebufferStatus',
-  glDeleteFramebuffersOES : 'glDeleteFramebuffers',
-  glDeleteRenderbuffersOES : 'glDeleteRenderbuffers',
+  glGenFramebuffersOES: 'glGenFramebuffers',
+  glGenRenderbuffersOES: 'glGenRenderbuffers',
+  glBindFramebufferOES: 'glBindFramebuffer',
+  glBindRenderbufferOES: 'glBindRenderbuffer',
+  glGetRenderbufferParameterivOES: 'glGetRenderbufferParameteriv',
+  glFramebufferRenderbufferOES: 'glFramebufferRenderbuffer',
+  glRenderbufferStorageOES: 'glRenderbufferStorage',
+  glCheckFramebufferStatusOES: 'glCheckFramebufferStatus',
+  glDeleteFramebuffersOES: 'glDeleteFramebuffers',
+  glDeleteRenderbuffersOES: 'glDeleteRenderbuffers',
   glFramebufferTexture2DOES: 'glFramebufferTexture2D',
 
   // GLU


### PR DESCRIPTION
The `recordGLProcAddressGet` helper was attempt to resolve and create aliases using `copyLibEntry`, but this function doesn't work when the target of the alias exists in a different library file.

This was resulting `undefined` being set for these aliases and the resulting JS code would contains, for example:

```
var glGenFramebuffersOES = undefined;
```

Completely removing the aliasing resolution and the symbol copying from `recordGLProcAddressGet` seems to do the right thing, and should save on code size too:

```
var _glGenFramebuffersOES = _glGenFramebuffers;
```