### PR TITLE
Support JSPI'd pthread entry function.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,6 +465,8 @@ jobs:
           test_targets: "posixtest"
   test-core0:
     executor: bionic
+    environment:
+      EMTEST_SKIP_NODE_CANARY: "1"
     steps:
       - run-tests-linux:
           test_targets: "core0"
@@ -472,6 +474,7 @@ jobs:
     executor: bionic
     environment:
       EMTEST_BROWSER: "node"
+      EMTEST_SKIP_NODE_CANARY: "1"
     steps:
       - run-tests-linux:
           # also run a few asan tests.  Run these with frozen_cache disabled
@@ -506,6 +509,8 @@ jobs:
       - upload-test-results
   test-core3:
     executor: bionic
+    environment:
+      EMTEST_SKIP_NODE_CANARY: "1"
     steps:
       - run-tests-linux:
           frozen_cache: false
@@ -556,11 +561,15 @@ jobs:
             wasmfs.test_fs_llseek
             wasmfs.test_freetype"
   test-wasm2js1:
+    environment:
+      EMTEST_SKIP_NODE_CANARY: "1"
     executor: bionic
     steps:
       - run-tests-linux:
           test_targets: "wasm2js1"
   test-wasm64:
+    environment:
+      EMTEST_SKIP_NODE_CANARY: "1"
     # We don't use `bionic` here since its tool old to run recent node versions:
     # `/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found`
     executor: linux-python
@@ -628,6 +637,8 @@ jobs:
     # We don't use `bionic` here since its tool old to run recent node versions:
     # `/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found`
     executor: linux-python
+    environment:
+      EMTEST_SKIP_V8: "1"
     steps:
       - checkout
       - run:
@@ -715,6 +726,7 @@ jobs:
       EMTEST_SKIP_WASM64: "1"
       EMTEST_SKIP_SIMD: "1"
       EMTEST_SKIP_SCONS: "1"
+      EMTEST_SKIP_NODE_CANARY: "1"
     steps:
       - checkout
       - run:
@@ -752,6 +764,7 @@ jobs:
       # test_sse1 (the only @crossplatform native clang test) currently fails
       # on the macOS bots).
       EMTEST_LACKS_NATIVE_CLANG: "1"
+      EMTEST_SKIP_NODE_CANARY: "1"
     steps:
       - setup-macos
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,7 +643,8 @@ jobs:
             other.test_gen_struct_info
             other.test_native_call_before_init
             other.test_node_unhandled_rejection
-            core2.test_hello_world"
+            core2.test_hello_world
+            core0.test_pthread_join_and_asyncify"
       # Run some basic tests with the minimum version of node that we currently
       # support.
       - install-node-version:

--- a/emcc.py
+++ b/emcc.py
@@ -2438,7 +2438,7 @@ def phase_linker_setup(options, state, newargs):
     settings.JS_LIBRARIES.append((0, 'library_pthread_stub.js'))
 
   if settings.MEMORY64:
-    if settings.ASYNCIFY and settings.MEMORY64 == 1:
+    if settings.ASYNCIFY == 1 and settings.MEMORY64 == 1:
       exit_with_error('MEMORY64=1 is not compatible with ASYNCIFY')
     # Any "pointers" passed to JS will now be i64's, in both modes.
     settings.WASM_BIGINT = 1

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -977,12 +977,6 @@ var LibraryEmbind = {
 
     var returns = (argTypes[0].name !== "void");
 
-#if ASYNCIFY
-    if (isAsync) {
-      cppInvokerFunc = Asyncify.makeAsyncFunction(cppInvokerFunc);
-    }
-#endif
-
 #if DYNAMIC_EXECUTION == 0
     var expectedArgCount = argCount - 2;
     var argsWired = new Array(expectedArgCount);

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -111,6 +111,7 @@ mergeInto(LibraryManager.library, {
 #endif
 #if ASYNCIFY == 2
       var exportPatterns = [{{{ ASYNCIFY_EXPORTS.map(x => new RegExp('^' + x.replace(/\*/g, '.*') + '$')) }}}];
+      Asyncify.asyncExports = new Set();
 #endif
       var ret = {};
       for (var x in exports) {
@@ -120,6 +121,7 @@ mergeInto(LibraryManager.library, {
 #if ASYNCIFY == 2
             // Wrap all exports with a promising WebAssembly function.
             var isAsyncifyExport = exportPatterns.some(pattern => !!x.match(pattern));
+            Asyncify.asyncExports.add(original);
             if (isAsyncifyExport) {
               original = Asyncify.makeAsyncFunction(original);
             }
@@ -415,6 +417,13 @@ mergeInto(LibraryManager.library, {
     //
     // JSPI implementation of Asyncify.
     //
+
+    // Stores all the exported raw Wasm functions that are wrapped with async
+    // WebAssembly.Functions.
+    asyncExports: null,
+    isAsyncExport: function(func) {
+      return Asyncify.asyncExports && Asyncify.asyncExports.has(func);
+    },
     handleSleep: function(startAsync) {
       {{{ runtimeKeepalivePush(); }}}
       var promise = new Promise((resolve) => {

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1108,17 +1108,24 @@ var LibraryPThread = {
 #if STACK_OVERFLOW_CHECK
     checkStackCookie();
 #endif
+    function finish(result) {
 #if MINIMAL_RUNTIME
-    // In MINIMAL_RUNTIME the noExitRuntime concept does not apply to
-    // pthreads. To exit a pthread with live runtime, use the function
-    // emscripten_unwind_to_js_event_loop() in the pthread body.
-    __emscripten_thread_exit(result);
-#else
-    if (keepRuntimeAlive()) {
-      PThread.setExitStatus(result);
-    } else {
+      // In MINIMAL_RUNTIME the noExitRuntime concept does not apply to
+      // pthreads. To exit a pthread with live runtime, use the function
+      // emscripten_unwind_to_js_event_loop() in the pthread body.
       __emscripten_thread_exit(result);
+#else
+      if (keepRuntimeAlive()) {
+        PThread.setExitStatus(result);
+      } else {
+        __emscripten_thread_exit(result);
+      }
+#endif
     }
+#if ASYNCIFY == 2
+    Promise.resolve(result).then(finish);
+#else
+    finish(result);
 #endif
   },
 

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -107,7 +107,7 @@ function callMain() {
     Module.realPrint('main() took ' + (Date.now() - start) + ' milliseconds');
 #endif
 
-#if ASYNCIFY == 2
+#if ASYNCIFY == 2 && !PROXY_TO_PTHREAD
     // The current spec of JSPI returns a promise only if the function suspends
     // and a plain value otherwise. This will likely change:
     // https://github.com/WebAssembly/js-promise-integration/issues/11

--- a/test/common.py
+++ b/test/common.py
@@ -190,6 +190,16 @@ def requires_node(func):
   return decorated
 
 
+def requires_node_canary(func):
+  assert callable(func)
+
+  def decorated(self, *args, **kwargs):
+    self.require_node_canary()
+    return func(self, *args, **kwargs)
+
+  return decorated
+
+
 def requires_wasm64(func):
   assert callable(func)
 
@@ -530,6 +540,18 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       else:
         self.fail('node required to run this test.  Use EMTEST_SKIP_NODE to skip')
     self.require_engine(config.NODE_JS)
+
+  def require_node_canary(self):
+    if config.NODE_JS or config.NODE_JS in config.JS_ENGINES:
+      version = shared.check_node_version()
+      if version >= (20, 0, 0):
+        self.require_engine(config.NODE_JS)
+        return
+
+    if 'EMTEST_SKIP_NODE_CANARY' in os.environ:
+      self.skipTest('test requires node canary and EMTEST_SKIP_NODE_CANARY is set')
+    else:
+      self.fail('node canary required to run this test.  Use EMTEST_SKIP_NODE_CANARY to skip')
 
   def require_engine(self, engine):
     logger.debug(f'require_engine: {engine}')

--- a/test/core/test_pthread_join_and_asyncify.c
+++ b/test/core/test_pthread_join_and_asyncify.c
@@ -1,0 +1,31 @@
+// Copyright 2023 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <emscripten.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <assert.h>
+
+EM_ASYNC_JS(int, async_call, (), {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return 42;
+});
+
+// TODO Remove EMSCRIPTEN_KEEPALIVE when support for async attributes is enabled.
+EMSCRIPTEN_KEEPALIVE void *run_thread(void *args) {
+  int ret = async_call();
+  assert(ret == 42);
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+  pthread_create(&id, NULL, run_thread, NULL);
+  printf("joining thread!\n");
+  pthread_join(id, NULL);
+  printf("joined thread!\n");
+
+  return 0;
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8448,6 +8448,18 @@ Module.onRuntimeInitialized = () => {
     self.set_setting('MAIN_MODULE', 2)
     self.do_core_test('test_hello_world.c')
 
+  # Test that pthread_join works correctly with asyncify.
+  @requires_node
+  def test_pthread_join_and_asyncify(self):
+    # TODO Test with ASYNCIFY=1 https://github.com/emscripten-core/emscripten/issues/17552
+    self.require_jspi()
+    self.do_runf(test_file('core/test_pthread_join_and_asyncify.c'), 'joining thread!\njoined thread!',
+                 emcc_args=['-sASYNCIFY=2',
+                            '-sASYNCIFY_EXPORTS=run_thread',
+                            '-sEXIT_RUNTIME=1',
+                            '-pthread', '-sPROXY_TO_PTHREAD',
+                            '-Wno-experimental'])
+
   @no_asan('asyncify stack operations confuse asan')
   @no_wasm64('TODO: asyncify for wasm64')
   @no_wasm2js('TODO: lazy loading in wasm2js')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -27,7 +27,7 @@ import common
 from common import RunnerCore, path_from_root, requires_native_clang, test_file, create_file
 from common import skip_if, needs_dylink, no_windows, no_mac, is_slow_test, parameterized
 from common import env_modify, with_env_modify, disabled, node_pthreads, also_with_wasm_bigint
-from common import read_file, read_binary, requires_v8, requires_node, compiler_for, crossplatform
+from common import read_file, read_binary, requires_v8, requires_node, requires_node_canary, compiler_for, crossplatform
 from common import with_both_sjlj
 from common import NON_ZERO, WEBIDL_BINDER, EMBUILDER, PYTHON
 import clang_native
@@ -8449,7 +8449,7 @@ Module.onRuntimeInitialized = () => {
     self.do_core_test('test_hello_world.c')
 
   # Test that pthread_join works correctly with asyncify.
-  @requires_node
+  @requires_node_canary
   def test_pthread_join_and_asyncify(self):
     # TODO Test with ASYNCIFY=1 https://github.com/emscripten-core/emscripten/issues/17552
     self.require_jspi()


### PR DESCRIPTION
- Adds tracking of which exports are JSPI functions so we can later
determine if a function in the function table is a JSPI function.
- Adds handling for when the pthread entry function is a JSPI function and
needs a wrapper created for it.
- Handles exiting the thread when the entry function resolves.

To use JSPI + pthreads the user will need to export the thread entry function
with either `EMSCRIPTEN_KEEPALIVE` or `-sEXPORTED_FUNCTIONS=...`. The function
also needs to be marked as JSPI with `-sASYNCIFY_EXPORTS=...`