### PR TITLE
jsifier: Add explicit error messages for missing/native alias targets

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -350,6 +350,16 @@ function ${name}(${args}) {
             // Redirection for aliases. We include the parent, and at runtime make ourselves equal to it.
             // This avoid having duplicate functions with identical content.
             const redirectedTarget = snippet;
+            if (!(redirectedTarget in LibraryManager.library)) {
+              error(`${symbol}: alias target not found in JS library: ${redirectedTarget}`);
+            }
+            if (WASM_EXPORTS.has(redirectedTarget)) {
+              // JS symbols cannot currently alias native symbols, because
+              // the JS symbols are declared earlier in the output file.
+              // e.g. we cannot output `foo = _bar;` if `_bar` is native symbol
+              // otherwise closure compilains of JSC_REFERENCE_BEFORE_DECLARE.
+              error(`${symbol}: alias target cannot be a native symbol: ${redirectedTarget}`);
+            }
             deps.push(redirectedTarget);
             snippet = mangleCSymbolName(redirectedTarget);
           }

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -838,7 +838,7 @@ function hasExportedSymbol(sym) {
 // it is a BigInt. Otherwise, we legalize into pairs of i32s.
 function defineI64Param(name) {
   if (WASM_BIGINT) {
-    return `/** @type {!BigInt} */ ${name}`;
+    return name;
   }
   return `${name}_low, ${name}_high`;
 }

--- a/system/lib/gl/webgl2.c
+++ b/system/lib/gl/webgl2.c
@@ -131,8 +131,6 @@ ASYNC_GL_FUNCTION_5(EM_FUNC_SIG_VIIIII, void, glTexStorage2D, GLenum, GLsizei, G
 ASYNC_GL_FUNCTION_6(EM_FUNC_SIG_VIIIIII, void, glTexStorage3D, GLenum, GLsizei, GLenum, GLsizei, GLsizei, GLsizei);
 VOID_SYNC_GL_FUNCTION_5(EM_FUNC_SIG_VIIIII, void, glGetInternalformativ, GLenum, GLenum, GLenum, GLsizei, GLint *);
 
-#endif // ~__EMSCRIPTEN_PTHREADS__
-
 // Extensions:
 GL_APICALL void GL_APIENTRY glVertexAttribDivisorNV(GLuint index, GLuint divisor) { glVertexAttribDivisor(index, divisor); }
 GL_APICALL void GL_APIENTRY glVertexAttribDivisorEXT(GLuint index, GLuint divisor) { glVertexAttribDivisor(index, divisor); }
@@ -152,6 +150,8 @@ GL_APICALL void GL_APIENTRY glGenVertexArraysOES(GLsizei n, GLuint *arrays) { gl
 GL_APICALL GLboolean GL_APIENTRY glIsVertexArrayOES(GLuint array) { return glIsVertexArray(array); }
 GL_APICALL void GL_APIENTRY glDrawBuffersEXT(GLsizei n, const GLenum *bufs) { glDrawBuffers(n, bufs); }
 GL_APICALL void GL_APIENTRY glDrawBuffersWEBGL(GLsizei n, const GLenum *bufs) { glDrawBuffers(n, bufs); }
+
+#endif // ~__EMSCRIPTEN_PTHREADS__
 
 // Returns a function pointer to the given WebGL 2 extension function, when queried without
 // a GL extension suffix such as "EXT", "OES", or "ANGLE". This function is used by

--- a/system/lib/gl/webgl_internal.h
+++ b/system/lib/gl/webgl_internal.h
@@ -7,6 +7,8 @@ EMSCRIPTEN_RESULT emscripten_webgl_do_commit_frame(void);
 EM_BOOL emscripten_supports_offscreencanvas(void);
 void _emscripten_proxied_gl_context_activated_from_main_browser_thread(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
+#if defined(__EMSCRIPTEN_PTHREADS__) && defined(__EMSCRIPTEN_OFFSCREEN_FRAMEBUFFER__)
+
 #ifdef EMSCRIPTEN_WEBGL_TRACE
 #define GL_FUNCTION_TRACE(func) printf(#func "\n")
 #else
@@ -51,8 +53,6 @@ void _emscripten_proxied_gl_context_activated_from_main_browser_thread(EMSCRIPTE
 #define VOID_SYNC_GL_FUNCTION_9(sig, ret, functionName, t0, t1, t2, t3, t4, t5, t6, t7, t8) ret functionName(t0 p0, t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8) { GL_FUNCTION_TRACE(functionName); if (pthread_getspecific(currentThreadOwnsItsWebGLContext)) emscripten_##functionName(p0, p1, p2, p3, p4, p5, p6, p7, p8); else emscripten_sync_run_in_main_runtime_thread(sig, &emscripten_##functionName, p0, p1, p2, p3, p4, p5, p6, p7, p8); }
 #define VOID_SYNC_GL_FUNCTION_10(sig, ret, functionName, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9) ret functionName(t0 p0, t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, t9 p9) { GL_FUNCTION_TRACE(functionName); if (pthread_getspecific(currentThreadOwnsItsWebGLContext)) emscripten_##functionName(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9); else emscripten_sync_run_in_main_runtime_thread(sig, &emscripten_##functionName, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9); }
 #define VOID_SYNC_GL_FUNCTION_11(sig, ret, functionName, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) ret functionName(t0 p0, t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, t9 p9, t10 p10) { GL_FUNCTION_TRACE(functionName); if (pthread_getspecific(currentThreadOwnsItsWebGLContext)) emscripten_##functionName(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10); else emscripten_sync_run_in_main_runtime_thread(sig, &emscripten_##functionName, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10); }
-
-#if defined(__EMSCRIPTEN_PTHREADS__) && defined(__EMSCRIPTEN_OFFSCREEN_FRAMEBUFFER__)
 
 #include <pthread.h>
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8656,6 +8656,7 @@ end
       '-sFETCH',
       '-sFETCH_SUPPORT_INDEXEDDB',
       '-sLEGACY_GL_EMULATION',
+      '-sMAX_WEBGL_VERSION=2',
     ] + args)
 
   def test_closure_webgpu(self):


### PR DESCRIPTION
Followup to #19033.

Updating the `test_closure_full_js_library` to include webgl2 caused a lot of `JSC_REFERENCE_BEFORE_DECLARE` closure errors.

This is because we had JS aliases who's target was defined both in JS and in native code.  In this case the jsifier chooses not to include the JS version but the location where the aliases are declared in the output comes before the native symbols are declared.

To fix this I removed the native aliases from webgl2.c, since these exact same aliases already exist in library_webgl.js.

This think is also more correct since it means that the `emscripten_xx` wrappers are defined fully in JS and are not effected by definitions in native code (which is the whole point of them I believe).