### PR TITLE
Always include library_sdl.js and library_glfw.js conditionally. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1993,6 +1993,7 @@ def phase_linker_setup(options, state, newargs):
     default_setting('AUTO_JS_LIBRARIES', 0)
     # When using MINIMAL_RUNTIME, symbols should only be exported if requested.
     default_setting('EXPORT_KEEPALIVE', 0)
+    default_setting('USE_GLFW', 0)
 
   if settings.STRICT_JS and (settings.MODULARIZE or settings.EXPORT_ES6):
     exit_with_error("STRICT_JS doesn't work with MODULARIZE or EXPORT_ES6")

--- a/src/modules.js
+++ b/src/modules.js
@@ -113,7 +113,6 @@ global.LibraryManager = {
         'library_webgl.js',
         'library_html5_webgl.js',
         'library_openal.js',
-        'library_sdl.js',
         'library_glut.js',
         'library_xlib.js',
         'library_egl.js',
@@ -122,8 +121,8 @@ global.LibraryManager = {
         'library_idbstore.js',
         'library_async.js',
       ]);
-      if (USE_GLFW) {
-        libraries.push('library_glfw.js');
+      if (USE_SDL != 2) {
+        libraries.push('library_sdl.js');
       }
     } else {
       if (ASYNCIFY) {
@@ -135,6 +134,10 @@ global.LibraryManager = {
       if (USE_SDL == 2) {
         libraries.push('library_egl.js', 'library_webgl.js', 'library_html5_webgl.js');
       }
+    }
+
+    if (USE_GLFW) {
+      libraries.push('library_glfw.js');
     }
 
     if (LZ4) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1292,6 +1292,7 @@ var EMSCRIPTEN_TRACING = false;
 // Specify the GLFW version that is being linked against.  Only relevant, if you
 // are linking against the GLFW library.  Valid options are 2 for GLFW2 and 3
 // for GLFW3.
+// In MINIMAL_RUNTIME builds, this option defaults to 0.
 // [link]
 var USE_GLFW = 2;
 

--- a/src/shell.js
+++ b/src/shell.js
@@ -27,6 +27,7 @@ var /** @type {{
   noAudioDecoding: boolean,
   noWasmDecoding: boolean,
   canvas: HTMLCanvasElement,
+  ctx: Object,
   dataFileDownloads: Object,
   preloadResults: Object,
   useWebGL: boolean,

--- a/tools/gen_sig_info.py
+++ b/tools/gen_sig_info.py
@@ -221,6 +221,7 @@ def extract_sig_info(sig_info, extra_settings=None, extra_cflags=None):
     'USE_PTHREADS': 1,
     'STACK_OVERFLOW_CHECK': 1,
     'FULL_ES3': 1,
+    'USE_SDL': 1,
     # Currently GLFW symbols have different sigs for the same symbol because the
     # signatures changed between v2 and v3, so for now we continue to maintain
     # them by hand.


### PR DESCRIPTION
Split out from #19028.

As of #18443, USE_SDL defaults to zero which means we don't want to include
library_sdl.js by default, even when `AUTO_JS_LIBRARIES` is set.

In order to make closure happy without `library_sdl.js` but with `INCLUDE_FULL_LIBRARY`
I had to add a closure type annotation for the `Module.ctx` object.  I'm really not sure
why this was needed now but not before.