### PR TITLE
Fix node version detection to handle non-numeric patch version. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -589,6 +589,7 @@ jobs:
             other.test_gen_struct_info
             other.test_native_call_before_init
             other.test_node_unhandled_rejection
+            other.test_min_node_version
             other.test_node_emscripten_num_logical_cores
             core2.test_pthread_create
             core2.test_i64_invoke_bigint

--- a/src/shell.js
+++ b/src/shell.js
@@ -182,7 +182,7 @@ if (ENVIRONMENT_IS_NODE) {
 #if ASSERTIONS
   var nodeVersion = process.versions.node;
   var numericVersion = nodeVersion.split('.').slice(0, 3);
-  numericVersion = (numericVersion[0] * 10000) + (numericVersion[1] * 100) + numericVersion[2] * 1;
+  numericVersion = (numericVersion[0] * 10000) + (numericVersion[1] * 100) + (numericVersion[2].split('-')[0] * 1);
   var minVersion = {{{ MIN_NODE_VERSION }}};
   if (numericVersion < {{{ MIN_NODE_VERSION }}}) {
     throw new Error('This emscripten-generated code requires node {{{ formattedMinNodeVersion() }}} (detected v' + nodeVersion + ')');

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13270,7 +13270,7 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     node_version = shared.check_node_version()
     node_version = '.'.join(str(x) for x in node_version)
     self.set_setting('MIN_NODE_VERSION', 210000)
-    expected = 'This emscripten-generated code requires node v21.0.0 (detected v%s)' % node_version
+    expected = 'This emscripten-generated code requires node v21.0.0 (detected v%s' % node_version
     self.do_runf(test_file('hello_world.c'), expected, assert_returncode=NON_ZERO)
 
   def test_deprecated_macros(self):


### PR DESCRIPTION
For example nightly builds of node report something like:

 v20.0.0-v8-canary202302081604228b65