### PR TITLE
Support OPFS on the main thread with JSPI.

### DIFF
--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -30,7 +30,9 @@ mergeInto(LibraryManager.library, {
     }
     async read(buffer, options = { at: 0 }) {
       let file = await this.handle.getFile();
-      let slice = await file.slice(options.at);
+      // The end position may be past the end of the file, but slice truncates
+      // it.
+      let slice = await file.slice(options.at, options.at + buffer.length);
       let fileBuffer = await slice.arrayBuffer();
       let array = new Uint8Array(fileBuffer);
       buffer.set(array);

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -312,19 +312,11 @@ mergeInto(LibraryManager.library, {
 
   _wasmfs_opfs_read_access__sig: 'iipii',
   _wasmfs_opfs_read_access__deps: ['$wasmfsOPFSAccessHandles'],
-#if USE_PTHREADS
-  _wasmfs_opfs_read_access: function(accessID, bufPtr, len, pos) {
-#else
-  _wasmfs_opfs_read_access: async function(accessID, bufPtr, len, pos) {
-#endif
+  _wasmfs_opfs_read_access: {{{ asyncIf(!USE_PTHREADS) }}}  function(accessID, bufPtr, len, pos) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     let data = HEAPU8.subarray(bufPtr, bufPtr + len);
     try {
-#if USE_PTHREADS
-      return accessHandle.read(data, {at: pos});
-#else
-      return await accessHandle.read(data, {at: pos});
-#endif
+      return {{{ awaitIf(!USE_PTHREADS) }}} accessHandle.read(data, {at: pos});
     } catch (e) {
       if (e.name == "TypeError") {
         return -{{{ cDefs.EINVAL }}};
@@ -368,19 +360,11 @@ mergeInto(LibraryManager.library, {
 
   _wasmfs_opfs_write_access__sig: 'iipii',
   _wasmfs_opfs_write_access__deps: ['$wasmfsOPFSAccessHandles'],
-#if USE_PTHREADS
-  _wasmfs_opfs_write_access: function(accessID, bufPtr, len, pos) {
-#else
-  _wasmfs_opfs_write_access: async function(accessID, bufPtr, len, pos) {
-#endif
+  _wasmfs_opfs_write_access: {{{ asyncIf(!USE_PTHREADS) }}} function(accessID, bufPtr, len, pos) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     let data = HEAPU8.subarray(bufPtr, bufPtr + len);
     try {
-#if USE_PTHREADS
-      return accessHandle.write(data, {at: pos});
-#else
-      return await accessHandle.write(data, {at: pos});
-#endif
+      return {{{ awaitIf(!USE_PTHREADS) }}} accessHandle.write(data, {at: pos});
     } catch (e) {
       if (e.name == "TypeError") {
         return -{{{ cDefs.EINVAL }}};

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -30,8 +30,9 @@ mergeInto(LibraryManager.library, {
     }
     async read(buffer, options = { at: 0 }) {
       let file = await this.handle.getFile();
-      let fileBuffer = await file.arrayBuffer();
-      let array = new Uint8Array(fileBuffer, options.at);
+      let slice = await file.slice(options.at);
+      let fileBuffer = await slice.arrayBuffer();
+      let array = new Uint8Array(fileBuffer);
       buffer.set(array);
       return array.length;
     }

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -15,7 +15,7 @@ mergeInto(LibraryManager.library, {
   $wasmfsOPFSBlobs: "new HandleAllocator()",
 
 #if !USE_PTHREADS
-  $wasmfsFileSystemASyncAccessHandle: class FileSystemASyncAccessHandle {
+  $wasmfsFileSystemAsyncAccessHandle: class FileSystemAsyncAccessHandle {
     // This class implements the same interface as the sync version, but has
     // async reads and writes. Hopefully this will one day be implemented by the
     // platform so we can remove it.
@@ -48,9 +48,9 @@ mergeInto(LibraryManager.library, {
     }
   },
 
-  $wasmfsOPFSCreateASyncAccessHandle__deps: ['$wasmfsFileSystemASyncAccessHandle'],
+  $wasmfsOPFSCreateASyncAccessHandle__deps: ['$wasmfsFileSystemAsyncAccessHandle'],
   $wasmfsOPFSCreateASyncAccessHandle: function(fileHandle) {
-    return new FileSystemASyncAccessHandle(fileHandle);
+    return new FileSystemAsyncAccessHandle(fileHandle);
   },
 #endif
 

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -15,7 +15,7 @@ mergeInto(LibraryManager.library, {
   $wasmfsOPFSBlobs: "new HandleAllocator()",
 
 #if !USE_PTHREADS
-  $wasmfsFileSystemAsyncAccessHandle: class FileSystemAsyncAccessHandle {
+  $FileSystemAsyncAccessHandle: class FileSystemAsyncAccessHandle {
     // This class implements the same interface as the sync version, but has
     // async reads and writes. Hopefully this will one day be implemented by the
     // platform so we can remove it.
@@ -51,7 +51,7 @@ mergeInto(LibraryManager.library, {
     }
   },
 
-  $wasmfsOPFSCreateASyncAccessHandle__deps: ['$wasmfsFileSystemAsyncAccessHandle'],
+  $wasmfsOPFSCreateASyncAccessHandle__deps: ['$FileSystemAsyncAccessHandle'],
   $wasmfsOPFSCreateASyncAccessHandle: function(fileHandle) {
     return new FileSystemAsyncAccessHandle(fileHandle);
   },

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -15,6 +15,7 @@ mergeInto(LibraryManager.library, {
   $wasmfsOPFSBlobs: "new HandleAllocator()",
 
 #if !USE_PTHREADS
+  // OPFS will only be used on modern browsers that supports JS classes.
   $FileSystemAsyncAccessHandle: class FileSystemAsyncAccessHandle {
     // This class implements the same interface as the sync version, but has
     // async reads and writes. Hopefully this will one day be implemented by the

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -52,8 +52,8 @@ mergeInto(LibraryManager.library, {
     }
   },
 
-  $wasmfsOPFSCreateASyncAccessHandle__deps: ['$FileSystemAsyncAccessHandle'],
-  $wasmfsOPFSCreateASyncAccessHandle: function(fileHandle) {
+  $wasmfsOPFSCreateAsyncAccessHandle__deps: ['$FileSystemAsyncAccessHandle'],
+  $wasmfsOPFSCreateAsyncAccessHandle: function(fileHandle) {
     return new FileSystemAsyncAccessHandle(fileHandle);
   },
 #endif
@@ -235,7 +235,7 @@ mergeInto(LibraryManager.library, {
   _wasmfs_opfs_open_access__deps: ['$wasmfsOPFSFileHandles',
                                    '$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish',
 #if !USE_PTHREADS
-                                   '$wasmfsOPFSCreateASyncAccessHandle'
+                                   '$wasmfsOPFSCreateAsyncAccessHandle'
 #endif
                                   ],
   _wasmfs_opfs_open_access: async function(ctx, fileID, accessIDPtr) {
@@ -252,7 +252,7 @@ mergeInto(LibraryManager.library, {
             {mode: "in-place"});
       }
 #else
-      accessHandle = await wasmfsOPFSCreateASyncAccessHandle(fileHandle);
+      accessHandle = await wasmfsOPFSCreateAsyncAccessHandle(fileHandle);
 #endif
       accessID = wasmfsOPFSAccessHandles.allocate(accessHandle);
     } catch (e) {

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -14,14 +14,64 @@ mergeInto(LibraryManager.library, {
   $wasmfsOPFSBlobs__deps: ["$HandleAllocator"],
   $wasmfsOPFSBlobs: "new HandleAllocator()",
 
-  _wasmfs_opfs_init_root_directory__deps: ['$wasmfsOPFSDirectoryHandles'],
+#if !USE_PTHREADS
+  $wasmfsFileSystemASyncAccessHandle: class FileSystemASyncAccessHandle {
+    // This class implements the same interface as the sync version, but has
+    // async reads and writes. Hopefully this will one day be implemented by the
+    // platform so we can remove it.
+    constructor(handle) {
+      this.handle = handle;
+    }
+    async close() {}
+    async flush() {}
+    async getSize() {
+      let file = await this.handle.getFile();
+      return file.size;
+    }
+    async read(buffer, options = { at: 0 }) {
+      let file = await this.handle.getFile();
+      let fileBuffer = await file.arrayBuffer();
+      let array = new Uint8Array(fileBuffer, options.at);
+      buffer.set(array);
+      return array.length;
+    }
+    async write(buffer, options = { at: 0 }) {
+      let writable = await this.handle.createWritable({keepExistingData: true});
+      await writable.write({ type: 'write', position: options.at, data: buffer });
+      await writable.close();
+      return buffer.length;
+    }
+    async truncate(size) {
+      let writable = await this.handle.createWritable({keepExistingData: true});
+      await writable.truncate(size);
+      await writable.close();
+    }
+  },
+
+  $wasmfsOPFSCreateASyncAccessHandle__deps: ['$wasmfsFileSystemASyncAccessHandle'],
+  $wasmfsOPFSCreateASyncAccessHandle: function(fileHandle) {
+    return new FileSystemASyncAccessHandle(fileHandle);
+  },
+#endif
+
+  $wasmfsOPFSProxyFinish: function(ctx) {
+    // When using pthreads the proxy needs to know when the work is finished.
+    // When used with JSPI the work will be executed in an async block so there
+    // is no need to notify when done.
+#if USE_PTHREADS
+    _emscripten_proxy_finish(ctx);
+#endif
+  },
+
+  _wasmfs_opfs_init_root_directory__sig: 'vp',
+  _wasmfs_opfs_init_root_directory__deps: ['$wasmfsOPFSDirectoryHandles', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_init_root_directory: async function(ctx) {
     // allocated.length starts off as 1 since 0 is a reserved handle
     if (wasmfsOPFSDirectoryHandles.allocated.length == 1) {
       let root = await navigator.storage.getDirectory();
       wasmfsOPFSDirectoryHandles.allocated.push(root);
     }
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
   // Return the file ID for the file with `name` under `parent`, creating it if
@@ -74,8 +124,9 @@ mergeInto(LibraryManager.library, {
     return wasmfsOPFSDirectoryHandles.allocate(childHandle);
   },
 
+  _wasmfs_opfs_get_child__sig: 'vpippp',
   _wasmfs_opfs_get_child__deps: ['$wasmfsOPFSGetOrCreateFile',
-                                 '$wasmfsOPFSGetOrCreateDir'],
+                                 '$wasmfsOPFSGetOrCreateDir', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_get_child:
       async function(ctx, parent, namePtr, childTypePtr, childIDPtr) {
     let name = UTF8ToString(namePtr);
@@ -87,10 +138,11 @@ mergeInto(LibraryManager.library, {
     }
     {{{ makeSetValue('childTypePtr', 0, 'childType', 'i32') }}};
     {{{ makeSetValue('childIDPtr', 0, 'childID', 'i32') }}};
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
-  _wasmfs_opfs_get_entries__deps: [],
+  _wasmfs_opfs_get_entries__sig: 'vpipp',
+  _wasmfs_opfs_get_entries__deps: ['$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_get_entries: async function(ctx, dirID, entriesPtr, errPtr) {
     let dirHandle = wasmfsOPFSDirectoryHandles.get(dirID);
 
@@ -111,28 +163,31 @@ mergeInto(LibraryManager.library, {
       let err = -{{{ cDefs.EIO }}};
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
-  _wasmfs_opfs_insert_file__deps: ['$wasmfsOPFSGetOrCreateFile'],
+  _wasmfs_opfs_insert_file__sig: 'vpipp',
+  _wasmfs_opfs_insert_file__deps: ['$wasmfsOPFSGetOrCreateFile', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_insert_file: async function(ctx, parent, namePtr, childIDPtr) {
     let name = UTF8ToString(namePtr);
     let childID = await wasmfsOPFSGetOrCreateFile(parent, name, true);
     {{{ makeSetValue('childIDPtr', 0, 'childID', 'i32') }}};
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
-  _wasmfs_opfs_insert_directory__deps: ['$wasmfsOPFSGetOrCreateDir'],
+  _wasmfs_opfs_insert_directory__sig: 'vpipp',
+  _wasmfs_opfs_insert_directory__deps: ['$wasmfsOPFSGetOrCreateDir', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_insert_directory:
       async function(ctx, parent, namePtr, childIDPtr) {
     let name = UTF8ToString(namePtr);
     let childID = await wasmfsOPFSGetOrCreateDir(parent, name, true);
     {{{ makeSetValue('childIDPtr', 0, 'childID', 'i32') }}};
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
+  _wasmfs_opfs_move__sig: 'vpiipp',
   _wasmfs_opfs_move__deps: ['$wasmfsOPFSFileHandles',
-                            '$wasmfsOPFSDirectoryHandles'],
+                            '$wasmfsOPFSDirectoryHandles', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_move: async function(ctx, fileID, newDirID, namePtr, errPtr) {
     let name = UTF8ToString(namePtr);
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
@@ -143,10 +198,11 @@ mergeInto(LibraryManager.library, {
       let err = -{{{ cDefs.EIO }}};
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
-  _wasmfs_opfs_remove_child__deps: ['$wasmfsOPFSDirectoryHandles'],
+  _wasmfs_opfs_remove_child__sig: 'vpipp',
+  _wasmfs_opfs_remove_child__deps: ['$wasmfsOPFSDirectoryHandles', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_remove_child: async function(ctx, dirID, namePtr, errPtr) {
     let name = UTF8ToString(namePtr);
     let dirHandle = wasmfsOPFSDirectoryHandles.get(dirID);
@@ -156,26 +212,34 @@ mergeInto(LibraryManager.library, {
       let err = -{{{ cDefs.EIO }}};
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
+  _wasmfs_opfs_free_file__sig: 'vi',
   _wasmfs_opfs_free_file__deps: ['$wasmfsOPFSFileHandles'],
   _wasmfs_opfs_free_file: function(fileID) {
     wasmfsOPFSFileHandles.free(fileID);
   },
 
+  _wasmfs_opfs_free_directory__sig: 'vi',
   _wasmfs_opfs_free_directory__deps: ['$wasmfsOPFSDirectoryHandles'],
   _wasmfs_opfs_free_directory: function(dirID) {
     wasmfsOPFSDirectoryHandles.free(dirID);
   },
 
+  _wasmfs_opfs_open_access__sig: 'vpip',
   _wasmfs_opfs_open_access__deps: ['$wasmfsOPFSFileHandles',
-                                   '$wasmfsOPFSAccessHandles'],
+                                   '$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish',
+#if !USE_PTHREADS
+                                   '$wasmfsOPFSCreateASyncAccessHandle'
+#endif
+                                  ],
   _wasmfs_opfs_open_access: async function(ctx, fileID, accessIDPtr) {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     let accessID;
     try {
       let accessHandle;
+#if USE_PTHREADS
       // TODO: Remove this once the Access Handles API has settled.
       if (FileSystemFileHandle.prototype.createSyncAccessHandle.length == 0) {
         accessHandle = await fileHandle.createSyncAccessHandle();
@@ -183,6 +247,9 @@ mergeInto(LibraryManager.library, {
         accessHandle = await fileHandle.createSyncAccessHandle(
             {mode: "in-place"});
       }
+#else
+      accessHandle = await wasmfsOPFSCreateASyncAccessHandle(fileHandle);
+#endif
       accessID = wasmfsOPFSAccessHandles.allocate(accessHandle);
     } catch (e) {
       // TODO: Presumably only one of these will appear in the final API?
@@ -197,11 +264,12 @@ mergeInto(LibraryManager.library, {
       }
     }
     {{{ makeSetValue('accessIDPtr', 0, 'accessID', 'i32') }}};
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
+  _wasmfs_opfs_open_blob__sig: 'vpip',
   _wasmfs_opfs_open_blob__deps: ['$wasmfsOPFSFileHandles',
-                                 '$wasmfsOPFSBlobs'],
+                                 '$wasmfsOPFSBlobs', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_open_blob: async function(ctx, fileID, blobIDPtr) {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     let blobID;
@@ -219,10 +287,11 @@ mergeInto(LibraryManager.library, {
       }
     }
     {{{ makeSetValue('blobIDPtr', 0, 'blobID', 'i32') }}};
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
-  _wasmfs_opfs_close_access__deps: ['$wasmfsOPFSAccessHandles'],
+  _wasmfs_opfs_close_access__sig: 'vpip',
+  _wasmfs_opfs_close_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_close_access: async function(ctx, accessID, errPtr) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     try {
@@ -232,20 +301,30 @@ mergeInto(LibraryManager.library, {
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
     wasmfsOPFSAccessHandles.free(accessID);
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
+  _wasmfs_opfs_close_blob__sig: 'vi',
   _wasmfs_opfs_close_blob__deps: ['$wasmfsOPFSBlobs'],
   _wasmfs_opfs_close_blob: function(blobID) {
     wasmfsOPFSBlobs.free(blobID);
   },
 
+  _wasmfs_opfs_read_access__sig: 'iipii',
   _wasmfs_opfs_read_access__deps: ['$wasmfsOPFSAccessHandles'],
+#if USE_PTHREADS
   _wasmfs_opfs_read_access: function(accessID, bufPtr, len, pos) {
+#else
+  _wasmfs_opfs_read_access: async function(accessID, bufPtr, len, pos) {
+#endif
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     let data = HEAPU8.subarray(bufPtr, bufPtr + len);
     try {
+#if USE_PTHREADS
       return accessHandle.read(data, {at: pos});
+#else
+      return await accessHandle.read(data, {at: pos});
+#endif
     } catch (e) {
       if (e.name == "TypeError") {
         return -{{{ cDefs.EINVAL }}};
@@ -257,7 +336,8 @@ mergeInto(LibraryManager.library, {
     }
   },
 
-  _wasmfs_opfs_read_blob__deps: ['$wasmfsOPFSBlobs'],
+  _wasmfs_opfs_read_blob__sig: 'ipipiip',
+  _wasmfs_opfs_read_blob__deps: ['$wasmfsOPFSBlobs', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_read_blob: async function(ctx, blobID, bufPtr, len, pos, nreadPtr) {
     let blob = wasmfsOPFSBlobs.get(blobID);
     let slice = blob.slice(pos, pos + len);
@@ -283,15 +363,24 @@ mergeInto(LibraryManager.library, {
     }
 
     {{{ makeSetValue('nreadPtr', 0, 'nread', 'i32') }}};
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
+  _wasmfs_opfs_write_access__sig: 'iipii',
   _wasmfs_opfs_write_access__deps: ['$wasmfsOPFSAccessHandles'],
+#if USE_PTHREADS
   _wasmfs_opfs_write_access: function(accessID, bufPtr, len, pos) {
+#else
+  _wasmfs_opfs_write_access: async function(accessID, bufPtr, len, pos) {
+#endif
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     let data = HEAPU8.subarray(bufPtr, bufPtr + len);
     try {
+#if USE_PTHREADS
       return accessHandle.write(data, {at: pos});
+#else
+      return await accessHandle.write(data, {at: pos});
+#endif
     } catch (e) {
       if (e.name == "TypeError") {
         return -{{{ cDefs.EINVAL }}};
@@ -303,7 +392,8 @@ mergeInto(LibraryManager.library, {
     }
   },
 
-  _wasmfs_opfs_get_size_access__deps: ['$wasmfsOPFSAccessHandles'],
+  _wasmfs_opfs_get_size_access__sig: 'vpip',
+  _wasmfs_opfs_get_size_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_get_size_access: async function(ctx, accessID, sizePtr) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     let size;
@@ -313,16 +403,18 @@ mergeInto(LibraryManager.library, {
       size = -{{{ cDefs.EIO }}};
     }
     {{{ makeSetValue('sizePtr', 0, 'size', 'i64') }}};
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
+  _wasmfs_opfs_get_size_blob__sig: 'ii',
   _wasmfs_opfs_get_size_blob__deps: ['$wasmfsOPFSBlobs'],
   _wasmfs_opfs_get_size_blob: function(blobID) {
     // This cannot fail.
     return wasmfsOPFSBlobs.get(blobID).size;
   },
 
-  _wasmfs_opfs_get_size_file__deps: ['$wasmfsOPFSFileHandles'],
+  _wasmfs_opfs_get_size_file__sig: 'vpip',
+  _wasmfs_opfs_get_size_file__deps: ['$wasmfsOPFSFileHandles', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_get_size_file: async function(ctx, fileID, sizePtr) {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     let size;
@@ -332,10 +424,11 @@ mergeInto(LibraryManager.library, {
       size = -{{{ cDefs.EIO }}};
     }
     {{{ makeSetValue('sizePtr', 0, 'size', 'i64') }}};
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
-  _wasmfs_opfs_set_size_access__deps: ['$wasmfsOPFSAccessHandles'],
+  _wasmfs_opfs_set_size_access__sig: 'vpijp',
+  _wasmfs_opfs_set_size_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_set_size_access: async function(ctx, accessID,
                                                {{{ defineI64Param('size') }}},
                                                errPtr) {
@@ -347,10 +440,11 @@ mergeInto(LibraryManager.library, {
       let err = -{{{ cDefs.EIO }}};
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
-  _wasmfs_opfs_set_size_file__deps: ['$wasmfsOPFSFileHandles'],
+  _wasmfs_opfs_set_size_file__sig: 'vpijp',
+  _wasmfs_opfs_set_size_file__deps: ['$wasmfsOPFSFileHandles', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_set_size_file: async function(ctx, fileID,
                                              {{{ defineI64Param('size') }}},
                                              errPtr) {
@@ -364,10 +458,11 @@ mergeInto(LibraryManager.library, {
       let err = -{{{ cDefs.EIO }}};
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   },
 
-  _wasmfs_opfs_flush_access__deps: ['$wasmfsOPFSAccessHandles'],
+  _wasmfs_opfs_flush_access__sig: 'vpip',
+  _wasmfs_opfs_flush_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'],
   _wasmfs_opfs_flush_access: async function(ctx, accessID, errPtr) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     try {
@@ -376,6 +471,6 @@ mergeInto(LibraryManager.library, {
       let err = -{{{ cDefs.EIO }}};
       {{{ makeSetValue('errPtr', 0, 'err', 'i32') }}};
     }
-    _emscripten_proxy_finish(ctx);
+    wasmfsOPFSProxyFinish(ctx);
   }
 });

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -917,6 +917,14 @@ function addReadyPromiseAssertions(promise) {
 });`;
 }
 
+function asyncIf(condition) {
+  return condition ? 'async' : '';
+}
+
+function awaitIf(condition) {
+  return condition ? 'await' : '';
+}
+
 function makeMalloc(source, param) {
   if (hasExportedSymbol('malloc')) {
     return `_malloc(${param})`;

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -118,6 +118,32 @@ void _wasmfs_opfs_flush_access(em_proxying_ctx* ctx, int access_id, int* err);
 namespace {
 
 using ProxyWorker = emscripten::ProxyWorker;
+using ProxyingQueue = emscripten::ProxyingQueue;
+
+class Worker {
+public:
+#ifdef __EMSCRIPTEN_PTHREADS__
+  ProxyWorker proxy;
+
+  void operator()(const std::function<void()>& func) {
+    proxy(func);
+  }
+  void operator()(const std::function<void(ProxyingQueue::ProxyingCtx)>& func) {
+    proxy(func);
+  }
+#else
+  // When used with JSPI on the main thread the various wasmfs_opfs_* functions
+  // can be directly executed since they are all async.
+  void operator()(const std::function<void()>& func) {
+    func();
+  }
+  void operator()(const std::function<void(ProxyingQueue::ProxyingCtx)>& func) {
+    // TODO: Find a way to remove this, since it's unused.
+    ProxyingQueue::ProxyingCtx p;
+    func(p);
+  }
+#endif
+};
 
 class OpenState {
 public:
@@ -131,7 +157,7 @@ private:
 public:
   Kind getKind() { return kind; }
 
-  int open(ProxyWorker& proxy, int fileID, oflags_t flags) {
+  int open(Worker& proxy, int fileID, oflags_t flags) {
     if (kind == None) {
       assert(openCount == 0);
       switch (flags) {
@@ -175,7 +201,7 @@ public:
     return 0;
   }
 
-  int close(ProxyWorker& proxy) {
+  int close(Worker& proxy) {
     // TODO: Downgrade to Blob access once the last writable file descriptor has
     // been closed.
     int err = 0;
@@ -214,11 +240,11 @@ public:
 
 class OPFSFile : public DataFile {
 public:
-  ProxyWorker& proxy;
+  Worker& proxy;
   int fileID;
   OpenState state;
 
-  OPFSFile(mode_t mode, backend_t backend, int fileID, ProxyWorker& proxy)
+  OPFSFile(mode_t mode, backend_t backend, int fileID, Worker& proxy)
     : DataFile(mode, backend), proxy(proxy), fileID(fileID) {}
 
   ~OPFSFile() override {
@@ -335,12 +361,12 @@ private:
 
 class OPFSDirectory : public Directory {
 public:
-  ProxyWorker& proxy;
+  Worker& proxy;
 
   // The ID of this directory in the JS library.
   int dirID = 0;
 
-  OPFSDirectory(mode_t mode, backend_t backend, int dirID, ProxyWorker& proxy)
+  OPFSDirectory(mode_t mode, backend_t backend, int dirID, Worker& proxy)
     : Directory(mode, backend), proxy(proxy), dirID(dirID) {}
 
   ~OPFSDirectory() override {
@@ -445,7 +471,7 @@ private:
 
 class OPFSBackend : public Backend {
 public:
-  ProxyWorker proxy;
+  Worker proxy;
 
   std::shared_ptr<DataFile> createFile(mode_t mode) override {
     // No way to support a raw file without a parent directory.
@@ -472,8 +498,9 @@ extern "C" {
 backend_t wasmfs_create_opfs_backend() {
   // ProxyWorker cannot safely be synchronously spawned from the main browser
   // thread. See comment in thread_utils.h for more details.
-  assert(!emscripten_is_main_browser_thread() &&
-         "Cannot safely create OPFS backend on main browser thread");
+  assert(!emscripten_is_main_browser_thread() || emscripten_has_asyncify() == 2 &&
+         "Cannot safely create OPFS backend on main browser thread without JSPI");
+
   return wasmFS.addBackend(std::make_unique<OPFSBackend>());
 }
 

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -132,13 +132,15 @@ public:
 #else
   // When used with JSPI on the main thread the various wasmfs_opfs_* functions
   // can be directly executed since they are all async.
-  void operator()(const std::function<void()>& func) {
-    func();
-  }
-  void operator()(const std::function<void(ProxyingQueue::ProxyingCtx)>& func) {
-    // TODO: Find a way to remove this, since it's unused.
-    ProxyingQueue::ProxyingCtx p;
-    func(p);
+  template <typename T>
+  void operator()(T func) {
+    if constexpr (std::is_invocable<T&, ProxyingQueue::ProxyingCtx>::value) {
+      // TODO: Find a way to remove this, since it's unused.
+      ProxyingQueue::ProxyingCtx p;
+      func(p);
+    } else {
+      func();
+    }
   }
 #endif
 };

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -125,10 +125,8 @@ public:
 #ifdef __EMSCRIPTEN_PTHREADS__
   ProxyWorker proxy;
 
-  void operator()(const std::function<void()>& func) {
-    proxy(func);
-  }
-  void operator()(const std::function<void(ProxyingQueue::ProxyingCtx)>& func) {
+  template<typename T>
+  void operator()(T func) {
     proxy(func);
   }
 #else

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -134,7 +134,7 @@ public:
   // can be directly executed since they are all async.
   template <typename T>
   void operator()(T func) {
-    if constexpr (std::is_invocable<T&, ProxyingQueue::ProxyingCtx>::value) {
+    if constexpr (std::is_invocable_v<T&, ProxyingQueue::ProxyingCtx>) {
       // TODO: Find a way to remove this, since it's unused.
       ProxyingQueue::ProxyingCtx p;
       func(p);

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5397,11 +5397,15 @@ Module["preRun"].push(function () {
                     args=['-sWASMFS', '-pthread', '-sPROXY_TO_PTHREAD', '-sINITIAL_MEMORY=32MB',
                           '--js-library', test_file('wasmfs/wasmfs_fetch.js')] + args)
 
-  @requires_threads
   @no_firefox('no OPFS support yet')
-  def test_wasmfs_opfs(self):
+  @parameterized({
+    '': (['-pthread', '-sPROXY_TO_PTHREAD'],),
+    'jspi': (['-Wno-experimental', '-sASYNCIFY=2'],),
+  })
+  @requires_threads
+  def test_wasmfs_opfs(self, args):
     test = test_file('wasmfs/wasmfs_opfs.c')
-    args = ['-sWASMFS', '-pthread', '-sPROXY_TO_PTHREAD', '-O3']
+    args = ['-sWASMFS', '-O3'] + args
     self.btest_exit(test, args=args + ['-DWASMFS_SETUP'])
     self.btest_exit(test, args=args + ['-DWASMFS_RESUME'])
 


### PR DESCRIPTION
The OPFS backend will now use async reaad/writes when used on the main thread. The ProxyWorker is stubbed out and calls are directly dispatched into JS. The JS side uses a new FileSystemASyncAccessHandle class that matches the sync version of the class, but has async read/writes. Hopefully, we can one day replace that with something from the platform.