### PR TITLE
HandleAllocator: Always reserve handle zero. NFC

### DIFF
--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -16,7 +16,8 @@ mergeInto(LibraryManager.library, {
 
   _wasmfs_opfs_init_root_directory__deps: ['$wasmfsOPFSDirectoryHandles'],
   _wasmfs_opfs_init_root_directory: async function(ctx) {
-    if (wasmfsOPFSDirectoryHandles.allocated.length == 0) {
+    // allocated.length start of as 1 since 0 is a reserved handle
+    if (wasmfsOPFSDirectoryHandles.allocated.length == 1) {
       // Directory 0 is reserved as the root
       let root = await navigator.storage.getDirectory();
       wasmfsOPFSDirectoryHandles.allocated.push(root);

--- a/system/lib/wasmfs/backends/opfs_backend.cpp
+++ b/system/lib/wasmfs/backends/opfs_backend.cpp
@@ -456,7 +456,7 @@ public:
 
   std::shared_ptr<Directory> createDirectory(mode_t mode) override {
     proxy([](auto ctx) { _wasmfs_opfs_init_root_directory(ctx.ctx); });
-    return std::make_shared<OPFSDirectory>(mode, this, 0, proxy);
+    return std::make_shared<OPFSDirectory>(mode, this, 1, proxy);
   }
 
   std::shared_ptr<Symlink> createSymlink(std::string target) override {

--- a/test/core/test_promise.c
+++ b/test/core/test_promise.c
@@ -253,7 +253,7 @@ static em_promise_result_t finish(void** result, void* data, void* value) {
 
   // We should not have leaked any handles.
   EM_ASM({
-    promiseMap.allocated.forEach(() => assert(false, "non-destroyed handle"));
+    promiseMap.allocated.forEach((p) => assert(typeof p === "undefined", "non-destroyed handle"));
   });
 
   // Cannot exit directly in a promise callback, since it would end up rejecting

--- a/test/other/test_dlopen_promise.c
+++ b/test/other/test_dlopen_promise.c
@@ -22,7 +22,7 @@ em_promise_result_t on_rejected(void **result, void* data, void *value) {
 
 int main() {
   em_promise_t inner = emscripten_dlopen_promise("libside.so", RTLD_NOW);
-  em_promise_t outer = emscripten_promise_then(outer, on_fullfilled, on_rejected, NULL);
+  em_promise_t outer = emscripten_promise_then(inner, on_fullfilled, on_rejected, NULL);
   emscripten_promise_destroy(outer);
   emscripten_promise_destroy(inner);
   printf("returning from main\n");


### PR DESCRIPTION
Also, set entries to `undefined` rather than using the `delete` operator on the
handle array.  Apparently using `delete` can lead to holes in the array which
can damage perf.

This actually revealed a hidden bug in test/other/test_dlopen_promise.c.

Split out from #19054