### PR TITLE
cmake: Fix counter used in em_link_pre_js/em_link_post_js etc

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -307,7 +307,7 @@ function(em_validate_asmjs_after_build target)
 endfunction()
 
 # A global counter to guarantee unique names for js library files.
-set(link_js_counter 1)
+set(link_js_counter 0 CACHE INTERNAL "")
 
 # Internal function: Do not call from user CMakeLists.txt files. Use one of
 # em_link_js_library()/em_link_pre_js()/em_link_post_js() instead.
@@ -350,6 +350,7 @@ function(em_add_tracked_link_flag target flagname)
       target_link_libraries(${target} "${flagname} \"${js_file_absolute_path}\"")
 
       math(EXPR link_js_counter "${link_js_counter} + 1")
+      set(link_js_counter ${link_js_counter} CACHE INTERNAL "")
     endforeach()
   endforeach()
 endfunction()

--- a/test/cmake/target_js/CMakeLists.txt
+++ b/test/cmake/target_js/CMakeLists.txt
@@ -4,21 +4,15 @@ project(test_cmake)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../cpp_lib ${CMAKE_CURRENT_BINARY_DIR}/cpp_lib)
 
-file(GLOB sourceFiles main.cpp)
-
-file(GLOB preJsFiles pre*.js)
-file(GLOB postJsFiles post*.js)
-file(GLOB libraryJsFiles jslibrary*.js)
-
 if (CMAKE_BUILD_TYPE STREQUAL Debug)
-  set(linkFlags "-g4 -sNO_EXIT_RUNTIME")
+  set(linkFlags "-g")
 else()
   # Either MinSizeRel, RelWithDebInfo or Release, all which run with optimizations enabled.
-  set(linkFlags "-O2 -sNO_EXIT_RUNTIME")
+  set(linkFlags "-O2")
 endif()
 
 # Ensure synchronous startup for this test, whose output expects it
-set(linkFlags "${linkFlags} -sWASM_ASYNC_COMPILATION=0")
+set(linkFlags "${linkFlags} -sNO_EXIT_RUNTIME -sWASM_ASYNC_COMPILATION=0")
 
 # Test that the CMake-provided macro check_function_exists() works.
 include(CheckFunctionExists)
@@ -82,19 +76,23 @@ if (NOT ${endian_result} EQUAL 0)
   message(FATAL_ERROR "TEST_BIG_ENDIAN did not return 0!")
 endif()
 
-add_executable(test_cmake ${sourceFiles})
+add_executable(test_cmake "main.cpp")
 target_link_libraries( test_cmake cpp_lib)
 
 # GOTCHA: If your project has custom link flags, these must be set *before*
 # calling any of the em_link_xxx functions!
 set_target_properties(test_cmake PROPERTIES LINK_FLAGS "${linkFlags}")
 
+file(GLOB libraryJsFiles jslibrary*.js)
 message(STATUS "js libs '${libraryJsFiles}'")
 # To link .js files using the --js-library flag, use the following helper function.
 em_link_js_library(test_cmake ${libraryJsFiles})
 
 # To link .js files using the --pre-js flag, use the following helper function.
-em_link_pre_js(test_cmake ${preJsFiles})
+em_link_pre_js(test_cmake "prejs.js")
+
+# Ensure that calling em_link_pre_js multiple times works as expected.
+em_link_pre_js(test_cmake "prejs.js")
 
 # To link .js files using the --post-js flag, use the following helper function.
-em_link_post_js(test_cmake ${postJsFiles})
+em_link_post_js(test_cmake "postjs.js")

--- a/test/cmake/target_js/out.txt
+++ b/test/cmake/target_js/out.txt
@@ -1,4 +1,5 @@
 prejs executed
+prejs executed
 lib_function
 lib_function2
 postjs executed


### PR DESCRIPTION
The existing code not safe against muliple calls to the function due to the way scoping works in cmake:
https://cmake.org/pipermail/cmake/2011-October/046701.html

Alternative to #18991