### PR TITLE
cmake: Use LINK_DEPENDS for em_link_js_library et al. NFC

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -306,50 +306,21 @@ function(em_validate_asmjs_after_build target)
   message(WARNING "em_validate_asmjs_after_build no longer exists")
 endfunction()
 
-# A global counter to guarantee unique names for js library files.
-set(link_js_counter 1)
-
 # Internal function: Do not call from user CMakeLists.txt files. Use one of
 # em_link_js_library()/em_link_pre_js()/em_link_post_js() instead.
-function(em_add_tracked_link_flag target flagname)
-
+function(em_add_link_deps target flagname)
   # User can input list of JS files either as a single list, or as variable
   # arguments to this function, so iterate over varargs, and treat each item in
   # varargs as a list itself, to support both syntax forms.
   foreach(jsFileList ${ARGN})
     foreach(jsfile ${jsFileList})
-      # If the user edits the JS file, we want to relink the emscripten
-      # application, but unfortunately it is not possible to make a link step
-      # depend directly on a source file. Instead, we must make a dummy no-op
-      # build target on that source file, and make the project depend on
-      # that target.
-
-      # Sanitate the source .js filename to a good symbol name to use as a dummy
-      # filename.
-      get_filename_component(jsname "${jsfile}" NAME)
-      string(REGEX REPLACE "[/:\\\\.\ ]" "_" dummy_js_target ${jsname})
-      set(dummy_lib_name ${target}_${link_js_counter}_${dummy_js_target})
-      set(dummy_c_name "${CMAKE_BINARY_DIR}/${dummy_js_target}_tracker.c")
-
-      # Create a new static library target that with a single dummy .c file.
-      add_library(${dummy_lib_name} STATIC ${dummy_c_name})
-      # Make the dummy .c file depend on the .js file we are linking, so that if
-      # the .js file is edited, the dummy .c file, and hence the static library
-      # will be rebuild (no-op). This causes the main application to be
-      # relinked, which is what we want.  This approach was recommended by
-      # http://www.cmake.org/pipermail/cmake/2010-May/037206.html
-      add_custom_command(OUTPUT ${dummy_c_name} COMMAND ${CMAKE_COMMAND} -E touch ${dummy_c_name} DEPENDS ${jsfile})
-      target_link_libraries(${target} ${dummy_lib_name})
-
-      # Link the js-library to the target
-      # When a linked library starts with a "-" cmake will just add it to the
-      # linker command line as it is.  The advantage of doing it this way is
-      # that the js-library will also be automatically linked to targets that
-      # depend on this target.
-      get_filename_component(js_file_absolute_path "${jsfile}" ABSOLUTE )
-      target_link_libraries(${target} "${flagname} \"${js_file_absolute_path}\"")
-
-      math(EXPR link_js_counter "${link_js_counter} + 1")
+      get_target_property(linkdeps ${target} LINK_DEPENDS)
+      if(linkdeps STREQUAL "linkdeps-NOTFOUND")
+        set(linkdeps "")
+      endif()
+      get_filename_component(jsfile_abs "${jsfile}" ABSOLUTE )
+      set_target_properties(${target} PROPERTIES LINK_DEPENDS "${linkdeps};${jsfile_abs}")
+      target_link_libraries(${target} "${flagname} \"${jsfile_abs}\"")
     endforeach()
   endforeach()
 endfunction()
@@ -361,21 +332,21 @@ endfunction()
 #    between the linked .js files and the main project, so that editing the .js
 #    file will cause the target project to be relinked.
 function(em_link_js_library target)
-  em_add_tracked_link_flag(${target} "--js-library" ${ARGN})
+  em_add_link_deps(${target} "--js-library" ${ARGN})
 endfunction()
 
 # This function is identical to em_link_js_library(), except the .js files will
 # be added with '--pre-js file.js' command line flag, which is generally used to
 # add some preamble .js code to a generated output file.
 function(em_link_pre_js target)
-  em_add_tracked_link_flag(${target} "--pre-js" ${ARGN})
+  em_add_link_deps(${target} "--pre-js" ${ARGN})
 endfunction()
 
 # This function is identical to em_link_js_library(), except the .js files will
 # be added with '--post-js file.js' command line flag, which is generally used
 # to add some postamble .js code to a generated output file.
 function(em_link_post_js target)
-  em_add_tracked_link_flag(${target} "--post-js" ${ARGN})
+  em_add_link_deps(${target} "--post-js" ${ARGN})
 endfunction()
 
 # Experimental support for targeting generation of Visual Studio project files

--- a/test/cmake/target_js/CMakeLists.txt
+++ b/test/cmake/target_js/CMakeLists.txt
@@ -4,17 +4,11 @@ project(test_cmake)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../cpp_lib ${CMAKE_CURRENT_BINARY_DIR}/cpp_lib)
 
-file(GLOB sourceFiles main.cpp)
-
-file(GLOB preJsFiles pre*.js)
-file(GLOB postJsFiles post*.js)
-file(GLOB libraryJsFiles jslibrary*.js)
-
 if (CMAKE_BUILD_TYPE STREQUAL Debug)
-  set(linkFlags "-g4 -sNO_EXIT_RUNTIME")
+  set(linkFlags "-g")
 else()
   # Either MinSizeRel, RelWithDebInfo or Release, all which run with optimizations enabled.
-  set(linkFlags "-O2 -sNO_EXIT_RUNTIME")
+  set(linkFlags "-O2")
 endif()
 
 # Ensure synchronous startup for this test, whose output expects it
@@ -82,19 +76,23 @@ if (NOT ${endian_result} EQUAL 0)
   message(FATAL_ERROR "TEST_BIG_ENDIAN did not return 0!")
 endif()
 
-add_executable(test_cmake ${sourceFiles})
+add_executable(test_cmake "main.cpp")
 target_link_libraries( test_cmake cpp_lib)
 
 # GOTCHA: If your project has custom link flags, these must be set *before*
 # calling any of the em_link_xxx functions!
 set_target_properties(test_cmake PROPERTIES LINK_FLAGS "${linkFlags}")
 
+file(GLOB libraryJsFiles jslibrary*.js)
 message(STATUS "js libs '${libraryJsFiles}'")
 # To link .js files using the --js-library flag, use the following helper function.
 em_link_js_library(test_cmake ${libraryJsFiles})
 
 # To link .js files using the --pre-js flag, use the following helper function.
-em_link_pre_js(test_cmake ${preJsFiles})
+em_link_pre_js(test_cmake "prejs.js")
+
+# Ensure that calling em_link_pre_js multiple times works as expected.
+em_link_pre_js(test_cmake "prejs.js")
 
 # To link .js files using the --post-js flag, use the following helper function.
-em_link_post_js(test_cmake ${postJsFiles})
+em_link_post_js(test_cmake "postjs.js")

--- a/test/cmake/target_js/out.txt
+++ b/test/cmake/target_js/out.txt
@@ -1,4 +1,5 @@
 prejs executed
+prejs executed
 lib_function
 lib_function2
 postjs executed


### PR DESCRIPTION
Fixes: #19070