### PR TITLE
stringToNewUTF8 moved to library_legacy.js.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 3.1.35 (in development)
 -----------------------
+- `stringToNewUTF8` JS library function is moved to `library_legacy.js`.  Prefer
+  the direct use of `allocateUTF8` which does the same thing.
 - `SDL_image` port was updated to version 2.6.0.
 - `-z` arguments are now passed directly to wasm-ld without the need for the
   `-Wl,` prefix.  This matches the behaviour of both clang and gcc. (#18956)

--- a/src/library.js
+++ b/src/library.js
@@ -52,8 +52,6 @@ mergeInto(LibraryManager.library, {
   // JavaScript <-> C string interop
   // ==========================================================================
 
-  $stringToNewUTF8: '$allocateUTF8',
-
 #if !MINIMAL_RUNTIME
   $exitJS__docs: '/** @param {boolean|number=} implicit */',
   $exitJS__deps: ['proc_exit'],

--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -6,7 +6,7 @@
 
 var LibraryGLEmulation = {
   // GL emulation: provides misc. functionality not present in OpenGL ES 2.0 or WebGL
-  $GLEmulation__deps: ['$GLImmediateSetup', 'glEnable', 'glDisable', 'glIsEnabled', 'glGetBooleanv', 'glGetIntegerv', 'glGetString', 'glCreateShader', 'glShaderSource', 'glCompileShader', 'glAttachShader', 'glDetachShader', 'glUseProgram', 'glDeleteProgram', 'glBindAttribLocation', 'glLinkProgram', 'glBindBuffer', 'glGetFloatv', 'glHint', 'glEnableVertexAttribArray', 'glDisableVertexAttribArray', 'glVertexAttribPointer', 'glActiveTexture', '$stringToNewUTF8', '$ptrToString'],
+  $GLEmulation__deps: ['$GLImmediateSetup', 'glEnable', 'glDisable', 'glIsEnabled', 'glGetBooleanv', 'glGetIntegerv', 'glGetString', 'glCreateShader', 'glShaderSource', 'glCompileShader', 'glAttachShader', 'glDetachShader', 'glUseProgram', 'glDeleteProgram', 'glBindAttribLocation', 'glLinkProgram', 'glBindBuffer', 'glGetFloatv', 'glHint', 'glEnableVertexAttribArray', 'glDisableVertexAttribArray', 'glVertexAttribPointer', 'glActiveTexture', '$allocateUTF8', '$ptrToString'],
   $GLEmulation__postset:
 #if USE_CLOSURE_COMPILER
     // Forward declare GL functions that are overridden by GLEmulation here to appease Closure compiler.
@@ -412,7 +412,7 @@ var LibraryGLEmulation = {
         if (GL.stringCache[name_]) return GL.stringCache[name_];
         switch (name_) {
           case 0x1F03 /* GL_EXTENSIONS */: // Add various extensions that we can support
-            var ret = stringToNewUTF8((GLctx.getSupportedExtensions() || []).join(' ') +
+            var ret = allocateUTF8((GLctx.getSupportedExtensions() || []).join(' ') +
                    ' GL_EXT_texture_env_combine GL_ARB_texture_env_crossbar GL_ATI_texture_env_combine3 GL_NV_texture_env_combine4 GL_EXT_texture_env_dot3 GL_ARB_multitexture GL_ARB_vertex_buffer_object GL_EXT_framebuffer_object GL_ARB_vertex_program GL_ARB_fragment_program GL_ARB_shading_language_100 GL_ARB_shader_objects GL_ARB_vertex_shader GL_ARB_fragment_shader GL_ARB_texture_cube_map GL_EXT_draw_range_elements' +
                    (GL.currentContext.compressionExt ? ' GL_ARB_texture_compression GL_EXT_texture_compression_s3tc' : '') +
                    (GL.currentContext.anisotropicExt ? ' GL_EXT_texture_filter_anisotropic' : '')

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2396,14 +2396,14 @@ var LibraryHTML5 = {
 #if OFFSCREENCANVAS_SUPPORT
   _emscripten_set_offscreencanvas_size: 'emscripten_set_canvas_element_size',
 
-  $setOffscreenCanvasSizeOnTargetThread__deps: ['$stringToNewUTF8', 'emscripten_dispatch_to_thread_', '$withStackSave'],
+  $setOffscreenCanvasSizeOnTargetThread__deps: ['$allocateUTF8', 'emscripten_dispatch_to_thread_', '$withStackSave'],
   $setOffscreenCanvasSizeOnTargetThread: function(targetThread, targetCanvas, width, height) {
     targetCanvas = targetCanvas ? UTF8ToString(targetCanvas) : '';
     withStackSave(function() {
       var varargs = stackAlloc(12);
       var targetCanvasPtr = 0;
       if (targetCanvas) {
-        targetCanvasPtr = stringToNewUTF8(targetCanvas);
+        targetCanvasPtr = allocateUTF8(targetCanvas);
       }
       {{{ makeSetValue('varargs', 0, 'targetCanvasPtr', 'i32')}}};
       {{{ makeSetValue('varargs', 4, 'width', 'i32')}}};

--- a/src/library_html5_webgl.js
+++ b/src/library_html5_webgl.js
@@ -445,9 +445,9 @@ var LibraryHtml5WebGL = {
   },
 
   emscripten_webgl_get_supported_extensions__proxy: 'sync_on_current_webgl_context_thread',
-  emscripten_webgl_get_supported_extensions__deps: ['$stringToNewUTF8'],
+  emscripten_webgl_get_supported_extensions__deps: ['$allocateUTF8'],
   emscripten_webgl_get_supported_extensions: function() {
-    return stringToNewUTF8(GLctx.getSupportedExtensions().join(' '));
+    return allocateUTF8(GLctx.getSupportedExtensions().join(' '));
   },
 
   emscripten_webgl_get_program_parameter_d__proxy: 'sync_on_current_webgl_context_thread',
@@ -456,9 +456,9 @@ var LibraryHtml5WebGL = {
   },
 
   emscripten_webgl_get_program_info_log_utf8__proxy: 'sync_on_current_webgl_context_thread',
-  emscripten_webgl_get_program_info_log_utf8__deps: ['$stringToNewUTF8'],
+  emscripten_webgl_get_program_info_log_utf8__deps: ['$allocateUTF8'],
   emscripten_webgl_get_program_info_log_utf8: function(program) {
-    return stringToNewUTF8(GLctx.getProgramInfoLog(GL.programs[program]));
+    return allocateUTF8(GLctx.getProgramInfoLog(GL.programs[program]));
   },
 
   emscripten_webgl_get_shader_parameter_d__proxy: 'sync_on_current_webgl_context_thread',
@@ -467,15 +467,15 @@ var LibraryHtml5WebGL = {
   },
 
   emscripten_webgl_get_shader_info_log_utf8__proxy: 'sync_on_current_webgl_context_thread',
-  emscripten_webgl_get_shader_info_log_utf8__deps: ['$stringToNewUTF8'],
+  emscripten_webgl_get_shader_info_log_utf8__deps: ['$allocateUTF8'],
   emscripten_webgl_get_shader_info_log_utf8: function(shader) {
-    return stringToNewUTF8(GLctx.getShaderInfoLog(GL.shaders[shader]));
+    return allocateUTF8(GLctx.getShaderInfoLog(GL.shaders[shader]));
   },
 
   emscripten_webgl_get_shader_source_utf8__proxy: 'sync_on_current_webgl_context_thread',
-  emscripten_webgl_get_shader_source_utf8__deps: ['$stringToNewUTF8'],
+  emscripten_webgl_get_shader_source_utf8__deps: ['$allocateUTF8'],
   emscripten_webgl_get_shader_source_utf8: function(shader) {
-    return stringToNewUTF8(GLctx.getShaderSource(GL.shaders[shader]));
+    return allocateUTF8(GLctx.getShaderSource(GL.shaders[shader]));
   },
 
   emscripten_webgl_get_vertex_attrib_d__proxy: 'sync_on_current_webgl_context_thread',
@@ -524,10 +524,10 @@ var LibraryHtml5WebGL = {
     return obj && obj.name;
   },
 
-  emscripten_webgl_get_parameter_utf8__deps: ['$stringToNewUTF8'],
+  emscripten_webgl_get_parameter_utf8__deps: ['$allocateUTF8'],
   emscripten_webgl_get_parameter_utf8__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_parameter_utf8: function(param) {
-    return stringToNewUTF8(GLctx.getParameter(param));
+    return allocateUTF8(GLctx.getParameter(param));
   },
 
   emscripten_webgl_get_parameter_i64v__proxy: 'sync_on_current_webgl_context_thread',

--- a/src/library_legacy.js
+++ b/src/library_legacy.js
@@ -37,4 +37,6 @@ mergeInto(LibraryManager.library, {
     HEAPU8.set(slab, ret);
     return ret;
   },
+
+  $stringToNewUTF8: '$allocateUTF8',
 });

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1148,7 +1148,7 @@ var LibraryGL = {
     GLctx.pixelStorei(pname, param);
   },
 
-  glGetString__deps: ['$stringToNewUTF8'],
+  glGetString__deps: ['$allocateUTF8'],
   glGetString: function(name_) {
     var ret = GL.stringCache[name_];
     if (!ret) {
@@ -1158,7 +1158,7 @@ var LibraryGL = {
 #if GL_EXTENSIONS_IN_PREFIXED_FORMAT
           exts = exts.concat(exts.map(function(e) { return "GL_" + e; }));
 #endif
-          ret = stringToNewUTF8(exts.join(' '));
+          ret = allocateUTF8(exts.join(' '));
           break;
         case 0x1F00 /* GL_VENDOR */:
         case 0x1F01 /* GL_RENDERER */:
@@ -1177,7 +1177,7 @@ var LibraryGL = {
 #endif
           }
 #endif
-          ret = s && stringToNewUTF8(s);
+          ret = s && allocateUTF8(s);
           break;
 
 #if GL_EMULATE_GLES_VERSION_STRING_FORMAT
@@ -1191,7 +1191,7 @@ var LibraryGL = {
           {
             glVersion = 'OpenGL ES 2.0 (' + glVersion + ')';
           }
-          ret = stringToNewUTF8(glVersion);
+          ret = allocateUTF8(glVersion);
           break;
         case 0x8B8C /* GL_SHADING_LANGUAGE_VERSION */:
           var glslVersion = GLctx.getParameter(0x8B8C /*GL_SHADING_LANGUAGE_VERSION*/);
@@ -1202,7 +1202,7 @@ var LibraryGL = {
             if (ver_num[1].length == 3) ver_num[1] = ver_num[1] + '0'; // ensure minor version has 2 digits
             glslVersion = 'OpenGL ES GLSL ES ' + ver_num[1] + ' (' + glslVersion + ')';
           }
-          ret = stringToNewUTF8(glslVersion);
+          ret = allocateUTF8(glslVersion);
           break;
 #endif
 #if GL_TRACK_ERRORS

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -5,7 +5,7 @@
  */
 
 var LibraryWebGL2 = {
-  glGetStringi__deps: ['$stringToNewUTF8'],
+  glGetStringi__deps: ['$allocateUTF8'],
   glGetStringi__sig: 'iii',
   glGetStringi: function(name, index) {
     if (GL.currentContext.version < 2) {
@@ -29,7 +29,7 @@ var LibraryWebGL2 = {
 #if GL_EXTENSIONS_IN_PREFIXED_FORMAT
         exts = exts.concat(exts.map(function(e) { return "GL_" + e; }));
 #endif
-        exts = exts.map(function(e) { return stringToNewUTF8(e); });
+        exts = exts.map(function(e) { return allocateUTF8(e); });
 
         stringiCache = GL.stringiCache[name] = exts;
         if (index < 0 || index >= stringiCache.length) {

--- a/test/pthread/call_sync_on_main_thread.js
+++ b/test/pthread/call_sync_on_main_thread.js
@@ -4,11 +4,11 @@ mergeInto(LibraryManager.library, {
   // Because it accesses the DOM, it must be called on the main thread.
   getDomElementContents__proxy: 'sync',
   getDomElementContents__sig: 'viii',
-  getDomElementContents__deps: ['$stringToNewUTF8'],
+  getDomElementContents__deps: ['$allocateUTF8'],
   getDomElementContents: function(domElementSelector) {
     var selector = UTF8ToString(domElementSelector);
     var text = document.querySelector(selector).innerHTML;
-    return stringToNewUTF8(text);
+    return allocateUTF8(text);
   },
 
   receivesAndReturnsAnInteger__proxy: 'sync',


### PR DESCRIPTION
Followup to #19064

All remaining internal usages converted to `allocateUTF8`.  These functions do the same thing and were made into aliases in #19064.

`stringToNewUTF8` was added in 443447b14d3 and has fewer uses than `allocateUTF8`.

`allocateUTF8` was added in 5174d2eae0b.