### PR TITLE
Change default log level to WARN to avoid spamming stderr

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -190,7 +190,7 @@ def main():
     settings.LTO = args.lto
 
   if args.verbose:
-    shared.PRINT_STAGES = True
+    shared.EMCC_VERBOSE = True
 
   if args.pic:
     settings.RELOCATABLE = 1

--- a/emcc.py
+++ b/emcc.py
@@ -3504,7 +3504,7 @@ def parse_args(newargs):
     elif check_flag('--ignore-dynamic-linking'):
       options.ignore_dynamic_linking = True
     elif arg == '-v':
-      shared.PRINT_STAGES = True
+      shared.EMCC_VERBOSE = True
     elif check_arg('--shell-file'):
       options.shell_path = consume_arg_file()
     elif check_arg('--source-map-base'):

--- a/emsymbolizer.py
+++ b/emsymbolizer.py
@@ -243,7 +243,7 @@ def get_args():
   parser.add_argument('address', help='Address to lookup')
   args = parser.parse_args()
   if args.verbose:
-    shared.PRINT_STAGES = 1
+    shared.EMCC_VERBOSE = True
     shared.DEBUG = True
   return args
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -256,6 +256,7 @@ class other(RunnerCore):
       self.assertContained('Target: wasm32-unknown-emscripten', proc.stderr)
       self.assertNotContained('this is dangerous', proc.stderr)
 
+  @with_env_modify({'EMCC_VERBOSE': '1'})
   def test_emcc_check(self):
     proc = self.run_process([EMCC, '--check'], stdout=PIPE, stderr=PIPE)
     self.assertEqual(proc.stdout, '')

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -308,6 +308,7 @@ fi
         output = self.do(cmd)
         self.assertNotContained(NODE_WARNING, output)
 
+  @with_env_modify({'EMCC_VERBOSE': '1'})
   def test_emcc(self):
     SANITY_FAIL_MESSAGE = 'sanity check failed to run'
 
@@ -379,6 +380,7 @@ fi
   def ensure_cache(self):
     self.do([EMCC, '-O2', test_file('hello_world.c')])
 
+  @with_env_modify({'EMCC_VERBOSE': '1'})
   def test_emcc_caching(self):
     BUILDING_MESSAGE = 'generating system library: %s'
 
@@ -398,6 +400,7 @@ fi
       self.assertExists(cache.cachedir)
       self.assertExists(os.path.join(cache.cachedir, libname))
 
+  @with_env_modify({'EMCC_VERBOSE': '1'})
   def test_cache_clearing_manual(self):
     # Manual cache clearing
     restore_and_set_up()
@@ -408,6 +411,7 @@ fi
     self.assertIn(SANITY_MESSAGE, output)
     self.assertCacheEmpty()
 
+  @with_env_modify({'EMCC_VERBOSE': '1'})
   def test_cache_clearing_auto(self):
     # Changing LLVM_ROOT, even without altering .emscripten, clears the cache
     restore_and_set_up()
@@ -691,6 +695,7 @@ fi
     with env_modify({'PATH': self.in_dir('fake') + os.pathsep + os.environ['PATH']}):
       self.check_working([EMCC])
 
+  @with_env_modify({'EMCC_VERBOSE': '1'})
   def test_embuilder_force(self):
     restore_and_set_up()
     self.do([EMBUILDER, 'build', 'libemmalloc'])
@@ -699,6 +704,7 @@ fi
     # Unless --force is specified
     self.assertContained('generating system library', self.do([EMBUILDER, 'build', 'libemmalloc', '--force']))
 
+  @with_env_modify({'EMCC_VERBOSE': '1'})
   def test_embuilder_force_port(self):
     restore_and_set_up()
     self.do([EMBUILDER, 'build', 'zlib'])

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -29,9 +29,15 @@ from . import colored_logger
 # Configure logging before importing any other local modules so even
 # log message during import are shown as expected.
 DEBUG = int(os.environ.get('EMCC_DEBUG', '0'))
+EMCC_VERBOSE = int(os.getenv('EMCC_VERBOSE', '0'))
+if DEBUG:
+  log_level = logging.DEBUG
+elif EMCC_VERBOSE:
+  log_level = logging.INFO
+else:
+  log_level = logging.WARN
 # can add  %(asctime)s  to see timestamps
-logging.basicConfig(format='%(name)s:%(levelname)s: %(message)s',
-                    level=logging.DEBUG if DEBUG else logging.INFO)
+logging.basicConfig(format='%(name)s:%(levelname)s: %(message)s', level=log_level)
 colored_logger.enable()
 
 from .utils import path_from_root, exit_with_error, safe_ensure_dirs, WINDOWS
@@ -618,7 +624,7 @@ def target_environment_may_be(environment):
 def print_compiler_stage(cmd):
   """Emulate the '-v' of clang/gcc by printing the name of the sub-command
   before executing it."""
-  if PRINT_STAGES:
+  if EMCC_VERBOSE:
     print(' "%s" %s' % (cmd[0], shlex_join(cmd[1:])), file=sys.stderr)
     sys.stderr.flush()
 
@@ -787,5 +793,3 @@ EMSCRIPTEN_TEMP_DIR = None
 setup_temp_dirs()
 
 cache.setup(config.CACHE)
-
-PRINT_STAGES = int(os.getenv('EMCC_VERBOSE', '0'))

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -112,7 +112,7 @@ def get_top_level_ninja_file():
 def run_ninja(build_dir):
   diagnostics.warning('experimental', 'ninja support is experimental')
   cmd = ['ninja', '-C', build_dir, f'-j{shared.get_num_cores()}']
-  if shared.PRINT_STAGES:
+  if shared.EMCC_VERBOSE:
     cmd.append('-v')
   shared.check_call(cmd, env=clean_env())
 

--- a/tools/toolchain_profiler.py
+++ b/tools/toolchain_profiler.py
@@ -13,6 +13,7 @@ import time
 from contextlib import ContextDecorator
 
 logger = logging.getLogger('profiler')
+logger.setLevel(logging.INFO)
 
 from . import response_file
 


### PR DESCRIPTION
By default we don't want random messages such as `cache:INFO: generating system asset:` from appearing on stdout.

EMCC_DEBUG and EMCC_VERBOSE can be used enable more info.

Fixes: #18622, #18607