### PR TITLE
Rename allocateUTF8OnStack -> stringToUTF8OnStack

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,8 +23,9 @@ See docs/process.md for more on how version tagging works.
 - `FS.loadFilesFromDB` and `FS.saveFilesToDB` were removed.  We think it's
   unlikly there were any users of these functions since there is now a separate
   IDBFS filesystem for folks that want persistence. (#19049)
-- `allocateUTF8` library function moved to `library_legacy.js`.  Prefer the
-  more accurately named `stringToNewUTF8`.
+- `allocateUTF8` and `allocateUTF8OnStack` library function moved to
+  `library_legacy.js`.  Prefer the more accurately named `stringToNewUTF8` and
+  `stringToUTF8OnStack`. (#19089)
 - `SDL_image` port was updated to version 2.6.0.
 - `-z` arguments are now passed directly to wasm-ld without the need for the
   `-Wl,` prefix.  This matches the behaviour of both clang and gcc. (#18956)

--- a/emscripten.py
+++ b/emscripten.py
@@ -157,7 +157,7 @@ def update_settings_glue(wasm_file, metadata):
   settings.MAIN_READS_PARAMS = metadata.mainReadsParams or bool(settings.MAIN_MODULE)
   if settings.MAIN_READS_PARAMS and not settings.STANDALONE_WASM:
     # callMain depends on this library function
-    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$allocateUTF8OnStack']
+    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$stringToUTF8OnStack']
 
   if settings.STACK_OVERFLOW_CHECK and not settings.SIDE_MODULE:
     # writeStackCookie and checkStackCookie both rely on emscripten_stack_get_end being

--- a/src/library.js
+++ b/src/library.js
@@ -3713,7 +3713,7 @@ DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.push(
   '$stringToUTF32',
   '$lengthBytesUTF32',
   '$stringToNewUTF8',
-  '$allocateUTF8OnStack',
+  '$stringToUTF8OnStack',
   '$writeStringToMemory',
   '$writeArrayToMemory',
   '$writeAsciiToMemory',

--- a/src/library_ccall.js
+++ b/src/library_ccall.js
@@ -15,7 +15,7 @@ mergeInto(LibraryManager.library, {
   },
 
   // C calling interface.
-  $ccall__deps: ['$getCFunc', '$writeArrayToMemory', '$allocateUTF8OnStack'],
+  $ccall__deps: ['$getCFunc', '$writeArrayToMemory', '$stringToUTF8OnStack'],
   $ccall__docs: `
   /**
    * @param {string|null=} returnType
@@ -33,7 +33,7 @@ mergeInto(LibraryManager.library, {
         var ret = 0;
         if (str !== null && str !== undefined && str !== 0) { // null string
           // at most 4 bytes per UTF-8 code point, +1 for the trailing '\0'
-          ret = allocateUTF8OnStack(str);
+          ret = stringToUTF8OnStack(str);
         }
         return {{{ to64('ret') }}};
       },

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -296,13 +296,13 @@ var LibraryDylink = {
   },
 
   $dlSetError__internal: true,
-  $dlSetError__deps: ['__dl_seterr', '$allocateUTF8OnStack', '$withStackSave'],
+  $dlSetError__deps: ['__dl_seterr', '$stringToUTF8OnStack', '$withStackSave'],
   $dlSetError: function(msg) {
 #if DYLINK_DEBUG
     dbg('dlSetError: ' + msg);
 #endif
     withStackSave(function() {
-      var cmsg = allocateUTF8OnStack(msg);
+      var cmsg = stringToUTF8OnStack(msg);
       ___dl_seterr(cmsg, 0);
     });
   },

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2459,7 +2459,7 @@ var LibraryHTML5 = {
   },
 #endif
 
-  $setCanvasElementSize__deps: ['emscripten_set_canvas_element_size', '$withStackSave', '$allocateUTF8OnStack'],
+  $setCanvasElementSize__deps: ['emscripten_set_canvas_element_size', '$withStackSave', '$stringToUTF8OnStack'],
   $setCanvasElementSize: function(target, width, height) {
 #if GL_DEBUG
     dbg('setCanvasElementSize(target='+target+',width='+width+',height='+height);
@@ -2471,7 +2471,7 @@ var LibraryHTML5 = {
       // This function is being called from high-level JavaScript code instead of asm.js/Wasm,
       // and it needs to synchronously proxy over to another thread, so marshal the string onto the heap to do the call.
       withStackSave(function() {
-        var targetInt = allocateUTF8OnStack(target.id);
+        var targetInt = stringToUTF8OnStack(target.id);
         _emscripten_set_canvas_element_size(targetInt, width, height);
       });
     }
@@ -2533,13 +2533,13 @@ var LibraryHTML5 = {
 #endif
 
   // JavaScript-friendly API, returns pair [width, height]
-  $getCanvasElementSize__deps: ['emscripten_get_canvas_element_size', '$withStackSave', '$allocateUTF8OnStack'],
+  $getCanvasElementSize__deps: ['emscripten_get_canvas_element_size', '$withStackSave', '$stringToUTF8OnStack'],
   $getCanvasElementSize: function(target) {
     return withStackSave(function() {
       var w = stackAlloc(8);
       var h = w + 4;
 
-      var targetInt = allocateUTF8OnStack(target.id);
+      var targetInt = stringToUTF8OnStack(target.id);
       var ret = _emscripten_get_canvas_element_size(targetInt, w, h);
       var size = [{{{ makeGetValue('w', 0, 'i32')}}}, {{{ makeGetValue('h', 0, 'i32')}}}];
       return size;

--- a/src/library_legacy.js
+++ b/src/library_legacy.js
@@ -39,4 +39,5 @@ mergeInto(LibraryManager.library, {
   },
 
   $allocateUTF8: '$stringToNewUTF8',
+  $allocateUTF8OnStack: '$stringToUTF8OnStack',
 });

--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -727,13 +727,13 @@ mergeInto(LibraryManager.library, {
    * Passing a NULL callback function to a emscripten_set_socket_*_callback call
    * will deregister the callback registered for that Event.
    */
-  $_setNetworkCallback__deps: ['$withStackSave', '$allocateUTF8OnStack'],
+  $_setNetworkCallback__deps: ['$withStackSave', '$stringToUTF8OnStack'],
   $_setNetworkCallback: function(event, userData, callback) {
     function _callback(data) {
       try {
         if (event === 'error') {
           withStackSave(function() {
-            var msg = allocateUTF8OnStack(data[2]);
+            var msg = stringToUTF8OnStack(data[2]);
             {{{ makeDynCall('viiii', 'callback') }}}(data[0], data[1], msg, userData);
           });
         } else {

--- a/src/library_stack_trace.js
+++ b/src/library_stack_trace.js
@@ -6,7 +6,7 @@
 
 var LibraryStackTrace = {
 #if DEMANGLE_SUPPORT
-  $demangle__deps: ['$withStackSave', '__cxa_demangle', 'free', '$allocateUTF8OnStack'],
+  $demangle__deps: ['$withStackSave', '__cxa_demangle', 'free', '$stringToUTF8OnStack'],
 #endif
   $demangle: function(func) {
 #if DEMANGLE_SUPPORT
@@ -19,7 +19,7 @@ var LibraryStackTrace = {
         var s = func;
         if (s.startsWith('__Z'))
           s = s.substr(1);
-        var buf = allocateUTF8OnStack(s);
+        var buf = stringToUTF8OnStack(s);
         var status = stackAlloc(4);
         var ret = ___cxa_demangle(buf, 0, 0, status);
         if ({{{ makeGetValue('status', '0', 'i32') }}} === 0 && ret) {

--- a/src/library_strings.js
+++ b/src/library_strings.js
@@ -234,7 +234,7 @@ mergeInto(LibraryManager.library, {
   },
 
   // Allocate stack space for a JS string, and write it there.
-  $allocateUTF8OnStack: function(str) {
+  $stringToUTF8OnStack: function(str) {
     var size = lengthBytesUTF8(str) + 1;
     var ret = stackAlloc(size);
     stringToUTF8Array(str, HEAP8, ret, size);

--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -17,7 +17,7 @@ mergeInto(LibraryManager.library, {
     '$asyncLoad',
     '$PATH',
     '$stringToNewUTF8',
-    '$allocateUTF8OnStack',
+    '$stringToUTF8OnStack',
     '$withStackSave',
     '$readI53FromI64',
   ],
@@ -134,7 +134,7 @@ mergeInto(LibraryManager.library, {
     mkdir: (path, mode) => {
       return withStackSave(() => {
         mode = mode !== undefined ? mode : 511 /* 0777 */;
-        var buffer = allocateUTF8OnStack(path);
+        var buffer = stringToUTF8OnStack(path);
         return __wasmfs_mkdir({{{ to64('buffer') }}}, mode);
       });
     },
@@ -145,7 +145,7 @@ mergeInto(LibraryManager.library, {
       flags = typeof flags == 'string' ? FS.modeStringToFlags(flags) : flags;
       mode = typeof mode == 'undefined' ? 438 /* 0666 */ : mode;
       return withStackSave(() => {
-        var buffer = allocateUTF8OnStack(path);
+        var buffer = stringToUTF8OnStack(path);
         return __wasmfs_open({{{ to64('buffer') }}}, flags, mode);
       })
     },
@@ -153,13 +153,13 @@ mergeInto(LibraryManager.library, {
     // TODO: close
     unlink: (path) => {
       return withStackSave(() => {
-        var buffer = allocateUTF8OnStack(path);
+        var buffer = stringToUTF8OnStack(path);
         return __wasmfs_unlink(buffer);
       });
     },
     chdir: (path) => {
       return withStackSave(() => {
-        var buffer = allocateUTF8OnStack(path);
+        var buffer = stringToUTF8OnStack(path);
         return __wasmfs_chdir(buffer);
       });
     },
@@ -171,7 +171,7 @@ mergeInto(LibraryManager.library, {
     // TODO: munmap
     writeFile: (path, data) => {
       return withStackSave(() => {
-        var pathBuffer = allocateUTF8OnStack(path);
+        var pathBuffer = stringToUTF8OnStack(path);
         if (typeof data == 'string') {
           var buf = new Uint8Array(lengthBytesUTF8(data) + 1);
           var actualNumBytes = stringToUTF8Array(data, buf, 0, buf.length);
@@ -191,8 +191,8 @@ mergeInto(LibraryManager.library, {
     },
     symlink: (target, linkpath) => {
       return withStackSave(() => {
-        var targetBuffer = allocateUTF8OnStack(target);
-        var linkpathBuffer = allocateUTF8OnStack(linkpath);
+        var targetBuffer = stringToUTF8OnStack(target);
+        var linkpathBuffer = stringToUTF8OnStack(linkpath);
         return __wasmfs_symlink(targetBuffer, linkpathBuffer);
       });
     },
@@ -201,7 +201,7 @@ mergeInto(LibraryManager.library, {
     // TODO: lstat
     chmod: (path, mode) => {
       return withStackSave(() => {
-        var buffer = allocateUTF8OnStack(path);
+        var buffer = stringToUTF8OnStack(path);
         return __wasmfs_chmod(buffer, mode);
       });
     },
@@ -225,7 +225,7 @@ mergeInto(LibraryManager.library, {
     },
     readdir: (path) => {
       return withStackSave(() => {
-        var pathBuffer = allocateUTF8OnStack(path);
+        var pathBuffer = stringToUTF8OnStack(path);
         var entries = [];
         var state = __wasmfs_readdir_start(pathBuffer);
         if (!state) {

--- a/src/library_wasmfs_node.js
+++ b/src/library_wasmfs_node.js
@@ -62,7 +62,7 @@ mergeInto(LibraryManager.library, {
     }
     entries.forEach((entry) => {
       withStackSave(() => {
-        let name = allocateUTF8OnStack(entry.name);
+        let name = stringToUTF8OnStack(entry.name);
         let type;
         // TODO: Figure out how to use `cDefine` here.
         if (entry.isFile()) {

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -100,7 +100,7 @@ mergeInto(LibraryManager.library, {
       for (let entry; entry = await iter.next(), !entry.done;) {
         let [name, child] = entry.value;
         withStackSave(() => {
-          let namePtr = allocateUTF8OnStack(name);
+          let namePtr = stringToUTF8OnStack(name);
           let type = child.kind == "file" ?
               {{{ cDefine('File::DataFileKind') }}} :
           {{{ cDefine('File::DirectoryKind') }}};

--- a/src/library_wget.js
+++ b/src/library_wget.js
@@ -16,7 +16,7 @@ var LibraryWget = {
     },
   },
 
-  emscripten_async_wget__deps: ['$PATH_FS', '$wget', '$callUserCallback', '$Browser', '$withStackSave', '$allocateUTF8OnStack'],
+  emscripten_async_wget__deps: ['$PATH_FS', '$wget', '$callUserCallback', '$Browser', '$withStackSave', '$stringToUTF8OnStack'],
   emscripten_async_wget__proxy: 'sync',
   emscripten_async_wget: function(url, file, onload, onerror) {
     {{{ runtimeKeepalivePush() }}}
@@ -29,7 +29,7 @@ var LibraryWget = {
         {{{ runtimeKeepalivePop() }}}
         callUserCallback(function() {
           withStackSave(function() {
-            {{{ makeDynCall('vi', 'callback') }}}(allocateUTF8OnStack(_file));
+            {{{ makeDynCall('vi', 'callback') }}}(stringToUTF8OnStack(_file));
           });
         });
       }
@@ -80,7 +80,7 @@ var LibraryWget = {
     }, true /* no need for run dependency, this is async but will not do any prepare etc. step */ );
   },
 
-  emscripten_async_wget2__deps: ['$PATH_FS', '$wget', '$withStackSave', '$allocateUTF8OnStack'],
+  emscripten_async_wget2__deps: ['$PATH_FS', '$wget', '$withStackSave', '$stringToUTF8OnStack'],
   emscripten_async_wget2__proxy: 'sync',
   emscripten_async_wget2: function(url, file, request, param, arg, onload, onerror, onprogress) {
     {{{ runtimeKeepalivePush() }}}
@@ -114,7 +114,7 @@ var LibraryWget = {
         FS.createDataFile( _file.substr(0, index), _file.substr(index + 1), new Uint8Array(/** @type{ArrayBuffer}*/(http.response)), true, true, false);
         if (onload) {
           withStackSave(function() {
-            {{{ makeDynCall('viii', 'onload') }}}(handle, arg, allocateUTF8OnStack(_file));
+            {{{ makeDynCall('viii', 'onload') }}}(handle, arg, stringToUTF8OnStack(_file));
           });
         }
       } else {
@@ -176,7 +176,7 @@ var LibraryWget = {
         withStackSave(() => {
           var statusText = 0;
           if (http.statusText) {
-            statusText = allocateUTF8OnStack(http.statusText);
+            statusText = stringToUTF8OnStack(http.statusText);
           }
           {{{ makeDynCall('viiii', 'onerror') }}}(handle, arg, http.status, statusText);
         });

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -54,7 +54,7 @@ function callMain() {
   var argv = stackAlloc((argc + 1) * {{{ POINTER_SIZE }}});
   var argv_ptr = argv >> {{{ POINTER_SHIFT }}};
   args.forEach((arg) => {
-    {{{ POINTER_HEAP }}}[argv_ptr++] = {{{ to64('allocateUTF8OnStack(arg)') }}};
+    {{{ POINTER_HEAP }}}[argv_ptr++] = {{{ to64('stringToUTF8OnStack(arg)') }}};
   });
   {{{ POINTER_HEAP }}}[argv_ptr] = {{{ to64('0') }}};
 #else

--- a/test/core/test_asan_js_stack_op.c
+++ b/test/core/test_asan_js_stack_op.c
@@ -5,10 +5,10 @@ EMSCRIPTEN_KEEPALIVE void c_func(char *str) {
   printf("%s\n", str);
 }
 
-EM_JS_DEPS(js_func, "$allocateUTF8OnStack");
+EM_JS_DEPS(js_func, "$stringToUTF8OnStack");
 
 EM_JS(void, js_func, (void), {
-  _c_func(allocateUTF8OnStack('Hello, World!'));
+  _c_func(stringToUTF8OnStack('Hello, World!'));
 });
 
 int main(void) {

--- a/test/stack_overflow.cpp
+++ b/test/stack_overflow.cpp
@@ -9,7 +9,7 @@
 #include <emscripten/em_asm.h>
 #include <emscripten/em_macros.h>
 
-EM_JS_DEPS(main, "$allocateUTF8OnStack");
+EM_JS_DEPS(main, "$stringToUTF8OnStack");
 
 void __attribute__((noinline)) InteropString(char *staticBuffer) {
   char *string = (char*)EM_ASM_PTR({
@@ -19,11 +19,11 @@ void __attribute__((noinline)) InteropString(char *staticBuffer) {
     for (var i = 0; i < 15; ++i) {
       str = str + str;
     }
-    allocateUTF8OnStack(str);
+    stringToUTF8OnStack(str);
 #else
     // allocate as many times as we need to overflow
     for (var i = 0; i < 1024 * 1024; i++) {
-      allocateUTF8OnStack(str);
+      stringToUTF8OnStack(str);
     }
     abort("we should never get here!");
 #endif

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13117,7 +13117,7 @@ j1: 8589934599, j2: 30064771074, j3: 12884901891
     create_file('f1.c', '''
     #include <emscripten.h>
 
-    EM_JS_DEPS(other, "$allocateUTF8OnStack");
+    EM_JS_DEPS(other, "$stringToUTF8OnStack");
     ''')
     create_file('f2.c', '''
     #include <emscripten.h>
@@ -13128,7 +13128,7 @@ j1: 8589934599, j2: 30064771074, j3: 12884901891
       EM_ASM({
         err(getHeapMax());
         var x = stackSave();
-        allocateUTF8OnStack("hello");
+        stringToUTF8OnStack("hello");
         stackRestore(x);
       });
       return 0;


### PR DESCRIPTION
The old name is still available as an alias in library_legacy.js.

Followup to #19089