### PR TITLE
Add a new way to mark async imports in library files.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -553,7 +553,7 @@ def get_js_sym_info():
   # it's normally for these file to get pruned as part of normal operation.  This means that it
   # can be deleted between the `cache.get()` then the `read_file`.
   with filelock.FileLock(cache.get_path(cache.get_path('symbol_lists.lock'))):
-    filename = cache.get(f'symbol_lists/{content_hash}.txt', build_symbol_list)
+    filename = cache.get(f'symbol_lists/{content_hash}.json', build_symbol_list)
     library_syms = json.loads(read_file(filename))
 
     # Limit of the overall size of the cache to 100 files.

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -74,7 +74,7 @@ if (symbolsOnly) {
 }
 
 // Side modules are pure wasm and have no JS
-assert(!SIDE_MODULE, 'JS compiler should not run on side modules');
+assert(!SIDE_MODULE || (ASYNCIFY && global.symbolsOnly), 'JS compiler should only run on side modules if asyncify is used.');
 
 // Output some info and warnings based on settings
 

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -40,7 +40,8 @@ mergeInto(LibraryManager.library, {
           var original = imports[x];
           var sig = original.sig;
           if (typeof original == 'function') {
-            var isAsyncifyImport = ASYNCIFY_IMPORTS.indexOf(x) >= 0 ||
+            var isAsyncifyImport = original.isAsync ||
+                                   ASYNCIFY_IMPORTS.indexOf(x) >= 0 ||
                                    x.startsWith('__asyncjs__');
 #if ASYNCIFY == 2
             // Wrap async imports with a suspending WebAssembly function.
@@ -451,6 +452,7 @@ mergeInto(LibraryManager.library, {
   },
 
   emscripten_sleep__deps: ['$safeSetTimeout'],
+  emscripten_sleep__async: true,
   emscripten_sleep: function(ms) {
     // emscripten_sleep() does not return a value, but we still need a |return|
     // here for stack switching support (ASYNCIFY=2). In that mode this function

--- a/src/utility.js
+++ b/src/utility.js
@@ -182,6 +182,7 @@ function isJsLibraryConfigIdentifier(ident) {
     '__noleakcheck',
     '__internal',
     '__user',
+    '__async',
   ];
   return suffixes.some((suffix) => ident.endsWith(suffix));
 }

--- a/tools/gen_sig_info.py
+++ b/tools/gen_sig_info.py
@@ -248,7 +248,7 @@ def extract_sig_info(sig_info, extra_settings=None, extra_cflags=None):
     output = shared.run_js_tool(utils.path_from_root('src/compiler.js'),
                                 ['--symbols-only', settings_json],
                                 stdout=subprocess.PIPE, cwd=utils.path_from_root())
-  symbols = json.loads(output).keys()
+  symbols = json.loads(output)['deps'].keys()
   symbols = [s for s in symbols if not ignore_symbol(s)]
   with tempfiles.get_file('.c') as c_file:
     create_c_file(c_file, symbols)


### PR DESCRIPTION
Allow library functions to be asyncify'd with either an `async` function or adding `$name_async`.

This is a minimal example, I filed #19090 as a follow up to move more to use this style.