### PR TITLE
Support multiple arguments for dbg().

### DIFF
--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -128,13 +128,12 @@ function prettyPrint(arg) {
 
 #if ASSERTIONS || RUNTIME_DEBUG
 // Used by XXXXX_DEBUG settings to output debug messages.
-function dbg(text) {
+function dbg() {
 #if ENVIRONMENT_MAY_BE_NODE && PTHREADS
   // Avoid using the console for debugging in multi-threaded node applications
   // See https://github.com/emscripten-core/emscripten/issues/14804
   if (ENVIRONMENT_IS_NODE) {
-    let output = arguments.length === 1 ? text : Array.from(arguments).join(' ');
-    fs.writeSync(2, output + '\n');
+    fs.writeSync(2, Array.from(arguments).join(' ') + '\n');
   } else
 #endif
   // TODO(sbc): Make this configurable somehow.  Its not always convenient for

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -128,7 +128,7 @@ function prettyPrint(arg) {
 
 #if ASSERTIONS || RUNTIME_DEBUG
 // Used by XXXXX_DEBUG settings to output debug messages.
-function dbg() {
+function dbg(text) {
 #if ENVIRONMENT_MAY_BE_NODE && PTHREADS
   // Avoid using the console for debugging in multi-threaded node applications
   // See https://github.com/emscripten-core/emscripten/issues/14804

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -133,11 +133,12 @@ function dbg(text) {
   // Avoid using the console for debugging in multi-threaded node applications
   // See https://github.com/emscripten-core/emscripten/issues/14804
   if (ENVIRONMENT_IS_NODE) {
-    fs.writeSync(2, text + '\n');
+    let output = arguments.length === 1 ? text : Array.from(arguments).join(' ');
+    fs.writeSync(2, output + '\n');
   } else
 #endif
   // TODO(sbc): Make this configurable somehow.  Its not always convenient for
   // logging to show up as errors.
-  console.error(text);
+  console.error.apply(console, arguments);
 }
 #endif

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11786,7 +11786,7 @@ exec "$@"
     if jspi:
       self.require_v8()
       self.v8_args.append('--experimental-wasm-stack-switching')
-      self.emcc_args += ['-g', '-sASYNCIFY_DEBUG', '-sASYNCIFY=2', '-sASYNCIFY_EXPORTS=[\'say_hello\']']
+      self.emcc_args += ['-g', '-sASYNCIFY=2', '-sASYNCIFY_EXPORTS=[\'say_hello\']']
     self.emcc_args += ['-sEXPORTED_FUNCTIONS=_malloc,_free']
     output = self.do_other_test('test_split_module.c')
     if jspi:


### PR DESCRIPTION
This seems to be already be used with multiple arguments and the debug output was getting cut off.