### PR TITLE
Acorn optimizer: Fix a crash on a direct call in isExportWrapperFunction

### DIFF
--- a/test/optimizer/emitDCEGraph.js
+++ b/test/optimizer/emitDCEGraph.js
@@ -110,3 +110,7 @@ dynCall('vii', ptr, [2, 3]); // use indirectly, depending on analysis of dynCall
   x++;
 });
 
+// Don't crash on this code pattern, which we should ignore.
+var _bad = function() {
+  return something();
+};

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -601,7 +601,9 @@ function isExportWrapperFunction(f) {
   const expr = f.body.body[0];
   if (expr.type == 'ReturnStatement') {
     const rtn = expr.argument;
-    if (rtn.type == 'CallExpression') {
+    // We are looking for a call of special target, like (x = y)(), and not a
+    // non-call or a normal direct call such as z().
+    if (rtn.type == 'CallExpression' && rtn.callee.object) {
       let target = rtn.callee.object;
       if (target.type == 'ParenthesizedExpression') {
         target = target.expression;


### PR DESCRIPTION
We assumed that a call in there is of a special expression, but it could also
be just a call to an identifier, a normal call like `z()`. We just need to ignore
that and not crash.

Fixes #19052