### PR TITLE
Fix test_closure_full_js_library

### DIFF
--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -1021,6 +1021,8 @@ var LibraryWebGL2 = {
     GLctx['vertexAttribIPointer'](index, size, type, stride, ptr);
   },
 
+#if !LEGACY_GL_EMULATION
+  // Defined in library_glemu.js when LEGACY_GL_EMULATION is set
   glDrawRangeElements__sig: 'viiiiii',
   glDrawRangeElements__deps: ['glDrawElements'],
   glDrawRangeElements: function(mode, start, end, count, type, indices) {
@@ -1030,6 +1032,7 @@ var LibraryWebGL2 = {
     // we work around by ignoring the range.
     _glDrawElements(mode, count, type, indices);
   },
+#endif
 
   glDrawArraysInstancedBaseInstanceWEBGL__sig: 'viiiii',
   glDrawArraysInstancedBaseInstanceWEBGL: function(mode, first, count, instanceCount, baseInstance) {


### PR DESCRIPTION
This test was updated in #19046, but went through CI before #19067 landed which made duplicate signatures into a warning.

`glDrawRangeElements` is defined both in `library_glemu.js` and in `library_webgl2.js` with the former taking precedence because it is included later.  This change avoid the duplicate definition.