### PR TITLE
Use `dbg` over `err` for syscall debugging. NFC

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -297,7 +297,6 @@ var SyscallsLibrary = {
   },
   __syscall_getsockname__deps: ['$getSocketFromFD', '$writeSockaddr', '$DNS'],
   __syscall_getsockname: function(fd, addr, addrlen, d1, d2, d3) {
-    err("__syscall_getsockname " + fd);
     var sock = getSocketFromFD(fd);
     // TODO: sock.saddr should never be undefined, see TODO in websocket_sock_ops.getname
     var errno = writeSockaddr(addr, sock.family, DNS.lookup_name(sock.saddr || '0.0.0.0'), sock.sport, addrlen);

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -383,7 +383,7 @@ var WasiLibrary = {
 
   $wasiRightsToMuslOFlags: function(rights) {
 #if SYSCALL_DEBUG
-    err('wasiRightsToMuslOFlags: ' + rights);
+    dbg('wasiRightsToMuslOFlags: ' + rights);
 #endif
     if ((rights & {{{ cDefs.__WASI_RIGHTS_FD_READ }}}) && (rights & {{{ cDefs.__WASI_RIGHTS_FD_WRITE }}})) {
       return {{{ cDefs.O_RDWR }}};
@@ -431,11 +431,11 @@ var WasiLibrary = {
     var pathname = UTF8ToString(path, path_len);
     var musl_oflags = wasiRightsToMuslOFlags(Number(fs_rights_base));
 #if SYSCALL_DEBUG
-    err("oflags1: 0x" + musl_oflags.toString(16));
+    dbg("oflags1: 0x" + musl_oflags.toString(16));
 #endif
     musl_oflags |= wasiOFlagsToMuslOFlags(Number(oflags));
 #if SYSCALL_DEBUG
-    err("oflags2: 0x" + musl_oflags.toString(16));
+    dbg("oflags2: 0x" + musl_oflags.toString(16));
 #endif
     var stream = FS.open(pathname, musl_oflags);
     {{{ makeSetValue('opened_fd', '0', 'stream.fd', 'i32') }}};


### PR DESCRIPTION
Also, remove stray `err` logging from #13272.