### PR TITLE
Fix wasi_path_open and add assertion to stringToUTF8

### DIFF
--- a/src/library_strings.js
+++ b/src/library_strings.js
@@ -157,6 +157,9 @@ mergeInto(LibraryManager.library, {
 #if CAN_ADDRESS_2GB
     outIdx >>>= 0;
 #endif
+#if ASSERTIONS
+    assert(typeof str === 'string');
+#endif
     // Parameter maxBytesToWrite is not optional. Negative values, 0, null,
     // undefined and false each don't write out any bytes.
     if (!(maxBytesToWrite > 0))

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -449,8 +449,11 @@ var WasiLibrary = {
     if (!(fd in preopens)) {
       return {{{ cDefs.EBADF }}};
     }
-    var preopen = preopens[fd];
-    stringToUTF8Array(preopens, HEAP8, path, path_len)
+    var preopen_path = preopens[fd];
+    stringToUTF8Array(preopen_path, HEAP8, path, path_len)
+#if SYSCALL_DEBUG
+    dbg('fd_prestat_dir_name -> "' + preopen_path + '"');
+#endif
     return 0;
   },
 

--- a/system/lib/compiler-rt/lib/asan/asan_flags.cpp
+++ b/system/lib/compiler-rt/lib/asan/asan_flags.cpp
@@ -132,7 +132,7 @@ void InitializeFlags() {
 #define MAKE_OPTION_LOAD(parser, name) \
     options = (char*)(long)EM_ASM_DOUBLE({ \
       return withBuiltinMalloc(function () { \
-        return stringToNewUTF8(Module[name] || 0); \
+        return stringToNewUTF8(Module[name] || ""); \
       }); \
     }); \
     parser.ParseString(options); \

--- a/system/lib/compiler-rt/lib/lsan/lsan.cpp
+++ b/system/lib/compiler-rt/lib/lsan/lsan.cpp
@@ -84,7 +84,7 @@ static void InitializeFlags() {
 #if SANITIZER_EMSCRIPTEN
   char *options = (char*) EM_ASM_PTR({
     return withBuiltinMalloc(function () {
-      return stringToNewUTF8(Module['LSAN_OPTIONS'] || 0);
+      return stringToNewUTF8(Module['LSAN_OPTIONS'] || "");
     });
   });
   parser.ParseString(options);

--- a/system/lib/compiler-rt/lib/ubsan/ubsan_flags.cpp
+++ b/system/lib/compiler-rt/lib/ubsan/ubsan_flags.cpp
@@ -79,7 +79,7 @@ void InitializeFlags() {
 #if SANITIZER_EMSCRIPTEN
   char *options = (char*) EM_ASM_PTR({
     return withBuiltinMalloc(function () {
-      return stringToNewUTF8(Module['UBSAN_OPTIONS'] || 0);
+      return stringToNewUTF8(Module['UBSAN_OPTIONS'] || "");
     });
   });
   parser.ParseString(options);


### PR DESCRIPTION
There were a few places where we were passing 0 instead of a string to `stringToUTF8`.