### PR TITLE
Move proxying change to correct location in ChangeLog.md

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -83,6 +83,9 @@ See docs/process.md for more on how version tagging works.
 - The WasmFS OPFS backend is now faster in browsers that implement
   [`Atomics.waitAsync`](https://caniuse.com/mdn-javascript_builtins_atomics_waitasync).
   (#18861)
+- The `emscripten_proxy_async_with_callback` API was replaced with a simpler
+  `emscripten_proxy_callback` API that takes a second callback to be called if
+  the worker thread dies before completing the proxied work.  
 
 3.1.32 - 02/17/23
 -----------------
@@ -101,9 +104,6 @@ See docs/process.md for more on how version tagging works.
 - Synchronous proxying functions in emscripten/proxying.h now return errors
   instead of hanging forever when the worker thread dies before the proxied work
   is finished.
-- The `emscripten_proxy_async_with_callback` API was replaced with a simpler
-  `emscripten_proxy_callback` API that takes a second callback to be called if
-  the worker thread dies before completing the proxied work.
 
 3.1.31 - 01/26/23
 -----------------


### PR DESCRIPTION
PR #18776 updated the changelog for 3.1.32, but it should have updated the changelog for 3.1.33, which was in development at the time.