### PR TITLE
[GLFW] Add missing checks before GLFW callbacks

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -370,7 +370,6 @@ var LibraryGLFW = {
 #if USE_GLFW == 2
       {{{ makeDynCall('vii', 'GLFW.active.charFunc') }}}(charCode, 1);
 #endif
-
 #if USE_GLFW == 3
       {{{ makeDynCall('vii', 'GLFW.active.charFunc') }}}(GLFW.active.id, charCode);
 #endif
@@ -387,16 +386,16 @@ var LibraryGLFW = {
 #endif
       GLFW.active.keys[key] = status;
       GLFW.active.domKeys[keyCode] = status;
-      if (!GLFW.active.keyFunc) return;
 
+      if (GLFW.active.keyFunc) {
 #if USE_GLFW == 2
-      {{{ makeDynCall('vii', 'GLFW.active.keyFunc') }}}(key, status);
+        {{{ makeDynCall('vii', 'GLFW.active.keyFunc') }}}(key, status);
 #endif
-
 #if USE_GLFW == 3
-      if (repeat) status = 2; // GLFW_REPEAT
-      {{{ makeDynCall('viiiii', 'GLFW.active.keyFunc') }}}(GLFW.active.id, key, keyCode, status, GLFW.getModBits(GLFW.active));
+        if (repeat) status = 2; // GLFW_REPEAT
+        {{{ makeDynCall('viiiii', 'GLFW.active.keyFunc') }}}(GLFW.active.id, key, keyCode, status, GLFW.getModBits(GLFW.active));
 #endif
+      }
     },
 
     onGamepadConnected: function(event) {
@@ -439,13 +438,14 @@ var LibraryGLFW = {
 
       if (event.target != Module["canvas"] || !GLFW.active.cursorPosFunc) return;
 
+      if (GLFW.active.cursorPosFunc) {
 #if USE_GLFW == 2
-      {{{ makeDynCall('vii', 'GLFW.active.cursorPosFunc') }}}(Browser.mouseX, Browser.mouseY);
+        {{{ makeDynCall('vii', 'GLFW.active.cursorPosFunc') }}}(Browser.mouseX, Browser.mouseY);
 #endif
-
 #if USE_GLFW == 3
-      {{{ makeDynCall('vidd', 'GLFW.active.cursorPosFunc') }}}(GLFW.active.id, Browser.mouseX, Browser.mouseY);
+        {{{ makeDynCall('vidd', 'GLFW.active.cursorPosFunc') }}}(GLFW.active.id, Browser.mouseX, Browser.mouseY);
 #endif
+      }
     },
 
     DOMToGLFWMouseButton: function(event) {
@@ -467,9 +467,11 @@ var LibraryGLFW = {
 
       if (event.target != Module["canvas"] || !GLFW.active.cursorEnterFunc) return;
 
+      if (GLFW.active.cursorEnterFunc) {
 #if USE_GLFW == 3
-      {{{ makeDynCall('vii', 'GLFW.active.cursorEnterFunc') }}}(GLFW.active.id, 1);
+        {{{ makeDynCall('vii', 'GLFW.active.cursorEnterFunc') }}}(GLFW.active.id, 1);
 #endif
+      }
     },
 
     onMouseleave: function(event) {
@@ -477,9 +479,11 @@ var LibraryGLFW = {
 
       if (event.target != Module["canvas"] || !GLFW.active.cursorEnterFunc) return;
 
+      if (GLFW.active.cursorEnterFunc) {
 #if USE_GLFW == 3
-      {{{ makeDynCall('vii', 'GLFW.active.cursorEnterFunc') }}}(GLFW.active.id, 0);
+        {{{ makeDynCall('vii', 'GLFW.active.cursorEnterFunc') }}}(GLFW.active.id, 0);
 #endif
+      }
     },
 
     onMouseButtonChanged: function(event, status) {
@@ -500,15 +504,14 @@ var LibraryGLFW = {
         GLFW.active.buttons &= ~(1 << eventButton);
       }
 
-      if (!GLFW.active.mouseButtonFunc) return;
-
+      if (GLFW.active.mouseButtonFunc) {
 #if USE_GLFW == 2
-      {{{ makeDynCall('vii', 'GLFW.active.mouseButtonFunc') }}}(eventButton, status);
+        {{{ makeDynCall('vii', 'GLFW.active.mouseButtonFunc') }}}(eventButton, status);
 #endif
-
 #if USE_GLFW == 3
-      {{{ makeDynCall('viiii', 'GLFW.active.mouseButtonFunc') }}}(GLFW.active.id, eventButton, status, GLFW.getModBits(GLFW.active));
+        {{{ makeDynCall('viiii', 'GLFW.active.mouseButtonFunc') }}}(GLFW.active.id, eventButton, status, GLFW.getModBits(GLFW.active));
 #endif
+      }
     },
 
     onMouseButtonDown: function(event) {
@@ -528,11 +531,9 @@ var LibraryGLFW = {
       GLFW.wheelPos += delta;
 
       if (!GLFW.active || !GLFW.active.scrollFunc || event.target != Module['canvas']) return;
-
 #if USE_GLFW == 2
       {{{ makeDynCall('vi', 'GLFW.active.scrollFunc') }}}(GLFW.wheelPos);
 #endif
-
 #if USE_GLFW == 3
       var sx = 0;
       var sy = delta;
@@ -594,30 +595,29 @@ var LibraryGLFW = {
     onWindowSizeChanged: function() {
       if (!GLFW.active) return;
 
-      if (!GLFW.active.windowSizeFunc) return;
-
+      if (GLFW.active.windowSizeFunc) {
 #if USE_GLFW == 2
-      {{{ makeDynCall('vii', 'GLFW.active.windowSizeFunc') }}}(GLFW.active.width, GLFW.active.height);
+        {{{ makeDynCall('vii', 'GLFW.active.windowSizeFunc') }}}(GLFW.active.width, GLFW.active.height);
 #endif
-
 #if USE_GLFW == 3
-      {{{ makeDynCall('viii', 'GLFW.active.windowSizeFunc') }}}(GLFW.active.id, GLFW.active.width, GLFW.active.height);
+        {{{ makeDynCall('viii', 'GLFW.active.windowSizeFunc') }}}(GLFW.active.id, GLFW.active.width, GLFW.active.height);
 #endif
+      }
     },
 
     onFramebufferSizeChanged: function() {
       if (!GLFW.active) return;
 
-      if (!GLFW.active.framebufferSizeFunc) return;
-
+      if (!GLFW.active.framebufferSizeFunc) {
 #if USE_GLFW == 3
-      {{{ makeDynCall('viii', 'GLFW.active.framebufferSizeFunc') }}}(GLFW.active.id, GLFW.active.width, GLFW.active.height);
+        {{{ makeDynCall('viii', 'GLFW.active.framebufferSizeFunc') }}}(GLFW.active.id, GLFW.active.width, GLFW.active.height);
 #endif
+      }
     },
 
     onWindowContentScaleChanged: function(scale) {
       GLFW.scale = scale;
-      if (!GLFW.active) return;
+      if (!GLFW.active || !GLFW.active.windowContentScaleFunc) return;
 
 #if USE_GLFW == 3
       {{{ makeDynCall('viff', 'GLFW.active.windowContentScaleFunc') }}}(GLFW.active.id, GLFW.scale, GLFW.scale);
@@ -988,15 +988,14 @@ var LibraryGLFW = {
         }
       }
 
-      if (!win.windowSizeFunc) return;
-
+      if (win.windowSizeFunc) {
 #if USE_GLFW == 2
-      {{{ makeDynCall('vii', 'win.windowSizeFunc') }}}(width, height);
+        {{{ makeDynCall('vii', 'win.windowSizeFunc') }}}(width, height);
 #endif
-
 #if USE_GLFW == 3
-      {{{ makeDynCall('viii', 'win.windowSizeFunc') }}}(win.id, width, height);
+        {{{ makeDynCall('viii', 'win.windowSizeFunc') }}}(win.id, width, height);
 #endif
+      }
     },
 
     createWindow: function(width, height, title, monitor, share) {
@@ -1063,8 +1062,9 @@ var LibraryGLFW = {
       if (!win) return;
 
 #if USE_GLFW == 3
-      if (win.windowCloseFunc)
+      if (win.windowCloseFunc) {
         {{{ makeDynCall('vi', 'win.windowCloseFunc') }}}(win.id);
+      }
 #endif
 
       GLFW.windows[win.id - 1] = null;

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -465,7 +465,7 @@ var LibraryGLFW = {
     onMouseenter: function(event) {
       if (!GLFW.active) return;
 
-      if (event.target != Module["canvas"] || !GLFW.active.cursorEnterFunc) return;
+      if (event.target != Module["canvas"]) return;
 
       if (GLFW.active.cursorEnterFunc) {
 #if USE_GLFW == 3
@@ -477,7 +477,7 @@ var LibraryGLFW = {
     onMouseleave: function(event) {
       if (!GLFW.active) return;
 
-      if (event.target != Module["canvas"] || !GLFW.active.cursorEnterFunc) return;
+      if (event.target != Module["canvas"]) return;
 
       if (GLFW.active.cursorEnterFunc) {
 #if USE_GLFW == 3

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -467,11 +467,11 @@ var LibraryGLFW = {
 
       if (event.target != Module["canvas"]) return;
 
-      if (GLFW.active.cursorEnterFunc) {
 #if USE_GLFW == 3
+      if (GLFW.active.cursorEnterFunc) {
         {{{ makeDynCall('vii', 'GLFW.active.cursorEnterFunc') }}}(GLFW.active.id, 1);
-#endif
       }
+#endif
     },
 
     onMouseleave: function(event) {
@@ -479,11 +479,11 @@ var LibraryGLFW = {
 
       if (event.target != Module["canvas"]) return;
 
-      if (GLFW.active.cursorEnterFunc) {
 #if USE_GLFW == 3
+      if (GLFW.active.cursorEnterFunc) {
         {{{ makeDynCall('vii', 'GLFW.active.cursorEnterFunc') }}}(GLFW.active.id, 0);
-#endif
       }
+#endif
     },
 
     onMouseButtonChanged: function(event, status) {
@@ -608,22 +608,22 @@ var LibraryGLFW = {
     onFramebufferSizeChanged: function() {
       if (!GLFW.active) return;
 
-      if (GLFW.active.framebufferSizeFunc) {
 #if USE_GLFW == 3
+      if (GLFW.active.framebufferSizeFunc) {
         {{{ makeDynCall('viii', 'GLFW.active.framebufferSizeFunc') }}}(GLFW.active.id, GLFW.active.width, GLFW.active.height);
-#endif
       }
+#endif
     },
 
     onWindowContentScaleChanged: function(scale) {
       GLFW.scale = scale;
       if (!GLFW.active) return;
 
-      if (GLFW.active.windowContentScaleFunc) {
 #if USE_GLFW == 3
+      if (GLFW.active.windowContentScaleFunc) {
         {{{ makeDynCall('viff', 'GLFW.active.windowContentScaleFunc') }}}(GLFW.active.id, GLFW.scale, GLFW.scale);
-#endif
       }
+#endif
     },
 
     getTime: function() {

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -617,11 +617,13 @@ var LibraryGLFW = {
 
     onWindowContentScaleChanged: function(scale) {
       GLFW.scale = scale;
-      if (!GLFW.active || !GLFW.active.windowContentScaleFunc) return;
+      if (!GLFW.active) return;
 
+      if (GLFW.active.windowContentScaleFunc) {
 #if USE_GLFW == 3
-      {{{ makeDynCall('viff', 'GLFW.active.windowContentScaleFunc') }}}(GLFW.active.id, GLFW.scale, GLFW.scale);
+        {{{ makeDynCall('viff', 'GLFW.active.windowContentScaleFunc') }}}(GLFW.active.id, GLFW.scale, GLFW.scale);
 #endif
+      }
     },
 
     getTime: function() {

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -608,7 +608,7 @@ var LibraryGLFW = {
     onFramebufferSizeChanged: function() {
       if (!GLFW.active) return;
 
-      if (!GLFW.active.framebufferSizeFunc) {
+      if (GLFW.active.framebufferSizeFunc) {
 #if USE_GLFW == 3
         {{{ makeDynCall('viii', 'GLFW.active.framebufferSizeFunc') }}}(GLFW.active.id, GLFW.active.width, GLFW.active.height);
 #endif


### PR DESCRIPTION
Also convert them all to `if (..) { .. }` notation (diff without whitespace is
smaller). A few were left in the old format if the code benefited from
that due to other reasons in the surrounding logic.

Fixes #19145 Verified this fixes that manually, but perhaps there's a way
to make an automatic test with events somehow..?