### PR TITLE
Implement `emscripten_promise_all_settled` in promise.h

### DIFF
--- a/src/generated_struct_info32.json
+++ b/src/generated_struct_info32.json
@@ -1330,6 +1330,11 @@
             "table_addr": 20,
             "table_size": 24
         },
+        "em_settled_result_t": {
+            "__size__": 8,
+            "result": 0,
+            "value": 4
+        },
         "emscripten_fetch_attr_t": {
             "__size__": 92,
             "attributes": 52,

--- a/src/generated_struct_info64.json
+++ b/src/generated_struct_info64.json
@@ -1330,6 +1330,11 @@
             "table_addr": 32,
             "table_size": 40
         },
+        "em_settled_result_t": {
+            "__size__": 16,
+            "result": 0,
+            "value": 8
+        },
         "emscripten_fetch_attr_t": {
             "__size__": 152,
             "attributes": 72,

--- a/src/library_promise.js
+++ b/src/library_promise.js
@@ -189,17 +189,17 @@ mergeInto(LibraryManager.library, {
       promise: Promise.allSettled(promises).then((results) => {
         if (resultBuf) {
           for (var i = 0; i < size; i++) {
-            let baseOffset = i * {{{ C_STRUCTS.em_settled_result_t.__size__ }}};
-            let resultOffset =
+            var baseOffset = i * {{{ C_STRUCTS.em_settled_result_t.__size__ }}};
+            var resultOffset =
                 baseOffset + {{{ C_STRUCTS.em_settled_result_t.result }}};
-            let valueOffset =
+            var valueOffset =
                 baseOffset + {{{ C_STRUCTS.em_settled_result_t.value }}};
             if (results[i].status === 'fulfilled') {
-              let fulfill = {{{ cDefs.EM_PROMISE_FULFILL }}};
+              var fulfill = {{{ cDefs.EM_PROMISE_FULFILL }}};
               {{{ makeSetValue('resultBuf', 'resultOffset', 'fulfill', 'i32') }}};
               {{{ makeSetValue('resultBuf', 'valueOffset', 'results[i].value', '*') }}};
             } else {
-              let reject = {{{ cDefs.EM_PROMISE_REJECT }}};
+              var reject = {{{ cDefs.EM_PROMISE_REJECT }}};
               {{{ makeSetValue('resultBuf', 'resultOffset', 'reject', 'i32') }}};
               {{{ makeSetValue('resultBuf', 'valueOffset', 'results[i].reason', '*') }}};
             }

--- a/src/library_promise.js
+++ b/src/library_promise.js
@@ -27,6 +27,16 @@ mergeInto(LibraryManager.library, {
     return promiseInfo;
   },
 
+  $idsToPromises__deps: ['$promiseMap', '$getPromise'],
+  $idsToPromises: function(idBuf, size) {
+    var promises = [];
+    for (var i = 0; i < size; i++) {
+      var id = {{{ makeGetValue('idBuf', `i*${POINTER_SIZE}`, 'i32') }}};
+      promises[i] = getPromise(id);
+    }
+    return promises;
+  },
+
   emscripten_promise_create__deps: ['$makePromise'],
   emscripten_promise_create: function() {
     return makePromise().id;
@@ -146,13 +156,9 @@ mergeInto(LibraryManager.library, {
     return newId;
   },
 
-  emscripten_promise_all__deps: ['$promiseMap', '$getPromise'],
+  emscripten_promise_all__deps: ['$promiseMap', '$idsToPromises'],
   emscripten_promise_all: function(idBuf, resultBuf, size) {
-    var promises = [];
-    for (var i = 0; i < size; i++) {
-      var id = {{{ makeGetValue('idBuf', `i*${POINTER_SIZE}`, 'i32') }}};
-      promises[i] = getPromise(id);
-    }
+    var promises = idsToPromises(idBuf, size);
 #if RUNTIME_DEBUG
     dbg('emscripten_promise_all: ' + promises);
 #endif
@@ -162,6 +168,41 @@ mergeInto(LibraryManager.library, {
           for (var i = 0; i < size; i++) {
             var result = results[i];
             {{{ makeSetValue('resultBuf', `i*${POINTER_SIZE}`, 'result', '*') }}};
+          }
+        }
+        return resultBuf;
+      })
+    });
+#if RUNTIME_DEBUG
+    dbg('create: ' + id);
+#endif
+    return id;
+  },
+
+  emscripten_promise_all_settled__deps: ['$promiseMap', '$idsToPromises'],
+  emscripten_promise_all_settled: function(idBuf, resultBuf, size) {
+    var promises = idsToPromises(idBuf, size);
+#if RUNTIME_DEBUG
+    dbg('emscripten_promise_all_settled: ' + promises);
+#endif
+    var id = promiseMap.allocate({
+      promise: Promise.allSettled(promises).then((results) => {
+        if (resultBuf) {
+          for (var i = 0; i < size; i++) {
+            let baseOffset = i * {{{ C_STRUCTS.em_settled_result_t.__size__ }}};
+            let resultOffset =
+                baseOffset + {{{ C_STRUCTS.em_settled_result_t.result }}};
+            let valueOffset =
+                baseOffset + {{{ C_STRUCTS.em_settled_result_t.value }}};
+            if (results[i].status === 'fulfilled') {
+              let fulfill = {{{ cDefs.EM_PROMISE_FULFILL }}};
+              {{{ makeSetValue('resultBuf', 'resultOffset', 'fulfill', 'i32') }}};
+              {{{ makeSetValue('resultBuf', 'valueOffset', 'results[i].value', '*') }}};
+            } else {
+              let reject = {{{ cDefs.EM_PROMISE_REJECT }}};
+              {{{ makeSetValue('resultBuf', 'resultOffset', 'reject', 'i32') }}};
+              {{{ makeSetValue('resultBuf', 'valueOffset', 'results[i].reason', '*') }}};
+            }
           }
         }
         return resultBuf;

--- a/src/library_promise.js
+++ b/src/library_promise.js
@@ -201,9 +201,9 @@ mergeInto(LibraryManager.library, {
             } else {
               var reject = {{{ cDefs.EM_PROMISE_REJECT }}};
               {{{ makeSetValue('resultBuf', 'resultOffset', 'reject', 'i32') }}};
-              // Closure can't type `reason` in some contexts
-              /** @suppress {checkTypes} */
-              {{{ makeSetValue('resultBuf', 'valueOffset', 'results[i].reason', '*') }}};
+              // Closure can't type `reason` in some contexts.
+              var reason = /** @type {number} */ (results[i].reason);
+              {{{ makeSetValue('resultBuf', 'valueOffset', 'reason', '*') }}};
             }
           }
         }

--- a/src/library_promise.js
+++ b/src/library_promise.js
@@ -201,6 +201,8 @@ mergeInto(LibraryManager.library, {
             } else {
               var reject = {{{ cDefs.EM_PROMISE_REJECT }}};
               {{{ makeSetValue('resultBuf', 'resultOffset', 'reject', 'i32') }}};
+              // Closure can't type `reason` in some contexts
+              /** @suppress {checkTypes} */
               {{{ makeSetValue('resultBuf', 'valueOffset', 'results[i].reason', '*') }}};
             }
           }

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -534,6 +534,7 @@ sigs = {
   emscripten_performance_now__sig: 'd',
   emscripten_print_double__sig: 'idpi',
   emscripten_promise_all__sig: 'pppp',
+  emscripten_promise_all_settled__sig: 'pppp',
   emscripten_promise_create__sig: 'p',
   emscripten_promise_destroy__sig: 'vp',
   emscripten_promise_resolve__sig: 'vpip',

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -262,7 +262,7 @@
             "O_PATH",
             "O_NONBLOCK",
             "O_CLOEXEC",
-            "F_GETOWN", 
+            "F_GETOWN",
             "F_GETOWN_EX",
             "F_SETFD",
             "O_EXCL",
@@ -1095,7 +1095,13 @@
             "EM_PROMISE_MATCH",
             "EM_PROMISE_MATCH_RELEASE",
             "EM_PROMISE_REJECT"
-        ]
+        ],
+        "structs": {
+            "em_settled_result_t": [
+                "result",
+                "value"
+            ]
+        }
     },
     {
         "file": "AL/al.h",

--- a/system/include/emscripten/promise.h
+++ b/system/include/emscripten/promise.h
@@ -92,17 +92,29 @@ emscripten_promise_then(em_promise_t promise,
                         void* data);
 
 // Call Promise.all to create and return a new promise that is either fulfilled
-// once the `num_promises` input promises in the `promises` have been fulfilled
-// or is rejected once any of the input promises has been rejected. When the
-// returned promise is fulfilled, the values each of the input promises were
-// resolved with will be written to the `results` array and the returned promise
-// will be fulfilled with the address of that array as well.
+// once the `num_promises` input promises passed in `promises` have been
+// fulfilled or is rejected once any of the input promises has been rejected.
+// When the returned promise is fulfilled, the values each of the input promises
+// were resolved with will be written to the `results` array if it is non-null
+// and the returned promise will be fulfilled with the address of that array as
+// well.
 __attribute__((warn_unused_result)) em_promise_t emscripten_promise_all(
   em_promise_t* promises, void** results, size_t num_promises);
 
-// TODO: emscripten_promise_all_settled
-// TODO: emscripten_promise_race
-// TODO: emscripten_promise_any
+typedef struct em_settled_result_t {
+  em_promise_result_t result;
+  void* value;
+} em_settled_result_t;
+
+// Call Promise.allSettled to create and return a new promise that is fulfilled
+// once the `num_promises` input promises passed in `promises` have been
+// settled. When the returned promise is fulfilled, the `results` buffer will be
+// filled with the result comprising of either EM_PROMISE_FULFILL and the
+// fulfilled value or EM_PROMISE_REJECT and the rejection reason for each of the
+// input promises if `results` is non-null. The returned promise will be
+// fulfilled with the value of `results` as well.
+__attribute__((warn_unused_result)) em_promise_t emscripten_promise_all_settled(
+  em_promise_t* promises, em_settled_result_t* results, size_t num_promises);
 
 #ifdef __cplusplus
 }

--- a/test/core/test_promise.out
+++ b/test/core/test_promise.out
@@ -15,4 +15,10 @@ promise_all results:
 1337
 0
 promise_all error: 1337
+test_all_settled
+promise_all_settled results:
+promise_all_settled results:
+fulfill 42
+reject 43
+fulfill 44
 finish


### PR DESCRIPTION
This is like `emscripten_promise_all`, but always fulfills and separately
reports whether each input promise is fulfilled or rejected.