### PR TITLE
Implement `emscripten_promise_any` in promise.h

### DIFF
--- a/src/library_promise.js
+++ b/src/library_promise.js
@@ -222,6 +222,9 @@ mergeInto(LibraryManager.library, {
 #if RUNTIME_DEBUG
     dbg('emscripten_promise_any: ' + promises);
 #endif
+#if ASSERTIONS
+    assert(typeof Promise.any !== 'undefined', "Promise.any does not exist");
+#endif
     var id = promiseMap.allocate({
       promise: Promise.any(promises).catch((err) => {
         if (errorBuf) {

--- a/src/library_promise.js
+++ b/src/library_promise.js
@@ -215,4 +215,26 @@ mergeInto(LibraryManager.library, {
 #endif
     return id;
   },
+
+  emscripten_promise_any__deps: ['$promiseMap', '$idsToPromises'],
+  emscripten_promise_any: function(idBuf, errorBuf, size) {
+    var promises = idsToPromises(idBuf, size);
+#if RUNTIME_DEBUG
+    dbg('emscripten_promise_any: ' + promises);
+#endif
+    var id = promiseMap.allocate({
+      promise: Promise.any(promises).catch((err) => {
+        if (errorBuf) {
+          for (var i = 0; i < size; i++) {
+            {{{ makeSetValue('errorBuf', `i*${POINTER_SIZE}`, 'err.errors[i]', '*') }}};
+          }
+        }
+        throw errorBuf;
+      })
+    });
+#if RUNTIME_DEBUG
+    dbg('create: ' + id);
+#endif
+    return id;
+  }
 });

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -535,6 +535,7 @@ sigs = {
   emscripten_print_double__sig: 'idpi',
   emscripten_promise_all__sig: 'pppp',
   emscripten_promise_all_settled__sig: 'pppp',
+  emscripten_promise_any__sig: 'pppp',
   emscripten_promise_create__sig: 'p',
   emscripten_promise_destroy__sig: 'vp',
   emscripten_promise_resolve__sig: 'vpip',

--- a/system/include/emscripten/promise.h
+++ b/system/include/emscripten/promise.h
@@ -116,6 +116,17 @@ typedef struct em_settled_result_t {
 __attribute__((warn_unused_result)) em_promise_t emscripten_promise_all_settled(
   em_promise_t* promises, em_settled_result_t* results, size_t num_promises);
 
+// Call Promise.any to create and return a new promise that is fulfilled once
+// any of the `num_promises` input promises passed in `promises` has been
+// fulfilled or is rejected once all of the input promises have been rejected.
+// If the returned promise is fulfilled, it will be fulfilled with the same
+// value as the first fulfilled input promise. Otherwise, if the returned
+// promise is rejected, the rejection reasons for each input promise will be
+// written to the `errors` buffer if it is non-null. The rejection reason for
+// the returned promise will also be the address of the `errors` buffer.
+__attribute__((warn_unused_result)) em_promise_t emscripten_promise_any(
+  em_promise_t* promises, void** errors, size_t num_promises);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/core/test_promise.c
+++ b/test/core/test_promise.c
@@ -334,13 +334,131 @@ test_all_settled(void** result, void* data, void* value) {
   emscripten_promise_destroy(null_in[2]);
 
   em_promise_t to_finish[3] = {empty_checked, full_checked, null_checked};
-  em_promise_t finish_test_all = emscripten_promise_all(to_finish, NULL, 3);
+  em_promise_t finish_test_all_settled =
+    emscripten_promise_all(to_finish, NULL, 3);
 
   emscripten_promise_destroy(empty_checked);
   emscripten_promise_destroy(full_checked);
   emscripten_promise_destroy(null_checked);
 
-  *result = finish_test_all;
+  *result = finish_test_all_settled;
+  return EM_PROMISE_MATCH_RELEASE;
+}
+
+typedef struct promise_any_state {
+  size_t size;
+  em_promise_t in[3];
+  void* expected;
+  void* err[3];
+  void* expected_err[3];
+} promise_any_state;
+
+static em_promise_result_t
+check_promise_any_result(void** result, void* data, void* value) {
+  promise_any_state* state = (promise_any_state*)data;
+  emscripten_console_logf("promise_all result: %ld", (uintptr_t)value);
+  assert(value == state->expected);
+  free(state);
+  return EM_PROMISE_FULFILL;
+}
+
+static em_promise_result_t
+check_promise_any_err(void** result, void* data, void* value) {
+  promise_any_state* state = (promise_any_state*)data;
+  assert(value == state->err);
+  emscripten_console_log("promise_all reasons:");
+  for (size_t i = 0; i < state->size; ++i) {
+    emscripten_console_logf("%ld", (uintptr_t)state->err[i]);
+    assert(state->err[i] == state->expected_err[i]);
+  }
+  free(state);
+  return EM_PROMISE_FULFILL;
+}
+
+static em_promise_result_t test_any(void** result, void* data, void* value) {
+  emscripten_console_log("test_any");
+  assert(data == (void*)6);
+
+  // No input should be handled ok and be rejected.
+  promise_any_state* state = malloc(sizeof(promise_any_state));
+  *state = (promise_any_state){
+    .size = 0, .in = {}, .expected = NULL, .err = {}, .expected_err = {}};
+  em_promise_t empty =
+    emscripten_promise_any(state->in, state->err, state->size);
+  em_promise_t empty_checked =
+    emscripten_promise_then(empty, fail, check_promise_any_err, state);
+  emscripten_promise_destroy(empty);
+
+  // The first fulfilled promise should be propagated.
+  state = malloc(sizeof(promise_any_state));
+  *state = (promise_any_state){.size = 3,
+                               .in = {emscripten_promise_create(),
+                                      emscripten_promise_create(),
+                                      emscripten_promise_create()},
+                               .expected = (void*)42,
+                               .err = {},
+                               .expected_err = {}};
+  em_promise_t full =
+    emscripten_promise_any(state->in, state->err, state->size);
+  em_promise_t full_checked =
+    emscripten_promise_then(full, check_promise_any_result, fail, state);
+  emscripten_promise_destroy(full);
+  emscripten_promise_resolve(state->in[0], EM_PROMISE_REJECT, (void*)41);
+  emscripten_promise_resolve(state->in[1], EM_PROMISE_FULFILL, (void*)42);
+  emscripten_promise_resolve(state->in[2], EM_PROMISE_FULFILL, (void*)43);
+  emscripten_promise_destroy(state->in[0]);
+  emscripten_promise_destroy(state->in[1]);
+  emscripten_promise_destroy(state->in[2]);
+
+  // If all promises are rejected, the result will be rejected with the reasons.
+  state = malloc(sizeof(promise_any_state));
+  *state =
+    (promise_any_state){.size = 3,
+                        .in = {emscripten_promise_create(),
+                               emscripten_promise_create(),
+                               emscripten_promise_create()},
+                        .expected = NULL,
+                        .err = {},
+                        .expected_err = {(void*)42, (void*)43, (void*)44}};
+  em_promise_t rejected =
+    emscripten_promise_any(state->in, state->err, state->size);
+  em_promise_t rejected_checked =
+    emscripten_promise_then(rejected, fail, check_promise_any_err, state);
+  emscripten_promise_destroy(rejected);
+  emscripten_promise_resolve(state->in[0], EM_PROMISE_REJECT, (void*)42);
+  emscripten_promise_resolve(state->in[1], EM_PROMISE_REJECT, (void*)43);
+  emscripten_promise_resolve(state->in[2], EM_PROMISE_REJECT, (void*)44);
+  emscripten_promise_destroy(state->in[0]);
+  emscripten_promise_destroy(state->in[1]);
+  emscripten_promise_destroy(state->in[2]);
+
+  // Same, but now the error reason buffer is null.
+  em_promise_t null_in[3] = {
+    emscripten_promise_create(),
+    emscripten_promise_create(),
+    emscripten_promise_create(),
+  };
+  em_promise_t null = emscripten_promise_any(null_in, NULL, 3);
+  em_promise_t null_checked =
+    emscripten_promise_then(null, fail, check_null, NULL);
+  emscripten_promise_destroy(null);
+  emscripten_promise_resolve(null_in[0], EM_PROMISE_REJECT, (void*)42);
+  emscripten_promise_resolve(null_in[1], EM_PROMISE_REJECT, (void*)43);
+  emscripten_promise_resolve(null_in[2], EM_PROMISE_REJECT, (void*)44);
+  emscripten_promise_destroy(null_in[0]);
+  emscripten_promise_destroy(null_in[1]);
+  emscripten_promise_destroy(null_in[2]);
+
+  em_promise_t to_finish[4] = {
+    empty_checked, full_checked, rejected_checked, null_checked};
+  em_promise_t finish_test_any = emscripten_promise_all(to_finish, NULL, 4);
+
+  emscripten_promise_destroy(empty_checked);
+  emscripten_promise_destroy(full_checked);
+  emscripten_promise_destroy(rejected_checked);
+  emscripten_promise_destroy(null_checked);
+
+  *result = finish_test_any;
   return EM_PROMISE_MATCH_RELEASE;
 }
 
@@ -390,8 +508,9 @@ int main() {
   em_promise_t test4 = emscripten_promise_then(test3, test_all, fail, (void*)4);
   em_promise_t test5 =
     emscripten_promise_then(test4, test_all_settled, fail, (void*)5);
+  em_promise_t test6 = emscripten_promise_then(test5, test_any, fail, (void*)6);
   em_promise_t assert_stack =
-    emscripten_promise_then(test5, check_stack, fail, NULL);
+    emscripten_promise_then(test6, check_stack, fail, NULL);
   em_promise_t end = emscripten_promise_then(assert_stack, finish, fail, NULL);
 
   emscripten_promise_resolve(start, EM_PROMISE_FULFILL, NULL);
@@ -403,6 +522,7 @@ int main() {
   emscripten_promise_destroy(test3);
   emscripten_promise_destroy(test4);
   emscripten_promise_destroy(test5);
+  emscripten_promise_destroy(test6);
   emscripten_promise_destroy(assert_stack);
   emscripten_promise_destroy(end);
 

--- a/test/core/test_promise.c
+++ b/test/core/test_promise.c
@@ -356,7 +356,7 @@ typedef struct promise_any_state {
 static em_promise_result_t
 check_promise_any_result(void** result, void* data, void* value) {
   promise_any_state* state = (promise_any_state*)data;
-  emscripten_console_logf("promise_all result: %ld", (uintptr_t)value);
+  emscripten_console_logf("promise_any result: %ld", (uintptr_t)value);
   assert(value == state->expected);
   free(state);
   return EM_PROMISE_FULFILL;
@@ -366,7 +366,7 @@ static em_promise_result_t
 check_promise_any_err(void** result, void* data, void* value) {
   promise_any_state* state = (promise_any_state*)data;
   assert(value == state->err);
-  emscripten_console_log("promise_all reasons:");
+  emscripten_console_log("promise_any reasons:");
   for (size_t i = 0; i < state->size; ++i) {
     emscripten_console_logf("%ld", (uintptr_t)state->err[i]);
     assert(state->err[i] == state->expected_err[i]);

--- a/test/core/test_promise.out
+++ b/test/core/test_promise.out
@@ -21,4 +21,11 @@ promise_all_settled results:
 fulfill 42
 reject 43
 fulfill 44
+test_any
+promise_all reasons:
+promise_all result: 42
+promise_all reasons:
+42
+43
+44
 finish

--- a/test/core/test_promise.out
+++ b/test/core/test_promise.out
@@ -22,9 +22,9 @@ fulfill 42
 reject 43
 fulfill 44
 test_any
-promise_all reasons:
-promise_all result: 42
-promise_all reasons:
+promise_any reasons:
+promise_any result: 42
+promise_any reasons:
 42
 43
 44


### PR DESCRIPTION
Similar to `emscripten_promise_all` and `emscripten_promise_all_settled`, this
function propagates the first of its input promises to be fulfilled or is
rejected with a list of reasons if its inputs are rejected.