### PR TITLE
Implement `emscripten_promise_race` in promise.h

### DIFF
--- a/src/library_promise.js
+++ b/src/library_promise.js
@@ -239,5 +239,20 @@ mergeInto(LibraryManager.library, {
     dbg('create: ' + id);
 #endif
     return id;
+  },
+
+  emscripten_promise_race__deps: ['$promiseMap', '$idsToPromises'],
+  emscripten_promise_race: function(idBuf, size) {
+    var promises = idsToPromises(idBuf, size);
+#if RUNTIME_DEBUG
+    dbg('emscripten_promise_race: ' + promises);
+#endif
+    var id = promiseMap.allocate({
+      promise: Promise.race(promises)
+    });
+#if RUNTIME_DEBUG
+    dbg('create: ' + id);
+#endif
+    return id;
   }
 });

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -540,6 +540,7 @@ sigs = {
   emscripten_promise_any__sig: 'pppp',
   emscripten_promise_create__sig: 'p',
   emscripten_promise_destroy__sig: 'vp',
+  emscripten_promise_race__sig: 'ppp',
   emscripten_promise_resolve__sig: 'vpip',
   emscripten_promise_then__sig: 'ppppp',
   emscripten_random__sig: 'f',

--- a/system/include/emscripten/promise.h
+++ b/system/include/emscripten/promise.h
@@ -127,6 +127,14 @@ __attribute__((warn_unused_result)) em_promise_t emscripten_promise_all_settled(
 __attribute__((warn_unused_result)) em_promise_t emscripten_promise_any(
   em_promise_t* promises, void** errors, size_t num_promises);
 
+// Call Promise.race to create and return a new promise that settles once any of
+// the `num_promises` input promises passed in `promises` has been settled. If
+// the first input promise to settle is fulfilled, the resulting promise is
+// fulfilled with the same value. Otherwise, if the first input promise to
+// settle is rejected, the resulting promise is rejected with the same reason.
+__attribute__((warn_unused_result)) em_promise_t
+emscripten_promise_race(em_promise_t* promises, size_t num_promises);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/core/test_promise.out
+++ b/test/core/test_promise.out
@@ -28,4 +28,7 @@ promise_any reasons:
 42
 43
 44
+test_race
+expected success: 42
+expected error: 42
 finish


### PR DESCRIPTION
Implement `emscripten_promise_race` in promise.h

This function propagates the result of its first input promise to settle,
whether it is fulfilled or rejected.

update library sig file