### PR TITLE
Update documentation and remove unneeded warning for --source-map base

### DIFF
--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -174,14 +174,14 @@ Options that are modified or new in *emcc* are listed below:
    different server, for example).
 
 "-gsource-map"
- [link]
-  Generate a source map using LLVM debug information (which must
-  be present in object files, i.e., they should have been compiled with ``-g``).
-  When this option is provided, the **.wasm** file is updated to have a
-  ``sourceMappingURL`` section. The resulting URL will have format:
-  ``<base-url>`` + ``<wasm-file-name>`` + ``.map``. ``<base-url>`` defaults
-  to being empty (which means the source map is served from the same directory
-  as the wasm file). It can be changed using --source-map-base
+  [link] Generate a source map using LLVM debug information (which
+  must be present in object files, i.e., they should have been 
+  compiled with "-g"). When this option is provided, the **.wasm**
+  file is updated to have a ""sourceMappingURL" section. The resulting
+  URL will have format: "<base-url>"" + "<wasm-file-name>" + ".map".
+  "<base-url>" defaults to being empty (which means the source map is
+  served from the same directory as the wasm file). It can be changed
+  using --source-map-base.
 
 "-g<level>"
    [compile+link] Controls the level of debuggability. Each level
@@ -380,9 +380,8 @@ Options that are modified or new in *emcc* are listed below:
        specified using the "-o" option.
 
 "--source-map-base <base-url>"
-  [link]
-  The base URL for the location where WebAssembly source maps will be published. Must be used
-  with `-gsource-map.
+  [link] The base URL for the location where WebAssembly source maps
+  will be published. Must be used with -gsource-map.
 
 "--minify 0"
    [same as -g1 if passed at compile time, otherwise applies at link]

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -174,14 +174,14 @@ Options that are modified or new in *emcc* are listed below:
    different server, for example).
 
 "-gsource-map"
-  [link] Generate a source map using LLVM debug information (which
-  must be present in object files, i.e., they should have been 
-  compiled with "-g"). When this option is provided, the **.wasm**
-  file is updated to have a ""sourceMappingURL" section. The resulting
-  URL will have format: "<base-url>"" + "<wasm-file-name>" + ".map".
-  "<base-url>" defaults to being empty (which means the source map is
-  served from the same directory as the wasm file). It can be changed
-  using --source-map-base.
+   [link] Generate a source map using LLVM debug information (which
+   must be present in object files, i.e., they should have been 
+   compiled with "-g"). When this option is provided, the **.wasm**
+   file is updated to have a "sourceMappingURL" section. The resulting
+   URL will have format: "<base-url>" + "<wasm-file-name>" + ".map".
+   "<base-url>" defaults to being empty (which means the source map is
+   served from the same directory as the wasm file). It can be changed
+   using --source-map-base.
 
 "-g<level>"
    [compile+link] Controls the level of debuggability. Each level
@@ -380,8 +380,8 @@ Options that are modified or new in *emcc* are listed below:
        specified using the "-o" option.
 
 "--source-map-base <base-url>"
-  [link] The base URL for the location where WebAssembly source maps
-  will be published. Must be used with -gsource-map.
+   [link] The base URL for the location where WebAssembly source maps
+   will be published. Must be used with -gsource-map.
 
 "--minify 0"
    [same as -g1 if passed at compile time, otherwise applies at link]

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -175,7 +175,7 @@ Options that are modified or new in *emcc* are listed below:
 
 "-gsource-map"
    [link] Generate a source map using LLVM debug information (which
-   must be present in object files, i.e., they should have been 
+   must be present in object files, i.e., they should have been
    compiled with "-g"). When this option is provided, the **.wasm**
    file is updated to have a "sourceMappingURL" section. The resulting
    URL will have format: "<base-url>" + "<wasm-file-name>" + ".map".

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -174,9 +174,14 @@ Options that are modified or new in *emcc* are listed below:
    different server, for example).
 
 "-gsource-map"
-   When linking, generate a source map using LLVM debug information
-   (which must be present in object files, i.e., they should have been
-   compiled with "-g").
+ [link]
+  Generate a source map using LLVM debug information (which must
+  be present in object files, i.e., they should have been compiled with ``-g``).
+  When this option is provided, the **.wasm** file is updated to have a
+  ``sourceMappingURL`` section. The resulting URL will have format:
+  ``<base-url>`` + ``<wasm-file-name>`` + ``.map``. ``<base-url>`` defaults
+  to being empty (which means the source map is served from the same directory
+  as the wasm file). It can be changed using --source-map-base
 
 "-g<level>"
    [compile+link] Controls the level of debuggability. Each level
@@ -375,10 +380,9 @@ Options that are modified or new in *emcc* are listed below:
        specified using the "-o" option.
 
 "--source-map-base <base-url>"
-   [link] The URL for the location where WebAssembly source maps will
-   be published. When this option is provided, the **.wasm** file is
-   updated to have a "sourceMappingURL" section. The resulting URL
-   will have format: "<base-url>" + "<wasm-file-name>" + ".map".
+  [link]
+  The base URL for the location where WebAssembly source maps will be published. Must be used
+  with `-gsource-map.
 
 "--minify 0"
    [same as -g1 if passed at compile time, otherwise applies at link]

--- a/emcc.py
+++ b/emcc.py
@@ -3639,8 +3639,6 @@ def parse_args(newargs):
 def phase_binaryen(target, options, wasm_target):
   global final_js
   logger.debug('using binaryen')
-  if settings.GENERATE_SOURCE_MAP and not settings.SOURCE_MAP_BASE:
-    logger.warning("Wasm source map won't be usable in a browser without --source-map-base")
   # whether we need to emit -g (function name debug info) in the final wasm
   debug_info = settings.DEBUG_LEVEL >= 2 or settings.EMIT_NAME_SECTION
   # whether we need to emit -g in the intermediate binaryen invocations (but not

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -169,7 +169,7 @@ Options that are modified or new in *emcc* are listed below:
   ``sourceMappingURL`` section. The resulting URL will have format:
   ``<base-url>`` + ``<wasm-file-name>`` + ``.map``. ``<base-url>`` defaults
   to being empty (which means the source map is served from the same directory
-  as the wasm file). It can be changed using :ref:`--source-map-base <emcc-source-map-base>`
+  as the wasm file). It can be changed using :ref:`--source-map-base <emcc-source-map-base>`.
 
 .. _emcc-gN:
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -162,8 +162,14 @@ Options that are modified or new in *emcc* are listed below:
 .. _emcc-gsource-map:
 
 ``-gsource-map``
-  When linking, generate a source map using LLVM debug information (which must
+  [link]
+  Generate a source map using LLVM debug information (which must
   be present in object files, i.e., they should have been compiled with ``-g``).
+  When this option is provided, the **.wasm** file is updated to have a
+  ``sourceMappingURL`` section. The resulting URL will have format:
+  ``<base-url>`` + ``<wasm-file-name>`` + ``.map``. ``<base-url>`` defaults
+  to being empty (which means the source map is served from the same directory
+  as the wasm file). It can be changed using :ref:`--source-map-base <emcc-source-map-base>`
 
 .. _emcc-gN:
 
@@ -352,7 +358,8 @@ Options that are modified or new in *emcc* are listed below:
 
 ``--source-map-base <base-url>``
   [link]
-  The URL for the location where WebAssembly source maps will be published. When this option is provided, the **.wasm** file is updated to have a ``sourceMappingURL`` section. The resulting URL will have format: ``<base-url>`` + ``<wasm-file-name>`` + ``.map``.
+  The base URL for the location where WebAssembly source maps will be published. Must be used
+  with :ref:`-gsource-map <emcc-gsource-map>`.
 
 .. _emcc-minify:
 


### PR DESCRIPTION
The behavior of the --source-map-base and -gsource-map flags has changed since their introduction but the documentation and link-time warning did not. The current behavior is what we want, so keep it and update the docs.