### PR TITLE
Remove `makeMalloc` utility function. NFC

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1272,10 +1272,11 @@ var LibraryGLFW = {
   glfwPostEmptyEvent: function() {},
 
   glfwGetMonitors__sig: 'ii',
+  glfwGetMonitors__deps: ['malloc'],
   glfwGetMonitors: function(count) {
     {{{ makeSetValue('count', '0', '1', 'i32') }}};
     if (!GLFW.monitors) {
-      GLFW.monitors = {{{ makeMalloc('glfwGetMonitors', POINTER_SIZE) }}};
+      GLFW.monitors = _malloc({{{ POINTER_SIZE }}});
       {{{ makeSetValue('GLFW.monitors', '0', '1', 'i32') }}};
     }
     return GLFW.monitors;

--- a/src/library_legacy.js
+++ b/src/library_legacy.js
@@ -17,7 +17,7 @@ mergeInto(LibraryManager.library, {
    * @param {(Uint8Array|Array<number>)} slab: An array of data.
    * @param {number=} allocator : How to allocate memory, see ALLOC_*
    */
-  $allocate__deps: ['$ALLOC_NORMAL', '$ALLOC_STACK'],
+  $allocate__deps: ['$ALLOC_NORMAL', '$ALLOC_STACK', 'malloc'],
   $allocate: function(slab, allocator) {
     var ret;
   #if ASSERTIONS
@@ -28,7 +28,7 @@ mergeInto(LibraryManager.library, {
     if (allocator == ALLOC_STACK) {
       ret = stackAlloc(slab.length);
     } else {
-      ret = {{{ makeMalloc('allocate', 'slab.length') }}};
+      ret = _malloc(slab.length);
     }
 
     if (!slab.subarray && !slab.slice) {

--- a/src/library_strings.js
+++ b/src/library_strings.js
@@ -479,10 +479,10 @@ mergeInto(LibraryManager.library, {
 
   // Allocate heap space for a JS string, and write it there.
   // It is the responsibility of the caller to free() that memory.
-  $stringToNewUTF8__deps: ['$lengthBytesUTF8', '$stringToUTF8'],
+  $stringToNewUTF8__deps: ['$lengthBytesUTF8', '$stringToUTF8', 'malloc'],
   $stringToNewUTF8: function(str) {
     var size = lengthBytesUTF8(str) + 1;
-    var ret = {{{ makeMalloc('stringToNewUTF8', 'size') }}};
+    var ret = _malloc(size);
     if (ret) stringToUTF8(str, ret, size);
     return ret;
   },

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -925,21 +925,6 @@ function awaitIf(condition) {
   return condition ? 'await' : '';
 }
 
-function makeMalloc(source, param) {
-  if (hasExportedSymbol('malloc')) {
-    return `_malloc(${param})`;
-  }
-  // It should be impossible to call some functions without malloc being
-  // included, unless we have a deps_info.json bug. To let closure not error
-  // on `_malloc` not being present, they don't call malloc and instead abort
-  // with an error at runtime.
-  // TODO: A more comprehensive deps system could catch this at compile time.
-  if (!ASSERTIONS) {
-    return 'abort();';
-  }
-  return `abort('malloc was not included, but is needed in ${source}. Adding "_malloc" to EXPORTED_FUNCTIONS should fix that. This may be a bug in the compiler, please file an issue.');`;
-}
-
 // Adds a call to runtimeKeepalivePush, if needed by the current build
 // configuration.
 // We skip this completely in MINIMAL_RUNTIME and also in builds that

--- a/src/parseTools_legacy.js
+++ b/src/parseTools_legacy.js
@@ -85,6 +85,10 @@ function makeCopyValues(dest, src, num, type, modifier, align, sep = ';') {
   return ret.join(sep);
 }
 
+function makeMalloc(source, param) {
+  return `_malloc(${param})`;
+}
+
 global.Runtime = {
   getNativeTypeSize: getNativeTypeSize,
   getNativeFieldSize: getNativeFieldSize,

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11519,25 +11519,6 @@ int main () {
       "malloc() called but not included in the build - add '_malloc' to EXPORTED_FUNCTIONS",
       "free() called but not included in the build - add '_free' to EXPORTED_FUNCTIONS"))
 
-  def test_missing_malloc_export_indirect(self):
-    # we used to include malloc by default. show a clear error in builds with
-    # ASSERTIONS to help with any confusion when the user calls a JS API that
-    # requires malloc
-    create_file('unincluded_malloc.c', r'''
-      #include <emscripten.h>
-      EM_JS_DEPS(main, "$stringToNewUTF8");
-      int main() {
-        EM_ASM({
-          try {
-            stringToNewUTF8("foo");
-          } catch(e) {
-            console.log('exception:', e);
-          }
-        });
-      }
-    ''')
-    self.do_runf('unincluded_malloc.c', 'malloc was not included, but is needed in stringToNewUTF8. Adding "_malloc" to EXPORTED_FUNCTIONS should fix that. This may be a bug in the compiler, please file an issue.')
-
   def test_getrusage(self):
     self.do_runf(test_file('other/test_getrusage.c'))
 

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -150,7 +150,7 @@ _deps_info = {
   'glewInit': ['malloc'],
   'glfwGetProcAddress': ['malloc'],
   'glfwInit': ['malloc', 'free'],
-  'glfwSleep': ['sleep'],
+  'glfwSleep': ['sleep', 'malloc'],
   'glfwGetMonitors': ['malloc'],
   'localtime': ['malloc'],
   'localtime_r': ['malloc'],


### PR DESCRIPTION
It seems much safer/cleaner to simply use explicit dependencies on `malloc`.  The one function where an optional dependency might be useful is `allocate` since it can operator both with and without `malloc`, but that function is deprecated/legacy.

See #19159