### PR TITLE
Deprecate the USES_DYNAMIC_ALLOC setting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 3.1.36 (in development)
 -----------------------
+- The `USES_DYNAMIC_ALLOC` setting has been deprecated.  You can get the same
+  effect from `-sMALLOC=none`. (#19164)
 
 3.1.35 - 04/03/23
 -----------------

--- a/emcc.py
+++ b/emcc.py
@@ -2331,10 +2331,6 @@ def phase_linker_setup(options, state, newargs):
         '_wasmfs_readdir_finish',
       ]
 
-  # Explicitly drop linking in a malloc implementation if program is not using any dynamic allocation calls.
-  if not settings.USES_DYNAMIC_ALLOC:
-    settings.MALLOC = 'none'
-
   if settings.FETCH and final_suffix in EXECUTABLE_ENDINGS:
     state.forced_stdlibs.append('libfetch')
     settings.JS_LIBRARIES.append((0, 'library_fetch.js'))

--- a/src/settings.js
+++ b/src/settings.js
@@ -1851,13 +1851,6 @@ var MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION = false;
 // [link]
 var MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION = false;
 
-// If building with MINIMAL_RUNTIME=1 and application uses sbrk()/malloc(),
-// enable this. If you are not using dynamic allocations, can set this to 0 to
-// save code size. This setting is ignored when building with -s
-// MINIMAL_RUNTIME=0.
-// [link]
-var USES_DYNAMIC_ALLOC = true;
-
 // If set to 'emscripten' or 'wasm', compiler supports setjmp() and longjmp().
 // If set to 0, these APIs are not available.  If you are using C++ exceptions,
 // but do not need setjmp()+longjmp() API, then you can set this to 0 to save a
@@ -2175,4 +2168,5 @@ var LEGACY_SETTINGS = [
   ['LLD_REPORT_UNDEFINED', [1], 'Disabling is no longer supported'],
   ['MEM_INIT_METHOD', [0], 'No longer supported'],
   ['USE_PTHREADS', [0, 1], 'No longer needed. Use -pthread instead'],
+  ['USES_DYNAMIC_ALLOC', [1], 'No longer supported. Use -sMALLOC=none'],
 ];

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9993,14 +9993,14 @@ int main () {
 
     math_sources = [test_file('code_size/math.c')]
     hello_world_sources = [test_file('small_hello_world.c'),
-                           '-sUSES_DYNAMIC_ALLOC=0']
+                           '-sMALLOC=none']
     random_printf_sources = [test_file('hello_random_printf.c'),
-                             '-sUSES_DYNAMIC_ALLOC=0',
+                             '-sMALLOC=none',
                              '-sSINGLE_FILE']
     hello_webgl_sources = [test_file('minimal_webgl/main.cpp'),
                            test_file('minimal_webgl/webgl.c'),
                            '--js-library', test_file('minimal_webgl/library_js.js'),
-                           '-sUSES_DYNAMIC_ALLOC', '-lwebgl.js',
+                           '-lwebgl.js',
                            '-sMODULARIZE']
     hello_webgl2_sources = hello_webgl_sources + ['-sMAX_WEBGL_VERSION=2']
     hello_wasm_worker_sources = [test_file('wasm_worker/wasm_worker_code_size.c'), '-sWASM_WORKERS', '-sENVIRONMENT=web,worker']


### PR DESCRIPTION
All this setting was doing was setting MALLOC=none so it doesn't seem like it needs to exist as a separate setting.

I think it used to do more, for example, prior to #12790 it used was used in some JS library code.  Another PR that removed a lot of usage of this settings was #12057.

Simply removing it simplifies another change I'm working on: #18905.

Also, the docs were incorrect in stating it was ignored except under MINIMAL_RUNTIME, but we had no testing for it.