### PR TITLE
Fix lto0.test_exceptions_allowed_uncaught failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,6 +492,7 @@ jobs:
           title: "core3+extras"
           test_targets: "
             lto2.test_dylink_syslibs_all
+            lto0.test_exceptions_allowed_uncaught
             core3
             core2g.test_externref
             corez.test_dylink_iostream

--- a/system/lib/libcxxabi/src/cxa_exception.h
+++ b/system/lib/libcxxabi/src/cxa_exception.h
@@ -24,7 +24,8 @@ namespace __cxxabiv1 {
 struct _LIBCXXABI_HIDDEN __cxa_exception {
   size_t referenceCount;
   std::type_info *exceptionType;
-  void (*exceptionDestructor)(void *);
+  // In wasm, destructors return 'this' as in ARM
+  void* (*exceptionDestructor)(void *);
   uint8_t caught;
   uint8_t rethrown;
   void *adjustedPtr;


### PR DESCRIPTION
This test started failing after #16627.  Prior to that change the exceptions destructors were called via the following code in JS:

```
   // In Wasm, destructors return 'this' as in ARM
   {{{ makeDynCall('pp', 'destructor') }}}(info.excPtr);
```

For some reason the LTO build produces the following for for the call       
to `exception_header->exceptionDestructor(thrown_object)` in             
`__cxa_decrement_exception_refcount`:                                    
                                                                         
```                                                                      
  call_indirect 0 (type 0)                                               
```                                                                      
                                                                         
Where as the normal non-LTO build produces:                                 
                                                                            
```                                                                      
  call 13 <invoke_ii>                                                    
```                                                                      
                                                                         
Because invoke_ii goes via JS it uses the sloppy type checking and       
doesn't trap, but `call_indirect` has strict type checking and so        
does trap.