### PR TITLE
Add %LOCALAPPDATA% to the path list to search from for the browers

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -1224,7 +1224,7 @@ def find_browser(name):
                          ('chrome', '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'),
                          ('chrome_canary', '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary')]
   elif WINDOWS:
-    pf_locations = ['ProgramFiles(x86)', 'ProgramFiles', 'ProgramW6432']
+    pf_locations = ['ProgramFiles(x86)', 'ProgramFiles', 'ProgramW6432', 'LOCALAPPDATA']
 
     for pf_env in pf_locations:
       if pf_env not in os.environ:


### PR DESCRIPTION
On Windows, when applications are installed without admin priviledges then they are installed in `LOCALAPPDATA` (= C:\Users\my.name\AppData\Local\)

(Tested OK with chrome installation)