### PR TITLE
Remove redundant Node worker listener. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -336,10 +336,6 @@ var LibraryPThread = {
         worker.on('error', function(e) {
           worker.onerror(e);
         });
-        worker.on('detachedExit', function() {
-          // TODO: update the worker queue?
-          // See: https://github.com/emscripten-core/emscripten/issues/9763
-        });
       }
 #endif
 


### PR DESCRIPTION
The corresponding TODO-item is no longer relevant after PR #18305 has landed.

Resolves: #9763.