### PR TITLE
Fix for EMCC_USE_NINJA + embuilder --force

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -268,7 +268,7 @@ def main():
     time_taken = time.time() - start_time
     logger.info('...success. Took %s(%.2fs)' % (('%02d:%02d mins ' % (time_taken // 60, time_taken % 60) if time_taken >= 60 else ''), time_taken))
 
-  if USE_NINJA and not do_clear:
+  if USE_NINJA and args.operation != 'clear':
     system_libs.build_deferred()
 
   if len(tasks) > 1 or USE_NINJA:


### PR DESCRIPTION
Since `--force` set `do_clear` we cannot use that as a sign not do run the build.