### PR TITLE
Add a stub __cxa_free_exception to cxa_noexception.cpp

### DIFF
--- a/system/lib/libcxxabi/src/cxa_noexception.cpp
+++ b/system/lib/libcxxabi/src/cxa_noexception.cpp
@@ -58,6 +58,22 @@ void *__cxa_allocate_exception(size_t thrown_size) _NOEXCEPT {
   char* allocation = (char*)malloc(thrown_size + sizeof(__cxa_exception));
   return allocation + sizeof(__cxa_exception);
 }
+
+static
+inline
+__cxa_exception*
+cxa_exception_from_thrown_object(void* thrown_object)
+{
+    return static_cast<__cxa_exception*>(thrown_object) - 1;
+}
+
+//  Free a __cxa_exception object allocated with __cxa_allocate_exception.
+void __cxa_free_exception(void *thrown_object) _NOEXCEPT {
+    // Compute the size of the padding before the header.
+    char *raw_buffer =
+        ((char *)cxa_exception_from_thrown_object(thrown_object));
+    free((void *)raw_buffer);
+}
 #endif
 
 }  // extern "C"


### PR DESCRIPTION
In some cases cxa_free_exception can be called by compiler-generated code, which may cause linkage failure in emscripten's default mode which allows throwing but not catching. This PR adds a "stub" __cxa_free_exception to go along with __cxa_allocate_exception.