### PR TITLE
Make sure that error() always generates failure in `compiler.js`

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -520,7 +520,9 @@ function ${name}(${args}) {
       includeFile('base64Utils.js');
     }
 
-    if (abortExecution) throw Error('Aborting compilation due to previous errors');
+    if (abortExecution) {
+      throw Error('Aborting compilation due to previous errors');
+    }
 
     // This is the main 'post' pass. Print out the generated code that we have here, together with the
     // rest of the output that we started to print out earlier (see comment on the
@@ -569,8 +571,11 @@ function ${name}(${args}) {
       deps: symbolDeps,
       asyncFuncs
     }));
-    return;
+  } else {
+    finalCombiner();
   }
 
-  finalCombiner();
+  if (abortExecution) {
+    throw Error('Aborting compilation due to previous errors');
+  }
 }

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -133,7 +133,7 @@ function preprocess(filename) {
             error(`${filename}:${i + 1}: #error ${trimmed.substring(trimmed.indexOf(' ')).trim()}`);
           }
         } else {
-          throw new Error(`${filename}:${i + 1}: Unknown preprocessor directive ${first}`);
+          error(`${filename}:${i + 1}: Unknown preprocessor directive ${first}`);
         }
       } else {
         if (showCurrentLine()) {


### PR DESCRIPTION
Previously we would report the error but then exit with 0.