### PR TITLE
fix library_websocket after pull request 19064 (len is undefined)

### DIFF
--- a/src/library_websocket.js
+++ b/src/library_websocket.js
@@ -238,8 +238,8 @@ var LibraryWebSocket = {
       HEAPU32[WS.socketEvent>>2] = socketId;
       if (typeof e.data == 'string') {
         var buf = stringToNewUTF8(e.data);
-#if WEBSOCKET_DEBUG
         var len = lengthBytesUTF8(e.data)+1;
+#if WEBSOCKET_DEBUG
         var s = (e.data.length < 256) ? e.data : (e.data.substr(0, 256) + ' (' + (e.data.length-256) + ' more characters)');
         dbg('WebSocket onmessage, received data: "' + e.data + '", ' + e.data.length + ' chars, ' + len + ' bytes encoded as UTF-8: "' + s + '"');
 #endif


### PR DESCRIPTION
In pull request #19064 variable "len" was moved to WEBSOCKET_DEBUG define, but it's used later in the function:
HEAPU32[(WS.socketEvent+8)>>2] = len;

So in case if we compile emscripten without "WEBSOCKET_DEBUG" define - value of "len" is undefined and being saved as 0 into structure on HEAP. Those websocket functionality with messages stops working.
This change was verified on our local project.