### PR TITLE
Add explicit GL dependency to library_html5_webgl

### DIFF
--- a/src/library_html5_webgl.js
+++ b/src/library_html5_webgl.js
@@ -68,14 +68,7 @@ var LibraryHtml5WebGL = {
   emscripten_webgl_commit_frame: 'emscripten_webgl_do_commit_frame',
 #endif
 
-  // This code is called from emscripten_webgl_create_context() and proxied
-  // to the main thread when in offscreen framebuffer mode. This won't be
-  // called if GL is not linked in, but also make sure to not add a dep on
-  // GL unnecessarily from here, as that would cause a linker error.
   emscripten_webgl_do_create_context__deps: [
-#if LibraryManager.has('library_webgl.js')
-  '$GL',
-#endif
 #if OFFSCREENCANVAS_SUPPORT
   'malloc',
 #endif
@@ -616,6 +609,10 @@ function handleWebGLProxying(funcs) {
 }
 
 handleWebGLProxying(LibraryHtml5WebGL);
+#endif // USE_PTHREADS
+
+#if LibraryManager.has('library_webgl.js')
+autoAddDeps(LibraryHtml5WebGL, '$GL');
 #endif
 
 mergeInto(LibraryManager.library, LibraryHtml5WebGL);


### PR DESCRIPTION
The dependency wrangling here was a workaround for a problem that was solved in #16405.   See the comment that is being deleted.  Prior to #16405 the native code in `pthread_create.c:_do_call` would have a reference to this function bug we didn't want all pthread programs to depend on GL.   Now now `pthread_create.c` has been fixed we don't have that problem anymore.

Pretty much all the functions in this depend either directly or indirectly on the global GL object, so it makes sense to use autoAddDeps rather than try to add individual deps.