### PR TITLE
acorn-optimizer.js: Make use of arrow functions

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,4 +1,3 @@
 singleQuote: true
 bracketSpacing: false
-arrowParens: avoid
 printWidth: 100


### PR DESCRIPTION
Also, update `.prettierrc.yml` to use the default setting for `arrowParens` which is `always`.  This seems to be the agreed upon norm for JS development.