### PR TITLE
Remove `__syscall_link` in favor `__syscall_linkat`. NFC

### DIFF
--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -244,7 +244,6 @@ sigs = {
   __syscall_getsockname__sig: 'iippiii',
   __syscall_getsockopt__sig: 'iiiippi',
   __syscall_ioctl__sig: 'iiip',
-  __syscall_linkat__sig: 'iipipi',
   __syscall_listen__sig: 'iiiiiii',
   __syscall_lstat64__sig: 'ipp',
   __syscall_mkdirat__sig: 'iipi',

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -864,11 +864,6 @@ var SyscallsLibrary = {
     FS.rename(oldpath, newpath);
     return 0;
   },
-  __syscall_linkat__nothrow: true,
-  __syscall_linkat__proxy: false,
-  __syscall_linkat: function(olddirfd, oldpath, newdirfd, newpath, flags) {
-    return -{{{ cDefs.EMLINK }}}; // no hardlinks for us
-  },
   __syscall_symlinkat: function(target, newdirfd, linkpath) {
 #if SYSCALL_DEBUG
     dbg('warning: untested syscall');

--- a/system/lib/libc/emscripten_syscall_stubs.c
+++ b/system/lib/libc/emscripten_syscall_stubs.c
@@ -108,7 +108,7 @@ weak int __syscall_getppid() {
   return g_ppid;
 }
 
-weak int __syscall_link(intptr_t oldpath, intptr_t newpath) {
+weak int __syscall_linkat(int olddirfd, intptr_t oldpath, int newdirfd, intptr_t newpath, int flags) {
   return -EMLINK; // no hardlinks for us
 }
 

--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h
@@ -1,4 +1,3 @@
-#define SYS_link		  __syscall_link
 #define SYS_chdir		 __syscall_chdir
 #define SYS_chmod		 __syscall_chmod
 #define SYS_getpid		 __syscall_getpid

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -12,7 +12,6 @@
 extern "C" {
 #endif
 
-int __syscall_link(intptr_t oldpath, intptr_t newpath);
 int __syscall_chdir(intptr_t path);
 int __syscall_mknod(intptr_t path, int mode, int dev);
 int __syscall_chmod(intptr_t path, int mode);


### PR DESCRIPTION
We already did this for most other syscalls that have both flavors. This matters less since we don't even implement it.