### PR TITLE
Cleanup test_utf8_textdecoder and add some tracing. NFC

### DIFF
--- a/test/benchmark/benchmark_utf8.c
+++ b/test/benchmark/benchmark_utf8.c
@@ -6,16 +6,18 @@
 #include <stdio.h>
 #include <string.h>
 #include <wchar.h>
-#include <iostream>
-#include <cassert>
+#include <assert.h>
 #include <emscripten.h>
+#include <time.h>
+
+EM_JS_DEPS(deps, "$UTF8ToString,emscripten_get_now");
 
 double test(const char *str) {
   double res = EM_ASM_DOUBLE({
     var t0 = _emscripten_get_now();
-    var str = Module.UTF8ToString($0);
+    var str = UTF8ToString($0);
     var t1 = _emscripten_get_now();
-//    out('t: ' + (t1 - t0) + ', len(result): ' + str.length + ', result: ' + str.slice(0, 100));
+    // out('t: ' + (t1 - t0) + ', len(result): ' + str.length + ', result: ' + str.slice(0, 100));
     return (t1-t0);
   }, str);
   return res;
@@ -30,38 +32,40 @@ char *randomString(int len) {
     fseek(handle, 0, SEEK_END);
     utf8_corpus_length = ftell(handle);
     assert(utf8_corpus_length > 0);
-    utf8_corpus = new char[utf8_corpus_length+1];
+    utf8_corpus = malloc(utf8_corpus_length+1);
     fseek(handle, 0, SEEK_SET);
     fread(utf8_corpus, 1, utf8_corpus_length, handle);
     fclose(handle);
     utf8_corpus[utf8_corpus_length] = '\0';
   }
   int startIdx = rand() % (utf8_corpus_length - len);
-  while(((unsigned char)utf8_corpus[startIdx] & 0xC0) == 0x80) {
+  while (((unsigned char)utf8_corpus[startIdx] & 0xC0) == 0x80) {
     ++startIdx;
     if (startIdx + len > utf8_corpus_length) len = utf8_corpus_length - startIdx;
   }
   assert(len > 0);
-  char *s = new char[len+1];
+  char *s = malloc(len+1);
   memcpy(s, utf8_corpus + startIdx, len);
   s[len] = '\0';
-  while(len > 0 && ((unsigned char)s[len-1] & 0xC0) == 0x80) { s[--len] = '\0'; }
-  while(len > 0 && ((unsigned char)s[len-1] & 0xC0) == 0xC0) { s[--len] = '\0'; }
+  while (len > 0 && ((unsigned char)s[len-1] & 0xC0) == 0x80) { s[--len] = '\0'; }
+  while (len > 0 && ((unsigned char)s[len-1] & 0xC0) == 0xC0) { s[--len] = '\0'; }
   assert(len >= 0);
   return s;
 }
 
 int main() {
-  srand(time(NULL));
+  time_t seed = time(NULL);
+  printf("Random seed: %lld\n", seed);
+  srand(seed);
   double t = 0;
   double t2 = emscripten_get_now();
-  for(int i = 0; i < 100000; ++i) {
+  for (int i = 0; i < 100000; ++i) {
     // Create strings of lengths 1-32, because the internals of text decoding
     // have a cutoff of 16 for when to use TextDecoder, and we wish to test both
     // (see UTF8ArrayToString).
     char *str = randomString((i % 32) + 1);
     t += test(str);
-    delete [] str;
+    free(str);
   }
   double t3 = emscripten_get_now();
   printf("OK. Time: %f (%f).\n", t, t3-t2);

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4363,7 +4363,7 @@ Module["preRun"].push(function () {
 
   @also_with_threads
   def test_utf8_textdecoder(self):
-    self.btest_exit(test_file('benchmark/benchmark_utf8.cpp'), 0, args=['--embed-file', test_file('utf8_corpus.txt') + '@/utf8_corpus.txt', '-sEXPORTED_RUNTIME_METHODS=[UTF8ToString]'])
+    self.btest_exit(test_file('benchmark/benchmark_utf8.c'), 0, args=['--embed-file', test_file('utf8_corpus.txt') + '@/utf8_corpus.txt'])
 
   @also_with_threads
   def test_utf16_textdecoder(self):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5896,9 +5896,8 @@ Module = {
 
   @also_with_wasm_bigint
   def test_utf8_textdecoder(self):
-    self.set_setting('EXPORTED_RUNTIME_METHODS', ['UTF8ToString', 'stringToUTF8'])
     self.emcc_args += ['--embed-file', test_file('utf8_corpus.txt') + '@/utf8_corpus.txt']
-    self.do_runf(test_file('benchmark/benchmark_utf8.cpp'), 'OK.')
+    self.do_runf(test_file('benchmark/benchmark_utf8.c'), 'OK.')
 
   # Test that invalid character in UTF8 does not cause decoding to crash.
   def test_utf8_invalid(self):


### PR DESCRIPTION
I've seen this test fail in CI a few times with a timeout.  The cause must be to do with the ransom see I would guess so add some tracing so we can reproduce if it ever happens again.