### PR TITLE
Add support for handling WebGL built-in preprocessor variables when custom preprocessor is in use

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -3047,9 +3047,9 @@ var LibraryGL = {
     // Remove comments and C-preprocess the input shader first, so that we can appropriately
     // parse the layout location directives.
     source = preprocess_c_code(remove_cpp_comments_in_shaders(source), {
-      'GL_FRAGMENT_PRECISION_HIGH': function() { return 1; },
-      'GL_ES': function() { return 1; },
-      '__VERSION__': function() { return source.includes('#version 300') ? 300 : 100; }
+      'GL_FRAGMENT_PRECISION_HIGH': () => 1,
+      'GL_ES': () => 1,
+      '__VERSION__': () => source.includes('#version 300') ? 300 : 100
     });
 #if GL_DEBUG
     dbg('Shader source after preprocessing: ' + source);

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -3038,9 +3038,19 @@ var LibraryGL = {
 #if GL_DEBUG
     dbg('Input shader source: ' + source);
 #endif
+
+#if ASSERTIONS
+    // These are not expected to be meaningful in WebGL, but issue a warning if they are present, to give some diagnostics about if they are present.
+    if (source.includes('__FILE__')) warnOnce(`When compiling shader: ${source}: Preprocessor variable __FILE__ is not handled by -sGL_EXPLICIT_UNIFORM_LOCATION/-sGL_EXPLICIT_UNIFORM_BINDING options!`);
+    if (source.includes('__LINE__')) warnOnce(`When compiling shader: ${source}: Preprocessor variable __LINE__ is not handled by -sGL_EXPLICIT_UNIFORM_LOCATION/-sGL_EXPLICIT_UNIFORM_BINDING options!`);
+#endif
     // Remove comments and C-preprocess the input shader first, so that we can appropriately
     // parse the layout location directives.
-    source = preprocess_c_code(remove_cpp_comments_in_shaders(source), { 'GL_FRAGMENT_PRECISION_HIGH': function() { return 1; }});
+    source = preprocess_c_code(remove_cpp_comments_in_shaders(source), {
+      'GL_FRAGMENT_PRECISION_HIGH': function() { return 1; },
+      'GL_ES': function() { return 1; },
+      '__VERSION__': function() { return source.includes('#version 300') ? 300 : 100; }
+    });
 #if GL_DEBUG
     dbg('Shader source after preprocessing: ' + source);
 #endif

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2726,6 +2726,16 @@ Module["preRun"].push(function () {
         continue
       self.btest_exit(test_file('html5_webgl.c'), args=['-sMAX_WEBGL_VERSION=2', '-lGL'] + mode)
 
+  @parameterized({
+    'webgl1': (['-DWEBGL_VERSION=1'],),
+    'webgl2': (['-sMAX_WEBGL_VERSION=2', '-DWEBGL_VERSION=2'],),
+    'webgl1_extensions': (['-DWEBGL_VERSION=1', '-sGL_EXPLICIT_UNIFORM_LOCATION'],),
+    'webgl2_extensions': (['-sMAX_WEBGL_VERSION=2', '-DWEBGL_VERSION=2', '-sGL_EXPLICIT_UNIFORM_LOCATION', '-sGL_EXPLICIT_UNIFORM_BINDING'],),
+  })
+  @requires_graphics_hardware
+  def test_webgl_preprocessor_variables(self, opts):
+    self.btest_exit(test_file('webgl_preprocessor_variables.c'), args=['-lGL'] + opts)
+
   @requires_graphics_hardware
   def test_webgl2_ubos(self):
     self.btest_exit(test_file('webgl2_ubos.cpp'), args=['-sMAX_WEBGL_VERSION=2', '-lGL'])

--- a/test/webgl_preprocessor_variables.c
+++ b/test/webgl_preprocessor_variables.c
@@ -1,0 +1,79 @@
+#include <emscripten/html5_webgl.h>
+#include <emscripten/html5.h>
+#include <webgl/webgl2.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+void test(const char *src)
+{
+  GLuint shader = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(shader, 1, &src, NULL);
+  glCompileShader(shader);
+  printf("%s\n", emscripten_webgl_get_shader_info_log_utf8(shader));
+  assert(emscripten_webgl_get_shader_parameter_d(shader, GL_COMPILE_STATUS) == 1);
+}
+
+int main()
+{
+  EmscriptenWebGLContextAttributes attrs;
+  emscripten_webgl_init_context_attributes(&attrs);
+  attrs.majorVersion = WEBGL_VERSION;
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context = emscripten_webgl_create_context("#canvas", &attrs);
+  emscripten_webgl_make_context_current(context);
+
+  // Test the presence of GL_FRAGMENT_PRECISION_HIGH built-in preprocessor
+  test("#ifdef GL_FRAGMENT_PRECISION_HIGH\n"
+    "void main() {}\n"
+    "#endif");
+  test("#if GL_FRAGMENT_PRECISION_HIGH == 1\n"
+    "void main() {}\n"
+    "#endif");
+
+  // Test GL_ES built-in preprocessor directive
+  test("#ifdef GL_ES\n"
+    "void main() {}\n"
+    "#endif");
+  test("#if GL_ES == 1\n"
+    "void main() {}\n"
+    "#endif");
+  test("#if GL_ES != 1\n" // Also check negation, i.e. that #if is not tautologically true
+    "error!\n"
+    "#else\n"
+    "void main() {}\n"
+    "#endif");
+
+  // Test __VERSION__ built-in preprocessor directive.
+  // Note that when WebGL 2 contexts are created, shaders
+  // still default to #version 100, unless explicit
+  // "#version 300 es" is specified.
+  test("#ifdef __VERSION__\n"
+    "void main() {}\n"
+    "#endif");
+  test("#if __VERSION__ == 100\n"
+    "void main() {}\n"
+    "#endif");
+  test("#if defined(GL_ES) && __VERSION__ < 300\n"
+    "void main() {}\n"
+    "#endif");
+  test("#if !defined(GL_ES) || __VERSION__ >= 300\n" // for good measure, check via negation
+    "error!\n"
+    "#else\n"
+    "void main() {}\n"
+    "#endif");
+
+#if WEBGL_VERSION >= 2
+  test("#version 100\n"
+    "#if __VERSION__ == 300\n"
+    "error!\n"
+    "#endif\n"
+    "void main() {}");
+  test("#version 300 es\n"
+    "#if __VERSION__ == 300\n"
+    "void main() {}\n"
+    "#endif");
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
Add support for handling WebGL built-in preprocessor variables `GL_ES` and `__VERSION__` when custom preprocessor is in use (i.e. when building with `-sGL_EXPLICIT_UNIFORM_LOCATION` and/or `-sGL_EXPLICIT_UNIFORM_BINDING`), and add a note of `__FILE__` and `__LINE__` not being handled (since there is no apparent benefit/uses of these, and adding them would just increase code size). Add a unit test for these variables.

This should cover the full set of GLES built-in preprocessor defines:

https://registry.khronos.org/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf

![image](https://user-images.githubusercontent.com/225351/233650741-10426ccf-271f-4e62-9f22-f157ab0030c7.png)
