### PR TITLE
library_tty.js: Add explicit dependency on $UTF8ArrayToString

### DIFF
--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -5,7 +5,7 @@
  */
 
 mergeInto(LibraryManager.library, {
-  $TTY__deps: ['$FS', '$intArrayFromString'],
+  $TTY__deps: ['$FS', '$intArrayFromString', '$UTF8ArrayToString'],
 #if !MINIMAL_RUNTIME
   $TTY__postset: function() {
     addAtInit('TTY.init();');


### PR DESCRIPTION
<details>
  <summary>Details</summary>

```
building:ERROR: Closure compiler run failed:

building:ERROR: /tmp/emscripten_temp__g5pxte0/vips.jso4.js:1028:8: ERROR - [JSC_UNDEFINED_VARIABLE] variable UTF8ArrayToString is undeclared
  1028|     out(UTF8ArrayToString(tty.output, 0));
                ^^^^^^^^^^^^^^^^^

1 error(s), 0 warning(s)

em++: error: closure compiler failed (rc: 1): /usr/bin/node --max_old_space_size=8192 /emsdk/upstream/emscripten/node_modules/.bin/google-closure-compiler --compilation_level ADVANCED_OPTIMIZATIONS --language_in ECMASCRIPT_2020 --language_out NO_TRANSPILE --emit_use_strict=false --externs /emsdk/upstream/emscripten/src/closure-externs/closure-externs.js --externs=/src/src/closure-externs/wasm-vips.js --js /tmp/emscripten_temp__g5pxte0/vips.jso4.js --js_output_file tmpmmz62v_i.cc.js the error message may be clearer with -g1 and EMCC_DEBUG=2 set
```
</details>

(not sure if this is reproducible without Closure)