### PR TITLE
Deprecate `sep` argument to makeSetValue. NFC

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -357,20 +357,21 @@ function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align) {
  * @param {bool} noNeedFirst Whether to ignore the offset in the pointer itself.
  * @param {bool} ignore: legacy, ignored.
  * @param {number} align: legacy, ignored.
- * @param {string} sep: TODO
+ * @param {string} sep: legacy, ignored.
  * @return {TODO}
  */
-function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, sep = ';') {
+function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, sep) {
   assert(typeof align === 'undefined', 'makeSetValue no longer supports align parameter');
   assert(typeof noNeedFirst === 'undefined', 'makeSetValue no longer supports noNeedFirst parameter');
+  assert(typeof sep === 'undefined', 'makeSetValue no longer supports sep parameter');
   if (type == 'i64' && (!WASM_BIGINT || !MEMORY64)) {
     // If we lack either BigInt support or Memory64 then we must fall back to an
     // unaligned read of a 64-bit value: without BigInt we do not have HEAP64,
     // and without Memory64 i64 fields are not guaranteed to be aligned to 64
     // bits, so HEAP64[ptr>>3] might be broken.
     return '(tempI64 = [' + splitI64(value) + '],' +
-            makeSetValue(ptr, pos, 'tempI64[0]', 'i32', noNeedFirst, ignore, align, ',') + ',' +
-            makeSetValue(ptr, getFastValue(pos, '+', getNativeTypeSize('i32')), 'tempI64[1]', 'i32', noNeedFirst, ignore, align, ',') + ')';
+            makeSetValue(ptr, pos, 'tempI64[0]', 'i32') + ',' +
+            makeSetValue(ptr, getFastValue(pos, '+', getNativeTypeSize('i32')), 'tempI64[1]', 'i32') + ')';
   }
 
   const offset = calcFastOffset(ptr, pos);


### PR DESCRIPTION
This argument was not actually being used anywhere. Its last usage was removed in #18678.