### PR TITLE
Remove `= NULL` from static data declaration. NFC

### DIFF
--- a/system/lib/pthread/emscripten_yield.c
+++ b/system/lib/pthread/emscripten_yield.c
@@ -7,7 +7,7 @@
 #include "syscall.h"
 #include "threading_internal.h"
 
-static _Atomic pthread_t crashed_thread_id = NULL;
+static _Atomic pthread_t crashed_thread_id;
 
 void _emscripten_thread_crashed() {
   crashed_thread_id = pthread_self();


### PR DESCRIPTION
This works around an issue with a recent llvm change that is currently blocking the auto-roller: https://reviews.llvm.org/D148730

Since static data is always zero initialized this initializer is completely redundant anyway so its safe to remove.