### PR TITLE
fix websocket in shared memory environment

### DIFF
--- a/src/library_websocket.js
+++ b/src/library_websocket.js
@@ -347,7 +347,7 @@ var LibraryWebSocket = {
 
     dbg('emscripten_websocket_send_binary(socketId='+socketId+',binaryData='+binaryData+ ',dataLength='+dataLength+'), ' + s);
 #endif
-#if PTHREADS
+#if SHARED_MEMORY
     // TODO: This is temporary to cast a shared Uint8Array to a non-shared Uint8Array. This could be removed if WebSocket API is improved
     // to allow passing in views to SharedArrayBuffers
     socket.send(new Uint8Array({{{ makeHEAPView('U8', 'binaryData', 'binaryData+dataLength') }}}));

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -325,17 +325,14 @@ class sockets(BrowserCore):
 
   # Test Emscripten WebSockets API to send and receive text and binary messages against an echo server.
   # N.B. running this test requires 'npm install ws' in Emscripten root directory
-  def test_websocket_send(self):
+  # NOTE: Shared buffer is not allowed for websocket sending.
+  @parameterized({
+    'non_shared': [['-lwebsocket', '-sNO_EXIT_RUNTIME', '-sWEBSOCKET_DEBUG']],
+    'shared': [['-lwebsocket', '-sSHARED_MEMORY', '-sNO_EXIT_RUNTIME', '-sWEBSOCKET_DEBUG']],
+  })
+  def test_websocket_send(self, args):
     with NodeJsWebSocketEchoServerProcess():
-      self.btest_exit(test_file('websocket/test_websocket_send.c'), args=['-lwebsocket', '-sNO_EXIT_RUNTIME', '-sWEBSOCKET_DEBUG'])
-
-  # Test Emscripten WebSockets API to send and receive text and binary messages against an echo server.
-  # N.B. running this test requires 'npm install ws' in Emscripten root directory
-  # test in shared memory environment
-  # websocket sending only allowd non shared buffer
-  def test_websocket_send_shared_memory(self):
-    with NodeJsWebSocketEchoServerProcess():
-      self.btest_exit(test_file('websocket/test_websocket_send.c'), args=['-lwebsocket', '-sSHARED_MEMORY', '-sNO_EXIT_RUNTIME', '-sWEBSOCKET_DEBUG'])
+      self.btest_exit(test_file('websocket/test_websocket_send.c'), args=args)
 
   # Test that native POSIX sockets API can be used by proxying calls to an intermediate WebSockets
   # -> POSIX sockets bridge server

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -329,6 +329,14 @@ class sockets(BrowserCore):
     with NodeJsWebSocketEchoServerProcess():
       self.btest_exit(test_file('websocket/test_websocket_send.c'), args=['-lwebsocket', '-sNO_EXIT_RUNTIME', '-sWEBSOCKET_DEBUG'])
 
+  # Test Emscripten WebSockets API to send and receive text and binary messages against an echo server.
+  # N.B. running this test requires 'npm install ws' in Emscripten root directory
+  # test in shared memory environment
+  # websocket sending only allowd non shared buffer
+  def test_websocket_send_shared_memory(self):
+    with NodeJsWebSocketEchoServerProcess():
+      self.btest_exit(test_file('websocket/test_websocket_send.c'), args=['-lwebsocket', '-sSHARED_MEMORY', '-sNO_EXIT_RUNTIME', '-sWEBSOCKET_DEBUG'])
+
   # Test that native POSIX sockets API can be used by proxying calls to an intermediate WebSockets
   # -> POSIX sockets bridge server
   def test_posix_proxy_sockets(self):

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -327,12 +327,12 @@ class sockets(BrowserCore):
   # N.B. running this test requires 'npm install ws' in Emscripten root directory
   # NOTE: Shared buffer is not allowed for websocket sending.
   @parameterized({
-    'non_shared': [['-lwebsocket', '-sNO_EXIT_RUNTIME', '-sWEBSOCKET_DEBUG']],
-    'shared': [['-lwebsocket', '-sSHARED_MEMORY', '-sNO_EXIT_RUNTIME', '-sWEBSOCKET_DEBUG']],
+    '': [[]],
+    'shared': [['-sSHARED_MEMORY']],
   })
   def test_websocket_send(self, args):
     with NodeJsWebSocketEchoServerProcess():
-      self.btest_exit(test_file('websocket/test_websocket_send.c'), args=args)
+      self.btest_exit(test_file('websocket/test_websocket_send.c'), args=['-lwebsocket', '-sNO_EXIT_RUNTIME', '-sWEBSOCKET_DEBUG'] + args)
 
   # Test that native POSIX sockets API can be used by proxying calls to an intermediate WebSockets
   # -> POSIX sockets bridge server


### PR DESCRIPTION
non pthreads environment will failed if worker is enabled. 

we might change the preprocessor condition from "PTHREADS" to "SHARED_MEMORY".

An example error message for who is struggling:
```
Uncaught TypeError: Failed to execute 'send' on 'WebSocket': The provided ArrayBufferView value must not be shared.
```
