### PR TITLE
Remove dead code (`getTypeFromHeap`) from src/parseTools.js. NFC

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -505,17 +505,6 @@ function charCode(char) {
   return char.charCodeAt(0);
 }
 
-function getTypeFromHeap(suffix) {
-  switch (suffix) {
-    case '8': return 'i8';
-    case '16': return 'i16';
-    case '32': return 'i32';
-    case 'F32': return 'float';
-    case 'F64': return 'double';
-  }
-  assert(false, 'bad type suffix: ' + suffix);
-}
-
 function ensureValidFFIType(type) {
   return type === 'float' ? 'double' : type; // ffi does not tolerate float XXX
 }


### PR DESCRIPTION
The last reference to this function was removed in f45be307a5493adff72e61530fe948708cbe2c8f