### PR TITLE
Add debug range checks for makeSetValue

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1899,7 +1899,7 @@ mergeInto(LibraryManager.library, {
       {{{ makeSetValue('ai', C_STRUCTS.addrinfo.ai_family, 'family', 'i32') }}};
       {{{ makeSetValue('ai', C_STRUCTS.addrinfo.ai_socktype, 'type', 'i32') }}};
       {{{ makeSetValue('ai', C_STRUCTS.addrinfo.ai_protocol, 'proto', 'i32') }}};
-      {{{ makeSetValue('ai', C_STRUCTS.addrinfo.ai_canonname, 'canon', 'i32') }}};
+      {{{ makeSetValue('ai', C_STRUCTS.addrinfo.ai_canonname, 'canon', '*') }}};
       {{{ makeSetValue('ai', C_STRUCTS.addrinfo.ai_addr, 'sa', '*') }}};
       if (family === {{{ cDefs.AF_INET6 }}}) {
         {{{ makeSetValue('ai', C_STRUCTS.addrinfo.ai_addrlen, C_STRUCTS.sockaddr_in6.__size__, 'i32') }}};

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -95,7 +95,37 @@ function unexportedRuntimeSymbol(sym) {
     });
   }
 }
-#endif
+
+#if ASSERTIONS == 2
+
+var MAX_UINT8  = (2 **  8) - 1;
+var MAX_UINT16 = (2 ** 16) - 1;
+var MAX_UINT32 = (2 ** 32) - 1;
+var MAX_UINT53 = (2 ** 53) - 1;
+var MAX_UINT64 = (2 ** 64) - 1;
+
+var MIN_INT8  = - (2 ** ( 8 - 1)) + 1;
+var MIN_INT16 = - (2 ** (16 - 1)) + 1;
+var MIN_INT32 = - (2 ** (32 - 1)) + 1;
+var MIN_INT53 = - (2 ** (53 - 1)) + 1;
+var MIN_INT64 = - (2 ** (64 - 1)) + 1;
+
+function checkInt(value, bits, min, max) {
+  assert(Number.isInteger(Number(value)), "attempt to write non-integer (" + value + ") into integer heap");
+  assert(value <= max, "value (" + value + ") too large to write as " + bits +"-bit value");
+  assert(value >= min, "value (" + value + ") too small to write as " + bits +"-bit value");
+}
+
+var checkInt1 = (value) => checkInt(value, 1, 1);
+var checkInt8 = (value) => checkInt(value, 8, MIN_INT8, MAX_UINT8);
+var checkInt16 = (value) => checkInt(value, 16, MIN_INT16, MAX_UINT16);
+var checkInt32 = (value) => checkInt(value, 32, MIN_INT32, MAX_UINT32);
+var checkInt53 = (value) => checkInt(value, 53, MIN_INT53, MAX_UINT53);
+var checkInt64 = (value) => checkInt(value, 64, MIN_INT64, MAX_UINT64);
+
+#endif // ASSERTIONS == 2
+
+#endif // ASSERTIONS
 
 #if RUNTIME_DEBUG
 var runtimeDebug = true; // Switch to false at runtime to disable logging at the right times

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12892,7 +12892,13 @@ int main() {
 
   @also_with_wasm_bigint
   def test_parseTools(self):
-    self.do_other_test('test_parseTools.c', emcc_args=['--js-library', test_file('other/test_parseTools.js')])
+    self.emcc_args += ['--js-library', test_file('other/test_parseTools.js')]
+    self.do_other_test('test_parseTools.c')
+
+    # If we run ths same test with -sASSERTIONS=2 we expect it to fail because it
+    # involves writing numbers that are exceed the side of the type.
+    expected = 'Aborted(Assertion failed: value (316059037807746200000) too large to write as 64-bit value)'
+    self.do_runf(test_file('other/test_parseTools.c'), expected, emcc_args=['-sASSERTIONS=2'], assert_returncode=NON_ZERO)
 
   def test_lto_atexit(self):
     self.emcc_args.append('-flto')
@@ -13200,8 +13206,8 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     create_file('lib.js', '''
       mergeInto(LibraryManager.library, {
         foo: function() {
-            return {{{ Runtime.POINTER_SIZE }}};
-          }
+          return {{{ Runtime.POINTER_SIZE }}};
+        }
       });
     ''')
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', 'foo')


### PR DESCRIPTION
Trying to store a value outside the range of the type being stored to can result in unexpected behaviour.  For example, storing 256 to a u8 will end up storing 1.

I decided to write this as a followup to #19239 to make it extra clear what the expected behaviour of makeSetValue is.

Adding these checks discovered real bug in out library code in `getaddrinfo`.

I ran the full other and core test suite with these checks enabled at ASSERTIONS=1 before deciding to use ASSERTIONS=2 (at least for now).