### PR TITLE
Remove vulcan-specific functions from src/library_glfw.js

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1733,15 +1733,6 @@ var LibraryGLFW = {
   glfwGetRequiredInstanceExtensions__sig: 'ii',
   glfwGetRequiredInstanceExtensions: function(count) { throw "glfwGetRequiredInstanceExtensions is not implemented."; },
 
-  glfwGetInstanceProcAddress__sig: 'iii',
-  glfwGetInstanceProcAddress: function(instance, procname) { throw "glfwGetInstanceProcAddress is not implemented."; },
-
-  glfwGetPhysicalDevicePresentationSupport__sig: 'iiii',
-  glfwGetPhysicalDevicePresentationSupport: function(instance, device, queuefamily) { throw "glfwGetPhysicalDevicePresentationSupport is not implemented"; },
-
-  glfwCreateWindowSurface__sig: 'iiiii',
-  glfwCreateWindowSurface: function(instance, winid, allocator, surface) { throw "glfwCreateWindowSurface is not implemented."; },
-
   glfwJoystickPresent__sig: 'ii',
   glfwJoystickPresent: function(joy) {
     GLFW.refreshJoysticks();


### PR DESCRIPTION
These functions are declared in GLFW/glfw3.h but are inside an `#if defined(VK_VERSION_1_0)` block, and requires a VkInstance type that emscripten doesn't provide, so its not possible enable them at C/C++ compile time.