### PR TITLE
Remove `getNativeFieldSize` build-time helper. NFC

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -258,8 +258,9 @@ function indentify(text, indent) {
 // Correction tools
 
 function getHeapOffset(offset, type) {
-  if (!WASM_BIGINT && getNativeFieldSize(type) > 4 && type == 'i64') {
-    // we emulate 64-bit integer values as 32 in asmjs-unknown-emscripten, but not double
+  if (type == 'i64' && !WASM_BIGINT) {
+    // We are foreced to use the 32-bit heap for 64-bit values when we don't
+    // have WASM_BIGINT.
     type = 'i32';
   }
 

--- a/src/parseTools_legacy.js
+++ b/src/parseTools_legacy.js
@@ -89,6 +89,10 @@ function makeMalloc(source, param) {
   return `_malloc(${param})`;
 }
 
+function getNativeFieldSize(type) {
+  return Math.max(getNativeTypeSize(type), POINTER_SIZE);
+}
+
 global.Runtime = {
   getNativeTypeSize: getNativeTypeSize,
   getNativeFieldSize: getNativeFieldSize,

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -33,7 +33,3 @@ function getNativeTypeSize(type) {
     }
   }
 }
-
-function getNativeFieldSize(type) {
-  return Math.max(getNativeTypeSize(type), POINTER_SIZE);
-}


### PR DESCRIPTION
This function had exactly one callsite, where its wasn't serving any useful purpose:

```
if (!WASM_BIGINT && getNativeFieldSize(type) > 4 && type == 'i64') {
```

Here the second clause in the condition would always return true when `type` in `i64` making the redundant in the face the third clause.  This is because `getNativeFieldSize('i64')` always returns 8.