### PR TITLE
Assert if splitI64 used when WASM_BIGINT is enabled. NFC

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -223,6 +223,7 @@ function splitI64(value) {
   // For negatives, we need to ensure a -1 if the value is overall negative,
   // even if not significant negative component
 
+  assert(!WASM_BIGINT, 'splitI64 should not be used when WASM_BIGINT is enabled');
   const low = value + '>>>0';
   const high = makeInlineCalculation(
       asmCoercion('Math.abs(VALUE)', 'double') + ' >= ' + asmEnsureFloat('1', 'double') + ' ? ' +


### PR DESCRIPTION
At least today, the idea is that this should never be used when WASM_BIGINT is enabled.