### PR TITLE
Remove fallback to BlobBuilder if Blob constructor is missing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 3.1.38 (in development)
 -----------------------
+- Remove extra code for falling back to long-deprecated BlobBuilder browser API
+  when Blob constructor is missing.  This was a fix for an issue that has long
+  been fixed. (#19277)
 
 3.1.37 - 04/26/23
 -----------------

--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -171,10 +171,6 @@ var wakaUnknownAfter;
  * @suppress {undefinedVars}
  */
 var wakaUnknownBefore;
-/**
- * @suppress {undefinedVars}
- */
-var MozBlobBuilder;
 
 // Module loaders externs, for AMD etc.
 

--- a/src/headless.js
+++ b/src/headless.js
@@ -295,19 +295,6 @@ if (typeof console == "undefined") {
     }
   };
 }
-var MozBlobBuilder = () => {
-  this.data = new Uint8Array(0);
-  this.append = function(buffer) {
-    var data = new Uint8Array(buffer);
-    var combined = new Uint8Array(this.data.length + data.length);
-    combined.set(this.data);
-    combined.set(data, this.data.length);
-    this.data = combined;
-  };
-  this.getBlob = function() {
-    return this.data.buffer; // return the buffer as a "blob". XXX We might need to change this if it is not opaque
-  };
-};
 
 // additional setup
 if (!Module['canvas']) {

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -105,15 +105,6 @@ var LibraryBrowser = {
 
       if (Browser.initted) return;
       Browser.initted = true;
-
-      try {
-        new Blob();
-        Browser.hasBlobConstructor = true;
-      } catch(e) {
-        Browser.hasBlobConstructor = false;
-        err("warning: no blob constructor, cannot create blobs with mimetypes");
-      }
-      Browser.BlobBuilder = typeof MozBlobBuilder != "undefined" ? MozBlobBuilder : (typeof WebKitBlobBuilder != "undefined" ? WebKitBlobBuilder : (!Browser.hasBlobConstructor ? err("warning: no BlobBuilder") : null));
       Browser.URLObject = typeof window != "undefined" ? (window.URL ? window.URL : window.webkitURL) : undefined;
       if (!Module.noImageDecoding && typeof Browser.URLObject == 'undefined') {
         err("warning: Browser does not support creating object URLs. Built-in browser image decoding will not be available.");
@@ -133,22 +124,10 @@ var LibraryBrowser = {
         return !Module.noImageDecoding && /\.(jpg|jpeg|png|bmp)$/i.test(name);
       };
       imagePlugin['handle'] = function imagePlugin_handle(byteArray, name, onload, onerror) {
-        var b = null;
-        if (Browser.hasBlobConstructor) {
-          try {
-            b = new Blob([byteArray], { type: Browser.getMimetype(name) });
-            if (b.size !== byteArray.length) { // Safari bug #118630
-              // Safari's Blob can only take an ArrayBuffer
-              b = new Blob([(new Uint8Array(byteArray)).buffer], { type: Browser.getMimetype(name) });
-            }
-          } catch(e) {
-            warnOnce('Blob constructor present but fails: ' + e + '; falling back to blob builder');
-          }
-        }
-        if (!b) {
-          var bb = new Browser.BlobBuilder();
-          bb.append((new Uint8Array(byteArray)).buffer); // we need to pass a buffer, and must copy the array to get the right data range
-          b = bb.getBlob();
+        var b = new Blob([byteArray], { type: Browser.getMimetype(name) });
+        if (b.size !== byteArray.length) { // Safari bug #118630
+          // Safari's Blob can only take an ArrayBuffer
+          b = new Blob([(new Uint8Array(byteArray)).buffer], { type: Browser.getMimetype(name) });
         }
         var url = Browser.URLObject.createObjectURL(b);
 #if ASSERTIONS
@@ -192,56 +171,48 @@ var LibraryBrowser = {
           preloadedAudios[name] = new Audio(); // empty shim
           if (onerror) onerror();
         }
-        if (Browser.hasBlobConstructor) {
-          try {
-            var b = new Blob([byteArray], { type: Browser.getMimetype(name) });
-          } catch(e) {
-            return fail();
-          }
-          var url = Browser.URLObject.createObjectURL(b); // XXX we never revoke this!
+        var b = new Blob([byteArray], { type: Browser.getMimetype(name) });
+        var url = Browser.URLObject.createObjectURL(b); // XXX we never revoke this!
 #if ASSERTIONS
-          assert(typeof url == 'string', 'createObjectURL must return a url as a string');
+        assert(typeof url == 'string', 'createObjectURL must return a url as a string');
 #endif
-          var audio = new Audio();
-          audio.addEventListener('canplaythrough', () => finish(audio), false); // use addEventListener due to chromium bug 124926
-          audio.onerror = function audio_onerror(event) {
-            if (done) return;
-            err('warning: browser could not fully decode audio ' + name + ', trying slower base64 approach');
-            function encode64(data) {
-              var BASE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-              var PAD = '=';
-              var ret = '';
-              var leftchar = 0;
-              var leftbits = 0;
-              for (var i = 0; i < data.length; i++) {
-                leftchar = (leftchar << 8) | data[i];
-                leftbits += 8;
-                while (leftbits >= 6) {
-                  var curr = (leftchar >> (leftbits-6)) & 0x3f;
-                  leftbits -= 6;
-                  ret += BASE[curr];
-                }
+        var audio = new Audio();
+        audio.addEventListener('canplaythrough', () => finish(audio), false); // use addEventListener due to chromium bug 124926
+        audio.onerror = function audio_onerror(event) {
+          if (done) return;
+          err('warning: browser could not fully decode audio ' + name + ', trying slower base64 approach');
+          function encode64(data) {
+            var BASE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+            var PAD = '=';
+            var ret = '';
+            var leftchar = 0;
+            var leftbits = 0;
+            for (var i = 0; i < data.length; i++) {
+              leftchar = (leftchar << 8) | data[i];
+              leftbits += 8;
+              while (leftbits >= 6) {
+                var curr = (leftchar >> (leftbits-6)) & 0x3f;
+                leftbits -= 6;
+                ret += BASE[curr];
               }
-              if (leftbits == 2) {
-                ret += BASE[(leftchar&3) << 4];
-                ret += PAD + PAD;
-              } else if (leftbits == 4) {
-                ret += BASE[(leftchar&0xf) << 2];
-                ret += PAD;
-              }
-              return ret;
             }
-            audio.src = 'data:audio/x-' + name.substr(-3) + ';base64,' + encode64(byteArray);
-            finish(audio); // we don't wait for confirmation this worked - but it's worth trying
-          };
-          audio.src = url;
-          // workaround for chrome bug 124926 - we do not always get oncanplaythrough or onerror
-          safeSetTimeout(() => {
-            finish(audio); // try to use it even though it is not necessarily ready to play
-          }, 10000);
-        } else {
-          return fail();
-        }
+            if (leftbits == 2) {
+              ret += BASE[(leftchar&3) << 4];
+              ret += PAD + PAD;
+            } else if (leftbits == 4) {
+              ret += BASE[(leftchar&0xf) << 2];
+              ret += PAD;
+            }
+            return ret;
+          }
+          audio.src = 'data:audio/x-' + name.substr(-3) + ';base64,' + encode64(byteArray);
+          finish(audio); // we don't wait for confirmation this worked - but it's worth trying
+        };
+        audio.src = url;
+        // workaround for chrome bug 124926 - we do not always get oncanplaythrough or onerror
+        safeSetTimeout(() => {
+          finish(audio); // try to use it even though it is not necessarily ready to play
+        }, 10000);
       };
       Module['preloadPlugins'].push(audioPlugin);
 

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -635,11 +635,7 @@ def generate_js(data_target, data_files, metadata):
           Module['FS_createPreloadedFile'](this.name, null, byteArray, true, true, function() {
             Module['removeRunDependency']('fp ' + that.name);
           }, function() {
-            if (that.audio) {
-              Module['removeRunDependency']('fp ' + that.name); // workaround for chromium bug 124926 (still no audio with this, but at least we don't hang)
-            } else {
-              err('Preloading file ' + that.name + ' failed');
-            }
+            err('Preloading file ' + that.name + ' failed');
           }, false, true); // canOwn this data in the filesystem, it is a slide into the heap that will never change\n'''
     create_data = '''// canOwn this data in the filesystem, it is a slide into the heap that will never change
           Module['FS_createDataFile'](this.name, null, byteArray, true, true, true);


### PR DESCRIPTION
This code for handling the absence of Blob constructor goes back to 2012: a97aab0522858f3e24ab96fe93e7be9e2b976878

I'm pretty sure there is nobody depending on this today.  I think we would have to go back to chrome 32 or firefox 14 or safari 6 in order to actually need this: https://caniuse.com/blobbuilder

I noticed this looked like it should be removed when following the link in tools/file_packager.py to https://crbug.com/124926, which was marked as WontFix over 10 years ago.