### PR TITLE
Correctly instrument ASYNCIFY_IMPORTS with a wildcard

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -38,15 +38,15 @@ mergeInto(LibraryManager.library, {
 #if ASYNCIFY_DEBUG
       dbg('asyncify instrumenting imports');
 #endif
-      var ASYNCIFY_IMPORTS = {{{ JSON.stringify(ASYNCIFY_IMPORTS.map((x) => x.split('.')[1])) }}};
+      var importPatterns = [{{{ ASYNCIFY_IMPORTS.map(x => new RegExp('^' + x.split('.')[1].replaceAll('*', '.*') + '$')) }}}];
+
       for (var x in imports) {
         (function(x) {
           var original = imports[x];
           var sig = original.sig;
           if (typeof original == 'function') {
             var isAsyncifyImport = original.isAsync ||
-                                   ASYNCIFY_IMPORTS.indexOf(x) >= 0 ||
-                                   x.startsWith('__asyncjs__');
+                                   importPatterns.some(pattern => !!x.match(pattern));
 #if ASYNCIFY == 2
             // Wrap async imports with a suspending WebAssembly function.
             if (isAsyncifyImport) {

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3412,6 +3412,7 @@ Module["preRun"].push(function () {
   # To make the test more precise we also use ASYNCIFY_IGNORE_INDIRECT here.
   @parameterized({
     'normal': (['-sASYNCIFY_IMPORTS=[sync_tunnel, sync_tunnel_bool]'],), # noqa
+    'pattern_imports': (['-sASYNCIFY_IMPORTS=[sync_tun*]'],), # noqa
     'response': (['-sASYNCIFY_IMPORTS=@filey.txt'],), # noqa
     'nothing': (['-DBAD'],), # noqa
     'empty_list': (['-DBAD', '-sASYNCIFY_IMPORTS=[]'],), # noqa


### PR DESCRIPTION
Wildcard was incorrectly handled, as only verbatim matches were accepted in Asyncify.instrumentWasmImports for imports listed in ASYNCIFY_IMPORTS, even though the collection also contains wildcards. Those were ignored, but are now transformed to suitable RegExes.

Also, don't single out __asyncjs__ as __asyncjs__* is already added as a default to ASYNCIFY_IMPORTS by emcc.py. Since now the wildcard will work correctly, there's no need to double-check for the prefix when determining if an import is an asyncify import.