### PR TITLE
Optimize code size of dynCall() when MEMORY64 is used, and add a memory size limit check.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2486,6 +2486,8 @@ def phase_linker_setup(options, state, newargs):
   def check_memory_setting(setting):
     if settings[setting] % webassembly.WASM_PAGE_SIZE != 0:
       exit_with_error(f'{setting} must be a multiple of WebAssembly page size (64KiB), was {settings[setting]}')
+    if settings[setting] >= 2**53:
+      exit_with_error(f'{setting} must be smaller than 2^53 bytes due to JS Numbers (doubles) being used to hold pointer addresses in JS side')
 
   check_memory_setting('INITIAL_MEMORY')
   check_memory_setting('MAXIMUM_MEMORY')

--- a/src/library.js
+++ b/src/library.js
@@ -3255,7 +3255,7 @@ mergeInto(LibraryManager.library, {
     // With MEMORY64 we have an additional step to convert `p` arguments to
     // bigint. This is the runtime equivalent of the wrappers we create for wasm
     // exports in `emscripten.py:create_wasm64_wrappers`.
-    for(var i = 1; i < sig.length; ++i) {
+    for (var i = 1; i < sig.length; ++i) {
       if (sig[i] == 'p') args[i-1] = BigInt(args[i-1]);
     }
 #endif

--- a/src/library.js
+++ b/src/library.js
@@ -3252,27 +3252,20 @@ mergeInto(LibraryManager.library, {
     assert(getWasmTableEntry(ptr), 'missing table entry in dynCall: ' + ptr);
 #endif
 #if MEMORY64
-    // With MEMORY64 we have an additional step to covert `p` arguments to
+    // With MEMORY64 we have an additional step to convert `p` arguments to
     // bigint. This is the runtime equivalent of the wrappers we create for wasm
     // exports in `emscripten.py:create_wasm64_wrappers`.
-    if (sig.includes('p')) {
-      var new_args = [];
-      args.forEach((arg, index) => {
-        if (sig[index + 1] == 'p') {
-          arg = BigInt(arg);
-        }
-        new_args.push(arg);
-      });
-      args = new_args;
+    for(let i = 0; i < sig.length; ++i) {
+      if (sig[i] == 'p') args[i] = BigInt(args[i]);
     }
 #endif
-    var rtn = getWasmTableEntry(ptr).apply(null, args);
+    let rtn = getWasmTableEntry(ptr)(...args);
 #if MEMORY64
-    if (sig[0] == 'p') {
-      rtn = Number(rtn);
-    }
-#endif
+    return sig[0] == 'p' ? Number(rtn) : rtn;
+#else
     return rtn;
+#endif
+
 #endif
   },
 

--- a/src/library.js
+++ b/src/library.js
@@ -248,7 +248,7 @@ mergeInto(LibraryManager.library, {
 #endif
     }
 
-    let alignUp = (x, multiple) => x + (multiple - x % multiple) % multiple;
+    var alignUp = (x, multiple) => x + (multiple - x % multiple) % multiple;
 
     // Loop through potential heap size increases. If we attempt a too eager
     // reservation that fails, cut down on the attempted size and reserve a
@@ -3255,11 +3255,11 @@ mergeInto(LibraryManager.library, {
     // With MEMORY64 we have an additional step to convert `p` arguments to
     // bigint. This is the runtime equivalent of the wrappers we create for wasm
     // exports in `emscripten.py:create_wasm64_wrappers`.
-    for(let i = 0; i < sig.length; ++i) {
+    for(var i = 0; i < sig.length; ++i) {
       if (sig[i] == 'p') args[i] = BigInt(args[i]);
     }
 #endif
-    let rtn = getWasmTableEntry(ptr)(...args);
+    var rtn = getWasmTableEntry(ptr).apply(null, args);
 #if MEMORY64
     return sig[0] == 'p' ? Number(rtn) : rtn;
 #else
@@ -3668,7 +3668,7 @@ mergeInto(LibraryManager.library, {
       return this.allocated[id];
     };
     this.allocate = function(handle) {
-      let id = this.freelist.pop() || this.allocated.length;
+      var id = this.freelist.pop() || this.allocated.length;
       this.allocated[id] = handle;
       return id;
     };

--- a/src/library.js
+++ b/src/library.js
@@ -3255,8 +3255,8 @@ mergeInto(LibraryManager.library, {
     // With MEMORY64 we have an additional step to convert `p` arguments to
     // bigint. This is the runtime equivalent of the wrappers we create for wasm
     // exports in `emscripten.py:create_wasm64_wrappers`.
-    for(var i = 0; i < sig.length; ++i) {
-      if (sig[i] == 'p') args[i] = BigInt(args[i]);
+    for(var i = 1; i < sig.length; ++i) {
+      if (sig[i] == 'p') args[i-1] = BigInt(args[i-1]);
     }
 #endif
     var rtn = getWasmTableEntry(ptr).apply(null, args);


### PR DESCRIPTION
Two small updates to MEMORY64 mode.