### PR TITLE
Add Opera as a browser that supports JSPI

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -149,8 +149,11 @@ def shell_with_script(shell_file, output_file, replacement):
   create_file(output_file, shell.replace('{{{ SCRIPT }}}', replacement))
 
 
+CHROMIUM_BASED_BROWSERS = ['chrom', 'edge', 'opera']
+
+
 def is_chrome():
-  return EMTEST_BROWSER and 'chrom' in EMTEST_BROWSER.lower()
+  return EMTEST_BROWSER and any(pattern in EMTEST_BROWSER.lower() for pattern in CHROMIUM_BASED_BROWSERS)
 
 
 def no_chrome(note='chrome is not supported'):
@@ -3350,7 +3353,7 @@ Module["preRun"].push(function () {
   })
   def test_async(self, args):
     if is_jspi(args) and not is_chrome():
-      self.skipTest('only chrome supports jspi')
+      self.skipTest(f'Current browser ({EMTEST_BROWSER}) does not support JSPI. Only chromium-based browsers ({CHROMIUM_BASED_BROWSERS}) support JSPI today.')
 
     for opts in [0, 1, 2, 3]:
       print(opts)


### PR DESCRIPTION
Opera is Chromium-based, so it also supports JSPI (since O96). Use the current simple detection algorithm based on executable full path part pattern detection, but extend it with a new pattern for Opera.

Also, print the available options for running test_async when a JSPI-capable browser was not provided.