### PR TITLE
Add test for `--preload-file` + `--closure=1`. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1743,6 +1743,7 @@ int f() {
     'embed': (['--embed-file', 'somefile.txt'],),
     'embed_twice': (['--embed-file', 'somefile.txt', '--embed-file', 'somefile.txt'],),
     'preload': (['--preload-file', 'somefile.txt'],),
+    'preload_closure': (['--preload-file', 'somefile.txt', '-O2', '--closure=1'],),
     'preload_and_embed': (['--preload-file', 'somefile.txt', '--embed-file', 'hello.txt'],)
   })
   @requires_node


### PR DESCRIPTION
I ran into the lack of testing (at least under node) of this config
recently.   In this case the output of file_packager is include as
a pre-js so it ends up going through closure compiler.