### PR TITLE
Stop requiring DYNAMIC_EXECUTION when building with RELOCATABLE

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 3.1.38 (in development)
 -----------------------
+- The restriction preventing the use of dynamic linking in combination with
+  `-sDYNAMIC_EXECUTION=0` was removed.  This restriction was being enforced
+  unnecessarily since dynamic linking has not depended on `eval()` for a while
+  now.
 - Remove extra code for falling back to long-deprecated BlobBuilder browser API
   when Blob constructor is missing.  This was a fix for an issue that has long
   been fixed. (#19277)

--- a/emcc.py
+++ b/emcc.py
@@ -2359,9 +2359,6 @@ def phase_linker_setup(options, state, newargs):
     # llvm change lands
     settings.EXPORT_IF_DEFINED.append('__wasm_apply_data_relocs')
 
-  if settings.RELOCATABLE and not settings.DYNAMIC_EXECUTION:
-    exit_with_error('cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()')
-
   if settings.SIDE_MODULE and 'GLOBAL_BASE' in user_settings:
     exit_with_error('GLOBAL_BASE is not compatible with SIDE_MODULE')
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -4584,10 +4584,8 @@ int main() {
     self.assertNotContained('new Function', src)
     delete_file('a.out.js')
 
-    # Test that -sDYNAMIC_EXECUTION and -sRELOCATABLE are not allowed together.
-    self.expect_fail([EMCC, test_file('hello_world.c'), '-O1',
-                      '-sDYNAMIC_EXECUTION=0', '-sRELOCATABLE'])
-    delete_file('a.out.js')
+    # Test that -sDYNAMIC_EXECUTION=0 and -sRELOCATABLE are allowed together.
+    self.do_runf(test_file('hello_world.c'), emcc_args=['-O1', '-sDYNAMIC_EXECUTION=0', '-sRELOCATABLE'])
 
     create_file('test.c', r'''
       #include <emscripten/emscripten.h>


### PR DESCRIPTION
I tracked this error all the way back to when it was first added back in 2015: 38157ef59e42b01078164098154baf78afbf8fc7.

Its not longer true that `loadDynamicLibrary` requires `eval()`.

It is true that if you have EM_ASM in your side modules that would require `eval()` but that usage is guarded using the `makeEval` helper (and also not common).