### PR TITLE
fix: make _PYTHON_SYSCONFIGDATA_NAME available to cmake

### DIFF
--- a/emcmake
+++ b/emcmake
@@ -12,8 +12,12 @@
 # `tools/create_entry_points.py`
 
 # $PYTHON -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal
-# of cpython used in cross compilation via setup.py.
+# of cpython used in cross compilation via setup.py. Pass it through our
+# own internal variable.
+set _EMCMAKE_PYTHON_SYSCONFIGDATA_NAMES "$_PYTHON_SYSCONFIGDATA_NAMES"
 unset _PYTHON_SYSCONFIGDATA_NAME
+
+
 
 if [ -z "$PYTHON" ]; then
   PYTHON=$EMSDK_PYTHON

--- a/emcmake.bat
+++ b/emcmake.bat
@@ -11,7 +11,9 @@
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal
-:: of cpython used in cross compilation via setup.py.
+:: of cpython used in cross compilation via setup.py. Pass it through our
+:: own internal variable.
+@set _EMCMAKE_PYTHON_SYSCONFIGDATA_NAMES="%_PYTHON_SYSCONFIGDATA_NAMES%"
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (

--- a/emcmake.py
+++ b/emcmake.py
@@ -27,6 +27,9 @@ variables so that emcc etc. are used. Typical usage:
 
   args = sys.argv[1:]
 
+  # Restore removed SYSCONFIG settings so they will be present in the CMake environment
+  os.environ["_PYTHON_SYSCONFIGDATA_NAME"] = os.environ["_EMCMAKE_PYTHON_SYSCONFIGDATA_NAME"]
+
   def has_substr(args, substr):
     return any(substr in s for s in args)
 


### PR DESCRIPTION
Cross compiling Python modules is broken if they use CMake to build, due to FindPython (and other libs like pybind11's config) not being able to get the correct cross-compiling values from sysconfig.

This is a suggested fix which allows `emcmake.py` to run by passing the value through and restoring it after Python starts up.

Personally not a fan of wrappers - most of the values here can be set via environment variables (`CMAKE_TOOLCHAIN_FILE` and `CMAKE_GENERATOR`), only `CMAKE_CROSSCOMPILING_EMULATOR` is technically needed AFAICT.

CC @hoodmane, this is a fix I suggested on Gitter.