### PR TITLE
Avoid using String.replaceAll at compile time. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,6 +577,7 @@ jobs:
             other.test_gen_struct_info
             other.test_native_call_before_init
             other.test_node_unhandled_rejection
+            other.test_full_js_library
             core2.test_hello_world"
       # Run a few test with the most recent version of node
       # In particular we have some tests that require node flags on older

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -38,7 +38,7 @@ mergeInto(LibraryManager.library, {
 #if ASYNCIFY_DEBUG
       dbg('asyncify instrumenting imports');
 #endif
-      var importPatterns = [{{{ ASYNCIFY_IMPORTS.map(x => new RegExp('^' + x.split('.')[1].replaceAll('*', '.*') + '$')) }}}];
+      var importPatterns = [{{{ ASYNCIFY_IMPORTS.map(x => '/^' + x.split('.')[1].replace(new RegExp('\\*', 'g'), '.*') + '$/') }}}];
 
       for (var x in imports) {
         (function(x) {

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8666,7 +8666,7 @@ end
     self.assertNotContained(WARNING, proc.stderr)
 
   def test_full_js_library(self):
-    self.run_process([EMCC, test_file('hello_world.c'), '-sSTRICT_JS', '-sINCLUDE_FULL_LIBRARY'])
+    self.run_process([EMCC, test_file('hello_world.c'), '-sSTRICT_JS', '-sINCLUDE_FULL_LIBRARY', '-sASYNCIFY'])
 
   def test_full_js_library_undefined(self):
     create_file('main.c', 'void foo(); int main() { foo(); return 0; }')


### PR DESCRIPTION
This requires node v15, and we still support running on older versions.

See #19280