### PR TITLE
[WasmFS] Gracefully error when moving OPFS directory

### DIFF
--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -189,13 +189,14 @@ mergeInto(LibraryManager.library, {
     wasmfsOPFSProxyFinish(ctx);
   },
 
-  _wasmfs_opfs_move__sig: 'vpiipp',
-  _wasmfs_opfs_move__deps: ['$wasmfsOPFSFileHandles',
-                            '$wasmfsOPFSDirectoryHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_move: async function(ctx, fileID, newDirID, namePtr, errPtr) {
+  _wasmfs_opfs_move_file__sig: 'vpiipp',
+  _wasmfs_opfs_move_file__deps: ['$wasmfsOPFSFileHandles',
+                                 '$wasmfsOPFSDirectoryHandles',
+                                 '$wasmfsOPFSProxyFinish'],
+  _wasmfs_opfs_move_file: async function(ctx, fileID, newParentID, namePtr, errPtr) {
     let name = UTF8ToString(namePtr);
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
-    let newDirHandle = wasmfsOPFSDirectoryHandles.get(newDirID);
+    let newDirHandle = wasmfsOPFSDirectoryHandles.get(newParentID);
     try {
       await fileHandle.move(newDirHandle, name);
     } catch {

--- a/test/wasmfs/wasmfs_opfs_errors.c
+++ b/test/wasmfs/wasmfs_opfs_errors.c
@@ -4,6 +4,7 @@
 #include <emscripten/wasmfs.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -118,6 +119,25 @@ int try_oob_write(void) {
   }
   emscripten_console_error(strerror(errno));
   close(fd);
+  return 2;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int try_rename_dir(void) {
+  int err = mkdir("/opfs/dir1", 0666);
+  if (err != 0) {
+    return 2;
+  }
+  err = rename("/opfs/dir1", "/opfs/dir2");
+  if (err == 0) {
+    return 1;
+  }
+  if (errno == EBUSY) {
+    rmdir("/opfs/dir1");
+    return 0;
+  }
+  emscripten_console_error(strerror(errno));
+  rmdir("/opfs/dir1");
   return 2;
 }
 

--- a/test/wasmfs/wasmfs_opfs_errors_post.js
+++ b/test/wasmfs/wasmfs_opfs_errors_post.js
@@ -66,5 +66,9 @@ async function run_test() {
           "nothing prevents it)";
   }
 
+  if (Module._try_rename_dir() != 0) {
+    throw "Did not get expected EBUSY while renaming directory";
+  }
+
   Module._report_result(0);
 }


### PR DESCRIPTION
The OPFS API does not yet support moving directories. When user code tried to
move a directory using the OPFS backend, we previously crashed because the
backend implementation incorrectly assumed that the moved file was a data file.
Fix the crash by returning EBUSY instead in that case.