### PR TITLE
Enable wasm workers to run under node

### DIFF
--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -139,7 +139,7 @@ mergeInto(LibraryManager.library, {
       'sb': stackLowestAddress, // sb = stack bottom (lowest stack address, SP points at this when stack is full)
       'sz': stackSize,          // sz = stack size
     });
-    worker.addEventListener('message', __wasm_worker_runPostMessage);
+    worker.onmessage = __wasm_worker_runPostMessage;
     return _wasm_workers_id++;
   },
 

--- a/src/shell.js
+++ b/src/shell.js
@@ -263,7 +263,7 @@ if (ENVIRONMENT_IS_NODE) {
 
   Module['inspect'] = () => '[Emscripten Module object]';
 
-#if PTHREADS
+#if PTHREADS || WASM_WORKERS
   let nodeWorkerThreads;
   try {
     nodeWorkerThreads = require('worker_threads');

--- a/test/code_size/hello_wasm_worker_wasm.js
+++ b/test/code_size/hello_wasm_worker_wasm.js
@@ -28,7 +28,7 @@ WebAssembly.instantiate(b.wasm, {
                 sb: a,
                 sz: d
             });
-            r.addEventListener("message", n);
+            r.onmessage = n;
             return k++;
         },
         c: function() {

--- a/test/code_size/hello_wasm_worker_wasm.json
+++ b/test/code_size/hello_wasm_worker_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 737,
   "a.html.gz": 433,
-  "a.js": 733,
-  "a.js.gz": 463,
+  "a.js": 715,
+  "a.js.gz": 465,
   "a.wasm": 1862,
   "a.wasm.gz": 1040,
-  "total": 3332,
-  "total_gz": 1936
+  "total": 3314,
+  "total_gz": 1938
 }

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9761,6 +9761,14 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.run_process([FILE_PACKAGER, 'test.data', '--preload', 'file1.txt', 'file2.txt', '--from-emcc', '--js-output=script2.js'])
     self.do_runf(test_file('test_emscripten_async_load_script.c'), emcc_args=['-sFORCE_FILESYSTEM'])
 
+  @node_pthreads
+  def test_wasm_worker_hello(self):
+    self.do_runf(test_file('wasm_worker/hello_wasm_worker.c'), emcc_args=['-sWASM_WORKERS'])
+
+  @node_pthreads
+  def test_wasm_worker_malloc(self):
+    self.do_runf(test_file('wasm_worker/malloc_wasm_worker.c'), emcc_args=['-sWASM_WORKERS'])
+
 
 # Generate tests for everything
 def make_run(name, emcc_args, settings=None, env=None,


### PR DESCRIPTION
This means we can run the tests without depending on the browser.