### PR TITLE
Bind `err` to `console.error` rather than `console.warn`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 3.1.39 (in development)
 -----------------------
+- The JS `err()` function will now bind to `console.error` by default rather
+  than `console.warning`.  For debugging/tracing/logging we recommend the
+  `dbg()` function instead. (#19326)
 
 3.1.38 - 05/10/23
 -----------------

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -167,7 +167,7 @@ function dbg(text) {
   } else
 #endif
   // TODO(sbc): Make this configurable somehow.  Its not always convenient for
-  // logging to show up as errors.
-  console.error.apply(console, arguments);
+  // logging to show up as warnings.
+  console.warn.apply(console, arguments);
 }
 #endif

--- a/src/shell.js
+++ b/src/shell.js
@@ -439,12 +439,12 @@ if (ENVIRONMENT_IS_NODE) {
 
 // Set up the out() and err() hooks, which are how we can print to stdout or
 // stderr, respectively.
-// Normally just binding console.log/console.warn here works fine, but
+// Normally just binding console.log/console.error here works fine, but
 // under node (with workers) we see missing/out-of-order messages so route
 // directly to stdout and stderr.
 // See https://github.com/emscripten-core/emscripten/issues/14804
 var defaultPrint = console.log.bind(console);
-var defaultPrintErr = console.warn.bind(console);
+var defaultPrintErr = console.error.bind(console);
 if (ENVIRONMENT_IS_NODE) {
   defaultPrint = (...args) => fs.writeSync(1, args.join(' ') + '\n');
   defaultPrintErr = (...args) => fs.writeSync(2, args.join(' ') + '\n');
@@ -453,7 +453,7 @@ if (ENVIRONMENT_IS_NODE) {
 {{{ makeModuleReceiveWithVar('err', 'printErr', 'defaultPrintErr', true) }}}
 #else
 {{{ makeModuleReceiveWithVar('out', 'print',    'console.log.bind(console)',  true) }}}
-{{{ makeModuleReceiveWithVar('err', 'printErr', 'console.warn.bind(console)', true) }}}
+{{{ makeModuleReceiveWithVar('err', 'printErr', 'console.error.bind(console)', true) }}}
 #endif
 
 // Merge back in the overrides


### PR DESCRIPTION
Now that we have `dbg()` for debug output (see #19126) we can redirect `err()` to `console.error()` so that folks who call `err()` will get a full stack trace in devtools.