### PR TITLE
Remove EM_JS version of `console_log` in test code. NFC

### DIFF
--- a/test/minimal_hello.c
+++ b/test/minimal_hello.c
@@ -1,11 +1,7 @@
-#include <emscripten.h>
-
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
+#include <emscripten/console.h>
 
 int main()
 {
-  console_log("minimal hello!");
+  emscripten_console_log("minimal hello!");
   return 0;
 }

--- a/test/wasm_worker/cancel_all_wait_asyncs.c
+++ b/test/wasm_worker/cancel_all_wait_asyncs.c
@@ -5,24 +5,20 @@
 
 // Test emscripten_atomic_cancel_all_wait_asyncs() function.
 
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
-
 volatile int32_t addr = 1;
 
 EM_BOOL testSucceeded = 1;
 
 void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
 {
-  console_log("asyncWaitFinishedShouldNotBeCalled");
+  emscripten_console_log("asyncWaitFinishedShouldNotBeCalled");
   testSucceeded = 0;
   assert(0); // We should not reach here
 }
 
 void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
 {
-  console_log("asyncWaitFinishedShouldBeCalled");
+  emscripten_console_log("asyncWaitFinishedShouldBeCalled");
 #ifdef REPORT_RESULT
   REPORT_RESULT(testSucceeded);
 #endif
@@ -30,51 +26,51 @@ void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RE
 
 int main()
 {
-  console_log("Async waiting on address should give a wait token");
+  emscripten_console_log("Async waiting on address should give a wait token");
   ATOMICS_WAIT_TOKEN_T ret = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 
-  console_log("Async waiting on address should give a wait token");
+  emscripten_console_log("Async waiting on address should give a wait token");
   ATOMICS_WAIT_TOKEN_T ret2 = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret2));
 
-  console_log("Canceling all async waits should return the number of waits cancelled");
+  emscripten_console_log("Canceling all async waits should return the number of waits cancelled");
   int numCancelled = emscripten_atomic_cancel_all_wait_asyncs();
   assert(numCancelled == 2);
 
-  console_log("Canceling an async wait that has already been cancelled should give an invalid param");
+  emscripten_console_log("Canceling an async wait that has already been cancelled should give an invalid param");
   EMSCRIPTEN_RESULT r = emscripten_atomic_cancel_wait_async(ret);
   assert(r == EMSCRIPTEN_RESULT_INVALID_PARAM);
 
-  console_log("Canceling an async wait that has already been cancelled should give an invalid param");
+  emscripten_console_log("Canceling an async wait that has already been cancelled should give an invalid param");
   r = emscripten_atomic_cancel_wait_async(ret2);
   assert(r == EMSCRIPTEN_RESULT_INVALID_PARAM);
 
-  console_log("Notifying an async wait should not trigger the callback function");
+  emscripten_console_log("Notifying an async wait should not trigger the callback function");
   int64_t numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
-  console_log("Notifying an async wait should return 0 threads woken");
+  emscripten_console_log("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
   addr = 2;
-  console_log("Notifying an async wait even after changed value should not trigger the callback function");
+  emscripten_console_log("Notifying an async wait even after changed value should not trigger the callback function");
   numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
-  console_log("Notifying an async wait should return 0 threads woken");
+  emscripten_console_log("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
-  console_log("Async waiting on address should give a wait token");
+  emscripten_console_log("Async waiting on address should give a wait token");
   ret = emscripten_atomic_wait_async((int32_t*)&addr, 2, asyncWaitFinishedShouldBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 
 #if 0
-  console_log("Notifying an async wait without value changing should still trigger the callback");
+  emscripten_console_log("Notifying an async wait without value changing should still trigger the callback");
   numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
   assert(numWoken == 1);
 #else
   // TODO: Switch to the above test instead after the Atomics.waitAsync() polyfill is dropped.
   addr = 3;
-  console_log("Notifying an async wait after value changing should trigger the callback");
+  emscripten_console_log("Notifying an async wait after value changing should trigger the callback");
   numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 #endif
 }

--- a/test/wasm_worker/cancel_all_wait_asyncs_at_address.c
+++ b/test/wasm_worker/cancel_all_wait_asyncs_at_address.c
@@ -5,24 +5,20 @@
 
 // Test emscripten_atomic_cancel_all_wait_asyncs() function.
 
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
-
 volatile int32_t addr = 1;
 
 EM_BOOL testSucceeded = 1;
 
 void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
 {
-  console_log("asyncWaitFinishedShouldNotBeCalled");
+  emscripten_console_log("asyncWaitFinishedShouldNotBeCalled");
   testSucceeded = 0;
   assert(0); // We should not reach here
 }
 
 void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
 {
-  console_log("asyncWaitFinishedShouldBeCalled");
+  emscripten_console_log("asyncWaitFinishedShouldBeCalled");
 #ifdef REPORT_RESULT
   REPORT_RESULT(testSucceeded);
 #endif
@@ -30,55 +26,55 @@ void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RE
 
 int main()
 {
-  console_log("Async waiting on address should give a wait token");
+  emscripten_console_log("Async waiting on address should give a wait token");
   ATOMICS_WAIT_TOKEN_T ret = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 
-  console_log("Async waiting on address should give a wait token");
+  emscripten_console_log("Async waiting on address should give a wait token");
   ATOMICS_WAIT_TOKEN_T ret2 = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret2));
 
-  console_log("Canceling all async waits at wait address should return the number of waits cancelled");
+  emscripten_console_log("Canceling all async waits at wait address should return the number of waits cancelled");
   int numCancelled = emscripten_atomic_cancel_all_wait_asyncs_at_address((int32_t*)&addr);
   assert(numCancelled == 2);
 
-  console_log("Canceling all async waits at some other address should return 0");
+  emscripten_console_log("Canceling all async waits at some other address should return 0");
   numCancelled = emscripten_atomic_cancel_all_wait_asyncs_at_address((int32_t*)0xbad);
   assert(numCancelled == 0);
 
-  console_log("Canceling an async wait that has already been cancelled should give an invalid param");
+  emscripten_console_log("Canceling an async wait that has already been cancelled should give an invalid param");
   EMSCRIPTEN_RESULT r = emscripten_atomic_cancel_wait_async(ret);
   assert(r == EMSCRIPTEN_RESULT_INVALID_PARAM);
 
-  console_log("Canceling an async wait that has already been cancelled should give an invalid param");
+  emscripten_console_log("Canceling an async wait that has already been cancelled should give an invalid param");
   r = emscripten_atomic_cancel_wait_async(ret2);
   assert(r == EMSCRIPTEN_RESULT_INVALID_PARAM);
 
-  console_log("Notifying an async wait should not trigger the callback function");
+  emscripten_console_log("Notifying an async wait should not trigger the callback function");
   int64_t numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
-  console_log("Notifying an async wait should return 0 threads woken");
+  emscripten_console_log("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
   addr = 2;
-  console_log("Notifying an async wait even after changed value should not trigger the callback function");
+  emscripten_console_log("Notifying an async wait even after changed value should not trigger the callback function");
   numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
-  console_log("Notifying an async wait should return 0 threads woken");
+  emscripten_console_log("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
-  console_log("Async waiting on address should give a wait token");
+  emscripten_console_log("Async waiting on address should give a wait token");
   ret = emscripten_atomic_wait_async((int32_t*)&addr, 2, asyncWaitFinishedShouldBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 
 #if 0
-  console_log("Notifying an async wait without value changing should still trigger the callback");
+  emscripten_console_log("Notifying an async wait without value changing should still trigger the callback");
   numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
   assert(numWoken == 1);
 #else
   // TODO: Switch to the above test instead after the Atomics.waitAsync() polyfill is dropped.
   addr = 3;
-  console_log("Notifying an async wait after value changing should trigger the callback");
+  emscripten_console_log("Notifying an async wait after value changing should trigger the callback");
   numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 #endif
 }

--- a/test/wasm_worker/cancel_wait_async.c
+++ b/test/wasm_worker/cancel_wait_async.c
@@ -5,24 +5,20 @@
 
 // Test emscripten_cancel_wait_async() function.
 
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
-
 volatile int32_t addr = 1;
 
 EM_BOOL testSucceeded = 1;
 
 void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
 {
-  console_log("asyncWaitFinishedShouldNotBeCalled");
+  emscripten_console_log("asyncWaitFinishedShouldNotBeCalled");
   testSucceeded = 0;
   assert(0); // We should not reach here
 }
 
 void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
 {
-  console_log("asyncWaitFinishedShouldBeCalled");
+  emscripten_console_log("asyncWaitFinishedShouldBeCalled");
 #ifdef REPORT_RESULT
   REPORT_RESULT(testSucceeded);
 #endif
@@ -30,43 +26,43 @@ void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RE
 
 int main()
 {
-  console_log("Async waiting on address should give a wait token");
+  emscripten_console_log("Async waiting on address should give a wait token");
   ATOMICS_WAIT_TOKEN_T ret = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 
-  console_log("Canceling an async wait should succeed");
+  emscripten_console_log("Canceling an async wait should succeed");
   EMSCRIPTEN_RESULT r = emscripten_atomic_cancel_wait_async(ret);
   assert(r == EMSCRIPTEN_RESULT_SUCCESS);
 
-  console_log("Canceling an async wait a second time should give invalid param");
+  emscripten_console_log("Canceling an async wait a second time should give invalid param");
   r = emscripten_atomic_cancel_wait_async(ret);
   assert(r == EMSCRIPTEN_RESULT_INVALID_PARAM);
 
-  console_log("Notifying an async wait should not trigger the callback function");
+  emscripten_console_log("Notifying an async wait should not trigger the callback function");
   int64_t numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
-  console_log("Notifying an async wait should return 0 threads woken");
+  emscripten_console_log("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
   addr = 2;
-  console_log("Notifying an async wait even after changed value should not trigger the callback function");
+  emscripten_console_log("Notifying an async wait even after changed value should not trigger the callback function");
   numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
-  console_log("Notifying an async wait should return 0 threads woken");
+  emscripten_console_log("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
-  console_log("Async waiting on address should give a wait token");
+  emscripten_console_log("Async waiting on address should give a wait token");
   ret = emscripten_atomic_wait_async((int32_t*)&addr, 2, asyncWaitFinishedShouldBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 
 #if 0
-  console_log("Notifying an async wait without value changing should still trigger the callback");
+  emscripten_console_log("Notifying an async wait without value changing should still trigger the callback");
   numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
   assert(numWoken == 1);
 #else
   // TODO: Switch to the above test instead after the Atomics.waitAsync() polyfill is dropped.
   addr = 3;
-  console_log("Notifying an async wait after value changing should trigger the callback");
+  emscripten_console_log("Notifying an async wait after value changing should trigger the callback");
   numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 #endif
 }

--- a/test/wasm_worker/lock_async_acquire.c
+++ b/test/wasm_worker/lock_async_acquire.c
@@ -6,10 +6,6 @@
 
 // Tests emscripten_lock_async_acquire() function.
 
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
-
 emscripten_lock_t lock = EMSCRIPTEN_LOCK_T_STATIC_INITIALIZER;
 
 // Two shared variables, always a delta distance of one from each other.
@@ -23,7 +19,7 @@ int numTimesWasmWorkerAcquiredLock = 0;
 
 void work()
 {
-//  console_log("work");
+//  emscripten_console_log("work");
   volatile int x = sharedState0;
   volatile int y = sharedState1;
   assert(x == y+1 || y == x+1);
@@ -51,7 +47,7 @@ void work()
     {
       if (!testFinished)
       {
-        console_log("test finished");
+        emscripten_console_log("test finished");
 #ifdef REPORT_RESULT
         REPORT_RESULT(0);
 #endif
@@ -65,7 +61,7 @@ void schedule_work(void *userData);
 
 void lock_async_acquired(volatile void *addr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
 {
-//  console_log("async lock acquired");
+//  emscripten_console_log("async lock acquired");
   assert(addr == &lock);
   assert(val == 0 || val == 1);
   assert(waitResult == ATOMICS_WAIT_OK);
@@ -82,7 +78,7 @@ void schedule_work(void *userData)
   if (emscripten_current_thread_is_wasm_worker() && emscripten_random() > 0.5)
   {
     emscripten_lock_waitinf_acquire(&lock);
-//    console_log("sync lock acquired");
+//    emscripten_console_log("sync lock acquired");
     work();
     emscripten_lock_release(&lock);
     if (!testFinished)

--- a/test/wasm_worker/lock_wait_acquire2.c
+++ b/test/wasm_worker/lock_wait_acquire2.c
@@ -6,38 +6,34 @@
 
 // Tests emscripten_lock_wait_acquire() between two Wasm Workers.
 
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
-
 emscripten_lock_t lock = EMSCRIPTEN_LOCK_T_STATIC_INITIALIZER;
 
 void worker1_main()
 {
-  console_log("worker1 main try_acquiring lock");
+  emscripten_console_log("worker1 main try_acquiring lock");
   EM_BOOL success = emscripten_lock_try_acquire(&lock); // Expect no contention on free lock.
-  console_log("worker1 try_acquire lock finished");
+  emscripten_console_log("worker1 try_acquire lock finished");
   assert(success);
-  console_log("worker1 try_acquire lock success, sleeping 1000 msecs");
+  emscripten_console_log("worker1 try_acquire lock success, sleeping 1000 msecs");
   emscripten_wasm_worker_sleep(1000 * 1000000ull);
 
-  console_log("worker1 slept 1000 msecs, releasing lock");
+  emscripten_console_log("worker1 slept 1000 msecs, releasing lock");
   emscripten_lock_release(&lock);
-  console_log("worker1 released lock");
+  emscripten_console_log("worker1 released lock");
 }
 
 void worker2_main()
 {
-  console_log("worker2 main sleeping 500 msecs");
+  emscripten_console_log("worker2 main sleeping 500 msecs");
   emscripten_wasm_worker_sleep(500 * 1000000ull);
-  console_log("worker2 slept 500 msecs, try_acquiring lock");
+  emscripten_console_log("worker2 slept 500 msecs, try_acquiring lock");
   EM_BOOL success = emscripten_lock_try_acquire(&lock); // At this time, the other thread should have the lock.
-  console_log("worker2 try_acquire lock finished");
+  emscripten_console_log("worker2 try_acquire lock finished");
   assert(!success);
 
   // Wait enough time to cover over the time that the other thread held the lock.
   success = emscripten_lock_wait_acquire(&lock, 2000 * 1000000ull);
-  console_log("worker2 wait_acquired lock");
+  emscripten_console_log("worker2 wait_acquired lock");
   assert(success);
 
 #ifdef REPORT_RESULT

--- a/test/wasm_worker/malloc_wasm_worker.c
+++ b/test/wasm_worker/malloc_wasm_worker.c
@@ -4,13 +4,9 @@
 
 // Test emscripten_malloc_wasm_worker() and emscripten_current_thread_is_wasm_worker() functions
 
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
-
 void worker_main()
 {
-  console_log("Hello from wasm worker!");
+  emscripten_console_log("Hello from wasm worker!");
   assert(emscripten_current_thread_is_wasm_worker());
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);

--- a/test/wasm_worker/post_function.c
+++ b/test/wasm_worker/post_function.c
@@ -4,28 +4,24 @@
 
 // Test emscripten_wasm_worker_post_function_*() API
 
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
-
 volatile int success = 0;
 
 void v()
 {
-  console_log("v");
+  emscripten_console_log("v");
   ++success;
 }
 
 void vi(int i)
 {
-  console_log("vi");
+  emscripten_console_log("vi");
   assert(i == 1);
   ++success;
 }
 
 void vii(int i, int j)
 {
-  console_log("vii");
+  emscripten_console_log("vii");
   assert(i == 2);
   assert(j == 3);
   ++success;
@@ -33,7 +29,7 @@ void vii(int i, int j)
 
 void viii(int i, int j, int k)
 {
-  console_log("viii");
+  emscripten_console_log("viii");
   assert(i == 4);
   assert(j == 5);
   assert(k == 6);
@@ -42,14 +38,14 @@ void viii(int i, int j, int k)
 
 void vd(double i)
 {
-  console_log("vd");
+  emscripten_console_log("vd");
   assert(i == 1.5);
   ++success;
 }
 
 void vdd(double i, double j)
 {
-  console_log("vdd");
+  emscripten_console_log("vdd");
   assert(i == 2.5);
   assert(j == 3.5);
   ++success;
@@ -57,7 +53,7 @@ void vdd(double i, double j)
 
 void vddd(double i, double j, double k)
 {
-  console_log("vddd");
+  emscripten_console_log("vddd");
   assert(i == 4.5);
   assert(j == 5.5);
   assert(k == 6.5);
@@ -66,7 +62,7 @@ void vddd(double i, double j, double k)
 
 void viiiiiidddddd(int a, int b, int c, int d, int e, int f, double g, double h, double i, double j, double k, double l)
 {
-  console_log("viiiiiidddddd");
+  emscripten_console_log("viiiiiidddddd");
   assert(a == 10);
   assert(b == 11);
   assert(c == 12);

--- a/test/wasm_worker/post_function_to_main_thread.c
+++ b/test/wasm_worker/post_function_to_main_thread.c
@@ -5,13 +5,9 @@
 // Test emscripten_wasm_worker_post_function_*() API and EMSCRIPTEN_WASM_WORKER_ID_PARENT
 // to send a message back from Worker to its parent thread.
 
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
-
 void test_success(int i, double d)
 {
-  console_log("test_success");
+  emscripten_console_log("test_success");
   assert(!emscripten_current_thread_is_wasm_worker());
   assert(i == 10);
   assert(d == 0.5);
@@ -22,7 +18,7 @@ void test_success(int i, double d)
 
 void worker_main()
 {
-  console_log("worker_main");
+  emscripten_console_log("worker_main");
   assert(emscripten_current_thread_is_wasm_worker());
   emscripten_wasm_worker_post_function_sig(EMSCRIPTEN_WASM_WORKER_ID_PARENT, test_success, "id", 10, 0.5);
 }

--- a/test/wasm_worker/semaphore_try_acquire.c
+++ b/test/wasm_worker/semaphore_try_acquire.c
@@ -6,32 +6,28 @@
 
 // Tests emscripten_semaphore_try_acquire() on the main thread
 
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
-
 emscripten_semaphore_t unavailable = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(0);
 emscripten_semaphore_t available = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(1);
 
 int main()
 {
-  console_log("try_acquiring unavailable semaphore should fail");
+  emscripten_console_log("try_acquiring unavailable semaphore should fail");
   int idx = emscripten_semaphore_try_acquire(&unavailable, 1);
   assert(idx == -1);
 
-  console_log("try_acquiring too many resources from an available semaphore should fail");
+  emscripten_console_log("try_acquiring too many resources from an available semaphore should fail");
   idx = emscripten_semaphore_try_acquire(&available, 2);
   assert(idx == -1);
 
-  console_log("try_acquiring a resource from an available semaphore should succeed");
+  emscripten_console_log("try_acquiring a resource from an available semaphore should succeed");
   idx = emscripten_semaphore_try_acquire(&available, 1);
   assert(idx == 0);
 
-  console_log("releasing semaphore resources on main thread should succeed");
+  emscripten_console_log("releasing semaphore resources on main thread should succeed");
   idx = emscripten_semaphore_release(&available, 10);
   assert(idx == 0);
 
-  console_log("try_acquiring multiple resources from an available semaphore should succeed");
+  emscripten_console_log("try_acquiring multiple resources from an available semaphore should succeed");
   idx = emscripten_semaphore_try_acquire(&available, 9);
   assert(idx == 1);
 

--- a/test/wasm_worker/semaphore_waitinf_acquire.c
+++ b/test/wasm_worker/semaphore_waitinf_acquire.c
@@ -6,10 +6,6 @@
 
 // Tests emscripten_semaphore_init(), emscripten_semaphore_waitinf_acquire() and emscripten_semaphore_release()
 
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
-
 emscripten_semaphore_t threadsWaiting = (emscripten_semaphore_t)12345315; // initialize with garbage
 emscripten_semaphore_t threadsRunning = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(0); // initialize with static initializer
 emscripten_semaphore_t threadsCompleted = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(0);
@@ -18,56 +14,56 @@ int threadCounter = 0;
 
 void worker_main()
 {
-  console_log("worker_main");
+  emscripten_console_log("worker_main");
 
   // Increment semaphore to mark that this thread is waiting for a signal from control thread to start.
   emscripten_semaphore_release(&threadsWaiting, 1);
 
   // Acquire thread run semaphore once main thread has given this thread a go signal.
-  console_log("worker_main: waiting for thread run signal");
+  emscripten_console_log("worker_main: waiting for thread run signal");
   emscripten_semaphore_waitinf_acquire(&threadsRunning, 1);
 
   // Do heavy computation:
-  console_log("worker_main: incrementing work");
+  emscripten_console_log("worker_main: incrementing work");
   emscripten_atomic_add_u32((void*)&threadCounter, 1);
 
   // Increment semaphore to signal that this thread has finished.
-  console_log("worker_main: thread completed");
+  emscripten_console_log("worker_main: thread completed");
   emscripten_semaphore_release(&threadsCompleted, 1);
 }
 
 void control_thread()
 {
   // Wait until we have three threads available to start running.
-  console_log("control_thread: waiting for three threads to complete loading");
+  emscripten_console_log("control_thread: waiting for three threads to complete loading");
   emscripten_semaphore_waitinf_acquire(&threadsWaiting, 3);
 
   // Set the three waiting threads to run simultaneously.
   assert(threadCounter == 0);
-  console_log("control_thread: release three threads to run");
+  emscripten_console_log("control_thread: release three threads to run");
   emscripten_semaphore_release(&threadsRunning, 3);
 
   // Wait until we have 3 threads completed their run.
-  console_log("control_thread: waiting for three threads to complete");
+  emscripten_console_log("control_thread: waiting for three threads to complete");
   emscripten_semaphore_waitinf_acquire(&threadsCompleted, 3);
   assert(threadCounter == 3);
 
   // Wait until we have next 3 threads available to start running.
-  console_log("control_thread: waiting for next three threads to be ready");
+  emscripten_console_log("control_thread: waiting for next three threads to be ready");
   emscripten_semaphore_waitinf_acquire(&threadsWaiting, 3);
 
   // Set the three waiting threads to run simultaneously.
   assert(threadCounter == 3);
-  console_log("control_thread: setting next three threads go");
+  emscripten_console_log("control_thread: setting next three threads go");
   emscripten_semaphore_release(&threadsRunning, 3);
 
   // Wait until we have the final 3 threads completed their run.
-  console_log("control_thread: waiting for the last three threads to finish");
+  emscripten_console_log("control_thread: waiting for the last three threads to finish");
   emscripten_semaphore_waitinf_acquire(&threadsCompleted, 3);
-  console_log("control_thread: threads finished");
+  emscripten_console_log("control_thread: threads finished");
   assert(threadCounter == 6);
 
-  console_log("control_thread: test finished");
+  emscripten_console_log("control_thread: test finished");
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);
 #endif

--- a/test/wasm_worker/wait32_notify.c
+++ b/test/wasm_worker/wait32_notify.c
@@ -1,42 +1,38 @@
-#include <emscripten.h>
+#include <emscripten/html5.h>
 #include <emscripten/wasm_worker.h>
 #include <emscripten/threading.h>
 #include <assert.h>
 
 // Test emscripten_wasm_wait_i32() and emscripten_wasm_notify() functions.
 
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
-
 volatile int32_t addr = 0;
 
 void worker_main()
 {
-  console_log("worker_main");
+  emscripten_console_log("worker_main");
   emscripten_atomic_store_u32((void*)&addr, 1);
 
-  console_log("Waiting on address with unexpected value should return 'not-equal'");
+  emscripten_console_log("Waiting on address with unexpected value should return 'not-equal'");
   ATOMICS_WAIT_RESULT_T ret = emscripten_wasm_wait_i32((int32_t*)&addr, 2, /*timeout=*/-1);
   assert(ret == ATOMICS_WAIT_NOT_EQUAL);
 
-  console_log("Waiting on address with unexpected value should return 'not-equal' also if timeout==0");
+  emscripten_console_log("Waiting on address with unexpected value should return 'not-equal' also if timeout==0");
   ret = emscripten_wasm_wait_i32((int32_t*)&addr, 2, /*timeout=*/0);
   assert(ret == ATOMICS_WAIT_NOT_EQUAL);
 
-  console_log("Waiting for 0 nanoseconds should return 'timed-out'");
+  emscripten_console_log("Waiting for 0 nanoseconds should return 'timed-out'");
   ret = emscripten_wasm_wait_i32((int32_t*)&addr, 1, /*timeout=*/0);
   assert(ret == ATOMICS_WAIT_TIMED_OUT);
 
-  console_log("Waiting for >0 nanoseconds should return 'timed-out'");
+  emscripten_console_log("Waiting for >0 nanoseconds should return 'timed-out'");
   ret = emscripten_wasm_wait_i32((int32_t*)&addr, 1, /*timeout=*/1000);
   assert(ret == ATOMICS_WAIT_TIMED_OUT);
 
-  console_log("Waiting for infinitely long should return 'ok'");
+  emscripten_console_log("Waiting for infinitely long should return 'ok'");
   ret = emscripten_wasm_wait_i32((int32_t*)&addr, 1, /*timeout=*/-1);
   assert(ret == ATOMICS_WAIT_OK);
 
-  console_log("Test finished");
+  emscripten_console_log("Test finished");
 
 #ifdef REPORT_RESULT
   REPORT_RESULT(addr);
@@ -50,12 +46,12 @@ EM_BOOL main_loop(double time, void *userData)
   if (addr == 1)
   {
     // Burn one second to make sure worker finishes its test.
-    console_log("main: seen worker running");
+    emscripten_console_log("main: seen worker running");
     double t0 = emscripten_performance_now();
     while(emscripten_performance_now() < t0 + 1000);
 
     // Wake the waiter
-    console_log("main: waking worker");
+    emscripten_console_log("main: waking worker");
     addr = 2;
     emscripten_wasm_notify((int32_t*)&addr, 1);
 
@@ -66,11 +62,11 @@ EM_BOOL main_loop(double time, void *userData)
 
 int main()
 {
-  console_log("main: creating worker");
+  emscripten_console_log("main: creating worker");
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
-  console_log("main: posting function");
+  emscripten_console_log("main: posting function");
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 
-  console_log("main: entering timeout loop to wait for wasm worker to run");
+  emscripten_console_log("main: entering timeout loop to wait for wasm worker to run");
   emscripten_set_timeout_loop(main_loop, 1000, 0);
 }

--- a/test/wasm_worker/wait64_notify.c
+++ b/test/wasm_worker/wait64_notify.c
@@ -5,38 +5,34 @@
 
 // Test emscripten_wasm_wait_i64() and emscripten_wasm_notify() functions.
 
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
-
 volatile int64_t addr = 0;
 
 void worker_main()
 {
-  console_log("worker_main");
+  emscripten_console_log("worker_main");
   emscripten_atomic_store_u64((void*)&addr, 0x100000000ull);
 
-  console_log("Waiting on address with unexpected value should return 'not-equal'");
+  emscripten_console_log("Waiting on address with unexpected value should return 'not-equal'");
   ATOMICS_WAIT_RESULT_T ret = emscripten_wasm_wait_i64((int64_t*)&addr, 0x200000000ull, /*timeout=*/-1);
   assert(ret == ATOMICS_WAIT_NOT_EQUAL);
 
-  console_log("Waiting on address with unexpected value should return 'not-equal' also if timeout==0");
+  emscripten_console_log("Waiting on address with unexpected value should return 'not-equal' also if timeout==0");
   ret = emscripten_wasm_wait_i64((int64_t*)&addr, 0x200000000ull, /*timeout=*/0);
   assert(ret == ATOMICS_WAIT_NOT_EQUAL);
 
-  console_log("Waiting for 0 nanoseconds should return 'timed-out'");
+  emscripten_console_log("Waiting for 0 nanoseconds should return 'timed-out'");
   ret = emscripten_wasm_wait_i64((int64_t*)&addr, 0x100000000ull, /*timeout=*/0);
   assert(ret == ATOMICS_WAIT_TIMED_OUT);
 
-  console_log("Waiting for >0 nanoseconds should return 'timed-out'");
+  emscripten_console_log("Waiting for >0 nanoseconds should return 'timed-out'");
   ret = emscripten_wasm_wait_i64((int64_t*)&addr, 0x100000000ull, /*timeout=*/1000);
   assert(ret == ATOMICS_WAIT_TIMED_OUT);
 
-  console_log("Waiting for infinitely long should return 'ok'");
+  emscripten_console_log("Waiting for infinitely long should return 'ok'");
   ret = emscripten_wasm_wait_i64((int64_t*)&addr, 0x100000000ull, /*timeout=*/-1);
   assert(ret == ATOMICS_WAIT_OK);
 
-  console_log("Test finished");
+  emscripten_console_log("Test finished");
 
 #ifdef REPORT_RESULT
   REPORT_RESULT(addr >> 32);
@@ -50,12 +46,12 @@ EM_BOOL main_loop(double time, void *userData)
   if (addr == 0x100000000ull)
   {
     // Burn one second to make sure worker finishes its test.
-    console_log("main: seen worker running");
+    emscripten_console_log("main: seen worker running");
     double t0 = emscripten_performance_now();
     while(emscripten_performance_now() < t0 + 1000);
 
     // Wake the waiter
-    console_log("main: waking worker");
+    emscripten_console_log("main: waking worker");
     addr = 0x200000000ull;
     emscripten_wasm_notify((int32_t*)&addr, 1);
 
@@ -66,11 +62,11 @@ EM_BOOL main_loop(double time, void *userData)
 
 int main()
 {
-  console_log("main: creating worker");
+  emscripten_console_log("main: creating worker");
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
-  console_log("main: posting function");
+  emscripten_console_log("main: posting function");
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 
-  console_log("main: entering timeout loop to wait for wasm worker to run");
+  emscripten_console_log("main: entering timeout loop to wait for wasm worker to run");
   emscripten_set_timeout_loop(main_loop, 1000, 0);
 }

--- a/test/wasm_worker/wait_async.c
+++ b/test/wasm_worker/wait_async.c
@@ -5,19 +5,15 @@
 
 // Test emscripten_wasm_wait_i64() and emscripten_wasm_notify() functions.
 
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
-
 volatile int32_t addr = 0;
 
 void worker_main()
 {
-  console_log("worker_main");
+  emscripten_console_log("worker_main");
   emscripten_wasm_worker_sleep(1000 * 1000000ull); // Sleep one second.
-  console_log("worker: addr = 1234");
+  emscripten_console_log("worker: addr = 1234");
   emscripten_atomic_store_u32((void*)&addr, 1234);
-  console_log("worker: notify async waiting main thread");
+  emscripten_console_log("worker: notify async waiting main thread");
   emscripten_wasm_notify((int32_t*)&addr, 1);
 }
 
@@ -27,7 +23,7 @@ int numCalled = 0;
 
 void asyncWaitShouldTimeout(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
 {
-  console_log("main: asyncWaitShouldTimeout");
+  emscripten_console_log("main: asyncWaitShouldTimeout");
   ++numCalled;
   assert(numCalled == 1);
   assert(ptr == &addr);
@@ -43,14 +39,14 @@ void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT
 
 void asyncWaitFinishedShouldBeOk(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
 {
-  console_log("main: asyncWaitFinished");
+  emscripten_console_log("main: asyncWaitFinished");
   assert(ptr == &addr);
   assert(val == 1);
   assert(userData == (void*)42);
   ++numCalled;
   assert(numCalled == 2);
   assert(waitResult == ATOMICS_WAIT_OK);
-  console_log("test finished");
+  emscripten_console_log("test finished");
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);
 #endif
@@ -58,30 +54,30 @@ void asyncWaitFinishedShouldBeOk(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT
 
 int main()
 {
-  console_log("main: creating worker");
+  emscripten_console_log("main: creating worker");
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
-  console_log("main: posting function");
+  emscripten_console_log("main: posting function");
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 
   addr = 1;
 
-  console_log("Async waiting on address with unexpected value should return 'not-equal'");
+  emscripten_console_log("Async waiting on address with unexpected value should return 'not-equal'");
   ATOMICS_WAIT_TOKEN_T ret = emscripten_atomic_wait_async((int32_t*)&addr, 2, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(ret == ATOMICS_WAIT_NOT_EQUAL);
 
-  console_log("Waiting on address with unexpected value should return 'not-equal' also if timeout==0");
+  emscripten_console_log("Waiting on address with unexpected value should return 'not-equal' also if timeout==0");
   ret = emscripten_atomic_wait_async((int32_t*)&addr, 2, asyncWaitFinishedShouldNotBeCalled, (void*)42, 0);
   assert(ret == ATOMICS_WAIT_NOT_EQUAL);
 
-  console_log("Waiting for 0 milliseconds should return 'timed-out'");
+  emscripten_console_log("Waiting for 0 milliseconds should return 'timed-out'");
   ret = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, 0);
   assert(ret == ATOMICS_WAIT_TIMED_OUT);
 
-  console_log("Waiting for >0 milliseconds should return 'ok' (but successfully time out in first call to asyncWaitFinished)");
+  emscripten_console_log("Waiting for >0 milliseconds should return 'ok' (but successfully time out in first call to asyncWaitFinished)");
   ret = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitShouldTimeout, (void*)42, 10);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 
-  console_log("Waiting for infinitely long should return 'ok' (and return 'ok' in second call to asyncWaitFinished)");
+  emscripten_console_log("Waiting for infinitely long should return 'ok' (and return 'ok' in second call to asyncWaitFinished)");
   ret = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldBeOk, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 }

--- a/test/wasm_worker/wasm_worker_self_id.c
+++ b/test/wasm_worker/wasm_worker_self_id.c
@@ -1,12 +1,7 @@
-#include <emscripten.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
 
 // Test the function emscripten_wasm_worker_self_id()
-
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
 
 emscripten_wasm_worker_t worker1 = 0;
 emscripten_wasm_worker_t worker2 = 0;

--- a/test/wasm_worker/wasm_worker_sleep.c
+++ b/test/wasm_worker/wasm_worker_sleep.c
@@ -1,9 +1,5 @@
-#include <emscripten.h>
+#include <emscripten/html5.h>
 #include <emscripten/wasm_worker.h>
-
-EM_JS(void, console_log, (char* str), {
-  console.log(UTF8ToString(str));
-});
 
 void worker_main()
 {


### PR DESCRIPTION
These is no need to re-implement this everywhere since `emscripten_console_log` does just this.  This pattern seems to have been copied around so removing it everywhere should avoid future copies.

See https://github.com/emscripten-core/emscripten/blob/ca1d374c624aba773b5c38ac5326e1fcb4add34b/src/library.js#L3388-L3393