### PR TITLE
Add TLS size to allocation in emscripten_malloc_wasm_worker

### DIFF
--- a/site/source/docs/api_reference/wasm_workers.rst
+++ b/site/source/docs/api_reference/wasm_workers.rst
@@ -23,7 +23,7 @@ Quick Example
 
   int main()
   {
-    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */1024);
+    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stackSize: */1024);
     emscripten_wasm_worker_post_function_v(worker, run_in_worker);
   }
 
@@ -33,8 +33,11 @@ which shares the same WebAssembly.Module and WebAssembly.Memory object. Then a
 ``postMessage()`` is passed to the Worker to ask it to execute the function
 ``run_in_worker()`` to print a string.
 
-To explicitly control the memory allocation placement when creating a worker, use the
-function ``emscripten_create_wasm_worker()``.
+To explicitly control the memory allocation placement when creating a worker,
+use the ``emscripten_create_wasm_worker()`` function. This function takes a
+region of memory that must be large enough to hold both the stack and the TLS
+data for the worker.  You can use ``__builtin_wasm_tls_size()`` to find out at
+runtime how much space is required for the program's TLS data.
 
 Introduction
 ============

--- a/system/include/emscripten/wasm_worker.h
+++ b/system/include/emscripten/wasm_worker.h
@@ -17,16 +17,20 @@ extern "C" {
                                   behaves, the dynamically allocated memory can never be freed, so use this function
                                   only in scenarios where the page does not need to deinitialize/tear itself down.
 
-   emscripten_create_wasm_worker: Creates a Wasm Worker on given placed stack address.
+   emscripten_create_wasm_worker: Creates a Wasm Worker given a preallocated region for stack and TLS data.
                                   Use this function to manually manage the memory that a Worker should use.
                                   This function does not use any dynamic memory allocation.
+                                  Unlike with the above function, this variant requires that size of the
+                                  region provided is large enough to hold both stack and TLS area.
+                                  The size of the TLS area can be determined at runtime by calling
+                                  __builtin_wasm_tls_size().
 
    Returns an ID that represents the given Worker. If not building with Wasm workers enabled (-sWASM_WORKERS=0),
    these functions will return 0 to denote failure.
    Note that the Worker will be loaded up asynchronously, and initially will not be executing any code. Use
    emscripten_wasm_worker_post_function_*() set of functions to start executing code on the Worker. */
-emscripten_wasm_worker_t emscripten_malloc_wasm_worker(uint32_t stackSize);
-emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackLowestAddress __attribute__((nonnull)), uint32_t stackSize);
+emscripten_wasm_worker_t emscripten_malloc_wasm_worker(size_t stackSize);
+emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackPlusTLSAddress __attribute__((nonnull)), size_t stackPlusTLSSize);
 
 // Terminates the given Wasm Worker some time after it has finished executing its current, or possibly some subsequent
 // posted functions. Note that this function is not C++ RAII safe, but you must manually coordinate to release any

--- a/system/lib/wasm_worker/library_wasm_worker.c
+++ b/system/lib/wasm_worker/library_wasm_worker.c
@@ -3,6 +3,7 @@
 #include <emscripten/threading.h>
 #include <emscripten/heap.h>
 #include <emscripten/stack.h>
+#include <emscripten/console.h>
 #include <malloc.h>
 
 #include "emscripten_internal.h"
@@ -10,6 +11,8 @@
 #ifndef __EMSCRIPTEN_WASM_WORKERS__
 #error __EMSCRIPTEN_WASM_WORKERS__ should be defined when building this file!
 #endif
+
+#define ROUND_UP(x, ALIGNMENT) (((x)+ALIGNMENT-1)&-ALIGNMENT)
 
 // Options:
 // #define STACK_OVERFLOW_CHECK 0/1/2 : set to the current stack overflow check mode
@@ -22,35 +25,38 @@ static void emscripten_wasm_worker_main_thread_initialize() {
 	assert((*sbrk_ptr & 15) == 0);
 	assert(__builtin_wasm_tls_align() <= 16);
 	__wasm_init_tls((void*)*sbrk_ptr);
-	*sbrk_ptr += (__builtin_wasm_tls_size() + 15) & -16;
+	*sbrk_ptr += ROUND_UP(__builtin_wasm_tls_size(), 16);
 }
 
-emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackLowestAddress, uint32_t stackSize)
+emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackPlusTLSAddress, size_t stackPlusTLSSize)
 {
-	assert(stackLowestAddress != 0);
-	assert((uintptr_t)stackLowestAddress % 16 == 0);
-	assert(stackSize > 0);
-	assert(stackSize % 16 == 0);
+	assert(stackPlusTLSAddress != 0);
+	assert((uintptr_t)stackPlusTLSAddress % 16 == 0);
+	assert(stackPlusTLSSize > 0);
+	assert(stackPlusTLSSize % 16 == 0);
 
 	// Guard against a programming oopsie: The target Worker's stack cannot be part of the calling
 	// thread's stack.
-	assert(emscripten_stack_get_base() <= (uintptr_t)stackLowestAddress || emscripten_stack_get_end() >= (uintptr_t)stackLowestAddress + stackSize
+	assert(emscripten_stack_get_base() <= (uintptr_t)stackPlusTLSAddress || emscripten_stack_get_end() >= (uintptr_t)stackPlusTLSAddress + stackPlusTLSSize
 		&& "When creating a Wasm Worker, its stack should be located either in global data or on the heap, not on the calling thread's own stack!");
 
-	// The Worker's TLS area will be spliced off from the stack region.
-    // We expect TLS area to need to be at most 16 bytes aligned
+	// We expect TLS area to need to be at most 16 bytes aligned
 	assert(__builtin_wasm_tls_align() == 0 || 16 % __builtin_wasm_tls_align() == 0);
 
 #ifndef NDEBUG
-	uint32_t tlsSize = (__builtin_wasm_tls_size() + 15) & -16;
-	assert(stackSize > tlsSize);
+	// The Worker's TLS area will be spliced off from the stack region, so the
+	// stack needs to be at least as large as the TLS region.
+	uint32_t tlsSize = ROUND_UP(__builtin_wasm_tls_size(), 16);
+	assert(stackPlusTLSSize > tlsSize);
 #endif
-
-	return _emscripten_create_wasm_worker(stackLowestAddress, stackSize);
+	return _emscripten_create_wasm_worker(stackPlusTLSAddress, stackPlusTLSSize);
 }
 
-emscripten_wasm_worker_t emscripten_malloc_wasm_worker(uint32_t stackSize)
+emscripten_wasm_worker_t emscripten_malloc_wasm_worker(size_t stackSize)
 {
+	// Add the TLS size to the provided stackSize so that the allocation
+	// will always be large enough to hold the worker TLS data.
+	stackSize += ROUND_UP(__builtin_wasm_tls_size(), 16);
 	return emscripten_create_wasm_worker(memalign(16, stackSize), stackSize);
 }
 

--- a/system/lib/wasm_worker/library_wasm_worker_stub.c
+++ b/system/lib/wasm_worker/library_wasm_worker_stub.c
@@ -8,11 +8,11 @@
 #error __EMSCRIPTEN_WASM_WORKERS__ should not be defined when building this file!
 #endif
 
-emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackLowestAddress, uint32_t stackSize) {
+emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackPlusTLSAddress, size_t stackPlusTLSSize) {
   return 0;
 }
 
-emscripten_wasm_worker_t emscripten_malloc_wasm_worker(uint32_t stackSize) {
+emscripten_wasm_worker_t emscripten_malloc_wasm_worker(size_t stackSize) {
   return 0;
 }
 

--- a/test/wasm_worker/hello_wasm_worker.c
+++ b/test/wasm_worker/hello_wasm_worker.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <emscripten/wasm_worker.h>
 #include <stdio.h>
 
@@ -14,5 +15,6 @@ void run_in_worker()
 int main()
 {
   emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */1024);
+  assert(worker);
   emscripten_wasm_worker_post_function_v(worker, run_in_worker);
 }

--- a/test/wasm_worker/malloc_wasm_worker.c
+++ b/test/wasm_worker/malloc_wasm_worker.c
@@ -17,5 +17,6 @@ int main()
 {
 	assert(!emscripten_current_thread_is_wasm_worker());
 	emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */1024);
+	assert(worker);
 	emscripten_wasm_worker_post_function_v(worker, worker_main);
 }


### PR DESCRIPTION
This fixes `lsan.test_wasm_worker_hello`.  The reason this was failing is that lsan adds about 26k of TLS data which meant that 1024 bytes of total allocation was not nearly enough.

Ideally we would fix this for `emscripten_create_wasm_worker` too.  We could either do this by saying that the TLS region is always separetly allocated or we could provide some way to for the user to discover the TLS size (i.e. a wrapper around __builtin_wasm_tls_size) so that can add it to their own allocation.