### PR TITLE
Fix bug in wasm preload plugin

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -27,7 +27,7 @@ var LibraryDylink = {
           () => loadWebAssemblyModule(byteArray, {loadAsync: true, nodelete: true})).then(
             (module) => {
               preloadedWasm[name] = module;
-              onload();
+              onload(byteArray);
             },
             (error) => {
               err('failed to instantiate wasm: ' + name + ': ' + error);


### PR DESCRIPTION
Because we were not passing `byteArray` to the onload handle, no data was actually getting written to the fileystem in FS_createPreloadedFile -> processData -> finish and these preloaded files were being written as empty files.

This matches the behavior of the other two plugins we have for images and audio.

Fixing this bug allows us to fix one of the issues with `test_preload_module`, which is that it was falling back to loading from the a URL if the file was not found.  By preloading the file under a different name we prevent the URL fallback from working.  The URL fallback had been silently masking the `FS_createPreloadedFile` issue.