### PR TITLE
Regression: malloc is no longer found if building with -sERROR_ON_UNDEFINED_SYMBOLS=0

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2820,7 +2820,7 @@ Module["preRun"].push(function () {
       self.btest_exit('browser/test_sdl_touch.c', args=opts + ['-DAUTOMATE_SUCCESS=1', '-lSDL', '-lGL'])
 
   def test_html5_mouse(self):
-    for opts in [[], ['-O2', '-g1', '--closure=1']]:
+    for opts in [['-sERROR_ON_UNDEFINED_SYMBOLS=0'], ['-O2', '-g1', '--closure=1']]:
       print(opts)
       self.btest(test_file('test_html5_mouse.c'), args=opts + ['-DAUTOMATE_SUCCESS=1'], expected='0')
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -135,10 +135,7 @@ def create_stub_object(external_symbols):
   stubfile = shared.get_temp_files().get('libemscripten_js_symbols.so').name
   stubs = ['#STUB']
   for name, deps in external_symbols.items():
-    if settings.ERROR_ON_UNDEFINED_SYMBOLS:
-      stubs.append('%s: %s' % (name, ','.join(deps)))
-    else:
-      stubs.append(name)
+    stubs.append('%s: %s' % (name, ','.join(deps)))
   utils.write_file(stubfile, '\n'.join(stubs))
   return stubfile
 


### PR DESCRIPTION
```
> emcc test\test_html5_mouse.c -sERROR_ON_UNDEFINED_SYMBOLS=0

warning: undefined symbol: malloc (referenced by $registerMouseEventCallback__deps: 
['$JSEvents','$fillMouseEventData','$findEventTarget','malloc','$getWasmTableEntry'], referenced
by emscripten_set_click_callback_on_thread__deps:
['$registerMouseEventCallback'], referenced by top-level compiled C/C++ code)
emcc: warning: warnings in JS library compilation [-Wjs-compiler]
```

Add test for the failing case, and see what CI thinkgs about a hacky "fix" that fixes the new test.