### PR TITLE
Fix `$preloadPlugins` ref in `library_dylink.js`, emscripten 3.1.38 affected

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -10,6 +10,7 @@ var dlopenMissingError = "'To use dlopen, you need enable dynamic linking, see h
 
 var LibraryDylink = {
 #if RELOCATABLE
+  $preloadPlugins: "{{{ makeModuleReceiveExpr('preloadPlugins', '[]') }}}",
   $registerWasmPlugin__deps: ['$preloadPlugins'],
   $registerWasmPlugin: function() {
     // Use string keys here to avoid minification since the plugin consumer


### PR DESCRIPTION
This PR fixes `$preloadPlugins` ref in `library_dylink.js`.

The error log is below:

```
  error: undefined symbol: $preloadPlugins (referenced by $registerWasmPlugin__deps: ['$preloadPlugins'], referenced by $preloadedWasm__deps: ['$registerWasmPlugin'], referenced by $loadDynamicLibrary__deps: ['$LDSO','$loadWebAssemblyModule','$isInternalSym','$mergeLibSymbols','$newDSO','$asyncLoad','$preloadedWasm'], referenced by $loadDylibs__deps: ['$loadDynamicLibrary','$reportUndefinedSymbols'], referenced by top-level compiled C/C++ code)
  warning: To disable errors for undefined symbols use `-sERROR_ON_UNDEFINED_SYMBOLS=0`
  warning: preloadPlugins may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
```

The issue:
- Exists in Emscripten **3.1.38** version
- Was introduced in https://github.com/emscripten-core/emscripten/pull/18963
- Originally reported: https://github.com/tree-sitter/tree-sitter/issues/2260

The fix is based on:
https://github.com/emscripten-core/emscripten/blob/90d76db21200d42f5536bc3a01a22303e398d8b4/src/library_fs_shared.js#L8