### PR TITLE
dylink: Make preload plugin dependency conditional on FILESYTEM

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -12,9 +12,11 @@ var LibraryBrowser = {
     '$safeSetTimeout',
     '$warnOnce',
     'emscripten_set_main_loop_timing',
+#if FILESYSTEM || WASMFS
     '$preloadPlugins',
 #if MAIN_MODULE
     '$preloadedWasm',
+#endif
 #endif
   ],
   $Browser__postset: `
@@ -105,6 +107,7 @@ var LibraryBrowser = {
       if (Browser.initted) return;
       Browser.initted = true;
 
+#if FILESYSTEM || WASMFS
       // Support for plugins that can process preloaded files. You can add more of these to
       // your app by creating and appending to preloadPlugins.
       //
@@ -209,6 +212,7 @@ var LibraryBrowser = {
         }, 10000);
       };
       preloadPlugins.push(audioPlugin);
+#endif
 
       // Canvas event setup
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -4994,7 +4994,7 @@ int main() {
 }''')
     self.run_process([EMXX, 'src.cpp'])
 
-  def test_syscall_without_filesystem(self):
+  def test_syscall_no_filesystem(self):
     # a program which includes a non-trivial syscall, but disables the filesystem.
     create_file('src.c', r'''
 #include <sys/time.h>
@@ -5003,6 +5003,9 @@ int main() {
   return openat(0, "foo", 0);
 }''')
     self.run_process([EMCC, 'src.c', '-sNO_FILESYSTEM'])
+
+  def test_dylink_no_filesystem(self):
+    self.run_process([EMCC, test_file('hello_world.c'), '-sMAIN_MODULE=2', '-sNO_FILESYSTEM'])
 
   def test_dashS(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-S'])


### PR DESCRIPTION
The preload plugin system is part of the core filesystem code in `library_fs_shared.py`.

Fixes: #19361