### PR TITLE
Define FILESYSTEM even when WASMFS is defined

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2303,7 +2303,7 @@ def phase_linker_setup(options, state, newargs):
 
   if settings.WASMFS:
     state.forced_stdlibs.append('libwasmfs')
-    settings.FILESYSTEM = 0
+    settings.FILESYSTEM = 1
     settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
     settings.JS_LIBRARIES.append((0, 'library_wasmfs.js'))
     settings.REQUIRED_EXPORTS += ['_wasmfs_read_file']

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -12,7 +12,7 @@ var LibraryBrowser = {
     '$safeSetTimeout',
     '$warnOnce',
     'emscripten_set_main_loop_timing',
-#if FILESYSTEM || WASMFS
+#if FILESYSTEM
     '$preloadPlugins',
 #if MAIN_MODULE
     '$preloadedWasm',
@@ -107,7 +107,7 @@ var LibraryBrowser = {
       if (Browser.initted) return;
       Browser.initted = true;
 
-#if FILESYSTEM || WASMFS
+#if FILESYSTEM
       // Support for plugins that can process preloaded files. You can add more of these to
       // your app by creating and appending to preloadPlugins.
       //

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -10,7 +10,7 @@ var dlopenMissingError = "'To use dlopen, you need enable dynamic linking, see h
 
 var LibraryDylink = {
 #if RELOCATABLE
-#if FILESYSTEM || WASMFS
+#if FILESYSTEM
   $registerWasmPlugin__deps: ['$preloadPlugins'],
   $registerWasmPlugin: function() {
     // Use string keys here to avoid minification since the plugin consumer
@@ -913,7 +913,7 @@ var LibraryDylink = {
   $loadDynamicLibrary__deps: ['$LDSO', '$loadWebAssemblyModule',
                               '$isInternalSym', '$mergeLibSymbols', '$newDSO',
                               '$asyncLoad',
-#if FILESYSTEM || WASMFS
+#if FILESYSTEM
                               '$preloadedWasm',
 #endif
   ],
@@ -987,7 +987,7 @@ var LibraryDylink = {
 
     // libName -> exports
     function getExports() {
-#if FILESYSTEM || WASMFS
+#if FILESYSTEM
       // lookup preloaded cache first
       if (preloadedWasm[libName]) {
 #if DYLINK_DEBUG

--- a/src/modules.js
+++ b/src/modules.js
@@ -78,35 +78,36 @@ global.LibraryManager = {
     }
 
     if (FILESYSTEM) {
-      // Core filesystem libraries (always linked against, unless -sFILESYSTEM=0 is specified)
-      libraries = libraries.concat([
-        'library_fs_shared.js',
-        'library_fs.js',
-        'library_memfs.js',
-        'library_tty.js',
-        'library_pipefs.js', // ok to include it by default since it's only used if the syscall is used
-        'library_sockfs.js', // ok to include it by default since it's only used if the syscall is used
-      ]);
+      libraries.push('library_fs_shared.js');
+      if (WASMFS) {
+        libraries = libraries.concat([
+          'library_wasmfs.js',
+          'library_wasmfs_js_file.js',
+          'library_wasmfs_jsimpl.js',
+          'library_wasmfs_fetch.js',
+          'library_wasmfs_node.js',
+          'library_wasmfs_opfs.js',
+        ]);
+      } else {
+        // Core filesystem libraries (always linked against, unless -sFILESYSTEM=0 is specified)
+        libraries = libraries.concat([
+          'library_fs.js',
+          'library_memfs.js',
+          'library_tty.js',
+          'library_pipefs.js', // ok to include it by default since it's only used if the syscall is used
+          'library_sockfs.js', // ok to include it by default since it's only used if the syscall is used
+        ]);
 
-      if (NODERAWFS) {
-        // NODERAWFS requires NODEFS
-        if (!JS_LIBRARIES.includes('library_nodefs.js')) {
-          libraries.push('library_nodefs.js');
+        if (NODERAWFS) {
+          // NODERAWFS requires NODEFS
+          if (!JS_LIBRARIES.includes('library_nodefs.js')) {
+            libraries.push('library_nodefs.js');
+          }
+          libraries.push('library_noderawfs.js');
+          // NODERAWFS overwrites library_path.js
+          libraries.push('library_nodepath.js');
         }
-        libraries.push('library_noderawfs.js');
-        // NODERAWFS overwrites library_path.js
-        libraries.push('library_nodepath.js');
       }
-    } else if (WASMFS) {
-      libraries = libraries.concat([
-        'library_fs_shared.js',
-        'library_wasmfs.js',
-        'library_wasmfs_js_file.js',
-        'library_wasmfs_jsimpl.js',
-        'library_wasmfs_fetch.js',
-        'library_wasmfs_node.js',
-        'library_wasmfs_opfs.js',
-      ]);
     }
 
     // Additional JS libraries (without AUTO_JS_LIBRARIES, link to these explicitly via -lxxx.js)


### PR DESCRIPTION
WasmFS already implement a some parts of the wasm JS API so I think it makes since to consider WASMFS and flavor/subset of FILESYSTEM.