### PR TITLE
Keep DSO file data around after dlsync. NFC

### DIFF
--- a/system/lib/libc/dynlink.c
+++ b/system/lib/libc/dynlink.c
@@ -163,10 +163,10 @@ static void load_library_done(struct dso* p) {
   // Block until all other threads have loaded this module.
   dlsync();
 #endif
-  if (p->file_data) {
-    free(p->file_data);
-    p->file_data_size = 0;
-  }
+  // TODO: figure out some way to tell when its safe to free p->file_data.  Its
+  // not safe to do here because some threads could have been alseep then when
+  // the "dlsync" occurred and those threads will synchronize when they wake,
+  // which could be an arbitrarily long time in the future.
 }
 
 static struct dso* load_library_start(const char* name, int flags) {

--- a/test/core/pthread/test_pthread_dlopen.c
+++ b/test/core/pthread/test_pthread_dlopen.c
@@ -52,7 +52,7 @@ int main() {
   while (!started) {}
 
   printf("loading dylib\n");
-  void* handle = dlopen("liblib.so", RTLD_NOW|RTLD_GLOBAL);
+  void* handle = dlopen("libside.so", RTLD_NOW|RTLD_GLOBAL);
   if (!handle) {
     printf("dlerror: %s\n", dlerror());
   }
@@ -77,6 +77,18 @@ int main() {
   rc = pthread_join(t, NULL);
   assert(rc == 0);
   printf("done join\n");
+
+  printf("starting second & third thread\n");
+  pthread_t t2, t3;
+  rc = pthread_create(&t2, NULL, thread_main, NULL);
+  assert(rc == 0);
+  rc = pthread_create(&t3, NULL, thread_main, NULL);
+  assert(rc == 0);
+  rc = pthread_join(t2, NULL);
+  assert(rc == 0);
+  rc = pthread_join(t3, NULL);
+  assert(rc == 0);
+  printf("starting second & third thread\n");
 
   dlclose(handle);
   return 0;

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9458,6 +9458,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args += ['-Wno-experimental', '-pthread']
     self.build_dlfcn_lib(test_file('core/pthread/test_pthread_dlopen_side.c'))
 
+    self.emcc_args += ['--embed-file', 'liblib.so@libside.so']
     self.prep_dlfcn_main()
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('PROXY_TO_PTHREAD')


### PR DESCRIPTION
Its not generally safe to free this data because some threads might have been alseep when the dlsync occurred.  In these cases they need to be able to catchup/sync when they wake at some point in the future.

This also happens to fix the issue where new threads that get created after the dlopen didn't have access to the file data.

The downside is that, for now, we leak the file data for DSOs that get loaded.

Fixes: #19371