### PR TITLE
feat: implement HEAPU8C

### DIFF
--- a/site/source/docs/api_reference/preamble.js.rst
+++ b/site/source/docs/api_reference/preamble.js.rst
@@ -330,6 +330,11 @@ The :ref:`emscripten-memory-model` uses a typed array buffer (``ArrayBuffer``) t
   View for 8-bit unsigned memory.
 
 
+.. js:data:: HEAPU8C
+
+  View for 8-bit unsigned clamped memory.
+
+
 .. js:data:: HEAPU16
 
   View for 16-bit unsigned memory.

--- a/src/growableHeap.js
+++ b/src/growableHeap.js
@@ -18,6 +18,12 @@ function GROWABLE_HEAP_U8() {
   }
   return HEAPU8;
 }
+function GROWABLE_HEAP_U8C() {
+  if (wasmMemory.buffer != HEAP8.buffer) {
+    updateMemoryViews();
+  }
+  return HEAPU8C;
+}
 function GROWABLE_HEAP_I16() {
   if (wasmMemory.buffer != HEAP8.buffer) {
     updateMemoryViews();

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -497,6 +497,7 @@ function getHeapForType(type) {
     case 'i1':     // fallthrough
     case 'i8':     return 'HEAP8';
     case 'u8':     return 'HEAPU8';
+    case 'u8c':    return 'HEAPU8C';
     case 'i16':    return 'HEAP16';
     case 'u16':    return 'HEAPU16';
     case 'i64':    // fallthrough

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -109,6 +109,8 @@ var HEAP,
   HEAP8,
 /** @type {!Uint8Array} */
   HEAPU8,
+/** @type {!Uint8ClampedArray} */
+  HEAPU8C,
 /** @type {!Int16Array} */
   HEAP16,
 /** @type {!Uint16Array} */
@@ -143,6 +145,7 @@ function updateMemoryViews() {
   Module['HEAP16'] = HEAP16 = new Int16Array(b);
   Module['HEAP32'] = HEAP32 = new Int32Array(b);
   Module['HEAPU8'] = HEAPU8 = new Uint8Array(b);
+  Module['HEAPU8C'] = HEAPU8C = new Uint8ClampedArray(b);
   Module['HEAPU16'] = HEAPU16 = new Uint16Array(b);
   Module['HEAPU32'] = HEAPU32 = new Uint32Array(b);
   Module['HEAPF32'] = HEAPF32 = new Float32Array(b);

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -60,7 +60,7 @@ if (Module['doWasm2JS']) {
 Module['wasm'] = base64Decode('<<< WASM_BINARY_DATA >>>');
 #endif
 
-var HEAP8, HEAP16, HEAP32, HEAPU8, HEAPU16, HEAPU32, HEAPF32, HEAPF64,
+var HEAP8, HEAP16, HEAP32, HEAPU8, HEAPU8C, HEAPU16, HEAPU32, HEAPF32, HEAPF64,
 #if WASM_BIGINT
   HEAP64, HEAPU64,
 #endif
@@ -81,6 +81,7 @@ function updateMemoryViews() {
   {{{ maybeExport('HEAP16') }}} HEAP16 = new Int16Array(b);
   {{{ maybeExport('HEAP32') }}} HEAP32 = new Int32Array(b);
   {{{ maybeExport('HEAPU8') }}} HEAPU8 = new Uint8Array(b);
+  {{{ maybeExport('HEAPU8C') }}} HEAPU8C = new Uint8ClampedArray(b);
   {{{ maybeExport('HEAPU16') }}} HEAPU16 = new Uint16Array(b);
   {{{ maybeExportIfAudioWorklet('HEAPU32') }}} HEAPU32 = new Uint32Array(b);
   {{{ maybeExportIfAudioWorklet('HEAPF32') }}} HEAPF32 = new Float32Array(b);

--- a/src/runtime_asan.js
+++ b/src/runtime_asan.js
@@ -23,6 +23,11 @@ function _asan_js_load_1u(ptr) {
   return HEAPU8[ptr];
 }
 /** @suppress{duplicate} */
+function _asan_js_load_1uc(ptr) {
+  if (runtimeInitialized) return __asan_c_load_1uc(ptr);
+  return HEAPU8C[ptr];
+}
+/** @suppress{duplicate} */
 function _asan_js_load_2(ptr) {
   if (runtimeInitialized) return __asan_c_load_2(ptr);
   return HEAP16[ptr];
@@ -62,6 +67,11 @@ function _asan_js_store_1(ptr, val) {
 function _asan_js_store_1u(ptr, val) {
   if (runtimeInitialized) return __asan_c_store_1u(ptr, val);
   return HEAPU8[ptr] = val;
+}
+/** @suppress{duplicate} */
+function _asan_js_store_1uc(ptr, val) {
+  if (runtimeInitialized) return __asan_c_store_1uc(ptr, val);
+  return HEAPU8C[ptr] = val;
 }
 /** @suppress{duplicate} */
 function _asan_js_store_2(ptr, val) {

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -1072,6 +1072,7 @@ function isEmscriptenHEAP(name) {
   switch (name) {
     case 'HEAP8':
     case 'HEAPU8':
+    case 'HEAPU8C':
     case 'HEAP16':
     case 'HEAPU16':
     case 'HEAP32':


### PR DESCRIPTION
This adds HEAPU8C for Uint8ClampedArray, alongside all the other typed arrays.

This is useful for any WASM library which renders custom image data or bitmaps to a canvas, this is because the fastest ways to paint on a canvas is via [ImageData](https://devdocs.io/dom/imagedata) which only accepts uint8c, with this one can directly do 
```js
new ImageData(HEAPU8C.subarray(pointer, pointer + size), height)
```
which is insanely fast, previously to get this functionality one needed to use pre-worker and use:
```js
updateMemoryViews = (_super => {
  return () => {
    _super()
    self.HEAPU8C = new Uint8ClampedArray(wasmMemory.buffer)
  }
})(updateMemoryViews)
```