### PR TITLE
Fix stack size for embind benchmark.

### DIFF
--- a/test/embind/build_benchmark
+++ b/test/embind/build_benchmark
@@ -1,2 +1,2 @@
 #!/bin/bash
-../../emcc --minify 0 -lembind --js-library=embind.benchmark.js -O2 --shell-file shell.html -o embind_benchmark.html embind_benchmark.cpp
+../../emcc -sTOTAL_STACK=1Mb --minify 0 -lembind --js-library=embind.benchmark.js -O2 --shell-file shell.html -o embind_benchmark.html embind_benchmark.cpp


### PR DESCRIPTION
The benchmark was failing with the new smaller stack size.