### PR TITLE
WasmFS: Open and close files in the JS API _wasmfs_write_file

### DIFF
--- a/system/lib/wasmfs/js_api.cpp
+++ b/system/lib/wasmfs/js_api.cpp
@@ -88,11 +88,24 @@ int _wasmfs_write_file(char* pathname, char* data, size_t data_size) {
   }
 
   auto lockedFile = dataFile->locked();
+  int err = lockedFile.open(O_WRONLY);
+  if (err < 0) {
+    emscripten_console_error("Fatal error in FS.writeFile");
+    abort();
+  }
+
   auto offset = lockedFile.getSize();
   auto result = lockedFile.write((uint8_t*)data, data_size, offset);
   if (result != __WASI_ERRNO_SUCCESS) {
     return 0;
   }
+
+  err = lockedFile.close();
+  if (err < 0) {
+    emscripten_console_error("Fatal error in FS.writeFile");
+    abort();
+  }
+
   return data_size;
 }
 


### PR DESCRIPTION
The memory backend appears to allow `lockedFile.write` without `.open` first,
but other backends like Node do not. In general, it seems correct to open
the file before writing and close it after, and the read JS API call does so, so this
fixes the write one.

This is necessary for NODERAWFS support and will be tested in that PR.