### PR TITLE
Rebaseline code size tests after LLVM update

### DIFF
--- a/test/code_size/hello_webgl2_wasm.json
+++ b/test/code_size/hello_webgl2_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 379,
   "a.js": 4971,
   "a.js.gz": 2430,
-  "a.wasm": 10482,
-  "a.wasm.gz": 6707,
-  "total": 16022,
-  "total_gz": 9516
+  "a.wasm": 10505,
+  "a.wasm.gz": 6720,
+  "total": 16045,
+  "total_gz": 9529
 }

--- a/test/code_size/hello_webgl2_wasm2js.json
+++ b/test/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 18252,
-  "a.js.gz": 8055,
+  "a.js": 18284,
+  "a.js.gz": 8070,
   "a.mem": 3171,
   "a.mem.gz": 2713,
-  "total": 21990,
-  "total_gz": 11147
+  "total": 22022,
+  "total_gz": 11162
 }

--- a/test/code_size/hello_webgl_wasm.json
+++ b/test/code_size/hello_webgl_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 379,
   "a.js": 4450,
   "a.js.gz": 2250,
-  "a.wasm": 10482,
-  "a.wasm.gz": 6707,
-  "total": 15501,
-  "total_gz": 9336
+  "a.wasm": 10505,
+  "a.wasm.gz": 6720,
+  "total": 15524,
+  "total_gz": 9349
 }

--- a/test/code_size/hello_webgl_wasm2js.json
+++ b/test/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 17724,
-  "a.js.gz": 7870,
+  "a.js": 17756,
+  "a.js.gz": 7893,
   "a.mem": 3171,
   "a.mem.gz": 2713,
-  "total": 21462,
-  "total_gz": 10962
+  "total": 21494,
+  "total_gz": 10985
 }


### PR DESCRIPTION
I didn't look more at these aside from to verify that it is indeed LLVM
(and not Binaryen or Emscripten) that is behind these minor regressions.