### PR TITLE
Add useful error when symbol resolution fails

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -727,6 +727,9 @@ var LibraryDylink = {
             var resolved;
             stubs[prop] = function() {
               if (!resolved) resolved = resolveSymbol(prop);
+              if (!resolved) {
+                throw new Error(`Dynamic linking error: cannot resolve symbol ${prop}`);
+              }
               return resolved.apply(null, arguments);
             };
           }


### PR DESCRIPTION
Currently if symbol resolution fails, we get:
```js
TypeError: Cannot read properties of undefined (reading 'apply')
```
It is very hard for newcomers to Emscripten to recognize this as a symbol resolution error. Even for people experienced with this message, it has the annoyance that it doesn't give any hint as to which symbol went missing.

This adds a descriptive error message with the name of the missing symbol.