### PR TITLE
WasmFS: Fix test_fcntl_misc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,6 +507,7 @@ jobs:
             wasmfs.test_atexit_standalone
             wasmfs.test_emscripten_get_now
             wasmfs.test_dyncall_specific_minimal_runtime
+            wasmfs.test_fcntl_misc
             wasmfs.test_utime
             wasmfs.test_unistd_unlink
             wasmfs.test_unistd_access

--- a/test/fcntl/test_fcntl_misc.c
+++ b/test/fcntl/test_fcntl_misc.c
@@ -25,12 +25,7 @@ int main() {
   printf("posix_fallocate: %d\n", posix_fallocate(f, 3, 2));
   printf("errno: %d\n", errno);
   stat("/test", &s);
-#if WASMFS
-  assert(s.st_size == 5);
-#else
-  // The old FS, incorrectly, reports 6 here (unlike linux and wasmfs)
   assert(s.st_size == 6);
-#endif
   memset(&s, 0, sizeof s);
   printf("\n");
   errno = 0;


### PR DESCRIPTION
I'm not sure why the test had that incorrect change in it... perhaps back then
wasmfs had some kind of bug that it worked around and I was confused. But
the test clearly creates a file of size 6:

https://github.com/emscripten-core/emscripten/blob/98b618f09bc106d401c0045fa7252f1cd15bd3c0/test/test_core.py#L5837-L5840

"`abcdef`" is 6 characters.