### PR TITLE
Ensure system libraries are built on demand

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -4182,8 +4182,8 @@ def process_libraries(state, linker_inputs):
     # let wasm-ld handle that.  However, we do want to map to the correct variant.
     # For example we map `-lc` to `-lc-mt` if we are building with threading support.
     if 'lib' + lib in system_libs_map:
-      lib = system_libs_map['lib' + lib]
-      new_flags.append((i, '-l' + strip_prefix(lib.get_base_name(), 'lib')))
+      lib = system_libs_map['lib' + lib].get_link_flag()
+      new_flags.append((i, lib))
       continue
 
     if building.map_and_apply_to_settings(lib):

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12109,8 +12109,6 @@ kill -9 $$
 
   def test_standard_library_mapping(self):
     # Test the `-l` flags on the command line get mapped the correct libraries variant
-    self.run_process([EMBUILDER, 'build', 'libc-mt-debug', 'libcompiler_rt-mt', 'libdlmalloc-mt'])
-
     libs = ['-lc', '-lbulkmemory', '-lcompiler_rt', '-lmalloc']
     err = self.run_process([EMCC, test_file('hello_world.c'), '-pthread', '-nodefaultlibs', '-v'] + libs, stderr=PIPE).stderr
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -426,7 +426,7 @@ class Library:
     This will trigger a build if this library is not in the cache.
     """
     fullpath = self.build()
-    # For non-libaries (e.g. crt1.o) we pass the entire path to the linker
+    # For non-libraries (e.g. crt1.o) we pass the entire path to the linker
     if self.get_ext() != '.a':
       return fullpath
     # For libraries (.a) files, we pass the abbreviated `-l` form.


### PR DESCRIPTION
Previously, when explicitly linking against a system library (e.g. `-lc`) that had not been built earlier, wasm-ld would raise an error indicating that the library could not be found.

Use the `get_link_flag()` function to ensure that it triggers a build if the system library is not present in the cache.

---
Previous behavior:
```console
$ emcc --clear-cache
$ emcc test/hello_world.c -pthread -nodefaultlibs -lc -lbulkmemory -lcompiler_rt -lmalloc
...
wasm-ld: error: unable to find library -lc-mt-debug
wasm-ld: error: unable to find library -lbulkmemory
wasm-ld: error: unable to find library -lcompiler_rt-mt
wasm-ld: error: unable to find library -ldlmalloc-mt
```

New behavior:
```console
$ emcc --clear-cache
$ emcc test/hello_world.c -pthread -nodefaultlibs -lc -lbulkmemory -lcompiler_rt -lmalloc
...
cache:INFO: generating system library: sysroot/lib/wasm32-emscripten/libc-mt-debug.a...
cache:INFO: generating system library: sysroot/lib/wasm32-emscripten/libbulkmemory.a...
cache:INFO: generating system library: sysroot/lib/wasm32-emscripten/libcompiler_rt-mt.a...
cache:INFO: generating system library: sysroot/lib/wasm32-emscripten/libdlmalloc-mt.a...
```