### PR TITLE
dylink: Ensure WASI module import is quoted

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -738,7 +738,7 @@ var LibraryDylink = {
         'GOT.mem': new Proxy({}, GOTHandler),
         'GOT.func': new Proxy({}, GOTHandler),
         'env': proxy,
-        {{{ WASI_MODULE_NAME }}}: proxy,
+        '{{{ WASI_MODULE_NAME }}}': proxy,
       };
 
       function postInstantiation(instance) {


### PR DESCRIPTION
Avoids that Closure compiler would rename/mangle the property, causing instantiation failures.
```console
$ node test.js
[TypeError: WebAssembly.instantiate(): Import #177 module="wasi_snapshot_preview1" error: module is not an object or function]

Node.js v18.16.0
$ wasm-objdump -j Import -x lib/vips-heif.wasm | grep 177
 - func[177] sig=4 <wasi_snapshot_preview1.environ_sizes_get> <- wasi_snapshot_preview1.environ_sizes_get
```

JS binary diff:
```diff
-l={"GOT.mem":new Proxy({},mb),"GOT.func":new Proxy({},mb),env:l,vd:l};
+l={"GOT.mem":new Proxy({},mb),"GOT.func":new Proxy({},mb),env:l,wasi_snapshot_preview1:l};
```