### PR TITLE
Add test for regression between 3.1.8 -> 3.1.38 where overriding dlopen() with a gracefully failing version broke

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -299,7 +299,7 @@ var LibraryDylink = {
   _emscripten_dlopen_js: function(handle, onsuccess, onerror, user_data) {
     abort(dlopenMissingError);
   },
-  _dlsym_js: function(handle, symbol) {
+  _dlsym_js: function(handle, symbol, symbolIndex) {
     abort(dlopenMissingError);
   },
   _dlsym_catchup_js: function(handle, symbolIndex) {

--- a/test/other/test_dlopen_graceful_fail.c
+++ b/test/other/test_dlopen_graceful_fail.c
@@ -1,0 +1,20 @@
+// Emscripten's stub implementation of dlopen() hard aborts execution.
+// Some users want to instead have dlopen() perform a graceful "return 0" failure
+// where they handle the dlopen failures in code, so they want to override
+// Emscripten's built-in JS library functions.
+
+// This test verifies that the ability to override dlopen() to not hard abort
+// will not regress.
+#include <dlfcn.h>
+#include <stdio.h>
+
+int main()
+{
+  printf("Attempting to dlopen\n");
+  void *dll = dlopen("nonexistent.dll", 0);
+  printf("dlopen completed: ptr %p. error: %s\n", dll, dlerror());
+  dlclose(0);
+  printf("dlclose(0) completed.\n");
+  if (!dll) printf("dlopen failed gracefully!\n");
+  return 0;
+}

--- a/test/other/test_dlopen_graceful_fail.js
+++ b/test/other/test_dlopen_graceful_fail.js
@@ -1,0 +1,56 @@
+#if !MAIN_MODULE
+#if !SIDE_MODULE
+// This code represents stable end-user facing API. Changing any part of this file
+// will break end users!
+mergeInto(LibraryManager.library, {
+  _dlopen_js__deps: ['$warnOnce'],
+  _dlopen_js: function(handle) {
+#if ASSERTIONS
+    warnOnce('_dlopen_js: Unable to open DLL! Dynamic linking is not supported in WebAssembly builds due to limitations to performance and code size. Please statically link in the needed libraries.');
+#endif
+  },
+
+  _emscripten_dlopen_js__deps: ['$warnOnce'],
+  _emscripten_dlopen_js: function(filename, flags, user_data, onsuccess, onerror) {
+#if ASSERTIONS
+    warnOnce('_emscripten_dlopen_js: Unable to open DLL ' + UTF8ToString(filename) + '! Dynamic linking is not supported in WebAssembly builds due to limitations to performance and code size. Please statically link in the needed libraries.');
+#endif
+  },
+
+  _dlsym_js__deps: ['$warnOnce'],
+  _dlsym_js: function(handle, symbol, symbolIndex) {
+#if ASSERTIONS
+    warnOnce('_dlsym_js: Unable to open DLL! Dynamic linking is not supported in WebAssembly builds due to limitations to performance and code size. Please statically link in the needed libraries.');
+#endif
+  },
+
+  _dlsym_catchup_js__deps: ['$warnOnce'],
+  _dlsym_catchup_js: function(handle, symbolIndex) {
+#if ASSERTIONS
+    warnOnce('_dlsym_catchup_js: Unable to open DLL! Dynamic linking is not supported in WebAssembly builds due to limitations to performance and code size. Please statically link in the needed libraries.');
+#endif
+  },
+
+  dlopen__deps: ['$warnOnce'],
+  dlopen: function(handle) {
+#if ASSERTIONS
+    warnOnce('dlopen: Unable to open DLL! Dynamic linking is not supported in WebAssembly builds due to limitations to performance and code size. Please statically link in the needed libraries.');
+#endif
+  },
+
+  emscripten_dlopen__deps: ['$warnOnce'],
+  emscripten_dlopen: function(handle, onsuccess, onerror, user_data) {
+#if ASSERTIONS
+    warnOnce('emscripten_dlopen: Unable to open DLL! Dynamic linking is not supported in WebAssembly builds due to limitations to performance and code size. Please statically link in the needed libraries.');
+#endif
+  },
+
+  __dlsym__deps: ['$warnOnce'],
+  __dlsym: function(handle, symbol) {
+#if ASSERTIONS
+    warnOnce('__dlsym: Unable to open DLL! Dynamic linking is not supported in WebAssembly builds due to limitations to performance and code size. Please statically link in the needed libraries.');
+#endif
+  },
+});
+#endif
+#endif

--- a/test/other/test_dlopen_graceful_fail.out
+++ b/test/other/test_dlopen_graceful_fail.out
@@ -1,0 +1,5 @@
+Attempting to dlopen
+warning: dlopen: Unable to open DLL! Dynamic linking is not supported in WebAssembly builds due to limitations to performance and code size. Please statically link in the needed libraries.
+dlopen completed: ptr 0. error: (null)
+dlclose(0) completed.
+dlopen failed gracefully!

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6635,6 +6635,11 @@ int main(int argc,char** argv) {
     self.set_setting('ASYNCIFY')
     self.do_other_test('test_dlopen_blocking.c')
 
+  # This test verifies that users can override dlopen symbols in their own code to
+  # replace the default aborting dlopen() implementation with a gracefully failing one.
+  def test_dlopen_graceful_fail(self):
+    self.do_other_test('test_dlopen_graceful_fail.c', emcc_args=['--js-library', test_file('other/test_dlopen_graceful_fail.js')])
+
   def test_dlsym_rtld_default(self):
     create_file('side.c', r'''
     int baz() {


### PR DESCRIPTION
In #16790 the consensus was to not add a built-in build option to make `dlopen()` gracefully fail, but that users should override the pertinent JS function symbols themselves.

That is what we did at Unity with 3.1.8. Now updating to 3.1.38, I see that this override capability has regressed since some of the JS function names have changed.

This PR adds a new test for this regression between 3.1.8 -> 3.1.38 where overriding dlopen() with a gracefully failing version broke, so that user code overriding dlopen() cannot regress again. It was possibly regressed by #18638.

This way the code cannot be changed around this area without test runner being aware that it will regress end users.