### PR TITLE
WasmFS: Use the shorter mkdirSync option form

### DIFF
--- a/src/library_wasmfs_node.js
+++ b/src/library_wasmfs_node.js
@@ -124,7 +124,7 @@ mergeInto(LibraryManager.library, {
   _wasmfs_node_insert_directory__deps: ['$wasmfsNodeConvertNodeCode'],
   _wasmfs_node_insert_directory: function(path_p, mode) {
     try {
-      fs.mkdirSync(UTF8ToString(path_p), { mode: mode });
+      fs.mkdirSync(UTF8ToString(path_p), mode);
     } catch (e) {
       if (!e.code) throw e;
       return wasmfsNodeConvertNodeCode(e);


### PR DESCRIPTION
This avoids a closure compiler error on the type not matching. This is also what
the old FS code does, so this makes us match that code.

This is a step towards WasmFS working with closure + FULL_LIBRARY, but more
steps will be needed before we can enable testing.