### PR TITLE
Don't break when -lc and -sSIDE_MODULE are both passed

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -4167,6 +4167,8 @@ def process_libraries(state, linker_inputs):
       new_flags.append((i, flag))
       continue
     lib = strip_prefix(flag, '-l')
+    if lib == "c":
+      continue
 
     logger.debug('looking for library "%s"', lib)
     js_libs, native_lib = building.map_to_js_libs(lib)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13493,3 +13493,7 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
   def test_standalone_whole_archive(self):
     self.emcc_args += ['-sSTANDALONE_WASM', '-pthread', '-Wl,--whole-archive', '-lbulkmemory', '-lstandalonewasm', '-Wl,--no-whole-archive']
     self.do_runf(test_file('hello_world.c'))
+
+  def test_lc_side_module(self):
+    create_file('side.c', 'int sidey() { return 42; }')
+    self.run_process([EMCC, '-sSIDE_MODULE', 'side.c', '-o', 'libside.so', '-lc'])


### PR DESCRIPTION
Resolves #16680.

> Why is the current behavior broken?

Well what is "broken" from my specific perspective is the failure on the main branch of the added test:
```py
  def test_lc_side_module(self):
    create_file('side.c', 'int sidey() { return 42; }')
    self.run_process([EMCC, '-sSIDE_MODULE', 'side.c', '-o', 'libside.so', '-lc'])
```
Rust, the libpng makefile, and various other tools pass `-lc` when they try to link shared libraries. It would be nice for it to work.