### PR TITLE
WasmFS: Fix __syscall_utimensat to handle nonstandard linux behavior

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -523,6 +523,7 @@ jobs:
             wasmfs.test_getcwd_with_non_ascii_name
             wasmfs.test_stat
             wasmfs.test_fstatat
+            wasmfs.test_futimens
             wasmfs.test_unistd_links_memfs
             wasmfs.test_fcntl_open
             wasmfs.test_freetype"

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1089,8 +1089,14 @@ int __syscall_utimensat(int dirFD, intptr_t path_, intptr_t times_, int flags) {
     return -EINVAL;
   }
 
+  // Add AT_EMPTY_PATH as Linux (and so, musl, and us) has a nonstandard
+  // behavior in which an empty path means to operate on whatever is in dirFD
+  // (directory or not), which is exactly the behavior of AT_EMPTY_PATH (but
+  // without passing that in). See "C library/kernel ABI differences" in
+  // https://man7.org/linux/man-pages/man2/utimensat.2.html
+  //
   // TODO: Handle AT_SYMLINK_NOFOLLOW once we traverse symlinks correctly.
-  auto parsed = path::parseFile(path, dirFD);
+  auto parsed = path::getFileAt(dirFD, path, flags | AT_EMPTY_PATH);
   if (auto err = parsed.getError()) {
     return err;
   }

--- a/test/utime/test_futimens.c
+++ b/test/utime/test_futimens.c
@@ -60,7 +60,6 @@ void test() {
   origTimes[1].tv_sec = (time_t)s.st_mtime;
   origTimes[1].tv_nsec = origTimes[1].tv_sec * 1000;
   err = futimens(fd, origTimes);
-  printf("err: %d %d %s\n", err, errno, strerror(errno));
   assert(!err);
 
   close(fd);

--- a/test/utime/test_futimens.c
+++ b/test/utime/test_futimens.c
@@ -60,6 +60,7 @@ void test() {
   origTimes[1].tv_sec = (time_t)s.st_mtime;
   origTimes[1].tv_nsec = origTimes[1].tv_sec * 1000;
   err = futimens(fd, origTimes);
+  printf("err: %d %d %s\n", err, errno, strerror(errno));
   assert(!err);
 
   close(fd);


### PR DESCRIPTION
Musl and Linux allow that syscall to get a null path and to then behave
as if `AT_EMPTY_PATH` were passed, but without passing that flag. That is,
if the path is null then the syscall is to operate on the FD (which might be
anything, and not just a directory, as the parameter normally is).

Another option to fix this might be to modify musl's source code to not
do that in `futimens` or `utimensat` but I think it's better to avoid modifing
musl source code.

With this, `wasmfs.test_futimens` passes.