### PR TITLE
WasmFS: Avoid malloc in FS.readFile

### DIFF
--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -49,10 +49,9 @@ FS.createPreloadedFile = FS_createPreloadedFile;
         throw new Error('Invalid encoding type "' + opts.encoding + '"');
       }
 
-      var buf = withStackSave(() => {
-        // Copy the file into a JS buffer on the heap.
-        return __wasmfs_read_file(stringToUTF8OnStack(path));
-      });
+      // Copy the file into a JS buffer on the heap.
+      var buf = withStackSave(() => __wasmfs_read_file(stringToUTF8OnStack(path)));
+
       // The signed integer length resides in the first 8 bytes of the buffer.
       var length = {{{ makeGetValue('buf', '0', 'i53') }}};
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13286,6 +13286,7 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
   def test_wasi_std_io_stderr(self):
     self.run_wasi_test_suite_test('std_io_stderr')
 
+  @also_with_wasmfs
   @requires_node
   def test_wasi_clock_res_get(self):
     self.run_wasi_test_suite_test('wasi_clock_res_get')


### PR DESCRIPTION
The dependency on malloc there caused a WASI test to fail. It looks like the
WASI test binary doesn't have malloc in it, but this is a post-link test so we
can't add malloc. In any case, we don't use malloc in other similar places in
the file, so switch to a stack allocation which also gets the test passing.

Diff without whitespace is smaller.

Also add a missing dep on `malloc` in `FORCE_FILESYSTEM` mode, as the
advanced JS APIs do actually require it.