### PR TITLE
Remove `RUNTIME_LOGGING` setting. NFC

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -145,8 +145,8 @@ function run() {
 #endif
 
   if (runDependencies > 0) {
-#if RUNTIME_LOGGING
-    err('run() called, but dependencies remain, so not running');
+#if RUNTIME_DEBUG
+    dbg('run() called, but dependencies remain, so not running');
 #endif
     return;
   }
@@ -171,8 +171,8 @@ function run() {
 
     // Loading dylibs can add run dependencies.
     if (runDependencies > 0) {
-#if RUNTIME_LOGGING
-      err('loadDylibs added run() dependencies, not running yet');
+#if RUNTIME_DEBUG
+      dbg('loadDylibs added run() dependencies, not running yet');
 #endif
       return;
     }
@@ -206,8 +206,8 @@ function run() {
 
   // a preRun added a dependency, run will be called later
   if (runDependencies > 0) {
-#if RUNTIME_LOGGING
-    err('run() called, but dependencies remain, so not running');
+#if RUNTIME_DEBUG
+    dbg('run() called, but dependencies remain, so not running');
 #endif
     return;
   }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -233,8 +233,8 @@ function initRuntime() {
 #endif
 
 #if STACK_OVERFLOW_CHECK >= 2
-#if RUNTIME_LOGGING
-  err('__set_stack_limits: ' + _emscripten_stack_get_base() + ', ' + _emscripten_stack_get_end());
+#if RUNTIME_DEBUG
+  dbg('__set_stack_limits: ' + _emscripten_stack_get_base() + ', ' + _emscripten_stack_get_end());
 #endif
   ___set_stack_limits(_emscripten_stack_get_base(), _emscripten_stack_get_end());
 #endif
@@ -759,8 +759,8 @@ function instantiateSync(file, info) {
       cachedCodeFile = locateFile(cachedCodeFile);
       var hasCached = fs.existsSync(cachedCodeFile);
       if (hasCached) {
-#if RUNTIME_LOGGING
-        err('NODE_CODE_CACHING: loading module');
+#if RUNTIME_DEBUG
+        dbg('NODE_CODE_CACHING: loading module');
 #endif
         try {
           module = v8.deserialize(fs.readFileSync(cachedCodeFile));
@@ -775,8 +775,8 @@ function instantiateSync(file, info) {
       module = new WebAssembly.Module(binary);
     }
     if (ENVIRONMENT_IS_NODE && !hasCached) {
-#if RUNTIME_LOGGING
-      err('NODE_CODE_CACHING: saving module');
+#if RUNTIME_DEBUG
+      dbg('NODE_CODE_CACHING: saving module');
 #endif
       fs.writeFileSync(cachedCodeFile, v8.serialize(module));
     }
@@ -1130,8 +1130,8 @@ function createWasm() {
 #endif
 
 #if WASM_ASYNC_COMPILATION
-#if RUNTIME_LOGGING
-  err('asynchronously preparing wasm');
+#if RUNTIME_DEBUG
+  dbg('asynchronously preparing wasm');
 #endif
 #if MODULARIZE
   // If instantiation fails, reject the module ready promise.

--- a/src/settings.js
+++ b/src/settings.js
@@ -50,12 +50,6 @@
 // [link]
 var ASSERTIONS = 1;
 
-// Whether extra logging should be enabled.
-// This logging isn't quite assertion-quality in that it isn't necessarily a
-// symptom that something is wrong.
-// [link]
-var RUNTIME_LOGGING = false;
-
 // Chooses what kind of stack smash checks to emit to generated code:
 // Building with ASSERTIONS=1 causes STACK_OVERFLOW_CHECK default to 1.
 // Since ASSERTIONS=1 is the default at -O0, which itself is the default
@@ -2135,4 +2129,5 @@ var LEGACY_SETTINGS = [
   ['USE_PTHREADS', [0, 1], 'No longer needed. Use -pthread instead'],
   ['USES_DYNAMIC_ALLOC', [1], 'No longer supported. Use -sMALLOC=none'],
   ['REVERSE_DEPS', ['auto', 'all', 'none'], 'No longer needed'],
+  ['RUNTIME_LOGGING', 'RUNTIME_DEBUG'],
 ];


### PR DESCRIPTION
This duplicates the behaviour of `RUNTIME_DEBUG` and is not tested anywhere.  Make it an alias for `RUNTIME_DEBUG` and use `dbg()` rather than `err()` to do ths logging.