### PR TITLE
WasmFS: Support LSan

### DIFF
--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -52,7 +52,7 @@ WasmFS::WasmFS() : rootDirectory(initRootDirectory()), cwd(rootDirectory) {
 // its findings, if it has any. To avoid that, define the LSan entry point as a
 // weak symbol, and call it; if LSan is not enabled this can be optimized out,
 // and if LSan is enabled then we'll check for leaks right at the start of the
-// WasmFS destructor, which is the last time during which it is valid to print
+// WasmFS destructor, which is the last time during which it is valid to print.
 // (Note that this means we can't find leaks inside WasmFS code itself, but that
 // seems fundamentally impossible for the above reasons, unless we made LSan log
 // its findings in a way that does not depend on normal file I/O.)
@@ -61,6 +61,12 @@ __attribute__((weak)) extern "C" void __lsan_do_leak_check(void) {
 
 WasmFS::~WasmFS() {
   // See comment above on this function.
+  //
+  // Note that it is ok for us to call it here, as LSan internally makes all
+  // calls after the first into no-ops. That is, calling it here makes the one
+  // time that leak checks are run be done here, or potentially earlier, but not
+  // later; and as mentioned in the comment above, this is the latest possible
+  // time for the checks to run (since right after this nothing can be printed).
   __lsan_do_leak_check();
 
   // Flush musl libc streams.

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -52,10 +52,10 @@ WasmFS::WasmFS() : rootDirectory(initRootDirectory()), cwd(rootDirectory) {
 // its findings, if it has any. To avoid that, define the LSan entry point as a
 // weak symbol, and call it; if LSan is not enabled this can be optimized out,
 // and if LSan is enabled then we'll check for leaks right at the start of the
-// WasmFS destructor, when it is still valid to print. (Note that this means we
-// can find leaks inside WasmFS code itself, but that seems fundamentally
-// impossible for the above reasons, unless we let LSan log its findings in a
-// way that does not depend on normal file I/O.)
+// WasmFS destructor, which is the last time during which it is valid to print
+// (Note that this means we can't find leaks inside WasmFS code itself, but that
+// seems fundamentally impossible for the above reasons, unless we made LSan log
+// its findings in a way that does not depend on normal file I/O.)
 __attribute__((weak)) extern "C" void __lsan_do_leak_check(void) {
 }
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10398,6 +10398,7 @@ int main(void) {
     'c': ['c', []],
     'cpp': ['cpp', []],
     'growth': ['cpp', ['-sALLOW_MEMORY_GROWTH']],
+    'wasmfs': ['c', ['-sWASMFS']],
   })
   def test_lsan_leaks(self, ext, args):
     self.do_runf(test_file('other/test_lsan_leaks.' + ext),


### PR DESCRIPTION
This is a rather tricky problem, since

* LSan needs WasmFS to be alive in order to printf.
* WasmFS allocates during startup.
* LSan starts up at the first allocation, which ends up inside WasmFS, so LSan starts up first.
* As a result LSan shuts down last due to the order of atexits, which is after WasmFS shut down, so it can't print.

That is, the order of events is

* WasmFS begins to start up, and allocates an innocent vector or such.
* LSan gets called from the allocation and it starts up and does an atexit.
* WasmFS finishes starting up and does its own atexit for its destructor automatically.
* WasmFS's atexit gets called.
* LSan's atexit gets called, but at this time without WasmFS being alive we can't print.

I considered other options here, like some special destructor / atexit
reordering, but everything was much more complex. The other other viable
option I can think of is to make LSan *not* print using printf, e.g., if it
printed using `emscripten_console_*` then that might work, at least on the
web, but not in standalone mode, and also it would be an intrusive change
to the LSan codebase.