### PR TITLE
WasmFS: Fix 4 closure errors due to outdated type annotations

### DIFF
--- a/src/library_wasmfs_node.js
+++ b/src/library_wasmfs_node.js
@@ -50,42 +50,37 @@ mergeInto(LibraryManager.library, {
     return wasmfsNodeFixStat(stat);
   },
 
+  // Ignore closure type errors due to outdated readdirSync annotations, see
+  // https://github.com/google/closure-compiler/pull/4093
+  _wasmfs_node_readdir__docs: '/** @suppress {checkTypes} */',
   _wasmfs_node_readdir__deps: ['$wasmfsNodeConvertNodeCode'],
   _wasmfs_node_readdir: function(path_p, vec) {
-    // Define a function here so that we can tell closure to ignore type
-    // errors, which we need due to outdated type annotations for readdirSync
-    // on both the inputs and outputs, see
-    // See https://github.com/google/closure-compiler/pull/4093
-    /** @suppress {checkTypes} */
-    function inner() {
-      let path = UTF8ToString(path_p);
-      let entries;
-      try {
-        entries = fs.readdirSync(path, { withFileTypes: true });
-      } catch (e) {
-        if (!e.code) throw e;
-        return wasmfsNodeConvertNodeCode(e);
-      }
-      entries.forEach((entry) => {
-        withStackSave(() => {
-          let name = stringToUTF8OnStack(entry.name);
-          let type;
-          // TODO: Figure out how to use `cDefine` here.
-          if (entry.isFile()) {
-            type = 1;
-          } else if (entry.isDirectory()) {
-            type = 2;
-          } else if (entry.isSymbolicLink()) {
-            type = 3;
-          } else {
-            type = 0;
-          }
-          __wasmfs_node_record_dirent(vec, name, type);
-        });
-      });
-      // implicitly return 0
+    let path = UTF8ToString(path_p);
+    let entries;
+    try {
+      entries = fs.readdirSync(path, { withFileTypes: true });
+    } catch (e) {
+      if (!e.code) throw e;
+      return wasmfsNodeConvertNodeCode(e);
     }
-    return inner();
+    entries.forEach((entry) => {
+      withStackSave(() => {
+        let name = stringToUTF8OnStack(entry.name);
+        let type;
+        // TODO: Figure out how to use `cDefine` here.
+        if (entry.isFile()) {
+          type = 1;
+        } else if (entry.isDirectory()) {
+          type = 2;
+        } else if (entry.isSymbolicLink()) {
+          type = 3;
+        } else {
+          type = 0;
+        }
+        __wasmfs_node_record_dirent(vec, name, type);
+      });
+    });
+    // implicitly return 0
   },
 
   _wasmfs_node_get_mode__deps: ['$wasmfsNodeLstat'],


### PR DESCRIPTION
Diff without whitespace is trivial.

Sadly closure doesn't seem to have a better way than to annotation an entire function here, since we need to annotate the `entry.isFile()` things inside ifs, and those cannot be annotated (see rules here: https://github.com/google/closure-compiler/wiki/@suppress-annotations and I spent some time trying to see if there was any wiggle room around those; there doesn't seem to be...).