### PR TITLE
Fix test_pthread_dlopen_many

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9412,7 +9412,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @needs_dylink
   @node_pthreads
-  @disabled('https://github.com/emscripten-core/emscripten/issues/18887')
   def test_pthread_dlopen_many(self):
     nthreads = 10
     self.emcc_args += ['-Wno-experimental', '-pthread']


### PR DESCRIPTION
When a thread sync was cancelled (due to a thread exit prior to performing the
task) we were treating that as an error, but we should treat that as success.

I was able to reproduce the issue by running this test a few times in
a row.  I confirmed that it did not happen in 160 runs after this fix.

Fixes: #18887