### PR TITLE
Skip the stack check cookies when STACK_FIRST. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2733,6 +2733,11 @@ def phase_linker_setup(options, state, newargs):
     # always does.
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$callRuntimeCallbacks']
 
+  # When the stack comes first it ends at address zero so that runtime
+  # will trap on overflow, so there no need to for the stack check cookie.
+  if settings.STACK_FIRST and settings.STACK_OVERFLOW_CHECK == 1 and not settings.PTHREADS:
+    settings.STACK_OVERFLOW_CHECK = 0
+
   if settings.EXIT_RUNTIME and not settings.STANDALONE_WASM:
     # Internal function implemented in musl that calls any functions registered
     # via `atexit` et al.  With STANDALONE_WASM this is all taken care of via

--- a/emscripten.py
+++ b/emscripten.py
@@ -163,7 +163,7 @@ def update_settings_glue(wasm_file, metadata):
     # callMain depends on this library function
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$stringToUTF8OnStack']
 
-  if settings.STACK_OVERFLOW_CHECK and not settings.SIDE_MODULE:
+  if settings.STACK_OVERFLOW_CHECK == 1 and not settings.SIDE_MODULE:
     # writeStackCookie and checkStackCookie both rely on emscripten_stack_get_end being
     # exported.  In theory it should always be present since its defined in compiler-rt.
     assert 'emscripten_stack_get_end' in metadata.exports

--- a/src/library.js
+++ b/src/library.js
@@ -3452,8 +3452,10 @@ mergeInto(LibraryManager.library, {
 #endif
       return EXITSTATUS;
     }
-#if STACK_OVERFLOW_CHECK
+#if STACK_OVERFLOW_CHECK == 1
     checkStackCookie();
+#endif
+#if ASSERTIONS
     if (e instanceof WebAssembly.RuntimeError) {
       if (_emscripten_stack_get_current() <= 0) {
         err('Stack overflow detected.  You can try increasing -sSTACK_SIZE (currently set to {{{ STACK_SIZE }}})');

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1005,7 +1005,7 @@ var LibraryBrowser = {
 
       Browser.mainLoop.runIter(browserIterationFunc);
 
-#if STACK_OVERFLOW_CHECK
+#if STACK_OVERFLOW_CHECK == 1
       checkStackCookie();
 #endif
 

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1079,7 +1079,7 @@ var LibraryPThread = {
     // Call inside wasm module to set up the stack frame for this pthread in wasm module scope
     stackRestore(stackHigh);
 
-#if STACK_OVERFLOW_CHECK
+#if STACK_OVERFLOW_CHECK == 1
     // Write the stack cookie last, after we have set up the proper bounds and
     // current position of the stack.
     writeStackCookie();
@@ -1114,7 +1114,7 @@ var LibraryPThread = {
     // flag -sEMULATE_FUNCTION_POINTER_CASTS to add in emulation for this x86
     // ABI extension.
     var result = {{{ makeDynCall('pp', 'ptr') }}}(arg);
-#if STACK_OVERFLOW_CHECK
+#if STACK_OVERFLOW_CHECK == 1
     checkStackCookie();
 #endif
 #if MINIMAL_RUNTIME

--- a/src/modules.js
+++ b/src/modules.js
@@ -405,7 +405,7 @@ function exportRuntime() {
     runtimeElements.push('WasmSourceMap');
   }
 
-  if (STACK_OVERFLOW_CHECK) {
+  if (STACK_OVERFLOW_CHECK == 1) {
     runtimeElements.push('writeStackCookie');
     runtimeElements.push('checkStackCookie');
   }

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -126,8 +126,10 @@ function stackCheckInit() {
 #else
   _emscripten_stack_init();
 #endif
+#if STACK_OVERFLOW_CHECK == 1
   // TODO(sbc): Move writeStackCookie to native to to avoid this.
   writeStackCookie();
+#endif
 }
 #endif
 
@@ -241,7 +243,7 @@ function run() {
   {
     doRun();
   }
-#if STACK_OVERFLOW_CHECK
+#if STACK_OVERFLOW_CHECK == 1
   checkStackCookie();
 #endif
 }

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -42,7 +42,7 @@ function run() {
 #endif
 #endif // PROXY_TO_PTHREAD
 
-#if STACK_OVERFLOW_CHECK
+#if STACK_OVERFLOW_CHECK == 1
   checkStackCookie();
 #endif
 }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -228,7 +228,7 @@ function initRuntime() {
   if (ENVIRONMENT_IS_PTHREAD) return;
 #endif
 
-#if STACK_OVERFLOW_CHECK
+#if STACK_OVERFLOW_CHECK == 1
   checkStackCookie();
 #endif
 
@@ -245,7 +245,7 @@ function initRuntime() {
 
 #if HAS_MAIN
 function preMain() {
-#if STACK_OVERFLOW_CHECK
+#if STACK_OVERFLOW_CHECK == 1
   checkStackCookie();
 #endif
 #if PTHREADS
@@ -268,7 +268,7 @@ function exitRuntime() {
   // ASYNCIFY cannot be used once the runtime starts shutting down.
   Asyncify.state = Asyncify.State.Disabled;
 #endif
-#if STACK_OVERFLOW_CHECK
+#if STACK_OVERFLOW_CHECK == 1
   checkStackCookie();
 #endif
 #if PTHREADS
@@ -287,7 +287,7 @@ function exitRuntime() {
 #endif
 
 function postRun() {
-#if STACK_OVERFLOW_CHECK
+#if STACK_OVERFLOW_CHECK == 1
   checkStackCookie();
 #endif
 #if PTHREADS

--- a/src/runtime_stack_check.js
+++ b/src/runtime_stack_check.js
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-#if STACK_OVERFLOW_CHECK
+#if STACK_OVERFLOW_CHECK == 1
+
+#if STACK_FIRST && !PTHREADS
+#error "stack check cookies are not needed when STACK_FIRST is set"
+#endif
+
 // Initializes the stack cookie. Called at the startup of main and at the startup of each thread in pthreads mode.
 function writeStackCookie() {
   var max = _emscripten_stack_get_end();

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13050,8 +13050,7 @@ j1: 8589934599, j2: 30064771074, j3: 12884901891
   @no_mac('https://github.com/emscripten-core/emscripten/issues/18175')
   @crossplatform
   def test_stack_overflow(self):
-    self.set_setting('STACK_OVERFLOW_CHECK', 1)
-    self.emcc_args += ['-O1', '--profiling-funcs']
+    self.emcc_args += ['--profiling-funcs']
     self.do_runf(test_file('core/stack_overflow.c'),
                  'Stack overflow detected.  You can try increasing -sSTACK_SIZE',
                  assert_returncode=NON_ZERO)


### PR DESCRIPTION
When STACK_FIRST is set the runtime will trap on stack overflow so there is no need to write or check the stack cookie values.

Fixes: #19389