### PR TITLE
Remove some remaining internal uses of the old USE_PTHREADS settings

### DIFF
--- a/src/shell_minimal_runtime.html
+++ b/src/shell_minimal_runtime.html
@@ -4,7 +4,7 @@
 <script>
 #if !MODULARIZE
   var {{{ EXPORT_NAME }}} = {
-#if USE_PTHREADS
+#if PTHREADS
     worker: '{{{ PTHREAD_WORKER_FILE }}}'
 #endif
 };

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10042,6 +10042,7 @@ int main () {
                                '-sMIN_CHROME_VERSION=58',
                                '-sGL_WORKAROUND_SAFARI_GETCONTEXT_BUG=0',
                                '-sNO_FILESYSTEM',
+                               '-sSTRICT',
                                '--output_eol', 'linux',
                                '-Oz',
                                '--closure=1',

--- a/tools/building.py
+++ b/tools/building.py
@@ -551,7 +551,7 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
   if settings.DYNCALLS:
     CLOSURE_EXTERNS += [path_from_root('src/closure-externs/dyncall-externs.js')]
 
-  if settings.MINIMAL_RUNTIME and settings.USE_PTHREADS:
+  if settings.MINIMAL_RUNTIME and settings.PTHREADS:
     CLOSURE_EXTERNS += [path_from_root('src/closure-externs/minimal_runtime_worker_externs.js')]
 
   args = ['--compilation_level', 'ADVANCED_OPTIMIZATIONS' if advanced else 'SIMPLE_OPTIMIZATIONS']
@@ -888,7 +888,7 @@ def wasm2js(js_file, wasm_file, opt_level, minify_whitespace, use_closure_compil
   # JS optimizations
   if opt_level >= 2:
     passes = []
-    if not debug_info and not settings.USE_PTHREADS:
+    if not debug_info and not settings.PTHREADS:
       passes += ['minifyNames']
       if symbols_file_js:
         passes += ['symbolMap=%s' % symbols_file_js]

--- a/tools/minimal_runtime_shell.py
+++ b/tools/minimal_runtime_shell.py
@@ -75,7 +75,7 @@ def generate_minimal_runtime_load_statement(target_basename):
     if download_wasm and settings.WASM_WORKERS == 1:
       files_to_load += ["binary('%s')" % (target_basename + '.ww.js')]
 
-  if settings.MODULARIZE and settings.USE_PTHREADS:
+  if settings.MODULARIZE and settings.PTHREADS:
     modularize_imports += ["worker: '{{{ PTHREAD_WORKER_FILE }}}'"]
 
   # Download Wasm2JS code if target browser does not support WebAssembly
@@ -153,7 +153,7 @@ def generate_minimal_runtime_load_statement(target_basename):
     # script load from direct script() load to a binary() load so we can still
     # immediately start the download, but can control when we add the script to the
     # DOM.
-    if settings.USE_PTHREADS or settings.WASM_WORKERS:
+    if settings.PTHREADS or settings.WASM_WORKERS:
       script_load = "script(url)"
     else:
       script_load = "script(url).then(() => { URL.revokeObjectURL(url) });"


### PR DESCRIPTION
These were not showing up in tests because they only show up with `-sSTRICT` + `-O2` (or above).

I'm not sure how I missed them in #18923.  My guess is that they might have shown up as part of later commits.

Fixes: #19471