### PR TITLE
wgpuBufferGetMappedRange alignment should be at least 16 if not more

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1859,7 +1859,7 @@ var LibraryWebGPU = {
 
   // In webgpu.h offset and size are passed in as size_t.
   // And library_webgpu assumes that size_t is always 32bit in emscripten.
-  wgpuBufferGetConstMappedRange__deps: ['$warnOnce', 'malloc', 'free'],
+  wgpuBufferGetConstMappedRange__deps: ['$warnOnce', 'memalign', 'free'],
   wgpuBufferGetConstMappedRange: function(bufferId, offset, size) {
     var bufferWrapper = WebGPU.mgrBuffer.objects[bufferId];
     {{{ gpu.makeCheckDefined('bufferWrapper') }}}
@@ -1880,7 +1880,7 @@ var LibraryWebGPU = {
       return 0;
     }
 
-    var data = _malloc(mapped.byteLength);
+    var data = _memalign(16, mapped.byteLength);
     HEAPU8.set(new Uint8Array(mapped), data);
     bufferWrapper.onUnmap.push(() => _free(data));
     return data;
@@ -1888,7 +1888,7 @@ var LibraryWebGPU = {
 
   // In webgpu.h offset and size are passed in as size_t.
   // And library_webgpu assumes that size_t is always 32bit in emscripten.
-  wgpuBufferGetMappedRange__deps: ['$warnOnce', 'malloc', 'free'],
+  wgpuBufferGetMappedRange__deps: ['$warnOnce', 'memalign', 'free'],
   wgpuBufferGetMappedRange: function(bufferId, offset, size) {
     var bufferWrapper = WebGPU.mgrBuffer.objects[bufferId];
     {{{ gpu.makeCheckDefined('bufferWrapper') }}}
@@ -1917,7 +1917,7 @@ var LibraryWebGPU = {
       return 0;
     }
 
-    var data = _malloc(mapped.byteLength);
+    var data = _memalign(16, mapped.byteLength);
     HEAPU8.fill(0, data, mapped.byteLength);
     bufferWrapper.onUnmap.push(() => {
       new Uint8Array(mapped).set(HEAPU8.subarray(data, data + mapped.byteLength));


### PR DESCRIPTION
Currently it is difficult if not impossible to directly use webgpu mapped buffers due to min 8 byte alignment. Any simd math library vector data types require at least 16 byte alignment.
I was trying to port working native webgpu code that used dawn implementation. And due to fact it directly casts mapped buffer to struct alignment is big issue. You can't even allocate more and align it yourself from wasm as for uniforms browser itself asserts that offset is of 256 byte alignment:
```js
Dynamic Offset[0] (8) is not 256 byte aligned.
 - While encoding [RenderPassEncoder].SetBindGroup(0, [BindGroup], 1, ...).
```
You could probably stage uniforms and memcpy them, but there is already overhead of copying buffer from js adding additional one seems unnecessary.

When testing dawn, it also seems to align buffers on 256 bytes. Not sure if its good idea to waste that much space on alignment but I think as a minimum mapped range should return memory aligned 16 bytes if not more.