### PR TITLE
WebIDL binder: Add missing dep on UTF8ToString

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -515,6 +515,7 @@ jobs:
             wasmfs.test_unistd_truncate
             wasmfs.test_readdir
             wasmfs.test_unistd_pipe
+            wasmfs.test_webidl
             wasmfs.test_dlfcn_self
             wasmfs.test_dlfcn_unique_sig
             wasmfs.test_dylink_basics

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -83,7 +83,7 @@ mid_js = []
 pre_c += [r'''
 #include <emscripten.h>
 
-EM_JS_DEPS(webidl_binder, "$intArrayFromString");
+EM_JS_DEPS(webidl_binder, "$intArrayFromString,$UTF8ToString");
 ''']
 
 mid_c += [r'''


### PR DESCRIPTION
This is not a new issue, but in the old FS we always include UTF8ToString so it
was not noticed. In WasmFS this is not the case, and we need to include the
dependency.

I know we've discussed adding dependencies directly from C++ code, but I
don't recall if we did anything? If we did, that would be another way to fix this,
as the usage of UTF8ToString appears in the JS output of the WebIDL binder
(so we could make it emit something matching in the C++, I think).
