### PR TITLE
CI: Avoid running wasm64l.test_bigswitch on older versions of node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,11 +545,13 @@ jobs:
       - install-v8
       - run-tests:
           title: "wasm64l"
-          test_targets: "wasm64l"
+          # On older versions of node wasm64l.test_bigswitch uses a lot (~3.5Gb)
+          # of memory, so skip it here, but run it below under node-canary.
+          test_targets: "wasm64l skip:wasm64l.test_bigswitch"
       - install-node-canary
       - run-tests:
           title: "wasm64"
-          test_targets: "wasm64"
+          test_targets: "wasm64 wasm64l.test_bigswitch"
       - upload-test-results
   test-node-compat:
     # We don't use `bionic` here since its tool old to run recent node versions:


### PR DESCRIPTION
We've seen this test flake a bunch recently and be kill with -9, presumably by the OOM killer.