### PR TITLE
[WebGPU] More use of i53 helpers. NFC

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1503,11 +1503,9 @@ var LibraryWebGPU = {
 
   wgpuQueueWriteBuffer: function(queueId,
       bufferId, {{{ defineI64Param('bufferOffset') }}}, data, size) {
-    {{{ receiveI64ParamAsI32s('bufferOffset') }}}
-
+    {{{ receiveI64ParamAsI53('bufferOffset') }}}
     var queue = WebGPU.mgrQueue.get(queueId);
     var buffer = WebGPU.mgrBuffer.get(bufferId);
-    var bufferOffset = convertI32PairToI53(bufferOffset_low, bufferOffset_high);
     // There is a size limitation for ArrayBufferView. Work around by passing in a subarray
     // instead of the whole heap. crbug.com/1201109
     var subarray = HEAPU8.subarray(data, data + size);
@@ -1706,16 +1704,13 @@ var LibraryWebGPU = {
   },
 
   wgpuCommandEncoderCopyBufferToBuffer: function(encoderId, srcId, {{{ defineI64Param('srcOffset') }}}, dstId, {{{ defineI64Param('dstOffset') }}}, {{{ defineI64Param('size') }}}) {
-    {{{ receiveI64ParamAsI32s('srcOffset') }}}
-    {{{ receiveI64ParamAsI32s('dstOffset') }}}
-    {{{ receiveI64ParamAsI32s('size') }}}
+    {{{ receiveI64ParamAsI53('srcOffset') }}}
+    {{{ receiveI64ParamAsI53('dstOffset') }}}
+    {{{ receiveI64ParamAsI53('size') }}}
     var commandEncoder = WebGPU.mgrCommandEncoder.get(encoderId);
     var src = WebGPU.mgrBuffer.get(srcId);
     var dst = WebGPU.mgrBuffer.get(dstId);
-    commandEncoder["copyBufferToBuffer"](
-      src, convertI32PairToI53(srcOffset_low, srcOffset_high),
-      dst, convertI32PairToI53(dstOffset_low, dstOffset_high),
-      convertI32PairToI53(size_low, size_high));
+    commandEncoder["copyBufferToBuffer"](src, srcOffset, dst, dstOffset, size);
   },
 
   wgpuCommandEncoderCopyBufferToTexture: function(encoderId, srcPtr, dstPtr, copySizePtr) {
@@ -1741,11 +1736,10 @@ var LibraryWebGPU = {
 
   wgpuCommandEncoderResolveQuerySet: function(encoderId, querySetId, firstQuery, queryCount,
       destinationId, {{{ defineI64Param('destinationOffset') }}}) {
-    {{{ receiveI64ParamAsI32s('destinationOffset') }}}
+    {{{ receiveI64ParamAsI53('destinationOffset') }}}
     var commandEncoder = WebGPU.mgrCommandEncoder.get(encoderId);
     var querySet = WebGPU.mgrQuerySet.get(querySetId);
     var destination = WebGPU.mgrBuffer.get(destinationId);
-    var destinationOffset = convertI32PairToI53(destinationOffset_low, destinationOffset_high);
 
     commandEncoder["resolveQuerySet"](querySet, firstQuery, queryCount, destination, destinationOffset);
   },
@@ -2085,9 +2079,8 @@ var LibraryWebGPU = {
     pass["dispatchWorkgroups"](x, y, z);
   },
   wgpuComputePassEncoderDispatchWorkgroupsIndirect: function(passId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
-    {{{ receiveI64ParamAsI32s('indirectOffset') }}}
+    {{{ receiveI64ParamAsI53('indirectOffset') }}}
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
-    var indirectOffset = convertI32PairToI53(indirectOffset_low, indirectOffset_high);
     var pass = WebGPU.mgrComputePassEncoder.get(passId);
     pass["dispatchWorkgroupsIndirect"](indirectBuffer, indirectOffset);
   },
@@ -2152,11 +2145,10 @@ var LibraryWebGPU = {
     pass["setBlendConstant"](color);
   },
   wgpuRenderPassEncoderSetIndexBuffer: function(passId, bufferId, format, {{{ defineI64Param('offset') }}}, {{{ defineI64Param('size') }}}) {
-    {{{ receiveI64ParamAsI32s('offset') }}}
+    {{{ receiveI64ParamAsI53('offset') }}}
     {{{ receiveI64ParamAsI32s('size') }}}
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
     var buffer = WebGPU.mgrBuffer.get(bufferId);
-    var offset = convertI32PairToI53(offset_low, offset_high);
     var size = {{{ gpu.convertI32PairToI53WithSentinelAsUndefined('size_low', 'size_high') }}};
     pass["setIndexBuffer"](buffer, WebGPU.IndexFormat[format], offset, size);
   },
@@ -2178,11 +2170,10 @@ var LibraryWebGPU = {
     pass["setStencilReference"](reference);
   },
   wgpuRenderPassEncoderSetVertexBuffer: function(passId, slot, bufferId, {{{ defineI64Param('offset') }}}, {{{ defineI64Param('size') }}}) {
-    {{{ receiveI64ParamAsI32s('offset') }}}
+    {{{ receiveI64ParamAsI53('offset') }}}
     {{{ receiveI64ParamAsI32s('size') }}}
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
     var buffer = WebGPU.mgrBuffer.get(bufferId);
-    var offset = convertI32PairToI53(offset_low, offset_high);
     var size = {{{ gpu.convertI32PairToI53WithSentinelAsUndefined('size_low', 'size_high') }}};
     pass["setVertexBuffer"](slot, buffer, offset, size);
   },
@@ -2196,16 +2187,14 @@ var LibraryWebGPU = {
     pass["drawIndexed"](indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
   },
   wgpuRenderPassEncoderDrawIndirect: function(passId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
-    {{{ receiveI64ParamAsI32s('indirectOffset') }}}
+    {{{ receiveI64ParamAsI53('indirectOffset') }}}
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
-    var indirectOffset = convertI32PairToI53(indirectOffset_low, indirectOffset_high);
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
     pass["drawIndirect"](indirectBuffer, indirectOffset);
   },
   wgpuRenderPassEncoderDrawIndexedIndirect: function(passId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
-    {{{ receiveI64ParamAsI32s('indirectOffset') }}}
+    {{{ receiveI64ParamAsI53('indirectOffset') }}}
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
-    var indirectOffset = convertI32PairToI53(indirectOffset_low, indirectOffset_high);
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
     pass["drawIndexedIndirect"](indirectBuffer, indirectOffset);
   },
@@ -2286,11 +2275,10 @@ var LibraryWebGPU = {
     }
   },
   wgpuRenderBundleEncoderSetIndexBuffer: function(bundleId, bufferId, format, {{{ defineI64Param('offset') }}}, {{{ defineI64Param('size') }}}) {
-    {{{ receiveI64ParamAsI32s('offset') }}}
+    {{{ receiveI64ParamAsI53('offset') }}}
     {{{ receiveI64ParamAsI32s('size') }}}
     var pass = WebGPU.mgrRenderBundleEncoder.get(bundleId);
     var buffer = WebGPU.mgrBuffer.get(bufferId);
-    var offset = convertI32PairToI53(offset_low, offset_high);
     var size = {{{ gpu.convertI32PairToI53WithSentinelAsUndefined('size_low', 'size_high') }}};
     pass["setIndexBuffer"](buffer, WebGPU.IndexFormat[format], offset, size);
   },
@@ -2300,11 +2288,10 @@ var LibraryWebGPU = {
     pass["setPipeline"](pipeline);
   },
   wgpuRenderBundleEncoderSetVertexBuffer: function(bundleId, slot, bufferId, {{{ defineI64Param('offset') }}}, {{{ defineI64Param('size') }}}) {
-    {{{ receiveI64ParamAsI32s('offset') }}}
+    {{{ receiveI64ParamAsI53('offset') }}}
     {{{ receiveI64ParamAsI32s('size') }}}
     var pass = WebGPU.mgrRenderBundleEncoder.get(bundleId);
     var buffer = WebGPU.mgrBuffer.get(bufferId);
-    var offset = convertI32PairToI53(offset_low, offset_high);
     var size = {{{ gpu.convertI32PairToI53WithSentinelAsUndefined('size_low', 'size_high') }}};
     pass["setVertexBuffer"](slot, buffer, offset, size);
   },
@@ -2318,16 +2305,14 @@ var LibraryWebGPU = {
     pass["drawIndexed"](indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
   },
   wgpuRenderBundleEncoderDrawIndirect: function(bundleId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
-    {{{ receiveI64ParamAsI32s('indirectOffset') }}}
+    {{{ receiveI64ParamAsI53('indirectOffset') }}}
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
-    var indirectOffset = convertI32PairToI53(indirectOffset_low, indirectOffset_high);
     var pass = WebGPU.mgrRenderBundleEncoder.get(bundleId);
     pass["drawIndirect"](indirectBuffer, indirectOffset);
   },
   wgpuRenderBundleEncoderDrawIndexedIndirect: function(bundleId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
-    {{{ receiveI64ParamAsI32s('indirectOffset') }}}
+    {{{ receiveI64ParamAsI53('indirectOffset') }}}
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
-    var indirectOffset = convertI32PairToI53(indirectOffset_low, indirectOffset_high);
     var pass = WebGPU.mgrRenderBundleEncoder.get(bundleId);
     pass["drawIndexedIndirect"](indirectBuffer, indirectOffset);
   },


### PR DESCRIPTION
Followup to #19480, I noticed we can just use the helper directly here. We can probably do something similar with
gpu.convertI32PairToI53WithSentinelAsUndefined but I'll eave that as a followup.