### PR TITLE
dylink: Share `dynamicLibraries` array across workers

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -379,6 +379,7 @@ var LibraryPThread = {
         'wasmOffsetConverter': wasmOffsetConverter,
 #endif
 #if MAIN_MODULE
+        'dynamicLibraries': dynamicLibraries,
         // Share all modules that have been loaded so far.  New workers
         // won't start running threads until these are all loaded.
         'sharedModules': sharedModules,

--- a/src/runtime_pthread.js
+++ b/src/runtime_pthread.js
@@ -129,6 +129,7 @@ if (ENVIRONMENT_IS_PTHREAD) {
         };
 
 #if MAIN_MODULE
+        dynamicLibraries = msgData['dynamicLibraries'];
         sharedModules = msgData['sharedModules'];
 #if RUNTIME_DEBUG
         dbg(`worker: received ${Object.keys(msgData['sharedModules']).length} shared modules: ${Object.keys(msgData.sharedModules)}`);

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9412,13 +9412,17 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args += args
     self.emcc_args += ['--pre-js', 'pre.js']
     self.emcc_args += ['--js-library', 'lib.js']
-    # This test is for setting dynamicLibraries at runtime so we don't
+    # This test is for setting dynamicLibraries at runtime, so we don't
     # want emscripten loading `liblib.so` automatically (which it would
-    # do without this setting.
+    # do without this setting)
     self.set_setting('NO_AUTOLOAD_DYLIBS')
 
     create_file('pre.js', '''
-      Module['dynamicLibraries'] = ['liblib.so'];
+      if (typeof ENVIRONMENT_IS_PTHREAD == 'undefined' || !ENVIRONMENT_IS_PTHREAD) {
+        // Load liblib.so on the main thread, this would be equivalent to
+        // defining it outside the module (e.g. in MODULARIZE mode).
+        Module['dynamicLibraries'] = ['liblib.so'];
+      }
     ''')
 
     create_file('lib.js', '''


### PR DESCRIPTION
To ensure that the same dynamic libraries are loaded among all workers, it remains necessary to share the `dynamicLibraries` array, especially when it is defined outside the module (e.g. in `MODULARIZE` mode).

Fixes a regression introduced in commit ceb2e284a2a714d9261ccb8d8721e5f92bb3cde7.

Resolves: #20507.