### PR TITLE
Setup the emscripten cache directory lazily

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -188,6 +188,7 @@ def main():
   # Check sanity so that if settings file has changed, the cache is cleared here.
   # Otherwise, the cache will clear in an emcc process, which is invoked while building
   # a system library into the cache, causing trouble.
+  cache.setup()
   shared.check_sanity()
 
   if args.lto:

--- a/emcc.py
+++ b/emcc.py
@@ -3513,7 +3513,7 @@ def parse_args(newargs):
       logger.error('jcache is no longer supported')
     elif check_arg('--cache'):
       config.CACHE = os.path.normpath(consume_arg())
-      cache.setup(config.CACHE)
+      cache.setup()
       # Ensure child processes share the same cache (e.g. when using emcc to compiler system
       # libraries)
       os.environ['EM_CACHE'] = config.CACHE

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -960,6 +960,7 @@ f.close()
       end = stderr.index('End of search list.')
       includes = stderr[start:end]
       includes = [i.strip() for i in includes.splitlines()[1:]]
+      cache.ensure_setup()
       cachedir = os.path.normpath(cache.cachedir)
       llvmroot = os.path.normpath(os.path.dirname(config.LLVM_ROOT))
       for i in includes:

--- a/tools/building.py
+++ b/tools/building.py
@@ -60,6 +60,7 @@ def remove_quotes(arg):
 
 
 def get_building_env():
+  cache.ensure()
   env = os.environ.copy()
   # point CC etc. to the em* tools.
   env['CC'] = EMCC

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -66,20 +66,24 @@ def lock(reason):
 
 
 def ensure():
+  ensure_setup()
   utils.safe_ensure_dirs(cachedir)
 
 
 def erase():
+  ensure_setup()
   with lock('erase'):
     # Delete everything except the lockfile itself
     utils.delete_contents(cachedir, exclude=[os.path.basename(cachelock_name)])
 
 
 def get_path(name):
+  ensure_setup()
   return Path(cachedir, name)
 
 
 def get_sysroot(absolute):
+  ensure_setup()
   if absolute:
     return os.path.join(cachedir, 'sysroot')
   return 'sysroot'
@@ -94,6 +98,7 @@ def get_sysroot_dir(*parts):
 
 
 def get_lib_dir(absolute):
+  ensure_setup()
   path = Path(get_sysroot(absolute=absolute), 'lib')
   if settings.MEMORY64:
     path = Path(path, 'wasm64-emscripten')
@@ -137,6 +142,7 @@ def get_lib(libname, *args, **kwargs):
 # Request a cached file. If it isn't in the cache, it will be created with
 # the given creator function
 def get(shortname, creator, what=None, force=False, quiet=False, deferred=False):
+  ensure_setup()
   cachename = Path(cachedir, shortname)
   # Check for existence before taking the lock in case we can avoid the
   # lock completely.
@@ -168,13 +174,18 @@ def get(shortname, creator, what=None, force=False, quiet=False, deferred=False)
   return str(cachename)
 
 
-def setup(dirname):
+def setup():
   global cachedir, cachelock, cachelock_name
   # figure out the root directory for all caching
-  cachedir = Path(dirname).resolve()
+  cachedir = Path(config.CACHE).resolve()
 
   # since the lock itself lives inside the cache directory we need to ensure it
   # exists.
   ensure()
   cachelock_name = Path(cachedir, 'cache.lock')
   cachelock = filelock.FileLock(cachelock_name)
+
+
+def ensure_setup():
+  if not cachedir:
+    setup()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -748,7 +748,6 @@ def get_llvm_target():
 def init():
   set_version_globals()
   setup_temp_dirs()
-  cache.setup(config.CACHE)
 
 
 # ============================================================================


### PR DESCRIPTION
This allows tools/scripts that don't use the cache at all to avoid setting one up.

See: #19490