### PR TITLE
WasmFS: Add missing JS library deps

### DIFF
--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -20,6 +20,8 @@ FS.createPreloadedFile = FS_createPreloadedFile;
     '$readI53FromI64',
     '$FS_createPreloadedFile',
     '$FS_getMode',
+    // For FS.readFile
+    '$UTF8ArrayToString',
 #if FORCE_FILESYSTEM
     '$FS_modeStringToFlags',
     'malloc',

--- a/src/library_wasmfs_node.js
+++ b/src/library_wasmfs_node.js
@@ -53,7 +53,11 @@ mergeInto(LibraryManager.library, {
   // Ignore closure type errors due to outdated readdirSync annotations, see
   // https://github.com/google/closure-compiler/pull/4093
   _wasmfs_node_readdir__docs: '/** @suppress {checkTypes} */',
-  _wasmfs_node_readdir__deps: ['$wasmfsNodeConvertNodeCode'],
+  _wasmfs_node_readdir__deps: [
+    '$wasmfsNodeConvertNodeCode',
+    '$withStackSave',
+    '$stringToUTF8OnStack'
+  ],
   _wasmfs_node_readdir: function(path_p, vec) {
     let path = UTF8ToString(path_p);
     let entries;

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -143,7 +143,7 @@ mergeInto(LibraryManager.library, {
     wasmfsOPFSProxyFinish(ctx);
   },
 
-  _wasmfs_opfs_get_entries__deps: ['$wasmfsOPFSProxyFinish'],
+  _wasmfs_opfs_get_entries__deps: ['$wasmfsOPFSProxyFinish', '$withStackSave'],
   _wasmfs_opfs_get_entries: async function(ctx, dirID, entriesPtr, errPtr) {
     let dirHandle = wasmfsOPFSDirectoryHandles.get(dirID);
 

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1285,7 +1285,7 @@ int __syscall_ioctl(int fd, int request, ...) {
     case TIOCGWINSZ:
     case TIOCSWINSZ: {
       // TTY operations that we do nothing for anyhow can just be ignored.
-      return -0;
+      return 0;
     }
     default: {
       return -EINVAL; // not supported


### PR DESCRIPTION
These were not noticed because we were including lots of JS code anyhow
any time WasmFS is used. These fixes will unblock improvements to JS code
size.

Also change an integer from `-0` to `0`.