### PR TITLE
Re-enable test_pthread_create_standalone

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9195,11 +9195,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args.append('-fPIC')
     self.do_core_test('test_hello_world.c')
 
-  # Marked as impure since we don't have a wasi-threads is still
-  # a WIP.
-  # Test is disabled on standalone because of flakes, see
-  # https://github.com/emscripten-core/emscripten/issues/18405
-  # @also_with_standalone_wasm(impure=True)
+  @also_with_standalone_wasm(impure=True)
   @node_pthreads
   def test_pthread_create(self):
     if not self.get_setting('STANDALONE_WASM'):


### PR DESCRIPTION
Assuming updating node took care of the flakiness, this will fix #18405