### PR TITLE
[WIP] Do not preventDefault() for Ctrl+v paste event

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -282,7 +282,11 @@ var LibraryHTML5 = {
       if (targetThread) JSEvents.queueEventHandlerOnThread_iiii(targetThread, callbackfunc, eventTypeId, keyEventData, userData);
       else
 #endif
-      if ({{{ makeDynCall('iiii', 'callbackfunc') }}}(eventTypeId, keyEventData, userData)) e.preventDefault();
+      if ({{{ makeDynCall('iiii', 'callbackfunc') }}}(eventTypeId, keyEventData, userData)) {
+        if(!(event.ctrlKey && event.key == 'v')) {
+          e.preventDefault();
+        }
+      }
     };
 
     var eventHandler = {


### PR DESCRIPTION
Hello Emscripten,

There has been somewhat lengthy debate on how to handle Copy/Paste events in our [imgui](https://github.com/ocornut/imgui) WASM apps cleanly. According to my search, this [thread on HelloImgui project repo](https://github.com/pthom/hello_imgui/issues/3) is a good summary.

@slowriot came up with a nice [single header](https://github.com/Armchair-Software/emscripten-browser-clipboard/blob/main/emscripten_browser_clipboard.h) that apparently solves the integration just about right.

It didn't work for me though, I had to use mouse middle button to generate the `paste` event. An experience I summarized over [here in this post](https://github.com/pthom/hello_imgui/issues/3#issuecomment-1564536870).

Following @pthom's suggestions, I realized that the change outlined in this PR helps me.
My ImGui SDL backed WASM app receives paste events now and I have a seamless Copy/Paste experience on my Linux Firefox system.

I do not think this is supposed to be the final solution as it is definitely missing some corner cases I am oblivious to.