### PR TITLE
Fix NODERAWFS regression caused by #19391

### DIFF
--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -94,7 +94,7 @@ mergeInto(LibraryManager.library, {
       }
       var newMode = NODEFS.getMode(pathTruncated);
       var node = { id: st.ino, mode: newMode, node_ops: NODERAWFS, path: path }
-      return FS.createStream({ nfd: nfd, position: 0, path: path, flags: flags, node: node, seekable: true }, nfd);
+      return FS.createStream({ nfd: nfd, position: 0, path: path, flags: flags, node: node, seekable: true });
     },
     createStream: function(stream, fd) {
       // Call the original FS.createStream


### PR DESCRIPTION
Thanks to @kleisauke for pointing out that the old code always passed -1 as the second argument and not `nfd`.  `nfd` here is the node raw FD which is different the FD space we return to the user.