### PR TITLE
Improve test/other/test_ioctl.c

### DIFF
--- a/test/other/test_ioctl.c
+++ b/test/other/test_ioctl.c
@@ -14,7 +14,7 @@
 int main() {
   // CLOEXEC is not supported
   assert(ioctl(STDOUT_FILENO, FIOCLEX, NULL) == -1);
-  assert(errno = EINVAL);
+  assert(errno == EINVAL);
 
   puts("success");
   return 0;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8971,7 +8971,7 @@ end
       self.do_other_test('test_ioctl_window_size.cpp')
 
   @also_with_wasmfs
-  def test_sys_ioctl(self):
+  def test_ioctl(self):
     # ioctl requires filesystem
     self.do_other_test('test_ioctl.c', emcc_args=['-sFORCE_FILESYSTEM'])
 


### PR DESCRIPTION
`assert(error = EINVAL)` looks wrong. I think you meant `==`.

Also, this changes the test name from `other.test_sys_ioctl` to `other.test_ioctl` because its file is named `test/other/test_ioctl.c`. (This does not really matter, but this inconsistency took me a little to understand the structure of the test. Let me know if it is intentional.)