### PR TITLE
Fix lsan false positive in emscripten_malloc_wasm_worker. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,6 +469,7 @@ jobs:
             asan.test_dlfcn_basic
             asan.test_async_hello_stack_switching
             asan.test_cubescript
+            asan.test_wasm_worker_hello
             lsan.test_stdio_locking
             lsan.test_dlfcn_basic
             lsan.test_pthread_create"

--- a/system/lib/wasm_worker/library_wasm_worker.c
+++ b/system/lib/wasm_worker/library_wasm_worker.c
@@ -57,7 +57,7 @@ emscripten_wasm_worker_t emscripten_malloc_wasm_worker(size_t stackSize)
 	// Add the TLS size to the provided stackSize so that the allocation
 	// will always be large enough to hold the worker TLS data.
 	stackSize += ROUND_UP(__builtin_wasm_tls_size(), 16);
-	return emscripten_create_wasm_worker(memalign(16, stackSize), stackSize);
+	return emscripten_create_wasm_worker(emscripten_builtin_memalign(16, stackSize), stackSize);
 }
 
 void emscripten_wasm_worker_sleep(int64_t nsecs)


### PR DESCRIPTION
This function never frees is memory so we don't want to consider the memory allocated here a memory leak.  This fixes a failure of the `asan.test_wasm_worker_hello` test which started failing after the recent compiler-rt update in #19506.