### PR TITLE
Make more use of emscripten_out/emscripten_err in test code. NFC

### DIFF
--- a/test/core/test_em_asm.cpp
+++ b/test/core/test_em_asm.cpp
@@ -12,7 +12,7 @@ int main() {
 
   unsigned long p = 8;
   EM_ASM({
-    console.log("int types:");
+    out("int types:");
     out("         char : " + $0);
     out("  signed char : " + $1);
     out("unsigned char : " + $2);
@@ -71,35 +71,35 @@ int main() {
 
   // Test mixing ints and doubles
   EM_ASM({
-    console.log("idii");
+    out("idii");
     out("a " + $0);
     out("b " + $1);
     out("c " + $2);
     out("d " + $3);
   }, 1, 3.14159, 3, 4);
   EM_ASM({
-    console.log("diii");
+    out("diii");
     out("a " + $0);
     out("b " + $1);
     out("c " + $2);
     out("d " + $3);
   }, 3.14159, 2, 3, 4);
   EM_ASM({
-    console.log("iidi");
+    out("iidi");
     out("a " + $0);
     out("b " + $1);
     out("c " + $2);
     out("d " + $3);
   }, 1, 2, 3.14159, 4);
   EM_ASM({
-    console.log("ddii");
+    out("ddii");
     out("a " + $0);
     out("b " + $1);
     out("c " + $2);
     out("d " + $3);
   }, 3.14159, 2.1828, 3, 4);
   EM_ASM({
-    console.log("iddi");
+    out("iddi");
     out("a " + $0);
     out("b " + $1);
     out("c " + $2);

--- a/test/core/test_em_asm_2.cpp
+++ b/test/core/test_em_asm_2.cpp
@@ -9,97 +9,97 @@
 int main()
 {
   printf("EM_ASM: Simple expression without trailing semicolon\n");
-  EM_ASM(console.log('1. expression without trailing semicolon'));
-  EM_ASM("console.log('2. expression without trailing semicolon')");
-  EM_ASM({"console.log('3. expression without trailing semicolon')"});
-  EM_ASM({console.log('4. expression without trailing semicolon')});
-  EM_ASM("{console.log('5. expression without trailing semicolon')}");
+  EM_ASM(out('1. expression without trailing semicolon'));
+  EM_ASM("out('2. expression without trailing semicolon')");
+  EM_ASM({"out('3. expression without trailing semicolon')"});
+  EM_ASM({out('4. expression without trailing semicolon')});
+  EM_ASM("{out('5. expression without trailing semicolon')}");
 
   printf("\nEM_ASM: Double quotes\n");
-  EM_ASM(console.log("1. string in double quotes"));
-  EM_ASM("console.log(\"2. string in double quotes\")");
-  EM_ASM({"console.log(\"3. string in double quotes\")"});
-  EM_ASM({console.log("4. string in double quotes")});
-  EM_ASM("{console.log(\"5. string in double quotes\")}");
+  EM_ASM(out("1. string in double quotes"));
+  EM_ASM("out(\"2. string in double quotes\")");
+  EM_ASM({"out(\"3. string in double quotes\")"});
+  EM_ASM({out("4. string in double quotes")});
+  EM_ASM("{out(\"5. string in double quotes\")}");
 
   printf("\nEM_ASM: Double quotes inside a string\n");
-  EM_ASM(console.log('1. this is \"double\" \"quotes\"'));
-  EM_ASM(console.log('2. this is "double" "quotes" without escaping'));
-  EM_ASM("console.log('3. this is \"double\" \"quotes\"')");
-  EM_ASM({"console.log('4. this is \"double\" \"quotes\"')"});
-  EM_ASM({console.log('5. this is \"double\" \"quotes\"')});
-  EM_ASM({console.log('6. this is "double" "quotes" without esacping')});
-  EM_ASM("{console.log('7. this is \"double\" \"quotes\"')}");
+  EM_ASM(out('1. this is \"double\" \"quotes\"'));
+  EM_ASM(out('2. this is "double" "quotes" without escaping'));
+  EM_ASM("out('3. this is \"double\" \"quotes\"')");
+  EM_ASM({"out('4. this is \"double\" \"quotes\"')"});
+  EM_ASM({out('5. this is \"double\" \"quotes\"')});
+  EM_ASM({out('6. this is "double" "quotes" without esacping')});
+  EM_ASM("{out('7. this is \"double\" \"quotes\"')}");
 
   printf("\nEM_ASM: Pass a string\n");
-  EM_ASM(console.log('1. hello ' + UTF8ToString($0)), "world!");
-  EM_ASM("console.log('2. hello ' + UTF8ToString($0))", "world!");
-  EM_ASM({"console.log('3. hello ' + UTF8ToString($0))"}, "world!");
-  EM_ASM({console.log('4. hello ' + UTF8ToString($0))}, "world!");
-  EM_ASM("{console.log('5. hello ' + UTF8ToString($0))}", "world!");
+  EM_ASM(out('1. hello ' + UTF8ToString($0)), "world!");
+  EM_ASM("out('2. hello ' + UTF8ToString($0))", "world!");
+  EM_ASM({"out('3. hello ' + UTF8ToString($0))"}, "world!");
+  EM_ASM({out('4. hello ' + UTF8ToString($0))}, "world!");
+  EM_ASM("{out('5. hello ' + UTF8ToString($0))}", "world!");
 
   printf("\nEM_ASM: Simple expression without trailing semicolon, wrap code block in extra parentheses\n");
-  EM_ASM((console.log('1. expression without trailing semicolon, in parentheses')));
-  EM_ASM(("console.log('2. expression without trailing semicolon, in parentheses')"));
-  EM_ASM(({"console.log('3. expression without trailing semicolon, in parentheses')"}));
-  EM_ASM(({console.log('4. expression without trailing semicolon, in parentheses')}));
-  EM_ASM(("{console.log('5. expression without trailing semicolon, in parentheses')}"));
+  EM_ASM((out('1. expression without trailing semicolon, in parentheses')));
+  EM_ASM(("out('2. expression without trailing semicolon, in parentheses')"));
+  EM_ASM(({"out('3. expression without trailing semicolon, in parentheses')"}));
+  EM_ASM(({out('4. expression without trailing semicolon, in parentheses')}));
+  EM_ASM(("{out('5. expression without trailing semicolon, in parentheses')}"));
 
   printf("\nEM_ASM: Two statements, separated with a semicolon\n");
-  EM_ASM(console.log('1. two'); console.log('1. statements'););
-  EM_ASM("console.log('2. two'); console.log('2. statements 2');");
-  EM_ASM({"console.log('3. two'); console.log('3. statements 3');"});
-  EM_ASM({console.log('4. two'); console.log('4. statements 4');});
-  EM_ASM("{console.log('5. two'); console.log('5. statements 5');}");
+  EM_ASM(out('1. two'); out('1. statements'););
+  EM_ASM("out('2. two'); out('2. statements 2');");
+  EM_ASM({"out('3. two'); out('3. statements 3');"});
+  EM_ASM({out('4. two'); out('4. statements 4');});
+  EM_ASM("{out('5. two'); out('5. statements 5');}");
 
   printf("\nEM_ASM: Pass an integer\n");
-  EM_ASM(console.log('1. int ' + $0), 42);
-  EM_ASM("console.log('2. int ' + $0)", 43);
-  EM_ASM({"console.log('3. int ' + $0)"}, 44);
-  EM_ASM({console.log('4. int ' + $0)}, 45);
-  EM_ASM("{console.log('5. int ' + $0)}", 46);
+  EM_ASM(out('1. int ' + $0), 42);
+  EM_ASM("out('2. int ' + $0)", 43);
+  EM_ASM({"out('3. int ' + $0)"}, 44);
+  EM_ASM({out('4. int ' + $0)}, 45);
+  EM_ASM("{out('5. int ' + $0)}", 46);
 
   printf("\nEM_ASM: Evaluate an anonymous function\n");
-  EM_ASM((function() {console.log('1. evaluating anonymous function ' + $0)})(), 42);
-  EM_ASM("(function() {console.log('2. evaluating anonymous function ' + $0)})()", 42);
-  EM_ASM({"(function() {console.log('3. evaluating anonymous function ' + $0)})()"}, 42);
-  EM_ASM({(function() {console.log('4. evaluating anonymous function ' + $0)})()}, 42);
-  EM_ASM("{(function() {console.log('5. evaluating anonymous function ' + $0)})()}", 42);
+  EM_ASM((function() {out('1. evaluating anonymous function ' + $0)})(), 42);
+  EM_ASM("(function() {out('2. evaluating anonymous function ' + $0)})()", 42);
+  EM_ASM({"(function() {out('3. evaluating anonymous function ' + $0)})()"}, 42);
+  EM_ASM({(function() {out('4. evaluating anonymous function ' + $0)})()}, 42);
+  EM_ASM("{(function() {out('5. evaluating anonymous function ' + $0)})()}", 42);
 
   printf("\nEM_ASM: Pass an integer and a double\n");
-  EM_ASM(console.log('1. int and double ' + $0 + ' ' + $1), 42, 43.5);
-  EM_ASM("console.log('2. int and double ' + $0 + ' ' + $1)", 42, 43.5);
-  EM_ASM({"console.log('3. int and double ' + $0 + ' ' + $1)"}, 42, 43.5);
-  EM_ASM({console.log('4. int and double ' + $0 + ' ' + $1)}, 42, 43.5);
-  EM_ASM("{console.log('5. int and double ' + $0 + ' ' + $1)}", 42, 43.5);
+  EM_ASM(out('1. int and double ' + $0 + ' ' + $1), 42, 43.5);
+  EM_ASM("out('2. int and double ' + $0 + ' ' + $1)", 42, 43.5);
+  EM_ASM({"out('3. int and double ' + $0 + ' ' + $1)"}, 42, 43.5);
+  EM_ASM({out('4. int and double ' + $0 + ' ' + $1)}, 42, 43.5);
+  EM_ASM("{out('5. int and double ' + $0 + ' ' + $1)}", 42, 43.5);
 
   int i;
 
   printf("\nEM_ASM_INT: Pass an integer, return an integer back\n");
-  i = EM_ASM_INT(console.log('1. got int ' + $0); return 3.5;, 42); printf("1. returned int %d\n", i);
-  i = EM_ASM_INT("console.log('2. got int ' + $0); return 4.5;", 42); printf("2. returned int %d\n", i);
-  i = EM_ASM_INT({"console.log('3. got int ' + $0); return 5.5;"}, 42); printf("3. returned int %d\n", i);
-  i = EM_ASM_INT({console.log('4. got int ' + $0); return 6.5;}, 42); printf("4. returned int %d\n", i);
-  i = EM_ASM_INT("{console.log('5. got int ' + $0); return 7.5;}", 42); printf("5. returned int %d\n", i);
+  i = EM_ASM_INT(out('1. got int ' + $0); return 3.5;, 42); printf("1. returned int %d\n", i);
+  i = EM_ASM_INT("out('2. got int ' + $0); return 4.5;", 42); printf("2. returned int %d\n", i);
+  i = EM_ASM_INT({"out('3. got int ' + $0); return 5.5;"}, 42); printf("3. returned int %d\n", i);
+  i = EM_ASM_INT({out('4. got int ' + $0); return 6.5;}, 42); printf("4. returned int %d\n", i);
+  i = EM_ASM_INT("{out('5. got int ' + $0); return 7.5;}", 42); printf("5. returned int %d\n", i);
 
   printf("\nEM_ASM_INT: Pass an integer, return an integer back, wrap code block in extra parentheses\n");
-  i = EM_ASM_INT((console.log('1. got int, extra parentheses ' + $0); return 3.5;), 42); printf("1. returned int, extra parentheses %d\n", i);
-  i = EM_ASM_INT(("console.log('2. got int, extra parentheses ' + $0); return 4.5;"), 42); printf("2. returned int, extra parentheses %d\n", i);
-  i = EM_ASM_INT(({"console.log('3. got int, extra parentheses ' + $0); return 5.5;"}), 42); printf("3. returned int, extra parentheses %d\n", i);
-  i = EM_ASM_INT(({console.log('4. got int, extra parentheses ' + $0); return 6.5;}), 42); printf("4. returned int, extra parentheses %d\n", i);
-  i = EM_ASM_INT(("{console.log('5. got int, extra parentheses ' + $0); return 7.5;}"), 42); printf("5. returned int, extra parentheses %d\n", i);
+  i = EM_ASM_INT((out('1. got int, extra parentheses ' + $0); return 3.5;), 42); printf("1. returned int, extra parentheses %d\n", i);
+  i = EM_ASM_INT(("out('2. got int, extra parentheses ' + $0); return 4.5;"), 42); printf("2. returned int, extra parentheses %d\n", i);
+  i = EM_ASM_INT(({"out('3. got int, extra parentheses ' + $0); return 5.5;"}), 42); printf("3. returned int, extra parentheses %d\n", i);
+  i = EM_ASM_INT(({out('4. got int, extra parentheses ' + $0); return 6.5;}), 42); printf("4. returned int, extra parentheses %d\n", i);
+  i = EM_ASM_INT(("{out('5. got int, extra parentheses ' + $0); return 7.5;}"), 42); printf("5. returned int, extra parentheses %d\n", i);
 
   printf("\nEM_ASM_INT: More imaginable ways for user to wrap in extra parentheses\n");
-  i = EM_ASM_INT({("console.log('1. got int, extra extra parentheses ' + $0); return 5.5;")}, 42); printf("1. returned int, extra extra parentheses %d\n", i);
-  i = EM_ASM_INT({(console.log('2. got int, extra extra parentheses ' + $0); return 6.5;)}, 42); printf("2. returned int, extra extra parentheses %d\n", i);
-  i = EM_ASM_INT(((((((((((console.log('3. got int, extra extra extra parentheses ' + $0); return 6.5;)))))))))), 42); printf("3. returned int, extra extra extra parentheses %d\n", i);
+  i = EM_ASM_INT({("out('1. got int, extra extra parentheses ' + $0); return 5.5;")}, 42); printf("1. returned int, extra extra parentheses %d\n", i);
+  i = EM_ASM_INT({(out('2. got int, extra extra parentheses ' + $0); return 6.5;)}, 42); printf("2. returned int, extra extra parentheses %d\n", i);
+  i = EM_ASM_INT(((((((((((out('3. got int, extra extra extra parentheses ' + $0); return 6.5;)))))))))), 42); printf("3. returned int, extra extra extra parentheses %d\n", i);
 
   printf("\nEM_ASM_INT: Return an integer back.\n");
-  i = EM_ASM_INT(console.log('1. got int ' + $0); return 3.5;, 42); printf("1. returned int %d\n", i);
-  i = EM_ASM_INT("console.log('2. got int ' + $0); return 4.5;", 42); printf("2. returned int %d\n", i);
-  i = EM_ASM_INT({"console.log('3. got int ' + $0); return 5.5;"}, 42); printf("3. returned int %d\n", i);
-  i = EM_ASM_INT({console.log('4. got int ' + $0); return 6.5;}, 42); printf("4. returned int %d\n", i);
-  i = EM_ASM_INT("{console.log('5. got int ' + $0); return 7.5;}", 42); printf("5. returned int %d\n", i);
+  i = EM_ASM_INT(out('1. got int ' + $0); return 3.5;, 42); printf("1. returned int %d\n", i);
+  i = EM_ASM_INT("out('2. got int ' + $0); return 4.5;", 42); printf("2. returned int %d\n", i);
+  i = EM_ASM_INT({"out('3. got int ' + $0); return 5.5;"}, 42); printf("3. returned int %d\n", i);
+  i = EM_ASM_INT({out('4. got int ' + $0); return 6.5;}, 42); printf("4. returned int %d\n", i);
+  i = EM_ASM_INT("{out('5. got int ' + $0); return 7.5;}", 42); printf("5. returned int %d\n", i);
 
   printf("\nEM_ASM_INT: Return an integer in a single brief statement.\n");
   i = EM_ASM_INT(return 42); printf("1. returned statement %d\n", i);
@@ -114,39 +114,39 @@ int main()
   double d;
 
   printf("\nEM_ASM_DOUBLE: Pass no parameters, return a double.\n");
-  d = EM_ASM_DOUBLE(console.log('1. returning double'); return 3.5;); printf("1. got double %f\n", d);
-  d = EM_ASM_DOUBLE("console.log('2. returning double'); return 4.5;"); printf("2. got double %f\n", d);
-  d = EM_ASM_DOUBLE({"console.log('3. returning double'); return 5.5;"}); printf("3. got double %f\n", d);
-  d = EM_ASM_DOUBLE({console.log('4. returning double'); return 6.5;}); printf("4. got double %f\n", d);
-  d = EM_ASM_DOUBLE("{console.log('5. returning double'); return 7.5;}"); printf("5. got double %f\n", d);
+  d = EM_ASM_DOUBLE(out('1. returning double'); return 3.5;); printf("1. got double %f\n", d);
+  d = EM_ASM_DOUBLE("out('2. returning double'); return 4.5;"); printf("2. got double %f\n", d);
+  d = EM_ASM_DOUBLE({"out('3. returning double'); return 5.5;"}); printf("3. got double %f\n", d);
+  d = EM_ASM_DOUBLE({out('4. returning double'); return 6.5;}); printf("4. got double %f\n", d);
+  d = EM_ASM_DOUBLE("{out('5. returning double'); return 7.5;}"); printf("5. got double %f\n", d);
 
   printf("\nEM_ASM_DOUBLE: Pass an integer, return a double.\n");
-  d = EM_ASM_DOUBLE(console.log('1. got int ' + $0); return 3.5;, 42); printf("1. returned double %f\n", d);
-  d = EM_ASM_DOUBLE("console.log('2. got int ' + $0); return 4.5;", 42); printf("2. returned double %f\n", d);
-  d = EM_ASM_DOUBLE({"console.log('3. got int ' + $0); return 5.5;"}, 42); printf("3. returned double %f\n", d);
-  d = EM_ASM_DOUBLE({console.log('4. got int ' + $0); return 6.5;}, 42); printf("4. returned double %f\n", d);
-  d = EM_ASM_DOUBLE("{console.log('5. got int ' + $0); return 7.5;}", 42); printf("5. returned double %f\n", d);
+  d = EM_ASM_DOUBLE(out('1. got int ' + $0); return 3.5;, 42); printf("1. returned double %f\n", d);
+  d = EM_ASM_DOUBLE("out('2. got int ' + $0); return 4.5;", 42); printf("2. returned double %f\n", d);
+  d = EM_ASM_DOUBLE({"out('3. got int ' + $0); return 5.5;"}, 42); printf("3. returned double %f\n", d);
+  d = EM_ASM_DOUBLE({out('4. got int ' + $0); return 6.5;}, 42); printf("4. returned double %f\n", d);
+  d = EM_ASM_DOUBLE("{out('5. got int ' + $0); return 7.5;}", 42); printf("5. returned double %f\n", d);
 
   printf("\nEM_ASM_DOUBLE: Pass a double and an integer, return a double.\n");
-  d = EM_ASM_DOUBLE(console.log('1. got double and int ' + $0 + ' ' + $1); return 3.5;, 5.5, 42); printf("1. returned double %f\n", d);
-  d = EM_ASM_DOUBLE("console.log('2. got double and int ' + $0 + ' ' + $1); return 4.5;", 5.5, 42); printf("2. returned double %f\n", d);
-  d = EM_ASM_DOUBLE({"console.log('3. got double and int ' + $0 + ' ' + $1); return 5.5;"}, 5.5, 42); printf("3. returned double %f\n", d);
-  d = EM_ASM_DOUBLE({console.log('4. got double and int ' + $0 + ' ' + $1); return 6.5;}, 5.5, 42); printf("4. returned double %f\n", d);
-  d = EM_ASM_DOUBLE("{console.log('5. got double and int ' + $0 + ' ' + $1); return 7.5;}", 5.5, 42); printf("5. returned double %f\n", d);
+  d = EM_ASM_DOUBLE(out('1. got double and int ' + $0 + ' ' + $1); return 3.5;, 5.5, 42); printf("1. returned double %f\n", d);
+  d = EM_ASM_DOUBLE("out('2. got double and int ' + $0 + ' ' + $1); return 4.5;", 5.5, 42); printf("2. returned double %f\n", d);
+  d = EM_ASM_DOUBLE({"out('3. got double and int ' + $0 + ' ' + $1); return 5.5;"}, 5.5, 42); printf("3. returned double %f\n", d);
+  d = EM_ASM_DOUBLE({out('4. got double and int ' + $0 + ' ' + $1); return 6.5;}, 5.5, 42); printf("4. returned double %f\n", d);
+  d = EM_ASM_DOUBLE("{out('5. got double and int ' + $0 + ' ' + $1); return 7.5;}", 5.5, 42); printf("5. returned double %f\n", d);
 
   printf("\nEM_ASM_INT: A comma character (,) inside the code block may need extra parentheses\n");
-// i = EM_ASM_INT(console.log('1. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b, 10); printf("1. returned %d\n", i); // This would not compile: use of undeclared identifier 'b'
-  i = EM_ASM_INT((console.log('1. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b), 10); printf("1. returned %d\n", i); // However by wrapping the code block inside parentheses, it will be ok
-  i = EM_ASM_INT("console.log('2. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b", 10); printf("2. returned %d\n", i);
-  i = EM_ASM_INT({"console.log('3. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b"}, 10); printf("3. returned %d\n", i);
-// i = EM_ASM_INT({console.log('4. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}, 10); printf("4. returned %d\n", i); // This would also not compile: use of undeclared identifier 'b'
-  i = EM_ASM_INT(({console.log('4. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}), 10); printf("4. returned %d\n", i); // Again by wrapping the code block inside parentheses, it will work
-  i = EM_ASM_INT("{console.log('5. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}", 10); printf("5. returned %d\n", i);
+// i = EM_ASM_INT(out('1. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b, 10); printf("1. returned %d\n", i); // This would not compile: use of undeclared identifier 'b'
+  i = EM_ASM_INT((out('1. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b), 10); printf("1. returned %d\n", i); // However by wrapping the code block inside parentheses, it will be ok
+  i = EM_ASM_INT("out('2. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b", 10); printf("2. returned %d\n", i);
+  i = EM_ASM_INT({"out('3. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b"}, 10); printf("3. returned %d\n", i);
+// i = EM_ASM_INT({out('4. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}, 10); printf("4. returned %d\n", i); // This would also not compile: use of undeclared identifier 'b'
+  i = EM_ASM_INT(({out('4. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}), 10); printf("4. returned %d\n", i); // Again by wrapping the code block inside parentheses, it will work
+  i = EM_ASM_INT("{out('5. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}", 10); printf("5. returned %d\n", i);
 
   printf("\nEM_ASM: Expression contains a tab character\n");
-  EM_ASM(console.log('1. the following word is delimited by tab characters: H\tE\tL\tL\tO\tT\tA\tB\tS'));
-  EM_ASM("console.log('2. the following word is delimited by tab characters: H\tE\tL\tL\tO\tT\tA\tB\tS')");
-  EM_ASM({"console.log('3. the following word is delimited by tab characters: H\tE\tL\tL\tO\tT\tA\tB\tS')"});
-  EM_ASM({console.log('4. the following word is delimited by tab characters: H\tE\tL\tL\tO\tT\tA\tB\tS')});
-  EM_ASM("{console.log('5. the following word is delimited by tab characters: H\tE\tL\tL\tO\tT\tA\tB\tS')}");
+  EM_ASM(out('1. the following word is delimited by tab characters: H\tE\tL\tL\tO\tT\tA\tB\tS'));
+  EM_ASM("out('2. the following word is delimited by tab characters: H\tE\tL\tL\tO\tT\tA\tB\tS')");
+  EM_ASM({"out('3. the following word is delimited by tab characters: H\tE\tL\tL\tO\tT\tA\tB\tS')"});
+  EM_ASM({out('4. the following word is delimited by tab characters: H\tE\tL\tL\tO\tT\tA\tB\tS')});
+  EM_ASM("{out('5. the following word is delimited by tab characters: H\tE\tL\tL\tO\tT\tA\tB\tS')}");
 }

--- a/test/core/test_em_asm_types.cpp
+++ b/test/core/test_em_asm_types.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
   // Promotions of arrays, function/member pointers and objects implicitly
   // convertible to numbers are excluded because they will not be translated
   // to corresponding JS objects.
-#define TEST_TYPE(type, value) EM_ASM({console.log(#type, Number($0));}, (type)(value));
+#define TEST_TYPE(type, value) EM_ASM({out(#type, Number($0));}, (type)(value));
   TEST_TYPE(int*, 0);
   TEST_TYPE(float, 1.5f);
   TEST_TYPE(double, 2.5);
@@ -39,14 +39,14 @@ int main(int argc, char **argv) {
 
   struct WithBitField w;
   w.x = 3;
-  EM_ASM({ console.log('bit field', $0); }, w.x);
+  EM_ASM({ out('bit field', $0); }, w.x);
 
 #ifdef __cplusplus
   TEST_TYPE(bool, true);
   TEST_TYPE(wchar_t, 50);
 #else
-  EM_ASM({console.log('bool 1')});
-  EM_ASM({console.log('wchar_t 50')});
+  EM_ASM({out('bool 1')});
+  EM_ASM({out('wchar_t 50')});
 #endif
 
   TEST_TYPE(enum SomeEnum, SIXTY);

--- a/test/core/test_em_js_i64.c
+++ b/test/core/test_em_js_i64.c
@@ -2,11 +2,11 @@
 #include <emscripten.h>
 
 EM_JS(void, foo, (uint64_t a, int64_t b), {
-  console.log(typeof a);
-  console.log(typeof b);
+  out(typeof a);
+  out(typeof b);
 
-  console.log('a:' + a);
-  console.log('b:' + b);
+  out('a:' + a);
+  out('b:' + b);
 })
 
 int main() {

--- a/test/core/test_get_exported_function.cpp
+++ b/test/core/test_get_exported_function.cpp
@@ -1,4 +1,5 @@
-#include <emscripten.h>
+#include <emscripten/emscripten.h>
+#include <emscripten/console.h>
 #include <emscripten/exports.h>
 
 extern "C" EMSCRIPTEN_KEEPALIVE int foo()
@@ -17,10 +18,10 @@ int main()
 {
 	intfunc f = (intfunc)emscripten_get_exported_function("_foo");
 	intfunc b = (intfunc)emscripten_get_exported_function("_bar");
-	EM_ASM(console.log($0 + ' ' + $1), f(), b());
+	emscripten_outf("%d %d", f(), b());
 
 	// Obtaining the same function pointer twice should return the
 	// same address.
 	intfunc b2 = (intfunc)emscripten_get_exported_function("_bar");
-	EM_ASM(console.log($0), b == b2);
+	emscripten_outf("%d", b == b2);
 }

--- a/test/embind/embind_jspi_test.cpp
+++ b/test/embind/embind_jspi_test.cpp
@@ -97,9 +97,9 @@ EM_ASYNC_JS(void, test, (), {
     setTimeout(Module.unsuspend);
     await Module.suspend();
 
-    console.log('done');
+    out('done');
   } catch (e) {
-    console.log('Failed: ' + e.stack);
+    out('Failed: ' + e.stack);
   }
 });
 

--- a/test/embind/test_float_constants.cpp
+++ b/test/embind/test_float_constants.cpp
@@ -19,10 +19,10 @@ EMSCRIPTEN_BINDINGS(constants) {
 }
 
 int main() {
-    EM_ASM(
-        console.log("PI (as double) = " + Module['PI']);
-        console.log("EULER = " + Module['EULER']);
-        console.log("pi (as float) = " + Module['pi']);
-        console.log("euler = " + Module['euler']);
-    );
+  EM_ASM(
+    out("PI (as double) = " + Module['PI']);
+    out("EULER = " + Module['EULER']);
+    out("pi (as float) = " + Module['pi']);
+    out("euler = " + Module['euler']);
+  );
 }

--- a/test/embind/test_negative_constants.cpp
+++ b/test/embind/test_negative_constants.cpp
@@ -22,10 +22,10 @@ EMSCRIPTEN_BINDINGS(constants) {
 
 int main() {
     EM_ASM(
-        console.log("NEGATIVE_FLOAT_NUM = " + Module['NEGATIVE_FLOAT_NUM']);
-        console.log("NEGATIVE_INT_NUM = " + Module['NEGATIVE_INT_NUM']);
-        console.log("negative_float_num = " + Module['negative_float_num']);
-        console.log("negative_double_num = " + Module['negative_double_num']);
-        console.log("negative_int_num = " + Module['negative_int_num']);
+      out("NEGATIVE_FLOAT_NUM = " + Module['NEGATIVE_FLOAT_NUM']);
+      out("NEGATIVE_INT_NUM = " + Module['NEGATIVE_INT_NUM']);
+      out("negative_float_num = " + Module['negative_float_num']);
+      out("negative_double_num = " + Module['negative_double_num']);
+      out("negative_int_num = " + Module['negative_int_num']);
     );
 }

--- a/test/fetch/sync_xhr.cpp
+++ b/test/fetch/sync_xhr.cpp
@@ -17,7 +17,7 @@ int main()
   // If an exception is thrown from the user callback, it bubbles up to self.onerror but is otherwise completely
   // swallowed by xhr.send.
   EM_ASM({self.onerror = function() {
-           console.log('Got error');
+           out('Got error');
            HEAP32[$0 >> 2] = 2;
          };}, &result);
   emscripten_fetch_attr_t attr;

--- a/test/pthread/hello_thread.c
+++ b/test/pthread/hello_thread.c
@@ -7,11 +7,11 @@
 
 #include <pthread.h>
 #include <emscripten.h>
-#include <emscripten/html5.h>
+#include <emscripten/console.h>
 
 void *thread_main(void *arg)
 {
-	EM_ASM(out('hello from thread!'));
+	emscripten_out("hello from thread!");
 	emscripten_force_exit(0);
 	__builtin_trap();
 }

--- a/test/pthread/test_pthread_atomics.cpp
+++ b/test/pthread/test_pthread_atomics.cpp
@@ -43,7 +43,7 @@ int rand_32()
 void *ThreadMain(void *arg)
 {
 	// Do some stdio to test proxying to the main thread.
-	printf("pthread %p starting\n", arg);
+	emscripten_outf("pthread %p starting\n", arg);
 
 	assert(pthread_self() != 0);
 	assert(globalUchar == 5);
@@ -52,7 +52,7 @@ void *ThreadMain(void *arg)
 	assert(globalFloat == 5.0f);
 	assert(globalDouble == 5.0);
 	struct Test *t = (struct Test*)arg;
-	EM_ASM(out('Thread ' + $0 + ' for test ' + $1 + ': starting computation.'), t->threadId, t->op);
+	emscripten_outf("Thread %d for test %d: starting computation", t->threadId, t->op);
 
 	for(int i = 0; i < 99999; ++i)
 		for(int j = 0; j < N; ++j)
@@ -92,7 +92,7 @@ void *ThreadMain(void *arg)
 				break;
 			}
 		}
-	EM_ASM(out('Thread ' + $0 + ' for test ' + $1 + ': finished, exit()ing.'), t->threadId, t->op);
+	emscripten_outf("Thread %d for test %d: finished, exit()ing", t->threadId, t->op);
 	pthread_exit(0);
 }
 
@@ -105,7 +105,7 @@ void RunTest(int test)
 	pthread_attr_init(&attr);
 	pthread_attr_setstacksize(&attr, 4*1024);
 
-	printf("Main thread has thread ID %d\n", (int)pthread_self());
+	emscripten_outf("Main thread has thread ID %d\n", (int)pthread_self());
 	assert(pthread_self() != 0);
 
 	switch(test)
@@ -115,7 +115,7 @@ void RunTest(int test)
 		default: memset(sharedData, 0, sizeof(sharedData)); break;
 	}
 
-	EM_ASM(out('Main: Starting test ' + $0), test);
+	emscripten_outf("Main: Starting test %d", test);
 
 	for(int i = 0; i < NUM_THREADS; ++i)
 	{
@@ -136,7 +136,7 @@ void RunTest(int test)
 	}
 
 	int val = sharedData[0];
-	EM_ASM(out('Main: Test ' + $0 + ' finished. Result: ' + $1), test, val);
+	emscripten_outf("Main: Test %d finished. Result: %d", test, val);
 	if (test != 6)
 	{
 		for(int i = 1; i < N; ++i)

--- a/test/pthread/test_pthread_cancel.cpp
+++ b/test/pthread/test_pthread_cancel.cpp
@@ -10,12 +10,12 @@
 #include <assert.h>
 #include <unistd.h>
 #include <errno.h>
-#include <emscripten/em_asm.h>
+#include <emscripten/console.h>
 
 _Atomic long res = 43;
 static void cleanup_handler(void *arg)
 {
-  EM_ASM(out('Called clean-up handler with arg ' + $0), arg);
+  emscripten_outf("Called clean-up handler with arg %p", arg);
   long a = (long)arg;
   res -= a;
 }
@@ -23,7 +23,7 @@ static void cleanup_handler(void *arg)
 static void *thread_start(void *arg)
 {
   pthread_cleanup_push(cleanup_handler, (void*)42);
-  EM_ASM(out('Thread started!'));
+  emscripten_out("Thread started!");
   for(;;)
   {
     pthread_testcancel();
@@ -38,7 +38,7 @@ int main()
 {
   int s = pthread_create(&thr, NULL, thread_start, (void*)0);
   assert(s == 0);
-  EM_ASM(out('Canceling thread..'););
+  emscripten_out("Canceling thread..");
   s = pthread_cancel(thr);
   assert(s == 0);
 
@@ -47,7 +47,7 @@ int main()
     int result = res;
     if (result == 1)
     {
-      EM_ASM_INT( { out('After canceling, shared variable = ' + $0 + '.'); }, result);
+      emscripten_outf("After canceling, shared variable = %d", result);
       return 0;
     }
   }

--- a/test/pthread/test_pthread_condition_variable.cpp
+++ b/test/pthread/test_pthread_condition_variable.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <emscripten/emscripten.h>
+#include <emscripten/console.h>
 
 #define NUM_THREADS  3
 #define TCOUNT 10
@@ -17,7 +18,7 @@ int     thread_ids[3] = {0,1,2};
 pthread_mutex_t count_mutex;
 pthread_cond_t count_threshold_cv;
 
-void *inc_count(void *t) 
+void *inc_count(void *t)
 {
   int i;
   long my_id = (long)t;
@@ -26,50 +27,43 @@ void *inc_count(void *t)
     pthread_mutex_lock(&count_mutex);
     count++;
 
-    /* 
+    /*
     Check the value of count and signal waiting thread when condition is
-    reached.  Note that this occurs while mutex is locked. 
+    reached.  Note that this occurs while mutex is locked.
     */
     if (count == COUNT_LIMIT) {
       pthread_cond_signal(&count_threshold_cv);
- //     printf("inc_count(): thread %ld, count = %d  Threshold reached.\n", 
- //            my_id, count);
-      EM_ASM(out('inc_count(): thread ' + $0 + ', count = ' + $1 + ', Threshold reached.'), my_id, count);
-      }
-//    printf("inc_count(): thread %ld, count = %d, unlocking mutex\n", 
-//	   my_id, count);
-    EM_ASM(out('inc_count(): thread ' + $0 + ', count = ' + $1 + ', unlocking mutex.'), my_id, count);
+      emscripten_outf("inc_count(): thread %ld, count = %d  Threshold reached.\n", my_id, count);
+    }
+    emscripten_outf("inc_count(): thread %ld, count = %d, unlocking mutex\n", my_id, count);
     pthread_mutex_unlock(&count_mutex);
 
     /* Do some "work" so threads can alternate on mutex lock */
     //sleep(1);
-    }
+  }
   pthread_exit(NULL);
 }
 
-void *watch_count(void *t) 
+void *watch_count(void *t)
 {
   long my_id = (long)t;
 
-//  printf("Starting watch_count(): thread %ld\n", my_id);
-  EM_ASM(out('Starting watch_count(): thread ' + $0), my_id);
+  emscripten_outf("Starting watch_count(): thread %ld\n", my_id);
 
   /*
-  Lock mutex and wait for signal.  Note that the pthread_cond_wait 
-  routine will automatically and atomically unlock mutex while it waits. 
+  Lock mutex and wait for signal.  Note that the pthread_cond_wait
+  routine will automatically and atomically unlock mutex while it waits.
   Also, note that if COUNT_LIMIT is reached before this routine is run by
   the waiting thread, the loop will be skipped to prevent pthread_cond_wait
-  from never returning. 
+  from never returning.
   */
   pthread_mutex_lock(&count_mutex);
   while (count<COUNT_LIMIT) {
     pthread_cond_wait(&count_threshold_cv, &count_mutex);
-//    printf("watch_count(): thread %ld Condition signal received.\n", my_id);
-    EM_ASM(out('watch_count(): thread ' + $0 + ' Condition signal received.'), my_id);
+    emscripten_outf("watch_count(): thread %ld Condition signal received.\n", my_id);
     count += 125;
-//    printf("watch_count(): thread %ld count now = %d.\n", my_id, count);
-    EM_ASM(out('watch_count(): thread ' + $0 + ', count now = ' + $1), my_id, count);
-    }
+    emscripten_outf("watch_count(): thread %ld count now = %d.\n", my_id, count);
+  }
   pthread_mutex_unlock(&count_mutex);
   pthread_exit(NULL);
 }
@@ -93,7 +87,7 @@ int main (int argc, char *argv[])
   for (i=0; i<NUM_THREADS; i++) {
     pthread_join(threads[i], NULL);
   }
-  printf ("Main(): Waited on %d  threads. Done.\n", NUM_THREADS);
+  emscripten_outf("Main(): Waited on %d  threads. Done.\n", NUM_THREADS);
 
   /* Clean up and exit */
   pthread_mutex_destroy(&count_mutex);

--- a/test/pthread/test_pthread_create.cpp
+++ b/test/pthread/test_pthread_create.cpp
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <emscripten/em_asm.h>
+#include <emscripten/console.h>
 #include <assert.h>
 
 #define NUM_THREADS 8
@@ -27,7 +28,7 @@ void *ThreadMain(void *arg)
 
 #define N 100
 
-	EM_ASM(err('Thread idx '+$0+': sorting ' + $1 + ' numbers with param ' + $2 + '.'), idx, N, param);
+	emscripten_errf("Thread idx %lu: sorting %d numbers with param %d", idx, N, param);
 
 	unsigned int n[N];
 	for(unsigned int i = 0; i < N; ++i)
@@ -50,7 +51,7 @@ void *ThreadMain(void *arg)
 		if (n[i] == i) ++numGood;
 		else EM_ASM(err('n['+$0+']='+$1), i, n[i]);
 
-	EM_ASM(out('Thread idx ' + $0 + ' with param '+$1+': all done with result '+$2+'.'), idx, param, numGood);
+	emscripten_outf("Thread idx %ld with param %d: all done with result %d.", idx, param, numGood);
 	pthread_exit((void*)numGood);
 }
 
@@ -62,7 +63,7 @@ void CreateThread(int i)
 {
 	static int counter = 1;
 	global_shared_data[i] = (counter++ * 12141231) & 0x7FFFFFFF; // Arbitrary random'ish data for perturbing the sort for this thread task.
-//	EM_ASM(out('Main: Creating thread idx ' + $0 + ' (param ' + $1 + ')'), i, global_shared_data[i]);
+//	emscripten_outf("Main: Creating thread idx %d (param %d)", i, global_shared_data[i]);
 	int rc = pthread_create(&thread[i], NULL, ThreadMain, (void*)i);
 	assert(rc == 0);
 }

--- a/test/pthread/test_pthread_create_pthread.cpp
+++ b/test/pthread/test_pthread_create_pthread.cpp
@@ -4,7 +4,7 @@
 // found in the LICENSE file.
 
 #include <pthread.h>
-#include <emscripten/em_asm.h>
+#include <emscripten/console.h>
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -13,14 +13,14 @@ volatile int result = 0;
 
 static void *thread2_start(void *arg)
 {
-  EM_ASM(out('thread2_start!'));
+  emscripten_out("thread2_start!");
   ++result;
   return NULL;
 }
 
 static void *thread1_start(void *arg)
 {
-  EM_ASM(out('thread1_start!'));
+  emscripten_out("thread1_start!");
   pthread_t thr;
   int rtn = pthread_create(&thr, NULL, thread2_start, NULL);
 #ifdef SMALL_POOL

--- a/test/pthread/test_pthread_file_io.cpp
+++ b/test/pthread/test_pthread_file_io.cpp
@@ -4,7 +4,7 @@
 // found in the LICENSE file.
 
 #include <pthread.h>
-#include <emscripten/em_asm.h>
+#include <emscripten/console.h>
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -12,7 +12,7 @@
 
 static void *thread1_start(void *arg)
 {
-  EM_ASM(out('thread1_start!'));
+  emscripten_out("thread1_start!");
 
   FILE *handle = fopen("file1.txt", "r");
   assert(handle);

--- a/test/pthread/test_pthread_global_data_initialization.c
+++ b/test/pthread/test_pthread_global_data_initialization.c
@@ -7,35 +7,35 @@
 
 #include <assert.h>
 #include <pthread.h>
-#include <emscripten.h>
+#include <emscripten/console.h>
 
 int globalData = 1;
 
 void *thread_main(void *arg)
 {
-  EM_ASM(out('hello from pthread 1: ' + $0), globalData);
+  emscripten_outf("hello from pthread 1: %d", globalData);
   assert(globalData == 10);
 
   globalData = 20;
-  EM_ASM(out('hello from pthread 2: ' + $0), globalData);
+  emscripten_outf("hello from pthread 2: %d", globalData);
   assert(globalData == 20);
   return 0;
 }
 
 int main()
 {
-  EM_ASM(out('hello from main 1: ' + $0), globalData);
+  emscripten_outf("hello from main 1: %d", globalData);
   assert(globalData == 1);
 
   globalData = 10;
-  EM_ASM(out('hello from main 2: ' + $0), globalData);
+  emscripten_outf("hello from main 2: %d", globalData);
   assert(globalData == 10);
 
   pthread_t thread;
   pthread_create(&thread, NULL, thread_main, NULL);
   pthread_join(thread, 0);
 
-  EM_ASM(out('hello from main 3: ' + $0), globalData);
+  emscripten_outf("hello from main 3: %d", globalData);
   assert(globalData == 20);
   return 0;
 }

--- a/test/pthread/test_pthread_hardware_concurrency.cpp
+++ b/test/pthread/test_pthread_hardware_concurrency.cpp
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <memory.h>
 #include <pthread.h>
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <assert.h>
 
 #include <thread>
@@ -19,7 +19,7 @@ struct Test
 
 void *ThreadMain(void *arg)
 {
-	EM_ASM(out('Thread ' + $0 + ' finished, exit()ing.'), ((Test*)arg)->threadId);
+	emscripten_outf("Thread %d finished, exit()ing", ((Test*)arg)->threadId);
 	pthread_exit(0);
 }
 
@@ -28,7 +28,7 @@ void RunTest(int test)
   int NUM_THREADS = std::thread::hardware_concurrency();
   assert(NUM_THREADS > 0);
 
-	EM_ASM(out('Main: Test ' + $0 + ' starting, with num cores: ' + $1), test, NUM_THREADS);
+	emscripten_outf("Main: Test %d starting, with num cores: %d", test, NUM_THREADS);
 
   struct Test t[NUM_THREADS];
   pthread_t thread[NUM_THREADS];
@@ -37,10 +37,10 @@ void RunTest(int test)
 	pthread_attr_init(&attr);
 	pthread_attr_setstacksize(&attr, 4*1024);
 
-	printf("Main thread has thread ID %ld\n", (long)pthread_self());
+	emscripten_outf("Main thread has thread ID %ld", pthread_self());
 	assert(pthread_self() != 0);
 
-	EM_ASM(out('Main: Starting test ' + $0), test);
+	emscripten_outf("Main: Starting test %d", test);
 
 	for(int i = 0; i < NUM_THREADS; ++i)
 	{
@@ -59,7 +59,7 @@ void RunTest(int test)
 		assert(status == 0);
 	}
 
-	EM_ASM(out('Main: Test ' + $0 + ' finished.'), test);
+	emscripten_outf("Main: Test %d finished", test);
 }
 
 int main()

--- a/test/pthread/test_pthread_join.cpp
+++ b/test/pthread/test_pthread_join.cpp
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <emscripten/em_asm.h>
+#include <emscripten/console.h>
 
 long fib(long n)
 {
@@ -22,9 +23,9 @@ long fib(long n)
 static void *thread_start(void *arg)
 {
   long n = (long)arg;
-  EM_ASM(out('Thread: Computing fib('+$0+')...'), n);
+  emscripten_outf("Thread: Computing fib(%ld)...", n);
   long fibn = fib(n);
-  EM_ASM(out('Thread: Computation done. fib('+$0+') = '+$1+'.'), n, fibn);
+  emscripten_outf("Thread: Computation done. fib(%ld) = %ld", n, fibn);
   pthread_exit((void*)fibn);
 }
 
@@ -40,10 +41,10 @@ int main()
   assert(EM_ASM_INT(return PThread.unusedWorkers.length) == 8); // This test should be run with a prepopulated pool of size 8.
 
   int n = 20;
-  EM_ASM(out('Main: Spawning thread to compute fib('+$0+')...'), n);
+  emscripten_outf("Main: Spawning thread to compute fib(%d)...", n);
   int s = pthread_create(&thr, NULL, thread_start, (void*)n);
   assert(s == 0);
-  EM_ASM(out('Main: Waiting for thread to join.'));
+  emscripten_out("Main: Waiting for thread to join");
   int result = 0;
 
   assert(EM_ASM_INT(return PThread.runningWorkers.length) == 1);
@@ -51,7 +52,7 @@ int main()
 
   s = pthread_join(thr, (void**)&result);
   assert(s == 0);
-  EM_ASM(out('Main: Thread joined with result: '+$0+'.'), result);
+  emscripten_outf("Main: Thread joined with result: %d", result);
 
   assert(EM_ASM_INT(return PThread.runningWorkers.length) == 0);
   assert(EM_ASM_INT(return PThread.unusedWorkers.length) == 8);

--- a/test/pthread/test_pthread_malloc.cpp
+++ b/test/pthread/test_pthread_malloc.cpp
@@ -4,7 +4,7 @@
 // found in the LICENSE file.
 
 #include <pthread.h>
-#include <emscripten/em_asm.h>
+#include <emscripten/console.h>
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -26,14 +26,14 @@ static void *thread_start(void *arg)
     long k = *mem[i];
     if (k != n+i)
     {
-      EM_ASM(console.error('Memory corrupted! mem[i]: ' + $0 + ', i: ' + $1 + ', n: ' + $2), k, i, n);
+      emscripten_errf("Memory corrupted! mem[i]: %ld, i: %ld, n: %ld", k, i, n);
       pthread_exit((void*)1);
     }
 
     assert(*mem[i] == n+i);
     free(mem[i]);
   }
-  EM_ASM(console.log('Worker with task number ' + $0 + ' finished.'), n);
+  emscripten_outf("Worker with task number %ld finished", n);
   pthread_exit(0);
 }
 

--- a/test/pthread/test_pthread_mutex.cpp
+++ b/test/pthread/test_pthread_mutex.cpp
@@ -9,6 +9,7 @@
 #include <pthread.h>
 #include <emscripten.h>
 #include <emscripten/threading.h>
+#include <emscripten/console.h>
 #include <unistd.h>
 
 #define NUM_THREADS 8
@@ -82,9 +83,9 @@ EM_BOOL WaitToJoin(double time, void *userData)
 	if (!threadsRunning)
 	{
 		if (counter == numThreadsToCreateTotal)
-			EM_ASM(console.log('All threads finished. Counter = ' + $0 + ' as expected.'), counter);
+			emscripten_outf("All threads finished. Counter = %d as expected", counter);
 		else
-			EM_ASM(console.error('All threads finished, but counter = ' + $0 + ' != ' + $1 + '!'), counter, numThreadsToCreateTotal);
+			emscripten_errf("All threads finished, but counter = %d != %d!", counter, numThreadsToCreateTotal);
 		assert(counter == 50);
 		emscripten_force_exit(0);
 		return EM_FALSE;

--- a/test/pthread/test_pthread_preallocates_workers.cpp
+++ b/test/pthread/test_pthread_preallocates_workers.cpp
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <emscripten/em_asm.h>
+#include <emscripten/console.h>
 #include <vector>
 
 pthread_t threads[5];
@@ -28,7 +29,7 @@ static void *thread_start(void *arg)
 }
 
 void CreateThread(int idx) {
-  EM_ASM(out('Main: Spawning thread '+$0+'...'), idx);
+  emscripten_outf("Main: Spawning thread %d...", idx);
   int rc = pthread_create(&threads[idx], NULL, thread_start, (void*)idx);
   assert(rc == 0);
 }

--- a/test/pthread/test_pthread_sbrk.cpp
+++ b/test/pthread/test_pthread_sbrk.cpp
@@ -72,7 +72,7 @@ static void *thread_start(void *arg)
       {
         ++return_code; // Failed! (but run to completion so that the barriers will all properly proceed without hanging)
         if (!reported_once) {
-          EM_ASM(console.error('Memory corrupted! mem[i]: ' + $0 + ' != ' + $1 + ', i: ' + $2 + ', j: ' + $3), allocated_buffers[i][j], id, i, j);
+          EM_ASM(err('Memory corrupted! mem[i]: ' + $0 + ' != ' + $1 + ', i: ' + $2 + ', j: ' + $3), allocated_buffers[i][j], id, i, j);
           reported_once = 1; // Avoid print flood that makes debugging hard.
         }
       }

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3823,7 +3823,7 @@ Module["preRun"].push(function () {
 
   # Test that the emscripten_ atomics api functions work.
   @parameterized({
-    'normal': ([],),
+    '': ([],),
     'closure': (['--closure=1'],),
   })
   @requires_threads

--- a/test/test_closure_warning.c
+++ b/test/test_closure_warning.c
@@ -2,5 +2,5 @@
 
 int main()
 {
-	EM_ASM(foo = 2; var foo; console.log(foo));
+	EM_ASM(foo = 2; var foo; out(foo));
 }

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1596,7 +1596,7 @@ int main(int argc, char **argv) {
                   // https://github.com/emscripten-core/emscripten/issues/17115
                   incrementExceptionRefcount(p);
 #endif
-                  console.log(getExceptionMessage(p).toString());
+                  out(getExceptionMessage(p).toString());
                   decrementExceptionRefcount(p);
               }
             }
@@ -7662,7 +7662,7 @@ void* operator new(size_t size) {
       #include <stdio.h>
 
       EM_JS(void, calltest, (), {
-        console.log("dotest returned: " + Module.dotest());
+        out("dotest returned: " + Module.dotest());
       });
 
       int main(int argc, char** argv){
@@ -7694,7 +7694,7 @@ void* operator new(size_t size) {
       #include <stdio.h>
 
       EM_JS(void, calltest, (), {
-        console.log("dotest returned: " + Module.dotest());
+        out("dotest returned: " + Module.dotest());
       });
 
       int main(int argc, char** argv){
@@ -8254,9 +8254,9 @@ Module.onRuntimeInitialized = () => {
   runtimeKeepalivePush();
   ccall('stringf', 'string', ['string'], ['first\n'], { async: true })
     .then(function(val) {
-      console.log(val);
+      out(val);
       ccall('floatf', 'number', null, null, { async: true }).then(function(arg) {
-        console.log(arg);
+        out(arg);
         runtimeKeepalivePop();
         maybeExit();
       });
@@ -8609,9 +8609,9 @@ Module.onRuntimeInitialized = () => {
         out(typeof FS.filesystems['IDBFS']);
         out(typeof FS.filesystems['NODEFS']);
         // Globals
-        console.log(typeof MEMFS);
-        console.log(typeof IDBFS);
-        console.log(typeof NODEFS);
+        out(typeof MEMFS);
+        out(typeof IDBFS);
+        out(typeof NODEFS);
       };
     ''')
     self.emcc_args += ['--pre-js', 'pre.js']
@@ -8627,14 +8627,14 @@ Module.onRuntimeInitialized = () => {
         out(typeof FS.filesystems['IDBFS']);
         out(typeof FS.filesystems['NODEFS']);
         // Globals
-        console.log(typeof MEMFS);
-        console.log(IDBFS);
-        console.log(NODEFS);
+        out(typeof MEMFS);
+        out(IDBFS);
+        out(NODEFS);
         FS.mkdir('/working1');
         try {
           FS.mount(IDBFS, {}, '/working1');
         } catch (e) {
-          console.log('|' + e + '|');
+          out('|' + e + '|');
         }
       };
     ''')
@@ -9489,14 +9489,14 @@ NODEFS is no longer included by default; build with -lnodefs.js
       'result is 42')
 
   # Tests the emscripten_get_exported_function() API.
-  def test_emscripten_get_exported_function(self):
+  def test_get_exported_function(self):
     self.set_setting('ALLOW_TABLE_GROWTH')
     self.emcc_args += ['-lexports.js']
     self.do_core_test('test_get_exported_function.cpp')
 
   # Tests the emscripten_get_exported_function() API.
   @no_asan('TODO: ASan support in minimal runtime')
-  def test_minimal_runtime_emscripten_get_exported_function(self):
+  def test_minimal_runtime_get_exported_function(self):
     self.set_setting('ALLOW_TABLE_GROWTH')
     self.set_setting('MINIMAL_RUNTIME')
     self.emcc_args += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1374,7 +1374,7 @@ int f() {
 
     create_file('pre.js', '''
       Module.onRuntimeInitialized = () => {
-        console.log(Module._libf1 ? Module._libf1() : 'unexported');
+        out(Module._libf1 ? Module._libf1() : 'unexported');
       };
     ''')
 
@@ -2421,7 +2421,7 @@ int f() {
         # Calling main later should still work, filesystem etc. must be set up.
         print('call main later')
         src = read_file('a.out.js')
-        src += '\nconsole.log("callMain -> " + Module.callMain());\n'
+        src += '\nout("callMain -> " + Module.callMain());\n'
         create_file('a.out.js', src)
         self.assertContained('hello from main\ncallMain -> 0\n', self.run_js('a.out.js'))
 
@@ -3372,7 +3372,7 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
     create_file('pre.js', '''
       Module.onRuntimeInitialized = () => {
         Module.setErrNo(88);
-        console.log('done');
+        out('done');
       };
     ''')
     self.do_runf(test_file('hello_world.c'), 'done', emcc_args=['--pre-js=pre.js', '-sEXPORTED_RUNTIME_METHODS=setErrNo'])
@@ -9073,8 +9073,9 @@ end
     create_file('pre.js', 'Module.onRuntimeInitialized = () => Module._foo();')
     create_file('src.c', r'''
 #include <emscripten.h>
+#include <emscripten/console.h>
 EMSCRIPTEN_KEEPALIVE void foo() {
-  EM_ASM({ console.log("bar") });
+  emscripten_out("bar");
 }
 ''')
     self.do_runf('src.c', 'bar', emcc_args=['--pre-js', 'pre.js', '-sMAIN_MODULE=2'])
@@ -10684,7 +10685,7 @@ int main(void) {
                                      changed)
 
   def test_INCOMING_MODULE_JS_API_missing(self):
-    create_file('pre.js', 'Module.onRuntimeInitialized = () => console.log("initialized");')
+    create_file('pre.js', 'Module.onRuntimeInitialized = () => out("initialized");')
     self.emcc_args += ['--pre-js=pre.js']
     self.do_runf(test_file('hello_world.c'), 'initialized')
 
@@ -10863,11 +10864,11 @@ int main(void) {
       #include <emscripten.h>
       int main() {
         EM_ASM({
-          console.log();
+          out();
           function check(name) {
             try {
               Module[name];
-              console.log("success: " + name);
+              out("success: " + name);
             } catch(e) {
             }
           }
@@ -10952,7 +10953,7 @@ Aborted(`Module.arguments` has been replaced by `arguments_` (the initial value 
     create_file('foo.c', '''
       #include <emscripten.h>
       void foo() {
-        EM_ASM({ console.log('Hello, world!'); });
+        EM_ASM({ out('Hello, world!'); });
       }
     ''')
     create_file('main.c', '''
@@ -10962,7 +10963,7 @@ Aborted(`Module.arguments` has been replaced by `arguments_` (the initial value 
 
       int main() {
         foo();
-        EM_ASM({ console.log('Hello, world!'); });
+        EM_ASM({ out('Hello, world!'); });
         return 0;
       }
     ''')
@@ -10975,7 +10976,7 @@ Aborted(`Module.arguments` has been replaced by `arguments_` (the initial value 
     create_file('src.c', '''
       #include <emscripten/em_asm.h>
       int main(void) {
-        EM_ASM({ console.log('hello'); });
+        EM_ASM({ out('hello'); });
       }\n''')
     self.run_process([EMCC, '-c', 'src.c',
                       '-pedantic', '-Wall', '-Werror',
@@ -10985,7 +10986,7 @@ Aborted(`Module.arguments` has been replaced by `arguments_` (the initial value 
     create_file('src.c', '''
       #include <emscripten/em_asm.h>
       int main() {
-        EM_ASM({ console.log('Hello, world!'); });
+        EM_ASM({ out('Hello, world!'); });
       }
     ''')
     err = self.expect_fail([EMCC, '-std=c11', 'src.c'])
@@ -11003,7 +11004,7 @@ Aborted(`Module.arguments` has been replaced by `arguments_` (the initial value 
         jmp_buf buf;
         setjmp(buf);
         EM_ASM({
-          console.log("hello world");
+          out("hello world");
         });
       }
     ''')
@@ -11476,7 +11477,7 @@ Aborted(`Module.arguments` has been replaced by `arguments_` (the initial value 
   def test_native_call_before_init(self):
     self.set_setting('ASSERTIONS')
     self.set_setting('EXPORTED_FUNCTIONS', ['_foo'])
-    self.add_pre_run('console.log("calling foo"); Module["_foo"]();')
+    self.add_pre_run('out("calling foo"); Module["_foo"]();')
     create_file('foo.c', '#include <stdio.h>\nint foo() { puts("foo called"); return 3; }')
     self.build('foo.c')
     out = self.run_js('foo.js', assert_returncode=NON_ZERO)
@@ -11485,7 +11486,7 @@ Aborted(`Module.arguments` has been replaced by `arguments_` (the initial value 
   def test_native_call_after_exit(self):
     self.set_setting('ASSERTIONS')
     self.set_setting('EXIT_RUNTIME')
-    self.add_on_exit('console.log("calling main again"); Module["_main"]();')
+    self.add_on_exit('out("calling main again"); Module["_main"]();')
     create_file('foo.c', '#include <stdio.h>\nint main() { puts("foo called"); return 0; }')
     self.build('foo.c')
     out = self.run_js('foo.js', assert_returncode=NON_ZERO)
@@ -11590,12 +11591,12 @@ int main () {
           try {
             _malloc(1);
           } catch(e) {
-            console.log('exception:', e);
+            out('exception:', e);
           }
           try {
             _free();
           } catch(e) {
-            console.log('exception:', e);
+            out('exception:', e);
           }
         });
       }

--- a/test/test_webgl2_runtime_no_context.cpp
+++ b/test/test_webgl2_runtime_no_context.cpp
@@ -20,9 +20,9 @@ int main()
   EM_ASM({
     var original = Module.canvas.getContext;
     Module.canvas.getContext = function(name, attrs) {
-      console.log('ask', name, attrs);
+      out('ask', name, attrs);
       if (name === "webgl2") return null;
-      console.log('provide!');
+      out('provide!');
       return original.call(Module.canvas, name, attrs);
     };
   });

--- a/test/test_webgl_context_attributes_common.c
+++ b/test/test_webgl_context_attributes_common.c
@@ -12,6 +12,7 @@
 #include <assert.h>
 
 #include <emscripten.h>
+#include <emscripten/console.h>
 
 #define BUFFER_OFFSET(i) ((char *)NULL + (i))
 
@@ -289,18 +290,18 @@ extern int webglAlphaSupported(void);
 static void checkContextAttributesSupport() {
   if (!webglAntialiasSupported()) {
     resultAA = true;
-    EM_ASM(err('warning: no antialiasing\n'));
+    emscripten_err("warning: no antialiasing");
   }
   if (!webglDepthSupported()) {
     resultDepth = true;
-    EM_ASM(err('warning: no depth\n'));
+    emscripten_err("warning: no depth");
   }
   if (!webglStencilSupported()) {
     resultStencil = true;
-    EM_ASM(err('warning: no stencil\n'));
+    emscripten_err("warning: no stencil");
   }
   if (!webglAlphaSupported()) {
     resultAlpha = true;
-    EM_ASM(err('warning: no alpha\n'));
+    emscripten_err("warning: no alpha");
   }
 }

--- a/test/wasm_worker/c11__Thread_local.c
+++ b/test/wasm_worker/c11__Thread_local.c
@@ -8,7 +8,7 @@ _Thread_local int __attribute__((aligned(64))) tls = 1;
 void main_thread_func()
 {
   assert(!emscripten_current_thread_is_wasm_worker());
-  EM_ASM(console.log($0), tls);
+  EM_ASM(out($0), tls);
 #ifdef REPORT_RESULT
   REPORT_RESULT(tls);
 #endif
@@ -29,7 +29,7 @@ char stack[1024];
 
 int main()
 {
-  EM_ASM(console.log($0), tls);
+  EM_ASM(out($0), tls);
   assert(((intptr_t)&tls % 64) == 0);
   assert(!emscripten_current_thread_is_wasm_worker());
   tls = 42;

--- a/test/wasm_worker/cpp11_thread_local.cpp
+++ b/test/wasm_worker/cpp11_thread_local.cpp
@@ -7,7 +7,7 @@ thread_local int tls = 1;
 void main_thread_func()
 {
   assert(!emscripten_current_thread_is_wasm_worker());
-  EM_ASM(console.log($0), tls);
+  EM_ASM(out($0), tls);
 #ifdef REPORT_RESULT
   REPORT_RESULT(tls);
 #endif
@@ -27,7 +27,7 @@ char stack[1024];
 
 int main()
 {
-  EM_ASM(console.log($0), tls);
+  EM_ASM(out($0), tls);
   assert(!emscripten_current_thread_is_wasm_worker());
   tls = 42;
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));

--- a/test/wasm_worker/gcc___Thread.c
+++ b/test/wasm_worker/gcc___Thread.c
@@ -8,7 +8,7 @@ __thread int tls = 1;
 void main_thread_func()
 {
   assert(!emscripten_current_thread_is_wasm_worker());
-  EM_ASM(console.log($0), tls);
+  EM_ASM(out($0), tls);
 #ifdef REPORT_RESULT
   REPORT_RESULT(tls);
 #endif
@@ -28,7 +28,7 @@ char stack[1024];
 
 int main()
 {
-  EM_ASM(console.log($0), tls);
+  EM_ASM(out($0), tls);
   assert(!emscripten_current_thread_is_wasm_worker());
   tls = 42;
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));

--- a/test/wasm_worker/lock_waitinf_acquire.c
+++ b/test/wasm_worker/lock_waitinf_acquire.c
@@ -17,7 +17,7 @@ volatile int numWorkersAlive = 0;
 
 void test_ended()
 {
-  EM_ASM(console.log(`Worker ${$0} last thread to finish. Reporting test end with sharedState0=${$1}, sharedState1=${$2}`), emscripten_wasm_worker_self_id(), sharedState0, sharedState1);
+  EM_ASM(out(`Worker ${$0} last thread to finish. Reporting test end with sharedState0=${$1}, sharedState1=${$2}`), emscripten_wasm_worker_self_id(), sharedState0, sharedState1);
   assert(sharedState0 == sharedState1 + 1 || sharedState1 == sharedState0 + 1);
 #ifdef REPORT_RESULT
   REPORT_RESULT(sharedState0);
@@ -26,7 +26,7 @@ void test_ended()
 
 void worker_main()
 {
-  EM_ASM(console.log(`Worker ${$0} running...`), emscripten_wasm_worker_self_id());
+  EM_ASM(out(`Worker ${$0} running...`), emscripten_wasm_worker_self_id());
   // Create contention on the lock from each thread, and stress the shared state
   // in a racy way that would show a breakage if the lock is not watertight.
   for(int i = 0; i < 1000; ++i)
@@ -50,7 +50,7 @@ void worker_main()
     emscripten_lock_release(&lock);
   }
 
-  EM_ASM(console.log(`Worker ${$0} finished.`), emscripten_wasm_worker_self_id());
+  EM_ASM(out(`Worker ${$0} finished.`), emscripten_wasm_worker_self_id());
 
   // Are we the last thread to finish? If so, test has ended.
   uint32_t v = emscripten_atomic_sub_u32((void*)&numWorkersAlive, 1);

--- a/test/wasm_worker/thread_stack.c
+++ b/test/wasm_worker/thread_stack.c
@@ -13,16 +13,16 @@ volatile int threadsOk = 0;
 
 void test_stack(int i)
 {
-  EM_ASM(console.log(`In thread ${$0}, stack low addr=0x${$1.toString(16)}, emscripten_stack_get_base()=0x${$2.toString(16)}, emscripten_stack_get_end()=0x${$3.toString(16)}, THREAD_STACK_SIZE=0x${$4.toString(16)}`),
+  EM_ASM(out(`In thread ${$0}, stack low addr=0x${$1.toString(16)}, emscripten_stack_get_base()=0x${$2.toString(16)}, emscripten_stack_get_end()=0x${$3.toString(16)}, THREAD_STACK_SIZE=0x${$4.toString(16)}`),
     i, thread_stack[i], emscripten_stack_get_base(), emscripten_stack_get_end(), THREAD_STACK_SIZE);
   assert(emscripten_stack_get_base() == (uintptr_t)thread_stack[i] + THREAD_STACK_SIZE);
   assert(emscripten_stack_get_end() == (uintptr_t)thread_stack[i]);
 
   int ok = __sync_fetch_and_add(&threadsOk, 1);
-  EM_ASM(console.log($0), ok);
+  EM_ASM(out($0), ok);
   if (ok == 1)
   {
-    EM_ASM(console.log(`Test finished!`));
+    EM_ASM(out(`Test finished!`));
 #ifdef REPORT_RESULT
     REPORT_RESULT(0);
 #endif
@@ -31,13 +31,13 @@ void test_stack(int i)
 
 int main()
 {
-  EM_ASM(console.log(`Main thread stack base=0x${$0.toString(16)}, end=0x${$1.toString(16)}`), emscripten_stack_get_base(), emscripten_stack_get_end());
+  EM_ASM(out(`Main thread stack base=0x${$0.toString(16)}, end=0x${$1.toString(16)}`), emscripten_stack_get_base(), emscripten_stack_get_end());
 
   for(int i = 0; i < NUM_THREADS; ++i)
   {
     thread_stack[i] = memalign(16, THREAD_STACK_SIZE);
     emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(thread_stack[i], THREAD_STACK_SIZE);
-    EM_ASM(console.log(`Created thread ${$0} with stack ptr=0x${$1.toString(16)}, size=0x${$2.toString(16)}`), i, thread_stack[i], THREAD_STACK_SIZE);
+    EM_ASM(out(`Created thread ${$0} with stack ptr=0x${$1.toString(16)}, size=0x${$2.toString(16)}`), i, thread_stack[i], THREAD_STACK_SIZE);
     emscripten_wasm_worker_post_function_vi(worker, test_stack, i);
   }
 }

--- a/test/wasm_worker/wasm_worker_and_pthread.c
+++ b/test/wasm_worker/wasm_worker_and_pthread.c
@@ -2,6 +2,7 @@
 #include <emscripten.h>
 #include <emscripten/wasm_worker.h>
 #include <emscripten/threading.h>
+#include <emscripten/console.h>
 #include <assert.h>
 
 volatile int pthread_ran = 0;
@@ -16,7 +17,7 @@ EM_JS(int, am_i_wasm_worker, (), {
 
 void *thread_main(void *arg)
 {
-  EM_ASM(out('hello from pthread!'));
+  emscripten_out("hello from pthread!");
   assert(am_i_pthread());
   assert(!am_i_wasm_worker());
   assert(!emscripten_current_thread_is_wasm_worker());
@@ -27,7 +28,7 @@ void *thread_main(void *arg)
 
 void worker_main()
 {
-  EM_ASM(out('hello from wasm worker!'));
+  emscripten_out("hello from wasm worker!");
   assert(!am_i_pthread());
   assert(am_i_wasm_worker());
   assert(emscripten_current_thread_is_wasm_worker());

--- a/test/wasmfs/wasmfs_opfs_errors.c
+++ b/test/wasmfs/wasmfs_opfs_errors.c
@@ -82,7 +82,7 @@ EMSCRIPTEN_KEEPALIVE
 int try_oob_read(void) {
   int fd = open(file, O_RDWR);
   if (fd < 0) {
-    EM_ASM({ console.log('fd', $0); }, fd);
+    emscripten_outf("fd %d", fd);
     return 2;
   }
   char buf;
@@ -95,7 +95,7 @@ int try_oob_read(void) {
     close(fd);
     return 0;
   }
-  EM_ASM({ console.log('errno', $0); }, errno);
+  emscripten_outf("errno %d", errno);
   close(fd);
   return 2;
 }
@@ -143,7 +143,7 @@ int try_rename_dir(void) {
 
 EMSCRIPTEN_KEEPALIVE
 void report_result(int result) {
-  EM_ASM({ console.log(new Error().stack); });
+  EM_ASM({ out(new Error().stack); });
 #ifdef REPORT_RESULT
   REPORT_RESULT(result);
 #else


### PR DESCRIPTION
Using these emscripten wrappers has some advantages. In particular, with workers we have seen issues with writes to
console.log/console.error being lost in some cases.