### PR TITLE
WasmFS JS API: Update write to match object returned by opened

### DIFF
--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -164,7 +164,7 @@ FS.createPreloadedFile = FS_createPreloadedFile;
       return bytesRead;
     },
     // Note that canOwn is an optimization that we ignore for now in WasmFS.
-    write: (fd, buffer, offset, length, position, canOwn) => {
+    write: (stream, buffer, offset, length, position, canOwn) => {
       var seeking = typeof position != 'undefined';
 
       var dataBuffer = _malloc(length);
@@ -174,9 +174,9 @@ FS.createPreloadedFile = FS_createPreloadedFile;
 
       var bytesRead;
       if (seeking) {
-        bytesRead = __wasmfs_pwrite(fd, dataBuffer, length, position);
+        bytesRead = __wasmfs_pwrite(stream.fd, dataBuffer, length, position);
       } else {
-        bytesRead = __wasmfs_write(fd, dataBuffer, length);
+        bytesRead = __wasmfs_write(stream.fd, dataBuffer, length);
       }
       bytesRead = FS.handleError(bytesRead);
       _free(dataBuffer);


### PR DESCRIPTION
My original PR for `write` (https://github.com/emscripten-core/emscripten/pull/19508) passed tests assuming that `open` returned an FD. We changed `open` to return an object in a PR after the `write` PR (https://github.com/emscripten-core/emscripten/pull/19542). `test_fs_write` failed for write after the `open` PR was merged in. This PR updates `write` to accept an object from `open` instead of just an fd. 