### PR TITLE
Wasmfs: Support SDL2_image

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1300,6 +1300,7 @@ var LibraryBrowser = {
     return 0;
   },
 
+#if !WASMFS // WasmFS implements this in wasm
   emscripten_get_preloaded_image_data_from_FILE__deps: ['emscripten_get_preloaded_image_data', 'fileno'],
   emscripten_get_preloaded_image_data_from_FILE__proxy: 'sync',
   emscripten_get_preloaded_image_data_from_FILE: function(file, w, h) {
@@ -1311,6 +1312,7 @@ var LibraryBrowser = {
 
     return 0;
   }
+#endif
 };
 
 autoAddDeps(LibraryBrowser, '$Browser');

--- a/system/lib/wasmfs/emscripten.cpp
+++ b/system/lib/wasmfs/emscripten.cpp
@@ -12,6 +12,8 @@
 //
 
 #include <emscripten.h>
+#include <stdio.h>
+
 #include <string>
 
 #include "file.h"
@@ -60,6 +62,6 @@ char *emscripten_get_preloaded_image_data_from_FILE(FILE *file,
     return 0;
   }
 
-  auto path = getPath(fd);
+  auto path = wasmfs::getPath(fd);
   return emscripten_get_preloaded_image_data(path.c_str(), w, h);
 }

--- a/system/lib/wasmfs/emscripten.cpp
+++ b/system/lib/wasmfs/emscripten.cpp
@@ -1,7 +1,15 @@
-// Copyright 2022 The Emscripten Authors.  All rights reserved.
+// Copyright 2023 The Emscripten Authors.  All rights reserved.
 // Emscripten is available under two separate licenses, the MIT license and the
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
+
+//
+// This file contains implementations of emscripten APIs that are compatible
+// with WasmFS. These replace APIs in src/library*js, and basically do things
+// in a simpler manner for the situation where the FS is in wasm and not JS
+// (in particular, these implemenations avoid calling from JS to wasm, and
+// dependency issues that arise from that).
+//
 
 #include <emscripten.h>
 #include <string>
@@ -10,9 +18,12 @@
 #include "file_table.h"
 #include "wasmfs.h"
 
+namespace wasmfs {
+
 // Given an fd, returns the string path that the fd refers to.
 // TODO: full error handling
-static std::string getPath(int fd) {
+// TODO: maybe make this a public API, as it is useful for debugging
+std::string getPath(int fd) {
   auto fileTable = wasmfs::wasmFS.getFileTable().locked();
 
   auto openFile = fileTable.getEntry(fd);
@@ -37,6 +48,8 @@ static std::string getPath(int fd) {
   }
   return result;
 }
+
+} // namespace wasmfs
 
 extern "C"
 char *emscripten_get_preloaded_image_data_from_FILE(FILE *file,

--- a/system/lib/wasmfs/emscripten.cpp
+++ b/system/lib/wasmfs/emscripten.cpp
@@ -1,0 +1,52 @@
+// Copyright 2022 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <emscripten.h>
+#include <string>
+
+#include "file.h"
+#include "file_table.h"
+#include "wasmfs.h"
+
+// Given an fd, returns the string path that the fd refers to.
+// TODO: full error handling
+static std::string getPath(int fd) {
+  auto fileTable = wasmfs::wasmFS.getFileTable().locked();
+
+  auto openFile = fileTable.getEntry(fd);
+  if (!openFile) {
+    return "!";
+  }
+
+  auto curr = openFile->locked().getFile();
+  std::string result = "";
+  while (curr != wasmfs::wasmFS.getRootDirectory()) {
+    auto parent = curr->locked().getParent();
+    // Check if the parent exists. The parent may not exist if curr was
+    // unlinked.
+    if (!parent) {
+      return "?/" + result;
+    }
+
+    auto parentDir = parent->dynCast<wasmfs::Directory>();
+    auto name = parentDir->locked().getName(curr);
+    result = '/' + name + result;
+    curr = parentDir;
+  }
+  return result;
+}
+
+extern "C"
+char *emscripten_get_preloaded_image_data_from_FILE(FILE *file,
+                                                    int *w,
+                                                    int *h) {
+  auto fd = fileno(file);
+  if (fd < 0) {
+    return 0;
+  }
+
+  auto path = getPath(fd);
+  return emscripten_get_preloaded_image_data(path.c_str(), w, h);
+}

--- a/test/browser/test_sdl2_image.c
+++ b/test/browser/test_sdl2_image.c
@@ -74,8 +74,5 @@ int main() {
 
   printf("you should see an image.\n");
 
-  SDL_Quit();
-
   return result;
 }
-

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2945,6 +2945,7 @@ Module["preRun"].push(function () {
       '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--use-preload-plugins'
     ])
 
+  @also_with_wasmfs
   @requires_graphics_hardware
   def test_sdl2_image_formats(self):
     shutil.copyfile(test_file('screenshot.png'), 'screenshot.png')

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1857,6 +1857,7 @@ class libwasmfs(DebugLibrary, AsanInstrumentedLibrary, MTLibrary):
         filenames=['file.cpp',
                    'file_table.cpp',
                    'js_api.cpp',
+                   'emscripten.cpp',
                    'paths.cpp',
                    'special_files.cpp',
                    'support.cpp',


### PR DESCRIPTION
To do that we need to implement

```
emscripten_get_preloaded_image_data_from_FILE
```

This is implemented in JS in the old FS, which then does `FS.getStream()` etc.,
which is more than we want to support in the WasmFS JS API. Instead, just
implement that function in a simple way in wasm, which is much more
straightforward anyhow.

(That implementation is trivial aside from a new `getPath()` helper, but that
helper is useful anyhow - I've been using that code to debug locally.)

This also removes an `SDL_Quit` - removing that allows the test to actually
show the image that was loaded (otherwise we quit before the render
happens, which confused me as I was debugging).