### PR TITLE
update __st_ino_truncated from i32 to i64

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -52,7 +52,7 @@ var SyscallsLibrary = {
         throw e;
       }
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_dev, 'stat.dev', 'i32') }}};
-      {{{ makeSetValue('buf', C_STRUCTS.stat.__st_ino_truncated, 'stat.ino', 'i32') }}};
+      {{{ makeSetValue('buf', C_STRUCTS.stat.__st_ino_truncated, 'stat.ino', 'i64') }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_mode, 'stat.mode', 'i32') }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_nlink, 'stat.nlink', SIZE_TYPE) }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_uid, 'stat.uid', 'i32') }}};


### PR DESCRIPTION
According to system/lib/libc/musl/arch/emscripten/bits/stat.h, __st_ino_truncated is a long, so should be i64. I was running my os in such a way that I was getting large enough inodes that this was causing problems.