### PR TITLE
Truncate inode number when writing to st_ino_truncated. NFC

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -52,7 +52,7 @@ var SyscallsLibrary = {
         throw e;
       }
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_dev, 'stat.dev', 'i32') }}};
-      {{{ makeSetValue('buf', C_STRUCTS.stat.__st_ino_truncated, 'stat.ino', 'i32') }}};
+      {{{ makeSetValue('buf', C_STRUCTS.stat.__st_ino_truncated, 'stat.ino >>> 0', 'i32') }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_mode, 'stat.mode', 'i32') }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_nlink, 'stat.nlink', SIZE_TYPE) }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_uid, 'stat.uid', 'i32') }}};


### PR DESCRIPTION
This field is designed to hold a potentially truncated inode number, as opposes the st_ino which hold the full 64-bit value.

Fixes: #19567