### PR TITLE
Remove legacy fields from stat struct. NFC

### DIFF
--- a/src/generated_struct_info32.json
+++ b/src/generated_struct_info32.json
@@ -1459,33 +1459,32 @@
             "sin6_port": 2
         },
         "stat": {
-            "__size__": 112,
-            "__st_ino_truncated": 8,
+            "__size__": 96,
             "st_atim": {
                 "__size__": 16,
-                "tv_nsec": 64,
-                "tv_sec": 56
+                "tv_nsec": 48,
+                "tv_sec": 40
             },
-            "st_blksize": 48,
-            "st_blocks": 52,
+            "st_blksize": 32,
+            "st_blocks": 36,
             "st_ctim": {
-                "__size__": 16,
-                "tv_nsec": 96,
-                "tv_sec": 88
-            },
-            "st_dev": 0,
-            "st_gid": 24,
-            "st_ino": 104,
-            "st_mode": 12,
-            "st_mtim": {
                 "__size__": 16,
                 "tv_nsec": 80,
                 "tv_sec": 72
             },
-            "st_nlink": 16,
-            "st_rdev": 28,
-            "st_size": 40,
-            "st_uid": 20
+            "st_dev": 0,
+            "st_gid": 16,
+            "st_ino": 88,
+            "st_mode": 4,
+            "st_mtim": {
+                "__size__": 16,
+                "tv_nsec": 64,
+                "tv_sec": 56
+            },
+            "st_nlink": 8,
+            "st_rdev": 20,
+            "st_size": 24,
+            "st_uid": 12
         },
         "statfs": {
             "__size__": 64,

--- a/src/generated_struct_info64.json
+++ b/src/generated_struct_info64.json
@@ -1459,33 +1459,32 @@
             "sin6_port": 2
         },
         "stat": {
-            "__size__": 120,
-            "__st_ino_truncated": 8,
+            "__size__": 104,
             "st_atim": {
                 "__size__": 16,
-                "tv_nsec": 72,
-                "tv_sec": 64
+                "tv_nsec": 56,
+                "tv_sec": 48
             },
-            "st_blksize": 56,
-            "st_blocks": 60,
+            "st_blksize": 40,
+            "st_blocks": 44,
             "st_ctim": {
-                "__size__": 16,
-                "tv_nsec": 104,
-                "tv_sec": 96
-            },
-            "st_dev": 0,
-            "st_gid": 36,
-            "st_ino": 112,
-            "st_mode": 16,
-            "st_mtim": {
                 "__size__": 16,
                 "tv_nsec": 88,
                 "tv_sec": 80
             },
-            "st_nlink": 24,
-            "st_rdev": 40,
-            "st_size": 48,
-            "st_uid": 32
+            "st_dev": 0,
+            "st_gid": 20,
+            "st_ino": 96,
+            "st_mode": 4,
+            "st_mtim": {
+                "__size__": 16,
+                "tv_nsec": 72,
+                "tv_sec": 64
+            },
+            "st_nlink": 8,
+            "st_rdev": 24,
+            "st_size": 32,
+            "st_uid": 16
         },
         "statfs": {
             "__size__": 104,

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -52,7 +52,6 @@ var SyscallsLibrary = {
         throw e;
       }
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_dev, 'stat.dev', 'i32') }}};
-      {{{ makeSetValue('buf', C_STRUCTS.stat.__st_ino_truncated, 'stat.ino', 'i32') }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_mode, 'stat.mode', 'i32') }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_nlink, 'stat.nlink', SIZE_TYPE) }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_uid, 'stat.uid', 'i32') }}};

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -35,7 +35,6 @@
         "structs": {
             "stat": [
                 "st_dev",
-                "__st_ino_truncated",
                 "st_mode",
                 "st_nlink",
                 "st_uid",

--- a/system/lib/libc/musl/arch/emscripten/bits/stat.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/stat.h
@@ -4,14 +4,18 @@
 struct stat
 {
 	dev_t st_dev;
+#ifndef __EMSCRIPTEN__
 	int __st_dev_padding;
 	long __st_ino_truncated;
+#endif
 	mode_t st_mode;
 	nlink_t st_nlink;
 	uid_t st_uid;
 	gid_t st_gid;
 	dev_t st_rdev;
+#ifndef __EMSCRIPTEN__
 	int __st_rdev_padding;
+#endif
 	off_t st_size;
 	blksize_t st_blksize;
 	blkcnt_t st_blocks;


### PR DESCRIPTION
Musl needs these in order to support the linux kernel but we don't need to use the same ABI in emscripten.

Fixes: #19567