### PR TITLE
Fix definition of wint_t

### DIFF
--- a/system/lib/libc/musl/arch/emscripten/bits/alltypes.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/alltypes.h
@@ -48,7 +48,7 @@ typedef int wchar_t;
 #endif
 #endif
 #if defined(__NEED_wint_t) && !defined(__DEFINED_wint_t)
-typedef unsigned wint_t;
+typedef __WINT_TYPE__ wint_t;
 #define __DEFINED_wint_t
 #endif
 

--- a/test/core/test_vswprintf_utf8.c
+++ b/test/core/test_vswprintf_utf8.c
@@ -12,8 +12,7 @@
 #include <errno.h>
 #include <assert.h>
 
-void test_vswprintf(const wchar_t *format, ...)
-{
+void test_vswprintf(const wchar_t *format, ...) {
   wchar_t buffer[256];
   va_list args;
   va_start(args, format);
@@ -25,9 +24,13 @@ void test_vswprintf(const wchar_t *format, ...)
   assert(errno == 0);
 }
 
-int main ()
-{
+int main() {
   setlocale(LC_ALL, "");
-  test_vswprintf(L"This is a character: %lc.\n", 0xF6 /* Unicode Character 'LATIN SMALL LETTER O WITH DIAERESIS' (U+00F6): http://www.fileformat.info/info/unicode/char/00f6/index.htm */);
+  /* Unicode Character 'LATIN SMALL LETTER O WITH DIAERESIS' (U+00F6):
+   * http://www.fileformat.info/info/unicode/char/00f6/index.htm */
+  wint_t wint = 0xF6;
+  wchar_t wchar = 0xF6;
+  printf("This is a wint: %lc.\n", wint);
+  test_vswprintf(L"This is a character: %lc.\n", wint, wchar);
   return 0;
 }

--- a/test/core/test_vswprintf_utf8.out
+++ b/test/core/test_vswprintf_utf8.out
@@ -1,2 +1,3 @@
+This is a wint: ö.
 This is a character: ö.
 number of characters in above string: 24. errno: 0

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8141,7 +8141,7 @@ void* operator new(size_t size) {
     self.do_run_in_out_file_test('core/test_setlocale.c')
 
   def test_vswprintf_utf8(self):
-    self.do_run_in_out_file_test('vswprintf_utf8.c')
+    self.do_core_test('test_vswprintf_utf8.c')
 
   # Test that a main with arguments is automatically asyncified.
   @no_wasm64('TODO: asyncify for wasm64')


### PR DESCRIPTION
This type, just like wchar and char, is signed by default under emscripten.  Also, use the clang builtin `__WINT_TYPE__` to avoid the possibility of getting it wrong..

Fixes: #19583