### PR TITLE
Improve/cleanup `-sVERBOSE` output

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -83,12 +83,6 @@ if (symbolsOnly) {
 // Side modules are pure wasm and have no JS
 assert(!SIDE_MODULE || (ASYNCIFY && global.symbolsOnly), 'JS compiler should only run on side modules if asyncify is used.');
 
-// Output some info and warnings based on settings
-
-if (VERBOSE) {
-  printErr('VERBOSE is on, this generates a lot of output and can slow down compilation');
-}
-
 // Load compiler code
 
 load('modules.js');

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -423,12 +423,12 @@ function(${args}) {
       }
 
       if (VERBOSE) {
-        printErr(`adding ${mangled} and deps ${deps} : ` + (snippet + '').substr(0, 40));
+        printErr(`adding ${symbol} (referenced by ${dependent})`)
       }
       const deps_list = deps.join("','");
       const identDependents = symbol + `__deps: ['${deps_list}']`;
       function addDependency(dep) {
-        return addFromLibrary(dep, `${identDependents}, referenced by ${dependent}`, dep === aliasTarget);
+        return addFromLibrary(dep, `${symbol}, referenced by ${dependent}`, dep === aliasTarget);
       }
       let contentText;
       if (isFunction) {
@@ -504,7 +504,7 @@ function(${args}) {
       return depsText + commentText + contentText;
     }
 
-    const JS = addFromLibrary(symbol, 'top-level compiled C/C++ code');
+    const JS = addFromLibrary(symbol, 'root reference (e.g. compiled C/C++ code)');
     libraryItems.push(JS);
   }
 


### PR DESCRIPTION
This now gives (IMHO) more useful/actionable information about for users want to figure out why each JS symbol was included was included.

The output now looks more like the error one sees when a symbols is missing:

```
adding $printChar (referenced by $flush_NO_FILESYSTEM, referenced by fd_write, referenced by root reference (e.g. compiled C/C++ code))
```