### PR TITLE
Limit exports generated by FORCE_FILEYSTEM

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 3.1.42 (in development)
 -----------------------
+- The `FORCE_FILESYSTEM` setting now only triggers the export of symbols needed
+  by the file packager output.  Specifically, `FS_unlink`, `FS_createLazyFile`,
+  and `FS_createDevice` are no longer automatically exported when
+  `FORCE_FILESYSTEM` is used. (#19590)
 - The log message that emcc will sometime print (for example when auto-building
   system libraries) can now be completely supressed by running with
   `EMCC_LOGGING=0`.

--- a/emcc.py
+++ b/emcc.py
@@ -2465,24 +2465,14 @@ def phase_linker_setup(options, state, newargs):
       settings.EXPORTED_RUNTIME_METHODS += ['stackSave', 'stackAlloc', 'stackRestore']
 
   if settings.FORCE_FILESYSTEM and not settings.MINIMAL_RUNTIME:
-    # when the filesystem is forced, we export by default methods that filesystem usage
-    # may need, including filesystem usage from standalone file packager output (i.e.
-    # file packages not built together with emcc, but that are loaded at runtime
-    # separately, and they need emcc's output to contain the support they need)
+    # When the filesystem is forced, we export FS method needed for standalone file
+    # packager output (i.e.  file packages not built together with emcc, but that
+    # are loaded at runtime separately, and they need emcc's output to contain the
+    # support they need)
     settings.EXPORTED_RUNTIME_METHODS += [
       'FS_createPath',
       'FS_createDataFile',
       'FS_createPreloadedFile',
-      'FS_unlink'
-    ]
-    if not settings.WASMFS:
-      # The old FS has some functionality that WasmFS lacks.
-      settings.EXPORTED_RUNTIME_METHODS += [
-        'FS_createLazyFile',
-        'FS_createDevice'
-      ]
-
-    settings.EXPORTED_RUNTIME_METHODS += [
       'addRunDependency',
       'removeRunDependency',
     ]

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -28,13 +28,7 @@ function isExportedByForceFilesystem(name) {
   return name === 'FS_createPath' ||
          name === 'FS_createDataFile' ||
          name === 'FS_createPreloadedFile' ||
-         name === 'FS_unlink' ||
          name === 'addRunDependency' ||
-#if !WASMFS
-         // The old FS has some functionality that WasmFS lacks.
-         name === 'FS_createLazyFile' ||
-         name === 'FS_createDevice' ||
-#endif
          name === 'removeRunDependency';
 }
 


### PR DESCRIPTION
Specifically, only export symbols that are actually neede by the output of the file packager.