### PR TITLE
Optimize glMapBufferRange() to not generate temporary JS garbage

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -3957,15 +3957,15 @@ var LibraryGL = {
       return 0;
     }
 
-    var mem = _malloc(length);
+    var mem = _malloc(length), binding = emscriptenWebGLGetBufferBinding(target);
     if (!mem) return 0;
 
-    GL.mappedBuffers[emscriptenWebGLGetBufferBinding(target)] = {
-      offset: offset,
-      length: length,
-      mem: mem,
-      access: access,
-    };
+    if (!GL.mappedBuffers[binding]) GL.mappedBuffers[binding] = {};
+    binding = GL.mappedBuffers[binding];
+    binding.offset = offset;
+    binding.length = length;
+    binding.mem = mem;
+    binding.access = access;
     return mem;
   },
 
@@ -4026,12 +4026,11 @@ var LibraryGL = {
 
     var buffer = emscriptenWebGLGetBufferBinding(target);
     var mapping = GL.mappedBuffers[buffer];
-    if (!mapping) {
+    if (!mapping || !mapping.mem) {
       GL.recordError(0x502 /* GL_INVALID_OPERATION */);
       err('buffer was never mapped in glUnmapBuffer');
       return 0;
     }
-    GL.mappedBuffers[buffer] = null;
 
     if (!(mapping.access & 0x10)) /* GL_MAP_FLUSH_EXPLICIT_BIT */
       if ({{{ isCurrentContextWebGL2() }}}) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
@@ -4040,6 +4039,7 @@ var LibraryGL = {
         GLctx.bufferSubData(target, mapping.offset, HEAPU8.subarray(mapping.mem, mapping.mem+mapping.length));
       }
     _free(mapping.mem);
+    mapping.mem = 0;
     return 1;
   },
 #endif


### PR DESCRIPTION
This was the largest remaining source of per-frame JS garbage in Unity's WebGL 2 backend.