### PR TITLE
Add note about space notation and remove leftovers

### DIFF
--- a/site/source/docs/getting_started/FAQ.rst
+++ b/site/source/docs/getting_started/FAQ.rst
@@ -404,8 +404,8 @@ what you want on the web: even though ``main()`` exited, you may have something
 asynchronous happening later that you want to execute.
 
 In some cases, though, you may want a more "commandline" experience, where we do
-shut down the runtime when ``main()`` exits. You can build with ``-s
-EXIT_RUNTIME``, and then we will call ``atexits`` and so forth. When you build
+shut down the runtime when ``main()`` exits. You can build with ``-sEXIT_RUNTIME``,
+and then we will call ``atexits`` and so forth. When you build
 with ``ASSERTIONS``, you should get a warning when you need this. For example,
 if your program prints something without a newline,
 
@@ -643,7 +643,7 @@ strings, so it accepts ``[a]`` or ``[a,b]`` etc.).
 
 
 Why do I get a Python ``SyntaxError: invalid syntax`` on ``file=..`` or on a string starting with ``f'..'``?
-============================================================================================================ 
+============================================================================================================
 
 Emscripten requires a recent-enough version of Python. An older Python version,
 like ``2.*``, will not support the print statement by default, so it will error on

--- a/site/source/docs/getting_started/Tutorial.rst
+++ b/site/source/docs/getting_started/Tutorial.rst
@@ -87,8 +87,8 @@ execute it. You can run them using :term:`node.js`:
 This prints "hello, world!" to the console, as expected.
 
 .. note:: Older node.js versions do not have WebAssembly support yet. In that
-   case you will see an error message suggesting that you build with ``-s
-   WASM=0`` to disable WebAssembly, and then emscripten will emit the compiled
+   case you will see an error message suggesting that you build with
+   ``-sWASM=0`` to disable WebAssembly, and then emscripten will emit the compiled
    code as JavaScript. In general, WebAssembly is recommended as it has
    widespread browser support and is more efficient both to execute and to
    download (and therefore emscripten emits it by default), but sometimes you

--- a/site/source/docs/porting/networking.rst
+++ b/site/source/docs/porting/networking.rst
@@ -46,8 +46,8 @@ complete at the moment, it is likely that you will run into problems out of the
 box and need to adapt the code to work within the limitations that this
 emulation provides.
 
-This is the default build mode for Emscripten. Use the linker flag ``-s
-WEBSOCKET_URL`` or ``Module['websocket']['url']`` to specify the WebSocket URL
+This is the default build mode for Emscripten. Use the linker flag
+``-sWEBSOCKET_URL`` or ``Module['websocket']['url']`` to specify the WebSocket URL
 to connect to, and the linker flag ``-sWEBSOCKET_SUBPROTOCOL`` or
 ``Module['websocket']['subprotocol']`` to control the connection type
 (``'binary'`` or ``'text'``).

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -137,6 +137,9 @@ Options that are modified or new in *emcc* are listed below:
 
   .. note:: Options can be specified as a single argument with or without a space
             between the ``-s`` and option name.  e.g. ``-sFOO`` or ``-s FOO``.
+            It's
+            `highly recommended <https://emscripten.org/docs/getting_started/FAQ.html#:~:text=However%2C%20some%20%2Ds%20options%20may%20require%20quoting%2C%20or%20the%20space%20between%20%2Ds%20and%20the%20next%20argument%20may%20confuse%20CMake%2C%20when%20using%20things%20like%20target_link_options.%20To%20avoid%20those%20problems%2C%20you%20can%20use%20%2DsX%3DY%20notation%2C%20that%20is%2C%20without%20a%20space%3A>`_
+            you use the notation without space.
 
 .. _emcc-g:
 


### PR DESCRIPTION
- Remove `s FOO=BAR` in favor of `sFOO=BAR`.
- Add note why it's preferred.