### PR TITLE
WasmFS JS API: Clean up API Wrappers

### DIFF
--- a/system/lib/wasmfs/js_api.cpp
+++ b/system/lib/wasmfs/js_api.cpp
@@ -126,19 +126,11 @@ int _wasmfs_mkdir(char* path, int mode) {
 int _wasmfs_rmdir(char* path){ return __syscall_unlinkat(AT_FDCWD, (intptr_t)path, AT_REMOVEDIR); }
 
 int _wasmfs_open(char* path, int flags, mode_t mode) {
-  int err = __syscall_openat(AT_FDCWD, (intptr_t)path, flags, mode);
-  if (err == -1) {
-    return -errno;
-  }
-  return err;
+  return __syscall_openat(AT_FDCWD, (intptr_t)path, flags, mode);
 }
 
 int _wasmfs_mknod(char* path, mode_t mode, dev_t dev) {
-  int err = __syscall_mknodat(AT_FDCWD, (intptr_t)path, mode, dev);
-  if (err == -1) {
-    return errno;
-  }
-  return err;
+  return __syscall_mknodat(AT_FDCWD, (intptr_t)path, mode, dev);
 }
 
 int _wasmfs_unlink(char* path) {
@@ -190,11 +182,7 @@ int _wasmfs_lchmod(char* path, mode_t mode) {
 }
 
 int _wasmfs_rename(char* oldpath, char* newpath) {
-  int err = __syscall_renameat(AT_FDCWD, (intptr_t)oldpath, AT_FDCWD, (intptr_t)newpath);
-  if (err == -1) {
-    return errno;
-  }
-  return err;
+  return __syscall_renameat(AT_FDCWD, (intptr_t)oldpath, AT_FDCWD, (intptr_t)newpath);
 };
 
 int _wasmfs_read(int fd, void *buf, size_t count) {
@@ -228,19 +216,11 @@ int _wasmfs_close(int fd) {
 }
 
 int _wasmfs_stat(char* path, struct stat* statBuf) {
-  int err = __syscall_stat64((intptr_t)path, (intptr_t)statBuf);
-  if (err == -1) {
-    return errno;
-  }
-  return err;
+  return __syscall_stat64((intptr_t)path, (intptr_t)statBuf);
 }
 
 int _wasmfs_lstat(char* path, struct stat* statBuf) {
-  int err = __syscall_lstat64((intptr_t)path, (intptr_t)statBuf);
-  if (err == -1) {
-    return errno;
-  }
-  return err;
+  return __syscall_lstat64((intptr_t)path, (intptr_t)statBuf);
 }
 
 // Helper method that identifies what a path is:


### PR DESCRIPTION
This PR removes the unnecessary if statements in the JS API, since the syscalls do not actually set `errno`. This PR does not change any functionality of the API wrapper methods. 