### PR TITLE
Move `atob` (ascii-to-base64) polyfill into its own file. NFC

### DIFF
--- a/src/base64Utils.js
+++ b/src/base64Utils.js
@@ -1,56 +1,25 @@
-// Copied from https://github.com/strophe/strophejs/blob/e06d027/src/polyfills.js#L149
-
-// This code was written by Tyler Akins and has been placed in the
-// public domain.  It would be nice if you left this header intact.
-// Base64 code from Tyler Akins -- http://rumkin.com
-
 /**
- * Decodes a base64 string.
- * @param {string} input The string to decode.
+ * @license
+ * Copyright 2017 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
  */
-var decodeBase64 = typeof atob == 'function' ? atob : function (input) {
-  var keyStr = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
 
-  var output = '';
-  var chr1, chr2, chr3;
-  var enc1, enc2, enc3, enc4;
-  var i = 0;
-  // remove all characters that are not A-Z, a-z, 0-9, +, /, or =
-  input = input.replace(/[^A-Za-z0-9\+\/\=]/g, '');
-  do {
-    enc1 = keyStr.indexOf(input.charAt(i++));
-    enc2 = keyStr.indexOf(input.charAt(i++));
-    enc3 = keyStr.indexOf(input.charAt(i++));
-    enc4 = keyStr.indexOf(input.charAt(i++));
-
-    chr1 = (enc1 << 2) | (enc2 >> 4);
-    chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
-    chr3 = ((enc3 & 3) << 6) | enc4;
-
-    output = output + String.fromCharCode(chr1);
-
-    if (enc3 !== 64) {
-      output = output + String.fromCharCode(chr2);
-    }
-    if (enc4 !== 64) {
-      output = output + String.fromCharCode(chr3);
-    }
-  } while (i < input.length);
-  return output;
-};
+#if POLYFILL &&  ENVIRONMENT_MAY_BE_NODE && MIN_NODE_VERSION < 160000
+#include "polyfill/atob.js"
+#endif
 
 // Converts a string of base64 into a byte array.
 // Throws error on invalid input.
 function intArrayFromBase64(s) {
 #if ENVIRONMENT_MAY_BE_NODE
-  if (typeof ENVIRONMENT_IS_NODE == 'boolean' && ENVIRONMENT_IS_NODE) {
+  if (typeof ENVIRONMENT_IS_NODE != 'undefined' && ENVIRONMENT_IS_NODE) {
     var buf = Buffer.from(s, 'base64');
     return new Uint8Array(buf['buffer'], buf['byteOffset'], buf['byteLength']);
   }
 #endif
 
   try {
-    var decoded = decodeBase64(s);
+    var decoded = atob(s);
     var bytes = new Uint8Array(decoded.length);
     for (var i = 0 ; i < decoded.length ; ++i) {
       bytes[i] = decoded.charCodeAt(i);

--- a/src/polyfill/atob.js
+++ b/src/polyfill/atob.js
@@ -1,0 +1,50 @@
+// Copied from https://github.com/strophe/strophejs/blob/e06d027/src/polyfills.js#L149
+
+// This code was written by Tyler Akins and has been placed in the
+// public domain.  It would be nice if you left this header intact.
+// Base64 code from Tyler Akins -- http://rumkin.com
+
+#if !POLYFILL
+#error "this file should never be included unless POLYFILL is set"
+#endif
+
+#if !ENVIRONMENT_MAY_BE_NODE
+#error "this polyfill should only be included when targetting node"
+#endif
+
+if (typeof ENVIRONMENT_IS_NODE != 'undefined' && ENVIRONMENT_IS_NODE && !global.atob) {
+  /**
+   * Decodes a base64 string.
+   * @param {string} input The string to decode.
+   */
+  global.atob = function(input) {
+    var keyStr = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+
+    var output = '';
+    var chr1, chr2, chr3;
+    var enc1, enc2, enc3, enc4;
+    var i = 0;
+    // remove all characters that are not A-Z, a-z, 0-9, +, /, or =
+    input = input.replace(/[^A-Za-z0-9\+\/\=]/g, '');
+    do {
+      enc1 = keyStr.indexOf(input.charAt(i++));
+      enc2 = keyStr.indexOf(input.charAt(i++));
+      enc3 = keyStr.indexOf(input.charAt(i++));
+      enc4 = keyStr.indexOf(input.charAt(i++));
+
+      chr1 = (enc1 << 2) | (enc2 >> 4);
+      chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
+      chr3 = ((enc3 & 3) << 6) | enc4;
+
+      output = output + String.fromCharCode(chr1);
+
+      if (enc3 !== 64) {
+        output = output + String.fromCharCode(chr2);
+      }
+      if (enc4 !== 64) {
+        output = output + String.fromCharCode(chr3);
+      }
+    } while (i < input.length);
+    return output;
+  };
+}

--- a/src/polyfill/bigint64array.js
+++ b/src/polyfill/bigint64array.js
@@ -1,5 +1,5 @@
 #if !POLYFILL
-assert(false, "this file should never be included unless POLYFILL is set");
+#error "this file should never be included unless POLYFILL is set"
 #endif
 
 if (typeof globalThis.BigInt64Array === "undefined") {

--- a/src/polyfill/objassign.js
+++ b/src/polyfill/objassign.js
@@ -2,7 +2,7 @@
 // https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/js/es6/util/assign.js
 
 #if !POLYFILL
-assert(false, "this file should never be included unless POLYFILL is set");
+#error "this file should never be included unless POLYFILL is set"
 #endif
 
 if (typeof Object.assign == 'undefined') {

--- a/src/polyfill/promise.js
+++ b/src/polyfill/promise.js
@@ -24,7 +24,7 @@
 //==============================================================================
 
 #if !POLYFILL
-assert(false, "this file should never be included unless POLYFILL is set");
+#error "this file should never be included unless POLYFILL is set"
 #endif
 
 /** @suppress{duplicate} This is already defined in from Closure's built-in

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -682,7 +682,7 @@ def generate_js(data_target, data_files, metadata):
         data = base64_encode(utils.read_binary(file_.srcpath))
         code += "      var fileData%d = '%s';\n" % (counter, data)
         # canOwn this data in the filesystem (i.e. there is no need to create a copy in the FS layer).
-        code += ("      Module['FS_createDataFile']('%s', '%s', decodeBase64(fileData%d), true, true, true);\n"
+        code += ("      Module['FS_createDataFile']('%s', '%s', atob(fileData%d), true, true, true);\n"
                  % (dirname, basename, counter))
     elif file_.mode == 'preload':
       # Preload


### PR DESCRIPTION
Also, include include it when targeting older versions of node. Browsers have always supported this API.