### PR TITLE
Fix browser.test_binaryen_async for WasmFS

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4366,8 +4366,11 @@ Module["preRun"].push(function () {
       (['-O1'], 1),
       (['-O2'], 1),
       (['-O3'], 1),
-      (['-sWASM_ASYNC_COMPILATION'], 1), # force it on
-      (['-O1', '-sWASM_ASYNC_COMPILATION=0'], 0), # force it off
+      # force it on
+      (['-sWASM_ASYNC_COMPILATION'], 1),
+      # force it off. note that we use -O3 here to make the binary small enough
+      # for chrome to allow compiling it synchronously
+      (['-O3', '-sWASM_ASYNC_COMPILATION=0'], 0),
     ]:
       print(opts, returncode)
       self.btest_exit('binaryen_async.c', assert_returncode=returncode, args=common_args + opts)


### PR DESCRIPTION
That test checks we can synchronously compile, but the WasmFS code size is
too big for Chrome to allow it. Switch to `-O3` which emits small-enough code
to work around that.

(Eventually we hope to improve code size here, but there's not really any harm
in keeping this at `-O3` anyhow, so I didn't add a TODO to change that.)