### PR TITLE
Fix SDL1 deps

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -26,11 +26,10 @@ var LibrarySDL = {
   $SDL_audio: function() { return SDL.audio; },
 
   $SDL__deps: [
-#if FILESYSTEM
-    '$FS',
-#endif
     '$PATH', '$Browser', 'SDL_GetTicks', 'SDL_LockSurface',
-    '$SDL_unicode', '$SDL_ttfContext', '$SDL_audio'
+    '$SDL_unicode', '$SDL_ttfContext', '$SDL_audio',
+    // For makeCEvent().
+    '$intArrayFromString',
   ],
   $SDL: {
     defaults: {
@@ -2687,7 +2686,11 @@ var LibrarySDL = {
     return 1;
   },
 
-  Mix_LoadWAV_RW__deps: ['$PATH_FS', 'fileno'],
+  Mix_LoadWAV_RW__deps: [
+    '$FS',
+    '$PATH_FS',
+    'fileno',
+  ],
   Mix_LoadWAV_RW__proxy: 'sync',
   Mix_LoadWAV_RW__docs: '/** @param {number} freesrc */',
   Mix_LoadWAV_RW: function(rwopsID, freesrc) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -601,7 +601,7 @@ var POLYFILL_OLD_MATH_FUNCTIONS = false;
 var LEGACY_VM_SUPPORT = false;
 
 // Specify which runtime environments the JS output will be capable of running
-// in.  For maximum portability this can configured to support all envionements
+// in.  For maximum portability this can configured to support all environments
 // or it can be limited to reduce overall code size.  The supported environments
 // are:
 //    'web'     - the normal web environment.

--- a/src/settings.js
+++ b/src/settings.js
@@ -1714,7 +1714,7 @@ var FETCH = false;
 // If set to 1, uses new filesystem implementation.
 // [link]
 // [experimental]
-var WASMFS = true;
+var WASMFS = false;
 
 // If set to 1, embeds all subresources in the emitted file as base64 string
 // literals. Embedded subresources may include (but aren't limited to) wasm,

--- a/src/settings.js
+++ b/src/settings.js
@@ -601,7 +601,7 @@ var POLYFILL_OLD_MATH_FUNCTIONS = false;
 var LEGACY_VM_SUPPORT = false;
 
 // Specify which runtime environments the JS output will be capable of running
-// in.  For maximum portability this can configured to support all environments
+// in.  For maximum portability this can configured to support all envionements
 // or it can be limited to reduce overall code size.  The supported environments
 // are:
 //    'web'     - the normal web environment.
@@ -1714,7 +1714,7 @@ var FETCH = false;
 // If set to 1, uses new filesystem implementation.
 // [link]
 // [experimental]
-var WASMFS = false;
+var WASMFS = true;
 
 // If set to 1, embeds all subresources in the emitted file as base64 string
 // literals. Embedded subresources may include (but aren't limited to) wasm,

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2096,6 +2096,7 @@ void *getBindBuffer() {
 ''')
     self.btest('third_party/cubegeom/cubegeom_proc.c', reference='third_party/cubegeom/cubegeom.png', args=opts + ['side.c', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
+  @also_with_wasmfs
   @requires_graphics_hardware
   def test_cubegeom_glew(self):
     self.btest('third_party/cubegeom/cubegeom_glew.c', reference='third_party/cubegeom/cubegeom.png', args=['-O2', '--closure=1', '-sLEGACY_GL_EMULATION', '-lGL', '-lGLEW', '-lSDL'])


### PR DESCRIPTION
FS is only used in one specific method, so put the dep there. That avoids a
WasmFS closure error on including FS without enough WasmFS code (which
should not happen in practice, as that method loads data from a file - so
WasmFS would be present to support those file operatoins).

Also `intArrayFromString` is used and was not declared.