### PR TITLE
WasmFS: Fix file packager use after startup

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1861,6 +1861,7 @@ keydown(100);keyup(100); // trigger the end
   def test_emscripten_api(self):
     self.btest_exit('emscripten_api_browser.c', args=['-sEXPORTED_FUNCTIONS=_main,_third', '-lSDL'])
 
+  @also_with_wasmfs
   def test_emscripten_async_load_script(self):
     def setup():
       create_file('script1.js', '''


### PR DESCRIPTION
During startup if we run file packager code then the `createDataFile` calls
are turned into code that caches the info for later, as we can't call into
WasmFS during startup. Then when WasmFS is running, it reads the cached
info and creates the files. But we also need to handle the case where file
packager code is run *after* startup, which is easier to support even if it
is more rare - just create the file.

This is unfortunately more complex than the old JS FS. The JS FS had the
advantage of being in JS, so it could be called into before the wasm was
running.