### PR TITLE
WasmFS: Fix and add deps

### DIFF
--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -92,6 +92,13 @@ FS.createPreloadedFile = FS_createPreloadedFile;
       }
       return current;
     },
+
+#if hasExportedSymbol('_wasmfs_read_file') // Support the JS function exactly
+                                           // when the __wasmfs_* function is
+                                           // present to be called (otherwise,
+                                           // we'd error anyhow). This depends
+                                           // on other code including the
+                                           // __wasmfs_* method properly.
     readFile: (path, opts = {}) => {
       opts.encoding = opts.encoding || 'binary';
       if (opts.encoding !== 'utf8' && opts.encoding !== 'binary') {
@@ -113,18 +120,9 @@ FS.createPreloadedFile = FS_createPreloadedFile;
 
       return ret;
     },
+#endif
 
-    // FS.cwd is in the awkward position of being used from various JS
-    // libraries through PATH_FS. FORCE_FILESYSTEM may not have been set while
-    // using those libraries, which means we cannot put this method in the
-    // ifdef for that setting just below. Instead, what we can use to tell if we
-    // need this method is whether the compiled get_cwd() method is present, as
-    // we include that both when FORCE_FILESYSTEM *and* when PATH_FS is in use
-    // (see the special PATH_FS deps logic for WasmFS).
-    //
-    // While this may seem odd, it also makes sense: we include this JS method
-    // exactly when the wasm method it wants to call is present.
-#if hasExportedSymbol('_wasmfs_get_cwd')
+#if hasExportedSymbol('_wasmfs_get_cwd') // Similar to readFile, above.
     cwd: () => UTF8ToString(__wasmfs_get_cwd()),
 #endif
 

--- a/src/library_wasmfs_fetch.js
+++ b/src/library_wasmfs_fetch.js
@@ -13,6 +13,7 @@ mergeInto(LibraryManager.library, {
     '$wasmFS$backends',
     '$wasmFS$JSMemoryFiles',
     '_wasmfs_create_js_file_backend_js',
+    '_wasmfs_fetch_get_file_path',
   ],
   _wasmfs_create_fetch_backend_js: async function(backend) {
     // Get a promise that fetches the data and stores it in JS memory (if it has

--- a/src/library_wasmfs_jsimpl.js
+++ b/src/library_wasmfs_jsimpl.js
@@ -52,6 +52,7 @@ mergeInto(LibraryManager.library, {
   // implementors of backends: the hooks we call should return Promises, which
   // we then connect to the calling C++.
 
+  _wasmfs_jsimpl_async_alloc_file__deps: ['emscripten_proxy_finish'],
   _wasmfs_jsimpl_async_alloc_file: async function(ctx, backend, file) {
 #if ASSERTIONS
     assert(wasmFS$backends[backend]);
@@ -60,6 +61,7 @@ mergeInto(LibraryManager.library, {
     _emscripten_proxy_finish(ctx);
   },
 
+  _wasmfs_jsimpl_async_free_file__deps: ['emscripten_proxy_finish'],
   _wasmfs_jsimpl_async_free_file: async function(ctx, backend, file) {
 #if ASSERTIONS
     assert(wasmFS$backends[backend]);
@@ -68,6 +70,7 @@ mergeInto(LibraryManager.library, {
     _emscripten_proxy_finish(ctx);
   },
 
+  _wasmfs_jsimpl_async_write__deps: ['emscripten_proxy_finish'],
   _wasmfs_jsimpl_async_write: async function(ctx, backend, file, buffer, length, {{{ defineI64Param('offset') }}}, result_p) {
     {{{ receiveI64ParamAsDouble('offset') }}}
 #if ASSERTIONS
@@ -78,6 +81,7 @@ mergeInto(LibraryManager.library, {
     _emscripten_proxy_finish(ctx);
   },
 
+  _wasmfs_jsimpl_async_read__deps: ['emscripten_proxy_finish'],
   _wasmfs_jsimpl_async_read: async function(ctx, backend, file, buffer, length, {{{ defineI64Param('offset') }}}, result_p) {
     {{{ receiveI64ParamAsDouble('offset') }}}
 #if ASSERTIONS
@@ -88,6 +92,7 @@ mergeInto(LibraryManager.library, {
     _emscripten_proxy_finish(ctx);
   },
 
+  _wasmfs_jsimpl_async_get_size__deps: ['emscripten_proxy_finish'],
   _wasmfs_jsimpl_async_get_size: async function(ctx, backend, file, size_p) {
 #if ASSERTIONS
     assert(wasmFS$backends[backend]);

--- a/src/library_wasmfs_node.js
+++ b/src/library_wasmfs_node.js
@@ -56,7 +56,8 @@ mergeInto(LibraryManager.library, {
   _wasmfs_node_readdir__deps: [
     '$wasmfsNodeConvertNodeCode',
     '$withStackSave',
-    '$stringToUTF8OnStack'
+    '$stringToUTF8OnStack',
+    '_wasmfs_node_record_dirent',
   ],
   _wasmfs_node_readdir: function(path_p, vec) {
     let path = UTF8ToString(path_p);

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -148,7 +148,11 @@ mergeInto(LibraryManager.library, {
     wasmfsOPFSProxyFinish(ctx);
   },
 
-  _wasmfs_opfs_get_entries__deps: ['$wasmfsOPFSProxyFinish', '$withStackSave'],
+  _wasmfs_opfs_get_entries__deps: [
+    '$wasmfsOPFSProxyFinish',
+    '$withStackSave',
+    '_wasmfs_opfs_record_entry',
+  ],
   _wasmfs_opfs_get_entries: async function(ctx, dirID, entriesPtr, errPtr) {
     let dirHandle = wasmfsOPFSDirectoryHandles.get(dirID);
 


### PR DESCRIPTION
Use the same method on readfile as on cwd. That works better for a method
inside a big object like FS. And it really makes a lot of sense the more I get
used to it: when the wasm code is there, expose the JS method that calls it,
and not otherwise; that avoids all possible problems (aside from code not
including the wasm code when it needs to - but that would be a bug in the
other code).

This gets us much closer to being able to run a closure+FULL_LIBRARY test.