### PR TITLE
Add note about casing inconsistencies

### DIFF
--- a/site/source/docs/api_reference/Filesystem-API.rst
+++ b/site/source/docs/api_reference/Filesystem-API.rst
@@ -180,7 +180,7 @@ By default:
 File system API
 ===============
 
-.. note:: Functions derived from libc like ``FS.readdir`` use all-lowercase names, whereas added functions like ``FS.readFile`` use camelCase names.
+.. note:: Functions derived from libc like ``FS.readdir()`` use all-lowercase names, whereas added functions like ``FS.readFile()`` use camelCase names.
 
 .. js:function:: FS.mount(type, opts, mountpoint)
 


### PR DESCRIPTION
`FS.readdir()` vs. `FS.readFile()`.