### PR TITLE
Remove references to dateNow

### DIFF
--- a/src/closure-externs/spidermonkey-externs.js
+++ b/src/closure-externs/spidermonkey-externs.js
@@ -34,11 +34,6 @@ var scriptArgs = [];
  */
 var quit = function(status) {};
 /**
- * @return {number}
- * @suppress {duplicate}
- */
-var dateNow = function() {};
-/**
  * This is to prevent Closure Compiler to use `gc` as variable name anywhere, otherwise it might collide with SpiderMonkey's shell `gc()` function
  */
 var gc = function () {};

--- a/src/closure-externs/v8-externs.js
+++ b/src/closure-externs/v8-externs.js
@@ -32,8 +32,3 @@ var scriptArgs = [];
  * @suppress {duplicate}
  */
 var quit = function(status) {};
-/**
- * @return {number}
- * @suppress {duplicate}
- */
-var dateNow = function() {};

--- a/src/library.js
+++ b/src/library.js
@@ -2334,11 +2334,6 @@ mergeInto(LibraryManager.library, {
     // respective time origins.
     _emscripten_get_now = () => performance.timeOrigin + {{{ getPerformanceNow() }}}();
 #else
-#if ENVIRONMENT_MAY_BE_SHELL
-    if (typeof dateNow != 'undefined') {
-      _emscripten_get_now = dateNow;
-    } else
-#endif
 #if MIN_IE_VERSION <= 9 || MIN_FIREFOX_VERSION <= 14 || MIN_CHROME_VERSION <= 23 || MIN_SAFARI_VERSION <= 80400 || AUDIO_WORKLET // https://caniuse.com/#feat=high-resolution-time
     // AudioWorkletGlobalScope does not have performance.now()
     // (https://github.com/WebAudio/web-audio-api/issues/2527), so if building
@@ -2368,11 +2363,6 @@ mergeInto(LibraryManager.library, {
       return 1; // nanoseconds
     }
 #endif
-#if ENVIRONMENT_MAY_BE_SHELL
-    if (typeof dateNow != 'undefined') {
-      return 1000; // microseconds (1/1000 of a millisecond)
-    }
-#endif
 #if MIN_IE_VERSION <= 9 || MIN_FIREFOX_VERSION <= 14 || MIN_CHROME_VERSION <= 23 || MIN_SAFARI_VERSION <= 80400 // https://caniuse.com/#feat=high-resolution-time
     if (typeof performance == 'object' && performance && typeof performance['now'] == 'function') {
       return 1000; // microseconds (1/1000 of a millisecond)
@@ -2392,9 +2382,6 @@ mergeInto(LibraryManager.library, {
      ((typeof performance == 'object' && performance && typeof performance['now'] == 'function')
 #if ENVIRONMENT_MAY_BE_NODE
       || ENVIRONMENT_IS_NODE
-#endif
-#if ENVIRONMENT_MAY_BE_SHELL
-      || (typeof dateNow != 'undefined')
 #endif
     );`,
 #else

--- a/test/optimizer/applyImportAndExportNameChanges2-output.js
+++ b/test/optimizer/applyImportAndExportNameChanges2-output.js
@@ -200,8 +200,6 @@ if (ENVIRONMENT_IS_NODE) {
   var t = process.hrtime();
   return t[0] * 1e3 + t[1] / 1e6;
  };
-} else if (typeof dateNow !== "undefined") {
- _emscripten_get_now = dateNow;
 } else if (typeof self === "object" && self["performance"] && typeof self["performance"]["now"] === "function") {
  _emscripten_get_now = function() {
   return self["performance"]["now"]();

--- a/test/optimizer/applyImportAndExportNameChanges2.js
+++ b/test/optimizer/applyImportAndExportNameChanges2.js
@@ -192,8 +192,6 @@ if (ENVIRONMENT_IS_NODE) {
         var t = process.hrtime();
         return t[0] * 1e3 + t[1] / 1e6
     }
-} else if (typeof dateNow !== "undefined") {
-    _emscripten_get_now = dateNow
 } else if (typeof self === "object" && self["performance"] && typeof self["performance"]["now"] === "function") {
     _emscripten_get_now = (function() {
         return self["performance"]["now"]()


### PR DESCRIPTION
It seems that this was once needed to support some JS shell or another. However, as of today the only shell the defines this is `spidermonkey`, and they also define performance.now() .. seemingly to the same thing:

```
$ ~/.jsvu/engines/spidermonkey/spidermonkey
js> dateNow() - performance.now()
-0.0029296875
js>
```

Neither d8 now jsc define dateNow.