### PR TITLE
Fix -sDETERMINISTIC under node >= 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -617,6 +617,7 @@ jobs:
       - run-tests:
           title: "selected subset"
           test_targets: "
+            other.test_deterministic
             other.test_gen_struct_info
             other.test_native_call_before_init
             other.test_node_unhandled_rejection

--- a/src/deterministic.js
+++ b/src/deterministic.js
@@ -9,9 +9,18 @@ Math.random = () => {
   MAGIC = Math.pow(MAGIC + 1.8912, 3) % 1;
   return MAGIC;
 };
+
 var TIME = 10000;
-Date.now = () => TIME++;
-if (typeof performance == 'object') performance.now = Date.now;
+function deterministicNow() {
+  return TIME++;
+}
+
+Date.now = deterministicNow;
+
+// Setting performance.now to deterministicNow doesn't work so we instead
+// use a helper function in parseTools (getPerformanceNow()) to call it
+// directly.
+// if (typeof performance == 'object') performance.now = Date.now;
 
 Module['thisProgram'] = 'thisProgram'; // for consistency between different builds than between runs of the same build
 

--- a/src/library.js
+++ b/src/library.js
@@ -2332,7 +2332,7 @@ mergeInto(LibraryManager.library, {
     // Pthreads need their clocks synchronized to the execution of the main
     // thread, so, when using them, make sure to adjust all timings to the
     // respective time origins.
-    _emscripten_get_now = () => performance.timeOrigin + performance.now();
+    _emscripten_get_now = () => performance.timeOrigin + {{{ getPerformanceNow() }}}();
 #else
 #if ENVIRONMENT_MAY_BE_SHELL
     if (typeof dateNow != 'undefined') {
@@ -2344,11 +2344,11 @@ mergeInto(LibraryManager.library, {
     // (https://github.com/WebAudio/web-audio-api/issues/2527), so if building
     // with
     // Audio Worklets enabled, do a dynamic check for its presence.
-    if (typeof performance != 'undefined' && performance.now) {
+    if (typeof performance != 'undefined' && {{{ getPerformanceNow() }}}) {
 #if PTHREADS
-      _emscripten_get_now = () => performance.timeOrigin + performance.now();
+      _emscripten_get_now = () => performance.timeOrigin + {{{ getPerformanceNow() }}}();
 #else
-      _emscripten_get_now = () => performance.now();
+      _emscripten_get_now = () => {{{ getPerformanceNow() }}}();
 #endif
     } else {
       _emscripten_get_now = Date.now;
@@ -2357,7 +2357,7 @@ mergeInto(LibraryManager.library, {
     // Modern environment where performance.now() is supported:
     // N.B. a shorter form "_emscripten_get_now = performance.now;" is
     // unfortunately not allowed even in current browsers (e.g. FF Nightly 75).
-    _emscripten_get_now = () => performance.now();
+    _emscripten_get_now = () => {{{ getPerformanceNow() }}}();
 #endif
 #endif
 `,

--- a/src/library_eventloop.js
+++ b/src/library_eventloop.js
@@ -113,10 +113,10 @@ LibraryJSEventLoop = {
     clearTimeout(id);
   },
 
-  emscripten_set_timeout_loop__deps: ['$callUserCallback'],
+  emscripten_set_timeout_loop__deps: ['$callUserCallback', 'emscripten_get_now'],
   emscripten_set_timeout_loop: function(cb, msecs, userData) {
     function tick() {
-      var t = performance.now();
+      var t = _emscripten_get_now();
       var n = t + msecs;
       {{{ runtimeKeepalivePop() }}}
       callUserCallback(function() {
@@ -125,7 +125,7 @@ LibraryJSEventLoop = {
           // negative setTimeout as timeout of 0
           // (https://stackoverflow.com/questions/8430966/is-calling-settimeout-with-a-negative-delay-ok)
           {{{ runtimeKeepalivePush() }}}
-          setTimeout(tick, n - performance.now());
+          setTimeout(tick, n - _emscripten_get_now());
         }
       });
     }

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2587,7 +2587,7 @@ var LibraryHTML5 = {
   },
 
   emscripten_performance_now: function() {
-    return performance.now();
+    return {{{ getPerformanceNow() }}}();
   },
 
   emscripten_get_device_pixel_ratio__proxy: 'sync',

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1019,3 +1019,11 @@ function formattedMinNodeVersion() {
   var rev = MIN_NODE_VERSION % 100
   return `v${major}.${minor}.${rev}`;
 }
+
+function getPerformanceNow() {
+  if (DETERMINISTIC) {
+    return 'deterministicNow';
+  } else {
+    return 'performance.now';
+  }
+}


### PR DESCRIPTION
It turns out you can't override `performance.now` on modern versions of not.  Not sure if that is bug, but we have to work around it.

This should make the CI green again since we updated emsdk to node 16.