### PR TITLE
Skip test_bigswitch when not optimizing. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2499,6 +2499,8 @@ int main(int argc, char **argv) {
 
   @no_wasm2js('massive switches can break js engines')
   def test_bigswitch(self):
+    if not self.is_optimizing():
+      self.skipTest('nodejs takes ~4GB to compile this if the wasm is not optimized, which OOMs')
     self.set_setting('USE_SDL')
     self.do_runf(test_file('bigswitch.cpp'), '''34962: GL_ARRAY_BUFFER (0x8892)
 26214: what?


### PR DESCRIPTION
With the recent node update from v15 to v16 the unoptimized version now uses enough memory to get OOM'd during CI, just like test_biggerswitch below.