### PR TITLE
CI: Disable test_sse1 on macOS due to native clang errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -726,6 +726,9 @@ jobs:
       EMTEST_SKIP_WASM64: "1"
       EMTEST_SKIP_SCONS: "1"
       EMCC_SKIP_SANITY_CHECK: "1"
+      # test_sse1 (the only @crossplatform native clang test) currently fails
+      # on the macOS bots).
+      EMTEST_LACKS_NATIVE_CLANG: "1"
     steps:
       - setup-macos
       - attach_workspace:


### PR DESCRIPTION
As in #19658, this test was previously not being run because we were using v15 and setting EMTEST_SKIP_SIMD.  Since v16 is not used in the emsdk the test started actually running and this failure was generated:

```
/Users/distiller/emsdk/upstream/bin/../include/c++/v1/stdlib.h:148:34: error: unknown type name 'ldiv_t'
  148 | inline _LIBCPP_INLINE_VISIBILITY ldiv_t div(long __x, long __y) _NOEXCEPT {
      |                                  ^
/Users/distiller/emsdk/upstream/bin/../include/c++/v1/stdlib.h:149:12: error: no member named 'ldiv' in the global namespace
  149 |   return ::ldiv(__x, __y);
      |          ~~^
/Users/distiller/emsdk/upstream/bin/../include/c++/v1/stdlib.h:152:34: error: unknown type name 'lldiv_t'
  152 | inline _LIBCPP_INLINE_VISIBILITY lldiv_t div(long long __x,
      |                                  ^
/Users/distiller/emsdk/upstream/bin/../include/c++/v1/stdlib.h:154:12: error: no member named 'lldiv' in the global namespace
  154 |   return ::lldiv(__x, __y);
      |          ~~^
In file included from /Users/distiller/project/test/sse/test_sse1.cpp:10:
In file included from /Users/distiller/emsdk/upstream/lib/clang/17/include/xmmintrin.h:31:
/Users/distiller/emsdk/upstream/lib/clang/17/include/mm_malloc.h:25:48: error: unknown type name 'size_t'
   25 | extern "C" int posix_memalign(void **__memptr, size_t __alignment, size_t __size);
      |                                                ^
/Users/distiller/emsdk/upstream/lib/clang/17/include/mm_malloc.h:25:68: error: unknown type name 'size_t'
   25 | extern "C" int posix_memalign(void **__memptr, size_t __alignment, size_t __size);
      |                                                                    ^
/Users/distiller/emsdk/upstream/lib/clang/17/include/mm_malloc.h:33:12: error: unknown type name 'size_t'
   33 | _mm_malloc(size_t __size, size_t __align) {
      |            ^
/Users/distiller/emsdk/upstream/lib/clang/17/include/mm_malloc.h:33:27: error: unknown type name 'size_t'
   33 | _mm_malloc(size_t __size, size_t __align) {
      |                           ^
/Users/distiller/emsdk/upstream/lib/clang/17/include/mm_malloc.h:62:3: error: use of undeclared identifier 'free'
   62 |   free(__p);
      |   ^
In file included from /Users/distiller/project/test/sse/test_sse1.cpp:11:
In file included from /Users/distiller/project/test/sse/test_sse.h:10:
/Users/distiller/emsdk/upstream/bin/../include/c++/v1/math.h:388:31: error: use of undeclared identifier 'FP_NAN'
  388 |   return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
      |                               ^
/Users/distiller/emsdk/upstream/bin/../include/c++/v1/math.h:388:39: error: use of undeclared identifier 'FP_INFINITE'
  388 |   return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
      |                                       ^
/Users/distiller/emsdk/upstream/bin/../include/c++/v1/math.h:388:52: error: use of undeclared identifier 'FP_NORMAL'
  388 |   return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
      |                                                    ^
/Users/distiller/emsdk/upstream/bin/../include/c++/v1/math.h:388:63: error: use of undeclared identifier 'FP_SUBNORMAL'
  388 |   return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
      |                                                               ^
/Users/distiller/emsdk/upstream/bin/../include/c++/v1/math.h:388:77: error: use of undeclared identifier 'FP_ZERO'
  388 |   return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
      |                                                                             ^
/Users/distiller/emsdk/upstream/bin/../include/c++/v1/math.h:393:21: error: use of undeclared identifier 'FP_ZERO'
  393 |   return __x == 0 ? FP_ZERO : FP_NORMAL;
      |                     ^
/Users/distiller/emsdk/upstream/bin/../include/c++/v1/math.h:393:31: error: use of undeclared identifier 'FP_NORMAL'
  393 |   return __x == 0 ? FP_ZERO : FP_NORMAL;
      |                               ^
In file included from /Users/distiller/project/test/sse/test_sse1.cpp:11:
/Users/distiller/project/test/sse/test_sse.h:11:10: fatal error: 'time.h' file not found
   11 | #include <time.h>
      |          ^~~~~~~~
17 errors generated.
```