### PR TITLE
WasmFS JS API: Remove chown TODOs

### DIFF
--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -310,9 +310,6 @@ FS.createPreloadedFile = FS_createPreloadedFile;
     fchmod: (fd, mode) => {
       return FS.handleError(__wasmfs_fchmod(fd, mode));
     },
-    // TDOO: chown
-    // TODO: lchown
-    // TODO: fchown
     utime: (path, atime, mtime) => (
       FS.handleError(withStackSave(() => (
         __wasmfs_utime(stringToUTF8OnStack(path), atime, mtime)


### PR DESCRIPTION
Alon and Thomas noted that since Emscripten does not support user ownership, it may not make sense to implement `chown`, `lchown`, and `fchown`. This PR removes the `TODOs` for those three methods. 