### PR TITLE
Fix broken scorecard.yml workflow

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -19,6 +19,8 @@ jobs:
       security-events: write
       actions: read
       contents: read
+      # Needed to publish results
+      id-token: write
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
#19637 bumped ossf/scorecard-action to a newer version. This version now relies on `id-token: write` to publish results to the public dataset. The previous PR hasn't noticed the workflow didn't yet have this permission, breaking the workflow.

This PR simply adds the `id-token: write` permission to the workflow.