### PR TITLE
test: Mark test_pthread_print_override_modularize as @crossplatform. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -5928,6 +5928,7 @@ int main(void) {
     output = self.run_js('run.js')
     self.assertEqual(output, 'hello, world!\n')
 
+  @crossplatform
   @node_pthreads
   def test_pthread_print_override_modularize(self):
     self.set_setting('EXPORT_NAME', 'Test')


### PR DESCRIPTION
This test if currently failing fairly consistencly on macOS.