### PR TITLE
Fix html5_event_callback_in_two_threads. NFC

### DIFF
--- a/test/html5_event_callback_in_two_threads.c
+++ b/test/html5_event_callback_in_two_threads.c
@@ -7,11 +7,11 @@
 #include <memory.h>
 #include <assert.h>
 
-void *application_main_thread_id = 0;
-void *main_browser_thread_id = 0;
+pthread_t application_thread_id = 0;
+pthread_t main_runtime_thread_id = 0;
 
-volatile int saw_keydown_event_on_enter_key_on_application_main_thread = 0;
-volatile int saw_keydown_event_on_enter_key_on_main_browser_thread = 0;
+volatile int saw_keydown_event_on_enter_key_on_application_thread = 0;
+volatile int saw_keydown_event_on_enter_key_on_main_runtime_thread = 0;
 volatile int saw_keypress_event_on_enter_key = 0;
 
 void ReportResult(int code)
@@ -23,41 +23,41 @@ void ReportResult(int code)
   exit(code);
 }
 
-EM_BOOL keydown_callback_on_application_main_thread(int eventType, const EmscriptenKeyboardEvent *e, void *userData)
+EM_BOOL keydown_callback_on_application_thread(int eventType, const EmscriptenKeyboardEvent *e, void *userData)
 {
   int dom_pk_code = emscripten_compute_dom_pk_code(e->code);
-  printf("keydown_callback_on_application_main_thread received on pthread: %p, application_main_thread_id: %p, dom_pk_code: %s\n", (void*)pthread_self(), application_main_thread_id, emscripten_dom_pk_code_to_string(dom_pk_code));
-  assert((void*)pthread_self() == application_main_thread_id);
+  printf("keydown_callback_on_application_thread received on pthread: %p, application_thread_id: %p, dom_pk_code: %s\n", pthread_self(), application_thread_id, emscripten_dom_pk_code_to_string(dom_pk_code));
+  assert(pthread_self() == application_thread_id);
 
-  if (dom_pk_code == DOM_PK_ENTER) saw_keydown_event_on_enter_key_on_application_main_thread = 1;
+  if (dom_pk_code == DOM_PK_ENTER) saw_keydown_event_on_enter_key_on_application_thread = 1;
   return 0;
 }
 
-EM_BOOL keydown_callback_on_main_browser_thread(int eventType, const EmscriptenKeyboardEvent *e, void *userData)
+EM_BOOL keydown_callback_on_main_runtime_thread(int eventType, const EmscriptenKeyboardEvent *e, void *userData)
 {
   int dom_pk_code = emscripten_compute_dom_pk_code(e->code);
-  printf("keydown_callback_on_main_browser_thread received on pthread: %p, main_browser_thread_id; %p, dom_pk_code: %s\n", (void*)pthread_self(), main_browser_thread_id, emscripten_dom_pk_code_to_string(dom_pk_code));
-  assert((void*)pthread_self() == main_browser_thread_id);
+  printf("keydown_callback_on_main_runtime_thread received on pthread: %p, main_runtime_thread_id; %p, dom_pk_code: %s\n", pthread_self(), main_runtime_thread_id, emscripten_dom_pk_code_to_string(dom_pk_code));
+  assert(pthread_self() == main_runtime_thread_id);
 
 #if __EMSCRIPTEN_PTHREADS__
   EmscriptenKeyboardEvent *duplicatedEventStruct = malloc(sizeof(*e));
   memcpy(duplicatedEventStruct, e, sizeof(*e));
-  emscripten_dispatch_to_thread(application_main_thread_id, EM_FUNC_SIG_IIII, keydown_callback_on_application_main_thread, duplicatedEventStruct, eventType, duplicatedEventStruct, userData);
+  emscripten_dispatch_to_thread(application_thread_id, EM_FUNC_SIG_IIII, keydown_callback_on_application_thread, duplicatedEventStruct, eventType, duplicatedEventStruct, userData);
 #else
-  keydown_callback_on_application_main_thread(eventType, e, userData);
+  keydown_callback_on_application_thread(eventType, e, userData);
 #endif
 
-  if (dom_pk_code == DOM_PK_ENTER) saw_keydown_event_on_enter_key_on_main_browser_thread = 1;
+  if (dom_pk_code == DOM_PK_ENTER) saw_keydown_event_on_enter_key_on_main_runtime_thread = 1;
 
   return dom_pk_code == DOM_PK_ENTER; // Suppress default event handling for the enter/return key so that it should not generate the keypress event.
 }
 
 
-EM_BOOL keypress_callback_on_application_main_thread(int eventType, const EmscriptenKeyboardEvent *e, void *userData)
+EM_BOOL keypress_callback_on_application_thread(int eventType, const EmscriptenKeyboardEvent *e, void *userData)
 {
   int dom_pk_code = emscripten_compute_dom_pk_code(e->code);
-  printf("keypress_callback_on_application_main_thread received on pthread: %p, application_main_thread_id; %p, dom_pk_code: %s\n", (void*)pthread_self(), application_main_thread_id, emscripten_dom_pk_code_to_string(dom_pk_code));
-  assert((void*)pthread_self() == application_main_thread_id);
+  printf("keypress_callback_on_application_thread received on pthread: %p, application_thread_id; %p, dom_pk_code: %s\n", pthread_self(), application_thread_id, emscripten_dom_pk_code_to_string(dom_pk_code));
+  assert(pthread_self() == application_thread_id);
 
   if (dom_pk_code == DOM_PK_ENTER)
   {
@@ -68,23 +68,23 @@ EM_BOOL keypress_callback_on_application_main_thread(int eventType, const Emscri
   return 0;
 }
 
-EM_BOOL keyup_callback_on_application_main_thread(int eventType, const EmscriptenKeyboardEvent *e, void *userData)
+EM_BOOL keyup_callback_on_application_thread(int eventType, const EmscriptenKeyboardEvent *e, void *userData)
 {
   int dom_pk_code = emscripten_compute_dom_pk_code(e->code);
-  printf("keyup_callback_on_application_main_thread received on pthread: %p, application_main_thread_id; %p, dom_pk_code: %s\n", (void*)pthread_self(), application_main_thread_id, emscripten_dom_pk_code_to_string(dom_pk_code));
-  assert((void*)pthread_self() == application_main_thread_id);
+  printf("keyup_callback_on_application_thread received on pthread: %p, application_thread_id; %p, dom_pk_code: %s\n", pthread_self(), application_thread_id, emscripten_dom_pk_code_to_string(dom_pk_code));
+  assert(pthread_self() == application_thread_id);
 
   if (dom_pk_code == DOM_PK_ENTER)
   {
-    if (!saw_keydown_event_on_enter_key_on_application_main_thread)
+    if (!saw_keydown_event_on_enter_key_on_application_thread)
     {
-      printf("Test failed! KeyUp event came through, but a KeyDown event should have first been processed on the application main thread!\n");
+      printf("Test failed! KeyUp event came through, but a KeyDown event should have first been processed on the application thread!\n");
       ReportResult(12346); // FAIL
     }
-    if (!saw_keydown_event_on_enter_key_on_main_browser_thread)
+    if (!saw_keydown_event_on_enter_key_on_main_runtime_thread)
     {
-      printf("Test failed! KeyUp event came through, but a KeyDown event should have first been processed on the main browser thread!\n");
-      ReportResult(12347); // FAIL      
+      printf("Test failed! KeyUp event came through, but a KeyDown event should have first been processed on the main runtime thread!\n");
+      ReportResult(12347); // FAIL
     }
     if (saw_keypress_event_on_enter_key)
     {
@@ -101,14 +101,14 @@ int main()
 {
   main_runtime_thread_id = emscripten_main_runtime_thread_id();
   assert(main_runtime_thread_id);
-  application_main_thread_id = (void*)pthread_self();
-  assert(application_main_thread_id);
+  application_thread_id = pthread_self();
+  assert(application_thread_id);
 
-  printf("Main runtime thread ID: %p, application main thread ID: %p\n", main_runtime_thread_id, application_main_thread_id);
+  printf("Main runtime thread ID: %p, application thread ID: %p\n", main_runtime_thread_id, application_thread_id);
 
-  emscripten_set_keydown_callback_on_thread(0, 0, 1, keydown_callback_on_main_browser_thread, EM_CALLBACK_THREAD_CONTEXT_MAIN_RUNTIME_THREAD);
-  emscripten_set_keypress_callback_on_thread(0, 0, 1, keypress_callback_on_application_main_thread, EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD);
-  emscripten_set_keyup_callback_on_thread(0, 0, 1, keyup_callback_on_application_main_thread, EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD);
+  emscripten_set_keydown_callback_on_thread(EMSCRIPTEN_EVENT_TARGET_WINDOW, 0, 1, keydown_callback_on_main_runtime_thread, EM_CALLBACK_THREAD_CONTEXT_MAIN_RUNTIME_THREAD);
+  emscripten_set_keypress_callback_on_thread(EMSCRIPTEN_EVENT_TARGET_WINDOW, 0, 1, keypress_callback_on_application_thread, EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD);
+  emscripten_set_keyup_callback_on_thread(EMSCRIPTEN_EVENT_TARGET_WINDOW, 0, 1, keyup_callback_on_application_thread, EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD);
 
   printf("Please press the Enter key.\n");
 


### PR DESCRIPTION
- There was a partial renaming in #18872 which broken the build of this test.
- The passing of 0 instead of EMSCRIPTEN_EVENT_TARGET_WINDOW was generating a warnings that null is not allowed for argument zero.
- No need to use (void*) when we can just use pthread_t.