### PR TITLE
Reduce limits on test output. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -354,7 +354,7 @@ def limit_size(string):
     max_line = 500
   else:
     max_line = 5000
-    maxlines = 100000
+    maxlines = 1000
   lines = string.splitlines()
   for i, line in enumerate(lines):
     if len(line) > max_line:


### PR DESCRIPTION
I noticed the following error on the emscripten-releases bot which makes me thing perhaps we are just writing too much output when certain tests fail:

```
  File "/b/s/w/ir/x/w/install/emscripten/test/runner.py", line 468, in <module>
    sys.exit(main(sys.argv))
  File "/b/s/w/ir/x/w/install/emscripten/test/runner.py", line 457, in main
    num_failures = run_tests(options, suites)
  File "/b/s/w/ir/x/w/install/emscripten/test/runner.py", line 333, in run_tests
    res = testRunner.run(suite)
  File "/b/s/w/ir/cache/vpython/store/cpython-n8umfpv0s1ufm2q1s4irhb59jc/contents/lib/python3.8/unittest/runner.py", line 183, in run
    result.printErrors()
  File "/b/s/w/ir/cache/vpython/store/cpython-n8umfpv0s1ufm2q1s4irhb59jc/contents/lib/python3.8/unittest/runner.py", line 110, in printErrors
    self.printErrorList('FAIL', self.failures)
  File "/b/s/w/ir/cache/vpython/store/cpython-n8umfpv0s1ufm2q1s4irhb59jc/contents/lib/python3.8/unittest/runner.py", line 117, in printErrorList
    self.stream.writeln("%s" % err)
  File "/b/s/w/ir/cache/vpython/store/cpython-n8umfpv0s1ufm2q1s4irhb59jc/contents/lib/python3.8/unittest/runner.py", line 25, in writeln
    self.write(arg)
BlockingIOError: [Errno 11] write could not complete without blocking
```

See https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket/8777566115217933025/+/u/Emscripten_testsuite__UBSan_/stdout

The failing test was generating a lot of output in this case.