### PR TITLE
Fix dyncall() functions on i64 parameters in WASM_BIGINT mode

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3158,6 +3158,7 @@ mergeInto(LibraryManager.library, {
 #endif
     if (args && args.length) {
       // j (64-bit integer) must be passed in as two numbers [low 32, high 32].
+      throw 'waka waka';
       assert(args.length === sig.substring(1).replace(/j/g, '--').length);
     } else {
       assert(sig.length == 1);

--- a/src/library.js
+++ b/src/library.js
@@ -3157,9 +3157,15 @@ mergeInto(LibraryManager.library, {
     assert(('dynCall_' + sig) in Module, `bad function pointer type - dynCall function not found for sig '${sig}'`);
 #endif
     if (args && args.length) {
+#if WASM_BIGINT
+      // j (64-bit integer) is fine, and is implemented as a BigInt. Without
+      // legalization, the number of parameters should match (j is not expanded
+      // into two i's).
+      assert(args.length === sig.length - 1);
+#else
       // j (64-bit integer) must be passed in as two numbers [low 32, high 32].
-      throw 'waka waka';
       assert(args.length === sig.substring(1).replace(/j/g, '--').length);
+#endif
     } else {
       assert(sig.length == 1);
     }

--- a/test/core/dyncall_specific.c
+++ b/test/core/dyncall_specific.c
@@ -5,17 +5,27 @@
  * found in the LICENSE file.
  */
 
+#include <assert.h>
 #include <emscripten.h>
 #include <stdint.h>
 #include <stdio.h>
 
 int waka(int w, long long xy, int z) {
+#ifndef WASM_BIGINT
   // xy should be 0xffff_ffff_0000_0004
-  int x = (int) xy;  // should be 4
-  int y = xy >> 32;  // should be -1
-  EM_ASM({
-    out('received ' + [$0, $1, $2, $3] + '.');
-  }, w, x, y, z);
+  int x = (int) xy;
+  int y = xy >> 32;
+  assert(w == 1);
+  assert(x == 4);
+  assert(y == -1);
+  assert(z == 9);
+#else
+  // With WASM_BIGINT things are straightforward: the 64-bit value just arrives
+  // with the expected value of 4.
+  assert(w == 1);
+  assert(xy == 4);
+  assert(z == 9);
+#endif
   return 42;
 }
 
@@ -23,8 +33,9 @@ EM_JS_DEPS(main, "$dynCall");
 
 int main() {
   EM_ASM({
-    // Note that these would need to use BigInts if the file were built with
-    // -sWASM_BIGINT
+
+#ifndef WASM_BIGINT
+
 #if DIRECT
     console.log('Received ' + dynCall_iiji($0, 1, 4, 0xffffffff, 9));
     return;
@@ -45,6 +56,33 @@ int main() {
     eval("console.log('Received ' + Module['dynCall_iiji'](" + $0 + ", 1, 4, 0xffffffff, 9))");
     return;
 #endif
+
+#else // WASM_BIGINT
+
+#if DIRECT
+    console.log('Received ' + dynCall_iiji($0, 1, BigInt(4), 9));
+    return;
+#endif
+#if DYNAMIC_SIG
+    console.log('Received ' + dynCall('iiji', $0, [1, BigInt(4), 9]));
+    return;
+#endif
+#if EXPORTED
+    console.log('Received ' + Module['dynCall_iiji']($0, 1, BigInt(4), 9));
+    return;
+#endif
+#if EXPORTED_DYNAMIC_SIG
+    console.log('Received ' + Module['dynCall']('iiji', $0, [1, BigInt(4), 9]));
+    return;
+#endif
+#if FROM_OUTSIDE
+    eval("console.log('Received ' + Module['dynCall_iiji'](" + $0 + ", 1, BigInt(4), 9))");
+    return;
+#endif
+
+#endif
+
+    // We should have run the test and returned before we get here.
     throw "no test mode";
   }, &waka);
 }

--- a/test/core/dyncall_specific.c
+++ b/test/core/dyncall_specific.c
@@ -11,19 +11,19 @@
 #include <stdio.h>
 
 int waka(int w, long long xy, int z) {
-#ifndef WASM_BIGINT
+#ifdef WASM_BIGINT
+  // With WASM_BIGINT things are straightforward: the 64-bit value just arrives
+  // with the expected value of 4.
+  assert(w == 1);
+  assert(xy == 4);
+  assert(z == 9);
+#else
   // xy should be 0xffff_ffff_0000_0004
   int x = (int) xy;
   int y = xy >> 32;
   assert(w == 1);
   assert(x == 4);
   assert(y == -1);
-  assert(z == 9);
-#else
-  // With WASM_BIGINT things are straightforward: the 64-bit value just arrives
-  // with the expected value of 4.
-  assert(w == 1);
-  assert(xy == 4);
   assert(z == 9);
 #endif
   return 42;
@@ -34,30 +34,7 @@ EM_JS_DEPS(main, "$dynCall");
 int main() {
   EM_ASM({
 
-#ifndef WASM_BIGINT
-
-#if DIRECT
-    console.log('Received ' + dynCall_iiji($0, 1, 4, 0xffffffff, 9));
-    return;
-#endif
-#if DYNAMIC_SIG
-    console.log('Received ' + dynCall('iiji', $0, [1, 4, 0xffffffff, 9]));
-    return;
-#endif
-#if EXPORTED
-    console.log('Received ' + Module['dynCall_iiji']($0, 1, 4, 0xffffffff, 9));
-    return;
-#endif
-#if EXPORTED_DYNAMIC_SIG
-    console.log('Received ' + Module['dynCall']('iiji', $0, [1, 4, 0xffffffff, 9]));
-    return;
-#endif
-#if FROM_OUTSIDE
-    eval("console.log('Received ' + Module['dynCall_iiji'](" + $0 + ", 1, 4, 0xffffffff, 9))");
-    return;
-#endif
-
-#else // WASM_BIGINT
+#ifdef WASM_BIGINT
 
 #if DIRECT
     console.log('Received ' + dynCall_iiji($0, 1, BigInt(4), 9));
@@ -77,6 +54,29 @@ int main() {
 #endif
 #if FROM_OUTSIDE
     eval("console.log('Received ' + Module['dynCall_iiji'](" + $0 + ", 1, BigInt(4), 9))");
+    return;
+#endif
+
+#else // WASM_BIGINT
+
+#if DIRECT
+    console.log('Received ' + dynCall_iiji($0, 1, 4, 0xffffffff, 9));
+    return;
+#endif
+#if DYNAMIC_SIG
+    console.log('Received ' + dynCall('iiji', $0, [1, 4, 0xffffffff, 9]));
+    return;
+#endif
+#if EXPORTED
+    console.log('Received ' + Module['dynCall_iiji']($0, 1, 4, 0xffffffff, 9));
+    return;
+#endif
+#if EXPORTED_DYNAMIC_SIG
+    console.log('Received ' + Module['dynCall']('iiji', $0, [1, 4, 0xffffffff, 9]));
+    return;
+#endif
+#if FROM_OUTSIDE
+    eval("console.log('Received ' + Module['dynCall_iiji'](" + $0 + ", 1, 4, 0xffffffff, 9))");
     return;
 #endif
 

--- a/test/core/dyncall_specific.out
+++ b/test/core/dyncall_specific.out
@@ -1,2 +1,1 @@
-received 1,4,-1,9.
 Received 42

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7212,6 +7212,9 @@ void* operator new(size_t size) {
     if self.get_setting('MEMORY64'):
       self.skipTest('not compatible with WASM_BIGINT')
     if self.get_setting('WASM_BIGINT'):
+      # define DYNCALLS because this test does test calling them directly, and
+      # in WASM_BIGINT mode we do not enable them by default (since we can do
+      # more without them - we don't need to legalize)
       args = list(args) + ['-sDYNCALLS=1', '-DWASM_BIGINT']
     cases = [
         ('DIRECT', []),

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7210,7 +7210,7 @@ void* operator new(size_t size) {
   })
   def test_dyncall_specific(self, *args):
     if self.get_setting('MEMORY64'):
-      self.skipTest('not compatible with WASM_BIGINT')
+      self.skipTest('not compatible with MEMORY64')
     if self.get_setting('WASM_BIGINT'):
       # define DYNCALLS because this test does test calling them directly, and
       # in WASM_BIGINT mode we do not enable them by default (since we can do

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7215,17 +7215,17 @@ void* operator new(size_t size) {
       # define DYNCALLS because this test does test calling them directly, and
       # in WASM_BIGINT mode we do not enable them by default (since we can do
       # more without them - we don't need to legalize)
-      args = list(args) + ['-sDYNCALLS=1', '-DWASM_BIGINT']
+      args = list(args) + ['-sDYNCALLS', '-DWASM_BIGINT']
     cases = [
         ('DIRECT', []),
-        ('DYNAMIC_SIG', ['-sDYNCALLS=1']),
+        ('DYNAMIC_SIG', ['-sDYNCALLS']),
       ]
     if '-sMINIMAL_RUNTIME=1' in args:
       self.emcc_args += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]
     else:
       cases += [
         ('EXPORTED', []),
-        ('EXPORTED_DYNAMIC_SIG', ['-sDYNCALLS=1', '-sEXPORTED_RUNTIME_METHODS=dynCall']),
+        ('EXPORTED_DYNAMIC_SIG', ['-sDYNCALLS', '-sEXPORTED_RUNTIME_METHODS=dynCall']),
         ('FROM_OUTSIDE', ['-sEXPORTED_RUNTIME_METHODS=dynCall_iiji'])
       ]
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7209,8 +7209,10 @@ void* operator new(size_t size) {
     'minimal_runtime': ['-sMINIMAL_RUNTIME=1']
   })
   def test_dyncall_specific(self, *args):
-    if self.get_setting('WASM_BIGINT') or self.get_setting('MEMORY64'):
+    if self.get_setting('MEMORY64'):
       self.skipTest('not compatible with WASM_BIGINT')
+    if self.get_setting('WASM_BIGINT'):
+      args = list(args) + ['-sDYNCALLS=1', '-DWASM_BIGINT']
     cases = [
         ('DIRECT', []),
         ('DYNAMIC_SIG', ['-sDYNCALLS=1']),


### PR DESCRIPTION
With BigInt support we don't legalize, so a `'j'` parameter is just a single value
(a BigInt) and not two legalized i32s.

This is the last remaining useful fix in #19156 that is worth landing standalone.

The test now works in both BigInt and non-BigInt mode. To make that simple
I moved some of the expectations from the text output into assertions.