### PR TITLE
Fix EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -210,9 +210,23 @@ var LibraryHTML5 = {
 #if PTHREADS
     getTargetThreadForEventCallback: function(targetThread) {
       switch (targetThread) {
-        case {{{ cDefs.EM_CALLBACK_THREAD_CONTEXT_MAIN_RUNTIME_THREAD }}}: return 0; // The event callback for the current event should be called on the main browser thread. (0 == don't proxy)
-        case {{{ cDefs.EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD }}}: return PThread.currentProxiedOperationCallerThread; // The event callback for the current event should be backproxied to the thread that is registering the event.
-        default: return targetThread; // The event callback for the current event should be proxied to the given specific thread.
+        case {{{ cDefs.EM_CALLBACK_THREAD_CONTEXT_MAIN_RUNTIME_THREAD }}}:
+          // The event callback for the current event should be called on the
+          // main browser thread. (0 == don't proxy)
+          return 0;
+        case {{{ cDefs.EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD }}}:
+          // The event callback for the current event should be backproxied to
+          // the thread that is registering the event.
+#if ASSERTIONS
+          // If we get here PThread.currentProxiedOperationCallerThread should
+          // be set to the calling thread.
+          assert(PThread.currentProxiedOperationCallerThread);
+#endif
+          return PThread.currentProxiedOperationCallerThread;
+        default:
+          // The event callback for the current event should be proxied to the
+          // given specific thread.
+          return targetThread;
       }
     },
 #endif

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -696,7 +696,7 @@ sigs = {
   emscripten_promise_resolve__sig: 'vpip',
   emscripten_promise_then__sig: 'ppppp',
   emscripten_random__sig: 'f',
-  emscripten_receive_on_main_thread_js__sig: 'diip',
+  emscripten_receive_on_main_thread_js__sig: 'dipip',
   emscripten_request_animation_frame__sig: 'ipp',
   emscripten_request_animation_frame_loop__sig: 'vpp',
   emscripten_request_fullscreen__sig: 'ipi',

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -188,7 +188,7 @@ static void _do_call(void* arg) {
       break;
     case EM_PROXIED_JS_FUNCTION:
       q->returnValue.d =
-        emscripten_receive_on_main_thread_js((intptr_t)q->functionPtr, q->args[0].i, &q->args[1].d);
+        emscripten_receive_on_main_thread_js((intptr_t)q->functionPtr, q->callingThread, q->args[0].i, &q->args[1].d);
       break;
     case EM_FUNC_SIG_V:
       ((em_func_v)q->functionPtr)();
@@ -430,10 +430,11 @@ double _emscripten_run_in_main_runtime_thread_js(int index, int num_args, int64_
   } else {
     c = em_queued_call_malloc();
   }
-  c->calleeDelete = 1-sync;
+  c->calleeDelete = !sync;
   c->functionEnum = EM_PROXIED_JS_FUNCTION;
   // Index not needed to ever be more than 32-bit.
   c->functionPtr = (void*)(intptr_t)index;
+  c->callingThread = pthread_self();
   assert(num_args+1 <= EM_QUEUED_JS_CALL_MAX_ARGS);
   // The types are only known at runtime in these calls, so we store values that
   // must be able to contain any valid JS value, including a 64-bit BigInt if

--- a/system/lib/pthread/threading_internal.h
+++ b/system/lib/pthread/threading_internal.h
@@ -33,6 +33,10 @@ typedef struct em_queued_call {
   em_variant_val args[EM_QUEUED_JS_CALL_MAX_ARGS];
   em_variant_val returnValue;
 
+  // Sets the PThread.currentProxiedOperationCallerThread global for the
+  // duration of the proxied call.
+  pthread_t callingThread;
+
   // An optional pointer to a secondary data block that should be free()d when
   // this queued call is freed.
   void *satelliteData;
@@ -163,4 +167,4 @@ int __pthread_create_js(struct __pthread *thread, const pthread_attr_t *attr, vo
 int _emscripten_default_pthread_stack_size();
 void __set_thread_state(pthread_t ptr, int is_main, int is_runtime, int can_block);
 
-double emscripten_receive_on_main_thread_js(int functionIndex, int numCallArgs, double* args);
+double emscripten_receive_on_main_thread_js(int functionIndex, pthread_t callingThread, int numCallArgs, double* args);


### PR DESCRIPTION
I think this has probably been broken for a long time.  Given that nobody has complained we could probably just remove this feature, but on the other hand the fix wasn't too hard.

Confirmed that interactive.test_html5_callback_on_two_threads fails before this change and passed afterwards.

Fixes: #19690