### PR TITLE
Remove receiveI64ParamAsI32s helper function

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -873,13 +873,6 @@ function defineI64Param(name) {
   return `${name}_low, ${name}_high`;
 }
 
-function receiveI64ParamAsI32s(name) {
-  if (WASM_BIGINT) {
-    return `var ${name}_low = Number(${name} & 0xffffffffn) | 0, ${name}_high = Number(${name} >> 32n) | 0;`;
-  }
-  return '';
-}
-
 function receiveI64ParamAsI53(name, onError) {
   if (WASM_BIGINT) {
     // Just convert the bigint into a double.

--- a/src/parseTools_legacy.js
+++ b/src/parseTools_legacy.js
@@ -24,6 +24,13 @@ function receiveI64ParamAsDouble(name) {
   return `var ${name} = ${name}_high * 0x100000000 + (${name}_low >>> 0);`;
 }
 
+function receiveI64ParamAsI32s(name) {
+  if (WASM_BIGINT) {
+    return `var ${name}_low = Number(${name} & 0xffffffffn) | 0, ${name}_high = Number(${name} >> 32n) | 0;`;
+  }
+  return '';
+}
+
 function stripCorrections(param) {
   let m;
   while (true) {


### PR DESCRIPTION
I'm working on a tools that automatically converts i64 to i53 without any extra macros or helpers in the source code.

This way of receiving an i64 was an outlier and removing it helps towards my goal.  The other problem with this method is that it doesn't make a lot of sense in WASM_BIGINT is enabled since it needless splits the incoming argument into two.