### PR TITLE
WasmFS: Enable warnings on using FS without FORCE_FILESYSTEM

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -494,7 +494,7 @@ function abort(what) {
 
 #include "memoryprofiler.js"
 
-#if ASSERTIONS && !('$FS' in addedLibraryItems) && !WASMFS
+#if ASSERTIONS && !('$FS' in addedLibraryItems)
 // show errors on likely calls to FS when it was not included
 var FS = {
   error: function() {

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7556,10 +7556,11 @@ int main() {}
     output = self.run_js('run.js')
     self.assertContained('|world|', output)
 
+  @also_with_wasmfs
   def test_warn_no_filesystem(self):
     error = 'Filesystem support (FS) was not included. The problem is that you are using files from JS, but files were not used from C/C++, so filesystem support was not auto-included. You can force-include filesystem support with -sFORCE_FILESYSTEM'
 
-    self.run_process([EMCC, test_file('hello_world.c')])
+    self.emcc(test_file('hello_world.c'))
     seen = self.run_js('a.out.js')
     self.assertNotContained(error, seen)
 


### PR DESCRIPTION
I'm not sure why these were disabled, but likely early in WasmFS development
they caused some kind of problem. Now they seem to work ok, and are necessary
for an important test to pass, which is enabled here.