### PR TITLE
Automate i64 -> i53 conversions parameters and return values of JS library funcs.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 3.1.43 (in development)
 -----------------------
+- Handling i64 arguments and return values in JS functions is now much simpler
+  with the new `__i53abi` decorator.  When this is set to true, i64 values are
+  automatically converted to JS numbers (i53) at the JS boundary.  Parameters
+  outside of the i53 will show up as NaN in the JS code (#19711)
 
 3.1.42 - 06/22/23
 -----------------

--- a/src/library.js
+++ b/src/library.js
@@ -436,6 +436,7 @@ mergeInto(LibraryManager.library, {
   // time.h
   // ==========================================================================
 
+  _mktime_js__i53abi: true,
   _mktime_js__deps: ['$ydayFromDate'],
   _mktime_js: (tmPtr) => {
     var date = new Date({{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_year, 'i32') }}} + 1900,
@@ -476,12 +477,11 @@ mergeInto(LibraryManager.library, {
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_mon, 'date.getMonth()', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_year, 'date.getYear()', 'i32') }}};
 
-    return {{{ makeReturn64('date.getTime() / 1000') }}};
+    return date.getTime() / 1000;
   },
 
-  _gmtime_js__deps: ['$readI53FromI64'].concat(i53ConversionDeps),
-  _gmtime_js: ({{{ defineI64Param('time') }}}, tmPtr) => {
-    {{{ receiveI64ParamAsI53('time') }}}
+  _gmtime_js__i53abi: true,
+  _gmtime_js: (time, tmPtr) => {
     var date = new Date(time * 1000);
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_sec, 'date.getUTCSeconds()', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_min, 'date.getUTCMinutes()', 'i32') }}};
@@ -495,6 +495,7 @@ mergeInto(LibraryManager.library, {
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_yday, 'yday', 'i32') }}};
   },
 
+  _timegm_js__i53abi: true,
   _timegm_js: (tmPtr) => {
     var time = Date.UTC({{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_year, 'i32') }}} + 1900,
                         {{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_mon, 'i32') }}},
@@ -510,12 +511,12 @@ mergeInto(LibraryManager.library, {
     var yday = ((date.getTime() - start) / (1000 * 60 * 60 * 24))|0;
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_yday, 'yday', 'i32') }}};
 
-    return {{{ makeReturn64('date.getTime() / 1000') }}};
+    return date.getTime() / 1000;
   },
 
-  _localtime_js__deps: ['$readI53FromI64', '$ydayFromDate'].concat(i53ConversionDeps),
-  _localtime_js: ({{{ defineI64Param('time') }}}, tmPtr) => {
-    {{{ receiveI64ParamAsI53('time') }}}
+  _localtime_js__i53abi: true,
+  _localtime_js__deps: ['$ydayFromDate'],
+  _localtime_js: (time, tmPtr) => {
     var date = new Date(time*1000);
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_sec, 'date.getSeconds()', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_min, 'date.getMinutes()', 'i32') }}};

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -122,6 +122,7 @@ var SyscallsLibrary = {
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },
 
+  _mmap_js__i53abi: true,
   _mmap_js__deps: ['$SYSCALLS',
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
     '$FS',
@@ -133,10 +134,10 @@ var SyscallsLibrary = {
     '$mmapAlloc',
     'emscripten_builtin_memalign',
 #endif
-  ].concat(i53ConversionDeps),
-  _mmap_js: function(len, prot, flags, fd, {{{ defineI64Param('offset') }}}, allocated, addr) {
-    {{{ receiveI64ParamAsI53('offset', -cDefs.EOVERFLOW) }}}
+  ],
+  _mmap_js: function(len, prot, flags, fd, offset, allocated, addr) {
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
+    if (isNaN(offset)) return {{{ cDefs.EOVERFLOW }}};
     var stream = SYSCALLS.getStreamFromFD(fd);
     var res = FS.mmap(stream, len, offset, prot, flags);
     var ptr = res.ptr;
@@ -151,14 +152,15 @@ var SyscallsLibrary = {
 #endif
   },
 
+  _munmap_js__i53abi: true,
   _munmap_js__deps: ['$SYSCALLS',
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
     '$FS',
 #endif
-  ].concat(i53ConversionDeps),
-  _munmap_js: function(addr, len, prot, flags, fd, {{{ defineI64Param('offset') }}}) {
-    {{{ receiveI64ParamAsI53('offset', -cDefs.EOVERFLOW) }}}
+  ],
+  _munmap_js: function(addr, len, prot, flags, fd, offset) {
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
+    if (isNaN(offset)) return {{{ cDefs.EOVERFLOW }}};
     var stream = SYSCALLS.getStreamFromFD(fd);
     if (prot & {{{ cDefs.PROT_WRITE }}}) {
       SYSCALLS.doMsync(addr, stream, len, flags, offset);
@@ -625,9 +627,9 @@ var SyscallsLibrary = {
 
     return total;
   },
-  _msync_js__deps: i53ConversionDeps,
-  _msync_js: function(addr, len, prot, flags, fd, {{{ defineI64Param('offset') }}}) {
-    {{{ receiveI64ParamAsI53('offset', -cDefs.EOVERFLOW) }}}
+  _msync_js__i53abi: true,
+  _msync_js: function(addr, len, prot, flags, fd, offset) {
+    if (isNaN(offset)) return {{{ cDefs.EOVERFLOW }}};
     SYSCALLS.doMsync(addr, SYSCALLS.getStreamFromFD(fd), len, flags, offset);
     return 0;
   },
@@ -664,16 +666,16 @@ var SyscallsLibrary = {
     stringToUTF8(cwd, buf, size);
     return cwdLengthInBytes;
   },
-  __syscall_truncate64__deps: i53ConversionDeps,
-  __syscall_truncate64: function(path, {{{ defineI64Param('length') }}}) {
-    {{{ receiveI64ParamAsI53('length', -cDefs.EOVERFLOW) }}}
+  __syscall_truncate64__i53abi: true,
+  __syscall_truncate64: function(path, length) {
+    if (isNaN(length)) return {{{ cDefs.EOVERFLOW }}};
     path = SYSCALLS.getStr(path);
     FS.truncate(path, length);
     return 0;
   },
-  __syscall_ftruncate64__deps: i53ConversionDeps,
-  __syscall_ftruncate64: function(fd, {{{ defineI64Param('length') }}}) {
-    {{{ receiveI64ParamAsI53('length', -cDefs.EOVERFLOW) }}}
+  __syscall_ftruncate64__i53abi: true,
+  __syscall_ftruncate64: function(fd, length) {
+    if (isNaN(length)) return {{{ cDefs.EOVERFLOW }}};
     FS.ftruncate(fd, length);
     return 0;
   },
@@ -996,10 +998,9 @@ var SyscallsLibrary = {
     FS.utime(path, atime, mtime);
     return 0;
   },
-  __syscall_fallocate__deps: i53ConversionDeps,
-  __syscall_fallocate: function(fd, mode, {{{ defineI64Param('offset') }}}, {{{ defineI64Param('len') }}}) {
-    {{{ receiveI64ParamAsI53('offset', -cDefs.EOVERFLOW) }}}
-    {{{ receiveI64ParamAsI53('len', -cDefs.EOVERFLOW) }}}
+  __syscall_fallocate__i53abi: true,
+  __syscall_fallocate: function(fd, mode, offset, len) {
+    if (isNaN(offset)) return {{{ cDefs.EOVERFLOW }}};
     var stream = SYSCALLS.getStreamFromFD(fd)
 #if ASSERTIONS
     assert(mode === 0);

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -158,9 +158,10 @@ var WasiLibrary = {
   // but the wasm file can't be legalized in standalone mode, which is where
   // this is needed. To get this code to be usable as a JS shim we need to
   // either wait for BigInt support or to legalize on the client.
+  clock_time_get__i53abi: true,
   clock_time_get__nothrow: true,
   clock_time_get__deps: ['emscripten_get_now', '$nowIsMonotonic', '$checkWasiClock'],
-  clock_time_get: (clk_id, {{{ defineI64Param('ignored_precision') }}}, ptime) => {
+  clock_time_get: (clk_id, ignored_precision, ptime) => {
     if (!checkWasiClock(clk_id)) {
       return {{{ cDefs.EINVAL }}};
     }
@@ -294,14 +295,13 @@ var WasiLibrary = {
     return 0;
   },
 
-  fd_pwrite__deps: [
 #if SYSCALLS_REQUIRE_FILESYSTEM
-    '$doWritev',
+  fd_pwrite__deps: ['$doWritev'],
 #endif
-  ].concat(i53ConversionDeps),
-  fd_pwrite: (fd, iov, iovcnt, {{{ defineI64Param('offset') }}}, pnum) => {
+  fd_pwrite__i53abi: true,
+  fd_pwrite: (fd, iov, iovcnt, offset, pnum) => {
 #if SYSCALLS_REQUIRE_FILESYSTEM
-    {{{ receiveI64ParamAsI53('offset', cDefs.EOVERFLOW) }}}
+    if (isNaN(offset)) return {{{ cDefs.EOVERFLOW }}};
     var stream = SYSCALLS.getStreamFromFD(fd)
     var num = doWritev(stream, iov, iovcnt, offset);
     {{{ makeSetValue('pnum', 0, 'num', SIZE_TYPE) }}};
@@ -348,14 +348,13 @@ var WasiLibrary = {
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },
 
-  fd_pread__deps: [
 #if SYSCALLS_REQUIRE_FILESYSTEM
-    '$doReadv',
+  fd_pread__deps: ['$doReadv'],
 #endif
-  ].concat(i53ConversionDeps),
-  fd_pread: (fd, iov, iovcnt, {{{ defineI64Param('offset') }}}, pnum) => {
+  fd_pread__i53abi: true,
+  fd_pread: (fd, iov, iovcnt, offset, pnum) => {
 #if SYSCALLS_REQUIRE_FILESYSTEM
-    {{{ receiveI64ParamAsI53('offset', cDefs.EOVERFLOW) }}}
+    if (isNaN(offset)) return {{{ cDefs.EOVERFLOW }}};
     var stream = SYSCALLS.getStreamFromFD(fd)
     var num = doReadv(stream, iov, iovcnt, offset);
     {{{ makeSetValue('pnum', 0, 'num', SIZE_TYPE) }}};
@@ -367,10 +366,10 @@ var WasiLibrary = {
 #endif
   },
 
-  fd_seek__deps: i53ConversionDeps,
-  fd_seek: (fd, {{{ defineI64Param('offset') }}}, whence, newOffset) => {
+  fd_seek__i53abi: true,
+  fd_seek: (fd, offset, whence, newOffset) => {
 #if SYSCALLS_REQUIRE_FILESYSTEM
-    {{{ receiveI64ParamAsI53('offset', cDefs.EOVERFLOW) }}}
+    if (isNaN(offset)) return {{{ cDefs.EOVERFLOW }}};
     var stream = SYSCALLS.getStreamFromFD(fd);
     FS.llseek(stream, offset, whence);
     {{{ makeSetValue('newOffset', '0', 'stream.position', 'i64') }}};

--- a/src/library_wasmfs_jsimpl.js
+++ b/src/library_wasmfs_jsimpl.js
@@ -24,18 +24,16 @@ mergeInto(LibraryManager.library, {
     return wasmFS$backends[backend].freeFile(file);
   },
 
-  _wasmfs_jsimpl_write__deps: i53ConversionDeps,
-  _wasmfs_jsimpl_write: function(backend, file, buffer, length, {{{ defineI64Param('offset') }}}) {
-    {{{ receiveI64ParamAsI53('offset') }}}
+  _wasmfs_jsimpl_write__i53abi: true,
+  _wasmfs_jsimpl_write: function(backend, file, buffer, length, offset) {
 #if ASSERTIONS
     assert(wasmFS$backends[backend]);
 #endif
     return wasmFS$backends[backend].write(file, buffer, length, offset);
   },
 
-  _wasmfs_jsimpl_read__deps: i53ConversionDeps,
-  _wasmfs_jsimpl_read: function(backend, file, buffer, length, {{{ defineI64Param('offset') }}}) {
-    {{{ receiveI64ParamAsI53('offset') }}}
+  _wasmfs_jsimpl_read__i53abi: true,
+  _wasmfs_jsimpl_read: function(backend, file, buffer, length, offset) {
 #if ASSERTIONS
     assert(wasmFS$backends[backend]);
 #endif
@@ -72,9 +70,9 @@ mergeInto(LibraryManager.library, {
     _emscripten_proxy_finish(ctx);
   },
 
-  _wasmfs_jsimpl_async_write__deps: ['emscripten_proxy_finish'].concat(i53ConversionDeps),
-  _wasmfs_jsimpl_async_write: async function(ctx, backend, file, buffer, length, {{{ defineI64Param('offset') }}}, result_p) {
-    {{{ receiveI64ParamAsI53('offset') }}}
+  _wasmfs_jsimpl_async_write__i53abi: true,
+  _wasmfs_jsimpl_async_write__deps: ['emscripten_proxy_finish'],
+  _wasmfs_jsimpl_async_write: async function(ctx, backend, file, buffer, length, offset, result_p) {
 #if ASSERTIONS
     assert(wasmFS$backends[backend]);
 #endif
@@ -83,9 +81,9 @@ mergeInto(LibraryManager.library, {
     _emscripten_proxy_finish(ctx);
   },
 
-  _wasmfs_jsimpl_async_read__deps: ['emscripten_proxy_finish'].concat(i53ConversionDeps),
-  _wasmfs_jsimpl_async_read: async function(ctx, backend, file, buffer, length, {{{ defineI64Param('offset') }}}, result_p) {
-    {{{ receiveI64ParamAsI53('offset') }}}
+  _wasmfs_jsimpl_async_read__i53abi: true,
+  _wasmfs_jsimpl_async_read__deps: ['emscripten_proxy_finish'],
+  _wasmfs_jsimpl_async_read: async function(ctx, backend, file, buffer, length, offset, result_p) {
 #if ASSERTIONS
     assert(wasmFS$backends[backend]);
 #endif

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -410,11 +410,9 @@ mergeInto(LibraryManager.library, {
     wasmfsOPFSProxyFinish(ctx);
   },
 
-  _wasmfs_opfs_set_size_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'].concat(i53ConversionDeps),
-  _wasmfs_opfs_set_size_access: async function(ctx, accessID,
-                                               {{{ defineI64Param('size') }}},
-                                               errPtr) {
-    {{{ receiveI64ParamAsI53('size') }}};
+  _wasmfs_opfs_set_size_access__i53abi: true,
+  _wasmfs_opfs_set_size_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'],
+  _wasmfs_opfs_set_size_access: async function(ctx, accessID, size, errPtr) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     try {
       await accessHandle.truncate(size);
@@ -425,11 +423,9 @@ mergeInto(LibraryManager.library, {
     wasmfsOPFSProxyFinish(ctx);
   },
 
-  _wasmfs_opfs_set_size_file__deps: ['$wasmfsOPFSFileHandles', '$wasmfsOPFSProxyFinish'].concat(i53ConversionDeps),
-  _wasmfs_opfs_set_size_file: async function(ctx, fileID,
-                                             {{{ defineI64Param('size') }}},
-                                             errPtr) {
-    {{{ receiveI64ParamAsI53('size') }}};
+  _wasmfs_opfs_set_size_file__i53abi: true,
+  _wasmfs_opfs_set_size_file__deps: ['$wasmfsOPFSFileHandles', '$wasmfsOPFSProxyFinish'],
+  _wasmfs_opfs_set_size_file: async function(ctx, fileID, size, errPtr) {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     try {
       let writable = await fileHandle.createWritable({keepExistingData: true});

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -153,7 +153,7 @@ wgpu${type}Release: function(id) { WebGPU.mgr${type}.release(id) },`;
 
 var LibraryWebGPU = {
   $WebGPU__postset: 'WebGPU.initManagers();',
-  $WebGPU__deps: ['$withStackSave', '$stringToUTF8OnStack', '$convertI32PairToI53'],
+  $WebGPU__deps: ['$withStackSave', '$stringToUTF8OnStack'],
   $WebGPU: {
     errorCallback: function(callback, type, message, userdata) {
       withStackSave(() => {
@@ -1488,7 +1488,7 @@ var LibraryWebGPU = {
   },
 
   wgpuQueueOnSubmittedWorkDone__deps: ['$callUserCallback'],
-  wgpuQueueOnSubmittedWorkDone: function(queueId, {{{ defineI64Param('signalValue') }}}, callback, userdata) {
+  wgpuQueueOnSubmittedWorkDone: function(queueId, signalValue, callback, userdata) {
     var queue = WebGPU.mgrQueue.get(queueId);
 #if ASSERTIONS
     assert(signalValue_low === 0 && signalValue_high === 0, 'signalValue not supported, must be 0');
@@ -1508,9 +1508,7 @@ var LibraryWebGPU = {
     });
   },
 
-  wgpuQueueWriteBuffer: function(queueId,
-      bufferId, {{{ defineI64Param('bufferOffset') }}}, data, size) {
-    {{{ receiveI64ParamAsI53('bufferOffset') }}}
+  wgpuQueueWriteBuffer: function(queueId, bufferId, bufferOffset, data, size) {
     var queue = WebGPU.mgrQueue.get(queueId);
     var buffer = WebGPU.mgrBuffer.get(bufferId);
     // There is a size limitation for ArrayBufferView. Work around by passing in a subarray
@@ -1697,20 +1695,15 @@ var LibraryWebGPU = {
     return WebGPU.mgrRenderPassEncoder.create(commandEncoder["beginRenderPass"](desc));
   },
 
-  wgpuCommandEncoderClearBuffer: function(encoderId, bufferId, {{{ defineI64Param('offset') }}}, {{{ defineI64Param('size') }}}) {
+  wgpuCommandEncoderClearBuffer: function(encoderId, bufferId, offset, size) {
     var commandEncoder = WebGPU.mgrCommandEncoder.get(encoderId);
-    {{{ receiveI64ParamAsI53('offset') }}}
-    {{{ receiveI64ParamAsI53('size') }}}
     {{{ gpu.convertSentinelToUndefined('size') }}}
 
     var buffer = WebGPU.mgrBuffer.get(bufferId);
     commandEncoder["clearBuffer"](buffer, offset, size);
   },
 
-  wgpuCommandEncoderCopyBufferToBuffer: function(encoderId, srcId, {{{ defineI64Param('srcOffset') }}}, dstId, {{{ defineI64Param('dstOffset') }}}, {{{ defineI64Param('size') }}}) {
-    {{{ receiveI64ParamAsI53('srcOffset') }}}
-    {{{ receiveI64ParamAsI53('dstOffset') }}}
-    {{{ receiveI64ParamAsI53('size') }}}
+  wgpuCommandEncoderCopyBufferToBuffer: function(encoderId, srcId, srcOffset, dstId, dstOffset, size) {
     var commandEncoder = WebGPU.mgrCommandEncoder.get(encoderId);
     var src = WebGPU.mgrBuffer.get(srcId);
     var dst = WebGPU.mgrBuffer.get(dstId);
@@ -1739,8 +1732,7 @@ var LibraryWebGPU = {
   },
 
   wgpuCommandEncoderResolveQuerySet: function(encoderId, querySetId, firstQuery, queryCount,
-      destinationId, {{{ defineI64Param('destinationOffset') }}}) {
-    {{{ receiveI64ParamAsI53('destinationOffset') }}}
+      destinationId, destinationOffset) {
     var commandEncoder = WebGPU.mgrCommandEncoder.get(encoderId);
     var querySet = WebGPU.mgrQuerySet.get(querySetId);
     var destination = WebGPU.mgrBuffer.get(destinationId);
@@ -2087,8 +2079,7 @@ var LibraryWebGPU = {
     var pass = WebGPU.mgrComputePassEncoder.get(passId);
     pass["dispatchWorkgroups"](x, y, z);
   },
-  wgpuComputePassEncoderDispatchWorkgroupsIndirect: function(passId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
-    {{{ receiveI64ParamAsI53('indirectOffset') }}}
+  wgpuComputePassEncoderDispatchWorkgroupsIndirect: function(passId, indirectBufferId, indirectOffset) {
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
     var pass = WebGPU.mgrComputePassEncoder.get(passId);
     pass["dispatchWorkgroupsIndirect"](indirectBuffer, indirectOffset);
@@ -2153,10 +2144,7 @@ var LibraryWebGPU = {
     var color = WebGPU.makeColor(colorPtr);
     pass["setBlendConstant"](color);
   },
-  wgpuRenderPassEncoderSetIndexBuffer: function(passId, bufferId, format, {{{ defineI64Param('offset') }}}, {{{ defineI64Param('size') }}}) {
-    {{{ receiveI64ParamAsI53('offset') }}}
-    {{{ receiveI64ParamAsI53('size') }}}
-    {{{ gpu.convertSentinelToUndefined('size') }}}
+  wgpuRenderPassEncoderSetIndexBuffer: function(passId, bufferId, format, offset, size) {
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
     var buffer = WebGPU.mgrBuffer.get(bufferId);
     pass["setIndexBuffer"](buffer, WebGPU.IndexFormat[format], offset, size);
@@ -2178,10 +2166,7 @@ var LibraryWebGPU = {
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
     pass["setStencilReference"](reference);
   },
-  wgpuRenderPassEncoderSetVertexBuffer: function(passId, slot, bufferId, {{{ defineI64Param('offset') }}}, {{{ defineI64Param('size') }}}) {
-    {{{ receiveI64ParamAsI53('offset') }}}
-    {{{ receiveI64ParamAsI53('size') }}}
-    {{{ gpu.convertSentinelToUndefined('size') }}}
+  wgpuRenderPassEncoderSetVertexBuffer: function(passId, slot, bufferId, offset, size) {
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
     var buffer = WebGPU.mgrBuffer.get(bufferId);
     pass["setVertexBuffer"](slot, buffer, offset, size);
@@ -2195,14 +2180,12 @@ var LibraryWebGPU = {
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
     pass["drawIndexed"](indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
   },
-  wgpuRenderPassEncoderDrawIndirect: function(passId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
-    {{{ receiveI64ParamAsI53('indirectOffset') }}}
+  wgpuRenderPassEncoderDrawIndirect: function(passId, indirectBufferId, indirectOffset) {
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
     pass["drawIndirect"](indirectBuffer, indirectOffset);
   },
-  wgpuRenderPassEncoderDrawIndexedIndirect: function(passId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
-    {{{ receiveI64ParamAsI53('indirectOffset') }}}
+  wgpuRenderPassEncoderDrawIndexedIndirect: function(passId, indirectBufferId, indirectOffset) {
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
     pass["drawIndexedIndirect"](indirectBuffer, indirectOffset);
@@ -2289,10 +2272,7 @@ var LibraryWebGPU = {
       pass["setBindGroup"](groupIndex, group, offsets);
     }
   },
-  wgpuRenderBundleEncoderSetIndexBuffer: function(bundleId, bufferId, format, {{{ defineI64Param('offset') }}}, {{{ defineI64Param('size') }}}) {
-    {{{ receiveI64ParamAsI53('offset') }}}
-    {{{ receiveI64ParamAsI53('size') }}}
-    {{{ gpu.convertSentinelToUndefined('size') }}}
+  wgpuRenderBundleEncoderSetIndexBuffer: function(bundleId, bufferId, format, offset, size) {
     var pass = WebGPU.mgrRenderBundleEncoder.get(bundleId);
     var buffer = WebGPU.mgrBuffer.get(bufferId);
     pass["setIndexBuffer"](buffer, WebGPU.IndexFormat[format], offset, size);
@@ -2302,10 +2282,7 @@ var LibraryWebGPU = {
     var pipeline = WebGPU.mgrRenderPipeline.get(pipelineId);
     pass["setPipeline"](pipeline);
   },
-  wgpuRenderBundleEncoderSetVertexBuffer: function(bundleId, slot, bufferId, {{{ defineI64Param('offset') }}}, {{{ defineI64Param('size') }}}) {
-    {{{ receiveI64ParamAsI53('offset') }}}
-    {{{ receiveI64ParamAsI53('size') }}}
-    {{{ gpu.convertSentinelToUndefined('size') }}}
+  wgpuRenderBundleEncoderSetVertexBuffer: function(bundleId, slot, bufferId, offset, size) {
     var pass = WebGPU.mgrRenderBundleEncoder.get(bundleId);
     var buffer = WebGPU.mgrBuffer.get(bufferId);
     pass["setVertexBuffer"](slot, buffer, offset, size);
@@ -2319,14 +2296,12 @@ var LibraryWebGPU = {
     var pass = WebGPU.mgrRenderBundleEncoder.get(bundleId);
     pass["drawIndexed"](indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
   },
-  wgpuRenderBundleEncoderDrawIndirect: function(bundleId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
-    {{{ receiveI64ParamAsI53('indirectOffset') }}}
+  wgpuRenderBundleEncoderDrawIndirect: function(bundleId, indirectBufferId, indirectOffset) {
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
     var pass = WebGPU.mgrRenderBundleEncoder.get(bundleId);
     pass["drawIndirect"](indirectBuffer, indirectOffset);
   },
-  wgpuRenderBundleEncoderDrawIndexedIndirect: function(bundleId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
-    {{{ receiveI64ParamAsI53('indirectOffset') }}}
+  wgpuRenderBundleEncoderDrawIndexedIndirect: function(bundleId, indirectBufferId, indirectOffset) {
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
     var pass = WebGPU.mgrRenderBundleEncoder.get(bundleId);
     pass["drawIndexedIndirect"](indirectBuffer, indirectOffset);
@@ -2680,6 +2655,10 @@ var LibraryWebGPU = {
 LibraryWebGPU.$WebGPU.FeatureNameString2Enum = {};
 for (var value in LibraryWebGPU.$WebGPU.FeatureName) {
   LibraryWebGPU.$WebGPU.FeatureNameString2Enum[LibraryWebGPU.$WebGPU.FeatureName[value]] = value;
+}
+
+for (const key of Object.keys(LibraryWebGPU)) {
+  LibraryWebGPU[key + '__i53abi'] = true;
 }
 
 autoAddDeps(LibraryWebGPU, '$WebGPU');

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -873,14 +873,16 @@ function defineI64Param(name) {
   return `${name}_low, ${name}_high`;
 }
 
-function receiveI64ParamAsI53(name, onError) {
+
+function receiveI64ParamAsI53(name, onError, handleErrors = true) {
+  var errorHandler = handleErrors ? `if (isNaN(${name})) return ${onError}` : '';
   if (WASM_BIGINT) {
     // Just convert the bigint into a double.
-    return `${name} = bigintToI53Checked(${name}); if (isNaN(${name})) return ${onError};`;
+    return `${name} = bigintToI53Checked(${name});${errorHandler};`;
   }
   // Convert the high/low pair to a Number, checking for
   // overflow of the I53 range and returning onError in that case.
-  return `var ${name} = convertI32PairToI53Checked(${name}_low, ${name}_high); if (isNaN(${name})) return ${onError};`;
+  return `var ${name} = convertI32PairToI53Checked(${name}_low, ${name}_high);${errorHandler};`;
 }
 
 function receiveI64ParamAsI53Unchecked(name) {

--- a/src/utility.js
+++ b/src/utility.js
@@ -183,6 +183,7 @@ function isJsLibraryConfigIdentifier(ident) {
     '__internal',
     '__user',
     '__async',
+    '__i53abi',
   ];
   return suffixes.some((suffix) => ident.endsWith(suffix));
 }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13155,8 +13155,8 @@ foo/version.txt
   def test_itimer_pthread(self):
     self.do_other_test('test_itimer.c')
 
-  def test_itimer_standlone(self):
-    self.emcc_args += ['-sSTANDALONE_WASM']
+  def test_itimer_standalone(self):
+    self.emcc_args += ['-sSTANDALONE_WASM', '-sWASM_BIGINT']
     self.do_other_test('test_itimer_standalone.c')
     for engine in config.WASM_ENGINES:
       print('wasm engine', engine)


### PR DESCRIPTION
Previously folks would need to use helper macros like `defineI64Param`
and `receiveI64ParamAsI53`, but with this change that is now completely
automatic.  All they need to do is opt in using a new `__i53abi`
decorator.