### PR TITLE
Refer specifically to the Emscripten FAQ in warnings/errors that mention it

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -315,7 +315,7 @@ function checkUnflushedContent() {
   out = oldOut;
   err = oldErr;
   if (has) {
-    warnOnce('stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1 (see the FAQ), or make sure to emit a newline when you printf etc.');
+    warnOnce('stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1 (see the Emscripten FAQ), or make sure to emit a newline when you printf etc.');
 #if FILESYSTEM == 0 || SYSCALLS_REQUIRE_FILESYSTEM == 0
     warnOnce('(this may also be due to not including full filesystem support - try building with -sFORCE_FILESYSTEM)');
 #endif

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -86,7 +86,7 @@ function unexportedRuntimeSymbol(sym) {
     Object.defineProperty(Module, sym, {
       configurable: true,
       get: function() {
-        var msg = "'" + sym + "' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the FAQ)";
+        var msg = "'" + sym + "' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the Emscripten FAQ)";
         if (isExportedByForceFilesystem(sym)) {
           msg += '. Alternatively, forcing filesystem support (-sFORCE_FILESYSTEM) can export this for you';
         }

--- a/test/core/FS_exports_assert_2.out
+++ b/test/core/FS_exports_assert_2.out
@@ -1,1 +1,1 @@
-Aborted('FS_createDataFile' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the FAQ). Alternatively, forcing filesystem support (-sFORCE_FILESYSTEM) can export this for you)
+Aborted('FS_createDataFile' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the Emscripten FAQ). Alternatively, forcing filesystem support (-sFORCE_FILESYSTEM) can export this for you)

--- a/test/core/legacy_exported_runtime_numbers_assert.out
+++ b/test/core/legacy_exported_runtime_numbers_assert.out
@@ -1,1 +1,1 @@
-Aborted('ALLOC_STACK' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the FAQ))
+Aborted('ALLOC_STACK' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the Emscripten FAQ))

--- a/test/core/test_getValue_setValue_assert.out
+++ b/test/core/test_getValue_setValue_assert.out
@@ -1,1 +1,1 @@
-Aborted('setValue' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the FAQ))
+Aborted('setValue' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the Emscripten FAQ))

--- a/test/other/test_fflush.out
+++ b/test/other/test_fflush.out
@@ -1,3 +1,3 @@
 Hey1
-warning: stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1 (see the FAQ), or make sure to emit a newline when you printf etc.
+warning: stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1 (see the Emscripten FAQ), or make sure to emit a newline when you printf etc.
 warning: (this may also be due to not including full filesystem support - try building with -sFORCE_FILESYSTEM)

--- a/test/other/test_fflush_fs.out
+++ b/test/other/test_fflush_fs.out
@@ -1,2 +1,2 @@
 Hey1
-warning: stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1 (see the FAQ), or make sure to emit a newline when you printf etc.
+warning: stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1 (see the Emscripten FAQ), or make sure to emit a newline when you printf etc.

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7306,7 +7306,7 @@ void* operator new(size_t size) {
     test('ALLOC_STACK is not defined', args=['-DDIRECT'], assert_returncode=NON_ZERO)
 
     # When assertions are enabled direct and indirect usage both abort with a useful error message.
-    not_exported = "Aborted('ALLOC_STACK' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the FAQ))"
+    not_exported = "Aborted('ALLOC_STACK' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the Emscripten FAQ))"
     not_included = "`ALLOC_STACK` is a library symbol and not included by default; add it to your library.js __deps or to DEFAULT_LIBRARY_FUNCS_TO_INCLUDE on the command line (e.g. -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE='$ALLOC_STACK')"
     self.set_setting('ASSERTIONS')
     test(not_exported, assert_returncode=NON_ZERO)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7596,7 +7596,7 @@ int main() {}
     self.assertNotContained(error, read_file('a.out.js'))
 
   def test_warn_module_out_err(self):
-    error = 'was not exported. add it to EXPORTED_RUNTIME_METHODS (see the FAQ)'
+    error = 'was not exported. add it to EXPORTED_RUNTIME_METHODS (see the Emscripten FAQ)'
 
     def test(contents, expected, args=[], assert_returncode=0):  # noqa
       create_file('src.c', r'''


### PR DESCRIPTION
Emscripten's runtime sometimes issues warnings/errors that refer to "the FAQ", which may be confusing downstream as it is not clear that this refers to the _Emscripten_ FAQ. For a specific example, I discovered this behavior while tinkering with [MicroPyScript](https://github.com/pyscript/MicroPyScript), which issues these errors from `micropython.js` when they occur. It wasn't too hard to identify that these errors were related to the Emscripten configuration, but a small change to the messages can prevent the ambiguity in the first place.

I have run the affected tests locally and there is no change from the results against `main`. I do see a few failures, but I think those are because I had trouble establishing a complete development environment, as they appear on both branches. I may still be missing a few things for some configurations that the tests are run against.