### PR TITLE
wrap an assert() in #if ASSERTIONS

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -2098,7 +2098,9 @@ var LibraryEmbind = {
     invoker,
     rawConstructor
   ) {
+#if ASSERTIONS
     assert(argCount > 0);
+#endif
     var rawArgTypes = heap32VectorToArray(argCount, rawArgTypesAddr);
     invoker = embind__requireFunction(invokerSignature, invoker);
     var args = [rawConstructor];


### PR DESCRIPTION
otherwise I'm seeing `assert is not defined` when building in opt.