### PR TITLE
Rename isJsLibraryConfigIdentifier -> isDecorator. NFC

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -30,12 +30,6 @@ function splitter(array, filter) {
   return { leftIn, splitOut };
 }
 
-// Functions that start with '$' should not be exported to the wasm module.
-// They are intended to be exclusive to JS code only.
-function isJsOnlySymbol(symbol) {
-  return symbol[0] == '$';
-}
-
 function escapeJSONKey(x) {
   if (/^[\d\w_]+$/.exec(x) || x[0] === '"' || x[0] === "'") return x;
   assert(!x.includes("'"), 'cannot have internal single quotes in keys: ' + x);
@@ -102,7 +96,7 @@ function runJSify() {
   }
   if (INCLUDE_FULL_LIBRARY) {
     for (const key of Object.keys(LibraryManager.library)) {
-      if (!isJsLibraryConfigIdentifier(key)) {
+      if (!isDecorator(key)) {
         symbolsNeeded.push(key);
       }
     }
@@ -261,7 +255,7 @@ function(${args}) {
 
       // don't process any special identifiers. These are looked up when
       // processing the base name of the identifier.
-      if (isJsLibraryConfigIdentifier(symbol)) {
+      if (isDecorator(symbol)) {
         return;
       }
 

--- a/src/library.js
+++ b/src/library.js
@@ -3707,7 +3707,7 @@ DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.push(
 #endif
 
 function wrapSyscallFunction(x, library, isWasi) {
-  if (x[0] === '$' || isJsLibraryConfigIdentifier(x)) {
+  if (isJsOnlySymbol(x) || isDecorator(x)) {
     return;
   }
 

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -4098,7 +4098,7 @@ function recordGLProcAddressGet(lib) {
   // allow name collisions with user-implemented things having the same name
   // (see gl.c)
   Object.keys(lib).forEach((x) => {
-    if (x.startsWith('gl') && !isJsLibraryConfigIdentifier(x)) {
+    if (x.startsWith('gl') && !isDecorator(x)) {
       lib['emscripten_' + x] = x;
     }
   });

--- a/src/modules.js
+++ b/src/modules.js
@@ -220,7 +220,7 @@ global.LibraryManager = {
         this.library = new Proxy(this.library, {
           set: (target, prop, value) => {
             target[prop] = value;
-            if (!isJsLibraryConfigIdentifier(prop)) {
+            if (!isDecorator(prop)) {
               target[prop + '__user'] = true;
             }
             return true;
@@ -303,7 +303,7 @@ function getUnusedLibarySymbols() {
   const missingSyms = new Set();
   for (const [ident, value] of Object.entries(LibraryManager.library)) {
     if (typeof value === 'function' || typeof value === 'number') {
-      if (ident[0] === '$' && !isJsLibraryConfigIdentifier(ident) && !isInternalSymbol(ident)) {
+      if (isJsOnlySymbol(ident) && !isDecorator(ident) && !isInternalSymbol(ident)) {
         const name = ident.substr(1);
         if (!librarySymbolSet.has(name)) {
           missingSyms.add(name);
@@ -450,7 +450,7 @@ function exportRuntime() {
   // '$ which indicates they are JS methods.
   let runtimeElementsSet = new Set(runtimeElements);
   for (const ident of Object.keys(LibraryManager.library)) {
-    if (ident[0] === '$' && !isJsLibraryConfigIdentifier(ident) && !isInternalSymbol(ident)) {
+    if (isJsOnlySymbol(ident) && !isDecorator(ident) && !isInternalSymbol(ident)) {
       const jsname = ident.substr(1);
       assert(!runtimeElementsSet.has(jsname), 'runtimeElements contains library symbol: ' + ident);
       runtimeElements.push(jsname);

--- a/src/utility.js
+++ b/src/utility.js
@@ -170,7 +170,7 @@ function isNumber(x) {
 }
 
 // Symbols that start with '$' are not exported to the wasm module.
-// They are intended to be called exclusive by JS code.
+// They are intended to be called exclusively by JS code.
 function isJsOnlySymbol(symbol) {
   return symbol[0] == '$';
 }

--- a/src/utility.js
+++ b/src/utility.js
@@ -130,7 +130,7 @@ function mergeInto(obj, other, options = null) {
 
   if (!options || !options.allowMissing) {
     for (const ident of Object.keys(other)) {
-      if (isJsLibraryConfigIdentifier(ident)) {
+      if (isDecorator(ident)) {
         const index = ident.lastIndexOf('__');
         const basename = ident.slice(0, index);
         if (!(basename in obj) && !(basename in other)) {
@@ -169,7 +169,13 @@ function isNumber(x) {
   return x == parseFloat(x) || (typeof x == 'string' && x.match(/^-?\d+$/)) || x == 'NaN';
 }
 
-function isJsLibraryConfigIdentifier(ident) {
+// Symbols that start with '$' are not exported to the wasm module.
+// They are intended to be called exclusive by JS code.
+function isJsOnlySymbol(symbol) {
+  return symbol[0] == '$';
+}
+
+function isDecorator(ident) {
   suffixes = [
     '__sig',
     '__proxy',


### PR DESCRIPTION
Also, make more use of the existing `isJsOnlySymbol` predicate.