### PR TITLE
Fix "make install" to avoid installing npm dev dependencies. NFC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ dist: $(DISTFILE)
 install:
 	@rm -rf $(DESTDIR)
 	./tools/install.py $(DESTDIR)
-	npm install --prefix $(DESTDIR)
+	npm install --production --prefix $(DESTDIR)
 
 # Create an distributable archive of emscripten suitable for use
 # by end users. This archive excludes node_modules as it can include native


### PR DESCRIPTION
End users of emscripten don't need to have devDependencies installed

We already pass this flag when building the emscripten package in the emscripten-releases repo.