### PR TITLE
Automatically convert i32 pointer args to unsigned when CAN_ADDRESS_2GB is set

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -133,6 +133,9 @@ function runJSify() {
           if (sig[i] == 'j' && i53abi) {
             argConvertions += `  ${receiveI64ParamAsI53(name, undefined, false)}\n`;
             newArgs.push(defineI64Param(name));
+          } else if (sig[i] == 'p' && CAN_ADDRESS_2GB) {
+            argConvertions += `  ${name} >>>= 0;\n`;
+            newArgs.push(name);
           } else {
             newArgs.push(name);
           }
@@ -191,8 +194,8 @@ function(${args}) {
 
     const sig = LibraryManager.library[symbol + '__sig'];
     const i53abi = LibraryManager.library[symbol + '__i53abi'];
-    if (sig && ((i53abi && sig.includes('j')) ||
-                (MEMORY64 && sig.includes('p')))) {
+    if (sig &&
+        ((i53abi && sig.includes('j')) || ((MEMORY64 || CAN_ADDRESS_2GB) && sig.includes('p')))) {
       snippet = handleI64Signatures(symbol, snippet, sig, i53abi);
       i53ConversionDeps.forEach((d) => deps.push(d))
     }

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1132,8 +1132,8 @@ FS.staticInit();` +
       return stream.position;
     },
     read: (stream, buffer, offset, length, position) => {
-#if CAN_ADDRESS_2GB
-      offset >>>= 0;
+#if ASSERTIONS
+      assert(offset >= 0);
 #endif
       if (length < 0 || position < 0) {
         throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
@@ -1166,8 +1166,8 @@ FS.staticInit();` +
       return bytesRead;
     },
     write: (stream, buffer, offset, length, position, canOwn) => {
-#if CAN_ADDRESS_2GB
-      offset >>>= 0;
+#if ASSERTIONS
+      assert(offset >= 0);
 #endif
       if (length < 0 || position < 0) {
         throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
@@ -1242,8 +1242,8 @@ FS.staticInit();` +
       return stream.stream_ops.mmap(stream, length, position, prot, flags);
     },
     msync: (stream, buffer, offset, length, mmapFlags) => {
-#if CAN_ADDRESS_2GB
-      offset >>>= 0;
+#if ASSERTIONS
+      assert(offset >= 0);
 #endif
       if (!stream.stream_ops.msync) {
         return 0;

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -105,9 +105,6 @@ mergeInto(LibraryManager.library, {
     // May allocate more, to provide automatic geometric increase and amortized linear performance appending writes.
     // Never shrinks the storage.
     expandFileStorage: function(node, newCapacity) {
-#if CAN_ADDRESS_2GB
-      newCapacity >>>= 0;
-#endif
       var prevCapacity = node.contents ? node.contents.length : 0;
       if (prevCapacity >= newCapacity) return; // No need to expand, the storage was already large enough.
       // Don't expand strictly to the given requested limit if it's only a very small increase, but instead geometrically grow capacity.
@@ -123,9 +120,6 @@ mergeInto(LibraryManager.library, {
 
     // Performs an exact resize of the backing file storage to the given size, if the size is not exactly this, the storage is fully reallocated.
     resizeFileStorage: function(node, newSize) {
-#if CAN_ADDRESS_2GB
-      newSize >>>= 0;
-#endif
       if (node.usedBytes == newSize) return;
       if (newSize == 0) {
         node.contents = null; // Fully decommit when requesting a resize to zero.
@@ -360,9 +354,6 @@ mergeInto(LibraryManager.library, {
           if (!ptr) {
             throw new FS.ErrnoError({{{ cDefs.ENOMEM }}});
           }
-#if CAN_ADDRESS_2GB
-          ptr >>>= 0;
-#endif
           HEAP8.set(contents, ptr);
         }
         return { ptr, allocated };

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -80,9 +80,6 @@ var SyscallsLibrary = {
         // MAP_PRIVATE calls need not to be synced back to underlying fs
         return 0;
       }
-#if CAN_ADDRESS_2GB
-      addr >>>= 0;
-#endif
       var buffer = HEAPU8.slice(addr, addr + len);
       FS.msync(stream, buffer, offset, len, flags);
     },
@@ -142,9 +139,6 @@ var SyscallsLibrary = {
     var res = FS.mmap(stream, len, offset, prot, flags);
     var ptr = res.ptr;
     {{{ makeSetValue('allocated', 0, 'res.allocated', 'i32') }}};
-#if CAN_ADDRESS_2GB
-    ptr >>>= 0;
-#endif
     {{{ makeSetValue('addr', 0, 'ptr', '*') }}};
     return 0;
 #else // no filesystem support; report lack of support

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1841,7 +1841,6 @@ var LibraryWebGPU = {
 
     if (size === 0) warnOnce('getMappedRange size=0 no longer means WGPU_WHOLE_MAP_SIZE');
 
-    size >>>= 0;
     if (size === {{{ gpu.WHOLE_MAP_SIZE }}}) size = undefined;
 
     var mapped;
@@ -1875,7 +1874,6 @@ var LibraryWebGPU = {
 
     if (size === 0) warnOnce('getMappedRange size=0 no longer means WGPU_WHOLE_MAP_SIZE');
 
-    size >>>= 0;
     if (size === {{{ gpu.WHOLE_MAP_SIZE }}}) size = undefined;
 
     if (bufferWrapper.mapMode !== {{{ gpu.MapMode.Write }}}) {
@@ -1916,7 +1914,6 @@ var LibraryWebGPU = {
     bufferWrapper.onUnmap = [];
     var buffer = bufferWrapper.object;
 
-    size >>>= 0;
     if (size === {{{ gpu.WHOLE_MAP_SIZE }}}) size = undefined;
 
     // `callback` takes (WGPUBufferMapAsyncStatus status, void * userdata)


### PR DESCRIPTION
This extends the use automatically-generated JS wrappers to handle conversion of incoming i32 pointer to u32 JS numbers.  This is only needed when CAN_ADDRESS_2GB is set.

See #19737