### PR TITLE
Add a result code to emscripten_wget

### DIFF
--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -1305,7 +1305,7 @@ Sleeping
 Network
 -------
 
-.. c:function:: void emscripten_wget(const char* url, const char* file)
+.. c:function:: int emscripten_wget(const char* url, const char* file)
 
   Load file from url in *synchronously*. For the asynchronous version, see the :c:func:`emscripten_async_wget`.
 
@@ -1315,6 +1315,7 @@ Network
 
   :param const char* url: The URL to load.
   :param const char* file: The name of the file created and loaded from the URL. If the file already exists it will be overwritten. If the destination directory for the file does not exist on the filesystem, it will be created. A relative pathname may be passed, which will be interpreted relative to the current working directory at the time of the call to this function.
+  :return: 0 on success or 1 on error.
 
 .. c:function:: void emscripten_wget_data(const char* url, void** pbuffer, int* pnum, int *perror);
 

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -921,7 +921,7 @@ sigs = {
   emscripten_websocket_set_onerror_callback_on_thread__sig: 'iippp',
   emscripten_websocket_set_onmessage_callback_on_thread__sig: 'iippp',
   emscripten_websocket_set_onopen_callback_on_thread__sig: 'iippp',
-  emscripten_wget__sig: 'vpp',
+  emscripten_wget__sig: 'ipp',
   emscripten_wget_data__sig: 'vpppp',
   endprotoent__sig: 'v',
   environ_get__sig: 'ipp',

--- a/system/include/emscripten/wget.h
+++ b/system/include/emscripten/wget.h
@@ -35,7 +35,8 @@ void emscripten_async_wget2_abort(int handle);
 
 // wget "sync"
 
-void emscripten_wget(const char* url, const char* file);
+int emscripten_wget(const char* url, const char* file);
+
 void emscripten_wget_data(const char* url, void** pbuffer, int* pnum, int *perror);
 
 #ifdef __cplusplus

--- a/test/test_wget.c
+++ b/test/test_wget.c
@@ -18,11 +18,13 @@ void test(const char* file) {
   const char *url = "/test.txt";
 
   printf("calling wget\n");
-  emscripten_wget(url , file);
+  int result = emscripten_wget(url , file);
+  assert(result == 0);
   printf("back from wget\n");
 
   printf("calling wget again to overwrite previous file\n");
-  emscripten_wget(file , file);
+  result = emscripten_wget(url , file);
+  assert(result == 0);
   printf("back from wget\n");
 
   FILE * f = fopen(file, "r");

--- a/tools/building.py
+++ b/tools/building.py
@@ -38,7 +38,7 @@ logger = logging.getLogger('building')
 
 #  Building
 binaryen_checked = False
-EXPECTED_BINARYEN_VERSION = 113
+EXPECTED_BINARYEN_VERSION = 114
 
 _is_ar_cache: Dict[str, bool] = {}
 # the exports the user requested


### PR DESCRIPTION
This allows for proper error handling.

In fact it found an error here - we did not set the mode of the file we
created, so it was readonly by default, and we failed to overwrite it later.