### PR TITLE
Avoid setting CAN_ADDRESS_2GB with MEMORY64

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2866,10 +2866,10 @@ def phase_linker_setup(options, state, newargs):
 
   # check if we can address the 2GB mark and higher: either if we start at
   # 2GB, or if we allow growth to either any amount or to 2GB or more.
-  if settings.INITIAL_MEMORY > 2 * 1024 * 1024 * 1024 or \
+  if not settings.MEMORY64 and (settings.INITIAL_MEMORY > 2 * 1024 * 1024 * 1024 or
      (settings.ALLOW_MEMORY_GROWTH and
       (settings.MAXIMUM_MEMORY < 0 or
-       settings.MAXIMUM_MEMORY > 2 * 1024 * 1024 * 1024)):
+       settings.MAXIMUM_MEMORY > 2 * 1024 * 1024 * 1024))):
     settings.CAN_ADDRESS_2GB = 1
 
   settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -122,7 +122,7 @@ function runJSify() {
       for (let i = 1; i < sig.length; i++) {
         const name = argNames[i - 1];
         if (!name) {
-          error(`convertPointerParams: missing name for argument ${i} in ${symbol}`);
+          error(`handleI64Signatures: missing name for argument ${i} in ${symbol}`);
           return snippet;
         }
         if (WASM_BIGINT) {

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -186,8 +186,12 @@ var WASM_SYSTEM_EXPORTS = ['stackAlloc', 'stackSave', 'stackRestore', 'getTempRe
 // Internal: value of -flto argument (either full or thin)
 var LTO = 0;
 
-// Whether we may be accessing the address 2GB or higher. If so then we need
-// to be using unsigned pointers in JS.
+// Whether we may be accessing the address 2GB or higher. If so, then we need
+// to interpret incoming i32 pointers as unsigned.
+//
+// This setting does not apply (and is never set to true) under MEMORY64, since
+// in that case we get 64-bit pointers coming through to JS (converting them to
+// i53 in most cases).
 var CAN_ADDRESS_2GB = false;
 
 // Whether to emit DWARF in a separate wasm file on the side (this is not called


### PR DESCRIPTION
Split out from #19740.