### PR TITLE
Automatically convert returned pointers to unsigned in CAN_ADDRESS_GB mode.

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -718,9 +718,6 @@ var LibraryEmbind = {
         // assumes 4-byte alignment
         var base = _malloc({{{ POINTER_SIZE }}} + length + 1);
         var ptr = base + {{{ POINTER_SIZE }}};
-#if CAN_ADDRESS_2GB
-        ptr >>>= 0;
-#endif
         {{{ makeSetValue('base', '0', 'length', SIZE_TYPE) }}};
         if (stdStringIsUTF8 && valueIsOfTypeString) {
           stringToUTF8(value, ptr, length + 1);
@@ -810,9 +807,6 @@ var LibraryEmbind = {
         // assumes 4-byte alignment
         var length = lengthBytesUTF(value);
         var ptr = _malloc(4 + length + charSize);
-#if CAN_ADDRESS_2GB
-        ptr >>>= 0;
-#endif
         HEAPU32[ptr >> 2] = length >> shift;
 
         encodeString(value, ptr + 4, length + charSize);

--- a/src/library.js
+++ b/src/library.js
@@ -200,7 +200,7 @@ mergeInto(LibraryManager.library, {
   emscripten_resize_heap: (requestedSize) => {
     var oldSize = HEAPU8.length;
 #if MEMORY64 != 1
-    requestedSize = requestedSize >>> 0;
+    requestedSize >>>= 0;
 #endif
 #if ALLOW_MEMORY_GROWTH == 0
 #if ABORTING_MALLOC
@@ -3090,7 +3090,7 @@ mergeInto(LibraryManager.library, {
   // Used by wasm-emscripten-finalize to implement STACK_OVERFLOW_CHECK
   __handle_stack_overflow__deps: ['emscripten_stack_get_base', 'emscripten_stack_get_end', '$ptrToString'],
   __handle_stack_overflow: (requested) => {
-    requested = requested >>> 0;
+    requested >>>= 0;
     var base = _emscripten_stack_get_base();
     var end = _emscripten_stack_get_end();
     abort(`stack overflow (Attempt to set SP to ${ptrToString(requested)}` +

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1841,7 +1841,7 @@ var LibraryWebGPU = {
 
     if (size === 0) warnOnce('getMappedRange size=0 no longer means WGPU_WHOLE_MAP_SIZE');
 
-    size = size >>> 0;
+    size >>>= 0;
     if (size === {{{ gpu.WHOLE_MAP_SIZE }}}) size = undefined;
 
     var mapped;
@@ -1875,7 +1875,7 @@ var LibraryWebGPU = {
 
     if (size === 0) warnOnce('getMappedRange size=0 no longer means WGPU_WHOLE_MAP_SIZE');
 
-    size = size >>> 0;
+    size >>>= 0;
     if (size === {{{ gpu.WHOLE_MAP_SIZE }}}) size = undefined;
 
     if (bufferWrapper.mapMode !== {{{ gpu.MapMode.Write }}}) {
@@ -1916,7 +1916,7 @@ var LibraryWebGPU = {
     bufferWrapper.onUnmap = [];
     var buffer = bufferWrapper.object;
 
-    size = size >>> 0;
+    size >>>= 0;
     if (size === {{{ gpu.WHOLE_MAP_SIZE }}}) size = undefined;
 
     // `callback` takes (WGPUBufferMapAsyncStatus status, void * userdata)

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -171,8 +171,8 @@ WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
   asm = output.instance.exports;
 #endif
 
-#if MEMORY64
-  asm = instrumentWasmExportsForMemory64(asm);
+#if MEMORY64 || CAN_ADDRESS_2GB
+  asm = applySignatureConversions(asm);
 #endif
 
 #if USE_OFFSET_CONVERTER

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -991,8 +991,8 @@ function createWasm() {
     reportUndefinedSymbols();
 #endif
 
-#if MEMORY64
-    exports = instrumentWasmExportsForMemory64(exports);
+#if MEMORY64 || CAN_ADDRESS_2GB
+    exports = applySignatureConversions(exports);
 #endif
 
     Module['asm'] = exports;

--- a/tools/js_manipulation.py
+++ b/tools/js_manipulation.py
@@ -182,4 +182,11 @@ def make_wasm64_wrapper(sig):
   # are certain places we need to avoid strict mode still.
   # e.g. emscripten_get_callstack (getCallstack) which uses the `arguments`
   # global.
-  return f'  var wasm64Wrapper_{sig} = (f) => function ({args_in}) {{ return {result} }};\n'
+  return f'  var makeWrapper_{sig} = (f) => function ({args_in}) {{ return {result} }};\n'
+
+
+def make_unsign_pointer_wrapper(sig):
+  assert sig[0] == 'p'
+  n_args = len(sig) - 1
+  args = ','.join('a%d' % i for i in range(n_args))
+  return f'  var makeWrapper_{sig} = (f) => ({args}) => f({args}) >>> 0;\n'


### PR DESCRIPTION
When we have a signature for native function and we know it returns a pointer we automatically interpret it as unsigned when it arrives in JS.