### PR TITLE
Fix error handlers in IDBStore

### DIFF
--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -83,7 +83,7 @@ mergeInto(LibraryManager.library, {
         callback(null, db);
       };
       req.onerror = (e) => {
-        callback(e.target.error || 'unknown error');
+        callback(e.target.error);
         e.preventDefault();
       };
     },
@@ -129,7 +129,7 @@ mergeInto(LibraryManager.library, {
         try {
           var transaction = db.transaction([IDBFS.DB_STORE_NAME], 'readonly');
           transaction.onerror = (e) => {
-            callback(e.target.error || 'unknown error');
+            callback(e.target.error);
             e.preventDefault();
           };
 
@@ -211,7 +211,7 @@ mergeInto(LibraryManager.library, {
       var req = store.get(path);
       req.onsuccess = (event) => { callback(null, event.target.result); };
       req.onerror = (e) => {
-        callback(e.target.error || 'unknown error');
+        callback(e.target.error);
         e.preventDefault();
       };
     },
@@ -224,7 +224,7 @@ mergeInto(LibraryManager.library, {
       }
       req.onsuccess = () => { callback(null); };
       req.onerror = (e) => {
-        callback(e.target.error || 'unknown error');
+        callback(e.target.error);
         e.preventDefault();
       };
     },
@@ -232,7 +232,7 @@ mergeInto(LibraryManager.library, {
       var req = store.delete(path);
       req.onsuccess = () => { callback(null); };
       req.onerror = (e) => {
-        callback(e.target.error || 'unknown error');
+        callback(e.target.error);
         e.preventDefault();
       };
     },

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -83,7 +83,7 @@ mergeInto(LibraryManager.library, {
         callback(null, db);
       };
       req.onerror = (e) => {
-        callback(this.error);
+        callback(req.error || 'unknown error');
         e.preventDefault();
       };
     },
@@ -129,7 +129,7 @@ mergeInto(LibraryManager.library, {
         try {
           var transaction = db.transaction([IDBFS.DB_STORE_NAME], 'readonly');
           transaction.onerror = (e) => {
-            callback(this.error);
+            callback(transaction.error || 'unknown error');
             e.preventDefault();
           };
 
@@ -211,7 +211,7 @@ mergeInto(LibraryManager.library, {
       var req = store.get(path);
       req.onsuccess = (event) => { callback(null, event.target.result); };
       req.onerror = (e) => {
-        callback(this.error);
+        callback(req.error || 'unknown error');
         e.preventDefault();
       };
     },
@@ -224,7 +224,7 @@ mergeInto(LibraryManager.library, {
       }
       req.onsuccess = () => { callback(null); };
       req.onerror = (e) => {
-        callback(this.error);
+        callback(req.error || 'unknown error');
         e.preventDefault();
       };
     },
@@ -232,7 +232,7 @@ mergeInto(LibraryManager.library, {
       var req = store.delete(path);
       req.onsuccess = () => { callback(null); };
       req.onerror = (e) => {
-        callback(this.error);
+        callback(req.error || 'unknown error');
         e.preventDefault();
       };
     },

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -83,7 +83,7 @@ mergeInto(LibraryManager.library, {
         callback(null, db);
       };
       req.onerror = (e) => {
-        callback(req.error || 'unknown error');
+        callback(e.target.error || 'unknown error');
         e.preventDefault();
       };
     },
@@ -129,7 +129,7 @@ mergeInto(LibraryManager.library, {
         try {
           var transaction = db.transaction([IDBFS.DB_STORE_NAME], 'readonly');
           transaction.onerror = (e) => {
-            callback(transaction.error || 'unknown error');
+            callback(e.target.error || 'unknown error');
             e.preventDefault();
           };
 
@@ -211,7 +211,7 @@ mergeInto(LibraryManager.library, {
       var req = store.get(path);
       req.onsuccess = (event) => { callback(null, event.target.result); };
       req.onerror = (e) => {
-        callback(req.error || 'unknown error');
+        callback(e.target.error || 'unknown error');
         e.preventDefault();
       };
     },
@@ -224,7 +224,7 @@ mergeInto(LibraryManager.library, {
       }
       req.onsuccess = () => { callback(null); };
       req.onerror = (e) => {
-        callback(req.error || 'unknown error');
+        callback(e.target.error || 'unknown error');
         e.preventDefault();
       };
     },
@@ -232,7 +232,7 @@ mergeInto(LibraryManager.library, {
       var req = store.delete(path);
       req.onsuccess = () => { callback(null); };
       req.onerror = (e) => {
-        callback(req.error || 'unknown error');
+        callback(e.target.error || 'unknown error');
         e.preventDefault();
       };
     },


### PR DESCRIPTION
JS arrow functions have no `this` (that part of their specs), so `this.error` was undefined. These changes also make sure the callback receives a valid error string instead of `undefined`.

One way to see the issue is to use an emscripten page that uses and IDBFS in private mode on Firefox: there will be lots of errors about "db is undefined" because the real error message ("Error syncing IDBFS: InvalidStateError: A mutation operation was attempted on a database that did not allow mutations.") is not captured properly.