### PR TITLE
Update test_dylink_exceptions_try_catch_3

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -418,7 +418,7 @@ var LibraryExceptions = {
 
 #if !WASM_EXCEPTIONS
 // In LLVM, exceptions generate a set of functions of form
-// __cxa_find_matching_catch_1(), __cxa_find_matching_catch_2(), etc.  where the
+// __cxa_find_matching_catch_2(), __cxa_find_matching_catch_3(), etc.  where the
 // number specifies the number of arguments.  In Emscripten, route all these to
 // a single function '__cxa_find_matching_catch' that variadically processes all
 // of these functions using JS 'arguments' object.
@@ -426,10 +426,13 @@ addCxaCatch = function(n) {
   LibraryManager.library['__cxa_find_matching_catch_' + n] = '__cxa_find_matching_catch';
 };
 
-// Add the first 10 catch handlers premptively.  Others get added on demand in
+// Add the first 2-5 catch handlers premptively.  Others get added on demand in
 // jsifier.  This is done here primarily so that these symbols end up with the
 // correct deps in the stub library that we pass to wasm-ld.
-for (let i = 1; i < 10; i++) {
+// Note: __cxa_find_matching_catch_N function uses N = NumClauses + 2 so
+// __cxa_find_matching_catch_2 is the first such function with zero clauses.
+// See WebAssemblyLowerEmscriptenEHSjLj.cpp.
+for (let i = 2; i < 5; i++) {
   addCxaCatch(i)
 }
 #endif

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5030,7 +5030,7 @@ res64 - external 64\n''', header='''\
     # Create a dependency on __cxa_find_matching_catch_6 (6 = num clauses + 2)
     # which is one higher than the default set of __cxa_find_matching_catch
     # functions created in library_exceptions.js.
-    # This means we end up depeneding on dynamic linking code to redirect
+    # This means we end up depending on dynamic linking code to redirect
     # __cxa_find_matching_catch_6 to __cxa_find_matching_catch.
     create_file('liblib.cpp', r'''
       #include <stdio.h>


### PR DESCRIPTION
Increase the number of clauses in the test and decrease the number of default.

This means that test actually triggers the code its trying to test in `library_dylink.js`.