### PR TITLE
Allow test_hello_world_above_2gb to run under node. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12572,8 +12572,6 @@ Module.postRun = () => {{
     self.emcc_args += ['--preload-file', 'js_backend_files/file.dat']
     self.do_run_in_out_file_test('wasmfs/wasmfs_before_preload.c')
 
-  # Requires v8 for now since the version of node we use in CI doesn't support >2GB heaps
-  @requires_v8
   def test_hello_world_above_2gb(self):
     self.do_runf(test_file('hello_world.c'), 'hello, world!', emcc_args=['-sGLOBAL_BASE=2GB', '-sINITIAL_MEMORY=3GB'])
 


### PR DESCRIPTION
Since the node update this now seems to work fine.