### PR TITLE
Run safe_heap_2 test under wasm64. NFC

### DIFF
--- a/src/runtime_safe_heap.js
+++ b/src/runtime_safe_heap.js
@@ -42,7 +42,7 @@ function SAFE_HEAP_STORE(dest, value, bytes, isFloat) {
 #else
   if (runtimeInitialized) {
 #endif
-    var brk = _sbrk() >>> 0;
+    var brk = _sbrk();
     if (dest + bytes > brk) abort(`segmentation fault, exceeded the top of the available dynamic heap when storing ${bytes} bytes to address ${dest}. DYNAMICTOP=${brk}`);
     assert(brk >= _emscripten_stack_get_base(), `brk >= _emscripten_stack_get_base() (brk=${brk}, _emscripten_stack_get_base()=${_emscripten_stack_get_base()})`); // sbrk-managed memory must be above the stack
     assert(brk <= wasmMemory.buffer.byteLength, `brk <= wasmMemory.buffer.byteLength (brk=${brk}, wasmMemory.buffer.byteLength=${wasmMemory.buffer.byteLength})`);
@@ -70,7 +70,7 @@ function SAFE_HEAP_LOAD(dest, bytes, unsigned, isFloat) {
 #else
   if (runtimeInitialized) {
 #endif
-    var brk = _sbrk() >>> 0;
+    var brk = _sbrk();
     if (dest + bytes > brk) abort(`segmentation fault, exceeded the top of the available dynamic heap when loading ${bytes} bytes from address ${dest}. DYNAMICTOP=${brk}`);
     assert(brk >= _emscripten_stack_get_base(), `brk >= _emscripten_stack_get_base() (brk=${brk}, _emscripten_stack_get_base()=${_emscripten_stack_get_base()})`); // sbrk-managed memory must be above the stack
     assert(brk <= wasmMemory.buffer.byteLength, `brk <= wasmMemory.buffer.byteLength (brk=${brk}, wasmMemory.buffer.byteLength=${wasmMemory.buffer.byteLength})`);

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10364,6 +10364,7 @@ int main () {
     self.run_process([EMCC, '-sSTRICT', '-sIGNORE_MISSING_MAIN', 'empty.c'])
 
   # Tests the difference between options -sSAFE_HEAP=1 and -sSAFE_HEAP=2.
+  @also_with_wasm64
   def test_safe_heap_2(self):
     self.do_runf(test_file('safe_heap_2.c'), 'alignment fault',
                  emcc_args=['-sSAFE_HEAP=1'], assert_returncode=NON_ZERO)


### PR DESCRIPTION
Also, remove explicit coercion of result of _sbrk() call.  As of #19755 this happens automatically.