### PR TITLE
Add stubs for sanitizer functions in standalone mode

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2904,6 +2904,20 @@ mergeInto(LibraryManager.library, {
       _free = prev_free;
     }
   },
+
+  _emscripten_sanitizer_use_colors: () => {
+    var setting = Module['printWithColors'];
+    if (setting !== undefined) {
+      return setting;
+    }
+    return ENVIRONMENT_IS_NODE && process.stderr.isTTY;
+  },
+
+  _emscripten_sanitizer_get_option__deps: ['$withBuiltinMalloc', '$stringToNewUTF8', '$UTF8ToString'],
+  _emscripten_sanitizer_get_option__sig: 'pp',
+  _emscripten_sanitizer_get_option: (name) => {
+    return withBuiltinMalloc(() => stringToNewUTF8(Module[UTF8ToString(name)] || ""));
+  },
 #endif
 
   $readEmAsmArgsArray: '=[]',

--- a/system/lib/compiler-rt/lib/asan/asan_flags.cpp
+++ b/system/lib/compiler-rt/lib/asan/asan_flags.cpp
@@ -23,8 +23,8 @@
 #include "ubsan/ubsan_platform.h"
 
 #if SANITIZER_EMSCRIPTEN
-extern "C" void emscripten_builtin_free(void *);
-#include <emscripten/em_asm.h>
+#include <emscripten/heap.h>
+#include "emscripten_internal.h"
 #endif
 
 
@@ -130,18 +130,16 @@ void InitializeFlags() {
   // Override from Emscripten Module.
   // TODO: add EM_ASM_I64 and avoid using a double for a 64-bit pointer.
 #define MAKE_OPTION_LOAD(parser, name) \
-    options = (char*)(long)EM_ASM_DOUBLE({ \
-      return withBuiltinMalloc(() => stringToNewUTF8(Module[name] || "")); \
-    }); \
+    options = _emscripten_sanitizer_get_option(name); \
     parser.ParseString(options); \
     emscripten_builtin_free(options);
 
-  MAKE_OPTION_LOAD(asan_parser, 'ASAN_OPTIONS');
+  MAKE_OPTION_LOAD(asan_parser, "ASAN_OPTIONS");
 #if CAN_SANITIZE_LEAKS
-  MAKE_OPTION_LOAD(lsan_parser, 'LSAN_OPTIONS');
+  MAKE_OPTION_LOAD(lsan_parser, "LSAN_OPTIONS");
 #endif
 #if CAN_SANITIZE_UB
-  MAKE_OPTION_LOAD(ubsan_parser, 'UBSAN_OPTIONS');
+  MAKE_OPTION_LOAD(ubsan_parser, "UBSAN_OPTIONS");
 #endif
 #else
   // Override from command line.

--- a/system/lib/compiler-rt/lib/lsan/lsan.cpp
+++ b/system/lib/compiler-rt/lib/lsan/lsan.cpp
@@ -21,8 +21,8 @@
 #include "sanitizer_common/sanitizer_interface_internal.h"
 
 #if SANITIZER_EMSCRIPTEN
-extern "C" void emscripten_builtin_free(void *);
-#include <emscripten/em_asm.h>
+#include "emscripten_internal.h"
+#include <emscripten/heap.h>
 #endif
 
 bool lsan_inited;
@@ -82,9 +82,7 @@ static void InitializeFlags() {
   const char *lsan_default_options = __lsan_default_options();
   parser.ParseString(lsan_default_options);
 #if SANITIZER_EMSCRIPTEN
-  char *options = (char*) EM_ASM_PTR({
-    return withBuiltinMalloc(() => stringToNewUTF8(Module['LSAN_OPTIONS'] || ""));
-  });
+  char *options = _emscripten_sanitizer_get_option("LSAN_OPTIONS");
   parser.ParseString(options);
   emscripten_builtin_free(options);
 #else

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cpp
@@ -25,6 +25,10 @@
 # include <sys/mman.h>
 #endif
 
+#if SANITIZER_EMSCRIPTEN
+#include "emscripten_internal.h"
+#endif
+
 namespace __sanitizer {
 
 #if !SANITIZER_GO
@@ -41,17 +45,9 @@ void ReportErrorSummary(const char *error_type, const AddressInfo &info,
 #endif
 
 #if SANITIZER_EMSCRIPTEN
-#include <emscripten/em_asm.h>
 
 static inline bool ReportSupportsColors() {
-  return !!EM_ASM_INT({
-    var setting = Module['printWithColors'];
-    if (setting != null) {
-      return setting;
-    } else {
-      return ENVIRONMENT_IS_NODE && process.stderr.isTTY;
-    }
-  });
+  return _emscripten_sanitizer_use_colors();
 }
 
 #elif !SANITIZER_FUCHSIA

--- a/system/lib/compiler-rt/lib/ubsan/ubsan_flags.cpp
+++ b/system/lib/compiler-rt/lib/ubsan/ubsan_flags.cpp
@@ -20,8 +20,8 @@
 #include <stdlib.h>
 
 #if SANITIZER_EMSCRIPTEN
-extern "C" void emscripten_builtin_free(void *);
-#include <emscripten/em_asm.h>
+#include <emscripten/heap.h>
+#include "emscripten_internal.h"
 #endif
 
 namespace __ubsan {
@@ -77,9 +77,7 @@ void InitializeFlags() {
   parser.ParseString(__ubsan_default_options());
   // Override from environment variable.
 #if SANITIZER_EMSCRIPTEN
-  char *options = (char*) EM_ASM_PTR({
-    return withBuiltinMalloc(() => stringToNewUTF8(Module['UBSAN_OPTIONS'] || ""));
-  });
+  char* options = _emscripten_sanitizer_get_option("UBSAN_OPTIONS");
   parser.ParseString(options);
   emscripten_builtin_free(options);
 #else

--- a/system/lib/libc/emscripten_internal.h
+++ b/system/lib/libc/emscripten_internal.h
@@ -114,6 +114,9 @@ double emscripten_get_now_res(void);
 
 void* emscripten_return_address(int level);
 
+int _emscripten_sanitizer_use_colors(void);
+char* _emscripten_sanitizer_get_option(const char* name);
+
 void _emscripten_fs_load_embedded_files(void* ptr);
 
 void _emscripten_throw_longjmp(void);

--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -114,6 +114,18 @@ weak int __syscall_fstat64(int fd, intptr_t buf) {
   return -ENOSYS;
 }
 
+weak int __syscall_stat64(intptr_t path, intptr_t buf) {
+  return -ENOSYS;
+}
+
+weak int __syscall_dup(int fd) {
+  return -ENOSYS;
+}
+
+weak int __syscall_mkdirat(int dirfd, intptr_t path, int mode) {
+  return -ENOSYS;
+}
+
 // There is no good source of entropy without an import. Make this weak so that
 // it can be replaced with a pRNG or a proper import.
 weak int getentropy(void* buffer, size_t length) {
@@ -267,4 +279,46 @@ int _setitimer_js(int which, double timeout) {
   // error.
   errno = ENOTSUP;
   return -1;
+}
+
+weak uintptr_t emscripten_stack_snapshot(void) {
+  return 0;
+}
+
+weak uint32_t emscripten_stack_unwind_buffer(uintptr_t pc,
+                                             uintptr_t* buffer,
+                                             uint32_t depth) {
+  return 0;
+}
+
+weak const char* emscripten_pc_get_function(uintptr_t pc) {
+  return NULL;
+}
+
+weak const char* emscripten_pc_get_file(uintptr_t pc) {
+  return NULL;
+}
+
+weak int emscripten_pc_get_line(uintptr_t pc) {
+  return 0;
+}
+
+weak int emscripten_pc_get_column(uintptr_t pc) {
+  return 0;
+}
+
+weak void* emscripten_return_address(int level) {
+  return NULL;
+}
+
+weak int _emscripten_sanitizer_use_colors(void) {
+  return 1;
+}
+
+weak char* _emscripten_sanitizer_get_option(const char* name) {
+  return strdup("");
+}
+
+weak char* emscripten_get_module_name(char* buf, size_t length) {
+  return strncpy(buf, "<unknown>", length);
 }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10510,6 +10510,7 @@ int main(void) {
       'SUMMARY: LeakSanitizer: 3427 byte(s) leaked in 3 allocation(s).',
     ])
 
+  @also_with_standalone_wasm()
   def test_asan_null_deref(self):
     self.do_runf(test_file('other/test_asan_null_deref.c'),
                  emcc_args=['-fsanitize=address'],

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1945,6 +1945,7 @@ class SanitizerLibrary(CompilerRTLibrary, MTLibrary):
 class libubsan_rt(SanitizerLibrary):
   name = 'libubsan_rt'
 
+  includes = ['system/lib/libc']
   cflags = ['-DUBSAN_CAN_USE_CXXABI']
   src_dir = 'system/lib/compiler-rt/lib/ubsan'
   src_glob_exclude = ['ubsan_diag_standalone.cpp']
@@ -1960,6 +1961,7 @@ class liblsan_common_rt(SanitizerLibrary):
 class liblsan_rt(SanitizerLibrary):
   name = 'liblsan_rt'
 
+  includes = ['system/lib/libc']
   src_dir = 'system/lib/compiler-rt/lib/lsan'
   src_glob_exclude = ['lsan_common.cpp', 'lsan_common_mac.cpp', 'lsan_common_linux.cpp',
                       'lsan_common_emscripten.cpp']
@@ -1968,6 +1970,7 @@ class liblsan_rt(SanitizerLibrary):
 class libasan_rt(SanitizerLibrary):
   name = 'libasan_rt'
 
+  includes = ['system/lib/libc']
   src_dir = 'system/lib/compiler-rt/lib/asan'
 
 


### PR DESCRIPTION
This is just enough to allow some basic usage of sanitizer in standalone mode.

Fixes: #19753