### PR TITLE
Allow handling of single expression arrow functions in modifyJSFunction

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -120,9 +120,7 @@ mergeInto(LibraryManager.library, {
   // We have a separate JS version `getHeapMax()` which can be called directly
   // avoiding any wrapper added for wasm64.
   emscripten_get_heap_max__deps: ['$getHeapMax'],
-  emscripten_get_heap_max: () => {
-    return getHeapMax();
-  },
+  emscripten_get_heap_max: () => getHeapMax(),
 
   $getHeapMax: () =>
 #if ALLOW_MEMORY_GROWTH

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -725,12 +725,13 @@ function modifyJSFunction(text, func) {
   }
   let body = rest;
   const bodyStart = rest.indexOf('{');
-  if (bodyStart >= 0) {
+  let oneliner = bodyStart < 0;
+  if (!oneliner) {
     const bodyEnd = rest.lastIndexOf('}');
     assert(bodyEnd > 0);
     body = rest.substring(bodyStart + 1, bodyEnd);
   }
-  return func(args, body, async_);
+  return func(args, body, async_, oneliner);
 }
 
 function runIfMainThread(text) {


### PR DESCRIPTION
I have changes in the works that make more use of this feature but for now just use it in a single place.