### PR TITLE
Allow optional chaining in JS library code

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2313,6 +2313,8 @@ def phase_linker_setup(options, state, newargs):
                                  settings.MIN_CHROME_VERSION < 49 or
                                  settings.MIN_SAFARI_VERSION < 110000 or
                                  settings.MIN_IE_VERSION != 0x7FFFFFFF)
+    if not feature_matrix.caniuse(feature_matrix.Feature.OPTIONAL_CHAINING):
+      settings.TRANSPILE_TO_ES5 = True
 
     if options.use_closure_compiler is None and settings.TRANSPILE_TO_ES5:
       diagnostics.warning('transpile', 'enabling transpilation via closure due to browser version settings.  This warning can be suppressed by passing `--closure=1` or `--closure=0` to opt into our explicitly.')

--- a/src/settings.js
+++ b/src/settings.js
@@ -1764,10 +1764,10 @@ var AUTO_NATIVE_LIBRARIES = true;
 // versions >= MIN_FIREFOX_VERSION
 // are desired to work. Pass -sMIN_FIREFOX_VERSION=majorVersion to drop support
 // for Firefox versions older than < majorVersion.
-// Firefox ESR 68 was released on July 9, 2019.
+// Firefox ESR 74 was released on March 10, 2020
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
 // [link]
-var MIN_FIREFOX_VERSION = 68;
+var MIN_FIREFOX_VERSION = 74;
 
 // Specifies the oldest version of desktop Safari to target. Version is encoded
 // in MMmmVV, e.g. 70101 denotes Safari 7.1.1.
@@ -1806,10 +1806,10 @@ var MIN_EDGE_VERSION = 0x7FFFFFFF;
 
 // Specifies the oldest version of Chrome. E.g. pass -sMIN_CHROME_VERSION=58 to
 // drop support for Chrome 57 and older.
-// Chrome 75.0.3770 was released on 2019-06-04
+// Chrome 80 was released on February 4, 2020
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
 // [link]
-var MIN_CHROME_VERSION = 75;
+var MIN_CHROME_VERSION = 80;
 
 // Specifies minimum node version to target for the generated code.  This is
 // distinct from the minimum version required run the emscripten compiler.

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12819,6 +12819,10 @@ Module.postRun = () => {{
         };
         global['foo'] = obj3;
         err('value2: ' + obj3.myMethod());
+
+        // optional chaining
+        let result = Module.foo?.doSomething();
+        err('result: ' + result);
       }
     });
     ''')
@@ -12833,6 +12837,7 @@ Module.postRun = () => {{
         self.assertContained(['() => 2', '()=>2'], js)
         self.assertContained('const ', js)
         self.assertContained('let ', js)
+        self.assertContained('foo?.doSomething()', js)
       else:
         self.verify_es5(filename)
         self.assertNotContained('foo(arg=', js)
@@ -12840,6 +12845,7 @@ Module.postRun = () => {{
         self.assertNotContained('()=>2', js)
         self.assertNotContained('const ', js)
         self.assertNotContained('let ', js)
+        self.assertNotContained('foo?.doSomething()', js)
 
     # Check that under normal circumstances none of these features get
     # removed / transpiled.
@@ -13336,10 +13342,10 @@ foo/version.txt
     self.assertTextDataIdentical(expected, response)
 
   def test_min_browser_version(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Werror', '-sWASM_BIGINT', '-sMIN_SAFARI_VERSION=120000'])
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Werror', '-sWASM_BIGINT', '-sMIN_SAFARI_VERSION=120000', '-Wno-transpile'])
     self.assertContained('emcc: error: MIN_SAFARI_VERSION=120000 is not compatible with WASM_BIGINT (150000 or above required)', err)
 
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Werror', '-pthread', '-sMIN_CHROME_VERSION=73'])
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Werror', '-pthread', '-sMIN_CHROME_VERSION=73', '-Wno-transpile'])
     self.assertContained('emcc: error: MIN_CHROME_VERSION=73 is not compatible with pthreads (74 or above required)', err)
 
   def test_signext_lowering(self):

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -23,6 +23,7 @@ class Feature(IntEnum):
   THREADS = auto()
   GLOBALTHIS = auto()
   PROMISE_ANY = auto()
+  OPTIONAL_CHAINING = auto()
 
 
 default_features = {Feature.SIGN_EXT, Feature.MUTABLE_GLOBALS}
@@ -70,6 +71,12 @@ min_browser_versions = {
     'firefox': 79,
     'safari': 140000,
     'node': 150000,
+  },
+  Feature.OPTIONAL_CHAINING: {
+    'chrome': 80,
+    'firefox': 74,
+    'safari': 130400,
+    'node': 140000,
   },
 }
 


### PR DESCRIPTION
This change verifies that closure can successfully lower the optional chaining away on older browsers.

This also requires bumping of chrome and safari minimum versions.. so maybe its not worth it?