### PR TITLE
Remove data URL handling from low level read/readAsync functions. NFC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 3.1.44 (in development)
 -----------------------
+- The internal `read_` and `readAsync` functions no longer handle date URIs.
+  This only effects builds that use `-sSINGLE_FILE` or `--memory-init-file`.
+  (#19792)
 
 3.1.43 - 07/10/23
 -----------------

--- a/src/node_shell_read.js
+++ b/src/node_shell_read.js
@@ -5,12 +5,6 @@
  */
 
 read_ = (filename, binary) => {
-#if SUPPORT_BASE64_EMBEDDING
-  var ret = tryParseAsDataURI(filename);
-  if (ret) {
-    return binary ? ret : ret.toString();
-  }
-#endif
   // We need to re-wrap `file://` strings to URLs. Normalizing isn't
   // necessary in that case, the path should already be absolute.
   filename = isFileURI(filename) ? new URL(filename) : nodePath.normalize(filename);
@@ -29,12 +23,6 @@ readBinary = (filename) => {
 };
 
 readAsync = (filename, onload, onerror, binary = true) => {
-#if SUPPORT_BASE64_EMBEDDING
-  var ret = tryParseAsDataURI(filename);
-  if (ret) {
-    onload(ret);
-  }
-#endif
   // See the comment in the `read_` function.
   filename = isFileURI(filename) ? new URL(filename) : nodePath.normalize(filename);
   fs.readFile(filename, binary ? undefined : 'utf8', (err, data) => {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -667,7 +667,11 @@ function getBinaryPromise(binaryFile) {
   // See https://github.com/github/fetch/pull/92#issuecomment-140665932
   // Cordova or Electron apps are typically loaded from a file:// url.
   // So use fetch if it is available and the url is not a file, otherwise fall back to XHR.
-  if (!wasmBinary && (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER)) {
+  if (!wasmBinary
+#if SUPPORT_BASE64_EMBEDDING
+      && !isDataURI(binaryFile)
+#endif
+      && (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER)) {
     if (typeof fetch == 'function'
 #if ENVIRONMENT_MAY_BE_WEBVIEW
       && !isFileURI(binaryFile)

--- a/src/shell.js
+++ b/src/shell.js
@@ -293,29 +293,14 @@ if (ENVIRONMENT_IS_SHELL) {
 #endif
 
   if (typeof read != 'undefined') {
-    read_ = (f) => {
-#if SUPPORT_BASE64_EMBEDDING
-      const data = tryParseAsDataURI(f);
-      if (data) {
-        return intArrayToString(data);
-      }
-#endif
-      return read(f);
-    };
+    read_ = read;
   }
 
   readBinary = (f) => {
-    let data;
-#if SUPPORT_BASE64_EMBEDDING
-    data = tryParseAsDataURI(f);
-    if (data) {
-      return data;
-    }
-#endif
     if (typeof readbuffer == 'function') {
       return new Uint8Array(readbuffer(f));
     }
-    data = read(f, 'binary');
+    let data = read(f, 'binary');
     assert(typeof data == 'object');
     return data;
   };

--- a/src/web_or_worker_shell_read.js
+++ b/src/web_or_worker_shell_read.js
@@ -5,43 +5,19 @@
  */
 
   read_ = (url) => {
-#if SUPPORT_BASE64_EMBEDDING
-    try {
-#endif
-      var xhr = new XMLHttpRequest();
-      xhr.open('GET', url, false);
-      xhr.send(null);
-      return xhr.responseText;
-#if SUPPORT_BASE64_EMBEDDING
-    } catch (err) {
-      var data = tryParseAsDataURI(url);
-      if (data) {
-        return intArrayToString(data);
-      }
-      throw err;
-    }
-#endif
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url, false);
+    xhr.send(null);
+    return xhr.responseText;
   }
 
   if (ENVIRONMENT_IS_WORKER) {
     readBinary = (url) => {
-#if SUPPORT_BASE64_EMBEDDING
-      try {
-#endif
-        var xhr = new XMLHttpRequest();
-        xhr.open('GET', url, false);
-        xhr.responseType = 'arraybuffer';
-        xhr.send(null);
-        return new Uint8Array(/** @type{!ArrayBuffer} */(xhr.response));
-#if SUPPORT_BASE64_EMBEDDING
-      } catch (err) {
-        var data = tryParseAsDataURI(url);
-        if (data) {
-          return data;
-        }
-        throw err;
-      }
-#endif
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', url, false);
+      xhr.responseType = 'arraybuffer';
+      xhr.send(null);
+      return new Uint8Array(/** @type{!ArrayBuffer} */(xhr.response));
     };
   }
 
@@ -54,13 +30,6 @@
         onload(xhr.response);
         return;
       }
-#if SUPPORT_BASE64_EMBEDDING
-      var data = tryParseAsDataURI(url);
-      if (data) {
-        onload(data.buffer);
-        return;
-      }
-#endif
       onerror();
     };
     xhr.onerror = onerror;


### PR DESCRIPTION
These functions are used by the higher level `getBinarySync` and `getBinaryPromise` APIs.  

`getBinary` already handled data URLs itself. 

This change adds data URL handling to `getBinaryPromise` and removes it from the various low level implemenations, making them much simpler.