### PR TITLE
Remove `-sMIN_CHROME_VERSION=58` from `test_minimal_runtime_code_size`. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10090,7 +10090,6 @@ int main () {
                                '-sGL_TRACK_ERRORS=0',
                                '-sGL_SUPPORT_EXPLICIT_SWAP_CONTROL=0',
                                '-sGL_POOL_TEMP_BUFFERS=0',
-                               '-sMIN_CHROME_VERSION=58',
                                '-sGL_WORKAROUND_SAFARI_GETCONTEXT_BUG=0',
                                '-sNO_FILESYSTEM',
                                '-sSTRICT',


### PR DESCRIPTION
This test is designed to verify the minimum code size so I can't see why we would want to enable support for an older browser here (potentially triggering the inclusion of polyfills).

This was added #9919 but its not clear to me why.