### PR TITLE
Mark LLVM_ADD_VERSION and CLANG_ADD_VERSION as legacy environment variables

### DIFF
--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -661,6 +661,24 @@ fi
     test_with_fake('got js backend! JavaScript (asm.js, emscripten) backend', 'LLVM has not been built with the WebAssembly backend')
     delete_dir(shared.CANONICAL_TEMP_DIR)
 
+  def test_llvm_add_version(self):
+    restore_and_set_up()
+
+    with open(EM_CONFIG, 'a') as f:
+      f.write('LLVM_ROOT = "' + self.in_dir('fake') + '"')
+
+    def make_fake(version):
+      print("fake LLVM version: %s" % (version))
+      make_fake_clang(self.in_dir('fake', f'clang-{version}'), expected_llvm_version)
+      make_fake_tool(self.in_dir('fake', f'llvm-ar-{version}'), expected_llvm_version)
+      make_fake_tool(self.in_dir('fake', f'llvm-nm-{version}'), expected_llvm_version)
+
+    make_fake('9.9')
+    out = self.expect_fail([EMCC, '-v'])
+    self.assertContained('No such file or directory', out)
+    with env_modify({'EM_LLVM_ADD_VERSION': '9.9', 'EM_CLANG_ADD_VERSION': '9.9'}):
+      self.check_working([EMCC])
+
   def test_required_config_settings(self):
     # with no binaryen root, an error is shown
     restore_and_set_up()

--- a/tools/config.py
+++ b/tools/config.py
@@ -92,13 +92,6 @@ def normalize_config_settings():
   if not PORTS:
     PORTS = os.path.join(CACHE, 'ports')
 
-  # Tools/paths
-  if LLVM_ADD_VERSION is None:
-    LLVM_ADD_VERSION = os.getenv('LLVM_ADD_VERSION')
-
-  if CLANG_ADD_VERSION is None:
-    CLANG_ADD_VERSION = os.getenv('CLANG_ADD_VERSION')
-
 
 def set_config_from_tool_location(config_key, tool_binary, f):
   val = globals()[config_key]
@@ -165,17 +158,25 @@ def read_config():
     parse_config_file()
 
   # In the past the default-generated .emscripten config file would read certain environment
-  # variables. We used generate a warning here but that could generates false positives
-  # See https://github.com/emscripten-core/emsdk/issues/862
+  # variables.
   LEGACY_ENV_VARS = {
     'LLVM': 'EM_LLVM_ROOT',
     'BINARYEN': 'EM_BINARYEN_ROOT',
     'NODE': 'EM_NODE_JS',
+    'LLVM_ADD_VERSION': 'EM_LLVM_ADD_VERSION',
+    'CLANG_ADD_VERSION': 'EM_CLANG_ADD_VERSION',
   }
+
   for key, new_key in LEGACY_ENV_VARS.items():
     env_value = os.environ.get(key)
     if env_value and new_key not in os.environ:
-      logger.debug(f'legacy environment variable found: `{key}`.  Please switch to using `{new_key}` instead`')
+      msg = f'legacy environment variable found: `{key}`.  Please switch to using `{new_key}` instead`'
+      # Use `debug` instead of `warning` for `NODE` specifically since there can be false positives:
+      # See https://github.com/emscripten-core/emsdk/issues/862
+      if key == 'NODE':
+        logger.debug(msg)
+      else:
+        logger.warning(msg)
 
   set_config_from_tool_location('LLVM_ROOT', 'clang', os.path.dirname)
   set_config_from_tool_location('NODE_JS', 'node', lambda x: x)


### PR DESCRIPTION
These can be set in the config file by these names but like all other config variables should have the `EM_` prefix when used as environment variables.

Also, add some testing for LLVM_ADD_VERSION and CLANG_ADD_VERSION which was previously untested.