### PR TITLE
Update documentation on emscripten config file

### DIFF
--- a/site/source/docs/building_from_source/configuring_emscripten_settings.rst
+++ b/site/source/docs/building_from_source/configuring_emscripten_settings.rst
@@ -4,21 +4,24 @@
 Configuring Emscripten Settings when Manually Building from Source
 ==================================================================
 
-The compiler settings used by Emscripten are defined in the :ref:`compiler
+Emscripten can be configured via a :ref:`compiler
 configuration file (.emscripten) <compiler-configuration-file>`. These settings
-include paths to the tools (LLVM, Clang, Java, etc.) and the compiler's
+include paths to the tools (LLVM, Clang, Binaryen, etc.) and the compiler's
 temporary directory for intermediate build files.
 
-This article explains how to create and update the file when you are building Emscripten :ref:`manually <installing-from-source>` from source.
+This confuration file is optional.  By default, emscripten will search
+for the tools it needs in the ``PATH``.
+
+This article explains how to create and update the file when you are building
+Emscripten :ref:`manually <installing-from-source>` from source.
 
 
 Creating the compiler configuration file
 ========================================
 
-A settings file is required to run :ref:`emcc <emccdoc>` (or any of the other
-Emscripten tools).  When you first run ``emcc`` it will direct you to the
-``--generate-config`` command line option which can be used to generate config
-file in the default location.
+A settings file may be used when running :ref:`emcc <emccdoc>` (or any of the
+other Emscripten tools).  You can run ``emcc`` with ``--generate-config``
+in order to generate one in the default location.
 
 1. Navigate to the directory where you cloned the Emscripten repository.
 2. Enter the command:
@@ -30,21 +33,20 @@ file in the default location.
   You should get a ``An Emscripten settings file has been generated at:``
   message, along with the contents of the config file.
 
-Emscripten makes a "best guess" at the correct locations for tools and updates
-the file appropriately. Where possible it will look for "system" apps (like
-Python and Java).
+When generating this file Emscripten will make its "best guess" at the correct
+locations for tools based on the current ``PATH``.
 
-In most cases it is necessary to edit the generated file and modify at least the
-``LLVM_ROOT`` and ``BINARYEN_ROOT`` settings to point to the correct location of
-your local LLVM and Binaryen installations respectively.
+In most cases it will be necessary to edit the generated file and modify
+least the ``LLVM_ROOT`` and ``BINARYEN_ROOT`` settings to point to the correct
+locations for your local LLVM and Binaryen installations.
 
 
 Locating the compiler configuration file (.emscripten)
-=======================================================
+======================================================
 
 The settings file (``.emscripten``) is created by default within the emscripten
 directory (alongsize ``emcc`` itself).  In cases where the emscripten directory
-is read-only the users home directory will be used:
+is read-only the user's home directory will be used:
 
   - On Linux and macOS this file is named **~/.emscripten**, where ~ is the
     user's home directory.
@@ -59,31 +61,29 @@ Compiler configuration file-format
 
 .. note:: While the syntax is identical, the appearance of the default **.emscripten** file created by *emcc* is quite different than that created by :ref:`emsdk <compiler-configuration-file>`. This is because *emsdk* manages multiple target environments, and where possible hard codes the locations of those tools when a new environment is activated. The default file, by contrast, is managed by the user — and is designed to make that task as easy as possible.
 
-The file simply assigns paths to a number of *variables* representing the main tools used by Emscripten. For example, if the user installed python to the **C:\\Python38\\** directory, then the file might have the line: ::
+The file simply assigns values to a number of *variables* representing the main
+tools used by Emscripten. For example, if your binaryen installation is in
+**C:\\tools\\binaryen\\**, then the file might contain the line: ::
 
-	PYTHON = 'C:\\Python38\\python.exe'
-	
+  BINARYEN_ROOT = 'C:\\tools\\binaryen\\'
 
-The default *emcc* configuration file often gets the paths from environment variables if defined. If no variable is defined the system will also attempt to find "system executables". For example:  ::
-
-	PYTHON = os.path.expanduser(os.getenv('PYTHON', 'C:\\Python38\\python.exe'))
-
-You can find out the other variable names from the default *.emscripten* file or the :ref:`example here <compiler-configuration-file>`. 
+You can find out the other variable names from the default *.emscripten* file or
+the :ref:`example here <compiler-configuration-file>`.
 
 Editing the compiler configuration file
 =======================================
 
-The compiler configuration file can be edited with the text editor of your choice. As stated above, most default settings are likely to be correct. If you're building manually from source, you are most likely to have to update the variable ``LLVM_ROOT``
+The compiler configuration file can be edited with the text editor of your
+choice. If you're building manually from source, you are most likely to have to
+update the variable ``LLVM_ROOT``
 
-		
-#. Edit the variable ``LLVM_ROOT`` to point to the directory where you built the LLVM binaries, such as:
-   
-	::
-   
-		LLVM_ROOT = os.path.expanduser(os.getenv('LLVM', '/home/ubuntu/a-path/llvm/build/bin'))
+#. Edit the variable ``LLVM_ROOT`` to point to the directory where you built the
+   LLVM binaries, such as:
 
-	.. note:: Use forward slashes!
+    ::
 
-.. comment .. The settings are now correct in the configuration file, but the paths and environment variables are not set in the command prompt/terminal. **HamishW** Follow up with Jukka on this.
- 
+      LLVM_ROOT = '/home/ubuntu/a-path/llvm/build/bin'
+
+    .. note:: Use forward slashes!
+
 After setting those paths, run ``emcc`` again. It should again perform the sanity checks to test the specified paths. There are further validation tests available at :ref:`verifying-the-emscripten-environment`.

--- a/site/source/docs/tools_reference/emsdk.rst
+++ b/site/source/docs/tools_reference/emsdk.rst
@@ -85,9 +85,12 @@ Emscripten Compiler Configuration File (.emscripten)
 The *Compiler Configuration File* stores the :term:`active <Active Tool/SDK>` configuration on behalf of the *emsdk*. The active configuration defines the specific set of tools that are used by default if Emscripten in called on the :ref:`Emscripten Command Prompt <emcmdprompt>`.
 
 The configuration file is named **.emscripten**. It is emsdk-specific, so it
-won't conflict with any config file the user might have in their home directory.
+won't conflict with any config file the user might have elsewhere on their
+system.
 
-The file should generally not be updated directly unless you're :ref:`building Emscripten from source <installing-from-source>`. Instead use the *emsdk* to activate specific SDKs and tools as needed (``emsdk activate <tool/SDK>``).
+The file should generally not be updated directly unless you're :ref:`building
+Emscripten from source <installing-from-source>`. Instead, use the *emsdk* to
+activate specific SDKs and tools as needed (``emsdk activate <tool/SDK>``).
 
 Below are examples of possible **.emscripten** files created by *emsdk*. Note
 the variable names used to point to the different tools::
@@ -97,7 +100,6 @@ the variable names used to point to the different tools::
   import os
   LLVM_ROOT='C:/Program Files/Emscripten/clang/e1.21.0_64bit'
   NODE_JS='C:/Program Files/Emscripten/node/0.10.17_64bit/node.exe'
-  JAVA='C:/Program Files/Emscripten/java/7.45_64bit/bin/java.exe'
 
 ::
 
@@ -110,7 +112,7 @@ the variable names used to point to the different tools::
 .. _emsdk_howto:
 
 "How to" guides
-=========================
+===============
 
 The following topics explain how to perform both common and advanced maintenance operations, ranging from installing the latest SDK through to installing your own fork from GitHub.
 
@@ -120,7 +122,7 @@ The following topics explain how to perform both common and advanced maintenance
 
 
 How do I just get the latest SDK?
-------------------------------------------------------------------------------------------------
+---------------------------------
 Use the ``update`` argument to fetch the current registry of available tools, and then specify the ``latest`` install target to get the most recent SDK: ::
 
   # Fetch the latest registry of available tools.
@@ -135,13 +137,13 @@ Use the ``update`` argument to fetch the current registry of available tools, an
 
 
 How do I use emsdk?
---------------------------------
+-------------------
 
 Use ``./emsdk help`` or just ``./emsdk`` to get information about all available commands.
 
 
 How do I check which versions of the SDK and tools are installed?
-------------------------------------------------------------------------------------------------
+-----------------------------------------------------------------
 
 To get a list of all currently installed tools and SDK versions (and all available tools) run: ::
 
@@ -167,7 +169,7 @@ For example: ::
 .. _emsdk-remove-tool-sdk:
 
 How do I remove a tool or an SDK?
-----------------------------------------------------------------
+---------------------------------
 
 Use the ``uninstall`` argument to delete a given tool or SDK from the local computer: ::
 
@@ -178,7 +180,7 @@ If you want to completely remove Emscripten from your system, follow the guide a
 
 
 How do I check for updates to the Emscripten SDK?
-----------------------------------------------------------------
+-------------------------------------------------
 
 First use the ``update`` command to fetch package information for all new tools and SDK versions. Then use ``install <tool/sdk name>`` to install a new version: ::
 
@@ -192,7 +194,7 @@ First use the ``update`` command to fetch package information for all new tools 
 .. _emsdk-set-active-tools:
 
 How do I change the currently active SDK version?
-----------------------------------------------------------------
+-------------------------------------------------
 
 Toggle between different tools and SDK versions using the :term:`activate
 <Active Tool/SDK>` command. This will set up ``.emscripten`` to point to that
@@ -231,7 +233,7 @@ How do I install and activate old Emscripten SDKs and tools?
 .. _emsdk-dev-sdk:
 
 How do I track the latest Emscripten development with the SDK?
-------------------------------------------------------------------------------------------------
+--------------------------------------------------------------
 
 It is also possible to use the latest and greatest versions of the tools on the GitHub repositories! This allows you to obtain new features and latest fixes immediately as they are pushed to GitHub, without having to wait for release to be tagged. **No GitHub account or fork of Emscripten is required.**
 
@@ -251,7 +253,7 @@ To switch to using the latest upstream git development branch (``main``), run th
 .. _emsdk-howto-use-own-fork:
 
 How do I use my own Emscripten GitHub fork with the SDK?
-----------------------------------------------------------------
+--------------------------------------------------------
 
 It is also possible to use your own fork of the Emscripten repository via the SDK. This is useful in the case when you want to make your own modifications to the Emscripten toolchain, but still keep using the SDK environment and tools.
 
@@ -271,7 +273,3 @@ The way this works is that you first install the ``sdk-upstream-main`` SDK as in
   git checkout -b mymain --track myremote/main
 
 You can switch back and forth between remotes via the ``git checkout`` command as usual.
-
-
-
-

--- a/tools/config.py
+++ b/tools/config.py
@@ -194,7 +194,7 @@ def generate_config(path):
 
   config_data = utils.read_file(path_from_root('tools/config_template.py'))
   config_data = config_data.splitlines()[3:] # remove the initial comment
-  config_data = '\n'.join(config_data)
+  config_data = '\n'.join(config_data) + '\n'
   # autodetect some default paths
   llvm_root = os.path.dirname(shutil.which('wasm-ld') or '/usr/bin/wasm-ld')
   config_data = config_data.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))


### PR DESCRIPTION
These days, the file itself is optional.

PYTHON is no longer a setting, so use BINARYEN_ROOT in the example instead.