### PR TITLE
Clarify comments on Emscripten EH-based settings

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -641,11 +641,12 @@ var ENVIRONMENT = 'web,webview,worker,node';
 // [link]
 var LZ4 = false;
 
-// Emscripten exception handling options.
+// Emscripten (JavaScript-based) exception handling options.
 // The three options below (DISABLE_EXCEPTION_CATCHING,
 // EXCEPTION_CATCHING_ALLOWED, and DISABLE_EXCEPTION_THROWING) only pertain to
-// Emscripten exception handling and do not control the native wasm exception
-// handling option (-fwasm-exceptions, internal setting: WASM_EXCEPTIONS).
+// JavaScript-based exception handling and do not control the native Wasm
+// exception handling option (-fwasm-exceptions, internal setting:
+// WASM_EXCEPTIONS).
 
 // Disables generating code to actually catch exceptions. This disabling is on
 // by default as the overhead of exceptions is quite high in size and speed
@@ -661,6 +662,9 @@ var LZ4 = false;
 //
 // This option is mutually exclusive with EXCEPTION_CATCHING_ALLOWED.
 //
+// This option only applies to Emscripten (JavaScript-based) exception handling
+// and does not control the native Wasm exception handling.
+//
 // [compile+link] - affects user code at compile and system libraries at link
 var DISABLE_EXCEPTION_CATCHING = 1;
 
@@ -669,8 +673,30 @@ var DISABLE_EXCEPTION_CATCHING = 1;
 //
 // This option is mutually exclusive with DISABLE_EXCEPTION_CATCHING.
 //
+// This option only applies to Emscripten (JavaScript-based) exception handling
+// and does not control the native Wasm exception handling.
+//
 // [compile+link] - affects user code at compile and system libraries at link
 var EXCEPTION_CATCHING_ALLOWED = [];
+
+// Internal: Tracks whether Emscripten should link in exception throwing (C++
+// 'throw') support library. This does not need to be set directly, but pass
+// -fno-exceptions to the build disable exceptions support. (This is basically
+// -fno-exceptions, but checked at final link time instead of individual .cpp
+// file compile time) If the program *does* contain throwing code (some source
+// files were not compiled with `-fno-exceptions`), and this flag is set at link
+// time, then you will get errors on undefined symbols, as the exception
+// throwing code is not linked in. If so you should either unset the option (if
+// you do want exceptions) or fix the compilation of the source files so that
+// indeed no exceptions are used).
+// TODO(sbc): Move to settings_internal (current blocked due to use in test
+// code).
+//
+// This option only applies to Emscripten (JavaScript-based) exception handling
+// and does not control the native Wasm exception handling.
+//
+// [link]
+var DISABLE_EXCEPTION_THROWING = false;
 
 // Make the exception message printing function, 'getExceptionMessage' available
 // in the JS library for use, by adding necessary symbols to EXPORTED_FUNCTIONS
@@ -708,21 +734,6 @@ var EXPORT_EXCEPTION_HANDLING_HELPERS = false;
 // This option implies EXPORT_EXCEPTION_HANDLING_HELPERS.
 // [link]
 var EXCEPTION_STACK_TRACES = false;
-
-// Internal: Tracks whether Emscripten should link in exception throwing (C++
-// 'throw') support library. This does not need to be set directly, but pass
-// -fno-exceptions to the build disable exceptions support. (This is basically
-// -fno-exceptions, but checked at final link time instead of individual .cpp
-// file compile time) If the program *does* contain throwing code (some source
-// files were not compiled with `-fno-exceptions`), and this flag is set at link
-// time, then you will get errors on undefined symbols, as the exception
-// throwing code is not linked in. If so you should either unset the option (if
-// you do want exceptions) or fix the compilation of the source files so that
-// indeed no exceptions are used).
-// TODO(sbc): Move to settings_internal (current blocked due to use in test
-// code).
-// [link]
-var DISABLE_EXCEPTION_THROWING = false;
 
 // Emscripten throws an ExitStatus exception to unwind when exit() is called.
 // Without this setting enabled this can show up as a top level unhandled


### PR DESCRIPTION
The original intention was to gather all Emscripten-EH settings in one place and put a single comment block saying "The below three only apply to Emscripten EH", but when you search for a setting you just do a keyword search and it is not easy to look up to see this comment. So this makes it clear that a certain option only applies to Emscripten EH in by putting a comment in each setting. Also move `DISABLE_EXCEPTION_THROWING` up so that all three Emscripten-EH-only settings are clumped together.