### PR TITLE
Don't generate function wrappers for exported tags. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -28,7 +28,7 @@ from tools import webassembly
 from tools import extract_metadata
 from tools.utils import exit_with_error, path_from_root, removeprefix
 from tools.shared import DEBUG, asmjs_mangle
-from tools.shared import treat_as_user_function
+from tools.shared import treat_as_user_export
 from tools.settings import settings
 
 logger = logging.getLogger('emscripten')
@@ -126,18 +126,13 @@ def update_settings_glue(wasm_file, metadata):
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
   else:
     syms = settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE + metadata.imports
-    syms = set(syms).difference(metadata.exports)
+    syms = set(syms).difference(metadata.all_exports)
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = sorted(syms)
     if settings.MAIN_MODULE:
       get_weak_imports(wasm_file)
 
-  settings.WASM_EXPORTS = metadata.exports + list(metadata.namedGlobals.keys())
-  settings.WASM_EXPORTS += list(metadata.emJsFuncs.keys())
-
-  # Store function exports so that Closure and metadce can track these even in
-  # -sDECLARE_ASM_MODULE_EXPORTS=0 builds.
-  settings.WASM_FUNCTION_EXPORTS = metadata.exports
-
+  settings.WASM_EXPORTS = metadata.all_exports
+  settings.WASM_GLOBAL_EXPORTS = list(metadata.namedGlobals.keys())
   settings.HAVE_EM_ASM = bool(settings.MAIN_MODULE or len(metadata.asmConsts) != 0)
 
   # start with the MVP features, and add any detected features.
@@ -165,7 +160,7 @@ def update_settings_glue(wasm_file, metadata):
   if settings.STACK_OVERFLOW_CHECK and not settings.SIDE_MODULE:
     # writeStackCookie and checkStackCookie both rely on emscripten_stack_get_end being
     # exported.  In theory it should always be present since its defined in compiler-rt.
-    assert 'emscripten_stack_get_end' in metadata.exports
+    assert 'emscripten_stack_get_end' in metadata.function_exports
 
   for deps in metadata.jsDeps:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.extend(deps.split(','))
@@ -317,7 +312,7 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, js_syms):
     metadata.imports += ['__memory_base32']
 
   if settings.ASYNCIFY == 1:
-    metadata.exports += ['asyncify_start_unwind', 'asyncify_stop_unwind', 'asyncify_start_rewind', 'asyncify_stop_rewind']
+    metadata.function_exports += ['asyncify_start_unwind', 'asyncify_stop_unwind', 'asyncify_start_rewind', 'asyncify_stop_rewind']
 
   update_settings_glue(out_wasm, metadata)
 
@@ -390,8 +385,6 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, js_syms):
         pre += f"  ignoredModuleProp('{sym}');\n"
     pre += "}\n"
 
-  exports = metadata.exports
-
   report_missing_symbols(forwarded_json['librarySymbols'])
 
   if not outfile_js:
@@ -422,11 +415,11 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, js_syms):
     out.write(pre)
     pre = None
 
-    receiving = create_receiving(exports)
+    receiving = create_receiving(metadata.function_exports)
 
     if settings.MINIMAL_RUNTIME:
       if settings.DECLARE_ASM_MODULE_EXPORTS:
-        post = compute_minimal_runtime_initializer_and_exports(post, exports, receiving)
+        post = compute_minimal_runtime_initializer_and_exports(post, metadata.function_exports, receiving)
       receiving = ''
 
     module = create_module(receiving, metadata, forwarded_json['librarySymbols'])
@@ -546,7 +539,7 @@ def finalize_wasm(infile, outfile, memfile, js_syms):
   # EMSCRIPTEN_KEEPALIVE (llvm.used).
   # These are any exports that were not requested on the command line and are
   # not known auto-generated system functions.
-  unexpected_exports = [e for e in metadata.exports if treat_as_user_function(e)]
+  unexpected_exports = [e for e in metadata.all_exports if treat_as_user_export(e)]
   unexpected_exports = [asmjs_mangle(e) for e in unexpected_exports]
   unexpected_exports = [e for e in unexpected_exports if e not in expected_exports]
   if '_main' in unexpected_exports:
@@ -702,7 +695,7 @@ def create_sending(metadata, library_symbols):
     # that are part of EXPORTED_FUNCTIONS (or in the case of MAIN_MODULE=1 add
     # all JS library functions).  This allows `dlsym(RTLD_DEFAULT)` to lookup JS
     # library functions, since `wasmImports` acts as the global symbol table.
-    wasm_exports = set(metadata.exports)
+    wasm_exports = set(metadata.function_exports)
     library_symbols = set(library_symbols)
     if settings.MAIN_MODULE == 1:
       for f in library_symbols:
@@ -746,9 +739,6 @@ def make_export_wrappers(exports, delay_assignment):
     return True
 
   for name in exports:
-    # Tags cannot be wrapped in createExportWrapper
-    if name == '__cpp_exception':
-      continue
     mangled = asmjs_mangle(name)
     wrapper = '/** @type {function(...*):?} */\nvar %s = ' % mangled
 
@@ -913,7 +903,7 @@ function applySignatureConversions(exports) {
 
   sigs_seen = set()
   wrap_functions = []
-  for symbol in metadata.exports:
+  for symbol in metadata.function_exports:
     sig = mapping.get(symbol)
     if sig:
       if settings.MEMORY64:

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -16,8 +16,8 @@
 // underscore.
 var WASM_EXPORTS = [];
 
-// Similar to above but only includes the functions symbols.
-var WASM_FUNCTION_EXPORTS = [];
+// Similar to above but only includes the global/data symbols.
+var WASM_GLOBAL_EXPORTS = [];
 
 // An array of all symbols exported from all the side modules specified on the
 // command line.

--- a/tools/building.py
+++ b/tools/building.py
@@ -517,9 +517,9 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
   # Closure compiler needs to know about all exports that come from the wasm module, because to optimize for small code size,
   # the exported symbols are added to global scope via a foreach loop in a way that evades Closure's static analysis. With an explicit
   # externs file for the exports, Closure is able to reason about the exports.
-  if settings.WASM_FUNCTION_EXPORTS and not settings.DECLARE_ASM_MODULE_EXPORTS:
+  if settings.WASM_EXPORTS and not settings.DECLARE_ASM_MODULE_EXPORTS:
     # Generate an exports file that records all the exported symbols from the wasm module.
-    module_exports_suppressions = '\n'.join(['/**\n * @suppress {duplicate, undefinedVars}\n */\nvar %s;\n' % asmjs_mangle(i) for i in settings.WASM_FUNCTION_EXPORTS])
+    module_exports_suppressions = '\n'.join(['/**\n * @suppress {duplicate, undefinedVars}\n */\nvar %s;\n' % asmjs_mangle(i) for i in settings.WASM_EXPORTS])
     exports_file = shared.get_temp_files().get('.js', prefix='emcc_module_exports_')
     exports_file.write(module_exports_suppressions.encode())
     exports_file.close()
@@ -722,7 +722,8 @@ def metadce(js_file, wasm_file, minify_whitespace, debug_info):
     # will take precedence.
     exports = settings.WASM_EXPORTS
   else:
-    exports = settings.WASM_FUNCTION_EXPORTS
+    # Ignore exported wasm globals.  Those get inlined directly into the JS code.
+    exports = sorted(set(settings.WASM_EXPORTS) - set(settings.WASM_GLOBAL_EXPORTS))
 
   extra_info = '{ "exports": [' + ','.join(f'["{asmjs_mangle(x)}", "{x}"]' for x in exports) + ']}'
 
@@ -735,21 +736,6 @@ def metadce(js_file, wasm_file, minify_whitespace, debug_info):
       export = asmjs_mangle(item['export'])
       if settings.EXPORT_ALL or export in required_symbols:
         item['root'] = True
-  # in standalone wasm, always export the memory
-  if not settings.IMPORTED_MEMORY:
-    graph.append({
-      'export': 'memory',
-      'name': 'emcc$export$memory',
-      'reaches': [],
-      'root': True
-    })
-  if not settings.RELOCATABLE:
-    graph.append({
-      'export': '__indirect_function_table',
-      'name': 'emcc$export$__indirect_function_table',
-      'reaches': [],
-      'root': True
-    })
   # fix wasi imports TODO: support wasm stable with an option?
   WASI_IMPORTS = {
     'environ_get',

--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -247,8 +247,8 @@ def get_named_globals(module, exports):
   return named_globals
 
 
-def get_export_names(module):
-  return [e.name for e in module.get_exports() if e.kind in [webassembly.ExternType.FUNC, webassembly.ExternType.TAG]]
+def get_function_exports(module):
+  return [e.name for e in module.get_exports() if e.kind == webassembly.ExternType.FUNC]
 
 
 def update_metadata(filename, metadata):
@@ -264,7 +264,8 @@ def update_metadata(filename, metadata):
       elif i.kind in (webassembly.ExternType.GLOBAL, webassembly.ExternType.TAG):
         imports.append(i.field)
 
-    metadata.exports = get_export_names(module)
+    metadata.function_exports = get_function_exports(module)
+    metadata.all_exports = [utils.removeprefix(e.name, '__em_js__') for e in module.get_exports()]
 
   metadata.imports = imports
   metadata.invokeFuncs = invoke_funcs
@@ -333,7 +334,8 @@ def extract_metadata(filename):
     # calls __original_main (which has no parameters).
     metadata = Metadata()
     metadata.imports = import_names
-    metadata.exports = get_export_names(module)
+    metadata.function_exports = get_function_exports(module)
+    metadata.all_exports = [utils.removeprefix(e.name, '__em_js__') for e in exports]
     metadata.asmConsts = get_section_strings(module, export_map, 'em_asm')
     metadata.jsDeps = [d for d in get_section_strings(module, export_map, 'em_lib_deps').values() if d]
     metadata.emJsFuncs = em_js_funcs

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -628,7 +628,7 @@ def is_c_symbol(name):
   return name.startswith('_') or name in settings.WASM_SYSTEM_EXPORTS
 
 
-def treat_as_user_function(name):
+def treat_as_user_export(name):
   if name.startswith('dynCall_'):
     return False
   if name in settings.WASM_SYSTEM_EXPORTS:
@@ -646,7 +646,7 @@ def asmjs_mangle(name):
   # to simply `main` which is expected by the emscripten JS glue code.
   if name == '__main_argc_argv':
     name = 'main'
-  if treat_as_user_function(name):
+  if treat_as_user_export(name):
     return '_' + name
   return name
 


### PR DESCRIPTION
Back in #17064 we added tags to `metadata.exports`, which previously        
contained only functions.  However, emscripten.py makes wrapper functions
for each element of this list which is not desirable for tag exports.       

This change makes things more explicit by calling this                   
`function_exports` and creating a new `metadata.all_exports`.            

We can also now be more precise when creating the metadce graph and         
include all exports (except wasm globals which are just constants),         
which in turn allows us to remove the hardcoded handling for the table   
and memory export.                                                       

This should be a minor code size saving for wasm-exceptions-using        
programs since we no longer generate the needless function wrapper for   
the tag.  
