### PR TITLE
Automatically convert pointer args for wasmfs funcs. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -903,6 +903,8 @@ def create_pointer_conversion_wrappers(metadata):
     '_emscripten_proxy_dlsync_async': '_pp',
     '_wasmfs_rmdir': '_p',
     '_wasmfs_unlink': '_p',
+    '_wasmfs_mkdir': '_p_',
+    '_wasmfs_open': '_p__',
     'emscripten_wasm_worker_initialize': '_p_',
   }
 

--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -148,7 +148,7 @@ FS.createPreloadedFile = FS_createPreloadedFile;
     mkdir: (path, mode) => FS.handleError(withStackSave(() => {
       mode = mode !== undefined ? mode : 511 /* 0777 */;
       var buffer = stringToUTF8OnStack(path);
-      return __wasmfs_mkdir({{{ to64('buffer') }}}, mode);
+      return __wasmfs_mkdir(buffer, mode);
     })),
     mkdirTree: (path, mode) => {
       var dirs = path.split('/');
@@ -170,7 +170,7 @@ FS.createPreloadedFile = FS_createPreloadedFile;
       flags = typeof flags == 'string' ? FS_modeStringToFlags(flags) : flags;
       mode = typeof mode == 'undefined' ? 438 /* 0666 */ : mode;
       var buffer = stringToUTF8OnStack(path);
-      var fd = FS.handleError(__wasmfs_open({{{ to64('buffer') }}}, flags, mode));
+      var fd = FS.handleError(__wasmfs_open(buffer, flags, mode));
       return { fd : fd };
     }),
     create: (path, mode) => {


### PR DESCRIPTION
We really should find a way for folks to attach this metadata to native functions in the source code.