### PR TITLE
JSPI - Cleanup up testing code.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -656,6 +656,10 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       self.fail('either d8 or node >= 16 required to run wasm-eh tests.  Use EMTEST_SKIP_EH to skip')
 
   def require_jspi(self):
+    # emcc warns about stack switching being experimental, and we build with
+    # warnings-as-errors, so disable that warning
+    self.emcc_args += ['-Wno-experimental']
+    self.emcc_args += ['-sASYNCIFY=2']
     if not self.is_wasm():
       self.skipTest('JSPI is not currently supported for WASM2JS')
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -190,11 +190,6 @@ def with_asyncify_and_jspi(f):
     if jspi:
       self.set_setting('ASYNCIFY', 2)
       self.require_jspi()
-      if not self.is_wasm():
-        self.skipTest('wasm2js does not support WebAssembly.Suspender yet')
-      # emcc warns about stack switching being experimental, and we build with
-      # warnings-as-errors, so disable that warning
-      self.emcc_args += ['-Wno-experimental']
       f(self)
     else:
       self.set_setting('ASYNCIFY')
@@ -8253,7 +8248,6 @@ Module.onRuntimeInitialized = () => {
   def test_async_ccall_promise(self, exit_runtime, asyncify):
     if asyncify == 2:
       self.require_jspi()
-      self.emcc_args += ['-Wno-experimental']
       self.set_setting('ASYNCIFY_EXPORTS', ['stringf', 'floatf'])
     self.set_setting('ASYNCIFY', asyncify)
     self.set_setting('EXIT_RUNTIME')
@@ -8431,11 +8425,9 @@ Module.onRuntimeInitialized = () => {
     # TODO Test with ASYNCIFY=1 https://github.com/emscripten-core/emscripten/issues/17552
     self.require_jspi()
     self.do_runf(test_file('core/test_pthread_join_and_asyncify.c'), 'joining thread!\njoined thread!',
-                 emcc_args=['-sASYNCIFY=2',
-                            '-sASYNCIFY_EXPORTS=run_thread',
+                 emcc_args=['-sASYNCIFY_EXPORTS=run_thread',
                             '-sEXIT_RUNTIME=1',
-                            '-pthread', '-sPROXY_TO_PTHREAD',
-                            '-Wno-experimental'])
+                            '-pthread', '-sPROXY_TO_PTHREAD'])
 
   @no_asan('asyncify stack operations confuse asan')
   @no_wasm64('TODO: asyncify for wasm64')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2744,9 +2744,8 @@ int f() {
     'no_dynamic': ['-sDYNAMIC_EXECUTION=0'],
   })
   def test_embind_jspi(self, extra):
-    self.require_v8()
-    self.v8_args.append('--experimental-wasm-stack-switching')
-    self.emcc_args += ['-lembind', '-g', '-sASYNCIFY=2', '-Wno-experimental']
+    self.require_jspi()
+    self.emcc_args += ['-lembind', '-g']
     self.emcc_args += [extra]
 
     self.do_runf(test_file('embind/embind_jspi_test.cpp'), 'done')
@@ -2869,9 +2868,8 @@ int f() {
     self.assertNotContained('Foo* destructed', output)
 
   def test_jspi_wildcard(self):
-    self.require_v8()
-    self.v8_args.append('--experimental-wasm-stack-switching')
-    self.emcc_args += ['-sASYNCIFY=2', '-sASYNCIFY_EXPORTS=async*', '-Wno-experimental']
+    self.require_jspi()
+    self.emcc_args += ['-sASYNCIFY_EXPORTS=async*']
 
     self.do_runf(test_file('other/test_jspi_wildcard.c'), 'done')
 
@@ -6677,9 +6675,7 @@ int main(int argc,char** argv) {
     if asyncify:
       self.set_setting('ASYNCIFY', asyncify)
       if asyncify == 2:
-        self.emcc_args.append('-Wno-experimental')
-        self.require_v8()
-        self.v8_args.append('--experimental-wasm-stack-switching')
+        self.require_jspi()
     self.emcc_args.append('libside.so')
     self.do_other_test('test_dlopen_blocking.c')
 
@@ -11803,9 +11799,8 @@ exec "$@"
     if customLoader:
       self.emcc_args += ['--pre-js', test_file('other/test_load_split_module.pre.js')]
     if jspi:
-      self.require_v8()
-      self.v8_args.append('--experimental-wasm-stack-switching')
-      self.emcc_args += ['-g', '-sASYNCIFY=2', '-sASYNCIFY_EXPORTS=[\'say_hello\']']
+      self.require_jspi()
+      self.emcc_args += ['-g', '-sASYNCIFY_EXPORTS=[\'say_hello\']']
     self.emcc_args += ['-sEXPORTED_FUNCTIONS=_malloc,_free']
     output = self.do_other_test('test_split_module.c')
     if jspi:


### PR DESCRIPTION
 - Automatically suppress the experimental warning when using require_jspi
 - Use require_jspi instead of require_v8 in more places