### PR TITLE
Allow `-target` to be specified on the command line. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13561,3 +13561,17 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
   @also_with_standalone_wasm()
   def test_console_out(self):
     self.do_other_test('test_console_out.c')
+
+  @requires_wasm64
+  def test_explicit_target(self):
+    self.do_runf(test_file('hello_world.c'), emcc_args=['-target', 'wasm32'])
+    self.do_runf(test_file('hello_world.c'), emcc_args=['-target', 'wasm64-unknown-emscripten', '-Wno-experimental'])
+
+    self.do_runf(test_file('hello_world.c'), emcc_args=['--target=wasm32'])
+    self.do_runf(test_file('hello_world.c'), emcc_args=['--target=wasm64-unknown-emscripten', '-Wno-experimental'])
+
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-target', 'wasm32', '-sMEMORY64'])
+    self.assertContained('emcc: error: wasm32 target is not compatible with -sMEMORY64', err)
+
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '--target=arm64'])
+    self.assertContained('emcc: error: unsupported target: arm64 (emcc only supports wasm64-unknown-emscripten and wasm32-unknown-emscripten', err)


### PR DESCRIPTION
This makes `-target wasm64` work and imply `-sMEMORY64`.

Supporting these flags makes us more compatible with upstream clang and with wasi-sdk.

See #19834