### PR TITLE
Rename `asm` to `wasmExports` under MINIMAL_RUNTIME

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -49,7 +49,7 @@ def compute_minimal_runtime_initializer_and_exports(post, exports, receiving):
   declares = 'var ' + ',\n '.join(exports_that_are_not_initializers) + ';'
   post = shared.do_replace(post, '<<< WASM_MODULE_EXPORTS_DECLARES >>>', declares)
 
-  # Generate assignments from all wasm exports out to the JS variables above: e.g. a = asm['a']; b = asm['b'];
+  # Generate assignments from all wasm exports out to the JS variables above: e.g. a = wasmExports['a']; b = wasmExports['b'];
   post = shared.do_replace(post, '<<< WASM_MODULE_EXPORTS >>>', receiving)
   return post
 
@@ -778,8 +778,8 @@ def create_receiving(function_exports):
       # existing in top level JS scope, i.e.
       # var _main;
       # WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
-      #   var asm = output.instance.exports;
-      #   _main = asm["_main"];
+      #   var wasmExports = output.instance.exports;
+      #   _main = wasmExports["_main"];
       generate_dyncall_assignment = settings.DYNCALLS and '$dynCall' in settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE
       exports_that_are_not_initializers = [x for x in function_exports if x != building.WASM_CALL_CTORS]
 
@@ -790,7 +790,7 @@ def create_receiving(function_exports):
         export_assignment = ''
         if settings.MODULARIZE and should_export:
           export_assignment = f"Module['{mangled}'] = "
-        receiving += [f'{export_assignment}{dynCallAssignment}{mangled} = asm["{s}"]']
+        receiving += [f'{export_assignment}{dynCallAssignment}{mangled} = wasmExports["{s}"]']
     else:
       receiving += make_export_wrappers(function_exports, delay_assignment)
   else:

--- a/src/library.js
+++ b/src/library.js
@@ -2983,7 +2983,7 @@ mergeInto(LibraryManager.library, {
   // When DECLARE_ASM_MODULE_EXPORTS is not set we export native symbols
   // at runtime rather than statically in JS code.
   $exportAsmFunctions__deps: ['$asmjsMangle'],
-  $exportAsmFunctions: (asm) => {
+  $exportAsmFunctions: (wasmExports) => {
 #if ENVIRONMENT_MAY_BE_NODE && ENVIRONMENT_MAY_BE_WEB
     var global_object = (typeof process != "undefined" ? global : this);
 #elif ENVIRONMENT_MAY_BE_NODE
@@ -2992,12 +2992,12 @@ mergeInto(LibraryManager.library, {
     var global_object = this;
 #endif
 
-    for (var __exportedFunc in asm) {
+    for (var __exportedFunc in wasmExports) {
       var jsname = asmjsMangle(__exportedFunc);
 #if MINIMAL_RUNTIME
-      global_object[jsname] = asm[__exportedFunc];
+      global_object[jsname] = wasmExports[__exportedFunc];
 #else
-      global_object[jsname] = Module[jsname] = asm[__exportedFunc];
+      global_object[jsname] = Module[jsname] = wasmExports[__exportedFunc];
 #endif
     }
 

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -533,7 +533,7 @@ mergeInto(LibraryManager.library, {
       // Add a callback for when all run dependencies are fulfilled, which happens when async wasm loading is done.
       dependenciesFulfilled = wakeUp;
       // Load the new wasm.
-      asm = createWasm();
+      createWasm();
     });
   },
 

--- a/src/library_exports.js
+++ b/src/library_exports.js
@@ -12,12 +12,7 @@ mergeInto(LibraryManager.library, {
     // Wasm backend does not use C name mangling on exports,
     // so adjust for that manually.
     if (name[0] == '_') name = name.substr(1);
-#if MINIMAL_RUNTIME
-    var exportedFunc = asm[name];
-#else
-    // In regular runtime, exports are available on the Module object.
     var exportedFunc = wasmExports[name];
-#endif
     if (exportedFunc) {
       // Record the created function pointer to each function object,
       // so that if the same function pointer is obtained several times,
@@ -26,7 +21,7 @@ mergeInto(LibraryManager.library, {
       return exportedFunc.ptr;
     }
 #if ASSERTIONS
-    err('No exported function found by name "' + exportedFunc + '"');
+    err(`No exported function found by name "{exportedFunc}"`);
 #endif
     // implicit return 0;
   }

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -48,7 +48,7 @@ function run() {
 }
 #endif
 
-function initRuntime(asm) {
+function initRuntime(wasmExports) {
 #if ASSERTIONS || SAFE_HEAP || USE_ASAN
   runtimeInitialized = true;
 #endif
@@ -77,11 +77,11 @@ function initRuntime(asm) {
 #endif
 
 #if PTHREADS
-  PThread.tlsInitFunctions.push(asm['_emscripten_tls_init']);
+  PThread.tlsInitFunctions.push(wasmExports['_emscripten_tls_init']);
 #endif
 
 #if hasExportedSymbol('__wasm_call_ctors')
-  asm['__wasm_call_ctors']();
+  wasmExports['__wasm_call_ctors']();
 #endif
 
   <<< ATINITS >>>
@@ -101,7 +101,7 @@ var imports = {
 // In non-fastcomp non-asm.js builds, grab wasm exports to outer scope
 // for emscripten_get_exported_function() to be able to access them.
 #if LibraryManager.has('library_exports.js')
-var asm;
+var wasmExports;
 #endif
 
 #if PTHREADS
@@ -142,7 +142,7 @@ WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
 
 #if !LibraryManager.has('library_exports.js') && !EMBIND
   // If not using the emscripten_get_exported_function() API or embind, keep the
-  // `asm` exports variable in local scope to this instantiate function to save
+  // `wasmExports` variable in local scope to this instantiate function to save
   // code size.  (otherwise access it without to export it to outer scope)
   var
 #endif
@@ -163,16 +163,16 @@ WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
   // that case, 'output' is a WebAssembly.Instance.
   // In main thread, Module['wasm'] is either a typed array or a fetch stream.
   // In that case, 'output.instance' is the WebAssembly.Instance.
-  asm = (output.instance || output).exports;
+  wasmExports = (output.instance || output).exports;
 #else
-  asm = output.exports;
+  wasmExports = output.exports;
 #endif
 #else
-  asm = output.instance.exports;
+  wasmExports = output.instance.exports;
 #endif
 
 #if MEMORY64 || CAN_ADDRESS_2GB
-  asm = applySignatureConversions(asm);
+  wasmExports = applySignatureConversions(wasmExports);
 #endif
 
 #if USE_OFFSET_CONVERTER
@@ -183,11 +183,11 @@ WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
 #endif
 
 #if !DECLARE_ASM_MODULE_EXPORTS
-  exportAsmFunctions(asm);
+  exportAsmFunctions(wasmExports);
 #else
   <<< WASM_MODULE_EXPORTS >>>
 #endif
-  wasmTable = asm['__indirect_function_table'];
+  wasmTable = wasmExports['__indirect_function_table'];
 #if ASSERTIONS
   assert(wasmTable);
 #endif
@@ -211,7 +211,7 @@ WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
 #endif
 
 #if !IMPORTED_MEMORY
-  wasmMemory = asm['memory'];
+  wasmMemory = wasmExports['memory'];
 #if ASSERTIONS
   assert(wasmMemory);
   assert(wasmMemory.buffer.byteLength === {{{ INITIAL_MEMORY }}});
@@ -226,7 +226,7 @@ WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
   HEAPU8.set(new Uint8Array(Module['mem']), {{{ GLOBAL_BASE }}});
 #endif
 
-  initRuntime(asm);
+  initRuntime(wasmExports);
 #if PTHREADS
   // Export Wasm module for pthread creation to access.
   wasmModule = output.module || Module['wasm'];

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -53,9 +53,7 @@ function missingGlobal(sym, msg) {
 }
 
 missingGlobal('buffer', 'Please use HEAP8.buffer or wasmMemory.buffer');
-#if !MINIMAL_RUNTIME
 missingGlobal('asm', 'Please use wasmExports instead');
-#endif
 
 function missingLibrarySymbol(sym) {
   if (typeof globalThis !== 'undefined' && !Object.getOwnPropertyDescriptor(globalThis, sym)) {

--- a/test/optimizer/applyDCEGraphRemovals-output.js
+++ b/test/optimizer/applyDCEGraphRemovals-output.js
@@ -5,15 +5,15 @@ var wasmImports = {
  save2: 2
 };
 
-var expD1 = Module["expD1"] = asm["expD1"];
+var expD1 = Module["expD1"] = wasmExports["expD1"];
 
-var expD2 = Module["expD2"] = asm["expD2"];
+var expD2 = Module["expD2"] = wasmExports["expD2"];
 
-var expD3 = Module["expD3"] = asm["expD3"];
+var expD3 = Module["expD3"] = wasmExports["expD3"];
 
 var expD4;
 
-var expD5 = asm["expD5"];
+var expD5 = wasmExports["expD5"];
 
 var expD6;
 
@@ -33,10 +33,10 @@ expD1;
 
 Module["expD2"];
 
-asm["expD3"];
+wasmExports["expD3"];
 
 expI1;
 
 Module["expI2"];
 
-asm["expI3"];
+wasmExports["expI3"];

--- a/test/optimizer/applyDCEGraphRemovals.js
+++ b/test/optimizer/applyDCEGraphRemovals.js
@@ -2,13 +2,13 @@ var name;
 var wasmImports = { save1: 1, number: 33, name: name, func: function() {}, save2: 2 };
 
 // exports gotten directly
-var expD1 = Module['expD1'] = asm['expD1'];
-var expD2 = Module['expD2'] = asm['expD2'];
-var expD3 = Module['expD3'] = asm['expD3'];
-var expD4 = Module['expD4'] = asm['expD4'];
+var expD1 = Module['expD1'] = wasmExports['expD1'];
+var expD2 = Module['expD2'] = wasmExports['expD2'];
+var expD3 = Module['expD3'] = wasmExports['expD3'];
+var expD4 = Module['expD4'] = wasmExports['expD4'];
 // Like above, but not exported on the Module
-var expD5 = asm['expD5'];
-var expD6 = asm['expD6'];
+var expD5 = wasmExports['expD5'];
+var expD6 = wasmExports['expD6'];
 
 // exports gotten indirectly (async compilation
 var expI1 = Module['expI1'] = () => (expI1 = Module['expI1'] = wasmExports['expI1'])();
@@ -23,10 +23,10 @@ var expI6 = () => (expI6 = wasmExports['expI6'])();
 // add uses for some of them, leave *4 as non-roots
 expD1;
 Module['expD2'];
-asm['expD3'];
+wasmExports['expD3'];
 
 expI1;
 Module['expI2'];
-asm['expI3'];
+wasmExports['expI3'];
 
 // EXTRA_INFO: { "unused": ["emcc$import$number", "emcc$import$name", "emcc$import$func", "emcc$export$expD4", "emcc$export$expD6", "emcc$export$expI4", "emcc$export$expI6"] }

--- a/test/optimizer/applyImportAndExportNameChanges-output.js
+++ b/test/optimizer/applyImportAndExportNameChanges-output.js
@@ -14,7 +14,7 @@ var wasmImports = {
  q: ___syscall146
 };
 
-var expD1 = Module["expD1"] = asm["c"];
+var expD1 = Module["expD1"] = wasmExports["c"];
 
 var expI1 = Module["expI1"] = function() {
  return wasmExports["d"].apply(null, arguments);

--- a/test/optimizer/applyImportAndExportNameChanges.js
+++ b/test/optimizer/applyImportAndExportNameChanges.js
@@ -14,7 +14,7 @@ var wasmImports = {
 };
 
 // exports
-var expD1 = Module['expD1'] = asm['expD1'];
+var expD1 = Module['expD1'] = wasmExports['expD1'];
 
 // exports gotten indirectly (async compilation
 var expI1 = Module['expI1'] = (function() {

--- a/test/optimizer/applyImportAndExportNameChanges2-output.js
+++ b/test/optimizer/applyImportAndExportNameChanges2-output.js
@@ -227,8 +227,8 @@ function run() {
  var ret = _main();
 }
 
-function initRuntime(asm) {
- asm["i"]();
+function initRuntime(wasmExports) {
+ wasmExports["i"]();
 }
 
 var env = wasmImports;
@@ -265,14 +265,14 @@ var imports = {
 var ___errno_location, _llvm_bswap_i32, _main, _memcpy, _memset, dynCall_ii, dynCall_iiii;
 
 WebAssembly.instantiate(Module["wasm"], imports).then(output => {
- var asm = output.instance.exports;
- ___errno_location = asm["j"];
- _llvm_bswap_i32 = asm["k"];
- _main = asm["l"];
- _memcpy = asm["m"];
- _memset = asm["n"];
- dynCall_ii = asm["o"];
- dynCall_iiii = asm["p"];
- initRuntime(asm);
+ var wasmExports = output.instance.exports;
+ ___errno_location = wasmExports["j"];
+ _llvm_bswap_i32 = wasmExports["k"];
+ _main = wasmExports["l"];
+ _memcpy = wasmExports["m"];
+ _memset = wasmExports["n"];
+ dynCall_ii = wasmExports["o"];
+ dynCall_iiii = wasmExports["p"];
+ initRuntime(wasmExports);
  ready();
 });

--- a/test/optimizer/applyImportAndExportNameChanges2.js
+++ b/test/optimizer/applyImportAndExportNameChanges2.js
@@ -218,8 +218,8 @@ function run() {
     var ret = _main()
 }
 
-function initRuntime(asm) {
-    asm["__GLOBAL__sub_I_test_global_initializer_cpp"]()
+function initRuntime(wasmExports) {
+    wasmExports["__GLOBAL__sub_I_test_global_initializer_cpp"]()
 }
 var env = wasmImports;
 env["memory"] = wasmMemory;
@@ -248,15 +248,15 @@ var imports = {
 };
 var ___errno_location, _llvm_bswap_i32, _main, _memcpy, _memset, dynCall_ii, dynCall_iiii;
 WebAssembly.instantiate(Module["wasm"], imports).then(((output) => {
-    var asm = output.instance.exports;
-    ___errno_location = asm["___errno_location"];
-    _llvm_bswap_i32 = asm["_llvm_bswap_i32"];
-    _main = asm["_main"];
-    _memcpy = asm["_memcpy"];
-    _memset = asm["_memset"];
-    dynCall_ii = asm["dynCall_ii"];
-    dynCall_iiii = asm["dynCall_iiii"];
-    initRuntime(asm);
+    var wasmExports = output.instance.exports;
+    ___errno_location = wasmExports["___errno_location"];
+    _llvm_bswap_i32 = wasmExports["_llvm_bswap_i32"];
+    _main = wasmExports["_main"];
+    _memcpy = wasmExports["_memcpy"];
+    _memset = wasmExports["_memset"];
+    dynCall_ii = wasmExports["dynCall_ii"];
+    dynCall_iiii = wasmExports["dynCall_iiii"];
+    initRuntime(wasmExports);
     ready()
 }))
 

--- a/test/optimizer/emitDCEGraph.js
+++ b/test/optimizer/emitDCEGraph.js
@@ -45,12 +45,12 @@ var wasmImports = {
 };
 
 // exports gotten directly
-var expD1 = Module['expD1'] = asm['expD1'];
-var expD2 = Module['expD2'] = asm['expD2'];
-var expD3 = Module['expD3'] = asm['expD3'];
-var expD4 = Module['expD4'] = asm['expD4'];
+var expD1 = Module['expD1'] = wasmExports['expD1'];
+var expD2 = Module['expD2'] = wasmExports['expD2'];
+var expD3 = Module['expD3'] = wasmExports['expD3'];
+var expD4 = Module['expD4'] = wasmExports['expD4'];
 // Same as above but not export on the Module
-var expD5 = asm['expD5'];
+var expD5 = wasmExports['expD5'];
 
 // exports gotten indirectly (async compilation
 var expI1 = Module['expI1'] = () => (expI1 = Module['expI1'] = wasmExports['expI1'])();
@@ -64,7 +64,7 @@ var expI5 = () => (expI5 = wasmExports['expI5'])();
 // add uses for some of them
 expD1;
 Module['expD2'];
-asm['expD3'];
+wasmExports['expD3'];
 
 expI1;
 Module['expI2'];

--- a/test/optimizer/minimal-runtime-2-emitDCEGraph.js
+++ b/test/optimizer/minimal-runtime-2-emitDCEGraph.js
@@ -64,11 +64,11 @@ var imports = {
   })
  }
 };
-var _main, _unused, asm;
+var _main, _unused, wasmExports;
 WebAssembly.instantiate(Module["wasm"], imports).then(((output) => {
- asm = output.instance.exports;
- _main = asm["b"];
- _unused = asm["c"];
+ wasmExports = output.instance.exports;
+ _main = wasmExports["b"];
+ _unused = wasmExports["c"];
  initRuntime();
  ready();
 }));

--- a/test/optimizer/minimal-runtime-applyDCEGraphRemovals-output.js
+++ b/test/optimizer/minimal-runtime-applyDCEGraphRemovals-output.js
@@ -6,11 +6,11 @@ var wasmImports = {
 };
 
 WebAssembly.instantiate(Module["wasm"], imports).then(output => {
- asm = output.instance.exports;
- expD1 = asm["expD1"];
- expD2 = asm["expD2"];
- expD3 = asm["expD3"];
- initRuntime(asm);
+ wasmExports = output.instance.exports;
+ expD1 = wasmExports["expD1"];
+ expD2 = wasmExports["expD2"];
+ expD3 = wasmExports["expD3"];
+ initRuntime(wasmExports);
  ready();
 });
 
@@ -18,4 +18,4 @@ expD1;
 
 Module["expD2"];
 
-asm["expD3"];
+wasmExports["expD3"];

--- a/test/optimizer/minimal-runtime-applyDCEGraphRemovals.js
+++ b/test/optimizer/minimal-runtime-applyDCEGraphRemovals.js
@@ -3,18 +3,18 @@ var wasmImports = { save1: 1, number: 33, name: name, func: function() {}, save2
 
 // exports gotten directly in the minimal runtime style
 WebAssembly.instantiate(Module["wasm"], imports).then((output) => {
- asm = output.instance.exports;
- expD1 = asm['expD1'];
- expD2 = asm['expD2'];
- expD3 = asm['expD3'];
- expD4 = asm['expD4'];
- initRuntime(asm);
+ wasmExports = output.instance.exports;
+ expD1 = wasmExports['expD1'];
+ expD2 = wasmExports['expD2'];
+ expD3 = wasmExports['expD3'];
+ expD4 = wasmExports['expD4'];
+ initRuntime(wasmExports);
  ready();
 });
 
 // add uses for some of them, leave *4 as non-roots
 expD1;
 Module['expD2'];
-asm['expD3'];
+wasmExports['expD3'];
 
 // EXTRA_INFO: { "unused": ["emcc$import$number", "emcc$import$name", "emcc$import$func", "emcc$export$expD4", "emcc$export$expI4"] }

--- a/test/optimizer/minimal-runtime-emitDCEGraph.js
+++ b/test/optimizer/minimal-runtime-emitDCEGraph.js
@@ -66,9 +66,9 @@ var imports = {
 };
 var _main, _unused;
 WebAssembly.instantiate(Module["wasm"], imports).then(((output) => {
- var asm = output.instance.exports;
- _main = asm["b"];
- _unused = asm["c"];
+ var wasmExports = output.instance.exports;
+ _main = wasmExports["b"];
+ _unused = wasmExports["c"];
  initRuntime();
  ready();
 }));

--- a/tools/emdump.py
+++ b/tools/emdump.py
@@ -303,7 +303,7 @@ def analyze_javascript_file_contents(filename, file_contents, total_source_set_s
         end_brace = file_contents.find(';', var_pos)
         minified_name = var_match.group(1)
 
-      # Special case ignore the 'var asm = (function(global, env, buffer) { 'use asm'; ... }; ' variable that contains all the asm.js code.
+      # Special case ignore the 'var wasmExports = (function(global, env, buffer) { 'use asm'; ... }; ' variable that contains all the asm.js code.
       # Ignoring this variable lets all the asm.js code be trated as functions in this parser, instead of assigning them to the asm variable.
       if file_contents[start_brace] == '(' and ("'use asm'" in file_contents[var_pos:end_brace] or '"use asm"' in file_contents[var_pos:end_brace] or "'almost asm'" in file_contents[var_pos:end_brace] or '"almost asm"' in file_contents[var_pos:end_brace]):
         continue


### PR DESCRIPTION
This matches the name used by the regualar runtime as of #19816 and removes one of them major differences between the two runtimes.