### PR TITLE
Fix webidl closure compiler warnings

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7745,8 +7745,6 @@ void* operator new(size_t size) {
   })
   def test_webidl(self, mode, allow_memory_growth):
     self.uses_es6 = True
-    # TODO(): Remove once we make webidl output closure-warning free.
-    self.ldflags.append('-Wno-error=closure')
     self.set_setting('WASM_ASYNC_COMPILATION', 0)
     if self.maybe_closure():
       # avoid closure minified names competing with our test code in the global name space

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -737,6 +737,7 @@ for name in names:
 
     if m.readonly:
       mid_js += [r'''
+    /** @suppress {checkTypes} */
     Object.defineProperty(%s.prototype, '%s', { get: %s.prototype.%s });''' % (name, attr, name, get_name)]
     else:
       set_name = 'set_' + attr
@@ -753,6 +754,7 @@ for name in names:
                       const=m.getExtendedAttribute('Const'),
                       array_attribute=m.type.isArray())
       mid_js += [r'''
+    /** @suppress {checkTypes} */
     Object.defineProperty(%s.prototype, '%s', { get: %s.prototype.%s, set: %s.prototype.%s });''' % (name, attr, name, get_name, name, set_name)]
 
   if not interface.getExtendedAttribute('NoDelete'):


### PR DESCRIPTION
I couldn't figure out how to make this work without suppressing them.