### PR TITLE
Fix applySignatureConversions under -O3. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2427,7 +2427,7 @@ def phase_linker_setup(options, state, newargs):
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$unSign']
 
   if not settings.DECLARE_ASM_MODULE_EXPORTS:
-    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$exportAsmFunctions']
+    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$exportWasmSymbols']
 
   if settings.ALLOW_MEMORY_GROWTH:
     # Setting ALLOW_MEMORY_GROWTH turns off ABORTING_MALLOC, as in that mode we default to

--- a/emscripten.py
+++ b/emscripten.py
@@ -755,7 +755,7 @@ def make_export_wrappers(function_exports, delay_assignment):
 
 def create_receiving(function_exports):
   # When not declaring asm exports this section is empty and we instead programatically export
-  # symbols on the global object by calling exportAsmFunctions after initialization
+  # symbols on the global object by calling exportWasmSymbols after initialization
   if not settings.DECLARE_ASM_MODULE_EXPORTS:
     return ''
 
@@ -884,9 +884,12 @@ def create_pointer_conversion_wrappers(metadata):
   }
 
   wrappers = '''
-function applySignatureConversions(exports) {
+// Argument name here must shadow the `wasmExports` global so
+// that it is recognised by metadce and minify-import-export-names
+// passes.
+function applySignatureConversions(wasmExports) {
   // First, make a copy of the incoming exports object
-  exports = Object.assign({}, exports);
+  wasmExports = Object.assign({}, wasmExports);
 '''
 
   sigs_seen = set()
@@ -907,8 +910,8 @@ function applySignatureConversions(exports) {
 
   for f in wrap_functions:
     sig = mapping[f]
-    wrappers += f"\n  exports['{f}'] = makeWrapper_{sig}(exports['{f}']);"
-  wrappers += '\n  return exports\n}'
+    wrappers += f"\n  wasmExports['{f}'] = makeWrapper_{sig}(wasmExports['{f}']);"
+  wrappers += 'return wasmExports;\n}'
 
   return wrappers
 

--- a/src/library.js
+++ b/src/library.js
@@ -2972,8 +2972,8 @@ mergeInto(LibraryManager.library, {
 #if !DECLARE_ASM_MODULE_EXPORTS
   // When DECLARE_ASM_MODULE_EXPORTS is not set we export native symbols
   // at runtime rather than statically in JS code.
-  $exportAsmFunctions__deps: ['$asmjsMangle'],
-  $exportAsmFunctions: (wasmExports) => {
+  $exportWasmSymbols__deps: ['$asmjsMangle'],
+  $exportWasmSymbols: (wasmExports) => {
 #if ENVIRONMENT_MAY_BE_NODE && ENVIRONMENT_MAY_BE_WEB
     var global_object = (typeof process != "undefined" ? global : this);
 #elif ENVIRONMENT_MAY_BE_NODE

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -183,7 +183,7 @@ WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
 #endif
 
 #if !DECLARE_ASM_MODULE_EXPORTS
-  exportAsmFunctions(wasmExports);
+  exportWasmSymbols(wasmExports);
 #else
   <<< WASM_MODULE_EXPORTS >>>
 #endif

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1040,7 +1040,7 @@ function createWasm() {
 #if !DECLARE_ASM_MODULE_EXPORTS
     // If we didn't declare the asm exports as top level enties this function
     // is in charge of programatically exporting them on the global object.
-    exportAsmFunctions(exports);
+    exportWasmSymbols(exports);
 #endif
 
 #if PTHREADS || WASM_WORKERS

--- a/test/optimizer/emitDCEGraph-output.js
+++ b/test/optimizer/emitDCEGraph-output.js
@@ -1,5 +1,9 @@
 [
  {
+  "name": "emcc$defun$applySignatureConversions",
+  "reaches": []
+ },
+ {
   "name": "emcc$defun$rootedFunc1",
   "reaches": [],
   "root": true

--- a/test/optimizer/emitDCEGraph.js
+++ b/test/optimizer/emitDCEGraph.js
@@ -61,6 +61,11 @@ var expI4 = Module['expI4'] = () => (expI4 = Module['expI4'] = wasmExports['expI
 // Same as above but not export on the Module.
 var expI5 = () => (expI5 = wasmExports['expI5'])();
 
+function applySignatureConversions() {
+  // Wrapping functions should not constitute a usage
+  wasmExports['expI5'] = foo(wasmExports['expI5']);
+}
+
 // add uses for some of them
 expD1;
 Module['expD2'];

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12871,10 +12871,16 @@ int main() {
 
   # Smoketest for MEMORY64 setting.  Most of the testing of MEMORY64 is by way of the wasm64
   # variant of the core test suite.
+  @parameterized({
+    'O0': (['-O0'],),
+    'O1': (['-O1'],),
+    'O2': (['-O2'],),
+    'O3': (['-O3'],),
+    'Oz': (['-Oz'],),
+  })
   @requires_wasm64
-  def test_memory64(self):
-    for opt in ['-O0', '-O1', '-O2', '-O3']:
-      self.do_runf(test_file('hello_world.c'), 'hello, world', emcc_args=['-sMEMORY64', '-Wno-experimental', opt])
+  def test_memory64(self, args):
+    self.do_run_in_out_file_test(test_file('core/test_hello_argc.c'), args=['hello', 'world'], emcc_args=['-sMEMORY64', '-Wno-experimental'] + args)
 
   # Verfy that MAIN_MODULE=1 (which includes all symbols from all libraries)
   # works with -sPROXY_POSIX_SOCKETS and -Oz, both of which affect linking of

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -687,6 +687,14 @@ function emitDCEGraph(ast) {
       });
       foundWasmImportsAssign = true;
       emptyOut(node); // ignore this in the second pass; this does not root
+    } else if (node.type === 'AssignmentExpression') {
+      const target = node.left;
+      const value = node.right;
+      // Ignore assignment to the wasmExports object (as happens in
+      // applySignatureConversions).
+      if (isExportUse(target)) {
+        emptyOut(node);
+      }
     } else if (node.type === 'VariableDeclaration') {
       if (node.declarations.length === 1) {
         const item = node.declarations[0];


### PR DESCRIPTION
Prior to this change the applySignatureConversions function would not work when imports/exports are minified, which would cause wasm64 programs to fail when calling any native function that needs i64->i53 conversions.