### PR TITLE
Enable -sASYNCIFY + -sMEMORY64=2

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -639,8 +639,6 @@ def get_binaryen_passes():
   # safe heap must run before post-emscripten, so post-emscripten can apply the sbrk ptr
   if settings.SAFE_HEAP:
     passes += ['--safe-heap']
-  if settings.MEMORY64 == 2:
-    passes += ['--memory64-lowering']
   # sign-ext is enabled by default by llvm.  If the target browser settings don't support
   # this we lower it away here using a binaryen pass.
   if not feature_matrix.caniuse(feature_matrix.Feature.SIGN_EXT):
@@ -708,6 +706,9 @@ def get_binaryen_passes():
     passes += ['--pass-arg=jspi-exports@%s' % ','.join(settings.ASYNCIFY_EXPORTS)]
     if settings.SPLIT_MODULE:
       passes += ['--pass-arg=jspi-split-module']
+
+  if settings.MEMORY64 == 2:
+    passes += ['--memory64-lowering']
 
   if settings.BINARYEN_IGNORE_IMPLICIT_TRAPS:
     passes += ['--ignore-implicit-traps']
@@ -2441,8 +2442,6 @@ def phase_linker_setup(options, state, newargs):
     settings.JS_LIBRARIES.append((0, 'library_pthread_stub.js'))
 
   if settings.MEMORY64:
-    if settings.ASYNCIFY and settings.MEMORY64 == 2:
-      exit_with_error('MEMORY64=2 is not compatible with ASYNCIFY')
     # Any "pointers" passed to JS will now be i64's, in both modes.
     settings.WASM_BIGINT = 1
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2110,7 +2110,6 @@ int main() {
     self.set_setting('RETAIN_COMPILER_SETTINGS')
     self.do_runf(src, read_file(output).replace('waka', shared.EMSCRIPTEN_VERSION))
 
-  @no_wasm64l("wasm64l doesn't support asyncify")
   def test_emscripten_has_asyncify(self):
     src = r'''
       #include <stdio.h>
@@ -4028,7 +4027,6 @@ ok
       '''
     self.do_run(src, 'float: 42.\n')
 
-  @no_wasm64l("wasm64l doesn't support asyncify")
   @needs_dylink
   def test_dlfcn_asyncify(self):
     self.set_setting('ASYNCIFY')
@@ -8185,7 +8183,6 @@ int main() {
   def test_async_hello_v8(self):
     self.test_async_hello()
 
-  @no_wasm64l("wasm64l doesn't support asyncify")
   def test_async_ccall_bad(self):
     # check bad ccall use
     # needs to flush stdio streams
@@ -8244,7 +8241,6 @@ Module.onRuntimeInitialized = () => {
     self.emcc_args += ['--pre-js', 'pre.js']
     self.do_runf('main.c', 'HelloWorld')
 
-  @no_wasm64l("wasm64l doesn't support asyncify")
   @parameterized({
     'asyncify': (False, 1),
     'exit_runtime_asyncify': (True, 1),
@@ -8293,7 +8289,6 @@ Module.onRuntimeInitialized = () => {
     self.emcc_args += ['--pre-js', 'pre.js']
     self.do_runf('main.c', 'stringf: first\nsecond\n6.4')
 
-  @no_wasm64l("wasm64l doesn't support asyncify")
   def test_fibers_asyncify(self):
     self.set_setting('ASYNCIFY')
     self.maybe_closure()
@@ -8305,7 +8300,6 @@ Module.onRuntimeInitialized = () => {
     # test a program not using asyncify, but the pref is set
     self.do_core_test('test_hello_world.c')
 
-  @no_wasm64l("wasm64l doesn't support asyncify")
   @parameterized({
     'normal': ([], True),
     'removelist_a': (['-sASYNCIFY_REMOVE=["foo(int, double)"]'], False),
@@ -8344,7 +8338,6 @@ Module.onRuntimeInitialized = () => {
         binary = read_binary(filename)
         self.assertFalse(b'main' in binary)
 
-  @no_wasm64l("wasm64l doesn't support asyncify")
   @parameterized({
     'normal': ([], True),
     'ignoreindirect': (['-sASYNCIFY_IGNORE_INDIRECT'], False),
@@ -8362,7 +8355,6 @@ Module.onRuntimeInitialized = () => {
       if should_pass:
         raise
 
-  @no_wasm64l("wasm64l doesn't support asyncify")
   @needs_dylink
   def test_asyncify_side_module(self):
     self.set_setting('ASYNCIFY')
@@ -8392,13 +8384,11 @@ Module.onRuntimeInitialized = () => {
       }
     ''', 'before sleep\n42\n42\nafter sleep\n', header='void my_sleep(int);', force_c=True)
 
-  @no_wasm64l("wasm64l doesn't support asyncify")
   @no_asan('asyncify stack operations confuse asan')
   def test_emscripten_scan_registers(self):
     self.set_setting('ASYNCIFY')
     self.do_core_test('test_emscripten_scan_registers.cpp')
 
-  @no_wasm64l("wasm64l doesn't support asyncify")
   def test_asyncify_assertions(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('ASYNCIFY_IMPORTS', ['suspend'])
@@ -8407,7 +8397,6 @@ Module.onRuntimeInitialized = () => {
 
   @no_lsan('leaks asyncify stack during exit')
   @no_asan('leaks asyncify stack during exit')
-  @no_wasm64l("wasm64l doesn't support asyncify")
   def test_asyncify_during_exit(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('ASSERTIONS')
@@ -8426,7 +8415,6 @@ Module.onRuntimeInitialized = () => {
     self.do_core_test('test_hello_world.c')
 
   # Test that pthread_join works correctly with asyncify.
-  @no_wasm64l("wasm64l doesn't support asyncify")
   @requires_node_canary
   def test_pthread_join_and_asyncify(self):
     # TODO Test with ASYNCIFY=1 https://github.com/emscripten-core/emscripten/issues/17552
@@ -8436,7 +8424,6 @@ Module.onRuntimeInitialized = () => {
                             '-sEXIT_RUNTIME=1',
                             '-pthread', '-sPROXY_TO_PTHREAD'])
 
-  @no_wasm64l("wasm64l doesn't support asyncify")
   @no_asan('asyncify stack operations confuse asan')
   @no_wasm2js('TODO: lazy loading in wasm2js')
   @parameterized({


### PR DESCRIPTION
It turns out that simply running the memory64 lowering pass after the asyncify pass is enough to make this work.