### PR TITLE
WasmFS JS API: Make _wasmfs_readlink add a null-terminating byte

### DIFF
--- a/system/lib/wasmfs/js_api.cpp
+++ b/system/lib/wasmfs/js_api.cpp
@@ -150,10 +150,11 @@ int _wasmfs_symlink(char* old_path, char* new_path) {
 intptr_t _wasmfs_readlink(char* path) {
   static thread_local void* readBuf = nullptr;
   readBuf = realloc(readBuf, PATH_MAX);
-  int err = __syscall_readlinkat(AT_FDCWD, (intptr_t)path, (intptr_t)readBuf, PATH_MAX);
-  if (err < 0) {
-    return err;
+  int bytes = __syscall_readlinkat(AT_FDCWD, (intptr_t)path, (intptr_t)readBuf, PATH_MAX);
+  if (bytes < 0) {
+    return bytes;
   }
+  ((char*)readBuf)[bytes] = '\0';
   return (intptr_t)readBuf;
 }
 


### PR DESCRIPTION
Based on https://stackoverflow.com/questions/63321015/why-doesnt-readlink-return-a-null-terminated-value, https://stackoverflow.com/questions/12697788/does-stdstringc-str-always-return-a-null-terminated-string, and https://stackoverflow.com/questions/11752705/does-stdstring-have-a-null-terminator, `__syscall_readlinkat` should not append a null-terminating byte to the end of a string. This caused some errors when I was working on `FS.syncfs()` (https://github.com/emscripten-core/emscripten/pull/19903) and caused some tests to fail by including garbage memory. This PR adds a null-terminating byte in `_wasmfs_readlink` so calling `UTF8ToString` in `library_wasmfs.js` works correctly. One other approach I played with a bit was calling `UTF8ToString()` with `maxBytesToRead = [# of bytes from __syscall_readlinkat + 1]`. Is one approach preferred over the other?

I tried a few different tests but wasn't able to reproduce the exact case that discovered this error, since `FS.syncfs()` is still a work-in-progress. 