### PR TITLE
Fix test_file_packager_depfile under windows

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -4296,7 +4296,7 @@ class ScriptSource:
 
 def is_valid_abspath(options, path_name):
   # Any path that is underneath the emscripten repository root must be ok.
-  if utils.path_from_root().replace('\\', '/') in path_name.replace('\\', '/'):
+  if utils.normalize_path(path_name).startswith(utils.normalize_path(utils.path_from_root())):
     return True
 
   def in_directory(root, child):

--- a/test/common.py
+++ b/test/common.py
@@ -902,7 +902,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     inputfile = os.path.abspath(filename)
     # For some reason es-check requires unix paths, even on windows
     if WINDOWS:
-      inputfile = inputfile.replace('\\', '/')
+      inputfile = utils.normalize_path(inputfile)
     try:
       # es-check prints the details of the errors to stdout, but it also prints
       # stuff in the case there are no errors:
@@ -1114,8 +1114,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
   # Tests that the given two paths are identical, modulo path delimiters. E.g. "C:/foo" is equal to "C:\foo".
   def assertPathsIdentical(self, path1, path2):
-    path1 = path1.replace('\\', '/')
-    path2 = path2.replace('\\', '/')
+    path1 = utils.normalize_path(path1)
+    path2 = utils.normalize_path(path2)
     return self.assertIdentical(path1, path2)
 
   # Tests that the given two multiline text content are identical, modulo line

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -380,13 +380,13 @@ If manually bisecting:
 
     # Test subdirectory handling with asset packaging.
     delete_dir('assets')
-    ensure_dir('assets/sub/asset1/'.replace('\\', '/'))
-    ensure_dir('assets/sub/asset1/.git'.replace('\\', '/')) # Test adding directory that shouldn't exist.
-    ensure_dir('assets/sub/asset2/'.replace('\\', '/'))
+    ensure_dir('assets/sub/asset1')
+    ensure_dir('assets/sub/asset1/.git') # Test adding directory that shouldn't exist.
+    ensure_dir('assets/sub/asset2')
     create_file('assets/sub/asset1/file1.txt', '''load me right before running the code please''')
     create_file('assets/sub/asset1/.git/shouldnt_be_embedded.txt', '''this file should not get embedded''')
     create_file('assets/sub/asset2/file2.txt', '''load me right before running the code please''')
-    absolute_assets_src_path = 'assets'.replace('\\', '/')
+    absolute_assets_src_path = 'assets'
 
     def make_main_two_files(path1, path2, nonexistingpath):
       create_file('main.cpp', r'''

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3109,19 +3109,22 @@ int f() {
     output = self.run_js('a.out.js')
     self.assertContained('hello data', output)
 
+  @crossplatform
   def test_file_packager_depfile(self):
     create_file('data1.txt', 'data1')
     ensure_dir('subdir')
     create_file('subdir/data2.txt', 'data2')
 
     self.run_process([FILE_PACKAGER, 'test.data', '--js-output=test.js', '--depfile=test.data.d', '--from-emcc', '--preload', '.'])
-    lines = read_file('test.data.d').splitlines()
+    output = read_file('test.data.d')
+    file_packager = utils.normalize_path(shared.replace_suffix(FILE_PACKAGER, '.py'))
+    lines = output.splitlines()
     split = lines.index(': \\')
     before, after = set(lines[:split]), set(lines[split + 1:])
     # Set comparison used because depfile is not order-sensitive.
     self.assertTrue('test.data \\' in before)
     self.assertTrue('test.js \\' in before)
-    self.assertTrue(FILE_PACKAGER + '.py \\' in after)
+    self.assertTrue(file_packager + ' \\' in after)
     self.assertTrue('. \\' in after)
     self.assertTrue('./data1.txt \\' in after)
     self.assertTrue('./subdir \\' in after)
@@ -4691,6 +4694,7 @@ int main() {
   def test_unlink(self):
     self.do_other_test('test_unlink.cpp')
 
+  @crossplatform
   def test_argv0_node(self):
     create_file('code.c', r'''
 #include <stdio.h>
@@ -4700,8 +4704,8 @@ int main(int argc, char **argv) {
 }
 ''')
 
-    self.run_process([EMCC, 'code.c'])
-    self.assertContained('I am ' + os.path.realpath(self.get_dir()).replace('\\', '/') + '/a.out.js', self.run_js('a.out.js').replace('\\', '/'))
+    output = self.do_runf('code.c')
+    self.assertContained('I am ' + utils.normalize_path(os.path.realpath(self.get_dir())) + '/code.js', utils.normalize_path(output))
 
   @parameterized({
     'no_exit_runtime': [True],
@@ -13158,7 +13162,7 @@ j1: 8589934599, j2: 30064771074, j3: 12884901891
     self.assertExists('foo.tar')
     names = []
     root = os.path.splitdrive(path_from_root())[1][1:]
-    root = root.replace('\\', '/')
+    root = utils.normalize_path(root)
     print('root: %s' % root)
     with tarfile.open('foo.tar') as f:
       for name in f.getnames():
@@ -13177,7 +13181,7 @@ foo/version.txt
 <root>/test/hello_world.c
 '''
     response = read_file('foo/response.txt')
-    response = response.replace('\\', '/')
+    response = utils.normalize_path(response)
     response = response.replace(root, '<root>')
     self.assertTextDataIdentical(expected, response)
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -944,7 +944,7 @@ def emit_debug_on_side(wasm_file):
     embedded_path = os.path.relpath(wasm_file_with_dwarf,
                                     os.path.dirname(wasm_file))
     # normalize the path to use URL-style separators, per the spec
-    embedded_path = embedded_path.replace('\\', '/').replace('//', '/')
+    embedded_path = utils.normalize_path(embedded_path)
 
   shutil.move(wasm_file, wasm_file_with_dwarf)
   strip(wasm_file_with_dwarf, wasm_file, debug=True)

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -142,10 +142,6 @@ def err(*args):
   print(*args, file=sys.stderr)
 
 
-def to_unix_path(p):
-  return p.replace(os.path.sep, '/')
-
-
 def base64_encode(b):
   b64 = base64.b64encode(b)
   return b64.decode('ascii')
@@ -281,7 +277,7 @@ def generate_object_file(data_files):
 
       size = os.path.getsize(f.srcpath)
       dstpath = to_asm_string(f.dstpath)
-      srcpath = to_unix_path(f.srcpath)
+      srcpath = utils.normalize_path(f.srcpath)
       out.write(dedent(f'''
       .section .rodata.{f.c_symbol_name},"",@
 
@@ -514,7 +510,7 @@ def main():
 
   for file_ in data_files:
     # name in the filesystem, native and emulated
-    file_.dstpath = to_unix_path(file_.dstpath)
+    file_.dstpath = utils.normalize_path(file_.dstpath)
     # If user has submitted a directory name as the destination but omitted
     # the destination filename, use the filename from source file
     if file_.dstpath.endswith('/'):
@@ -593,6 +589,7 @@ def escape_for_makefile(fpath):
   # Escapes for CMake's "pathname" grammar as described here:
   #   https://cmake.org/cmake/help/latest/command/add_custom_command.html#grammar-token-depfile-pathname
   # Which is congruent with how Ninja and GNU Make expect characters escaped.
+  fpath = utils.normalize_path(fpath)
   return fpath.replace('$', '$$').replace('#', '\\#').replace(' ', '\\ ')
 
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -25,6 +25,17 @@ def path_from_root(*pathelems):
   return str(Path(__rootpath__, *pathelems))
 
 
+def normalize_path(path):
+  """Normalize path separators to UNIX-style forward slashes.
+
+  This can be useful when converting paths to URLs or JS strings,
+  or when trying to generate consistent output file contents
+  across all platforms.  In most cases UNIX-style separators work
+  fine on windows.
+  """
+  return path.replace('\\', '/').replace('//', '/')
+
+
 def safe_ensure_dirs(dirname):
   os.makedirs(dirname, exist_ok=True)
 

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -251,10 +251,6 @@ def read_dwarf_entries(wasm, options):
   return sorted(entries, key=lambda entry: entry['address'])
 
 
-def normalize_path(path):
-  return path.replace('\\', '/').replace('//', '/')
-
-
 def build_sourcemap(entries, code_section_offset, prefixes, collect_sources, base_path):
   sources = []
   sources_content = [] if collect_sources else None
@@ -275,7 +271,7 @@ def build_sourcemap(entries, code_section_offset, prefixes, collect_sources, bas
       column = 1
     address = entry['address'] + code_section_offset
     file_name = entry['file']
-    file_name = normalize_path(file_name)
+    file_name = utils.normalize_path(file_name)
     # if prefixes were provided, we use that; otherwise, we emit a relative
     # path
     if prefixes.provided():
@@ -285,7 +281,7 @@ def build_sourcemap(entries, code_section_offset, prefixes, collect_sources, bas
         file_name = os.path.relpath(file_name, base_path)
       except ValueError:
         file_name = os.path.abspath(file_name)
-      file_name = normalize_path(file_name)
+      file_name = utils.normalize_path(file_name)
       source_name = file_name
     if source_name not in sources_map:
       source_id = len(sources)


### PR DESCRIPTION
Mark the test as @crossplatform so it run on windows.

Fix the test by always writing paths with unix-style separators when
writing the deps file.

Also unify all the places where we do this unix-style path
normalization.