### PR TITLE
Don't enable USE_GLFW by default

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,6 +32,11 @@ See docs/process.md for more on how version tagging works.
   silent failures.
 - JS library decorators such as `__deps` and `__async` are now type checked so
   that errors are not silently ignored.
+- The `USE_GLFW` settings now defaults to 0 rather than 2.  This matches other
+  other settings such as `USE_SDL` that default to 0 these days and also matches
+  the existing behaviour for `MINIMAL_RUNTIME` and `STRICT` mode.
+  If you use GLFW you now need to explictly opt into it using `-sUSE_GLFW` or
+  `-lglfw`. (#19939)
 
 3.1.45 - 08/23/23
 -----------------

--- a/emcc.py
+++ b/emcc.py
@@ -54,7 +54,7 @@ from tools import js_manipulation
 from tools import webassembly
 from tools import config
 from tools import cache
-from tools.settings import user_settings, settings, MEM_SIZE_SETTINGS, COMPILE_TIME_SETTINGS
+from tools.settings import default_setting, user_settings, settings, MEM_SIZE_SETTINGS, COMPILE_TIME_SETTINGS
 from tools.utils import read_file, write_file, read_binary, delete_file, removeprefix
 
 logger = logging.getLogger('emcc')
@@ -408,11 +408,6 @@ def expand_byte_size_suffixes(value):
     size_suffixes = {suffix: 1024 ** i for i, suffix in enumerate(['b', 'kb', 'mb', 'gb', 'tb'])}
     value *= size_suffixes[suffix.lower()]
   return value
-
-
-def default_setting(name, new_default):
-  if name not in user_settings:
-    setattr(settings, name, new_default)
 
 
 def apply_user_settings():
@@ -2028,7 +2023,6 @@ def phase_linker_setup(options, state, newargs):
     default_setting('AUTO_JS_LIBRARIES', 0)
     # When using MINIMAL_RUNTIME, symbols should only be exported if requested.
     default_setting('EXPORT_KEEPALIVE', 0)
-    default_setting('USE_GLFW', 0)
 
   if settings.STRICT_JS and (settings.MODULARIZE or settings.EXPORT_ES6):
     exit_with_error("STRICT_JS doesn't work with MODULARIZE or EXPORT_ES6")
@@ -2036,7 +2030,6 @@ def phase_linker_setup(options, state, newargs):
   if settings.STRICT:
     if not settings.MODULARIZE and not settings.EXPORT_ES6:
       default_setting('STRICT_JS', 1)
-    default_setting('USE_GLFW', 0)
     default_setting('AUTO_JS_LIBRARIES', 0)
     default_setting('AUTO_NATIVE_LIBRARIES', 0)
     default_setting('AUTO_ARCHIVE_INDEXES', 0)

--- a/src/settings.js
+++ b/src/settings.js
@@ -1307,9 +1307,8 @@ var EMSCRIPTEN_TRACING = false;
 // Specify the GLFW version that is being linked against.  Only relevant, if you
 // are linking against the GLFW library.  Valid options are 2 for GLFW2 and 3
 // for GLFW3.
-// This defaults to 0 in either MINIMAL_RUNTIME or STRICT modes.
 // [link]
-var USE_GLFW = 2;
+var USE_GLFW = 0;
 
 // Whether to use compile code to WebAssembly. Set this to 0 to compile to JS
 // instead of wasm.

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1620,7 +1620,11 @@ keydown(100);keyup(100); // trigger the end
 
   @requires_graphics_hardware
   def test_glfw(self):
+    # Using only the `-l` flag
     self.btest_exit('browser/test_glfw.c', args=['-sLEGACY_GL_EMULATION', '-lglfw', '-lGL'])
+    # Using only the `-s` flag
+    self.btest_exit('browser/test_glfw.c', args=['-sLEGACY_GL_EMULATION', '-sUSE_GLFW=2', '-lGL'])
+    # Using both `-s` and `-l` flags
     self.btest_exit('browser/test_glfw.c', args=['-sLEGACY_GL_EMULATION', '-sUSE_GLFW=2', '-lglfw', '-lGL'])
 
   def test_glfw_minimal(self):

--- a/tools/building.py
+++ b/tools/building.py
@@ -32,7 +32,7 @@ from .shared import asmjs_mangle, DEBUG
 from .shared import LLVM_DWARFDUMP, demangle_c_symbol_name
 from .shared import get_emscripten_temp_dir, exe_suffix, is_c_symbol
 from .utils import WINDOWS
-from .settings import settings
+from .settings import settings, default_setting
 
 logger = logging.getLogger('building')
 
@@ -1114,6 +1114,15 @@ def map_to_js_libs(library_name, emit_tsd):
     'embind': 'libembind',
     'GL': 'libGL',
   }
+  settings_map = {
+    'glfw': {'USE_GLFW': 2},
+    'glfw3': {'USE_GLFW': 3},
+    'SDL': {'USE_SDL': 1},
+  }
+
+  if library_name in settings_map:
+    for key, value in settings_map[library_name].items():
+      default_setting(key, value)
 
   if library_name in library_map:
     libs = library_map[library_name]

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -95,6 +95,11 @@ INTERNAL_SETTINGS = {
 user_settings: Dict[str, str] = {}
 
 
+def default_setting(name, new_default):
+  if name not in user_settings:
+    setattr(settings, name, new_default)
+
+
 class SettingsManager:
   attrs: Dict[str, Any] = {}
   types: Dict[str, Any] = {}


### PR DESCRIPTION
This changes the default behaviour to match that of STRICT mode and MINIMAL_RUNTIME node.

We made a similar change for USE_SDL back in #18443.

As part of this change I also updated the code that maps `-l` flags to JS libraries.  In some cases we also want these to set the corresponding `-sUSE_XXX` setting.