### PR TITLE
Fix: mktime/gmtime return float or NaN value cause BigInt RangeError

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -469,7 +469,7 @@ mergeInto(LibraryManager.library, {
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_mon, 'date.getMonth()', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_year, 'date.getYear()', 'i32') }}};
 
-    return date.getTime() / 1000;
+    return (date.getTime() / 1000) | 0;
   },
 
   _gmtime_js__i53abi: true,
@@ -503,7 +503,7 @@ mergeInto(LibraryManager.library, {
     var yday = ((date.getTime() - start) / (1000 * 60 * 60 * 24))|0;
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_yday, 'yday', 'i32') }}};
 
-    return date.getTime() / 1000;
+    return (date.getTime() / 1000) | 0;
   },
 
   _localtime_js__i53abi: true,


### PR DESCRIPTION
Reason: Compiler output is "var __mktime_js = function (tmPtr) {
    // ...
    var ret = (() => {
        // ...
        return date.getTime() / 1e3 // fix -> (date.getTime() / 1e3) | 0
    })();
    return BigInt(ret) // RangeError here
};"