### PR TITLE
Add wasm64_gb test config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,6 +606,7 @@ jobs:
           title: "wasm64"
           test_targets: "
             wasm64
+            wasm64_4gb.test_hello_world
             wasm64l.test_bigswitch
             other.test_memory64_proxies
             other.test_failing_growth_wasm64"

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9800,6 +9800,13 @@ wasm64 = make_run('wasm64', emcc_args=['-O1', '-Wno-experimental', '--profiling-
                   settings={'MEMORY64': 1}, require_wasm64=True, require_node=True)
 wasm64_v8 = make_run('wasm64_v8', emcc_args=['-Wno-experimental', '--profiling-funcs'],
                      settings={'MEMORY64': 1}, require_wasm64=True, require_v8=True)
+# Run the wasm64 tests with all memory offsets > 4gb.  Be careful running this test
+# suite with any kind of parallelism.
+wasm64_4gb = make_run('wasm64_4gb', emcc_args=['-Wno-experimental', '--profiling-funcs'],
+                      settings={'MEMORY64': 1, 'INITIAL_MEMORY': '4200mb',
+                                'MAXIMUM_MEMORY': '4200mb', # TODO(sbc): should not be needed
+                                'GLOBAL_BASE': '4gb'},
+                      require_wasm64=True)
 # MEMORY64=2, or "lowered"
 wasm64l = make_run('wasm64l', emcc_args=['-O1', '-Wno-experimental', '--profiling-funcs'],
                    settings={'MEMORY64': 2},


### PR DESCRIPTION
This test configuration sets GLOBAL_BASE to 4gb meaning that all memory addresses used by emscripten will be larger then 4gb.

This should allow is to quickly fine the remaining bugs with wasm64 handling in our JS code.