### PR TITLE
Ensure MAXIMUM_MEMORY is set correctly

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9803,9 +9803,7 @@ wasm64_v8 = make_run('wasm64_v8', emcc_args=['-Wno-experimental', '--profiling-f
 # Run the wasm64 tests with all memory offsets > 4gb.  Be careful running this test
 # suite with any kind of parallelism.
 wasm64_4gb = make_run('wasm64_4gb', emcc_args=['-Wno-experimental', '--profiling-funcs'],
-                      settings={'MEMORY64': 1, 'INITIAL_MEMORY': '4200mb',
-                                'MAXIMUM_MEMORY': '4200mb', # TODO(sbc): should not be needed
-                                'GLOBAL_BASE': '4gb'},
+                      settings={'MEMORY64': 1, 'INITIAL_MEMORY': '4200mb', 'GLOBAL_BASE': '4gb'},
                       require_wasm64=True)
 # MEMORY64=2, or "lowered"
 wasm64l = make_run('wasm64l', emcc_args=['-O1', '-Wno-experimental', '--profiling-funcs'],

--- a/tools/building.py
+++ b/tools/building.py
@@ -213,6 +213,7 @@ def lld_flags_for_executable(external_symbols):
     cmd += [
       '-z', 'stack-size=%s' % settings.STACK_SIZE,
       '--initial-memory=%d' % settings.INITIAL_MEMORY,
+      '--max-memory=%d' % settings.MAXIMUM_MEMORY,
     ]
 
     if settings.STANDALONE_WASM:
@@ -228,10 +229,6 @@ def lld_flags_for_executable(external_symbols):
         # `__main_argv_argc`, but we should address that by using a single `_start`
         # function like we do in STANDALONE_WASM mode.
         cmd += ['--no-entry']
-    if not settings.ALLOW_MEMORY_GROWTH:
-      cmd.append('--max-memory=%d' % settings.INITIAL_MEMORY)
-    elif settings.MAXIMUM_MEMORY != -1:
-      cmd.append('--max-memory=%d' % settings.MAXIMUM_MEMORY)
 
   if settings.STACK_FIRST:
     cmd.append('--stack-first')


### PR DESCRIPTION
This avoids issues where MAXIMUM_MEMORY is inconsistent and simplifies check that wants to check for max memory address.  Without this change the following check in preable.js was producing the wrong result when INITIAL_MEMORY was set to >4gb but MAXIMUM_MEMORY was not set:

```
#if MEMORY64 && MAXIMUM_MEMORY > FOUR_GB
```

When the user specifies INITIAL_MEMORY that should set a lower bound for MAXIMUM_MEMORY.

When memory growth is disallowed MAXIMUM_MEMORY should match INITIAL_MEMORY.