### PR TITLE
Add new internal setting: MINIFY_WHITESPACE. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -384,10 +384,6 @@ def setup_environment_settings():
     exit_with_error('When building with multithreading enabled and a "-sENVIRONMENT=" directive is specified, it must include "worker" as a target! (Try e.g. -sENVIRONMENT=web,worker)')
 
 
-def minify_whitespace():
-  return settings.OPT_LEVEL >= 2 and settings.DEBUG_LEVEL == 0
-
-
 def embed_memfile(options):
   return (settings.SINGLE_FILE or
           (settings.WASM2JS and not options.memory_init_file and
@@ -2944,6 +2940,8 @@ def phase_linker_setup(options, state, newargs):
   settings.PRE_JS_FILES = [os.path.abspath(f) for f in options.pre_js]
   settings.POST_JS_FILES = [os.path.abspath(f) for f in options.post_js]
 
+  settings.MINIFY_WHITESPACE = settings.OPT_LEVEL >= 2 and settings.DEBUG_LEVEL == 0
+
   return target, wasm_target
 
 
@@ -3216,8 +3214,8 @@ def create_worker_file(input_file, target_dir, output_file):
   contents = shared.read_and_preprocess(input_file, expand_macros=True)
   write_file(output_file, contents)
 
-  # Minify the worker JS files file in optimized builds
-  if (settings.OPT_LEVEL >= 1 or settings.SHRINK_LEVEL >= 1) and not settings.DEBUG_LEVEL:
+  # Minify the worker JS file, if JS minification is enabled.
+  if settings.MINIFY_WHITESPACE:
     contents = building.acorn_optimizer(output_file, ['minifyWhitespace'], return_output=True)
     write_file(output_file, contents)
 
@@ -3251,7 +3249,7 @@ def phase_final_emitting(options, state, target, wasm_target, memfile):
     # Finally, rerun Closure compile with simple optimizations. It will be able
     # to further minify the code. (n.b. it would not be safe to run in advanced
     # mode)
-    final_js = building.closure_compiler(final_js, pretty=False, advanced=False, extra_closure_args=options.closure_args)
+    final_js = building.closure_compiler(final_js, advanced=False, extra_closure_args=options.closure_args)
 
   # Unmangle previously mangled `import.meta` and `await import` references in
   # both main code and libraries.
@@ -3762,7 +3760,6 @@ def phase_binaryen(target, options, wasm_target):
         final_js = building.minify_wasm_js(js_file=final_js,
                                            wasm_file=wasm_target,
                                            expensive_optimizations=will_metadce(),
-                                           minify_whitespace=minify_whitespace() and not options.use_closure_compiler,
                                            debug_info=intermediate_debug_info)
         save_intermediate_with_wasm('postclean', wasm_target)
 
@@ -3773,11 +3770,10 @@ def phase_binaryen(target, options, wasm_target):
   if final_js and (options.use_closure_compiler or settings.TRANSPILE_TO_ES5):
     if options.use_closure_compiler:
       with ToolchainProfiler.profile_block('closure_compile'):
-        final_js = building.closure_compiler(final_js, pretty=not minify_whitespace(),
-                                             extra_closure_args=options.closure_args)
+        final_js = building.closure_compiler(final_js, extra_closure_args=options.closure_args)
     else:
       with ToolchainProfiler.profile_block('closure_transpile'):
-        final_js = building.closure_transpile(final_js, pretty=not minify_whitespace())
+        final_js = building.closure_transpile(final_js)
     save_intermediate_with_wasm('closure', wasm_target)
 
   symbols_file = None
@@ -3803,7 +3799,6 @@ def phase_binaryen(target, options, wasm_target):
     wasm2js = building.wasm2js(wasm2js_template,
                                wasm_target,
                                opt_level=settings.OPT_LEVEL,
-                               minify_whitespace=minify_whitespace(),
                                use_closure_compiler=options.use_closure_compiler,
                                debug_info=debug_info,
                                symbols_file=symbols_file,

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -265,3 +265,5 @@ var POST_JS_FILES = [];
 var PTHREADS = false;
 
 var BULK_MEMORY = false;
+
+var MINIFY_WHITESPACE = true;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -306,7 +306,7 @@ class other(RunnerCore):
     self.assertContained("new Worker(new URL('hello_world.worker.js', import.meta.url))", src)
     self.assertContained('export default Module;', src)
     src = read_file('subdir/hello_world.worker.js')
-    self.assertContained('import("./hello_world.mjs")', src)
+    self.assertContained("import('./hello_world.mjs')", src)
     self.assertContained('hello, world!', self.run_js('subdir/hello_world.mjs'))
 
   @node_pthreads

--- a/tools/building.py
+++ b/tools/building.py
@@ -488,16 +488,16 @@ def get_closure_compiler_and_env(user_args):
 
 
 @ToolchainProfiler.profile()
-def closure_transpile(filename, pretty):
+def closure_transpile(filename):
   user_args = []
   closure_cmd, env = get_closure_compiler_and_env(user_args)
   closure_cmd += ['--language_out', 'ES5']
   closure_cmd += ['--compilation_level', 'WHITESPACE_ONLY']
-  return run_closure_cmd(closure_cmd, filename, env, pretty)
+  return run_closure_cmd(closure_cmd, filename, env)
 
 
 @ToolchainProfiler.profile()
-def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
+def closure_compiler(filename, advanced=True, extra_closure_args=None):
   user_args = []
   env_args = os.environ.get('EMCC_CLOSURE_ARGS')
   if env_args:
@@ -576,10 +576,10 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
   args += user_args
 
   cmd = closure_cmd + args
-  return run_closure_cmd(cmd, filename, env, pretty=pretty)
+  return run_closure_cmd(cmd, filename, env)
 
 
-def run_closure_cmd(cmd, filename, env, pretty):
+def run_closure_cmd(cmd, filename, env):
   cmd += ['--js', filename]
 
   # Closure compiler is unable to deal with path names that are not 7-bit ASCII:
@@ -608,7 +608,7 @@ def run_closure_cmd(cmd, filename, env, pretty):
 
   # Specify output file relative to the temp directory to avoid specifying non-7-bit-ASCII path names.
   cmd += ['--js_output_file', os.path.relpath(outfile, tempfiles.tmpdir)]
-  if pretty:
+  if not settings.MINIFY_WHITESPACE:
     cmd += ['--formatting', 'PRETTY_PRINT']
 
   shared.print_compiler_stage(cmd)
@@ -648,7 +648,7 @@ def run_closure_cmd(cmd, filename, env, pretty):
 
     # Exit and print final hint to get clearer output
     msg = f'closure compiler failed (rc: {proc.returncode}): {shared.shlex_join(cmd)}'
-    if not pretty:
+    if settings.MINIFY_WHITESPACE:
       msg += ' the error message may be clearer with -g1 and EMCC_DEBUG=2 set'
     exit_with_error(msg)
 
@@ -660,7 +660,7 @@ def run_closure_cmd(cmd, filename, env, pretty):
       logger.warn(proc.stderr)
 
     # Exit and/or print final hint to get clearer output
-    if not pretty:
+    if settings.MINIFY_WHITESPACE:
       logger.warn('(rerun with -g1 linker flag for an unminified output)')
     elif DEBUG != 2:
       logger.warn('(rerun with EMCC_DEBUG=2 enabled to dump Closure input file)')
@@ -673,14 +673,16 @@ def run_closure_cmd(cmd, filename, env, pretty):
 
 # minify the final wasm+JS combination. this is done after all the JS
 # and wasm optimizations; here we do the very final optimizations on them
-def minify_wasm_js(js_file, wasm_file, expensive_optimizations, minify_whitespace, debug_info):
+def minify_wasm_js(js_file, wasm_file, expensive_optimizations, debug_info):
   # start with JSDCE, to clean up obvious JS garbage. When optimizing for size,
   # use AJSDCE (aggressive JS DCE, performs multiple iterations). Clean up
   # whitespace if necessary too.
   passes = []
   if not settings.LINKABLE:
     passes.append('JSDCE' if not expensive_optimizations else 'AJSDCE')
-  if minify_whitespace:
+  # Don't minify if we are going to run closure compiler afterwards
+  minify = settings.MINIFY_WHITESPACE and not settings.USE_CLOSURE_COMPILER
+  if minify:
     passes.append('minifyWhitespace')
   if passes:
     logger.debug('running cleanup on shell code: ' + ' '.join(passes))
@@ -691,24 +693,23 @@ def minify_wasm_js(js_file, wasm_file, expensive_optimizations, minify_whitespac
     # if we are optimizing for size, shrink the combined wasm+JS
     # TODO: support this when a symbol map is used
     if expensive_optimizations:
-      js_file = metadce(js_file, wasm_file, minify_whitespace=minify_whitespace, debug_info=debug_info)
+      js_file = metadce(js_file, wasm_file, debug_info=debug_info)
       # now that we removed unneeded communication between js and wasm, we can clean up
       # the js some more.
       passes = ['AJSDCE']
-      if minify_whitespace:
+      if minify:
         passes.append('minifyWhitespace')
       logger.debug('running post-meta-DCE cleanup on shell code: ' + ' '.join(passes))
       js_file = acorn_optimizer(js_file, passes)
       if settings.MINIFY_WASM_IMPORTS_AND_EXPORTS:
         js_file = minify_wasm_imports_and_exports(js_file, wasm_file,
-                                                  minify_whitespace=minify_whitespace,
                                                   minify_exports=settings.MINIFY_WASM_EXPORT_NAMES,
                                                   debug_info=debug_info)
   return js_file
 
 
 # run binaryen's wasm-metadce to dce both js and wasm
-def metadce(js_file, wasm_file, minify_whitespace, debug_info):
+def metadce(js_file, wasm_file, debug_info):
   logger.debug('running meta-DCE')
   temp_files = shared.get_temp_files()
   # first, get the JS part of the graph
@@ -791,7 +792,7 @@ def metadce(js_file, wasm_file, minify_whitespace, debug_info):
       unused.append(name)
   # remove them
   passes = ['applyDCEGraphRemovals']
-  if minify_whitespace:
+  if settings.MINIFY_WHITESPACE:
     passes.append('minifyWhitespace')
   extra_info = {'unused': unused}
   return acorn_optimizer(js_file, passes, extra_info=json.dumps(extra_info))
@@ -822,7 +823,7 @@ def asyncify_lazy_load_code(wasm_target, debug):
                debug=debug)
 
 
-def minify_wasm_imports_and_exports(js_file, wasm_file, minify_whitespace, minify_exports, debug_info):
+def minify_wasm_imports_and_exports(js_file, wasm_file, minify_exports, debug_info):
   logger.debug('minifying wasm imports and exports')
   # run the pass
   if minify_exports:
@@ -853,13 +854,13 @@ def minify_wasm_imports_and_exports(js_file, wasm_file, minify_whitespace, minif
       mapping[old] = new
   # apply them
   passes = ['applyImportAndExportNameChanges']
-  if minify_whitespace:
+  if settings.MINIFY_WHITESPACE:
     passes.append('minifyWhitespace')
   extra_info = {'mapping': mapping}
   return acorn_optimizer(js_file, passes, extra_info=json.dumps(extra_info))
 
 
-def wasm2js(js_file, wasm_file, opt_level, minify_whitespace, use_closure_compiler, debug_info, symbols_file=None, symbols_file_js=None):
+def wasm2js(js_file, wasm_file, opt_level, use_closure_compiler, debug_info, symbols_file=None, symbols_file_js=None):
   logger.debug('wasm2js')
   args = ['--emscripten']
   if opt_level > 0:
@@ -879,7 +880,7 @@ def wasm2js(js_file, wasm_file, opt_level, minify_whitespace, use_closure_compil
       passes += ['minifyNames']
       if symbols_file_js:
         passes += ['symbolMap=%s' % symbols_file_js]
-    if minify_whitespace:
+    if settings.MINIFY_WHITESPACE:
       passes += ['minifyWhitespace']
     passes += ['last']
     if passes:
@@ -900,7 +901,7 @@ def wasm2js(js_file, wasm_file, opt_level, minify_whitespace, use_closure_compil
     temp = shared.get_temp_files().get('.js').name
     with open(temp, 'a') as f:
       f.write(wasm2js_js)
-    temp = closure_compiler(temp, pretty=not minify_whitespace, advanced=False)
+    temp = closure_compiler(temp, advanced=False)
     wasm2js_js = utils.read_file(temp)
     # closure may leave a trailing `;`, which would be invalid given where we place
     # this code (inside parens)


### PR DESCRIPTION
This centralizes the control of JS minification behind a single setting. We have had a feature request to be able to disable JS minifiction so the output can be passed to closure compiler after link time.

This change doesn't yet allow the user to directly control this setting. We can consider that part as a followup.

The `test_emcc_output_worker_mjs` test expectation changed because
we now minify the worker.js file based on the same set of criteria as
the main js file.  Previously these were independent and had slightly
different criteria.