### PR TITLE
Add parameter names to GL Emulation functions to fix 4GB mode link error

### DIFF
--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -3810,18 +3810,18 @@ var LibraryGLEmulation = {
     }
   },
 
-  glTexGeni: function() { throw 'glTexGeni: TODO' },
-  glTexGenfv: function() { throw 'glTexGenfv: TODO' },
-  glTexEnvi: function() { warnOnce('glTexEnvi: TODO') },
-  glTexEnvf: function() { warnOnce('glTexEnvf: TODO') },
-  glTexEnvfv: function() { warnOnce('glTexEnvfv: TODO') },
+  glTexGeni: function(coord, pname, param) { throw 'glTexGeni: TODO' },
+  glTexGenfv: function(coord, pname, param) { throw 'glTexGenfv: TODO' },
+  glTexEnvi: function(target, pname, params) { warnOnce('glTexEnvi: TODO') },
+  glTexEnvf: function(target, pname, params) { warnOnce('glTexEnvf: TODO') },
+  glTexEnvfv: function(target, pname, params) { warnOnce('glTexEnvfv: TODO') },
 
   glGetTexEnviv: function(target, pname, param) { throw 'GL emulation not initialized!'; },
   glGetTexEnvfv: function(target, pname, param) { throw 'GL emulation not initialized!'; },
 
-  glTexImage1D: function() { throw 'glTexImage1D: TODO' },
-  glTexCoord3f: function() { throw 'glTexCoord3f: TODO' },
-  glGetTexLevelParameteriv: function() { throw 'glGetTexLevelParameteriv: TODO' },
+  glTexImage1D: function(target, level, internalformat, width, border, format, type, data) { throw 'glTexImage1D: TODO' },
+  glTexCoord3f: function(target, level, internalformat, width, border, format, type, data) { throw 'glTexCoord3f: TODO' },
+  glGetTexLevelParameteriv: function(target, level, pname, params) { throw 'glGetTexLevelParameteriv: TODO' },
 
   glShadeModel: function() { warnOnce('TODO: glShadeModel') },
 

--- a/test/glgettexenv.c
+++ b/test/glgettexenv.c
@@ -69,12 +69,6 @@ int main(int argc, char *argv[])
     assert(colora[2] == colorb[2]);
     assert(colora[3] == colorb[3]);
 
-    // Check for no compilation errors with the following.
-    if (argc == 1234) {
-      GLint i;
-      glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &i);
-    }
-
     SDL_Quit();
 
 #ifdef REPORT_RESULT

--- a/test/glgettexenv.c
+++ b/test/glgettexenv.c
@@ -68,8 +68,15 @@ int main(int argc, char *argv[])
     assert(colora[1] == colorb[1]);
     assert(colora[2] == colorb[2]);
     assert(colora[3] == colorb[3]);
+
+    // Check for no compilation errors with the following.
+    if (argc == 1234) {
+      GLint i;
+      glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &i);
+    }
+
     SDL_Quit();
-    
+
 #ifdef REPORT_RESULT
     REPORT_RESULT(1);
 #endif

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2197,7 +2197,9 @@ void *getBindBuffer() {
 
   @requires_graphics_hardware
   def test_glgettexenv(self):
-    self.btest('glgettexenv.c', args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'], expected='1')
+    # Test with 4GB maximum memory to test that GL emulation does not error
+    # during link.
+    self.btest('glgettexenv.c', args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-sMAXIMUM_MEMORY=4GB', '-sALLOW_MEMORY_GROWTH'], expected='1')
 
   def test_sdl_canvas_blank(self):
     self.btest('browser/test_sdl_canvas_blank.c', args=['-lSDL', '-lGL'], reference='browser/test_sdl_canvas_blank.png')

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2197,9 +2197,7 @@ void *getBindBuffer() {
 
   @requires_graphics_hardware
   def test_glgettexenv(self):
-    # Test with 4GB maximum memory to test that GL emulation does not error
-    # during link.
-    self.btest('glgettexenv.c', args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-sMAXIMUM_MEMORY=4GB', '-sALLOW_MEMORY_GROWTH'], expected='1')
+    self.btest('glgettexenv.c', args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'], expected='1')
 
   def test_sdl_canvas_blank(self):
     self.btest('browser/test_sdl_canvas_blank.c', args=['-lSDL', '-lGL'], reference='browser/test_sdl_canvas_blank.png')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8774,7 +8774,7 @@ end
   @parameterized({
     '': ([],),
     'asyncify': (['-sASYNCIFY'],),
-    'gl_emu': (['-sLEGACY_GL_EMULATION'],),
+    'gl_emu': (['-sLEGACY_GL_EMULATION', '-sMAXIMUM_MEMORY=4GB', '-sALLOW_MEMORY_GROWTH'],),
     'no_exception_throwing': (['-sDISABLE_EXCEPTION_THROWING'],),
     'minimal_runtime': (['-sMINIMAL_RUNTIME'],),
   })

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8774,6 +8774,7 @@ end
   @parameterized({
     '': ([],),
     'asyncify': (['-sASYNCIFY'],),
+    # set max_memory to 4GB to test handleI64Signatures() with GL emulation
     'gl_emu': (['-sLEGACY_GL_EMULATION', '-sMAXIMUM_MEMORY=4GB', '-sALLOW_MEMORY_GROWTH'],),
     'no_exception_throwing': (['-sDISABLE_EXCEPTION_THROWING'],),
     'minimal_runtime': (['-sMINIMAL_RUNTIME'],),


### PR DESCRIPTION
Fixes #19944 

Without this, we hit
```
error: handleI64Signatures: missing name for argument 1 in glGetTexLevelParameteriv
```
