### PR TITLE
Fix for async cancellation during __timedwait. NFC

### DIFF
--- a/test/pthread/test_pthread_cancel.out
+++ b/test/pthread/test_pthread_cancel.out
@@ -1,0 +1,4 @@
+Canceling thread..
+Thread started!
+Called clean-up handler with arg 42
+After canceling, shared variable = 1.

--- a/test/pthread/test_pthread_cancel_async.c
+++ b/test/pthread/test_pthread_cancel_async.c
@@ -1,0 +1,73 @@
+// Copyright 2015 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <pthread.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <unistd.h>
+#include <errno.h>
+#include <emscripten/console.h>
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+_Atomic long res = 43;
+_Atomic int started = false;
+
+static void cleanup_handler(void *arg)
+{
+  long a = (long)arg;
+  emscripten_outf("Called clean-up handler with arg %ld", a);
+  res -= a;
+}
+
+static void *thread_start(void *arg) {
+  // Setup thread for async cancelation only
+  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+  pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+
+  pthread_cleanup_push(cleanup_handler, (void*)42);
+
+  emscripten_out("Thread started!");
+
+  // Signal the main thread that are started
+  started = true;
+
+  // This mutex is locked by the main thread so this call should never return.
+  // pthread_mutex_lock is not a cancellation point so deferred cancellation
+  // won't work here, async cancelation should.
+  pthread_mutex_lock(&mutex);
+
+  assert(false && "pthread_mutex_lock returned!");
+  pthread_cleanup_pop(0);
+}
+
+int main() {
+  pthread_mutex_lock(&mutex);
+
+  emscripten_out("Starting thread..");
+  pthread_t thr;
+  int s = pthread_create(&thr, NULL, thread_start, (void*)0);
+  assert(s == 0);
+  // Busy wait until thread is started
+  while (!started) {
+    sched_yield();
+  }
+
+  emscripten_out("Canceling thread..");
+  s = pthread_cancel(thr);
+  assert(s == 0);
+  // Busy wait until thread cancel handler has been run
+  while (res != 1) {
+    sched_yield();
+  }
+
+  emscripten_out("Joining thread..");
+  s = pthread_join(thr, NULL);
+  assert(s == 0);
+  emscripten_out("done");
+  return 0;
+}

--- a/test/pthread/test_pthread_cancel_async.out
+++ b/test/pthread/test_pthread_cancel_async.out
@@ -1,0 +1,6 @@
+Starting thread..
+Thread started!
+Canceling thread..
+Called clean-up handler with arg 42
+Joining thread..
+done

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2691,6 +2691,14 @@ The current type of b is: 9
     self.set_setting('EXIT_RUNTIME')
     self.do_core_test('test_atexit_threads.cpp')
 
+  @node_pthreads
+  def test_pthread_cancel(self):
+    self.do_run_in_out_file_test('pthread/test_pthread_cancel.cpp')
+
+  @node_pthreads
+  def test_pthread_cancel_async(self):
+    self.do_run_in_out_file_test('pthread/test_pthread_cancel_async.c')
+
   @no_asan('test relies on null pointer reads')
   def test_pthread_specific(self):
     self.do_run_in_out_file_test('pthread/specific.c')


### PR DESCRIPTION
Emscripten doesn't have real async cancellation but we don't want __timedwait_cp to return the thread has been canceled while while its running.

This fixes a problem in the test_pthread_setcanceltype_1_1 test which was not being correctly reported but shows up as a real problem with the switch to the new proxying system in #19947.

Specifically, without this change, a thread this async canceled during pthread_mutex_lock call will return ECANCELED, but instead it should never return and thread should be canceled, which is the behaviour after this change.