### PR TITLE
Make mktime return a correct value of -1 with a NaN date

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -469,6 +469,8 @@ mergeInto(LibraryManager.library, {
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_mon, 'date.getMonth()', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_year, 'date.getYear()', 'i32') }}};
 
+    if (isNaN(date.getTime()))
+      return -1;
     return date.getTime() / 1000;
   },
 

--- a/test/core/test_time.cpp
+++ b/test/core/test_time.cpp
@@ -163,6 +163,14 @@ int main() {
   printf("mktime guesses DST (winter): %d\n", tm_winter.tm_isdst == oldDstWinter);
   printf("mktime guesses DST (summer): %d\n", tm_summer.tm_isdst == oldDstSummer);
 
+  struct tm tm_big = {0};
+  tm_big.tm_year = 292278994;
+  tm_big.tm_mday = 31;
+  tm_big.tm_hour = 23;
+  tm_big.tm_min = 59;
+  tm_big.tm_sec = 59;
+  assert(mktime(&tm_big) == -1);
+
   // Verify localtime_r() doesn't clobber static data.
   time_t t3 = 60*60*24*5; // Jan 5 1970
   struct tm tm3;


### PR DESCRIPTION
This is particularly helpful as now we have i53abi, which funnels the return value to a BigInt. If we return a NaN here, JS will throw when BigInt's construction is attempted.