### PR TITLE
Fix error reporting in fd_sync + ASYNCIFY. NFC

### DIFF
--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -552,7 +552,7 @@ var WasiLibrary = {
       }
       mount.type.syncfs(mount, false, function(err) {
         if (err) {
-          wakeUp(function() { return {{{ cDefs.EIO }}} });
+          wakeUp({{{ cDefs.EIO }}});
           return;
         }
         wakeUp(0);


### PR DESCRIPTION
I think the wakeUp function just takes the value to return to the resumed caller.  I looks like this was perhaps wrong since it was first added back in #8808.