### PR TITLE
[Wasm64] Fix EM_ASM for addresses >4GB addresses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -617,6 +617,7 @@ jobs:
           test_targets: "
             wasm64
             wasm64_4gb.test_hello_world
+            wasm64_4gb.test_em_asm
             wasm64l.test_bigswitch
             other.test_memory64_proxies
             other.test_failing_growth_wasm64"

--- a/src/library.js
+++ b/src/library.js
@@ -2869,7 +2869,6 @@ addToLibrary({
     var ch;
     // Most arguments are i32s, so shift the buffer pointer so it is a plain
     // index into HEAP32.
-    buf >>= 2;
     while (ch = HEAPU8[sigPtr++]) {
 #if ASSERTIONS
       var chr = String.fromCharCode(ch);
@@ -2885,22 +2884,22 @@ addToLibrary({
 #endif
       assert(validChars.includes(chr), `Invalid character ${ch}("${chr}") in readEmAsmArgs! Use only [${validChars}], and do not specify "v" for void return argument.`);
 #endif
-      // Floats are always passed as doubles, and doubles and int64s take up 8
-      // bytes (two 32-bit slots) in memory, align reads to these:
-      buf += (ch != {{{ charCode('i') }}}) & buf;
+      // Floats are always passed as doubles, so all types except for 'i'
+      // are 8 bytes and require alignment.
+      buf += (ch != {{{ charCode('i') }}}) && buf % 8 ? 4 : 0;
       readEmAsmArgsArray.push(
-        ch == {{{ charCode('i') }}} ? HEAP32[buf] :
 #if MEMORY64
         // Special case for pointers under wasm64 which we read as int53 Numbers.
-        ch == {{{ charCode('p') }}} ? {{{ makeGetValue('buf++ << 2', 0, '*') }}} :
+        ch == {{{ charCode('p') }}} ?  {{{ makeGetValue('buf', 0, '*') }}} :
 #endif
 #if WASM_BIGINT
-        (ch == {{{ charCode('j') }}} ? HEAP64 : HEAPF64)[buf++ >> 1]
-#else
-        HEAPF64[buf++ >> 1]
+        ch == {{{ charCode('j') }}} ?  {{{ makeGetValue('buf', 0, 'i64') }}} :
 #endif
+        ch == {{{ charCode('i') }}} ?
+          {{{ makeGetValue('buf', 0, 'i32') }}} :
+          {{{ makeGetValue('buf', 0, 'double') }}}
       );
-      ++buf;
+      buf += ch == {{{ charCode('i') }}} ? 4 : 8;
     }
     return readEmAsmArgsArray;
   },

--- a/test/runner.py
+++ b/test/runner.py
@@ -284,7 +284,7 @@ def load_test_suites(args, modules):
       for test in tests:
         suite.addTest(test)
       suites.append((m.__name__, suite))
-  if total_tests == 1:
+  if total_tests == 1 or parallel_testsuite.num_cores() == 1:
     common.EMTEST_SAVE_DIR = True
   return suites, unmatched_test_names
 


### PR DESCRIPTION
This change use makeGetValue helper macros to avoid direct heap access.
    
This does come with a 6 byte code size cost (I measured the size of the
JS code generated for wasm64.test_em_asm with -O2 going from 9275 to
9281).

