### PR TITLE
Fix EM_ASM with addresses over 2gb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -618,6 +618,7 @@ jobs:
             wasm64
             wasm64_4gb.test_hello_world
             wasm64_4gb.test_em_asm
+            core_2gb.test_em_asm
             wasm64l.test_bigswitch
             other.test_memory64_proxies
             other.test_failing_growth_wasm64"

--- a/test/runner.py
+++ b/test/runner.py
@@ -56,6 +56,7 @@ passing_core_test_modes = [
   'core3',
   'cores',
   'corez',
+  'core_2gb',
   'strict',
   'wasm2js0',
   'wasm2js1',

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9789,6 +9789,10 @@ core3 = make_run('core3', emcc_args=['-O3'])
 cores = make_run('cores', emcc_args=['-Os'])
 corez = make_run('corez', emcc_args=['-Oz'])
 
+# Test >2gb memory addresses
+core_2gb = make_run('core_2gb', emcc_args=['--profiling-funcs'],
+                    settings={'INITIAL_MEMORY': '2200mb', 'GLOBAL_BASE': '2gb'})
+
 # MEMORY64=1
 wasm64 = make_run('wasm64', emcc_args=['-O1', '-Wno-experimental', '--profiling-funcs'],
                   settings={'MEMORY64': 1}, require_wasm64=True, require_node=True)

--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -149,12 +149,19 @@ def get_passive_segment_offsets(module):
   return offset_map
 
 
+def to_unsigned(val):
+  if val < 0:
+    return val & ((2 ** 32) - 1)
+  else:
+    return val
+
+
 def find_segment_with_address(module, address):
   segments = module.get_segments()
   active = [s for s in segments if s.init]
 
   for seg in active:
-    offset = get_const_expr_value(seg.init)
+    offset = to_unsigned(get_const_expr_value(seg.init))
     if offset is None:
       continue
     if address >= offset and address < offset + seg.size:
@@ -194,8 +201,8 @@ def get_section_strings(module, export_map, section_name):
   end = export_map[stop_name]
   start_global = module.get_global(start.index)
   end_global = module.get_global(end.index)
-  start_addr = get_global_value(start_global)
-  end_addr = get_global_value(end_global)
+  start_addr = to_unsigned(get_global_value(start_global))
+  end_addr = to_unsigned(get_global_value(end_global))
 
   seg = find_segment_with_address(module, start_addr)
   if not seg:

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -236,8 +236,10 @@ class Module:
     while 1:
       opcode = OpCode(self.read_byte())
       args = []
-      if opcode in (OpCode.GLOBAL_GET, OpCode.I32_CONST, OpCode.I64_CONST):
+      if opcode == OpCode.GLOBAL_GET:
         args.append(self.read_uleb())
+      elif opcode in (OpCode.I32_CONST, OpCode.I64_CONST):
+        args.append(self.read_sleb())
       elif opcode in (OpCode.REF_NULL,):
         args.append(self.read_type())
       elif opcode in (OpCode.END, OpCode.I32_ADD, OpCode.I64_ADD):


### PR DESCRIPTION
This change use makeGetValue helper macros to avoid direct heap access.

This does come with a 6 byte code size cost (I measured the size of the
JS code generated for wasm64.test_em_asm with -O2 going from 9275 to
9281).
