### PR TITLE
Showcase the ASYNCIFY=2 problem with out params

### DIFF
--- a/test/browser/test_idbstore_sync.c
+++ b/test/browser/test_idbstore_sync.c
@@ -25,7 +25,10 @@ void test() {
   sum++;
 
   printf("checking\n");
+  exists = 5555;
   emscripten_idb_exists(DB, "the_secret", &exists, &error);
+  // exists is still 5555 here!!!
+  assert(exists != 5555);
   assert(!error);
   assert(exists);
   sum++;

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1510,7 +1510,7 @@ keydown(100);keyup(100); // trigger the end
   @also_with_wasm64
   def test_idbstore_sync(self):
     secret = str(time.time())
-    self.btest(test_file('browser/test_idbstore_sync.c'), '6', args=['-lidbstore.js', f'-DSECRET="{secret}"', '-O3', '-g2', '-sASYNCIFY'])
+    self.btest(test_file('browser/test_idbstore_sync.c'), '6', args=['-lidbstore.js', f'-DSECRET="{secret}"', '-O3', '-g2', '-sASYNCIFY=2', '-Wno-experimental'])
 
   def test_idbstore_sync_worker(self):
     secret = str(time.time())


### PR DESCRIPTION
There's a problem with out parameters when compiling with ASYNCIFY=2
Functions like
emscripten_idb_exists
do not see their out parameters modified when control gets back to WASM
The modified test shows what the problem is. I'd appreciate any possible solution.
I've debugged this and it seems that any change to HEAP32 is not properly reflected on WASM side later on.
See #19989