### PR TITLE
Mark "missing symbol" stub functions as such

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -396,11 +396,12 @@ function(${args}) {
         }
         if (!RELOCATABLE) {
           // emit a stub that will fail at runtime
-          LibraryManager.library[symbol] = new Function(`err('missing function: ${symbol}'); abort(-1);`);
+          LibraryManager.library[symbol] = new Function(`abort('missing function: ${symbol}');`);
           // We have already warned/errored about this function, so for the purposes of Closure use, mute all type checks
           // regarding this function, marking ot a variadic function that can take in anything and return anything.
           // (not useful to warn/error multiple times)
           LibraryManager.library[symbol + '__docs'] = '/** @type {function(...*):?} */';
+          isStub = true;
         } else {
           // Create a stub for this symbol which can later be replaced by the
           // dynamic linker.  If this stub is called before the symbol is

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12115,7 +12115,7 @@ exec "$@"
 
   @also_with_wasm64
   def test_missing_symbols_at_runtime(self):
-    # We deliberately pick as symbol there that take a pointer as an argument.
+    # We deliberately pick a symbol there that takes a pointer as an argument.
     # We had a regression where the pointer-handling wrapper function could
     # not be created because the "missing functions" stubs don't take any
     # arguments.


### PR DESCRIPTION
This prevents, for example, the creation of i64-handling wrapper functions around these stubs, which would fail due to the argument cound of the stub function bring zero.

Fixes: #19944