### PR TITLE
WasmFS: Fix browser pthread asan test reporting

### DIFF
--- a/test/browser_reporting.js
+++ b/test/browser_reporting.js
@@ -70,7 +70,9 @@ if (typeof window === 'object' && window) {
 if (hasModule) {
   if (!Module['onExit']) {
     Module['onExit'] = function(status) {
-      maybeReportResultToServer('exit:' + status);
+      if (Module['REPORT_EXIT'] !== false) {
+        maybeReportResultToServer('exit:' + status);
+      }
     }
   }
 

--- a/test/browser_reporting.js
+++ b/test/browser_reporting.js
@@ -70,6 +70,8 @@ if (typeof window === 'object' && window) {
 if (hasModule) {
   if (!Module['onExit']) {
     Module['onExit'] = function(status) {
+      // If Module['REPORT_EXIT'] is set to false, do not report the result of
+      // onExit.
       if (Module['REPORT_EXIT'] !== false) {
         maybeReportResultToServer('exit:' + status);
       }

--- a/test/pthread/test_pthread_asan_use_after_free.js
+++ b/test/pthread/test_pthread_asan_use_after_free.js
@@ -22,4 +22,6 @@
     output.push(text);
     console.log(text);
   };
+  // We manually report our result from the printErr hook above.
+  Module['REPORT_EXIT'] = false;
 })();

--- a/test/pthread/test_pthread_asan_use_after_free_2.js
+++ b/test/pthread/test_pthread_asan_use_after_free_2.js
@@ -22,4 +22,6 @@
     output.push(text);
     console.log(text);
   };
+  // We manually report our result from the printErr hook above.
+  Module['REPORT_EXIT'] = false;
 })();

--- a/test/pthread/test_pthread_lsan_leak.js
+++ b/test/pthread/test_pthread_lsan_leak.js
@@ -28,4 +28,6 @@
     output.push(text);
   };
   Module['LSAN_OPTIONS'] = 'exitcode=0';
+  // We manually report our result from the printErr hook above.
+  Module['REPORT_EXIT'] = false;
 })();

--- a/test/pthread/test_pthread_lsan_no_leak.js
+++ b/test/pthread/test_pthread_lsan_no_leak.js
@@ -8,4 +8,6 @@
     output.push(text);
   };
   Module['LSAN_OPTIONS'] = 'exitcode=0';
+  // We manually report our result from the printErr hook above.
+  Module['REPORT_EXIT'] = false;
 })();

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4259,6 +4259,7 @@ Module["preRun"].push(function () {
   def test_pthread_asan_use_after_free(self):
     self.btest(test_file('pthread/test_pthread_asan_use_after_free.cpp'), expected='1', args=['-fsanitize=address', '-sINITIAL_MEMORY=256MB', '-pthread', '-sPROXY_TO_PTHREAD', '--pre-js', test_file('pthread/test_pthread_asan_use_after_free.js')])
 
+  @also_with_wasmfs
   @requires_threads
   def test_pthread_asan_use_after_free_2(self):
     # similiar to test_pthread_asan_use_after_free, but using a pool instead

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4259,6 +4259,7 @@ Module["preRun"].push(function () {
   def test_pthread_asan_use_after_free(self):
     self.btest(test_file('pthread/test_pthread_asan_use_after_free.cpp'), expected='1', args=['-fsanitize=address', '-sINITIAL_MEMORY=256MB', '-pthread', '-sPROXY_TO_PTHREAD', '--pre-js', test_file('pthread/test_pthread_asan_use_after_free.js')])
 
+  @no_firefox('https://github.com/emscripten-core/emscripten/issues/20006')
   @also_with_wasmfs
   @requires_threads
   def test_pthread_asan_use_after_free_2(self):


### PR DESCRIPTION
These tests work as follows:

* Listen for the print to stderr of the ASan output, check it is right, and report the result to the server.
* The reported result sets `reportResultToServer = true`.
* When we exit from main, we see that `true` and do not report the exit code from main (if we did, we'd error on excessive logging).

That does not work in WasmFS because the print to stderr happens on the pthread
(because we do not proxy every single stdio operation to the main thread constantly).
As a result, we set `reportResultToServer = true` on one thread, but when main exits
it checks it on another thread, and ends up reporting a second result which errored.

To fix that, let tests that report results themselves set a flag that prevents reporting
the result of main. A downside to this is that if the normal reporting fails, the test will
hang rather than error, but I don't have a good idea of how to avoid that.
