### PR TITLE
WasmFS: external wasmMemory backend

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -399,6 +399,9 @@ var LibraryPThread = {
 #if ASSERTIONS
         'workerID': worker.workerID,
 #endif
+#if WASMFS
+        'extWasmMemFS': Module['extWasmMemFS'],
+#endif
       });
     }),
 

--- a/src/library_wasmfs_extwasmmem.js
+++ b/src/library_wasmfs_extwasmmem.js
@@ -1,0 +1,619 @@
+/**
+ * @license
+ * Copyright 2023 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+// for cpp users: use fallocate() in advance to get better write performance.
+
+// WARNING for library developer: do not use << for uint in js, use * 4 instead.
+
+var LibraryExtWasmMemFS = {
+  $extWasmMemFS_local: {
+    /**@type Uint32Array*/
+    dataFilesU32: null, 
+    // empty_block: |block_size|next_empty_block_ptr|prev_empty_block_ptr|....|
+    // file_block: |block_size|0xffffffff|.....| // 0xffffffff marks file block.
+    // block size include itself, and should be allocated with 4 byte boundary, 12 byte minimal.
+
+    /**@type Uint8Array */
+    dataFilesU8: null,
+
+    /**@type Int32Array */
+    control: null, // | w_mutex | r_count | index_count | head_empty_ptr | unalloc_ptr | 
+
+    /** @type Uint32Array*/
+    index: null,  // |file_start_ptr|file_size| 
+    //file_start_ptr can be 0 for the space that have not been allocated.
+
+    
+    /**************** function below require proper rwlock. *****************/
+    get_block_size: function(ptr) {
+      return extWasmMemFS_local.dataFilesU32[ptr >>> 2];
+    },
+
+    get_next_empty_ptr: function(ptr) {
+      return extWasmMemFS_local.dataFilesU32[(ptr >>> 2) + 1];
+    },
+
+    set_next_empty_ptr: function(ptr, next_ptr) {
+      #if ASSERTIONS
+      assert(ptr > 0);
+      assert(next_ptr >= 0);
+      #endif
+      extWasmMemFS_local.dataFilesU32[(ptr >>> 2) + 1] = next_ptr;
+    },
+
+    get_prev_empty_ptr: function(ptr) {
+      return extWasmMemFS_local.dataFilesU32[(ptr >>> 2) + 2];
+    },
+
+    set_prev_empty_ptr: function(ptr, prev_ptr) {
+      #if ASSERTIONS
+      assert(ptr > 0);
+      assert(prev_ptr >= 0);
+      #endif
+      extWasmMemFS_local.dataFilesU32[(ptr >>> 2) + 2] = prev_ptr;
+    },
+
+    get_adjacent_block_ptr: function(ptr) {
+      return ptr + extWasmMemFS_local.get_block_size(ptr);
+    },
+
+    is_file_block: function(ptr) {
+      return extWasmMemFS_local.get_next_empty_ptr(ptr) === 0xffffffff;
+    },
+    
+    set_block_size: function(ptr, size) {
+      #if ASSERTIONS
+      assert(ptr > 0);
+      assert(size > 0);
+      #endif
+      extWasmMemFS_local.dataFilesU32[ptr >>> 2] = size;
+    },
+    
+    init_file_block: function(ptr, block_size) {
+      #if ASSERTIONS
+      assert(ptr > 0);
+      assert(block_size > 0);
+      #endif
+      extWasmMemFS_local.set_block_size(ptr, block_size);
+      extWasmMemFS_local.dataFilesU32[(ptr >>> 2) + 1] = 0xffffffff;
+    },
+
+    init_empty_block: function(ptr, block_size) {
+      #if ASSERTIONS
+      assert(ptr > 0);
+      assert(block_size > 0);
+      #endif
+      extWasmMemFS_local.set_block_size(ptr, block_size);
+      extWasmMemFS_local.set_prev_empty_ptr(ptr, 0);
+      extWasmMemFS_local.set_next_empty_ptr(ptr, 0);
+    },
+
+    get_empty_head: function() {
+      return extWasmMemFS_local.control[3];
+    },
+
+    get_empty_unalloc: function() {
+      return extWasmMemFS_local.control[4];
+    },
+
+    set_empty_head: function(new_head) {
+      extWasmMemFS_local.control[3] = new_head;
+    },
+
+    set_empty_unalloc: function(new_tail) {
+      extWasmMemFS_local.control[4] = new_tail;
+    },
+
+    remove_block_from_empty_list: function(ptr) {
+      #if ASSERTIONS
+      assert(ptr > 0);
+      #endif
+
+      var next = extWasmMemFS_local.get_next_empty_ptr(ptr);
+      var prev = extWasmMemFS_local.get_prev_empty_ptr(ptr);
+      if (prev === 0) {
+        extWasmMemFS_local.set_empty_head(next);
+      }
+
+      if (next !== 0) {
+        extWasmMemFS_local.set_prev_empty_ptr(next, prev);
+      }
+      
+      if (prev !== 0) {
+        extWasmMemFS_local.set_next_empty_ptr(prev, next);
+      }
+      extWasmMemFS_local.set_next_empty_ptr(ptr, 0);
+      extWasmMemFS_local.set_prev_empty_ptr(ptr, 0);
+    },
+
+    check_last_block_and_merge_into_unalloc: function(ptr) {
+      #if ASSERTIONS
+      assert(ptr > 0);
+      //the block should not be in empty list.
+      assert(extWasmMemFS_local.get_next_empty_ptr(ptr) === 0 || extWasmMemFS_local.get_next_empty_ptr(ptr) === 0xffffffff); 
+      #endif
+      if (extWasmMemFS_local.get_adjacent_block_ptr(ptr) === extWasmMemFS_local.get_empty_unalloc()) {
+        extWasmMemFS_local.dataFilesU8.fill(0, ptr, ptr+12);
+        extWasmMemFS_local.set_empty_unalloc(ptr);
+        return true;
+      }
+      return false;
+    },
+
+    check_continuous_empty_block_and_merge: function (ptr) {
+      #if ASSERTIONS
+      assert(ptr > 0);
+      #endif
+      //check if we can combine more empty block together.
+      var cptr = extWasmMemFS_local.get_adjacent_block_ptr(ptr);
+      var csize = extWasmMemFS_local.get_block_size(ptr);
+      var unalloc = extWasmMemFS_local.get_empty_unalloc();
+      while (cptr < unalloc && (!extWasmMemFS_local.is_file_block(cptr))) {
+        let bsize = extWasmMemFS_local.get_block_size(cptr);
+        csize += bsize;
+        if (bsize === 0) {
+          throw new Error("bad fs data block");
+        }
+        extWasmMemFS_local.remove_block_from_empty_list(cptr);
+        cptr = extWasmMemFS_local.get_adjacent_block_ptr(cptr);
+      }
+      extWasmMemFS_local.set_block_size(ptr, csize);
+    },
+
+    insert_empty_block_to_head: function (ptr) {
+      #if ASSERTIONS
+      assert(ptr > 0);
+      assert(extWasmMemFS_local.get_block_size(ptr) !== 0);
+      #endif
+
+      extWasmMemFS_local.check_continuous_empty_block_and_merge(ptr);            
+
+      //check if the block is last block in linear memory.
+      if (extWasmMemFS_local.check_last_block_and_merge_into_unalloc(ptr)) {
+        return;
+      }
+
+      var ohead = extWasmMemFS_local.get_empty_head();
+      if (ohead !== 0) {
+        extWasmMemFS_local.set_next_empty_ptr(ptr, ohead);
+        extWasmMemFS_local.set_prev_empty_ptr(ohead, ptr);
+        extWasmMemFS_local.set_prev_empty_ptr(ptr, 0);
+      } else {
+        extWasmMemFS_local.set_prev_empty_ptr(ptr, 0);
+        extWasmMemFS_local.set_next_empty_ptr(ptr, 0);
+      }
+
+      extWasmMemFS_local.set_empty_head(ptr);
+    },
+
+    update_typed_arrays: function () {
+      extWasmMemFS_local.dataFilesU32 = new Uint32Array(Module['extWasmMemFS']['dataFiles'].buffer); //data files may grow.
+      extWasmMemFS_local.dataFilesU8 = new Uint8Array(Module['extWasmMemFS']['dataFiles'].buffer);
+    },
+
+    ensure_underlied_buffer_size: function (byteLength) {
+      var buffer_size = extWasmMemFS_local.dataFilesU8.buffer.byteLength;
+      var deltaInByte = byteLength - buffer_size;
+      if (deltaInByte > 0) {
+        var delta = Math.max(deltaInByte, 200 * 1024 * 1024);
+        delta = (delta + 65535) >>> 16;
+        try {
+          Module['extWasmMemFS']['dataFiles'].grow(delta);
+        } catch (e) {
+          if (e instanceof RangeError) {
+            throw "ENOBUFS";
+          } else {
+            throw e;
+          }
+        }
+        extWasmMemFS_local.update_typed_arrays();
+      }
+    },
+
+    alloc_new_file_block_on_unalloc_region: function (size) {
+      var unalloc = extWasmMemFS_local.get_empty_unalloc();
+      extWasmMemFS_local.ensure_underlied_buffer_size(unalloc + size + 1);
+      extWasmMemFS_local.set_empty_unalloc(unalloc + size);
+      extWasmMemFS_local.init_file_block(unalloc, size);
+      return unalloc;
+    },
+
+    alloc_new_file_block_on_empty_block: function(empty_ptr, file_block_size) {
+      #if ASSERTIONS
+      assert(empty_ptr > 0);
+      assert(extWasmMemFS_local.get_block_size(empty_ptr) > 8);
+      #endif
+      var empty_size = extWasmMemFS_local.get_block_size(empty_ptr);
+      var real_alloc_size = (empty_size - file_block_size > 32)? file_block_size: empty_size;
+      extWasmMemFS_local.remove_block_from_empty_list(empty_ptr);
+      if (real_alloc_size < empty_size) {
+        //cut one empty block into two.
+        var new_empty_ptr = empty_ptr + real_alloc_size;
+        var new_empty_size = empty_size - real_alloc_size;
+        extWasmMemFS_local.init_empty_block(new_empty_ptr, new_empty_size);
+        extWasmMemFS_local.insert_empty_block_to_head(new_empty_ptr);
+      }
+      extWasmMemFS_local.init_file_block(empty_ptr, real_alloc_size);
+      return empty_ptr;
+    },
+
+    alloc_new_file_block: function (file_block_size) {           
+      var eptr = extWasmMemFS_local.get_empty_head();
+      while (eptr !== 0) {
+        extWasmMemFS_local.check_continuous_empty_block_and_merge(eptr);
+        if (extWasmMemFS_local.get_block_size(eptr) >= file_block_size) {
+          //found an empty block.
+          break;
+        }
+        eptr = extWasmMemFS_local.get_next_empty_ptr(eptr);
+      }
+
+      if (eptr !== 0) {
+        // found an empty block.
+        return extWasmMemFS_local.alloc_new_file_block_on_empty_block(eptr, file_block_size);
+      } 
+
+      return extWasmMemFS_local.alloc_new_file_block_on_unalloc_region(file_block_size);                        
+    },
+
+    try_expand_file_block: function (ptr, required_size, initalizeToZero) {
+      var original_size = extWasmMemFS_local.get_block_size(ptr);
+      var delta = required_size - original_size;
+      if (delta <= 0) {
+        return true; //large enough.
+      }
+      
+      // 1. if current block is last block, get space from unalloc region, expand the dataFile buffer with grow if needed.
+      var unalloc = extWasmMemFS_local.get_empty_unalloc();
+      var adjacent_ptr = extWasmMemFS_local.get_adjacent_block_ptr(ptr);
+      if (adjacent_ptr >= unalloc) {
+        try {
+          extWasmMemFS_local.ensure_underlied_buffer_size(ptr + required_size + 1);
+        } catch (e) {
+          if (e === "ENOBUFS") {
+            return false;
+          } else {
+            throw e;
+          }
+        }
+        extWasmMemFS_local.set_empty_unalloc(ptr + required_size);
+        extWasmMemFS_local.set_block_size(ptr, required_size);
+        return true;
+      }
+
+      // 2. if not last block, use get_adjacent_ptr to find empty blocks behind current file block.
+      if (!extWasmMemFS_local.is_file_block(adjacent_ptr)) {
+        var empty_block_size = extWasmMemFS_local.get_block_size(adjacent_ptr);
+        if (empty_block_size + original_size >= required_size) {
+          
+          //for situation that empty block is too large and need split.
+          extWasmMemFS_local.alloc_new_file_block_on_empty_block(adjacent_ptr, required_size - original_size);
+          var new_block_size = extWasmMemFS_local.get_block_size(adjacent_ptr);
+          extWasmMemFS_local.set_block_size(ptr, original_size + new_block_size);
+          if (initalizeToZero) {
+            extWasmMemFS_local.dataFilesU8.fill(0, adjacent_ptr, adjacent_ptr + new_block_size);
+          }
+          return true;
+        }
+      }
+
+      return false;
+    },
+
+    shrink_file_block: function (ptr, shrink_size) {
+      //not implemented.
+    },
+
+    delete_file_block: function (ptr) {
+      extWasmMemFS_local.init_empty_block(ptr, extWasmMemFS_local.get_block_size(ptr))
+      extWasmMemFS_local.insert_empty_block_to_head(ptr);
+    },
+    /*********** Function above require proper rwlock. ***********/
+
+  },
+  $extWasmMemFS_local__postset:
+  `
+extWasmMemFS_local.control = new Uint32Array(Module['extWasmMemFS']['control']);
+extWasmMemFS_local.index = new Uint32Array(Module['extWasmMemFS']['index']);
+  `,
+
+  $extWasmMemFS_rwlock: {    
+    r_lock: function () {
+      while (1) {
+        while (Atomics.load(extWasmMemFS_local.control, 0) === 1) {}
+        Atomics.add(extWasmMemFS_local.control, 1, 1);
+        if (Atomics.load(extWasmMemFS_local.control, 0) === 1) {
+          Atomics.sub(extWasmMemFS_local.control, 1, 1);
+        } else {
+          break;
+        }
+      }
+      extWasmMemFS_local.update_typed_arrays();
+    },
+
+    r_unlock: function () {
+      Atomics.sub(extWasmMemFS_local.control, 1, 1);
+    },
+
+    w_lock: function() {
+      while(Atomics.exchange(extWasmMemFS_local.control, 0, 1) === 0) {}
+      while(Atomics.load(extWasmMemFS_local.control, 1) !== 0) {}
+      extWasmMemFS_local.update_typed_arrays();
+    },
+  
+    w_unlock: function() {
+      Atomics.store(extWasmMemFS_local.control, 0, 0);
+    }
+  },
+
+  wasmfs_extwasmmem_file_handle_alloc__sig:'i',
+  wasmfs_extwasmmem_file_handle_alloc: function() {
+    let myindex = Atomics.add(extWasmMemFS_local.control, 2, 1);
+    return myindex;
+  },
+
+  wasmfs_extwasmmem_file_open__sig:'iii',
+  wasmfs_extwasmmem_file_open: function(handle, bCreate) {
+    return 0;
+  },
+
+  wasmfs_extwasmmem_file_delete__sig:'vi',
+  wasmfs_extwasmmem_file_delete: function(handle) {
+    extWasmMemFS_rwlock.w_lock();
+    var file_block_ptr = extWasmMemFS_local.index[handle * 2];
+    if (file_block_ptr > 0) {
+      //delete twice or empty file will cause file_block_ptr to be 0
+      extWasmMemFS_local.index[handle * 2 + 1] = 0;
+      extWasmMemFS_local.index[handle * 2] = 0;
+      extWasmMemFS_local.delete_file_block(file_block_ptr);
+    }
+    extWasmMemFS_rwlock.w_unlock();
+  },
+
+  $wasmfs_extwasmmem_file_read_internal: function (handle, wasmBuf, len, offset) {
+    var file_block_ptr = extWasmMemFS_local.index[handle * 2];
+    var file_size = extWasmMemFS_local.index[handle * 2 + 1];
+    if (file_block_ptr === 0) {
+      return 0;
+    }
+
+    var read_start = file_block_ptr + 8 + offset;
+    var read_end = Math.min(file_block_ptr + 8 + offset + len, file_block_ptr + 8 + file_size);
+    if (read_start >= read_end) {
+      return 0;
+    }
+
+    if (wasmBuf === null) {
+      return extWasmMemFS_local.dataFilesU8.slice(read_start, read_end);
+    } else {
+      HEAPU8.set(extWasmMemFS_local.dataFilesU8.subarray(read_start, read_end), wasmBuf);
+    }
+    return read_end - read_start
+  },
+
+  wasmfs_extwasmmem_file_read__deps: ['$wasmfs_extwasmmem_file_read_internal'],
+  wasmfs_extwasmmem_file_read__sig:'iipii',
+  wasmfs_extwasmmem_file_read: function(handle, wasmBuf, len, offset) {
+    extWasmMemFS_rwlock.r_lock();
+    var ret = wasmfs_extwasmmem_file_read_internal(handle, wasmBuf, len, offset);
+    extWasmMemFS_rwlock.r_unlock();
+    return ret;
+  },
+
+  $wasmfs_extwasmmem_file_write_internal: function (handle, sourceArray, len, offset, isSetSize) {
+    if (len > 2147483647) return -{{{cDefine('EFBIG')}}};
+    var file_block_ptr = extWasmMemFS_local.index[handle * 2];
+    var file_size = extWasmMemFS_local.index[(handle * 2) + 1];
+    var file_exists = (file_block_ptr > 0);
+    var file_block_size = 0;
+    if (file_exists) {
+      file_block_size = extWasmMemFS_local.get_block_size(file_block_ptr);
+    }
+    var new_file_size = Math.max(file_size, offset + len);
+    var required_block_size = ((new_file_size + 8 + 3) >>> 2) * 4; // 3->4, 4->4, 5->8, 6->8, etc. 
+
+    //1. block is not large enough, try to expand it.
+    if (file_exists && file_block_size < required_block_size) {
+      
+      //allocate more at first try.
+      var success = false;
+      if (!isSetSize){ 
+        var rec = ((Math.floor(required_block_size * 1.25) + 3) >>> 2) * 4;
+        success = extWasmMemFS_local.try_expand_file_block(file_block_ptr, rec, false);
+      }
+      
+      if (!success) {
+        success = extWasmMemFS_local.try_expand_file_block(file_block_ptr, required_block_size, isSetSize);
+      }
+      
+      if (success) {
+        file_block_size = extWasmMemFS_local.get_block_size(file_block_ptr);
+      }
+    }
+    
+    //2. file exists and file block is large enough.
+    if (file_exists && file_block_size >= required_block_size) {
+      if (offset > file_size) {
+        extWasmMemFS_local.dataFilesU8.fill(0, file_block_ptr + 8 + file_size, file_block_ptr + 8 + offset);
+      }
+      if (sourceArray === null) {
+        extWasmMemFS_local.dataFilesU8.fill(0, file_block_ptr + 8 + offset, file_block_ptr + 8 + offset + len);
+      } else {
+        extWasmMemFS_local.dataFilesU8.set(sourceArray, file_block_ptr + 8 + offset);
+      }
+      extWasmMemFS_local.index[(handle * 2) + 1] = new_file_size;
+      return len;
+    }
+
+    //3. file not exists or file block is not large enough, alloc a new block.
+    var recommended_alloc_space = required_block_size;
+    if (!isSetSize) {
+      recommended_alloc_space = recommended_alloc_space > 64 * 1024 ? required_block_size * 1.2 : required_block_size * 2; 
+      recommended_alloc_space = ((Math.ceil(recommended_alloc_space) + 3) >>> 2) * 4;
+    } 
+    var new_file_block_ptr = extWasmMemFS_local.alloc_new_file_block(recommended_alloc_space);
+    
+    //4. write to new place
+    extWasmMemFS_local.dataFilesU8.copyWithin(new_file_block_ptr + 8, file_block_ptr + 8, file_block_ptr + 8 + file_size);
+    if (offset > file_size) {
+      extWasmMemFS_local.dataFilesU8.fill(0, new_file_block_ptr + 8 + file_size, new_file_block_ptr + 8 + offset);
+    }
+    if (sourceArray === null) {
+      extWasmMemFS_local.dataFilesU8.fill(0, new_file_block_ptr + 8 + offset, new_file_block_ptr + 8 + offset + len);
+    } else {
+      extWasmMemFS_local.dataFilesU8.set(sourceArray, new_file_block_ptr + 8 + offset);
+    }
+    
+    //5. update index.
+    extWasmMemFS_local.index[handle * 2] = new_file_block_ptr;
+    extWasmMemFS_local.index[handle * 2 + 1] = new_file_size;
+
+    //6. if file exists originally, free the orignal space.
+    if (file_exists) {
+      extWasmMemFS_local.delete_file_block(file_block_ptr);
+    }
+    return len;
+  },
+
+  wasmfs_extwasmmem_file_write__deps: ['$wasmfs_extwasmmem_file_write_internal'],
+  wasmfs_extwasmmem_file_write__sig:'iipii',
+  wasmfs_extwasmmem_file_write: function(handle, buf, len, offset) {
+    if (len === 0) {
+      return 0;
+    }
+    extWasmMemFS_rwlock.w_lock();
+    var ret;
+    try {
+      ret = wasmfs_extwasmmem_file_write_internal(handle, HEAPU8.subarray(buf, buf + len), len, offset, false);
+    } catch (e) {
+      if (e === "ENOBUFS") {
+        ret = 0;
+      } else {
+        throw e;
+      }
+    } finally {
+      extWasmMemFS_rwlock.w_unlock();
+    }
+    
+    if (ret < 0) {
+      return 0;
+    }
+    return ret;
+  },
+
+  wasmfs_extwasmmem_file_getSize__sig:'ii',
+  wasmfs_extwasmmem_file_getSize: function(handle) {
+    extWasmMemFS_rwlock.r_lock();
+    var size = extWasmMemFS_local.index[(handle << 1) | 1];
+    extWasmMemFS_rwlock.r_unlock();
+    return size;
+  },
+
+  wasmfs_extwasmmem_file_setSize__deps: ['$wasmfs_extwasmmem_file_write_internal'],
+  wasmfs_extwasmmem_file_setSize__sig:'iii',
+  wasmfs_extwasmmem_file_setSize: function(handle, targetSize) {
+    extWasmMemFS_rwlock.w_lock();
+    
+    var file_block_ptr = extWasmMemFS_local.index[handle * 2];
+    var file_size = extWasmMemFS_local.index[(handle * 2) + 1];
+    if (file_size >= targetSize && file_block_ptr > 0) {
+      extWasmMemFS_local.shrink_file_block(file_block_ptr, targetSize);
+      extWasmMemFS_local.index[(handle * 2) + 1] = targetSize;
+    } else {
+      wasmfs_extwasmmem_file_write_internal(handle, null, targetSize - file_size, file_size, true);
+    }
+
+    extWasmMemFS_rwlock.w_unlock();
+    return 0;
+  },
+
+  // js api for fast r/w file, mainly for use in main thread.
+  // File and its dir should be created with posix file api in advance.
+  // For other file operation, use posix file api as well.
+  $ExtWasmMemFS__deps: ['$withStackSave', '$allocateUTF8OnStack', '$wasmfs_extwasmmem_file_write_internal', '$wasmfs_extwasmmem_file_read_internal', 'wasmfs_extwasmmem_file_setSize', '_extwasmmem_get_file_handle_by_path'],
+  $ExtWasmMemFS: {
+    
+    /**
+     * 
+     * @param {string} path 
+     * @param {Uint8Array} data 
+     */
+    writeFile: function (path, data, entire_file_hint) {
+      var u8array = data;
+      var len = u8array.length;
+      if (entire_file_hint === undefined) {
+        entire_file_hint = true; //default to true.
+      }
+
+      var handle = withStackSave(() => {
+        let __path = allocateUTF8OnStack(path);
+        let handle = __extwasmmem_get_file_handle_by_path(__path, /*createIfNotExist = */1);
+        return handle;
+      });
+
+      let ret = handle;
+      if (handle >= 0) {
+        if (len === 0) {
+          return 0;
+        }
+        extWasmMemFS_rwlock.w_lock();
+        try {
+          ret = wasmfs_extwasmmem_file_write_internal(handle, u8array, len, 0, entire_file_hint);
+        } catch (ex) {
+          if (ex === 'ENOBUFS') {
+            return -{{{cDefine('ENOBUFS')}}};
+          } else {
+            throw ex;
+          }
+        } finally {
+          extWasmMemFS_rwlock.w_unlock();
+        }
+      }
+
+      if (ret < 0) {
+        err("extwasmmemFS bad write, errno: "+ ret);
+      }
+      
+      return ret;
+    },
+
+    /**
+     * 
+     * @param {string} path 
+     * @param {{len: number, offset: number}} opts
+     * @return {Uint8Array | number} content read in a new Uint8Array or negative errno.
+     */
+    readFile: function (path, opts={}) {
+      var len = opts.len = opts.len || 0xffffffff;
+      var offset = opts.offset = opts.offset || 0;
+      var handle = withStackSave(() => {
+        let __path = allocateUTF8OnStack(path);
+        let handle = __extwasmmem_get_file_handle_by_path(__path, /*createIfNotExist = */0);
+        return handle;
+      });
+      let ret = handle;
+      if (handle >= 0) {
+        extWasmMemFS_rwlock.r_lock();
+        ret = wasmfs_extwasmmem_file_read_internal(handle, null, len, offset);
+        extWasmMemFS_rwlock.r_unlock();
+      }
+
+      if ((typeof ret) === 'number' && ret < 0) {
+        err("extwasmmemFS bad read, errno: " + ret);
+        return ret;
+      } else if (ret === 0) {
+        ret = new Uint8Array();
+      }
+      
+      return ret;
+    }
+  }
+};
+
+autoAddDeps(LibraryExtWasmMemFS, "$extWasmMemFS_local");
+autoAddDeps(LibraryExtWasmMemFS, "$extWasmMemFS_rwlock");
+mergeInto(LibraryManager.library, LibraryExtWasmMemFS);
+DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.push('$ExtWasmMemFS');

--- a/src/modules.js
+++ b/src/modules.js
@@ -93,6 +93,7 @@ global.LibraryManager = {
           'library_wasmfs_fetch.js',
           'library_wasmfs_node.js',
           'library_wasmfs_opfs.js',
+          'library_wasmfs_extwasmmem.js',
         ]);
       } else {
         // Core filesystem libraries (always linked against, unless -sFILESYSTEM=0 is specified)

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -178,6 +178,7 @@ assert(!Module['INITIAL_MEMORY'], 'Detected runtime INITIAL_MEMORY setting.  Use
 #include "runtime_init_table.js"
 #include "runtime_stack_check.js"
 #include "runtime_assertions.js"
+#include "runtime_init_extwasmmemfs.js"
 
 var __ATPRERUN__  = []; // functions called before the runtime is initialized
 var __ATINIT__    = []; // functions called during startup

--- a/src/runtime_init_extwasmmemfs.js
+++ b/src/runtime_init_extwasmmemfs.js
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2023 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+#if WASMFS
+if (!ENVIRONMENT_IS_WORKER) {
+  Module["extWasmMemFS"] = {
+    "dataFiles": new WebAssembly.Memory({
+      initial: 1 << 9, // 32 MB
+      maximum: 1 << 16, // 4 GB
+      shared: true,
+    }),
+    "control": new SharedArrayBuffer(64),
+    "index": new SharedArrayBuffer(2 * 1024 * 1024 * 8), // 2M files max.
+  }
+
+  let __extWasmMem$dataFile = new Uint32Array(Module["extWasmMemFS"]["dataFiles"].buffer);
+  __extWasmMem$dataFile[0] = 0; //ensure block 0 is unusable.
+  __extWasmMem$dataFile[1] = 0;
+
+  let __extWasmMem$control = new Uint32Array(Module["extWasmMemFS"]["control"]);
+  __extWasmMem$control[3] = 0;
+  __extWasmMem$control[4] = 8;
+}
+#endif

--- a/src/worker.js
+++ b/src/worker.js
@@ -142,6 +142,12 @@ function handleMessage(e) {
       Module['wasmModule'] = e.data.wasmModule;
 #endif // MINIMAL_RUNTIME
 
+#if WASMFS
+      if (e.data.extWasmMemFS) {
+        Module['extWasmMemFS'] = e.data.extWasmMemFS;
+      }
+#endif
+
 #if MAIN_MODULE
       Module['sharedModules'] = e.data.sharedModules;
 #if RUNTIME_DEBUG

--- a/system/include/emscripten/wasmfs.h
+++ b/system/include/emscripten/wasmfs.h
@@ -74,6 +74,14 @@ backend_t wasmfs_create_opfs_backend(void);
 
 backend_t wasmfs_create_icase_backend(backend_t backend);
 
+// Note: This is similar to a memory backend but data files are saved in another 
+// growable WebAssembly.Memory instance, which ensures a maximum 4GB seperated 
+// file storage. 
+// 
+// Note: ExtWasmMem is optimized for multi-thread read/write performance. It also
+// has its own faster file read/write JS API, see in library_wasmfs_extwasmmem.js
+backend_t wasmfs_create_extwasmmem_backend(void);
+
 // Similar to fflush(0), but also flushes all internal buffers inside WasmFS.
 // This is necessary because in a Web environment we must buffer at an
 // additional level after libc, since console.log() prints entire lines, that

--- a/system/lib/wasmfs/backends/extwasmmem_backend.cpp
+++ b/system/lib/wasmfs/backends/extwasmmem_backend.cpp
@@ -1,0 +1,150 @@
+// Copyright 2023 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include "../paths.h"
+#include "backend.h"
+#include "memory_backend.h"
+#include "support.h"
+#include "thread_utils.h"
+#include "wasmfs.h"
+#include <condition_variable>
+#include <emscripten/emscripten.h>
+#include <emscripten/threading.h>
+#include <memory>
+#include <mutex>
+#include <stdlib.h>
+#include <thread>
+
+extern "C" {
+int wasmfs_extwasmmem_file_handle_alloc();
+void wasmfs_extwasmmem_file_delete(int dataFileHandle);
+int wasmfs_extwasmmem_file_open(int dataFileHandle, int bCreate);
+ssize_t wasmfs_extwasmmem_file_read(int dataFileHandle,
+                                    uint8_t* buf,
+                                    unsigned long len,
+                                    long offset);
+ssize_t wasmfs_extwasmmem_file_write(int dataFileHandle,
+                                     const uint8_t* buf,
+                                     unsigned long len,
+                                     long offset);
+int wasmfs_extwasmmem_file_getSize(int dataFileHandle);
+int wasmfs_extwasmmem_file_setSize(int dataFileHandle, unsigned long size);
+}
+
+namespace wasmfs {
+
+class ExtWasmMemFSFile : public DataFile {
+public:
+  ExtWasmMemFSFile(mode_t mode, backend_t backend) : DataFile(mode, backend) {
+    js_handle = wasmfs_extwasmmem_file_handle_alloc();
+  }
+
+  virtual ~ExtWasmMemFSFile() override {
+    wasmfs_extwasmmem_file_delete(js_handle);
+  }
+
+  // Notify the backend when this file is opened or closed. The backend is
+  // responsible for keeping files accessible as long as they are open, even if
+  // they are unlinked. Returns 0 on success or a negative error code.
+  virtual int open(oflags_t flags) override {
+    return wasmfs_extwasmmem_file_open(js_handle, (flags & O_CREAT));
+  }
+  virtual int close() override { return 0; }
+
+  // Return the accessed length or a negative error code. It is not an error to
+  // access fewer bytes than requested. Will only be called on opened files.
+  // TODO: Allow backends to override the version of read with
+  // multiple iovecs to make it possible to implement pipes. See #16269.
+  virtual ssize_t read(uint8_t* buf, size_t len, off_t offset) override {
+    return wasmfs_extwasmmem_file_read(js_handle, buf, len, offset);
+  }
+
+  virtual ssize_t write(const uint8_t* buf, size_t len, off_t offset) override {
+    return wasmfs_extwasmmem_file_write(js_handle, buf, len, offset);
+  }
+
+  // The the size in bytes of a file or return a negative error code. May be
+  // called on files that have not been opened.
+  virtual off_t getSize() override {
+    return wasmfs_extwasmmem_file_getSize(js_handle);
+  }
+
+  // Sets the size of the file to a specific size. If new space is allocated, it
+  // should be zero-initialized. May be called on files that have not been
+  // opened. Returns 0 on success or a negative error code.
+  virtual int setSize(off_t size) override {
+    return wasmfs_extwasmmem_file_setSize(js_handle, size);
+  }
+
+  // Sync the file data to the underlying persistent storage, if any. Returns 0
+  // on success or a negative error code.
+  virtual int flush() override { return 0; }
+
+  int getHandle() { return js_handle; }
+
+private:
+  int js_handle;
+};
+
+class ExtWasmMemFSBackEnd : public Backend {
+public:
+  std::shared_ptr<DataFile> createFile(mode_t mode) override {
+    return std::make_shared<ExtWasmMemFSFile>(mode, this);
+  }
+  std::shared_ptr<Directory> createDirectory(mode_t mode) override {
+    return std::make_shared<MemoryDirectory>(mode, this);
+  }
+  std::shared_ptr<Symlink> createSymlink(std::string target) override {
+    return std::make_shared<MemorySymlink>(target, this);
+  }
+};
+} // namespace wasmfs
+
+using namespace wasmfs;
+extern "C" {
+backend_t wasmfs_create_extwasmmem_backend() {
+  return wasmFS.addBackend(std::make_unique<ExtWasmMemFSBackEnd>());
+}
+
+int EMSCRIPTEN_KEEPALIVE
+_extwasmmem_get_file_handle_by_path(const char* path, int createIfNotExist) {
+  auto parsedParent = path::parseParent(path);
+  if (parsedParent.getError()) {
+    return -EFAULT;
+  }
+  auto& [parent, childNameView] = parsedParent.getParentChild();
+  std::string childName(childNameView);
+
+  std::shared_ptr<File> child;
+  {
+    auto lockedParent = parent->locked();
+    child = lockedParent.getChild(childName);
+    if (!child) {
+      if (createIfNotExist) {
+        // Lookup failed; try creating the file.
+        child = lockedParent.insertDataFile(childName, 0777);
+      }
+      if (!child) {
+        // File creation failed; nothing else to do.
+        return -EFAULT;
+      }
+    }
+  }
+
+  auto dataFile = child->dynCast<DataFile>();
+  if (!dataFile) {
+    // There is something here but it isn't a data file.
+    return -EFAULT;
+  }
+
+  auto extwasmmem_file = std::dynamic_pointer_cast<ExtWasmMemFSFile>(dataFile);
+  if (extwasmmem_file == nullptr) {
+    assert(extwasmmem_file &&
+           "file is not hosted by extWasmMem, check your path.");
+    return -EFAULT;
+  }
+  return extwasmmem_file->getHandle();
+}
+}

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1857,7 +1857,8 @@ class libwasmfs(DebugLibrary, AsanInstrumentedLibrary, MTLibrary):
                    'js_file_backend.cpp',
                    'memory_backend.cpp',
                    'node_backend.cpp',
-                   'opfs_backend.cpp'])
+                   'opfs_backend.cpp',
+                   'extwasmmem_backend.cpp'])
     return backends + files_in_path(
         path='system/lib/wasmfs',
         filenames=['file.cpp',


### PR DESCRIPTION
Recently we developed this new wasmfs backend based on our demands, and we are happy to contribute it to the webassembly community. Any suggestion is welcome.

We have deployed this backend in our web app for 3 months in the production environment, and it works well. This pr is a fully productive version, and tests will be completed in a few weeks. For this pr, we would like to know everyone's idea on whether this feature could be merged and how to improve it further.

The doc is attached below.

# ExtWasmMemFS: A 'WebAssembly.Memory' Based, Fully-Multithreaded Synchronizing WasmFS Backend
This doc describes a file storage system implemented using WebAssembly.Memory. Provides the ability to synchronize reads and writes directly from any thread.
Based on Emscripten 3.1.28 + version.

## Spotlights
1. Based on Memorybackend, but use another WebAssembly.Memory instance as a memory pool to save datafiles.
2. File storage will not occupy runtime memory, and can grow on demand.
3. Full 4GB maximum storage support (tested and used on our app).
2. All threads can access file content without `postmessage` to other threads, so the performance will not be affected by main thread usage.
3. Atomic lock implemented for thread-safe and main-thread access.
4. Provides JS API for fast read/write to file in JS code by copying data from external wasm memory directly to js arraybuffer.


## Implementation
The essence is to implement a memory pool on WebAssembly.Memory.
### Data Layout
All ExtWasmMemFS data is stored in the following singleton object, shared with all threads:
```
Module["extWasmMemFS"] = {
    "dataFiles": new WebAssembly.Memory({
        initial: 1 << 9, // 32 MB
        maximum: 1 << 16, // 4 GB
        shared: true,
    }),
    "control": new SharedArrayBuffer(20),
    "index": new SharedArrayBuffer(2 * 1024 * 1024 * 8), // 2M files max.
}
```
Our data is stored in three buffers: dataFiles, control, and index.

### extWasmMemFS.dataFiles
The dataFiles buffer is the main buffer for storing the contents of the file, so WebAssembly.Memory, which can be grown, is used.
The dataFiles are composed as follows:
```
dataFiles: |0|block 1|block 2| ... |block n|......unalloc area......|
            ^                               ^                       ^
         (8 bytes)                          unalloc_pointer         buffer.byteLength

Block can be one of file_block or empty_block.

empty_block: |block_size|next_empty_block_ptr|prev_empty_block_ptr|.......(trash data).......|
                4 bytes         4 bytes               4 bytes        (block_size - 12) bytes   

file_block:  |block_size|0xFFFFFFFF|.........(file content).......|
                4 bytes    4 bytes       (block_size - 8) bytes

block_size include itself.
Every block should be allocated at a 4-byte boundary and has 12 bytes for minimal size.
```
To ensure continuous memory read and write, for copy performance, each file is saved in a single file_block.
All empty_blocks form a doubly linked list. The first 8 bytes of dataFiles are not used in order to guarantee that ptr == 0 is meaningless.

### extWasmMemFS.index
`index` stores the file_block header pointer for each file, as well as the file size.
The layout is as follows:
```
index: |file_0_block_ptr| file_0_size| file_1_block_ptr | file_1_size | ... |
             4 byte         4 byte          4 byte           4 byte
Each file occupies 8 bytes of space. Note that file_size is different from file_block_size.
```

### extWasmMemFS.control
Store 5 int32 numbers
```
| w_mutex | r_count | index_count | head_empty_ptr | unalloc_ptr |
```
- w_mutex, r_count: Two atomic variables that make up a read-write lock. Both reads and writes to ExtWasmMemFS use the same read-write lock.
- index_count: Atomic variable that records the number of files in the index buffer, increasing only.
- head_empty_ptr: Head of the empty_block doubly linked list in the dataFiles buffer. (Tail pointer is not recorded for it is not used.)
- unalloc_ptr: Pointer to an unallocated position in the dataFiles, 1 byte behind the end of the last block, probably just beyond buffer.bytelength.

## Function Details
### Read-write lock
- All operations on ExtWasmMemFS use one read-write lock implemented by atomic operation, write operations are guaranteed to be operated by only one thread, and all waits are synchronous spin waits.
- Insufficient subsequent write performance can be optimized by seperating memory pool operation locks and single file locks, reducing granularity. (Not implemented, Our app does not care write performance.)
### Handle provided to the C++ section
- Each C++ DataFile instance corresponds to an index buffer number. Allocated by the index_count counter in the control buffer.
### Method for allocating file blocks of a given size on dataFiles
- Find a large enough block by head_empty_ptr traversing the doubly linked list.
  - Try to expand each empty_block backward while traversing (see the Defragmentation section below.)
- If an available empty_block is found.
  - Remove this block from the linked list.
  - The block will be splitted into two blocks, where the first block is the required file_block and the second block is a new empty_block.
    - If there is no enough space (emphirical value is used here), there will be no second block, and the original block will be turned into a file_block as a whole (the size may be larger than the application value, but it ensures that the adjacent blocks are continuous, and the empty_block will not be too small and scattered.)
  - Initialize file_block and empty_block (write block_size and file 0xffffffff flag)
  - Insert a new empty_block into the doubly linked list. (Just insert from the table header using head_empty_ptr)
- If there is no empty_block available.
  - Allocate a block from the unalloc area
  - If the allocated size exceeds the buffer length, call memory.grow () to request more memory.
  - Initialization file_block
  - Update unalloc_ptr
### How to delete file blocks on dataFiles
- Defragmentation
  - Try to expand the block backwards.
  - If the block is the last block, it is directly put into unalloc area.
- If not, insert the block into the doubly linked list. (Just insert it at the head position using head_empty_ptr)
### Defrag - Expand blocks backwards
  - Find the next adjacent block by block_size, if it is an empty_block:
    - Remove the next adjacent block from the list and add size to the previous block_size.
    - Repeat until the next block is not a empty_block or reaching unalloc area;
### Defrag - try to put into unalloc
  - If block is the last block (block_ptr + block_size > = unalloc_ptr)
    - unalloc_ptr = block_ptr;
### Try to expand a file_block in place:
  1. If the current block is the last block in the buffer, the space is taken from the unalloc area, and dataFiles.buffer.grow () is used to request more memory when needed.
  5. If it is not the last block, try to find a empty_block after the current file block.
    1. Because we have defragmentation to expand empty_blocks backwards, one empty_block lookahead is enough.
    2. If the empty_block too large, we will split it into two blocks,maintain doubly linked list, and then merged the front one into file_block.
### File writing (write API)
  - Read file_block_ptr from index_buffer
  - If file_block large enough, write directly
  - Try to expand file_block
  - Unable to expand, assign new file_block
    - file_block Pre-allocation size calculation strategy: file_size > 65536? file_size * 1.2: file_size * 2;
    - Copy existing content to a new file_block
  - Write content
### File reading (read API)
  - Read according to the data layout. 🤪

## In-thread TypedArray object cache and cache invalidation
The read/write of SharedArrayBuffer requires the creation of TypedArray objects, and frequent creation of TypedArray objects will affect performance, so we need to maintain a set of TypedArray objects per thread to facilitate reading and writing. In ExtWasmMemFS we construct the following extWasmMemFS_local object in each web worker:
```
$extWasmMemFS_local: {
        /**@type Uint32Array*/
        dataFilesU32: null, 

        /**@type Uint8Array */
        dataFilesU8: null,

        /**@type Int32Array */
        control: null,

        /** @type Uint32Array*/
        index: null,
}

//run in __postset
extWasmMemFS_local.control = new Int32Array(Module['extWasmMemFS']['control']);
extWasmMemFS_local.index = new Uint32Array(Module['extWasmMemFS']['index']);
extWasmMemFS_local.dataFilesU32 = new Uint32Array(Module['extWasmMemFS']['dataFiles'].buffer);
extWasmMemFS_local.dataFilesU8 = new Uint8Array(Module['extWasmMemFS']['dataFiles'].buffer);
```

However, the cache may be invalid when WebAssembly.Memory.prototype.grow() get called. At that time, it is necessary to recreate the corresponding TypedArray:
```
extWasmMemFS_local.dataFilesU32 = new Uint32Array(Module['extWasmMemFS']['dataFiles'].buffer);
extWasmMemFS_local.dataFilesU8 = new Uint8Array(Module['extWasmMemFS']['dataFiles'].buffer);
```
Because we shall maintain a multi-threaded architecture, other threads cannot receive messages about buffer changes, so other threads need to check and update at a certain time.

And, because the thread must take the write lock of the global read-write lock when perform the buffer grow. So in other thread, it is sufficient to do a typearray recreation only after every time the thread gets the write lock.