### PR TITLE
Declare _emscripten_thread_supports_atomics_wait in threading_internal.h. NFC

### DIFF
--- a/system/lib/pthread/emscripten_futex_wait.c
+++ b/system/lib/pthread/emscripten_futex_wait.c
@@ -17,8 +17,6 @@
 
 extern void* _emscripten_main_thread_futex;
 
-int _emscripten_thread_supports_atomics_wait(void);
-
 static int futex_wait_main_browser_thread(volatile void* addr,
                                           uint32_t val,
                                           double timeout) {

--- a/system/lib/pthread/thread_mailbox.c
+++ b/system/lib/pthread/thread_mailbox.c
@@ -44,9 +44,6 @@ void emscripten_thread_mailbox_unref(pthread_t thread) {
   }
 }
 
-// Defined in emscripten_thread_state.S.
-int _emscripten_thread_supports_atomics_wait(void);
-
 void _emscripten_thread_mailbox_shutdown(pthread_t thread) {
   assert(thread == pthread_self());
 

--- a/system/lib/pthread/threading_internal.h
+++ b/system/lib/pthread/threading_internal.h
@@ -96,3 +96,8 @@ int _emscripten_default_pthread_stack_size();
 void __set_thread_state(pthread_t ptr, int is_main, int is_runtime, int can_block);
 
 double _emscripten_receive_on_main_thread_js(int functionIndex, pthread_t callingThread, int numCallArgs, double* args);
+
+// Return non-zero if the calling thread supports Atomic.wait (For example
+// if called from the main browser thread, this function will return zero
+// since blocking is not allowed there).
+int _emscripten_thread_supports_atomics_wait(void);

--- a/test/webaudio/audioworklet_emscripten_futex_wake.cpp
+++ b/test/webaudio/audioworklet_emscripten_futex_wake.cpp
@@ -13,8 +13,6 @@
 int futexLocation = 0;
 int testSuccess = 0;
 
-extern "C" int _emscripten_thread_supports_atomics_wait(void);
-
 EM_BOOL ProcessAudio(int numInputs, const AudioSampleFrame *inputs, int numOutputs, AudioSampleFrame *outputs, int numParams, const AudioParamFrame *params, void *userData)
 {
   int supportsAtomicWait = _emscripten_thread_supports_atomics_wait();


### PR DESCRIPTION
Since there are several callers its just good practice.  Also we are likely adding more caller: #20011