### PR TITLE
Use normal property access in intArrayFromBase64. NFC

### DIFF
--- a/src/base64Utils.js
+++ b/src/base64Utils.js
@@ -14,7 +14,7 @@ function intArrayFromBase64(s) {
 #if ENVIRONMENT_MAY_BE_NODE
   if (typeof ENVIRONMENT_IS_NODE != 'undefined' && ENVIRONMENT_IS_NODE) {
     var buf = Buffer.from(s, 'base64');
-    return new Uint8Array(buf['buffer'], buf['byteOffset'], buf['byteLength']);
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.length);
   }
 #endif
 

--- a/third_party/closure-compiler/node-externs/buffer.js
+++ b/third_party/closure-compiler/node-externs/buffer.js
@@ -102,6 +102,11 @@ nodeBuffer.Buffer.prototype.toJSON = function() {};
 nodeBuffer.Buffer.prototype.length;
 
 /**
+ * @type {number}
+ */
+nodeBuffer.Buffer.prototype.byteOffset;
+
+/**
  * @param {nodeBuffer.Buffer} targetBuffer
  * @param {number=} targetStart
  * @param {number=} sourceStart
@@ -422,7 +427,6 @@ nodeBuffer.Buffer.prototype.binaryWrite = function(string, offset) {};
 nodeBuffer.Buffer.prototype.asciiWrite = function(string, offset) {};
 
 /**
- * @return {ArrayBuffer}
- * @nosideeffects
+ * @type {ArrayBuffer}
  */
-nodeBuffer.Buffer.prototype.buffer = function() {};
+nodeBuffer.Buffer.prototype.buffer;


### PR DESCRIPTION
I also updated the closure type definitions for the buffer to match the
node Buffer type.

Also update test_single_file to use `@parameterized`, at lest for one of its
params.  This basically cuts the test in half.