### PR TITLE
Fix WASM Worker exception issue in Node.js environment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -593,3 +593,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Michael Schmuki <michael@schmuki.io>
 * Skye Gibney <skyejgibney@gmail.com>
 * Piotr Wierciński <laminowany@gmail.com>
+* 郑苏波 (Super Zheng) <superzheng@tencent.com>

--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -225,7 +225,7 @@ addToLibrary({
   // see https://bugs.chromium.org/p/chromium/issues/detail?id=1167541
   // https://github.com/tc39/proposal-atomics-wait-async/blob/master/PROPOSAL.md
   // This polyfill performs polling with setTimeout() to observe a change in the target memory location.
-  emscripten_atomic_wait_async__postset: `if (!Atomics.waitAsync || jstoi_q((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91) {
+  emscripten_atomic_wait_async__postset: `if (!Atomics.waitAsync || (typeof navigator !== 'undefined' && jstoi_q((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91)) {
 let __Atomics_waitAsyncAddresses = [/*[i32a, index, value, maxWaitMilliseconds, promiseResolve]*/];
 function __Atomics_pollWaitAsyncAddresses() {
   let now = performance.now();
@@ -284,7 +284,7 @@ Atomics.waitAsync = (i32a, index, value, maxWaitMilliseconds) => {
     wait.value.then((value) => {
       if (atomicLiveWaitAsyncs[counter]) {
         delete atomicLiveWaitAsyncs[counter];
-        {{{ makeDynCall('viiii', 'asyncWaitFinished') }}}(addr, val, atomicWaitStates.indexOf(value), userData);
+        {{{ makeDynCall('vpiip', 'asyncWaitFinished') }}}(addr, val, atomicWaitStates.indexOf(value), userData);
       }
     });
     return -counter;

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9708,6 +9708,10 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_wasm_worker_malloc(self):
     self.do_runf(test_file('wasm_worker/malloc_wasm_worker.c'), emcc_args=['-sWASM_WORKERS'])
 
+  @node_pthreads
+  def test_wasm_worker_wait_async(self):
+    self.do_runf(test_file('wasm_worker/wait_async.c'), emcc_args=['-sWASM_WORKERS'])
+
 
 # Generate tests for everything
 def make_run(name, emcc_args, settings=None, env=None,


### PR DESCRIPTION
The `Atomics.waitAsync()` polyfill does not
take into account that the `navigator` object
does not exist in the Node.js context.