### PR TITLE
Update test expectations for module name in node output. NFC

### DIFF
--- a/test/emscripten_log/emscripten_log.cpp
+++ b/test/emscripten_log/emscripten_log.cpp
@@ -89,18 +89,18 @@ void __attribute__((noinline)) bar(int = 0, char * = 0, double = 0) {
   } else {
     MYASSERT(!!strstr(callstack, ".js:"), "Callstack was %s!", callstack);
   }
-  MYASSERT(!!strstr(callstack, "at bar(int, char*, double)"), "Callstack was %s!", callstack);
-  MYASSERT(!!strstr(callstack, "at void Foo<int>()"), "Callstack was %s!", callstack);
+  MYASSERT(!!strstr(callstack, "bar(int, char*, double)"), "Callstack was %s!", callstack);
+  MYASSERT(!!strstr(callstack, "void Foo<int>()"), "Callstack was %s!", callstack);
 
   // 5. Clean up.
   delete[] callstack;
 
   // Test that obtaining a truncated callstack works. (https://github.com/emscripten-core/emscripten/issues/2171)
-  char *buffer = new char[21];
-  buffer[20] = 0x01; // Magic sentinel that should not change its value.
-  emscripten_get_callstack(EM_LOG_C_STACK | EM_LOG_NO_PATHS | EM_LOG_FUNC_PARAMS, buffer, 20);
-  MYASSERT(!!strstr(buffer, "at bar(int,"), "Truncated callstack was %s!", buffer);
-  MYASSERT(buffer[20] == 0x01, "");
+  char *buffer = new char[50];
+  buffer[50] = 0x01; // Magic sentinel that should not change its value.
+  emscripten_get_callstack(EM_LOG_C_STACK | EM_LOG_NO_PATHS | EM_LOG_FUNC_PARAMS, buffer, 50);
+  MYASSERT(!!strstr(buffer, "bar(int,"), "Truncated callstack was %s!", buffer);
+  MYASSERT(buffer[50] == 0x01, "");
   delete[] buffer;
 
   // Or alternatively use a fixed-size buffer for the callstack (and get a truncated output if it was too small).

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8423,21 +8423,21 @@ int main() {
 
     # Stack trace and message example for this example code:
     # exiting due to exception: [object WebAssembly.Exception],Error: std::runtime_error,my message
-    #     at __cxa_throw (wasm://wasm/009a7c9a:wasm-function[1551]:0x24367)
-    #     at bar() (wasm://wasm/009a7c9a:wasm-function[12]:0xf53)
-    #     at foo() (wasm://wasm/009a7c9a:wasm-function[19]:0x154e)
+    #     at src.wasm.__cxa_throw (wasm://wasm/009a7c9a:wasm-function[1551]:0x24367)
+    #     at src.wasm.bar() (wasm://wasm/009a7c9a:wasm-function[12]:0xf53)
+    #     at src.wasm.foo() (wasm://wasm/009a7c9a:wasm-function[19]:0x154e)
     #     at __original_main (wasm://wasm/009a7c9a:wasm-function[20]:0x15a6)
-    #     at main (wasm://wasm/009a7c9a:wasm-function[56]:0x25be)
+    #     at src.wasm.main (wasm://wasm/009a7c9a:wasm-function[56]:0x25be)
     #     at test.js:833:22
     #     at callMain (test.js:4567:15)
     #     at doRun (test.js:4621:23)
     #     at run (test.js:4636:5)
     stack_trace_checks = [
       'std::runtime_error[:,][ ]?my message',  # 'std::runtime_error: my message' for Emscripten EH
-      'at [_]{2,3}cxa_throw',  # '___cxa_throw' (JS symbol) for Emscripten EH
-      'at bar',
-      'at foo',
-      'at main']
+      'at (src.wasm.)?_?__cxa_throw',  # '___cxa_throw' (JS symbol) for Emscripten EH
+      'at (src.wasm.)?bar',
+      'at (src.wasm.)?foo',
+      'at (src.wasm.)?main']
 
     if wasm_eh:
       # FIXME Node v18.13 (LTS as of Jan 2023) has not yet implemented the new
@@ -12485,7 +12485,7 @@ void foo() {}
     self.emcc_args += ['--profiling-funcs', '-pthread']
     output = self.do_runf(test_file('pthread/test_pthread_trap.c'), assert_returncode=NON_ZERO)
     self.assertContained('sent an error!', output)
-    self.assertContained('at thread_main', output)
+    self.assertContained('at (test_pthread_trap.wasm.?)thread_main', output, regex=True)
 
   @node_pthreads
   def test_emscripten_set_interval(self):


### PR DESCRIPTION
LLVM is being updated to a module name by default. See https://reviews.llvm.org/D158001.  Apparently node reports this as a prefix on every function name so this change updates the test expectations to handle both cases.