### PR TITLE
Remove use of `cgi` module from emrun.py

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,9 @@ See docs/process.md for more on how version tagging works.
   `mergeInto`, to the more specific `addToLibrary`.  This new function does not
   require the passing of `LibraryManager.library` as a first argument.  The old
   `mergeInto` continues to exist for backwards compat.
+- The `--log_html` option was removed from `emrun`.  This option was already not
+  working with python3.8 or above so we hope is safe to say that nobody was
+  relying on it.
 
 3.1.44 - 07/25/23
 -----------------

--- a/site/source/docs/compiling/Running-html-files-with-emrun.rst
+++ b/site/source/docs/compiling/Running-html-files-with-emrun.rst
@@ -113,7 +113,6 @@ The following command line flags affect logging output:
 - ``--lot_stderr <filename>``: Write all ``stderr`` messages from the application to the named file (instead of printing to terminal).
 - ``--system_info``: Print detailed information about the current system before launching. This is useful during automated runs when you want to capture hardware information to logs.
 - ``--browser_info``: Print information about which browser is about to be launched.
-- ``--log_html``: Reformat application output as HTML markup.
 - ``--no_emrun_detect``: Hide the warning message that is launched if a target **.html** file is detected to not have been built with ``--emrun``.
 
 


### PR DESCRIPTION
The cgi module is due for removal from python and in recent versions generates a warning message on import.  Furthermore the only usage of this module was to call `cgi.escape` in `format_html` and it turns out that `cgi.escape` does not exist in the `cgi` module, and least not int python 3.8 or above.

Working backwards I think we can just remove the `--log_html` option which was the only way to enable `format_html`.