### PR TITLE
When building system libraries, use a separate macro to signal dynamic linking support. NFC

### DIFF
--- a/system/lib/libc/emscripten_libc_stubs.c
+++ b/system/lib/libc/emscripten_libc_stubs.c
@@ -225,7 +225,7 @@ weak int sigaltstack(const stack_t *restrict ss, stack_t *restrict old_ss) {
 // dlfcn.h
 // ==========================================================================
 
-#ifndef __PIC__
+#ifndef EMSCRIPTEN_DYNAMIC_LINKING
 void __dl_seterr(const char*, ...);
 
 weak void *__dlsym(void *restrict p, const char *restrict s, void *restrict ra) {

--- a/system/lib/libc/musl/src/internal/pthread_impl.h
+++ b/system/lib/libc/musl/src/internal/pthread_impl.h
@@ -102,7 +102,10 @@ struct pthread {
 	// Otherwise the notification has to fall back to the postMessage path.
 	_Atomic int waiting_async;
 #endif
-#if _REENTRANT
+#ifdef EMSCRIPTEN_DYNAMIC_LINKING
+	// When dynamic linking is enabled, threads use this to facilitate the
+	// synchronization of loaded code between threads.
+	// See emscripten_futex_wait.c.
 	_Atomic char sleeping;
 #endif
 };

--- a/system/lib/pthread/emscripten_futex_wait.c
+++ b/system/lib/pthread/emscripten_futex_wait.c
@@ -137,7 +137,7 @@ int emscripten_futex_wait(volatile void *addr, uint32_t val, double max_wait_ms)
   if (max_wait_ms != INFINITY) {
     max_wait_ns = (int64_t)(max_wait_ms*1000*1000);
   }
-#ifdef __PIC__
+#ifdef EMSCRIPTEN_DYNAMIC_LINKING
   // After the main thread queues dlopen events, it checks if the target threads
   // are sleeping.
   // If `sleeping` is set then the main thread knows that event will be
@@ -153,7 +153,7 @@ int emscripten_futex_wait(volatile void *addr, uint32_t val, double max_wait_ms)
   }
 #endif
   ret = __builtin_wasm_memory_atomic_wait32((int*)addr, val, max_wait_ns);
-#ifdef __PIC__
+#ifdef EMSCRIPTEN_DYNAMIC_LINKING
   if (!is_runtime_thread) {
     __pthread_self()->sleeping = 0;
     _emscripten_process_dlopen_queue();

--- a/system/lib/pthread/emscripten_yield.c
+++ b/system/lib/pthread/emscripten_yield.c
@@ -45,7 +45,7 @@ void _emscripten_yield(double now) {
     // singlethreaded.
     emscripten_main_thread_process_queued_calls();
   }
-#ifdef __PIC__
+#ifdef EMSCRIPTEN_DYNAMIC_LINKING
   else {
     _emscripten_process_dlopen_queue();
   }

--- a/system/lib/pthread/pthread_create.c
+++ b/system/lib/pthread/pthread_create.c
@@ -340,7 +340,7 @@ void _emscripten_thread_exit(void* result) {
     // Mark the thread as no longer running, so it can be joined.
     // Once we publish this, any threads that are waiting to join with us can
     // proceed and this worker can be recycled and used on another thread.
-#ifdef __PIC__
+#ifdef EMSCRIPTEN_DYNAMIC_LINKING
     // When dynamic linking is enabled we need to keep track of zombie threads
     _emscripten_thread_exit_joinable(self);
 #endif

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -56,7 +56,7 @@ def get_base_cflags(force_object_files=False):
   if settings.LTO and not force_object_files:
     flags += ['-flto=' + settings.LTO]
   if settings.RELOCATABLE:
-    flags += ['-sRELOCATABLE']
+    flags += ['-sRELOCATABLE', '-DEMSCRIPTEN_DYNAMIC_LINKING']
   if settings.MEMORY64:
     flags += ['-Wno-experimental', '-sMEMORY64=' + str(settings.MEMORY64)]
   return flags


### PR DESCRIPTION
This allows for the bazel build (or aother builders) to build the standard library with `-fPIC` but without assuming dynamic library support.

Fixes: #20057