### PR TITLE
embind: Stub out val dependencies for TS generation.

### DIFF
--- a/src/embind/embind_ts.js
+++ b/src/embind/embind_ts.js
@@ -535,6 +535,11 @@ var LibraryEmbind = {
     const printer = new TsPrinter(moduleDefinitions);
     printer.print();
   },
+
+  // Stub functions used by eval, but not needed for TS generation:
+  $makeLegalFunctionName: () => assert(false, 'stub function should not be called'),
+  $newFunc: () => assert(false, 'stub function should not be called'),
+  $runDestructors: () => assert(false, 'stub function should not be called'),
 };
 
 DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.push('$embindEmitTypes');

--- a/test/other/embind_tsgen_val.cpp
+++ b/test/other/embind_tsgen_val.cpp
@@ -1,0 +1,17 @@
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+using namespace emscripten;
+
+int global_fn(int, int) { return 0; }
+
+EMSCRIPTEN_BINDINGS(Test) {
+  function("global_fn", &global_fn);
+}
+
+int main() {
+  val::global("window").call<val>("setTimeout");
+  // Main should not be run during TypeScript generation.
+  abort();
+  return 0;
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2915,6 +2915,12 @@ int f() {
     self.assertNotExists('out.js')
     self.assertFileContents(test_file('other/embind_tsgen.d.ts'), actual)
 
+  def test_embind_tsgen_val(self):
+    # Check that any dependencies from val still works with TS generation enabled.
+    self.run_process([EMCC, test_file('other/embind_tsgen_val.cpp'),
+                      '-lembind', '--embind-emit-tsd', 'embind_tsgen_val.d.ts'])
+    self.assertExists('embind_tsgen_val.d.ts')
+
   def test_emconfig(self):
     output = self.run_process([emconfig, 'LLVM_ROOT'], stdout=PIPE).stdout.strip()
     self.assertEqual(output, config.LLVM_ROOT)


### PR DESCRIPTION
These dependencies are used by val but defined in embind.js. They aren't actually used during TS generation but need to be defined for linking.