### PR TITLE
Fix some embind tests under >2gb addressing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -619,6 +619,8 @@ jobs:
             wasm64_4gb.test_async_main
             wasm64_4gb.*embind*
             core_2gb.test_em_asm
+            core_2gb.test_embind_unsigned_bigint
+            core_2gb.test_embind_no_rtti
             wasm64l.test_bigswitch
             other.test_memory64_proxies
             other.test_failing_growth_wasm64"

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -140,10 +140,8 @@ function runJSify() {
           error(`handleI64Signatures: missing name for argument ${i} in ${symbol}`);
           return snippet;
         }
-        if (WASM_BIGINT) {
-          if (sig[i] == 'p' || (sig[i] == 'j' && i53abi)) {
-            argConvertions += `  ${receiveI64ParamAsI53(name, undefined, false)}\n`;
-          }
+        if (WASM_BIGINT && ((MEMORY64 && sig[i] == 'p') || (i53abi && sig[i] == 'j'))) {
+          argConvertions += `  ${receiveI64ParamAsI53(name, undefined, false)}\n`;
         } else {
           if (sig[i] == 'j' && i53abi) {
             argConvertions += `  ${receiveI64ParamAsI53(name, undefined, false)}\n`;

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -296,6 +296,8 @@ function getHeapOffset(offset, type) {
   const shifts = Math.log(sz) / Math.LN2;
   if (MEMORY64 == 1) {
     return `((${offset})/${2 ** shifts})`;
+  } else if (CAN_ADDRESS_2GB) {
+    return `((${offset})>>>${shifts})`;
   } else {
     return `((${offset})>>${shifts})`;
   }
@@ -422,7 +424,8 @@ function makeSetValueImpl(ptr, pos, value, type) {
 
 function makeHEAPView(which, start, end) {
   const size = parseInt(which.replace('U', '').replace('F', '')) / 8;
-  const mod = size == 1 ? '' : ('>>' + Math.log2(size));
+  const shift = Math.log2(size);
+  const mod = size == 1 ? '' : CAN_ADDRESS_2GB ? ('>>>' + shift) : ('>>' + shift);
   return `HEAP${which}.subarray((${start})${mod}, (${end})${mod})`;
 }
 

--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -320,7 +320,7 @@ def extract_metadata(filename):
       if e.kind == webassembly.ExternType.GLOBAL and e.name.startswith('__em_js__'):
         name = utils.removeprefix(e.name, '__em_js__')
         globl = module.get_global(e.index)
-        string_address = get_global_value(globl)
+        string_address = to_unsigned(get_global_value(globl))
         em_js_funcs[name] = get_string_at(module, string_address)
 
     for i in imports:


### PR DESCRIPTION
This fixes a bug in `handleI64Signatures` which was using `receiveI64ParamAsI53` erroneously for incoming pointers under wasm32.