### PR TITLE
embind: Support readonly properties

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -146,6 +146,7 @@ For example:
        .constructor<int, std::string>()
        .function("incrementX", &MyClass::incrementX)
        .property("x", &MyClass::getX, &MyClass::setX)
+       .property("x_readonly", &MyClass::getX)
        .class_function("getStringFromInstance", &MyClass::getStringFromInstance)
        ;
    }

--- a/src/embind/embind_ts.js
+++ b/src/embind/embind_ts.js
@@ -101,13 +101,14 @@ var LibraryEmbind = {
     }
   },
   $ClassProperty: class ClassProperty {
-    constructor(type, name) {
+    constructor(type, name, readonly) {
       this.type = type;
       this.name = name;
+      this.readonly = readonly;
     }
 
     print(nameMap, out) {
-      out.push(`${this.name}: ${nameMap(this.type)}`);
+      out.push(`${this.readonly ? 'readonly ' : ''}${this.name}: ${nameMap(this.type)}`);
     }
   },
   $ConstantDefinition: class ConstantDefinition {
@@ -377,11 +378,12 @@ var LibraryEmbind = {
                                             setter,
                                             setterContext) {
     fieldName = readLatin1String(fieldName);
-    assert(getterReturnType === setterArgumentType, 'Mismatched getter and setter types are not supported.');
+    const readonly = setter === 0;
+    assert(readonly || getterReturnType === setterArgumentType, 'Mismatched getter and setter types are not supported.');
     whenDependentTypesAreResolved([], [classType], function(classType) {
       classType = classType[0];
       whenDependentTypesAreResolved([], [getterReturnType], function(types) {
-        const prop = new ClassProperty(types[0], fieldName);
+        const prop = new ClassProperty(types[0], fieldName, readonly);
         classType.properties.push(prop);
         return [];
       });

--- a/test/other/embind_tsgen.cpp
+++ b/test/other/embind_tsgen.cpp
@@ -16,12 +16,15 @@ class Test {
   int getX() const { return x; }
   void setX(int x_) { x = x_; }
 
+  int getY() const { return y; }
+
   static int static_function(int x) { return 1; }
 
   static int static_property;
 
 private:
   int x;
+  int y;
 };
 
 Test class_returning_fn() { return Test(); }
@@ -88,6 +91,7 @@ EMSCRIPTEN_BINDINGS(Test) {
       .function("functionFour", &Test::function_four)
       .function("constFn", &Test::const_fn)
       .property("x", &Test::getX, &Test::setX)
+      .property("y", &Test::getY)
       .class_function("staticFunction", &Test::static_function)
       .class_property("staticProperty", &Test::static_property)
 	;

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -1,5 +1,6 @@
 export interface Test {
   x: number;
+  readonly y: number;
   functionOne(_0: number, _1: number): number;
   functionTwo(_0: number, _1: number): number;
   functionFour(_0: boolean): number;


### PR DESCRIPTION
@brendandahl Great work with TS generator! I was only facing an issue using the example you provided, when trying to make the property read-only with the following binding code:

```cpp
class Test {
 public:
  int getX() const;

 private:
  int x;
};

EMSCRIPTEN_BINDINGS() {
  class_<Test>("Test")
      .property("x", &Test::getX);
}
```

I get this error: `Mismatched getter and setter types are not supported.`

With this PR, I check if no setter is provided then mark the property as read-only and ignore the assertion for matching getter and setter.
