### PR TITLE
embind: Run test_embind with TS generation enabled.

### DIFF
--- a/test/embind/embind_test.cpp
+++ b/test/embind/embind_test.cpp
@@ -2173,7 +2173,6 @@ EMSCRIPTEN_BINDINGS(tests) {
     function("embind_test_accept_big_class_instance", &embind_test_accept_big_class_instance);
 
     class_<UniquePtrToConstructor>("UniquePtrToConstructor")
-        .constructor<std::unique_ptr<int>>()
         .function("getValue", &UniquePtrToConstructor::getValue)
         ;
 
@@ -2669,6 +2668,7 @@ struct BoundClass {
     UnboundClass property;
 };
 
+#ifndef SKIP_UNBOUND_TYPES
 EMSCRIPTEN_BINDINGS(incomplete) {
     constant("hasUnboundTypeNames", emscripten::has_unbound_type_names);
 
@@ -2694,6 +2694,7 @@ EMSCRIPTEN_BINDINGS(incomplete) {
         .property("property", &BoundClass::property)
         ;
 }
+#endif
 
 class Noncopyable {
     Noncopyable(const Noncopyable&) = delete;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2915,6 +2915,12 @@ int f() {
     self.assertNotExists('out.js')
     self.assertFileContents(test_file('other/embind_tsgen.d.ts'), actual)
 
+  def test_embind_tsgen_test_embind(self):
+    self.run_process([EMCC, test_file('embind/embind_test.cpp'),
+                      '-lembind', '--embind-emit-tsd', 'embind_tsgen_test_embind.d.ts',
+                      '-DSKIP_UNBOUND_TYPES']) # TypeScript generation requires all type to be bound.
+    self.assertExists('embind_tsgen_test_embind.d.ts')
+
   def test_embind_tsgen_val(self):
     # Check that any dependencies from val still works with TS generation enabled.
     self.run_process([EMCC, test_file('other/embind_tsgen_val.cpp'),


### PR DESCRIPTION
To get this running:
 - Map all integers to a JS number.
 - Add missing c++ string to JS string mappings.
 - Stub out embind_tsgen_test_embind which is not needed.
 - Add missing function dependency.
 - Skip tests for unbound types.
 - Remove invalid constructor with unique_ptr argument.