### PR TITLE
Update compiler-rt's version to llvm 16.0.6

### DIFF
--- a/system/lib/compiler-rt/readme.txt
+++ b/system/lib/compiler-rt/readme.txt
@@ -1,7 +1,7 @@
 llvm's compiler-rt
 ------------------
 
-These files are from the llvm-project based on release 16.0.4.
+These files are from the llvm-project based on release 16.0.6.
 
 We maintain a local fork of llvm-project that contains any emscripten
 specific patches:
@@ -13,11 +13,11 @@ The current patch is based on the emscripten-libs-16 branch.
 Update Instructions
 -------------------
 
-Run `system/lib/update_compiler_rt.py path/to/llvm-root`
+Run `system/lib/update_compiler_rt.py path/to/llvm-project`
 
 Modifications
 -------------
 
 For a list of changes from upstream see the compiler-rt files that are part of:
 
-https://github.com/llvm/llvm-project/compare/llvmorg-16.0.4...emscripten-core:emscripten-libs-16
+https://github.com/llvm/llvm-project/compare/llvmorg-16.0.6...emscripten-core:emscripten-libs-16


### PR DESCRIPTION
It doesn't have any changes, but given that we updated other libraries (libcxx/libcxxabi/libunwind) to 16.0.6 (#20088 and #20094), I'd like to bring this to 16.0.6 to be consistent.