### PR TITLE
Remove assert on exceptfds, since they are supported (just never happen)

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -555,11 +555,11 @@ var SyscallsLibrary = {
   __syscall__newselect: (nfds, readfds, writefds, exceptfds, timeout) => {
     // readfds are supported,
     // writefds checks socket open status
-    // exceptfds not supported
-    // timeout is always 0 - fully async
+    // exceptfds are supported, although on web, such exceptional conditions never arise in web sockets
+    //                          and so the exceptfds list will always return empty.
+    // timeout is supported, although on SOCKFS and PIPEFS these are ignored and always treated as 0 - fully async
 #if ASSERTIONS
     assert(nfds <= 64, 'nfds must be less than or equal to 64');  // fd sets have 64 bits // TODO: this could be 1024 based on current musl headers
-    assert(!exceptfds, 'exceptfds not supported');
 #endif
 
     var total = 0;


### PR DESCRIPTION
Web Sockets do not have out of band data like TCP does. If e.g. a Node.js TCP sockets based implementation would support that, it does look like the exceptfds routing implementation is already wired there in the body of the function, so we should not say exceptfds are not supported - they just never happen in the current backends.