### PR TITLE
[Wasm64] Fix creation of 64-bit memories from JS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ commands:
     description: "install canary version of node"
     steps:
       - install-node-version:
-         node_version: "20.0.0-v8-canary2023041819be670741"
+         node_version: "21.0.0-v8-canary20230822f5e30d0702"
          canary: true
   install-v8:
     description: "install v8 using jsvu"

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1042,8 +1042,8 @@ var LibraryPThread = {
   $establishStackSpace__internal: true,
   $establishStackSpace: () => {
     var pthread_ptr = _pthread_self();
-    var stackHigh = {{{ makeGetValue('pthread_ptr', C_STRUCTS.pthread.stack, 'i32') }}};
-    var stackSize = {{{ makeGetValue('pthread_ptr', C_STRUCTS.pthread.stack_size, 'i32') }}};
+    var stackHigh = {{{ makeGetValue('pthread_ptr', C_STRUCTS.pthread.stack, '*') }}};
+    var stackSize = {{{ makeGetValue('pthread_ptr', C_STRUCTS.pthread.stack_size, '*') }}};
     var stackLow = stackHigh - stackSize;
 #if PTHREADS_DEBUG
     dbg(`establishStackSpace: ${ptrToString(stackHigh)} -> ${ptrToString(stackLow)}`);

--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -244,7 +244,7 @@ if (ENVIRONMENT_IS_WASM_WORKER) {
   // https://github.com/tc39/proposal-atomics-wait-async/blob/master/PROPOSAL.md
   // This polyfill performs polling with setTimeout() to observe a change in the
   // target memory location.
-  emscripten_atomic_wait_async__postset: `if (!Atomics.waitAsync || (typeof navigator !== 'undefined' && jstoi_q((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91)) {
+  emscripten_atomic_wait_async__postset: `if (!Atomics.waitAsync || (typeof navigator !== 'undefined' && navigator.userAgent && jstoi_q((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91)) {
 let __Atomics_waitAsyncAddresses = [/*[i32a, index, value, maxWaitMilliseconds, promiseResolve]*/];
 function __Atomics_pollWaitAsyncAddresses() {
   let now = performance.now();

--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -35,13 +35,15 @@ if (ENVIRONMENT_IS_PTHREAD) {
       // https://github.com/emscripten-core/emscripten/issues/14130
       // And in the pthreads case we definitely need to emit a maximum. So
       // always emit one.
-      'maximum': {{{ MAXIMUM_MEMORY }}} / {{{ WASM_PAGE_SIZE }}}
+      'maximum': {{{ MAXIMUM_MEMORY }}} / {{{ WASM_PAGE_SIZE }}},
 #else
-      'maximum': INITIAL_MEMORY / {{{ WASM_PAGE_SIZE }}}
+      'maximum': INITIAL_MEMORY / {{{ WASM_PAGE_SIZE }}},
 #endif // ALLOW_MEMORY_GROWTH
 #if SHARED_MEMORY
-      ,
-      'shared': true
+      'shared': true,
+#endif
+#if MEMORY64 == 1
+      'index': 'u64',
 #endif
     });
 #if SHARED_MEMORY

--- a/test/common.py
+++ b/test/common.py
@@ -713,10 +713,6 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     self.emcc_args += ['-Wno-pthreads-mem-growth', '-pthread']
     if self.get_setting('MINIMAL_RUNTIME'):
       self.skipTest('node pthreads not yet supported with MINIMAL_RUNTIME')
-    # Pthread support requires IMPORTED_MEMORY which depends on the JS API
-    # for creating 64-bit memories.
-    if self.get_setting('GLOBAL_BASE') == '4gb':
-      self.skipTest('no support for IMPORTED_MEMORY over 4gb yet')
     self.js_engines = [config.NODE_JS]
     self.node_args += shared.node_pthread_flags()
 

--- a/test/core/test_module_wasm_memory64.js
+++ b/test/core/test_module_wasm_memory64.js
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2019 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+Module['wasmMemory'] = new WebAssembly.Memory({ 'initial': 256, 'maximum': 256, 'index': 'u64' });

--- a/test/pthread/test_pthread_attr_getstack.c
+++ b/test/pthread/test_pthread_attr_getstack.c
@@ -18,7 +18,6 @@ void TestStack() {
   void *stbase;
   size_t stsize;
   char dummy;
-  intptr_t result;
 
   rc = pthread_attr_init(&attr);
   assert(rc == 0);

--- a/test/pthread/test_pthread_proxying_canceled_work.c
+++ b/test/pthread/test_pthread_proxying_canceled_work.c
@@ -39,7 +39,7 @@ void set_flag(void* flag) {
   // because this code needs to run after the thread runtime has exited.
 
   // clang-format off
-  EM_ASM({setTimeout(() => Atomics.store(HEAP32, $0 >>> 2, 1))}, flag);
+  EM_ASM({setTimeout(() => Atomics.store(HEAP32, $0 / 4, 1))}, flag);
   // clang-format on
 }
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2440,7 +2440,10 @@ int main(int argc, char **argv) {
   @no_4gb('depends on memory size')
   @no_2gb('depends on memory size')
   def test_module_wasm_memory(self):
-    self.emcc_args += ['--pre-js', test_file('core/test_module_wasm_memory.js')]
+    if self.get_setting('MEMORY64') == 1:
+      self.emcc_args += ['--pre-js', test_file('core/test_module_wasm_memory64.js')]
+    else:
+      self.emcc_args += ['--pre-js', test_file('core/test_module_wasm_memory.js')]
     self.set_setting('IMPORTED_MEMORY')
     self.do_runf(test_file('core/test_module_wasm_memory.c'), 'success')
 
@@ -8489,7 +8492,6 @@ Module.onRuntimeInitialized = () => {
     'conditional': (True,),
     'unconditional': (False,),
   })
-  @no_4gb('uses imported memory')
   def test_emscripten_lazy_load_code(self, conditional):
     if self.get_setting('STACK_OVERFLOW_CHECK'):
       self.skipTest('https://github.com/emscripten-core/emscripten/issues/16828')


### PR DESCRIPTION
This enables quite a few tests that were previously disabled.

The extra check for `navigator.userAgent` is because node added support for the navigator object: https://github.com/nodejs/node/pull/47769.

This change is also part of #19959, which could land instead.