### PR TITLE
Don't import emscripten_notify_memory_growth when building with PURE_WASI

### DIFF
--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -155,7 +155,7 @@ size_t emscripten_get_heap_max() {
 }
 
 int emscripten_resize_heap(size_t size) {
-#ifdef EMSCRIPTEN_MEMORY_GROWTH
+#if defined(EMSCRIPTEN_MEMORY_GROWTH) && !defined(EMSCRIPTEN_PURE_WASI)
   size_t old_size = __builtin_wasm_memory_size(0) * WASM_PAGE_SIZE;
   assert(old_size < size);
   ssize_t diff = (size - old_size + WASM_PAGE_SIZE - 1) / WASM_PAGE_SIZE;

--- a/test/common.py
+++ b/test/common.py
@@ -363,6 +363,8 @@ def also_with_standalone_wasm(impure=False):
         if not can_do_standalone(self, impure):
           self.skipTest('Test configuration is not compatible with STANDALONE_WASM')
         self.set_setting('STANDALONE_WASM')
+        if not impure:
+          self.set_setting('PURE_WASI')
         # we will not legalize the JS ffi interface, so we must use BigInt
         # support in order for JS to have a chance to run this without trapping
         # when it sees an i64 on the ffi.

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8760,6 +8760,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @also_with_standalone_wasm()
   def test_sbrk(self):
     self.do_runf(test_file('sbrk_brk.cpp'), 'OK.')
+    self.set_setting('ALLOW_MEMORY_GROWTH')
+    self.do_runf(test_file('sbrk_brk.cpp'), 'OK.')
 
   def test_brk(self):
     self.emcc_args += ['-DTEST_BRK=1']

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2006,6 +2006,7 @@ class libstandalonewasm(MuslInternalLibrary):
 
   def __init__(self, **kwargs):
     self.is_mem_grow = kwargs.pop('is_mem_grow')
+    self.is_pure = kwargs.pop('is_pure')
     self.nocatch = kwargs.pop('nocatch')
     super().__init__(**kwargs)
 
@@ -2015,6 +2016,8 @@ class libstandalonewasm(MuslInternalLibrary):
       name += '-nocatch'
     if self.is_mem_grow:
       name += '-memgrow'
+    if self.is_pure:
+      name += '-pure'
     return name
 
   def get_cflags(self):
@@ -2022,18 +2025,21 @@ class libstandalonewasm(MuslInternalLibrary):
     cflags += ['-DNDEBUG', '-DEMSCRIPTEN_STANDALONE_WASM']
     if self.is_mem_grow:
       cflags += ['-DEMSCRIPTEN_MEMORY_GROWTH']
+    if self.is_pure:
+      cflags += ['-DEMSCRIPTEN_PURE_WASI']
     if self.nocatch:
       cflags.append('-DEMSCRIPTEN_NOCATCH')
     return cflags
 
   @classmethod
   def vary_on(cls):
-    return super().vary_on() + ['is_mem_grow', 'nocatch']
+    return super().vary_on() + ['is_mem_grow', 'is_pure', 'nocatch']
 
   @classmethod
   def get_default_variation(cls, **kwargs):
     return super().get_default_variation(
       is_mem_grow=settings.ALLOW_MEMORY_GROWTH,
+      is_pure=settings.PURE_WASI,
       nocatch=settings.DISABLE_EXCEPTION_CATCHING and not settings.WASM_EXCEPTIONS,
       **kwargs
     )


### PR DESCRIPTION
This adds another dimension to the build of `libstandalone.a`, but this is a pretty small library so the I think its not a big deal.

Fixes: #20106