### PR TITLE
DOCS Update Module-Splitting code

### DIFF
--- a/site/source/docs/optimizing/Module-Splitting.rst
+++ b/site/source/docs/optimizing/Module-Splitting.rst
@@ -124,23 +124,25 @@ included in the profile.
 Here’s the function to write the profile and our new main function::
 
   EM_JS(void, write_profile, (), {
-    var __write_profile = wasmExports['__write_profile'];
-    if (__write_profile) {
-
-      // Get the size of the profile and allocate a buffer for it.
-      var len = __write_profile(0, 0);
-      var ptr = _malloc(len);
-
-      // Write the profile data to the buffer.
-      __write_profile(ptr, len);
-
-      // Write the profile file.
-      var profile_data = new Uint8Array(buffer, ptr, len);
-      nodeFS.writeFileSync('profile.data', profile_data);
-
-      // Free the buffer.
-      _free(ptr);
+    var __write_profile = Module.asm.__write_profile;
+    if (!__write_profile) {
+      return;
     }
+
+    // Get the size of the profile and allocate a buffer for it.
+    var len = __write_profile(0, 0);
+    var ptr = _malloc(len);
+
+    // Write the profile data to the buffer.
+    __write_profile(ptr, len);
+
+    // Write the profile file.
+    var profile_data = new Uint8Array(HEAP8.buffer, ptr, len);
+    const fs = require("fs");
+    fs.writeFileSync('profile.data', profile_data);
+
+    // Free the buffer.
+    _free(ptr);
   });
 
   int main() {

--- a/site/source/docs/optimizing/Module-Splitting.rst
+++ b/site/source/docs/optimizing/Module-Splitting.rst
@@ -124,7 +124,7 @@ included in the profile.
 Here’s the function to write the profile and our new main function::
 
   EM_JS(void, write_profile, (), {
-    var __write_profile = Module.asm.__write_profile;
+    var __write_profile = wasmExports.__write_profile;
     if (!__write_profile) {
       return;
     }


### PR DESCRIPTION
A few fixes to the module splitting code example:
1. I'm not sure when `wasmExports` exists, but when I tried this, I had to use `Module.asm` instead.
2. Using `buffer` yields an error saying it's been removed and to use `HEAP8.buffer` instead.
3. `nodeFS` is not defined unless we specifically `require` it.