### PR TITLE
Always preserve comments with `--minify=0` is used

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,9 @@ See docs/process.md for more on how version tagging works.
 3.1.46 (in development)
 -----------------------
 - libunwind updated to LLVM 16.0.6. (#20088)
+- The `--minify=0` commnad line flag will now preserve comments as well as
+  whitespace.  This means the resulting output can then be run though closure
+  compiler or some other tool that gives comments semantic meaning. (#20121)
 
 3.1.45 - 08/23/23
 -----------------

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13705,3 +13705,23 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
                       '-Wno-experimental',
                       '--extern-post-js', test_file('other/test_memory64_proxies.js')])
     self.run_js('a.out.js')
+
+  def test_no_minify(self):
+    # Test that comments are preserved with `--minify=0` is used, even in `-Oz` builds.
+    # This allows the output of emscripten to be run through the closure compiler as
+    # as a seperate build step.
+    create_file('pre.js', '''
+    /**
+     * This comment should be preserved
+     */
+    console.log('hello');
+    ''')
+    comment = 'This comment should be preserved'
+
+    self.run_process([EMCC, test_file('hello_world.c'), '--pre-js=pre.js', '-Oz'])
+    content = read_file('a.out.js')
+    self.assertNotContained(comment, content)
+
+    self.run_process([EMCC, test_file('hello_world.c'), '--pre-js=pre.js', '-Oz', '--minify=0'])
+    content = read_file('a.out.js')
+    self.assertContained(comment, content)

--- a/tools/building.py
+++ b/tools/building.py
@@ -336,7 +336,7 @@ def acorn_optimizer(filename, passes, extra_info=None, return_output=False):
   cmd = config.NODE_JS + [optimizer, filename] + passes
   # Keep JS code comments intact through the acorn optimization pass so that JSDoc comments
   # will be carried over to a later Closure run.
-  if settings.USE_CLOSURE_COMPILER:
+  if settings.USE_CLOSURE_COMPILER or not settings.MINIFY_WHITESPACE:
     cmd += ['--closureFriendly']
   if settings.EXPORT_ES6:
     cmd += ['--exportES6']


### PR DESCRIPTION
This is useful for folks who want to run the closure compiler as an external step, after linking.

Fixes google-internal issue: https://buganizer.corp.google.com/issues/287520718