### PR TITLE
Re-enable _LARGEFILE64_SOURCE when _GNU_SOURCE is defined

### DIFF
--- a/system/lib/libc/musl/include/features.h
+++ b/system/lib/libc/musl/include/features.h
@@ -16,6 +16,13 @@
 #define _XOPEN_SOURCE 700
 #endif
 
+#if defined(__EMSCRIPTEN__) && defined(_GNU_SOURCE)
+// In emscripten the LFS functions are kept around when _GNU_SOURCE is
+// defined, for increased compatabiliy. This is also what glibc does.
+#undef _LARGEFILE64_SOURCE
+#define _LARGEFILE64_SOURCE 1
+#endif
+
 #if __STDC_VERSION__ >= 199901L
 #define __restrict restrict
 #elif !defined(__GNUC__)

--- a/test/stat/test_stat.c
+++ b/test/stat/test_stat.c
@@ -5,6 +5,9 @@
  * found in the LICENSE file.
  */
 
+// For LFS functions (e.g. stat64)
+#define _GNU_SOURCE 1
+
 #include <assert.h>
 #include <dirent.h>
 #include <errno.h>
@@ -57,6 +60,12 @@ void test() {
 
   // non-existent
   err = stat("does_not_exist", &s);
+  assert(err == -1);
+  assert(errno == ENOENT);
+
+  // test stat64 LFS functions
+  struct stat64 s64;
+  err = stat("does_not_exist", &s64);
   assert(err == -1);
   assert(errno == ENOENT);
 
@@ -208,7 +217,7 @@ void test() {
   );
 
   symlink("folder/file", "folder/symlinkfile");
-  
+
   EM_ASM(
     var linkStats = FS.lstat("folder/symlinkfile");
     assert(linkStats.dev == 1);
@@ -224,7 +233,7 @@ void test() {
     assert(linkStats.atime);
     assert(linkStats.mtime);
     assert(linkStats.ctime);
-    
+
     var ex;
     try {
       FS.stat("nonexistent");


### PR DESCRIPTION
When we updated to the latest version of musl it broke some codebases that were using LFS functions (e.g. `stat64`) and assuming those functions would be defined when `_GNU_SOURCE` is defined.

See https://github.com/bminor/musl/commit/25e6fee27f4a293728dd15b659170e7b9c7db9bc

This change effectively reverts the above one by defining _LARGEFILE64_SOURCE whenever _GNU_SOURCE is defined.

This is what glibc does:

https://github.com/lattera/glibc/blob/895ef79e04a953cac1493863bcae29ad85657ee1/include/features.h#L206