### PR TITLE
Replace __EMSCRIPTEN__ with __wasm__ in libunwind

### DIFF
--- a/system/lib/libunwind/src/config.h
+++ b/system/lib/libunwind/src/config.h
@@ -98,7 +98,7 @@
                                              SYMBOL_NAME(name)))               \
   extern "C" _LIBUNWIND_EXPORT __typeof(name) aliasname;
 #endif
-#elif defined(__EMSCRIPTEN__)
+#elif defined(__wasm__)
 #else
 #error Unsupported target
 #endif


### PR DESCRIPTION
This is not specific to Emscripten and may be used with other Wasm libraries, e.g., WASI.