### PR TITLE
Disable warning in test_giflib. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2176,6 +2176,8 @@ int f() {
                  emcc_args=['--embed-file', 'pngtest.png', '-sUSE_LIBPNG', '-pthread'])
 
   def test_giflib(self):
+    # giftext.c contains a sprintf warning
+    self.emcc_args += ['-Wno-fortify-source']
     shutil.copyfile(test_file('third_party/giflib/treescap.gif'), 'treescap.gif')
     self.do_runf(test_file('third_party/giflib/giftext.c'),
                  'GIF file terminated normally',


### PR DESCRIPTION
This is currently blockin the llvm roller because llvm got a new warning about the sprintf buffer size: https://reviews.llvm.org/D158562.