### PR TITLE
MINIMAL_RUNTIME: Fix declaration of wasmExports when using embind

### DIFF
--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -98,16 +98,6 @@ var imports = {
 #endif // MINIFY_WASM_IMPORTED_MODULES
 };
 
-// In non-fastcomp non-asm.js builds, grab wasm exports to outer scope
-// for emscripten_get_exported_function() to be able to access them.
-#if LibraryManager.has('library_exports.js')
-var wasmExports;
-#endif
-
-#if PTHREADS
-var wasmModule;
-#endif
-
 #if DECLARE_ASM_MODULE_EXPORTS
 <<< WASM_MODULE_EXPORTS_DECLARES >>>
 #endif

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -67,6 +67,12 @@ var HEAP8, HEAP16, HEAP32, HEAPU8, HEAPU16, HEAPU32, HEAPF32, HEAPF64,
 #if SUPPORT_BIG_ENDIAN
   HEAP_DATA_VIEW,
 #endif
+#if LibraryManager.has('library_exports.js') || EMBIND
+  wasmExports,
+#endif
+#if PTHREADS
+  wasmModule,
+#endif
   wasmMemory, wasmTable;
 
 function updateMemoryViews() {


### PR DESCRIPTION
The conditions under which wasmExports was declared global vs locally
were out of sync.

Also, move the declaration of the global wasmExports alongside the
other wasm globals.

See: #20145