### PR TITLE
Fix wasmExports declaration under MINIMAL_RUNTIME. NFC

### DIFF
--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -140,8 +140,8 @@ if (!Module['wasm']) throw 'Must load WebAssembly Module in to variable Module.w
 WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
 #endif
 
-#if !LibraryManager.has('library_exports.js') && !EMBIND
-  // If not using the emscripten_get_exported_function() API or embind, keep the
+#if !LibraryManager.has('library_exports.js')
+  // If not using the emscripten_get_exported_function() API, keep the
   // `wasmExports` variable in local scope to this instantiate function to save
   // code size.  (otherwise access it without to export it to outer scope)
   var


### PR DESCRIPTION
The declaration and definition of the wasmExports global were out of sync.  One included EMBIND and the other didn't.

I traced the original addition of EMBIND here back to #10417.  At that point embind did depend on the `asm` global (now `wasmExports`) in order to do `asm['dynCall_' ..`.   Nowadays MINIMAL_RUNTIME has a separate
`dynCalls` globals where these live do the dyncall mechanism no longer
depends on the `asm`/`wasmExports` global.

Fixes: #20145