### PR TITLE
Fixing build of libwasmfs.a with llvm autoroller

### DIFF
--- a/system/lib/wasmfs/backends/ignore_case_backend.cpp
+++ b/system/lib/wasmfs/backends/ignore_case_backend.cpp
@@ -180,7 +180,7 @@ int IgnoreCaseDirectory::removeChild(const std::string& name) {
 
 Directory::MaybeEntries IgnoreCaseDirectory::getEntries() {
   auto entries = real->locked().getEntries();
-  if (auto err = entries.getError()) {
+  if (entries.getError()) {
     return entries;
   }
   for (auto& entry : *entries) {

--- a/system/lib/wasmfs/virtual.h
+++ b/system/lib/wasmfs/virtual.h
@@ -112,9 +112,9 @@ protected:
 inline std::shared_ptr<File> devirtualize(std::shared_ptr<File> file) {
   if (file->is<DataFile>()) {
     return std::static_pointer_cast<VirtualDataFile>(file)->real;
-  } else if (auto dir = file->is<Directory>()) {
+  } else if (file->is<Directory>()) {
     return std::static_pointer_cast<VirtualDirectory>(file)->real;
-  } else if (auto link = file->is<Symlink>()) {
+  } else if (file->is<Symlink>()) {
     return std::static_pointer_cast<VirtualDirectory>(file)->real;
   }
   WASMFS_UNREACHABLE("unexpected file kind");


### PR DESCRIPTION
The autoroll of llvm-project into Emscripten [has been failing for almost a day](https://chromium-review.googlesource.com/c/emscripten-releases/+/4824781). The [build failure](https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket/8771363337933967825/+/u/Build_Emscripten__upstream_/stdout) reveals clang is generating errors for 3 unused variables:

```cache:INFO: generating system library: sysroot/lib/wasm32-emscripten/libwasmfs.a... (this will be cached in "/b/s/w/ir/x/w/install/emscripten/cache/sysroot/lib/wasm32-emscripten/libwasmfs.a" for subsequent builds)
In file included from /b/s/w/ir/x/w/install/emscripten/system/lib/wasmfs/backends/ignore_case_backend.cpp:18:
/b/s/w/ir/x/w/install/emscripten/system/lib/wasmfs/virtual.h:117:19: error: unused variable 'link' [-Werror,-Wunused-variable]
  117 |   } else if (auto link = file->is<Symlink>()) {
      |                   ^~~~
/b/s/w/ir/x/w/install/emscripten/system/lib/wasmfs/virtual.h:115:19: error: unused variable 'dir' [-Werror,-Wunused-variable]
  115 |   } else if (auto dir = file->is<Directory>()) {
      |                   ^~~
/b/s/w/ir/x/w/install/emscripten/system/lib/wasmfs/backends/ignore_case_backend.cpp:183:12: error: unused variable 'err' [-Werror,-Wunused-variable]
  183 |   if (auto err = entries.getError()) {
      |            ^~~
3 errors generated.
```

As a result, this PR removes those variables. Hooray for better clang detection of unused variables 🥂 