### PR TITLE
Change _NOEXCEPT back to throw()

### DIFF
--- a/system/lib/libcxxabi/include/cxxabi.h
+++ b/system/lib/libcxxabi/include/cxxabi.h
@@ -40,9 +40,9 @@ extern "C"  {
 
 // 2.4.2 Allocating the Exception Object
 extern _LIBCXXABI_FUNC_VIS void *
-__cxa_allocate_exception(size_t thrown_size) _NOEXCEPT;
+__cxa_allocate_exception(size_t thrown_size) throw();
 extern _LIBCXXABI_FUNC_VIS void
-__cxa_free_exception(void *thrown_exception) _NOEXCEPT;
+__cxa_free_exception(void *thrown_exception) throw();
 
 // 2.4.3 Throwing the Exception Object
 extern _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void
@@ -55,9 +55,9 @@ __cxa_throw(void *thrown_exception, std::type_info *tinfo,
 
 // 2.5.3 Exception Handlers
 extern _LIBCXXABI_FUNC_VIS void *
-__cxa_get_exception_ptr(void *exceptionObject) _NOEXCEPT;
+__cxa_get_exception_ptr(void *exceptionObject) throw();
 extern _LIBCXXABI_FUNC_VIS void *
-__cxa_begin_catch(void *exceptionObject) _NOEXCEPT;
+__cxa_begin_catch(void *exceptionObject) throw();
 extern _LIBCXXABI_FUNC_VIS void __cxa_end_catch();
 #if defined(_LIBCXXABI_ARM_EHABI)
 extern _LIBCXXABI_FUNC_VIS bool
@@ -152,17 +152,17 @@ extern _LIBCXXABI_FUNC_VIS char *__cxa_demangle(const char *mangled_name,
 
 // Apple additions to support C++ 0x exception_ptr class
 // These are primitives to wrap a smart pointer around an exception object
-extern _LIBCXXABI_FUNC_VIS void *__cxa_current_primary_exception() _NOEXCEPT;
+extern _LIBCXXABI_FUNC_VIS void *__cxa_current_primary_exception() throw();
 extern _LIBCXXABI_FUNC_VIS void
 __cxa_rethrow_primary_exception(void *primary_exception);
 extern _LIBCXXABI_FUNC_VIS void
-__cxa_increment_exception_refcount(void *primary_exception) _NOEXCEPT;
+__cxa_increment_exception_refcount(void *primary_exception) throw();
 extern _LIBCXXABI_FUNC_VIS void
-__cxa_decrement_exception_refcount(void *primary_exception) _NOEXCEPT;
+__cxa_decrement_exception_refcount(void *primary_exception) throw();
 
 // Apple extension to support std::uncaught_exception()
-extern _LIBCXXABI_FUNC_VIS bool __cxa_uncaught_exception() _NOEXCEPT;
-extern _LIBCXXABI_FUNC_VIS unsigned int __cxa_uncaught_exceptions() _NOEXCEPT;
+extern _LIBCXXABI_FUNC_VIS bool __cxa_uncaught_exception() throw();
+extern _LIBCXXABI_FUNC_VIS unsigned int __cxa_uncaught_exceptions() throw();
 
 #if defined(__linux__) || defined(__Fuchsia__)
 // Linux and Fuchsia TLS support. Not yet an official part of the Itanium ABI.

--- a/system/lib/libcxxabi/src/cxa_exception.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception.cpp
@@ -180,7 +180,7 @@ extern "C" {
 //  object. Zero-fill the object. If memory can't be allocated, call
 //  std::terminate. Return a pointer to the memory to be used for the
 //  user's exception object.
-void *__cxa_allocate_exception(size_t thrown_size) _NOEXCEPT {
+void *__cxa_allocate_exception(size_t thrown_size) throw() {
     size_t actual_size = cxa_exception_size_from_exception_thrown_size(thrown_size);
 
     // Allocate extra space before the __cxa_exception header to ensure the
@@ -198,7 +198,7 @@ void *__cxa_allocate_exception(size_t thrown_size) _NOEXCEPT {
 
 
 //  Free a __cxa_exception object allocated with __cxa_allocate_exception.
-void __cxa_free_exception(void *thrown_object) _NOEXCEPT {
+void __cxa_free_exception(void *thrown_object) throw() {
     // Compute the size of the padding before the header.
     size_t header_offset = get_cxa_exception_offset();
     char *raw_buffer =
@@ -312,7 +312,7 @@ The adjusted pointer is computed by the personality routine during phase 1
 
   Requires:  exception is native
 */
-void *__cxa_get_exception_ptr(void *unwind_exception) _NOEXCEPT {
+void *__cxa_get_exception_ptr(void *unwind_exception) throw() {
 #if defined(_LIBCXXABI_ARM_EHABI)
     return reinterpret_cast<void*>(
         static_cast<_Unwind_Control_Block*>(unwind_exception)->barrier_cache.bitpattern[0]);
@@ -327,7 +327,7 @@ void *__cxa_get_exception_ptr(void *unwind_exception) _NOEXCEPT {
 The routine to be called before the cleanup.  This will save __cxa_exception in
 __cxa_eh_globals, so that __cxa_end_cleanup() can recover later.
 */
-bool __cxa_begin_cleanup(void *unwind_arg) _NOEXCEPT {
+bool __cxa_begin_cleanup(void *unwind_arg) throw() {
     _Unwind_Exception* unwind_exception = static_cast<_Unwind_Exception*>(unwind_arg);
     __cxa_eh_globals* globals = __cxa_get_globals();
     __cxa_exception* exception_header =
@@ -451,7 +451,7 @@ to terminate or unexpected during unwinding.
   _Unwind_Exception and return a pointer to that.
 */
 void*
-__cxa_begin_catch(void* unwind_arg) _NOEXCEPT
+__cxa_begin_catch(void* unwind_arg) throw()
 {
     _Unwind_Exception* unwind_exception = static_cast<_Unwind_Exception*>(unwind_arg);
     bool native_exception = __isOurExceptionClass(unwind_exception);
@@ -667,7 +667,7 @@ void __cxa_rethrow() {
     Requires:  If thrown_object is not NULL, it is a native exception.
 */
 void
-__cxa_increment_exception_refcount(void *thrown_object) _NOEXCEPT {
+__cxa_increment_exception_refcount(void *thrown_object) throw() {
     if (thrown_object != NULL )
     {
         __cxa_exception* exception_header = cxa_exception_from_thrown_object(thrown_object);
@@ -684,7 +684,7 @@ __cxa_increment_exception_refcount(void *thrown_object) _NOEXCEPT {
     Requires:  If thrown_object is not NULL, it is a native exception.
 */
 _LIBCXXABI_NO_CFI
-void __cxa_decrement_exception_refcount(void *thrown_object) _NOEXCEPT {
+void __cxa_decrement_exception_refcount(void *thrown_object) throw() {
     if (thrown_object != NULL )
     {
         __cxa_exception* exception_header = cxa_exception_from_thrown_object(thrown_object);
@@ -707,7 +707,7 @@ void __cxa_decrement_exception_refcount(void *thrown_object) _NOEXCEPT {
     been no exceptions thrown, ever, on this thread, we can return NULL without
     the need to allocate the exception-handling globals.
 */
-void *__cxa_current_primary_exception() _NOEXCEPT {
+void *__cxa_current_primary_exception() throw() {
 //  get the current exception
     __cxa_eh_globals* globals = __cxa_get_globals_fast();
     if (NULL == globals)
@@ -779,10 +779,10 @@ __cxa_rethrow_primary_exception(void* thrown_object)
 }
 
 bool
-__cxa_uncaught_exception() _NOEXCEPT { return __cxa_uncaught_exceptions() != 0; }
+__cxa_uncaught_exception() throw() { return __cxa_uncaught_exceptions() != 0; }
 
 unsigned int
-__cxa_uncaught_exceptions() _NOEXCEPT
+__cxa_uncaught_exceptions() throw()
 {
     // This does not report foreign exceptions in flight
     __cxa_eh_globals* globals = __cxa_get_globals_fast();

--- a/system/lib/libcxxabi/src/cxa_exception_emscripten.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception_emscripten.cpp
@@ -85,7 +85,7 @@ extern "C" {
 //  object. Zero-fill the object. If memory can't be allocated, call
 //  std::terminate. Return a pointer to the memory to be used for the
 //  user's exception object.
-void *__cxa_allocate_exception(size_t thrown_size) _NOEXCEPT {
+void *__cxa_allocate_exception(size_t thrown_size) throw() {
     size_t actual_size = cxa_exception_size_from_exception_thrown_size(thrown_size);
 
     char *raw_buffer =
@@ -100,7 +100,7 @@ void *__cxa_allocate_exception(size_t thrown_size) _NOEXCEPT {
 
 
 //  Free a __cxa_exception object allocated with __cxa_allocate_exception.
-void __cxa_free_exception(void *thrown_object) _NOEXCEPT {
+void __cxa_free_exception(void *thrown_object) throw() {
     // Compute the size of the padding before the header.
     char *raw_buffer =
         ((char *)cxa_exception_from_thrown_object(thrown_object));
@@ -115,7 +115,7 @@ void __cxa_free_exception(void *thrown_object) _NOEXCEPT {
     Requires:  If thrown_object is not NULL, it is a native exception.
 */
 void
-__cxa_increment_exception_refcount(void *thrown_object) _NOEXCEPT {
+__cxa_increment_exception_refcount(void *thrown_object) throw() {
     if (thrown_object != NULL )
     {
         __cxa_exception* exception_header = cxa_exception_from_thrown_object(thrown_object);
@@ -133,7 +133,7 @@ __cxa_increment_exception_refcount(void *thrown_object) _NOEXCEPT {
     Requires:  If thrown_object is not NULL, it is a native exception.
 */
 _LIBCXXABI_NO_CFI
-void __cxa_decrement_exception_refcount(void *thrown_object) _NOEXCEPT {
+void __cxa_decrement_exception_refcount(void *thrown_object) throw() {
     if (thrown_object != NULL )
     {
         __cxa_exception* exception_header = cxa_exception_from_thrown_object(thrown_object);

--- a/system/lib/libcxxabi/src/cxa_noexception.cpp
+++ b/system/lib/libcxxabi/src/cxa_noexception.cpp
@@ -54,7 +54,7 @@ __cxa_uncaught_exceptions() throw() { return 0; }
 // DISABLE_EXCEPTION_CATCHING is set but DISABLE_EXCEPTION_THROWING is not.
 // TODO(sbc): Perhaps just call std::terminate here. It could
 // just be some test code that needs updating.
-void *__cxa_allocate_exception(size_t thrown_size) _NOEXCEPT {
+void *__cxa_allocate_exception(size_t thrown_size) throw() {
   char* allocation = (char*)malloc(thrown_size + sizeof(__cxa_exception));
   return allocation + sizeof(__cxa_exception);
 }
@@ -68,7 +68,7 @@ cxa_exception_from_thrown_object(void* thrown_object)
 }
 
 //  Free a __cxa_exception object allocated with __cxa_allocate_exception.
-void __cxa_free_exception(void *thrown_object) _NOEXCEPT {
+void __cxa_free_exception(void *thrown_object) throw() {
     // Compute the size of the padding before the header.
     char *raw_buffer =
         ((char *)cxa_exception_from_thrown_object(thrown_object));


### PR DESCRIPTION
This changes `_NOEXCEPT` back to `throw()` to follow the upstream libcxxabi. I'm actually not sure why I changed `throw()` to `_NOEXCEPT` in #10787 3 years ago, given that we were already handling `throw()` the same way as `noexcept`:
https://reviews.llvm.org/D79655?vs=263218&id=264335#2039395
https://github.com/llvm/llvm-project/blob/b86d3cbc1288b4d0799746c82611d17888413aec/clang/lib/CodeGen/CGException.cpp#L498-L509 
https://github.com/llvm/llvm-project/blob/b86d3cbc1288b4d0799746c82611d17888413aec/clang/lib/CodeGen/CGException.cpp#L602-L609

The upstream libcxxabi inconsistently uses both `noexcept` and `throw()`, but given that we treat them the same, I think it's better to minimize the difference between our port and the upstream, especially now we are trying to [upstream](https://reviews.llvm.org/D158918) the library.