### PR TITLE
Emsymbolizer: Handle 1-length source map entries

### DIFF
--- a/emsymbolizer.py
+++ b/emsymbolizer.py
@@ -89,8 +89,12 @@ def get_sourceMappingURL_section(module):
 
 
 class WasmSourceMap(object):
-  # This implementation is derived from emscripten's sourcemap-support.js
-  Location = namedtuple('Location', ['source', 'line', 'column'])
+  class Location(object):
+    def __init__(self, source=None, line=0, column=0, func=None):
+      self.source = source
+      self.line = line
+      self.column = column
+      self.func = func
 
   def __init__(self):
     self.version = None


### PR DESCRIPTION
After https://github.com/WebAssembly/binaryen/pull/5906 Binaryen can emit such entries, which
emsymbolizer should not error on.

This should unblock the binaryen-emscripten roller: https://github.com/WebAssembly/binaryen/pull/5906#issuecomment-1700391431