### PR TITLE
Fix the WASM Worker cannot start in node.js environment

### DIFF
--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -47,7 +47,12 @@ addToLibrary({
   $_wasmWorkerRunPostMessage: (e) => {
     // '_wsc' is short for 'wasm call', trying to use an identifier name that
     // will never conflict with user code
-    let data = e.data, wasmCall = data['_wsc'];
+#if ENVIRONMENT_MAY_BE_NODE
+    const data = ENVIRONMENT_IS_NODE ? e : e.data;
+#else
+    const data = e.data;
+#endif
+    const wasmCall = data['_wsc'];
     wasmCall && getWasmTableEntry(wasmCall)(...data['x']);
   },
 

--- a/src/wasm_worker.js
+++ b/src/wasm_worker.js
@@ -1,12 +1,45 @@
 // N.B. The contents of this file are duplicated in src/library_wasm_worker.js
 // in variable "_wasmWorkerBlobUrl" (where the contents are pre-minified) If
 // doing any changes to this file, be sure to update the contents there too.
-onmessage = function(d) {
+
+'use strict';
+
+#if ENVIRONMENT_MAY_BE_NODE
+// Node.js support
+var ENVIRONMENT_IS_NODE = typeof process == 'object' && typeof process.versions == 'object' && typeof process.versions.node == 'string';
+if (ENVIRONMENT_IS_NODE) {
+  // Create as web-worker-like an environment as we can.
+
+  var nodeWorkerThreads = require('worker_threads');
+
+  var parentPort = nodeWorkerThreads.parentPort;
+
+  parentPort.on('message', (data) => typeof onmessage === "function" && onmessage({ data: data }));
+
+  var fs = require('fs');
+
+  Object.assign(global, {
+    self: global,
+    require,
+    location: {
+      href: __filename
+    },
+    Worker: nodeWorkerThreads.Worker,
+    importScripts: (f) => (0, eval)(fs.readFileSync(f, 'utf8') + '//# sourceURL=' + f),
+    postMessage: (msg) => parentPort.postMessage(msg),
+    performance: global.performance || { now: Date.now },
+    addEventListener: (name, handler) => parentPort.on(name, handler),
+    removeEventListener: (name, handler) => parentPort.off(name, handler),
+  });
+}
+#endif // ENVIRONMENT_MAY_BE_NODE
+
+self.onmessage = function(d) {
 	// The first message sent to the Worker is always the bootstrap message.
 	// Drop this message listener, it served its purpose of bootstrapping
 	// the Wasm Module load, and is no longer needed. Let user code register
 	// any desired message handlers from now on.
-	onmessage = null;
+	self.onmessage = null;
 	d = d.data;
 #if !MODULARIZE
 	self.{{{ EXPORT_NAME }}} = d;

--- a/test/common.py
+++ b/test/common.py
@@ -1064,7 +1064,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def run_js(self, filename, engine=None, args=None,
              output_nicerizer=None,
              assert_returncode=0,
-             interleaved_output=True):
+             interleaved_output=True,
+             timeout=None, timeout_as_error=True):
     # use files, as PIPE can get too full and hang us
     stdout_file = self.in_dir('stdout')
     stderr_file = None
@@ -1086,9 +1087,11 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       jsrun.run_js(filename, engine, args,
                    stdout=stdout,
                    stderr=stderr,
-                   assert_returncode=assert_returncode)
+                   assert_returncode=assert_returncode,
+                   timeout=timeout)
     except subprocess.TimeoutExpired as e:
-      timeout_error = e
+      if timeout_as_error:
+        timeout_error = e
     except subprocess.CalledProcessError as e:
       error = e
     finally:
@@ -1506,7 +1509,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
                      check_for_error=True, force_c=False, emcc_args=None,
                      interleaved_output=True,
                      regex=False,
-                     output_basename=None):
+                     output_basename=None,
+                     timeout=None, timeout_as_error=True):
     logger.debug(f'_build_and_run: {filename}')
 
     if no_build:
@@ -1533,7 +1537,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       js_output = self.run_js(js_file, engine, args,
                               output_nicerizer=output_nicerizer,
                               assert_returncode=assert_returncode,
-                              interleaved_output=interleaved_output)
+                              interleaved_output=interleaved_output,
+                              timeout=timeout,
+                              timeout_as_error=timeout_as_error)
       js_output = js_output.replace('\r\n', '\n')
       if expected_output:
         if type(expected_output) not in [list, tuple]:

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9795,15 +9795,15 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @node_pthreads
   def test_wasm_worker_hello(self):
-    self.do_runf(test_file('wasm_worker/hello_wasm_worker.c'), emcc_args=['-sWASM_WORKERS'])
+    self.do_run_in_out_file_test(test_file('wasm_worker/hello_wasm_worker.c'), emcc_args=['-sWASM_WORKERS'], timeout=3)
 
   @node_pthreads
   def test_wasm_worker_malloc(self):
-    self.do_runf(test_file('wasm_worker/malloc_wasm_worker.c'), emcc_args=['-sWASM_WORKERS'])
+    self.do_runf(test_file('wasm_worker/malloc_wasm_worker.c'), emcc_args=['-sWASM_WORKERS'], timeout=3)
 
   @node_pthreads
   def test_wasm_worker_wait_async(self):
-    self.do_runf(test_file('wasm_worker/wait_async.c'), emcc_args=['-sWASM_WORKERS'])
+    self.do_runf(test_file('wasm_worker/wait_async.c'), emcc_args=['-sWASM_WORKERS'], timeout=3)
 
 
 # Generate tests for everything

--- a/test/wasm_worker/hello_wasm_worker.out
+++ b/test/wasm_worker/hello_wasm_worker.out
@@ -1,0 +1,1 @@
+Hello from wasm worker!

--- a/test/wasm_worker/malloc_wasm_worker.out
+++ b/test/wasm_worker/malloc_wasm_worker.out
@@ -1,0 +1,1 @@
+Hello from wasm worker!


### PR DESCRIPTION
`emscripten_malloc_wasm_worker` and
`emscripten_create_wasm_worker` functions
adapted to the nodejs environment and
modified the core related tests.