### PR TITLE
[CI] Remove `update-tags` step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ commands:
             export PATH="`pwd`/node-v15.14.0-linux-x64/bin:${PATH}"
             npm install jsvu -g
             jsvu --os=default --engines=v8
-  build:
+  install-emsdk:
     description: "Install emsdk"
     steps:
       - run:
@@ -135,7 +135,6 @@ commands:
             tar -C ~ -xf ~/emsdk-main.tar.gz
             mv ~/emsdk-main ~/emsdk
             cd ~/emsdk
-            ./emsdk update-tags
             ./emsdk install tot
             ./emsdk activate tot
             # Remove the emsdk version of emscripten to save space in the
@@ -458,7 +457,7 @@ jobs:
             tar xvf libclang_rt.builtins-wasm32-wasi-11.0.tar.gz -C ~/wasi-sdk
             tar xvf wasi-sysroot-11.0.tar.gz -C ~/wasi-sdk/
       - install-v8
-      - build
+      - install-emsdk
       - build-libs
       - persist
   # Perhaps we don't need to run this suite with every commit. Consider moving this to FYI bot.
@@ -650,7 +649,7 @@ jobs:
           name: submodule update
           command: git submodule update --init
       - pip-install
-      - build
+      - install-emsdk
       - run:
           name: install jsc
           command: |
@@ -672,7 +671,7 @@ jobs:
           name: submodule update
           command: git submodule update --init
       - pip-install
-      - build
+      - install-emsdk
       - run:
           name: install spidermonkey
           command: |
@@ -698,7 +697,7 @@ jobs:
           name: submodule update
           command: git submodule update --init
       - pip-install
-      - build
+      - install-emsdk
       - install-node-canary
       - run-tests:
           title: "selected subset"
@@ -796,7 +795,7 @@ jobs:
           command: echo "export PATH=\"$PATH:/c/Python27amd64/\"" >> $BASH_ENV
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
-      - build
+      - install-emsdk
       - pip-install:
           python: "$EMSDK_PYTHON"
       - run-tests:
@@ -833,7 +832,7 @@ jobs:
             rm -rf ~/emsdk ~/vms ~/.jsvu
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
-      - build
+      - install-emsdk
       - pip-install:
           python: "$EMSDK_PYTHON"
       - run-tests:
@@ -855,7 +854,7 @@ jobs:
       EMCC_SKIP_SANITY_CHECK: "1"
     steps:
       - setup-macos
-      - build
+      - install-emsdk
       # TODO: We can't currently do pip install here since numpy and other packages
       # are currently missing arm64 macos binaries.
       # TODO: Remove this once emsdk has an arm64 version of node


### PR DESCRIPTION
Its not longer needed and generates a warning.

Also rename the step to match what its really doing.