### PR TITLE
[ports] Remove support for `Port.get()` returning a .txt file. NFC

### DIFF
--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -390,8 +390,8 @@ def get_libs(settings):
   for port in dependency_order(needed):
     if port.needed(settings):
       port.linker_setup(Ports, settings)
-      # ports return their output files, which will be linked, or a txt file
-      ret += [f for f in port.get(Ports, settings, shared) if not f.endswith('.txt')]
+      # port.get returns a list of libraries to link
+      ret += port.get(Ports, settings, shared)
 
   ret.reverse()
   return ret


### PR DESCRIPTION
The binaryen port used to do this but it was removed back in #9411.