### PR TITLE
Simplify Asyncify runtime pattern matching

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -119,7 +119,7 @@ addToLibrary({
       dbg('asyncify instrumenting exports');
 #endif
 #if ASYNCIFY == 2
-      var exportPatterns = [{{{ ASYNCIFY_EXPORTS.map(x => new RegExp('^' + x.replace(/\*/g, '.*') + '$')) }}}];
+      var exportPattern = {{{ new RegExp(`^(${ASYNCIFY_EXPORTS.join('|').replace(/\*/g, '.*')})$`) }}};
       Asyncify.asyncExports = new Set();
 #endif
       var ret = {};
@@ -129,7 +129,7 @@ addToLibrary({
           if (typeof original == 'function') {
 #if ASYNCIFY == 2
             // Wrap all exports with a promising WebAssembly function.
-            var isAsyncifyExport = exportPatterns.some(pattern => !!x.match(pattern));
+            var isAsyncifyExport = exportPattern.test(x);
             if (isAsyncifyExport) {
               Asyncify.asyncExports.add(original);
               original = Asyncify.makeAsyncFunction(original);

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -41,15 +41,14 @@ addToLibrary({
 #if ASYNCIFY_DEBUG
       dbg('asyncify instrumenting imports');
 #endif
-      var importPatterns = [{{{ ASYNCIFY_IMPORTS.map(x => '/^' + x.split('.')[1].replace(new RegExp('\\*', 'g'), '.*') + '$/') }}}];
+      var importPattern = {{{ new RegExp(`^(${ASYNCIFY_IMPORTS.map(x => x.split('.')[1]).join('|').replace(/\*/g, '.*')})$`) }}};
 
       for (var x in imports) {
         (function(x) {
           var original = imports[x];
           var sig = original.sig;
           if (typeof original == 'function') {
-            var isAsyncifyImport = original.isAsync ||
-                                   importPatterns.some(pattern => !!x.match(pattern));
+            var isAsyncifyImport = original.isAsync || importPattern.test(x);
 #if ASYNCIFY == 2
             // Wrap async imports with a suspending WebAssembly function.
             if (isAsyncifyImport) {


### PR DESCRIPTION
Instead of generating an array of regexes and checking them one by one, generate a single regex containing all patterns.

This slightly simplifies code, and in theory might make a tiny dent on file size and speed as well.

Ideally we shouldn't even need to keep the entire list (where some patterns might never match), and instead statically add `isAsyncFunction` to relevant functions when generating the `wasmImports` object. But until then I figured it doesn't hurt sending even a tiny improvement.