### PR TITLE
Ensure Unique Keys in @memoize Decorator

### DIFF
--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -60,7 +60,7 @@ def memoize(method):
   @wraps(method)
   def wrapper(self, *args, **kwargs):
     assert not kwargs
-    key = method
+    key = (method.__name__, args)
     if key not in self._cache:
       self._cache[key] = method(self, *args, **kwargs)
     return self._cache[key]


### PR DESCRIPTION
Previously, the key used in the @memoize decorator was not unique. By including the method's arguments in the key, we now ensure that the key is unique for each call.

Fixes #20217