### PR TITLE
Asyncify JS library funcs under any namespace

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -100,9 +100,7 @@ UNSUPPORTED_LLD_FLAGS = {
     '-install_name': True,
 }
 
-DEFAULT_ASYNCIFY_IMPORTS = [
-  'wasi_snapshot_preview1.fd_sync', '__wasi_fd_sync', '__asyncjs__*'
-]
+DEFAULT_ASYNCIFY_IMPORTS = ['__asyncjs__*']
 
 DEFAULT_ASYNCIFY_EXPORTS = [
   'main',
@@ -1332,7 +1330,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       for sym in settings.EXPORTED_RUNTIME_METHODS:
         add_js_deps(shared.demangle_c_symbol_name(sym))
     if settings.ASYNCIFY:
-      settings.ASYNCIFY_IMPORTS += ['env.' + x for x in js_info['asyncFuncs']]
+      settings.ASYNCIFY_IMPORTS += ['*.' + x for x in js_info['asyncFuncs']]
 
   phase_calculate_system_libraries(state, linker_arguments, newargs)
 

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -562,6 +562,7 @@ var WasiLibrary = {
     return {{{ cDefs.ENOSYS }}};
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },
+  fd_sync__async: true,
 };
 
 for (var x in WasiLibrary) {


### PR DESCRIPTION
Previously any JS library funcs were passed to ASYNCIFY_IMPORTS under `env.` prefix.

This can be problematic when implementing WASI functions using Asyncify, since we pass the same `wasmImports` object under both `env` and `wasi_snapshot_preview1` namespaces, and don't really differentiate under which namespace it will be called in the JS code.

One existing example of this was `fd_sync` which already had to be hardcoded in `DEFAULT_ASYNCIFY_IMPORTS`, but there can be more examples both in the future as well as today in user's code that wants to override WASI functions with some Asyncify code.

The simplest and most reliable fix to cover those scenarios is to do what JS already does and not differentiate between namespaces - that is, pass `*.{name}` instead of `env.{name}` so that function is correctly Asyncified no matter under which namespace it ends up imported in the Wasm module.