### PR TITLE
assign $$ in ClassHandle constructor

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -1619,6 +1619,7 @@ var LibraryEmbind = {
   $ClassHandle__postset: 'init_ClassHandle()',
   // root of all pointer and smart pointer handles in embind
   $ClassHandle: function() {
+    this.$$ = undefined;
   },
 
   $ClassHandle_isAliasOf: function(other) {
@@ -1631,7 +1632,6 @@ var LibraryEmbind = {
 
     var leftClass = this.$$.ptrType.registeredClass;
     var left = this.$$.ptr;
-    other.$$ = /** @type {Object} */ (other.$$);
     var rightClass = other.$$.ptrType.registeredClass;
     var right = other.$$.ptr;
 


### PR DESCRIPTION
It appears in some cases `$$` is readonly and will result in a runtime error attempting to do the otherwise no-op assignment meant to help the jscompiler. Instead, we can assign the property in the constructor to undefined.

The error I'm seeing is a runtime error `TypeError: Cannot assign to read only property '$$' of object '[object Object]`. This indicates that `$$` is readonly (which I can confirm with a breakpoint and inspecting the object), but I can't find a call to `Object.freeze` or where `writable` would be set to `false`.

@brendandahl any idea if `$$` ends up being set as readonly by embind at some point? If it does, then I believe this patch is correct.