### PR TITLE
Rename the `exports` variable in preamble.js to `instExports`

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -948,18 +948,18 @@ function createWasm() {
   // performing other necessary setup
   /** @param {WebAssembly.Module=} module*/
   function receiveInstance(instance, module) {
-    var instExports = instance.exports;
+    var wasmExports = instance.exports;
 
 #if RELOCATABLE
-    instExports = relocateExports(instExports, {{{ GLOBAL_BASE }}});
+    wasmExports = relocateExports(wasmExports, {{{ GLOBAL_BASE }}});
 #endif
 
 #if ASYNCIFY
-    instExports = Asyncify.instrumentWasmExports(instExports);
+    wasmExports = Asyncify.instrumentWasmExports(wasmExports);
 #endif
 
 #if ABORT_ON_WASM_EXCEPTIONS
-    instExports = instrumentWasmExportsWithAbort(instExports);
+    wasmExports = instrumentWasmExportsWithAbort(wasmExports);
 #endif
 
 #if MAIN_MODULE
@@ -969,7 +969,7 @@ function createWasm() {
       dynamicLibraries = metadata.neededDynlibs.concat(dynamicLibraries);
     }
 #endif
-    mergeLibSymbols(instExports, 'main')
+    mergeLibSymbols(wasmExports, 'main')
 #if '$LDSO' in addedLibraryItems
     LDSO.init();
 #endif
@@ -979,10 +979,9 @@ function createWasm() {
 #endif
 
 #if MEMORY64 || CAN_ADDRESS_2GB
-    instExports = applySignatureConversions(instExports);
+    wasmExports = applySignatureConversions(wasmExports);
 #endif
 
-    wasmExports = instExports;
     {{{ receivedSymbol('wasmExports') }}}
 
 #if PTHREADS
@@ -1039,7 +1038,7 @@ function createWasm() {
 #if !DECLARE_ASM_MODULE_EXPORTS
     // If we didn't declare the asm exports as top level enties this function
     // is in charge of programatically exporting them on the global object.
-    exportWasmSymbols(instExports);
+    exportWasmSymbols(wasmExports);
 #endif
 
 #if PTHREADS || WASM_WORKERS
@@ -1047,7 +1046,7 @@ function createWasm() {
     wasmModule = module;
 #endif
     removeRunDependency('wasm-instantiate');
-    return instExports;
+    return wasmExports;
   }
   // wait for the pthread pool (if any)
   addRunDependency('wasm-instantiate');

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -948,18 +948,18 @@ function createWasm() {
   // performing other necessary setup
   /** @param {WebAssembly.Module=} module*/
   function receiveInstance(instance, module) {
-    var exports = instance.exports;
+    var instExports = instance.exports;
 
 #if RELOCATABLE
-    exports = relocateExports(exports, {{{ GLOBAL_BASE }}});
+    instExports = relocateExports(instExports, {{{ GLOBAL_BASE }}});
 #endif
 
 #if ASYNCIFY
-    exports = Asyncify.instrumentWasmExports(exports);
+    instExports = Asyncify.instrumentWasmExports(instExports);
 #endif
 
 #if ABORT_ON_WASM_EXCEPTIONS
-    exports = instrumentWasmExportsWithAbort(exports);
+    instExports = instrumentWasmExportsWithAbort(instExports);
 #endif
 
 #if MAIN_MODULE
@@ -969,7 +969,7 @@ function createWasm() {
       dynamicLibraries = metadata.neededDynlibs.concat(dynamicLibraries);
     }
 #endif
-    mergeLibSymbols(exports, 'main')
+    mergeLibSymbols(instExports, 'main')
 #if '$LDSO' in addedLibraryItems
     LDSO.init();
 #endif
@@ -979,10 +979,10 @@ function createWasm() {
 #endif
 
 #if MEMORY64 || CAN_ADDRESS_2GB
-    exports = applySignatureConversions(exports);
+    instExports = applySignatureConversions(instExports);
 #endif
 
-    wasmExports = exports;
+    wasmExports = instExports;
     {{{ receivedSymbol('wasmExports') }}}
 
 #if PTHREADS
@@ -1039,7 +1039,7 @@ function createWasm() {
 #if !DECLARE_ASM_MODULE_EXPORTS
     // If we didn't declare the asm exports as top level enties this function
     // is in charge of programatically exporting them on the global object.
-    exportWasmSymbols(exports);
+    exportWasmSymbols(instExports);
 #endif
 
 #if PTHREADS || WASM_WORKERS
@@ -1047,7 +1047,7 @@ function createWasm() {
     wasmModule = module;
 #endif
     removeRunDependency('wasm-instantiate');
-    return exports;
+    return instExports;
   }
   // wait for the pthread pool (if any)
   addRunDependency('wasm-instantiate');

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -948,7 +948,7 @@ function createWasm() {
   // performing other necessary setup
   /** @param {WebAssembly.Module=} module*/
   function receiveInstance(instance, module) {
-    var wasmExports = instance.exports;
+    wasmExports = instance.exports;
 
 #if RELOCATABLE
     wasmExports = relocateExports(wasmExports, {{{ GLOBAL_BASE }}});


### PR DESCRIPTION
This avoids a bug (or limitation) in Google's Closure compiler that does not allow any variable named `exports` to be reassigned. Without this change, some build configurations result in an error message like this:

```
[JSC_EXPORT_NOT_AT_MODULE_SCOPE] Exports must be at the top-level of a module  543|
     exports = Asyncify.instrumentWasmExports(exports);  
```

The Closure logic lives [here](https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/ClosureCheckModule.java#L436), and is intended to block Closure's module exports object from getting reassigned.

Since the exports variable used in the preamble is not related to Closure modules, simply renaming the variable does the trick.

The name `instExports` is already used elsewhere in the preamble to refer to the same thing, so it seems like a good choice here as well.