### PR TITLE
Exclude async JS library funcs from the regexp

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1330,6 +1330,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       for sym in settings.EXPORTED_RUNTIME_METHODS:
         add_js_deps(shared.demangle_c_symbol_name(sym))
     if settings.ASYNCIFY:
+      settings.ASYNCIFY_IMPORTS_EXCEPT_JS_LIBS = settings.ASYNCIFY_IMPORTS[:]
       settings.ASYNCIFY_IMPORTS += ['*.' + x for x in js_info['asyncFuncs']]
 
   phase_calculate_system_libraries(state, linker_arguments, newargs)

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -41,7 +41,7 @@ addToLibrary({
 #if ASYNCIFY_DEBUG
       dbg('asyncify instrumenting imports');
 #endif
-      var importPattern = {{{ new RegExp(`^(${ASYNCIFY_IMPORTS.map(x => x.split('.')[1]).join('|').replace(/\*/g, '.*')})$`) }}};
+      var importPattern = {{{ new RegExp(`^(${ASYNCIFY_IMPORTS_EXCEPT_JS_LIBS.map(x => x.split('.')[1]).join('|').replace(/\*/g, '.*')})$`) }}};
 
       for (var x in imports) {
         (function(x) {

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -272,3 +272,5 @@ var PTHREADS = false;
 var BULK_MEMORY = false;
 
 var MINIFY_WHITESPACE = true;
+
+var ASYNCIFY_IMPORTS_EXCEPT_JS_LIBS = [];


### PR DESCRIPTION
Asyncify JS library functions are already statically marked with `.isAsync = true`, so there's no need to additionally exclude them in the regexp.

This saves quite a bit of code, particularly because a lot of such JS functions in ASYNCIFY_IMPORTS might be included in the list simply due to the inclusion of the parent library, even though given function is not used by the actual code.

Example of generated JS before the change:

```js
var importPattern = /^(invoke_.*|__asyncjs__.*|fd_sync|emscripten_promise_await|emscripten_idb_load|emscripten_idb_store|emscripten_idb_delete|emscripten_idb_exists|emscripten_idb_clear|emscripten_idb_load_blob|emscripten_idb_store_blob|emscripten_sleep|emscripten_wget_data|emscripten_scan_registers|emscripten_lazy_load_code|_load_secondary_module|emscripten_fiber_swap|SDL_Delay)$/;
```

After:

```js
var importPattern = /^(invoke_.*|__asyncjs__.*)$/;
```