### PR TITLE
Use addEventListener in a few places instead of registering on to .onmessage 

### DIFF
--- a/src/audio_worklet.js
+++ b/src/audio_worklet.js
@@ -142,6 +142,7 @@ class BootstrapMessages extends AudioWorkletProcessor {
     // Listen to messages from the main thread. These messages will ask this scope to create the real
     // AudioWorkletProcessors that call out to Wasm to do audio processing.
     let p = globalThis['messagePort'] = this.port;
+    // We are the only user of this BootstrapMessages processor, so can use the .onmessage handler directly instead of addEventListener().
     p.onmessage = (msg) => {
       let d = msg.data;
       if (d['_wpn']) { // '_wpn' is short for 'Worklet Processor Node', using an identifier that will never conflict with user messages

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -255,7 +255,7 @@ var LibraryPThread = {
     //                    the workers have been initialized and are
     //                    ready to host pthreads.
     loadWasmModuleToWorker: (worker) => new Promise((onFinishedLoading) => {
-      worker.onmessage = (e) => {
+      worker.addEventListener('message', (e) => {
         var d = e['data'];
         var cmd = d['cmd'];
 
@@ -311,7 +311,7 @@ var LibraryPThread = {
           // recognized commands:
           err(`worker sent an unknown command ${cmd}`);
         }
-      };
+      });
 
       worker.onerror = (e) => {
         var message = 'worker sent an error!';
@@ -524,12 +524,12 @@ var LibraryPThread = {
     // the worker now dead and we don't want to hear from it again, so we stub
     // out its message handler here.  This avoids having to check in each of
     // the onmessage handlers if the message was coming from valid worker.
-    worker.onmessage = (e) => {
+    worker.addEventListener('message', (e) => {
 #if ASSERTIONS
       var cmd = e['data']['cmd'];
       err(`received "${cmd}" command from terminated worker: ${worker.workerID}`);
 #endif
-    };
+    });
   },
 
   $killThread__deps: ['_emscripten_thread_free_data', '$terminateWorker'],

--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -156,7 +156,7 @@ if (ENVIRONMENT_IS_WASM_WORKER) {
       'sb': stackLowestAddress, // sb = stack bottom (lowest stack address, SP points at this when stack is full)
       'sz': stackSize,          // sz = stack size
     });
-    worker.onmessage = _wasmWorkerRunPostMessage;
+    worker.addEventListener('message', _wasmWorkerRunPostMessage);
     return _wasmWorkersID++;
   },
 

--- a/src/library_webaudio.js
+++ b/src/library_webaudio.js
@@ -187,6 +187,7 @@ let LibraryWebAudio = {
           'sz': stackSize,          // sz = stack size
         }
       });
+      // We are the only user of this BootstrapMessages processor, so can use the .onmessage handler directly instead of addEventListener().
       audioWorklet.bootstrapMessage.port.onmessage = _EmAudioDispatchProcessorCallback;
 
       // AudioWorklets do not have a importScripts() function like Web Workers do (and AudioWorkletGlobalScope does not allow dynamic import() either),


### PR DESCRIPTION
Use addEventListener in a few places instead of registering on to .onmessage so that end users can utilize the .onmessage themselves.

Addresses #20192.