### PR TITLE
Optimise handleAsync for JSPI

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -441,21 +441,18 @@ addToLibrary({
     isAsyncExport(func) {
       return Asyncify.asyncExports && Asyncify.asyncExports.has(func);
     },
-    handleSleep(startAsync) {
+    async handleAsync(startAsync) {
       {{{ runtimeKeepalivePush(); }}}
-      var promise = new Promise((resolve) => {
-        startAsync(resolve);
-      });
-      promise.finally(() => {
+      try {
+        return await startAsync();
+      } finally {
         {{{ runtimeKeepalivePop(); }}}
-      });
-      return promise;
+      }
     },
-    handleAsync(startAsync) {
-      return Asyncify.handleSleep((wakeUp) => {
-        // TODO: add error handling as a second param when handleSleep implements it.
-        startAsync().then(wakeUp);
-      });
+    handleSleep(startAsync) {
+      return Asyncify.handleAsync(() => (
+        new Promise((wakeUp) => startAsync(wakeUp))
+      ));
     },
     makeAsyncFunction(original) {
 #if ASYNCIFY_DEBUG

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -441,7 +441,7 @@ addToLibrary({
     isAsyncExport(func) {
       return Asyncify.asyncExports && Asyncify.asyncExports.has(func);
     },
-    async handleAsync(startAsync) {
+    handleAsync: async (startAsync) => {
       {{{ runtimeKeepalivePush(); }}}
       try {
         return await startAsync();


### PR DESCRIPTION
With current handling, in JSPI mode handleAsync was doing unnecessary double wrapping-unwrapping of promises: invoke startAsync, it returns the promise, convert it to callback-style function with wakeUp, pass to handleSleep, handleSleep takes the callback and converts it back to another promise.

For JSPI Promises are native, so it makes more sense to invert the relationsheep between those 2 APIs and make handleAsync just await the original promise, while handleSleep would be the only one converting between callback and promise styles.