### PR TITLE
[embind] Fix closure warning about emval_registeredMethods

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -388,7 +388,7 @@ var LibraryEmVal = {
     return id;
   },
 
-  $emval_registeredMethods: [],
+  $emval_registeredMethods: {},
   _emval_get_method_caller__deps: [
     '$emval_addMethodCaller', '$emval_lookupTypes',,
     '$makeLegalFunctionName', '$emval_registeredMethods',

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7612,6 +7612,7 @@ void* operator new(size_t size) {
     'flag': (['--bind'],),
   })
   def test_embind(self, args):
+    self.maybe_closure()
     create_file('test_embind.cpp', r'''
       #include <stdio.h>
       #include <emscripten/val.h>


### PR DESCRIPTION
`emval_registeredMethods` is an object/map, not an array.

Closure was rightly complaining about this:

```
/tmp/emscripten_temp_8ico2w6n/test_embind.jso1.js:1191:25: WARNING - [JSC_TYPE_MISMATCH] restricted index type
found   : string
required: number
  1191|  emval_registeredMethods[signatureName] = returnId;
                                 ^^^^^^^^^^^^^
```