### PR TITLE
Ensure all core embind tests can run with closure. NFC

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -408,6 +408,7 @@ var LibraryEmbind = {
   },
 
 #if WASM_BIGINT
+  _embind_register_bigint__docs: '/** @suppress {globalThis} */',
   _embind_register_bigint__deps: [
     '$embindRepr', '$readLatin1String', '$registerType', '$integerReadValueFromPointer'],
   _embind_register_bigint: (primitiveType, name, size, minRange, maxRange) => {

--- a/test/core/embind_lib_with_asyncify.test.js
+++ b/test/core/embind_lib_with_asyncify.test.js
@@ -1,19 +1,19 @@
-Module.onRuntimeInitialized = async () => {
+Module['onRuntimeInitialized'] = async () => {
   try {
-    let delayedThrowResult = Module.delayed_throw();
+    let delayedThrowResult = Module["delayed_throw"]();
     assert(delayedThrowResult instanceof Promise);
     let err = await delayedThrowResult.then(() => '', err => err.message);
     assert(err === 'my message', `"${err}" doesn't contain the expected error`);
 
-    let fooResult = Module.foo();
+    let fooResult = Module["foo"]();
     assert(fooResult instanceof Promise);
     fooResult = await fooResult;
     assert(fooResult === 10);
 
-    let barInstancePromise = new Module.Bar();
+    let barInstancePromise = new Module["Bar"]();
     assert(barInstancePromise instanceof Promise);
     let barInstance = await barInstancePromise;
-    assert(barInstance instanceof Module.Bar);
+    assert(barInstance instanceof Module["Bar"]);
     assert(barInstance.x === 20);
 
     let barMethodResult = barInstance.method();
@@ -27,7 +27,7 @@ Module.onRuntimeInitialized = async () => {
     assert(barMethodResult instanceof Promise);
     assert(await barMethodResult === undefined);
 
-    let barStaticMethodResult = Module.Bar.static_method();
+    let barStaticMethodResult = Module["Bar"].static_method();
     assert(barStaticMethodResult instanceof Promise);
     assert(await barStaticMethodResult === 50);
 

--- a/test/core/test_embind_5.cpp
+++ b/test/core/test_embind_5.cpp
@@ -51,10 +51,10 @@ EMSCRIPTEN_BINDINGS(my_module) {
 int main(int argc, char **argv) {
   EM_ASM(
     try {
-      var foo = new Module.MyFoo();
-      foo.doit();
-      var bar = new Module.MyBar();
-      bar.doit();
+      var foo = new Module['MyFoo']();
+      foo['doit']();
+      var bar = new Module['MyBar']();
+      bar['doit']();
     } catch(e) {
       out(e);
     } finally {

--- a/test/core/test_embind_polymorphic_class_no_rtti.cpp
+++ b/test/core/test_embind_polymorphic_class_no_rtti.cpp
@@ -9,7 +9,7 @@
 #include <stdio.h>
 
 EM_JS(void, calltest, (), {
-  var foo = new Module.Foo();
+  var foo = new Module["Foo"]();
   console.log("foo.test() returned: " + foo.test());
   foo.delete();
 });

--- a/test/embind/test_custom_marshal.js
+++ b/test/embind/test_custom_marshal.js
@@ -1,4 +1,4 @@
-Module.js_func = function(x) {
+Module['js_func'] = function(x) {
     console.log('JS got', x, typeof(x));
     return 20;
 }

--- a/test/embind/test_finalization.js
+++ b/test/embind/test_finalization.js
@@ -1,6 +1,6 @@
 Module.onRuntimeInitialized = () => {
-  const foo1 = new Module.Foo("Constructed from JS");
-  const foo2 = Module.foo();
-  const foo3 = Module.pFoo();
+  const foo1 = new Module["Foo"]("Constructed from JS");
+  const foo2 = Module["foo"]();
+  const foo3 = Module["pFoo"]();
   setTimeout(gc, 100);
 }

--- a/test/embind/test_i64_val.cpp
+++ b/test/embind/test_i64_val.cpp
@@ -63,6 +63,7 @@ int main()
   std::array<std::int64_t, 5> int64Array = {-2, -1, 0, 1, 2};
 
   printf("start\n");
+  EM_ASM({globalThis.a = null});
 
   test("val(int64_t v)");
   val::global().set("a", val(int64_t(1234)));

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7637,10 +7637,11 @@ void* operator new(size_t size) {
   })
   @node_pthreads
   def test_embind_2(self, args):
+    self.maybe_closure()
     self.emcc_args += ['-lembind', '--post-js', 'post.js'] + args
     create_file('post.js', '''
       function printLerp() {
-        out('lerp ' + Module.lerp(100, 200, 66) + '.');
+        out('lerp ' + Module['lerp'](100, 200, 66) + '.');
       }
     ''')
     create_file('test_embind_2.cpp', r'''
@@ -7668,7 +7669,7 @@ void* operator new(size_t size) {
     create_file('post.js', '''
       function ready() {
         try {
-          Module.compute(new Uint8Array([1,2,3]));
+          Module['compute'](new Uint8Array([1,2,3]));
         } catch(e) {
           out(e);
         }
@@ -7695,7 +7696,7 @@ void* operator new(size_t size) {
     self.emcc_args += ['-lembind', '--post-js', 'post.js']
     create_file('post.js', '''
       function printFirstElement() {
-        out(Module.getBufferView()[0]);
+        out(Module['getBufferView']()[0]);
       }
     ''')
     create_file('test_embind_4.cpp', r'''
@@ -7779,7 +7780,7 @@ void* operator new(size_t size) {
       #include <stdio.h>
 
       EM_JS(void, calltest, (), {
-        out("dotest returned: " + Module.dotest());
+        out("dotest returned: " + Module["dotest"]());
       });
 
       int main(int argc, char** argv){
@@ -7811,7 +7812,7 @@ void* operator new(size_t size) {
       #include <stdio.h>
 
       EM_JS(void, calltest, (), {
-        out("dotest returned: " + Module.dotest());
+        out("dotest returned: " + Module["dotest"]());
       });
 
       int main(int argc, char** argv){


### PR DESCRIPTION
This change doesn't actually run them all with closure (don't want to add too much time to CI), but I verified that they all at least do run now.