### PR TITLE
Fix compiler warnings in websocket_to_posix_proxy. NFC

### DIFF
--- a/tools/websocket_to_posix_proxy/CMakeLists.txt
+++ b/tools/websocket_to_posix_proxy/CMakeLists.txt
@@ -2,15 +2,17 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(websocket_to_posix_proxy)
 
+if (WIN32)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  add_compile_options(/wd4200) # "nonstandard extension used: zero-sized array in struct/union"
+  target_link_libraries(websocket_to_posix_proxy Ws2_32.lib)
+else()
+  add_compile_options(-Werror -Wall)
+endif()
+
 file(GLOB sourceFiles src/*.cpp src/*.c src/*.h)
 
 add_executable(websocket_to_posix_proxy ${sourceFiles})
 
 find_package(Threads)
 target_link_libraries(websocket_to_posix_proxy ${CMAKE_THREAD_LIBS_INIT})
-
-if (WIN32)
-  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-  add_definitions(/wd4200) # "nonstandard extension used: zero-sized array in struct/union"
-  target_link_libraries(websocket_to_posix_proxy Ws2_32.lib)
-endif()

--- a/tools/websocket_to_posix_proxy/src/main.cpp
+++ b/tools/websocket_to_posix_proxy/src/main.cpp
@@ -110,7 +110,7 @@ bool WebSocketValidateMessageSize(uint8_t *data, uint64_t obtainedNumBytes) {
   uint64_t expectedNumBytes = WebSocketFullMessageSize(data, obtainedNumBytes);
 
   if (expectedNumBytes != obtainedNumBytes) {
-    printf("Corrupt WebSocket message size! (got %llu bytes, expected %llu bytes)\n", obtainedNumBytes, expectedNumBytes);
+    printf("Corrupt WebSocket message size! (got %lu bytes, expected %lu bytes)\n", obtainedNumBytes, expectedNumBytes);
     printf("Received data:");
     for (size_t i = 0; i < obtainedNumBytes; ++i)
       printf(" %02X", data[i]);
@@ -187,14 +187,14 @@ void DumpWebSocketMessage(uint8_t *data, uint64_t numBytes) {
   uint64_t payloadLength = WebSocketMessagePayloadLength(data, numBytes);
   uint8_t *payload = WebSocketMessageData(data, numBytes);
 
-  printf("Received: FIN: %d, opcode: %s, mask: 0x%08X, payload length: %llu bytes, unmasked payload:", header->fin, WebSocketOpcodeToString(header->opcode),
+  printf("Received: FIN: %d, opcode: %s, mask: 0x%08X, payload length: %lu bytes, unmasked payload:", header->fin, WebSocketOpcodeToString(header->opcode),
     WebSocketMessageMaskingKey(data, numBytes), payloadLength);
   for (uint64_t i = 0; i < payloadLength; ++i) {
     if (i%16 == 0) printf("\n");
     if (i%8==0) printf(" ");
     printf(" %02X", payload[i]);
     if (i >= 63 && payloadLength > 64) {
-      printf("\n   ... (%llu more bytes)", payloadLength-i);
+      printf("\n   ... (%lu more bytes)", payloadLength-i);
       break;
     }
   }

--- a/tools/websocket_to_posix_proxy/src/websocket_to_posix_proxy.c
+++ b/tools/websocket_to_posix_proxy/src/websocket_to_posix_proxy.c
@@ -61,11 +61,11 @@ typedef struct SocketCallHeader {
   int function;
 } SocketCallHeader;
 
-static char buf_temp_str[2048] = {};
-
+#ifdef POSIX_SOCKET_DEBUG
 // not thread-safe, but only used for debug prints, so expected not to cause
 // trouble
 static char *BufferToString(const void *buf, size_t len) {
+  static char buf_temp_str[2048] = {};
   uint8_t *b = (uint8_t *)buf;
   if (!b) {
     sprintf(buf_temp_str, "(null ptr) (%d bytes)", (int)len);
@@ -78,6 +78,7 @@ static char *BufferToString(const void *buf, size_t len) {
   sprintf(buf_temp_str + len*3, " (%d bytes)", (int)len);
   return buf_temp_str;
 }
+#endif
 
 // thread-safe, re-entrant
 void WebSocketMessageUnmaskPayload(uint8_t* payload,


### PR DESCRIPTION
Some of these warnings are showing up in CI polluting stdout with extra noise.