### PR TITLE
[wasm64] Add MAIN_THREAD_EM_ASM_PTR

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2958,6 +2958,11 @@ addToLibrary({
     return runMainThreadEmAsm(code, sigPtr, argbuf, 1);
   },
 
+  emscripten_asm_const_ptr_sync_on_main_thread__deps: ['$runMainThreadEmAsm'],
+  emscripten_asm_const_ptr_sync_on_main_thread: (code, sigPtr, argbuf) => {
+    return runMainThreadEmAsm(code, sigPtr, argbuf, 1);
+  },
+
   emscripten_asm_const_double_sync_on_main_thread: 'emscripten_asm_const_int_sync_on_main_thread',
   emscripten_asm_const_async_on_main_thread__deps: ['$runMainThreadEmAsm'],
   emscripten_asm_const_async_on_main_thread: (code, sigPtr, argbuf) => runMainThreadEmAsm(code, sigPtr, argbuf, 0),

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -565,6 +565,7 @@ sigs = {
   emscripten_asm_const_int__sig: 'ippp',
   emscripten_asm_const_int_sync_on_main_thread__sig: 'ippp',
   emscripten_asm_const_ptr__sig: 'pppp',
+  emscripten_asm_const_ptr_sync_on_main_thread__sig: 'pppp',
   emscripten_async_call__sig: 'vppi',
   emscripten_async_load_script__sig: 'vppp',
   emscripten_async_run_script__sig: 'vpi',

--- a/test/core/test_em_asm_2.cpp
+++ b/test/core/test_em_asm_2.cpp
@@ -111,6 +111,15 @@ int main()
   // Note that expressions do not evaluate to return values, but the "return" keyword is needed. That is, the following line would return undefined and store i <- 0.
   // i = EM_ASM_INT(HEAP8.length); printf("returned statement %d\n", i);
 
+  void* p;
+
+  printf("\nEM_ASM_PTR: Return a pointer back.\n");
+  p = EM_ASM_PTR(out('1. got arg ' + $0); return 3;, 42); printf("1. returned ptr %p\n", p);
+  p = EM_ASM_PTR("out('2. got arg ' + $0); return 4;", 42); printf("2. returned ptr %p\n", p);
+  p = EM_ASM_PTR({"out('3. got arg ' + $0); return 5;"}, 42); printf("3. returned ptr %p\n", p);
+  p = EM_ASM_PTR({out('4. got arg ' + $0); return 6;}, 42); printf("4. returned ptr %p\n", p);
+  p = EM_ASM_PTR("{out('5. got arg ' + $0); return 7;}", 42); printf("5. returned ptr %p\n", p);
+
   double d;
 
   printf("\nEM_ASM_DOUBLE: Pass no parameters, return a double.\n");

--- a/test/core/test_em_asm_2.out
+++ b/test/core/test_em_asm_2.out
@@ -119,6 +119,18 @@ EM_ASM_INT: Return an integer in a single brief statement.
 4. returned statement 45
 5. returned statement 46
 
+EM_ASM_PTR: Return a pointer back.
+1. got arg 42
+1. returned ptr 0x3
+2. got arg 42
+2. returned ptr 0x4
+3. got arg 42
+3. returned ptr 0x5
+4. got arg 42
+4. returned ptr 0x6
+5. got arg 42
+5. returned ptr 0x7
+
 EM_ASM_DOUBLE: Pass no parameters, return a double.
 1. returning double
 1. got double 3.500000

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2196,9 +2196,12 @@ int main(int argc, char **argv) {
     self.emcc_args.append('-std=gnu89')
     self.do_core_test('test_em_asm_2.cpp', force_c=True)
 
-  # Tests various different ways to invoke the MAIN_THREAD_EM_ASM(), MAIN_THREAD_EM_ASM_INT() and MAIN_THREAD_EM_ASM_DOUBLE() macros.
-  # This test is identical to test_em_asm_2, just search-replaces EM_ASM to MAIN_THREAD_EM_ASM on the test file. That way if new
-  # test cases are added to test_em_asm_2.cpp for EM_ASM, they will also get tested in MAIN_THREAD_EM_ASM form.
+  # Tests various different ways to invoke the MAIN_THREAD_EM_ASM(),
+  # MAIN_THREAD_EM_ASM_INT(), MAIN_THREAD_EM_ASM_PTR, and
+  # MAIN_THREAD_EM_ASM_DOUBLE() macros.  This test is identical to
+  # test_em_asm_2, just search-replaces EM_ASM to MAIN_THREAD_EM_ASM on the test
+  # file. That way if new test cases are added to test_em_asm_2.cpp for EM_ASM,
+  # they will also get tested in MAIN_THREAD_EM_ASM form.
   def test_main_thread_em_asm(self):
     src = read_file(test_file('core/test_em_asm_2.cpp'))
     create_file('src.cpp', src.replace('EM_ASM', 'MAIN_THREAD_EM_ASM'))


### PR DESCRIPTION
This compliments MAIN_THREAD_EM_ASM_INT in the same way 
that EM_ASM_PTR was added to compliment EM_ASM_INT.

This is needed to fix the wasm64 SDL2 build. See
https://github.com/libsdl-org/SDL/issues/8241.
