### PR TITLE
[test] Temporarily disable wasm64 + threads browser test

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4714,7 +4714,9 @@ Module["preRun"] = () => {
 
   # Tests that response headers get set on emscripten_fetch_t values.
   @no_firefox('https://github.com/emscripten-core/emscripten/issues/16868')
-  @also_with_wasm2js_or_wasm64
+  # TODO(sbc): https://github.com/emscripten-core/emscripten/issues/20262
+  # @also_with_wasm2js_or_wasm64
+  @also_with_wasm2js
   @requires_threads
   def test_fetch_response_headers(self):
     shutil.copyfile(test_file('gears.png'), 'gears.png')
@@ -4747,7 +4749,9 @@ Module["preRun"] = () => {
   # Tests emscripten_fetch() usage in synchronous mode when used from the main
   # thread proxied to a Worker with -sPROXY_TO_PTHREAD option.
   @no_firefox('https://github.com/emscripten-core/emscripten/issues/16868')
-  @also_with_wasm64
+  # TODO(sbc): https://github.com/emscripten-core/emscripten/issues/20262
+  # @also_with_wasm2js_or_wasm64
+  @also_with_wasm2js
   @requires_threads
   def test_fetch_sync_xhr(self):
     shutil.copyfile(test_file('gears.png'), 'gears.png')
@@ -4756,7 +4760,8 @@ Module["preRun"] = () => {
   # Tests emscripten_fetch() usage when user passes none of the main 3 flags (append/replace/no_download).
   # In that case, in append is implicitly understood.
   @no_firefox('https://github.com/emscripten-core/emscripten/issues/16868')
-  @also_with_wasm64
+  # TODO(sbc): https://github.com/emscripten-core/emscripten/issues/20262
+  # @also_with_wasm64
   @requires_threads
   def test_fetch_implicit_append(self):
     shutil.copyfile(test_file('gears.png'), 'gears.png')
@@ -5589,7 +5594,8 @@ Module["preRun"] = () => {
   # Tests the AudioWorklet demo
   @parameterized({
     '': ([],),
-    'memory64': (['-sMEMORY64', '-Wno-experimental'],),
+    # TODO(sbc): https://github.com/emscripten-core/emscripten/issues/20262
+    # 'memory64': (['-sMEMORY64', '-Wno-experimental'],),
     'with_fs': (['--preload-file', test_file('hello_world.c') + '@/'],),
     'closure': (['--closure', '1', '-Oz'],),
     'asyncify': (['-sASYNCIFY'],),


### PR DESCRIPTION
We are using `index: 'i64'` for our memory type which isn't currently compatible with the chrome unstable build we use in CI but will be once this change makes it into an unstable release: https://chromium-review.googlesource.com/c/v8/v8/+/4807493.