### PR TITLE
dylink.js : handle ** argument case

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -802,7 +802,7 @@ var LibraryDylink = {
           if (cSig != 'void') {
             cSig = cSig.split(',');
             for (var i in cSig) {
-              var jsArg = cSig[i].split(' ').pop();
+              var jsArg = cSig[i].split(' ').pop().replace('*', '');
               jsArgs.push(jsArg.replace('*', ''));
             }
           }


### PR DESCRIPTION
as seen with 3.1.46(tot) when linking to libffi
`ffi_call_js sig=ffi_cif *cif, ffi_fp fn, void *rvalue, void **avalue` is only turning arg to *avalue instead of avalue causing a syntax error