### PR TITLE
Temporarily disable pch/gch tests while LLVM rolls in

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -4107,6 +4107,8 @@ Module.print = (x) => { throw '<{(' + x + ')}>' };
     'pch': ['pch'],
   })
   def test_precompiled_headers(self, suffix):
+    self.skipTest('disable while LLVM changes to pch roll in (new defaults&output)')
+
     create_file('header.h', '#define X 5\n')
     self.run_process([EMCC, '-xc++-header', 'header.h', '-c'])
     self.assertExists('header.h.gch') # default output is gch


### PR DESCRIPTION
It seems LLVM has changed both the default output from gch to pch,
and also the contents of pch file metadata (which we check) are now
quite different as well.

This will unbreak the roller, and then we can adjust the test for new LLVM.