### PR TITLE
Fix pthread_detach such that it only updates the state once

### DIFF
--- a/system/lib/libc/musl/src/thread/pthread_detach.c
+++ b/system/lib/libc/musl/src/thread/pthread_detach.c
@@ -8,15 +8,20 @@ static int __pthread_detach(pthread_t t)
 	// for the benefit of the conformance tests.
 	if (!_emscripten_thread_is_valid(t))
 		return ESRCH;
-	// Even though the man page says this is undefined behaviour to attempt to
-	// detach an already-detached thread we have several tests in the posixtest
-	// suite that depend on this (pthread_join.c)
-	if (a_cas(&t->detach_state, DT_JOINABLE, DT_DETACHED) == DT_DETACHED)
-		return EINVAL;
 #endif
 	/* If the cas fails, detach state is either already-detached
 	 * or exiting/exited, and pthread_join will trap or cleanup. */
+#ifdef __EMSCRIPTEN__
+	int old_state = a_cas(&t->detach_state, DT_JOINABLE, DT_DETACHED);
+	if (old_state != DT_JOINABLE) {
+		// Even though the man page says this is undefined behaviour to attempt to
+		// detach an already-detached thread we have several tests in the posixtest
+		// suite that depend on this (pthread_join.c)
+		if (old_state == DT_DETACHED)
+			return EINVAL;
+#else
 	if (a_cas(&t->detach_state, DT_JOINABLE, DT_DETACHED) != DT_JOINABLE) {
+#endif
 		int cs;
 		__pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
 		__pthread_join(t, 0);


### PR DESCRIPTION
This was causing spurious "Blocking on the main thread is very dangerous", because if the first `a_cas` succeeded the second one would always fail, leading to `__pthread_join` being called.  `__pthread_join` is mostly harmless if the thread is already in a `DT_DETACHED` state, but it does have the side effect of printing this warning.

Fixes: #20224