### PR TITLE
Fix warnings in webidl test code. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7892,7 +7892,7 @@ void* operator new(size_t size) {
 
     # Export things on "TheModule". This matches the typical use pattern of the bound library
     # being used as Box2D.* or Ammo.*, and we cannot rely on "Module" being always present (closure may remove it).
-    self.emcc_args += ['--post-js=glue.js', '--extern-post-js=extern-post.js']
+    self.emcc_args += ['-Wall', '--post-js=glue.js', '--extern-post-js=extern-post.js']
     if mode == 'ALL':
       self.emcc_args += ['-sASSERTIONS']
     if allow_memory_growth:

--- a/test/webidl/test.cpp
+++ b/test/webidl/test.cpp
@@ -5,8 +5,15 @@
 
 #include "test.h"
 
-Parent::Parent(int val) : value(val), immutableAttr(8), attr(6) { printf("Parent:%d\n", val); }
-Parent::Parent(Parent *p, Parent *q) : value(p->value + q->value), immutableAttr(8), attr(6) { printf("Parent:%d\n", value); }
+Parent::Parent(int val) : value(val), attr(6), immutableAttr(8) {
+  printf("Parent:%d\n", val);
+}
+
+Parent::Parent(Parent* p, Parent* q)
+  : value(p->value + q->value), attr(6), immutableAttr(8) {
+  printf("Parent:%d\n", value);
+}
+
 void Parent::mulVal(int mul) { value *= mul; }
 
 typedef EnumClass::EnumWithinClass EnumClass_EnumWithinClass;

--- a/test/webidl/test.h
+++ b/test/webidl/test.h
@@ -33,6 +33,7 @@ public:
 class Child2 : public Parent {
 public:
   Child2() : Parent(9) { printf("Child2:%d\n", value); };
+  virtual ~Child2() = default;
   int getValCube() { return value*value*value; }
   static void printStatic() { printf("*static*\n"); }
 


### PR DESCRIPTION
This allows us to run with `-Wall` which also detects warnings in the generated code.