### PR TITLE
Remove old/unused warning from jsifier

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -428,11 +428,9 @@ function(${args}) {
       const original = LibraryManager.library[symbol];
       let snippet = original;
 
+      // Check for dependencies on `__internal` symbols from user libraries.
       const isUserSymbol = LibraryManager.library[symbol + '__user'];
       deps.forEach((dep) => {
-        if (typeof snippet == 'string' && !(dep in LibraryManager.library)) {
-          warn(`missing library dependency ${dep}, make sure you are compiling with the right options (see #if in src/library*.js)`);
-        }
         if (isUserSymbol && LibraryManager.library[dep + '__internal']) {
           warn(`user library symbol '${symbol}' depends on internal symbol '${dep}'`);
         }


### PR DESCRIPTION
I'm fairly sure this no longer correct and doesn't fire in any of our test code.

This warning only fires for library members that are of type 'string' for some reason (as of 1ddb637687e685a7aa17853e3327ceae88e40547), and since library members with deps are almost universally functions I've never seen it fire.

However @RReverser saw this want library functions were strings:

```
addToLibrary({
  myfunc__deps: ['malloc'],
  myfunc: '() => _malloc(4)',
});
```
Results  in:

```
warning: missing library dependency malloc, make sure you are compiling with the right options (see #if in src/library*.js)
```
