### PR TITLE
Honor `-fno-lto` command line flag

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3454,6 +3454,8 @@ def parse_args(newargs):
         settings.LTO = arg.split('=')[1]
       else:
         settings.LTO = 'full'
+    elif arg == '-fno-lto':
+      settings.LTO = 0
     elif check_arg('--llvm-lto'):
       logger.warning('--llvm-lto ignored when using llvm backend')
       consume_arg()


### PR DESCRIPTION
Writing a test for this is tricky because the repro case actually does produce an LTO object (because clang honors this flag already).

Fixes: #20308