### PR TITLE
embind: Also build program normally when using `--embind-emit-tsd`.

### DIFF
--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -408,9 +408,7 @@ Options that are modified or new in *emcc* are listed below:
 "--embind-emit-tsd <path>"
    [link] Generate a TypeScript definition file from the exported
    embind bindings. The program will be instrumented and run in node
-   in order to to generate the file. Note that the program itself will
-   not be generated when this flag is used.  You will need to be
-   rebuild without this flag to build the program itself.
+   in order to to generate the file.
 
 "--ignore-dynamic-linking"
    [link] Tells the compiler to ignore dynamic linking (the user will

--- a/emcc.py
+++ b/emcc.py
@@ -1274,7 +1274,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   if state.mode == Mode.POST_LINK_ONLY:
     settings.limit_settings(None)
     target, wasm_target = phase_linker_setup(options, state, newargs)
-    process_libraries(state, [], options)
+    process_libraries(state, [])
     if len(input_files) != 1:
       exit_with_error('--post-link requires a single input file')
     phase_post_link(options, state, input_files[0][1], wasm_target, target, {})
@@ -1360,7 +1360,7 @@ def phase_calculate_linker_inputs(options, state, linker_inputs):
   state.link_flags = filter_link_flags(state.link_flags, using_lld)
 
   # Decide what we will link
-  process_libraries(state, linker_inputs, options.embind_emit_tsd)
+  process_libraries(state, linker_inputs)
 
   linker_args = [val for _, val in sorted(linker_inputs + state.link_flags)]
 
@@ -1842,27 +1842,6 @@ def phase_linker_setup(options, state, newargs):
   if options.js_transform and settings.GENERATE_SOURCE_MAP:
     logger.warning('disabling source maps because a js transform is being done')
     settings.GENERATE_SOURCE_MAP = 0
-
-  if options.embind_emit_tsd:
-    # Ignore any -o command line arguments when running in --embind-emit-tsd
-    # With this option we don't actually output the program itself only the
-    # TS bindings.
-    options.output_file = in_temp('a.out.js')
-    # Don't invoke the program's `main` function.
-    settings.INVOKE_RUN = False
-    # Ignore -sMODULARIZE which could otherwise effect how we run the module
-    # to generate the bindings.
-    settings.MODULARIZE = False
-    # Don't include any custom user JS or files.
-    options.pre_js = []
-    options.post_js = []
-    options.extern_pre_js = []
-    options.extern_post_js = []
-    options.use_preload_cache = False
-    options.preload_files = []
-    options.embed_files = []
-    # Force node since that is where the tool runs.
-    settings.ENVIRONMENT = 'node'
 
   # options.output_file is the user-specified one, target is what we will generate
   if options.output_file:
@@ -3204,6 +3183,9 @@ def phase_post_link(options, state, in_wasm, wasm_target, target, js_syms):
   else:
     memfile = shared.replace_or_append_suffix(target, '.mem')
 
+  if options.embind_emit_tsd:
+    phase_embind_emit_tsd(options, in_wasm, wasm_target, memfile, js_syms)
+
   phase_emscript(options, in_wasm, wasm_target, memfile, js_syms)
 
   if options.js_transform:
@@ -3230,6 +3212,37 @@ def phase_emscript(options, in_wasm, wasm_target, memfile, js_syms):
 
   emscripten.run(in_wasm, wasm_target, final_js, memfile, js_syms)
   save_intermediate('original')
+
+
+@ToolchainProfiler.profile_block('embind emit tsd')
+def phase_embind_emit_tsd(options, in_wasm, wasm_target, memfile, js_syms):
+  logger.debug('emit tsd')
+  # Save settings so they can be restored after TS generation.
+  original_settings = settings.backup()
+
+  # Ignore any options or settings that can conflict with running the TS
+  # generation output.
+  # Don't invoke the program's `main` function.
+  settings.INVOKE_RUN = False
+  # Ignore -sMODULARIZE which could otherwise effect how we run the module
+  # to generate the bindings.
+  settings.MODULARIZE = False
+  # Don't include any custom user JS or files.
+  settings.PRE_JS_FILES = []
+  settings.POST_JS_FILES = []
+  # Force node since that is where the tool runs.
+  settings.ENVIRONMENT = 'node'
+  setup_environment_settings()
+  # Replace embind with the TypeScript generation version.
+  embind_index = settings.JS_LIBRARIES.index('embind/embind.js')
+  settings.JS_LIBRARIES[embind_index] = 'embind/embind_ts.js'
+
+  outfile_js = 'tsgen_a.out.js'
+  emscripten.run(in_wasm, wasm_target, outfile_js, memfile, js_syms)
+  out = shared.run_js_tool(outfile_js, [], stdout=PIPE)
+  write_file(options.embind_emit_tsd, out)
+  delete_file(outfile_js)
+  settings.restore(original_settings)
 
 
 @ToolchainProfiler.profile_block('source transforms')
@@ -3350,10 +3363,6 @@ def phase_final_emitting(options, state, target, wasm_target, memfile):
 
   if options.executable:
     make_js_executable(js_target)
-
-  if options.embind_emit_tsd:
-    out = shared.run_js_tool(js_target, [], stdout=PIPE)
-    write_file(options.embind_emit_tsd, out)
 
 
 def version_string():
@@ -4221,7 +4230,7 @@ def find_library(lib, lib_dirs):
   return None
 
 
-def process_libraries(state, linker_inputs, embind_emit_tsd):
+def process_libraries(state, linker_inputs):
   new_flags = []
   libraries = []
   suffixes = STATICLIB_ENDINGS + DYNAMICLIB_ENDINGS
@@ -4236,7 +4245,7 @@ def process_libraries(state, linker_inputs, embind_emit_tsd):
 
     logger.debug('looking for library "%s"', lib)
 
-    js_libs, native_lib = building.map_to_js_libs(lib, embind_emit_tsd)
+    js_libs, native_lib = building.map_to_js_libs(lib)
     if js_libs is not None:
       libraries += [(i, js_lib) for js_lib in js_libs]
       # If native_lib is returned then include it in the link

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -388,9 +388,6 @@ Options that are modified or new in *emcc* are listed below:
   [link]
   Generate a TypeScript definition file from the exported embind bindings. The
   program will be instrumented and run in node in order to to generate the file.
-  Note that the program itself will not be generated when this flag is
-  used.  You will need to be rebuild without this flag to build the program
-  itself.
 
 ``--ignore-dynamic-linking``
   [link]

--- a/test/other/embind_tsgen.cpp
+++ b/test/other/embind_tsgen.cpp
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <memory>
 #include <string>
 #include <emscripten/bind.h>
@@ -158,7 +159,8 @@ EMSCRIPTEN_BINDINGS(Test) {
 int Test::static_property = 42;
 
 int main() {
-  // Main should not be run during TypeScript generation.
-  abort();
+  // Main should not be run during TypeScript generation, but should run when
+  // the program is run normally.
+  printf("main ran\n");
   return 0;
 }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2919,13 +2919,18 @@ int f() {
     self.do_runf(test_file('other/test_jspi_add_function.c'), 'done')
 
   def test_embind_tsgen(self):
+    # Check that TypeScript generation works and that the program is runs as
+    # expected.
+    self.do_runf(test_file('other/embind_tsgen.cpp'), 'main ran',
+                 emcc_args=['-lembind', '--embind-emit-tsd', 'embind_tsgen.d.ts'])
+    actual = read_file('embind_tsgen.d.ts')
+    self.assertFileContents(test_file('other/embind_tsgen.d.ts'), actual)
+
+  def test_embind_tsgen_ignore(self):
     create_file('fail.js', 'assert(false);')
     # These extra arguments are not related to TS binding generation but we want to
     # verify that they do not interfere with it.
-    extra_args = ['-o',
-                  'out.html',
-                  '-sMODULARIZE',
-                  '-sALLOW_MEMORY_GROWTH=1',
+    extra_args = ['-sALLOW_MEMORY_GROWTH=1',
                   '-sMAXIMUM_MEMORY=4GB',
                   '--pre-js', 'fail.js',
                   '--post-js', 'fail.js',
@@ -2933,14 +2938,14 @@ int f() {
                   '--extern-post-js', 'fail.js',
                   '-sENVIRONMENT=worker',
                   '--use-preload-cache',
-                  '--preload-file', 'fail.js',
+                  '--preload-file', 'fail.js']
+    self.run_process([EMCC, test_file('other/embind_tsgen.cpp'),
+                      '-lembind', '--embind-emit-tsd', 'embind_tsgen.d.ts'] + extra_args)
+    # Test these args separately since they conflict with arguments in the first test.
+    extra_args = ['-sMODULARIZE',
                   '--embed-file', 'fail.js']
     self.run_process([EMCC, test_file('other/embind_tsgen.cpp'),
                       '-lembind', '--embind-emit-tsd', 'embind_tsgen.d.ts'] + extra_args)
-    actual = read_file('embind_tsgen.d.ts')
-    self.assertNotExists('out.html')
-    self.assertNotExists('out.js')
-    self.assertFileContents(test_file('other/embind_tsgen.d.ts'), actual)
 
   def test_embind_tsgen_test_embind(self):
     self.run_process([EMCC, test_file('embind/embind_test.cpp'),

--- a/tools/building.py
+++ b/tools/building.py
@@ -1072,7 +1072,7 @@ def is_wasm_dylib(filename):
   return False
 
 
-def map_to_js_libs(library_name, emit_tsd):
+def map_to_js_libs(library_name):
   """Given the name of a special Emscripten-implemented system library, returns an
   pair containing
   1. Array of absolute paths to JS library files, inside emscripten/src/ that corresponds to the
@@ -1081,11 +1081,8 @@ def map_to_js_libs(library_name, emit_tsd):
   2. Optional name of a corresponding native library to link in.
   """
   # Some native libraries are implemented in Emscripten as system side JS libraries
-  embind = 'embind/embind.js'
-  if emit_tsd:
-    embind = 'embind/embind_ts.js'
   library_map = {
-    'embind': [embind, 'embind/emval.js'],
+    'embind': ['embind/embind.js', 'embind/emval.js'],
     'EGL': ['library_egl.js'],
     'GL': ['library_webgl.js', 'library_html5_webgl.js'],
     'webgl.js': ['library_webgl.js', 'library_html5_webgl.js'],

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -3,6 +3,7 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
+import copy
 import difflib
 import os
 import re
@@ -246,6 +247,12 @@ class SettingsManager:
 
   def __setitem__(self, key, value):
     self.attrs[key] = value
+
+  def backup(self):
+    return copy.deepcopy(self.attrs)
+
+  def restore(self, previous):
+    self.attrs.update(previous)
 
 
 settings = SettingsManager()


### PR DESCRIPTION
Changes the behavior `--embind-emit-tsd` so that the program is built normally, but the TypeScript definition generation also happens as a side affect. This is implemented by generating the program normally until `emscript` phase when a separate "emscript" like phase is run to create the JS output file, but with `embind_ts.js` replacing `embind.js`. The instrumented version is then run in node like before. After the TS definitions are created, the settings and options are restored and compiling finishes as it normally would.

The test for options that conflict with embind-emit-tsd is now a separate test since the original test needs to be run and work.