### PR TITLE
Reflect library changes after upstreaming

### DIFF
--- a/system/lib/libcxxabi/include/cxxabi.h
+++ b/system/lib/libcxxabi/include/cxxabi.h
@@ -48,6 +48,7 @@ __cxa_free_exception(void *thrown_exception) throw();
 extern _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void
 __cxa_throw(void *thrown_exception, std::type_info *tinfo,
 #ifdef __USING_WASM_EXCEPTIONS__
+            // In Wasm, a destructor returns its argument
             void *(_LIBCXXABI_DTOR_FUNC *dest)(void *));
 #else
             void (_LIBCXXABI_DTOR_FUNC *dest)(void *));

--- a/system/lib/libcxxabi/src/cxa_exception.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception.cpp
@@ -262,7 +262,7 @@ void __throw_exception_with_stack_trace(_Unwind_Exception*);
 
 void
 #ifdef __USING_WASM_EXCEPTIONS__
-// In wasm, destructors return their argument
+// In Wasm, a destructor returns its argument
 __cxa_throw(void *thrown_object, std::type_info *tinfo, void *(_LIBCXXABI_DTOR_FUNC *dest)(void *)) {
 #else
 __cxa_throw(void *thrown_object, std::type_info *tinfo, void (_LIBCXXABI_DTOR_FUNC *dest)(void *)) {

--- a/system/lib/libcxxabi/src/cxa_exception.h
+++ b/system/lib/libcxxabi/src/cxa_exception.h
@@ -64,7 +64,7 @@ struct _LIBCXXABI_HIDDEN __cxa_exception {
     //  Manage the exception object itself.
     std::type_info *exceptionType;
 #ifdef __USING_WASM_EXCEPTIONS__
-    // In wasm, destructors return their argument
+    // In Wasm, a destructor returns its argument
     void *(_LIBCXXABI_DTOR_FUNC *exceptionDestructor)(void *);
 #else
     void (_LIBCXXABI_DTOR_FUNC *exceptionDestructor)(void *);

--- a/system/lib/libunwind/include/unwind_itanium.h
+++ b/system/lib/libunwind/include/unwind_itanium.h
@@ -24,7 +24,7 @@ struct _Unwind_Exception {
                             _Unwind_Exception *exc);
 #if defined(__SEH__) && !defined(__USING_SJLJ_EXCEPTIONS__)
   uintptr_t private_[6];
-#elif !defined(__USING_WASM_EXCEPTIONS__)
+#else
   uintptr_t private_1; // non-zero means forced unwind
   uintptr_t private_2; // holds sp that phase1 found for phase2 to use
 #endif

--- a/system/lib/libunwind/src/config.h
+++ b/system/lib/libunwind/src/config.h
@@ -83,7 +83,7 @@
   __asm__(".globl " SYMBOL_NAME(aliasname));                                   \
   __asm__(SYMBOL_NAME(aliasname) " = " SYMBOL_NAME(name));                     \
   _LIBUNWIND_ALIAS_VISIBILITY(SYMBOL_NAME(aliasname))
-#elif defined(__ELF__) || defined(_AIX)
+#elif defined(__ELF__) || defined(_AIX) || defined(__wasm__)
 #define _LIBUNWIND_WEAK_ALIAS(name, aliasname)                                 \
   extern "C" _LIBUNWIND_EXPORT __typeof(name) aliasname                        \
       __attribute__((weak, alias(#name)));
@@ -98,7 +98,6 @@
                                              SYMBOL_NAME(name)))               \
   extern "C" _LIBUNWIND_EXPORT __typeof(name) aliasname;
 #endif
-#elif defined(__wasm__)
 #else
 #error Unsupported target
 #endif


### PR DESCRIPTION
This contains changes after libcxxabi and libunwind have been reviewed and upstreamed.
Reviews:
- https://reviews.llvm.org/D158918
- https://reviews.llvm.org/D158919

Commits:
- https://github.com/llvm/llvm-project/commit/e6cbba749490a20127359a3fbd05d8db7faef535
- https://github.com/llvm/llvm-project/commit/058222b2316615194c089f2bc68d11341f39d26e

New changes include the removal of `__USING_SJLJ_OR_WASM_EXCEPTIONS__` (in favor of using `__USING_SJLJ_EXCEPTIONS__` and `__USING_SJLJ_OR_WASM_EXCEPTIONS__` directly) and some cosmetic changes in libunwind.