### PR TITLE
[test] Remove test_noexitruntime. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8204,26 +8204,6 @@ void* operator new(size_t size) {
     print('.. _Exit')
     self.do_runf('exit.c', 'hello, world!\nI see exit status: 118', assert_returncode=118, emcc_args=['-DCAPITAL_EXIT'])
 
-  def test_noexitruntime(self):
-    src = r'''
-      #include <emscripten.h>
-      #include <stdio.h>
-      static int testPre = TEST_PRE;
-      struct Global {
-        Global() {
-          printf("in Global()\n");
-          if (testPre) { EM_ASM(noExitRuntime = true;); }
-        }
-        ~Global() { printf("ERROR: in ~Global()\n"); }
-      } global;
-      int main() {
-        if (!testPre) { EM_ASM(noExitRuntime = true;); }
-        printf("in main()\n");
-      }
-    '''
-    self.do_run(src.replace('TEST_PRE', '0'), 'in Global()\nin main()')
-    self.do_run(src.replace('TEST_PRE', '1'), 'in Global()\nin main()')
-
   def test_minmax(self):
     self.do_runf(test_file('test_minmax.c'), 'NAN != NAN\nSuccess!')
 


### PR DESCRIPTION
I'm can't see anything that this test is actually testing.  This test was added back in 5e633806, but without any explanation why its useful or what its testing.

`noExitRuntime` is the default so the destructor in this test is never run, regardless of which EM_ASM block runs.

Furthermore even if the destructor or does run, it would add its error to the end of stdout, which would not be caught by the check (which ignore trailing lines in the output).