### PR TITLE
Handle shorthand method syntax in JS libs

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -204,6 +204,12 @@ ${argConvertions}
     // uniform.
     snippet = snippet.toString().replace(/\r\n/gm, '\n');
 
+    // Is this a shorthand `foo() {}` method syntax?
+    // If so, prepend a function keyword so that it's valid syntax when extracted.
+    if (snippet.startsWith(symbol)) {
+      snippet = 'function ' + snippet;
+    }
+
     if (isStub) {
       return snippet;
     }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3903,7 +3903,7 @@ addToLibrary({
     ''')
     self.do_runf('src.c', 'main\ndone\n', emcc_args=['-sEXIT_RUNTIME', '-pthread', '-sPROXY_TO_PTHREAD', '--js-library', 'lib.js'])
 
-  def test_js_lib_shorthand(self):
+  def test_js_lib_method_syntax(self):
     create_file('lib.js', r'''
 addToLibrary({
   foo() {

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3903,6 +3903,23 @@ addToLibrary({
     ''')
     self.do_runf('src.c', 'main\ndone\n', emcc_args=['-sEXIT_RUNTIME', '-pthread', '-sPROXY_TO_PTHREAD', '--js-library', 'lib.js'])
 
+  def test_js_lib_shorthand(self):
+    create_file('lib.js', r'''
+addToLibrary({
+  foo() {
+    out('foo');
+  },
+});
+''')
+    create_file('src.c', r'''
+    #include <stdio.h>
+    void foo();
+    int main() {
+      foo();
+    }
+    ''')
+    self.do_runf('src.c', 'foo', emcc_args=['--js-library', 'lib.js'])
+
   def test_js_lib_exported(self):
     create_file('lib.js', r'''
 addToLibrary({


### PR DESCRIPTION
Same fix as stringifyWithFunctions also has.

Fixes #20314.