### PR TITLE
Fix EM_JS_DEPS inside anonymous C++ namespaces

### DIFF
--- a/system/include/emscripten/em_js.h
+++ b/system/include/emscripten/em_js.h
@@ -9,14 +9,6 @@
 
 #include <emscripten/em_macros.h>
 
-#ifdef __cplusplus
-#define _EM_JS_CPP_BEGIN extern "C" {
-#define _EM_JS_CPP_END   }
-#else // __cplusplus
-#define _EM_JS_CPP_BEGIN
-#define _EM_JS_CPP_END
-#endif // __cplusplus
-
 // EM_JS declares JS functions in C code.
 // Example uses can be found in test/core/test_em_js.cpp
 
@@ -67,13 +59,12 @@
 // array of JS function strings to be included in the JS output.
 
 #define _EM_JS(ret, c_name, js_name, params, code)                             \
-  _EM_JS_CPP_BEGIN                                                             \
+  _EM_CDECL                                                                    \
   ret c_name params EM_IMPORT(js_name);                                        \
   __attribute__((used)) static void* __em_js_ref_##c_name = (void*)&c_name;    \
   EMSCRIPTEN_KEEPALIVE                                                         \
   __attribute__((section("em_js"), aligned(1))) char __em_js__##js_name[] =    \
-    #params "<::>" code;                                                       \
-  _EM_JS_CPP_END
+    #params "<::>" code;
 
 #define EM_JS(ret, name, params, ...) _EM_JS(ret, name, name, params, #__VA_ARGS__)
 

--- a/system/include/emscripten/em_macros.h
+++ b/system/include/emscripten/em_macros.h
@@ -15,6 +15,12 @@
 #define EM_IMPORT(NAME)
 #endif
 
+#ifdef __cplusplus
+#define _EM_CDECL extern "C"
+#else
+#define _EM_CDECL
+#endif
+
 /*
  * EM_JS_DEPS: Use this macro to declare indirect dependencies on JS symbols.
  * The first argument is just unique name for the set of dependencies.  The
@@ -40,4 +46,5 @@
   EMSCRIPTEN_KEEPALIVE                    \
   __attribute__((section("em_lib_deps"))) \
   __attribute__((aligned(1)))             \
+  _EM_CDECL                               \
   char __em_lib_deps_##tag[] = deps;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13315,15 +13315,14 @@ j1: 8589934599, j2: 30064771074, j3: 12884901891
 
     namespace {
       EM_JS_DEPS(test, "$stringToUTF8OnStack");
-      EM_JS(void, test, (), {
+    }
+
+    int main() {
+      EM_ASM({
         var x = stackSave();
         stringToUTF8OnStack("hello");
         stackRestore(x);
       });
-    }
-
-    int main() {
-      test();
     }
     ''')
     self.do_runf('test_em_js_deps.cpp')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13308,6 +13308,26 @@ j1: 8589934599, j2: 30064771074, j3: 12884901891
     ''')
     self.do_runf('f2.c', emcc_args=['f1.c'])
 
+  def test_em_js_deps_cpp(self):
+    # Check that EM_JS_DEPS is not mangled in C++.
+    create_file('test_em_js_deps.cpp', '''
+    #include <emscripten.h>
+
+    namespace {
+      EM_JS_DEPS(test, "$stringToUTF8OnStack");
+      EM_JS(void, test, (), {
+        var x = stackSave();
+        stringToUTF8OnStack("hello");
+        stackRestore(x);
+      });
+    }
+
+    int main() {
+      test();
+    }
+    ''')
+    self.do_runf('test_em_js_deps.cpp')
+
   @no_mac('https://github.com/emscripten-core/emscripten/issues/18175')
   @crossplatform
   def test_stack_overflow(self):

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13308,8 +13308,9 @@ j1: 8589934599, j2: 30064771074, j3: 12884901891
     ''')
     self.do_runf('f2.c', emcc_args=['f1.c'])
 
-  def test_em_js_deps_cpp(self):
-    # Check that EM_JS_DEPS is not mangled in C++.
+  def test_em_js_deps_anon_ns(self):
+    # Check that EM_JS_DEPS is not eliminated in
+    # an anonymous C++ namespace.
     create_file('test_em_js_deps.cpp', '''
     #include <emscripten.h>
 


### PR DESCRIPTION
`EM_JS` already had `extern "C"` to prevent mangling, but `EM_JS_DEPS` didn't, leading to inconsistent behaviour.