### PR TITLE
Always assert on calling proxied function from wasm worker. NFC

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -253,7 +253,8 @@ if (ENVIRONMENT_IS_PTHREAD)
 ${body}
 }\n`
           });
-        } else if (WASM_WORKERS && ASSERTIONS) {
+        }
+        if (WASM_WORKERS && ASSERTIONS) {
           // In ASSERTIONS builds add runtime checks that proxied functions are not attempted to be called in Wasm Workers
           // (since there is no automatic proxying architecture available)
           snippet = modifyJSFunction(snippet, (args, body) => `

--- a/src/library.js
+++ b/src/library.js
@@ -3794,7 +3794,7 @@ function wrapSyscallFunction(x, library, isWasi) {
   if (!WASMFS) {
     library[x + '__deps'].push('$SYSCALLS');
   }
-#if PTHREADS
+#if SHARED_MEMORY
   // Most syscalls need to happen on the main JS thread (e.g. because the
   // filesystem is in JS and on that thread). Proxy synchronously to there.
   // There are some exceptions, syscalls that we know are ok to just run in
@@ -3804,6 +3804,10 @@ function wrapSyscallFunction(x, library, isWasi) {
   // instead of synchronously, and marked with
   //  __proxy: 'async'
   // (but essentially all syscalls do have return values).
+  //
+  // Note that we add this even in the WASM_WORKERS case since we want calls
+  // to these functions from wasm workers to assert in debug builds (since wasm
+  // workers lack proxying support).
   if (library[x + '__proxy'] === undefined) {
     library[x + '__proxy'] = 'sync';
   }

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -263,8 +263,11 @@ var WasiLibrary = {
   },
   fd_write__deps: ['$flush_NO_FILESYSTEM', '$printChar'],
   fd_write__postset: () => addAtExit('flush_NO_FILESYSTEM()'),
+  // Avoid proxying when we are not using the filesystem
+  fd_write__proxy: 'none',
 #else
   fd_write__deps: ['$printChar'],
+  fd_write__proxy: 'none',
 #endif
   fd_write: (fd, iov, iovcnt, pnum) => {
 #if SYSCALLS_REQUIRE_FILESYSTEM
@@ -305,6 +308,9 @@ var WasiLibrary = {
 #endif
   },
 
+#if !SYSCALLS_REQUIRE_FILESYSTEM
+  fd_close__sync: 'none',
+#endif
   fd_close: (fd) => {
 #if SYSCALLS_REQUIRE_FILESYSTEM
     var stream = SYSCALLS.getStreamFromFD(fd);


### PR DESCRIPTION
Follow up to #20135.

See https://github.com/emscripten-core/emscripten/pull/20135#discussion_r1323329351