### PR TITLE
Add thread checks to emscripten::val

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,9 @@ See docs/process.md for more on how version tagging works.
   validated at build time. (#20258)
 - `MAIN_THREAD_EM_ASM_PTR` macro added for code that returns a pointer.  This
   mirrors the existing `EM_ASM_PTR`. (#20261)
+- `emscripten::val` now prevents accidental access to the underlying JavaScript
+  value from threads other than its owner. This already didn't work correctly
+  in majority of cases, but now it will throw a clear assertion failure. (#20344)
 
 3.1.46 - 09/15/23
 -----------------

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -426,15 +426,14 @@ public:
   }
 
   val& operator=(val&& v) & {
+    val tmp(std::move(v));
     this->~val();
-    new (this) val(std::move(v));
+    new (this) val(std::move(tmp));
     return *this;
   }
 
   val& operator=(const val& v) & {
-    this->~val();
-    new (this) val(v);
-    return *this;
+    return *this = val(v);
   }
 
   bool hasOwnProperty(const char* key) const {

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -411,7 +411,7 @@ public:
   }
 
   EM_VAL as_handle() const {
-#if !defined(NDEBUG) && defined(_REENTRANT)
+#ifdef _REENTRANT
     assert(pthread_equal(thread, pthread_self()) && "val accessed from wrong thread");
 #endif
     return handle;
@@ -595,10 +595,7 @@ public:
 private:
   // takes ownership, assumes handle already incref'd and lives on the same thread
   explicit val(EM_VAL handle)
-      : handle(handle)
-#if !defined(NDEBUG) && defined(_REENTRANT)
-      , thread(pthread_self())
-#endif
+      : handle(handle), thread(pthread_self())
   {}
 
   template<typename WrapperType>
@@ -622,9 +619,7 @@ private:
     return v;
   }
 
-#if !defined(NDEBUG) && defined(_REENTRANT)
   pthread_t thread;
-#endif
   EM_VAL handle;
 
   friend struct internal::BindingType<val>;

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -395,7 +395,11 @@ public:
       : val(internal::_emval_new_cstring(v))
   {}
 
-  val(val&& v) : val(v.as_handle()) {
+  // Note: unlike other constructors, this doesn't use as_handle() because
+  // it just moves a value and doesn't need to go via incref/decref.
+  // This means it's safe to move values across threads - an error will
+  // only arise if you access or free it from the wrong thread later.
+  val(val&& v) : handle(v.handle), thread(v.thread) {
     v.handle = 0;
   }
 

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -396,17 +396,17 @@ public:
   {}
 
   val(val&& v) : val(v.as_handle()) {
-    v.handle_ = 0;
+    v.handle = 0;
   }
 
   val(const val& v) : val(v.as_handle()) {
-    internal::_emval_incref(handle_);
+    internal::_emval_incref(handle);
   }
 
   ~val() {
     if (EM_VAL handle = as_handle()) {
       internal::_emval_decref(handle);
-      handle_ = 0;
+      handle = 0;
     }
   }
 
@@ -414,7 +414,7 @@ public:
 #if !defined(NDEBUG) && defined(_REENTRANT)
     assert(pthread_equal(thread, pthread_self()) && "val accessed from wrong thread");
 #endif
-    return handle_;
+    return handle;
   }
 
   val& operator=(val&& v) & {
@@ -595,7 +595,7 @@ public:
 private:
   // takes ownership, assumes handle already incref'd and lives on the same thread
   explicit val(EM_VAL handle)
-      : handle_(handle)
+      : handle(handle)
 #if !defined(NDEBUG) && defined(_REENTRANT)
       , thread(pthread_self())
 #endif
@@ -625,7 +625,7 @@ private:
 #if !defined(NDEBUG) && defined(_REENTRANT)
   pthread_t thread;
 #endif
-  EM_VAL handle_;
+  EM_VAL handle;
 
   friend struct internal::BindingType<val>;
 };

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -396,7 +396,7 @@ public:
   {}
 
   val(val&& v) : handle_(v.handle_)
-#if defined(DEBUG) && defined(_REENTRANT)
+#if !defined(NDEBUG) && defined(_REENTRANT)
       , thread(pthread_self())
 #endif
   {
@@ -404,7 +404,7 @@ public:
   }
 
   val(const val& v) : handle_(v.handle_)
-#if defined(DEBUG) && defined(_REENTRANT)
+#if !defined(NDEBUG) && defined(_REENTRANT)
       , thread(pthread_self())
 #endif
   {
@@ -419,7 +419,7 @@ public:
   }
 
   EM_VAL as_handle() const {
-#if defined(DEBUG) && defined(_REENTRANT)
+#if !defined(NDEBUG) && defined(_REENTRANT)
     assert(pthread_equal(thread, pthread_self()) && "val accessed from wrong thread");
 #endif
     return handle_;
@@ -604,7 +604,7 @@ private:
   // takes ownership, assumes handle already incref'd and lives on the same thread
   explicit val(EM_VAL handle)
       : handle_(handle)
-#if defined(DEBUG) && defined(_REENTRANT)
+#if !defined(NDEBUG) && defined(_REENTRANT)
       , thread(pthread_self())
 #endif
   {}
@@ -630,7 +630,7 @@ private:
     return v;
   }
 
-#if defined(DEBUG) && defined(_REENTRANT)
+#if !defined(NDEBUG) && defined(_REENTRANT)
   pthread_t thread;
 #endif
   EM_VAL handle_;

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -397,7 +397,7 @@ public:
 
   val(val&& v) : handle_(v.handle_)
 #if !defined(NDEBUG) && defined(_REENTRANT)
-      , thread(pthread_self())
+      , thread(v.thread)
 #endif
   {
     v.handle_ = 0;
@@ -405,7 +405,7 @@ public:
 
   val(const val& v) : handle_(v.handle_)
 #if !defined(NDEBUG) && defined(_REENTRANT)
-      , thread(pthread_self())
+      , thread(v.thread)
 #endif
   {
     internal::_emval_incref(handle_);

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -644,11 +644,11 @@ struct BindingType<val> {
 
 template <typename T, typename... Policies>
 std::vector<T> vecFromJSArray(const val& v, Policies... policies) {
-  const size_t l = v["length"].as<size_t>();
+  const uint32_t l = v["length"].as<uint32_t>();
 
   std::vector<T> rv;
   rv.reserve(l);
-  for (size_t i = 0; i < l; ++i) {
+  for (uint32_t i = 0; i < l; ++i) {
     rv.push_back(v[i].as<T>(std::forward<Policies>(policies)...));
   }
 

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -395,25 +395,17 @@ public:
       : val(internal::_emval_new_cstring(v))
   {}
 
-  val(val&& v) : handle_(v.handle_)
-#if !defined(NDEBUG) && defined(_REENTRANT)
-      , thread(v.thread)
-#endif
-  {
+  val(val&& v) : val(v.as_handle()) {
     v.handle_ = 0;
   }
 
-  val(const val& v) : handle_(v.handle_)
-#if !defined(NDEBUG) && defined(_REENTRANT)
-      , thread(v.thread)
-#endif
-  {
+  val(const val& v) : val(v.as_handle()) {
     internal::_emval_incref(handle_);
   }
 
   ~val() {
-    if (handle_) {
-      internal::_emval_decref(handle_);
+    if (EM_VAL handle = as_handle()) {
+      internal::_emval_decref(handle);
       handle_ = 0;
     }
   }

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7780,6 +7780,7 @@ void* operator new(size_t size) {
       #include <emscripten.h>
       #include <emscripten/val.h>
       #include <thread>
+      #include <stdio.h>
 
       using emscripten::val;
 
@@ -7791,7 +7792,10 @@ void* operator new(size_t size) {
           value = val(1);
         }).join();
         // Try to access the stored handle from the main thread.
-        value.as<int>();
+        // Without the check (if compiled with -DNDEBUG) this will incorrectly
+        // print "0" instead of "1" since the handle with the same ID
+        // resolves to different values on different threads.
+        printf("%d\n", value.as<int>());
       }
     ''')
     self.do_runf('test_embind_val_cross_thread.cpp', 'val accessed from wrong thread', assert_returncode=NON_ZERO)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7774,8 +7774,9 @@ void* operator new(size_t size) {
     err = self.expect_fail([EMCC, test_file('embind/test_val_assignment.cpp'), '-lembind', '-c'])
     self.assertContained('candidate function not viable: expects an lvalue for object argument', err)
 
+  @node_pthreads
   def test_embind_val_cross_thread(self):
-    self.emcc_args += ['--bind', '-pthread']
+    self.emcc_args += ['--bind']
     self.setup_node_pthreads()
     create_file('test_embind_val_cross_thread.cpp', r'''
       #include <emscripten.h>

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7774,6 +7774,28 @@ void* operator new(size_t size) {
     err = self.expect_fail([EMCC, test_file('embind/test_val_assignment.cpp'), '-lembind', '-c'])
     self.assertContained('candidate function not viable: expects an lvalue for object argument', err)
 
+  def test_embind_val_cross_thread(self):
+    self.emcc_args += ['--bind', '-pthread']
+    create_file('test_embind_val_cross_thread.cpp', r'''
+      #include <emscripten.h>
+      #include <emscripten/val.h>
+      #include <thread>
+
+      using emscripten::val;
+
+      int main(int argc, char **argv) {
+        // Store a value handle from the main thread.
+        val value(0);
+        std::thread([&] {
+          // Set to a value handle from a different thread.
+          value = val(1);
+        }).join();
+        // Try to access the stored handle from the main thread.
+        value.as<int>();
+      }
+    ''')
+    self.do_runf('test_embind_val_cross_thread.cpp', 'val accessed from wrong thread', assert_returncode=NON_ZERO)
+
   def test_embind_dynamic_initialization(self):
     self.emcc_args += ['-lembind']
     self.do_run_in_out_file_test('embind/test_dynamic_initialization.cpp')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7776,6 +7776,7 @@ void* operator new(size_t size) {
 
   def test_embind_val_cross_thread(self):
     self.emcc_args += ['--bind', '-pthread']
+    self.setup_node_pthreads()
     create_file('test_embind_val_cross_thread.cpp', r'''
       #include <emscripten.h>
       #include <emscripten/val.h>


### PR DESCRIPTION
In multithreading environment using `emscripten::val` is very error-prone and hard to debug. The reason for that is that, on one hand, `val` represents JavaScript values which cannot be (easily) shared between threads, but, on another, `val` itself is a thin wrapper around an integer handle which can be shared across threads way too easily.

As a result, accessing `val` from the wrong thread sometimes succeeds by accident (such as for built-in constants like `undefined`/`false`/`true`), sometimes crashes with invalid handle, and sometimes just quietly returns completely different JS value because a handle with the same ID happened to be valid on both threads, but points to different underlying values.

In the last scenario code can even keep going forward for some time, using and making changes on the incorrect JS value before it's apparent that something went very wrong.

To make it easier to catch such cases, in this PR I'm adding a `pthread_t` field to the `val` class that stores the owner thread of the given handle. User can still store `val` and send it across threads, but the moment they try to operate on the underlying JS value on the wrong thread, an assertion will fire with a clear message.

This check is activated only when code is compiled with pthread support, and only if user didn't disable assertions via `NDEBUG` (we can't use the `-sASSERTIONS` setting here because it's a header not compiled code). This still adds a tiny size overhead if the user is not passing `-DNDEBUG`, but typical build systems (e.g. CMake) pass it automatically in release builds, and overall I believe benefits outweigh the overhead in this scenario.

In the future we might also automatically proxy all operations to the correct thread so that `emscripten::val` behaves like any other native object. However, that's out of scope of this particular PR, so for now just laying the groundwork and making those failure scenarios more visible.