### PR TITLE
Fixup extern "C" block

### DIFF
--- a/system/include/emscripten/em_js.h
+++ b/system/include/emscripten/em_js.h
@@ -59,13 +59,13 @@
 // array of JS function strings to be included in the JS output.
 
 #define _EM_JS(ret, c_name, js_name, params, code)                             \
-  _EM_JS_CPP_BEGIN                                                             \
+  _EM_BEGIN_CDECL                                                              \
   ret c_name params EM_IMPORT(js_name);                                        \
   __attribute__((used)) static void* __em_js_ref_##c_name = (void*)&c_name;    \
   EMSCRIPTEN_KEEPALIVE                                                         \
   __attribute__((section("em_js"), aligned(1))) char __em_js__##js_name[] =    \
     #params "<::>" code;                                                       \
-  _EM_JS_CPP_END
+  _EM_END_CDECL
 
 #define EM_JS(ret, name, params, ...) _EM_JS(ret, name, name, params, #__VA_ARGS__)
 

--- a/system/include/emscripten/em_js.h
+++ b/system/include/emscripten/em_js.h
@@ -59,12 +59,13 @@
 // array of JS function strings to be included in the JS output.
 
 #define _EM_JS(ret, c_name, js_name, params, code)                             \
-  _EM_CDECL                                                                    \
+  _EM_JS_CPP_BEGIN                                                             \
   ret c_name params EM_IMPORT(js_name);                                        \
   __attribute__((used)) static void* __em_js_ref_##c_name = (void*)&c_name;    \
   EMSCRIPTEN_KEEPALIVE                                                         \
   __attribute__((section("em_js"), aligned(1))) char __em_js__##js_name[] =    \
-    #params "<::>" code;
+    #params "<::>" code;                                                       \
+  _EM_JS_CPP_END
 
 #define EM_JS(ret, name, params, ...) _EM_JS(ret, name, name, params, #__VA_ARGS__)
 

--- a/system/include/emscripten/em_macros.h
+++ b/system/include/emscripten/em_macros.h
@@ -16,10 +16,12 @@
 #endif
 
 #ifdef __cplusplus
-#define _EM_CDECL extern "C"
-#else
-#define _EM_CDECL
-#endif
+#define _EM_JS_CPP_BEGIN extern "C" {
+#define _EM_JS_CPP_END   }
+#else // __cplusplus
+#define _EM_JS_CPP_BEGIN
+#define _EM_JS_CPP_END
+#endif // __cplusplus
 
 /*
  * EM_JS_DEPS: Use this macro to declare indirect dependencies on JS symbols.
@@ -42,9 +44,11 @@
  * it makes sense co-locate them with the EM_JS or EM_ASM code they correspond
  * to.
  */
-#define EM_JS_DEPS(tag, deps)            \
+#define EM_JS_DEPS(tag, deps)             \
+  _EM_JS_CPP_BEGIN                        \
   EMSCRIPTEN_KEEPALIVE                    \
   __attribute__((section("em_lib_deps"))) \
   __attribute__((aligned(1)))             \
   _EM_CDECL                               \
-  char __em_lib_deps_##tag[] = deps;
+  char __em_lib_deps_##tag[] = deps;      \
+  _EM_JS_CPP_END

--- a/system/include/emscripten/em_macros.h
+++ b/system/include/emscripten/em_macros.h
@@ -49,6 +49,5 @@
   EMSCRIPTEN_KEEPALIVE                    \
   __attribute__((section("em_lib_deps"))) \
   __attribute__((aligned(1)))             \
-  _EM_CDECL                               \
   char __em_lib_deps_##tag[] = deps;      \
   _EM_JS_CPP_END

--- a/system/include/emscripten/em_macros.h
+++ b/system/include/emscripten/em_macros.h
@@ -16,11 +16,11 @@
 #endif
 
 #ifdef __cplusplus
-#define _EM_JS_CPP_BEGIN extern "C" {
-#define _EM_JS_CPP_END   }
+#define _EM_BEGIN_CDECL extern "C" {
+#define _EM_END_CDECL   }
 #else // __cplusplus
-#define _EM_JS_CPP_BEGIN
-#define _EM_JS_CPP_END
+#define _EM_BEGIN_CDECL
+#define _EM_END_CDECL
 #endif // __cplusplus
 
 /*
@@ -45,9 +45,9 @@
  * to.
  */
 #define EM_JS_DEPS(tag, deps)             \
-  _EM_JS_CPP_BEGIN                        \
+  _EM_BEGIN_CDECL                         \
   EMSCRIPTEN_KEEPALIVE                    \
   __attribute__((section("em_lib_deps"))) \
   __attribute__((aligned(1)))             \
   char __em_lib_deps_##tag[] = deps;      \
-  _EM_JS_CPP_END
+  _EM_END_CDECL


### PR DESCRIPTION
Follow-up to #20342 - tests pass, but realised that actually `__em_js*` prefixed variables are no longer preserved from mangling.