### PR TITLE
Fix assembly files to avoid llvm crash/bug. NFC

### DIFF
--- a/system/lib/compiler-rt/emscripten_tempret.s
+++ b/system/lib/compiler-rt/emscripten_tempret.s
@@ -1,5 +1,9 @@
+.section .globals,"",@
+
 .globaltype tempRet0, i32
 tempRet0:
+
+.section .text,"",@
 
 .globl setTempRet0
 setTempRet0:

--- a/system/lib/compiler-rt/stack_limits.S
+++ b/system/lib/compiler-rt/stack_limits.S
@@ -16,12 +16,16 @@
 
 .globaltype __stack_pointer, PTR
 
+.section .globals,"",@
+
 # TODO(sbc): It would be nice if these we initialized directly
 # using PTR.const rather than using the `emscripten_stack_init`
 .globaltype __stack_end, PTR
 __stack_end:
 .globaltype __stack_base, PTR
 __stack_base:
+
+.section .text,"",@
 
 emscripten_stack_get_base:
   .functype emscripten_stack_get_base () -> (PTR)

--- a/system/lib/pthread/emscripten_thread_state.S
+++ b/system/lib/pthread/emscripten_thread_state.S
@@ -4,6 +4,8 @@
 #define PTR i32
 #endif
 
+.section .globals,"",@
+
 .globaltype thread_ptr, PTR
 thread_ptr:
 
@@ -15,6 +17,8 @@ is_runtime_thread:
 
 .globaltype supports_wait, i32
 supports_wait:
+
+.section .text,"",@
 
 .globl __get_tp
 __get_tp:


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/issues/56270

The previous workaround we had was to simply not pass `-g`.  The new workaround is declare globals outside the `.text` section.