### PR TITLE
embind: ensure paths are correct for TS generation

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3243,10 +3243,11 @@ def phase_embind_emit_tsd(options, in_wasm, wasm_target, memfile, js_syms):
   embind_index = settings.JS_LIBRARIES.index('embind/embind.js')
   settings.JS_LIBRARIES[embind_index] = 'embind/embind_ts.js'
 
-  outfile_js = 'tsgen_a.out.js'
+  outfile_js = os.path.join(os.path.dirname(wasm_target), 'tsgen_a.out.js')
   emscripten.run(in_wasm, wasm_target, outfile_js, memfile, js_syms)
   out = shared.run_js_tool(outfile_js, [], stdout=PIPE)
-  write_file(options.embind_emit_tsd, out)
+  write_file(
+    os.path.join(os.path.dirname(wasm_target), options.embind_emit_tsd), out)
   delete_file(outfile_js)
   settings.restore(original_settings)
 


### PR DESCRIPTION
`outfile_js` needs to be in the same directory as `wasm_target` in order to load it correctly. This ensures that is the case.