### PR TITLE
embind: Add helper for registering a std::optional type.

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -925,14 +925,15 @@ Out of the box, *embind* provides converters for many standard C++ types:
 +---------------------+--------------------------------------------------------------------+
 
 For convenience, *embind* provides factory functions to register
-``std::vector<T>`` (:cpp:func:`register_vector`) and ``std::map<K, V>``
-(:cpp:func:`register_map`) types:
+``std::vector<T>`` (:cpp:func:`register_vector`), ``std::map<K, V>``
+(:cpp:func:`register_map`), and ``std::optional<T>`` (:cpp:func:`register_optional`) types:
 
 .. code:: cpp
 
     EMSCRIPTEN_BINDINGS(stl_wrappers) {
         register_vector<int>("VectorInt");
         register_map<int,int>("MapIntInt");
+        register_map<std::string>("OptionalString");
     }
 
 A full example is shown below:
@@ -942,6 +943,7 @@ A full example is shown below:
     #include <emscripten/bind.h>
     #include <string>
     #include <vector>
+    #include <optional>
 
     using namespace emscripten;
 
@@ -956,13 +958,20 @@ A full example is shown below:
       return m;
     }
 
+    std::optional<std::string> returnOptionalData() {
+      return "hello";
+    }
+
     EMSCRIPTEN_BINDINGS(module) {
       function("returnVectorData", &returnVectorData);
       function("returnMapData", &returnMapData);
+      function("returnOptionalData", &returnOptionalData);
 
-      // register bindings for std::vector<int> and std::map<int, std::string>.
+      // register bindings for std::vector<int>, std::map<int, std::string>, and
+      // std::optional<std::string>.
       register_vector<int>("vector<int>");
       register_map<int, std::string>("map<int, string>");
+      register_optional<std::string>("optional<string>");
     }
 
 
@@ -1008,6 +1017,12 @@ The following JavaScript can be used to interact with the above C++.
 
     // reset the value at the given index position
     retMap.set(10, "OtherValue");
+
+    // Using an optional<std::string>.
+    var optional = Module['returnOptionalData']();
+    if (optional.hasValue()) {
+        console.log(optional.value());
+    }
 
 
 TypeScript Definitions

--- a/test/embind/embind.test.js
+++ b/test/embind/embind.test.js
@@ -1186,6 +1186,28 @@ module({
        });
     });
 
+    BaseFixture.extend("optional", function() {
+        if (!("embind_test_return_optional_string_with_value" in cm)) {
+            return;
+        }
+        test("std::optional returns works with value", function() {
+            var optional = cm.embind_test_return_optional_string_with_value();
+
+            assert.equal(true, optional.hasValue());
+            assert.equal("hello", optional.value());
+
+            optional.delete();
+        });
+
+        test("std::optional returns works with empty value", function() {
+            var optional = cm.embind_test_return_optional_string_empty();
+
+            assert.equal(false, optional.hasValue());
+
+            optional.delete();
+        });
+    });
+
     BaseFixture.extend("functors", function() {
         test("can get and call function ptrs", function() {
             var ptr = cm.emval_test_get_function_ptr();

--- a/test/embind/embind_test.cpp
+++ b/test/embind/embind_test.cpp
@@ -10,6 +10,10 @@
 #include <emscripten/heap.h>
 #include <emscripten/em_asm.h>
 
+#if defined(EMSCRIPTEN_HAS_OPTIONAL)
+#include <optional>
+#endif
+
 using namespace emscripten;
 
 val emval_test_mallinfo() {
@@ -1282,6 +1286,16 @@ void test_string_with_vec(const std::string& p1, std::vector<std::string>& v1) {
     printf("%s\n", p1.c_str());
 }
 
+#if defined(EMSCRIPTEN_HAS_OPTIONAL)
+std::optional<std::string> embind_test_return_optional_string_with_value() {
+    return "hello";
+}
+
+std::optional<std::string> embind_test_return_optional_string_empty() {
+    return {};
+}
+#endif
+
 val embind_test_getglobal() {
     return val::global();
 }
@@ -2277,6 +2291,12 @@ EMSCRIPTEN_BINDINGS(tests) {
         ;
 
     function("test_string_with_vec", &test_string_with_vec);
+
+#if defined(EMSCRIPTEN_HAS_OPTIONAL)
+    register_optional<std::string>("OptionalString");
+    function("embind_test_return_optional_string_with_value", &embind_test_return_optional_string_with_value);
+    function("embind_test_return_optional_string_empty", &embind_test_return_optional_string_empty);
+#endif
 
     register_map<std::string, int>("StringIntMap");
     function("embind_test_get_string_int_map", embind_test_get_string_int_map);


### PR DESCRIPTION
Fixes #20082

This seems to be a common enough feature request and is slightly tricky to add for users.