### PR TITLE
Use more reliable check for `typeof`

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -570,7 +570,7 @@ public:
   }
 
 // If code is not being compiled with GNU extensions enabled, typeof() is not a reserved keyword, so support that as a member function.
-#if __STRICT_ANSI__
+#if __is_identifier(typeof)
   val typeof() const {
     return val(internal::_emval_typeof(as_handle()));
   }

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -574,8 +574,9 @@ public:
     return val(internal::_emval_typeof(as_handle()));
   }
 
-// If code is not being compiled with GNU extensions enabled, typeof() is not a reserved keyword, so support that as a member function.
+// If code is not being compiled with GNU extensions enabled, typeof() is a valid identifier, so support that as a member function.
 #if __is_identifier(typeof)
+  [[deprecated("Use typeOf() instead.")]]
   val typeof() const {
     return typeOf();
   }

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -569,17 +569,17 @@ public:
     return  _emval_as_uint64(as_handle(), targetType.getTypes()[0]);
   }
 
-// If code is not being compiled with GNU extensions enabled, typeof() is not a reserved keyword, so support that as a member function.
-#if __is_identifier(typeof)
-  val typeof() const {
-    return val(internal::_emval_typeof(as_handle()));
-  }
-#endif
-
 // Prefer calling val::typeOf() over val::typeof(), since this form works in both C++11 and GNU++11 build modes. "typeof" is a reserved word in GNU++11 extensions.
   val typeOf() const {
     return val(internal::_emval_typeof(as_handle()));
   }
+
+// If code is not being compiled with GNU extensions enabled, typeof() is not a reserved keyword, so support that as a member function.
+#if __is_identifier(typeof)
+  val typeof() const {
+    return typeOf();
+  }
+#endif
 
   bool instanceof(const val& v) const {
     return internal::_emval_instanceof(as_handle(), v.as_handle());


### PR DESCRIPTION
I was always wondering why I'm seeing error squiggles in VSCode for some functions. Apparently it's because `typeof` was incorrectly parsed as an operator depending on compiler mode (C/C+) and standards used.

I haven't fully figured out which exact combinations cause this, but a switch to the more reliable Clang intrinsic `__is_identifier` fixes the issue.