### PR TITLE
Add iterator support to emval

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,8 @@ See docs/process.md for more on how version tagging works.
 - `emscripten::val` now prevents accidental access to the underlying JavaScript
   value from threads other than its owner. This already didn't work correctly
   in majority of cases, but now it will throw a clear assertion failure. (#20344)
+- `emscripten::val` can now be iterated over with a C++ range-based for loop.
+  (#20364)
 
 3.1.46 - 09/15/23
 -----------------

--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -521,6 +521,19 @@ var LibraryEmVal = {
     });
   },
 #endif
+
+  _emval_iter_begin__deps: ['$Emval'],
+  _emval_iter_begin: (iterable) => {
+    iterable = Emval.toValue(iterable);
+    return Emval.toHandle(iterable[Symbol.iterator]());
+  },
+
+  _emval_iter_next__deps: ['$Emval'],
+  _emval_iter_next: (iterator) => {
+    iterator = Emval.toValue(iterator);
+    var result = iterator.next();
+    return result.done ? 0 : Emval.toHandle(result.value);
+  },
 };
 
 addToLibrary(LibraryEmVal);

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -352,6 +352,8 @@ sigs = {
   _emval_instanceof__sig: 'ipp',
   _emval_is_number__sig: 'ip',
   _emval_is_string__sig: 'ip',
+  _emval_iter_begin__sig: 'pp',
+  _emval_iter_next__sig: 'pp',
   _emval_less_than__sig: 'ipp',
   _emval_new__sig: 'ppipp',
   _emval_new_array__sig: 'p',

--- a/test/embind/test_val.cpp
+++ b/test/embind/test_val.cpp
@@ -73,6 +73,11 @@ int main() {
   ensure_js("a[1] == 1");
   ensure_js("a[2] == 3");
   ensure_js_not("a[2] == 2");
+  vector<int> vec2_from_iter;
+  for (val&& v : val::global("a")) {
+    vec2_from_iter.push_back(v.as<int>());
+  }
+  ensure(vec2 == vec2_from_iter);
 
   test("template<typename Iter> val array(Iter begin, Iter end)");
   val::global().set("a", val::array(vec1.begin(), vec1.end()));


### PR DESCRIPTION
Allows to natively iterate over any iterable JS values using a C++ range for loop. 