### PR TITLE
Remove try/catch from intArrayFromBase64. NFC

### DIFF
--- a/src/base64Utils.js
+++ b/src/base64Utils.js
@@ -8,8 +8,7 @@
 #include "polyfill/atob.js"
 #endif
 
-// Converts a string of base64 into a byte array.
-// Throws error on invalid input.
+// Converts a string of base64 into a byte array (Uint8Array).
 function intArrayFromBase64(s) {
 #if ENVIRONMENT_MAY_BE_NODE
   if (typeof ENVIRONMENT_IS_NODE != 'undefined' && ENVIRONMENT_IS_NODE) {
@@ -18,16 +17,12 @@ function intArrayFromBase64(s) {
   }
 #endif
 
-  try {
-    var decoded = atob(s);
-    var bytes = new Uint8Array(decoded.length);
-    for (var i = 0 ; i < decoded.length ; ++i) {
-      bytes[i] = decoded.charCodeAt(i);
-    }
-    return bytes;
-  } catch (_) {
-    throw new Error('Converting base64 string to bytes failed.');
+  var decoded = atob(s);
+  var bytes = new Uint8Array(decoded.length);
+  for (var i = 0 ; i < decoded.length ; ++i) {
+    bytes[i] = decoded.charCodeAt(i);
   }
+  return bytes;
 }
 
 // If filename is a base64 data URI, parses and returns data (Buffer on node,


### PR DESCRIPTION
It seems like the error is strictly worse than just letting the exception propagate out.  For example, we have a report of someone hitting this error but I can't tell what the root cause was: https://github.com/emscripten-core/emscripten/issues/20349

This try/catch and this error message was part of the original function back #5296 but I don't see any reason for them.