### PR TITLE
embind: Fix TS generation when optimization is enabled.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3241,6 +3241,9 @@ def phase_embind_emit_tsd(options, in_wasm, wasm_target, memfile, js_syms):
   # Required function to trigger TS generation.
   settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$callRuntimeCallbacks']
   settings.EXPORT_ES6 = False
+  # Disable minify since the binaryen pass has not been run yet to change the
+  # import names.
+  settings.MINIFY_WASM_IMPORTED_MODULES = False
   setup_environment_settings()
   # Replace embind with the TypeScript generation version.
   embind_index = settings.JS_LIBRARIES.index('embind/embind.js')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2938,7 +2938,8 @@ int f() {
                   '--extern-post-js', 'fail.js',
                   '-sENVIRONMENT=worker',
                   '--use-preload-cache',
-                  '--preload-file', 'fail.js']
+                  '--preload-file', 'fail.js',
+                  '-O3']
     self.run_process([EMCC, test_file('other/embind_tsgen.cpp'),
                       '-lembind', '--embind-emit-tsd', 'embind_tsgen.d.ts'] + extra_args)
     # Test these args separately since they conflict with arguments in the first test.


### PR DESCRIPTION
Optimizations enabled cause the imports to be renamed, but binaryen hasn't been run yet in the tsgen phase.