### PR TITLE
Move emscripten_wasm_notify/wait functions from wasm_worker.h to atomic.h. NFC

### DIFF
--- a/site/source/docs/api_reference/wasm_workers.rst
+++ b/site/source/docs/api_reference/wasm_workers.rst
@@ -287,7 +287,7 @@ table.
 
     <tr><td class='cellborder'>Futex API</td>
     <td class='cellborder'><pre>emscripten_futex_wait</pre><pre>emscripten_futex_wake</pre> in emscripten/threading.h</td>
-    <td class='cellborder'><pre>emscripten_wasm_wait_i32</pre><pre>emscripten_wasm_wait_i64</pre><pre>emscripten_wasm_notify</pre> in emscripten/wasm_workers.h</td></tr>
+    <td class='cellborder'><pre>emscripten_atomic_wait_u32</pre><pre>emscripten_atomic_wait_u64</pre><pre>emscripten_atomic_notify</pre> in emscripten/atomic.h</td></tr>
 
     <tr><td class='cellborder'>Asynchronous futex wait</td>
     <td class='cellborder'>N/A</td>

--- a/system/include/emscripten/atomic.h
+++ b/system/include/emscripten/atomic.h
@@ -179,6 +179,50 @@ _EM_INLINE void emscripten_atomic_fence(void) {
   emscripten_atomic_or_u8(&temp, 0);
 }
 
+#define ATOMICS_WAIT_RESULT_T int
+
+// Numbering dictated by https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md#wait
+#define ATOMICS_WAIT_OK 0
+#define ATOMICS_WAIT_NOT_EQUAL 1
+#define ATOMICS_WAIT_TIMED_OUT 2
+
+#define ATOMICS_WAIT_DURATION_INFINITE -1ll
+
+// Issues the wasm 'memory.atomic.wait32' instruction:
+// If the given memory address contains value 'expectedValue', puts the calling
+// thread to sleep to wait for that address to be notified.
+// Returns one of the ATOMICS_WAIT_* return codes.
+// NOTE: This function takes in the wait value in int64_t nanosecond units. Pass
+// in maxWaitNanoseconds = -1 (or ATOMICS_WAIT_DURATION_INFINITE) to wait
+// infinitely long.
+_EM_INLINE ATOMICS_WAIT_RESULT_T emscripten_atomic_wait_u32(void /*uint32_t*/*addr __attribute__((nonnull)), uint32_t expectedValue, int64_t maxWaitNanoseconds) {
+  return __builtin_wasm_memory_atomic_wait32((int32_t*)addr, expectedValue, maxWaitNanoseconds);
+}
+
+// Issues the wasm 'memory.atomic.wait64' instruction:
+// If the given memory address contains value 'expectedValue', puts the calling
+// thread to sleep to wait for that address to be notified.
+// Returns one of the ATOMICS_WAIT_* return codes.
+// NOTE: This function takes in the wait value in int64_t nanosecond units. Pass
+// in maxWaitNanoseconds = -1 (or ATOMICS_WAIT_DURATION_INFINITE) to wait
+// infinitely long.
+_EM_INLINE ATOMICS_WAIT_RESULT_T emscripten_atomic_wait_u64(void /*uint64_t*/*addr __attribute__((nonnull)), uint64_t expectedValue, int64_t maxWaitNanoseconds) {
+  return __builtin_wasm_memory_atomic_wait64((int64_t*)addr, expectedValue, maxWaitNanoseconds);
+}
+
+#define EMSCRIPTEN_NOTIFY_ALL_WAITERS (-1LL)
+
+// Issues the wasm 'memory.atomic.notify' instruction:
+// Notifies the given number of threads waiting on a location.
+// Pass count == EMSCRIPTEN_NOTIFY_ALL_WAITERS to notify all waiters on the
+// given location.
+// Returns the number of threads that were woken up.
+// Note: this function is used to notify both waiters waiting on an u32 and u64
+// addresses.
+_EM_INLINE int64_t emscripten_atomic_notify(void *addr __attribute__((nonnull)), int64_t count) {
+  return __builtin_wasm_memory_atomic_notify((int*)addr, count);
+}
+
 #undef _EM_INLINE
 
 #ifdef __cplusplus

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5353,12 +5353,12 @@ Module["preRun"] = () => {
   def test_wasm_worker_hardware_concurrency_is_lock_free(self):
     self.btest('wasm_worker/hardware_concurrency_is_lock_free.c', expected='0', args=['-sWASM_WORKERS'])
 
-  # Tests emscripten_wasm_wait_i32() and emscripten_wasm_notify() functions.
+  # Tests emscripten_atomic_wait_u32() and emscripten_atomic_notify() functions.
   @also_with_minimal_runtime
   def test_wasm_worker_wait32_notify(self):
     self.btest('wasm_worker/wait32_notify.c', expected='2', args=['-sWASM_WORKERS'])
 
-  # Tests emscripten_wasm_wait_i64() and emscripten_wasm_notify() functions.
+  # Tests emscripten_atomic_wait_u64() and emscripten_atomic_notify() functions.
   @also_with_minimal_runtime
   def test_wasm_worker_wait64_notify(self):
     self.btest('wasm_worker/wait64_notify.c', expected='2', args=['-sWASM_WORKERS'])

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2921,6 +2921,15 @@ The current type of b is: 9
     self.set_setting('EXIT_RUNTIME')
     self.do_runf(test_file('pthread/test_pthread_run_script.c'))
 
+  @node_pthreads
+  def test_pthread_wait32_notify(self):
+    self.do_run_in_out_file_test(test_file('wasm_worker/wait32_notify.c'))
+
+  @node_pthreads
+  @no_wasm2js('https://github.com/WebAssembly/binaryen/issues/5991')
+  def test_pthread_wait64_notify(self):
+    self.do_run_in_out_file_test(test_file('wasm_worker/wait64_notify.c'))
+
   def test_tcgetattr(self):
     self.do_runf(test_file('termios/test_tcgetattr.c'), 'success')
 

--- a/test/wasm_worker/cancel_all_wait_asyncs.c
+++ b/test/wasm_worker/cancel_all_wait_asyncs.c
@@ -47,14 +47,14 @@ int main()
   assert(r == EMSCRIPTEN_RESULT_INVALID_PARAM);
 
   emscripten_console_log("Notifying an async wait should not trigger the callback function");
-  int64_t numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
+  int64_t numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
   emscripten_console_log("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
   addr = 2;
   emscripten_console_log("Notifying an async wait even after changed value should not trigger the callback function");
-  numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
+  numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
   emscripten_console_log("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
@@ -65,12 +65,12 @@ int main()
 
 #if 0
   emscripten_console_log("Notifying an async wait without value changing should still trigger the callback");
-  numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
+  numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
   assert(numWoken == 1);
 #else
   // TODO: Switch to the above test instead after the Atomics.waitAsync() polyfill is dropped.
   addr = 3;
   emscripten_console_log("Notifying an async wait after value changing should trigger the callback");
-  numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
+  numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 #endif
 }

--- a/test/wasm_worker/cancel_all_wait_asyncs_at_address.c
+++ b/test/wasm_worker/cancel_all_wait_asyncs_at_address.c
@@ -51,14 +51,14 @@ int main()
   assert(r == EMSCRIPTEN_RESULT_INVALID_PARAM);
 
   emscripten_console_log("Notifying an async wait should not trigger the callback function");
-  int64_t numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
+  int64_t numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
   emscripten_console_log("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
   addr = 2;
   emscripten_console_log("Notifying an async wait even after changed value should not trigger the callback function");
-  numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
+  numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
   emscripten_console_log("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
@@ -69,12 +69,12 @@ int main()
 
 #if 0
   emscripten_console_log("Notifying an async wait without value changing should still trigger the callback");
-  numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
+  numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
   assert(numWoken == 1);
 #else
   // TODO: Switch to the above test instead after the Atomics.waitAsync() polyfill is dropped.
   addr = 3;
   emscripten_console_log("Notifying an async wait after value changing should trigger the callback");
-  numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
+  numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 #endif
 }

--- a/test/wasm_worker/cancel_wait_async.c
+++ b/test/wasm_worker/cancel_wait_async.c
@@ -39,14 +39,14 @@ int main()
   assert(r == EMSCRIPTEN_RESULT_INVALID_PARAM);
 
   emscripten_console_log("Notifying an async wait should not trigger the callback function");
-  int64_t numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
+  int64_t numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
   emscripten_console_log("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
   addr = 2;
   emscripten_console_log("Notifying an async wait even after changed value should not trigger the callback function");
-  numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
+  numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
   emscripten_console_log("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
@@ -57,12 +57,12 @@ int main()
 
 #if 0
   emscripten_console_log("Notifying an async wait without value changing should still trigger the callback");
-  numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
+  numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
   assert(numWoken == 1);
 #else
   // TODO: Switch to the above test instead after the Atomics.waitAsync() polyfill is dropped.
   addr = 3;
   emscripten_console_log("Notifying an async wait after value changing should trigger the callback");
-  numWoken = emscripten_wasm_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
+  numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 #endif
 }

--- a/test/wasm_worker/wait32_notify.c
+++ b/test/wasm_worker/wait32_notify.c
@@ -1,72 +1,101 @@
+#include <emscripten/atomic.h>
 #include <emscripten/html5.h>
-#include <emscripten/wasm_worker.h>
-#include <emscripten/threading.h>
 #include <assert.h>
 
-// Test emscripten_wasm_wait_i32() and emscripten_wasm_notify() functions.
+#ifdef __EMSCRIPTEN_WASM_WORKERS__
+#include <emscripten/wasm_worker.h>
+#else
+#include <pthread.h>
+#endif
+
+// Test emscripten_atomic_wait_u32() and emscripten_atomic_notify() functions.
 
 volatile int32_t addr = 0;
 
-void worker_main()
-{
-  emscripten_console_log("worker_main");
+void run_test() {
+  emscripten_out("worker_main");
   emscripten_atomic_store_u32((void*)&addr, 1);
 
-  emscripten_console_log("Waiting on address with unexpected value should return 'not-equal'");
-  ATOMICS_WAIT_RESULT_T ret = emscripten_wasm_wait_i32((int32_t*)&addr, 2, /*timeout=*/-1);
+  emscripten_out("Waiting on address with unexpected value should return 'not-equal'");
+  ATOMICS_WAIT_RESULT_T ret = emscripten_atomic_wait_u32((int32_t*)&addr, 2, /*timeout=*/-1);
   assert(ret == ATOMICS_WAIT_NOT_EQUAL);
 
-  emscripten_console_log("Waiting on address with unexpected value should return 'not-equal' also if timeout==0");
-  ret = emscripten_wasm_wait_i32((int32_t*)&addr, 2, /*timeout=*/0);
+  emscripten_out("Waiting on address with unexpected value should return 'not-equal' also if timeout==0");
+  ret = emscripten_atomic_wait_u32((int32_t*)&addr, 2, /*timeout=*/0);
   assert(ret == ATOMICS_WAIT_NOT_EQUAL);
 
-  emscripten_console_log("Waiting for 0 nanoseconds should return 'timed-out'");
-  ret = emscripten_wasm_wait_i32((int32_t*)&addr, 1, /*timeout=*/0);
+  emscripten_out("Waiting for 0 nanoseconds should return 'timed-out'");
+  ret = emscripten_atomic_wait_u32((int32_t*)&addr, 1, /*timeout=*/0);
   assert(ret == ATOMICS_WAIT_TIMED_OUT);
 
-  emscripten_console_log("Waiting for >0 nanoseconds should return 'timed-out'");
-  ret = emscripten_wasm_wait_i32((int32_t*)&addr, 1, /*timeout=*/1000);
+  emscripten_out("Waiting for >0 nanoseconds should return 'timed-out'");
+  ret = emscripten_atomic_wait_u32((int32_t*)&addr, 1, /*timeout=*/1000);
   assert(ret == ATOMICS_WAIT_TIMED_OUT);
 
-  emscripten_console_log("Waiting for infinitely long should return 'ok'");
-  ret = emscripten_wasm_wait_i32((int32_t*)&addr, 1, /*timeout=*/-1);
+  emscripten_out("Waiting for infinitely long should return 'ok'");
+  ret = emscripten_atomic_wait_u32((int32_t*)&addr, 1, /*timeout=*/-1);
   assert(ret == ATOMICS_WAIT_OK);
 
-  emscripten_console_log("Test finished");
+  emscripten_out("Test finished");
+}
+
+
+// This test run in both wasm workers and pthreads mode
+#ifdef __EMSCRIPTEN_WASM_WORKERS__
+
+char stack[1024];
+
+void worker_main() {
+  run_test();
 
 #ifdef REPORT_RESULT
   REPORT_RESULT(addr);
 #endif
 }
 
-char stack[1024];
+#else
 
-EM_BOOL main_loop(double time, void *userData)
-{
-  if (addr == 1)
-  {
+pthread_t t;
+
+void* thread_main(void* arg) {
+  run_test();
+  return 0;
+}
+
+#endif
+
+
+EM_BOOL main_loop(double time, void *userData) {
+  if (addr == 1) {
     // Burn one second to make sure worker finishes its test.
-    emscripten_console_log("main: seen worker running");
+    emscripten_out("main: seen worker running");
     double t0 = emscripten_performance_now();
     while(emscripten_performance_now() < t0 + 1000);
 
     // Wake the waiter
-    emscripten_console_log("main: waking worker");
+    emscripten_out("main: waking worker");
     addr = 2;
-    emscripten_wasm_notify((int32_t*)&addr, 1);
+    emscripten_atomic_notify((int32_t*)&addr, 1);
+
+#ifndef __EMSCRIPTEN_WASM_WORKERS__
+    pthread_join(t, NULL);
+#endif
 
     return EM_FALSE;
   }
   return EM_TRUE;
 }
 
-int main()
-{
-  emscripten_console_log("main: creating worker");
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
-  emscripten_console_log("main: posting function");
-  emscripten_wasm_worker_post_function_v(worker, worker_main);
+int main() {
+  emscripten_out("main: creating worker");
 
-  emscripten_console_log("main: entering timeout loop to wait for wasm worker to run");
-  emscripten_set_timeout_loop(main_loop, 1000, 0);
+#ifdef __EMSCRIPTEN_WASM_WORKERS__
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
+  emscripten_wasm_worker_post_function_v(worker, worker_main);
+#else
+  pthread_create(&t, NULL, thread_main, NULL);
+#endif
+
+  emscripten_out("main: entering timeout loop to wait for wasm worker to run");
+  emscripten_set_timeout_loop(main_loop, 50, 0);
 }

--- a/test/wasm_worker/wait32_notify.out
+++ b/test/wasm_worker/wait32_notify.out
@@ -1,0 +1,11 @@
+main: creating worker
+main: entering timeout loop to wait for wasm worker to run
+worker_main
+Waiting on address with unexpected value should return 'not-equal'
+Waiting on address with unexpected value should return 'not-equal' also if timeout==0
+Waiting for 0 nanoseconds should return 'timed-out'
+Waiting for >0 nanoseconds should return 'timed-out'
+Waiting for infinitely long should return 'ok'
+main: seen worker running
+main: waking worker
+Test finished

--- a/test/wasm_worker/wait64_notify.c
+++ b/test/wasm_worker/wait64_notify.c
@@ -1,72 +1,96 @@
+#include <emscripten/atomic.h>
+#include <emscripten/html5.h> // for emscripten_performance_now()
 #include <emscripten.h>
-#include <emscripten/wasm_worker.h>
-#include <emscripten/threading.h>
 #include <assert.h>
 
-// Test emscripten_wasm_wait_i64() and emscripten_wasm_notify() functions.
+#ifdef __EMSCRIPTEN_WASM_WORKERS__
+#include <emscripten/wasm_worker.h>
+#else
+#include <pthread.h>
+#endif
+
+// Test emscripten_atomic_wait_u64() and emscripten_atomic_notify() functions.
 
 volatile int64_t addr = 0;
 
-void worker_main()
-{
-  emscripten_console_log("worker_main");
+void run_test() {
+  emscripten_out("worker_main");
   emscripten_atomic_store_u64((void*)&addr, 0x100000000ull);
 
-  emscripten_console_log("Waiting on address with unexpected value should return 'not-equal'");
-  ATOMICS_WAIT_RESULT_T ret = emscripten_wasm_wait_i64((int64_t*)&addr, 0x200000000ull, /*timeout=*/-1);
+  emscripten_out("Waiting on address with unexpected value should return 'not-equal'");
+  ATOMICS_WAIT_RESULT_T ret = emscripten_atomic_wait_u64((int64_t*)&addr, 0x200000000ull, /*timeout=*/-1);
   assert(ret == ATOMICS_WAIT_NOT_EQUAL);
 
-  emscripten_console_log("Waiting on address with unexpected value should return 'not-equal' also if timeout==0");
-  ret = emscripten_wasm_wait_i64((int64_t*)&addr, 0x200000000ull, /*timeout=*/0);
+  emscripten_out("Waiting on address with unexpected value should return 'not-equal' also if timeout==0");
+  ret = emscripten_atomic_wait_u64((int64_t*)&addr, 0x200000000ull, /*timeout=*/0);
   assert(ret == ATOMICS_WAIT_NOT_EQUAL);
 
-  emscripten_console_log("Waiting for 0 nanoseconds should return 'timed-out'");
-  ret = emscripten_wasm_wait_i64((int64_t*)&addr, 0x100000000ull, /*timeout=*/0);
+  emscripten_out("Waiting for 0 nanoseconds should return 'timed-out'");
+  ret = emscripten_atomic_wait_u64((int64_t*)&addr, 0x100000000ull, /*timeout=*/0);
   assert(ret == ATOMICS_WAIT_TIMED_OUT);
 
-  emscripten_console_log("Waiting for >0 nanoseconds should return 'timed-out'");
-  ret = emscripten_wasm_wait_i64((int64_t*)&addr, 0x100000000ull, /*timeout=*/1000);
+  emscripten_out("Waiting for >0 nanoseconds should return 'timed-out'");
+  ret = emscripten_atomic_wait_u64((int64_t*)&addr, 0x100000000ull, /*timeout=*/1000);
   assert(ret == ATOMICS_WAIT_TIMED_OUT);
 
-  emscripten_console_log("Waiting for infinitely long should return 'ok'");
-  ret = emscripten_wasm_wait_i64((int64_t*)&addr, 0x100000000ull, /*timeout=*/-1);
+  emscripten_out("Waiting for infinitely long should return 'ok'");
+  ret = emscripten_atomic_wait_u64((int64_t*)&addr, 0x100000000ull, /*timeout=*/-1);
   assert(ret == ATOMICS_WAIT_OK);
 
-  emscripten_console_log("Test finished");
+  emscripten_out("Test finished");
+}
 
+
+// This test run in both wasm workers and pthreads mode
+#ifdef __EMSCRIPTEN_WASM_WORKERS__
+
+char stack[1024];
+
+void worker_main() {
+  run_test();
 #ifdef REPORT_RESULT
   REPORT_RESULT(addr >> 32);
 #endif
 }
 
-char stack[1024];
+#else
 
-EM_BOOL main_loop(double time, void *userData)
-{
-  if (addr == 0x100000000ull)
-  {
+pthread_t t;
+
+void* thread_main(void* arg) {
+  run_test();
+  return 0;
+}
+
+#endif
+
+EM_BOOL main_loop(double time, void *userData) {
+  if (addr == 0x100000000ull) {
     // Burn one second to make sure worker finishes its test.
-    emscripten_console_log("main: seen worker running");
+    emscripten_out("main: seen worker running");
     double t0 = emscripten_performance_now();
     while(emscripten_performance_now() < t0 + 1000);
 
     // Wake the waiter
-    emscripten_console_log("main: waking worker");
+    emscripten_out("main: waking worker");
     addr = 0x200000000ull;
-    emscripten_wasm_notify((int32_t*)&addr, 1);
+    emscripten_atomic_notify((int32_t*)&addr, 1);
 
     return EM_FALSE;
   }
   return EM_TRUE;
 }
 
-int main()
-{
-  emscripten_console_log("main: creating worker");
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
-  emscripten_console_log("main: posting function");
-  emscripten_wasm_worker_post_function_v(worker, worker_main);
+int main() {
+  emscripten_out("main: creating worker");
 
-  emscripten_console_log("main: entering timeout loop to wait for wasm worker to run");
-  emscripten_set_timeout_loop(main_loop, 1000, 0);
+#ifdef __EMSCRIPTEN_WASM_WORKERS__
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
+  emscripten_wasm_worker_post_function_v(worker, worker_main);
+#else
+  pthread_create(&t, NULL, thread_main, NULL);
+#endif
+
+  emscripten_out("main: entering timeout loop to wait for wasm worker to run");
+  emscripten_set_timeout_loop(main_loop, 50, 0);
 }

--- a/test/wasm_worker/wait64_notify.out
+++ b/test/wasm_worker/wait64_notify.out
@@ -1,0 +1,10 @@
+main: creating worker
+main: entering timeout loop to wait for wasm worker to run
+worker_main
+Waiting on address with unexpected value should return 'not-equal'
+Waiting on address with unexpected value should return 'not-equal' also if timeout==0
+Waiting for 0 nanoseconds should return 'timed-out'
+Waiting for >0 nanoseconds should return 'timed-out'
+Waiting for infinitely long should return 'ok'
+main: seen worker running
+main: waking worker

--- a/test/wasm_worker/wait_async.c
+++ b/test/wasm_worker/wait_async.c
@@ -3,7 +3,7 @@
 #include <emscripten/threading.h>
 #include <assert.h>
 
-// Test emscripten_wasm_wait_i64() and emscripten_wasm_notify() functions.
+// Test emscripten_atomic_wait_u64() and emscripten_atomic_notify() functions.
 
 volatile int32_t addr = 0;
 
@@ -14,7 +14,7 @@ void worker_main()
   emscripten_console_log("worker: addr = 1234");
   emscripten_atomic_store_u32((void*)&addr, 1234);
   emscripten_console_log("worker: notify async waiting main thread");
-  emscripten_wasm_notify((int32_t*)&addr, 1);
+  emscripten_atomic_notify((int32_t*)&addr, 1);
 }
 
 


### PR DESCRIPTION
Also, rename them from `emscripten_wasm_xx` to `emscripten_atomic_xx` to match the other functions in this file (and the
`emscripten_atomic_wait_async` functions which I've leaving in `wasm_workers.h` for now, but will likely move in a followup).

In addition to moving these functions I've also added tests for using them in pthreads (based on the existing wasm worker tests).

We should also probably move `emscripten_atomics_is_lock_free` but that can also be a followup.