### PR TITLE
embind: Fix TS generation with simd enabled.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3247,12 +3247,13 @@ def phase_embind_emit_tsd(options, in_wasm, wasm_target, memfile, js_syms):
   embind_index = settings.JS_LIBRARIES.index('embind/embind.js')
   settings.JS_LIBRARIES[embind_index] = 'embind/embind_ts.js'
 
-  outfile_js = os.path.join(os.path.dirname(wasm_target), 'tsgen_a.out.js')
-  emscripten.run(in_wasm, wasm_target, outfile_js, memfile, js_syms)
+  outfile_js = in_temp('tsgen_a.out.js')
+  # The Wasm outfile may be modified by emscripten.run, so use a temporary file.
+  outfile_wasm = in_temp('tsgen_a.out.wasm')
+  emscripten.run(in_wasm, outfile_wasm, outfile_js, memfile, js_syms)
   out = shared.run_js_tool(outfile_js, [], stdout=PIPE)
   write_file(
     os.path.join(os.path.dirname(wasm_target), options.embind_emit_tsd), out)
-  delete_file(outfile_js)
   settings.restore(original_settings)
 
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2939,7 +2939,8 @@ int f() {
                   '-sENVIRONMENT=worker',
                   '--use-preload-cache',
                   '--preload-file', 'fail.js',
-                  '-O3']
+                  '-O3',
+                  '-msimd128']
     self.run_process([EMCC, test_file('other/embind_tsgen.cpp'),
                       '-lembind', '--embind-emit-tsd', 'embind_tsgen.d.ts'] + extra_args)
     # Test these args separately since they conflict with arguments in the first test.


### PR DESCRIPTION
With simd enabled `emscripten.run` was stripping out feature information
from the wasm file. That file was then used later, but with the missing
feature information it failed to detect that simd was enabled.