### PR TITLE
Wrap Emscripten stuff with #ifdef __EMSCRIPTEN__ in libcxxabi

### DIFF
--- a/system/lib/libcxxabi/src/cxa_exception.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception.cpp
@@ -640,7 +640,7 @@ void __cxa_rethrow() {
     }
 #ifdef __USING_SJLJ_EXCEPTIONS__
     _Unwind_SjLj_RaiseException(&exception_header->unwindHeader);
-#elif defined(__EMSCRIPTEN_) && defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
+#elif defined(__EMSCRIPTEN__) && defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
     // In debug mode, call a JS library function to use WebAssembly.Exception JS
     // API, which enables us to include stack traces
     __throw_exception_with_stack_trace(&exception_header->unwindHeader);

--- a/system/lib/libcxxabi/src/cxa_exception.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception.cpp
@@ -254,7 +254,7 @@ will call terminate, assuming that there was no handler for the
 exception.
 */
 
-#if defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
+#if defined(__EMSCRIPTEN__) && defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
 extern "C" {
 void __throw_exception_with_stack_trace(_Unwind_Exception*);
 } // extern "C"
@@ -287,7 +287,7 @@ __cxa_throw(void *thrown_object, std::type_info *tinfo, void (_LIBCXXABI_DTOR_FU
 
 #ifdef __USING_SJLJ_EXCEPTIONS__
     _Unwind_SjLj_RaiseException(&exception_header->unwindHeader);
-#elif defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
+#elif defined(__EMSCRIPTEN__) && defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
     // In debug mode, call a JS library function to use WebAssembly.Exception JS
     // API, which enables us to include stack traces
     __throw_exception_with_stack_trace(&exception_header->unwindHeader);
@@ -640,7 +640,7 @@ void __cxa_rethrow() {
     }
 #ifdef __USING_SJLJ_EXCEPTIONS__
     _Unwind_SjLj_RaiseException(&exception_header->unwindHeader);
-#elif defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
+#elif defined(__EMSCRIPTEN_) && defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
     // In debug mode, call a JS library function to use WebAssembly.Exception JS
     // API, which enables us to include stack traces
     __throw_exception_with_stack_trace(&exception_header->unwindHeader);
@@ -769,7 +769,7 @@ __cxa_rethrow_primary_exception(void* thrown_object)
         dep_exception_header->unwindHeader.exception_cleanup = dependent_exception_cleanup;
 #ifdef __USING_SJLJ_EXCEPTIONS__
         _Unwind_SjLj_RaiseException(&dep_exception_header->unwindHeader);
-#elif defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
+#elif defined(__EMSCRIPTEN__) && defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
         // In debug mode, call a JS library function to use
         // WebAssembly.Exception JS API, which enables us to include stack
         // traces

--- a/system/lib/libcxxabi/src/cxa_exception_emscripten.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception_emscripten.cpp
@@ -11,6 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifdef __EMSCRIPTEN__
+
 #include "cxxabi.h"
 #include "cxa_exception.h"
 #include "include/atomic_support.h"
@@ -153,3 +155,5 @@ void __cxa_decrement_exception_refcount(void *thrown_object) throw() {
 }  // extern "C"
 
 }  // abi
+
+#endif // __EMSCRIPTEN__

--- a/system/lib/libcxxabi/src/cxa_exception_js_utils.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception_js_utils.cpp
@@ -1,3 +1,5 @@
+#ifdef __EMSCRIPTEN__
+
 #include "cxxabi.h"
 
 #include "cxa_exception.h"
@@ -103,3 +105,5 @@ char* __get_exception_terminate_message(void* thrown_object) {
 } // extern "C"
 
 } // namespace __cxxabiv1
+
+#endif // __EMSCRIPTEN__


### PR DESCRIPTION
This wraps more Emscripten-only stuff with `#ifdef __EMSCRIPTEN__`, for example, JS-interacting code.