### PR TITLE
[EH] Move call to __throw_exception_with_stack_trace to libunwind (NFC)

### DIFF
--- a/system/lib/libcxxabi/src/cxa_exception.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception.cpp
@@ -287,10 +287,6 @@ __cxa_throw(void *thrown_object, std::type_info *tinfo, void (_LIBCXXABI_DTOR_FU
 
 #ifdef __USING_SJLJ_EXCEPTIONS__
     _Unwind_SjLj_RaiseException(&exception_header->unwindHeader);
-#elif defined(__EMSCRIPTEN__) && defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
-    // In debug mode, call a JS library function to use WebAssembly.Exception JS
-    // API, which enables us to include stack traces
-    __throw_exception_with_stack_trace(&exception_header->unwindHeader);
 #else
     _Unwind_RaiseException(&exception_header->unwindHeader);
 #endif
@@ -640,10 +636,6 @@ void __cxa_rethrow() {
     }
 #ifdef __USING_SJLJ_EXCEPTIONS__
     _Unwind_SjLj_RaiseException(&exception_header->unwindHeader);
-#elif defined(__EMSCRIPTEN__) && defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
-    // In debug mode, call a JS library function to use WebAssembly.Exception JS
-    // API, which enables us to include stack traces
-    __throw_exception_with_stack_trace(&exception_header->unwindHeader);
 #else
     _Unwind_RaiseException(&exception_header->unwindHeader);
 #endif
@@ -769,11 +761,6 @@ __cxa_rethrow_primary_exception(void* thrown_object)
         dep_exception_header->unwindHeader.exception_cleanup = dependent_exception_cleanup;
 #ifdef __USING_SJLJ_EXCEPTIONS__
         _Unwind_SjLj_RaiseException(&dep_exception_header->unwindHeader);
-#elif defined(__EMSCRIPTEN__) && defined(__USING_WASM_EXCEPTIONS__) && !defined(NDEBUG)
-        // In debug mode, call a JS library function to use
-        // WebAssembly.Exception JS API, which enables us to include stack
-        // traces
-        __throw_exception_with_stack_trace(&exception_header->unwindHeader);
 #else
         _Unwind_RaiseException(&exception_header->unwindHeader);
 #endif

--- a/system/lib/libunwind/src/Unwind-wasm.c
+++ b/system/lib/libunwind/src/Unwind-wasm.c
@@ -66,7 +66,7 @@ _Unwind_RaiseException(_Unwind_Exception *exception_object) {
 #if defined(__EMSCRIPTEN__) && !defined(NDEBUG)
   // In debug mode, call a JS library function to use WebAssembly.Exception JS
   // API, which enables us to include stack traces
-  __throw_exception_with_stack_trace(&exception_header->unwindHeader);
+  __throw_exception_with_stack_trace(exception_object);
 #else
   // Use Wasm EH's 'throw' instruction.
   __builtin_wasm_throw(0, exception_object);

--- a/system/lib/libunwind/src/Unwind-wasm.c
+++ b/system/lib/libunwind/src/Unwind-wasm.c
@@ -63,8 +63,14 @@ _LIBUNWIND_EXPORT _Unwind_Reason_Code
 _Unwind_RaiseException(_Unwind_Exception *exception_object) {
   _LIBUNWIND_TRACE_API("_Unwind_RaiseException(exception_object=%p)",
                        (void *)exception_object);
+#if defined(__EMSCRIPTEN__) && !defined(NDEBUG)
+  // In debug mode, call a JS library function to use WebAssembly.Exception JS
+  // API, which enables us to include stack traces
+  __throw_exception_with_stack_trace(&exception_header->unwindHeader);
+#else
   // Use Wasm EH's 'throw' instruction.
   __builtin_wasm_throw(0, exception_object);
+#endif
 }
 
 /// Called by __cxa_end_catch.


### PR DESCRIPTION
We've been using a series of `ifdef`s to figure out whether we should call `_Unwind_RaiseException` or `__throw_exception_with_stack_trace` in libcxxabi now, and it was [suggested](https://github.com/emscripten-core/emscripten/pull/20372#discussion_r1343245981) this be moved into libunwind to reduce the repetition.