### PR TITLE
embind: Fix tsgen when embind is linked multiple times.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3243,6 +3243,8 @@ def phase_embind_emit_tsd(options, in_wasm, wasm_target, memfile, js_syms):
   # import names.
   settings.MINIFY_WASM_IMPORTED_MODULES = False
   setup_environment_settings()
+  # Embind may be included multiple times, de-duplicate the list first.
+  settings.JS_LIBRARIES = dedup_list(settings.JS_LIBRARIES)
   # Replace embind with the TypeScript generation version.
   embind_index = settings.JS_LIBRARIES.index('embind/embind.js')
   settings.JS_LIBRARIES[embind_index] = 'embind/embind_ts.js'

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2940,9 +2940,12 @@ int f() {
                   '--use-preload-cache',
                   '--preload-file', 'fail.js',
                   '-O3',
-                  '-msimd128']
+                  '-msimd128',
+                  '-lembind', # Test duplicated link option.
+                  ]
     self.run_process([EMCC, test_file('other/embind_tsgen.cpp'),
                       '-lembind', '--embind-emit-tsd', 'embind_tsgen.d.ts'] + extra_args)
+    self.assertFileContents(test_file('other/embind_tsgen.d.ts'), read_file('embind_tsgen.d.ts'))
     # Test these args separately since they conflict with arguments in the first test.
     extra_args = ['-sMODULARIZE',
                   '--embed-file', 'fail.js',
@@ -2950,6 +2953,7 @@ int f() {
                   '-sEXPORT_ES6=1']
     self.run_process([EMCC, test_file('other/embind_tsgen.cpp'),
                       '-lembind', '--embind-emit-tsd', 'embind_tsgen.d.ts'] + extra_args)
+    self.assertFileContents(test_file('other/embind_tsgen.d.ts'), read_file('embind_tsgen.d.ts'))
 
   def test_embind_tsgen_test_embind(self):
     self.run_process([EMCC, test_file('embind/embind_test.cpp'),


### PR DESCRIPTION
When embind was linked multiple times the js file would be included multiple times and regular embind library would override the instrumented version causing an empty TS file to be created.