### PR TITLE
[test] Fix flakiness in test_pthread_wait32/64_notify

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5296,12 +5296,12 @@ Module["preRun"] = () => {
   # Tests emscripten_atomic_wait_u32() and emscripten_atomic_notify() functions.
   @also_with_minimal_runtime
   def test_wasm_worker_wait32_notify(self):
-    self.btest('wasm_worker/wait32_notify.c', expected='2', args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/wait32_notify.c', expected='3', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_wait_u64() and emscripten_atomic_notify() functions.
   @also_with_minimal_runtime
   def test_wasm_worker_wait64_notify(self):
-    self.btest('wasm_worker/wait64_notify.c', expected='2', args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/wait64_notify.c', expected='3', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_wait_async() function.
   @also_with_minimal_runtime

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2923,11 +2923,13 @@ The current type of b is: 9
 
   @node_pthreads
   def test_pthread_wait32_notify(self):
+    self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test(test_file('wasm_worker/wait32_notify.c'))
 
   @node_pthreads
   @no_wasm2js('https://github.com/WebAssembly/binaryen/issues/5991')
   def test_pthread_wait64_notify(self):
+    self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test(test_file('wasm_worker/wait64_notify.c'))
 
   def test_tcgetattr(self):

--- a/test/wasm_worker/wait64_notify.c
+++ b/test/wasm_worker/wait64_notify.c
@@ -34,7 +34,8 @@ void run_test() {
   assert(ret == ATOMICS_WAIT_TIMED_OUT);
 
   emscripten_out("Waiting for infinitely long should return 'ok'");
-  ret = emscripten_atomic_wait_u64((int64_t*)&addr, 0x100000000ull, /*timeout=*/-1);
+  emscripten_atomic_store_u64((void*)&addr, 0x300000000ull);
+  ret = emscripten_atomic_wait_u64((int64_t*)&addr, 0x300000000ull, /*timeout=*/-1);
   assert(ret == ATOMICS_WAIT_OK);
 
   emscripten_out("Test finished");
@@ -65,7 +66,7 @@ void* thread_main(void* arg) {
 #endif
 
 EM_BOOL main_loop(double time, void *userData) {
-  if (addr == 0x100000000ull) {
+  if (addr == 0x300000000ull) {
     // Burn one second to make sure worker finishes its test.
     emscripten_out("main: seen worker running");
     double t0 = emscripten_performance_now();
@@ -73,7 +74,6 @@ EM_BOOL main_loop(double time, void *userData) {
 
     // Wake the waiter
     emscripten_out("main: waking worker");
-    addr = 0x200000000ull;
     emscripten_atomic_notify((int32_t*)&addr, 1);
 
     return EM_FALSE;

--- a/test/wasm_worker/wait64_notify.out
+++ b/test/wasm_worker/wait64_notify.out
@@ -8,3 +8,4 @@ Waiting for >0 nanoseconds should return 'timed-out'
 Waiting for infinitely long should return 'ok'
 main: seen worker running
 main: waking worker
+Test finished


### PR DESCRIPTION
Avoid racing between the main thread and the worker by only triggering the main thread to notify once the workers done printing all its messages.