### PR TITLE
C++20 co_await support for Embind promises

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -41,6 +41,8 @@ See docs/process.md for more on how version tagging works.
   sidestep some of the issues with legacy cmd.exe, but developers must
   explicitly opt-in to running PowerShell scripts in system settings or
   via the `Set-ExecutionPolicy` command. (#20416)
+- `emscripten::val` now supports C++20 `co_await` operator for JavaScript
+  `Promise`s. (#20420)
 
 3.1.47 - 10/09/23
 -----------------

--- a/emscripten.py
+++ b/emscripten.py
@@ -944,6 +944,7 @@ def create_pointer_conversion_wrappers(metadata):
     'stbi_load_from_memory': 'pp_ppp_',
     'emscripten_proxy_finish': '_p',
     'emscripten_proxy_execute_queue': '_p',
+    '_emval_coro_resume': '_pp',
   }
 
   for function in settings.SIGNATURE_CONVERSIONS:

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -339,6 +339,8 @@ sigs = {
   _emval_await__sig: 'pp',
   _emval_call__sig: 'dpppp',
   _emval_call_method__sig: 'dppppp',
+  _emval_coro_make_promise__sig: 'ppp',
+  _emval_coro_suspend__sig: 'vpp',
   _emval_decref__sig: 'vp',
   _emval_delete__sig: 'ipp',
   _emval_equals__sig: 'ipp',

--- a/test/embind/test_val_coro.cpp
+++ b/test/embind/test_val_coro.cpp
@@ -1,0 +1,41 @@
+#include <emscripten.h>
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+#include <assert.h>
+#include <stdexcept>
+
+using namespace emscripten;
+
+EM_JS(EM_VAL, promise_sleep_impl, (int ms, int result), {
+  let promise = new Promise(resolve => setTimeout(resolve, ms, result));
+  let handle = Emval.toHandle(promise);
+  // FIXME. See https://github.com/emscripten-core/emscripten/issues/16975.
+#if __wasm64__
+  handle = BigInt(handle);
+#endif
+  return handle;
+});
+
+val promise_sleep(int ms, int result = 0) {
+  return val::take_ownership(promise_sleep_impl(ms, result));
+}
+
+val asyncCoro() {
+  // check that just sleeping works
+  co_await promise_sleep(1);
+  // check that sleeping and receiving value works
+  val v = co_await promise_sleep(1, 12);
+  assert(v.as<int>() == 12);
+  // check that returning value works (checked by JS in tests)
+  co_return 34;
+}
+
+val throwingCoro() {
+  throw std::runtime_error("error in a coroutine");
+  co_return 56;
+}
+
+EMSCRIPTEN_BINDINGS(test_val_coro) {
+  function("asyncCoro", asyncCoro);
+  function("throwingCoro", throwingCoro);
+}

--- a/test/embind/test_val_coro.cpp
+++ b/test/embind/test_val_coro.cpp
@@ -31,7 +31,7 @@ val asyncCoro() {
 }
 
 val throwingCoro() {
-  throw std::runtime_error("error in a coroutine");
+  throw std::runtime_error("bang from throwingCoro!");
   co_return 56;
 }
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7869,7 +7869,7 @@ void* operator new(size_t size) {
       Module.throwingCoro().then(
         console.log,
         err => console.error(`rejected with: ${err.stack}`)
-      });
+      );
     ''')
     self.emcc_args += ['-std=c++20', '--bind', '--post-js=post.js', '-fexceptions']
     self.do_runf('embind/test_val_coro.cpp', 'rejected with: std::runtime_error: bang from throwingCoro!\n')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7857,15 +7857,22 @@ void* operator new(size_t size) {
     self.do_runf('test_embind_val_cross_thread.cpp')
 
   def test_embind_val_coro(self):
-    create_file('post.js', "Module.onRuntimeInitialized = () => Module.asyncCoro().then(console.log);")
+    create_file('post.js', r'''Module.onRuntimeInitialized = () => {
+      Module.asyncCoro().then(console.log);
+    }''')
     self.emcc_args += ['-std=c++20', '--bind', '--post-js=post.js']
-    self.do_runf(test_file('embind/test_val_coro.cpp'), '34\n')
+    self.do_runf('embind/test_val_coro.cpp', '34\n')
 
   def test_embind_val_coro_caught(self):
     self.set_setting('EXCEPTION_STACK_TRACES')
-    create_file('post.js', "Module.onRuntimeInitialized = () => Module.throwingCoro().then(console.log, err => console.error(`caught: ${err.stack}`));")
+    create_file('post.js', r'''Module.onRuntimeInitialized = () => {
+      Module.throwingCoro().then(
+        console.log,
+        err => console.error(`caught: ${err.stack}`)
+      });
+    ''')
     self.emcc_args += ['-std=c++20', '--bind', '--post-js=post.js', '-fexceptions']
-    self.do_runf(test_file('embind/test_val_coro.cpp'), 'caught: std::runtime_error: error in a coroutine\n')
+    self.do_runf('embind/test_val_coro.cpp', 'caught: std::runtime_error: error in a coroutine\n')
 
   def test_embind_dynamic_initialization(self):
     self.emcc_args += ['-lembind']

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7870,7 +7870,7 @@ void* operator new(size_t size) {
         console.log,
         err => console.error(`rejected with: ${err.stack}`)
       );
-    ''')
+    }''')
     self.emcc_args += ['-std=c++20', '--bind', '--post-js=post.js', '-fexceptions']
     self.do_runf('embind/test_val_coro.cpp', 'rejected with: std::runtime_error: bang from throwingCoro!\n')
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7868,11 +7868,11 @@ void* operator new(size_t size) {
     create_file('post.js', r'''Module.onRuntimeInitialized = () => {
       Module.throwingCoro().then(
         console.log,
-        err => console.error(`caught: ${err.stack}`)
+        err => console.error(`rejected with: ${err.stack}`)
       });
     ''')
     self.emcc_args += ['-std=c++20', '--bind', '--post-js=post.js', '-fexceptions']
-    self.do_runf('embind/test_val_coro.cpp', 'caught: std::runtime_error: error in a coroutine\n')
+    self.do_runf('embind/test_val_coro.cpp', 'rejected with: std::runtime_error: bang from throwingCoro!\n')
 
   def test_embind_dynamic_initialization(self):
     self.emcc_args += ['-lembind']

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7856,6 +7856,17 @@ void* operator new(size_t size) {
     ''')
     self.do_runf('test_embind_val_cross_thread.cpp')
 
+  def test_embind_val_coro(self):
+    create_file('post.js', "Module.onRuntimeInitialized = () => Module.asyncCoro().then(console.log);")
+    self.emcc_args += ['-std=c++20', '--bind', '--post-js=post.js']
+    self.do_runf(test_file('embind/test_val_coro.cpp'), '34\n')
+
+  def test_embind_val_coro_caught(self):
+    self.set_setting('EXCEPTION_STACK_TRACES')
+    create_file('post.js', "Module.onRuntimeInitialized = () => Module.throwingCoro().then(console.log, err => console.error(`caught: ${err.stack}`));")
+    self.emcc_args += ['-std=c++20', '--bind', '--post-js=post.js', '-fexceptions']
+    self.do_runf(test_file('embind/test_val_coro.cpp'), 'caught: std::runtime_error: error in a coroutine\n')
+
   def test_embind_dynamic_initialization(self):
     self.emcc_args += ['-lembind']
     self.do_run_in_out_file_test('embind/test_dynamic_initialization.cpp')

--- a/tools/maint/gen_sig_info.py
+++ b/tools/maint/gen_sig_info.py
@@ -391,7 +391,7 @@ def main(args):
                               'USE_SDL': 0,
                               'MAX_WEBGL_VERSION': 0,
                               'AUTO_JS_LIBRARIES': 0,
-                              'ASYNCIFY': 1}, cxx=True)
+                              'ASYNCIFY': 1}, cxx=True, extra_cflags=['-std=c++20'])
   extract_sig_info(sig_info, {'LEGACY_GL_EMULATION': 1}, ['-DGLES'])
   extract_sig_info(sig_info, {'USE_GLFW': 2, 'FULL_ES3': 1, 'MAX_WEBGL_VERSION': 2})
   extract_sig_info(sig_info, {'STANDALONE_WASM': 1})


### PR DESCRIPTION
This adds support for `co_await`-ing Promises represented by `emscripten::val`.

The surrounding coroutine should also return `emscripten::val`, which will be a promise representing the whole coroutine's return value.

Note that this feature uses LLVM coroutines and so, doesn't depend on either Asyncify or JSPI. It doesn't pause the entire program, but only the coroutine itself, so it serves somewhat different usecases even though all those features operate on promises.

Nevertheless, if you are not implementing a syscall that must behave as-if it was synchronous, but instead simply want to await on some async operations and return a new promise to the user, this feature will be much more efficient.

Here's a simple benchmark measuring runtime overhead from awaiting on a no-op Promise repeatedly in a deep call stack:

```cpp

using namespace emscripten;

// clang-format off
EM_JS(EM_VAL, wait_impl, (), {
  return Emval.toHandle(Promise.resolve());
});
// clang-format on

val wait() { return val::take_ownership(wait_impl()); }

val coro_co_await(int depth) {
  co_await wait();
  if (depth > 0) {
    co_await coro_co_await(depth - 1);
  }
  co_return val();
}

val asyncify_val_await(int depth) {
  wait().await();
  if (depth > 0) {
    asyncify_val_await(depth - 1);
  }
  return val();
}

EMSCRIPTEN_BINDINGS(bench) {
  function("coro_co_await", coro_co_await);
  function("asyncify_val_await", asyncify_val_await, async());
}
```

And the JS runner also comparing with pure-JS implementation:

```js
import Benchmark from 'benchmark';
import initModule from './async-bench.mjs';

let Module = await initModule();
let suite = new Benchmark.Suite();

function addAsyncBench(name, func) {
	suite.add(name, {
		defer: true,
		fn: (deferred) => func(1000).then(() => deferred.resolve()),
	});
}

for (const name of ['coro_co_await', 'asyncify_val_await']) {
  addAsyncBench(name, Module[name]);
}

addAsyncBench('pure_js', async function pure_js(depth) {
  await Promise.resolve();
  if (depth > 0) {
    await pure_js(depth - 1);
  }
});

suite
  .on('cycle', function (event) {
    console.log(String(event.target));
  })
  .run({async: true});
```

Results with regular Asyncify (I had to bump up `ASYNCIFY_STACK_SIZE` to accomodate said deep stack):

```bash
> ./emcc async-bench.cpp -std=c++20 -O3 -o async-bench.mjs --bind -s ASYNCIFY -s ASYNCIFY_STACK_SIZE=1000000
> node --no-liftoff --no-wasm-tier-up --no-wasm-lazy-compilation --no-sparkplug async-bench-runner.mjs

coro_co_await x 727 ops/sec ±10.59% (47 runs sampled)
asyncify_val_await x 58.05 ops/sec ±6.91% (53 runs sampled)
pure_js x 3,022 ops/sec ±8.06% (52 runs sampled)
```

Results with JSPI (I had to disable `DYNAMIC_EXECUTION` because I was getting `RuntimeError: table index is out of bounds` in random places depending on optimisation mode - JSPI miscompilation?):

```bash
> ./emcc async-bench.cpp -std=c++20 -O3 -o async-bench.mjs --bind -s ASYNCIFY=2 -s DYNAMIC_EXECUTION=0
> node --no-liftoff --no-wasm-tier-up --no-wasm-lazy-compilation --no-sparkplug --experimental-wasm-stack-switching async-bench-runner.mjs

coro_co_await x 955 ops/sec ±9.25% (62 runs sampled)
asyncify_val_await x 924 ops/sec ±8.27% (62 runs sampled)
pure_js x 3,258 ops/sec ±8.98% (53 runs sampled)
```

So the performance is much faster than regular Asyncify, and on par with JSPI.

Fixes #20413.