### PR TITLE
Fix returning EM_VAL in wasm64 mode

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -72,12 +72,13 @@ var LibraryEmVal = {
 
     toHandle: (value) => {
       switch (value) {
-        case undefined: return 1;
-        case null: return 2;
-        case true: return 3;
-        case false: return 4;
+        case undefined: return {{{ to64(1) }}};
+        case null: return {{{ to64(2) }}};
+        case true: return {{{ to64(3) }}};
+        case false: return {{{ to64(4) }}};
         default:{
-          return emval_handles.allocate({refcount: 1, value: value});
+          let id = emval_handles.allocate({refcount: 1, value: value});
+          return {{{ to64('id') }}};
         }
       }
     }

--- a/test/embind/test_val.cpp
+++ b/test/embind/test_val.cpp
@@ -39,6 +39,10 @@ EMSCRIPTEN_BINDINGS(test_bindings) {
   emscripten::function("makeDummy", &makeDummy, emscripten::allow_raw_pointers());
 }
 
+EM_JS(EM_VAL, roundtrip, (EM_VAL v), {
+  return Emval.toHandle(Emval.toValue(v));
+});
+
 int main() {
   printf("start\n");
 
@@ -108,12 +112,19 @@ int main() {
   val::global().set("a", val::object());
   ensure_js("a instanceof Object");
 
-  // Test emval{From,To}Handle roundtrip.
+  test("emval{From,To}Handle roundtrip via EM_ASM");
   {
     val a = val::global("a");
     val a_roundtrip = val::take_ownership(EM_VAL(EM_ASM_PTR({
       return Emval.toHandle(Emval.toValue($0));
     }, a.as_handle())));
+    ensure(a == a_roundtrip);
+  }
+
+  test("emval{From,To}Handle roundtrip via EM_JS");
+  {
+    val a = val::global("a");
+    val a_roundtrip = val::take_ownership(roundtrip(a.as_handle()));
     ensure(a == a_roundtrip);
   }
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13996,3 +13996,22 @@ addToLibrary({
 ''')
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js', '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=foo'])
     self.assertContained('error: noExitRuntime cannot be referenced via __deps mechansim', err)
+
+  @also_with_wasm64
+  def test_return_emval(self):
+    create_file('test.cpp', r'''
+    #include <emscripten.h>
+    #include <emscripten/val.h>
+
+    using namespace emscripten;
+
+    EM_JS(EM_VAL, get_val, (), {
+      return Emval.toHandle(0);
+    });
+
+    int main() {
+      return val::take_ownership(get_val()).as<int>();
+    }
+    ''')
+    self.emcc_args += ['--bind']
+    self.do_runf('test.cpp')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13996,22 +13996,3 @@ addToLibrary({
 ''')
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js', '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=foo'])
     self.assertContained('error: noExitRuntime cannot be referenced via __deps mechansim', err)
-
-  @also_with_wasm64
-  def test_return_emval(self):
-    create_file('test.cpp', r'''
-    #include <emscripten.h>
-    #include <emscripten/val.h>
-
-    using namespace emscripten;
-
-    EM_JS(EM_VAL, get_val, (), {
-      return Emval.toHandle(0);
-    });
-
-    int main() {
-      return val::take_ownership(get_val()).as<int>();
-    }
-    ''')
-    self.emcc_args += ['--bind']
-    self.do_runf('test.cpp')


### PR DESCRIPTION
I suspect other handles in other parts of the codebase will suffer from the same problem, so maybe this conversion needs to be done in `HandleAllocator::allocate` or somewhere higher up instead, but for now trying to keep it scoped and fixing just for emval.