### PR TITLE
[acorn-optimizer] Don't ignore usages in default arguments

### DIFF
--- a/test/hello_world_argv.c
+++ b/test/hello_world_argv.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2023 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+  printf("hello, world! (%d)\n", argc);
+  return 0;
+}

--- a/test/optimizer/JSDCE-defaultArg-output.js
+++ b/test/optimizer/JSDCE-defaultArg-output.js
@@ -1,0 +1,7 @@
+var usedAsDefaultArg = 42;
+
+function g(a, b = usedAsDefaultArg) {
+ return a + b + 1;
+}
+
+Module["g"] = g;

--- a/test/optimizer/JSDCE-defaultArg.js
+++ b/test/optimizer/JSDCE-defaultArg.js
@@ -1,0 +1,9 @@
+var usedAsDefaultArg = 42;
+var notUsed = 43;
+
+// exported
+function g(a, b = usedAsDefaultArg) {
+  return a+b+1;
+}
+
+Module['g'] = g;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2502,6 +2502,7 @@ int f() {
     'minifyLocals': ('optimizer/test-js-optimizer-minifyLocals.js', ['minifyLocals']),
     'JSDCE': ('optimizer/JSDCE.js', ['JSDCE']),
     'JSDCE-hasOwnProperty': ('optimizer/JSDCE-hasOwnProperty.js', ['JSDCE']),
+    'JSDCE-defaultArg': ('optimizer/JSDCE-defaultArg.js', ['JSDCE']),
     'JSDCE-fors': ('optimizer/JSDCE-fors.js', ['JSDCE']),
     'JSDCE-objectPattern': ('optimizer/JSDCE-objectPattern.js', ['JSDCE']),
     'AJSDCE': ('optimizer/AJSDCE.js', ['AJSDCE']),
@@ -14008,3 +14009,9 @@ addToLibrary({
 ''')
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js', '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=foo'])
     self.assertContained('error: noExitRuntime cannot be referenced via __deps mechansim', err)
+
+  def test_hello_world_argv(self):
+    self.do_runf(test_file('hello_world_argv.c'), 'hello, world! (1)')
+
+  def test_arguments_global(self):
+    self.emcc(test_file('hello_world_argv.c'), ['-sENVIRONMENT=web', '-sSTRICT', '--closure=1', '-O2'])

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -370,12 +370,20 @@ function runJSDCE(ast, aggressive) {
         ensureData(scopes[scopes.length - 1], node.id.name).def = 1;
       }
       const scope = {};
+      scopes.push(scope);
       node.params.forEach((param) => {
+        if (param.type === 'RestElement') {
+          param = param.argument;
+        }
+        if (param.type === 'AssignmentPattern') {
+          c(param.right);
+          param = param.left;
+        }
+        assert(param.type === 'Identifier', param.type);
         const name = param.name;
         ensureData(scope, name).def = 1;
         scope[name].param = 1;
       });
-      scopes.push(scope);
       c(node.body);
       // we can ignore self-references, i.e., references to ourselves inside
       // ourselves, for named defined (defun) functions


### PR DESCRIPTION
This includes a unit test and real world test based on a user reported issue where `function run(args = arguments_)` was failing to keep the `arguments_` global alive.