### PR TITLE
Warn if python scripts are not run via launcher scripts

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/em++
+++ b/em++
@@ -32,6 +32,7 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 if [ -z "$_EMCC_CCACHE" ]; then
   exec "$PYTHON" -E "$0.py" "$@"
 else

--- a/em++.bat
+++ b/em++.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/em-config
+++ b/em-config
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/em-config.bat
+++ b/em-config.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emar
+++ b/emar
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/emar.bat
+++ b/emar.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/embuilder
+++ b/embuilder
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/embuilder.bat
+++ b/embuilder.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emcc
+++ b/emcc
@@ -32,6 +32,7 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 if [ -z "$_EMCC_CCACHE" ]; then
   exec "$PYTHON" -E "$0.py" "$@"
 else

--- a/emcc.bat
+++ b/emcc.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emcmake
+++ b/emcmake
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/emcmake.bat
+++ b/emcmake.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emconfigure
+++ b/emconfigure
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/emconfigure.bat
+++ b/emconfigure.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emdump
+++ b/emdump
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$(dirname $0)/tools/emdump.py" "$@"

--- a/emdump.bat
+++ b/emdump.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emdwp
+++ b/emdwp
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$(dirname $0)/tools/emdwp.py" "$@"

--- a/emdwp.bat
+++ b/emdwp.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emmake
+++ b/emmake
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/emmake.bat
+++ b/emmake.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emnm
+++ b/emnm
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$(dirname $0)/tools/emnm.py" "$@"

--- a/emnm.bat
+++ b/emnm.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emprofile
+++ b/emprofile
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$(dirname $0)/tools/emprofile.py" "$@"

--- a/emprofile.bat
+++ b/emprofile.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emranlib
+++ b/emranlib
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/emranlib.bat
+++ b/emranlib.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emrun
+++ b/emrun
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/emrun.bat
+++ b/emrun.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emscons
+++ b/emscons
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/emscons.bat
+++ b/emscons.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emsize
+++ b/emsize
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/emsize.bat
+++ b/emsize.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emstrip
+++ b/emstrip
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/emstrip.bat
+++ b/emstrip.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/emsymbolizer
+++ b/emsymbolizer
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/emsymbolizer.bat
+++ b/emsymbolizer.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/system/bin/sdl-config
+++ b/system/bin/sdl-config
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/system/bin/sdl-config.bat
+++ b/system/bin/sdl-config.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/system/bin/sdl2-config
+++ b/system/bin/sdl2-config
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/system/bin/sdl2-config.bat
+++ b/system/bin/sdl2-config.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/test/runner
+++ b/test/runner
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/test/runner.bat
+++ b/test/runner.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/tools/file_packager
+++ b/tools/file_packager
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/tools/file_packager.bat
+++ b/tools/file_packager.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/tools/run_python.bat
+++ b/tools/run_python.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/tools/run_python.sh
+++ b/tools/run_python.sh
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/tools/run_python_compiler.bat
+++ b/tools/run_python_compiler.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal

--- a/tools/run_python_compiler.sh
+++ b/tools/run_python_compiler.sh
@@ -32,6 +32,7 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 if [ -z "$_EMCC_CCACHE" ]; then
   exec "$PYTHON" -E "$0.py" "$@"
 else

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -747,6 +747,10 @@ def get_llvm_target():
 def init():
   set_version_globals()
   setup_temp_dirs()
+  if 'EM_LAUNCHER' not in os.environ:
+    actual = bat_suffix(os.path.basename(sys.argv[0]))
+    launcher = os.path.splitext(actual)[0]
+    diagnostics.warning('unsupported', f'python script (`{actual}`) was run directly rather than run via launcher.  Running via `{launcher}` is recommended')
 
 
 # ============================================================================

--- a/tools/webidl_binder
+++ b/tools/webidl_binder
@@ -32,4 +32,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" -E "$0.py" "$@"

--- a/tools/webidl_binder.bat
+++ b/tools/webidl_binder.bat
@@ -8,6 +8,8 @@
 :: N.b. In Windows .bat scripts, the ':' character cannot appear inside any if () blocks,
 :: or there will be a parsing error.
 
+@set EM_LAUNCHER=1
+
 :: All env. vars specified in this file are to be local only to this script.
 @setlocal
 :: -E will not ignore _PYTHON_SYSCONFIGDATA_NAME an internal


### PR DESCRIPTION
Ideally we would only support a single way to run emscripten scripts. Discouraging the direct running the `.py` files mean we can do things like move the `.py` files or even potentially re-write them in a differently language.