### PR TITLE
Load Workers with {type:'module'} in ESM mode

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -452,10 +452,10 @@ var LibraryPThread = {
               createScriptURL: (ignored) => new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url);
             }
           );
-          worker = new Worker(p.createScriptURL('ignored'));
+          worker = new Worker(p.createScriptURL('ignored'), {type: 'module'});
         } else
 #endif
-        worker = new Worker(new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url));
+        worker = new Worker(new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url), {type: 'module'});
       } else {
 #endif
       // Allow HTML module to configure the location where the 'worker.js' file will be loaded from,
@@ -568,7 +568,7 @@ var LibraryPThread = {
     // Called when a thread needs to be strongly referenced.
     // Currently only used for:
     // - keeping the "main" thread alive in PROXY_TO_PTHREAD mode;
-    // - crashed threads that needs to propagate the uncaught exception 
+    // - crashed threads that needs to propagate the uncaught exception
     //   back to the main thread.
 #if ENVIRONMENT_MAY_BE_NODE
     if (ENVIRONMENT_IS_NODE) {

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -303,7 +303,7 @@ class other(RunnerCore):
                       test_file('hello_world.c')] + args)
     src = read_file('subdir/hello_world.mjs')
     self.assertContained("new URL('hello_world.wasm', import.meta.url)", src)
-    self.assertContained("new Worker(new URL('hello_world.worker.js', import.meta.url))", src)
+    self.assertContained("new Worker(new URL('hello_world.worker.js', import.meta.url), {type: 'module'})", src)
     self.assertContained('export default Module;', src)
     src = read_file('subdir/hello_world.worker.js')
     self.assertContained("import('./hello_world.mjs')", src)
@@ -317,7 +317,7 @@ class other(RunnerCore):
                       test_file('hello_world.c'), '-sSINGLE_FILE'])
     src = read_file('hello_world.mjs')
     self.assertNotContained("new URL('data:", src)
-    self.assertContained("new Worker(new URL('hello_world.worker.js', import.meta.url))", src)
+    self.assertContained("new Worker(new URL('hello_world.worker.js', import.meta.url), {type: 'module'})", src)
     self.assertContained('hello, world!', self.run_js('hello_world.mjs'))
 
   def test_emcc_output_mjs_closure(self):


### PR DESCRIPTION
Even in ESM mode, we use dynamic import to load main code from the Web Worker, so, technically, our Workers dont *have* to be ESM as well - they're compatible with regular script mode too.

Unfortunately, unlike browsers, some bundlers care about the distinction and don't bundle Workers correctly when `new Worker(...)` is used without `{type: 'module'}`. Some recent examples where I've seen this:

- issue with parcel bundler: https://github.com/parcel-bundler/parcel/issues/8727#issuecomment-1747193852
 - issue with esbuild bundler used by popular vite toolchain: https://github.com/GoogleChromeLabs/web-gphoto2/pull/12

In both cases adding `{type: 'module'}` fixes the build.

One difference this change will make is that `{type: 'module'}` forces Worker to be loaded as a module which always runs in strict JS mode.

Our main code should already be compatible with `use strict`, or it wouldn't work as ESM at all, and our `src/worker.js` code has `use strict` at the top, so it's compatible too, so I don't expect any issues, but it's something worth keeping in mind if we get breakage reports.

Also note that older browsers without Module Workers support will ignore `{type: 'module'}` and run Workers in script mode, so as long as we don't use static imports or `import.meta.url` in `src/worker.js`, this is a backward-compatible change.