### PR TITLE
Set autoconf macro search to Emscripten sysroot

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -79,7 +79,7 @@ def get_building_env():
   env['PKG_CONFIG_PATH'] = os.environ.get('EM_PKG_CONFIG_PATH', '')
   env['EMSCRIPTEN'] = path_from_root()
   env['PATH'] = cache.get_sysroot_dir('bin') + os.pathsep + env['PATH']
-  env['ACLOCAL_PATH'] = cache.get_sysroot_dir('share/aclocal') + os.pathsep + env['ACLOCAL_PATH']
+  env['ACLOCAL_PATH'] = cache.get_sysroot_dir('share/aclocal')
   env['CROSS_COMPILE'] = path_from_root('em') # produces /path/to/emscripten/em , which then can have 'cc', 'ar', etc appended to it
   return env
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -79,7 +79,7 @@ def get_building_env():
   env['PKG_CONFIG_PATH'] = os.environ.get('EM_PKG_CONFIG_PATH', '')
   env['EMSCRIPTEN'] = path_from_root()
   env['PATH'] = cache.get_sysroot_dir('bin') + os.pathsep + env['PATH']
-  env['ACLOCAL_PATH'] = cache.get_sysroot_dir('share', 'aclocal') + os.pathsep + env['ACLOCAL_PATH']
+  env['ACLOCAL_PATH'] = cache.get_sysroot_dir('share/aclocal') + os.pathsep + env['ACLOCAL_PATH']
   env['CROSS_COMPILE'] = path_from_root('em') # produces /path/to/emscripten/em , which then can have 'cc', 'ar', etc appended to it
   return env
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -79,6 +79,7 @@ def get_building_env():
   env['PKG_CONFIG_PATH'] = os.environ.get('EM_PKG_CONFIG_PATH', '')
   env['EMSCRIPTEN'] = path_from_root()
   env['PATH'] = cache.get_sysroot_dir('bin') + os.pathsep + env['PATH']
+  env['ACLOCAL_PATH'] = cache.get_sysroot_dir('share', 'aclocal') + os.pathsep + env['ACLOCAL_PATH']
   env['CROSS_COMPILE'] = path_from_root('em') # produces /path/to/emscripten/em , which then can have 'cc', 'ar', etc appended to it
   return env
 


### PR DESCRIPTION
When a library installs .m4 macros that other libs want to find, it will look for them in couple of places: https://www.gnu.org/software/automake/manual/html_node/Macro-Search-Path.html

The simplest option for a custom sysroot seems to be via `ACLOCAL_PATH=(custom sysroot)/share/aclocal`.

I checked that such override works on the libgphoto2 project a while back, and meant to upstream but then it got lost among other branches.