### PR TITLE
Separate out `Atomics.waitAsync` polyfill. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2503,7 +2503,7 @@ def phase_linker_setup(options, state, newargs):
     # set location of Wasm Worker bootstrap JS file
     if settings.WASM_WORKERS == 1:
       settings.WASM_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.ww.js'
-    settings.JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_wasm_worker.js')))
+    settings.JS_LIBRARIES.append((0, 'library_wasm_worker.js'))
 
   # Set min browser versions based on certain settings such as WASM_BIGINT,
   # PTHREADS, AUDIO_WORKLET

--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -244,7 +244,8 @@ if (ENVIRONMENT_IS_WASM_WORKER) {
   // https://github.com/tc39/proposal-atomics-wait-async/blob/master/PROPOSAL.md
   // This polyfill performs polling with setTimeout() to observe a change in the
   // target memory location.
-  emscripten_atomic_wait_async__postset: `if (!Atomics.waitAsync || (typeof navigator !== 'undefined' && navigator.userAgent && jstoi_q((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91)) {
+  $polyfillWaitAsync__deps: ['$jstoi_q'],
+  $polyfillWaitAsync__postset: `if (!Atomics.waitAsync || (typeof navigator !== 'undefined' && navigator.userAgent && jstoi_q((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91)) {
 let __Atomics_waitAsyncAddresses = [/*[i32a, index, value, maxWaitMilliseconds, promiseResolve]*/];
 function __Atomics_pollWaitAsyncAddresses() {
   let now = performance.now();
@@ -279,20 +280,19 @@ Atomics.waitAsync = (i32a, index, value, maxWaitMilliseconds) => {
   return { async: true, value: promise };
 };
 }`,
-
-  // These dependencies are artificial, issued so that we still get the
-  // waitAsync polyfill emitted if code only calls
-  // emscripten_lock/semaphore_async_acquire() but not
-  // emscripten_atomic_wait_async() directly.
-  emscripten_lock_async_acquire__deps: ['emscripten_atomic_wait_async'],
-  emscripten_semaphore_async_acquire__deps: ['emscripten_atomic_wait_async'],
-
 #endif
 
-  $liveAtomicWaitAsyncs: '{}',
-  $liveAtomicWaitAsyncCounter: '0',
+  $polyfillWaitAsync__internal: true,
+  $polyfillWaitAsync: () => {
+    // nop, used for its postset to ensure `Atomics.waitAsync()` polyfill is
+    // included exactly once and only included when needed.
+    // Any function using Atomics.waitAsync should depend on this.
+  },
 
-  emscripten_atomic_wait_async__deps: ['$atomicWaitStates', '$liveAtomicWaitAsyncs', '$liveAtomicWaitAsyncCounter', '$jstoi_q'],
+  $liveAtomicWaitAsyncs: {},
+  $liveAtomicWaitAsyncCounter: 0,
+
+  emscripten_atomic_wait_async__deps: ['$atomicWaitStates', '$liveAtomicWaitAsyncs', '$liveAtomicWaitAsyncCounter', '$polyfillWaitAsync'],
   emscripten_atomic_wait_async: (addr, val, asyncWaitFinished, userData, maxWaitMilliseconds) => {
     let wait = Atomics.waitAsync(HEAP32, {{{ getHeapOffset('addr', 'i32') }}}, val, maxWaitMilliseconds);
     if (!wait.async) return atomicWaitStates.indexOf(wait.value);
@@ -372,6 +372,7 @@ Atomics.waitAsync = (i32a, index, value, maxWaitMilliseconds) => {
     return Atomics.isLockFree(width);
   },
 
+  emscripten_lock_async_acquire__deps: ['$polyfillWaitAsync'],
   emscripten_lock_async_acquire: (lock, asyncWaitFinished, userData, maxWaitMilliseconds) => {
     let dispatch = (val, ret) => {
       setTimeout(() => {
@@ -393,6 +394,7 @@ Atomics.waitAsync = (i32a, index, value, maxWaitMilliseconds) => {
     tryAcquireLock();
   },
 
+  emscripten_semaphore_async_acquire__deps: ['$polyfillWaitAsync'],
   emscripten_semaphore_async_acquire: (sem, num, asyncWaitFinished, userData, maxWaitMilliseconds) => {
     let dispatch = (idx, ret) => {
       setTimeout(() => {


### PR DESCRIPTION
Split out from #20404.

Rather than adding artificial dependencies on
`emscripten_atomic_wait_async` we can use the same technique used by `$polyfillSetImmediate` in `library_eventloop.js`.