### PR TITLE
Add support for -### compiler flag

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -198,7 +198,7 @@ def main():
     settings.LTO = args.lto
 
   if args.verbose:
-    shared.PRINT_STAGES = True
+    shared.PRINT_SUBPROCS = True
 
   if args.pic:
     settings.RELOCATABLE = 1

--- a/emsymbolizer.py
+++ b/emsymbolizer.py
@@ -246,7 +246,7 @@ def get_args():
   parser.add_argument('address', help='Address to lookup')
   args = parser.parse_args()
   if args.verbose:
-    shared.PRINT_STAGES = 1
+    shared.PRINT_SUBPROCS = 1
     shared.DEBUG = True
   return args
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -140,7 +140,7 @@ def get_top_level_ninja_file():
 def run_ninja(build_dir):
   diagnostics.warning('experimental', 'ninja support is experimental')
   cmd = ['ninja', '-C', build_dir, f'-j{shared.get_num_cores()}']
-  if shared.PRINT_STAGES:
+  if shared.PRINT_SUBPROCS:
     cmd.append('-v')
   shared.check_call(cmd, env=clean_env())
 


### PR DESCRIPTION
From the gcc man page:

```
-###
  Like -v except the commands are not executed and arguments are quoted unless they
  contain only alphanumeric characters or "./-_".  This is useful for shell scripts to
  capture the driver-generated command lines.
```

Fixes: #20468
