### PR TITLE
Simplify createNamedFunction. NFC

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -167,18 +167,23 @@ var LibraryEmbind = {
     return errorClass;
   },
 
-
-  $createNamedFunction__deps: ['$makeLegalFunctionName'],
   $createNamedFunction: function(name, body) {
-    name = makeLegalFunctionName(name);
-    // Use an abject with a computed property name to create a new function with
-    // a name specified at runtime, but without using `new Function` or `eval`.
-    return {
-      [name]: function() {
-        return body.apply(this, arguments);
-      }
-    }[name];
+    return Object.defineProperty(body, 'name', {
+      value: name
+    });
   },
+  // All browsers that support WebAssembly also support configurable function name,
+  // but we might be building for very old browsers via WASM2JS.
+#if MIN_CHROME_VERSION < 43 || MIN_EDGE_VERSION < 14 || MIN_SAFARI_VERSION < 100101 || MIN_FIREFOX_VERSION < 38
+  // In that case, check if configurable function name is supported at init time
+  // and, if not, replace with a fallback that returns function as-is as those browsers
+  // don't support other methods either.
+  $createNamedFunction__postset: `
+    if (!Object.getOwnPropertyDescriptor(Function.prototype, 'name').configurable) {
+      createNamedFunction = (name, body) => body;
+    }
+  `,
+#endif
 
   $embindRepr: (v) => {
     if (v === null) {


### PR DESCRIPTION
Slight improvement of createNamedFunction on top of #18748: we can avoid extra JS trampoline by setting `name` of the function directly.

This is only supported via "configuring" it by `Object.defineProperty` rather than plain assignment, but otherwise has exactly same effect - it sets debug name of the function in-place.

Also, ever since #18748 switched away from `eval`, there is no requirement for the function name to be "legal" - we can set it to the plain demangled string, making debug names even more readable.