### PR TITLE
Replace deprecated intrinsics in simd.rst

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -426,13 +426,13 @@ The following table highlights the availability and expected performance of diff
    * - _mm_add_sd
      - ⚠️ emulated with a shuffle
    * - _mm_adds_epi16
-     - ✅ wasm_i16x8_add_saturate
+     - ✅ wasm_i16x8_add_sat
    * - _mm_adds_epi8
-     - ✅ wasm_i8x16_add_saturate
+     - ✅ wasm_i8x16_add_sat
    * - _mm_adds_epu16
-     - ✅ wasm_u16x8_add_saturate
+     - ✅ wasm_u16x8_add_sat
    * - _mm_adds_epu8
-     - ✅ wasm_u8x16_add_saturate
+     - ✅ wasm_u8x16_add_sat
    * - _mm_and_pd
      - 🟡 wasm_v128_and. VM must guess type.
    * - _mm_and_si128
@@ -804,13 +804,13 @@ The following table highlights the availability and expected performance of diff
    * - _mm_sub_sd
      - ⚠️ emulated with a shuffle
    * - _mm_subs_epi16
-     - ✅ wasm_i16x8_sub_saturate
+     - ✅ wasm_i16x8_sub_sat
    * - _mm_subs_epi8
-     - ✅ wasm_i8x16_sub_saturate
+     - ✅ wasm_i8x16_sub_sat
    * - _mm_subs_epu16
-     - ✅ wasm_u16x8_sub_saturate
+     - ✅ wasm_u16x8_sub_sat
    * - _mm_subs_epu8
-     - ✅ wasm_u8x16_sub_saturate
+     - ✅ wasm_u8x16_sub_sat
    * - _mm_ucomieq_sd
      - ❌ scalarized
    * - _mm_ucomige_sd


### PR DESCRIPTION
Use the non-deprecated intrinsic names instead.

Fixes #20482.