### PR TITLE
s/PipelineStatisticsQuery/ChromiumExperimentalPipelineStatisticsQuery/g

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -400,7 +400,7 @@ var LibraryWebGPU = {
       'depth-clip-control',
       'depth32float-stencil8',
       'timestamp-query',
-      'pipeline-statistics-query',
+      'chromium-experimental-pipeline-statistics-query',
       'texture-compression-bc',
       'texture-compression-etc2',
       'texture-compression-astc',

--- a/system/include/webgpu/webgpu.h
+++ b/system/include/webgpu/webgpu.h
@@ -323,7 +323,7 @@ typedef enum WGPUFeatureName {
     WGPUFeatureName_DepthClipControl = 0x00000001,
     WGPUFeatureName_Depth32FloatStencil8 = 0x00000002,
     WGPUFeatureName_TimestampQuery = 0x00000003,
-    WGPUFeatureName_PipelineStatisticsQuery = 0x00000004,
+    WGPUFeatureName_ChromiumExperimentalPipelineStatisticsQuery = 0x00000004,
     WGPUFeatureName_TextureCompressionBC = 0x00000005,
     WGPUFeatureName_TextureCompressionETC2 = 0x00000006,
     WGPUFeatureName_TextureCompressionASTC = 0x00000007,

--- a/system/include/webgpu/webgpu_cpp.h
+++ b/system/include/webgpu/webgpu_cpp.h
@@ -282,7 +282,7 @@ namespace wgpu {
         DepthClipControl = 0x00000001,
         Depth32FloatStencil8 = 0x00000002,
         TimestampQuery = 0x00000003,
-        PipelineStatisticsQuery = 0x00000004,
+        ChromiumExperimentalPipelineStatisticsQuery = 0x00000004,
         TextureCompressionBC = 0x00000005,
         TextureCompressionETC2 = 0x00000006,
         TextureCompressionASTC = 0x00000007,

--- a/system/lib/webgpu/webgpu_cpp.cpp
+++ b/system/lib/webgpu/webgpu_cpp.cpp
@@ -198,7 +198,7 @@ namespace wgpu {
     static_assert(static_cast<uint32_t>(FeatureName::DepthClipControl) == WGPUFeatureName_DepthClipControl, "value mismatch for FeatureName::DepthClipControl");
     static_assert(static_cast<uint32_t>(FeatureName::Depth32FloatStencil8) == WGPUFeatureName_Depth32FloatStencil8, "value mismatch for FeatureName::Depth32FloatStencil8");
     static_assert(static_cast<uint32_t>(FeatureName::TimestampQuery) == WGPUFeatureName_TimestampQuery, "value mismatch for FeatureName::TimestampQuery");
-    static_assert(static_cast<uint32_t>(FeatureName::PipelineStatisticsQuery) == WGPUFeatureName_PipelineStatisticsQuery, "value mismatch for FeatureName::PipelineStatisticsQuery");
+    static_assert(static_cast<uint32_t>(FeatureName::ChromiumExperimentalPipelineStatisticsQuery) == WGPUFeatureName_ChromiumExperimentalPipelineStatisticsQuery, "value mismatch for FeatureName::WGPUFeatureName_ChromiumExperimentalPipelineStatisticsQuery");
     static_assert(static_cast<uint32_t>(FeatureName::TextureCompressionBC) == WGPUFeatureName_TextureCompressionBC, "value mismatch for FeatureName::TextureCompressionBC");
     static_assert(static_cast<uint32_t>(FeatureName::TextureCompressionETC2) == WGPUFeatureName_TextureCompressionETC2, "value mismatch for FeatureName::TextureCompressionETC2");
     static_assert(static_cast<uint32_t>(FeatureName::TextureCompressionASTC) == WGPUFeatureName_TextureCompressionASTC, "value mismatch for FeatureName::TextureCompressionASTC");


### PR DESCRIPTION
Following https://dawn-review.googlesource.com/c/dawn/+/156823, this PR renames the feature name `WGPUFeatureName_PipelineStatisticsQuery` to `WGPUFeatureName_ChromiumExperimentalPipelineStatisticsQuery`

@kainino0x Please review. 