### PR TITLE
Inline returns in arrow functions. NFC

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -238,9 +238,7 @@ var LibraryEmbind = {
   },
 
   $getInheritedInstanceCount__deps: ['$registeredInstances'],
-  $getInheritedInstanceCount: () => {
-    return Object.keys(registeredInstances).length;
-  },
+  $getInheritedInstanceCount: () => Object.keys(registeredInstances).length,
 
   $getLiveInheritedInstances__deps: ['$registeredInstances'],
   $getLiveInheritedInstances: () => {
@@ -1085,9 +1083,7 @@ var LibraryEmbind = {
         var setterArgumentType = elementTypes[i + elementsLength];
         var setter = elt.setter;
         var setterContext = elt.setterContext;
-        elt.read = (ptr) => {
-          return getterReturnType['fromWireType'](getter(getterContext, ptr));
-        };
+        elt.read = (ptr) => getterReturnType['fromWireType'](getter(getterContext, ptr));
         elt.write = (ptr, o) => {
           var destructors = [];
           setter(setterContext, ptr, setterArgumentType['toWireType'](destructors, o));
@@ -1191,10 +1187,7 @@ var LibraryEmbind = {
         var setter = field.setter;
         var setterContext = field.setterContext;
         fields[fieldName] = {
-          read: (ptr) => {
-            return getterReturnType['fromWireType'](
-                getter(getterContext, ptr));
-          },
+          read: (ptr) => getterReturnType['fromWireType'](getter(getterContext, ptr)),
           write: (ptr, o) => {
             var destructors = [];
             setter(setterContext, ptr, setterArgumentType['toWireType'](destructors, o));

--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -105,9 +105,7 @@ var LibraryEmVal = {
   },
 
   _emval_new_array__deps: ['$Emval'],
-  _emval_new_array: () => {
-    return Emval.toHandle([]);
-  },
+  _emval_new_array: () => Emval.toHandle([]),
 
   _emval_new_array_from_memory_view__deps: ['$Emval'],
   _emval_new_array_from_memory_view: (view) => {
@@ -119,24 +117,16 @@ var LibraryEmVal = {
   },
 
   _emval_new_object__deps: ['$Emval'],
-  _emval_new_object: () => {
-    return Emval.toHandle({});
-  },
+  _emval_new_object: () => Emval.toHandle({}),
 
   _emval_new_cstring__deps: ['$getStringOrSymbol', '$Emval'],
-  _emval_new_cstring: (v) => {
-    return Emval.toHandle(getStringOrSymbol(v));
-  },
+  _emval_new_cstring: (v) => Emval.toHandle(getStringOrSymbol(v)),
 
   _emval_new_u8string__deps: ['$Emval'],
-  _emval_new_u8string: (v) => {
-    return Emval.toHandle(UTF8ToString(v));
-  },
+  _emval_new_u8string: (v) => Emval.toHandle(UTF8ToString(v)),
 
   _emval_new_u16string__deps: ['$Emval'],
-  _emval_new_u16string: (v) => {
-    return Emval.toHandle(UTF16ToString(v));
-  },
+  _emval_new_u16string: (v) => Emval.toHandle(UTF16ToString(v)),
 
   _emval_take_value__deps: ['$Emval', '$requireRegisteredType'],
   _emval_take_value: (type, arg) => {

--- a/src/headless.js
+++ b/src/headless.js
@@ -227,15 +227,13 @@ var XMLHttpRequest = function() {
     },
   };
 };
-var Audio = () => {
-  return {
-    play() {},
-    pause() {},
-    cloneNode() {
-      return this;
-    },
-  };
-};
+var Audio = () => ({
+  play() {},
+  pause() {},
+  cloneNode() {
+    return this;
+  },
+});
 var Image = () => {
   window.setTimeout(function() {
     this.complete = true;

--- a/src/library.js
+++ b/src/library.js
@@ -643,9 +643,7 @@ addToLibrary({
   $MONTH_DAYS_REGULAR_CUMULATIVE: [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
   $MONTH_DAYS_LEAP_CUMULATIVE: [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335],
 
-  $isLeapYear: (year) => {
-      return year%4 === 0 && (year%100 !== 0 || year%400 === 0);
-  },
+  $isLeapYear: (year) => year%4 === 0 && (year%100 !== 0 || year%400 === 0),
 
   $ydayFromDate__deps: ['$isLeapYear', '$MONTH_DAYS_LEAP_CUMULATIVE', '$MONTH_DAYS_REGULAR_CUMULATIVE'],
   $ydayFromDate: (date) => {

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -523,16 +523,14 @@ addToLibrary({
   },
 
   emscripten_lazy_load_code__async: true,
-  emscripten_lazy_load_code: () => {
-    return Asyncify.handleSleep((wakeUp) => {
-      // Update the expected wasm binary file to be the lazy one.
-      wasmBinaryFile += '.lazy.wasm';
-      // Add a callback for when all run dependencies are fulfilled, which happens when async wasm loading is done.
-      dependenciesFulfilled = wakeUp;
-      // Load the new wasm.
-      createWasm();
-    });
-  },
+  emscripten_lazy_load_code: () => Asyncify.handleSleep((wakeUp) => {
+    // Update the expected wasm binary file to be the lazy one.
+    wasmBinaryFile += '.lazy.wasm';
+    // Add a callback for when all run dependencies are fulfilled, which happens when async wasm loading is done.
+    dependenciesFulfilled = wakeUp;
+    // Load the new wasm.
+    createWasm();
+  }),
 
   _load_secondary_module__sig: 'v',
   _load_secondary_module: async function() {

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -877,11 +877,11 @@ var LibraryDylink = {
 
     // now load needed libraries and the module itself.
     if (flags.loadAsync) {
-      return metadata.neededDynlibs.reduce((chain, dynNeeded) => {
-        return chain.then(() => {
-          return loadDynamicLibrary(dynNeeded, flags);
-        });
-      }, Promise.resolve()).then(loadModule);
+      return metadata.neededDynlibs
+        .reduce((chain, dynNeeded) => chain.then(() =>
+          loadDynamicLibrary(dynNeeded, flags)
+        ), Promise.resolve())
+        .then(loadModule);
     }
 
     metadata.neededDynlibs.forEach((needed) => loadDynamicLibrary(needed, flags, localScope));
@@ -1089,18 +1089,18 @@ var LibraryDylink = {
 
     // Load binaries asynchronously
     addRunDependency('loadDylibs');
-    dynamicLibraries.reduce((chain, lib) => {
-      return chain.then(() => {
-        return loadDynamicLibrary(lib, {loadAsync: true, global: true, nodelete: true, allowUndefined: true});
+    dynamicLibraries
+      .reduce((chain, lib) => chain.then(() =>
+        loadDynamicLibrary(lib, {loadAsync: true, global: true, nodelete: true, allowUndefined: true})
+      ), Promise.resolve())
+      .then(() => {
+        // we got them all, wonderful
+        reportUndefinedSymbols();
+        removeRunDependency('loadDylibs');
+  #if DYLINK_DEBUG
+        dbg('loadDylibs done!');
+  #endif
       });
-    }, Promise.resolve()).then(() => {
-      // we got them all, wonderful
-      reportUndefinedSymbols();
-      removeRunDependency('loadDylibs');
-#if DYLINK_DEBUG
-      dbg('loadDylibs done!');
-#endif
-    });
   },
 
   // void* dlopen(const char* filename, int flags);

--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -930,9 +930,7 @@ var LibraryGLEmulation = {
 
       // Exports:
       return {
-        create: () => {
-          return new CMapTree();
-        },
+        create: () => new CMapTree(),
       };
     },
 

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -627,9 +627,7 @@ var LibraryGLFW = {
 #endif
     },
 
-    getTime: () => {
-      return _emscripten_get_now() / 1000;
-    },
+    getTime: () => _emscripten_get_now() / 1000,
 
     /* GLFW2 wrapping */
 

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2375,9 +2375,7 @@ var LibraryHTML5 = {
 
   $setCanvasElementSizeMainThread__proxy: 'sync',
   $setCanvasElementSizeMainThread__deps: ['$setCanvasElementSizeCallingThread'],
-  $setCanvasElementSizeMainThread: (target, width, height) => {
-    return setCanvasElementSizeCallingThread(target, width, height);
-  },
+  $setCanvasElementSizeMainThread: (target, width, height) => setCanvasElementSizeCallingThread(target, width, height),
 
   emscripten_set_canvas_element_size__deps: ['$JSEvents', '$setCanvasElementSizeCallingThread', '$setCanvasElementSizeMainThread', '$findCanvasEventTarget'],
   emscripten_set_canvas_element_size: (target, width, height) => {

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -94,9 +94,7 @@ addToLibrary({
         return p !== '.' && p !== '..';
       };
       function toAbsolute(root) {
-        return (p) => {
-          return PATH.join2(root, p);
-        }
+        return (p) => PATH.join2(root, p);
       };
 
       var check = FS.readdir(mount.mountpoint).filter(isRealDir).map(toAbsolute(mount.mountpoint));

--- a/src/library_idbstore.js
+++ b/src/library_idbstore.js
@@ -94,105 +94,91 @@ var LibraryIDBStore = {
 #if ASYNCIFY
   emscripten_idb_load__async: true,
   emscripten_idb_load__deps: ['malloc'],
-  emscripten_idb_load: (db, id, pbuffer, pnum, perror) => {
-    return Asyncify.handleSleep((wakeUp) => {
-      IDBStore.getFile(UTF8ToString(db), UTF8ToString(id), (error, byteArray) => {
-        if (error) {
-          {{{ makeSetValue('perror', 0, '1', 'i32') }}};
-          wakeUp();
-          return;
-        }
-        var buffer = _malloc(byteArray.length); // must be freed by the caller!
-        HEAPU8.set(byteArray, buffer);
-        {{{ makeSetValue('pbuffer', 0, 'buffer', 'i32') }}};
-        {{{ makeSetValue('pnum',    0, 'byteArray.length', 'i32') }}};
-        {{{ makeSetValue('perror',  0, '0', 'i32') }}};
+  emscripten_idb_load: (db, id, pbuffer, pnum, perror) => Asyncify.handleSleep((wakeUp) => {
+    IDBStore.getFile(UTF8ToString(db), UTF8ToString(id), (error, byteArray) => {
+      if (error) {
+        {{{ makeSetValue('perror', 0, '1', 'i32') }}};
         wakeUp();
-      });
+        return;
+      }
+      var buffer = _malloc(byteArray.length); // must be freed by the caller!
+      HEAPU8.set(byteArray, buffer);
+      {{{ makeSetValue('pbuffer', 0, 'buffer', 'i32') }}};
+      {{{ makeSetValue('pnum',    0, 'byteArray.length', 'i32') }}};
+      {{{ makeSetValue('perror',  0, '0', 'i32') }}};
+      wakeUp();
     });
-  },
+  }),
   emscripten_idb_store__async: true,
-  emscripten_idb_store: (db, id, ptr, num, perror) => {
-    return Asyncify.handleSleep((wakeUp) => {
-      IDBStore.setFile(UTF8ToString(db), UTF8ToString(id), new Uint8Array(HEAPU8.subarray(ptr, ptr+num)), (error) => {
-        {{{ makeSetValue('perror', 0, '!!error', 'i32') }}};
-        wakeUp();
-      });
+  emscripten_idb_store: (db, id, ptr, num, perror) => Asyncify.handleSleep((wakeUp) => {
+    IDBStore.setFile(UTF8ToString(db), UTF8ToString(id), new Uint8Array(HEAPU8.subarray(ptr, ptr+num)), (error) => {
+      {{{ makeSetValue('perror', 0, '!!error', 'i32') }}};
+      wakeUp();
     });
-  },
+  }),
   emscripten_idb_delete__async: true,
-  emscripten_idb_delete: (db, id, perror) => {
-    return Asyncify.handleSleep((wakeUp) => {
-      IDBStore.deleteFile(UTF8ToString(db), UTF8ToString(id), (error) => {
-        {{{ makeSetValue('perror', 0, '!!error', 'i32') }}};
-        wakeUp();
-      });
+  emscripten_idb_delete: (db, id, perror) => Asyncify.handleSleep((wakeUp) => {
+    IDBStore.deleteFile(UTF8ToString(db), UTF8ToString(id), (error) => {
+      {{{ makeSetValue('perror', 0, '!!error', 'i32') }}};
+      wakeUp();
     });
-  },
+  }),
   emscripten_idb_exists__async: true,
-  emscripten_idb_exists: (db, id, pexists, perror) => {
-    return Asyncify.handleSleep((wakeUp) => {
-      IDBStore.existsFile(UTF8ToString(db), UTF8ToString(id), (error, exists) => {
-        {{{ makeSetValue('pexists', 0, '!!exists', 'i32') }}};
-        {{{ makeSetValue('perror',  0, '!!error', 'i32') }}};
-        wakeUp();
-      });
+  emscripten_idb_exists: (db, id, pexists, perror) => Asyncify.handleSleep((wakeUp) => {
+    IDBStore.existsFile(UTF8ToString(db), UTF8ToString(id), (error, exists) => {
+      {{{ makeSetValue('pexists', 0, '!!exists', 'i32') }}};
+      {{{ makeSetValue('perror',  0, '!!error', 'i32') }}};
+      wakeUp();
     });
-  },
+  }),
   emscripten_idb_clear__async: true,
-  emscripten_idb_clear: (db, perror) => {
-    return Asyncify.handleSleep((wakeUp) => {
-      IDBStore.clearStore(UTF8ToString(db), (error) => {
-        {{{ makeSetValue('perror', 0, '!!error', 'i32') }}};
-        wakeUp();
-      });
+  emscripten_idb_clear: (db, perror) => Asyncify.handleSleep((wakeUp) => {
+    IDBStore.clearStore(UTF8ToString(db), (error) => {
+      {{{ makeSetValue('perror', 0, '!!error', 'i32') }}};
+      wakeUp();
     });
-  },
+  }),
   // extra worker methods - proxied
   emscripten_idb_load_blob__async: true,
-  emscripten_idb_load_blob: (db, id, pblob, perror) => {
-    return Asyncify.handleSleep((wakeUp) => {
-      assert(!IDBStore.pending);
-      IDBStore.pending = (msg) => {
-        IDBStore.pending = null;
-        var blob = msg.blob;
-        if (!blob) {
-          {{{ makeSetValue('perror', 0, '1', 'i32') }}};
-          wakeUp();
-          return;
-        }
-        assert(blob instanceof Blob);
-        var blobId = IDBStore.blobs.length;
-        IDBStore.blobs.push(blob);
-        {{{ makeSetValue('pblob', 0, 'blobId', 'i32') }}};
+  emscripten_idb_load_blob: (db, id, pblob, perror) => Asyncify.handleSleep((wakeUp) => {
+    assert(!IDBStore.pending);
+    IDBStore.pending = (msg) => {
+      IDBStore.pending = null;
+      var blob = msg.blob;
+      if (!blob) {
+        {{{ makeSetValue('perror', 0, '1', 'i32') }}};
         wakeUp();
-      };
-      postMessage({
-        target: 'IDBStore',
-        method: 'loadBlob',
-        db: UTF8ToString(db),
-        id: UTF8ToString(id)
-      });
+        return;
+      }
+      assert(blob instanceof Blob);
+      var blobId = IDBStore.blobs.length;
+      IDBStore.blobs.push(blob);
+      {{{ makeSetValue('pblob', 0, 'blobId', 'i32') }}};
+      wakeUp();
+    };
+    postMessage({
+      target: 'IDBStore',
+      method: 'loadBlob',
+      db: UTF8ToString(db),
+      id: UTF8ToString(id)
     });
-  },
+  }),
   emscripten_idb_store_blob__async: true,
-  emscripten_idb_store_blob: (db, id, ptr, num, perror) => {
-    return Asyncify.handleSleep((wakeUp) => {
-      assert(!IDBStore.pending);
-      IDBStore.pending = (msg) => {
-        IDBStore.pending = null;
-        {{{ makeSetValue('perror', 0, '!!msg.error', 'i32') }}};
-        wakeUp();
-      };
-      postMessage({
-        target: 'IDBStore',
-        method: 'storeBlob',
-        db: UTF8ToString(db),
-        id: UTF8ToString(id),
-        blob: new Blob([new Uint8Array(HEAPU8.subarray(ptr, ptr+num))])
-      });
+  emscripten_idb_store_blob: (db, id, ptr, num, perror) => Asyncify.handleSleep((wakeUp) => {
+    assert(!IDBStore.pending);
+    IDBStore.pending = (msg) => {
+      IDBStore.pending = null;
+      {{{ makeSetValue('perror', 0, '!!msg.error', 'i32') }}};
+      wakeUp();
+    };
+    postMessage({
+      target: 'IDBStore',
+      method: 'storeBlob',
+      db: UTF8ToString(db),
+      id: UTF8ToString(id),
+      blob: new Blob([new Uint8Array(HEAPU8.subarray(ptr, ptr+num))])
     });
-  },
+  }),
   emscripten_idb_read_from_blob: (blobId, start, num, buffer) => {
     var blob = IDBStore.blobs[blobId];
     if (!blob) return 1;

--- a/src/library_int53.js
+++ b/src/library_int53.js
@@ -137,9 +137,7 @@ addToLibrary({
   // pointer or size_t and is expected to be withing the int53 range.
   // Returns NaN if the incoming bigint is outside the range.
   $bigintToI53Checked__deps: ['$MAX_INT53', '$MIN_INT53'],
-  $bigintToI53Checked: (num) => {
-    return (num < MIN_INT53 || num > MAX_INT53) ? NaN : Number(num);
-  },
+  $bigintToI53Checked: (num) => (num < MIN_INT53 || num > MAX_INT53) ? NaN : Number(num),
 #endif
 });
 

--- a/src/library_path.js
+++ b/src/library_path.js
@@ -76,9 +76,7 @@ addToLibrary({
       var paths = Array.prototype.slice.call(arguments);
       return PATH.normalize(paths.join('/'));
     },
-    join2: (l, r) => {
-      return PATH.normalize(l + '/' + r);
-    },
+    join2: (l, r) => PATH.normalize(l + '/' + r),
   },
   // The FS-using parts are split out into a separate object, so simple path
   // usage does not require the FS.

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -694,9 +694,7 @@ var LibraryPThread = {
     return 0;
   },
 
-  emscripten_has_threading_support: () => {
-    return typeof SharedArrayBuffer != 'undefined';
-  },
+  emscripten_has_threading_support: () => typeof SharedArrayBuffer != 'undefined',
 
   emscripten_num_logical_cores: () => {
 #if ENVIRONMENT_MAY_BE_NODE
@@ -727,9 +725,7 @@ var LibraryPThread = {
   $pthreadCreateProxied__internal: true,
   $pthreadCreateProxied__proxy: 'sync',
   $pthreadCreateProxied__deps: ['__pthread_create_js'],
-  $pthreadCreateProxied: (pthread_ptr, attr, startRoutine, arg) => {
-    return ___pthread_create_js(pthread_ptr, attr, startRoutine, arg);
-  },
+  $pthreadCreateProxied: (pthread_ptr, attr, startRoutine, arg) => ___pthread_create_js(pthread_ptr, attr, startRoutine, arg),
 
 #if OFFSCREENCANVAS_SUPPORT
   // ASan wraps the emscripten_builtin_pthread_create call in

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -424,9 +424,7 @@ var LibrarySDL = {
         usePageCanvas,
         source,
 
-        isFlagSet: (flag) => {
-          return flags & flag;
-        }
+        isFlagSet: (flag) => flags & flag
       };
 
       return surf;
@@ -1812,9 +1810,7 @@ var LibrarySDL = {
 
   SDL_CreateRGBSurface__deps: ['malloc', 'free'],
   SDL_CreateRGBSurface__proxy: 'sync',
-  SDL_CreateRGBSurface: (flags, width, height, depth, rmask, gmask, bmask, amask) => {
-    return SDL.makeSurface(width, height, flags, false, 'CreateRGBSurface', rmask, gmask, bmask, amask);
-  },
+  SDL_CreateRGBSurface: (flags, width, height, depth, rmask, gmask, bmask, amask) => SDL.makeSurface(width, height, flags, false, 'CreateRGBSurface', rmask, gmask, bmask, amask),
 
   SDL_CreateRGBSurfaceFrom__proxy: 'sync',
   SDL_CreateRGBSurfaceFrom: (pixels, width, height, depth, pitch, rmask, gmask, bmask, amask) => {
@@ -3027,9 +3023,7 @@ var LibrarySDL = {
   },
 
   Mix_PausedMusic__proxy: 'sync',
-  Mix_PausedMusic: () => {
-    return (SDL.music.audio && SDL.music.audio.paused) ? 1 : 0;
-  },
+  Mix_PausedMusic: () => (SDL.music.audio && SDL.music.audio.paused) ? 1 : 0,
 
   // http://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_33.html#SEC33
   Mix_Resume__proxy: 'sync',
@@ -3306,9 +3300,7 @@ var LibrarySDL = {
   // SDL 2
 
   SDL_GL_ExtensionSupported__proxy: 'sync',
-  SDL_GL_ExtensionSupported: (extension) => {
-    return Module.ctx.getExtension(extension) | 0;
-  },
+  SDL_GL_ExtensionSupported: (extension) => Module.ctx.getExtension(extension) | 0,
 
   SDL_DestroyWindow: (window) => {},
 

--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -201,9 +201,7 @@ if (ENVIRONMENT_IS_WASM_WORKER) {
 #endif
   },
 
-  emscripten_wasm_worker_self_id: () => {
-    return Module['$ww'];
-  },
+  emscripten_wasm_worker_self_id: () => Module['$ww'],
 
   emscripten_wasm_worker_post_function_v: (id, funcPtr) => {
     _wasmWorkers[id].postMessage({'_wsc': funcPtr, 'x': [] }); // "WaSm Call"

--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -391,7 +391,7 @@ FS.init();
             return -e.errno;
           }
           Module.HEAP8.set(bufferArray, buffer);
-          return bytesWritten;       
+          return bytesWritten;
         },
       };
 
@@ -506,12 +506,10 @@ FS.init();
   },
 
   $FS_mknod__deps: ['_wasmfs_mknod'],
-  $FS_mknod: (path, mode, dev) => {
-    return FS.handleError(withStackSave(() => {
-      var pathBuffer = stringToUTF8OnStack(path);
-      return __wasmfs_mknod(pathBuffer, mode, dev);
-    }));
-  },
+  $FS_mknod: (path, mode, dev) => FS.handleError(withStackSave(() => {
+    var pathBuffer = stringToUTF8OnStack(path);
+    return __wasmfs_mknod(pathBuffer, mode, dev);
+  })),
 
   $FS_create__deps: ['$FS_mknod'],
   $FS_create: (path, mode) => {

--- a/src/library_wasmfs_js_file.js
+++ b/src/library_wasmfs_js_file.js
@@ -44,9 +44,7 @@ addToLibrary({
         HEAPU8.set(fileData.subarray(offset, offset + length), buffer);
         return length;
       },
-      getSize: (file) => {
-        return wasmFS$JSMemoryFiles[file] ? wasmFS$JSMemoryFiles[file].length : 0;
-      },
+      getSize: (file) => wasmFS$JSMemoryFiles[file] ? wasmFS$JSMemoryFiles[file].length : 0,
     };
   },
 });

--- a/src/library_wasmfs_opfs.js
+++ b/src/library_wasmfs_opfs.js
@@ -53,9 +53,7 @@ addToLibrary({
   },
 
   $wasmfsOPFSCreateAsyncAccessHandle__deps: ['$FileSystemAsyncAccessHandle'],
-  $wasmfsOPFSCreateAsyncAccessHandle: (fileHandle) => {
-    return new FileSystemAsyncAccessHandle(fileHandle);
-  },
+  $wasmfsOPFSCreateAsyncAccessHandle: (fileHandle) => new FileSystemAsyncAccessHandle(fileHandle),
 #endif
 
 #if PTHREADS

--- a/src/library_webaudio.js
+++ b/src/library_webaudio.js
@@ -35,9 +35,7 @@ let LibraryWebAudio = {
 
   // Call this function from JavaScript to get the Web Audio object corresponding to the given
   // Wasm handle ID.
-  $emscriptenGetAudioObject: (objectHandle) => {
-    return EmAudio[objectHandle];
-  },
+  $emscriptenGetAudioObject: (objectHandle) => EmAudio[objectHandle],
 
   // emscripten_create_audio_context() does not itself use emscriptenGetAudioObject() function, but mark it as a
   // dependency, because the user will not be able to utilize the node unless they call emscriptenGetAudioObject()
@@ -276,9 +274,7 @@ let LibraryWebAudio = {
   },
 #endif // ~AUDIO_WORKLET
 
-  emscripten_current_thread_is_audio_worklet: () => {
-    return typeof AudioWorkletGlobalScope !== 'undefined';
-  },
+  emscripten_current_thread_is_audio_worklet: () => typeof AudioWorkletGlobalScope !== 'undefined',
 
   emscripten_audio_worklet_post_function_v: (audioContext, funcPtr) => {
     (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : globalThis['messagePort']).postMessage({'_wsc': funcPtr, 'x': [] }); // "WaSm Call"

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -83,9 +83,7 @@ var LibraryGL = {
     return HEAPU16;
   },
 
-  $heapAccessShiftForWebGLHeap: (heap) => {
-    return 31 - Math.clz32(heap.BYTES_PER_ELEMENT);
-  },
+  $heapAccessShiftForWebGLHeap: (heap) => 31 - Math.clz32(heap.BYTES_PER_ELEMENT),
 
 #if MIN_WEBGL_VERSION == 1
   $webgl_enable_ANGLE_instanced_arrays: (ctx) => {
@@ -100,9 +98,7 @@ var LibraryGL = {
   },
 
   emscripten_webgl_enable_ANGLE_instanced_arrays__deps: ['$webgl_enable_ANGLE_instanced_arrays'],
-  emscripten_webgl_enable_ANGLE_instanced_arrays: (ctx) => {
-    return webgl_enable_ANGLE_instanced_arrays(GL.contexts[ctx].GLctx);
-  },
+  emscripten_webgl_enable_ANGLE_instanced_arrays: (ctx) => webgl_enable_ANGLE_instanced_arrays(GL.contexts[ctx].GLctx),
 
   $webgl_enable_OES_vertex_array_object: (ctx) => {
     // Extension available in WebGL 1 from Firefox 25 and WebKit 536.28/desktop Safari 6.0.3 onwards. Core feature in WebGL 2.
@@ -117,9 +113,7 @@ var LibraryGL = {
   },
 
   emscripten_webgl_enable_OES_vertex_array_object__deps: ['$webgl_enable_OES_vertex_array_object'],
-  emscripten_webgl_enable_OES_vertex_array_object: (ctx) => {
-    return webgl_enable_OES_vertex_array_object(GL.contexts[ctx].GLctx);
-  },
+  emscripten_webgl_enable_OES_vertex_array_object: (ctx) => webgl_enable_OES_vertex_array_object(GL.contexts[ctx].GLctx),
 
   $webgl_enable_WEBGL_draw_buffers: (ctx) => {
     // Extension available in WebGL 1 from Firefox 28 onwards. Core feature in WebGL 2.
@@ -131,9 +125,7 @@ var LibraryGL = {
   },
 
   emscripten_webgl_enable_WEBGL_draw_buffers__deps: ['$webgl_enable_WEBGL_draw_buffers'],
-  emscripten_webgl_enable_WEBGL_draw_buffers: (ctx) => {
-    return webgl_enable_WEBGL_draw_buffers(GL.contexts[ctx].GLctx);
-  },
+  emscripten_webgl_enable_WEBGL_draw_buffers: (ctx) => webgl_enable_WEBGL_draw_buffers(GL.contexts[ctx].GLctx),
 #endif
 
   $webgl_enable_WEBGL_multi_draw: (ctx) => {
@@ -142,9 +134,7 @@ var LibraryGL = {
   },
 
   emscripten_webgl_enable_WEBGL_multi_draw__deps: ['$webgl_enable_WEBGL_multi_draw'],
-  emscripten_webgl_enable_WEBGL_multi_draw: (ctx) => {
-    return webgl_enable_WEBGL_multi_draw(GL.contexts[ctx].GLctx);
-  },
+  emscripten_webgl_enable_WEBGL_multi_draw: (ctx) => webgl_enable_WEBGL_multi_draw(GL.contexts[ctx].GLctx),
 
   $GL__postset: 'var GLctx;',
 #if GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS
@@ -266,9 +256,7 @@ var LibraryGL = {
     // Precompute a lookup table for the function ceil(log2(x)), i.e. how many bits are needed to represent x, or,
     // if x was rounded up to next pow2, which index is the single '1' bit at?
     // Then log2ceilLookup[x] returns ceil(log2(x)).
-    log2ceilLookup: (i) => {
-      return 32 - Math.clz32(i === 0 ? 0 : i - 1);
-    },
+    log2ceilLookup: (i) => 32 - Math.clz32(i === 0 ? 0 : i - 1),
 
     generateTempBuffers: (quads, context) => {
       var largestIndex = GL.log2ceilLookup(GL.MAX_TEMP_BUFFER_SIZE);
@@ -2114,9 +2102,7 @@ var LibraryGL = {
   // Closure does counterproductive inlining: https://github.com/google/closure-compiler/issues/3203, so prevent
   // inlining manually.
   $webglGetLeftBracePos__docs: '/** @noinline */',
-  $webglGetLeftBracePos: (name) => {
-    return name.slice(-1) == ']' && name.lastIndexOf('[');
-  },
+  $webglGetLeftBracePos: (name) => name.slice(-1) == ']' && name.lastIndexOf('['),
 
   glGetUniformLocation__deps: ['$jstoi_q', '$webglPrepareUniformLocationsBeforeFirstUse', '$webglGetLeftBracePos'],
   glGetUniformLocation: (program, name) => {

--- a/src/library_websocket.js
+++ b/src/library_websocket.js
@@ -403,9 +403,7 @@ var LibraryWebSocket = {
   },
 
   emscripten_websocket_is_supported__proxy: 'sync',
-  emscripten_websocket_is_supported: () => {
-    return typeof WebSocket != 'undefined';
-  },
+  emscripten_websocket_is_supported: () => typeof WebSocket != 'undefined',
 
   emscripten_websocket_deinitialize__deps: ['$WS'],
   emscripten_websocket_deinitialize__proxy: 'sync',

--- a/src/memoryprofiler.js
+++ b/src/memoryprofiler.js
@@ -613,7 +613,7 @@ var emscriptenMemoryProfiler = {
         if (calls.length > 0) {
           if (sortOrder != 'fixed') {
             var sortIdx = (sortOrder == 'count') ? 0 : 1;
-            calls.sort((a,b) => { return b[sortIdx] - a[sortIdx]; });
+            calls.sort((a,b) => b[sortIdx] - a[sortIdx]);
           }
           html += '<h4>Allocation sites with more than ' + self.formatBytes(self.trackedCallstackMinSizeBytes) + ' of accumulated allocations, or more than ' + self.trackedCallstackMinAllocCount + ' simultaneously outstanding allocations:</h4>'
           for (var i in calls) {

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -7,15 +7,11 @@
 {{{
   // Helper function to export a symbol on the module object
   // if requested.
-  global.maybeExport = (x) => {
-    return MODULARIZE && EXPORT_ALL ? `Module['${x}'] = ` : '';
-  };
+  global.maybeExport = (x) => MODULARIZE && EXPORT_ALL ? `Module['${x}'] = ` : '';
   // Export to the AudioWorkletGlobalScope the needed variables to access
   // the heap. AudioWorkletGlobalScope is unable to access global JS vars
   // in the compiled main JS file.
-  global.maybeExportIfAudioWorklet = (x) => {
-    return (MODULARIZE && EXPORT_ALL) || AUDIO_WORKLET ? `Module['${x}'] = ` : '';
-  };
+  global.maybeExportIfAudioWorklet = (x) => (MODULARIZE && EXPORT_ALL) || AUDIO_WORKLET ? `Module['${x}'] = ` : '';
   null;
 }}}
 

--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -34,7 +34,7 @@ if (typeof Module == 'undefined') {
   Module = {
     canvas: {
       addEventListener: () => {},
-      getBoundingClientRect: () => { return { bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0 }; },
+      getBoundingClientRect: () => ({ bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0 }),
     },
   };
 }

--- a/src/proxyWorker.js
+++ b/src/proxyWorker.js
@@ -200,16 +200,14 @@ document.createElement = (what) => {
         }
       };
       canvas.boundingClientRect = {};
-      canvas.getBoundingClientRect = () => {
-        return {
-          width: canvas.boundingClientRect.width,
-          height: canvas.boundingClientRect.height,
-          top: canvas.boundingClientRect.top,
-          left: canvas.boundingClientRect.left,
-          bottom: canvas.boundingClientRect.bottom,
-          right: canvas.boundingClientRect.right
-        };
-      };
+      canvas.getBoundingClientRect = () => ({
+        width: canvas.boundingClientRect.width,
+        height: canvas.boundingClientRect.height,
+        top: canvas.boundingClientRect.top,
+        left: canvas.boundingClientRect.left,
+        bottom: canvas.boundingClientRect.bottom,
+        right: canvas.boundingClientRect.right
+      });
       canvas.style = new PropertyBag();
       canvas.exitPointerLock = () => {};
 
@@ -222,9 +220,7 @@ document.createElement = (what) => {
             postMessage({ target: 'canvas', op: 'resize', width: canvas.width_, height: canvas.height_ });
           }
         },
-        get: () => {
-          return canvas.width_;
-        }
+        get: () => canvas.width_
       });
       Object.defineProperty(canvas, 'height', {
         set: (value) => {
@@ -233,9 +229,7 @@ document.createElement = (what) => {
             postMessage({ target: 'canvas', op: 'resize', width: canvas.width_, height: canvas.height_ });
           }
         },
-        get: () => {
-          return canvas.height_;
-        }
+        get: () => canvas.height_
       });
 
       var style = {


### PR DESCRIPTION
Done with ast-grep + minimal formatting tweaks.

Commands:

1. `sg -p '($$$ARGS) => { return {$$$OBJ}; }' -r '($$$ARGS) => ({$$$OBJ})' -l js -i` to handle objects as they must be wrapped into parentheses
2. `sg -p '($$$ARGS) => { return $EXPR; }' -r '($$$ARGS) => $EXPR' -l js -i` for everything else.

Might need another pair of eyes for broken code but hopefully CI will catch it.