### PR TITLE
Add #if ASSERTIONS guard around assert in embind_shared

### DIFF
--- a/src/embind/embind_shared.js
+++ b/src/embind/embind_shared.js
@@ -129,9 +129,9 @@ var LibraryEmbindShared = {
     signature = signature.trim();
     const argsIndex = signature.indexOf("(");
     if (argsIndex !== -1) {
-      #if ASSERTIONS
+#if ASSERTIONS
       assert(signature[signature.length - 1] == ")", "Parentheses for argument names should match.");
-      #endif
+#endif
       return signature.substr(0, argsIndex);
     } else {
       return signature;
@@ -142,9 +142,9 @@ var LibraryEmbindShared = {
     signature = signature.trim();
     const argsIndex = signature.indexOf("(") + 1;
     if (argsIndex !== 0) {
-      #if ASSERTIONS
+#if ASSERTIONS
       assert(signature[signature.length - 1] == ")", "Parentheses for argument names should match.");
-      #endif
+#endif
       return signature.substr(argsIndex, signature.length - argsIndex - 1).replaceAll(" ", "").split(",").filter(n => n.length);
     } else {
       return [];

--- a/src/embind/embind_shared.js
+++ b/src/embind/embind_shared.js
@@ -129,7 +129,9 @@ var LibraryEmbindShared = {
     signature = signature.trim();
     const argsIndex = signature.indexOf("(");
     if (argsIndex !== -1) {
+      #if ASSERTIONS
       assert(signature[signature.length - 1] == ")", "Parentheses for argument names should match.");
+      #endif
       return signature.substr(0, argsIndex);
     } else {
       return signature;
@@ -140,7 +142,9 @@ var LibraryEmbindShared = {
     signature = signature.trim();
     const argsIndex = signature.indexOf("(") + 1;
     if (argsIndex !== 0) {
+      #if ASSERTIONS
       assert(signature[signature.length - 1] == ")", "Parentheses for argument names should match.");
+      #endif
       return signature.substr(argsIndex, signature.length - argsIndex - 1).replaceAll(" ", "").split(",").filter(n => n.length);
     } else {
       return [];


### PR DESCRIPTION
Adding the #if ASSERTIONS guard fixes the error

 ERROR - [JSC_NOT_FUNCTION_TYPE] {
  __clutz_actual_namespace: string,
  assert: function(*, (Error|string)=): undefined
} expressions are not callable
        assert(signature[signature.length - 1] == ")", "Parentheses for argument names should match.");
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^