### PR TITLE
Add size test for minimal emscripten::val demo

### DIFF
--- a/test/code_size/embind_val_hello_world.cpp
+++ b/test/code_size/embind_val_hello_world.cpp
@@ -1,7 +1,8 @@
 #include <emscripten/val.h>
+#include <string>
 
 using emscripten::val;
 
 int main() {
-  val::global("console").call<void>("log", val("Hello world! The answer is"), 42);
+  val::global("console").call<void>("log", std::string("Hello world! The answer is"), 42);
 }

--- a/test/code_size/embind_val_hello_world.cpp
+++ b/test/code_size/embind_val_hello_world.cpp
@@ -1,0 +1,7 @@
+#include <emscripten/val.h>
+
+using emscripten::val;
+
+int main() {
+  val::global("console").call<void>("log", val("Hello world! The answer is"), 42);
+}

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 673,
   "a.html.gz": 431,
-  "a.js": 7400,
-  "a.js.gz": 3091,
-  "a.wasm": 8958,
-  "a.wasm.gz": 4612,
-  "total": 17031,
-  "total_gz": 8134
+  "a.js": 7376,
+  "a.js.gz": 3077,
+  "a.wasm": 9653,
+  "a.wasm.gz": 4951,
+  "total": 17702,
+  "total_gz": 8459
 }

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 673,
   "a.html.gz": 431,
-  "a.js": 7376,
-  "a.js.gz": 3077,
-  "a.wasm": 9656,
-  "a.wasm.gz": 4950,
-  "total": 17705,
-  "total_gz": 8458
+  "a.js": 7498,
+  "a.js.gz": 3144,
+  "a.wasm": 9669,
+  "a.wasm.gz": 4962,
+  "total": 17840,
+  "total_gz": 8537
 }

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 431,
   "a.js": 7376,
   "a.js.gz": 3077,
-  "a.wasm": 9653,
-  "a.wasm.gz": 4951,
-  "total": 17702,
-  "total_gz": 8459
+  "a.wasm": 9656,
+  "a.wasm.gz": 4950,
+  "total": 17705,
+  "total_gz": 8458
 }

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -1,0 +1,10 @@
+{
+  "a.html": 673,
+  "a.html.gz": 431,
+  "a.js": 7400,
+  "a.js.gz": 3091,
+  "a.wasm": 8958,
+  "a.wasm.gz": 4612,
+  "total": 17031,
+  "total_gz": 8134
+}

--- a/test/minimal_webgl/main.c
+++ b/test/minimal_webgl/main.c
@@ -18,7 +18,7 @@ float mod_dist(float v, float t)
   return fminf(d, 6.f - d);
 }
 // Per-frame animation tick.
-EM_BOOL draw_frame(double t, void *)
+EM_BOOL draw_frame(double t, void *unused)
 {
   static double prevT;
   double dt = t - prevT;
@@ -57,7 +57,7 @@ EM_BOOL draw_frame(double t, void *)
       clamp01(2.f - mod_dist(c, 0.f)),
       clamp01(2.f - mod_dist(c, 2.f)),
       clamp01(2.f - mod_dist(c, 4.f)),
-      1.f, text[i], 64.f, true);
+      1.f, text[i], 64.f, EM_TRUE);
   }
 
   // snow foreground

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10387,7 +10387,7 @@ int main () {
     random_printf_sources = [test_file('hello_random_printf.c'),
                              '-sMALLOC=none',
                              '-sSINGLE_FILE']
-    hello_webgl_sources = [test_file('minimal_webgl/main.cpp'),
+    hello_webgl_sources = [test_file('minimal_webgl/main.c'),
                            test_file('minimal_webgl/webgl.c'),
                            '--js-library', test_file('minimal_webgl/library_js.js'),
                            '-lwebgl.js',
@@ -10398,10 +10398,7 @@ int main () {
                           '-lembind',
                           '-fno-rtti',
                           '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0',
-                          '-sDYNAMIC_EXECUTION=0',
-                          '-lc++',
-                          '-lc++abi'
-                          ]
+                          '-sDYNAMIC_EXECUTION=0']
 
     sources = {
       'hello_world': hello_world_sources,
@@ -10442,7 +10439,7 @@ int main () {
       if not common.EMTEST_REBASELINE:
         raise
 
-    args = [EMCC, '-o', 'a.html'] + args + sources
+    args = [compiler_for(sources[0]), '-o', 'a.html'] + args + sources
     print(shared.shlex_join(args))
     self.run_process(args)
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10398,7 +10398,9 @@ int main () {
                           '-lembind',
                           '-fno-rtti',
                           '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0',
-                          '-sDYNAMIC_EXECUTION=0'
+                          '-sDYNAMIC_EXECUTION=0',
+                          '-lc++',
+                          '-lc++abi'
                           ]
 
     sources = {

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10351,6 +10351,7 @@ int main () {
     'hello_webgl2_wasm2js': ('hello_webgl2', True),
     'math': ('math', False),
     'hello_wasm_worker': ('hello_wasm_worker', False, True),
+    'hello_embind_val': ('embind_val', False),
   })
   @crossplatform
   def test_minimal_runtime_code_size(self, test_name, js, compare_js_output=False):
@@ -10393,6 +10394,12 @@ int main () {
                            '-sMODULARIZE']
     hello_webgl2_sources = hello_webgl_sources + ['-sMAX_WEBGL_VERSION=2']
     hello_wasm_worker_sources = [test_file('wasm_worker/wasm_worker_code_size.c'), '-sWASM_WORKERS', '-sENVIRONMENT=web,worker']
+    embind_val_sources = [test_file('code_size/embind_val_hello_world.cpp'),
+                          '-lembind',
+                          '-fno-rtti',
+                          '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0',
+                          '-sDYNAMIC_EXECUTION=0'
+                          ]
 
     sources = {
       'hello_world': hello_world_sources,
@@ -10400,7 +10407,9 @@ int main () {
       'hello_webgl': hello_webgl_sources,
       'math': math_sources,
       'hello_webgl2': hello_webgl2_sources,
-      'hello_wasm_worker': hello_wasm_worker_sources}[test_name]
+      'hello_wasm_worker': hello_wasm_worker_sources,
+      'embind_val': embind_val_sources,
+    }[test_name]
 
     def print_percent(actual, expected):
       if actual == expected:


### PR DESCRIPTION
Noticed we don't have any size tests for it so adding a minimal one to track improvements/regressions to emscripten::val.