### PR TITLE
embind: Ignore proxy to pthread and pthread pool during tsgen.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3259,6 +3259,9 @@ def phase_embind_emit_tsd(options, in_wasm, wasm_target, memfile, js_syms):
   # Required function to trigger TS generation.
   settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$callRuntimeCallbacks']
   settings.EXPORT_ES6 = False
+  # Disable proxying and thread pooling so a worker is not automatically created.
+  settings.PROXY_TO_PTHREAD = False
+  settings.PTHREAD_POOL_SIZE = 0
   # Disable minify since the binaryen pass has not been run yet to change the
   # import names.
   settings.MINIFY_WASM_IMPORTED_MODULES = False

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2961,6 +2961,9 @@ int f() {
                   '--preload-file', 'fail.js',
                   '-O3',
                   '-msimd128',
+                  '-sUSE_PTHREADS',
+                  '-sPROXY_TO_PTHREAD',
+                  '-sPTHREAD_POOL_SIZE=1',
                   '-lembind', # Test duplicated link option.
                   ]
     self.run_process([EMCC, test_file('other/embind_tsgen.cpp'),


### PR DESCRIPTION
Neither of these are needed during TS definition generation and cause errors.

Fixes #20524