### PR TITLE
Improve error message with 'undefined top-level compiled C/C++ code'

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -589,7 +589,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   # For internal consistency, ensure we don't attempt or read or write any link time
   # settings until we reach the linking phase.
-#  settings.limit_settings(COMPILE_TIME_SETTINGS)
+  settings.limit_settings(COMPILE_TIME_SETTINGS)
 
   newargs, input_files = phase_setup(options, state, newargs)
 

--- a/emcc.py
+++ b/emcc.py
@@ -589,7 +589,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   # For internal consistency, ensure we don't attempt or read or write any link time
   # settings until we reach the linking phase.
-  settings.limit_settings(COMPILE_TIME_SETTINGS)
+#  settings.limit_settings(COMPILE_TIME_SETTINGS)
 
   newargs, input_files = phase_setup(options, state, newargs)
 
@@ -633,6 +633,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   ## Compile source code to object files
   linker_inputs = phase_compile_inputs(options, state, newargs, input_files)
+  settings.LINKER_INPUTS = [x[1] for x in linker_inputs]
 
   if state.mode != Mode.COMPILE_AND_LINK:
     logger.debug('stopping after compile phase')

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -274,3 +274,5 @@ var BULK_MEMORY = false;
 var MINIFY_WHITESPACE = true;
 
 var ASYNCIFY_IMPORTS_EXCEPT_JS_LIBS = [];
+
+var LINKER_INPUTS = [];

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2458,6 +2458,30 @@ int f() {
     self.run_process([EMCC, 'main.c', '-Wl,--unresolved-symbols=ignore-all'])
     self.run_process([EMCC, 'main.c', '-Wl,--allow-undefined'])
 
+  # Tests that when C/C++ code has an undefined symbol at link time,
+  # that the error message that is presented is a readable one.
+  def test_readable_undefined_symbols_error(self):
+    create_file('lib.js', r'''
+mergeInto(LibraryManager.library, {
+  qwer__deps: ['zxcv'],
+  qwer: function() {
+
+  },
+  this_is_undefined__deps: ['qwer'],
+  this_is_undefined: function(){}
+});
+''')
+    create_file('file_is_missing_symbol.c', r'''
+    void this_is_undefined(void);
+
+    int main() {
+      this_is_undefined();
+    }
+    ''')
+    output = self.expect_fail([EMCC, 'file_is_missing_symbol.c', '--js-library', 'lib.js'])
+    self.assertContained('asdf', output)
+
+
   def test_GetProcAddress_LEGACY_GL_EMULATION(self):
     # without legacy gl emulation, getting a proc from there should fail
     self.do_other_test('test_GetProcAddress_LEGACY_GL_EMULATION.cpp', args=['0'], emcc_args=['-sLEGACY_GL_EMULATION=0', '-sGL_ENABLE_GET_PROC_ADDRESS'])

--- a/tools/building.py
+++ b/tools/building.py
@@ -84,6 +84,11 @@ def get_building_env():
   return env
 
 
+# Given a list of LLVM .o object files, returns a dictionary of
+# filename -> set(undefined symbols)
+# objects that specify the U symbols (undefs) in each file.
+# This is used to track which file(s) a missing link input
+# dependency came from.
 @ToolchainProfiler.profile()
 def find_undef_symbols(files):
   cmd = get_command_with_possible_response_file([LLVM_NM, '--print-file-name'] + files)

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -173,6 +173,28 @@ def apply_static_code_hooks(forwarded_json, code):
   return code
 
 
+# Finds all occurrences of undefined symbols with "referenced by top-level compiled C/C++ code"
+# coming from compiler.js, and exhaustively searches all linker input files to tell the user
+# which inputs those undefined symbols were referenced in.
+def print_compiler_error_with_undefs(stderr):
+  undefs = building.find_undef_symbols(settings.LINKER_INPUTS)
+  errs = []
+  for line in stderr.split('\n'):
+    top_level_undefined = re.match('error: undefined symbol: (.*) \\(referenced by top-level compiled C/C\\+\\+ code\\)', line)
+    if top_level_undefined:
+      undef = top_level_undefined[1]
+      refs = []
+      for filename, nm in undefs.items():
+        if undef in list(nm):
+          refs += [filename]
+
+      refs = ','.join(refs) if len(refs) > 0 else 'referenced by top-level compiled C/C++ code'
+      errs += [f'undefined symbol: {undef} (referenced by {refs})']
+    else:
+      errs += [line]
+  logger.error('\n'.join(errs))
+
+
 def compile_javascript(symbols_only=False):
   stderr_file = os.environ.get('EMCC_STDERR_FILE')
   if stderr_file:
@@ -197,27 +219,16 @@ def compile_javascript(symbols_only=False):
                           cwd=path_from_root('src'), env=env, encoding='utf-8')
     out = ret.stdout
 
-    if ret.stderr:
-      undefs = building.find_undef_symbols(settings.LINKER_INPUTS)
+    # If compiler.js fails, it may have one or more of undefined symbol errors in it.
+    # To make these errors more readable for the user, search through all linker
+    # inputs (but do this only when necessary, since that search is relatively costly)
+    if ret.stderr and 'referenced by top-level compiled' in ret.stderr:
+      print_compiler_error_with_undefs(ret.stderr)
+    else:
+      # Compiler failed on something else than on undefined symbols, so we can print
+      # out the error directly.
+      logger.error(ret.stderr)
 
-      errs = []
-      for line in ret.stderr.split('\n'):
-        top_level_undefined = re.match('error: undefined symbol: (.*) \\(referenced by top-level compiled C/C\\+\\+ code\\)', line)
-        if top_level_undefined:
-          undef = top_level_undefined[1]
-          logger.error(f'"{undef}" is undefined, searching')
-
-          refs = []
-          for filename, nm in undefs.items():
-            logger.error(f'searching file {filename}, got {nm}')
-            if undef in list(nm):
-              refs += [filename]
-
-          refs = ','.join(refs) if len(refs) > 0 else 'referenced by top-level compiled C/C++ code'
-          errs += [f'undefined symbol: {undef} (referenced by {refs})']
-        else:
-          errs += [line]
-      logger.error('\n'.join(errs))
     if ret.returncode:
       sys.exit(ret.returncode)
   if symbols_only:

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -80,6 +80,7 @@ COMPILE_TIME_SETTINGS = {
     'LTO',
     'OPT_LEVEL',
     'DEBUG_LEVEL',
+    'LINKER_INPUTS',
 
     # Affects ports
     'GL_ENABLE_GET_PROC_ADDRESS', # NOTE: if SDL2 is updated to not rely on eglGetProcAddress(), this can be removed


### PR DESCRIPTION
In #20534 the error message from the link produces an unhelpful

```
emscripten:ERROR: undefined symbol: __cxa_find_matching_catch_3 (referenced by top-level compiled C/C++ code)
emscripten:ERROR: undefined symbol: __resumeException (referenced by top-level compiled C/C++ code)
emscripten:ERROR: undefined symbol: llvm_eh_typeid_for (referenced by top-level compiled C/C++ code)
```

In our huge Unity build system, I am likewise troubleshooting the same above errors, and also a separate build error with

```
Building Library\Bee\artifacts\WebGL\build\debug_WebGL_wasm\build.js failed with output:
emscripten:ERROR: undefined symbol: emscripten_longjmp (referenced by top-level compiled C/C++ code)
```

In a vast codebase that is built with several different build systems from external third party libraries, the above makes it impossible to understand where the source is coming from.

This PR improves Emscripten to report more helpful error messages:

```
emscripten:ERROR: undefined symbol: __cxa_find_matching_catch_3 (referenced by a.a:a.o)
emscripten:ERROR: undefined symbol: __resumeException (referenced by a.a:a.o)
emscripten:ERROR: undefined symbol: llvm_eh_typeid_for (referenced by a.a:a.o)
```

```
Building Library\Bee\artifacts\WebGL\build\debug_WebGL_wasm\build.js failed with output:
emscripten:ERROR: undefined symbol: emscripten_longjmp (referenced by C:/unity/build/WebGLSupport/BuildTools/lib/modules_development_wasm23/WebGLSupport_UnityPlayer.CoreModule_Dynamic.a:External_libtess2_libtess2_0_p6uvq.o,C:/unity/build/WebGLSupport/BuildTools/lib/modules_development_wasm23/WebGLSupport_UnityPlayer.ImageConversionModule_Dynamic.a:Modules_ImageConversion_0_rbqj9.o,C:/unity/build/WebGLSupport/BuildTools/lib/modules_development_wasm23/WebGLSupport_UnityPlayer.ImageConversionModule_Dynamic.a:External_libpng_src_1_7kqn7.o,C:/unity/build/WebGLSupport/BuildTools/lib/modules_development_wasm23/WebGLSupport_UnityPlayer.TextRenderingModule_Dynamic.a:ftbase_8zl7l.o,C:/unity/build/WebGLSupport/BuildTools/lib/modules_development_wasm23/WebGLSupport_UnityPlayer.TextRenderingModule_Dynamic.a:sfnt_0b4ju.o,C:/unity/build/WebGLSupport/BuildTools/lib/modules_development_wasm23/WebGLSupport_UnityPlayer.TextRenderingModule_Dynamic.a:otvalid_yeic4.o,C:/unity/build/WebGLSupport/BuildTools/lib/modules_development_wasm23/WebGLSupport_UnityPlayer.TextRenderingModule_Dynamic.a:smooth_9uxt4.o,C:/unity/build/WebGLSupport/BuildTools/lib/modules_development_wasm23/WebGLSupport_UnityPlayer.TextRenderingModule_Dynamic.a:External_libpng_src_1_7kqn7.o)
```
that is a massive aid for the developer figure out where to go look at.

Needs a better solution than the `settings.LINKER_INPUTS` variable, feedback welcome. Also could not use `shared.run_js_tool` because it does not allow receiving `stderr` back.