### PR TITLE
Fix LTO runs of test_nothrow_new_nogrow

### DIFF
--- a/test/core/test_nothrow_new.cpp
+++ b/test/core/test_nothrow_new.cpp
@@ -3,18 +3,14 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
-#include <iostream>
+#include <cassert>
+#include <cstdio>
 #include <new>
 
-char* data;
-
 int main() {
-  data = new (std::nothrow) char[20 * 1024 * 1024];
-  if (data == nullptr) {
-    std::cout << "success" << std::endl;
-    return 0;
-  } else {
-    std::cout << "failure" << std::endl;
-    return 1;
-  }
+  char* data = new (std::nothrow) char[20 * 1024 * 1024];
+  printf("data: %p\n", data);
+  assert(data == nullptr);
+  printf("success\n");
+  return 0;
 }

--- a/test/core/test_nothrow_new.out
+++ b/test/core/test_nothrow_new.out
@@ -1,1 +1,2 @@
+data: 0
 success


### PR DESCRIPTION
This test was recently added in #20154 but has been failing on the emscripten-releases waterfall in thinlto modes.

I'm not sure exactly why, but it seems that perhaps when the value of `data` is not actually thinLTO simple removes the call the new/malloc?  I'm not sure why this wasn't also failing under full LTO.