### PR TITLE
Remove remaining references to removed `emscripten_memcpy_big`. NFC

### DIFF
--- a/test/optimizer/applyImportAndExportNameChanges-output.js
+++ b/test/optimizer/applyImportAndExportNameChanges-output.js
@@ -8,7 +8,7 @@ var wasmImports = {
  memset: _memset,
  sbrk: _sbrk,
  memcpy: _memcpy,
- emscripten_memcpy_big: _emscripten_memcpy_big,
+ emscripten_memcpy_js: _emscripten_memcpy_js,
  c: ___syscall54,
  d: ___syscall140,
  q: ___syscall146

--- a/test/optimizer/applyImportAndExportNameChanges.js
+++ b/test/optimizer/applyImportAndExportNameChanges.js
@@ -7,7 +7,7 @@ var wasmImports = {
   memset: _memset,
   sbrk: _sbrk,
   memcpy: _memcpy,
-  emscripten_memcpy_big: _emscripten_memcpy_big,
+  emscripten_memcpy_js: _emscripten_memcpy_js,
   __syscall54: ___syscall54,
   __syscall140: ___syscall140,
   __syscall146: ___syscall146

--- a/test/optimizer/applyImportAndExportNameChanges2-output.js
+++ b/test/optimizer/applyImportAndExportNameChanges2-output.js
@@ -191,7 +191,7 @@ function _emscripten_random() {
  return Math.random();
 }
 
-function _emscripten_memcpy_big(dest, src, num) {
+function _emscripten_memcpy_js(dest, src, num) {
  HEAPU8.set(HEAPU8.subarray(src, src + num), dest);
 }
 
@@ -219,7 +219,7 @@ var wasmImports = {
  g: ___syscall54,
  f: ___syscall6,
  e: _emscripten_get_now,
- d: _emscripten_memcpy_big,
+ d: _emscripten_memcpy_js,
  c: _emscripten_random
 };
 

--- a/test/optimizer/applyImportAndExportNameChanges2.js
+++ b/test/optimizer/applyImportAndExportNameChanges2.js
@@ -184,7 +184,7 @@ function _emscripten_random() {
     return Math.random()
 }
 
-function _emscripten_memcpy_big(dest, src, num) {
+function _emscripten_memcpy_js(dest, src, num) {
     HEAPU8.set(HEAPU8.subarray(src, src + num), dest)
 }
 if (ENVIRONMENT_IS_NODE) {
@@ -210,7 +210,7 @@ var wasmImports = {
     ___syscall54: ___syscall54,
     ___syscall6: ___syscall6,
     _emscripten_get_now: _emscripten_get_now,
-    _emscripten_memcpy_big: _emscripten_memcpy_big,
+    _emscripten_memcpy_js: _emscripten_memcpy_js,
     _emscripten_random: _emscripten_random
 };
 
@@ -262,4 +262,4 @@ WebAssembly.instantiate(Module["wasm"], imports).then(((output) => {
 
 
 
-// EXTRA_INFO: {"mapping": {"_llvm_bswap_i32": "k", "_emscripten_random": "c", "dynCall_ii": "o", "__GLOBAL__sub_I_test_global_initializer_cpp": "i", "___errno_location": "j", "dynCall_iiii": "p", "___syscall6": "f", "_memset": "n", "_memcpy": "m", "abort": "b", "___syscall146": "a", "_emscripten_memcpy_big": "d", "___syscall54": "g", "___syscall140": "h", "_emscripten_get_now": "e", "_main": "l"}}
+// EXTRA_INFO: {"mapping": {"_llvm_bswap_i32": "k", "_emscripten_random": "c", "dynCall_ii": "o", "__GLOBAL__sub_I_test_global_initializer_cpp": "i", "___errno_location": "j", "dynCall_iiii": "p", "___syscall6": "f", "_memset": "n", "_memcpy": "m", "abort": "b", "___syscall146": "a", "_emscripten_memcpy_js": "d", "___syscall54": "g", "___syscall140": "h", "_emscripten_get_now": "e", "_main": "l"}}

--- a/test/optimizer/wasm2js-output.js
+++ b/test/optimizer/wasm2js-output.js
@@ -28,7 +28,7 @@ function instantiate(H, I, J) {
   var w = E.NaN;
   var x = E.Infinity;
   var y = F.fd_write;
-  var z = F.emscripten_memcpy_big;
+  var z = F.emscripten_memcpy_js;
   var A = 5245632;
   var B = 0;
   

--- a/test/optimizer/wasm2js.js
+++ b/test/optimizer/wasm2js.js
@@ -31,7 +31,7 @@ function asmFunc(global, env, buffer) {
  var nan = global.NaN;
  var infinity = global.Infinity;
  var fimport$0 = env.fd_write;
- var fimport$1 = env.emscripten_memcpy_big;
+ var fimport$1 = env.emscripten_memcpy_js;
  var global$0 = 5245632;
  var i64toi32_i32$HIGH_BITS = 0;
  // EMSCRIPTEN_START_FUNCS

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13752,8 +13752,9 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
         self.assertContained('_emscripten_memcpy_js', js)
         self.assertNotIn('$emscripten_memcpy_bulkmem', funcs)
 
-    # By default we expect to find _emscripten_memcpy_big in the generaed JS and not in the
-    # native code.
+    # By default we expect to find `_emscripten_memcpy_js` in the generaed JS
+    # and not to find the `emscripten_memcpy_bulkmem` function on the wasm
+    # side.
     run([], expect_bulk_mem=False)
 
     # With bulk memory enabled we expect *not* to find it.


### PR DESCRIPTION
This function was renamed in #20144.  This change updates/removes the remaining references.