### PR TITLE
Update the minimum supported build-time version of node to 16.20.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 3.1.48 (in development)
 -----------------------
+- The minimum version of node required run the compiler was updated from
+  10.19 to 16.20.  This does not effect the node requirements of the generated
+  JavaScript code. (#20551)
 - A new top-level `bootstrap` script was added.  This script is for emscripten
   developers and helps take a care of post-checkout tasks such as `npm install`.
   If this script needs to be run (e.g. becuase package.json was changed, emcc

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -281,8 +281,8 @@ class sanity(RunnerCore):
     for version, succeed in [('v0.8.0', False),
                              ('v4.1.0', False),
                              ('v10.18.0', False),
-                             ('v10.19.0', True),
-                             ('v10.19.1-pre', True),
+                             ('v16.20.0', True),
+                             ('v16.20.1-pre', True),
                              ('cheez', False)]:
       print(version, succeed)
       delete_file(SANITY_FILE)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -52,11 +52,12 @@ DEBUG_SAVE = DEBUG or int(os.environ.get('EMCC_DEBUG_SAVE', '0'))
 PRINT_SUBPROCS = int(os.getenv('EMCC_VERBOSE', '0'))
 SKIP_SUBPROCS = False
 
-# Minimum node version required to run the emscripten compiler.  This is distinct
-# from the minimum version required to execute the generated code.  This is not an
-# exact requirement, but is the oldest version of node that we do any testing with.
-# This version aligns with the current Ubuuntu TLS 20.04 (Focal).
-MINIMUM_NODE_VERSION = (10, 19, 0)
+# Minimum node version required to run the emscripten compiler.  This is
+# distinct from the minimum version required to execute the generated code
+# (settings.MIN_NODE_VERSION).
+# This version currently matches the node version that we ship with emsdk
+# which means that we can say for sure that this version is well supported.
+MINIMUM_NODE_VERSION = (16, 20, 0)
 EXPECTED_LLVM_VERSION = 18
 
 # These get set by setup_temp_dirs


### PR DESCRIPTION
Bump the minimum build-time version of node 10.19.0 -> 16.20.0

This new minimum version matches the version that we ship with emsdk.
Critically it supports null coalescing & logical assignment needed
by #20549.