### PR TITLE
Update to stable wasmer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -444,7 +444,7 @@ jobs:
       - run:
           name: get wasmer
           command: |
-            wget https://github.com/wasmerio/wasmer/releases/download/0.11.0/wasmer-linux-amd64.tar.gz
+            wget https://github.com/wasmerio/wasmer/releases/download/v4.2.3/wasmer-linux-amd64.tar.gz
             tar -xf wasmer-linux-amd64.tar.gz
             mkdir ~/vms
             cp bin/wasmer ~/vms

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -444,7 +444,7 @@ jobs:
       - run:
           name: get wasmer
           command: |
-            wget https://github.com/wasmerio/wasmer/releases/download/v3.3.0/wasmer-linux-amd64.tar.gz
+            wget https://github.com/wasmerio/wasmer/releases/download/v3.1.1/wasmer-linux-amd64.tar.gz
             tar -xf wasmer-linux-amd64.tar.gz
             mkdir ~/vms
             cp bin/wasmer ~/vms

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -444,7 +444,7 @@ jobs:
       - run:
           name: get wasmer
           command: |
-            wget https://github.com/wasmerio/wasmer/releases/download/v4.2.3/wasmer-linux-amd64.tar.gz
+            wget https://github.com/wasmerio/wasmer/releases/download/v3.3.0/wasmer-linux-amd64.tar.gz
             tar -xf wasmer-linux-amd64.tar.gz
             mkdir ~/vms
             cp bin/wasmer ~/vms


### PR DESCRIPTION
Previously we were using very old pre-release version of wasmer on CI, which, unlike all other engines we will support soon, didn't have bulk memory enabled by default.

I haven't actually tried this locally but hopefully just changing the version is enough.