### PR TITLE
Remove warning for Ninja being experimental

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -139,7 +139,6 @@ def get_top_level_ninja_file():
 
 
 def run_ninja(build_dir):
-  diagnostics.warning('experimental', 'ninja support is experimental')
   cmd = ['ninja', '-C', build_dir, f'-j{shared.get_num_cores()}']
   if shared.PRINT_SUBPROCS:
     cmd.append('-v')


### PR DESCRIPTION
Ninja support is opt-in anyway, and has been around for a while now, so no point in showing the warning on each invocation.

Fixes #19079.