### PR TITLE
Disable bulk memory on wasm64 for older Node.js

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2517,6 +2517,12 @@ def phase_linker_setup(options, state, newargs):
   settings.SUPPORTS_PROMISE_ANY = feature_matrix.caniuse(feature_matrix.Feature.PROMISE_ANY)
   if not settings.BULK_MEMORY:
     settings.BULK_MEMORY = feature_matrix.caniuse(feature_matrix.Feature.BULK_MEMORY)
+    if settings.MEMORY64 and settings.MIN_NODE_VERSION < 180000:
+      logger.warning(
+        "Disabling bulk memory because it doesn't work correctly with wasm64 in Node.js < 18.\n"
+        "Set MIN_NODE_VERSION to 180000 or above to enable it."
+      )
+      settings.BULK_MEMORY = 0
 
   if settings.AUDIO_WORKLET:
     if settings.AUDIO_WORKLET == 1:

--- a/emcc.py
+++ b/emcc.py
@@ -2518,6 +2518,15 @@ def phase_linker_setup(options, state, newargs):
   if not settings.BULK_MEMORY:
     settings.BULK_MEMORY = feature_matrix.caniuse(feature_matrix.Feature.BULK_MEMORY)
     if settings.MEMORY64 and settings.MIN_NODE_VERSION < 180000:
+      # Note that we do not update tools/feature_matrix.py for this, as this issue is
+      # wasm64-specific: bulk memory for wasm32 has shipped in Node.js 12.5, but
+      # bulk memory for wasm64 has shipped only in Node.js 18.
+      #
+      # Feature matrix currently cannot express such complex combinations of
+      # features, so the only options are to either choose the least common
+      # denominator and disable bulk memory altogether for Node.js < 18 or to
+      # special-case this situation here. The former would be limiting for
+      # wasm32 users, so instead we do the latter:
       logger.warning(
         "Disabling bulk memory because it doesn't work correctly with wasm64 in Node.js < 18.\n"
         "Set MIN_NODE_VERSION to 180000 or above to enable it."


### PR DESCRIPTION
Bulk memory for wasm64 was implemented in V8 at https://github.com/v8/v8/commit/18469ec4bfb301991158d0423f07d53c338d09da which was first shipped in Node.js 18 (thanks @kleisauke).

Split out from https://github.com/emscripten-core/emscripten/pull/20549 where this was caught initially.

Fixes #20560.