### PR TITLE
allow to generate imports w/o using dynamic expressions

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -372,7 +372,12 @@ var LibraryPThread = {
         // it could load up the same file. In that case, developer must either deliver the Blob
         // object in Module['mainScriptUrlOrBlob'], or a URL to it, so that pthread Workers can
         // independently load up the same main application file.
-        'urlOrBlob': Module['mainScriptUrlOrBlob']
+        'urlOrBlob':
+#if expectToReceiveOnModule('mainScriptUrlOrBlob')
+        Module['mainScriptUrlOrBlob']
+#else
+        undefined
+#endif
 #if !EXPORT_ES6
         || _scriptDir
 #endif
@@ -438,8 +443,10 @@ var LibraryPThread = {
       var pthreadMainJs = Module['worker'];
 #else
 #if EXPORT_ES6 && USE_ES6_IMPORT_META
+#if expectToReceiveOnModule('locateFile')
       // If we're using module output and there's no explicit override, use bundler-friendly pattern.
       if (!Module['locateFile']) {
+#endif
 #if PTHREADS_DEBUG
         dbg('Allocating a new web worker from ' + new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url));
 #endif
@@ -456,7 +463,9 @@ var LibraryPThread = {
         } else
 #endif
         worker = new Worker(new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url), {type: 'module'});
+#if expectToReceiveOnModule('locateFile')
       } else {
+#endif
 #endif
       // Allow HTML module to configure the location where the 'worker.js' file will be loaded from,
       // via Module.locateFile() function. If not specified, then the default URL 'worker.js' relative
@@ -474,7 +483,7 @@ var LibraryPThread = {
       } else
 #endif
       worker = new Worker(pthreadMainJs{{{ EXPORT_ES6 ? ", {type: 'module'}" : '' }}});
-#if EXPORT_ES6 && USE_ES6_IMPORT_META
+#if EXPORT_ES6 && USE_ES6_IMPORT_META && expectToReceiveOnModule('locateFile')
     }
 #endif
     PThread.unusedWorkers.push(worker);

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -613,15 +613,19 @@ function instrumentWasmTableWithAbort() {
 #endif
 
 var wasmBinaryFile;
-#if EXPORT_ES6 && USE_ES6_IMPORT_META && !SINGLE_FILE
+#if EXPORT_ES6 && USE_ES6_IMPORT_META && !SINGLE_FILE && expectToReceiveOnModule('locateFile')
 if (Module['locateFile']) {
 #endif
   wasmBinaryFile = '{{{ WASM_BINARY_FILE }}}';
+#if expectToReceiveOnModule('locateFile')
   if (!isDataURI(wasmBinaryFile)) {
     wasmBinaryFile = locateFile(wasmBinaryFile);
   }
+#endif
 #if EXPORT_ES6 && USE_ES6_IMPORT_META && !SINGLE_FILE // in single-file mode, repeating WASM_BINARY_FILE would emit the contents again
+#if expectToReceiveOnModule('locateFile')
 } else {
+#endif
 #if ENVIRONMENT_MAY_BE_SHELL
   if (ENVIRONMENT_IS_SHELL)
     wasmBinaryFile = '{{{ WASM_BINARY_FILE }}}';
@@ -629,7 +633,9 @@ if (Module['locateFile']) {
 #endif
   // Use bundler-friendly `new URL(..., import.meta.url)` pattern; works in browsers too.
   wasmBinaryFile = new URL('{{{ WASM_BINARY_FILE }}}', import.meta.url).href;
+#if expectToReceiveOnModule('locateFile')
 }
+#endif
 #endif
 
 function getBinarySync(file) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -180,9 +180,14 @@ function handleMessage(e) {
 #endif
 
 #if MODULARIZE && EXPORT_ES6
-      (e.data.urlOrBlob ? import(e.data.urlOrBlob) : import('./{{{ TARGET_JS_NAME }}}'))
+      (
+#if expectToReceiveOnModule('mainScriptUrlOrBlob')
+        e.data.urlOrBlob ? import(e.data.urlOrBlob) :
+#endif
+        import('./{{{ TARGET_JS_NAME }}}'))
       .then(exports => exports.default(Module));
 #else
+#if expectToReceiveOnModule('mainScriptUrlOrBlob')
       if (typeof e.data.urlOrBlob == 'string') {
 #if TRUSTED_TYPES
         if (typeof self.trustedTypes != 'undefined' && self.trustedTypes.createPolicy) {
@@ -209,6 +214,7 @@ function handleMessage(e) {
       {{{ EXPORT_NAME }}}(Module);
 #endif
 #endif
+#endif // expectToReceiveOnModule('mainScriptUrlOrBlob')
 #endif // MODULARIZE && EXPORT_ES6
     } else if (e.data.cmd === 'run') {
       // Pass the thread address to wasm to store it for fast access.

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -356,6 +356,21 @@ class other(RunnerCore):
     self.assertNotContained('import.meta.url', src)
     self.assertContained('export default Module;', src)
 
+  def test_emcc_output_mjs_no_import_expression(self):
+    # Ensure there are no imports using dynamic expressions
+    self.run_process([EMCC, '-o', 'hello_world.mjs',
+                      test_file('hello_world.c'),
+                      '-pthread',
+                      '-sMODULARIZE=1',
+                      '-sEXPORT_ES6',
+                      '-sENVIRONMENT=web,worker',
+                      '-sUSE_ES6_IMPORT_META=1',
+                      '-sINCOMING_MODULE_JS_API=[]'
+                    ])
+    src = read_file('hello_world.mjs')
+    self.assertNotContained('import(e.data.urlOrBlob)', src)
+    self.assertContained('import.meta.url', src)
+
   def test_export_es6_implies_modularize(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-sEXPORT_ES6'])
     src = read_file('a.out.js')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -356,7 +356,7 @@ class other(RunnerCore):
     self.assertNotContained('import.meta.url', src)
     self.assertContained('export default Module;', src)
 
-  def test_emcc_output_mjs_no_import_expression(self):
+  def test_emcc_output_mjs_no_dynamic_import(self):
     # Ensure there are no imports using dynamic expressions
     self.run_process([EMCC, '-o', 'hello_world.mjs',
                       test_file('hello_world.c'),
@@ -369,7 +369,8 @@ class other(RunnerCore):
                     ])
     src = read_file('hello_world.mjs')
     self.assertNotContained('import(e.data.urlOrBlob)', src)
-    self.assertContained('import.meta.url', src)
+    self.assertContained('new URL("*.wasm",import.meta.url)')
+    self.assertContained('new URL("*.worker.js",import.meta.url)')
 
   def test_export_es6_implies_modularize(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-sEXPORT_ES6'])

--- a/tools/preprocessor.js
+++ b/tools/preprocessor.js
@@ -55,6 +55,12 @@ const inputFile = arguments_[1];
 const expandMacros = arguments_.includes('--expandMacros');
 
 load(settingsFile);
+
+if (!ALL_INCOMING_MODULE_JS_API.length) {
+  ALL_INCOMING_MODULE_JS_API = INCOMING_MODULE_JS_API;
+}
+INCOMING_MODULE_JS_API = new Set(INCOMING_MODULE_JS_API);
+
 load('utility.js');
 load('modules.js');
 load('parseTools.js');


### PR DESCRIPTION
Refs: #20503

* Render the code fragments referencing `Module['mainScriptUrlOrBlob']` and `Module['locateFile']` optional
* Add `INCOMING_MODULE_JS_API` processing logic to `preprocessor.js`