### PR TITLE
Support separate version of Node.js for running tests. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,8 +98,8 @@ commands:
               wget https://nodejs.org/dist/v${version}/node-v${version}-linux-x64.tar.xz
             fi
             tar xf node-v${version}-linux-x64.tar.xz
-            echo "NODE_JS = [os.path.expanduser('~/node-v${version}-linux-x64/bin/node')]" >> ~/emsdk/.emscripten
-            echo "JS_ENGINES = [NODE_JS]" >> ~/emsdk/.emscripten
+            echo "NODE_JS_TEST = [os.path.expanduser('~/node-v${version}-linux-x64/bin/node')]" >> ~/emsdk/.emscripten
+            echo "JS_ENGINES = [NODE_JS_TEST]" >> ~/emsdk/.emscripten
             echo "if os.path.exists(V8_ENGINE[0]): JS_ENGINES.append(V8_ENGINE)" >> ~/emsdk/.emscripten
             cat ~/emsdk/.emscripten
             echo "export PATH=\"$HOME/node-v${version}-linux-x64/bin:\$PATH\"" >> $BASH_ENV

--- a/emcc.py
+++ b/emcc.py
@@ -748,7 +748,7 @@ def make_js_executable(script):
   if settings.MEMORY64 == 1:
     cmd += shared.node_memory64_flags()
   elif settings.WASM_BIGINT:
-    cmd += shared.node_bigint_flags()
+    cmd += shared.node_bigint_flags(config.NODE_JS)
   if len(cmd) > 1 or not os.path.isabs(cmd[0]):
     # Using -S (--split-string) here means that arguments to the executable are
     # correctly parsed.  We don't do this by default because old versions of env

--- a/emcmake.py
+++ b/emcmake.py
@@ -39,7 +39,7 @@ variables so that emcc etc. are used. Typical usage:
     node_js = [config.NODE_JS[0]]
     # In order to allow cmake to run code built with pthreads we need to pass
     # some extra flags to node.
-    node_js += shared.node_pthread_flags()
+    node_js += shared.node_pthread_flags(config.NODE_JS)
     node_js = ';'.join(node_js)
     # See https://github.com/emscripten-core/emscripten/issues/15522
     args.append(f'-DCMAKE_CROSSCOMPILING_EMULATOR={node_js}')

--- a/test/common.py
+++ b/test/common.py
@@ -83,6 +83,8 @@ EMRUN = shared.bat_suffix(shared.path_from_root('emrun'))
 WASM_DIS = Path(building.get_binaryen_bin(), 'wasm-dis')
 LLVM_OBJDUMP = os.path.expanduser(shared.build_llvm_tool_path(shared.exe_suffix('llvm-objdump')))
 PYTHON = sys.executable
+if not config.NODE_JS_TEST:
+  config.NODE_JS_TEST = config.NODE_JS
 
 
 def test_file(*path_components):
@@ -317,7 +319,8 @@ def also_with_wasm_bigint(f):
       if self.get_setting('WASM_BIGINT') is not None:
         self.skipTest('redundant in bigint test config')
       self.set_setting('WASM_BIGINT')
-      self.node_args += shared.node_bigint_flags()
+      nodejs = self.require_node()
+      self.node_args += shared.node_bigint_flags(nodejs)
       f(self)
     else:
       f(self)
@@ -381,7 +384,8 @@ def also_with_standalone_wasm(impure=False):
         # if we are impure, disallow all wasm engines
         if impure:
           self.wasm_engines = []
-        self.node_args += shared.node_bigint_flags()
+        nodejs = self.require_node()
+        self.node_args += shared.node_bigint_flags(nodejs)
         func(self)
 
     metafunc._parameterize = {'': (False,),
@@ -606,19 +610,27 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     self.require_engine(config.V8_ENGINE)
     self.emcc_args.append('-sENVIRONMENT=shell')
 
+  def get_nodejs(self):
+    if config.NODE_JS_TEST not in self.js_engines:
+      return None
+    return config.NODE_JS_TEST
+
   def require_node(self):
-    if not config.NODE_JS or config.NODE_JS not in config.JS_ENGINES:
+    nodejs = self.get_nodejs()
+    if not nodejs:
       if 'EMTEST_SKIP_NODE' in os.environ:
         self.skipTest('test requires node and EMTEST_SKIP_NODE is set')
       else:
         self.fail('node required to run this test.  Use EMTEST_SKIP_NODE to skip')
-    self.require_engine(config.NODE_JS)
+    self.require_engine(nodejs)
+    return nodejs
 
   def require_node_canary(self):
-    if config.NODE_JS or config.NODE_JS in config.JS_ENGINES:
-      version = shared.check_node_version()
+    nodejs = self.get_nodejs()
+    if nodejs:
+      version = shared.get_node_version(nodejs)
       if version >= (20, 0, 0):
-        self.require_engine(config.NODE_JS)
+        self.require_engine(nodejs)
         return
 
     if 'EMTEST_SKIP_NODE_CANARY' in os.environ:
@@ -635,10 +647,11 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     self.wasm_engines = []
 
   def require_wasm64(self):
-    if config.NODE_JS and config.NODE_JS in self.js_engines:
-      version = shared.check_node_version()
+    nodejs = self.get_nodejs()
+    if nodejs:
+      version = shared.get_node_version(nodejs)
       if version >= (16, 0, 0):
-        self.js_engines = [config.NODE_JS]
+        self.js_engines = [nodejs]
         self.node_args += shared.node_memory64_flags()
         return
 
@@ -654,10 +667,11 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       self.fail('either d8 or node >= 16 required to run wasm64 tests.  Use EMTEST_SKIP_WASM64 to skip')
 
   def require_simd(self):
-    if config.NODE_JS and config.NODE_JS in self.js_engines:
-      version = shared.check_node_version()
+    nodejs = self.get_nodejs()
+    if nodejs:
+      version = shared.get_node_version(nodejs)
       if version >= (16, 0, 0):
-        self.js_engines = [config.NODE_JS]
+        self.js_engines = [nodejs]
         return
 
     if config.V8_ENGINE and config.V8_ENGINE in self.js_engines:
@@ -671,10 +685,11 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       self.fail('either d8 or node >= 16 required to run wasm64 tests.  Use EMTEST_SKIP_SIMD to skip')
 
   def require_wasm_eh(self):
-    if config.NODE_JS and config.NODE_JS in self.js_engines:
-      version = shared.check_node_version()
+    nodejs = self.get_nodejs()
+    if nodejs:
+      version = shared.get_node_version(nodejs)
       if version >= (17, 0, 0):
-        self.js_engines = [config.NODE_JS]
+        self.js_engines = [nodejs]
         return
 
     if config.V8_ENGINE and config.V8_ENGINE in self.js_engines:
@@ -701,12 +716,13 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       return
 
     exp_args = ['--experimental-wasm-stack-switching', '--experimental-wasm-type-reflection']
-    if config.NODE_JS and config.NODE_JS in self.js_engines:
-      version = shared.check_node_version()
+    nodejs = self.get_nodejs()
+    if nodejs:
+      version = shared.get_node_version(nodejs)
       # Support for JSPI came earlier than 19, but 19 is what currently works
       # with emscripten's implementation.
       if version >= (19, 0, 0):
-        self.js_engines = [config.NODE_JS]
+        self.js_engines = [nodejs]
         self.node_args += exp_args
         return
 
@@ -726,8 +742,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     self.emcc_args += ['-Wno-pthreads-mem-growth', '-pthread']
     if self.get_setting('MINIMAL_RUNTIME'):
       self.skipTest('node pthreads not yet supported with MINIMAL_RUNTIME')
-    self.js_engines = [config.NODE_JS]
-    self.node_args += shared.node_pthread_flags()
+    nodejs = self.get_nodejs()
+    self.js_engines = [nodejs]
+    self.node_args += shared.node_pthread_flags(nodejs)
 
   def uses_memory_init_file(self):
     if self.get_setting('SIDE_MODULE') or (self.is_wasm() and not self.get_setting('WASM2JS')):
@@ -753,14 +770,16 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
   def setUp(self):
     super().setUp()
+    self.js_engines = config.JS_ENGINES.copy()
     self.settings_mods = {}
     self.emcc_args = ['-Wclosure', '-Werror', '-Wno-limited-postlink-optimizations']
     self.ldflags = []
     # Increate stack trace limit to maximise usefulness of test failure reports
     self.node_args = ['--stack-trace-limit=50']
 
-    node_version = shared.check_node_version()
-    if node_version:
+    nodejs = self.get_nodejs()
+    if nodejs:
+      node_version = shared.get_node_version(nodejs)
       if node_version < (11, 0, 0):
         self.node_args.append('--unhandled-rejections=strict')
         self.node_args.append('--experimental-wasm-se')
@@ -787,11 +806,10 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     self.env = {}
     self.temp_files_before_run = []
     self.uses_es6 = False
-    self.js_engines = config.JS_ENGINES.copy()
     self.required_engine = None
     self.wasm_engines = config.WASM_ENGINES.copy()
     self.use_all_engines = EMTEST_ALL_ENGINES
-    if self.js_engines[0] != config.NODE_JS:
+    if self.js_engines[0] != config.NODE_JS_TEST:
       # If our primary JS engine is something other than node then enable
       # shell support.
       default_envs = 'web,webview,worker,node'
@@ -935,7 +953,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     # use --quiet once its available
     # See: https://github.com/dollarshaveclub/es-check/pull/126/
     es_check_env = os.environ.copy()
-    es_check_env['PATH'] = os.path.dirname(config.NODE_JS[0]) + os.pathsep + es_check_env['PATH']
+    es_check_env['PATH'] = os.path.dirname(config.NODE_JS_TEST[0]) + os.pathsep + es_check_env['PATH']
     inputfile = os.path.abspath(filename)
     # For some reason es-check requires unix paths, even on windows
     if WINDOWS:
@@ -1091,7 +1109,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     timeout_error = None
     if not engine:
       engine = self.js_engines[0]
-    if engine == config.NODE_JS:
+    if engine == config.NODE_JS_TEST:
       engine = engine + self.node_args
     if engine == config.V8_ENGINE:
       engine = engine + self.v8_args
@@ -2103,8 +2121,8 @@ class BrowserCore(RunnerCore):
     if not isinstance(expected, list):
       expected = [expected]
     if EMTEST_BROWSER == 'node':
-      self.require_node()
-      self.node_args += shared.node_pthread_flags()
+      nodejs = self.require_node()
+      self.node_args += shared.node_pthread_flags(nodejs)
       output = self.run_js('test.js')
       self.assertContained('RESULT: ' + expected[0], output)
     else:

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7480,7 +7480,7 @@ Resolved: "/" => "/"
     ''')
 
     # Run the test and confirm the output is as expected.
-    self.node_args += shared.node_bigint_flags()
+    self.node_args += shared.node_bigint_flags(self.get_nodejs())
     out = self.run_js('testrun.js')
     self.assertContained('''\
 input = 0xaabbccdd11223344
@@ -7720,7 +7720,7 @@ int main() {}
       for engine in config.JS_ENGINES:
         if engine == config.V8_ENGINE:
           continue # ban v8, weird failures
-        actual = 'NODE' if engine == config.NODE_JS else 'SHELL'
+        actual = 'NODE' if engine == config.NODE_JS_TEST else 'SHELL'
         print(env, actual, engine)
         module = {'ENVIRONMENT': env}
         if env != actual:
@@ -9831,7 +9831,7 @@ test_module().then((test_module_instance) => {
   def test_node_eval(self):
     self.run_process([EMCC, '-sENVIRONMENT=node', test_file('hello_world.c'), '-o', 'a.js', '-O3'])
     js = read_file('a.js')
-    ret = self.run_process(config.NODE_JS + ['-e', js], stdout=PIPE).stdout
+    ret = self.run_process(config.NODE_JS_TEST + ['-e', js], stdout=PIPE).stdout
     self.assertContained('hello, world!', ret)
 
   def test_is_bitcode(self):
@@ -12223,7 +12223,7 @@ exec "$@"
     self.assertFileContents(path_from_root('src/generated_struct_info32.json'), read_file('out.json'))
 
     # Same again for wasm64
-    node_version = shared.check_node_version()
+    node_version = shared.get_node_version(self.get_nodejs())
     if node_version and node_version >= (14, 0, 0):
       self.run_process([PYTHON, path_from_root('tools/gen_struct_info.py'), '--wasm64', '-o', 'out.json'])
       self.assertFileContents(path_from_root('src/generated_struct_info64.json'), read_file('out.json'))
@@ -12732,7 +12732,7 @@ void foo() {}
     self.build('main.c', emcc_args=['--pre-js=pre.js', '-sNODEJS_CATCH_REJECTION=0'])
     self.assertNotContained('unhandledRejection', read_file('main.js'))
 
-    if shared.check_node_version()[0] >= 15:
+    if shared.get_node_version(self.get_nodejs())[0] >= 15:
       self.skipTest('old behaviour of node JS cannot be tested on node v15 or above')
 
     output = self.run_js('main.js')
@@ -12930,7 +12930,7 @@ Module.postRun = () => {{
   def test_wasmfs_readfile_bigint(self):
     self.set_setting('FORCE_FILESYSTEM')
     self.set_setting('WASM_BIGINT')
-    self.node_args += shared.node_bigint_flags()
+    self.node_args += shared.node_bigint_flags(self.get_nodejs())
     self.do_run_in_out_file_test('wasmfs/wasmfs_readfile.c')
 
   def test_wasmfs_jsfile(self):
@@ -13161,7 +13161,7 @@ int main() {
   @also_with_minimal_runtime
   def test_shared_memory(self):
     self.do_runf('wasm_worker/shared_memory.c', '0', emcc_args=[])
-    self.node_args += shared.node_pthread_flags()
+    self.node_args += shared.node_pthread_flags(self.get_nodejs())
     self.do_runf('wasm_worker/shared_memory.c', '1', emcc_args=['-sSHARED_MEMORY'])
     self.do_runf('wasm_worker/shared_memory.c', '1', emcc_args=['-sWASM_WORKERS'])
     self.do_runf('wasm_worker/shared_memory.c', '1', emcc_args=['-pthread'])
@@ -13201,7 +13201,7 @@ int main() {
 
   # Tests the internal test suite of tools/unsafe_optimizations.js
   def test_unsafe_optimizations(self):
-    self.run_process(config.NODE_JS + [path_from_root('tools', 'unsafe_optimizations.js'), '--test'])
+    self.run_process(config.NODE_JS_TEST + [path_from_root('tools', 'unsafe_optimizations.js'), '--test'])
 
   @requires_v8
   def test_extended_const(self):
@@ -13635,8 +13635,9 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     self.do_runf('hello_world.c', '4\nhello, world!',
                  emcc_args=['--post-js=post.js', '--js-library=lib.js'])
 
+  @requires_node
   def test_min_node_version(self):
-    node_version = shared.check_node_version()
+    node_version = shared.get_node_version(self.get_nodejs())
     node_version = '.'.join(str(x) for x in node_version)
     self.set_setting('MIN_NODE_VERSION', 210000)
     expected = 'This emscripten-generated code requires node v21.0.0 (detected v%s' % node_version
@@ -13694,7 +13695,7 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
   def run_wasi_test_suite_test(self, name):
     if not os.path.exists(path_from_root('test/third_party/wasi-test-suite')):
       self.fail('wasi-testsuite not found; run `git submodule update --init`')
-    self.node_args += shared.node_bigint_flags()
+    self.node_args += shared.node_bigint_flags(self.get_nodejs())
     wasm = path_from_root('test', 'third_party', 'wasi-test-suite', name + '.wasm')
     with open(path_from_root('test', 'third_party', 'wasi-test-suite', name + '.json')) as f:
       config = json.load(f)

--- a/tools/config.py
+++ b/tools/config.py
@@ -20,6 +20,7 @@ logger = logging.getLogger('config')
 # See parse_config_file below.
 EMSCRIPTEN_ROOT = __rootpath__
 NODE_JS = None
+NODE_JS_TEST = None
 BINARYEN_ROOT = None
 SPIDERMONKEY_ENGINE = None
 V8_ENGINE: Optional[List[str]] = None
@@ -61,7 +62,7 @@ def root_is_writable():
 
 def normalize_config_settings():
   global CACHE, PORTS, LLVM_ADD_VERSION, CLANG_ADD_VERSION, CLOSURE_COMPILER
-  global NODE_JS, V8_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, WASM_ENGINES
+  global NODE_JS, NODE_JS_TEST, V8_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, WASM_ENGINES
 
   # EM_CONFIG stuff
   if not JS_ENGINES:
@@ -74,6 +75,7 @@ def normalize_config_settings():
       new_spidermonkey += ['-w']
     SPIDERMONKEY_ENGINE = fix_js_engine(SPIDERMONKEY_ENGINE, new_spidermonkey)
   NODE_JS = fix_js_engine(NODE_JS, listify(NODE_JS))
+  NODE_JS_TEST = fix_js_engine(NODE_JS_TEST, listify(NODE_JS_TEST))
   V8_ENGINE = fix_js_engine(V8_ENGINE, listify(V8_ENGINE))
   JS_ENGINES = [listify(engine) for engine in JS_ENGINES]
   WASM_ENGINES = [listify(engine) for engine in WASM_ENGINES]
@@ -120,6 +122,7 @@ def parse_config_file():
 
   CONFIG_KEYS = (
     'NODE_JS',
+    'NODE_JS_TEST',
     'BINARYEN_ROOT',
     'SPIDERMONKEY_ENGINE',
     'V8_ENGINE',

--- a/tools/config_template.py
+++ b/tools/config_template.py
@@ -27,13 +27,14 @@ JAVA = 'java' # executable
 #
 # Alternative JS engines to use during testing:
 #
+# NODE_JS_TEST = 'node' # executable
 # SPIDERMONKEY_ENGINE = ['js'] # executable
 # V8_ENGINE = 'd8' # executable
 #
 # All JS engines to use when running the automatic tests. Not all the engines in
 # this list must exist (if they don't, they will be skipped in the test runner).
 #
-# JS_ENGINES = [NODE_JS] # add V8_ENGINE or SPIDERMONKEY_ENGINE if you have them installed too.
+# JS_ENGINES = [NODE_JS_TEST] # add V8_ENGINE or SPIDERMONKEY_ENGINE if you have them installed too.
 #
 # import os
 # WASMER = os.path.expanduser(os.path.join('~', '.wasmer', 'bin', 'wasmer'))

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -68,6 +68,7 @@ __rootdir__ = os.path.dirname(__scriptdir__)
 sys.path.insert(0, __rootdir__)
 
 from tools import building
+from tools import config
 from tools import shared
 from tools import system_libs
 from tools import utils
@@ -280,7 +281,7 @@ def inspect_headers(headers, cflags):
   show('Calling generated program... ' + js_file[1])
   args = []
   if settings.MEMORY64:
-    args += shared.node_bigint_flags()
+    args += shared.node_bigint_flags(config.NODE_JS)
   info = shared.run_js_tool(js_file[1], node_args=args, stdout=shared.PIPE).splitlines()
 
   if not DEBUG:


### PR DESCRIPTION
This is needed for #20551 so that we can continue to run tests under versions of node that are too old to run the compiler.