### PR TITLE
Fix for SINGLE_FILE + sync compilation + missing `atob`

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -6,10 +6,6 @@
 
 // === Auto-generated postamble setup entry stuff ===
 
-#if SUPPORT_BASE64_EMBEDDING || FORCE_FILESYSTEM
-#include "base64Utils.js"
-#endif
-
 #if HEADLESS
 if (!ENVIRONMENT_IS_WEB) {
 #include "headlessCanvas.js"

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -49,6 +49,10 @@ if (typeof WebAssembly != 'object') {
 #include "runtime_asan.js"
 #endif
 
+#if SUPPORT_BASE64_EMBEDDING || FORCE_FILESYSTEM
+#include "base64Utils.js"
+#endif
+
 // Wasm globals
 
 var wasmMemory;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8917,6 +8917,10 @@ int main() {
   def test_single_file_shell(self):
     self.do_runf('hello_world.c', emcc_args=['-sSINGLE_FILE'])
 
+  @requires_v8
+  def test_single_file_shell_sync_compile(self):
+    self.do_runf('hello_world.c', emcc_args=['-sSINGLE_FILE', '-sWASM_ASYNC_COMPILATION=0'])
+
   def test_emar_M(self):
     create_file('file1', ' ')
     create_file('file2', ' ')


### PR DESCRIPTION
In this configuration the `atob` polfill is required but was not being installed until after `createWasm` which (in the case of SINGLE_FILE) depends on `atob`.

See #20349