### PR TITLE
Allow both -print-search-dirs and --print-search-dirs

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1279,18 +1279,18 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     print(shared.get_llvm_target())
     return 0
 
-  if '-print-search-dirs' in newargs:
+  if '-print-search-dirs' in newargs or '--print-search-dirs' in newargs:
     print(f'programs: ={config.LLVM_ROOT}')
     print(f'libraries: ={cache.get_lib_dir(absolute=True)}')
     return 0
 
-  if '-print-libgcc-file-name' in newargs:
+  if '-print-libgcc-file-name' in newargs or '--print-libgcc-file-name' in newargs:
     settings.limit_settings(None)
     compiler_rt = system_libs.Library.get_usable_variations()['libcompiler_rt']
     print(compiler_rt.get_path(absolute=True))
     return 0
 
-  print_file_name = [a for a in args if a.startswith('-print-file-name=')]
+  print_file_name = [a for a in newargs if a.startswith('-print-file-name=') or a.startswith('--print-file-name=')]
   if print_file_name:
     libname = print_file_name[-1].split('=')[1]
     system_libpath = cache.get_lib_dir(absolute=True)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -706,8 +706,10 @@ f.close()
     'lto': [['-flto']],
     'wasm64': [['-sMEMORY64']],
   })
-  def test_emcc_print_search_dirs(self, args):
+  def test_print_search_dirs(self, args):
     output = self.run_process([EMCC, '-print-search-dirs'] + args, stdout=PIPE).stdout
+    output2 = self.run_process([EMCC, '-print-search-dirs'] + args, stdout=PIPE).stdout
+    self.assertEqual(output, output2)
     self.assertContained('programs: =', output)
     self.assertContained('libraries: =', output)
     libpath = output.split('libraries: =', 1)[1].strip()
@@ -724,8 +726,10 @@ f.close()
     'lto': [['-flto']],
     'wasm64': [['-sMEMORY64']],
   })
-  def test_emcc_print_libgcc_file_name(self, args):
+  def test_print_libgcc_file_name(self, args):
     output = self.run_process([EMCC, '-print-libgcc-file-name'] + args, stdout=PIPE).stdout
+    output2 = self.run_process([EMCC, '--print-libgcc-file-name'] + args, stdout=PIPE).stdout
+    self.assertEqual(output, output2)
     settings.LTO = '-flto' in args
     settings.MEMORY64 = int('-sMEMORY64' in args)
     libdir = cache.get_lib_dir(absolute=True)
@@ -738,10 +742,12 @@ f.close()
     'lto': [['-flto']],
     'wasm64': [['-sMEMORY64', '-Wno-experimental']],
   })
-  def test_emcc_print_file_name(self, args):
+  def test_print_file_name(self, args):
     # make sure the corresponding version of libc exists in the cache
     self.run_process([EMCC, test_file('hello_world.c'), '-O2'] + args)
     output = self.run_process([EMCC, '-print-file-name=libc.a'] + args, stdout=PIPE).stdout
+    output2 = self.run_process([EMCC, '--print-file-name=libc.a'] + args, stdout=PIPE).stdout
+    self.assertEqual(output, output2)
     filename = Path(output)
     settings.LTO = '-flto' in args
     settings.MEMORY64 = int('-sMEMORY64' in args)


### PR DESCRIPTION
Both forms are supported by gcc and clang.

Followup to #20575