### PR TITLE
Remove return type from FS.createDataFile

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1593,7 +1593,6 @@ FS.staticInit();` +
         FS.close(stream);
         FS.chmod(node, mode);
       }
-      return node;
     },
     createDevice(parent, name, input, output) {
       var path = PATH.join2(typeof parent == 'string' ? parent : FS.getPath(parent), name);
@@ -1872,7 +1871,7 @@ FS.staticInit();` +
 
   $FS_createDataFile__deps: ['$FS'],
   $FS_createDataFile: (parent, name, fileData, canRead, canWrite, canOwn) => {
-    return FS.createDataFile(parent, name, fileData, canRead, canWrite, canOwn);
+    FS.createDataFile(parent, name, fileData, canRead, canWrite, canOwn);
   },
 
   $FS_unlink__deps: ['$FS'],

--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -99,7 +99,7 @@ FS.init();
       FS.ErrnoError.prototype.constructor = FS.ErrnoError;
     },
     createDataFile(parent, name, fileData, canRead, canWrite, canOwn) {
-      return FS_createDataFile(parent, name, fileData, canRead, canWrite, canOwn);
+      FS_createDataFile(parent, name, fileData, canRead, canWrite, canOwn);
     },
     createPath(parent, path, canRead, canWrite) {
       // Cache file path directory names.


### PR DESCRIPTION
The wasmfs version of this function doesn't (and cannot AFAICT) return a value, so to make them consistent we simply remove the return type.

This also happens to fix and internal google issue we had regarding the type of this function and closure compiler.