### PR TITLE
Remove tools/maint from list of directories excluded from install

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -19,7 +19,6 @@ import sys
 
 EXCLUDES = [os.path.normpath(x) for x in '''
 test/third_party
-tools/maint
 site
 node_modules
 Makefile


### PR DESCRIPTION
This is needed after #20586 because e.g. gen_struct_info.py is used to generate system libraries, which can be done at runtime.