### PR TITLE
Fix for non-utf-8 headers in ports

### DIFF
--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -89,12 +89,9 @@ def maybe_copy(src, dest):
   building/installing a new flavor of a given library.  In this case the
   headers will be "re-installed" but we skip the actual filesystem mods
   to avoid racing with other processes that might be reading these files.
-  """
-  try:
-    if os.path.exists(dest) and utils.read_file(src) == utils.read_file(dest):
-      return
-  except UnicodeDecodeError:
-    ...
+  """  
+  if os.path.exists(dest) and utils.read_binary(src) == utils.read_binary(dest):
+    return
   shutil.copyfile(src, dest)
 
 

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -89,7 +89,7 @@ def maybe_copy(src, dest):
   building/installing a new flavor of a given library.  In this case the
   headers will be "re-installed" but we skip the actual filesystem mods
   to avoid racing with other processes that might be reading these files.
-  """  
+  """
   if os.path.exists(dest) and utils.read_binary(src) == utils.read_binary(dest):
     return
   shutil.copyfile(src, dest)

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -90,8 +90,11 @@ def maybe_copy(src, dest):
   headers will be "re-installed" but we skip the actual filesystem mods
   to avoid racing with other processes that might be reading these files.
   """
-  if os.path.exists(dest) and utils.read_file(src) == utils.read_file(dest):
-    return
+  try:
+    if os.path.exists(dest) and utils.read_file(src) == utils.read_file(dest):
+      return
+  except UnicodeDecodeError as e:
+    ...
   shutil.copyfile(src, dest)
 
 

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -93,7 +93,7 @@ def maybe_copy(src, dest):
   try:
     if os.path.exists(dest) and utils.read_file(src) == utils.read_file(dest):
       return
-  except UnicodeDecodeError as e:
+  except UnicodeDecodeError:
     ...
   shutil.copyfile(src, dest)
 


### PR DESCRIPTION
utils.read_file can only read unicode files but eg SDL2_gfx has a non unicode header "SDL2_gfxPrimitives_font.h"