### PR TITLE
Reproducer for issue #20507

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -1075,6 +1075,9 @@ var LibraryDylink = {
   $loadDylibs__internal: true,
   $loadDylibs__deps: ['$loadDynamicLibrary', '$reportUndefinedSymbols'],
   $loadDylibs: () => {
+#if PTHREADS
+    if (ENVIRONMENT_IS_PTHREAD) return;
+#endif
     if (!dynamicLibraries.length) {
 #if DYLINK_DEBUG
       dbg('loadDylibs: no libraries to preload');


### PR DESCRIPTION
This is a reproducer for issue #20507, which PR #19496 is attempting to fix in a trivial manner.

The issue is that the `dynamicLibraries` array would be empty at this point when `ENVIRONMENT_IS_PTHREAD`, causing 
`loadDylibs()` to be no-op. According to https://github.com/emscripten-core/emscripten/pull/19496#issuecomment-1572619363, the `__emscripten_dlsync_self()` function is responsible for loading the same libraries that the main thread loaded, so this change _ought_ to be safe.