### PR TITLE
Use --keep-section=target_features linker flag

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14165,3 +14165,8 @@ addToLibrary({
     self.do_runf(test_file('other/test_unused_destructor.c'), emcc_args=['-flto', '-O2'])
     # Verify that the string constant in the destructor is not included in the binary
     self.assertNotIn(b'hello from dtor', read_binary('test_unused_destructor.wasm'))
+
+  def test_strip_all(self):
+    # Test that even with `-Wl,--strip-all` the target features section is generated
+    # by wasm-ld so that later phases (e.g. wasm-opt) can read it.
+    self.do_runf('hello_world.c', emcc_args=['-Wl,--strip-all', '-pthread'])

--- a/tools/building.py
+++ b/tools/building.py
@@ -269,6 +269,11 @@ def link_lld(args, target, external_symbols=None):
   if settings.STRICT:
     args.append('--fatal-warnings')
 
+  if '--strip-all' in args:
+    # Tell wasm-ld to always generate a target_features section even if --strip-all
+    # is passed.
+    args.append('--keep-section=target_features')
+
   cmd = [WASM_LD, '-o', target] + args
   for a in llvm_backend_args():
     cmd += ['-mllvm', a]


### PR DESCRIPTION
This ensures that this sections is preserved even when `-Wl,--strip-all` is passed.