### PR TITLE
Automatically retry flaky tests when running tests for PRs 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,9 +238,17 @@ commands:
         type: string
         default: ""
     steps:
+      - when:
+          # We only set EMTEST_RETRY_FLAKY on pull requests.  When we run
+          # normal CI jobs on branches like main we still want to be able to
+          # detect flakyness.
+          condition: ${CIRCLE_PULL_REQUEST}
+          steps:
+            set-retry-flaky-tests
       - run:
           name: run tests (<< parameters.title >>)
           command: |
+            env
             ./test/runner << parameters.test_targets >>
             $EMSDK_PYTHON ./test/check_clean.py
   freeze-cache:
@@ -249,6 +257,12 @@ commands:
       - run:
           name: Add EM_FROZEN_CACHE to bash env
           command: echo "export EM_FROZEN_CACHE=1" >> $BASH_ENV
+  set-retry-flaky-tests:
+    description: "Set EMTEST_RETRY_FLAKY"
+    steps:
+      - run:
+          name: Add EMTEST_RETRY_FLAKY to bash env
+          command: echo "export EMTEST_RETRY_FLAKY=2" >> $BASH_ENV
   run-tests-linux:
     description: "Runs emscripten tests"
     parameters:

--- a/test/runner.py
+++ b/test/runner.py
@@ -393,6 +393,7 @@ def configure():
   common.EMTEST_ALL_ENGINES = int(os.getenv('EMTEST_ALL_ENGINES', '0'))
   common.EMTEST_SKIP_SLOW = int(os.getenv('EMTEST_SKIP_SLOW', '0'))
   common.EMTEST_SKIP_FLAKY = int(os.getenv('EMTEST_SKIP_FLAKY', '0'))
+  common.EMTEST_RETRY_FLAKY = int(os.getenv('EMTEST_RETRY_FLAKY', '0'))
   common.EMTEST_LACKS_NATIVE_CLANG = int(os.getenv('EMTEST_LACKS_NATIVE_CLANG', '0'))
   common.EMTEST_REBASELINE = int(os.getenv('EMTEST_REBASELINE', '0'))
   common.EMTEST_VERBOSE = int(os.getenv('EMTEST_VERBOSE', '0')) or shared.DEBUG


### PR DESCRIPTION
Note that when we run tests on the main branch we don't auto-retry
so that way circleci can still take advantage of circleci's tracking
of flaky tests.

See #19795