### PR TITLE
Fix test_embind_2's use of pthreads

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7678,14 +7678,14 @@ void* operator new(size_t size) {
     ''')
     self.do_runf('test_embind.cpp', 'abs(-10): 10\nabs(-11): 11', emcc_args=args)
 
-  @parameterized({
-    '': ([],),
-    'pthreads': (['-pthread', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'],),
-  })
   @node_pthreads
-  def test_embind_2(self, args):
+  def test_embind_2(self):
     self.maybe_closure()
-    self.emcc_args += ['-lembind', '--post-js', 'post.js'] + args
+    self.emcc_args += [
+      '-lembind', '--post-js', 'post.js',
+      # for extra coverage, test using pthreads
+      '-pthread', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'
+    ]
     create_file('post.js', '''
       function printLerp() {
         out('lerp ' + Module['lerp'](100, 200, 66) + '.');


### PR DESCRIPTION
The test was parameterized as having a pthreads and non-pthreads mode, but the
decorator was on the entire test, making it all run as pthreads, which meant the
non-pthreads case was not really tested.

It seems simplest to just refocus the test as a single test, and use pthreads there
for coverage. I don't think we are losing anything of value that way, and it's
simpler than adding logic to support both modes in one test.