### PR TITLE
Fix benchmark profiling logic

### DIFF
--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -211,7 +211,7 @@ class EmscriptenBenchmarker(Benchmarker):
     ] + LLVM_FEATURE_FLAGS
     if shared_args:
       cmd += shared_args
-    if common.EMTEST_FORCE64:
+    if PROFILING:
       cmd += ['--profiling']
     else:
       cmd += ['--closure=1', '-sMINIMAL_RUNTIME']
@@ -220,8 +220,6 @@ class EmscriptenBenchmarker(Benchmarker):
     cmd += emcc_args + self.extra_args
     if '-sFILESYSTEM' not in cmd and '-sFORCE_FILESYSTEM' not in cmd:
       cmd += ['-sFILESYSTEM=0']
-    if PROFILING:
-      cmd += ['--profiling-funcs']
     self.cmd = cmd
     run_process(cmd, env=self.env)
     if self.binaryen_opts:


### PR DESCRIPTION
I'm not sure why force64 set profiling mode - was there a reason? - but I assume
it isn't needed now. And we had logic for both profiling and profling-funcs; merge
those and use profiling.