### PR TITLE
Fix malloc_bench calloc logic

### DIFF
--- a/test/malloc_bench.c
+++ b/test/malloc_bench.c
@@ -85,12 +85,12 @@ void randoms() {
           total_allocated += size;
         }
       } else {
-        if (!calloc_ || !USE_CALLOC) {
-          bins[bin] = malloc(size);
+        if (calloc_ && USE_CALLOC) {
+          bins[bin] = calloc(size, 1);
           allocated[bin] = size;
           total_allocated += size;
         } else {
-          bins[bin] = calloc(size, 1);
+          bins[bin] = malloc(size);
           allocated[bin] = size;
           total_allocated += size;
         }

--- a/test/malloc_bench.c
+++ b/test/malloc_bench.c
@@ -85,7 +85,7 @@ void randoms() {
           total_allocated += size;
         }
       } else {
-        if (calloc_ && USE_CALLOC) {
+        if (!calloc_ || !USE_CALLOC) {
           bins[bin] = malloc(size);
           allocated[bin] = size;
           total_allocated += size;


### PR DESCRIPTION
The condition was flipped, that is, if calloc mode was disabled we actually ran
calloc.