### PR TITLE
Fix website ribbon

### DIFF
--- a/site/source/_themes/emscripten_sphinx_rtd_theme/layout.html
+++ b/site/source/_themes/emscripten_sphinx_rtd_theme/layout.html
@@ -134,7 +134,7 @@
 	('docs/index', 'GitHub', '')
 ] -%}
 
-   <a href="https://github.com/emscripten-core/emscripten"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
+   <a href="https://github.com/emscripten-core/emscripten"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" data-canonical-src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png"></a>
   
    <div class="main-nav-bar" style="">   
    


### PR DESCRIPTION
Visually it is identical to before, but now it links to the URL in the github post that
announced these ribbons back in the day,

https://github.blog/2008-12-19-github-ribbons/

Those links still work, while the AWS links we were using (and many other people)
have stopped for some reason.

Fixes #20644