### PR TITLE
Fix strftime test failure

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -528,7 +528,7 @@ addToLibrary({
 
     var yday = ydayFromDate(date)|0;
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_yday, 'yday', 'i32') }}};
-    {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_gmtoff, '-(date.getTimezoneOffset() * 60)', '*') }}};
+    {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_gmtoff, '-(date.getTimezoneOffset() * 60)', LONG_TYPE) }}};
 
     // Attention: DST is in December in South, and some regions don't have DST at all.
     var start = new Date(date.getFullYear(), 0, 1);
@@ -711,9 +711,10 @@ addToLibrary({
       tm_wday: {{{ makeGetValue('tm', C_STRUCTS.tm.tm_wday, 'i32') }}},
       tm_yday: {{{ makeGetValue('tm', C_STRUCTS.tm.tm_yday, 'i32') }}},
       tm_isdst: {{{ makeGetValue('tm', C_STRUCTS.tm.tm_isdst, 'i32') }}},
-      tm_gmtoff: {{{ makeGetValue('tm', C_STRUCTS.tm.tm_gmtoff, '*') }}},
+      tm_gmtoff: {{{ makeGetValue('tm', C_STRUCTS.tm.tm_gmtoff, LONG_TYPE) }}},
       tm_zone: tm_zone ? UTF8ToString(tm_zone) : ''
     };
+    {{{ from64('date.tm_gmtoff') }}}
 
     var pattern = UTF8ToString(format);
 
@@ -1199,7 +1200,7 @@ addToLibrary({
       {{{ makeSetValue('tm', C_STRUCTS.tm.tm_wday, 'fullDate.getDay()', 'i32') }}};
       {{{ makeSetValue('tm', C_STRUCTS.tm.tm_yday, 'arraySum(isLeapYear(fullDate.getFullYear()) ? MONTH_DAYS_LEAP : MONTH_DAYS_REGULAR, fullDate.getMonth()-1)+fullDate.getDate()-1', 'i32') }}};
       {{{ makeSetValue('tm', C_STRUCTS.tm.tm_isdst, '0', 'i32') }}};
-      {{{ makeSetValue('tm', C_STRUCTS.tm.tm_gmtoff, 'date.gmtoff', '*') }}};
+      {{{ makeSetValue('tm', C_STRUCTS.tm.tm_gmtoff, 'date.gmtoff', LONG_TYPE) }}};
  
       // we need to convert the matched sequence into an integer array to take care of UTF-8 characters > 0x7F
       // TODO: not sure that intArrayFromString handles all unicode characters correctly

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -182,6 +182,7 @@ const POINTER_TYPE = `u${POINTER_BITS}`;
 const POINTER_JS_TYPE = MEMORY64 ? "'bigint'" : "'number'";
 const POINTER_SHIFT = MEMORY64 ? '3' : '2';
 const POINTER_HEAP = MEMORY64 ? 'HEAP64' : 'HEAP32';
+const LONG_TYPE = `i${POINTER_BITS}`;
 
 const SIZE_TYPE = POINTER_TYPE;
 


### PR DESCRIPTION
The `tm_gmtoff` field is of type `long` which is signed.  Using `POINTER_TYPE` leads it u32/u64 which when reading a negative value leads the wrong JS value (i.e. a very large integer rather than a negative one).

Fix for a breakage caused by #20470