### PR TITLE
Fix line endings of generated on windows

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -4207,7 +4207,6 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
   shell = do_replace(shell, '{{{ SCRIPT }}}', script.replacement())
   shell = shell.replace('{{{ SHELL_CSS }}}', utils.read_file(utils.path_from_root('src/shell.css')))
   shell = shell.replace('{{{ SHELL_LOGO }}}', utils.read_file(utils.path_from_root('media/powered_by_logo_mini.svg')))
-  shell = tools.line_endings.convert_line_endings(shell, '\n', options.output_eol)
 
   check_output_file(target)
   write_file(target, shell)
@@ -4276,6 +4275,8 @@ def generate_html(target, options, js_target, target_basename,
 
   if settings.MINIFY_HTML and (settings.OPT_LEVEL >= 1 or settings.SHRINK_LEVEL >= 1):
     minify_html(target)
+
+  tools.line_endings.convert_line_endings_in_file(target, os.linesep, options.output_eol)
 
 
 def generate_worker_js(target, js_target, target_basename):

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7904,6 +7904,7 @@ int main() {
     output = self.run_process([common.LLVM_OBJDUMP, '-t', 'test.o'], stdout=PIPE).stdout
     self.assertContained('foo', output)
 
+  @crossplatform
   def test_output_eol(self):
     for params in [[], ['--proxy-to-worker'], ['--proxy-to-worker', '-sWASM=0']]:
       for output_suffix in ['html', 'js']:
@@ -7922,7 +7923,7 @@ int main() {
               expected_ending = '\r\n'
 
             ret = line_endings.check_line_endings(f, expect_only=expected_ending)
-            assert ret == 0
+            self.assertEqual(ret, 0)
 
           for f in files:
             delete_file(f)
@@ -9779,6 +9780,7 @@ console.error('JSLIB: none of the above');
     self.assertContained('JSLIB: EXIT_RUNTIME', err)
     self.assertNotContained('JSLIB: MAIN_MODULE', err)
 
+  @crossplatform
   def test_html_preprocess(self):
     src_file = test_file('module/test_stdin.c')
     output_file = 'test_stdin.html'
@@ -9786,7 +9788,7 @@ console.error('JSLIB: none of the above');
 
     self.run_process([EMCC, '-o', output_file, src_file, '--shell-file', shell_file, '-sASSERTIONS=0'], stdout=PIPE, stderr=PIPE)
     output = read_file(output_file)
-    self.assertContained("""<style>
+    self.assertContained('''<style>
 /* Disable preprocessing inside style block as syntax is ambiguous with CSS */
 #include {background-color: black;}
 #if { background-color: red;}
@@ -9799,7 +9801,7 @@ T2:ASSERTIONS != 1
 T3:ASSERTIONS < 2
 T4:(else) ASSERTIONS <= 1
 T5:(else) ASSERTIONS
-T6:!ASSERTIONS""", output)
+T6:!ASSERTIONS''', output)
 
     self.run_process([EMCC, '-o', output_file, src_file, '--shell-file', shell_file, '-sASSERTIONS'], stdout=PIPE, stderr=PIPE)
     output = read_file(output_file)

--- a/tools/line_endings.py
+++ b/tools/line_endings.py
@@ -46,7 +46,7 @@ def check_line_endings(filename, expect_only=None, print_errors=True, print_info
     if print_errors:
       print("File '" + filename + "' contains BAD line endings of form \\r\\r\\n!", file=sys.stderr)
       bad_line = data[index - 50:index + 50].replace(b'\r', b'\\r').replace(b'\n', b'\\n')
-      print("Content around the location: '" + bad_line + "'", file=sys.stderr)
+      print("Content around the location: '" + bad_line.decode('utf-8') + "'", file=sys.stderr)
     return 1 # Bad line endings in file, return a non-zero process exit code.
 
   has_dos_line_endings = False


### PR DESCRIPTION
A couple of windows tests started failing after #20663.

If we write the file as text file we need to perform the line ending conversions on the file after we write it and not before.