### PR TITLE
Add missing #if ASSERTIONS guard in runtime_init_memory.js

### DIFF
--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -11,8 +11,10 @@
 
 {{{ makeModuleReceiveWithVar('INITIAL_MEMORY', undefined, INITIAL_MEMORY) }}}
 
+#if ASSERTIONS
 assert(INITIAL_MEMORY >= {{{STACK_SIZE}}}, 'INITIAL_MEMORY should be larger than STACK_SIZE, was ' + INITIAL_MEMORY + '! (STACK_SIZE=' + {{{STACK_SIZE}}} + ')');
-
+#endif
+  
 // check for full engine support (use string 'subarray' to avoid closure compiler confusion)
 
 #if PTHREADS

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2449,6 +2449,8 @@ int main(int argc, char **argv) {
     else:
       self.emcc_args += ['--pre-js', test_file('core/test_module_wasm_memory.js')]
     self.set_setting('IMPORTED_MEMORY')
+    self.set_setting('STRICT')
+    self.set_setting('INCOMING_MODULE_JS_API', ['wasmMemory'])
     self.do_runf('core/test_module_wasm_memory.c', 'success')
 
   def test_ssr(self): # struct self-ref


### PR DESCRIPTION
`assert()` might not be defined if ASSERTIONS are disabled. This was breaking my build with `-sSTRICT=1` on version `3.1.48`.