### PR TITLE
embind: Use last defined constructor for TS definitions.

### DIFF
--- a/src/embind/embind_ts.js
+++ b/src/embind/embind_ts.js
@@ -98,7 +98,8 @@ var LibraryEmbind = {
     printModuleEntry(nameMap, out) {
       out.push(`  ${this.name}: {new`);
       // TODO Handle constructor overloading
-      const constructor = this.constructors[this.constructors.length > 1 ? 1 : 0];
+      // Use the last defined constructor for now.
+      const constructor = this.constructors[this.constructors.length - 1];
       constructor.printSignature(nameMap, out);
       for (const method of this.staticMethods) {
         out.push('; ');

--- a/test/other/embind_tsgen.cpp
+++ b/test/other/embind_tsgen.cpp
@@ -61,6 +61,12 @@ class ClassWithConstructor {
   int fn(int x) { return 0; }
 };
 
+class ClassWithTwoConstructors {
+ public:
+  ClassWithTwoConstructors() {}
+  ClassWithTwoConstructors(int) {}
+};
+
 class ClassWithSmartPtrConstructor {
  public:
   ClassWithSmartPtrConstructor(int, const ValArr&) {}
@@ -150,6 +156,11 @@ EMSCRIPTEN_BINDINGS(Test) {
   class_<ClassWithConstructor>("ClassWithConstructor")
       .constructor<int, const ValArr&>()
       .function("fn", &ClassWithConstructor::fn);
+
+  // The last defined constructor should be used in the definition.
+  class_<ClassWithTwoConstructors>("ClassWithTwoConstructors")
+      .constructor<>()
+      .constructor<int>();
 
   class_<ClassWithSmartPtrConstructor>("ClassWithSmartPtrConstructor")
       .smart_ptr_constructor(

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -47,6 +47,10 @@ export interface ClassWithConstructor {
   delete(): void;
 }
 
+export interface ClassWithTwoConstructors {
+  delete(): void;
+}
+
 export interface ClassWithSmartPtrConstructor {
   fn(_0: number): number;
   delete(): void;
@@ -76,6 +80,7 @@ export interface MainModule {
   IntVec: {new(): IntVec};
   Foo: {new(): Foo};
   ClassWithConstructor: {new(_0: number, _1: ValArr): ClassWithConstructor};
+  ClassWithTwoConstructors: {new(_0: number): ClassWithTwoConstructors};
   ClassWithSmartPtrConstructor: {new(_0: number, _1: ValArr): ClassWithSmartPtrConstructor};
   BaseClass: {new(): BaseClass};
   DerivedClass: {new(): DerivedClass};


### PR DESCRIPTION
This really isn't any better than what it did before, but this behavior matches an internal tool.