### PR TITLE
Allow subclassing coroutines

### DIFF
--- a/system/lib/embind/bind.cpp
+++ b/system/lib/embind/bind.cpp
@@ -63,7 +63,7 @@ void _embind_register_bindings(InitFunc* f) {
   init_funcs = f;
 }
 
-void _emval_coro_resume(val_awaiter* awaiter, EM_VAL result) {
+void _emval_coro_resume(val::awaiter* awaiter, EM_VAL result) {
   awaiter->resume_with(val::take_ownership(result));
 }
 

--- a/test/embind/test_val_coro.cpp
+++ b/test/embind/test_val_coro.cpp
@@ -27,9 +27,7 @@ public:
   typed_promise(val&& promise): val(std::move(promise)) {}
 
   auto operator co_await() const {
-    struct typed_awaiter: val::awaiter {
-      using val::awaiter::awaiter;
-
+    struct typed_awaiter: public val::awaiter {
       T await_resume() {
         return val::awaiter::await_resume().template as<T>();
       }


### PR DESCRIPTION
Slight refactoring of coroutine glue to allow subclassing via the public API.

This doesn't change how `co_await some_val;` behaves, but makes it possible to create your own subclasses that can also be awaited.

Someday this `typed_promise` could probably become a public API (in particular cc @tlively as it would then intersect even more with your C++ API ideas) but that would require more work.

For now just test that users can at least make their own subclasses that work with `val`-based coroutine.