### PR TITLE
Handle NaN return from JS date.getTime. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -437,7 +437,7 @@ addToLibrary({
   // ==========================================================================
 
   _mktime_js__i53abi: true,
-  _mktime_js__deps: ['$ydayFromDate'],
+  _mktime_js__deps: ['$ydayFromDate', '$setErrNo'],
   _mktime_js: (tmPtr) => {
     var date = new Date({{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_year, 'i32') }}} + 1900,
                         {{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_mon, 'i32') }}},
@@ -477,7 +477,13 @@ addToLibrary({
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_mon, 'date.getMonth()', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_year, 'date.getYear()', 'i32') }}};
 
-    return date.getTime() / 1000;
+    var timeMs = date.getTime();
+    if (isNaN(timeMs)) {
+      setErrNo({{{ cDefs.EOVERFLOW }}});
+      return -1;
+    }
+    // Return time in microseconds
+    return timeMs / 1000;
   },
 
   _gmtime_js__i53abi: true,

--- a/test/core/test_time.cpp
+++ b/test/core/test_time.cpp
@@ -3,6 +3,7 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -10,8 +11,7 @@
 #include <assert.h>
 #include <math.h>
 
-void check_gmtime_localtime(time_t time)
-{
+void check_gmtime_localtime(time_t time) {
   char gmbuf[32], locbuf[32];
   const char fmt[] = "%Y-%m-%d %H:%M:%S";
   struct tm *gm;
@@ -162,6 +162,15 @@ int main() {
   mktime(&tm_winter); mktime(&tm_summer);
   printf("mktime guesses DST (winter): %d\n", tm_winter.tm_isdst == oldDstWinter);
   printf("mktime guesses DST (summer): %d\n", tm_summer.tm_isdst == oldDstSummer);
+
+  // Verify that timestamps outside of the range supported by date.getNow()
+  // cause failure with EOVERFLOW.
+  struct tm tm_big = {0};
+  tm_big.tm_year = 292278994;
+  time_t tbig = mktime(&tm_big);
+  printf("tbig: %lld\n", tbig);
+  assert(tbig == -1);
+  assert(errno == EOVERFLOW);
 
   // Verify localtime_r() doesn't clobber static data.
   time_t t3 = 60*60*24*5; // Jan 5 1970

--- a/test/core/test_time.out
+++ b/test/core/test_time.out
@@ -27,6 +27,7 @@ mktime updates parameter to be in range: 1
 mktime parameter is equivalent to localtime return: 1
 mktime guesses DST (winter): 1
 mktime guesses DST (summer): 1
+tbig: -1
 old year still: 102
 new year: 70
 time: 1


### PR DESCRIPTION
This is always wrong even with wasm32 but showed up as JS exception under wasm64:

```
RangeError: The number NaN cannot be converted to a BigInt because it is not an integer
```

Supercedes: #19952 #19966