### PR TITLE
Remove dependency on assert from SAFE_HEAP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,6 +553,7 @@ jobs:
             core2ss.test_pthread_dylink
             core2ss.test_pthread_thread_local_storage
             core2s.test_dylink_syslibs_missing_assertions
+            core2s.test_module_wasm_memory
             wasm2js3.test_memorygrowth_2
             wasmfs.test_hello_world
             wasmfs.test_hello_world_standalone

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -23,7 +23,7 @@
 #include "runtime_asan.js"
 #endif
 
-#if ASSERTIONS || SAFE_HEAP
+#if ASSERTIONS
 /** @type {function(*, string=)} */
 function assert(condition, text) {
   if (!condition) throw text;

--- a/src/runtime_safe_heap.js
+++ b/src/runtime_safe_heap.js
@@ -15,7 +15,7 @@ function getSafeHeapType(bytes, isFloat) {
     case 2: return 'i16';
     case 4: return isFloat ? 'float' : 'i32';
     case 8: return isFloat ? 'double' : 'i64';
-    default: assert(0, `getSafeHeapType() invalid bytes=${bytes}`);
+    default: abort(`getSafeHeapType() invalid bytes=${bytes}`);
   }
 }
 
@@ -44,8 +44,8 @@ function SAFE_HEAP_STORE(dest, value, bytes, isFloat) {
 #endif
     var brk = _sbrk(0);
     if (dest + bytes > brk) abort(`segmentation fault, exceeded the top of the available dynamic heap when storing ${bytes} bytes to address ${dest}. DYNAMICTOP=${brk}`);
-    assert(brk >= _emscripten_stack_get_base(), `brk >= _emscripten_stack_get_base() (brk=${brk}, _emscripten_stack_get_base()=${_emscripten_stack_get_base()})`); // sbrk-managed memory must be above the stack
-    assert(brk <= wasmMemory.buffer.byteLength, `brk <= wasmMemory.buffer.byteLength (brk=${brk}, wasmMemory.buffer.byteLength=${wasmMemory.buffer.byteLength})`);
+    if (brk < _emscripten_stack_get_base()) abort(`brk >= _emscripten_stack_get_base() (brk=${brk}, _emscripten_stack_get_base()=${_emscripten_stack_get_base()})`); // sbrk-managed memory must be above the stack
+    if (brk > wasmMemory.buffer.byteLength) abort(`brk <= wasmMemory.buffer.byteLength (brk=${brk}, wasmMemory.buffer.byteLength=${wasmMemory.buffer.byteLength})`);
   }
   setValue_safe(dest, value, getSafeHeapType(bytes, isFloat));
   return value;
@@ -72,8 +72,8 @@ function SAFE_HEAP_LOAD(dest, bytes, unsigned, isFloat) {
 #endif
     var brk = _sbrk(0);
     if (dest + bytes > brk) abort(`segmentation fault, exceeded the top of the available dynamic heap when loading ${bytes} bytes from address ${dest}. DYNAMICTOP=${brk}`);
-    assert(brk >= _emscripten_stack_get_base(), `brk >= _emscripten_stack_get_base() (brk=${brk}, _emscripten_stack_get_base()=${_emscripten_stack_get_base()})`); // sbrk-managed memory must be above the stack
-    assert(brk <= wasmMemory.buffer.byteLength, `brk <= wasmMemory.buffer.byteLength (brk=${brk}, wasmMemory.buffer.byteLength=${wasmMemory.buffer.byteLength})`);
+    if (brk < _emscripten_stack_get_base()) abort(`brk >= _emscripten_stack_get_base() (brk=${brk}, _emscripten_stack_get_base()=${_emscripten_stack_get_base()})`); // sbrk-managed memory must be above the stack
+    if (brk > wasmMemory.buffer.byteLength) abort(`brk <= wasmMemory.buffer.byteLength (brk=${brk}, wasmMemory.buffer.byteLength=${wasmMemory.buffer.byteLength})`);
   }
   var type = getSafeHeapType(bytes, isFloat);
   var ret = getValue_safe(dest, type);


### PR DESCRIPTION
As of #20592, `assert` is no longer defined in release builds in STRICT
mode, but its still possible to use SAFE_HEAP in this configuration.
Instead of complicating the definition of `assert` to match
`preamble_minimal.js` this change instead removed the dependency of
SAFE_HEAP on the assert function.

This fixes the `core2s.test_module_wasm_memory` which is currently failing on the emscripten-releases tree.