### PR TITLE
[Fix] #20600 : Calling GLFW.setWindowSize with the screen size leads to browser error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,11 @@ See docs/process.md for more on how version tagging works.
 
 3.1.49 (in development)
 -----------------------
+- The `glfwSetWindowSize` function no longer switches to fullscreen when the
+  width/height provided as parameters match the screen size. This behavior
+  now matches the behavior of SDL and glut. In order to switch to fullscreen,
+  the client code should invoke `Module.requestFullscreen(...)` from a user 
+  triggered event otherwise the browser raises an error. (#20600)
 
 3.1.48 - 11/05/23
 -----------------

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -981,9 +981,9 @@ var LibraryGLFW = {
       if (!win) return;
 
       if (GLFW.active.id == win.id) {
-          Browser.setCanvasSize(width, height);
-          win.width = width;
-          win.height = height;
+        Browser.setCanvasSize(width, height);
+        win.width = width;
+        win.height = height;
       }
 
       if (win.windowSizeFunc) {

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -981,14 +981,9 @@ var LibraryGLFW = {
       if (!win) return;
 
       if (GLFW.active.id == win.id) {
-        if (width == screen.width && height == screen.height) {
-          Browser.requestFullscreen();
-        } else {
-          Browser.exitFullscreen();
           Browser.setCanvasSize(width, height);
           win.width = width;
           win.height = height;
-        }
       }
 
       if (win.windowSizeFunc) {


### PR DESCRIPTION
As pointed out in the [discussion about this issue](https://github.com/emscripten-core/emscripten/issues/20600#issuecomment-1808405716), it is very odd that `glfwSetWindowSize` automatically triggers a fullscreen when the size parameters happen to be the exact size of the screen. When invoking it via code, this triggers the error in browsers because it is not a user event.

If the client code wants to go fullscreen, it should simply call `Module.requestFullscreen` which is made available to the `Module` when the `Browser` library is initialized.

Neither `library_sdl.js` nor `library_glut.js` implement such a behavior.