### PR TITLE
Remove limits of ES6 features in standard library code

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,10 @@ See docs/process.md for more on how version tagging works.
   `warning: treating 'c' input as 'c++' when in C++ mode`.  This also means that
   the `DEFAULT_TO_CXX` setting now only applies when linking and not when
   compiling. (#20712)
+- JavaScript library code can now use the full range ES6 features and we rely
+  on closure compiler to transpile for ES5 when targetting older browsers.
+  For those that want to would rather perform transpilation seperately outside
+  of emscripten you can use the `-sPOLYFILL=0` setting.  (#20700)
 
 3.1.49 - 11/14/23
 -----------------

--- a/emcc.py
+++ b/emcc.py
@@ -2318,7 +2318,7 @@ def phase_linker_setup(options, state, newargs):
 
   setup_environment_settings()
 
-  if options.use_closure_compiler != 0:
+  if options.use_closure_compiler != 0 and settings.POLYFILL:
     # Emscripten requires certain ES6 constructs by default in library code
     # - https://caniuse.com/let              : EDGE:12 FF:44 CHROME:49 SAFARI:11
     # - https://caniuse.com/const            : EDGE:12 FF:36 CHROME:49 SAFARI:11

--- a/tools/building.py
+++ b/tools/building.py
@@ -513,7 +513,8 @@ def closure_transpile(filename):
   user_args = []
   closure_cmd, env = get_closure_compiler_and_env(user_args)
   closure_cmd += ['--language_out', 'ES5']
-  closure_cmd += ['--compilation_level', 'WHITESPACE_ONLY']
+  closure_cmd += ['--compilation_level', 'SIMPLE_OPTIMIZATIONS']
+  closure_cmd += ['--formatting', 'PRETTY_PRINT']
   return run_closure_cmd(closure_cmd, filename, env)
 
 


### PR DESCRIPTION
When transpiling to ES5 use closure with `SIMPLE_OPTIMIZATIONS` rather then `WHITESPACE_ONLY`.  This means that polyfills cant be included as needed and removes the limits on what ES6 features we can use.

The downside of this is that is slows down builds for ES5 users but this seems like a reasonable tradeoff.  It also makes debugging harder for such users since closure will minify the names of locals in this configuration even though we pass 
`--formatting=PRETTY_PRINT` which seems to prevent minification of global names.

Fixes: #11984