### PR TITLE
embind: Support overloaded constructors for TS generation.

### DIFF
--- a/src/embind/embind_ts.js
+++ b/src/embind/embind_ts.js
@@ -68,9 +68,7 @@ var LibraryEmbind = {
       this.methods = [];
       this.staticMethods = [];
       this.staticProperties = [];
-      this.constructors = [
-        new FunctionDefinition('default', this, [])
-      ];
+      this.constructors = [];
       this.base = base;
       this.properties = [];
     }
@@ -96,18 +94,25 @@ var LibraryEmbind = {
     }
 
     printModuleEntry(nameMap, out) {
-      out.push(`  ${this.name}: {new`);
-      // TODO Handle constructor overloading
-      const constructor = this.constructors[this.constructors.length > 1 ? 1 : 0];
-      constructor.printSignature(nameMap, out);
+      out.push(`  ${this.name}: {`);
+      const entries = [];
+      for(const construct of this.constructors) {
+        const entry = [];
+        entry.push('new');
+        construct.printSignature(nameMap, entry);
+        entries.push(entry.join(''));
+      }
       for (const method of this.staticMethods) {
-        out.push('; ');
-        method.printFunction(nameMap, out);
+        const entry = [];
+        method.printFunction(nameMap, entry);
+        entries.push(entry.join(''));
       }
       for (const prop of this.staticProperties) {
-        out.push('; ');
-        prop.print(nameMap, out);
+        const entry = [];
+        prop.print(nameMap, entry);
+        entries.push(entry.join(''));
       }
+      out.push(entries.join('; '));
       out.push('};\n');
     }
   },

--- a/test/other/embind_tsgen.cpp
+++ b/test/other/embind_tsgen.cpp
@@ -61,6 +61,12 @@ class ClassWithConstructor {
   int fn(int x) { return 0; }
 };
 
+class ClassWithTwoConstructors {
+ public:
+  ClassWithTwoConstructors() {}
+  ClassWithTwoConstructors(int) {}
+};
+
 class ClassWithSmartPtrConstructor {
  public:
   ClassWithSmartPtrConstructor(int, const ValArr&) {}
@@ -150,6 +156,11 @@ EMSCRIPTEN_BINDINGS(Test) {
   class_<ClassWithConstructor>("ClassWithConstructor")
       .constructor<int, const ValArr&>()
       .function("fn", &ClassWithConstructor::fn);
+
+  // The last defined constructor should be used in the definition.
+  class_<ClassWithTwoConstructors>("ClassWithTwoConstructors")
+      .constructor<>()
+      .constructor<int>();
 
   class_<ClassWithSmartPtrConstructor>("ClassWithSmartPtrConstructor")
       .smart_ptr_constructor(

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -47,6 +47,10 @@ export interface ClassWithConstructor {
   delete(): void;
 }
 
+export interface ClassWithTwoConstructors {
+  delete(): void;
+}
+
 export interface ClassWithSmartPtrConstructor {
   fn(_0: number): number;
   delete(): void;
@@ -65,7 +69,7 @@ export interface DerivedClass extends BaseClass {
 export type ValArr = [ number, number, number ];
 
 export interface MainModule {
-  Test: {new(): Test; staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number};
+  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number};
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   a_class_instance: Test;
@@ -74,11 +78,12 @@ export interface MainModule {
   EmptyEnum: {};
   enum_returning_fn(): Bar;
   IntVec: {new(): IntVec};
-  Foo: {new(): Foo};
+  Foo: {};
   ClassWithConstructor: {new(_0: number, _1: ValArr): ClassWithConstructor};
+  ClassWithTwoConstructors: {new(): ClassWithTwoConstructors; new(_0: number): ClassWithTwoConstructors};
   ClassWithSmartPtrConstructor: {new(_0: number, _1: ValArr): ClassWithSmartPtrConstructor};
-  BaseClass: {new(): BaseClass};
-  DerivedClass: {new(): DerivedClass};
+  BaseClass: {};
+  DerivedClass: {};
   a_bool: boolean;
   an_int: number;
   global_fn(_0: number, _1: number): number;


### PR DESCRIPTION
This also removes the default constructor which was producing an inaccurate
TS definition for classes, since a class binding that doesn't have `constructor<>()`
won't have a JS constructor.

Thanks to @walkingeyerobot for finding this solution.