### PR TITLE
Reduce overhead of sanity checks on compiler startup

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -626,6 +626,12 @@ def phase_linker_setup(options, state, newargs):
   system_libpath = '-L' + str(cache.get_lib_dir(absolute=True))
   state.add_link_flag(sys.maxsize, system_libpath)
 
+  # We used to do this check during on startup during `check_sanity`, but
+  # we now only do it when linking, in order to reduce the overhead when
+  # only compiling.
+  if not shared.SKIP_SUBPROCS:
+    shared.check_llvm_version()
+
   autoconf = os.environ.get('EMMAKEN_JUST_CONFIGURE') or 'conftest.c' in state.orig_args or 'conftest.cpp' in state.orig_args
   if autoconf:
     # configure tests want a more shell-like style, where we emit return codes on exit()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -412,9 +412,10 @@ def set_version_globals():
 
 
 def generate_sanity():
-  return f'{EMSCRIPTEN_VERSION}|{config.LLVM_ROOT}|{get_clang_version()}'
+  return f'{EMSCRIPTEN_VERSION}|{config.LLVM_ROOT}\n'
 
 
+@memoize
 def perform_sanity_checks():
   # some warning, mostly not fatal checks - do them even if EM_IGNORE_SANITY is on
   check_node_version()
@@ -485,14 +486,10 @@ def check_sanity(force=False):
       pass
     if sanity_data == expected:
       logger.debug(f'sanity file up-to-date: {sanity_file}')
-      # Even if the sanity file is up-to-date we still need to at least
-      # check the llvm version. This comes at no extra performance cost
-      # since the version was already extracted and cached by the
-      # generate_sanity() call above.
+      # Even if the sanity file is up-to-date we still run the checks
+      # when force is set.
       if force:
         perform_sanity_checks()
-      else:
-        check_llvm_version()
       return True # all is well
     return False
 


### PR DESCRIPTION
 Stop included the llvm version in the sanity file.  The  the cost
 of running `clang --version` is fairly significant.  On my machine this
 was about 25% of the `emcc` overhead (compared to just calling clang).
    
With this change we no longer check the llvm version when compiling
and only when linking.  The idea here is that for most project link
commands are more rare that compile commands.

The slight downside is that we won't catch folks using the wrong version
of clang until they get to link time.

This change cam about when I was profiling the startup cost of emcc.  See #18623