### PR TITLE
Refactor line_endings.py. NFC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 4.0.4 (in development)
 ----------------------
+- The `--output_eol` command line flag was renamed `--output-eol` for
+  consistency with other flags. The old name continues to work as an alias.
+  (#20735)
 
 4.0.3 - 02/07/25
 ----------------

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -574,12 +574,12 @@ Options that are modified or new in *emcc* are listed below:
    [compile] Tells *emcc* to emit an object file which can then be
    linked with other object files to produce an executable.
 
-"--output_eol windows|linux"
+"--output-eol windows|linux"
    [link] Specifies the line ending to generate for the text files
-   that are outputted. If "--output_eol windows" is passed, the final
-   output files will have Windows rn line endings in them. With "--
-   output_eol linux", the final generated files will be written with
-   Unix n line endings.
+   that are outputted. If "--output-eol windows" is passed, the final
+   output files will have Windows "\r\n" line endings in them. With "
+   --output-eol linux", the final generated files will be written with
+   Unix "\n" line endings.
 
 "--cflags"
    [other] Prints out the flags "emcc" would pass to "clang" to

--- a/emcc.py
+++ b/emcc.py
@@ -82,7 +82,7 @@ LINK_ONLY_FLAGS = {
     '--bind', '--closure', '--cpuprofiler', '--embed-file',
     '--emit-symbol-map', '--emrun', '--exclude-file', '--extern-post-js',
     '--extern-pre-js', '--ignore-dynamic-linking', '--js-library',
-    '--js-transform', '--oformat', '--output_eol',
+    '--js-transform', '--oformat', '--output_eol', '--output-eol',
     '--post-js', '--pre-js', '--preload-file', '--profiling-funcs',
     '--proxy-to-worker', '--shell-file', '--source-map-base',
     '--threadprofiler', '--use-preload-plugins'
@@ -1348,14 +1348,14 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
       exit_with_error('--default-obj-ext is no longer supported by emcc')
     elif arg.startswith('-fsanitize=cfi'):
       exit_with_error('emscripten does not currently support -fsanitize=cfi')
-    elif check_arg('--output_eol'):
+    elif check_arg('--output_eol') or check_arg('--output-eol'):
       style = consume_arg()
       if style.lower() == 'windows':
         options.output_eol = '\r\n'
       elif style.lower() == 'linux':
         options.output_eol = '\n'
       else:
-        exit_with_error(f'Invalid value "{style}" to --output_eol!')
+        exit_with_error(f'invalid value for --output-eol: `{style}`')
     # Record PTHREADS setting because it controls whether --shared-memory is passed to lld
     elif arg == '-pthread':
       settings.PTHREADS = 1

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -566,9 +566,9 @@ Options that are modified or new in *emcc* are listed below:
   [compile]
   Tells *emcc* to emit an object file which can then be linked with other object files to produce an executable.
 
-``--output_eol windows|linux``
+``--output-eol windows|linux``
   [link]
-  Specifies the line ending to generate for the text files that are outputted. If "--output_eol windows" is passed, the final output files will have Windows \r\n line endings in them. With "--output_eol linux", the final generated files will be written with Unix \n line endings.
+  Specifies the line ending to generate for the text files that are outputted. If "--output-eol windows" is passed, the final output files will have Windows ``\r\n`` line endings in them. With "--output-eol linux", the final generated files will be written with Unix ``\n`` line endings.
 
 ``--cflags``
   [other]

--- a/test/common.py
+++ b/test/common.py
@@ -33,11 +33,12 @@ import queue
 
 import clang_native
 import jsrun
+import line_endings
 from tools.shared import EMCC, EMXX, DEBUG, EMCONFIGURE, EMCMAKE
 from tools.shared import get_canonical_temp_dir, path_from_root
 from tools.utils import MACOS, WINDOWS, read_file, read_binary, write_binary, exit_with_error
 from tools.settings import COMPILE_TIME_SETTINGS
-from tools import shared, feature_matrix, line_endings, building, config, utils
+from tools import shared, feature_matrix, building, config, utils
 
 logger = logging.getLogger('common')
 

--- a/test/line_endings.py
+++ b/test/line_endings.py
@@ -7,22 +7,7 @@
 import os
 import sys
 
-
-def convert_line_endings(text, from_eol, to_eol):
-  if from_eol == to_eol:
-    return text
-  return text.replace(from_eol, to_eol)
-
-
-def convert_line_endings_in_file(filename, from_eol, to_eol):
-  if from_eol == to_eol:
-    return # No conversion needed
-
-  with open(filename, 'rb') as f:
-    text = f.read()
-  text = convert_line_endings(text, from_eol.encode(), to_eol.encode())
-  with open(filename, 'wb') as f:
-    f.write(text)
+from tools import utils
 
 
 def check_line_endings(filename, expect_only=None, print_errors=True, print_info=False):
@@ -38,8 +23,7 @@ def check_line_endings(filename, expect_only=None, print_errors=True, print_info
       print('File not found: ' + filename, file=sys.stderr)
     return 1
 
-  with open(filename, 'rb') as f:
-    data = f.read()
+  data = utils.read_binary(filename)
 
   index = data.find(b"\r\r\n")
   if index != -1:
@@ -75,15 +59,15 @@ def check_line_endings(filename, expect_only=None, print_errors=True, print_info
     old_macos_line_ending_example = data[index - 50:index + 50].replace(b'\r', b'\\r').replace(b'\n', b'\\n')
     if print_errors:
       print('File \'' + filename + '\' contains OLD macOS line endings "\\r"', file=sys.stderr)
-      print("Content around an OLD macOS line ending location: '" + old_macos_line_ending_example + "'", file=sys.stderr)
+      print("Content around an OLD macOS line ending location: '" + old_macos_line_ending_example.decode('utf-8') + "'", file=sys.stderr)
     # We don't want to use the old macOS (9.x) line endings anywhere.
     return 1
 
   if has_dos_line_endings and has_unix_line_endings:
     if print_errors:
       print('File \'' + filename + '\' contains both DOS "\\r\\n" and UNIX "\\n" line endings! (' + str(dos_line_ending_count) + ' DOS line endings, ' + str(unix_line_ending_count) + ' UNIX line endings)', file=sys.stderr)
-      print("Content around a DOS line ending location: '" + dos_line_ending_example + "'", file=sys.stderr)
-      print("Content around an UNIX line ending location: '" + unix_line_ending_example + "'", file=sys.stderr)
+      print("Content around a DOS line ending location: '" + dos_line_ending_example.decode('utf-8') + "'", file=sys.stderr)
+      print("Content around an UNIX line ending location: '" + unix_line_ending_example.decode('utf-8') + "'", file=sys.stderr)
     # Mixed line endings
     return 1
 
@@ -96,13 +80,13 @@ def check_line_endings(filename, expect_only=None, print_errors=True, print_info
   if expect_only == '\n' and has_dos_line_endings:
     if print_errors:
       print('File \'' + filename + '\' contains DOS "\\r\\n" line endings! (' + str(dos_line_ending_count) + ' DOS line endings), but expected only UNIX line endings!', file=sys.stderr)
-      print("Content around a DOS line ending location: '" + dos_line_ending_example + "'", file=sys.stderr)
+      print("Content around a DOS line ending location: '" + dos_line_ending_example.decode('utf-8') + "'", file=sys.stderr)
     return 1 # DOS line endings, but expected UNIX
 
   if expect_only == '\r\n' and has_unix_line_endings:
     if print_errors:
       print('File \'' + filename + '\' contains UNIX "\\n" line endings! (' + str(unix_line_ending_count) + ' UNIX line endings), but expected only DOS line endings!', file=sys.stderr)
-      print("Content around a UNIX line ending location: '" + unix_line_ending_example + "'", file=sys.stderr)
+      print("Content around a UNIX line ending location: '" + unix_line_ending_example.decode('utf-8') + "'", file=sys.stderr)
     return 1 # UNIX line endings, but expected DOS
 
   return 0

--- a/tools/minimal_runtime_shell.py
+++ b/tools/minimal_runtime_shell.py
@@ -8,7 +8,6 @@ __rootdir__ = os.path.dirname(__scriptdir__)
 sys.path.insert(0, __rootdir__)
 
 from . import shared
-from . import line_endings
 from . import utils
 from . import feature_matrix
 from .settings import settings
@@ -211,5 +210,4 @@ def generate_minimal_runtime_html(target, options, js_target, target_basename):
   else:
     js_contents = ''
   shell = shell.replace('{{{ JS_CONTENTS_IN_SINGLE_FILE_BUILD }}}', js_contents)
-  shell = line_endings.convert_line_endings(shell, '\n', options.output_eol)
-  utils.write_file(target, shell)
+  utils.write_file(target, shell, options.output_eol)

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -47,6 +47,14 @@ def removeprefix(string, prefix):
   return string
 
 
+def convert_line_endings_in_file(filename, to_eol):
+  if to_eol == os.linesep:
+    return # No conversion needed
+
+  text = read_file(filename)
+  write_file(filename, text, line_endings=to_eol)
+
+
 def read_file(file_path):
   """Read from a file opened in text mode"""
   with open(file_path, encoding='utf-8') as fh:
@@ -59,10 +67,14 @@ def read_binary(file_path):
     return fh.read()
 
 
-def write_file(file_path, text):
+def write_file(file_path, text, line_endings=None):
   """Write to a file opened in text mode"""
-  with open(file_path, 'w', encoding='utf-8') as fh:
-    fh.write(text)
+  if line_endings and line_endings != os.linesep:
+    text = text.replace('\n', line_endings)
+    write_binary(file_path, text.encode('utf-8'))
+  else:
+    with open(file_path, 'w', encoding='utf-8') as fh:
+      fh.write(text)
 
 
 def write_binary(file_path, contents):


### PR DESCRIPTION
Most of the code in this file is used only for testing and is not part
of emscripten proper, so move that code into `test/line_endings.py`.
    
Move the remaining utility functions to `tools/utils.py`.
    
Update `write_file` utility so it can write a file with the correct
line endings. This simplifies the callers who want to write a file
with specific line endings.
