### PR TITLE
Fix asan.test_asyncify_longjmp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -520,6 +520,7 @@ jobs:
             asan.test_cubescript
             asan.test_wasm_worker_hello
             asan.test_externref_emjs_dynlink
+            asan.test_asyncify_longjmp
             lsan.test_stdio_locking
             lsan.test_dlfcn_basic
             lsan.test_pthread_create"

--- a/system/lib/compiler-rt/lib/asan/asan_rtl.cpp
+++ b/system/lib/compiler-rt/lib/asan/asan_rtl.cpp
@@ -447,7 +447,9 @@ static void AsanInitInternal() {
 
   ReplaceSystemMalloc();
 
+#if !SANITIZER_EMSCRIPTEN
   DisableCoreDumperIfNecessary();
+#endif
 
   InitializeShadowMemory();
 

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cpp
@@ -83,6 +83,7 @@ bool DontDumpShadowMemory(uptr addr, uptr length) {
 #endif  // MADV_DONTDUMP
 }
 
+#if !SANITIZER_EMSCRIPTEN
 static rlim_t getlim(int res) {
   rlimit rlim;
   CHECK_EQ(0, getrlimit(res, &rlim));
@@ -127,6 +128,7 @@ void SetAddressSpaceUnlimited() {
   setlim(RLIMIT_AS, RLIM_INFINITY);
   CHECK(AddressSpaceIsUnlimited());
 }
+#endif
 
 void Abort() {
 #if !SANITIZER_GO


### PR DESCRIPTION
This test started failing after the compiler-rt upgrade because we started depending on the `getrlimit` syscall, and this test builds in `-sSTRICT` mode which disables `ALLOW_UNIMPLEMENTED_SYSCALLS` which means stub syscalls are not included.