### PR TITLE
emmalloc: Ask sbrk for aligned sizes

### DIFF
--- a/system/lib/emmalloc.c
+++ b/system/lib/emmalloc.c
@@ -597,7 +597,7 @@ static void *attempt_allocate(Region *freeRegion, size_t alignment, size_t size)
   ASSERT_MALLOC_IS_ACQUIRED();
 
 #ifdef EMMALLOC_VERBOSE
-  MAIN_THREAD_ASYNC_EM_ASM(out('waka attempt_allocate(freeRegion=' + ptrToString($0) + ',alignment=' + Number($1) + ',size=' + Number($2) + ')'), freeRegion, alignment, size);
+  MAIN_THREAD_ASYNC_EM_ASM(out('attempt_allocate(freeRegion=' + ptrToString($0) + ',alignment=' + Number($1) + ',size=' + Number($2) + ')'), freeRegion, alignment, size);
 #endif
 
   assert(freeRegion);

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 431,
   "a.js": 7498,
   "a.js.gz": 3142,
-  "a.wasm": 11525,
-  "a.wasm.gz": 5766,
-  "total": 19696,
-  "total_gz": 9339
+  "a.wasm": 11533,
+  "a.wasm.gz": 5767,
+  "total": 19704,
+  "total_gz": 9340
 }

--- a/test/code_size/hello_wasm_worker_wasm.json
+++ b/test/code_size/hello_wasm_worker_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 433,
   "a.js": 667,
   "a.js.gz": 458,
-  "a.wasm": 1855,
-  "a.wasm.gz": 1049,
-  "total": 3259,
-  "total_gz": 1940
+  "a.wasm": 1863,
+  "a.wasm.gz": 1051,
+  "total": 3267,
+  "total_gz": 1942
 }

--- a/test/code_size/hello_webgl2_wasm.json
+++ b/test/code_size/hello_webgl2_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 379,
   "a.js": 4699,
   "a.js.gz": 2419,
-  "a.wasm": 10467,
-  "a.wasm.gz": 6706,
-  "total": 15735,
-  "total_gz": 9504
+  "a.wasm": 10475,
+  "a.wasm.gz": 6710,
+  "total": 15743,
+  "total_gz": 9508
 }

--- a/test/code_size/hello_webgl2_wasm2js.json
+++ b/test/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 17912,
-  "a.js.gz": 8067,
+  "a.js": 17921,
+  "a.js.gz": 8079,
   "a.mem": 3171,
   "a.mem.gz": 2713,
-  "total": 21650,
-  "total_gz": 11159
+  "total": 21659,
+  "total_gz": 11171
 }

--- a/test/code_size/hello_webgl_wasm.json
+++ b/test/code_size/hello_webgl_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 379,
   "a.js": 4185,
   "a.js.gz": 2243,
-  "a.wasm": 10467,
-  "a.wasm.gz": 6706,
-  "total": 15221,
-  "total_gz": 9328
+  "a.wasm": 10475,
+  "a.wasm.gz": 6710,
+  "total": 15229,
+  "total_gz": 9332
 }

--- a/test/code_size/hello_webgl_wasm2js.json
+++ b/test/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 17390,
-  "a.js.gz": 7895,
+  "a.js": 17399,
+  "a.js.gz": 7910,
   "a.mem": 3171,
   "a.mem.gz": 2713,
-  "total": 21128,
-  "total_gz": 10987
+  "total": 21137,
+  "total_gz": 11002
 }


### PR DESCRIPTION
If we give it an unaligned size, then it will align it, and then memory will
seem non-contiguous. That is, if we sbrk 4 bytes from address 0 then it
returns 0 (the start of the allocation), and logically we reserved the range
0-4. Our next sbrk of any amount will return 8, because sbrk aligns up the
address to multiples of 8. So it seems like we have a region 0-4 and another
8-. Because of this emmalloc would generate separate root regions for
them, that is, they would not get merged because of the 4 bytes of dead
space in the middle.

With this PR, the amount of new regions created in
`test_emmalloc_memvalidate_verbose` goes from 1311 to 1234. I'm not sure
if it's worth testing that, as it would make updating the test difficult, and this
is such an internal detail of emmalloc.

Also add some verbose logging that helps debug this.

Noticed in https://github.com/emscripten-core/emscripten/pull/20704#issuecomment-1819915895
