### PR TITLE
Add a browser64_4gb mode and run a few tests in that mode. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -792,7 +792,13 @@ jobs:
     steps:
       - run-tests-chrome:
           title: "browser64"
-          test_targets: "browser64 skip:browser64.test_4gb_fail"
+          # skip test_4gb_fail as it OOMs on the current bot
+          # Run a few tests in browser64_4gb mode too.
+          test_targets: "
+            browser64
+            skip:browser64.test_4gb_fail
+            browser64_4gb.test_emscripten_log
+            "
   test-browser-firefox:
     executor: bionic
     steps:

--- a/test/runner.py
+++ b/test/runner.py
@@ -96,6 +96,7 @@ misc_test_modes = [
   'wasm64l',
   'bigint',
   'browser64',
+  'browser64_4gb',
 ]
 
 

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5887,3 +5887,13 @@ class browser64(browser):
     self.set_setting('MEMORY64')
     self.emcc_args.append('-Wno-experimental')
     self.require_wasm64()
+
+
+class browser64_4gb(browser):
+  def setUp(self):
+    super().setUp()
+    self.set_setting('MEMORY64')
+    self.set_setting('INITIAL_MEMORY', '4200mb')
+    self.set_setting('GLOBAL_BASE', '4gb')
+    self.emcc_args.append('-Wno-experimental')
+    self.require_wasm64()


### PR DESCRIPTION
This matches the wasm64_4gb mode which runs the tests with all data offset such that it lives above 4gb.