### PR TITLE
WasmFS: Handle overflow in growing MemoryFile buffers

### DIFF
--- a/system/lib/wasmfs/backends/memory_backend.cpp
+++ b/system/lib/wasmfs/backends/memory_backend.cpp
@@ -11,8 +11,6 @@
 #include "backend.h"
 #include "wasmfs.h"
 
-#include <emscripten.h>
-
 namespace wasmfs {
 
 ssize_t MemoryDataFile::write(const uint8_t* buf, size_t len, off_t offset) {

--- a/system/lib/wasmfs/backends/memory_backend.cpp
+++ b/system/lib/wasmfs/backends/memory_backend.cpp
@@ -15,6 +15,11 @@ namespace wasmfs {
 
 ssize_t MemoryDataFile::write(const uint8_t* buf, size_t len, off_t offset) {
   if (offset + len > buffer.size()) {
+    size_t newSize = offset + len;
+    if (newSize <= offset + len) {
+      // Overflow: the necessary size fits in an off_t, but not in a size_t.
+      return -EIO;
+    }
     buffer.resize(offset + len);
   }
   std::memcpy(&buffer[offset], buf, len);

--- a/system/lib/wasmfs/backends/memory_backend.cpp
+++ b/system/lib/wasmfs/backends/memory_backend.cpp
@@ -11,13 +11,15 @@
 #include "backend.h"
 #include "wasmfs.h"
 
+#include <emscripten.h>
+
 namespace wasmfs {
 
 ssize_t MemoryDataFile::write(const uint8_t* buf, size_t len, off_t offset) {
   if (offset + len > buffer.size()) {
-    size_t newSize = offset + len;
-    if (newSize <= offset + len) {
-      // Overflow: the necessary size fits in an off_t, but not in a size_t.
+    if (offset + len > buffer.max_size()) {
+      // Overflow: the necessary size fits in an off_t, but cannot fit in the
+      // container.
       return -EIO;
     }
     buffer.resize(offset + len);


### PR DESCRIPTION
Fixes #20741

I am not sure how to test this. The testcase in #20741 exhibits an interesting situation: we seek to a very high address and then write a single byte, in effect trying to grow the file to that size. musl accepts the write, and simply buffers it. WasmFS is not even reached at this point. Only when we `fclose` the file does musl decide to flush out this write, at which point this PR will make us return an error rather than overflow, but that error is swallowed somewhere in musl's flushing logic, and, seemingly, ignored. Certainly that error does not reach the user, whose `fwrite` command already succeeded earlier... (musl only buffered the write at that time, because it was a single byte... so the write returned "success").