### PR TITLE
Remove old/unused BENCHMARK setting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -35,6 +35,10 @@ See docs/process.md for more on how version tagging works.
   emscripten you can use the `-sPOLYFILL=0` setting. (#20700)
 - libcxx, libcxxabi, libunwind, and compiler-rt were updated to LLVM 17.0.4.
   (#20705, #20707, and #20708)
+- Remove `BENCHMARK` setting. That has not been used by the benchmark suite for
+  some time now (at least not by default), and is much less useful these days
+  given lazy compilation in VMs (which makes it impossible to truly benchmark
+  execution separately from compilation, which `BENCHMARK` hoped to do).
 
 3.1.49 - 11/14/23
 -----------------

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -82,10 +82,6 @@ function callMain() {
 #endif // MAIN_READS_PARAMS
 
   try {
-#if BENCHMARK
-    var start = Date.now();
-#endif
-
 #if ABORT_ON_WASM_EXCEPTIONS
     // See abortWrapperDepth in preamble.js!
     abortWrapperDepth += 1;
@@ -99,10 +95,6 @@ function callMain() {
 #else
     var ret = entryFunction(argc, {{{ to64('argv') }}});
 #endif // STANDALONE_WASM
-
-#if BENCHMARK
-    Module.realPrint('main() took ' + (Date.now() - start) + ' milliseconds');
-#endif
 
 #if ASYNCIFY == 2 && !PROXY_TO_PTHREAD
     // The current spec of JSPI returns a promise only if the function suspends

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -14,11 +14,6 @@
 // An online HTML version (which may be of a different version of Emscripten)
 //    is up at http://kripken.github.io/emscripten-site/docs/api_reference/preamble.js.html
 
-#if BENCHMARK
-Module.realPrint = out;
-out = err = () => {};
-#endif
-
 #if RELOCATABLE
 {{{ makeModuleReceiveWithVar('dynamicLibraries', undefined, '[]', true) }}}
 #endif

--- a/src/settings.js
+++ b/src/settings.js
@@ -1268,11 +1268,6 @@ var EXPORT_ES6 = false;
 // [link]
 var USE_ES6_IMPORT_META = true;
 
-// If 1, will just time how long main() takes to execute, and not print out
-// anything at all whatsoever. This is useful for benchmarking.
-// [link]
-var BENCHMARK = false;
-
 // Global variable to export the module as for environments without a
 // standardized module loading system (e.g. the browser and SM shell).
 // [link]

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -44,8 +44,6 @@ if 'benchmark.' in str(sys.argv):
 
 non_core = unittest.skipIf(CORE_BENCHMARKS, "only running core benchmarks")
 
-IGNORE_COMPILATION = 0
-
 OPTIMIZATIONS = '-O3'
 
 PROFILING = 0
@@ -73,10 +71,7 @@ class Benchmarker():
         raise ValueError('Incorrect benchmark output:\n' + output)
 
       if not output_parser or args == ['0']: # if arg is 0, we are not running code, and have no output to parse
-        if IGNORE_COMPILATION:
-          curr = float(re.search(r'took +([\d\.]+) milliseconds', output).group(1)) / 1000
-        else:
-          curr = time.time() - start
+        curr = time.time() - start
       else:
         try:
           curr = output_parser(output)
@@ -206,7 +201,6 @@ class EmscriptenBenchmarker(Benchmarker):
       OPTIMIZATIONS,
       '-sINITIAL_MEMORY=256MB',
       '-sENVIRONMENT=node,shell',
-      '-sBENCHMARK=%d' % (1 if IGNORE_COMPILATION and not has_output_parser else 0),
       '-o', final
     ] + LLVM_FEATURE_FLAGS
     if shared_args:
@@ -369,7 +363,7 @@ class benchmark(common.RunnerCore):
     for benchmarker in benchmarkers:
       benchmarker.prepare()
 
-    fingerprint = ['ignoring compilation' if IGNORE_COMPILATION else 'including compilation', time.asctime()]
+    fingerprint = ['including compilation', time.asctime()]
     try:
       fingerprint.append('em: ' + run_process(['git', 'show'], stdout=PIPE).stdout.splitlines()[0])
     except Exception:


### PR DESCRIPTION
Fixes #20771 as suggested by @sbc100 there. Yeah, I think we can remove this, as
given lazy compilation it can't really measure execution in a pure way anyhow, and
the benchmark suite has not used this setting for some time anyhow.