### PR TITLE
Fix debug-compilation-dir for system libs

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9800,6 +9800,8 @@ int main() {
 
   @crossplatform
   def test_dwarf_system_lib(self):
+    if config.FROZEN_CACHE:
+      self.skipTest("test doesn't work with frozen cache")
     self.run_process([EMBUILDER, 'build', 'libemmalloc', '--force'])
     libc = os.path.join(config.CACHE, 'sysroot', 'lib', 'wasm32-emscripten', 'libemmalloc.a')
     self.assertExists(libc)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9810,7 +9810,7 @@ int main() {
         [LLVM_DWARFDUMP, libc, '-debug-info', '-debug-line', '--recurse-depth=0'],
         stdout=PIPE).stdout
     # Check that the embedded location of the source file is correct.
-    self.assertIn('DW_AT_name\t("/emsdk/emscripten/system/lib/emmalloc.c")', dwdump)
+    self.assertIn('DW_AT_name\t("system/lib/emmalloc.c")', dwdump)
     self.assertIn('DW_AT_comp_dir\t("/emsdk/emscripten")', dwdump)
 
   @parameterized({

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9798,6 +9798,7 @@ int main() {
                       '-sSEPARATE_DWARF_URL=http://somewhere.com/hosted.wasm'])
     self.assertIn(b'somewhere.com/hosted.wasm', read_binary('a.out.wasm'))
 
+  @crossplatform
   def test_dwarf_system_lib(self):
     self.run_process([EMBUILDER, 'build', 'libemmalloc', '--force'])
     libc = os.path.join(config.CACHE, 'sysroot', 'lib', 'wasm32-emscripten', 'libemmalloc.a')

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -471,8 +471,10 @@ class Library:
     cflags = self.get_cflags()
     if self.deterministic_paths:
       source_dir = utils.path_from_root()
+      relative_source_dir = os.path.relpath(source_dir, build_dir)
       cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten',
-                 f'-fdebug-compilation-dir={build_dir}']
+                 f'-ffile-prefix-map={relative_source_dir}=/emsdk/emscripten',
+                 f'-fdebug-compilation-dir=/emsdk/emscripten']
     asflags = get_base_cflags(preprocess=False)
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -491,8 +493,10 @@ class Library:
     cflags = self.get_cflags()
     if self.deterministic_paths:
       source_dir = utils.path_from_root()
+      relative_source_dir = os.path.relpath(source_dir, build_dir)
       cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten',
-                 f'-fdebug-compilation-dir={build_dir}']
+                 f'-ffile-prefix-map={relative_source_dir}=/emsdk/emscripten',
+                 f'-fdebug-compilation-dir=/emsdk/emscripten']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       ext = shared.suffix(src)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -473,7 +473,7 @@ class Library:
       source_dir = utils.path_from_root()
       relative_source_dir = os.path.relpath(source_dir, build_dir)
       cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten',
-                 f'-ffile-prefix-map={relative_source_dir}=/emsdk/emscripten',
+                 f'-ffile-prefix-map={relative_source_dir}/=',
                  '-fdebug-compilation-dir=/emsdk/emscripten']
     asflags = get_base_cflags(preprocess=False)
     input_files = self.get_files()
@@ -495,7 +495,7 @@ class Library:
       source_dir = utils.path_from_root()
       relative_source_dir = os.path.relpath(source_dir, build_dir)
       cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten',
-                 f'-ffile-prefix-map={relative_source_dir}=/emsdk/emscripten',
+                 f'-ffile-prefix-map={relative_source_dir}/=',
                  '-fdebug-compilation-dir=/emsdk/emscripten']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -474,7 +474,7 @@ class Library:
       relative_source_dir = os.path.relpath(source_dir, build_dir)
       cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten',
                  f'-ffile-prefix-map={relative_source_dir}=/emsdk/emscripten',
-                 f'-fdebug-compilation-dir=/emsdk/emscripten']
+                 '-fdebug-compilation-dir=/emsdk/emscripten']
     asflags = get_base_cflags(preprocess=False)
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -496,7 +496,7 @@ class Library:
       relative_source_dir = os.path.relpath(source_dir, build_dir)
       cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten',
                  f'-ffile-prefix-map={relative_source_dir}=/emsdk/emscripten',
-                 f'-fdebug-compilation-dir=/emsdk/emscripten']
+                 '-fdebug-compilation-dir=/emsdk/emscripten']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       ext = shared.suffix(src)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -472,7 +472,7 @@ class Library:
     if self.deterministic_paths:
       source_dir = utils.path_from_root()
       cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten',
-                 '-fdebug-compilation-dir=/emsdk/emscripten']
+                 f'-fdebug-compilation-dir={build_dir}']
     asflags = get_base_cflags(preprocess=False)
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -492,7 +492,7 @@ class Library:
     if self.deterministic_paths:
       source_dir = utils.path_from_root()
       cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten',
-                 '-fdebug-compilation-dir=/emsdk/emscripten']
+                 f'-fdebug-compilation-dir={build_dir}']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       ext = shared.suffix(src)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -535,6 +535,7 @@ class Library:
         # Use relative paths to reduce the length of the command line.
         # This allows to avoid switching to a response file as often.
         src = os.path.relpath(src, build_dir)
+        src = utils.normalize_path(src)
         batches.setdefault(tuple(cmd), []).append(src)
       objects.add(o)
 


### PR DESCRIPTION
Fixes #20775

Before this change:

```
$ llvm-dwarfdump -debug-info -debug-line --recurse-depth=0  emscripten/cache/sysroot/lib/wasm32-emscripten/libcompiler_rt.a
...
              DW_AT_name    ("../../../system/lib/compiler-rt/__trap.c")
              DW_AT_comp_dir    ("/emsdk/emscripten")
```

After this change:

```
$ llvm-dwarfdump -debug-info -debug-line --recurse-depth=0  emscripten/cache/sysroot/lib/wasm32-emscripten/libcompiler_rt.a
...
              DW_AT_name    ("../../../system/lib/compiler-rt/__trap.c")
              DW_AT_comp_dir    ("/emsdk/emscripten/cache/build/libcompiler_rt-tmp")
```