### PR TITLE
Fix source map gen for relative include directories

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9564,6 +9564,8 @@ int main() {
     self.assertRegexpMatches(output, r'"mappings":\s*"[A-Za-z0-9+/]+,[A-Za-z0-9+/]+"')
 
   def test_wasm_sourcemap_relative_paths(self):
+    ensure_dir('build')
+
     def test(infile, source_map_added_dir=''):
       expected_source_map_path = 'a.cpp'
       if source_map_added_dir:
@@ -9577,8 +9579,14 @@ int main() {
       ]
       for curr in infiles:
         print('  ', curr)
+        print('    ', 'same CWD for compiler and linker')
         self.run_process([EMCC, curr, '-gsource-map'])
         self.assertIn('"%s"' % expected_source_map_path, read_file('a.out.wasm.map'))
+
+        print('    ', 'different CWD for compiler and linker')
+        self.run_process([EMCC, curr, '-g', '-c', '-o', 'build/a.o'])
+        self.run_process([EMCC, 'a.o', '-gsource-map'], cwd='build')
+        self.assertIn('"../%s"' % expected_source_map_path, read_file('build/a.out.wasm.map'))
 
     test('a.cpp')
 

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -224,12 +224,12 @@ def read_dwarf_entries(wasm, options):
 
     include_directories = {'0': comp_dir}
     for dir in re.finditer(r"include_directories\[\s*(\d+)\] = \"([^\"]*)", line_chunk):
-      include_directories[dir.group(1)] = dir.group(2)
+      include_directories[dir.group(1)] = os.path.join(comp_dir, dir.group(2))
 
     files = {}
     for file in re.finditer(r"file_names\[\s*(\d+)\]:\s+name: \"([^\"]*)\"\s+dir_index: (\d+)", line_chunk):
       dir = include_directories[file.group(3)]
-      file_path = (dir + '/' if file.group(2)[0] != '/' else '') + file.group(2)
+      file_path = os.path.join(dir, file.group(2))
       files[file.group(1)] = file_path
 
     for line in re.finditer(r"\n0x([0-9a-f]+)\s+(\d+)\s+(\d+)\s+(\d+)(.*?end_sequence)?", line_chunk):


### PR DESCRIPTION
Since #20577, relative paths are used in command line to build system libraries.
As such, we need to properly handle those relative paths to generate a source map pointing to real source file locations.