### PR TITLE
Fix JavaScriptCore argument handling in test runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,7 +689,6 @@ jobs:
             echo "JS_ENGINES = [JSC_ENGINE]" >> ~/emsdk/.emscripten
       - run-tests:
           test_targets: "
-            core0.test_hello_world
             core0.test_hello_argc
             other.test_modularize_incoming
             other.test_modularize_incoming_export_name"
@@ -714,7 +713,9 @@ jobs:
             echo "SPIDERMONKEY_ENGINE = [os.path.expanduser('~/.jsvu/bin/spidermonkey')]" >> ~/emsdk/.emscripten
             echo "JS_ENGINES = [SPIDERMONKEY_ENGINE]" >> ~/emsdk/.emscripten
       - run-tests:
-          test_targets: "core0.test_hello_world core2.test_demangle_stacks_symbol_map"
+          test_targets: "
+            core0.test_hello_argc
+            core2.test_demangle_stacks_symbol_map"
   test-node-compat:
     # We don't use `bionic` here since its too old to run recent node versions:
     # `/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -688,7 +688,11 @@ jobs:
             echo "JSC_ENGINE = [os.path.expanduser('~/.jsvu/bin/javascriptcore')]" >> ~/emsdk/.emscripten
             echo "JS_ENGINES = [JSC_ENGINE]" >> ~/emsdk/.emscripten
       - run-tests:
-          test_targets: "core0.test_hello_world other.test_modularize_incoming other.test_modularize_incoming_export_name"
+          test_targets: "
+            core0.test_hello_world
+            core0.test_hello_argc
+            other.test_modularize_incoming
+            other.test_modularize_incoming_export_name"
   test-spidermonkey:
     executor: linux-python
     steps:

--- a/test/jsrun.py
+++ b/test/jsrun.py
@@ -36,7 +36,7 @@ def make_command(filename, engine, args=None):
   jsengine = os.path.basename(engine[0])
   # Use "'d8' in" because the name can vary, e.g. d8_g, d8, etc.
   is_d8 = 'd8' in jsengine or 'v8' in jsengine
-  is_jsc = 'jsc' in jsengine
+  is_jsc = 'jsc' in jsengine or 'javascriptcore' in jsengine
   is_wasmer = 'wasmer' in jsengine
   is_wasmtime = 'wasmtime' in jsengine
   command_flags = []


### PR DESCRIPTION
This fixes `core0.test_hello_argc`. The functionality actually worked already, but the
test runner did not identify jsc as jsc there so it didn't add `--` for the arguments.

Split out from #20787