### PR TITLE
Avoid flakiness in other.test_exceptions_rethrow_stack_trace_and_message

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8740,12 +8740,12 @@ int main() {
     rethrow_src1 = r'''
       #include <stdexcept>
 
-      void bar() {
+      void important_function() {
         throw std::runtime_error("my message");
       }
       void foo() {
         try {
-          bar();
+          important_function();
         } catch (...) {
           throw; // rethrowing by throw;
         }
@@ -8758,12 +8758,12 @@ int main() {
     rethrow_src2 = r'''
       #include <stdexcept>
 
-      void bar() {
+      void important_function() {
         throw std::runtime_error("my message");
       }
       void foo() {
         try {
-          bar();
+          important_function();
         } catch (...) {
           auto e = std::current_exception();
           std::rethrow_exception(e); // rethrowing by std::rethrow_exception
@@ -8783,10 +8783,10 @@ int main() {
     self.set_setting('ASSERTIONS', 1)
     err = self.do_run(rethrow_src1, assert_all=True, assert_returncode=NON_ZERO,
                       expected_output=rethrow_stack_trace_checks, regex=True)
-    self.assertNotContained('bar', err)
+    self.assertNotContained('important_function', err)
     err = self.do_run(rethrow_src2, assert_all=True, assert_returncode=NON_ZERO,
                       expected_output=rethrow_stack_trace_checks, regex=True)
-    self.assertNotContained('bar', err)
+    self.assertNotContained('important_function', err)
 
   @requires_node
   def test_jsrun(self):


### PR DESCRIPTION
The test checked that "`bar` " was not contained in the output, but randomly the
name of the directory we run in can contain it :smile: which led to a flake here:

https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket/8763235314082986593/+/u/Emscripten_testsuite__other_/stdout

> at EmscriptenEH (/b/s/w/ir/x/t/emtest_bji7rbs8/emscripten_test_other_2p1h**bar**c/src.js:714:1)

To reduce that chance practically to nothing make the function name much
longer.