### PR TITLE
Link shared libraries with `--unresolved-symbols=import-dynamic`. NFC

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -206,6 +206,7 @@ def lld_flags_for_executable(external_symbols):
 
   if settings.RELOCATABLE:
     cmd.append('--experimental-pic')
+    cmd.append('--unresolved-symbols=import-dynamic')
     if settings.SIDE_MODULE:
       cmd.append('-shared')
     else:


### PR DESCRIPTION
This is currently the default for shared libraries and PIC executables in the linker but I'm hoping to change that soon.  This change means emscripten will not get broken if/when that happens.

See #18198