### PR TITLE
embind: Use single type object for emval.

### DIFF
--- a/src/embind/embind_gen.js
+++ b/src/embind/embind_gen.js
@@ -463,8 +463,9 @@ var LibraryEmbind = {
   _embind_register_std_wstring: (rawType, charSize, name) => {
     registerPrimitiveType(rawType, name, 'function');
   },
-  _embind_register_emval: (rawType, name) => {
-    registerPrimitiveType(rawType, name, 'none');
+  _embind_register_emval__deps: ['$registerType', '$PrimitiveType'],
+  _embind_register_emval: (rawType) => {
+    registerType(rawType, new PrimitiveType(rawType, 'emscripten::val', 'none'));
   },
   _embind_register_user_type__deps: ['$registerType', '$readLatin1String', '$UserType'],
   _embind_register_user_type: (rawType, name) => {

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -297,7 +297,7 @@ sigs = {
   _embind_register_class_function__sig: 'vppippppii',
   _embind_register_class_property__sig: 'vpppppppppp',
   _embind_register_constant__sig: 'vppd',
-  _embind_register_emval__sig: 'vpp',
+  _embind_register_emval__sig: 'vp',
   _embind_register_enum__sig: 'vpppi',
   _embind_register_enum_value__sig: 'vppi',
   _embind_register_float__sig: 'vppp',

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -91,8 +91,7 @@ void _embind_register_std_wstring(
     const char* name);
 
 void _embind_register_emval(
-    TYPEID emvalType,
-    const char* name);
+    TYPEID emvalType);
 
 void _embind_register_memory_view(
     TYPEID memoryViewType,

--- a/system/lib/embind/bind.cpp
+++ b/system/lib/embind/bind.cpp
@@ -154,7 +154,7 @@ EMSCRIPTEN_BINDINGS(builtin) {
   _embind_register_std_wstring(TypeID<std::wstring>::get(), sizeof(wchar_t), "std::wstring");
   _embind_register_std_wstring(TypeID<std::u16string>::get(), sizeof(char16_t), "std::u16string");
   _embind_register_std_wstring(TypeID<std::u32string>::get(), sizeof(char32_t), "std::u32string");
-  _embind_register_emval(TypeID<val>::get(), "emscripten::val");
+  _embind_register_emval(TypeID<val>::get());
 
   // Some of these types are aliases for each other. Luckily,
   // embind.js's _embind_register_memory_view ignores duplicate

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 673,
   "a.html.gz": 431,
-  "a.js": 7395,
-  "a.js.gz": 3109,
-  "a.wasm": 11458,
-  "a.wasm.gz": 5733,
-  "total": 19526,
-  "total_gz": 9273
+  "a.js": 7411,
+  "a.js.gz": 3140,
+  "a.wasm": 11439,
+  "a.wasm.gz": 5729,
+  "total": 19523,
+  "total_gz": 9300
 }


### PR DESCRIPTION
If register_type is used, emval will be registered multiple times for different type id's, but only a single type object is needed on the JS side for all of them.