### PR TITLE
[Docs] Advise to wait after creating LTO commit

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -93,8 +93,9 @@ How:
    resulting SHA be `<LTO-sha>`. An example of this CL is
    https://chromium-review.googlesource.com/c/emscripten-releases/+/3781978.
    After landing the CL, wait for a couple hours before proceeding because
-   building and creating a binary for the new commit will take some time. If the
-   binary is not ready, `create_release.py` in the next step will fail.
+   building and archiving for the new commit will take some time. Check
+   https://ci.chromium.org/p/emscripten-releases/g/main/console to see if the
+   commit has passed "Archive Binaries" phase for all three platforms.
 1. Run [`scripts/create_release.py`][create_release_emsdk] in the emsdk
    repository. When we do both an LTO and a non-LTO release, run:
    ```

--- a/docs/process.md
+++ b/docs/process.md
@@ -95,7 +95,8 @@ How:
    After landing the CL, wait for a couple hours before proceeding because
    building and archiving for the new commit will take some time. Check
    https://ci.chromium.org/p/emscripten-releases/g/main/console to see if the
-   commit has passed "Archive Binaries" phase for all three platforms.
+   commit has passed "Archive Binaries" phase for all three platforms and
+   additionally "Archive Binaries (arm64)" for Mac.
 1. Run [`scripts/create_release.py`][create_release_emsdk] in the emsdk
    repository. When we do both an LTO and a non-LTO release, run:
    ```

--- a/docs/process.md
+++ b/docs/process.md
@@ -92,6 +92,9 @@ How:
    [emscripten-releases][releases_repo] repo. When this CL is committed, let the
    resulting SHA be `<LTO-sha>`. An example of this CL is
    https://chromium-review.googlesource.com/c/emscripten-releases/+/3781978.
+   After landing the CL, wait for a couple hours before proceeding because
+   building and creating a binary for the new commit will take some time. If the
+   binary is not ready, `create_release.py` in the next step will fail.
 1. Run [`scripts/create_release.py`][create_release_emsdk] in the emsdk
    repository. When we do both an LTO and a non-LTO release, run:
    ```


### PR DESCRIPTION
Otherwise you might see the failure when you run `create_release.py` in emsdk.