### PR TITLE
Remove warning about very large functions.

### DIFF
--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -329,11 +329,6 @@ EMSCRIPTEN_FUNCS();
       if not os.environ.get('EMCC_NO_OPT_SORT'):
         funcs.sort(key=lambda x: (len(x[1]), x[0]), reverse=True)
 
-      if 'last' in passes and len(funcs):
-        count = funcs[0][1].count('\n')
-        if count > 3000:
-          print('warning: Output contains some very large functions (%s lines in %s), consider building source files with -Os or -Oz)' % (count, funcs[0][0]), file=sys.stderr)
-
       for func in funcs:
         f.write(func[1])
       funcs = None


### PR DESCRIPTION
4 years ago, commit 49d7717600bdb89010e84f50bf326a34ee85d439 removed OUTLINING_LIMIT which was the only actionable item a user could do to avoid this warning. Suggesting to compile with -Oz when the user is already compiling with -Oz is just stupidly insulting and not constructive user feedback.

It is not Emscripten's job to have opinions about the size of functions.

Fixes <https://github.com/emscripten-core/emscripten/issues/20811>.