### PR TITLE
Streamline metadce by avoiding wasted work

### DIFF
--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -987,7 +987,10 @@ function emitDCEGraph(ast) {
   print(JSON.stringify(graph, null, ' '));
 }
 
-// Apply graph removals from running wasm-metadce
+// Apply graph removals from running wasm-metadce. This only removes imports and
+// exports from JS side, effectively disentangling the wasm and JS sides that
+// way (and we leave further DCE on the JS and wasm sides to their respective
+// optimizers, closure compiler and binaryen).
 function applyDCEGraphRemovals(ast) {
   const unused = new Set(extraInfo.unused);
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -810,9 +810,15 @@ def metadce(js_file, wasm_file, debug_info):
   for line in out.splitlines():
     if line.startswith(PREFIX):
       name = line.replace(PREFIX, '').strip()
+      # we only remove imports and exports in applyDCEGraphRemovals
       if name in import_name_map:
         name = import_name_map[name]
-      unused.append(name)
+        unused.append(name)
+      elif name.startswith('emcc$export$'):
+        unused.append(name)
+  if not unused:
+    # nothing to do
+    return js_file
   # remove them
   passes = ['applyDCEGraphRemovals']
   if settings.MINIFY_WHITESPACE:

--- a/tools/building.py
+++ b/tools/building.py
@@ -817,7 +817,7 @@ def metadce(js_file, wasm_file, debug_info):
       elif name.startswith('emcc$export$'):
         unused.append(name)
   if not unused:
-    # nothing to do
+    # nothing found to be unused, so we have nothing to remove
     return js_file
   # remove them
   passes = ['applyDCEGraphRemovals']


### PR DESCRIPTION
Clarify that we only remove imports and exports, and use that information to
only call the "apply" stage if we in fact have something to remove. In practice
it looks like we end up with nothing to remove only when using the minimal
runtime, as the normal runtime has stuff like `errno` that is almost always
removable.

This is probably not a significant speedup, but it doesn't hurt, and it is nice I
think to clarify what work we do exactly - this would have saved me some
debugging time right now in fact.