### PR TITLE
embind: Fix the TypeScript definitions for std::string and std::wstring.

### DIFF
--- a/test/other/embind_tsgen.cpp
+++ b/test/other/embind_tsgen.cpp
@@ -89,6 +89,14 @@ int function_with_callback_param(CallbackType ct) {
 
 int global_fn(int, int) { return 0; }
 
+std::string string_test(std::string arg) {
+  return "hi";
+}
+
+std::wstring wstring_test(std::wstring arg) {
+  return L"hi";
+}
+
 class BaseClass {
  public:
   virtual ~BaseClass() = default;
@@ -155,6 +163,9 @@ EMSCRIPTEN_BINDINGS(Test) {
   class_<Foo>("Foo").function("process", &Foo::process);
 
   function("global_fn", &global_fn);
+
+  function("string_test", &string_test);
+  function("wstring_test", &wstring_test);
 
   class_<ClassWithConstructor>("ClassWithConstructor")
       .constructor<int, const ValArr&>()

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -91,4 +91,6 @@ export interface MainModule {
   smart_ptr_function(_0: ClassWithSmartPtrConstructor): number;
   smart_ptr_function_with_params(foo: ClassWithSmartPtrConstructor): number;
   function_with_callback_param(_0: (message: string) => void): number;
+  string_test(_0: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): string;
+  wstring_test(_0: string): string;
 }


### PR DESCRIPTION
 - The return type for std::string is always a JS string.
 - std::wstring always takes in a JS string and returns a JS string.

Fixes #20564