### PR TITLE
Update node canary used in testing. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ commands:
     description: "install canary version of node"
     steps:
       - install-node-version:
-         node_version: "21.0.0-v8-canary202309143a48826a08"
+         node_version: "22.0.0-v8-canary20231108ff311d5a39"
          canary: true
   install-v8:
     description: "install v8 using jsvu"
@@ -651,6 +651,7 @@ jobs:
       - upload-test-results
   test-wasm64_4gb:
     environment:
+      LANG: "C.UTF-8"
       # Only run 2 tests at a time to avoid OOM (since each tests used >4gb)
       EMCC_CORES: "2"
     # We don't use `bionic` here since its too old to run recent node versions:
@@ -721,6 +722,7 @@ jobs:
     # `/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found`
     executor: linux-python
     environment:
+      LANG: "C.UTF-8"
       EMTEST_SKIP_V8: "1"
     steps:
       - checkout

--- a/test/core/test_env.out
+++ b/test/core/test_env.out
@@ -4,7 +4,7 @@ LOGNAME=web_user
 PATH=/
 PWD=/
 HOME=/home/web_user
-LANG=C.UTF-8
+LANG=(C|en_US).UTF-8
 _=.*(/test_env.js|./this.program)
 
 getenv\(PATH\): /

--- a/test/core/test_environ.out
+++ b/test/core/test_environ.out
@@ -3,5 +3,5 @@ LOGNAME=web_user
 PATH=/
 PWD=/
 HOME=/home/web_user
-LANG=C.UTF-8
+LANG=(C|en_US).UTF-8
 _=.*(/test_environ.js|/this.program)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6412,9 +6412,19 @@ Module.onRuntimeInitialized = () => {
   def test_unary_literal(self):
     self.do_core_test('test_unary_literal.cpp')
 
+  @crossplatform
+  # Explictly set LANG here since new versions of node expose
+  # `navigator.languages` which emscripten will honor and we
+  # want the test output to be consistent.
+  @with_env_modify({'LANG': 'en_US.UTF-8'})
   def test_env(self):
     self.do_core_test('test_env.c', regex=True)
 
+  @crossplatform
+  # Explictly set LANG here since new versions of node expose
+  # `navigator.languages` which emscripten will honor and we
+  # want the test output to be consistent.
+  @with_env_modify({'LANG': 'en_US.UTF-8'})
   def test_environ(self):
     self.do_core_test('test_environ.c', regex=True)
 


### PR DESCRIPTION
The two tests that explicitly check the LANG environment needed updating
because the new version of node now exposed `navigator.language`.
Support both `en-US` and `C` in the test output in order to support both
old and new versions of node.  (Sadly setting LANG=C in the version
doesn't work, and just results it me seeing my default locale).

Split out from #20725