### PR TITLE
Increase node stack size of 8Mb when running js_optimizer

### DIFF
--- a/site/source/docs/getting_started/FAQ.rst
+++ b/site/source/docs/getting_started/FAQ.rst
@@ -654,10 +654,10 @@ Why do I get a stack size error when optimizing: ``RangeError: Maximum call stac
 
 You may need to increase the stack size for :term:`node.js`.
 
-On Linux and Mac macOS, you can just do ``NODE_JS = ['node',
-'--stack_size=8192']`` in the :ref:`compiler-configuration-file`. On Windows,
-you will also need ``--max-stack-size=8192``, and also run ``editbin
-/stack:33554432 node.exe``.
+On Linux and Mac macOS, you can just do ``NODE_JS = ['/path/to/node',
+'--stack_size=8192']`` in the :ref:`compiler-configuration-file`. On Windows
+(for node versions older than v19), you will also need
+``--max-stack-size=8192``, and also run ``editbin /stack:33554432 node.exe``.
 
 
 How do I pass int64_t and uint64_t values from js into Wasm functions?

--- a/tools/building.py
+++ b/tools/building.py
@@ -342,7 +342,7 @@ def opt_level_to_str(opt_level, shrink_level=0):
 def js_optimizer(filename, passes):
   from . import js_optimizer
   try:
-    return js_optimizer.run_on_js(filename, passes)
+    return js_optimizer.run_on_file(filename, passes)
   except subprocess.CalledProcessError as e:
     exit_with_error("'%s' failed (%d)", ' '.join(e.cmd), e.returncode)
 


### PR DESCRIPTION
On windows the default stack size is still limited to 1MB in older versions of node.  See https://github.com/nodejs/node/pull/43632 which made it into v19.0.0.

Fixes: #17897