### PR TITLE
Fix Glfw window resize

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1206,6 +1206,9 @@ var LibraryGLFW = {
     window.addEventListener("keypress", GLFW.onKeyPress, true);
     window.addEventListener("keyup", GLFW.onKeyup, true);
     window.addEventListener("blur", GLFW.onBlur, true);
+    window.addEventListener("resize", () => {
+      GLFW.onCanvasResize(window.innerWidth, window.innerHeight);
+    });
     // from https://stackoverflow.com/a/70514686/7484780 . maybe add this to browser.js?
     // no idea how to remove this listener.
     (function updatePixelRatio(){


### PR DESCRIPTION
Window resize events are not piped to neither glfwSetFramebufferSizeCallback nor glfwSetWindowSizeCallback making the application unaware that the browser window was dynamically resized.

I noticed the behavior on Windows and MacOS with a [small WebGpu application](https://github.com/pierricgimmig/web_gpu_app/tree/web_only). The suggested code fixes the issue, but I'm not sure if it's the right solution. It seems `Browser.resizeListeners` are not called when resizing the browser window, perhaps there's a problem with this mechanism.

Associated issue: https://github.com/emscripten-core/emscripten/issues/20830