### PR TITLE
Fix js-optimizer crash on empty array destructuring element

### DIFF
--- a/test/optimizer/JSDCE-objectPattern-output.js
+++ b/test/optimizer/JSDCE-objectPattern-output.js
@@ -5,7 +5,7 @@ let z = 50;
 globalThis.f = function(r) {
  let {a: a, b: b} = r;
  let {z: c} = r;
- let [i, {foo: p, bar: q}] = r;
+ let [, i, {foo: p, bar: q}] = r;
  return g(a, b, c, d, z);
 };
 

--- a/test/optimizer/JSDCE-objectPattern.js
+++ b/test/optimizer/JSDCE-objectPattern.js
@@ -13,7 +13,7 @@ let z = 50;
 globalThis.f = function(r) {
   let { a, b } = r;
   let { z: c } = r;
-  let [i, {foo : p, bar : q}] = r;
+  let [/*empty*/, i, {foo : p, bar : q}] = r;
   return g(a, b, c, d, z);
 };
 

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -433,7 +433,7 @@ function runJSDCE(ast, aggressive) {
             }
           } else if (id.type === 'ArrayPattern') {
             for (const elem of id.elements) {
-              traverse(elem);
+              if (elem) traverse(elem);
             }
           } else {
             assertAt(id.type === 'Identifier', id, `expected Indentifier but found ${id.type}`);


### PR DESCRIPTION
Followup to #20835.

Fixes: #20818