### PR TITLE
Add missing sphinx theme MIT license file

### DIFF
--- a/site/source/_themes/emscripten_sphinx_rtd_theme/LICENSE
+++ b/site/source/_themes/emscripten_sphinx_rtd_theme/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Dave Snider
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/site/source/_themes/emscripten_sphinx_rtd_theme/readme.txt
+++ b/site/source/_themes/emscripten_sphinx_rtd_theme/readme.txt
@@ -1,0 +1,4 @@
+These files are from:
+
+https://github.com/readthedocs/sphinx_rtd_theme/tree/master
+


### PR DESCRIPTION
Fixes #12794 , see discussion there: it seems the LICENSE file was missed back when
those files were imported.