### PR TITLE
Run fewer basic math tests, and move a test to other

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -597,71 +597,7 @@ class TestCoreBase(RunnerCore):
                          ('64bitisslow', '64D8470573635EC354FEE7B7F87C566FCAF1EFB491041670')]:
       self.do_run('src.js', 'hash value: ' + output, args=[text], no_build=True)
 
-  def test_unaligned(self):
-    self.skipTest('LLVM marks the reads of s as fully aligned, making this test invalid')
-    src = r'''
-      #include <stdio.h>
-
-      struct S {
-        double x;
-        int y;
-      };
-
-      int main() {
-        // the 64-bit value here will not be 8-byte aligned
-        S s0[3] = { {0x12a751f430142, 22}, {0x17a5c85bad144, 98}, {1, 1}};
-        char buffer[10*sizeof(S)];
-        int b = int(buffer);
-        S *s = (S*)(b + 4-b%8);
-        s[0] = s0[0];
-        s[1] = s0[1];
-        s[2] = s0[2];
-
-        printf("*%d : %d : %d\n", sizeof(S), ((unsigned long)&s[0]) % 8 != ((unsigned long)&s[1]) % 8,
-                                             ((unsigned long)&s[1]) - ((unsigned long)&s[0]));
-        s[0].x++;
-        s[0].y++;
-        s[1].x++;
-        s[1].y++;
-        printf("%.1f,%d,%.1f,%d\n", s[0].x, s[0].y, s[1].x, s[1].y);
-        return 0;
-      }
-      '''
-
-    # TODO: A version of this with int64s as well
-
-    self.do_run(src, '*12 : 1 : 12\n328157500735811.0,23,416012775903557.0,99\n')
-
-    return # TODO: continue to the next part here
-
-    # Test for undefined behavior in C. This is not legitimate code, but does exist
-
-    src = r'''
-      #include <stdio.h>
-
-      int main()
-      {
-        int x[10];
-        char *p = (char*)&x[0];
-        p++;
-        short *q = (short*)p;
-        *q = 300;
-        printf("*%d:%ld*\n", *q, ((long)q)%2);
-        int *r = (int*)p;
-        *r = 515559;
-        printf("*%d*\n", *r);
-        long long *t = (long long*)p;
-        *t = 42949672960;
-        printf("*%lld*\n", *t);
-        return 0;
-      }
-    '''
-
-    try:
-      self.do_run(src, '*300:1*\n*515559*\n*42949672960*\n')
-    except Exception as e:
-      assert 'must be aligned' in str(e), e # expected to fail without emulation
-
+  @only_wasm2js('tests 64-bit alignment of structs')
   def test_align64(self):
     src = r'''
       #include <stdio.h>
@@ -710,12 +646,7 @@ class TestCoreBase(RunnerCore):
 0.00,10,123.46,0.00 : 0.00,10,123.46,0.00
 ''')
 
-  @no_asan('asan errors on corner cases we check')
-  @no_lsan('lsan errors on corner cases we check')
-  def test_aligned_alloc(self):
-    self.do_runf('test_aligned_alloc.c', '',
-                 emcc_args=['-Wno-non-power-of-two-alignment'])
-
+  @only_wasm2js('tests signed vs unsigned values')
   def test_unsigned(self):
     src = '''
       #include <stdio.h>
@@ -801,12 +732,14 @@ class TestCoreBase(RunnerCore):
     '''
     self.do_run(src, '*255*\n*65535*\n*-1*\n*-1*\n*-1*')
 
+  @only_wasm2js('tests 1-bit fields')
   def test_bitfields(self):
     self.do_core_test('test_bitfields.c')
 
   def test_floatvars(self):
     self.do_core_test('test_floatvars.cpp')
 
+  @only_wasm2js('tests pointer casts')
   def test_closebitcasts(self):
     self.do_core_test('closebitcasts.c')
 
@@ -814,9 +747,11 @@ class TestCoreBase(RunnerCore):
     self.emcc_args += ['-ffast-math']
     self.do_core_test('test_fast_math.c', args=['5', '6', '8'])
 
+  @only_wasm2js('tests division by zero')
   def test_zerodiv(self):
     self.do_core_test('test_zerodiv.c')
 
+  @only_wasm2js('tests multiplication by zero')
   def test_zero_multiplication(self):
     # needs to flush stdio streams
     self.set_setting('EXIT_RUNTIME')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14241,3 +14241,7 @@ addToLibrary({
   def test_force_filesystem_error(self):
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sFILESYSTEM=0', '-sFORCE_FILESYSTEM'])
     self.assertContained('emcc: error: `-sFORCE_FILESYSTEM` cannot be used with `-sFILESYSTEM=0`', err)
+
+  def test_aligned_alloc(self):
+    self.do_runf('test_aligned_alloc.c', '',
+                 emcc_args=['-Wno-non-power-of-two-alignment'])


### PR DESCRIPTION
`test_aligned_alloc` was moved to `other` as it tests a libc method (`aligned_alloc`) which
does not depend on the emcc optimization level we run the test with.

`test_unaligned` was not being run as it is irrelevant for the wasm backend, so remove it.