### PR TITLE
Re-enable wasmfs metadce tests after roll

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7459,7 +7459,7 @@ Resolved: "/" => "/"
     self.run_process([EMCC, 'src.c'])
     self.assertContained('double-freed', self.run_js('a.out.js'))
     # in debug mode, the double-free is caught
-    self.run_process([EMCC, 'src.c', '-sASSERTIONS=2'])
+    self.run_process([EMCC, 'src.c', '-sASSERTIONS=2'] )
     out = self.run_js('a.out.js', assert_returncode=NON_ZERO)
     self.assertContained('native code called abort()', out)
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8296,8 +8296,7 @@ int main() {
     # code. mode 2 ignores those and fully optimizes out the ctors
     'ctors1':    (['-O2', '-sEVAL_CTORS'],   [], ['waka']), # noqa
     'ctors2':    (['-O2', '-sEVAL_CTORS=2'], [], ['waka']), # noqa
-    # disable for roll
-    # 'wasmfs':    (['-O2', '-sWASMFS'],       [], ['waka']), # noqa
+    'wasmfs':    (['-O2', '-sWASMFS'],       [], ['waka']), # noqa
   })
   def test_metadce_cxx(self, *args):
     # do not check functions in this test as there are a lot of libc++ functions
@@ -8320,8 +8319,7 @@ int main() {
     # larger for wasm backend.
     'dylink': (['-O3', '-sMAIN_MODULE=2'], [], []), # noqa
     # WasmFS should not be fully linked into a hello world program.
-    # disable for roll
-    # 'wasmfs': (['-O3', '-sWASMFS'],        [], []), # noqa
+    'wasmfs': (['-O3', '-sWASMFS'],        [], []), # noqa
   })
   def test_metadce_hello(self, *args):
     self.run_metadce_test('hello_world.cpp', *args)
@@ -8362,8 +8360,7 @@ int main() {
 
   @parameterized({
     'js_fs':  (['-O3', '-sNO_WASMFS'], [], []), # noqa
-    # disable for roll
-    # 'wasmfs': (['-O3', '-sWASMFS'],    [], []), # noqa
+    'wasmfs': (['-O3', '-sWASMFS'],    [], []), # noqa
   })
   def test_metadce_files(self, *args):
     self.run_metadce_test('files.cpp', *args)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7459,7 +7459,7 @@ Resolved: "/" => "/"
     self.run_process([EMCC, 'src.c'])
     self.assertContained('double-freed', self.run_js('a.out.js'))
     # in debug mode, the double-free is caught
-    self.run_process([EMCC, 'src.c', '-sASSERTIONS=2'] )
+    self.run_process([EMCC, 'src.c', '-sASSERTIONS=2'])
     out = self.run_js('a.out.js', assert_returncode=NON_ZERO)
     self.assertContained('native code called abort()', out)
 


### PR DESCRIPTION
Preparing this, but it needs to wait on the disabled tests to roll in via emscripten,
then for the binaryen inlining update to roll in, and then I can land it.