### PR TITLE
Use `globalThis` rather than `global` in JS compiler. NFC

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -8,15 +8,15 @@
 // LLVM => JavaScript compiler, main entry point
 
 const fs = require('fs');
-global.vm = require('vm');
-global.assert = require('assert');
-global.nodePath = require('path');
+globalThis.vm = require('vm');
+globalThis.assert = require('assert');
+globalThis.nodePath = require('path');
 
-global.print = (x) => {
+globalThis.print = (x) => {
   process.stdout.write(x + '\n');
 };
 
-global.printErr = (x) => {
+globalThis.printErr = (x) => {
   process.stderr.write(x + '\n');
 };
 
@@ -32,7 +32,7 @@ function find(filename) {
   return filename;
 }
 
-global.read = (filename) => {
+globalThis.read = (filename) => {
   assert(filename);
   const absolute = find(filename);
   return fs.readFileSync(absolute).toString();
@@ -62,7 +62,7 @@ assert(settingsFile);
 const settings = JSON.parse(read(settingsFile));
 Object.assign(global, settings);
 
-global.symbolsOnly = symbolsOnlyArg != -1;
+globalThis.symbolsOnly = symbolsOnlyArg != -1;
 
 // In case compiler.js is run directly (as in gen_sig_info)
 // ALL_INCOMING_MODULE_JS_API might not be populated yet.
@@ -81,7 +81,7 @@ if (symbolsOnly) {
 }
 
 // Side modules are pure wasm and have no JS
-assert(!SIDE_MODULE || (ASYNCIFY && global.symbolsOnly), 'JS compiler should only run on side modules if asyncify is used.');
+assert(!SIDE_MODULE || (ASYNCIFY && globalThis.symbolsOnly), 'JS compiler should only run on side modules if asyncify is used.');
 
 // Load compiler code
 

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -9,15 +9,15 @@
 // Convert analyzed data to javascript. Everything has already been calculated
 // before this stage, which just does the final conversion to JavaScript.
 
-global.addedLibraryItems = {};
+globalThis.addedLibraryItems = {};
 
-global.extraLibraryFuncs = [];
+globalThis.extraLibraryFuncs = [];
 
 // Some JS-implemented library functions are proxied to be called on the main
 // browser thread, if the Emscripten runtime is executing in a Web Worker.
 // Each such proxied function is identified via an ordinal number (this is not
 // the same namespace as function pointers in general).
-global.proxiedFunctionTable = [];
+globalThis.proxiedFunctionTable = [];
 
 // Mangles the given C/JS side function name to assembly level function name (adds an underscore)
 function mangleCSymbolName(f) {

--- a/src/library_html5_webgpu.js
+++ b/src/library_html5_webgpu.js
@@ -1,6 +1,6 @@
 {{{
   // Helper functions for code generation
-  global.html5_gpu = {
+  globalThis.html5_gpu = {
     makeImportExport: (snake_case, CamelCase) => {
       return `
 LibraryHTML5WebGPU.emscripten_webgpu_import_${snake_case}__deps = ['$WebGPU', '$JsValStore'];

--- a/src/library_int53.js
+++ b/src/library_int53.js
@@ -142,7 +142,7 @@ addToLibrary({
 });
 
 #if WASM_BIGINT
-global.i53ConversionDeps = ['$bigintToI53Checked'];
+globalThis.i53ConversionDeps = ['$bigintToI53Checked'];
 #else
-global.i53ConversionDeps = ['$convertI32PairToI53Checked'];
+globalThis.i53ConversionDeps = ['$convertI32PairToI53Checked'];
 #endif

--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -7,9 +7,9 @@
 #if WASM_WORKERS == 2
 // Helpers for _wasmWorkerBlobUrl used in WASM_WORKERS == 2 mode
 {{{
-  global.captureModuleArg = () => MODULARIZE ? '' : 'self.Module=d;';
-  global.instantiateModule = () => MODULARIZE ? `${EXPORT_NAME}(d);` : '';
-  global.instantiateWasm = () => MINIMAL_RUNTIME ? '' : 'd[`instantiateWasm`]=(i,r)=>{var n=new WebAssembly.Instance(d[`wasm`],i);return r(n,d[`wasm`]);};';
+  globalThis.captureModuleArg = () => MODULARIZE ? '' : 'self.Module=d;';
+  globalThis.instantiateModule = () => MODULARIZE ? `${EXPORT_NAME}(d);` : '';
+  globalThis.instantiateWasm = () => MINIMAL_RUNTIME ? '' : 'd[`instantiateWasm`]=(i,r)=>{var n=new WebAssembly.Instance(d[`wasm`],i);return r(n,d[`wasm`]);};';
   null;
 }}}
 #endif

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -9,7 +9,7 @@
 {{{ GL_POOL_TEMP_BUFFERS_SIZE = 2*9*16 }}} // = 288
 
 {{{
-  global.isCurrentContextWebGL2 = () => {
+  globalThis.isCurrentContextWebGL2 = () => {
     if (MIN_WEBGL_VERSION >= 2) return 'true';
     if (MAX_WEBGL_VERSION <= 1) return 'false';
     return 'GL.currentContext.version >= 2';

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -23,7 +23,7 @@
 
 {{{
   // Helper functions for code generation
-  global.gpu = {
+  globalThis.gpu = {
     makeInitManager: function(type) {
       var mgr = `WebGPU.mgr${type}`;
       return `${mgr} = ${mgr} || new Manager();`;

--- a/src/modules.js
+++ b/src/modules.js
@@ -18,9 +18,9 @@ function genArgSequence(n) {
 }
 
 // List of symbols that were added from the library.
-global.librarySymbols = [];
+globalThis.librarySymbols = [];
 
-global.LibraryManager = {
+globalThis.LibraryManager = {
   library: {},
   structs: {},
   loaded: false,

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -8,7 +8,7 @@
  * Tests live in test/other/test_parseTools.js.
  */
 
-global.FOUR_GB = 4 * 1024 * 1024 * 1024;
+globalThis.FOUR_GB = 4 * 1024 * 1024 * 1024;
 const FLOAT_TYPES = new Set(['float', 'double']);
 
 // Does simple 'macro' substitution, using Django-like syntax,
@@ -175,8 +175,8 @@ function needsQuoting(ident) {
   return true;
 }
 
-global.POINTER_SIZE = MEMORY64 ? 8 : 4;
-global.STACK_ALIGN = 16;
+globalThis.POINTER_SIZE = MEMORY64 ? 8 : 4;
+globalThis.STACK_ALIGN = 16;
 const POINTER_BITS = POINTER_SIZE * 8;
 const POINTER_TYPE = `u${POINTER_BITS}`;
 const POINTER_JS_TYPE = MEMORY64 ? "'bigint'" : "'number'";
@@ -645,13 +645,13 @@ function makeEval(code) {
   return ret;
 }
 
-global.ATINITS = [];
+globalThis.ATINITS = [];
 
 function addAtInit(code) {
   ATINITS.push(code);
 }
 
-global.ATEXITS = [];
+globalThis.ATEXITS = [];
 
 function addAtExit(code) {
   if (EXIT_RUNTIME) {

--- a/src/parseTools_legacy.js
+++ b/src/parseTools_legacy.js
@@ -107,14 +107,14 @@ function getNativeFieldSize(type) {
   return Math.max(getNativeTypeSize(type), POINTER_SIZE);
 }
 
-global.Runtime = {
+globalThis.Runtime = {
   getNativeTypeSize,
   getNativeFieldSize,
   POINTER_SIZE,
   QUANTUM_SIZE: POINTER_SIZE,
 };
 
-global.ATMAINS = [];
+globalThis.ATMAINS = [];
 
 function addAtMain(code) {
   warn('use of legacy parseTools function: addAtMain');

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -7,11 +7,11 @@
 {{{
   // Helper function to export a symbol on the module object
   // if requested.
-  global.maybeExport = (x) => MODULARIZE && EXPORT_ALL ? `Module['${x}'] = ` : '';
+  globalThis.maybeExport = (x) => MODULARIZE && EXPORT_ALL ? `Module['${x}'] = ` : '';
   // Export to the AudioWorkletGlobalScope the needed variables to access
   // the heap. AudioWorkletGlobalScope is unable to access global JS vars
   // in the compiled main JS file.
-  global.maybeExportIfAudioWorklet = (x) => (MODULARIZE && EXPORT_ALL) || AUDIO_WORKLET ? `Module['${x}'] = ` : '';
+  globalThis.maybeExportIfAudioWorklet = (x) => (MODULARIZE && EXPORT_ALL) || AUDIO_WORKLET ? `Module['${x}'] = ` : '';
   null;
 }}}
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -36,8 +36,8 @@ function dump(item) {
   }
 }
 
-global.warnings = false;
-global.currentFile = null;
+globalThis.warnings = false;
+globalThis.currentFile = null;
 
 function errorPrefix() {
   if (currentFile) {
@@ -48,7 +48,7 @@ function errorPrefix() {
 }
 
 function warn(a, msg) {
-  global.warnings = true;
+  globalThis.warnings = true;
   if (!msg) {
     msg = a;
     a = false;
@@ -71,7 +71,7 @@ function warnOnce(a, msg) {
   }
 }
 
-global.abortExecution = false;
+globalThis.abortExecution = false;
 
 function error(msg) {
   abortExecution = true;


### PR DESCRIPTION
Since we updated out min node version to 16 in #20551 we can now assume that `globalThis` (the more standard name) is always available

See https://nodejs.org/api/globals.html#global