### PR TITLE
Fix HTML5 lib LTO build with PTHREADS (#20275)

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2038,7 +2038,7 @@ class libhtml5(Library):
   cflags = ['-Oz', '-fno-inline-functions']
   src_dir = 'system/lib/html5'
   src_glob = '*.c'
-
+  force_object_files = True
 
 class CompilerRTLibrary(Library):
   cflags = ['-fno-builtin']


### PR DESCRIPTION
This is workaround for a bug in wasm-ld.

We use WebGPU, pthread and PROXY_TO_PTHREAD and noticed a linker error in our release builds where we enable LTO:

wasm-ld: error: C:\\Dev\\emsdk\\upstream\\emscripten\\cache\\sysroot\\lib\\wasm32-emscripten\\lto\libhtml5.a(callback.o): attempt to add bitcode file after LTO (_emscripten_run_callback_on_thread)

Judging by other tickets this seems like the place to fix it, but let me know if that's wrong.