### PR TITLE
Fix minimal runtime for initial memory over 4GB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -807,6 +807,7 @@ jobs:
             browser64
             skip:browser64.test_4gb_fail
             browser64_4gb.test_async_*
+            browser64_4gb.test_audio_worklet*
             browser64_4gb.test_emscripten_log
             "
   test-browser-firefox:

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -96,9 +96,9 @@ if (!ENVIRONMENT_IS_PTHREAD) {
     Module['mem'] ||
 #endif
     new WebAssembly.Memory({
-      'initial': {{{ INITIAL_MEMORY >>> 16 }}},
+      'initial': {{{ INITIAL_MEMORY / WASM_PAGE_SIZE }}},
 #if SHARED_MEMORY || !ALLOW_MEMORY_GROWTH || MAXIMUM_MEMORY != FOUR_GB
-      'maximum': {{{ (ALLOW_MEMORY_GROWTH && MAXIMUM_MEMORY != FOUR_GB ? MAXIMUM_MEMORY : INITIAL_MEMORY) >>> 16 }}},
+      'maximum': {{{ (ALLOW_MEMORY_GROWTH && MAXIMUM_MEMORY != FOUR_GB ? MAXIMUM_MEMORY : INITIAL_MEMORY) / WASM_PAGE_SIZE }}},
 #endif
 #if SHARED_MEMORY
       'shared': true,


### PR DESCRIPTION
`{{{ INITIAL_MEMORY >>> 16 }}}` does not work for values larger than 2^32 because it causes conversion a uint32.

Note that this is a compile time calculation so performance is not effected.