### PR TITLE
WebGPU: consolidate all object tables, move some impl to "layered" webgpu.cpp

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -72,6 +72,7 @@ MINIMAL_TASKS = [
     'libnoexit',
     'sqlite3',
     'sqlite3-mt',
+    'libwebgpu',
     'libwebgpu_cpp',
 ]
 

--- a/src/library_html5_webgpu.js
+++ b/src/library_html5_webgpu.js
@@ -5,11 +5,11 @@
       return `
 LibraryHTML5WebGPU.emscripten_webgpu_import_${snake_case}__deps = ['$WebGPU', '$JsValStore'];
 LibraryHTML5WebGPU.emscripten_webgpu_import_${snake_case} = (handle) =>
-  WebGPU.mgr${CamelCase}.create(JsValStore.get(handle));
+  WebGPU._tableInsert(JsValStore.get(handle));
 
 LibraryHTML5WebGPU.emscripten_webgpu_export_${snake_case}__deps = ['$WebGPU', '$JsValStore'];
 LibraryHTML5WebGPU.emscripten_webgpu_export_${snake_case} = (handle) =>
-  JsValStore.add(WebGPU.mgr${CamelCase}.get(handle));`
+  JsValStore.add(WebGPU._tableGet(handle));`
     },
   };
   null;
@@ -48,17 +48,17 @@ var LibraryHTML5WebGPU = {
   emscripten_webgpu_release_js_handle__deps: ['$JsValStore'],
   emscripten_webgpu_release_js_handle: (id) => JsValStore.remove(id),
 
-  emscripten_webgpu_get_device__deps: ['$WebGPU'],
+  emscripten_webgpu_get_device__deps: ['$WebGPU', 'emwgpuAddRef'],
   emscripten_webgpu_get_device: () => {
 #if ASSERTIONS
     assert(Module['preinitializedWebGPUDevice']);
 #endif
     if (WebGPU.preinitializedDeviceId === undefined) {
       var device = Module['preinitializedWebGPUDevice'];
-      var deviceWrapper = { queueId: WebGPU.mgrQueue.create(device["queue"]) };
-      WebGPU.preinitializedDeviceId = WebGPU.mgrDevice.create(device, deviceWrapper);
+      var deviceWrapper = { queueId: WebGPU._tableInsert(device["queue"]) };
+      WebGPU.preinitializedDeviceId = WebGPU._tableInsert(device, deviceWrapper);
     }
-    WebGPU.mgrDevice.reference(WebGPU.preinitializedDeviceId);
+    _emwgpuAddRef(WebGPU.preinitializedDeviceId);
     return WebGPU.preinitializedDeviceId;
   },
 };

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -2190,10 +2190,6 @@ var LibraryWebGPU = {
 
   // Instance
 
-  wgpuCreateInstance: (descriptor) => 1,
-  wgpuInstanceReference: (instance) => {}, // no-op
-  wgpuInstanceRelease: (instance) => {}, // no-op
-
   wgpuInstanceCreateSurface__deps: ['$findCanvasEventTarget'],
   wgpuInstanceCreateSurface: (instanceId, descriptor) => {
     {{{ gpu.makeCheck('descriptor') }}}

--- a/system/lib/webgpu/webgpu.cpp
+++ b/system/lib/webgpu/webgpu.cpp
@@ -10,6 +10,8 @@
 
 #include <webgpu/webgpu.h>
 
+#include <cassert>
+
 //
 // Declarations for JS emwgpu functions (defined in library_webgpu.js)
 //
@@ -39,6 +41,18 @@ void emwgpuDestroy(void* id);
 // WebGPU function definitions, with methods organized by "class". Note these
 // don't need to be extern "C" because they are already declared in webgpu.h.
 //
+
+// Standalone (non-method) functions
+
+WGPUInstance wgpuCreateInstance(const WGPUInstanceDescriptor* descriptor) {
+  assert(descriptor == nullptr); // descriptor not implemented yet
+  return reinterpret_cast<WGPUInstance>(1);
+}
+
+// Instance
+
+void wgpuInstanceReference(WGPUInstance) { /* no-op for now */ }
+void wgpuInstanceRelease(WGPUInstance) { /* no-op for now */ }
 
 // Surface
 

--- a/system/lib/webgpu/webgpu.cpp
+++ b/system/lib/webgpu/webgpu.cpp
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2023 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * This file and library_webgpu.js together implement <webgpu/webgpu.h>.
+ */
+
+#include <webgpu/webgpu.h>
+
+//
+// Declarations for JS emwgpu functions (defined in library_webgpu.js)
+//
+
+extern "C" {
+
+void emwgpuAddRef(void* id);
+void emwgpuRelease(void* id);
+void emwgpuSetLabel(void* id, const char* label);
+void emwgpuDestroy(void* id);
+
+} // extern "C"
+
+//
+// Implementation helpers
+//
+
+#define DEFINE_ADDREF_RELEASE(Name) \
+  void wgpu##Name##Reference(WGPU##Name o) { emwgpuAddRef(o); } \
+  void wgpu##Name##Release(WGPU##Name o) { emwgpuRelease(o); }
+#define DEFINE_SETLABEL(Name) \
+  void wgpu##Name##SetLabel(WGPU##Name o, const char* label) { emwgpuSetLabel(o, label); }
+#define DEFINE_DESTROY(Name) \
+  void wgpu##Name##Destroy(WGPU##Name o) { emwgpuDestroy(o); }
+
+//
+// WebGPU function definitions, with methods organized by "class". Note these
+// don't need to be extern "C" because they are already declared in webgpu.h.
+//
+
+// Surface
+
+DEFINE_ADDREF_RELEASE(Surface)
+
+// SwapChain
+
+DEFINE_ADDREF_RELEASE(SwapChain)
+
+// Adapter
+
+DEFINE_ADDREF_RELEASE(Adapter)
+
+// Device
+
+DEFINE_ADDREF_RELEASE(Device)
+DEFINE_SETLABEL(Device)
+DEFINE_DESTROY(Device)
+
+// Queue
+
+DEFINE_ADDREF_RELEASE(Queue)
+DEFINE_SETLABEL(Queue)
+
+// CommandBuffer
+
+DEFINE_ADDREF_RELEASE(CommandBuffer)
+DEFINE_SETLABEL(CommandBuffer)
+
+// CommandEncoder
+
+DEFINE_ADDREF_RELEASE(CommandEncoder)
+DEFINE_SETLABEL(CommandEncoder)
+
+// RenderPassEncoder
+
+DEFINE_ADDREF_RELEASE(RenderPassEncoder)
+DEFINE_SETLABEL(RenderPassEncoder)
+
+// ComputePassEncoder
+
+DEFINE_ADDREF_RELEASE(ComputePassEncoder)
+DEFINE_SETLABEL(ComputePassEncoder)
+
+// BindGroup
+
+DEFINE_ADDREF_RELEASE(BindGroup)
+DEFINE_SETLABEL(BindGroup)
+
+// Buffer
+
+DEFINE_ADDREF_RELEASE(Buffer)
+DEFINE_SETLABEL(Buffer)
+// wgpuBufferDestroy is implemented in library_webgpu.js.
+
+// Sampler
+
+DEFINE_ADDREF_RELEASE(Sampler)
+DEFINE_SETLABEL(Sampler)
+
+// Texture
+
+DEFINE_ADDREF_RELEASE(Texture)
+DEFINE_SETLABEL(Texture)
+DEFINE_DESTROY(Texture)
+
+// TextureView
+
+DEFINE_ADDREF_RELEASE(TextureView)
+DEFINE_SETLABEL(TextureView)
+
+// QuerySet
+
+DEFINE_ADDREF_RELEASE(QuerySet)
+DEFINE_SETLABEL(QuerySet)
+DEFINE_DESTROY(QuerySet)
+
+// BindGroupLayout
+
+DEFINE_ADDREF_RELEASE(BindGroupLayout)
+DEFINE_SETLABEL(BindGroupLayout)
+
+// PipelineLayout
+
+DEFINE_ADDREF_RELEASE(PipelineLayout)
+DEFINE_SETLABEL(PipelineLayout)
+
+// RenderPipeline
+
+DEFINE_ADDREF_RELEASE(RenderPipeline)
+DEFINE_SETLABEL(RenderPipeline)
+
+// ComputePipeline
+
+DEFINE_ADDREF_RELEASE(ComputePipeline)
+DEFINE_SETLABEL(ComputePipeline)
+
+// ShaderModule
+
+DEFINE_ADDREF_RELEASE(ShaderModule)
+DEFINE_SETLABEL(ShaderModule)
+
+// RenderBundleEncoder
+
+DEFINE_ADDREF_RELEASE(RenderBundleEncoder)
+DEFINE_SETLABEL(RenderBundleEncoder)
+
+// RenderBundle
+
+DEFINE_ADDREF_RELEASE(RenderBundle)
+DEFINE_SETLABEL(RenderBundle)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1835,6 +1835,14 @@ class libGL(MTLibrary):
     )
 
 
+class libwebgpu(MTLibrary):
+  name = 'libwebgpu'
+
+  cflags = ['-std=c++11']
+  src_dir = 'system/lib/webgpu'
+  src_files = ['webgpu.cpp']
+
+
 class libwebgpu_cpp(MTLibrary):
   name = 'libwebgpu_cpp'
 
@@ -2306,6 +2314,7 @@ def get_libs_to_link(args, forced, only_forced):
     add_library('libsockets')
 
   if settings.USE_WEBGPU:
+    add_library('libwebgpu')
     add_library('libwebgpu_cpp')
 
   if settings.WASM_WORKERS:


### PR DESCRIPTION
This WILL break any code that was depending on the `WebGPU.mgr*` implementation details. They should use `JsValStore.add`/`get` and `emscripten_webgpu_import_*`/`export_*` instead.

I'm planning to move more implementation code into webgpu.cpp over time. For example, if we move the refcounts there, then they can be accessed from multiple threads, but this is complicated to do.

There are modest code size improvements from this change, which at least validates my theories about how this change would pan out. Comparison by building this project with `-O3 -flto --closure=1`:
https://github.com/kainino0x/webgpu-cross-platform-demo

```
- Before:
  hello.js:   29241 bytes / 11416 gzipped
  hello.wasm: 19785 bytes /  9082 gzipped
  total:      49026 bytes / 20498 gzipped separately
- After:
  hello.js:   27862 bytes / 10931 gzipped
  hello.wasm: 19610 bytes /  8940 gzipped
  total:      47472 bytes / 19871 gzipped separately
```

The second commit message contains a code size analysis just for one single small change. Note `-flto` is critical, otherwise that change increases the binary size (as expected - inlining is a key part of my justification for this layering).