### PR TITLE
Drop support for EdgeHTML browser using `-sMIN_EDGE_VESRION`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 3.1.51 (in development)
 -----------------------
+- Support for explicitly targeting the legacy EdgeHTML browser (edge version
+  prior to the chromium-based edge) via `-sMIN_EDGE_VERSION` was removed.
+  Using `-sLEGACY_VM_SUPPORT` should still work if anyone still wanted to target
+  this or any other legacy browser.
 - Breaking change: Using the `*glGetProcAddress()` family of functions now
   requires passing a linker flag -sGL_ENABLE_GET_PROC_ADDRESS. This prevents
   ports of native GL renderers from later accidentally attempting to activate

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -175,7 +175,7 @@ var LibraryEmbind = {
   }),
   // All browsers that support WebAssembly also support configurable function name,
   // but we might be building for very old browsers via WASM2JS.
-#if MIN_CHROME_VERSION < 43 || MIN_EDGE_VERSION < 14 || MIN_SAFARI_VERSION < 100101 || MIN_FIREFOX_VERSION < 38
+#if MIN_CHROME_VERSION < 43 || MIN_SAFARI_VERSION < 100101 || MIN_FIREFOX_VERSION < 38
   // In that case, check if configurable function name is supported at init time
   // and, if not, replace with a fallback that returns function as-is as those browsers
   // don't support other methods either.

--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -297,7 +297,7 @@ var LibraryEmVal = {
     return id;
   },
 
-#if MIN_CHROME_VERSION < 49 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 42 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 100101
+#if MIN_CHROME_VERSION < 49 || MIN_FIREFOX_VERSION < 42 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 100101
   $reflectConstruct: null,
   $reflectConstruct__postset: `
     if (typeof Reflect !== 'undefined') {

--- a/src/library.js
+++ b/src/library.js
@@ -402,7 +402,7 @@ addToLibrary({
   // so we cannot override parts of it, and therefore cannot use libc_optz.
 #if (SHRINK_LEVEL < 2 || LINKABLE || process.env.EMCC_FORCE_STDLIBS) && !STANDALONE_WASM && !BULK_MEMORY
 
-#if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 100101
+#if MIN_CHROME_VERSION < 45 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 100101
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin lists browsers that support TypedArray.prototype.copyWithin, but it
   // has outdated information for Safari, saying it would not support it.
   // https://github.com/WebKit/webkit/commit/24a800eea4d82d6d595cdfec69d0f68e733b5c52#diff-c484911d8df319ba75fce0d8e7296333R1 suggests support was added on Aug 28, 2015.
@@ -3090,7 +3090,7 @@ addToLibrary({
   },
 
   $listenOnce: (object, event, func) => {
-#if MIN_CHROME_VERSION < 55 || MIN_EDGE_VERSION < 18 || MIN_FIREFOX_VERSION < 50 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
+#if MIN_CHROME_VERSION < 55 || MIN_FIREFOX_VERSION < 50 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
     object.addEventListener(event, function handler() {
       func();
       object.removeEventListener(event, handler);

--- a/src/library_atomic.js
+++ b/src/library_atomic.js
@@ -7,14 +7,14 @@
 assert(SHARED_MEMORY);
 
 addToLibrary({
-// Chrome 87 (and hence Edge 87) shipped Atomics.waitAsync:
+// Chrome 87 shipped Atomics.waitAsync:
 //   https://www.chromestatus.com/feature/6243382101803008
 // However its implementation is faulty:
 //   https://bugs.chromium.org/p/chromium/issues/detail?id=1167541
 // Firefox Nightly 86.0a1 (2021-01-15) does not yet have it:
 //   https://bugzilla.mozilla.org/show_bug.cgi?id=1467846
 // And at the time of writing, no other browser has it either.
-#if MIN_EDGE_VERSION < 91 || MIN_CHROME_VERSION < 91 || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED || MIN_FIREFOX_VERSION != TARGET_NOT_SUPPORTED || ENVIRONMENT_MAY_BE_NODE
+#if MIN_CHROME_VERSION < 91 || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED || MIN_FIREFOX_VERSION != TARGET_NOT_SUPPORTED || ENVIRONMENT_MAY_BE_NODE
   // Partially polyfill Atomics.waitAsync() if not available in the browser.
   // Also polyfill for old Chrome-based browsers, where Atomics.waitAsync is
   // broken until Chrome 91, see:

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -32,7 +32,7 @@ var LibraryHTML5 = {
     // so that we can report information about that element in the event message.
     previousFullscreenElement: null,
 
-#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION <= 80000 || MIN_EDGE_VERSION <= 12 || MIN_CHROME_VERSION <= 21 // https://caniuse.com/#search=movementX
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION <= 80000 || MIN_CHROME_VERSION <= 21 // https://caniuse.com/#search=movementX
     // Remember the current mouse coordinates in case we need to emulate movementXY generation for browsers that don't support it.
     // Some browsers (e.g. Safari 6.0.5) only give movementXY when Pointerlock is active.
     previousScreenX: null,
@@ -469,7 +469,7 @@ var LibraryHTML5 = {
 #if MIN_CHROME_VERSION <= 36 // || MIN_ANDROID_BROWSER_VERSION <= 4.4.4
       || e["webkitMovementX"]
 #endif
-#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION <= 80000 || MIN_EDGE_VERSION <= 12 || MIN_CHROME_VERSION <= 21 // https://caniuse.com/#search=movementX
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION <= 80000 || MIN_CHROME_VERSION <= 21 // https://caniuse.com/#search=movementX
       || (e.screenX-JSEvents.previousScreenX)
 #endif
       ;
@@ -481,7 +481,7 @@ var LibraryHTML5 = {
 #if MIN_CHROME_VERSION <= 36 // || MIN_ANDROID_BROWSER_VERSION <= 4.4.4
       || e["webkitMovementY"]
 #endif
-#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION <= 80000 || MIN_EDGE_VERSION <= 12 || MIN_CHROME_VERSION <= 21 // https://caniuse.com/#search=movementX
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION <= 80000 || MIN_CHROME_VERSION <= 21 // https://caniuse.com/#search=movementX
       || (e.screenY-JSEvents.previousScreenY)
 #endif
       ;
@@ -500,7 +500,7 @@ var LibraryHTML5 = {
     HEAP32[idx + {{{ C_STRUCTS.EmscriptenMouseEvent.targetX / 4 }}}] = e.clientX - rect.left;
     HEAP32[idx + {{{ C_STRUCTS.EmscriptenMouseEvent.targetY / 4 }}}] = e.clientY - rect.top;
 
-#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION <= 80000 || MIN_EDGE_VERSION <= 12 || MIN_CHROME_VERSION <= 21 // https://caniuse.com/#search=movementX
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION <= 80000 || MIN_CHROME_VERSION <= 21 // https://caniuse.com/#search=movementX
 #if MIN_CHROME_VERSION <= 76
     // wheel and mousewheel events contain wrong screenX/screenY on chrome/opera <= 76,
     // so there we should not record previous screen coordinates on wheel events.
@@ -1284,10 +1284,10 @@ var LibraryHTML5 = {
 #if MIN_FIREFOX_VERSION <= 63 // https://caniuse.com/#feat=mdn-api_documentorshadowroot_fullscreenelement
         || document.mozFullScreenElement
 #endif
-#if MIN_EDGE_VERSION != TARGET_NOT_SUPPORTED || MIN_CHROME_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED // https://caniuse.com/#feat=mdn-api_documentorshadowroot_fullscreenelement
+#if MIN_CHROME_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED // https://caniuse.com/#feat=mdn-api_documentorshadowroot_fullscreenelement
         || document.webkitFullscreenElement
 #endif
-#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_EDGE_VERSION < 76
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED
         || document.msFullscreenElement
 #endif
         ;
@@ -1781,7 +1781,7 @@ var LibraryHTML5 = {
     } else if (target.webkitRequestPointerLock) {
       target.webkitRequestPointerLock();
 #endif
-#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_EDGE_VERSION < 76
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED
     } else if (target.msRequestPointerLock) {
       target.msRequestPointerLock();
 #endif
@@ -1795,7 +1795,7 @@ var LibraryHTML5 = {
 #if MIN_CHROME_VERSION <= 36 // https://caniuse.com/#feat=pointerlock
         || document.body.webkitRequestPointerLock
 #endif
-#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_EDGE_VERSION < 76
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED
         || document.body.msRequestPointerLock
 #endif
         ) {
@@ -1821,7 +1821,7 @@ var LibraryHTML5 = {
 #if MIN_CHROME_VERSION <= 36 // https://caniuse.com/#feat=pointerlock
       && !target.webkitRequestPointerLock
 #endif
-#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_EDGE_VERSION < 76
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED
       && !target.msRequestPointerLock
 #endif
       ) {
@@ -1854,7 +1854,7 @@ var LibraryHTML5 = {
 
     if (document.exitPointerLock) {
       document.exitPointerLock();
-#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_EDGE_VERSION < 76
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED
     } else if (document.msExitPointerLock) {
       document.msExitPointerLock();
 #endif

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -682,7 +682,7 @@ for (/**@suppress{duplicate}*/var i = 0; i < {{{ GL_POOL_TEMP_BUFFERS_SIZE }}}; 
 #endif
         (canvas.getContext("webgl", webGLContextAttributes)
           // https://caniuse.com/#feat=webgl
-#if MIN_IE_VERSION <= 10 || MIN_EDGE_VERSION <= 18 || MIN_FIREFOX_VERSION <= 23 || MIN_CHROME_VERSION <= 32 || MIN_SAFARI_VERSION <= 70101
+#if MIN_IE_VERSION <= 10 || MIN_FIREFOX_VERSION <= 23 || MIN_CHROME_VERSION <= 32 || MIN_SAFARI_VERSION <= 70101
           || canvas.getContext("experimental-webgl", webGLContextAttributes)
 #endif
           );

--- a/src/runtime_math.js
+++ b/src/runtime_math.js
@@ -5,7 +5,7 @@
  */
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul
-#if POLYFILL_OLD_MATH_FUNCTIONS || MIN_CHROME_VERSION < 28 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 20 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 90000 // || MIN_NODE_VERSION < 0.12
+#if POLYFILL_OLD_MATH_FUNCTIONS || MIN_CHROME_VERSION < 28 || MIN_FIREFOX_VERSION < 20 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 90000 // || MIN_NODE_VERSION < 0.12
 // || MIN_NODE_VERSION < 0.12
 // check for imul support, and also for correctness ( https://bugs.webkit.org/show_bug.cgi?id=126345 )
 if (!Math.imul || Math.imul(0xffffffff, 5) !== -5) Math.imul = (a, b) => {
@@ -18,7 +18,7 @@ if (!Math.imul || Math.imul(0xffffffff, 5) !== -5) Math.imul = (a, b) => {
 #endif
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/fround
-#if POLYFILL_OLD_MATH_FUNCTIONS || MIN_CHROME_VERSION < 38 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 26 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000 // || MIN_NODE_VERSION < 0.12
+#if POLYFILL_OLD_MATH_FUNCTIONS || MIN_CHROME_VERSION < 38 || MIN_FIREFOX_VERSION < 26 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000 // || MIN_NODE_VERSION < 0.12
 if (!Math.fround) {
   var froundBuffer = new Float32Array(1);
   Math.fround = (x) => { froundBuffer[0] = x; return froundBuffer[0] };
@@ -26,7 +26,7 @@ if (!Math.fround) {
 #endif
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32
-#if POLYFILL_OLD_MATH_FUNCTIONS || MIN_CHROME_VERSION < 38 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 31 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED // || MIN_NODE_VERSION < 0.12
+#if POLYFILL_OLD_MATH_FUNCTIONS || MIN_CHROME_VERSION < 38 || MIN_FIREFOX_VERSION < 31 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED // || MIN_NODE_VERSION < 0.12
 Math.clz32 ||= (x) => {
   var n = 32;
   var y = x >> 16; if (y) { n -= 16; x = y; }
@@ -39,7 +39,7 @@ Math.clz32 ||= (x) => {
 #endif
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc
-#if POLYFILL_OLD_MATH_FUNCTIONS || MIN_CHROME_VERSION < 38 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 25 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000 // || MIN_NODE_VERSION < 0.12
+#if POLYFILL_OLD_MATH_FUNCTIONS || MIN_CHROME_VERSION < 38 || MIN_FIREFOX_VERSION < 25 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000 // || MIN_NODE_VERSION < 0.12
 Math.trunc ||= (x) => {
   return x < 0 ? Math.ceil(x) : Math.floor(x);
 };

--- a/src/settings.js
+++ b/src/settings.js
@@ -1805,21 +1805,6 @@ var MIN_SAFARI_VERSION = 140100;
 // [link]
 var MIN_IE_VERSION = 0x7FFFFFFF;
 
-// Specifies the oldest version of Edge (EdgeHTML, the non-Chromium based
-// flavor) to target. E.g. pass -sMIN_EDGE_VERSION=40 to drop support for
-// EdgeHTML 39 and older.
-// EdgeHTML 44.17763 was released on November 13, 2018
-// EdgeHTML was completely in April 2021 and replaced by the current
-// Chromium-based Edge.
-// Since version 79, Edge version numbers have mirrored chromium version
-// numbers, so it no longer makes sense specify MIN_EDGE_VERSION independenly.
-// If Chromium and Edge ever start to diverage this setting may be revived with
-// more modern post-chromium default value.
-// See https://en.wikipedia.org/wiki/Microsoft_Edge#New_Edge_release_history
-// MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-// [link]
-var MIN_EDGE_VERSION = 0x7FFFFFFF;
-
 // Specifies the oldest version of Chrome. E.g. pass -sMIN_CHROME_VERSION=58 to
 // drop support for Chrome 57 and older.
 // Chrome 85 was released on 2020-08-25.
@@ -2179,4 +2164,5 @@ var LEGACY_SETTINGS = [
   ['USES_DYNAMIC_ALLOC', [1], 'No longer supported. Use -sMALLOC=none'],
   ['REVERSE_DEPS', ['auto', 'all', 'none'], 'No longer needed'],
   ['RUNTIME_LOGGING', 'RUNTIME_DEBUG'],
+  ['MIN_EDGE_VERSION', [0x7FFFFFFF], 'No longer supported'],
 ];

--- a/src/shell.js
+++ b/src/shell.js
@@ -44,7 +44,7 @@ var Module = typeof {{{ EXPORT_NAME }}} != 'undefined' ? {{{ EXPORT_NAME }}} : {
 #endif // USE_CLOSURE_COMPILER
 
 #if POLYFILL
-#if ((MAYBE_WASM2JS && WASM != 2) || MODULARIZE) && (MIN_CHROME_VERSION < 33 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 29 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000)
+#if ((MAYBE_WASM2JS && WASM != 2) || MODULARIZE) && (MIN_CHROME_VERSION < 33 || MIN_FIREFOX_VERSION < 29 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000)
 // Include a Promise polyfill for legacy browsers. This is needed either for
 // wasm2js, where we polyfill the wasm API which needs Promises, or when using
 // modularize which creates a Promise for when the module is ready.
@@ -52,7 +52,7 @@ var Module = typeof {{{ EXPORT_NAME }}} != 'undefined' ? {{{ EXPORT_NAME }}} : {
 #include "polyfill/promise.js"
 #endif
 
-#if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 90000
+#if MIN_CHROME_VERSION < 45 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 90000
 // See https://caniuse.com/mdn-javascript_builtins_object_assign
 #include "polyfill/objassign.js"
 #endif

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -149,7 +149,7 @@ function ready() {
 
 #if POLYFILL
 // See https://caniuse.com/mdn-javascript_builtins_object_assign
-#if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 90000
+#if MIN_CHROME_VERSION < 45 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 90000
 #include "polyfill/objassign.js"
 #endif
 #endif

--- a/test/minimal_webgl/CMakeLists.txt
+++ b/test/minimal_webgl/CMakeLists.txt
@@ -44,7 +44,6 @@ if (EMSCRIPTEN)
 	append_linker_flags("-sMIN_FIREFOX_VERSION=70")
 	append_linker_flags("-sMIN_SAFARI_VERSION=130000")
 	append_linker_flags("-sMIN_IE_VERSION=0x7FFFFFFF") # Do not support Internet Explorer at all (this is the Emscripten default, shown here for posterity)
-	append_linker_flags("-sMIN_EDGE_VERSION=79") # Require Chromium-based Edge browser
 	append_linker_flags("-sMIN_CHROME_VERSION=80")
 
 	# Fine tuning for code size: do not generate code to abort program execution on malloc() failures, that will

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2712,7 +2712,7 @@ Module["preRun"] = () => {
     'closure': (['-O2', '-g1', '--closure=1', '-sHTML5_SUPPORT_DEFERRING_USER_SENSITIVE_REQUESTS=0'],),
     'pthread': (['-pthread'],),
     'proxy_to_pthread': (['-pthread', '-sPROXY_TO_PTHREAD'],),
-    'legacy': (['-sMIN_FIREFOX_VERSION=0', '-sMIN_SAFARI_VERSION=0', '-sMIN_IE_VERSION=0', '-sMIN_EDGE_VERSION=0', '-sMIN_CHROME_VERSION=0', '-Wno-transpile'],)
+    'legacy': (['-sMIN_FIREFOX_VERSION=0', '-sMIN_SAFARI_VERSION=0', '-sMIN_IE_VERSION=0', '-sMIN_CHROME_VERSION=0', '-Wno-transpile'],)
   })
   @requires_threads
   def test_html5_core(self, opts):

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -84,11 +84,6 @@ def caniuse(feature):
   if settings.MIN_CHROME_VERSION < min_versions['chrome']:
     report_missing('MIN_CHROME_VERSION')
     return False
-  # For edge we just use the same version requirements as chrome since,
-  # at least for modern versions of edge, they share version numbers.
-  if settings.MIN_EDGE_VERSION < min_versions['chrome']:
-    report_missing('MIN_EDGE_VERSION')
-    return False
   if settings.MIN_FIREFOX_VERSION < min_versions['firefox']:
     report_missing('MIN_FIREFOX_VERSION')
     return False

--- a/tools/link.py
+++ b/tools/link.py
@@ -1099,7 +1099,6 @@ def phase_linker_setup(options, state, newargs):
     settings.MIN_FIREFOX_VERSION = 0
     settings.MIN_SAFARI_VERSION = 0
     settings.MIN_IE_VERSION = 0
-    settings.MIN_EDGE_VERSION = 0
     settings.MIN_CHROME_VERSION = 0
     settings.MIN_NODE_VERSION = 0
 
@@ -1130,16 +1129,15 @@ def phase_linker_setup(options, state, newargs):
     # Emscripten requires certain ES6+ constructs by default in library code
     # - (various ES6 operators available in all browsers listed below)
     # - https://caniuse.com/mdn-javascript_operators_nullish_coalescing:
-    #                                          EDGE:80 FF:72 CHROME:80 SAFARI:13.1 NODE:14
+    #                                          FF:72 CHROME:80 SAFARI:13.1 NODE:14
     # - https://caniuse.com/mdn-javascript_operators_optional_chaining:
-    #                                          EDGE:80 FF:74 CHROME:80 SAFARI:13.1 NODE:14
+    #                                          FF:74 CHROME:80 SAFARI:13.1 NODE:14
     # - https://caniuse.com/mdn-javascript_operators_logical_or_assignment:
-    #                                          EDGE:85 FF:79 CHROME:85 SAFARI:14 NODE:16
+    #                                          FF:79 CHROME:85 SAFARI:14 NODE:16
     # Taking the highest requirements gives is our minimum:
-    #                             Max Version: EDGE:85 FF:79 CHROME:85 SAFARI:14 NODE:16
+    #                             Max Version: FF:79 CHROME:85 SAFARI:14 NODE:16
     # TODO: replace this with feature matrix in the future.
-    settings.TRANSPILE_TO_ES5 = (settings.MIN_EDGE_VERSION < 85 or
-                                 settings.MIN_FIREFOX_VERSION < 79 or
+    settings.TRANSPILE_TO_ES5 = (settings.MIN_FIREFOX_VERSION < 79 or
                                  settings.MIN_CHROME_VERSION < 85 or
                                  settings.MIN_SAFARI_VERSION < 140000 or
                                  settings.MIN_NODE_VERSION < 160000 or
@@ -1148,9 +1146,8 @@ def phase_linker_setup(options, state, newargs):
     if options.use_closure_compiler is None and settings.TRANSPILE_TO_ES5:
       diagnostics.warning('transpile', 'enabling transpilation via closure due to browser version settings.  This warning can be suppressed by passing `--closure=1` or `--closure=0` to opt into this explicitly.')
 
-  # https://caniuse.com/class: EDGE:13 FF:45 CHROME:49 SAFARI:9
-  supports_es6_classes = (settings.MIN_EDGE_VERSION >= 13 and
-                          settings.MIN_FIREFOX_VERSION >= 45 and
+  # https://caniuse.com/class: FF:45 CHROME:49 SAFARI:9
+  supports_es6_classes = (settings.MIN_FIREFOX_VERSION >= 45 and
                           settings.MIN_CHROME_VERSION >= 49 and
                           settings.MIN_SAFARI_VERSION >= 90000 and
                           settings.MIN_IE_VERSION == 0x7FFFFFFF)


### PR DESCRIPTION
This browser was replaced with the chromium-based Edge back in 2018: https://blog.mozilla.org/en/mozilla/goodbye-edge/

According to https://www.statista.com/statistics/545520/market-share-of-internet-browsers-usa/ Edge Legacy accouts for just 0.05% of the browser market.