### PR TITLE
Use `os.execv` when we only running `clang` to compile. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -934,6 +934,15 @@ def get_clang_output_extension(state):
     return '.o'
 
 
+def exec_subprocess_and_exit(cmd):
+  if utils.WINDOWS:
+    shared.check_call(cmd)
+    sys.exit(0)
+  else:
+    shared.print_compiler_stage(cmd)
+    os.execv(cmd[0], cmd)
+
+
 @ToolchainProfiler.profile_block('compile inputs')
 def phase_compile_inputs(options, state, newargs, input_files):
   if shared.run_via_emxx:
@@ -982,8 +991,7 @@ def phase_compile_inputs(options, state, newargs, input_files):
     # output the dependency rule. Warning: clang and gcc behave differently
     # with -MF! (clang seems to not recognize it)
     logger.debug(('just preprocessor ' if state.has_dash_E else 'just dependencies: ') + ' '.join(cmd))
-    shared.check_call(cmd)
-    sys.exit(0)
+    exec_subprocess_and_exit(cmd)
 
   # Precompiled headers support
   if state.mode == Mode.PCH:
@@ -995,8 +1003,7 @@ def phase_compile_inputs(options, state, newargs, input_files):
     if options.output_file:
       cmd += ['-o', options.output_file]
     logger.debug(f"running (for precompiled headers): {cmd[0]} {' '.join(cmd[1:])}")
-    shared.check_call(cmd)
-    sys.exit(0)
+    exec_subprocess_and_exit(cmd)
 
   if state.mode == Mode.COMPILE_ONLY:
     inputs = [i[1] for i in input_files]
@@ -1009,13 +1016,19 @@ def phase_compile_inputs(options, state, newargs, input_files):
       if get_file_suffix(options.output_file) == '.bc' and not settings.LTO and '-emit-llvm' not in state.orig_args:
         diagnostics.warning('emcc', '.bc output file suffix used without -flto or -emit-llvm.  Consider using .o extension since emcc will output an object file, not a bitcode file')
     ext = get_clang_output_extension(state)
-    shared.check_call(cmd)
     if not options.output_file and options.default_object_extension != ext:
+      # If we are using a non-standard output file extention we cannot use
+      # exec_subprocess_and_exit here since we need to rename the files
+      # after clang runs (since clang does not support --default-obj-ext)
+      # TODO: Remove '--default-obj-ext' to reduce this complexity
+      shared.check_call(cmd)
       for i in inputs:
         output = unsuffixed_basename(i) + ext
         new_output = unsuffixed_basename(i) + options.default_object_extension
         shutil.move(output, new_output)
-    sys.exit(0)
+      sys.exit(0)
+    else:
+      exec_subprocess_and_exit(cmd)
 
   # In COMPILE_AND_LINK we need to compile source files too, but we also need to
   # filter out the link flags


### PR DESCRIPTION
This saves about 10ms of overhead on my linux machine which is about 10% of the overall overhead or emcc.py over base clang.

It will also save on memory since python no longer needs to be resident at the same time as clang.