### PR TITLE
Link from docs/process.md to "contributing" section of the webside

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -1,5 +1,8 @@
 # Development Processes
 
+More information can be found in the [Contribution
+section](https://emscripten.org/docs/contributing/contributing.html) of the
+webside.
 
 ## Landing PRs
 

--- a/site/source/docs/contributing/contributing.rst
+++ b/site/source/docs/contributing/contributing.rst
@@ -4,27 +4,35 @@
 Contributing
 ============
 
-Anyone can contribute to Emscripten — if you find it useful and want to help improve the project, follow the suggestions below.
+Anyone can contribute to Emscripten — if you find it useful and want to help
+improve the project, follow the suggestions below.
 
-Feel free to file :ref:`bug reports <bug-reports>`, :ref:`join the discussion <contact>` and share your own ideas with the community!
+Feel free to file :ref:`bug reports <bug-reports>`, :ref:`join the discussion
+<contact>` and share your own ideas with the community!
 
 
 Getting started
 ===============
 
-A good starting point is to work on the `open issues on GitHub <https://github.com/emscripten-core/emscripten/issues?state=open>`_. Many issues can be resolved without an in-depth knowledge of compiler internals, and this is a great way to learn more about the project.
+A good starting point is to work on the `open issues on GitHub
+<https://github.com/emscripten-core/emscripten/issues?state=open>`_. Many issues
+can be resolved without an in-depth knowledge of compiler internals, and this is
+a great way to learn more about the project.
 
-.. tip:: We really appreciate your help. Every existing issue closed means more time for the core contributors to work on new features, optimizations and other enhancements.
+.. tip:: We really appreciate your help. Every existing issue closed means more
+   time for the core contributors to work on new features, optimizations and
+   other enhancements.
 
-In addition to improving the toolchain, you can also :ref:`review and update this documentation <about-this-site-contributing>`.
+In addition to improving the toolchain, you can also :ref:`review and update
+this documentation <about-this-site-contributing>`.
 
 
 Next steps
 ==========
 
-As a new contributor you should read the :ref:`Developer's-Guide`. You may also need to :ref:`install Emscripten from source <installing-from-source>` and become familiar with :ref:`Debugging` and :ref:`Building-Projects`.
+As a new contributor you should read the :ref:`Developer's-Guide`. You may also
+need to :ref:`install Emscripten from source <installing-from-source>` and
+become familiar with :ref:`Debugging` and :ref:`Building-Projects`.
 
-Please :ref:`get in touch with the community <contact>` to share your ideas and work out where you can make the most difference.
-
-
-
+Please :ref:`get in touch with the community <contact>` to share your ideas and
+work out where you can make the most difference.

--- a/site/source/docs/contributing/developers_guide.rst
+++ b/site/source/docs/contributing/developers_guide.rst
@@ -8,7 +8,8 @@ This article provides information that is relevant to people who want to
 contribute to Emscripten. We welcome contributions from anyone that is
 interested in helping out!
 
-.. tip:: The information will be less relevant if you're just using Emscripten, but may still be of interest.
+.. tip:: The information will be less relevant if you're just using Emscripten,
+   but may still be of interest.
 
 .. _developers-guide-setting-up:
 


### PR DESCRIPTION
I guess we should consolidate these somehow.

Also format long lines in `contributing.rst`