### PR TITLE
Remove some magic handling of native shared libraries

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,17 @@ See docs/process.md for more on how version tagging works.
 - Support for explicitly targeting the legacy Interet Explorer or EdgeHTML
   (edge version prior to the chromium-based edge) browsers via
   `-sMIN_EDGE_VERSION/-sMIN_IE_VERSION` was removed. (#20881)
+- Emscripten is now more strict about handling unsupported shared library
+  inputs.  For example, under the old behaviour if a system shared library
+  such as `/usr/lib/libz.so` was passed to emscripten it would silently re-write
+  this to `-lz`, which would then search this a libz in its own sysroot.  Now
+  this file is passed though the linker like any other input file and you will
+  see an `unknown file type` error from the linker (just like you would with the
+  native clang or gcc toolchains). (#20886)
+- Support for explicitly targeting the legacy EdgeHTML browser (edge version
+  prior to the chromium-based edge) via `-sMIN_EDGE_VERSION` was removed.
+  Using `-sLEGACY_VM_SUPPORT` should still work if anyone still wanted to target
+  this or any other legacy browser.
 - Breaking change: Using the `*glGetProcAddress()` family of functions now
   requires passing a linker flag -sGL_ENABLE_GET_PROC_ADDRESS. This prevents
   ports of native GL renderers from later accidentally attempting to activate

--- a/emcc.py
+++ b/emcc.py
@@ -761,16 +761,7 @@ def phase_setup(options, state, newargs):
         else:
           message = arg + ': Unknown format, not a static library!'
         exit_with_error(message)
-      if file_suffix in DYNAMICLIB_ENDINGS and not building.is_bitcode(arg) and not building.is_wasm(arg):
-        # For shared libraries that are neither bitcode nor wasm, assuming its local native
-        # library and attempt to find a library by the same name in our own library path.
-        # TODO(sbc): Do we really need this feature?  See test_other.py:test_local_link
-        libname = removeprefix(get_library_basename(arg), 'lib')
-        flag = '-l' + libname
-        diagnostics.warning('map-unrecognized-libraries', f'unrecognized file type: `{arg}`.  Mapping to `{flag}` and hoping for the best')
-        state.add_link_flag(i, flag)
-      else:
-        input_files.append((i, arg))
+      input_files.append((i, arg))
     elif arg.startswith('-L'):
       state.add_link_flag(i, arg)
       newargs[i] = ''


### PR DESCRIPTION
We had this rather strange (I imagine completely unused) feature where is emscripten is passed a concrete path to a shared library file (e.g. /path/to/libfoo.so) and it could determine that the shared library was not indented for emscripten then it would instead search the library for other things called `libfoo` that might work.

This seems too magical at best and harmful/confusing a worst.

The presence of this feature is blocking the way for some internal optimizations and refactorings (e.g. #20884)

I tracked the addition of this feature back to 03033b2f in 2012. 