### PR TITLE
[test] Remove redundant setting in test_minimal_runtime_code_size. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10488,7 +10488,6 @@ int main () {
                                '-sGL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS=0',
                                '-sGL_SUPPORT_SIMPLE_ENABLE_EXTENSIONS=0',
                                '-sGL_TRACK_ERRORS=0',
-                               '-sGL_SUPPORT_EXPLICIT_SWAP_CONTROL=0',
                                '-sGL_POOL_TEMP_BUFFERS=0',
                                '-sGL_WORKAROUND_SAFARI_GETCONTEXT_BUG=0',
                                '-sNO_FILESYSTEM',


### PR DESCRIPTION
This setting already defaults to zero.  Removing it make fewer false positives show up when searching for uses of this settings.