### PR TITLE
Fix for STRICT_JS + pthreads

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -25,6 +25,7 @@ if (ENVIRONMENT_IS_NODE) {
   parentPort.on('message', (data) => onmessage({ data: data }));
 
   var fs = require('fs');
+  var vm = require('vm');
 
   Object.assign(global, {
     self: global,
@@ -34,7 +35,7 @@ if (ENVIRONMENT_IS_NODE) {
       href: __filename
     },
     Worker: nodeWorkerThreads.Worker,
-    importScripts: (f) => (0, eval)(fs.readFileSync(f, 'utf8') + '//# sourceURL=' + f),
+    importScripts: (f) => vm.runInThisContext(fs.readFileSync(f, 'utf8'), {filename: f}),
     postMessage: (msg) => parentPort.postMessage(msg),
     performance: global.performance || { now: Date.now },
   });

--- a/test/runner.py
+++ b/test/runner.py
@@ -58,6 +58,7 @@ passing_core_test_modes = [
   'corez',
   'core_2gb',
   'strict',
+  'strict_js',
   'wasm2js0',
   'wasm2js1',
   'wasm2js2',

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9339,6 +9339,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # test that the node environment can be specified by itself, and that still
     # works with pthreads (even though we did not specify 'node,worker')
     self.set_setting('ENVIRONMENT', 'node')
+    self.set_setting('STRICT_JS')
     self.do_run_in_out_file_test('core/pthread/create.cpp')
 
   @node_pthreads
@@ -10017,6 +10018,7 @@ bigint = make_run('bigint', emcc_args=['--profiling-funcs'], settings={'WASM_BIG
 
 # Add DEFAULT_TO_CXX=0
 strict = make_run('strict', emcc_args=[], settings={'STRICT': 1})
+strict_js = make_run('strict_js', emcc_args=[], settings={'STRICT_JS': 1})
 
 ubsan = make_run('ubsan', emcc_args=['-fsanitize=undefined', '--profiling'])
 lsan = make_run('lsan', emcc_args=['-fsanitize=leak', '--profiling'], settings={'ALLOW_MEMORY_GROWTH': 1})

--- a/test/unistd/access.c
+++ b/test/unistd/access.c
@@ -20,10 +20,10 @@ int main() {
     FS.mount(NODEFS, { root: '.' }, 'working');
 #endif
     FS.chdir('working');
-    FS.writeFile('forbidden', ""); FS.chmod('forbidden', 0000);
-    FS.writeFile('readable',  ""); FS.chmod('readable',  0444);
-    FS.writeFile('writeable', ""); FS.chmod('writeable', 0222);
-    FS.writeFile('allaccess', ""); FS.chmod('allaccess', 0777);
+    FS.writeFile('forbidden', ""); FS.chmod('forbidden', 0o000);
+    FS.writeFile('readable',  ""); FS.chmod('readable',  0o444);
+    FS.writeFile('writeable', ""); FS.chmod('writeable', 0o222);
+    FS.writeFile('allaccess', ""); FS.chmod('allaccess', 0o777);
     FS.writeFile('fchmodtest', "");
   );
 

--- a/test/unistd/truncate.c
+++ b/test/unistd/truncate.c
@@ -25,7 +25,7 @@ void setup() {
     FS.chdir('working');
     FS.writeFile('towrite', 'abcdef');
     FS.writeFile('toread', 'abcdef');
-    FS.chmod('toread', 0444);
+    FS.chmod('toread', 0o444);
   );
 #else
   FILE* f = fopen("towrite", "w");


### PR DESCRIPTION
Switch from using `eval` to `vm.runInThisContext` when emulating `importScripts` under node.  Using `eval` is generally no a good idea especially since its behaviour changes according the `use strict`.