### PR TITLE
Defer `linker input unused` and `no input files` warnings to clang. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11458,7 +11458,7 @@ Aborted(`Module.arguments` has been replaced by `arguments_` (the initial value 
 
   def test_linker_flags_unused(self):
     err = self.run_process([EMXX, test_file('hello_world.cpp'), '-c', '-lbar'], stderr=PIPE).stderr
-    self.assertContained("warning: argument unused during compilation: '-lbar' [-Wunused-command-line-argument]", err)
+    self.assertContained("warning: -lbar: 'linker' input unused [-Wunused-command-line-argument]", err)
 
   def test_linker_input_unused(self):
     self.run_process([EMXX, '-c', test_file('hello_world.cpp')])
@@ -14279,3 +14279,7 @@ addToLibrary({
 
   def test_errar(self):
     self.do_other_test('test_errar.c')
+
+  def test_no_input_files(self):
+    err = self.expect_fail([EMCC, '-c'])
+    self.assertContained('clang: error: no input files', err)

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -142,11 +142,13 @@ class sanity(RunnerCore):
   def check_working(self, command, expected=None):
     if type(command) is not list:
       command = [command]
+    if command == [EMCC]:
+      command = [EMCC, '--version']
     if expected is None:
       if command[0] == EMCC or (len(command) >= 2 and command[1] == EMCC):
-        expected = 'no input files'
+        expected = 'emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld)'
       else:
-        expected = "could not find the following tests: blahblah"
+        expected = 'could not find the following tests: blahblah'
 
     output = self.do(command)
     self.assertContained(expected, output)


### PR DESCRIPTION
Rather than removing any linker-only flags early on, we now allow those to be
passed onto clang so that:

(a) clang can take care of reporting warning about them so we don't have to
(b) we can exit early, paving the way for the use of `os.execv` when we run clang

Split out from #20884