### PR TITLE
[embind] Change GenericEnumValue's type to int

### DIFF
--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -300,7 +300,7 @@ sigs = {
   _embind_register_constant__sig: 'vppd',
   _embind_register_emval__sig: 'vpp',
   _embind_register_enum__sig: 'vpppi',
-  _embind_register_enum_value__sig: 'vppp',
+  _embind_register_enum_value__sig: 'vppi',
   _embind_register_float__sig: 'vppp',
   _embind_register_function__sig: 'vpippppi',
   _embind_register_integer__sig: 'vpppii',

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -37,7 +37,7 @@ enum class sharing_policy {
 
 namespace internal {
 
-typedef long GenericEnumValue;
+typedef int GenericEnumValue;
 
 typedef void* GenericFunction;
 typedef void (*VoidFunctionPtr)(void);

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14331,5 +14331,5 @@ addToLibrary({
       }
     '''
     expected = '-1\n0\n1\n'
-    self.do_run(src, assert_identical=True, expected_output=expected,
+    self.do_run(src, expected_output=expected,
                 emcc_args=['-lembind', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=4GB'])

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14311,9 +14311,9 @@ addToLibrary({
 
       int main() {
         EM_ASM(
-          console.log(Module.value.neg.value);
-          console.log(Module.value.zero.value);
-          console.log(Module.value.pos.value);
+        console.log(Module.value.neg.value);
+        console.log(Module.value.zero.value);
+        console.log(Module.value.pos.value);
         );
       }
 
@@ -14324,10 +14324,10 @@ addToLibrary({
       };
 
       EMSCRIPTEN_BINDINGS(utility) {
-          enum_<value>("value")
-              .value("neg", value::neg)
-              .value("zero", value::zero)
-              .value("pos", value::pos);
+        enum_<value>("value")
+          .value("neg", value::neg)
+          .value("zero", value::zero)
+          .value("pos", value::pos);
       }
     '''
     expected = '-1\n0\n1\n'

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14298,3 +14298,38 @@ addToLibrary({
   def test_no_input_files(self):
     err = self.expect_fail([EMCC, '-c'])
     self.assertContained('clang: error: no input files', err)
+
+  def test_negative_enum_values(self):
+    # Test if negative enum values are printed correctly and not overflown to
+    # large values when CAN_ADDRESS_2GB is true.
+    src =  r'''
+      #include <stdio.h>
+      #include <emscripten.h>
+      #include <emscripten/bind.h>
+
+      using namespace emscripten;
+
+      int main() {
+        EM_ASM(
+          console.log(Module.value.neg.value);
+          console.log(Module.value.zero.value);
+          console.log(Module.value.pos.value);
+        );
+      }
+
+      enum class value {
+        neg = -1,
+        zero = 0,
+        pos = 1,
+      };
+
+      EMSCRIPTEN_BINDINGS(utility) {
+          enum_<value>("value")
+              .value("neg", value::neg)
+              .value("zero", value::zero)
+              .value("pos", value::pos);
+      }
+    '''
+    expected = '-1\n0\n1\n'
+    self.do_run(src, assert_identical=True, expected_output=expected,
+                emcc_args=['-lembind', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=4GB'])

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14302,7 +14302,7 @@ addToLibrary({
   def test_embind_negative_enum_values(self):
     # Test if negative enum values are printed correctly and not overflown to
     # large values when CAN_ADDRESS_2GB is true.
-    src =  r'''
+    src = r'''
       #include <stdio.h>
       #include <emscripten.h>
       #include <emscripten/bind.h>

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14299,7 +14299,7 @@ addToLibrary({
     err = self.expect_fail([EMCC, '-c'])
     self.assertContained('clang: error: no input files', err)
 
-  def test_negative_enum_values(self):
+  def test_embind_negative_enum_values(self):
     # Test if negative enum values are printed correctly and not overflown to
     # large values when CAN_ADDRESS_2GB is true.
     src =  r'''


### PR DESCRIPTION
`long` is interpreted as a pointer and causes negative `enum class` values to be casted to unsigned and become large overflown values when `CAN_ADDRESS_2GB` is true:
https://github.com/emscripten-core/emscripten/blob/0a3b7539856df97370c2e42e174850883c735c9a/src/jsifier.js#L153