### PR TITLE
Flush stdout and stderr before calling os.execv

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -940,6 +940,8 @@ def exec_subprocess_and_exit(cmd):
     sys.exit(0)
   else:
     shared.print_compiler_stage(cmd)
+    sys.stdout.flush()
+    sys.stderr.flush()
     os.execv(cmd[0], cmd)
 
 


### PR DESCRIPTION
This seems to be needed on older versions of python but not on python3.11 on my machine.  It in recommended practice according to the python docs.