### PR TITLE
Clean the output of .bat files (#20913)

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/em++.bat
+++ b/em++.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/em-config.bat
+++ b/em-config.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/emar.bat
+++ b/emar.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/embuilder.bat
+++ b/embuilder.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/emcc.bat
+++ b/emcc.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/emcmake.bat
+++ b/emcmake.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/emconfigure.bat
+++ b/emconfigure.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/emdump.bat
+++ b/emdump.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (tools\emdump.bat) do (
   @if exist %%~$PATH:I (

--- a/emdwp.bat
+++ b/emdwp.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (tools\emdwp.bat) do (
   @if exist %%~$PATH:I (

--- a/emmake.bat
+++ b/emmake.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/emnm.bat
+++ b/emnm.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (tools\emnm.bat) do (
   @if exist %%~$PATH:I (

--- a/emprofile.bat
+++ b/emprofile.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (tools\emprofile.bat) do (
   @if exist %%~$PATH:I (

--- a/emranlib.bat
+++ b/emranlib.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/emrun.bat
+++ b/emrun.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/emscons.bat
+++ b/emscons.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/emsize.bat
+++ b/emsize.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/emstrip.bat
+++ b/emstrip.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/emsymbolizer.bat
+++ b/emsymbolizer.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/system/bin/sdl-config.bat
+++ b/system/bin/sdl-config.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/system/bin/sdl2-config.bat
+++ b/system/bin/sdl2-config.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/test/runner.bat
+++ b/test/runner.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/tools/file_packager.bat
+++ b/tools/file_packager.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/tools/maint/run_python.bat
+++ b/tools/maint/run_python.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/tools/maint/run_python_compiler.bat
+++ b/tools/maint/run_python_compiler.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (

--- a/tools/webidl_binder.bat
+++ b/tools/webidl_binder.bat
@@ -23,8 +23,8 @@
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
 @if exist %~f0 (
-  set MYDIR=%~dp0
-  goto FOUND_MYDIR
+  @set MYDIR=%~dp0
+  @goto FOUND_MYDIR
 )
 @for %%I in (%~n0.bat) do (
   @if exist %%~$PATH:I (


### PR DESCRIPTION
This prevents echoing out "set MYDIR=foo" and "goto FOUND_MYDIR" by prepending the lines with a "@".