### PR TITLE
Gamepad API fix, take two

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2066,39 +2066,34 @@ var LibraryHTML5 = {
     return JSEvents.registerOrRemoveHandler(eventHandler);
   },
 
-  $disableGamepadApiIfItThrows__docs: '/** @suppress {checkTypes} */',
-  $disableGamepadApiIfItThrows: () => {
-    try {
-      navigator.getGamepads();
-    } catch(e) {
-#if ASSERTIONS
-      err(`navigator.getGamepads() exists, but failed to execute with exception ${e}. Disabling Gamepad access.`);
-#endif
-      navigator.getGamepads = null; // Disable getGamepads() so that other functions will not attempt to use it.
-      return 1;
-    }
-  },
-
   emscripten_set_gamepadconnected_callback_on_thread__proxy: 'sync',
-  emscripten_set_gamepadconnected_callback_on_thread__deps: ['$registerGamepadEventCallback', '$disableGamepadApiIfItThrows'],
+  emscripten_set_gamepadconnected_callback_on_thread__deps: ['$registerGamepadEventCallback', 'emscripten_sample_gamepad_data'],
   emscripten_set_gamepadconnected_callback_on_thread: (userData, useCapture, callbackfunc, targetThread) => {
-    if (!navigator.getGamepads || disableGamepadApiIfItThrows()) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
+    if (_emscripten_sample_gamepad_data()) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     return registerGamepadEventCallback({{{ cDefs.EMSCRIPTEN_EVENT_TARGET_WINDOW }}}, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_GAMEPADCONNECTED }}}, "gamepadconnected", targetThread);
   },
 
   emscripten_set_gamepaddisconnected_callback_on_thread__proxy: 'sync',
-  emscripten_set_gamepaddisconnected_callback_on_thread__deps: ['$registerGamepadEventCallback', '$disableGamepadApiIfItThrows'],
+  emscripten_set_gamepaddisconnected_callback_on_thread__deps: ['$registerGamepadEventCallback', 'emscripten_sample_gamepad_data'],
   emscripten_set_gamepaddisconnected_callback_on_thread: (userData, useCapture, callbackfunc, targetThread) => {
-    if (!navigator.getGamepads || disableGamepadApiIfItThrows()) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
+    if (_emscripten_sample_gamepad_data()) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     return registerGamepadEventCallback({{{ cDefs.EMSCRIPTEN_EVENT_TARGET_WINDOW }}}, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_GAMEPADDISCONNECTED }}}, "gamepaddisconnected", targetThread);
   },
 
+  emscripten_sample_gamepad_data__docs: '/** @suppress {checkTypes} */', // We assign null to navigator.getGamepads, which Closure would like to complain about.
   emscripten_sample_gamepad_data__proxy: 'sync',
-  emscripten_sample_gamepad_data__deps: ['$JSEvents', '$disableGamepadApiIfItThrows'],
+  emscripten_sample_gamepad_data__deps: ['$JSEvents'],
   emscripten_sample_gamepad_data: () => {
-    if (!navigator.getGamepads || disableGamepadApiIfItThrows()) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
-    return (JSEvents.lastGamepadState = navigator.getGamepads())
-      ? {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}} : {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
+    try {
+      if (navigator.getGamepads) return (JSEvents.lastGamepadState = navigator.getGamepads())
+        ? {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}} : {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
+    } catch(e) {
+#if ASSERTIONS
+      err(`navigator.getGamepads() exists, but failed to execute with exception ${e}. Disabling Gamepad access.`);
+#endif
+      navigator.getGamepads = null; // Disable getGamepads() so that it won't be attempted to be used again.
+    }
+    return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
   },
 
   emscripten_get_num_gamepads__proxy: 'sync',


### PR DESCRIPTION
The previous PR that added exception guards to Gamepad API created a subtle possible bug that the Gamepad API would start to be sampled twice in emscripten_sample_gamepad_data() function. Revise the PR so that the function `emscripten_sample_gamepad_data()` only calls `navigator.getGamepads()` exactly once.
