### PR TITLE
Fix for chatty bat files when path contains spaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -828,6 +828,7 @@ jobs:
   # windows and mac do not have separate build and test jobs, as they only run
   # a limited set of tests; it is simpler and faster to do it all in one job.
   test-windows:
+    working_directory: "~/path with spaces"
     executor:
       name: win/vs2019
       shell: bash.exe -eo pipefail

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/em++.bat
+++ b/em++.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/em-config.bat
+++ b/em-config.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emar.bat
+++ b/emar.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/embuilder.bat
+++ b/embuilder.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emcc.bat
+++ b/emcc.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emcmake.bat
+++ b/emcmake.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emconfigure.bat
+++ b/emconfigure.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emdump.bat
+++ b/emdump.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emdwp.bat
+++ b/emdwp.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emmake.bat
+++ b/emmake.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emnm.bat
+++ b/emnm.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emprofile.bat
+++ b/emprofile.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emranlib.bat
+++ b/emranlib.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emrun.bat
+++ b/emrun.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emscons.bat
+++ b/emscons.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emsize.bat
+++ b/emsize.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emstrip.bat
+++ b/emstrip.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/emsymbolizer.bat
+++ b/emsymbolizer.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/system/bin/sdl-config.bat
+++ b/system/bin/sdl-config.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/system/bin/sdl2-config.bat
+++ b/system/bin/sdl2-config.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/test/runner.bat
+++ b/test/runner.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3269,6 +3269,7 @@ int f() {
     self.run_process([FILE_PACKAGER, 'test.data', '--js-output=test.js', '--depfile=test.data.d', '--from-emcc', '--preload', '.'])
     output = read_file('test.data.d')
     file_packager = utils.normalize_path(shared.replace_suffix(FILE_PACKAGER, '.py'))
+    file_packager = file_packager.replace(' ', '\\ ')
     lines = output.splitlines()
     split = lines.index(': \\')
     before, after = set(lines[:split]), set(lines[split + 1:])
@@ -14333,3 +14334,9 @@ addToLibrary({
     expected = '-1\n0\n1\n'
     self.do_run(src, expected_output=expected,
                 emcc_args=['-lembind', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=4GB'])
+
+  @crossplatform
+  def test_no_extra_output(self):
+    self.run_process([EMCC, '-c', test_file('hello_world.c')])
+    output = self.run_process([EMCC, '-c', test_file('hello_world.c')], stdout=PIPE, stderr=STDOUT).stdout
+    self.assertEqual(output, '')

--- a/tools/file_packager.bat
+++ b/tools/file_packager.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/tools/maint/run_python.bat
+++ b/tools/maint/run_python.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/tools/maint/run_python_compiler.bat
+++ b/tools/maint/run_python_compiler.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )

--- a/tools/webidl_binder.bat
+++ b/tools/webidl_binder.bat
@@ -22,7 +22,7 @@
 :: script is invoked via enclosing the invocation in quotes via PATH lookup, then %~f0 and
 :: %~dp0 expansions will not work.
 :: So first try if %~dp0 might work, and if not, manually look up this script from PATH.
-@if exist %~f0 (
+@if exist "%~f0" (
   set MYDIR=%~dp0
   goto FOUND_MYDIR
 )


### PR DESCRIPTION
I have no idea what causes this issue but unless we code the path passed to `@if exist` then the commands within are echoed.  This only happens when the path contains spaces, and only for the to commands within the `@if exist`.

The endless mystery of cmd.exe.

Fixes: #20913