### PR TITLE
Remove support for --default-obj-ext

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@ See docs/process.md for more on how version tagging works.
 
 3.1.51 (in development)
 -----------------------
+- The `--default-obj-ext` command line flag was removed. (#20917)
 - Support for explicitly targeting the legacy Interet Explorer or EdgeHTML
   (edge version prior to the chromium-based edge) browsers via
   `-sMIN_EDGE_VERSION/-sMIN_IE_VERSION` was removed. (#20881)

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -569,13 +569,6 @@ Options that are modified or new in *emcc* are listed below:
    the user's home directory ("~/.emscripten"). This can be overridden
    using the "EM_CONFIG" environment variable.
 
-"--default-obj-ext <.ext>"
-   [compile] Specifies the output suffix to use when compiling with
-   "-c" in the absence of "-o".  For example, when compiling multiple
-   sources files with "emcc -c *.c" the compiler will normally output
-   files with the ".o" extension, but "--default-obj-ext .obj" can be
-   used to instead generate files with the *.obj* extension.
-
 "--valid-abspath <path>"
    [compile+link] Note an allowed absolute path, which we should not
    warn about (absolute include paths normally are warned about, since

--- a/emcc.py
+++ b/emcc.py
@@ -27,7 +27,6 @@ import logging
 import os
 import re
 import shlex
-import shutil
 import sys
 import time
 import tarfile
@@ -78,7 +77,6 @@ EXTRA_INCOMING_JS_API = [
 
 SIMD_INTEL_FEATURE_TOWER = ['-msse', '-msse2', '-msse3', '-mssse3', '-msse4.1', '-msse4.2', '-msse4', '-mavx']
 SIMD_NEON_FLAGS = ['-mfpu=neon']
-COMPILE_ONLY_FLAGS = {'--default-obj-ext'}
 LINK_ONLY_FLAGS = {
     '--bind', '--closure', '--cpuprofiler', '--embed-file',
     '--emit-symbol-map', '--emrun', '--exclude-file', '--extern-post-js',
@@ -149,7 +147,6 @@ class EmccOptions:
     self.memory_init_file = None
     self.use_preload_cache = False
     self.use_preload_plugins = False
-    self.default_object_extension = '.o'
     self.valid_abspaths = []
     # Specifies the line ending format to use for all generated text files.
     # Defaults to using the native EOL on each platform (\r\n on Windows, \n on
@@ -811,23 +808,6 @@ def phase_setup(options, state, newargs):
         diagnostics.warning(
             'unused-command-line-argument',
             "linker flag ignored during compilation: '%s'" % arg)
-    if state.has_dash_c:
-      if '-emit-llvm' in newargs:
-        options.default_object_extension = '.bc'
-    elif state.has_dash_S:
-      if '-emit-llvm' in newargs:
-        options.default_object_extension = '.ll'
-      else:
-        options.default_object_extension = '.s'
-    elif '-M' in newargs or '-MM' in newargs:
-      options.default_object_extension = '.mout' # not bitcode, not js; but just dependency rule of the input file
-
-  else:
-    for arg in state.orig_args:
-      if any(arg.startswith(f) for f in COMPILE_ONLY_FLAGS):
-        diagnostics.warning(
-            'unused-command-line-argument',
-            "compiler flag ignored during linking: '%s'" % arg)
 
   if settings.MAIN_MODULE or settings.SIDE_MODULE:
     settings.RELOCATABLE = 1
@@ -1006,20 +986,7 @@ def phase_compile_inputs(options, state, newargs, input_files):
       cmd += ['-o', options.output_file]
       if get_file_suffix(options.output_file) == '.bc' and not settings.LTO and '-emit-llvm' not in state.orig_args:
         diagnostics.warning('emcc', '.bc output file suffix used without -flto or -emit-llvm.  Consider using .o extension since emcc will output an object file, not a bitcode file')
-    ext = get_clang_output_extension(state)
-    if not options.output_file and options.default_object_extension != ext:
-      # If we are using a non-standard output file extention we cannot use
-      # exec_process here since we need to rename the files
-      # after clang runs (since clang does not support --default-obj-ext)
-      # TODO: Remove '--default-obj-ext' to reduce this complexity
-      shared.check_call(cmd)
-      for i in inputs:
-        output = unsuffixed_basename(i) + ext
-        new_output = unsuffixed_basename(i) + options.default_object_extension
-        shutil.move(output, new_output)
-      sys.exit(0)
-    else:
-      shared.exec_process(cmd)
+    shared.exec_process(cmd)
 
   # In COMPILE_AND_LINK we need to compile source files too, but we also need to
   # filter out the link flags
@@ -1039,7 +1006,7 @@ def phase_compile_inputs(options, state, newargs, input_files):
     return unsuffixed(name) + '_' + seen_names[name] + shared.suffix(name)
 
   def get_object_filename(input_file):
-    return in_temp(unsuffixed(uniquename(input_file)) + options.default_object_extension)
+    return in_temp(shared.replace_suffix(uniquename(input_file), '.o'))
 
   def compile_source_file(i, input_file):
     logger.debug(f'compiling source file: {input_file}')
@@ -1384,9 +1351,7 @@ def parse_args(newargs):
     elif arg == '-fignore-exceptions':
       settings.DISABLE_EXCEPTION_CATCHING = 1
     elif check_arg('--default-obj-ext'):
-      options.default_object_extension = consume_arg()
-      if not options.default_object_extension.startswith('.'):
-        options.default_object_extension = '.' + options.default_object_extension
+      exit_with_error('--default-obj-ext is no longer supported by emcc')
     elif arg.startswith('-fsanitize=cfi'):
       exit_with_error('emscripten does not currently support -fsanitize=cfi')
     elif check_arg('--output_eol'):

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -528,14 +528,6 @@ Options that are modified or new in *emcc* are listed below:
   directory itself, and then in the user's home directory (``~/.emscripten``).
   This can be overridden using the ``EM_CONFIG`` environment variable.
 
-``--default-obj-ext <.ext>``
-  [compile]
-  Specifies the output suffix to use when compiling with ``-c`` in the absence
-  of ``-o``.  For example, when compiling multiple sources files with ``emcc -c
-  *.c`` the compiler will normally output files with the ``.o`` extension, but
-  ``--default-obj-ext .obj`` can be used to instead generate files with the
-  `.obj` extension.
-
 ``--valid-abspath <path>``
   [compile+link]
   Note an allowed absolute path, which we should not warn about (absolute

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -4188,13 +4188,6 @@ printErr('dir was ' + process.env.EMCC_BUILD_DIR);
     err = self.expect_fail([EMCC, '-c', test_file('hello_world.c'), '-o', 'out_dir/'])
     self.assertContained('error: unable to open output file', err)
 
-  def test_default_obj_ext(self):
-    self.run_process([EMCC, '-c', test_file('hello_world.c')])
-    self.assertExists('hello_world.o')
-
-    self.run_process([EMCC, '-c', test_file('hello_world.c'), '--default-obj-ext', 'obj'])
-    self.assertExists('hello_world.obj')
-
   def test_doublestart_bug(self):
     create_file('code.c', r'''
 #include <stdio.h>
@@ -12584,10 +12577,6 @@ kill -9 $$
   def test_link_only_flag_warning(self):
     err = self.run_process([EMCC, '--embed-file', 'file', '-c', test_file('hello_world.c')], stderr=PIPE).stderr
     self.assertContained("warning: linker flag ignored during compilation: '--embed-file' [-Wunused-command-line-argument]", err)
-
-  def test_compile_only_flag_warning(self):
-    err = self.run_process([EMCC, '--default-obj-ext', 'foo', test_file('hello_world.c')], stderr=PIPE).stderr
-    self.assertContained("warning: compiler flag ignored during linking: '--default-obj-ext' [-Wunused-command-line-argument]", err)
 
   def test_no_deprecated(self):
     # Test that -Wno-deprecated is passed on to clang driver


### PR DESCRIPTION
As far as I can tell the only user of this option was add mostly in support for custom cmake and visual studio integration that was removed in #20901.

This feature is something that neither clang nor gcc and I'd like to remove it so that we can move closer to being a pure clang wrapper.