### PR TITLE
Remove explicit support for JAVA and running closure compiler via java

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,12 @@ See docs/process.md for more on how version tagging works.
 
 3.1.52 (in development)
 -----------------------
+- Remove JAVA from the list of `.emscripten` config file settings.  In the
+  past we used this to run the java version of closure compiler.  If there are
+  folks who prefer to use the java version of closure compiler for some reason
+  it should be possible by adding `--platform=java` to `--closure-args` or
+  `EMCC_CLOSURE_ARGS` but emscripten will no longer do this automatically.
+  (#20919)
 - The WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG setting was
   removed.  This was a workaround from 2018 (#7459) that should no longer be
   needed. (#20925)

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -268,10 +268,6 @@ Options that are modified or new in *emcc* are listed below:
        before the closure-compiled code runs, because then it will
        reuse that variable.
 
-     * If closure compiler hits an out-of-memory, try adjusting
-       "JAVA_HEAP_SIZE" in the environment (for example, to 4096m for
-       4GB).
-
      * Closure is only run if JavaScript opts are being done ("-O2" or
        above).
 

--- a/site/source/docs/building_from_source/verify_emscripten_environment.rst
+++ b/site/source/docs/building_from_source/verify_emscripten_environment.rst
@@ -21,14 +21,15 @@ Open a terminal in the directory in which you installed Emscripten (on Windows o
 
 .. note:: On Windows, invoke the tool with **emcc** instead of **./emcc**.
 
-For example, the following output reports an installation where Java is missing:
+For example, the following output reports that the correct version of clang
+could not be found:
 
 .. code-block:: none
   :emphasize-lines: 3
 
   emcc (Emscripten GCC-like replacement + linker emulating GNU ld) 1.21.0
   shared:INFO: (Emscripten: Running sanity checks)
-  shared:WARNING: java does not seem to exist, required for closure compiler. -O2 and above will fail. You need to define JAVA in .emscripten
+  emcc: warning: LLVM version for clang executable "/usr/bin/clang" appears incorrect (seeing "16.0", expected "18") [-Wversion-check]
 
 At this point you need to :ref:`Install and activate <fixing-missing-components-emcc>` any missing components. When everything is set up properly, ``emcc ---check`` should give no warnings, and if you just enter ``emcc`` (without any input files), it will give an error ::
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -259,7 +259,6 @@ Options that are modified or new in *emcc* are listed below:
 
     - Consider using ``-sMODULARIZE`` when using closure, as it minifies globals to names that might conflict with others in the global scope. ``MODULARIZE`` puts all the output into a function (see ``src/settings.js``).
     - Closure will minify the name of `Module` itself, by default! Using ``MODULARIZE`` will solve that as well. Another solution is to make sure a global variable called `Module` already exists before the closure-compiled code runs, because then it will reuse that variable.
-    - If closure compiler hits an out-of-memory, try adjusting ``JAVA_HEAP_SIZE`` in the environment (for example, to 4096m for 4GB).
     - Closure is only run if JavaScript opts are being done (``-O2`` or above).
 
 ``--closure-args=<args>``

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12790,9 +12790,8 @@ void foo() {}
     self.run_process([EMCC, test_file('hello_world.c'), '--closure=1'])
     with env_modify({'EM_CLOSURE_COMPILER': sys.executable}):
       err = self.expect_fail([EMCC, test_file('hello_world.c'), '--closure=1'])
-    self.assertContained('closure compiler', err)
+    self.assertContained('emcc: error: unrecognized closure compiler --version output', err)
     self.assertContained(sys.executable, err)
-    self.assertContained('not execute properly!', err)
 
   def test_node_unhandled_rejection(self):
     create_file('pre.js', '''

--- a/tools/building.py
+++ b/tools/building.py
@@ -454,24 +454,18 @@ def get_closure_compiler():
   return cmd
 
 
-def check_closure_compiler(cmd, args, env, allowed_to_fail):
+def check_closure_compiler(cmd, args, env):
   cmd = cmd + args + ['--version']
   try:
     output = run_process(cmd, stdout=PIPE, env=env).stdout
   except Exception as e:
-    if allowed_to_fail:
-      return False
     if isinstance(e, subprocess.CalledProcessError):
       sys.stderr.write(e.stdout)
     sys.stderr.write(str(e) + '\n')
     exit_with_error('closure compiler (%s) did not execute properly!' % shared.shlex_join(cmd))
 
   if 'Version:' not in output:
-    if allowed_to_fail:
-      return False
     exit_with_error('unrecognized closure compiler --version output (%s):\n%s' % (shared.shlex_join(cmd), output))
-
-  return True
 
 
 # Remove this once we require python3.7 and can use std.isascii.
@@ -488,25 +482,7 @@ def isascii(s):
 def get_closure_compiler_and_env(user_args):
   env = shared.env_with_node_in_path()
   closure_cmd = get_closure_compiler()
-
-  native_closure_compiler_works = check_closure_compiler(closure_cmd, user_args, env, allowed_to_fail=True)
-  if not native_closure_compiler_works and not any(a.startswith('--platform') for a in user_args):
-    # Run with Java Closure compiler as a fallback if the native version does not work
-    user_args.append('--platform=java')
-    check_closure_compiler(closure_cmd, user_args, env, allowed_to_fail=False)
-
-  if config.JAVA and '--platform=java' in user_args:
-    # Closure compiler expects JAVA_HOME to be set *and* java.exe to be in the PATH in order
-    # to enable use the java backend.  Without this it will only try the native and JavaScript
-    # versions of the compiler.
-    java_bin = os.path.dirname(config.JAVA)
-    if java_bin:
-      def add_to_path(dirname):
-        env['PATH'] = env['PATH'] + os.pathsep + dirname
-      add_to_path(java_bin)
-      java_home = os.path.dirname(java_bin)
-      env.setdefault('JAVA_HOME', java_home)
-
+  check_closure_compiler(closure_cmd, user_args, env)
   return closure_cmd, env
 
 

--- a/tools/config.py
+++ b/tools/config.py
@@ -28,7 +28,6 @@ LLVM_ROOT = None
 LLVM_ADD_VERSION = None
 CLANG_ADD_VERSION = None
 CLOSURE_COMPILER = None
-JAVA = None
 JS_ENGINES: List[List[str]] = []
 WASMER = None
 WASMTIME = None
@@ -130,7 +129,6 @@ def parse_config_file():
     'LLVM_ADD_VERSION',
     'CLANG_ADD_VERSION',
     'CLOSURE_COMPILER',
-    'JAVA',
     'JS_ENGINES',
     'WASMER',
     'WASMTIME',

--- a/tools/config_template.py
+++ b/tools/config_template.py
@@ -19,8 +19,6 @@ BINARYEN_ROOT = '{{{ BINARYEN_ROOT }}}' # directory
 # This engine must exist, or nothing can be compiled.
 NODE_JS = '{{{ NODE }}}' # executable
 
-JAVA = 'java' # executable
-
 ################################################################################
 #
 # Test suite options:

--- a/tools/scons/site_scons/site_tools/emscripten/emscripten.py
+++ b/tools/scons/site_scons/site_tools/emscripten/emscripten.py
@@ -27,7 +27,7 @@ def generate(env, emscripten_path=None, **kw):
               'EMSCRIPTEN_SUPPRESS_USAGE_WARNING', 'NODE_PATH', 'EMCC_JSOPT_MIN_CHUNK_SIZE',
               'EMCC_JSOPT_MAX_CHUNK_SIZE', 'EMCC_CORES', 'EMCC_NO_OPT_SORT',
               'EMCC_BUILD_DIR', 'EMCC_DEBUG_SAVE', 'EMCC_SKIP_SANITY_CHECK',
-              'EM_PKG_CONFIG_PATH', 'EMCC_CLOSURE_ARGS', 'JAVA_HEAP_SIZE',
+              'EM_PKG_CONFIG_PATH', 'EMCC_CLOSURE_ARGS',
               'EMCC_FORCE_STDLIBS', 'EMCC_ONLY_FORCED_STDLIBS', 'EM_PORTS', 'IDL_CHECKS', 'IDL_VERBOSE']:
     if os.environ.get(var):
       env['ENV'][var] = os.environ.get(var)


### PR DESCRIPTION
It should still be possible for a user to explictly run the java version of closure using `EMCC_CLOSURE_ARGS=--platform=java` or `--closure-args=--platform=java`, but this isn't something we need to have explict support for and its not something we test.