### PR TITLE
Put in place some minimum browser versions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,12 @@ See docs/process.md for more on how version tagging works.
 - emcc will now treat `.bc` files as source files.  These means that will get
   compiled by clang before being passed to the linker.  This matches the
   behaviour of clang. (#20922)
+- Emscripten now only supports browsers going back to certain versions. The
+  current set of minimum versions are: Chrome 32, Firefox 34, Safari 9.
+  Attempting to targets version older this using, for example
+  `MIN_CHROME_VERSION` will now result in build-time error.  All of these
+  browser versions are at least 8 years old now so the hope is that nobody
+  is intending to target them today.  (#20924)
 
 3.1.51 - 12/13/23
 -----------------

--- a/src/settings.js
+++ b/src/settings.js
@@ -1774,6 +1774,7 @@ var AUTO_NATIVE_LIBRARIES = true;
 // for Firefox versions older than < majorVersion.
 // Firefox 79 was released on 2020-07-28.
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
+// Minimum supported value is 34 which was released on 2014-12-01.
 // [link]
 var MIN_FIREFOX_VERSION = 79;
 
@@ -1787,6 +1788,7 @@ var MIN_FIREFOX_VERSION = 79;
 // older, i.e. iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 and older,
 // see https://github.com/emscripten-core/emscripten/pull/7191.
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
+// Minimum supported value is 90000 which was released in 2015.
 // [link]
 var MIN_SAFARI_VERSION = 140100;
 
@@ -1794,13 +1796,15 @@ var MIN_SAFARI_VERSION = 140100;
 // drop support for Chrome 57 and older.
 // Chrome 85 was released on 2020-08-25.
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
+// Minimum supported value is 32, which was released on 2014-01-04.
 // [link]
 var MIN_CHROME_VERSION = 85;
 
 // Specifies minimum node version to target for the generated code.  This is
 // distinct from the minimum version required run the emscripten compiler.
 // This version aligns with the current Ubuuntu TLS 20.04 (Focal).
-// Version is encoded in MMmmVV, e.g. 1814101 denotes Node 18.14.01.
+// Version is encoded in MMmmVV, e.g. 181401 denotes Node 18.14.01.
+// Minimum supported value is 101900, which was released 2020-02-05.
 var MIN_NODE_VERSION = 160000;
 
 // Tracks whether we are building with errno support enabled. Set to 0

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13158,7 +13158,7 @@ myMethod: 43
     # to transpile.
     print('with old browser')
     self.emcc_args.remove('-Werror')
-    self.set_setting('MIN_CHROME_VERSION', '10')
+    self.set_setting('LEGACY_VM_SUPPORT')
     self.do_runf('test.c', expected, output_basename='test_old')
     check_for_es6('test_old.js', False)
 
@@ -14350,3 +14350,7 @@ addToLibrary({
     self.run_process([EMCC, '-c', test_file('hello_world.c')])
     output = self.run_process([EMCC, '-c', test_file('hello_world.c')], stdout=PIPE, stderr=STDOUT).stdout
     self.assertEqual(output, '')
+
+  def test_browser_too_old(self):
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sMIN_CHROME_VERSION=10'])
+    self.assertContained('emcc: error: MIN_CHROME_VERSION older than 32 is not supported', err)

--- a/tools/building.py
+++ b/tools/building.py
@@ -515,6 +515,7 @@ def transpile(filename):
   config_json = json.dumps(config, indent=2)
   outfile = shared.get_temp_files().get('babel.js').name
   config_file = shared.get_temp_files().get('babel_config.json').name
+  logger.debug(config_json)
   utils.write_file(config_file, config_json)
   cmd = shared.get_npm_cmd('babel') + [filename, '-o', outfile, '--presets', '@babel/preset-env', '--config-file', config_file]
   check_call(cmd, cwd=path_from_root())

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -15,6 +15,16 @@ logger = logging.getLogger('feature_matrix')
 
 UNSUPPORTED = 0x7FFFFFFF
 
+# Oldest support browser versions.  These have been set somewhat
+# arbitrarily for now.
+# TODO(sbc): Design a of policy for managing these values.
+OLDEST_SUPPORTED_CHROME = 32
+OLDEST_SUPPORTED_FIREFOX = 34
+OLDEST_SUPPORTED_SAFARI = 90000
+# 10.19.0 is the oldest version of node that we do any testing with.
+# Keep this in sync with the test-node-compat in .circleci/config.yml.
+OLDEST_SUPPORTED_NODE = 101900
+
 
 class Feature(IntEnum):
   NON_TRAPPING_FPTOINT = auto()


### PR DESCRIPTION
Having these minimums in place will allows us to remove support for         
older browsers from the codebase over time.  For example, as a followup  
to this change we should be able to remove out polyfills for Promise and 
for Object.assign.  

See #20601
