### PR TITLE
Fix echoing of commands run using `exec_process` on windows

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -715,6 +715,7 @@ f.close()
           out = self.run_js('a.out.js', engine=engine)
           self.assertContained('hello, world!', out)
 
+  @crossplatform
   def test_emcc_cflags(self):
     output = self.run_process([EMCC, '--cflags'], stdout=PIPE)
     flags = output.stdout.strip()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -241,11 +241,11 @@ def check_call(cmd, *args, **kw):
 
 
 def exec_process(cmd):
+  print_compiler_stage(cmd)
   if utils.WINDOWS:
     rtn = run_process(cmd, stdin=sys.stdin, check=False).returncode
     sys.exit(rtn)
   else:
-    print_compiler_stage(cmd)
     sys.stdout.flush()
     sys.stderr.flush()
     os.execv(cmd[0], cmd)


### PR DESCRIPTION
This should fix windows waterfall and the auto-rollers.  I'm not sure how this change manged to roll in to be honest.