### PR TITLE
--embind-emit-tsd requires a "=" to be placed before path

### DIFF
--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -406,7 +406,7 @@ Options that are modified or new in *emcc* are listed below:
    [link] Links against embind library.  Deprecated: Use "-lembind"
    instead.
 
-"--embind-emit-tsd <path>"
+"--embind-emit-tsd=<path>"
    [link] Generate a TypeScript definition file from the exported
    embind bindings. The program will be instrumented and run in node
    in order to to generate the file.


### PR DESCRIPTION
As I tested, without "=", the .d.ts won't be generated.