### PR TITLE
Mimic musl's upstream include path when building musl. NFC

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -876,6 +876,7 @@ class MuslInternalLibrary(Library):
   includes = [
     'system/lib/libc/musl/src/internal',
     'system/lib/libc/musl/src/include',
+    'system/lib/libc/musl/include',
     'system/lib/libc',
     'system/lib/pthread',
   ]


### PR DESCRIPTION
This is not fixing any known bug but does help with an internal issue we had at google when converting these libraries to bazel rules.