### PR TITLE
Include GL extension fliter/allowlist if and only if its needed

### DIFF
--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -6,7 +6,15 @@
 
 var LibraryGLEmulation = {
   // GL emulation: provides misc. functionality not present in OpenGL ES 2.0 or WebGL
-  $GLEmulation__deps: ['$GLImmediateSetup', 'glEnable', 'glDisable', 'glIsEnabled', 'glGetBooleanv', 'glGetIntegerv', 'glGetString', 'glCreateShader', 'glShaderSource', 'glCompileShader', 'glAttachShader', 'glDetachShader', 'glUseProgram', 'glDeleteProgram', 'glBindAttribLocation', 'glLinkProgram', 'glBindBuffer', 'glGetFloatv', 'glHint', 'glEnableVertexAttribArray', 'glDisableVertexAttribArray', 'glVertexAttribPointer', 'glActiveTexture', '$stringToNewUTF8', '$ptrToString'],
+  $GLEmulation__deps: ['$GLImmediateSetup', 'glEnable', 'glDisable',
+    'glIsEnabled', 'glGetBooleanv', 'glGetIntegerv', 'glGetString',
+    'glCreateShader', 'glShaderSource', 'glCompileShader', 'glAttachShader',
+    'glDetachShader', 'glUseProgram', 'glDeleteProgram', 'glBindAttribLocation',
+    'glLinkProgram', 'glBindBuffer', 'glGetFloatv', 'glHint',
+    'glEnableVertexAttribArray', 'glDisableVertexAttribArray',
+    'glVertexAttribPointer', 'glActiveTexture', '$stringToNewUTF8',
+    '$ptrToString', '$getEmscriptenSupportedExtensions',
+  ],
   $GLEmulation__postset:
 #if MAYBE_CLOSURE_COMPILER
     // Forward declare GL functions that are overridden by GLEmulation here to appease Closure compiler.
@@ -394,7 +402,7 @@ var LibraryGLEmulation = {
         if (GL.stringCache[name_]) return GL.stringCache[name_];
         switch (name_) {
           case 0x1F03 /* GL_EXTENSIONS */: // Add various extensions that we can support
-            var ret = stringToNewUTF8((GLctx.getSupportedExtensions() || []).join(' ') +
+            var ret = stringToNewUTF8(getEmscriptenSupportedExtensions(GLctx).join(' ') +
                    ' GL_EXT_texture_env_combine GL_ARB_texture_env_crossbar GL_ATI_texture_env_combine3 GL_NV_texture_env_combine4 GL_EXT_texture_env_dot3 GL_ARB_multitexture GL_ARB_vertex_buffer_object GL_EXT_framebuffer_object GL_ARB_vertex_program GL_ARB_fragment_program GL_ARB_shading_language_100 GL_ARB_shader_objects GL_ARB_vertex_shader GL_ARB_fragment_shader GL_ARB_texture_cube_map GL_EXT_draw_range_elements' +
                    (GL.currentContext.compressionExt ? ' GL_ARB_texture_compression GL_EXT_texture_compression_s3tc' : '') +
                    (GL.currentContext.anisotropicExt ? ' GL_EXT_texture_filter_anisotropic' : '')

--- a/src/library_glew.js
+++ b/src/library_glew.js
@@ -20,7 +20,7 @@
  */
 
 var LibraryGLEW = {
-  $GLEW__deps: ['glGetString', '$stringToNewUTF8', '$UTF8ToString'],
+  $GLEW__deps: ['glGetString', '$stringToNewUTF8', '$UTF8ToString', '$webglGetExtensions'],
   $GLEW: {
     isLinaroFork: 1,
     extensions: null,
@@ -99,7 +99,7 @@ var LibraryGLEW = {
     },
 
     extensionIsSupported(name) {
-      GLEW.extensions ||= GL.getExtensions();
+      GLEW.extensions ||= webglGetExtensions();
 
       if (GLEW.extensions.includes(name))
         return 1;

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1468,9 +1468,9 @@ var LibraryGLFW = {
     GLFW.initialTime = GLFW.getTime() - time;
   },
 
-  glfwExtensionSupported__deps: ['glGetString'],
+  glfwExtensionSupported__deps: ['glGetString', '$webglGetExtensions'],
   glfwExtensionSupported: (extension) => {
-    GLFW.extensions ||= GL.getExtensions();
+    GLFW.extensions ||= webglGetExtensions();
 
     if (GLFW.extensions.includes(extension)) return 1;
 

--- a/src/library_html5_webgl.js
+++ b/src/library_html5_webgl.js
@@ -440,6 +440,9 @@ var LibraryHtml5WebGL = {
 
   emscripten_webgl_get_supported_extensions__proxy: 'sync_on_current_webgl_context_thread',
   emscripten_webgl_get_supported_extensions__deps: ['$stringToNewUTF8'],
+  // Here we report the full list of extensions supported by WebGL rather than
+  // using getEmscriptenSupportedExtensions which filters the list based on
+  // what is has explicit support in.
   emscripten_webgl_get_supported_extensions: () =>
     stringToNewUTF8(GLctx.getSupportedExtensions().join(' ')),
 

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -5,7 +5,7 @@
  */
 
 var LibraryWebGL2 = {
-  glGetStringi__deps: ['$stringToNewUTF8'],
+  glGetStringi__deps: ['$webglGetExtensions', '$stringToNewUTF8'],
   glGetStringi: (name, index) => {
     if (GL.currentContext.version < 2) {
       GL.recordError(0x502 /* GL_INVALID_OPERATION */); // Calling GLES3/WebGL2 function with a GLES2/WebGL1 context
@@ -24,7 +24,7 @@ var LibraryWebGL2 = {
     }
     switch (name) {
       case 0x1F03 /* GL_EXTENSIONS */:
-        var exts = GL.getExtensions().map(stringToNewUTF8);
+        var exts = webglGetExtensions().map(stringToNewUTF8);
         stringiCache = GL.stringiCache[name] = exts;
         if (index < 0 || index >= stringiCache.length) {
           GL.recordError(0x501/*GL_INVALID_VALUE*/);


### PR DESCRIPTION
Here we use the JS library dependency mechanism to include this code only when its needed.

Sadly this will end up being present in almost all GL-using programs because most of them will
end up using `emscriptenWebGLGet` (e.g. any app that calls `glGetInteger`, `glGetString`, etc).
The code size impact of this change (for codebases that call glGetString but don't otherwise
call GetProcAddress is 858 bytes of JS or 356 compressed).

Fixes: #20798

