### PR TITLE
Handle use case when canvas size is already controlled by css

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1076,6 +1076,11 @@ var LibraryGLFW = {
       // not valid
       if (width <= 0 || height <= 0) return 0;
 
+      // check whether css is modifying the size
+      const canvas = Module['canvas'];
+      canvas.width = 1; canvas.height = 1;
+      GLFW.hasExternalSizing = canvas.clientWidth != 1 || canvas.clientHeight != 1;
+
       if (monitor) {
         Browser.requestFullscreen();
       } else {
@@ -1109,7 +1114,6 @@ var LibraryGLFW = {
       if (!Module.ctx && useWebGL) return 0;
 
       // Get non alive id
-      const canvas = Module['canvas'];
       var win = new GLFW_Window(id, canvas.clientWidth, canvas.clientHeight, canvas.width, canvas.height, title, monitor, share);
 
       // Set window to array
@@ -1142,7 +1146,12 @@ var LibraryGLFW = {
       for (var i = 0; i < GLFW.windows.length; i++)
         if (GLFW.windows[i] !== null) return;
 
-      Module.ctx = Browser.destroyContext(Module['canvas'], true, true);
+      const canvas = Module['canvas'];
+      if (!GLFW.hasExternalSizing) {
+        canvas.style.removeProperty( "width");
+        canvas.style.removeProperty("height");
+      }
+      Module.ctx = Browser.destroyContext(canvas, true, true);
     },
 
     swapBuffers: (winid) => {
@@ -1245,13 +1254,15 @@ var LibraryGLFW = {
       const hNativeScaled = Math.floor(hNative * scale);
       if (canvas.width  != wNativeScaled) canvas.width  = wNativeScaled;
       if (canvas.height != hNativeScaled) canvas.height = hNativeScaled;
-      if (typeof canvas.style != 'undefined') {
-        if (wNativeScaled != wNative || hNativeScaled != hNative) {
-          canvas.style.setProperty( "width", wNative + "px", "important");
-          canvas.style.setProperty("height", hNative + "px", "important");
-        } else {
-          canvas.style.removeProperty( "width");
-          canvas.style.removeProperty("height");
+      if (!GLFW.hasExternalSizing) {
+        if (typeof canvas.style != 'undefined') {
+          if (wNativeScaled != wNative || hNativeScaled != hNative) {
+            canvas.style.setProperty( "width", wNative + "px", "important");
+            canvas.style.setProperty("height", hNative + "px", "important");
+          } else {
+            canvas.style.removeProperty( "width");
+            canvas.style.removeProperty("height");
+          }
         }
       }
     },


### PR DESCRIPTION
When I was checking the SDL implementation I noticed that they were doing something like this:

```cpp
    emscripten_set_canvas_element_size(wdata->canvas_id, 1, 1);
    emscripten_get_element_css_size(wdata->canvas_id, &css_w, &css_h);
    wdata->external_size = SDL_floor(css_w) != 1 || SDL_floor(css_h) != 1;
```

Then they use this flag `wdata->external_size` to not rewrite the css property, for example:

```cpp
            if (!window_data->external_size && window_data->pixel_ratio != 1.0f) {
                emscripten_set_element_css_size(window_data->canvas_id, w, h);
            }
```

I changed the glfw code to use the same "trick" and implement a similar logic. This way there is no need to wrap the canvas in a `<div>` when the canvas needs to be full window (`width: 100% / height: 100%`)
