### PR TITLE
Use hello_world.c rather than hello_world.cpp for metadce test. NFC

### DIFF
--- a/test/other/metadce/hello_world.c
+++ b/test/other/metadce/hello_world.c
@@ -5,8 +5,6 @@
 
 #include <stdio.h>
 
-class Test {}; // This will fail in C mode
-
 int main() {
   printf("hello, world!\n");
   return 0;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8330,7 +8330,7 @@ int main() {
     'wasmfs': (['-O3', '-sWASMFS'],        [], []), # noqa
   })
   def test_metadce_hello(self, *args):
-    self.run_metadce_test('hello_world.cpp', *args)
+    self.run_metadce_test('hello_world.c', *args)
 
   @parameterized({
     'O3':                 ('mem.c', ['-O3'],


### PR DESCRIPTION
I think this file was originally copied from `test/hello_world.cpp` before we had the pure C version in place.