### PR TITLE
Avoiding exporting ready promise. NFC

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -935,7 +935,7 @@ function to64(x) {
 
 // Add assertions to catch common errors when using the Promise object we
 // create on Module.ready() and return from MODULARIZE Module() invocations.
-function addReadyPromiseAssertions(promise) {
+function addReadyPromiseAssertions() {
   // Warn on someone doing
   //
   //  var instance = Module();
@@ -948,8 +948,8 @@ function addReadyPromiseAssertions(promise) {
   const warningEnding = ' on the Promise object, instead of the instance. Use .then() to get called back with the instance, see the MODULARIZE docs in src/settings.js';
   const res = JSON.stringify(properties);
   return res + `.forEach((prop) => {
-  if (!Object.getOwnPropertyDescriptor(${promise}, prop)) {
-    Object.defineProperty(${promise}, prop, {
+  if (!Object.getOwnPropertyDescriptor(readyPromise, prop)) {
+    Object.defineProperty(readyPromise, prop, {
       get: () => abort('You are getting ' + prop + '${warningEnding}'),
       set: () => abort('You are setting ' + prop + '${warningEnding}'),
     });

--- a/src/shell.js
+++ b/src/shell.js
@@ -66,12 +66,12 @@ var Module = typeof {{{ EXPORT_NAME }}} != 'undefined' ? {{{ EXPORT_NAME }}} : {
 #if MODULARIZE
 // Set up the promise that indicates the Module is initialized
 var readyPromiseResolve, readyPromiseReject;
-Module['ready'] = new Promise((resolve, reject) => {
+var readyPromise = new Promise((resolve, reject) => {
   readyPromiseResolve = resolve;
   readyPromiseReject = reject;
 });
 #if ASSERTIONS
-{{{ addReadyPromiseAssertions("Module['ready']") }}}
+{{{ addReadyPromiseAssertions() }}}
 #endif
 #endif
 

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -36,12 +36,12 @@ var Module = {{{ EXPORT_NAME }}};
 #if MODULARIZE && EXPORT_READY_PROMISE
 // Set up the promise that indicates the Module is initialized
 var readyPromiseResolve, readyPromiseReject;
-Module['ready'] = new Promise((resolve, reject) => {
+var readyPromise = new Promise((resolve, reject) => {
   readyPromiseResolve = resolve;
   readyPromiseReject = reject;
 });
 #if ASSERTIONS
-{{{ addReadyPromiseAssertions("Module['ready']") }}}
+{{{ addReadyPromiseAssertions() }}}
 #endif
 #endif
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -2312,14 +2312,12 @@ def modularize():
      shared.target_environment_may_be('web'):
     async_emit = 'async '
 
-  # Return the incoming `moduleArg`.  This is is equeivielt to the `Module` var within the
-  # generated code but its not run through closure minifiection so we can reference it in
-  # the the return statement.
-  return_value = 'moduleArg'
   if settings.WASM_ASYNC_COMPILATION:
-    return_value += '.ready'
-  if not settings.EXPORT_READY_PROMISE:
-    return_value = '{}'
+    return_value = 'readyPromise'
+    if not settings.EXPORT_READY_PROMISE:
+      return_value = '{}'
+  else:
+    return_value = 'Module'
 
   # TODO: Remove when https://bugs.webkit.org/show_bug.cgi?id=223533 is resolved.
   if async_emit != '' and settings.EXPORT_NAME == 'config':


### PR DESCRIPTION
This promise is defined and used only in MODULARIZE mode and the promise itself is returned, so there is no need to export it on the Module object.