### PR TITLE
Make unused main warning suppressable

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1866,7 +1866,7 @@ int main() {
     # Sanitizers are not compatible with LINKABLE (dynamic linking.
     if not is_sanitizing(self.emcc_args) and not self.is_wasm64():
       # test EXPORT_ALL
-      self.set_setting('EXPORTED_FUNCTIONS', [])
+      self.clear_setting('EXPORTED_FUNCTIONS')
       self.set_setting('EXPORT_ALL')
       self.set_setting('LINKABLE')
       self.do_core_test('test_emscripten_api.cpp')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7924,10 +7924,10 @@ int main() {}
     test("Module['print']('print'); Module['printErr']('err'); ", 'print\nerr', ['-sEXPORTED_RUNTIME_METHODS=print,printErr', '-Wno-js-compiler'])
 
   def test_warn_unexported_main(self):
-    WARNING = 'main() is in the input files, but "_main" is not in EXPORTED_FUNCTIONS, which means it may be eliminated as dead code. Export it if you want main() to run.'
+    warning = 'emcc: warning: `main` is defined in the input files, but `_main` is not in `EXPORTED_FUNCTIONS`, which means it may be eliminated as dead code. Export it if you want `main` to run. [-Wunused-main]'
 
     proc = self.run_process([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS=[]'], stderr=PIPE)
-    self.assertContained(WARNING, proc.stderr)
+    self.assertContained(warning, proc.stderr)
 
   def test_source_file_with_fixed_language_mode(self):
     create_file('src_tmp_fixed_lang', '''

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -568,8 +568,8 @@ def finalize_wasm(infile, outfile, js_syms):
   unexpected_exports = [e for e in metadata.all_exports if treat_as_user_export(e)]
   unexpected_exports = [asmjs_mangle(e) for e in unexpected_exports]
   unexpected_exports = [e for e in unexpected_exports if e not in expected_exports]
-  if '_main' in unexpected_exports:
-    logger.warning('main() is in the input files, but "_main" is not in EXPORTED_FUNCTIONS, which means it may be eliminated as dead code. Export it if you want main() to run.')
+  if not settings.STANDALONE_WASM and '_main' in unexpected_exports:
+    diagnostics.warning('unused-main', '`main` is defined in the input files, but `_main` is not in `EXPORTED_FUNCTIONS`, which means it may be eliminated as dead code. Export it if you want `main` to run.')
     unexpected_exports.remove('_main')
 
   building.user_requested_exports.update(unexpected_exports)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -91,6 +91,7 @@ diagnostics.add_warning('em-js-i64')
 diagnostics.add_warning('js-compiler')
 diagnostics.add_warning('compatibility')
 diagnostics.add_warning('unsupported')
+diagnostics.add_warning('unused-main')
 # Closure warning are not (yet) enabled by default
 diagnostics.add_warning('closure', enabled=False)
 


### PR DESCRIPTION
Because this also means that `-Werror` turns this into an error I had to
also fix couple of places where we were generating this warning in our
test code.

Fixes: #20967