### PR TITLE
Revert "Handle use case when canvas size is already controlled by css"

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1076,13 +1076,6 @@ var LibraryGLFW = {
       // not valid
       if (width <= 0 || height <= 0) return 0;
 
-      // check whether css is modifying the size
-      const canvas = Module['canvas'];
-      const originalCanvasWidth = canvas.width;
-      const orginalCanvasHeight = canvas.height;
-      canvas.width = 1; canvas.height = 1;
-      GLFW.hasExternalSizing = canvas.clientWidth != 1 || canvas.clientHeight != 1;
-
       if (monitor) {
         Browser.requestFullscreen();
       } else {
@@ -1116,10 +1109,8 @@ var LibraryGLFW = {
       if (!Module.ctx && useWebGL) return 0;
 
       // Get non alive id
+      const canvas = Module['canvas'];
       var win = new GLFW_Window(id, canvas.clientWidth, canvas.clientHeight, canvas.width, canvas.height, title, monitor, share);
-
-      win.originalCanvasWidth = originalCanvasWidth;
-      win.orginalCanvasHeight = orginalCanvasHeight;
 
       // Set window to array
       if (id - 1 == GLFW.windows.length) {
@@ -1151,14 +1142,7 @@ var LibraryGLFW = {
       for (var i = 0; i < GLFW.windows.length; i++)
         if (GLFW.windows[i] !== null) return;
 
-      const canvas = Module['canvas'];
-      if (!GLFW.hasExternalSizing && typeof canvas.style != 'undefined') {
-        canvas.style.removeProperty('width');
-        canvas.style.removeProperty('height');
-      }
-      Module.ctx = Browser.destroyContext(canvas, true, true);
-      canvas.width = win.originalCanvasWidth;
-      canvas.height = win.orginalCanvasHeight;
+      Module.ctx = Browser.destroyContext(Module['canvas'], true, true);
     },
 
     swapBuffers: (winid) => {
@@ -1261,13 +1245,13 @@ var LibraryGLFW = {
       const hNativeScaled = Math.floor(hNative * scale);
       if (canvas.width  != wNativeScaled) canvas.width  = wNativeScaled;
       if (canvas.height != hNativeScaled) canvas.height = hNativeScaled;
-      if (!GLFW.hasExternalSizing && typeof canvas.style != 'undefined') {
+      if (typeof canvas.style != 'undefined') {
         if (wNativeScaled != wNative || hNativeScaled != hNative) {
-          canvas.style.setProperty( 'width', wNative + 'px', 'important');
-          canvas.style.setProperty('height', hNative + 'px', 'important');
+          canvas.style.setProperty( "width", wNative + "px", "important");
+          canvas.style.setProperty("height", hNative + "px", "important");
         } else {
-          canvas.style.removeProperty('width');
-          canvas.style.removeProperty('height');
+          canvas.style.removeProperty( "width");
+          canvas.style.removeProperty("height");
         }
       }
     },


### PR DESCRIPTION
@sbc100 Hi Sam. I am sure you know how these things are, but while sleeping I thought about a use case that I did not double check. So when I got up I checked it, and of course it fails. I profusely apologize for this oversight.

I am not too sure how to fix it yet and I don't want to rush to find a solution and introduce another issue. So I would like to revert the changes for the time being.

Again, I am truly sorry

Thanks

Reverts emscripten-core/emscripten#20956