### PR TITLE
embind: Fix tsgen when Wasm exceptions and assertions are enabled.

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3082,6 +3082,12 @@ int f() {
                      self.get_emcc_args())
     self.assertFileContents(test_file('other/embind_tsgen_memory64.d.ts'), read_file('embind_tsgen_memory64.d.ts'))
 
+  def test_embind_tsgen_exceptions(self):
+    # Check that when Wasm exceptions and assertions are enabled bindings still generate.
+    self.run_process([EMCC, test_file('other/embind_tsgen.cpp'),
+                      '-lembind', '--embind-emit-tsd', 'embind_tsgen.d.ts', '-fwasm-exceptions', '-sASSERTIONS'])
+    self.assertFileContents(test_file('other/embind_tsgen.d.ts'), read_file('embind_tsgen.d.ts'))
+
   def test_emconfig(self):
     output = self.run_process([emconfig, 'LLVM_ROOT'], stdout=PIPE).stdout.strip()
     self.assertEqual(output, config.LLVM_ROOT)

--- a/tools/link.py
+++ b/tools/link.py
@@ -1929,8 +1929,6 @@ def run_embind_gen(wasm_target, js_syms, extra_settings):
   setup_environment_settings()
   # Use a separate Wasm file so the JS does not need to be modified after emscripten.run.
   settings.SINGLE_FILE = False
-  # Disable support for wasm exceptions
-  settings.WASM_EXCEPTIONS = False
   # Embind may be included multiple times, de-duplicate the list first.
   settings.JS_LIBRARIES = dedup_list(settings.JS_LIBRARIES)
   # Replace embind with the TypeScript generation version.
@@ -1944,6 +1942,8 @@ def run_embind_gen(wasm_target, js_syms, extra_settings):
   node_args = []
   if settings.MEMORY64:
     node_args += shared.node_memory64_flags()
+  if settings.WASM_EXCEPTIONS:
+    node_args += shared.node_exception_flags()
   # Run the generated JS file with the proper flags to generate the TypeScript bindings.
   out = shared.run_js_tool(outfile_js, [], node_args, stdout=PIPE)
   settings.restore(original_settings)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -397,6 +397,10 @@ def node_memory64_flags():
   return ['--experimental-wasm-memory64']
 
 
+def node_exception_flags():
+  return ['--experimental-wasm-eh']
+
+
 def node_pthread_flags(nodejs):
   node_version = get_node_version(nodejs)
   # bulk memory and wasm threads were enabled by default in node v16.


### PR DESCRIPTION
When exceptions and assertions are enabled the Wasm binary needs several symbols that will not be defined if we disable WASM_EXCEPTIONS during TS generation. Instead of disabling, just enable exception handling when running node.

Fixes: #20949