### PR TITLE
Avoid a race condition in the output of other.test_pthread_lsan_no_leak

### DIFF
--- a/test/pthread/test_pthread_lsan_no_leak.cpp
+++ b/test/pthread/test_pthread_lsan_no_leak.cpp
@@ -13,7 +13,6 @@ void g(void) {
   void *stuff = malloc(3432);
   tls_ptr = malloc(1234);
   atomic_store(&thread_done, true);
-  printf("thread done\n");
   while (1);
 }
 

--- a/test/pthread/test_pthread_lsan_no_leak.out
+++ b/test/pthread/test_pthread_lsan_no_leak.out
@@ -1,3 +1,2 @@
 start
-thread done
 LSAN TEST COMPLETE


### PR DESCRIPTION
A race just happened here:

https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket/8759889468299571121/+/u/Emscripten_testsuite__other_/stdout

To avoid it, simply remove the logging from the pthread. There is really no
purpose to it in the test, and there is the chance it will show up before or
after LSan's output (which is the point of the test).