### PR TITLE
Remove stub for thrd_exit. NFC

### DIFF
--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -224,7 +224,6 @@ _Noreturn void __pthread_exit(void* status) {
 
 weak_alias(__pthread_exit, emscripten_builtin_pthread_exit);
 weak_alias(__pthread_exit, pthread_exit);
-weak_alias(__pthread_exit, thrd_exit);
 
 int __pthread_detach(pthread_t t) {
   return 0;


### PR DESCRIPTION
This stub is not needed since the default implementation simply calls through to pthread_exit, which itself is already stubbed.

This also fixes a signature mismatch warning under wasm64 since pthread_exit and thrd_exit don't have the same argument type.