### PR TITLE
Fix wgpuQueueWriteBuffer & wgpuQueueWriteTexture on Firefox with PTHREADS=1

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1544,7 +1544,7 @@ var LibraryWebGPU = {
     // There is a size limitation for ArrayBufferView. Work around by passing in a subarray
     // instead of the whole heap. crbug.com/1201109
 #if PTHREADS
-    var subarray = HEAPU8.splice(data, data + size);
+    var subarray = HEAPU8.slice(data, data + size);
 #else
     var subarray = HEAPU8.subarray(data, data + size);
 #endif
@@ -1561,7 +1561,7 @@ var LibraryWebGPU = {
     // This subarray isn't strictly necessary, but helps work around an issue
     // where Chromium makes a copy of the entire heap. crbug.com/1134457
 #if PTHREADS
-    var subarray = HEAPU8.splice(data, data + dataSize);
+    var subarray = HEAPU8.slice(data, data + dataSize);
 #else
     var subarray = HEAPU8.subarray(data, data + size);
 #endif

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1543,7 +1543,11 @@ var LibraryWebGPU = {
     var buffer = WebGPU.mgrBuffer.get(bufferId);
     // There is a size limitation for ArrayBufferView. Work around by passing in a subarray
     // instead of the whole heap. crbug.com/1201109
+#if PTHREADS
+    var subarray = HEAPU8.splice(data, data + size);
+#else
     var subarray = HEAPU8.subarray(data, data + size);
+#endif
     queue["writeBuffer"](buffer, bufferOffset, subarray, 0, size);
   },
 
@@ -1556,7 +1560,11 @@ var LibraryWebGPU = {
     var writeSize = WebGPU.makeExtent3D(writeSizePtr);
     // This subarray isn't strictly necessary, but helps work around an issue
     // where Chromium makes a copy of the entire heap. crbug.com/1134457
-    var subarray = HEAPU8.subarray(data, data + dataSize);
+#if PTHREADS
+    var subarray = HEAPU8.splice(data, data + dataSize);
+#else
+    var subarray = HEAPU8.subarray(data, data + size);
+#endif
     queue["writeTexture"](destination, subarray, dataLayout, writeSize);
   },
 


### PR DESCRIPTION
Resolves "Uncaught TypeError: GPUQueue.writeBuffer: ArrayBufferView branch of (ArrayBufferView or ArrayBuffer) can't be a SharedArrayBuffer or an ArrayBufferView backed by a SharedArrayBuffer" in Firefox Nightly with PTHREADS=1