### PR TITLE
Fix unexported `main` warning for main functions that take arguments

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7924,13 +7924,17 @@ int main() {}
     test("Module['print']('print'); Module['printErr']('err'); ", 'print\nerr', ['-sEXPORTED_RUNTIME_METHODS=print,printErr', '-Wno-js-compiler'])
 
   @parameterized({
+    '': ('hello_world.c',),
+    'argv': ('hello_world_argv.c',),
+  })
+  @parameterized({
     '': ([],),
     'O2': (['-O2'],),
   })
-  def test_warn_unexported_main(self, args):
+  def test_warn_unexported_main(self, args, filename):
     warning = 'emcc: warning: `main` is defined in the input files, but `_main` is not in `EXPORTED_FUNCTIONS`. Add it to this list if you want `main` to run. [-Wunused-main]'
 
-    proc = self.run_process([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS=[]'] + args, stderr=PIPE)
+    proc = self.run_process([EMCC, test_file(filename), '-sEXPORTED_FUNCTIONS=[]'] + args, stderr=PIPE)
     # This warning only shows up when ASSERTIONS are enabled.
     # We run both ways those to ensure that main doesn't get run in either case.
     if '-O2' in args:

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -577,7 +577,10 @@ def finalize_wasm(infile, outfile, js_syms):
   if not settings.STANDALONE_WASM and '_main' in unexpected_exports:
     diagnostics.warning('unused-main', '`main` is defined in the input files, but `_main` is not in `EXPORTED_FUNCTIONS`. Add it to this list if you want `main` to run.')
     unexpected_exports.remove('_main')
-    metadata.all_exports.remove('main')
+    if 'main' in metadata.all_exports:
+      metadata.all_exports.remove('main')
+    else:
+      metadata.all_exports.remove('__main_argc_argv')
 
   building.user_requested_exports.update(unexpected_exports)
   settings.EXPORTED_FUNCTIONS.extend(unexpected_exports)

--- a/tools/link.py
+++ b/tools/link.py
@@ -847,7 +847,7 @@ def phase_linker_setup(options, state, newargs):
     # See other.test_warn_unexported_main.
     # This is not needed in STANDALONE_WASM mode since we export _start
     # (unconditionally) rather than main.
-    settings.EXPORT_IF_DEFINED.append('main')
+    settings.EXPORT_IF_DEFINED += ['main', '__main_argc_argv']
 
   if settings.ASSERTIONS:
     # Exceptions are thrown with a stack trace by default when ASSERTIONS is


### PR DESCRIPTION
Prior to this change the warning would only show up for `main` functions with no arguments.