### PR TITLE
Use `-isystem` for port include paths

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 3.1.52 (in development)
 -----------------------
+- Include paths added by ports (e.g. `-sUSE_SDL=2`) now use `-isystem` rather
+  then `-I`.  This means that files in user-specified include directories will
+  now take precedence over port includes. (#21014)
 - Certain settings that only apply when generating JavaScript output will now
   trigger a warning if used when generating only Wasm.
 - Fix bug where `main` was mistakenly included in debug builds but not in

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -52,7 +52,7 @@ def clear(ports, settings, shared):
 
 
 def process_args(ports):
-  return ['-I' + ports.get_include_dir('bullet')]
+  return ['-isystem', ports.get_include_dir('bullet')]
 
 
 def show():

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -69,7 +69,7 @@ def process_dependencies(settings):
 def process_args(ports):
   args = []
   for include in make_includes(ports.get_include_dir('cocos2d')):
-    args.append('-I' + include)
+    args += ['-isystem', include]
   return args
 
 

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -112,7 +112,7 @@ def clear(ports, settings, shared):
 
 
 def process_args(ports):
-  return ['-I' + ports.get_include_dir('freetype2')]
+  return ['-isystem', ports.get_include_dir('freetype2')]
 
 
 def show():

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -148,7 +148,7 @@ def process_dependencies(settings):
 
 
 def process_args(ports):
-  return ['-I' + ports.get_include_dir('harfbuzz')]
+  return ['-isystem', ports.get_include_dir('harfbuzz')]
 
 
 def show():

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -87,7 +87,7 @@ def linker_setup(ports, settings):
 
 
 def process_args(ports):
-  return ['-I' + ports.get_include_dir('SDL2')]
+  return ['-isystem', ports.get_include_dir('SDL2')]
 
 
 def show():


### PR DESCRIPTION
This means that they will get searched after any user include paths.

Without this change, since the results of process_args are pre-pended to the compiler flags, it is not possible for the user to override these include paths with their own.