### PR TITLE
Always error on missing native symbols listed in EXPORTED_FUNCTIONS

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 3.1.52 (in development)
 -----------------------
+- Symbols that are explicitly exported using `EXPORTED_FUNCTIONS` will now always
+  generate a linker error if they are not found.  The
+  `ERROR_ON_UNDEFINED_SYMBOLS` flag does not affect these explicitly exported
+  symbols. (#21020)
 - Include paths added by ports (e.g. `-sUSE_SDL=2`) now use `-isystem` rather
   then `-I`.  This means that files in user-specified include directories will
   now take precedence over port includes. (#21014)

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1509,8 +1509,10 @@ implement everything, when you know what is not going to actually be called
 (and don't want to mess with the existing buildsystem), and functions might
 be implemented later on, say in --pre-js, so you may want to build with -s
 WARN_ON_UNDEFINED_SYMBOLS=0 to disable the warnings if they annoy you.  See
-also ERROR_ON_UNDEFINED_SYMBOLS.  Any undefined symbols that are listed in-
-EXPORTED_FUNCTIONS will also be reported.
+also ERROR_ON_UNDEFINED_SYMBOLS.
+
+Note: This does not effect symbols that are explictly exported (e.g. via
+EXPORTED_FUNCTIONS).
 
 .. _error_on_undefined_symbols:
 
@@ -1520,8 +1522,10 @@ ERROR_ON_UNDEFINED_SYMBOLS
 If set to 1, we will give a link-time error on any undefined symbols (see
 WARN_ON_UNDEFINED_SYMBOLS). To allow undefined symbols at link time set this
 to 0, in which case if an undefined function is called a runtime error will
-occur.  Any undefined symbols that are listed in EXPORTED_FUNCTIONS will also
-be reported.
+occur.
+
+Note: This does not effect symbols that are explictly exported (e.g. via
+EXPORTED_FUNCTIONS).
 
 .. _small_xhr_chunks:
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1183,16 +1183,20 @@ var STRICT_JS = false;
 // (and don't want to mess with the existing buildsystem), and functions might
 // be implemented later on, say in --pre-js, so you may want to build with -s
 // WARN_ON_UNDEFINED_SYMBOLS=0 to disable the warnings if they annoy you.  See
-// also ERROR_ON_UNDEFINED_SYMBOLS.  Any undefined symbols that are listed in-
-// EXPORTED_FUNCTIONS will also be reported.
+// also ERROR_ON_UNDEFINED_SYMBOLS.
+//
+// Note: This does not effect symbols that are explictly exported (e.g. via
+// EXPORTED_FUNCTIONS).
 // [link]
 var WARN_ON_UNDEFINED_SYMBOLS = true;
 
 // If set to 1, we will give a link-time error on any undefined symbols (see
 // WARN_ON_UNDEFINED_SYMBOLS). To allow undefined symbols at link time set this
 // to 0, in which case if an undefined function is called a runtime error will
-// occur.  Any undefined symbols that are listed in EXPORTED_FUNCTIONS will also
-// be reported.
+// occur.
+//
+// Note: This does not effect symbols that are explictly exported (e.g. via
+// EXPORTED_FUNCTIONS).
 // [link]
 var ERROR_ON_UNDEFINED_SYMBOLS = true;
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2389,10 +2389,6 @@ int f() {
     err = self.expect_fail(cmd)
     self.assertContained('undefined exported symbol: "foobar"', err)
 
-    # setting `-Wno-undefined` should suppress error
-    cmd += ['-Wno-undefined']
-    self.run_process(cmd)
-
   @parameterized({
     'warn': ('WARN',),
     'error': ('ERROR',),
@@ -7682,9 +7678,11 @@ high = 1234
     self.assertContained('error: undefined exported symbol: "foo"', err)
 
   def test_dash_s_hex(self):
-    self.run_process([EMCC, test_file('hello_world.c'), '-nostdlib', '-sERROR_ON_UNDEFINED_SYMBOLS=0'])
+    create_file('undefined.c', 'extern int foo(); int main() { return foo(); }')
+    self.expect_fail([EMCC, 'undefined.c'])
+    self.run_process([EMCC, 'undefined.c', '-sERROR_ON_UNDEFINED_SYMBOLS=0'])
     # Ensure that 0x0 is parsed as a zero and not as the string '0x0'.
-    self.run_process([EMCC, test_file('hello_world.c'), '-nostdlib', '-sERROR_ON_UNDEFINED_SYMBOLS=0x0'])
+    self.run_process([EMCC, 'undefined.c', '-sERROR_ON_UNDEFINED_SYMBOLS=0x0'])
 
   def test_zeroinit(self):
     create_file('src.c', r'''

--- a/tools/building.py
+++ b/tools/building.py
@@ -194,13 +194,15 @@ def lld_flags_for_executable(external_symbols):
   # Filter out symbols external/JS symbols
   c_exports = [e for e in c_exports if e not in external_symbols]
   c_exports += settings.REQUIRED_EXPORTS
-  if settings.MAIN_MODULE:
-    c_exports += side_module_external_deps(external_symbols)
   for export in c_exports:
-    if settings.ERROR_ON_UNDEFINED_SYMBOLS:
-      cmd.append('--export=' + export)
-    else:
-      cmd.append('--export-if-defined=' + export)
+    cmd.append('--export=' + export)
+
+  if settings.MAIN_MODULE:
+    for export in side_module_external_deps(external_symbols):
+      if settings.ERROR_ON_UNDEFINED_SYMBOLS:
+        cmd.append('--export=' + export)
+      else:
+        cmd.append('--export-if-defined=' + export)
 
   for e in settings.EXPORT_IF_DEFINED:
     cmd.append('--export-if-defined=' + e)

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -216,7 +216,7 @@ def report_missing_symbols(js_symbols):
   defined_symbols = set(asmjs_mangle(e) for e in settings.WASM_EXPORTS).union(js_symbols)
   missing = set(settings.USER_EXPORTED_FUNCTIONS) - defined_symbols
   for symbol in sorted(missing):
-    diagnostics.warning('undefined', f'undefined exported symbol: "{symbol}"')
+    exit_with_error(f'undefined exported symbol: "{symbol}"')
 
   # Special hanlding for the `_main` symbol
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -78,7 +78,6 @@ diagnostics.add_warning('legacy-settings', enabled=False, part_of_all=False)
 # Catch-all for other emcc warnings
 diagnostics.add_warning('linkflags')
 diagnostics.add_warning('emcc')
-diagnostics.add_warning('undefined', error=True)
 diagnostics.add_warning('deprecated', shared=True)
 diagnostics.add_warning('version-check')
 diagnostics.add_warning('export-main')


### PR DESCRIPTION
We already were reporting these are warnings in `report_missing_symbols` in `emscripten.py`, but this change means explicitly exported symbols are now always required at `wasm-ld` time.

This change is useful for #20970.