### PR TITLE
Fix for gh issue: 21031, use proper size for WGPUTextureFormat

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -912,7 +912,7 @@ var LibraryWebGPU = {
     var viewFormatCount = {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUTextureDescriptor.viewFormatCount) }}};
     if (viewFormatCount) {
       var viewFormatsPtr = {{{ makeGetValue('descriptor', C_STRUCTS.WGPUTextureDescriptor.viewFormats, '*') }}};
-      desc["viewFormats"] = Array.from({{{ makeHEAPView(`${POINTER_BITS}`, 'viewFormatsPtr', `viewFormatsPtr + viewFormatCount * ${POINTER_SIZE}`) }}},
+      desc["viewFormats"] = Array.from({{{ makeHEAPView(`32`, 'viewFormatsPtr', `viewFormatsPtr + viewFormatCount * 4`) }}},
         function(format) { return WebGPU.TextureFormat[format]; });
     }
 


### PR DESCRIPTION
Fix for https://github.com/emscripten-core/emscripten/issues/21031
- Use proper size for WGPUTextureFormat U64 -> U32