### PR TITLE
[Pthreads] Fix worker.js in ES6 module environments

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 3.1.52 (in development)
 -----------------------
+- Building with `pthreads+EXPORT_ES6` will now emit the worker file as
+  `NAME.worker.mjs` rather than `.js`. This is a necessary breaking change to
+  resolve other `pthreads+EXPORT_ES6` issues in Node.js (because Node.js is
+  affected by the suffix in some cases). (#21041)
 - Include paths added by ports (e.g. `-sUSE_SDL=2`) now use `-isystem` rather
   then `-I`.  This means that files in user-specified include directories will
   now take precedence over port includes. (#21014)

--- a/src/worker.js
+++ b/src/worker.js
@@ -18,8 +18,11 @@ var ENVIRONMENT_IS_NODE = typeof process == 'object' && typeof process.versions 
 if (ENVIRONMENT_IS_NODE) {
   // Create as web-worker-like an environment as we can.
 
-  // See the parallel code in shell.js.
-#if EXPORT_ES6 && ENVIRONMENT_MAY_BE_WEB
+  // See the parallel code in shell.js, but here we don't need the condition on
+  // multi-environment builds, as we do not have the need to interact with the
+  // modularization logic as shell.js must (see link.py:node_es6_imports and
+  // how that is used in link.py).
+#if EXPORT_ES6
   const { createRequire } = await import('module');
   /** @suppress{duplicate} */
   var require = createRequire(import.meta.url);

--- a/src/worker.js
+++ b/src/worker.js
@@ -40,7 +40,7 @@ if (ENVIRONMENT_IS_NODE) {
     Module,
     location: {
       // __filename is undefined in ES6 modules
-      href: typeof __filename !== 'undefined' ? __filename : undefined
+      href: typeof __filename !== 'undefined' ? __filename : import.meta.url
     },
     Worker: nodeWorkerThreads.Worker,
     importScripts: (f) => vm.runInThisContext(fs.readFileSync(f, 'utf8'), {filename: f}),

--- a/src/worker.js
+++ b/src/worker.js
@@ -18,6 +18,13 @@ var ENVIRONMENT_IS_NODE = typeof process == 'object' && typeof process.versions 
 if (ENVIRONMENT_IS_NODE) {
   // Create as web-worker-like an environment as we can.
 
+  // See the parallel code in shell.js.
+#if EXPORT_ES6 && ENVIRONMENT_MAY_BE_WEB
+  const { createRequire } = await import('module');
+  /** @suppress{duplicate} */
+  var require = createRequire(import.meta.url);
+#endif
+
   var nodeWorkerThreads = require('worker_threads');
 
   var parentPort = nodeWorkerThreads.parentPort;
@@ -32,7 +39,8 @@ if (ENVIRONMENT_IS_NODE) {
     require,
     Module,
     location: {
-      href: __filename
+      // __filename is undefined in ES6 modules
+      href: typeof __filename !== 'undefined' ? __filename : undefined
     },
     Worker: nodeWorkerThreads.Worker,
     importScripts: (f) => vm.runInThisContext(fs.readFileSync(f, 'utf8'), {filename: f}),

--- a/src/worker.js
+++ b/src/worker.js
@@ -39,8 +39,13 @@ if (ENVIRONMENT_IS_NODE) {
     require,
     Module,
     location: {
-      // __filename is undefined in ES6 modules
+      // __filename is undefined in ES6 modules, and import.meta.url only in ES6
+      // modules.
+#if EXPORT_ES6
       href: typeof __filename !== 'undefined' ? __filename : import.meta.url
+#else
+      href: typeof __filename
+#endif
     },
     Worker: nodeWorkerThreads.Worker,
     importScripts: (f) => vm.runInThisContext(fs.readFileSync(f, 'utf8'), {filename: f}),

--- a/src/worker.js
+++ b/src/worker.js
@@ -47,7 +47,7 @@ if (ENVIRONMENT_IS_NODE) {
 #if EXPORT_ES6
       href: typeof __filename !== 'undefined' ? __filename : import.meta.url
 #else
-      href: typeof __filename
+      href: __filename
 #endif
     },
     Worker: nodeWorkerThreads.Worker,

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -343,10 +343,10 @@ class other(RunnerCore):
                       test_file('hello_world.c')] + args)
     src = read_file('subdir/hello_world.mjs')
     self.assertContained("new URL('hello_world.wasm', import.meta.url)", src)
-    self.assertContained("new Worker(new URL('hello_world.worker.js', import.meta.url), {type: 'module'})", src)
+    self.assertContained("new Worker(new URL('hello_world.worker.mjs', import.meta.url), {type: 'module'})", src)
     self.assertContained("new Worker(pthreadMainJs, {type: 'module'})", src)
     self.assertContained('export default Module;', src)
-    src = read_file('subdir/hello_world.worker.js')
+    src = read_file('subdir/hello_world.worker.mjs')
     self.assertContained("import('./hello_world.mjs')", src)
     self.assertContained('hello, world!', self.run_js('subdir/hello_world.mjs'))
 
@@ -358,7 +358,7 @@ class other(RunnerCore):
                       test_file('hello_world.c'), '-sSINGLE_FILE'])
     src = read_file('hello_world.mjs')
     self.assertNotContained("new URL('data:", src)
-    self.assertContained("new Worker(new URL('hello_world.worker.js', import.meta.url), {type: 'module'})", src)
+    self.assertContained("new Worker(new URL('hello_world.worker.mjs', import.meta.url), {type: 'module'})", src)
     self.assertContained("new Worker(pthreadMainJs, {type: 'module'})", src)
     self.assertContained('hello, world!', self.run_js('hello_world.mjs'))
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -513,6 +513,10 @@ def do_split_module(wasm_file, options):
   building.run_binaryen_command('wasm-split', wasm_file + '.orig', outfile=wasm_file, args=args)
 
 
+def get_worker_js_suffix():
+  return '.worker.mjs' if settings.EXPORT_ES6 else '.worker.js'
+
+
 def setup_pthreads(target):
   if settings.RELOCATABLE:
     # phtreads + dyanmic linking has certain limitations
@@ -569,7 +573,7 @@ def setup_pthreads(target):
   building.user_requested_exports.update(worker_imports)
 
   # set location of worker.js
-  settings.PTHREAD_WORKER_FILE = unsuffixed_basename(target) + '.worker.js'
+  settings.PTHREAD_WORKER_FILE = unsuffixed_basename(target) + get_worker_js_suffix()
 
   if settings.MINIMAL_RUNTIME:
     building.user_requested_exports.add('exit')
@@ -2606,7 +2610,7 @@ def generate_worker_js(target, js_target, target_basename):
     proxy_worker_filename = get_subresource_location(js_target)
   else:
     # compiler output goes in .worker.js file
-    move_file(js_target, shared.replace_suffix(js_target, '.worker.js'))
+    move_file(js_target, shared.replace_suffix(js_target, get_worker_js_suffix()))
     worker_target_basename = target_basename + '.worker'
     proxy_worker_filename = (settings.PROXY_TO_WORKER_FILENAME or worker_target_basename) + '.js'
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -2011,6 +2011,7 @@ def fix_es6_import_statements(js_file):
              .replace('EMSCRIPTEN$IMPORT$META', 'import.meta')
              .replace('EMSCRIPTEN$AWAIT$IMPORT', 'await import'))
 
+
 def create_worker_file(input_file, target_dir, output_file):
   output_file = os.path.join(target_dir, output_file)
   input_file = utils.path_from_root(input_file)


### PR DESCRIPTION
This file can be an ES6 module if a `package.json` file indicates that all
files in the directory are.

We need to apply the same tricks as we apply to the main JS file in that
case, with `createRequire` etc.

Followup to #20939 and fixes the `package.json` discussion after that PR landed.