### PR TITLE
[webidl_binder] Add support for static methods

### DIFF
--- a/test/webidl/post.js
+++ b/test/webidl/post.js
@@ -81,7 +81,7 @@ try {
 } catch(e) {}
 console.log(succeeded);
 
-TheModule.Child2.prototype.printStatic(); // static calls go through the prototype
+TheModule.Child2.prototype.printStatic(42); // static calls go through the prototype
 
 // virtual function
 c2.virtualFunc();

--- a/test/webidl/test.h
+++ b/test/webidl/test.h
@@ -35,7 +35,7 @@ public:
   Child2() : Parent(9) { printf("Child2:%d\n", value); };
   virtual ~Child2() = default;
   int getValCube() { return value*value*value; }
-  static void printStatic() { printf("*static*\n"); }
+  static void printStatic(int arg0) { printf("*static*: %d\n", arg0); }
 
   virtual void virtualFunc() { printf("*virtualf*\n"); }
   virtual void virtualFunc2() { printf("*virtualf2*\n"); }

--- a/test/webidl/test.idl
+++ b/test/webidl/test.idl
@@ -25,7 +25,7 @@ Child1 implements Parent;
 interface Child2 {
   void Child2();
   long getValCube();
-  static void printStatic();
+  static void printStatic(long arg0);
   void virtualFunc();
   void virtualFunc2();
   void virtualFunc3(long x);

--- a/test/webidl/test_ALL.out
+++ b/test/webidl/test_ALL.out
@@ -41,7 +41,7 @@ Child2:9
 0
 0
 1
-*static*
+*static*: 42
 *virtualf*
 *virtualf*
 *virtualf2*

--- a/test/webidl/test_DEFAULT.out
+++ b/test/webidl/test_DEFAULT.out
@@ -41,7 +41,7 @@ Child2:9
 0
 0
 1
-*static*
+*static*: 42
 *virtualf*
 *virtualf*
 *virtualf2*

--- a/test/webidl/test_FAST.out
+++ b/test/webidl/test_FAST.out
@@ -41,7 +41,7 @@ Child2:9
 0
 0
 1
-*static*
+*static*: 42
 *virtualf*
 *virtualf*
 *virtualf2*


### PR DESCRIPTION
Previously we were just including a null/undefined self/this.  This removes that unused argument which is more correct and saves a little on code size too.