### PR TITLE
Avoid setErrno dependency in __syscall_fcntl64. NFC

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -758,7 +758,6 @@ var SyscallsLibrary = {
     FS.llseek(stream, idx * struct_size, {{{ cDefs.SEEK_SET }}});
     return pos;
   },
-  __syscall_fcntl64__deps: ['$setErrNo'],
   __syscall_fcntl64: (fd, cmd, varargs) => {
 #if SYSCALLS_REQUIRE_FILESYSTEM == 0
 #if SYSCALL_DEBUG
@@ -800,20 +799,16 @@ var SyscallsLibrary = {
       case {{{ cDefs.F_SETLK }}}:
       case {{{ cDefs.F_SETLKW }}}:
         return 0; // Pretend that the locking is successful.
+#if SYSCALL_DEBUG
       case {{{ cDefs.F_GETOWN_EX }}}:
       case {{{ cDefs.F_SETOWN }}}:
-        return -{{{ cDefs.EINVAL }}}; // These are for sockets. We don't have them fully implemented yet.
       case {{{ cDefs.F_GETOWN }}}:
-        // musl trusts getown return values, due to a bug where they must be, as they overlap with errors. just return -1 here, so fcntl() returns that, and we set errno ourselves.
-        setErrNo({{{ cDefs.EINVAL }}});
-        return -1;
-      default: {
-#if SYSCALL_DEBUG
+        return -{{{ cDefs.EINVAL }}};
+      default:
         dbg(`warning: fcntl unrecognized command ${cmd}`);
 #endif
-        return -{{{ cDefs.EINVAL }}};
-      }
     }
+    return -{{{ cDefs.EINVAL }}};
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },
 

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1525,16 +1525,6 @@ int __syscall_fcntl64(int fd, int cmd, ...) {
       // Always error for now, until we implement byte-range locks.
       return -EACCES;
     }
-    case F_GETOWN_EX:
-    case F_SETOWN:
-      // These are for sockets. We don't have them fully implemented yet.
-      return -EINVAL;
-    case F_GETOWN:
-      // Work around what seems to be a musl bug, where they do not set errno
-      // in the caller. This has been an issue since the JS filesystem and had
-      // the same workaround there.
-      errno = EINVAL;
-      return -1;
     default: {
       // TODO: support any remaining cmds
       return -EINVAL;


### PR DESCRIPTION
From the manpage for fcntl:

```
   F_GETOWN
       A  limitation of the Linux system call conventions on some architectures (notably
       i386) means that if a (negative) process group ID  to  be  returned  by  F_GETOWN
       falls  in  the range -1 to -4095, then the return value is wrongly interpreted by
       glibc as an error in the system call; that is, the return value of  fcntl()  will
       be  -1,  and  errno will contain the (positive) process group ID.  The Linux-spe‐
       cific F_GETOWN_EX operation avoids this problem.  Since glibc 2.11,  glibc  makes
       the kernel F_GETOWN problem invisible by implementing F_GETOWN using F_GETOWN_EX.
```