### PR TITLE
[EH] Don't write to readonly Exception.stack property

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -327,20 +327,6 @@ var LibraryExceptions = {
   __throw_exception_with_stack_trace: (ex) => {
     var e = new WebAssembly.Exception(getCppExceptionTag(), [ex], {traceStack: true});
     e.message = getExceptionMessage(e);
-    // The generated stack trace will be in the form of:
-    //
-    // Error
-    //     at ___throw_exception_with_stack_trace(test.js:1139:13)
-    //     at __cxa_throw (wasm://wasm/009a7c9a:wasm-function[1551]:0x24367)
-    //     ...
-    //
-    // Remove this JS function name, which is in the second line, from the stack
-    // trace. Note that .stack does not yet exist in all browsers (see #18828).
-    if (e.stack) {
-      var arr = e.stack.split('\n');
-      arr.splice(1,1);
-      e.stack = arr.join('\n');
-    }
     throw e;
   },
 #endif


### PR DESCRIPTION
Apparently `WebAssembly.Exception.stack` has been `readonly` all along and I wasn't aware. While I'm not sure if this should be `readonly` and this may change in the future, for now writing to this property is not spec compliant, so this removes the routine that tidies up the stack trace, which is not the end of the world.

Fixes #21044.