### PR TITLE
Avoid setErrNo in _time_js. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -437,7 +437,7 @@ addToLibrary({
   // ==========================================================================
 
   _mktime_js__i53abi: true,
-  _mktime_js__deps: ['$ydayFromDate', '$setErrNo'],
+  _mktime_js__deps: ['$ydayFromDate'],
   _mktime_js: (tmPtr) => {
     var date = new Date({{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_year, 'i32') }}} + 1900,
                         {{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_mon, 'i32') }}},
@@ -479,7 +479,6 @@ addToLibrary({
 
     var timeMs = date.getTime();
     if (isNaN(timeMs)) {
-      setErrNo({{{ cDefs.EOVERFLOW }}});
       return -1;
     }
     // Return time in microseconds

--- a/system/lib/libc/mktime.c
+++ b/system/lib/libc/mktime.c
@@ -4,6 +4,7 @@
  * University of Illinois/NCSA Open Source License.  Both these licenses can be
  * found in the LICENSE file.
  */
+#include <errno.h>
 #include <time.h>
 
 #include "emscripten_internal.h"
@@ -15,7 +16,11 @@ weak time_t timegm(struct tm *tm) {
 
 weak time_t mktime(struct tm *tm) {
   tzset();
-  return _mktime_js(tm);
+  time_t t = _mktime_js(tm);
+  if (t == -1) {
+    errno = EOVERFLOW;
+  }
+  return t;
 }
 
 weak struct tm *__localtime_r(const time_t *restrict t, struct tm *restrict tm) {


### PR DESCRIPTION
This avoids the export of __errno_location.