### PR TITLE
WebGPU: fix sentinel handling for depthSlice

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1610,7 +1610,7 @@ var LibraryWebGPU = {
         return undefined;
       }
 
-      var depthSlice = {{{ gpu.makeGetU32('caPtr', C_STRUCTS.WGPURenderPassColorAttachment.depthSlice) }}};
+      var depthSlice = {{{ makeGetValue('caPtr', C_STRUCTS.WGPURenderPassColorAttachment.depthSlice, 'i32') }}};
       {{{ gpu.convertSentinelToUndefined('depthSlice') }}}
 
       var loadOpInt = {{{ gpu.makeGetU32('caPtr', C_STRUCTS.WGPURenderPassColorAttachment.loadOp) }}};


### PR DESCRIPTION
depthSlice is actually u32, but like other fields with sentinel values we can just load it as i32 because values over 0x7FFFFFFF are going to be errors anyway.

This fixes `browser.test_webgpu_basic_rendering`.

I suggested the wrong code in https://github.com/emscripten-core/emscripten/pull/21057#issuecomment-1885650867 . My bad.

cc @beaufortfrancois 