### PR TITLE
WebGPU WASM64: Fix requiredFeatures, and test viewFormats

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -921,7 +921,8 @@ var LibraryWebGPU = {
     var viewFormatCount = {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUTextureDescriptor.viewFormatCount) }}};
     if (viewFormatCount) {
       var viewFormatsPtr = {{{ makeGetValue('descriptor', C_STRUCTS.WGPUTextureDescriptor.viewFormats, '*') }}};
-      desc["viewFormats"] = Array.from({{{ makeHEAPView(`32`, 'viewFormatsPtr', `viewFormatsPtr + viewFormatCount * 4`) }}},
+      // viewFormatsPtr pointer to an array of TextureFormat which is an enum of size uint32_t
+      desc["viewFormats"] = Array.from({{{ makeHEAPView('32', 'viewFormatsPtr', `viewFormatsPtr + viewFormatCount * 4`) }}},
         function(format) { return WebGPU.TextureFormat[format]; });
     }
 
@@ -2516,7 +2517,7 @@ var LibraryWebGPU = {
       var requiredFeaturesCount = {{{ gpu.makeGetU32('descriptor', C_STRUCTS.WGPUDeviceDescriptor.requiredFeaturesCount) }}};
       if (requiredFeaturesCount) {
         var requiredFeaturesPtr = {{{ makeGetValue('descriptor', C_STRUCTS.WGPUDeviceDescriptor.requiredFeatures, '*') }}};
-        desc["requiredFeatures"] = Array.from({{{ makeHEAPView(`${POINTER_BITS}`, 'requiredFeaturesPtr', `requiredFeaturesPtr + requiredFeaturesCount * ${POINTER_SIZE}`) }}},
+        desc["requiredFeatures"] = Array.from({{{ makeHEAPView('32', 'requiredFeaturesPtr', `requiredFeaturesPtr + requiredFeaturesCount * ${POINTER_SIZE}`) }}},
           (feature) => WebGPU.FeatureName[feature]);
       }
       var requiredLimitsPtr = {{{ makeGetValue('descriptor', C_STRUCTS.WGPUDeviceDescriptor.requiredLimits, '*') }}};

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -16,7 +16,7 @@
  *
  * To test this, run the following tests:
  * - test/runner.py other.test_webgpu_compiletest
- * - EMTEST_BROWSERS="/path/to/chrome --user-data-dir=chromeuserdata --enable-unsafe-webgpu" \
+ * - EMTEST_BROWSER="/path/to/chrome --user-data-dir=chromeuserdata --enable-unsafe-webgpu" \
  *   test/runner.py browser.test_webgpu_basic_rendering
  *   (requires WebGPU to be available - otherwise the test will skip itself and pass)
  */

--- a/test/webgpu_basic_rendering.cpp
+++ b/test/webgpu_basic_rendering.cpp
@@ -8,6 +8,7 @@
 #include <webgpu/webgpu_cpp.h>
 
 #undef NDEBUG
+#include <array>
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
@@ -309,6 +310,13 @@ void doRenderTest() {
         descriptor.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::CopySrc;
         descriptor.size = {1, 1, 1};
         descriptor.format = wgpu::TextureFormat::BGRA8Unorm;
+
+        // Test for viewFormats binding
+        std::array<wgpu::TextureFormat, 2> viewFormats =
+            { wgpu::TextureFormat::BGRA8Unorm, wgpu::TextureFormat::BGRA8Unorm };
+        descriptor.viewFormatCount = viewFormats.size();
+        descriptor.viewFormats = viewFormats.data();
+
         readbackTexture = device.CreateTexture(&descriptor);
     }
     wgpu::Texture depthTexture;


### PR DESCRIPTION
Followup to #21034. Confirmed `browser64.test_webgpu_basic_rendering` fails without that fix.

```
EMTEST_BROWSER='/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary --enable-experimental-webassembly-features' test/runner.py browser64.test_webgpu_basic_rendering
```