### PR TITLE
Re-enable running of closure compiler under java

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -919,10 +919,6 @@ jobs:
       - install-emsdk
       # TODO: We can't currently do pip install here since numpy and other packages
       # are currently missing arm64 macos binaries.
-      # TODO: Remove this once emsdk has an arm64 version of node
-      - run:
-          name: Install Rosetta
-          command: /usr/sbin/softwareupdate --install-rosetta --agree-to-license
       - run-tests:
           title: "crossplatform tests"
           test_targets: "--crossplatform-only"

--- a/tools/building.py
+++ b/tools/building.py
@@ -454,18 +454,24 @@ def get_closure_compiler():
   return cmd
 
 
-def check_closure_compiler(cmd, args, env):
+def check_closure_compiler(cmd, args, env, allowed_to_fail):
   cmd = cmd + args + ['--version']
   try:
     output = run_process(cmd, stdout=PIPE, env=env).stdout
   except Exception as e:
+    if allowed_to_fail:
+      return False
     if isinstance(e, subprocess.CalledProcessError):
       sys.stderr.write(e.stdout)
     sys.stderr.write(str(e) + '\n')
     exit_with_error('closure compiler (%s) did not execute properly!' % shared.shlex_join(cmd))
 
   if 'Version:' not in output:
+    if allowed_to_fail:
+      return False
     exit_with_error('unrecognized closure compiler --version output (%s):\n%s' % (shared.shlex_join(cmd), output))
+
+  return True
 
 
 # Remove this once we require python3.7 and can use std.isascii.
@@ -482,7 +488,15 @@ def isascii(s):
 def get_closure_compiler_and_env(user_args):
   env = shared.env_with_node_in_path()
   closure_cmd = get_closure_compiler()
-  check_closure_compiler(closure_cmd, user_args, env)
+
+  native_closure_compiler_works = check_closure_compiler(closure_cmd, user_args, env, allowed_to_fail=True)
+  if not native_closure_compiler_works and not any(a.startswith('--platform') for a in user_args):
+    # Run with Java Closure compiler as a fallback if the native version does not work.
+    # This can happen, for example, on arm64 macOS machines that do not have Rosetta installed.
+    logger.warn('falling back to java version of closure compiler')
+    user_args.append('--platform=java')
+    check_closure_compiler(closure_cmd, user_args, env, allowed_to_fail=False)
+
   return closure_cmd, env
 
 


### PR DESCRIPTION
This is a partial revert of #20919.

It turns out that we were still depending on falling back to the java
version of closure compiler in some cases.  Specifically, on macOS arm64
when Rosetta is not installed, we were falling back to the Java version
since google-closure-compiler doesn't ship arm64 binaries.  I imagine
the same will be true of linux-arm64.
