### PR TITLE
Run textwrap.dedent on text files created by the test runner

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -25,6 +25,7 @@ import string
 import subprocess
 import sys
 import tempfile
+import textwrap
 import time
 import webbrowser
 import unittest
@@ -505,6 +506,10 @@ def create_file(name, contents, binary=False, absolute=False):
   if binary:
     name.write_bytes(contents)
   else:
+    # Dedent the contents of text files so that the files on disc all
+    # start in column 1, even if they are indented when embedded in the
+    # python test code.
+    contents = textwrap.dedent(contents)
     name.write_text(contents, encoding='utf-8')
 
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1240,24 +1240,24 @@ f.close()
 
   def test_commons_link(self):
     create_file('a.h', r'''
-#if !defined(A_H)
-#define A_H
-extern int foo[8];
-#endif
-''')
+      #if !defined(A_H)
+      #define A_H
+      extern int foo[8];
+      #endif
+    ''')
     create_file('a.c', r'''
-#include "a.h"
-int foo[8];
-''')
+      #include "a.h"
+      int foo[8];
+    ''')
     create_file('main.c', r'''
-#include <stdio.h>
-#include "a.h"
+      #include <stdio.h>
+      #include "a.h"
 
-int main() {
-    printf("|%d|\n", foo[0]);
-    return 0;
-}
-''')
+      int main() {
+        printf("|%d|\n", foo[0]);
+        return 0;
+      }
+    ''')
 
     self.run_process([EMCC, '-o', 'a.o', '-c', 'a.c'])
     self.run_process([EMAR, 'rv', 'library.a', 'a.o'])


### PR DESCRIPTION
This means we can indent out test snippets in the python code and should never need to use column 1.

The files on disc that the test runner writes will have sane/normal indentation even if we use extra indentation in the python source to make things readable.

For example:

```
    create_file('a.c', '''
       int main()
         printf("hello\n");
       }
    ''')
```

Would generate a file on disc containing:

```
int main()
  printf("hello\n");
}
```