### PR TITLE
Allow property access in `EXPORT_NAME`

### DIFF
--- a/tools/js_manipulation.py
+++ b/tools/js_manipulation.py
@@ -103,7 +103,7 @@ def is_legal_sig(sig):
 
 def isidentifier(name):
   # https://stackoverflow.com/questions/43244604/check-that-a-string-is-a-valid-javascript-identifier-name-using-python-3
-  return name.replace('$', '_').isidentifier()
+  return all(ident.isidentifier() for ident in name.replace('$', '_').split('.'))
 
 
 def make_dynCall(sig, args):


### PR DESCRIPTION
`EXPORT_NAME` at some point changed to disallow names that included property access. This has caused issues. Namely, I discovered this problem in the repo for iPlug2: https://github.com/iPlug2/iPlug2/issues/804

Property access is valid javascript, and it's certainly desirable in some instances. iPlug2 specifically attempts to set EXPORT_NAME to something like this:

```
EXPORT_NAME="AudioWorkletGlobalScope.WAM.IPlugResponsiveUI"
```

to generate javascript assets that start something like this:

```javascript
AudioWorkletGlobalScope.WAM = AudioWorkletGlobalScope.WAM || {};
AudioWorkletGlobalScope.WAM.IPlugResponsiveUI = { ENVIRONMENT: "WEB" };
var Module =
  typeof AudioWorkletGlobalScope.WAM.IPlugResponsiveUI != "undefined"
    ? AudioWorkletGlobalScope.WAM.IPlugResponsiveUI
    : {};
var moduleOverrides = Object.assign({}, Module);
var arguments_ = [];
// ...
```

The failure introduced to `EXPORT_NAME` and inability to disable this warning has broken this functionality. Users of the iPlug2 sdk have resorted to [hacks using sed](https://github.com/webaudiomodules/webdx7/blob/3c6f9f360a8974c7c0900d9ae68502cbdb50c1d1/build/Makefile#L21-L22):

```makefile
$(TARGET): $(OBJECTS)
	$(CC) $(CFLAGS) $(LDFLAGS) $(JSFLAGS) -o $@ $(SRC)
	# emmake complains about `.` characters in the `EXPORT_NAME`, so we add them manually...
	sed -i 's/AudioWorkletGlobalScope_WAM_DX7/AudioWorkletGlobalScope\.WAM\.DX7/g' $(TARGET)
	node encode-wasm.js dx7.wasm
```

If it's imperative to disallow property access in `EXPORT_NAME` for some reason, I'd like to propose that this error have an off-switch for intrepid users. Otherwise, this PR allows `EXPORT_NAME` to be set to a value that includes property access.