### PR TITLE
Fix makeBlendState asserting for non-existent nextInChain

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1283,7 +1283,6 @@ var LibraryWebGPU = {
 
     function makeBlendState(bsPtr) {
       if (!bsPtr) return undefined;
-      {{{ gpu.makeCheckDescriptor('bsPtr') }}}
       return {
         "alpha": makeBlendComponent(bsPtr + {{{ C_STRUCTS.WGPUBlendState.alpha }}}),
         "color": makeBlendComponent(bsPtr + {{{ C_STRUCTS.WGPUBlendState.color }}}),


### PR DESCRIPTION
This started occurring for us with 3.1.52 - think it is because a few enums changed since the latest Dawn header roll where the first value became 1 instead of 0, so we just got lucky before.

@kainino0x let me know if this is wrong! P.S. Not sure how Emscripten approaches hotfixes, but could make sense to do a new release as otherwise WebGPU isn't functional by default in that release (with asserts on).