### PR TITLE
Remove code for automatically adding archive indexes

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1467,7 +1467,6 @@ Changes enabled by this:
   - IGNORE_MISSING_MAIN is disabled.
   - AUTO_JS_LIBRARIES is disabled.
   - AUTO_NATIVE_LIBRARIES is disabled.
-  - AUTO_ARCHIVE_INDEXES is disabled.
   - DEFAULT_TO_CXX is disabled.
   - USE_GLFW is set to 0 rather than 2 by default.
   - ALLOW_UNIMPLEMENTED_SYSCALLS is disabled.
@@ -1484,16 +1483,6 @@ Allow program to link with or without ``main`` symbol.
 If this is disabled then one must provide a ``main`` symbol or explicitly
 opt out by passing ``--no-entry`` or an EXPORTED_FUNCTIONS list that doesn't
 include ``_main``.
-
-.. _auto_archive_indexes:
-
-AUTO_ARCHIVE_INDEXES
-====================
-
-Automatically attempt to add archive indexes at link time to archives that
-don't already have them.  This can happen when GNU ar or GNU ranlib is used
-rather than ``llvm-ar`` or ``emar`` since the former don't understand the wasm
-object format.
 
 .. _strict_js:
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1153,7 +1153,6 @@ var LINKABLE = false;
 //   - IGNORE_MISSING_MAIN is disabled.
 //   - AUTO_JS_LIBRARIES is disabled.
 //   - AUTO_NATIVE_LIBRARIES is disabled.
-//   - AUTO_ARCHIVE_INDEXES is disabled.
 //   - DEFAULT_TO_CXX is disabled.
 //   - USE_GLFW is set to 0 rather than 2 by default.
 //   - ALLOW_UNIMPLEMENTED_SYSCALLS is disabled.
@@ -1167,13 +1166,6 @@ var STRICT = false;
 // include ``_main``.
 // [link]
 var IGNORE_MISSING_MAIN = true;
-
-// Automatically attempt to add archive indexes at link time to archives that
-// don't already have them.  This can happen when GNU ar or GNU ranlib is used
-// rather than ``llvm-ar`` or ``emar`` since the former don't understand the wasm
-// object format.
-// [link]
-var AUTO_ARCHIVE_INDEXES = true;
 
 // Add ``"use strict;"`` to generated JS
 // [link]
@@ -2188,4 +2180,5 @@ var LEGACY_SETTINGS = [
   ['MIN_EDGE_VERSION', [0x7FFFFFFF], 'No longer supported'],
   ['MIN_IE_VERSION', [0x7FFFFFFF], 'No longer supported'],
   ['WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG', [0], 'No longer supported'],
+  ['AUTO_ARCHIVE_INDEXES', [0, 1], 'No longer needed'],
 ];

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9121,22 +9121,6 @@ end
     create_file('test.rsp', b'\xef\xbb\xbf--version', binary=True)
     self.run_process([EMCC, '@test.rsp'])
 
-  def test_archive_empty(self):
-    # This test added because we had an issue with the AUTO_ARCHIVE_INDEXES failing on empty
-    # archives (which inherently don't have indexes).
-    self.run_process([EMAR, 'crS', 'libfoo.a'])
-    self.run_process([EMCC, '-Werror', 'libfoo.a', test_file('hello_world.c')])
-
-  def test_archive_no_index(self):
-    create_file('foo.c', 'int foo = 1;')
-    self.run_process([EMCC, '-c', 'foo.c'])
-    self.run_process([EMCC, '-c', test_file('hello_world.c')])
-    # The `S` flag means don't add an archive index
-    self.run_process([EMAR, 'crS', 'libfoo.a', 'foo.o'])
-    # wasm-ld supports archive files without an index (unlike GNU ld) as of
-    # https://github.com/llvm/llvm-project/pull/78821
-    self.run_process([EMCC, 'libfoo.a', 'hello_world.o'])
-
   def test_archive_non_objects(self):
     create_file('file.txt', 'test file')
     self.run_process([EMCC, '-c', test_file('hello_world.c')])


### PR DESCRIPTION
Now that wasm-ld no longer requires and index this code is no longer needed.