### PR TITLE
Restore 'no input files' error

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14432,6 +14432,9 @@ addToLibrary({
     err = self.expect_fail([EMCC, '-c'])
     self.assertContained('clang: error: no input files', err)
 
+    err = self.expect_fail([EMCC])
+    self.assertContained('emcc: error: no input files', err)
+
   def test_embind_negative_enum_values(self):
     # Test if negative enum values are printed correctly and not overflown to
     # large values when CAN_ADDRESS_2GB is true.

--- a/tools/link.py
+++ b/tools/link.py
@@ -2958,6 +2958,9 @@ def run(linker_inputs, options, state, newargs):
   # We have now passed the compile phase, allow reading/writing of all settings.
   settings.limit_settings(None)
 
+  if not linker_inputs and not state.link_flags:
+    exit_with_error('no input files')
+
   if options.output_file and options.output_file.startswith('-'):
     exit_with_error(f'invalid output filename: `{options.output_file}`')
 


### PR DESCRIPTION
This change partially reverts #20905.

Fixes: #21116