### PR TITLE
Avoid use of `lsan::GetCurrentThread` in `lsan_common_emscripten.cpp`

### DIFF
--- a/system/lib/compiler-rt/lib/asan/asan_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/asan/asan_emscripten.cpp
@@ -109,8 +109,6 @@ void GetAllocatorCacheRange(uptr *begin, uptr *end) {
 }
 #endif
 
-u32 GetCurrentThread() { return __asan::GetCurrentThread()->tid(); }
-
 } // namespace __lsan
 
 #endif // SANITIZER_EMSCRIPTEN

--- a/system/lib/compiler-rt/lib/lsan/lsan_common_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/lsan/lsan_common_emscripten.cpp
@@ -112,8 +112,6 @@ void LockStuffAndStopTheWorld(StopTheWorldCallback callback,
   UnlockThreads();
 }
 
-u32 GetCurrentThreadId();
-
 // This is based on ProcessThreads in lsan_common.cc.
 // We changed this to be a callback that gets called per thread by
 // ThreadRegistry::RunCallbackForEachThreadLocked.
@@ -142,7 +140,7 @@ static void ProcessThreadsCallback(ThreadContextBase *tctx, void *arg) {
 
     // We can't get the SP for other threads to narrow down the range, but we
     // we can for the current thread.
-    if (tctx->tid == GetCurrentThreadId()) {
+    if (tctx->os_id == GetTid()) {
       uptr sp = (uptr) __builtin_frame_address(0);
       if (sp < stack_begin || sp >= stack_end) {
         // SP is outside the recorded stack range (e.g. the thread is running a


### PR DESCRIPTION
This code was depending in a dummy version of `lsan::GetCurrentThread` that was added to `asan_emscripten.cpp`.

However as far as I can tell this never worked since the dummy version of `lsan::GetCurrentThread` was returning a TID directly, but its expected to return a pointer.