### PR TITLE
Reduce the exports with EXPORT_EXCEPTION_HANDLING_HELPERS. NFC

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -1770,9 +1770,9 @@ def phase_linker_setup(options, state, newargs):
     # What you need to do is different depending on the kind of EH you use
     # (https://github.com/emscripten-core/emscripten/issues/17115).
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$getExceptionMessage', '$incrementExceptionRefcount', '$decrementExceptionRefcount']
-    settings.EXPORTED_FUNCTIONS += ['getExceptionMessage', '___get_exception_message', '_free']
+    settings.EXPORTED_FUNCTIONS += ['getExceptionMessage', '$incrementExceptionRefcount', '$decrementExceptionRefcount']
     if settings.WASM_EXCEPTIONS:
-      settings.EXPORTED_FUNCTIONS += ['___cpp_exception', '___cxa_increment_exception_refcount', '___cxa_decrement_exception_refcount', '___thrown_object_from_unwind_exception']
+      settings.REQUIRED_EXPORTS += ['__cpp_exception']
 
   if settings.SIDE_MODULE:
     # For side modules, we ignore all REQUIRED_EXPORTS that might have been added above.


### PR DESCRIPTION
Now that JS -> native dependencies work at the linker level I don't think these indirect dependencies need to be explicitly exported here.