### PR TITLE
Minor webidl binder fixes

### DIFF
--- a/test/webidl/post.js
+++ b/test/webidl/post.js
@@ -186,13 +186,13 @@ console.log('int_array[0] == ' + arrayClass.get_int_array(0));
 console.log('int_array[7] == ' + arrayClass.get_int_array(7));
 
 try {
-  arrayClass.set_int_array(-1, struct);
+  arrayClass.set_int_array(-1, 42);
 } catch (e) {
   console.log('idx -1: ' + e);
 }
 
 try {
-  arrayClass.set_int_array(8, struct);
+  arrayClass.set_int_array(8, 42);
 } catch (e) {
   console.log('idx 8: ' + e);
 }
@@ -270,7 +270,7 @@ if (isMemoryGrowthAllowed) {
     intArray = intArray.concat(intArray);
     storeArray.setArray(intArray);
   }
-  
+
   // Make sure the array was copied to the newly allocated HEAP
   var numCopiedEntries = 0;
   for (var i = 0; i < intArray.length; i++) {


### PR DESCRIPTION
Split out from #21151.

The only semantic change here is the fix the type of second argument to the array member getter function (previously it was using `m.type` which is the array type itself, but that second argument to the setter function is actually the inner type `m.type.inner`).

This enables the type of this argument to be checked correctly, which in turn required a minor fix to the test case.  This only effects `IDL_CHECKS=all` builds.