### PR TITLE
Fix webidl_binder so it can't handle missing assert function

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7637,6 +7637,7 @@ void* operator new(size_t size) {
   def test_webidl(self, mode, allow_memory_growth):
     self.uses_es6 = True
     self.set_setting('WASM_ASYNC_COMPILATION', 0)
+    self.set_setting('STRICT')
     if self.maybe_closure():
       # avoid closure minified names competing with our test code in the global name space
       self.set_setting('MODULARIZE')
@@ -7670,7 +7671,7 @@ void* operator new(size_t size) {
 
     # Export things on "TheModule". This matches the typical use pattern of the bound library
     # being used as Box2D.* or Ammo.*, and we cannot rely on "Module" being always present (closure may remove it).
-    self.emcc_args += ['--post-js=glue.js', '--extern-post-js=extern-post.js']
+    self.emcc_args += ['--no-entry', '--post-js=glue.js', '--extern-post-js=extern-post.js']
     if mode == 'ALL':
       self.emcc_args += ['-sASSERTIONS']
     if allow_memory_growth:

--- a/test/webidl/post.js
+++ b/test/webidl/post.js
@@ -239,7 +239,7 @@ try {
 } catch (e) {}
 
 try {
-  s = new TheModule.StringUser('abc', 1);
+  var s = new TheModule.StringUser('abc', 1);
   s.Print(123, null); // Expects a string or a wrapped pointer
 } catch (e) {}
 

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -133,6 +133,15 @@ function WrapperObject() {
 mid_js += build_constructor('WrapperObject')
 
 mid_js += ['''
+/*
+ * For now, the webidl-generated code unconditionally depends on the `assert` function,
+ * but there are certain build modes where emscripten does not define this.
+ * TODO(sbc): Make the usage of assert conditional.
+ */
+if (typeof assert == "undefined") {
+  assert = (cond) => {}
+}
+
 /** @suppress {duplicate} (TODO: avoid emitting this multiple times, it is redundant)
     @param {*=} __class__ */
 function getCache(__class__) {


### PR DESCRIPTION
This can happen when ASSERTIONS is not set and we are in STRICT mode or MINIMAL_RUNTIME mode.

See #20592