### PR TITLE
Dynamic linking requires WASM_BIGINT to be enabled

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,9 @@ See docs/process.md for more on how version tagging works.
 3.1.53 (in development)
 -----------------------
 - The llvm version that emscripten uses was updated to 19.0.0 trunk. (#21165)
+- When using dynamic linking (e.g. `MAIN_MODULE` or `SIDE_MODULE`) emscripten
+  will now enable `WASM_BIGINT` by default.  This means targetting older
+  browers with dyanmic linking is no longer possible.
 
 3.1.52 - 01/19/24
 -----------------

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14415,3 +14415,14 @@ addToLibrary({
     # "window.crypto.getRandomValues"
     self.assertContained(").randomBytes", js_out)
     self.assertContained("window.crypto.getRandomValues", js_out)
+
+  def test_bigint_required(self):
+    # Certain settings require WASM_BIGINT and make disabling it impossible
+    err = self.expect_fail([EMCC, '-sMEMORY64', '-sWASM_BIGINT=0', test_file('hello_world.c')])
+    self.assertContained('emcc: error: WASM_BIGINT cannot be disabled due to MEMORY64', err);
+
+    err = self.expect_fail([EMCC, '-sSIDE_MODULE', '-sWASM_BIGINT=0', test_file('hello_world.c')])
+    self.assertContained('emcc: error: WASM_BIGINT cannot be disabled due to dynamic linking', err);
+
+    err = self.expect_fail([EMCC, '-sMAIN_MODULE', '-sWASM_BIGINT=0', test_file('hello_world.c')])
+    self.assertContained('emcc: error: WASM_BIGINT cannot be disabled due to dynamic linking', err);

--- a/tools/link.py
+++ b/tools/link.py
@@ -1308,9 +1308,17 @@ def phase_linker_setup(options, state, newargs):
       exit_with_error('-sPROXY_TO_PTHREAD requires -pthread to work!')
     settings.JS_LIBRARIES.append((0, 'library_pthread_stub.js'))
 
+  def require_bigint(reason):
+    if user_settings['WASM_BIGINT'] == '0':
+      exit_with_error(f'WASM_BIGINT cannot be disabled due to {reason}')
+    settings.WASM_BIGINT = 1
+
   if settings.MEMORY64:
     # Any "pointers" passed to JS will now be i64's, in both modes.
-    settings.WASM_BIGINT = 1
+    require_bigint('MEMORY64')
+
+  if settings.RELOCATABLE:
+    require_bigint('dynamic linking')
 
   if settings.WASM_WORKERS:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$_wasmWorkerInitializeRuntime']


### PR DESCRIPTION
This change is in preparation for a linker change to have the linker honor the names of imports and exports in dynamic libraries.  The type legalization that is performed by wasm-emscripten-finalize when bigint is not available, renames symbols and modifies their signatures, which makes that linker fail (with signature mismatches).