### PR TITLE
Remove unused arguments from test_emmalloc_trim. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -869,9 +869,9 @@ base align: 0, 0, 0, 0'''])
   @no_2gb('output is sensitive to absolute data layout')
   @no_asan('ASan does not support custom memory allocators')
   @no_lsan('LSan does not support custom memory allocators')
-  def test_emmalloc_trim(self, *args):
+  def test_emmalloc_trim(self):
     self.set_setting('MALLOC', 'emmalloc')
-    self.emcc_args += ['-sINITIAL_MEMORY=128MB', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=2147418112'] + list(args)
+    self.emcc_args += ['-sINITIAL_MEMORY=128MB', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=2147418112']
 
     self.do_core_test('test_emmalloc_trim.cpp')
 


### PR DESCRIPTION
This test was originally added with these unused args. Perhaps while it was being developed in was parameterized, but is not anymore.