### PR TITLE
Allow-list 7 more WebGL extensions

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -162,18 +162,25 @@ for (/**@suppress{duplicate}*/var i = 0; i < {{{ GL_POOL_TEMP_BUFFERS_SIZE }}}; 
 #if MAX_WEBGL_VERSION >= 2
       // WebGL 2 extensions
       'EXT_color_buffer_float',
+      'EXT_conservative_depth',
       'EXT_disjoint_timer_query_webgl2',
       'EXT_texture_norm16',
+      'NV_shader_noperspective_interpolation',
       'WEBGL_clip_cull_distance',
 #endif
       // WebGL 1 and WebGL 2 extensions
       'EXT_color_buffer_half_float',
+      'EXT_depth_clamp',
       'EXT_float_blend',
       'EXT_texture_compression_bptc',
       'EXT_texture_compression_rgtc',
       'EXT_texture_filter_anisotropic',
       'KHR_parallel_shader_compile',
       'OES_texture_float_linear',
+      'WEBGL_blend_func_extended',
+      'WEBGL_compressed_texture_astc',
+      'WEBGL_compressed_texture_etc',
+      'WEBGL_compressed_texture_etc1',
       'WEBGL_compressed_texture_s3tc',
       'WEBGL_compressed_texture_s3tc_srgb',
       'WEBGL_debug_renderer_info',


### PR DESCRIPTION
These 6 extensions don't add any entry points, so shouldn't require any Emscripten support (aside from having any enums present in gl2ext.h, which they do):

- EXT_conservative_depth
- NV_shader_noperspective_interpolation
- EXT_depth_clamp
- WEBGL_blend_func_extended
- WEBGL_compressed_texture_etc
- WEBGL_compressed_texture_etc1

Finally:

- WEBGL_compressed_texture_astc does add an entry point getSupportedProfiles() in WebGL. This is a WEBGL_ extension, so it is still safe to allow-list without implementing a C version of that function. There is no corresponding GLES entry point for this; instead, profile support is indicated by the presence of KHR_texture_compression_astc_{ldr,hdr}. Emscripten should emulate those extensions by checking getSupportedProfiles(), but I haven't implemented this. Applications can still use the WEBGL_ version directly.

  WEBGL_compressed_texture_astc guarantees support for the LDR profile (since HDR is a superset of LDR, and there are only two profiles), so applications that only need LDR don't need to call this function. It can also be easily called using EM_ASM in applications that do use the HDR profile.

Fixes #21183