### PR TITLE
Add wcstod() and wcstof() functions

### DIFF
--- a/system/lib/libcxx/include/__support/musl/xlocale.h
+++ b/system/lib/libcxx/include/__support/musl/xlocale.h
@@ -46,6 +46,14 @@ inline _LIBCPP_HIDE_FROM_ABI_C long double wcstold_l(const wchar_t* __nptr, wcha
   return ::wcstold(__nptr, __endptr);
 }
 
+inline _LIBCPP_HIDE_FROM_ABI_C double wcstod_l(const wchar_t* __nptr, wchar_t** __endptr, locale_t) {
+  return ::wcstod(__nptr, __endptr);
+}
+
+inline _LIBCPP_HIDE_FROM_ABI_C float wcstof_l(const wchar_t* __nptr, wchar_t** __endptr, locale_t) {
+  return ::wcstof(__nptr, __endptr);
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Functions `wcstod()`, `wcstof()`, and `wcstold()` convert a wide-character string into a double, float, and long double, respectively. Emscripten only supports wcstold() and I received the following errors when I compiled a code that calls two other functions:

1) `error: no member named 'wcstof_l' in the global namespace; did you mean 'wcstold_l'?`
2) `error: no member named 'wcstod_l' in the global namespace; did you mean 'wcstold_l'?`

This pull request adds two functions `wcstod()` and `wcstof()`.