### PR TITLE
Don't force the use of imported memory under WASM2JS

### DIFF
--- a/test/code_size/hello_webgl2_wasm2js.json
+++ b/test/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 17760,
-  "a.js.gz": 7958,
+  "a.js": 17790,
+  "a.js.gz": 7987,
   "a.mem": 3123,
   "a.mem.gz": 2693,
-  "total": 21450,
-  "total_gz": 11030
+  "total": 21480,
+  "total_gz": 11059
 }

--- a/test/code_size/hello_webgl_wasm2js.json
+++ b/test/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 17239,
-  "a.js.gz": 7781,
+  "a.js": 17263,
+  "a.js.gz": 7819,
   "a.mem": 3123,
   "a.mem.gz": 2693,
-  "total": 20929,
-  "total_gz": 10853
+  "total": 20953,
+  "total_gz": 10891
 }

--- a/test/code_size/hello_world_wasm2js.js
+++ b/test/code_size/hello_world_wasm2js.js
@@ -1,59 +1,64 @@
-var b = Module, g = new function(a) {
-    this.buffer = new ArrayBuffer(65536 * a.initial);
-}({
-    initial: 256,
-    maximum: 256
-}), k = g.buffer, d = new Uint8Array(k), l = new TextDecoder("utf8"), m;
+var c = Module, g, h, k = new TextDecoder("utf8"), l;
 
-function c(a) {
-    this.exports = function(h) {
-        function n(f) {
-            f.set = function(e, p) {
-                this[e] = p;
+function d(b) {
+    this.exports = function(f) {
+        function m(e) {
+            e.set = function(a, n) {
+                this[a] = n;
             };
-            f.get = function(e) {
-                return this[e];
+            e.get = function(a) {
+                return this[a];
             };
-            return f;
+            return e;
         }
-        return function(f) {
-            var e = f.a.a;
+        return function(e) {
+            var a = new ArrayBuffer(16777216), n = e.a.a;
+            e = m([]);
             return {
-                b: function() {},
-                c: function(p, q) {
-                    e(1024);
+                b: Object.create(Object.prototype, {
+                    grow: {},
+                    buffer: {
+                        get: function() {
+                            return a;
+                        }
+                    }
+                }),
+                c: function() {},
+                d: function(p, q) {
+                    n(1024);
                     return 0;
                 },
-                d: n([])
+                e: e
             };
-        }(h);
-    }(a);
+        }(f);
+    }(b);
 }
 
-(function(a, h) {
+(function(b, f) {
     return {
-        then: function(n) {
-            n({
-                instance: new c(h)
+        then: function(m) {
+            m({
+                instance: new d(f)
             });
         }
     };
-})(b.wasm, {
+})(c.wasm, {
     a: {
-        a: a => {
-            var h = console, n = h.log;
-            if (a) {
-                for (var f = a + void 0, e = a; !(e >= f) && d[e]; ) ++e;
-                a = l.decode(d.subarray(a, e));
-            } else a = "";
-            n.call(h, a);
-        },
-        memory: g
+        a: b => {
+            var f = console, m = f.log;
+            if (b) {
+                for (var e = b + void 0, a = b; !(a >= e) && g[a]; ) ++a;
+                b = k.decode(g.subarray(b, a));
+            } else b = "";
+            m.call(f, b);
+        }
     }
-}).then((a => {
-    a = a.instance.exports;
-    m = a.c;
-    d.set(new Uint8Array(b.mem), 1024);
-    a.b();
-    m();
+}).then((b => {
+    b = b.instance.exports;
+    l = b.d;
+    h = b.b;
+    g = new Uint8Array(h.buffer);
+    g.set(new Uint8Array(c.mem), 1024);
+    b.c();
+    l();
 }));

--- a/test/code_size/hello_world_wasm2js.json
+++ b/test/code_size/hello_world_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 671,
   "a.html.gz": 430,
-  "a.js": 692,
-  "a.js.gz": 430,
+  "a.js": 708,
+  "a.js.gz": 444,
   "a.mem": 6,
   "a.mem.gz": 32,
-  "total": 1369,
-  "total_gz": 892
+  "total": 1385,
+  "total_gz": 906
 }

--- a/test/code_size/random_printf_wasm2js.json
+++ b/test/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17264,
-  "a.html.gz": 7529,
-  "total": 17264,
-  "total_gz": 7529
+  "a.html": 17279,
+  "a.html.gz": 7541,
+  "total": 17279,
+  "total_gz": 7541
 }

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3664,7 +3664,7 @@ Module["preRun"] = () => {
       create_file('dummy_file', 'dummy')
       # compile the code with the modularize feature and the preload-file option enabled
       # no wasm, since this tests customizing total memory at runtime
-      self.compile_btest('test.c', ['-sWASM=0', '-sMODULARIZE', '-sEXPORT_NAME="Foo"', '--preload-file', 'dummy_file'] + opts, reporting=Reporting.JS_ONLY)
+      self.compile_btest('test.c', ['-sWASM=0', '-sIMPORTED_MEMORY', '-sMODULARIZE', '-sEXPORT_NAME="Foo"', '--preload-file', 'dummy_file'] + opts, reporting=Reporting.JS_ONLY)
       create_file('a.html', '''
         <script src="a.out.js"></script>
         <script>
@@ -4817,7 +4817,7 @@ Module["preRun"] = () => {
   # Preallocating the buffer in this was is asm.js only (wasm needs a Memory).
   @requires_wasm2js
   def test_preallocated_heap(self):
-    self.btest_exit('test_preallocated_heap.cpp', args=['-sWASM=0', '-sINITIAL_MEMORY=16MB', '-sABORTING_MALLOC=0', '--shell-file', test_file('test_preallocated_heap_shell.html')])
+    self.btest_exit('test_preallocated_heap.cpp', args=['-sWASM=0', '-sIMPORTED_MEMORY', '-sINITIAL_MEMORY=16MB', '-sABORTING_MALLOC=0', '--shell-file', test_file('test_preallocated_heap_shell.html')])
 
   # Tests emscripten_fetch() usage to XHR data directly to memory without persisting results to IndexedDB.
   @also_with_wasm2js

--- a/tools/link.py
+++ b/tools/link.py
@@ -1445,8 +1445,7 @@ def phase_linker_setup(options, state, newargs):
      (options.shell_path == DEFAULT_SHELL_HTML or options.shell_path == utils.path_from_root('src/shell_minimal.html')):
     exit_with_error(f'Due to collision in variable name "Module", the shell file "{options.shell_path}" is not compatible with build options "-sMODULARIZE -sEXPORT_NAME=Module". Either provide your own shell file, change the name of the export to something else to avoid the name collision. (see https://github.com/emscripten-core/emscripten/issues/7950 for details)')
 
-  # TODO(sbc): Remove WASM2JS here once the size regression it would introduce has been fixed.
-  if settings.SHARED_MEMORY or settings.RELOCATABLE or settings.ASYNCIFY_LAZY_LOAD_CODE or settings.WASM2JS:
+  if settings.SHARED_MEMORY or settings.RELOCATABLE or settings.ASYNCIFY_LAZY_LOAD_CODE:
     settings.IMPORTED_MEMORY = 1
 
   if settings.WASM_BIGINT:


### PR DESCRIPTION
Setting `IMPORTED_MEMORY` can have other implications and we don't
want to be enabling by default just because we chose WASM2JS.

The there is a very minor code size regression here that only effects
WASM2JS, but when combined with #21196 the overall effect is still a
win.

See #21071