### PR TITLE
Run unsafe_optimizations.js again after closure

### DIFF
--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 673,
   "a.html.gz": 431,
-  "a.js": 7411,
-  "a.js.gz": 3140,
+  "a.js": 7387,
+  "a.js.gz": 3112,
   "a.wasm": 11433,
   "a.wasm.gz": 5725,
-  "total": 19517,
-  "total_gz": 9296
+  "total": 19493,
+  "total_gz": 9268
 }

--- a/test/code_size/hello_wasm_worker_wasm.json
+++ b/test/code_size/hello_wasm_worker_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 737,
   "a.html.gz": 433,
-  "a.js": 667,
-  "a.js.gz": 458,
+  "a.js": 665,
+  "a.js.gz": 455,
   "a.wasm": 1852,
   "a.wasm.gz": 1049,
-  "total": 3256,
-  "total_gz": 1940
+  "total": 3254,
+  "total_gz": 1937
 }

--- a/test/code_size/hello_webgl2_wasm.json
+++ b/test/code_size/hello_webgl2_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 569,
   "a.html.gz": 379,
-  "a.js": 4593,
-  "a.js.gz": 2369,
+  "a.js": 4584,
+  "a.js.gz": 2351,
   "a.wasm": 10451,
   "a.wasm.gz": 6724,
-  "total": 15613,
-  "total_gz": 9472
+  "total": 15604,
+  "total_gz": 9454
 }

--- a/test/code_size/hello_webgl2_wasm2js.json
+++ b/test/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 17937,
-  "a.js.gz": 8074,
+  "a.js": 17760,
+  "a.js.gz": 7958,
   "a.mem": 3123,
   "a.mem.gz": 2693,
-  "total": 21627,
-  "total_gz": 11146
+  "total": 21450,
+  "total_gz": 11030
 }

--- a/test/code_size/hello_webgl_wasm.json
+++ b/test/code_size/hello_webgl_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 569,
   "a.html.gz": 379,
-  "a.js": 4080,
-  "a.js.gz": 2198,
+  "a.js": 4071,
+  "a.js.gz": 2179,
   "a.wasm": 10451,
   "a.wasm.gz": 6724,
-  "total": 15100,
-  "total_gz": 9301
+  "total": 15091,
+  "total_gz": 9282
 }

--- a/test/code_size/hello_webgl_wasm2js.json
+++ b/test/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 17415,
-  "a.js.gz": 7891,
+  "a.js": 17239,
+  "a.js.gz": 7781,
   "a.mem": 3123,
   "a.mem.gz": 2693,
-  "total": 21105,
-  "total_gz": 10963
+  "total": 20929,
+  "total_gz": 10853
 }

--- a/test/code_size/hello_world_wasm.json
+++ b/test/code_size/hello_world_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 673,
   "a.html.gz": 431,
-  "a.js": 292,
-  "a.js.gz": 252,
+  "a.js": 291,
+  "a.js.gz": 249,
   "a.wasm": 103,
   "a.wasm.gz": 112,
-  "total": 1068,
-  "total_gz": 795
+  "total": 1067,
+  "total_gz": 792
 }

--- a/test/code_size/hello_world_wasm2js.json
+++ b/test/code_size/hello_world_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 671,
   "a.html.gz": 430,
-  "a.js": 694,
-  "a.js.gz": 433,
+  "a.js": 692,
+  "a.js.gz": 430,
   "a.mem": 6,
   "a.mem.gz": 32,
-  "total": 1371,
-  "total_gz": 895
+  "total": 1369,
+  "total_gz": 892
 }

--- a/test/code_size/math_wasm.json
+++ b/test/code_size/math_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 673,
   "a.html.gz": 431,
-  "a.js": 111,
-  "a.js.gz": 127,
+  "a.js": 110,
+  "a.js.gz": 125,
   "a.wasm": 2728,
   "a.wasm.gz": 1672,
-  "total": 3512,
-  "total_gz": 2230
+  "total": 3511,
+  "total_gz": 2228
 }

--- a/test/code_size/random_printf_wasm2js.json
+++ b/test/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17331,
-  "a.html.gz": 7543,
-  "total": 17331,
-  "total_gz": 7543
+  "a.html": 17264,
+  "a.html.gz": 7529,
+  "total": 17264,
+  "total_gz": 7529
 }

--- a/tools/link.py
+++ b/tools/link.py
@@ -1974,6 +1974,7 @@ def fix_es6_import_statements(js_file):
   write_file(js_file, src
              .replace('EMSCRIPTEN$IMPORT$META', 'import.meta')
              .replace('EMSCRIPTEN$AWAIT$IMPORT', 'await import'))
+  save_intermediate('es6-module')
 
 
 def create_worker_file(input_file, target_dir, output_file):
@@ -2019,13 +2020,17 @@ def phase_final_emitting(options, state, target, wasm_target, memfile):
   # steps that occurred after Closure.
   if settings.MINIMAL_RUNTIME == 2 and settings.USE_CLOSURE_COMPILER and settings.DEBUG_LEVEL == 0:
     shared.run_js_tool(utils.path_from_root('tools/unsafe_optimizations.js'), [final_js, '-o', final_js], cwd=utils.path_from_root('.'))
+    save_intermediate('unsafe-optimizations')
     # Finally, rerun Closure compile with simple optimizations. It will be able
     # to further minify the code. (n.b. it would not be safe to run in advanced
     # mode)
     final_js = building.closure_compiler(final_js, advanced=False, extra_closure_args=options.closure_args)
+    # Run unsafe_optimizations.js once more.  This allows the cleanup of newly
+    # unused things that closure compiler leaves behing (e.g `new Float64Array(x)`).
+    shared.run_js_tool(utils.path_from_root('tools/unsafe_optimizations.js'), [final_js, '-o', final_js], cwd=utils.path_from_root('.'))
+    save_intermediate('unsafe-optimizations2')
 
   fix_es6_import_statements(final_js)
-  save_intermediate('es6-module')
 
   # Apply pre and postjs files
   if options.extern_pre_js or options.extern_post_js:


### PR DESCRIPTION
This allows `unsafe_optimizations.js` to cleanup some thing that closure compiler was able to remove usages of.

Split out from #21195