### PR TITLE
Fix GL.getSource bug introduced in #21184

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -425,7 +425,7 @@ for (/**@suppress{duplicate}*/var i = 0; i < {{{ GL_POOL_TEMP_BUFFERS_SIZE }}}; 
     getSource: (shader, count, string, length) => {
       var source = '';
       for (var i = 0; i < count; ++i) {
-        var len = length ? {{{ makeGetValue('length', 'i*' * POINTER_SIZE, '*') }}} : undefined;
+        var len = length ? {{{ makeGetValue('length', 'i*' + POINTER_SIZE, '*') }}} : undefined;
         source += UTF8ToString({{{ makeGetValue('string', 'i*' + POINTER_SIZE, '*') }}}, len);
       }
 #if LEGACY_GL_EMULATION


### PR DESCRIPTION
This only seems to show up in `browser.test_sdl_ogl_regal`.