### PR TITLE
[debug] Use two digits for the temporary file counter. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2704,7 +2704,7 @@ int f() {
             self.assertFalse(os.path.exists(self.canonical_temp_dir))
           else:
             print(sorted(os.listdir(self.canonical_temp_dir)))
-            self.assertExists(os.path.join(self.canonical_temp_dir, 'emcc-3-original.js'))
+            self.assertExists(os.path.join(self.canonical_temp_dir, 'emcc-03-original.js'))
 
   def test_debuginfo_line_tables_only(self):
     def test(do_compile):

--- a/tools/building.py
+++ b/tools/building.py
@@ -1297,7 +1297,7 @@ def run_wasm_opt(infile, outfile=None, args=[], **kwargs):  # noqa
 
 def save_intermediate(src, dst):
   if DEBUG:
-    dst = 'emcc-%d-%s' % (save_intermediate.counter, dst)
+    dst = 'emcc-%02d-%s' % (save_intermediate.counter, dst)
     save_intermediate.counter += 1
     dst = os.path.join(shared.CANONICAL_TEMP_DIR, dst)
     logger.debug('saving debug copy %s' % dst)


### PR DESCRIPTION
This means that filenames will sort correctly under normal sorting rules.