### PR TITLE
embind - Fix reading various bindings types from val on wasm64.

### DIFF
--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 673,
   "a.html.gz": 431,
-  "a.js": 7387,
-  "a.js.gz": 3112,
+  "a.js": 7325,
+  "a.js.gz": 3088,
   "a.wasm": 11433,
   "a.wasm.gz": 5725,
-  "total": 19493,
-  "total_gz": 9268
+  "total": 19431,
+  "total_gz": 9244
 }

--- a/test/embind/test_val_read_pointer.cpp
+++ b/test/embind/test_val_read_pointer.cpp
@@ -1,0 +1,81 @@
+#include <emscripten/bind.h>
+#include <emscripten.h>
+
+using namespace emscripten;
+
+struct ValueObject {
+  ValueObject(): value(43) {};
+  int value;
+};
+
+struct ValueArray {
+  ValueArray(): x(44) {};
+  int x;
+};
+
+struct Foo {
+  Foo(): value(45) {};
+  int value;
+};
+
+enum Enum { ONE, TWO };
+
+EMSCRIPTEN_BINDINGS(xxx) {
+  value_object<ValueObject>("ValueObject")
+    .field("value", &ValueObject::value);
+  
+  value_array<ValueArray>("ValueArray")
+    .element(&ValueArray::x);
+  
+  class_<Foo>("Foo")
+    .property("value", &Foo::value);
+
+  enum_<Enum>("Enum")
+    .value("ONE", ONE)
+    .value("TWO", TWO);
+}
+
+
+int main() {
+  EM_ASM(
+    globalThis["passthrough"] = (arg) => {
+      return arg;
+    };
+    globalThis["passthroughValueObject"] = (arg) => {
+      return arg.value;
+    };
+    globalThis["passthroughValueArray"] = (arg) => {
+      return arg[0];
+    };
+    globalThis["passthroughClass"] = (arg) => {
+      const value = arg.value;
+      arg.delete();
+      return value;
+    };
+    globalThis["passthroughMemoryView"] = (arg) => {
+      return arg[2];
+    };
+  );
+
+  // These tests execute all the various readValueFromPointer functions for each
+  // of the different binding types.
+  assert(val::global().call<bool>("passthrough", true));
+  assert(val::global().call<int>("passthrough", 42) == 42);
+  assert(val::global().call<double>("passthrough", 42.2) == 42.2);
+  ValueObject vo;
+  assert(val::global().call<int>("passthroughValueObject", vo) == 43);
+  ValueArray va;
+  assert(val::global().call<int>("passthroughValueArray", va) == 44);
+  Foo foo;
+  assert(val::global().call<int>("passthroughClass", foo) == 45);
+  assert(val::global().call<std::string>("passthrough", val("abc")) == "abc");
+  std::string str = "hello";
+  assert(val::global().call<std::string>("passthrough", str) == "hello");
+  std::wstring wstr = L"abc";
+  assert(val::global().call<std::wstring>("passthrough", wstr) == L"abc");
+  static const int data[] = {0, 1, 2};
+  assert(val::global().call<int>("passthroughMemoryView", typed_memory_view(3, data)) == 2);
+  assert(val::global().call<Enum>("passthrough", ONE) == ONE);
+
+  return 0;
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7471,6 +7471,10 @@ void* operator new(size_t size) {
     self.emcc_args += ['-lembind']
     self.do_run_in_out_file_test('embind/test_val.cpp')
 
+  def test_embind_val_read_pointer(self):
+    self.emcc_args += ['-lembind']
+    self.do_runf('embind/test_val_read_pointer.cpp')
+
   def test_embind_val_assignment(self):
     err = self.expect_fail([EMCC, test_file('embind/test_val_assignment.cpp'), '-lembind', '-c'])
     self.assertContained('candidate function not viable: expects an lvalue for object argument', err)


### PR DESCRIPTION
 - The function simpleReadValueFromPointer was always reading pointers as i32 numbers which was incorrect on wasm64.
- Decoding of std::wstring was using a right shift to read pointers. Right shift was truncating numbers larger than i32 and causing misreads.
- Added tests to execute readValueFromPointer on all the binding types to ensure these don't break on wasm64.