### PR TITLE
Fix emscripten_webgl_make_context_current under wasm64/CAN_ADDRESS_2GB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -799,10 +799,7 @@ jobs:
       - run-tests-chrome:
           title: "browser"
           # Skip test_4gb_fail as it OOMs on the current bot
-          # Include an representative selection of browser_2gb
           test_targets: "
-            browser_2gb.test_gles2_uniform_arrays
-            browser_2gb.test_fetch_to_memory
             browser skip:browser.test_4gb_fail
             "
   test-browser-chrome-wasm64:
@@ -811,6 +808,16 @@ jobs:
       - run-tests-chrome:
           title: "browser64"
           test_targets: "browser64"
+  test-browser-chrome-2gb:
+    executor: bionic
+    steps:
+      - run-tests-chrome:
+          title: "browser_2gb"
+          test_targets: "
+            browser_2gb.test_gles2_uniform_arrays
+            browser_2gb.test_fetch_to_memory
+            browser_2gb.test_emscripten_animate_canvas_element_size_manual_css
+            "
   test-browser-chrome-wasm64-4gb:
     executor: bionic
     steps:
@@ -823,6 +830,7 @@ jobs:
             browser64_4gb.test_emscripten_log
             browser64_4gb.test_clientside_vertex_arrays_es3
             browser64_4gb.test_fetch*
+            browser64_4gb.test_emscripten_animate_canvas_element_size_manual_css
             "
   test-browser-firefox:
     executor: bionic
@@ -976,6 +984,9 @@ workflows:
           requires:
             - build-linux
       - test-browser-chrome:
+          requires:
+            - build-linux
+      - test-browser-chrome-2gb:
           requires:
             - build-linux
       - test-browser-chrome-wasm64:

--- a/src/library_html5_webgl.js
+++ b/src/library_html5_webgl.js
@@ -57,7 +57,7 @@ var LibraryHtml5WebGL = {
 #if ASSERTIONS
     assert(attributes);
 #endif
-    var a = attributes >> 2;
+    var a = {{{ getHeapOffset('attributes', 'i32') }}};
     var powerPreference = HEAP32[a + ({{{ C_STRUCTS.EmscriptenWebGLContextAttributes.powerPreference }}}>>2)];
     var contextAttributes = {
       'alpha': !!HEAP32[a + ({{{ C_STRUCTS.EmscriptenWebGLContextAttributes.alpha }}}>>2)],
@@ -184,7 +184,7 @@ var LibraryHtml5WebGL = {
   },
 #if PTHREADS && OFFSCREEN_FRAMEBUFFER
   // Runs on the calling thread, proxies if needed.
-  emscripten_webgl_make_context_current_calling_thread__sig: 'ii',
+  emscripten_webgl_make_context_current_calling_thread__sig: 'ip',
   emscripten_webgl_make_context_current_calling_thread: (contextHandle) => {
     var success = GL.makeContextCurrent(contextHandle);
     if (success) GL.currentContextIsProxied = false; // If succeeded above, we will have a local GL context from this thread (worker or main).

--- a/test/canvas_animate_resize.c
+++ b/test/canvas_animate_resize.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <pthread.h>
@@ -33,8 +34,7 @@ int program;
 int frameNumber = 0;
 EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx;
 
-void tick()
-{
+void tick() {
   double sizeScale = 21.0 + 20.0 * sin(emscripten_get_now()*0.001);
   double w = 18.0*sizeScale;
   double h = 11.0*sizeScale;
@@ -73,8 +73,7 @@ void tick()
 #endif
 
   ++frameNumber;
-  if (frameNumber >= NUM_FRAMES_TO_RENDER)
-  {
+  if (frameNumber >= NUM_FRAMES_TO_RENDER) {
 #if TEST_EMSCRIPTEN_SET_MAIN_LOOP
     emscripten_cancel_main_loop();
 #endif
@@ -85,8 +84,8 @@ void tick()
   }
 }
 
-void init()
-{
+void init() {
+  printf("init\n");
   glGenBuffers(1, &vb);
   glBindBuffer(GL_ARRAY_BUFFER, vb);
   float vertices[] = { -1, -1, -1,  1, 1, -1, 1,  1 };
@@ -123,9 +122,8 @@ int main()
   attr.explicitSwapControl = EM_TRUE;
 #endif
   ctx = emscripten_webgl_create_context("#canvas", &attr);
-  printf("Created context with handle %u\n", (unsigned int)ctx);
-  if (!ctx)
-  {
+  printf("Created context with handle %#lx\n", ctx);
+  if (!ctx) {
     if (!emscripten_supports_offscreencanvas()) {
       EM_ASM({
         xhr = new XMLHttpRequest();
@@ -144,8 +142,7 @@ int main()
 #if TEST_EMSCRIPTEN_SET_MAIN_LOOP
   emscripten_set_main_loop(tick, 0, 0);
 #else
-  for(int i = 0; i < NUM_FRAMES_TO_RENDER; ++i)
-  {
+  for (int i = 0; i < NUM_FRAMES_TO_RENDER; ++i) {
     tick();
     emscripten_current_thread_process_queued_calls();
     usleep(16*1000);

--- a/test/common.py
+++ b/test/common.py
@@ -227,7 +227,7 @@ def no_4gb(note):
 
     @wraps(f)
     def decorated(self, *args, **kwargs):
-      if self.get_setting('INITIAL_MEMORY') == '4200mb':
+      if self.is_4gb():
         self.skipTest(note)
       f(self, *args, **kwargs)
     return decorated
@@ -658,6 +658,12 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
   def is_wasm64(self):
     return self.get_setting('MEMORY64')
+
+  def is_4gb(self):
+    return self.get_setting('INITIAL_MEMORY') == '4200mb'
+
+  def is_2gb(self):
+    return self.get_setting('INITIAL_MEMORY') == '2200mb'
 
   def check_dylink(self):
     if self.get_setting('ALLOW_MEMORY_GROWTH') == 1 and not self.is_wasm():

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4987,10 +4987,14 @@ Module["preRun"] = () => {
     'manual_css': (['-sPROXY_TO_PTHREAD', '-pthread', '-sOFFSCREEN_FRAMEBUFFER', '-DTEST_EXPLICIT_CONTEXT_SWAP=1', '-DTEST_MANUALLY_SET_ELEMENT_CSS_SIZE=1'], False),
   })
   def test_emscripten_animate_canvas_element_size(self, args, main_loop):
-    cmd = ['-lGL', '-O3', '-g2', '--shell-file', test_file('canvas_animate_resize_shell.html'), '-sGL_DEBUG', '--threadprofiler', '-sASSERTIONS'] + args
+    cmd = ['-lGL', '-O3', '-g2', '--shell-file', test_file('canvas_animate_resize_shell.html'), '-sGL_DEBUG', '-sASSERTIONS'] + args
+    if not self.is_2gb() and not self.is_4gb():
+      # Thread profiler does not yet work with large pointers.
+      # https://github.com/emscripten-core/emscripten/issues/21229
+      cmd.append('--threadprofiler')
     if main_loop:
       cmd.append('-DTEST_EMSCRIPTEN_SET_MAIN_LOOP=1')
-    self.btest_exit('canvas_animate_resize.cpp', args=cmd)
+    self.btest_exit('canvas_animate_resize.c', args=cmd)
 
   # Tests the absolute minimum pthread-enabled application.
   @parameterized({


### PR DESCRIPTION
The first problem here was that
emscripten_webgl_make_context_current_calling_thread had the
wrong signature.
    
The second issue was use of `>> 2` on a pointer in
`emscripten_webgl_do_create_context` which doesn't work under wasm64
or CAN_ADDRESS_2GB.
