### PR TITLE
Support WGPUPrimitiveDepthClipControl / unclippedDepth

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1268,9 +1268,9 @@ var LibraryWebGPU = {
           {{{ gpu.makeGetU32('rsPtr', C_STRUCTS.WGPUPrimitiveState.stripIndexFormat) }}}],
         "frontFace": WebGPU.FrontFace[
           {{{ gpu.makeGetU32('rsPtr', C_STRUCTS.WGPUPrimitiveState.frontFace) }}}],
-          "cullMode": WebGPU.CullMode[
-            {{{ gpu.makeGetU32('rsPtr', C_STRUCTS.WGPUPrimitiveState.cullMode) }}}],
-          "unclippedDepth": sType === {{{ gpu.SType.PrimitiveDepthClipControl }}} && {{{ gpu.makeGetBool('nextInChainPtr', C_STRUCTS.WGPUPrimitiveDepthClipControl.unclippedDepth) }}},
+        "cullMode": WebGPU.CullMode[
+          {{{ gpu.makeGetU32('rsPtr', C_STRUCTS.WGPUPrimitiveState.cullMode) }}}],
+        "unclippedDepth": sType === {{{ gpu.SType.PrimitiveDepthClipControl }}} && {{{ gpu.makeGetBool('nextInChainPtr', C_STRUCTS.WGPUPrimitiveDepthClipControl.unclippedDepth) }}},
       };
     }
 

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1256,7 +1256,11 @@ var LibraryWebGPU = {
     {{{ gpu.makeCheckDescriptor('descriptor') }}}
     function makePrimitiveState(rsPtr) {
       if (!rsPtr) return undefined;
-      {{{ gpu.makeCheckDescriptor('rsPtr') }}}
+      {{{ gpu.makeCheck('rsPtr') }}}
+
+      var nextInChainPtr = {{{ makeGetValue('rsPtr', C_STRUCTS.WGPUPrimitiveState.nextInChain, '*') }}};
+      var sType = {{{ gpu.makeGetU32('nextInChainPtr', C_STRUCTS.WGPUChainedStruct.sType) }}};
+      
       return {
         "topology": WebGPU.PrimitiveTopology[
           {{{ gpu.makeGetU32('rsPtr', C_STRUCTS.WGPUPrimitiveState.topology) }}}],
@@ -1264,8 +1268,9 @@ var LibraryWebGPU = {
           {{{ gpu.makeGetU32('rsPtr', C_STRUCTS.WGPUPrimitiveState.stripIndexFormat) }}}],
         "frontFace": WebGPU.FrontFace[
           {{{ gpu.makeGetU32('rsPtr', C_STRUCTS.WGPUPrimitiveState.frontFace) }}}],
-        "cullMode": WebGPU.CullMode[
-          {{{ gpu.makeGetU32('rsPtr', C_STRUCTS.WGPUPrimitiveState.cullMode) }}}],
+          "cullMode": WebGPU.CullMode[
+            {{{ gpu.makeGetU32('rsPtr', C_STRUCTS.WGPUPrimitiveState.cullMode) }}}],
+          "unclippedDepth": sType === {{{ gpu.SType.PrimitiveDepthClipControl }}} && {{{ gpu.makeGetBool('nextInChainPtr', C_STRUCTS.WGPUPrimitiveDepthClipControl.unclippedDepth) }}},
       };
     }
 

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1258,8 +1258,12 @@ var LibraryWebGPU = {
       if (!rsPtr) return undefined;
       {{{ gpu.makeCheck('rsPtr') }}}
 
+      // TODO: This small hack assumes that there's only one type that can be in the chain of
+      // WGPUPrimitiveState. The correct thing would be to traverse the chain, but unclippedDepth
+      // is going to move into the core object soon, so we'll just do this for now. See:
+      // https://github.com/webgpu-native/webgpu-headers/issues/212#issuecomment-1682801259
       var nextInChainPtr = {{{ makeGetValue('rsPtr', C_STRUCTS.WGPUPrimitiveState.nextInChain, '*') }}};
-      var sType = {{{ gpu.makeGetU32('nextInChainPtr', C_STRUCTS.WGPUChainedStruct.sType) }}};
+      var sType = nextInChainPtr ? {{{ gpu.makeGetU32('nextInChainPtr', C_STRUCTS.WGPUChainedStruct.sType) }}} : 0;
       
       return {
         "topology": WebGPU.PrimitiveTopology[


### PR DESCRIPTION
This adds support for reading `WGPUPrimitiveDepthClipControl ` as a chained structure from `WGPUPrimitiveState`, in order to support `WGPUPrimitiveState.unclippedDepth`. Note that support requires the "depth-clip-control" feature.