### PR TITLE
[embuilder] Add support for '*' wildcard for matching library names

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -13,6 +13,7 @@ running multiple build commands in parallel, confusion can occur).
 """
 
 import argparse
+import fnmatch
 import logging
 import sys
 import time
@@ -120,7 +121,7 @@ legacy_prefixes = {
 
 
 def get_help():
-  all_tasks = get_system_tasks()[1] + PORTS
+  all_tasks = get_all_tasks()
   all_tasks.sort()
   return '''
 Available targets:
@@ -161,6 +162,10 @@ def get_system_tasks():
   system_libraries = system_libs.Library.get_all_variations()
   system_tasks = list(system_libraries.keys())
   return system_libraries, system_tasks
+
+
+def get_all_tasks():
+  return get_system_tasks()[1] + PORTS
 
 
 def main():
@@ -239,7 +244,10 @@ def main():
   for name, targets in task_targets.items():
     if targets is None:
       # Use target name as task
-      tasks.append(name)
+      if '*' in name:
+        tasks.extend(fnmatch.filter(get_all_tasks(), name))
+      else:
+        tasks.append(name)
     else:
       # There are some ports that we don't want to build as part
       # of ALL since the are not well tested or widely used:

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -3,6 +3,7 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
+import glob
 import os
 import platform
 import shutil
@@ -729,15 +730,23 @@ fi
     # Unless --force is specified
     self.assertContained('Building targets: zlib', self.do([EMBUILDER, 'build', 'zlib', 'MINIMAL', '--force']))
 
-  def test_embuilder_wasm_backend(self):
+  def test_embuilder(self):
     restore_and_set_up()
-    # the --lto flag makes us build wasm-bc
+    # the --lto flag makes us build LTO libraries
     self.clear_cache()
     self.run_process([EMBUILDER, 'build', 'libemmalloc'])
     self.assertExists(os.path.join(config.CACHE, 'sysroot', 'lib', 'wasm32-emscripten'))
     self.clear_cache()
     self.run_process([EMBUILDER, 'build', 'libemmalloc', '--lto'])
     self.assertExists(os.path.join(config.CACHE, 'sysroot', 'lib', 'wasm32-emscripten', 'lto'))
+
+  def test_embuilder_wildcards(self):
+    restore_and_set_up()
+    glob_match = os.path.join(config.CACHE, 'sysroot', 'lib', 'wasm32-emscripten', 'libwebgpu*.a')
+    self.run_process([EMBUILDER, 'clear', 'libwebgpu*'])
+    self.assertFalse(glob.glob(glob_match))
+    self.run_process([EMBUILDER, 'build', 'libwebgpu*'])
+    self.assertGreater(len(glob.glob(glob_match)), 3)
 
   def test_binaryen_version(self):
     restore_and_set_up()


### PR DESCRIPTION
This is very useful for doing things like `./embuild build libGL*` to `./embuilder clean libc*`.