### PR TITLE
[wasm64] Fix wasm64 memory read in Fetch.js

### DIFF
--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -320,7 +320,7 @@ function fetchXHR(fetch, onsuccess, onerror, onprogress, onreadystatechange) {
   function saveResponseAndStatus() {
     var ptr = 0;
     var ptrLen = 0;
-    if (xhr.response && fetchAttrLoadToMemory && HEAPU32[fetch + {{{ C_STRUCTS.emscripten_fetch_t.data }}} >> 2] === 0) {
+    if (xhr.response && fetchAttrLoadToMemory && {{{ makeGetValue('fetch', C_STRUCTS.emscripten_fetch_t.data, '*') }}} === 0) {
       ptrLen = xhr.response.byteLength;
     }
     if (ptrLen > 0) {

--- a/test/fetch/test_fetch_sync_xhr.cpp
+++ b/test/fetch/test_fetch_sync_xhr.cpp
@@ -15,8 +15,8 @@ int result = -1;
 int main() {
   // If an exception is thrown from the user callback, it bubbles up to
   // self.onerror but is otherwise completely swallowed by xhr.send.
-  EM_ASM({self.onerror = function() {
-           out('Got error');
+  EM_ASM({self.onerror = (e) => {
+           out('Got error', e);
            HEAP32[$0 >> 2] = 2;
          };}, &result);
   emscripten_fetch_attr_t attr;

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5908,6 +5908,16 @@ class browser64_4gb(browser):
     self.require_wasm64()
 
 
+class browser64_2gb(browser):
+  def setUp(self):
+    super().setUp()
+    self.set_setting('MEMORY64')
+    self.set_setting('INITIAL_MEMORY', '2200gb')
+    self.set_setting('GLOBAL_BASE', '2gb')
+    self.emcc_args.append('-Wno-experimental')
+    self.require_wasm64()
+
+
 class browser_2gb(browser):
   def setUp(self):
     super().setUp()


### PR DESCRIPTION
This bug only showed up under wasm64 when the address of the fetch object was between 2Gb and 4Gb.  This causes the JS ">> 2" operation to generate a negative number becuase the high bit is set:

```
$ node
> a = 2**31 + 10
2147483658
> a >> 2
-536870910
>
```

In `browser64_4gb` mode this bug resulted in a read from the first 4gb of memory somewhere, which results a in 0 whereas read from a negative address yields `undefined`.