### PR TITLE
Fix "emscripten emit" typo in Optimizing Code - WebAssembly section

### DIFF
--- a/site/source/docs/optimizing/Optimizing-Code.rst
+++ b/site/source/docs/optimizing/Optimizing-Code.rst
@@ -84,7 +84,7 @@ There are several flags you can :ref:`pass to the compiler <emcc-s-option-value>
 WebAssembly
 ===========
 
-Emscripten will emit WebAssembly by default. You can switch that off with ``-sWASM=0`` (in which case emscripten emit JavaScript), which is necessary if you want the output to run in places where Wasm support is not present yet, but the downside is larger and slower code.
+Emscripten emits WebAssembly by default. You can switch that off with ``-sWASM=0`` (in which case emscripten emits JavaScript), which is necessary if you want the output to run in places where Wasm support is not present yet, but the downside is larger and slower code.
 
 .. _optimizing-code-size:
 

--- a/site/source/docs/optimizing/Optimizing-Code.rst
+++ b/site/source/docs/optimizing/Optimizing-Code.rst
@@ -84,7 +84,7 @@ There are several flags you can :ref:`pass to the compiler <emcc-s-option-value>
 WebAssembly
 ===========
 
-Emscripten emits WebAssembly by default. You can switch that off with ``-sWASM=0`` (in which case emscripten emits JavaScript), which is necessary if you want the output to run in places where Wasm support is not present yet, but the downside is larger and slower code.
+Emscripten emits WebAssembly by default. You can switch that off with ``-sWASM=0`` (in which case emscripten will emit JavaScript), which is necessary if you want the output to run in places where Wasm support is not present yet, but the downside is larger and slower code.
 
 .. _optimizing-code-size:
 


### PR DESCRIPTION
Fixed typo in the sentence "in which case emscripten emit JavaScript". Also changed the tense in the first sentence, this avoids repetition and makes sense to me (what it already does by default vs what it will do with the flag). 