### PR TITLE
WebGPU: Swapchain getCurrentTexture

### DIFF
--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -1715,6 +1715,7 @@ sigs = {
   wgpuSurfaceGetPreferredFormat__sig: 'ipp',
   wgpuSurfaceReference__sig: 'vp',
   wgpuSurfaceRelease__sig: 'vp',
+  wgpuSwapChainGetCurrentTexture__sig: 'pp',
   wgpuSwapChainGetCurrentTextureView__sig: 'pp',
   wgpuSwapChainPresent__sig: 'vp',
   wgpuSwapChainReference__sig: 'vp',

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -2701,6 +2701,10 @@ var LibraryWebGPU = {
     return WebGPU.mgrSwapChain.create(context);
   },
 
+  wgpuSwapChainGetCurrentTexture: (swapChainId) => {
+    var context = WebGPU.mgrSwapChain.get(swapChainId);
+    return WebGPU.mgrTexture.create(context["getCurrentTexture"]());
+  },
   wgpuSwapChainGetCurrentTextureView: (swapChainId) => {
     var context = WebGPU.mgrSwapChain.get(swapChainId);
     return WebGPU.mgrTextureView.create(context["getCurrentTexture"]()["createView"]());

--- a/system/include/webgpu/webgpu.h
+++ b/system/include/webgpu/webgpu.h
@@ -1537,6 +1537,7 @@ typedef void (*WGPUProcSurfaceReference)(WGPUSurface surface) WGPU_FUNCTION_ATTR
 typedef void (*WGPUProcSurfaceRelease)(WGPUSurface surface) WGPU_FUNCTION_ATTRIBUTE;
 
 // Procs of SwapChain
+typedef WGPUTexture (*WGPUProcSwapChainGetCurrentTexture)(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
 typedef WGPUTextureView (*WGPUProcSwapChainGetCurrentTextureView)(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcSwapChainPresent)(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcSwapChainReference)(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
@@ -1775,6 +1776,7 @@ WGPU_EXPORT void wgpuSurfaceReference(WGPUSurface surface) WGPU_FUNCTION_ATTRIBU
 WGPU_EXPORT void wgpuSurfaceRelease(WGPUSurface surface) WGPU_FUNCTION_ATTRIBUTE;
 
 // Methods of SwapChain
+WGPU_EXPORT WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUTextureView wgpuSwapChainGetCurrentTextureView(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuSwapChainPresent(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuSwapChainReference(WGPUSwapChain swapChain) WGPU_FUNCTION_ATTRIBUTE;

--- a/system/include/webgpu/webgpu_cpp.h
+++ b/system/include/webgpu/webgpu_cpp.h
@@ -1137,7 +1137,7 @@ namespace wgpu {
         using ObjectBase::ObjectBase;
         using ObjectBase::operator=;
 
-        TextureView GetCurrentTexture() const;
+        Texture GetCurrentTexture() const;
         TextureView GetCurrentTextureView() const;
         void Present() const;
 

--- a/system/include/webgpu/webgpu_cpp.h
+++ b/system/include/webgpu/webgpu_cpp.h
@@ -1137,6 +1137,7 @@ namespace wgpu {
         using ObjectBase::ObjectBase;
         using ObjectBase::operator=;
 
+        TextureView GetCurrentTexture() const;
         TextureView GetCurrentTextureView() const;
         void Present() const;
 

--- a/system/lib/webgpu/webgpu_cpp.cpp
+++ b/system/lib/webgpu/webgpu_cpp.cpp
@@ -2585,6 +2585,10 @@ template <typename T>
     static_assert(sizeof(SwapChain) == sizeof(WGPUSwapChain), "sizeof mismatch for SwapChain");
     static_assert(alignof(SwapChain) == alignof(WGPUSwapChain), "alignof mismatch for SwapChain");
 
+    Texture SwapChain::GetCurrentTexture() const {
+        auto result = wgpuSwapChainGetCurrentTexture(Get());
+        return Texture::Acquire(result);
+    }
     TextureView SwapChain::GetCurrentTextureView() const {
         auto result = wgpuSwapChainGetCurrentTextureView(Get());
         return TextureView::Acquire(result);


### PR DESCRIPTION
Right now `getCurrentTextureView` is supported, but if one wants to use the current texture as a texture (in my case, for copying to/from) that is not possible. This exposes `getCurrentTexture` to the WebGPU lib.

This feature is also available on Dawn, so it works for compatibility reasons.