### PR TITLE
[Docs] Added note to clarify glfw3 port (contrib ports part 2.1)

### DIFF
--- a/site/source/docs/compiling/Contrib-Ports.rst
+++ b/site/source/docs/compiling/Contrib-Ports.rst
@@ -25,7 +25,7 @@ web/webassembly platform.
   These can be activated with the :ref:`settings <use_glfw>` ``-sUSE_GLFW=2``
   and ``-sUSE_GLFW=3``. This non-official contribution, written in C++,
   provides a more extensive and up-to-date implementation of the GLFW 3 API
-  than the in-built port. It is enabled with the option
+  than the built-in port. It is enabled with the option
   ``--use-port=contrib.glfw3``.
 
 `Project information <https://github.com/pongasoft/emscripten-glfw>`_

--- a/site/source/docs/compiling/Contrib-Ports.rst
+++ b/site/source/docs/compiling/Contrib-Ports.rst
@@ -17,7 +17,16 @@ available in emscripten. In order to use a contrib port you use the
 contrib.glfw3
 =============
 
-This project is an emscripten port of glfw written in C++ for the web/webassembly platform
+This project is an emscripten port of GLFW written in C++ for the
+web/webassembly platform.
+
+.. note::
+  emscripten includes support for both GLFW 2 and 3 written in Javascript.
+  These can be activated with the :ref:`settings <use_glfw>` ``-sUSE_GLFW=2``
+  and ``-sUSE_GLFW=3``. This non-official contribution, written in C++,
+  provides a more extensive and up-to-date implementation of the GLFW 3 API
+  than the in-built port. It is enabled with the option
+  ``--use-port=contrib.glfw3``.
 
 `Project information <https://github.com/pongasoft/emscripten-glfw>`_
 

--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -10,7 +10,7 @@ HASH = 'c3c96718e5d2b37df434a46c4a93ddfd9a768330d33f0d6ce2d08c139752894c2421cdd0
 
 # contrib port information (required)
 URL = 'https://github.com/pongasoft/emscripten-glfw'
-DESCRIPTION = 'This project is an emscripten port of glfw written in C++ for the web/webassembly platform'
+DESCRIPTION = 'This project is an emscripten port of GLFW written in C++ for the web/webassembly platform'
 LICENSE = 'Apache 2.0 license'
 
 


### PR DESCRIPTION
Hi @sbc100 

I thought about clarifying further the distinction between the contrib port and the built-in port. Although they have very different names, and the contrib port is in the contrib ports section, I can imagine that it could be confusing. I have updated the documentation to make it more clear.

Let me know if you think that is a good idea or if you want to tweak the wording.

Thank you