### PR TITLE
docs: EXPORT_ES6 implicit behavior.

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1619,7 +1619,9 @@ EXPORT_ES6
 ==========
 
 Export using an ES6 Module export rather than a UMD export.  MODULARIZE must
-be enabled for ES6 exports.
+be enabled for ES6 exports and is implicitly enabled if not already set.
+
+This is implicitly enabled if the output suffix is set to 'mjs'.
 
 .. _use_es6_import_meta:
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1276,7 +1276,10 @@ var DETERMINISTIC = false;
 var MODULARIZE = false;
 
 // Export using an ES6 Module export rather than a UMD export.  MODULARIZE must
-// be enabled for ES6 exports.
+// be enabled for ES6 exports and is implicitly enabled if not already set.
+//
+// This is implicitly enabled if the output suffix is set to 'mjs'.
+//
 // [link]
 var EXPORT_ES6 = false;
 


### PR DESCRIPTION
* It is implicitly enabled for .mjs output.
* MODULARIZE is implicitly enabled when EXPORT_ES6 is set.