### PR TITLE
Add option to emit TypeScript definitions for Wasm module exports.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -140,6 +140,7 @@ class EmccOptions:
     self.ignore_dynamic_linking = False
     self.shell_path = None
     self.source_map_base = ''
+    self.emit_tsd = ''
     self.embind_emit_tsd = ''
     self.emrun = False
     self.cpu_profiler = False
@@ -1276,6 +1277,9 @@ def parse_args(newargs):
       options.source_map_base = consume_arg()
     elif check_arg('--embind-emit-tsd'):
       options.embind_emit_tsd = consume_arg()
+    elif check_arg('--emit-tsd'):
+      diagnostics.warning('experimental', '--emit-tsd is still experimental. Not all definitions are generated.')
+      options.emit_tsd = consume_arg()
     elif check_flag('--no-entry'):
       options.no_entry = True
     elif check_arg('--js-library'):

--- a/src/embind/embind_gen.js
+++ b/src/embind/embind_gen.js
@@ -365,7 +365,7 @@ var LibraryEmbind = {
         def.print(this.typeToJsName.bind(this), out);
       }
       // Print module definitions
-      out.push('export interface MainModule {\n');
+      out.push('interface EmbindModule {\n');
       for (const def of this.definitions) {
         if (!def.printModuleEntry) {
           continue;

--- a/test/other/embind_tsgen_bigint.d.ts
+++ b/test/other/embind_tsgen_bigint.d.ts
@@ -1,3 +1,8 @@
-export interface MainModule {
+// TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
+interface WasmModule {
+}
+
+interface EmbindModule {
   bigintFn(_0: bigint): bigint;
 }
+export type MainModule = WasmModule & EmbindModule;

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -1,6 +1,13 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
 interface WasmModule {
+  _pthread_self(): number;
   _main(_0: number, _1: number): number;
+  __emscripten_tls_init(): number;
+  __emscripten_proxy_main(_0: number, _1: number): number;
+  __embind_initialize_bindings(): void;
+  __emscripten_thread_init(_0: number, _1: number, _2: number, _3: number, _4: number, _5: number): void;
+  __emscripten_thread_crashed(): void;
+  __emscripten_thread_exit(_0: number): void;
 }
 
 export interface Test {

--- a/test/other/embind_tsgen_ignore_2.d.ts
+++ b/test/other/embind_tsgen_ignore_2.d.ts
@@ -1,6 +1,5 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
 interface WasmModule {
-  _main(_0: number, _1: number): number;
 }
 
 export interface Test {

--- a/test/other/embind_tsgen_memory64.d.ts
+++ b/test/other/embind_tsgen_memory64.d.ts
@@ -1,3 +1,8 @@
-export interface MainModule {
+// TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
+interface WasmModule {
+}
+
+interface EmbindModule {
   longFn(_0: bigint): bigint;
 }
+export type MainModule = WasmModule & EmbindModule;

--- a/test/other/test_emit_tsd.c
+++ b/test/other/test_emit_tsd.c
@@ -1,0 +1,10 @@
+#include <emscripten.h>
+
+EMSCRIPTEN_KEEPALIVE void fooVoid() {}
+EMSCRIPTEN_KEEPALIVE int fooInt(int a, int b) {
+  return 42;
+}
+
+int main() {
+
+}

--- a/test/other/test_emit_tsd.d.ts
+++ b/test/other/test_emit_tsd.d.ts
@@ -1,0 +1,8 @@
+// TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
+interface WasmModule {
+  _fooVoid(): void;
+  _fooInt(_0: number, _1: number): number;
+  _main(_0: number, _1: number): number;
+}
+
+export type MainModule = WasmModule;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3083,14 +3083,14 @@ int f() {
                   '-lembind', # Test duplicated link option.
                   ]
     self.emcc(test_file('other/embind_tsgen.cpp'), extra_args)
-    self.assertFileContents(test_file('other/embind_tsgen.d.ts'), read_file('embind_tsgen.d.ts'))
+    self.assertFileContents(test_file('other/embind_tsgen_ignore_1.d.ts'), read_file('embind_tsgen.d.ts'))
     # Test these args separately since they conflict with arguments in the first test.
     extra_args = ['-sMODULARIZE',
                   '--embed-file', 'fail.js',
                   '-sMINIMAL_RUNTIME=2',
                   '-sEXPORT_ES6=1']
     self.emcc(test_file('other/embind_tsgen.cpp'), extra_args)
-    self.assertFileContents(test_file('other/embind_tsgen.d.ts'), read_file('embind_tsgen.d.ts'))
+    self.assertFileContents(test_file('other/embind_tsgen_ignore_2.d.ts'), read_file('embind_tsgen.d.ts'))
 
   def test_embind_tsgen_test_embind(self):
     self.run_process([EMCC, test_file('embind/embind_test.cpp'),
@@ -3135,6 +3135,12 @@ int f() {
     # Test that when method pointers are allocated at different addresses that
     # AOT JS generation still works correctly.
     self.do_runf('other/embind_jsgen_method_pointer_stability.cpp', 'done')
+
+  def test_emit_tsd(self):
+    self.run_process([EMCC, test_file('other/test_emit_tsd.c'),
+                      '--emit-tsd', 'test_emit_tsd.d.ts', '-Wno-experimental'] +
+                     self.get_emcc_args())
+    self.assertFileContents(test_file('other/test_emit_tsd.d.ts'), read_file('test_emit_tsd.d.ts'))
 
   def test_emconfig(self):
     output = self.run_process([emconfig, 'LLVM_ROOT'], stdout=PIPE).stdout.strip()

--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -258,7 +258,7 @@ def get_function_exports(module):
   rtn = {}
   for e in module.get_exports():
     if e.kind == webassembly.ExternType.FUNC:
-      rtn[e.name] = len(module.get_function_type(e.index).params)
+      rtn[e.name] = module.get_function_type(e.index)
   return rtn
 
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -1832,13 +1832,13 @@ def phase_post_link(options, state, in_wasm, wasm_target, target, js_syms):
 
   settings.TARGET_JS_NAME = os.path.basename(state.js_target)
 
-  phase_emscript(options, in_wasm, wasm_target, js_syms)
+  metadata = phase_emscript(options, in_wasm, wasm_target, js_syms)
 
   if settings.EMBIND_AOT:
     phase_embind_aot(wasm_target, js_syms)
 
-  if options.embind_emit_tsd:
-    phase_embind_emit_tsd(options, wasm_target, js_syms)
+  if options.embind_emit_tsd or options.emit_tsd:
+    phase_emit_tsd(options, wasm_target, js_syms, metadata)
 
   if options.js_transform:
     phase_source_transforms(options)
@@ -1865,8 +1865,9 @@ def phase_emscript(options, in_wasm, wasm_target, js_syms):
   if shared.SKIP_SUBPROCS:
     return
 
-  emscripten.emscript(in_wasm, wasm_target, final_js, js_syms)
+  metadata = emscripten.emscript(in_wasm, wasm_target, final_js, js_syms)
   save_intermediate('original')
+  return metadata
 
 
 def run_embind_gen(wasm_target, js_syms, extra_settings):
@@ -1920,12 +1921,21 @@ def run_embind_gen(wasm_target, js_syms, extra_settings):
   return out
 
 
-@ToolchainProfiler.profile_block('embind emit tsd')
-def phase_embind_emit_tsd(options, wasm_target, js_syms):
+@ToolchainProfiler.profile_block('emit tsd')
+def phase_emit_tsd(options, wasm_target, js_syms, metadata):
   logger.debug('emit tsd')
-  out = run_embind_gen(wasm_target, js_syms, {'EMBIND_JS': False})
-  out_file = os.path.join(os.path.dirname(wasm_target), options.embind_emit_tsd)
-  write_file(out_file, out)
+  filename = ''
+  # Support using either option for now, but prefer emit_tsd if specified.
+  if options.emit_tsd:
+    filename = options.emit_tsd
+  else:
+    filename = options.embind_emit_tsd
+  embind_tsd = ''
+  if settings.EMBIND:
+    embind_tsd = run_embind_gen(wasm_target, js_syms, {'EMBIND_JS': False})
+  all_tsd = emscripten.create_tsd(metadata, embind_tsd)
+  out_file = os.path.join(os.path.dirname(wasm_target), filename)
+  write_file(out_file, all_tsd)
 
 
 @ToolchainProfiler.profile_block('embind aot js')


### PR DESCRIPTION
The new flag `--emit-tsd <filename>` will generate a TypeScript defintion file for any Wasm module exports. If embind is also used the definitions for those types will also be included in the same file.

This still doesn't give the full picture of Wasm module e.g. missing HEAP<N> and the various helper functions defined in JS.