### PR TITLE
Don't run PThread.initMainThread() on Wasm Workers. Fixes #20279.

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -93,14 +93,10 @@ var LibraryPThread = {
 #if ASSERTIONS
       PThread.debugInit();
 #endif
-      if (ENVIRONMENT_IS_PTHREAD
-#if AUDIO_WORKLET
-        || ENVIRONMENT_IS_AUDIO_WORKLET
-#endif
-        ) {
-        PThread.initWorker();
-      } else {
+      if ({{{ ENVIRONMENT_IS_MAIN_THREAD() }}}) {
         PThread.initMainThread();
+      } else {
+        PThread.initWorker();
       }
     },
     initMainThread() {

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -1080,6 +1080,15 @@ function implicitSelf() {
   return ENVIRONMENT.includes('node') ? 'self.' : '';
 }
 
+function ENVIRONMENT_IS_MAIN_THREAD() {
+  var envs = [];
+  if (PTHREADS) envs.push('ENVIRONMENT_IS_PTHREAD');
+  if (WASM_WORKERS) envs.push('ENVIRONMENT_IS_WASM_WORKER');
+  if (AUDIO_WORKLET) envs.push('ENVIRONMENT_IS_AUDIO_WORKLET');
+  if (envs.length == 0) return 'true';
+  return '(!(' + envs.join('||') + '))';
+}
+
 addToCompileTimeContext({
   ATEXITS,
   ATINITS,
@@ -1097,6 +1106,7 @@ addToCompileTimeContext({
   STACK_ALIGN,
   TARGET_NOT_SUPPORTED,
   WASM_PAGE_SIZE,
+  ENVIRONMENT_IS_MAIN_THREAD,
   addAtExit,
   addAtInit,
   addReadyPromiseAssertions,


### PR DESCRIPTION
One could argue we shouldn't even run PThread.initWorker() on WASM_WORKERS or AUDIO_WORKLETS, but looking at the current contents of that function, it should be safe to do so (and may lead to some useful functionality), so leaving that in for now.