### PR TITLE
[NFC] Assert we do not use --low-memory-unused when STACK_FIRST

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8194,7 +8194,6 @@ int main() {
     # sizes must be different, as the flag has an impact
     self.assertEqual(len(set(sizes)), 2)
 
-  @uses_canonical_tmp
   @parameterized({
     # In a simple -O0 build we do not set --low-memory-unused (as the stack is
     # first, which is nice for debugging but bad for code size (larger globals)
@@ -8205,13 +8204,12 @@ int main() {
     # But a low global base prevents it.
     'O2_GB_512': (['-O2', '-sGLOBAL_BASE=512'], False),
     # A large-enough global base allows it.
-    'O2_GB_512': (['-O2', '-sGLOBAL_BASE=1024'], True),
+    'O2_GB_1024': (['-O2', '-sGLOBAL_BASE=1024'], True),
   })
   def test_binaryen_low_memory_unused(self, args, low_memory_unused):
-    with env_modify({'EMCC_DEBUG': '1'}):
-      cmd = [EMCC, test_file('hello_world.c')] + args
-      err = self.run_process(cmd, stdout=PIPE, stderr=PIPE).stderr
-      self.assertContainedIf('--low-memory-unused ', err, low_memory_unused)
+    cmd = [EMCC, test_file('hello_world.c'), '-v'] + args
+    err = self.run_process(cmd, stdout=PIPE, stderr=PIPE).stderr
+    self.assertContainedIf('--low-memory-unused ', err, low_memory_unused)
 
   def test_binaryen_passes_extra(self):
     def build(args):

--- a/tools/link.py
+++ b/tools/link.py
@@ -357,12 +357,10 @@ def get_binaryen_passes(memfile):
   if optimizing:
     passes += [building.opt_level_to_str(settings.OPT_LEVEL, settings.SHRINK_LEVEL)]
   # when optimizing, use the fact that low memory is never used (1024 is a
-  # hardcoded value in the binaryen pass)
-  if optimizing and settings.GLOBAL_BASE >= 1024:
+  # hardcoded value in the binaryen pass). we also cannot do it when the stack
+  # is first, as then the stack is in the low memory that should be unused.
+  if optimizing and settings.GLOBAL_BASE >= 1024 and not settings.STACK_FIRST:
     passes += ['--low-memory-unused']
-    # we cannot do this if the stack is first, but we only put it first if not
-    # optimizing
-    assert not settings.STACK_FIRST
   if settings.AUTODEBUG:
     # adding '--flatten' here may make these even more effective
     passes += ['--instrument-locals']

--- a/tools/link.py
+++ b/tools/link.py
@@ -360,6 +360,9 @@ def get_binaryen_passes(memfile):
   # hardcoded value in the binaryen pass)
   if optimizing and settings.GLOBAL_BASE >= 1024:
     passes += ['--low-memory-unused']
+    # we cannot do this if the stack is first, but we only put it first if not
+    # optimizing
+    assert not settings.STACK_FIRST
   if settings.AUTODEBUG:
     # adding '--flatten' here may make these even more effective
     passes += ['--instrument-locals']


### PR DESCRIPTION
Assuming low memory was unused when the stack was first - which is where low
memory is - would be wrong. We never did that wrong thing as we only use that
optimization when not optimizing. Add an assertion + tests to prevent regressions.