### PR TITLE
file_packager: fix computation of `remote_package_name` when package is not at root

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -752,7 +752,7 @@ def generate_js(data_target, data_files, metadata):
 
     package_name = data_target
     remote_package_size = os.path.getsize(package_name)
-    remote_package_name = os.path.basename(package_name)
+    remote_package_name = os.path.relpath(package_name)
     ret += '''
       var PACKAGE_PATH = '';
       if (typeof window === 'object') {


### PR DESCRIPTION
fixes #21289
