### PR TITLE
Don't include `main.c` in libSDL_mixer

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3405,7 +3405,7 @@ Module["preRun"] = () => {
 
   @no_wasm64('SDL2 + wasm64')
   @parameterized({
-    'dash_s': (['-sUSE_SDL=2', '-sUSE_SDL_MIXER=2'],),
+    '': (['-sUSE_SDL=2', '-sUSE_SDL_MIXER=2'],),
     'dash_l': (['-lSDL2', '-lSDL2_mixer'],),
   })
   @requires_sound_hardware

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -83,6 +83,7 @@ def get(ports, settings, shared):
       exclude_files=[
         'playmus.c',
         'playwave.c',
+        'main.c',
       ],
       exclude_dirs=[
         'native_midi',


### PR DESCRIPTION
This was broken when sdl2_mixer was updated recently in in #21013.

Fixes: #21321