### PR TITLE
library_idbfs.js: Handle `transaction.onabort` in `reconcile()`

### DIFF
--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -269,8 +269,9 @@ addToLibrary({
         }
       };
 
-      transaction.onerror = (e) => {
-        done(this.error);
+      // transaction may abort if (for example) there is a QuotaExceededError
+      transaction.onerror = transaction.onabort = (e) => {
+        done(e.target.error);
         e.preventDefault();
       };
 
@@ -278,12 +279,6 @@ addToLibrary({
         if (!errored) {
           callback(null);
         }
-      };
-
-      // transaction may abort if (for example) there is a QuotaExceededError
-      transaction.onabort = (e) => {
-        done(e.target.error); // DOMException
-        e.preventDefault();
       };
 
       // sort paths in ascending order so directory entries are created

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -280,6 +280,12 @@ addToLibrary({
         }
       };
 
+      // transaction may abort if (for example) there is a QuotaExceededError
+      transaction.onabort = (e) => {
+        done(e.target.error); // DOMException
+        e.preventDefault();
+      };
+
       // sort paths in ascending order so directory entries are created
       // before the files inside them
       create.sort().forEach((path) => {


### PR DESCRIPTION
If the transaction aborts (which can happen due to, for example, a `QuotaExceededError`), `onabort` must be handled to ensure that the `callback` actually gets called.

Fixes: #21325