### PR TITLE
Allow comments in response files.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -44,6 +44,8 @@ See docs/process.md for more on how version tagging works.
   #21276)
 - Added concept of external ports which live outside emscripten and are
   loaded on demand using the syntax `--use-port=/path/to/my_port.py` (#21316)
+- Allow comments in response files. Any line starting with `#` is now ignored.
+  This is useful when listing exported symbols. (#21330)
 
 
 3.1.53 - 01/29/24

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -147,6 +147,9 @@ Options that are modified or new in *emcc* are listed below:
 
      * The specified file path must be absolute, not relative.
 
+     * The file may contain comments where the first character of the
+       line is "'#'".
+
    Note:
 
      Options can be specified as a single argument with or without a

--- a/emcc.py
+++ b/emcc.py
@@ -1450,7 +1450,7 @@ def parse_symbol_list_file(contents):
   kind of quoting or escaping.
   """
   values = contents.splitlines()
-  return [v.strip() for v in values]
+  return [v.strip() for v in values if not v.startswith('#')]
 
 
 def parse_value(text, expected_type):

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -134,6 +134,8 @@ Options that are modified or new in *emcc* are listed below:
 
     - In this case the file should contain a list of symbols, one per line.  For legacy use cases JSON-formatted files are also supported: e.g. ``["_func1", "func2"]``.
     - The specified file path must be absolute, not relative.
+    - The file may contain comments where the first character of the line is ``'#'``.
+
 
   .. note:: Options can be specified as a single argument with or without a space
             between the ``-s`` and option name.  e.g. ``-sFOO`` or ``-s FOO``.

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7714,6 +7714,10 @@ high = 1234
     self.run_process([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS=@response_file.txt'])
     self.run_process([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS=@response_file.json'])
 
+  def test_dash_s_response_file_list_with_comments(self):
+    create_file('response_file.txt', '_main\n#_nope_ish_nope\n_malloc\n')
+    self.run_process([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS=@response_file.txt'])
+
   def test_dash_s_response_file_misssing(self):
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS=@foo'])
     self.assertContained('error: foo: file not found parsing argument: EXPORTED_FUNCTIONS=@foo', err)


### PR DESCRIPTION
It can be useful to have comments in a response file for exported symbols to explain what some stuff might be in there for.