### PR TITLE
[wasm64] Run all browser tests in 4gb mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -814,24 +814,12 @@ jobs:
           test_targets: "browser_2gb"
   test-browser-chrome-wasm64-4gb:
     executor: bionic
+    environment:
+      EMTEST_SKIP_NODE_CANARY: "1"
     steps:
       - run-tests-chrome:
           title: "browser64_4gb"
-          test_targets: "
-            browser64_4gb.test_TextDecoder*
-            browser64_4gb.test_async_*
-            browser64_4gb.test_audio_worklet*
-            browser64_4gb.test_emscripten_log
-            browser64_4gb.test_clientside_vertex_arrays_es3
-            browser64_4gb.test_fetch*
-            browser64_4gb.test_emscripten_animate_canvas_element_size_manual_css
-            browser64_4gb.test_fulles2_sdlproc
-            browser64_4gb.test_html5_webgl_create_context*
-            browser64_4gb.test_sdl_image
-            browser64_4gb.test_wasm_worker*
-            browser64_4gb.test_cube_explosion
-            browser64_4gb.test_cubegeom_*
-            "
+          test_targets: "browser64_4gb"
   test-browser-firefox:
     executor: bionic
     steps:

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2273,7 +2273,7 @@ var LibraryHTML5 = {
       }
 #if OFFSCREENCANVAS_SUPPORT
     } else if (canvas.canvasSharedPtr) {
-      var targetThread = {{{ makeGetValue('canvas.canvasSharedPtr', 8, 'i32') }}};
+      var targetThread = {{{ makeGetValue('canvas.canvasSharedPtr', 8, '*') }}};
       setOffscreenCanvasSizeOnTargetThread(targetThread, target, width, height);
       return {{{ cDefs.EMSCRIPTEN_RESULT_DEFERRED }}}; // This will have to be done asynchronously
 #endif

--- a/src/library_idbstore.js
+++ b/src/library_idbstore.js
@@ -103,7 +103,7 @@ var LibraryIDBStore = {
       }
       var buffer = _malloc(byteArray.length); // must be freed by the caller!
       HEAPU8.set(byteArray, buffer);
-      {{{ makeSetValue('pbuffer', 0, 'buffer', 'i32') }}};
+      {{{ makeSetValue('pbuffer', 0, 'buffer', '*') }}};
       {{{ makeSetValue('pnum',    0, 'byteArray.length', 'i32') }}};
       {{{ makeSetValue('perror',  0, '0', 'i32') }}};
       wakeUp();

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -875,7 +875,7 @@ var LibraryPThread = {
     // owns the OffscreenCanvas.
     for (var canvas of Object.values(offscreenCanvases)) {
       // pthread ptr to the thread that owns this canvas.
-      {{{ makeSetValue('canvas.canvasSharedPtr', 8, 'pthread_ptr', 'i32') }}};
+      {{{ makeSetValue('canvas.canvasSharedPtr', 8, 'pthread_ptr', '*') }}};
     }
 #endif
 

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1731,7 +1731,8 @@ for (/**@suppress{duplicate}*/var i = 0; i < {{{ GL_POOL_TEMP_BUFFERS_SIZE }}}; 
         GLctx.readPixels(x, y, width, height, format, type, pixels);
       } else {
         var heap = heapObjectForWebGLType(type);
-        GLctx.readPixels(x, y, width, height, format, type, heap, toTypedArrayIndex(pixels, heap));
+        var target = toTypedArrayIndex(pixels, heap);
+        GLctx.readPixels(x, y, width, height, format, type, heap, target);
       }
       return;
     }
@@ -3310,7 +3311,7 @@ for (/**@suppress{duplicate}*/var i = 0; i < {{{ GL_POOL_TEMP_BUFFERS_SIZE }}}; 
     if (length) {{{ makeSetValue('length', '0', 'numBytesWrittenExclNull', 'i32') }}};
   },
 
-  glGetShaderiv : (shader, pname, p) => {
+  glGetShaderiv: (shader, pname, p) => {
     if (!p) {
       // GLES2 specification does not specify how to behave if p is a null
       // pointer. Since calling this function does not make sense if p == null,

--- a/test/browser/webgl2_garbage_free_entrypoints.cpp
+++ b/test/browser/webgl2_garbage_free_entrypoints.cpp
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
   glDrawArrays(GL_TRIANGLES, 0, 6);
 
   unsigned char pixel[4];
-  glReadPixels(1,1,1,1,GL_RGBA,GL_UNSIGNED_BYTE, pixel);
+  glReadPixels(1, 1, 1, 1, GL_RGBA,GL_UNSIGNED_BYTE, pixel);
   printf("%d,%d,%d,%d\n", pixel[0], pixel[1], pixel[2], pixel[3]);
   assert(pixel[0] == 255);
   assert(pixel[1] == 178);

--- a/test/browser/webgl2_get_buffer_sub_data.cpp
+++ b/test/browser/webgl2_get_buffer_sub_data.cpp
@@ -21,10 +21,19 @@ int main()
   glBindBuffer(GL_ARRAY_BUFFER, buffer);
   glBufferData(GL_ARRAY_BUFFER, sizeof(data), data, GL_STATIC_DRAW);
 
-  uint8_t data2[8] = {};
+  uint8_t data2[8] = { 1, 1, 1, 1, 1, 1, 1, 1 };
 
   // Test full buffer read
   glGetBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(data), data2);
+  printf("read data: %x %x %x %x %x %x %x %x\n",
+         data2[0],
+         data2[1],
+         data2[2],
+         data2[3],
+         data2[4],
+         data2[5],
+         data2[6],
+         data2[7]);
   assert(!memcmp(data, data2, sizeof(data)));
 
   // Test partial buffer read

--- a/test/resize_offscreencanvas_from_main_thread.cpp
+++ b/test/resize_offscreencanvas_from_main_thread.cpp
@@ -14,8 +14,7 @@
 // If not defined, the pthread that owns the OffscreenCanvas is using emscripten_set_main_loop() so periodically yields back to the event loop.
 // #define TEST_SYNC_BLOCKING_LOOP
 
-void thread_local_main_loop()
-{
+void thread_local_main_loop() {
   int w = 0, h = 0;
   emscripten_get_canvas_element_size("#canvas", &w, &h);
   if (w == 699 && h == 299) {
@@ -27,11 +26,10 @@ void thread_local_main_loop()
 
     emscripten_force_exit(0);
   }
-  printf("%dx%d\n", w, h);
+  printf("thread_local_main_loop: %dx%d\n", w, h);
 }
 
-void *thread_main(void *arg)
-{
+void *thread_main(void *arg) {
   EmscriptenWebGLContextAttributes attr;
   emscripten_webgl_init_context_attributes(&attr);
   attr.explicitSwapControl = EM_TRUE;
@@ -57,14 +55,13 @@ void *thread_main(void *arg)
   return 0;
 }
 
-void resize_canvas(void *)
-{
+void resize_canvas(void* arg) {
   // Test that on the main thread, we can observe size changes to the canvas size.
   int w, h;
   emscripten_get_canvas_element_size("#canvas", &w, &h);
+  printf("Main thread saw canvas to get resized to %dx%d.\n", w, h);
   assert(w == 355 && "We did not observe the effect of pthread having resized OffscreenCanvas");
   assert(h == 233);
-  printf("Main thread saw canvas to get resized to %dx%d.\n", w, h);
 
   // Test that on the main thread, we can also change the size. (pthread listens to see this)
   printf("Main thread resizing OffscreenCanvas to size 699x299.\n");
@@ -72,16 +69,14 @@ void resize_canvas(void *)
 }
 
 //should be able to do this regardless of offscreen canvas support
-void get_canvas_size()
-{
+void get_canvas_size() {
   int w, h;
   emscripten_get_canvas_element_size("#canvas", &w, &h);
   assert(h == 150);
   assert(w == 300);
 }
 
-int main()
-{
+int main() {
   get_canvas_size();
   if (!emscripten_supports_offscreencanvas()) {
     printf("Current browser does not support OffscreenCanvas. Skipping the rest of the tests.\n");

--- a/test/runtime_misuse.cpp
+++ b/test/runtime_misuse.cpp
@@ -11,7 +11,7 @@ extern "C" {
 int noted = 0;
 
 char* EMSCRIPTEN_KEEPALIVE note(int n) {
-  EM_ASM({ Module.noted = Number($0); out("set noted " + Module.noted) }, (long)&noted);
+  EM_ASM({ Module.noted = Number($0); out("set noted " + Module.noted) }, &noted);
   EM_ASM({ out([$0, $1]) }, n, noted);
   noted += n;
   EM_ASM({ out(['noted is now', $0]) }, noted);

--- a/test/runtime_misuse_2.cpp
+++ b/test/runtime_misuse_2.cpp
@@ -11,7 +11,7 @@ extern "C" {
 int noted = 0;
 
 char* EMSCRIPTEN_KEEPALIVE note(int n) {
-  EM_ASM({ Module.noted = Number($0) }, (long)&noted);
+  EM_ASM({ Module.noted = Number($0); out("set noted " + Module.noted) }, &noted);
   EM_ASM({ out([$0, $1]) }, n, noted);
   noted += n;
   EM_ASM({ out(['noted is now', $0]) }, noted);


### PR DESCRIPTION
There are still 5 tests for which I've failed to figure out what is broken, and
they are marked as "failure to render" because no error is reported other
than the reference image not being produced.