### PR TITLE
[test] Improve test_sdl2_key/mouse. NFC

### DIFF
--- a/test/browser/test_sdl2_key.c
+++ b/test/browser/test_sdl2_key.c
@@ -19,14 +19,14 @@ int EventHandler(void *userdata, SDL_Event *event) {
       break;
     case SDL_KEYDOWN:
       switch (event->key.keysym.sym) {
-        case SDLK_RIGHT: printf("right\n"); result *= 7; break;
-        case SDLK_LEFT: printf("left\n"); result *= 11; break;
-        case SDLK_DOWN: printf("down\n"); result *= 13; break;
-        case SDLK_UP: printf("up\n"); result *= 17; break;
-        case SDLK_a: printf("a\n"); result *= 19; break;
+        case SDLK_RIGHT: printf("KEYDOWN: right\n"); result *= 7; break;
+        case SDLK_LEFT: printf("KEYDOWN: left\n"); result *= 11; break;
+        case SDLK_DOWN: printf("KEYDOWN: down\n"); result *= 13; break;
+        case SDLK_UP: printf("KEYDOWN: up\n"); result *= 17; break;
+        case SDLK_a: printf("KEYDOWN: a\n"); result *= 19; break;
         default: {
           if (event->key.keysym.scancode == SDL_SCANCODE_B) {
-            printf("b scancode\n"); result *= 23; break;
+            printf("KEYDOWN: b scancode\n"); result *= 23; break;
           }
           printf("unknown key: sym %d scancode %d\n", event->key.keysym.sym, event->key.keysym.scancode);
           emscripten_force_exit(result); // comment this out to leave event handling active. Use the following to log DOM keys:
@@ -35,8 +35,9 @@ int EventHandler(void *userdata, SDL_Event *event) {
       }
       break;
     case SDL_TEXTINPUT:
+      printf("TEXTINPUT: %c\n", event->text.text[0]);
       if (event->text.text[0] == 'A') {
-        printf("a\n");result *= 5;
+        result *= 5;
       }
       break;
     default: /* Report an unhandled event */
@@ -45,13 +46,11 @@ int EventHandler(void *userdata, SDL_Event *event) {
   return 0;
 }
 
-void one() {
-#ifndef TEST_EMSCRIPTEN_SDL_SETEVENTHANDLER
+void pump_events() {
   SDL_Event event;
   while (SDL_PollEvent(&event)) {
     EventHandler(0, &event);
   }
-#endif
 }
 
 int main(int argc, char **argv) {
@@ -60,12 +59,6 @@ int main(int argc, char **argv) {
   window = SDL_CreateWindow("sdl2_key",
                             SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
                             640, 480, 0);
-
-#ifdef TEST_EMSCRIPTEN_SDL_SETEVENTHANDLER
-  emscripten_SDL_SetEventHandler(EventHandler, 0);
-#else
-  one();
-#endif
 
   SDL_StartTextInput();
 
@@ -77,7 +70,7 @@ int main(int argc, char **argv) {
   emscripten_run_script("keydown(66);keyup(66);"); // b
   emscripten_run_script("keydown(100);keyup(100);"); // trigger the end
 
-  emscripten_exit_with_live_runtime();
+  emscripten_set_main_loop(pump_events, 3, 0);
   return 99;
 }
 

--- a/test/browser/test_sdl2_mouse.c
+++ b/test/browser/test_sdl2_mouse.c
@@ -71,8 +71,6 @@ void one() {
   }
 }
 
-void main_2(void* arg);
-
 int main() {
   SDL_Init(SDL_INIT_VIDEO);
   SDL_Window *window;
@@ -84,17 +82,11 @@ int main() {
   SDL_Rect rect = { 0, 0, 600, 450 };
   SDL_RenderFillRect(renderer, &rect);
 
-  emscripten_async_call(main_2, NULL, 3000); // avoid startup delays and intermittent errors
-
-  return 99;
-}
-
-void main_2(void* arg) {
-  emscripten_run_script("window.simulateMouseEvent(10, 20, -1)"); // move from 0,0 to 10,20
-  emscripten_run_script("window.simulateMouseEvent(10, 20, 0)"); // click
-  emscripten_run_script("window.simulateMouseEvent(10, 20, 0)"); // click some more, but this one should be ignored through PeepEvent
-  emscripten_run_script("window.simulateMouseEvent(30, 70, -1)"); // move some more
-  emscripten_run_script("window.simulateMouseEvent(30, 70, 1)"); // trigger the end
+  emscripten_run_script("simulateMouseEvent(10, 20, -1)"); // move from 0,0 to 10,20
+  emscripten_run_script("simulateMouseEvent(10, 20, 0)"); // click
+  emscripten_run_script("simulateMouseEvent(10, 20, 0)"); // click some more, but this one should be ignored through PeepEvent
+  emscripten_run_script("simulateMouseEvent(30, 70, -1)"); // move some more
+  emscripten_run_script("simulateMouseEvent(30, 70, 1)"); // trigger the end
 
   emscripten_set_main_loop(one, 0, 0);
 }

--- a/test/browser/test_sdl_mouse.c
+++ b/test/browser/test_sdl_mouse.c
@@ -70,17 +70,11 @@ int main() {
   SDL_Rect rect = { 0, 0, 600, 450 };
   SDL_FillRect(screen, &rect, 0x2244ffff);
 
-  emscripten_async_call(main_2, NULL, 3000); // avoid startup delays and intermittent errors
-
-  return 99;
-}
-
-void main_2(void* arg) {
-  emscripten_run_script("window.simulateMouseEvent(10, 20, -1)"); // move from 0,0 to 10,20
-  emscripten_run_script("window.simulateMouseEvent(10, 20, 0)"); // click
-  emscripten_run_script("window.simulateMouseEvent(10, 20, 0)"); // click some more, but this one should be ignored through PeepEvent
-  emscripten_run_script("window.simulateMouseEvent(30, 77, -1)"); // move some more
-  emscripten_run_script("window.simulateMouseEvent(30, 77, 1)"); // trigger the end
+  emscripten_run_script("simulateMouseEvent(10, 20, -1)"); // move from 0,0 to 10,20
+  emscripten_run_script("simulateMouseEvent(10, 20, 0)"); // click
+  emscripten_run_script("simulateMouseEvent(10, 20, 0)"); // click some more, but this one should be ignored through PeepEvent
+  emscripten_run_script("simulateMouseEvent(30, 77, -1)"); // move some more
+  emscripten_run_script("simulateMouseEvent(30, 77, 1)"); // trigger the end
 
   emscripten_set_main_loop(one, 0, 0);
 }

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1046,7 +1046,7 @@ keydown(100);keyup(100); // trigger the end
 
   def test_sdl_mouse(self):
     create_file('pre.js', '''
-      function simulateMouseEvent(x, y, button) {
+      globalThis.simulateMouseEvent = (x, y, button) => {
         var event = document.createEvent("MouseEvents");
         if (button >= 0) {
           var event1 = document.createEvent("MouseEvents");
@@ -1070,14 +1070,13 @@ keydown(100);keyup(100); // trigger the end
           Module['canvas'].dispatchEvent(event1);
         }
       }
-      window['simulateMouseEvent'] = simulateMouseEvent;
     ''')
 
     self.btest_exit('test_sdl_mouse.c', args=['-O2', '--minify=0', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
 
   def test_sdl_mouse_offsets(self):
     create_file('pre.js', '''
-      function simulateMouseEvent(x, y, button) {
+      globalThis.simulateMouseEvent = (x, y, button) => {
         var event = document.createEvent("MouseEvents");
         if (button >= 0) {
           var event1 = document.createEvent("MouseEvents");
@@ -1101,7 +1100,6 @@ keydown(100);keyup(100); // trigger the end
           Module['canvas'].dispatchEvent(event1);
         }
       }
-      window['simulateMouseEvent'] = simulateMouseEvent;
     ''')
     create_file('page.html', '''
       <html>
@@ -3041,14 +3039,6 @@ Module["preRun"] = () => {
   @no_wasm64('SDL2 + wasm64')
   def test_sdl2_key(self):
     create_file('pre.js', '''
-      Module.postRun = () => {
-        function doOne() {
-          Module._one();
-          setTimeout(doOne, 1000/60);
-        }
-        setTimeout(doOne, 1000/60);
-      }
-
       function keydown(c) {
         var event = new KeyboardEvent("keydown", { 'keyCode': c, 'charCode': c, 'view': window, 'bubbles': true, 'cancelable': true });
         var prevented = !document.dispatchEvent(event);
@@ -3066,7 +3056,7 @@ Module["preRun"] = () => {
       }
     ''')
 
-    self.btest_exit('test_sdl2_key.c', 37182145, args=['-sUSE_SDL=2', '--pre-js', 'pre.js', '-sEXPORTED_FUNCTIONS=_main,_one'])
+    self.btest_exit('test_sdl2_key.c', 37182145, args=['-sUSE_SDL=2', '--pre-js', 'pre.js'])
 
   @no_wasm64('SDL2 + wasm64')
   def test_sdl2_text(self):
@@ -3091,7 +3081,7 @@ Module["preRun"] = () => {
   @requires_graphics_hardware
   def test_sdl2_mouse(self):
     create_file('pre.js', '''
-      function simulateMouseEvent(x, y, button) {
+      globalThis.simulateMouseEvent = (x, y, button) => {
         var event = document.createEvent("MouseEvents");
         if (button >= 0) {
           var event1 = document.createEvent("MouseEvents");
@@ -3115,16 +3105,15 @@ Module["preRun"] = () => {
           Module['canvas'].dispatchEvent(event1);
         }
       }
-      window['simulateMouseEvent'] = simulateMouseEvent;
     ''')
 
-    self.btest_exit('test_sdl2_mouse.c', args=['-O2', '--minify=0', '-o', 'page.html', '--pre-js', 'pre.js', '-sUSE_SDL=2'])
+    self.btest_exit('test_sdl2_mouse.c', args=['-O2', '--minify=0', '--pre-js', 'pre.js', '-sUSE_SDL=2'])
 
   @no_wasm64('SDL2 + wasm64')
   @requires_graphics_hardware
   def test_sdl2_mouse_offsets(self):
     create_file('pre.js', '''
-      function simulateMouseEvent(x, y, button) {
+      globalThis.simulateMouseEvent = (x, y, button) => {
         var event = document.createEvent("MouseEvents");
         if (button >= 0) {
           var event1 = document.createEvent("MouseEvents");
@@ -3148,7 +3137,6 @@ Module["preRun"] = () => {
           Module['canvas'].dispatchEvent(event1);
         }
       }
-      window['simulateMouseEvent'] = simulateMouseEvent;
     ''')
     create_file('page.html', '''
       <html>


### PR DESCRIPTION
The TEST_EMSCRIPTEN_SDL_SETEVENTHANDLER macro is copied over from `test_sdl_key.c` (the SDL1 version) but its not applicable with SDL2.

Remove the 3 second delay from test_sdl_mouse/test_sdl2_mouse.  I ran
these tests many times without any issues.  We can perhaps revive with
something less long but I can't really see how a delay here could be
useful in practice.