### PR TITLE
Fix python error when build with audio worklets enabled since #20881

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5817,6 +5817,7 @@ Module["preRun"] = () => {
     if '-sMEMORY64' in args and is_firefox():
       self.skipTest('https://github.com/emscripten-core/emscripten/issues/19161')
     self.btest_exit('webaudio/audioworklet.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'] + args)
+    self.btest_exit('webaudio/audioworklet.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sSTRICT'] + args)
 
   # Tests that posting functions between the main thread and the audioworklet thread works
   @parameterized({

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5816,7 +5816,7 @@ Module["preRun"] = () => {
   def test_audio_worklet(self, args):
     if '-sMEMORY64' in args and is_firefox():
       self.skipTest('https://github.com/emscripten-core/emscripten/issues/19161')
-    self.btest_exit('webaudio/audioworklet.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'] + args)
+    self.btest_exit('webaudio/audioworklet.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sSTRICT'] + args)
 
   # Tests that posting functions between the main thread and the audioworklet thread works
   @parameterized({
@@ -5824,14 +5824,14 @@ Module["preRun"] = () => {
     'closure': (['--closure', '1', '-Oz'],),
   })
   def test_audio_worklet_post_function(self, args):
-    self.btest('webaudio/audioworklet_post_function.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'] + args, expected='1')
+    self.btest('webaudio/audioworklet_post_function.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sSTRICT'] + args, expected='1')
 
   @parameterized({
     '': ([],),
     'closure': (['--closure', '1', '-Oz'],),
   })
   def test_audio_worklet_modularize(self, args):
-    self.btest_exit('webaudio/audioworklet.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sMODULARIZE=1', '-sEXPORT_NAME=MyModule', '--shell-file', test_file('shell_that_launches_modularize.html')] + args)
+    self.btest_exit('webaudio/audioworklet.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sSTRICT', '-sMODULARIZE=1', '-sEXPORT_NAME=MyModule', '--shell-file', test_file('shell_that_launches_modularize.html')] + args)
 
   def test_error_reporting(self):
     # Test catching/reporting Error objects

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5812,12 +5812,12 @@ Module["preRun"] = () => {
     'minimal_runtime_pthreads_and_closure': (['-sMINIMAL_RUNTIME', '-pthread', '--closure', '1', '-Oz'],),
     'pthreads_es6': (['-pthread', '-sPTHREAD_POOL_SIZE=2', '-sEXPORT_ES6'],),
     'es6': (['-sEXPORT_ES6'],),
+    'strict': (['-sSTRICT'],),
   })
   def test_audio_worklet(self, args):
     if '-sMEMORY64' in args and is_firefox():
       self.skipTest('https://github.com/emscripten-core/emscripten/issues/19161')
     self.btest_exit('webaudio/audioworklet.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'] + args)
-    self.btest_exit('webaudio/audioworklet.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sSTRICT'] + args)
 
   # Tests that posting functions between the main thread and the audioworklet thread works
   @parameterized({

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5816,7 +5816,7 @@ Module["preRun"] = () => {
   def test_audio_worklet(self, args):
     if '-sMEMORY64' in args and is_firefox():
       self.skipTest('https://github.com/emscripten-core/emscripten/issues/19161')
-    self.btest_exit('webaudio/audioworklet.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sSTRICT'] + args)
+    self.btest_exit('webaudio/audioworklet.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'] + args)
 
   # Tests that posting functions between the main thread and the audioworklet thread works
   @parameterized({
@@ -5824,14 +5824,14 @@ Module["preRun"] = () => {
     'closure': (['--closure', '1', '-Oz'],),
   })
   def test_audio_worklet_post_function(self, args):
-    self.btest('webaudio/audioworklet_post_function.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sSTRICT'] + args, expected='1')
+    self.btest('webaudio/audioworklet_post_function.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'] + args, expected='1')
 
   @parameterized({
     '': ([],),
     'closure': (['--closure', '1', '-Oz'],),
   })
   def test_audio_worklet_modularize(self, args):
-    self.btest_exit('webaudio/audioworklet.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sSTRICT', '-sMODULARIZE=1', '-sEXPORT_NAME=MyModule', '--shell-file', test_file('shell_that_launches_modularize.html')] + args)
+    self.btest_exit('webaudio/audioworklet.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sMODULARIZE=1', '-sEXPORT_NAME=MyModule', '--shell-file', test_file('shell_that_launches_modularize.html')] + args)
 
   def test_error_reporting(self):
     # Test catching/reporting Error objects

--- a/test/test_interactive.py
+++ b/test/test_interactive.py
@@ -270,7 +270,6 @@ class interactive(BrowserCore):
   def test_audio_worklet(self):
     self.btest('webaudio/audioworklet.c', expected='0', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '--preload-file', test_file('hello_world.c') + '@/'])
     self.btest('webaudio/audioworklet.c', expected='0', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-pthread'])
-    self.btest('webaudio/audioworklet.c', expected='0', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sSTRICT'])
 
   # Tests AudioWorklet with emscripten_futex_wake().
   @also_with_minimal_runtime

--- a/test/test_interactive.py
+++ b/test/test_interactive.py
@@ -270,6 +270,7 @@ class interactive(BrowserCore):
   def test_audio_worklet(self):
     self.btest('webaudio/audioworklet.c', expected='0', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '--preload-file', test_file('hello_world.c') + '@/'])
     self.btest('webaudio/audioworklet.c', expected='0', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-pthread'])
+    self.btest('webaudio/audioworklet.c', expected='0', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sSTRICT'])
 
   # Tests AudioWorklet with emscripten_futex_wake().
   @also_with_minimal_runtime

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -72,7 +72,6 @@ min_browser_versions = {
   },
   Feature.GLOBALTHIS: {
     'chrome': 71,
-    'edge': 79,
     'firefox': 65,
     'safari': 120100,
     'node': 120000,

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -72,6 +72,7 @@ min_browser_versions = {
   },
   Feature.GLOBALTHIS: {
     'chrome': 71,
+    'edge': 79,
     'firefox': 65,
     'safari': 120100,
     'node': 120000,


### PR DESCRIPTION
Hello,

I build my project with -sAUDIO_WORKLET=1 enabled, it worked fine in version 3.1.50, but since version 3.1.51 I've had this error at the link time : 

```
Traceback (most recent call last):
  File "emsdk\upstream\emscripten\em++.py", line 15, in <module>
    sys.exit(emcc.main(sys.argv))
  File "emsdk\python\3.9.2-nuget_64bit\lib\contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "emsdk\upstream\emscripten\emcc.py", line 1554, in main
    ret = run(args)
  File "emsdk\upstream\emscripten\emcc.py", line 637, in run
    return link.run(linker_inputs, options, state, newargs)
  File "emsdk\upstream\emscripten\tools\link.py", line 2919, in run
    target, wasm_target = phase_linker_setup(options, state, newargs)
  File "emsdk\python\3.9.2-nuget_64bit\lib\contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "emsdk\upstream\emscripten\tools\link.py", line 1325, in phase_linker_setup
    feature_matrix.apply_min_browser_versions()
  File "emsdk\upstream\emscripten\tools\feature_matrix.py", line 139, in apply_min_browser_versions
    enable_feature(Feature.GLOBALTHIS, 'AUDIO_WORKLET')
  File "emsdk\upstream\emscripten\tools\feature_matrix.py", line 117, in enable_feature
    if settings[name] < min_version:
  File "emsdk\upstream\emscripten\tools\settings.py", line 269, in __getitem__
    return self.attrs[key]
KeyError: 'MIN_EDGE_VERSION'
ninja: build stopped: subcommand failed.
```

After a bit of digging, it seems to be linked to this PR #20881
And this code in the file **feature_matrix.py** : 

```
def apply_min_browser_versions():
  if settings.WASM_BIGINT:
    enable_feature(Feature.JS_BIGINT_INTEGRATION, 'WASM_BIGINT')
  if settings.PTHREADS:
    enable_feature(Feature.THREADS, 'pthreads')
    enable_feature(Feature.BULK_MEMORY, 'pthreads')
  if settings.AUDIO_WORKLET:
    enable_feature(Feature.GLOBALTHIS, 'AUDIO_WORKLET')
```

```
def enable_feature(feature, reason):
  """Updates default settings for browser versions such that the given
  feature is available everywhere.
  """
  for name, min_version in min_browser_versions[feature].items():
    name = f'MIN_{name.upper()}_VERSION'
```

```
Feature.GLOBALTHIS: {
    'chrome': 71,
    'edge': 79,
    'firefox': 65,
    'safari': 120100,
    'node': 120000,
  },
```

I removed the **edge** value and it builds correctly, so I propose this fix, to be discussed of course!
