### PR TITLE
Use `isfile` rather than `exists` when checking for config files

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -261,7 +261,7 @@ def apply_user_settings():
     filename = None
     if value and value[0] == '@':
       filename = removeprefix(value, '@')
-      if not os.path.exists(filename):
+      if not os.path.isfile(filename):
         exit_with_error('%s: file not found parsing argument: %s=%s' % (filename, key, value))
       value = read_file(filename).strip()
     else:
@@ -612,7 +612,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     libname = print_file_name[-1].split('=')[1]
     system_libpath = cache.get_lib_dir(absolute=True)
     fullpath = os.path.join(system_libpath, libname)
-    if os.path.exists(fullpath):
+    if os.path.isfile(fullpath):
       print(fullpath)
     else:
       print(libname)

--- a/tools/config.py
+++ b/tools/config.py
@@ -99,7 +99,7 @@ def set_config_from_tool_location(config_key, tool_binary, f):
   if val is None:
     path = shutil.which(tool_binary)
     if not path:
-      if not os.path.exists(EM_CONFIG):
+      if not os.path.isfile(EM_CONFIG):
         diagnostics.warn('config file not found: %s.  You can create one by hand or run `emcc --generate-config`', EM_CONFIG)
       exit_with_error('%s not set in config (%s), and `%s` not found in PATH', config_key, EM_CONFIG, tool_binary)
     globals()[config_key] = f(path)
@@ -155,11 +155,11 @@ def parse_config_file():
 
 
 def read_config():
-  if os.path.exists(EM_CONFIG):
+  if os.path.isfile(EM_CONFIG):
     parse_config_file()
 
-  # In the past the default-generated .emscripten config file would read certain environment
-  # variables.
+  # In the past the default-generated .emscripten config file would read
+  # certain environment variables.
   LEGACY_ENV_VARS = {
     'LLVM': 'EM_LLVM_ROOT',
     'BINARYEN': 'EM_BINARYEN_ROOT',
@@ -172,7 +172,8 @@ def read_config():
     env_value = os.environ.get(key)
     if env_value and new_key not in os.environ:
       msg = f'legacy environment variable found: `{key}`.  Please switch to using `{new_key}` instead`'
-      # Use `debug` instead of `warning` for `NODE` specifically since there can be false positives:
+      # Use `debug` instead of `warning` for `NODE` specifically
+      # since there can be false positives:
       # See https://github.com/emscripten-core/emsdk/issues/862
       if key == 'NODE':
         logger.debug(msg)
@@ -266,13 +267,13 @@ def find_config_file():
   if 'EM_CONFIG' in os.environ:
     return os.environ['EM_CONFIG']
 
-  if os.path.exists(embedded_config):
+  if os.path.isfile(embedded_config):
     return embedded_config
 
-  if os.path.exists(emsdk_embedded_config):
+  if os.path.isfile(emsdk_embedded_config):
     return emsdk_embedded_config
 
-  if os.path.exists(user_home_config):
+  if os.path.isfile(user_home_config):
     return user_home_config
 
   # No config file found.  Return the default location.
@@ -292,13 +293,17 @@ def init():
 
   EM_CONFIG = os.path.expanduser(EM_CONFIG)
 
-  # This command line flag needs to work even in the absence of a config file, so we must process it
-  # here at script import time (otherwise the error below will trigger).
+  # This command line flag needs to work even in the absence of a config
+  # file, so we must process it here at script import time (otherwise
+  # the error below will trigger).
   if '--generate-config' in sys.argv:
     generate_config(EM_CONFIG)
     sys.exit(0)
 
-  logger.debug('emscripten config is located in ' + EM_CONFIG)
+  if os.path.isfile(EM_CONFIG):
+    logger.debug(f'using config file: ${EM_CONFIG}')
+  else:
+    logger.debug('config file not found; using default config')
 
   # Emscripten compiler spawns other processes, which can reimport shared.py, so
   # make sure that those child processes get the same configuration file by


### PR DESCRIPTION
This avoids trying parse non-files.

Also, explicitly log when we are not using a config file at all.