### PR TITLE
Fix for resize events when building with ASSERTIONS

### DIFF
--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -596,7 +596,7 @@ Struct
 
   .. c:member:: long detail
 
-    Specifies additional detail/information about this event.
+    For resize and scroll events this is always zero.
 
   .. c:member:: int documentBodyClientWidth
     int documentBodyClientHeight
@@ -616,7 +616,7 @@ Struct
   .. c:member:: int scrollTop
     int scrollLeft
 
-    The page scroll position.
+    The page scroll position (rounded down to the nearest pixel).
 
 
 Callback functions

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -710,7 +710,7 @@ var LibraryHTML5 = {
       var uiEvent = JSEvents.uiEvent;
 #endif
       // e.detail is seen as undefined
-      {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.detail, '((typeof e.detail !== "undefined") ? e.detail : 0), 'i32') }}};
+      {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.detail, '(typeof e.detail !== "undefined") ? e.detail : 0', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.documentBodyClientWidth, 'b.clientWidth', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.documentBodyClientHeight, 'b.clientHeight', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.windowInnerWidth, 'innerWidth', 'i32') }}};

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -709,7 +709,8 @@ var LibraryHTML5 = {
 #else
       var uiEvent = JSEvents.uiEvent;
 #endif
-      {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.detail, 'e.detail', 'i32') }}};
+      // e.detail is seen as undefined
+      {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.detail, '((typeof e.detail !== "undefined") ? e.detail : 0), 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.documentBodyClientWidth, 'b.clientWidth', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.documentBodyClientHeight, 'b.clientHeight', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.windowInnerWidth, 'innerWidth', 'i32') }}};

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -710,7 +710,7 @@ var LibraryHTML5 = {
       var uiEvent = JSEvents.uiEvent;
 #endif
       // e.detail is seen as undefined
-      {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.detail, '(typeof e.detail !== "undefined") ? e.detail : 0', 'i32') }}};
+      {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.detail, 'e.detail || 0', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.documentBodyClientWidth, 'b.clientWidth', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.documentBodyClientHeight, 'b.clientHeight', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.windowInnerWidth, 'innerWidth', 'i32') }}};

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -709,16 +709,15 @@ var LibraryHTML5 = {
 #else
       var uiEvent = JSEvents.uiEvent;
 #endif
-      // e.detail is seen as undefined
-      {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.detail, 'e.detail || 0', 'i32') }}};
+      {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.detail, '0', 'i32') }}}; // always zero for resize and scroll
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.documentBodyClientWidth, 'b.clientWidth', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.documentBodyClientHeight, 'b.clientHeight', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.windowInnerWidth, 'innerWidth', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.windowInnerHeight, 'innerHeight', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.windowOuterWidth, 'outerWidth', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.windowOuterHeight, 'outerHeight', 'i32') }}};
-      {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.scrollTop, 'pageXOffset', 'i32') }}};
-      {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.scrollLeft, 'pageYOffset', 'i32') }}};
+      {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.scrollTop, 'pageXOffset | 0', 'i32') }}}; // scroll offsets are float
+      {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.scrollLeft, 'pageYOffset | 0', 'i32') }}};
 #if PTHREADS
       if (targetThread) __emscripten_run_callback_on_thread(targetThread, callbackfunc, eventTypeId, uiEvent, userData);
       else


### PR DESCRIPTION
Building with `ASSERTIONS` is failing the safe heap checks for resize events given that `e.detail` is seen as `undefined` (the specs say `UIEvent.detail` [should be zero](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail)). Seen here with the latest Emscripten 3.1.54, tested in Safari and Chrome on Mac.

<img width="385" alt="detail" src="https://github.com/emscripten-core/emscripten/assets/8437014/f407d0ff-2723-4cdb-86b3-1b29c2fcc56f">

The resulting error is:
```
Uncaught RuntimeError: Aborted(Assertion failed: attempt to write non-integer (undefined) into integer heap)
```
It's reported specifically in #21091 which is closed in favour of #20992. This fixes #21091 which fails without SDL, just with a simple `emscripten_set_resize_callback()` and `-s ASSERTIONS`.