### PR TITLE
[emval] Reduce C++ -> JS calls in emscripten::val lifetime management

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -386,13 +386,13 @@ public:
   }
 
   val(const val& v) : val(v.as_handle()) {
-    if (uses_refcount()) {
+    if (uses_ref_count()) {
       internal::_emval_incref(handle);
     }
   }
 
   ~val() {
-    if (uses_refcount()) {
+    if (uses_ref_count()) {
       internal::_emval_decref(as_handle());
       handle = 0;
     }
@@ -642,7 +642,7 @@ private:
 
   // Whether this value is a uses incref/decref (true) or is a special reserved
   // value (false).
-  bool uses_refcount() const {
+  bool uses_ref_count() const {
     return handle > reinterpret_cast<EM_VAL>(internal::_EMVAL_LAST_RESERVED_HANDLE);
   }
 
@@ -813,7 +813,7 @@ struct BindingType<T, typename std::enable_if<std::is_base_of<val, T>::value &&
   // reference count.
   static WireType toWireType(const val& v) {
     EM_VAL handle = v.as_handle();
-    if (v.uses_refcount()) {
+    if (v.uses_ref_count()) {
       _emval_incref(handle);
     }
     return handle;

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -406,7 +406,7 @@ public:
   }
 
   // Takes ownership of the handle away from, and invalidates, this instance.
-  EM_VAL take_handle() {
+  EM_VAL release_handle() {
     EM_VAL taken = as_handle();
     handle = 0;
     return taken;
@@ -806,7 +806,7 @@ struct BindingType<T, typename std::enable_if<std::is_base_of<val, T>::value &&
   // Marshall to JS with move semantics when we can invalidate the temporary val
   // object.
   static WireType toWireType(val&& v) {
-    return v.take_handle();
+    return v.release_handle();
   }
 
   // Marshal to JS with copy semantics when we cannot transfer the val objects

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -797,7 +797,7 @@ struct BindingType<T, typename std::enable_if<std::is_base_of<val, T>::value &&
   typedef EM_VAL WireType;
   static WireType toWireType(const val& v) {
     EM_VAL handle = v.as_handle();
-    if (uses_refcount()) {
+    if (v.uses_refcount()) {
       _emval_incref(handle);
     }
     return handle;

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -406,7 +406,7 @@ public:
   }
 
   // Takes ownership of the handle away from, and invalidates, this instance.
-  EM_VAL release_handle() {
+  EM_VAL release_ownership() {
     EM_VAL taken = as_handle();
     handle = 0;
     return taken;
@@ -806,7 +806,7 @@ struct BindingType<T, typename std::enable_if<std::is_base_of<val, T>::value &&
   // Marshall to JS with move semantics when we can invalidate the temporary val
   // object.
   static WireType toWireType(val&& v) {
-    return v.release_handle();
+    return v.release_ownership();
   }
 
   // Marshal to JS with copy semantics when we cannot transfer the val objects

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 431,
   "a.js": 7080,
   "a.js.gz": 2999,
-  "a.wasm": 11436,
-  "a.wasm.gz": 5728,
+  "a.wasm": 11431,
+  "a.wasm.gz": 5727,
   "total": 19184,
-  "total_gz": 9158
+  "total_gz": 9157
 }

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -5,6 +5,6 @@
   "a.js.gz": 2999,
   "a.wasm": 11436,
   "a.wasm.gz": 5728,
-  "total": 19189,
+  "total": 19184,
   "total_gz": 9158
 }

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 431,
   "a.js": 7080,
   "a.js.gz": 2999,
-  "a.wasm": 11428,
-  "a.wasm.gz": 5724,
-  "total": 19181,
-  "total_gz": 9154
+  "a.wasm": 11436,
+  "a.wasm.gz": 5728,
+  "total": 19189,
+  "total_gz": 9158
 }


### PR DESCRIPTION
Related to #21300, but some obviously good incremental wins to reduce the cost of ref counting:

1. Have C++ consistently avoid inc/dec for the special reserved values that don't need to be counted, this saves decref calls every time such a `val` object goes out of scope.
2. Add an rvalue reference version of toWireType for `emscripten::val` that can transfer ownership to JS. This saves one call to incref and one call to decref for the case of a c++ function with return type `emscripten::val`  

The cost seems to be single-digit bytes to the WASM.