### PR TITLE
Fixes to build with Closure (--closure 1)

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -260,12 +260,3 @@ var moduleArg;
  */
 Navigator.prototype.webkitGetUserMedia = function(
     constraints, successCallback, errorCallback) {};
-
-/**
- * Global object for custom event target mappings, see:
- * https://emscripten.org/docs/api_reference/html5.h.html#how-to-use-this-api
- *
- * @type {Object}
- * @suppress {duplicate}
- */
-var specialHTMLTargets;

--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -260,3 +260,12 @@ var moduleArg;
  */
 Navigator.prototype.webkitGetUserMedia = function(
     constraints, successCallback, errorCallback) {};
+
+/**
+ * Global object for custom event target mappings, see:
+ * https://emscripten.org/docs/api_reference/html5.h.html#how-to-use-this-api
+ *
+ * @type {Object}
+ * @suppress {duplicate}
+ */
+var specialHTMLTargets;

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -138,7 +138,9 @@ var LibraryBrowser = {
 #endif
         var img = new Image();
         img.onload = () => {
+#if ASSERTIONS
           assert(img.complete, `Image ${name} could not be decoded`);
+#endif
           var canvas = /** @type {!HTMLCanvasElement} */ (document.createElement('canvas'));
           canvas.width = img.width;
           canvas.height = img.height;
@@ -302,8 +304,9 @@ var LibraryBrowser = {
       if (!ctx) return null;
 
       if (setInModule) {
+#if ASSERTIONS
         if (!useWebGL) assert(typeof GLctx == 'undefined', 'cannot set in module if GLctx is used, but we are a non-GL context that would replace it');
-
+#endif
         Module.ctx = ctx;
         if (useWebGL) GL.makeContextCurrent(contextHandle);
         Module.useWebGL = useWebGL;
@@ -783,8 +786,9 @@ var LibraryBrowser = {
       return onerror ? onerror() : undefined;
     }
 #endif
+#if ASSERTIONS
     assert(runDependencies === 0, 'async_load_script must be run when no other dependencies are active');
-
+#endif
     {{{ runtimeKeepalivePush() }}}
 
     var loadDone = () => {
@@ -911,8 +915,9 @@ var LibraryBrowser = {
    * @param {boolean=} noSetTiming
    */`,
   $setMainLoop: (browserIterationFunc, fps, simulateInfiniteLoop, arg, noSetTiming) => {
+#if ASSERTIONS
     assert(!Browser.mainLoop.func, 'emscripten_set_main_loop: there can only be one main loop function at once: call emscripten_cancel_main_loop to cancel the previous one before setting a new one with different parameters.');
-
+#endif
     Browser.mainLoop.func = browserIterationFunc;
     Browser.mainLoop.arg = arg;
 

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -315,6 +315,7 @@ var LibraryHTML5 = {
   // Users can also add more special event targets, basically by just doing something like
   //    specialHTMLTargets["!canvas"] = Module.canvas;
   // (that will let !canvas map to the canvas held in Module.canvas).
+  $specialHTMLTargets__docs: '/** @type {Object} */',
 #if ENVIRONMENT_MAY_BE_WORKER || ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL || PTHREADS
   $specialHTMLTargets: "[0, typeof document != 'undefined' ? document : 0, typeof window != 'undefined' ? window : 0]",
 #else

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -16,7 +16,9 @@ addToLibrary({
       if (typeof indexedDB != 'undefined') return indexedDB;
       var ret = null;
       if (typeof window == 'object') ret = window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB || window.msIndexedDB;
+#if ASSERTIONS
       assert(ret, 'IDBFS used, but indexedDB not supported');
+#endif
       return ret;
     },
     DB_VERSION: 21,


### PR DESCRIPTION
A few minor fixes to build using `--closure=1` on release builds. Code was built with `-O2 -s ASSERTIONS=0 -s STRICT=1 --closure=1` to test. The first two are due to Emscripten 3.1.48 changes, where the release notes say "The JS `assert` function is no longer available in release builds when `-sSTRICT` is used" . The third due to missing annotations.

1.  For `library_idbfs.js` there are a few `assert()` calls without the appropriate `#if ASSERTIONS` around them.  A simple repro is to build:
```c
#include <emscripten/em_js.h>

EM_JS(void, test_idbfs, (), {
	FS.mount(IDBFS, {}, "/mnt");
});

int main() {
	test_idbfs();
}
```
2. The same above applies to `library_browser.js` with an even simpler repro:
```c
#include <emscripten/emscripten.h>

int main() {
	emscripten_cancel_main_loop();
}
```
3. `library_html5.js` adds the missing `specialHTMLTargets` (see the [docs](https://emscripten.org/docs/api_reference/html5.h.html#how-to-use-this-api)).  The repro case is:
```c
#include <emscripten/em_js.h>

EM_JS(void, test_special, (), {
	specialHTMLTargets["!canvas"] = Module["canvas"];
});

int main() {
	test_special();
}
```