### PR TITLE
Avoid calling addCxaCatch when not linking as C++

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -319,7 +319,7 @@ function(${args}) {
     // the number specifies the number of arguments. In Emscripten, route all
     // these to a single function 'findMatchingCatch' that takes an array
     // of argument.
-    if (!WASM_EXCEPTIONS && symbol.startsWith('__cxa_find_matching_catch_')) {
+    if (LINK_AS_CXX && !WASM_EXCEPTIONS && symbol.startsWith('__cxa_find_matching_catch_')) {
       if (DISABLE_EXCEPTION_THROWING) {
         error('DISABLE_EXCEPTION_THROWING was set (likely due to -fno-exceptions), which means no C++ exception throwing support code is linked in, but exception catching code appears. Either do not set DISABLE_EXCEPTION_THROWING (if you do want exception throwing) or compile all source files with -fno-except (so that no exceptions support code is required); also make sure DISABLE_EXCEPTION_CATCHING is set to the right value - if you want exceptions, it should be off, and vice versa.');
         return;

--- a/test/other/test_exceptions_c_linker.c
+++ b/test/other/test_exceptions_c_linker.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+__attribute__((import_name("__cxa_find_matching_catch_1")))
+void __cxa_find_matching_catch_1();
+
+int main() {
+  __cxa_find_matching_catch_1();
+  printf("done");
+  return 0;
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8796,6 +8796,12 @@ int main() {
       out = self.run_js('a.out.js', assert_returncode=NON_ZERO)
       self.assertContained('no native wasm support detected', out)
 
+  def test_exceptions_c_linker(self):
+    # Test that we don't try to create __cxa_find_matching_catch_xx function automatically
+    # when not linking as C++.
+    stderr = self.expect_fail([EMCC, '-sSTRICT', test_file('other/test_exceptions_c_linker.c')])
+    self.assertContained('error: undefined symbol: __cxa_find_matching_catch_1', stderr)
+
   @parameterized({
     '': (False,),
     'wasm': (True,),


### PR DESCRIPTION
For the test I was unable to figure out a way to generate a call to `__cxa_find_matching_catch` withing hand coding it like this.

This doesn't fix #21381 but it makes the error message way less confusing.