### PR TITLE
Fix webgl tracing issues

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2325,10 +2325,12 @@ void *getBindBuffer() {
   @requires_graphics_hardware
   @parameterized({
     '': ([],),
+    'tracing': (['-sTRACE_WEBGL_CALLS'],),
     'es2': (['-sMIN_WEBGL_VERSION=2', '-sFULL_ES2', '-sWEBGL2_BACKWARDS_COMPATIBILITY_EMULATION'],),
+    'es2_tracing': (['-sMIN_WEBGL_VERSION=2', '-sFULL_ES2', '-sWEBGL2_BACKWARDS_COMPATIBILITY_EMULATION', '-sTRACE_WEBGL_CALLS'],),
   })
   def test_subdata(self, args):
-    if self.is_4gb() and args:
+    if self.is_4gb() and '-sMIN_WEBGL_VERSION=2' in args:
       self.skipTest('texSubImage2D fails: https://crbug.com/325090165')
     self.btest('gl_subdata.c', reference='float_tex.png', args=['-lGL', '-lglut'] + args)
 


### PR DESCRIPTION
The webgl tracing mechanism was assuming a fixed number of arguments for a given function whereas some webgl function can take variable number of arguments.

Fix this by using the rest operator.  This is not as slow as using `arguments`.  Also, performance is not really an issue here since we are about to serialize all the arguments to string and send to the console which will vastly out weight the cost of using spread here.

I believe the comments here about hot and cold functions as well as the comment at about the cost of using `arguments` were copied from the cpuprofiler.js but they don't apply here.

Also, avoid serializing the entire heap, which can cause chrome to hang.