### PR TITLE
Fix dup in nodefs by refcounting nodefs file descriptors

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -471,6 +471,11 @@ FS.staticInit();` +
     closeStream(fd) {
       FS.streams[fd] = null;
     },
+    dupStream(origStream, fd = -1) {
+      var stream = FS.createStream(origStream, fd);
+      stream.stream_ops?.dup?.(stream);
+      return stream;
+    },
 
     //
     // devices

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -270,7 +270,7 @@ addToLibrary({
         }
       },
       dup(stream) {
-        stream.shared.refcount ++;
+        stream.shared.refcount++;
       },
       read(stream, buffer, offset, length, position) {
         // Node.js < 6 compatibility: node errors on 0 length reads

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -183,7 +183,7 @@ var SyscallsLibrary = {
   },
   __syscall_dup: (fd) => {
     var old = SYSCALLS.getStreamFromFD(fd);
-    return FS.createStream(old).fd;
+    return FS.dupStream(old).fd;
   },
   __syscall_pipe__deps: ['$PIPEFS'],
   __syscall_pipe: (fdPtr) => {
@@ -760,7 +760,7 @@ var SyscallsLibrary = {
           arg++;
         }
         var newStream;
-        newStream = FS.createStream(stream, arg);
+        newStream = FS.dupStream(stream, arg);
         return newStream.fd;
       }
       case {{{ cDefs.F_GETFD }}}:
@@ -1007,7 +1007,7 @@ var SyscallsLibrary = {
     if (old.fd === newfd) return -{{{ cDefs.EINVAL }}};
     var existing = FS.getStream(newfd);
     if (existing) FS.close(existing);
-    return FS.createStream(old, newfd).fd;
+    return FS.dupStream(old, newfd).fd;
   },
 };
 

--- a/test/fs/test_nodefs_dup.c
+++ b/test/fs/test_nodefs_dup.c
@@ -5,9 +5,10 @@
  * found in the LICENSE file.
  */
 
-#include <stdio.h>
-#include <fcntl.h>
+#include <assert.h>
 #include <emscripten.h>
+#include <fcntl.h>
+#include <stdio.h>
 #include <unistd.h>
 
 #ifdef NODERAWFS
@@ -27,13 +28,18 @@ int main(void)
         FS.close(FS.open('/working/test.txt', 'w'));
 #endif
     );
-    int fd1 = open(CWD "test.txt", O_RDONLY);
+    int fd1 = open(CWD "test.txt", O_WRONLY);
     int fd2 = dup(fd1);
     int fd3 = fcntl(fd1, F_DUPFD_CLOEXEC, 0);
 
-    printf("fd1: %d, fd2: %d\n", fd1, fd2);
-    printf("close(fd1): %d\n", close(fd1));
-    printf("close(fd2): %d\n", close(fd2));
-    printf("close(fd3): %d\n", close(fd3));
+    assert(fd1 == 3);
+    assert(fd2 == 4);
+    assert(fd3 == 5);
+    assert(close(fd1) == 0);
+    assert(write(fd2, "abcdef", 6) == 6);
+    assert(close(fd2) == 0);
+    assert(write(fd3, "ghijkl", 6) == 6);
+    assert(close(fd3) == 0);
+    printf("success\n");
     return 0;
 }

--- a/test/fs/test_nodefs_dup.c
+++ b/test/fs/test_nodefs_dup.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <emscripten.h>
+#include <unistd.h>
+
+#ifdef NODERAWFS
+#define CWD ""
+#else
+#define CWD "/working/"
+#endif
+
+int main(void)
+{
+    EM_ASM(
+#ifdef NODERAWFS
+        FS.close(FS.open('test.txt', 'w'));
+#else
+        FS.mkdir('/working');
+        FS.mount(NODEFS, {root: '.'}, '/working');
+        FS.close(FS.open('/working/test.txt', 'w'));
+#endif
+    );
+    int fd1 = open(CWD "test.txt", O_RDONLY);
+    int fd2 = dup(fd1);
+    int fd3 = fcntl(fd1, F_DUPFD_CLOEXEC, 0);
+
+    printf("fd1: %d, fd2: %d\n", fd1, fd2);
+    printf("close(fd1): %d\n", close(fd1));
+    printf("close(fd2): %d\n", close(fd2));
+    printf("close(fd3): %d\n", close(fd3));
+    return 0;
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5755,9 +5755,7 @@ Module = {
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
     self.emcc_args += ['-lnodefs.js']
-    expected = "fd1: 3, fd2: 4\nclose(fd1): 0\nclose(fd2): 0\nclose(fd3): 0"
-
-    self.do_runf('fs/test_nodefs_dup.c', expected)
+    self.do_runf('fs/test_nodefs_dup.c', 'success')
 
   @requires_node
   def test_fs_nodefs_home(self):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5749,6 +5749,16 @@ Module = {
     self.emcc_args += ['-lnodefs.js']
     self.do_runf('fs/test_nodefs_cloexec.c', 'success')
 
+  @also_with_noderawfs
+  @requires_node
+  def test_fs_nodefs_dup(self):
+    if self.get_setting('WASMFS'):
+      self.set_setting('FORCE_FILESYSTEM')
+    self.emcc_args += ['-lnodefs.js']
+    expected = "fd1: 3, fd2: 4\nclose(fd1): 0\nclose(fd2): 0\nclose(fd3): 0"
+
+    self.do_runf('fs/test_nodefs_dup.c', expected)
+
   @requires_node
   def test_fs_nodefs_home(self):
     self.set_setting('FORCE_FILESYSTEM')


### PR DESCRIPTION
This fixes https://github.com/pyodide/pyodide/issues/4541.

> Emscripten's filesystem maintains separate file descriptors from the linux host, so it has a mapping from the emscripten file descriptor to the linux file descriptor. In the reproduction, the file is opened and linux assigns it descriptor 27, Emscripten assigns it descriptor 3. When we dup the descriptor, Emscripten makes a new descriptor 4, also pointing to linux descriptor 27. Then when we close emscripten descriptor 4 which closes linux descriptor 27 and finally when emscripten descriptor 3 is closed it tries to close linux descriptor 27 again which raises EBADF: close() on bad file descriptor which propagates into the OS error you see. We either need to also do a native dup on the linux descriptor or reference count it.

https://github.com/pyodide/pyodide/issues/4541#issuecomment-1959951809