### PR TITLE
Fix EM_JS macro in the face of recent llvm change

### DIFF
--- a/system/include/emscripten/em_js.h
+++ b/system/include/emscripten/em_js.h
@@ -61,7 +61,8 @@
 #define _EM_JS(ret, c_name, js_name, params, code)                             \
   _EM_BEGIN_CDECL                                                              \
   ret c_name params EM_IMPORT(js_name);                                        \
-  __attribute__((used)) static void* __em_js_ref_##c_name = (void*)&c_name;    \
+  __attribute__((visibility("hidden")))                                        \
+  void* __em_js_ref_##c_name = (void*)&c_name;                                 \
   EMSCRIPTEN_KEEPALIVE                                                         \
   __attribute__((section("em_js"), aligned(1))) char __em_js__##js_name[] =    \
     #params "<::>" code;                                                       \


### PR DESCRIPTION
A recent change to llvm (https://github.com/llvm/llvm-project/pull/81539) means that the `used` attribute on data forces the segment to be present in the output file, even if it's not used.

The usage here in `em_js.h` was assuming that the data was not incldued in the final output.  This change makes the symbol non-static instead of used, which is enough to force clang to keep the data around but not the linker (which is exactly the effect we want).