### PR TITLE
Mark test_itimer_pthread as flaky. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13847,6 +13847,7 @@ foo/version.txt
     self.do_other_test('test_itimer.c')
 
   @node_pthreads
+  @flaky('https://github.com/emscripten-core/emscripten/issues/20125')
   def test_itimer_pthread(self):
     self.do_other_test('test_itimer.c')
 


### PR DESCRIPTION
This should have been marked as such when the other itimer tests were.