### PR TITLE
Fix a pthread stack corruption problem

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1063,8 +1063,12 @@ var LibraryPThread = {
 
   $establishStackSpace__internal: true,
   $establishStackSpace__deps: ['$stackRestore'],
-  $establishStackSpace: () => {
-    var pthread_ptr = _pthread_self();
+  $establishStackSpace: (pthread_ptr) => {
+#if ALLOW_MEMORY_GROWTH
+    // If memory growth is enabled, the memory views may have gotten out of date,
+    // so resync them before accessing the pthread ptr below.
+    updateMemoryViews();
+#endif
     var stackHigh = {{{ makeGetValue('pthread_ptr', C_STRUCTS.pthread.stack, '*') }}};
     var stackSize = {{{ makeGetValue('pthread_ptr', C_STRUCTS.pthread.stack_size, '*') }}};
     var stackLow = stackHigh - stackSize;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -139,7 +139,7 @@ var HEAP,
 /* BigInt64Array type is not correctly defined in closure
 /** not-@type {!BigInt64Array} */
   HEAP64,
-/* BigUInt64Array type is not correctly defined in closure
+/* BigUint64Array type is not correctly defined in closure
 /** not-t@type {!BigUint64Array} */
   HEAPU64,
 #endif


### PR DESCRIPTION
Fix a problem with pthread creation where it would call from JS to C/C++ function `_emscripten_thread_init()` before having correctly initialized the C/C++ program stack, leading the pthread to stomp on the main thread's stack for the execution of that function.
