### PR TITLE
Remove remaining uses of `eval` in the JS compiler

### DIFF
--- a/src/compiler.mjs
+++ b/src/compiler.mjs
@@ -45,8 +45,8 @@ globalThis.read = (filename) => {
 };
 
 function load(f) {
-  (0, eval)(read(f) + '//# sourceURL=' + find(f));
-};
+  vm.runInThisContext(read(f), { filename: find(f) });
+}
 
 // Basic utilities
 load('utility.js');

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -105,7 +105,7 @@ function shouldPreprocess(fileName) {
 function getIncludeFile(fileName, needsPreprocess) {
   let result = `// include: ${fileName}\n`;
   if (needsPreprocess) {
-    result += processMacros(preprocess(fileName));
+    result += processMacros(preprocess(fileName), fileName);
   } else {
     result += read(fileName);
   }

--- a/src/modules.js
+++ b/src/modules.js
@@ -233,7 +233,7 @@ globalThis.LibraryManager = {
       }
       currentFile = filename;
       try {
-        processed = processMacros(preprocess(filename));
+        processed = processMacros(preprocess(filename), filename);
         vm.runInThisContext(processed, { filename: filename.replace(/\.\w+$/, '.preprocessed$&') });
       } catch (e) {
         error(`failure to execute js library "${filename}":`);

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -9,23 +9,20 @@
  */
 
 globalThis.FOUR_GB = 4 * 1024 * 1024 * 1024;
+globalThis.WASM_PAGE_SIZE = 64 * 1024;
+
 const FLOAT_TYPES = new Set(['float', 'double']);
 
 // Does simple 'macro' substitution, using Django-like syntax,
 // {{{ code }}} will be replaced with |eval(code)|.
 // NOTE: Be careful with that ret check. If ret is |0|, |ret ? ret.toString() : ''| would result in ''!
-function processMacros(text) {
+function processMacros(text, filename) {
   // The `?` here in makes the regex non-greedy so it matches with the closest
   // set of closing braces.
   // `[\s\S]` works like `.` but include newline.
   return text.replace(/{{{([\s\S]+?)}}}/g, (_, str) => {
-    try {
-      const ret = eval(str);
-      return ret !== null ? ret.toString() : '';
-    } catch (ex) {
-      ex.stack = `In the following macro:\n\n${str}\n\n${ex.stack}`;
-      throw ex;
-    }
+    const ret = vm.runInThisContext(str, { filename: filename });
+    return ret !== null ? ret.toString() : '';
   });
 }
 
@@ -180,21 +177,21 @@ function needsQuoting(ident) {
 globalThis.POINTER_SIZE = MEMORY64 ? 8 : 4;
 globalThis.POINTER_MAX = MEMORY64 ? 'Number.MAX_SAFE_INTEGER' : '0xFFFFFFFF';
 globalThis.STACK_ALIGN = 16;
-const POINTER_BITS = POINTER_SIZE * 8;
-const POINTER_TYPE = `u${POINTER_BITS}`;
-const POINTER_JS_TYPE = MEMORY64 ? "'bigint'" : "'number'";
-const POINTER_SHIFT = MEMORY64 ? '3' : '2';
-const POINTER_HEAP = MEMORY64 ? 'HEAP64' : 'HEAP32';
-const LONG_TYPE = `i${POINTER_BITS}`;
+globalThis.POINTER_BITS = POINTER_SIZE * 8;
+globalThis.POINTER_TYPE = `u${POINTER_BITS}`;
+globalThis.POINTER_JS_TYPE = MEMORY64 ? "'bigint'" : "'number'";
+globalThis.POINTER_SHIFT = MEMORY64 ? '3' : '2';
+globalThis.POINTER_HEAP = MEMORY64 ? 'HEAP64' : 'HEAP32';
+globalThis.LONG_TYPE = `i${POINTER_BITS}`;
 
-const SIZE_TYPE = POINTER_TYPE;
+globalThis.SIZE_TYPE = POINTER_TYPE;
 
 
 // Similar to POINTER_TYPE, but this is the actual wasm type that is
 // used in practice, while POINTER_TYPE is the more refined internal
 // type (that is unsigned, where as core wasm does not have unsigned
 // types).
-const POINTER_WASM_TYPE = `i${POINTER_BITS}`;
+globalThis.POINTER_WASM_TYPE = `i${POINTER_BITS}`;
 
 function isPointerType(type) {
   return type[type.length - 1] == '*';
@@ -698,9 +695,6 @@ function makeRetainedCompilerSettings() {
   }
   return ret;
 }
-
-// In wasm, the heap size must be a multiple of 64KiB.
-const WASM_PAGE_SIZE = 65536;
 
 // Receives a function as text, and a function that constructs a modified
 // function, to which we pass the parsed-out arguments, body, and possible

--- a/tools/preprocessor.mjs
+++ b/tools/preprocessor.mjs
@@ -52,7 +52,7 @@ global.read = (filename) => {
 };
 
 global.load = (f) => {
-  (0, eval)(read(f) + '//# sourceURL=' + find(f));
+  vm.runInThisContext(read(f), { filename: find(f) });
 };
 
 assert(args.length >= 2);
@@ -65,5 +65,8 @@ load('utility.js');
 load('modules.js');
 load('parseTools.js');
 
-const output = expandMacros ? processMacros(preprocess(inputFile)) : preprocess(inputFile);
+let output = preprocess(inputFile);
+if (expandMacros) {
+  output = processMacros(output, inputFile)
+}
 process.stdout.write(output);


### PR DESCRIPTION
Use `vm.runInCurrentContext` instead.

We already use this in the preprocessor, but not we also use it for macro expansion and loading of the compiler code itself.

This change should facilitate future changes to the JS compiler, such as changing the compiler itself to use JS modules.