### PR TITLE
Multiple fixes to EmscriptenOrientationChangeEvent

### DIFF
--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -929,7 +929,7 @@ Defines
 
 .. c:macro:: EMSCRIPTEN_ORIENTATION_UNSUPPORTED
 
-  The orientation API is not supported and the type is invalid.
+  The orientation API is not supported.
 
 .. c:macro:: EMSCRIPTEN_ORIENTATION_PORTRAIT_PRIMARY
 

--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -927,9 +927,9 @@ Defines
     Emscripten `orientationchange <https://w3c.github.io/screen-orientation/>`_ event.
 
 
-.. c:macro:: EMSCRIPTEN_ORIENTATION_UNSUPPORTED
+.. c:macro:: EMSCRIPTEN_ORIENTATION_UNKNOWN
 
-  The orientation API is not supported.
+  Either the orientation API is not supported or the orientation type is not known.
 
 .. c:macro:: EMSCRIPTEN_ORIENTATION_PORTRAIT_PRIMARY
 
@@ -958,7 +958,7 @@ Struct
 
   .. c:member:: int orientationIndex
 
-    One of the :c:type:`EM_ORIENTATION_PORTRAIT_xxx <EMSCRIPTEN_ORIENTATION_PORTRAIT_PRIMARY>` fields, or -1 if unknown.
+    One of the :c:type:`EM_ORIENTATION_PORTRAIT_xxx <EMSCRIPTEN_ORIENTATION_PORTRAIT_PRIMARY>` fields, or :c:type:`EMSCRIPTEN_ORIENTATION_UNKNOWN` if unknown.
 
   .. c:member:: int orientationAngle
 

--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -927,6 +927,10 @@ Defines
     Emscripten `orientationchange <https://w3c.github.io/screen-orientation/>`_ event.
 
 
+.. c:macro:: EMSCRIPTEN_ORIENTATION_UNSUPPORTED
+
+  The orientation API is not supported and the type is invalid.
+
 .. c:macro:: EMSCRIPTEN_ORIENTATION_PORTRAIT_PRIMARY
 
   Primary portrait mode orientation.

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -942,16 +942,21 @@ var LibraryHTML5 = {
 
     var orientationIndex = -1;
     var orientationAngle =  0;
-    var orientation = screenOrientation();
-    if (orientation) {
-      orientationIndex = orientationsType1.indexOf(orientation.type);
+    var screenOrientObj  = screenOrientation();
+    if (screenOrientObj) {
+      orientationIndex = orientationsType1.indexOf(screenOrientObj.type);
       if (orientationIndex == -1) {
-        orientationIndex = orientationsType2.indexOf(orientation.type);
+        orientationIndex = orientationsType2.indexOf(screenOrientObj.type);
       }
       if (orientationIndex != -1) {
         orientationIndex = 1 << orientationIndex;
       }
-      orientationAngle = orientation.angle;
+      orientationAngle = screenOrientObj.angle;
+    } else {
+      // fallback on the deprecated API (mostly for Safari before 2023)
+      if (window && (window["orientation"] !== undefined)) {
+        orientationAngle = window["orientation"];
+      }
     }
 
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenOrientationChangeEvent.orientationIndex, 'orientationIndex', 'i32') }}};

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -944,14 +944,21 @@ var LibraryHTML5 = {
     var orientationAngle =  0;
     var screenOrientObj  = screenOrientation();
     if (screenOrientObj) {
-      orientationIndex = orientationsType1.indexOf(screenOrientObj.type);
+      var orientationType;
+      if (typeof screenOrientObj === 'object') {
+        orientationType  = screenOrientObj.type;
+        orientationAngle = screenOrientObj.angle;
+      } else {
+        // Edge only supports the older string type until 2020 (pre-Chrome)
+        orientationType  = String(screenOrientObj);
+      }
+      orientationIndex = orientationsType1.indexOf(orientationType);
       if (orientationIndex == -1) {
-        orientationIndex = orientationsType2.indexOf(screenOrientObj.type);
+        orientationIndex = orientationsType2.indexOf(orientationType);
       }
       if (orientationIndex != -1) {
         orientationIndex = 1 << orientationIndex;
       }
-      orientationAngle = screenOrientObj.angle;
     } else {
       // fallback on the deprecated API (mostly for Safari before 2023)
       if (window && (window['orientation'] !== undefined)) {

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -935,17 +935,27 @@ var LibraryHTML5 = {
 
   $fillOrientationChangeEventData__deps: ['$screenOrientation'],
   $fillOrientationChangeEventData: (eventStruct) => {
-    var orientations  = ["portrait-primary", "portrait-secondary", "landscape-primary", "landscape-secondary"];
-    var orientations2 = ["portrait",         "portrait",           "landscape",         "landscape"];
+    // OrientationType enum
+    var orientationsType1 = ["portrait-primary", "portrait-secondary", "landscape-primary", "landscape-secondary"];
+    // alternative selection from OrientationLockType enum
+    var orientationsType2 = ["portrait",         "portrait",           "landscape",         "landscape"];
 
-    var orientationString = screenOrientation();
-    var orientation = orientations.indexOf(orientationString);
-    if (orientation == -1) {
-      orientation = orientations2.indexOf(orientationString);
+    var orientationIndex = -1;
+    var orientationAngle =  0;
+    var orientation = screenOrientation();
+    if (orientation) {
+      orientationIndex = orientationsType1.indexOf(orientation.type);
+      if (orientationIndex == -1) {
+        orientationIndex = orientationsType2.indexOf(orientation.type);
+      }
+      if (orientationIndex != -1) {
+        orientationIndex = 1 << orientationIndex;
+      }
+      orientationAngle = orientation.angle;
     }
 
-    {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenOrientationChangeEvent.orientationIndex, '1 << orientation', 'i32') }}};
-    {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenOrientationChangeEvent.orientationAngle, 'orientation', 'i32') }}};
+    {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenOrientationChangeEvent.orientationIndex, 'orientationIndex', 'i32') }}};
+    {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenOrientationChangeEvent.orientationAngle, 'orientationAngle', 'i32') }}};
   },
 
   $registerOrientationChangeEventCallback__deps: ['$JSEvents', '$fillOrientationChangeEventData', '$findEventTarget', 'malloc'],

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -952,8 +952,8 @@ var LibraryHTML5 = {
         orientationIndex = 1 << orientationIndex;
       }
       orientationAngle = screenOrientObj.angle;
-    } else {
 #if MIN_SAFARI_VERSION < 0x100400
+    } else {
       // fallback for Safari earlier than 16.4 (March 2023)
       orientationAngle = window.orientation;
 #endif

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -930,7 +930,7 @@ var LibraryHTML5 = {
 
   $screenOrientation: () => {
     if (!screen) return undefined;
-    return screen.orientation || screen.mozOrientation || screen.webkitOrientation || screen.msOrientation;
+    return screen.orientation || screen.mozOrientation || screen.webkitOrientation;
   },
 
   $fillOrientationChangeEventData__deps: ['$screenOrientation'],
@@ -943,28 +943,19 @@ var LibraryHTML5 = {
     var orientationIndex = -1;
     var orientationAngle =  0;
     var screenOrientObj  = screenOrientation();
-    if (screenOrientObj) {
-      var orientationType;
-      if (typeof screenOrientObj === 'object') {
-        orientationType  = screenOrientObj.type;
-        orientationAngle = screenOrientObj.angle;
-      } else {
-        // Edge only supports the older string type until 2020 (pre-Chrome)
-        orientationType  = String(screenOrientObj);
+    if (typeof screenOrientObj === 'object') {
+      orientationIndex = orientationsType1.indexOf(screenOrientObj.type);
+      if (orientationIndex < 0) {
+        orientationIndex = orientationsType2.indexOf(screenOrientObj.type);
       }
-      orientationIndex = orientationsType1.indexOf(orientationType);
-      if (orientationIndex == -1) {
-        orientationIndex = orientationsType2.indexOf(orientationType);
-      }
-      if (orientationIndex != -1) {
+      if (orientationIndex < 0) {
         orientationIndex = 1 << orientationIndex;
       }
+      orientationAngle = screenOrientObj.angle;
     } else {
 #if MIN_SAFARI_VERSION < 0x100400
       // fallback for Safari earlier than 16.4 (March 2023)
-      if (window && (window['orientation'] !== undefined)) {
-        orientationAngle = window['orientation'];
-      }
+      orientationAngle = window.orientation;
 #endif
     }
 

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -930,7 +930,7 @@ var LibraryHTML5 = {
 
   $screenOrientation: () => {
     if (!screen) return undefined;
-    return screen.orientation || screen.mozOrientation || screen.webkitOrientation;
+    return screen.orientation || screen['mozOrientation'] || screen['webkitOrientation'];
   },
 
   $fillOrientationChangeEventData__deps: ['$screenOrientation'],

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -936,9 +936,9 @@ var LibraryHTML5 = {
   $fillOrientationChangeEventData__deps: ['$screenOrientation'],
   $fillOrientationChangeEventData: (eventStruct) => {
     // OrientationType enum
-    var orientationsType1 = ["portrait-primary", "portrait-secondary", "landscape-primary", "landscape-secondary"];
+    var orientationsType1 = ['portrait-primary', 'portrait-secondary', 'landscape-primary', 'landscape-secondary'];
     // alternative selection from OrientationLockType enum
-    var orientationsType2 = ["portrait",         "portrait",           "landscape",         "landscape"];
+    var orientationsType2 = ['portrait',         'portrait',           'landscape',         'landscape'];
 
     var orientationIndex = -1;
     var orientationAngle =  0;
@@ -954,8 +954,8 @@ var LibraryHTML5 = {
       orientationAngle = screenOrientObj.angle;
     } else {
       // fallback on the deprecated API (mostly for Safari before 2023)
-      if (window && (window["orientation"] !== undefined)) {
-        orientationAngle = window["orientation"];
+      if (window && (window['orientation'] !== undefined)) {
+        orientationAngle = window['orientation'];
       }
     }
 

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1006,6 +1006,7 @@ var LibraryHTML5 = {
   emscripten_get_orientation_status__proxy: 'sync',
   emscripten_get_orientation_status__deps: ['$fillOrientationChangeEventData', '$screenOrientation'],
   emscripten_get_orientation_status: (orientationChangeEvent) => {
+    // screenOrientation() resolving standard, window.orientation being the deprecated mobile-only
     if (!screenOrientation() && typeof orientation == 'undefined') return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     fillOrientationChangeEventData(orientationChangeEvent);
     return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -952,12 +952,13 @@ var LibraryHTML5 = {
         orientationIndex = 1 << orientationIndex;
       }
       orientationAngle = screenOrientObj.angle;
+    }
 #if MIN_SAFARI_VERSION < 0x100400
-    } else {
+    else {
       // fallback for Safari earlier than 16.4 (March 2023)
       orientationAngle = window.orientation;
-#endif
     }
+#endif
 
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenOrientationChangeEvent.orientationIndex, 'orientationIndex', 'i32') }}};
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenOrientationChangeEvent.orientationAngle, 'orientationAngle', 'i32') }}};

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -929,7 +929,7 @@ var LibraryHTML5 = {
   },
 
   $screenOrientation: () => {
-    if (!screen) return undefined;
+    if (!window.screen) return undefined;
     return screen.orientation || screen['mozOrientation'] || screen['webkitOrientation'];
   },
 
@@ -999,7 +999,7 @@ var LibraryHTML5 = {
   emscripten_set_orientationchange_callback_on_thread__proxy: 'sync',
   emscripten_set_orientationchange_callback_on_thread__deps: ['$registerOrientationChangeEventCallback'],
   emscripten_set_orientationchange_callback_on_thread: (userData, useCapture, callbackfunc, targetThread) => {
-    if (!screen || !screen.orientation) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
+    if (!window.screen || !screen.orientation) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     return registerOrientationChangeEventCallback(screen.orientation, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_ORIENTATIONCHANGE }}}, 'change', targetThread);
   },
 

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -940,15 +940,15 @@ var LibraryHTML5 = {
     // alternative selection from OrientationLockType enum
     var orientationsType2 = ['portrait',         'portrait',           'landscape',         'landscape'];
 
-    var orientationIndex = -1;
-    var orientationAngle =  0;
+    var orientationIndex = 0;
+    var orientationAngle = 0;
     var screenOrientObj  = screenOrientation();
     if (typeof screenOrientObj === 'object') {
       orientationIndex = orientationsType1.indexOf(screenOrientObj.type);
       if (orientationIndex < 0) {
         orientationIndex = orientationsType2.indexOf(screenOrientObj.type);
       }
-      if (orientationIndex < 0) {
+      if (orientationIndex >= 0) {
         orientationIndex = 1 << orientationIndex;
       }
       orientationAngle = screenOrientObj.angle;

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1000,7 +1000,7 @@ var LibraryHTML5 = {
   emscripten_set_orientationchange_callback_on_thread__deps: ['$registerOrientationChangeEventCallback'],
   emscripten_set_orientationchange_callback_on_thread: (userData, useCapture, callbackfunc, targetThread) => {
     if (!screen || !screen.orientation) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
-    return registerOrientationChangeEventCallback(screen.orientation, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_ORIENTATIONCHANGE }}}, "change", targetThread);
+    return registerOrientationChangeEventCallback(screen.orientation, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_ORIENTATIONCHANGE }}}, 'change', targetThread);
   },
 
   emscripten_get_orientation_status__proxy: 'sync',

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -986,10 +986,6 @@ var LibraryHTML5 = {
       if ({{{ makeDynCall('iipp', 'callbackfunc') }}}(eventTypeId, orientationChangeEvent, userData)) e.preventDefault();
     };
 
-    if (eventTypeId == {{{ cDefs.EMSCRIPTEN_EVENT_ORIENTATIONCHANGE }}} && screen.mozOrientation !== undefined) {
-      eventTypeString = "mozorientationchange";
-    }
-
     var eventHandler = {
       target,
       eventTypeString,
@@ -1003,8 +999,8 @@ var LibraryHTML5 = {
   emscripten_set_orientationchange_callback_on_thread__proxy: 'sync',
   emscripten_set_orientationchange_callback_on_thread__deps: ['$registerOrientationChangeEventCallback'],
   emscripten_set_orientationchange_callback_on_thread: (userData, useCapture, callbackfunc, targetThread) => {
-    if (!screen || !screen['addEventListener']) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
-    return registerOrientationChangeEventCallback(screen, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_ORIENTATIONCHANGE }}}, "orientationchange", targetThread);
+    if (!screen || !screen['orientation']) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
+    return registerOrientationChangeEventCallback(screen.orientation, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_ORIENTATIONCHANGE }}}, "change", targetThread);
   },
 
   emscripten_get_orientation_status__proxy: 'sync',

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1026,8 +1026,6 @@ var LibraryHTML5 = {
       succeeded = screen.mozLockOrientation(orientations);
     } else if (screen.webkitLockOrientation) {
       succeeded = screen.webkitLockOrientation(orientations);
-    } else if (screen.msLockOrientation) {
-      succeeded = screen.msLockOrientation(orientations);
     } else {
       return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
@@ -1045,8 +1043,6 @@ var LibraryHTML5 = {
       screen.mozUnlockOrientation();
     } else if (screen.webkitUnlockOrientation) {
       screen.webkitUnlockOrientation();
-    } else if (screen.msUnlockOrientation) {
-      screen.msUnlockOrientation();
     } else {
       return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -999,7 +999,7 @@ var LibraryHTML5 = {
   emscripten_set_orientationchange_callback_on_thread__proxy: 'sync',
   emscripten_set_orientationchange_callback_on_thread__deps: ['$registerOrientationChangeEventCallback'],
   emscripten_set_orientationchange_callback_on_thread: (userData, useCapture, callbackfunc, targetThread) => {
-    if (!screen || !screen['orientation']) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
+    if (!screen || !screen.orientation) return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     return registerOrientationChangeEventCallback(screen.orientation, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_ORIENTATIONCHANGE }}}, "change", targetThread);
   },
 

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -960,10 +960,12 @@ var LibraryHTML5 = {
         orientationIndex = 1 << orientationIndex;
       }
     } else {
-      // fallback on the deprecated API (mostly for Safari before 2023)
+#if MIN_SAFARI_VERSION < 0x100400
+      // fallback for Safari earlier than 16.4 (March 2023)
       if (window && (window['orientation'] !== undefined)) {
         orientationAngle = window['orientation'];
       }
+#endif
     }
 
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenOrientationChangeEvent.orientationIndex, 'orientationIndex', 'i32') }}};

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -224,6 +224,7 @@ EMSCRIPTEN_RESULT emscripten_set_devicemotion_callback_on_thread(void *userData,
 
 EMSCRIPTEN_RESULT emscripten_get_devicemotion_status(EmscriptenDeviceMotionEvent *motionState __attribute__((nonnull)));
 
+#define EMSCRIPTEN_ORIENTATION_UNSUPPORTED         0
 #define EMSCRIPTEN_ORIENTATION_PORTRAIT_PRIMARY    1
 #define EMSCRIPTEN_ORIENTATION_PORTRAIT_SECONDARY  2
 #define EMSCRIPTEN_ORIENTATION_LANDSCAPE_PRIMARY   4


### PR DESCRIPTION
This fixes multiple issues with `EmscriptenOrientationChangeEvent`. Buckle in!

- The existing implementation doesn't work at all and is only useful to notify the orientation did change. It's incorrectly processed as a string from the start but is a `ScreenOrientation` object.
https://github.com/emscripten-core/emscripten/blob/b5b7fedda835bdf8f172a700726109a4a3899909/src/library_html5.js#L940
The lookup should be from `screen.orientation.type`:
<img width="290" alt="ScreenOrientation object" src="https://github.com/emscripten-core/emscripten/assets/8437014/a95d5177-6379-4d2b-958f-a6c49ac32031">

- Since it will always fail the string lookup it only ever results in `-1`, which then gets stored in the `EmscriptenOrientationChangeEvent` as `1 << orientation`, not matching any of the known values:
https://github.com/emscripten-core/emscripten/blob/b5b7fedda835bdf8f172a700726109a4a3899909/src/library_html5.js#L946

- The orientation angle is never correct, since it's the same  `-1` as above:
https://github.com/emscripten-core/emscripten/blob/b5b7fedda835bdf8f172a700726109a4a3899909/src/library_html5.js#L947

- Building with `-s ASSERTIONS=2 -s SAFE_HEAP=1` always asserts due to the same issue:
```
Aborted(Assertion failed: value (-2147483648) too small to write as 32-bit value)
```

- The docs mention `window.orientation` as an Emscripten extension but the code doesn't contain any of this:
https://github.com/emscripten-core/emscripten/blob/b5b7fedda835bdf8f172a700726109a4a3899909/site/source/docs/api_reference/html5.h.rst#L961

A repro case is to build the existing `test_html5_core.c` with `SAFE_HEAP` to trigger all the cases above:
```
emcc -O0 -g3 -s ASSERTIONS=2 -s SAFE_HEAP=1 -s USE_WEBGL2=1 -lGL test_html5_core.c -o index.html
```

This will assert on opening (even on desktop), then any devices that generate orientation changes will be always filled with the same data.

This fix:
- Rewrites the JS to pull the values out of the `ScreenOrientation` object.
- Correctly sets the `EM_ORIENTATION_PORTRAIT_xxx` type.
- Correctly sets the angle.
- For older browsers that's don't support `screen.orientation` (Safari before 2023) fallback to the `window.orientation` mentioned in the docs for the angle.
