### PR TITLE
Remove DEMANGLE_SUPPORT from docs (NFC)

### DIFF
--- a/site/source/docs/porting/Debugging.rst
+++ b/site/source/docs/porting/Debugging.rst
@@ -137,11 +137,6 @@ Some important settings are:
     performance. Default value is 1 if ``ASSERTIONS=1`` is set, and disabled
     otherwise.
 
-  -
-    .. _debugging-DEMANGLE_SUPPORT:
-
-    ``DEMANGLE_SUPPORT=1`` links in code to automatically demangle stack traces, that is, emit human-readable C++ function names instead of ``_ZN..`` ones.
-
 A number of other useful debug settings are defined in `src/settings.js <https://github.com/emscripten-core/emscripten/blob/main/src/settings.js>`_. For more information, search that file for the keywords "check" and "debug".
 
 .. _debugging-sanitizers:
@@ -166,7 +161,7 @@ Manual print debugging
 
 You can also manually instrument the source code with ``printf()`` statements, then compile and run the code to investigate issues. Note that ``printf()`` is line-buffered, make sure to add ``\n`` to see output in the console.
 
-If you have a good idea of the problem line you can add ``print(new Error().stack)`` to the JavaScript to get a stack trace at that point. Also available is :js:func:`stackTrace`, which emits a stack trace and also tries to demangle C++ function names if ``DEMANGLE_SUPPORT`` is enabled (if you don't want or need C++ demangling in a specific stack trace, you can call :js:func:`jsStackTrace`).
+If you have a good idea of the problem line you can add ``print(new Error().stack)`` to the JavaScript to get a stack trace at that point. Also available is :js:func:`stackTrace`, which emits stack trace with any extra details available (alternatively call :js:func:`jsStackTrace` to get just the stack trace).
 
 Debug printouts can even execute arbitrary JavaScript. For example::
 


### PR DESCRIPTION
The `DEMANGLE_SUPPORT` flag was deprecated as of Emscripten 3.1.54. Building with `-sDEMANGLE_SUPPORT` and `-Werror` will now fail, and as the error says "mangled names no longer appear in stack traces".

Since both JS `stackTrace()` and `jsStackTrace()` still exist, the documentation mentions both (`stackTrace() appends the result of `extraStackTrace()` but I couldn't find any docs for this).