### PR TITLE
Limit `isCurrentContextWebGL2` usage. NFC

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -10,8 +10,9 @@
 
 {{{
   globalThis.isCurrentContextWebGL2 = () => {
+    // This function should only be called inside of `#if MAX_WEBGL_VERSION >= 2` blocks
+    assert(MAX_WEBGL_VERSION >= 2, 'isCurrentContextWebGL2 called without webgl2 support');
     if (MIN_WEBGL_VERSION >= 2) return 'true';
-    if (MAX_WEBGL_VERSION <= 1) return 'false';
     return 'GL.currentContext.version >= 2';
   }
   null;


### PR DESCRIPTION
I observed that this helper macro is only needed when webgl2 is supported.

In fact, it would be a bug if it was used when webgl2 was not supported.