### PR TITLE
Update expected binaryen version to 116

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -39,7 +39,7 @@ logger = logging.getLogger('building')
 
 #  Building
 binaryen_checked = False
-EXPECTED_BINARYEN_VERSION = 117
+EXPECTED_BINARYEN_VERSION = 116
 
 _is_ar_cache: Dict[str, bool] = {}
 # the exports the user requested

--- a/tools/building.py
+++ b/tools/building.py
@@ -39,7 +39,7 @@ logger = logging.getLogger('building')
 
 #  Building
 binaryen_checked = False
-EXPECTED_BINARYEN_VERSION = 115
+EXPECTED_BINARYEN_VERSION = 117
 
 _is_ar_cache: Dict[str, bool] = {}
 # the exports the user requested


### PR DESCRIPTION
After https://github.com/WebAssembly/binaryen/pull/6358, we need to update this to pass the tests.