### PR TITLE
Update Binaryen version to 117

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -39,7 +39,7 @@ logger = logging.getLogger('building')
 
 #  Building
 binaryen_checked = False
-EXPECTED_BINARYEN_VERSION = 116
+EXPECTED_BINARYEN_VERSION = 117
 
 _is_ar_cache: Dict[str, bool] = {}
 # the exports the user requested


### PR DESCRIPTION
After https://github.com/WebAssembly/binaryen/pull/6358, I tried to update this to 117, but it looks due to some unfinished builds I ended up updating it to 116
(https://github.com/emscripten-core/emscripten/pull/21446#issuecomment-1969533426). This brings it up to 117.