### PR TITLE
Improve ES6 support in TypeScript definitions generation

### DIFF
--- a/test/other/embind_tsgen_ignore_2.d.ts
+++ b/test/other/embind_tsgen_ignore_2.d.ts
@@ -109,3 +109,4 @@ interface EmbindModule {
   wstring_test(_0: string): string;
 }
 export type MainModule = WasmModule & EmbindModule;
+export default function MainModuleFactory (options?: unknown): Promise<MainModule>;

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -631,6 +631,8 @@ def create_tsd(metadata, embind_tsd):
   if embind_tsd:
     export_interfaces += ' & EmbindModule'
   out += f'export type MainModule = {export_interfaces};\n'
+  if settings.EXPORT_ES6 and settings.MODULARIZE:
+    out += 'export default function MainModuleFactory (options?: unknown): Promise<MainModule>;\n'
   return out
 
 


### PR DESCRIPTION
## Overview

This PR merges changes to include ES6 default functor exports, when appropriate, to generated TypeScript definitions.

## Commit Messages

> Users building with --emit-tsd and the EXPORT_ES6 setting should get TypeScript definitions accounting for the fact that ES6 modules include a default export that is a functor to instantiate and access the wasm module in question
> 
> When generating TS definitions, query the EXPORT_ES6 setting and, if present, add the appropriate exports to the output