### PR TITLE
Re-enable test_dlfcn_em_asm. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2979,7 +2979,6 @@ The current type of b is: 9
     self.do_run(src, '|65830|')
 
   @needs_dylink
-  @disabled('EM_ASM in not yet supported in SIDE_MODULE')
   def test_dlfcn_em_asm(self):
     create_file('liblib.cpp', '''
       #include <emscripten.h>


### PR DESCRIPTION
This test was disabled due to EM_ASM not working in side modules but that was fixed in #18228.