### PR TITLE
Fix acorn-optimizer error when destructuring array including empty element in function parameters

### DIFF
--- a/test/optimizer/JSDCE-objectPattern-output.js
+++ b/test/optimizer/JSDCE-objectPattern-output.js
@@ -2,7 +2,7 @@ let d = 40;
 
 let z = 50;
 
-globalThis.f = function(r) {
+globalThis.f = function([, r]) {
  let {a: a, b: b} = r;
  let {z: c} = r;
  let [, i, {foo: p, bar: q}] = r;

--- a/test/optimizer/JSDCE-objectPattern.js
+++ b/test/optimizer/JSDCE-objectPattern.js
@@ -10,7 +10,7 @@ let d = 40;
 // z.
 let z = 50;
 
-globalThis.f = function(r) {
+globalThis.f = function([/*empty*/, r]) {
   let { a, b } = r;
   let { z: c } = r;
   let [/*empty*/, i, {foo : p, bar : q}] = r;

--- a/tools/acorn-optimizer.mjs
+++ b/tools/acorn-optimizer.mjs
@@ -388,7 +388,7 @@ function runJSDCE(ast, aggressive) {
         }
         if (param.type === 'ArrayPattern') {
           for (var elem of param.elements) {
-            traverse(elem);
+            if (elem) traverse(elem);
           }
         } else if (param.type === 'ObjectPattern') {
           for (var prop of param.properties) {


### PR DESCRIPTION
# Overview

Fix acorn-optimizer error when destructuring array including empty element in function parameters like this:

```javascript
function ([, a, b, c]) {
  // snip
}
```

# Cause

When the optimizer processes a function, it recursively traverses its parameters. If one of the parameters is `ArrayPattern` node (array destructuring pattern), the original code tries to walk the all elements. However, array destructuring pattern may include empty elements like this: `[, a, b, c]`.

```javascript
        if (param.type === 'ArrayPattern') {
          for (var elem of param.elements) {
            traverse(elem); // here
          }
        }
```

# Solution

Check if each element in `ArrayPattern` node is empty or not before calling `traverse` function.


# Note

It will fix a problem similar to #20843.

#20843 fixed this case:

```javascript
[, a] = x;
```

This commit will fix this case:

```javascript
function ([, a]) { }
```