### PR TITLE
Add a setjmp/longjmp runtime for a new sjlj translation proposed in LLVM

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -597,3 +597,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * James Hu <jameshu2022@gmail.com>
 * Jerry Zhuang <jerry.zhuang@jwzg.com>
 * Taisei Kon <kinsei0916@gmail.com>
+* YAMAMOTO Takashi <yamamoto@midokura.com>

--- a/system/lib/compiler-rt/emscripten_setjmp.c
+++ b/system/lib/compiler-rt/emscripten_setjmp.c
@@ -109,21 +109,19 @@ uint32_t __wasm_setjmp_test(void* env, void* func_invocation_id) {
 }
 
 #ifdef __USING_WASM_SJLJ__
-void
-__wasm_longjmp(void *env, int val)
-{
-        struct jmp_buf_impl *jb = env;
-        struct __WasmLongjmpArgs *arg = &jb->arg;
-        /*
-         * C standard says:
-         * The longjmp function cannot cause the setjmp macro to return
-         * the value 0; if val is 0, the setjmp macro returns the value 1.
-         */
-        if (val == 0) {
-                val = 1;
-        }
-        arg->env = env;
-        arg->val = val;
-        __builtin_wasm_throw(1, arg); /* 1 == C_LONGJMP */
+void __wasm_longjmp(void* env, int val) {
+  struct jmp_buf_impl* jb = env;
+  struct __WasmLongjmpArgs* arg = &jb->arg;
+  /*
+   * C standard says:
+   * The longjmp function cannot cause the setjmp macro to return
+   * the value 0; if val is 0, the setjmp macro returns the value 1.
+   */
+  if (val == 0) {
+    val = 1;
+  }
+  arg->env = env;
+  arg->val = val;
+  __builtin_wasm_throw(1, arg); /* 1 == C_LONGJMP */
 }
 #endif

--- a/system/lib/compiler-rt/emscripten_setjmp.c
+++ b/system/lib/compiler-rt/emscripten_setjmp.c
@@ -74,40 +74,20 @@ void emscripten_longjmp(uintptr_t env, int val) {
 #endif
 
 #ifdef __USING_WASM_SJLJ__
-
 struct __WasmLongjmpArgs {
   void *env;
   int val;
 };
-
-thread_local struct __WasmLongjmpArgs __wasm_longjmp_args;
-
-// llvm uses `1` for the __c_longjmp tag.
-// See https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/CodeGen/WasmEHFuncInfo.h
-#define C_LONGJMP 1
-
-// Wasm EH allows us to throw and catch multiple values, but that requires
-// multivalue support in the toolchain, whch is not reliable at the time.
-// TODO Consider switching to throwing two values at the same time later.
-void __wasm_longjmp(void *env, int val) {
-  __wasm_longjmp_args.env = env;
-  /*
-￼  * C standard:
-￼  *   The longjmp function cannot cause the setjmp macro to return
-￼  *   the value 0; if val is 0, the setjmp macro returns the value 1.
-￼  */
-  if (val == 0) {
-    val = 1;
-  }
-  __wasm_longjmp_args.val = val;
-  __builtin_wasm_throw(C_LONGJMP, &__wasm_longjmp_args);
-}
+#endif
 
 // jmp_buf should have large enough size and alignment to contain
 // this structure.
 struct jmp_buf_impl {
   void* func_invocation_id;
   uint32_t label;
+#ifdef __USING_WASM_SJLJ__
+  struct __WasmLongjmpArgs arg;
+#endif
 };
 
 void __wasm_setjmp(void* env, uint32_t label, void* func_invocation_id) {
@@ -126,5 +106,24 @@ uint32_t __wasm_setjmp_test(void* env, void* func_invocation_id) {
     return jb->label;
   }
   return 0;
+}
+
+#ifdef __USING_WASM_SJLJ__
+void
+__wasm_longjmp(void *env, int val)
+{
+        struct jmp_buf_impl *jb = env;
+        struct __WasmLongjmpArgs *arg = &jb->arg;
+        /*
+         * C standard says:
+         * The longjmp function cannot cause the setjmp macro to return
+         * the value 0; if val is 0, the setjmp macro returns the value 1.
+         */
+        if (val == 0) {
+                val = 1;
+        }
+        arg->env = env;
+        arg->val = val;
+        __builtin_wasm_throw(1, arg); /* 1 == C_LONGJMP */
 }
 #endif


### PR DESCRIPTION
the new runtime code is basically a copy from:
https://github.com/yamt/garbage/blob/wasm-sjlj-alt2/wasm/longjmp/rt.c.

The corresponding LLVM change:
https://github.com/llvm/llvm-project/pull/84137

Discussion:
https://docs.google.com/document/d/1ZvTPT36K5jjiedF8MCXbEmYjULJjI723aOAks1IdLLg/edit