### PR TITLE
Generate TypeScript definitions for runtime exports.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint-config-prettier": "^9.1.0",
         "prettier": "^3.1.1",
         "source-map": "0.7.4",
+        "typescript": "^5.4.2",
         "webpack": "^5.89.0",
         "webpack-cli": "^5.1.4",
         "ws": "^8.16.0"
@@ -4807,6 +4808,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -8657,6 +8671,12 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.1.1",
     "source-map": "0.7.4",
+    "typescript": "^5.4.2",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",
     "ws": "^8.16.0"

--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -653,8 +653,17 @@ function(${args}) {
       if (force) {
         commentText += '/** @suppress {duplicate } */\n';
       }
-      if (LibraryManager.library[symbol + '__docs']) {
-        commentText += LibraryManager.library[symbol + '__docs'] + '\n';
+
+      let docs = LibraryManager.library[symbol + '__docs'];
+      if (docs) {
+        commentText += docs + '\n';
+      }
+
+      if (EMIT_TSD) {
+        LibraryManager.libraryDefinitions[mangled] = {
+          docs: docs || '',
+          snippet,
+        };
       }
 
       const depsText = deps
@@ -741,6 +750,7 @@ var proxiedFunctionTable = [
           librarySymbols,
           warnings: warningOccured(),
           asyncFuncs,
+          libraryDefinitions: LibraryManager.libraryDefinitions,
           ATINITS: ATINITS.join('\n'),
           ATMAINS: STRICT ? '' : ATMAINS.join('\n'),
           ATEXITS: ATEXITS.join('\n'),

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -28,6 +28,8 @@ export const librarySymbols = [];
 
 export const LibraryManager = {
   library: {},
+  // The JS and JS docs of each library definition indexed my mangled name.
+  libraryDefinitions: {},
   structs: {},
   loaded: false,
   libraries: [],

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -89,6 +89,9 @@ var USE_ASAN = false;
 // Whether embind has been enabled.
 var EMBIND = false;
 
+// Whether a TypeScript definition file has been requested.
+var EMIT_TSD = false;
+
 // Whether the main() function reads the argc/argv parameters.
 var MAIN_READS_PARAMS = true;
 

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -1,4 +1,16 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
+declare namespace RuntimeExports {
+    let HEAPF64: any;
+    let HEAP_DATA_VIEW: any;
+    let HEAP8: any;
+    let HEAPU8: any;
+    let HEAP16: any;
+    let HEAPU16: any;
+    let HEAP32: any;
+    let HEAPU32: any;
+    let HEAP64: any;
+    let HEAPU64: any;
+}
 interface WasmModule {
   _main(_0: number, _1: number): number;
 }
@@ -109,4 +121,4 @@ interface EmbindModule {
   string_test(_0: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): string;
   wstring_test(_0: string): string;
 }
-export type MainModule = WasmModule & EmbindModule;
+export type MainModule = WasmModule & typeof RuntimeExports & EmbindModule;

--- a/test/other/embind_tsgen_bigint.d.ts
+++ b/test/other/embind_tsgen_bigint.d.ts
@@ -1,8 +1,20 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
+declare namespace RuntimeExports {
+    let HEAPF64: any;
+    let HEAP_DATA_VIEW: any;
+    let HEAP8: any;
+    let HEAPU8: any;
+    let HEAP16: any;
+    let HEAPU16: any;
+    let HEAP32: any;
+    let HEAPU32: any;
+    let HEAP64: any;
+    let HEAPU64: any;
+}
 interface WasmModule {
 }
 
 interface EmbindModule {
   bigintFn(_0: bigint): bigint;
 }
-export type MainModule = WasmModule & EmbindModule;
+export type MainModule = WasmModule & typeof RuntimeExports & EmbindModule;

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -1,4 +1,28 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
+declare namespace RuntimeExports {
+    let HEAPF64: any;
+    let HEAP_DATA_VIEW: any;
+    let HEAP8: any;
+    let HEAPU8: any;
+    let HEAP16: any;
+    let HEAPU16: any;
+    let HEAP32: any;
+    let HEAPU32: any;
+    let HEAP64: any;
+    let HEAPU64: any;
+    function keepRuntimeAlive(): any;
+    /** @constructor */
+    function ExitStatus(status: any): void;
+    let wasmMemory: any;
+    let FS_createPath: any;
+    function FS_createDataFile(parent: any, name: any, fileData: any, canRead: any, canWrite: any, canOwn: any): void;
+    function FS_createPreloadedFile(parent: any, name: any, url: any, canRead: any, canWrite: any, onload: any, onerror: any, dontCreateFile: any, canOwn: any, preFinish: any): void;
+    function FS_unlink(path: any): any;
+    let FS_createLazyFile: any;
+    let FS_createDevice: any;
+    let addRunDependency: any;
+    let removeRunDependency: any;
+}
 interface WasmModule {
   _pthread_self(): number;
   _main(_0: number, _1: number): number;
@@ -116,4 +140,4 @@ interface EmbindModule {
   string_test(_0: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): string;
   wstring_test(_0: string): string;
 }
-export type MainModule = WasmModule & EmbindModule;
+export type MainModule = WasmModule & typeof RuntimeExports & EmbindModule;

--- a/test/other/embind_tsgen_ignore_3.d.ts
+++ b/test/other/embind_tsgen_ignore_3.d.ts
@@ -1,4 +1,16 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
+declare namespace RuntimeExports {
+    let HEAPF64: any;
+    let HEAP_DATA_VIEW: any;
+    let HEAP8: any;
+    let HEAPU8: any;
+    let HEAP16: any;
+    let HEAPU16: any;
+    let HEAP32: any;
+    let HEAPU32: any;
+    let HEAP64: any;
+    let HEAPU64: any;
+}
 interface WasmModule {
   _main(_0: number, _1: number): number;
 }
@@ -109,4 +121,4 @@ interface EmbindModule {
   string_test(_0: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): string;
   wstring_test(_0: string): string;
 }
-export type MainModule = WasmModule & EmbindModule;
+export type MainModule = WasmModule & typeof RuntimeExports & EmbindModule;

--- a/test/other/embind_tsgen_memory64.d.ts
+++ b/test/other/embind_tsgen_memory64.d.ts
@@ -1,8 +1,20 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
+declare namespace RuntimeExports {
+    let HEAPF64: any;
+    let HEAP_DATA_VIEW: any;
+    let HEAP8: any;
+    let HEAPU8: any;
+    let HEAP16: any;
+    let HEAPU16: any;
+    let HEAP32: any;
+    let HEAPU32: any;
+    let HEAP64: any;
+    let HEAPU64: any;
+}
 interface WasmModule {
 }
 
 interface EmbindModule {
   longFn(_0: bigint): bigint;
 }
-export type MainModule = WasmModule & EmbindModule;
+export type MainModule = WasmModule & typeof RuntimeExports & EmbindModule;

--- a/test/other/test_emit_tsd.d.ts
+++ b/test/other/test_emit_tsd.d.ts
@@ -1,8 +1,32 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
+declare namespace RuntimeExports {
+    /**
+     * Given a pointer 'idx' to a null-terminated UTF8-encoded string in the given
+     * array that contains uint8 values, returns a copy of that string as a
+     * Javascript String object.
+     * heapOrArray is either a regular array, or a JavaScript typed array view.
+     * @param {number} idx
+     * @param {number=} maxBytesToRead
+     * @return {string}
+     */
+    function UTF8ArrayToString(heapOrArray: any, idx: number, maxBytesToRead?: number): string;
+    let HEAPF32: any;
+    let HEAPF64: any;
+    let HEAP_DATA_VIEW: any;
+    let HEAP8: any;
+    let HEAPU8: any;
+    let HEAP16: any;
+    let HEAPU16: any;
+    let HEAP32: any;
+    let HEAPU32: any;
+    let HEAP64: any;
+    let HEAPU64: any;
+}
 interface WasmModule {
   _fooVoid(): void;
   _fooInt(_0: number, _1: number): number;
   _main(_0: number, _1: number): number;
 }
 
-export type MainModule = WasmModule;
+export type MainModule = WasmModule & typeof RuntimeExports;
+export default function MainModuleFactory (options?: unknown): Promise<MainModule>;

--- a/test/other/test_tsd.ts
+++ b/test/other/test_tsd.ts
@@ -1,0 +1,8 @@
+import moduleFactory from './test_emit_tsd.js'
+
+async function go() {
+  const module = await moduleFactory();
+  module._fooVoid();
+  let result = module._fooInt(7, 8);
+  module.UTF8ArrayToString([], 99);
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3246,9 +3246,14 @@ More info: https://emscripten.org
 
   def test_emit_tsd(self):
     self.run_process([EMCC, test_file('other/test_emit_tsd.c'),
-                      '--emit-tsd', 'test_emit_tsd.d.ts', '-Wno-experimental'] +
+                      '--emit-tsd', 'test_emit_tsd.d.ts', '-sEXPORT_ES6',
+                      '-sMODULARIZE', '-sEXPORTED_RUNTIME_METHODS=UTF8ArrayToString',
+                      '-Wno-experimental', '-o', 'test_emit_tsd.js'] +
                      self.get_emcc_args())
     self.assertFileContents(test_file('other/test_emit_tsd.d.ts'), read_file('test_emit_tsd.d.ts'))
+    # Test that the output compiles with a TS file that uses the defintions.
+    cmd = shared.get_npm_cmd('tsc') + [test_file('other/test_tsd.ts'), '--noEmit']
+    shared.check_call(cmd)
 
   def test_emconfig(self):
     output = self.run_process([emconfig, 'LLVM_ROOT'], stdout=PIPE).stdout.strip()

--- a/tools/link.py
+++ b/tools/link.py
@@ -1344,6 +1344,9 @@ def phase_linker_setup(options, state, newargs):
   if '-lembind' in [x for _, x in state.link_flags]:
     settings.EMBIND = 1
 
+  if options.embind_emit_tsd or options.emit_tsd:
+    settings.EMIT_TSD = True
+
   if settings.PTHREADS:
     setup_pthreads(target)
     settings.JS_LIBRARIES.append((0, 'library_pthread.js'))


### PR DESCRIPTION
When building the JS library, collect the JS and corresponding JS docs so they can be used by the TypeScript compiler to generate definitions for any of the exported runtime functions.

I also added a test for using the output in a TS file.

Note: Initially I tried running tsc on the final JS output, but it often got confused when the Module had dynamic properties added to it. Maybe once we clean things up this will be a better option.