### PR TITLE
Use lvalue rather than rvalue references

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -265,9 +265,9 @@ EMSCRIPTEN_ALWAYS_INLINE void writeGenericWireTypes(GenericWireType*& cursor, Fi
 
 template<typename... Args>
 struct WireTypePack {
-  WireTypePack(Args&&... args) {
+  WireTypePack(const Args&... args) {
     GenericWireType* cursor = elements.data();
-    writeGenericWireTypes(cursor, std::forward<Args>(args)...);
+    writeGenericWireTypes(cursor, args...);
   }
 
   operator EM_VAR_ARGS() const {


### PR DESCRIPTION
(Note that these were not forwarding references.  Using rvalue references here had caused an awkward need for std::move at <https://git.libreoffice.org/core/+/0bab5cda2123ecc7f3775d05ca5103bdef23bfe8%5E%21> "Add Embing'ing of UNO Any getter for enums" etc.)