### PR TITLE
Revert "Warn when setting used on the command line more than once (#21464)"

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -684,9 +684,6 @@ def phase_parse_arguments(state):
   for s in settings_changes:
     key, value = s.split('=', 1)
     key, value = normalize_boolean_setting(key, value)
-    old_value = user_settings.get(key)
-    if old_value and old_value != value:
-      diagnostics.warning('unused-command-line-argument', f'-s{key} specified multiple times. Ignoring previous value (`{old_value}`)')
     user_settings[key] = value
 
   # STRICT is used when applying settings so it needs to be applied first before

--- a/test/common.py
+++ b/test/common.py
@@ -903,7 +903,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     # For historical reasons emcc compiles and links as C++ by default.
     # However we want to run our tests in a more strict manner.  We can
     # remove this if the issue above is ever fixed.
-    self.set_setting('DEFAULT_TO_CXX', 0)
+    self.set_setting('NO_DEFAULT_TO_CXX')
     self.ldflags = []
     # Increate stack trace limit to maximise usefulness of test failure reports
     self.node_args = ['--stack-trace-limit=50']

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4773,7 +4773,7 @@ Module["preRun"] = () => {
     'modularize': (['-sMODULARIZE', '-sEXPORT_NAME=MyModule'],),
     'O3': (['-O3'],),
     'O3_modularize': (['-O3', '-sMODULARIZE', '-sEXPORT_NAME=MyModule'],),
-    'O3_modularize_MINIMAL_RUNTIME_2': (['-O3', '-sMODULARIZE', '-sEXPORT_NAME=MyModule', '-sMINIMAL_RUNTIME=2', '-Wno-unused-command-line-argument'],),
+    'O3_modularize_MINIMAL_RUNTIME_2': (['-O3', '-sMODULARIZE', '-sEXPORT_NAME=MyModule', '-sMINIMAL_RUNTIME=2'],),
   })
   def test_minimal_runtime_hello_thread(self, opts):
     self.btest_exit('pthread/hello_thread.c', args=['--closure=1', '-sMINIMAL_RUNTIME', '-pthread'] + opts)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9125,9 +9125,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # embind should work with stack overflow checks (see #12356)
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
     self.set_setting('EXIT_RUNTIME')
-    self.set_setting('DEFAULT_TO_CXX')
     self.emcc_args += ['-lembind']
-    self.do_run_in_out_file_test('core/pthread/create.c')
+    self.do_run_in_out_file_test('core/pthread/create.c', emcc_args=['-sDEFAULT_TO_CXX'])
 
   @node_pthreads
   def test_pthread_exceptions(self):

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7815,10 +7815,6 @@ high = 1234
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS=[{"a":1}]'])
     self.assertContained("list members in settings must be strings (not $<class 'dict'>)", err)
 
-  def test_dash_s_repeated(self):
-    err = self.expect_fail([EMCC, '-Werror', test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS=foo', '-sEXPORTED_FUNCTIONS=bar'])
-    self.assertContained('emcc: error: -sEXPORTED_FUNCTIONS specified multiple times. Ignoring previous value (`foo`) [-Wunused-command-line-argument]', err)
-
   def test_zeroinit(self):
     create_file('src.c', r'''
 #include <stdio.h>
@@ -12023,23 +12019,21 @@ Aborted(`Module.arguments` has been replaced by `arguments_` (the initial value 
 
   @parameterized({
     '': ([],),
-    'minimal': (['-sMINIMAL_RUNTIME'],),
+    'minimal': (['-sMINIMAL_RUNTIME', '-sSUPPORT_ERRNO'],),
   })
   def test_support_errno(self, args):
     self.emcc_args += args + ['-sEXPORTED_FUNCTIONS=_main,___errno_location', '-Wno-deprecated']
 
-    self.do_other_test('test_support_errno.c', emcc_args=['-sSUPPORT_ERRNO'])
-    size_enabled = os.path.getsize('test_support_errno.js')
+    self.do_other_test('test_support_errno.c')
+    size_default = os.path.getsize('test_support_errno.js')
 
     # Run the same test again but with SUPPORT_ERRNO disabled.  This time we don't expect errno
     # to be set after the failing syscall.
-    self.do_other_test('test_support_errno.c', emcc_args=['-sSUPPORT_ERRNO=0'], out_suffix='_disabled')
+    self.emcc_args += ['-sSUPPORT_ERRNO=0']
+    self.do_other_test('test_support_errno.c', out_suffix='_disabled')
 
     # Verify the JS output was smaller
-    size_disabled = os.path.getsize('test_support_errno.js')
-    print(size_enabled)
-    print(size_disabled)
-    self.assertLess(size_disabled, size_enabled)
+    self.assertLess(os.path.getsize('test_support_errno.js'), size_default)
 
   def test_assembly(self):
     self.run_process([EMCC, '-c', test_file('other/test_asm.s'), '-o', 'foo.o'])

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -332,7 +332,7 @@ class sockets(BrowserCore):
   })
   def test_websocket_send(self, args):
     with NodeJsWebSocketEchoServerProcess():
-      self.btest_exit('websocket/test_websocket_send.c', args=['-lwebsocket', '-sWEBSOCKET_DEBUG'] + args)
+      self.btest_exit('websocket/test_websocket_send.c', args=['-lwebsocket', '-sNO_EXIT_RUNTIME', '-sWEBSOCKET_DEBUG'] + args)
 
   # Test that native POSIX sockets API can be used by proxying calls to an intermediate WebSockets
   # -> POSIX sockets bridge server


### PR DESCRIPTION
This reverts commit 696b4f292630ad954ad55babd79ff78a4a384b73.

After some discussion we decided it was best not to issue a warning here, since many folks
expect later flag to silently override earlier ones.