### PR TITLE
Pointer can be `const void*` in GenericWireType

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -207,7 +207,7 @@ union GenericWireType {
     unsigned u;
     size_t s;
     float f;
-    void* p;
+    const void* p;
   } w[2];
   double d;
   uint64_t u;


### PR DESCRIPTION
...as it had already been prior to abeba41cb92b868e51a0c931d04d226727942181 "[Wasm64] Initial work for get parts of embind working".  It being non-const caused some issue for client code at
<https://git.libreoffice.org/core/+/98c42f7e961e77d7f1c02d53862e4e78ecd07653%5E!> "Adapt to emsdk 3.1.46".