### PR TITLE
Finish converting JS compiler to ES6 modules. NFC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 3.1.57 (in development)
 -----------------------
+- JS library code is now executed in its own context/scope, which limits how
+  much of the compiler internals are accessible. If there are build time JS
+  symbols that you are depending on, but that were not added to this scope,
+  please file a bug and we can add more to this scope. (#21542)
 
 3.1.56 - 03/14/24
 -----------------

--- a/src/parseTools_legacy.mjs
+++ b/src/parseTools_legacy.mjs
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  */
 
+import {warn, addToCompileTimeContext} from './utility.mjs';
+import {ATMAINS, POINTER_SIZE, runIfMainThread} from './parseTools.mjs';
+
 // Takes a pair of return values, stashes one in tempRet0 and returns the other.
 // Should probably be renamed to `makeReturn64` but keeping this old name in
 // case external JS library code uses this name.
@@ -109,14 +112,11 @@ function getNativeFieldSize(type) {
   return Math.max(getNativeTypeSize(type), POINTER_SIZE);
 }
 
-globalThis.Runtime = {
-  getNativeTypeSize,
+const Runtime = {
   getNativeFieldSize,
   POINTER_SIZE,
   QUANTUM_SIZE: POINTER_SIZE,
 };
-
-globalThis.ATMAINS = [];
 
 function addAtMain(code) {
   warn('use of legacy parseTools function: addAtMain');
@@ -137,3 +137,16 @@ function asmFFICoercion(value, type) {
 
 // Legacy name for runIfMainThread.
 const runOnMainThread = runIfMainThread;
+
+addToCompileTimeContext({
+  ATMAINS,
+  Runtime,
+  addAtMain,
+  asmFFICoercion,
+  makeCopyValues,
+  makeMalloc,
+  makeStructuralReturn,
+  receiveI64ParamAsDouble,
+  receiveI64ParamAsI32s,
+  runOnMainThread,
+});

--- a/tools/preprocessor.mjs
+++ b/tools/preprocessor.mjs
@@ -12,61 +12,28 @@
 //                   file with modified settings and supply the filename here.
 //    input file     This is the file that will be processed by the preprocessor
 
-'use strict';
-
-import * as fs from 'fs';
-import * as path from 'path';
-import * as vm from 'vm';
 import assert from 'assert';
-import * as url from 'url';
+
+import {loadSettingsFile} from '../src/utility.mjs';
 
 const args = process.argv.slice(2);
 const debug = false;
 
-// Anything needed by the script that we load below must be added to the
-// global object.  These, for example, are all needed by parseTools.js.
-global.vm = vm;
-global.assert = assert;
-global.print = (x) => {
-  process.stdout.write(x + '\n');
-};
-global.printErr = (x) => {
-  process.stderr.write(x + '\n');
-};
-
-function find(filename) {
-  const dirname = url.fileURLToPath(new URL('.', import.meta.url));
-  const prefixes = [process.cwd(), path.join(dirname, '..', 'src')];
-  for (let i = 0; i < prefixes.length; ++i) {
-    const combined = path.join(prefixes[i], filename);
-    if (fs.existsSync(combined)) {
-      return combined;
-    }
-  }
-  return filename;
-}
-
-global.read = (filename) => {
-  const absolute = find(filename);
-  return fs.readFileSync(absolute).toString();
-};
-
-global.load = (f) => {
-  vm.runInThisContext(read(f), {filename: find(f)});
-};
-
-assert(args.length >= 2);
+assert(args.length >= 2, 'Script requires 2 arguments');
 const settingsFile = args[0];
 const inputFile = args[1];
 const expandMacros = args.includes('--expandMacros');
 
-load(settingsFile);
-load('utility.js');
-load('modules.js');
-load('parseTools.js');
+loadSettingsFile(settingsFile);
 
-let output = preprocess(inputFile);
+// We can't use static import statements here because several of these
+// file depend on having the settings defined in the global scope (which
+// we do dynamically above.
+const parseTools = await import('../src/parseTools.mjs');
+await import('../src/modules.mjs');
+
+let output = parseTools.preprocess(inputFile);
 if (expandMacros) {
-  output = processMacros(output, inputFile);
+  output = parseTools.processMacros(output, inputFile);
 }
 process.stdout.write(output);


### PR DESCRIPTION
The compiler itself is now purely JS modules.

As part of this change I create a new global context object in which all library code is processed.  This allows is to have a clean separation between the compiler code itself and code being processed. Only symbols explicitly added to the macro context are available to JS library code.