### PR TITLE
Remove unused `bind` and `sum` utilities. NFC

### DIFF
--- a/src/parseTools_legacy.js
+++ b/src/parseTools_legacy.js
@@ -65,6 +65,10 @@ function stripCorrections(param) {
 
 const UNROLL_LOOP_MAX = 8;
 
+function range(size) {
+  return Array.from(Array(size).keys());
+}
+
 function makeCopyValues(dest, src, num, type, modifier, align, sep = ';') {
   warn('use of legacy parseTools function: makeCopyValues');
   assert(typeof align === 'undefined');

--- a/src/utility.js
+++ b/src/utility.js
@@ -78,20 +78,6 @@ function error(msg) {
   printErr(`error: ${errorPrefix()}${msg}`);
 }
 
-function range(size) {
-  return Array.from(Array(size).keys());
-}
-
-function bind(self, func) {
-  return function(...args) {
-    func.apply(self, args);
-  };
-}
-
-function sum(x) {
-  return x.reduce((a, b) => a + b, 0);
-}
-
 // options is optional input object containing mergeInto params
 // currently, it can contain
 //


### PR DESCRIPTION
Move `range` utility to `parseTools_legacy.js` which is the only place it was used.