### PR TITLE
Run prettier on compiler-internal JS files. NFC

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -225,13 +225,15 @@ globalThis.LibraryManager = {
       currentFile = filename;
       try {
         processed = processMacros(preprocess(filename), filename);
-        vm.runInThisContext(processed, { filename: filename.replace(/\.\w+$/, '.preprocessed$&') });
+        vm.runInThisContext(processed, {filename: filename.replace(/\.\w+$/, '.preprocessed$&')});
       } catch (e) {
         error(`failure to execute js library "${filename}":`);
         if (VERBOSE) {
           const orig = read(filename);
           if (processed) {
-            error(`preprocessed source (you can run a js engine on this to get a clearer error message sometimes):\n=============\n${processed}\n=============`);
+            error(
+              `preprocessed source (you can run a js engine on this to get a clearer error message sometimes):\n=============\n${processed}\n=============`,
+            );
           } else {
             error(`original source:\n=============\n${orig}\n=============`);
           }
@@ -252,7 +254,7 @@ globalThis.LibraryManager = {
 if (!BOOTSTRAPPING_STRUCT_INFO) {
   let structInfoFile = 'generated_struct_info32.json';
   if (MEMORY64) {
-    structInfoFile = 'generated_struct_info64.json'
+    structInfoFile = 'generated_struct_info64.json';
   }
   // Load struct and define information.
   const temp = JSON.parse(read(structInfoFile));
@@ -268,19 +270,23 @@ if (!BOOTSTRAPPING_STRUCT_INFO) {
 C_STRUCTS = new Proxy(C_STRUCTS, {
   get(target, prop, receiver) {
     if (!(prop in target)) {
-      throw new Error(`Missing C struct ${prop}! If you just added it to struct_info.json, you need to run ./tools/gen_struct_info.py`);
+      throw new Error(
+        `Missing C struct ${prop}! If you just added it to struct_info.json, you need to run ./tools/gen_struct_info.py`,
+      );
     }
-    return target[prop]
-  }
+    return target[prop];
+  },
 });
 
 cDefs = C_DEFINES = new Proxy(C_DEFINES, {
   get(target, prop, receiver) {
     if (!(prop in target)) {
-      throw new Error(`Missing C define ${prop}! If you just added it to struct_info.json, you need to run ./tools/gen_struct_info.py`);
+      throw new Error(
+        `Missing C define ${prop}! If you just added it to struct_info.json, you need to run ./tools/gen_struct_info.py`,
+      );
     }
-    return target[prop]
-  }
+    return target[prop];
+  },
 });
 
 // Legacy function that existed solely to give error message.  These are now
@@ -383,10 +389,14 @@ function exportRuntime() {
     'HEAPF32',
     'HEAPF64',
     'HEAP_DATA_VIEW',
-    'HEAP8',  'HEAPU8',
-    'HEAP16', 'HEAPU16',
-    'HEAP32', 'HEAPU32',
-    'HEAP64', 'HEAPU64',
+    'HEAP8',
+    'HEAPU8',
+    'HEAP16',
+    'HEAPU16',
+    'HEAP32',
+    'HEAPU32',
+    'HEAP64',
+    'HEAPU64',
   ];
 
   // These are actually native wasm functions these days but we allow exporting
@@ -424,11 +434,11 @@ function exportRuntime() {
   }
 
   if (RETAIN_COMPILER_SETTINGS) {
-    runtimeElements.push('getCompilerSetting')
+    runtimeElements.push('getCompilerSetting');
   }
 
   if (RUNTIME_DEBUG) {
-    runtimeElements.push('prettyPrint')
+    runtimeElements.push('prettyPrint');
   }
 
   // dynCall_* methods are not hardcoded here, as they

--- a/src/parseTools_legacy.js
+++ b/src/parseTools_legacy.js
@@ -38,23 +38,23 @@ function stripCorrections(param) {
   warn('use of legacy parseTools function: stripCorrections');
   let m;
   while (true) {
-    if (m = /^\((.*)\)$/.exec(param)) {
+    if ((m = /^\((.*)\)$/.exec(param))) {
       param = m[1];
       continue;
     }
-    if (m = /^\(([$_\w]+)\)&\d+$/.exec(param)) {
+    if ((m = /^\(([$_\w]+)\)&\d+$/.exec(param))) {
       param = m[1];
       continue;
     }
-    if (m = /^\(([$_\w()]+)\)\|0$/.exec(param)) {
+    if ((m = /^\(([$_\w()]+)\)\|0$/.exec(param))) {
       param = m[1];
       continue;
     }
-    if (m = /^\(([$_\w()]+)\)\>>>0$/.exec(param)) {
+    if ((m = /^\(([$_\w()]+)\)\>>>0$/.exec(param))) {
       param = m[1];
       continue;
     }
-    if (m = /CHECK_OVERFLOW\(([^,)]*),.*/.exec(param)) {
+    if ((m = /CHECK_OVERFLOW\(([^,)]*),.*/.exec(param))) {
       param = m[1];
       continue;
     }
@@ -69,14 +69,16 @@ function makeCopyValues(dest, src, num, type, modifier, align, sep = ';') {
   warn('use of legacy parseTools function: makeCopyValues');
   assert(typeof align === 'undefined');
   function unroll(type, num, jump = 1) {
-    const setValues = range(num).map((i) => makeSetValue(dest, i * jump, makeGetValue(src, i * jump, type), type));
+    const setValues = range(num).map((i) =>
+      makeSetValue(dest, i * jump, makeGetValue(src, i * jump, type), type),
+    );
     return setValues.join(sep);
   }
   // If we don't know how to handle this at compile-time, or handling it is best
   // done in a large amount of code, call memcpy
   if (!isNumber(num)) num = stripCorrections(num);
   if (!isNumber(align)) align = stripCorrections(align);
-  if (!isNumber(num) || (parseInt(num) / align >= UNROLL_LOOP_MAX)) {
+  if (!isNumber(num) || parseInt(num) / align >= UNROLL_LOOP_MAX) {
     return '(_memcpy(' + dest + ', ' + src + ', ' + num + ')|0)';
   }
   num = parseInt(num);
@@ -88,7 +90,7 @@ function makeCopyValues(dest, src, num, type, modifier, align, sep = ';') {
   [4, 2, 1].forEach((possibleAlign) => {
     if (num == 0) return;
     if (align >= possibleAlign) {
-      ret.push(unroll('i' + (possibleAlign * 8), Math.floor(num / possibleAlign), possibleAlign));
+      ret.push(unroll('i' + possibleAlign * 8, Math.floor(num / possibleAlign), possibleAlign));
       src = getFastValue(src, '+', Math.floor(num / possibleAlign) * possibleAlign);
       dest = getFastValue(dest, '+', Math.floor(num / possibleAlign) * possibleAlign);
       num %= possibleAlign;

--- a/src/utility.js
+++ b/src/utility.js
@@ -41,7 +41,7 @@ globalThis.currentFile = null;
 
 function errorPrefix() {
   if (currentFile) {
-    return currentFile + ': '
+    return currentFile + ': ';
   } else {
     return '';
   }
@@ -102,7 +102,9 @@ function mergeInto(obj, other, options = null) {
     if (options.noOverride) {
       for (const key of Object.keys(other)) {
         if (obj.hasOwnProperty(key)) {
-          error(`Symbol re-definition in JavaScript library: ${key}. Do not use noOverride if this is intended`);
+          error(
+            `Symbol re-definition in JavaScript library: ${key}. Do not use noOverride if this is intended`,
+          );
           return;
         }
       }
@@ -154,28 +156,32 @@ function mergeInto(obj, other, options = null) {
       if (decoratorName === '__deps') {
         const deps = other[key];
         if (!Array.isArray(deps)) {
-          error(`JS library directive ${key}=${deps.toString()} is of type '${type}', but it should be an array`);
+          error(
+            `JS library directive ${key}=${deps.toString()} is of type '${type}', but it should be an array`,
+          );
         }
         for (let dep of deps) {
           if (dep && typeof dep !== 'string' && typeof dep !== 'function') {
-            error(`__deps entries must be of type 'string' or 'function' not '${typeof dep}': ${key}`)
+            error(
+              `__deps entries must be of type 'string' or 'function' not '${typeof dep}': ${key}`,
+            );
           }
         }
       } else {
         // General type checking for all other decorators
         const decoratorTypes = {
-          '__sig': 'string',
-          '__proxy': 'string',
-          '__asm': 'boolean',
-          '__inline': 'boolean',
-          '__postset': ['string', 'function'],
-          '__docs': 'string',
-          '__nothrow': 'boolean',
-          '__noleakcheck': 'boolean',
-          '__internal': 'boolean',
-          '__user': 'boolean',
-          '__async': 'boolean',
-          '__i53abi': 'boolean',
+          __sig: 'string',
+          __proxy: 'string',
+          __asm: 'boolean',
+          __inline: 'boolean',
+          __postset: ['string', 'function'],
+          __docs: 'string',
+          __nothrow: 'boolean',
+          __noleakcheck: 'boolean',
+          __internal: 'boolean',
+          __user: 'boolean',
+          __async: 'boolean',
+          __i53abi: 'boolean',
         };
         const expected = decoratorTypes[decoratorName];
         if (type !== expected && !expected.includes(type)) {
@@ -219,7 +225,7 @@ function isDecorator(ident) {
 }
 
 function isPowerOfTwo(x) {
-  return x > 0 && ((x & (x - 1)) == 0);
+  return x > 0 && (x & (x - 1)) == 0;
 }
 
 class Benchmarker {
@@ -249,7 +255,9 @@ class Benchmarker {
     const ids = Object.keys(this.totals);
     if (ids.length > 0) {
       ids.sort((a, b) => this.totals[b] - this.totals[a]);
-      printErr(text + ' times: \n' + ids.map((id) => id + ' : ' + this.totals[id] + ' ms').join('\n'));
+      printErr(
+        text + ' times: \n' + ids.map((id) => id + ' : ' + this.totals[id] + ' ms').join('\n'),
+      );
     }
   }
 }


### PR DESCRIPTION
This is in preparation for #21542 which converts them to `.mjs`.  Since we run prettier during CI on all `.mjs` files this change this change avoid superfluous changes at the point of rename.