### PR TITLE
Restore `range` function from #21544

### DIFF
--- a/src/parseTools_legacy.js
+++ b/src/parseTools_legacy.js
@@ -65,10 +65,6 @@ function stripCorrections(param) {
 
 const UNROLL_LOOP_MAX = 8;
 
-function range(size) {
-  return Array.from(Array(size).keys());
-}
-
 function makeCopyValues(dest, src, num, type, modifier, align, sep = ';') {
   warn('use of legacy parseTools function: makeCopyValues');
   assert(typeof align === 'undefined');

--- a/src/utility.js
+++ b/src/utility.js
@@ -78,6 +78,10 @@ function error(msg) {
   printErr(`error: ${errorPrefix()}${msg}`);
 }
 
+function range(size) {
+  return Array.from(Array(size).keys());
+}
+
 // options is optional input object containing mergeInto params
 // currently, it can contain
 //


### PR DESCRIPTION
I was wicked and didn't wait for the CI to finish.  Turns out this function was bring used by library_webgl.js.