### PR TITLE
Fix wasm workers futex support

### DIFF
--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -99,7 +99,7 @@ addToLibrary({
     _emscripten_wasm_worker_initialize(m['sb'], m['sz']);
 #if PTHREADS
     // Record that this Wasm Worker supports synchronous blocking in emscripten_futex_wake().
-    ___set_thread_state(/*thread_ptr=*/0, /*is_main_thread=*/0, /*is_runtime_thread=*/0, /*supports_wait=*/0);
+    ___set_thread_state(/*thread_ptr=*/0, /*is_main_thread=*/0, /*is_runtime_thread=*/0, /*supports_wait=*/1);
 #endif
 #if STACK_OVERFLOW_CHECK >= 2
     // Fix up stack base. (TLS frame is created at the bottom address end of the stack)


### PR DESCRIPTION
With PTHREADS and WASM workers this would cause an error in emscripten_futex_wait due to going into the main browser thread code path.

I'm not familiar with the concept of audio workers so that should be verified by someone more knowledgeable. For reference, the failure point was here: https://github.com/emscripten-core/emscripten/blob/918e131fae0b5c7b1d05a5c75d7e8e676c377713/system/lib/pthread/emscripten_futex_wait.c#L129

specifically the code below. TBH that code is flawed and should likely be change to simply check if we are the main thread - futex_wait_main_browser_thread is hardwired around the concept of CAS on one specific address so it falls apart if used from more than one thread.
```
  // For the main browser thread and audio worklets we can't use
  // __builtin_wasm_memory_atomic_wait32 so we have busy wait instead.
  if (!_emscripten_thread_supports_atomics_wait()) {
    ret = futex_wait_main_browser_thread(addr, val, max_wait_ms);
    emscripten_conditional_set_current_thread_status(EM_THREAD_STATUS_WAITFUTEX, EM_THREAD_STATUS_RUNNING);
    return ret;
  }
```