### PR TITLE
Skip export wrapper for `stackRestore` function.

### DIFF
--- a/test/other/test_exceptions_exit_runtime.cpp
+++ b/test/other/test_exceptions_exit_runtime.cpp
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+void foo() {
+  printf("foo\n");
+  exit(0);
+}
+
+int main() {
+  printf("main\n");
+  try {
+    // `foo` calls `exit()` which triggers the runtime to exit and then
+    // the stack to unwind.
+    // This test verifies that we don't error during the unwinding due
+    // to the runtime having already exited.
+    foo();
+  } catch(...) {
+    printf("caught\n");
+  }
+}

--- a/test/other/test_exceptions_exit_runtime.out
+++ b/test/other/test_exceptions_exit_runtime.out
@@ -1,0 +1,2 @@
+main
+foo

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8998,6 +8998,19 @@ int main() {
                       expected_output=rethrow_stack_trace_checks, regex=True)
     self.assertNotContained('important_function', err)
 
+  @parameterized({
+    '': (False,),
+    'wasm': (True,),
+  })
+  def test_exceptions_exit_runtime(self, wasm_eh):
+    self.set_setting('EXIT_RUNTIME')
+    if wasm_eh:
+      self.require_wasm_eh()
+      self.emcc_args.append('-fwasm-exceptions')
+    else:
+      self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
+    self.do_other_test('test_exceptions_exit_runtime.cpp')
+
   @requires_node
   def test_jsrun(self):
     print(config.NODE_JS)


### PR DESCRIPTION
The `stackRestore` function used by `invoke_xxx` wrappers and gets called as the stack unwinds after a call to `exit`.

Alternatively we could add a check in each of the `invoke_xxx` wrappers to avoid calling `stackRestore`, but that doesn't seem worth it.

Fixes: #21474