### PR TITLE
new contrib.glfw3 version (fix joystick issue)

### DIFF
--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -6,8 +6,8 @@
 import os
 from typing import Dict
 
-TAG = '1.1.0'
-HASH = 'ca97ef5db558d957f78f2698ca6aef66f17e3253ad6434417793d6283f3cda16cbe18a460d9403b9a939651e0e5349f53a859b7d19a9220b2e168030f74fcb56'
+TAG = '3.4.0.20240318'
+HASH = 'fb90b43d74c234b5534c8936973c1f98e8843c16fae81ce4e1415ea947d1364aa7a167eed4cf263150f1df0f137319d0151e8fe39dc00d4eeb0c3ad48ede03f3'
 
 # contrib port information (required)
 URL = 'https://github.com/pongasoft/emscripten-glfw'


### PR DESCRIPTION
This is a new version of contrib.glfw3 which fixes a joystick issue ([release notes](https://github.com/pongasoft/emscripten-glfw/releases/tag/v3.4.0.20240318))

I took this opportunity to change the version numbering as per your request. It's now GLFW version + date of release of port. There is no real reason to have a specific port version (hence using the date). There are other projects that follow this versioning scheme.

