### PR TITLE
Avoid exporting "ready" promise on the module object

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -242,7 +242,20 @@ var sampleRate;
  */
 var id;
 
+/**
+ * Used in MODULARIZE mode as the name of the incoming module argument.
+ * This is generated outside of the code we pass to closure so from closure's
+ * POV this is "extern".
+ */
 var moduleArg;
+
+/**
+ * Used in MODULARIZE mode.
+ * We need to access this after the code we pass to closure so from closure's
+ * POV this is "extern".
+ * @suppress {duplicate}
+ */
+var readyPromise;
 
 /**
  * This was removed from upstream closure compiler in

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -984,8 +984,8 @@ function to64(x) {
 }
 
 // Add assertions to catch common errors when using the Promise object we
-// create on Module.ready() and return from MODULARIZE Module() invocations.
-function addReadyPromiseAssertions(promise) {
+// return from MODULARIZE Module() invocations.
+function addReadyPromiseAssertions() {
   // Warn on someone doing
   //
   //  var instance = Module();
@@ -1001,8 +1001,8 @@ function addReadyPromiseAssertions(promise) {
   return (
     res +
     `.forEach((prop) => {
-  if (!Object.getOwnPropertyDescriptor(${promise}, prop)) {
-    Object.defineProperty(${promise}, prop, {
+  if (!Object.getOwnPropertyDescriptor(readyPromise, prop)) {
+    Object.defineProperty(readyPromise, prop, {
       get: () => abort('You are getting ' + prop + '${warningEnding}'),
       set: () => abort('You are setting ' + prop + '${warningEnding}'),
     });

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -202,9 +202,9 @@ var WASM_EXCEPTIONS = false;
 // EXPORTED_FUNCTIONS then this gets set to 0.
 var EXPECT_MAIN = true;
 
-// Provide and export a .ready() Promise. This is currently used by default with
-// MODULARIZE, and returned from the factory function.
-var EXPORT_READY_PROMISE = true;
+// Return a "ready" Promise from the MODULARIZE factory function.
+// We disable this under some circumstance if we know its not needed.
+var USE_READY_PROMISE = true;
 
 // If true, building against Emscripten's wasm heap memory profiler.
 var MEMORYPROFILER = false;

--- a/src/shell.js
+++ b/src/shell.js
@@ -66,12 +66,12 @@ var Module = typeof {{{ EXPORT_NAME }}} != 'undefined' ? {{{ EXPORT_NAME }}} : {
 #if MODULARIZE
 // Set up the promise that indicates the Module is initialized
 var readyPromiseResolve, readyPromiseReject;
-Module['ready'] = new Promise((resolve, reject) => {
+var readyPromise = new Promise((resolve, reject) => {
   readyPromiseResolve = resolve;
   readyPromiseReject = reject;
 });
 #if ASSERTIONS
-{{{ addReadyPromiseAssertions("Module['ready']") }}}
+{{{ addReadyPromiseAssertions() }}}
 #endif
 #endif
 

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -33,15 +33,15 @@ var Module =
 var Module = {{{ EXPORT_NAME }}};
 #endif
 
-#if MODULARIZE && EXPORT_READY_PROMISE
+#if MODULARIZE && USE_READY_PROMISE
 // Set up the promise that indicates the Module is initialized
 var readyPromiseResolve, readyPromiseReject;
-Module['ready'] = new Promise((resolve, reject) => {
+var readyPromise = new Promise((resolve, reject) => {
   readyPromiseResolve = resolve;
   readyPromiseReject = reject;
 });
 #if ASSERTIONS
-{{{ addReadyPromiseAssertions("Module['ready']") }}}
+{{{ addReadyPromiseAssertions() }}}
 #endif
 #endif
 
@@ -125,7 +125,7 @@ var err = (text) => console.error(text);
 // compilation is ready. In that callback, call the function run() to start
 // the program.
 function ready() {
-#if MODULARIZE && EXPORT_READY_PROMISE
+#if MODULARIZE && USE_READY_PROMISE
   readyPromiseResolve(Module);
 #endif // MODULARIZE
 #if INVOKE_RUN && HAS_MAIN

--- a/tools/link.py
+++ b/tools/link.py
@@ -1141,7 +1141,7 @@ def phase_linker_setup(options, state, newargs):
     # Promise. However, in Pthreads mode the Promise is used for worker
     # creation.
     if settings.MINIMAL_RUNTIME and options.oformat == OFormat.HTML and not settings.PTHREADS:
-      settings.EXPORT_READY_PROMISE = 0
+      settings.USE_READY_PROMISE = 0
 
   if settings.WASM2JS and settings.LEGACY_VM_SUPPORT:
     settings.POLYFILL_OLD_MATH_FUNCTIONS = 1
@@ -2334,9 +2334,10 @@ def modularize():
   # the return statement.
   return_value = 'moduleArg'
   if settings.WASM_ASYNC_COMPILATION:
-    return_value += '.ready'
-  if not settings.EXPORT_READY_PROMISE:
-    return_value = '{}'
+    if settings.USE_READY_PROMISE:
+      return_value = 'readyPromise'
+    else:
+      return_value = '{}'
 
   # TODO: Remove when https://bugs.webkit.org/show_bug.cgi?id=223533 is resolved.
   if async_emit != '' and settings.EXPORT_NAME == 'config':


### PR DESCRIPTION
I believe the "ready" promise was set on the Module object here primarily so that closure would not minify the name.  Instead of polluting the Module namespace we can instead just tell closure not to minify it.

In addition to polluting the `Module` namespace exporting a `ready` promise is also confusing since the only way to get a module object when `-sMODULARIZE` is used is via waiting on the promise returned from the factory function.  So, by definition, the promise has already resolved before anyone can access it.

Instead we use the `closure-externs.js` file to suppress the minifiction which matches the behavior of the incoming `moduleArg` argument.