### PR TITLE
Use short timezone names in _tzset_js

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -618,7 +618,11 @@ addToLibrary({
     return ret;
   },
 
-  _tzset_js__deps: ['$stringToUTF8'],
+  _tzset_js__deps: ['$stringToUTF8',
+#if ASSERTIONS
+    '$lengthBytesUTF8',
+#endif
+  ],
   _tzset_js__internal: true,
   _tzset_js: (timezone, daylight, std_name, dst_name) => {
     // TODO: Use (malleable) environment variables instead of system settings.
@@ -645,12 +649,13 @@ addToLibrary({
 
     {{{ makeSetValue('daylight', '0', 'Number(winterOffset != summerOffset)', 'i32') }}};
 
-    function extractZone(date) {
-      var match = date.toTimeString().match(/\(([A-Za-z ]+)\)$/);
-      return match ? match[1] : "GMT";
-    };
+    var extractZone = (date) => date.toLocaleTimeString(undefined, {timeZoneName:'short'}).split(' ')[2];
     var winterName = extractZone(winter);
     var summerName = extractZone(summer);
+#if ASSERTIONS
+    assert(lengthBytesUTF8(winterName) <= {{{ cDefs.TZNAME_MAX }}}, `timezone name truncated to fit in TZNAME_MAX (${winterName})`);
+    assert(lengthBytesUTF8(summerName) <= {{{ cDefs.TZNAME_MAX }}}, `timezone name truncated to fit in TZNAME_MAX (${summerName})`);
+#endif
     if (summerOffset < winterOffset) {
       // Northern hemisphere
       stringToUTF8(winterName, std_name, {{{ cDefs.TZNAME_MAX + 1 }}});

--- a/test/runner.py
+++ b/test/runner.py
@@ -135,7 +135,7 @@ def get_all_tests(modules):
 
 
 def get_crossplatform_tests(modules):
-  suites = ['core2', 'other'] # We don't need all versions of every test
+  suites = ['core0', 'other'] # We don't need all versions of every test
   crossplatform_tests = []
   # Walk over the test suites and find the test functions with the
   # is_crossplatform_test attribute applied by @crossplatform decorator

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2656,6 +2656,7 @@ The current type of b is: 9
     self.set_setting('EXIT_RUNTIME')
     self.do_core_test('test_strptime_reentrant.c')
 
+  @crossplatform
   def test_strftime(self):
     self.do_core_test('test_strftime.c')
 


### PR DESCRIPTION
Without this change then timezone names will be the long form (Pacific
Standard Time) rather than the short form (PST), and since TZNAME_MAX
in musl is 6 (same in POSIX) the long names were getting truncated.

Fixes: #21582