### PR TITLE
[Fix] contrib.glfw3 overrides built-in GLFW (in cache)

### DIFF
--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -166,7 +166,7 @@ class Ports:
     dest = Ports.get_include_dir()
     assert os.path.exists(dest)
     if target:
-      dest = os.path.join(dest, target)
+      dest = os.path.join(dest, *target.split('/'))
       shared.safe_ensure_dirs(dest)
     matches = glob.glob(os.path.join(src_dir, pattern))
     assert matches, f'no headers found to install in {src_dir}'

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -167,14 +167,12 @@ class Ports:
     assert os.path.exists(dest)
     if target:
       dest = os.path.join(dest, target)
+      shared.safe_ensure_dirs(dest)
     matches = glob.glob(os.path.join(src_dir, pattern))
     assert matches, f'no headers found to install in {src_dir}'
     for f in matches:
-      rel_path = os.path.relpath(f, start=src_dir)
-      dest_path = os.path.join(dest, os.path.dirname(rel_path))
-      shared.safe_ensure_dirs(dest_path)
-      logger.debug('installing: ' + os.path.join(dest_path, os.path.basename(f)))
-      maybe_copy(f, os.path.join(dest_path, os.path.basename(f)))
+      logger.debug('installing: ' + os.path.join(dest, os.path.basename(f)))
+      maybe_copy(f, os.path.join(dest, os.path.basename(f)))
 
   @staticmethod
   def build_port(src_dir, output_path, port_name, includes=[], flags=[], cxxflags=[], exclude_files=[], exclude_dirs=[], srcs=[]):  # noqa

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -166,13 +166,15 @@ class Ports:
     dest = Ports.get_include_dir()
     assert os.path.exists(dest)
     if target:
-      dest = os.path.join(dest, *target.split('/'))
-      shared.safe_ensure_dirs(dest)
+      dest = os.path.join(dest, target)
     matches = glob.glob(os.path.join(src_dir, pattern))
     assert matches, f'no headers found to install in {src_dir}'
     for f in matches:
-      logger.debug('installing: ' + os.path.join(dest, os.path.basename(f)))
-      maybe_copy(f, os.path.join(dest, os.path.basename(f)))
+      rel_path = os.path.relpath(f, start=src_dir)
+      dest_path = os.path.join(dest, os.path.dirname(rel_path))
+      shared.safe_ensure_dirs(dest_path)
+      logger.debug('installing: ' + os.path.join(dest_path, os.path.basename(f)))
+      maybe_copy(f, os.path.join(dest_path, os.path.basename(f)))
 
   @staticmethod
   def build_port(src_dir, output_path, port_name, includes=[], flags=[], cxxflags=[], exclude_files=[], exclude_dirs=[], srcs=[]):  # noqa

--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -47,7 +47,7 @@ def get(ports, settings, shared):
     source_path = os.path.join(root_path, 'src', 'cpp')
     source_include_paths = [os.path.join(root_path, 'external'), os.path.join(root_path, 'include')]
     for source_include_path in source_include_paths:
-      ports.install_headers(source_include_path, pattern="GLFW/*.h", target='contrib.glfw3')
+      ports.install_headers(os.path.join(source_include_path, 'GLFW'), target=os.path.join('contrib.glfw3', 'GLFW'))
 
     flags = []
 

--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -45,9 +45,9 @@ def get(ports, settings, shared):
   def create(final):
     root_path = os.path.join(ports.get_dir(), 'contrib.glfw3')
     source_path = os.path.join(root_path, 'src', 'cpp')
-    source_include_paths = [os.path.join(root_path, 'external', 'GLFW'), os.path.join(root_path, 'include', 'GLFW')]
+    source_include_paths = [os.path.join(root_path, 'external'), os.path.join(root_path, 'include')]
     for source_include_path in source_include_paths:
-      ports.install_headers(source_include_path, target='GLFW')
+      ports.install_headers(f'{source_include_path}/GLFW', target='contrib.glfw3/GLFW')
 
     flags = []
 

--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -47,7 +47,7 @@ def get(ports, settings, shared):
     source_path = os.path.join(root_path, 'src', 'cpp')
     source_include_paths = [os.path.join(root_path, 'external'), os.path.join(root_path, 'include')]
     for source_include_path in source_include_paths:
-      ports.install_headers(f'{source_include_path}/GLFW', target='contrib.glfw3/GLFW')
+      ports.install_headers(source_include_path, pattern="GLFW/*.h", target='contrib.glfw3')
 
     flags = []
 


### PR DESCRIPTION
As I was working on another port, something that should not be working was working... so I investigated and found an issue. The contrib port ended up overriding the built-in GLFW in the cache.

After this fix it doesn't happen anymore:

```
# ls -la cache/sysroot/include/GLFW
-rw-r--r--@ 1 ypujante  wheel  215860 Mar 21 12:54 glfw3.h
# ls -la cache/sysroot/include/contrib.glfw3/GLFW
-rw-r--r--@ 1 ypujante  wheel    6219 Mar 21 12:54 emscripten_glfw3.h
-rw-r--r--@ 1 ypujante  wheel  241826 Mar 21 12:54 glfw3.h
```

As you can see after the fix the 2 directories contain different versions of glfw3.h (which is expected since as you know I upgraded the contrib port to GLFW 3.4).

When you run the `emcc` command, you can see that the search path is set properly:

```text
/usr/local/emsdk/emscripten/main/emcc --verbose --use-port=contrib.glfw3 --shell-file=shell.html main.cpp -o build/index.html
#include "..." search starts here:
#include <...> search starts here:
 /usr/local/include
 /usr/local/emsdk/emscripten/main/cache/sysroot/include/contrib.glfw3
 /usr/local/emsdk/emscripten/main/cache/sysroot/include/fakesdl
 /usr/local/emsdk/emscripten/main/cache/sysroot/include/compat
 /usr/local/emsdk/emscripten/main/cache/sysroot/include/c++/v1
 /usr/local/emsdk/upstream/lib/clang/19/include
 /usr/local/emsdk/emscripten/main/cache/sysroot/include
```

So when a source code includes

```cpp
#include <GLFW/glfw3.h>
```

then it will pick up the right one under `cache/sysroot/include/contrib.glfw3` (and not the one under `cache/sysroot/include` which is last in the list)

This fix requires a minor change in `ports.install_headers` to allow for nested folders (which BTW, I also need for another project I am working on)
