### PR TITLE
Avoid duplicate initialization of bindings

### DIFF
--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -2133,10 +2133,10 @@ inline void register_type(const char* name) {
 // __attribute__((constructor)) (they run before C++ constructors in the same
 // file).
 #define EMSCRIPTEN_BINDINGS(name)                                              \
-  static void embind_init_##name();                                            \
-  static struct EmBindInit_##name : emscripten::internal::InitFunc {           \
+  inline void embind_init_##name();                                            \
+  inline struct EmBindInit_##name : emscripten::internal::InitFunc {           \
     EmBindInit_##name() : InitFunc(embind_init_##name) {}                      \
   } EmBindInit_##name##_instance;                                              \
-  static void embind_init_##name()
+  inline void embind_init_##name()
 
 } // end namespace emscripten


### PR DESCRIPTION
`EMSCRIPTEN_BINDINGS(binding_context)` macro can be used in a header file (an example is `emscripten/bind.h`
When such a header is #included in multiple translation units, it can cause duplicate registration of the same bindings, resulting in a runtime error. 
This fix eliminates duplicate global `EmBindInit_..._instance` objects.