### PR TITLE
Specify dependencies compatible with sphinx==2.4.4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,13 @@ lxml==4.9.2
 # This version is mentioned in `site/source/docs/site/about.rst`.
 # Please keep them in sync.
 sphinx==2.4.4
+# See https://github.com/emscripten-core/emscripten/issues/21590
+sphinxcontrib-applehelp<=1.0.4
+sphinxcontrib-devhelp<=1.0.2
+sphinxcontrib-htmlhelp<=2.0.0
+sphinxcontrib-serializinghtml<=1.1.5
+sphinxcontrib-qthelp<=1.0.3
+alabaster<=0.7.12
 # See https://github.com/readthedocs/readthedocs.org/issues/9038
 jinja2<3.1
 


### PR DESCRIPTION
fixes: #21590