### PR TITLE
JS type legalization is still performed regardless of LEGALIZE_JS_FFI

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -1495,6 +1495,11 @@ def phase_linker_setup(options, state, newargs):
 
   if settings.WASM_BIGINT:
     settings.LEGALIZE_JS_FFI = 0
+  else:
+    # These symbols are needed for the JS API legalization pass in emscripten-wasm-finalize
+    # Legalization is only *fully* disabled when bigint is available.  LEGALIZE_JS_FFI=0 does not
+    # disable all legalization.
+    settings.REQUIRED_EXPORTS += ['__get_temp_ret', '__set_temp_ret']
 
   if settings.SINGLE_FILE:
     settings.GENERATE_SOURCE_MAP = 0
@@ -1518,9 +1523,6 @@ def phase_linker_setup(options, state, newargs):
 
   if settings.AUTODEBUG:
     settings.REQUIRED_EXPORTS += ['setTempRet0']
-
-  if settings.LEGALIZE_JS_FFI:
-    settings.REQUIRED_EXPORTS += ['__get_temp_ret', '__set_temp_ret']
 
   if settings.SPLIT_MODULE and settings.ASYNCIFY == 2:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['_load_secondary_module']


### PR DESCRIPTION
`wasm-emscripten-finalize` will always performs some amount of type legalization unless WASM_BIGINT is enabled.  The logic in `finalize_wasm` was getting this wrong.

I'm not sure exactly what the side effects of this are today but I'm working on change to `getTempRet0`/`setTempRet0` handling where this becomes a problem because `js_legalization_pass_flags` was not being passed to `wasm-emscripten-finalize` even though some amount of legalization was happening.  This was only effecting the `WASM_BIGINT=0` + `LEGALIZE_JS_FFI=0` case in which partial legalization occurs.

See: #21579