### PR TITLE
Document -sWASM_WORKERS=2 build mode better.

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -1635,9 +1635,13 @@ var USE_SQLITE3 = false;
 // [compile+link] - affects user code at compile and system libraries at link.
 var SHARED_MEMORY = false;
 
-// If true, enables support for Wasm Workers. Wasm Workers enable applications
+// If 1, enables support for Wasm Workers. Wasm Workers enable applications
 // to create threads using a lightweight web-specific API that builds on top
-// of Wasm SharedArrayBuffer + Atomics API.
+// of Wasm SharedArrayBuffer + Atomics API. When enabled, a new build output
+// file a.ww.js will be generated to bootstrap the Wasm Worker JS contexts.
+// If 2, enables support for Wasm Workers, but without using a separate a.ww.js
+// file on the side. This can simplify deployment of builds, but will have a
+// downside that the generated build will no longer be csp-eval compliant.
 // [compile+link] - affects user code at compile and system libraries at link.
 var WASM_WORKERS = 0;
 


### PR DESCRIPTION
Document -sWASM_WORKERS=2 build mode better. It was previously documented directly in code in https://github.com/emscripten-core/emscripten/blob/8b180923ccc1f1e05688f76bd935675d7e7c8ff1/src/library_wasm_worker.js#L130-L134 , but was not that discoverable. Closes #21609.