### PR TITLE
Clean up internal Python "KeyError: 'libwasm_workers'" from appearing…

### DIFF
--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -20,6 +20,8 @@
 #error "Internal error! SHARED_MEMORY should be enabled when building with WASM_WORKERS"
 #endif
 #if SINGLE_FILE
+// Supporting SINGLE_FILE with WASM_WORKERS would be tedious but doable: it would require programmatically extracting the
+// JS <script> tag contents from the main .html file (distinguishing between multiple such <script> elements), and then eval()ing it.
 #error "-sSINGLE_FILE is not supported with -sWASM_WORKERS!"
 #endif
 #if LINKABLE
@@ -33,6 +35,9 @@
 #endif
 #if PROXY_TO_WORKER
 #error "-sPROXY_TO_WORKER is not supported with -sWASM_WORKERS!"
+#endif
+#if RELOCATABLE
+#error "-sRELOCATABLE is not supported with -sWASM_WORKERS!"
 #endif
 
 #endif // ~WASM_WORKERS

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13518,6 +13518,15 @@ int main() {
   def test_wasm_worker_preprocessor_flags(self):
     self.run_process([EMCC, '-c', test_file('wasm_worker/wasm_worker_preprocessor_flags.c'), '-sWASM_WORKERS'])
 
+  # Tests that when attempting to use WASM_WORKERS with SINGLE_FILE, a proper error message is presented.
+  def test_wasm_workers_error_messages(self):
+    stderr = self.expect_fail([EMCC, test_file('wasm_worker/hello_wasm_worker.c'), '-sWASM_WORKERS', '-sSINGLE_FILE'])
+    self.assertContained('-sSINGLE_FILE is not supported with -sWASM_WORKERS', stderr)
+    stderr = self.expect_fail([EMCC, test_file('wasm_worker/hello_wasm_worker.c'), '-sWASM_WORKERS', '-sRELOCATABLE'])
+    self.assertContained('-sRELOCATABLE is not supported with -sWASM_WORKERS', stderr)
+    stderr = self.expect_fail([EMCC, test_file('wasm_worker/hello_wasm_worker.c'), '-sWASM_WORKERS', '-sPROXY_TO_WORKER'])
+    self.assertContained('-sPROXY_TO_WORKER is not supported with -sWASM_WORKERS', stderr)
+
   @parameterized({
     # we will warn here since -O2 runs the optimizer and -g enables DWARF
     'O2_g': (True, ['-O2', '-g'],),

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1427,11 +1427,6 @@ class libwasm_workers(MTLibrary):
         path='system/lib/wasm_worker',
         filenames=['library_wasm_worker.c' if self.is_ww or self.is_mt else 'library_wasm_worker_stub.c'])
 
-  def can_use(self):
-    # see src/library_wasm_worker.js
-    return super().can_use() and not settings.SINGLE_FILE \
-      and not settings.RELOCATABLE and not settings.PROXY_TO_WORKER
-
 
 class libsockets(MuslInternalLibrary, MTLibrary):
   name = 'libsockets'


### PR DESCRIPTION
… when attempting to use -sWASM_WORKERS with -sSINGLE_FILE.