### PR TITLE
[test] Disable test_strftime_zZ_gb_locale on macOS. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -918,9 +918,7 @@ jobs:
           python: "$EMSDK_PYTHON"
       - run-tests:
           title: "crossplatform tests"
-          # Skipping test_strftime_zZ_gb_locale since this test forces the
-          # locale to one that is not necessarily available on macOS.
-          test_targets: "--crossplatform-only skip:other.test_strftime_zZ_gb_locale"
+          test_targets: "--crossplatform-only"
       - upload-test-results
 
   test-mac-arm64:
@@ -942,9 +940,7 @@ jobs:
       # are currently missing arm64 macos binaries.
       - run-tests:
           title: "crossplatform tests"
-          # Skipping test_strftime_zZ_gb_locale since this test forces the
-          # locale to one that is not necessarily available on macOS.
-          test_targets: "--crossplatform-only skip:other.test_strftime_zZ_gb_locale"
+          test_targets: "--crossplatform-only"
       - upload-test-results
 
 workflows:

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
   raise Exception('do not run this file directly; do something like: test/runner other')
 
 from tools.shared import config
-from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, FILE_PACKAGER, WINDOWS, LLVM_NM
+from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, FILE_PACKAGER, LLVM_NM
 from tools.shared import CLANG_CC, CLANG_CXX, LLVM_AR, LLVM_DWARFDUMP, LLVM_DWP, EMCMAKE, EMCONFIGURE, WASM_LD
 from common import RunnerCore, path_from_root, is_slow_test, ensure_dir, disabled, make_executable
 from common import env_modify, no_mac, no_windows, only_windows, requires_native_clang, with_env_modify
@@ -40,7 +40,7 @@ from common import also_with_minimal_runtime, also_with_wasm_bigint, also_with_w
 from common import EMTEST_BUILD_VERBOSE, PYTHON, WEBIDL_BINDER
 from common import requires_network
 from tools import shared, building, utils, response_file, cache
-from tools.utils import read_file, write_file, delete_file, read_binary
+from tools.utils import read_file, write_file, delete_file, read_binary, MACOS, WINDOWS
 import common
 import jsrun
 import clang_native
@@ -5721,6 +5721,8 @@ int main()
   @crossplatform
   @also_with_env_modify({'gb_locale': {'LC_ALL': 'en_GB'}, 'long_tz': {'TZ': 'Asia/Kathmandu'}})
   def test_strftime_zZ(self):
+    if os.environ.get('LC_ALL') == 'en_GB' and MACOS:
+      self.skipTest('setting LC_ALL is not compatible with macOS python')
     self.do_runf('other/test_strftime_zZ.c', 'ok!')
 
   def test_strptime_symmetry(self):


### PR DESCRIPTION
This test doesn't currently run on macOS due to python failing to start when LC_ALL is set to an unavailable locale.