### PR TITLE
[wasm-split] Fix renaming of wasm to wasm.orig

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -454,7 +454,7 @@ def make_js_executable(script):
 
 
 def do_split_module(wasm_file, options):
-  os.rename(wasm_file, wasm_file + '.orig')
+  os.replace(wasm_file, wasm_file + '.orig')
   args = ['--instrument']
   if options.requested_debug:
     # Tell wasm-split to preserve function names.


### PR DESCRIPTION
When renaming `wasm` to `wasm.orig`, `os.rename` fails on windows platform when `wasm.orig` already exists. It can be replaced with `os.replace` to achieve same behaviour with no failure.