### PR TITLE
Minor cleanup of emscripten_setjmp.c. NFC

### DIFF
--- a/system/lib/compiler-rt/emscripten_exception_builtins.c
+++ b/system/lib/compiler-rt/emscripten_exception_builtins.c
@@ -12,6 +12,8 @@
 #include <stdint.h>
 #include <threads.h>
 
+#include "emscripten_internal.h"
+
 thread_local uintptr_t __THREW__ = 0;
 thread_local int __threwValue = 0;
 

--- a/system/lib/libc/emscripten_internal.h
+++ b/system/lib/libc/emscripten_internal.h
@@ -26,6 +26,8 @@
 extern "C" {
 #endif
 
+void setThrew(uintptr_t threw, int value);
+
 // An external JS implementation that is efficient for very large copies, using
 // HEAPU8.set()
 void _emscripten_memcpy_js(void* __restrict__ dest,


### PR DESCRIPTION
- Move `emscripten_longjmp` down alongside `__wasm_longjmp` where it can live in and `#else` block.
- Move `C_LONGJMP` down to where it is used.
- Declare `setThrew` in emscripten_internal.h