### PR TITLE
Fix lto0.test_longjmp_standalone_standalone. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -550,6 +550,7 @@ jobs:
             lto2.test_dylink_syslibs_all
             lto2.test_float_builtins
             lto0.test_exceptions_allowed_uncaught
+            lto0.test_longjmp_standalone_standalone
             core3
             core2g.test_externref
             corez.test_dylink_iostream

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -923,7 +923,7 @@ class libcompiler_rt(MTLibrary, SjLjLibrary):
   # restriction soon: https://reviews.llvm.org/D71738
   force_object_files = True
 
-  cflags = ['-fno-builtin']
+  cflags = ['-fno-builtin', '-DNDEBUG']
   src_dir = 'system/lib/compiler-rt/lib/builtins'
   includes = ['system/lib/libc']
   # gcc_personality_v0.c depends on libunwind, which don't include by default.


### PR DESCRIPTION
As part of #21502 some assertions were added to the wasm SjLj helpers.

Because calls to these functions can be generated during LTO we exclude compiler-rt from LTO and always build it as normal object files. Because these normal object files could be pulled in after LTO takes
place, they cannot themsleves refer to LTO objects.   Sadly `assert`
referees to printf and stdout stuff which is compiled as LTO.  This
leads the failures we are currently setting for
lto0.test_longjmp_standalone_standalone:

```
wasm-ld: error: /usr/local/google/home/sbc/dev/wasm/emscripten/cache/sysroot/lib/wasm32-emscripten/lto/libc-debug.a(stderr.o): attempt to add bitcode file after LTO (__stderr_FILE)
wasm-ld: error: /usr/local/google/home/sbc/dev/wasm/emscripten/cache/sysroot/lib/wasm32-emscripten/lto/libc-debug.a(fprintf.o): attempt to add bitcode file after LTO (fprintf)
```

Building with `-DNDEBUG` works around this issue by not actually including the assert code.  Its also more correct to do so for compiler-rt which is not a debug library.