### PR TITLE
[embind] Only allow class types for unique_ptr bindings.

### DIFF
--- a/system/include/emscripten/wire.h
+++ b/system/include/emscripten/wire.h
@@ -106,6 +106,7 @@ struct TypeID {
 
 template<typename T>
 struct TypeID<std::unique_ptr<T>> {
+    static_assert(std::is_class<T>::value, "The type for a std::unique_ptr binding must be a class.");
     static constexpr TYPEID get() {
         return TypeID<T>::get();
     }

--- a/test/embind/embind_test.cpp
+++ b/test/embind/embind_test.cpp
@@ -1043,30 +1043,42 @@ void emval_test_call_function(val v, int i, float f, TupleVector tv, StructVecto
     v(i, f, tv, sv);
 }
 
+struct CharWrapper {
+    CharWrapper(char v) {
+        value = v;
+    };
+
+    char getValue() {
+        return value;
+    }
+
+    char value;
+};
+
 class UniquePtrToConstructor {
 public:
-    UniquePtrToConstructor(std::unique_ptr<int> p)
-        : value(*p)
+    UniquePtrToConstructor(std::unique_ptr<CharWrapper> p)
+        : value((*p).getValue())
     {}
     
-    int getValue() const {
+    char getValue() const {
         return value;
     }
     
 private:
-    int value;
+    char value;
 };
 
-std::unique_ptr<int> embind_test_return_unique_ptr(int v) {
-    return std::unique_ptr<int>(new int(v));
+std::unique_ptr<CharWrapper> embind_test_return_unique_ptr(char v) {
+    return std::unique_ptr<CharWrapper>(new CharWrapper(v));
 }
 
-UniquePtrToConstructor* embind_test_construct_class_with_unique_ptr(int v) {
+UniquePtrToConstructor* embind_test_construct_class_with_unique_ptr(char v) {
     return new UniquePtrToConstructor(embind_test_return_unique_ptr(v));
 }
 
-int embind_test_accept_unique_ptr(std::unique_ptr<int> p) {
-    return *p.get();
+char embind_test_accept_unique_ptr(std::unique_ptr<CharWrapper> p) {
+    return (*p.get()).getValue();
 }
 
 std::unique_ptr<ValHolder> emval_test_return_unique_ptr() {
@@ -2251,6 +2263,7 @@ EMSCRIPTEN_BINDINGS(tests) {
     class_<UniquePtrToConstructor>("UniquePtrToConstructor")
         .function("getValue", &UniquePtrToConstructor::getValue)
         ;
+    class_<CharWrapper>("CharWrapper");
 
     function("embind_test_construct_class_with_unique_ptr", embind_test_construct_class_with_unique_ptr, allow_raw_pointer<ret_val>());
     function("embind_test_return_unique_ptr", embind_test_return_unique_ptr);

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3073,6 +3073,7 @@ More info: https://emscripten.org
     'no_dynamic': ['-sDYNAMIC_EXECUTION=0'],
     'aot_js': ['-sDYNAMIC_EXECUTION=0', '-sEMBIND_AOT', '-DSKIP_UNBOUND_TYPES'],
     'wasm64': ['-sMEMORY64', '-Wno-experimental'],
+    '2gb': ['-sINITIAL_MEMORY=2200mb', '-sGLOBAL_BASE=2gb'],
   })
   @parameterized({
     # With no arguments we are effectively testing c++17 since it is the default.


### PR DESCRIPTION
As pointed out by #21625, when using unique_ptr's with primitive types the raw pointer was being passed between wasm and JS, but it was using the underlying type (e.g. char, int, etc) to convert the value. This means the pointer was truncated to a char at the boundary.

Embind doesn't allow pointers or references to primitive types so it doesn't make sense to allow a unique_ptr for these types either.