### PR TITLE
Avoid using `forced_stdlibs` for cases that don't need it. NFC

### DIFF
--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -26,9 +26,9 @@ declare namespace RuntimeExports {
 interface WasmModule {
   _pthread_self(): number;
   _main(_0: number, _1: number): number;
+  __embind_initialize_bindings(): void;
   __emscripten_tls_init(): number;
   __emscripten_proxy_main(_0: number, _1: number): number;
-  __embind_initialize_bindings(): void;
   __emscripten_thread_init(_0: number, _1: number, _2: number, _3: number, _4: number, _5: number): void;
   __emscripten_thread_crashed(): void;
   __emscripten_thread_exit(_0: number): void;

--- a/tools/building.py
+++ b/tools/building.py
@@ -1154,11 +1154,6 @@ def map_to_js_libs(library_name):
     # for compatibility with GNU toolchains.
     'stdc++': [],
   }
-  # And some are hybrid and require JS and native libraries to be included
-  native_library_map = {
-    'embind': 'libembind',
-    'GL': 'libGL',
-  }
   settings_map = {
     'glfw': {'USE_GLFW': 2},
     'glfw3': {'USE_GLFW': 3},
@@ -1172,12 +1167,12 @@ def map_to_js_libs(library_name):
   if library_name in library_map:
     libs = library_map[library_name]
     logger.debug('Mapping library `%s` to JS libraries: %s' % (library_name, libs))
-    return (libs, native_library_map.get(library_name))
+    return libs
 
   if library_name.endswith('.js') and os.path.isfile(path_from_root('src', f'library_{library_name}')):
-    return ([f'library_{library_name}'], None)
+    return [f'library_{library_name}']
 
-  return (None, None)
+  return None
 
 
 # Map a linker flag to a settings. This lets a user write -lSDL2 and it will

--- a/tools/link.py
+++ b/tools/link.py
@@ -2632,14 +2632,9 @@ def process_libraries(state, linker_inputs):
 
     logger.debug('looking for library "%s"', lib)
 
-    js_libs, native_lib = building.map_to_js_libs(lib)
+    js_libs = building.map_to_js_libs(lib)
     if js_libs is not None:
       libraries += [(i, js_lib) for js_lib in js_libs]
-      # If native_lib is returned then include it in the link
-      # via forced_stdlibs.
-      if native_lib:
-        state.forced_stdlibs.append(native_lib)
-      continue
 
     # We don't need to resolve system libraries to absolute paths here, we can just
     # let wasm-ld handle that.  However, we do want to map to the correct variant.
@@ -2647,6 +2642,9 @@ def process_libraries(state, linker_inputs):
     if 'lib' + lib in system_libs_map:
       lib = system_libs_map['lib' + lib].get_link_flag()
       new_flags.append((i, lib))
+      continue
+
+    if js_libs is not None:
       continue
 
     if building.map_and_apply_to_settings(lib):


### PR DESCRIPTION
This change simplifies both `building.map_to_js_libs` and the code that calls it.

Avoiding `forced_stdlibs` means we don't do add `--whole-archive` `--no-whole-archive` around normal libraries when we don't need to.