### PR TITLE
[tsgen] Remove experimental warning for the `--emit-tsd` option.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,9 @@ See docs/process.md for more on how version tagging works.
   - The `-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE` flag for `--pre-js`/`--post-js`
     code
   (#21555)
+- TypeScript definitions for Wasm exports, runtime exports, and embind bindings
+  can now be generated with `--emit-tsd`. The option `--embind-emit-tsd` has been
+  deprecated, use `--emit-tsd` instead.
 
 3.1.56 - 03/14/24
 -----------------

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -410,9 +410,15 @@ Options that are modified or new in *emcc* are listed below:
    instead.
 
 "--embind-emit-tsd <path>"
-   [link] Generate a TypeScript definition file from the exported
-   embind bindings. The program will be instrumented and run in node
-   in order to to generate the file.
+   [link] Generates TypeScript definition file.  Deprecated: Use "--
+   emit-tsd" instead.
+
+"--emit-tsd <path>"
+   [link] Generate a TypeScript definition file for the emscripten
+   module. The definition file will include exported Wasm functions,
+   runtime exports, and exported embind bindings (if used). In order
+   to generate bindings from embind, the program will be instrumented
+   and run in node.
 
 "--ignore-dynamic-linking"
    [link] Tells the compiler to ignore dynamic linking (the user will

--- a/emcc.py
+++ b/emcc.py
@@ -1277,9 +1277,9 @@ def parse_args(newargs):
     elif check_arg('--source-map-base'):
       options.source_map_base = consume_arg()
     elif check_arg('--embind-emit-tsd'):
-      options.embind_emit_tsd = consume_arg()
+      diagnostics.warning('deprecated', '--embind-emit-tsd is deprecated.  Use --emit-tsd instead.')
+      options.emit_tsd = consume_arg()
     elif check_arg('--emit-tsd'):
-      diagnostics.warning('experimental', '--emit-tsd is still experimental. Not all definitions are generated.')
       options.emit_tsd = consume_arg()
     elif check_flag('--no-entry'):
       options.no_entry = True

--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -1043,9 +1043,9 @@ Generating
 
 Embind supports generating TypeScript definition files from :cpp:func:`EMSCRIPTEN_BINDINGS`
 blocks. To generate **.d.ts** files invoke *emcc* with the
-:ref:`embind-emit-tsd <emcc-embind-emit-tsd>` option::
+:ref:`embind-emit-tsd <emcc-emit-tsd>` option::
 
-   emcc -lembind quick_example.cpp --embind-emit-tsd interface.d.ts
+   emcc -lembind quick_example.cpp --emit-tsd interface.d.ts
 
 Running this command will build the program with an instrumented version of embind
 that is then run in *node* to generate the definition files.

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -395,8 +395,16 @@ Options that are modified or new in *emcc* are listed below:
 
 ``--embind-emit-tsd <path>``
   [link]
-  Generate a TypeScript definition file from the exported embind bindings. The
-  program will be instrumented and run in node in order to to generate the file.
+  Generates TypeScript definition file.  Deprecated: Use ``--emit-tsd`` instead.
+
+.. _emcc-emit-tsd:
+
+``--emit-tsd <path>``
+  [link]
+  Generate a TypeScript definition file for the emscripten module. The definition
+  file will include exported Wasm functions, runtime exports, and exported
+  embind bindings (if used). In order to generate bindings from embind, the
+  program will be instrumented and run in node.
 
 ``--ignore-dynamic-linking``
   [link]

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3159,13 +3159,13 @@ More info: https://emscripten.org
     # Check that TypeScript generation works and that the program is runs as
     # expected.
     self.do_runf('other/embind_tsgen.cpp', 'main ran',
-                 emcc_args=['-lembind', '--embind-emit-tsd', 'embind_tsgen.d.ts'])
+                 emcc_args=['-lembind', '--emit-tsd', 'embind_tsgen.d.ts'])
     actual = read_file('embind_tsgen.d.ts')
     self.assertFileContents(test_file('other/embind_tsgen.d.ts'), actual)
 
   def test_embind_tsgen_ignore(self):
     create_file('fail.js', 'assert(false);')
-    self.emcc_args += ['-lembind', '--embind-emit-tsd', 'embind_tsgen.d.ts']
+    self.emcc_args += ['-lembind', '--emit-tsd', 'embind_tsgen.d.ts']
     # These extra arguments are not related to TS binding generation but we want to
     # verify that they do not interfere with it.
     extra_args = ['-sALLOW_MEMORY_GROWTH=1',
@@ -3202,7 +3202,7 @@ More info: https://emscripten.org
 
   def test_embind_tsgen_test_embind(self):
     self.run_process([EMXX, test_file('embind/embind_test.cpp'),
-                      '-lembind', '--embind-emit-tsd', 'embind_tsgen_test_embind.d.ts',
+                      '-lembind', '--emit-tsd', 'embind_tsgen_test_embind.d.ts',
                       # This test explicitly creates std::string from unsigned char pointers
                       # which is deprecated in upstream LLVM.
                       '-Wno-deprecated-declarations',
@@ -3213,11 +3213,11 @@ More info: https://emscripten.org
   def test_embind_tsgen_val(self):
     # Check that any dependencies from val still works with TS generation enabled.
     self.run_process([EMCC, test_file('other/embind_tsgen_val.cpp'),
-                      '-lembind', '--embind-emit-tsd', 'embind_tsgen_val.d.ts'])
+                      '-lembind', '--emit-tsd', 'embind_tsgen_val.d.ts'])
     self.assertExists('embind_tsgen_val.d.ts')
 
   def test_embind_tsgen_bigint(self):
-    args = [EMXX, test_file('other/embind_tsgen_bigint.cpp'), '-lembind', '--embind-emit-tsd', 'embind_tsgen_bigint.d.ts']
+    args = [EMXX, test_file('other/embind_tsgen_bigint.cpp'), '-lembind', '--emit-tsd', 'embind_tsgen_bigint.d.ts']
     # Check that TypeScript generation fails when code contains bigints but their support is not enabled
     stderr = self.expect_fail(args)
     self.assertContained("Missing primitive type to TS type for 'int64_t", stderr)
@@ -3228,14 +3228,17 @@ More info: https://emscripten.org
   def test_embind_tsgen_memory64(self):
     # Check that when memory64 is enabled longs & unsigned longs are mapped to bigint in the generated TS bindings
     self.run_process([EMXX, test_file('other/embind_tsgen_memory64.cpp'),
-                      '-lembind', '--embind-emit-tsd', 'embind_tsgen_memory64.d.ts', '-sMEMORY64', '-Wno-experimental'] +
+                      '-lembind', '--emit-tsd', 'embind_tsgen_memory64.d.ts', '-sMEMORY64', '-Wno-experimental'] +
                      self.get_emcc_args())
     self.assertFileContents(test_file('other/embind_tsgen_memory64.d.ts'), read_file('embind_tsgen_memory64.d.ts'))
 
   def test_embind_tsgen_exceptions(self):
     # Check that when Wasm exceptions and assertions are enabled bindings still generate.
     self.run_process([EMXX, test_file('other/embind_tsgen.cpp'),
-                      '-lembind', '--embind-emit-tsd', 'embind_tsgen.d.ts', '-fwasm-exceptions', '-sASSERTIONS'])
+                      '-lembind', '-fwasm-exceptions', '-sASSERTIONS',
+                      # Use the deprecated `--embind-emit-tsd` to ensure it
+                      # still works until removed.
+                      '--embind-emit-tsd', 'embind_tsgen.d.ts', '-Wno-deprecated'])
     self.assertFileContents(test_file('other/embind_tsgen.d.ts'), read_file('embind_tsgen.d.ts'))
 
   def test_embind_jsgen_method_pointer_stability(self):

--- a/tools/link.py
+++ b/tools/link.py
@@ -1344,7 +1344,7 @@ def phase_linker_setup(options, state, newargs):
   if '-lembind' in [x for _, x in state.link_flags]:
     settings.EMBIND = 1
 
-  if options.embind_emit_tsd or options.emit_tsd:
+  if options.emit_tsd:
     settings.EMIT_TSD = True
 
   if settings.PTHREADS:
@@ -1895,7 +1895,7 @@ def phase_post_link(options, state, in_wasm, wasm_target, target, js_syms):
   if settings.EMBIND_AOT:
     phase_embind_aot(wasm_target, js_syms)
 
-  if options.embind_emit_tsd or options.emit_tsd:
+  if options.emit_tsd:
     phase_emit_tsd(options, wasm_target, js_syms, metadata)
 
   if options.js_transform:
@@ -1981,12 +1981,7 @@ def run_embind_gen(wasm_target, js_syms, extra_settings):
 @ToolchainProfiler.profile_block('emit tsd')
 def phase_emit_tsd(options, wasm_target, js_syms, metadata):
   logger.debug('emit tsd')
-  filename = ''
-  # Support using either option for now, but prefer emit_tsd if specified.
-  if options.emit_tsd:
-    filename = options.emit_tsd
-  else:
-    filename = options.embind_emit_tsd
+  filename = options.emit_tsd
   embind_tsd = ''
   if settings.EMBIND:
     embind_tsd = run_embind_gen(wasm_target, js_syms, {'EMBIND_JS': False})


### PR DESCRIPTION
 - Document the new option.
 - Deprecates the `--embind-emit-tsd` option.