### PR TITLE
Remove internal `FETCH_WORKER_FILE` setting. NFC

### DIFF
--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -95,9 +95,6 @@ var EMIT_TSD = false;
 // Whether the main() function reads the argc/argv parameters.
 var MAIN_READS_PARAMS = true;
 
-// Name of the file containing the Fetch *.fetch.js, if relevant
-var FETCH_WORKER_FILE = '';
-
 var WASI_MODULE_NAME = "wasi_snapshot_preview1";
 
 // List of JS libraries explicitly linked against.  This includes JS system

--- a/tools/link.py
+++ b/tools/link.py
@@ -1284,8 +1284,6 @@ def phase_linker_setup(options, state, newargs):
   if settings.FETCH and final_suffix in EXECUTABLE_ENDINGS:
     state.forced_stdlibs.append('libfetch')
     settings.JS_LIBRARIES.append((0, 'library_fetch.js'))
-    if settings.PTHREADS:
-      settings.FETCH_WORKER_FILE = unsuffixed_basename(target) + '.fetch.js'
 
   if settings.DEMANGLE_SUPPORT:
     settings.REQUIRED_EXPORTS += ['__cxa_demangle', 'free']


### PR DESCRIPTION
This should have been removed in #11942.