### PR TITLE
Add append_link_flag helper allowing removal of `forced_stdlibs`. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -105,15 +105,26 @@ class EmccState:
     self.has_dash_c = False
     self.has_dash_E = False
     self.has_dash_S = False
+    # List of link options paired with their position on the command line [(i, option), ...].
     self.link_flags = []
     self.lib_dirs = []
-    self.forced_stdlibs = []
 
-  def add_link_flag(self, i, f):
-    if f.startswith('-L'):
-      self.lib_dirs.append(f[2:])
+  def has_link_flag(self, f):
+    return f in [x for _, x in self.link_flags]
 
-    self.link_flags.append((i, f))
+  def add_link_flag(self, i, flag):
+    if flag.startswith('-L'):
+      self.lib_dirs.append(flag[2:])
+    # Link flags should be adding in strictly ascending order
+    assert not self.link_flags or i > self.link_flags[-1][0], self.link_flags
+    self.link_flags.append((i, flag))
+
+  def append_link_flag(self, flag):
+    if self.link_flags:
+      index = self.link_flags[-1][0] + 1
+    else:
+      index = 1
+    self.add_link_flag(index, flag)
 
 
 class EmccOptions:

--- a/tools/building.py
+++ b/tools/building.py
@@ -1142,6 +1142,7 @@ def map_to_js_libs(library_name):
     'X11': ['library_xlib.js'],
     'SDL': ['library_sdl.js'],
     'uuid': ['library_uuid.js'],
+    'fetch': ['library_fetch.js'],
     'websocket': ['library_websocket.js'],
     # These 4 libraries are separate under glibc but are all rolled into
     # libc with musl.  For compatibility with glibc we just ignore them

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2190,7 +2190,7 @@ class libstubs(DebugLibrary):
   src_files = ['emscripten_syscall_stubs.c', 'emscripten_libc_stubs.c']
 
 
-def get_libs_to_link(args, forced, only_forced):
+def get_libs_to_link(args):
   libs_to_link = []
 
   if '-nostdlib' in args:
@@ -2206,11 +2206,19 @@ def get_libs_to_link(args, forced, only_forced):
   # ones you want
   force_include = []
   force = os.environ.get('EMCC_FORCE_STDLIBS')
+  # Setting this will only use the forced libs in EMCC_FORCE_STDLIBS. This
+  # avoids spending time checking for unresolved symbols in your project files,
+  # which can speed up linking, but if you do not have the proper list of
+  # actually needed libraries, errors can occur.
+  only_forced = os.environ.get('EMCC_ONLY_FORCED_STDLIBS')
+  if only_forced:
+    # One of the purposes EMCC_ONLY_FORCED_STDLIBS was to skip the scanning
+    # of the input files for reverse dependencies.
+    diagnostics.warning('deprecated', 'EMCC_ONLY_FORCED_STDLIBS is deprecated.  Use `-nostdlib` to avoid linking standard libraries')
   if force == '1':
     force_include = [name for name, lib in system_libs_map.items() if not lib.never_force]
   elif force is not None:
     force_include = force.split(',')
-  force_include += forced
   if force_include:
     logger.debug(f'forcing stdlibs: {force_include}')
 
@@ -2342,17 +2350,9 @@ def get_libs_to_link(args, forced, only_forced):
   return libs_to_link
 
 
-def calculate(args, forced):
-  # Setting this will only use the forced libs in EMCC_FORCE_STDLIBS. This avoids spending time checking
-  # for unresolved symbols in your project files, which can speed up linking, but if you do not have
-  # the proper list of actually needed libraries, errors can occur.
-  only_forced = os.environ.get('EMCC_ONLY_FORCED_STDLIBS')
-  if only_forced:
-    # One of the purposes EMCC_ONLY_FORCED_STDLIBS was to skip the scanning
-    # of the input files for reverse dependencies.
-    diagnostics.warning('deprecated', 'EMCC_ONLY_FORCED_STDLIBS is deprecated.  Use `-nostdlib` to avoid linking standard libraries')
+def calculate(args):
 
-  libs_to_link = get_libs_to_link(args, forced, only_forced)
+  libs_to_link = get_libs_to_link(args)
 
   # When LINKABLE is set the entire link command line is wrapped in --whole-archive by
   # building.link_ldd.  And since --whole-archive/--no-whole-archive processing does not nest we


### PR DESCRIPTION
After #21644 there was only one remaining use of `forced_stdlibs` and this change allows that one to be removed too, removing the need for this feature.