### PR TITLE
Fix embind+lto link failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,6 +551,7 @@ jobs:
             lto2.test_float_builtins
             lto0.test_exceptions_allowed_uncaught
             lto0.test_longjmp_standalone_standalone
+            lto0.test_embind_i64_val
             core3
             core2g.test_externref
             corez.test_dylink_iostream

--- a/tools/link.py
+++ b/tools/link.py
@@ -1342,6 +1342,11 @@ def phase_linker_setup(options, state, newargs):
   if state.has_link_flag('-lembind'):
     settings.EMBIND = 1
 
+  if settings.EMBIND:
+    # Workaround for embind+LTO issue:
+    # https://github.com/emscripten-core/emscripten/issues/21653
+    settings.REQUIRED_EXPORTS.append('__getTypeName')
+
   if options.emit_tsd:
     settings.EMIT_TSD = True
 


### PR DESCRIPTION
This was broken by #21639 which means were accidentally depending on embind being included using `--whole-archive` previously.

See #21653