### PR TITLE
Typo fix in other.test_exceptions_stack_trace_and_message_wasm

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8815,7 +8815,7 @@ int main() {
       'at (src.wasm.)?foo',
       'at (src.wasm.)?main']
 
-    if '-fwasm-excpeptions' in self.emcc_args:
+    if '-fwasm-exceptions' in self.emcc_args:
       # FIXME Node v18.13 (LTS as of Jan 2023) has not yet implemented the new
       # optional 'traceStack' option in WebAssembly.Exception constructor
       # (https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Exception/Exception)


### PR DESCRIPTION
This typo was introduced in #21559. But I wonder, how is the test still passing in the CI? It fails locally for me, which lead me to discover this.