### PR TITLE
Exclude 80-bit long double sources

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -926,8 +926,30 @@ class libcompiler_rt(MTLibrary, SjLjLibrary):
   cflags = ['-fno-builtin', '-DNDEBUG']
   src_dir = 'system/lib/compiler-rt/lib/builtins'
   includes = ['system/lib/libc']
-  # gcc_personality_v0.c depends on libunwind, which don't include by default.
-  src_files = glob_in_path(src_dir, '*.c', excludes=['gcc_personality_v0.c', 'truncdfbf2.c', 'truncsfbf2.c', 'crtbegin.c', 'crtend.c'])
+  excludes = [
+    # gcc_personality_v0.c depends on libunwind, which don't include by default.
+    'gcc_personality_v0.c',
+    # bfloat16
+    'truncdfbf2.c',
+    'truncsfbf2.c',
+    # We provide our own crt
+    'crtbegin.c',
+    'crtend.c',
+    # 80-bit long double
+    'divxc3.c',
+    'fixxfdi.c',
+    'fixxfti.c',
+    'fixunsxfdi.c',
+    'fixunsxfsi.c',
+    'fixunsxfti.c',
+    'floatdixf.c',
+    'floattixf.c',
+    'floatundixf.c',
+    'floatuntixf.c',
+    'mulxc3.c',
+    'powixf2.c',
+  ]
+  src_files = glob_in_path(src_dir, '*.c', excludes=excludes)
   src_files += files_in_path(
       path='system/lib/compiler-rt',
       filenames=[


### PR DESCRIPTION
This is the list of files using 80-bit long double: https://github.com/llvm/llvm-project/blob/6009708b4367171ccdbf4b5905cb6a803753fe18/compiler-rt/lib/builtins/CMakeLists.txt#L279-L294 (This file is from LLVM 17.0.6, which is currently our compiler-rt
 version)

We don't have 80-bit long doubles so it looks we can exclude them.