### PR TITLE
Add `ASYNCIFY_PROPAGATE_ADD` setting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,6 +42,9 @@ See docs/process.md for more on how version tagging works.
 - TypeScript definitions for Wasm exports, runtime exports, and embind bindings
   can now be generated with `--emit-tsd`. The option `--embind-emit-tsd` has been
   deprecated, use `--emit-tsd` instead.
+- Added the `ASYNCIFY_PROPAGATE_ADD` setting, to control whether the `ASYNCIFY_ADD`
+  list propagates or not. By default this is enabled; to return to the previous
+  behaviour, disable that setting.
 
 3.1.56 - 03/14/24
 -----------------

--- a/site/source/docs/porting/asyncify.rst
+++ b/site/source/docs/porting/asyncify.rst
@@ -355,12 +355,16 @@ If you know that some indirect calls matter and others do not, then you
 can provide a manual list of functions to Asyncify:
 
 * ``ASYNCIFY_REMOVE`` is a list of functions that do not unwind the stack.
-  Asyncify will do its normal whole-program analysis, then remove these
-  functions from the list of instrumented functions.
-* ``ASYNCIFY_ADD`` is a list of functions that do unwind the stack, and
-  are added after doing the normal whole-program analysis. This is mostly useful
+  As Asyncify processes the call tree, functions in this list will be removed,
+  and neither they nor their callers will be instrumented (unless their callers
+  need to be instrumented for other reasons.)
+* ``ASYNCIFY_ADD`` is a list of functions that do unwind the stack, and will be
+  processed like the imports. This is mostly useful
   if you use ``ASYNCIFY_IGNORE_INDIRECT`` but want to also mark some additional
-  functions that need to unwind.
+  functions that need to unwind. If the ``ASYNCIFY_PROPAGATE_ADD`` setting is
+  disabled however, then this list will only be added after the whole-program
+  analysis. If ``ASYNCIFY_PROPAGATE_ADD`` is disabled then you must also add
+  their callers, their callers' callers, and so on.
 * ``ASYNCIFY_ONLY`` is a list of the **only** functions that can unwind
   the stack. Asyncify will instrument exactly those and no others.
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -895,6 +895,12 @@ var ASYNCIFY_REMOVE = [];
 // [link]
 var ASYNCIFY_ADD = [];
 
+// If enabled, instrumentation status will be propagated from the add-list, ie.
+// their callers, and their callers' callers, and so on. If disabled then all
+// callers must be manually added to the add-list (like the only-list).
+// [link]
+var ASYNCIFY_PROPAGATE_ADD = true;
+
 // If the Asyncify only-list is provided, then *only* the functions in the list
 // will be instrumented. Like the remove-list, getting this wrong will break
 // your application.

--- a/tools/link.py
+++ b/tools/link.py
@@ -370,6 +370,8 @@ def get_binaryen_passes():
       passes += ['--pass-arg=asyncify-verbose']
     if settings.ASYNCIFY_IGNORE_INDIRECT:
       passes += ['--pass-arg=asyncify-ignore-indirect']
+    if settings.ASYNCIFY_PROPAGATE_ADD:
+      passes += ['--pass-arg=asyncify-propagate-addlist']
     passes += ['--pass-arg=asyncify-imports@%s' % ','.join(settings.ASYNCIFY_IMPORTS)]
 
     # shell escaping can be confusing; try to emit useful warnings


### PR DESCRIPTION
Adds a `ASYNCIFY_PROPAGATE_ADD` setting to control whether the `ASYNCIFY_ADD` list propagates. Closes #13150

I set this to be on by default, which does change the behaviour of `ASYNCIFY_ADD`. I think having it off by default is unsafe, and also greatly reduces its usefulness. There are few examples in public code of people actually using it, probably because it requires you to list everything above it in the call tree. Here's one of the few examples I could find, which could probably be substantially simplified by this: https://github.com/Siv3D/OpenSiv3D/blob/c81400c5a39405d66843c07ce1cf90f46e01a86a/Web/App/CMakeLists.txt#L29
Thanks to @nokotan for getting the code working in Binaryen!

Note: I don't know if the Binaryen changes are in Emscripten yet.