### PR TITLE
Add a test case for shared library dependencies. NFC

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -2754,7 +2754,7 @@ def process_dynamic_libs(dylibs, lib_dirs):
         extras.append(path)
         seen.add(needed)
       else:
-        exit_with_error(f'{os.path.normpath(dylib)}: shared library dependency not found: `{needed}`')
+        exit_with_error(f'{os.path.normpath(dylib)}: shared library dependency not found in library path: `{needed}`. (library path: {lib_dirs}')
       to_process.append(path)
 
   dylibs += extras


### PR DESCRIPTION
This change doesn't fix #21667 but just encodes the current behavior in a test.

As a followup we could consider resolving shared libraries dependencies based on previous command line arguments which would solve #21667 without the need for adding `-L.`.