### PR TITLE
Add emscripten_memset_js and use it from memset

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -441,6 +441,7 @@ addToLibrary({
 #else
   _emscripten_memcpy_js: (dest, src, num) => HEAPU8.copyWithin(dest, src, src + num),
 #endif
+  _emscripten_memset_js: (dest, value, num) => HEAPU8.fill(value, dest, dest + num),
 
 #endif
 
@@ -1204,7 +1205,7 @@ addToLibrary({
         // GMT offset as either 'Z' or +-HH:MM or +-HH or +-HHMM
         if (value.toLowerCase() === 'z'){
           date.gmtoff = 0;
-        } else {          
+        } else {
           var match = value.match(/^((?:\-|\+)\d\d):?(\d\d)?/);
           date.gmtoff = match[1] * 3600;
           if (match[2]) {
@@ -1237,7 +1238,7 @@ addToLibrary({
       {{{ makeSetValue('tm', C_STRUCTS.tm.tm_yday, 'arraySum(isLeapYear(fullDate.getFullYear()) ? MONTH_DAYS_LEAP : MONTH_DAYS_REGULAR, fullDate.getMonth()-1)+fullDate.getDate()-1', 'i32') }}};
       {{{ makeSetValue('tm', C_STRUCTS.tm.tm_isdst, '0', 'i32') }}};
       {{{ makeSetValue('tm', C_STRUCTS.tm.tm_gmtoff, 'date.gmtoff', LONG_TYPE) }}};
- 
+
       // we need to convert the matched sequence into an integer array to take care of UTF-8 characters > 0x7F
       // TODO: not sure that intArrayFromString handles all unicode characters correctly
       return buf+intArrayFromString(matches[0]).length-1;

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -326,6 +326,7 @@ sigs = {
   _emscripten_get_progname__sig: 'vpi',
   _emscripten_lookup_name__sig: 'ip',
   _emscripten_memcpy_js__sig: 'vppp',
+  _emscripten_memset_js__sig: 'vpip',
   _emscripten_notify_mailbox_postmessage__sig: 'vppp',
   _emscripten_push_main_loop_blocker__sig: 'vppp',
   _emscripten_push_uncounted_main_loop_blocker__sig: 'vppp',

--- a/system/lib/libc/emscripten_internal.h
+++ b/system/lib/libc/emscripten_internal.h
@@ -31,6 +31,9 @@ extern "C" {
 void _emscripten_memcpy_js(void* __restrict__ dest,
                            const void* __restrict__ src,
                            size_t n) EM_IMPORT(_emscripten_memcpy_js);
+void _emscripten_memset_js(void* __restrict__ dest,
+                           int value,
+                           size_t n) EM_IMPORT(_emscripten_memset_js);
 
 void* _emscripten_memcpy_bulkmem(void* __restrict__ dest,
                                  const void* __restrict__ src,

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14057,9 +14057,11 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
       js = read_file('test_memops_bulk_memory.js')
       if expect_bulk_mem:
         self.assertNotContained('_emscripten_memcpy_js', js)
+        self.assertNotContained('_emscripten_memset_js', js)
         self.assertIn('$_emscripten_memcpy_bulkmem', funcs)
       else:
         self.assertContained('_emscripten_memcpy_js', js)
+        self.assertContained('_emscripten_memset_js', js)
         self.assertNotIn('$_emscripten_memcpy_bulkmem', funcs)
 
     # By default we expect to find `_emscripten_memcpy_js` in the generaed JS


### PR DESCRIPTION
Addresses https://github.com/emscripten-core/emscripten/issues/21620

Sorry if I got something wrong here, I'm kind of flying blind based on the documentation... I was only able to successfully run the "other" tests and some of them fail out of the box on an unmodified checkout for me.

I'm guessing I need to update all of the text files under test/ that mention _emscripten_memcpy_js to also mention _emscripten_memset_js? Or are they automatically generated? When I did a local run it only seemed like my changes added one additional test failure, so I'm guessing I ran the wrong tests.