### PR TITLE
Mark LEGALIZE_JS_FFI as deprecated. NFC

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1861,6 +1861,8 @@ to automatically demote i64 to i32 and promote f32 to f64. This is necessary
 in order to interface with JavaScript.  For non-web/non-JS embeddings, setting
 this to 0 may be desirable.
 
+.. note:: This setting is deprecated
+
 .. _use_sdl:
 
 USE_SDL

--- a/src/settings.js
+++ b/src/settings.js
@@ -1465,6 +1465,7 @@ var EMIT_EMSCRIPTEN_LICENSE = false;
 // in order to interface with JavaScript.  For non-web/non-JS embeddings, setting
 // this to 0 may be desirable.
 // [link]
+// [deprecated]
 var LEGALIZE_JS_FFI = true;
 
 // Ports

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -121,6 +121,7 @@ DEPRECATED_SETTINGS = {
     'DEMANGLE_SUPPORT': 'mangled names no longer appear in stack traces',
     'RUNTIME_LINKED_LIBS': 'you can simply list the libraries directly on the commandline now',
     'CLOSURE_WARNINGS': 'use -Wclosure instead',
+    'LEGALIZE_JS_FFI': 'to disable JS type legalization use `-sWASM_BIGINT` or `-sSTANDALONE_WASM`',
 }
 
 # Settings that don't need to be externalized when serializing to json because they


### PR DESCRIPTION
This setting can cause issues if used on its own without `-sWASM_BIGINT`.  See #21689.