### PR TITLE
[embind] Use type alias for string arguments definitions.

### DIFF
--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -15,6 +15,7 @@ interface WasmModule {
   _main(_0: number, _1: number): number;
 }
 
+type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;
 export interface Test {
   x: number;
   readonly y: number;
@@ -24,8 +25,8 @@ export interface Test {
   functionFive(x: number, y: number): number;
   constFn(): number;
   longFn(_0: number): number;
-  functionThree(_0: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): number;
-  functionSix(str: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): number;
+  functionThree(_0: EmbindString): number;
+  functionSix(str: EmbindString): number;
   delete(): void;
 }
 
@@ -118,7 +119,8 @@ interface EmbindModule {
   smart_ptr_function(_0: ClassWithSmartPtrConstructor): number;
   smart_ptr_function_with_params(foo: ClassWithSmartPtrConstructor): number;
   function_with_callback_param(_0: (message: string) => void): number;
-  string_test(_0: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): string;
+  string_test(_0: EmbindString): string;
   wstring_test(_0: string): string;
 }
+
 export type MainModule = WasmModule & typeof RuntimeExports & EmbindModule;

--- a/test/other/embind_tsgen_bigint.d.ts
+++ b/test/other/embind_tsgen_bigint.d.ts
@@ -17,4 +17,5 @@ interface WasmModule {
 interface EmbindModule {
   bigintFn(_0: bigint): bigint;
 }
+
 export type MainModule = WasmModule & typeof RuntimeExports & EmbindModule;

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -34,6 +34,7 @@ interface WasmModule {
   __emscripten_thread_exit(_0: number): void;
 }
 
+type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;
 export interface Test {
   x: number;
   readonly y: number;
@@ -43,8 +44,8 @@ export interface Test {
   functionFive(x: number, y: number): number;
   constFn(): number;
   longFn(_0: number): number;
-  functionThree(_0: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): number;
-  functionSix(str: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): number;
+  functionThree(_0: EmbindString): number;
+  functionSix(str: EmbindString): number;
   delete(): void;
 }
 
@@ -137,7 +138,8 @@ interface EmbindModule {
   smart_ptr_function(_0: ClassWithSmartPtrConstructor): number;
   smart_ptr_function_with_params(foo: ClassWithSmartPtrConstructor): number;
   function_with_callback_param(_0: (message: string) => void): number;
-  string_test(_0: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): string;
+  string_test(_0: EmbindString): string;
   wstring_test(_0: string): string;
 }
+
 export type MainModule = WasmModule & typeof RuntimeExports & EmbindModule;

--- a/test/other/embind_tsgen_ignore_2.d.ts
+++ b/test/other/embind_tsgen_ignore_2.d.ts
@@ -2,6 +2,7 @@
 interface WasmModule {
 }
 
+type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;
 export interface Test {
   x: number;
   readonly y: number;
@@ -11,8 +12,8 @@ export interface Test {
   functionFive(x: number, y: number): number;
   constFn(): number;
   longFn(_0: number): number;
-  functionThree(_0: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): number;
-  functionSix(str: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): number;
+  functionThree(_0: EmbindString): number;
+  functionSix(str: EmbindString): number;
   delete(): void;
 }
 
@@ -105,8 +106,9 @@ interface EmbindModule {
   smart_ptr_function(_0: ClassWithSmartPtrConstructor): number;
   smart_ptr_function_with_params(foo: ClassWithSmartPtrConstructor): number;
   function_with_callback_param(_0: (message: string) => void): number;
-  string_test(_0: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): string;
+  string_test(_0: EmbindString): string;
   wstring_test(_0: string): string;
 }
+
 export type MainModule = WasmModule & EmbindModule;
 export default function MainModuleFactory (options?: unknown): Promise<MainModule>;

--- a/test/other/embind_tsgen_ignore_3.d.ts
+++ b/test/other/embind_tsgen_ignore_3.d.ts
@@ -15,6 +15,7 @@ interface WasmModule {
   _main(_0: number, _1: number): number;
 }
 
+type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;
 export interface Test {
   x: number;
   readonly y: number;
@@ -24,8 +25,8 @@ export interface Test {
   functionFive(x: number, y: number): number;
   constFn(): number;
   longFn(_0: number): number;
-  functionThree(_0: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): number;
-  functionSix(str: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): number;
+  functionThree(_0: EmbindString): number;
+  functionSix(str: EmbindString): number;
   delete(): void;
 }
 
@@ -118,7 +119,8 @@ interface EmbindModule {
   smart_ptr_function(_0: ClassWithSmartPtrConstructor): number;
   smart_ptr_function_with_params(foo: ClassWithSmartPtrConstructor): number;
   function_with_callback_param(_0: (message: string) => void): number;
-  string_test(_0: ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string): string;
+  string_test(_0: EmbindString): string;
   wstring_test(_0: string): string;
 }
+
 export type MainModule = WasmModule & typeof RuntimeExports & EmbindModule;

--- a/test/other/embind_tsgen_memory64.d.ts
+++ b/test/other/embind_tsgen_memory64.d.ts
@@ -17,4 +17,5 @@ interface WasmModule {
 interface EmbindModule {
   longFn(_0: bigint): bigint;
 }
+
 export type MainModule = WasmModule & typeof RuntimeExports & EmbindModule;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3160,6 +3160,11 @@ More info: https://emscripten.org
     # expected.
     self.do_runf('other/embind_tsgen.cpp', 'main ran',
                  emcc_args=['-lembind', '--emit-tsd', 'embind_tsgen.d.ts'])
+
+    # Test that the output compiles with a TS file that uses the defintions.
+    cmd = shared.get_npm_cmd('tsc') + ['embind_tsgen.d.ts', '--noEmit']
+    shared.check_call(cmd)
+
     actual = read_file('embind_tsgen.d.ts')
     self.assertFileContents(test_file('other/embind_tsgen.d.ts'), actual)
 


### PR DESCRIPTION
Makes the TypeScript output easier to read.

Fixes #21642