### PR TITLE
[cpuprofiler] Check navigator variable before usage

### DIFF
--- a/src/cpuprofiler.js
+++ b/src/cpuprofiler.js
@@ -15,17 +15,13 @@
 // That doesn't work for Chrome in turn, so need to resort to user agent
 // sniffing.. (sad :/)
 if (!performance.realNow) {
-  if (typeof navigator !== "undefined") {
-    var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-    if (isSafari) {
-      var realPerformance = performance;
-      performance = {
-        realNow: () => realPerformance.now(),
-        now: () => realPerformance.now()
-      };
-    } else {
-      performance.realNow = performance.now;
-    }
+  var isSafari = typeof navigator !== "undefined" && /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  if (isSafari) {
+    var realPerformance = performance;
+    performance = {
+      realNow: () => realPerformance.now(),
+      now: () => realPerformance.now()
+    };
   } else {
     performance.realNow = performance.now;
   }

--- a/src/cpuprofiler.js
+++ b/src/cpuprofiler.js
@@ -15,13 +15,17 @@
 // That doesn't work for Chrome in turn, so need to resort to user agent
 // sniffing.. (sad :/)
 if (!performance.realNow) {
-  var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-  if (isSafari) {
-    var realPerformance = performance;
-    performance = {
-      realNow: () => realPerformance.now(),
-      now: () => realPerformance.now()
-    };
+  if (typeof navigator !== "undefined") {
+    var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+    if (isSafari) {
+      var realPerformance = performance;
+      performance = {
+        realNow: () => realPerformance.now(),
+        now: () => realPerformance.now()
+      };
+    } else {
+      performance.realNow = performance.now;
+    }
   } else {
     performance.realNow = performance.now;
   }

--- a/src/cpuprofiler.js
+++ b/src/cpuprofiler.js
@@ -15,7 +15,7 @@
 // That doesn't work for Chrome in turn, so need to resort to user agent
 // sniffing.. (sad :/)
 if (!performance.realNow) {
-  var isSafari = typeof navigator !== "undefined" && /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  var isSafari = typeof navigator !== 'undefined' && /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
   if (isSafari) {
     var realPerformance = performance;
     performance = {


### PR DESCRIPTION
Hello,


This PR fix the bug:
When you compile a project with --cpuprofiler options, you can't use it in nodejs anymore (the index.js will crash).

This PR enable the user to compile his project with the --cpuprofiler options and then use it both in nodeJS and the browser