### PR TITLE
Install mimalloc headers in sysroot

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14596,3 +14596,14 @@ addToLibrary({
     stderr = self.expect_fail([compiler, test_file('hello_world.c'), '--use-port=sdl2_image:formats=jpg:formats=png', '-o', 'out.js'])
     self.assertFalse(os.path.exists('out.js'))
     self.assertContained('error with `--use-port=sdl2_image:formats=jpg:formats=png` | duplicate option `formats`', stderr)
+
+  def test_mimalloc_headers(self, compiler):
+    src = r'''
+      #include <mimalloc.h>
+
+      int main() {
+          mi_option_enable(mi_option_verbose);
+          return 0;
+      }
+    '''
+    self.do_run(src, emcc_args=['-sMALLOC=mimalloc'] )

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14597,7 +14597,7 @@ addToLibrary({
     self.assertFalse(os.path.exists('out.js'))
     self.assertContained('error with `--use-port=sdl2_image:formats=jpg:formats=png` | duplicate option `formats`', stderr)
 
-  def test_mimalloc_headers(self, compiler):
+  def test_mimalloc_headers(self):
     src = r'''
       #include <mimalloc.h>
 
@@ -14606,4 +14606,4 @@ addToLibrary({
           return 0;
       }
     '''
-    self.do_run(src, emcc_args=['-sMALLOC=mimalloc'] )
+    self.do_run(src, emcc_args=['-sMALLOC=mimalloc'])

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2436,6 +2436,7 @@ def install_system_headers(stamp):
     ('lib', 'libc', 'musl', 'include'): '',
     ('lib', 'libcxx', 'include'): os.path.join('c++', 'v1'),
     ('lib', 'libcxxabi', 'include'): os.path.join('c++', 'v1'),
+    ('lib', 'mimalloc', 'include'): '',
   }
 
   target_include_dir = cache.get_include_dir()


### PR DESCRIPTION
In my tests the mimalloc headers were available after this change.
This should resolve #21652.

Should you need a test for this I will do my best to provide one.