### PR TITLE
Avoid recursive import in test_pthread_offset_converter_modularize. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9216,8 +9216,9 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('USE_OFFSET_CONVERTER')
     self.set_setting('MODULARIZE')
-    create_file('post.js', 'var m = require("./test_return_address.js"); m();')
-    self.emcc_args += ['--extern-post-js', 'post.js', '-sEXPORT_NAME=foo']
+    self.set_setting('EXPORT_NAME', 'foo')
+    create_file('post.js', 'foo();')
+    self.emcc_args += ['--extern-post-js', 'post.js']
     if '-g' in self.emcc_args:
       self.emcc_args += ['-DDEBUG']
     self.do_runf('core/test_return_address.c', 'passed')


### PR DESCRIPTION
This test seems to needless import itself which leads to some strange behaviour where new workers would load script via `importSripts` and then also via `require`.