### PR TITLE
Re-enable test_pthread_create_minimal_runtime. NFC

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3875,9 +3875,7 @@ Module["preRun"] = () => {
   @parameterized({
     '': ([],),
     'O3': (['-O3'],),
-    # TODO: re-enable minimal runtime once the flakiness is figured out,
-    # https://github.com/emscripten-core/emscripten/issues/12368
-    # 'minimal_runtime': (['-sMINIMAL_RUNTIME'],),
+    'minimal_runtime': (['-sMINIMAL_RUNTIME'],),
   })
   def test_pthread_create(self, args):
     self.btest_exit('pthread/test_pthread_create.c',


### PR DESCRIPTION
Lets see if this flakieness still persists.  I ran the test 10 times locally and didn't see it.