### PR TITLE
Improve testing of `mainScriptUrlOrBlob`. NFC

### DIFF
--- a/test/manual_download_data.html
+++ b/test/manual_download_data.html
@@ -186,7 +186,7 @@
       var dataDownload = download('/test/manual_download_data.data').then((data) => {
         console.log('downloaded data file');
         Module['downloadedData'] = data;
-        var jsDownload = download('manual_download_data.js').then((data) => {
+        var jsDownload = download('/test/manual_download_data.js').then((data) => {
           console.log('downloaded js file');
           Module['mainScriptUrlOrBlob'] = new Blob([data], { type: 'application/javascript' });
           addScriptToDom(data);

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -443,12 +443,13 @@ If manually bisecting:
   def test_preload_file_with_manual_data_download(self, args):
     create_file('file.txt', 'Hello!')
 
-    self.compile_btest('manual_download_data.cpp', ['-o', 'manual_download_data.js', '--preload-file', 'file.txt@/file.txt'] + args)
+    self.compile_btest('manual_download_data.cpp', ['-o', 'out.js', '--preload-file', 'file.txt@/file.txt'] + args)
     shutil.copyfile(test_file('manual_download_data.html'), 'manual_download_data.html')
 
     # Move .data file out of server root to ensure that getPreloadedPackage is actually used
     os.mkdir('test')
-    shutil.move('manual_download_data.data', 'test/manual_download_data.data')
+    shutil.move('out.js', 'test/manual_download_data.js')
+    shutil.move('out.data', 'test/manual_download_data.data')
 
     self.run_browser('manual_download_data.html', '/report_result?1')
 
@@ -4817,11 +4818,16 @@ Module["preRun"] = () => {
   def test_pthread_reltime(self):
     self.btest_exit('pthread/test_pthread_reltime.cpp', args=['-pthread', '-sPTHREAD_POOL_SIZE'])
 
-  # Tests that it is possible to load the main .js file of the application manually via a Blob URL, and still use pthreads.
+  # Tests that it is possible to load the main .js file of the application manually via a Blob URL,
+  # and still use pthreads.
   def test_load_js_from_blob_with_pthreads(self):
     # TODO: enable this with wasm, currently pthreads/atomics have limitations
     self.set_setting('EXIT_RUNTIME')
-    self.compile_btest('pthread/hello_thread.c', ['-pthread', '-o', 'hello_thread_with_blob_url.js'], reporting=Reporting.JS_ONLY)
+    self.compile_btest('pthread/hello_thread.c', ['-pthread', '-o', 'out.js'], reporting=Reporting.JS_ONLY)
+
+    # Now run the test with the JS file renamed and with its content
+    # stored in Module['mainScriptUrlOrBlob'].
+    shutil.move('out.js', 'hello_thread_with_blob_url.js')
     shutil.copyfile(test_file('pthread/main_js_as_blob_loader.html'), 'hello_thread_with_blob_url.html')
     self.run_browser('hello_thread_with_blob_url.html', '/report_result?exit:0')
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7669,8 +7669,9 @@ void* operator new(size_t size) {
     post_js += '\n\n'
     create_file('extern-post.js', post_js)
 
-    # Export things on "TheModule". This matches the typical use pattern of the bound library
-    # being used as Box2D.* or Ammo.*, and we cannot rely on "Module" being always present (closure may remove it).
+    # Export things on "TheModule". This matches the typical use pattern of
+    # the bound library being used as Box2D.* or Ammo.*, and we cannot rely
+    # on "Module" being always present (closure may remove it).
     self.emcc_args += ['--post-js=glue.js', '--extern-post-js=extern-post.js']
     if mode == 'ALL':
       self.emcc_args += ['-sASSERTIONS']
@@ -7681,8 +7682,10 @@ void* operator new(size_t size) {
 
     self.do_run_in_out_file_test(test_file('webidl/test.cpp'), out_suffix='_' + mode, includes=['.'])
 
-  # Test that we can perform fully-synchronous initialization when combining WASM_ASYNC_COMPILATION=0 + PTHREAD_POOL_DELAY_LOAD=1.
-  # Also checks that PTHREAD_POOL_DELAY_LOAD=1 adds a pthreadPoolReady promise that users can wait on for pthread initialization.
+  # Test that we can perform fully-synchronous initialization when combining
+  # WASM_ASYNC_COMPILATION=0 + PTHREAD_POOL_DELAY_LOAD=1.  Also checks that
+  # PTHREAD_POOL_DELAY_LOAD=1 adds a pthreadPoolReady promise that users
+  # can wait on for pthread initialization.
   @node_pthreads
   def test_embind_sync_if_pthread_delayed(self):
     self.set_setting('WASM_ASYNC_COMPILATION', 0)


### PR DESCRIPTION
I noticed when working on #21701 then these tests were not renaming the `.js` output, which meant that if `mainScriptUrlOrBlob` was completely ignored the tests would still pass.

These changes rename the output `.js` file such that the default name will not longer work and the tests would fail if `mainScriptUrlOrBlob` were ignored.