### PR TITLE
Rename internal `_scriptDir` to `_scriptName`. NFC

### DIFF
--- a/src/closure-externs/modularize-externs.js
+++ b/src/closure-externs/modularize-externs.js
@@ -1,7 +1,7 @@
-// Due to the way MODULARIZE works, Closure is run on generated code that does not define _scriptDir,
-// but only after MODULARIZE has finished, _scriptDir is injected to the generated code.
+// Due to the way MODULARIZE works, Closure is run on generated code that does not define _scriptName,
+// but only after MODULARIZE has finished, _scriptName is injected to the generated code.
 // Therefore it cannot be minified.
 /**
  * @suppress {duplicate, undefinedVars}
  */
-var _scriptDir;
+var _scriptName;

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -380,7 +380,7 @@ var LibraryPThread = {
         // independently load up the same main application file.
         'urlOrBlob': Module['mainScriptUrlOrBlob']
 #if !EXPORT_ES6
-        || _scriptDir
+        || _scriptName
 #endif
         ,
 #if WASM2JS

--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -174,7 +174,7 @@ if (ENVIRONMENT_IS_WASM_WORKER) {
       'mem': wasmMemory,
 #else
       'wasm': wasmModule,
-      'js': Module['mainScriptUrlOrBlob'] || _scriptDir,
+      'js': Module['mainScriptUrlOrBlob'] || _scriptName,
       'wasmMemory': wasmMemory,
 #endif
       'sb': stackLowestAddress, // sb = stack bottom (lowest stack address, SP points at this when stack is full)

--- a/src/library_webaudio.js
+++ b/src/library_webaudio.js
@@ -202,7 +202,7 @@ let LibraryWebAudio = {
 #if MINIMAL_RUNTIME
         Module['js']
 #else
-        Module['mainScriptUrlOrBlob'] || _scriptDir
+        Module['mainScriptUrlOrBlob'] || _scriptName
 #endif
       );
     }).then(() => {

--- a/src/shell.js
+++ b/src/shell.js
@@ -144,16 +144,16 @@ var quit_ = (status, toThrow) => {
 };
 
 #if SHARED_MEMORY && !MODULARIZE
-// In MODULARIZE mode _scriptDir needs to be captured already at the very top of the page immediately when the page is parsed, so it is generated there
+// In MODULARIZE mode _scriptName needs to be captured already at the very top of the page immediately when the page is parsed, so it is generated there
 // before the page load. In non-MODULARIZE modes generate it here.
-var _scriptDir = (typeof document != 'undefined') ? document.currentScript?.src : undefined;
+var _scriptName = (typeof document != 'undefined') ? document.currentScript?.src : undefined;
 
 if (ENVIRONMENT_IS_WORKER) {
-  _scriptDir = self.location.href;
+  _scriptName = self.location.href;
 }
 #if ENVIRONMENT_MAY_BE_NODE
 else if (ENVIRONMENT_IS_NODE) {
-  _scriptDir = __filename;
+  _scriptName = __filename;
 }
 #endif // ENVIRONMENT_MAY_BE_NODE
 #endif // SHARED_MEMORY && !MODULARIZE
@@ -371,8 +371,8 @@ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
 #if MODULARIZE
   // When MODULARIZE, this JS may be executed later, after document.currentScript
   // is gone, so we saved it, and we use it here instead of any other info.
-  if (_scriptDir) {
-    scriptDirectory = _scriptDir;
+  if (_scriptName) {
+    scriptDirectory = _scriptName;
   }
 #endif
   // blob urls look like blob:http://site.com/etc/etc and we cannot infer anything from them.

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -153,17 +153,17 @@ var ENVIRONMENT_IS_WORKER = typeof importScripts == 'function',
 #if PTHREADS
 
 #if !MODULARIZE
-// In MODULARIZE mode _scriptDir needs to be captured already at the very top of the page immediately when the page is parsed, so it is generated there
+// In MODULARIZE mode _scriptName needs to be captured already at the very top of the page immediately when the page is parsed, so it is generated there
 // before the page load. In non-MODULARIZE modes generate it here.
-var _scriptDir = (typeof document != 'undefined') ? document.currentScript?.src : undefined;
+var _scriptName = (typeof document != 'undefined') ? document.currentScript?.src : undefined;
 #endif
 
 if (ENVIRONMENT_IS_WORKER) {
-  _scriptDir = self.location.href;
+  _scriptName = self.location.href;
 }
 #if ENVIRONMENT_MAY_BE_NODE
 else if (ENVIRONMENT_IS_NODE) {
-  _scriptDir = __filename;
+  _scriptName = __filename;
 }
 #endif
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -2372,10 +2372,10 @@ def modularize():
     else:
       script_url = "typeof document != 'undefined' ? document.currentScript?.src : undefined"
       if shared.target_environment_may_be('node'):
-        script_url_node = "if (typeof __filename != 'undefined') _scriptDir ||= __filename;"
+        script_url_node = "if (typeof __filename != 'undefined') _scriptName ||= __filename;"
     src = '''%(node_imports)s
 var %(EXPORT_NAME)s = (() => {
-  var _scriptDir = %(script_url)s;
+  var _scriptName = %(script_url)s;
   %(script_url_node)s
   return (%(src)s);
 })();


### PR DESCRIPTION
This always seems to refer to full filename/url.  Perhaps in the past it actually did hold the directory name?