### PR TITLE
Don't clobber existing `.wasm` file in `-sSINGLE_FILE` mode

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -983,11 +983,7 @@ def strip(infile, outfile, debug=False, sections=None):
 
 # extract the DWARF info from the main file, and leave the wasm with
 # debug into as a file on the side
-def emit_debug_on_side(wasm_file):
-  # if the dwarf filename wasn't provided, use the default target + a suffix
-  wasm_file_with_dwarf = settings.SEPARATE_DWARF
-  if wasm_file_with_dwarf is True:
-    wasm_file_with_dwarf = wasm_file + '.debug.wasm'
+def emit_debug_on_side(wasm_file, wasm_file_with_dwarf):
   embedded_path = settings.SEPARATE_DWARF_URL
   if not embedded_path:
     # a path was provided - make it relative to the wasm.


### PR DESCRIPTION
Use a temp file for when the wasm is not going to be part of the output.

As part of this change I had to update `--emit-tsd` to output relative to the JS rather than
the wasm file, since the wasm file might be in the tmp directory after this change.