### PR TITLE
[tsgen] Fix emitting TypeScript for wasm only output.

### DIFF
--- a/test/other/test_emit_tsd_wasm_only.d.ts
+++ b/test/other/test_emit_tsd_wasm_only.d.ts
@@ -1,0 +1,8 @@
+// TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
+interface WasmModule {
+  _fooVoid(): void;
+  _fooInt(_0: number, _1: number): number;
+  __start(): void;
+}
+
+export type MainModule = WasmModule;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3307,6 +3307,12 @@ More info: https://emscripten.org
     cmd = shared.get_npm_cmd('tsc') + [test_file('other/test_tsd.ts'), '--noEmit']
     shared.check_call(cmd)
 
+  def test_emit_tsd_wasm_only(self):
+    self.run_process([EMCC, test_file('other/test_emit_tsd.c'),
+                      '--emit-tsd', 'test_emit_tsd_wasm_only.d.ts', '-o', 'out.wasm'] +
+                     self.get_emcc_args())
+    self.assertFileContents(test_file('other/test_emit_tsd_wasm_only.d.ts'), read_file('test_emit_tsd_wasm_only.d.ts'))
+
   def test_emconfig(self):
     output = self.run_process([emconfig, 'LLVM_ROOT'], stdout=PIPE).stdout.strip()
     self.assertEqual(output, config.LLVM_ROOT)


### PR DESCRIPTION
Skip generating runtime definitions when wasm only output is requested.

Fixes #21740