### PR TITLE
Add some missing musl file

### DIFF
--- a/system/lib/libc/musl/src/internal/emulate_wait4.c
+++ b/system/lib/libc/musl/src/internal/emulate_wait4.c
@@ -1,0 +1,55 @@
+#include <sys/wait.h>
+#include "syscall.h"
+
+#ifndef SYS_wait4
+hidden long __emulate_wait4(int pid, int *status, int options, void *kru, int cp)
+{
+	idtype_t t;
+	int r;
+	siginfo_t info;
+
+	info.si_pid = 0;
+	if (pid < -1) {
+		t = P_PGID;
+		pid = -pid;
+	} else if (pid == -1) {
+		t = P_ALL;
+	} else if (pid == 0) {
+		t = P_PGID;
+	} else {
+		t = P_PID;
+	}
+
+	if (cp) r = __syscall_cp(SYS_waitid, t, pid, &info, options|WEXITED, kru);
+	else r = __syscall(SYS_waitid, t, pid, &info, options|WEXITED, kru);
+
+	if (r<0) return r;
+
+	if (info.si_pid && status) {
+		int sw=0;
+		switch (info.si_code) {
+		case CLD_CONTINUED:
+			sw = 0xffff;
+			break;
+		case CLD_DUMPED:
+			sw = info.si_status&0x7f | 0x80;
+			break;
+		case CLD_EXITED:
+			sw = (info.si_status&0xff) << 8;
+			break;
+		case CLD_KILLED:
+			sw = info.si_status&0x7f;
+			break;
+		case CLD_STOPPED:
+		case CLD_TRAPPED:
+			/* see ptrace(2); the high bits of si_status can contain */
+			/* PTRACE_EVENT_ values which must be preserved */
+			sw = (info.si_status << 8) + 0x7f;
+			break;
+		}
+		*status = sw;
+	}
+
+	return info.si_pid;
+}
+#endif

--- a/system/lib/libc/musl/src/linux/preadv2.c
+++ b/system/lib/libc/musl/src/linux/preadv2.c
@@ -1,0 +1,17 @@
+#define _GNU_SOURCE
+#include <sys/uio.h>
+#include <unistd.h>
+#include "syscall.h"
+
+ssize_t preadv2(int fd, const struct iovec *iov, int count, off_t ofs, int flags)
+{
+#ifdef SYS_preadv
+	if (!flags) {
+		if (ofs==-1) return readv(fd, iov, count);
+		return syscall_cp(SYS_preadv, fd, iov, count,
+			(long)(ofs), (long)(ofs>>32));
+	}
+#endif
+	return syscall_cp(SYS_preadv2, fd, iov, count,
+		(long)(ofs), (long)(ofs>>32), flags);
+}

--- a/system/lib/libc/musl/src/linux/pwritev2.c
+++ b/system/lib/libc/musl/src/linux/pwritev2.c
@@ -1,0 +1,17 @@
+#define _GNU_SOURCE
+#include <sys/uio.h>
+#include <unistd.h>
+#include "syscall.h"
+
+ssize_t pwritev2(int fd, const struct iovec *iov, int count, off_t ofs, int flags)
+{
+#ifdef SYS_pwritev
+	if (!flags) {
+		if (ofs==-1) return writev(fd, iov, count);
+		return syscall_cp(SYS_pwritev, fd, iov, count,
+			(long)(ofs), (long)(ofs>>32));
+	}
+#endif
+	return syscall_cp(SYS_pwritev2, fd, iov, count,
+		(long)(ofs), (long)(ofs>>32), flags);
+}

--- a/system/lib/libc/musl/src/linux/statx.c
+++ b/system/lib/libc/musl/src/linux/statx.c
@@ -1,0 +1,46 @@
+#define _GNU_SOURCE
+#include <sys/stat.h>
+#include <string.h>
+#include <syscall.h>
+#include <sys/sysmacros.h>
+#include <errno.h>
+
+int statx(int dirfd, const char *restrict path, int flags, unsigned mask, struct statx *restrict stx)
+{
+#ifdef __EMSCRIPTEN__
+	int ret;
+#else
+	int ret = __syscall(SYS_statx, dirfd, path, flags, mask, stx);
+
+#ifndef SYS_fstatat
+	return __syscall_ret(ret);
+#endif
+
+	if (ret != -ENOSYS) return __syscall_ret(ret);
+#endif
+
+	struct stat st;
+	ret = fstatat(dirfd, path, &st, flags);
+	if (ret) return ret;
+
+	stx->stx_dev_major = major(st.st_dev);
+	stx->stx_dev_minor = minor(st.st_dev);
+	stx->stx_ino = st.st_ino;
+	stx->stx_mode = st.st_mode;
+	stx->stx_nlink = st.st_nlink;
+	stx->stx_uid = st.st_uid;
+	stx->stx_gid = st.st_gid;
+	stx->stx_size = st.st_size;
+	stx->stx_blksize = st.st_blksize;
+	stx->stx_blocks = st.st_blocks;
+	stx->stx_atime.tv_sec = st.st_atim.tv_sec;
+	stx->stx_atime.tv_nsec = st.st_atim.tv_nsec;
+	stx->stx_mtime.tv_sec = st.st_mtim.tv_sec;
+	stx->stx_mtime.tv_nsec = st.st_mtim.tv_nsec;
+	stx->stx_ctime.tv_sec = st.st_ctim.tv_sec;
+	stx->stx_ctime.tv_nsec = st.st_ctim.tv_nsec;
+	stx->stx_btime = (struct statx_timestamp){.tv_sec=0, .tv_nsec=0};
+	stx->stx_mask = STATX_BASIC_STATS;
+
+	return 0;
+}

--- a/system/lib/libc/musl/src/select/ppoll.c
+++ b/system/lib/libc/musl/src/select/ppoll.c
@@ -1,0 +1,26 @@
+#define _BSD_SOURCE
+#include <poll.h>
+#include <signal.h>
+#include <errno.h>
+#include "syscall.h"
+
+#define IS32BIT(x) !((x)+0x80000000ULL>>32)
+#define CLAMP(x) (int)(IS32BIT(x) ? (x) : 0x7fffffffU+((0ULL+(x))>>63))
+
+int ppoll(struct pollfd *fds, nfds_t n, const struct timespec *to, const sigset_t *mask)
+{
+	time_t s = to ? to->tv_sec : 0;
+	long ns = to ? to->tv_nsec : 0;
+#ifdef SYS_ppoll_time64
+	int r = -ENOSYS;
+	if (SYS_ppoll == SYS_ppoll_time64 || !IS32BIT(s))
+		r = __syscall_cp(SYS_ppoll_time64, fds, n,
+			to ? ((long long[]){s, ns}) : 0,
+			mask, _NSIG/8);
+	if (SYS_ppoll == SYS_ppoll_time64 || r != -ENOSYS)
+		return __syscall_ret(r);
+	s = CLAMP(s);
+#endif
+	return syscall_cp(SYS_ppoll, fds, n,
+		to ? ((long[]){s, ns}) : 0, mask, _NSIG/8);
+}

--- a/test/stat/test_statx.c
+++ b/test/stat/test_statx.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#define _GNU_SOURCE
+
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+void create_file(const char *path, const char *buffer, int mode) {
+  int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, mode);
+  assert(fd >= 0);
+
+  int err = write(fd, buffer, sizeof(char) * strlen(buffer));
+  assert(err ==  (sizeof(char) * strlen(buffer)));
+
+  close(fd);
+}
+
+void setup() {
+  mkdir("folder", 0777);
+  create_file("folder/file", "abcdef", 0777);
+  symlink("file", "folder/file-link");
+}
+
+int main() {
+  setup();
+
+  int rc;
+  struct statx buf;
+
+  rc = statx(AT_FDCWD, "folder", 0, STATX_ALL, &buf);
+  assert(rc == 0);
+  assert(S_ISDIR(buf.stx_mode));
+
+  rc = statx(AT_FDCWD, "folder/file", 0, STATX_ALL, &buf);
+  assert(rc == 0);
+  assert(S_ISREG(buf.stx_mode));
+
+  rc = statx(AT_FDCWD, "folder/file-link", 0, STATX_ALL, &buf);
+  assert(rc == 0);
+  assert(S_ISREG(buf.stx_mode));
+
+  rc = statx(AT_FDCWD, "folder/file-link", AT_SYMLINK_NOFOLLOW, STATX_ALL, &buf);
+  assert(rc == 0);
+  assert(S_ISLNK(buf.stx_mode));
+
+  printf("success\n");
+  return 0;
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5590,6 +5590,10 @@ Module = {
     self.do_runf('stat/test_stat.c', 'success')
     self.verify_in_strict_mode('test_stat.js')
 
+  def test_statx(self):
+    self.set_setting("FORCE_FILESYSTEM")
+    self.do_runf('stat/test_statx.c', 'success')
+
   def test_fstatat(self):
     self.do_runf('stat/test_fstatat.c', 'success')
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1092,6 +1092,7 @@ class libc(MuslInternalLibrary,
         'memcpy.c', 'memset.c', 'memmove.c', 'getaddrinfo.c', 'getnameinfo.c',
         'res_query.c', 'res_querydomain.c',
         'proto.c',
+        'ppoll.c',
         'syscall.c', 'popen.c', 'pclose.c',
         'getgrouplist.c', 'initgroups.c', 'wordexp.c', 'timer_create.c',
         'getentropy.c',
@@ -1232,7 +1233,7 @@ class libc(MuslInternalLibrary,
 
     libc_files += files_in_path(
         path='system/lib/libc/musl/src/linux',
-        filenames=['getdents.c', 'gettid.c', 'utimes.c'])
+        filenames=['getdents.c', 'gettid.c', 'utimes.c', 'statx.c'])
 
     libc_files += files_in_path(
         path='system/lib/libc/musl/src/sched',


### PR DESCRIPTION
These should have been included in the v1.2.5 update (#21598).

In particular `statx.c` contains the implementation of the `statx` function which has been reported as being undefined.

Note that we don't actually do this by implementing a statx syscall. We simply rely on the emulation via statat.