### PR TITLE
Use shorthand object initialization for wasmImports where possible. NFC

### DIFF
--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -854,7 +854,15 @@ def create_sending(metadata, library_symbols):
     # This prevents closure compiler from minifying the field names in this
     # object.
     prefix = '/** @export */\n  '
-  return '{\n  ' + ',\n  '.join(f'{prefix}{k}: {v}' for k, v in sorted_items) + '\n}'
+
+  elems = []
+  for k, v in sorted_items:
+    if k == v:
+      elems.append(f'{prefix}{k}')
+    else:
+      elems.append(f'{prefix}{k}: {v}')
+
+  return '{\n  ' + ',\n  '.join(elems) + '\n}'
 
 
 def make_export_wrappers(function_exports):


### PR DESCRIPTION
As of today this doesn't do much since only the invoke_xx function are not mangled using the leading underscore.  If we ever manage to remove that mangling then this will effect basically all imports.