### PR TITLE
[tsgen] Emit TypeScript definitions for empty runtime exports.

### DIFF
--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -661,8 +661,8 @@ function(${args}) {
 
       if (EMIT_TSD) {
         LibraryManager.libraryDefinitions[mangled] = {
-          docs: docs || '',
-          snippet,
+          docs: docs ?? null,
+          snippet: snippet ?? null,
         };
       }
 

--- a/src/library.js
+++ b/src/library.js
@@ -3272,6 +3272,7 @@ addToLibrary({
   $getNativeTypeSize__deps: ['$POINTER_SIZE'],
   $getNativeTypeSize: {{{ getNativeTypeSize }}},
 
+  $wasmTable__docs: '/** @type {WebAssembly.Table} */',
 #if RELOCATABLE
   // In RELOCATABLE mode we create the table in JS.
   $wasmTable: `=new WebAssembly.Table({

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -1,5 +1,6 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
 declare namespace RuntimeExports {
+    let HEAPF32: any;
     let HEAPF64: any;
     let HEAP_DATA_VIEW: any;
     let HEAP8: any;

--- a/test/other/embind_tsgen_bigint.d.ts
+++ b/test/other/embind_tsgen_bigint.d.ts
@@ -1,5 +1,6 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
 declare namespace RuntimeExports {
+    let HEAPF32: any;
     let HEAPF64: any;
     let HEAP_DATA_VIEW: any;
     let HEAP8: any;

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -1,5 +1,6 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
 declare namespace RuntimeExports {
+    let HEAPF32: any;
     let HEAPF64: any;
     let HEAP_DATA_VIEW: any;
     let HEAP8: any;

--- a/test/other/embind_tsgen_ignore_3.d.ts
+++ b/test/other/embind_tsgen_ignore_3.d.ts
@@ -1,5 +1,6 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
 declare namespace RuntimeExports {
+    let HEAPF32: any;
     let HEAPF64: any;
     let HEAP_DATA_VIEW: any;
     let HEAP8: any;

--- a/test/other/embind_tsgen_memory64.d.ts
+++ b/test/other/embind_tsgen_memory64.d.ts
@@ -1,5 +1,6 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
 declare namespace RuntimeExports {
+    let HEAPF32: any;
     let HEAPF64: any;
     let HEAP_DATA_VIEW: any;
     let HEAP8: any;

--- a/test/other/test_emit_tsd.d.ts
+++ b/test/other/test_emit_tsd.d.ts
@@ -10,6 +10,7 @@ declare namespace RuntimeExports {
      * @return {string}
      */
     function UTF8ArrayToString(heapOrArray: any, idx: number, maxBytesToRead?: number): string;
+    let wasmTable: WebAssembly.Table;
     let HEAPF32: any;
     let HEAPF64: any;
     let HEAP_DATA_VIEW: any;

--- a/test/other/test_emit_tsd_sync.d.ts
+++ b/test/other/test_emit_tsd_sync.d.ts
@@ -1,5 +1,6 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
 declare namespace RuntimeExports {
+    let HEAPF32: any;
     let HEAPF64: any;
     let HEAP_DATA_VIEW: any;
     let HEAP8: any;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3312,7 +3312,7 @@ More info: https://emscripten.org
   def test_emit_tsd(self):
     self.run_process([EMCC, test_file('other/test_emit_tsd.c'),
                       '--emit-tsd', 'test_emit_tsd.d.ts', '-sEXPORT_ES6',
-                      '-sMODULARIZE', '-sEXPORTED_RUNTIME_METHODS=UTF8ArrayToString',
+                      '-sMODULARIZE', '-sEXPORTED_RUNTIME_METHODS=UTF8ArrayToString,wasmTable',
                       '-Wno-experimental', '-o', 'test_emit_tsd.js'] +
                      self.get_emcc_args())
     self.assertFileContents(test_file('other/test_emit_tsd.d.ts'), read_file('test_emit_tsd.d.ts'))

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -613,13 +613,25 @@ def create_tsd_exported_runtime_methods(metadata):
   # Use the TypeScript compiler to generate defintions for all of the runtime
   # exports. The JS from the library any JS docs are included in the file used
   # for generation.
-  js_doc = 'var RuntimeExports = {};'
+  js_doc = 'var RuntimeExports = {};\n'
   for name in settings.EXPORTED_RUNTIME_METHODS:
+    docs = '/** @type {{any}} */'
+    snippet = ''
     if name in metadata.library_definitions:
       definition = metadata.library_definitions[name]
-      js_doc += f'{definition["docs"]}\nRuntimeExports[\'{name}\'] = \n{definition["snippet"]};\n'
-    else:
-      js_doc += f'/** @type {{any}} */RuntimeExports[\'{name}\'];\n'
+      if definition['snippet']:
+        snippet = ' = ' + definition['snippet']
+        # Clear the doc so the type is either computed from the snippet or
+        # defined by the definition below.
+        docs = ''
+      if definition['docs']:
+        docs = definition['docs']
+        # TSC does not generate the correct type if there are jsdocs and nothing
+        # is assigned to the property.
+        if not snippet:
+          snippet = ' = null'
+    js_doc += f'{docs}\nRuntimeExports[\'{name}\']{snippet};\n'
+
   js_doc_file = in_temp('jsdoc.js')
   tsc_output_file = in_temp('jsdoc.d.ts')
   utils.write_file(js_doc_file, js_doc)


### PR DESCRIPTION
 - Fixes error when a runtime export is undefined.
 - Adds jsdoc for wasmTable.
 - Fixes first runtime export definition missing because of missing new line.

Fixes #21788