### PR TITLE
Define unimplemented syscalls as weak symbols in stubs

### DIFF
--- a/system/lib/libc/emscripten_syscall_stubs.c
+++ b/system/lib/libc/emscripten_syscall_stubs.c
@@ -38,7 +38,7 @@ static mode_t g_umask = S_IRWXU | S_IRWXG | S_IRWXO;
 #endif
 
 #define UNIMPLEMENTED(name, args) \
-  int __syscall_##name args { \
+  weak int __syscall_##name args { \
     REPORT(name); \
     return -ENOSYS; \
   }


### PR DESCRIPTION
With the current implementation of stubs, users can provide overrides for syscalls with existing implementations. However overriding unimplemented stubs is currently impossible. This fixes that. 