### PR TITLE
Cleanup test_unistd_links. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6049,12 +6049,10 @@ Module.onRuntimeInitialized = () => {
     self.do_runf('unistd/unlink.c', 'success')
 
   @parameterized({
-    'memfs': (['-DMEMFS'], False),
+    'memfs': ([], False),
     'nodefs': (['-DNODEFS', '-lnodefs.js'], True)
   })
   def test_unistd_links(self, args, nodefs):
-    self.emcc_args += args
-
     if nodefs:
       self.require_node()
       if WINDOWS:
@@ -6068,7 +6066,7 @@ Module.onRuntimeInitialized = () => {
         self.skipTest('TODO: wasmfs+node')
       self.emcc_args += ['-sFORCE_FILESYSTEM']
 
-    self.do_run_in_out_file_test('unistd/links.c')
+    self.do_run_in_out_file_test('unistd/links.c', emcc_args=args)
 
   @no_windows('Skipping NODEFS test, since it would require administrative privileges.')
   @requires_node

--- a/test/unistd/links.c
+++ b/test/unistd/links.c
@@ -6,13 +6,20 @@
  */
 
 #include <assert.h>
-#include <emscripten.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 
-int main() {
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#else
+#include <sys/stat.h>
+#include <fcntl.h>
+#endif
+
+void setup() {
+#ifdef __EMSCRIPTEN__
   EM_ASM(
     FS.mkdir('working');
 #if NODEFS
@@ -23,14 +30,28 @@ int main() {
     FS.writeFile('file', 'test');
     FS.mkdir('folder');
   );
+#else
+  mkdir("working", 0777);
+  chdir("working");
+  symlink("../test/../there!", "link");
+  int fd = open("file", O_RDWR);
+  write(fd, "test", 5);
+  close(fd);
+  mkdir("folder", 0777);
+#endif
+}
+
+int main() {
+  setup();
 
   char* files[] = {"link", "file", "folder"};
   char buffer[256] = {0};
+  int ret;
 
   for (int i = 0; i < sizeof files / sizeof files[0]; i++) {
     printf("readlink(%s)\n", files[i]);
-    int ret = readlink(files[i], buffer, 256);
-    printf("errno: %d\n", errno);
+    ret = readlink(files[i], buffer, 256);
+    printf("errno: %s\n", strerror(errno));
     if (ret < 0) {
       printf("not a link\n\n");
       continue;
@@ -39,7 +60,7 @@ int main() {
     // seeing the symlink as a string. The old JS FS instead normalizes it and
     // returns something modified.
     // The same happens in the assertions below.
-#ifdef WASMFS
+#if !defined(__EMSCRIPTEN__) || defined(WASMFS)
     assert(strcmp(buffer, "../test/../there!") == 0);
 #else
     assert(strcmp(buffer, "/there!") == 0);
@@ -50,32 +71,34 @@ int main() {
   }
 
   printf("symlink/overwrite\n");
-  printf("ret: %d\n", symlink("new-nonexistent-path", "link"));
-  printf("errno: %d\n\n", errno);
+  ret = symlink("new-nonexistent-path", "link");
+  assert(ret == -1);
+  assert(errno == EEXIST);
   errno = 0;
 
-  printf("symlink/normal\n");
-  printf("ret: %d\n", symlink("new-nonexistent-path", "folder/link"));
-  printf("errno: %d\n", errno);
+  printf("\nsymlink/normal\n");
+  ret = symlink("new-nonexistent-path", "folder/link");
+  assert(ret == 0);
+  assert(errno == 0);
   errno = 0;
 
-  printf("readlink(created link)\n");
-  int ret = readlink("folder/link", buffer, 256);
-  printf("errno: %d\n", errno);
-#ifdef WASMFS
+  printf("\nreadlink(created link)\n");
+  ret = readlink("folder/link", buffer, 256);
+  assert(errno == 0);
+#if !defined(__EMSCRIPTEN__) || defined(WASMFS)
   assert(strcmp(buffer, "new-nonexistent-path") == 0);
 #else
   assert(strcmp(buffer, "/working/folder/new-nonexistent-path") == 0);
 #endif
   assert(strlen(buffer) == ret);
   errno = 0;
-  printf("\n");
 
   buffer[0] = buffer[1] = buffer[2] = buffer[3] = buffer[4] = buffer[5] = '*';
-  printf("readlink(short buffer)\n");
-  printf("ret: %zd\n", readlink("link", buffer, 4));
-  printf("errno: %d\n", errno);
-#ifdef WASMFS
+  printf("\nreadlink(short buffer)\n");
+  ret = readlink("link", buffer, 4);
+  assert(errno == 0);
+  assert(ret == 4);
+#if !defined(__EMSCRIPTEN__) || defined(WASMFS)
   assert(strcmp(buffer, "../t**nexistent-path") == 0);
 #else
   assert(strcmp(buffer, "/the**ng/folder/new-nonexistent-path") == 0);
@@ -87,10 +110,9 @@ int main() {
   //
   // This test doesn't work in wasmfs -- probably because access sees the
   // symlink and returns true without bothering to chase the symlink
-  symlink("./linkX/inside","./linkX");
-  int result = access("linkX", F_OK);
-  assert(result == -1);
-  printf("errno: %d\n", errno);
+  symlink("./linkX/inside", "./linkX");
+  ret = access("linkX", F_OK);
+  assert(ret == -1);
   assert(errno == ELOOP);
   errno = 0;
 

--- a/test/unistd/links.out
+++ b/test/unistd/links.out
@@ -1,24 +1,18 @@
 readlink(link)
-errno: 0
+errno: No error information
 
 readlink(file)
-errno: 28
+errno: Invalid argument
 not a link
 
 readlink(folder)
-errno: 28
+errno: Invalid argument
 not a link
 
 symlink/overwrite
-ret: -1
-errno: 20
 
 symlink/normal
-ret: 0
-errno: 0
+
 readlink(created link)
-errno: 0
 
 readlink(short buffer)
-ret: 4
-errno: 0


### PR DESCRIPTION
Use assertions to make the test fail early rather than depending on file output comparison.