### PR TITLE
Remove internal `emscripten_get_module_name` helper. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2466,15 +2466,6 @@ addToLibrary({
     else return lengthBytesUTF8(str);
   },
 
-  emscripten_get_module_name__deps: ['$stringToUTF8'],
-  emscripten_get_module_name: (buf, length) => {
-#if MINIMAL_RUNTIME
-    return stringToUTF8('{{{ TARGET_BASENAME }}}.wasm', buf, length);
-#else
-    return stringToUTF8(wasmBinaryFile, buf, length);
-#endif
-  },
-
 #if USE_ASAN || USE_LSAN || UBSAN_RUNTIME
   // When lsan or asan is enabled withBuiltinMalloc temporarily replaces calls
   // to malloc, free, and memalign.
@@ -2953,17 +2944,9 @@ addToLibrary({
 
   // Use program_invocation_short_name and program_invocation_name in compiled
   // programs. This function is for implementing them.
-#if !MINIMAL_RUNTIME
-  _emscripten_get_progname__deps: ['$stringToUTF8'],
-#endif
+  _emscripten_get_progname__deps: ['$getExecutableName', '$stringToUTF8'],
   _emscripten_get_progname: (str, len) => {
-#if !MINIMAL_RUNTIME
-#if ASSERTIONS
-    assert(typeof str == 'number');
-    assert(typeof len == 'number');
-#endif
-    stringToUTF8(thisProgram, str, len);
-#endif
+    stringToUTF8(getExecutableName(), str, len);
   },
 
   emscripten_console_log: (str) => {

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -642,7 +642,6 @@ sigs = {
   emscripten_get_gamepad_status__sig: 'iip',
   emscripten_get_heap_max__sig: 'p',
   emscripten_get_main_loop_timing__sig: 'vpp',
-  emscripten_get_module_name__sig: 'ppp',
   emscripten_get_mouse_status__sig: 'ip',
   emscripten_get_now__sig: 'd',
   emscripten_get_now_res__sig: 'd',

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_emscripten.cpp
@@ -34,7 +34,7 @@ void ListOfModules::init() {
   modules_.Initialize(2);
 
   char name[256];
-  emscripten_get_module_name(name, 256);
+  _emscripten_get_progname(name, 256);
 
   LoadedModule main_module;
   main_module.set(name, 0);

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -1251,7 +1251,7 @@ uptr GetPageSize() {
 #  endif  // !SANITIZER_ANDROID
 
 #  if SANITIZER_EMSCRIPTEN
-extern "C" uptr emscripten_get_module_name(char *buf, uptr buf_len);
+extern "C" void _emscripten_get_progname(char *buf, int buf_len);
 #  endif
 
 uptr ReadBinaryName(/*out*/ char *buf, uptr buf_len) {
@@ -1260,7 +1260,8 @@ uptr ReadBinaryName(/*out*/ char *buf, uptr buf_len) {
   CHECK_NE(default_module_name, NULL);
   return internal_snprintf(buf, buf_len, "%s", default_module_name);
 #  elif SANITIZER_EMSCRIPTEN
-  return emscripten_get_module_name(buf, buf_len);
+  _emscripten_get_progname(buf, buf_len);
+  return internal_strlen(buf);
 #  else
 #    if SANITIZER_FREEBSD || SANITIZER_NETBSD
 #      if SANITIZER_FREEBSD

--- a/system/lib/libc/emscripten_internal.h
+++ b/system/lib/libc/emscripten_internal.h
@@ -55,7 +55,6 @@ const char* emscripten_pc_get_file(uintptr_t pc);
 int emscripten_pc_get_line(uintptr_t pc);
 int emscripten_pc_get_column(uintptr_t pc);
 
-char* emscripten_get_module_name(char* buf, size_t length);
 void* emscripten_builtin_mmap(
   void* addr, size_t length, int prot, int flags, int fd, off_t offset);
 int emscripten_builtin_munmap(void* addr, size_t length);

--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -332,8 +332,8 @@ weak char* _emscripten_sanitizer_get_option(const char* name) {
   return strdup("");
 }
 
-weak char* emscripten_get_module_name(char* buf, size_t length) {
-  return strncpy(buf, "<unknown>", length);
+weak void _emscripten_get_progname(char* buf, int length) {
+  strncpy(buf, "<unknown>", length);
 }
 
 weak void _emscripten_runtime_keepalive_clear() {}


### PR DESCRIPTION
This helper was added when we implement sanitizes in #8651.  It was never added to any public header file and should only have these two internal users.

Instead of this function we can just use the existing internal `_emscripten_get_progname` function, which can in turn then be implemented in terms of the existing `getExecutableName` JavaScript function.