### PR TITLE
[NFC] Add assert to emmalloc test

### DIFF
--- a/test/other/test_emmalloc_high_align.c
+++ b/test/other/test_emmalloc_high_align.c
@@ -16,6 +16,8 @@ int main() {
   // MB). This is similar to what mimalloc does in practice.
   void* before = sbrk(0);
   void* p = aligned_alloc(ALIGN, SIZE);
+  // aligned_alloc returns NULL on error; validate we actually allocated.
+  assert(p);
   void* after = sbrk(0);
   emscripten_console_logf("before: %p  after: %p  p: %p\n", before, after, p);
 


### PR DESCRIPTION
The test checked alignment of the output of `aligned_alloc`, but that method
returns 0 on errors and 0 is fully aligned, so in theory the test could have
missed a problem.