### PR TITLE
Fix pthread + modularize + running in node worker

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -198,6 +198,9 @@ if (ENVIRONMENT_IS_WORKER) {
 // `/` should be present at the end if `scriptDirectory` is not empty
 var scriptDirectory = '';
 function locateFile(path) {
+#if RUNTIME_DEBUG
+  dbg('locateFile:', path, 'scriptDirectory:', scriptDirectory);
+#endif
 #if expectToReceiveOnModule('locateFile')
   if (Module['locateFile']) {
     return Module['locateFile'](path, scriptDirectory);
@@ -232,18 +235,14 @@ if (ENVIRONMENT_IS_NODE) {
   var fs = require('fs');
   var nodePath = require('path');
 
-  if (ENVIRONMENT_IS_WORKER) {
-    scriptDirectory = nodePath.dirname(scriptDirectory) + '/';
-  } else {
 #if EXPORT_ES6
-    // EXPORT_ES6 + ENVIRONMENT_IS_NODE always requires use of import.meta.url,
-    // since there's no way getting the current absolute path of the module when
-    // support for that is not available.
-    scriptDirectory = require('url').fileURLToPath(new URL('./', import.meta.url)); // includes trailing slash
+  // EXPORT_ES6 + ENVIRONMENT_IS_NODE always requires use of import.meta.url,
+  // since there's no way getting the current absolute path of the module when
+  // support for that is not available.
+  scriptDirectory = require('url').fileURLToPath(new URL('./', import.meta.url)); // includes trailing slash
 #else
-    scriptDirectory = __dirname + '/';
+  scriptDirectory = __dirname + '/';
 #endif
-  }
 
 #include "node_shell_read.js"
 

--- a/src/wasm_worker.js
+++ b/src/wasm_worker.js
@@ -23,6 +23,7 @@ if (ENVIRONMENT_IS_NODE) {
     self: global,
     require,
     __filename,
+    __dirname,
     Worker: nodeWorkerThreads.Worker,
     importScripts: (f) => vm.runInThisContext(fs.readFileSync(f, 'utf8'), {filename: f}),
     postMessage: (msg) => parentPort.postMessage(msg),


### PR DESCRIPTION
The issue here was the special case for the setting of `scriptDirectory` under
nodejs when `ENVIRONMENT_IS_WORKER`.

Previously this path was not being hit when the main thread was running in
a worker because we were not setting `ENVIRONMENT_IS_WORKER` in
this case.   This was fixed in #21701 and `ENVIRONMENT_IS_WORKER`
was correctly set, but that meant that `scriptDirectory` then started being
set incorrectly.

Fixes: #21827