### PR TITLE
 [test] Don't pass `-O` compiler flags when building assembly files. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1109,12 +1109,14 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   # param @main_file whether this is the main file of the test. some arguments
   #                  (like --pre-js) do not need to be passed when building
   #                  libraries, for example
-  def get_emcc_args(self, main_file=False, compile_only=False):
+  def get_emcc_args(self, main_file=False, compile_only=False, asm_only=False):
     def is_ldflag(f):
       return any(f.startswith(s) for s in ['-sENVIRONMENT=', '--pre-js=', '--post-js='])
 
-    args = self.serialize_settings(compile_only) + self.emcc_args
-    if compile_only:
+    args = self.serialize_settings(compile_only or asm_only) + self.emcc_args
+    if asm_only:
+      args = [a for a in args if not a.startswith('-O')]
+    if compile_only or asm_only:
       args = [a for a in args if not is_ldflag(a)]
     else:
       args += self.ldflags

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9613,7 +9613,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_wasm2js('wasm2js does not support reference types')
   @no_sanitize('.s files cannot be sanitized')
   def test_externref(self):
-    self.run_process([EMCC, '-c', test_file('core/test_externref.s'), '-o', 'asm.o'] + self.get_emcc_args(compile_only=True))
+    self.run_process([EMCC, '-c', test_file('core/test_externref.s'), '-o', 'asm.o'] + self.get_emcc_args(asm_only=True))
     self.emcc_args += ['--js-library', test_file('core/test_externref.js')]
     self.emcc_args += ['-mreference-types']
     self.do_core_test('test_externref.c', libraries=['asm.o'])


### PR DESCRIPTION
This starting failing after an llvm change:
https://github.com/llvm/llvm-project/pull/90013

```
clang: error: argument unused during compilation: '-O2' [-Werror,-Wunused-command-line-argument]
```