### PR TITLE
Note newly enabled features in LLVM in ChangeLog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,9 @@ See docs/process.md for more on how version tagging works.
   of pthread builds so that is generated alongside the main JavaScript file.
   See #21701. ()
 - `-sASYNCIFY=2` is setting now deprecated, use `-sJSPI` instead.
+- LLVM now enables multivalue and reference-types features by default. Enabling
+  multivalue feature only enables the language feature and does not turn on the
+  multivalue ABI. (https://github.com/llvm/llvm-project/pull/80923)
 
 3.1.58 - 04/23/24
 -----------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,9 +24,10 @@ See docs/process.md for more on how version tagging works.
   of pthread builds so that is generated alongside the main JavaScript file.
   See #21701. ()
 - `-sASYNCIFY=2` is setting now deprecated, use `-sJSPI` instead.
-- LLVM now enables multivalue and reference-types features by default. Enabling
-  multivalue feature only enables the language feature and does not turn on the
-  multivalue ABI. (https://github.com/llvm/llvm-project/pull/80923)
+- Due to the upstream LLVM change
+  (https://github.com/llvm/llvm-project/pull/80923), multivalue and
+  reference-types features are now enabled by default in Emscripten. This only
+  enables the language features and does not turn on the multivalue ABI.
 
 3.1.58 - 04/23/24
 -----------------


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/80923 enabled multivalue and reference-types by default. Even though this is an LLVM change, given that we release emsdk with all LLVM/Binaryen/Emscripten versions, it could be worth mentioning in the ChangeLog.