### PR TITLE
Add @requires_webgpu, make WebGPU tests fail if unavailable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,6 +368,7 @@ commands:
             # TODO: Do GL testing when https://bugzil.la/1375585 (lack of WebGL
             #       support in headless mode) resolves
             EMTEST_LACKS_GRAPHICS_HARDWARE: "1"
+            EMTEST_LACKS_WEBGPU: "1"
             EMTEST_LACKS_SOUND_HARDWARE: "1"
             # OffscreenCanvas support is not yet done in Firefox.
             EMTEST_LACKS_OFFSCREEN_CANVAS: "1"

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -186,6 +186,7 @@ def skipExecIf(cond, message):
 
 
 requires_graphics_hardware = skipExecIf(os.getenv('EMTEST_LACKS_GRAPHICS_HARDWARE'), 'This test requires graphics hardware')
+requires_webgpu = unittest.skipIf(os.getenv('EMTEST_LACKS_WEBGPU'), "This test requires WebGPU to be available")
 requires_sound_hardware = skipExecIf(os.getenv('EMTEST_LACKS_SOUND_HARDWARE'), 'This test requires sound hardware')
 requires_offscreen_canvas = skipExecIf(os.getenv('EMTEST_LACKS_OFFSCREEN_CANVAS'), 'This test requires a browser with OffscreenCanvas')
 
@@ -4518,12 +4519,12 @@ Module["preRun"] = () => {
     'closure_advanced': (['-sASSERTIONS', '--closure=1', '-O3'],),
     'main_module': (['-sMAIN_MODULE=1'],),
   })
-  @requires_graphics_hardware
+  @requires_webgpu
   def test_webgpu_basic_rendering(self, args):
     self.btest_exit('webgpu_basic_rendering.cpp', args=['-sUSE_WEBGPU'] + args)
 
   # TODO(#19645): Extend this test to proxied WebGPU when it's re-enabled.
-  @requires_graphics_hardware
+  @requires_webgpu
   def test_webgpu_basic_rendering_pthreads(self):
     self.btest_exit('webgpu_basic_rendering.cpp', args=['-sUSE_WEBGPU', '-pthread', '-sOFFSCREENCANVAS_SUPPORT'])
 

--- a/test/webgpu_basic_rendering.cpp
+++ b/test/webgpu_basic_rendering.cpp
@@ -25,19 +25,6 @@ void GetDevice(void (*callback)(wgpu::Device)) {
         if (message) {
             printf("RequestAdapter: %s\n", message);
         }
-        if (status == WGPURequestAdapterStatus_Unavailable) {
-            printf("WebGPU unavailable; exiting cleanly\n");
-            // exit(0) (rather than emscripten_force_exit(0)) ensures there is
-            // no dangling keepalive.
-#if _REENTRANT
-            // FIXME: In multi-threaded builds this callback runs on the main
-            // which seems to be causing the runtime to stay alive here and
-            // results in the 99 being returned.
-            emscripten_force_exit(0);
-#else
-            exit(0);
-#endif
-        }
         assert(status == WGPURequestAdapterStatus_Success);
 
         wgpu::Adapter adapter = wgpu::Adapter::Acquire(cAdapter);


### PR DESCRIPTION
**WIP, needs rebase over #21799**

This makes these tests safer so they won't just silently pass if you happen to run against a browser/system where WebGPU isn't available (currently including Chrome on Linux and Firefox/Safari).

Verified these 5 tests fail, using:
`EMTEST_BROWSER='/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary --disable-gpu' test/runner.py 'browser.test_webgpu*'`
(`--disable-gpu` has the side effect of disabling WebGPU since we don't ship a software fallback in Chrome right now.)