### PR TITLE
[contrib.glfw3] New version

### DIFF
--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -6,8 +6,8 @@
 import os
 from typing import Dict
 
-TAG = '3.4.0.20240318'
-HASH = 'fb90b43d74c234b5534c8936973c1f98e8843c16fae81ce4e1415ea947d1364aa7a167eed4cf263150f1df0f137319d0151e8fe39dc00d4eeb0c3ad48ede03f3'
+TAG = '3.4.0.20240501'
+HASH = 'bc773e73c13f29b64ec09548cee5f48935e6239201e6a68c37f2c8238f0a8467125603bfd249dc85c98d212b6409e49926e1b665317c857af5e219c571c11e38'
 
 # contrib port information (required)
 URL = 'https://github.com/pongasoft/emscripten-glfw'


### PR DESCRIPTION
There is a new version of the port which contains a (nullptr) bug fix. Release notes for [3.4.0.20240501 ](https://github.com/pongasoft/emscripten-glfw/releases/tag/v3.4.0.20240501)