### PR TITLE
Use library symbols instead of legacyRuntimeElements. NFC

### DIFF
--- a/src/library_legacy.js
+++ b/src/library_legacy.js
@@ -126,7 +126,11 @@ legacyFuncs = {
     var js = jsStackTrace();
     if (Module['extraStackTrace']) js += '\n' + Module['extraStackTrace']();
     return js;
-  }
+  },
+
+  // Legacy names for runtime `out`/`err` symbols.
+  $print: 'out',
+  $printErr: 'err',
 };
 
 if (WARN_DEPRECATED && !INCLUDE_FULL_LIBRARY) {

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -350,7 +350,7 @@ var LibraryPThread = {
 #endif
       ];
       for (var handler of knownHandlers) {
-        if (Module.hasOwnProperty(handler)) {
+        if (Module.propertyIsEnumerable(handler)) {
           handlers.push(handler);
         }
       }

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -370,11 +370,6 @@ function addMissingLibraryStubs(unusedLibSymbols) {
 function exportRuntime() {
   const EXPORTED_RUNTIME_METHODS_SET = new Set(EXPORTED_RUNTIME_METHODS);
 
-  const legacyRuntimeElements = new Map([
-    ['print', 'out'],
-    ['printErr', 'err'],
-  ]);
-
   // optionally export something.
   // in ASSERTIONS mode we show a useful error if it is used without
   // being exported. how we show the message depends on whether it's
@@ -391,8 +386,6 @@ function exportRuntime() {
       if (exported.startsWith('FS_')) {
         // this is a filesystem value, FS.x exported as FS_x
         exported = 'FS.' + exported.substr(3);
-      } else if (legacyRuntimeElements.has(exported)) {
-        exported = legacyRuntimeElements.get(exported);
       }
       return `Module['${name}'] = ${exported};`;
     }
@@ -477,16 +470,6 @@ function exportRuntime() {
   for (const name of EXPORTED_RUNTIME_METHODS_SET) {
     if (/^dynCall_/.test(name)) {
       // a specific dynCall; add to the list
-      runtimeElements.push(name);
-    }
-  }
-
-  // Only export legacy runtime elements when explicitly
-  // requested.
-  for (const name of EXPORTED_RUNTIME_METHODS_SET) {
-    if (legacyRuntimeElements.has(name)) {
-      const newName = legacyRuntimeElements.get(name);
-      warn(`deprecated item in EXPORTED_RUNTIME_METHODS: ${name} use ${newName} instead.`);
       runtimeElements.push(name);
     }
   }

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -85,6 +85,11 @@ function missingLibrarySymbol(sym) {
 }
 
 function unexportedRuntimeSymbol(sym) {
+#if PTHREADS
+  if (ENVIRONMENT_IS_PTHREAD) {
+    return;
+  }
+#endif
   if (!Object.getOwnPropertyDescriptor(Module, sym)) {
     Object.defineProperty(Module, sym, {
       configurable: true,

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8077,19 +8077,18 @@ int main() {}
     self.assertNotContained(error, read_file('a.out.js'))
 
   def test_warn_module_out_err(self):
-    error = 'was not exported. add it to EXPORTED_RUNTIME_METHODS (see the Emscripten FAQ)'
-
     def test(contents, expected, args=[], assert_returncode=0):  # noqa
       create_file('src.c', r'''
-  #include <emscripten.h>
-  int main() {
-    EM_ASM({ %s });
-    return 0;
-  }
-  ''' % contents)
+        #include <emscripten.h>
+        int main() {
+          EM_ASM({ %s });
+          return 0;
+        }
+        ''' % contents)
       self.do_runf('src.c', expected, emcc_args=args, assert_returncode=assert_returncode)
 
     # error shown (when assertions are on)
+    error = 'was not exported. add it to EXPORTED_RUNTIME_METHODS (see the Emscripten FAQ)'
     test("Module.out('x')", error, assert_returncode=NON_ZERO)
     test("Module['out']('x')", error, assert_returncode=NON_ZERO)
     test("Module.err('x')", error, assert_returncode=NON_ZERO)


### PR DESCRIPTION
We only had two symbols in `legacyRuntimeElements` and it seems cleaner to handle these legacy aliases via the JS library system that we have for that.

This helps with my work towards #8380