### PR TITLE
Fix regal build after recent clang change. NFC

### DIFF
--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -107,7 +107,8 @@ def get(ports, settings, shared):
       '-I' + source_path_lookup3,
       '-I' + source_path_boost,
       '-Wno-deprecated-register',
-      '-Wno-unused-parameter'
+      '-Wno-unused-parameter',
+      '-fdelayed-template-parsing',
     ]
     if settings.PTHREADS:
       flags += ['-pthread']


### PR DESCRIPTION
There appears to be a typo in Regal's linear.h:

```
linear.h:585:26: error: no member named 'negate' in 'Vec4<T>'; did you mean 'Negate'?
  585 |       Vec4 rv(*this); rv.negate(); return rv;
      |                          ^~~~~~
      |                          Negate
linear.h:534:11: note: 'Negate' declared here
  534 |     void  Negate() {
```

This was not an issue until https://github.com/llvm/llvm-project/pull/90152 landed.

Adding `-fdelayed-template-parsing` seems to fix the issue.