### PR TITLE
asyncLoad: fix empty error message

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3125,11 +3125,11 @@ addToLibrary({
 #endif
       onload(new Uint8Array(arrayBuffer));
       if (dep) removeRunDependency(dep);
-    }, (event) => {
+    }, (err) => {
       if (onerror) {
-        onerror();
+        onerror(err);
       } else {
-        throw `Loading data file "${url}" failed.`;
+        throw err;
       }
     });
     if (dep) addRunDependency(dep);


### PR DESCRIPTION
Before:
```
[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "undefined".] {
  code: 'ERR_UNHANDLED_REJECTION'
}
```

After:
```
[Error: ENOENT: no such file or directory, open 'A:\path\to\foo.wasm'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'open',
  path: 'A:\\path\\to\\foo.wasm'
}
```