### PR TITLE
Avoid calling `addEventListener` in audio worklet

### DIFF
--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -143,12 +143,13 @@ addToLibrary({
 #endif
   ],
   _emscripten_create_wasm_worker__postset: `
-if (ENVIRONMENT_IS_WASM_WORKER) {
-  _wasmWorkers[0] = this;
+if (ENVIRONMENT_IS_WASM_WORKER
+// AudioWorkletGlobalScope does not contain addEventListener
 #if AUDIO_WORKLET
-  // Audio Worklets do not have postMessage()ing capabilities.
-  if (!ENVIRONMENT_IS_AUDIO_WORKLET)
+  && !ENVIRONMENT_IS_AUDIO_WORKLET
 #endif
+  ) {
+  _wasmWorkers[0] = this;
   addEventListener("message", _wasmWorkerAppendToQueue);
 }`,
   _emscripten_create_wasm_worker: (stackLowestAddress, stackSize) => {

--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -145,6 +145,10 @@ addToLibrary({
   _emscripten_create_wasm_worker__postset: `
 if (ENVIRONMENT_IS_WASM_WORKER) {
   _wasmWorkers[0] = this;
+#if AUDIO_WORKLET
+  // Audio Worklets do not have postMessage()ing capabilities.
+  if (!ENVIRONMENT_IS_AUDIO_WORKLET)
+#endif
   addEventListener("message", _wasmWorkerAppendToQueue);
 }`,
   _emscripten_create_wasm_worker: (stackLowestAddress, stackSize) => {

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5479,6 +5479,14 @@ Module["preRun"] = () => {
       self.skipTest('https://github.com/emscripten-core/emscripten/issues/19161')
     self.btest_exit('webaudio/audioworklet.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'] + args)
 
+  # Tests that audioworklets and workers can be used at the same time
+  @parameterized({
+    '': ([],),
+    'closure': (['--closure', '1', '-Oz'],),
+  })
+  def test_audio_worklet_worker(self, args):
+    self.btest('webaudio/audioworklet_worker.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'] + args, expected='1')
+
   # Tests that posting functions between the main thread and the audioworklet thread works
   @parameterized({
     '': ([],),

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5482,7 +5482,6 @@ Module["preRun"] = () => {
   # Tests that audioworklets and workers can be used at the same time
   @parameterized({
     '': ([],),
-    'closure': (['--closure', '1', '-Oz'],),
   })
   def test_audio_worklet_worker(self, args):
     self.btest('webaudio/audioworklet_worker.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'] + args, expected='1')

--- a/test/webaudio/audioworklet_worker.c
+++ b/test/webaudio/audioworklet_worker.c
@@ -1,0 +1,49 @@
+#include <emscripten/webaudio.h>
+#include <emscripten/wasm_worker.h>
+#include <emscripten/threading.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+// Tests that
+// - audioworklets and workers can be used at the same time.
+// - an audioworklet can emscripten_futex_wake() a waiting worker.
+// - global values can be shared between audioworklets and workers.
+
+int workletToWorkerFutexLocation = 0;
+int workletToWorkerFlag = 0;
+
+void run_in_worker()
+{
+  while(0 == emscripten_futex_wait(&workletToWorkerFutexLocation, 0, 30000)) {
+    if(workletToWorkerFlag == 1) {
+      printf("Test success\n");
+      break;
+    }
+  }
+
+#ifdef REPORT_RESULT
+  REPORT_RESULT(workletToWorkerFlag == 1);
+#endif
+}
+
+// This event will fire on the audio worklet thread.
+void MessageReceivedInAudioWorkletThread() {
+  assert(emscripten_current_thread_is_audio_worklet());
+  workletToWorkerFlag = 1;
+  emscripten_futex_wake(&workletToWorkerFutexLocation, 1);
+}
+
+void WebAudioWorkletThreadInitialized(EMSCRIPTEN_WEBAUDIO_T audioContext, EM_BOOL success, void *userData) {
+  emscripten_audio_worklet_post_function_v(audioContext, MessageReceivedInAudioWorkletThread);
+}
+
+uint8_t wasmAudioWorkletStack[4096];
+
+int main() {
+  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stackSize: */1024);
+  emscripten_wasm_worker_post_function_v(worker, run_in_worker);
+
+  EMSCRIPTEN_WEBAUDIO_T context = emscripten_create_audio_context(0);
+  emscripten_start_wasm_audio_worklet_thread_async(context, wasmAudioWorkletStack, sizeof(wasmAudioWorkletStack), WebAudioWorkletThreadInitialized, 0);
+}

--- a/test/webaudio/audioworklet_worker.c
+++ b/test/webaudio/audioworklet_worker.c
@@ -13,10 +13,9 @@
 int workletToWorkerFutexLocation = 0;
 int workletToWorkerFlag = 0;
 
-void run_in_worker()
-{
-  while(0 == emscripten_futex_wait(&workletToWorkerFutexLocation, 0, 30000)) {
-    if(workletToWorkerFlag == 1) {
+void run_in_worker() {
+  while (0 == emscripten_futex_wait(&workletToWorkerFutexLocation, 0, 30000)) {
+    if (workletToWorkerFlag == 1) {
       printf("Test success\n");
       break;
     }


### PR DESCRIPTION
When building an application that uses both an audio worklet and a normal worker, the main module wrapper (`a.out.js`) calls `addEventListener` whenever `ENVIRONMENT_IS_WASM_WORKER`. This flag is set for audio worklets, but `addEventListener` is not available in the audio worker global scope. The audio worklet load process then fails.

This doesn't occur when using *only* the audio worklet APIs, because `_emscripten_create_wasm_worker__postset` doesn't happen. There's already a check to prevent a similar error just above the lines modified by this PR: https://github.com/emscripten-core/emscripten/blob/fa80cf25b8641974d60605b8a24cb7150fd63701/src/library_wasm_worker.js#L112C5-L112C58 so the missing check here seems like an oversight.

Here's a minimal example that reproduces the failure:

```
#include <emscripten/webaudio.h>
#include <emscripten/wasm_worker.h>
#include <stdio.h>

void run_in_worker()
{
  printf("Hello from Worker!\n");
}

uint8_t audioThreadStack[4096];

EM_BOOL Callback(int numInputs, const AudioSampleFrame *inputs,
                 int numOutputs, AudioSampleFrame *outputs,
                 int numParams, const AudioParamFrame *params,
                 void *userData)
{
  return EM_TRUE;
}

void AudioWorkletProcessorCreated(EMSCRIPTEN_WEBAUDIO_T audioContext, EM_BOOL success, void *userData)
{
  if (!success) return;

  int outputChannelCounts[1] = { 1 };
  EmscriptenAudioWorkletNodeCreateOptions options = {
    .numberOfInputs = 0,
    .numberOfOutputs = 1,
    .outputChannelCounts = outputChannelCounts
  };

  EMSCRIPTEN_AUDIO_WORKLET_NODE_T wasmAudioWorklet = emscripten_create_wasm_audio_worklet_node(audioContext, "my-node", &options, &Callback, 0);

  EM_ASM({emscriptenGetAudioObject($0).connect(emscriptenGetAudioObject($1).destination)},
    wasmAudioWorklet, audioContext);
}

void AudioThreadInitialized(EMSCRIPTEN_WEBAUDIO_T audioContext, EM_BOOL success, void *userData)
{
  if (!success) return;

  WebAudioWorkletProcessorCreateOptions opts = {
    .name = "my-node",
  };
  emscripten_create_wasm_audio_worklet_processor_async(audioContext, &opts, &AudioWorkletProcessorCreated, 0);
}

int main()
{
  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stackSize: */1024);
  emscripten_wasm_worker_post_function_v(worker, run_in_worker);
  
  EMSCRIPTEN_WEBAUDIO_T context = emscripten_create_audio_context(0);

  emscripten_start_wasm_audio_worklet_thread_async(context, audioThreadStack, sizeof(audioThreadStack), &AudioThreadInitialized, 0);
}
```

Build with `emcc -sAUDIO_WORKLET=1 -sWASM_WORKERS=1 example.cc`