### PR TITLE
Fix ChangeLog related to new default LLVM features

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,11 @@ See docs/process.md for more on how version tagging works.
 - The `EXPORTED_FUNCTIONS` list can now include JS library symbols even if they
   have not been otherwise included (e.g. via `DEFAULT_LIBRARY_FUNCS_TO_INCLUDE`).
   (#21867)
+- Due to the upstream LLVM change
+  (https://github.com/llvm/llvm-project/pull/80923 and
+  https://github.com/llvm/llvm-project/pull/90792), multivalue feature is now
+  enabled by default in Emscripten. This only enables the language features and
+  does not turn on the multivalue ABI.
 
 3.1.59 - 04/30/24
 -----------------
@@ -32,10 +37,6 @@ See docs/process.md for more on how version tagging works.
   of pthread builds so that is generated alongside the main JavaScript file.
   See #21701. ()
 - `-sASYNCIFY=2` is setting now deprecated, use `-sJSPI` instead.
-- Due to the upstream LLVM change
-  (https://github.com/llvm/llvm-project/pull/80923), multivalue and
-  reference-types features are now enabled by default in Emscripten. This only
-  enables the language features and does not turn on the multivalue ABI.
 
 3.1.58 - 04/23/24
 -----------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,7 +25,7 @@ See docs/process.md for more on how version tagging works.
 - The `EXPORTED_FUNCTIONS` list can now include JS library symbols even if they
   have not been otherwise included (e.g. via `DEFAULT_LIBRARY_FUNCS_TO_INCLUDE`).
   (#21867)
-- Due to the upstream LLVM change
+- Due to the upstream LLVM changes
   (https://github.com/llvm/llvm-project/pull/80923 and
   https://github.com/llvm/llvm-project/pull/90792), multivalue feature is now
   enabled by default in Emscripten. This only enables the language features and


### PR DESCRIPTION
I submitted #21853 before landing
https://github.com/llvm/llvm-project/pull/80923, so the previous version (3.1.59) was released before the LLVM change actually landed. And then we decided to disable reference-types temporarily
(https://github.com/llvm/llvm-project/pull/90792) while the node version is being resolved
(https://github.com/emscripten-core/emsdk/issues/1173#issuecomment-2088779911).

This moves the entry to the current release and only mentions multivalue is the newly enabled feature.