### PR TITLE
fix friend declaration in val.h

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -676,7 +676,8 @@ private:
   pthread_t thread;
   EM_VAL handle;
 
-  friend struct internal::BindingType<val>;
+  template <typename T, typename>
+  friend struct ::emscripten::internal::BindingType;
 };
 
 struct val::iterator {


### PR DESCRIPTION
The code as it was trying to declare a template instantiation as a friend, and then specialize it later, which caused a build break. This fix just declares the whole template as a friend.