### PR TITLE
[WebIDL] Fixed octet[] evaluation in argument lists

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -599,3 +599,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Taisei Kon <kinsei0916@gmail.com>
 * YAMAMOTO Takashi <yamamoto@midokura.com>
 * Artur Gatin <agatin@teladochealth.com> (copyright owned by Teladoc Health, Inc.)
+* Christian Lloyd <clloyd@teladochealth.com> (copyright owned by Teladoc Health, Inc.)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7709,7 +7709,7 @@ void* operator new(size_t size) {
     # Export things on "TheModule". This matches the typical use pattern of
     # the bound library being used as Box2D.* or Ammo.*, and we cannot rely
     # on "Module" being always present (closure may remove it).
-    self.emcc_args += ['--post-js=glue.js', '--extern-post-js=extern-post.js']
+    self.emcc_args += ['-sEXPORTED_FUNCTIONS=_malloc,_free', '-sEXPORTED_RUNTIME_METHODS=stringToUTF8', '--post-js=glue.js', '--extern-post-js=extern-post.js']
     if mode == 'ALL':
       self.emcc_args += ['-sASSERTIONS']
     if allow_memory_growth:

--- a/test/webidl/post.js
+++ b/test/webidl/post.js
@@ -257,6 +257,22 @@ TheModule.destroy(factory)
 
 // end of issue 14745
 
+// octet[] to char* (issue 14827)
+
+const arrayTestObj = new TheModule.ArrayArgumentTest();
+const bufferAddr = TheModule._malloc(35);
+TheModule.stringToUTF8('I should match the member variable', bufferAddr, 35);
+
+const arrayTestResult = arrayTestObj.byteArrayTest(bufferAddr);
+const arrayDomStringResult = arrayTestObj.domStringTest('I should match the member variable');
+console.log(arrayTestResult);
+console.log(arrayDomStringResult);
+
+TheModule.destroy(arrayTestObj)
+TheModule._free(bufferAddr);
+	
+// end of issue 14827
+
 // Check for overflowing the stack
 
 var before = Date.now();

--- a/test/webidl/test.h
+++ b/test/webidl/test.h
@@ -229,3 +229,13 @@ public:
 private:
   ObjectProvider m_ObjectProvider;
 };
+
+class ArrayArgumentTest {
+public:
+  ArrayArgumentTest() : m_array("I should match the member variable"){};
+  ~ArrayArgumentTest(){};
+  bool byteArrayTest(const char* arg) { return strcmp(arg, m_array) == 0; }
+  bool domStringTest(const char* arg) { return strcmp(arg, m_array) == 0; }
+private:
+  const char* m_array;
+};

--- a/test/webidl/test.idl
+++ b/test/webidl/test.idl
@@ -196,3 +196,16 @@ interface ObjectFactory {
   void ObjectFactory();
   IObjectProvider getProvider();
 };
+
+interface ArrayArgumentTest {
+  void ArrayArgumentTest();
+  boolean byteArrayTest([Const] byte[] arg);
+  boolean domStringTest([Const] DOMString arg);
+};
+
+[JSImplementation = "ArrayArgumentTest"] 
+interface JSArrayArgumentTest {
+  void JSArrayArgumentTest();
+  boolean byteArrayTest([Const] byte[] arg);
+  boolean domStringTest([Const] DOMString arg);
+};

--- a/test/webidl/test_ALL.out
+++ b/test/webidl/test_ALL.out
@@ -110,3 +110,5 @@ Parent:42
 Aborted(Assertion failed: [CHECK FAILED] Parent::voidStar(something:something): Expecting <pointer>)
 Aborted(Assertion failed: [CHECK FAILED] StringUser::Print(anotherString:anotherString): Expecting <string>)
 123
+true
+true

--- a/test/webidl/test_DEFAULT.out
+++ b/test/webidl/test_DEFAULT.out
@@ -109,5 +109,7 @@ Parent:0
 Parent:42
 |abc|1|(null)|123|
 123
+true
+true
 
 done.

--- a/test/webidl/test_FAST.out
+++ b/test/webidl/test_FAST.out
@@ -109,5 +109,7 @@ Parent:0
 Parent:42
 |abc|1|(null)|123|
 123
+true
+true
 
 done.

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -376,9 +376,7 @@ def deref_if_nonpointer(m):
 
 
 def type_to_cdec(raw):
-  ret = type_to_c(raw.type.name, non_pointing=True)
-  if raw.getExtendedAttribute('Const'):
-    ret = 'const ' + ret
+  ret = type_to_c(full_typename(raw), non_pointing=True)
   if raw.type.name not in interfaces:
     return ret
   if raw.getExtendedAttribute('Ref'):


### PR DESCRIPTION
This PR fixes the problem behind issue [14827](https://github.com/emscripten-core/emscripten/issues/14827). This is a re-submission of an older PR that was never finalized:
https://github.com/emscripten-core/emscripten/pull/15023

The author is no longer involved with the project this issue is blocking and I'm following up on getting it fixed. Please refer to the original PR for details.