### PR TITLE
Fix for register_vector and optional class_ collision.

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -678,7 +678,8 @@ var LibraryEmbind = {
 
   _embind_register_emval__deps: [
     '$registerType',  '$EmValType'],
-  _embind_register_emval: (rawType) => registerType(rawType, EmValType),
+  _embind_register_emval: (rawType) =>
+      registerType(rawType, EmValType, {ignoreDuplicateRegistrations: true}),
 
   _embind_register_user_type__deps: ['_embind_register_emval'],
   _embind_register_user_type: (rawType, name) => {

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -1919,14 +1919,8 @@ public:
 #if __cplusplus >= 201703L
 template<typename T>
 void register_optional() {
-    // Optional types are automatically registered for some internal types so
-    // only run the register method once so we don't conflict with a user's
-    // bindings if they also register the optional type.
-    thread_local bool hasRun;
-    if (hasRun) {
-        return;
-    }
-    hasRun = true;
+    // Optional types are automatically registered for some internal types; the
+    // JS implementation will ignore duplicate registrations.
     internal::_embind_register_optional(
         internal::TypeID<std::optional<T>>::get(),
         internal::TypeID<typename std::remove_pointer<T>::type>::get());

--- a/test/embind/embind_test.cpp
+++ b/test/embind/embind_test.cpp
@@ -2382,6 +2382,16 @@ EMSCRIPTEN_BINDINGS(tests) {
     function("test_string_with_vec", &test_string_with_vec);
 
 #if __cplusplus >= 201703L
+    // Backwards compatibility test for binding code with optionals that
+    // predates the register_optional helper added in 3.1.52.
+    struct SomeOptType {};
+    class_<std::optional<SomeOptType>>("OptionalSomeOptType")
+        .constructor();
+    // register_vector internally calls register_optional, which should not
+    // error out when registering an optional already registered, whether with
+    // register_optional or a pre-3.1.52 class_ binding.
+    register_vector<SomeOptType>("SomeOptTypeVec");
+
     register_optional<int>();
     register_optional<float>();
     register_optional<SmallClass>();


### PR DESCRIPTION
Fixes `BindingError: Cannot register type 'emscripten::val' twice` error. This happened with pre-existing binding code that was migrated to Emscripten 3.1.52 which introduces the register_optional function, used internally by register_vector, in https://github.com/emscripten-core/emscripten/pull/21076.

The fix ignores duplicate registrations of emscripten::val, and doesn't rely on the boolean already-registered flag local to the register_optional function.