### PR TITLE
[SjLj] __USING_WASM_SJLJ__ -> __WASM_SJLJ__

### DIFF
--- a/system/lib/compiler-rt/emscripten_setjmp.c
+++ b/system/lib/compiler-rt/emscripten_setjmp.c
@@ -13,7 +13,7 @@
 
 #include "emscripten_internal.h"
 
-#ifdef __USING_WASM_SJLJ__
+#ifdef __WASM_SJLJ__
 struct __WasmLongjmpArgs {
   void *env;
   int val;
@@ -25,7 +25,7 @@ struct __WasmLongjmpArgs {
 struct jmp_buf_impl {
   void* func_invocation_id;
   uint32_t label;
-#ifdef __USING_WASM_SJLJ__
+#ifdef __WASM_SJLJ__
   struct __WasmLongjmpArgs arg;
 #endif
 };
@@ -48,7 +48,7 @@ uint32_t __wasm_setjmp_test(void* env, void* func_invocation_id) {
   return 0;
 }
 
-#ifdef __USING_WASM_SJLJ__
+#ifdef __WASM_SJLJ__
 // llvm uses `1` for the __c_longjmp tag.
 // See https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/CodeGen/WasmEHFuncInfo.h
 #define C_LONGJMP 1

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -853,7 +853,7 @@ class SjLjLibrary(Library):
       # EH/SjLj, so we should reverse it.
       cflags += ['-sSUPPORT_LONGJMP=wasm',
                  '-sDISABLE_EXCEPTION_THROWING',
-                 '-D__USING_WASM_SJLJ__']
+                 '-D__WASM_SJLJ__']
     return cflags
 
   def get_base_name(self):


### PR DESCRIPTION
In line with #21970, this changes `__USING_WASM_SJLJ__` to `__WASM_SJLJ__`. We don't define this in Clang now (which we can maybe consider, but given that Clang doesn't have dedicated flags for SjLj and there don't seem to be other platforms doing similar things), but given that the affected files currently are only in Emscripten, I think we can safely change this.