### PR TITLE
[EH] Guard destructor changes in libc++abi with __wasm__

### DIFF
--- a/system/lib/libcxxabi/include/cxxabi.h
+++ b/system/lib/libcxxabi/include/cxxabi.h
@@ -58,7 +58,7 @@ __cxa_init_primary_exception(void* object, std::type_info* tinfo, void(_LIBCXXAB
 // 2.4.3 Throwing the Exception Object
 extern _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void
 __cxa_throw(void *thrown_exception, std::type_info *tinfo,
-#ifdef __WASM_EXCEPTIONS__
+#ifdef __wasm__
             void *(_LIBCXXABI_DTOR_FUNC *dest)(void *));
 #else
             void (_LIBCXXABI_DTOR_FUNC *dest)(void *));

--- a/system/lib/libcxxabi/src/cxa_exception.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception.cpp
@@ -207,7 +207,7 @@ void __cxa_free_exception(void *thrown_object) throw() {
 }
 
 __cxa_exception* __cxa_init_primary_exception(void* object, std::type_info* tinfo,
-#ifdef __WASM_EXCEPTIONS__
+#ifdef __wasm__
 // In Wasm, a destructor returns its argument
                                               void *(_LIBCXXABI_DTOR_FUNC* dest)(void*)) throw() {
 #else
@@ -279,7 +279,7 @@ void __throw_exception_with_stack_trace(_Unwind_Exception*);
 #endif
 
 void
-#ifdef __WASM_EXCEPTIONS__
+#ifdef __wasm__
 // In Wasm, a destructor returns its argument
 __cxa_throw(void *thrown_object, std::type_info *tinfo, void *(_LIBCXXABI_DTOR_FUNC *dest)(void *)) {
 #else

--- a/system/lib/libcxxabi/src/cxa_exception.h
+++ b/system/lib/libcxxabi/src/cxa_exception.h
@@ -63,7 +63,7 @@ struct _LIBCXXABI_HIDDEN __cxa_exception {
 
     //  Manage the exception object itself.
     std::type_info *exceptionType;
-#ifdef __WASM_EXCEPTIONS__
+#ifdef __wasm__
     // In Wasm, a destructor returns its argument
     void *(_LIBCXXABI_DTOR_FUNC *exceptionDestructor)(void *);
 #else


### PR DESCRIPTION
These changes are due to that Wasm destructor returns its argument, so in case someone wants to compile out libc++abi _without_ using Wasm EH, these will error out too. In Emscripten this has been fine because in `system_lib.py` we only build these files when Wasm EH is enabled, but this may not be the case if we upstream our changes.