### PR TITLE
 Fix findMatchingCatch iterating over argument array prototype chain

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -254,9 +254,7 @@ var LibraryExceptions = {
     // Due to inheritance, those types may not precisely match the
     // type of the thrown object. Find one which matches, and
     // return the type of the catch block which should be called.
-    for (var arg in args) {
-      var caughtType = args[arg];
-
+    for (var caughtType in args) {
       if (caughtType === 0 || caughtType === thrownType) {
         // Catch all clause matched or exactly the same type is caught
         break;

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -254,7 +254,7 @@ var LibraryExceptions = {
     // Due to inheritance, those types may not precisely match the
     // type of the thrown object. Find one which matches, and
     // return the type of the catch block which should be called.
-    for (var caughtType in args) {
+    for (var caughtType of args) {
       if (caughtType === 0 || caughtType === thrownType) {
         // Catch all clause matched or exactly the same type is caught
         break;


### PR DESCRIPTION
A bug was introduced in #19760 where when iterating over the arguments passed to findMatchingCatch, it iterates not just over the elements in the array, but all properties in the Array prototype chain (due to the semantics of for..in vs for..of). This can cause exception handling to segfault in ___cxa_can_catch, as it is not being passed a valid pointer in the case of iterating over something like a utility function added to the array prototype without marking it as enumerable.

I discovered this when debugging onnxruntime and discovering that their custom errors (which inherit from `std::exception`) were causing segfaults during exception handling (whereas changing to `std::logic_error` would work fine), and have confirmed this fix resolves that issue. However, I could use guidance on adding a test for this change.