### PR TITLE
[acorn-optimizer] Remove dummy 'last' pass

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2852,7 +2852,7 @@ More info: https://emscripten.org
     self.run_process([PYTHON, path_from_root('tools/js_optimizer.py'), 'huge.js', '--minify-whitespace'])
 
   @parameterized({
-    'wasm2js': ('wasm2js', ['minifyNames', 'last']),
+    'wasm2js': ('wasm2js', ['minifyNames']),
     'constructor': ('constructor', ['minifyNames'])
   })
   @crossplatform

--- a/tools/acorn-optimizer.mjs
+++ b/tools/acorn-optimizer.mjs
@@ -2056,8 +2056,6 @@ const registry = {
   applyImportAndExportNameChanges: applyImportAndExportNameChanges,
   emitDCEGraph: emitDCEGraph,
   applyDCEGraphRemovals: applyDCEGraphRemovals,
-  // TODO: remove 'last' in the python driver code
-  last: () => {},
   dump: () => dump(ast),
   littleEndianHeap: littleEndianHeap,
   growableHeap: growableHeap,

--- a/tools/building.py
+++ b/tools/building.py
@@ -933,7 +933,6 @@ def wasm2js(js_file, wasm_file, opt_level, use_closure_compiler, debug_info, sym
         passes += ['symbolMap=%s' % symbols_file_js]
     if settings.MINIFY_WHITESPACE:
       passes += ['--minify-whitespace']
-    passes += ['last']
     if passes:
       # hackish fixups to work around wasm2js style and the js optimizer FIXME
       wasm2js_js = f'// EMSCRIPTEN_START_ASM\n{wasm2js_js}// EMSCRIPTEN_END_ASM\n'


### PR DESCRIPTION
I'm not sure what this was actually ever used for in the past but is doesn't seem necessary now.