### PR TITLE
[webgpu] Set surfaceConfiguration alphaMode default value to auto

### DIFF
--- a/system/include/webgpu/webgpu_cpp.h
+++ b/system/include/webgpu/webgpu_cpp.h
@@ -1560,7 +1560,7 @@ namespace wgpu {
         TextureUsage usage = TextureUsage::RenderAttachment;
         size_t viewFormatCount = 0;
         TextureFormat const * viewFormats;
-        CompositeAlphaMode alphaMode = CompositeAlphaMode::Opaque;
+        CompositeAlphaMode alphaMode = CompositeAlphaMode::Auto;
         uint32_t width;
         uint32_t height;
         PresentMode presentMode = PresentMode::Fifo;


### PR DESCRIPTION
As raised in https://github.com/emscripten-core/emscripten/pull/21939#discussion_r1613843466, the default value for surfaceConfiguration alphaMode should be `"auto"`, not `"opaque"`.

Here's the Dawn CL: https://dawn-review.googlesource.com/c/dawn/+/190080