### PR TITLE
[tsgen] Check parameter types match

### DIFF
--- a/src/embind/embind_shared.js
+++ b/src/embind/embind_shared.js
@@ -145,7 +145,7 @@ var LibraryEmbindShared = {
 #if ASSERTIONS
       assert(signature[signature.length - 1] == ")", "Parentheses for argument names should match.");
 #endif
-      return signature.substr(argsIndex, signature.length - argsIndex - 1).replaceAll(" ", "").split(",").filter(n => n.length);
+      return signature.substr(argsIndex, signature.length - argsIndex - 1).match(/\w+(?=\s*(,|$))/g) || [];
     } else {
       return [];
     }

--- a/test/other/embind_tsgen.cpp
+++ b/test/other/embind_tsgen.cpp
@@ -31,6 +31,20 @@ private:
   int y;
 };
 
+class TestParamNames {
+ public:
+  int function_one(char x, int y) { return 42; }
+  int function_two(unsigned char x, int y) { return 43; }
+  int function_three(const std::string&) { return 1; }
+  int function_four(bool x) { return 2; }
+
+  long long_fn(unsigned long a) { return 3; }
+
+  int const_fn() const { return 0; }
+
+  static int static_function(int x) { return 1; }
+};
+
 Test class_returning_fn() { return Test(); }
 
 std::unique_ptr<Test> class_unique_ptr_returning_fn() {
@@ -137,6 +151,17 @@ EMSCRIPTEN_BINDINGS(Test) {
       .class_property("staticProperty", &Test::static_property)
 	;
 
+    class_<TestParamNames>("TestParamNames")
+      .EMSCRIPTEN_MEMBER_FUNCTION("functionOne", &TestParamNames::function_one, (char x, int y))
+      .EMSCRIPTEN_MEMBER_FUNCTION("functionTwo", &TestParamNames::function_two, (unsigned char x, int y))
+      .EMSCRIPTEN_MEMBER_FUNCTION("functionThree", &TestParamNames::function_three, (const std::string& str))
+      .EMSCRIPTEN_MEMBER_FUNCTION("functionFour", &TestParamNames::function_four, (bool x))
+      .EMSCRIPTEN_MEMBER_FUNCTION("longFn", &TestParamNames::long_fn, (unsigned long a))
+      .EMSCRIPTEN_MEMBER_FUNCTION("constFn", &TestParamNames::const_fn, ())
+      .EMSCRIPTEN_CLASS_FUNCTION("staticFunctionWithParam", &TestParamNames::static_function, (int x))
+	;
+
+
   function("class_returning_fn", &class_returning_fn);
   function("class_unique_ptr_returning_fn",
                    &class_unique_ptr_returning_fn);
@@ -177,6 +202,8 @@ EMSCRIPTEN_BINDINGS(Test) {
   class_<Foo>("Foo").function("process", &Foo::process);
 
   function("global_fn", &global_fn);
+
+  EMSCRIPTEN_FUNCTION("global_fn_with_parameter_names", &global_fn, (int x, int y));
 
   register_optional<int>();
   register_optional<Foo>();

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -31,6 +31,16 @@ export interface Test {
   delete(): void;
 }
 
+export interface TestParamNames {
+  functionOne(x: number, y: number): number;
+  functionTwo(x: number, y: number): number;
+  functionFour(x: boolean): number;
+  constFn(): number;
+  longFn(a: number): number;
+  functionThree(str: EmbindString): number;
+  delete(): void;
+}
+
 export interface BarValue<T extends number> {
   value: T;
 }
@@ -99,6 +109,7 @@ export type ValArr = [ number, number, number ];
 
 interface EmbindModule {
   Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number};
+  TestParamNames: {staticFunctionWithParam(x: number): number};
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   a_class_instance: Test;
@@ -118,6 +129,7 @@ interface EmbindModule {
   an_int: number;
   optional_test(_0?: Foo): number | undefined;
   global_fn(_0: number, _1: number): number;
+  global_fn_with_parameter_names(x: number, y: number): number;
   optional_and_nonoptional_test(_0: Foo | undefined, _1: number): number | undefined;
   smart_ptr_function(_0: ClassWithSmartPtrConstructor): number;
   smart_ptr_function_with_params(foo: ClassWithSmartPtrConstructor): number;

--- a/test/other/embind_tsgen_parameter_mismatch.cpp
+++ b/test/other/embind_tsgen_parameter_mismatch.cpp
@@ -1,0 +1,20 @@
+#include <emscripten/bind.h>
+#include <string>
+
+void fn1(int x) {}
+void fn2(char x) {}
+void fn3(std::string x) {}
+
+EMSCRIPTEN_BINDINGS(Test) {
+    EMSCRIPTEN_FUNCTION("fn1_1", &fn1, ());
+    EMSCRIPTEN_FUNCTION("fn1_2", &fn1, (char x));
+    EMSCRIPTEN_FUNCTION("fn1_3", &fn1, (std::string x));
+
+    EMSCRIPTEN_FUNCTION("fn2_1", &fn2, ());
+    EMSCRIPTEN_FUNCTION("fn2_2", &fn2, (int x));
+    EMSCRIPTEN_FUNCTION("fn2_3", &fn2, (std::string x));
+
+    EMSCRIPTEN_FUNCTION("fn3_1", &fn3, ());
+    EMSCRIPTEN_FUNCTION("fn3_2", &fn3, (char x));
+    EMSCRIPTEN_FUNCTION("fn3_3", &fn3, (int x));
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3309,6 +3309,21 @@ More info: https://emscripten.org
                       '-lembind', '--emit-tsd', 'embind_tsgen_val.d.ts'])
     self.assertExists('embind_tsgen_val.d.ts')
 
+  def test_embind_tsgen_parameter_mismatch(self):
+    args = [EMXX, test_file('other/embind_tsgen_parameter_mismatch.cpp'), '-lembind', '--emit-tsd', 'embind_tsgen_parameter_mismatch.d.ts']
+    stderr = self.expect_fail(args)
+    self.assertContained("fn1_1", stderr)
+    self.assertContained("fn1_2", stderr)
+    self.assertContained("fn1_3", stderr)
+    self.assertContained("fn2_1", stderr)
+    self.assertContained("fn2_2", stderr)
+    self.assertContained("fn2_3", stderr)
+    self.assertContained("fn3_1", stderr)
+    self.assertContained("fn3_2", stderr)
+    self.assertContained("fn3_3", stderr)
+    self.assertContained("Argument list does not match function signature", stderr)
+    self.assertContained("9 errors generated.", stderr)
+
   def test_embind_tsgen_bigint(self):
     args = [EMXX, test_file('other/embind_tsgen_bigint.cpp'), '-lembind', '--emit-tsd', 'embind_tsgen_bigint.d.ts']
     # Check that TypeScript generation fails when code contains bigints but their support is not enabled


### PR DESCRIPTION
When using embind::function() with --emit-tsd, parameter names for TypeScript definitions cannot be detected automatically and must be supplied manually in string form in the function name. This is error-prone as it duplicates the function prototype but in a form that the compiler can't type-check. This change adds some macros which allow specifying the parameter names and types in a form that the compiler can type-check. This will reduce the likelihood of parameters in embind::function() declarations getting out of sync with the functions they expose.

This change also reduces the burden of maintaining the parameter names, as one can simply copy and paste directly from the function prototype without modification. Previously you were required to edit out the types from the function prototype manually.

Addresses #22001