### PR TITLE
Re-enable extern-pre-js and extern-post-js under pthreads

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9268,7 +9268,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('USE_OFFSET_CONVERTER')
     self.set_setting('MODULARIZE')
     self.set_setting('EXPORT_NAME', 'foo')
-    create_file('post.js', 'foo();')
+    create_file('post.js', 'if (!isPthread) foo();')
     self.emcc_args += ['--extern-post-js', 'post.js']
     if '-g' in self.emcc_args:
       self.emcc_args += ['-DDEBUG']

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -366,7 +366,7 @@ class other(RunnerCore):
   })
   @node_pthreads
   def test_emcc_output_worker_mjs(self, args):
-    create_file('extern-post.js', 'await Module();')
+    create_file('extern-post.js', 'if (!isPthread) await Module();')
     os.mkdir('subdir')
     self.run_process([EMCC, '-o', 'subdir/hello_world.mjs',
                       '-sEXIT_RUNTIME', '-sPROXY_TO_PTHREAD', '-pthread', '-O1',


### PR DESCRIPTION
In #21701 the running of extern-pre/post-js in pthreads was disabled. The reason was that we had a couple of tests that seemed to be assuming this.  However, it turns out that there are important use cases that depend on this code running in threads.

Instead, fix the two test cases by adding an extra condition.

Fixes: #22012