### PR TITLE
Use fetch() for loading file packages.

### DIFF
--- a/src/polyfill/fetch.js
+++ b/src/polyfill/fetch.js
@@ -1,0 +1,80 @@
+// Fetch polyfill from https://github.com/developit/unfetch
+// License:
+//==============================================================================
+// Copyright (c) 2017 Jason Miller
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//==============================================================================
+
+#if !POLYFILL
+#error "this file should never be included unless POLYFILL is set"
+#endif
+
+if (typeof globalThis.fetch == 'undefined') {
+  globalThis.fetch = function (url, options) {
+    options = options || {};
+    return new Promise((resolve, reject) => {
+      const request = new XMLHttpRequest();
+      const keys = [];
+      const headers = {};
+
+      request.responseType = 'arraybuffer';
+
+      const response = () => ({
+        ok: ((request.status / 100) | 0) == 2, // 200-299
+        statusText: request.statusText,
+        status: request.status,
+        url: request.responseURL,
+        text: () => Promise.resolve(request.responseText),
+        json: () => Promise.resolve(request.responseText).then(JSON.parse),
+        blob: () => Promise.resolve(new Blob([request.response])),
+        arrayBuffer: () => Promise.resolve(request.response),
+        clone: response,
+        headers: {
+          keys: () => keys,
+          entries: () => keys.map((n) => [n, request.getResponseHeader(n)]),
+          get: (n) => request.getResponseHeader(n),
+          has: (n) => request.getResponseHeader(n) != null,
+        },
+      });
+
+      request.open(options.method || "get", url, true);
+
+      request.onload = () => {
+        request
+          .getAllResponseHeaders()
+          .toLowerCase()
+          .replace(/^(.+?):/gm, (m, key) => {
+            headers[key] || keys.push((headers[key] = key));
+          });
+        resolve(response());
+      };
+
+      request.onerror = reject;
+
+      request.withCredentials = options.credentials == "include";
+
+      for (const i in options.headers) {
+        request.setRequestHeader(i, options.headers[i]);
+      }
+
+      request.send(options.body || null);
+    });
+  }
+}

--- a/src/shell.js
+++ b/src/shell.js
@@ -61,6 +61,11 @@ var Module = typeof {{{ EXPORT_NAME }}} != 'undefined' ? {{{ EXPORT_NAME }}} : {
 // See https://caniuse.com/mdn-javascript_builtins_bigint64array
 #include "polyfill/bigint64array.js"
 #endif
+
+#if MIN_CHROME_VERSION < 40 || MIN_FIREFOX_VERSION < 39 || MIN_SAFARI_VERSION < 103000
+// See https://caniuse.com/fetch
+#include "polyfill/fetch.js"
+#endif
 #endif // POLYFILL
 
 #if MODULARIZE

--- a/test/common.py
+++ b/test/common.py
@@ -2270,7 +2270,7 @@ class BrowserCore(RunnerCore):
       if reporting == Reporting.FULL:
         # If C reporting (i.e. the REPORT_RESULT macro) is required we
         # also include report_result.c and force-include report_result.h
-        self.run_process([EMCC, '-c', '-I' + TEST_ROOT,
+        self.run_process([EMCC, '-c', '-fPIC', '-I' + TEST_ROOT,
                           '-DEMTEST_PORT_NUMBER=%d' % self.port,
                           test_file('report_result.c')] + self.get_emcc_args(compile_only=True))
         args += ['report_result.o', '-include', test_file('report_result.h')]

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -699,7 +699,8 @@ If manually bisecting:
           <center><canvas id='canvas' width='256' height='256'></canvas></center>
           <hr><div id='output'></div><hr>
           <script type='text/javascript'>
-            window.onerror = (error) => {
+            window.addEventListener('unhandledrejection', event => {
+              const error = String(event.reason);
               window.disableErrorReporting = true;
               window.onerror = null;
               var result = error.includes("test.data") ? 1 : 0;
@@ -707,7 +708,7 @@ If manually bisecting:
               xhr.open('GET', 'http://localhost:8888/report_result?' + result, true);
               xhr.send();
               setTimeout(function() { window.close() }, 1000);
-            }
+            });
             var Module = {
               locateFile: function (path, prefix) {if (path.endsWith(".wasm")) {return prefix + path;} else {return "''' + assetLocalization + r'''" + path;}},
               print: (function() {
@@ -5548,6 +5549,133 @@ Module["preRun"] = () => {
       self.run_process(shared.get_npm_cmd('webpack') + ['--mode=development', '--no-devtool'])
     shutil.copyfile('webpack/src/hello.wasm', 'webpack/dist/hello.wasm')
     self.run_browser('webpack/dist/index.html', '/report_result?exit:0')
+
+  def test_fetch_polyfill_preload(self):
+    path = 'hello-world.txt'
+    create_file(path, 'hello, world!')
+    create_file('main.cpp', r'''
+      #include <stdio.h>
+      #include <string.h>
+      #include <emscripten.h>
+      int main() {
+        FILE *f = fopen("%s", "r");
+        char buf[100];
+        fread(buf, 1, 20, f);
+        buf[20] = 0;
+        fclose(f);
+        printf("|%%s|\n", buf);
+        return 0;
+      }
+      ''' % path)
+    create_file('on_window_error_shell.html', r'''
+      <html>
+          <center><canvas id='canvas' width='256' height='256'></canvas></center>
+          <hr><div id='output'></div><hr>
+          <script type='text/javascript'>
+            window.addEventListener('error', event => {
+              const error = String(event.message);
+              console.log({error});
+              window.disableErrorReporting = true;
+              window.onerror = null;
+              var xhr = new XMLHttpRequest();
+              xhr.open('GET', 'http://localhost:8888/report_result?' + error, true);
+              xhr.send();
+              setTimeout(function() { window.close() }, 1000);
+            });
+            var Module = {
+              print: (function() {
+                var element = document.getElementById('output');
+                return function(text) {
+                  console.log({text});
+                  if(window.disableErrorReporting) return;
+                  element.innerHTML += text.replace('\n', '<br>', 'g') + '<br>';
+                  var xhr = new XMLHttpRequest();
+                  xhr.open('GET', 'http://localhost:8888/report_result?' + (text === '|hello, world!|' ? 1 : 0), true);
+                  xhr.send();
+                };
+              })(),
+              canvas: document.getElementById('canvas')
+            };
+          </script>
+          {{{ SCRIPT }}}
+        </body>
+      </html>''')
+
+    def test(args, expect_fail):
+      self.compile_btest('main.cpp', args + ['--preload-file', path, '--shell-file', 'on_window_error_shell.html', '-o', 'a.out.html'])
+      js = read_file('a.out.js')
+      if expect_fail:
+        create_file('a.out.js', 'fetch = undefined;\n' + js)
+        return self.run_browser('a.out.html', '/report_result?TypeError: fetch is not a function')
+      else:
+         return self.run_browser('a.out.html', '/report_result?1')
+
+    test([], expect_fail=True)
+    test(['-sLEGACY_VM_SUPPORT'], expect_fail=False)
+    test(['-sLEGACY_VM_SUPPORT', '-sNO_POLYFILL'], expect_fail=True)
+
+  def test_fetch_polyfill_shared_lib(self):
+    create_file('library.c', r'''
+      #include <stdio.h>
+      int library_func() {
+        return 42;
+      }
+    ''')
+    create_file('main.c', r'''
+      #include <assert.h>
+      #include <dlfcn.h>
+      #include <stdio.h>
+      #include <emscripten.h>
+      int main() {
+        int found = EM_ASM_INT(
+          return preloadedWasm['/library.so'] !== undefined;
+        );
+        void *lib_handle = dlopen("/library.so", RTLD_NOW);
+        typedef int (*voidfunc)();
+        voidfunc x = (voidfunc)dlsym(lib_handle, "library_func");
+        printf("Got val: %d\n", x());
+        assert(x() == 42);
+        return 0;
+      }
+    ''')
+    create_file('on_window_error_shell.html', r'''
+      <html>
+          <center><canvas id='canvas' width='256' height='256'></canvas></center>
+          <hr><div id='output'></div><hr>
+          <script type='text/javascript'>
+            var Module = {
+              print: (function() {
+                var element = document.getElementById('output');
+                return function(text) {
+                  if(window.disableErrorReporting) return;
+                  element.innerHTML += text.replace('\n', '<br>', 'g') + '<br>';
+                  var result = text.includes("42") ? 1 : 0;
+                  var xhr = new XMLHttpRequest();
+                  xhr.open('GET', 'http://localhost:8888/report_result?' + result, true);
+                  xhr.send();
+                };
+              })(),
+              canvas: document.getElementById('canvas')
+            };
+          </script>
+          {{{ SCRIPT }}}
+        </body>
+      </html>''')
+
+    self.run_process([EMCC, 'library.c', '-sSIDE_MODULE', '-O2', '-o', 'library.so'])
+
+    def test(args, expect_fail):
+      self.compile_btest('main.c', ['library.so', '-sMAIN_MODULE', '--shell-file', 'on_window_error_shell.html', '-o', 'a.out.html'])
+      js = read_file('a.out.js')
+      if expect_fail:
+        create_file('a.out.js', 'fetch = undefined;\n' + js)
+        return self.run_browser('a.out.html', '/report_result?abort:TypeError')
+      else:
+         return self.run_browser('a.out.html', '/report_result?1')
+
+    test([], expect_fail=True)
+    test(['-sLEGACY_VM_SUPPORT'], expect_fail=False)
+    test(['-sLEGACY_VM_SUPPORT', '-sNO_POLYFILL'], expect_fail=True)
 
 
 class emrun(RunnerCore):


### PR DESCRIPTION
This PR switches AJAX requests for file packages to be loaded with fetch() rather than XmlHttpRequest(). This allows service workers to make AJAX requests, since XmlHttpRequest is not available in service workers.

Previously, --embed-file was necessary to load file packages, which embeds the files into the binary and precludes caching and re-use of the package.

Partially fixes https://github.com/emscripten-core/emscripten/issues/22003