### PR TITLE
Use `node:` prefix when importing code node modules. NFC

### DIFF
--- a/src/compiler.mjs
+++ b/src/compiler.mjs
@@ -7,9 +7,9 @@
 
 // LLVM => JavaScript compiler, main entry point
 
-import * as fs from 'fs';
-import * as path from 'path';
-import * as url from 'url';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as url from 'node:url';
 
 import {Benchmarker, applySettings, assert, loadSettingsFile, printErr, read} from './utility.mjs';
 

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 import {
   isDecorator,

--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -7,11 +7,11 @@
 // General JS utilities - things that might be useful in any JS project.
 // Nothing specific to Emscripten appears here.
 
-import * as url from 'url';
-import * as path from 'path';
-import * as fs from 'fs';
-import * as vm from 'vm';
-import assert from 'assert';
+import * as url from 'node:url';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as vm from 'node:vm';
+import assert from 'node:assert';
 
 export {assert};
 

--- a/tools/acorn-optimizer.mjs
+++ b/tools/acorn-optimizer.mjs
@@ -2,7 +2,7 @@
 
 import * as acorn from 'acorn';
 import * as terser from '../third_party/terser/terser.js';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 // Utilities
 

--- a/tools/lz4-compress.mjs
+++ b/tools/lz4-compress.mjs
@@ -4,8 +4,8 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 function print(x) {
   process.stdout.write(x + '\n');

--- a/tools/unsafe_optimizations.mjs
+++ b/tools/unsafe_optimizations.mjs
@@ -3,7 +3,7 @@
 /** Implements a set of potentially unsafe JavaScript AST optimizations for aggressive code size optimizations.
     Enabled when building with -sMINIMAL_RUNTIME=2 linker flag. */
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import * as acorn from 'acorn';
 import * as terser from '../third_party/terser/terser.js';
 


### PR DESCRIPTION
See https://stateful.com/blog/node-18-prefix-only-modules