### PR TITLE
[test] Remove unused `sync` variant of `ReportResult`. NFC

### DIFF
--- a/test/browser_reporting.js
+++ b/test/browser_reporting.js
@@ -1,8 +1,9 @@
 var hasModule = typeof Module === 'object' && Module;
 
-/** @param {boolean=} sync
-    @param {number=} port */
-function reportResultToServer(result, sync, port) {
+/**
+ * @param {number=} port
+ */
+function reportResultToServer(result, port) {
   port = port || 8888;
   if (reportResultToServer.reported) {
     // Only report one result per test, even if the test misbehaves and tries to report more.
@@ -13,7 +14,7 @@ function reportResultToServer(result, sync, port) {
     out('RESULT: ' + result);
   } else {
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', 'http://localhost:' + port + '/report_result?' + result, !sync);
+    xhr.open('GET', 'http://localhost:' + port + '/report_result?' + result);
     xhr.send();
     if (typeof window === 'object' && window && hasModule && !Module['pageThrewException']) {
       /* for easy debugging, don't close window on failure */
@@ -22,11 +23,12 @@ function reportResultToServer(result, sync, port) {
   }
 }
 
-/** @param {boolean=} sync
-    @param {number=} port */
-function maybeReportResultToServer(result, sync, port) {
+/**
+ * @param {number=} port
+ */
+function maybeReportResultToServer(result, port) {
   if (reportResultToServer.reported) return;
-  reportResultToServer(result, sync, port);
+  reportResultToServer(result, port);
 }
 
 function reportErrorToServer(message) {

--- a/test/pthread/call_async_on_main_thread.js
+++ b/test/pthread/call_async_on_main_thread.js
@@ -7,6 +7,6 @@ addToLibrary({
       console.error('This function should be getting called on the main thread!');
     }
     console.log('got ' + param1 + ' ' + param2 + ' ' + param3);
-    __ReportResult(param1 + param2 * param3, 0);
+    __ReportResult(param1 + param2 * param3);
   }
 });

--- a/test/report_result.c
+++ b/test/report_result.c
@@ -24,23 +24,23 @@ extern "C" {
 #error "EMTEST_PORT_NUMBER not defined"
 #endif
 
-void EMSCRIPTEN_KEEPALIVE _ReportResult(int result, int sync) {
+void EMSCRIPTEN_KEEPALIVE _ReportResult(int result) {
   EM_ASM({
-    reportResultToServer($0, $1, $2);
-  }, result, sync, EMTEST_PORT_NUMBER);
+    reportResultToServer($0, $1);
+  }, result, EMTEST_PORT_NUMBER);
 }
 
-void EMSCRIPTEN_KEEPALIVE _MaybeReportResult(int result, int sync) {
+void EMSCRIPTEN_KEEPALIVE _MaybeReportResult(int result) {
   EM_ASM({
-    maybeReportResultToServer($0, $1, $2);
-  }, result, sync, EMTEST_PORT_NUMBER);
+    maybeReportResultToServer($0, $1);
+  }, result, EMTEST_PORT_NUMBER);
 }
 
 #else
 
 static bool reported = false;
 
-void _ReportResult(int result, int sync) {
+void _ReportResult(int result) {
   if (reported) {
     printf("ERROR: result already reported\n");
     exit(1);
@@ -49,8 +49,8 @@ void _ReportResult(int result, int sync) {
   printf("RESULT: %d\n", result);
 }
 
-void _MaybeReportResult(int result, int sync) {
-  if (!reported) _ReportResult(result, sync);
+void _MaybeReportResult(int result) {
+  if (!reported) _ReportResult(result);
 }
 
 #endif // __EMSCRIPTEN__ && !defined EMTEST_NODE

--- a/test/report_result.h
+++ b/test/report_result.h
@@ -4,7 +4,7 @@
  * University of Illinois/NCSA Open Source License.  Both these licenses can be
  * found in the LICENSE file.
  *
- * Define REPORT_RESULT and REPORT_RESULT_SYNC for using in test code
+ * Define REPORT_RESULT for using in test code
  */
 
 #ifndef REPORT_RESULT_H_
@@ -16,8 +16,8 @@
 extern "C" {
 #endif
 
-void _ReportResult(int result, int sync);
-void _MaybeReportResult(int result, int sync);
+void _ReportResult(int result);
+void _MaybeReportResult(int result);
 
 #ifdef __cplusplus
 }
@@ -26,15 +26,11 @@ void _MaybeReportResult(int result, int sync);
 #if defined __EMSCRIPTEN__ && defined __EMSCRIPTEN_PTHREADS__ && !defined(__EMSCRIPTEN_WASM_WORKERS__)
   #include <emscripten.h>
   #include <emscripten/threading.h>
-  #define REPORT_RESULT(result) emscripten_async_run_in_main_runtime_thread(EM_FUNC_SIG_VII, _ReportResult, (result), 0)
-  #define REPORT_RESULT_SYNC(result) emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VII, _ReportResult, (result), 1)
-  #define MAYBE_REPORT_RESULT(result) emscripten_async_run_in_main_runtime_thread(EM_FUNC_SIG_VII, _MaybeReportResult, (result), 0)
-  #define MAYBE_REPORT_RESULT_SYNC(result) emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VII, _MaybeReportResult, (result), 1)
+  #define REPORT_RESULT(result) emscripten_async_run_in_main_runtime_thread(EM_FUNC_SIG_VI, _ReportResult, (result))
+  #define MAYBE_REPORT_RESULT(result) emscripten_async_run_in_main_runtime_thread(EM_FUNC_SIG_VI, _MaybeReportResult, (result))
 #else
-  #define REPORT_RESULT(result) _ReportResult((result), 0)
-  #define REPORT_RESULT_SYNC(result) _ReportResult((result), 1)
-  #define MAYBE_REPORT_RESULT(result) _MaybeReportResult((result), 0)
-  #define MAYBE_REPORT_RESULT_SYNC(result) _MaybeReportResult((result), 1)
+  #define REPORT_RESULT(result) _ReportResult((result))
+  #define MAYBE_REPORT_RESULT(result) _MaybeReportResult((result))
 #endif
 
 #endif

--- a/test/webaudio/create_webaudio.c
+++ b/test/webaudio/create_webaudio.c
@@ -24,7 +24,7 @@ int main()
 			if (audioContext.state != 'running') {
 				audioContext.resume();
 #ifdef REPORT_RESULT
-				__ReportResult(0, 0);
+				__ReportResult(0);
 #endif
 			} else {
 				audioContext.suspend();


### PR DESCRIPTION
Split out from #22018.