### PR TITLE
Update require_node_canary, make require_jspi and exnref use it

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -914,9 +914,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       return
 
     if 'EMTEST_SKIP_EH' in os.environ:
-      self.skipTest('test requires node >= 22 or d8 (and EMTEST_SKIP_EH is set)')
+      self.skipTest('test requires canary or d8 (and EMTEST_SKIP_EH is set)')
     else:
-      self.fail('either d8 or node >= 22 required to run wasm-eh tests.  Use EMTEST_SKIP_EH to skip')
+      self.fail('either d8 or node canary required to run wasm-eh tests.  Use EMTEST_SKIP_EH to skip')
 
   def require_jspi(self):
     # emcc warns about stack switching being experimental, and we build with

--- a/test/common.py
+++ b/test/common.py
@@ -935,6 +935,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     nodejs = self.get_nodejs()
     if nodejs:
       version = shared.get_node_version(nodejs)
+      print('NODE VERSION ' + str(version))
       # Support for JSPI came earlier than 22, but the new API changes are not yet in any node
       if version >= (23, 0, 0):
         self.js_engines = [nodejs]

--- a/test/common.py
+++ b/test/common.py
@@ -902,8 +902,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def require_wasm_exnref(self):
     nodejs = self.get_nodejs()
     if nodejs:
-      version = shared.get_node_version(nodejs)
-      if version >= (22, 0, 0):
+      if self.node_is_canary(nodejs):
         self.js_engines = [nodejs]
         self.node_args.append('--experimental-wasm-exnref')
         return

--- a/test/common.py
+++ b/test/common.py
@@ -821,16 +821,15 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     self.require_engine(nodejs)
     return nodejs
 
-  def node_is_canary(self):
-    nodejs = self.get_nodejs()
-    if nodejs:
-      if 'canary' in nodejs:
+  def node_is_canary(self, nodejs):
+    if nodejs and 'canary' in nodejs:
         return True
     return False
 
   def require_node_canary(self):
-    if self.node_is_canary():
-        self.require_engine(self.get_nodejs())
+    nodejs = self.get_nodejs()
+    if self.node_is_canary(nodejs):
+        self.require_engine(nodejs)
         return
 
     if 'EMTEST_SKIP_NODE_CANARY' in os.environ:
@@ -937,10 +936,10 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
     exp_args = ['--experimental-wasm-stack-switching', '--experimental-wasm-type-reflection']
     nodejs = self.get_nodejs()
-    print('NODEJS is ' + str(nodejs))
+    print('NODEJS is ' + nodejs)
     if nodejs:
       # Support for JSPI came earlier than 22, but the new API changes are not yet in any node
-      if self.node_is_canary():
+      if self.node_is_canary(nodejs):
         self.js_engines = [nodejs]
         self.node_args += exp_args
         return

--- a/test/common.py
+++ b/test/common.py
@@ -935,9 +935,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     nodejs = self.get_nodejs()
     if nodejs:
       version = shared.get_node_version(nodejs)
-      # Support for JSPI came earlier than 19, but 19 is what currently works
-      # with emscripten's implementation.
-      if version >= (19, 0, 0):
+      # Support for JSPI came earlier than 22, but the new API changes are not yet in any node
+      if version > (22, 0, 0):
         self.js_engines = [nodejs]
         self.node_args += exp_args
         return
@@ -949,9 +948,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       return
 
     if 'EMTEST_SKIP_JSPI' in os.environ:
-      self.skipTest('test requires node >= 19 or d8 (and EMTEST_SKIP_JSPI is set)')
+      self.skipTest('test requires node > 22 or d8 (and EMTEST_SKIP_JSPI is set)')
     else:
-      self.fail('either d8 or node >= 19 required to run JSPI tests.  Use EMTEST_SKIP_JSPI to skip')
+      self.fail('either d8 or node > 22 required to run JSPI tests.  Use EMTEST_SKIP_JSPI to skip')
 
   def require_wasm2js(self):
     if self.is_wasm64():

--- a/test/common.py
+++ b/test/common.py
@@ -822,9 +822,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     return nodejs
 
   def node_is_canary(self, nodejs):
-    if nodejs and 'canary' in nodejs:
-        return True
-    return False
+    return nodejs and nodejs[0] and 'canary' in nodejs[0]
 
   def require_node_canary(self):
     nodejs = self.get_nodejs()
@@ -936,7 +934,6 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
     exp_args = ['--experimental-wasm-stack-switching', '--experimental-wasm-type-reflection']
     nodejs = self.get_nodejs()
-    print('NODEJS is ' + nodejs)
     if nodejs:
       # Support for JSPI came earlier than 22, but the new API changes are not yet in any node
       if self.node_is_canary(nodejs):

--- a/test/common.py
+++ b/test/common.py
@@ -937,6 +937,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
     exp_args = ['--experimental-wasm-stack-switching', '--experimental-wasm-type-reflection']
     nodejs = self.get_nodejs()
+    print('NODEJS is ' + str(nodejs))
     if nodejs:
       # Support for JSPI came earlier than 22, but the new API changes are not yet in any node
       if self.node_is_canary():

--- a/test/common.py
+++ b/test/common.py
@@ -936,7 +936,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     if nodejs:
       version = shared.get_node_version(nodejs)
       # Support for JSPI came earlier than 22, but the new API changes are not yet in any node
-      if version > (22, 0, 0):
+      if version >= (23, 0, 0):
         self.js_engines = [nodejs]
         self.node_args += exp_args
         return
@@ -948,9 +948,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       return
 
     if 'EMTEST_SKIP_JSPI' in os.environ:
-      self.skipTest('test requires node > 22 or d8 (and EMTEST_SKIP_JSPI is set)')
+      self.skipTest('test requires node >= 23 or d8 (and EMTEST_SKIP_JSPI is set)')
     else:
-      self.fail('either d8 or node > 22 required to run JSPI tests.  Use EMTEST_SKIP_JSPI to skip')
+      self.fail('either d8 or node >= 23 required to run JSPI tests.  Use EMTEST_SKIP_JSPI to skip')
 
   def require_wasm2js(self):
     if self.is_wasm64():


### PR DESCRIPTION
This PR does 2 things:
1. It updates `require_node_canary` to check the path of the node binary for the string 'canary'. This is hacky but
the only known way to distinguish a canary build (which has a bleeding-edge v8 version) from a release build.

2. Updates `require_jspi` and `require_wasm_exnref` to check for the canary version instead of v19, because we now require the Suspender-free
API update. This update is not yet in any release, so we require canary.