### PR TITLE
Set errno correctly during __stdio_close

### DIFF
--- a/system/lib/libc/musl/src/stdio/__stdio_close.c
+++ b/system/lib/libc/musl/src/stdio/__stdio_close.c
@@ -11,7 +11,7 @@ weak_alias(dummy, __aio_close);
 int __stdio_close(FILE *f)
 {
 #ifdef __EMSCRIPTEN__
-	return __wasi_fd_close(__aio_close(f->fd));
+	return __wasi_syscall_ret(__wasi_fd_close(__aio_close(f->fd)));
 #else
 	return syscall(SYS_close, __aio_close(f->fd));
 #endif

--- a/test/test_files.c
+++ b/test/test_files.c
@@ -4,12 +4,25 @@
 // found in the LICENSE file.
 
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+void test_fclose() {
+  FILE* f = fopen("temp.txt", "w");
+  int fd = fileno(f);
+  // Close the underlying FD, which should then cause fclose to
+  // fail.
+  int ret = close(fd);
+  assert(ret == 0);
+  ret = fclose(f);
+  printf("fclose error: %s\n", strerror(errno));
+  assert(ret == EOF);
+}
 
 // Reading
 void test_reading() {
@@ -161,6 +174,7 @@ void test_tempfiles() {
 }
 
 int main() {
+  test_fclose();
   test_reading();
   test_stdstreams();
   test_writing();


### PR DESCRIPTION
Fixes: #22033