### PR TITLE
support to locateFile on initializing audioworklet

### DIFF
--- a/src/library_webaudio.js
+++ b/src/library_webaudio.js
@@ -170,7 +170,7 @@ let LibraryWebAudio = {
 
     // TODO: In MINIMAL_RUNTIME builds, read this file off of a preloaded Blob,
     // and/or embed from a string like with WASM_WORKERS==2 mode.
-    audioWorklet.addModule('{{{ TARGET_BASENAME }}}.aw.js').then(() => {
+    audioWorklet.addModule(locateFile('{{{ TARGET_BASENAME }}}.aw.js')).then(() => {
 #if WEBAUDIO_DEBUG
       console.log(`emscripten_start_wasm_audio_worklet_thread_async() addModule('audioworklet.js') completed`);
 #endif


### PR DESCRIPTION
as using audio worklet, the worker module (.aw.js file) needs to be loaded from the root directory. Perhaps it should be loaded like the wasm or worker, i.e. use locateFile to find its current path?