### PR TITLE
Important bugfixes to OpenAL implementation.

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -726,7 +726,7 @@ var LibraryOpenAL = {
       if (src.bufQueue[src.bufsProcessed].audioBuf !== null) {
         src.bufsProcessed = 0;
         while (offset > src.bufQueue[src.bufsProcessed].audioBuf.duration) {
-          offset -= src.bufQueue[src.bufsProcessed].audiobuf.duration;
+          offset -= src.bufQueue[src.bufsProcessed].audioBuf.duration;
           src.bufsProcessed++;
         }
 

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -3081,7 +3081,7 @@ var LibraryOpenAL = {
       return;
     }
     switch (param) {
-    case 'AL_SOURCE_DISTANCE_MODEL':
+    case 0x200 /* AL_SOURCE_DISTANCE_MODEL */:
       AL.currentCtx.sourceDistanceModel = true;
       AL.updateContextGlobal(AL.currentCtx);
       break;
@@ -3103,7 +3103,7 @@ var LibraryOpenAL = {
       return;
     }
     switch (param) {
-    case 'AL_SOURCE_DISTANCE_MODEL':
+    case 0x200 /* AL_SOURCE_DISTANCE_MODEL */:
       AL.currentCtx.sourceDistanceModel = false;
       AL.updateContextGlobal(AL.currentCtx);
       break;
@@ -3125,7 +3125,7 @@ var LibraryOpenAL = {
       return 0;
     }
     switch (param) {
-    case 'AL_SOURCE_DISTANCE_MODEL':
+    case 0x200 /* AL_SOURCE_DISTANCE_MODEL */:
       return AL.currentCtx.sourceDistanceModel ? {{{ cDefs.AL_FALSE }}} : {{{ cDefs.AL_TRUE }}};
     default:
 #if OPENAL_DEBUG

--- a/test/openal_playback.cpp
+++ b/test/openal_playback.cpp
@@ -257,6 +257,11 @@ int main() {
 #elif defined(TEST_ANIMATED_LOOPED_DOPPLER_PLAYBACK)
   printf("You should hear a continuously looping clip of the 1902 piano song \"The Entertainer\" played back at a dynamic playback rate that smoothly varies its pitch according to a sine wave doppler shift. Press OK when confirmed.\n");
 #elif defined(TEST_ANIMATED_LOOPED_PANNED_PLAYBACK)
+  assert(!alIsEnabled(AL_SOURCE_DISTANCE_MODEL));
+  alDisable(AL_SOURCE_DISTANCE_MODEL);
+  assert(!alIsEnabled(AL_SOURCE_DISTANCE_MODEL));
+  alEnable(AL_SOURCE_DISTANCE_MODEL);
+  assert(alIsEnabled(AL_SOURCE_DISTANCE_MODEL));
   printf("You should hear a continuously looping clip of the 1902 piano song \"The Entertainer\" smoothly panning around the listener. Press OK when confirmed.\n");
 #elif defined(TEST_ANIMATED_LOOPED_RELATIVE_PLAYBACK)
   alSourcei(sources[0], AL_SOURCE_RELATIVE, AL_TRUE);


### PR DESCRIPTION
- The ``audiobuf`` in ``offset -= src.bufQueue[src.bufsProcessed].audiobuf.duration;`` is misspelled - ``audioBuf`` was likely intended. I found this because I was getting a ``TypeError: src.bufQueue[src.bufsProcessed] is undefined``, although I'm not 100% sure it was caused by the typo.
- ``switch`` cases for ``AL_SOURCE_DISTANCE_MODEL`` were checking against the string ``'AL_SOURCE_DISTANCE_MODEL'`` instead of the integer value ``0x200``, causing ``AL_INVALID_ENUM`` on ``alIsEnabled``, ``alEnable`` and ``alDisable`` with this enum.
- ``updateSourceTime`` sometimes leaves the src.bufOffset with a ``NaN`` value, although sadly I'm not sophisticated enough to understand why. I have added a harmless check that just sets it to 0 in case it turns ``NaN``, which arguably shouldn't break anything, and it completely fixes the following crash:
	```
	TypeError: AudioBufferSourceNode.start: Argument 2 is not a finite floating-point value.
		scheduleSourceAudio http://localhost:6931/Hypersomnia.js:8343
		setSourceState http://localhost:6931/Hypersomnia.js:8498
		sourceSeek http://localhost:6931/Hypersomnia.js:8853
		setSourceParam http://localhost:6931/Hypersomnia.js:9397
		_alSourcef http://localhost:6931/Hypersomnia.js:10089
		__emscripten_receive_on_main_thread_js http://localhost:6931/Hypersomnia.js:7102
	```
	I have already battle-tested this one ``if`` clause in [my browser game](https://github.com/TeamHypersomnia/Hypersomnia) and it seems to work.
