### PR TITLE
Fix asan.test_dlfcn_preload. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -3980,7 +3980,7 @@ ok
     ''')
     self.build_dlfcn_lib('libb.c', outfile='libb.so', emcc_args=['liba.so'])
 
-    self.prep_dlfcn_main(['--preload-file', 'libb.so', '--use-preload-plugins'])
+    self.prep_dlfcn_main(['--preload-file', 'libb.so', '--use-preload-plugins', '-L.', '-sAUTOLOAD_DYLIBS=0', 'libb.so'])
     create_file('main.c', r'''
       #include <assert.h>
       #include <dlfcn.h>


### PR DESCRIPTION
This was a new test added in #21985.

This changes means that any symbols that libb.so needs are exported/preserved when building the main module.