### PR TITLE
Make embind work with -fvisibility=hidden

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -285,7 +285,7 @@ private:
 static const char name##_symbol[] = #name;                          \
 static const ::emscripten::internal::symbol_registrar<name##_symbol> name##_registrar
 
-class val {
+class EMBIND_VISIBILITY_DEFAULT val {
 public:
   // missing operators:
   // * ~ - + ++ --

--- a/system/include/emscripten/wire.h
+++ b/system/include/emscripten/wire.h
@@ -24,6 +24,7 @@
 #include <string>
 
 #define EMSCRIPTEN_ALWAYS_INLINE __attribute__((always_inline))
+#define EMBIND_VISIBILITY_DEFAULT __attribute__((visibility("default")))
 
 #ifndef EMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES
 #define EMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES 1
@@ -430,7 +431,7 @@ constexpr bool typeSupportsMemoryView() {
 } // namespace internal
 
 template<typename ElementType>
-struct memory_view {
+struct EMBIND_VISIBILITY_DEFAULT memory_view {
     memory_view() = delete;
     explicit memory_view(size_t size, const ElementType* data)
         : size(size)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7718,6 +7718,36 @@ void* operator new(size_t size) {
     else:
       self.assertTrue(seen_lines.issuperset([6, 7, 11, 12]), seen_lines)
 
+  @needs_dylink
+  def test_embind_dylink_visibility_hidden(self):
+    # Check that embind is usable from a library built with "-fvisibility=hidden"
+
+    create_file('liblib.cpp', r'''
+      #include <emscripten/val.h>
+      #define EXPORT __attribute__((visibility("default")))
+      using namespace emscripten;
+      EXPORT void liba_fun() {
+        unsigned char buffer[1];
+        val view(typed_memory_view(1, buffer));
+      }
+    ''')
+    self.build_dlfcn_lib('liblib.cpp', emcc_args=['-fvisibility=hidden'])
+
+    self.prep_dlfcn_main()
+    self.clear_setting('NO_AUTOLOAD_DYLIBS')
+    create_file('main.cpp', r'''
+      #include <stdio.h>
+      #include <emscripten/val.h>
+      using namespace emscripten;
+      void liba_fun();
+      int main() {
+        liba_fun();
+        printf("done\n");
+        return 0;
+      }
+    ''')
+    self.do_runf('main.cpp', 'done\n', emcc_args=['--bind'])
+
   @no_wasm2js('TODO: source maps in wasm2js')
   def test_dwarf(self):
     self.emcc_args.append('-g')


### PR DESCRIPTION
Export emscripten::val and emscripten::memory_view in order to prevent embind errors:

  BindingError: _emval_take_value has unknown type N10emscripten11memory_viewIhEE

Embind generates a numerical type id from the address of the std::type_info object resulting from evaluating a typeid expressiion (e.g. 'void *id = &typeid(T)').

However, C++ does not guarantee that this address is identical for all evaluations of the typeid expression. In practice it is when using static linking, but not when using dynamic linking when the libraries are
built with the '-fvisibility=hidden' compiler option.

The non-identical id's then cause embind to decide that types have not been registered when used from a library, since they have been registered with a different id by the main wasm module.

Exporting the types in question makes typeid addresses identical again, and fixes/works around the issue.