### PR TITLE
Add a benchmarker that stores sizes in a skia perf compatible file.

### DIFF
--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -57,7 +57,7 @@ EMTEST_BENCHMARKERS = os.getenv('EMTEST_BENCHMARKERS', 'clang,v8,v8-lto,v8-ctors
 
 
 class Benchmarker():
-  # whether to record statistics. set by SizeBenchmarker.
+  # Whether to record statistics. Set by SizeBenchmarker.
   record_stats = False
 
   # called when we init the object, which is during startup, even if we are
@@ -269,12 +269,16 @@ class EmscriptenBenchmarker(Benchmarker):
     return ret
 
 
+# This benchmarker will make a test benchmark build with Emscripten and record
+# the file output sizes in out/test/stats.json. The file format is specified at
+# https://skia.googlesource.com/buildbot/+/refs/heads/main/perf/FORMAT.md
+# Running the benchmark will be skipped.
 class SizeBenchmarker(EmscriptenBenchmarker):
   record_stats = True
 
   def __init__(self, name):
     # do not set an engine, as we will not run the code
-    super().__init__(name, engine=None, extra_args=[])
+    super().__init__(name, engine=None)
 
   def run(self, args):
     return

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -454,8 +454,8 @@ class benchmark(common.RunnerCore):
     for b in benchmarkers:
       if skip_native and isinstance(b, NativeBenchmarker):
         continue
-      if isinstance(b, SizeBenchmarker):
-        # The size benchmarker doesn't need to do repetitions.
+      if not b.run:
+        # If we won't run the benchmark, we don't need repetitions.
         reps = 0
       baseline = b
       print('Running benchmarker: %s: %s' % (b.__class__.__name__, b.name))

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -10,6 +10,7 @@ import shutil
 import sys
 import time
 import unittest
+import json
 import zlib
 from pathlib import Path
 from typing import List
@@ -56,6 +57,7 @@ EMTEST_BENCHMARKERS = os.getenv('EMTEST_BENCHMARKERS', 'clang,v8,v8-lto,v8-ctors
 
 
 class Benchmarker():
+  record_stats = False
   # called when we init the object, which is during startup, even if we are
   # not running benchmarks
   def __init__(self, name):
@@ -112,13 +114,38 @@ class Benchmarker():
 
     # size
 
-    size = sum(os.path.getsize(f) for f in self.get_output_files())
-    gzip_size = sum(len(zlib.compress(read_binary(f))) for f in self.get_output_files())
+    recorded_stats = []
 
-    print('        size: %8s, compressed: %8s' % (size, gzip_size), end=' ')
+    def add_stat(name, size, gzip_size):
+      recorded_stats.append({
+        'value': name,
+        'measurement': size,
+      })
+      recorded_stats.append({
+        'value': name + ' (gzipped)',
+        'measurement': gzip_size,
+      })
+
+    total_size = 0
+    total_gzip_size = 0
+
+    for file in self.get_output_files():
+      size = os.path.getsize(file)
+      gzip_size = len(zlib.compress(read_binary(file)))
+      if self.record_stats:
+        add_stat(utils.removeprefix(os.path.basename(file), 'size_'), size, gzip_size)
+      total_size += size
+      total_gzip_size += gzip_size
+
+    if self.record_stats:
+      add_stat('total', total_size, total_gzip_size)
+
+    print('        size: %8s, compressed: %8s' % (total_size, total_gzip_size), end=' ')
     if self.get_size_text():
       print('  (' + self.get_size_text() + ')', end=' ')
     print()
+
+    return recorded_stats
 
   def get_size_text(self):
     return ''
@@ -240,6 +267,16 @@ class EmscriptenBenchmarker(Benchmarker):
     return ret
 
 
+class SizeBenchmarker(EmscriptenBenchmarker):
+  record_stats = True
+
+  def __init__(self, name):
+    super().__init__(name, None, [])
+
+  def run(self, args):
+    return
+
+
 CHEERP_BIN = '/opt/cheerp/bin/'
 
 
@@ -317,6 +354,7 @@ aot_v8 = (config.V8_ENGINE if config.V8_ENGINE else []) + ['--no-liftoff']
 named_benchmarkers = {
   'clang': NativeBenchmarker('clang', [CLANG_CC], [CLANG_CXX]),
   'gcc': NativeBenchmarker('gcc',   ['gcc', '-no-pie'],  ['g++', '-no-pie']),
+  'size': SizeBenchmarker('size'),
   'v8': EmscriptenBenchmarker('v8', aot_v8),
   'v8-lto': EmscriptenBenchmarker('v8-lto', aot_v8, ['-flto']),
   'v8-ctors': EmscriptenBenchmarker('v8-ctors', aot_v8, ['-sEVAL_CTORS']),
@@ -337,6 +375,7 @@ for name in EMTEST_BENCHMARKERS.split(','):
 
 class benchmark(common.RunnerCore):
   save_dir = True
+  stats = [] # type: ignore
 
   @classmethod
   def setUpClass(cls):
@@ -357,6 +396,17 @@ class benchmark(common.RunnerCore):
       pass
     fingerprint.append('llvm: ' + config.LLVM_ROOT)
     print('Running Emscripten benchmarks... [ %s ]' % ' | '.join(fingerprint))
+
+  @classmethod
+  def tearDownClass(cls):
+    super().tearDownClass()
+    if cls.stats:
+      output = {
+        'version': 1,
+        'git_hash': '',
+        'results': cls.stats
+      }
+      utils.write_file('stats.json', json.dumps(output, indent=2) + '\n')
 
   # avoid depending on argument reception from the commandline
   def hardcode_arguments(self, code):
@@ -397,11 +447,27 @@ class benchmark(common.RunnerCore):
     for b in benchmarkers:
       if skip_native and isinstance(b, NativeBenchmarker):
         continue
+      if isinstance(b, SizeBenchmarker):
+        # The size benchmarker doesn't need to do repetitions.
+        reps = 0
       baseline = b
       print('Running benchmarker: %s: %s' % (b.__class__.__name__, b.name))
       b.build(self, filename, args, shared_args, emcc_args, native_args, native_exec, lib_builder, has_output_parser=output_parser is not None)
       b.bench(args, output_parser, reps, expected_output)
-      b.display(baseline)
+      recorded_stats = b.display(baseline)
+      if recorded_stats:
+        self.add_stats(name, recorded_stats)
+
+  def add_stats(self, name, stats):
+    self.stats.append({
+      'key': {
+        'test': name,
+        'units': 'bytes'
+      },
+      'measurements': {
+        'stats': stats
+      }
+    })
 
   def test_primes(self, check=True):
     src = r'''

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -273,7 +273,8 @@ class SizeBenchmarker(EmscriptenBenchmarker):
   record_stats = True
 
   def __init__(self, name):
-    super().__init__(name, None, [])
+    # do not set an engine, as we will not run the code
+    super().__init__(name, engine=None, extra_args=[])
 
   def run(self, args):
     return

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -280,8 +280,8 @@ class SizeBenchmarker(EmscriptenBenchmarker):
     # do not set an engine, as we will not run the code
     super().__init__(name, engine=None)
 
-  def run(self, args):
-    return
+  # we will not actually run the benchmarks
+  run = None
 
 
 CHEERP_BIN = '/opt/cheerp/bin/'

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -57,7 +57,9 @@ EMTEST_BENCHMARKERS = os.getenv('EMTEST_BENCHMARKERS', 'clang,v8,v8-lto,v8-ctors
 
 
 class Benchmarker():
+  # whether to record statistics. set by SizeBenchmarker.
   record_stats = False
+
   # called when we init the object, which is during startup, even if we are
   # not running benchmarks
   def __init__(self, name):


### PR DESCRIPTION
This will be run by emscripten releases to start tracking size benchmarks on our skia perf instance. I've intentially only added two benchmarks to start for testing.

The output format was verified using perf-tool. More info on the format at https://skia.googlesource.com/buildbot/+/refs/heads/main/perf/FORMAT.md