### PR TITLE
[contrib.glfw3] New version

### DIFF
--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -6,8 +6,8 @@
 import os
 from typing import Dict
 
-TAG = '3.4.0.20240616'
-HASH = 'a067effe2044020ed36199f7508c7ef143ee19b6d97e2e1e532974a97f8f2d510da486be0187630a9e0793a38ad7e67a52e74cddb40369c049b463cdebe304d4'
+TAG = '3.4.0.20240617'
+HASH = '148609b09e322e7f2433f5335431ba142ffe570248f296eb3a89d3d671476112657e30ebfe2ae23c09b99e7b0eddf875bfef149b43dbd50d5f58ccfc22770f89'
 
 # contrib port information (required)
 URL = 'https://github.com/pongasoft/emscripten-glfw'

--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -6,8 +6,8 @@
 import os
 from typing import Dict
 
-TAG = '3.4.0.20240601'
-HASH = '3083c320b402fd97c3cf9b55c2c1025bb133b3de0ab32cbb4af13e2471f9a9202bb0c9ae11f578829ae59568bb332762a67686be33689b7803343b84d8032254'
+TAG = '3.4.0.20240616'
+HASH = 'a067effe2044020ed36199f7508c7ef143ee19b6d97e2e1e532974a97f8f2d510da486be0187630a9e0793a38ad7e67a52e74cddb40369c049b463cdebe304d4'
 
 # contrib port information (required)
 URL = 'https://github.com/pongasoft/emscripten-glfw'


### PR DESCRIPTION
Contains 2 emscripten-glfw version with following release notes:

#### 3.4.0.20240617 - 2024-06-17 | emscripten TBD

- Fixed [#3](https://github.com/pongasoft/emscripten-glfw/issues/3): glfwGetKey must return one of `GLFW_PRESS` or `GLFW_RELEASE`

#### 3.4.0.20240616 - 2024-06-16 | emscripten TBD

- Implemented `glfwGetClipboardString`. Note that due to the async (and restrictive) nature of the 
  `navigator.clipboard.readText` call, this synchronous API returns whatever was set via a previous call
  to `glfwSetClipboardString` and ignores the external clipboard entirely.
