### PR TITLE
Correct some wrong English grammar

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -350,7 +350,7 @@ Default value: 1024
 TABLE_BASE
 ==========
 
-Where where table slots (function addresses) are allocated.
+Where table slots (function addresses) are allocated.
 This must be at least 1 to reserve the zero slot for the null pointer.
 
 Default value: 1

--- a/src/settings.js
+++ b/src/settings.js
@@ -273,7 +273,7 @@ var ALLOW_TABLE_GROWTH = false;
 // [link]
 var GLOBAL_BASE = 1024;
 
-// Where where table slots (function addresses) are allocated.
+// Where table slots (function addresses) are allocated.
 // This must be at least 1 to reserve the zero slot for the null pointer.
 // [link]
 var TABLE_BASE = 1;


### PR DESCRIPTION
Double "where" in succession.