### PR TITLE
Fix single line comment preservation in acorn-optimizer

### DIFF
--- a/test/optimizer/test-unsignPointers-output.js
+++ b/test/optimizer/test-unsignPointers-output.js
@@ -1,5 +1,8 @@
-HEAP32[x >>> 2];
+/**
+ * This is a multi-line comment
+ */ HEAP32[x >>> 2];
 
+// This is a single-line comment
 HEAP8[x >>> 0];
 
 HEAP8.length;
@@ -20,6 +23,7 @@ HEAPU8.subarray(x >>> 0, y >>> 0);
 
 process.versions.node;
 
+// something completely different
 insideCall(HEAP32[x >>> 2]);
 
 heap[x >>> 0];

--- a/test/optimizer/test-unsignPointers.js
+++ b/test/optimizer/test-unsignPointers.js
@@ -1,5 +1,9 @@
+/**
+ * This is a multi-line comment
+ */
 HEAP32[x >> 2];
 
+// This is a single-line comment
 HEAP8[x];
 
 HEAP8.length;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2825,7 +2825,7 @@ More info: https://emscripten.org
     'standalone-emitDCEGraph': ('optimizer/standalone-emitDCEGraph.js', ['emitDCEGraph', '--no-print']),
     'emittedJSPreservesParens': ('optimizer/emittedJSPreservesParens.js', []),
     'growableHeap': ('optimizer/test-growableHeap.js', ['growableHeap']),
-    'unsignPointers': ('optimizer/test-unsignPointers.js', ['unsignPointers']),
+    'unsignPointers': ('optimizer/test-unsignPointers.js', ['unsignPointers', '--closure-friendly']),
     'asanify': ('optimizer/test-asanify.js', ['asanify']),
     'safeHeap': ('optimizer/test-safeHeap.js', ['safeHeap']),
     'LittleEndianHeap': ('optimizer/test-LittleEndianHeap.js', ['littleEndianHeap']),
@@ -8370,12 +8370,12 @@ int main() {
         (['-O0', '--profiling-funcs'], False, False, True, False),
         (['-O1'],        False, False, True, False),
         (['-O2'],        False, True,  False, False),
-        (['-O2', '-g1'], False, True,  True, False),
+        (['-O2', '-g1'], False, False, True, False),
         (['-O2', '-g'],  True,  False, True, False),
         (['-O2', '--closure=1'],         False, True, False, True),
         (['-O2', '--closure=1', '-g1'],  False, True, True,  True),
       ]:
-      print(args, expect_emit_text)
+      print(args, expect_emit_text, expect_clean_js, expect_whitespace_js, expect_closured)
       delete_file('a.out.wat')
       cmd = [EMCC, test_file('hello_world.c')] + args
       print(' '.join(cmd))

--- a/tools/acorn-optimizer.mjs
+++ b/tools/acorn-optimizer.mjs
@@ -1954,19 +1954,19 @@ function reattachComments(ast, comments) {
       ++j;
     }
     if (j >= symbols.length) {
+      trace(`dropping comment: no symbol comes after it (${comments[i].value.slice(0, 30)})`);
       break;
     }
     if (symbols[j].start.pos - comments[i].end > 20) {
       // This comment is too far away to refer to the given symbol. Drop
       // the comment altogether.
+      trace(`dropping comment: too far from any symbol (${comments[i].value.slice(0, 30)})`);
       continue;
     }
-    if (!Array.isArray(symbols[j].start.comments_before)) {
-      symbols[j].start.comments_before = [];
-    }
+    symbols[j].start.comments_before ??= [];
     symbols[j].start.comments_before.push(
       new terser.AST_Token(
-        comments[i].type == 'Line' ? 'comment' : 'comment2',
+        comments[i].type == 'Line' ? 'comment1' : 'comment2',
         comments[i].value,
         undefined,
         undefined,

--- a/tools/building.py
+++ b/tools/building.py
@@ -339,7 +339,7 @@ def js_optimizer(filename, passes):
 
 
 # run JS optimizer on some JS, ignoring asm.js contents if any - just run on it all
-def acorn_optimizer(filename, passes, extra_info=None, return_output=False):
+def acorn_optimizer(filename, passes, extra_info=None, return_output=False, worker_js=False):
   optimizer = path_from_root('tools/acorn-optimizer.mjs')
   original_filename = filename
   if extra_info is not None:
@@ -350,12 +350,13 @@ def acorn_optimizer(filename, passes, extra_info=None, return_output=False):
       f.write('// EXTRA_INFO: ' + extra_info)
     filename = temp
   cmd = config.NODE_JS + [optimizer, filename] + passes
-  # Keep JS code comments intact through the acorn optimization pass so that
-  # JSDoc comments will be carried over to a later Closure run.
-  if settings.MAYBE_CLOSURE_COMPILER:
-    cmd += ['--closure-friendly']
-  if settings.EXPORT_ES6:
-    cmd += ['--export-es6']
+  if not worker_js:
+    # Keep JS code comments intact through the acorn optimization pass so that
+    # JSDoc comments will be carried over to a later Closure run.
+    if settings.MAYBE_CLOSURE_COMPILER:
+      cmd += ['--closure-friendly']
+    if settings.EXPORT_ES6:
+      cmd += ['--export-es6']
   if settings.VERBOSE:
     cmd += ['--verbose']
   if return_output:

--- a/tools/link.py
+++ b/tools/link.py
@@ -2042,7 +2042,7 @@ def create_worker_file(input_file, target_dir, output_file, options):
 
   # Minify the worker JS file, if JS minification is enabled.
   if settings.MINIFY_WHITESPACE:
-    contents = building.acorn_optimizer(output_file, ['--minify-whitespace'], return_output=True)
+    contents = building.acorn_optimizer(output_file, ['--minify-whitespace'], return_output=True, worker_js=True)
     write_file(output_file, contents)
 
   tools.line_endings.convert_line_endings_in_file(output_file, os.linesep, options.output_eol)


### PR DESCRIPTION
Terser has `comment1` and `comment2` types but there is no such thing as just `comment`.