### PR TITLE
Fix a crash in miniTempWebGL*Buffers optimization

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -28,13 +28,14 @@ var LibraryGL = {
 
   $miniTempWebGLFloatBuffers: [],
   $miniTempWebGLFloatBuffers__postset: `var miniTempWebGLFloatBuffersStorage = new Float32Array({{{ GL_POOL_TEMP_BUFFERS_SIZE }}});
-for (/**@suppress{duplicate}*/var i = 0; i < {{{ GL_POOL_TEMP_BUFFERS_SIZE }}}; ++i) {
+// Create GL_POOL_TEMP_BUFFERS_SIZE+1 temporary buffers, for uploads of size 0 through GL_POOL_TEMP_BUFFERS_SIZE inclusive
+for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}}; ++i) {
   miniTempWebGLFloatBuffers[i] = miniTempWebGLFloatBuffersStorage.subarray(0, i);
 }`,
 
   $miniTempWebGLIntBuffers: [],
   $miniTempWebGLIntBuffers__postset: `var miniTempWebGLIntBuffersStorage = new Int32Array({{{ GL_POOL_TEMP_BUFFERS_SIZE }}});
-for (/**@suppress{duplicate}*/var i = 0; i < {{{ GL_POOL_TEMP_BUFFERS_SIZE }}}; ++i) {
+for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}}; ++i) {
   miniTempWebGLIntBuffers[i] = miniTempWebGLIntBuffersStorage.subarray(0, i);
 }`,
 

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -35,6 +35,7 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
 
   $miniTempWebGLIntBuffers: [],
   $miniTempWebGLIntBuffers__postset: `var miniTempWebGLIntBuffersStorage = new Int32Array({{{ GL_POOL_TEMP_BUFFERS_SIZE }}});
+// Create GL_POOL_TEMP_BUFFERS_SIZE+1 temporary buffers, for uploads of size 0 through GL_POOL_TEMP_BUFFERS_SIZE inclusive
 for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}}; ++i) {
   miniTempWebGLIntBuffers[i] = miniTempWebGLIntBuffersStorage.subarray(0, i);
 }`,

--- a/test/browser/webgl_draw_triangle_with_uniform_color.c
+++ b/test/browser/webgl_draw_triangle_with_uniform_color.c
@@ -99,12 +99,56 @@ int main() {
   glEnableVertexAttribArray(0);
   glEnableVertexAttribArray(1);
 
+  // Spot-test for miniTempWebGLFloatBuffers optimization in library_webgl.js.
+  // Note there WILL be GL errors from this, but the test doesn't check for them
+  // so it won't cause it to fail.
+#define GL_POOL_TEMP_BUFFERS_SIZE 288
+  {
+    GLfloat fdata[GL_POOL_TEMP_BUFFERS_SIZE + 4] = {};
+    // Just under the optimization limit (should use unoptimized codepath)
+    glUniform4fv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE / 4 - 1, fdata);
+    glUniform2fv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE / 2 - 1, fdata);
+    glUniform1fv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE - 1, fdata);
+    // Just at the optimization limit (should use optimized codepath)
+    glUniform4fv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE / 4, fdata);
+    glUniform2fv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE / 2, fdata);
+    glUniform1fv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE, fdata);
+    // Just over the optimization limit (should use optimized codepath)
+    glUniform4fv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE / 4 + 1, fdata);
+    glUniform2fv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE / 2 + 1, fdata);
+    glUniform1fv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE + 1, fdata);
+
+    GLint idata[GL_POOL_TEMP_BUFFERS_SIZE + 4] = {};
+    // Just under the optimization limit (should use unoptimized codepath)
+    glUniform4iv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE / 4 - 1, idata);
+    glUniform2iv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE / 2 - 1, idata);
+    glUniform1iv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE - 1, idata);
+    // Just at the optimization limit (should use optimized codepath)
+    glUniform4iv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE / 4, idata);
+    glUniform2iv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE / 2, idata);
+    glUniform1iv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE, idata);
+    // Just over the optimization limit (should use optimized codepath)
+    glUniform4iv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE / 4 + 1, idata);
+    glUniform2iv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE / 2 + 1, idata);
+    glUniform1iv(glGetUniformLocation(program, "color2"), GL_POOL_TEMP_BUFFERS_SIZE + 1, idata);
+  }
+
+  // Actual upload for the rest of the test (overwrites the previous one).
   float color2[4] = { 0.0f, 1.f, 0.0f, 1.0f };
   glUniform4fv(glGetUniformLocation(program, "color2"), 1, color2);
 
   // Test that passing zero for the size paramater does not cause error
   // https://github.com/emscripten-core/emscripten/issues/21567
-  glUniform4fv(glGetUniformLocation(program, "color2"), 0, color2);
+  // (These are zero-sized, so shouldn't overwrite anything.)
+  {
+    GLfloat fdata[4] = {};
+    glUniform4fv(glGetUniformLocation(program, "color2"), 0, fdata);
+    glUniform4fv(glGetUniformLocation(program, "color2"), 0, NULL);
+
+    GLint idata[4] = {};
+    glUniform4iv(glGetUniformLocation(program, "color2"), 0, idata);
+    glUniform4iv(glGetUniformLocation(program, "color2"), 0, NULL);
+  }
 
   glClearColor(0.3f,0.3f,0.3f,1);
   glClear(GL_COLOR_BUFFER_BIT);


### PR DESCRIPTION
library_webgl.js attempts to use a pool of temp float or int buffers for uniform uploads up to 288 elements, however it would only allocate 288 temp buffers, so 0 through 287 would be fine but 288 would crash (miniTempWebGLFloatBuffers[288] would be undefined).

Confirmed manually that any one of the six "Just at the optimization limit" calls would crash before, and with the fix does not.

Fix for the change in PR #21573