### PR TITLE
Improve comment preservation in acorn-optimizer. NFC

### DIFF
--- a/test/optimizer/test-unsignPointers-output.js
+++ b/test/optimizer/test-unsignPointers-output.js
@@ -1,8 +1,14 @@
 /**
- * This is a multi-line comment
+ * Multi-line comment.
+ */ /**
+ * Another multi-line comment.
+ */ /**
+ * A third multi-line comment.
  */ HEAP32[x >>> 2];
 
-// This is a single-line comment
+// Single line comment
+// Another single line comment
+// A third single line comment
 HEAP8[x >>> 0];
 
 HEAP8.length;

--- a/test/optimizer/test-unsignPointers.js
+++ b/test/optimizer/test-unsignPointers.js
@@ -1,9 +1,17 @@
 /**
- * This is a multi-line comment
+ * Multi-line comment.
+ */
+/**
+ * Another multi-line comment.
+ */
+/**
+ * A third multi-line comment.
  */
 HEAP32[x >> 2];
 
-// This is a single-line comment
+// Single line comment
+// Another single line comment
+// A third single line comment
 HEAP8[x];
 
 HEAP8.length;

--- a/tools/acorn-optimizer.mjs
+++ b/tools/acorn-optimizer.mjs
@@ -1932,7 +1932,7 @@ function minifyGlobals(ast) {
 
 // Utilities
 
-function reattachComments(ast, comments) {
+function reattachComments(ast, commentsMap) {
   const symbols = [];
 
   // Collect all code symbols
@@ -1949,33 +1949,37 @@ function reattachComments(ast, comments) {
 
   // Walk through all comments in ascending line number, and match each
   // comment to the appropriate code block.
-  for (let i = 0, j = 0; i < comments.length; ++i) {
-    while (j < symbols.length && symbols[j].start.pos < comments[i].end) {
+  let j = 0;
+  for (const [pos, comments] of Object.entries(commentsMap)) {
+    while (j < symbols.length && symbols[j].start.pos < pos) {
       ++j;
     }
     if (j >= symbols.length) {
-      trace(`dropping comment: no symbol comes after it (${comments[i].value.slice(0, 30)})`);
+      trace('dropping comments: no symbol comes after them');
       break;
     }
-    if (symbols[j].start.pos - comments[i].end > 20) {
+    if (symbols[j].start.pos - pos > 20) {
       // This comment is too far away to refer to the given symbol. Drop
       // the comment altogether.
-      trace(`dropping comment: too far from any symbol (${comments[i].value.slice(0, 30)})`);
+      trace('dropping comments: too far from any symbol');
       continue;
     }
     symbols[j].start.comments_before ??= [];
-    symbols[j].start.comments_before.push(
-      new terser.AST_Token(
-        comments[i].type == 'Line' ? 'comment1' : 'comment2',
-        comments[i].value,
-        undefined,
-        undefined,
-        false,
-        undefined,
-        undefined,
-        '0',
-      ),
-    );
+    for (const comment of comments) {
+      trace('reattaching comment');
+      symbols[j].start.comments_before.push(
+        new terser.AST_Token(
+          comment.type == 'Line' ? 'comment1' : 'comment2',
+          comment.value,
+          undefined,
+          undefined,
+          false,
+          undefined,
+          undefined,
+          '0',
+        ),
+      );
+    }
   }
 }
 
@@ -2029,19 +2033,30 @@ let extraInfo = null;
 if (extraInfoStart > 0) {
   extraInfo = JSON.parse(input.substr(extraInfoStart + 14));
 }
-// Collect all JS code comments to this array so that we can retain them in the outputted code
-// if --closureFriendly was requested.
-const sourceComments = [];
+// Collect all JS code comments to this map so that we can retain them in the
+// outputted code if --closureFriendly was requested.
+const sourceComments = {};
+const params = {
+  // Keep in sync with --language_in that we pass to closure in building.py
+  ecmaVersion: 2021,
+  sourceType: exportES6 ? 'module' : 'script',
+  allowAwaitOutsideFunction: true,
+};
+if (closureFriendly) {
+  const currentComments = [];
+  Object.assign(params, {
+    preserveParens: true,
+    onToken: (token) => {
+      // Associate comments with the start position of the next token.
+      sourceComments[token.start] = currentComments.slice();
+      currentComments.length = 0;
+    },
+    onComment: currentComments,
+  });
+}
 let ast;
 try {
-  ast = acorn.parse(input, {
-    // Keep in sync with --language_in that we pass to closure in building.py
-    ecmaVersion: 2021,
-    preserveParens: closureFriendly,
-    onComment: closureFriendly ? sourceComments : undefined,
-    sourceType: exportES6 ? 'module' : 'script',
-    allowAwaitOutsideFunction: true,
-  });
+  ast = acorn.parse(input, params);
 } catch (err) {
   err.message += (() => {
     let errorMessage = '\n' + input.split(acorn.lineBreak)[err.loc.line - 1] + '\n';


### PR DESCRIPTION
Prior to this change we would drop any comment that was more than 20 characters from JS symbol, based on the end of the commend and that start of the symbol.    This mean that all but the last single-line comments in a sequence would be dropped.

With this change we map all comments to the start of the next symbol. This means that we can have many comments in row that all map the same location and we decide to either keep all of them or discard them.