### PR TITLE
[contrib.glfw3] new version (workaround / bug fix)

### DIFF
--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -6,8 +6,8 @@
 import os
 from typing import Dict
 
-TAG = '3.4.0.20240617'
-HASH = '148609b09e322e7f2433f5335431ba142ffe570248f296eb3a89d3d671476112657e30ebfe2ae23c09b99e7b0eddf875bfef149b43dbd50d5f58ccfc22770f89'
+TAG = '3.4.0.20240625'
+HASH = '318cb351628286fd2aa98bfbf76949f91114fabd2b13a6468109d97c138689f73ae05526cb083d4644746f661cc81f17270680b4636457943e3cb646eafb49bd'
 
 # contrib port information (required)
 URL = 'https://github.com/pongasoft/emscripten-glfw'


### PR DESCRIPTION
I released a new version of contrib.glfw3 with a workaround/bug fix. I wanted to point out that there is the same issue that was [created](https://github.com/emscripten-core/emscripten/issues/18089) on 10/22 for the built-in implementation. That was never addressed. I also wanted to point out that SDL2 also suffers from the same issue...

I found [this issue](https://github.com/ocornut/imgui/issues/7732) while working on a project using ImGui.

![Meta_V](https://github.com/ocornut/imgui/assets/357116/0cec5893-d146-40fe-ae15-2fd00e7bd319)

Release notes:
- Implemented workaround for [#4](https://github.com/pongasoft/emscripten-glfw/issues/4): _Using Super + "Key" on macOS results in "Key" not being released_.
  Due to the [broken state](https://stackoverflow.com/questions/11818637/why-does-javascript-drop-keyup-events-when-the-metakey-is-pressed-on-mac-browser) of javascript handling the `Super/Meta` key, there is no good solution. The workaround implemented, releases all keys when `Super` is released. Although not a perfect solution, it guarantees that the state is _eventually_ consistent:
    - if "Key" was released while "Super" was held, then when "Super" gets released, "Key" is released (later than when actually released, final state is consistent: "Key" in `Release` state)
    - if "Key" is still held when "Super" is released, "Key" is released when "Super" gets released, but immediately gets a down event (Up/Down event, final state is consistent": "Key" in `Pressed` state)
