### PR TITLE
Updated Arch Linux external references

### DIFF
--- a/site/source/docs/getting_started/downloads.rst
+++ b/site/source/docs/getting_started/downloads.rst
@@ -258,5 +258,5 @@ The following is a partial list of such unofficial emscripten packages:
  - maintainer: @chenrui333
 
 **Arch Linux**
- - package info: https://github.com/archlinux/svntogit-community/tree/packages/emscripten/trunk
- - maintainer: Sven-Hendrik Haase <svenstaro@gmail.com>
+ - package info: https://archlinux.org/packages/extra/x86_64/emscripten
+ - maintainer: Sven-Hendrik Haase <svenstaro@archlinux.org>


### PR DESCRIPTION
Updates to the Arch Linux subsection within "Unofficial Packages" docs. External link now points to current package page on archlinux.org, and the maintainer email address now reflects the official email found in the Arch PKGBUILD.

Closes #22147 