### PR TITLE
changed LLVM root path to lower case in sanity.txt output for Windows

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -433,7 +433,10 @@ def set_version_globals():
 
 
 def generate_sanity():
-  return f'{EMSCRIPTEN_VERSION}|{config.LLVM_ROOT}\n'
+  llvm_root = config.LLVM_ROOT
+  if WINDOWS:
+    llvm_root = config.LLVM_ROOT.lower()
+  return f'{EMSCRIPTEN_VERSION}|{llvm_root}\n'
 
 
 @memoize


### PR DESCRIPTION
Visual Studio Code [CMakeTools](https://github.com/microsoft/vscode-cmake-tools) extension cleans cache when the editor opens in Windows. Possible root cause is different LLVM root paths string case in santiy.txt: 
- For startup it produces path starting with  'c:\' e.g  `c:\projects\emscripten\upstream\bin`
- For regular cmake configuration or build it produces path starting with 'C:\' e.g `C:\projects\emscripten\upstream\bin` 
This leads to rebuilding cache every time the editor is launched, which is a bit frustrating 
Link to similar [issue](https://github.com/microsoft/vscode-cpptools/issues/9770)

For windows path to folders is case independent anyways, so possible fix is just put lowercase string to sainty.txt for Windows.