### PR TITLE
Preserve system library ordering even under EMCC_FORCE_STDLIBS=1

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -5876,6 +5876,12 @@ int main()
       self.run_process([EMXX, 'src.cpp', '-sDISABLE_EXCEPTION_CATCHING=0'])
     self.assertContained('Caught exception: std::exception', self.run_js('a.out.js'))
 
+  @with_env_modify({'EMCC_FORCE_STDLIBS': '1'})
+  def test_force_stdlibs(self):
+    self.do_runf('hello_world.c')
+    # See https://github.com/emscripten-core/emscripten/issues/22161
+    self.do_runf('hello_world.c', emcc_args=['-sWASM_BIGINT'])
+
   @crossplatform
   @also_with_env_modify({'gb_locale': {'LC_ALL': 'en_GB'}, 'long_tz': {'TZ': 'Asia/Kathmandu'}})
   def test_strftime_zZ(self):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2292,12 +2292,17 @@ def get_libs_to_link(args):
   if settings.SIDE_MODULE:
     return libs_to_link
 
-  for forced in force_include:
-    if forced not in system_libs_map:
-      shared.exit_with_error('invalid forced library: %s', forced)
-    add_library(forced)
+  # We add the forced libs last so that any libraries that are added in the normal
+  # sequence below are added in the correct order even when they are also part of
+  # EMCC_FORCE_STDLIBS.
+  def add_forced_libs():
+    for forced in force_include:
+      if forced not in system_libs_map:
+        shared.exit_with_error('invalid forced library: %s', forced)
+      add_library(forced)
 
   if '-nodefaultlibs' in args:
+    add_forced_libs()
     return libs_to_link
 
   sanitize = settings.USE_LSAN or settings.USE_ASAN or settings.UBSAN_RUNTIME
@@ -2325,6 +2330,7 @@ def get_libs_to_link(args):
   if only_forced:
     add_library('libcompiler_rt')
     add_sanitizer_libs()
+    add_forced_libs()
     return libs_to_link
 
   if settings.AUTO_NATIVE_LIBRARIES:
@@ -2390,6 +2396,7 @@ def get_libs_to_link(args):
     add_library('libwasmfs')
 
   add_sanitizer_libs()
+  add_forced_libs()
   return libs_to_link
 
 


### PR DESCRIPTION
In particular `EMCC_FORCE_STDLIBS=1` would previously place libc before libbulkmemory which don't work.  libbulkmemory always needs to come first on the link line.

Fixes: #22161