### PR TITLE
Temporarily disable test_biggerswitch

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2221,6 +2221,8 @@ int main(int argc, char **argv) {
   @no_wasm2js('massive switches can break js engines')
   @is_slow_test
   def test_biggerswitch(self):
+    if self.is_optimizing():
+      self.skipTest('https://github.com/emscripten-core/emscripten/issues/22179')
     if not self.is_optimizing():
       self.skipTest('nodejs takes >6GB to compile this if the wasm is not optimized, which OOMs, see https://github.com/emscripten-core/emscripten/issues/7928#issuecomment-458308453')
     num_cases = 20000


### PR DESCRIPTION
This test is timing out consistently on circleci at higher optimization levels.

See #22179