### PR TITLE
Remove stray $ character from logging message. NFC

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -301,7 +301,7 @@ def init():
     sys.exit(0)
 
   if os.path.isfile(EM_CONFIG):
-    logger.debug(f'using config file: ${EM_CONFIG}')
+    logger.debug(f'using config file: {EM_CONFIG}')
   else:
     logger.debug('config file not found; using default config')
 


### PR DESCRIPTION
Here I use the JS syntax by mistake.