### PR TITLE
Make emscripten_resize_heap compatible with PURE_WASI

### DIFF
--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -152,14 +152,16 @@ size_t emscripten_get_heap_max() {
 }
 
 int emscripten_resize_heap(size_t size) {
-#if defined(EMSCRIPTEN_MEMORY_GROWTH) && !defined(EMSCRIPTEN_PURE_WASI)
+#if defined(EMSCRIPTEN_MEMORY_GROWTH)
   size_t old_size = __builtin_wasm_memory_size(0) * WASM_PAGE_SIZE;
   assert(old_size < size);
   ssize_t diff = (size - old_size + WASM_PAGE_SIZE - 1) / WASM_PAGE_SIZE;
   size_t result = __builtin_wasm_memory_grow(0, diff);
   if (result != (size_t)-1) {
+#if !defined(EMSCRIPTEN_PURE_WASI)
     // Success, update JS (see https://github.com/WebAssembly/WASI/issues/82)
     emscripten_notify_memory_growth(0);
+#endif
     return 1;
   }
 #endif

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2087,7 +2087,7 @@ int main(int argc, char **argv) {
     self.set_setting('SAFE_HEAP')
     self.do_core_test('test_memorygrowth_3.c')
 
-  @also_with_standalone_wasm(impure=True)
+  @also_with_standalone_wasm()
   @no_4gb('depends on INITIAL_MEMORY')
   @no_2gb('depends on INITIAL_MEMORY')
   def test_memorygrowth_MAXIMUM_MEMORY(self):


### PR DESCRIPTION
Previosly, using PURE_WASI was incompatible with
EMSCRIPTEN_MEMORY_GROWTH flag, and was not documented.

Now, using EMSCRIPTEN_MEMORY_GROWTH with PURE_WASI is possible. It will not require the host to export
emscripten_notify_memory_growth and will grow the memory as expected from EMSCRIPTEN_MEMORY_GROWTH.

Fixes #22211