### PR TITLE
Remove workaround for v8 bug in emscripten_resize_heap

### DIFF
--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -157,10 +157,7 @@ int emscripten_resize_heap(size_t size) {
   assert(old_size < size);
   ssize_t diff = (size - old_size + WASM_PAGE_SIZE - 1) / WASM_PAGE_SIZE;
   size_t result = __builtin_wasm_memory_grow(0, diff);
-  // Its seems v8 has a bug in memory.grow that causes it to return
-  // (uint32_t)-1 even with memory64:
-  // https://bugs.chromium.org/p/v8/issues/detail?id=13948
-  if (result != (uint32_t)-1 && result != (size_t)-1) {
+  if (result != (size_t)-1) {
     // Success, update JS (see https://github.com/WebAssembly/WASI/issues/82)
     emscripten_notify_memory_growth(0);
     return 1;


### PR DESCRIPTION
This was a bug that only effected standalone+wasm64 and is covered by the test_memorygrowth_MAXIMUM_MEMORY_standalone test.