### PR TITLE
Fix racy bevaviour in Ports.install_header_dir. NFC

### DIFF
--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -153,12 +153,12 @@ class Ports:
 
   @staticmethod
   def install_header_dir(src_dir, target=None):
+    """Like install_headers but recusively copied all files in a directory"""
     if not target:
       target = os.path.basename(src_dir)
     dest = Ports.get_include_dir(target)
-    utils.delete_dir(dest)
     logger.debug(f'installing headers: {dest}')
-    shutil.copytree(src_dir, dest)
+    shutil.copytree(src_dir, dest, dirs_exist_ok=True, copy_function=maybe_copy)
 
   @staticmethod
   def install_headers(src_dir, pattern='*.h', target=None):

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -19,7 +19,7 @@ def get(ports, settings, shared):
   def create(final):
     source_path = os.path.join(ports.get_dir(), 'ogg', 'Ogg-' + TAG)
     ports.write_file(os.path.join(source_path, 'include', 'ogg', 'config_types.h'), config_types_h)
-    ports.install_header_dir(os.path.join(source_path, 'include', 'ogg'), 'ogg')
+    ports.install_headers(os.path.join(source_path, 'include', 'ogg'), target='ogg')
     ports.build_port(os.path.join(source_path, 'src'), final, 'ogg')
 
   return [shared.cache.get_lib('libogg.a', create)]

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -20,7 +20,7 @@ def get(ports, settings, shared):
 
   def create(final):
     source_path = os.path.join(ports.get_dir(), 'vorbis', 'Vorbis-' + TAG)
-    ports.install_header_dir(os.path.join(source_path, 'include', 'vorbis'))
+    ports.install_headers(os.path.join(source_path, 'include', 'vorbis'), target='vorbis')
     ports.build_port(os.path.join(source_path, 'lib'), final, 'vorbis',
                      flags=['-sUSE_OGG'],
                      exclude_files=['psytune', 'barkmel', 'tone', 'misc'])


### PR DESCRIPTION
This change reduces to usage of install_header_dir to just the ports that need it, and updates it to use `maybe_copy` which avoids touching files that are already up-to-date.

Fixes: #22224