### PR TITLE
Ensure emscripten root is at the start of python path

### DIFF
--- a/test/benchmark/benchmark_sse.py
+++ b/test/benchmark/benchmark_sse.py
@@ -13,7 +13,7 @@ import tempfile
 from subprocess import Popen
 
 __rootpath__ = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.append(__rootpath__)
+sys.path.insert(0, __rootpath__)
 
 from tools.shared import WINDOWS, CLANG_CXX, EMCC, PIPE
 from tools.shared import run_process

--- a/test/runner.py
+++ b/test/runner.py
@@ -33,7 +33,7 @@ import unittest
 # Setup
 
 __rootpath__ = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.append(__rootpath__)
+sys.path.insert(0, __rootpath__)
 
 import jsrun
 import parallel_testsuite

--- a/tools/maint/check_struct_info.py
+++ b/tools/maint/check_struct_info.py
@@ -11,7 +11,7 @@ import subprocess
 script_dir = os.path.dirname(os.path.abspath(__file__))
 root_dir = os.path.dirname(os.path.dirname(script_dir))
 
-sys.path.append(root_dir)
+sys.path.insert(0, root_dir)
 
 from tools import utils
 

--- a/tools/maint/create_release.py
+++ b/tools/maint/create_release.py
@@ -12,7 +12,7 @@ import sys
 script_dir = os.path.dirname(os.path.abspath(__file__))
 root_dir = os.path.dirname(os.path.dirname(script_dir))
 
-sys.path.append(root_dir)
+sys.path.insert(0, root_dir)
 from tools import shared, utils
 
 

--- a/tools/maint/update_settings_docs.py
+++ b/tools/maint/update_settings_docs.py
@@ -23,7 +23,7 @@ import subprocess
 script_dir = os.path.dirname(os.path.abspath(__file__))
 root_dir = os.path.dirname(os.path.dirname(script_dir))
 
-sys.path.append(root_dir)
+sys.path.insert(0, root_dir)
 
 from tools.utils import path_from_root, read_file, safe_ensure_dirs
 


### PR DESCRIPTION
This avoids issues where something called e.g. `tools` already exists in the python path.

See https://github.com/emscripten-core/emsdk/issues/1420#issuecomment-2226178120