### PR TITLE
Temporarily add WASM_BIGINT to dylink tests

### DIFF
--- a/src/library_int53.js
+++ b/src/library_int53.js
@@ -130,14 +130,14 @@ addToLibrary({
   },
 
 #if WASM_BIGINT
-  $MAX_INT53: '{{{ Math.pow(2, 53) }}}',
-  $MIN_INT53: '-{{{ Math.pow(2, 53) }}}',
+  $INT53_MAX: '{{{ Math.pow(2, 53) }}}',
+  $INT53_MIN: '-{{{ Math.pow(2, 53) }}}',
   // Counvert a bigint value (usually coming from Wasm->JS call) into an int53
   // JS Number.  This is used when we have an incoming i64 that we know is a
   // pointer or size_t and is expected to be within the int53 range.
   // Returns NaN if the incoming bigint is outside the range.
-  $bigintToI53Checked__deps: ['$MAX_INT53', '$MIN_INT53'],
-  $bigintToI53Checked: (num) => (num < MIN_INT53 || num > MAX_INT53) ? NaN : Number(num),
+  $bigintToI53Checked__deps: ['$INT53_MAX', '$INT53_MIN'],
+  $bigintToI53Checked: (num) => (num < INT53_MIN || num > INT53_MAX) ? NaN : Number(num),
 #endif
 });
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -3986,6 +3986,11 @@ ok
 
   def dylink_test(self, main, side, expected=None, header=None, force_c=False,
                   main_module=2, **kwargs):
+    # Temporarily enableing WASM_BIGINT in all dylink tests in order to allow
+    # a recent llvm change to land:
+    # https://github.com/llvm/llvm-project/pull/75242
+    # Once that lands we can use --no-shlib-sigcheck instead.
+    self.set_setting('WASM_BIGINT')
     # Same as dylink_testf but take source code in string form
     if not isinstance(side, list):
       side_file = 'liblib.cpp' if not force_c else 'liblib.c'


### PR DESCRIPTION
This allows https://github.com/llvm/llvm-project/pull/75242 to roll in.

Also, rename MIN_INT53 in library_int53.js to avoid conflicts with runtime_debug.js
(this is needed because I enabled WASM_BIGINT in these tests which pulls in
library_int53.js in more tests).