### PR TITLE
[ci] Don't run entire wasm64l test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -616,17 +616,6 @@ jobs:
     steps:
       - run-tests-linux:
           test_targets: "wasm2js1"
-  test-wasm64l:
-    environment:
-      EMTEST_SKIP_NODE_CANARY: "1"
-    executor: bionic
-    steps:
-      - run-tests-linux:
-          frozen_cache: false
-          # On older versions of node wasm64l.test_bigswitch uses a lot (~3.5Gb)
-          # of memory, so skip it here, but run it in test-wasm64 instead which
-          # has node canary installed.
-          test_targets: "wasm64l skip:wasm64l.test_bigswitch"
   test-wasm64:
     # We don't use `bionic` here since its tool old to run recent node versions:
     # `/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found`
@@ -644,6 +633,7 @@ jobs:
             wasm64
             core_2gb.test_*em_asm*
             core_2gb.test_*embind*
+            wasm64l.test_hello_world
             wasm64l.test_bigswitch
             other.test_memory64_proxies
             other.test_failing_growth_wasm64"
@@ -945,9 +935,6 @@ workflows:
           requires:
             - build-linux
       - test-wasm64-4gb:
-          requires:
-            - build-linux
-      - test-wasm64l:
           requires:
             - build-linux
       - test-wasm2js1:


### PR DESCRIPTION
We do run this whole suite on the emscripten-releases waterfall but its not such an important configuration that we need to test the whole thing here.