### PR TITLE
Remove temporary setting of WASM_BIGINT in dylink tests. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -795,11 +795,6 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       self.skipTest('no dynamic linking support in wasm2js yet')
     if '-fsanitize=undefined' in self.emcc_args:
       self.skipTest('no dynamic linking support in UBSan yet')
-    # Temporarily enableing WASM_BIGINT in all dylink tests in order to allow
-    # a recent llvm change to land:
-    # https://github.com/llvm/llvm-project/pull/75242
-    # Once that lands we can use --no-shlib-sigcheck instead.
-    self.set_setting('WASM_BIGINT')
     # MEMORY64=2 mode doesn't currently support dynamic linking because
     # The side modules are lowered to wasm32 when they are built, making
     # them unlinkable with wasm64 binaries.

--- a/tools/building.py
+++ b/tools/building.py
@@ -194,6 +194,12 @@ def lld_flags_for_executable(external_symbols):
   if settings.RELOCATABLE:
     cmd.append('--experimental-pic')
     cmd.append('--unresolved-symbols=import-dynamic')
+    if not settings.WASM_BIGINT:
+      # When we don't have WASM_BIGINT available, JS signature legalization
+      # in binaryen will mutate the signatures of the imports/exports of our
+      # shared libraries.  Because of this we need to disabled signature
+      # checking of shared library functions in this case.
+      cmd.append('--no-shlib-sigcheck')
     if settings.SIDE_MODULE:
       cmd.append('-shared')
     else:


### PR DESCRIPTION
The llvm change that includes `--no-shlib-sigcheck` has now langed (https://github.com/llvm/llvm-project/pull/75242) so we can use that instead.