### PR TITLE
Save intermediate object files when `--save-temps` is used. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14940,3 +14940,13 @@ addToLibrary({
 
   def test_stack_protector(self):
     self.do_other_test('test_stack_protector.c', emcc_args=['-fstack-protector'], assert_returncode=NON_ZERO)
+
+  def test_save_temp(self):
+    self.run_process([EMCC, '--save-temps', test_file('hello_world.c')])
+    self.assertExists('a.out.js')
+    # clang itself takes care of creating these three
+    self.assertExists('hello_world.i')
+    self.assertExists('hello_world.s')
+    self.assertExists('hello_world.bc')
+    # emcc takes care of creating the .o
+    self.assertExists('hello_world.o')


### PR DESCRIPTION
clang takes care of saving the `.s`, `.i` and `.bc` files but its up to the compiler driver (in this case emcc) to save the temporary object files.

Interestingly if two source files have the same basename then `clang --save-temps` doesn't work since the object files will clobber each other in the current working directory.  This is probably a bug in clang so I didn't recreate it here.