### PR TITLE
Add target features section to bulk memory asm files

### DIFF
--- a/system/lib/libc/emscripten_memcpy_bulkmem.S
+++ b/system/lib/libc/emscripten_memcpy_bulkmem.S
@@ -13,3 +13,9 @@ _emscripten_memcpy_bulkmem:
   memory.copy 0, 0
   local.get 0
   end_function
+
+.section .custom_section.target_features,"",@
+.int8 1
+.int8 43
+.int8 11
+.ascii "bulk-memory"

--- a/system/lib/libc/emscripten_memset_bulkmem.S
+++ b/system/lib/libc/emscripten_memset_bulkmem.S
@@ -13,3 +13,9 @@ _emscripten_memset_bulkmem:
   memory.fill 0
   local.get 0
   end_function
+
+.section .custom_section.target_features,"",@
+.int8 1
+.int8 43
+.int8 11
+.ascii "bulk-memory"


### PR DESCRIPTION
Without this the feature might not be enabled when linked into the final binary.

This fixes the lto2.test_dylink_syslibs_all which was broken by #22231 which enabled bigint, whicn in turn enabled bulk memory (by bumping the min browser version).