### PR TITLE
Fix timezone extraction not working for all languages

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -657,12 +657,7 @@ addToLibrary({
 
     {{{ makeSetValue('daylight', '0', 'Number(winterOffset != summerOffset)', 'i32') }}};
 
-    var extractZone = (date) => {
-      var timezoneOffset = date.getTimezoneOffset();
-      if (isNaN(timezoneOffset) || timezoneOffset === 0) {
-        return `UTC`;
-      }
-
+    var extractZone = (timezoneOffset) => {
       // Why inverse sign?
       // Read here https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset
       var sign = timezoneOffset >= 0 ? "-" : "+";
@@ -674,8 +669,8 @@ addToLibrary({
       return `UTC${sign}${hours}${minutes}`;
     }
 
-    var winterName = extractZone(winter);
-    var summerName = extractZone(summer);
+    var winterName = extractZone(winterOffset);
+    var summerName = extractZone(summerOffset);
 #if ASSERTIONS
     assert(winterName);
     assert(summerName);

--- a/src/library.js
+++ b/src/library.js
@@ -657,7 +657,23 @@ addToLibrary({
 
     {{{ makeSetValue('daylight', '0', 'Number(winterOffset != summerOffset)', 'i32') }}};
 
-    var extractZone = (date) => date.toLocaleTimeString(undefined, {hour12:false, timeZoneName:'short'}).split(' ')[1];
+    var extractZone = (date) => {
+      var timezoneOffset = date.getTimezoneOffset();
+      if (isNaN(timezoneOffset) || timezoneOffset === 0) {
+        return `UTC`;
+      }
+
+      // Why inverse sign?
+      // Read here https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset
+      var sign = timezoneOffset >= 0 ? "-" : "+";
+
+      var absOffset = Math.abs(timezoneOffset)
+      var hours = String(Math.floor(absOffset / 60)).padStart(2, "0");
+      var minutes = String(absOffset % 60).padStart(2, "0");
+
+      return `UTC${sign}${hours}${minutes}`;
+    }
+
     var winterName = extractZone(winter);
     var summerName = extractZone(summer);
 #if ASSERTIONS

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -5946,15 +5946,16 @@ int main()
     if MACOS:
       self.skipTest('setting LC_ALL is not compatible with macOS python')
 
-    tz_lang_envs = [
-        {"LC_ALL": "en_GB", "TZ": "Europe/London"},
-        {"LC_ALL": "th_TH", "TZ": "Asia/Bangkok"},
-        {"LC_ALL": "ar-AE", "TZ": "United Arab Emirates"},
+    tz_lang_infos = [
+      {"env": {"LC_ALL": "en_GB", "TZ": "Europe/London"}, "expected_utc": "UTC+0100"},
+      {"env": {"LC_ALL": "th_TH", "TZ": "Asia/Bangkok"}, "expected_utc": "UTC+0700"},
+      {"env": {"LC_ALL": "ar-AE", "TZ": "Asia/Dubai"}, "expected_utc": "UTC+0400"},
+      {"env": {"LC_ALL": "en-US", "TZ": "America/Los_Angeles"}, "expected_utc": "UTC-0700"}
     ]
 
-    for tz_lang_env in tz_lang_envs:
-        with env_modify(tz_lang_env):
-            self.do_runf('other/test_strftime_zZ.c', 'ok!')
+    for tz_lang_info in tz_lang_infos:
+      with env_modify(tz_lang_info["env"]):
+        self.do_runf('other/test_strftime_zZ.c', "The current timezone is: %s" % (tz_lang_info["expected_utc"]))
 
   def test_strptime_symmetry(self):
     self.do_other_test('test_strptime_symmetry.c')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -36,7 +36,7 @@ from common import env_modify, no_mac, no_windows, only_windows, requires_native
 from common import create_file, parameterized, NON_ZERO, node_pthreads, TEST_ROOT, test_file
 from common import compiler_for, EMBUILDER, requires_v8, requires_node, requires_wasm64, requires_node_canary
 from common import requires_wasm_exnref, crossplatform, with_all_eh_sjlj, with_all_sjlj
-from common import also_with_standalone_wasm, also_with_env_modify, also_with_wasm2js
+from common import also_with_standalone_wasm, also_with_wasm2js
 from common import also_with_minimal_runtime, also_with_wasm_bigint, also_with_wasm64, flaky
 from common import EMTEST_BUILD_VERBOSE, PYTHON, WEBIDL_BINDER
 from common import requires_network, parameterize
@@ -5942,11 +5942,19 @@ int main()
     self.do_runf('hello_world.c', emcc_args=['-sWASM_BIGINT'])
 
   @crossplatform
-  @also_with_env_modify({'gb_locale': {'LC_ALL': 'en_GB'}, 'long_tz': {'TZ': 'Asia/Kathmandu'}})
   def test_strftime_zZ(self):
-    if os.environ.get('LC_ALL') == 'en_GB' and MACOS:
+    if MACOS:
       self.skipTest('setting LC_ALL is not compatible with macOS python')
-    self.do_runf('other/test_strftime_zZ.c', 'ok!')
+
+    tz_lang_envs = [
+        {"LC_ALL": "en_GB", "TZ": "Europe/London"},
+        {"LC_ALL": "th_TH", "TZ": "Asia/Bangkok"},
+        {"LC_ALL": "ar-AE", "TZ": "United Arab Emirates"},
+    ]
+
+    for tz_lang_env in tz_lang_envs:
+        with env_modify(tz_lang_env):
+            self.do_runf('other/test_strftime_zZ.c', 'ok!')
 
   def test_strptime_symmetry(self):
     self.do_other_test('test_strptime_symmetry.c')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -5947,15 +5947,15 @@ int main()
       self.skipTest('setting LC_ALL is not compatible with macOS python')
 
     tz_lang_infos = [
-      {"env": {"LC_ALL": "en_GB", "TZ": "Europe/London"}, "expected_utc": "UTC+0100"},
-      {"env": {"LC_ALL": "th_TH", "TZ": "Asia/Bangkok"}, "expected_utc": "UTC+0700"},
-      {"env": {"LC_ALL": "ar-AE", "TZ": "Asia/Dubai"}, "expected_utc": "UTC+0400"},
-      {"env": {"LC_ALL": "en-US", "TZ": "America/Los_Angeles"}, "expected_utc": "UTC-0700"}
+      {'env': {'LC_ALL': 'en_GB', 'TZ': 'Europe/London'}, 'expected_utc': 'UTC+0100'},
+      {'env': {'LC_ALL': 'th_TH', 'TZ': 'Asia/Bangkok'}, 'expected_utc': 'UTC+0700'},
+      {'env': {'LC_ALL': 'ar-AE', 'TZ': 'Asia/Dubai'}, 'expected_utc': 'UTC+0400'},
+      {'env': {'LC_ALL': 'en-US', 'TZ': 'America/Los_Angeles'}, 'expected_utc': 'UTC-0700'}
     ]
 
     for tz_lang_info in tz_lang_infos:
-      with env_modify(tz_lang_info["env"]):
-        self.do_runf('other/test_strftime_zZ.c', "The current timezone is: %s" % (tz_lang_info["expected_utc"]))
+      with env_modify(tz_lang_info['env']):
+        self.do_runf('other/test_strftime_zZ.c', 'The current timezone is: %s' % (tz_lang_info['expected_utc']))
 
   def test_strptime_symmetry(self):
     self.do_other_test('test_strptime_symmetry.c')


### PR DESCRIPTION
With certain language I've noticed that the timezone extraction algorithm doesn't work. For example consider the following:


Test file:
```JavaScript
const date = new Date();
console.log(date.toLocaleTimeString(undefined, {hour12: false, timeZoneName: 'short'}))
```

Run test file with specific local such as `th-TH` or `ar-AE`
```bash
LC_ALL="th-TH" TZ="Asia/Bangkok" node test.js
# prints "15 นาฬิกา 53 นาที 54 วินาที GMT+7"
```
And so the current logic for extracting would fail and return "นาฬิกา" (second item when splitting by space)

In this PR, a new approach is proposed for extracting the timezone offset and tests are updated with new test-case

The table bellow shows the previous (invalid) values for extract zone and what is the new value now (the `fr-FR` is only here to show a working case, all others are failing cases)

| LC_ALL | `date.toLocaleTimeString(undefined, {hour12:false, timeZoneName:'short'})` | Current `extractZone` value | New `extractZone` value |
| --- | --- | --- | --- |
 | fr-FR | 9:30:08 UTC+2 | UTC+2 | UTC+0200 |
  | am-ET | 09:28:50 ጂ ኤም ቲ+2 | ጂ | UTC+0200 |
 | ar-AE | 09:28:50 غرينتش+2 | غرينتش+2 | UTC+0200 |
 | ar-BH | ٠٩:٢٨:٥٠ غرينتش+٢ | غرينتش+٢ | UTC+0200 |
 | ar-DZ | 09:28:50 غرينتش+2 | غرينتش+2 | UTC+0200 |
 | ar-EG | ٠٩:٢٨:٥٠ غرينتش+٢ | غرينتش+٢ | UTC+0200 |
 | ar-IQ | ٠٩:٢٨:٥٠ غرينتش+٢ | غرينتش+٢ | UTC+0200 |
 | ar-JO | ٠٩:٢٨:٥١ غرينتش+٢ | غرينتش+٢ | UTC+0200 |
 | ar-KW | ٠٩:٢٨:٥١ غرينتش+٢ | غرينتش+٢ | UTC+0200 |
 | ar-LB | ٠٩:٢٨:٥١ غرينتش+٢ | غرينتش+٢ | UTC+0200 |
 | ar-LY | 09:28:51 غرينتش+2 | غرينتش+2 | UTC+0200 |
 | ar-MA | 9:28:51 غرينتش+2 | غرينتش+2 | UTC+0200 |
 | ar-OM | ٠٩:٢٨:٥١ غرينتش+٢ | غرينتش+٢ | UTC+0200 |
 | ar-QA | ٠٩:٢٨:٥١ غرينتش+٢ | غرينتش+٢ | UTC+0200 |
 | ar-SA | ٠٩:٢٨:٥١ غرينتش+٢ | غرينتش+٢ | UTC+0200 |
 | ar-SD | ٠٩:٢٨:٥١ غرينتش+٢ | غرينتش+٢ | UTC+0200 |
 | ar-SY | ٠٩:٢٨:٥١ غرينتش+٢ | غرينتش+٢ | UTC+0200 |
 | ar-TN | 09:28:51 غرينتش+2 | غرينتش+2 | UTC+0200 |
 | ar-YE | ٠٩:٢٨:٥١ غرينتش+٢ | غرينتش+٢ | UTC+0200 |
 | bg-BG | 9:28:51 ч. Гринуич+2 | ч. | UTC+0200 |
 | bn-BD | ০৯:২৮:৫১ GMT +২ | GMT | UTC+0200 |
 | bn-IN | ০৯:২৮:৫১ GMT +২ | GMT | UTC+0200 |
 | bs-Latn-BA | 9:28:51 CEST | CEST | UTC+0200 |
 | et-EE | 9:28:51 GMT +2 | GMT | UTC+0200 |
 | eu-ES | 9:28:51 (CEST) | (CEST) | UTC+0200 |
 | fa-IR | ۹:۲۸:۵۱ (+۲ گرینویچ) | (+۲ | UTC+0200 |
 | fr-BE | 9 h 28 min 51 s UTC+2 | h | UTC+0200 |
 | fr-CA | 9 h 28 min 51 s UTC+2 | h | UTC+0200 |
 | he-IL | 9:28:51 GMT+2 | GMT+2 | UTC+0200 |
 | iw-IL | 9:28:51 GMT+2 | GMT+2 | UTC+0200 |
 | km-KH | 09:28:51 ម៉ោងសកល +2 | ម៉ោងសកល | UTC+0200 |
 | ko-KR | 9시 28분 51초 GMT+2 | 28분 | UTC+0200 |
 | lo-LA | 9 ໂມງ 28 ນາທີ 51 ວິນາທີ GMT+2 | ໂມງ | UTC+0200 |
 | ml-IN | 09:28:51 ജിഎംടി +2 | ജിഎംടി | UTC+0200 |
 | mn-MN | 9:28:51 (GMT+2) | (GMT+2) | UTC+0200 |
 | mn-Mong-CN | 9:28:52 GMT+2 | GMT+2 | UTC+0200 |
 | mr-IN | ०९:२८:५२ [GMT]+२ | [GMT]+२ | UTC+0200 |
 | prs-AF | 9:28:52 GMT+2 | GMT+2 | UTC+0200 |
 | ps-AF | ۹:۲۸:۵۲ (GMT+۲) | (GMT+۲) | UTC+0200 |
 | sa-IN | ०९:२८:५२ जी.एम.टी. +२ | जी.एम.टी. | UTC+0200 |
 | se-FI | 9:28:52 CEST | CEST | UTC+0200 |
 | si-LK | 9.28.52 ග්‍රිමවේ+2 | ග්‍රිමවේ+2 | UTC+0200 |
 | sw-KE | 9:28:52 GMT +2 | GMT | UTC+0200 |
 | tg-Cyrl-TJ | 9:28:52 Вақти GMT +2 | Вақти | UTC+0200 |
 | th-TH | 9 นาฬิกา 28 นาที 52 วินาที GMT+2 | นาฬิกา | UTC+0200 |
 | ur-PK | 09:28:52 GMT +2 | GMT | UTC+0200 |
 | uz-Cyrl-UZ | 9:28:52 (GMT+2) | (GMT+2) | UTC+0200 |
 | uz-Latn-UZ | 9:28:52 (GMT+2) | (GMT+2) | UTC+0200 |
 | uz-uz | 9:28:52 (GMT+2) | (GMT+2) | UTC+0200 |
 | zh-CN | GMT+2 9:28:52 | 9:28:52 | UTC+0200 |
 | zh-HK | 09:28:52 [GMT+2] | [GMT+2] | UTC+0200 |
 | zh-MO | 09:28:52 [GMT+2] | [GMT+2] | UTC+0200 |
 | zh-SG | GMT+2 09:28:52 | 09:28:52 | UTC+0200 |
 | zh-TW | 09:28:52 [GMT+2] | [GMT+2] | UTC+0200 |

## Notes
The following scripts have been used for testing:

`date-tz.js`
```JavaScript
var extractZone = (timezoneOffset) => {
  // Why inverse sign?
  // Read here https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset
  const sign = timezoneOffset >= 0 ? "-" : "+";

  const absOffset = Math.abs(timezoneOffset)
  const hours = String(Math.floor(absOffset / 60)).padStart(2, "0");
  const minutes = String(absOffset % 60).padStart(2, "0");

  return `UTC${sign}${hours}${minutes}`;
}

const date = new Date();

const emscriptenFormattedDate = date.toLocaleTimeString(undefined, {hour12:false, timeZoneName:'short'})
const emscriptenZone = emscriptenFormattedDate.split(' ')[1];
const fixedZone = extractZone(date.getTimezoneOffset());

console.log(`| ${process.env.LC_ALL} | ${emscriptenFormattedDate} | ${emscriptenZone} | ${fixedZone} | `);
```

`test-tz.sh`
```bash
#!/bin/bash
LOCALES="fr-FR am-ET ar-AE ar-BH ar-DZ ar-EG ar-IQ ar-JO ar-KW ar-LB ar-LY ar-MA ar-OM ar-QA ar-SA ar-SD ar-SY ar-TN ar-YE bg-BG bn-BD bn-IN bs-Latn-BA et-EE eu-ES fa-IR fr-BE fr-CA he-IL iw-IL km-KH ko-KR lo-LA ml-IN mn-MN mn-Mong-CN mr-IN prs-AF ps-AF sa-IN se-FI si-LK sw-KE tg-Cyrl-TJ th-TH ur-PK uz-Cyrl-UZ uz-Latn-UZ uz-uz zh-CN zh-HK zh-MO zh-SG zh-TW"
for LOCAL in $LOCALES; do
  LC_ALL=$LOCAL node ./date-tz.js
done
```

## See also
https://github.com/emscripten-core/emscripten/pull/21596