### PR TITLE
Fix partial write case when using _fd_write/doWritev/writev

### DIFF
--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -223,7 +223,10 @@ var WasiLibrary = {
       var curr = FS.write(stream, HEAP8, ptr, len, offset);
       if (curr < 0) return -1;
       ret += curr;
-      if (curr < len) break; // no more space to write
+      if (curr < len) {
+        // No more space to write.
+        break;
+      }
       if (typeof offset != 'undefined') {
         offset += curr;
       }

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -223,6 +223,7 @@ var WasiLibrary = {
       var curr = FS.write(stream, HEAP8, ptr, len, offset);
       if (curr < 0) return -1;
       ret += curr;
+      if (curr < len) break; // no more space to write
       if (typeof offset != 'undefined') {
         offset += curr;
       }

--- a/test/fs/test_writev_partial_write.c
+++ b/test/fs/test_writev_partial_write.c
@@ -68,7 +68,9 @@ void test_writev_direct(void) {
 // and is included here as this code most closely matches the original bug
 // report
 void test_via_stdio(void) {
-  FILE* f = fopen("/device", "w");
+  // XXX: We open in append mode because truncating JS based files is not
+  // supported yet. See #22262
+  FILE* f = fopen("/device", "a");
   assert(f);
   // Use line buffering. The bug is exposed with line buffering because with
   // line buffering two entries in __stdio_write's iovs are used.

--- a/test/fs/test_writev_partial_write.c
+++ b/test/fs/test_writev_partial_write.c
@@ -70,7 +70,11 @@ void test_writev_direct(void) {
 void test_via_stdio(void) {
   // XXX: We open in append mode because truncating JS based files is not
   // supported yet. See #22262
+#ifdef WASMFS
   FILE* f = fopen("/device", "a");
+#else
+  FILE* f = fopen("/device", "w");
+#endif
   assert(f);
   // Use line buffering. The bug is exposed with line buffering because with
   // line buffering two entries in __stdio_write's iovs are used.

--- a/test/fs/test_writev_partial_write.c
+++ b/test/fs/test_writev_partial_write.c
@@ -16,8 +16,7 @@
 
 EM_JS_DEPS(main, "$ERRNO_CODES");
 
-int main() {
-
+void setup(void) {
  EM_ASM(
     var device = FS.makedev(80, 0);
     FS.registerDevice(device, {
@@ -32,53 +31,58 @@ int main() {
     });
     FS.mkdev('/device', device);
   );
+}
 
-  // Run the test with writev directly
-  {
-    int fd = open("/device", O_WRONLY);
-    assert(fd);
-    struct iovec iovs[] = {{.iov_base = "ABC", .iov_len = 3},
-                           {.iov_base = "XYZ", .iov_len = 3}};
-    struct iovec* iov = iovs;
+// Run the test with writev directly
+void test_writev_direct(void) {
+  int fd = open("/device", O_WRONLY);
+  assert(fd);
+  struct iovec iovs[] = {{.iov_base = "ABC", .iov_len = 3},
+                         {.iov_base = "XYZ", .iov_len = 3}};
+  struct iovec* iov = iovs;
 
-    size_t rem = iov[0].iov_len + iov[1].iov_len;
-    int iovcnt = 2;
-    ssize_t cnt;
-    for (;;) {
-      cnt = writev(fd, iov, iovcnt);
-      assert(cnt >= 0);
-      if (cnt == rem) {
-        // All data written
-        break;
-      }
-      rem -= cnt;
-      if (cnt > iov[0].iov_len) {
-        cnt -= iov[0].iov_len;
-        iov++;
-        iovcnt--;
-      }
-      iov[0].iov_base = (char*)iov[0].iov_base + cnt;
-      iov[0].iov_len -= cnt;
+  size_t rem = iov[0].iov_len + iov[1].iov_len;
+  int iovcnt = 2;
+  ssize_t cnt;
+  for (;;) {
+    cnt = writev(fd, iov, iovcnt);
+    assert(cnt >= 0);
+    if (cnt == rem) {
+      // All data written
+      break;
     }
-
-    close(fd);
+    rem -= cnt;
+    if (cnt > iov[0].iov_len) {
+      cnt -= iov[0].iov_len;
+      iov++;
+      iovcnt--;
+    }
+    iov[0].iov_base = (char*)iov[0].iov_base + cnt;
+    iov[0].iov_len -= cnt;
   }
 
-  // Run the test using stdio, this test is dependent on specific buffering used
-  // and is included here as this code most closely matches the original bug
-  // report
-  {
-    FILE* f = fopen("/device", "w");
-    assert(f);
-    // Use line buffering. The bug is exposed with line buffering because with
-    // line buffering two entries in __stdio_write's iovs are used.
-    setvbuf(f, NULL, _IOLBF, 0);
-    fputs("abc", f);
-    fputs("\n", f);
-    fflush(f);
-    fclose(f);
-  }
+  close(fd);
+}
 
+// Run the test using stdio, this test is dependent on specific buffering used
+// and is included here as this code most closely matches the original bug
+// report
+void test_via_stdio(void) {
+  FILE* f = fopen("/device", "w");
+  assert(f);
+  // Use line buffering. The bug is exposed with line buffering because with
+  // line buffering two entries in __stdio_write's iovs are used.
+  setvbuf(f, NULL, _IOLBF, 0);
+  fputs("abc", f);
+  fputs("\n", f);
+  fflush(f);
+  fclose(f);
+}
+
+int main() {
+  setup();
+  test_writev_direct();
+  test_via_stdio();
   printf("done\n");
   return 0;
 }

--- a/test/fs/test_writev_partial_write.c
+++ b/test/fs/test_writev_partial_write.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Emscripten Authors.  All rights reserved.
+ * Copyright 2024 The Emscripten Authors.  All rights reserved.
  * Emscripten is available under two separate licenses, the MIT license and the
  * University of Illinois/NCSA Open Source License.  Both these licenses can be
  * found in the LICENSE file.

--- a/test/fs/test_writev_partial_write.c
+++ b/test/fs/test_writev_partial_write.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#include <emscripten.h>
+
+EM_JS_DEPS(main, "$ERRNO_CODES");
+
+int main() {
+
+ EM_ASM(
+    var device = FS.makedev(80, 0);
+    FS.registerDevice(device, {
+      write: function(stream, buffer, offset, length, pos) {
+        if (length === 0) {
+          return 0;
+        }
+        // Only do a partial write of one byte each time
+        out('TO DEVICE: ' + JSON.stringify(String.fromCharCode(buffer[offset])));
+        return 1;
+      }
+    });
+    FS.mkdev('/device', device);
+  );
+
+  // Run the test with writev directly
+  {
+    int fd = open("/device", O_WRONLY);
+    assert(fd);
+    struct iovec iovs[] = {{.iov_base = "ABC", .iov_len = 3},
+                           {.iov_base = "XYZ", .iov_len = 3}};
+    struct iovec* iov = iovs;
+
+    size_t rem = iov[0].iov_len + iov[1].iov_len;
+    int iovcnt = 2;
+    ssize_t cnt;
+    for (;;) {
+      cnt = writev(fd, iov, iovcnt);
+      assert(cnt >= 0);
+      if (cnt == rem) {
+        // All data written
+        break;
+      }
+      rem -= cnt;
+      if (cnt > iov[0].iov_len) {
+        cnt -= iov[0].iov_len;
+        iov++;
+        iovcnt--;
+      }
+      iov[0].iov_base = (char*)iov[0].iov_base + cnt;
+      iov[0].iov_len -= cnt;
+    }
+
+    close(fd);
+  }
+
+  // Run the test using stdio, this test is dependent on specific buffering used
+  // and is included here as this code most closely matches the original bug
+  // report
+  {
+    FILE* f = fopen("/device", "w");
+    assert(f);
+    // Use line buffering. The bug is exposed with line buffering because with
+    // line buffering two entries in __stdio_write's iovs are used.
+    setvbuf(f, NULL, _IOLBF, 0);
+    fputs("abc", f);
+    fputs("\n", f);
+    fflush(f);
+    fclose(f);
+  }
+
+  printf("done\n");
+  return 0;
+}

--- a/test/fs/test_writev_partial_write.out
+++ b/test/fs/test_writev_partial_write.out
@@ -1,0 +1,11 @@
+TO DEVICE: "A"
+TO DEVICE: "B"
+TO DEVICE: "C"
+TO DEVICE: "X"
+TO DEVICE: "Y"
+TO DEVICE: "Z"
+TO DEVICE: "a"
+TO DEVICE: "b"
+TO DEVICE: "c"
+TO DEVICE: "\n"
+done

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5942,6 +5942,10 @@ Module.onRuntimeInitialized = () => {
     self.set_setting('FORCE_FILESYSTEM')
     self.do_runf('fs/test_writev.c', 'success')
 
+  def test_fs_writev_partial_write(self):
+    self.set_setting('FORCE_FILESYSTEM')
+    self.do_run_in_out_file_test('fs/test_writev_partial_write.c')
+
   def test_fs_64bit(self):
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5942,10 +5942,6 @@ Module.onRuntimeInitialized = () => {
     self.set_setting('FORCE_FILESYSTEM')
     self.do_runf('fs/test_writev.c', 'success')
 
-  def test_fs_writev_partial_write(self):
-    self.set_setting('FORCE_FILESYSTEM')
-    self.do_run_in_out_file_test('fs/test_writev_partial_write.c')
-
   def test_fs_64bit(self):
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15029,5 +15029,6 @@ addToLibrary({
     self.assertContained('(before) AF_INET=2', stderr)
     self.assertContained('(after) AF_INET=42', stderr)
 
+  @also_with_wasmfs
   def test_fs_writev_partial_write(self):
     self.do_run_in_out_file_test('fs/test_writev_partial_write.c')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15030,5 +15030,4 @@ addToLibrary({
     self.assertContained('(after) AF_INET=42', stderr)
 
   def test_fs_writev_partial_write(self):
-    self.set_setting('FORCE_FILESYSTEM')
     self.do_run_in_out_file_test('fs/test_writev_partial_write.c')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15031,4 +15031,5 @@ addToLibrary({
 
   @also_with_wasmfs
   def test_fs_writev_partial_write(self):
+    self.set_setting('FORCE_FILESYSTEM')
     self.do_run_in_out_file_test('fs/test_writev_partial_write.c')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15028,3 +15028,7 @@ addToLibrary({
     stderr = self.run_process([EMCC, test_file('hello_world.c'), '--js-library', test_file('other/test_extra_struct_info.js')], stderr=PIPE).stderr
     self.assertContained('(before) AF_INET=2', stderr)
     self.assertContained('(after) AF_INET=42', stderr)
+
+  def test_fs_writev_partial_write(self):
+    self.set_setting('FORCE_FILESYSTEM')
+    self.do_run_in_out_file_test('fs/test_writev_partial_write.c')


### PR DESCRIPTION
doWritev iterates through the iovs structure writing the data for each entry. The bug fixed here is that if a write does not write all data, the loop continues. If the subsequent write also accepts data, it has accepted data out of order.

Without the fix to doWritev this new test outputs:

```
TO DEVICE: "A"
TO DEVICE: "X"
TO DEVICE: "C"
TO DEVICE: "X"
TO DEVICE: "Y"
TO DEVICE: "Z"
TO DEVICE: "a"
TO DEVICE: "\n"
TO DEVICE: "c"
TO DEVICE: "\n"
done
```

Fixes #22258