### PR TITLE
Fix copy-paste error in the comment

### DIFF
--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -159,7 +159,7 @@ static __wasi_errno_t writeAtOffset(OffsetHandling setOffset,
     // The write was successful.
     bytesWritten += result;
     if (result < len) {
-      // The read was short, so stop here.
+      // The write was short, so stop here.
       break;
     }
   }


### PR DESCRIPTION
This is the same code as the read method, but as this is in the write method it should say "write" in this comment.

xref: https://github.com/emscripten-core/emscripten/pull/22261#discussion_r1683684192