### PR TITLE
Prevent closure mangling of Module properties in MODULARIZE mode

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -235,6 +235,17 @@ var id;
  * Used in MODULARIZE mode as the name of the incoming module argument.
  * This is generated outside of the code we pass to closure so from closure's
  * POV this is "extern".
+ * @type {{
+ *   noImageDecoding: boolean,
+ *   noAudioDecoding: boolean,
+ *   noWasmDecoding: boolean,
+ *   canvas: HTMLCanvasElement,
+ *   ctx: Object,
+ *   dataFileDownloads: Object,
+ *   preloadResults: Object,
+ *   useWebGL: boolean,
+ *   expectedDataFileDownloads: number,
+ * }}
  */
 var moduleArg;
 


### PR DESCRIPTION
Avoids that Closure compiler would rename/mangle `noImageDecoding`, `noAudioDecoding`, `noWasmDecoding`, etc., in `MODULARIZE` mode.

Before:
```console
$ emcc test/hello_world.c -sMODULARIZE --closure=1 --use-preload-plugins
$ grep noImageDecoding a.out.js || echo "Closure mangled noImageDecoding"
Closure mangled noImageDecoding
```

After:
```console
$ emcc test/hello_world.c -sMODULARIZE --closure=1 --use-preload-plugins
$ grep noImageDecoding a.out.js || echo "Closure mangled noImageDecoding"
      return !f.noImageDecoding && /\.(jpg|jpeg|png|bmp)$/i.test(c);
```

Note: these type declarations need to be kept in-sync with:
https://github.com/emscripten-core/emscripten/blob/eba870222fbd2e2bc0488de7d74a232a9a590a71/src/shell.js#L27-L37