### PR TITLE
[contrib.glfw3] new version 3.4.0.20240727

### DIFF
--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -6,8 +6,8 @@
 import os
 from typing import Dict
 
-TAG = '3.4.0.20240627'
-HASH = '6598834deece7087fd5dda14ec6d410ae651c39b9955eb050dd736a7d3eb650075fc69cf70340f4f0514bef63723a5bbcc315397ec44ba7cab46e59fa137e27f'
+TAG = '3.4.0.20240727'
+HASH = 'aa90c76e0d87166c1db13d5219a47af6bd2e690d30e3528d4d8993b45e5f699c4f94ad3f0ca77be096807d68efe3189ffd21985dae072b46c9039060e186a58c'
 
 # contrib port information (required)
 URL = 'https://github.com/pongasoft/emscripten-glfw'


### PR DESCRIPTION
Release notes for the changes

- Introduced C++ API (namespace `emscripten::glfw3`) included with `GLFW3/emscripten_glfw3.h`:
  - provides a more correct API with sensible defaults (ex: `std::string_view` / `std::optional<std::string_view>` 
    vs `char const *` which may or may not be `nullptr`)
  - allow for C++ only API (ex: `std::future`)
  - the C API is still available if you would rather stick to it
- Implemented  `emscripten::glfw3::GetClipboardString` (C++ only) which provides a way of fetching the global
  clipboard in a browser environment (`glfwGetClipboardString` is not the right API due to the asynchronous nature   of the underlying platform API).
- The cursor position is no longer clamped to the window size, and as a result, can have negative values or values
  greater than the window size.
  Note that GLFW implements a similar behavior on the macOS desktop platform.
- Implemented `glfwSetWindowPosCallback`
- Added support for GLFW Window Attribute `GLFW_HOVERED`
- Fixed [#6](https://github.com/pongasoft/emscripten-glfw/issues/6): _`emscripten_glfw_make_canvas_resizable` does not clean up properly_.
- Fixed an issue with opacity: when using opacity, the handle is not working unless its z-index is higher than the 
  canvas z-index
