### PR TITLE
Remove support for MINIFY_HTML

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,9 @@ See docs/process.md for more on how version tagging works.
   is only useful under very specific circumstances, and has some downsides, so
   disabling it by default makes sense. (#22257)
 - Add WebP (`.webp`) decoding support in file preloading. (#22282)
+- The `MINIFY_HTML` settings, along with the internal use of terser to minify
+  html output was removed.  Folks who want to run terser of their html can
+  continue to do so via an explict separate build step. (#22297)
 
 3.1.64 - 07/22/24
 -----------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
         "@babel/core": "^7.24.7",
         "@babel/preset-env": "^7.24.7",
         "acorn": "^8.12.0",
-        "google-closure-compiler": "20230802.0.0",
-        "html-minifier-terser": "7.2.0"
+        "google-closure-compiler": "20230802.0.0"
       },
       "devDependencies": {
         "es-check": "^7.2.1",
@@ -1852,6 +1851,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
       "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -2379,7 +2379,8 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -2388,15 +2389,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2465,25 +2457,6 @@
       "dev": true,
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/clean-css": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
-      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
-    },
-    "node_modules/clean-css/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/clone": {
@@ -2668,15 +2641,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.807",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.807.tgz",
@@ -2699,17 +2663,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/envinfo": {
@@ -3461,34 +3414,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/html-minifier-terser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "clean-css": "~5.3.2",
-        "commander": "^10.0.0",
-        "entities": "^4.4.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.15.1"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/html-minifier-terser/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -3867,14 +3792,6 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3981,15 +3898,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
@@ -4077,15 +3985,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4096,15 +3995,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-exists": {
@@ -4396,14 +4286,6 @@
         "jsesc": "bin/jsesc"
       }
     },
-    "node_modules/relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -4624,6 +4506,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -4633,6 +4516,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4713,6 +4597,7 @@
       "version": "5.26.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
       "integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -4763,7 +4648,8 @@
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "node_modules/text-hex": {
       "version": "1.0.0",
@@ -4805,11 +4691,6 @@
       "engines": {
         "node": ">= 14.0.0"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6488,6 +6369,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
       "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+      "dev": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -6922,22 +6804,14 @@
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
-    },
-    "camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "requires": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
     },
     "caniuse-lite": {
       "version": "1.0.30001636",
@@ -6975,21 +6849,6 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "dev": true
-    },
-    "clean-css": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
-      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
-      "requires": {
-        "source-map": "~0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
     },
     "clone": {
       "version": "2.1.2",
@@ -7145,15 +7004,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "electron-to-chromium": {
       "version": "1.4.807",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.807.tgz",
@@ -7174,11 +7024,6 @@
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
       }
-    },
-    "entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "envinfo": {
       "version": "7.11.0",
@@ -7710,27 +7555,6 @@
         "function-bind": "^1.1.2"
       }
     },
-    "html-minifier-terser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-      "requires": {
-        "camel-case": "^4.1.2",
-        "clean-css": "~5.3.2",
-        "commander": "^10.0.0",
-        "entities": "^4.4.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.15.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
-        }
-      }
-    },
     "ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -8012,14 +7836,6 @@
         "triple-beam": "^1.3.0"
       }
     },
-    "lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "requires": {
-        "tslib": "^2.0.3"
-      }
-    },
     "lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -8105,15 +7921,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "requires": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node-releases": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
@@ -8180,15 +7987,6 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
-    "param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8196,15 +7994,6 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
-      }
-    },
-    "pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "path-exists": {
@@ -8417,11 +8206,6 @@
         }
       }
     },
-    "relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
-    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -8573,6 +8357,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -8581,7 +8366,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -8637,6 +8423,7 @@
       "version": "5.26.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
       "integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
+      "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -8647,7 +8434,8 @@
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
         }
       }
     },
@@ -8695,11 +8483,6 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
       "dev": true
-    },
-    "tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "@babel/core": "^7.24.7",
     "@babel/preset-env": "^7.24.7",
     "acorn": "^8.12.0",
-    "google-closure-compiler": "20230802.0.0",
-    "html-minifier-terser": "7.2.0"
+    "google-closure-compiler": "20230802.0.0"
   },
   "scripts": {
     "lint": "eslint --ext .js --ext .mjs .",

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -3061,20 +3061,6 @@ size if your application does not need support for deferred calls.
 
 Default value: true
 
-.. _minify_html:
-
-MINIFY_HTML
-===========
-
-Specifies whether the generated .html file is run through html-minifier. The
-set of optimization passes run by html-minifier depends on debug and
-optimization levels. In -g2 and higher, no minification is performed. In -g1,
-minification is done, but whitespace is retained. Minification requires at
-least -O1 or -Os to be used. Pass -sMINIFY_HTML=0 to explicitly choose to
-disable HTML minification altogether.
-
-Default value: true
-
 .. _maybe_wasm2js:
 
 MAYBE_WASM2JS

--- a/src/settings.js
+++ b/src/settings.js
@@ -1995,15 +1995,6 @@ var DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = true;
 // [link]
 var HTML5_SUPPORT_DEFERRING_USER_SENSITIVE_REQUESTS = true;
 
-// Specifies whether the generated .html file is run through html-minifier. The
-// set of optimization passes run by html-minifier depends on debug and
-// optimization levels. In -g2 and higher, no minification is performed. In -g1,
-// minification is done, but whitespace is retained. Minification requires at
-// least -O1 or -Os to be used. Pass -sMINIFY_HTML=0 to explicitly choose to
-// disable HTML minification altogether.
-// [link]
-var MINIFY_HTML = true;
-
 // Whether we *may* be using wasm2js. This compiles to wasm normally, but lets
 // you run wasm2js *later* on the wasm, and you can pick between running the
 // normal wasm or that wasm2js code. For details of how to do that, see the
@@ -2257,4 +2248,5 @@ var LEGACY_SETTINGS = [
   ['MIN_IE_VERSION', [0x7FFFFFFF], 'No longer supported'],
   ['WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG', [0], 'No longer supported'],
   ['AUTO_ARCHIVE_INDEXES', [0, 1], 'No longer needed'],
+  ['MINIFY_HTML', [0], 'No longer supported'],
 ];

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.html": 552,
-  "a.html.gz": 380,
+  "a.html": 955,
+  "a.html.gz": 567,
   "a.js": 7072,
   "a.js.gz": 2997,
   "a.wasm": 11586,
   "a.wasm.gz": 5782,
-  "total": 19210,
-  "total_gz": 9159
+  "total": 19613,
+  "total_gz": 9346
 }

--- a/test/code_size/hello_wasm_worker_wasm.json
+++ b/test/code_size/hello_wasm_worker_wasm.json
@@ -1,12 +1,12 @@
 {
-  "a.html": 618,
-  "a.html.gz": 384,
+  "a.html": 1038,
+  "a.html.gz": 578,
   "a.js": 665,
   "a.js.gz": 455,
   "a.ww.js": 115,
   "a.ww.js.gz": 127,
   "a.wasm": 1848,
   "a.wasm.gz": 1046,
-  "total": 3246,
-  "total_gz": 2012
+  "total": 3666,
+  "total_gz": 2206
 }

--- a/test/code_size/hello_webgl2_wasm.json
+++ b/test/code_size/hello_webgl2_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.html": 454,
-  "a.html.gz": 328,
+  "a.html": 1107,
+  "a.html.gz": 660,
   "a.js": 4521,
   "a.js.gz": 2308,
   "a.wasm": 10399,
   "a.wasm.gz": 6695,
-  "total": 15374,
-  "total_gz": 9331
+  "total": 16027,
+  "total_gz": 9663
 }

--- a/test/code_size/hello_webgl2_wasm2js.json
+++ b/test/code_size/hello_webgl2_wasm2js.json
@@ -1,8 +1,8 @@
 {
-  "a.html": 346,
-  "a.html.gz": 262,
+  "a.html": 715,
+  "a.html.gz": 437,
   "a.js": 22193,
   "a.js.gz": 11583,
-  "total": 22539,
-  "total_gz": 11845
+  "total": 22908,
+  "total_gz": 12020
 }

--- a/test/code_size/hello_webgl_wasm.json
+++ b/test/code_size/hello_webgl_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.html": 454,
-  "a.html.gz": 328,
+  "a.html": 1107,
+  "a.html.gz": 660,
   "a.js": 4059,
   "a.js.gz": 2153,
   "a.wasm": 10399,
   "a.wasm.gz": 6695,
-  "total": 14912,
-  "total_gz": 9176
+  "total": 15565,
+  "total_gz": 9508
 }

--- a/test/code_size/hello_webgl_wasm2js.json
+++ b/test/code_size/hello_webgl_wasm2js.json
@@ -1,8 +1,8 @@
 {
-  "a.html": 346,
-  "a.html.gz": 262,
+  "a.html": 715,
+  "a.html.gz": 437,
   "a.js": 21719,
   "a.js.gz": 11419,
-  "total": 22065,
-  "total_gz": 11681
+  "total": 22434,
+  "total_gz": 11856
 }

--- a/test/code_size/hello_world_wasm.json
+++ b/test/code_size/hello_world_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.html": 552,
-  "a.html.gz": 380,
+  "a.html": 955,
+  "a.html.gz": 567,
   "a.js": 283,
   "a.js.gz": 244,
   "a.wasm": 103,
   "a.wasm.gz": 113,
-  "total": 938,
-  "total_gz": 737
+  "total": 1341,
+  "total_gz": 924
 }

--- a/test/code_size/hello_world_wasm2js.json
+++ b/test/code_size/hello_world_wasm2js.json
@@ -1,8 +1,8 @@
 {
-  "a.html": 323,
-  "a.html.gz": 253,
+  "a.html": 675,
+  "a.html.gz": 426,
   "a.js": 1052,
   "a.js.gz": 630,
-  "total": 1375,
-  "total_gz": 883
+  "total": 1727,
+  "total_gz": 1056
 }

--- a/test/code_size/math_wasm.json
+++ b/test/code_size/math_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.html": 552,
-  "a.html.gz": 380,
+  "a.html": 955,
+  "a.html.gz": 567,
   "a.js": 110,
   "a.js.gz": 125,
   "a.wasm": 2719,
   "a.wasm.gz": 1673,
-  "total": 3381,
-  "total_gz": 2178
+  "total": 3784,
+  "total_gz": 2365
 }

--- a/test/code_size/random_printf_wasm.json
+++ b/test/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 12690,
-  "a.html.gz": 6855,
-  "total": 12690,
-  "total_gz": 6855
+  "a.html": 12996,
+  "a.html.gz": 7080,
+  "total": 12996,
+  "total_gz": 7080
 }

--- a/test/code_size/random_printf_wasm2js.json
+++ b/test/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17277,
-  "a.html.gz": 7486,
-  "total": 17277,
-  "total_gz": 7486
+  "a.html": 17872,
+  "a.html.gz": 7854,
+  "total": 17872,
+  "total_gz": 7854
 }

--- a/tools/link.py
+++ b/tools/link.py
@@ -15,7 +15,6 @@ import re
 import shlex
 import stat
 import shutil
-import time
 from subprocess import PIPE
 from urllib.parse import quote
 
@@ -2581,50 +2580,6 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
   write_file(target, shell)
 
 
-def minify_html(filename):
-  if settings.DEBUG_LEVEL >= 2:
-    return
-
-  opts = []
-  # -g1 and greater retain whitespace and comments in source
-  if settings.DEBUG_LEVEL == 0:
-    opts += ['--collapse-whitespace',
-             '--collapse-inline-tag-whitespace',
-             '--remove-comments',
-             '--remove-tag-whitespace',
-             '--sort-attributes',
-             '--sort-class-name']
-  # -g2 and greater do not minify HTML at all
-  if settings.DEBUG_LEVEL <= 1:
-    opts += ['--decode-entities',
-             '--collapse-boolean-attributes',
-             '--remove-attribute-quotes',
-             '--remove-redundant-attributes',
-             '--remove-script-type-attributes',
-             '--remove-style-link-type-attributes',
-             '--use-short-doctype',
-             '--minify-css', 'true',
-             '--minify-js', 'true']
-
-  # html-minifier also has the following options, but they look unsafe for use:
-  # '--remove-optional-tags': removes e.g. <head></head> and <body></body> tags from the page.
-  #                           (Breaks at least browser.test_sdl2glshader)
-  # '--remove-empty-attributes': removes all attributes with whitespace-only values.
-  #                              (Breaks at least browser.test_asmfs_hello_file)
-  # '--remove-empty-elements': removes all elements with empty contents.
-  #                            (Breaks at least browser.test_asm_swapping)
-
-  logger.debug(f'minifying HTML file {filename}')
-  size_before = os.path.getsize(filename)
-  start_time = time.time()
-  shared.check_call(shared.get_npm_cmd('html-minifier-terser') + [filename, '-o', filename] + opts, env=shared.env_with_node_in_path())
-
-  elapsed_time = time.time() - start_time
-  size_after = os.path.getsize(filename)
-  delta = size_after - size_before
-  logger.debug(f'HTML minification took {elapsed_time:.2f} seconds, and shrunk size of {filename} from {size_before} to {size_after} bytes, delta={delta} ({delta * 100.0 / size_before:+.2f}%)')
-
-
 def generate_html(target, options, js_target, target_basename, wasm_target):
   logger.debug('generating HTML')
 
@@ -2632,9 +2587,6 @@ def generate_html(target, options, js_target, target_basename, wasm_target):
     generate_minimal_runtime_html(target, options, js_target, target_basename)
   else:
     generate_traditional_runtime_html(target, options, js_target, target_basename, wasm_target)
-
-  if settings.MINIFY_HTML and (settings.OPT_LEVEL >= 1 or settings.SHRINK_LEVEL >= 1):
-    minify_html(target)
 
   tools.line_endings.convert_line_endings_in_file(target, os.linesep, options.output_eol)
 


### PR DESCRIPTION
This setting has been causing some problems (see #22188) so I think we should just remove it.

My understanding is that most users of emscripten use it to generate JS and not html.  Going forward I'm tempted to also remove the `--shell-file` command line flag since I'm not sure there any many compelling use cases for a custom shell html.  While html generation is certainly useful for quick testing and examples, its not really something web sites are likely to use in production since they will likely have their own existing flow for build html.

Fixes: #22188