### PR TITLE
Avoid defining `Module` in `shell_minimal.js`. NFC

### DIFF
--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -16,10 +16,9 @@ if (!Module) /** @suppress{checkTypes}*/Module =
 #endif
   {"__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__":1};
 
-#elif ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL
-
-// When running on the web we expect Module to be defined externally, in the
-// HTML.  Otherwise we must define it here before its first use
+#else
+// Module must defined before its first use, but it may be defined
+// externally, e.g. in the html.
 var Module =
 #if SUPPORTS_GLOBALTHIS
   // As a small code size optimization, we can use 'globalThis' to refer to the global scope Module variable.
@@ -28,9 +27,6 @@ var Module =
   // Otherwise do a good old typeof check.
   typeof {{{ EXPORT_NAME }}} != 'undefined' ? {{{ EXPORT_NAME }}} : {};
 #endif
-
-#else
-var Module = {{{ EXPORT_NAME }}};
 #endif
 
 #if MODULARIZE && USE_READY_PROMISE

--- a/src/shell_minimal_runtime.html
+++ b/src/shell_minimal_runtime.html
@@ -3,12 +3,8 @@
 <canvas style='display:block; margin:auto;'></canvas>
 <script>
 
-#if !MODULARIZE
-var {{{ EXPORT_NAME }}} = {}
-#endif
-
 #if WASM == 2
-  var supportsWasm = window.WebAssembly && location.search.indexOf('_rwasm=0') < 0;
+var supportsWasm = window.WebAssembly && location.search.indexOf('_rwasm=0') < 0;
 #endif
 
 // Depending on the build flags that one uses, different files need to be downloaded

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.html": 552,
-  "a.html.gz": 380,
+  "a.html": 542,
+  "a.html.gz": 375,
   "a.js": 7072,
   "a.js.gz": 2997,
   "a.wasm": 11586,
   "a.wasm.gz": 5782,
-  "total": 19210,
-  "total_gz": 9159
+  "total": 19200,
+  "total_gz": 9154
 }

--- a/test/code_size/hello_wasm_worker_wasm.json
+++ b/test/code_size/hello_wasm_worker_wasm.json
@@ -1,12 +1,12 @@
 {
-  "a.html": 618,
-  "a.html.gz": 384,
+  "a.html": 608,
+  "a.html.gz": 380,
   "a.js": 665,
   "a.js.gz": 455,
   "a.ww.js": 115,
   "a.ww.js.gz": 127,
   "a.wasm": 1848,
   "a.wasm.gz": 1046,
-  "total": 3246,
-  "total_gz": 2012
+  "total": 3236,
+  "total_gz": 2008
 }

--- a/test/code_size/hello_world_wasm.json
+++ b/test/code_size/hello_world_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.html": 552,
-  "a.html.gz": 380,
+  "a.html": 542,
+  "a.html.gz": 375,
   "a.js": 283,
   "a.js.gz": 244,
   "a.wasm": 103,
   "a.wasm.gz": 113,
-  "total": 938,
-  "total_gz": 737
+  "total": 928,
+  "total_gz": 732
 }

--- a/test/code_size/hello_world_wasm2js.json
+++ b/test/code_size/hello_world_wasm2js.json
@@ -1,8 +1,8 @@
 {
-  "a.html": 323,
-  "a.html.gz": 253,
+  "a.html": 309,
+  "a.html.gz": 243,
   "a.js": 1052,
   "a.js.gz": 630,
-  "total": 1375,
-  "total_gz": 883
+  "total": 1361,
+  "total_gz": 873
 }

--- a/test/code_size/math_wasm.json
+++ b/test/code_size/math_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.html": 552,
-  "a.html.gz": 380,
+  "a.html": 542,
+  "a.html.gz": 375,
   "a.js": 110,
   "a.js.gz": 125,
   "a.wasm": 2719,
   "a.wasm.gz": 1673,
-  "total": 3381,
-  "total_gz": 2178
+  "total": 3371,
+  "total_gz": 2173
 }

--- a/test/code_size/random_printf_wasm.json
+++ b/test/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 12690,
-  "a.html.gz": 6855,
-  "total": 12690,
-  "total_gz": 6855
+  "a.html": 12680,
+  "a.html.gz": 6851,
+  "total": 12680,
+  "total_gz": 6851
 }

--- a/test/code_size/random_printf_wasm2js.json
+++ b/test/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17277,
-  "a.html.gz": 7486,
-  "total": 17277,
-  "total_gz": 7486
+  "a.html": 17267,
+  "a.html.gz": 7482,
+  "total": 17267,
+  "total_gz": 7482
 }


### PR DESCRIPTION
Instead we can just always use the same technique to define `Module` in `shell_minimal.js`, regardless of the target environment.

This simplifies the code and reduces code size.