### PR TITLE
Fix --emit-tsd when worker environment is required

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3353,6 +3353,14 @@ More info: https://emscripten.org
     self.emcc(test_file('other/embind_tsgen.cpp'), extra_args)
     self.assertFileContents(test_file('other/embind_tsgen_ignore_3.d.ts'), read_file('embind_tsgen.d.ts'))
 
+  def test_embind_tsgen_worker_env(self):
+    self.emcc_args += ['-lembind', '--emit-tsd', 'embind_tsgen.d.ts']
+    # Passing -sWASM_WORKERS or -sPROXY_TO_WORKER requires the 'worker' environment
+    # at link time. Verify that TS binding generation still works in this case.
+    for flag in ('-sWASM_WORKERS', '-sPROXY_TO_WORKER'):
+      self.emcc(test_file('other/embind_tsgen.cpp'), [flag])
+      self.assertFileContents(test_file('other/embind_tsgen.d.ts'), read_file('embind_tsgen.d.ts'))
+
   def test_embind_tsgen_test_embind(self):
     self.run_process([EMXX, test_file('embind/embind_test.cpp'),
                       '-lembind', '--emit-tsd', 'embind_tsgen_test_embind.d.ts',

--- a/tools/link.py
+++ b/tools/link.py
@@ -1940,7 +1940,8 @@ def run_embind_gen(wasm_target, js_syms, extra_settings):
   settings.PRE_JS_FILES = []
   settings.POST_JS_FILES = []
   # Force node since that is where the tool runs.
-  settings.ENVIRONMENT = 'node'
+  # When SHARED_MEMORY or PROXY_TO_WORKER are enabled, add the required 'worker' environment.
+  settings.ENVIRONMENT = 'node' + (',worker' if settings.SHARED_MEMORY or settings.PROXY_TO_WORKER else '')
   settings.MINIMAL_RUNTIME = 0
   # Required function to trigger TS generation.
   settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$callRuntimeCallbacks']


### PR DESCRIPTION
This PR fixes the following issue when combining `--emit-tsd` with `-sWASM_WORKERS` or `-sPROXY_TO_WORKER`:

```
$ echo 'int main(){}' > foo.c
$ emcc -sWASM_WORKERS -lembind --emit-tsd foo.d.ts foo.c
emcc: error: when building with multithreading enabled and a "-sENVIRONMENT=" directive is specified, it must include "worker" as a target! (Try e.g. -sENVIRONMENT=web,worker)
```

When `run_embind_gen` in `link.py` sets up a separate linking pass to generate the temporary executable that will emit bindings, it doesn't include the `worker` environment required when using `-sWASM_WORKERS` or `-sPROXY_TO_WORKER`. This PR simply adds the `worker` environment when either of these flags is present.

Note: It's not sufficient to set `settings.WASM_WORKERS = 0` in `run_embind_gen`, as linking the binding-emitting executable will fail if the code depends on any WASM_WORKERS features.