### PR TITLE
[contrib.glfw3] new project version 3.4.0.20240731

### DIFF
--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -38,6 +38,7 @@ opts: Dict[str, Union[str, bool]] = {
 
 port_name = 'contrib.glfw3'
 
+
 def get_lib_name(settings):
   return (f'lib_{port_name}-O{opts["optimizationLevel"]}' +
           ('-nw' if opts['disableWarning'] else '') +


### PR DESCRIPTION
This contains 2 new versions with the following release notes for the underlying project:

#### 3.4.0.20240731 - 2024-07-31

- Added `emscripten_glfw_get_clipboard_string` the C version of  `emscripten::glfw3::GetClipboardString` to
  retrieve the clipboard asynchronously
- Added a helper class `emscripten::glfw3::FutureClipboardString` to greatly simplify the more frequent use-cases
- `GetClipboardString::value()` now returns the internal clipboard in case of error, instead of throwing exception
- Added `optimizationLevel` option to the emscripten port

#### 3.4.0.20240727 - 2024-07-27

- Introduced C++ API (namespace `emscripten::glfw3`) included with `GLFW3/emscripten_glfw3.h`:
  - provides a more correct API with sensible defaults (ex: `std::string_view` / `std::optional<std::string_view>` 
    vs `char const *` which may or may not be `nullptr`)
  - allow for C++ only API (ex: `std::future`)
  - the C API is still available if you would rather stick to it
- Implemented  `emscripten::glfw3::GetClipboardString` which provides a way of fetching the global
  clipboard in a browser environment (`glfwGetClipboardString` is not the right API due to the asynchronous nature 
  of the underlying platform API).
- The cursor position is no longer clamped to the window size, and as a result, can have negative values or values
  greater than the window size.
  Note that GLFW implements a similar behavior on the macOS desktop platform.
- Implemented `glfwSetWindowPosCallback`
- Added support for GLFW Window Attribute `GLFW_HOVERED`
- Fixed [#6](https://github.com/pongasoft/emscripten-glfw/issues/6): _`emscripten_glfw_make_canvas_resizable` does not clean up properly_.
- Fixed an issue with opacity: when using opacity, the handle is not working unless its z-index is higher than the 
  canvas z-index

