### PR TITLE
Fix CheckTypeSize when flags imply shared memory

### DIFF
--- a/cmake/Modules/CheckTypeSize.cmake
+++ b/cmake/Modules/CheckTypeSize.cmake
@@ -113,7 +113,7 @@ function(__check_type_size_impl type var map builtin language)
   configure_file(${__check_type_size_dir}/CheckTypeSize.c.in ${src} @ONLY)
   try_compile(HAVE_${var} ${CMAKE_BINARY_DIR} ${src}
     COMPILE_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS}
-    LINK_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} "--oformat=wasm" "-sWASM=1"
+    LINK_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} "--oformat=bare" "-sWASM=1"
     CMAKE_FLAGS
       "-DCOMPILE_DEFINITIONS:STRING=${CMAKE_REQUIRED_FLAGS}"
       "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_REQUIRED_INCLUDES}"


### PR DESCRIPTION
This PR fixes emscripten's patched `CheckTypeSize` CMake module to work when compiler flags imply shared memory use.

Before this change, trying to configure a CMake project that uses `check_type_size` when compiler flags implied shared memory (e.g. `-sWASM_WORKERS`) caused an error:

```
usr/bin/cmake -E cmake_link_script CMakeFiles/cmTC_ae175.dir/link.txt --verbose=1
/.../emcc  -O3 -msimd128 -sWASM_WORKERS  @CMakeFiles/cmTC_ae175.dir/objects1 -o cmTC_ae175.js @CMakeFiles/cmTC_ae175.dir/linkLibs.rsp
error: library_pthread_stub.js: library_pthread_stub.js:11: #error "STANDALONE_WASM does not support shared memories yet"
```

This PR resolves the issue by changing `oformat` to `bare`, which skips the post-link phase. Type size information can still be extracted from the output.