### PR TITLE
Fix argument names in em_dlopen_callback declaration. NFC

### DIFF
--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -176,7 +176,7 @@ void emscripten_scan_stack(em_scan_func func);
 
 // Asynchronous version of dlopen.  Since WebAssembly module loading in general
 // is asynchronous the normal dlopen function can't be used in all situations.
-typedef void (*em_dlopen_callback)(void* handle, void* user_data);
+typedef void (*em_dlopen_callback)(void* user_data, void* handle);
 void emscripten_dlopen(const char *filename, int flags, void* user_data, em_dlopen_callback onsuccess, em_arg_callback_func onerror);
 
 // Promisified version of emscripten_dlopen


### PR DESCRIPTION
This matches the order in which the current implementation and the current tests expect that argument to be passed.  Ideally we would pass the dso handler first, but that would be breaking change.

Fixes: #22265