### PR TITLE
Fix gmtime etc in STANDALONE_WASM mode

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -446,15 +446,14 @@ addToLibrary({
 
 #endif
 
+#if !STANDALONE_WASM
   // ==========================================================================
   // assert.h
   // ==========================================================================
 
-#if !STANDALONE_WASM
   __assert_fail: (condition, filename, line, func) => {
     abort(`Assertion failed: ${UTF8ToString(condition)}, at: ` + [filename ? UTF8ToString(filename) : 'unknown filename', line, func ? UTF8ToString(func) : 'unknown function']);
   },
-#endif
 
   // ==========================================================================
   // time.h
@@ -595,6 +594,7 @@ addToLibrary({
     stringToUTF8(s, buf, 26);
     return buf;
   },
+#endif
 
 #if STACK_OVERFLOW_CHECK >= 2
   // Set stack limits used by binaryen's `StackCheck` pass.
@@ -626,6 +626,7 @@ addToLibrary({
     return ret;
   },
 
+#if !STANDALONE_WASM
   _tzset_js__deps: ['$stringToUTF8',
 #if ASSERTIONS
     '$lengthBytesUTF8',
@@ -686,6 +687,7 @@ addToLibrary({
       stringToUTF8(summerName, std_name, {{{ cDefs.TZNAME_MAX + 1 }}});
     }
   },
+#endif
 
   $MONTH_DAYS_REGULAR: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
   $MONTH_DAYS_LEAP: [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],

--- a/test/core/test_time.out
+++ b/test/core/test_time.out
@@ -1,6 +1,5 @@
 stime: -1
 tzname[0] set: 1
-tzname[1] set: 1
 sec: 43
 min: 22
 hour: 3
@@ -11,7 +10,6 @@ wday: 3
 yday: 358
 dst: 0
 off: 0
-zone: GMT
 timegm <-> gmtime: 1
 old year still: 102
 new year: 70
@@ -27,7 +25,6 @@ mktime updates parameter to be in range: 1
 mktime parameter is equivalent to localtime return: 1
 mktime guesses DST (winter): 1
 mktime guesses DST (summer): 1
-tbig: -1
 old year still: 102
 new year: 70
 time: 1

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2668,6 +2668,7 @@ The current type of b is: 9
   def test_tcgetattr(self):
     self.do_runf('termios/test_tcgetattr.c', 'success')
 
+  @also_with_standalone_wasm()
   def test_time(self):
     self.do_core_test('test_time.c')
     for tz in ['EST+05EDT', 'UTC+0', 'CET']:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2197,6 +2197,7 @@ class libstandalonewasm(MuslInternalLibrary):
     files += files_in_path(
         path='system/lib/libc/musl/src/time',
         filenames=['__secs_to_tm.c',
+                   '__tz.c',
                    'clock.c',
                    'clock_gettime.c',
                    'gettimeofday.c',


### PR DESCRIPTION
This was broken in #21379.

Replaces: #22276