### PR TITLE
Remove redundant NODEJS_CATCH_EXIT setting. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9244,7 +9244,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # Check that an unhandled promise rejection is propagated to the main thread
     # as an error.
     self.set_setting('PROXY_TO_PTHREAD')
-    self.set_setting('NODEJS_CATCH_EXIT', 0)
     self.emcc_args += ['--post-js', test_file('pthread/test_pthread_unhandledrejection.post.js')]
     self.do_runf('pthread/test_pthread_unhandledrejection.c', 'passed')
 


### PR DESCRIPTION
The default for this settings is 0 now.  This should have been part of #22257.