### PR TITLE
Move `useWebGL` from Module to Browser. NFC

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -104,6 +104,7 @@ var LibraryBrowser = {
 #endif
       }
     },
+    useWebGL: false,
     isFullscreen: false,
     pointerLock: false,
     moduleContextCreatedCallbacks: [],
@@ -309,7 +310,7 @@ var LibraryBrowser = {
 #endif
         Module.ctx = ctx;
         if (useWebGL) GL.makeContextCurrent(contextHandle);
-        Module.useWebGL = useWebGL;
+        Browser.useWebGL = useWebGL;
         Browser.moduleContextCreatedCallbacks.forEach((callback) => callback());
         Browser.init();
       }

--- a/src/library_egl.js
+++ b/src/library_egl.js
@@ -365,7 +365,7 @@ var LibraryEGL = {
 
       // Run callbacks so that GL emulation works
       GL.makeContextCurrent(EGL.context);
-      Module.useWebGL = true;
+      Browser.useWebGL = true;
       Browser.moduleContextCreatedCallbacks.forEach(function(callback) { callback() });
 
       // Note: This function only creates a context, but it shall not make it active.

--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -2821,7 +2821,7 @@ var LibraryGLEmulation = {
       err('WARNING: using emscripten GL immediate mode emulation. This is very limited in what it supports');
       GLImmediate.initted = true;
 
-      if (!Module.useWebGL) return; // a 2D canvas may be currently used TODO: make sure we are actually called in that case
+      if (!Browser.useWebGL) return; // a 2D canvas may be currently used TODO: make sure we are actually called in that case
 
       // User can override the maximum number of texture units that we emulate. Using fewer texture units increases runtime performance
       // slightly, so it is advantageous to choose as small value as needed.

--- a/src/shell.js
+++ b/src/shell.js
@@ -27,7 +27,6 @@ var Module = moduleArg;
 var /** @type {{
   canvas: HTMLCanvasElement,
   ctx: Object,
-  useWebGL: boolean,
 }}
  */ Module;
 if (!Module) /** @suppress{checkTypes}*/Module = {"__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__":1};


### PR DESCRIPTION
I can't find any documentation about why this might be exposed on the Module object.

It looks like it was first introduced just as a kind of global variable: 695e06078d