### PR TITLE
Move main out of the extern "C" block in test_rust_gxx_personality_v0

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13990,10 +13990,10 @@ int main() {
       #include <stdint.h>
       extern "C" {
         int __gxx_personality_v0(int version, void* actions, uint64_t exception_class, void* exception_object, void* context);
-        int main() {
-          __gxx_personality_v0(0, NULL, 0, NULL, NULL);
-          return 0;
-        }
+      }
+      int main() {
+        __gxx_personality_v0(0, NULL, 0, NULL, NULL);
+        return 0;
       }
     ''', assert_returncode=NON_ZERO, emcc_args=['-fexceptions'])
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/101853 started to enforce the C++ standard langauge that disallows main from being declared in a linkage specification.