### PR TITLE
Unify `also_with_wasmfs` decorator. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -363,6 +363,23 @@ def with_env_modify(updates):
   return decorated
 
 
+def also_with_wasmfs(f):
+  assert callable(f)
+
+  @wraps(f)
+  def metafunc(self, wasmfs, *args, **kwargs):
+    if wasmfs:
+      self.set_setting('WASMFS')
+      self.emcc_args.append('-DWASMFS')
+      f(self, *args, **kwargs)
+    else:
+      f(self, *args, **kwargs)
+
+  parameterize(metafunc, {'': (False,),
+                          'wasmfs': (True,)})
+  return metafunc
+
+
 def also_with_noderawfs(func):
   assert callable(func)
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -26,7 +26,8 @@ from common import RunnerCore, path_from_root, requires_native_clang, test_file,
 from common import skip_if, no_windows, no_mac, is_slow_test, parameterized, parameterize
 from common import env_modify, with_env_modify, disabled, flaky, node_pthreads, also_with_wasm_bigint
 from common import read_file, read_binary, requires_v8, requires_node, requires_wasm2js, requires_node_canary
-from common import compiler_for, crossplatform, no_4gb, no_2gb, also_with_minimal_runtime, also_with_noderawfs
+from common import compiler_for, crossplatform, no_4gb, no_2gb, also_with_minimal_runtime
+from common import also_with_noderawfs, also_with_wasmfs
 from common import with_all_eh_sjlj, with_all_sjlj, also_with_standalone_wasm, can_do_standalone, no_wasm64, requires_wasm_exnref
 from common import NON_ZERO, WEBIDL_BINDER, EMBUILDER, PYTHON
 import clang_native
@@ -145,21 +146,6 @@ def only_wasm2js(note=''):
 
   def decorated(f):
     return skip_if(f, 'is_wasm2js', note, negate=True)
-  return decorated
-
-
-def also_with_wasmfs(func):
-  def decorated(self):
-    func(self)
-    if self.get_setting('WASMFS'):
-      # Nothing more to test.
-      return
-    print('wasmfs')
-    if self.get_setting('STANDALONE_WASM'):
-      self.skipTest("test currently cannot run both with WASMFS and STANDALONE_WASM")
-    self.set_setting('WASMFS')
-    self.emcc_args = self.emcc_args.copy() + ['-DWASMFS']
-    func(self)
   return decorated
 
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -36,7 +36,7 @@ from common import env_modify, no_mac, no_windows, only_windows, requires_native
 from common import create_file, parameterized, NON_ZERO, node_pthreads, TEST_ROOT, test_file
 from common import compiler_for, EMBUILDER, requires_v8, requires_node, requires_wasm64, requires_node_canary
 from common import requires_wasm_exnref, crossplatform, with_all_eh_sjlj, with_all_sjlj
-from common import also_with_standalone_wasm, also_with_wasm2js, also_with_noderawfs
+from common import also_with_standalone_wasm, also_with_wasm2js, also_with_noderawfs, also_with_wasmfs
 from common import also_with_minimal_runtime, also_with_wasm_bigint, also_with_wasm64, flaky
 from common import EMTEST_BUILD_VERBOSE, PYTHON, WEBIDL_BINDER
 from common import requires_network, parameterize
@@ -108,23 +108,6 @@ def with_both_compilers(f):
   parameterize(f, {'': (EMCC,),
                    'emxx': (EMXX,)})
   return f
-
-
-def also_with_wasmfs(f):
-  assert callable(f)
-
-  @wraps(f)
-  def metafunc(self, wasmfs, *args, **kwargs):
-    if wasmfs:
-      self.set_setting('WASMFS')
-      self.emcc_args.append('-DWASMFS')
-      f(self, *args, **kwargs)
-    else:
-      f(self, *args, **kwargs)
-
-  parameterize(metafunc, {'': (False,),
-                          'wasmfs': (True,)})
-  return metafunc
 
 
 def wasmfs_all_backends(f):


### PR DESCRIPTION
This also means that also_with_wasmfs in test_core.py now used parameterization.