### PR TITLE
add PThread to runtime elements

### DIFF
--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -418,17 +418,21 @@ function exportRuntime() {
     'HEAPU64',
   ];
 
-  if (PTHREADS && ALLOW_MEMORY_GROWTH) {
-    runtimeElements.push(
-      'GROWABLE_HEAP_I8',
-      'GROWABLE_HEAP_U8',
-      'GROWABLE_HEAP_I16',
-      'GROWABLE_HEAP_U16',
-      'GROWABLE_HEAP_I32',
-      'GROWABLE_HEAP_U32',
-      'GROWABLE_HEAP_F32',
-      'GROWABLE_HEAP_F64',
-    );
+  if (PTHREADS) {
+    runtimeElements.push('PThread');
+
+    if (ALLOW_MEMORY_GROWTH) {
+      runtimeElements.push(
+        'GROWABLE_HEAP_I8',
+        'GROWABLE_HEAP_U8',
+        'GROWABLE_HEAP_I16',
+        'GROWABLE_HEAP_U16',
+        'GROWABLE_HEAP_I32',
+        'GROWABLE_HEAP_U32',
+        'GROWABLE_HEAP_F32',
+        'GROWABLE_HEAP_F64',
+      );
+    }
   }
   if (USE_OFFSET_CONVERTER) {
     runtimeElements.push('WasmOffsetConverter');


### PR DESCRIPTION
Since 37e1e68d516, PThread is no longer included in EXPORTED_RUNTIME_METHODS, since it's not necessary for emscripten.

Currently, exporting it by manually including it in EXPORTED_RUNTIME_METHODS when configuring
yields a warning: `warning: invalid item in EXPORTED_RUNTIME_METHODS: PThread`

However, nothing breaks and PThread can be used as normal. Thus, I think it would make sense to include 
it in runtimeElements to suppress this warning.