### PR TITLE
Remove TEST_MEMORY_GROWTH_FAILS. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -182,10 +182,6 @@ addToLibrary({
   },
 #endif // ABORTING_MALLOC
 
-#if TEST_MEMORY_GROWTH_FAILS
-  $growMemory: (size) => false,
-#else
-
   // Grows the wasm memory to the given byte size, and updates the JS views to
   // it. Returns 1 on success, 0 on error.
   $growMemory: (size) => {
@@ -215,7 +211,6 @@ addToLibrary({
     // implicit 0 return to save code size (caller will cast "undefined" into 0
     // anyhow)
   },
-#endif // ~TEST_MEMORY_GROWTH_FAILS
 
   emscripten_resize_heap__deps: [
     '$getHeapMax',

--- a/src/settings.js
+++ b/src/settings.js
@@ -2171,10 +2171,6 @@ var SIGNATURE_CONVERSIONS = [];
 // [link]
 var OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH = false;
 
-// Internal (testing only): Forces memory growing to fail.
-// [link]
-var TEST_MEMORY_GROWTH_FAILS = false;
-
 // For renamed settings the format is:
 // [OLD_NAME, NEW_NAME]
 // For removed settings (which now effectively have a fixed value and can no

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2113,7 +2113,8 @@ int main(int argc, char **argv) {
       self.skipTest('test needs to modify memory growth')
 
     self.set_setting('ALLOW_MEMORY_GROWTH')
-    self.set_setting('TEST_MEMORY_GROWTH_FAILS')
+    # Force memory growth to fail at runtime
+    self.add_pre_run('growMemory = (size) => false;')
     self.do_core_test('test_memorygrowth_3.c')
 
   @parameterized({

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6834,6 +6834,8 @@ int main() {
   })
   @also_with_wasm2js
   def test_failing_alloc(self, growth):
+    # Force memory growth to fail at runtime
+    self.add_pre_run('growMemory = (size) => false;')
     for pre_fail, post_fail, opts in [
       ('', '', []),
       ('EM_ASM( Module.temp = _sbrk() );', 'EM_ASM( assert(Module.temp === _sbrk(), "must not adjust brk when an alloc fails!") );', []),
@@ -6880,7 +6882,6 @@ int main() {
 }
 ''' % (pre_fail, post_fail))
         args = [EMXX, 'main.cpp', '-sEXPORTED_FUNCTIONS=_main,_sbrk', '-sINITIAL_MEMORY=16MB'] + opts + aborting_args
-        args += ['-sTEST_MEMORY_GROWTH_FAILS'] # In this test, force memory growing to fail
         if growth:
           args += ['-sALLOW_MEMORY_GROWTH']
         # growth disables aborting by default, but it can be overridden


### PR DESCRIPTION
We shouldn't be adding test-specific settings like this unless there is some really good reason.