### PR TITLE
Ensure POSIX path normalizing behavior under NODERAWFS

### DIFF
--- a/src/library_nodepath.js
+++ b/src/library_nodepath.js
@@ -14,11 +14,11 @@
 addToLibrary({
   $PATH: {
     isAbs: (path) => nodePath['isAbsolute'](path),
-    normalize: (path) => nodePath['normalize'](path),
+    normalize: (path) => nodePath['posix']['normalize'](path),
     dirname: (path) => nodePath['dirname'](path),
     basename: (path) => nodePath['basename'](path),
-    join: (...args) => nodePath['join'](...args),
-    join2: (l, r) => nodePath['join'](l, r),
+    join: (...args) => nodePath['posix']['join'](...args),
+    join2: (l, r) => nodePath['posix']['join'](l, r),
   },
   // The FS-using parts are split out into a separate object, so simple path
   // usage does not require the FS.

--- a/test/common.py
+++ b/test/common.py
@@ -383,6 +383,7 @@ def also_with_wasmfs(f):
 def also_with_noderawfs(func):
   assert callable(func)
 
+  @wraps(func)
   def metafunc(self, rawfs, *args, **kwargs):
     if rawfs:
       self.require_node()

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9640,6 +9640,7 @@ end
     self.assertContained('block "main" took', stderr)
 
   @also_with_wasmfs
+  @crossplatform
   def test_noderawfs(self):
     self.run_process([EMXX, test_file('fs/test_fopen_write.cpp'), '-sNODERAWFS'] + self.get_emcc_args())
     self.assertContained("read 11 bytes. Result: Hello data!", self.run_js('a.out.js'))


### PR DESCRIPTION
Avoids mangling `C:/tmp` to `C:\tmp`. Should be safe, the underlying Windows API can accept either the backslash or slash to separate directory and file components of a path.

See: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file

Ensures `NODERAWFS` compatibility on Windows that was regressed since #18163.