### PR TITLE
Use `@wraps` on all test decorators

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -247,6 +247,7 @@ def requires_native_clang(func):
 def requires_node(func):
   assert callable(func)
 
+  @wraps(func)
   def decorated(self, *args, **kwargs):
     self.require_node()
     return func(self, *args, **kwargs)
@@ -257,6 +258,7 @@ def requires_node(func):
 def requires_node_canary(func):
   assert callable(func)
 
+  @wraps(func)
   def decorated(self, *args, **kwargs):
     self.require_node_canary()
     return func(self, *args, **kwargs)
@@ -267,6 +269,7 @@ def requires_node_canary(func):
 def requires_wasm64(func):
   assert callable(func)
 
+  @wraps(func)
   def decorated(self, *args, **kwargs):
     self.require_wasm64()
     return func(self, *args, **kwargs)
@@ -277,6 +280,7 @@ def requires_wasm64(func):
 def requires_wasm_eh(func):
   assert callable(func)
 
+  @wraps(func)
   def decorated(self, *args, **kwargs):
     self.require_wasm_eh()
     return func(self, *args, **kwargs)
@@ -287,6 +291,7 @@ def requires_wasm_eh(func):
 def requires_wasm_exnref(func):
   assert callable(func)
 
+  @wraps(func)
   def decorated(self, *args, **kwargs):
     self.require_wasm_exnref()
     return func(self, *args, **kwargs)
@@ -297,6 +302,7 @@ def requires_wasm_exnref(func):
 def requires_v8(func):
   assert callable(func)
 
+  @wraps(func)
   def decorated(self, *args, **kwargs):
     self.require_v8()
     return func(self, *args, **kwargs)
@@ -316,6 +322,8 @@ def requires_wasm2js(f):
 
 
 def node_pthreads(f):
+  assert callable(f)
+
   @wraps(f)
   def decorated(self, *args, **kwargs):
     self.setup_node_pthreads()

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -41,6 +41,8 @@ EM_SIGABRT = 6
 
 
 def wasm_simd(f):
+  assert callable(f)
+
   @wraps(f)
   def decorated(self, *args, **kwargs):
     self.require_simd()
@@ -58,6 +60,9 @@ def wasm_simd(f):
 
 
 def wasm_relaxed_simd(f):
+  assert callable(f)
+
+  @wraps(f)
   def decorated(self):
     if self.get_setting('MEMORY64') == 2:
       self.skipTest('https://github.com/WebAssembly/binaryen/issues/4638')
@@ -70,6 +75,9 @@ def wasm_relaxed_simd(f):
 
 
 def needs_non_trapping_float_to_int(f):
+  assert callable(f)
+
+  @wraps(f)
   def decorated(self):
     if self.is_wasm2js():
       self.skipTest('wasm2js only supports MVP for now')
@@ -151,6 +159,9 @@ def only_wasm2js(note=''):
 
 # Similar to also_with_wasmfs, but also enables the full JS API
 def also_with_wasmfs_js(func):
+  assert callable(func)
+
+  @wraps(func)
   def decorated(self):
     func(self)
     print('wasmfs')
@@ -166,6 +177,7 @@ def also_with_wasmfs_js(func):
 def with_asyncify_and_jspi(f):
   assert callable(f)
 
+  @wraps(f)
   def metafunc(self, jspi):
     if jspi:
       self.set_setting('ASYNCIFY', 2)
@@ -186,6 +198,7 @@ def no_optimize(note=''):
   def decorator(func):
     assert callable(func)
 
+    @wraps(func)
     def decorated(self):
       if self.is_optimizing():
         self.skipTest(note)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -111,6 +111,9 @@ def with_both_compilers(f):
 
 
 def wasmfs_all_backends(f):
+  assert callable(f)
+
+  @wraps(f)
   def metafunc(self, backend):
     self.set_setting('WASMFS')
     self.emcc_args.append('-DWASMFS')


### PR DESCRIPTION
Without this the decorated function doesn't mirror properties of the underlying tests, which was breaking things like `@crossplatform`.

See #18163