### PR TITLE
[JSPI] Support using LLVM annotations to mark JSPI functions.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1980,7 +1980,7 @@ addToLibrary({
       if (funcPtr >= wasmTableMirror.length) wasmTableMirror.length = funcPtr + 1;
       wasmTableMirror[funcPtr] = func = wasmTable.get(funcPtr);
 #if ASYNCIFY == 2
-      if (Asyncify.isAsyncExport(func)) {
+      if (func && Asyncify.isAsyncExport(func)) {
         wasmTableMirror[funcPtr] = func = Asyncify.makeAsyncFunction(func);
       }
 #endif

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -258,6 +258,13 @@ var MINIFY_WHITESPACE = true;
 
 var ASYNCIFY_IMPORTS_EXCEPT_JS_LIBS = [];
 
+// A map of LLVM annotations that are read from a custom section in the Wasm
+// file. The key is the annotation name and the value is an array of function
+// indexes that had the annotation.
+// For example `__attribute__((annotate("a_name"))) void foo();` becomes
+// `{a_name: [<func_index>]}`.
+var LLVM_ANNOTATIONS = {};
+
 var WARN_DEPRECATED = true;
 
 // WebGL 2 provides new garbage-free entry points to call to WebGL. Use

--- a/system/include/emscripten/em_macros.h
+++ b/system/include/emscripten/em_macros.h
@@ -51,3 +51,13 @@
   __attribute__((aligned(1)))             \
   char __em_lib_deps_##tag[] = deps;      \
   _EM_END_CDECL
+
+/*
+ * EM_JSPI: Use this macro to mark a function that is asynchronous. The marked
+ * function will be wrapped with a JavaScript Promise Integration wrapper. This
+ * can be used on functions that are exported, or put in the function reference
+ * table.
+ *
+ * Note: This requires -sJSPI.
+ */
+#define EM_JSPI __attribute__((annotate("jspi")))

--- a/test/core/test_pthread_join_and_asyncify.c
+++ b/test/core/test_pthread_join_and_asyncify.c
@@ -13,8 +13,7 @@ EM_ASYNC_JS(int, async_call, (), {
   return 42;
 });
 
-// TODO Remove EMSCRIPTEN_KEEPALIVE when support for async attributes is enabled.
-EMSCRIPTEN_KEEPALIVE void *run_thread(void *args) {
+EM_JSPI void *run_thread(void *args) {
   int ret = async_call();
   assert(ret == 42);
   return NULL;

--- a/test/other/test_jspi_annotate.c
+++ b/test/other/test_jspi_annotate.c
@@ -1,0 +1,15 @@
+#include <emscripten.h>
+
+extern int async_import();
+
+EMSCRIPTEN_KEEPALIVE EM_JSPI int async_export() {
+  return async_import();
+}
+
+EM_JSPI int async_internal() {
+  return async_import();
+}
+
+EMSCRIPTEN_KEEPALIVE void* get_func_ptr() {
+  return &async_internal;
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3321,6 +3321,42 @@ More info: https://emscripten.org
       '-Wno-experimental']
     self.do_runf('other/test_jspi_add_function.c', 'done')
 
+  @requires_jspi
+  def test_jspi_annotate(self):
+    create_file('library.js', r'''
+      addToLibrary({
+        async_import__async: true,
+        async_import: () => { return Promise.resolve(42); },
+        $call_async_func_ptr: (func_ptr) => { return {{{ makeDynCall('v', 'func_ptr') }}}(); }
+    });''')
+    create_file('test.js', r'''
+      let m = await Module();
+      let result = m._async_export();
+      console.log(`isPromise=${result instanceof Promise}`);
+      console.log(await result);
+      let func_ptr = m._get_func_ptr();
+      result = m.call_async_func_ptr(func_ptr);
+      console.log(`isPromise=${result instanceof Promise}`);
+      console.log(await result);
+      console.log('done');
+    ''')
+    self.run_process([EMCC, test_file('other/test_jspi_annotate.c'),
+                      '-o', 'a.out.mjs',
+                      '--js-library', 'library.js',
+                      '--extern-post-js', 'test.js',
+                      '-sJSPI',
+                      '-Wno-experimental',
+                      '-sEXPORTED_RUNTIME_METHODS=call_async_func_ptr'])
+    output = self.run_js('a.out.mjs', assert_returncode=0)
+    expected_output = '\n'.join([
+      'isPromise=true',
+      '42',
+      'isPromise=true',
+      '42',
+      'done\n'
+    ])
+    self.assertContained(output, expected_output)
+
   def test_embind_tsgen(self):
     # Check that TypeScript generation works and that the program is runs as
     # expected.

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -339,6 +339,8 @@ def emscript(in_wasm, out_wasm, outfile_js, js_syms, finalize=True, base_metadat
   if finalize:
     update_settings_glue(out_wasm, metadata, base_metadata)
 
+  settings.LLVM_ANNOTATIONS = metadata.llvm_annotations
+
   if not settings.WASM_BIGINT and metadata.em_js_funcs:
     import_map = {}
 

--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -294,6 +294,7 @@ class Metadata:
   invoke_funcs: List[str]
   main_reads_params: bool
   global_exports: List[str]
+  llvm_annotations: Dict[str, List[int]]
 
   def __init__(self):
     pass
@@ -349,6 +350,7 @@ def extract_metadata(filename):
     metadata.invoke_funcs = invoke_funcs
     metadata.main_reads_params = get_main_reads_params(module, export_map)
     metadata.global_exports = get_global_exports(module, exports)
+    metadata.llvm_annotations = module.parse_llvm_annotations_section()
 
     # print("Metadata parsed: " + pprint.pformat(metadata))
     return metadata


### PR DESCRIPTION
 - Adds a new macro `EM_JSPI` to mark JSPI'd functions with an LLVM annotation.
 - Adds support to webassembly.py to read the custom section that has the LLVM annotations.
 - Automatically creates JSPI wrappers for any exported functions or functions in the function table that had the annotation.