### PR TITLE
Keep the endianness check when assertions are off for node

### DIFF
--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-#if ASSERTIONS
 
+#if (ASSERTIONS || ENVIRONMENT_MAY_BE_NODE) && !SUPPORT_BIG_ENDIAN
 // Endianness check
-#if !SUPPORT_BIG_ENDIAN
+// Note that s390 node *occasionally* pops up and is big-endian.
 (function() {
   var h16 = new Int16Array(1);
   var h8 = new Int8Array(h16.buffer);
@@ -15,6 +15,8 @@
   if (h8[0] !== 0x73 || h8[1] !== 0x63) throw 'Runtime error: expected the system to be little-endian! (Run with -sSUPPORT_BIG_ENDIAN to bypass)';
 })();
 #endif
+
+#if ASSERTIONS
 
 function legacyModuleProp(prop, newName, incoming=true) {
   if (!Object.getOwnPropertyDescriptor(Module, prop)) {


### PR DESCRIPTION
Node.js has a big-endian s390 version which occasionally turns up; silent failure of an emscripten module used in a JavaScript library can be hard to debug.

Disabling node output and assertions will keep the check off. If the check sees a big-endian system, it will throw an error during initialization and this will be visible in debug logging, letting the affected downstream users know what's wrong and how they might fix or work around it.

Helps with: https://github.com/emscripten-core/emscripten/issues/12387