### PR TITLE
Adds wait4/wait3 to libc build, fixes #19188

### DIFF
--- a/test/other/test_syscall_stubs.c
+++ b/test/other/test_syscall_stubs.c
@@ -1,0 +1,10 @@
+#include <sys/wait.h>
+#include <stddef.h>
+
+int main() {
+    // The current implementation uses the stub symbol __syscall_wait4.
+    // This test exists simply to ensure that it compile and link.
+    waitpid(0, NULL, 0);
+    wait3(NULL, 0, NULL);
+    wait4(0, NULL, 0, NULL);
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12707,6 +12707,9 @@ exec "$@"
   def test_syslog(self):
     self.do_other_test('test_syslog.c')
 
+  def test_syscall_stubs(self):
+    self.do_other_test('test_syscall_stubs.c')
+
   @parameterized({
     '': (False, False),
     'custom': (True, False),

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1239,7 +1239,7 @@ class libc(MuslInternalLibrary,
 
     libc_files += files_in_path(
         path='system/lib/libc/musl/src/linux',
-        filenames=['getdents.c', 'gettid.c', 'utimes.c', 'statx.c'])
+        filenames=['getdents.c', 'gettid.c', 'utimes.c', 'statx.c', 'wait4.c', 'wait3.c'])
 
     libc_files += files_in_path(
         path='system/lib/libc/musl/src/sched',


### PR DESCRIPTION
Fixes missing `wait4` and `wait3` functions by adding the relevant source files from the musl libc to the build process of the libc.