### PR TITLE
[tsgen] Emit getters/setters for properties when the types are differ…

### DIFF
--- a/src/embind/embind_gen.js
+++ b/src/embind/embind_gen.js
@@ -243,7 +243,15 @@ var LibraryEmbind = {
     }
 
     print(nameMap, out) {
-      out.push(`${this.readonly ? 'readonly ' : ''}${this.name}: ${nameMap(this.type)}`);
+      const setType = nameMap(this.type, false);
+      const getType = nameMap(this.type, true);
+      if (this.readonly || setType === getType) {
+        out.push(`${this.readonly ? 'readonly ' : ''}${this.name}: ${getType}`);
+        return;
+      }
+      // The getter/setter types don't match, so generate each get/set definition.
+      out.push(`get ${this.name}(): ${getType};`);
+      out.push(`set ${this.name}(value: ${setType})`);
     }
   },
   $ConstantDefinition: class {

--- a/src/embind/embind_gen.js
+++ b/src/embind/embind_gen.js
@@ -207,9 +207,15 @@ var LibraryEmbind = {
       for (const prop of this.staticProperties) {
         const entry = [];
         prop.print(nameMap, entry);
-        entries.push(entry.join('; '));
+        entries.push(...entry);
       }
-      out.push(entries.join('; '));
+      if (entries.length) {
+        out.push('\n');
+        for (const entry of entries) {
+          out.push(`    ${entry};\n`);
+        }
+        out.push('  ');
+      }
       out.push('};\n');
     }
 

--- a/src/embind/embind_gen.js
+++ b/src/embind/embind_gen.js
@@ -175,9 +175,11 @@ var LibraryEmbind = {
       }
       out.push(' {\n');
       for (const property of this.properties) {
-        out.push('  ');
-        property.print(nameMap, out);
-        out.push(';\n');
+        const props = [];
+        property.print(nameMap, props);
+        for (const formattedProp of props) {
+          out.push(`  ${formattedProp};\n`);
+        }
       }
       for (const method of this.methods) {
         out.push('  ');
@@ -205,7 +207,7 @@ var LibraryEmbind = {
       for (const prop of this.staticProperties) {
         const entry = [];
         prop.print(nameMap, entry);
-        entries.push(entry.join(''));
+        entries.push(entry.join('; '));
       }
       out.push(entries.join('; '));
       out.push('};\n');
@@ -250,7 +252,7 @@ var LibraryEmbind = {
         return;
       }
       // The getter/setter types don't match, so generate each get/set definition.
-      out.push(`get ${this.name}(): ${getType};`);
+      out.push(`get ${this.name}(): ${getType}`);
       out.push(`set ${this.name}(value: ${setType})`);
     }
   },

--- a/test/other/embind_tsgen.cpp
+++ b/test/other/embind_tsgen.cpp
@@ -22,9 +22,12 @@ class Test {
 
   int getY() const { return y; }
 
+  std::string string_property;
+
   static int static_function(int x) { return 1; }
 
   static int static_property;
+  static std::string static_string_property;
 
 private:
   int x;
@@ -135,9 +138,11 @@ EMSCRIPTEN_BINDINGS(Test) {
       .function("constFn", &Test::const_fn)
       .property("x", &Test::getX, &Test::setX)
       .property("y", &Test::getY)
+      .property("stringProperty", &Test::string_property)
       .class_function("staticFunction", &Test::static_function)
       .class_function("staticFunctionWithParam(x)", &Test::static_function)
       .class_property("staticProperty", &Test::static_property)
+      .class_property("staticStringProperty", &Test::static_string_property)
 	;
 
   function("class_returning_fn", &class_returning_fn);
@@ -221,6 +226,7 @@ EMSCRIPTEN_BINDINGS(Test) {
 }
 
 int Test::static_property = 42;
+std::string Test::static_string_property = "";
 
 int main() {
   // Main should not be run during TypeScript generation, but should run when

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -20,6 +20,7 @@ type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;
 export interface Test {
   x: number;
   readonly y: number;
+  get stringProperty(): string;set stringProperty(value: EmbindString);
   functionOne(_0: number, _1: number): number;
   functionTwo(_0: number, _1: number): number;
   functionFour(_0: boolean): number;
@@ -102,7 +103,7 @@ export interface DerivedClass extends BaseClass {
 export type ValArr = [ number, number, number ];
 
 interface EmbindModule {
-  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number};
+  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string;set staticStringProperty(value: EmbindString)};
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   Obj: {};

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -104,7 +104,13 @@ export interface DerivedClass extends BaseClass {
 export type ValArr = [ number, number, number ];
 
 interface EmbindModule {
-  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string; set staticStringProperty(value: EmbindString)};
+  Test: {
+    staticFunction(_0: number): number;
+    staticFunctionWithParam(x: number): number;
+    staticProperty: number;
+    get staticStringProperty(): string;
+    set staticStringProperty(value: EmbindString);
+  };
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   Obj: {};
@@ -114,12 +120,23 @@ interface EmbindModule {
   Bar: {valueOne: BarValue<0>, valueTwo: BarValue<1>, valueThree: BarValue<2>};
   EmptyEnum: {};
   enum_returning_fn(): Bar;
-  IntVec: {new(): IntVec};
-  MapIntInt: {new(): MapIntInt};
+  IntVec: {
+    new(): IntVec;
+  };
+  MapIntInt: {
+    new(): MapIntInt;
+  };
   Foo: {};
-  ClassWithConstructor: {new(_0: number, _1: ValArr): ClassWithConstructor};
-  ClassWithTwoConstructors: {new(): ClassWithTwoConstructors; new(_0: number): ClassWithTwoConstructors};
-  ClassWithSmartPtrConstructor: {new(_0: number, _1: ValArr): ClassWithSmartPtrConstructor};
+  ClassWithConstructor: {
+    new(_0: number, _1: ValArr): ClassWithConstructor;
+  };
+  ClassWithTwoConstructors: {
+    new(): ClassWithTwoConstructors;
+    new(_0: number): ClassWithTwoConstructors;
+  };
+  ClassWithSmartPtrConstructor: {
+    new(_0: number, _1: ValArr): ClassWithSmartPtrConstructor;
+  };
   BaseClass: {};
   DerivedClass: {};
   a_bool: boolean;

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -20,7 +20,8 @@ type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;
 export interface Test {
   x: number;
   readonly y: number;
-  get stringProperty(): string;set stringProperty(value: EmbindString);
+  get stringProperty(): string;
+  set stringProperty(value: EmbindString);
   functionOne(_0: number, _1: number): number;
   functionTwo(_0: number, _1: number): number;
   functionFour(_0: boolean): number;
@@ -103,7 +104,7 @@ export interface DerivedClass extends BaseClass {
 export type ValArr = [ number, number, number ];
 
 interface EmbindModule {
-  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string;set staticStringProperty(value: EmbindString)};
+  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string; set staticStringProperty(value: EmbindString)};
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   Obj: {};

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -113,7 +113,13 @@ export interface DerivedClass extends BaseClass {
 export type ValArr = [ number, number, number ];
 
 interface EmbindModule {
-  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string; set staticStringProperty(value: EmbindString)};
+  Test: {
+    staticFunction(_0: number): number;
+    staticFunctionWithParam(x: number): number;
+    staticProperty: number;
+    get staticStringProperty(): string;
+    set staticStringProperty(value: EmbindString);
+  };
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   Obj: {};
@@ -123,12 +129,23 @@ interface EmbindModule {
   Bar: {valueOne: BarValue<0>, valueTwo: BarValue<1>, valueThree: BarValue<2>};
   EmptyEnum: {};
   enum_returning_fn(): Bar;
-  IntVec: {new(): IntVec};
-  MapIntInt: {new(): MapIntInt};
+  IntVec: {
+    new(): IntVec;
+  };
+  MapIntInt: {
+    new(): MapIntInt;
+  };
   Foo: {};
-  ClassWithConstructor: {new(_0: number, _1: ValArr): ClassWithConstructor};
-  ClassWithTwoConstructors: {new(): ClassWithTwoConstructors; new(_0: number): ClassWithTwoConstructors};
-  ClassWithSmartPtrConstructor: {new(_0: number, _1: ValArr): ClassWithSmartPtrConstructor};
+  ClassWithConstructor: {
+    new(_0: number, _1: ValArr): ClassWithConstructor;
+  };
+  ClassWithTwoConstructors: {
+    new(): ClassWithTwoConstructors;
+    new(_0: number): ClassWithTwoConstructors;
+  };
+  ClassWithSmartPtrConstructor: {
+    new(_0: number, _1: ValArr): ClassWithSmartPtrConstructor;
+  };
   BaseClass: {};
   DerivedClass: {};
   a_bool: boolean;

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -29,7 +29,8 @@ type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;
 export interface Test {
   x: number;
   readonly y: number;
-  get stringProperty(): string;set stringProperty(value: EmbindString);
+  get stringProperty(): string;
+  set stringProperty(value: EmbindString);
   functionOne(_0: number, _1: number): number;
   functionTwo(_0: number, _1: number): number;
   functionFour(_0: boolean): number;
@@ -112,7 +113,7 @@ export interface DerivedClass extends BaseClass {
 export type ValArr = [ number, number, number ];
 
 interface EmbindModule {
-  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string;set staticStringProperty(value: EmbindString)};
+  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string; set staticStringProperty(value: EmbindString)};
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   Obj: {};

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -29,6 +29,7 @@ type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;
 export interface Test {
   x: number;
   readonly y: number;
+  get stringProperty(): string;set stringProperty(value: EmbindString);
   functionOne(_0: number, _1: number): number;
   functionTwo(_0: number, _1: number): number;
   functionFour(_0: boolean): number;
@@ -111,7 +112,7 @@ export interface DerivedClass extends BaseClass {
 export type ValArr = [ number, number, number ];
 
 interface EmbindModule {
-  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number};
+  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string;set staticStringProperty(value: EmbindString)};
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   Obj: {};

--- a/test/other/embind_tsgen_ignore_2.d.ts
+++ b/test/other/embind_tsgen_ignore_2.d.ts
@@ -90,7 +90,13 @@ export interface DerivedClass extends BaseClass {
 export type ValArr = [ number, number, number ];
 
 interface EmbindModule {
-  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string; set staticStringProperty(value: EmbindString)};
+  Test: {
+    staticFunction(_0: number): number;
+    staticFunctionWithParam(x: number): number;
+    staticProperty: number;
+    get staticStringProperty(): string;
+    set staticStringProperty(value: EmbindString);
+  };
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   Obj: {};
@@ -100,12 +106,23 @@ interface EmbindModule {
   Bar: {valueOne: BarValue<0>, valueTwo: BarValue<1>, valueThree: BarValue<2>};
   EmptyEnum: {};
   enum_returning_fn(): Bar;
-  IntVec: {new(): IntVec};
-  MapIntInt: {new(): MapIntInt};
+  IntVec: {
+    new(): IntVec;
+  };
+  MapIntInt: {
+    new(): MapIntInt;
+  };
   Foo: {};
-  ClassWithConstructor: {new(_0: number, _1: ValArr): ClassWithConstructor};
-  ClassWithTwoConstructors: {new(): ClassWithTwoConstructors; new(_0: number): ClassWithTwoConstructors};
-  ClassWithSmartPtrConstructor: {new(_0: number, _1: ValArr): ClassWithSmartPtrConstructor};
+  ClassWithConstructor: {
+    new(_0: number, _1: ValArr): ClassWithConstructor;
+  };
+  ClassWithTwoConstructors: {
+    new(): ClassWithTwoConstructors;
+    new(_0: number): ClassWithTwoConstructors;
+  };
+  ClassWithSmartPtrConstructor: {
+    new(_0: number, _1: ValArr): ClassWithSmartPtrConstructor;
+  };
   BaseClass: {};
   DerivedClass: {};
   a_bool: boolean;

--- a/test/other/embind_tsgen_ignore_2.d.ts
+++ b/test/other/embind_tsgen_ignore_2.d.ts
@@ -6,6 +6,7 @@ type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;
 export interface Test {
   x: number;
   readonly y: number;
+  get stringProperty(): string;set stringProperty(value: EmbindString);
   functionOne(_0: number, _1: number): number;
   functionTwo(_0: number, _1: number): number;
   functionFour(_0: boolean): number;
@@ -88,7 +89,7 @@ export interface DerivedClass extends BaseClass {
 export type ValArr = [ number, number, number ];
 
 interface EmbindModule {
-  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number};
+  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string;set staticStringProperty(value: EmbindString)};
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   Obj: {};

--- a/test/other/embind_tsgen_ignore_2.d.ts
+++ b/test/other/embind_tsgen_ignore_2.d.ts
@@ -6,7 +6,8 @@ type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;
 export interface Test {
   x: number;
   readonly y: number;
-  get stringProperty(): string;set stringProperty(value: EmbindString);
+  get stringProperty(): string;
+  set stringProperty(value: EmbindString);
   functionOne(_0: number, _1: number): number;
   functionTwo(_0: number, _1: number): number;
   functionFour(_0: boolean): number;
@@ -89,7 +90,7 @@ export interface DerivedClass extends BaseClass {
 export type ValArr = [ number, number, number ];
 
 interface EmbindModule {
-  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string;set staticStringProperty(value: EmbindString)};
+  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string; set staticStringProperty(value: EmbindString)};
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   Obj: {};

--- a/test/other/embind_tsgen_ignore_3.d.ts
+++ b/test/other/embind_tsgen_ignore_3.d.ts
@@ -20,6 +20,7 @@ type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;
 export interface Test {
   x: number;
   readonly y: number;
+  get stringProperty(): string;set stringProperty(value: EmbindString);
   functionOne(_0: number, _1: number): number;
   functionTwo(_0: number, _1: number): number;
   functionFour(_0: boolean): number;
@@ -102,7 +103,7 @@ export interface DerivedClass extends BaseClass {
 export type ValArr = [ number, number, number ];
 
 interface EmbindModule {
-  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number};
+  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string;set staticStringProperty(value: EmbindString)};
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   Obj: {};

--- a/test/other/embind_tsgen_ignore_3.d.ts
+++ b/test/other/embind_tsgen_ignore_3.d.ts
@@ -104,7 +104,13 @@ export interface DerivedClass extends BaseClass {
 export type ValArr = [ number, number, number ];
 
 interface EmbindModule {
-  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string; set staticStringProperty(value: EmbindString)};
+  Test: {
+    staticFunction(_0: number): number;
+    staticFunctionWithParam(x: number): number;
+    staticProperty: number;
+    get staticStringProperty(): string;
+    set staticStringProperty(value: EmbindString);
+  };
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   Obj: {};
@@ -114,12 +120,23 @@ interface EmbindModule {
   Bar: {valueOne: BarValue<0>, valueTwo: BarValue<1>, valueThree: BarValue<2>};
   EmptyEnum: {};
   enum_returning_fn(): Bar;
-  IntVec: {new(): IntVec};
-  MapIntInt: {new(): MapIntInt};
+  IntVec: {
+    new(): IntVec;
+  };
+  MapIntInt: {
+    new(): MapIntInt;
+  };
   Foo: {};
-  ClassWithConstructor: {new(_0: number, _1: ValArr): ClassWithConstructor};
-  ClassWithTwoConstructors: {new(): ClassWithTwoConstructors; new(_0: number): ClassWithTwoConstructors};
-  ClassWithSmartPtrConstructor: {new(_0: number, _1: ValArr): ClassWithSmartPtrConstructor};
+  ClassWithConstructor: {
+    new(_0: number, _1: ValArr): ClassWithConstructor;
+  };
+  ClassWithTwoConstructors: {
+    new(): ClassWithTwoConstructors;
+    new(_0: number): ClassWithTwoConstructors;
+  };
+  ClassWithSmartPtrConstructor: {
+    new(_0: number, _1: ValArr): ClassWithSmartPtrConstructor;
+  };
   BaseClass: {};
   DerivedClass: {};
   a_bool: boolean;

--- a/test/other/embind_tsgen_ignore_3.d.ts
+++ b/test/other/embind_tsgen_ignore_3.d.ts
@@ -20,7 +20,8 @@ type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;
 export interface Test {
   x: number;
   readonly y: number;
-  get stringProperty(): string;set stringProperty(value: EmbindString);
+  get stringProperty(): string;
+  set stringProperty(value: EmbindString);
   functionOne(_0: number, _1: number): number;
   functionTwo(_0: number, _1: number): number;
   functionFour(_0: boolean): number;
@@ -103,7 +104,7 @@ export interface DerivedClass extends BaseClass {
 export type ValArr = [ number, number, number ];
 
 interface EmbindModule {
-  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string;set staticStringProperty(value: EmbindString)};
+  Test: {staticFunction(_0: number): number; staticFunctionWithParam(x: number): number; staticProperty: number; get staticStringProperty(): string; set staticStringProperty(value: EmbindString)};
   class_returning_fn(): Test;
   class_unique_ptr_returning_fn(): Test;
   Obj: {};


### PR DESCRIPTION
…ent.

Emitting a better type was already done for functions that returned strings, but now works with properties as well.

Fixes #22387