### PR TITLE
[embind] Cleanup createJsInvoker. NFC

### DIFF
--- a/src/embind/embind_shared.js
+++ b/src/embind/embind_shared.js
@@ -209,18 +209,23 @@ var LibraryEmbindShared = {
   $createJsInvoker__deps: ['$usesDestructorStack'],
   $createJsInvoker(argTypes, isClassMethodFunc, returns, isAsync) {
     var needsDestructorStack = usesDestructorStack(argTypes);
-    var argCount = argTypes.length;
-    var argsList = "";
-    var argsListWired = "";
-    for (var i = 0; i < argCount - 2; ++i) {
-      argsList += (i!==0?", ":"")+"arg"+i;
-      argsListWired += (i!==0?", ":"")+"arg"+i+"Wired";
+    var argCount = argTypes.length - 2;
+    var argsList = [];
+    var argsListWired = ['fn'];
+    if (isClassMethodFunc) {
+      argsListWired.push('thisWired');
     }
+    for (var i = 0; i < argCount; ++i) {
+      argsList.push(`arg${i}`)
+      argsListWired.push(`arg${i}Wired`)
+    }
+    argsList = argsList.join(',')
+    argsListWired = argsListWired.join(',')
 
     var invokerFnBody = `
       return function (${argsList}) {
-      if (arguments.length !== ${argCount - 2}) {
-        throwBindingError('function ' + humanName + ' called with ' + arguments.length + ' arguments, expected ${argCount - 2}');
+      if (arguments.length !== ${argCount}) {
+        throwBindingError('function ' + humanName + ' called with ' + arguments.length + ' arguments, expected ${argCount}');
       }`;
 
 #if EMSCRIPTEN_TRACING
@@ -239,20 +244,15 @@ var LibraryEmbindShared = {
 #endif
 
     if (isClassMethodFunc) {
-      invokerFnBody += "var thisWired = classParam['toWireType']("+dtorStack+", this);\n";
+      invokerFnBody += `var thisWired = classParam['toWireType'](${dtorStack}, this);\n`;
     }
 
-    for (var i = 0; i < argCount - 2; ++i) {
-      invokerFnBody += "var arg"+i+"Wired = argType"+i+"['toWireType']("+dtorStack+", arg"+i+");\n";
-      args1.push("argType"+i);
+    for (var i = 0; i < argCount; ++i) {
+      invokerFnBody += `var arg${i}Wired = argType${i}['toWireType'](${dtorStack}, arg${i});\n`;
+      args1.push(`argType${i}`);
     }
 
-    if (isClassMethodFunc) {
-      argsListWired = "thisWired" + (argsListWired.length > 0 ? ", " : "") + argsListWired;
-    }
-
-    invokerFnBody +=
-        (returns || isAsync ? "var rv = ":"") + "invoker(fn"+(argsListWired.length>0?", ":"")+argsListWired+");\n";
+    invokerFnBody += (returns || isAsync ? "var rv = ":"") + `invoker(${argsListWired});\n`;
 
     var returnVal = returns ? "rv" : "";
 #if ASYNCIFY == 1

--- a/test/code_size/embind_hello_wasm.json
+++ b/test/code_size/embind_hello_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 380,
-  "a.js": 9961,
-  "a.js.gz": 4350,
+  "a.js": 9920,
+  "a.js.gz": 4354,
   "a.wasm": 7715,
   "a.wasm.gz": 3508,
-  "total": 18228,
-  "total_gz": 8238
+  "total": 18187,
+  "total_gz": 8242
 }


### PR DESCRIPTION
I couple of minor cleanups:

1. I noticed that argCount was always followed by - 2.
2. I noticed that argsListWired was always being used `fn` as the first argument
3. The `argsLists` were being constructs as comma separated strings, which `join` is really good at.