### PR TITLE
Add embind code size test. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1856,14 +1856,21 @@ addToLibrary({
   },
 
 #if DYNCALLS || !WASM_BIGINT
-#if MAIN_MODULE == 1
-  $dynCallLegacy__deps: ['$createDyncallWrapper'],
+#if MINIMAL_RUNTIME
+  $dynCalls: '[]',
 #endif
+  $dynCallLegacy__deps: [
+#if MAIN_MODULE == 1
+    '$createDyncallWrapper'
+#endif
+#if MINIMAL_RUNTIME
+    '$dynCalls',
+#endif
+  ],
   $dynCallLegacy: (sig, ptr, args) => {
     sig = sig.replace(/p/g, {{{ MEMORY64 ? "'j'" : "'i'" }}})
 #if ASSERTIONS
 #if MINIMAL_RUNTIME
-    assert(typeof dynCalls != 'undefined', 'Global dynCalls dictionary was not generated in the build! Pass -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$dynCall linker flag to include it!');
     assert(sig in dynCalls, `bad function pointer type - sig is not in dynCalls: '${sig}'`);
 #else
     assert(('dynCall_' + sig) in Module, `bad function pointer type - dynCall function not found for sig '${sig}'`);

--- a/test/code_size/embind_hello_wasm.json
+++ b/test/code_size/embind_hello_wasm.json
@@ -1,0 +1,10 @@
+{
+  "a.html": 552,
+  "a.html.gz": 380,
+  "a.js": 10171,
+  "a.js.gz": 4395,
+  "a.wasm": 7820,
+  "a.wasm.gz": 3526,
+  "total": 18543,
+  "total_gz": 8301
+}

--- a/test/code_size/embind_hello_world.cpp
+++ b/test/code_size/embind_hello_world.cpp
@@ -1,0 +1,17 @@
+#include <string>
+#include <emscripten/emscripten.h>
+#include <emscripten/bind.h>
+
+using namespace emscripten;
+
+int main() {
+  EM_ASM(out(Module.getString()));
+}
+
+std::string getString() {
+  return "Hello, world";
+}
+
+EMSCRIPTEN_BINDINGS(typeOf) {
+  function("getString", &getString);
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10904,6 +10904,7 @@ int main () {
     'math': ('math', False),
     'hello_wasm_worker': ('hello_wasm_worker', False, True),
     'hello_embind_val': ('embind_val', False),
+    'hello_embind': ('embind_hello', False),
   })
   @crossplatform
   def test_minimal_runtime_code_size(self, test_name, js, compare_js_output=False):
@@ -10945,6 +10946,7 @@ int main () {
                            '-sMODULARIZE']
     hello_webgl2_sources = hello_webgl_sources + ['-sMAX_WEBGL_VERSION=2']
     hello_wasm_worker_sources = [test_file('wasm_worker/wasm_worker_code_size.c'), '-sWASM_WORKERS', '-sENVIRONMENT=web,worker']
+    embind_hello_sources = [test_file('code_size/embind_hello_world.cpp'), '-lembind']
     embind_val_sources = [test_file('code_size/embind_val_hello_world.cpp'),
                           '-lembind',
                           '-fno-rtti',
@@ -10959,6 +10961,7 @@ int main () {
       'hello_webgl2': hello_webgl2_sources,
       'hello_wasm_worker': hello_wasm_worker_sources,
       'embind_val': embind_val_sources,
+      'embind_hello': embind_hello_sources,
     }[test_name]
 
     def print_percent(actual, expected):

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -60,10 +60,6 @@ def compute_minimal_runtime_initializer_and_exports(post, exports, receiving):
 
   exports = [asmjs_mangle(x) for x in exports if x != building.WASM_CALL_CTORS]
 
-  # Decide whether we should generate the global dynCalls dictionary for the dynCall() function?
-  if settings.DYNCALLS and '$dynCall' in settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE and len([x for x in exports if x.startswith('dynCall_')]) > 0:
-    exports += ['dynCalls = {}']
-
   declares = 'var ' + ',\n '.join(exports) + ';'
   post = shared.do_replace(post, '<<< WASM_MODULE_EXPORTS_DECLARES >>>', declares)
 


### PR DESCRIPTION
In order to make this new test even compile I moved the declaration of `dynCalls` from being hand coded in python to being decoratively included in library.js, which makes more sense anyway.

See #22416