### PR TITLE
getsockopt mismatch in websocket_to_posix_proxy vs. _socket

### DIFF
--- a/tools/websocket_to_posix_proxy/src/websocket_to_posix_proxy.c
+++ b/tools/websocket_to_posix_proxy/src/websocket_to_posix_proxy.c
@@ -1349,7 +1349,6 @@ void Getsockopt(int client_fd, uint8_t *data, uint64_t numBytes) {
     int callId;
     int ret;
     int errno_;
-    int option_len;
     uint8_t option_value[];
   } Result;
 
@@ -1359,7 +1358,6 @@ void Getsockopt(int client_fd, uint8_t *data, uint64_t numBytes) {
   r->callId = d->header.callId;
   r->ret = ret;
   r->errno_ = errorCode;
-  r->option_len = option_len;
   memcpy(r->option_value, option_value, actualOptionLen);
   SendWebSocketMessage(client_fd, r, resultSize);
   free(r);


### PR DESCRIPTION
It appears that ever since 31309a8c12aaf142ec483dbe3edc0aa195c1bbca "full_posix_sockets (#7672)", the _proxy side sent back a result that included an explicit option_len while the _socket side computes that value from the overall result size.