### PR TITLE
Fix computation of size to send in getsockname in websocket_to_posix_socket.c

### DIFF
--- a/system/lib/websocket/websocket_to_posix_socket.c
+++ b/system/lib/websocket/websocket_to_posix_socket.c
@@ -492,7 +492,7 @@ int getsockname(int socket, struct sockaddr *address, socklen_t *address_len) {
   d.header.function = POSIX_SOCKET_MSG_GETSOCKNAME;
   d.socket = socket;
   d.address_len = *address_len;
-  emscripten_websocket_send_binary(bridgeSocket, &d, sizeof(d) + *address_len - MAX_SOCKADDR_SIZE);
+  emscripten_websocket_send_binary(bridgeSocket, &d, sizeof(d));
 
   wait_for_call_result(b);
   int ret = b->data->ret;


### PR DESCRIPTION
...that appears to have been bogus ever since
31309a8c12aaf142ec483dbe3edc0aa195c1bbca "full_posix_sockets (#7672)"