### PR TITLE
Fix link error if `-lhtml5` is used without ASYNCIFY

### DIFF
--- a/system/lib/html5/emscripten_wget.c
+++ b/system/lib/html5/emscripten_wget.c
@@ -1,9 +1,12 @@
+#if ASYNCIFY // emscripten_wget requires asyncify
+
 #include <emscripten.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
 
 // Creates all ancestor directories of a given file, if they do not already
 // exist. Returns 0 on success or 1 on error.
@@ -53,3 +56,5 @@ int emscripten_wget(const char* url, const char* file) {
   free(buffer);
   return fd < 0;
 }
+
+#endif


### PR DESCRIPTION
`emscripten_wget` requires asyncify but it isn't used by other functions in libhtml5, so we should drop it if asyncify is not in use.