### PR TITLE
Fix pthreads in `-sSTRICT` mode

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9111,6 +9111,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # works with pthreads (even though we did not specify 'node,worker')
     self.set_setting('ENVIRONMENT', 'node')
     self.set_setting('STRICT_JS')
+    self.set_setting('STRICT')
     self.do_run_in_out_file_test('core/pthread/create.c')
 
   @node_pthreads

--- a/tools/link.py
+++ b/tools/link.py
@@ -490,6 +490,10 @@ def setup_pthreads():
 
   default_setting('DEFAULT_PTHREAD_STACK_SIZE', settings.STACK_SIZE)
 
+  if not settings.MINIMAL_RUNTIME and 'instantiateWasm' not in settings.INCOMING_MODULE_JS_API:
+    # pthreads runtime depends on overriding instantiateWasm
+    settings.INCOMING_MODULE_JS_API.append('instantiateWasm')
+
   # Functions needs by runtime_pthread.js
   settings.REQUIRED_EXPORTS += [
     '_emscripten_thread_free_data',


### PR DESCRIPTION
`STRICT` has the effect of making `INCOMING_MODULE_JS_API` empty by default, but the pthread runtime relies on overriding `instantiateWasm`.

See #21844