### PR TITLE
Fix `maybeExit` usage in browser main loop handling

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -898,7 +898,7 @@ var LibraryBrowser = {
 #if OFFSCREEN_FRAMEBUFFER
     'emscripten_webgl_commit_frame',
 #endif
-#if EXIT_RUNTIME && !MINIMAL_RUNTIME
+#if !MINIMAL_RUNTIME
     '$maybeExit',
 #endif
   ],
@@ -931,10 +931,10 @@ var LibraryBrowser = {
     function checkIsRunning() {
       if (thisMainLoopId < Browser.mainLoop.currentlyRunningMainloop) {
 #if RUNTIME_DEBUG
-        dbg('main loop exiting..');
+        dbg('main loop exiting');
 #endif
         {{{ runtimeKeepalivePop() }}}
-#if EXIT_RUNTIME && !MINIMAL_RUNTIME
+#if !MINIMAL_RUNTIME
         maybeExit();
 #endif
         return false;

--- a/test/other/test_pthread_set_main_loop.c
+++ b/test/other/test_pthread_set_main_loop.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <emscripten.h>
+
+_Atomic bool term = false;
+_Atomic bool loopthread_done = false;
+pthread_t thread;
+int loopcount = 0;
+
+void loop() {
+  printf("loop thread: %d\n", loopcount);
+
+  if (loopcount++ > 10) {
+    // This should exit the thread and allow join to complete below, but it doesn't work
+    emscripten_cancel_main_loop();
+    printf("loop thread done\n");
+    loopthread_done = true;
+  }
+}
+
+void* loopthread(void* arg) {
+  emscripten_set_main_loop(loop, 0, false);
+  return NULL;
+}
+
+void mainloop() {
+  if (loopthread_done) {
+    printf("joinng..\n");
+    pthread_join(thread, NULL);
+    printf("join done\n");
+    emscripten_cancel_main_loop();
+  }
+}
+
+int main() {
+  pthread_create(&thread, NULL, loopthread, NULL);
+  emscripten_set_main_loop(mainloop, 0, false);
+  return 0;
+}

--- a/test/other/test_pthread_set_main_loop.out
+++ b/test/other/test_pthread_set_main_loop.out
@@ -1,0 +1,15 @@
+loop thread: 0
+loop thread: 1
+loop thread: 2
+loop thread: 3
+loop thread: 4
+loop thread: 5
+loop thread: 6
+loop thread: 7
+loop thread: 8
+loop thread: 9
+loop thread: 10
+loop thread: 11
+loop thread done
+joinng..
+join done

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13424,6 +13424,10 @@ void foo() {}
     self.emcc_args.append('-pthread')
     self.do_other_test('test_pthread_icu.cpp')
 
+  @node_pthreads
+  def test_pthread_set_main_loop(self):
+    self.do_other_test('test_pthread_set_main_loop.c')
+
   # unistd tests
 
   def test_unistd_confstr(self):


### PR DESCRIPTION
I think what happened here was that #18374 changed `maybeExit` to
only be defined when `EXIT_RUNTIME` was set.  This change was
effectively reversed in #18782 but this location was not updated.

Fixes: #22310