### PR TITLE
Run tools\maint\update_settings_docs.py

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -2525,9 +2525,13 @@ Default value: false
 WASM_WORKERS
 ============
 
-If true, enables support for Wasm Workers. Wasm Workers enable applications
+If 1, enables support for Wasm Workers. Wasm Workers enable applications
 to create threads using a lightweight web-specific API that builds on top
-of Wasm SharedArrayBuffer + Atomics API.
+of Wasm SharedArrayBuffer + Atomics API. When enabled, a new build output
+file a.ww.js will be generated to bootstrap the Wasm Worker JS contexts.
+If 2, enables support for Wasm Workers, but without using a separate a.ww.js
+file on the side. This can simplify deployment of builds, but will have a
+downside that the generated build will no longer be csp-eval compliant.
 [compile+link] - affects user code at compile and system libraries at link.
 
 Default value: 0


### PR DESCRIPTION
Ugh, forgot that we have an automated script to copy settings docs, and force-landed https://github.com/emscripten-core/emscripten/pull/21614 without that being up to date with latest.

This PR runs the settings docs update.