### PR TITLE
Fix sockets.test_posix_proxy_sockets on Windows

### DIFF
--- a/tools/websocket_to_posix_proxy/CMakeLists.txt
+++ b/tools/websocket_to_posix_proxy/CMakeLists.txt
@@ -5,7 +5,6 @@ project(websocket_to_posix_proxy)
 if (WIN32)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
   add_compile_options(/wd4200) # "nonstandard extension used: zero-sized array in struct/union"
-  target_link_libraries(websocket_to_posix_proxy Ws2_32.lib)
 else()
   add_compile_options(-Werror -Wall)
 endif()
@@ -16,3 +15,7 @@ add_executable(websocket_to_posix_proxy ${sourceFiles})
 
 find_package(Threads)
 target_link_libraries(websocket_to_posix_proxy ${CMAKE_THREAD_LIBS_INIT})
+
+if (WIN32)
+  target_link_libraries(websocket_to_posix_proxy Ws2_32.lib)
+endif()

--- a/tools/websocket_to_posix_proxy/src/socket_registry.cpp
+++ b/tools/websocket_to_posix_proxy/src/socket_registry.cpp
@@ -5,10 +5,13 @@
 #include <algorithm>
 #include "threads.h"
 
-extern MUTEX_T socketRegistryLock;
-
 namespace {
+  MUTEX_T socketRegistryLock;
   std::map<int, std::vector<SOCKET_T> > socketsPerProxyConnection;
+}
+
+void InitWebSocketRegistry() {
+  CREATE_MUTEX(&socketRegistryLock);
 }
 
 void TrackSocketUsedByConnection(int proxyConnection, SOCKET_T usedSocket) {

--- a/tools/websocket_to_posix_proxy/src/socket_registry.h
+++ b/tools/websocket_to_posix_proxy/src/socket_registry.h
@@ -8,6 +8,7 @@ extern "C" {
 
 // Socket Registry remembers all the sockets created by incoming proxy connections, so that those sockets can be properly
 // shut down when an incoming proxy connection disconnects.
+void InitWebSocketRegistry();
 
 // Tracks that the given socket is part of the specified proxy connection. When proxyConnection disconnects, all sockets
 // used by it are shut down.

--- a/tools/websocket_to_posix_proxy/src/websocket_to_posix_proxy.c
+++ b/tools/websocket_to_posix_proxy/src/websocket_to_posix_proxy.c
@@ -100,20 +100,22 @@ void WebSocketMessageUnmaskPayload(uint8_t* payload,
   }
 }
 
-extern MUTEX_T webSocketSendLock;
+void lock_websocket_send_lock(void);
+void unlock_websocket_send_lock(void);
 
 void SendWebSocketMessage(int client_fd, void *buf, uint64_t numBytes) {
   // Guard send() calls to the client_fd socket so that two threads won't ever race to send to the
   // same socket. (This could be per-socket, currently global for simplicity)
-  LOCK_MUTEX(&webSocketSendLock);
-  uint8_t headerData[sizeof(WebSocketMessageHeader) + 8/*possible extended length*/] = {};
+  lock_websocket_send_lock();
+  uint8_t headerData[sizeof(WebSocketMessageHeader) + 8/*possible extended length*/];
+  memset(headerData, 0, sizeof(headerData));
   WebSocketMessageHeader *header = (WebSocketMessageHeader *)headerData;
   header->opcode = 0x02;
   header->fin = 1;
   int headerBytes = 2;
 
   if (numBytes < 126) {
-    header->payloadLength = numBytes;
+    header->payloadLength = (unsigned int)numBytes;
   } else if (numBytes <= 65535) {
     header->payloadLength = 126;
     *(uint16_t*)(headerData+headerBytes) = htons((unsigned short)numBytes);
@@ -139,7 +141,7 @@ void SendWebSocketMessage(int client_fd, void *buf, uint64_t numBytes) {
 
   send(client_fd, (const char*)headerData, headerBytes, 0); // header
   send(client_fd, (const char*)buf, (int)numBytes, 0); // payload
-  UNLOCK_MUTEX(&webSocketSendLock);
+  unlock_websocket_send_lock();
 }
 
 #define MUSL_PF_UNSPEC       0
@@ -967,7 +969,8 @@ void Accept(int client_fd, uint8_t *data, uint64_t numBytes) {
   } MSG;
   MSG *d = (MSG*)data;
 
-  uint8_t address[MAX_SOCKADDR_SIZE] = {};
+  uint8_t address[MAX_SOCKADDR_SIZE];
+  memset(address, 0, sizeof(address));
   socklen_t addressLen = (socklen_t)MAX(0, MIN(d->address_len, MAX_SOCKADDR_SIZE));
 
   SOCKET_T ret;
@@ -1446,7 +1449,8 @@ void Getaddrinfo(int client_fd, uint8_t *data, uint64_t numBytes) {
   if (errorCode) PRINT_SOCKET_ERROR(errorCode);
 #endif
 
-  char ai_canonname[MAX_NODE_LEN] = {};
+  char ai_canonname[MAX_NODE_LEN];
+  memset(ai_canonname, 0, sizeof(ai_canonname));
   int ai_addrTotalLen = 0;
   int addrCount = 0;
 


### PR DESCRIPTION
Previous PRs #16585, #20256 broke tools/websocket_to_posix_proxy to no longer compile on Windows with Visual Studio. Fix errors and warnings to make the test sockets.test_posix_proxy_sockets to pass on Windows again.

CMake Error at CMakeLists.txt:8 (target_link_libraries):
  Cannot specify link libraries for target "websocket_to_posix_proxy" which
  is not built by this project.

websocket_to_posix_proxy.obj : error LNK2001: unresolved external symbol webSocketSendLock [C:\emsdk\emscripten\main\out\test\websocket_to_posix_proxy.vcxproj]
    Hint on symbols that are defined and could potentially match:
      "struct _RTL_CRITICAL_SECTION webSocketSendLock" (?webSocketSendLock@@3U_RTL_CRITICAL_SECTION@@A)

C:\emsdk\emscripten\main\tools\websocket_to_posix_proxy\src\websocket_to_posix_proxy.c(117,29): warning C4244: '=': conversion from 'uint64_t' to 'unsigned int', possible loss of data

C:\emsdk\emscripten\main\tools\websocket_to_posix_proxy\src\main.cpp(113,12): warning C4477: 'printf' : format string '%lu' requires an argument of type 'unsigned long', but variadic argument 1 has type 'uint64_t' [C:\emsdk\emscripten\main\out\test\websocket_to_posix_proxy.vcxproj]
C:\emsdk\emscripten\main\tools\websocket_to_posix_proxy\src\main.cpp(113,12): warning C4477: 'printf' : format string '%lu' requires an argument of type 'unsigned long', but variadic argument 2 has type 'uint64_t' [C:\emsdk\emscripten\main\out\test\websocket_to_posix_proxy.vcxproj]
C:\emsdk\emscripten\main\tools\websocket_to_posix_proxy\src\main.cpp(190,10): warning C4477: 'printf' : format string '%lu' requires an argument of type 'unsigned long', but variadic argument 4 has type 'uint64_t' [C:\emsdk\emscripten\main\out\test\websocket_to_posix_proxy.vcxproj]
C:\emsdk\emscripten\main\tools\websocket_to_posix_proxy\src\main.cpp(197,14): warning C4477: 'printf' : format string '%lu' requires an argument of type 'unsigned long', but variadic argument 1 has type 'uint64_t' [C:\emsdk\emscripten\main\out\test\websocket_to_posix_proxy.vcxproj]

C:\emsdk\emscripten\main\tools\websocket_to_posix_proxy\src\websocket_to_posix_proxy.c(109,89): error C2059: syntax error: '}' [C:\emsdk\emscripten\main\out\test\ websocket_to_posix_proxy.vcxproj]
C:\emsdk\emscripten\main\tools\websocket_to_posix_proxy\src\websocket_to_posix_proxy.c(970,41): error C2059: syntax error: '}' [C:\emsdk\emscripten\main\out\test\ websocket_to_posix_proxy.vcxproj]
C:\emsdk\emscripten\main\tools\websocket_to_posix_proxy\src\websocket_to_posix_proxy.c(1449,38): error C2059: syntax error: '}' [C:\emsdk\emscripten\main\out\test \websocket_to_posix_proxy.vcxproj]