### PR TITLE
Fix Closure breaking AUDIO_WORKLET

### DIFF
--- a/src/audio_worklet.js
+++ b/src/audio_worklet.js
@@ -168,15 +168,19 @@ class BootstrapMessages extends AudioWorkletProcessor {
         }
 #endif
         // Register a real AudioWorkletProcessor that will actually do audio processing.
-        registerProcessor(d['_wpn'], createWasmAudioWorkletProcessor(d['audioParams']));
+        // 'ap' being the audio params
+        registerProcessor(d['_wpn'], createWasmAudioWorkletProcessor(d['ap']));
 #if WEBAUDIO_DEBUG
-        console.log(`Registered a new WasmAudioWorkletProcessor "${d['_wpn']}" with AudioParams: ${d['audioParams']}`);
+        console.log(`Registered a new WasmAudioWorkletProcessor "${d['_wpn']}" with AudioParams: ${d['ap']}`);
 #endif
         // Post a Wasm Call message back telling that we have now registered the
         // AudioWorkletProcessor class, and should trigger the user onSuccess
         // callback of the
         // emscripten_create_wasm_audio_worklet_processor_async() call.
-        p.postMessage({'_wsc': d['callback'], 'x': [d['contextHandle'], 1/*EM_TRUE*/, d['userData']] }); // "WaSm Call"
+        // 'cb' is the callback function
+        // 'ch' the context handle
+        // 'ud' the passed user data
+        p.postMessage({'_wsc': d['cb'], 'x': [d['ch'], 1/*EM_TRUE*/, d['ud']] }); // "WaSm Call"
       } else if (d['_wsc']) {
         // '_wsc' is short for 'wasm call', using an identifier that will never
         // conflict with user messages

--- a/src/audio_worklet.js
+++ b/src/audio_worklet.js
@@ -174,16 +174,16 @@ class BootstrapMessages extends AudioWorkletProcessor {
         console.log(`Registered a new WasmAudioWorkletProcessor "${d['_wpn']}" with AudioParams: ${d['ap']}`);
 #endif
         // Post a Wasm Call message back telling that we have now registered the
-        // AudioWorkletProcessor class, and should trigger the user onSuccess
-        // callback of the
-        // emscripten_create_wasm_audio_worklet_processor_async() call.
-        // 'cb' is the callback function
-        // 'ch' the context handle
-        // 'ud' the passed user data
-        p.postMessage({'_wsc': d['cb'], 'x': [d['ch'], 1/*EM_TRUE*/, d['ud']] }); // "WaSm Call"
-      } else if (d['_wsc']) {
+        // AudioWorkletProcessor, and should trigger the user onSuccess callback
+        // of the emscripten_create_wasm_audio_worklet_processor_async() call.
+        //
         // '_wsc' is short for 'wasm call', using an identifier that will never
         // conflict with user messages
+        // 'cb' the callback function
+        // 'ch' the context handle
+        // 'ud' the passed user data
+        p.postMessage({'_wsc': d['cb'], 'x': [d['ch'], 1/*EM_TRUE*/, d['ud']] });
+      } else if (d['_wsc']) {
         Module['wasmTable'].get(d['_wsc'])(...d['x']);
       };
     }

--- a/src/library_webaudio.js
+++ b/src/library_webaudio.js
@@ -249,14 +249,15 @@ let LibraryWebAudio = {
 #endif
 
     EmAudio[contextHandle].audioWorklet.bootstrapMessage.port.postMessage({
-      // '_wpn' == 'Worklet Processor Name', use a deliberately mangled name so
-      // that this field won't accidentally be mixed with user submitted
-      // messages.
+      // Deliberately mangled and short names used here ('_wpn', the 'Worklet
+      // Processor Name', to not get accidentally mixed with user submitted
+      // messages, the remainder for space saving reasons, abbreviated from
+      // their variable names).
       '_wpn': UTF8ToString(HEAPU32[options]),
-      'audioParams': audioParams,
-      'contextHandle': contextHandle,
-      'callback': callback,
-      'userData': userData
+      'ap': audioParams,
+      'ch': contextHandle,
+      'cb': callback,
+      'ud': userData
     });
   },
 

--- a/src/library_webaudio.js
+++ b/src/library_webaudio.js
@@ -253,9 +253,9 @@ let LibraryWebAudio = {
 
     EmAudio[contextHandle].audioWorklet.bootstrapMessage.port.postMessage({
       // Deliberately mangled and short names used here ('_wpn', the 'Worklet
-      // Processor Name', to not get accidentally mixed with user submitted
-      // messages, the remainder for space saving reasons, abbreviated from
-      // their variable names).
+      // Processor Name' used as a 'key' to verify the message type so as to
+      // not get accidentally mixed with user submitted messages, the remainder
+      // for space saving reasons, abbreviated from their variable names).
       '_wpn': UTF8ToString(HEAPU32[options]),
       'ap': audioParams,
       'ch': contextHandle,

--- a/src/library_webaudio.js
+++ b/src/library_webaudio.js
@@ -252,11 +252,11 @@ let LibraryWebAudio = {
       // '_wpn' == 'Worklet Processor Name', use a deliberately mangled name so
       // that this field won't accidentally be mixed with user submitted
       // messages.
-      _wpn: UTF8ToString(HEAPU32[options]),
-      audioParams,
-      contextHandle,
-      callback,
-      userData
+      '_wpn': UTF8ToString(HEAPU32[options]),
+      'audioParams': audioParams,
+      'contextHandle': contextHandle,
+      'callback': callback,
+      'userData': userData
     });
   },
 

--- a/src/library_webaudio.js
+++ b/src/library_webaudio.js
@@ -122,9 +122,12 @@ let LibraryWebAudio = {
   },
 
 #if AUDIO_WORKLET
+  // emscripten_start_wasm_audio_worklet_thread_async() doesn't use stackAlloc,
+  // etc., but the created worklet does.
   emscripten_start_wasm_audio_worklet_thread_async__deps: [
     '$_wasmWorkersID',
-    '$_EmAudioDispatchProcessorCallback'],
+    '$_EmAudioDispatchProcessorCallback',
+    '$stackAlloc', '$stackRestore', '$stackSave'],
   emscripten_start_wasm_audio_worklet_thread_async: (contextHandle, stackLowestAddress, stackSize, callback, userData) => {
 
 #if ASSERTIONS

--- a/src/runtime_shared.js
+++ b/src/runtime_shared.js
@@ -13,7 +13,7 @@
     if (!shouldExport) {
       if (MODULARIZE && EXPORT_ALL) {
         shouldExport = true;
-      } else if (AUDIO_WORKLET && (x == 'HEAP32' || x == 'HEAPU32')) {
+      } else if (AUDIO_WORKLET && (x == 'HEAP32' || x == 'HEAPU32' || x == 'HEAPF32')) {
         // Export to the AudioWorkletGlobalScope the needed variables to access
         // the heap. AudioWorkletGlobalScope is unable to access global JS vars
         // in the compiled main JS file.

--- a/src/runtime_shared.js
+++ b/src/runtime_shared.js
@@ -13,7 +13,7 @@
     if (!shouldExport) {
       if (MODULARIZE && EXPORT_ALL) {
         shouldExport = true;
-      } else if (AUDIO_WORKLET && (x == 'HEAP32' || x == 'HEAPU32' || x == 'HEAPF32')) {
+      } else if (AUDIO_WORKLET && (x == 'HEAPU32' || x == 'HEAPF32')) {
         // Export to the AudioWorkletGlobalScope the needed variables to access
         // the heap. AudioWorkletGlobalScope is unable to access global JS vars
         // in the compiled main JS file.


### PR DESCRIPTION
If building with `-sAUDIO_WORKLET` and `--closure=1` the generated glue JS will minimise the property names passed to the worklet's message handler:
https://github.com/emscripten-core/emscripten/blob/9445d6a1c3e3872d6e909565301a47c9c4fbd35b/src/audio_worklet.js#L179
E.g. these are received as:
```
A: 3,
B: 1,
F: 0,
s: "noise-generator"
```
No sound will be generated as a result, since calls to `emscripten_create_wasm_audio_worklet_processor_async()` will never call the passed function.

The quick fix being to add the names to the literal notation for the message (as per the commit). It might be worthwhile renaming the property names to something shorter though whilst making the changes.

Compiling any of the [webaudio](//github.com/emscripten-core/emscripten/tree/5402fc921374cf11f19600e5c3f23eeae76fba5c/test/webaudio) tests with `--closure` will reproduce the error:
```
emcc -O2 --closure=1 -sAUDIO_WORKLET=1 -sWASM_WORKERS=1 -o index.html tone_generator.c
```
Links here for precompiled [before](//wip.numfum.com/cw/2024-08-29/before.html) and [after](//wip.numfum.com/cw/2024-08-29/after.html). On the _before_ test the 'Toggle playback' button doesn't get added because [AudioWorkletProcessorCreated](//github.com/emscripten-core/emscripten/blob/5402fc921374cf11f19600e5c3f23eeae76fba5c/test/webaudio/tone_generator.c#L65) never gets called.