### PR TITLE
Fix flakiness in test_futimens_rawfs

### DIFF
--- a/src/closure-externs/node-externs.js
+++ b/src/closure-externs/node-externs.js
@@ -104,3 +104,18 @@ Buffer.prototype.toString = function(encoding, start, end) {};
 
 Worker.prototype.ref = function() {};
 Worker.prototype.unref = function() {};
+
+/**
+ * @type {number}
+ */
+fs.Stats.prototype.atimeMs;
+
+/**
+ * @type {number}
+ */
+fs.Stats.prototype.mtimeMs;
+
+/**
+ * @type {number}
+ */
+fs.Stats.prototype.ctimeMs;

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -93,8 +93,8 @@ addToLibrary({
     },
     utime(path, atime, mtime) {
       // -1 here for atime or mtime means UTIME_OMIT was passed.  Since node
-      // doean't support this concept we need first find the existing timestamps
-      // in order to preserve them.
+      // doesn't support this concept we need to first find the existing
+      // timestamps in order to preserve them.
       if (atime == -1 || mtime == -1) {
         var st = fs.statSync(path);
         if (atime == -1) atime = st.atimeMs;

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -91,7 +91,17 @@ addToLibrary({
       var stream = FS.getStreamChecked(fd);
       fs.ftruncateSync(stream.nfd, len);
     },
-    utime(path, atime, mtime) { fs.utimesSync(path, atime/1000, mtime/1000); },
+    utime(path, atime, mtime) {
+      // -1 here for atime or mtime means UTIME_OMIT was passed.  Since node
+      // doean't support this concept we need first find the existing timestamps
+      // in order to preserve them.
+      if (atime == -1 || mtime == -1) {
+        var st = fs.statSync(path);
+        if (atime == -1) atime = st.atimeMs;
+        if (mtime == -1) mtime = st.mtimeMs;
+      }
+      fs.utimesSync(path, atime/1000, mtime/1000);
+    },
     open(path, flags, mode) {
       if (typeof flags == "string") {
         flags = FS_modeStringToFlags(flags)


### PR DESCRIPTION
This newly added test was flaky because noderawfs wasn't handling the value of -1 correctly here.