### PR TITLE
Fix Typo: Add Missing End Quote In Code Block

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -1078,7 +1078,7 @@ For convenience, *embind* provides factory functions to register
     EMSCRIPTEN_BINDINGS(stl_wrappers) {
         register_vector<int>("VectorInt");
         register_map<int,int>("MapIntInt");
-        register_optional<std::string>("Optional);
+        register_optional<std::string>("Optional");
     }
 
 A full example is shown below:


### PR DESCRIPTION
There was a code block with a string `"Optional"` that was missing an end quote.

```C++
EMSCRIPTEN_BINDINGS(stl_wrappers) {
    register_vector<int>("VectorInt");
    register_map<int,int>("MapIntInt");
    register_optional<std::string>("Optional);
}
```

This pull request adds the missing end quote.
```C++
EMSCRIPTEN_BINDINGS(stl_wrappers) {
    register_vector<int>("VectorInt");
    register_map<int,int>("MapIntInt");
    register_optional<std::string>("Optional");
}
```

> URL: https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html#built-in-type-conversions