### PR TITLE
Check if cmake is on the PATH in emcmake.py

### DIFF
--- a/emcmake.py
+++ b/emcmake.py
@@ -45,6 +45,11 @@ variables so that emcc etc. are used. Typical usage:
     # See https://github.com/emscripten-core/emscripten/issues/15522
     args.append(f'-DCMAKE_CROSSCOMPILING_EMULATOR={node_js}')
 
+  # Print a better error if we have no CMake executable on the PATH
+  if not os.path.isabs(args[0]) and not shutil.which(args[0]):
+    print(f'emcmake: cmake executable not found on PATH: `{args[0]}`')
+    return 1
+
   # On Windows specify MinGW Makefiles or ninja if we have them and no other
   # toolchain was specified, to keep CMake from pulling in a native Visual
   # Studio, or Unix Makefiles.

--- a/emcmake.py
+++ b/emcmake.py
@@ -46,7 +46,7 @@ variables so that emcc etc. are used. Typical usage:
     args.append(f'-DCMAKE_CROSSCOMPILING_EMULATOR={node_js}')
 
   # Print a better error if we have no CMake executable on the PATH
-  if not os.path.isabs(args[0]) and not shutil.which(args[0]):
+  if not os.path.dirname(args[0]) and not shutil.which(args[0]):
     print(f'emcmake: cmake executable not found on PATH: `{args[0]}`')
     return 1
 

--- a/emcmake.py
+++ b/emcmake.py
@@ -47,7 +47,7 @@ variables so that emcc etc. are used. Typical usage:
 
   # Print a better error if we have no CMake executable on the PATH
   if not os.path.dirname(args[0]) and not shutil.which(args[0]):
-    print(f'emcmake: cmake executable not found on PATH: `{args[0]}`')
+    print(f'emcmake: cmake executable not found on PATH: `{args[0]}`', file=sys.stderr)
     return 1
 
   # On Windows specify MinGW Makefiles or ninja if we have them and no other


### PR DESCRIPTION
Currently, users who run emcmake without cmake on the PATH are greeted with confusing errors like:

```
emcmake cmake ..
configure: cmake .. -DCMAKE_TOOLCHAIN_FILE=D:\src\emsdk\upstream\emscripten\cmake\Modules\Platform\Emscripten.cmake -DCMAKE_CROSSCOMPILING_EMULATOR=D:/src/emsdk/node/18.20.3_64bit/bin/node.exe -G Ninja emcmake: error: 'cmake .. -DCMAKE_TOOLCHAIN_FILE=D:\src\emsdk\upstream\emscripten\cmake\Modules\Platform\Emscripten.cmake -DCMAKE_CROSSCOMPILING_EMULATOR=D:/src/emsdk/node/18.20.3_64bit/bin/node.exe -G Ninja' failed: [WinError 2] The system cannot find the file specified
```