### PR TITLE
WebGPU: support Premultiplied canvas output

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -109,6 +109,7 @@ wgpu${type}Release: (id) => WebGPU.mgr${type}.release(id),`;
     CompositeAlphaMode: {
       Auto: 0,
       Opaque: 1,
+      Premultiplied: 2,
     },
     CreatePipelineAsyncStatus: {
       Success: 0,
@@ -436,6 +437,11 @@ var LibraryWebGPU = {
       'clamp-to-edge',
       'repeat',
       'mirror-repeat',
+    ],
+    AlphaMode: [
+      undefined, // "Auto" uses the default (which is always opaque according to the spec's IDL)
+      'opaque',
+      'premultiplied',
     ],
     BlendFactor: [
       undefined,
@@ -2753,10 +2759,6 @@ var LibraryWebGPU = {
     var viewFormatCount = {{{ gpu.makeGetU32('config', C_STRUCTS.WGPUSurfaceConfiguration.viewFormatCount) }}};
     var viewFormats = {{{ makeGetValue('config', C_STRUCTS.WGPUSurfaceConfiguration.viewFormats, '*') }}};
     assert(viewFormatCount === 0 && viewFormats === 0, "TODO: Support viewFormats.");
-    var alphaMode = {{{ gpu.makeGetU32('config', C_STRUCTS.WGPUSurfaceConfiguration.alphaMode) }}};
-    assert(alphaMode === {{{ gpu.CompositeAlphaMode.Auto }}} ||
-      alphaMode === {{{ gpu.CompositeAlphaMode.Opaque }}},
-      "TODO: Support WGPUCompositeAlphaMode_Premultiplied.");
     assert({{{ gpu.PresentMode.Fifo }}} ===
       {{{ gpu.makeGetU32('config', C_STRUCTS.WGPUSurfaceConfiguration.presentMode) }}});
 #endif
@@ -2779,7 +2781,8 @@ var LibraryWebGPU = {
       "format": WebGPU.TextureFormat[
         {{{ gpu.makeGetU32('config', C_STRUCTS.WGPUSurfaceConfiguration.format) }}}],
       "usage": {{{ gpu.makeGetU32('config', C_STRUCTS.WGPUSurfaceConfiguration.usage) }}},
-      "alphaMode": "opaque",
+      "alphaMode": WebGPU.AlphaMode[
+        {{{ gpu.makeGetU32('config', C_STRUCTS.WGPUSurfaceConfiguration.alphaMode) }}}],
     };
     context.configure(configuration);
   },


### PR DESCRIPTION
(Note the default HTML template page's canvas has a black background, so the difference is not visible there.)

Fixes #22491