### PR TITLE
Use object literal shorthand in js_optimizer. NFC

### DIFF
--- a/test/js_optimizer/JSDCE-defaultArg-output.js
+++ b/test/js_optimizer/JSDCE-defaultArg-output.js
@@ -2,7 +2,7 @@ var usedAsDefaultArg = 42;
 
 var usedAsDefaultArg2 = [ 1, 2 ];
 
-function g({notUsed: notUsed}, a, b = usedAsDefaultArg, [c, d] = usedAsDefaultArg2) {
+function g({notUsed}, a, b = usedAsDefaultArg, [c, d] = usedAsDefaultArg2) {
   return a + b + notUsed + 1;
 }
 

--- a/test/js_optimizer/JSDCE-objectPattern-output.js
+++ b/test/js_optimizer/JSDCE-objectPattern-output.js
@@ -3,7 +3,7 @@ let d = 40;
 let z = 50;
 
 globalThis.f = function([, r]) {
-  let {a: a, b: b} = r;
+  let {a, b} = r;
   let {z: c} = r;
   let [, i, {foo: p, bar: q}] = r;
   return g(a, b, c, d, z);

--- a/test/js_optimizer/applyImportAndExportNameChanges2-output.js
+++ b/test/js_optimizer/applyImportAndExportNameChanges2-output.js
@@ -246,9 +246,9 @@ env["__memory_base"] = STATIC_BASE;
 env["__table_base"] = 0;
 
 var imports = {
-  env: env,
+  env,
   global: {
-    NaN: NaN,
+    NaN,
     Infinity: Infinity
   },
   "global.Math": Math,

--- a/test/js_optimizer/constructor-output.js
+++ b/test/js_optimizer/constructor-output.js
@@ -40,17 +40,17 @@ function u(a) {
     };
   }
   return m({
-    Int8Array: Int8Array,
-    Int16Array: Int16Array,
-    Int32Array: Int32Array,
-    Uint8Array: Uint8Array,
-    Uint16Array: Uint16Array,
-    Uint32Array: Uint32Array,
-    Float32Array: Float32Array,
-    Float64Array: Float64Array,
-    NaN: NaN,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    Float32Array,
+    Float64Array,
+    NaN,
     Infinity: Infinity,
-    Math: Math
+    Math
   }, q, r.buffer);
 }
 // EMSCRIPTEN_END_ASM

--- a/test/js_optimizer/test-object-literals-output.js
+++ b/test/js_optimizer/test-object-literals-output.js
@@ -1,0 +1,13 @@
+var foo = 1;
+
+var baz = {};
+
+var bar = {
+  foo,
+  baz
+};
+
+var bar2 = {
+  foo,
+  baz
+};

--- a/test/js_optimizer/test-object-literals-output.js
+++ b/test/js_optimizer/test-object-literals-output.js
@@ -9,5 +9,6 @@ var bar = {
 
 var bar2 = {
   foo,
-  baz
+  baz,
+  bar: foo
 };

--- a/test/js_optimizer/test-object-literals.js
+++ b/test/js_optimizer/test-object-literals.js
@@ -1,0 +1,14 @@
+var foo = 1;
+var baz = {};
+
+// Verify that shorthand object literals are preserved.
+var bar = {
+  foo,
+  baz,
+};
+
+// Objects that don't use shorthand should also be preserved, as-is
+var bar2 = {
+  foo: foo,
+  baz: baz,
+};

--- a/test/js_optimizer/test-object-literals.js
+++ b/test/js_optimizer/test-object-literals.js
@@ -7,8 +7,9 @@ var bar = {
   baz,
 };
 
-// Objects that don't use shorthand should also be preserved, as-is
+// Objects that could use shorthand are also converted where possible.
 var bar2 = {
   foo: foo,
-  baz: baz,
+  "baz": baz,
+  bar: foo,
 };

--- a/test/js_optimizer/wasm2js-output.js
+++ b/test/js_optimizer/wasm2js-output.js
@@ -430,17 +430,17 @@ function X() {}
     };
   }
   return D({
-    Int8Array: Int8Array,
-    Int16Array: Int16Array,
-    Int32Array: Int32Array,
-    Uint8Array: Uint8Array,
-    Uint16Array: Uint16Array,
-    Uint32Array: Uint32Array,
-    Float32Array: Float32Array,
-    Float64Array: Float64Array,
-    NaN: NaN,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    Float32Array,
+    Float64Array,
+    NaN,
     Infinity: Infinity,
-    Math: Math
+    Math
   }, H, I.buffer);
 }
 // EMSCRIPTEN_END_ASM

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2889,6 +2889,7 @@ More info: https://emscripten.org
     'unsignPointers': ('test-unsignPointers.js', ['unsignPointers', '--closure-friendly']),
     'asanify': ('test-asanify.js', ['asanify']),
     'safeHeap': ('test-safeHeap.js', ['safeHeap']),
+    'object_literals': ('test-object-literals.js', []),
     'LittleEndianHeap': ('test-LittleEndianHeap.js', ['littleEndianHeap']),
   })
   @crossplatform

--- a/tools/acorn-optimizer.mjs
+++ b/tools/acorn-optimizer.mjs
@@ -2107,6 +2107,7 @@ if (!noPrint) {
     keep_quoted_props: closureFriendly, // for closure
     wrap_func_args: false, // don't add extra braces
     comments: true, // for closure as well
+    shorthand: true, // Use object literal shorthand notation
   });
 
   output += '\n';


### PR DESCRIPTION
Without this change running code trough acorn-optimizer will expand these object literals, removing the use of the shorthand.
