### PR TITLE
Micro-optimize emscripten_request_animation_frame_loop()

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2471,12 +2471,13 @@ var LibraryHTML5 = {
   emscripten_cancel_animation_frame: (id) => cancelAnimationFrame(id),
 
   emscripten_request_animation_frame_loop: (cb, userData) => {
+    cb = {{{ makeDynCall('idp', 'cb') }}};
     function tick(timeStamp) {
-      if ({{{ makeDynCall('idp', 'cb') }}}(timeStamp, userData)) {
+      if (cb(timeStamp, userData)) {
         requestAnimationFrame(tick);
       }
     }
-    return requestAnimationFrame(tick);
+    requestAnimationFrame(tick);
   },
 
   emscripten_date_now: () => Date.now(),


### PR DESCRIPTION
Micro-optimize emscripten_request_animation_frame_loop(): the return type is void, so avoid redundant return, and hoist the getWasmTableEntry() call to occur only once up front.