### PR TITLE
Simplify `from64` macro

### DIFF
--- a/src/library_ccall.js
+++ b/src/library_ccall.js
@@ -46,8 +46,7 @@ addToLibrary({
 
     function convertReturnValue(ret) {
       if (returnType === 'string') {
-        {{{ from64('ret') }}}
-        return UTF8ToString(ret);
+        return UTF8ToString({{{ from64Expr('ret') }}});
       }
 #if MEMORY64
       if (returnType === 'pointer') return Number(ret);

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -814,8 +814,7 @@ var LibraryDylink = {
         for (var name in moduleExports) {
           if (name.startsWith('__em_js__')) {
             var start = moduleExports[name]
-            {{{ from64('start') }}}
-            var jsString = UTF8ToString(start);
+            var jsString = UTF8ToString({{{ from64Expr('start') }}});
             // EM_JS strings are stored in the data section in the form
             // SIG<::>BODY.
             var parts = jsString.split('<::>');

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -949,18 +949,18 @@ function receiveI64ParamAsI53Unchecked(name) {
   return `var ${name} = convertI32PairToI53(${name}_low, ${name}_high);`;
 }
 
-// Any function called from wasm64 may have bigint args, this function takes
-// a list of variable names to convert to number.
+// Convert a pointer value under wasm64 from BigInt (used at local level API
+// level) to Number (used in JS library code).  No-op under wasm32.
 function from64(x) {
-  if (!MEMORY64) {
-    return '';
-  }
-  if (Array.isArray(x)) {
-    let ret = '';
-    for (e of x) ret += from64(e);
-    return ret;
-  }
+  if (!MEMORY64) return '';
   return `${x} = Number(${x});`;
+}
+
+// Like from64 above but generate an expression instead of an assignment
+// statement.
+function from64Expr(x, assign = true) {
+  if (!MEMORY64) return x;
+  return `Number(${x})`;
 }
 
 function to64(x) {
@@ -1118,6 +1118,7 @@ addToCompileTimeContext({
   expectToReceiveOnModule,
   formattedMinNodeVersion,
   from64,
+  from64Expr,
   getEntryFunction,
   getHeapForType,
   getHeapOffset,


### PR DESCRIPTION
Also, add a variant that simply generates an expression, similar to how the `to64` macro works.  This is needed for #22497