### PR TITLE
Fix automatic run of interactive web audio tests.

### DIFF
--- a/test/webaudio/audio_worklet_tone_generator.c
+++ b/test/webaudio/audio_worklet_tone_generator.c
@@ -84,6 +84,9 @@ void AudioWorkletProcessorCreated(EMSCRIPTEN_WEBAUDIO_T audioContext, EM_BOOL su
 
   EM_ASM({
     let audioContext = emscriptenGetAudioObject($0);
+    let audioWorkletNode = emscriptenGetAudioObject($1);
+    // Connect the audio worklet node to the graph.
+    audioWorkletNode.connect(audioContext.destination);
 
     // Add a button on the page to toggle playback as a response to user click.
     let startButton = document.createElement('button');
@@ -93,10 +96,6 @@ void AudioWorkletProcessorCreated(EMSCRIPTEN_WEBAUDIO_T audioContext, EM_BOOL su
     startButton.onclick = () => {
       if (audioContext.state != 'running') {
         audioContext.resume();
-        let audioWorkletNode = emscriptenGetAudioObject($1);
-
-        // Connect the audio worklet node to the graph.
-        audioWorkletNode.connect(audioContext.destination);
       } else {
         audioContext.suspend();
       }

--- a/test/webaudio/audioworklet.c
+++ b/test/webaudio/audioworklet.c
@@ -50,6 +50,8 @@ EM_BOOL ProcessAudio(int numInputs, const AudioSampleFrame *inputs, int numOutpu
 EM_JS(void, InitHtmlUi, (EMSCRIPTEN_WEBAUDIO_T audioContext, EMSCRIPTEN_AUDIO_WORKLET_NODE_T audioWorkletNode), {
   audioContext = emscriptenGetAudioObject(audioContext);
   audioWorkletNode = emscriptenGetAudioObject(audioWorkletNode);
+  // Connect the audio worklet node to the graph.
+  audioWorkletNode.connect(audioContext.destination);
 
   // Add a button on the page to toggle playback as a response to user click.
   let startButton = document.createElement('button');
@@ -59,8 +61,6 @@ EM_JS(void, InitHtmlUi, (EMSCRIPTEN_WEBAUDIO_T audioContext, EMSCRIPTEN_AUDIO_WO
   startButton.onclick = () => {
     if (audioContext.state != 'running') {
       audioContext.resume();
-      // Connect the audio worklet node to the graph.
-      audioWorkletNode.connect(audioContext.destination);
     } else {
       audioContext.suspend();
     }

--- a/test/webaudio/audioworklet_emscripten_futex_wake.cpp
+++ b/test/webaudio/audioworklet_emscripten_futex_wake.cpp
@@ -29,12 +29,12 @@ EM_BOOL ProcessAudio(int numInputs, const AudioSampleFrame *inputs, int numOutpu
 EM_JS(void, InitHtmlUi, (EMSCRIPTEN_WEBAUDIO_T audioContext, EMSCRIPTEN_AUDIO_WORKLET_NODE_T audioWorkletNode), {
   audioContext = emscriptenGetAudioObject(audioContext);
   audioWorkletNode = emscriptenGetAudioObject(audioWorkletNode);
+  audioWorkletNode.connect(audioContext.destination);
   let startButton = document.createElement('button');
   startButton.innerHTML = 'Start playback';
   document.body.appendChild(startButton);
 
   startButton.onclick = () => {
-    audioWorkletNode.connect(audioContext.destination);
     audioContext.resume();
   };
 });


### PR DESCRIPTION
Audio contexts cannot start until human interacts with the page, e.g. by clicking a button.

Therefore interactive audioworklet tests require user to press a button.

However, after clicking a button, all later interactive tests will have the audio context access already unlocked, so user does not need to click a button on each test when running multiple audio worklet tests, only the first one.

In such scenario, there was a bug that nothing played back from speakers on later tests, because the audio worklet was not connected to output on those later tests until user clicks a button. But since this button click was not needed, the subsequent interactive tests would surprisingly pass without actually playing back any audio.