### PR TITLE
Remove unsed/unneeded code in in proxyClient.js

### DIFF
--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -120,22 +120,18 @@ if (typeof window != 'undefined') {
 
 var frameId = 0;
 
-// Temporarily handling this at run-time pending Python preprocessor support
-
-var SUPPORT_BASE64_EMBEDDING;
-
 // Worker
 
 var filename;
 filename ||= '<<< filename >>>';
 
 var workerURL = filename;
-if (SUPPORT_BASE64_EMBEDDING) {
-  var fileBytes = tryParseAsDataURI(filename);
-  if (fileBytes) {
-    workerURL = URL.createObjectURL(new Blob([fileBytes], {type: 'application/javascript'}));
-  }
+#if SUPPORT_BASE64_EMBEDDING
+var fileBytes = tryParseAsDataURI(filename);
+if (fileBytes) {
+  workerURL = URL.createObjectURL(new Blob([fileBytes], {type: 'application/javascript'}));
 }
+#endif
 var worker = new Worker(workerURL);
 
 #if ENVIRONMENT_MAY_BE_NODE
@@ -166,7 +162,9 @@ worker.onmessage = (event) => {
   if (!workerResponded) {
     workerResponded = true;
     Module.setStatus?.('');
-    if (SUPPORT_BASE64_EMBEDDING && workerURL !== filename) URL.revokeObjectURL(workerURL);
+#if SUPPORT_BASE64_EMBEDDING
+    if (workerURL !== filename) URL.revokeObjectURL(workerURL);
+#endif
   }
 
   var data = event.data;

--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -125,14 +125,7 @@ var frameId = 0;
 var filename;
 filename ||= '<<< filename >>>';
 
-var workerURL = filename;
-#if SUPPORT_BASE64_EMBEDDING
-var fileBytes = tryParseAsDataURI(filename);
-if (fileBytes) {
-  workerURL = URL.createObjectURL(new Blob([fileBytes], {type: 'application/javascript'}));
-}
-#endif
-var worker = new Worker(workerURL);
+var worker = new Worker(filename);
 
 #if ENVIRONMENT_MAY_BE_NODE
 if (ENVIRONMENT_IS_NODE) {
@@ -162,9 +155,6 @@ worker.onmessage = (event) => {
   if (!workerResponded) {
     workerResponded = true;
     Module.setStatus?.('');
-#if SUPPORT_BASE64_EMBEDDING
-    if (workerURL !== filename) URL.revokeObjectURL(workerURL);
-#endif
   }
 
   var data = event.data;

--- a/tools/link.py
+++ b/tools/link.py
@@ -2640,7 +2640,7 @@ def generate_html(target, options, js_target, target_basename, wasm_target):
 
 def generate_worker_js(target, js_target, target_basename):
   if settings.SINGLE_FILE:
-    # compiler output is embedded as base64
+    # compiler output is embedded as base64 data URL
     proxy_worker_filename = get_subresource_location(js_target)
   else:
     # compiler output goes in .worker.js file
@@ -2655,7 +2655,7 @@ def generate_worker_js(target, js_target, target_basename):
 def worker_js_script(proxy_worker_filename):
   web_gl_client_src = read_file(utils.path_from_root('src/webGLClient.js'))
   proxy_client_src = shared.read_and_preprocess(utils.path_from_root('src/proxyClient.js'), expand_macros=True)
-  if not os.path.dirname(proxy_worker_filename):
+  if not settings.SINGLE_FILE and not os.path.dirname(proxy_worker_filename):
     proxy_worker_filename = './' + proxy_worker_filename
   proxy_client_src = do_replace(proxy_client_src, '<<< filename >>>', proxy_worker_filename)
   return web_gl_client_src + '\n' + proxy_client_src


### PR DESCRIPTION
The code being removed here was never been used because the local `SUPPORT_BASE64_EMBEDDING` variable was never being set.

The code is not needed since `new Worker` already operates on data URLs and `<<< filename >>>` is encoded as a data URL in SINGLE_FILE mode.