### PR TITLE
Avoid reading in logo data if we don't need it.

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -2573,9 +2573,10 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
 
   shell = do_replace(shell, '{{{ SCRIPT }}}', script.replacement())
   shell = shell.replace('{{{ SHELL_CSS }}}', utils.read_file(utils.path_from_root('src/shell.css')))
-  logo_filename = utils.path_from_root('media/powered_by_logo_shell.png')
-  logo_b64 = base64_encode(logo_filename)
-  shell = shell.replace('{{{ SHELL_LOGO }}}', f'<img id="emscripten_logo" src="data:image/png;base64,{logo_b64}">')
+  if '{{{ SHELL_LOGO }}}' in shell:
+    logo_filename = utils.path_from_root('media/powered_by_logo_shell.png')
+    logo_b64 = base64_encode(logo_filename)
+    shell = shell.replace('{{{ SHELL_LOGO }}}', f'<img id="emscripten_logo" src="data:image/png;base64,{logo_b64}">')
 
   check_output_file(target)
   write_file(target, shell)


### PR DESCRIPTION
When using a custom shell (potentially without the availability of the logo image), only try to read the logo if necessary.