### PR TITLE
Use `bool` type for `simulate_infinite_loop` argument of `emscripten_set_main_loop`

### DIFF
--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -349,7 +349,7 @@ Guide material for the following APIs can be found in :ref:`emscripten-runtime-e
 Functions
 ---------
 
-.. c:function:: void emscripten_set_main_loop(em_callback_func func, int fps, int simulate_infinite_loop)
+.. c:function:: void emscripten_set_main_loop(em_callback_func func, int fps, bool simulate_infinite_loop)
 
   Set a C function as the main event loop for the calling thread.
 
@@ -373,10 +373,10 @@ Functions
 
   :param em_callback_func func: C function to set as main event loop for the calling thread.
   :param int fps: Number of frames per second that the JavaScript will call the function. Setting ``int <=0`` (recommended) uses the browser’s ``requestAnimationFrame`` mechanism to call the function.
-  :param int simulate_infinite_loop: If true, this function will throw an exception in order to stop execution of the caller.
+  :param bool simulate_infinite_loop: If true, this function will throw an exception in order to stop execution of the caller.
 
 
-.. c:function:: void emscripten_set_main_loop_arg(em_arg_callback_func func, void *arg, int fps, int simulate_infinite_loop)
+.. c:function:: void emscripten_set_main_loop_arg(em_arg_callback_func func, void *arg, int fps, bool simulate_infinite_loop)
 
   Set a C function as the main event loop for the calling thread, passing it user-defined data.
 
@@ -385,7 +385,7 @@ Functions
   :param em_arg_callback_func func: C function to set as main event loop. The function signature must have a ``void*`` parameter for passing the ``arg`` value.
   :param void* arg: User-defined data passed to the main loop function, untouched by the API itself.
   :param int fps: Number of frames per second at which the JavaScript will call the function. Setting ``int <=0`` (recommended) uses the browser’s ``requestAnimationFrame`` mechanism to call the function.
-  :param int simulate_infinite_loop: If true, this function will throw an exception in order to stop execution of the caller.
+  :param bool simulate_infinite_loop: If true, this function will throw an exception in order to stop execution of the caller.
 
 
 .. c:function:: void emscripten_push_main_loop_blocker(em_arg_callback_func func, void *arg)

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -38,7 +38,7 @@ char *emscripten_run_script_string(const char *script __attribute__((nonnull)));
 void emscripten_async_run_script(const char *script __attribute__((nonnull)), int millis);
 void emscripten_async_load_script(const char *script __attribute__((nonnull)), em_callback_func onload, em_callback_func onerror);
 
-void emscripten_set_main_loop(em_callback_func func, int fps, int simulate_infinite_loop);
+void emscripten_set_main_loop(em_callback_func func, int fps, bool simulate_infinite_loop);
 
 #define EM_TIMING_SETTIMEOUT 0
 #define EM_TIMING_RAF 1
@@ -46,7 +46,7 @@ void emscripten_set_main_loop(em_callback_func func, int fps, int simulate_infin
 
 int emscripten_set_main_loop_timing(int mode, int value);
 void emscripten_get_main_loop_timing(int *mode, int *value); // Pass a null pointer to skip receiving that particular value
-void emscripten_set_main_loop_arg(em_arg_callback_func func, void *arg, int fps, int simulate_infinite_loop);
+void emscripten_set_main_loop_arg(em_arg_callback_func func, void *arg, int fps, bool simulate_infinite_loop);
 void emscripten_pause_main_loop(void);
 void emscripten_resume_main_loop(void);
 void emscripten_cancel_main_loop(void);


### PR DESCRIPTION
This argument has already been treated as a bool.  The change just makes it more clear.

Since `bool` (uint8_t) and `int` (int32_t) both compile down to i32 at the wasm level this change won't be backwards compatibility issue for binary object files.