### PR TITLE
Enable SINGLE_FILE + PTHREADS html output

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3693,11 +3693,17 @@ Module["preRun"] = () => {
     '': ([],),
     'O3': (['-O3'],),
     'minimal_runtime': (['-sMINIMAL_RUNTIME'],),
+    'single_file': (['-sSINGLE_FILE'],),
   })
   def test_pthread_create(self, args):
     self.btest_exit('pthread/test_pthread_create.c',
                     args=['-pthread', '-sPTHREAD_POOL_SIZE=8'] + args,
                     extra_tries=0) # this should be 100% deterministic
+    files = os.listdir('.')
+    if '-sSINGLE_FILE' in args:
+      self.assertEqual(len(files), 1, files)
+    else:
+      self.assertEqual(len(files), 4, files)
 
   # Test that preallocating worker threads work.
   def test_pthread_preallocates_workers(self):


### PR DESCRIPTION
In SINGLE_FILE mode, the JS is inlined directly into the generated HTML.  However for pthreads builds we need to be able to create workers that use the same inlined JS. To enable this we encode the JS file into a data URL that can be used for the script `src` attribute.  The pthread worker can then use this `src`.

Prior to this change using SINGLE_FILE + PTHREADS + html output would simply fail.