### PR TITLE
Add error when PROXY_TO_WORKER and SINGLE_FILE are used together.

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15117,3 +15117,7 @@ addToLibrary({
   def test_fs_writev_partial_write(self):
     self.set_setting('FORCE_FILESYSTEM')
     self.do_run_in_out_file_test('fs/test_writev_partial_write.c')
+
+  def test_proxy_to_worker_single_file(self):
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sPROXY_TO_WORKER', '-sSINGLE_FILE'])
+    self.assertContained('error: cannot have both PROXY_TO_WORKER and SINGLE_FILE enabled at the same time', err)

--- a/tools/link.py
+++ b/tools/link.py
@@ -952,15 +952,17 @@ def phase_linker_setup(options, state, newargs):
   if settings.WASM == 2 and settings.SINGLE_FILE:
     exit_with_error('cannot have both WASM=2 and SINGLE_FILE enabled at the same time')
 
+  if settings.PROXY_TO_WORKER and settings.SINGLE_FILE:
+    exit_with_error('cannot have both PROXY_TO_WORKER and SINGLE_FILE enabled at the same time')
+
   if settings.SEPARATE_DWARF and settings.WASM2JS:
     exit_with_error('cannot have both SEPARATE_DWARF and WASM2JS at the same time (as there is no wasm file)')
 
   if settings.MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION and settings.MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION:
     exit_with_error('MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION and MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION are mutually exclusive!')
 
-  if options.emrun:
-    if settings.MINIMAL_RUNTIME:
-      exit_with_error('--emrun is not compatible with MINIMAL_RUNTIME')
+  if options.emrun and settings.MINIMAL_RUNTIME:
+    exit_with_error('--emrun is not compatible with MINIMAL_RUNTIME')
 
   if options.use_closure_compiler:
     settings.USE_CLOSURE_COMPILER = 1


### PR DESCRIPTION
These settings (AFAICT) have never worked at the same time.