### PR TITLE
Remove unused argument from emscripten_notify_mailbox_postmessage. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1242,7 +1242,7 @@ var LibraryPThread = {
   // new thread that has not had a chance to initialize itself and execute
   // Atomics.waitAsync to prepare for the notification.
   _emscripten_notify_mailbox_postmessage__deps: ['$checkMailbox'],
-  _emscripten_notify_mailbox_postmessage: (targetThreadId, currThreadId, mainThreadId) => {
+  _emscripten_notify_mailbox_postmessage: (targetThreadId, currThreadId) => {
     if (targetThreadId == currThreadId) {
       setTimeout(checkMailbox);
     } else if (ENVIRONMENT_IS_PTHREAD) {

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -324,7 +324,7 @@ sigs = {
   _emscripten_init_main_thread_js__sig: 'vp',
   _emscripten_lookup_name__sig: 'ip',
   _emscripten_memcpy_js__sig: 'vppp',
-  _emscripten_notify_mailbox_postmessage__sig: 'vppp',
+  _emscripten_notify_mailbox_postmessage__sig: 'vpp',
   _emscripten_push_main_loop_blocker__sig: 'vppp',
   _emscripten_push_uncounted_main_loop_blocker__sig: 'vppp',
   _emscripten_receive_on_main_thread_js__sig: 'dippip',

--- a/system/lib/pthread/thread_mailbox.c
+++ b/system/lib/pthread/thread_mailbox.c
@@ -108,8 +108,7 @@ void emscripten_thread_mailbox_send(pthread_t thread, task t) {
     if (thread->waiting_async) {
       __builtin_wasm_memory_atomic_notify((int*)thread, -1);
     } else {
-      _emscripten_notify_mailbox_postmessage(
-        thread, pthread_self(), emscripten_main_runtime_thread_id());
+      _emscripten_notify_mailbox_postmessage(thread, pthread_self());
     }
   }
 }

--- a/system/lib/pthread/thread_mailbox.h
+++ b/system/lib/pthread/thread_mailbox.h
@@ -34,8 +34,7 @@ void _emscripten_thread_mailbox_await(pthread_t thread);
 void _emscripten_thread_mailbox_shutdown(pthread_t thread);
 
 // Send a postMessage notification telling the target thread to check its
-// mailbox when it returns to its event loop. Pass in the current thread and
-// main thread ids to minimize calls back into Wasm.
+// mailbox when it returns to its event loop. Pass in the current thread id
+// minimize calls back into Wasm.
 void _emscripten_notify_mailbox_postmessage(pthread_t target_thread,
-                                            pthread_t curr_thread,
-                                            pthread_t main_thread);
+                                            pthread_t curr_thread);


### PR DESCRIPTION
This is an internal function so changing its signature should not be a user-visible change.