### PR TITLE
[embind] Fix TS generation when using AOT JS.

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3364,11 +3364,10 @@ More info: https://emscripten.org
     'with_jsgen': [['-sEMBIND_AOT']]
   })
   def test_embind_tsgen(self, opts):
-    self.emcc_args += opts
     # Check that TypeScript generation works and that the program is runs as
     # expected.
     self.do_runf('other/embind_tsgen.cpp', 'main ran',
-                 emcc_args=['-lembind', '--emit-tsd', 'embind_tsgen.d.ts'])
+                 emcc_args=['-lembind', '--emit-tsd', 'embind_tsgen.d.ts'] + opts)
 
     # Test that the output compiles with a TS file that uses the defintions.
     cmd = shared.get_npm_cmd('tsc') + ['embind_tsgen.d.ts', '--noEmit']

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3359,7 +3359,12 @@ More info: https://emscripten.org
       '-Wno-experimental']
     self.do_runf('other/test_jspi_add_function.c', 'done')
 
-  def test_embind_tsgen(self):
+  @parameterized({
+    '': [[]],
+    'with_jsgen': [['-sEMBIND_AOT']]
+  })
+  def test_embind_tsgen(self, opts):
+    self.emcc_args += opts
     # Check that TypeScript generation works and that the program is runs as
     # expected.
     self.do_runf('other/embind_tsgen.cpp', 'main ran',

--- a/tools/link.py
+++ b/tools/link.py
@@ -1999,7 +1999,7 @@ def phase_emit_tsd(options, wasm_target, js_target, js_syms, metadata, linker_in
   filename = options.emit_tsd
   embind_tsd = ''
   if settings.EMBIND:
-    embind_tsd = run_embind_gen(wasm_target, js_syms, {'EMBIND_JS': False}, linker_inputs)
+    embind_tsd = run_embind_gen(wasm_target, js_syms, {'EMBIND_AOT': False}, linker_inputs)
   all_tsd = emscripten.create_tsd(metadata, embind_tsd)
   out_file = os.path.join(os.path.dirname(js_target), filename)
   write_file(out_file, all_tsd)


### PR DESCRIPTION
Some AOT JS was ending up in the TS definition file because the setting to turn AOT JS was wrong.