### PR TITLE
Support preallocated pthread & wasm worker from blob

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -98,10 +98,20 @@ var LibraryPThread = {
     },
     initMainThread() {
 #if PTHREAD_POOL_SIZE
-      var pthreadPoolSize = {{{ PTHREAD_POOL_SIZE }}};
-      // Start loading up the Worker pool, if requested.
-      while (pthreadPoolSize--) {
-        PThread.allocateUnusedWorker();
+      preallocateWorkers = () => {
+        var pthreadPoolSize = {{{ PTHREAD_POOL_SIZE }}};
+        // Start loading up the Worker pool, if requested.
+        while (pthreadPoolSize--) {
+         PThread.allocateUnusedWorker();
+        }
+      };
+#if expectToReceiveOnModule('mainScriptUrlOrBlobPromise')
+      if (Module['mainScriptUrlOrBlobPromise']) {
+        Module['mainScriptUrlOrBlobPromise'].then(preallocateWorkers);
+      } else 
+#endif
+      {
+        preallocateWorkers();
       }
 #endif
 #if !MINIMAL_RUNTIME

--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -182,7 +182,7 @@ if (ENVIRONMENT_IS_WASM_WORKER
       'mem': wasmMemory,
 #else
       'wasm': wasmModule,
-      'js': Module['mainScriptUrlOrBlob'] || _scriptName,
+      'js': URL.createObjectURL(Module["mainScriptUrlOrBlob"]) || _scriptName,
       'wasmMemory': wasmMemory,
 #endif
       'sb': stackLowestAddress, // sb = stack bottom (lowest stack address, SP points at this when stack is full)


### PR DESCRIPTION
This amends existing `mainScriptUrlOrBlob` logic to make sure that we can preload JS for pthread and wasm workers reliably.

On the pthread side, this amends PTHREAD_POOL_SIZE warmup logic to allow waiting for a promise on top of existing logic in `PThread.allocateUnusedWorker`. Otherwise, there would be a race which would probably mean the JS file would be loaded several times anyways.

On the wasm worker side, simply fixes the ability to provide a blob - previously it would only accept a javascript string. We use WASM_WORKERS=2 to keep this working, mixing wasm workers + pthread.

See below for example of how it's used. I considered just refactoring the scriptUrlOrBlobPromise logic to automatically cache all worker startups, but figured that would be harder to get integrated since it would break backwards compatibility & tests that use it in emscripten main.

```
Module['mainScriptUrlOrBlobPromise'] = fetch('myscript.js', { priority: 'high' })
    .then(response => response.text())
    .then(workerScript => {
    Module['mainScriptUrlOrBlob'] = new Blob([workerScript], { type: 'application/javascript' });
});
```