### PR TITLE
Revert "[tsgen] Handle different get/set types for value_objects too."

### DIFF
--- a/src/embind/embind_gen.js
+++ b/src/embind/embind_gen.js
@@ -243,18 +243,6 @@ var LibraryEmbind = {
     }
 
   },
-  $printProperty: (prop, nameMap, out) => {
-    const setType = nameMap(prop.type, false);
-    const getType = nameMap(prop.type, true);
-    if (prop.readonly || setType === getType) {
-      out.push(`${prop.readonly ? 'readonly ' : ''}${prop.name}: ${getType}`);
-      return;
-    }
-    // The getter/setter types don't match, so generate each get/set definition.
-    out.push(`get ${prop.name}(): ${getType}`);
-    out.push(`set ${prop.name}(value: ${setType})`);
-  },
-  $ClassProperty__deps: ['$printProperty'],
   $ClassProperty: class {
     constructor(type, name, readonly) {
       this.type = type;
@@ -263,7 +251,15 @@ var LibraryEmbind = {
     }
 
     print(nameMap, out) {
-      printProperty(this, nameMap, out);
+      const setType = nameMap(this.type, false);
+      const getType = nameMap(this.type, true);
+      if (this.readonly || setType === getType) {
+        out.push(`${this.readonly ? 'readonly ' : ''}${this.name}: ${getType}`);
+        return;
+      }
+      // The getter/setter types don't match, so generate each get/set definition.
+      out.push(`get ${this.name}(): ${getType}`);
+      out.push(`set ${this.name}(value: ${setType})`);
     }
   },
   $ConstantDefinition: class {
@@ -329,7 +325,6 @@ var LibraryEmbind = {
       out.push(' ];\n\n');
     }
   },
-  $ValueObjectDefinition__deps: ['$printProperty'],
   $ValueObjectDefinition: class {
     constructor(typeId, name) {
       this.typeId = typeId;
@@ -341,14 +336,12 @@ var LibraryEmbind = {
     }
 
     print(nameMap, out) {
-      out.push(`export type ${this.name} = {\n  `);
+      out.push(`export type ${this.name} = {\n`);
       const outFields = [];
-      for (const field of this.fields) {
-        const property = [];
-        printProperty(field, nameMap, property);
-        outFields.push(...property);
+      for (const {name, type} of this.fields) {
+        outFields.push(`  ${name}: ${nameMap(type)}`);
       }
-      out.push(outFields.join(',\n  '))
+      out.push(outFields.join(',\n'))
       out.push('\n};\n\n');
     }
   },

--- a/test/other/embind_tsgen.cpp
+++ b/test/other/embind_tsgen.cpp
@@ -60,7 +60,6 @@ EMSCRIPTEN_DECLARE_VAL_TYPE(CallbackType);
 struct ValObj {
   Foo foo;
   Bar bar;
-  std::string str;
   CallbackType callback;
   ValObj() : callback(val::undefined()) {}
 };
@@ -179,7 +178,6 @@ EMSCRIPTEN_BINDINGS(Test) {
   value_object<ValObj>("ValObj")
       .field("foo", &ValObj::foo)
       .field("bar", &ValObj::bar)
-      .field("str", &ValObj::str)
       .field("callback", &ValObj::callback);
 
   register_vector<int>("IntVec");

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -85,6 +85,12 @@ export interface ClassWithSmartPtrConstructor {
   delete(): void;
 }
 
+export type ValObj = {
+  foo: Foo,
+  bar: Bar,
+  callback: (message: string) => void
+};
+
 export interface BaseClass {
   fn(_0: number): number;
   delete(): void;
@@ -96,14 +102,6 @@ export interface DerivedClass extends BaseClass {
 }
 
 export type ValArr = [ number, number, number ];
-
-export type ValObj = {
-  foo: Foo,
-  bar: Bar,
-  get str(): string,
-  set str(value: EmbindString),
-  callback: (message: string) => void
-};
 
 interface EmbindModule {
   Test: {

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -94,6 +94,12 @@ export interface ClassWithSmartPtrConstructor {
   delete(): void;
 }
 
+export type ValObj = {
+  foo: Foo,
+  bar: Bar,
+  callback: (message: string) => void
+};
+
 export interface BaseClass {
   fn(_0: number): number;
   delete(): void;
@@ -105,14 +111,6 @@ export interface DerivedClass extends BaseClass {
 }
 
 export type ValArr = [ number, number, number ];
-
-export type ValObj = {
-  foo: Foo,
-  bar: Bar,
-  get str(): string,
-  set str(value: EmbindString),
-  callback: (message: string) => void
-};
 
 interface EmbindModule {
   Test: {

--- a/test/other/embind_tsgen_ignore_2.d.ts
+++ b/test/other/embind_tsgen_ignore_2.d.ts
@@ -71,6 +71,12 @@ export interface ClassWithSmartPtrConstructor {
   delete(): void;
 }
 
+export type ValObj = {
+  foo: Foo,
+  bar: Bar,
+  callback: (message: string) => void
+};
+
 export interface BaseClass {
   fn(_0: number): number;
   delete(): void;
@@ -82,14 +88,6 @@ export interface DerivedClass extends BaseClass {
 }
 
 export type ValArr = [ number, number, number ];
-
-export type ValObj = {
-  foo: Foo,
-  bar: Bar,
-  get str(): string,
-  set str(value: EmbindString),
-  callback: (message: string) => void
-};
 
 interface EmbindModule {
   Test: {

--- a/test/other/embind_tsgen_ignore_3.d.ts
+++ b/test/other/embind_tsgen_ignore_3.d.ts
@@ -85,6 +85,12 @@ export interface ClassWithSmartPtrConstructor {
   delete(): void;
 }
 
+export type ValObj = {
+  foo: Foo,
+  bar: Bar,
+  callback: (message: string) => void
+};
+
 export interface BaseClass {
   fn(_0: number): number;
   delete(): void;
@@ -96,14 +102,6 @@ export interface DerivedClass extends BaseClass {
 }
 
 export type ValArr = [ number, number, number ];
-
-export type ValObj = {
-  foo: Foo,
-  bar: Bar,
-  get str(): string,
-  set str(value: EmbindString),
-  callback: (message: string) => void
-};
 
 interface EmbindModule {
   Test: {


### PR DESCRIPTION
Reverts emscripten-core/emscripten#22439

This was working okay for when the user gets a value_object in TS, but when setting a value_object with an object literal this code does not type check correctly. There's an [upstream issues about this](51229). I think instead of generating getter/setters we can instead have two type definitions for each value_object. One for reading from TS and one for write from TS. Until I get around to trying that I think we can revert this in the meantime.