### PR TITLE
Fix macro conflict for USE_FREETYPE=1

### DIFF
--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -488,9 +488,9 @@ FT_BEGIN_HEADER
 #if ( __GNUC__ >= 2                         || \
       defined( __IBM__TYPEOF__ )            || \
       ( __SUNPRO_C >= 0x5110 && !__STDC__ ) )
-#define TYPEOF( type )  (__typeof__ (type))
+#define FT_TYPEOF( type )  (__typeof__ (type))
 #else
-#define TYPEOF( type )  /* empty */
+#define FT_TYPEOF( type )  /* empty */
 #endif
 
 


### PR DESCRIPTION
Basically backport of https://github.com/freetype/freetype/commit/5931268 / https://github.com/emscripten-ports/FreeType/commit/5931268eec



We want to avoid publicly exporting the `TYPEOF` macro which conflicts with other libraries. . IIUC the header here is the one that gets included in the compiler with `-s USE_FREETYPE=1` ? This should fix https://github.com/emscripten-core/emscripten/issues/22571
