### PR TITLE
[tsgen] Expand TS generation test to compile and run a TS file.

### DIFF
--- a/test/other/embind_tsgen.cpp
+++ b/test/other/embind_tsgen.cpp
@@ -58,11 +58,18 @@ struct ValArr {
 EMSCRIPTEN_DECLARE_VAL_TYPE(CallbackType);
 
 struct ValObj {
-  Foo foo;
   Bar bar;
+  std::string string;
   CallbackType callback;
   ValObj() : callback(val::undefined()) {}
 };
+
+ValObj getValObj() {
+  ValObj o;
+  return o;
+}
+
+void setValObj(ValObj v) {}
 
 class ClassWithConstructor {
  public:
@@ -190,9 +197,11 @@ EMSCRIPTEN_BINDINGS(Test) {
     .element(emscripten::index<3>());
 
   value_object<ValObj>("ValObj")
-      .field("foo", &ValObj::foo)
+      .field("string", &ValObj::string)
       .field("bar", &ValObj::bar)
       .field("callback", &ValObj::callback);
+  function("getValObj", &getValObj);
+  function("setValObj", &setValObj);
 
   register_vector<int>("IntVec");
 

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -108,6 +108,12 @@ export interface InterfaceWrapper extends Interface {
 
 export type ValArr = [ number, number, number ];
 
+export type ValObj = {
+  string: EmbindString,
+  bar: Bar,
+  callback: (message: string) => void
+};
+
 interface EmbindModule {
   Test: {
     staticFunction(_0: number): number;
@@ -158,6 +164,8 @@ interface EmbindModule {
   smart_ptr_function(_0: ClassWithSmartPtrConstructor | null): number;
   smart_ptr_function_with_params(foo: ClassWithSmartPtrConstructor | null): number;
   function_with_callback_param(_0: (message: string) => void): number;
+  getValObj(): ValObj;
+  setValObj(_0: ValObj): void;
   string_test(_0: EmbindString): string;
   wstring_test(_0: string): string;
 }

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -84,12 +84,6 @@ export interface ClassWithSmartPtrConstructor extends ClassHandle {
   fn(_0: number): number;
 }
 
-export type ValObj = {
-  foo: Foo,
-  bar: Bar,
-  callback: (message: string) => void
-};
-
 export interface BaseClass extends ClassHandle {
   fn(_0: number): number;
 }

--- a/test/other/embind_tsgen_ignore_2.d.ts
+++ b/test/other/embind_tsgen_ignore_2.d.ts
@@ -70,12 +70,6 @@ export interface ClassWithSmartPtrConstructor extends ClassHandle {
   fn(_0: number): number;
 }
 
-export type ValObj = {
-  foo: Foo,
-  bar: Bar,
-  callback: (message: string) => void
-};
-
 export interface BaseClass extends ClassHandle {
   fn(_0: number): number;
 }
@@ -93,6 +87,12 @@ export interface InterfaceWrapper extends Interface {
 }
 
 export type ValArr = [ number, number, number ];
+
+export type ValObj = {
+  string: EmbindString,
+  bar: Bar,
+  callback: (message: string) => void
+};
 
 interface EmbindModule {
   Test: {
@@ -144,6 +144,8 @@ interface EmbindModule {
   smart_ptr_function(_0: ClassWithSmartPtrConstructor | null): number;
   smart_ptr_function_with_params(foo: ClassWithSmartPtrConstructor | null): number;
   function_with_callback_param(_0: (message: string) => void): number;
+  getValObj(): ValObj;
+  setValObj(_0: ValObj): void;
   string_test(_0: EmbindString): string;
   wstring_test(_0: string): string;
 }

--- a/test/other/embind_tsgen_ignore_3.d.ts
+++ b/test/other/embind_tsgen_ignore_3.d.ts
@@ -84,12 +84,6 @@ export interface ClassWithSmartPtrConstructor extends ClassHandle {
   fn(_0: number): number;
 }
 
-export type ValObj = {
-  foo: Foo,
-  bar: Bar,
-  callback: (message: string) => void
-};
-
 export interface BaseClass extends ClassHandle {
   fn(_0: number): number;
 }
@@ -107,6 +101,12 @@ export interface InterfaceWrapper extends Interface {
 }
 
 export type ValArr = [ number, number, number ];
+
+export type ValObj = {
+  string: EmbindString,
+  bar: Bar,
+  callback: (message: string) => void
+};
 
 interface EmbindModule {
   Test: {
@@ -158,6 +158,8 @@ interface EmbindModule {
   smart_ptr_function(_0: ClassWithSmartPtrConstructor | null): number;
   smart_ptr_function_with_params(foo: ClassWithSmartPtrConstructor | null): number;
   function_with_callback_param(_0: (message: string) => void): number;
+  getValObj(): ValObj;
+  setValObj(_0: ValObj): void;
   string_test(_0: EmbindString): string;
   wstring_test(_0: string): string;
 }

--- a/test/other/embind_tsgen_main.ts
+++ b/test/other/embind_tsgen_main.ts
@@ -1,0 +1,30 @@
+// Example TS program that consumes the emscripten-generated module to to
+// illustrate how the type definitions are used and test they are workings as
+// expected.
+import moduleFactory from './embind_tsgen.mjs';
+
+const module = await moduleFactory();
+
+// Test a few variations of passing value_objects with strings.
+module.setValObj({
+  bar: module.Bar.valueOne,
+  string: "ABCD",
+  callback: () => {}
+});
+
+module.setValObj({
+  bar: module.Bar.valueOne,
+  string: new Int8Array([65, 66, 67, 68]),
+  callback: () => {}
+});
+
+const valObj = module.getValObj();
+// TODO: remove the cast below when better definitions are generated for value
+// objects.
+const valString : string = valObj.string as string;
+
+// Ensure nonnull pointers do no need a cast or nullptr check to use.
+const obj = module.getNonnullPointer();
+obj.delete();
+
+console.log('ts ran');

--- a/test/other/embind_tsgen_module.d.ts
+++ b/test/other/embind_tsgen_module.d.ts
@@ -11,18 +11,9 @@ declare namespace RuntimeExports {
     let HEAPU32: any;
     let HEAP64: any;
     let HEAPU64: any;
-    let FS_createPath: any;
-    function FS_createDataFile(parent: any, name: any, fileData: any, canRead: any, canWrite: any, canOwn: any): void;
-    function FS_createPreloadedFile(parent: any, name: any, url: any, canRead: any, canWrite: any, onload: any, onerror: any, dontCreateFile: any, canOwn: any, preFinish: any): void;
-    function FS_unlink(path: any): any;
-    let FS_createLazyFile: any;
-    let FS_createDevice: any;
-    let addRunDependency: any;
-    let removeRunDependency: any;
 }
 interface WasmModule {
   _main(_0: number, _1: number): number;
-  __emscripten_proxy_main(_0: number, _1: number): number;
 }
 
 type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;
@@ -174,3 +165,4 @@ interface EmbindModule {
 }
 
 export type MainModule = WasmModule & typeof RuntimeExports & EmbindModule;
+export default function MainModuleFactory (options?: unknown): Promise<MainModule>;

--- a/test/other/embind_tsgen_package.json
+++ b/test/other/embind_tsgen_package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3396,10 +3396,10 @@ More info: https://emscripten.org
     shutil.copyfile(test_file('other/embind_tsgen_package.json'), 'package.json')
     cmd = shared.get_npm_cmd('tsc') + ['embind_tsgen.d.ts', 'main.ts', '--module', 'NodeNext', '--moduleResolution', 'nodenext']
     shared.check_call(cmd)
-    self.assertContained('main ran\nts ran', self.run_js('main.js'))
-
     actual = read_file('embind_tsgen.d.ts')
     self.assertFileContents(test_file('other/embind_tsgen_module.d.ts'), actual)
+    self.assertContained('main ran\nts ran', self.run_js('main.js'))
+
 
   def test_embind_tsgen_ignore(self):
     create_file('fail.js', 'assert(false);')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3391,8 +3391,8 @@ More info: https://emscripten.org
 
     # Test that the output compiles with a TS file that uses the defintions.
     shutil.copyfile(test_file('other/embind_tsgen_main.ts'), 'main.ts')
-    # A package file with type=module is needed to tell the TSC that we're
-    # using modules.
+    # A package file with type=module is needed to enabled ES modules in TSC and
+    # also run the output JS file as a module in node.
     shutil.copyfile(test_file('other/embind_tsgen_package.json'), 'package.json')
     cmd = shared.get_npm_cmd('tsc') + ['embind_tsgen.d.ts', 'main.ts', '--module', 'NodeNext', '--moduleResolution', 'nodenext']
     shared.check_call(cmd)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3400,7 +3400,6 @@ More info: https://emscripten.org
     self.assertFileContents(test_file('other/embind_tsgen_module.d.ts'), actual)
     self.assertContained('main ran\nts ran', self.run_js('main.js'))
 
-
   def test_embind_tsgen_ignore(self):
     create_file('fail.js', 'assert(false);')
     self.emcc_args += ['-lembind', '--emit-tsd', 'embind_tsgen.d.ts']

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3386,15 +3386,20 @@ More info: https://emscripten.org
   def test_embind_tsgen(self, opts):
     # Check that TypeScript generation works and that the program is runs as
     # expected.
-    self.do_runf('other/embind_tsgen.cpp', 'main ran',
-                 emcc_args=['-lembind', '--emit-tsd', 'embind_tsgen.d.ts'] + opts)
+    self.emcc(test_file('other/embind_tsgen.cpp'),
+              ['-o', 'embind_tsgen.mjs', '-lembind', '--emit-tsd', 'embind_tsgen.d.ts'] + opts)
 
     # Test that the output compiles with a TS file that uses the defintions.
-    cmd = shared.get_npm_cmd('tsc') + ['embind_tsgen.d.ts', '--noEmit']
+    shutil.copyfile(test_file('other/embind_tsgen_main.ts'), 'main.ts')
+    # A package file with type=module is needed to tell the TSC that we're
+    # using modules.
+    shutil.copyfile(test_file('other/embind_tsgen_package.json'), 'package.json')
+    cmd = shared.get_npm_cmd('tsc') + ['embind_tsgen.d.ts', 'main.ts', '--module', 'NodeNext', '--moduleResolution', 'nodenext']
     shared.check_call(cmd)
+    self.assertContained('main ran\nts ran', self.run_js('main.js'))
 
     actual = read_file('embind_tsgen.d.ts')
-    self.assertFileContents(test_file('other/embind_tsgen.d.ts'), actual)
+    self.assertFileContents(test_file('other/embind_tsgen_module.d.ts'), actual)
 
   def test_embind_tsgen_ignore(self):
     create_file('fail.js', 'assert(false);')


### PR DESCRIPTION
In the new TS file we can add tests for things where just checking if the definition file compiles is not enough. This will help catch issues like #22569.