### PR TITLE
Allow JS files to be executable

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -774,6 +774,8 @@ def phase_linker_setup(options, state, newargs):
   else:
     # Otherwise the wasm file is produced alongside the final target.
     wasm_target = get_secondary_target(target, '.wasm')
+    if final_suffix in EXECUTABLE_ENDINGS:
+        options.executable = True
 
   if settings.SAFE_HEAP not in [0, 1, 2]:
     exit_with_error('emcc: SAFE_HEAP must be 0, 1 or 2')


### PR DESCRIPTION
Here's a quick comparison of behavior before and after:

Before:

````
# emcc main.c -o main
# ls -alh main
-rw-r--r-- 1 root root  54K Sep 20 06:41 main # NOTE the missing `x` executable flag
````

After:

````
# emcc main.c -o main
# ls -alh main
-rwxr--r-- 1 root root 54K Sep 20 06:37 main
````

For comparison to gcc:

````
gcc main.c -o main
# ls -alh main
-rwxr-xr-x 1 root root 9.1K Sep 20 06:42 main
````

I was noticing some projects I tried to compile to web assembly were failing because they generated intermediary utilities that were then used as part of the build process in later stages. it was non-trivial to modify the original build scripts so this was a way to solve it in my case.

Personally, I think it's better to match the behavior of GCC more closely, in generally, thus the pull request. It looks like a previous workaround for this was added just for `conftest.c` for automake. see: https://github.com/emscripten-core/emscripten/blob/b435a7c46f38750e6c4490d4c0f726f452b67c82/tools/link.py#L652

Related issue: https://github.com/emscripten-core/emscripten/issues/12707

