### PR TITLE
Stop generating empty `.worker.js` in pthreads builds

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 3.1.68 (in development)
 -----------------------
+- Pthread-based programs no longer generates `.worker.js` file.  This file was
+  made redundant back in 3.1.58 and now is completely removed. (#22598)
 - The freetype port was updated from v2.6 to v2.13.3. (#22585)
 - The number of arguments passed to Embind function calls is now only verified
   with ASSERTIONS enabled. (#22591)

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3697,7 +3697,7 @@ Module["preRun"] = () => {
     if '-sSINGLE_FILE' in args:
       self.assertEqual(len(files), 1, files)
     else:
-      self.assertEqual(len(files), 4, files)
+      self.assertEqual(len(files), 3, files)
 
   # Test that preallocating worker threads work.
   def test_pthread_preallocates_workers(self):

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -439,11 +439,6 @@ class other(RunnerCore):
       Hello();
     ''')
 
-    if package_json:
-      # This makes node load all files in the directory as ES6 modules,
-      # including the worker.js file.
-      create_file('package.json', '{"type":"module"}')
-
     self.assertContained('hello, world!', self.run_js('runner.mjs'))
 
   def test_emcc_out_file(self):
@@ -14881,20 +14876,9 @@ addToLibrary({
     create_file('b.cpp', '#include <emscripten/bind.h>')
     self.run_process([EMXX, '-std=c++23', '-lembind', 'a.cpp', 'b.cpp'])
 
-  def test_legacy_pthread_worker_js(self):
-    self.do_runf('hello_world.c', emcc_args=['-pthread', '-sSTRICT'])
-    self.assertNotExists('hello_world.worker.js')
-    self.do_runf('hello_world.c', emcc_args=['-pthread'])
-    self.assertExists('hello_world.worker.js')
-    os.mkdir('out')
-    self.do_runf('hello_world.c', output_basename='out/foo', emcc_args=['-pthread'])
-    self.assertExists('out/foo.js')
-    self.assertExists('out/foo.worker.js')
-
   def test_no_pthread(self):
     self.do_runf('hello_world.c', emcc_args=['-pthread', '-no-pthread'])
     self.assertExists('hello_world.js')
-    self.assertNotExists('hello_world.worker.js')
     self.assertNotContained('Worker', read_file('hello_world.js'))
 
   def test_sysroot_includes_first(self):

--- a/tools/link.py
+++ b/tools/link.py
@@ -2073,15 +2073,6 @@ def phase_final_emitting(options, state, target, wasm_target):
     return
 
   target_dir = os.path.dirname(os.path.abspath(target))
-  if settings.PTHREADS and not settings.STRICT and not settings.SINGLE_FILE:
-    worker_file = shared.replace_suffix(target, get_worker_js_suffix())
-    write_file(worker_file, '''\
-// This file is no longer used by emscripten and has been created as a placeholder
-// to allow build systems to transition away from depending on it.
-//
-// Future versions of emscripten will likely stop generating this file at all.
-throw new Error('Dummy worker.js file should never be used');
-''')
 
   # Deploy the Wasm Worker bootstrap file as an output file (*.ww.js)
   if settings.WASM_WORKERS == 1:


### PR DESCRIPTION
We stopped using a separate worker file back in #21701.  That was released in 3.1.58 back in April.

This change ends the transition period by no longer generating a dummy/useless worker.js file alongside the output.