### PR TITLE
[SjLj] Make Wasm SjLj run with PURE_WASI

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14494,6 +14494,21 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
   def test_wasi_sched_yield(self):
     self.run_wasi_test_suite_test('wasi_sched_yield')
 
+  def test_wasi_with_sjlj(self):
+    # When PURE_WASI is set and Wasm exception is not being used, we turn off
+    # SUPPORT_LONGJMP by default because it uses a JS-based simulation of
+    # longjmp.
+    self.set_setting('PURE_WASI')
+    err = self.expect_fail([EMCC, test_file('core/test_longjmp.c')] + self.get_emcc_args())
+    self.assertContained('error: longjmp support was disabled (SUPPORT_LONGJMP=0)', err)
+
+    # When using Wasm exception, SUPPORT_LONGJMP defaults to 'wasm', which does
+    # not use the JS-based support. This should succeed.
+    self.emcc_args.append('-fwasm-exceptions')
+    # -fwasm-exceptions exports __cpp_exception, so this is necessary
+    self.set_setting('DEFAULT_TO_CXX')
+    self.do_runf(test_file('core/test_longjmp.c'), emcc_args=self.get_emcc_args())
+
   def test_memops_bulk_memory(self):
     self.emcc_args += ['--profiling-funcs', '-fno-builtin']
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -802,7 +802,11 @@ def phase_linker_setup(options, state, newargs):
   if settings.PURE_WASI:
     settings.STANDALONE_WASM = 1
     settings.WASM_BIGINT = 1
-    settings.SUPPORT_LONGJMP = 0
+    # WASI does not support Emscripten (JS-based) exception catching, which the
+    # JS-based longjmp support also uses. Emscripten EH is by default disabled
+    # so we don't need to do anything here.
+    if not settings.WASM_EXCEPTIONS:
+      default_setting('SUPPORT_LONGJMP', 0)
 
   if options.no_entry:
     settings.EXPECT_MAIN = 0


### PR DESCRIPTION
Previously `-sPURE_WASI` disabled SjLj support because it uses the JS-based simultion, but accidentally also disabled Wasm SjLj. This makes setting `PURE_WASI` disable SjLj support by default only when Wasm EH is not used. Also this does not force disabling; it only makes the default SjLj setting to be disabled, meaning you can experiment with it if you manually set `-sSUPPORT_LONGJMP` to be other values.

Fixes #22566.