### PR TITLE
library_pthread.js: Ensure transferredCanvasNames is iterable

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -716,8 +716,10 @@ var LibraryPThread = {
       transferredCanvasNames = '{{{ OFFSCREENCANVASES_TO_PTHREAD }}}';
     } else
 #endif
-    transferredCanvasNames &&= UTF8ToString(transferredCanvasNames).trim();
-    transferredCanvasNames &&= transferredCanvasNames.split(',');
+    {
+      transferredCanvasNames = UTF8ToString(transferredCanvasNames).trim();
+    }
+    transferredCanvasNames = transferredCanvasNames ? transferredCanvasNames.split(',') : [];
 #if GL_DEBUG
     dbg(`pthread_create: transferredCanvasNames="${transferredCanvasNames}"`);
 #endif

--- a/test/other/test_pthread_hello.c
+++ b/test/other/test_pthread_hello.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+
+void* thread_func(void* arg) {
+  printf("Hello from thread\n");
+  return NULL;
+}
+
+int main() {
+  pthread_t t;
+  pthread_create(&t, NULL, thread_func, NULL);
+  assert(t);
+  pthread_join(t, NULL);
+  printf("done\n");
+  return 0;
+}

--- a/test/other/test_pthread_hello.out
+++ b/test/other/test_pthread_hello.out
@@ -1,0 +1,2 @@
+Hello from thread
+done

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12080,6 +12080,14 @@ Aborted(`Module.arguments` has been replaced by `arguments_` (the initial value 
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     self.do_other_test('test_pthread_reuse.c')
 
+  @parameterized({
+    '': ([],),
+    'offscreen_canvas': (['-sOFFSCREENCANVAS_SUPPORT', '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$GL'],),
+  })
+  @node_pthreads
+  def test_pthread_hello(self, args):
+    self.do_other_test('test_pthread_hello.c', args)
+
   @node_pthreads
   def test_pthread_relocatable(self):
     self.do_run_in_out_file_test('hello_world.c', emcc_args=['-sRELOCATABLE'])


### PR DESCRIPTION
This was first broken back in #17577 and then fixed in #17752.

I then broke it again in #22545 (yay!) (see #22620).

This time I will include a test to ensure this doesn't happen again.