### PR TITLE
Mark test_pthread_c11_threads_proxied as flaky

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9102,6 +9102,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('STRICT')
     self.do_run_in_out_file_test('core/pthread/create.c')
 
+  @flaky('https://github.com/emscripten-core/emscripten/issues/22617')
   @node_pthreads
   @parameterized({
     '': ([],),


### PR DESCRIPTION
Only the proxied version is flaky but all the variants need to be marked.

Tracked in #22617