### PR TITLE
[nodefs] Return real values for statvfs via __syscall_statfs64

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -690,7 +690,7 @@ FS.staticInit();
       };
 
       var parent = FS.lookupPath(path, {follow: true}).node;
-      if (typeof parent.node_ops?.statfs) {
+      if (parent.node_ops.statfs) {
         Object.assign(rtn, parent.node_ops.statfs(parent.mount.opts.root));
       }
       return rtn;

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -673,8 +673,6 @@ FS.staticInit();
       return parent.node_ops.mknod(parent, name, mode, dev);
     },
     statfs(path) {
-      var lookup = FS.lookupPath(path, { follow: true });
-      var parent = lookup.node
 
       // NOTE: None of the defaults here are true. We're just returning safe and
       //       sane values.
@@ -691,11 +689,13 @@ FS.staticInit();
         namelen: 255,
       };
 
-      if (typeof parent.node_ops?.statfs === 'function') {
-        return { ...defaults, ...parent.node_ops.statfs(parent.mount.opts.root) };
-      } else {
+      var lookup = FS.lookupPath(path, {follow: true});
+      var parent = lookup.node;
+      if (typeof parent.node_ops?.statfs !== 'function') {
         return defaults;
       }
+
+      return { ...defaults, ...parent.node_ops.statfs(parent.mount.opts.root) };
     },
     // helpers to create specific types of nodes
     create(path, mode) {

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -690,8 +690,7 @@ FS.staticInit();
         namelen: 255,
       };
 
-      var lookup = FS.lookupPath(path, {follow: true});
-      var parent = lookup.node;
+      var parent = FS.lookupPath(path, {follow: true}).node;
       if (typeof parent.node_ops?.statfs !== 'function') {
         return defaults;
       }

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -676,26 +676,24 @@ FS.staticInit();
 
       // NOTE: None of the defaults here are true. We're just returning safe and
       //       sane values.
-      var ffree = FS.nextInode - 1; // Free inodes can not be larger than total inodes
-      var defaults = {
+      var rtn = {
         bsize: 4096,
         frsize: 4096,
         blocks: 1e6,
         bfree: 5e5,
         bavail: 5e5,
         files: FS.nextInode,
-        ffree,
+        ffree: FS.nextInode - 1,
         fsid: 42,
         flags: 2,
         namelen: 255,
       };
 
       var parent = FS.lookupPath(path, {follow: true}).node;
-      if (typeof parent.node_ops?.statfs !== 'function') {
-        return defaults;
+      if (typeof parent.node_ops?.statfs) {
+        Object.assign(rtn, parent.node_ops.statfs(parent.mount.opts.root));
       }
-
-      return { ...defaults, ...parent.node_ops.statfs(parent.mount.opts.root) };
+      return rtn;
     },
     // helpers to create specific types of nodes
     create(path, mode) {

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -683,7 +683,8 @@ FS.staticInit();
         bfree: 5e5,
         bavail: 5e5,
         files: FS.nextInode,
-        ffree: 1e6,
+        // Free inodes can not be larger than total inodes so calculate a reasonable value here
+        ffree: () => Math.max(0, Math.floor(this.files * 0.9) - this.files),
         fsid: 42,
         flags: 2,
         namelen: 255,

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -676,6 +676,7 @@ FS.staticInit();
 
       // NOTE: None of the defaults here are true. We're just returning safe and
       //       sane values.
+      var ffree = FS.nextInode - 1; // Free inodes can not be larger than total inodes
       var defaults = {
         bsize: 4096,
         frsize: 4096,
@@ -683,8 +684,7 @@ FS.staticInit();
         bfree: 5e5,
         bavail: 5e5,
         files: FS.nextInode,
-        // Free inodes can not be larger than total inodes so calculate a reasonable value here
-        ffree: () => Math.max(0, Math.floor(this.files * 0.9) - this.files),
+        ffree,
         fsid: 42,
         flags: 2,
         namelen: 255,

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -676,7 +676,8 @@ FS.staticInit();
       var lookup = FS.lookupPath(path, { follow: true });
       var parent = lookup.node
 
-      // Error handling
+      // NOTE: None of the defaults here are true. We're just returning safe and
+      //       sane values.
       var defaults = {
         bsize: 4096,
         frsize: 4096,

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -687,7 +687,7 @@ FS.staticInit();
         ffree: 1e6,
         fsid: 42,
         flags: 2,
-        namelen: 255
+        namelen: 255,
       };
 
       if (typeof parent.node_ops?.statfs === 'function') {

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -672,6 +672,30 @@ FS.staticInit();
       }
       return parent.node_ops.mknod(parent, name, mode, dev);
     },
+    statfs(path) {
+      var lookup = FS.lookupPath(path, { follow: true });
+      var parent = lookup.node
+
+      // Error handling
+      var defaults = {
+        bsize: 4096,
+        frsize: 4096,
+        blocks: 1e6,
+        bfree: 5e5,
+        bavail: 5e5,
+        files: FS.nextInode,
+        ffree: 1e6,
+        fsid: 42,
+        flags: 2,
+        namelen: 255
+      };
+
+      if (typeof parent.node_ops?.statfs === 'function') {
+        return { ...defaults, ...parent.node_ops.statfs(parent.mount.opts.root) };
+      } else {
+        return defaults;
+      }
+    },
     // helpers to create specific types of nodes
     create(path, mode) {
       mode = mode !== undefined ? mode : 438 /* 0666 */;

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -117,6 +117,7 @@ addToLibrary({
       }
       return newFlags;
     },
+
     node_ops: {
       getattr(node) {
         var path = NODEFS.realPath(node);

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -118,6 +118,9 @@ addToLibrary({
       return newFlags;
     },
 
+    statfs: function(path) {
+      return fs.statfsSync(path);
+    },
     node_ops: {
       getattr(node) {
         var path = NODEFS.realPath(node);
@@ -214,6 +217,19 @@ addToLibrary({
         var path = NODEFS.realPath(node);
         return NODEFS.tryFSOperation(() => fs.readlinkSync(path));
       },
+      statfs(path) {
+        var stats = fs.statfsSync(path);
+        return {
+          bsize: stats.bsize,
+          frsize: stats.bsize,
+          blocks: stats.blocks,
+          bfree: stats.bfree,
+          bavail: stats.bavail,
+          files: stats.files,
+          ffree: stats.ffree,
+          fsid: stats.type
+        }
+      }
     },
     stream_ops: {
       open(stream) {

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -218,18 +218,11 @@ addToLibrary({
         return NODEFS.tryFSOperation(() => fs.readlinkSync(path));
       },
       statfs(path) {
-        var stats = fs.statfsSync(path);
-        console.log(stats.type)
+        var stats = NODEFS.tryFSOperation(() => fs.statfsSync(path));
         return {
-          bsize: stats.bsize,
-          frsize: stats.bsize,
-          blocks: stats.blocks,
-          bfree: stats.bfree,
-          bavail: stats.bavail,
-          files: stats.files,
-          ffree: stats.ffree,
-          type: stats.type
-        }
+          ...stats,
+          frsize: stats.bsize
+        };
       }
     },
     stream_ops: {

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -219,6 +219,7 @@ addToLibrary({
       },
       statfs(path) {
         var stats = fs.statfsSync(path);
+        console.log(stats.type)
         return {
           bsize: stats.bsize,
           frsize: stats.bsize,
@@ -227,7 +228,7 @@ addToLibrary({
           bavail: stats.bavail,
           files: stats.files,
           ffree: stats.ffree,
-          fsid: stats.type
+          type: stats.type
         }
       }
     },

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -216,10 +216,10 @@ addToLibrary({
       },
       statfs(path) {
         var stats = NODEFS.tryFSOperation(() => fs.statfsSync(path));
-        return {
-          ...stats,
-          frsize: stats.bsize
-        };
+        // Node.js doesn't provide frsize (fragment size). Set it to bsize (block size)
+        // as they're often the same in many file systems. May not be accurate for all.
+        stats.frsize = stats.bsize;
+        return stats;
       }
     },
     stream_ops: {

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -117,10 +117,6 @@ addToLibrary({
       }
       return newFlags;
     },
-
-    statfs: function(path) {
-      return fs.statfsSync(path);
-    },
     node_ops: {
       getattr(node) {
         var path = NODEFS.realPath(node);

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -802,22 +802,22 @@ var SyscallsLibrary = {
   },
 
   __syscall_statfs64: (path, size, buf) => {
-    path = SYSCALLS.getStr(path);
 #if ASSERTIONS
     assert(size === {{{ C_STRUCTS.statfs.__size__ }}});
 #endif
+    var defaults = FS.statfs(SYSCALLS.getStr(path));
     // NOTE: None of the constants here are true. We're just returning safe and
     //       sane values.
-    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_bsize, '4096', 'i32') }}};
-    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_frsize, '4096', 'i32') }}};
-    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_blocks, '1000000', 'i32') }}};
-    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_bfree, '500000', 'i32') }}};
-    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_bavail, '500000', 'i32') }}};
-    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_files, 'FS.nextInode', 'i32') }}};
-    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_ffree, '1000000', 'i32') }}};
-    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_fsid, '42', 'i32') }}};
-    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_flags, '2', 'i32') }}};  // ST_NOSUID
-    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_namelen, '255', 'i32') }}};
+    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_bsize, 'defaults.bsize', 'i32') }}};
+    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_frsize, 'defaults.bsize', 'i32') }}};
+    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_blocks, 'defaults.blocks', 'i32') }}};
+    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_bfree, 'defaults.bfree', 'i32') }}};
+    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_bavail, 'defaults.bavail', 'i32') }}};
+    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_files, 'defaults.files', 'i32') }}};
+    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_ffree, 'defaults.ffree', 'i32') }}};
+    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_fsid, 'defaults.fsid', 'i32') }}};
+    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_flags, 'defaults.flags', 'i32') }}};  // ST_NOSUID
+    {{{ makeSetValue('buf', C_STRUCTS.statfs.f_namelen, 'defaults.namelen', 'i32') }}};
     return 0;
   },
   __syscall_fstatfs64__deps: ['__syscall_statfs64'],

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -806,8 +806,6 @@ var SyscallsLibrary = {
     assert(size === {{{ C_STRUCTS.statfs.__size__ }}});
 #endif
     var defaults = FS.statfs(SYSCALLS.getStr(path));
-    // NOTE: None of the constants here are true. We're just returning safe and
-    //       sane values.
     {{{ makeSetValue('buf', C_STRUCTS.statfs.f_bsize, 'defaults.bsize', 'i32') }}};
     {{{ makeSetValue('buf', C_STRUCTS.statfs.f_frsize, 'defaults.bsize', 'i32') }}};
     {{{ makeSetValue('buf', C_STRUCTS.statfs.f_blocks, 'defaults.blocks', 'i32') }}};

--- a/test/core/test_statvfs.c
+++ b/test/core/test_statvfs.c
@@ -8,10 +8,13 @@
 #include <stdio.h>
 #include <errno.h>
 #include <sys/statvfs.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 int main() {
   struct statvfs s;
 
+  mkdir("/test", S_IRWXU | S_IRWXG | S_IRWXO);
   printf("result: %d\n", statvfs("/test", &s));
   printf("errno: %d\n", errno);
 

--- a/test/core/test_statvfs.c
+++ b/test/core/test_statvfs.c
@@ -24,8 +24,8 @@ int main() {
   printf("f_bfree: %u\n", s.f_bfree);
   printf("f_bavail: %u\n", s.f_bavail);
   printf("f_files: %d\n", s.f_files > 5);
-  printf("f_ffree: %u\n", s.f_ffree);
-  printf("f_favail: %u\n", s.f_favail);
+  printf("f_ffree: %u\n", s.f_ffree <= s.f_files && s.f_ffree > 0);
+  printf("f_favail: %u\n", s.f_favail <= s.f_files && s.f_favail > 0);
   printf("f_fsid: %lu\n", s.f_fsid);
   printf("f_flag: %lu\n", s.f_flag);
   printf("f_namemax: %lu\n", s.f_namemax);

--- a/test/core/test_statvfs.out
+++ b/test/core/test_statvfs.out
@@ -6,8 +6,8 @@ f_blocks: 1000000
 f_bfree: 500000
 f_bavail: 500000
 f_files: 1
-f_ffree: 1000000
-f_favail: 1000000
+f_ffree: 1
+f_favail: 1
 f_fsid: 42
 f_flag: 2
 f_namemax: 255

--- a/test/fs/test_nodefs_statfs.c
+++ b/test/fs/test_nodefs_statfs.c
@@ -10,12 +10,7 @@ void test_statfs(const char *path) {
 
     assert(result == 0 && "statvfs should succeed");
 
-    printf("File system block size: %lu\n", st.f_bsize);
-    printf("Total blocks: %lu\n", st.f_blocks);
-    printf("Free blocks: %lu\n", st.f_bfree);
-    printf("Available blocks: %lu\n", st.f_bavail);
-    printf("Total inodes: %lu\n", st.f_files);
-    printf("Free inodes: %lu\n", st.f_ffree);
+
 
     // Basic sanity checks
     assert(st.f_bsize > 0 && "Block size should be positive");

--- a/test/fs/test_nodefs_statfs.c
+++ b/test/fs/test_nodefs_statfs.c
@@ -10,8 +10,6 @@ void test_statfs(const char *path) {
 
     assert(result == 0 && "statvfs should succeed");
 
-
-
     // Basic sanity checks
     assert(st.f_bsize > 0 && "Block size should be positive");
     assert(st.f_blocks > 0 && "Total blocks should be positive");

--- a/test/fs/test_nodefs_statfs.c
+++ b/test/fs/test_nodefs_statfs.c
@@ -19,16 +19,19 @@ void test_statfs(const char *path) {
     assert(st.f_ffree <= st.f_files && "Free inodes should not exceed total inodes");
 }
 
+void setup() {
+	EM_ASM(
+		FS.mkdir('/working');
+		FS.mount(NODEFS, { root: '.' }, '/working');
+	);
+}
+
 int main() {
     // Test the root filesystem (which should be MEMFS by default)
+
     test_statfs("/");
 
-    // Mount NODEFS and test it
-    EM_ASM(
-        FS.mkdir('/working');
-        FS.mount(NODEFS, { root: '.' }, '/working');
-    );
-
+	setup();
     test_statfs("/working");
 
     puts("success");

--- a/test/fs/test_nodefs_statvfs.c
+++ b/test/fs/test_nodefs_statvfs.c
@@ -4,32 +4,32 @@
 #include <emscripten.h>
 
 void test_statvfs(const char *path) {
-    printf("Testing statfs for path: %s\n", path);
-    struct statvfs st;
-    int result = statvfs(path, &st);
+  printf("Testing statfs for path: %s\n", path);
+  struct statvfs st;
+  int result = statvfs(path, &st);
 
-    assert(result == 0 && "statvfs should succeed");
+  assert(result == 0 && "statvfs should succeed");
 
-    // Basic sanity checks
-    assert(st.f_bsize > 0 && "Block size should be positive");
-    assert(st.f_blocks > 0 && "Total blocks should be positive");
-    assert(st.f_bfree <= st.f_blocks && "Free blocks should not exceed total blocks");
-    assert(st.f_bavail <= st.f_bfree && "Available blocks should not exceed free blocks");
-    assert(st.f_files > 0 && "Total inodes should be positive");
-    assert(st.f_ffree <= st.f_files && "Free inodes should not exceed total inodes");
+  // Basic sanity checks
+  assert(st.f_bsize > 0 && "Block size should be positive");
+  assert(st.f_blocks > 0 && "Total blocks should be positive");
+  assert(st.f_bfree <= st.f_blocks && "Free blocks should not exceed total blocks");
+  assert(st.f_bavail <= st.f_bfree && "Available blocks should not exceed free blocks");
+  assert(st.f_files >= 0 && "Total inodes should be 0 or positive");
+  assert(st.f_ffree <= st.f_files && "Free inodes should not exceed total inodes");
 }
 
 void setup() {
-	EM_ASM(
-		FS.mkdir('/working');
-		FS.mount(NODEFS, { root: '.' }, '/working');
-	);
+  EM_ASM(
+    FS.mkdir('/working');
+    FS.mount(NODEFS, { root: '.' }, '/working');
+  );
 }
 
 int main() {
-	setup();
-    // Test the root filesystem (which should be MEMFS by default)
-    test_statvfs("/");
-    test_statvfs("/working");
-    puts("success");
+  setup();
+  // Test the root filesystem (which should be MEMFS by default)
+  test_statvfs("/");
+  test_statvfs("/working");
+  puts("success");
 }

--- a/test/fs/test_nodefs_statvfs.c
+++ b/test/fs/test_nodefs_statvfs.c
@@ -3,7 +3,7 @@
 #include <sys/statvfs.h>
 #include <emscripten.h>
 
-void test_statfs(const char *path) {
+void test_statvfs(const char *path) {
     printf("Testing statfs for path: %s\n", path);
     struct statvfs st;
     int result = statvfs(path, &st);
@@ -27,12 +27,9 @@ void setup() {
 }
 
 int main() {
-    // Test the root filesystem (which should be MEMFS by default)
-
-    test_statfs("/");
-
 	setup();
-    test_statfs("/working");
-
+    // Test the root filesystem (which should be MEMFS by default)
+    test_statvfs("/");
+    test_statvfs("/working");
     puts("success");
 }

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5779,6 +5779,15 @@ got: 10
     self.emcc_args += ['-lnodefs.js']
     self.do_runf('fs/test_nodefs_readdir.c', 'success')
 
+  @requires_node
+  def test_fs_nodefs_statfs(self):
+    # externally setup an existing folder structure: existing/a
+    if self.get_setting('WASMFS'):
+      self.set_setting('FORCE_FILESYSTEM')
+    os.makedirs(os.path.join(self.working_dir, 'existing', 'a'))
+    self.emcc_args += ['-lnodefs.js']
+    self.do_runf('fs/test_nodefs_statfs.c', 'success')
+
   @no_windows('no symlink support on windows')
   @requires_node
   def test_fs_noderawfs_nofollow(self):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5775,18 +5775,19 @@ got: 10
     # externally setup an existing folder structure: existing/a
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
-    os.makedirs(os.path.join(self.working_dir, 'existing', 'a'))
+    os.makedirs('existing/a')
     self.emcc_args += ['-lnodefs.js']
     self.do_runf('fs/test_nodefs_readdir.c', 'success')
 
   @requires_node
-  def test_fs_nodefs_statfs(self):
+  @crossplatform
+  def test_fs_nodefs_statvfs(self):
     # externally setup an existing folder structure: existing/a
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
-    os.makedirs(os.path.join(self.working_dir, 'existing', 'a'))
+    os.makedirs('existing/a')
     self.emcc_args += ['-lnodefs.js']
-    self.do_runf('fs/test_nodefs_statfs.c', 'success')
+    self.do_runf('fs/test_nodefs_statvfs.c', 'success')
 
   @no_windows('no symlink support on windows')
   @requires_node


### PR DESCRIPTION
See #22607 

statfs syscall functions are returning hardcoded default values which can in some cases lead to unexpected results.

This PR introduces a way for `__syscall_statfs64` to return real values if the underlying filesystem supports this. For now, I've only implemented this for the NODEFS filesystem but we can expand this to other filesystems when it makes sense.

Additionally, in the previous defaults, `ffree` could be larger than `files` which is incorrect, this has also been addressed.

Ive added a test `test/fs/test_nodefs_statfs.c` which can be executed by running:
`test/runner test_fs_nodefs_statfs`

As I am a new contributor I'm happy to get feedback and make improvements where needed.