### PR TITLE
Add (optional) post-commit git hook for running bootstrap script

### DIFF
--- a/tools/maint/post-checkout
+++ b/tools/maint/post-checkout
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Git post-checkout script that takes care of running emscirpten's
+# bootstrap script when changing branches.
+#
+# The bootstrap script itself is smart enough to basically do nothing unless
+# one of the relevant files was updated (e.g. package.json).
+
+# Test for the existence of the bootstrap script itself to handle branches
+# that predate its existence.
+test -f ./bootstrap && exec ./bootstrap


### PR DESCRIPTION
Once installed this script will automatically bootstrap emscripten on each branch checkout.

Use `./bootstrap -i/--install-post-checkout` to install the script.  We could consider doing this automatically too as a followup if folks end up liking this solution.

Fixes: #22550