### PR TITLE
Append em-pthread id to the web worker name.

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -405,7 +405,11 @@ var LibraryPThread = {
 #if ENVIRONMENT_MAY_BE_WEB || ENVIRONMENT_MAY_BE_WORKER
         // This is the way that we signal to the Web Worker that it is hosting
         // a pthread.
+#if ASSERTIONS
+        'name': 'em-pthread-' + PThread.nextWorkerID,
+#else
         'name': 'em-pthread',
+#endif
 #endif
       };
 #if EXPORT_ES6 && USE_ES6_IMPORT_META

--- a/src/shell.js
+++ b/src/shell.js
@@ -112,7 +112,7 @@ var ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIR
 
 // The way we signal to a worker that it is hosting a pthread is to construct
 // it with a specific name.
-var ENVIRONMENT_IS_PTHREAD = ENVIRONMENT_IS_WORKER && self.name == 'em-pthread';
+var ENVIRONMENT_IS_PTHREAD = ENVIRONMENT_IS_WORKER && self.name?.startsWith('em-pthread');
 
 #if MODULARIZE && ASSERTIONS
 if (ENVIRONMENT_IS_PTHREAD) {

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -138,7 +138,7 @@ function ready() {
 // MINIMAL_RUNTIME does not support --proxy-to-worker option, so Worker and Pthread environments
 // coincide.
 var ENVIRONMENT_IS_WORKER = typeof importScripts == 'function';
-var ENVIRONMENT_IS_PTHREAD = ENVIRONMENT_IS_WORKER && self.name == 'em-pthread';
+var ENVIRONMENT_IS_PTHREAD = ENVIRONMENT_IS_WORKER && self.name?.startsWith('em-pthread');
 
 #if !MODULARIZE
 // In MODULARIZE mode _scriptName needs to be captured already at the very top of the page immediately when the page is parsed, so it is generated there

--- a/tools/link.py
+++ b/tools/link.py
@@ -2458,7 +2458,7 @@ else if (typeof define === 'function' && define['amd'])
     # when running in MODULARIZE mode we need use this to know if we should
     # run the module constructor on startup (true only for pthreads).
     if settings.ENVIRONMENT_MAY_BE_WEB or settings.ENVIRONMENT_MAY_BE_WORKER:
-      src += "var isPthread = globalThis.self?.name === 'em-pthread';\n"
+      src += "var isPthread = globalThis.self?.name?.startsWith('em-pthread');\n"
       # In order to support both web and node we also need to detect node here.
       if settings.ENVIRONMENT_MAY_BE_NODE:
         src += "var isNode = typeof globalThis.process?.versions?.node == 'string';\n"


### PR DESCRIPTION
Simplifies picking a web worker when using browser debug tools.