### PR TITLE
Fix missing dependencies in sanitizer builds. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,7 +519,8 @@ jobs:
             lsan.test_stdio_locking
             lsan.test_dlfcn_basic
             lsan.test_pthread_create
-            lsan.test_pthread_exit_main_stub"
+            lsan.test_pthread_exit_main_stub
+            ubsan.test_externref_emjs_dynlink"
       - freeze-cache
       - run-tests:
           # also run a single test of EMTEST_BROWSER=node.

--- a/tools/link.py
+++ b/tools/link.py
@@ -1522,6 +1522,19 @@ def phase_linker_setup(options, state, newargs):
 
   if sanitize:
     settings.USE_OFFSET_CONVERTER = 1
+    # These symbols are needed by `withBuiltinMalloc` which used to implement
+    # the `__noleakcheck` attribute.  However this dependency is not yet represented in the JS
+    # symbol graph generated when we run the compiler with `--symbols-only`.
+    settings.REQUIRED_EXPORTS += [
+      'malloc',
+      'calloc',
+      'memalign',
+      'free',
+      'emscripten_builtin_malloc',
+      'emscripten_builtin_calloc',
+      'emscripten_builtin_memalign',
+      'emscripten_builtin_free',
+    ]
 
   if ('leak' in sanitize or 'address' in sanitize) and not settings.ALLOW_MEMORY_GROWTH:
     # Increase the minimum memory requirements to account for extra memory


### PR DESCRIPTION
This change reverts part of #22596.

A better fix for this would be to add the missing deps to `--symbols-only` but this change seems like the quickest fix.