### PR TITLE
[test] Remove `manually_trigger_reftest` option. NFC

### DIFF
--- a/test/browser/test_sdl2_image_prepare.c
+++ b/test/browser/test_sdl2_image_prepare.c
@@ -15,8 +15,7 @@ SDL_Renderer *renderer;
 
 int testImage(const char* fileName) {
   SDL_Surface *image = IMG_Load(fileName);
-  if (!image)
-  {
+  if (!image) {
      printf("IMG_Load: %s\n", IMG_GetError());
      return 0;
   }
@@ -41,8 +40,6 @@ void ready(const char *f) {
   testImage("screenshot.jpg"); // relative path
 
   SDL_RenderPresent(renderer);
-
-  EM_ASM({ doReftest() });
 }
 
 int main() {

--- a/test/browser/test_sdl2_image_prepare_data.c
+++ b/test/browser/test_sdl2_image_prepare_data.c
@@ -15,8 +15,7 @@ SDL_Renderer *renderer;
 
 int testImage(const char* fileName) {
   SDL_Surface *image = IMG_Load(fileName);
-  if (!image)
-  {
+  if (!image) {
      printf("IMG_Load: %s\n", IMG_GetError());
      return 0;
   }
@@ -56,8 +55,6 @@ void ready(void *arg, const char *fileName) {
     free((void*)seenName); // As the API docs say, we are responsible for freeing the 'fake' names we are given
 
     SDL_RenderPresent(renderer);
-
-    EM_ASM({ doReftest() });
   }
 }
 

--- a/test/browser/test_sdl_image_must_prepare.c
+++ b/test/browser/test_sdl_image_must_prepare.c
@@ -36,8 +36,6 @@ void ready(const char *f) {
   testImage("screenshot.jpg", 1);
 
   SDL_Flip(screen);
-
-  EM_ASM({ doReftest() });
 }
 
 int main() {

--- a/test/browser/test_sdl_image_prepare.c
+++ b/test/browser/test_sdl_image_prepare.c
@@ -37,8 +37,6 @@ void ready(const char *f) {
   testImage("screenshot.jpg"); // relative path
 
   SDL_Flip(screen);
-
-  EM_ASM({ doReftest() });
 }
 
 int main() {

--- a/test/browser/test_sdl_image_prepare_data.c
+++ b/test/browser/test_sdl_image_prepare_data.c
@@ -55,8 +55,6 @@ void ready(void *arg, const char *fileName) {
     free((void*)seenName); // As the API docs say, we are responsible for freeing the 'fake' names we are given
 
     SDL_Flip(screen);
-
-    EM_ASM({ doReftest() });
   }
 }
 

--- a/test/common.py
+++ b/test/common.py
@@ -2204,9 +2204,7 @@ class BrowserCore(RunnerCore):
       time.sleep(5)
       print('(moving on..)')
 
-  # @manually_trigger If set, we do not assume we should run the reftest when main() is done.
-  #                   Instead, call doReftest() in JS yourself at the right time.
-  def make_reftest(self, expected, manually_trigger=False):
+  def make_reftest(self, expected):
     # make sure the pngs used here have no color correction, using e.g.
     #   pngcrush -rem gAMA -rem cHRM -rem iCCP -rem sRGB infile outfile
     reporting = read_file(test_file('browser_reporting.js'))
@@ -2215,6 +2213,7 @@ class BrowserCore(RunnerCore):
       function doReftest() {
         if (doReftest.done) return;
         doReftest.done = true;
+        console.log('doReftest');
         var img = new Image();
         img.onload = () => {
           assert(img.width == Module.canvas.width, `Invalid width: ${Module.canvas.width}, should be ${img.width}`);
@@ -2290,11 +2289,6 @@ class BrowserCore(RunnerCore):
 
       /** @suppress {uselessCode} */
       function setupRefTest() {
-        // Automatically trigger the reftest?
-        var manuallyTrigger = %s;
-        if (!manuallyTrigger) {
-          // Yes, automatically
-
           Module['postRun'] = doReftest;
 
           if (typeof WebGLClient !== 'undefined') {
@@ -2317,19 +2311,10 @@ class BrowserCore(RunnerCore):
               }
             };
           }
-
-        } else {
-          // Manually trigger the reftest.
-
-          // The user will call it.
-          // Add an event loop iteration to ensure rendering, so users don't need to bother.
-          var realDoReftest = doReftest;
-          doReftest = () => setTimeout(realDoReftest, 1);
-        }
       }
 
       setupRefTest();
-''' % (reporting, EMTEST_REBASELINE, int(manually_trigger)))
+''' % (reporting, EMTEST_REBASELINE))
 
   def compile_btest(self, filename, args, reporting=Reporting.FULL):
     # Inject support code for reporting results. This adds an include a header so testcases can
@@ -2352,23 +2337,19 @@ class BrowserCore(RunnerCore):
       filename = test_file(filename)
     self.run_process([compiler_for(filename), filename] + self.get_emcc_args() + args)
 
-  def reftest(self, filename, reference, reference_slack=0, manual_reference=False, manually_trigger_reftest=False, *args, **kwargs):
+  def reftest(self, filename, reference, reference_slack=0, *args, **kwargs):
     """Special case of `btest` that uses reference image
     """
     if self.proxied:
-      assert not manual_reference
-      manual_reference = True
-      manually_trigger_reftest = False
       assert 'post_build' not in kwargs
       kwargs['post_build'] = self.post_manual_reftest
 
     reference = find_browser_test_file(reference)
     assert 'expected' not in kwargs
     expected = [str(i) for i in range(0, reference_slack + 1)]
-    self.make_reftest(reference, manually_trigger=manually_trigger_reftest)
-    if not manual_reference:
-      kwargs.setdefault('args', [])
-      kwargs['args'] += ['--pre-js', 'reftest.js', '-sGL_TESTING']
+    self.make_reftest(reference)
+    kwargs.setdefault('args', [])
+    kwargs['args'] += ['--pre-js', 'reftest.js', '-sGL_TESTING']
 
     try:
       return self.btest(filename, expected=expected, *args, **kwargs)

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -793,7 +793,7 @@ If manually bisecting:
   def test_sdl_image_prepare(self):
     # load an image file, get pixel data.
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.not')
-    self.reftest('test_sdl_image_prepare.c', 'screenshot.jpg', args=['--preload-file', 'screenshot.not', '-lSDL', '-lGL'], manually_trigger_reftest=True)
+    self.reftest('test_sdl_image_prepare.c', 'screenshot.jpg', args=['--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
   @parameterized({
     '': ([],),
@@ -805,12 +805,12 @@ If manually bisecting:
   def test_sdl_image_prepare_data(self, args):
     # load an image file, get pixel data.
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.not')
-    self.reftest('test_sdl_image_prepare_data.c', 'screenshot.jpg', args=['--preload-file', 'screenshot.not', '-lSDL', '-lGL'] + args, manually_trigger_reftest=True)
+    self.reftest('test_sdl_image_prepare_data.c', 'screenshot.jpg', args=['--preload-file', 'screenshot.not', '-lSDL', '-lGL'] + args)
 
   def test_sdl_image_must_prepare(self):
     # load an image file, get pixel data.
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.jpg')
-    self.reftest('test_sdl_image_must_prepare.c', 'screenshot.jpg', args=['--preload-file', 'screenshot.jpg', '-lSDL', '-lGL'], manually_trigger_reftest=True)
+    self.reftest('test_sdl_image_must_prepare.c', 'screenshot.jpg', args=['--preload-file', 'screenshot.jpg', '-lSDL', '-lGL'])
 
   def test_sdl_stb_image(self):
     # load an image file, get pixel data.
@@ -874,7 +874,7 @@ window.close = () => {
 
   def test_sdl_canvas_proxy(self):
     create_file('data.txt', 'datum')
-    self.reftest('test_sdl_canvas_proxy.c', 'test_sdl_canvas_proxy.png', args=['--proxy-to-worker', '--preload-file', 'data.txt', '-lSDL', '-lGL'], manual_reference=True, post_build=self.post_manual_reftest)
+    self.reftest('test_sdl_canvas_proxy.c', 'test_sdl_canvas_proxy.png', args=['--proxy-to-worker', '--preload-file', 'data.txt', '-lSDL', '-lGL'], post_build=self.post_manual_reftest)
 
   @requires_graphics_hardware
   def test_glgears_proxy_jstarget(self):
@@ -2977,18 +2977,18 @@ Module["preRun"] = () => {
   def test_sdl2_image_prepare(self):
     # load an image file, get pixel data.
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.not')
-    self.reftest('test_sdl2_image_prepare.c', 'screenshot.jpg', args=['--preload-file', 'screenshot.not', '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2'], manually_trigger_reftest=True)
+    self.reftest('test_sdl2_image_prepare.c', 'screenshot.jpg', args=['--preload-file', 'screenshot.not', '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2'])
 
   @requires_graphics_hardware
   def test_sdl2_image_prepare_data(self):
     # load an image file, get pixel data.
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.not')
-    self.reftest('test_sdl2_image_prepare_data.c', 'screenshot.jpg', args=['--preload-file', 'screenshot.not', '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2'], manually_trigger_reftest=True)
+    self.reftest('test_sdl2_image_prepare_data.c', 'screenshot.jpg', args=['--preload-file', 'screenshot.not', '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2'])
 
   @requires_graphics_hardware
   def test_sdl2_canvas_proxy(self):
     create_file('data.txt', 'datum')
-    self.reftest('test_sdl2_canvas_proxy.c', 'test_sdl2_canvas.png', args=['-sUSE_SDL=2', '--proxy-to-worker', '--preload-file', 'data.txt', '-sGL_TESTING'], manual_reference=True, post_build=self.post_manual_reftest)
+    self.reftest('test_sdl2_canvas_proxy.c', 'test_sdl2_canvas.png', args=['-sUSE_SDL=2', '--proxy-to-worker', '--preload-file', 'data.txt'], post_build=self.post_manual_reftest)
 
   def test_sdl2_pumpevents(self):
     # key events should be detected using SDL_PumpEvents
@@ -3067,7 +3067,7 @@ Module["preRun"] = () => {
 
   @requires_graphics_hardware
   def test_sdl2_gl_frames_swap(self):
-    self.reftest('test_sdl2_gl_frames_swap.c', 'test_sdl2_gl_frames_swap.png', args=['--proxy-to-worker', '-sGL_TESTING', '-sUSE_SDL=2'], manual_reference=True, post_build=self.post_manual_reftest)
+    self.reftest('test_sdl2_gl_frames_swap.c', 'test_sdl2_gl_frames_swap.png', args=['--proxy-to-worker', '-sUSE_SDL=2'], post_build=self.post_manual_reftest)
 
   @requires_graphics_hardware
   def test_sdl2_ttf(self):


### PR DESCRIPTION
This option was only being used by 5 tests.  These 5 tests are all for SDL_image and they seem to work perfectly fine with automatic reftest which happens when the application is done