### PR TITLE
[AUDIO_WORKLET] Add new emscripten_audio_node_connect API

### DIFF
--- a/site/source/docs/api_reference/wasm_audio_worklets.rst
+++ b/site/source/docs/api_reference/wasm_audio_worklets.rst
@@ -126,8 +126,7 @@ which resumes the audio context when the user clicks on the DOM Canvas element t
                                                               "noise-generator", &options, &GenerateNoise, 0);
 
     // Connect it to audio context destination
-    EM_ASM({emscriptenGetAudioObject($0).connect(emscriptenGetAudioObject($1).destination)},
-      wasmAudioWorklet, audioContext);
+    emscripten_audio_worklet_node_connect(audioContext, wasmAudioWorklet);
 
     // Resume context on mouse click
     emscripten_set_click_callback("canvas", (void*)audioContext, 0, OnCanvasClick);

--- a/site/source/docs/api_reference/wasm_audio_worklets.rst
+++ b/site/source/docs/api_reference/wasm_audio_worklets.rst
@@ -126,7 +126,7 @@ which resumes the audio context when the user clicks on the DOM Canvas element t
                                                               "noise-generator", &options, &GenerateNoise, 0);
 
     // Connect it to audio context destination
-    emscripten_audio_worklet_node_connect(audioContext, wasmAudioWorklet);
+    emscripten_audio_node_connect(wasmAudioWorklet, audioContext, 0, 0);
 
     // Resume context on mouse click
     emscripten_set_click_callback("canvas", (void*)audioContext, 0, OnCanvasClick);

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -587,6 +587,7 @@ sigs = {
   emscripten_atomic_wait_async__sig: 'ipippd',
   emscripten_atomics_is_lock_free__sig: 'ii',
   emscripten_audio_context_state__sig: 'ii',
+  emscripten_audio_worklet_node_connect__sig: 'vii',
   emscripten_audio_worklet_post_function_sig__sig: 'vippp',
   emscripten_audio_worklet_post_function_v__sig: 'vip',
   emscripten_audio_worklet_post_function_vd__sig: 'vipd',

--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -587,7 +587,7 @@ sigs = {
   emscripten_atomic_wait_async__sig: 'ipippd',
   emscripten_atomics_is_lock_free__sig: 'ii',
   emscripten_audio_context_state__sig: 'ii',
-  emscripten_audio_worklet_node_connect__sig: 'vii',
+  emscripten_audio_node_connect__sig: 'viiii',
   emscripten_audio_worklet_post_function_sig__sig: 'vippp',
   emscripten_audio_worklet_post_function_v__sig: 'vip',
   emscripten_audio_worklet_post_function_vd__sig: 'vipd',

--- a/src/library_webaudio.js
+++ b/src/library_webaudio.js
@@ -293,6 +293,19 @@ let LibraryWebAudio = {
   },
 #endif // ~AUDIO_WORKLET
 
+  emscripten_audio_worklet_node_connect: (contextHandle, workletNode) => {
+#if ASSERTIONS
+    assert(EmAudio[contextHandle], `Called emscripten_audio_worklet_node_connect() with an invalid AudioContext handle ${contextHandle}!`);
+    assert(EmAudio[contextHandle] instanceof (window.AudioContext || window.webkitAudioContext), `Called emscripten_audio_worklet_node_connect() on context handle ${contextHandle} that is not an AudioContext, but of type ${typeof EmAudio[contextHandle]} (${EmAudio[contextHandle]})`);
+    assert(EmAudio[workletNode], `Called emscripten_audio_worklet_node_connect() with an invalid AudioWorkletNode handle ${workletNode}`);
+    assert(EmAudio[workletNode].connect, `Called emscripten_audio_worklet_node_connect() on a handle ${workletNode} that is not an AudioWorkletNode, but of type ${typeof EmAudio[workletNode]} (${EmAudio[workletNode]})`);
+#endif
+#if WEBAUDIO_DEBUG
+    console.log(`Connecting worklet with node ID ${workletNode} to Web Audio context with ID ${contextHandle}`);
+#endif
+    EmAudio[workletNode].connect(EmAudio[contextHandle].destination);
+  },
+
   emscripten_current_thread_is_audio_worklet: () => typeof AudioWorkletGlobalScope !== 'undefined',
 
   emscripten_audio_worklet_post_function_v: (audioContext, funcPtr) => {

--- a/src/library_webaudio.js
+++ b/src/library_webaudio.js
@@ -293,17 +293,19 @@ let LibraryWebAudio = {
   },
 #endif // ~AUDIO_WORKLET
 
-  emscripten_audio_worklet_node_connect: (contextHandle, workletNode) => {
+  emscripten_audio_node_connect: (source, destination, outputIndex, inputIndex) => {
+    var srcNode = EmAudio[source];
+    var dstNode = EmAudio[destination];
 #if ASSERTIONS
-    assert(EmAudio[contextHandle], `Called emscripten_audio_worklet_node_connect() with an invalid AudioContext handle ${contextHandle}!`);
-    assert(EmAudio[contextHandle] instanceof (window.AudioContext || window.webkitAudioContext), `Called emscripten_audio_worklet_node_connect() on context handle ${contextHandle} that is not an AudioContext, but of type ${typeof EmAudio[contextHandle]} (${EmAudio[contextHandle]})`);
-    assert(EmAudio[workletNode], `Called emscripten_audio_worklet_node_connect() with an invalid AudioWorkletNode handle ${workletNode}`);
-    assert(EmAudio[workletNode].connect, `Called emscripten_audio_worklet_node_connect() on a handle ${workletNode} that is not an AudioWorkletNode, but of type ${typeof EmAudio[workletNode]} (${EmAudio[workletNode]})`);
+    assert(srcNode, `Called emscripten_audio_node_connect() with an invalid AudioNode handle ${source}`);
+    assert(srcNode instanceof window.AudioNode, `Called emscripten_audio_node_connect() on handle ${source} that is not an AudiotNode, but of type ${srcNode}`);
+    assert(dstNode, `Called emscripten_audio_node_connect() with an invalid AudioNode handle ${destination}!`);
+    assert(dstNode instanceof (window.AudioContext || window.webkitAudioContext) || dstNode instanceof window.AudioNode, `Called emscripten_audio_node_connect() on handle ${destination} that is not an AudioContext or AudioNode, but of type ${dstNode}`);
 #endif
 #if WEBAUDIO_DEBUG
-    console.log(`Connecting worklet with node ID ${workletNode} to Web Audio context with ID ${contextHandle}`);
+    console.log(`Connecting audio node ID ${source} to audio node ID ${destination} (${srcNode} to ${dstNode})`);
 #endif
-    EmAudio[workletNode].connect(EmAudio[contextHandle].destination);
+    srcNode.connect(dstNode.destination || dstNode, outputIndex, inputIndex);
   },
 
   emscripten_current_thread_is_audio_worklet: () => typeof AudioWorkletGlobalScope !== 'undefined',

--- a/system/include/emscripten/webaudio.h
+++ b/system/include/emscripten/webaudio.h
@@ -129,6 +129,9 @@ typedef struct EmscriptenAudioWorkletNodeCreateOptions
 // userData4: A custom userdata pointer to pass to the callback function. This value will be passed on to the call to the given EmscriptenWorkletNodeProcessCallback callback function.
 EMSCRIPTEN_AUDIO_WORKLET_NODE_T emscripten_create_wasm_audio_worklet_node(EMSCRIPTEN_WEBAUDIO_T audioContext, const char *name, const EmscriptenAudioWorkletNodeCreateOptions *options, EmscriptenWorkletNodeProcessCallback processCallback, void *userData4);
 
+// Connects the audio worklet node to the audio context
+void emscripten_audio_worklet_node_connect(EMSCRIPTEN_WEBAUDIO_T audioContext, EMSCRIPTEN_AUDIO_WORKLET_NODE_T workletNode);
+
 // Returns true if the current thread is executing a Wasm AudioWorklet, false otherwise.
 // Note that calling this function can be relatively slow as it incurs a Wasm->JS transition,
 // so avoid calling it in hot paths.

--- a/system/include/emscripten/webaudio.h
+++ b/system/include/emscripten/webaudio.h
@@ -129,8 +129,9 @@ typedef struct EmscriptenAudioWorkletNodeCreateOptions
 // userData4: A custom userdata pointer to pass to the callback function. This value will be passed on to the call to the given EmscriptenWorkletNodeProcessCallback callback function.
 EMSCRIPTEN_AUDIO_WORKLET_NODE_T emscripten_create_wasm_audio_worklet_node(EMSCRIPTEN_WEBAUDIO_T audioContext, const char *name, const EmscriptenAudioWorkletNodeCreateOptions *options, EmscriptenWorkletNodeProcessCallback processCallback, void *userData4);
 
-// Connects the audio worklet node to the audio context
-void emscripten_audio_worklet_node_connect(EMSCRIPTEN_WEBAUDIO_T audioContext, EMSCRIPTEN_AUDIO_WORKLET_NODE_T workletNode);
+// Connects a node's output to a target, e.g., connect the worklet node to the context.
+// For outputIndex and inputIndex, see the AudioNode.connect() documentation (setting 0 as the default values)
+void emscripten_audio_node_connect(EMSCRIPTEN_WEBAUDIO_T source, EMSCRIPTEN_WEBAUDIO_T destination, int outputIndex, int inputIndex);
 
 // Returns true if the current thread is executing a Wasm AudioWorklet, false otherwise.
 // Note that calling this function can be relatively slow as it incurs a Wasm->JS transition,

--- a/test/webaudio/audio_worklet_tone_generator.c
+++ b/test/webaudio/audio_worklet_tone_generator.c
@@ -83,7 +83,7 @@ void AudioWorkletProcessorCreated(EMSCRIPTEN_WEBAUDIO_T audioContext, bool succe
   EMSCRIPTEN_AUDIO_WORKLET_NODE_T wasmAudioWorklet = emscripten_create_wasm_audio_worklet_node(audioContext, "tone-generator", &options, &ProcessAudio, 0);
 
   // Connect the audio worklet node to the graph.
-  emscripten_audio_worklet_node_connect(audioContext, wasmAudioWorklet);
+  emscripten_audio_node_connect(wasmAudioWorklet, audioContext, 0, 0);
   EM_ASM({
     // Add a button on the page to toggle playback as a response to user click.
     let startButton = document.createElement('button');

--- a/test/webaudio/audio_worklet_tone_generator.c
+++ b/test/webaudio/audio_worklet_tone_generator.c
@@ -82,17 +82,15 @@ void AudioWorkletProcessorCreated(EMSCRIPTEN_WEBAUDIO_T audioContext, bool succe
   // Instantiate the noise-generator Audio Worklet Processor.
   EMSCRIPTEN_AUDIO_WORKLET_NODE_T wasmAudioWorklet = emscripten_create_wasm_audio_worklet_node(audioContext, "tone-generator", &options, &ProcessAudio, 0);
 
+  // Connect the audio worklet node to the graph.
+  emscripten_audio_worklet_node_connect(audioContext, wasmAudioWorklet);
   EM_ASM({
-    let audioContext = emscriptenGetAudioObject($0);
-    let audioWorkletNode = emscriptenGetAudioObject($1);
-    // Connect the audio worklet node to the graph.
-    audioWorkletNode.connect(audioContext.destination);
-
     // Add a button on the page to toggle playback as a response to user click.
     let startButton = document.createElement('button');
     startButton.innerHTML = 'Toggle playback';
     document.body.appendChild(startButton);
 
+    let audioContext = emscriptenGetAudioObject($0);
     startButton.onclick = () => {
       if (audioContext.state != 'running') {
         audioContext.resume();
@@ -100,7 +98,7 @@ void AudioWorkletProcessorCreated(EMSCRIPTEN_WEBAUDIO_T audioContext, bool succe
         audioContext.suspend();
       }
     };
-  }, audioContext, wasmAudioWorklet);
+  }, audioContext);
 
 #ifdef REPORT_RESULT
   emscripten_set_timeout_loop(observe_test_end, 10, 0);

--- a/test/webaudio/audioworklet.c
+++ b/test/webaudio/audioworklet.c
@@ -95,7 +95,7 @@ void AudioWorkletProcessorCreated(EMSCRIPTEN_WEBAUDIO_T audioContext, bool succe
   // Instantiate the noise-generator Audio Worklet Processor.
   EMSCRIPTEN_AUDIO_WORKLET_NODE_T wasmAudioWorklet = emscripten_create_wasm_audio_worklet_node(audioContext, "noise-generator", &options, &ProcessAudio, 0);
   // Connect the audio worklet node to the graph.
-  emscripten_audio_worklet_node_connect(audioContext, wasmAudioWorklet);
+  emscripten_audio_node_connect(wasmAudioWorklet, audioContext, 0, 0);
 
 #ifdef REPORT_RESULT
   emscripten_set_timeout_loop(main_thread_tls_access, 10, 0);

--- a/test/webaudio/audioworklet_emscripten_futex_wake.cpp
+++ b/test/webaudio/audioworklet_emscripten_futex_wake.cpp
@@ -26,14 +26,12 @@ bool ProcessAudio(int numInputs, const AudioSampleFrame *inputs, int numOutputs,
   return false;
 }
 
-EM_JS(void, InitHtmlUi, (EMSCRIPTEN_WEBAUDIO_T audioContext, EMSCRIPTEN_AUDIO_WORKLET_NODE_T audioWorkletNode), {
-  audioContext = emscriptenGetAudioObject(audioContext);
-  audioWorkletNode = emscriptenGetAudioObject(audioWorkletNode);
-  audioWorkletNode.connect(audioContext.destination);
+EM_JS(void, InitHtmlUi, (EMSCRIPTEN_WEBAUDIO_T audioContext), {
   let startButton = document.createElement('button');
   startButton.innerHTML = 'Start playback';
   document.body.appendChild(startButton);
 
+  audioContext = emscriptenGetAudioObject(audioContext);
   startButton.onclick = () => {
     audioContext.resume();
   };
@@ -54,7 +52,8 @@ void AudioWorkletProcessorCreated(EMSCRIPTEN_WEBAUDIO_T audioContext, bool succe
   int outputChannelCounts[1] = { 1 };
   EmscriptenAudioWorkletNodeCreateOptions options = { .numberOfInputs = 0, .numberOfOutputs = 1, .outputChannelCounts = outputChannelCounts };
   EMSCRIPTEN_AUDIO_WORKLET_NODE_T wasmAudioWorklet = emscripten_create_wasm_audio_worklet_node(audioContext, "noise-generator", &options, &ProcessAudio, 0);
-  InitHtmlUi(audioContext, wasmAudioWorklet);
+  emscripten_audio_worklet_node_connect(audioContext, wasmAudioWorklet);
+  InitHtmlUi(audioContext);
 }
 
 void WebAudioWorkletThreadInitialized(EMSCRIPTEN_WEBAUDIO_T audioContext, bool success, void *userData) {

--- a/test/webaudio/audioworklet_emscripten_futex_wake.cpp
+++ b/test/webaudio/audioworklet_emscripten_futex_wake.cpp
@@ -52,7 +52,7 @@ void AudioWorkletProcessorCreated(EMSCRIPTEN_WEBAUDIO_T audioContext, bool succe
   int outputChannelCounts[1] = { 1 };
   EmscriptenAudioWorkletNodeCreateOptions options = { .numberOfInputs = 0, .numberOfOutputs = 1, .outputChannelCounts = outputChannelCounts };
   EMSCRIPTEN_AUDIO_WORKLET_NODE_T wasmAudioWorklet = emscripten_create_wasm_audio_worklet_node(audioContext, "noise-generator", &options, &ProcessAudio, 0);
-  emscripten_audio_worklet_node_connect(audioContext, wasmAudioWorklet);
+  emscripten_audio_node_connect(wasmAudioWorklet, audioContext, 0, 0);
   InitHtmlUi(audioContext);
 }
 


### PR DESCRIPTION
In all the examples and in the docs, connecting the context and worklet is done with the following type of code:

```
EM_ASM({
  emscriptenGetAudioObject($0).connect(emscriptenGetAudioObject($1).destination)
}, wasmAudioWorklet, audioContext);
```

Every example or usage needs this to play audio. Granted, more complex graphs will add more node types and `emscriptenGetAudioObject()` will have its uses, but for the general use case a simpler call without JS is preferred:

```
emscripten_audio_worklet_node_connect(audioContext, wasmAudioWorklet);
```

See here for how it's done in the examples:

https://github.com/emscripten-core/emscripten/blob/7df48f680e2e901b9bf1f5312d27ca939753548d/test/webaudio/audioworklet.c#L50

I updated the examples and the documentation.

@juj Comments or ideas?