### PR TITLE
Fix ordering of source maps fields.

### DIFF
--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -317,9 +317,9 @@ def build_sourcemap(entries, code_section_offset, prefixes, collect_sources, bas
     last_line = line
     last_column = column
   return {'version': 3,
-          'names': [],
           'sources': sources,
           'sourcesContent': sources_content,
+          'names': [],
           'mappings': ','.join(mappings)}
 
 


### PR DESCRIPTION
The order is specified in https://github.com/tc39/source-map/blob/main/source-map-rev3.md#proposed-format

This was causing binaryen to fail after https://github.com/WebAssembly/binaryen/pull/6795