### PR TITLE
[test] Re-instate ability to delay reference image collection. NFC

### DIFF
--- a/test/browser/test_sdl2_image_prepare.c
+++ b/test/browser/test_sdl2_image_prepare.c
@@ -40,6 +40,8 @@ void ready(const char *f) {
   testImage("screenshot.jpg"); // relative path
 
   SDL_RenderPresent(renderer);
+
+  EM_ASM(reftestUnblock());
 }
 
 int main() {
@@ -56,6 +58,7 @@ int main() {
 
   assert(emscripten_run_preload_plugins("screenshot.jpg", ready, NULL) == 0);
 
+  EM_ASM(reftestBlock());
   return 0;
 }
 

--- a/test/browser/test_sdl2_image_prepare_data.c
+++ b/test/browser/test_sdl2_image_prepare_data.c
@@ -55,6 +55,8 @@ void ready(void *arg, const char *fileName) {
     free((void*)seenName); // As the API docs say, we are responsible for freeing the 'fake' names we are given
 
     SDL_RenderPresent(renderer);
+
+    EM_ASM(reftestUnblock());
   }
 }
 
@@ -75,6 +77,7 @@ int main() {
   emscripten_run_preload_plugins_data(buffer, SIZE, "jpg", (void*)25, ready, NULL);
   emscripten_run_preload_plugins_data(buffer, SIZE, "jpg", (void*)33, ready, NULL); // twice to see different filenames
 
+  EM_ASM(reftestBlock());
   return 0;
 }
 

--- a/test/browser/test_sdl_image_must_prepare.c
+++ b/test/browser/test_sdl_image_must_prepare.c
@@ -36,6 +36,8 @@ void ready(const char *f) {
   testImage("screenshot.jpg", 1);
 
   SDL_Flip(screen);
+
+  EM_ASM(reftestUnblock());
 }
 
 int main() {
@@ -48,6 +50,7 @@ int main() {
 
   assert(emscripten_run_preload_plugins("screenshot.jpg", ready, NULL) == 0);
 
+  EM_ASM(reftestBlock());
   return 0;
 }
 

--- a/test/browser/test_sdl_image_prepare.c
+++ b/test/browser/test_sdl_image_prepare.c
@@ -37,6 +37,8 @@ void ready(const char *f) {
   testImage("screenshot.jpg"); // relative path
 
   SDL_Flip(screen);
+
+  EM_ASM(reftestUnblock());
 }
 
 int main() {
@@ -51,6 +53,7 @@ int main() {
 
   assert(emscripten_run_preload_plugins("screenshot.jpg", ready, NULL) == 0);
 
+  EM_ASM(reftestBlock());
   return 0;
 }
 

--- a/test/browser/test_sdl_image_prepare_data.c
+++ b/test/browser/test_sdl_image_prepare_data.c
@@ -55,6 +55,7 @@ void ready(void *arg, const char *fileName) {
     free((void*)seenName); // As the API docs say, we are responsible for freeing the 'fake' names we are given
 
     SDL_Flip(screen);
+    EM_ASM(reftestUnblock());
   }
 }
 
@@ -73,6 +74,7 @@ int main() {
   emscripten_run_preload_plugins_data(buffer, SIZE, "jpg", (void*)25, ready, NULL);
   emscripten_run_preload_plugins_data(buffer, SIZE, "jpg", (void*)33, ready, NULL); // twice to see different filenames
 
+  EM_ASM(reftestBlock());
   return 0;
 }
 


### PR DESCRIPTION
In #22665 I removed the manually_trigger_reftest. However this resulted in racey behaviour in some tests.  It turns out that running `doReftest` during `postRun` was working, but only because `doReftest` itself was doing async work, thus delaying the actual capture of the canvas bits.

This change re-instates the behaviour but without the need to test setting in python.