### PR TITLE
Revert conversion of test_utf32 from cpp to c.

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5680,8 +5680,8 @@ got: 10
     self.do_core_test('test_utf.c')
 
   def test_utf32(self):
-    self.do_runf('core/test_utf32.c', 'OK.')
-    self.do_runf('core/test_utf32.c', 'OK.', args=['-fshort-wchar'])
+    self.do_runf('utf32.cpp', 'OK.')
+    self.do_runf('utf32.cpp', 'OK.', args=['-fshort-wchar'])
 
   @crossplatform
   def test_utf16(self):

--- a/test/utf32.cpp
+++ b/test/utf32.cpp
@@ -4,9 +4,9 @@
 // found in the LICENSE file.
 
 #include <stdio.h>
-#include <string.h>
+#include <string>
 #include <emscripten.h>
-#include <assert.h>
+#include <cassert>
 #include <wchar.h>
 
 typedef unsigned int utf32;
@@ -19,24 +19,23 @@ int main() {
   // U+2603 is snowman,
   // U+20AC is the Euro sign,
   // U+2007C is a Chinese Han character that looks like three raindrops.
-  wchar_t wstr[] = L"abc\u2603\u20AC\U0002007C123 --- abc\u2603\u20AC\U0002007C123";
-  size_t wstr_len = wcslen(wstr);
+  std::wstring wstr = L"abc\u2603\u20AC\U0002007C123 --- abc\u2603\u20AC\U0002007C123";
 
   printf("sizeof(wchar_t): %d.\n", (int)sizeof(wchar_t));
 
   if (sizeof(wchar_t) == 4) {
-    utf32 *memory = malloc(wstr_len*sizeof(utf32));
+    utf32 *memory = new utf32[wstr.length()+1];
 
     EM_ASM({
       var str = UTF32ToString($0);
       out(str);
       var numBytesWritten = stringToUTF32(str, $1, Number($2));
       if (numBytesWritten != 23*4) throw 'stringToUTF32 wrote an invalid length ' + numBytesWritten;
-    }, wstr, memory, (wstr_len+1)*sizeof(utf32));
+    }, wstr.c_str(), memory, (wstr.length()+1)*sizeof(utf32));
 
     // Compare memory to confirm that the string is intact after taking a route
     // through JS side.
-    const utf32 *srcPtr = (const utf32 *)(wstr);
+    const utf32 *srcPtr = reinterpret_cast<const utf32 *>(wstr.c_str());
     for (int i = 0;; ++i) {
       assert(memory[i] == srcPtr[i]);
       if (srcPtr[i] == 0)
@@ -48,24 +47,24 @@ int main() {
       out(str);
       var numBytesWritten = stringToUTF32(str, $1, Number($2));
       if (numBytesWritten != 5*4) throw 'stringToUTF32 wrote an invalid length ' + numBytesWritten;
-    }, wstr, memory, 6*sizeof(utf32));
+    }, wstr.c_str(), memory, 6*sizeof(utf32));
     assert(memory[5] == 0);
 
-    free(memory);
+    delete[] memory;
   } else {
     // sizeof(wchar_t) == 2, and we're building with -fshort-wchar.
-    utf16 *memory = malloc((2*wstr_len+1) * sizeof(utf16));
+    utf16 *memory = new utf16[2*wstr.length()+1];
 
     EM_ASM({
       var str = UTF16ToString($0);
       out(str);
       var numBytesWritten = stringToUTF16(str, $1, $2);
       if (numBytesWritten != 25*2) throw 'stringToUTF16 wrote an invalid length ' + numBytesWritten;
-    }, wstr, memory, (2*wstr_len+1)*sizeof(utf16));
+    }, wstr.c_str(), memory, (2*wstr.length()+1)*sizeof(utf16));
 
     // Compare memory to confirm that the string is intact after taking a route
     // through JS side.
-    const utf16 *srcPtr = (const utf16 *)(wstr);
+    const utf16 *srcPtr = reinterpret_cast<const utf16 *>(wstr.c_str());
     for (int i = 0;; ++i) {
       assert(memory[i] == srcPtr[i]);
       if (srcPtr[i] == 0)
@@ -77,10 +76,10 @@ int main() {
       out(str);
       var numBytesWritten = stringToUTF16(str, $1, $2);
       if (numBytesWritten != 5*2) throw 'stringToUTF16 wrote an invalid length ' + numBytesWritten;
-    }, wstr, memory, 6*sizeof(utf16));
+    }, wstr.c_str(), memory, 6*sizeof(utf16));
     assert(memory[5] == 0);
 
-    free(memory);
+    delete[] memory;
   }
 
   printf("OK.\n");


### PR DESCRIPTION
This test was failing asan after the conversion in #22669.

https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket/8735090587456463425/+/u/Emscripten_testsuite__ASan_/stdout