### PR TITLE
[Doc] embind.rst - remove "Optional" arg from register_optional

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -1078,7 +1078,7 @@ For convenience, *embind* provides factory functions to register
     EMSCRIPTEN_BINDINGS(stl_wrappers) {
         register_vector<int>("VectorInt");
         register_map<int,int>("MapIntInt");
-        register_optional<std::string>("Optional");
+        register_optional<std::string>();
     }
 
 A full example is shown below:


### PR DESCRIPTION
Calling `register_optional<std::string>("Optional");` results in:

```
error: no matching function for call to 'register_optional'
    8 |   emscripten::register_optional<std::string>("Optional");
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/emsdk/upstream/emscripten/cache/sysroot/include/emscripten/bind.h:1880:6: note: candidate function template not viable: requires 0 arguments, but 1 was provided
 1880 | void register_optional() {
      |      ^
1 error generated
```

As shown in later in the doc and in usage in https://github.com/emscripten-core/emscripten/pull/21076, `register_optional` should not take in an argument. Also see the source code: https://github.com/emscripten-core/emscripten/blob/df2200953b57af106dc8a597692580b796f542ef/system/include/emscripten/bind.h#L2006