### PR TITLE
Fix regression in i64 argument handling in webgpu+bigint

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@ See docs/process.md for more on how version tagging works.
 - The usage of `EM_BOOL` in the emscripten API has been replaced with C/C++
   bool.  This change should not be observable since `EM_BOOL` has been
   equivalent to `bool` since #22157. (#22155)
+- Fix regression introduced in 3.1.67 (#22557) which broke webgpu / int64
+  integration. (#22689)
 
 3.1.68 - 09/30/24
 -----------------

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -2883,9 +2883,9 @@ for (var value in LibraryWebGPU.$WebGPU.FeatureName) {
 
 for (const key of Object.keys(LibraryWebGPU)) {
   if (typeof LibraryWebGPU[key] === 'function') {
-    const sig = LibraryWebGPU[key + '__sig'];
+    const sig = LibraryManager.library[key + '__sig'];
     if (sig?.includes('j')) {
-      LibraryWebGPU[key + '__i53abi'] = true;
+      LibraryManager.library[key + '__i53abi'] = true;
     }
   }
 }

--- a/test/webgpu_basic_rendering.cpp
+++ b/test/webgpu_basic_rendering.cpp
@@ -225,6 +225,11 @@ void doCopyTestMappedAtCreation(bool useRange) {
         dst = device.CreateBuffer(&descriptor);
     }
 
+    // Write some random data to the buffer, just to verify that
+    // wgpuQueueWriteBuffer works.
+    char data[4];
+    queue.WriteBuffer(dst, 0, data, sizeof(data));
+
     wgpu::CommandBuffer commands;
     {
         wgpu::CommandEncoder encoder = device.CreateCommandEncoder();


### PR DESCRIPTION
This was caused by #22557, which was checking the `LibraryWebGPU` object for `__sig` members when the sigs are stored in a separate file and therefore live on the global `LibraryManager.library` object.

Fixes: #22682