### PR TITLE
[contrib.glfw3] new version 3.4.0.20241004

### DIFF
--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -6,8 +6,8 @@
 import os
 from typing import Union, Dict
 
-TAG = '3.4.0.20240907'
-HASH = '48aba179ef50b5efd564535cd549528d06f74d18f7028a06212fccc425b784106b0efb3aa7bf72da6fb80c32a31b410f13a87d4599417cad8dc3af15664fa1b2'
+TAG = '3.4.0.20241004'
+HASH = 'd2745e9f621090b6f78e1c8122d1e6a2e7e774d27799f14945ddcfd543aedeac0e6acdecf42fe74f9ecdbc25aa3599372798ecfc55ddd941661e0628c494cda6'
 
 # contrib port information (required)
 URL = 'https://github.com/pongasoft/emscripten-glfw'


### PR DESCRIPTION
I released a new version 3.4.0.20241004 with the following release notes:

- Implemented custom cursors (`glfwCreateCursor`)
  - uses a canvas to draw the cursor image into it and convert it into a URL (`canvas.toDataURL()`)
  - uses the CSS property syntax: `cursor: url(xxx) xhot yhot, auto` when calling `glfwSetCursor` with a custom cursor
