### PR TITLE
Update SDL2 port from 2.28.4 to 2.30.8

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,7 @@ See docs/process.md for more on how version tagging works.
   equivalent to `bool` since #22157. (#22155)
 - Fix regression introduced in 3.1.67 (#22557) which broke webgpu / int64
   integration. (#22689)
+- SDL2 port updated from 2.28.4 to 2.30.8. (#22697)
 
 3.1.68 - 09/30/24
 -----------------

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -5,8 +5,8 @@
 
 import os
 
-TAG = 'release-2.28.4'
-HASH = '8dd593fd7d8660efdeb53b7d1706f5743eb68491a29eb0cf0c028d8f8b8a7945c0dc5bf1117b5e4e871d7622be277c0838d08cc6eabdecb563000dfcc0c94639'
+TAG = 'release-2.30.8'
+HASH = '6e54c2f93c675b134ff311cb91e5f7b3ad77eb41335b172dc6d3e9774d2ea4728eba9d51667f799cfa1c52cc63169f88f0420c2330574ad3230ee0cb0642e3d4'
 SUBDIR = 'SDL-' + TAG
 
 variants = {'sdl2-mt': {'PTHREADS': 1}}
@@ -39,6 +39,7 @@ def get(ports, settings, shared):
     events/SDL_scancode_tables.c events/SDL_mouse.c events/SDL_quit.c
     events/SDL_touch.c events/SDL_windowevents.c file/SDL_rwops.c haptic/SDL_haptic.c
     joystick/controller_type.c joystick/SDL_gamecontroller.c joystick/SDL_joystick.c
+    joystick/SDL_steam_virtual_gamepad.c
     power/SDL_power.c render/SDL_d3dmath.c render/SDL_render.c
     render/SDL_yuv_sw.c render/direct3d/SDL_render_d3d.c render/direct3d11/SDL_render_d3d11.c
     render/opengl/SDL_render_gl.c render/opengl/SDL_shaders_gl.c render/opengles/SDL_render_gles.c
@@ -58,7 +59,7 @@ def get(ports, settings, shared):
     video/emscripten/SDL_emscriptenframebuffer.c video/emscripten/SDL_emscriptenmouse.c
     video/emscripten/SDL_emscriptenopengles.c video/emscripten/SDL_emscriptenvideo.c
     audio/emscripten/SDL_emscriptenaudio.c video/dummy/SDL_nullevents.c
-    video/dummy/SDL_nullframebuffer.c video/dummy/SDL_nullvideo.c video/yuv2rgb/yuv_rgb.c
+    video/dummy/SDL_nullframebuffer.c video/dummy/SDL_nullvideo.c video/yuv2rgb/yuv_rgb_std.c
     audio/disk/SDL_diskaudio.c audio/dummy/SDL_dummyaudio.c loadso/dlopen/SDL_sysloadso.c
     power/emscripten/SDL_syspower.c joystick/emscripten/SDL_sysjoystick.c
     filesystem/emscripten/SDL_sysfilesystem.c timer/unix/SDL_systimer.c haptic/dummy/SDL_syshaptic.c
@@ -70,6 +71,9 @@ def get(ports, settings, shared):
 
     srcs = [os.path.join(src_dir, 'src', s) for s in srcs]
     flags = ['-sUSE_SDL=0']
+    # SDL2 currently has the wrong definition of SDL_PRIs64 for emscripten.
+    # TODO: Remove this when we roll SDL2 to include https://github.com/libsdl-org/SDL/pull/11127
+    flags += ['-Wno-format']
     includes = [ports.get_include_dir('SDL2')]
     if settings.PTHREADS:
       flags += ['-pthread']


### PR DESCRIPTION
This is in anticipation of https://github.com/libsdl-org/SDL/pull/11127 landing in the next SDL2 release.