### PR TITLE
Allow MapMode.Read in wgpuBufferGetMappedRange

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -2052,13 +2052,14 @@ var LibraryWebGPU = {
     }
 
     var data = _memalign(16, mapped.byteLength);
-    HEAPU8.fill(0, data, mapped.byteLength);
     if (bufferWrapper.mapMode === {{{ gpu.MapMode.Write }}}) {
+      HEAPU8.fill(0, data, mapped.byteLength);
       bufferWrapper.onUnmap.push(() => {
         new Uint8Array(mapped).set(HEAPU8.subarray(data, data + mapped.byteLength));
         _free(data);
       });
     } else {
+      HEAPU8.set(new Uint8Array(mapped), data);
       bufferWrapper.onUnmap.push(() => _free(data));
     }
     return data;


### PR DESCRIPTION
Emscripten's distribution of the WebGPU API prohibits the usage of MapMode.Read in wgpuBufferGetMappedRange, even though this is allowed in the C++ spec.

This would be useful considering that wgpuBufferGetConstMappedRange is not present in some distributions of WebGPU.
In fact, both wgpuBufferGetMappedRange and wgpuBufferGetConstMappedRange already forward their calls to bufferWrapper.object.getMappedRange.

This pull request makes wgpuBufferGetConstMappedRange behave like wgpuBufferGetMappedRange when it is called with MapMode.Read.