### PR TITLE
Update SDL2 port to version that includes wasm64 fixes.

### DIFF
--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -2047,7 +2047,7 @@ var LibraryGLEmulation = {
         GLImmediate.rendererComponents[name] = 1;
 #if ASSERTIONS
         if (GLImmediate.enabledClientAttributes[name]) {
-          out("Warning: glTexCoord used after EnableClientState for TEXTURE_COORD_ARRAY for TEXTURE0. Disabling TEXTURE_COORD_ARRAY...");
+          warnOnce("Warning: glTexCoord used after EnableClientState for TEXTURE_COORD_ARRAY for TEXTURE0. Disabling TEXTURE_COORD_ARRAY...");
         }
 #endif
         GLImmediate.enabledClientAttributes[name] = true;
@@ -2980,11 +2980,10 @@ var LibraryGLEmulation = {
           var attr = attributes[i];
           var srcStride = Math.max(attr.sizeBytes, attr.stride);
           if ((srcStride & 3) == 0 && (attr.sizeBytes & 3) == 0) {
-            var size4 = attr.sizeBytes>>2;
-            var srcStride4 = Math.max(attr.sizeBytes, attr.stride)>>2;
             for (var j = 0; j < count; j++) {
-              for (var k = 0; k < size4; k++) { // copy in chunks of 4 bytes, our alignment makes this possible
-                HEAP32[((start + attr.offset + bytes*j)>>2) + k] = HEAP32[(attr.pointer>>2) + j*srcStride4 + k];
+              for (var k = 0; k < attr.sizeBytes; k+=4) { // copy in chunks of 4 bytes, our alignment makes this possible
+                var val = {{{ makeGetValue('attr.pointer', 'j*srcStride + k', 'i32') }}};
+                {{{ makeSetValue('start + attr.offset', 'bytes*j + k', 'val', 'i32') }}};
               }
             }
           } else {
@@ -3533,7 +3532,7 @@ var LibraryGLEmulation = {
     if (!GLctx.currentElementArrayBufferBinding) {
       assert(type == GLctx.UNSIGNED_SHORT); // We can only emulate buffers of this kind, for now
     }
-    out("DrawElements doesn't actually prepareClientAttributes properly.");
+    warnOnce("DrawElements doesn't actually prepareClientAttributes properly.");
 #endif
     GLImmediate.prepareClientAttributes(count, false);
     GLImmediate.mode = mode;

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3050,8 +3050,6 @@ Module["preRun"] = () => {
     # SDL, OpenGL, readPixels
     self.btest_exit('test_sdl2_gl_read.c', args=['-sUSE_SDL=2'])
 
-  @no_4gb('https://github.com/libsdl-org/SDL/issues/9052')
-  @no_2gb('https://github.com/libsdl-org/SDL/issues/9052')
   @requires_graphics_hardware
   def test_sdl2_glmatrixmode_texture(self):
     self.reftest('test_sdl2_glmatrixmode_texture.c', 'test_sdl2_glmatrixmode_texture.png',
@@ -3105,8 +3103,6 @@ Module["preRun"] = () => {
   def test_sdl2_unwasteful(self):
     self.btest_exit('test_sdl2_unwasteful.c', args=['-sUSE_SDL=2', '-O1'])
 
-  @no_2gb('https://github.com/libsdl-org/SDL/issues/9052')
-  @no_4gb('https://github.com/libsdl-org/SDL/issues/9052')
   def test_sdl2_canvas_write(self):
     self.btest_exit('test_sdl2_canvas_write.c', args=['-sUSE_SDL=2'])
 

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -5,8 +5,11 @@
 
 import os
 
-TAG = 'release-2.30.8'
-HASH = '6e54c2f93c675b134ff311cb91e5f7b3ad77eb41335b172dc6d3e9774d2ea4728eba9d51667f799cfa1c52cc63169f88f0420c2330574ad3230ee0cb0642e3d4'
+# For now we pin to specific commit since we want to include
+# https://github.com/libsdl-org/SDL/pull/11127
+# Once the next version of SDL2 is tagged we can use that here instead.
+TAG = '3deb07ea395373204462130c1e062bc1f71fe060'
+HASH = '551082bffb28442ad20662c6963fb02701449d43e7da6aa68fbec922e47b060609e3cdf5f9e3bfde7458a92547e008f010af79ddadf448665e55ca8759cfbcdb'
 SUBDIR = 'SDL-' + TAG
 
 variants = {'sdl2-mt': {'PTHREADS': 1}}
@@ -71,9 +74,6 @@ def get(ports, settings, shared):
 
     srcs = [os.path.join(src_dir, 'src', s) for s in srcs]
     flags = ['-sUSE_SDL=0']
-    # SDL2 currently has the wrong definition of SDL_PRIs64 for emscripten.
-    # TODO: Remove this when we roll SDL2 to include https://github.com/libsdl-org/SDL/pull/11127
-    flags += ['-Wno-format']
     includes = [ports.get_include_dir('SDL2')]
     if settings.PTHREADS:
       flags += ['-pthread']


### PR DESCRIPTION
Also, fix a wasm64 bug GL emulation that was only exposed by running the tests which are no longer disabled.