### PR TITLE
Micro-optimize zeroMemory / mmapAlloc. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -62,7 +62,6 @@ addToLibrary({
     }
 #endif
     HEAPU8.fill(0, address, address + size);
-    return address;
   },
 
 #if SAFE_HEAP
@@ -2278,8 +2277,8 @@ addToLibrary({
 #if hasExportedSymbol('emscripten_builtin_memalign')
     size = alignMemory(size, {{{ WASM_PAGE_SIZE }}});
     var ptr = _emscripten_builtin_memalign({{{ WASM_PAGE_SIZE }}}, size);
-    if (!ptr) return 0;
-    return zeroMemory(ptr, size);
+    if (ptr) zeroMemory(ptr, size);
+    return ptr;
 #elif ASSERTIONS
     abort('internal error: mmapAlloc called but `emscripten_builtin_memalign` native symbol not exported');
 #else


### PR DESCRIPTION
We can skip the return statement from zeroMemory and reduce the number of return statements in mmapAlloc to just one.