### PR TITLE
[embind] Simplify makeLegalFunctionName. NFC

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -2269,9 +2269,9 @@ var LibraryEmbind = {
   $char_9: '9'.charCodeAt(0),
   $makeLegalFunctionName__deps: ['$char_0', '$char_9'],
   $makeLegalFunctionName: (name) => {
-    if (undefined === name) {
-      return '_unknown';
-    }
+#if ASSERTIONS
+    assert(typeof name === 'string');
+#endif
     name = name.replace(/[^a-zA-Z0-9_]/g, '$');
     var f = name.charCodeAt(0);
     if (f >= char_0 && f <= char_9) {


### PR DESCRIPTION
This function only has a single call site and that argument passed cannot be undefined.  Include an assertion just in case.