### PR TITLE
Fix wasm workers under node

### DIFF
--- a/src/runtime_pthread.js
+++ b/src/runtime_pthread.js
@@ -27,7 +27,7 @@ if (ENVIRONMENT_IS_PTHREAD) {
     // Create as web-worker-like an environment as we can.
 
     var parentPort = worker_threads['parentPort'];
-    parentPort.on('message', (data) => onmessage({ data: data }));
+    parentPort.on('message', (msg) => onmessage({ data: msg }));
 
     Object.assign(globalThis, {
       self: global,

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4981,21 +4981,21 @@ Module["preRun"] = () => {
   # Tests the hello_wasm_worker.c documentation example code.
   @also_with_minimal_runtime
   def test_wasm_worker_hello(self):
-    self.btest('wasm_worker/hello_wasm_worker.c', expected='0', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/hello_wasm_worker.c', args=['-sWASM_WORKERS'])
 
   def test_wasm_worker_hello_minimal_runtime_2(self):
-    self.btest('wasm_worker/hello_wasm_worker.c', expected='0', args=['-sWASM_WORKERS', '-sMINIMAL_RUNTIME=2'])
+    self.btest_exit('wasm_worker/hello_wasm_worker.c', args=['-sWASM_WORKERS', '-sMINIMAL_RUNTIME=2'])
 
   # Tests Wasm Workers build in Wasm2JS mode.
   @requires_wasm2js
   @also_with_minimal_runtime
   def test_wasm_worker_hello_wasm2js(self):
-    self.btest('wasm_worker/hello_wasm_worker.c', expected='0', args=['-sWASM_WORKERS', '-sWASM=0'])
+    self.btest_exit('wasm_worker/hello_wasm_worker.c', args=['-sWASM_WORKERS', '-sWASM=0'])
 
   # Tests the WASM_WORKERS=2 build mode, which embeds the Wasm Worker bootstrap JS script file to the main JS file.
   @also_with_minimal_runtime
-  def test_wasm_worker_embedded(self):
-    self.btest('wasm_worker/hello_wasm_worker.c', expected='0', args=['-sWASM_WORKERS=2'])
+  def test_wasm_worker_hello_embedded(self):
+    self.btest_exit('wasm_worker/hello_wasm_worker.c', args=['-sWASM_WORKERS=2'])
 
   # Tests that it is possible to call emscripten_futex_wait() in Wasm Workers.
   @parameterized({
@@ -5059,7 +5059,7 @@ Module["preRun"] = () => {
   # Tests emscripten_terminate_wasm_worker()
   @also_with_minimal_runtime
   def test_wasm_worker_terminate(self):
-    self.btest('wasm_worker/terminate_wasm_worker.c', expected='0', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/terminate_wasm_worker.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_terminate_all_wasm_workers()
   @also_with_minimal_runtime
@@ -5133,7 +5133,7 @@ Module["preRun"] = () => {
   # Tests emscripten_lock_async_acquire() function.
   @also_with_minimal_runtime
   def test_wasm_worker_lock_async_acquire(self):
-    self.btest('wasm_worker/lock_async_acquire.c', expected='0', args=['--closure=1', '-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/lock_async_acquire.c', args=['--closure=1', '-sWASM_WORKERS'])
 
   # Tests emscripten_lock_busyspin_wait_acquire() in Worker and main thread.
   @also_with_minimal_runtime

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13904,6 +13904,12 @@ int main() {
     else:
       self.run_process([EMCC, test_file('hello_world.c'), '-Werror'] + args)
 
+  def test_wasm_worker_hello(self):
+    self.do_runf(test_file('wasm_worker/hello_wasm_worker.c'), emcc_args=['-sWASM_WORKERS'])
+
+  def test_wasm_worker_terminate(self):
+    self.do_runf(test_file('wasm_worker/terminate_wasm_worker.c'), emcc_args=['-sWASM_WORKERS'])
+
   @also_with_minimal_runtime
   def test_wasm_worker_closure(self):
     self.run_process([EMCC, test_file('wasm_worker/lock_async_acquire.c'), '-O2', '-sWASM_WORKERS', '--closure=1'])

--- a/test/wasm_worker/hello_wasm_worker.c
+++ b/test/wasm_worker/hello_wasm_worker.c
@@ -1,20 +1,25 @@
+#include <emscripten/emscripten.h>
 #include <emscripten/console.h>
 #include <emscripten/em_asm.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
 
 // This is the code example in site/source/docs/api_reference/wasm_workers.rst
+void do_exit() {
+  emscripten_out("do_exit");
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
+}
 
 void run_in_worker() {
   emscripten_out("Hello from wasm worker!\n");
   EM_ASM(typeof checkStackCookie == 'function' && checkStackCookie());
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, do_exit);
 }
 
 int main() {
   emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */1024);
   assert(worker);
   emscripten_wasm_worker_post_function_v(worker, run_in_worker);
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/terminate_wasm_worker.c
+++ b/test/wasm_worker/terminate_wasm_worker.c
@@ -1,3 +1,4 @@
+#include <emscripten/emscripten.h>
 #include <emscripten/console.h>
 #include <emscripten/em_asm.h>
 #include <emscripten/em_js.h>
@@ -13,17 +14,13 @@ static volatile int worker_started = 0;
 void this_function_should_not_be_called(void *userData) {
   worker_started = -1;
   emscripten_err("this_function_should_not_be_called");
-#ifdef REPORT_RESULT
-  REPORT_RESULT(1/*fail*/);
-#endif
+  emscripten_force_exit(1);
 }
 
 void test_passed(void *userData) {
   if (worker_started == 1) {
     emscripten_err("test_passed");
-#ifdef REPORT_RESULT
-    REPORT_RESULT(0/*ok*/);
-#endif
+    emscripten_force_exit(0);
   }
 }
 


### PR DESCRIPTION
- Use callUserCallback to invoke callback in _wasmWorkerRunPostMessage.
  Without this calls to exit/emscripten_force_exit within the callback
  don't work as expected (they cause unhandled exception errors).
- Fix `onmessage` handling under node so that the message payload always
  arrives as the `data` member of the message.
- Update a few of the wasm workers tests do they actually exit (required
   for running tests under node).
