### PR TITLE
Move threading helper functions to library_atomic.js. NFC

### DIFF
--- a/src/library_atomic.js
+++ b/src/library_atomic.js
@@ -148,4 +148,12 @@ addToLibrary({
     });
     return numCancelled;
   },
+
+  emscripten_has_threading_support: () => typeof SharedArrayBuffer != 'undefined',
+
+  emscripten_num_logical_cores: () =>
+#if ENVIRONMENT_MAY_BE_NODE
+    ENVIRONMENT_IS_NODE ? require('os').cpus().length :
+#endif
+    navigator['hardwareConcurrency'],
 });

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -647,14 +647,6 @@ var LibraryPThread = {
     return 0;
   },
 
-  emscripten_has_threading_support: () => typeof SharedArrayBuffer != 'undefined',
-
-  emscripten_num_logical_cores: () =>
-#if ENVIRONMENT_MAY_BE_NODE
-    ENVIRONMENT_IS_NODE ? require('os').cpus().length :
-#endif
-    navigator['hardwareConcurrency'],
-
   _emscripten_init_main_thread_js: (tb) => {
     // Pass the thread address to the native code where they stored in wasm
     // globals which act as a form of TLS. Global constructors trying


### PR DESCRIPTION
These utility function are not specifically related pthreads so move them to a file that is included also when SHARED_MEMORY/WASM_WORKERS are used.