### PR TITLE
Fix audio worklet + memory64

### DIFF
--- a/src/audio_worklet.js
+++ b/src/audio_worklet.js
@@ -138,8 +138,7 @@ class BootstrapMessages extends AudioWorkletProcessor {
     // initialize the Wasm Module.
     globalThis.Module['instantiateWasm'] = (info, receiveInstance) => {
       var instance = new WebAssembly.Instance(Module['wasm'], info);
-      receiveInstance(instance, Module['wasm']);
-      return instance.exports;
+      return receiveInstance(instance, Module['wasm']);
     };
 #endif
 #if WEBAUDIO_DEBUG
@@ -184,7 +183,12 @@ class BootstrapMessages extends AudioWorkletProcessor {
         // 'ud' the passed user data
         p.postMessage({'_wsc': d['cb'], 'x': [d['ch'], 1/*EM_TRUE*/, d['ud']] });
       } else if (d['_wsc']) {
-        Module['wasmTable'].get(d['_wsc'])(...d['x']);
+#if MEMORY64
+        var ptr = BigInt(d['_wsc']);
+#else
+        var ptr = d['_wsc'];
+#endif
+        Module['wasmTable'].get(ptr)(...d['x']);
       };
     }
   }

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -1130,6 +1130,6 @@ function applySignatureConversions(wasmExports) {
   for f in wrap_functions:
     sig = mapping[f]
     wrappers += f"\n  wasmExports['{f}'] = makeWrapper_{sig}(wasmExports['{f}']);"
-  wrappers += 'return wasmExports;\n}'
+  wrappers += '\n  return wasmExports;\n}'
 
   return wrappers


### PR DESCRIPTION
There are a two different fixes here, neither of which are needed except in the nightly version of chrome.

1. In the `instantiateWasm` override used in audio worklets return the result of `receiveInstance` rather then directly returning the wasm exports.  This means that the resulting object has the needed wrappers applied.  This was causing an exception even on older version of chrome, but the tests still passed regardless.  With newer versions of chrome the exception seems to cause the worklet creation to fail.  (see #18711)
2. Using BigInt when indexing the wasm table.  I would have prefered to use `toIndexType` here but that doesn't work in `audio_worklet.js`.