### PR TITLE
Use execvp rather then execv in exec_process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -787,7 +787,7 @@ jobs:
       EMTEST_SKIP_NODE_CANARY: "1"
       EMTEST_SKIP_WASM64: "1"
     steps:
-      - run: apt-get install -q -y ninja-build scons
+      - run: apt-get install -q -y ninja-build scons ccache
       - run-tests-linux:
           # some native-dependent tests fail because of the lack of native
           # headers on emsdk-bundled clang

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -249,7 +249,7 @@ def exec_process(cmd):
   else:
     sys.stdout.flush()
     sys.stderr.flush()
-    os.execv(cmd[0], cmd)
+    os.execvp(cmd[0], cmd)
 
 
 def run_js_tool(filename, jsargs=[], node_args=[], **kw):  # noqa: mutable default args


### PR DESCRIPTION
When this code was added in #20909 it broke users who were doing `EM_COMPILER_WRAPPER=cache` since it was not using PATH to find the executable (unlike the subprocess module).

Fixes: #22736