### PR TITLE
Fix `__errno_location` under wasm workers. NFC

### DIFF
--- a/system/lib/libc/musl/src/errno/__errno_location.c
+++ b/system/lib/libc/musl/src/errno/__errno_location.c
@@ -1,22 +1,19 @@
 #include <errno.h>
 #include "pthread_impl.h"
 
-#if __EMSCRIPTEN_PTHREADS__
-// for pthreads, use the proper location on the thread info, so each
-// thread has its own errno
-int *__errno_location(void)
-{
-	return &__pthread_self()->errno_val;
-}
-#else
-// for single-threaded mode, avoid linking in pthreads support code
-// just for this
-static int __errno_storage = 0;
+#if __EMSCRIPTEN__
+// For emscripten we use TLS here instead of `__pthread_self`, so that in single
+// threaded builds this gets lowered away to normal global variable.
+static _Thread_local int __errno_storage = 0;
+#endif
 
 int *__errno_location(void)
 {
+#if __EMSCRIPTEN__
 	return &__errno_storage;
-}
+#else
+	return &__pthread_self()->errno_val;
 #endif
+}
 
 weak_alias(__errno_location, ___errno_location);

--- a/test/code_size/hello_wasm_worker_wasm.json
+++ b/test/code_size/hello_wasm_worker_wasm.json
@@ -5,8 +5,8 @@
   "a.js.gz": 455,
   "a.ww.js": 115,
   "a.ww.js.gz": 127,
-  "a.wasm": 1850,
-  "a.wasm.gz": 1050,
-  "total": 3248,
-  "total_gz": 2016
+  "a.wasm": 1894,
+  "a.wasm.gz": 1077,
+  "total": 3292,
+  "total_gz": 2043
 }

--- a/test/wasm_worker/thread_stack.c
+++ b/test/wasm_worker/thread_stack.c
@@ -1,10 +1,12 @@
 #include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <emscripten/stack.h>
+#include <emscripten/console.h>
 #include <stdio.h>
 #include <assert.h>
 #include <stdlib.h>
 
+#define ALIGN(x,y) ((x)+(y)-1 & -(y))
 #define THREAD_STACK_SIZE 2048
 #define NUM_THREADS 2
 void *thread_stack[NUM_THREADS];
@@ -18,7 +20,11 @@ void test_stack(int i) {
     (void*)emscripten_stack_get_end(),
     THREAD_STACK_SIZE);
   assert(emscripten_stack_get_base() == (uintptr_t)thread_stack[i] + THREAD_STACK_SIZE);
-  assert(emscripten_stack_get_end() == (uintptr_t)thread_stack[i]);
+  emscripten_outf("__builtin_wasm_tls_size: %lu", __builtin_wasm_tls_size());
+  // The stack region in wasm workers also incldues TLS, so we need to take
+  // this into account when calulating our expected stack end.
+  size_t expected_stack_end = (uintptr_t)thread_stack[i] + ALIGN(__builtin_wasm_tls_size(), 16);
+  assert(emscripten_stack_get_end() == expected_stack_end);
 
   int ok = __sync_fetch_and_add(&threadsOk, 1);
   emscripten_outf("%d", ok);
@@ -36,7 +42,7 @@ int main() {
   for (int i = 0; i < NUM_THREADS; ++i) {
     thread_stack[i] = memalign(16, THREAD_STACK_SIZE);
     emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(thread_stack[i], THREAD_STACK_SIZE);
-    emscripten_outf("Created thread %d with stack ptr=%p, size=%x", i, thread_stack[i], THREAD_STACK_SIZE);
+    emscripten_outf("Created thread %d with stack ptr=%p, end=%p, size=%x", i, thread_stack[i], thread_stack[i] + THREAD_STACK_SIZE, THREAD_STACK_SIZE);
     emscripten_wasm_worker_post_function_vi(worker, test_stack, i);
   }
 }


### PR DESCRIPTION
Previously the wasm workers build of `__errno_location` was using the
single threaded code path which doesn't use a thead local location.

In addition this change avoids the use of `__EMSCRIPTEN_PTHREADS__` in
`__errno_location.c` which is helpful for unifying the shared memory
libc build.  See #22735.