### PR TITLE
[embind] Fix warning in example. [ci skip]

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -597,6 +597,7 @@ implemented in JavaScript.
 .. code:: cpp
 
     struct Interface {
+        virtual ~Interface() {}
         virtual void invoke(const std::string& str) = 0;
     };
 


### PR DESCRIPTION
Fixes the warning "delete called on 'Interface' that is abstract but has non-virtual destructor"