### PR TITLE
Cleanup wasm worker tests. NFC

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5011,9 +5011,13 @@ Module["preRun"] = () => {
 
   # Tests Wasm Worker thread stack setup
   @also_with_minimal_runtime
-  def test_wasm_worker_thread_stack(self):
-    for mode in (0, 1, 2):
-      self.btest('wasm_worker/thread_stack.c', expected='0', args=['-sWASM_WORKERS', f'-sSTACK_OVERFLOW_CHECK={mode}'])
+  @parameterized({
+    '0': (0,),
+    '1': (1,),
+    '2': (2,),
+  })
+  def test_wasm_worker_thread_stack(self, mode):
+    self.btest('wasm_worker/thread_stack.c', expected='0', args=['-sWASM_WORKERS', f'-sSTACK_OVERFLOW_CHECK={mode}'])
 
   # Tests emscripten_malloc_wasm_worker() and emscripten_current_thread_is_wasm_worker() functions
   @also_with_minimal_runtime

--- a/test/wasm_worker/c11__Thread_local.c
+++ b/test/wasm_worker/c11__Thread_local.c
@@ -5,8 +5,7 @@
 
 _Thread_local int __attribute__((aligned(64))) tls = 1;
 
-void main_thread_func()
-{
+void main_thread_func() {
   assert(!emscripten_current_thread_is_wasm_worker());
   EM_ASM(out($0), tls);
 #ifdef REPORT_RESULT
@@ -14,8 +13,7 @@ void main_thread_func()
 #endif
 }
 
-void worker_main()
-{
+void worker_main() {
   assert(emscripten_current_thread_is_wasm_worker());
   assert(((intptr_t)&tls % 64) == 0);
   assert(tls != 42);
@@ -27,8 +25,7 @@ void worker_main()
 
 char stack[1024];
 
-int main()
-{
+int main() {
   EM_ASM(out($0), tls);
   assert(((intptr_t)&tls % 64) == 0);
   assert(!emscripten_current_thread_is_wasm_worker());

--- a/test/wasm_worker/cancel_all_wait_asyncs.c
+++ b/test/wasm_worker/cancel_all_wait_asyncs.c
@@ -9,23 +9,20 @@ volatile int32_t addr = 1;
 
 bool testSucceeded = 1;
 
-void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
-{
+void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
   emscripten_console_log("asyncWaitFinishedShouldNotBeCalled");
   testSucceeded = 0;
   assert(0); // We should not reach here
 }
 
-void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
-{
+void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
   emscripten_console_log("asyncWaitFinishedShouldBeCalled");
 #ifdef REPORT_RESULT
   REPORT_RESULT(testSucceeded);
 #endif
 }
 
-int main()
-{
+int main() {
   emscripten_console_log("Async waiting on address should give a wait token");
   ATOMICS_WAIT_TOKEN_T ret = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));

--- a/test/wasm_worker/cancel_all_wait_asyncs_at_address.c
+++ b/test/wasm_worker/cancel_all_wait_asyncs_at_address.c
@@ -9,23 +9,20 @@ volatile int32_t addr = 1;
 
 bool testSucceeded = 1;
 
-void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
-{
+void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
   emscripten_console_log("asyncWaitFinishedShouldNotBeCalled");
   testSucceeded = 0;
   assert(0); // We should not reach here
 }
 
-void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
-{
+void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
   emscripten_console_log("asyncWaitFinishedShouldBeCalled");
 #ifdef REPORT_RESULT
   REPORT_RESULT(testSucceeded);
 #endif
 }
 
-int main()
-{
+int main() {
   emscripten_console_log("Async waiting on address should give a wait token");
   ATOMICS_WAIT_TOKEN_T ret = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));

--- a/test/wasm_worker/cancel_wait_async.c
+++ b/test/wasm_worker/cancel_wait_async.c
@@ -9,23 +9,20 @@ volatile int32_t addr = 1;
 
 bool testSucceeded = 1;
 
-void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
-{
+void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
   emscripten_console_log("asyncWaitFinishedShouldNotBeCalled");
   testSucceeded = 0;
   assert(0); // We should not reach here
 }
 
-void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
-{
+void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
   emscripten_console_log("asyncWaitFinishedShouldBeCalled");
 #ifdef REPORT_RESULT
   REPORT_RESULT(testSucceeded);
 #endif
 }
 
-int main()
-{
+int main() {
   emscripten_console_log("Async waiting on address should give a wait token");
   ATOMICS_WAIT_TOKEN_T ret = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));

--- a/test/wasm_worker/gcc___Thread.c
+++ b/test/wasm_worker/gcc___Thread.c
@@ -5,8 +5,7 @@
 
 __thread int tls = 1;
 
-void main_thread_func()
-{
+void main_thread_func() {
   assert(!emscripten_current_thread_is_wasm_worker());
   EM_ASM(out($0), tls);
 #ifdef REPORT_RESULT
@@ -14,8 +13,7 @@ void main_thread_func()
 #endif
 }
 
-void worker_main()
-{
+void worker_main() {
   assert(emscripten_current_thread_is_wasm_worker());
   assert(tls != 42);
   assert(tls != 0);
@@ -26,8 +24,7 @@ void worker_main()
 
 char stack[1024];
 
-int main()
-{
+int main() {
   EM_ASM(out($0), tls);
   assert(!emscripten_current_thread_is_wasm_worker());
   tls = 42;

--- a/test/wasm_worker/hardware_concurrency_is_lock_free.c
+++ b/test/wasm_worker/hardware_concurrency_is_lock_free.c
@@ -4,8 +4,7 @@
 
 // Test emscripten_navigator_hardware_concurrency() and emscripten_atomics_is_lock_free() functions
 
-void test()
-{
+void test() {
   // Assume that test suite does have navigator.hardwareConcurrency.
   assert(emscripten_navigator_hardware_concurrency() >= 2);
   assert(emscripten_atomics_is_lock_free(1));
@@ -17,8 +16,7 @@ void test()
   assert(!emscripten_atomics_is_lock_free(31));
 }
 
-void worker_main()
-{
+void worker_main() {
   test();
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);
@@ -27,8 +25,7 @@ void worker_main()
 
 char stack[1024];
 
-int main()
-{
+int main() {
   test();
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);

--- a/test/wasm_worker/hello_wasm_worker.c
+++ b/test/wasm_worker/hello_wasm_worker.c
@@ -5,16 +5,14 @@
 
 // This is the code example in site/source/docs/api_reference/wasm_workers.rst
 
-void run_in_worker()
-{
+void run_in_worker() {
   emscripten_console_log("Hello from wasm worker!\n");
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);
 #endif
 }
 
-int main()
-{
+int main() {
   emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */1024);
   assert(worker);
   emscripten_wasm_worker_post_function_v(worker, run_in_worker);

--- a/test/wasm_worker/lock_async_acquire.c
+++ b/test/wasm_worker/lock_async_acquire.c
@@ -17,36 +17,32 @@ bool testFinished = false;
 int numTimesMainThreadAcquiredLock = 0;
 int numTimesWasmWorkerAcquiredLock = 0;
 
-void work()
-{
-//  emscripten_console_log("work");
+void work() {
+  // emscripten_console_log("work");
   volatile int x = sharedState0;
   volatile int y = sharedState1;
   assert(x == y+1 || y == x+1);
 
-  if (emscripten_current_thread_is_wasm_worker())
+  if (emscripten_current_thread_is_wasm_worker()) {
     ++numTimesWasmWorkerAcquiredLock;
-  else
+  } else {
     ++numTimesMainThreadAcquiredLock;
-
-  if (x < y)
-  {
-    x = y + 1;
-    if (emscripten_current_thread_is_wasm_worker())
-      emscripten_wasm_worker_sleep(/*nsecs=*/(rand()%100000));
-    sharedState0 = x;
   }
-  else
-  {
+
+  if (x < y) {
+    x = y + 1;
+    if (emscripten_current_thread_is_wasm_worker()) {
+      emscripten_wasm_worker_sleep(/*nsecs=*/(rand()%100000));
+    }
+    sharedState0 = x;
+  } else {
     y = x + 1;
     if (emscripten_current_thread_is_wasm_worker())
       emscripten_wasm_worker_sleep(/*nsecs=*/(rand()%100000));
     sharedState1 = y;
 
-    if (y > 100 && numTimesMainThreadAcquiredLock && numTimesWasmWorkerAcquiredLock)
-    {
-      if (!testFinished)
-      {
+    if (y > 100 && numTimesMainThreadAcquiredLock && numTimesWasmWorkerAcquiredLock) {
+      if (!testFinished) {
         emscripten_console_log("test finished");
 #ifdef REPORT_RESULT
         REPORT_RESULT(0);
@@ -59,9 +55,8 @@ void work()
 
 void schedule_work(void *userData);
 
-void lock_async_acquired(volatile void *addr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData)
-{
-//  emscripten_console_log("async lock acquired");
+void lock_async_acquired(volatile void *addr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
+  // emscripten_console_log("async lock acquired");
   assert(addr == &lock);
   assert(val == 0 || val == 1);
   assert(waitResult == ATOMICS_WAIT_OK);
@@ -69,23 +64,20 @@ void lock_async_acquired(volatile void *addr, uint32_t val, ATOMICS_WAIT_RESULT_
   work();
   emscripten_lock_release(&lock);
 
-  if (!testFinished)
+  if (!testFinished) {
     emscripten_set_timeout(schedule_work, 10, 0);
+  }
 }
 
-void schedule_work(void *userData)
-{
-  if (emscripten_current_thread_is_wasm_worker() && emscripten_random() > 0.5)
-  {
+void schedule_work(void *userData) {
+  if (emscripten_current_thread_is_wasm_worker() && emscripten_random() > 0.5) {
     emscripten_lock_waitinf_acquire(&lock);
-//    emscripten_console_log("sync lock acquired");
+    // emscripten_console_log("sync lock acquired");
     work();
     emscripten_lock_release(&lock);
     if (!testFinished)
       emscripten_set_timeout(schedule_work, 0, 0);
-  }
-  else
-  {
+  } else {
     emscripten_lock_async_acquire(&lock, lock_async_acquired, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   }
 }
@@ -94,11 +86,9 @@ void start_worker(int arg) {
   schedule_work(0);
 }
 
-int main()
-{
+int main() {
 #define NUM_THREADS 10
-  for(int i = 0; i < NUM_THREADS; ++i)
-  {
+  for (int i = 0; i < NUM_THREADS; ++i) {
     emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
     emscripten_wasm_worker_post_function_vi(worker, start_worker, 0);
   }

--- a/test/wasm_worker/lock_busyspin_wait_acquire.c
+++ b/test/wasm_worker/lock_busyspin_wait_acquire.c
@@ -8,31 +8,37 @@
 
 emscripten_lock_t lock = EMSCRIPTEN_LOCK_T_STATIC_INITIALIZER;
 
-void test()
-{
-  bool success = emscripten_lock_busyspin_wait_acquire(&lock, 0); // Expect no contention on free lock.
+void test() {
+  // Expect no contention on free lock.
+  bool success = emscripten_lock_busyspin_wait_acquire(&lock, 0);
   assert(success == true);
 
   double t0 = emscripten_performance_now();
-  success = emscripten_lock_busyspin_wait_acquire(&lock, 0); // We already have the lock, and emscripten_lock is not recursive, so this should fail.
+  // We already have the lock, and emscripten_lock is not recursive, so this
+  // should fail.
+  success = emscripten_lock_busyspin_wait_acquire(&lock, 0);
   double t1 = emscripten_performance_now();
   assert(!success);
-  assert(t1 - t0 < 25); // Shouldn't have taken too much time to try the lock.
+  // Shouldn't have taken too much time to try the lock.
+  assert(t1 - t0 < 25);
 
   success = emscripten_lock_try_acquire(&lock);
   assert(!success); // We already have the lock.
 
   t0 = emscripten_performance_now();
-  success = emscripten_lock_busyspin_wait_acquire(&lock, 1000.0); // We already have the lock, and emscripten_lock is not recursive, so this should fail.
+  // We already have the lock, and emscripten_lock is not recursive, so this
+  // should fail.
+  success = emscripten_lock_busyspin_wait_acquire(&lock, 1000.0);
   t1 = emscripten_performance_now();
   assert(!success);
-  assert(t1 - t0 >= 900); // We should have waited for the requested duration for the lock.. apply some slack since timing can have some noise.
+  // We should have waited for the requested duration for the lock.. apply some
+  // slack since timing can have some noise.
+  assert(t1 - t0 >= 900);
 
   emscripten_lock_release(&lock);
 }
 
-void worker_main()
-{
+void worker_main() {
   test();
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);
@@ -41,8 +47,7 @@ void worker_main()
 
 char stack[1024];
 
-int main()
-{
+int main() {
   test();
 
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));

--- a/test/wasm_worker/lock_busyspin_waitinf_acquire.c
+++ b/test/wasm_worker/lock_busyspin_waitinf_acquire.c
@@ -10,8 +10,7 @@ emscripten_lock_t lock = EMSCRIPTEN_LOCK_T_STATIC_INITIALIZER;
 
 volatile int sharedState = 0;
 
-void worker_main()
-{
+void worker_main() {
   emscripten_lock_busyspin_waitinf_acquire(&lock);
   emscripten_atomic_add_u32((void*)&sharedState, 1);
 #ifdef REPORT_RESULT
@@ -21,14 +20,12 @@ void worker_main()
 
 char stack[1024];
 
-void releaseLock(void *userData)
-{
+void releaseLock(void *userData) {
   emscripten_atomic_sub_u32((void*)&sharedState, 1);
   emscripten_lock_release(&lock);
 }
 
-int main()
-{
+int main() {
   // Acquire the lock at startup.
   emscripten_lock_busyspin_waitinf_acquire(&lock);
   emscripten_atomic_add_u32((void*)&sharedState, 1);

--- a/test/wasm_worker/lock_wait_acquire.c
+++ b/test/wasm_worker/lock_wait_acquire.c
@@ -8,25 +8,32 @@
 
 emscripten_lock_t lock = EMSCRIPTEN_LOCK_T_STATIC_INITIALIZER;
 
-void worker_main()
-{
-  bool success = emscripten_lock_wait_acquire(&lock, 0); // Expect no contention on free lock.
+void worker_main() {
+  // Expect no contention on free lock.
+  bool success = emscripten_lock_wait_acquire(&lock, 0);
   assert(success == true);
 
   double t0 = emscripten_performance_now();
-  success = emscripten_lock_wait_acquire(&lock, 0); // We already have the lock, and emscripten_lock is not recursive, so this should fail.
+  // We already have the lock, and emscripten_lock is not recursive, so this
+  // should fail.
+  success = emscripten_lock_wait_acquire(&lock, 0);
   double t1 = emscripten_performance_now();
   assert(!success);
-  assert(t1 - t0 < 25); // Shouldn't have taken too much time to try the lock.
+  // Shouldn't have taken too much time to try the lock.
+  assert(t1 - t0 < 25);
 
   success = emscripten_lock_try_acquire(&lock);
-  assert(!success); // We already have the lock.
+  // We already have the lock.
+  assert(!success);
 
   t0 = emscripten_performance_now();
-  success = emscripten_lock_wait_acquire(&lock, 1000 * 1000000ull); // We already have the lock, and emscripten_lock is not recursive, so this should fail.
+  // We already have the lock, and emscripten_lock is not recursive, so this
+  // should fail.
+  success = emscripten_lock_wait_acquire(&lock, 1000 * 1000000ull);
   t1 = emscripten_performance_now();
   assert(!success);
-  assert(t1 - t0 >= 1000); // We should have waited for the requested duration for the lock.
+  // We should have waited for the requested duration for the lock.
+  assert(t1 - t0 >= 1000);
 
   emscripten_lock_release(&lock);
 
@@ -40,8 +47,7 @@ void worker_main()
 
 char stack[1024];
 
-int main()
-{
+int main() {
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/test/wasm_worker/lock_wait_acquire2.c
+++ b/test/wasm_worker/lock_wait_acquire2.c
@@ -8,8 +8,7 @@
 
 emscripten_lock_t lock = EMSCRIPTEN_LOCK_T_STATIC_INITIALIZER;
 
-void worker1_main()
-{
+void worker1_main() {
   emscripten_console_log("worker1 main try_acquiring lock");
   bool success = emscripten_lock_try_acquire(&lock); // Expect no contention on free lock.
   emscripten_console_log("worker1 try_acquire lock finished");
@@ -22,8 +21,7 @@ void worker1_main()
   emscripten_console_log("worker1 released lock");
 }
 
-void worker2_main()
-{
+void worker2_main() {
   emscripten_console_log("worker2 main sleeping 500 msecs");
   emscripten_wasm_worker_sleep(500 * 1000000ull);
   emscripten_console_log("worker2 slept 500 msecs, try_acquiring lock");
@@ -44,8 +42,7 @@ void worker2_main()
 char stack1[1024];
 char stack2[1024];
 
-int main()
-{
+int main() {
   emscripten_wasm_worker_t worker1 = emscripten_create_wasm_worker(stack1, sizeof(stack1));
   emscripten_wasm_worker_t worker2 = emscripten_create_wasm_worker(stack2, sizeof(stack2));
   emscripten_wasm_worker_post_function_v(worker1, worker1_main);

--- a/test/wasm_worker/malloc_wasm_worker.c
+++ b/test/wasm_worker/malloc_wasm_worker.c
@@ -5,8 +5,7 @@
 
 // Test emscripten_malloc_wasm_worker() and emscripten_current_thread_is_wasm_worker() functions
 
-void worker_main()
-{
+void worker_main() {
   emscripten_out("Hello from wasm worker!");
   assert(emscripten_current_thread_is_wasm_worker());
 #ifdef REPORT_RESULT
@@ -14,10 +13,9 @@ void worker_main()
 #endif
 }
 
-int main()
-{
-	assert(!emscripten_current_thread_is_wasm_worker());
-	emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */1024);
-	assert(worker);
-	emscripten_wasm_worker_post_function_v(worker, worker_main);
+int main() {
+  assert(!emscripten_current_thread_is_wasm_worker());
+  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */1024);
+  assert(worker);
+  emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/test/wasm_worker/no_proxied_js_functions.c
+++ b/test/wasm_worker/no_proxied_js_functions.c
@@ -6,8 +6,7 @@
 
 void proxied_js_function(void);
 
-int should_throw(void(*func)())
-{
+int should_throw(void(*func)()) {
   int threw = EM_ASM_INT({
     // Patch over assert() so that it does not abort execution on assert failure, but instead
     // throws a catchable exception.
@@ -29,13 +28,11 @@ int should_throw(void(*func)())
   return threw;
 }
 
-void test()
-{
+void test() {
   proxied_js_function();
 }
 
-void worker_main()
-{
+void worker_main() {
   assert(should_throw(test));
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);
@@ -44,8 +41,7 @@ void worker_main()
 
 char stack[1024];
 
-int main()
-{
+int main() {
   proxied_js_function();
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);

--- a/test/wasm_worker/post_function.c
+++ b/test/wasm_worker/post_function.c
@@ -7,29 +7,25 @@
 
 volatile int success = 0;
 
-void v()
-{
+void v() {
   emscripten_console_log("v");
   ++success;
 }
 
-void vi(int i)
-{
+void vi(int i) {
   emscripten_console_log("vi");
   assert(i == 1);
   ++success;
 }
 
-void vii(int i, int j)
-{
+void vii(int i, int j) {
   emscripten_console_log("vii");
   assert(i == 2);
   assert(j == 3);
   ++success;
 }
 
-void viii(int i, int j, int k)
-{
+void viii(int i, int j, int k) {
   emscripten_console_log("viii");
   assert(i == 4);
   assert(j == 5);
@@ -37,23 +33,20 @@ void viii(int i, int j, int k)
   ++success;
 }
 
-void vd(double i)
-{
+void vd(double i) {
   emscripten_console_log("vd");
   assert(i == 1.5);
   ++success;
 }
 
-void vdd(double i, double j)
-{
+void vdd(double i, double j) {
   emscripten_console_log("vdd");
   assert(i == 2.5);
   assert(j == 3.5);
   ++success;
 }
 
-void vddd(double i, double j, double k)
-{
+void vddd(double i, double j, double k) {
   emscripten_console_log("vddd");
   assert(i == 4.5);
   assert(j == 5.5);
@@ -61,8 +54,7 @@ void vddd(double i, double j, double k)
   ++success;
 }
 
-void viiiiiidddddd(int a, int b, int c, int d, int e, int f, double g, double h, double i, double j, double k, double l)
-{
+void viiiiiidddddd(int a, int b, int c, int d, int e, int f, double g, double h, double i, double j, double k, double l) {
   emscripten_console_log("viiiiiidddddd");
   assert(a == 10);
   assert(b == 11);
@@ -79,8 +71,7 @@ void viiiiiidddddd(int a, int b, int c, int d, int e, int f, double g, double h,
   ++success;
 }
 
-void test_finished()
-{
+void test_finished() {
 #ifdef REPORT_RESULT
   REPORT_RESULT(success);
 #endif
@@ -88,8 +79,7 @@ void test_finished()
 
 char stack[1024];
 
-int main()
-{
+int main() {
   assert(!emscripten_current_thread_is_wasm_worker());
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, v);

--- a/test/wasm_worker/post_function_to_main_thread.c
+++ b/test/wasm_worker/post_function_to_main_thread.c
@@ -6,8 +6,7 @@
 // Test emscripten_wasm_worker_post_function_*() API and EMSCRIPTEN_WASM_WORKER_ID_PARENT
 // to send a message back from Worker to its parent thread.
 
-void test_success(int i, double d)
-{
+void test_success(int i, double d) {
   emscripten_console_log("test_success");
   assert(!emscripten_current_thread_is_wasm_worker());
   assert(i == 10);
@@ -17,8 +16,7 @@ void test_success(int i, double d)
 #endif
 }
 
-void worker_main()
-{
+void worker_main() {
   emscripten_console_log("worker_main");
   assert(emscripten_current_thread_is_wasm_worker());
   emscripten_wasm_worker_post_function_sig(EMSCRIPTEN_WASM_WORKER_ID_PARENT, test_success, "id", 10, 0.5);
@@ -26,8 +24,7 @@ void worker_main()
 
 char stack[1024];
 
-int main()
-{
+int main() {
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/test/wasm_worker/proxied_function.c
+++ b/test/wasm_worker/proxied_function.c
@@ -6,13 +6,11 @@
 
 void proxied_js_function(void);
 
-void test_finished()
-{
+void test_finished() {
   REPORT_RESULT(0);
 }
 
-void run_in_worker()
-{
+void run_in_worker() {
   int threw = EM_ASM_INT({
     try {
       _proxied_js_function();
@@ -28,8 +26,9 @@ void run_in_worker()
   }
 }
 
-int main()
-{
+int main() {
   emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(1024), run_in_worker);
-  proxied_js_function(); // Pin a dependency from C code to the JS function to avoid needing to mess with cmdline export directives
+  // Pin a dependency from C code to the JS function to avoid needing to mess
+  // with cmdline export directives
+  proxied_js_function();
 }

--- a/test/wasm_worker/semaphore_try_acquire.c
+++ b/test/wasm_worker/semaphore_try_acquire.c
@@ -9,8 +9,7 @@
 emscripten_semaphore_t unavailable = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(0);
 emscripten_semaphore_t available = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(1);
 
-int main()
-{
+int main() {
   emscripten_console_log("try_acquiring unavailable semaphore should fail");
   int idx = emscripten_semaphore_try_acquire(&unavailable, 1);
   assert(idx == -1);

--- a/test/wasm_worker/semaphore_waitinf_acquire.c
+++ b/test/wasm_worker/semaphore_waitinf_acquire.c
@@ -12,8 +12,7 @@ emscripten_semaphore_t threadsCompleted = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALI
 
 int threadCounter = 0;
 
-void worker_main()
-{
+void worker_main() {
   emscripten_console_log("worker_main");
 
   // Increment semaphore to mark that this thread is waiting for a signal from control thread to start.
@@ -32,8 +31,7 @@ void worker_main()
   emscripten_semaphore_release(&threadsCompleted, 1);
 }
 
-void control_thread()
-{
+void control_thread() {
   // Wait until we have three threads available to start running.
   emscripten_console_log("control_thread: waiting for three threads to complete loading");
   emscripten_semaphore_waitinf_acquire(&threadsWaiting, 3);
@@ -69,16 +67,14 @@ void control_thread()
 #endif
 }
 
-int main()
-{
+int main() {
   emscripten_semaphore_init(&threadsWaiting, 0);
 
   emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
   emscripten_wasm_worker_post_function_v(worker, control_thread);
 
 #define NUM_THREADS 6
-  for(int i = 0; i < NUM_THREADS; ++i)
-  {
+  for (int i = 0; i < NUM_THREADS; ++i) {
     emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
     emscripten_wasm_worker_post_function_v(worker, worker_main);
   }

--- a/test/wasm_worker/terminate_all_wasm_workers.c
+++ b/test/wasm_worker/terminate_all_wasm_workers.c
@@ -9,8 +9,7 @@
 
 static volatile int worker_started = 0;
 
-void this_function_should_not_be_called(void *userData)
-{
+void this_function_should_not_be_called(void *userData) {
   worker_started = -1;
   emscripten_err("this_function_should_not_be_called");
 #ifdef REPORT_RESULT
@@ -18,10 +17,8 @@ void this_function_should_not_be_called(void *userData)
 #endif
 }
 
-void test_passed(void *userData)
-{
-  if (worker_started == 2)
-  {
+void test_passed(void *userData) {
+  if (worker_started == 2) {
     emscripten_err("test_passed");
 #ifdef REPORT_RESULT
     REPORT_RESULT(0/*ok*/);
@@ -29,8 +26,7 @@ void test_passed(void *userData)
   }
 }
 
-void worker_main()
-{
+void worker_main() {
   ++worker_started;
   emscripten_err("Hello from wasm worker!");
   // Schedule a function to be called, that should never happen, since the Worker
@@ -41,8 +37,7 @@ void worker_main()
 char stack1[1024];
 char stack2[1024];
 
-int should_throw(void(*func)(emscripten_wasm_worker_t worker), emscripten_wasm_worker_t worker)
-{
+int should_throw(void(*func)(emscripten_wasm_worker_t worker), emscripten_wasm_worker_t worker) {
   int threw = EM_ASM_INT({
     try {
       dynCall('vi', $0, $1);
@@ -58,21 +53,18 @@ int should_throw(void(*func)(emscripten_wasm_worker_t worker), emscripten_wasm_w
 
 emscripten_wasm_worker_t worker[2];
 
-void post_bad_function(emscripten_wasm_worker_t worker)
-{
+void post_bad_function(emscripten_wasm_worker_t worker) {
   // Try to post a function to the worker, this should throw
   emscripten_wasm_worker_post_function_vi(worker, (void(*)(int))this_function_should_not_be_called, 0);
 }
 
-void terminate_worker(void *userData)
-{
+void terminate_worker(void *userData) {
   emscripten_terminate_all_wasm_workers();
   assert(should_throw(post_bad_function, worker[0]));
   assert(should_throw(post_bad_function, worker[1]));
 }
 
-int main()
-{
+int main() {
   worker[0] = emscripten_create_wasm_worker(stack1, sizeof(stack1));
   worker[1] = emscripten_create_wasm_worker(stack2, sizeof(stack2));
   emscripten_wasm_worker_post_function_v(worker[0], worker_main);

--- a/test/wasm_worker/terminate_wasm_worker.c
+++ b/test/wasm_worker/terminate_wasm_worker.c
@@ -9,8 +9,7 @@
 
 static volatile int worker_started = 0;
 
-void this_function_should_not_be_called(void *userData)
-{
+void this_function_should_not_be_called(void *userData) {
   worker_started = -1;
   emscripten_console_error("this_function_should_not_be_called");
 #ifdef REPORT_RESULT
@@ -18,10 +17,8 @@ void this_function_should_not_be_called(void *userData)
 #endif
 }
 
-void test_passed(void *userData)
-{
-  if (worker_started == 1)
-  {
+void test_passed(void *userData) {
+  if (worker_started == 1) {
     emscripten_console_error("test_passed");
 #ifdef REPORT_RESULT
     REPORT_RESULT(0/*ok*/);
@@ -29,8 +26,7 @@ void test_passed(void *userData)
   }
 }
 
-void worker_main()
-{
+void worker_main() {
   worker_started = 1;
   emscripten_console_error("Hello from wasm worker!");
   // Schedule a function to be called, that should never happen, since the Worker
@@ -40,8 +36,7 @@ void worker_main()
 
 char stack[1024];
 
-int should_throw(void(*func)())
-{
+int should_throw(void(*func)()) {
   int threw = EM_ASM_INT({
     try {
       dynCall('v', Number($0));
@@ -57,20 +52,17 @@ int should_throw(void(*func)())
 
 emscripten_wasm_worker_t worker = 0;
 
-void post_bad_function()
-{
+void post_bad_function() {
   // Try to post a function to the worker, this should throw
   emscripten_wasm_worker_post_function_vi(worker, (void(*)(int))this_function_should_not_be_called, 0);
 }
 
-void terminate_worker(void *userData)
-{
+void terminate_worker(void *userData) {
   emscripten_terminate_wasm_worker(worker);
   assert(should_throw(post_bad_function));
 }
 
-int main()
-{
+int main() {
   worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 

--- a/test/wasm_worker/thread_stack.c
+++ b/test/wasm_worker/thread_stack.c
@@ -1,43 +1,42 @@
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <emscripten/stack.h>
 #include <stdio.h>
 #include <assert.h>
 #include <stdlib.h>
 
-#define THREAD_STACK_SIZE 1024
+#define THREAD_STACK_SIZE 2048
 #define NUM_THREADS 2
 void *thread_stack[NUM_THREADS];
 
 volatile int threadsOk = 0;
 
-void test_stack(int i)
-{
-  EM_ASM(out(`In thread ${$0}, stack low addr=0x${$1.toString(16)}, emscripten_stack_get_base()=0x${$2.toString(16)}, emscripten_stack_get_end()=0x${$3.toString(16)}, THREAD_STACK_SIZE=0x${$4.toString(16)}`),
-    i, thread_stack[i], emscripten_stack_get_base(), emscripten_stack_get_end(), THREAD_STACK_SIZE);
+void test_stack(int i) {
+  emscripten_outf("In thread %d, stack low addr=%p, emscripten_stack_get_base()=%p, emscripten_stack_get_end()=%p, THREAD_STACK_SIZE=%d",
+    i, thread_stack[i],
+    (void*)emscripten_stack_get_base(),
+    (void*)emscripten_stack_get_end(),
+    THREAD_STACK_SIZE);
   assert(emscripten_stack_get_base() == (uintptr_t)thread_stack[i] + THREAD_STACK_SIZE);
   assert(emscripten_stack_get_end() == (uintptr_t)thread_stack[i]);
 
   int ok = __sync_fetch_and_add(&threadsOk, 1);
-  EM_ASM(out($0), ok);
-  if (ok == 1)
-  {
-    EM_ASM(out(`Test finished!`));
+  emscripten_outf("%d", ok);
+  if (ok == 1) {
+    emscripten_out("Test finished!");
 #ifdef REPORT_RESULT
     REPORT_RESULT(0);
 #endif
   }
 }
 
-int main()
-{
-  EM_ASM(out(`Main thread stack base=0x${$0.toString(16)}, end=0x${$1.toString(16)}`), emscripten_stack_get_base(), emscripten_stack_get_end());
+int main() {
+  emscripten_outf("Main thread stack base=%p, end=%p", (void*)emscripten_stack_get_base(), (void*)emscripten_stack_get_end());
 
-  for(int i = 0; i < NUM_THREADS; ++i)
-  {
+  for (int i = 0; i < NUM_THREADS; ++i) {
     thread_stack[i] = memalign(16, THREAD_STACK_SIZE);
     emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(thread_stack[i], THREAD_STACK_SIZE);
-    EM_ASM(out(`Created thread ${$0} with stack ptr=0x${$1.toString(16)}, size=0x${$2.toString(16)}`), i, thread_stack[i], THREAD_STACK_SIZE);
+    emscripten_outf("Created thread %d with stack ptr=%p, size=%x", i, thread_stack[i], THREAD_STACK_SIZE);
     emscripten_wasm_worker_post_function_vi(worker, test_stack, i);
   }
 }

--- a/test/wasm_worker/wasm_worker_and_pthread.c
+++ b/test/wasm_worker/wasm_worker_and_pthread.c
@@ -15,8 +15,7 @@ EM_JS(int, am_i_wasm_worker, (), {
   return ENVIRONMENT_IS_WASM_WORKER;
 });
 
-void *thread_main(void *arg)
-{
+void *thread_main(void *arg) {
   emscripten_out("hello from pthread!");
   assert(am_i_pthread());
   assert(!am_i_wasm_worker());
@@ -26,8 +25,7 @@ void *thread_main(void *arg)
   return 0;
 }
 
-void worker_main()
-{
+void worker_main() {
   emscripten_out("hello from wasm worker!");
   assert(!am_i_pthread());
   assert(am_i_wasm_worker());
@@ -41,8 +39,7 @@ void worker_main()
 #endif
 }
 
-int main()
-{
+int main() {
   pthread_t thread;
   pthread_create(&thread, NULL, thread_main, NULL);
 

--- a/test/wasm_worker/wasm_worker_code_size.c
+++ b/test/wasm_worker/wasm_worker_code_size.c
@@ -7,12 +7,10 @@ EM_JS(void, hello, (void), {
   console.log("Hello from wasm worker!");
 });
 
-void run_in_worker()
-{
+void run_in_worker() {
   hello();
 }
 
-int main()
-{
+int main() {
   emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(1024), run_in_worker);
 }

--- a/test/wasm_worker/wasm_worker_self_id.c
+++ b/test/wasm_worker/wasm_worker_self_id.c
@@ -8,40 +8,37 @@ emscripten_wasm_worker_t worker2 = 0;
 
 int successes = 0;
 
-void test_success()
-{
+void test_success() {
 #ifdef REPORT_RESULT
-	if (__atomic_add_fetch(&successes, 1, __ATOMIC_SEQ_CST) == 2)
-	{
-  		REPORT_RESULT(0);
-  	}
+  if (__atomic_add_fetch(&successes, 1, __ATOMIC_SEQ_CST) == 2) {
+    REPORT_RESULT(0);
+  }
 #endif
 }
 
-void worker1_main()
-{
+void worker1_main() {
   assert(emscripten_wasm_worker_self_id() != 0);
   assert(emscripten_wasm_worker_self_id() == worker1);
-  if (emscripten_wasm_worker_self_id() == worker1)
-  	test_success();
+  if (emscripten_wasm_worker_self_id() == worker1) {
+    test_success();
+  }
 }
 
-void worker2_main()
-{
+void worker2_main() {
   assert(emscripten_wasm_worker_self_id() != 0);
   assert(emscripten_wasm_worker_self_id() == worker2);
-  if (emscripten_wasm_worker_self_id() == worker2)
-  	test_success();
+  if (emscripten_wasm_worker_self_id() == worker2) {
+    test_success();
+  }
 }
 
 char stack1[1024];
 char stack2[1024];
 
-int main()
-{
-	assert(emscripten_wasm_worker_self_id() == 0);
-	worker1 = emscripten_create_wasm_worker(stack1, sizeof(stack1));
-	worker2 = emscripten_create_wasm_worker(stack2, sizeof(stack2));
-	emscripten_wasm_worker_post_function_v(worker1, worker1_main);
-	emscripten_wasm_worker_post_function_v(worker2, worker2_main);
+int main() {
+  assert(emscripten_wasm_worker_self_id() == 0);
+  worker1 = emscripten_create_wasm_worker(stack1, sizeof(stack1));
+  worker2 = emscripten_create_wasm_worker(stack2, sizeof(stack2));
+  emscripten_wasm_worker_post_function_v(worker1, worker1_main);
+  emscripten_wasm_worker_post_function_v(worker2, worker2_main);
 }

--- a/test/wasm_worker/wasm_worker_sleep.c
+++ b/test/wasm_worker/wasm_worker_sleep.c
@@ -1,20 +1,18 @@
 #include <emscripten/html5.h>
 #include <emscripten/wasm_worker.h>
 
-void worker_main()
-{
-	double t0 = emscripten_performance_now();
-	emscripten_wasm_worker_sleep(/*nsecs=*/1500*1000000);
-	double t1 = emscripten_performance_now();
+void worker_main() {
+  double t0 = emscripten_performance_now();
+  emscripten_wasm_worker_sleep(/*nsecs=*/1500*1000000);
+  double t1 = emscripten_performance_now();
 #ifdef REPORT_RESULT
-  	REPORT_RESULT(t1-t0 >= 1500);
+  REPORT_RESULT(t1-t0 >= 1500);
 #endif
 }
 
 char stack[1024];
 
-int main()
-{
-	emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
-	emscripten_wasm_worker_post_function_v(worker, worker_main);
+int main() {
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
+  emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/test/wasm_worker/wasm_worker_tls_wasm_assembly.c
+++ b/test/wasm_worker/wasm_worker_tls_wasm_assembly.c
@@ -8,33 +8,30 @@ int globalData = 1;
 int get_tls_variable(void);
 void set_tls_variable(int var);
 
-void main_thread_func()
-{
-	assert(!emscripten_current_thread_is_wasm_worker());
-	assert(globalData == 3);
+void main_thread_func() {
+  assert(!emscripten_current_thread_is_wasm_worker());
+  assert(globalData == 3);
 #ifdef REPORT_RESULT
-	REPORT_RESULT(get_tls_variable());
+  REPORT_RESULT(get_tls_variable());
 #endif
 }
 
-void worker_main()
-{
-	assert(emscripten_current_thread_is_wasm_worker());
-	assert(get_tls_variable() == 0);
-	assert(globalData == 2);
-	globalData = 3;
+void worker_main() {
+  assert(emscripten_current_thread_is_wasm_worker());
+  assert(get_tls_variable() == 0);
+  assert(globalData == 2);
+  globalData = 3;
   set_tls_variable(123456); // Try to write garbage data to the memory location.
-	emscripten_wasm_worker_post_function_v(0, main_thread_func);
+  emscripten_wasm_worker_post_function_v(0, main_thread_func);
 }
 
 char stack[1024];
 
-int main()
-{
-	assert(!emscripten_current_thread_is_wasm_worker());
-	assert(globalData == 1);
-	globalData = 2;
-	set_tls_variable(42);
-	emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
-	emscripten_wasm_worker_post_function_v(worker, worker_main);
+int main() {
+  assert(!emscripten_current_thread_is_wasm_worker());
+  assert(globalData == 1);
+  globalData = 2;
+  set_tls_variable(42);
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
+  emscripten_wasm_worker_post_function_v(worker, worker_main);
 }


### PR DESCRIPTION
- Use `emscripten_out` helper instead of EM_ASM(out(...)).
- Remove tabs
- Curly braces on the same line as keyword
- Parameterize one test