### PR TITLE
Fix STACK_OVERFLOW_CHECK + WASM_WORKERS

### DIFF
--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -110,6 +110,12 @@ addToLibrary({
     ___set_stack_limits(_emscripten_stack_get_base(), _emscripten_stack_get_end());
 #endif
 
+#if STACK_OVERFLOW_CHECK
+    // Write the stack cookie last, after we have set up the proper bounds and
+    // current position of the stack.
+    writeStackCookie();
+#endif
+
 #if AUDIO_WORKLET
     // Audio Worklets do not have postMessage()ing capabilities.
     if (typeof AudioWorkletGlobalScope === 'undefined') {

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -162,13 +162,6 @@ function run() {
     return;
   }
 
-#if STACK_OVERFLOW_CHECK
-#if PTHREADS
-  if (!ENVIRONMENT_IS_PTHREAD)
-#endif
-    stackCheckInit();
-#endif
-
 #if WASM_WORKERS
   if (ENVIRONMENT_IS_WASM_WORKER) {
 #if MODULARIZE
@@ -190,6 +183,10 @@ function run() {
     startWorker(Module);
     return;
   }
+#endif
+
+#if STACK_OVERFLOW_CHECK
+  stackCheckInit();
 #endif
 
   if (!calledPrerun) {

--- a/test/wasm_worker/hello_wasm_worker.c
+++ b/test/wasm_worker/hello_wasm_worker.c
@@ -7,6 +7,7 @@
 
 void run_in_worker() {
   emscripten_console_log("Hello from wasm worker!\n");
+  EM_ASM(typeof checkStackCookie == 'function' && checkStackCookie());
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);
 #endif


### PR DESCRIPTION
We we not calling `writeStackCookie()` in the right place which means that `checkStackCookie()` would always fail in wasm workers.

Required for #22721
