### PR TITLE
[embind] Fix closure with assertions enabled.

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -266,7 +266,7 @@ var LibraryEmbind = {
   $registerType__docs: '/** @param {Object=} options */',
   $registerType: function(rawType, registeredInstance, options = {}) {
 #if ASSERTIONS
-    if (!('argPackAdvance' in registeredInstance)) {
+    if (registeredInstance.argPackAdvance === undefined) {
       throw new TypeError('registerType registeredInstance requires argPackAdvance');
     }
 #endif

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3243,7 +3243,7 @@ More info: https://emscripten.org
     'o1': ['-O1'],
     'o2': ['-O2'],
     'o2_mem_growth': ['-O2', '-sALLOW_MEMORY_GROWTH', test_file('embind/isMemoryGrowthEnabled=true.cpp')],
-    'o2_closure': ['-O2', '--closure=1', '--closure-args', '--externs ' + shlex.quote(test_file('embind/underscore-externs.js'))],
+    'o2_closure': ['-O2', '--closure=1', '--closure-args', '--externs ' + shlex.quote(test_file('embind/underscore-externs.js')), '-sASSERTIONS=1'],
     'strict_js': ['-sSTRICT_JS']
   })
   def test_embind(self, *extra_args):


### PR DESCRIPTION
`argPackAdvance` was being minified so the check for the property was not working when assertions were enabled with closure.

Fixes #22759