### PR TITLE
Use emscripten_out/err in wasm worker tests. NFC

### DIFF
--- a/test/wasm_worker/c11__Thread_local.c
+++ b/test/wasm_worker/c11__Thread_local.c
@@ -1,4 +1,4 @@
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
 #include <threads.h>
@@ -7,7 +7,7 @@ _Thread_local int __attribute__((aligned(64))) tls = 1;
 
 void main_thread_func() {
   assert(!emscripten_current_thread_is_wasm_worker());
-  EM_ASM(out($0), tls);
+  emscripten_outf("%d", tls);
 #ifdef REPORT_RESULT
   REPORT_RESULT(tls);
 #endif
@@ -26,7 +26,7 @@ void worker_main() {
 char stack[1024];
 
 int main() {
-  EM_ASM(out($0), tls);
+  emscripten_outf("%d", tls);
   assert(((intptr_t)&tls % 64) == 0);
   assert(!emscripten_current_thread_is_wasm_worker());
   tls = 42;

--- a/test/wasm_worker/cancel_all_wait_asyncs.c
+++ b/test/wasm_worker/cancel_all_wait_asyncs.c
@@ -1,4 +1,4 @@
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <emscripten/threading.h>
 #include <assert.h>
@@ -10,64 +10,64 @@ volatile int32_t addr = 1;
 bool testSucceeded = 1;
 
 void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
-  emscripten_console_log("asyncWaitFinishedShouldNotBeCalled");
+  emscripten_out("asyncWaitFinishedShouldNotBeCalled");
   testSucceeded = 0;
   assert(0); // We should not reach here
 }
 
 void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
-  emscripten_console_log("asyncWaitFinishedShouldBeCalled");
+  emscripten_out("asyncWaitFinishedShouldBeCalled");
 #ifdef REPORT_RESULT
   REPORT_RESULT(testSucceeded);
 #endif
 }
 
 int main() {
-  emscripten_console_log("Async waiting on address should give a wait token");
+  emscripten_out("Async waiting on address should give a wait token");
   ATOMICS_WAIT_TOKEN_T ret = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 
-  emscripten_console_log("Async waiting on address should give a wait token");
+  emscripten_out("Async waiting on address should give a wait token");
   ATOMICS_WAIT_TOKEN_T ret2 = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret2));
 
-  emscripten_console_log("Canceling all async waits should return the number of waits cancelled");
+  emscripten_out("Canceling all async waits should return the number of waits cancelled");
   int numCancelled = emscripten_atomic_cancel_all_wait_asyncs();
   assert(numCancelled == 2);
 
-  emscripten_console_log("Canceling an async wait that has already been cancelled should give an invalid param");
+  emscripten_out("Canceling an async wait that has already been cancelled should give an invalid param");
   EMSCRIPTEN_RESULT r = emscripten_atomic_cancel_wait_async(ret);
   assert(r == EMSCRIPTEN_RESULT_INVALID_PARAM);
 
-  emscripten_console_log("Canceling an async wait that has already been cancelled should give an invalid param");
+  emscripten_out("Canceling an async wait that has already been cancelled should give an invalid param");
   r = emscripten_atomic_cancel_wait_async(ret2);
   assert(r == EMSCRIPTEN_RESULT_INVALID_PARAM);
 
-  emscripten_console_log("Notifying an async wait should not trigger the callback function");
+  emscripten_out("Notifying an async wait should not trigger the callback function");
   int64_t numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
-  emscripten_console_log("Notifying an async wait should return 0 threads woken");
+  emscripten_out("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
   addr = 2;
-  emscripten_console_log("Notifying an async wait even after changed value should not trigger the callback function");
+  emscripten_out("Notifying an async wait even after changed value should not trigger the callback function");
   numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
-  emscripten_console_log("Notifying an async wait should return 0 threads woken");
+  emscripten_out("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
-  emscripten_console_log("Async waiting on address should give a wait token");
+  emscripten_out("Async waiting on address should give a wait token");
   ret = emscripten_atomic_wait_async((int32_t*)&addr, 2, asyncWaitFinishedShouldBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 
 #if 0
-  emscripten_console_log("Notifying an async wait without value changing should still trigger the callback");
+  emscripten_out("Notifying an async wait without value changing should still trigger the callback");
   numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
   assert(numWoken == 1);
 #else
   // TODO: Switch to the above test instead after the Atomics.waitAsync() polyfill is dropped.
   addr = 3;
-  emscripten_console_log("Notifying an async wait after value changing should trigger the callback");
+  emscripten_out("Notifying an async wait after value changing should trigger the callback");
   numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 #endif
 }

--- a/test/wasm_worker/cancel_all_wait_asyncs_at_address.c
+++ b/test/wasm_worker/cancel_all_wait_asyncs_at_address.c
@@ -1,4 +1,4 @@
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <emscripten/threading.h>
 #include <assert.h>
@@ -10,68 +10,68 @@ volatile int32_t addr = 1;
 bool testSucceeded = 1;
 
 void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
-  emscripten_console_log("asyncWaitFinishedShouldNotBeCalled");
+  emscripten_out("asyncWaitFinishedShouldNotBeCalled");
   testSucceeded = 0;
   assert(0); // We should not reach here
 }
 
 void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
-  emscripten_console_log("asyncWaitFinishedShouldBeCalled");
+  emscripten_out("asyncWaitFinishedShouldBeCalled");
 #ifdef REPORT_RESULT
   REPORT_RESULT(testSucceeded);
 #endif
 }
 
 int main() {
-  emscripten_console_log("Async waiting on address should give a wait token");
+  emscripten_out("Async waiting on address should give a wait token");
   ATOMICS_WAIT_TOKEN_T ret = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 
-  emscripten_console_log("Async waiting on address should give a wait token");
+  emscripten_out("Async waiting on address should give a wait token");
   ATOMICS_WAIT_TOKEN_T ret2 = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret2));
 
-  emscripten_console_log("Canceling all async waits at wait address should return the number of waits cancelled");
+  emscripten_out("Canceling all async waits at wait address should return the number of waits cancelled");
   int numCancelled = emscripten_atomic_cancel_all_wait_asyncs_at_address((int32_t*)&addr);
   assert(numCancelled == 2);
 
-  emscripten_console_log("Canceling all async waits at some other address should return 0");
+  emscripten_out("Canceling all async waits at some other address should return 0");
   numCancelled = emscripten_atomic_cancel_all_wait_asyncs_at_address((int32_t*)0xbad);
   assert(numCancelled == 0);
 
-  emscripten_console_log("Canceling an async wait that has already been cancelled should give an invalid param");
+  emscripten_out("Canceling an async wait that has already been cancelled should give an invalid param");
   EMSCRIPTEN_RESULT r = emscripten_atomic_cancel_wait_async(ret);
   assert(r == EMSCRIPTEN_RESULT_INVALID_PARAM);
 
-  emscripten_console_log("Canceling an async wait that has already been cancelled should give an invalid param");
+  emscripten_out("Canceling an async wait that has already been cancelled should give an invalid param");
   r = emscripten_atomic_cancel_wait_async(ret2);
   assert(r == EMSCRIPTEN_RESULT_INVALID_PARAM);
 
-  emscripten_console_log("Notifying an async wait should not trigger the callback function");
+  emscripten_out("Notifying an async wait should not trigger the callback function");
   int64_t numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
-  emscripten_console_log("Notifying an async wait should return 0 threads woken");
+  emscripten_out("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
   addr = 2;
-  emscripten_console_log("Notifying an async wait even after changed value should not trigger the callback function");
+  emscripten_out("Notifying an async wait even after changed value should not trigger the callback function");
   numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
-  emscripten_console_log("Notifying an async wait should return 0 threads woken");
+  emscripten_out("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
-  emscripten_console_log("Async waiting on address should give a wait token");
+  emscripten_out("Async waiting on address should give a wait token");
   ret = emscripten_atomic_wait_async((int32_t*)&addr, 2, asyncWaitFinishedShouldBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 
 #if 0
-  emscripten_console_log("Notifying an async wait without value changing should still trigger the callback");
+  emscripten_out("Notifying an async wait without value changing should still trigger the callback");
   numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
   assert(numWoken == 1);
 #else
   // TODO: Switch to the above test instead after the Atomics.waitAsync() polyfill is dropped.
   addr = 3;
-  emscripten_console_log("Notifying an async wait after value changing should trigger the callback");
+  emscripten_out("Notifying an async wait after value changing should trigger the callback");
   numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 #endif
 }

--- a/test/wasm_worker/cancel_wait_async.c
+++ b/test/wasm_worker/cancel_wait_async.c
@@ -1,4 +1,4 @@
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <emscripten/threading.h>
 #include <assert.h>
@@ -10,56 +10,56 @@ volatile int32_t addr = 1;
 bool testSucceeded = 1;
 
 void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
-  emscripten_console_log("asyncWaitFinishedShouldNotBeCalled");
+  emscripten_out("asyncWaitFinishedShouldNotBeCalled");
   testSucceeded = 0;
   assert(0); // We should not reach here
 }
 
 void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
-  emscripten_console_log("asyncWaitFinishedShouldBeCalled");
+  emscripten_out("asyncWaitFinishedShouldBeCalled");
 #ifdef REPORT_RESULT
   REPORT_RESULT(testSucceeded);
 #endif
 }
 
 int main() {
-  emscripten_console_log("Async waiting on address should give a wait token");
+  emscripten_out("Async waiting on address should give a wait token");
   ATOMICS_WAIT_TOKEN_T ret = emscripten_atomic_wait_async((int32_t*)&addr, 1, asyncWaitFinishedShouldNotBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 
-  emscripten_console_log("Canceling an async wait should succeed");
+  emscripten_out("Canceling an async wait should succeed");
   EMSCRIPTEN_RESULT r = emscripten_atomic_cancel_wait_async(ret);
   assert(r == EMSCRIPTEN_RESULT_SUCCESS);
 
-  emscripten_console_log("Canceling an async wait a second time should give invalid param");
+  emscripten_out("Canceling an async wait a second time should give invalid param");
   r = emscripten_atomic_cancel_wait_async(ret);
   assert(r == EMSCRIPTEN_RESULT_INVALID_PARAM);
 
-  emscripten_console_log("Notifying an async wait should not trigger the callback function");
+  emscripten_out("Notifying an async wait should not trigger the callback function");
   int64_t numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
-  emscripten_console_log("Notifying an async wait should return 0 threads woken");
+  emscripten_out("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
   addr = 2;
-  emscripten_console_log("Notifying an async wait even after changed value should not trigger the callback function");
+  emscripten_out("Notifying an async wait even after changed value should not trigger the callback function");
   numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 
-  emscripten_console_log("Notifying an async wait should return 0 threads woken");
+  emscripten_out("Notifying an async wait should return 0 threads woken");
   assert(numWoken == 0);
 
-  emscripten_console_log("Async waiting on address should give a wait token");
+  emscripten_out("Async waiting on address should give a wait token");
   ret = emscripten_atomic_wait_async((int32_t*)&addr, 2, asyncWaitFinishedShouldBeCalled, (void*)42, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
   assert(EMSCRIPTEN_IS_VALID_WAIT_TOKEN(ret));
 
 #if 0
-  emscripten_console_log("Notifying an async wait without value changing should still trigger the callback");
+  emscripten_out("Notifying an async wait without value changing should still trigger the callback");
   numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
   assert(numWoken == 1);
 #else
   // TODO: Switch to the above test instead after the Atomics.waitAsync() polyfill is dropped.
   addr = 3;
-  emscripten_console_log("Notifying an async wait after value changing should trigger the callback");
+  emscripten_out("Notifying an async wait after value changing should trigger the callback");
   numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 #endif
 }

--- a/test/wasm_worker/cpp11_thread_local.cpp
+++ b/test/wasm_worker/cpp11_thread_local.cpp
@@ -1,20 +1,18 @@
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
 
 thread_local int tls = 1;
 
-void main_thread_func()
-{
+void main_thread_func() {
   assert(!emscripten_current_thread_is_wasm_worker());
-  EM_ASM(out($0), tls);
+  emscripten_outf("%d", tls);
 #ifdef REPORT_RESULT
   REPORT_RESULT(tls);
 #endif
 }
 
-void worker_main()
-{
+void worker_main() {
   assert(emscripten_current_thread_is_wasm_worker());
   assert(tls != 42);
   assert(tls != 0);
@@ -25,9 +23,8 @@ void worker_main()
 
 char stack[1024];
 
-int main()
-{
-  EM_ASM(out($0), tls);
+int main() {
+  emscripten_outf("%d", tls);
   assert(!emscripten_current_thread_is_wasm_worker());
   tls = 42;
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));

--- a/test/wasm_worker/gcc___Thread.c
+++ b/test/wasm_worker/gcc___Thread.c
@@ -1,4 +1,4 @@
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
 #include <threads.h>
@@ -7,7 +7,7 @@ __thread int tls = 1;
 
 void main_thread_func() {
   assert(!emscripten_current_thread_is_wasm_worker());
-  EM_ASM(out($0), tls);
+  emscripten_outf("%d", tls);
 #ifdef REPORT_RESULT
   REPORT_RESULT(tls);
 #endif
@@ -25,7 +25,7 @@ void worker_main() {
 char stack[1024];
 
 int main() {
-  EM_ASM(out($0), tls);
+  emscripten_outf("%d", tls);
   assert(!emscripten_current_thread_is_wasm_worker());
   tls = 42;
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));

--- a/test/wasm_worker/hello_wasm_worker.c
+++ b/test/wasm_worker/hello_wasm_worker.c
@@ -1,12 +1,12 @@
-#include <emscripten.h>
 #include <emscripten/console.h>
+#include <emscripten/em_asm.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
 
 // This is the code example in site/source/docs/api_reference/wasm_workers.rst
 
 void run_in_worker() {
-  emscripten_console_log("Hello from wasm worker!\n");
+  emscripten_out("Hello from wasm worker!\n");
   EM_ASM(typeof checkStackCookie == 'function' && checkStackCookie());
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);

--- a/test/wasm_worker/lock_async_acquire.c
+++ b/test/wasm_worker/lock_async_acquire.c
@@ -1,4 +1,4 @@
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <emscripten/threading.h>
 #include <stdlib.h>
@@ -18,7 +18,7 @@ int numTimesMainThreadAcquiredLock = 0;
 int numTimesWasmWorkerAcquiredLock = 0;
 
 void work() {
-  // emscripten_console_log("work");
+  // emscripten_out("work");
   volatile int x = sharedState0;
   volatile int y = sharedState1;
   assert(x == y+1 || y == x+1);
@@ -43,7 +43,7 @@ void work() {
 
     if (y > 100 && numTimesMainThreadAcquiredLock && numTimesWasmWorkerAcquiredLock) {
       if (!testFinished) {
-        emscripten_console_log("test finished");
+        emscripten_out("test finished");
 #ifdef REPORT_RESULT
         REPORT_RESULT(0);
 #endif
@@ -56,7 +56,7 @@ void work() {
 void schedule_work(void *userData);
 
 void lock_async_acquired(volatile void *addr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
-  // emscripten_console_log("async lock acquired");
+  // emscripten_out("async lock acquired");
   assert(addr == &lock);
   assert(val == 0 || val == 1);
   assert(waitResult == ATOMICS_WAIT_OK);
@@ -72,7 +72,7 @@ void lock_async_acquired(volatile void *addr, uint32_t val, ATOMICS_WAIT_RESULT_
 void schedule_work(void *userData) {
   if (emscripten_current_thread_is_wasm_worker() && emscripten_random() > 0.5) {
     emscripten_lock_waitinf_acquire(&lock);
-    // emscripten_console_log("sync lock acquired");
+    // emscripten_out("sync lock acquired");
     work();
     emscripten_lock_release(&lock);
     if (!testFinished)

--- a/test/wasm_worker/lock_wait_acquire2.c
+++ b/test/wasm_worker/lock_wait_acquire2.c
@@ -1,4 +1,4 @@
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <emscripten/threading.h>
 #include <stdlib.h>
@@ -9,29 +9,29 @@
 emscripten_lock_t lock = EMSCRIPTEN_LOCK_T_STATIC_INITIALIZER;
 
 void worker1_main() {
-  emscripten_console_log("worker1 main try_acquiring lock");
+  emscripten_out("worker1 main try_acquiring lock");
   bool success = emscripten_lock_try_acquire(&lock); // Expect no contention on free lock.
-  emscripten_console_log("worker1 try_acquire lock finished");
+  emscripten_out("worker1 try_acquire lock finished");
   assert(success);
-  emscripten_console_log("worker1 try_acquire lock success, sleeping 1000 msecs");
+  emscripten_out("worker1 try_acquire lock success, sleeping 1000 msecs");
   emscripten_wasm_worker_sleep(1000 * 1000000ull);
 
-  emscripten_console_log("worker1 slept 1000 msecs, releasing lock");
+  emscripten_out("worker1 slept 1000 msecs, releasing lock");
   emscripten_lock_release(&lock);
-  emscripten_console_log("worker1 released lock");
+  emscripten_out("worker1 released lock");
 }
 
 void worker2_main() {
-  emscripten_console_log("worker2 main sleeping 500 msecs");
+  emscripten_out("worker2 main sleeping 500 msecs");
   emscripten_wasm_worker_sleep(500 * 1000000ull);
-  emscripten_console_log("worker2 slept 500 msecs, try_acquiring lock");
+  emscripten_out("worker2 slept 500 msecs, try_acquiring lock");
   bool success = emscripten_lock_try_acquire(&lock); // At this time, the other thread should have the lock.
-  emscripten_console_log("worker2 try_acquire lock finished");
+  emscripten_out("worker2 try_acquire lock finished");
   assert(!success);
 
   // Wait enough time to cover over the time that the other thread held the lock.
   success = emscripten_lock_wait_acquire(&lock, 2000 * 1000000ull);
-  emscripten_console_log("worker2 wait_acquired lock");
+  emscripten_out("worker2 wait_acquired lock");
   assert(success);
 
 #ifdef REPORT_RESULT

--- a/test/wasm_worker/lock_waitinf_acquire.c
+++ b/test/wasm_worker/lock_waitinf_acquire.c
@@ -16,7 +16,7 @@ volatile int sharedState1 = 1;
 volatile int numWorkersAlive = 0;
 
 void test_ended() {
-  EM_ASM(out(`Worker ${$0} last thread to finish. Reporting test end with sharedState0=${$1}, sharedState1=${$2}`), emscripten_wasm_worker_self_id(), sharedState0, sharedState1);
+  emscripten_outf("Worker %d last thread to finish. Reporting test end with sharedState0=%d, sharedState1=%d", emscripten_wasm_worker_self_id(), sharedState0, sharedState1);
   assert(sharedState0 == sharedState1 + 1 || sharedState1 == sharedState0 + 1);
 #ifdef REPORT_RESULT
   REPORT_RESULT(sharedState0);
@@ -24,7 +24,7 @@ void test_ended() {
 }
 
 void worker_main() {
-  EM_ASM(out(`Worker ${$0} running...`), emscripten_wasm_worker_self_id());
+  emscripten_outf("Worker %d running...", emscripten_wasm_worker_self_id());
   // Create contention on the lock from each thread, and stress the shared state
   // in a racy way that would show a breakage if the lock is not watertight.
   for (int i = 0; i < 1000; ++i) {
@@ -44,7 +44,7 @@ void worker_main() {
     emscripten_lock_release(&lock);
   }
 
-  EM_ASM(out(`Worker ${$0} finished.`), emscripten_wasm_worker_self_id());
+  emscripten_outf("Worker %d finished.", emscripten_wasm_worker_self_id());
 
   // Are we the last thread to finish? If so, test has ended.
   uint32_t v = emscripten_atomic_sub_u32((void*)&numWorkersAlive, 1);

--- a/test/wasm_worker/post_function.c
+++ b/test/wasm_worker/post_function.c
@@ -1,4 +1,3 @@
-#include <emscripten.h>
 #include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
@@ -8,25 +7,25 @@
 volatile int success = 0;
 
 void v() {
-  emscripten_console_log("v");
+  emscripten_out("v");
   ++success;
 }
 
 void vi(int i) {
-  emscripten_console_log("vi");
+  emscripten_out("vi");
   assert(i == 1);
   ++success;
 }
 
 void vii(int i, int j) {
-  emscripten_console_log("vii");
+  emscripten_out("vii");
   assert(i == 2);
   assert(j == 3);
   ++success;
 }
 
 void viii(int i, int j, int k) {
-  emscripten_console_log("viii");
+  emscripten_out("viii");
   assert(i == 4);
   assert(j == 5);
   assert(k == 6);
@@ -34,20 +33,20 @@ void viii(int i, int j, int k) {
 }
 
 void vd(double i) {
-  emscripten_console_log("vd");
+  emscripten_out("vd");
   assert(i == 1.5);
   ++success;
 }
 
 void vdd(double i, double j) {
-  emscripten_console_log("vdd");
+  emscripten_out("vdd");
   assert(i == 2.5);
   assert(j == 3.5);
   ++success;
 }
 
 void vddd(double i, double j, double k) {
-  emscripten_console_log("vddd");
+  emscripten_out("vddd");
   assert(i == 4.5);
   assert(j == 5.5);
   assert(k == 6.5);
@@ -55,7 +54,7 @@ void vddd(double i, double j, double k) {
 }
 
 void viiiiiidddddd(int a, int b, int c, int d, int e, int f, double g, double h, double i, double j, double k, double l) {
-  emscripten_console_log("viiiiiidddddd");
+  emscripten_out("viiiiiidddddd");
   assert(a == 10);
   assert(b == 11);
   assert(c == 12);

--- a/test/wasm_worker/post_function_to_main_thread.c
+++ b/test/wasm_worker/post_function_to_main_thread.c
@@ -1,4 +1,3 @@
-#include <emscripten.h>
 #include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
@@ -7,7 +6,7 @@
 // to send a message back from Worker to its parent thread.
 
 void test_success(int i, double d) {
-  emscripten_console_log("test_success");
+  emscripten_out("test_success");
   assert(!emscripten_current_thread_is_wasm_worker());
   assert(i == 10);
   assert(d == 0.5);
@@ -17,7 +16,7 @@ void test_success(int i, double d) {
 }
 
 void worker_main() {
-  emscripten_console_log("worker_main");
+  emscripten_out("worker_main");
   assert(emscripten_current_thread_is_wasm_worker());
   emscripten_wasm_worker_post_function_sig(EMSCRIPTEN_WASM_WORKER_ID_PARENT, test_success, "id", 10, 0.5);
 }

--- a/test/wasm_worker/semaphore_try_acquire.c
+++ b/test/wasm_worker/semaphore_try_acquire.c
@@ -1,4 +1,4 @@
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <emscripten/threading.h>
 #include <stdlib.h>
@@ -10,23 +10,23 @@ emscripten_semaphore_t unavailable = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(0
 emscripten_semaphore_t available = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(1);
 
 int main() {
-  emscripten_console_log("try_acquiring unavailable semaphore should fail");
+  emscripten_out("try_acquiring unavailable semaphore should fail");
   int idx = emscripten_semaphore_try_acquire(&unavailable, 1);
   assert(idx == -1);
 
-  emscripten_console_log("try_acquiring too many resources from an available semaphore should fail");
+  emscripten_out("try_acquiring too many resources from an available semaphore should fail");
   idx = emscripten_semaphore_try_acquire(&available, 2);
   assert(idx == -1);
 
-  emscripten_console_log("try_acquiring a resource from an available semaphore should succeed");
+  emscripten_out("try_acquiring a resource from an available semaphore should succeed");
   idx = emscripten_semaphore_try_acquire(&available, 1);
   assert(idx == 0);
 
-  emscripten_console_log("releasing semaphore resources on main thread should succeed");
+  emscripten_out("releasing semaphore resources on main thread should succeed");
   idx = emscripten_semaphore_release(&available, 10);
   assert(idx == 0);
 
-  emscripten_console_log("try_acquiring multiple resources from an available semaphore should succeed");
+  emscripten_out("try_acquiring multiple resources from an available semaphore should succeed");
   idx = emscripten_semaphore_try_acquire(&available, 9);
   assert(idx == 1);
 

--- a/test/wasm_worker/semaphore_waitinf_acquire.c
+++ b/test/wasm_worker/semaphore_waitinf_acquire.c
@@ -1,4 +1,4 @@
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <emscripten/threading.h>
 #include <stdlib.h>
@@ -13,55 +13,55 @@ emscripten_semaphore_t threadsCompleted = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALI
 int threadCounter = 0;
 
 void worker_main() {
-  emscripten_console_log("worker_main");
+  emscripten_out("worker_main");
 
   // Increment semaphore to mark that this thread is waiting for a signal from control thread to start.
   emscripten_semaphore_release(&threadsWaiting, 1);
 
   // Acquire thread run semaphore once main thread has given this thread a go signal.
-  emscripten_console_log("worker_main: waiting for thread run signal");
+  emscripten_out("worker_main: waiting for thread run signal");
   emscripten_semaphore_waitinf_acquire(&threadsRunning, 1);
 
   // Do heavy computation:
-  emscripten_console_log("worker_main: incrementing work");
+  emscripten_out("worker_main: incrementing work");
   emscripten_atomic_add_u32((void*)&threadCounter, 1);
 
   // Increment semaphore to signal that this thread has finished.
-  emscripten_console_log("worker_main: thread completed");
+  emscripten_out("worker_main: thread completed");
   emscripten_semaphore_release(&threadsCompleted, 1);
 }
 
 void control_thread() {
   // Wait until we have three threads available to start running.
-  emscripten_console_log("control_thread: waiting for three threads to complete loading");
+  emscripten_out("control_thread: waiting for three threads to complete loading");
   emscripten_semaphore_waitinf_acquire(&threadsWaiting, 3);
 
   // Set the three waiting threads to run simultaneously.
   assert(threadCounter == 0);
-  emscripten_console_log("control_thread: release three threads to run");
+  emscripten_out("control_thread: release three threads to run");
   emscripten_semaphore_release(&threadsRunning, 3);
 
   // Wait until we have 3 threads completed their run.
-  emscripten_console_log("control_thread: waiting for three threads to complete");
+  emscripten_out("control_thread: waiting for three threads to complete");
   emscripten_semaphore_waitinf_acquire(&threadsCompleted, 3);
   assert(threadCounter == 3);
 
   // Wait until we have next 3 threads available to start running.
-  emscripten_console_log("control_thread: waiting for next three threads to be ready");
+  emscripten_out("control_thread: waiting for next three threads to be ready");
   emscripten_semaphore_waitinf_acquire(&threadsWaiting, 3);
 
   // Set the three waiting threads to run simultaneously.
   assert(threadCounter == 3);
-  emscripten_console_log("control_thread: setting next three threads go");
+  emscripten_out("control_thread: setting next three threads go");
   emscripten_semaphore_release(&threadsRunning, 3);
 
   // Wait until we have the final 3 threads completed their run.
-  emscripten_console_log("control_thread: waiting for the last three threads to finish");
+  emscripten_out("control_thread: waiting for the last three threads to finish");
   emscripten_semaphore_waitinf_acquire(&threadsCompleted, 3);
-  emscripten_console_log("control_thread: threads finished");
+  emscripten_out("control_thread: threads finished");
   assert(threadCounter == 6);
 
-  emscripten_console_log("control_thread: test finished");
+  emscripten_out("control_thread: test finished");
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);
 #endif

--- a/test/wasm_worker/terminate_wasm_worker.c
+++ b/test/wasm_worker/terminate_wasm_worker.c
@@ -1,5 +1,5 @@
-#include <emscripten.h>
 #include <emscripten/console.h>
+#include <emscripten/em_asm.h>
 #include <emscripten/eventloop.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
@@ -11,7 +11,7 @@ static volatile int worker_started = 0;
 
 void this_function_should_not_be_called(void *userData) {
   worker_started = -1;
-  emscripten_console_error("this_function_should_not_be_called");
+  emscripten_err("this_function_should_not_be_called");
 #ifdef REPORT_RESULT
   REPORT_RESULT(1/*fail*/);
 #endif
@@ -19,7 +19,7 @@ void this_function_should_not_be_called(void *userData) {
 
 void test_passed(void *userData) {
   if (worker_started == 1) {
-    emscripten_console_error("test_passed");
+    emscripten_err("test_passed");
 #ifdef REPORT_RESULT
     REPORT_RESULT(0/*ok*/);
 #endif
@@ -28,7 +28,7 @@ void test_passed(void *userData) {
 
 void worker_main() {
   worker_started = 1;
-  emscripten_console_error("Hello from wasm worker!");
+  emscripten_err("Hello from wasm worker!");
   // Schedule a function to be called, that should never happen, since the Worker
   // dies before that.
   emscripten_set_timeout(this_function_should_not_be_called, 2000, 0);


### PR DESCRIPTION
Also replace some EM_ASM that only existed to call `out` or `err`.

For multi-threads tests that run under node its better to use `out` / `err` than `console.log` / `console.error` since the former get redirected to stdout/stderr directly whereas it seem the later requires some sort of messaging with the main thread.