### PR TITLE
Drop explicitly passed -lc unless -nodefaultlibs or similar is passed

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15169,3 +15169,6 @@ addToLibrary({
 
   def test_embool(self):
     self.do_other_test('test_embool.c')
+
+  def test_user_passed_lc(self):
+    self.run_process([EMCC, '-lc', '-sDISABLE_EXCEPTION_CATCHING=0', '-sMIN_SAFARI_VERSION=150000'])


### PR DESCRIPTION
There have been a lot of bugs when the caller passes `-lc` over the years. For example it crashes if we do:
```
emcc -lc -sDISABLE_EXCEPTION_CATCHING=0 -sMIN_SAFARI_VERSION=150000
```

Rust likes to pass `-lc`. Let's drop it and stop causing trouble for Rust.

Resolves #22758, #22742 and would have resolved #16680 if it hadn't disappeared first.