### PR TITLE
[Docs] Mark `-sWASM_EXNREF` as a link-only setting

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1166,8 +1166,6 @@ Emit instructions for the new Wasm exception handling proposal with exnref,
 which was adopted on Oct 2023. The implementation of the new proposal is
 still in progress and this feature is currently experimental.
 
-.. note:: Applicable during both linking and compilation
-
 Default value: false
 
 .. _nodejs_catch_exit:

--- a/src/settings.js
+++ b/src/settings.js
@@ -781,7 +781,7 @@ var EXCEPTION_STACK_TRACES = false;
 // Emit instructions for the new Wasm exception handling proposal with exnref,
 // which was adopted on Oct 2023. The implementation of the new proposal is
 // still in progress and this feature is currently experimental.
-// [compile+link]
+// [link]
 var WASM_EXNREF = false;
 
 // Emscripten throws an ExitStatus exception to unwind when exit() is called.


### PR DESCRIPTION
```
emcc: error: linker setting ignored during compilation: 'WASM_EXNREF' [-Wunused-command-line-argument] [-Werror]
```