### PR TITLE
Allowing all binary C++ operators in WebIDL

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.rst
@@ -318,7 +318,7 @@ You can bind to C++ operators using ``[Operator=]``:
 .. note::
 
   - The operator name can be anything (``add`` is just an example).
-  - Support is currently limited to operators that contain ``=``: ``+=``, ``*=``, ``-=`` etc., and to the array indexing operator ``[]``.
+  - Support is currently limited to the following binary operators: ``+``, ``-``, ``*``, ``/``, ``%``, ``^``, ``&``, ``|``, ``=``, ``<``, ``>``, ``+=``, ``-=``, ``*=``, ``/=``, ``%=``, ``^=``, ``&=``, ``|=``, ``<<``, ``>>``, ``>>=``, ``<<=``, ``==``, ``!=``, ``<=``, ``>=``, ``<=>``, ``&&``, ``||``, and to the array indexing operator ``[]``.
 
 
 enums

--- a/test/webidl/post.js
+++ b/test/webidl/post.js
@@ -144,6 +144,8 @@ console.log(new TheModule.Inner().get());
 console.log('getAsArray: ' + new TheModule.Inner().getAsArray(12));
 new TheModule.Inner().mul(2);
 new TheModule.Inner().incInPlace(new TheModule.Inner());
+console.log('add: ' + new TheModule.Inner(1).add(new TheModule.Inner(2)).get_value());
+console.log('mul2: ' + new TheModule.Inner(10).mul2(5));
 
 console.log(TheModule.enum_value1);
 console.log(TheModule.enum_value2);

--- a/test/webidl/test.h
+++ b/test/webidl/test.h
@@ -95,14 +95,17 @@ struct VoidPointerUser {
 namespace Space {
   struct Inner {
     int value;
-    Inner() : value(1) {}
+    Inner(int x = 1) : value(x) {}
     int get() { return 198; }
+    int get_value() { return value; }
     Inner& operator*=(float x) { return *this; }
     int operator[](int x) { return x*2; }
     void operator+=(const Inner& other) {
       value += other.value;
       printf("Inner::+= => %d\n", value);
     }
+    Inner operator+(const Inner& other) { return Inner(value + other.value); }
+    int operator*(int x) { return value * x; }
   };
 
   // We test compilation of abstract base classes in a namespace here.

--- a/test/webidl/test.idl
+++ b/test/webidl/test.idl
@@ -85,11 +85,14 @@ interface VoidPointerUser {
 
 [Prefix="Space::"]
 interface Inner {
-  void Inner();
+  void Inner(optional long value);
   long get();
+  long get_value();
   [Operator="*=", Ref] Inner mul(float x);
   [Operator="[]"] long getAsArray(long x);
   [Operator="+="] void incInPlace([Const, Ref] Inner i);
+  [Operator="+", Value] Inner add([Const, Ref] Inner i);
+  [Operator="*"] long mul2(long x);
 };
 
 [Prefix = "Space::"]

--- a/test/webidl/test_ALL.out
+++ b/test/webidl/test_ALL.out
@@ -71,6 +71,8 @@ object
 198
 getAsArray: 24
 Inner::+= => 2
+add: 3
+mul2: 50
 0
 1
 34,34

--- a/test/webidl/test_DEFAULT.out
+++ b/test/webidl/test_DEFAULT.out
@@ -71,6 +71,8 @@ object
 198
 getAsArray: 24
 Inner::+= => 2
+add: 3
+mul2: 50
 0
 1
 34,34

--- a/test/webidl/test_FAST.out
+++ b/test/webidl/test_FAST.out
@@ -71,6 +71,8 @@ object
 198
 getAsArray: 24
 Inner::+= => 2
+add: 3
+mul2: 50
 0
 1
 34,34

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -614,7 +614,10 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer,
         # this function comes from an ancestor class; for operators, we must cast it
         cast_self = 'dynamic_cast<' + type_to_c(func_scope) + '>(' + cast_self + ')'
       maybe_deref = deref_if_nonpointer(raw[0])
-      if '=' in operator:
+      operator = operator.strip()
+      if operator in ["+", "-", "*", "/", "%", "^", "&", "|", "=",
+                      "<", ">", "+=", "-=", "*=", "/=", "%=", "^=", "&=", "|=", "<<", ">>", ">>=",
+                      "<<=", "==", "!=", "<=", ">=", "<=>", "&&", "||"]:
         call = '(*%s %s %s%s)' % (cast_self, operator, maybe_deref, args[0])
       elif operator == '[]':
         call = '((*%s)[%s%s])' % (cast_self, maybe_deref, args[0])


### PR DESCRIPTION
This expands the list of supported operators by the 'Operator' WebIDL attribute to all binary operators that are supported by C++.

Fixes #9415