### PR TITLE
Added --thread_safe option to webidl_binder.py

### DIFF
--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -629,7 +629,8 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer,
     if non_pointer:
       return_prefix += '&'
     if copy:
-      pre += '  static %s temp;\n' % type_to_c(return_type, non_pointing=True)
+      # Avoid sharing this static temp var between threads, which could race.
+      pre += '  static thread_local %s temp;\n' % type_to_c(return_type, non_pointing=True)
       return_prefix += '(temp = '
       return_postfix += ', &temp)'
 


### PR DESCRIPTION
This emits all temporaries as 'static thread_local <type> temp;' instead of 'static <type> temp;' and prevents race conditions when you use the resulting library in a multithreaded environment.

E.g. if you create an IDL file like:

```
interface Vec3 {
	[Const, Value] Vec3 Cross([Const, Ref] Vec3 inRHS);
};
```

Previously the generated cpp file would look like:

```C++
const Vec3* EMSCRIPTEN_KEEPALIVE emscripten_bind_Vec3_Cross_1(Vec3* self, const Vec3* inRHS) {
  static Vec3 temp;
  return (temp = self->Cross(*inRHS), &temp);
}
```

Which has a race condition when you call into the `Cross` function from multiple JavaScript threads as they all use the same `temp` variable.

With this new parameter the resulting code will look like:

```C++
const Vec3* EMSCRIPTEN_KEEPALIVE emscripten_bind_Vec3_Cross_1(Vec3* self, const Vec3* inRHS) {
  static thread_local Vec3 temp;
  return (temp = self->Cross(*inRHS), &temp);
}
```

Which guarantees that no other threads overwrite `temp`.