### PR TITLE
Convert all remaining wasm worker tests to btest_exit. NFC

### DIFF
--- a/test/atomic/test_wait64_notify.c
+++ b/test/atomic/test_wait64_notify.c
@@ -47,11 +47,16 @@ void run_test() {
 
 char stack[1024];
 
+void do_exit() {
+  emscripten_out("do_exit");
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
+}
+
 void worker_main() {
   run_test();
-#ifdef REPORT_RESULT
-  REPORT_RESULT(addr >> 32);
-#endif
+  assert(addr == 0x300000000ull);
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, do_exit);
 }
 
 #else
@@ -91,6 +96,7 @@ int main() {
 #ifdef __EMSCRIPTEN_WASM_WORKERS__
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
+  emscripten_runtime_keepalive_push();
 #else
   pthread_create(&t, NULL, thread_main, NULL);
 #endif

--- a/test/atomic/test_wait_async.c
+++ b/test/atomic/test_wait_async.c
@@ -73,12 +73,12 @@ void asyncWaitFinishedShouldBeOk(int32_t* ptr,
   assert(numCalled == 2);
   assert(waitResult == ATOMICS_WAIT_OK);
   emscripten_out("test finished");
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
-#if !defined(__EMSCRIPTEN_WASM_WORKERS__)
+#ifdef __EMSCRIPTEN_WASM_WORKERS__
+  emscripten_terminate_all_wasm_workers();
+#else
   pthread_join(t, NULL);
 #endif
+  emscripten_force_exit(0);
 }
 
 int main() {

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5003,7 +5003,7 @@ Module["preRun"] = () => {
     'pthread': (['-pthread'],),
   })
   def test_wasm_worker_futex_wait(self, args):
-    self.btest('wasm_worker/wasm_worker_futex_wait.c', expected='0', args=['-sWASM_WORKERS=1', '-sASSERTIONS'] + args)
+    self.btest_exit('wasm_worker/wasm_worker_futex_wait.c', args=['-sWASM_WORKERS=1', '-sASSERTIONS'] + args)
 
   # Tests Wasm Worker thread stack setup
   @also_with_minimal_runtime
@@ -5013,48 +5013,48 @@ Module["preRun"] = () => {
     '2': (2,),
   })
   def test_wasm_worker_thread_stack(self, mode):
-    self.btest('wasm_worker/thread_stack.c', expected='0', args=['-sWASM_WORKERS', f'-sSTACK_OVERFLOW_CHECK={mode}'])
+    self.btest_exit('wasm_worker/thread_stack.c', args=['-sWASM_WORKERS', f'-sSTACK_OVERFLOW_CHECK={mode}'])
 
   # Tests emscripten_malloc_wasm_worker() and emscripten_current_thread_is_wasm_worker() functions
   @also_with_minimal_runtime
   def test_wasm_worker_malloc(self):
-    self.btest('wasm_worker/malloc_wasm_worker.c', expected='0', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/malloc_wasm_worker.c', args=['-sWASM_WORKERS'])
 
   # Tests Wasm Worker+pthreads simultaneously
   @also_with_minimal_runtime
   def test_wasm_worker_and_pthreads(self):
-    self.btest('wasm_worker/wasm_worker_and_pthread.c', expected='0', args=['-sWASM_WORKERS', '-pthread'])
+    self.btest_exit('wasm_worker/wasm_worker_and_pthread.c', args=['-sWASM_WORKERS', '-pthread'])
 
   # Tests emscripten_wasm_worker_self_id() function
   @also_with_minimal_runtime
   def test_wasm_worker_self_id(self):
-    self.btest('wasm_worker/wasm_worker_self_id.c', expected='0', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/wasm_worker_self_id.c', args=['-sWASM_WORKERS'])
 
   # Tests direct Wasm Assembly .S file based TLS variables in Wasm Workers
   @also_with_minimal_runtime
   def test_wasm_worker_tls_wasm_assembly(self):
-    self.btest('wasm_worker/wasm_worker_tls_wasm_assembly.c',
-               expected='42', args=['-sWASM_WORKERS', test_file('wasm_worker/wasm_worker_tls_wasm_assembly.S')])
+    self.btest_exit('wasm_worker/wasm_worker_tls_wasm_assembly.c',
+                    args=['-sWASM_WORKERS', test_file('wasm_worker/wasm_worker_tls_wasm_assembly.S')])
 
   # Tests C++11 keyword thread_local for TLS in Wasm Workers
   @also_with_minimal_runtime
   def test_wasm_worker_cpp11_thread_local(self):
-    self.btest('wasm_worker/cpp11_thread_local.cpp', expected='42', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/cpp11_thread_local.cpp', args=['-sWASM_WORKERS'])
 
   # Tests C11 keyword _Thread_local for TLS in Wasm Workers
   @also_with_minimal_runtime
   def test_wasm_worker_c11__Thread_local(self):
-    self.btest('wasm_worker/c11__Thread_local.c', expected='42', args=['-sWASM_WORKERS', '-std=gnu11']) # Cannot test C11 - because of EM_ASM must test Gnu11.
+    self.btest_exit('wasm_worker/c11__Thread_local.c', args=['-sWASM_WORKERS', '-std=gnu11']) # Cannot test C11 - because of EM_ASM must test Gnu11.
 
   # Tests GCC specific extension keyword __thread for TLS in Wasm Workers
   @also_with_minimal_runtime
   def test_wasm_worker_gcc___thread(self):
-    self.btest('wasm_worker/gcc___Thread.c', expected='42', args=['-sWASM_WORKERS', '-std=gnu11'])
+    self.btest_exit('wasm_worker/gcc___Thread.c', args=['-sWASM_WORKERS', '-std=gnu11'])
 
   # Tests emscripten_wasm_worker_sleep()
   @also_with_minimal_runtime
   def test_wasm_worker_sleep(self):
-    self.btest('wasm_worker/wasm_worker_sleep.c', expected='1', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/wasm_worker_sleep.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_terminate_wasm_worker()
   @also_with_minimal_runtime
@@ -5064,71 +5064,70 @@ Module["preRun"] = () => {
   # Tests emscripten_terminate_all_wasm_workers()
   @also_with_minimal_runtime
   def test_wasm_worker_terminate_all(self):
-    self.set_setting('WASM_WORKERS')
     # Test uses the dynCall library function in its EM_ASM code
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$dynCall'])
-    self.btest('wasm_worker/terminate_all_wasm_workers.c', expected='0')
+    self.btest_exit('wasm_worker/terminate_all_wasm_workers.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_wasm_worker_post_function_*() API
   @also_with_minimal_runtime
   def test_wasm_worker_post_function(self):
-    self.btest('wasm_worker/post_function.c', expected='8', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/post_function.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_wasm_worker_post_function_*() API and EMSCRIPTEN_WASM_WORKER_ID_PARENT
   # to send a message back from Worker to its parent thread.
   @also_with_minimal_runtime
   def test_wasm_worker_post_function_to_main_thread(self):
-    self.btest('wasm_worker/post_function_to_main_thread.c', expected='10', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/post_function_to_main_thread.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_navigator_hardware_concurrency() and emscripten_atomics_is_lock_free()
   @also_with_minimal_runtime
   def test_wasm_worker_hardware_concurrency_is_lock_free(self):
-    self.btest('wasm_worker/hardware_concurrency_is_lock_free.c', expected='0', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/hardware_concurrency_is_lock_free.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_wait_u32() and emscripten_atomic_notify() functions.
   @also_with_minimal_runtime
   def test_wasm_worker_wait32_notify(self):
-    self.btest('atomic/test_wait32_notify.c', expected='3', args=['-sWASM_WORKERS'])
+    self.btest_exit('atomic/test_wait32_notify.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_wait_u64() and emscripten_atomic_notify() functions.
   @also_with_minimal_runtime
   def test_wasm_worker_wait64_notify(self):
-    self.btest('atomic/test_wait64_notify.c', expected='3', args=['-sWASM_WORKERS'])
+    self.btest_exit('atomic/test_wait64_notify.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_wait_async() function.
   @also_with_minimal_runtime
   def test_wasm_worker_wait_async(self):
-    self.btest('atomic/test_wait_async.c', expected='0', args=['-sWASM_WORKERS'])
+    self.btest_exit('atomic/test_wait_async.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_cancel_wait_async() function.
   @also_with_minimal_runtime
   def test_wasm_worker_cancel_wait_async(self):
-    self.btest('wasm_worker/cancel_wait_async.c', expected='1', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/cancel_wait_async.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_cancel_all_wait_asyncs() function.
   @also_with_minimal_runtime
   def test_wasm_worker_cancel_all_wait_asyncs(self):
-    self.btest('wasm_worker/cancel_all_wait_asyncs.c', expected='1', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/cancel_all_wait_asyncs.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_cancel_all_wait_asyncs_at_address() function.
   @also_with_minimal_runtime
   def test_wasm_worker_cancel_all_wait_asyncs_at_address(self):
-    self.btest('wasm_worker/cancel_all_wait_asyncs_at_address.c', expected='1', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/cancel_all_wait_asyncs_at_address.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_lock_init(), emscripten_lock_waitinf_acquire() and emscripten_lock_release()
   @also_with_minimal_runtime
   def test_wasm_worker_lock_waitinf(self):
-    self.btest('wasm_worker/lock_waitinf_acquire.c', expected='4000', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/lock_waitinf_acquire.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_lock_wait_acquire() and emscripten_lock_try_acquire() in Worker.
   @also_with_minimal_runtime
   def test_wasm_worker_lock_wait(self):
-    self.btest('wasm_worker/lock_wait_acquire.c', expected='0', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/lock_wait_acquire.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_lock_wait_acquire() between two Wasm Workers.
   @also_with_minimal_runtime
   def test_wasm_worker_lock_wait2(self):
-    self.btest('wasm_worker/lock_wait_acquire2.c', expected='0', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/lock_wait_acquire2.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_lock_async_acquire() function.
   @also_with_minimal_runtime
@@ -5138,12 +5137,12 @@ Module["preRun"] = () => {
   # Tests emscripten_lock_busyspin_wait_acquire() in Worker and main thread.
   @also_with_minimal_runtime
   def test_wasm_worker_lock_busyspin_wait(self):
-    self.btest('wasm_worker/lock_busyspin_wait_acquire.c', expected='0', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/lock_busyspin_wait_acquire.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_lock_busyspin_waitinf_acquire() in Worker and main thread.
   @also_with_minimal_runtime
   def test_wasm_worker_lock_busyspin_waitinf(self):
-    self.btest('wasm_worker/lock_busyspin_waitinf_acquire.c', expected='1', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/lock_busyspin_waitinf_acquire.c', args=['-sWASM_WORKERS'])
 
   # Tests that proxied JS functions cannot be called from Wasm Workers
   @also_with_minimal_runtime
@@ -5152,18 +5151,18 @@ Module["preRun"] = () => {
     self.set_setting('ASSERTIONS')
     # Test uses the dynCall library function in its EM_ASM code
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$dynCall'])
-    self.btest('wasm_worker/no_proxied_js_functions.c', expected='0',
-               args=['--js-library', test_file('wasm_worker/no_proxied_js_functions.js')])
+    self.btest_exit('wasm_worker/no_proxied_js_functions.c',
+                    args=['--js-library', test_file('wasm_worker/no_proxied_js_functions.js')])
 
   # Tests emscripten_semaphore_init(), emscripten_semaphore_waitinf_acquire() and emscripten_semaphore_release()
   @also_with_minimal_runtime
   def test_wasm_worker_semaphore_waitinf_acquire(self):
-    self.btest('wasm_worker/semaphore_waitinf_acquire.c', expected='0', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/semaphore_waitinf_acquire.c', args=['-sWASM_WORKERS'])
 
   # Tests emscripten_semaphore_try_acquire() on the main thread
   @also_with_minimal_runtime
   def test_wasm_worker_semaphore_try_acquire(self):
-    self.btest('wasm_worker/semaphore_try_acquire.c', expected='0', args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/semaphore_try_acquire.c', args=['-sWASM_WORKERS'])
 
   # Tests that calling any proxied function in a Wasm Worker will abort at runtime when ASSERTIONS are enabled.
   def test_wasm_worker_proxied_function(self):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9647,23 +9647,16 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.run_process([FILE_PACKAGER, 'test.data', '--preload', 'file1.txt', 'file2.txt', '--from-emcc', '--js-output=script2.js'])
     self.do_runf('test_emscripten_async_load_script.c', emcc_args=['-sFORCE_FILESYSTEM'])
 
-  def prep_wasm_worker_in_node(self):
-    # Auto exit after 3 seconds in Nodejs environment to get WASM Worker stdout
-    self.add_pre_run("setTimeout(()=>process.exit(), 3000);")
-
   @node_pthreads
   def test_wasm_worker_hello(self):
-    self.prep_wasm_worker_in_node()
     self.do_run_in_out_file_test('wasm_worker/hello_wasm_worker.c', emcc_args=['-sWASM_WORKERS'])
 
   @node_pthreads
   def test_wasm_worker_malloc(self):
-    self.prep_wasm_worker_in_node()
     self.do_run_in_out_file_test('wasm_worker/malloc_wasm_worker.c', emcc_args=['-sWASM_WORKERS'])
 
   @node_pthreads
   def test_wasm_worker_wait_async(self):
-    self.prep_wasm_worker_in_node()
     self.do_runf('atomic/test_wait_async.c', emcc_args=['-sWASM_WORKERS'])
 
 

--- a/test/wasm_worker/c11__Thread_local.c
+++ b/test/wasm_worker/c11__Thread_local.c
@@ -1,4 +1,5 @@
 #include <emscripten/console.h>
+#include <emscripten/emscripten.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
 #include <threads.h>
@@ -8,9 +9,9 @@ _Thread_local int __attribute__((aligned(64))) tls = 1;
 void main_thread_func() {
   assert(!emscripten_current_thread_is_wasm_worker());
   emscripten_outf("%d", tls);
-#ifdef REPORT_RESULT
-  REPORT_RESULT(tls);
-#endif
+  assert(tls == 42);
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
 }
 
 void worker_main() {
@@ -32,4 +33,5 @@ int main() {
   tls = 42;
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/cancel_all_wait_asyncs.c
+++ b/test/wasm_worker/cancel_all_wait_asyncs.c
@@ -17,9 +17,8 @@ void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT
 
 void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
   emscripten_out("asyncWaitFinishedShouldBeCalled");
-#ifdef REPORT_RESULT
-  REPORT_RESULT(testSucceeded);
-#endif
+  assert(testSucceeded);
+  emscripten_force_exit(0);
 }
 
 int main() {
@@ -70,4 +69,5 @@ int main() {
   emscripten_out("Notifying an async wait after value changing should trigger the callback");
   numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 #endif
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/cancel_all_wait_asyncs_at_address.c
+++ b/test/wasm_worker/cancel_all_wait_asyncs_at_address.c
@@ -17,9 +17,8 @@ void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT
 
 void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
   emscripten_out("asyncWaitFinishedShouldBeCalled");
-#ifdef REPORT_RESULT
-  REPORT_RESULT(testSucceeded);
-#endif
+  assert(testSucceeded);
+  emscripten_force_exit(0);
 }
 
 int main() {
@@ -74,4 +73,6 @@ int main() {
   emscripten_out("Notifying an async wait after value changing should trigger the callback");
   numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 #endif
+
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/cancel_wait_async.c
+++ b/test/wasm_worker/cancel_wait_async.c
@@ -17,9 +17,8 @@ void asyncWaitFinishedShouldNotBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT
 
 void asyncWaitFinishedShouldBeCalled(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT_T waitResult, void *userData) {
   emscripten_out("asyncWaitFinishedShouldBeCalled");
-#ifdef REPORT_RESULT
-  REPORT_RESULT(testSucceeded);
-#endif
+  assert(testSucceeded);
+  emscripten_force_exit(0);
 }
 
 int main() {
@@ -62,4 +61,5 @@ int main() {
   emscripten_out("Notifying an async wait after value changing should trigger the callback");
   numWoken = emscripten_atomic_notify((int32_t*)&addr, EMSCRIPTEN_NOTIFY_ALL_WAITERS);
 #endif
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/cpp11_thread_local.cpp
+++ b/test/wasm_worker/cpp11_thread_local.cpp
@@ -1,4 +1,5 @@
 #include <emscripten/console.h>
+#include <emscripten/emscripten.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
 
@@ -7,9 +8,9 @@ thread_local int tls = 1;
 void main_thread_func() {
   assert(!emscripten_current_thread_is_wasm_worker());
   emscripten_outf("%d", tls);
-#ifdef REPORT_RESULT
-  REPORT_RESULT(tls);
-#endif
+  assert(tls == 42);
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
 }
 
 void worker_main() {
@@ -29,4 +30,5 @@ int main() {
   tls = 42;
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/gcc___Thread.c
+++ b/test/wasm_worker/gcc___Thread.c
@@ -1,4 +1,5 @@
 #include <emscripten/console.h>
+#include <emscripten/emscripten.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
 #include <threads.h>
@@ -8,9 +9,9 @@ __thread int tls = 1;
 void main_thread_func() {
   assert(!emscripten_current_thread_is_wasm_worker());
   emscripten_outf("%d", tls);
-#ifdef REPORT_RESULT
-  REPORT_RESULT(tls);
-#endif
+  assert(tls == 42);
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
 }
 
 void worker_main() {
@@ -30,4 +31,5 @@ int main() {
   tls = 42;
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/lock_busyspin_wait_acquire.c
+++ b/test/wasm_worker/lock_busyspin_wait_acquire.c
@@ -38,11 +38,15 @@ void test() {
   emscripten_lock_release(&lock);
 }
 
+void do_exit() {
+  emscripten_out("do_exit");
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
+}
+
 void worker_main() {
   test();
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, do_exit);
 }
 
 char stack[1024];
@@ -52,4 +56,5 @@ int main() {
 
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/lock_busyspin_waitinf_acquire.c
+++ b/test/wasm_worker/lock_busyspin_waitinf_acquire.c
@@ -10,12 +10,16 @@ emscripten_lock_t lock = EMSCRIPTEN_LOCK_T_STATIC_INITIALIZER;
 
 volatile int sharedState = 0;
 
+void do_exit() {
+  emscripten_out("do_exit");
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
+}
+
 void worker_main() {
   emscripten_lock_busyspin_waitinf_acquire(&lock);
   emscripten_atomic_add_u32((void*)&sharedState, 1);
-#ifdef REPORT_RESULT
-  REPORT_RESULT(sharedState);
-#endif
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, do_exit);
 }
 
 char stack[1024];
@@ -36,4 +40,6 @@ int main() {
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 
   emscripten_set_timeout(releaseLock, 1000, 0);
+
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/lock_wait_acquire2.c
+++ b/test/wasm_worker/lock_wait_acquire2.c
@@ -21,6 +21,12 @@ void worker1_main() {
   emscripten_out("worker1 released lock");
 }
 
+void do_exit() {
+  emscripten_out("do_exit");
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
+}
+
 void worker2_main() {
   emscripten_out("worker2 main sleeping 500 msecs");
   emscripten_wasm_worker_sleep(500 * 1000000ull);
@@ -34,9 +40,7 @@ void worker2_main() {
   emscripten_out("worker2 wait_acquired lock");
   assert(success);
 
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, do_exit);
 }
 
 char stack1[1024];
@@ -47,4 +51,5 @@ int main() {
   emscripten_wasm_worker_t worker2 = emscripten_create_wasm_worker(stack2, sizeof(stack2));
   emscripten_wasm_worker_post_function_v(worker1, worker1_main);
   emscripten_wasm_worker_post_function_v(worker2, worker2_main);
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/lock_waitinf_acquire.c
+++ b/test/wasm_worker/lock_waitinf_acquire.c
@@ -15,12 +15,17 @@ volatile int sharedState1 = 1;
 
 volatile int numWorkersAlive = 0;
 
+void do_exit() {
+  emscripten_out("do_exit");
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
+}
+
 void test_ended() {
   emscripten_outf("Worker %d last thread to finish. Reporting test end with sharedState0=%d, sharedState1=%d", emscripten_wasm_worker_self_id(), sharedState0, sharedState1);
   assert(sharedState0 == sharedState1 + 1 || sharedState1 == sharedState0 + 1);
-#ifdef REPORT_RESULT
-  REPORT_RESULT(sharedState0);
-#endif
+  assert(sharedState0 == 4000);
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, do_exit);
 }
 
 void worker_main() {
@@ -62,4 +67,6 @@ int main() {
     emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
     emscripten_wasm_worker_post_function_v(worker, worker_main);
   }
+
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/malloc_wasm_worker.c
+++ b/test/wasm_worker/malloc_wasm_worker.c
@@ -5,12 +5,16 @@
 
 // Test emscripten_malloc_wasm_worker() and emscripten_current_thread_is_wasm_worker() functions
 
+void do_exit() {
+  emscripten_out("do_exit");
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
+}
+
 void worker_main() {
   emscripten_out("Hello from wasm worker!");
   assert(emscripten_current_thread_is_wasm_worker());
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, do_exit);
 }
 
 int main() {
@@ -18,4 +22,5 @@ int main() {
   emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */1024);
   assert(worker);
   emscripten_wasm_worker_post_function_v(worker, worker_main);
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/no_proxied_js_functions.c
+++ b/test/wasm_worker/no_proxied_js_functions.c
@@ -1,4 +1,5 @@
-#include <emscripten.h>
+#include <emscripten/console.h>
+#include <emscripten/emscripten.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
 
@@ -32,11 +33,15 @@ void test() {
   proxied_js_function();
 }
 
+void do_exit() {
+  emscripten_out("do_exit");
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
+}
+
 void worker_main() {
   assert(should_throw(test));
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, do_exit);
 }
 
 char stack[1024];
@@ -45,4 +50,5 @@ int main() {
   proxied_js_function();
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/post_function.c
+++ b/test/wasm_worker/post_function.c
@@ -1,4 +1,5 @@
 #include <emscripten/console.h>
+#include <emscripten/emscripten.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
 
@@ -70,10 +71,15 @@ void viiiiiidddddd(int a, int b, int c, int d, int e, int f, double g, double h,
   ++success;
 }
 
+void do_exit() {
+  assert(success == 8);
+  emscripten_out("do_exit");
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
+}
+
 void test_finished() {
-#ifdef REPORT_RESULT
-  REPORT_RESULT(success);
-#endif
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, do_exit);
 }
 
 char stack[1024];
@@ -90,4 +96,5 @@ int main() {
   emscripten_wasm_worker_post_function_vddd(worker, vddd, 4.5, 5.5, 6.5);
   emscripten_wasm_worker_post_function_sig(worker, viiiiiidddddd, "iiiiiidddddd", 10, 11, 12, 13, 14, 15, 16.5, 17.5, 18.5, 19.5, 20.5, 21.5);
   emscripten_wasm_worker_post_function_v(worker, test_finished);
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/post_function_to_main_thread.c
+++ b/test/wasm_worker/post_function_to_main_thread.c
@@ -1,4 +1,5 @@
 #include <emscripten/console.h>
+#include <emscripten/emscripten.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
 
@@ -10,9 +11,8 @@ void test_success(int i, double d) {
   assert(!emscripten_current_thread_is_wasm_worker());
   assert(i == 10);
   assert(d == 0.5);
-#ifdef REPORT_RESULT
-  REPORT_RESULT(i);
-#endif
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
 }
 
 void worker_main() {
@@ -26,4 +26,5 @@ char stack[1024];
 int main() {
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/semaphore_try_acquire.c
+++ b/test/wasm_worker/semaphore_try_acquire.c
@@ -30,7 +30,5 @@ int main() {
   idx = emscripten_semaphore_try_acquire(&available, 9);
   assert(idx == 1);
 
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  return 0;
 }

--- a/test/wasm_worker/semaphore_waitinf_acquire.c
+++ b/test/wasm_worker/semaphore_waitinf_acquire.c
@@ -31,6 +31,12 @@ void worker_main() {
   emscripten_semaphore_release(&threadsCompleted, 1);
 }
 
+void do_exit() {
+  emscripten_out("do_exit");
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
+}
+
 void control_thread() {
   // Wait until we have three threads available to start running.
   emscripten_out("control_thread: waiting for three threads to complete loading");
@@ -62,9 +68,7 @@ void control_thread() {
   assert(threadCounter == 6);
 
   emscripten_out("control_thread: test finished");
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, do_exit);
 }
 
 int main() {
@@ -78,4 +82,6 @@ int main() {
     emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
     emscripten_wasm_worker_post_function_v(worker, worker_main);
   }
+
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/terminate_all_wasm_workers.c
+++ b/test/wasm_worker/terminate_all_wasm_workers.c
@@ -1,4 +1,4 @@
-#include <emscripten.h>
+#include <emscripten/emscripten.h>
 #include <emscripten/eventloop.h>
 #include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
@@ -12,17 +12,13 @@ static volatile int worker_started = 0;
 void this_function_should_not_be_called(void *userData) {
   worker_started = -1;
   emscripten_err("this_function_should_not_be_called");
-#ifdef REPORT_RESULT
-  REPORT_RESULT(1/*fail*/);
-#endif
+  assert(0);
 }
 
 void test_passed(void *userData) {
   if (worker_started == 2) {
     emscripten_err("test_passed");
-#ifdef REPORT_RESULT
-    REPORT_RESULT(0/*ok*/);
-#endif
+    emscripten_force_exit(0);
   }
 }
 

--- a/test/wasm_worker/wasm_worker_self_id.c
+++ b/test/wasm_worker/wasm_worker_self_id.c
@@ -1,3 +1,5 @@
+#include <emscripten/emscripten.h>
+#include <emscripten/console.h>
 #include <emscripten/wasm_worker.h>
 #include <assert.h>
 
@@ -8,12 +10,16 @@ emscripten_wasm_worker_t worker2 = 0;
 
 int successes = 0;
 
+void do_exit() {
+  emscripten_out("do_exit");
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
+}
+
 void test_success() {
-#ifdef REPORT_RESULT
   if (__atomic_add_fetch(&successes, 1, __ATOMIC_SEQ_CST) == 2) {
-    REPORT_RESULT(0);
+    emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, do_exit);
   }
-#endif
 }
 
 void worker1_main() {
@@ -41,4 +47,5 @@ int main() {
   worker2 = emscripten_create_wasm_worker(stack2, sizeof(stack2));
   emscripten_wasm_worker_post_function_v(worker1, worker1_main);
   emscripten_wasm_worker_post_function_v(worker2, worker2_main);
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/wasm_worker_sleep.c
+++ b/test/wasm_worker/wasm_worker_sleep.c
@@ -1,13 +1,23 @@
+#include <assert.h>
+#include <emscripten/console.h>
 #include <emscripten/html5.h>
 #include <emscripten/wasm_worker.h>
+
+int exitStatus = 1;
+
+void do_exit() {
+  emscripten_out("do_exit");
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
+}
 
 void worker_main() {
   double t0 = emscripten_performance_now();
   emscripten_wasm_worker_sleep(/*nsecs=*/1500*1000000);
   double t1 = emscripten_performance_now();
-#ifdef REPORT_RESULT
-  REPORT_RESULT(t1-t0 >= 1500);
-#endif
+  assert(t1-t0 >= 1500);
+  exitStatus = t1-t0 >= 1500;
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, do_exit);
 }
 
 char stack[1024];
@@ -15,4 +25,5 @@ char stack[1024];
 int main() {
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
+  emscripten_exit_with_live_runtime();
 }

--- a/test/wasm_worker/wasm_worker_tls_wasm_assembly.c
+++ b/test/wasm_worker/wasm_worker_tls_wasm_assembly.c
@@ -11,9 +11,9 @@ void set_tls_variable(int var);
 void main_thread_func() {
   assert(!emscripten_current_thread_is_wasm_worker());
   assert(globalData == 3);
-#ifdef REPORT_RESULT
-  REPORT_RESULT(get_tls_variable());
-#endif
+  assert(get_tls_variable() == 42);
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
 }
 
 void worker_main() {
@@ -34,4 +34,5 @@ int main() {
   set_tls_variable(42);
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
+  emscripten_exit_with_live_runtime();
 }


### PR DESCRIPTION
Amongst other things this allows all these test to be run under node.