### PR TITLE
[wasm64] Rename `index` to `address` in new WebAssembly.Memory

### DIFF
--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -46,6 +46,10 @@ if (!ENVIRONMENT_IS_PTHREAD) {
       'shared': true,
 #endif
 #if MEMORY64 == 1
+      'address': 'i64',
+      // TODO(sbc): remove this alias for `address` once both firefox and
+      // chrome roll out the spec change.
+      // See https://github.com/WebAssembly/memory64/pull/92
       'index': 'i64',
 #endif
     });

--- a/src/runtime_shared.js
+++ b/src/runtime_shared.js
@@ -55,7 +55,7 @@ var toIndexType = (function() {
   var bigintMemoryBounds = 1;
   try {
     /** @suppress {checkTypes} */
-    new WebAssembly.Memory({'initial': 1n, 'index': 'i64'});
+    new WebAssembly.Memory({'initial': 1n, 'index': 'i64', 'address': 'i64'});
   } catch (e) {
     bigintMemoryBounds = 0;
   }


### PR DESCRIPTION
See https://github.com/WebAssembly/memory64/pull/92