### PR TITLE
Remove TargetFeaturePrefix::REQUIRED (NFC)

### DIFF
--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -165,7 +165,6 @@ class DylinkType(IntEnum):
 class TargetFeaturePrefix(IntEnum):
   USED = 0x2b
   DISALLOWED = 0x2d
-  REQUIRED = 0x3d
 
 
 class InvalidWasmError(BaseException):


### PR DESCRIPTION
This has not been emitted in LLVM since
https://github.com/llvm/llvm-project/commit/3f34e1b883351c7d98426b084386a7aa762aa366.

The corresponding proposed tool-conventions change:
https://github.com/WebAssembly/tool-conventions/pull/236