### PR TITLE
Use a fixed timestamp for test_strftime_zZ

### DIFF
--- a/test/other/test_strftime_zZ.c
+++ b/test/other/test_strftime_zZ.c
@@ -18,7 +18,7 @@ int main() {
 
   struct tm tm;
 
-  // Use a timesamp corresponding to July 2024, to avoid depending on the
+  // Use a timestamp corresponding to July 2024, to avoid depending on the
   // current time (which may fail e.g. when DST/summer-time changes).
   const time_t now = 1719792000;
 

--- a/test/other/test_strftime_zZ.c
+++ b/test/other/test_strftime_zZ.c
@@ -4,8 +4,6 @@
 #include <time.h>
 
 int main() {
-  void tzset(void);
-
   // Buffer to hold the current hour of the day.  Format is HH + nul
   // character.
   char hour[3];
@@ -20,8 +18,9 @@ int main() {
 
   struct tm tm;
 
-  // Get the current timestamp.
-  const time_t now = time(NULL);
+  // Use a timesamp corresponding to July 2024, to avoid depending on the
+  // current time (which may fail e.g. when DST/summer-time changes).
+  const time_t now = 1719792000;
 
   // What time is that here?
   if (localtime_r(&now, &tm) == NULL) {


### PR DESCRIPTION
This test was using the current time test timezone offsets, but that approach fails when the local UTC offset changes for DST/summer-time. Instead, use a fixed timestamp for an unchanging date.