### PR TITLE
Suppress new Clang warnings on memcpy of nontrivially-copyable objects

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 3.1.71 (in development)
 -----------------------
+- The `-Wnontrivial-memaccess` warning has been updated to also warn about
+  passing non-trivially-copyable destrination parameter to `memcpy`,
+  `memset` and similar functions for which it is a documented undefined
+  behavior (#22798). See https://github.com/llvm/llvm-project/pull/111434
 
 3.1.70 - 10/25/24
 -----------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,7 +20,7 @@ See docs/process.md for more on how version tagging works.
 
 3.1.71 (in development)
 -----------------------
-- The `-Wnontrivial-memaccess` warning has been updated to also warn about
+- LLVM's `-Wnontrivial-memaccess` warning has been updated to also warn about
   passing non-trivially-copyable destrination parameter to `memcpy`,
   `memset` and similar functions for which it is a documented undefined
   behavior (#22798). See https://github.com/llvm/llvm-project/pull/111434

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6795,6 +6795,7 @@ void* operator new(size_t size) {
       '-Wno-format',
       '-Wno-bitfield-constant-conversion',
       '-Wno-int-to-void-pointer-cast',
+      '-Wno-nontrivial-memaccess',
     ]
 
     # extra testing for ASSERTIONS == 2
@@ -6818,7 +6819,7 @@ void* operator new(size_t size) {
   @is_slow_test
   def test_poppler(self):
     # See https://github.com/emscripten-core/emscripten/issues/20757
-    self.emcc_args.append('-Wno-deprecated-declarations')
+    self.emcc_args.extend(['-Wno-deprecated-declarations', '-Wno-nontrivial-memaccess'])
     poppler = self.get_poppler_library()
     shutil.copy(test_file('poppler/paper.pdf'), '.')
 


### PR DESCRIPTION

See https://github.com/llvm/llvm-project/pull/111434