### PR TITLE
Allow more features for maybe-wasm2js and wasm-split

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12859,7 +12859,9 @@ exec "$@"
     self.assertExists('profile.data')
 
     wasm_split = os.path.join(building.get_binaryen_bin(), 'wasm-split')
-    wasm_split_run = [wasm_split, '-g', '-all', '--export-prefix=%', 'test_split_module.wasm.orig', '-o1', 'primary.wasm', '-o2', 'secondary.wasm', '--profile=profile.data']
+    wasm_split_run = [wasm_split, '-g',
+                      '--enable-mutable-globals', '--enable-bulk-memory', '--enable-nontrapping-float-to-int',
+                      '--export-prefix=%', 'test_split_module.wasm.orig', '-o1', 'primary.wasm', '-o2', 'secondary.wasm', '--profile=profile.data']
     if jspi:
       wasm_split_run += ['--jspi', '--enable-reference-types']
     self.run_process(wasm_split_run)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12859,7 +12859,7 @@ exec "$@"
     self.assertExists('profile.data')
 
     wasm_split = os.path.join(building.get_binaryen_bin(), 'wasm-split')
-    wasm_split_run = [wasm_split, '-g', '--enable-mutable-globals', '--export-prefix=%', 'test_split_module.wasm.orig', '-o1', 'primary.wasm', '-o2', 'secondary.wasm', '--profile=profile.data']
+    wasm_split_run = [wasm_split, '-g', '-all', '--export-prefix=%', 'test_split_module.wasm.orig', '-o1', 'primary.wasm', '-o2', 'secondary.wasm', '--profile=profile.data']
     if jspi:
       wasm_split_run += ['--jspi', '--enable-reference-types']
     self.run_process(wasm_split_run)

--- a/tools/maybe_wasm2js.py
+++ b/tools/maybe_wasm2js.py
@@ -41,7 +41,7 @@ opts = sys.argv[3:]
 
 # main
 
-cmd = [os.path.join(building.get_binaryen_bin(), 'wasm2js'), '--emscripten', wasm_file]
+cmd = [os.path.join(building.get_binaryen_bin(), 'wasm2js'), '--emscripten', '-all', wasm_file]
 cmd += opts
 js = shared.run_process(cmd, stdout=subprocess.PIPE).stdout
 # assign the instantiate function to where it will be used


### PR DESCRIPTION
 Allow more features for maybe-wasm2js and wasm-split

This is in preparation for alloing bulk memory and nontrapping-fp by default.
Maybe-wasm2js just allows all features for simplicity (although if a feature
unsupported by wasm2js is used, the test may fail anyway).
The wasm-split test fails when reference types are enabled; I haven't
investigated that yet, but for now we just enable the 2 we are interested in.