### PR TITLE
Remove automatic fallback to $HOME/.emscripten_cache. NFC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,11 @@ See docs/process.md for more on how version tagging works.
   passing non-trivially-copyable destrination parameter to `memcpy`,
   `memset` and similar functions for which it is a documented undefined
   behavior (#22798). See https://github.com/llvm/llvm-project/pull/111434
+- The automatic fallback to `$HOME/.emscripten_cache` when the emscripten
+  directory is read-only was removed.  This automatic behaviour could cause
+  confusion.  Anyone who really wants to use `$HOME/.emscripten_cache` can
+  still do so either via an environment variable (`EMCC_CACHE`) or via a config
+  file setting `CACHE`.
 
 3.1.70 - 10/25/24
 -----------------

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -23,12 +23,19 @@ cachelock = None
 cachelock_name = None
 
 
+def is_writable(path):
+  return os.access(path, os.W_OK)
+
+
 def acquire_cache_lock(reason):
   global acquired_count
   if config.FROZEN_CACHE:
     # Raise an exception here rather than exit_with_error since in practice this
     # should never happen
     raise Exception('Attempt to lock the cache but FROZEN_CACHE is set')
+
+  if not is_writable(cachedir):
+    utils.exit_with_error(f'cache directory "{cachedir}" is not writable while accessing cache for: {reason} (see https://emscripten.org/docs/tools_reference/emcc.html for info on setting the cache directory)')
 
   if acquired_count == 0:
     logger.debug(f'PID {os.getpid()} acquiring multiprocess file lock to Emscripten cache at {cachedir}')
@@ -67,7 +74,11 @@ def lock(reason):
 
 def ensure():
   ensure_setup()
-  utils.safe_ensure_dirs(cachedir)
+  if not os.path.isdir(cachedir):
+    parent_dir = os.path.dirname(cachedir)
+    if not is_writable(parent_dir):
+      utils.exit_with_error('unable to create cache directory "{cachdir}": parent directory not writable (see https://emscripten.org/docs/tools_reference/emcc.html for info on setting the cache directory)')
+    utils.safe_ensure_dirs(cachedir)
 
 
 def erase():

--- a/tools/config.py
+++ b/tools/config.py
@@ -55,10 +55,6 @@ def fix_js_engine(old, new):
   return new
 
 
-def root_is_writable():
-  return os.access(__rootpath__, os.W_OK)
-
-
 def normalize_config_settings():
   global CACHE, PORTS, LLVM_ADD_VERSION, CLANG_ADD_VERSION, CLOSURE_COMPILER
   global NODE_JS, NODE_JS_TEST, V8_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, WASM_ENGINES
@@ -80,16 +76,7 @@ def normalize_config_settings():
   WASM_ENGINES = [listify(engine) for engine in WASM_ENGINES]
   CLOSURE_COMPILER = listify(CLOSURE_COMPILER)
   if not CACHE:
-    if FROZEN_CACHE or root_is_writable():
-      CACHE = path_from_root('cache')
-    else:
-      # Use the legacy method of putting the cache in the user's home directory
-      # if the emscripten root is not writable.
-      # This is useful mostly for read-only installation and perhaps could
-      # be removed in the future since such installations should probably be
-      # setting a specific cache location.
-      logger.debug('Using home-directory for emscripten cache due to read-only root')
-      CACHE = os.path.expanduser(os.path.join('~', '.emscripten_cache'))
+    CACHE = path_from_root('cache')
   if not PORTS:
     PORTS = os.path.join(CACHE, 'ports')
 
@@ -274,10 +261,6 @@ def find_config_file():
     return emsdk_embedded_config
 
   if os.path.isfile(user_home_config):
-    return user_home_config
-
-  # No config file found.  Return the default location.
-  if not root_is_writable():
     return user_home_config
 
   return embedded_config


### PR DESCRIPTION
Putting the cache in the `$HOME` directory is not a great idea since its a location that is shared by any/all versions of emscripten.  If anyone really wants to use that location they can do so via the config file setting `CACHE` or via the environment variable `EMCC_CACHE`.