### PR TITLE
Use the -E flag (preprocess only) in test_standalone_system_headers

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9365,12 +9365,12 @@ int main() {
         if cxx_only:
           create_file('a.cxx', inc)
           create_file('b.cxx', inc)
-          self.run_process([EMXX, '-Werror', '-Wall', '-pedantic', 'a.cxx', 'b.cxx'])
+          self.run_process([EMXX, '-Werror', '-Wall', '-pedantic', 'a.cxx', 'b.cxx', '-E'], stdout=subprocess.DEVNULL)
         else:
           create_file('a.c', inc)
           create_file('b.c', inc)
           for std in ([], ['-std=c89']):
-            self.run_process([EMCC] + std + ['-Werror', '-Wall', '-pedantic', 'a.c', 'b.c'])
+            self.run_process([EMCC] + std + ['-Werror', '-Wall', '-pedantic', 'a.c', 'b.c', '-E'], stdout=subprocess.DEVNULL)
 
   @is_slow_test
   @parameterized({


### PR DESCRIPTION
This test only checks header inclusion, so it doesn't need to link or even compile. This change makes this (still slow) test 5x faster.