### PR TITLE
[library_sockfs] Report socket connect failures via select()

### DIFF
--- a/test/sockets/test_sockets_echo_client.c
+++ b/test/sockets/test_sockets_echo_client.c
@@ -29,6 +29,7 @@
 #endif
 
 typedef enum {
+  MSG_CONNECT,
   MSG_READ,
   MSG_WRITE
 } msg_state_t;
@@ -109,6 +110,21 @@ void main_loop() {
     }
   }
 
+  if (server.state == MSG_CONNECT) {
+    if (!FD_ISSET(server.fd, &fdw)) {
+      return;
+    }
+    int error = 0;
+    socklen_t len = sizeof(error);
+    int ret = getsockopt(server.fd, SOL_SOCKET, SO_ERROR, &error, &len);
+    if (error != 0) {
+      printf("connect failed: %s\n", strerror(error));
+      finish(EXIT_FAILURE);
+    }
+    printf("connected\n");
+    server.state = MSG_WRITE;
+  }
+
   if (server.state == MSG_WRITE) {
     if (!FD_ISSET(server.fd, &fdw)) {
       return;
@@ -160,7 +176,7 @@ int main() {
   int res;
 
   memset(&server, 0, sizeof(server_t));
-  server.state = MSG_WRITE;
+  server.state = MSG_CONNECT;
 
   // setup the message we're going to echo
   memset(&echo_msg, 0, sizeof(msg_t));
@@ -191,7 +207,7 @@ int main() {
     perror("inet_pton failed");
     finish(EXIT_FAILURE);
   }
-  
+
   res = connect(server.fd, (struct sockaddr *)&addr, sizeof(addr));
   if (res == -1 && errno != EINPROGRESS) {
     perror("connect failed");

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
 import clang_native
 import common
 from common import BrowserCore, no_windows, create_file, test_file, read_file
-from common import parameterized, requires_native_clang, crossplatform, PYTHON
+from common import parameterized, requires_native_clang, crossplatform, PYTHON, NON_ZERO
 from tools import config, utils
 from tools.shared import EMCC, path_from_root, run_process, CLANG_CC
 
@@ -291,6 +291,9 @@ class sockets(BrowserCore):
     with harness_class(test_file('sockets/test_sockets_echo_server.c'), args, port) as harness:
       expected = 'do_msg_read: read 14 bytes'
       self.do_runf('sockets/test_sockets_echo_client.c', expected, emcc_args=['-DSOCKK=%d' % harness.listen_port] + args)
+
+  def test_nodejs_sockets_connect_failure(self):
+    self.do_runf('sockets/test_sockets_echo_client.c', 'connect failed: Connection refused', emcc_args=['-DSOCKK=666'], assert_returncode=NON_ZERO)
 
   @requires_native_clang
   def test_nodejs_sockets_echo_subprotocol(self):


### PR DESCRIPTION
When connect fails on a NON_BLOCKING socket the socket is supposed to become writable and the status made available via SO_ERROR.

Without this change `test_sockets_echo_client.c` will loop forever polling for read/write status on the socket fd.