### PR TITLE
Remove expectation of no non-debug custom sections in separate-dwarf files

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10226,6 +10226,7 @@ int main() {
         # with name sections but no code sections.
         # if sec.type == webassembly.SecType.CODE:
         #   self.fail(f'section of type "{sec.type}" found in separate dwarf file')
+        pass
 
     # Check that dwarfdump can dump the debug info
     dwdump = self.run_process(

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10220,7 +10220,7 @@ int main() {
     with webassembly.Module('subdir/output.wasm.debug.wasm') as debug_wasm:
       if not debug_wasm.has_name_section():
         self.fail('name section not found in separate dwarf file')
-      for sec in debug_wasm.sections():
+      for _sec in debug_wasm.sections():
         # TODO(https://github.com/emscripten-core/emscripten/issues/13084):
         # Re-enable this code once the debugger extension can handle wasm files
         # with name sections but no code sections.

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10226,8 +10226,6 @@ int main() {
         # with name sections but no code sections.
         # if sec.type == webassembly.SecType.CODE:
         #   self.fail(f'section of type "{sec.type}" found in separate dwarf file')
-        if sec.name and sec.name != 'name' and not sec.name.startswith('.debug'):
-          self.fail(f'non-debug section "{sec.name}" found in separate dwarf file')
 
     # Check that dwarfdump can dump the debug info
     dwdump = self.run_process(


### PR DESCRIPTION
This test is now failing after https://github.com/WebAssembly/binaryen/pull/7043 because the target_features section is in the output binary and gets copied over to the separate-dwarf file (this is because the separate-dwarf file is just a copy of the original file).

An alternative to this would be to strip all non-debug custom sections from the side file, although there could be sections that emscripten doesn't know about that it would be desirable to have.