### PR TITLE
[test] Fix WebsockifyServerHarness on ipv6 enabled machine. NFC

### DIFF
--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -65,7 +65,10 @@ class WebsockifyServerHarness():
 
     # start the websocket proxy
     print('running websockify on %d, forward to tcp %d' % (self.listen_port, self.target_port), file=sys.stderr)
-    wsp = websockify.WebSocketProxy(verbose=True, listen_port=self.listen_port, target_host="127.0.0.1", target_port=self.target_port, run_once=True)
+    # source_is_ipv6=True here signals to websockify that it should prefer ipv6 address when
+    # resolving host names.  This matches what the node `ws` module does and means that `localhost`
+    # resolves to `::1` on IPv6 systems.
+    wsp = websockify.WebSocketProxy(verbose=True, source_is_ipv6=True, listen_port=self.listen_port, target_host="127.0.0.1", target_port=self.target_port, run_once=True)
     self.websockify = multiprocessing.Process(target=wsp.start_server)
     self.websockify.start()
     self.processes.append(self.websockify)


### PR DESCRIPTION
The test_nodejs_sockets_echo_subprotocol_runtime test was failing on my machine because node was resolving "localhost" to the IPv6 address ::1 but the websockify server was running on the IPv4 address 127.0.0.1.

The only thing that `source_is_ipv6=True `does is set `prefer_ip6` which in turn just reveres the list of results from the DNS lookup: https://github.com/novnc/websockify/blob/417210f2cf8db9cd3cd9d86c45ef954778176b0e/websockify/websockifyserver.py#L454-L455