### PR TITLE
[mimalloc] Prefer emscripten_err in _mi_prim_out_stderr. NFC

### DIFF
--- a/system/lib/mimalloc/src/prim/emscripten/prim.c
+++ b/system/lib/mimalloc/src/prim/emscripten/prim.c
@@ -169,7 +169,7 @@ void _mi_prim_process_info(mi_process_info_t* pinfo)
 #include <emscripten/console.h>
 
 void _mi_prim_out_stderr( const char* msg) {
-  emscripten_console_error(msg);
+  emscripten_err(msg);
 }
 
 


### PR DESCRIPTION
This function maps directly to stderr under node which is more direct than console.error and better in workers.