### PR TITLE
Fix for `none` proxying mode

### DIFF
--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -326,7 +326,7 @@ function(${args}) {
       if (proxyingMode !== 'sync' && proxyingMode !== 'async' && proxyingMode !== 'none') {
         throw new Error(`Invalid proxyingMode ${symbol}__proxy: '${proxyingMode}' specified!`);
       }
-      if (SHARED_MEMORY) {
+      if (SHARED_MEMORY && proxyingMode != 'none') {
         const sync = proxyingMode === 'sync';
         if (PTHREADS) {
           snippet = modifyJSFunction(snippet, (args, body, async_, oneliner) => {


### PR DESCRIPTION
It looks like this mode was broken from the moment it as added back in PR #20110.  However it went unnoticed since it was only being used with a single function: `__syscall_fadvise64`.

Split out from #22820.