### PR TITLE
Reapply "In MODULARIZE mode avoid modifying the incoming moduleArg. (#21775)"

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -21,7 +21,7 @@
 // before the code. Then that object will be used in the code, and you
 // can continue to use Module afterwards as well.
 #if MODULARIZE
-var Module = moduleArg;
+var Module = Object.assign({}, moduleArg);
 #elif USE_CLOSURE_COMPILER
 // if (!Module)` is crucial for Closure Compiler here as it will otherwise replace every `Module` occurrence with a string
 var /** @type {{

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6770,6 +6770,19 @@ typeof result.then: undefined
 after
 ''', self.run_js('a.out.js'))
 
+  def test_modularize_argument_misuse(self):
+    create_file('test.c', '''
+      #include <emscripten.h>
+      EMSCRIPTEN_KEEPALIVE int foo() { return 42; }''')
+
+    create_file('post.js', r'''
+      var arg = { bar: 1 };
+      var promise = Module(arg);
+      arg._foo();''')
+
+    expected = "Aborted(Access to module property ('_foo') is no longer possible via the module constructor argument; Instead, use the result of the module constructor"
+    self.do_runf('test.c', expected, assert_returncode=NON_ZERO, emcc_args=['--no-entry', '-sMODULARIZE', '--extern-post-js=post.js'])
+
   def test_export_all_3142(self):
     create_file('src.cpp', r'''
 typedef unsigned int Bit32u;


### PR DESCRIPTION
This change was reverted in #21994 because the file_packager generated code expected to be able to use propertied on the Module object that was passed to the constructor/factor function.  However that issue was fixed in #22086 so we can try to land this once again.