### PR TITLE
Update node canary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ commands:
     description: "install canary version of node"
     steps:
       - install-node-version:
-         node_version: "23.0.0-v8-canary20240819f52f1c2f1c"
+         node_version: "24.0.0-v8-canary202411045365c9d9be"
          canary: true
   install-v8:
     description: "install v8 using jsvu"

--- a/src/library.js
+++ b/src/library.js
@@ -2344,6 +2344,10 @@ addToLibrary({
   'maximum': {{{ toIndexType(INITIAL_TABLE) }}},
 #endif
 #if MEMORY64 == 1
+  'address': 'i64',
+   // TODO(sbc): remove this alias for 'address' once both firefox and
+   // chrome roll out the spec change.
+   // See https://github.com/WebAssembly/memory64/pull/92
   'index': 'i64',
 #endif
   'element': 'anyfunc'

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -639,7 +639,7 @@ var LibraryDylink = {
         var memAlign = Math.pow(2, metadata.memoryAlign);
         // prepare memory
         var memoryBase = metadata.memorySize ? alignMemory(getMemory(metadata.memorySize + memAlign), memAlign) : 0; // TODO: add to cleanups
-        var tableBase = metadata.tableSize ? wasmTable.length : 0;
+        var tableBase = metadata.tableSize ? {{{ from64Expr('wasmTable.length') }}} : 0;
         if (handle) {
           {{{ makeSetValue('handle', C_STRUCTS.dso.mem_allocated, '1', 'i8') }}};
           {{{ makeSetValue('handle', C_STRUCTS.dso.mem_addr, 'memoryBase', '*') }}};
@@ -657,7 +657,7 @@ var LibraryDylink = {
 #if DYLINK_DEBUG
         dbg("loadModule: growing table: " + tableGrowthNeeded);
 #endif
-        wasmTable.grow(tableGrowthNeeded);
+        wasmTable.grow({{{ toIndexType('tableGrowthNeeded') }}});
       }
 #if DYLINK_DEBUG
       dbg("loadModule: memory[" + memoryBase + ":" + (memoryBase + metadata.memorySize) + "]" +

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -588,7 +588,7 @@ function instrumentWasmTableWithAbort() {
   var realGet = wasmTable.get;
   var wrapperCache = {};
   wasmTable.get = (i) => {
-    var func = realGet.call(wasmTable, i);
+    var func = realGet.call(wasmTable, {{{ toIndexType('i') }}});
     var cached = wrapperCache[i];
     if (!cached || cached.func !== func) {
       cached = wrapperCache[i] = {

--- a/test/core/test_module_wasm_memory.js
+++ b/test/core/test_module_wasm_memory.js
@@ -6,8 +6,17 @@
  * found in the LICENSE file.
  */
 
-Module['wasmMemory'] = new WebAssembly.Memory({ 'initial': 256, 'maximum': 256,
+Module['wasmMemory'] = new WebAssembly.Memory({
 #if MEMORY64
-  'index': 'i64'
+  'initial': 256n,
+  'maximum': 256n,
+  'address': 'i64',
+   // TODO(sbc): remove this alias for `address` once both firefox and
+   // chrome roll out the spec change.
+   // See https://github.com/WebAssembly/memory64/pull/92
+  'index': 'i64',
+#else
+  'initial': 256,
+  'maximum': 256,
 #endif
 });


### PR DESCRIPTION
This involved using toIndexType in a few more places due to recent wasm64 changes requiring BitInt in more places.

Split out from #22773