### PR TITLE
Mention C/C++ system libraries on the "Building Emscripten from Source" docs page

### DIFF
--- a/site/source/docs/building_from_source/index.rst
+++ b/site/source/docs/building_from_source/index.rst
@@ -13,6 +13,9 @@ before it can be used (e.g. ``npm install``).  The ``bootstrap`` script in the
 top level of the repository takes care of running these steps and ``emcc`` will
 error out if it detects that ``bootstrap`` needs to be run.
 
+Emscripten comes with its own versions some C/C++ system libaries which ``emcc``
+builds automatically as and when needed (In the emsdk builds, these are precompiled).
+
 In addition to the main emscripten repository you will also need to checkout
 and build LLVM and Binaryen (as detailed below).  After compiling these, you
 will need to edit your ``.emscripten`` file to point to their corresponding

--- a/site/source/docs/building_from_source/index.rst
+++ b/site/source/docs/building_from_source/index.rst
@@ -14,7 +14,7 @@ top level of the repository takes care of running these steps and ``emcc`` will
 error out if it detects that ``bootstrap`` needs to be run.
 
 Emscripten comes with its own versions some C/C++ system libaries which ``emcc``
-builds automatically as and when needed (In the emsdk builds, these are precompiled).
+builds automatically as and when needed (in the emsdk builds, these are precompiled).
 You can also build them manually with the ``embuilder`` tool - see ``embuilder --help``
 for more information.
 

--- a/site/source/docs/building_from_source/index.rst
+++ b/site/source/docs/building_from_source/index.rst
@@ -15,6 +15,8 @@ error out if it detects that ``bootstrap`` needs to be run.
 
 Emscripten comes with its own versions some C/C++ system libaries which ``emcc``
 builds automatically as and when needed (In the emsdk builds, these are precompiled).
+You can also build them manually with the ``embuilder`` tool - see ``embuilder --help``
+for more information.
 
 In addition to the main emscripten repository you will also need to checkout
 and build LLVM and Binaryen (as detailed below).  After compiling these, you


### PR DESCRIPTION
Offered as a PR following [a conversation](https://github.com/emscripten-core/emscripten/issues/14453#issuecomment-2453541585) with @kripken 

I suggest the statement

> Emscripten itself is written in Python and JavaScript so it does not need to be compiled.

is 100% true, but potentially confusing for anyone who's peeked inside the repo and noticed there are C/C++ system.  Certainly I was confused.

This is my best attempt to write clarifying text.  Happy for it to be rewritten.  Happy to recieve suggestions for further refinement.

Regret I haven't been able to get the Spinix build to work on my machine or Docker to check what the rendered html output looks like.