### PR TITLE
[library_html5] Simplify JSEvent system. NFC

### DIFF
--- a/test/code_size/hello_webgl2_wasm.json
+++ b/test/code_size/hello_webgl2_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 328,
   "a.js": 4531,
   "a.js.gz": 2312,
-  "a.wasm": 10402,
-  "a.wasm.gz": 6704,
-  "total": 15387,
-  "total_gz": 9344
+  "a.wasm": 10421,
+  "a.wasm.gz": 6697,
+  "total": 15406,
+  "total_gz": 9337
 }

--- a/test/code_size/hello_webgl2_wasm2js.json
+++ b/test/code_size/hello_webgl2_wasm2js.json
@@ -1,8 +1,8 @@
 {
   "a.html": 346,
   "a.html.gz": 262,
-  "a.js": 22199,
-  "a.js.gz": 11579,
-  "total": 22545,
-  "total_gz": 11841
+  "a.js": 22320,
+  "a.js.gz": 11639,
+  "total": 22666,
+  "total_gz": 11901
 }

--- a/test/code_size/hello_webgl_wasm.json
+++ b/test/code_size/hello_webgl_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 328,
   "a.js": 4069,
   "a.js.gz": 2158,
-  "a.wasm": 10402,
-  "a.wasm.gz": 6704,
-  "total": 14925,
-  "total_gz": 9190
+  "a.wasm": 10421,
+  "a.wasm.gz": 6697,
+  "total": 14944,
+  "total_gz": 9183
 }

--- a/test/code_size/hello_webgl_wasm2js.json
+++ b/test/code_size/hello_webgl_wasm2js.json
@@ -1,8 +1,8 @@
 {
   "a.html": 346,
   "a.html.gz": 262,
-  "a.js": 21725,
-  "a.js.gz": 11413,
-  "total": 22071,
-  "total_gz": 11675
+  "a.js": 21846,
+  "a.js.gz": 11479,
+  "total": 22192,
+  "total_gz": 11741
 }

--- a/test/test_html5_mouse.c
+++ b/test/test_html5_mouse.c
@@ -5,21 +5,11 @@
  * found in the LICENSE file.
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <emscripten.h>
 #include <string.h>
 #include <emscripten/html5.h>
-
-void report_result(int result) {
-  if (result == 0) {
-    printf("Test successful!\n");
-  } else {
-    printf("Test failed!\n");
-  }
-#ifdef REPORT_RESULT
-  REPORT_RESULT(result);
-#endif
-}
 
 static inline const char *emscripten_event_type_to_string(int eventType) {
   const char *events[] = { "(invalid)", "(none)", "keypress", "keydown", "keyup", "click", "mousedown", "mouseup", "dblclick", "mousemove", "wheel", "resize", 
@@ -62,7 +52,12 @@ void instruction() {
   if (!gotMouseMove) { printf("Please move the mouse on the canvas.\n"); return; }
   if (!gotWheel) { printf("Please scroll the mouse wheel.\n"); return; }
 
-  if (gotClick && gotMouseDown && gotMouseUp && gotDblClick && gotMouseMove && gotWheel) report_result(0);
+  if (gotClick && gotMouseDown && gotMouseUp && gotDblClick && gotMouseMove && gotWheel) {
+    printf("Test successful!\n");
+#ifdef REPORT_RESULT
+    REPORT_RESULT(0);
+#endif
+  }
 }
 
 bool mouse_callback(int eventType, const EmscriptenMouseEvent *e, void *userData) {
@@ -82,7 +77,7 @@ bool mouse_callback(int eventType, const EmscriptenMouseEvent *e, void *userData
   if (eventType == EMSCRIPTEN_EVENT_CLICK && e->screenX == -500000) {
     printf("ERROR! Received an event to a callback that should have been unregistered!\n");
     gotClick = 0;
-    report_result(1);
+    assert(false && "Received an event to a callback that should have been unregistered");
   }
 
   instruction();
@@ -141,7 +136,7 @@ int main() {
   if (mouseEvent.screenX != 123 || mouseEvent.screenY != 456
     || mouseEvent.clientX != 123 || mouseEvent.clientY != 456) {
     printf("ERROR! Incorrect mouse status\n");
-    report_result(1);
+    assert(false && "Incorrect mouse status");
   }
 
   // Test that unregistering a callback works. Clicks should no longer be received.


### PR DESCRIPTION
This change extracts a few helper function to make the JS event system smaller and more internally consistent.

Firstly, we now use a single storage location for the event data pointer used in event callback.  This is allocated on demand in `allocateEventStruct`.  We then use a new `dispatchEvent` all the many loction that previously duplicated the event dispatching logic.

In order to handler the 3 cases where we need to keep a copy of the last dispatched event we also have two new helpers: `getCachedEvent`, `cacheEvent`.  These allocate separate copies of the last generated event, but only for the 3 event types where this is required.