### PR TITLE
Allow avxintrin.h to be used by C compiler

### DIFF
--- a/system/include/compat/avxintrin.h
+++ b/system/include/compat/avxintrin.h
@@ -40,7 +40,7 @@ typedef struct {
   __m128i_u v1;
 } __m256i_u;
 
-union m256_data {
+union __m256_data {
   __m256i int_view;
   __m256d double_view;
   __m256 float_view;
@@ -1771,42 +1771,42 @@ _mm256_setzero_si256(void) {
 
 static __inline__ __m256 __attribute__((__always_inline__, __nodebug__))
 _mm256_castpd_ps(__m256d __a) {
-  m256_data ret;
+  union __m256_data ret;
   ret.double_view = __a;
   return ret.float_view;
 }
 
 static __inline__ __m256i __attribute__((__always_inline__, __nodebug__))
 _mm256_castpd_si256(__m256d __a) {
-  m256_data ret;
+  union __m256_data ret;
   ret.double_view = __a;
   return ret.int_view;
 }
 
 static __inline__ __m256d __attribute__((__always_inline__, __nodebug__))
 _mm256_castps_pd(__m256 __a) {
-  m256_data ret;
+  union __m256_data ret;
   ret.float_view = __a;
   return ret.double_view;
 }
 
 static __inline__ __m256i __attribute__((__always_inline__, __nodebug__))
 _mm256_castps_si256(__m256 __a) {
-  m256_data ret;
+  union __m256_data ret;
   ret.float_view = __a;
   return ret.int_view;
 }
 
 static __inline__ __m256 __attribute__((__always_inline__, __nodebug__))
 _mm256_castsi256_ps(__m256i __a) {
-  m256_data ret;
+  union __m256_data ret;
   ret.int_view = __a;
   return ret.float_view;
 }
 
 static __inline__ __m256d __attribute__((__always_inline__, __nodebug__))
 _mm256_castsi256_pd(__m256i __a) {
-  m256_data ret;
+  union __m256_data ret;
   ret.int_view = __a;
   return ret.double_view;
 }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9475,7 +9475,7 @@ int main() {
           'wire.h', 'val.h', 'bind.h',
           'webgpu_cpp.h', 'webgpu_cpp_chained_struct.h', 'webgpu_enum_class_bitmasks.h',
           # Some headers are not yet C compatible
-          'arm_neon.h', 'avxintrin.h', 'immintrin.h',
+          'arm_neon.h',
         ]
         if directory and directory != 'compat':
           header = f'{directory}/{header}'


### PR DESCRIPTION
An internal union defined to implement 256-bit AVX support added in PR emscripten-core/emscripten#22430 is missing `union` keywords at declarations so causes errors when used with the C compiler.

Add the `union` keyword to the declarations of the `m256_data` union in avxintrin.h. Also adds `__` prefix to make type `__m256_data` to avoid further polluting global namespace.