### PR TITLE
Improve test_standalone_system_headers. NFC

### DIFF
--- a/system/include/compat/xlocale.h
+++ b/system/include/compat/xlocale.h
@@ -1,6 +1,9 @@
 #ifndef _COMPAT_XLOCALE_H_
 #define _COMPAT_XLOCALE_H_
 
+#define __NEED_locale_t
+#include <bits/alltypes.h>
+
 #include <locale.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Include `compat` headers.

See #22850