### PR TITLE
[WASM_WORKERS] Ensure TLS is initialized

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -614,7 +614,7 @@ def with_all_sjlj(f):
   assert callable(f)
 
   @wraps(f)
-  def metafunc(self, mode):
+  def metafunc(self, mode, *args, **kwargs):
     if mode == 'wasm' or mode == 'wasm_exnref':
       if self.is_wasm2js():
         self.skipTest('wasm2js does not support wasm SjLj')
@@ -627,10 +627,10 @@ def with_all_sjlj(f):
       if mode == 'wasm_exnref':
         self.require_wasm_exnref()
         self.set_setting('WASM_EXNREF')
-      f(self)
+      f(self, *args, **kwargs)
     else:
       self.set_setting('SUPPORT_LONGJMP', 'emscripten')
-      f(self)
+      f(self, *args, **kwargs)
 
   parameterize(metafunc, {'emscripten': ('emscripten',),
                           'wasm': ('wasm',),

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -863,6 +863,9 @@ base align: 0, 0, 0, 0'''])
   def test_longjmp(self):
     self.do_core_test('test_longjmp.c')
 
+  def test_longjmp_wasm_workers(self):
+    self.do_core_test('test_longjmp.c', emcc_args=['-sWASM_WORKERS'])
+
   @with_all_sjlj
   def test_longjmp_zero(self):
     if '-fsanitize=undefined' in self.emcc_args and self.get_setting('SUPPORT_LONGJMP') == 'emscripten':


### PR DESCRIPTION
The main thread TLS region get initialized via a static constructor in `library_wasm_worker.c`.  Without this change programs that don't otherwise reference `library_wasm_worker.c` will not have this static constructor run.

Fixes: #22852