### PR TITLE
[wasm64] Fix MEMORY64=2 after #22773

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -641,6 +641,7 @@ jobs:
             wasm64l.test_hello_world
             wasm64l.test_bigswitch
             wasm64l.test_module_wasm_memory
+            wasm64l.test_longjmp2_emscripten
             other.test_memory64_proxies
             other.test_failing_growth_wasm64"
       - upload-test-results

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -964,7 +964,8 @@ function from64Expr(x, assign = true) {
 }
 
 function toIndexType(x) {
-  return to64(x);
+  if (MEMORY64 == 1) return `BigInt(${x})`;
+  return x;
 }
 
 function to64(x) {


### PR DESCRIPTION
Its a good job we kept `toIndexType` around in #22773 because it turns out it does need different semantics to `to64` after all.