### PR TITLE
Use GLctx in library_egl.js and library_glut.js. NFC

### DIFF
--- a/src/library_egl.js
+++ b/src/library_egl.js
@@ -634,6 +634,7 @@ var LibraryEGL = {
   eglGetCurrentDisplay: () => EGL.currentContext ? {{{ eglDefaultDisplay }}} : 0,
 
   // EGLAPI EGLBoolean EGLAPIENTRY eglSwapBuffers(EGLDisplay dpy, EGLSurface surface);
+  eglSwapBuffers__deps: ['$GLctx'],
   eglSwapBuffers__proxy: 'sync',
   eglSwapBuffers: (dpy, surface) => {
 #if PROXY_TO_WORKER
@@ -642,9 +643,9 @@ var LibraryEGL = {
 
     if (!EGL.defaultDisplayInitialized) {
       EGL.setErrorCode(0x3001 /* EGL_NOT_INITIALIZED */);
-    } else if (!Module.ctx) {
+    } else if (!GLctx) {
       EGL.setErrorCode(0x3002 /* EGL_BAD_ACCESS */);
-    } else if (Module.ctx.isContextLost()) {
+    } else if (GLctx.isContextLost()) {
       EGL.setErrorCode(0x300E /* EGL_CONTEXT_LOST */);
     } else {
       // According to documentation this does an implicit flush.

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -399,13 +399,13 @@ var LibraryGLUT = {
         var now = Date.now();
         return now - GLUT.initTime;
       case 0x0069: /* GLUT_WINDOW_STENCIL_SIZE */
-        return Module.ctx.getContextAttributes().stencil ? 8 : 0;
+        return GLctx.getContextAttributes().stencil ? 8 : 0;
       case 0x006A: /* GLUT_WINDOW_DEPTH_SIZE */
-        return Module.ctx.getContextAttributes().depth ? 8 : 0;
+        return GLctx.getContextAttributes().depth ? 8 : 0;
       case 0x006E: /* GLUT_WINDOW_ALPHA_SIZE */
-        return Module.ctx.getContextAttributes().alpha ? 8 : 0;
+        return GLctx.getContextAttributes().alpha ? 8 : 0;
       case 0x0078: /* GLUT_WINDOW_NUM_SAMPLES */
-        return Module.ctx.getContextAttributes().antialias ? 1 : 0;
+        return GLctx.getContextAttributes().antialias ? 1 : 0;
 
       default:
         throw "glutGet(" + type + ") not implemented yet";


### PR DESCRIPTION
I'm trying to reduce/remove the usage of `Module.ctx` with a view to possibly removing it from the `Module` object.  These usages should be using `GLctx` anyway I believe.