### PR TITLE
Use quoted access for `Module['ctx']`. NFC

### DIFF
--- a/src/cpuprofiler.js
+++ b/src/cpuprofiler.js
@@ -593,7 +593,7 @@ var emscriptenCpuProfiler = {
   detectWebGLContext() {
     if (Module['canvas']?.GLctxObject?.GLctx) return Module['canvas'].GLctxObject.GLctx;
     else if (typeof GLctx != 'undefined') return GLctx;
-    else if (Module.ctx) return Module.ctx;
+    else if (Module['ctx']) return Module['ctx'];
     return null;
   },
 

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -192,7 +192,7 @@ var LibraryBrowser = {
     },
 
     createContext(/** @type {HTMLCanvasElement} */ canvas, useWebGL, setInModule, webGLContextAttributes) {
-      if (useWebGL && Module.ctx && canvas == Module['canvas']) return Module.ctx; // no need to recreate GL context if it's already been created for this canvas.
+      if (useWebGL && Module['ctx'] && canvas == Module['canvas']) return Module['ctx']; // no need to recreate GL context if it's already been created for this canvas.
 
       var ctx;
       var contextHandle;
@@ -235,7 +235,7 @@ var LibraryBrowser = {
 #if ASSERTIONS
         if (!useWebGL) assert(typeof GLctx == 'undefined', 'cannot set in module if GLctx is used, but we are a non-GL context that would replace it');
 #endif
-        Module.ctx = ctx;
+        Module['ctx'] = ctx;
         if (useWebGL) GL.makeContextCurrent(contextHandle);
         Browser.useWebGL = useWebGL;
         Browser.moduleContextCreatedCallbacks.forEach((callback) => callback());

--- a/src/library_eventloop.js
+++ b/src/library_eventloop.js
@@ -472,7 +472,7 @@ LibraryJSEventLoop = {
       }
 
 #if ASSERTIONS
-      if (MainLoop.method === 'timeout' && Module.ctx) {
+      if (MainLoop.method === 'timeout' && Module['ctx']) {
         warnOnce('Looks like you are rendering without using requestAnimationFrame for the main loop. You should use 0 for the frame rate in emscripten_set_main_loop in order to use requestAnimationFrame, as that can greatly improve your frame rates!');
         MainLoop.method = ''; // just warn once per call to set main loop
       }

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1108,7 +1108,7 @@ var LibraryGLFW = {
       }
 
       // If context creation failed, do not return a valid window
-      if (!Module.ctx && useWebGL) return 0;
+      if (!Module['ctx'] && useWebGL) return 0;
 
       // Initializes the framebuffer size from the canvas
       const canvas = Module['canvas'];
@@ -1144,7 +1144,7 @@ var LibraryGLFW = {
       for (var i = 0; i < GLFW.windows.length; i++)
         if (GLFW.windows[i] !== null) return;
 
-      delete Module.ctx;
+      delete Module['ctx'];
     },
 
     swapBuffers: (winid) => {

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -575,7 +575,7 @@ var LibraryGLUT = {
   glutDestroyWindow__proxy: 'sync',
   glutDestroyWindow__deps: ['$Browser'],
   glutDestroyWindow: (name) => {
-    delete Module.ctx;
+    delete Module['ctx'];
     return 1;
   },
 

--- a/src/library_html5_webgl.js
+++ b/src/library_html5_webgl.js
@@ -223,7 +223,7 @@ var LibraryHtml5WebGL = {
     });`,
 #endif
   _emscripten_proxied_gl_context_activated_from_main_browser_thread: (contextHandle) => {
-    GLctx = Module.ctx = GL.currentContext = contextHandle;
+    GLctx = Module['ctx'] = GL.currentContext = contextHandle;
     GL.currentContextIsProxied = true;
   },
 #else

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1170,7 +1170,7 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
       // Active Emscripten GL layer context object.
       GL.currentContext = GL.contexts[contextHandle];
       // Active WebGL context object.
-      Module.ctx = GLctx = GL.currentContext?.GLctx;
+      Module['ctx'] = GLctx = GL.currentContext?.GLctx;
       return !(contextHandle && !GLctx);
     },
 

--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -103,7 +103,7 @@ function renderFrame() {
       dst[i] = renderFrameData[i];
     }
   }
-  Module.ctx.putImageData(Module.canvasData, 0, 0);
+  Module['ctx'].putImageData(Module.canvasData, 0, 0);
   renderFrameData = null;
 }
 
@@ -190,9 +190,9 @@ worker.onmessage = (event) => {
     case 'canvas': {
       switch (data.op) {
         case 'getContext': {
-          Module.ctx = Module['canvas'].getContext(data.type, data.attributes);
+          Module['ctx'] = Module['canvas'].getContext(data.type, data.attributes);
           if (data.type !== '2d') {
-            // possible GL_DEBUG entry point: Module.ctx = wrapDebugGL(Module.ctx);
+            // possible GL_DEBUG entry point: Module['ctx'] = wrapDebugGL(Module['ctx']);
             Module.glClient = new WebGLClient();
           }
           break;
@@ -200,7 +200,7 @@ worker.onmessage = (event) => {
         case 'resize': {
           Module['canvas'].width = data.width;
           Module['canvas'].height = data.height;
-          if (Module.ctx?.getImageData) Module.canvasData = Module.ctx.getImageData(0, 0, data.width, data.height);
+          if (Module['ctx']?.getImageData) Module.canvasData = Module['ctx'].getImageData(0, 0, data.width, data.height);
           worker.postMessage({ target: 'canvas', boundingClientRect: cloneObject(Module['canvas'].getBoundingClientRect()) });
           break;
         }

--- a/src/shell.js
+++ b/src/shell.js
@@ -23,11 +23,9 @@
 #if MODULARIZE
 var Module = moduleArg;
 #elif USE_CLOSURE_COMPILER
+/** @type{Object} */
+var Module;
 // if (!Module)` is crucial for Closure Compiler here as it will otherwise replace every `Module` occurrence with a string
-var /** @type {{
-  ctx: Object,
-}}
- */ Module;
 if (!Module) /** @suppress{checkTypes}*/Module = {"__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__":1};
 #elif AUDIO_WORKLET
 var Module = globalThis.Module || (typeof {{{ EXPORT_NAME }}} != 'undefined' ? {{{ EXPORT_NAME }}} : {});

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -7,9 +7,10 @@
 #if MODULARIZE
 var Module = moduleArg;
 #elif USE_CLOSURE_COMPILER
+/** @type{Object} */
+var Module;
 // if (!Module)` is crucial for Closure Compiler here as it will
 // otherwise replace every `Module` occurrence with the object below
-var /** @type{Object} */ Module;
 if (!Module) /** @suppress{checkTypes}*/Module = 
 #if AUDIO_WORKLET
   globalThis.{{{ EXPORT_NAME }}} || 

--- a/src/webGLClient.js
+++ b/src/webGLClient.js
@@ -272,7 +272,7 @@ function WebGLClient() {
   };
 
   function renderCommands(buf) {
-    ctx = Module.ctx;
+    ctx = Module['ctx'];
     i = 0;
     buffer = buf;
     var len = buffer.length;

--- a/test/code_size/hello_webgl2_wasm.json
+++ b/test/code_size/hello_webgl2_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 454,
   "a.html.gz": 328,
-  "a.js": 4531,
-  "a.js.gz": 2312,
+  "a.js": 4532,
+  "a.js.gz": 2315,
   "a.wasm": 10402,
   "a.wasm.gz": 6704,
-  "total": 15387,
-  "total_gz": 9344
+  "total": 15388,
+  "total_gz": 9347
 }

--- a/test/code_size/hello_webgl2_wasm2js.json
+++ b/test/code_size/hello_webgl2_wasm2js.json
@@ -1,8 +1,8 @@
 {
   "a.html": 346,
   "a.html.gz": 262,
-  "a.js": 22199,
-  "a.js.gz": 11579,
-  "total": 22545,
-  "total_gz": 11841
+  "a.js": 22200,
+  "a.js.gz": 11582,
+  "total": 22546,
+  "total_gz": 11844
 }

--- a/test/code_size/hello_webgl_wasm.json
+++ b/test/code_size/hello_webgl_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 454,
   "a.html.gz": 328,
-  "a.js": 4069,
+  "a.js": 4070,
   "a.js.gz": 2158,
   "a.wasm": 10402,
   "a.wasm.gz": 6704,
-  "total": 14925,
+  "total": 14926,
   "total_gz": 9190
 }

--- a/test/code_size/hello_webgl_wasm2js.json
+++ b/test/code_size/hello_webgl_wasm2js.json
@@ -1,8 +1,8 @@
 {
   "a.html": 346,
   "a.html.gz": 262,
-  "a.js": 21725,
-  "a.js.gz": 11413,
-  "total": 22071,
-  "total_gz": 11675
+  "a.js": 21726,
+  "a.js.gz": 11415,
+  "total": 22072,
+  "total_gz": 11677
 }


### PR DESCRIPTION
This was the last property explicitly listed in the closure type annotate for the `Module` object.  This means that it was previously being preserved by closure via this mechanism, but now we preserve it via the normal quoting mechanism.

I've been looking at removing `ctx` and `canvas` from the `Module` object, but this change is just about consistency.

See #22876