### PR TITLE
Fix typo in Closure extern

### DIFF
--- a/third_party/closure-compiler/node-externs/os.js
+++ b/third_party/closure-compiler/node-externs/os.js
@@ -33,7 +33,7 @@ var os = {};
  * @return {string}
  * @nosideeffects
  */
-os.tmdDir = function() {};
+os.tmpdir = function() {};
 
 /**
  * @return {string}


### PR DESCRIPTION
Prevents Closure compiler from mangling `require('os').tmpdir()`.