### PR TITLE
Log SDL keyboard events as part of RUNTIME_DEBUG.

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -3297,7 +3297,9 @@ Default value: true
 RUNTIME_DEBUG
 =============
 
-If true, add tracing to core runtime functions.
+If non-zero, add tracing to core runtime functions.  Can be set to 2 for
+extra tracing (for example, tracing that occurs on each turn of the event
+loop or each user callback, which can flood the console).
 This setting is enabled by default if any of the following debugging settings
 are enabled:
 - PTHREADS_DEBUG
@@ -3311,7 +3313,7 @@ are enabled:
 - SOCKET_DEBUG
 - FETCH_DEBUG
 
-Default value: false
+Default value: 0
 
 .. _legacy_runtime:
 

--- a/src/library.js
+++ b/src/library.js
@@ -2160,7 +2160,7 @@ addToLibrary({
       return;
     }
 #endif
-#if RUNTIME_DEBUG
+#if RUNTIME_DEBUG >= 2
     dbg(`maybeExit: user callback done: runtimeKeepaliveCounter=${runtimeKeepaliveCounter}`);
 #endif
     if (!keepRuntimeAlive()) {

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -826,6 +826,9 @@ var LibrarySDL = {
       if (code >= 65 && code <= 90) {
         code += 32; // make lowercase for SDL
       } else {
+#if RUNTIME_DEBUG
+        if (!(event.keyCode in SDL.keyCodes)) dbg('unknown keyCode: ', event.keyCode);
+#endif
         code = SDL.keyCodes[event.keyCode] || event.keyCode;
         // If this is one of the modifier keys (224 | 1<<10 - 227 | 1<<10), and the event specifies that it is
         // a right key, add 4 to get the right key SDL key code.
@@ -930,7 +933,9 @@ var LibrarySDL = {
       switch (event.type) {
         case 'keydown': case 'keyup': {
           var down = event.type === 'keydown';
-          //dbg('Received key event: ' + event.keyCode);
+#if RUNTIME_DEBUG
+          dbg(`received ${event.type} event: keyCode=${event.keyCode}, key=${event.key}, code=${event.code}`);
+#endif
           var key = SDL.lookupKeyCodeForEvent(event);
           var scan;
           if (key >= 1024) {

--- a/src/runtime_stack_check.js
+++ b/src/runtime_stack_check.js
@@ -36,7 +36,7 @@ function checkStackCookie() {
   if (ABORT) return;
 #endif
   var max = _emscripten_stack_get_end();
-#if RUNTIME_DEBUG
+#if RUNTIME_DEBUG >= 2
   dbg(`checkStackCookie: ${ptrToString(max)}`);
 #endif
   // See writeStackCookie().

--- a/src/settings.js
+++ b/src/settings.js
@@ -2137,7 +2137,9 @@ var TRUSTED_TYPES = false;
 // settings is *only* needed when also explicitly targeting older browsers.
 var POLYFILL = true;
 
-// If true, add tracing to core runtime functions.
+// If non-zero, add tracing to core runtime functions.  Can be set to 2 for
+// extra tracing (for example, tracing that occurs on each turn of the event
+// loop or each user callback, which can flood the console).
 // This setting is enabled by default if any of the following debugging settings
 // are enabled:
 // - PTHREADS_DEBUG
@@ -2151,7 +2153,7 @@ var POLYFILL = true;
 // - SOCKET_DEBUG
 // - FETCH_DEBUG
 // [link]
-var RUNTIME_DEBUG = false;
+var RUNTIME_DEBUG = 0;
 
 // Include JS library symbols that were previously part of the default runtime.
 // Without this, such symbols can be made available by adding them to

--- a/test/browser/test_sdl_key_proxy.c
+++ b/test/browser/test_sdl_key_proxy.c
@@ -15,8 +15,7 @@ int result = 1;
 EMSCRIPTEN_KEEPALIVE void one() {
   SDL_Event event;
   while (SDL_PollEvent(&event)) {
-    printf("got event %d\n", event.type);
-    switch(event.type) {
+    switch (event.type) {
       case SDL_KEYDOWN:
         break;
       case SDL_KEYUP:
@@ -24,15 +23,20 @@ EMSCRIPTEN_KEEPALIVE void one() {
         if (event.key.keysym.sym == SDLK_LCTRL ||
             event.key.keysym.sym == SDLK_LSHIFT ||
             event.key.keysym.sym == SDLK_LALT) {
+          printf("got modifier: %d\n", event.key.keysym.sym);
           return;
         }
+        printf("got SDL_KEYUP: ");
         if ((event.key.keysym.mod & KMOD_LCTRL) || (event.key.keysym.mod & KMOD_RCTRL)) {
+          printf("CTRL + ");
           result *= 2;
         }
         if ((event.key.keysym.mod & KMOD_LSHIFT) || (event.key.keysym.mod & KMOD_RSHIFT)) {
+          printf("SHIFT + ");
           result *= 3;
         }
         if ((event.key.keysym.mod & KMOD_LALT) || (event.key.keysym.mod & KMOD_RALT)) {
+          printf("ALT + ");
           result *= 5;
         }
         switch (event.key.keysym.sym) {
@@ -52,7 +56,8 @@ EMSCRIPTEN_KEEPALIVE void one() {
         }
         break;
       default: /* Report an unhandled event */
-        printf("I don't know what this event is!\n");
+        printf("I don't know what this event is! (%d)\n", event.type);
+        emscripten_force_exit(1);
     }
   }
 }

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1001,7 +1001,7 @@ simulateKeyDown(100);simulateKeyUp(100); // trigger the end
 </body>''')
       create_file('test.html', html)
 
-    self.btest_exit('test_sdl_key_proxy.c', 223092870, args=['--proxy-to-worker', '--pre-js', 'pre.js', '-lSDL', '-lGL'], post_build=post)
+    self.btest_exit('test_sdl_key_proxy.c', 223092870, args=['--proxy-to-worker', '--pre-js', 'pre.js', '-lSDL', '-lGL', '-sRUNTIME_DEBUG'], post_build=post)
 
   def test_canvas_focus(self):
     self.btest_exit('canvas_focus.c')

--- a/test/test_interactive.py
+++ b/test/test_interactive.py
@@ -48,6 +48,9 @@ class interactive(BrowserCore):
   def test_sdl_wm_togglefullscreen(self):
     self.btest_exit('test_sdl_wm_togglefullscreen.c')
 
+  def test_sdl_key_test(self):
+    self.btest_exit('test_sdl_key_test.c', args=['-sRUNTIME_DEBUG'])
+
   def test_sdl_fullscreen_samecanvassize(self):
     self.btest_exit('test_sdl_fullscreen_samecanvassize.c')
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -666,18 +666,19 @@ def phase_linker_setup(options, state, newargs):
   if options.cpu_profiler:
     options.post_js.append(utils.path_from_root('src/cpuprofiler.js'))
 
-  if not settings.RUNTIME_DEBUG:
-    settings.RUNTIME_DEBUG = bool(settings.LIBRARY_DEBUG or
-                                  settings.GL_DEBUG or
-                                  settings.DYLINK_DEBUG or
-                                  settings.OPENAL_DEBUG or
-                                  settings.SYSCALL_DEBUG or
-                                  settings.WEBSOCKET_DEBUG or
-                                  settings.SOCKET_DEBUG or
-                                  settings.FETCH_DEBUG or
-                                  settings.EXCEPTION_DEBUG or
-                                  settings.PTHREADS_DEBUG or
-                                  settings.ASYNCIFY_DEBUG)
+  # Unless RUNTIME_DEBUG is explicitly set then we enable it when any of the
+  # more specfic debug settings are present.
+  default_setting('RUNTIME_DEBUG', int(settings.LIBRARY_DEBUG or
+                                       settings.GL_DEBUG or
+                                       settings.DYLINK_DEBUG or
+                                       settings.OPENAL_DEBUG or
+                                       settings.SYSCALL_DEBUG or
+                                       settings.WEBSOCKET_DEBUG or
+                                       settings.SOCKET_DEBUG or
+                                       settings.FETCH_DEBUG or
+                                       settings.EXCEPTION_DEBUG or
+                                       settings.PTHREADS_DEBUG or
+                                       settings.ASYNCIFY_DEBUG))
 
   if options.memory_profiler:
     settings.MEMORYPROFILER = 1


### PR DESCRIPTION
Also, test_sdl_key_test.c to test_interactive.py.  This test was not being run anywhere else and serves as simple way to test/debug keyboard events.

Also, only set the `RUNTIME_DEBUG` default if the user does not explicitly set it themselves.  This allows for `-sSOCKETS_DEBUG -sRUNTIM_DEBUG=0` to opt out of the `RUNTIME_DEBUG` channel.

Finally, disable the `RUNTIME_DEBUG` traces that occur during turns of the event loop unless `RUNTIME_DEBUG` is set to 2.  This avoids flooding the console will messages in applications that are using the event loop.