### PR TITLE
Ignore unknown keyCodes in library_sdl.js

### DIFF
--- a/test/browser/test_sdl_key.c
+++ b/test/browser/test_sdl_key.c
@@ -72,8 +72,8 @@ int main(int argc, char **argv) {
 
   emscripten_set_main_loop(one, 0, 0);
 
-  EM_ASM({keydown(1250);keydown(38);keyup(38);keyup(1250);}); // alt, up
-  EM_ASM({keydown(1248);keydown(1249);keydown(40);keyup(40);keyup(1249);keyup(1248);}); // ctrl, shift, down
+  EM_ASM({keydown(18);keydown(38);keyup(38);keyup(18);}); // alt, up
+  EM_ASM({keydown(17);keydown(16);keydown(40);keyup(40);keyup(16);keyup(17);}); // ctrl, shift, down
   EM_ASM({keydown(37);keyup(37);}); // left
   EM_ASM({keydown(39);keyup(39);}); // right
 

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -990,8 +990,8 @@ If manually bisecting:
       html = html.replace('</body>', '''
 <script src='fake_events.js'></script>
 <script>
-simulateKeyDown(1250);simulateKeyDown(38);simulateKeyUp(38);simulateKeyUp(1250); // alt, up
-simulateKeyDown(1248);simulateKeyDown(1249);simulateKeyDown(40);simulateKeyUp(40);simulateKeyUp(1249);simulateKeyUp(1248); // ctrl, shift, down
+simulateKeyDown(18);simulateKeyDown(38);simulateKeyUp(38);simulateKeyUp(18); // alt, up
+simulateKeyDown(17);simulateKeyDown(16);simulateKeyDown(40);simulateKeyUp(40);simulateKeyUp(16);simulateKeyUp(17); // ctrl, shift, down
 simulateKeyDown(37);simulateKeyUp(37); // left
 simulateKeyDown(39);simulateKeyUp(39); // right
 simulateKeyDown(65);simulateKeyUp(65); // a


### PR DESCRIPTION
Prior to this change any unrecognized DOM keyCode would be directly passed through with the DOM keyCode used as an SDL keycode.

This strange behavior is what allowed `test_sdl_key_proxy` to use SDL key codes when generating new `KeyboardEvent`s.  The number previously hardcoded in the test (1248, 1249, 1250) correspond to (SDLK_LCTRL, SDLK_LSHIFT, SDLK_LALT) but don't make any sense as DOM keyboard codes.