### PR TITLE
Add multi-threaded versions of sdl2_image and sdl2_ttf

### DIFF
--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -752,7 +752,7 @@ fi
   def test_embuilder_with_use_port_syntax(self):
     restore_and_set_up()
     self.run_process([EMBUILDER, 'build', 'sdl2_image:formats=png,jpg', '--force'])
-    self.assertExists(os.path.join(config.CACHE, 'sysroot', 'lib', 'wasm32-emscripten', 'libSDL2_image_jpg-png.a'))
+    self.assertExists(os.path.join(config.CACHE, 'sysroot', 'lib', 'wasm32-emscripten', 'libSDL2_image-jpg-png.a'))
     self.assertContained('error building port `sdl2_image:formats=invalid` | invalid is not a supported format', self.do([EMBUILDER, 'build', 'sdl2_image:formats=invalid', '--force']))
 
   def test_embuilder_external_ports(self):

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -11,8 +11,10 @@ HASH = '2175d11a90211871f2289c8d57b31fe830e4b46af7361925c2c30cd521c1c677d2ee244f
 
 deps = ['sdl2']
 variants = {
-  'sdl2_image_jpg':  {'SDL2_IMAGE_FORMATS': ["jpg"]},
-  'sdl2_image_png': {'SDL2_IMAGE_FORMATS': ["png"]},
+  'sdl2_image-jpg':    {'SDL2_IMAGE_FORMATS': ["jpg"]},
+  'sdl2_image-png':    {'SDL2_IMAGE_FORMATS': ["png"]},
+  'sdl2_image-jpg-mt': {'SDL2_IMAGE_FORMATS': ["jpg"], 'PTHREADS': 1},
+  'sdl2_image-png-mt': {'SDL2_IMAGE_FORMATS': ["png"], 'PTHREADS': 1},
 }
 
 OPTIONS = {
@@ -41,7 +43,9 @@ def get_lib_name(settings):
 
   libname = 'libSDL2_image'
   if formats != '':
-    libname += '_' + formats
+    libname += '-' + formats
+  if settings.PTHREADS:
+    libname += '-mt'
   return libname + '.a'
 
 
@@ -58,20 +62,23 @@ def get(ports, settings, shared):
               IMG_tif.c IMG_xcf.c IMG_xpm.c IMG_xv.c IMG_webp.c IMG_ImageIO.m
               IMG_avif.c IMG_jxl.c IMG_svg.c IMG_qoi.c'''.split()
 
-    defs = ['-O2', '-sUSE_SDL=2', '-Wno-format-security']
+    flags = ['-O2', '-sUSE_SDL=2', '-Wno-format-security']
 
     formats = get_formats(settings)
 
     for fmt in formats:
-      defs.append('-DLOAD_' + fmt.upper())
+      flags.append('-DLOAD_' + fmt.upper())
 
     if 'png' in formats:
-      defs += ['-sUSE_LIBPNG']
+      flags += ['-sUSE_LIBPNG']
 
     if 'jpg' in formats:
-      defs += ['-sUSE_LIBJPEG']
+      flags += ['-sUSE_LIBJPEG']
 
-    ports.build_port(src_dir, final, 'sdl2_image', flags=defs, srcs=srcs)
+    if settings.PTHREADS:
+      flags += ['-pthread']
+
+    ports.build_port(src_dir, final, 'sdl2_image', flags=flags, srcs=srcs)
 
   return [shared.cache.get_lib(libname, create, what='port')]
 

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -8,9 +8,15 @@ HASH = '8a625d29bef2ab7cbfe2143136a303c0fdb066ecd802d6c725de1b73ad8b056908cb524f
 
 deps = ['freetype', 'sdl2', 'harfbuzz']
 
+variants = {'sdl2_ttf-mt': {'PTHREADS': 1}}
+
 
 def needed(settings):
   return settings.USE_SDL_TTF == 2
+
+
+def get_lib_name(settings):
+  return 'libSDL2_ttf' + ('-mt' if settings.PTHREADS else '') + '.a'
 
 
 def get(ports, settings, shared):
@@ -20,13 +26,15 @@ def get(ports, settings, shared):
     src_root = ports.get_dir('sdl2_ttf', 'SDL_ttf-' + TAG)
     ports.install_headers(src_root, target='SDL2')
     flags = ['-DTTF_USE_HARFBUZZ=1', '-sUSE_SDL=2', '-sUSE_FREETYPE', '-sUSE_HARFBUZZ']
+    if settings.PTHREADS:
+      flags += ['-pthread']
     ports.build_port(src_root, final, 'sdl2_ttf', flags=flags, srcs=['SDL_ttf.c'])
 
-  return [shared.cache.get_lib('libSDL2_ttf.a', create, what='port')]
+  return [shared.cache.get_lib(get_lib_name(settings), create, what='port')]
 
 
 def clear(ports, settings, shared):
-  shared.cache.erase_lib('libSDL2_ttf.a')
+  shared.cache.erase_lib(get_lib_name(settings))
 
 
 def process_dependencies(settings):


### PR DESCRIPTION
Because some possible dependencies of these libraries have `-mt` variants (specifically png and harfbuzz) we also needs to declare `-mt` variant of these libraries.

The reason for this is a little complex: When we find the set of transitive dependencies of given library we select the correct variant of each library.  This means that if we are building with `-pthread` then we select and include the `-mt` variants of all dependencies. However if libsdl2_image or libsdl2_ttf themselves then need to be built we end up building them without `-pthread` which means that emcc subprocesses will try to select and build the single threaded variants of the dependencies.  This is mostly a serious problem because we don't allow for nested calls to emcc (we assume all dependencies have been already built before we try to build a given library and the we error out with `EM_CACHE_IS_LOCKED` if that is not the case).

Testing this fix requires the cache to be setup just right so I'm not sure its worth it.

Fixes: #22941, #20204