### PR TITLE
Display correct version of boost headers with --show-ports

### DIFF
--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -44,4 +44,4 @@ def process_args(ports):
 
 
 def show():
-  return 'boost_headers - Boost headers v1.70.0 (-sUSE_BOOST_HEADERS=1 or --use-port=boost_headers; Boost license)'
+  return f'boost_headers - Boost headers v{TAG} (-sUSE_BOOST_HEADERS=1 or --use-port=boost_headers; Boost license)'


### PR DESCRIPTION
Use TAG as source for version info