### PR TITLE
Move emscripten_date_now/emscripten_performance_now. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1363,6 +1363,10 @@ addToLibrary({
 
   emscripten_random: () => Math.random(),
 
+  emscripten_date_now: () => Date.now(),
+
+  emscripten_performance_now: () => {{{ getPerformanceNow() }}}(),
+
 #if PTHREADS && !AUDIO_WORKLET
   // Pthreads need their clocks synchronized to the execution of the main
   // thread, so, when using them, make sure to adjust all timings to the

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2486,10 +2486,6 @@ var LibraryHTML5 = {
     return requestAnimationFrame(tick);
   },
 
-  emscripten_date_now: () => Date.now(),
-
-  emscripten_performance_now: () => {{{ getPerformanceNow() }}}(),
-
   emscripten_get_device_pixel_ratio__proxy: 'sync',
   emscripten_get_device_pixel_ratio: () => {
 #if ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL


### PR DESCRIPTION
These are not HTML5 specific, they both work under node too.  Better for them to live alongside `emscripten_get_now`.