### PR TITLE
Fix requires_rust to be consistent with environment variable

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -174,7 +174,7 @@ def requires_scons(func):
 
 def requires_rust(func):
   assert callable(func)
-  return requires_tool('cargo')(func)
+  return requires_tool('rust')(func)
 
 
 def requires_pkg_config(func):


### PR DESCRIPTION
Fix for #22964 
We are using 'EMTEST_SKIP_RUST' in the environments, but were using 'cargo' in the skipping logic