### PR TITLE
Remove `abort` reference from setTimeout polyfill.

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -319,7 +319,7 @@ if (ENVIRONMENT_IS_SHELL) {
   globalThis.clearTimeout ??= (id) => {};
 
   // spidermonkey lacks setTimeout but we use it above in readAsync.
-  globalThis.setTimeout ??= (f) => (typeof f == 'function') ? f() : abort();
+  globalThis.setTimeout ??= (f) => f();
 
   // v8 uses `arguments_` whereas spidermonkey uses `scriptArgs`
   arguments_ = globalThis.arguments || globalThis.scriptArgs;


### PR DESCRIPTION
Adding a reference from `globalThis` -> `abort` ends up preventing GC of the whole `Module` since `abort` references `Module`.

Fixes: #22979