### PR TITLE
Set errno to ENOTDIR instead of ENOENT when appropriate

### DIFF
--- a/test/other/test_enotdir.c
+++ b/test/other/test_enotdir.c
@@ -1,0 +1,9 @@
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+
+int main(void) {
+    open("a/b", O_RDWR | O_CREAT | O_EXCL);
+    printf("Error %d: %s\n", errno, strerror(errno));
+}

--- a/test/other/test_enotdir.out
+++ b/test/other/test_enotdir.out
@@ -1,0 +1,1 @@
+Error 54: Not a directory

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15402,3 +15402,6 @@ addToLibrary({
        return 0;
     }''')
     self.do_runf('main.cpp', 'Hello from rust!', emcc_args=[lib])
+
+  def test_enotdir(self):
+    self.do_other_test("test_enotdir.c")


### PR DESCRIPTION
Resolves #22991.