### PR TITLE
Make readlink system call not resolve the link

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -895,7 +895,7 @@ FS.staticInit();
       }
 #endif
     },
-    readlink(path) {
+    readlink(path, opts = {}) {
       var lookup = FS.lookupPath(path);
       var link = lookup.node;
       if (!link) {
@@ -904,7 +904,11 @@ FS.staticInit();
       if (!link.node_ops.readlink) {
         throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
-      return PATH_FS.resolve(FS.getPath(link.parent), link.node_ops.readlink(link));
+      const target = link.node_ops.readlink(link);
+      if (opts.noResolve) {
+        return target;
+      }
+      return PATH_FS.resolve(FS.getPath(link.parent), target);
     },
     stat(path, dontFollow) {
       var lookup = FS.lookupPath(path, { follow: !dontFollow });

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -904,8 +904,7 @@ FS.staticInit();
       if (!link.node_ops.readlink) {
         throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
-      var target = link.node_ops.readlink(link);
-      return PATH_FS.resolve(FS.getPath(link.parent), target);
+      return link.node_ops.readlink(link);
     },
     stat(path, dontFollow) {
       var lookup = FS.lookupPath(path, { follow: !dontFollow });

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -895,7 +895,7 @@ FS.staticInit();
       }
 #endif
     },
-    readlink(path, opts = {}) {
+    readlink(path) {
       var lookup = FS.lookupPath(path);
       var link = lookup.node;
       if (!link) {
@@ -904,10 +904,7 @@ FS.staticInit();
       if (!link.node_ops.readlink) {
         throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
-      const target = link.node_ops.readlink(link);
-      if (opts.noResolve) {
-        return target;
-      }
+      var target = link.node_ops.readlink(link);
       return PATH_FS.resolve(FS.getPath(link.parent), target);
     },
     stat(path, dontFollow) {

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -919,7 +919,7 @@ var SyscallsLibrary = {
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);
     if (bufsize <= 0) return -{{{ cDefs.EINVAL }}};
-    var ret = FS.readlink(path, {noResolve: true});
+    var ret = FS.readlink(path);
 
     var len = Math.min(bufsize, lengthBytesUTF8(ret));
     var endChar = HEAP8[buf+len];

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -919,7 +919,7 @@ var SyscallsLibrary = {
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);
     if (bufsize <= 0) return -{{{ cDefs.EINVAL }}};
-    var ret = FS.readlink(path);
+    var ret = FS.readlink(path, {noResolve: true});
 
     var len = Math.min(bufsize, lengthBytesUTF8(ret));
     var endChar = HEAP8[buf+len];

--- a/test/unistd/links.c
+++ b/test/unistd/links.c
@@ -81,15 +81,7 @@ void test_reading_existing_symlinks() {
       continue;
     }
 
-    // WASMFS behaves the same as Linux (and as best as I can tell, the spec),
-    // seeing the symlink as a string. The old JS FS instead normalizes it and
-    // returns something modified.
-    // The same happens in the assertions below.
-#if !defined(__EMSCRIPTEN__) || defined(WASMFS)
     assert(strcmp(buffer, "../test/../there!") == 0);
-#else
-    assert(strcmp(buffer, "/there!") == 0);
-#endif
     assert(strlen(buffer) == rtn);
     errno = 0;
   }
@@ -111,11 +103,7 @@ void test_creating_symlink() {
   char buffer[256] = {0};
   rtn = readlink("directory/link", buffer, 256);
   assert(errno == 0);
-#if !defined(__EMSCRIPTEN__) || defined(WASMFS)
   assert(strcmp(buffer, "new-nonexistent-path") == 0);
-#else
-  assert(strcmp(buffer, "/working/directory/new-nonexistent-path") == 0);
-#endif
   assert(strlen(buffer) == rtn);
   errno = 0;
 }
@@ -127,11 +115,7 @@ void test_reading_shortened_symlink() {
   int rtn = readlink("link", buffer, 4);
   assert(errno == 0);
   assert(rtn == 4);
-#if !defined(__EMSCRIPTEN__) || defined(WASMFS)
   assert(strcmp(buffer, "../t**nexistent-path") == 0);
-#else
-  assert(strcmp(buffer, "/the**ng/directory/new-nonexistent-path") == 0);
-#endif
   errno = 0;
 }
 


### PR DESCRIPTION
Readlink in linux does not resolve the link, it returns the exact link contents. Resolves #22999.