### PR TITLE
Remove cleanup code from stdlib tests. NFC

### DIFF
--- a/test/dirent/test_readdir.c
+++ b/test/dirent/test_readdir.c
@@ -40,14 +40,6 @@ void setup() {
   create_file("foobar/file.txt", "ride into the danger zone", 0666);
 }
 
-void cleanup() {
-  rmdir("nocanread");
-  unlink("foobar/file.txt");
-  rmdir("foobar");
-  chdir("..");
-  rmdir("testtmp");
-}
-
 void test() {
   int err;
   long loc, loc2;
@@ -208,11 +200,9 @@ void test_scandir() {
 }
 
 int main() {
-  atexit(cleanup);
-  signal(SIGABRT, cleanup);
   setup();
   test();
   test_scandir();
 
-  return EXIT_SUCCESS;
+  return 0;
 }

--- a/test/fcntl/test_fcntl_open.c
+++ b/test/fcntl/test_fcntl_open.c
@@ -10,7 +10,6 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -34,20 +33,6 @@ void setup() {
   create_file("test-file", "abcdef", 0777);
   mkdir("test-folder", 0777);
   symlink("test-file", "test-link");
-  assert(!errno);
-}
-
-void cleanup() {
-  unlink("test-file");
-  rmdir("test-folder");
-  for (int i = 0; i < 3; i++) {
-    for (int j = 0; j < 32; j++) {
-      sprintf(nonexistent_name, "noexist-%c%d", 'a' + i, j);
-      unlink(nonexistent_name);
-    }
-  }
-  errno = 0;
-  unlink("creat-me");
   assert(!errno);
 }
 
@@ -167,9 +152,7 @@ void test() {
 }
 
 int main() {
-  atexit(cleanup);
-  signal(SIGABRT, cleanup);
   setup();
   test();
-  return EXIT_SUCCESS;
+  return 0;
 }

--- a/test/stat/test_chmod.c
+++ b/test/stat/test_chmod.c
@@ -143,8 +143,6 @@ void test() {
 }
 
 int main() {
-  atexit(cleanup);
-  signal(SIGABRT, cleanup);
   setup();
   test();
   return EXIT_SUCCESS;

--- a/test/stat/test_mknod.c
+++ b/test/stat/test_mknod.c
@@ -11,7 +11,6 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <utime.h>
@@ -20,13 +19,6 @@
 
 void setup() {
   mkdir("folder-readonly", 0555);
-}
-
-void cleanup() {
-  unlink("mknod-file");
-  unlink("mknod-device");
-  rmdir("folder");
-  rmdir("folder-readonly");
 }
 
 void test() {
@@ -93,9 +85,7 @@ void test() {
 }
 
 int main() {
-  atexit(cleanup);
-  signal(SIGABRT, cleanup);
   setup();
   test();
-  return EXIT_SUCCESS;
+  return 0;
 }

--- a/test/stdio/test_fgetc_ungetc.c
+++ b/test/stdio/test_fgetc_ungetc.c
@@ -9,10 +9,12 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
+#ifdef __EMSCRIPTEN__
 #include <emscripten.h>
+#endif
 
 static void create_file(const char *path, const char *buffer, int mode) {
   int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, mode);
@@ -26,10 +28,6 @@ static void create_file(const char *path, const char *buffer, int mode) {
 
 void setup() {
   create_file("/tmp/file.txt", "cd", 0666);
-}
-
-void cleanup() {
-  unlink("/tmp/file.txt");
 }
 
 void test() {
@@ -90,14 +88,14 @@ void test() {
 }
 
 int main() {
+#ifdef __EMSCRIPTEN__
 #ifdef NODEFS
   EM_ASM(FS.mount(NODEFS, { root: '.' }, '/tmp'));
 #elif MEMFS
   EM_ASM(FS.mount(MEMFS, {}, '/tmp'));
 #endif
-  atexit(cleanup);
-  signal(SIGABRT, cleanup);
+#endif
   setup();
   test();
-  return EXIT_SUCCESS;
+  return 0;
 }

--- a/test/stdio/test_rename.c
+++ b/test/stdio/test_rename.c
@@ -10,7 +10,6 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -51,39 +50,6 @@ void setup() {
   mkdir("dir/b/", 0777);
   mkdir("dir/b/c", 0777);
   create_file("dir-nonempty/file", "abcdef", 0777);
-}
-
-void cleanup() {
-  // We're hulk-smashing and removing original + renamed files to
-  // make sure we get it all regardless of anything failing
-  unlink("file");
-  unlink("dir/file");
-  unlink("dir/file1");
-  unlink("dir/file2");
-  rmdir("dir/subdir/subsubdir");
-  rmdir("dir/subdir");
-  rmdir("dir/subdir1");
-  rmdir("dir/subdir2");
-  rmdir("dir/subdir3/subdir3_1/subdir1 renamed");
-  rmdir("dir/subdir3/subdir3_1");
-  rmdir("dir/subdir3");
-  rmdir("dir/subdir4/");
-  rmdir("dir/subdir5/");
-  rmdir("dir/b/c");
-  rmdir("dir/b");
-  rmdir("dir/rename-dir/subdir/subsubdir");
-  rmdir("dir/rename-dir/subdir");
-  rmdir("dir/rename-dir");
-  rmdir("dir");
-#ifndef WASMFS
-  chmod("dir-readonly2", 0777);
-#endif
-  rmdir("dir-readonly2/somename");
-  rmdir("dir-readonly2");
-  rmdir("new-dir");
-  rmdir("dir-readonly");
-  unlink("dir-nonempty/file");
-  rmdir("dir-nonempty");
 }
 
 void test() {
@@ -254,9 +220,7 @@ void test() {
 }
 
 int main() {
-  atexit(cleanup);
-  signal(SIGABRT, cleanup);
   setup();
   test();
-  return EXIT_SUCCESS;
+  return 0;
 }

--- a/test/termios/test_tcgetattr.c
+++ b/test/termios/test_tcgetattr.c
@@ -10,7 +10,6 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <termios.h>
 #include <unistd.h>
@@ -26,43 +25,37 @@ static void create_file(const char *path, const char *buffer, int mode) {
 }
 
 void setup() {
-	create_file("test.txt", "abcdefg", 0666);
-}
-
-void cleanup() {
-	unlink("test.txt");
+  create_file("test.txt", "abcdefg", 0666);
 }
 
 void test() {
-	struct termios tc;
-	int ret;
-	int fd;
+  struct termios tc;
+  int ret;
+  int fd;
 
-	fd = open("test.txt", O_RDONLY);
+  fd = open("test.txt", O_RDONLY);
 
-	ret = tcgetattr(fd, &tc);
-	assert(ret == -1);
-	assert(errno = ENOTTY);
+  ret = tcgetattr(fd, &tc);
+  assert(ret == -1);
+  assert(errno == ENOTTY);
 
-	ret = tcgetattr(STDIN_FILENO, &tc);
-	assert(!ret);
+  ret = tcgetattr(STDIN_FILENO, &tc);
+  assert(!ret);
 
-	ret = tcsetattr(fd, 0, &tc);
-	assert(ret == -1);
-	assert(errno = ENOTTY);
+  ret = tcsetattr(fd, 0, &tc);
+  assert(ret == -1);
+  assert(errno == ENOTTY);
 
-	ret = tcsetattr(STDIN_FILENO, 0, &tc);
-	assert(!ret);
+  ret = tcsetattr(STDIN_FILENO, 0, &tc);
+  assert(!ret);
 
-	close(fd);
+  close(fd);
 
-	puts("success");
+  puts("success");
 }
 
 int main() {
-  atexit(cleanup);
-  signal(SIGABRT, cleanup);
   setup();
   test();
-  return EXIT_SUCCESS;
+  return 0;
 }

--- a/test/unistd/unlink.c
+++ b/test/unistd/unlink.c
@@ -10,7 +10,6 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -57,26 +56,6 @@ void setup() {
   chmod("file-readonly", 0555);
   mkdir("dir-full", 0777);
   create_file("dir-full/anotherfile", "test", 0777);
-}
-
-void cleanup() {
-  unlink("file");
-  unlink("file1");
-#ifndef NO_SYMLINK
-  unlink("file1-link");
-#endif
-  rmdir("dir-empty");
-#ifndef NO_SYMLINK
-  unlink("dir-empty-link");
-#endif
-  chmod("dir-readonly", 0777);
-  chmod("file-readonly", 0777);
-  unlink("file-readonly");
-  unlink("dir-readonly/anotherfile");
-  rmdir("dir-readonly/anotherdir");
-  rmdir("dir-readonly");
-  unlink("dir-full/anotherfile");
-  rmdir("dir-full");
 }
 
 void test() {
@@ -201,10 +180,8 @@ void test() {
 }
 
 int main() {
-  atexit(cleanup);
-  signal(SIGABRT, cleanup);
   setup();
   test();
 
-  return EXIT_SUCCESS;
+  return 0;
 }

--- a/test/utime/test_utime.c
+++ b/test/utime/test_utime.c
@@ -22,11 +22,6 @@ void setup() {
   mkdir("unwriteable", 0111);
 }
 
-void cleanup() {
-  rmdir("writeable");
-  rmdir("unwriteable");
-}
-
 void test() {
   struct stat s;
   // currently, the most recent timestamp is shared for atime,
@@ -73,9 +68,7 @@ void test() {
 }
 
 int main() {
-  atexit(cleanup);
-  signal(SIGABRT, cleanup);
   setup();
   test();
-  return EXIT_SUCCESS;
+  return 0;
 }


### PR DESCRIPTION
When running tests in emscripten there is no requirement to clean up after yourself.  The test framework automatically gives each test a clean directory to work in.

In fact, cleaning up after yourself like this makes debugging harder because in the failure case you can no longer see the state of the filesystem at the point of failure.

In addition, it meant that all these tests were also relying on and testing `atexit` and `signal` handling, making the tests more complex that less precise.

As part of this change I also made sure all these tests could be compiled outside of emscripten (on my desktop linux machine).