### PR TITLE
Remove redundant __syscall_symlink. NFC

### DIFF
--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -273,7 +273,6 @@ sigs = {
   __syscall_socket__sig: 'iiiiiii',
   __syscall_stat64__sig: 'ipp',
   __syscall_statfs64__sig: 'ippp',
-  __syscall_symlink__sig: 'ipp',
   __syscall_symlinkat__sig: 'ipip',
   __syscall_truncate64__sig: 'ipj',
   __syscall_unlinkat__sig: 'iipi',

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -300,12 +300,6 @@ var SyscallsLibrary = {
     }
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },
-  __syscall_symlink: (target, linkpath) => {
-    target = SYSCALLS.getStr(target);
-    linkpath = SYSCALLS.getStr(linkpath);
-    FS.symlink(target, linkpath);
-    return 0;
-  },
   __syscall_fchmod: (fd, mode) => {
     FS.fchmod(fd, mode);
     return 0;
@@ -830,9 +824,6 @@ var SyscallsLibrary = {
     return FS.open(path, flags, mode).fd;
   },
   __syscall_mkdirat: (dirfd, path, mode) => {
-#if SYSCALL_DEBUG
-    dbg('warning: untested syscall');
-#endif
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);
     // remove a trailing slash, if one - /a/b/ has basename of '', but
@@ -843,9 +834,6 @@ var SyscallsLibrary = {
     return 0;
   },
   __syscall_mknodat: (dirfd, path, mode, dev) => {
-#if SYSCALL_DEBUG
-    dbg('warning: untested syscall');
-#endif
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);
     // we don't want this in the JS API as it uses mknod to create all nodes.
@@ -862,9 +850,6 @@ var SyscallsLibrary = {
     return 0;
   },
   __syscall_fchownat: (dirfd, path, owner, group, flags) => {
-#if SYSCALL_DEBUG
-    dbg('warning: untested syscall');
-#endif
     path = SYSCALLS.getStr(path);
     var nofollow = flags & {{{ cDefs.AT_SYMLINK_NOFOLLOW }}};
     flags = flags & (~{{{ cDefs.AT_SYMLINK_NOFOLLOW }}});
@@ -906,11 +891,10 @@ var SyscallsLibrary = {
     FS.rename(oldpath, newpath);
     return 0;
   },
-  __syscall_symlinkat: (target, newdirfd, linkpath) => {
-#if SYSCALL_DEBUG
-    dbg('warning: untested syscall');
-#endif
-    linkpath = SYSCALLS.calculateAt(newdirfd, linkpath);
+  __syscall_symlinkat: (target, dirfd, linkpath) => {
+    target = SYSCALLS.getStr(target);
+    linkpath = SYSCALLS.getStr(linkpath);
+    linkpath = SYSCALLS.calculateAt(dirfd, linkpath);
     FS.symlink(target, linkpath);
     return 0;
   },
@@ -937,9 +921,6 @@ var SyscallsLibrary = {
     return 0;
   },
   __syscall_faccessat: (dirfd, path, amode, flags) => {
-#if SYSCALL_DEBUG
-    dbg('warning: untested syscall');
-#endif
     path = SYSCALLS.getStr(path);
 #if ASSERTIONS
     assert(flags === 0 || flags == {{{ cDefs.AT_EACCESS }}});

--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h
@@ -14,7 +14,6 @@
 #define SYS_setsid		 __syscall_setsid
 #define SYS_setrlimit		 __syscall_setrlimit
 #define SYS_getrusage		 __syscall_getrusage
-#define SYS_symlink		 __syscall_symlink
 #define SYS_munmap		 __syscall_munmap
 #define SYS_fchmod		 __syscall_fchmod
 #define SYS_getpriority	 __syscall_getpriority

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -31,7 +31,6 @@ int __syscall_getpgrp(void);
 int __syscall_setsid(void);
 int __syscall_setrlimit(int resource, intptr_t limit);
 int __syscall_getrusage(int who, intptr_t usage);
-int __syscall_symlink(intptr_t target, intptr_t linkpath);
 int __syscall_munmap(intptr_t addr, size_t len);
 int __syscall_fchmod(int fd, int mode);
 int __syscall_getpriority(int which, int who);

--- a/system/lib/wasmfs/js_api.cpp
+++ b/system/lib/wasmfs/js_api.cpp
@@ -151,7 +151,7 @@ int _wasmfs_unlink(char* path) {
 int _wasmfs_chdir(char* path) { return __syscall_chdir((intptr_t)path); }
 
 int _wasmfs_symlink(char* old_path, char* new_path) {
-  return __syscall_symlink((intptr_t)old_path, (intptr_t)new_path);
+  return __syscall_symlinkat((intptr_t)old_path, AT_FDCWD, (intptr_t)new_path);
 }
 
 intptr_t _wasmfs_readlink(char* path) {

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1095,10 +1095,6 @@ int __syscall_symlinkat(intptr_t target, int newdirfd, intptr_t linkpath) {
   return 0;
 }
 
-int __syscall_symlink(intptr_t target, intptr_t linkpath) {
-  return __syscall_symlinkat(target, AT_FDCWD, linkpath);
-}
-
 // TODO: Test this with non-AT_FDCWD values.
 int __syscall_readlinkat(int dirfd,
                          intptr_t path,


### PR DESCRIPTION
We have `__syscall_symlinkat` so there is no need to also define `__syscall_symlink`.  Also, remove the warnings from these `at` syscalls which are actually tested these days.