### PR TITLE
Skip test_stat_chmod_rawfs on windows. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5592,9 +5592,12 @@ got: 10
   def test_fstatat(self):
     self.do_runf('stat/test_fstatat.c', 'success')
 
+  @crossplatform
   @also_with_wasmfs
   @also_with_noderawfs
   def test_stat_chmod(self):
+    if self.get_setting('NODERAWFS') and WINDOWS:
+      self.skipTest('mode bits work differently on windows')
     if self.get_setting('WASMFS') and self.get_setting('NODERAWFS'):
       self.skipTest('test requires symlink creation which currently missing from wasmfs+noderawfs')
     self.do_runf('stat/test_chmod.c', 'success')


### PR DESCRIPTION
This test depends on separate R/W/X permission bits that windows lacks.

Followup to #23004