### PR TITLE
[tsgen] Ignore checking library types when generating TS definitions.

### DIFF
--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -649,7 +649,11 @@ def create_tsd_exported_runtime_methods(metadata):
     tsc = [tsc]
   else:
     tsc = shared.get_npm_cmd('tsc')
-  cmd = tsc + ['--outFile', tsc_output_file, '--declaration', '--emitDeclarationOnly', '--allowJs', js_doc_file]
+  cmd = tsc + ['--outFile', tsc_output_file,
+               '--skipLibCheck', # Avoid checking any of the user's types e.g. node_modules/@types.
+               '--declaration',
+               '--emitDeclarationOnly',
+               '--allowJs', js_doc_file]
   shared.check_call(cmd, cwd=path_from_root())
   return utils.read_file(tsc_output_file)
 


### PR DESCRIPTION
We don't need to validate other types when generating definitions since they may be in bad state.

Fixes #22996