### PR TITLE
Fix data address exports under `-sMAIN_MODULE=1`

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -4435,6 +4435,27 @@ res64 - external 64\n''', header='''\
       int x = 123;
     ''', expected=['extern is 123.\n'], force_c=True)
 
+  @needs_dylink
+  def test_dylink_global_var_export(self):
+    self.do_run(r'''
+      #include <assert.h>
+      #include <stdio.h>
+      #include <emscripten.h>
+      #include <emscripten/em_asm.h>
+
+      EMSCRIPTEN_KEEPALIVE int my_number = 123456;
+
+      int main(void) {
+        void* js_address = EM_ASM_PTR({
+          console.log("JS:_my_number:", _my_number, HEAP32[_my_number/4]);
+          return _my_number;
+        });
+        printf("C: my_number: %ld %d\n", (long)&my_number, my_number);
+        assert(js_address == &my_number);
+        return 0;
+      }
+    ''', emcc_args=['-sMAIN_MODULE'], force_c=True)
+
   @with_dylink_reversed
   def test_dylink_global_var_modded(self):
     self.dylink_test(main=r'''

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -441,7 +441,9 @@ def emscript(in_wasm, out_wasm, outfile_js, js_syms, finalize=True, base_metadat
 
   if base_metadata:
     function_exports = base_metadata.function_exports
-    global_exports = base_metadata.global_exports
+    # We want the real values from the final metadata but we only want to
+    # include names from the base_metadata.  See phase_link() in link.py.
+    global_exports = {k: v for k, v in metadata.global_exports.items() if k in base_metadata.global_exports}
   else:
     function_exports = metadata.function_exports
     global_exports = metadata.global_exports


### PR DESCRIPTION
In `-sMAIN_MODULE=1` mode we actually link twice, once to get the names the user exported symbols then again with everything exported.

We when use the this `base_metadata` to limit the things that we export to on the JS module.  However for data symbols we cannot use the addresses/values present in `base_metadata`.

Fixes: #22980