### PR TITLE
Use preset to set doesNotExistError instead of postset. NFC

### DIFF
--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -7,7 +7,7 @@
 addToLibrary({
   $MEMFS__deps: ['$FS', '$mmapAlloc'],
 #if !ASSERTIONS
-  $MEMFS__postset: `
+  $MEMFS__preset: `
     // This error may happen quite a bit. To avoid overhead we reuse it (and
     // suffer a lack of stack info).
     MEMFS.doesNotExistError = new FS.ErrnoError({{{ cDefs.ENOENT }}});


### PR DESCRIPTION
Sometimes we throw `MEMFS.doesNotExistError` before it is initialized. It doesn't really matter because the `undefined` we throw gets caught and thrown away, but it seems better to fix.