### PR TITLE
Fix typos discovered by codespell in the `tools` directory 

### DIFF
--- a/tools/acorn-optimizer.mjs
+++ b/tools/acorn-optimizer.mjs
@@ -397,7 +397,7 @@ function JSDCE(ast, aggressive) {
               if (elem) traverse(elem);
             }
           } else {
-            assertAt(id.type === 'Identifier', id, `expected Indentifier but found ${id.type}`);
+            assertAt(id.type === 'Identifier', id, `expected Identifier but found ${id.type}`);
             const name = id.name;
             ensureData(scopes[scopes.length - 1], name).def = 1;
           }
@@ -862,7 +862,7 @@ function emitDCEGraph(ast) {
   // must find the info we need
   assert(
     foundWasmImportsAssign,
-    'could not find the assigment to "wasmImports". perhaps --pre-js or --post-js code moved it out of the global scope? (things like that should be done after emcc runs, as they do not need to be run through the optimizer which is the special thing about --pre-js/--post-js code)',
+    'could not find the assignment to "wasmImports". perhaps --pre-js or --post-js code moved it out of the global scope? (things like that should be done after emcc runs, as they do not need to be run through the optimizer which is the special thing about --pre-js/--post-js code)',
   );
   // Read exports that were declared in extraInfo
   if (extraInfo) {
@@ -932,7 +932,7 @@ function emitDCEGraph(ast) {
           if (infos[reached]) {
             infos[reached].root = true; // in global scope, root it
           } else {
-            // An info might not exist for the identifer if it is missing, for
+            // An info might not exist for the identifier if it is missing, for
             // example, we might call Module.dynCall_vi in library code, but it
             // won't exist in a standalone (non-JS) build anyhow. We can ignore
             // it in that case as the JS won't be used, but warn to be safe.

--- a/tools/create_dom_pk_codes.py
+++ b/tools/create_dom_pk_codes.py
@@ -239,7 +239,7 @@ def hash_all(k1, k2):
   return (hashes, str_to_hash)
 
 
-# Find an approprite hash function that is collision free within the set of all input strings
+# Find an appropriate hash function that is collision free within the set of all input strings
 # Try hash function format h_i = ((h_(i-1) ^ k_1) << k_2) ^ s_i, where h_i is the hash function
 # value at step i, k_1 and k_2 are the constants we are searching, and s_i is the i'th input
 # character

--- a/tools/emdwp.py
+++ b/tools/emdwp.py
@@ -4,7 +4,7 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-"""Wrapper scripte around `llvm-dwp`.
+"""Wrapper script around `llvm-dwp`.
 """
 
 import sys

--- a/tools/emnm.py
+++ b/tools/emnm.py
@@ -4,7 +4,7 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-"""Wrapper scripte around `llvm-nm`.
+"""Wrapper script around `llvm-nm`.
 """
 
 import os

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -620,7 +620,7 @@ def finalize_wasm(infile, outfile, js_syms):
 
 
 def create_tsd_exported_runtime_methods(metadata):
-  # Use the TypeScript compiler to generate defintions for all of the runtime
+  # Use the TypeScript compiler to generate definitions for all of the runtime
   # exports. The JS from the library any JS docs are included in the file used
   # for generation.
   js_doc = 'var RuntimeExports = {};\n'
@@ -660,7 +660,7 @@ def create_tsd(metadata, embind_tsd):
   out = '// TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.\n'
   if settings.EXPORTED_RUNTIME_METHODS:
     out += create_tsd_exported_runtime_methods(metadata)
-  # Manually generate defintions for any Wasm function exports.
+  # Manually generate definitions for any Wasm function exports.
   out += 'interface WasmModule {\n'
   for name, functype in metadata.function_exports.items():
     mangled = asmjs_mangle(name)
@@ -683,7 +683,7 @@ def create_tsd(metadata, embind_tsd):
   export_interfaces = 'WasmModule'
   if settings.EXPORTED_RUNTIME_METHODS:
     export_interfaces += ' & typeof RuntimeExports'
-  # Add in embind defintions.
+  # Add in embind definitions.
   if embind_tsd:
     export_interfaces += ' & EmbindModule'
   out += f'export type MainModule = {export_interfaces};\n'

--- a/tools/experimental/reproduceriter.py
+++ b/tools/experimental/reproduceriter.py
@@ -96,7 +96,7 @@ Examples
    make a browser build, record a trace, then make a shell build and copy the trace
    there so you can run it.
 
-   The last parameter specifies what to do when the event loop is idle: We fire an event and then set onIdle (which was this function) to null, so this is a one-time occurence.
+   The last parameter specifies what to do when the event loop is idle: We fire an event and then set onIdle (which was this function) to null, so this is a one-time occurrence.
 
 Notes
 

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -501,7 +501,7 @@ def main():
         err('Error: Embedding "%s" which is not contained within the current directory '
             '"%s".  This is invalid since the current directory becomes the '
             'root that the generated code will see.  To include files outside of the current '
-            'working directoty you can use the `--preload-file srcpath@dstpath` syntax to '
+            'working directory you can use the `--preload-file srcpath@dstpath` syntax to '
             'explicitly specify the target location.' % (path, curr_abspath))
         sys.exit(1)
       file_.dstpath = abspath[len(curr_abspath) + 1:]
@@ -702,7 +702,7 @@ def generate_js(data_target, data_files, metadata):
       }\n''' % (create_preloaded if options.use_preload_plugins else create_data)
 
   if options.has_embedded and not options.obj_output:
-    err('--obj-output is recommended when using --embed.  This outputs an object file for linking directly into your application is more effecient than JS encoding')
+    err('--obj-output is recommended when using --embed.  This outputs an object file for linking directly into your application is more efficient than JS encoding')
 
   for counter, file_ in enumerate(data_files):
     filename = file_.dstpath

--- a/tools/filelock.py
+++ b/tools/filelock.py
@@ -301,7 +301,7 @@ class BaseFileLock:
         """
         Releases the file lock.
 
-        Please note, that the lock is only completly released, if the lock
+        Please note, that the lock is only completely released, if the lock
         counter is 0.
 
         Also note, that the lock file itself is not automatically deleted.

--- a/tools/line_endings.py
+++ b/tools/line_endings.py
@@ -26,7 +26,7 @@ def convert_line_endings_in_file(filename, from_eol, to_eol):
 
 
 def check_line_endings(filename, expect_only=None, print_errors=True, print_info=False):
-  """Detect inconsitent/invalid line endings.
+  """Detect inconsistent/invalid line endings.
 
   This function checks and prints out the detected line endings in the given
   file. If the file only contains either Windows \\r\\n line endings or Unix \\n

--- a/tools/link.py
+++ b/tools/link.py
@@ -590,7 +590,7 @@ def set_max_memory():
     if initial_memory_known:
       settings.MAXIMUM_MEMORY = settings.INITIAL_MEMORY
 
-  # Automaticaly up the default maximum when the user requested a large minimum.
+  # Automatically up the default maximum when the user requested a large minimum.
   if 'MAXIMUM_MEMORY' not in user_settings:
     if settings.ALLOW_MEMORY_GROWTH:
       if any([settings.INITIAL_HEAP != -1 and settings.INITIAL_HEAP >= 2 * 1024 * 1024 * 1024,
@@ -667,7 +667,7 @@ def phase_linker_setup(options, state, newargs):
     options.post_js.append(utils.path_from_root('src/cpuprofiler.js'))
 
   # Unless RUNTIME_DEBUG is explicitly set then we enable it when any of the
-  # more specfic debug settings are present.
+  # more specific debug settings are present.
   default_setting('RUNTIME_DEBUG', int(settings.LIBRARY_DEBUG or
                                        settings.GL_DEBUG or
                                        settings.DYLINK_DEBUG or
@@ -1934,7 +1934,7 @@ def phase_emscript(in_wasm, wasm_target, js_syms, base_metadata):
   # Emscripten
   logger.debug('emscript')
 
-  # No need to support base64 embeddeding in wasm2js mode since
+  # No need to support base64 embedding in wasm2js mode since
   # the module is already in JS format.
   settings.SUPPORT_BASE64_EMBEDDING = settings.SINGLE_FILE and not settings.WASM2JS
 

--- a/tools/maint/README.md
+++ b/tools/maint/README.md
@@ -1,5 +1,5 @@
 Maintenance Scripts for Emscripten Developers
 =============================================
 
-This directory contains maintentance scripts used by emscripten developers.  For
+This directory contains maintenance scripts used by emscripten developers.  For
 more information see the comments at the top of each script.

--- a/tools/maint/check_for_unused_test_files.py
+++ b/tools/maint/check_for_unused_test_files.py
@@ -81,7 +81,7 @@ def check_file(dirpath, filename):
     if ext == '.json' and grep("'" + os.path.basename(stem) + "'"):
       return
 
-  # test_asan builds it pathnames programatically based on the basename, so just
+  # test_asan builds it pathnames programmatically based on the basename, so just
   # search for the basename.
   if filename.startswith('test_asan_'):
     relpath = os.path.basename(relpath)

--- a/tools/maint/gen_sig_info.py
+++ b/tools/maint/gen_sig_info.py
@@ -374,8 +374,8 @@ def extract_sig_info(sig_info, extra_settings=None, extra_cflags=None, cxx=False
 def main(args):
   parser = argparse.ArgumentParser()
   parser.add_argument('-o', '--output', default='src/library_sigs.js')
-  parser.add_argument('-r', '--remove', action='store_true', help='remove from JS library files any `__sig` entires that are part of the auto-generated file')
-  parser.add_argument('-u', '--update', action='store_true', help='update with JS library files any `__sig` entires that are part of the auto-generated file')
+  parser.add_argument('-r', '--remove', action='store_true', help='remove from JS library files any `__sig` entries that are part of the auto-generated file')
+  parser.add_argument('-u', '--update', action='store_true', help='update with JS library files any `__sig` entries that are part of the auto-generated file')
   args = parser.parse_args()
 
   print('generating signatures ...')

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -153,7 +153,7 @@ class Ports:
 
   @staticmethod
   def install_header_dir(src_dir, target=None):
-    """Like install_headers but recusively copied all files in a directory"""
+    """Like install_headers but recursively copied all files in a directory"""
     if not target:
       target = os.path.basename(src_dir)
     dest = Ports.get_include_dir(target)
@@ -404,7 +404,7 @@ def dependency_order(port_list):
   # Perform topological sort of ports according to the dependency DAG
   port_map = {p.name: p for p in port_list}
 
-  # Perform depth first search of dependecy graph adding nodes to
+  # Perform depth first search of dependency graph adding nodes to
   # the stack only after all children have been explored.
   stack = []
   unsorted = OrderedSet(port_list)

--- a/tools/ports/mpg123.py
+++ b/tools/ports/mpg123.py
@@ -115,10 +115,10 @@ config_h = r'''/* src/config.h.  Generated from config.h.in by configure.  */
 /* The default audio output module(s) to use */
 #define DEFAULT_OUTPUT_MODULE "sdl"
 
-/* Define if building with dynamcally linked libmpg123 */
+/* Define if building with dynamically linked libmpg123 */
 /* #undef DYNAMIC_BUILD */
 
-/* Use EFBIG as substitude for EOVERFLOW, mingw.org may lack the latter */
+/* Use EFBIG as substitute for EOVERFLOW, mingw.org may lack the latter */
 /* #undef EOVERFLOW */
 
 /* Define if FIFO support is enabled. */
@@ -842,7 +842,7 @@ enum mpg123_param_flags
 	 */
 	,MPG123_FORCE_SEEKABLE = 0x40000 /**< 19th bit: Force the stream to be seekable. */
 	,MPG123_STORE_RAW_ID3  = 0x80000 /**< store raw ID3 data (even if skipping) */
-	,MPG123_FORCE_ENDIAN   = 0x100000 /**< Enforce endianess of output samples.
+	,MPG123_FORCE_ENDIAN   = 0x100000 /**< Enforce endianness of output samples.
 	 *  This is not reflected in the format codes. If this flag is set along with
 	 *  MPG123_BIG_ENDIAN, MPG123_ENC_SIGNED16 means s16be, without
 	 *  MPG123_BIG_ENDIAN, it means s16le. Normal operation without
@@ -983,7 +983,7 @@ MPG123_EXPORT int mpg123_feature2(int key);
 enum mpg123_errors
 {
 	MPG123_DONE=-12,	/**< Message: Track ended. Stop decoding. */
-	MPG123_NEW_FORMAT=-11,	/**< Message: Output format will be different on next call. Note that some libmpg123 versions between 1.4.3 and 1.8.0 insist on you calling mpg123_getformat() after getting this message code. Newer verisons behave like advertised: You have the chance to call mpg123_getformat(), but you can also just continue decoding and get your data. */
+	MPG123_NEW_FORMAT=-11,	/**< Message: Output format will be different on next call. Note that some libmpg123 versions between 1.4.3 and 1.8.0 insist on you calling mpg123_getformat() after getting this message code. Newer versions behave like advertised: You have the chance to call mpg123_getformat(), but you can also just continue decoding and get your data. */
 	MPG123_NEED_MORE=-10,	/**< Message: For feed reader: "Feed me more!" (call mpg123_feed() or mpg123_decode() with some new input data). */
 	MPG123_ERR=-1,			/**< Generic Error */
 	MPG123_OK=0, 			/**< Success */
@@ -1038,7 +1038,7 @@ enum mpg123_errors
  */
 MPG123_EXPORT const char* mpg123_plain_strerror(int errcode);
 
-/** Give string describing what error has occured in the context of handle mh.
+/** Give string describing what error has occurred in the context of handle mh.
  *  When a function operating on an mpg123 handle returns MPG123_ERR, you should check for the actual reason via
  *  char *errmsg = mpg123_strerror(mh)
  *  This function will catch mh == NULL and return the message for MPG123_BAD_HANDLE.
@@ -1047,7 +1047,7 @@ MPG123_EXPORT const char* mpg123_plain_strerror(int errcode);
  */
 MPG123_EXPORT const char* mpg123_strerror(mpg123_handle *mh);
 
-/** Return the plain errcode intead of a string.
+/** Return the plain errcode instead of a string.
  *  \param mh handle
  *  \return error code recorded in handle or MPG123_BAD_HANDLE
  */
@@ -1082,7 +1082,7 @@ MPG123_EXPORT const char **mpg123_supported_decoders(void);
 MPG123_EXPORT int mpg123_decoder(mpg123_handle *mh, const char* decoder_name);
 
 /** Get the currently active decoder name.
- *  The active decoder engine can vary depening on output constraints,
+ *  The active decoder engine can vary depending on output constraints,
  *  mostly non-resampling, integer output is accelerated via 3DNow & Co. but for
  *  other modes a fallback engine kicks in.
  *  Note that this can return a decoder that is only active in the hidden and not
@@ -1108,7 +1108,7 @@ MPG123_EXPORT const char* mpg123_current_decoder(mpg123_handle *mh);
  *
  * The mpg123 library decides what output format to use when encountering the first frame in a stream, or actually any frame that is still valid but differs from the frames before in the prompted output format. At such a deciding point, an internal table of allowed encodings, sampling rates and channel setups is consulted. According to this table, an output format is chosen and the decoding engine set up accordingly (including optimized routines for different output formats). This might seem unusual but it just follows from the non-existence of "MPEG audio files" with defined overall properties. There are streams, streams are concatenations of (semi) independent frames. We store streams on disk and call them "MPEG audio files", but that does not change their nature as the decoder is concerned (the LAME/Xing header for gapless decoding makes things interesting again).
  *
- * To get to the point: What you do with mpg123_format() and friends is to fill the internal table of allowed formats before it is used. That includes removing support for some formats or adding your forced sample rate (see MPG123_FORCE_RATE) that will be used with the crude internal resampler. Also keep in mind that the sample encoding is just a question of choice -- the MPEG frames do only indicate their native sampling rate and channel count. If you want to decode to integer or float samples, 8 or 16 bit ... that is your decision. In a "clean" world, libmpg123 would always decode to 32 bit float and let you handle any sample conversion. But there are optimized routines that work faster by directly decoding to the desired encoding / accuracy. We prefer efficiency over conceptual tidyness.
+ * To get to the point: What you do with mpg123_format() and friends is to fill the internal table of allowed formats before it is used. That includes removing support for some formats or adding your forced sample rate (see MPG123_FORCE_RATE) that will be used with the crude internal resampler. Also keep in mind that the sample encoding is just a question of choice -- the MPEG frames do only indicate their native sampling rate and channel count. If you want to decode to integer or float samples, 8 or 16 bit ... that is your decision. In a "clean" world, libmpg123 would always decode to 32 bit float and let you handle any sample conversion. But there are optimized routines that work faster by directly decoding to the desired encoding / accuracy. We prefer efficiency over conceptual tidiness.
  *
  * People often start out thinking that mpg123_format() should change the actual decoding format on the fly. That is wrong. It only has effect on the next natural change of output format, when libmpg123 will consult its format table again. To make life easier, you might want to call mpg123_format_none() before any thing else and then just allow one desired encoding and a limited set of sample rates / channel choices that you actually intend to deal with. You can force libmpg123 to decode everything to 44100 KHz, stereo, 16 bit integer ... it will duplicate mono channels and even do resampling if needed (unless that feature is disabled in the build, same with some encodings). But I have to stress that the resampling of libmpg123 is very crude and doesn't even contain any kind of "proper" interpolation.
  *
@@ -1249,7 +1249,7 @@ MPG123_EXPORT int mpg123_getformat2( mpg123_handle *mh
  *  MPEG files. You could set MPG123_FORCE_RATE beforehand, but that may trigger
  *  low-quality resampling in the decoder, only do so if in dire need.
  *  The library will convert mono files to stereo for you, and vice versa.
- *  If any constraint cannot be satisified (most likely because of a non-default
+ *  If any constraint cannot be satisfied (most likely because of a non-default
  *  build of libmpg123), you get MPG123_ERR returned and can query the detailed
  *  cause from the handle. Only on MPG123_OK there will an open file that you
  *  then close using mpg123_close(), or implicitly on mpg123_delete() or the next
@@ -1463,7 +1463,7 @@ MPG123_EXPORT off_t mpg123_tellframe(mpg123_handle *mh);
 MPG123_EXPORT off_t mpg123_tell_stream(mpg123_handle *mh);
 
 /** Seek to a desired sample offset.
- *  Usage is modelled afer the standard lseek().
+ *  Usage is modelled after the standard lseek().
  * \param mh handle
  * \param sampleoff offset in PCM samples
  * \param whence one of SEEK_SET, SEEK_CUR or SEEK_END
@@ -1484,7 +1484,7 @@ MPG123_EXPORT off_t mpg123_feedseek( mpg123_handle *mh
 ,	off_t sampleoff, int whence, off_t *input_offset );
 
 /** Seek to a desired MPEG frame offset.
- *  Usage is modelled afer the standard lseek().
+ *  Usage is modelled after the standard lseek().
  * \param mh handle
  * \param frameoff offset in MPEG frames
  * \param whence one of SEEK_SET, SEEK_CUR or SEEK_END
@@ -1762,8 +1762,8 @@ MPG123_EXPORT long mpg123_clip(mpg123_handle *mh);
 /** The key values for state information from mpg123_getstate(). */
 enum mpg123_state
 {
-	 MPG123_ACCURATE = 1 /**< Query if positons are currently accurate (integer value, 0 if false, 1 if true). */
-	,MPG123_BUFFERFILL   /**< Get fill of internal (feed) input buffer as integer byte count returned as long and as double. An error is returned on integer overflow while converting to (signed) long, but the returned floating point value shold still be fine. */
+	 MPG123_ACCURATE = 1 /**< Query if positions are currently accurate (integer value, 0 if false, 1 if true). */
+	,MPG123_BUFFERFILL   /**< Get fill of internal (feed) input buffer as integer byte count returned as long and as double. An error is returned on integer overflow while converting to (signed) long, but the returned floating point value should still be fine. */
 	,MPG123_FRANKENSTEIN /**< Stream consists of carelessly stitched together files. Seeking may yield unexpected results (also with MPG123_ACCURATE, it may be confused). */
 	,MPG123_FRESH_DECODER /**< Decoder structure has been updated, possibly indicating changed stream (integer value, 0 if false, 1 if true). Flag is cleared after retrieval. */
 	,MPG123_ENC_DELAY /** Encoder delay read from Info tag (layer III, -1 if unknown). */
@@ -1801,7 +1801,7 @@ typedef struct
 	size_t fill; /**< number of used bytes (including closing zero byte) */
 } mpg123_string;
 
-/** Allocate and intialize a new string.
+/** Allocate and initialize a new string.
  *  \param val optional initial string value (can be NULL)
  */
 MPG123_EXPORT mpg123_string* mpg123_new_string(const char* val);
@@ -1927,7 +1927,7 @@ MPG123_EXPORT int mpg123_same_string(mpg123_string *a, mpg123_string *b);
 /** The mpg123 text encodings. This contains encodings we encounter in ID3 tags or ICY meta info. */
 enum mpg123_text_encoding
 {
-	 mpg123_text_unknown  = 0 /**< Unkown encoding... mpg123_id3_encoding can return that on invalid codes. */
+	 mpg123_text_unknown  = 0 /**< Unknown encoding... mpg123_id3_encoding can return that on invalid codes. */
 	,mpg123_text_utf8     = 1 /**< UTF-8 */
 	,mpg123_text_latin1   = 2 /**< ISO-8859-1. Note that sometimes latin1 in ID3 is abused for totally different encodings. */
 	,mpg123_text_icy      = 3 /**< ICY metadata encoding, usually CP-1252 but we take it as UTF-8 if it qualifies as such. */
@@ -2040,11 +2040,11 @@ typedef struct
 	mpg123_string *genre;   /**< Genre String (pointer into text_list). The genre string(s) may very well need postprocessing, esp. for ID3v2.3. */
 	mpg123_string *comment; /**< Pointer to last encountered comment text with empty description. */
 	/* Encountered ID3v2 fields are appended to these lists.
-	   There can be multiple occurences, the pointers above always point to the last encountered data. */
+	   There can be multiple occurrences, the pointers above always point to the last encountered data. */
 	mpg123_text    *comment_list; /**< Array of comments. */
 	size_t          comments;     /**< Number of comments. */
 	mpg123_text    *text;         /**< Array of ID3v2 text fields (including USLT) */
-	size_t          texts;        /**< Numer of text fields. */
+	size_t          texts;        /**< Number of text fields. */
 	mpg123_text    *extra;        /**< The array of extra (TXXX) fields. */
 	size_t          extras;       /**< Number of extra text (TXXX) fields. */
 	mpg123_picture  *picture;     /**< Array of ID3v2 pictures fields (APIC).
@@ -2083,7 +2083,7 @@ MPG123_EXPORT int mpg123_meta_check(mpg123_handle *mh);
  */
 MPG123_EXPORT void mpg123_meta_free(mpg123_handle *mh);
 
-/** Point v1 and v2 to existing data structures wich may change on any next read/decode function call.
+/** Point v1 and v2 to existing data structures which may change on any next read/decode function call.
  *  v1 and/or v2 can be set to NULL when there is no corresponding data.
  *  \return MPG123_OK on success
  */
@@ -2105,7 +2105,7 @@ MPG123_EXPORT int mpg123_id3_raw( mpg123_handle *mh
 ,	unsigned char **v1, size_t *v1_size
 ,	unsigned char **v2, size_t *v2_size );
 
-/** Point icy_meta to existing data structure wich may change on any next read/decode function call.
+/** Point icy_meta to existing data structure which may change on any next read/decode function call.
  *  \param mh handle
  *  \param icy_meta return address for ICY meta string (set to NULL if nothing there)
  *  \return MPG123_OK on success

--- a/tools/ports/mpg123.py
+++ b/tools/ports/mpg123.py
@@ -115,10 +115,10 @@ config_h = r'''/* src/config.h.  Generated from config.h.in by configure.  */
 /* The default audio output module(s) to use */
 #define DEFAULT_OUTPUT_MODULE "sdl"
 
-/* Define if building with dynamically linked libmpg123 */
+/* Define if building with dynamcally linked libmpg123 */
 /* #undef DYNAMIC_BUILD */
 
-/* Use EFBIG as substitute for EOVERFLOW, mingw.org may lack the latter */
+/* Use EFBIG as substitude for EOVERFLOW, mingw.org may lack the latter */
 /* #undef EOVERFLOW */
 
 /* Define if FIFO support is enabled. */
@@ -842,7 +842,7 @@ enum mpg123_param_flags
 	 */
 	,MPG123_FORCE_SEEKABLE = 0x40000 /**< 19th bit: Force the stream to be seekable. */
 	,MPG123_STORE_RAW_ID3  = 0x80000 /**< store raw ID3 data (even if skipping) */
-	,MPG123_FORCE_ENDIAN   = 0x100000 /**< Enforce endianness of output samples.
+	,MPG123_FORCE_ENDIAN   = 0x100000 /**< Enforce endianess of output samples.
 	 *  This is not reflected in the format codes. If this flag is set along with
 	 *  MPG123_BIG_ENDIAN, MPG123_ENC_SIGNED16 means s16be, without
 	 *  MPG123_BIG_ENDIAN, it means s16le. Normal operation without
@@ -983,7 +983,7 @@ MPG123_EXPORT int mpg123_feature2(int key);
 enum mpg123_errors
 {
 	MPG123_DONE=-12,	/**< Message: Track ended. Stop decoding. */
-	MPG123_NEW_FORMAT=-11,	/**< Message: Output format will be different on next call. Note that some libmpg123 versions between 1.4.3 and 1.8.0 insist on you calling mpg123_getformat() after getting this message code. Newer versions behave like advertised: You have the chance to call mpg123_getformat(), but you can also just continue decoding and get your data. */
+	MPG123_NEW_FORMAT=-11,	/**< Message: Output format will be different on next call. Note that some libmpg123 versions between 1.4.3 and 1.8.0 insist on you calling mpg123_getformat() after getting this message code. Newer verisons behave like advertised: You have the chance to call mpg123_getformat(), but you can also just continue decoding and get your data. */
 	MPG123_NEED_MORE=-10,	/**< Message: For feed reader: "Feed me more!" (call mpg123_feed() or mpg123_decode() with some new input data). */
 	MPG123_ERR=-1,			/**< Generic Error */
 	MPG123_OK=0, 			/**< Success */
@@ -1038,7 +1038,7 @@ enum mpg123_errors
  */
 MPG123_EXPORT const char* mpg123_plain_strerror(int errcode);
 
-/** Give string describing what error has occurred in the context of handle mh.
+/** Give string describing what error has occured in the context of handle mh.
  *  When a function operating on an mpg123 handle returns MPG123_ERR, you should check for the actual reason via
  *  char *errmsg = mpg123_strerror(mh)
  *  This function will catch mh == NULL and return the message for MPG123_BAD_HANDLE.
@@ -1047,7 +1047,7 @@ MPG123_EXPORT const char* mpg123_plain_strerror(int errcode);
  */
 MPG123_EXPORT const char* mpg123_strerror(mpg123_handle *mh);
 
-/** Return the plain errcode instead of a string.
+/** Return the plain errcode intead of a string.
  *  \param mh handle
  *  \return error code recorded in handle or MPG123_BAD_HANDLE
  */
@@ -1082,7 +1082,7 @@ MPG123_EXPORT const char **mpg123_supported_decoders(void);
 MPG123_EXPORT int mpg123_decoder(mpg123_handle *mh, const char* decoder_name);
 
 /** Get the currently active decoder name.
- *  The active decoder engine can vary depending on output constraints,
+ *  The active decoder engine can vary depening on output constraints,
  *  mostly non-resampling, integer output is accelerated via 3DNow & Co. but for
  *  other modes a fallback engine kicks in.
  *  Note that this can return a decoder that is only active in the hidden and not
@@ -1108,7 +1108,7 @@ MPG123_EXPORT const char* mpg123_current_decoder(mpg123_handle *mh);
  *
  * The mpg123 library decides what output format to use when encountering the first frame in a stream, or actually any frame that is still valid but differs from the frames before in the prompted output format. At such a deciding point, an internal table of allowed encodings, sampling rates and channel setups is consulted. According to this table, an output format is chosen and the decoding engine set up accordingly (including optimized routines for different output formats). This might seem unusual but it just follows from the non-existence of "MPEG audio files" with defined overall properties. There are streams, streams are concatenations of (semi) independent frames. We store streams on disk and call them "MPEG audio files", but that does not change their nature as the decoder is concerned (the LAME/Xing header for gapless decoding makes things interesting again).
  *
- * To get to the point: What you do with mpg123_format() and friends is to fill the internal table of allowed formats before it is used. That includes removing support for some formats or adding your forced sample rate (see MPG123_FORCE_RATE) that will be used with the crude internal resampler. Also keep in mind that the sample encoding is just a question of choice -- the MPEG frames do only indicate their native sampling rate and channel count. If you want to decode to integer or float samples, 8 or 16 bit ... that is your decision. In a "clean" world, libmpg123 would always decode to 32 bit float and let you handle any sample conversion. But there are optimized routines that work faster by directly decoding to the desired encoding / accuracy. We prefer efficiency over conceptual tidiness.
+ * To get to the point: What you do with mpg123_format() and friends is to fill the internal table of allowed formats before it is used. That includes removing support for some formats or adding your forced sample rate (see MPG123_FORCE_RATE) that will be used with the crude internal resampler. Also keep in mind that the sample encoding is just a question of choice -- the MPEG frames do only indicate their native sampling rate and channel count. If you want to decode to integer or float samples, 8 or 16 bit ... that is your decision. In a "clean" world, libmpg123 would always decode to 32 bit float and let you handle any sample conversion. But there are optimized routines that work faster by directly decoding to the desired encoding / accuracy. We prefer efficiency over conceptual tidyness.
  *
  * People often start out thinking that mpg123_format() should change the actual decoding format on the fly. That is wrong. It only has effect on the next natural change of output format, when libmpg123 will consult its format table again. To make life easier, you might want to call mpg123_format_none() before any thing else and then just allow one desired encoding and a limited set of sample rates / channel choices that you actually intend to deal with. You can force libmpg123 to decode everything to 44100 KHz, stereo, 16 bit integer ... it will duplicate mono channels and even do resampling if needed (unless that feature is disabled in the build, same with some encodings). But I have to stress that the resampling of libmpg123 is very crude and doesn't even contain any kind of "proper" interpolation.
  *
@@ -1249,7 +1249,7 @@ MPG123_EXPORT int mpg123_getformat2( mpg123_handle *mh
  *  MPEG files. You could set MPG123_FORCE_RATE beforehand, but that may trigger
  *  low-quality resampling in the decoder, only do so if in dire need.
  *  The library will convert mono files to stereo for you, and vice versa.
- *  If any constraint cannot be satisfied (most likely because of a non-default
+ *  If any constraint cannot be satisified (most likely because of a non-default
  *  build of libmpg123), you get MPG123_ERR returned and can query the detailed
  *  cause from the handle. Only on MPG123_OK there will an open file that you
  *  then close using mpg123_close(), or implicitly on mpg123_delete() or the next
@@ -1463,7 +1463,7 @@ MPG123_EXPORT off_t mpg123_tellframe(mpg123_handle *mh);
 MPG123_EXPORT off_t mpg123_tell_stream(mpg123_handle *mh);
 
 /** Seek to a desired sample offset.
- *  Usage is modelled after the standard lseek().
+ *  Usage is modelled afer the standard lseek().
  * \param mh handle
  * \param sampleoff offset in PCM samples
  * \param whence one of SEEK_SET, SEEK_CUR or SEEK_END
@@ -1484,7 +1484,7 @@ MPG123_EXPORT off_t mpg123_feedseek( mpg123_handle *mh
 ,	off_t sampleoff, int whence, off_t *input_offset );
 
 /** Seek to a desired MPEG frame offset.
- *  Usage is modelled after the standard lseek().
+ *  Usage is modelled afer the standard lseek().
  * \param mh handle
  * \param frameoff offset in MPEG frames
  * \param whence one of SEEK_SET, SEEK_CUR or SEEK_END
@@ -1762,8 +1762,8 @@ MPG123_EXPORT long mpg123_clip(mpg123_handle *mh);
 /** The key values for state information from mpg123_getstate(). */
 enum mpg123_state
 {
-	 MPG123_ACCURATE = 1 /**< Query if positions are currently accurate (integer value, 0 if false, 1 if true). */
-	,MPG123_BUFFERFILL   /**< Get fill of internal (feed) input buffer as integer byte count returned as long and as double. An error is returned on integer overflow while converting to (signed) long, but the returned floating point value should still be fine. */
+	 MPG123_ACCURATE = 1 /**< Query if positons are currently accurate (integer value, 0 if false, 1 if true). */
+	,MPG123_BUFFERFILL   /**< Get fill of internal (feed) input buffer as integer byte count returned as long and as double. An error is returned on integer overflow while converting to (signed) long, but the returned floating point value shold still be fine. */
 	,MPG123_FRANKENSTEIN /**< Stream consists of carelessly stitched together files. Seeking may yield unexpected results (also with MPG123_ACCURATE, it may be confused). */
 	,MPG123_FRESH_DECODER /**< Decoder structure has been updated, possibly indicating changed stream (integer value, 0 if false, 1 if true). Flag is cleared after retrieval. */
 	,MPG123_ENC_DELAY /** Encoder delay read from Info tag (layer III, -1 if unknown). */
@@ -1801,7 +1801,7 @@ typedef struct
 	size_t fill; /**< number of used bytes (including closing zero byte) */
 } mpg123_string;
 
-/** Allocate and initialize a new string.
+/** Allocate and intialize a new string.
  *  \param val optional initial string value (can be NULL)
  */
 MPG123_EXPORT mpg123_string* mpg123_new_string(const char* val);
@@ -1927,7 +1927,7 @@ MPG123_EXPORT int mpg123_same_string(mpg123_string *a, mpg123_string *b);
 /** The mpg123 text encodings. This contains encodings we encounter in ID3 tags or ICY meta info. */
 enum mpg123_text_encoding
 {
-	 mpg123_text_unknown  = 0 /**< Unknown encoding... mpg123_id3_encoding can return that on invalid codes. */
+	 mpg123_text_unknown  = 0 /**< Unkown encoding... mpg123_id3_encoding can return that on invalid codes. */
 	,mpg123_text_utf8     = 1 /**< UTF-8 */
 	,mpg123_text_latin1   = 2 /**< ISO-8859-1. Note that sometimes latin1 in ID3 is abused for totally different encodings. */
 	,mpg123_text_icy      = 3 /**< ICY metadata encoding, usually CP-1252 but we take it as UTF-8 if it qualifies as such. */
@@ -2040,11 +2040,11 @@ typedef struct
 	mpg123_string *genre;   /**< Genre String (pointer into text_list). The genre string(s) may very well need postprocessing, esp. for ID3v2.3. */
 	mpg123_string *comment; /**< Pointer to last encountered comment text with empty description. */
 	/* Encountered ID3v2 fields are appended to these lists.
-	   There can be multiple occurrences, the pointers above always point to the last encountered data. */
+	   There can be multiple occurences, the pointers above always point to the last encountered data. */
 	mpg123_text    *comment_list; /**< Array of comments. */
 	size_t          comments;     /**< Number of comments. */
 	mpg123_text    *text;         /**< Array of ID3v2 text fields (including USLT) */
-	size_t          texts;        /**< Number of text fields. */
+	size_t          texts;        /**< Numer of text fields. */
 	mpg123_text    *extra;        /**< The array of extra (TXXX) fields. */
 	size_t          extras;       /**< Number of extra text (TXXX) fields. */
 	mpg123_picture  *picture;     /**< Array of ID3v2 pictures fields (APIC).
@@ -2083,7 +2083,7 @@ MPG123_EXPORT int mpg123_meta_check(mpg123_handle *mh);
  */
 MPG123_EXPORT void mpg123_meta_free(mpg123_handle *mh);
 
-/** Point v1 and v2 to existing data structures which may change on any next read/decode function call.
+/** Point v1 and v2 to existing data structures wich may change on any next read/decode function call.
  *  v1 and/or v2 can be set to NULL when there is no corresponding data.
  *  \return MPG123_OK on success
  */
@@ -2105,7 +2105,7 @@ MPG123_EXPORT int mpg123_id3_raw( mpg123_handle *mh
 ,	unsigned char **v1, size_t *v1_size
 ,	unsigned char **v2, size_t *v2_size );
 
-/** Point icy_meta to existing data structure which may change on any next read/decode function call.
+/** Point icy_meta to existing data structure wich may change on any next read/decode function call.
  *  \param mh handle
  *  \param icy_meta return address for ICY meta string (set to NULL if nothing there)
  *  \return MPG123_OK on success

--- a/tools/ports/sqlite3.py
+++ b/tools/ports/sqlite3.py
@@ -3,7 +3,7 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-# sqlite amalgamation download URL uses relase year and tag
+# sqlite amalgamation download URL uses release year and tag
 # 2022  and (3, 38, 5) -> '/2022/sqlite-amalgamation-3380500.zip'
 VERSION = (3, 39, 0)
 VERSION_YEAR = 2022

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -160,7 +160,7 @@ class SettingsManager:
       with open(filename) as fh:
         settings = fh.read()
       # Use a bunch of regexs to convert the file from JS to python
-      # TODO(sbc): This is kind hacky and we should probably covert
+      # TODO(sbc): This is kind hacky and we should probably convert
       # this file in format that python can read directly (since we
       # no longer read this file from JS at all).
       settings = settings.replace('//', '#')
@@ -273,7 +273,7 @@ class SettingsManager:
     expected_type = self.types.get(name)
     if not expected_type:
       return
-    # Allow itegers 1 and 0 for type `bool`
+    # Allow integers 1 and 0 for type `bool`
     if expected_type == bool:
       if value in (1, 0):
         value = bool(value)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -116,7 +116,7 @@ def shlex_join(cmd):
 def run_process(cmd, check=True, input=None, *args, **kw):
   """Runs a subprocess returning the exit code.
 
-  By default this function will raise an exception on failure.  Therefor this should only be
+  By default this function will raise an exception on failure.  Therefore this should only be
   used if you want to handle such failures.  For most subprocesses, failures are not recoverable
   and should be fatal.  In those cases the `check_call` wrapper should be preferred.
   """
@@ -511,7 +511,7 @@ def check_sanity(force=False):
     return
 
   with cache.lock('sanity'):
-    # Check again once the cache lock as aquired
+    # Check again once the cache lock as acquired
     if sanity_is_correct():
       return
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1710,7 +1710,7 @@ class libmalloc(MTLibrary):
 
   cflags = ['-fno-builtin', '-Wno-unused-function', '-Wno-unused-but-set-variable', '-Wno-unused-variable']
   # malloc/free/calloc are runtime functions and can be generated during LTO
-  # Therefor they cannot themselves be part of LTO.
+  # Therefore they cannot themselves be part of LTO.
   force_object_files = True
 
   def __init__(self, **kwargs):
@@ -1810,7 +1810,7 @@ class libmimalloc(MTLibrary):
   ]
 
   # malloc/free/calloc are runtime functions and can be generated during LTO
-  # Therefor they cannot themselves be part of LTO.
+  # Therefore they cannot themselves be part of LTO.
   force_object_files = True
 
   includes = ['system/lib/mimalloc/include']

--- a/tools/toolchain_profiler.results_template.html
+++ b/tools/toolchain_profiler.results_template.html
@@ -631,7 +631,7 @@ function createSwimlaneChart(data) {
           .duration(500)
           .style("opacity", 0);
     }
-    // upate the item rects
+    // update the item rects
     var rects = itemRects.selectAll('rect')
       .data(visItems, function (d) { return d.id; })
       .attr('x', function(d) { return x1(d.start); })

--- a/tools/unsafe_optimizations.mjs
+++ b/tools/unsafe_optimizations.mjs
@@ -75,7 +75,7 @@ function optPassRemoveRedundantOperatorNews(ast) {
         // referenced (a least in some builds).
         //
         // Another exception is made for `new WebAssembly.*` since we create and
-        // unused `WebAssembly.Memory` when probing for wasm64 fatures.
+        // unused `WebAssembly.Memory` when probing for wasm64 features.
         if (
           n.expression.callee.name !== 'Promise' &&
           n.expression.callee.object?.name !== 'WebAssembly'

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -3,7 +3,7 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-"""Utilties for manipulating WebAssembly binaries from python.
+"""Utilities for manipulating WebAssembly binaries from python.
 """
 
 from collections import namedtuple

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -693,7 +693,7 @@ for name, interface in interfaces.items():
     continue
   implements[name] = [js_impl[0]]
 
-# Compute the height in the inheritance tree of each node. Note that the order of interation
+# Compute the height in the inheritance tree of each node. Note that the order of iteration
 # of `implements` is irrelevant.
 #
 # After one iteration of the loop, all ancestors of child are guaranteed to have a larger

--- a/tools/websocket_to_posix_proxy/src/websocket_to_posix_proxy.c
+++ b/tools/websocket_to_posix_proxy/src/websocket_to_posix_proxy.c
@@ -1599,7 +1599,7 @@ void ProcessWebSocketMessage(int client_fd, uint8_t *payload, uint64_t numBytes)
       header->function == POSIX_SOCKET_MSG_RECVMSG ||
       header->function == POSIX_SOCKET_MSG_CONNECT ||
       header->function == POSIX_SOCKET_MSG_ACCEPT) {
-    // Synchonous/blocking recv()s can halt indefinitely until a message is actually received. An application might
+    // Synchronous/blocking recv()s can halt indefinitely until a message is actually received. An application might
     // be send()ing messages in one thread while using another thread to wait for recv(). Therefore run these potentially
     // blocking recv()s in a separate thread. The nonblocking operations can run synchronously in calling thread (they could
     // also run in a background thread, but for performance, do not offload them since it is not necessary)


### PR DESCRIPTION
% `codespell --ignore-words-list=dum,implementor,tre --write-changes tools`
* https://pypi.org/project/codespell