### PR TITLE
Handle trailing % in strftime

### DIFF
--- a/system/lib/libc/musl/src/time/strftime.c
+++ b/system/lib/libc/musl/src/time/strftime.c
@@ -226,7 +226,7 @@ size_t __strftime_l(char *restrict s, size_t n, const char *restrict f, const st
 			s[l] = 0;
 			return l;
 		}
-		if (*f != '%') {
+		if (*f != '%' || !f[1]) {
 			s[l++] = *f;
 			continue;
 		}

--- a/test/other/test_strftime.c
+++ b/test/other/test_strftime.c
@@ -307,5 +307,8 @@ int main() {
   size = strftime(s, sizeof(s), "%Ec", &tm);
   TEST(!cmp(s, "Mon Dec 17 00:00:00 2018"), "strftime test #36a", s);
 
+  size = strftime(s, sizeof(s), "trailing %", &tm);
+  TEST((size == 10), "strftime test #37", s);
+  TEST(!cmp(s, "trailing %"), "strftime test #37", s);
   return 0;
 }


### PR DESCRIPTION
"In glibc a trailing % in strftime() acts like printf, ie it's a literal %". This is breaking some Python tests. I've applied the patch suggested here: https://www.openwall.com/lists/musl/2022/12/19/2