### PR TITLE
Fix path resolution for symlinks

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -38,7 +38,10 @@ var SyscallsLibrary = {
         }
         return dir;
       }
-      return PATH.join2(dir, path);
+      if (!dir.endsWith("/")) {
+        dir += "/"
+      }
+      return dir + path;
     },
 
     doStat(func, path, buf) {
@@ -826,7 +829,6 @@ var SyscallsLibrary = {
     path = SYSCALLS.calculateAt(dirfd, path);
     // remove a trailing slash, if one - /a/b/ has basename of '', but
     // we want to create b in the context of this function
-    path = PATH.normalize(path);
     if (path[path.length-1] === '/') path = path.substr(0, path.length-1);
     FS.mkdir(path, mode, 0);
     return 0;

--- a/test/fs/test_symlink_resolution.c
+++ b/test/fs/test_symlink_resolution.c
@@ -1,0 +1,57 @@
+#include <unistd.h>
+#include <fcntl.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#if defined(__EMSCRIPTEN__)
+#include "emscripten.h"
+#endif
+
+void makedir(const char *dir) {
+  int rtn = mkdir(dir, 0777);
+  assert(rtn == 0);
+}
+
+void changedir(const char *dir) {
+  int rtn = chdir(dir);
+  assert(rtn == 0);
+}
+
+static void create_file(const char *path) {
+  printf("creating: %s\n", path);
+  int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0777);
+  assert(fd >= 0);
+
+  close(fd);
+}
+
+void setup() {
+#if defined(__EMSCRIPTEN__) && defined(NODEFS)
+  makedir("working");
+  EM_ASM(FS.mount(NODEFS, { root: '.' }, 'working'));
+  changedir("working");
+#endif
+    makedir("a");
+    makedir("b");
+    makedir("b/c");
+    symlink("../b/c", "a/link");
+}
+
+
+int main() {
+    setup();
+    create_file("a/link/../x.txt");
+    struct stat statBuf;
+    assert(stat("a/link/../x.txt", &statBuf) == 0);
+    assert(stat("b/x.txt", &statBuf) == 0);
+    makedir("a/link/../d");
+    assert(stat("a/link/../d", &statBuf) == 0);
+    assert(stat("b/d", &statBuf) == 0);
+
+    assert(truncate("a/link/../x.txt", 0) == 0);
+    assert(chmod("a/link/../x.txt", 0777) == 0);
+    printf("success\n");
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5925,6 +5925,20 @@ Module.onRuntimeInitialized = () => {
       self.set_setting('FORCE_FILESYSTEM')
     self.do_runf('fs/test_64bit.c', 'success')
 
+  @requires_node
+  @parameterized({
+    '': ([],),
+    'nodefs': (['-DNODEFS', '-lnodefs.js'],),
+    'noderawfs': (['-sNODERAWFS'],),
+  })
+  def test_fs_symlink_resolution(self, args):
+    nodefs = '-DNODEFS' in args or '-sNODERAWFS' in args
+    if self.get_setting('WASMFS'):
+      if nodefs:
+        self.skipTest('NODEFS in WasmFS')
+      self.set_setting('FORCE_FILESYSTEM')
+    self.do_runf('fs/test_symlink_resolution.c', 'success', emcc_args=args)
+
   def test_sigalrm(self):
     self.do_runf('test_sigalrm.c', 'Received alarm!')
     self.set_setting('EXIT_RUNTIME')


### PR DESCRIPTION
If `/a/link` is a symlink to directory `/b/c` then `/a/link/..` should be resolved to `/b/c/..` which is `/b`. Currently, we cancel out `link/..` to get `/a`. The problem is that we apply `PATH_FS.resolve` and `PATH_FS.normalize` to paths. These functions cancel `..` incorrectly.

This at least partially handles the situation. `lookupPath` is modified to avoid calls that call `PATH_FS.normalize()`. We check that `mkdir`, `open`, and `stat` now work correctly.