### PR TITLE
Use encodeURIComponent in browser_reporting. NFC

### DIFF
--- a/test/browser_reporting.js
+++ b/test/browser_reporting.js
@@ -14,7 +14,7 @@ function reportResultToServer(result, port) {
     out(`RESULT: ${result}`);
   } else {
     let doFetch = typeof origFetch != 'undefined' ? origFetch : fetch;
-    doFetch(`http://localhost:${port}/report_result?${result}`).then(() => {
+    doFetch(`http://localhost:${port}/report_result?${encodeURIComponent(result)}`).then(() => {
       if (typeof window === 'object' && window && hasModule && !Module['pageThrewException']) {
         /* for easy debugging, don't close window on failure */
         window.close();
@@ -24,7 +24,7 @@ function reportResultToServer(result, port) {
 }
 
 function sendFileToServer(filename, contents) {
-  fetch(`http://localhost:8888/?file=${filename}`, {method: "POST", body: contents});
+  fetch(`http://localhost:8888/?file=${encodeURIComponent(filename)}`, {method: "POST", body: contents});
 }
 
 /**
@@ -39,7 +39,7 @@ function reportErrorToServer(message) {
   if (typeof ENVIRONMENT_IS_NODE !== 'undefined' && ENVIRONMENT_IS_NODE) {
     err(message);
   } else {
-    fetch(encodeURI(`http://localhost:8888?stderr=${message}`));
+    fetch(`http://localhost:8888?stderr=${encodeURIComponent(message)}`);
   }
 }
 


### PR DESCRIPTION
While working on a separate change I ran into issues where chrome was refusing to fetch a report_result and this fixed the issue.

It seems that the angle brackets in the backtrace after my PR were the issue:

Before:
```
exception:fetch is not a function / TypeError: fetch is not a function           
    at readAsync (￼https://b2607f8….proxy.googlers.com/a.out.js:284:12)             
    at getBinaryPromise (￼https://b2607f8….proxy.googlers.com/a.out.js:774:12)   
    at instantiateArrayBuffer (￼https://b2607f8….proxy.googlers.com/a.out.js:786:10)
    at instantiateAsync (￼https://b2607f8….proxy.googlers.com/a.out.js:832:10)   
    at createWasm (￼https://b2607f8….proxy.googlers.com/a.out.js:909:3)             
    at ￼https://b2607f8….proxy.googlers.com/a.out.js:5310:19         
```               
After:

```                                                                                                                                                  
exception:fetch is not a function / TypeError: fetch is not a function              
    at readAsync (￼https://b2607f8….proxy.googlers.com/a.out.js:294:12)             
    at getBinaryPromise (￼https://b2607f8….proxy.googlers.com/a.out.js:818:12)   
    at ￼https://b2607f8….proxy.googlers.com/a.out.js:831:5                          
    at new Promise (<anonymous>)                                                    
    at instantiateArrayBuffer (￼https://b2607f8….proxy.googlers.com/a.out.js:830:10)
    at instantiateAsync (￼https://b2607f8….proxy.googlers.com/a.out.js:881:10)   
    at createWasm (￼https://b2607f8….proxy.googlers.com/a.out.js:958:3)             
    at ￼https://b2607f8….proxy.googlers.com/a.out.js:5368:19  
```