### PR TITLE
Change log level in library_glemu.js

### DIFF
--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -185,9 +185,9 @@ var LibraryGLEmulation = {
 
 
       // Add some emulation workarounds
-      err('WARNING: using emscripten GL emulation. This is a collection of limited workarounds, do not expect it to work.');
+      console.warning('WARNING: using emscripten GL emulation. This is a collection of limited workarounds, do not expect it to work.');
 #if GL_UNSAFE_OPTS == 1
-      err('WARNING: using emscripten GL emulation unsafe opts. If weirdness happens, try -sGL_UNSAFE_OPTS=0');
+      console.warning('WARNING: using emscripten GL emulation unsafe opts. If weirdness happens, try -sGL_UNSAFE_OPTS=0');
 #endif
 
       // XXX some of the capabilities we don't support may lead to incorrect rendering, if we do not emulate them in shaders


### PR DESCRIPTION
Change the log level from error to warning during GL emulation.

It's a bit annoying since the console log receives a lot of error level messages, which are actually warnings.