### PR TITLE
Disable test_fs_enotdir on Windows

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5782,6 +5782,7 @@ got: 10
     self.do_run_in_out_file_test('fs/test_emptyPath.c')
 
   @no_windows('https://github.com/emscripten-core/emscripten/issues/8882')
+  @crossplatform
   @also_with_noderawfs
   def test_fs_enotdir(self):
     self.do_run_in_out_file_test('fs/test_enotdir.c')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5781,6 +5781,7 @@ got: 10
   def test_fs_emptyPath(self):
     self.do_run_in_out_file_test('fs/test_emptyPath.c')
 
+  @no_windows('https://github.com/emscripten-core/emscripten/issues/8882')
   @also_with_noderawfs
   def test_fs_enotdir(self):
     self.do_run_in_out_file_test('fs/test_enotdir.c')


### PR DESCRIPTION
This seems to be another instance of #8882 where errno values don't
match. This could be "fixed" by making the error check a little
looser if we care about the behavior of NODERAWFS on Windows.
For now just disable to unblock the rollers.
