### PR TITLE
Cleanup test_offset_converter. NFC

### DIFF
--- a/test/browser/test_offset_converter.c
+++ b/test/browser/test_offset_converter.c
@@ -1,21 +1,26 @@
+#include <assert.h>
 #include <stdio.h>
 #include <emscripten.h>
 
-void *get_pc(void) { return __builtin_return_address(0); }
+void *get_pc(void) {
+  return __builtin_return_address(0);
+}
 
-int magic_test_function(void) {
+void magic_test_function(void) {
   int result = EM_ASM_INT({
     function report(x) {
-      fetch(encodeURI('http://localhost:8888?stdout=' + x));
+      out(x);
+      fetch('http://localhost:8888?stdout=' + encodeURIComponent(x));
     }
     report('magic_test_function: input=' + $0);
     var converted = wasmOffsetConverter.getName($0);
     report('magic_test_function: converted=' + converted);
     return converted == 'magic_test_function';
   }, get_pc());
-  return result;
+  assert(result);
 }
 
 int main(void) {
-  return magic_test_function();
+  magic_test_function();
+  return 0;
 }

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4948,8 +4948,12 @@ Module["preRun"] = () => {
   def test_minimal_runtime_hello_world(self, args):
     self.btest_exit('small_hello_world.c', args=args + ['-sMINIMAL_RUNTIME'])
 
-  def test_offset_converter(self, *args):
-    self.btest_exit('test_offset_converter.c', assert_returncode=1, args=['-sUSE_OFFSET_CONVERTER', '-gsource-map', '-sPROXY_TO_PTHREAD', '-pthread'])
+  @parameterized({
+    '': ([],),
+    'pthread': (['-sPROXY_TO_PTHREAD', '-pthread'],)
+  })
+  def test_offset_converter(self, args):
+    self.btest_exit('test_offset_converter.c', args=['-sUSE_OFFSET_CONVERTER', '-gsource-map'] + args)
 
   # Tests emscripten_unwind_to_js_event_loop() behavior
   def test_emscripten_unwind_to_js_event_loop(self, *args):


### PR DESCRIPTION
- Using zero return code for success.
- Run test both with and without pthreads.