### PR TITLE
Remove `runDependencies` handling code from  `emscripten_async_load_script`

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -661,28 +661,16 @@ var LibraryBrowser = {
       return;
     }
 #endif
-#if ASSERTIONS
-    assert(runDependencies === 0, 'async_load_script must be run when no other dependencies are active');
-#endif
     {{{ runtimeKeepalivePush() }}}
 
     var loadDone = () => {
       {{{ runtimeKeepalivePop() }}}
-      if (onload) {
-        var onloadCallback = () => callUserCallback({{{ makeDynCall('v', 'onload') }}});
-        if (runDependencies > 0) {
-          dependenciesFulfilled = onloadCallback;
-        } else {
-          onloadCallback();
-        }
-      }
-    }
+      onload && callUserCallback({{{ makeDynCall('v', 'onload') }}});
+    };
 
     var loadError = () => {
       {{{ runtimeKeepalivePop() }}}
-      if (onerror) {
-        callUserCallback({{{ makeDynCall('v', 'onerror') }}});
-      }
+      onerror && callUserCallback({{{ makeDynCall('v', 'onerror') }}});
     };
 
 #if ENVIRONMENT_MAY_BE_NODE && DYNAMIC_EXECUTION


### PR DESCRIPTION
This handling of `runDependencies` was included when this code was first added in 1fc6762e3.  While there may have been reason for this back then I can't see how or why this is useful today.  We don't have any internal usage of `emscripten_async_load_script` so there should be no way to call it before the program is running.