### PR TITLE
[test] Remove (broken) EMTEST_BROWSER_PORT test setting

### DIFF
--- a/site/source/docs/porting/files/Synchronous-Virtual-XHR-Backed-File-System-Usage.rst
+++ b/site/source/docs/porting/files/Synchronous-Virtual-XHR-Backed-File-System-Usage.rst
@@ -63,6 +63,6 @@ Instructions
 
   .. include:: ../../../../../test/test_browser.py
     :literal:
-    :start-after: create_file('main.html',
-    :end-before: """ % (worker_filename, self.port))
+    :start-after: create_file('main.html', '''
+    :end-before: ''' % self.PORT)
     :code: html

--- a/test/report_result.c
+++ b/test/report_result.c
@@ -20,20 +20,13 @@ extern "C" {
 #endif
 
 #if defined __EMSCRIPTEN__ && !defined EMTEST_NODE
-#ifndef EMTEST_PORT_NUMBER
-#error "EMTEST_PORT_NUMBER not defined"
-#endif
 
 void EMSCRIPTEN_KEEPALIVE _ReportResult(int result) {
-  EM_ASM({
-    reportResultToServer($0, $1);
-  }, result, EMTEST_PORT_NUMBER);
+  EM_ASM(reportResultToServer($0), result);
 }
 
 void EMSCRIPTEN_KEEPALIVE _MaybeReportResult(int result) {
-  EM_ASM({
-    maybeReportResultToServer($0, $1);
-  }, result, EMTEST_PORT_NUMBER);
+  EM_ASM(maybeReportResultToServer($0), result);
 }
 
 #else

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1608,7 +1608,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
         </script>
       </body>
       </html>
-    ''' % self.port)
+    ''' % self.PORT)
 
     cmd = [EMCC, test_file('hello_world_worker.c'), '-o', 'worker.js'] + self.get_emcc_args()
     if file_data:
@@ -1671,7 +1671,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
         </script>
       </body>
       </html>
-    """ % (worker_filename, self.port))
+    """ % (worker_filename, self.PORT))
 
     create_file('worker_prejs.js', r"""
       Module.arguments = ["/bigfile"];
@@ -1688,7 +1688,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
     data = os.urandom(10 * chunkSize + 1) # 10 full chunks and one 1 byte chunk
     checksum = zlib.adler32(data) & 0xffffffff # Python 2 compatibility: force bigint
 
-    server = multiprocessing.Process(target=test_chunked_synchronous_xhr_server, args=(True, chunkSize, data, checksum, self.port))
+    server = multiprocessing.Process(target=test_chunked_synchronous_xhr_server, args=(True, chunkSize, data, checksum, self.PORT))
     server.start()
 
     # block until the server is actually ready
@@ -2422,7 +2422,7 @@ void *getBindBuffer() {
         doCwrapCall(200);
         doDirectCall(300);
       }
-    ''' % self.port
+    ''' % self.PORT
 
     create_file('pre_runtime.js', r'''
       Module.onRuntimeInitialized = myJSCallback;
@@ -2569,7 +2569,7 @@ Module["preRun"] = () => {
       window.disableErrorReporting = true;
       window.addEventListener('error', (event) => {
         if (!event.message.includes('exception:fullscreen error')) {
-          report_error(event);
+          reportTopLevelError(event);
         }
       });
       ''')


### PR DESCRIPTION
The `browser_reporting.js` file (which does most of the reporting these days) was not honoring it anyway.  I've never found the need to configure this in all the years I've been working on emscripten so hopefully we don't need to bring it back.