### PR TITLE
mark test_fs_dev_random as crossplatform

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6107,6 +6107,8 @@ int main() {
   @also_with_noderawfs
   @crossplatform
   def test_fs_dev_random(self):
+    if WINDOWS and self.get_setting('NODERAWFS'):
+      self.skipTest('Crashes on Windows and NodeFS')
     self.do_runf('fs/test_fs_dev_random.c', 'success')
 
   @parameterized({

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6105,6 +6105,7 @@ int main() {
 
   @also_with_wasmfs
   @also_with_noderawfs
+  @crossplatform
   def test_fs_dev_random(self):
     self.do_runf('fs/test_fs_dev_random.c', 'success')
 


### PR DESCRIPTION
Disable it on Windows. It wasn't running there before #23088