### PR TITLE
[test] Remove EMSCRIPTEN_KEEPALIVE from _ReportResult. NFC

### DIFF
--- a/test/pthread/call_async_on_main_thread.js
+++ b/test/pthread/call_async_on_main_thread.js
@@ -7,6 +7,6 @@ addToLibrary({
       console.error('This function should be getting called on the main thread!');
     }
     console.log('got ' + param1 + ' ' + param2 + ' ' + param3);
-    __ReportResult(param1 + param2 * param3);
+    reportResultToServer(param1 + param2 * param3);
   }
 });

--- a/test/report_result.c
+++ b/test/report_result.c
@@ -21,11 +21,11 @@ extern "C" {
 
 #if defined __EMSCRIPTEN__ && !defined EMTEST_NODE
 
-void EMSCRIPTEN_KEEPALIVE _ReportResult(int result) {
+void _ReportResult(int result) {
   EM_ASM(reportResultToServer($0), result);
 }
 
-void EMSCRIPTEN_KEEPALIVE _MaybeReportResult(int result) {
+void _MaybeReportResult(int result) {
   EM_ASM(maybeReportResultToServer($0), result);
 }
 

--- a/test/webaudio/create_webaudio.c
+++ b/test/webaudio/create_webaudio.c
@@ -23,9 +23,7 @@ int main()
 		startButton.onclick = () => {
 			if (audioContext.state != 'running') {
 				audioContext.resume();
-#ifdef REPORT_RESULT
-				__ReportResult(0);
-#endif
+				reportResultToServer(0);
 			} else {
 				audioContext.suspend();
 			}


### PR DESCRIPTION
On the emscripten side we have `reportResultToServer` already.