### PR TITLE
Fix UB in test_unistd_write_broken_link

### DIFF
--- a/test/unistd/test_unistd_write_broken_link.c
+++ b/test/unistd/test_unistd_write_broken_link.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -10,13 +11,14 @@ int main() {
   printf("link result: %d\n", res);
   int src_fd = open("link_source", O_CREAT | O_WRONLY, 0777);
   printf("source_fd: %d, errno: %d %s\n", src_fd, errno, strerror(errno));
-  write(src_fd, "abc", 3);
+  write(src_fd, "abc\0", 4);
   close(src_fd);
   {
     int target_fd = open("link_target", O_RDONLY);
     printf("target_fd: %d, errno: %d %s\n", target_fd, errno, strerror(errno));
     char buf[10];
-    read(target_fd, buf, 10);
+    size_t r = read(target_fd, buf, 10);
+    assert(r == 4);
     printf("buf: '%s'\n", buf);
     close(target_fd);
   }
@@ -24,7 +26,8 @@ int main() {
     int target_fd = open("link_source", O_RDONLY);
     printf("target_fd: %d, errno: %d %s\n", target_fd, errno, strerror(errno));
     char buf[10];
-    read(target_fd, buf, 10);
+    size_t r = read(target_fd, buf, 10);
+    assert(r == 4);
     printf("buf: '%s'\n", buf);
     close(target_fd);
   }

--- a/test/unistd/test_unistd_write_broken_link.c
+++ b/test/unistd/test_unistd_write_broken_link.c
@@ -11,14 +11,15 @@ int main() {
   printf("link result: %d\n", res);
   int src_fd = open("link_source", O_CREAT | O_WRONLY, 0777);
   printf("source_fd: %d, errno: %d %s\n", src_fd, errno, strerror(errno));
-  write(src_fd, "abc\0", 4);
+  write(src_fd, "abc", 3);
   close(src_fd);
   {
     int target_fd = open("link_target", O_RDONLY);
     printf("target_fd: %d, errno: %d %s\n", target_fd, errno, strerror(errno));
     char buf[10];
+    memset(buf, 0, 10);
     size_t r = read(target_fd, buf, 10);
-    assert(r == 4);
+    assert(r == 3);
     printf("buf: '%s'\n", buf);
     close(target_fd);
   }
@@ -26,8 +27,9 @@ int main() {
     int target_fd = open("link_source", O_RDONLY);
     printf("target_fd: %d, errno: %d %s\n", target_fd, errno, strerror(errno));
     char buf[10];
+    memset(buf, 0, 10);
     size_t r = read(target_fd, buf, 10);
-    assert(r == 4);
+    assert(r == 3);
     printf("buf: '%s'\n", buf);
     close(target_fd);
   }


### PR DESCRIPTION
The test was failing under ASan because no null byte was being
read from the file, so the strlen inside printf was running
off the buffer. It just happened to work on non-ASan because
wasm memory is initialized to zero.
