### PR TITLE
[AUDIO_WORKLET] Fix when compiling with STRICT

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -1403,7 +1403,7 @@ def phase_linker_setup(options, state, newargs):  # noqa: C901, PLR0912, PLR0915
       # MINIMAL_RUNTIME exports these manually, since this export mechanism is placed
       # in global scope that is not suitable for MINIMAL_RUNTIME loader.
       settings.EXPORTED_RUNTIME_METHODS += ['stackSave', 'stackAlloc', 'stackRestore', 'wasmTable']
-      # The following symbols need exposing to load the Audio Worklet:
+      # The following symbols need exposing to load the audio worklet:
       settings.INCOMING_MODULE_JS_API += ['instantiateWasm', 'wasm', 'wasmMemory']
 
   if settings.FORCE_FILESYSTEM and not settings.MINIMAL_RUNTIME:

--- a/tools/link.py
+++ b/tools/link.py
@@ -1403,7 +1403,7 @@ def phase_linker_setup(options, state, newargs):  # noqa: C901, PLR0912, PLR0915
       # MINIMAL_RUNTIME exports these manually, since this export mechanism is placed
       # in global scope that is not suitable for MINIMAL_RUNTIME loader.
       settings.EXPORTED_RUNTIME_METHODS += ['stackSave', 'stackAlloc', 'stackRestore', 'wasmTable']
-      # The following symbols need exposing to load the audio worklet:
+      # The following symbols need exposing to load and bootstrap the audio worklet:
       settings.INCOMING_MODULE_JS_API += ['instantiateWasm', 'wasm', 'wasmMemory']
 
   if settings.FORCE_FILESYSTEM and not settings.MINIMAL_RUNTIME:

--- a/tools/link.py
+++ b/tools/link.py
@@ -1403,6 +1403,8 @@ def phase_linker_setup(options, state, newargs):  # noqa: C901, PLR0912, PLR0915
       # MINIMAL_RUNTIME exports these manually, since this export mechanism is placed
       # in global scope that is not suitable for MINIMAL_RUNTIME loader.
       settings.EXPORTED_RUNTIME_METHODS += ['stackSave', 'stackAlloc', 'stackRestore', 'wasmTable']
+      # The following symbols need exposing to load the Audio Worklet:
+      settings.INCOMING_MODULE_JS_API += ['instantiateWasm', 'wasm', 'wasmMemory']
 
   if settings.FORCE_FILESYSTEM and not settings.MINIMAL_RUNTIME:
     # when the filesystem is forced, we export by default methods that filesystem usage


### PR DESCRIPTION
Fix for #22971.

This highlights that the AW tests weren't catching this or other issues in the parameterised tests. Running, for example:
```
test/runner browser.test_audio_worklet_strict
```
Passes, but if compiled with the same settings doesn't run.