### PR TITLE
[tsgen] Fix overriding Embind's ClassHandle clone method.

### DIFF
--- a/src/embind/embind_gen.js
+++ b/src/embind/embind_gen.js
@@ -417,7 +417,7 @@ var LibraryEmbind = {
           '  delete(): void;\n',
           '  deleteLater(): this;\n',
           '  isDeleted(): boolean;\n',
-          '  clone(): this;\n',
+          '  clone(): ThisType<this>;\n',
           '}\n',
         );
       }

--- a/test/other/embind_tsgen.cpp
+++ b/test/other/embind_tsgen.cpp
@@ -39,6 +39,13 @@ class Foo {
   void process(const Test& input) {}
 };
 
+struct Override {
+  Override clone() const {
+    Override o;
+    return o;
+  }
+};
+
 Test class_returning_fn() { return Test(); }
 
 std::unique_ptr<Test> class_unique_ptr_returning_fn() {
@@ -251,6 +258,11 @@ EMSCRIPTEN_BINDINGS(Test) {
     .function("invoke", &Interface::invoke, pure_virtual())
     .allow_subclass<InterfaceWrapper>("InterfaceWrapper")
     ;
+
+  // Override ClassHandle's clone method.
+  class_<Override>("Override")
+    .constructor().
+    function("clone", &Override::clone);
 }
 
 int Test::static_property = 42;

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -22,7 +22,7 @@ export interface ClassHandle {
   delete(): void;
   deleteLater(): this;
   isDeleted(): boolean;
-  clone(): this;
+  clone(): ThisType<this>;
 }
 export interface Test extends ClassHandle {
   x: number;
@@ -100,6 +100,10 @@ export interface InterfaceWrapper extends Interface {
   notifyOnDestruction(): void;
 }
 
+export interface Override extends ClassHandle {
+  clone(): Override;
+}
+
 export type ValArr = [ number, number, number ];
 
 export type ValObj = {
@@ -150,6 +154,9 @@ interface EmbindModule {
     extend(_0: EmbindString, _1: any): any;
   };
   InterfaceWrapper: {};
+  Override: {
+    new(): Override;
+  };
   a_bool: boolean;
   an_int: number;
   optional_test(_0?: Foo): number | undefined;

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -31,7 +31,7 @@ export interface ClassHandle {
   delete(): void;
   deleteLater(): this;
   isDeleted(): boolean;
-  clone(): this;
+  clone(): ThisType<this>;
 }
 export interface Test extends ClassHandle {
   x: number;
@@ -109,6 +109,10 @@ export interface InterfaceWrapper extends Interface {
   notifyOnDestruction(): void;
 }
 
+export interface Override extends ClassHandle {
+  clone(): Override;
+}
+
 export type ValArr = [ number, number, number ];
 
 export type ValObj = {
@@ -159,6 +163,9 @@ interface EmbindModule {
     extend(_0: EmbindString, _1: any): any;
   };
   InterfaceWrapper: {};
+  Override: {
+    new(): Override;
+  };
   a_bool: boolean;
   an_int: number;
   optional_test(_0?: Foo): number | undefined;

--- a/test/other/embind_tsgen_ignore_2.d.ts
+++ b/test/other/embind_tsgen_ignore_2.d.ts
@@ -8,7 +8,7 @@ export interface ClassHandle {
   delete(): void;
   deleteLater(): this;
   isDeleted(): boolean;
-  clone(): this;
+  clone(): ThisType<this>;
 }
 export interface Test extends ClassHandle {
   x: number;
@@ -86,6 +86,10 @@ export interface InterfaceWrapper extends Interface {
   notifyOnDestruction(): void;
 }
 
+export interface Override extends ClassHandle {
+  clone(): Override;
+}
+
 export type ValArr = [ number, number, number ];
 
 export type ValObj = {
@@ -136,6 +140,9 @@ interface EmbindModule {
     extend(_0: EmbindString, _1: any): any;
   };
   InterfaceWrapper: {};
+  Override: {
+    new(): Override;
+  };
   a_bool: boolean;
   an_int: number;
   optional_test(_0?: Foo): number | undefined;

--- a/test/other/embind_tsgen_ignore_3.d.ts
+++ b/test/other/embind_tsgen_ignore_3.d.ts
@@ -22,7 +22,7 @@ export interface ClassHandle {
   delete(): void;
   deleteLater(): this;
   isDeleted(): boolean;
-  clone(): this;
+  clone(): ThisType<this>;
 }
 export interface Test extends ClassHandle {
   x: number;
@@ -100,6 +100,10 @@ export interface InterfaceWrapper extends Interface {
   notifyOnDestruction(): void;
 }
 
+export interface Override extends ClassHandle {
+  clone(): Override;
+}
+
 export type ValArr = [ number, number, number ];
 
 export type ValObj = {
@@ -150,6 +154,9 @@ interface EmbindModule {
     extend(_0: EmbindString, _1: any): any;
   };
   InterfaceWrapper: {};
+  Override: {
+    new(): Override;
+  };
   a_bool: boolean;
   an_int: number;
   optional_test(_0?: Foo): number | undefined;

--- a/test/other/embind_tsgen_module.d.ts
+++ b/test/other/embind_tsgen_module.d.ts
@@ -22,7 +22,7 @@ export interface ClassHandle {
   delete(): void;
   deleteLater(): this;
   isDeleted(): boolean;
-  clone(): this;
+  clone(): ThisType<this>;
 }
 export interface Test extends ClassHandle {
   x: number;
@@ -100,6 +100,10 @@ export interface InterfaceWrapper extends Interface {
   notifyOnDestruction(): void;
 }
 
+export interface Override extends ClassHandle {
+  clone(): Override;
+}
+
 export type ValArr = [ number, number, number ];
 
 export type ValObj = {
@@ -150,6 +154,9 @@ interface EmbindModule {
     extend(_0: EmbindString, _1: any): any;
   };
   InterfaceWrapper: {};
+  Override: {
+    new(): Override;
+  };
   a_bool: boolean;
   an_int: number;
   optional_test(_0?: Foo): number | undefined;


### PR DESCRIPTION
The return type of `clone` should actually be `ThisType<this>` to better match what the JS is actually doing. This also makes it possible to override the clone method.