### PR TITLE
Remove unnecessary functions from jsmath.c. NFC

### DIFF
--- a/system/include/emscripten/em_math.h
+++ b/system/include/emscripten/em_math.h
@@ -29,7 +29,7 @@ extern "C" {
 // Math.ceil -> f32.ceil and f64.ceil (ceil() and ceilf() in math.h)
 // Math.clz32(x) -> i32.clz and i64.clz (call __builtin_clz() and __builtin_clzll())
 // Math.floor -> f32.floor and f64.floor (floor() and floorf() in math.h)
-// Math.fround -> f64.promote_f32(f32.demote_f64()) (call double d = (double)(float)someDouble;)
+// Math.fround -> f64.promote_f32(f32.demote_f64()) (double d = (double)(float)someDouble;)
 // Math.imul(x, y) -> i32.mul and i64.mul (directly multiply two signed integers)
 // Math.min -> f32.min and f64.min (fminf() and fmin() in math.h)
 // Math.max -> f32.max and f64.max (fmaxf() and fmax() in math.h)

--- a/system/lib/jsmath.c
+++ b/system/lib/jsmath.c
@@ -23,9 +23,6 @@ CALL_JS_1_TRIPLE(atan, Math.atan)
 CALL_JS_1_TRIPLE(exp, Math.exp)
 CALL_JS_1_TRIPLE(log, Math.log)
 CALL_JS_1_TRIPLE(sqrt, Math.sqrt)
-CALL_JS_1_TRIPLE(fabs, Math.abs)
-CALL_JS_1_TRIPLE(ceil, Math.ceil)
-CALL_JS_1_TRIPLE(floor, Math.floor)
 
 #define CALL_JS_2(cname, jsname, type) \
   EM_JS(type, JS_##cname, (type x, type y), { return jsname(x, y) }); \
@@ -55,6 +52,3 @@ CALL_JS_1_IMPL_TRIPLE(rint,  {
   }
   return (x - Math.floor(x) != .5) ? round(x) : round(x / 2) * 2;
 })
-
-double nearbyint(double x) { return rint(x); }
-float nearbyintf(float x) { return rintf(x); }


### PR DESCRIPTION
See the comments at the top of `emscripten/js_math.h` for why JS versions of these functions are not needed.

As a followup I plan to map `jsmath.c` functions to `em_math.h` functions instead of using EM_JS here.

See #19284