### PR TITLE
Use `em_math.h` functions in `jsmath.c`

### DIFF
--- a/system/lib/jsmath.c
+++ b/system/lib/jsmath.c
@@ -2,38 +2,37 @@
 // See JS_MATH setting in settings.js for details.
 //
 
-#include <emscripten.h>
+#include <emscripten/em_math.h>
+#include <emscripten/em_js.h>
 #include <math.h>
 #include <stdlib.h>
 
 #define CALL_JS_1(cname, jsname, type) \
-  EM_JS(type, JS_##cname, (type x), { return jsname(x) }); \
-  type cname(type x) { return JS_##cname(x); }
+  type cname(type x) { return (type)emscripten_math_##jsname(x); }
 
-#define CALL_JS_1_TRIPLE(cname, jsname) \
-  CALL_JS_1(cname, jsname, double) \
-  CALL_JS_1(cname##f, jsname, float)
+#define CALL_JS_1_TRIPLE(name) \
+  CALL_JS_1(name, name, double) \
+  CALL_JS_1(name##f, name, float)
 
-CALL_JS_1_TRIPLE(cos, Math.cos)
-CALL_JS_1_TRIPLE(sin, Math.sin)
-CALL_JS_1_TRIPLE(tan, Math.tan)
-CALL_JS_1_TRIPLE(acos, Math.acos)
-CALL_JS_1_TRIPLE(asin, Math.asin)
-CALL_JS_1_TRIPLE(atan, Math.atan)
-CALL_JS_1_TRIPLE(exp, Math.exp)
-CALL_JS_1_TRIPLE(log, Math.log)
-CALL_JS_1_TRIPLE(sqrt, Math.sqrt)
+CALL_JS_1_TRIPLE(cos)
+CALL_JS_1_TRIPLE(sin)
+CALL_JS_1_TRIPLE(tan)
+CALL_JS_1_TRIPLE(acos)
+CALL_JS_1_TRIPLE(asin)
+CALL_JS_1_TRIPLE(atan)
+CALL_JS_1_TRIPLE(exp)
+CALL_JS_1_TRIPLE(log)
+CALL_JS_1_TRIPLE(sqrt)
 
 #define CALL_JS_2(cname, jsname, type) \
-  EM_JS(type, JS_##cname, (type x, type y), { return jsname(x, y) }); \
-  type cname(type x, type y) { return JS_##cname(x, y); }
+  type cname(type x, type y) { return (type)emscripten_math_##jsname(x, y); }
 
-#define CALL_JS_2_TRIPLE(cname, jsname) \
-  CALL_JS_2(cname, jsname, double) \
-  CALL_JS_2(cname##f, jsname, float)
+#define CALL_JS_2_TRIPLE(name) \
+  CALL_JS_2(name, name, double) \
+  CALL_JS_2(name##f, name, float)
 
-CALL_JS_2_TRIPLE(atan2, Math.atan2)
-CALL_JS_2_TRIPLE(pow, Math.pow)
+CALL_JS_2_TRIPLE(atan2)
+CALL_JS_2_TRIPLE(pow)
 
 #define CALL_JS_1_IMPL(cname, type, impl) \
   EM_JS(type, JS_##cname, (type x), impl); \


### PR DESCRIPTION
Unlike the current EM_JS implementations, the `em_math.h` functions map directly to `Math.xxx` without a wrapper function.

The other advantage of doing it this way is that we avoid duplicate implementations of all these functions.

Fixes: #19284