### PR TITLE
Remove rint from jsmath library. NFC

### DIFF
--- a/system/lib/jsmath.c
+++ b/system/lib/jsmath.c
@@ -45,9 +45,3 @@ CALL_JS_2_TRIPLE(pow)
 CALL_JS_1_IMPL_TRIPLE(round, {
   return x >= 0 ? Math.floor(x + 0.5) : Math.ceil(x - 0.5);
 })
-CALL_JS_1_IMPL_TRIPLE(rint,  {
-  function round(x) {
-    return x >= 0 ? Math.floor(x + 0.5) : Math.ceil(x - 0.5);
-  }
-  return (x - Math.floor(x) != .5) ? round(x) : round(x / 2) * 2;
-})


### PR DESCRIPTION
We  use `__builtin_rint` (which lowers to a single `f64.nearest`
instruction) when compiling the musl version of `rint.c` so there there is
no need to use a JS call for this case.
