### PR TITLE
Don't normalize path in basename 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 3.1.75 (in development)
 -----------------------
+- `FS.basename()` no longer calls `PATH.normalize()`, so that
+  `FS.basename("a/.")` returns `"."` instead of `"a"` and `FS.basename("a/b/..")`
+  returns `".."` instead of `"a"`.
 
 3.1.74 - 12/14/24
 -----------------

--- a/src/library_path.js
+++ b/src/library_path.js
@@ -66,7 +66,6 @@ addToLibrary({
     basename: (path) => {
       // EMSCRIPTEN return '/'' for '/', not an empty string
       if (path === '/') return '/';
-      path = PATH.normalize(path);
       path = path.replace(/\/$/, "");
       var lastSlash = path.lastIndexOf('/');
       if (lastSlash === -1) return path;


### PR DESCRIPTION
This brings it in line with the behavior of basename im coreutils and node.
