### PR TITLE
Fix some WasmFS APIs for BIGINT support

### DIFF
--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -198,7 +198,7 @@ FS.init();
 
       var bytesRead;
       if (seeking) {
-        bytesRead = __wasmfs_pread(stream.fd, dataBuffer, length, position);
+        bytesRead = __wasmfs_pread(stream.fd, dataBuffer, length, {{{ splitI64('position') }}});
       } else {
         bytesRead = __wasmfs_read(stream.fd, dataBuffer, length);
       }
@@ -222,7 +222,7 @@ FS.init();
 
       var bytesRead;
       if (seeking) {
-        bytesRead = __wasmfs_pwrite(stream.fd, dataBuffer, length, position);
+        bytesRead = __wasmfs_pwrite(stream.fd, dataBuffer, length, {{{ splitI64('position') }}});
       } else {
         bytesRead = __wasmfs_write(stream.fd, dataBuffer, length);
       }

--- a/src/library_wasmfs_jsimpl.js
+++ b/src/library_wasmfs_jsimpl.js
@@ -53,6 +53,7 @@ addToLibrary({
     return wasmFS$backends[backend].getSize(file);
   },
 
+  _wasmfs_jsimpl_set_size__i53abi: true,
   _wasmfs_jsimpl_set_size: (backend, file, size) => {
 #if ASSERTIONS
     assert(wasmFS$backends[backend]);


### PR DESCRIPTION
These aren't covered by bigint-enabled tests currently, but will be
shortly when we turn bigint on by default.
