### PR TITLE
[test] Remove also_with_wasmfs_js. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -157,23 +157,6 @@ def only_wasm2js(note=''):
   return decorated
 
 
-# Similar to also_with_wasmfs, but also enables the full JS API
-def also_with_wasmfs_js(func):
-  assert callable(func)
-
-  @wraps(func)
-  def decorated(self):
-    func(self)
-    print('wasmfs')
-    if self.get_setting('STANDALONE_WASM'):
-      self.skipTest("test currently cannot run both with WASMFS and STANDALONE_WASM")
-    self.set_setting('WASMFS')
-    self.set_setting('FORCE_FILESYSTEM')
-    self.emcc_args = self.emcc_args.copy() + ['-DWASMFS']
-    func(self)
-  return decorated
-
-
 def with_asyncify_and_jspi(f):
   assert callable(f)
 
@@ -5757,7 +5740,7 @@ got: 10
     self.do_run_in_out_file_test('fs/test_trackingdelegate.c')
 
   @also_with_noderawfs
-  @also_with_wasmfs_js
+  @also_with_wasmfs
   def test_fs_writeFile(self):
     if self.get_setting('WASMFS'):
       self.set_setting("FORCE_FILESYSTEM")


### PR DESCRIPTION
The only different here with `also_with_wasmfs` was that this decorator adds `FORCE_FILESYSTEM`, but the only test to use this decorator was already adding this flag.