### PR TITLE
Define __FILE__ as an empty string in release mode

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -765,6 +765,9 @@ class DebugLibrary(Library):
     cflags = super().get_cflags()
     if not self.is_debug:
       cflags += ['-DNDEBUG']
+      # To make reproducible builds and the results of code size tests
+      # consistent, don't embed the actual __FILE__ paths in release builds.
+      cflags += ['-D__FILE__=""', '-Wno-builtin-macro-redefined']
     return cflags
 
   def get_base_name(self):


### PR DESCRIPTION
This removes all absolute and relative file paths generated by `__FILE__` macro from release build, making the release build reproducible and the results of code size tests consistent.

Without `-Wno-builtin-macro-redefined`, the build errors out:
```console
In file included from <built-in>:365:
<command line>:3:9: error: redefining builtin macro [-Werror,-Wbuiltin-macro-redefined]
    3 | #define __FILE__ ""
      |         ^
1 error generated.
```

The more detailed description on why this is necessary is in #23195.

Fixes #23195.