### PR TITLE
Bump Binaryen to 120

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -39,7 +39,7 @@ logger = logging.getLogger('building')
 
 #  Building
 binaryen_checked = False
-EXPECTED_BINARYEN_VERSION = 119
+EXPECTED_BINARYEN_VERSION = 121
 
 _is_ar_cache: Dict[str, bool] = {}
 # the exports the user requested

--- a/tools/building.py
+++ b/tools/building.py
@@ -39,7 +39,7 @@ logger = logging.getLogger('building')
 
 #  Building
 binaryen_checked = False
-EXPECTED_BINARYEN_VERSION = 121
+EXPECTED_BINARYEN_VERSION = 120
 
 _is_ar_cache: Dict[str, bool] = {}
 # the exports the user requested


### PR DESCRIPTION
https://github.com/WebAssembly/binaryen/pull/7153 updated Binaryen version to 121, but bumping the version to 121 here does not pass the CI (because Binaryen version is behind by 2), so this updates the version to 120 for the moment.