### PR TITLE
Remove pinned version of lxml from requirements-dev.txt. NFC

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,9 +10,6 @@ ruff==0.8.2
 types-requests==2.27.14
 unittest-xml-reporting==3.1.0
 
-# See https://github.com/emscripten-core/emscripten/issues/19785
-lxml==4.9.2
-
 # This version is mentioned in `site/source/docs/site/about.rst`.
 # Please keep them in sync.
 sphinx==7.1.2


### PR DESCRIPTION
It seems like the underlying issue with the mac package has been fixes somehow, and I was running into issues with this version of lxml not being installable on python 3.12 (which is in ubuntu-latest on github CI).

See #19785