### PR TITLE
Bump Binaryen version to 121

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -39,7 +39,7 @@ logger = logging.getLogger('building')
 
 #  Building
 binaryen_checked = False
-EXPECTED_BINARYEN_VERSION = 120
+EXPECTED_BINARYEN_VERSION = 121
 
 _is_ar_cache: Dict[str, bool] = {}
 # the exports the user requested


### PR DESCRIPTION
https://github.com/WebAssembly/binaryen/pull/7153 updated Binaryen version to 121, and we updated it in Emscripten to 120 to make the CI pass (#23197). Now that https://chromium-review.googlesource.com/c/emscripten-releases/+/6103023 has landed, I think we can update it to 121.