### PR TITLE
Remove old warning about firefox bug

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -2385,10 +2385,6 @@ def modularize():
   if settings.EXPORT_ES6 and settings.ENVIRONMENT_MAY_BE_NODE:
     async_emit = 'async '
 
-  # TODO: Remove when https://bugs.webkit.org/show_bug.cgi?id=223533 is resolved.
-  if async_emit != '' and settings.EXPORT_NAME == 'config':
-    diagnostics.warning('emcc', 'EXPORT_NAME should not be named "config" when targeting Safari')
-
   if settings.MODULARIZE == 'instance':
     src = '''
 export default async function init(moduleArg = {}) {


### PR DESCRIPTION
Firstly the bug has a been fixed.  Secondly, the warning is no longer up-to-date with the code and it looks like someone would have to do `-sEXPORT_NAME=moduleArg` to hit this name collision now.. which seems more than unlikely.