### PR TITLE
Remove unnecessary @nocollape. NFC

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -2414,7 +2414,7 @@ export default async function init(moduleArg = {}) {
   if settings.MINIMAL_RUNTIME and not settings.PTHREADS:
     # Single threaded MINIMAL_RUNTIME programs do not need access to
     # document.currentScript, so a simple export declaration is enough.
-    src = f'/** @nocollapse */ var {settings.EXPORT_NAME} = {wrapper_function};'
+    src = f'var {settings.EXPORT_NAME} = {wrapper_function};'
   else:
     script_url_node = ''
     # When MODULARIZE this JS may be executed later,


### PR DESCRIPTION
This was added back in #20191 but I can't see how it can work.  The thing is being applied to here is a function variable. e.g.:

```
var Modulle = function() { ... return the a new module };
```

From the documentation for @nocollape is not clear to me that it has any effect on normal variables like this.