### PR TITLE
Remove unnecessary `await` in `MODULARIZE=instance` mode. NFC

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -2392,7 +2392,7 @@ export default async function init(moduleArg = {}) {
 
 %(generated_js)s
 
-  return await moduleRtn;
+  return moduleRtn;
 }
 ''' % {
       'generated_js': generated_js


### PR DESCRIPTION
Since the init function is already marks as async it fine/better to simply return the promise here rather than awaiting on it.