### PR TITLE
Use consistent prefix map when building deterministic system libraries

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10409,7 +10409,7 @@ int main() {
         [LLVM_DWARFDUMP, libc, '-debug-info', '-debug-line', '--recurse-depth=0'],
         stdout=PIPE).stdout
     # Check that the embedded location of the source file is correct.
-    self.assertIn('DW_AT_name\t("system/lib/emmalloc.c")', dwdump)
+    self.assertIn('DW_AT_name\t("/emsdk/emscripten/system/lib/emmalloc.c")', dwdump)
     self.assertIn('DW_AT_comp_dir\t("/emsdk/emscripten")', dwdump)
 
   @parameterized({

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -42,9 +42,9 @@ LIBC_SOCKETS = ['socket.c', 'socketpair.c', 'shutdown.c', 'bind.c', 'connect.c',
 # link time.
 USE_NINJA = int(os.environ.get('EMCC_USE_NINJA', '0'))
 
-# A fake emscripten path to use in __FILE__ macro and debug info to produce
-# reproducible builds across platforms.
-FAKE_EMSCRIPTEN_PATH = '/emsdk/emscripten'
+# A (fake) deterministic emscripten path to use in __FILE__ macro and debug info
+# to produce reproducible builds across platforms.
+DETERMINISITIC_PREFIX = '/emsdk/emscripten'
 
 
 def files_in_path(path, filenames):
@@ -476,9 +476,9 @@ class Library:
     if self.deterministic_paths:
       source_dir = utils.path_from_root()
       relative_source_dir = os.path.relpath(source_dir, build_dir)
-      cflags += [f'-ffile-prefix-map={source_dir}={FAKE_EMSCRIPTEN_PATH}',
-                 f'-ffile-prefix-map={relative_source_dir}={FAKE_EMSCRIPTEN_PATH}',
-                 f'-fdebug-compilation-dir={FAKE_EMSCRIPTEN_PATH}']
+      cflags += [f'-ffile-prefix-map={source_dir}={DETERMINISITIC_PREFIX}',
+                 f'-ffile-prefix-map={relative_source_dir}={DETERMINISITIC_PREFIX}',
+                 f'-fdebug-compilation-dir={DETERMINISITIC_PREFIX}']
     asflags = get_base_cflags(preprocess=False)
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -500,9 +500,9 @@ class Library:
       source_dir = utils.path_from_root()
       if batch_inputs:
         relative_source_dir = os.path.relpath(source_dir, build_dir)
-        cflags += [f'-ffile-prefix-map={relative_source_dir}={FAKE_EMSCRIPTEN_PATH}']
-      cflags += [f'-ffile-prefix-map={source_dir}={FAKE_EMSCRIPTEN_PATH}',
-                 f'-fdebug-compilation-dir={FAKE_EMSCRIPTEN_PATH}']
+        cflags += [f'-ffile-prefix-map={relative_source_dir}={DETERMINISITIC_PREFIX}']
+      cflags += [f'-ffile-prefix-map={source_dir}={DETERMINISITIC_PREFIX}',
+                 f'-fdebug-compilation-dir={DETERMINISITIC_PREFIX}']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       ext = shared.suffix(src)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -42,6 +42,10 @@ LIBC_SOCKETS = ['socket.c', 'socketpair.c', 'shutdown.c', 'bind.c', 'connect.c',
 # link time.
 USE_NINJA = int(os.environ.get('EMCC_USE_NINJA', '0'))
 
+# A fake emscripten path to use in __FILE__ macro and debug info to produce
+# reproducible builds across platforms.
+FAKE_EMSCRIPTEN_PATH = '/emsdk/emscripten'
+
 
 def files_in_path(path, filenames):
   srcdir = utils.path_from_root(path)
@@ -472,9 +476,9 @@ class Library:
     if self.deterministic_paths:
       source_dir = utils.path_from_root()
       relative_source_dir = os.path.relpath(source_dir, build_dir)
-      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten',
-                 f'-ffile-prefix-map={relative_source_dir}/=',
-                 '-fdebug-compilation-dir=/emsdk/emscripten']
+      cflags += [f'-ffile-prefix-map={source_dir}={FAKE_EMSCRIPTEN_PATH}',
+                 f'-ffile-prefix-map={relative_source_dir}={FAKE_EMSCRIPTEN_PATH}',
+                 '-fdebug-compilation-dir={FAKE_EMSCRIPTEN_PATH}']
     asflags = get_base_cflags(preprocess=False)
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -496,9 +500,9 @@ class Library:
       source_dir = utils.path_from_root()
       if batch_inputs:
         relative_source_dir = os.path.relpath(source_dir, build_dir)
-        cflags += [f'-ffile-prefix-map={relative_source_dir}/=']
-      cflags += [f'-ffile-prefix-map={source_dir}=/emsdk/emscripten',
-                 '-fdebug-compilation-dir=/emsdk/emscripten']
+        cflags += [f'-ffile-prefix-map={relative_source_dir}={FAKE_EMSCRIPTEN_PATH}']
+      cflags += [f'-ffile-prefix-map={source_dir}={FAKE_EMSCRIPTEN_PATH}',
+                 '-fdebug-compilation-dir={FAKE_EMSCRIPTEN_PATH}']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       ext = shared.suffix(src)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -478,7 +478,7 @@ class Library:
       relative_source_dir = os.path.relpath(source_dir, build_dir)
       cflags += [f'-ffile-prefix-map={source_dir}={FAKE_EMSCRIPTEN_PATH}',
                  f'-ffile-prefix-map={relative_source_dir}={FAKE_EMSCRIPTEN_PATH}',
-                 '-fdebug-compilation-dir={FAKE_EMSCRIPTEN_PATH}']
+                 f'-fdebug-compilation-dir={FAKE_EMSCRIPTEN_PATH}']
     asflags = get_base_cflags(preprocess=False)
     input_files = self.get_files()
     ninja_file = os.path.join(build_dir, 'build.ninja')
@@ -502,7 +502,7 @@ class Library:
         relative_source_dir = os.path.relpath(source_dir, build_dir)
         cflags += [f'-ffile-prefix-map={relative_source_dir}={FAKE_EMSCRIPTEN_PATH}']
       cflags += [f'-ffile-prefix-map={source_dir}={FAKE_EMSCRIPTEN_PATH}',
-                 '-fdebug-compilation-dir={FAKE_EMSCRIPTEN_PATH}']
+                 f'-fdebug-compilation-dir={FAKE_EMSCRIPTEN_PATH}']
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       ext = shared.suffix(src)


### PR DESCRIPTION
When `deterministic_paths` is set, we are currently using `-ffile-prefix-map` to produce the same path in data and debug info. In the case of absolute paths, their emscripten path is replaced with a fake path `/emsdk/emscripten`, and in the case of relative paths, all path relative to the emscripten directory is removed, so `../../system/lib/somefile.c` becomes `system/lib/somefiles.c`. https://github.com/emscripten-core/emscripten/blob/f66b5d706e174d9e5cc6122c06ea29dcd2735cd0/tools/system_libs.py#L472-L477 https://github.com/emscripten-core/emscripten/blob/f66b5d706e174d9e5cc6122c06ea29dcd2735cd0/tools/system_libs.py#L495-L501

So this does not make relative paths and absolute paths the same, which can lead to different builds depending on whether the command line uses absolute paths vs. relative ones. Currently we use relative paths when `EMCC_BATCH_BUILD` is set. And Ninja builds cannot use relative paths.

This is also what was suggested in https://github.com/emscripten-core/emscripten/issues/23195#issuecomment-2549784273 while discussins `__FILE__` problem in #23195.

This does not change any code size tests because no code size tests happens to contain `__FILE__` at the moment. (One will be added in #22994)