### PR TITLE
Add deterministic prefix in Library.get_flags() (NFC)

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -472,6 +472,7 @@ class Library:
     ensure_sysroot()
     utils.safe_ensure_dirs(build_dir)
     self.batch_inputs = True
+    self.build_dir = build_dir
 
     cflags = self.get_cflags()
     asflags = get_base_cflags(preprocess=False)
@@ -487,6 +488,7 @@ class Library:
     with the `cflags` returned by `self.get_cflags()`.
     """
     self.batch_inputs = int(os.environ.get('EMCC_BATCH_BUILD', '1'))
+    self.build_dir = build_dir
     batches = {}
     commands = []
     objects = set()
@@ -602,7 +604,7 @@ class Library:
     if self.deterministic_paths:
       source_dir = utils.path_from_root()
       if self.batch_inputs:
-        relative_source_dir = os.path.relpath(source_dir, build_dir)
+        relative_source_dir = os.path.relpath(source_dir, self.build_dir)
         cflags += [f'-ffile-prefix-map={relative_source_dir}={DETERMINISITIC_PREFIX}']
       cflags += [f'-ffile-prefix-map={source_dir}={DETERMINISITIC_PREFIX}',
                  f'-fdebug-compilation-dir={DETERMINISITIC_PREFIX}']

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -530,7 +530,7 @@ class Library:
       elif self.batch_inputs:
         # Use relative paths to reduce the length of the command line.
         # This allows to avoid switching to a response file as often.
-        src = os.path.relpath(src, build_dir)
+        src = os.path.relpath(src, self.build_dir)
         src = utils.normalize_path(src)
         batches.setdefault(tuple(cmd), []).append(src)
       else:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -529,7 +529,7 @@ class Library:
       elif batch_inputs:
         # Use relative paths to reduce the length of the command line.
         # This allows to avoid switching to a response file as often.
-        src = os.path.relpath(src, self.build_dir)
+        src = os.path.relpath(src, build_dir)
         src = utils.normalize_path(src)
         batches.setdefault(tuple(cmd), []).append(src)
       else:


### PR DESCRIPTION
This factors duplicate routines to add deterministic prefix paths out to `Library.get_cflags()`. Suggested in
https://github.com/emscripten-core/emscripten/pull/23222#discussion_r1891063416.