### PR TITLE
Remove test_export_es6_allows_export_in_post_js. NFC

### DIFF
--- a/test/export_module.js
+++ b/test/export_module.js
@@ -1,5 +1,0 @@
-function doNothing() {
-  return false;
-}
-
-export {doNothing};

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -425,11 +425,6 @@ class other(RunnerCore):
                             '-sENVIRONMENT=node', '-sEXPORT_ES6', '-sUSE_ES6_IMPORT_META=0'])
     self.assertContained('EXPORT_ES6 and ENVIRONMENT=*node* requires USE_ES6_IMPORT_META to be set', err)
 
-  def test_export_es6_allows_export_in_post_js(self):
-    self.run_process([EMCC, test_file('hello_world.c'), '-O3', '-sEXPORT_ES6', '--post-js', test_file('export_module.js')])
-    src = read_file('a.out.js')
-    self.assertContained('export{doNothing};', src)
-
   @parameterized({
     '': (False,),
     'package_json': (True,),


### PR DESCRIPTION
This test was added in #13937.  Here we are testing something that we actually decided we did not want to support.  Specifically in #13894 we decided that `--extern-post-js` was the place to allow this.

More importantly the resulting JS module simple doesn't work because in `MODULARIZE` mode the code from `--post-js` does not end up at the top level but instead inside a factory function.  Note that this test does not try to exectute the resulting JS.  If you try to execute it you get `SyntaxError: Unexpected token 'export'`.

Since we don't support it I think its best to remove this test.

I'm also working on a change to move the modularization code before acorn and closure, and with that change this won't even compile (because the modularization process puts all the code inside and inner scope).