### PR TITLE
Fix Sanitizer failures in FS tests

### DIFF
--- a/test/fs/test_fs_enotdir.c
+++ b/test/fs/test_fs_enotdir.c
@@ -17,7 +17,7 @@ int main() {
     assert(errno == ENOTDIR);
   }
   {
-    assert(open("./does-not-exist/", O_CREAT) == -1);
+    assert(open("./does-not-exist/", O_CREAT, 0777) == -1);
     assert(errno == EISDIR);
   }
   printf("success\n");

--- a/test/fs/test_fs_readdir_ino_matches_stat_ino.c
+++ b/test/fs/test_fs_readdir_ino_matches_stat_ino.c
@@ -58,5 +58,6 @@ int main() {
   assert(a_ino == sta.st_ino);
   assert(b_ino == stb.st_ino);
   printf("success\n");
+  closedir(dirp);
   return 0;
 }


### PR DESCRIPTION
* Add a mode parameter to the open() call in test_fs_enotdir to avoid
  reading the uninitialized parameter when using O_CREAT
* Add a call to closedir pair the call to fdopendir in in
  test_fs_readdir_ino_matches_stat_ino, which allows the implementation to
  free the underlying stream and make LSan happy.
