### PR TITLE
fix memory leak in setOffscreenCanvasSizeOnTargetThread

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2307,6 +2307,7 @@ var LibraryHTML5 = {
       targetCanvasPtr = stringToNewUTF8(targetCanvas);
     }
     __emscripten_set_offscreencanvas_size_on_thread(targetThread, targetCanvasPtr, width, height);
+    _free(targetCanvasPtr);
   },
 #endif
 


### PR DESCRIPTION
As I was debugging my code, I noticed that the memory was allocated (`stringToNewUTF8`) but not freed afterwards.

I may be wrong but that looks like a memory leak, hence the fix...

