### PR TITLE
Update docs on oldest supported browser versions.  NFC

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -2905,7 +2905,8 @@ are desired to work. Pass -sMIN_FIREFOX_VERSION=majorVersion to drop support
 for Firefox versions older than < majorVersion.
 Firefox 79 was released on 2020-07-28.
 MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-Minimum supported value is 34 which was released on 2014-12-01.
+Minimum supported value is 40 which was released on 2015-09-11 (see
+feature_matrix.py)
 
 Default value: 79
 
@@ -2924,7 +2925,8 @@ NOTE: Emscripten is unable to produce code that would work in iOS 9.3.5 and
 older, i.e. iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 and older,
 see https://github.com/emscripten-core/emscripten/pull/7191.
 MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-Minimum supported value is 90000 which was released in 2015.
+Minimum supported value is 101000 which was released in 2016-09 (see
+feature_matrix.py).
 
 Default value: 140100
 
@@ -2939,7 +2941,8 @@ This setting also applies to modern Chromium-based Edge, which shares version
 numbers with Chrome.
 Chrome 85 was released on 2020-08-25.
 MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-Minimum supported value is 33, which was released on 2014-02-18.
+Minimum supported value is 45, which was released on 2015-09-01 (see
+feature_matrix.py).
 
 Default value: 85
 
@@ -2952,7 +2955,8 @@ Specifies minimum node version to target for the generated code.  This is
 distinct from the minimum version required run the emscripten compiler.
 This version aligns with the current Ubuuntu TLS 20.04 (Focal).
 Version is encoded in MMmmVV, e.g. 181401 denotes Node 18.14.01.
-Minimum supported value is 101900, which was released 2020-02-05.
+Minimum supported value is 101900, which was released 2020-02-05 (see
+feature_matrix.py).
 
 Default value: 160000
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1895,7 +1895,8 @@ var AUTO_NATIVE_LIBRARIES = true;
 // for Firefox versions older than < majorVersion.
 // Firefox 79 was released on 2020-07-28.
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-// Minimum supported value is 34 which was released on 2014-12-01.
+// Minimum supported value is 40 which was released on 2015-09-11 (see
+// feature_matrix.py)
 // [link]
 var MIN_FIREFOX_VERSION = 79;
 
@@ -1909,7 +1910,8 @@ var MIN_FIREFOX_VERSION = 79;
 // older, i.e. iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 and older,
 // see https://github.com/emscripten-core/emscripten/pull/7191.
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-// Minimum supported value is 90000 which was released in 2015.
+// Minimum supported value is 101000 which was released in 2016-09 (see
+// feature_matrix.py).
 // [link]
 var MIN_SAFARI_VERSION = 140100;
 
@@ -1919,7 +1921,8 @@ var MIN_SAFARI_VERSION = 140100;
 // numbers with Chrome.
 // Chrome 85 was released on 2020-08-25.
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-// Minimum supported value is 33, which was released on 2014-02-18.
+// Minimum supported value is 45, which was released on 2015-09-01 (see
+// feature_matrix.py).
 // [link]
 var MIN_CHROME_VERSION = 85;
 
@@ -1927,7 +1930,8 @@ var MIN_CHROME_VERSION = 85;
 // distinct from the minimum version required run the emscripten compiler.
 // This version aligns with the current Ubuuntu TLS 20.04 (Focal).
 // Version is encoded in MMmmVV, e.g. 181401 denotes Node 18.14.01.
-// Minimum supported value is 101900, which was released 2020-02-05.
+// Minimum supported value is 101900, which was released 2020-02-05 (see
+// feature_matrix.py).
 var MIN_NODE_VERSION = 160000;
 
 // Whether we support setting errno from JS library code.


### PR DESCRIPTION
These were changed in #23077 and #23118 but the docs were not updated.
