### PR TITLE
Include CJS / AMD module exports under MINIMAL_RUNTIME

### DIFF
--- a/test/code_size/hello_webgl2_wasm.json
+++ b/test/code_size/hello_webgl2_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 454,
   "a.html.gz": 328,
-  "a.js": 4538,
-  "a.js.gz": 2320,
+  "a.js": 4706,
+  "a.js.gz": 2383,
   "a.wasm": 10206,
   "a.wasm.gz": 6663,
-  "total": 15198,
-  "total_gz": 9311
+  "total": 15366,
+  "total_gz": 9374
 }

--- a/test/code_size/hello_webgl2_wasm2js.json
+++ b/test/code_size/hello_webgl2_wasm2js.json
@@ -1,8 +1,8 @@
 {
   "a.html": 346,
   "a.html.gz": 262,
-  "a.js": 22202,
-  "a.js.gz": 11604,
-  "total": 22548,
-  "total_gz": 11866
+  "a.js": 22370,
+  "a.js.gz": 11669,
+  "total": 22716,
+  "total_gz": 11931
 }

--- a/test/code_size/hello_webgl_wasm.json
+++ b/test/code_size/hello_webgl_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 454,
   "a.html.gz": 328,
-  "a.js": 4076,
-  "a.js.gz": 2163,
+  "a.js": 4244,
+  "a.js.gz": 2227,
   "a.wasm": 10206,
   "a.wasm.gz": 6663,
-  "total": 14736,
-  "total_gz": 9154
+  "total": 14904,
+  "total_gz": 9218
 }

--- a/test/code_size/hello_webgl_wasm2js.json
+++ b/test/code_size/hello_webgl_wasm2js.json
@@ -1,8 +1,8 @@
 {
   "a.html": 346,
   "a.html.gz": 262,
-  "a.js": 21728,
-  "a.js.gz": 11435,
-  "total": 22074,
-  "total_gz": 11697
+  "a.js": 21896,
+  "a.js.gz": 11500,
+  "total": 22242,
+  "total_gz": 11762
 }

--- a/tools/link.py
+++ b/tools/link.py
@@ -2494,7 +2494,7 @@ var %(EXPORT_NAME)s = (() => {
       src += 'export {' + ', '.join(exports) + '};\n'
     else:
       src += 'export default %s;\n' % settings.EXPORT_NAME
-  elif not settings.MINIMAL_RUNTIME:
+  else:
     src += '''\
 if (typeof exports === 'object' && typeof module === 'object') {
   module.exports = %(EXPORT_NAME)s;


### PR DESCRIPTION
I don't see why `-sMINIMAL_RUNTIME` users would not want the same exporting of the module.  The EXPORT_ES6 behaviour was already matching. This change is necessary are part of #23261 which feeds the modularized code through closure and our acorn optimizations.  Without this closer things the entire module factory is seen as unused and is deleted.