### PR TITLE
Add backspace/tab tests for input elements [NFC]

### DIFF
--- a/test/browser/test_glfw_events.c
+++ b/test/browser/test_glfw_events.c
@@ -163,6 +163,27 @@ static void on_error(int error, const char *msg) {
 }
 #endif
 
+void test_text_input() {
+  EM_ASM({
+    // Create an input element, add it to the DOM, and focus on it.
+    input = document.createElement("input");
+    document.body.appendChild(input);
+
+    // When sent to an input element, backspace and tab are treated like any
+    // other key. TODO: this is not yet functional, see
+    // https://github.com/emscripten-core/emscripten/pull/22879
+    // After that lands, the two "!" here can be removed.
+    assert( simulateKeyEvent("keydown", 65, 65, 'A', input));
+    assert(!simulateKeyEvent("keydown",  8,  8, "Backspace", input));
+    assert(!simulateKeyEvent("keydown",  9,  9, "Tab", input));
+
+    // When sent anywhere else, backspace and tab are preventDefaulted.
+    assert( simulateKeyEvent("keydown", 65, 65, 'A'));
+    assert(!simulateKeyEvent("keydown",  8,  8, "Backspace"));
+    assert(!simulateKeyEvent("keydown",  9,  9, "Tab"));
+  });
+}
+
 int main() {
   unsigned int success = (1 << (sizeof(g_tests) / sizeof(test_t))) - 1; // (2^count)-1;
 
@@ -234,6 +255,8 @@ int main() {
       break;
     }
   }
+
+  test_text_input();
 
   glfwTerminate();
 

--- a/test/browser/test_sdl_key.c
+++ b/test/browser/test_sdl_key.c
@@ -62,9 +62,32 @@ void one() {
 #endif
 }
 
+void test_text_input() {
+  EM_ASM({
+    // Create an input element, add it to the DOM, and focus on it.
+    input = document.createElement("input");
+    document.body.appendChild(input);
+
+    // When sent to an input element, backspace and tab are treated like any
+    // other key. TODO: this is not yet functional, see
+    // https://github.com/emscripten-core/emscripten/pull/22879
+    // After that lands, the two "!" here can be removed.
+    assert( simulateKeyEvent("keydown", 65, 65, 'A', input));
+    assert(!simulateKeyEvent("keydown",  8,  8, "Backspace", input));
+    assert(!simulateKeyEvent("keydown",  9,  9, "Tab", input));
+
+    // When sent anywhere else, backspace and tab are preventDefaulted.
+    assert( simulateKeyEvent("keydown", 65, 65, 'A'));
+    assert(!simulateKeyEvent("keydown",  8,  8, "Backspace"));
+    assert(!simulateKeyEvent("keydown",  9,  9, "Tab"));
+  });
+}
+
 int main(int argc, char **argv) {
   SDL_Init(SDL_INIT_VIDEO);
   SDL_Surface *screen = SDL_SetVideoMode(600, 450, 32, SDL_HWSURFACE);
+
+  test_text_input();
 
 #ifdef TEST_EMSCRIPTEN_SDL_SETEVENTHANDLER
   emscripten_SDL_SetEventHandler(EventHandler, 0);


### PR DESCRIPTION
This adds tests for #22879

The glfw test passes as is, and when modified for that PR, passes with that PR.

However, the SDL test does *not* work, even before that PR, related to SDL
checking `!SDL.unicode && !SDL.textInput` before doing `preventDefault`,

https://github.com/emscripten-core/emscripten/pull/22879/files#diff-d34003e633a5e6cebdd7d5f53a624b636ea6e36f59c208107fb829f5cefcd107L699

That suggests to me that perhaps the SDL side is not actually needed.