### PR TITLE
Warn on the incompatibility between source maps and SINGLE_FILE

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9541,6 +9541,11 @@ int main() {
     self.assertExists('hello_world.js')
     self.assertFileContents('hello_world.wasm', 'not wasm')
 
+  def test_single_file_disables_source_map(self):
+    cmd = [EMCC, test_file('hello_world.c'), '-sSINGLE_FILE', '-gsource-map']
+    stderr = self.run_process(cmd, stderr=PIPE).stderr
+    self.assertContained('warning: SINGLE_FILE disables source map support', stderr)
+
   def test_wasm2js_no_clobber_wasm(self):
     create_file('hello_world.wasm', 'not wasm')
     self.do_runf('hello_world.c', emcc_args=['-sWASM=0'])

--- a/tools/link.py
+++ b/tools/link.py
@@ -1499,7 +1499,8 @@ def phase_linker_setup(options, state, newargs):  # noqa: C901, PLR0912, PLR0915
   if settings.WASM_BIGINT:
     settings.LEGALIZE_JS_FFI = 0
 
-  if settings.SINGLE_FILE:
+  if settings.SINGLE_FILE and settings.GENERATE_SOURCE_MAP:
+    diagnostics.warning('emcc', 'SINGLE_FILE disables source map support (which requires a .map file)')
     settings.GENERATE_SOURCE_MAP = 0
 
   if settings.EVAL_CTORS:


### PR DESCRIPTION
Source maps require a source map file, which SINGLE_FILE disallows. We
disable source maps in that case, but did not show a warning before
this PR.

Fixes #23257