### PR TITLE
[test] Simplify `also_with_proxying`. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1117,7 +1117,6 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     self.js_engines = config.JS_ENGINES.copy()
     self.settings_mods = {}
     self.skip_exec = None
-    self.proxied = False
     self.emcc_args = ['-Wclosure', '-Werror', '-Wno-limited-postlink-optimizations']
     # TODO(https://github.com/emscripten-core/emscripten/issues/11121)
     # For historical reasons emcc compiles and links as C++ by default.
@@ -1286,7 +1285,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   #                  libraries, for example
   def get_emcc_args(self, main_file=False, compile_only=False, asm_only=False):
     def is_ldflag(f):
-      return any(f.startswith(s) for s in ['-sEXPORT_ES6', '-sPROXY_TO_PTHREAD', '-sENVIRONMENT=', '--pre-js=', '--post-js=', '-sPTHREAD_POOL_SIZE='])
+      return any(f.startswith(s) for s in ['-sEXPORT_ES6', '--proxy-to-worker', '-sGL_TESTING', '-sPROXY_TO_WORKER', '-sPROXY_TO_PTHREAD', '-sENVIRONMENT=', '--pre-js=', '--post-js=', '-sPTHREAD_POOL_SIZE='])
 
     args = self.serialize_settings(compile_only or asm_only) + self.emcc_args
     if asm_only:
@@ -1692,7 +1691,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         self.fail(f'subprocess exited with non-zero return code({e.returncode}): `{shared.shlex_join(cmd)}`')
 
   def emcc(self, filename, args=[], output_filename=None, **kwargs):  # noqa
-    cmd = [compiler_for(filename), filename] + self.get_emcc_args(compile_only='-c' in args) + args
+    compile_only = '-c' in args or '-sSIDE_MODULE' in args
+    cmd = [compiler_for(filename), filename] + self.get_emcc_args(compile_only=compile_only) + args
     if output_filename:
       cmd += ['-o', output_filename]
     self.run_process(cmd, **kwargs)
@@ -2326,11 +2326,6 @@ class BrowserCore(RunnerCore):
       args = []
     args = args.copy()
     filename = find_browser_test_file(filename)
-
-    # Run via --proxy-to-worker.  This gets set by the @also_with_proxying.
-    if self.proxied:
-      args += ['--proxy-to-worker', '-sGL_TESTING']
-
     outfile = output_basename + '.html'
     args += ['-o', outfile]
     # print('all args:', args)

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -105,7 +105,8 @@ def also_with_proxying(f):
   def metafunc(self, proxied, *args, **kwargs):
     if DEBUG:
       print('parameterize:proxied=%d' % proxied)
-    self.proxied = proxied
+    if proxied:
+      self.proxy_to_worker()
     f(self, *args, **kwargs)
 
   parameterize(metafunc, {'': (False,),
@@ -118,7 +119,7 @@ def proxied(f):
 
   @wraps(f)
   def decorated(self, *args, **kwargs):
-    self.proxied = True
+    self.proxy_to_worker()
     return f(self, *args, **kwargs)
 
   return decorated
@@ -243,6 +244,9 @@ class browser(BrowserCore):
       '-Wno-int-conversion',
     ]
 
+  def proxy_to_worker(self):
+    self.emcc_args += ['--proxy-to-worker', '-sGL_TESTING']
+
   def require_jspi(self):
     if not is_chrome():
       self.skipTest(f'Current browser ({EMTEST_BROWSER}) does not support JSPI. Only chromium-based browsers ({CHROMIUM_BASED_BROWSERS}) support JSPI today.')
@@ -283,7 +287,7 @@ window.close = () => {
     assert 'expected' not in kwargs
     expected = [str(i) for i in range(0, reference_slack + 1)]
     self.make_reftest(reference)
-    if self.proxied:
+    if '--proxy-to-worker' in self.emcc_args:
       assert 'post_build' not in kwargs
       kwargs['post_build'] = self.post_manual_reftest
       create_file('fakereftest.js', 'var reftestUnblock = () => {}; var reftestBlock = () => {};')
@@ -2032,7 +2036,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
   })
   @requires_graphics_hardware
   def test_cubegeom(self, args):
-    if self.proxied and args:
+    if '--proxy-to-worker' in self.emcc_args and args:
       # proxy only in the simple, normal case (we can't trace GL calls when proxied)
       self.skipTest('tracing + proxying not supported')
     self.reftest('third_party/cubegeom/cubegeom.c', 'third_party/cubegeom/cubegeom.png', args=['-O2', '-g', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'] + args)
@@ -2995,7 +2999,7 @@ Module["preRun"] = () => {
   @requires_graphics_hardware
   @also_with_proxying
   def test_sdl2_glshader(self):
-    if not self.proxied:
+    if '--proxy-to-worker' not in self.emcc_args:
       # closure build current fails on proxying
       self.emcc_args += ['--closure=1', '-g1']
     self.reftest('test_sdl2_glshader.c', 'test_sdl_glshader.png', args=['-sUSE_SDL=2', '-sLEGACY_GL_EMULATION'])
@@ -3430,11 +3434,8 @@ Module["preRun"] = () => {
     self.btest('webidl/test.cpp', '1', args=['--post-js', 'glue.js', '-I.', '-DBROWSER'] + args)
 
   @no_wasm64('https://github.com/llvm/llvm-project/issues/98778')
-  @parameterized({
-    '': ([],),
-    'proxy_to_worker': (['--proxy-to-worker'],),
-  })
-  def test_dylink(self, args):
+  @also_with_proxying
+  def test_dylink(self):
     create_file('main.c', r'''
       #include <assert.h>
       #include <stdio.h>
@@ -3455,7 +3456,7 @@ Module["preRun"] = () => {
       }
     ''')
     self.emcc('side.c', ['-sSIDE_MODULE', '-O2', '-o', 'side.wasm'])
-    self.btest_exit('main.c', args=['-sMAIN_MODULE=2', '-O2', 'side.wasm'] + args)
+    self.btest_exit('main.c', args=['-sMAIN_MODULE=2', '-O2', 'side.wasm'])
 
   def test_dlopen_async(self):
     create_file('side.c', 'int foo = 42;\n')


### PR DESCRIPTION
Implement `also_with_proxying` solely in `test_browser.py` avoiding the need for `self.proxying` handling in `common.js`.