### PR TITLE
Raise ENOSYS if AT_SYMLINK_NOFOLLOW is used with chmod or chown in nodefs

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -972,7 +972,8 @@ FS.staticInit();
       }
       node.node_ops.setattr(node, {
         mode: (mode & {{{ cDefs.S_IALLUGO }}}) | (node.mode & ~{{{ cDefs.S_IALLUGO }}}),
-        ctime: Date.now()
+        ctime: Date.now(),
+        dontFollow
       });
     },
     lchmod(path, mode) {
@@ -994,7 +995,8 @@ FS.staticInit();
         throw new FS.ErrnoError({{{ cDefs.EPERM }}});
       }
       node.node_ops.setattr(node, {
-        timestamp: Date.now()
+        timestamp: Date.now(),
+        dontFollow
         // we ignore the uid / gid for now
       });
     },

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -153,6 +153,9 @@ addToLibrary({
         };
       },
       setattr(node, attr) {
+        if (attr.dontFollow) {
+          throw new FS.ErrnoError({{{ cDefs.ENOSYS }}});
+        }
         var path = NODEFS.realPath(node);
         NODEFS.tryFSOperation(() => {
           if (attr.mode !== undefined) {

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -153,12 +153,12 @@ addToLibrary({
         };
       },
       setattr(node, attr) {
-        if (attr.dontFollow) {
-          throw new FS.ErrnoError({{{ cDefs.ENOSYS }}});
-        }
         var path = NODEFS.realPath(node);
         NODEFS.tryFSOperation(() => {
           if (attr.mode !== undefined) {
+            if (attr.dontFollow) {
+              throw new FS.ErrnoError({{{ cDefs.ENOSYS }}});
+            }
             var mode = attr.mode;
             if (NODEFS.isWindows) {
               // Windows only supports S_IREAD / S_IWRITE (S_IRUSR / S_IWUSR)

--- a/test/stat/test_chmod.c
+++ b/test/stat/test_chmod.c
@@ -93,6 +93,15 @@ void test() {
   err = fchmodat(AT_FDCWD, "otherfile", S_IXUSR, 0);
   assert(!err);
 
+  assert(symlink("otherfile", "link") == 0);
+  err = fchmodat(AT_FDCWD, "link", S_IXGRP, AT_SYMLINK_NOFOLLOW);
+#if defined(NODEFS) || defined(NODERAWFS)
+  assert(err == -1);
+  assert(errno == ENOTSUP);
+#else
+  assert(err == 0);
+#endif
+
   memset(&s, 0, sizeof s);
   stat("otherfile", &s);
   assert(s.st_mode == (S_IXUSR | S_IFREG));

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5524,8 +5524,7 @@ got: 10
     self.do_runf('stat/test_fstatat.c', 'success')
 
   @crossplatform
-  @also_with_wasmfs
-  @also_with_noderawfs
+  @with_all_fs
   def test_stat_chmod(self):
     if self.get_setting('NODERAWFS') and WINDOWS:
       self.skipTest('mode bits work differently on windows')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5526,7 +5526,8 @@ got: 10
   @crossplatform
   @with_all_fs
   def test_stat_chmod(self):
-    if self.get_setting('NODERAWFS') and WINDOWS:
+    nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
+    if nodefs and WINDOWS:
       self.skipTest('mode bits work differently on windows')
     if self.get_setting('WASMFS') and self.get_setting('NODERAWFS'):
       self.skipTest('test requires symlink creation which currently missing from wasmfs+noderawfs')


### PR DESCRIPTION
It cannot support this since node doesn't support it. So we should tell the truth that we can't do it instead of ignoring it.