### PR TITLE
Update default Safari version target to 15.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,17 +22,23 @@ See docs/process.md for more on how version tagging works.
 ----------------------
 - compiler-rt, libcxx, libcxxabi, and libunwind were updated to LLVM 19.1.6.
   (#22937, #22994, and #23294)
-- The Wasm nontrapping-fptoint feature has been enabled by default. clang will
-  generate nontrapping (saturating) float-to-int conversion instructions for
-  C typecasts. This should have no effect on programs that do not have
-  undefined behavior but if the casted floating-point value is outside the range
-  of the target integer type, the result will be a number of the max or min value
-  instead of a trap. This also results in a small code size improvement because
-  of details of the LLVM IR semantics. This feature can be disabled in clang with
-  the -mno-nontrapping-fptoint flag. (#23007)
-- The `WASM_BIGINT` feature has been enabled by default. This has the effect that
-  Wasm i64 values are passed and returned between Wasm and JS as BigInt values
-  rather than being split by Binaryen into pairs of Numbers. (#22993)
+- The default Safari version targeted by Emscripten has been raised from 14.1
+  to 15.0 (the `MIN_SAFARI_VERSION` setting) (#23312). This has several effects:
+  - The Wasm nontrapping-fptoint feature is enabled by default. Clang will
+    generate nontrapping (saturating) float-to-int conversion instructions for
+    C typecasts. This should have no effect on programs that do not have
+    undefined behavior but if the casted floating-point value is outside the range
+    of the target integer type, the result will be a number of the max or min value
+    instead of a trap. This also results in a small code size improvement because
+    of details of the LLVM IR semantics. This feature can be disabled in clang with
+    the -mno-nontrapping-fptoint flag. (#23007)
+  - The `WASM_BIGINT` feature is enabled by default. This has the effect that
+    Wasm i64 values are passed and returned between Wasm and JS as BigInt values
+    rather than being split by Binaryen into pairs of Numbers. (#22993)
+  - The `BULK_MEMORY` feature is enabled by default. `memory.copy` and
+    `memory.fill` instructions are used in the implementation of C `memcpy` and
+    `memset`, and Clang may generate them elsewhere (#22873). It can be
+    disabled with the `-mno-bulk-memory` flag.
 - When using `-sMODULARIZE` we now assert if the factory function is called with
   the JS `new` keyword.  e.g. `a = new Module()` rather than `b = Module()`.
   This paves the way for marking the function as `async` which does not allow

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -2928,7 +2928,7 @@ MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
 Minimum supported value is 101000 which was released in 2016-09 (see
 feature_matrix.py).
 
-Default value: 140100
+Default value: 150000
 
 .. _min_chrome_version:
 

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -2186,8 +2186,7 @@ WASM_BIGINT
 
 WebAssembly integration with JavaScript BigInt. When enabled we don't need to
 legalize i64s into pairs of i32s, as the wasm VM will use a BigInt where an
-i64 is used. If WASM_BIGINT is present, the default minimum supported browser
-versions will be increased to the min version that supports BigInt.
+i64 is used.
 
 Default value: true
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1913,7 +1913,7 @@ var MIN_FIREFOX_VERSION = 79;
 // Minimum supported value is 101000 which was released in 2016-09 (see
 // feature_matrix.py).
 // [link]
-var MIN_SAFARI_VERSION = 140100;
+var MIN_SAFARI_VERSION = 150000;
 
 // Specifies the oldest version of Chrome. E.g. pass -sMIN_CHROME_VERSION=58 to
 // drop support for Chrome 57 and older.

--- a/src/settings.js
+++ b/src/settings.js
@@ -1495,8 +1495,7 @@ var DYNCALLS = false;
 
 // WebAssembly integration with JavaScript BigInt. When enabled we don't need to
 // legalize i64s into pairs of i32s, as the wasm VM will use a BigInt where an
-// i64 is used. If WASM_BIGINT is present, the default minimum supported browser
-// versions will be increased to the min version that supports BigInt.
+// i64 is used.
 // [link]
 var WASM_BIGINT = true;
 

--- a/src/shell.js
+++ b/src/shell.js
@@ -34,8 +34,7 @@ var Module = typeof {{{ EXPORT_NAME }}} != 'undefined' ? {{{ EXPORT_NAME }}} : {
 #endif // USE_CLOSURE_COMPILER
 
 #if POLYFILL
-#if WASM_BIGINT && MIN_SAFARI_VERSION < 140100
-// TODO(https://github.com/emscripten-core/emscripten/issues/23184): Fix this back to 150000
+#if WASM_BIGINT && MIN_SAFARI_VERSION < 150000
 // See https://caniuse.com/mdn-javascript_builtins_bigint64array
 #include "polyfill/bigint64array.js"
 #endif

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10482,6 +10482,12 @@ int main() {
     compile(['-sMIN_SAFARI_VERSION=150000', '-mno-bulk-memory'])
     verify_features_sec_linked('bulk-memory-opt', False)
 
+    # Bigint ovrride does not cause other features to enable
+    compile(['-sMIN_SAFARI_VERSION=140100', '-sWASM_BIGINT=1'])
+    verify_features_sec_linked('bulk-memory-opt', False)
+
+    compile(['-sMIN_SAFARI_VERSION=140100', '-mbulk-memory'])
+    verify_features_sec_linked('nontrapping-fptoint', False)
 
   def test_js_preprocess(self):
     # Use stderr rather than stdout here because stdout is redirected to the output JS file itself.

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10443,6 +10443,7 @@ int main() {
     def compile(flags):
       self.run_process([EMCC, test_file('hello_world.c')] + flags)
 
+    # Default features, unlinked and linked
     compile(['-c'])
     verify_features_sec('bulk-memory', True)
     verify_features_sec('nontrapping-fptoint', True)
@@ -10451,17 +10452,28 @@ int main() {
     verify_features_sec('multivalue', True)
     verify_features_sec('reference-types', True)
 
+    compile([])
+    verify_features_sec_linked('sign-ext', True)
+    verify_features_sec_linked('mutable-globals', True)
+    verify_features_sec_linked('multivalue', True)
+    verify_features_sec_linked('bulk-memory-opt', True)
+    verify_features_sec_linked('nontrapping-fptoint', True)
+    verify_features_sec_linked('reference-types', True)
+
     # Disable a feature
     compile(['-mno-sign-ext', '-c'])
     verify_features_sec('sign-ext', False)
     # Disable via browser selection
     compile(['-sMIN_FIREFOX_VERSION=61'])
     verify_features_sec_linked('sign-ext', False)
+    compile(['-sMIN_SAFARI_VERSION=140100'])
+    verify_features_sec_linked('bulk-memory-opt', False)
+    verify_features_sec_linked('nontrapping-fptoint', False)
     # Flag disabling overrides default browser versions
     compile(['-mno-sign-ext'])
     verify_features_sec_linked('sign-ext', False)
     # Flag disabling overrides explicit browser version
-    compile(['-sMIN_SAFARI_VERSION=150000', '-mno-sign-ext'])
+    compile(['-sMIN_SAFARI_VERSION=160000', '-mno-sign-ext'])
     verify_features_sec_linked('sign-ext', False)
     # Flag enabling overrides explicit browser version
     compile(['-sMIN_FIREFOX_VERSION=61', '-msign-ext'])
@@ -10470,18 +10482,6 @@ int main() {
     compile(['-sMIN_SAFARI_VERSION=150000', '-mno-bulk-memory'])
     verify_features_sec_linked('bulk-memory-opt', False)
 
-    # TODO(https://github.com/emscripten-core/emscripten/issues/23184) set this back to 14.1
-    # Also the section below can be deleted/updated once the default is 15.1
-    compile(['-sMIN_SAFARI_VERSION=140000'])
-    verify_features_sec_linked('bulk-memory-opt', False)
-    verify_features_sec_linked('nontrapping-fptoint', False)
-
-    compile(['-sMIN_SAFARI_VERSION=150000'])
-    verify_features_sec_linked('sign-ext', True)
-    verify_features_sec_linked('mutable-globals', True)
-    verify_features_sec_linked('multivalue', True)
-    verify_features_sec_linked('bulk-memory-opt', True)
-    verify_features_sec_linked('nontrapping-fptoint', True)
 
   def test_js_preprocess(self):
     # Use stderr rather than stdout here because stdout is redirected to the output JS file itself.
@@ -12360,8 +12360,7 @@ Aborted(`Module.arguments` has been replaced by `arguments_` (the initial value 
     # plain -O0
     legalization_message = 'to disable int64 legalization (which requires changes after link) use -sWASM_BIGINT'
     fail(['-sWASM_BIGINT=0'], legalization_message)
-    # TODO(https://github.com/emscripten-core/emscripten/issues/23184): change this back to 140100 after 15 is default
-    fail(['-sMIN_SAFARI_VERSION=140000'], legalization_message)
+    fail(['-sMIN_SAFARI_VERSION=140100'], legalization_message)
     # optimized builds even without legalization
     optimization_message = '-O2+ optimizations always require changes, build with -O0 or -O1 instead'
     fail(['-O2'], optimization_message)
@@ -14435,8 +14434,7 @@ foo/version.txt
 
   def test_min_browser_version(self):
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Wno-transpile', '-Werror', '-sWASM_BIGINT', '-sMIN_SAFARI_VERSION=120000'])
-    # TODO(https://github.com/emscripten-core/emscripten/issues/23184): fix back to 15000 once Safari 15 is default
-    self.assertContained('emcc: error: MIN_SAFARI_VERSION=120000 is not compatible with WASM_BIGINT (140100 or above required)', err)
+    self.assertContained('emcc: error: MIN_SAFARI_VERSION=120000 is not compatible with WASM_BIGINT (150000 or above required)', err)
 
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Wno-transpile', '-Werror', '-pthread', '-sMIN_CHROME_VERSION=73'])
     self.assertContained('emcc: error: MIN_CHROME_VERSION=73 is not compatible with pthreads (74 or above required)', err)

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -46,7 +46,7 @@ min_browser_versions = {
   Feature.NON_TRAPPING_FPTOINT: {
     'chrome': 75,
     'firefox': 65,
-    'safari': 140100, # TODO: Reset back to 150000 when the default changes
+    'safari': 150000,
     'node': 130000,
   },
   Feature.SIGN_EXT: {
@@ -58,7 +58,7 @@ min_browser_versions = {
   Feature.BULK_MEMORY: {
     'chrome': 75,
     'firefox': 79,
-    'safari': 140100, # TODO: Reset this to 150000 when we update the default.
+    'safari': 150000,
     'node': 130000,
   },
   Feature.MUTABLE_GLOBALS: {
@@ -70,7 +70,7 @@ min_browser_versions = {
   Feature.JS_BIGINT_INTEGRATION: {
     'chrome': 67,
     'firefox': 68,
-    'safari': 140100, # TODO(https://github.com/emscripten-core/emscripten/issues/23184): set this back to 15 after we update the default targets.
+    'safari': 150000,
     'node': 130000,
   },
   Feature.THREADS: {


### PR DESCRIPTION
Update the default MIN_SAFARI_VERSION from 14.1 to 15.0.
Also fix the feature matrix code to be correct again as described in #23184
