### PR TITLE
Fix bug in `--reproduce` with `-ofoo.js` flag

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -203,7 +203,7 @@ def create_reproduce_file(name, args):
           if arg.startswith('--reproduce='):
             continue
 
-          if arg.startswith('-o='):
+          if len(arg) > 2 and arg.startswith('-o'):
             rsp.write('-o\n')
             arg = arg[3:]
             output_arg = True

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14416,7 +14416,8 @@ int main() {
 
   @crossplatform
   def test_reproduce(self):
-    self.run_process([EMCC, '-sASSERTIONS=1', '--reproduce=foo.tar', test_file('hello_world.c')])
+    ensure_dir('tmp')
+    self.run_process([EMCC, '-sASSERTIONS=1', '--reproduce=foo.tar', '-otmp/out.js', test_file('hello_world.c')])
     self.assertExists('foo.tar')
     names = []
     root = os.path.splitdrive(path_from_root())[1][1:]
@@ -14436,6 +14437,8 @@ foo/version.txt
     self.assertTextDataIdentical(expected, names)
     expected = '''\
 -sASSERTIONS=1
+-o
+out.js
 <root>/test/hello_world.c
 '''
     response = read_file('foo/response.txt')


### PR DESCRIPTION
The `-o` flag is not ever followed by an equals sign (`-o=out.js` will produce a file called `=out.js`) so this code was not handling the use case it was indented to.