### PR TITLE
[test] Bump memory64 node-canary requirment from v23 to v24. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -962,7 +962,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     nodejs = self.get_nodejs()
     if nodejs:
       version = shared.get_node_version(nodejs)
-      if version >= (23, 0, 0):
+      if version >= (24, 0, 0):
         self.js_engines = [nodejs]
         return
 
@@ -972,9 +972,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       return
 
     if 'EMTEST_SKIP_WASM64' in os.environ:
-      self.skipTest('test requires node >= 23 or d8 (and EMTEST_SKIP_WASM64 is set)')
+      self.skipTest('test requires node >= 24 or d8 (and EMTEST_SKIP_WASM64 is set)')
     else:
-      self.fail('either d8 or node >= 23 required to run wasm64 tests.  Use EMTEST_SKIP_WASM64 to skip')
+      self.fail('either d8 or node >= 24 required to run wasm64 tests.  Use EMTEST_SKIP_WASM64 to skip')
 
   def require_simd(self):
     if self.is_browser_test():


### PR DESCRIPTION
Node v23 (which has been released) doesn't support the final version to memory64 (specifically table64).

Node v24 (available via node canary builds) is the only version I know of that does.