### PR TITLE
[docs] Minor doc fixes around workers API. NFC

### DIFF
--- a/site/source/docs/api_reference/wasm_workers.rst
+++ b/site/source/docs/api_reference/wasm_workers.rst
@@ -402,4 +402,4 @@ The following build options are not supported at the moment with Wasm Workers:
 Example Code
 ============
 
-See the directory ``test/wasm_workers/`` for code examples on different Wasm Workers API functionality.
+See the directory ``test/wasm_worker/`` for code examples on different Wasm Workers API functionality.

--- a/system/include/emscripten/wasm_worker.h
+++ b/system/include/emscripten/wasm_worker.h
@@ -83,9 +83,9 @@ uint32_t emscripten_wasm_worker_self_id(void);
 // never be called.
 // Passing messages between threads with this family of functions is relatively
 // slow and has a really high latency cost compared to direct coordination using
-// atomics and synchronization primitives like mutexes and synchronization
-// primitives. Additionally these functions will generate garbage on the JS
-// heap.  Therefore avoid using these functions where performance is critical.
+// atomics and synchronization primitives like mutexes. Additionally these 
+// functions will generate garbage on the JS heap.  Therefore avoid using these 
+// functions where performance is critical.
 void emscripten_wasm_worker_post_function_v(emscripten_wasm_worker_t id, void (*funcPtr)(void) __attribute__((nonnull)));
 void emscripten_wasm_worker_post_function_vi(emscripten_wasm_worker_t id, void (*funcPtr)(int) __attribute__((nonnull)), int arg0);
 void emscripten_wasm_worker_post_function_vii(emscripten_wasm_worker_t id, void (*funcPtr)(int, int) __attribute__((nonnull)), int arg0, int arg1);


### PR DESCRIPTION
Two very minor docs fixes:
- The path "test/wasm_workers" in the workers reference is incorrect.
- A comment in the header repeats "synchronisation primitives".