### PR TITLE
Delay processing of --js-library flags. NFC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ lint.ignore = [
   "PLW2901",
 ]
 lint.per-file-ignores."emrun.py" = [ "PLE0704" ]
-lint.mccabe.max-complexity = 48 # Recommended: 10
+lint.mccabe.max-complexity = 49 # Recommended: 10
 lint.pylint.allow-magic-value-types = [
   "bytes",
   "float",
@@ -58,7 +58,7 @@ lint.pylint.allow-magic-value-types = [
   "str",
 ]
 lint.pylint.max-args = 15 # Recommended: 5
-lint.pylint.max-branches = 49 # Recommended: 12
+lint.pylint.max-branches = 50 # Recommended: 12
 lint.pylint.max-returns = 16 # Recommended: 6
 lint.pylint.max-statements = 142 # Recommended: 50
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -1240,7 +1240,7 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
       state.append_link_flag('--no-whole-archive')
     settings.FILESYSTEM = 1
     settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
-    settings.JS_LIBRARIES.append((0, 'library_wasmfs.js'))
+    settings.JS_LIBRARIES.append('library_wasmfs.js')
     if settings.ASSERTIONS:
       # used in assertion checks for unflushed content
       settings.REQUIRED_EXPORTS += ['wasmfs_flush']
@@ -1362,14 +1362,14 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
 
   if settings.PTHREADS:
     setup_pthreads()
-    settings.JS_LIBRARIES.append((0, 'library_pthread.js'))
+    settings.JS_LIBRARIES.append('library_pthread.js')
     if settings.PROXY_TO_PTHREAD:
       settings.PTHREAD_POOL_SIZE_STRICT = 0
       settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$runtimeKeepalivePush']
   else:
     if settings.PROXY_TO_PTHREAD:
       exit_with_error('-sPROXY_TO_PTHREAD requires -pthread to work!')
-    settings.JS_LIBRARIES.append((0, 'library_pthread_stub.js'))
+    settings.JS_LIBRARIES.append('library_pthread_stub.js')
 
   if settings.MEMORY64:
     # Any "pointers" passed to JS will now be i64's, in both modes.
@@ -1383,7 +1383,7 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
     # set location of Wasm Worker bootstrap JS file
     if settings.WASM_WORKERS == 1:
       settings.WASM_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.ww.js'
-    settings.JS_LIBRARIES.append((0, 'library_wasm_worker.js'))
+    settings.JS_LIBRARIES.append('library_wasm_worker.js')
 
   # Set min browser versions based on certain settings such as WASM_BIGINT,
   # PTHREADS, AUDIO_WORKLET
@@ -1401,7 +1401,7 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
   if settings.AUDIO_WORKLET:
     if settings.AUDIO_WORKLET == 1:
       settings.AUDIO_WORKLET_FILE = unsuffixed(os.path.basename(target)) + '.aw.js'
-    settings.JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_webaudio.js')))
+    settings.JS_LIBRARIES.append(shared.path_from_root('src', 'library_webaudio.js'))
     if not settings.MINIMAL_RUNTIME:
       # If we are in the audio worklet environment, we can only access the Module object
       # and not the global scope of the main JS script. Therefore we need to export
@@ -2807,12 +2807,15 @@ def map_to_js_libs(library_name):
 
 def process_libraries(state):
   new_flags = []
-  libraries = []
   suffixes = STATICLIB_ENDINGS + DYNAMICLIB_ENDINGS
   system_libs_map = system_libs.Library.get_usable_variations()
 
-  # Find library files
+  # Process `-l` and `--js-library` flags
   for i, flag in state.link_flags:
+    if flag.startswith('--js-library='):
+      js_lib = os.path.abspath(flag.split('=', 1)[1])
+      settings.JS_LIBRARIES.append(js_lib)
+      continue
     if not flag.startswith('-l'):
       new_flags.append((i, flag))
       continue
@@ -2822,7 +2825,7 @@ def process_libraries(state):
 
     js_libs = map_to_js_libs(lib)
     if js_libs is not None:
-      libraries += [(i, js_lib) for js_lib in js_libs]
+      settings.JS_LIBRARIES += js_libs
 
     # We don't need to resolve system libraries to absolute paths here, we can just
     # let wasm-ld handle that.  However, we do want to map to the correct variant.
@@ -2848,12 +2851,6 @@ def process_libraries(state):
 
     new_flags.append((i, flag))
 
-  settings.JS_LIBRARIES += libraries
-
-  # At this point processing JS_LIBRARIES is finished, no more items will be added to it.
-  # Sort the input list from (order, lib_name) pairs to a flat array in the right order.
-  settings.JS_LIBRARIES.sort(key=lambda lib: lib[0])
-  settings.JS_LIBRARIES = [lib[1] for lib in settings.JS_LIBRARIES]
   state.link_flags = new_flags
 
 


### PR DESCRIPTION
By delaying the processing of `--js-library` arguments we avoid having to jump through hoops and store them alongside their ordinal number for half the time.