### PR TITLE
Disable emmalloc_trim

### DIFF
--- a/system/lib/emmalloc.c
+++ b/system/lib/emmalloc.c
@@ -1227,6 +1227,7 @@ struct mallinfo emmalloc_mallinfo() {
 }
 EMMALLOC_ALIAS(mallinfo, emmalloc_mallinfo);
 
+#if 0
 // Note! This function is not fully multithreading safe: while this function is running, other threads should not be
 // allowed to call sbrk()!
 static int trim_dynamic_heap_reservation(size_t pad) {
@@ -1280,12 +1281,19 @@ static int trim_dynamic_heap_reservation(size_t pad) {
   // All successful, and we actually trimmed memory!
   return 1;
 }
+#endif
 
 int emmalloc_trim(size_t pad) {
+  // Reducing the size of the sbrk region is currently broken.
+  // See https://github.com/emscripten-core/emscripten/issues/23343
+  // And https://github.com/emscripten-core/emscripten/pull/13442
+  return 0;
+  /*
   MALLOC_ACQUIRE();
   int success = trim_dynamic_heap_reservation(pad);
   MALLOC_RELEASE();
   return success;
+  */
 }
 EMMALLOC_ALIAS(malloc_trim, emmalloc_trim)
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -821,6 +821,7 @@ base align: 0, 0, 0, 0'''])
   @no_4gb('output is sensitive to absolute data layout')
   @no_asan('ASan does not support custom memory allocators')
   @no_lsan('LSan does not support custom memory allocators')
+  @disabled('https://github.com/emscripten-core/emscripten/issues/23343')
   def test_emmalloc_trim(self):
     self.set_setting('MALLOC', 'emmalloc')
     self.emcc_args += ['-sINITIAL_MEMORY=128MB', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=2147418112']


### PR DESCRIPTION
I believe this function has not been working correctly since #13442 when sbrk stopped accepting negative values.

Maybe we can find a way to bring this functionality back but disabling it for now seems safest.

See: #23343