### PR TITLE
Simplify file finding/reading files in JS compiler. NFC

### DIFF
--- a/src/compiler.mjs
+++ b/src/compiler.mjs
@@ -7,28 +7,11 @@
 
 // LLVM => JavaScript compiler, main entry point
 
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as url from 'node:url';
-
 import {Benchmarker, applySettings, assert, loadSettingsFile, printErr, read} from './utility.mjs';
 
-function find(filename) {
-  assert(filename);
-  const dirname = url.fileURLToPath(new URL('.', import.meta.url));
-  const prefixes = [dirname, process.cwd()];
-  for (let i = 0; i < prefixes.length; ++i) {
-    const combined = path.join(prefixes[i], filename);
-    if (fs.existsSync(combined)) {
-      return combined;
-    }
-  }
-  return filename;
-}
-
 // Load default settings
-loadSettingsFile(find('settings.js'));
-loadSettingsFile(find('settings_internal.js'));
+loadSettingsFile('settings.js');
+loadSettingsFile('settings_internal.js');
 
 const argv = process.argv.slice(2);
 const symbolsOnlyArg = argv.indexOf('--symbols-only');

--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -7,7 +7,6 @@
 // General JS utilities - things that might be useful in any JS project.
 // Nothing specific to Emscripten appears here.
 
-import * as url from 'node:url';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as vm from 'node:vm';
@@ -240,11 +239,9 @@ export function read(filename) {
   return fs.readFileSync(absolute).toString();
 }
 
-export function find(filename) {
-  const dirname = url.fileURLToPath(new URL('.', import.meta.url));
-  const prefixes = [process.cwd(), path.join(dirname, '..', 'src')];
-  for (let i = 0; i < prefixes.length; ++i) {
-    const combined = path.join(prefixes[i], filename);
+function find(filename) {
+  for (const prefix of [process.cwd(), import.meta.dirname]) {
+    const combined = path.join(prefix, filename);
     if (fs.existsSync(combined)) {
       return combined;
     }


### PR DESCRIPTION
- Use import.meta.dirname
- Remove duplicate copy of `find` function.
- Remove `export` of find function
