### PR TITLE
Remove unused isPowerOfTwo function from JS compiler. NFC

### DIFF
--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -231,13 +231,9 @@ export function isDecorator(ident) {
   return suffixes.some((suffix) => ident.endsWith(suffix));
 }
 
-export function isPowerOfTwo(x) {
-  return x > 0 && (x & (x - 1)) == 0;
-}
-
 export function read(filename) {
   const absolute = find(filename);
-  return fs.readFileSync(absolute).toString();
+  return fs.readFileSync(absolute, 'utf8');
 }
 
 export function find(filename) {


### PR DESCRIPTION
Also, add `utf8` to read function to avoid the extra `toString()` call (which itself defaults to `utf8`).