### PR TITLE
Remove legacy/broken makeCopyValues from parseTools_legacy.mjs.  NFC

### DIFF
--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -12,7 +12,6 @@ import {
   addToCompileTimeContext,
   assert,
   error,
-  isNumber,
   printErr,
   read,
   runInMacroContext,
@@ -335,6 +334,11 @@ function ensureDot(value) {
   const e = value.indexOf('e');
   if (e < 0) return value + '.0';
   return value.substr(0, e) + '.0' + value.substr(e);
+}
+
+export function isNumber(x) {
+  // XXX this does not handle 0xabc123 etc. We should likely also do x == parseInt(x) (which handles that), and remove hack |// handle 0x... as well|
+  return x == parseFloat(x) || (typeof x == 'string' && x.match(/^-?\d+$/)) || x == 'NaN';
 }
 
 // ensures that a float type has either 5.5 (clearly a float) or +5 (float due to asm coercion)

--- a/src/parseTools_legacy.mjs
+++ b/src/parseTools_legacy.mjs
@@ -37,71 +37,6 @@ function receiveI64ParamAsI32s(name) {
   return '';
 }
 
-function stripCorrections(param) {
-  warn('use of legacy parseTools function: stripCorrections');
-  let m;
-  while (true) {
-    if ((m = /^\((.*)\)$/.exec(param))) {
-      param = m[1];
-      continue;
-    }
-    if ((m = /^\(([$_\w]+)\)&\d+$/.exec(param))) {
-      param = m[1];
-      continue;
-    }
-    if ((m = /^\(([$_\w()]+)\)\|0$/.exec(param))) {
-      param = m[1];
-      continue;
-    }
-    if ((m = /^\(([$_\w()]+)\)\>>>0$/.exec(param))) {
-      param = m[1];
-      continue;
-    }
-    if ((m = /CHECK_OVERFLOW\(([^,)]*),.*/.exec(param))) {
-      param = m[1];
-      continue;
-    }
-    break;
-  }
-  return param;
-}
-
-const UNROLL_LOOP_MAX = 8;
-
-function makeCopyValues(dest, src, num, type, modifier, align, sep = ';') {
-  warn('use of legacy parseTools function: makeCopyValues');
-  assert(typeof align === 'undefined');
-  function unroll(type, num, jump = 1) {
-    const setValues = range(num).map((i) =>
-      makeSetValue(dest, i * jump, makeGetValue(src, i * jump, type), type),
-    );
-    return setValues.join(sep);
-  }
-  // If we don't know how to handle this at compile-time, or handling it is best
-  // done in a large amount of code, call memcpy
-  if (!isNumber(num)) num = stripCorrections(num);
-  if (!isNumber(align)) align = stripCorrections(align);
-  if (!isNumber(num) || parseInt(num) / align >= UNROLL_LOOP_MAX) {
-    return '(_memcpy(' + dest + ', ' + src + ', ' + num + ')|0)';
-  }
-  num = parseInt(num);
-  // remove corrections, since we will be correcting after we add anyhow,
-  dest = stripCorrections(dest);
-  src = stripCorrections(src);
-  // and in the heap assignment expression
-  const ret = [];
-  [4, 2, 1].forEach((possibleAlign) => {
-    if (num == 0) return;
-    if (align >= possibleAlign) {
-      ret.push(unroll('i' + possibleAlign * 8, Math.floor(num / possibleAlign), possibleAlign));
-      src = getFastValue(src, '+', Math.floor(num / possibleAlign) * possibleAlign);
-      dest = getFastValue(dest, '+', Math.floor(num / possibleAlign) * possibleAlign);
-      num %= possibleAlign;
-    }
-  });
-  return ret.join(sep);
-}
-
 function makeMalloc(source, param) {
   warn('use of legacy parseTools function: makeMalloc');
   return `_malloc(${param})`;
@@ -143,7 +78,6 @@ addToCompileTimeContext({
   Runtime,
   addAtMain,
   asmFFICoercion,
-  makeCopyValues,
   makeMalloc,
   makeStructuralReturn,
   receiveI64ParamAsDouble,

--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -200,11 +200,6 @@ export function mergeInto(obj, other, options = null) {
   return Object.assign(obj, other);
 }
 
-export function isNumber(x) {
-  // XXX this does not handle 0xabc123 etc. We should likely also do x == parseInt(x) (which handles that), and remove hack |// handle 0x... as well|
-  return x == parseFloat(x) || (typeof x == 'string' && x.match(/^-?\d+$/)) || x == 'NaN';
-}
-
 // Symbols that start with '$' are not exported to the wasm module.
 // They are intended to be called exclusively by JS code.
 export function isJsOnlySymbol(symbol) {


### PR DESCRIPTION
This function was calling functions that are not imported by this module (at least isNumber and getFastValue).  Rather than fix this by importing them I think we can safely simple remove this.

Also, move isNumber in to parseTools.mjs which is its only user.

Also remove `stripCorrections` which was not exported via `addToCompileTimeContext` is was not visible at all.