### PR TITLE
Always use `size_t` in dlmalloc's mallinfo

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -64,6 +64,8 @@ See docs/process.md for more on how version tagging works.
 - JavaScript libraries can now be specified via `-lfoo.js`.  This works like the
   existing `--js-library` flag but will search the library path (all paths
   specified with `-L`) for `libfoo.js`. (#23338)
+- The `mallinfo` struct members are now defined as `size_t` which makes them
+  compatible with larger memories, and is also how linux defines them. (#23368)
 
 3.1.74 - 12/14/24
 -----------------

--- a/system/include/compat/malloc.h
+++ b/system/include/compat/malloc.h
@@ -11,16 +11,16 @@ extern "C" {
    system/lib/dlmalloc.c.  */
 
 struct mallinfo {
-  int arena;    /* total space allocated from system */
-  int ordblks;  /* number of non-inuse chunks */
-  int smblks;   /* unused -- always zero */
-  int hblks;    /* number of mmapped regions */
-  int hblkhd;   /* total space in mmapped regions */
-  int usmblks;  /* unused -- always zero */
-  int fsmblks;  /* unused -- always zero */
-  int uordblks; /* total allocated space */
-  int fordblks; /* total non-inuse space */
-  int keepcost; /* top-most, releasable (via malloc_trim) space */
+  size_t arena;    /* total space allocated from system */
+  size_t ordblks;  /* number of non-inuse chunks */
+  size_t smblks;   /* unused -- always zero */
+  size_t hblks;    /* number of mmapped regions */
+  size_t hblkhd;   /* total space in mmapped regions */
+  size_t usmblks;  /* unused -- always zero */
+  size_t fsmblks;  /* unused -- always zero */
+  size_t uordblks; /* total allocated space */
+  size_t fordblks; /* total non-inuse space */
+  size_t keepcost; /* top-most, releasable (via malloc_trim) space */
 };
 
 /* The routines.  */

--- a/system/lib/dlmalloc.c
+++ b/system/lib/dlmalloc.c
@@ -16,7 +16,6 @@
 #define ABORT __builtin_unreachable()
 /* allow malloc stats only in debug builds, which brings in stdio code. */
 #define NO_MALLOC_STATS 1
-#define MALLINFO_FIELD_TYPE int
 #endif
 /* XXX Emscripten Tracing API. This defines away the code if tracing is disabled. */
 #include <emscripten/trace.h>

--- a/test/core/test_setjmp_noleak.c
+++ b/test/core/test_setjmp_noleak.c
@@ -16,7 +16,7 @@ void luaWork(int d){
 
 void dump() {
   struct mallinfo m = mallinfo();
-  emscripten_outf("dump: %d , %d", m.arena, m.uordblks);
+  emscripten_outf("dump: %zu , %zu", m.arena, m.uordblks);
 }
 
 void work(int n) {


### PR DESCRIPTION
For some reason emscripten was overriding `MALLINFO_FIELD_TYPE` to be `int` even though this defaults `size_t` and `size_t` is what linux uses, and `size_t` allows for correct reporting of numbers larger than 2^32.

What is worse, the `MALLINFO_FIELD_TYPE` override was only applied when `DLMALLOC_DEBUG` was defined which meant that `MALLINFO_FIELD_TYPE` varied between `-sASSERTIONS=1` and `-sASSERTIONS=2` builds of dlmalloc!

This means that `-sMEMORY64 + -sASSERTIONS=2` builds of dlmalloc were simply broken WRT `mallinfo` since the public definition of mallinfo disagreed with the dlmalloc-internal version.

I verified that the follow tests fails without this change:  `EMCC_CFLAGS=-sASSERTIONS=2 ./test/runner wasm64.test_mallinfo`

I'm not updating the actual test code here since test coverage will be coming in #23330.

This change was spit out from #23330.