### PR TITLE
[embind] Simplify string.toWireType. NFC

### DIFF
--- a/test/code_size/embind_hello_wasm.json
+++ b/test/code_size/embind_hello_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 380,
-  "a.js": 9878,
-  "a.js.gz": 4282,
+  "a.js": 9753,
+  "a.js.gz": 4262,
   "a.wasm": 7348,
   "a.wasm.gz": 3375,
-  "total": 17778,
-  "total_gz": 8037
+  "total": 17653,
+  "total_gz": 8017
 }

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 380,
-  "a.js": 7153,
-  "a.js.gz": 3041,
+  "a.js": 7028,
+  "a.js.gz": 3021,
   "a.wasm": 9119,
   "a.wasm.gz": 4701,
-  "total": 16824,
-  "total_gz": 8122
+  "total": 16699,
+  "total_gz": 8102
 }


### PR DESCRIPTION
- Simplify the type check
- Restructure the loop to avoid checking stdStringIsUTF8 twice

