### PR TITLE
Enable eslint `no-undef` rule in JS compiler. NFC

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,12 +1,22 @@
 import globals from 'globals';
 import js from '@eslint/js';
 import { FlatCompat } from '@eslint/eslintrc';
+import { loadDefaultSettings } from './src/utility.mjs';
 
 const compat = new FlatCompat({
   baseDirectory: import.meta.dirname,
   recommendedConfig: js.configs.recommended,
   allConfig: js.configs.all
 });
+
+
+// Emscripten settings are made available to the compiler as global
+// variables.  Make sure eslint knows about them.
+const settings = loadDefaultSettings();
+const settingsGlobals = {};
+for (const name of Object.keys(settings)) {
+  settingsGlobals[name] = 'writable';
+}
 
 export default [{
   ignores: [
@@ -56,9 +66,10 @@ export default [{
     globals: {
       ...globals.browser,
       ...globals.node,
+      ...settingsGlobals,
     },
 
-    ecmaVersion: 13,
+    ecmaVersion: 'latest',
     sourceType: 'module',
   },
 
@@ -77,6 +88,7 @@ export default [{
   files: ['**/*.mjs'],
 
   rules: {
+    'no-undef': 'error',
     'no-unused-vars': ['error', {
       vars: 'all',
       args: 'none',

--- a/src/compiler.mjs
+++ b/src/compiler.mjs
@@ -7,11 +7,16 @@
 
 // LLVM => JavaScript compiler, main entry point
 
-import {Benchmarker, applySettings, assert, loadSettingsFile, printErr, read} from './utility.mjs';
+import {
+  Benchmarker,
+  applySettings,
+  assert,
+  loadDefaultSettings,
+  printErr,
+  read,
+} from './utility.mjs';
 
-// Load default settings
-loadSettingsFile('settings.js');
-loadSettingsFile('settings_internal.js');
+loadDefaultSettings();
 
 const argv = process.argv.slice(2);
 const symbolsOnlyArg = argv.indexOf('--symbols-only');

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -893,23 +893,6 @@ function buildStringArray(array) {
   }
 }
 
-function _asmjsDemangle(symbol) {
-  if (symbol.startsWith('dynCall_')) {
-    return symbol;
-  }
-  // Strip leading "_"
-  assert(symbol.startsWith('_'), `expected mangled symbol: ${symbol}`);
-  return symbol.substr(1);
-}
-
-// TODO(sbc): Remove this function along with _asmjsDemangle.
-function hasExportedFunction(func) {
-  warnOnce(
-    'hasExportedFunction has been replaced with hasExportedSymbol, which takes and unmangled (no leading underscore) symbol name',
-  );
-  return WASM_EXPORTS.has(_asmjsDemangle(func));
-}
-
 function hasExportedSymbol(sym) {
   return WASM_EXPORTS.has(sym);
 }
@@ -1109,7 +1092,6 @@ addToCompileTimeContext({
   getNativeTypeSize,
   getPerformanceNow,
   getUnsharedTextDecoderView,
-  hasExportedFunction,
   hasExportedSymbol,
   implicitSelf,
   isSymbolNeeded,

--- a/src/parseTools_legacy.mjs
+++ b/src/parseTools_legacy.mjs
@@ -7,15 +7,6 @@
 import {warn, addToCompileTimeContext} from './utility.mjs';
 import {ATMAINS, POINTER_SIZE, runIfMainThread} from './parseTools.mjs';
 
-// Takes a pair of return values, stashes one in tempRet0 and returns the other.
-// Should probably be renamed to `makeReturn64` but keeping this old name in
-// case external JS library code uses this name.
-function makeStructuralReturn(values) {
-  warn('use of legacy parseTools function: makeStructuralReturn');
-  assert(values.length == 2);
-  return 'setTempRet0(' + values[1] + '); return ' + asmCoercion(values[0], 'i32');
-}
-
 // Replaced (at least internally) with receiveI64ParamAsI53 that does
 // bounds checking.
 function receiveI64ParamAsDouble(name) {
@@ -42,33 +33,10 @@ function makeMalloc(source, param) {
   return `_malloc(${param})`;
 }
 
-function getNativeFieldSize(type) {
-  warn('use of legacy parseTools function: getNativeFieldSize');
-  return Math.max(getNativeTypeSize(type), POINTER_SIZE);
-}
-
 const Runtime = {
-  getNativeFieldSize,
   POINTER_SIZE,
   QUANTUM_SIZE: POINTER_SIZE,
 };
-
-function addAtMain(code) {
-  warn('use of legacy parseTools function: addAtMain');
-  assert(HAS_MAIN, 'addAtMain called but program has no main function');
-  ATMAINS.push(code);
-}
-
-function ensureValidFFIType(type) {
-  return type === 'float' ? 'double' : type; // ffi does not tolerate float XXX
-}
-
-// FFI return values must arrive as doubles, and we can force them to floats afterwards
-function asmFFICoercion(value, type) {
-  value = asmCoercion(value, ensureValidFFIType(type));
-  if (type === 'float') value = asmCoercion(value, 'float');
-  return value;
-}
 
 // Legacy name for runIfMainThread.
 const runOnMainThread = runIfMainThread;
@@ -76,10 +44,7 @@ const runOnMainThread = runIfMainThread;
 addToCompileTimeContext({
   ATMAINS,
   Runtime,
-  addAtMain,
-  asmFFICoercion,
   makeMalloc,
-  makeStructuralReturn,
   receiveI64ParamAsDouble,
   receiveI64ParamAsI32s,
   runOnMainThread,

--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -313,6 +313,13 @@ export function loadSettingsFile(f) {
   var settings = {};
   vm.runInNewContext(read(f), settings, {filename: find(f)});
   applySettings(settings);
+  return settings;
+}
+
+export function loadDefaultSettings() {
+  const rtn = loadSettingsFile('settings.js');
+  Object.assign(rtn, loadSettingsFile('settings_internal.js'));
+  return rtn;
 }
 
 export function runInMacroContext(code, options) {


### PR DESCRIPTION
This required making eslint aware of the settings globals which are used throughout the compiler.

Running this change revealed several legacy parseTools function that simply do not run due to references to undefined symbols (because of this we know that there are no active/current user of these functions).