### PR TITLE
[contrib.glfw3] Fixes GLFW_CONTEXT_VERSION_MAJOR ignored

### DIFF
--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -88,6 +88,7 @@ def linker_setup(ports, settings):
   root_path = os.path.join(ports.get_dir(), port_name)
   source_js_path = os.path.join(root_path, 'src', 'js', 'lib_emscripten_glfw3.js')
   settings.JS_LIBRARIES += [source_js_path]
+  settings.MAX_WEBGL_VERSION = 2 # for GLFW_CONTEXT_VERSION_MAJOR to work
 
 
 # Using contrib.glfw3 to avoid installing headers into top level include path


### PR DESCRIPTION
This is a follow up to the [ticket](https://github.com/emscripten-core/emscripten/issues/23372) discussion.

When users are using my port, the window hint `GLFW_CONTEXT_VERSION_MAJOR` is ignored due to how Emscripten behaves internally.

If the port sets the linker flag `MAX_WEBGL_VERSION=2`, then for a user of the library, which interact throught the GLFW API, it transparently works without asking the user to understand the internals of Emscripten and modify their build script.