### PR TITLE
Only allow absolute paths for EM_CONFIG/EM_CACHE, etc.

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15385,6 +15385,11 @@ addToLibrary({
     }''')
     self.do_runf('main.cpp', 'Hello from rust!', emcc_args=[lib])
 
+  def test_relative_em_cache(self):
+    with env_modify({'EM_CACHE': 'foo'}):
+      err = self.expect_fail([EMCC, '-c', test_file('hello_world.c')])
+      self.assertContained('emcc: error: environment variable EM_CACHE must be an absolute path: foo', err)
+
   @crossplatform
   def test_create_cache_directory(self):
     if config.FROZEN_CACHE:

--- a/tools/config.py
+++ b/tools/config.py
@@ -134,8 +134,11 @@ def parse_config_file():
       if env_value in ('', '0'):
         env_value = None
       # Unlike the other keys these two should always be lists.
-      if key in ('JS_ENGINES', 'WASM_ENGINES'):
+      if env_var in ('EM_JS_ENGINES', 'EM_WASM_ENGINES'):
         env_value = env_value.split(',')
+      if env_var in ('EM_CONFIG', 'EM_CACHE', 'EM_PORTS', 'EM_LLVM_ROOT', 'EM_BINARYEN_ROOT'):
+        if not os.path.isabs(env_value):
+          exit_with_error(f'environment variable {env_var} must be an absolute path: {env_value}')
       globals()[key] = env_value
     elif key in config:
       globals()[key] = config[key]


### PR DESCRIPTION
Allowing relative paths here breaks when emcc is run as a subprocess in a different directory.  This happens in when building system libraries in batch build mode.

One alternative to doing this would be convert all these paths to absolute paths when we read them and then re-export them with those different values for our sub-processes, but that seems more complex and error prone than just requiring them to be absolute in the first place.

I'm also not sure it makes much sense to use relative paths here since if the environment contains a relative path then the compiler cannot be used from different directories.  e.g.

```
$ export EM_CACHE=foo
$ emcc hello.c
$ cd foo && emcc foo.c  # confusingly would use a different cache
```

Fixes: #23374