### PR TITLE
MINIMAL_RUNTIME: Remove the need for WASM_MODULE_EXPORTS_DECLARES. NFC

### DIFF
--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -92,10 +92,6 @@ var wasmExports;
 var wasmModule;
 #endif
 
-#if DECLARE_ASM_MODULE_EXPORTS
-<<< WASM_MODULE_EXPORTS_DECLARES >>>
-#endif
-
 #if PTHREADS
 function loadModule() {
   assignWasmImports();


### PR DESCRIPTION
In MINIMAL_RUNTIME we had extra replacements that were doing for declaring and assigned wasm exports:

- WASM_MODULE_EXPORTS_DECLARES
- WASM_MODULE_EXPORTS

This change avoids the need for the first of these by instead modifying the `receiving`.