### PR TITLE
[MINIMAL_RUNTIME] Remove WASM_MODULE_EXPORTS replacement. NFC

### DIFF
--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -183,7 +183,7 @@ WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
 #if !DECLARE_ASM_MODULE_EXPORTS
   exportWasmSymbols(wasmExports);
 #else
-  <<< WASM_MODULE_EXPORTS >>>
+  assignWasmExports(wasmExports);
 #endif
 #if '$wasmTable' in addedLibraryItems
   wasmTable = wasmExports['__indirect_function_table'];

--- a/test/js_optimizer/minimal-runtime-2-emitDCEGraph.js
+++ b/test/js_optimizer/minimal-runtime-2-emitDCEGraph.js
@@ -65,11 +65,14 @@ var imports = {
  }
 };
 var _main, _unused, wasmExports;
-WebAssembly.instantiate(Module["wasm"], imports).then(((output) => {
- wasmExports = output.instance.exports;
+function assignWasmExports(wasmExports) {
  _main = wasmExports["b"];
  _unused = wasmExports["c"];
- initRuntime();
+}
+WebAssembly.instantiate(Module["wasm"], imports).then(((output) => {
+ wasmExports = output.instance.exports;
+ assignWasmExports(wasmExports);
+ initRuntime(wasmExports);
  ready();
 }));
 

--- a/test/js_optimizer/minimal-runtime-emitDCEGraph.js
+++ b/test/js_optimizer/minimal-runtime-emitDCEGraph.js
@@ -36,7 +36,7 @@ var wasmImports = {
 function run() {
  var ret = _main();
 }
-function initRuntime() {
+function initRuntime(wasmExports) {
  for (var i in __ATINIT__) __ATINIT__[i].func();
 }
 var env = wasmImports;
@@ -65,11 +65,15 @@ var imports = {
  }
 };
 var _main, _unused;
-WebAssembly.instantiate(Module["wasm"], imports).then(((output) => {
- var wasmExports = output.instance.exports;
+function assignWasmExports(wasmExports) {
  _main = wasmExports["b"];
  _unused = wasmExports["c"];
- initRuntime();
+}
+
+WebAssembly.instantiate(Module["wasm"], imports).then(((output) => {
+ var wasmExports = output.instance.exports;
+ assignWasmExports(wasmExports);
+ initRuntime(wasmExports);
  ready();
 }));
 

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -53,20 +53,6 @@ ASAN_C_HELPERS = [
 ]
 
 
-def compute_minimal_runtime_initializer_and_exports(post, exports, receiving):
-  # Declare all exports out to global JS scope so that JS library functions can access them in a
-  # way that minifies well with Closure
-  # e.g. var a,b,c,d,e,f;
-
-  # `receiving` contains all of the assignments from wasm exports to
-  # global JS variables: e.g. a = wasmExports['a']; b = wasmExports['b'];
-  post = shared.do_replace(post, '<<< WASM_MODULE_EXPORTS >>>', receiving)
-
-  exports = [asmjs_mangle(x) for x in exports if x != building.WASM_CALL_CTORS]
-  receiving = 'var ' + ',\n '.join(exports) + ';'
-  return post, receiving
-
-
 def write_output_file(outfile, module):
   for chunk in module:
     outfile.write(chunk)
@@ -458,12 +444,6 @@ def emscript(in_wasm, out_wasm, outfile_js, js_syms, finalize=True, base_metadat
     pre = None
 
     receiving = create_receiving(function_exports)
-
-    if settings.MINIMAL_RUNTIME:
-      if settings.DECLARE_ASM_MODULE_EXPORTS:
-        post, receiving = compute_minimal_runtime_initializer_and_exports(post, function_exports, receiving)
-      else:
-        receiving = ''
 
     module = create_module(receiving, metadata, global_exports, forwarded_json['librarySymbols'])
 
@@ -964,30 +944,30 @@ def create_receiving(function_exports):
   receiving = []
 
   if settings.MINIMAL_RUNTIME:
-    # In Wasm exports are assigned inside a function to variables
+    # Exports are assigned inside a function to variables
     # existing in top level JS scope, i.e.
     # var _main;
-    # WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
-    #   var wasmExports = output.instance.exports;
+    # function assignWasmExports(wasmExport) {
     #   _main = wasmExports["_main"];
     generate_dyncall_assignment = settings.DYNCALLS and '$dynCall' in settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE
-    exports_that_are_not_initializers = [x for x in function_exports if x != building.WASM_CALL_CTORS]
-
-    for s in exports_that_are_not_initializers:
+    exports = [x for x in function_exports if x != building.WASM_CALL_CTORS]
+    receiving.append('function assignWasmExports(wasmExports) {')
+    for s in exports:
       mangled = asmjs_mangle(s)
       dynCallAssignment = ('dynCalls["' + s.replace('dynCall_', '') + '"] = ') if generate_dyncall_assignment and mangled.startswith('dynCall_') else ''
       should_export = settings.EXPORT_ALL or (settings.EXPORT_KEEPALIVE and mangled in settings.EXPORTED_FUNCTIONS)
       export_assignment = ''
       if settings.MODULARIZE and should_export:
         export_assignment = f"Module['{mangled}'] = "
-      receiving += [f'{export_assignment}{dynCallAssignment}{mangled} = wasmExports["{s}"]']
+      receiving.append(f"  {export_assignment}{dynCallAssignment}{mangled} = wasmExports['{s}'];")
+    receiving.append('}')
+    sep = ',\n  '
+    mangled = [asmjs_mangle(s) for s in exports]
+    receiving.append(f'var {sep.join(mangled)};')
   else:
     receiving += make_export_wrappers(function_exports)
 
-  if settings.MINIMAL_RUNTIME:
-    return '\n  '.join(receiving) + '\n'
-  else:
-    return '\n'.join(receiving) + '\n'
+  return '\n'.join(receiving) + '\n'
 
 
 def create_module(receiving, metadata, global_exports, library_symbols):


### PR DESCRIPTION
Followup to #23403

We now generate a new function called `assignWasmExports` which gets called instead of the `WASM_MODULE_EXPORTS` replacement.

As is evident from the lack of code size changes closure is able to inline this function.

The motivation for this change is 3-fold:

1. Remove differences between MINIMAL_RUNTIME and regular runtime.
2. Simplifies and logic by removing magic late stage replacement.
3. Sets the stage for regular runtime to use the same technique.