### PR TITLE
Fix import.meta.dirname in node 18

### DIFF
--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -232,6 +232,10 @@ export function read(filename) {
 
 function find(filename) {
   for (const prefix of [process.cwd(), import.meta.dirname]) {
+    // import.meta.dirname does not work in all versions of node.
+    if (!prefix) {
+      continue;
+    }
     const combined = path.join(prefix, filename);
     if (fs.existsSync(combined)) {
       return combined;


### PR DESCRIPTION
Likely I am doing something wrong, but I need this change, or else this happens for me locally with node `v18.20.1`:
```
$ ./emcc test/hello_world.c
node:internal/errors:496
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:405:5)
    at validateString (node:internal/validators:162:11)
    at Module.join (node:path:1171:7)
    at find (file:///emscripten/src/utility.mjs:235:27)
    at read (file:///emscripten/src/utility.mjs:229:20)
    at file:///emscripten/src/compiler.mjs:30:34
    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:337:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:106:12) {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v18.20.1
emcc: error: 'nodejs emscripten/src/compiler.mjs /tmp/tmp9wv0eyav.json' failed (returned 1)
```
Clearing the cache, running bootstrap, `npm ci` etc., nothing works except for this patch.