### PR TITLE
Add a way to clear all IndexedDB databases in browser tests

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -604,13 +604,7 @@ If manually bisecting:
         fclose(f);
         printf("|%%s|\n", buf);
 
-        if (strcmp("load me right before", buf)) {
-          puts("bad data");
-          // Return a code that is easily differentiable from the 0, 1 that
-          // the main test returns, which is the # of cached packages.
-          emscripten_force_exit(99);
-        }
-
+        assert(strcmp("load me right before", buf) == 0);
         return checkPreloadResults();
       }
     ''' % 'somefile.txt')


### PR DESCRIPTION
Without this, `browser.test_preload_caching` works once, but running it again
finds the cached data and makes it error.

Also clean up the test a little while there.

Unblocks the test for #23059