### PR TITLE
Bump emscripten's internal node dependency to from v16 to v20

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@ See docs/process.md for more on how version tagging works.
 
 4.0.0 - 01/14/25
 ----------------
+- The mimimum version of node required to run emscripten was bumped from v16.20
+  to v20.18.  This matches the version of node that is shipped in emsdk.
 - Emscripten version was bumped to 4.0.0. Happy new year, happy new major
   version!  While version has a few interesting changes, there is nothing huge
   that makes it different from any other release. (#19053)

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -286,8 +286,9 @@ class sanity(RunnerCore):
     for version, succeed in (('v0.8.0', False),
                              ('v4.1.0', False),
                              ('v10.18.0', False),
-                             ('v16.20.0', True),
-                             ('v16.20.1-pre', True),
+                             ('v16.20.0', False),
+                             ('v20.18.0', True),
+                             ('v20.18.1-pre', True),
                              ('cheez', False)):
       print(version, succeed)
       delete_file(SANITY_FILE)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -57,9 +57,9 @@ SKIP_SUBPROCS = False
 # Minimum node version required to run the emscripten compiler.  This is
 # distinct from the minimum version required to execute the generated code
 # (settings.MIN_NODE_VERSION).
-# This version currently matches the node version that we ship with emsdk
-# which means that we can say for sure that this version is well supported.
-MINIMUM_NODE_VERSION = (16, 20, 0)
+# This version matches the node version that we ship with emsdk which means
+# that we know it has good test coverage.
+MINIMUM_NODE_VERSION = (20, 18, 0)
 EXPECTED_LLVM_VERSION = 20
 
 # These get set by setup_temp_dirs


### PR DESCRIPTION
This is the minimum version of node need to run the compiler itself and not related to the version needed to run the generated code.

This change should probably have been made back when we update emsdk back in October: https://github.com/emscripten-core/emsdk/pull/1476.

Up until #23349 this was not actually an issue.

See #23396 and #23407