### PR TITLE
Revert use of `import.meta.dirname` in the compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -642,7 +642,7 @@ jobs:
       # version of node (node canary) when running the compiler output (e.g.
       # in configure tests.
       - run:
-          name: configure node canary
+          name: configure compiler to use node-canary
           command: echo "NODE_JS = NODE_JS_TEST" >> ~/emsdk/.emscripten
       - run-tests:
           title: "wasm64"
@@ -746,6 +746,18 @@ jobs:
           command: git submodule update --init
       - pip-install
       - install-emsdk
+      # `install-node-version` only changes the NODE_JS_TEST (the version of
+      # node used to run test), not NODE_JS (the version of node used to run the
+      # compiler itself).
+      # In order to test that the compiler itself can run under the oldest
+      # supported version of node, we run all the tests in the runner under that
+      # version.
+      # Keep this in sync with MINIMUM_NODE_VERSION in tools/shared.py.
+      - install-node-version:
+          node_version: "18.0.0"
+      - run:
+          name: configure compiler to use 18.0.0
+          command: echo "NODE_JS = '$(which node)'" >> ~/emsdk/.emscripten
       - install-node-canary
       - run-tests:
           title: "node (canary)"
@@ -760,7 +772,8 @@ jobs:
             core0.test_async_ccall_promise_exit_runtime_jspi
             core0.test_cubescript_jspi"
       # Run some basic tests with the minimum version of node that we currently
-      # support.
+      # support in the generated code.
+      # Keep this in sync with `OLDEST_SUPPORTED_NODE` in `feature_matrix.py`
       - install-node-version:
           node_version: "10.19.0"
       - run-tests:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 4.0.1 (in development)
 ----------------------
+- The minimum version of node required to run emscripten was bumped from v16.20
+  to v18.  Version 4.0 was mistakenly shipped with a change that required v20,
+  but that was revered. (#23410)
 
 4.0.0 - 01/14/25
 ----------------

--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -7,6 +7,7 @@
 // General JS utilities - things that might be useful in any JS project.
 // Nothing specific to Emscripten appears here.
 
+import * as url from 'node:url';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as vm from 'node:vm';
@@ -230,8 +231,11 @@ export function read(filename) {
   return fs.readFileSync(absolute, 'utf8');
 }
 
+// Use import.meta.dirname here once we drop support for node v18.
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+
 function find(filename) {
-  for (const prefix of [process.cwd(), import.meta.dirname]) {
+  for (const prefix of [process.cwd(), __dirname]) {
     const combined = path.join(prefix, filename);
     if (fs.existsSync(combined)) {
       return combined;

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -286,8 +286,9 @@ class sanity(RunnerCore):
     for version, succeed in (('v0.8.0', False),
                              ('v4.1.0', False),
                              ('v10.18.0', False),
-                             ('v16.20.0', True),
-                             ('v16.20.1-pre', True),
+                             ('v16.20.0', False),
+                             ('v18.0.0', True),
+                             ('v18.0.1-pre', True),
                              ('cheez', False)):
       print(version, succeed)
       delete_file(SANITY_FILE)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -57,9 +57,9 @@ SKIP_SUBPROCS = False
 # Minimum node version required to run the emscripten compiler.  This is
 # distinct from the minimum version required to execute the generated code
 # (settings.MIN_NODE_VERSION).
-# This version currently matches the node version that we ship with emsdk
-# which means that we can say for sure that this version is well supported.
-MINIMUM_NODE_VERSION = (16, 20, 0)
+# This is currently set to v18 since this is the version of node available
+# in debian/stable (bookworm).
+MINIMUM_NODE_VERSION = (18, 0, 0)
 EXPECTED_LLVM_VERSION = 20
 
 # These get set by setup_temp_dirs


### PR DESCRIPTION
In #23349 we (I) accidentally broke running emscripten with node older than v19 and as it happens debian/stable still ships v18: https://packages.debian.org/bookworm/nodejs

This change reverts #23349 and also explicitly bumps the minimum version up to v18.  I've also added some testing to CI to ensure we can actually run using this version.

See #23396 and #23407