### PR TITLE
Fix compat between libc++ and emscripten's xlocale.h

### DIFF
--- a/system/lib/libcxx/include/__locale_dir/locale_base_api.h
+++ b/system/lib/libcxx/include/__locale_dir/locale_base_api.h
@@ -9,7 +9,9 @@
 #ifndef _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_H
 #define _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_H
 
-#if defined(_LIBCPP_MSVCRT_LIKE)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__EMSCRIPTEN__)
+#  include <xlocale.h>
+#elif defined(_LIBCPP_MSVCRT_LIKE)
 #  include <__locale_dir/locale_base_api/win32.h>
 #elif defined(_AIX) || defined(__MVS__)
 #  include <__locale_dir/locale_base_api/ibm.h>
@@ -25,8 +27,6 @@
 #  include <__locale_dir/locale_base_api/fuchsia.h>
 #elif defined(__wasi__) || defined(_LIBCPP_HAS_MUSL_LIBC)
 #  include <__locale_dir/locale_base_api/musl.h>
-#elif defined(__APPLE__) || defined(__FreeBSD__)
-#  include <xlocale.h>
 #endif
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/test/other/test_xlocale.c
+++ b/test/other/test_xlocale.c
@@ -1,3 +1,8 @@
+#ifdef __cplusplus
+// Test compatibility with libc++'s locale header
+#include <locale>
+#endif
+
 #include <xlocale.h>
 #include <stdio.h>
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14279,6 +14279,7 @@ int main() {
   def test_xlocale(self):
     # Test for xlocale.h compatibility header
     self.do_other_test('test_xlocale.c')
+    self.do_other_test('test_xlocale.c', emcc_args=['-x', 'c++'])
 
   def test_print_map(self):
     self.run_process([EMCC, '-c', test_file('hello_world.c')])


### PR DESCRIPTION
libc++ was assuming that musl doesn't have `xlocale.h` which is true, but emscripten adds xlocale.h for compatibility (I'm not sure we really need to, but we do).

Fixes: #23413