### PR TITLE
Add Webgl major version checks

### DIFF
--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -2069,7 +2069,11 @@ Functions
   .. note::
 
     - A successful call to this function will not immediately make that rendering context active. Call :c:func:`emscripten_webgl_make_context_current` after creating a context to activate it.
-    - This function will try to initialize the context version that was *exactly* requested. It will not e.g. initialize a newer backwards-compatible version or similar.
+    - A word of caution about :c:type:`EmscriptenWebGLContextAttributes.majorVersion`:
+
+      - When no (WEBGL) linker flags are set, then this attribute is ignored and the context returned is WebGL 1.0
+      - When the linker flag ``-sMIN_WEBGL_VERSION=2`` is set, then this attribute is ignored and the context returned is WebGL 2.0
+      - When the linker flag ``-sMAX_WEBGL_VERSION=2`` is set, then this attribute is used and the context returned matches the value of this attribute
 
   :param target: The DOM canvas element in which to initialize the WebGL context.
   :type target: const char*

--- a/src/library_html5_webgl.js
+++ b/src/library_html5_webgl.js
@@ -91,6 +91,16 @@ var LibraryHtml5WebGL = {
       renderViaOffscreenBackBuffer: HEAP8[attributes + {{{ C_STRUCTS.EmscriptenWebGLContextAttributes.renderViaOffscreenBackBuffer }}}]
     };
 
+
+#if ASSERTIONS
+    assert(contextAttributes.majorVersion === 1 || contextAttributes.majorVersion === 2, `${contextAttributes.majorVersion} is not a valid value for contextAttributes.majorVersion (should be 1 or 2)`);
+#if MIN_WEBGL_VERSION >= 2
+    assert(contextAttributes.majorVersion === 2, 'Requesting a WebGL context with version 1 is incompatible with linker flag -sMIN_WEBGL_VERSION=2');
+#elif MAX_WEBGL_VERSION == 1
+    assert(contextAttributes.majorVersion === 1, 'Requesting a WebGL context with version 2 requires either -sMIN_WEBGL_VERSION=2 or -sMAX_WEBGL_VERSION=2 linker flag');
+#endif
+#endif
+
     var canvas = findCanvasEventTarget(target);
 
 #if GL_DEBUG

--- a/test/browser/test_webgl_context_major_version.c
+++ b/test/browser/test_webgl_context_major_version.c
@@ -1,0 +1,19 @@
+// Copyright 2025 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <assert.h>
+#include <emscripten/html5.h>
+
+
+int main()
+{
+  EmscriptenWebGLContextAttributes attrs;
+  emscripten_webgl_init_context_attributes(&attrs);
+  attrs.majorVersion = WEBGL_CONTEXT_MAJOR_VERSION; // provided when invoking the test
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context;
+  context = emscripten_webgl_create_context("#canvas", &attrs);
+  assert(context);
+  emscripten_webgl_destroy_context(context);
+}

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2731,6 +2731,24 @@ Module["preRun"] = () => {
     self.btest_exit('test_webgl2_runtime_no_context.cpp', args=['-sMAX_WEBGL_VERSION=2'])
 
   @requires_graphics_hardware
+  def test_webgl_context_major_version(self):
+    # testing that majorVersion accepts only valid values
+    self.btest('test_webgl_context_major_version.c', expected='abort:Assertion failed: 0 is not a valid value for contextAttributes.majorVersion (should be 1 or 2)', args=['-lGL', '-DWEBGL_CONTEXT_MAJOR_VERSION=0'])
+    self.btest('test_webgl_context_major_version.c', expected='abort:Assertion failed: 3 is not a valid value for contextAttributes.majorVersion (should be 1 or 2)', args=['-lGL', '-DWEBGL_CONTEXT_MAJOR_VERSION=3'])
+
+    # no linker flag (equivalent to -sMIN_WEBGL_VERSION=1 -sMAX_WEBGL_VERSION=1) => only 1 allowed
+    self.btest_exit('test_webgl_context_major_version.c', args=['-lGL', '-DWEBGL_CONTEXT_MAJOR_VERSION=1'])
+    self.btest('test_webgl_context_major_version.c', expected='abort:Assertion failed: Requesting a WebGL context with version 2 requires either -sMIN_WEBGL_VERSION=2 or -sMAX_WEBGL_VERSION=2 linker flag', args=['-lGL', '-DWEBGL_CONTEXT_MAJOR_VERSION=2'])
+
+    # -sMIN_WEBGL_VERSION=2 => only 2 allowed
+    self.btest('test_webgl_context_major_version.c', expected='abort:Assertion failed: Requesting a WebGL context with version 1 is incompatible with linker flag -sMIN_WEBGL_VERSION=2', args=['-lGL', '-sMIN_WEBGL_VERSION=2', '-DWEBGL_CONTEXT_MAJOR_VERSION=1'])
+    self.btest_exit('test_webgl_context_major_version.c', args=['-lGL', '-sMIN_WEBGL_VERSION=2', '-DWEBGL_CONTEXT_MAJOR_VERSION=2'])
+
+    # -sMAX_WEBGL_VERSION=2 => 1 and 2 are ok
+    self.btest_exit('test_webgl_context_major_version.c', args=['-lGL', '-sMAX_WEBGL_VERSION=2', '-DWEBGL_CONTEXT_MAJOR_VERSION=1'])
+    self.btest_exit('test_webgl_context_major_version.c', args=['-lGL', '-sMAX_WEBGL_VERSION=2', '-DWEBGL_CONTEXT_MAJOR_VERSION=2'])
+
+  @requires_graphics_hardware
   def test_webgl2_invalid_teximage2d_type(self):
     self.btest_exit('webgl2_invalid_teximage2d_type.cpp', args=['-sMAX_WEBGL_VERSION=2'])
 


### PR DESCRIPTION
This are the changes we discussed in #23372 

I modified the documentation and changed the code to abort (only when assertions are enabled).

I added a comprehensive test for the changes. I would not be surprised if other tests fail, but I guess I will fix them accordingly. I have manually tested `test_webgl2_runtime_no_context` and it works. 