### PR TITLE
Update min python version from 3.6 to 3.8

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@ See docs/process.md for more on how version tagging works.
 - emscan-deps tools was added.  This tool wraps clang-scan-deps and injects the
   needed `--target` and `--sysroot` argument that would normally be injected by
   emcc itself.  This enables support for C++20 in cmake projects. (#21987)
+- The version of python required to run emscripten was bumped from 3.6 to 3.8.
+  (#23417)
 
 4.0.2 - 01/30/25
 ----------------

--- a/tools/building.py
+++ b/tools/building.py
@@ -483,17 +483,6 @@ def check_closure_compiler(cmd, args, env, allowed_to_fail):
   return True
 
 
-# Remove this once we require python3.7 and can use std.isascii.
-# See: https://docs.python.org/3/library/stdtypes.html#str.isascii
-def isascii(s):
-  try:
-    s.encode('ascii')
-  except UnicodeEncodeError:
-    return False
-  else:
-    return True
-
-
 def get_closure_compiler_and_env(user_args):
   env = shared.env_with_node_in_path()
   closure_cmd = get_closure_compiler()
@@ -630,7 +619,7 @@ def run_closure_cmd(cmd, filename, env):
   tempfiles = shared.get_temp_files()
 
   def move_to_safe_7bit_ascii_filename(filename):
-    if isascii(filename):
+    if filename.isascii():
       return os.path.abspath(filename)
     safe_filename = tempfiles.get('.js').name  # Safe 7-bit filename
     shutil.copyfile(filename, safe_filename)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -19,9 +19,9 @@ import stat
 import sys
 import tempfile
 
-# We depend on python 3.6 for fstring support
-if sys.version_info < (3, 6):
-  print('error: emscripten requires python 3.6 or above', file=sys.stderr)
+# We depend on python 3.8 features
+if sys.version_info < (3, 8):
+  print(f'error: emscripten requires python 3.8 or above ({sys.executable} {sys.version})', file=sys.stderr)
   sys.exit(1)
 
 from . import colored_logger

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2457,17 +2457,8 @@ def calculate(options):
   return ret
 
 
-# Once we require python 3.8 we can use shutil.copytree with
-# dirs_exist_ok=True and remove this function.
 def copytree_exist_ok(src, dst):
-  os.makedirs(dst, exist_ok=True)
-  for entry in os.scandir(src):
-    srcname = os.path.join(src, entry.name)
-    dstname = os.path.join(dst, entry.name)
-    if entry.is_dir():
-      copytree_exist_ok(srcname, dstname)
-    else:
-      shared.safe_copy(srcname, dstname)
+  shutil.copytree(src, dst, dirs_exist_ok=True)
 
 
 def install_system_headers(stamp):


### PR DESCRIPTION
The reason for picking 3.8 here is that it provides all the features we currently have need of, and it available in the places we care about:

- debian/stable (bookworm): 3.11
- ubuntu/LTS (focal): 3.8
- emsdk: 3.9.2

The motivation for this change is twofold:

1. We get access to a few more python features.
2. We actually test using the version we claim to support (3.8 on ubuntu/focal in CI).  Currently the claim that we support 3.6 could well be a lie.  We don't do any testing on 3.6 do who knows if incompatibilities have snuck in.

Replaces: #23378
Fixes: #23387