### PR TITLE
[jspi] Fix TSD generation when using asyncify library functions.

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -38,6 +38,10 @@ addToLibrary({
     rewindArguments: {},
 #endif
     instrumentWasmImports(imports) {
+#if EMBIND_GEN_MODE
+      // Instrumenting is not needed when generating code.
+      return imports;
+#endif
 #if ASYNCIFY_DEBUG
       dbg('asyncify instrumenting imports');
 #endif
@@ -103,6 +107,10 @@ addToLibrary({
     },
 #endif
     instrumentWasmExports(exports) {
+#if EMBIND_GEN_MODE
+      // Instrumenting is not needed when generating code.
+      return exports;
+#endif
 #if ASYNCIFY_DEBUG
       dbg('asyncify instrumenting exports');
 #endif

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -92,6 +92,10 @@ var EMBIND = false;
 // Whether a TypeScript definition file has been requested.
 var EMIT_TSD = false;
 
+// This will be true during the generation of code in run_embind_gen. Helpful
+// for detecting if either TSD file or embind AOT JS generation is running.
+var EMBIND_GEN_MODE = false;
+
 // Whether the main() function reads the argc/argv parameters.
 var MAIN_READS_PARAMS = true;
 

--- a/test/other/embind_tsgen_jspi.cpp
+++ b/test/other/embind_tsgen_jspi.cpp
@@ -1,8 +1,11 @@
 #include <emscripten/bind.h>
+#include <emscripten.h>
 
 using namespace emscripten;
 
-void sleep() {}
+void sleep() {
+  emscripten_sleep(0);
+}
 
 EMSCRIPTEN_BINDINGS(Test) {
   function("sleep", &sleep, async());

--- a/test/other/embind_tsgen_jspi.d.ts
+++ b/test/other/embind_tsgen_jspi.d.ts
@@ -1,17 +1,4 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
-declare namespace RuntimeExports {
-    let HEAPF32: any;
-    let HEAPF64: any;
-    let HEAP_DATA_VIEW: any;
-    let HEAP8: any;
-    let HEAPU8: any;
-    let HEAP16: any;
-    let HEAPU16: any;
-    let HEAP32: any;
-    let HEAPU32: any;
-    let HEAP64: any;
-    let HEAPU64: any;
-}
 interface WasmModule {
 }
 
@@ -19,4 +6,4 @@ interface EmbindModule {
   sleep(): Promise<void>;
 }
 
-export type MainModule = WasmModule & typeof RuntimeExports & EmbindModule;
+export type MainModule = WasmModule & EmbindModule;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3530,7 +3530,7 @@ More info: https://emscripten.org
   @requires_jspi
   def test_embind_tsgen_jspi(self):
     self.run_process([EMXX, test_file('other/embind_tsgen_jspi.cpp'),
-                      '-lembind', '--emit-tsd', 'embind_tsgen_jspi.d.ts', '-sJSPI'] +
+                      '-lembind', '--emit-tsd', 'embind_tsgen_jspi.d.ts', '-sJSPI', '-sSTRICT', '--no-entry'] +
                      self.get_emcc_args())
     self.assertFileContents(test_file('other/embind_tsgen_jspi.d.ts'), read_file('embind_tsgen_jspi.d.ts'))
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -1964,6 +1964,7 @@ def run_embind_gen(wasm_target, js_syms, extra_settings, linker_inputs):
   # Save settings so they can be restored after TS generation.
   original_settings = settings.backup()
   settings.attrs.update(extra_settings)
+  settings.EMBIND_GEN_MODE = True
 
   if settings.MAIN_MODULE and linker_inputs:
     # Copy libraries to the temp directory so they can be used when running
@@ -2001,11 +2002,6 @@ def run_embind_gen(wasm_target, js_syms, extra_settings, linker_inputs):
   setup_environment_settings()
   # Use a separate Wasm file so the JS does not need to be modified after emscripten.emscript.
   settings.SINGLE_FILE = False
-  if settings.ASYNCIFY == 2:
-    # JSPI is not needed to generate the definitions.
-    # TODO: when the emsdk node version supports JSPI, it probably makes more sense
-    # to enable it in node than disabling the setting here.
-    settings.ASYNCIFY = 0
   # Embind may be included multiple times, de-duplicate the list first.
   settings.JS_LIBRARIES = dedup_list(settings.JS_LIBRARIES)
   # Replace embind with the TypeScript generation version.


### PR DESCRIPTION
Instead of disabling JSPI during TSD generation just skip instrumenting the wasm exports and imports so JSPI isn't needed.

Fixes #23418