### PR TITLE
Fix cores.test_minimal_runtime_safe_heap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,6 +566,7 @@ jobs:
             core2ss.test_pthread_thread_local_storage
             core2s.test_dylink_syslibs_missing_assertions
             core2s.test_module_wasm_memory
+            cores.test_minimal_runtime_safe_heap
             wasm2js3.test_memorygrowth_2
             wasmfs.test_hello_world
             wasmfs.test_unistd_links*

--- a/tools/acorn-optimizer.mjs
+++ b/tools/acorn-optimizer.mjs
@@ -1958,10 +1958,10 @@ function reattachComments(ast, commentsMap) {
       trace('dropping comments: no symbol comes after them');
       break;
     }
-    if (symbols[j].start.pos - pos > 20) {
-      // This comment is too far away to refer to the given symbol. Drop
-      // the comment altogether.
-      trace('dropping comments: too far from any symbol');
+    if (symbols[j].start.pos != pos) {
+      // This comment must have been associated with a node that still
+      // exists in the AST, otherwise to drop it.
+      trace('dropping comments: not linked to any remaining AST node');
       continue;
     }
     symbols[j].start.comments_before ??= [];


### PR DESCRIPTION
This test was broken after #23403 because an `@export` comment that was associated with deleted symbol/node got incorrectly matches with the following symbol/node.

Not the most satisfactory fix but its seems work.

Fixes: #23422