### PR TITLE
[emcc.py] Handle all pass-through args correctly

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1132,6 +1132,12 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
     arg = newargs[i]
     arg_value = None
 
+    if arg in CLANG_FLAGS_WITH_ARGS:
+      # Ignore the next argument rather than trying to parse it.  This is needed
+      # because that next arg could, for example, start with `-o` and we don't want
+      # to confuse that with a normal `-o` flag.
+      skip = True
+
     def check_flag(value):
       # Check for and consume a flag
       if arg == value:
@@ -1480,11 +1486,6 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
         exit_with_error(f'unsupported target: {options.target} (emcc only supports wasm64-unknown-emscripten and wasm32-unknown-emscripten)')
     elif check_arg('--use-port'):
       ports.handle_use_port_arg(settings, consume_arg())
-    elif arg == '-mllvm':
-      # Ignore the next argument rather than trying to parse it.  This is needed
-      # because llvm args could, for example, start with `-o` and we don't want
-      # to confuse that with a normal `-o` flag.
-      skip = True
 
   if should_exit:
     sys.exit(0)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12244,6 +12244,10 @@ Aborted(`Module.arguments` has been replaced by `arguments_` (the initial value 
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Xlinker', '--waka'])
     self.assertContained('wasm-ld: error: unknown argument: --waka', err)
 
+    # Explicitly check that emcc doesn't try to process passthrough args
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Xlinker', '--post-link'])
+    self.assertContained('wasm-ld: error: unknown argument: --post-link', err)
+
     err = self.run_process([EMCC, test_file('hello_world.c'), '-z', 'foo'], stderr=PIPE).stderr
     self.assertContained('wasm-ld: warning: unknown -z value: foo', err)
 


### PR DESCRIPTION
We were only handling `-mllvm` and not all the other ones.