### PR TITLE
[compiler.mjs] Simplify file opening and finding logic. NFC

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -25,7 +25,7 @@
 /*global throwInstanceAlreadyDeleted, shallowCopyInternalPointer*/
 /*global RegisteredPointer_fromWireType, constNoSmartPtrRawPointerToWireType, nonConstNoSmartPtrRawPointerToWireType, genericPointerToWireType*/
 
-#include "embind/embind_shared.js"
+#include "embind_shared.js"
 
 var LibraryEmbind = {
   $UnboundTypeError__postset: "UnboundTypeError = Module['UnboundTypeError'] = extendError(Error, 'UnboundTypeError');",

--- a/src/embind/embind_gen.js
+++ b/src/embind/embind_gen.js
@@ -2,7 +2,7 @@
 // Emscripten is available under two separate licenses, the MIT license and the
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
-#include "embind/embind_shared.js"
+#include "embind_shared.js"
 
 var LibraryEmbind = {
 

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -18,6 +18,7 @@ import {
   addToCompileTimeContext,
   runInMacroContext,
   mergeInto,
+  localFile,
 } from './utility.mjs';
 import {preprocess, processMacros} from './parseTools.mjs';
 
@@ -217,7 +218,7 @@ export const LibraryManager = {
     // Save the list for has() queries later.
     this.libraries = libraries;
 
-    for (const filename of libraries) {
+    for (var filename of libraries) {
       const isUserLibrary = path.isAbsolute(filename);
       if (VERBOSE) {
         if (isUserLibrary) {
@@ -241,6 +242,9 @@ export const LibraryManager = {
             return true;
           },
         });
+      } else {
+        // System libraries are specified relatative to the `src` directory
+        filename = localFile(filename);
       }
       const oldFile = setCurrentFile(filename);
       try {
@@ -301,9 +305,9 @@ function loadStructInfo(filename) {
 if (!BOOTSTRAPPING_STRUCT_INFO) {
   // Load struct and define information.
   if (MEMORY64) {
-    loadStructInfo('struct_info_generated_wasm64.json');
+    loadStructInfo(localFile('struct_info_generated_wasm64.json'));
   } else {
-    loadStructInfo('struct_info_generated.json');
+    loadStructInfo(localFile('struct_info_generated.json'));
   }
 }
 

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -8,6 +8,8 @@
  * Tests live in test/other/test_parseTools.js.
  */
 
+import * as path from 'node:path';
+
 import {
   addToCompileTimeContext,
   assert,
@@ -119,15 +121,19 @@ export function preprocess(filename) {
           showStack.push(truthy ? SHOW : IGNORE);
         } else if (first === '#include') {
           if (showCurrentLine()) {
-            let filename = line.substr(line.indexOf(' ') + 1);
-            if (filename.startsWith('"')) {
-              filename = filename.substr(1, filename.length - 2);
+            let includeFile = line.substr(line.indexOf(' ') + 1);
+            if (includeFile.startsWith('"')) {
+              includeFile = includeFile.substr(1, includeFile.length - 2);
             }
-            const result = preprocess(filename);
+            // Include files are always relative to the current file being processed
+            if (!path.isAbsolute(includeFile)) {
+              includeFile = path.join(path.dirname(filename), includeFile);
+            }
+            const result = preprocess(includeFile);
             if (result) {
-              ret += `// include: ${filename}\n`;
+              ret += `// include: ${includeFile}\n`;
               ret += result;
-              ret += `// end include: ${filename}\n`;
+              ret += `// end include: ${includeFile}\n`;
             }
           }
         } else if (first === '#else') {

--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -227,21 +227,17 @@ export function isDecorator(ident) {
 }
 
 export function read(filename) {
-  const absolute = find(filename);
-  return fs.readFileSync(absolute, 'utf8');
+  return fs.readFileSync(filename, 'utf8');
 }
 
 // Use import.meta.dirname here once we drop support for node v18.
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
-function find(filename) {
-  for (const prefix of [process.cwd(), __dirname]) {
-    const combined = path.join(prefix, filename);
-    if (fs.existsSync(combined)) {
-      return combined;
-    }
-  }
-  return filename;
+// Returns an absolute path for a file, resolving it relative to this script
+// (i.e. relative to the src/ directory).
+export function localFile(filename) {
+  assert(!path.isAbsolute(filename));
+  return path.join(__dirname, filename);
 }
 
 // Anything needed by the script that we load below must be added to the
@@ -314,15 +310,15 @@ export function applySettings(obj) {
 }
 
 export function loadSettingsFile(f) {
-  var settings = {};
-  vm.runInNewContext(read(f), settings, {filename: find(f)});
+  const settings = {};
+  vm.runInNewContext(read(f), settings, {filename: f});
   applySettings(settings);
   return settings;
 }
 
 export function loadDefaultSettings() {
-  const rtn = loadSettingsFile('settings.js');
-  Object.assign(rtn, loadSettingsFile('settings_internal.js'));
+  const rtn = loadSettingsFile(localFile('settings.js'));
+  Object.assign(rtn, loadSettingsFile(localFile('settings_internal.js')));
   return rtn;
 }
 

--- a/tools/maint/gen_sig_info.py
+++ b/tools/maint/gen_sig_info.py
@@ -307,12 +307,12 @@ def extract_sig_info(sig_info, extra_settings=None, extra_cflags=None, cxx=False
     'AUDIO_WORKLET': 1,
     'WASM_WORKERS': 1,
     'JS_LIBRARIES': [
-      'src/library_websocket.js',
-      'src/library_exports.js',
-      'src/library_webaudio.js',
-      'src/library_fetch.js',
-      'src/library_pthread.js',
-      'src/library_trace.js',
+      'library_websocket.js',
+      'library_exports.js',
+      'library_webaudio.js',
+      'library_fetch.js',
+      'library_pthread.js',
+      'library_trace.js',
     ],
     'SUPPORT_LONGJMP': 'emscripten'
   }
@@ -390,9 +390,9 @@ def main(args):
                               'BUILD_AS_WORKER': 1,
                               'LINK_AS_CXX': 1,
                               'AUTO_JS_LIBRARIES': 0}, cxx=True)
-  extract_sig_info(sig_info, {'WASM_WORKERS': 1, 'JS_LIBRARIES': ['src/library_wasm_worker.js']})
+  extract_sig_info(sig_info, {'WASM_WORKERS': 1, 'JS_LIBRARIES': ['library_wasm_worker.js']})
   extract_sig_info(sig_info, {'USE_GLFW': 3}, ['-DGLFW3'])
-  extract_sig_info(sig_info, {'JS_LIBRARIES': ['src/embind/embind.js', 'src/embind/emval.js'],
+  extract_sig_info(sig_info, {'JS_LIBRARIES': ['embind/embind.js', 'embind/emval.js'],
                               'USE_SDL': 0,
                               'MAX_WEBGL_VERSION': 0,
                               'AUTO_JS_LIBRARIES': 0,


### PR DESCRIPTION
Removes the magic `find` function and instead require explicit file locations at all the various call sites.  This means that in each circumstance were we want to load a file there is only once place it can/should be.

One side effect of this is that when using the `#include` preprocessor directive the filename must either be absolute or relative to the current file.