### PR TITLE
GLES compatibility layer: covers the situation when an element buffer is bound, but an array buffer is not.

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -3851,7 +3851,7 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
   glDrawElements: (mode, count, type, indices) => {
 #if FULL_ES2
     var buf;
-    var vertexes = 0;
+    var vertexes = count;
     if (!GLctx.currentElementArrayBufferBinding) {
       var size = GL.calcBufLength(1, type, 0, count);
       buf = GL.getTempIndexBuffer(size);

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1839,6 +1839,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
       ('third_party/glbook/Chapter_9/Simple_Texture2D/Simple_Texture2D_orig.c', 'third_party/glbook/CH09_SimpleTexture2D.png'),
       ('third_party/glbook/Chapter_10/MultiTexture/MultiTexture_orig.c', 'third_party/glbook/CH10_MultiTexture.png'),
       ('third_party/glbook/Chapter_13/ParticleSystem/ParticleSystem_orig.c', 'third_party/glbook/CH13_ParticleSystem.png'),
+      ('third_party/glbook/Chapter_2/Hello_Triangle/Hello_Triangle_DrawElements.c', 'third_party/glbook/CH02_HelloTriangle.png'),
     ]:
       print(source)
       self.reftest(source, reference,

--- a/test/third_party/glbook/Chapter_2/Hello_Triangle/Hello_Triangle_DrawElements.c
+++ b/test/third_party/glbook/Chapter_2/Hello_Triangle/Hello_Triangle_DrawElements.c
@@ -1,0 +1,207 @@
+//
+// Book:      OpenGL(R) ES 2.0 Programming Guide
+// Authors:   Aaftab Munshi, Dan Ginsburg, Dave Shreiner
+// ISBN-10:   0321502795
+// ISBN-13:   9780321502797
+// Publisher: Addison-Wesley Professional
+// URLs:      http://safari.informit.com/9780321563835
+//            http://www.opengles-book.com
+//
+
+// Hello_Triangle.c
+//
+//    This is a simple example that draws a single triangle with
+//    a minimal vertex/fragment shader.  The purpose of this 
+//    example is to demonstrate the basic concepts of 
+//    OpenGL ES 2.0 rendering.
+
+// Modified version that draws a triangle using glDrawElements
+// In this case we used bound indexed buffer and unbound vertex buffer
+
+#include <stdlib.h>
+#include "esUtil.h"
+
+typedef struct
+{
+   // Handle to a program object
+   GLuint programObject;
+   GLuint indexBuffer;
+} UserData;
+
+///
+// Create a shader object, load the shader source, and
+// compile the shader.
+//
+GLuint LoadShader ( GLenum type, const char *shaderSrc )
+{
+   GLuint shader;
+   GLint compiled;
+   
+   // Create the shader object
+   shader = glCreateShader ( type );
+
+   if ( shader == 0 )
+   	return 0;
+
+   // Load the shader source
+   glShaderSource ( shader, 1, &shaderSrc, NULL );
+   
+   // Compile the shader
+   glCompileShader ( shader );
+
+   // Check the compile status
+   glGetShaderiv ( shader, GL_COMPILE_STATUS, &compiled );
+
+   if ( !compiled ) 
+   {
+      GLint infoLen = 0;
+
+      glGetShaderiv ( shader, GL_INFO_LOG_LENGTH, &infoLen );
+      
+      if ( infoLen > 1 )
+      {
+         char* infoLog = malloc (sizeof(char) * infoLen );
+
+         glGetShaderInfoLog ( shader, infoLen, NULL, infoLog );
+         esLogMessage ( "Error compiling shader:\n%s\n", infoLog );            
+         
+         free ( infoLog );
+      }
+
+      glDeleteShader ( shader );
+      return 0;
+   }
+
+   return shader;
+
+}
+
+///
+// Initialize the shader and program object
+//
+int Init ( ESContext *esContext )
+{
+   esContext->userData = malloc(sizeof(UserData));
+   UserData *userData = esContext->userData;
+
+   glGenBuffers(1, &userData->indexBuffer);
+
+   GLushort indices[] = { 0, 1, 2 };
+
+   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, userData->indexBuffer);
+   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
+
+   GLbyte vShaderStr[] =  
+      "attribute vec4 vPosition;    \n"
+      "void main()                  \n"
+      "{                            \n"
+      "   gl_Position = vPosition;  \n"
+      "}                            \n";
+   
+   GLbyte fShaderStr[] =  
+      "precision mediump float;\n"\
+      "void main()                                  \n"
+      "{                                            \n"
+      "  gl_FragColor = vec4 ( 1.0, 0.0, 0.0, 1.0 );\n"
+      "}                                            \n";
+
+   GLuint vertexShader;
+   GLuint fragmentShader;
+   GLuint programObject;
+   GLint linked;
+
+   // Load the vertex/fragment shaders
+   vertexShader = LoadShader ( GL_VERTEX_SHADER, vShaderStr );
+   fragmentShader = LoadShader ( GL_FRAGMENT_SHADER, fShaderStr );
+
+   // Create the program object
+   programObject = glCreateProgram ( );
+   
+   if ( programObject == 0 )
+      return 0;
+
+   glAttachShader ( programObject, vertexShader );
+   glAttachShader ( programObject, fragmentShader );
+
+   // Bind vPosition to attribute 0   
+   glBindAttribLocation ( programObject, 0, "vPosition" );
+
+   // Link the program
+   glLinkProgram ( programObject );
+
+   // Check the link status
+   glGetProgramiv ( programObject, GL_LINK_STATUS, &linked );
+
+   if ( !linked ) 
+   {
+      GLint infoLen = 0;
+
+      glGetProgramiv ( programObject, GL_INFO_LOG_LENGTH, &infoLen );
+      
+      if ( infoLen > 1 )
+      {
+         char* infoLog = malloc (sizeof(char) * infoLen );
+
+         glGetProgramInfoLog ( programObject, infoLen, NULL, infoLog );
+         esLogMessage ( "Error linking program:\n%s\n", infoLog );            
+         
+         free ( infoLog );
+      }
+
+      glDeleteProgram ( programObject );
+      return GL_FALSE;
+   }
+
+   // Store the program object
+   userData->programObject = programObject;
+
+   glClearColor ( 0.0f, 0.0f, 0.0f, 0.0f );
+   return GL_TRUE;
+}
+
+///
+// Draw a triangle using the shader pair created in Init()
+//
+void Draw ( ESContext *esContext )
+{
+   UserData *userData = esContext->userData;
+
+   GLfloat vVertices[] = {  0.0f,  0.5f, 0.0f, 
+                           -0.5f, -0.5f, 0.0f,
+                            0.5f, -0.5f, 0.0f };
+      
+   // Set the viewport
+   glViewport ( 0, 0, esContext->width, esContext->height );
+   
+   // Clear the color buffer
+   glClear ( GL_COLOR_BUFFER_BIT );
+
+   // Use the program object
+   glUseProgram ( userData->programObject );
+
+   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, userData->indexBuffer);
+
+   // Load the vertex data
+   glVertexAttribPointer ( 0, 3, GL_FLOAT, GL_FALSE, 0, vVertices );
+   glEnableVertexAttribArray ( 0 );
+
+   glDrawElements(GL_TRIANGLES, 3, GL_UNSIGNED_SHORT, 0);
+}
+
+int main ( int argc, char *argv[] )
+{
+   ESContext esContext;
+   UserData  userData;
+
+   esInitContext ( &esContext );
+   esContext.userData = &userData;
+
+   esCreateWindow ( &esContext, "Hello Triangle", 320, 240, ES_WINDOW_RGB );
+
+   if ( !Init ( &esContext ) )
+      return 0;
+
+   esRegisterDrawFunc ( &esContext, Draw );
+
+   esMainLoop ( &esContext );
+}


### PR DESCRIPTION
I found a case where GLES2/3 emulation does not work correctly. In GLES2/3, there are two ways to bind vertex data:

1. **Using an array buffer:** Bind an array buffer and pass an offset within it to `glVertexAttribPointer`.
2. **Using a direct pointer:** Pass a pointer directly to the vertex data and set the array buffer to 0.

However, there is an issue when using an **element array buffer** (used for indexed drawing) but not using an **array buffer**. In this case, the rendering process fails to set the correct vertices for the `glDrawElements` call. This issue arises due to the following code:

```javascript
glDrawElements: (mode, count, type, indices) => {
#if FULL_ES2
    var buf;
    var vertexes = 0;
    if (!GLctx.currentElementArrayBufferBinding) {
```

As you can see, the `vertexes` variable is initialized to zero. However, when `currentElementArrayBufferBinding` exists, the relevant code to initialize `vertexes` is skipped. This causes `GL.preDrawHandleClientVertexAttribBindings(vertexes)` to be called with `vertexes` set to zero, resulting in no data being bound to the vertex attributes.

To fix this, I initialized `vertexes` with `count` (the number of vertices) and added a test to verify the fix. However, I am not very experienced in 3D programming, so I am unsure if this change might unintentionally break something. Can someone review this and provide feedback?