### PR TITLE
Remove -soname from UNSUPPORTED_LLD_FLAGS

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -73,7 +73,6 @@ UNSUPPORTED_LLD_FLAGS = {
     '-bind_at_load': False,
     # wasm-ld doesn't support soname or other dynamic linking flags (yet).   Ignore them
     # in order to aid build systems that want to pass these flags.
-    '-soname': True,
     '-allow-shlib-undefined': False,
     '-rpath': True,
     '-rpath-link': True,


### PR DESCRIPTION
wasm-ld supports this flag as of https://reviews.llvm.org/D158001 so there is no need to remove it or warn when it is used.
