### PR TITLE
[emcc.py] Simplify compiler modes. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -101,10 +101,11 @@ CLANG_FLAGS_WITH_ARGS = {
 
 @unique
 class Mode(Enum):
-  PREPROCESS_ONLY = auto()
-  PCH = auto()
+  # Used any time we are not linking, including PCH, pre-processing, etc
   COMPILE_ONLY = auto()
+  # Only when --post-link is specified
   POST_LINK_ONLY = auto()
+  # This is the default mode, in the absence of any flags such as -c, -E, etc
   COMPILE_AND_LINK = auto()
 
 
@@ -837,14 +838,10 @@ def phase_setup(options, state, newargs):
 
   if options.post_link:
     state.mode = Mode.POST_LINK_ONLY
-  elif options.dash_E or options.dash_M:
-    state.mode = Mode.PREPROCESS_ONLY
-  elif has_header_inputs:
-    state.mode = Mode.PCH
-  elif options.dash_c or options.dash_S or options.syntax_only:
+  elif has_header_inputs or options.dash_c or options.dash_S or options.syntax_only or options.dash_E or options.dash_M:
     state.mode = Mode.COMPILE_ONLY
 
-  if state.mode in (Mode.COMPILE_ONLY, Mode.PREPROCESS_ONLY):
+  if state.mode == Mode.COMPILE_ONLY:
     for key in user_settings:
       if key not in COMPILE_TIME_SETTINGS:
         diagnostics.warning(
@@ -994,23 +991,6 @@ def phase_compile_inputs(options, state, newargs):
 
   def get_clang_command_asm():
     return compiler + get_target_flags()
-
-  # preprocessor-only (-E/-M) support
-  if state.mode == Mode.PREPROCESS_ONLY:
-    cmd = get_clang_command() + newargs
-    # Do not compile, but just output the result from preprocessing stage or
-    # output the dependency rule. Warning: clang and gcc behave differently
-    # with -MF! (clang seems to not recognize it)
-    logger.debug(('just preprocessor: ' if options.dash_E else 'just dependencies: ') + ' '.join(cmd))
-    shared.exec_process(cmd)
-    assert False, 'exec_process does not return'
-
-  # Precompiled headers support
-  if state.mode == Mode.PCH:
-    cmd = get_clang_command() + newargs
-    logger.debug(f"running (for precompiled headers): {cmd[0]} {' '.join(cmd[1:])}")
-    shared.exec_process(cmd)
-    assert False, 'exec_process does not return'
 
   if state.mode == Mode.COMPILE_ONLY:
     if options.output_file and get_file_suffix(options.output_file) == '.bc' and not settings.LTO and '-emit-llvm' not in state.orig_args:


### PR DESCRIPTION
As a followup to #23454 we no longer need to distinguish between the some of these compiler modes.  Specifically, `PCH` and `PREPROCESS_ONLY` are now subsumed by `COMPILE_ONLY` since all these modes simply exec clang and exit.