### PR TITLE
Remove `ATMAINS` from JS compiler

### DIFF
--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -10,7 +10,6 @@
 import {
   ATEXITS,
   ATINITS,
-  ATMAINS,
   defineI64Param,
   indentify,
   makeReturn64,
@@ -774,7 +773,6 @@ var proxiedFunctionTable = [
           asyncFuncs,
           libraryDefinitions: LibraryManager.libraryDefinitions,
           ATINITS: ATINITS.join('\n'),
-          ATMAINS: STRICT ? '' : ATMAINS.join('\n'),
           ATEXITS: ATEXITS.join('\n'),
         }),
     );

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -731,8 +731,6 @@ function makeEval(code) {
   return ret;
 }
 
-export const ATMAINS = [];
-
 export const ATINITS = [];
 
 function addAtInit(code) {

--- a/src/parseTools_legacy.mjs
+++ b/src/parseTools_legacy.mjs
@@ -5,7 +5,7 @@
  */
 
 import {warn, addToCompileTimeContext} from './utility.mjs';
-import {ATMAINS, POINTER_SIZE, runIfMainThread} from './parseTools.mjs';
+import {POINTER_SIZE, runIfMainThread} from './parseTools.mjs';
 
 // Replaced (at least internally) with receiveI64ParamAsI53 that does
 // bounds checking.
@@ -42,7 +42,6 @@ const Runtime = {
 const runOnMainThread = runIfMainThread;
 
 addToCompileTimeContext({
-  ATMAINS,
   Runtime,
   makeMalloc,
   receiveI64ParamAsDouble,

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -13,8 +13,6 @@ function run() {
   emscriptenMemoryProfiler.onPreloadComplete();
 #endif
 
-  <<< ATMAINS >>>
-
 #if PROXY_TO_PTHREAD
   // User requested the PROXY_TO_PTHREAD option, so call a stub main which
   // pthread_create()s a new thread that will call the user's real main() for

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -229,7 +229,6 @@ function preMain() {
 #if PTHREADS
   if (ENVIRONMENT_IS_PTHREAD) return; // PThreads reuse the runtime from the main thread.
 #endif
-  <<< ATMAINS >>>
   callRuntimeCallbacks(__ATMAIN__);
 }
 #endif

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -162,8 +162,6 @@ def update_settings_glue(wasm_file, metadata, base_metadata):
 
 def apply_static_code_hooks(forwarded_json, code):
   code = shared.do_replace(code, '<<< ATINITS >>>', str(forwarded_json['ATINITS']))
-  if settings.HAS_MAIN:
-    code = shared.do_replace(code, '<<< ATMAINS >>>', str(forwarded_json['ATMAINS']))
   if settings.EXIT_RUNTIME and (not settings.MINIMAL_RUNTIME or settings.HAS_MAIN):
     code = shared.do_replace(code, '<<< ATEXITS >>>', str(forwarded_json['ATEXITS']))
   return code


### PR DESCRIPTION
As far as I can tell the compile-time constant was never documented.

Unlike `ATEXITS` and `ATINITS` there was never any corresponding `addAtMain`, and even the `ATMAIN` symbol itself was already not available in `-sSTRICT` or `-sLEGACY_RUNTIME=0` mode.

It looks like it was specifically added in order to facilitate the sealing of the filesystem in #8083, but its no longer used for that purpose, and we have no current internal usages.