### PR TITLE
[FS] Make fstat work on file descriptors with no name in nodefs

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5845,8 +5845,6 @@ Module.onRuntimeInitialized = () => {
   @crossplatform
   @with_all_fs
   def test_fs_stat_unnamed_file_descriptor(self):
-    if '-DNODEFS' in self.emcc_args:
-      self.skipTest('TODO: doesnt work in nodefs')
     self.do_runf('fs/test_stat_unnamed_file_descriptor.c', 'success')
 
   @requires_node


### PR DESCRIPTION
This makes fstat work on anonymous nodefs file descriptors. It is the last part of #23058.