### PR TITLE
[WasmFS] Enable NODEFS tests on WasmFS

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5855,6 +5855,7 @@ Module.onRuntimeInitialized = () => {
   def test_fs_symlink_resolution(self):
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
+    nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
     if nodefs and WINDOWS:
       self.skipTest('No symlinks on Windows')
     self.do_runf('fs/test_fs_symlink_resolution.c', 'success')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5859,8 +5859,6 @@ Module.onRuntimeInitialized = () => {
     if nodefs:
       if WINDOWS:
         self.skipTest('No symlinks on Windows')
-      if self.get_setting('WASMFS'):
-        self.skipTest('NODEFS in WasmFS')
     self.do_runf('fs/test_fs_symlink_resolution.c', 'success')
 
   @with_all_fs
@@ -5910,8 +5908,6 @@ Module.onRuntimeInitialized = () => {
     nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
-      if nodefs:
-        self.skipTest('NODEFS in WasmFS')
     # On windows we have slighly different output because we the same
     # level of permissions are not available. For example, on windows
     # its not possible have a file that is not readable, but writable.
@@ -5949,8 +5945,6 @@ Module.onRuntimeInitialized = () => {
     nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
-      if nodefs:
-        self.skipTest('TODO: NODEFS in WasmFS')
     if WINDOWS or os.geteuid() == 0:
       self.skipTest('Root access invalidates this test by being able to write on readonly files')
     self.do_run_in_out_file_test('unistd/truncate.c')
@@ -5983,8 +5977,6 @@ Module.onRuntimeInitialized = () => {
   @with_all_fs
   def test_unistd_unlink(self):
     nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
-    if self.get_setting('WASMFS') and nodefs:
-      self.skipTest('NODEFS in WasmFS')
 
     # symlinks on node.js on non-linux behave differently (e.g. on Windows they require administrative privileges)
     # so skip testing those bits on that combination.
@@ -6035,8 +6027,6 @@ Module.onRuntimeInitialized = () => {
   @also_with_nodefs
   def test_unistd_io(self):
     if self.get_setting('WASMFS'):
-      if '-DNODEFS' in self.emcc_args:
-        self.skipTest('NODEFS in WasmFS')
       self.set_setting('FORCE_FILESYSTEM')
     self.do_run_in_out_file_test('unistd/io.c')
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5904,7 +5904,6 @@ Module.onRuntimeInitialized = () => {
   @crossplatform
   @with_all_fs
   def test_unistd_access(self):
-    nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
     # On windows we have slighly different output because we the same
@@ -5913,7 +5912,7 @@ Module.onRuntimeInitialized = () => {
     # We also report all files as executable since there is no x bit
     # recorded there.
     # See https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/chmod-wchmod?view=msvc-170#remarks
-    if WINDOWS and nodefs:
+    if WINDOWS and '-DNODERAWFS' in self.emcc_args:
       out_suffix = '.win'
     else:
       out_suffix = ''

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5853,12 +5853,10 @@ Module.onRuntimeInitialized = () => {
   @crossplatform
   @with_all_fs
   def test_fs_symlink_resolution(self):
-    nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
-    if nodefs:
-      if WINDOWS:
-        self.skipTest('No symlinks on Windows')
+    if nodefs and WINDOWS:
+      self.skipTest('No symlinks on Windows')
     self.do_runf('fs/test_fs_symlink_resolution.c', 'success')
 
   @with_all_fs
@@ -5914,7 +5912,7 @@ Module.onRuntimeInitialized = () => {
     # We also report all files as executable since there is no x bit
     # recorded there.
     # See https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/chmod-wchmod?view=msvc-170#remarks
-    if WINDOWS and '-DNODERAWFS' in self.emcc_args:
+    if WINDOWS and nodefs:
       out_suffix = '.win'
     else:
       out_suffix = ''
@@ -5942,7 +5940,6 @@ Module.onRuntimeInitialized = () => {
 
   @with_all_fs
   def test_unistd_truncate(self):
-    nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
     if WINDOWS or os.geteuid() == 0:
@@ -5976,8 +5973,6 @@ Module.onRuntimeInitialized = () => {
   @no_windows('https://github.com/emscripten-core/emscripten/issues/8882')
   @with_all_fs
   def test_unistd_unlink(self):
-    nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
-
     # symlinks on node.js on non-linux behave differently (e.g. on Windows they require administrative privileges)
     # so skip testing those bits on that combination.
     if '-DNODEFS' in self.emcc_args:


### PR DESCRIPTION
We had various tests disabled from before we had NODEFS support in WasmFS.