### PR TITLE
Replace eval with indirect eval

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1300,12 +1300,12 @@ addToLibrary({
   // ==========================================================================
 
   emscripten_run_script: (ptr) => {
-    {{{ makeEval('eval(UTF8ToString(ptr));') }}}
+    {{{ makeEval('(0, eval)(UTF8ToString(ptr));') }}}
   },
 
   emscripten_run_script_int__docs: '/** @suppress{checkTypes} */',
   emscripten_run_script_int: (ptr) => {
-    {{{ makeEval('return eval(UTF8ToString(ptr))|0;') }}}
+    {{{ makeEval('return (0, eval)(UTF8ToString(ptr))|0;') }}}
   },
 
   // Mark as `noleakcheck` otherwise lsan will report the last returned string
@@ -1313,7 +1313,7 @@ addToLibrary({
   emscripten_run_script_string__noleakcheck: true,
   emscripten_run_script_string__deps: ['$lengthBytesUTF8', '$stringToUTF8', 'malloc'],
   emscripten_run_script_string: (ptr) => {
-    {{{ makeEval("var s = eval(UTF8ToString(ptr));") }}}
+    {{{ makeEval("var s = (0, eval)(UTF8ToString(ptr));") }}}
     if (s == null) {
       return 0;
     }
@@ -2440,7 +2440,7 @@ function wrapSyscallFunction(x, library, isWasi) {
     t = modifyJSFunction(t, (args, body) => `function (${args}) {\n${pre}${body}${post}}\n`);
   }
 
-  library[x] = eval('(' + t + ')');
+  library[x] = (0, eval)('(' + t + ')');
   // Automatically add dependency on `$SYSCALLS`
   if (!WASMFS && t.includes('SYSCALLS')) {
     library[x + '__deps'].push('$SYSCALLS');

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -786,7 +786,7 @@ var LibraryDylink = {
 #if DYLINK_DEBUG
           dbg(`adding new EM_ASM constant at: ${ptrToString(start)}`);
 #endif
-          {{{ makeEval('ASM_CONSTS[start] = eval(func)') }}};
+          {{{ makeEval('ASM_CONSTS[start] = (0, eval)(func)') }}};
         }
 
         // Add any EM_ASM function that exist in the side module
@@ -819,7 +819,7 @@ var LibraryDylink = {
 #if DYLINK_DEBUG
           dbg(`adding new EM_JS function: ${jsArgs} = ${func}`);
 #endif
-          {{{ makeEval('moduleExports[name] = eval(func)') }}};
+          {{{ makeEval('moduleExports[name] = (0, eval)(func)') }}};
         }
 
         for (var name in moduleExports) {


### PR DESCRIPTION
Indirect eval doesn't expose the local scope to the evaluated code, and won't warn as much from bundlers

Fixes #23464
