### PR TITLE
[eslint] Enable unused argument linting within the JS compiler. NFC

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -90,11 +90,8 @@ export default [{
   files: ['**/*.mjs'],
 
   rules: {
-    'no-undef': 'error',
     'no-unused-vars': ['error', {
-      vars: 'all',
-      args: 'none',
-      ignoreRestSiblings: false,
+      argsIgnorePattern: '^_',
       destructuredArrayIgnorePattern: '^_',
     }],
   },

--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -112,7 +112,7 @@ function resolveAlias(symbol) {
   return symbol;
 }
 
-function getTransitiveDeps(symbol, debug) {
+function getTransitiveDeps(symbol) {
   // TODO(sbc): Use some kind of cache to avoid quadratic behaviour here.
   const transitiveDeps = new Set();
   const seen = new Set();

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -334,7 +334,7 @@ if (!BOOTSTRAPPING_STRUCT_INFO) {
 // Use proxy objects for C_DEFINES and C_STRUCTS so that we can give useful
 // error messages.
 const C_STRUCTS = new Proxy(structs, {
-  get(target, prop, receiver) {
+  get(target, prop) {
     if (!(prop in target)) {
       throw new Error(
         `Missing C struct ${prop}! If you just added it to struct_info.json, you need to run ./tools/maint/gen_struct_info.py (then run a second time with --wasm64)`,
@@ -345,7 +345,7 @@ const C_STRUCTS = new Proxy(structs, {
 });
 
 const C_DEFINES = new Proxy(defines, {
-  get(target, prop, receiver) {
+  get(target, prop) {
     if (!(prop in target)) {
       throw new Error(
         `Missing C define ${prop}! If you just added it to struct_info.json, you need to run ./tools/maint/gen_struct_info.py (then run a second time with --wasm64)`,

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -214,7 +214,7 @@ no matching #endif found (${showStack.length$}' unmatched preprocessing directiv
 }
 
 // Returns true if ident is a niceIdent (see toNiceIdent). Also allow () and spaces.
-function isNiceIdent(ident, loose) {
+function isNiceIdent(ident) {
   return /^\(?[$_]+[\w$_\d ]*\)?$/.test(ident);
 }
 
@@ -970,7 +970,7 @@ function from64(x) {
 
 // Like from64 above but generate an expression instead of an assignment
 // statement.
-function from64Expr(x, assign = true) {
+function from64Expr(x) {
   if (!MEMORY64) return x;
   return `Number(${x})`;
 }

--- a/tools/acorn-optimizer.mjs
+++ b/tools/acorn-optimizer.mjs
@@ -289,7 +289,7 @@ function JSDCE(ast, aggressive) {
     }
     function cleanUp(ast, names) {
       recursiveWalk(ast, {
-        VariableDeclaration(node, c) {
+        VariableDeclaration(node, _c) {
           const old = node.declarations;
           let removedHere = 0;
           node.declarations = node.declarations.filter((node) => {
@@ -315,7 +315,7 @@ function JSDCE(ast, aggressive) {
             node.oldDeclarations = old;
           }
         },
-        ExpressionStatement(node, c) {
+        ExpressionStatement(node, _c) {
           if (aggressive && !hasSideEffects(node)) {
             if (!isNull(node.expression) && !isUseStrict(node.expression)) {
               convertToNullStatement(node);
@@ -323,7 +323,7 @@ function JSDCE(ast, aggressive) {
             }
           }
         },
-        FunctionDeclaration(node, c) {
+        FunctionDeclaration(node, _c) {
           if (Object.prototype.hasOwnProperty.call(names, node.id.name)) {
             removed++;
             emptyOut(node);
@@ -436,7 +436,7 @@ function JSDCE(ast, aggressive) {
       ArrowFunctionExpression(node, c) {
         handleFunction(node, c);
       },
-      Identifier(node, c) {
+      Identifier(node, _c) {
         const name = node.name;
         ensureData(scopes[scopes.length - 1], name).use = 1;
       },
@@ -1678,7 +1678,7 @@ function minifyLocals(ast) {
       localNames.add(param.name);
     }
     simpleWalk(fun, {
-      VariableDeclaration(node, c) {
+      VariableDeclaration(node, _c) {
         for (const dec of node.declarations) {
           localNames.add(dec.id.name);
         }
@@ -1704,7 +1704,7 @@ function minifyLocals(ast) {
     // Don't actually minify them yet as that might interfere with local
     // variable names; just mark them as used, and what their new name will be.
     simpleWalk(fun, {
-      Identifier(node, c) {
+      Identifier(node, _c) {
         const name = node.name;
         if (!isLocalName(name)) {
           const minified = extraInfo.globals[name];
@@ -1714,7 +1714,7 @@ function minifyLocals(ast) {
           }
         }
       },
-      CallExpression(node, c) {
+      CallExpression(node, _c) {
         // We should never call a local name, as in asm.js-style code our
         // locals are just numbers, not functions; functions are all declared
         // in the outer scope. If a local is called, that is a bug.
@@ -1775,12 +1775,12 @@ function minifyLocals(ast) {
         node.label.name = labelNames.get(node.label.name);
         c(node.body);
       },
-      BreakStatement(node, c) {
+      BreakStatement(node, _c) {
         if (node.label) {
           node.label.name = labelNames.get(node.label.name);
         }
       },
-      ContinueStatement(node, c) {
+      ContinueStatement(node, _c) {
         if (node.label) {
           node.label.name = labelNames.get(node.label.name);
         }


### PR DESCRIPTION
Also, remove the explicit `'no-undef'` specifier since we now get that as part of `js.configs.recommended` above.

Also, remove `vars: 'all'` which is the default.