### PR TITLE
Fix: Fix module not working on Deno

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -103,9 +103,13 @@ if (ENVIRONMENT_IS_NODE) {
 #if EXPORT_ES6
   // When building an ES module `require` is not normally available.
   // We need to use `createRequire()` to construct the require()` function.
-  const { createRequire } = await import('module');
+  const { createRequire } = await import('node:module');
   /** @suppress{duplicate} */
   var require = createRequire('/');
+
+  if (typeof Deno !== "undefined") {
+    var Buffer = require('buffer').Buffer;
+  }
 #endif
 
 #if PTHREADS || WASM_WORKERS


### PR DESCRIPTION
The written .mjs file does not work on Deno, so I fixed that.
- Use `node:module` instead of `module`, so Deno can import that.
- Added polyfill of `Buffer`.