### PR TITLE
[test] Test params should not start with `_`. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -792,6 +792,7 @@ def parameterize(func, parameters):
   test functions.
   """
   prev = getattr(func, '_parameterize', None)
+  assert not any(p.startswith('_') for p in parameters)
   if prev:
     # If we're parameterizing 2nd time, construct a cartesian product for various combinations.
     func._parameterize = {

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7017,7 +7017,7 @@ void* operator new(size_t size) {
 
   @parameterized({
     '': ([],),
-    '_files': (['-DUSE_FILES'],)
+    'files': (['-DUSE_FILES'],)
   })
   def test_FS_exports(self, extra_args):
     # these used to be exported, but no longer are by default

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -999,7 +999,7 @@ f.close()
   @requires_ninja
   @parameterized({
     '': [[]],
-    '_no_gnu': [['-DNO_GNU_EXTENSIONS=1']],
+    'no_gnu': [['-DNO_GNU_EXTENSIONS=1']],
   })
   def test_cmake_with_embind_cpp11_mode(self, args):
     # Use ninja generator here since we assume its always installed on our build/test machines.
@@ -1022,7 +1022,7 @@ f.close()
 
   @parameterized({
     '': ['0'],
-    '_suffix': ['1'],
+    'suffix': ['1'],
   })
   def test_cmake_static_lib(self, custom):
     # Test that one is able to use custom suffixes for static libraries.
@@ -14970,8 +14970,8 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
 
   @parameterized({
     '':   ([],),
-    '_single_file': (['-sSINGLE_FILE'],),
-    '_single_file_es6': (['-sSINGLE_FILE', '-sEXPORT_ES6', '--extern-post-js', test_file('modularize_post_js.js')],),
+    'single_file': (['-sSINGLE_FILE'],),
+    'single_file_es6': (['-sSINGLE_FILE', '-sEXPORT_ES6', '--extern-post-js', test_file('modularize_post_js.js')],),
   })
   def test_proxy_to_worker(self, args):
     self.do_runf('hello_world.c', emcc_args=['--proxy-to-worker'] + args)


### PR DESCRIPTION
The params names are implicitly joined to the test name with `_`.