### PR TITLE
Simplify linker flag handling. NFC

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -270,7 +270,7 @@ def filter_link_flags(flags, using_lld):
           return False, skip_next
       return True, False
     else:
-      if f in SUPPORTED_LINKER_FLAGS:
+      if not f.startswith('-') or f in SUPPORTED_LINKER_FLAGS:
         return True, False
       # Silently ignore -l/-L flags when not using lld.  If using lld allow
       # them to pass through the linker
@@ -285,7 +285,7 @@ def filter_link_flags(flags, using_lld):
     if skip_next:
       skip_next = False
       continue
-    keep, skip_next = is_supported(f[1])
+    keep, skip_next = is_supported(f)
     if keep:
       results.append(f)
 
@@ -631,7 +631,7 @@ def check_browser_versions():
 
 
 @ToolchainProfiler.profile_block('linker_setup')
-def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
+def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
   """Future modifications should consider refactoring to reduce complexity.
 
   * The McCabe cyclomatiic complexity is currently 251 vs 10 recommended.
@@ -640,10 +640,9 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
 
   To revalidate these numbers, run `ruff check --select=C901,PLR091`.
   """
-  system_libpath = '-L' + str(cache.get_lib_dir(absolute=True))
-  system_js_path = '-L' + utils.path_from_root('src', 'lib')
-  state.append_link_flag(system_libpath)
-  state.append_link_flag(system_js_path)
+
+  apply_library_settings(linker_args)
+  linker_args += calc_extra_ldflags(options)
 
   # We used to do this check during on startup during `check_sanity`, but
   # we now only do it when linking, in order to reduce the overhead when
@@ -1203,7 +1202,6 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
     settings.EXCEPTION_STACK_TRACES = 0
 
   if settings.STB_IMAGE:
-    state.append_link_flag('-lstb_image')
     settings.EXPORTED_FUNCTIONS += ['_stbi_load', '_stbi_load_from_memory', '_stbi_image_free']
 
   if settings.USE_WEBGL2:
@@ -1233,15 +1231,6 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
     exit_with_error('`-sFORCE_FILESYSTEM` cannot be used with `-sFILESYSTEM=0`')
 
   if settings.WASMFS:
-    if settings.NODERAWFS:
-      # wasmfs will be included normally in system_libs.py, but we must include
-      # noderawfs in a forced manner so that it is always linked in (the hook it
-      # implements can remain unimplemented, so it won't be linked in
-      # automatically)
-      # TODO: find a better way to do this
-      state.append_link_flag('--whole-archive')
-      state.append_link_flag('-lwasmfs_noderawfs')
-      state.append_link_flag('--no-whole-archive')
     settings.FILESYSTEM = 1
     settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
     settings.JS_LIBRARIES.append('libwasmfs.js')
@@ -1296,9 +1285,6 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
         '_wasmfs_get_cwd',
       ]
 
-  if settings.FETCH:
-    state.append_link_flag('-lfetch')
-
   if settings.DEMANGLE_SUPPORT:
     settings.REQUIRED_EXPORTS += ['__cxa_demangle', 'free']
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$demangle', '$stackTrace']
@@ -1352,9 +1338,6 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
     # a standard system would. However, if the user sets the flag it
     # overrides that.
     default_setting('ABORTING_MALLOC', 0)
-
-  if state.has_link_flag('-lembind'):
-    settings.EMBIND = 1
 
   if settings.EMBIND:
     # Workaround for embind+LTO issue:
@@ -1464,7 +1447,7 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
   # When not declaring wasm module exports in outer scope one by one, disable minifying
   # wasm module export names so that the names can be passed directly to the outer scope.
   # Also, if using libexports.js API, disable minification so that the feature can work.
-  if not settings.DECLARE_ASM_MODULE_EXPORTS or state.has_link_flag('-lexports.js'):
+  if not settings.DECLARE_ASM_MODULE_EXPORTS or '-lexports.js' in linker_args:
     settings.MINIFY_WASM_EXPORT_NAMES = 0
 
   # Enable minification of wasm imports and exports when appropriate, if we
@@ -1667,7 +1650,7 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
     # (because stack overflows will trap rather than corrupting data).
     settings.STACK_FIRST = True
 
-  if state.has_link_flag('--stack-first'):
+  if '--stack-first' in linker_args:
     settings.STACK_FIRST = True
     if settings.USE_ASAN:
       exit_with_error('--stack-first is not compatible with asan')
@@ -1862,19 +1845,19 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
 
 
 @ToolchainProfiler.profile_block('calculate system libraries')
-def phase_calculate_system_libraries(options, linker_arguments):
+def phase_calculate_system_libraries(options):
   extra_files_to_link = []
   # Link in ports and system libraries, if necessary
   if not settings.SIDE_MODULE:
     # Ports are always linked into the main module, never the side module.
     extra_files_to_link += ports.get_libs(settings)
   extra_files_to_link += system_libs.calculate(options)
-  linker_arguments.extend(extra_files_to_link)
+  return extra_files_to_link
 
 
 @ToolchainProfiler.profile_block('link')
-def phase_link(linker_arguments, wasm_target, js_syms):
-  logger.debug(f'linking: {linker_arguments}')
+def phase_link(linker_args, wasm_target, js_syms):
+  logger.debug(f'linking: {linker_args}')
 
   # Make a final pass over settings.EXPORTED_FUNCTIONS to remove any
   # duplication between functions added by the driver/libraries and function
@@ -1895,16 +1878,16 @@ def phase_link(linker_arguments, wasm_target, js_syms):
     # TODO(sbc): Remove this double execution of wasm-ld if we ever find a way to
     # distinguish EMSCRIPTEN_KEEPALIVE exports from `--export-dynamic` exports.
     settings.LINKABLE = False
-    building.link_lld(linker_arguments, wasm_target, external_symbols=js_syms)
+    building.link_lld(linker_args, wasm_target, external_symbols=js_syms)
     settings.LINKABLE = True
     rtn = extract_metadata.extract_metadata(wasm_target)
 
-  building.link_lld(linker_arguments, wasm_target, external_symbols=js_syms)
+  building.link_lld(linker_args, wasm_target, external_symbols=js_syms)
   return rtn
 
 
 @ToolchainProfiler.profile_block('post link')
-def phase_post_link(options, in_wasm, wasm_target, target, js_syms, base_metadata=None, linker_inputs=None):
+def phase_post_link(options, in_wasm, wasm_target, target, js_syms, base_metadata=None):
   global final_js
 
   target_basename = unsuffixed_basename(target)
@@ -1924,10 +1907,10 @@ def phase_post_link(options, in_wasm, wasm_target, target, js_syms, base_metadat
   metadata = phase_emscript(in_wasm, wasm_target, js_syms, base_metadata)
 
   if settings.EMBIND_AOT:
-    phase_embind_aot(wasm_target, js_syms, linker_inputs)
+    phase_embind_aot(options, wasm_target, js_syms)
 
   if options.emit_tsd:
-    phase_emit_tsd(options, wasm_target, js_target, js_syms, metadata, linker_inputs)
+    phase_emit_tsd(options, wasm_target, js_target, js_syms, metadata)
 
   if options.js_transform:
     phase_source_transforms(options)
@@ -1961,18 +1944,18 @@ def phase_emscript(in_wasm, wasm_target, js_syms, base_metadata):
   return metadata
 
 
-def run_embind_gen(wasm_target, js_syms, extra_settings, linker_inputs):
+def run_embind_gen(options, wasm_target, js_syms, extra_settings):
   # Save settings so they can be restored after TS generation.
   original_settings = settings.backup()
   settings.attrs.update(extra_settings)
   settings.EMBIND_GEN_MODE = True
 
-  if settings.MAIN_MODULE and linker_inputs:
+  if settings.MAIN_MODULE:
     # Copy libraries to the temp directory so they can be used when running
     # in node.
-    for _i, linker_input in linker_inputs:
-      if building.is_wasm_dylib(linker_input):
-        safe_copy(linker_input, in_temp(''))
+    for f in options.input_files:
+      if building.is_wasm_dylib(f):
+        safe_copy(f, in_temp(''))
 
   settings.EXPORTED_RUNTIME_METHODS = []
   # Ignore any options or settings that can conflict with running the TS
@@ -2032,20 +2015,20 @@ def run_embind_gen(wasm_target, js_syms, extra_settings, linker_inputs):
 
 
 @ToolchainProfiler.profile_block('emit tsd')
-def phase_emit_tsd(options, wasm_target, js_target, js_syms, metadata, linker_inputs):
+def phase_emit_tsd(options, wasm_target, js_target, js_syms, metadata):
   logger.debug('emit tsd')
   filename = options.emit_tsd
   embind_tsd = ''
   if settings.EMBIND:
-    embind_tsd = run_embind_gen(wasm_target, js_syms, {'EMBIND_AOT': False}, linker_inputs)
+    embind_tsd = run_embind_gen(options, wasm_target, js_syms, {'EMBIND_AOT': False})
   all_tsd = emscripten.create_tsd(metadata, embind_tsd)
   out_file = os.path.join(os.path.dirname(js_target), filename)
   write_file(out_file, all_tsd)
 
 
 @ToolchainProfiler.profile_block('embind aot js')
-def phase_embind_aot(wasm_target, js_syms, linker_inputs):
-  out = run_embind_gen(wasm_target, js_syms, {}, linker_inputs)
+def phase_embind_aot(options, wasm_target, js_syms):
+  out = run_embind_gen(options, wasm_target, js_syms, {})
   if DEBUG:
     write_file(in_temp('embind_aot.js'), out)
   src = read_file(final_js)
@@ -2762,16 +2745,6 @@ def map_to_js_libs(library_name):
     'stdc++': [],
     'SDL2_mixer': [],
   }
-  settings_map = {
-    'glfw': {'USE_GLFW': 2},
-    'glfw3': {'USE_GLFW': 3},
-    'SDL': {'USE_SDL': 1},
-    'SDL2_mixer': {'USE_SDL_MIXER': 2},
-  }
-
-  if library_name in settings_map:
-    for key, value in settings_map[library_name].items():
-      default_setting(key, value)
 
   if library_name in library_map:
     libs = library_map[library_name]
@@ -2781,18 +2754,18 @@ def map_to_js_libs(library_name):
   return None
 
 
-def process_libraries(state):
+def process_libraries(options, flags):
   new_flags = []
   system_libs_map = system_libs.Library.get_usable_variations()
 
   # Process `-l` and `--js-library` flags
-  for i, flag in state.link_flags:
+  for flag in flags:
     if flag.startswith('--js-library='):
       js_lib = os.path.abspath(flag.split('=', 1)[1])
       settings.JS_LIBRARIES.append(js_lib)
       continue
     if not flag.startswith('-l'):
-      new_flags.append((i, flag))
+      new_flags.append(flag)
       continue
     lib = removeprefix(flag, '-l')
 
@@ -2807,7 +2780,7 @@ def process_libraries(state):
     # For example we map `-lc` to `-lc-mt` if we are building with threading support.
     if 'lib' + lib in system_libs_map:
       lib = system_libs_map['lib' + lib].get_link_flag()
-      new_flags.append((i, lib))
+      new_flags.append(lib)
       continue
 
     if js_libs is not None:
@@ -2815,7 +2788,7 @@ def process_libraries(state):
 
     if lib.endswith('.js'):
       name = 'lib' + lib
-      path = find_library(name, state.lib_dirs)
+      path = find_library(name, options.lib_dirs)
       if not path:
         exit_with_error(f'unable to find library {flag}')
       settings.JS_LIBRARIES.append(os.path.abspath(path))
@@ -2830,18 +2803,36 @@ def process_libraries(state):
       found_dylib = False
       for ext in DYLIB_EXTENSIONS:
         name = 'lib' + lib + ext
-        path = find_library(name, state.lib_dirs)
+        path = find_library(name, options.lib_dirs)
         if path:
           found_dylib = True
-          new_flags.append((i, path))
+          new_flags.append(path)
           break
 
       if found_dylib:
         continue
 
-    new_flags.append((i, flag))
+    new_flags.append(flag)
 
-  state.link_flags = new_flags
+  return new_flags
+
+
+def apply_library_settings(linker_args):
+  for arg in linker_args:
+    if not arg.startswith('-l'):
+      continue
+    library_name = arg[2:]
+    settings_map = {
+      'embind': {'EMBIND': 1},
+      'glfw': {'USE_GLFW': 2},
+      'glfw3': {'USE_GLFW': 3},
+      'SDL': {'USE_SDL': 1},
+      'SDL2_mixer': {'USE_SDL_MIXER': 2},
+    }
+
+    if library_name in settings_map:
+      for key, value in settings_map[library_name].items():
+        default_setting(key, value)
 
 
 class ScriptSource:
@@ -3069,17 +3060,10 @@ def package_files(options, target):
 
 
 @ToolchainProfiler.profile_block('calculate linker inputs')
-def phase_calculate_linker_inputs(options, state, linker_inputs):
+def phase_calculate_linker_inputs(options, linker_args):
   using_lld = not (options.oformat == OFormat.OBJECT and settings.LTO)
-  state.link_flags = filter_link_flags(state.link_flags, using_lld)
 
-  # Decide what we will link
-  process_libraries(state)
-
-  # Interleave the linker inputs with the linker flags while maintainging their
-  # relative order on the command line (both of these list are pairs, with the
-  # first element being their command line position).
-  linker_args = [val for _, val in sorted(linker_inputs + state.link_flags)]
+  linker_args = filter_link_flags(linker_args, using_lld)
 
   # If we are linking to an intermediate object then ignore other
   # "fake" dynamic libraries, since otherwise we will end up with
@@ -3091,44 +3075,72 @@ def phase_calculate_linker_inputs(options, state, linker_inputs):
 
   if settings.MAIN_MODULE:
     dylibs = [a for a in linker_args if building.is_wasm_dylib(a)]
-    process_dynamic_libs(dylibs, state.lib_dirs)
+    process_dynamic_libs(dylibs, options.lib_dirs)
 
   return linker_args
 
 
-def run_post_link(wasm_input, options, state):
+def calc_extra_ldflags(options):
+  extra_args = []
+  system_libpath = str(cache.get_lib_dir(absolute=True))
+  system_js_path = utils.path_from_root('src', 'lib')
+  options.lib_dirs.append(system_libpath)
+  options.lib_dirs.append(system_js_path)
+  extra_args.append('-L' + system_libpath)
+  extra_args.append('-L' + system_js_path)
+
+  if settings.FETCH:
+    extra_args.append('-lfetch')
+  if settings.STB_IMAGE:
+    extra_args.append('-lstb_image')
+  if settings.WASMFS and settings.NODERAWFS:
+    # wasmfs will be included normally in system_libs.py, but we must include
+    # noderawfs in a forced manner so that it is always linked in (the hook it
+    # implements can remain unimplemented, so it won't be linked in
+    # automatically)
+    # TODO: find a better way to do this
+    extra_args.append('--whole-archive')
+    extra_args.append('-lwasmfs_noderawfs')
+    extra_args.append('--no-whole-archive')
+
+  return extra_args
+
+
+def run_post_link(wasm_input, options, linker_args):
   settings.limit_settings(None)
-  target, wasm_target = phase_linker_setup(options, state)
-  process_libraries(state)
+  target, wasm_target = phase_linker_setup(options, linker_args)
+  process_libraries(options, linker_args)
   phase_post_link(options, wasm_input, wasm_target, target, {})
 
 
-def run(linker_inputs, options, state):
+def run(options, linker_args):
   # We have now passed the compile phase, allow reading/writing of all settings.
   settings.limit_settings(None)
 
-  if not linker_inputs and not state.link_flags:
+  if not linker_args:
     exit_with_error('no input files')
 
   if options.output_file and options.output_file.startswith('-'):
     exit_with_error(f'invalid output filename: `{options.output_file}`')
 
-  target, wasm_target = phase_linker_setup(options, state)
+  target, wasm_target = phase_linker_setup(options, linker_args)
+
+  linker_args = process_libraries(options, linker_args)
 
   # Link object files using wasm-ld or llvm-link (for bitcode linking)
-  linker_arguments = phase_calculate_linker_inputs(options, state, linker_inputs)
+  linker_args = phase_calculate_linker_inputs(options, linker_args)
 
   # Embed and preload files
   if len(options.preload_files) or len(options.embed_files):
-    linker_arguments += package_files(options, target)
+    linker_args += package_files(options, target)
 
   if options.oformat == OFormat.OBJECT:
-    logger.debug(f'link_to_object: {linker_arguments} -> {target}')
-    building.link_to_object(linker_arguments, target)
+    logger.debug(f'link_to_object: {linker_args} -> {target}')
+    building.link_to_object(linker_args, target)
     logger.debug('stopping after linking to object file')
     return 0
 
-  phase_calculate_system_libraries(options, linker_arguments)
+  linker_args += phase_calculate_system_libraries(options)
 
   js_syms = {}
   if (not settings.SIDE_MODULE or settings.ASYNCIFY) and not shared.SKIP_SUBPROCS:
@@ -3157,11 +3169,11 @@ def run(linker_inputs, options, state):
       settings.ASYNCIFY_IMPORTS_EXCEPT_JS_LIBS = settings.ASYNCIFY_IMPORTS[:]
       settings.ASYNCIFY_IMPORTS += ['*.' + x for x in js_info['asyncFuncs']]
 
-  base_metadata = phase_link(linker_arguments, wasm_target, js_syms)
+  base_metadata = phase_link(linker_args, wasm_target, js_syms)
 
   # Special handling for when the user passed '-Wl,--version'.  In this case the linker
   # does not create the output file, but just prints its version and exits with 0.
-  if '--version' in linker_arguments:
+  if '--version' in linker_args:
     return 0
 
   # TODO(sbc): In theory we should really run the whole pipeline even if the output is
@@ -3171,6 +3183,6 @@ def run(linker_inputs, options, state):
 
   # Perform post-link steps (unless we are running bare mode)
   if options.oformat != OFormat.BARE:
-    phase_post_link(options, wasm_target, wasm_target, target, js_syms, base_metadata, linker_inputs)
+    phase_post_link(options, wasm_target, wasm_target, target, js_syms, base_metadata)
 
   return 0


### PR DESCRIPTION
This change simplifies the interface between emcc.py (the compiler driver) and link.py (the linker).

Linker flags are no longer stored in the EmccState or stored alongside their ordinal number. Instead passed directly the link.py as a simple list.

This change brings us closer to de-coupling the linker process with the hope of creating a standalone emld entry point.