### PR TITLE
Fix proxy-to-worker + modularize error reporting

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14971,7 +14971,6 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
   @parameterized({
     '':   ([],),
     'single_file': (['-sSINGLE_FILE'],),
-    'single_file_es6': (['-sSINGLE_FILE', '-sEXPORT_ES6', '--extern-post-js', test_file('modularize_post_js.js')],),
   })
   def test_proxy_to_worker(self, args):
     self.do_runf('hello_world.c', emcc_args=['--proxy-to-worker'] + args)

--- a/tools/link.py
+++ b/tools/link.py
@@ -915,6 +915,12 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
     # When using MINIMAL_RUNTIME, symbols should only be exported if requested.
     default_setting('EXPORT_KEEPALIVE', 0)
 
+  if settings.EXPORT_ES6 and not settings.MODULARIZE:
+    # EXPORT_ES6 requires output to be a module
+    if 'MODULARIZE' in user_settings:
+      exit_with_error('EXPORT_ES6 requires MODULARIZE to be set')
+    settings.MODULARIZE = 1
+
   if settings.STRICT_JS and (settings.MODULARIZE or settings.EXPORT_ES6):
     exit_with_error("STRICT_JS doesn't work with MODULARIZE or EXPORT_ES6")
 
@@ -926,7 +932,7 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
       options.shell_path = DEFAULT_SHELL_HTML
 
   if settings.STRICT:
-    if not settings.MODULARIZE and not settings.EXPORT_ES6:
+    if not settings.MODULARIZE:
       default_setting('STRICT_JS', 1)
     default_setting('DEFAULT_TO_CXX', 0)
     default_setting('IGNORE_MISSING_MAIN', 0)
@@ -1441,17 +1447,11 @@ def phase_linker_setup(options, state):  # noqa: C901, PLR0912, PLR0915
 
   set_initial_memory()
 
-  if settings.EXPORT_ES6:
-    if not settings.MODULARIZE:
-      # EXPORT_ES6 requires output to be a module
-      if 'MODULARIZE' in user_settings:
-        exit_with_error('EXPORT_ES6 requires MODULARIZE to be set')
-      settings.MODULARIZE = 1
-    if settings.ENVIRONMENT_MAY_BE_NODE and not settings.USE_ES6_IMPORT_META:
-      # EXPORT_ES6 + ENVIRONMENT=*node* requires the use of import.meta.url
-      if 'USE_ES6_IMPORT_META' in user_settings:
-        exit_with_error('EXPORT_ES6 and ENVIRONMENT=*node* requires USE_ES6_IMPORT_META to be set')
-      settings.USE_ES6_IMPORT_META = 1
+  if settings.EXPORT_ES6 and settings.ENVIRONMENT_MAY_BE_NODE and not settings.USE_ES6_IMPORT_META:
+    # EXPORT_ES6 + ENVIRONMENT=*node* requires the use of import.meta.url
+    if 'USE_ES6_IMPORT_META' in user_settings:
+      exit_with_error('EXPORT_ES6 and ENVIRONMENT=*node* requires USE_ES6_IMPORT_META to be set')
+    settings.USE_ES6_IMPORT_META = 1
 
   if settings.MODULARIZE and not settings.DECLARE_ASM_MODULE_EXPORTS:
     # When MODULARIZE option is used, currently requires declaring all module exports


### PR DESCRIPTION
This configuration is not supported by was going undetected when `-sEXPORT_ES6` was used due to the order to checking vs setting the `MODULARIZE` setting.

This change doesn't add or remove any checks, it only changes the ordering so we don't check settings before they are set.