### PR TITLE
Remove the need for jscompiler to run with CWD=emscripten/src. NFC

### DIFF
--- a/src/compiler.mjs
+++ b/src/compiler.mjs
@@ -7,10 +7,9 @@
 
 // JavaScript compiler, main entry point
 
-import {Benchmarker, applySettings, loadDefaultSettings, printErr, read} from './utility.mjs';
-
 import assert from 'node:assert';
 import {parseArgs} from 'node:util';
+import {Benchmarker, applySettings, loadDefaultSettings, printErr, readFile} from './utility.mjs';
 
 loadDefaultSettings();
 
@@ -31,10 +30,14 @@ Usage: compiler.mjs <settings.json> [-o out.js] [--symbols-only]`);
 // Load settings from JSON passed on the command line
 const settingsFile = positionals[0];
 assert(settingsFile, 'settings file not specified');
-const user_settings = JSON.parse(read(settingsFile));
+const user_settings = JSON.parse(readFile(settingsFile));
 applySettings(user_settings);
 
 export const symbolsOnly = values['symbols-only'];
+
+// TODO(sbc): Remove EMCC_BUILD_DIR at some point.  It used to be required
+// back when ran the JS compiler with overridden CWD.
+process.env['EMCC_BUILD_DIR'] = process.cwd()
 
 // In case compiler.mjs is run directly (as in gen_sig_info)
 // ALL_INCOMING_MODULE_JS_API might not be populated yet.

--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -8,6 +8,7 @@
 // before this stage, which just does the final conversion to JavaScript.
 
 import assert from 'node:assert';
+import * as path from 'node:path';
 import {
   ATEXITS,
   ATINITS,
@@ -29,10 +30,11 @@ import {
   compileTimeContext,
   print,
   printErr,
-  read,
+  readFile,
   warn,
   warnOnce,
   warningOccured,
+  localFile,
 } from './utility.mjs';
 import {LibraryManager, librarySymbols} from './modules.mjs';
 
@@ -137,16 +139,18 @@ function getTransitiveDeps(symbol) {
 }
 
 function shouldPreprocess(fileName) {
-  var content = read(fileName).trim();
+  var content = readFile(fileName).trim();
   return content.startsWith('#preprocess\n') || content.startsWith('#preprocess\r\n');
 }
 
-function getIncludeFile(fileName, needsPreprocess) {
+function getIncludeFile(fileName, alwaysPreprocess) {
   let result = `// include: ${fileName}\n`;
-  if (needsPreprocess) {
-    result += processMacros(preprocess(fileName), fileName);
+  const absFile = path.isAbsolute(fileName) ? fileName : localFile(fileName);
+  const doPreprocess = alwaysPreprocess || shouldPreprocess(absFile);
+  if (doPreprocess) {
+    result += processMacros(preprocess(absFile), fileName);
   } else {
-    result += read(fileName);
+    result += readFile(absFile);
   }
   result += `// end include: ${fileName}\n`;
   return result;
@@ -155,7 +159,7 @@ function getIncludeFile(fileName, needsPreprocess) {
 function preJS() {
   let result = '';
   for (const fileName of PRE_JS_FILES) {
-    result += getIncludeFile(fileName, shouldPreprocess(fileName));
+    result += getIncludeFile(fileName, /*alwaysPreprocess=*/ false);
   }
   return result;
 }
@@ -697,8 +701,8 @@ function(${args}) {
     libraryItems.push(JS);
   }
 
-  function includeFile(fileName, needsPreprocess = true) {
-    print(getIncludeFile(fileName, needsPreprocess));
+  function includeFile(fileName, alwaysPreprocess = true) {
+    print(getIncludeFile(fileName, alwaysPreprocess));
   }
 
   function finalCombiner() {
@@ -755,7 +759,7 @@ var proxiedFunctionTable = [
     includeFile(postFile);
 
     for (const fileName of POST_JS_FILES) {
-      includeFile(fileName, shouldPreprocess(fileName));
+      includeFile(fileName, /*alwaysPreprocess=*/ false);
     }
 
     if (MODULARIZE) {

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -13,7 +13,7 @@ import {
   isDecorator,
   isJsOnlySymbol,
   error,
-  read,
+  readFile,
   warn,
   setCurrentFile,
   printErr,
@@ -273,7 +273,7 @@ export const LibraryManager = {
       } catch (e) {
         error(`failure to execute js library "${filename}":`);
         if (VERBOSE) {
-          const orig = read(filename);
+          const orig = readFile(filename);
           if (processed) {
             error(
               `preprocessed source (you can run a js engine on this to get a clearer error message sometimes):\n=============\n${processed}\n=============`,
@@ -317,7 +317,7 @@ let defines = {};
  * that can then be used in JavaScript via macros.
  */
 function loadStructInfo(filename) {
-  const temp = JSON.parse(read(filename));
+  const temp = JSON.parse(readFile(filename));
   Object.assign(structs, temp.structs);
   Object.assign(defines, temp.defines);
 }

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -16,7 +16,7 @@ import {
   addToCompileTimeContext,
   error,
   printErr,
-  read,
+  readFile,
   runInMacroContext,
   setCurrentFile,
   warn,
@@ -64,7 +64,7 @@ function findIncludeFile(filename, currentDir) {
 // ident checked is true in our global.
 // Also handles #include x.js (similar to C #include <file>)
 export function preprocess(filename) {
-  let text = read(filename);
+  let text = readFile(filename);
   if (EXPORT_ES6 && USE_ES6_IMPORT_META) {
     // `eval`, Terser and Closure don't support module syntax; to allow it,
     // we need to temporarily replace `import.meta` and `await import` usages

--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -224,7 +224,7 @@ export function isDecorator(ident) {
   return suffixes.some((suffix) => ident.endsWith(suffix));
 }
 
-export function read(filename) {
+export function readFile(filename) {
   return fs.readFileSync(filename, 'utf8');
 }
 
@@ -238,6 +238,15 @@ export const srcDir = __dirname;
 export function localFile(filename) {
   assert(!path.isAbsolute(filename));
   return path.join(srcDir, filename);
+}
+
+// Helper function for JS library files that can be used to read files
+// relative to the src/ directory.
+function read(filename) {
+  if (!path.isAbsolute(filename)) {
+    filename = localFile(filename);
+  }
+  return readFile(filename);
 }
 
 // Anything needed by the script that we load below must be added to the
@@ -311,7 +320,7 @@ export function applySettings(obj) {
 
 export function loadSettingsFile(f) {
   const settings = {};
-  vm.runInNewContext(read(f), settings, {filename: f});
+  vm.runInNewContext(readFile(f), settings, {filename: f});
   applySettings(settings);
   return settings;
 }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -4961,14 +4961,15 @@ extraLibraryFuncs.push('jsfunc');
     self.do_runf(test_file('hello_world.c'), emcc_args=['-L', '-lfoo.js'])
 
   def test_EMCC_BUILD_DIR(self):
-    # EMCC_BUILD_DIR env var contains the dir we were building in, when running the js compiler (e.g. when
-    # running a js library). We force the cwd to be src/ for technical reasons, so this lets you find out
-    # where you were.
+    # EMCC_BUILD_DIR was necessary in the past since we used to force the cwd to be src/ for
+    # technical reasons.
     create_file('lib.js', r'''
-printErr('dir was ' + process.env.EMCC_BUILD_DIR);
+printErr('EMCC_BUILD_DIR: ' + process.env.EMCC_BUILD_DIR);
+printErr('CWD: ' + process.cwd());
 ''')
     err = self.run_process([EMXX, test_file('hello_world.c'), '--js-library', 'lib.js'], stderr=PIPE).stderr
-    self.assertContained('dir was ' + os.path.realpath(os.path.normpath(self.get_dir())), err)
+    self.assertContained('EMCC_BUILD_DIR: ' + os.path.realpath(os.path.normpath(self.get_dir())), err)
+    self.assertContained('CWD: ' + os.path.realpath(os.path.normpath(self.get_dir())), err)
 
   def test_float_h(self):
     process = self.run_process([EMCC, test_file('float+.c')], stdout=PIPE, stderr=PIPE)

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -183,14 +183,11 @@ def compile_javascript(symbols_only=False):
       json.dump(settings.external_dict(), s, sort_keys=True, indent=2)
 
     # Call js compiler
-    env = os.environ.copy()
-    env['EMCC_BUILD_DIR'] = os.getcwd()
     args = [settings_file]
     if symbols_only:
       args += ['--symbols-only']
     out = shared.run_js_tool(path_from_root('src/compiler.mjs'),
-                             args, stdout=subprocess.PIPE, stderr=stderr_file,
-                             cwd=path_from_root('src'), env=env, encoding='utf-8')
+                             args, stdout=subprocess.PIPE, stderr=stderr_file, encoding='utf-8')
   if symbols_only:
     glue = None
     forwarded_data = out

--- a/tools/maint/gen_sig_info.py
+++ b/tools/maint/gen_sig_info.py
@@ -322,7 +322,7 @@ def extract_sig_info(sig_info, extra_settings=None, extra_cflags=None, cxx=False
     utils.write_file(settings_json, json.dumps(settings))
     output = shared.run_js_tool(utils.path_from_root('src/compiler.mjs'),
                                 ['--symbols-only', settings_json],
-                                stdout=subprocess.PIPE, cwd=utils.path_from_root())
+                                stdout=subprocess.PIPE)
   symbols = json.loads(output)['deps'].keys()
   symbols = [s for s in symbols if not ignore_symbol(s, cxx)]
   if cxx:


### PR DESCRIPTION
The only place that CWD was relied upon here was the use of the `read()`
function in some JS library code that was expecting to be able to read
files relative to the `src` directory.  To deal with this use case I
created a new `readFile` function for compiler usage and modified the
exported `read` function to explicitly support `src/` relative files.

This change makes the existing `EMCC_BUILD_DIR` environment variable
obsolete since it was only needed because we were modifying CWD when
running the JS compiler.
