### PR TITLE
Support modularize instance exports in the acorn optimizer.

### DIFF
--- a/test/js_optimizer/emitDCEGraph-output.js
+++ b/test/js_optimizer/emitDCEGraph-output.js
@@ -110,6 +110,17 @@
   "reaches": []
  },
  {
+  "name": "emcc$export$expESM1",
+  "export": "expESM1",
+  "reaches": []
+ },
+ {
+  "name": "emcc$export$expESM2",
+  "export": "expESM2",
+  "reaches": [],
+  "root": true
+ },
+ {
   "name": "emcc$export$expI1",
   "export": "expI1",
   "reaches": [],

--- a/test/js_optimizer/emitDCEGraph.js
+++ b/test/js_optimizer/emitDCEGraph.js
@@ -61,6 +61,10 @@ var expI4 = Module['expI4'] = () => (expI4 = Module['expI4'] = wasmExports['expI
 // Same as above but not export on the Module.
 var expI5 = () => (expI5 = wasmExports['expI5'])();
 
+// Modularize instance style exports.
+var expESM1 = __exp_expESM1 = wasmExports['expESM1'];
+var expESM2 = __exp_expESM2 = wasmExports['expESM2'];
+
 function applySignatureConversions() {
   // Wrapping functions should not constitute a usage
   wasmExports['expI5'] = foo(wasmExports['expI5']);
@@ -74,6 +78,8 @@ wasmExports['expD3'];
 expI1;
 Module['expI2'];
 wasmExports['expI3'];
+
+expESM2;
 
 // deep uses, that we can't scan
 function usedFromDeep() {


### PR DESCRIPTION
Helps identify exports in the style of:

`var foo = __exp__foo = wasmExports['_foo']`