### PR TITLE
[embind] Stricter function argument name checking

### DIFF
--- a/src/lib/libembind_gen.js
+++ b/src/lib/libembind_gen.js
@@ -499,13 +499,13 @@ var LibraryEmbind = {
         }
         argStart = 2;
       }
-      if (argsName.length && argsName.length != (argTypes.length - hasThis - 1)) {
+      if (argsName && argsName.length != (argTypes.length - hasThis - 1)) {
         throw new Error('Argument names should match number of parameters.');
       }
 
       const args = [];
       for (let i = argStart, x = 0; i < argTypes.length; i++) {
-        if (x < argsName.length) {
+        if (argsName) {
           args.push(new Argument(argsName[x++], argTypes[i]));
         } else {
           args.push(new Argument(`_${i - argStart}`, argTypes[i]));

--- a/src/lib/libembind_shared.js
+++ b/src/lib/libembind_shared.js
@@ -126,27 +126,21 @@ var LibraryEmbindShared = {
   $getFunctionName: (signature) => {
     signature = signature.trim();
     const argsIndex = signature.indexOf("(");
-    if (argsIndex !== -1) {
+    if (argsIndex === -1) return signature;
 #if ASSERTIONS
-      assert(signature.endsWith(")"), "Parentheses for argument names should match.");
+    assert(signature.endsWith(")"), "Parentheses for argument names should match.");
 #endif
-      return signature.slice(0, argsIndex);
-    } else {
-      return signature;
-    }
+    return signature.slice(0, argsIndex);
   },
   $getFunctionArgsName__deps: [],
   $getFunctionArgsName: (signature) => {
     signature = signature.trim();
-    const argsIndex = signature.indexOf("(") + 1;
-    if (argsIndex !== 0) {
+    const argsIndex = signature.indexOf("(");
+    if (argsIndex == -1) return; // Return undefined to mean we don't have any argument names
 #if ASSERTIONS
-      assert(signature.endsWith(")"), "Parentheses for argument names should match.");
+    assert(signature.endsWith(")"), "Parentheses for argument names should match.");
 #endif
-      return signature.slice(argsIndex, -1).replaceAll(" ", "").split(",").filter(n => n.length);
-    } else {
-      return [];
-    }
+    return signature.slice(argsIndex + 1, -1).replaceAll(" ", "").split(",").filter(n => n.length);
   },
   $heap32VectorToArray: (count, firstElement) => {
     var array = [];

--- a/test/code_size/embind_hello_wasm.json
+++ b/test/code_size/embind_hello_wasm.json
@@ -2,9 +2,9 @@
   "a.html": 552,
   "a.html.gz": 380,
   "a.js": 9878,
-  "a.js.gz": 4285,
+  "a.js.gz": 4282,
   "a.wasm": 7348,
   "a.wasm.gz": 3375,
   "total": 17778,
-  "total_gz": 8040
+  "total_gz": 8037
 }


### PR DESCRIPTION
Distinguish between unknown argument list and the empty argument list when parsing function names.

Also use early return to make the code a little more compact.