### PR TITLE
Fix CMAKE_C[XX]_IMPLICIT_INCLUDE_DIRECTORIES

### DIFF
--- a/test/cmake/static_lib/CMakeLists.txt
+++ b/test/cmake/static_lib/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.0)
 
 project(static_library)
 
+if (CMAKE_EXPORT_COMPILE_COMMANDS)
+  message(STATUS "CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES -> ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES}")
+  set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+endif()
+
 # Test mode that checks that it's possible to override the file suffix
 # (independent of whether ar archive or LLVM bitcode file is created)
 # Note that "-DCMAKE_STATIC_LIBRARY_SUFFIX=foo" cannot be passed to CMake from


### PR DESCRIPTION
This fixes CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES for the case when we don't use compiler-auto-detection. i.e.
`-DEMSCRIPTEN_FORCE_COMPILERS=OFF` which happens to be the default today.

As a followup we should consider completely removing `EMSCRIPTEN_FORCE_COMPILERS`.

Fixes: #23444