### PR TITLE
[cmake] Run normal compiler auto-detection by default

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,10 @@ See docs/process.md for more on how version tagging works.
 - The system JS libraries in `src/` were renamed from `library_foo.js` to
   `lib/libfoo.js`. They are still included via the same `-lfoo.js` flag so
   this should not be a user-visible change. (#23348)
+- When using cmake the emscripten toolchain will no longer skip the toolchain
+  detection stages.  This means the initial cmake run will be slower, but will
+  result in more accruate information.  If cmake is running too slow for you,
+  you can revert to the previous behaviour with `-DEMSCRIPTEN_FORCE_COMPILERS=ON`.
 
 4.0.1 - 01/17/25
 ----------------

--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -120,11 +120,9 @@ endif()
 file(TO_CMAKE_PATH "${_emcache_output}" _emcache_output)
 set(EMSCRIPTEN_SYSROOT "${_emcache_output}/sysroot")
 
-# Don't allow CMake to autodetect the compiler, since this is quite slow with
-# Emscripten.
-# Pass -DEMSCRIPTEN_FORCE_COMPILERS=OFF to disable (sensible mostly only for
-# testing/debugging purposes).
-option(EMSCRIPTEN_FORCE_COMPILERS "Force C/C++ compiler" ON)
+# Allow skipping of CMake compiler autodetection, since this is quite slow with
+# Emscripten. Pass -DEMSCRIPTEN_FORCE_COMPILERS=ON to enable
+option(EMSCRIPTEN_FORCE_COMPILERS "Force C/C++ compiler" OFF)
 if (EMSCRIPTEN_FORCE_COMPILERS)
 
   # Detect version of the 'emcc' executable. Note that for CMake, we tell it the

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -966,7 +966,11 @@ f.close()
   # If we update LLVM version and this test fails, copy over the new advertised features from Clang
   # and place them to cmake/Modules/Platform/Emscripten.cmake.
   @no_windows('Skipped on Windows because CMake does not configure native Clang builds well on Windows.')
-  def test_cmake_compile_features(self):
+  @parameterized({
+    '': ([],),
+    'force': (['-DEMSCRIPTEN_FORCE_COMPILERS=ON'],),
+  })
+  def test_cmake_compile_features(self, args):
     os.mkdir('build_native')
     cmd = ['cmake',
            '-DCMAKE_C_COMPILER=' + CLANG_CC, '-DCMAKE_C_FLAGS=--target=' + clang_native.get_native_triple(),
@@ -976,7 +980,7 @@ f.close()
     native_features = self.run_process(cmd, stdout=PIPE, cwd='build_native').stdout
 
     os.mkdir('build_emcc')
-    cmd = [EMCMAKE, 'cmake', test_file('cmake/stdproperty')]
+    cmd = [EMCMAKE, 'cmake', test_file('cmake/stdproperty')] + args
     print(str(cmd))
     emscripten_features = self.run_process(cmd, stdout=PIPE, cwd='build_emcc').stdout
 
@@ -1023,7 +1027,7 @@ f.close()
   @crossplatform
   @parameterized({
     '': ([],),
-    'noforce': (['-DEMSCRIPTEN_FORCE_COMPILERS=OFF'],),
+    'force': (['-DEMSCRIPTEN_FORCE_COMPILERS=ON'],),
   })
   def test_cmake_compile_commands(self, args):
     self.run_process([EMCMAKE, 'cmake', test_file('cmake/static_lib'), '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON'] + args)


### PR DESCRIPTION
This change disables `EMSCRIPTEN_FORCE_COMPILERS` by default which means cmake will run all the normal compiler detection phases.  This has the advantage that things get setup correctly without taking any shortcuts. See #23444.

The downside is the that cmake phase itself is now slower since its needs to compiler, link and run a bunch of test binaries.

On my machine running all the cmake tests went from 27 to 36 seconds. Running a single empty cmake project when from 1s to 4.5s.  Since running cmake is normally rare compared to building the project itself I think this slowdown is worth it, but I've left the `EMSCRIPTEN_FORCE_COMPILERS` setting in place for now that folks that want fast cmake.

Also, remember that cmake itself caches all this stuff so its only the first run that get slowed down.