### PR TITLE
[test] Consistent use of cmake_minimum_required in test code. NFC

### DIFF
--- a/test/cmake/check_type_size/CMakeLists.txt
+++ b/test/cmake/check_type_size/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(test_cmake)
 

--- a/test/cmake/cmake_with_emval/CMakeLists.txt
+++ b/test/cmake/cmake_with_emval/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(cmake_with_emval)
 

--- a/test/cmake/cpp_lib/CMakeLists.txt
+++ b/test/cmake/cpp_lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(cpp_library)
 

--- a/test/cmake/cxx20/CMakeLists.txt
+++ b/test/cmake/cxx20/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...3.28)
+cmake_minimum_required(VERSION 3.16...3.28)
 
 project(cxx20test)
 

--- a/test/cmake/emscripten_system_processor/CMakeLists.txt
+++ b/test/cmake/emscripten_system_processor/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.16)
+
 project(emscripten_system_processor)
 
 # Test that EMSCRIPTEN_SYSTEM_PROCESSOR can be overridden, and that

--- a/test/cmake/emscripten_version/CMakeLists.txt
+++ b/test/cmake/emscripten_version/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.16)
+
 project(emscripten_version)
 
 # EMSCRIPTEN_VERSION CMake variable is introduced in Emscripten version 1.38.6,

--- a/test/cmake/find_modules/CMakeLists.txt
+++ b/test/cmake/find_modules/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 project(find_modules)
 
 add_executable(test_prog test.c)

--- a/test/cmake/find_package/CMakeLists.txt
+++ b/test/cmake/find_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(find_package VERSION 0.42)
 

--- a/test/cmake/find_pkg_config/CMakeLists.txt
+++ b/test/cmake/find_pkg_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 project(find_pkg_config)
 
 message(STATUS "PKG_CONFIG_LIBDIR: $ENV{PKG_CONFIG_LIBDIR}")

--- a/test/cmake/find_stuff/CMakeLists.txt
+++ b/test/cmake/find_stuff/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(find_stuff)
 

--- a/test/cmake/install_lib/CMakeLists.txt
+++ b/test/cmake/install_lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(foo VERSION 1.42)
 

--- a/test/cmake/post_build/CMakeLists.txt
+++ b/test/cmake/post_build/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(post_build)
 

--- a/test/cmake/static_lib/CMakeLists.txt
+++ b/test/cmake/static_lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(static_library)
 

--- a/test/cmake/stdproperty/CMakeLists.txt
+++ b/test/cmake/stdproperty/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 project(helloworld)
 
 add_executable(helloworld main.cpp)

--- a/test/cmake/target_html/CMakeLists.txt
+++ b/test/cmake/target_html/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(hello_world_gles)
 

--- a/test/cmake/target_js/CMakeLists.txt
+++ b/test/cmake/target_js/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(test_cmake)
 

--- a/test/cmake/target_library/CMakeLists.txt
+++ b/test/cmake/target_library/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(test_cmake)
 

--- a/test/cmake/threads/CMakeLists.txt
+++ b/test/cmake/threads/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(threads VERSION 0.42)
 

--- a/test/minimal_webgl/CMakeLists.txt
+++ b/test/minimal_webgl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.16)
 
 # Default to release build if not specified
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Lower values were causing cmake to print verbose warnings on each test run.

I chose 3.16 here since that is the version available in ubuntu/focal which is the oldest version we test against AFAICT.
