### PR TITLE
[libc++abi] Add more checks to ensure our patch is upstreamable

### DIFF
--- a/system/lib/libcxxabi/src/private_typeinfo.cpp
+++ b/system/lib/libcxxabi/src/private_typeinfo.cpp
@@ -1546,7 +1546,7 @@ __base_class_type_info::search_below_dst(__dynamic_cast_info* info,
 
 
 // XXX EMSCRIPTEN
-#ifndef __WASM_EXCEPTIONS__
+#if defined(__wasm__) && !defined(__WASM_EXCEPTIONS__)
 
 #include "cxa_exception.h"
 
@@ -1601,5 +1601,5 @@ void *__cxa_get_exception_ptr(void *thrown_object) throw() {
 
 }  // __cxxabiv1
 
-#endif // !__WASM_EXCEPTIONS__
+#endif // __wasm__ && !__WASM_EXCEPTIONS__
 


### PR DESCRIPTION
We use the same libcxxabi for every platform and emscripten patches break compilation when targeting linux-armv7a