### PR TITLE
Remove logic for skipping legacy EH tests

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -277,17 +277,6 @@ def requires_wasm64(func):
   return decorated
 
 
-def requires_wasm_legacy_eh(func):
-  assert callable(func)
-
-  @wraps(func)
-  def decorated(self, *args, **kwargs):
-    self.require_wasm_legacy_eh()
-    return func(self, *args, **kwargs)
-
-  return decorated
-
-
 def requires_wasm_eh(func):
   assert callable(func)
 
@@ -648,8 +637,6 @@ def with_all_eh_sjlj(f):
       self.set_setting('SUPPORT_LONGJMP', 'wasm')
       if mode == 'wasm':
         self.require_wasm_eh()
-      if mode == 'wasm_legacy':
-        self.require_wasm_legacy_eh()
       f(self, *args, **kwargs)
     else:
       self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
@@ -683,8 +670,6 @@ def with_all_sjlj(f):
       self.set_setting('SUPPORT_LONGJMP', 'wasm')
       if mode == 'wasm':
         self.require_wasm_eh()
-      if mode == 'wasm_legacy':
-        self.require_wasm_legacy_eh()
       f(self, *args, **kwargs)
     else:
       self.set_setting('SUPPORT_LONGJMP', 'emscripten')
@@ -986,45 +971,6 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     else:
       self.fail('either d8 or node >= 24 required to run wasm64 tests.  Use EMTEST_SKIP_WASM64 to skip')
 
-  def require_simd(self):
-    if self.is_browser_test():
-      return
-
-    nodejs = self.get_nodejs()
-    if nodejs:
-      version = shared.get_node_version(nodejs)
-      if version >= (16, 0, 0):
-        self.js_engines = [nodejs]
-        return
-
-    if config.V8_ENGINE and config.V8_ENGINE in self.js_engines:
-      self.emcc_args.append('-sENVIRONMENT=shell')
-      self.js_engines = [config.V8_ENGINE]
-      return
-
-    if 'EMTEST_SKIP_SIMD' in os.environ:
-      self.skipTest('test requires node >= 16 or d8 (and EMTEST_SKIP_SIMD is set)')
-    else:
-      self.fail('either d8 or node >= 16 required to run wasm64 tests.  Use EMTEST_SKIP_SIMD to skip')
-
-  def require_wasm_legacy_eh(self):
-    self.set_setting('WASM_LEGACY_EXCEPTIONS')
-    nodejs = self.get_nodejs()
-    if nodejs:
-      version = shared.get_node_version(nodejs)
-      if version >= (17, 0, 0):
-        self.js_engines = [nodejs]
-        return
-
-    if config.V8_ENGINE and config.V8_ENGINE in self.js_engines:
-      self.emcc_args.append('-sENVIRONMENT=shell')
-      self.js_engines = [config.V8_ENGINE]
-      return
-
-    if 'EMTEST_SKIP_EH' in os.environ:
-      self.skipTest('test requires node >= 17 or d8 (and EMTEST_SKIP_EH is set)')
-    else:
-      self.fail('either d8 or node >= 17 required to run wasm-eh tests.  Use EMTEST_SKIP_EH to skip')
 
   def require_wasm_eh(self):
     self.set_setting('WASM_LEGACY_EXCEPTIONS', 0)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9406,14 +9406,6 @@ int main() {
       'at (src.wasm.)?foo',
       'at (src.wasm.)?main']
 
-    if '-fwasm-exceptions' in self.emcc_args:
-      # FIXME Node v18.13 (LTS as of Jan 2023) has not yet implemented the new
-      # optional 'traceStack' option in WebAssembly.Exception constructor
-      # (https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Exception/Exception)
-      # and embeds stack traces unconditionally. Change this back to
-      # self.require_wasm_legacy_eh() if this issue is fixed later.
-      self.require_v8()
-
     # Stack traces are enabled when either of ASSERTIONS or
     # EXCEPTION_STACK_TRACES is enabled. You can't disable
     # EXCEPTION_STACK_TRACES when ASSERTIONS is enabled.
@@ -9447,13 +9439,6 @@ int main() {
   @with_all_eh_sjlj
   def test_exceptions_rethrow_stack_trace_and_message(self):
     self.emcc_args += ['-g']
-    if '-fwasm-exceptions' in self.emcc_args:
-      # FIXME Node v18.13 (LTS as of Jan 2023) has not yet implemented the new
-      # optional 'traceStack' option in WebAssembly.Exception constructor
-      # (https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Exception/Exception)
-      # and embeds stack traces unconditionally. Change this back to
-      # self.require_wasm_legacy_eh() if this issue is fixed later.
-      self.require_v8()
     # Rethrowing exception currently loses the stack trace before the rethrowing
     # due to how rethrowing is implemented. So in the examples below we don't
     # print 'bar' at the moment.


### PR DESCRIPTION
All of our testing platforms have nodejs > v18 and support legacy EH.
The stack trace API also seems to be fixed in node v20.
