### PR TITLE
[test] Remove require_simd and requires_wasm_legacy_eh helpers. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -277,17 +277,6 @@ def requires_wasm64(func):
   return decorated
 
 
-def requires_wasm_legacy_eh(func):
-  assert callable(func)
-
-  @wraps(func)
-  def decorated(self, *args, **kwargs):
-    self.require_wasm_legacy_eh()
-    return func(self, *args, **kwargs)
-
-  return decorated
-
-
 def requires_wasm_eh(func):
   assert callable(func)
 
@@ -648,8 +637,6 @@ def with_all_eh_sjlj(f):
       self.set_setting('SUPPORT_LONGJMP', 'wasm')
       if mode == 'wasm':
         self.require_wasm_eh()
-      if mode == 'wasm_legacy':
-        self.require_wasm_legacy_eh()
       f(self, *args, **kwargs)
     else:
       self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
@@ -683,8 +670,6 @@ def with_all_sjlj(f):
       self.set_setting('SUPPORT_LONGJMP', 'wasm')
       if mode == 'wasm':
         self.require_wasm_eh()
-      if mode == 'wasm_legacy':
-        self.require_wasm_legacy_eh()
       f(self, *args, **kwargs)
     else:
       self.set_setting('SUPPORT_LONGJMP', 'emscripten')
@@ -985,46 +970,6 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       self.skipTest('test requires node >= 24 or d8 (and EMTEST_SKIP_WASM64 is set)')
     else:
       self.fail('either d8 or node >= 24 required to run wasm64 tests.  Use EMTEST_SKIP_WASM64 to skip')
-
-  def require_simd(self):
-    if self.is_browser_test():
-      return
-
-    nodejs = self.get_nodejs()
-    if nodejs:
-      version = shared.get_node_version(nodejs)
-      if version >= (16, 0, 0):
-        self.js_engines = [nodejs]
-        return
-
-    if config.V8_ENGINE and config.V8_ENGINE in self.js_engines:
-      self.emcc_args.append('-sENVIRONMENT=shell')
-      self.js_engines = [config.V8_ENGINE]
-      return
-
-    if 'EMTEST_SKIP_SIMD' in os.environ:
-      self.skipTest('test requires node >= 16 or d8 (and EMTEST_SKIP_SIMD is set)')
-    else:
-      self.fail('either d8 or node >= 16 required to run wasm64 tests.  Use EMTEST_SKIP_SIMD to skip')
-
-  def require_wasm_legacy_eh(self):
-    self.set_setting('WASM_LEGACY_EXCEPTIONS')
-    nodejs = self.get_nodejs()
-    if nodejs:
-      version = shared.get_node_version(nodejs)
-      if version >= (17, 0, 0):
-        self.js_engines = [nodejs]
-        return
-
-    if config.V8_ENGINE and config.V8_ENGINE in self.js_engines:
-      self.emcc_args.append('-sENVIRONMENT=shell')
-      self.js_engines = [config.V8_ENGINE]
-      return
-
-    if 'EMTEST_SKIP_EH' in os.environ:
-      self.skipTest('test requires node >= 17 or d8 (and EMTEST_SKIP_EH is set)')
-    else:
-      self.fail('either d8 or node >= 17 required to run wasm-eh tests.  Use EMTEST_SKIP_EH to skip')
 
   def require_wasm_eh(self):
     self.set_setting('WASM_LEGACY_EXCEPTIONS', 0)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -45,7 +45,6 @@ def wasm_simd(f):
 
   @wraps(f)
   def decorated(self, *args, **kwargs):
-    self.require_simd()
     if self.get_setting('MEMORY64') == 2:
       self.skipTest('https://github.com/WebAssembly/binaryen/issues/4638')
     if self.is_wasm2js():
@@ -54,7 +53,6 @@ def wasm_simd(f):
       self.skipTest('SIMD tests are too slow with -O3 in the new LLVM pass manager, https://github.com/emscripten-core/emscripten/issues/13427')
     self.emcc_args.append('-msimd128')
     self.emcc_args.append('-fno-lax-vector-conversions')
-    self.v8_args.append('--experimental-wasm-simd')
     f(self, *args, **kwargs)
   return decorated
 


### PR DESCRIPTION
These helpers were requiring node v16 and v17 which is older than the version of node we ship with emsdk these days (v20).

We do run node compat tests using older version of node but we run an explicit subset of tests in those modes, never the whole suite.