### PR TITLE
Move gen_struct_info.py from tools/maint to tools

### DIFF
--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -337,7 +337,7 @@ const C_STRUCTS = new Proxy(structs, {
   get(target, prop) {
     if (!(prop in target)) {
       throw new Error(
-        `Missing C struct ${prop}! If you just added it to struct_info.json, you need to run ./tools/maint/gen_struct_info.py (then run a second time with --wasm64)`,
+        `Missing C struct ${prop}! If you just added it to struct_info.json, you need to run ./tools/gen_struct_info.py (then run a second time with --wasm64)`,
       );
     }
     return target[prop];
@@ -348,7 +348,7 @@ const C_DEFINES = new Proxy(defines, {
   get(target, prop) {
     if (!(prop in target)) {
       throw new Error(
-        `Missing C define ${prop}! If you just added it to struct_info.json, you need to run ./tools/maint/gen_struct_info.py (then run a second time with --wasm64)`,
+        `Missing C define ${prop}! If you just added it to struct_info.json, you need to run ./tools/gen_struct_info.py (then run a second time with --wasm64)`,
       );
     }
     return target[prop];

--- a/system/include/webgpu/README.md
+++ b/system/include/webgpu/README.md
@@ -46,8 +46,8 @@ To update these bindings from Dawn:
 
     ```
     emcc --clear-cache
-    ./tools/maint/gen_struct_info.py
-    ./tools/maint/gen_struct_info.py --wasm64
+    ./tools/gen_struct_info.py
+    ./tools/gen_struct_info.py --wasm64
     ./tools/maint/gen_sig_info.py
     ```
 

--- a/test/other/test_extra_struct_info.h
+++ b/test/other/test_extra_struct_info.h
@@ -1,0 +1,2 @@
+#define AF_INET 42
+

--- a/test/other/test_extra_struct_info.js
+++ b/test/other/test_extra_struct_info.js
@@ -1,6 +1,6 @@
 console.error("(before) AF_INET=" + {{{ cDefs.AF_INET }}});
 
 /* Loading this struct info file will override the default AF_INET value */
-{{{ loadStructInfo(__dirname + '/test_extra_struct_info.json'), null }}}
+{{{ loadStructInfo('generated.json'), null }}}
 
 console.error("(after) AF_INET=" + {{{ cDefs.AF_INET }}});

--- a/test/other/test_extra_struct_info.json
+++ b/test/other/test_extra_struct_info.json
@@ -1,5 +1,8 @@
-{
-    "defines": {
-        "AF_INET": 42
+[
+    {
+        "file": "test_extra_struct_info.h",
+        "defines": [
+          "AF_INET"
+        ]
     }
-}
+]

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13205,13 +13205,13 @@ exec "$@"
   def test_gen_struct_info(self):
     # This test will start failing whenever the struct info changes (e.g. offset or defines
     # change).  However it's easy to rebaseline with --rebaseline.
-    self.run_process([PYTHON, path_from_root('tools/maint/gen_struct_info.py'), '-o', 'out.json'])
+    self.run_process([PYTHON, path_from_root('tools/gen_struct_info.py'), '-o', 'out.json'])
     self.assertFileContents(path_from_root('src/struct_info_generated.json'), read_file('out.json'))
 
     # Same again for wasm64
     node_version = shared.get_node_version(self.get_nodejs())
     if node_version and node_version >= (14, 0, 0):
-      self.run_process([PYTHON, path_from_root('tools/maint/gen_struct_info.py'), '--wasm64', '-o', 'out.json'])
+      self.run_process([PYTHON, path_from_root('tools/gen_struct_info.py'), '--wasm64', '-o', 'out.json'])
       self.assertFileContents(path_from_root('src/struct_info_generated_wasm64.json'), read_file('out.json'))
 
   @crossplatform
@@ -13228,7 +13228,7 @@ exec "$@"
     # linking) to effect the internal building and running of this code.
     # For example -O2 causes printf -> iprintf which will fail with undefined symbol iprintf.
     with env_modify({'EMCC_CFLAGS': '-O2 BAD_ARG', 'EMCC_FORCE_STDLIBS': '1', 'EMCC_ONLY_FORCED_STDLIBS': '1'}):
-      self.run_process([PYTHON, path_from_root('tools/maint/gen_struct_info.py'), '-o', 'out.json'])
+      self.run_process([PYTHON, path_from_root('tools/gen_struct_info.py'), '-o', 'out.json'])
 
   def test_relocatable_limited_exports(self):
     # Building with RELOCATABLE should *not* automatically export all sybmols.
@@ -14724,13 +14724,13 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
       {{{ C_STRUCTS.Foo }}}
     ''')
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js'])
-    self.assertContained('Error: Missing C struct Foo! If you just added it to struct_info.json, you need to run ./tools/maint/gen_struct_info.py (then run a second time with --wasm64)', err)
+    self.assertContained('Error: Missing C struct Foo! If you just added it to struct_info.json, you need to run ./tools/gen_struct_info.py (then run a second time with --wasm64)', err)
 
     create_file('lib.js', '''
       {{{ C_DEFINES.Foo }}}
     ''')
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js'])
-    self.assertContained('Error: Missing C define Foo! If you just added it to struct_info.json, you need to run ./tools/maint/gen_struct_info.py (then run a second time with --wasm64)', err)
+    self.assertContained('Error: Missing C define Foo! If you just added it to struct_info.json, you need to run ./tools/gen_struct_info.py (then run a second time with --wasm64)', err)
 
   def run_wasi_test_suite_test(self, name):
     if not os.path.exists(path_from_root('test/third_party/wasi-test-suite')):
@@ -15432,6 +15432,7 @@ addToLibrary({
     self.assertExists('hello_world.o')
 
   def test_extra_struct_info(self):
+    self.run_process([PYTHON, path_from_root('tools/gen_struct_info.py'), test_file('other/test_extra_struct_info.json'), '-o', 'generated.json', '-I', test_file('other')])
     stderr = self.run_process([EMCC, test_file('hello_world.c'), '--js-library', test_file('other/test_extra_struct_info.js')], stderr=PIPE).stderr
     self.assertContained('(before) AF_INET=2', stderr)
     self.assertContained('(after) AF_INET=42', stderr)

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -64,7 +64,7 @@ import tempfile
 import subprocess
 
 __scriptdir__ = os.path.dirname(os.path.abspath(__file__))
-__rootdir__ = os.path.dirname(os.path.dirname(__scriptdir__))
+__rootdir__ = os.path.dirname(__scriptdir__)
 sys.path.insert(0, __rootdir__)
 
 from tools import building


### PR DESCRIPTION
Also update the extra_struct_info test to that it actually uses gen_struct_info to generated the struct_info json file.

Fixes: #23436