### PR TITLE
Fix filter_out_dynamic_libs WRT to `-soname`

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12838,6 +12838,11 @@ int main () {
     self.assertContained('warning: -shared/-r used with executable output suffix', err)
     self.run_js('out.js')
 
+  def test_shared_soname(self):
+    self.run_process([EMCC, '-shared', '-Wl,-soname', '-Wl,libfoo.so.13', test_file('hello_world.c'), '-lc', '-o', 'libfoo.so'])
+    self.run_process([EMCC, '-sSTRICT', 'libfoo.so'])
+    self.assertContained('hello, world!', self.run_js('a.out.js'))
+
   def test_shared_and_side_module_flag(self):
     # Test that `-shared` and `-sSIDE_MODULE` flag causes wasm dylib generation without a warning.
     err = self.run_process([EMCC, '-shared', '-sSIDE_MODULE', test_file('hello_world.c'), '-o', 'out.foo'], stderr=PIPE).stderr

--- a/tools/link.py
+++ b/tools/link.py
@@ -2876,17 +2876,17 @@ class ScriptSource:
       return '<script>\n%s\n</script>' % self.inline
 
 
-def filter_out_dynamic_libs(options, inputs):
+def filter_out_fake_dynamic_libs(options, inputs):
   # Filters out "fake" dynamic libraries that are really just intermediate object files.
-  def check(input_file):
-    if get_file_suffix(input_file) in DYLIB_EXTENSIONS and not building.is_wasm_dylib(input_file):
+  def is_fake_dylib(input_file):
+    if get_file_suffix(input_file) in DYLIB_EXTENSIONS and os.path.exists(input_file) and not building.is_wasm_dylib(input_file):
       if not options.ignore_dynamic_linking:
         diagnostics.warning('emcc', 'ignoring dynamic library %s because not compiling to JS or HTML, remember to link it when compiling to JS or HTML at the end', os.path.basename(input_file))
-      return False
-    else:
       return True
+    else:
+      return False
 
-  return [f for f in inputs if check(f)]
+  return [f for f in inputs if not is_fake_dylib(f)]
 
 
 def filter_out_duplicate_dynamic_libs(inputs):
@@ -3072,7 +3072,7 @@ def phase_calculate_linker_inputs(options, state, linker_inputs):
   # "fake" dynamic libraries, since otherwise we will end up with
   # multiple copies in the final executable.
   if options.oformat == OFormat.OBJECT or options.ignore_dynamic_linking:
-    linker_args = filter_out_dynamic_libs(options, linker_args)
+    linker_args = filter_out_fake_dynamic_libs(options, linker_args)
   else:
     linker_args = filter_out_duplicate_dynamic_libs(linker_args)
 


### PR DESCRIPTION
The `filter_out_dynamic_libs` was incorrectly removing the `libfoo.so` flag from `-soname libfoo.so` which means that next argument was then being treated as the soname.

Fixes: #23555