### PR TITLE
[emscan-deps] Add full set of default include paths

### DIFF
--- a/emscan-deps.py
+++ b/emscan-deps.py
@@ -10,9 +10,9 @@ This script acts as a frontend replacement for clang-scan-deps.
 """
 
 import sys
-from tools import shared, cache
+import emcc
+from tools import shared
 
 args = sys.argv[1:]
-args.append('--sysroot=' + cache.get_sysroot(absolute=True))
-args.append('--target=' + shared.get_llvm_target())
+args += emcc.get_cflags(tuple(args))
 shared.exec_process([shared.CLANG_SCAN_DEPS] + args)

--- a/test/cmake/cxx20/main.cpp
+++ b/test/cmake/cxx20/main.cpp
@@ -3,11 +3,9 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
-#include <stdio.h>
-
-class Test {}; // This will fail in C mode
+#include <iostream>
 
 int main() {
-  printf("hello, world!\n");
+  std::cout << "hello, world!" << std::endl;
   return 0;
 }


### PR DESCRIPTION
Specifically we were missing the `include/compat` directory which is needed for including `<xlocale.h>`, which is transitively required by `<iostream>`.

Fixes: #23567