### PR TITLE
[test] Remove un-needed cflags from browser_tests. NFC

### DIFF
--- a/test/browser/webgl_timer_query.c
+++ b/test/browser/webgl_timer_query.c
@@ -86,7 +86,7 @@ int main() {
 
   /* Check if the extension is actually supported. Firefox reports
      EXT_disjoint_timer_query on WebGL 2 as well. */
-  if (!strstr(glGetString(GL_EXTENSIONS), "EXT_disjoint_timer_query")) {
+  if (!strstr((const char*)glGetString(GL_EXTENSIONS), "EXT_disjoint_timer_query")) {
     printf("EXT_disjoint_timer_query[_webgl2] not supported\n");
     return 0;
   }

--- a/test/full_es2_sdlproc.c
+++ b/test/full_es2_sdlproc.c
@@ -731,5 +731,5 @@ main(int argc, char *argv[])
    gears_init();
    gears_draw();
 
-   return 1;
+   return 0;
 }

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -236,14 +236,6 @@ class browser(BrowserCore):
       print('Running the browser tests. Make sure the browser allows popups from localhost.')
       print()
 
-  def setUp(self):
-    super().setUp()
-    # avoid various compiler warnings that many browser tests currently generate
-    self.emcc_args += [
-      '-Wno-pointer-sign',
-      '-Wno-int-conversion',
-    ]
-
   def proxy_to_worker(self):
     self.emcc_args += ['--proxy-to-worker', '-sGL_TESTING']
 
@@ -1784,7 +1776,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
 
   @requires_graphics_hardware
   def test_fulles2_sdlproc(self):
-    self.btest_exit('full_es2_sdlproc.c', assert_returncode=1, args=['-sGL_TESTING', '-DHAVE_BUILTIN_SINCOS', '-sFULL_ES2', '-lGL', '-lSDL', '-lglut', '-sGL_ENABLE_GET_PROC_ADDRESS'])
+    self.btest_exit('full_es2_sdlproc.c', args=['-sGL_TESTING', '-DHAVE_BUILTIN_SINCOS', '-sFULL_ES2', '-lGL', '-lSDL', '-lglut', '-sGL_ENABLE_GET_PROC_ADDRESS', '-Wno-int-conversion'])
 
   @requires_graphics_hardware
   def test_glgears_deriv(self):
@@ -1850,7 +1842,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
                          test_file('third_party/glbook/Common/esShader.c'),
                          test_file('third_party/glbook/Common/esShapes.c'),
                          test_file('third_party/glbook/Common/esTransform.c'),
-                         '-lGL', '-lEGL', '-lX11',
+                         '-lGL', '-lEGL', '-lX11', '-Wno-int-conversion', '-Wno-pointer-sign',
                          '--preload-file', 'basemap.tga', '--preload-file', 'lightmap.tga', '--preload-file', 'smoke.tga'] + args)
 
   @requires_graphics_hardware


### PR DESCRIPTION
While updating the cflags for `full_es2_sdlproc.c` I also updated to
return 0 rather than 1 which is the convention in our tests.
