### PR TITLE
[jspi] Fix dlopen with MEMORY64 and JSPI.

### DIFF
--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -248,22 +248,23 @@ export async function runJSify(outputFile, symbolsOnly) {
       }
 
       if ((sig[0] == 'j' && i53abi) || (sig[0] == 'p' && MEMORY64)) {
+        const await_ = (async_ ? 'await ' : '');
         // For functions that where we need to mutate the return value, we
         // also need to wrap the body in an inner function.
         if (oneliner) {
           if (argConversions) {
             return `${async_}(${args}) => {
 ${argConversions}
-  return ${makeReturn64(body)};
+  return ${makeReturn64(await_ + body)};
 }`;
           }
-          return `${async_}(${args}) => ${makeReturn64(body)};`;
+          return `${async_}(${args}) => ${makeReturn64(await_ + body)};`;
         }
         return `\
 ${async_}function(${args}) {
 ${argConversions}
-  var ret = (() => { ${body} })();
-  return ${makeReturn64('ret')};
+  var ret = (${async_}() => { ${body} })();
+  return ${makeReturn64(await_ + 'ret')};
 }`;
       }
 

--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -248,7 +248,7 @@ export async function runJSify(outputFile, symbolsOnly) {
       }
 
       if ((sig[0] == 'j' && i53abi) || (sig[0] == 'p' && MEMORY64)) {
-        const await_ = (async_ ? 'await ' : '');
+        const await_ = async_ ? 'await ' : '';
         // For functions that where we need to mutate the return value, we
         // also need to wrap the body in an inner function.
         if (oneliner) {
@@ -263,7 +263,7 @@ ${argConversions}
         return `\
 ${async_}function(${args}) {
 ${argConversions}
-  var ret = (${async_}() => { ${body} })();
+  var ret = (() => { ${body} })();
   return ${makeReturn64(await_ + 'ret')};
 }`;
       }

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1159,9 +1159,9 @@ var LibraryDylink = {
 #if ASYNCIFY
   _dlopen_js__async: true,
 #endif
-  _dlopen_js: (handle) => {
+  _dlopen_js: {{{ asyncIf(ASYNCIFY == 2) }}} (handle) => {
 #if ASYNCIFY
-    return Asyncify.handleSleep((wakeUp) => {
+    return {{{ awaitIf(ASYNCIFY == 2) }}} Asyncify.handleSleep((wakeUp) => {
       dlopenInternal(handle, { loadAsync: true })
         .then(wakeUp)
         .catch(() => wakeUp(0));

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1161,7 +1161,7 @@ var LibraryDylink = {
 #endif
   _dlopen_js: {{{ asyncIf(ASYNCIFY == 2) }}} (handle) => {
 #if ASYNCIFY
-    return {{{ awaitIf(ASYNCIFY == 2) }}} Asyncify.handleSleep((wakeUp) => {
+    return Asyncify.handleSleep((wakeUp) => {
       dlopenInternal(handle, { loadAsync: true })
         .then(wakeUp)
         .catch(() => wakeUp(0));

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -3729,8 +3729,6 @@ ok
   @needs_dylink
   @with_asyncify_and_jspi
   def test_dlfcn_asyncify(self):
-    if self.is_wasm64() and self.get_setting('ASYNCIFY') == 2:
-      self.skipTest('https://github.com/emscripten-core/emscripten/issues/23585')
     create_file('liblib.c', r'''
       #include <stdio.h>
       #include <emscripten/emscripten.h>


### PR DESCRIPTION
Adds the various `async` and `awaits` before the conversion to BigInt.