### PR TITLE
Skip the search for dynamic libraries when static library exists

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -2821,7 +2821,8 @@ def process_libraries(state):
       settings.JS_LIBRARIES.append(os.path.abspath(path))
       continue
 
-    if not settings.RELOCATABLE:
+    static_lib = f'lib{lib}.a'
+    if not settings.RELOCATABLE and not find_library(static_lib, state.lib_dirs):
       # Normally we can rely on the native linker to expand `-l` args.
       # However, emscripten also supports `.so` files that are actually just
       # regular object file.  This means we need to support `.so` files even


### PR DESCRIPTION
This is a fix for a regression caused by #23336.  

Prior to #23336 all `-l` flags were expanded by emcc to full filenames, with `.a` files being searched for first.   After #23336 we only expand the the paths of fake shared libraries which wasm-ld itself don't look for.   

Fixes: #23591