### PR TITLE
Add all git submodules to bootstrap.py. NFC

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -26,9 +26,12 @@ actions = [
      'tools/maint/run_python.bat',
      'tools/maint/run_python.sh',
      'tools/maint/run_python.ps1',
-   ],
-   [sys.executable, 'tools/maint/create_entry_points.py']),
-  ('git submodules', ['test/third_party/posixtestsuite/'], [shutil.which('git'), 'submodule', 'update', '--init']),
+   ], [sys.executable, 'tools/maint/create_entry_points.py']),
+  ('git submodules', [
+     'test/third_party/posixtestsuite/',
+     'test/third_party/googletest',
+     'test/third_party/wasi-test-suite',
+   ], [shutil.which('git'), 'submodule', 'update', '--init']),
 ]
 
 


### PR DESCRIPTION
This means that if any of these submodules are updated the bootstrap script will run git submodule update.  This is especially useful for folks like me that have bootstrap run on checkout since it works when bisecting across submodule updates.