### PR TITLE
[test] Fix test_side_module_ignore on windows. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9328,7 +9328,7 @@ int main() {
 
     # Attempting to link statically against a side module (libside.so) should fail.
     err = self.expect_fail([EMCC, '-L.', '-lside'])
-    self.assertContained('error: attempted static link of dynamic object ./libside.so', err)
+    self.assertContained(r'error: attempted static link of dynamic object \.[/\\]libside.so', err, regex=True)
 
     # But a static library in the same location (libside.a) should take precedence.
     self.run_process([EMCC, test_file('hello_world.c'), '-c'])


### PR DESCRIPTION
This slipped past CI because our windows builder we out of commission at the time when #23593 landed.