### PR TITLE
Fix js library location in link.py

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -215,7 +215,8 @@ def get_js_sym_info():
   # and can contain full paths to temporary files.
   skip_settings = {'PRE_JS_FILES', 'POST_JS_FILES'}
   input_files = [json.dumps(settings.external_dict(skip_keys=skip_settings), sort_keys=True, indent=2)]
-  jslibs = glob.glob(utils.path_from_root('src') + '/library*.js')
+  jslibs = glob.glob(utils.path_from_root('src/lib') + '/lib*.js')
+  assert jslibs
   input_files.extend(read_file(jslib) for jslib in sorted(jslibs))
   for jslib in settings.JS_LIBRARIES:
     if not os.path.isabs(jslib):


### PR DESCRIPTION
This was broken when I move the library files in #23348

This was only used for generating the symbol lists, so the only side effect was the the symbol lists would remain stale if somebody was modifying the system libraries (i.e. it only effected emscripten developers, not users).