### PR TITLE
Replace python subprocess's `universal_newlines` with `text`. NFC

### DIFF
--- a/tools/maint/check_for_closed_issues.py
+++ b/tools/maint/check_for_closed_issues.py
@@ -16,7 +16,7 @@ root_dir = os.path.dirname(os.path.dirname(script_dir))
 
 
 def run(*args, **kwargs):
-  kwargs['universal_newlines'] = True
+  kwargs['text'] = True
   return subprocess.check_output(*args, **kwargs)
 
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -126,7 +126,7 @@ def run_process(cmd, check=True, input=None, *args, **kw):
   # output before messages that we have already written.
   sys.stdout.flush()
   sys.stderr.flush()
-  kw.setdefault('universal_newlines', True)
+  kw.setdefault('text', True)
   kw.setdefault('encoding', 'utf-8')
   ret = subprocess.run(cmd, check=check, input=input, *args, **kw)
   debug_text = '%sexecuted %s' % ('successfully ' if check else '', shlex_join(cmd))


### PR DESCRIPTION
In python 3.7 the `universal_newlines` parameter was deprecated in favor of the more readable `text` parameter.

We updated our minimum supported python version to 3.8 in #23417.