### PR TITLE
Update webgpu-externs.js

### DIFF
--- a/src/closure-externs/webgpu-externs.js
+++ b/src/closure-externs/webgpu-externs.js
@@ -199,6 +199,8 @@ GPUAdapter.prototype.isFallbackAdapter;
 GPUAdapter.prototype.requestDevice = function() {};
 /** @return {!Promise<!GPUAdapterInfo>} */
 GPUAdapter.prototype.requestAdapterInfo = function() {};
+/** @type {!GPUAdapterInfo} */
+GPUAdapter.prototype.info;
 
 /** @constructor */
 function GPUDevice() {}
@@ -250,6 +252,8 @@ GPUDevice.prototype.pushErrorScope = function() {};
 GPUDevice.prototype.popErrorScope = function() {};
 /** @type {!Function} */
 GPUDevice.prototype.onuncapturederror;
+/** @type {!GPUAdapterInfo} */
+GPUDevice.prototype.adapterInfo;
 
 /** @constructor */
 function GPUBuffer() {}


### PR DESCRIPTION
Add type declaration for `GPUAdapter.info` and `GPUDevice.adapterInfo`

Dawn is maintaining an forked up-to-date version of library_webgpu.js, but the webgpu-extern.js is not forked.
