### PR TITLE
[Draft] FETCHFS: allow dirent operations with http fileserver

### DIFF
--- a/src/library_sigs.js
+++ b/src/library_sigs.js
@@ -397,6 +397,7 @@ sigs = {
   _wasmfs_get_preloaded_path_name__sig: 'vip',
   _wasmfs_jsimpl_alloc_file__sig: 'vpp',
   _wasmfs_jsimpl_async_alloc_file__sig: 'vppp',
+  _wasmfs_jsimpl_async_fetch_init__sig: 'vppp',
   _wasmfs_jsimpl_async_free_file__sig: 'vppp',
   _wasmfs_jsimpl_async_get_size__sig: 'vpppp',
   _wasmfs_jsimpl_async_read__sig: 'vpppppjp',

--- a/src/library_wasmfs_fetch.js
+++ b/src/library_wasmfs_fetch.js
@@ -79,6 +79,9 @@ addToLibrary({
         }
         return jsFileOps.read(file, buffer, length, offset);
       },
+      fetchInit: async (file) =>{
+        getFile(file);
+      },
       getSize: async (file) => {
         try {
           await getFile(file);

--- a/src/library_wasmfs_jsimpl.js
+++ b/src/library_wasmfs_jsimpl.js
@@ -107,4 +107,14 @@ addToLibrary({
     {{{ makeSetValue('size_p', 0, 'size', 'i64') }}};
     _emscripten_proxy_finish(ctx);
   },
+
+_wasmfs_jsimpl_async_fetch_init__deps: ['emscripten_proxy_finish'],
+  _wasmfs_jsimpl_async_fetch_init: async function(ctx, backend, file) {
+#if ASSERTIONS
+    assert(wasmFS$backends[backend]);
+#endif
+    wasmFS$backends[backend].fetchInit(file);
+    _emscripten_proxy_finish(ctx);
+  },
+
 });

--- a/system/lib/wasmfs/backends/memory_backend.cpp
+++ b/system/lib/wasmfs/backends/memory_backend.cpp
@@ -47,6 +47,7 @@ std::shared_ptr<File> MemoryDirectory::getChild(const std::string& name) {
   if (auto entry = findEntry(name); entry != entries.end()) {
     return entry->child;
   }
+
   return nullptr;
 }
 

--- a/system/lib/wasmfs/js_impl_backend.h
+++ b/system/lib/wasmfs/js_impl_backend.h
@@ -65,6 +65,7 @@ int _wasmfs_jsimpl_read(js_index_t backend,
                         size_t length,
                         off_t offset);
 int _wasmfs_jsimpl_get_size(js_index_t backend, js_index_t index);
+int _wasmfs_jsimpl_fetch_file(js_index_t backend, js_index_t index);
 }
 
 namespace wasmfs {

--- a/system/lib/wasmfs/paths.cpp
+++ b/system/lib/wasmfs/paths.cpp
@@ -9,6 +9,8 @@
 #include "paths.h"
 #include "wasmfs.h"
 
+
+
 namespace wasmfs::path {
 
 namespace {

--- a/system/lib/wasmfs/proxied_async_js_impl_backend.h
+++ b/system/lib/wasmfs/proxied_async_js_impl_backend.h
@@ -67,11 +67,17 @@ void _wasmfs_jsimpl_async_get_size(em_proxying_ctx* ctx,
                                    js_index_t backend,
                                    js_index_t index,
                                    off_t* result);
+
+void _wasmfs_jsimpl_async_fetch_init(em_proxying_ctx* ctx,
+                                    js_index_t backend,
+                                    js_index_t index);
+
 }
 
 namespace wasmfs {
 
 class ProxiedAsyncJSImplFile : public DataFile {
+  public:
   emscripten::ProxyWorker& proxy;
 
   js_index_t getBackendIndex() {
@@ -84,6 +90,7 @@ class ProxiedAsyncJSImplFile : public DataFile {
     return js_index_t(this);
   }
 
+  protected:
   // TODO: Notify the JS about open and close events?
   int open(oflags_t) override { return 0; }
   int close() override { return 0; }
@@ -116,6 +123,7 @@ class ProxiedAsyncJSImplFile : public DataFile {
     });
     return result;
   }
+
 
   int setSize(off_t size) override {
     WASMFS_UNREACHABLE("TODO: ProxiedAsyncJSImplFile setSize");


### PR DESCRIPTION
Currently FetchFS does not provide any directory information. Due to this, getdents or similar syscalls fail to present proper directory structure to the program.

This patch solves this issue and allows working with directories seamlessly.