### PR TITLE
[ptheads] Rename receiveObjectTransfer. NFC

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -203,8 +203,8 @@ var LibraryPThread = {
       // linear memory.
       __emscripten_thread_free_data(pthread_ptr);
     },
-    receiveObjectTransfer(data) {
 #if OFFSCREENCANVAS_SUPPORT
+    receiveOffscreenCanvases(data) {
       if (typeof GL != 'undefined') {
         Object.assign(GL.offscreenCanvases, data.offscreenCanvases);
         if (!Module['canvas'] && data.moduleCanvasId && GL.offscreenCanvases[data.moduleCanvasId]) {
@@ -212,8 +212,8 @@ var LibraryPThread = {
           Module['canvas'].id = data.moduleCanvasId;
         }
       }
-#endif
     },
+#endif
     // Called by worker.js each time a thread is started.
     threadInitTLS() {
 #if PTHREADS_DEBUG

--- a/src/runtime_pthread.js
+++ b/src/runtime_pthread.js
@@ -157,7 +157,9 @@ if (ENVIRONMENT_IS_PTHREAD) {
         // Pass the thread address to wasm to store it for fast access.
         __emscripten_thread_init(msgData.pthread_ptr, /*is_main=*/0, /*is_runtime=*/0, /*can_block=*/1, 0, 0);
 
-        PThread.receiveObjectTransfer(msgData);
+#if OFFSCREENCANVAS_SUPPORT
+        PThread.receiveOffscreenCanvases(msgData);
+#endif
         PThread.threadInitTLS();
 
         // Await mailbox notifications with `Atomics.waitAsync` so we can start


### PR DESCRIPTION
Followup to #14875.

The name receiveObjectTransfer implies that all kinds of things can be received but its really only for the offscreen canvas.