### PR TITLE
Move compiler.mjs to tools/ directory. NFC

### DIFF
--- a/site/source/docs/contributing/developers_guide.rst
+++ b/site/source/docs/contributing/developers_guide.rst
@@ -82,7 +82,7 @@ The :ref:`Emscripten Compiler Frontend (emcc) <emccdoc>` is a python script that
 - **emcc** then calls `emscripten.py <https://github.com/emscripten-core/emscripten/blob/main/tools/emscripten.py>`_
   which performs the final transformation to Wasm (including invoking
   **wasm-emscripten-finalize** from Binaryen) and calls the JS compiler
-  (see ``src/compiler.mjs`` and related files) which emits the JS.
+  (see ``tools/compiler.mjs`` and related files) which emits the JS.
 - If optimizing Wasm, **emcc** will then call **wasm-opt**, run meta-dce, and
   other useful things. It will also run JS optimizations on the JS that is
   emitted alongside the Wasm.

--- a/tools/compiler.mjs
+++ b/tools/compiler.mjs
@@ -9,7 +9,13 @@
 
 import assert from 'node:assert';
 import {parseArgs} from 'node:util';
-import {Benchmarker, applySettings, loadDefaultSettings, printErr, readFile} from './utility.mjs';
+import {
+  Benchmarker,
+  applySettings,
+  loadDefaultSettings,
+  printErr,
+  readFile,
+} from '../src/utility.mjs';
 
 loadDefaultSettings();
 
@@ -70,12 +76,12 @@ assert(
 // We can't use static import statements here because several of these
 // file depend on having the settings defined in the global scope (which
 // we do dynamically above.
-await import('./modules.mjs');
-await import('./parseTools.mjs');
+await import('../src/modules.mjs');
+await import('../src/parseTools.mjs');
 if (!STRICT) {
-  await import('./parseTools_legacy.mjs');
+  await import('../src/parseTools_legacy.mjs');
 }
-const jsifier = await import('./jsifier.mjs');
+const jsifier = await import('../src/jsifier.mjs');
 
 // ===============================
 // Main
@@ -93,7 +99,7 @@ try {
     printErr(err);
   } else {
     // Compiler failed on internal compiler error!
-    printErr('Internal compiler error in src/compiler.mjs!');
+    printErr('Internal compiler error JS compiler');
     printErr('Please create a bug report at https://github.com/emscripten-core/emscripten/issues/');
     printErr(
       'with a log of the build and the input files used to run. Exception message: "' +

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -190,7 +190,7 @@ def compile_javascript(symbols_only=False):
     args = [settings_file]
     if symbols_only:
       args += ['--symbols-only']
-    out = shared.run_js_tool(path_from_root('src/compiler.mjs'),
+    out = shared.run_js_tool(path_from_root('tools/compiler.mjs'),
                              args, stdout=subprocess.PIPE, stderr=stderr_file, encoding='utf-8')
   if symbols_only:
     glue = None

--- a/tools/maint/gen_sig_info.py
+++ b/tools/maint/gen_sig_info.py
@@ -320,7 +320,7 @@ def extract_sig_info(sig_info, extra_settings=None, extra_cflags=None, cxx=False
     settings.update(extra_settings)
   with tempfiles.get_file('.json') as settings_json:
     utils.write_file(settings_json, json.dumps(settings))
-    output = shared.run_js_tool(utils.path_from_root('src/compiler.mjs'),
+    output = shared.run_js_tool(utils.path_from_root('tools/compiler.mjs'),
                                 ['--symbols-only', settings_json],
                                 stdout=subprocess.PIPE)
   symbols = json.loads(output)['deps'].keys()


### PR DESCRIPTION
For consistency with the other JS entry points we have (preprocessor.mjs and acorn-optimizer.mjs) that already live in the tools directory.