### PR TITLE
Use the same json interchange format preprocessor.mjs as compiler.mjs. NFC

### DIFF
--- a/tools/compiler.mjs
+++ b/tools/compiler.mjs
@@ -39,8 +39,8 @@ Usage: compiler.mjs <settings.json> [-o out.js] [--symbols-only]`);
 // Load settings from JSON passed on the command line
 const settingsFile = positionals[0];
 assert(settingsFile, 'settings file not specified');
-const user_settings = JSON.parse(readFile(settingsFile));
-applySettings(user_settings);
+const userSettings = JSON.parse(readFile(settingsFile));
+applySettings(userSettings);
 
 export const symbolsOnly = values['symbols-only'];
 

--- a/tools/preprocessor.mjs
+++ b/tools/preprocessor.mjs
@@ -15,7 +15,7 @@
 import assert from 'node:assert';
 import {parseArgs} from 'node:util';
 
-import {loadSettingsFile} from '../src/utility.mjs';
+import {readFile, loadDefaultSettings, applySettings} from '../src/utility.mjs';
 
 const options = {
   'expand-macros': {type: 'boolean'},
@@ -31,11 +31,17 @@ Usage: preprocessor.mjs <settings.json> <input-file> [--expand-macros]`);
   process.exit(0);
 }
 
-assert(positionals.length == 2, 'Script requires 2 arguments');
-const settingsFile = positionals[0];
-const inputFile = positionals[1];
+loadDefaultSettings();
 
-loadSettingsFile(settingsFile);
+assert(positionals.length == 2, 'Script requires 2 arguments');
+
+// Load settings from JSON passed on the command line
+const settingsFile = positionals[0];
+assert(settingsFile, 'settings file not specified');
+const userSettings = JSON.parse(readFile(settingsFile));
+applySettings(userSettings);
+
+const inputFile = positionals[1];
 
 // We can't use static import statements here because several of these
 // file depend on having the settings defined in the global scope (which

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -723,29 +723,24 @@ def read_and_preprocess(filename, expand_macros=False):
   temp_dir = get_emscripten_temp_dir()
   # Create a settings file with the current settings to pass to the JS preprocessor
 
-  settings_str = ''
-  for key, value in settings.external_dict().items():
-    assert key == key.upper()  # should only ever be uppercase keys in settings
-    jsoned = json.dumps(value, sort_keys=True)
-    settings_str += f'var {key} = {jsoned};\n'
+  with get_temp_files().get_file('.json') as settings_file:
+    with open(settings_file, 'w') as s:
+      json.dump(settings.external_dict(), s, sort_keys=True, indent=2)
 
-  settings_file = os.path.join(temp_dir, 'settings.js')
-  utils.write_file(settings_file, settings_str)
+    # Run the JS preprocessor
+    # N.B. We can't use the default stdout=PIPE here as it only allows 64K of output before it hangs
+    # and shell.html is bigger than that!
+    # See https://thraxil.org/users/anders/posts/2008/03/13/Subprocess-Hanging-PIPE-is-your-enemy/
+    dirname, filename = os.path.split(filename)
+    if not dirname:
+      dirname = None
+    stdout = os.path.join(temp_dir, 'stdout')
+    args = [settings_file, filename]
+    if expand_macros:
+      args += ['--expand-macros']
 
-  # Run the JS preprocessor
-  # N.B. We can't use the default stdout=PIPE here as it only allows 64K of output before it hangs
-  # and shell.html is bigger than that!
-  # See https://thraxil.org/users/anders/posts/2008/03/13/Subprocess-Hanging-PIPE-is-your-enemy/
-  dirname, filename = os.path.split(filename)
-  if not dirname:
-    dirname = None
-  stdout = os.path.join(temp_dir, 'stdout')
-  args = [settings_file, filename]
-  if expand_macros:
-    args += ['--expand-macros']
-
-  run_js_tool(path_from_root('tools/preprocessor.mjs'), args, stdout=open(stdout, 'w'), cwd=dirname)
-  out = utils.read_file(stdout)
+    run_js_tool(path_from_root('tools/preprocessor.mjs'), args, stdout=open(stdout, 'w'), cwd=dirname)
+    out = utils.read_file(stdout)
 
   return out
 


### PR DESCRIPTION
I'm not sure why used `.js` in once case and `.json` in another.

The other nice thing about this change is that it has the preprocessor read the default settings (just like compiler.mjs) so the json file can contain just the changes from the default.