### PR TITLE
Only serialize modified settings. NFC

### DIFF
--- a/tools/settings.py
+++ b/tools/settings.py
@@ -144,6 +144,7 @@ def default_setting(name, new_default):
 
 class SettingsManager:
   attrs: Dict[str, Any] = {}
+  defaults: Dict[str, tuple] = {}
   types: Dict[str, Any] = {}
   allowed_settings: Set[str] = set()
   legacy_settings: Dict[str, tuple] = {}
@@ -153,6 +154,7 @@ class SettingsManager:
   def __init__(self):
     self.attrs.clear()
     self.legacy_settings.clear()
+    self.defaults.clear()
     self.alt_names.clear()
     self.internal_settings.clear()
     self.allowed_settings.clear()
@@ -177,8 +179,9 @@ class SettingsManager:
     self.attrs.update(internal_attrs)
     self.infer_types()
 
+    strict_override = False
     if 'EMCC_STRICT' in os.environ:
-      self.attrs['STRICT'] = int(os.environ.get('EMCC_STRICT'))
+      strict_override = int(os.environ.get('EMCC_STRICT'))
 
     # Special handling for LEGACY_SETTINGS.  See src/setting.js for more
     # details
@@ -194,10 +197,16 @@ class SettingsManager:
         self.legacy_settings[name] = (fixed_values, err)
         default_value = fixed_values[0]
       assert name not in self.attrs, 'legacy setting (%s) cannot also be a regular setting' % name
-      if not self.attrs['STRICT']:
+      if not strict_override:
         self.attrs[name] = default_value
 
     self.internal_settings.update(internal_attrs.keys())
+    # Stash a deep copy of all settings in self.defaults.  This allows us to detect which settings
+    # have local mods.
+    self.defaults.update(copy.deepcopy(self.attrs))
+
+    if strict_override:
+      self.attrs['STRICT'] = strict_override
 
   def infer_types(self):
     for key, value in self.attrs.items():
@@ -207,11 +216,15 @@ class SettingsManager:
     return self.attrs
 
   def external_dict(self, skip_keys={}): # noqa
-    external_settings = {k: v for k, v in self.dict().items() if k not in INTERNAL_SETTINGS and k not in skip_keys}
-    # Only the names of the legacy settings are used by the JS compiler
-    # so we can reduce the size of serialized json by simplifying this
-    # otherwise complex value.
-    external_settings['LEGACY_SETTINGS'] = [l[0] for l in external_settings['LEGACY_SETTINGS']]
+    external_settings = {}
+    for key, value in self.dict().items():
+      if value != self.defaults.get(key) and key not in INTERNAL_SETTINGS and key not in skip_keys:
+        external_settings[key] = value # noqa: PERF403
+    if not self.attrs['STRICT']:
+      # When not running in strict mode we also externalize all leggacy settings
+      # (Since the external tools do process LEGACY_SETTINGS themselves)
+      for key in self.legacy_settings:
+        external_settings[key] = self.attrs[key]
     return external_settings
 
   def keys(self):


### PR DESCRIPTION
This means that when we run the compiler or the preprocessor we don't serialize all setting to JSON, only setting that were are set to something other than the default.