### PR TITLE
Avoid stdout file in read_and_preprocess. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15409,6 +15409,18 @@ addToLibrary({
     self.do_runf('hello_world.c', 'assertions disabled\n4', emcc_args=['-sASSERTIONS=0'])
     self.assertNotContained('#preprocess', read_file('hello_world.js'))
 
+  @crossplatform
+  def test_js_preprocess_huge_file(self):
+    # Check that huge files can be preprocessed.  We once had issues with files
+    # larger then 64k being sent over stdout using python's subprocess.
+    huge_js = '#preprocess\nfunction hugeFunc() {\n'
+    huge_js += 100000 * '  console.log("huge function");\n'
+    huge_js += '}\n'
+    create_file('huge.js', huge_js)
+    assert len(huge_js) > (1024 * 1024)
+    self.do_runf('hello_world.c', 'hello, world!\n', emcc_args=['--pre-js=huge.js'])
+    self.assertContained('function hugeFunc', read_file('hello_world.js'))
+
   @with_both_compilers
   def test_use_port_errors(self, compiler):
     stderr = self.expect_fail([compiler, test_file('hello_world.c'), '--use-port=invalid', '-o', 'out.js'])

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -720,29 +720,20 @@ def safe_copy(src, dst):
 
 
 def read_and_preprocess(filename, expand_macros=False):
-  temp_dir = get_emscripten_temp_dir()
   # Create a settings file with the current settings to pass to the JS preprocessor
-
   with get_temp_files().get_file('.json') as settings_file:
     with open(settings_file, 'w') as s:
       json.dump(settings.external_dict(), s, sort_keys=True, indent=2)
 
     # Run the JS preprocessor
-    # N.B. We can't use the default stdout=PIPE here as it only allows 64K of output before it hangs
-    # and shell.html is bigger than that!
-    # See https://thraxil.org/users/anders/posts/2008/03/13/Subprocess-Hanging-PIPE-is-your-enemy/
     dirname, filename = os.path.split(filename)
     if not dirname:
       dirname = None
-    stdout = os.path.join(temp_dir, 'stdout')
     args = [settings_file, filename]
     if expand_macros:
       args += ['--expand-macros']
 
-    run_js_tool(path_from_root('tools/preprocessor.mjs'), args, stdout=open(stdout, 'w'), cwd=dirname)
-    out = utils.read_file(stdout)
-
-  return out
+    return run_js_tool(path_from_root('tools/preprocessor.mjs'), args, stdout=subprocess.PIPE, cwd=dirname)
 
 
 def do_replace(input_, pattern, replacement):


### PR DESCRIPTION
The comment here suggests there is bug with stdout streaming in python but we use `stdout=PIPE` when we run `compiler.mjs`, which tends to generate a lot more output that `preprocessor.mjs`

See `compile_javascript` in `emscripten.py`.