### PR TITLE
Remove support for no-longer-supported browser versions. NFC

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1341,7 +1341,7 @@ addToLibrary({
   // respective time origins.
   emscripten_get_now: () => performance.timeOrigin + {{{ getPerformanceNow() }}}(),
 #else
-#if MIN_FIREFOX_VERSION <= 14 || MIN_CHROME_VERSION <= 23 || MIN_SAFARI_VERSION <= 80400 || AUDIO_WORKLET // https://caniuse.com/#feat=high-resolution-time
+#if AUDIO_WORKLET // https://github.com/WebAudio/web-audio-api/issues/2413
   emscripten_get_now: `;
     // AudioWorkletGlobalScope does not have performance.now()
     // (https://github.com/WebAudio/web-audio-api/issues/2527), so if building
@@ -1371,7 +1371,7 @@ addToLibrary({
       return 1; // nanoseconds
     }
 #endif
-#if MIN_FIREFOX_VERSION <= 14 || MIN_CHROME_VERSION <= 23 || MIN_SAFARI_VERSION <= 80400 // https://caniuse.com/#feat=high-resolution-time
+#if AUDIO_WORKLET // https://github.com/WebAudio/web-audio-api/issues/2413
     if (typeof performance == 'object' && performance && typeof performance['now'] == 'function') {
       return 1000; // microseconds (1/1000 of a millisecond)
     }
@@ -1385,13 +1385,8 @@ addToLibrary({
   // Represents whether emscripten_get_now is guaranteed monotonic; the Date.now
   // implementation is not :(
   $nowIsMonotonic__internal: true,
-#if MIN_FIREFOX_VERSION <= 14 || MIN_CHROME_VERSION <= 23 || MIN_SAFARI_VERSION <= 80400 // https://caniuse.com/#feat=high-resolution-time
-  $nowIsMonotonic: `
-     ((typeof performance == 'object' && performance && typeof performance['now'] == 'function')
-#if ENVIRONMENT_MAY_BE_NODE
-      || ENVIRONMENT_IS_NODE
-#endif
-    );`,
+#if AUDIO_WORKLET // // https://github.com/WebAudio/web-audio-api/issues/2413
+  $nowIsMonotonic: `((typeof performance == 'object' && performance && typeof performance['now'] == 'function'));`,
 #else
   // Modern environment where performance.now() is supported
   $nowIsMonotonic: 1,

--- a/src/lib/libembind.js
+++ b/src/lib/libembind.js
@@ -176,21 +176,7 @@ var LibraryEmbind = {
     return errorClass;
   },
 
-  $createNamedFunction: (name, body) => Object.defineProperty(body, 'name', {
-    value: name
-  }),
-  // All browsers that support WebAssembly also support configurable function name,
-  // but we might be building for very old browsers via WASM2JS.
-#if MIN_CHROME_VERSION < 43 || MIN_SAFARI_VERSION < 100101 || MIN_FIREFOX_VERSION < 38
-  // In that case, check if configurable function name is supported at init time
-  // and, if not, replace with a fallback that returns function as-is as those browsers
-  // don't support other methods either.
-  $createNamedFunction__postset: `
-    if (!Object.getOwnPropertyDescriptor(Function.prototype, 'name').configurable) {
-      createNamedFunction = (name, body) => body;
-    }
-  `,
-#endif
+  $createNamedFunction: (name, func) => Object.defineProperty(func, 'name', { value: name }),
 
   $embindRepr: (v) => {
     if (v === null) {

--- a/src/lib/libwebgl.js
+++ b/src/lib/libwebgl.js
@@ -787,12 +787,7 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
 #endif
         :
 #endif
-        (canvas.getContext("webgl", webGLContextAttributes)
-          // https://caniuse.com/#feat=webgl
-#if MIN_FIREFOX_VERSION <= 23 || MIN_CHROME_VERSION <= 32 || MIN_SAFARI_VERSION <= 70101
-          || canvas.getContext("experimental-webgl", webGLContextAttributes)
-#endif
-          );
+        canvas.getContext("webgl", webGLContextAttributes);
 #endif // MAX_WEBGL_VERSION >= 2
 
 #if GL_PREINITIALIZED_CONTEXT


### PR DESCRIPTION
Our current oldest supported browser versions (from feature_matrix.py):

```
OLDEST_SUPPORTED_CHROME = 45  # September 1, 2015
OLDEST_SUPPORTED_FIREFOX = 40  # August 11, 2015
OLDEST_SUPPORTED_SAFARI = 101000  # September 20, 2016
OLDEST_SUPPORTED_NODE = 101900
```