### PR TITLE
Update copyright year reported by --version. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -568,7 +568,7 @@ emcc: supported targets: llvm bitcode, WebAssembly, NOT elf
   if '--version' in args:
     print(version_string())
     print('''\
-Copyright (C) 2014 the Emscripten authors (see AUTHORS.txt)
+Copyright (C) 2025 the Emscripten authors (see AUTHORS.txt)
 This is free and open source software under the MIT license.
 There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ''')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7,6 +7,7 @@
 # noqa: E241
 
 from functools import wraps
+from datetime import datetime
 import glob
 import gzip
 import importlib
@@ -484,8 +485,10 @@ class other(RunnerCore):
     # --version
     output = self.run_process([compiler, '--version'], stdout=PIPE, stderr=PIPE)
     output = output.stdout.replace('\r', '')
+    # This test will require updating once per year. Sorry.
+    this_year = datetime.now().year
     self.assertContained('emcc (Emscripten gcc/clang-like replacement', output)
-    self.assertContained('''Copyright (C) 2014 the Emscripten authors (see AUTHORS.txt)
+    self.assertContained(f'''Copyright (C) {this_year} the Emscripten authors (see AUTHORS.txt)
 This is free and open source software under the MIT license.
 There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ''', output)


### PR DESCRIPTION
It seems the reporting the most recent year is what tools like gcc do:

```
$ gcc --version
gcc (Debian 14.2.0-3+build3) 14.2.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```