### PR TITLE
Bump min supported node version from 10.19 to 12.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -774,10 +774,10 @@ jobs:
       # support in the generated code.
       # Keep this in sync with `OLDEST_SUPPORTED_NODE` in `feature_matrix.py`
       - install-node-version:
-          node_version: "10.19.0"
+          node_version: "12.20.0"
       - run-tests:
-          title: "node (oldest / 10.19.0)"
-          extra-cflags: "-sMIN_NODE_VERSION=101900"
+          title: "node (oldest / 12.20.0)"
+          extra-cflags: "-sMIN_NODE_VERSION=122000"
           # We include most but not all of the nodefs and node rawfs tests here.
           # test_fs_nodefs_rw, test_fs_nodefs_statvfs, and test_unistd_io_nodefs_bigint fail.
           test_targets: "

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -2955,7 +2955,7 @@ Specifies minimum node version to target for the generated code.  This is
 distinct from the minimum version required run the emscripten compiler.
 This version aligns with the current Ubuuntu TLS 20.04 (Focal).
 Version is encoded in MMmmVV, e.g. 181401 denotes Node 18.14.01.
-Minimum supported value is 101900, which was released 2020-02-05 (see
+Minimum supported value is 122000, which was released 2020-11-25 (see
 feature_matrix.py).
 
 Default value: 160000

--- a/src/settings.js
+++ b/src/settings.js
@@ -1929,7 +1929,7 @@ var MIN_CHROME_VERSION = 85;
 // distinct from the minimum version required run the emscripten compiler.
 // This version aligns with the current Ubuuntu TLS 20.04 (Focal).
 // Version is encoded in MMmmVV, e.g. 181401 denotes Node 18.14.01.
-// Minimum supported value is 101900, which was released 2020-02-05 (see
+// Minimum supported value is 122000, which was released 2020-11-25 (see
 // feature_matrix.py).
 var MIN_NODE_VERSION = 160000;
 

--- a/test/common.py
+++ b/test/common.py
@@ -1188,7 +1188,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     nodejs = self.get_nodejs()
     if nodejs:
       node_version = shared.get_node_version(nodejs)
-      if node_version < (11, 0, 0):
+      if node_version < (13, 1, 0):
         self.node_args.append('--unhandled-rejections=strict')
         self.node_args.append('--experimental-wasm-se')
       else:

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -21,9 +21,8 @@ UNSUPPORTED = 0x7FFFFFFF
 OLDEST_SUPPORTED_CHROME = 45  # September 1, 2015
 OLDEST_SUPPORTED_FIREFOX = 40  # August 11, 2015
 OLDEST_SUPPORTED_SAFARI = 101000  # September 20, 2016
-# 10.19.0 is the oldest version of node that we do any testing with.
 # Keep this in sync with the test-node-compat in .circleci/config.yml.
-OLDEST_SUPPORTED_NODE = 101900
+OLDEST_SUPPORTED_NODE = 122000
 
 
 class Feature(IntEnum):


### PR DESCRIPTION
This is the minimum node version that we support targeting.  Bumping to v12.20 specifically allows us to start using `node:xx` for imports. See #18235

Fixes: #23652