### PR TITLE
Avoid converting --pre-js/--post-js files to absolute paths. NFC

### DIFF
--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -9,7 +9,6 @@
 
 import assert from 'node:assert';
 import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
 import {
   ATEXITS,
   ATINITS,
@@ -146,23 +145,27 @@ function shouldPreprocess(fileName) {
   return content.startsWith('#preprocess\n') || content.startsWith('#preprocess\r\n');
 }
 
-function getIncludeFile(fileName, alwaysPreprocess) {
-  let result = `// include: ${fileName}\n`;
-  const absFile = path.isAbsolute(fileName) ? fileName : localFile(fileName);
-  const doPreprocess = alwaysPreprocess || shouldPreprocess(absFile);
+function getIncludeFile(fileName, alwaysPreprocess, shortName) {
+  shortName ??= fileName;
+  let result = `// include: ${shortName}\n`;
+  const doPreprocess = alwaysPreprocess || shouldPreprocess(fileName);
   if (doPreprocess) {
-    result += processMacros(preprocess(absFile), fileName);
+    result += processMacros(preprocess(fileName), fileName);
   } else {
-    result += readFile(absFile);
+    result += readFile(fileName);
   }
-  result += `// end include: ${fileName}\n`;
+  result += `// end include: ${shortName}\n`;
   return result;
+}
+
+function getSystemIncludeFile(fileName) {
+  return getIncludeFile(localFile(fileName), /*alwaysPreprocess=*/ true, /*shortName=*/ fileName);
 }
 
 function preJS() {
   let result = '';
   for (const fileName of PRE_JS_FILES) {
-    result += getIncludeFile(fileName, /*alwaysPreprocess=*/ false);
+    result += getIncludeFile(fileName);
   }
   return result;
 }
@@ -714,8 +717,12 @@ function(${args}) {
     libraryItems.push(JS);
   }
 
-  function includeFile(fileName, alwaysPreprocess = true) {
-    writeOutput(getIncludeFile(fileName, alwaysPreprocess));
+  function includeSystemFile(fileName) {
+    writeOutput(getSystemIncludeFile(fileName));
+  }
+
+  function includeFile(fileName) {
+    writeOutput(getIncludeFile(fileName));
   }
 
   function finalCombiner() {
@@ -741,10 +748,10 @@ function(${args}) {
     postSets.push(...orderedPostSets);
 
     const shellFile = MINIMAL_RUNTIME ? 'shell_minimal.js' : 'shell.js';
-    includeFile(shellFile);
+    includeSystemFile(shellFile);
 
     const preFile = MINIMAL_RUNTIME ? 'preamble_minimal.js' : 'preamble.js';
-    includeFile(preFile);
+    includeSystemFile(preFile);
 
     for (const item of libraryItems.concat(postSets)) {
       writeOutput(indentify(item || '', 2));
@@ -769,14 +776,14 @@ var proxiedFunctionTable = [
     writeOutput('// EMSCRIPTEN_END_FUNCS\n');
 
     const postFile = MINIMAL_RUNTIME ? 'postamble_minimal.js' : 'postamble.js';
-    includeFile(postFile);
+    includeSystemFile(postFile);
 
     for (const fileName of POST_JS_FILES) {
-      includeFile(fileName, /*alwaysPreprocess=*/ false);
+      includeFile(fileName);
     }
 
     if (MODULARIZE) {
-      includeFile('postamble_modularize.js');
+      includeSystemFile('postamble_modularize.js');
     }
 
     if (errorOccured()) {

--- a/tools/link.py
+++ b/tools/link.py
@@ -1826,8 +1826,8 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
   if settings.PTHREADS:
     settings.REQUIRED_EXPORTS.append('_emscripten_tls_init')
 
-  settings.PRE_JS_FILES = [os.path.abspath(f) for f in options.pre_js]
-  settings.POST_JS_FILES = [os.path.abspath(f) for f in options.post_js]
+  settings.PRE_JS_FILES = options.pre_js
+  settings.POST_JS_FILES = options.post_js
 
   settings.MINIFY_WHITESPACE = settings.OPT_LEVEL >= 2 and settings.DEBUG_LEVEL == 0 and not options.no_minify
 


### PR DESCRIPTION
Now that we change CWD when running `compiler.mjs` (See #23519) we no longer need to convert these to absolute paths in `link.py`.

This also makes explicit the difference between system and user includes in `jsifier.mjs`.