### PR TITLE
Add createFile to JS API for wasmfs (#23667)

### DIFF
--- a/src/lib/libwasmfs.js
+++ b/src/lib/libwasmfs.js
@@ -98,6 +98,7 @@ FS.init();
       FS.ErrnoError.prototype = new Error();
       FS.ErrnoError.prototype.constructor = FS.ErrnoError;
     },
+    createFile: (path, mode, backend) => FS.handleError(withStackSave(() => _wasmfs_create_file(stringToUTF8OnStack(path), mode, backend))),
     createDataFile(parent, name, fileData, canRead, canWrite, canOwn) {
       FS_createDataFile(parent, name, fileData, canRead, canWrite, canOwn);
     },


### PR DESCRIPTION
Per #23667, add a createFile function to the WASMFS JS API that calls out to `wasmfs_create_file`.