### PR TITLE
Fix an edge case in wasmfs_fetch for reads far past end of file

### DIFF
--- a/src/lib/libwasmfs_fetch.js
+++ b/src/lib/libwasmfs_fetch.js
@@ -55,7 +55,7 @@ addToLibrary({
             chunks: [],
             chunkSize: chunkSize
           };
-          lastChunk = Math.min(lastChunk, ((size-1) / chunkSize));
+          lastChunk = Math.min(lastChunk, ((size-1) / chunkSize)) | 0;
         } else {
           // may as well/forced to download the whole file
           var wholeFileReq = await fetch(url);

--- a/src/lib/libwasmfs_fetch.js
+++ b/src/lib/libwasmfs_fetch.js
@@ -122,7 +122,10 @@ addToLibrary({
 
       // read/getSize fetch the data, then forward to the parent class.
       read: async (file, buffer, length, offset) => {
-        if (offset < 0 || length == 0) {
+        // This function assumes that offset is non-negative and length is positive.
+        // C read() doesn't take an offset and so doesn't have to deal with the former situation,
+        // and if the length is 0 or the offset is negative there's no reasonable read we can make.
+        if (offset < 0 || length <= 0) {
           return 0;
         }
         try {
@@ -132,7 +135,8 @@ addToLibrary({
         }
         var fileInfo = wasmFS$JSMemoryRanges[file];
         length = Math.min(length, fileInfo.size-offset+1) | 0;
-        if (offset < 0 || length <= 0) {
+        // As above, we check the length just in case offset was beyond size and length is now negative.
+        if (length <= 0) {
           return 0;
         }
         var chunks = fileInfo.chunks;

--- a/src/lib/libwasmfs_fetch.js
+++ b/src/lib/libwasmfs_fetch.js
@@ -49,11 +49,14 @@ addToLibrary({
             fileInfo.headers.has('Content-Length') &&
             fileInfo.headers.get('Accept-Ranges') == 'bytes' &&
             (parseInt(fileInfo.headers.get('Content-Length'), 10) > chunkSize*2)) {
+          var size = parseInt(fileInfo.headers.get('Content-Length'), 10);
           wasmFS$JSMemoryRanges[file] = {
-            size: parseInt(fileInfo.headers.get('Content-Length'), 10),
+            size,
             chunks: [],
             chunkSize: chunkSize
           };
+          firstChunk = 0;
+          lastChunk = Math.min(lastChunk, ((size-1) / chunkSize));
         } else {
           // may as well/forced to download the whole file
           var wholeFileReq = await fetch(url);
@@ -133,7 +136,9 @@ addToLibrary({
         var chunkSize = fileInfo.chunkSize;
         var firstChunk = (offset / chunkSize) | 0;
         // See comments in getFileRange.
-        var lastChunk = ((offset+length-1) / chunkSize) | 0;
+        var lastChunk = Math.min(
+          ((offset+length-1) / chunkSize),
+          ((fileInfo.size-1) / chunkSize)) | 0;
         var readLength = 0;
         for (var i = firstChunk; i <= lastChunk; i++) {
           var chunk = chunks[i];

--- a/src/lib/libwasmfs_fetch.js
+++ b/src/lib/libwasmfs_fetch.js
@@ -55,7 +55,6 @@ addToLibrary({
             chunks: [],
             chunkSize: chunkSize
           };
-          firstChunk = 0;
           lastChunk = Math.min(lastChunk, ((size-1) / chunkSize));
         } else {
           // may as well/forced to download the whole file

--- a/test/wasmfs/wasmfs_fetch.c
+++ b/test/wasmfs/wasmfs_fetch.c
@@ -171,6 +171,7 @@ void test_small_chunks() {
   buf[size] = 0;
   printf("buf %s\n",buf);
   assert(strcmp(buf, "hello") == 0);
+  assert(read(fd, buf+size-1, 1024) == 1);
 
   assert(close(fd) == 0);
 


### PR DESCRIPTION
Use the minimum of the requested last chunk and the actual last chunk when accessing chunked data.