### PR TITLE
Issue #23587: Allow omitting optional fields in value objects

### DIFF
--- a/src/lib/libembind.js
+++ b/src/lib/libembind.js
@@ -1112,6 +1112,7 @@ var LibraryEmbind = {
       fieldRecords.forEach((field, i) => {
         var fieldName = field.fieldName;
         var getterReturnType = fieldTypes[i];
+        var optional = fieldTypes[i].optional;
         var getter = field.getter;
         var getterContext = field.getterContext;
         var setterArgumentType = fieldTypes[i + fieldRecords.length];
@@ -1123,7 +1124,8 @@ var LibraryEmbind = {
             var destructors = [];
             setter(setterContext, ptr, setterArgumentType['toWireType'](destructors, o));
             runDestructors(destructors);
-          }
+          },
+          optional,
         };
       });
 
@@ -1141,7 +1143,7 @@ var LibraryEmbind = {
           // todo: Here we have an opportunity for -O3 level "unsafe" optimizations:
           // assume all fields are present without checking.
           for (var fieldName in fields) {
-            if (!(fieldName in o)) {
+            if (!(fieldName in o) && !fields[fieldName].optional) {
               throw new TypeError(`Missing field: "${fieldName}"`);
             }
           }

--- a/test/embind/embind.test.js
+++ b/test/embind/embind.test.js
@@ -1281,6 +1281,12 @@ module({
             cm.embind_test_optional_multiple_arg(1);
             cm.embind_test_optional_multiple_arg(1, 2);
         });
+        test("std::optional properties can be omitted", function() {
+            // Sanity check: Not omitting still works.
+            cm.embind_test_optional_property({x: 1, y: 2});
+            // Omitting should also work, since "y" is std::optional.
+            cm.embind_test_optional_property({x: 1});
+        });
     });
 
     BaseFixture.extend("functors", function() {

--- a/test/embind/embind_test.cpp
+++ b/test/embind/embind_test.cpp
@@ -1342,6 +1342,13 @@ void embind_test_optional_multiple_arg(int arg1,
                                        std::optional<int> arg2,
                                        std::optional<int> arg3) {
 }
+
+struct StructWithOptionalProperty {
+  int x;
+  std::optional<int> y;
+};
+void embind_test_optional_property(const StructWithOptionalProperty &arg) {
+}
 #endif
 
 val embind_test_getglobal() {
@@ -2369,6 +2376,11 @@ EMSCRIPTEN_BINDINGS(tests) {
   function("embind_test_optional_string_arg", &embind_test_optional_string_arg);
   function("embind_test_optional_small_class_arg", &embind_test_optional_small_class_arg);
   function("embind_test_optional_multiple_arg", &embind_test_optional_multiple_arg);
+  value_object<StructWithOptionalProperty>("StructWithOptionalProperty")
+      .field("x", &StructWithOptionalProperty::x)
+      .field("y", &StructWithOptionalProperty::y)
+  ;
+  function("embind_test_optional_property", &embind_test_optional_property);
 #endif
 
   register_map<std::string, int>("StringIntMap");


### PR DESCRIPTION
This PR modifies `libembind.js` to skip presence checks for `std::optional` fields in value objects. As discussed in #23587 with @brendandahl . I added a test and verified that the test fails without the `libembind.js` change and passes with it. All other `test_embind` cases still pass.