### PR TITLE
[test] Remove some startup noise from test suite. NFC

### DIFF
--- a/test/runner.py
+++ b/test/runner.py
@@ -329,8 +329,8 @@ def run_tests(options, suites):
   resultMessages = []
   num_failures = 0
 
-  print('Test suites:')
-  print([s[0] for s in suites])
+  if len(suites) > 1:
+    print('Test suites:', [s[0] for s in suites])
   # Run the discovered tests
 
   # We currently don't support xmlrunner on macOS M1 runner since


### PR DESCRIPTION
This information is redundant, especially in the case when there is only one suite.

```
$ ./test/runner other.test_jslib_native_deps
Test suites:
['test_other']
Running test_other: (1 tests)
(checking sanity from test runner)
shared:INFO: (Emscripten: Running sanity checks)
test_jslib_native_deps (test_other.other.test_jslib_native_deps) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.714s

OK
```