### PR TITLE
New contrib port: lua

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,8 @@ See docs/process.md for more on how version tagging works.
 - The `--output_eol` command line flag was renamed `--output-eol` for
   consistency with other flags. The old name continues to work as an alias.
   (#20735)
+- Added Lua contrib port (`--use-port=contrib.lua`) to easily embed the Lua
+  scripting language in any C/C++ Emscripten project (#23682)
 
 4.0.3 - 02/07/25
 ----------------

--- a/site/source/docs/compiling/Contrib-Ports.rst
+++ b/site/source/docs/compiling/Contrib-Ports.rst
@@ -17,17 +17,53 @@ available in emscripten. In order to use a contrib port you use the
 contrib.glfw3
 =============
 
-This project is an emscripten port of GLFW written in C++ for the
+This project is an Emscripten port of GLFW written in C++ for the
 web/webassembly platform.
 
 .. note::
-  emscripten includes support for both GLFW 2 and 3 written in Javascript.
+  Emscripten includes support for both GLFW 2 and 3 written in Javascript.
   These can be activated with the :ref:`settings <use_glfw>` ``-sUSE_GLFW=2``
   and ``-sUSE_GLFW=3``. This non-official contribution, written in C++,
   provides a more extensive and up-to-date implementation of the GLFW 3 API
   than the built-in port. It is enabled with the option
   ``--use-port=contrib.glfw3``.
 
-`Project information <https://github.com/pongasoft/emscripten-glfw>`_
+`Project information <https://github.com/pongasoft/emscripten-glfw>`__
 
 License: Apache 2.0 license
+
+.. _contrib.lua:
+
+contrib.lua
+===========
+
+Lua is a powerful, efficient, lightweight, embeddable scripting language.
+
+Example usage:
+
+.. code-block:: text
+
+  // main.c
+  #include <lua.h>
+  #include <lualib.h>
+  #include <lauxlib.h>
+  #include <stdio.h>
+
+  int main() {
+    lua_State *L = luaL_newstate();
+    luaL_openlibs(L);
+    if (luaL_dostring(L, "print('hello world')") != LUA_OK) {
+      printf("Error running Lua code %s\n", lua_tostring(L, -1));
+      lua_pop(L, 1);
+    }
+    lua_close(L);
+    return 0;
+  }
+
+  // compile with
+  emcc --use-port=contrib.lua main.c -o /tmp/index.html
+
+
+`Project information <https://www.lua.org/>`__
+
+License: MIT License

--- a/test/other/test_port_contrib_lua.c
+++ b/test/other/test_port_contrib_lua.c
@@ -1,17 +1,16 @@
 /*
-* Copyright 2025 The Emscripten Authors.  All rights reserved.
-* Emscripten is available under two separate licenses, the MIT license and the
-* University of Illinois/NCSA Open Source License.  Both these licenses can be
-* found in the LICENSE file.
-*/
+ * Copyright 2025 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
 
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>
 #include <stdio.h>
 
-int main()
-{
+int main() {
   // Create a new Lua state
   lua_State *L = luaL_newstate();
 

--- a/test/other/test_port_contrib_lua.c
+++ b/test/other/test_port_contrib_lua.c
@@ -1,0 +1,41 @@
+/*
+* Copyright 2025 The Emscripten Authors.  All rights reserved.
+* Emscripten is available under two separate licenses, the MIT license and the
+* University of Illinois/NCSA Open Source License.  Both these licenses can be
+* found in the LICENSE file.
+*/
+
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+#include <stdio.h>
+
+int main()
+{
+  // Create a new Lua state
+  lua_State *L = luaL_newstate();
+
+  // Load standard Lua libraries
+  luaL_openlibs(L);
+  
+  char const *chunks[3] = {
+    "print('hello world')",                                // test Basic Library
+    "print(string.upper('hello world'))",                  // test string library
+    "print('sqrt(16)=' .. math.tointeger(math.sqrt(16)))", // test math library
+  };
+
+  // Iterate over each chunk of Lua code and execute it
+  for (size_t i = 0; i <= 3; i++) {
+    if (luaL_dostring(L, chunks[i]) != LUA_OK) {
+      printf("Error running Lua code: %s\n", lua_tostring(L, -1));
+      lua_pop(L, 1); // Remove the error message from the stack
+      lua_close(L);
+      return 1; // returning error so the test can fail
+    }
+  }
+
+  // Close the Lua state
+  lua_close(L);
+
+  return 0;
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6598,25 +6598,6 @@ void* operator new(size_t size) {
 
     self.do_runf('third_party/libiberty/cp-demangle.c', '*d_demangle(char const*, int, unsigned int*)*', args=['_ZL10d_demanglePKciPj'])
 
-  @needs_make('make')
-  @crossplatform
-  def test_lua(self):
-    self.emcc_args.remove('-Werror')
-    env_init = {
-      'SYSCFLAGS': ' '.join(self.get_emcc_args(compile_only=True)),
-      'SYSLDFLAGS': ' '.join(self.get_emcc_args())
-    }
-    libs = self.get_library('third_party/lua',
-                            ['src/lua.o', 'src/liblua.a'],
-                            make=['make', 'echo', 'generic'],
-                            env_init=env_init,
-                            configure=None)
-    self.do_run('',
-                'hello lua world!\n17\n1\n2\n3\n4\n7',
-                args=['-e', '''print("hello lua world!");print(17);for x = 1,4 do print(x) end;print(10-3)'''],
-                libraries=libs,
-                includes=[test_file('lua')])
-
   @no_asan('issues with freetype itself')
   @needs_make('configure script')
   @is_slow_test

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2626,7 +2626,7 @@ More info: https://emscripten.org
 
   @requires_network
   def test_port_contrib_lua(self):
-    self.do_runf('other/test_port_contrib_lua.c', 'hello world\nHELLO WORLD\nsqrt(16)=4\n', emcc_args=[f'--use-port=contrib.lua'])
+    self.do_runf('other/test_port_contrib_lua.c', 'hello world\nHELLO WORLD\nsqrt(16)=4\n', emcc_args=['--use-port=contrib.lua'])
 
   def test_link_memcpy(self):
     # memcpy can show up *after* optimizations, so after our opportunity to link in libc, so it must be special-cased

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2624,6 +2624,10 @@ Options:
 More info: https://emscripten.org
 ''', stdout)
 
+  @requires_network
+  def test_port_contrib_lua(self):
+    self.do_runf('other/test_port_contrib_lua.c', 'hello world\nHELLO WORLD\nsqrt(16)=4\n', emcc_args=[f'--use-port=contrib.lua'])
+
   def test_link_memcpy(self):
     # memcpy can show up *after* optimizations, so after our opportunity to link in libc, so it must be special-cased
     create_file('main.c', r'''

--- a/tools/ports/contrib/lua.py
+++ b/tools/ports/contrib/lua.py
@@ -15,10 +15,7 @@ DESCRIPTION = 'Lua is a powerful, efficient, lightweight, embeddable scripting l
 LICENSE = 'MIT License'
 
 port_name = 'contrib.lua'
-
-
-def get_lib_name(settings):
-  return f'lib_{port_name}.a'
+lib_name = 'liblua.a'
 
 
 def get(ports, settings, shared):
@@ -44,8 +41,8 @@ def get(ports, settings, shared):
 
     ports.build_port(source_path, final, port_name, srcs=srcs, flags=flags)
 
-  return [shared.cache.get_lib(get_lib_name(settings), create, what='port')]
+  return [shared.cache.get_lib(lib_name, create, what='port')]
 
 
 def clear(ports, settings, shared):
-  shared.cache.erase_lib(get_lib_name(settings))
+  shared.cache.erase_lib(lib_name)

--- a/tools/ports/contrib/lua.py
+++ b/tools/ports/contrib/lua.py
@@ -7,7 +7,6 @@ import os
 
 TAG = '5.4.7'
 HASH = '98c5c8978dfdf867e37e9eb3b3ec83dee92d199243b5119505da83895e33f10d43c841be6a7d3b106daba8a0b2bd25fe099ebff8f87831dcc55c79c78b97d8b8'
-ZIP_URL = f'https://www.lua.org/ftp/lua-{TAG}.tar.gz'
 
 # contrib port information (required)
 URL = 'https://www.lua.org/'
@@ -20,7 +19,7 @@ lib_name = 'liblua.a'
 
 def get(ports, settings, shared):
   # get the port
-  ports.fetch_project(port_name, ZIP_URL, sha512hash=HASH)
+  ports.fetch_project(port_name, f'https://www.lua.org/ftp/lua-{TAG}.tar.gz', sha512hash=HASH)
 
   def create(final):
     root_path = os.path.join(ports.get_dir(), port_name, f'lua-{TAG}')

--- a/tools/ports/contrib/lua.py
+++ b/tools/ports/contrib/lua.py
@@ -1,0 +1,55 @@
+# Copyright 2025 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+import os
+
+TAG = '5.4.7'
+HASH = '98c5c8978dfdf867e37e9eb3b3ec83dee92d199243b5119505da83895e33f10d43c841be6a7d3b106daba8a0b2bd25fe099ebff8f87831dcc55c79c78b97d8b8'
+ZIP_URL = f'https://www.lua.org/ftp/lua-{TAG}.tar.gz'
+
+# contrib port information (required)
+URL = 'https://www.lua.org/'
+DESCRIPTION = f'Lua is a powerful, efficient, lightweight, embeddable scripting language'
+LICENSE = 'MIT License'
+
+port_name = 'contrib.lua'
+
+
+def get_lib_name(settings):
+  return f'lib_{port_name}.a'
+
+
+def get(ports, settings, shared):
+  # get the port
+  ports.fetch_project(port_name, ZIP_URL, sha512hash=HASH)
+
+  def create(final):
+    root_path = os.path.join(ports.get_dir(), port_name, f'lua-{TAG}')
+    source_path = os.path.join(root_path, 'src')
+
+    # install headers
+    includes = ['lua.h', 'lua.hpp', 'luaconf.h', 'lauxlib.h', 'lualib.h']
+    for f in includes:
+      ports.install_headers(source_path, pattern=f, target='lua')
+
+    srcs = '''
+       lapi.c lcode.c lctype.c ldebug.c ldo.c ldump.c lfunc.c lgc.c llex.c lmem.c lobject.c lopcodes.c 
+       lparser.c lstate.c lstring.c ltable.c ltm.c lundump.c lvm.c lzio.c lauxlib.c lbaselib.c lcorolib.c
+       ldblib.c liolib.c lmathlib.c loadlib.c loslib.c lstrlib.c ltablib.c lutf8lib.c linit.c
+       '''.split()
+
+    flags = ['-DLUA_COMPAT_5_3']
+
+    ports.build_port(source_path, final, port_name, srcs=srcs, flags=flags)
+
+  return [shared.cache.get_lib(get_lib_name(settings), create, what='port')]
+
+
+def clear(ports, settings, shared):
+  shared.cache.erase_lib(get_lib_name(settings))
+
+
+def process_args(ports):
+  return ['-isystem', ports.get_include_dir('lua')]

--- a/tools/ports/contrib/lua.py
+++ b/tools/ports/contrib/lua.py
@@ -11,7 +11,7 @@ ZIP_URL = f'https://www.lua.org/ftp/lua-{TAG}.tar.gz'
 
 # contrib port information (required)
 URL = 'https://www.lua.org/'
-DESCRIPTION = f'Lua is a powerful, efficient, lightweight, embeddable scripting language'
+DESCRIPTION = 'Lua is a powerful, efficient, lightweight, embeddable scripting language'
 LICENSE = 'MIT License'
 
 port_name = 'contrib.lua'
@@ -35,7 +35,7 @@ def get(ports, settings, shared):
       ports.install_headers(source_path, pattern=f, target='lua')
 
     srcs = '''
-       lapi.c lcode.c lctype.c ldebug.c ldo.c ldump.c lfunc.c lgc.c llex.c lmem.c lobject.c lopcodes.c 
+       lapi.c lcode.c lctype.c ldebug.c ldo.c ldump.c lfunc.c lgc.c llex.c lmem.c lobject.c lopcodes.c
        lparser.c lstate.c lstring.c ltable.c ltm.c lundump.c lvm.c lzio.c lauxlib.c lbaselib.c lcorolib.c
        ldblib.c liolib.c lmathlib.c loadlib.c loslib.c lstrlib.c ltablib.c lutf8lib.c linit.c
        '''.split()

--- a/tools/ports/contrib/lua.py
+++ b/tools/ports/contrib/lua.py
@@ -32,7 +32,7 @@ def get(ports, settings, shared):
     # install headers
     includes = ['lua.h', 'lua.hpp', 'luaconf.h', 'lauxlib.h', 'lualib.h']
     for f in includes:
-      ports.install_headers(source_path, pattern=f, target='lua')
+      ports.install_headers(source_path, pattern=f)
 
     srcs = '''
        lapi.c lcode.c lctype.c ldebug.c ldo.c ldump.c lfunc.c lgc.c llex.c lmem.c lobject.c lopcodes.c
@@ -49,7 +49,3 @@ def get(ports, settings, shared):
 
 def clear(ports, settings, shared):
   shared.cache.erase_lib(get_lib_name(settings))
-
-
-def process_args(ports):
-  return ['-isystem', ports.get_include_dir('lua')]


### PR DESCRIPTION
I don't know if there is any interest, but I wrote a port of lua, which allows to embed lua directly in C/C++ in Emscripten without having to deal with how to fetch/compile (which is the point of Emscripten ports...).

It's ok if you do not want to add it to Emscripten, since with external port, I can push it instead to my other [project](https://github.com/pongasoft/emscripten-ports).

A "hello world" program that would use this is

```c
#include <lua.h>
#include <lualib.h>
#include <lauxlib.h>
#include <stdio.h>

int main()
{
  // Create a new Lua state
  lua_State *L = luaL_newstate();

  // Load standard Lua libraries (for print)
  luaL_openlibs(L);

  // Execute Lua code
  if(luaL_dostring(L, "print('hello world')") != LUA_OK)
  {
    printf("Error running Lua code %s\n", lua_tostring(L, -1));
    lua_pop(L, 1); // Remove the error message from the stack
  }

  // Close the Lua state
  lua_close(L);

  return 0;
}
```

and is compiled like this:

```sh
emcc --use-port=contrib.lua main.c -o /tmp/build/index.html
```

I did not change any documentation or Changelog, since I did not want to do extra work if this PR does not go any further. But I will of course update this PR with these changes, if it there is interest.

Let me know. I am fine either way.