### PR TITLE
Fix -sMODULARIZE + -sLEGACY_VM_SUPPORT

### DIFF
--- a/src/lib/libglemu.js
+++ b/src/lib/libglemu.js
@@ -61,11 +61,6 @@ var LibraryGLEmulation = {
     '/**@suppress {duplicate, undefinedVars}*/var _emscripten_glEnableVertexAttribArray;' +
     '/**@suppress {duplicate, undefinedVars}*/var _emscripten_glDisableVertexAttribArray;' +
     '/**@suppress {duplicate, undefinedVars}*/var _emscripten_glVertexAttribPointer;' +
-    '/**@suppress {duplicate, undefinedVars}*/var _glTexEnvf;' +
-    '/**@suppress {duplicate, undefinedVars}*/var _glTexEnvi;' +
-    '/**@suppress {duplicate, undefinedVars}*/var _glTexEnvfv;' +
-    '/**@suppress {duplicate, undefinedVars}*/var _glGetTexEnviv;' +
-    '/**@suppress {duplicate, undefinedVars}*/var _glGetTexEnvfv;' +
 #endif
     'GLEmulation.init();',
   $GLEmulation: {

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7098,6 +7098,9 @@ Descriptor desc;
     self.run_process([EMXX, 'src.cpp', '-O2', '-sEXPORT_ALL'])
     self.assertExists('a.out.js')
 
+  def test_modularize_legacy(self):
+    self.do_runf('hello_world.c', emcc_args=['-sMODULARIZE', '-sLEGACY_VM_SUPPORT'])
+
   def test_emmake_emconfigure(self):
     def check(what, args, fail=True, expect=''):
       args = [what] + args

--- a/tools/building.py
+++ b/tools/building.py
@@ -511,7 +511,7 @@ def version_split(v):
 @ToolchainProfiler.profile()
 def transpile(filename):
   config = {
-    'sourceType': 'script',
+    'sourceType': 'module',
     'targets': {}
   }
   if settings.MIN_CHROME_VERSION != UNSUPPORTED:


### PR DESCRIPTION
When we run babel in `-sMODULARIZE` mode the input to babel contains `await` calls.  This code appears to be top-level code at the point at which we run babel since we have yet to perform the modularization process which wraps the output in a factory function.

Fixes: #23687