### PR TITLE
[WasmFS] Ignore fcntl F_SETLK (inter-process file locking)

### DIFF
--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -794,7 +794,11 @@ var SyscallsLibrary = {
       }
       case {{{ cDefs.F_SETLK }}}:
       case {{{ cDefs.F_SETLKW }}}:
-        return 0; // Pretend that the locking is successful.
+        // Pretend that the locking is successful. These are process-level locks,
+        // and Emscripten programs are a single process. If we supported linking a
+        // filesystem between programs, we'd need to do more here.
+        // See https://github.com/emscripten-core/emscripten/issues/23697
+        return 0;
 #if SYSCALL_DEBUG
       case {{{ cDefs.F_GETOWN_EX }}}:
       case {{{ cDefs.F_SETOWN }}}:

--- a/system/lib/libc/emscripten_libc_stubs.c
+++ b/system/lib/libc/emscripten_libc_stubs.c
@@ -147,8 +147,10 @@ weak void setgrent(void) {
 // ==========================================================================
 
 weak int flock(int fd, int operation) {
-  // int flock(int fd, int operation);
-  // Pretend to succeed
+  // Pretend that the locking is successful. These are process-level locks,
+  // and Emscripten programs are a single process. If we supported linking a
+  // filesystem between programs, we'd need to do more here.
+  // See https://github.com/emscripten-core/emscripten/issues/23697
   return 0;
 }
 

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1521,8 +1521,11 @@ int __syscall_fcntl64(int fd, int cmd, ...) {
     case F_SETLKW: {
       static_assert(F_SETLK == F_SETLK64);
       static_assert(F_SETLKW == F_SETLKW64);
-      // Always error for now, until we implement byte-range locks.
-      return -EACCES;
+      // Pretend that the locking is successful. These are process-level locks,
+      // and Emscripten programs are a single process. If we supported linking a
+      // filesystem between programs, we'd need to do more here.
+      // See https://github.com/emscripten-core/emscripten/issues/23697
+      return 0;
     }
     default: {
       // TODO: support any remaining cmds

--- a/test/sqlite/test.c
+++ b/test/sqlite/test.c
@@ -32,20 +32,22 @@ int main(){
     NULL
   };
 
-  rc = sqlite3_open(":memory:", &db);
-  if( rc ){
-    fprintf(stderr, "Can't open database: %s\n", sqlite3_errmsg(db));
+  rc = sqlite3_open("test.db", &db);
+  if (rc) {
+    printf("Can't open database: %s\n", sqlite3_errmsg(db));
     sqlite3_close(db);
     exit(1);
   }
+
   for (i = 0; commands[i]; i++) {
     rc = sqlite3_exec(db, commands[i], callback, 0, &zErrMsg);
-    if( rc!=SQLITE_OK ){
-      fprintf(stderr, "SQL error on %d: %s\n", i, zErrMsg);
+    if (rc != SQLITE_OK){
+      printf("SQL error on %d: %s\n", i, zErrMsg);
       sqlite3_free(zErrMsg);
       exit(1);
     }
   }
+
   sqlite3_close(db);
   return 0;
 }

--- a/test/sqlite/test.out
+++ b/test/sqlite/test.out
@@ -1,7 +1,5 @@
 count(*) = 2
 
-datetime('2012-04-16 12:35:57', '+1 days') = 2012-04-17 12:35:57
-
 a = 1
 b = 13153
 c = thirteen thousand one hundred fifty three

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6661,6 +6661,7 @@ void* operator new(size_t size) {
   @no_asan('local count too large for VMs')
   @no_ubsan('local count too large for VMs')
   @is_slow_test
+  @also_with_wasmfs
   @parameterized({
     '': (False,),
     'pthreads': (True,),
@@ -6670,7 +6671,7 @@ void* operator new(size_t size) {
       self.emcc_args.append('-pthread')
       self.setup_node_pthreads()
     self.emcc_args += ['-sUSE_SQLITE3']
-    self.do_run_in_out_file_test('sqlite/benchmark.c')
+    self.do_run_in_out_file_test('sqlite/test.c')
 
   @needs_make('mingw32-make')
   @is_slow_test


### PR DESCRIPTION
This is the current behaviour of the legacy FS and the flock function so it seems reasonable to do the same thing, at least for now.  See #23697


This fixes sqlite which makes use of this fcntl to lock the database when accessing it from multiple different processes.

Fixes: #23692