### PR TITLE
[test] Update testsuite to match python3.12 changes. NFC

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -107,6 +107,9 @@ class BufferedParallelTestResult():
   def test(self):
     return self.buffered_result.test
 
+  def addDuration(self, test, elapsed):
+    pass
+
   def updateResult(self, result):
     result.startTest(self.test)
     self.buffered_result.updateResult(result)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10371,7 +10371,7 @@ int main() {
     # has "sourcesContent" entry with source code (included with `-s` option)
     self.assertIn('int foo()', output)
     # has some entries
-    self.assertRegexpMatches(output, r'"mappings":\s*"[A-Za-z0-9+/]')
+    self.assertRegex(output, r'"mappings":\s*"[A-Za-z0-9+/]')
 
   def test_wasm_sourcemap_dead(self):
     wasm_map_cmd = [PYTHON, path_from_root('tools/wasm-sourcemap.py'),
@@ -10383,7 +10383,7 @@ int main() {
     self.run_process(wasm_map_cmd, stdout=PIPE, stderr=PIPE)
     output = read_file('a.out.wasm.map')
     # has only two entries
-    self.assertRegexpMatches(output, r'"mappings":\s*"[A-Za-z0-9+/]+,[A-Za-z0-9+/]+"')
+    self.assertRegex(output, r'"mappings":\s*"[A-Za-z0-9+/]+,[A-Za-z0-9+/]+"')
 
   def test_wasm_sourcemap_relative_paths(self):
     ensure_dir('build')


### PR DESCRIPTION
I'm not sure if it was a major or minor update but these changes are now needed with the latest version of python3.12 which is the default on my debian-based desktop at work.