### PR TITLE
[test] Existing AudioWorklet futex test moved to browser tests (now audio works)

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5512,6 +5512,13 @@ Module["preRun"] = () => {
     shutil.copy(test_file('webaudio/audio_files/emscripten-bass.mp3'), 'audio_files/')
     self.btest_exit('webaudio/audioworklet_in_out_stereo.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-DBROWSER_TEST'] + args)
 
+  # Tests AudioWorklet with emscripten_futex_wake().
+  @requires_sound_hardware
+  @also_with_minimal_runtime
+  @disabled('https://github.com/emscripten-core/emscripten/issues/22962')
+  def test_audio_worklet_emscripten_futex_wake(self):
+    self.btest('webaudio/audioworklet_emscripten_futex_wake.cpp', expected='0', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-pthread', '-sPTHREAD_POOL_SIZE=2'])
+
   def test_error_reporting(self):
     # Test catching/reporting Error objects
     create_file('post.js', 'throw new Error("oops");')

--- a/test/test_interactive.py
+++ b/test/test_interactive.py
@@ -293,11 +293,6 @@ class interactive(BrowserCore):
     self.btest('webaudio/audioworklet.c', expected='0', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '--preload-file', test_file('hello_world.c') + '@/'])
     self.btest('webaudio/audioworklet.c', expected='0', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-pthread'])
 
-  # Tests AudioWorklet with emscripten_futex_wake().
-  @also_with_minimal_runtime
-  def test_audio_worklet_emscripten_futex_wake(self):
-    self.btest('webaudio/audioworklet_emscripten_futex_wake.cpp', expected='0', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-pthread', '-sPTHREAD_POOL_SIZE=2'])
-
   # Tests a second AudioWorklet example: sine wave tone generator.
   def test_audio_worklet_tone_generator(self):
     self.btest('webaudio/audio_worklet_tone_generator.c', expected='0', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])

--- a/test/webaudio/audioworklet_emscripten_futex_wake.cpp
+++ b/test/webaudio/audioworklet_emscripten_futex_wake.cpp
@@ -13,6 +13,9 @@
 int futexLocation = 0;
 int testSuccess = 0;
 
+// Internal, found in 'system/lib/pthread/threading_internal.h'
+extern "C" int _emscripten_thread_supports_atomics_wait();
+
 bool ProcessAudio(int numInputs, const AudioSampleFrame *inputs, int numOutputs, AudioSampleFrame *outputs, int numParams, const AudioParamFrame *params, void *userData) {
   int supportsAtomicWait = _emscripten_thread_supports_atomics_wait();
   printf("supportsAtomicWait: %d\n", supportsAtomicWait);


### PR DESCRIPTION
Now that the audio tests are running in CI (see #23665) this existing AudioWorklet/futex test can be moved from `interactive` to `browser`:

https://github.com/emscripten-core/emscripten/blob/32832575e0d200afcccd1d892ff3555baf54bc83/test/webaudio/audioworklet_emscripten_futex_wake.cpp

It's had the bare minimum to enable it to compile but is otherwise broken and therefore disabled. The issue is here #22962.

A fix is [already done](https://github.com/cwoffenden/emscripten/tree/cw-audio-spinlock-fix) with more advanced lock tests, but needs this to land first to get things in the right order.

To confirm the test is broken, comment out the `@disabled` in line 5518 and run with:
```
test/runner browser.test_audio_worklet_emscripten_futex_wake
```

It will fail with:
```
test.js:1003 Uncaught RuntimeError: Aborted(Assertion failed: emscripten_is_main_browser_thread(), at: /emsdk/emscripten/system/lib/pthread/emscripten_futex_wait.c,26,futex_wait_main_browser_thread)
    at abort (test.js:1003:11)
    at ___assert_fail (test.js:1945:7)
    at test.wasm:0x10a8
    at test.wasm:0xf34
    at test.wasm:0xa78
    at WasmAudioWorkletProcessor.process (test.aw.js:113:34)
```

@sbc100 This is the last of my planned additions to the audio tests, next are the fixes.