### PR TITLE
Add preprocessor builtin __EMSCRIPTEN_HAS_ASYNCIFY__

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -439,6 +439,10 @@ def get_cflags(user_args):
   if settings.WASM_WORKERS:
     cflags.append('-D__EMSCRIPTEN_WASM_WORKERS__=1')
 
+  if settings.ASYNCIFY:
+    # Note this macro doesn't care whether we're using JSPI or not.
+    cflags.append('-D__EMSCRIPTEN_HAS_ASYNCIFY__=1')
+
   if not settings.STRICT:
     # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code
     # in strict mode. Code should use the define __EMSCRIPTEN__ instead.

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -1090,6 +1090,7 @@ Functions
 .. c:function:: int emscripten_has_asyncify()
 
   Returns whether pseudo-synchronous functions can be used.
+  (Use the preprocessor macro ``__EMSCRIPTEN_HAS_ASYNCIFY__`` if compile-time switching is needed.)
 
   :rtype: int
   :returns: 1 if program was compiled with -sASYNCIFY, 0 otherwise.


### PR DESCRIPTION
Proposal.
This can be useful in libraries which want to provide additional features when Asyncify is available. It is similar to emscripten_has_asyncify(), but since it's a macro it can reduce code size. (We want to use it in `webgpu.cpp`, but without requiring some build file setup that will set a custom preprocessor macro correctly.)