### PR TITLE
Avoid node TimeoutNegativeWarning in emscripten_set_timeout_loop

### DIFF
--- a/src/lib/libeventloop.js
+++ b/src/lib/libeventloop.js
@@ -135,11 +135,16 @@ LibraryJSEventLoop = {
       {{{ runtimeKeepalivePop() }}}
       callUserCallback(() => {
         if ({{{ makeDynCall('idp', 'cb') }}}(t, userData)) {
+          {{{ runtimeKeepalivePush() }}}
           // Save a little bit of code space: modern browsers should treat
           // negative setTimeout as timeout of 0
           // (https://stackoverflow.com/questions/8430966/is-calling-settimeout-with-a-negative-delay-ok)
-          {{{ runtimeKeepalivePush() }}}
-          setTimeout(tick, n - _emscripten_get_now());
+          var remaining = n - _emscripten_get_now();
+#if ENVIRONMENT_MAY_BE_NODE
+          // Recent revsions of node, however, give TimeoutNegativeWarning
+          remaining = Math.max(0, remaining);
+#endif
+          setTimeout(tick, remaining);
         }
       });
     }


### PR DESCRIPTION
This restores the two different paths for calculating the remaining milliseconds which was removed in #12122.

Inspired by #23716