### PR TITLE
Avoid unnecessary globalThis usage when defining JS library macros

### DIFF
--- a/src/lib/libegl.js
+++ b/src/lib/libegl.js
@@ -17,11 +17,12 @@
 
 {{{
 // Magic ID for Emscripten 'default display' 
-globalThis.eglDefaultDisplay = 62000;
+const eglDefaultDisplay = 62000;
 // Magic ID for the only EGLConfig supported by Emscripten
-globalThis.eglDefaultConfig = 62002;
+const eglDefaultConfig = 62002;
 // Magic ID for Emscripten EGLContext
-globalThis.eglDefaultContext = 62004;
+const eglDefaultContext = 62004;
+null;
 }}}
 
 var LibraryEGL = {

--- a/src/lib/libemval.js
+++ b/src/lib/libemval.js
@@ -17,9 +17,9 @@
 /*global emval_get_global*/
 
 // Number of handles reserved for non-use (0) or common values w/o refcount.
-{{{ 
-  globalThis.EMVAL_RESERVED_HANDLES = 5;
-  globalThis.EMVAL_LAST_RESERVED_HANDLE = globalThis.EMVAL_RESERVED_HANDLES * 2 - 1;
+{{{
+  const EMVAL_RESERVED_HANDLES = 5;
+  const EMVAL_LAST_RESERVED_HANDLE = EMVAL_RESERVED_HANDLES * 2 - 1;
   null;
 }}}
 var LibraryEmVal = {

--- a/src/lib/libglemu.js
+++ b/src/lib/libglemu.js
@@ -5,11 +5,11 @@
  */
 
 {{{
-  globalThis.copySigs = (func) => {
+  const copySigs = (func) => {
     if (!RELOCATABLE) return '';
     return ` _${func}.sig = _emscripten_${func}.sig = orig_${func}.sig;`;
   };
-  globalThis.fromPtr = (arg) => {
+  const fromPtr = (arg) => {
     if (CAN_ADDRESS_2GB) {
       return `${arg} >>>= 0`;
     } else if (MEMORY64) {

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -25,15 +25,15 @@
 
 {{{
 #if MEMORY64
-globalThis.MAX_PTR = Number((2n ** 64n) - 1n);
+const MAX_PTR = Number((2n ** 64n) - 1n);
 #else
-globalThis.MAX_PTR = (2 ** 32) - 1
+const MAX_PTR = (2 ** 32) - 1
 #endif
 // Use a macro to avoid duplicating pthread worker options.
 // We cannot use a normal JS variable since the vite bundler requires that worker
 // options be inline.
 // See https://github.com/emscripten-core/emscripten/issues/22394
-globalThis.pthreadWorkerOptions = `{
+const pthreadWorkerOptions = `{
 #if EXPORT_ES6
         'type': 'module',
 #endif

--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -7,9 +7,9 @@
 #if WASM_WORKERS == 2
 // Helpers for _wasmWorkerBlobUrl used in WASM_WORKERS == 2 mode
 {{{
-  globalThis.captureModuleArg = () => MODULARIZE ? '' : 'self.Module=d;';
-  globalThis.instantiateModule = () => MODULARIZE ? `${EXPORT_NAME}(d);` : '';
-  globalThis.instantiateWasm = () => MINIMAL_RUNTIME ? '' : 'd[`instantiateWasm`]=(i,r)=>{var n=new WebAssembly.Instance(d[`wasm`],i);return r(n,d[`wasm`]);};';
+  const captureModuleArg = () => MODULARIZE ? '' : 'self.Module=d;';
+  const instantiateModule = () => MODULARIZE ? `${EXPORT_NAME}(d);` : '';
+  const instantiateWasm = () => MINIMAL_RUNTIME ? '' : 'd[`instantiateWasm`]=(i,r)=>{var n=new WebAssembly.Instance(d[`wasm`],i);return r(n,d[`wasm`]);};';
   null;
 }}}
 #endif
@@ -33,7 +33,7 @@
 #endif
 
 {{{
-  globalThis.workerSupportsFutexWait = () => AUDIO_WORKLET ? "typeof AudioWorkletGlobalScope === 'undefined'" : '1';
+  const workerSupportsFutexWait = () => AUDIO_WORKLET ? "typeof AudioWorkletGlobalScope === 'undefined'" : '1';
   null;
 }}}
 

--- a/src/lib/libwebgl.js
+++ b/src/lib/libwebgl.js
@@ -6,15 +6,15 @@
 
 // Specifies the size of the GL temp buffer pool, in bytes. Must be a multiple
 // of 9 and 16.
-{{{ GL_POOL_TEMP_BUFFERS_SIZE = 2*9*16 }}} // = 288
-
 {{{
-  globalThis.isCurrentContextWebGL2 = () => {
+  const GL_POOL_TEMP_BUFFERS_SIZE = 2*9*16 // = 288
+
+  const isCurrentContextWebGL2 = () => {
     // This function should only be called inside of `#if MAX_WEBGL_VERSION >= 2` blocks
     assert(MAX_WEBGL_VERSION >= 2, 'isCurrentContextWebGL2 called without webgl2 support');
     if (MIN_WEBGL_VERSION >= 2) return 'true';
     return 'GL.currentContext.version >= 2';
-  };
+  }
   null;
 }}}
 

--- a/src/lib/libwebgpu.js
+++ b/src/lib/libwebgpu.js
@@ -28,7 +28,7 @@
 
 {{{
   // Helper functions for code generation
-  globalThis.gpu = {
+  const gpu = {
     makeInitManager: function(type) {
       return `WebGPU.mgr${type} = new Manager();`;
     },


### PR DESCRIPTION
When the macro only need to be available to other library files this is not needed.