### PR TITLE
[jscompiler] Cleanup warn/warnOnce utility functions. NFC

### DIFF
--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -62,26 +62,16 @@ function errorPrefix() {
   }
 }
 
-export function warn(a, msg) {
+export function warn(msg) {
   warnings = true;
-  if (!msg) {
-    msg = a;
-    a = false;
-  }
-  if (!a) {
-    printErr(`warning: ${errorPrefix()}${msg}`);
-  }
+  printErr(`warning: ${errorPrefix()}${msg}`);
 }
 
-export function warnOnce(a, msg) {
-  if (!msg) {
-    msg = a;
-    a = false;
-  }
-  if (!a) {
-    warnOnce.msgs ||= {};
-    if (msg in warnOnce.msgs) return;
-    warnOnce.msgs[msg] = true;
+const seenWarnings = new Set();
+
+export function warnOnce(msg) {
+  if (!seenWarnings.has(msg)) {
+    seenWarnings.add(msg);
     warn(msg);
   }
 }


### PR DESCRIPTION
I'm not sure why we have the two argument versions of these functions.

The two-argument version of warnOnce was introduced in ca58e84149 but doesn't seem to have ever had any callers.

The two-argument version of `warn` was introduced in 46e3b2a787, but I can't see any users of it from back then.  It was modified to take a single argument in 06b58cbbe.