### PR TITLE
[test] Remove check for `strict warnings:` in JS stdout. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1554,8 +1554,6 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       else:
         self.fail('JS subprocess failed (%s): %s (expected=%s).  Output:\n%s' % (error.cmd, error.returncode, assert_returncode, ret))
 
-    #  We should pass all strict mode checks
-    self.assertNotContained('strict warning:', ret)
     return ret
 
   def assertExists(self, filename, msg=None):


### PR DESCRIPTION
This check was added back in 2011: acbb1e6a.  It looks like it was combined with a `-s` spidermonkey flag.  However, `-s` is not longer a valid spidermonkey flag and the string "strict warnings" does not appear in the v8 or spidermonkey source today.