### PR TITLE
[test] Rename AudioWorklet lock test file

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5522,7 +5522,7 @@ Module["preRun"] = () => {
   @requires_sound_hardware
   @also_with_minimal_runtime
   def test_audio_worklet_emscripten_locks(self):
-    self.btest_exit('webaudio/audioworklet_emscripten_futex_wake.cpp', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-pthread'])
+    self.btest_exit('webaudio/audioworklet_emscripten_locks.c', args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-pthread'])
 
   def test_error_reporting(self):
     # Test catching/reporting Error objects

--- a/test/webaudio/audioworklet_emscripten_locks.c
+++ b/test/webaudio/audioworklet_emscripten_locks.c
@@ -14,7 +14,7 @@
 // - emscripten_get_now()
 
 // Internal, found in 'system/lib/pthread/threading_internal.h' (and requires building with -pthread)
-extern "C" int _emscripten_thread_supports_atomics_wait(void);
+int _emscripten_thread_supports_atomics_wait(void);
 
 typedef enum {
   // No wait support in audio worklets


### PR DESCRIPTION
Performed as a separate step from #23729 to not lose the history. The C++ file had already been converted to C as part of the previous PR, this now updates the filename and its extension.