### PR TITLE
Fix off-by-one error in wasmfs getcwd

### DIFF
--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -776,7 +776,7 @@ int __syscall_getcwd(intptr_t buf, size_t size) {
 
   // Check if the size argument is less than the length of the absolute
   // pathname of the working directory, including null terminator.
-  if (len >= size) {
+  if (len > size) {
     return -ERANGE;
   }
 

--- a/test/wasmfs/wasmfs_chdir.c
+++ b/test/wasmfs/wasmfs_chdir.c
@@ -16,14 +16,27 @@
 #include <unistd.h>
 
 int main() {
+  char cwd[100];
+
   // Set up test directories.
   assert(mkdir("working", 0777) != -1);
   assert(mkdir("/working/test", 0777) != -1);
 
-  // Try to print the root directory.
-  char cwd[100];
+  // Try to pass a size of 0.
+  errno = 0;
+  getcwd(cwd, 0);
+  printf("Errno: %s\n", strerror(errno));
+  assert(errno == EINVAL);
+
+  // Try to write to a buffer of size 1.
+  errno = 0;
+  getcwd(cwd, 1);
+  assert(errno == ERANGE);
+
+  // Try to print the root directory, using size 2
   char* ret;
-  ret = getcwd(cwd, sizeof(cwd));
+  errno = 0;
+  ret = getcwd(cwd, 2);
   assert(ret == cwd);
   printf("Current working dir: %s\n", cwd);
 
@@ -86,16 +99,5 @@ int main() {
   assert(ret == cwd);
   printf("Current working dir is still: %s\n", cwd);
 
-  // Try to pass a size of 0.
-  errno = 0;
-  getcwd(cwd, 0);
-  printf("Errno: %s\n", strerror(errno));
-  assert(errno == EINVAL);
-
-  // Try to write to a buffer of size 1.
-  errno = 0;
-  char smallBuffer[1];
-  getcwd(smallBuffer, 1);
-  assert(errno == ERANGE);
   return 0;
 }

--- a/test/wasmfs/wasmfs_chdir.out
+++ b/test/wasmfs/wasmfs_chdir.out
@@ -1,3 +1,4 @@
+Errno: Invalid argument
 Current working dir: /
 Current working dir: /working
 Current working dir: /
@@ -11,4 +12,3 @@ Current working dir is still: /working
 Current working dir: /dev
 Errno: Not a directory
 Current working dir is still: /dev
-Errno: Invalid argument


### PR DESCRIPTION
When the buffer is exactly the correct size wasmfs was incorrectly erroring out.