### PR TITLE
Make 'instantiateWasm' callback resolve the result return from 'recei…

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -990,8 +990,7 @@ function getWasmImports() {
       try {
 #endif
         Module['instantiateWasm'](info, (mod, inst) => {
-          receiveInstance(mod, inst);
-          resolve(mod.exports);
+          resolve(receiveInstance(mod, inst));
         });
 #if ASSERTIONS
       } catch(e) {


### PR DESCRIPTION
In js output content. 

When ASYNCIFY enabled, wasmExports modified by **Asyncify.instrumentWasmExports**. [source](https://github.com/emscripten-core/emscripten/blob/4b7653130284439898345419f2990c1e14fa60a1/src/preamble.js#L871)

But when **Module['instantiateWasm']** used. The **createWasm** function will always resolve the original wasmExports. [source](https://github.com/emscripten-core/emscripten/blob/4b7653130284439898345419f2990c1e14fa60a1/src/preamble.js#L994).

It will case crash when async C++ function rewind.

So I make 'instantiateWasm' callback resolve the result return from 'receiveInstance'.