### PR TITLE
Remove unused arguments from makeGetValue

### DIFF
--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -406,27 +406,13 @@ function asmFloatToInt(x) {
 }
 
 // See makeSetValue
-function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, _ignore, align) {
-  assert(typeof align === 'undefined', 'makeGetValue no longer supports align parameter');
-  assert(
-    typeof noNeedFirst === 'undefined',
-    'makeGetValue no longer supports noNeedFirst parameter',
-  );
-  if (typeof unsigned !== 'undefined') {
-    // TODO(sbc): make this into an error at some point.
-    printErr(
-      'makeGetValue: Please use u8/u16/u32/u64 unsigned types in favor of additional argument',
-    );
-    if (unsigned && type.startsWith('i')) {
-      type = `u${type.slice(1)}`;
-    }
-  } else if (type.startsWith('u')) {
-    // Set `unsigned` based on the type name.
-    unsigned = true;
-  }
+function makeGetValue(ptr, pos, type) {
+  assert(arguments.length == 3, 'makeGetValue expects 3 arguments');
 
   const offset = calcFastOffset(ptr, pos);
   if (type === 'i53' || type === 'u53') {
+    // Set `unsigned` based on the type name.
+    const unsigned = type.startsWith('u');
     return `readI53From${unsigned ? 'U' : 'I'}64(${offset})`;
   }
 

--- a/test/other/test_parseTools.js
+++ b/test/other/test_parseTools.js
@@ -55,11 +55,6 @@ addToLibrary({
     out('u32: ' + val.toString(16))
     assert(val == 0xedcba988);
 
-    // unsigned i32 (legacy)
-    val = {{{ makeGetValue('ptr', '0', 'i32', undefined, /*unsigned=*/true) }}};
-    out('u32 legacy: ' + val.toString(16))
-    assert(val == 0xedcba988);
-
     // i16
     val = {{{ makeGetValue('ptr', '0', 'i16') }}};
     out('i16: ' + val.toString(16))
@@ -70,11 +65,6 @@ addToLibrary({
     out('u16: ' + val.toString(16))
     assert(val == 43400);
 
-    // unsigned i16 (legacy)
-    val = {{{ makeGetValue('ptr', '0', 'i16', undefined, /*unsigned=*/true) }}};
-    out('u16 legacy: ' + val.toString(16))
-    assert(val == 43400);
-
     // i8
     val = {{{ makeGetValue('ptr', '0', 'i8') }}};
     out('i8: ' + val.toString(16))
@@ -83,11 +73,6 @@ addToLibrary({
     // u8
     val = {{{ makeGetValue('ptr', '0', 'u8') }}};
     out('u8: ' + val.toString(16))
-    assert(val == 0x88);
-
-    // unsigned i8 (legacy)
-    val = {{{ makeGetValue('ptr', '0', 'i8', undefined, /*unsigned=*/true) }}};
-    out('u8 legacy: ' + val.toString(16))
     assert(val == 0x88);
 
     // pointer

--- a/test/other/test_parseTools.out
+++ b/test/other/test_parseTools.out
@@ -7,13 +7,10 @@ i53: -aabb12345678
 u53: ffff5544edcba800
 i32: -12345678
 u32: edcba988
-u32 legacy: edcba988
 i16: -5678
 u16: a988
-u16 legacy: a988
 i8: -78
 u8: 88
-u8 legacy: 88
 ptr: edcba988
 ptr: edcba988
 


### PR DESCRIPTION
The last 4 arguments to this helper function are no used and we have had assertions in the code a for while now with no reports of folks depending on these.