### PR TITLE
Use `warn` for printing `#warning` messages in JS libraries

### DIFF
--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -180,7 +180,7 @@ export function preprocess(filename) {
           showStack.pop();
         } else if (first === '#warning') {
           if (showCurrentLine()) {
-            printErr(
+            warn(
               `${filename}:${i + 1}: #warning ${trimmed.substring(trimmed.indexOf(' ')).trim()}`,
             );
           }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -4919,6 +4919,13 @@ extraLibraryFuncs.push('jsfunc');
     self.assertNotContained('This warning should not be present!', proc.stderr)
     self.assertContained('warning_in_js_libraries.js:5: #warning This is a warning string!', proc.stderr)
     self.assertContained('warning_in_js_libraries.js:7: #warning This is a second warning string!', proc.stderr)
+    self.assertContained('emcc: warning: warnings in JS library compilation [-Wjs-compiler]', proc.stderr)
+
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '--js-library', test_file('warning_in_js_libraries.js'), '-Werror'])
+    self.assertNotContained('This warning should not be present!', err)
+    self.assertContained('warning_in_js_libraries.js:5: #warning This is a warning string!', err)
+    self.assertContained('warning_in_js_libraries.js:7: #warning This is a second warning string!', err)
+    self.assertContained('emcc: error: warnings in JS library compilation [-Wjs-compiler] [-Werror]', err)
 
   # Tests using the #error directive in JS library files
   def test_jslib_errors(self):


### PR DESCRIPTION
Previously we were only writing the message to stderr, and not recording it as an actual warning.  After this change, such messages are now reported as warnings and controllable using `-Werror`, etc.