### PR TITLE
Remove unused JS library function: `jstoi_s`. NFC

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1658,11 +1658,6 @@ addToLibrary({
   $jstoi_q__docs: '/** @suppress {checkTypes} */',
   $jstoi_q: (str) => parseInt(str),
 
-  // Converts a JS string to an integer base-10, with signaling error
-  // handling (throws a JS exception on error). E.g. jstoi_s("123abc")
-  // throws an exception.
-  $jstoi_s: 'Number',
-
 #if LINK_AS_CXX
   // libunwind
 


### PR DESCRIPTION
This function was also mis-documented.  Its was added #10457 but even then it was unused only add because "good to have for completeness".

However, the behavior of the JS `Number` function is not as described in the comment.  Instead `Number("123abc")` returns NaN.

On balance I think its better to just remove it.