### PR TITLE
Remove unnecessary usage of jstoi_q. NFC

### DIFF
--- a/src/lib/libatomic.js
+++ b/src/lib/libatomic.js
@@ -22,7 +22,7 @@ addToLibrary({
   //   https://github.com/tc39/proposal-atomics-wait-async/blob/master/PROPOSAL.md
   // This polyfill performs polling with setTimeout() to observe a change in the
   // target memory location.
-  $polyfillWaitAsync__postset: `if (!Atomics.waitAsync || (typeof navigator != 'undefined' && navigator.userAgent && jstoi_q((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91)) {
+  $polyfillWaitAsync__postset: `if (!Atomics.waitAsync || (typeof navigator != 'undefined' && navigator.userAgent && Number((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91)) {
   let __Atomics_waitAsyncAddresses = [/*[i32a, index, value, maxWaitMilliseconds, promiseResolve]*/];
   function __Atomics_pollWaitAsyncAddresses() {
     let now = performance.now();
@@ -60,7 +60,6 @@ addToLibrary({
     return { async: true, value: promise };
   };
 }`,
-  $polyfillWaitAsync__deps: ['$jstoi_q'],
 #endif
 
   $polyfillWaitAsync__internal: true,

--- a/src/lib/libc_preprocessor.js
+++ b/src/lib/libc_preprocessor.js
@@ -35,7 +35,7 @@ addToLibrary({
   // Runs C preprocessor algorithm on the given string 'code'.
   // Supported preprocessor directives: #if, #ifdef, #ifndef, #else, #elif, #endif, #define and #undef.
   // predefs: Specifies a dictionary of { 'key1': function(arg0, arg1) {...}, 'key2': ... } of predefined preprocessing variables
-  $preprocess_c_code__deps: ['$jstoi_q', '$find_closing_parens_index'],
+  $preprocess_c_code__deps: ['$find_closing_parens_index'],
   $preprocess_c_code: function(code, defs = {}) {
     var i = 0, // iterator over the input string
       len = code.length, // cache input length
@@ -207,7 +207,7 @@ addToLibrary({
           if (tokens[i] == ')') throw 'Parsing failure, mismatched parentheses in parsing!' + tokens.toString();
           assert(operatorAndPriority == -1);
 #endif
-          var num = jstoi_q(tokens[i]);
+          var num = Number(tokens[i]);
           return [function() { return num; }]
         })(tokens);
       }

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -647,7 +647,7 @@ addToLibrary({
   },
   $inetNtop4: (addr) =>
     (addr & 0xff) + '.' + ((addr >> 8) & 0xff) + '.' + ((addr >> 16) & 0xff) + '.' + ((addr >> 24) & 0xff),
-  $inetPton6__deps: ['htons', '$jstoi_q'],
+  $inetPton6__deps: ['htons'],
   $inetPton6: (str) => {
     var words;
     var w, offset, z, i;
@@ -671,8 +671,8 @@ addToLibrary({
       // parse IPv4 embedded stress
       str = str.replace(new RegExp('[.]', 'g'), ":");
       words = str.split(":");
-      words[words.length-4] = jstoi_q(words[words.length-4]) + jstoi_q(words[words.length-3])*256;
-      words[words.length-3] = jstoi_q(words[words.length-2]) + jstoi_q(words[words.length-1])*256;
+      words[words.length-4] = Number(words[words.length-4]) + Number(words[words.length-3])*256;
+      words[words.length-3] = Number(words[words.length-2]) + Number(words[words.length-1])*256;
       words = words.slice(0, words.length-2);
     } else {
       words = str.split(":");

--- a/src/lib/libtime.js
+++ b/src/lib/libtime.js
@@ -257,7 +257,7 @@ addToLibrary({
   },
 
   strptime__deps: ['$isLeapYear', '$arraySum', '$addDays', '$MONTH_DAYS_REGULAR', '$MONTH_DAYS_LEAP',
-                   '$jstoi_q', '$intArrayFromString' ],
+                   '$intArrayFromString' ],
   strptime: (buf, format, tm) => {
     // char *strptime(const char *restrict buf, const char *restrict format, struct tm *restrict tm);
     // http://pubs.opengroup.org/onlinepubs/009695399/functions/strptime.html
@@ -362,21 +362,21 @@ addToLibrary({
 
       // seconds
       if ((value=getMatch('S'))) {
-        date.sec = jstoi_q(value);
+        date.sec = Number(value);
       }
 
       // minutes
       if ((value=getMatch('M'))) {
-        date.min = jstoi_q(value);
+        date.min = Number(value);
       }
 
       // hours
       if ((value=getMatch('H'))) {
         // 24h clock
-        date.hour = jstoi_q(value);
+        date.hour = Number(value);
       } else if ((value = getMatch('I'))) {
         // AM/PM clock
-        var hour = jstoi_q(value);
+        var hour = Number(value);
         if ((value=getMatch('p'))) {
           hour += value.toUpperCase()[0] === 'P' ? 12 : 0;
         }
@@ -386,13 +386,13 @@ addToLibrary({
       // year
       if ((value=getMatch('Y'))) {
         // parse from four-digit year
-        date.year = jstoi_q(value);
+        date.year = Number(value);
       } else if ((value=getMatch('y'))) {
         // parse from two-digit year...
-        var year = jstoi_q(value);
+        var year = Number(value);
         if ((value=getMatch('C'))) {
           // ...and century
-          year += jstoi_q(value)*100;
+          year += Number(value)*100;
         } else {
           // ...and rule-of-thumb
           year += year<69 ? 2000 : 1900;
@@ -403,7 +403,7 @@ addToLibrary({
       // month
       if ((value=getMatch('m'))) {
         // parse from month number
-        date.month = jstoi_q(value)-1;
+        date.month = Number(value)-1;
       } else if ((value=getMatch('b'))) {
         // parse from month name
         date.month = MONTH_NUMBERS[value.substring(0,3).toUpperCase()] || 0;
@@ -413,10 +413,10 @@ addToLibrary({
       // day
       if ((value=getMatch('d'))) {
         // get day of month directly
-        date.day = jstoi_q(value);
+        date.day = Number(value);
       } else if ((value=getMatch('j'))) {
         // get day of month from day of year ...
-        var day = jstoi_q(value);
+        var day = Number(value);
         var leapYear = isLeapYear(date.year);
         for (var month=0; month<12; ++month) {
           var daysUntilMonth = arraySum(leapYear ? MONTH_DAYS_LEAP : MONTH_DAYS_REGULAR, month-1);
@@ -432,7 +432,7 @@ addToLibrary({
           // Week number of the year (Sunday as the first day of the week) as a decimal number [00,53].
           // All days in a new year preceding the first Sunday are considered to be in week 0.
           var weekDayNumber = DAY_NUMBERS_SUN_FIRST[weekDay];
-          var weekNumber = jstoi_q(value);
+          var weekNumber = Number(value);
 
           // January 1st
           var janFirst = new Date(date.year, 0, 1);
@@ -451,7 +451,7 @@ addToLibrary({
           // Week number of the year (Monday as the first day of the week) as a decimal number [00,53].
           // All days in a new year preceding the first Monday are considered to be in week 0.
           var weekDayNumber = DAY_NUMBERS_MON_FIRST[weekDay];
-          var weekNumber = jstoi_q(value);
+          var weekNumber = Number(value);
 
           // January 1st
           var janFirst = new Date(date.year, 0, 1);

--- a/src/lib/libwebgl.js
+++ b/src/lib/libwebgl.js
@@ -3205,7 +3205,7 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
 #if GL_DEBUG
       console.dir(match);
 #endif
-      explicitUniformLocations[match[5]] = jstoi_q(match[1]);
+      explicitUniformLocations[match[5]] = Number(match[1]);
 #if GL_TRACK_ERRORS
       if (!(explicitUniformLocations[match[5]] >= 0 && explicitUniformLocations[match[5]] < 1048576)) {
         err(`Specified an out of range layout(location=x) directive "${explicitUniformLocations[match[5]]}"! (${match[0]})`);


### PR DESCRIPTION
The `jstoi_q` was introduced in #10457 because of issues with using `parseInt` directly and closure compiler.  However, in many cases its simpler to just use `Number`.  See https://github.com/google/closure-compiler/issues/3230

Split out from #23789.