### PR TITLE
Add adjustWasmImports incoming Module setting

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -977,6 +977,12 @@ function getWasmImports() {
 
   var info = getWasmImports();
 
+#if expectToReceiveOnModule('adjustWasmImports')
+  if (Module['adjustWasmImports']) {
+    Module['adjustWasmImports'](info);
+  }
+#endif
+
 #if expectToReceiveOnModule('instantiateWasm')
   // User shell pages can write their own Module.instantiateWasm = function(imports, successCallback) callback
   // to manually instantiate the Wasm module themselves. This allows pages to

--- a/src/settings.js
+++ b/src/settings.js
@@ -999,7 +999,7 @@ var INCOMING_MODULE_JS_API = [
   'SDL_numSimultaneouslyQueuedBuffers', 'INITIAL_MEMORY', 'wasmMemory', 'arguments',
   'buffer', 'canvas', 'doNotCaptureKeyboard', 'dynamicLibraries',
   'elementPointerLock', 'extraStackTrace', 'forcedAspectRatio',
-  'instantiateWasm', 'keyboardListeningElement', 'freePreloadedMediaOnUse',
+  'instantiateWasm', 'adjustWasmImports', 'keyboardListeningElement', 'freePreloadedMediaOnUse',
   'loadSplitModule', 'locateFile', 'logReadFiles', 'mainScriptUrlOrBlob', 'mem',
   'monitorRunDependencies', 'noExitRuntime', 'noInitialRun', 'onAbort',
   'onCustomMessage', 'onExit', 'onFree', 'onFullScreen', 'onMalloc',

--- a/test/other/test_adjust_wasm_imports.c
+++ b/test/other/test_adjust_wasm_imports.c
@@ -1,0 +1,13 @@
+#include "assert.h"
+#include "stdio.h"
+
+int __attribute__((import_module("env"), import_name("js_fun"))) js_func(int x, int y);
+
+int main() {
+    int x = 7;
+    int y = 9;
+    printf("Calling js_func(%d, %d);\n", x, y);
+    int res = js_func(x, y);
+    assert(res == 16);
+    return 0;
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15690,6 +15690,16 @@ addToLibrary({
       }''')
     self.do_runf('test_manual_wasm_instantiate.c', emcc_args=['--pre-js=pre.js'])
 
+  @also_with_modularize
+  def test_adjust_wasm_imports(self):
+    create_file('pre.js', '''
+      Module['adjustWasmImports'] = (imports) => {
+        imports.env.js_fun = (x, y) => x + y;
+      };
+    ''')
+    self.emcc_args.remove('-Werror')
+    self.do_runf('other/test_adjust_wasm_imports.c', emcc_args=['--pre-js=pre.js', '-sERROR_ON_UNDEFINED_SYMBOLS=0'])
+
   def test_late_module_api_assignment(self):
     # When sync instantiation is used (or when async/await is used in MODULARIZE mode) certain
     # Module properties cannot be assigned in `--post-js` code because its too late by the time


### PR DESCRIPTION
This provides a way to add symbols to the `wasmImports` dynamically. This doesn't allow anything new compared to `instantiateWasm` except that it doesn't interfere with sourcemaps or ASAN and it doesn't require reproducing the somewhat tricky behavior in the standard `instantiateWasm` function.

As an alternative, we could expose something like `instantiateWasmDefault` to the user, and then they could do this like:
```js
Module['instantiateWasm'] = (imports, successCallback) => {
   adjustWasmImports(imports);
   instantiateWasmDefault(imports, successCallback);
}
```