### PR TITLE
Avoid converting user JS library paths to absolute paths. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1219,7 +1219,6 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
         options.memory_profiler = True
       newargs[i] = ''
       settings_changes.append('EMSCRIPTEN_TRACING=1')
-      settings.JS_LIBRARIES.append('libtrace.js')
     elif check_flag('--emit-symbol-map'):
       options.emit_symbol_map = True
       settings.EMIT_SYMBOL_MAP = 1

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -5,7 +5,6 @@
  */
 
 import * as path from 'node:path';
-import * as fs from 'node:fs';
 import {fileURLToPath} from 'node:url';
 import assert from 'node:assert';
 
@@ -201,19 +200,14 @@ function calculateLibraries() {
     libraries.push('liblittle_endian_heap.js');
   }
 
+  // Resolve system libraries
+  libraries = libraries.map((filename) => path.join(systemLibdir, filename));
+
   // Add all user specified JS library files to the link.
   // These must be added last after all Emscripten-provided system libraries
   // above, so that users can override built-in JS library symbols in their
   // own code.
   libraries.push(...JS_LIBRARIES);
-
-  // Resolve all filenames to absolute paths
-  libraries = libraries.map((filename) => {
-    if (!path.isAbsolute(filename) && fs.existsSync(path.join(systemLibdir, filename))) {
-      filename = path.join(systemLibdir, filename);
-    }
-    return path.resolve(filename);
-  });
 
   // Deduplicate libraries to avoid processing any library file multiple times
   libraries = libraries.filter((item, pos) => libraries.indexOf(item) == pos);

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -5001,6 +5001,23 @@ extraLibraryFuncs.push('jsfunc');
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js', '-sEXPORTED_FUNCTIONS=obj,_main'])
     self.assertContained('cannot stringify Map with data', err)
 
+  def test_jslib_system_lib_name(self):
+    create_file('libcore.js', r'''
+addToLibrary({
+ jslibfunc: (x) => 2 * x
+});
+''')
+    create_file('src.c', r'''
+#include <emscripten.h>
+#include <stdio.h>
+int jslibfunc(int x);
+int main() {
+  printf("jslibfunc: %d\n", jslibfunc(6));
+  return 0;
+}
+''')
+    self.do_runf('src.c', 'jslibfunc: 12', emcc_args=['--js-library', 'libcore.js'])
+
   def test_EMCC_BUILD_DIR(self):
     # EMCC_BUILD_DIR was necessary in the past since we used to force the cwd to be src/ for
     # technical reasons.

--- a/tools/maint/gen_sig_info.py
+++ b/tools/maint/gen_sig_info.py
@@ -318,6 +318,7 @@ def extract_sig_info(sig_info, extra_settings=None, extra_cflags=None, cxx=False
   }
   if extra_settings:
     settings.update(extra_settings)
+  settings['JS_LIBRARIES'] = [os.path.join(utils.path_from_root('src/lib'), s) for s in settings['JS_LIBRARIES']]
   with tempfiles.get_file('.json') as settings_json:
     utils.write_file(settings_json, json.dumps(settings))
     output = shared.run_js_tool(utils.path_from_root('tools/compiler.mjs'),


### PR DESCRIPTION
System library paths are converted to absolute paths, both in link.py and in modules.mjs, but use JS libraries are left in their original form.

Added a test to confirm that a user library can have the same name as as system library without issue.

Split out from #23787