### PR TITLE
Support blob URLs on ES6 with USE_ES6_IMPORT_META enabled

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -424,12 +424,16 @@ var LibraryPThread = {
         worker = new Worker(p.createScriptURL('ignored'), {{{ pthreadWorkerOptions }}});
       } else
 #endif
-      // We need to generate the URL with import.meta.url as the base URL of the JS file
-      // instead of just using new URL(import.meta.url) because bundler's only recognize
-      // the first case in their bundling step. The latter ends up producing an invalid
-      // URL to import from the server (e.g., for webpack the file:// path).
-      // See https://github.com/webpack/webpack/issues/12638
-      worker = new Worker(new URL('{{{ TARGET_JS_NAME }}}', import.meta.url), {{{ pthreadWorkerOptions }}});
+#if expectToReceiveOnModule('mainScriptUrlOrBlob')
+        if (Module['mainScriptUrlOrBlob']) {
+          var pthreadMainJs = Module['mainScriptUrlOrBlob'];
+          if (typeof pthreadMainJs != 'string') {
+            pthreadMainJs = URL.createObjectURL(pthreadMainJs);
+          }
+          worker = new Worker(new URL(pthreadMainJs, import.meta.url), {{{ pthreadWorkerOptions }}});
+        } else
+#endif
+          worker = new Worker(import.meta.url, {{{ pthreadWorkerOptions }}});
 #else // EXPORT_ES6
       var pthreadMainJs = _scriptName;
 #if expectToReceiveOnModule('mainScriptUrlOrBlob')


### PR DESCRIPTION
Per the discussion in #23769, implement this policy:

- If mainScriptUrlOrBlob is set, create the worker as in the old non-use-import-meta case
- If import.meta.url is a blob url, use it for the worker script
- Otherwise, use new URL(TARGET_JS_NAME, import.meta.url)

I know I didn't add any automated tests; I'd appreciate pointers on how to implement tests for this.