### PR TITLE
Simplify worker creation for TRUSTED_TYPES + ESM. NFC

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -422,12 +422,7 @@ var LibraryPThread = {
 #if TRUSTED_TYPES
       // Use Trusted Types compatible wrappers.
       if (typeof trustedTypes != 'undefined' && trustedTypes.createPolicy) {
-        var p = trustedTypes.createPolicy(
-          'emscripten#workerPolicy1',
-          {
-            createScriptURL: (ignored) => new URL("{{{ TARGET_JS_NAME }}}", import.meta.url)
-          }
-        );
+        var p = trustedTypes.createPolicy('emscripten#workerPolicy1', { createScriptURL: (ignored) => import.meta.url });
         worker = new Worker(p.createScriptURL('ignored'), {{{ pthreadWorkerOptions }}});
       } else
 #endif
@@ -435,6 +430,7 @@ var LibraryPThread = {
       // instead of just using new URL(import.meta.url) because bundler's only recognize
       // the first case in their bundling step. The latter ends up producing an invalid
       // URL to import from the server (e.g., for webpack the file:// path).
+      // See https://github.com/webpack/webpack/issues/12638
       worker = new Worker(new URL('{{{ TARGET_JS_NAME }}}', import.meta.url), {{{ pthreadWorkerOptions }}});
 #else // EXPORT_ES6
       var pthreadMainJs = _scriptName;


### PR DESCRIPTION
The trustedTypes.createPolicy call there is now subject to the same limitation as the `new Worker` call below.  Its can simply use `import.meta.url` directly I believe.