### PR TITLE
Display Overloading Method Name in WebIDL Assertion Errors

### DIFF
--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -768,7 +768,7 @@ for name in names:
         assert return_type == ret.name, 'overloads must have the same return type'
       for i in range(len(args) + 1):
         if i == len(args) or args[i].optional:
-          assert i not in sigs, 'overloading must differentiate by # of arguments (cannot have two signatures that differ by types but not by length)'
+          assert i not in sigs, f"{m.identifier.name}: overloading must differentiate by # of arguments (cannot have two signatures that differ by types but not by length)"
           sigs[i] = args[:i]
     render_function(name,
                     m.identifier.name, sigs, return_type,


### PR DESCRIPTION
When working with a large WebIDL file and a mistake occurs, it’s nearly impossible to determine where the overloading method is located. 
This small change simply adds the method name to the error message, making it easier to identify and resolve the issue:

`AssertionError: overloading must differentiate by # of arguments (cannot have two signatures that differ by types but not by length)`
![image](https://github.com/user-attachments/assets/ae491f4a-c4c5-4d71-90ff-2da4610a35e0)

By including the method identifier in the error message, it becomes much simpler to pinpoint the exact location to investigate, especially in WebIDL files exceeding 3,000 lines:

`AssertionError: OffsetCenterOfMassShapeSettings: overloading must differentiate by # of arguments (cannot have two signatures that differ by types but not by length)`
![image](https://github.com/user-attachments/assets/6603d63e-e01c-463f-8aa1-972d1d50da9b)

