### PR TITLE
[WasmFS] Create public `wasmfs_mount` function

### DIFF
--- a/src/lib/libwasmfs.js
+++ b/src/lib/libwasmfs.js
@@ -348,7 +348,7 @@ addToLibrary({
       }
 #endif
       var backendPointer = type.createBackend(opts);
-      return FS.handleError(withStackSave(() => __wasmfs_mount(stringToUTF8OnStack(mountpoint), backendPointer)));
+      return FS.handleError(withStackSave(() => _wasmfs_mount(stringToUTF8OnStack(mountpoint), backendPointer)));
     },
     unmount: (mountpoint) => (
       FS.handleError(withStackSave(() => _wasmfs_unmount(stringToUTF8OnStack(mountpoint))))

--- a/system/include/emscripten/wasmfs.h
+++ b/system/include/emscripten/wasmfs.h
@@ -29,10 +29,12 @@ backend_t wasmfs_get_backend_by_fd(int fd);
 // TODO: Remove this function so that only directories can be mounted.
 int wasmfs_create_file(const char* pathname __attribute__((nonnull)), mode_t mode, backend_t backend);
 
-// Creates a new directory using a specific backend.
-// Returns 0 on success like `mkdir`, or a negative value on error.
-// TODO: Add an alias with wasmfs_mount.
+// Legacy function. This function works like `mkdir` + `wasmfs_mount`.
 int wasmfs_create_directory(const char* path __attribute__((nonnull)), mode_t mode, backend_t backend);
+
+// Mount a backend at a given location in the filesystem
+// `path` must be an existing directory.
+int wasmfs_mount(const char* path __attribute__((nonnull)), backend_t backend);
 
 // Unmounts the directory (Which must be a valid mountpoint) at a specific path.
 // Returns 0 on success, or a negative value on error.

--- a/system/lib/wasmfs/js_api.cpp
+++ b/system/lib/wasmfs/js_api.cpp
@@ -277,21 +277,6 @@ int _wasmfs_lstat(const char* path, struct stat* statBuf) {
   return __syscall_lstat64((intptr_t)path, (intptr_t)statBuf);
 }
 
-// The legacy JS API requires a mountpoint to already exist, so  WasmFS will
-// attempt to remove the target directory if it exists before replacing it with
-// a mounted directory.
-int _wasmfs_mount(const char* path, ::backend_t created_backend) {
-  int err = __syscall_rmdir((intptr_t)path);
-
-  // The legacy JS API mount requires the directory to already exist, but we
-  // will also allow it to be missing.
-  if (err && err != -ENOENT) {
-    return err;
-  }
-
-  return wasmfs_create_directory(path, 0777, created_backend);
-}
-
 // Helper method that identifies what a path is:
 //   ENOENT - if nothing exists there
 //   EISDIR - if it is a directory

--- a/tools/link.py
+++ b/tools/link.py
@@ -1265,7 +1265,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
         'emscripten_builtin_memalign',
         'wasmfs_create_file',
         'wasmfs_unmount',
-        '_wasmfs_mount',
+        'wasmfs_mount',
         '_wasmfs_read_file',
         '_wasmfs_write_file',
         '_wasmfs_open',


### PR DESCRIPTION
We already had `wasmfs_unmount` so it seems logical we should have this one too.

This is designed to replace `wasmfs_create_directory` which has a rather misleading name.

I have left `wasmfs_create_directory` around for now but is simply combination of `mkdir` + `mount` (which is essentially what is was doing already).

This change ends up simplifying `doMkdir` which no longer needs to take  a backend argument.  