### PR TITLE
Configure freetype/poppler for cross-building

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -2004,7 +2004,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     ]
     return self.get_library(os.path.join('third_party', 'freetype'),
                             os.path.join('objs', '.libs', 'libfreetype.a'),
-                            configure_args=['--disable-shared', '--without-zlib'])
+                             # freetype's config.sub doesn't recognize Emscripten, so fake it with Linux
+                            configure_args=['--disable-shared', '--without-zlib', '--build=i686-linux'])
 
   def get_poppler_library(self, env_init=None):
     freetype = self.get_freetype_library()
@@ -2040,7 +2041,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         os.path.join('third_party', 'poppler'),
         [os.path.join('utils', 'pdftoppm.o'), os.path.join('utils', 'parseargs.o'), os.path.join('poppler', '.libs', 'libpoppler.a')],
         env_init=env_init,
-        configure_args=['--disable-libjpeg', '--disable-libpng', '--disable-poppler-qt', '--disable-poppler-qt4', '--disable-cms', '--disable-cairo-output', '--disable-abiword-output', '--disable-shared'])
+        configure_args=['--disable-libjpeg', '--disable-libpng', '--disable-poppler-qt', '--disable-poppler-qt4', '--disable-cms', '--disable-cairo-output', '--disable-abiword-output', '--disable-shared', '--build=wasm32-emscripten'])
 
     return poppler + freetype
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6722,6 +6722,7 @@ void* operator new(size_t size) {
   @needs_make('depends on freetype')
   @no_4gb('runs out of memory')
   @is_slow_test
+  @crossplatform
   def test_poppler(self):
     # See https://github.com/emscripten-core/emscripten/issues/20757
     self.emcc_args.extend(['-Wno-deprecated-declarations', '-Wno-nontrivial-memaccess'])


### PR DESCRIPTION
Currently configure is just detecting the build machine and OS rather than cross building.
Specify a build system to make it work the same on at least Mac and Linux systems.
Freetype's config.sub doesn't recognize wasm32-emscripten so we just use Linux to
at least get consistent behavior.