### PR TITLE
Update test_wasmfs_getdents. NFC

### DIFF
--- a/test/wasmfs/wasmfs_getdents.out
+++ b/test/wasmfs/wasmfs_getdents.out
@@ -1,15 +1,15 @@
 ------------- Reading from root/working Directory -------------
 d.d_name = .
 d.d_reclen = 280
-d.d_type = directory
+d.d_type = DT_DIR
 
 d.d_name = ..
 d.d_reclen = 280
-d.d_type = directory
+d.d_type = DT_DIR
 
 d.d_name = test
 d.d_reclen = 280
-d.d_type = directory
+d.d_type = DT_DIR
 
 Errno: Bad file descriptor
 Errno: Invalid argument
@@ -18,35 +18,35 @@ Errno: Not a directory
 ------------- Reading from /dev Directory -------------
 d.d_name = .
 d.d_reclen = 280
-d.d_type = directory
+d.d_type = DT_DIR
 
 d.d_name = ..
 d.d_reclen = 280
-d.d_type = directory
+d.d_type = DT_DIR
 
 d.d_name = null
 d.d_reclen = 280
-d.d_type = regular
+d.d_type = DT_REG
 
 d.d_name = random
 d.d_reclen = 280
-d.d_type = regular
+d.d_type = DT_REG
 
 d.d_name = stderr
 d.d_reclen = 280
-d.d_type = regular
+d.d_type = DT_REG
 
 d.d_name = stdin
 d.d_reclen = 280
-d.d_type = regular
+d.d_type = DT_REG
 
 d.d_name = stdout
 d.d_reclen = 280
-d.d_type = regular
+d.d_type = DT_REG
 
 d.d_name = urandom
 d.d_reclen = 280
-d.d_type = regular
+d.d_type = DT_REG
 
 ------------- Reading from /dev Directory via JS -------------
 .
@@ -58,25 +58,34 @@ stdin
 stdout
 urandom
 
-root/working file position is: 1
+d.d_name = .
+d.d_reclen = 280
+d.d_type = DT_DIR
+
+d.d_name = ..
+d.d_reclen = 280
+d.d_type = DT_DIR
+
+rewinding from position 2 to 1
 ------------- Reading one from root/working Directory -------------
 d.d_name = ..
 d.d_reclen = 280
-d.d_type = directory
+d.d_type = DT_DIR
 
 ------------- Reading from root/working Directory -------------
 d.d_name = .
 d.d_reclen = 280
-d.d_type = directory
+d.d_type = DT_DIR
 
 d.d_name = ..
 d.d_reclen = 280
-d.d_type = directory
+d.d_type = DT_DIR
 
 d.d_name = foobar
 d.d_reclen = 280
-d.d_type = regular
+d.d_type = DT_REG
 
 d.d_name = test
 d.d_reclen = 280
-d.d_type = directory
+d.d_type = DT_DIR
+


### PR DESCRIPTION
Handle more file entry types.

Don't attempt to seek to position 1.  Instead seek back to a previously seen position.  I'm honestly not even sure this is valid but both old and new filesystems support this.

These changes are in preparation for running this test on all filesystem types.