### PR TITLE
Fix closure warning when building with base64.js and webgl.js

### DIFF
--- a/src/lib/libwebgl.js
+++ b/src/lib/libwebgl.js
@@ -23,7 +23,7 @@ var LibraryGL = {
   // glInvalidateSubFramebuffer that need to pass a short array to the WebGL
   // API, create a set of short fixed-length arrays to avoid having to generate
   // any garbage when calling those functions.
-  $tempFixedLengthArray__postset: 'for (var i = 0; i < 32; ++i) tempFixedLengthArray.push(new Array(i));',
+  $tempFixedLengthArray__postset: 'for (let i = 0; i < 32; ++i) tempFixedLengthArray.push(new Array(i));',
   $tempFixedLengthArray: [],
 
   $miniTempWebGLFloatBuffers: [],

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10008,6 +10008,7 @@ end
     self.build(test_file('hello_world.c'), emcc_args=[
       '--closure=1',
       '--minify=0',
+      '-lbase64.js',
       '-Werror=closure',
       '-sINCLUDE_FULL_LIBRARY',
       '-sOFFSCREEN_FRAMEBUFFER',


### PR DESCRIPTION
Fixes: #23841