### PR TITLE
Remove unnecessary use of wasmfs_create_file. NFC

### DIFF
--- a/test/stdio/test_rename.c
+++ b/test/stdio/test_rename.c
@@ -207,8 +207,7 @@ void test() {
   // Create a directory and a file.
   err = wasmfs_create_directory("/js-dir", 0777, js_backend);
   assert(err == 0);
-  int fd = wasmfs_create_file("/js-dir/js-file", 0777, js_backend);
-  assert(fd >= 0);
+  create_file("/js-dir/js-file", "foo", 0777);
 
   // Try to move it.
   err = rename("/js-dir/js-file", "/moved-js-file");


### PR DESCRIPTION
This file will be created in the JS backend by virtue of its location.