### PR TITLE
Experimental per-file cache locking

### DIFF
--- a/tools/cache.py
+++ b/tools/cache.py
@@ -143,7 +143,7 @@ def erase_lib(name):
 
 def erase_file(shortname):
   name = Path(cachedir, shortname)
-  with lock('erase: ' + shortname, name):
+  with lock('erase: ' + shortname, shortname):
     if name.exists():
       logger.info(f'deleting cached file: {name}')
       utils.delete_file(name)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -552,7 +552,9 @@ class Library:
   def do_build(self, out_filename, generate_only=False):
     """Builds the library and returns the path to the file."""
     assert out_filename == self.get_path(absolute=True)
-    build_dir = os.path.join(cache.get_path('build'), self.get_base_name())
+    # Make separate build directories for each lib dir (e.g. wasm64, PIC, LTO)
+    lib_subdir = cache.get_lib_dir(False).relative_to(cache.get_sysroot(False) + '/lib')
+    build_dir = os.path.join(cache.get_path('build'), lib_subdir, self.get_base_name())
     if USE_NINJA:
       self.generate_ninja(build_dir, out_filename)
       if not generate_only:


### PR DESCRIPTION
Rather than locking the entire cache, use a lock for each cached file.
The lock is held while e.g. building the library, and only blocks other
processes that want the same library. (Other processes are not blocked
when they try to build separate libraries or variants).

