### PR TITLE
respect mainScriptUrlOrBlob for esm targets

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -436,7 +436,7 @@ var LibraryPThread = {
 #endif
       }
 #if PTHREADS_DEBUG
-      dbg(`Allocating a new web worker from ${workerUrl}`);
+      dbg(`Allocating a new web worker from ${workerUrl ?? workerPolicyUrl}`);
 #endif
 #if TRUSTED_TYPES
       // Use Trusted Types compatible wrappers.
@@ -445,7 +445,10 @@ var LibraryPThread = {
         workerUrl = p.createScriptURL('ignored');
       }
 #endif
-      var worker = new Worker(workerUrl, {{{ pthreadWorkerOptions }}});
+      var options = {{{ pthreadWorkerOptions }}};
+      var worker = workerUrl 
+        ? new Worker(workerUrl, options)
+        : new Worker(new URL("{{{ TARGET_JS_NAME }}}", import.meta.url), options);
 #if ASSERTIONS
       worker.workerID = PThread.nextWorkerID++;
 #endif

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -439,7 +439,7 @@ var LibraryPThread = {
         workerUrl = p.createScriptURL('ignored');
       }
 #endif
-      var worker, workerOptions = {{{ pthreadWorkerOptions }}};
+      var worker;
 #if EXPORT_ES6
       if (!workerUrl) {
       // We need to generate the URL with import.meta.url as the base URL of the JS file
@@ -447,10 +447,10 @@ var LibraryPThread = {
       // the first case in their bundling step. The latter ends up producing an invalid
       // URL to import from the server (e.g., for webpack the file:// path).
       // See https://github.com/webpack/webpack/issues/12638
-        worker = new Worker(new URL("{{{ TARGET_JS_NAME }}}", import.meta.url), workerOptions);
+        worker = new Worker(new URL("{{{ TARGET_JS_NAME }}}", import.meta.url), {{{ pthreadWorkerOptions }}});
       } else
 #endif
-      worker = new Worker(workerUrl, workerOptions);
+      worker = new Worker(workerUrl, {{{ pthreadWorkerOptions }}});
 #if ASSERTIONS
       worker.workerID = PThread.nextWorkerID++;
 #endif

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -424,12 +424,6 @@ var LibraryPThread = {
 #endif
       if (!workerUrl) {
 #if EXPORT_ES6
-      // We need to generate the URL with import.meta.url as the base URL of the JS file
-      // instead of just using new URL(import.meta.url) because bundler's only recognize
-      // the first case in their bundling step. The latter ends up producing an invalid
-      // URL to import from the server (e.g., for webpack the file:// path).
-      // See https://github.com/webpack/webpack/issues/12638
-        workerUrl = new URL("{{{ TARGET_JS_NAME }}}", import.meta.url);
         workerPolicyUrl = import.meta.url
 #else
         workerUrl = workerPolicyUrl = _scriptName;
@@ -448,6 +442,11 @@ var LibraryPThread = {
       var options = {{{ pthreadWorkerOptions }}};
       var worker = workerUrl 
         ? new Worker(workerUrl, options)
+      // We need to generate the URL with import.meta.url as the base URL of the JS file
+      // instead of just using new URL(import.meta.url) because bundler's only recognize
+      // the first case in their bundling step. The latter ends up producing an invalid
+      // URL to import from the server (e.g., for webpack the file:// path).
+      // See https://github.com/webpack/webpack/issues/12638
         : new Worker(new URL("{{{ TARGET_JS_NAME }}}", import.meta.url), options);
 #if ASSERTIONS
       worker.workerID = PThread.nextWorkerID++;

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -440,6 +440,7 @@ var LibraryPThread = {
       }
 #endif
       var options = {{{ pthreadWorkerOptions }}};
+#if EXPORT_ES6
       var worker = workerUrl 
         ? new Worker(workerUrl, options)
       // We need to generate the URL with import.meta.url as the base URL of the JS file
@@ -448,6 +449,9 @@ var LibraryPThread = {
       // URL to import from the server (e.g., for webpack the file:// path).
       // See https://github.com/webpack/webpack/issues/12638
         : new Worker(new URL("{{{ TARGET_JS_NAME }}}", import.meta.url), options);
+#else
+      var worker = new Worker(workerUrl, options);
+#endif
 #if ASSERTIONS
       worker.workerID = PThread.nextWorkerID++;
 #endif


### PR DESCRIPTION
we would like to serve emscripten javascripts from a content hashed url, but the EXPORT_ES6 code path always bootstraps pthreads with `new Worker(new URL('{{{ TARGET_JS_NAME }}}', import.meta.url), ...)`. if it's possible to support mainScriptUrlOrBlob for esm, that would make our day.

- EXPORT_ES6 linked javascripts will use Module['mainScriptUrlOrBlob'] if specified.
- other logic should be unchanged
- maybe a few bytes fatter after minification