### PR TITLE
Fix for core_2gb.test_fs_js_api_wasmfs. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -662,6 +662,7 @@ jobs:
             wasm64
             core_2gb.test_*em_asm*
             core_2gb.test_*embind*
+            core_2gb.test_fs_js_api_wasmfs
             wasm64l.test_hello_world
             wasm64l.test_bigswitch
             wasm64l.test_module_wasm_memory

--- a/src/lib/libwasmfs.js
+++ b/src/lib/libwasmfs.js
@@ -242,8 +242,12 @@ addToLibrary({
       __wasmfs_symlink(stringToUTF8OnStack(target), stringToUTF8OnStack(linkpath))
     )),
     readlink(path) {
-      var readBuffer = FS.handleError(withStackSave(() => __wasmfs_readlink(stringToUTF8OnStack(path))));
-      return UTF8ToString(readBuffer);
+      return withStackSave(() => {
+        var bufPtr = stackAlloc({{{ POINTER_SIZE }}});
+        FS.handleError(__wasmfs_readlink(stringToUTF8OnStack(path), bufPtr));
+        var readBuffer = {{{ makeGetValue('bufPtr', '0', '*') }}};
+        return UTF8ToString(readBuffer);
+      });
     },
     statBufToObject(statBuf) {
       // i53/u53 are enough for times and ino in practice.

--- a/system/lib/wasmfs/js_api.cpp
+++ b/system/lib/wasmfs/js_api.cpp
@@ -140,7 +140,7 @@ int _wasmfs_symlink(const char* old_path, const char* new_path) {
   return __syscall_symlinkat((intptr_t)old_path, AT_FDCWD, (intptr_t)new_path);
 }
 
-intptr_t _wasmfs_readlink(const char* path) {
+int _wasmfs_readlink(const char* path, char** out_ptr) {
   static thread_local char* readBuf = (char*)malloc(PATH_MAX);
   int bytes =
     __syscall_readlinkat(AT_FDCWD, (intptr_t)path, (intptr_t)readBuf, PATH_MAX);
@@ -148,7 +148,8 @@ intptr_t _wasmfs_readlink(const char* path) {
     return bytes;
   }
   readBuf[bytes] = '\0';
-  return (intptr_t)readBuf;
+  *out_ptr = readBuf;
+  return 0;
 }
 
 int _wasmfs_write(int fd, void* buf, size_t count) {

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -1078,7 +1078,7 @@ def create_pointer_conversion_wrappers(metadata):
     '_emscripten_proxy_dlsync_async': '_pp',
     '_emscripten_wasm_worker_initialize': '_p_',
     '_wasmfs_rename': '_pp',
-    '_wasmfs_readlink': 'pp',
+    '_wasmfs_readlink': '_pp',
     '_wasmfs_truncate': '_p_',
     '_wasmfs_mmap': 'pp____',
     '_wasmfs_munmap': '_pp',


### PR DESCRIPTION
This tests is failing on the emscripten-releases waterfall.

In 2Gb+ mode its no longer possible to fix the returning of pointers with the returning of `-errno` since negative number are valid pointers in this mode.