### PR TITLE
[CI] Upgrade to latest macOS image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ executors:
     environment:
       EMSDK_NOTTY: "1"
     macos:
-      xcode: "14.2.0"
+      xcode: "16.2.0"
     resource_class: macos.m1.medium.gen1
 
 commands:


### PR DESCRIPTION
This xcode version is that latest and corresponds to macOS 14.6.1.