### PR TITLE
[CI] Skip brew update step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,9 +330,7 @@ commands:
           name: Install brew package dependencies
           environment:
             HOMEBREW_NO_AUTO_UPDATE: "1"
-          command: |
-            brew update
-            brew install cmake ninja pkg-config
+          command: brew install cmake ninja pkg-config
       - checkout
       - run:
           name: submodule update


### PR DESCRIPTION
I'm not sure why we needed this.. lets try removing it and see what breaks