### PR TITLE
[CI] Only test wasm64 in 4gb mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -658,22 +658,12 @@ jobs:
           command: echo "NODE_JS = NODE_JS_TEST" >> ~/emsdk/.emscripten
       - run-tests:
           title: "wasm64"
-          test_targets: "
-            wasm64
-            core_2gb.test_*em_asm*
-            core_2gb.test_*embind*
-            core_2gb.test_fs_js_api_wasmfs
-            wasm64l.test_hello_world
-            wasm64l.test_bigswitch
-            wasm64l.test_module_wasm_memory
-            wasm64l.test_longjmp2_emscripten
-            other.test_memory64_proxies
-            other.test_failing_growth_wasm64"
+          test_targets: "wasm64"
       - upload-test-results
   test-wasm64-4gb:
     environment:
       LANG: "C.UTF-8"
-      # Only run 2 tests at a time to avoid OOM (since each tests used >4gb)
+      # Only run 2 tests at a time to avoid OOM (since each test used >4gb)
       EMCC_CORES: "2"
     # We don't use `bionic` here since its too old to run recent node versions:
     # `/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found`
@@ -693,7 +683,16 @@ jobs:
           command: echo "NODE_JS = NODE_JS_TEST" >> ~/emsdk/.emscripten
       - run-tests:
           title: "wasm64_4gb"
-          test_targets: "wasm64_4gb"
+          test_targets: "wasm64_4gb
+            core_2gb.test_*em_asm*
+            core_2gb.test_*embind*
+            core_2gb.test_fs_js_api_wasmfs
+            wasm64l.test_hello_world
+            wasm64l.test_bigswitch
+            wasm64l.test_module_wasm_memory
+            wasm64l.test_longjmp2_emscripten
+            other.test_memory64_proxies
+            other.test_failing_growth_wasm64"
       - upload-test-results
   test-jsc:
     executor: linux-python
@@ -1066,9 +1065,6 @@ workflows:
           requires:
             - build-linux
       - test-core3:
-          requires:
-            - build-linux
-      - test-wasm64:
           requires:
             - build-linux
       - test-wasm64-4gb:


### PR DESCRIPTION
The idea is that this should catch all the normal wasm64 bugs in addition to the high-memory related ones.

We still do some testing on the non-high-memory mode in the test_other.py test suite.