### PR TITLE
Run test_fs_js_api all FS backends and fix related issues

### DIFF
--- a/src/lib/libnoderawfs.js
+++ b/src/lib/libnoderawfs.js
@@ -113,7 +113,13 @@ addToLibrary({
       var stream = FS.getStreamChecked(fd);
       fs.fchownSync(stream.nfd, owner, group);
     },
-    truncate(...args) { fs.truncateSync(...args); },
+    truncate(path, len) {
+      // See https://github.com/nodejs/node/issues/35632
+      if (len < 0) {
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
+      }
+      return fs.truncateSync(path, len);
+    },
     ftruncate(fd, len) {
       // See https://github.com/nodejs/node/issues/35632
       if (len < 0) {
@@ -160,7 +166,7 @@ addToLibrary({
     },
     close(stream) {
       VFS.closeStream(stream.fd);
-      if (!stream.stream_ops && --stream.shared.refcnt === 0) {
+      if (!stream.stream_ops && --stream.shared.refcnt <= 0) {
         // This stream is created by our Node.js filesystem, close the
         // native file descriptor when its reference count drops to 0.
         fs.closeSync(stream.nfd);

--- a/test/fs/test_fs_js_api.c
+++ b/test/fs/test_fs_js_api.c
@@ -406,7 +406,7 @@ void test_fs_mkdirTree() {
     assert(ex.name === "ErrnoError" && ex.errno === 2 /* EACCES */);
   );
 
-  chdir("test1");
+  chdir("/test1");
   EM_ASM(
     FS.mkdirTree("foo/bar"); // Relative path
   );
@@ -448,22 +448,37 @@ void test_fs_utime() {
   remove("utimetest");
 }
 
+#if !defined(NODERAWFS)
+// NODERAWFS don't support absolute paths since we cannot write the
+// actual root directory.
+// In addition, abs paths testing is not really running correctly
+// when we build run with NODEFS because the NODEFS filesystem is mounted
+// at /nodefs in that case.
+// TODO(sbc): Refactor these tests such that they test both relative
+// and absolute paths, and don't depend on write access to the root
+// directory.
+#define ABS_PATH_OK
+#endif
+
 int main() {
-  test_fs_open();
+#ifdef ABS_PATH_OK
   test_fs_createPath();
+  test_fs_mkdirTree();
+  test_fs_close();
+  test_fs_readlink();
+  test_fs_rmdir();
+#endif
+  test_fs_open();
   test_fs_readFile();
   test_fs_rename();
-  test_fs_readlink();
   test_fs_read();
-  test_fs_rmdir();
-  test_fs_close();
   test_fs_mknod();
   test_fs_truncate();
 #if WASMFS
   // TODO: Fix legacy API FS.mmap bug involving emscripten_builtin_memalign
   test_fs_mmap();
 #endif
-  test_fs_mkdirTree();
+
   test_fs_utime();
 
   puts("success");

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5756,7 +5756,7 @@ got: 10
       self.set_setting("FORCE_FILESYSTEM")
     self.do_run_in_out_file_test('fs/test_writeFile.cpp')
 
-  @also_with_wasmfs
+  @with_all_fs
   def test_fs_js_api(self):
     self.set_setting("FORCE_FILESYSTEM")
     self.do_runf('fs/test_fs_js_api.c', 'success')


### PR DESCRIPTION
I order to make the tests work I had to convert all paths to relative paths but I don't think that should effect any of the tests.

A couple bug fixes were needed to make this work:

1. FS.FS_mkdirTree was fixes such that if works for relative directory tree.
2. NODERAWFS truncate requires the same workaround as it already had for ftruncate.
3. NODERAWFS close now fails correctly when called more than once.