### PR TITLE
Remove libsqlite from MINIMAL build

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -86,8 +86,6 @@ MINIMAL_TASKS = [
     'libunwind-legacyexcept',
     'libunwind-wasmexcept',
     'libnoexit',
-    'sqlite3',
-    'sqlite3-mt',
     'libwebgpu',
     'libwebgpu_cpp',
 ]


### PR DESCRIPTION
libsqlite is really slow building, and causes the MINIMAL build step to be much slower (especially since it's not parallel). 
The testers that use frozen caches also do not depend on it, as they use the ALL library target.
This has the effect that it pushes building this library from the fast/highly parallel build-linux builder to the test builders, and makes build-linux faster. 