### PR TITLE
fix 'set EM_PY' in batch files

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/em++.bat
+++ b/em++.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/em-config.bat
+++ b/em-config.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emar.bat
+++ b/emar.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/embuilder.bat
+++ b/embuilder.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emcc.bat
+++ b/emcc.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emcmake.bat
+++ b/emcmake.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emconfigure.bat
+++ b/emconfigure.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emdump.bat
+++ b/emdump.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emdwp.bat
+++ b/emdwp.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emmake.bat
+++ b/emmake.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emnm.bat
+++ b/emnm.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emprofile.bat
+++ b/emprofile.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emranlib.bat
+++ b/emranlib.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emrun.bat
+++ b/emrun.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emscan-deps.bat
+++ b/emscan-deps.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emscons.bat
+++ b/emscons.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emsize.bat
+++ b/emsize.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emstrip.bat
+++ b/emstrip.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/emsymbolizer.bat
+++ b/emsymbolizer.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/system/bin/sdl-config.bat
+++ b/system/bin/sdl-config.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/system/bin/sdl2-config.bat
+++ b/system/bin/sdl2-config.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/test/runner.bat
+++ b/test/runner.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/tools/file_packager.bat
+++ b/tools/file_packager.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/tools/maint/run_python.bat
+++ b/tools/maint/run_python.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/tools/maint/run_python_compiler.bat
+++ b/tools/maint/run_python_compiler.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this

--- a/tools/webidl_binder.bat
+++ b/tools/webidl_binder.bat
@@ -15,7 +15,7 @@
 @set _PYTHON_SYSCONFIGDATA_NAME=
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
-  set EM_PY=python
+  set EM_PY=python.exe
 )
 
 :: Work around Windows bug https://github.com/microsoft/terminal/issues/15212 : If this


### PR DESCRIPTION
This fixes the following error:

```
  '"python"' is not recognized as an internal or external command,
```

This is not usually triggered because usually `EMSDK_PYTHON` is set.