### PR TITLE
CI: Clean build directory on the library builder before persisting the workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,8 +495,9 @@ jobs:
       - install-v8
       - install-emsdk
       - build-libs
-      - run: name: Clean build directory
-        command: rm -rf ~/cache/build
+      - run:
+          name: Clean build directory
+          command: rm -rf ~/cache/build
       - persist
   # Perhaps we don't need to run this suite with every commit. Consider moving this to FYI bot.
   test-posixtest:


### PR DESCRIPTION
The Ninja build of the libraries leaves behind all of the object files when
building the archives. This is nice for developers if you're working on the
libraries themselves but for CI, we are just bloating the persisted
workspace and not using the object files. So rather than automatically
clearing in embuilder or system_libs.py after the build, do it on CI.
