### PR TITLE
Fix iteration of OpenAL src.bufQueue

### DIFF
--- a/src/lib/libopenal.js
+++ b/src/lib/libopenal.js
@@ -4056,7 +4056,7 @@ var LibraryOpenAL = {
 
     // Find the first non-zero buffer in the queue to determine the proper format
     var templateBuf = AL.buffers[0];
-    for (var buf of src.bufQueue.length) {
+    for (var buf of src.bufQueue) {
       if (buf.id !== 0) {
         templateBuf = buf;
         break;

--- a/test/openal/test_openal_buffers.c
+++ b/test/openal/test_openal_buffers.c
@@ -89,7 +89,9 @@ void iter() {
   alGetSourcef(source, AL_PITCH, &testPitch);
   assert(pitch == testPitch);
 #endif
-
+#ifdef TEST_FAST
+  offset = size;
+#endif
   // Exit once we've processed the entire clip.
   if (offset >= size) {
 #if __EMSCRIPTEN__
@@ -192,7 +194,6 @@ int main(int argc, char* argv[]) {
   ALint srcLen = 0;
   alGetSourcei(source, 0x2009 /* AL_BYTE_LENGTH_SOFT */, &srcLen);
   assert(srcLen == NUM_BUFFERS * BUFFER_SIZE);
-
 #ifdef TEST_ANIMATED_PITCH
   printf("You should hear a clip of the 1902 piano song \"The Entertainer\" played back at a high pitch rate, and animated to slow down to half playback speed.\n");
 #else

--- a/test/openal/test_openal_buffers.c
+++ b/test/openal/test_openal_buffers.c
@@ -89,7 +89,7 @@ void iter() {
   alGetSourcef(source, AL_PITCH, &testPitch);
   assert(pitch == testPitch);
 #endif
-#ifdef TEST_FAST
+#ifndef TEST_INTERACTIVE
   offset = size;
 #endif
   // Exit once we've processed the entire clip.

--- a/test/openal/test_openal_playback.c
+++ b/test/openal/test_openal_playback.c
@@ -295,10 +295,11 @@ int main() {
 
 #ifdef __EMSCRIPTEN__
 
+  intptr_t first_src = sources[0];
 #if defined(TEST_LOOPED_PLAYBACK)
-  emscripten_set_main_loop_arg(main_tick, (void*)sources[0], 0, 0);
+  emscripten_set_main_loop_arg(main_tick, (void*)first_src, 0, 0);
 #else
-  emscripten_async_call(playSource, (void*)(sources[0]), 700);
+  emscripten_async_call(playSource, (void*)first_src, 700);
 #endif
 #else
   usleep(700000);

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2332,7 +2332,7 @@ void *getBindBuffer() {
     self.btest('openal/test_openal_playback.c', '1', emcc_args=['-O2', '--preload-file', 'audio.wav'] + args)
 
   def test_openal_buffers(self):
-    self.btest_exit('openal/test_openal_buffers.c', emcc_args=['-DTEST_FAST=1','--preload-file', test_file('sounds/the_entertainer.wav') + '@/'],)
+    self.btest_exit('openal/test_openal_buffers.c', emcc_args=['--preload-file', test_file('sounds/the_entertainer.wav') + '@/'],)
     
   def test_runtimelink(self):
     create_file('header.h', r'''

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2323,6 +2323,17 @@ void *getBindBuffer() {
   def test_openal_extensions(self):
     self.btest_exit('openal/test_openal_extensions.c')
 
+  @parameterized({
+    '': ([],),
+    'proxy_to_pthread': (['-sPROXY_TO_PTHREAD', '-pthread'],),
+  })
+  def test_openal_playback(self, args):
+    shutil.copy(test_file('sounds/audio.wav'), '.')
+    self.btest('openal/test_openal_playback.c', '1', emcc_args=['-O2', '--preload-file', 'audio.wav'] + args)
+
+  def test_openal_buffers(self):
+    self.btest_exit('openal/test_openal_buffers.c', emcc_args=['-DTEST_FAST=1','--preload-file', test_file('sounds/the_entertainer.wav') + '@/'],)
+    
   def test_runtimelink(self):
     create_file('header.h', r'''
       struct point {

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2323,17 +2323,13 @@ void *getBindBuffer() {
   def test_openal_extensions(self):
     self.btest_exit('openal/test_openal_extensions.c')
 
-  @parameterized({
-    '': ([],),
-    'proxy_to_pthread': (['-sPROXY_TO_PTHREAD', '-pthread'],),
-  })
-  def test_openal_playback(self, args):
+  def test_openal_playback(self):
     shutil.copy(test_file('sounds/audio.wav'), '.')
-    self.btest('openal/test_openal_playback.c', '1', emcc_args=['-O2', '--preload-file', 'audio.wav'] + args)
+    self.btest_exit('openal/test_openal_playback.c', emcc_args=['-O2', '--preload-file', 'audio.wav'],)
 
   def test_openal_buffers(self):
     self.btest_exit('openal/test_openal_buffers.c', emcc_args=['--preload-file', test_file('sounds/the_entertainer.wav') + '@/'],)
-    
+
   def test_runtimelink(self):
     create_file('header.h', r'''
       struct point {

--- a/test/test_interactive.py
+++ b/test/test_interactive.py
@@ -159,10 +159,10 @@ class interactive(BrowserCore):
     self.btest('openal/test_openal_playback.c', '1', emcc_args=['-O2', '--preload-file', 'audio.wav'] + args)
 
   def test_openal_buffers(self):
-    self.btest_exit('openal/test_openal_buffers.c', emcc_args=['--preload-file', test_file('sounds/the_entertainer.wav') + '@/'],)
+    self.btest_exit('openal/test_openal_buffers.c', emcc_args=['-DTEST_INTERACTIVE=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/'],)
 
   def test_openal_buffers_animated_pitch(self):
-    self.btest_exit('openal/test_openal_buffers.c', emcc_args=['-DTEST_ANIMATED_PITCH=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/'],)
+    self.btest_exit('openal/test_openal_buffers.c', emcc_args=['-DTEST_INTERACTIVE=1', '-DTEST_ANIMATED_PITCH=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/'],)
 
   def test_openal_looped_pitched_playback(self):
     self.btest('openal/test_openal_playback.c', '1', emcc_args=['-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'],)


### PR DESCRIPTION
This failing test shows up under the interactive tests only, so I guess CI didn't catch it.  Caused by #23867 .