### PR TITLE
Remove old `index` name from WebAssembly.Memory & Table constructors

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -2275,10 +2275,6 @@ addToLibrary({
 #endif
 #if MEMORY64 == 1
   'address': 'i64',
-   // TODO(sbc): remove this alias for 'address' once both firefox and
-   // chrome roll out the spec change.
-   // See https://github.com/WebAssembly/memory64/pull/92
-  'index': 'i64',
 #endif
   'element': 'anyfunc'
 });

--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -48,10 +48,6 @@ if (!ENVIRONMENT_IS_PTHREAD) {
 #endif
 #if MEMORY64 == 1
       'address': 'i64',
-      // TODO(sbc): remove this alias for `address` once both firefox and
-      // chrome roll out the spec change.
-      // See https://github.com/WebAssembly/memory64/pull/92
-      'index': 'i64',
 #endif
     });
   }

--- a/test/core/test_module_wasm_memory.js
+++ b/test/core/test_module_wasm_memory.js
@@ -11,10 +11,6 @@ Module['wasmMemory'] = new WebAssembly.Memory({
   'initial': 256n,
   'maximum': 256n,
   'address': 'i64',
-   // TODO(sbc): remove this alias for `address` once both firefox and
-   // chrome roll out the spec change.
-   // See https://github.com/WebAssembly/memory64/pull/92
-  'index': 'i64',
 #else
   'initial': 256,
   'maximum': 256,


### PR DESCRIPTION
The new name should now be supported in all places memory64 is supported.