### PR TITLE
Disable test_emcc_sourcemap_options on windows. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10475,6 +10475,8 @@ int main() {
     ], 0),
     'sources': ([], 1)
   })
+  @crossplatform
+  @no_windows('https://github.com/emscripten-core/emscripten/pull/23741#issuecomment-2725574867')
   def test_emcc_sourcemap_options(self, prefixes, sources):
     wasm_sourcemap = importlib.import_module('tools.wasm-sourcemap')
     cwd = os.getcwd()


### PR DESCRIPTION
This test was recently add in #23741 but currently fails on windows.