### PR TITLE
Fix flake8 errors/warnings. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,8 +437,8 @@ jobs:
       - checkout
       - pip-install
       - run: ruff check
-      # TODO (cclauss): When ruff supports rules E20,E30 without --preview, remove following line
-      - run: ruff check --preview --select=E20,E30
+      # TODO (cclauss): When ruff supports rules these errors without --preview, remove following line
+      - run: ruff check --preview --select=E20,E30,E221,E225,E226
   mypy:
     executor: focal
     steps:

--- a/emsymbolizer.py
+++ b/emsymbolizer.py
@@ -211,7 +211,7 @@ def symbolize_address_sourcemap(module, address, force_file):
     print(sm.mappings)
     # Print with section offsets to easily compare against dwarf
     for k, v in sm.mappings.items():
-      print(f'{k-csoff:x}: {v}')
+      print(f'{k - csoff:x}: {v}')
   sm.lookup(address).print()
 
 

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1370,7 +1370,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
 
     args = ['--pre-js', 'pre.js', '-lidbfs.js', '-sEXIT_RUNTIME', '-sASYNCIFY']
     secret = str(time.time())
-    self.btest('fs/test_idbfs_fsync.c', '1', emcc_args=args + ['-DFIRST', f'-DSECRET="{secret }"', '-lidbfs.js'])
+    self.btest('fs/test_idbfs_fsync.c', '1', emcc_args=args + ['-DFIRST', f'-DSECRET="{secret}"', '-lidbfs.js'])
     self.btest('fs/test_idbfs_fsync.c', '1', emcc_args=args + [f'-DSECRET="{secret}"', '-lidbfs.js'])
 
   def test_fs_memfs_fsync(self):
@@ -1392,7 +1392,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
         }, '/work');
       };
     ''' % (secret, secret2))
-    self.btest_exit('fs/test_workerfs_read.c', emcc_args=['-lworkerfs.js', '--pre-js', 'pre.js', f'-DSECRET="{secret }"', f'-DSECRET2="{secret2}"', '--proxy-to-worker', '-lworkerfs.js'])
+    self.btest_exit('fs/test_workerfs_read.c', emcc_args=['-lworkerfs.js', '--pre-js', 'pre.js', f'-DSECRET="{secret}"', f'-DSECRET2="{secret2}"', '--proxy-to-worker', '-lworkerfs.js'])
 
   def test_fs_workerfs_package(self):
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$ccall')
@@ -1445,8 +1445,8 @@ simulateKeyUp(100, undefined, 'Numpad4');
     self.btest_exit('fs/test_lz4fs.cpp', 1, emcc_args=['-DLOAD_MANUALLY', '-sLZ4', '-sFORCE_FILESYSTEM', '-O2'])
     print('    opts+closure')
     self.btest_exit('fs/test_lz4fs.cpp', 1, emcc_args=['-DLOAD_MANUALLY', '-sLZ4',
-                                                  '-sFORCE_FILESYSTEM', '-O2',
-                                                  '--closure=1', '-g1', '-Wno-closure'])
+                                                       '-sFORCE_FILESYSTEM', '-O2',
+                                                       '--closure=1', '-g1', '-Wno-closure'])
 
     '''# non-lz4 for comparison
     try:
@@ -4367,12 +4367,12 @@ Module["preRun"] = () => {
   def test_webgl_draw_base_vertex_base_instance(self, multi_draw, draw_elements):
     self.reftest('webgl_draw_base_vertex_base_instance_test.c', 'webgl_draw_instanced_base_vertex_base_instance.png',
                  emcc_args=['-lGL',
-                       '-sMAX_WEBGL_VERSION=2',
-                       '-sOFFSCREEN_FRAMEBUFFER',
-                       '-DMULTI_DRAW=' + str(multi_draw),
-                       '-DDRAW_ELEMENTS=' + str(draw_elements),
-                       '-DEXPLICIT_SWAP=1',
-                       '-DWEBGL_CONTEXT_VERSION=2'])
+                            '-sMAX_WEBGL_VERSION=2',
+                            '-sOFFSCREEN_FRAMEBUFFER',
+                            '-DMULTI_DRAW=' + str(multi_draw),
+                            '-DDRAW_ELEMENTS=' + str(draw_elements),
+                            '-DEXPLICIT_SWAP=1',
+                            '-DWEBGL_CONTEXT_VERSION=2'])
 
   @requires_graphics_hardware
   def test_webgl_sample_query(self):
@@ -5353,8 +5353,8 @@ Module["preRun"] = () => {
     create_file('subdir/backendfile2', 'file 2')
     self.btest_exit('wasmfs/wasmfs_fetch.c',
                     emcc_args=['-sWASMFS', '-pthread', '-sPROXY_TO_PTHREAD',
-                          '-sFORCE_FILESYSTEM', '-lfetchfs.js',
-                          '--js-library', test_file('wasmfs/wasmfs_fetch.js')] + args)
+                               '-sFORCE_FILESYSTEM', '-lfetchfs.js',
+                               '--js-library', test_file('wasmfs/wasmfs_fetch.js')] + args)
 
   @no_firefox('no OPFS support yet')
   @no_wasm64()

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -3778,8 +3778,7 @@ ok
         "side.so",
         test_file("core/test_dlfcn_jspi_side.c"),
         "-sSIDE_MODULE",
-      ]
-      + self.get_emcc_args()
+      ] + self.get_emcc_args()
     )
     self.do_run_in_out_file_test("core/test_dlfcn_jspi.c", emcc_args=["side.so", "-sMAIN_MODULE=2"])
 
@@ -8068,7 +8067,7 @@ Module.onRuntimeInitialized = () => {
   })
   @with_asyncify_and_jspi
   def test_async_ccall_promise(self, exit_runtime):
-    if self.get_setting('ASYNCIFY') ==  2:
+    if self.get_setting('ASYNCIFY') == 2:
       self.set_setting('JSPI_EXPORTS', ['stringf', 'floatf'])
     self.set_setting('ASSERTIONS')
     self.set_setting('INVOKE_RUN', 0)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8501,15 +8501,15 @@ int main() {
       return os.path.getsize('a.out.wasm')
 
     print('no bad ctor')
-    first  = test(1000, 2000, 3000, 0xe, 0x58e) # noqa
-    second = test(3000, 1000, 2000, 0xe, 0x8e5) # noqa
-    third  = test(2000, 3000, 1000, 0xe, 0xe58) # noqa
+    first  = test(1000, 2000, 3000, 0xe, 0x58e) # noqa: E221
+    second = test(3000, 1000, 2000, 0xe, 0x8e5)
+    third  = test(2000, 3000, 1000, 0xe, 0xe58) # noqa: E221
     print(first, second, third)
     assert first == second and second == third
     print('with bad ctor')
-    first  = test(1000, 2000, 3000, 0xf, 0x58f) # noqa; 2 will succeed
-    second = test(3000, 1000, 2000, 0xf, 0x8f5) # noqa; 1 will succedd
-    third  = test(2000, 3000, 1000, 0xf, 0xf58) # noqa; 0 will succeed
+    first  = test(1000, 2000, 3000, 0xf, 0x58f) # noqa: E221. 2 will succeed
+    second = test(3000, 1000, 2000, 0xf, 0x8f5) # 1 will succedd
+    third  = test(2000, 3000, 1000, 0xf, 0xf58) # noqa: E221. 0 will succeed
     print(first, second, third)
     self.assertLess(first, second)
     self.assertLess(second, third)
@@ -9182,12 +9182,12 @@ int main() {
     self.run_codesize_test('hello_libcxx.cpp', *args, check_funcs=False)
 
   @parameterized({
-    'O0': ([],      [], ['waka']), # noqa
-    'O1': (['-O1'], [], ['waka']), # noqa
-    'O2': (['-O2'], [], ['waka']), # noqa
-    'O3': (['-O3'], [], []), # noqa; in -O3, -Os and -Oz we metadce
-    'Os': (['-Os'], [], []), # noqa
-    'Oz': (['-Oz'], [], []), # noqa
+    'O0': ([],      [], ['waka']),
+    'O1': (['-O1'], [], ['waka']),
+    'O2': (['-O2'], [], ['waka']),
+    'O3': (['-O3'], [], []), # in -O3, -Os and -Oz we metadce
+    'Os': (['-Os'], [], []),
+    'Oz': (['-Oz'], [], []),
     # finally, check what happens when we export nothing. wasm should be almost empty
     'export_nothing':
           (['-Os', '-sEXPORTED_FUNCTIONS=[]'],    [], []), # noqa

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -284,7 +284,7 @@ def generate_object_file(data_files):
       # The name of file
       {f.c_symbol_name}_name:
       .asciz "{dstpath}"
-      .size {f.c_symbol_name}_name, {len(dstpath)+1}
+      .size {f.c_symbol_name}_name, {len(dstpath) + 1}
 
       # The size of the file followed by the content itself
       {f.c_symbol_name}:

--- a/tools/maint/npm_update.py
+++ b/tools/maint/npm_update.py
@@ -23,7 +23,7 @@ def run(cmd, **args):
 def main():
   if run(['git', 'status', '-uno', '--porcelain']).strip():
     print('tree is not clean')
-    #return 1
+    return 1
 
   output = run(['npx', 'npm-check-updates', '-u'], stderr=subprocess.STDOUT).strip()
 


### PR DESCRIPTION
Turns out ruff still doesn't support several flake8 warnings.  I've enabled some more that are in preview-only mode.

See #23085