### PR TITLE
Temporarily disable some tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -954,44 +954,6 @@ jobs:
       - run-tests-chrome:
           title: "browser64_4gb"
           test_targets: "browser64_4gb"
-  test-browser-firefox:
-    executor: focal
-    steps:
-      - prepare-for-tests
-      - run-tests-firefox:
-          title: "browser"
-          # browser.test_sdl2_mouse and/or SDL2 should be fixed. The case happens
-          # to be failing here, and the root cause might be related with the
-          # initial position of the mouse pointer relative to the canvas.
-          # browser.test_html5_webgl_create_context is skipped because
-          # anti-aliasing is not well supported.
-          # browser.test_webgl_offscreen_canvas_in_pthread and
-          # browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread
-          # are crashing Firefox (bugzil.la/1281796). The former case is
-          # further blocked by issue #6897.
-          test_targets: "
-            browser
-            skip:browser.test_sdl2_mouse
-            skip:browser.test_html5_webgl_create_context
-            skip:browser.test_webgl_offscreen_canvas_in_pthread
-            skip:browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread
-            skip:browser.test_glut_glutget
-            "
-  test-browser-firefox-wasm64:
-    executor: focal
-    steps:
-      - checkout
-      - run:
-          name: submodule update
-          command: git submodule update --init
-      - pip-install
-      - install-emsdk
-      - run-tests-firefox:
-          title: "browser64"
-          test_targets: "
-            browser64.test_sdl_image
-            browser64.test_dylink_many
-            "
   # TODO(sbc): Re-enable once we figure out why the emrun tests are
   # locking up.
   #test-browser-chrome-emrun:
@@ -1003,72 +965,6 @@ jobs:
     executor: focal
     steps:
       - test-sockets-chrome
-  # windows and mac do not have separate build and test jobs, as they only run
-  # a limited set of tests; it is simpler and faster to do it all in one job.
-  test-windows:
-    working_directory: "~/path with spaces"
-    executor:
-      name: win/server-2019
-      shell: bash.exe -eo pipefail
-    environment:
-      PYTHONUNBUFFERED: "1"
-      EMSDK_NOTTY: "1"
-      # clang can compile but not link in the current setup, see
-      # https://github.com/emscripten-core/emscripten/pull/11382#pullrequestreview-428902638
-      EMTEST_LACKS_NATIVE_CLANG: "1"
-      EMTEST_SKIP_V8: "1"
-      EMTEST_SKIP_EH: "1"
-      EMTEST_SKIP_WASM64: "1"
-      EMTEST_SKIP_SCONS: "1"
-      EMTEST_SKIP_RUST: "1"
-      EMTEST_SKIP_NODE_CANARY: "1"
-      EMTEST_BROWSER: "0"
-    steps:
-      - checkout
-      - run:
-          name: Install packages
-          command: |
-            choco install -y cmake.portable ninja pkgconfiglite
-      - run:
-          name: Add python to bash path
-          command: echo "export PATH=\"$PATH:/c/Python27amd64/\"" >> $BASH_ENV
-      # note we do *not* build all libraries and freeze the cache; as we run
-      # only limited tests here, it's more efficient to build on demand
-      - install-emsdk
-      - pip-install:
-          python: "$EMSDK_PYTHON"
-      - run-tests:
-          title: "crossplatform tests"
-          test_targets: "--crossplatform-only"
-      - upload-test-results
-      # Run a single websockify-based test to ensure it works on windows.
-      - run-tests:
-          title: "sockets.test_nodejs_sockets_echo*"
-          test_targets: "sockets.test_nodejs_sockets_echo*"
-      - upload-test-results
-
-  test-mac-arm64:
-    executor: mac-arm64
-    environment:
-      # We don't install d8 or modern node on the mac runner so we skip any
-      # tests that depend on those.
-      EMTEST_SKIP_V8: "1"
-      EMTEST_SKIP_EH: "1"
-      EMTEST_SKIP_WASM64: "1"
-      EMTEST_SKIP_SCONS: "1"
-      EMTEST_SKIP_RUST: "1"
-      # Some native clang tests assume x86 clang (e.g. -sse2)
-      EMTEST_LACKS_NATIVE_CLANG: "1"
-      EMCC_SKIP_SANITY_CHECK: "1"
-    steps:
-      - setup-macos
-      - install-emsdk
-      # TODO: We can't currently do pip install here since numpy and other packages
-      # are currently missing arm64 macos binaries.
-      - run-tests:
-          title: "crossplatform tests"
-          test_targets: "--crossplatform-only"
-      - upload-test-results
 
 workflows:
   build-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1114,15 +1114,9 @@ workflows:
       - test-browser-chrome-wasm64-4gb:
           requires:
             - build-linux
-      - test-browser-firefox:
-          requires:
-            - build-linux
-      - test-browser-firefox-wasm64
       - test-sockets-chrome:
           requires:
             - build-linux
       - test-jsc
       - test-spidermonkey
       - test-node-compat
-      - test-windows
-      - test-mac-arm64


### PR DESCRIPTION
Mac and Windows tests are still covered on Chromium CI, and we expect
    to restore this coverage soon.