### PR TITLE
Experimental separate CircleCI pipeline

### DIFF
--- a/.circleci/extra.yml
+++ b/.circleci/extra.yml
@@ -1,0 +1,496 @@
+version: 2.1
+
+orbs:
+  win: circleci/windows@5.0
+
+executors:
+  linux-node:
+    docker:
+      - image: cimg/node:20.15.1
+  linux-python:
+    docker:
+      - image: cimg/python:3.10.7
+  focal:
+    docker:
+      - image: emscripten/emscripten-ci:focal
+    environment:
+      LANG: "C.UTF-8"
+      EMCC_CORES: "4"
+      EMSDK_NOTTY: "1"
+      EMTEST_WASI_SYSROOT: "~/wasi-sdk/wasi-sysroot"
+      EMTEST_BUILD_VERBOSE: "2"
+      EMTEST_DETECT_TEMPFILE_LEAKS: "1"
+  mac-arm64:
+    environment:
+      EMSDK_NOTTY: "1"
+    macos:
+      xcode: "16.2.0"
+    resource_class: macos.m1.medium.gen1
+
+commands:
+  # TODO Deduplicate
+  download-chrome:
+    description: "Download chrome"
+    steps:
+      - run:
+          name: download chrome
+          command: |
+            # TODO: Make these part of the base image
+            apt-get install -q -y libu2f-udev libvulkan1 xdg-utils
+            # wget -O ~/chrome.deb https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
+            # If that download link breaks, temporarily use this URL instead:
+            # wget -O ~/chrome.deb https://storage.googleapis.com/webassembly/chrome/google-chrome-stable_current_amd64.deb
+            wget -O ~/chrome.deb https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb
+            dpkg -i ~/chrome.deb
+  emsdk-env:
+    description: "emsdk_env.sh"
+    steps:
+      - run:
+          name: emsdk_env.sh
+          command: |
+            EMSDK_BASH=1 ~/emsdk/emsdk construct_env >> $BASH_ENV
+            # In order make our external version of emscripten use the emsdk
+            # config we need to explicitly set EM_CONFIG here.
+            echo "export EM_CONFIG=~/emsdk/.emscripten" >> $BASH_ENV
+  bootstrap:
+    description: "bootstrap"
+    steps:
+      - run: ./bootstrap
+  pip-install:
+    description: "pip install"
+    parameters:
+      python:
+        description: "Python executable to use"
+        type: string
+        default: python3
+    steps:
+      - run:
+          name: pip install
+          command: << parameters.python >> -m pip install -r requirements-dev.txt
+  install-rust:
+    steps:
+      - run:
+          name: install rust
+          command: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            export PATH=${HOME}/.cargo/bin:${PATH}
+            rustup target add wasm32-unknown-emscripten
+            echo "export PATH=\"\$HOME/.cargo/bin:\$PATH\"" >> $BASH_ENV
+  install-node-version:
+    description: "install a specific version of node"
+    parameters:
+      node_version:
+        description: "version of node to install"
+        type: string
+      canary:
+        description: "install a canary version of node"
+        type: boolean
+        default: false
+    steps:
+      - run:
+          name: setup node v<< parameters.node_version >>
+          command: |
+            cd $HOME
+            version=<< parameters.node_version >>
+            if [[ << parameters.canary >> == "true" ]]; then
+              wget https://nodejs.org/download/v8-canary/v${version}/node-v${version}-linux-x64.tar.xz
+            else
+              wget https://nodejs.org/dist/v${version}/node-v${version}-linux-x64.tar.xz
+            fi
+            tar xf node-v${version}-linux-x64.tar.xz
+            echo "NODE_JS_TEST = [os.path.expanduser('~/node-v${version}-linux-x64/bin/node')]" >> ~/emsdk/.emscripten
+            echo "JS_ENGINES = [NODE_JS_TEST]" >> ~/emsdk/.emscripten
+            echo "if os.path.exists(V8_ENGINE[0]): JS_ENGINES.append(V8_ENGINE)" >> ~/emsdk/.emscripten
+            cat ~/emsdk/.emscripten
+            echo "export PATH=\"$HOME/node-v${version}-linux-x64/bin:\$PATH\"" >> $BASH_ENV
+  install-node-latest:
+    description: "install latest version of node"
+    steps:
+      - install-node-version:
+         node_version: "19.0.0"
+  install-node-canary:
+    description: "install canary version of node"
+    steps:
+      - install-node-version:
+         node_version: "24.0.0-v8-canary20250303cbbb63ede3"
+         canary: true
+  install-v8:
+    description: "install v8 using jsvu"
+    steps:
+      - run:
+          name: get v8
+          command: |
+            # We can't use a more recent version of node here because the linux
+            # image we are using doesn't have a recent enough glibc.
+            cd $HOME
+            wget https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-x64.tar.xz
+            tar -xf node-v15.14.0-linux-x64.tar.xz
+            export PATH="`pwd`/node-v15.14.0-linux-x64/bin:${PATH}"
+            npm install jsvu -g
+            jsvu --os=default --engines=v8
+  install-emsdk:
+    description: "Install emsdk"
+    steps:
+      - run:
+          name: install emsdk
+          command: |
+            curl -# -L -o ~/emsdk-main.tar.gz https://github.com/emscripten-core/emsdk/archive/main.tar.gz
+            tar -C ~ -xf ~/emsdk-main.tar.gz
+            mv ~/emsdk-main ~/emsdk
+            cd ~/emsdk
+            ./emsdk install tot
+            ./emsdk activate tot
+            # Remove the emsdk version of emscripten to save space in the
+            # persistent workspace and to avoid any confusion with the version
+            # we are trying to test.
+            rm -Rf emscripten
+            echo "import os" >> .emscripten
+            # We use an out-of-tree cache directory so it can be part of the
+            # persisted workspace (see below).
+            echo "CACHE = os.path.expanduser('~/cache')" >> .emscripten
+            # Refer to commit 0bc3640 if we need to pin V8 version.
+            echo "V8_ENGINE = [os.path.expanduser('~/.jsvu/bin/v8')]" >> .emscripten
+            echo "JS_ENGINES = [NODE_JS]" >> .emscripten
+            echo "if os.path.exists(V8_ENGINE[0]): JS_ENGINES.append(V8_ENGINE)" >> .emscripten
+            echo "WASM_ENGINES = []" >> .emscripten
+            test -f ~/vms/wasmtime && echo "WASMTIME = os.path.expanduser(os.path.join('~', 'vms', 'wasmtime')) ; WASM_ENGINES.append(WASMTIME)" >> .emscripten || true
+            test -f ~/vms/wasmer && echo "WASMER = os.path.expanduser(os.path.join('~', 'vms', 'wasmer')) ; WASM_ENGINES.append(WASMER)" >> .emscripten || true
+            test -d ~/wasi-sdk && cp -a ~/wasi-sdk/lib/ $(~/emsdk/upstream/bin/clang -print-resource-dir)
+            cd -
+            echo "final .emscripten:"
+            cat ~/emsdk/.emscripten
+      - emsdk-env
+      - bootstrap
+  build-libs:
+    description: "Build all libraries"
+    steps:
+      - run:
+          name: clear cache
+          command: |
+            ./emcc --clear-cache
+      - pip-install
+      - run: apt-get install -q -y ninja-build
+      - run:
+          name: embuilder build ALL
+          command: |
+            ./embuilder build ALL
+            ./test/runner test_hello_world
+      - run:
+          name: embuilder (LTO)
+          command: |
+            ./embuilder build MINIMAL --lto
+            ./test/runner test_hello_world
+      - run:
+          name: embuilder (WASM64)
+          command: |
+            ./embuilder build MINIMAL --wasm64
+      - run:
+          name: embuilder (PIC)
+          command: |
+            ./embuilder build MINIMAL_PIC --pic
+            ./test/runner test_hello_world
+      - run:
+          name: embuilder (PIC+LTO)
+          command: |
+            ./embuilder build MINIMAL --pic --lto
+            ./test/runner test_hello_world
+  persist:
+    description: "Persist the emsdk, libraries, and engines"
+    steps:
+      - persist_to_workspace:
+          # Must be an absolute path, or relative path from working_directory
+          root: ~/
+          # Must be relative path from root
+          paths:
+            - emsdk/
+            - cache/
+            - vms/
+            - wasi-sdk/
+            - .jsvu/
+  prepare-for-tests:
+    description: "Setup emscripten tests"
+    steps:
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: ~/
+      - checkout
+      - run:
+          name: submodule update
+          command: git submodule update --init
+      - emsdk-env
+      - bootstrap
+      - pip-install
+  upload-test-results:
+    description: "Upload test results"
+    steps:
+      - store_test_results:
+          path: out/test-results.xml
+  run-tests:
+    description: "Runs emscripten tests"
+    parameters:
+      test_targets:
+        description: "Test suites to run"
+        type: string
+      title:
+        description: "Name of given test suite"
+        type: string
+        default: ""
+      extra-cflags:
+        description: "Extra EMCC_CFLAGS"
+        type: string
+        default: ""
+    steps:
+      - when:
+          # We only set EMTEST_RETRY_FLAKY on pull requests.  When we run
+          # normal CI jobs on branches like main we still want to be able to
+          # detect flakyness.
+          condition: ${CIRCLE_PULL_REQUEST}
+          steps:
+            - set-retry-flaky-tests
+      - run:
+          name: run tests (<< parameters.title >>)
+          environment:
+            EMCC_CFLAGS: << parameters.extra-cflags >>
+          command: |
+            env
+            ./test/runner << parameters.test_targets >>
+            $EMSDK_PYTHON ./test/check_clean.py
+  freeze-cache:
+    description: "Freeze emscripten cache"
+    steps:
+      - run:
+          name: Add EM_FROZEN_CACHE to bash env
+          command: echo "export EM_FROZEN_CACHE=1" >> $BASH_ENV
+  set-retry-flaky-tests:
+    description: "Set EMTEST_RETRY_FLAKY"
+    steps:
+      - run:
+          name: Add EMTEST_RETRY_FLAKY to bash env
+          command: echo "export EMTEST_RETRY_FLAKY=2" >> $BASH_ENV
+  run-tests-linux:
+    description: "Runs emscripten tests"
+    parameters:
+      test_targets:
+        description: "Test suites to run"
+        type: string
+      frozen_cache:
+        description: "Run with cache frozen"
+        type: boolean
+        default: true
+      title:
+        description: "Name of given test suite"
+        type: string
+        default: ""
+    steps:
+      - prepare-for-tests
+      - when:
+          condition: << parameters.frozen_cache >>
+          steps:
+            - freeze-cache
+      - run-tests:
+          test_targets: << parameters.test_targets >>
+          title: << parameters.title >>
+      - upload-test-results
+  run-tests-chrome:
+    description: "Runs browser tests under chrome"
+    parameters:
+      test_targets:
+        description: "Test suites to run"
+        type: string
+      title:
+        description: "Name of given test suite"
+        type: string
+        default: ""
+    steps:
+      - prepare-for-tests
+      - download-chrome
+      - run:
+          name: run tests (<< parameters.title >>)
+          environment:
+            EMTEST_DETECT_TEMPFILE_LEAKS: "0"
+            # --no-sandbox because we are running as root and chrome requires
+            # this flag for now: https://crbug.com/638180
+            CHROME_FLAGS_BASE: "--no-first-run -start-maximized --no-sandbox --use-gl=swiftshader --user-data-dir=/tmp/chrome-emscripten-profile --enable-experimental-web-platform-features"
+            CHROME_FLAGS_HEADLESS: "--headless=new --remote-debugging-port=1234"
+            CHROME_FLAGS_WASM: "--enable-experimental-webassembly-features --js-flags=\"--experimental-wasm-stack-switching --experimental-wasm-type-reflection\""
+            CHROME_FLAGS_NOCACHE: "--disk-cache-dir=/dev/null --disk-cache-size=1 --media-cache-size=1 --disable-application-cache --incognito"
+            # The runners lack sound hardware so fallback to a dummy device (and
+            # bypass the user gesture so audio tests work without interaction)
+            CHROME_FLAGS_AUDIO: " --use-fake-device-for-media-stream --autoplay-policy=no-user-gesture-required"
+          command: |
+            export EMTEST_BROWSER="/usr/bin/google-chrome $CHROME_FLAGS_BASE $CHROME_FLAGS_HEADLESS $CHROME_FLAGS_WASM $CHROME_FLAGS_NOCACHE $CHROME_FLAGS_AUDIO"
+            # There are tests in the browser test suite that using libraries
+            # that are not included by "./embuilder build ALL".  For example the
+            # PIC version of libSDL which is used by test_sdl2_misc_main_module
+            export EM_FROZEN_CACHE=""
+            test/runner << parameters.test_targets >>
+      - upload-test-results
+  setup-macos:
+    steps:
+      - run:
+          name: Install brew package dependencies
+          environment:
+            HOMEBREW_NO_AUTO_UPDATE: "1"
+          # Use --force-bottle to force homebrew use binary packages avoiding
+          # costly build times.
+          command: brew install --force-bottle cmake ninja pkg-config
+      - checkout
+      - run:
+          name: submodule update
+          command: git submodule update --init
+  run-tests-firefox:
+    description: "Runs emscripten tests under firefox"
+    parameters:
+      test_targets:
+        description: "Test suites to run"
+        type: string
+      title:
+        description: "Name of given test suite"
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: download firefox
+          command: |
+            wget -O ~/ff.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
+            tar -C ~ -xf ~/ff.tar.bz2
+      - run:
+          name: Add audio dependencies
+          command: |
+            # This should add and start PulseAudio's dummy mixer. It will warn
+            # that "This program is not intended to be run as root" but it can
+            # be ignored.
+            apt-get update -y
+            apt-get install -q -y pulseaudio
+            pulseaudio --start
+      - run:
+          name: configure firefox
+          command: |
+            # Note: the autoplay pref allows playback without user interaction
+            mkdir ~/tmp-firefox-profile/
+            cat > ~/tmp-firefox-profile/user.js \<<EOF
+            user_pref("gfx.offscreencanvas.enabled", true);
+            user_pref("javascript.options.shared_memory", true);
+            user_pref("javascript.options.wasm_memory64", true);
+            user_pref("dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled", true);
+            user_pref("media.autoplay.default", 0);
+            EOF
+      - run:
+          name: run tests (<< parameters.title >>)
+          environment:
+            GALLIUM_DRIVER: softpipe # TODO: use the default llvmpipe when it supports more extensions
+            # TODO: Do GL testing when https://bugzil.la/1375585 (lack of WebGL
+            #       support in headless mode) resolves
+            EMTEST_LACKS_GRAPHICS_HARDWARE: "1"
+            EMTEST_LACKS_WEBGPU: "1"
+            # OffscreenCanvas support is not yet done in Firefox.
+            EMTEST_LACKS_OFFSCREEN_CANVAS: "1"
+            EMTEST_DETECT_TEMPFILE_LEAKS: "0"
+            DISPLAY: ":0"
+          command: |
+            export EMTEST_BROWSER="$HOME/firefox/firefox -headless -profile $HOME/tmp-firefox-profile/"
+            # There are tests in the browser test suite that using libraries
+            # that are not included by "./embuilder build ALL".  For example the
+            # PIC version of libSDL which is used by test_sdl2_misc_main_module
+            export EM_FROZEN_CACHE=""
+            echo "-----"
+            echo "Running browser tests"
+            echo "-----"
+            test/runner << parameters.test_targets >>
+            # posix and emrun suites are disabled because firefox errors on
+            #  "Firefox is already running, but is not responding."
+            # TODO: find out a way to shut down and restart firefox
+      - upload-test-results
+  test-sockets-chrome:
+    description: "Runs emscripten sockets tests under chrome"
+    steps:
+      - prepare-for-tests
+      - download-chrome
+      - run:
+          name: run sockets tests
+          environment:
+            EMTEST_LACKS_SOUND_HARDWARE: "1"
+            EMTEST_DETECT_TEMPFILE_LEAKS: "0"
+            # --no-sandbox becasue we are running as root and chrome requires
+            # this flag for now: https://crbug.com/638180
+            CHROME_FLAGS_BASE: "--no-first-run -start-maximized --no-sandbox --use-gl=swiftshader --user-data-dir=/tmp/chrome-emscripten-profile"
+            CHROME_FLAGS_HEADLESS: "--headless=new --remote-debugging-port=1234"
+            CHROME_FLAGS_WASM: "--enable-experimental-webassembly-features"
+            CHROME_FLAGS_NOCACHE: "--disk-cache-dir=/dev/null --disk-cache-size=1 --media-cache-size=1 --disable-application-cache --incognito"
+          command: |
+            export EMTEST_BROWSER="/usr/bin/google-chrome $CHROME_FLAGS_BASE $CHROME_FLAGS_HEADLESS $CHROME_FLAGS_WASM $CHROME_FLAGS_NOCACHE"
+            test/runner sockets
+      - upload-test-results
+
+jobs:
+  # windows and mac do not have separate build and test jobs, as they only run
+  # a limited set of tests; it is simpler and faster to do it all in one job.
+  test-windows:
+    working_directory: "~/path with spaces"
+    executor:
+      name: win/server-2019
+      shell: bash.exe -eo pipefail
+    environment:
+      PYTHONUNBUFFERED: "1"
+      EMSDK_NOTTY: "1"
+      # clang can compile but not link in the current setup, see
+      # https://github.com/emscripten-core/emscripten/pull/11382#pullrequestreview-428902638
+      EMTEST_LACKS_NATIVE_CLANG: "1"
+      EMTEST_SKIP_V8: "1"
+      EMTEST_SKIP_EH: "1"
+      EMTEST_SKIP_WASM64: "1"
+      EMTEST_SKIP_SCONS: "1"
+      EMTEST_SKIP_RUST: "1"
+      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_BROWSER: "0"
+    steps:
+      - checkout
+      - run:
+          name: Install packages
+          command: |
+            choco install -y cmake.portable ninja pkgconfiglite
+      - run:
+          name: Add python to bash path
+          command: echo "export PATH=\"$PATH:/c/Python27amd64/\"" >> $BASH_ENV
+      # note we do *not* build all libraries and freeze the cache; as we run
+      # only limited tests here, it's more efficient to build on demand
+      - install-emsdk
+      - pip-install:
+          python: "$EMSDK_PYTHON"
+      - run-tests:
+          title: "crossplatform tests"
+          test_targets: "--crossplatform-only"
+      - upload-test-results
+      # Run a single websockify-based test to ensure it works on windows.
+      - run-tests:
+          title: "sockets.test_nodejs_sockets_echo*"
+          test_targets: "sockets.test_nodejs_sockets_echo*"
+      - upload-test-results
+
+  test-mac-arm64:
+    executor: mac-arm64
+    environment:
+      # We don't install d8 or modern node on the mac runner so we skip any
+      # tests that depend on those.
+      EMTEST_SKIP_V8: "1"
+      EMTEST_SKIP_EH: "1"
+      EMTEST_SKIP_WASM64: "1"
+      EMTEST_SKIP_SCONS: "1"
+      EMTEST_SKIP_RUST: "1"
+      # Some native clang tests assume x86 clang (e.g. -sse2)
+      EMTEST_LACKS_NATIVE_CLANG: "1"
+      EMCC_SKIP_SANITY_CHECK: "1"
+    steps:
+      - setup-macos
+      - install-emsdk
+      # TODO: We can't currently do pip install here since numpy and other packages
+      # are currently missing arm64 macos binaries.
+      - run-tests:
+          title: "crossplatform tests"
+          test_targets: "--crossplatform-only"
+      - upload-test-results
+
+workflows:
+  extra-test:
+      - test-windows
+      - test-mac-arm64


### PR DESCRIPTION
Separate Windows and Mac into a new pipeline, manually triggerable by adding "run ci" label.