### PR TITLE
Fix sourcemap prefix path substitution on windows

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10476,7 +10476,6 @@ int main() {
     'sources': ([], 1)
   })
   @crossplatform
-  @no_windows('https://github.com/emscripten-core/emscripten/pull/23741#issuecomment-2725574867')
   def test_emcc_sourcemap_options(self, prefixes, sources):
     wasm_sourcemap = importlib.import_module('tools.wasm-sourcemap')
     cwd = os.getcwd()

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -55,10 +55,10 @@ class Prefixes:
     for p in args:
       if '=' in p:
         prefix, replacement = p.split('=')
-        prefixes.append({'prefix': prefix, 'replacement': replacement})
+        prefixes.append({'prefix': utils.normalize_path(prefix), 'replacement': replacement})
       else:
-        prefixes.append({'prefix': p, 'replacement': ''})
-    self.base_path = base_path
+        prefixes.append({'prefix': utils.normalize_path(p), 'replacement': ''})
+    self.base_path = utils.normalize_path(base_path) if base_path is not None else None
     self.preserve_deterministic_prefix = preserve_deterministic_prefix
     self.prefixes = prefixes
     self.cache = {}


### PR DESCRIPTION
Normalize prefixes instead of expecting windows users to do it. 

See https://github.com/emscripten-core/emscripten/pull/23741#issuecomment-2725574867

The tests now pass on windows. 