### PR TITLE
Deprecate EMULATE_FUNCTION_POINTER_CASTS setting

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7142,7 +7142,7 @@ void* operator new(size_t size) {
     # https://github.com/emscripten-core/emscripten/issues/15081
     self.set_setting('EXIT_RUNTIME', 0)
     self.set_setting('EMULATE_FUNCTION_POINTER_CASTS')
-    self.do_core_test('test_emulate_function_pointer_casts.cpp')
+    self.do_core_test('test_emulate_function_pointer_casts.cpp', emcc_args=['-Wno-deprecated'])
 
   @no_wasm2js('TODO: nicely printed names in wasm2js')
   @parameterized({

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -5715,7 +5715,7 @@ int main() {
         if safe:
           cmd += ['-sSAFE_HEAP']
         if emulate_casts:
-          cmd += ['-sEMULATE_FUNCTION_POINTER_CASTS']
+          cmd += ['-sEMULATE_FUNCTION_POINTER_CASTS', '-Wno-deprecated']
         if relocatable:
           cmd += ['-sRELOCATABLE'] # disables asm-optimized safe heap
         print(cmd)
@@ -12488,7 +12488,7 @@ Aborted(`Module.arguments` has been replaced by `arguments_` (the initial value 
         }
       }
     ''')
-    self.do_runf('src.c', 'ok\ndone\n', emcc_args=['-sEMULATE_FUNCTION_POINTER_CASTS'])
+    self.do_runf('src.c', 'ok\ndone\n', emcc_args=['-Wno-deprecated', '-sEMULATE_FUNCTION_POINTER_CASTS'])
 
   def test_no_lto(self):
     # This used to fail because settings.LTO didn't reflect `-fno-lto`.

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -124,7 +124,8 @@ DEPRECATED_SETTINGS = {
     'RUNTIME_LINKED_LIBS': 'you can simply list the libraries directly on the commandline now',
     'CLOSURE_WARNINGS': 'use -Wclosure instead',
     'LEGALIZE_JS_FFI': 'to disable JS type legalization use `-sWASM_BIGINT` or `-sSTANDALONE_WASM`',
-    'ASYNCIFY_EXPORTS': 'please use JSPI_EXPORTS instead'
+    'ASYNCIFY_EXPORTS': 'please use JSPI_EXPORTS instead',
+    'EMULATE_FUNCTION_POINTER_CASTS': 'lack of usage',
 }
 
 # Settings that don't need to be externalized when serializing to json because they


### PR DESCRIPTION
Users who use this setting will now see the following warning:

```
emcc: warning: EMULATE_FUNCTION_POINTER_CASTS is deprecated (no known users). Please open a bug if you have a continuing need for this setting [-Wdeprecated]
```

See #23952