### PR TITLE
Simplify use of `new Function` in embind. NFC

### DIFF
--- a/src/lib/libembind.js
+++ b/src/lib/libembind.js
@@ -858,9 +858,7 @@ var LibraryEmbind = {
 #else
 
     let [args, invokerFnBody] = createJsInvoker(argTypes, isClassMethodFunc, returns, isAsync);
-    args.push(invokerFnBody);
-    var invokerFn = new Function(...args)(...closureArgs);
-
+    var invokerFn = new Function(...args, invokerFnBody)(...closureArgs);
 #endif
 #endif
     return createNamedFunction(humanName, invokerFn);

--- a/src/lib/libemval.js
+++ b/src/lib/libemval.js
@@ -381,8 +381,7 @@ var LibraryEmVal = {
     functionBody +=
       "};\n";
 
-    params.push(functionBody);
-    var invokerFunction = new Function(...params)(...args);
+    var invokerFunction = new Function(...params, functionBody)(...args);
 #endif
     var functionName = `methodCaller<(${types.map(t => t.name).join(', ')}) => ${retType.name}>`;
     return emval_addMethodCaller(createNamedFunction(functionName, invokerFunction));

--- a/test/code_size/embind_hello_wasm.json
+++ b/test/code_size/embind_hello_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 380,
-  "a.js": 9482,
-  "a.js.gz": 4164,
+  "a.js": 9473,
+  "a.js.gz": 4157,
   "a.wasm": 7348,
   "a.wasm.gz": 3378,
-  "total": 17382,
-  "total_gz": 7922
+  "total": 17373,
+  "total_gz": 7915
 }


### PR DESCRIPTION
Passing the function body explicitly seems less magical, and also saves a little on code size.