### PR TITLE
Reimplement resolve_path in JS Take 2 NFC

### DIFF
--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1238,7 +1238,14 @@ var LibraryDylink = {
   _dylink_resolve_path_js__deps: ['$UTF8ToString', '$stringToUTF8', '$locateLibraryFromFS', '$getDefaultLibDirs'],
   _dylink_resolve_path_js__proxy: 'sync',
   _dylink_resolve_path_js: (cbuf, cfile, buflen) => {
-    var file = UTF8ToString(cfile);
+    var cfilePtr = cfile;
+
+#if MEMORY64
+    cfilePtr = Number(cfilePtr);
+#endif
+
+    var file = UTF8ToString(cfilePtr);
+
     if (file.startsWith("/")) {
       return cfile;
     }

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1215,6 +1215,9 @@ var LibraryDylink = {
 #endif
         return res.path;
       } catch(e) {
+#if DYLINK_DEBUG
+        dbg(`locateLibraryFromFS: ${path} not found: ${e}`);
+#endif
         // do nothing is file is not found
       }
     }
@@ -1238,10 +1241,6 @@ var LibraryDylink = {
     if (file.startsWith("/")) {
       return cfile;
     }
-
-// #if DYLINK_DEBUG
-//     dbg("_dylink_resolve_path_js: entries in sharedModules: " + Object.keys(sharedModules));
-// #endif
 
     var res = locateLibraryFromFS(file, getDefaultLibDirs(), buflen - 1);
     if (!res) {

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1239,9 +1239,9 @@ var LibraryDylink = {
       return cfile;
     }
 
-#if DYLINK_DEBUG
-    dbg("_dylink_resolve_path_js: entries in sharedModules: " + Object.keys(sharedModules));
-#endif
+// #if DYLINK_DEBUG
+//     dbg("_dylink_resolve_path_js: entries in sharedModules: " + Object.keys(sharedModules));
+// #endif
 
     var res = locateLibraryFromFS(file, getDefaultLibDirs(), buflen - 1);
     if (!res) {

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -656,7 +656,7 @@ var LibraryDylink = {
       }
 #if DYLINK_DEBUG
       dbg(`loadModule: memory[${memoryBase}:${memoryBase + metadata.memorySize}]` +
-                     ` table[${tableBasex}:${tableBase + metadata.tableSize}]`);
+                     ` table[${tableBase}:${tableBase + metadata.tableSize}]`);
 #endif
 
       // This is the export map that we ultimately return.  We declare it here
@@ -1170,6 +1170,88 @@ var LibraryDylink = {
 #else
     return dlopenInternal(handle, { loadAsync: false });
 #endif
+  },
+
+  $locateLibraryFromFS__deps: ['$FS'],
+  $locateLibraryFromFS: (filename, searchDirs, maxLength = Infinity) => {
+    // Find the library in the filesystem.
+    // returns null if not found.
+    if (typeof FS.lookupPath !== 'function') {
+      // wasmfs does not implement FS.lookupPath
+#if DYLINK_DEBUG
+      dbg("locateLibraryFromFS: FS.lookupPath not implemented");
+#endif
+      return null;
+    }
+
+    var candidates = [];
+    if (filename.charAt(0) === '/') {  // abs path
+      candidates.push(filename);
+    } else if (searchDirs) {
+      for (var dir of searchDirs) {
+        // PATH.join does not work well with symlinks
+        candidates.push(dir + '/' + filename);
+      }
+    } else {
+      return null;
+    }
+
+#if DYLINK_DEBUG
+    dbg("locateLibraryFromFS: candidates " + candidates);
+#endif
+
+    for (var path of candidates) {
+      try {
+        var res = FS.lookupPath(path);
+        if (res.node.isDir || res.node.isDevice) {
+          continue
+        }
+
+        if (res.path.length >= maxLength) {
+          continue
+        }
+#if DYLINK_DEBUG
+        dbg(`locateLibraryFromFS: found ${res.path} for (${filename})`);
+#endif
+        return res.path;
+      } catch(e) {
+        // do nothing is file is not found
+      }
+    }
+
+    return null;
+  },
+
+  $getDefaultLibDirs__deps: ['$ENV'],
+  $getDefaultLibDirs: () => {
+    var ldLibraryPath = ENV['LD_LIBRARY_PATH']
+#if DYLINK_DEBUG
+    dbg(`getDefaultLibDirs: LD_LIBRARY_PATH=${ldLibraryPath}`);
+#endif
+    // return ldLibraryPath?.split(':') ?? [];
+    return "/lib:/usr/lib:/usr/local/lib".split(':');
+  },
+
+  _dylink_resolve_path_js__deps: ['$UTF8ToString', '$stringToUTF8', '$locateLibraryFromFS', '$getDefaultLibDirs'],
+  _dylink_resolve_path_js: (cbuf, cfile, buflen) => {
+    var file = UTF8ToString(cfile);
+    if (file.startsWith("/")) {
+      return cfile;
+    }
+
+#if DYLINK_DEBUG
+    dbg("_dylink_resolve_path_js: entries in sharedModules: " + Object.keys(sharedModules));
+#endif
+
+    var res = locateLibraryFromFS(file, getDefaultLibDirs(), buflen - 1);
+    if (!res) {
+#if DYLINK_DEBUG
+    dbg("_dylink_resolve_path_js: fail to locate " + file);
+#endif
+      return cfile;
+    }
+    stringToUTF8(res, cbuf, buflen);
+    return cbuf;
   },
 
   // Async version of dlopen.

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1251,7 +1251,7 @@ var LibraryDylink = {
       return cfile;
     }
 
-    var res = locateLibraryFromFS(file, getDefaultLibDirs(), buflenMinusOne);
+    var res = locateLibraryFromFS(file, getDefaultLibDirs(), buflen - 1);
     if (!res) {
 #if DYLINK_DEBUG
     dbg("_dylink_resolve_path_js: fail to locate " + file);

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1250,7 +1250,10 @@ var LibraryDylink = {
       return cfile;
     }
 
-    var res = locateLibraryFromFS(file, getDefaultLibDirs(), buflen - 1);
+    // Use decrement instead of subtracting 1 normally to handle memory64 case
+    var buflenMinusOne = buflen;
+    buflenMinusOne--;
+    var res = locateLibraryFromFS(file, getDefaultLibDirs(), buflenMinusOne);
     if (!res) {
 #if DYLINK_DEBUG
     dbg("_dylink_resolve_path_js: fail to locate " + file);

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1242,6 +1242,7 @@ var LibraryDylink = {
 
 #if MEMORY64
     cfilePtr = Number(cfilePtr);
+    buflen = Number(buflen)
 #endif
 
     var file = UTF8ToString(cfilePtr);
@@ -1250,9 +1251,6 @@ var LibraryDylink = {
       return cfile;
     }
 
-    // Use decrement instead of subtracting 1 normally to handle memory64 case
-    var buflenMinusOne = buflen;
-    buflenMinusOne--;
     var res = locateLibraryFromFS(file, getDefaultLibDirs(), buflenMinusOne);
     if (!res) {
 #if DYLINK_DEBUG

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1226,13 +1226,13 @@ var LibraryDylink = {
   },
 
   $getDefaultLibDirs__deps: ['$ENV'],
+  $getDefaultLibDirs__proxy: 'sync',
   $getDefaultLibDirs: () => {
     var ldLibraryPath = ENV['LD_LIBRARY_PATH']
 #if DYLINK_DEBUG
     dbg(`getDefaultLibDirs: LD_LIBRARY_PATH=${ldLibraryPath}`);
 #endif
-    // return ldLibraryPath?.split(':') ?? [];
-    return "/lib:/usr/lib:/usr/local/lib".split(':');
+    return ldLibraryPath?.split(':') ?? [];
   },
 
   _dylink_resolve_path_js__deps: ['$UTF8ToString', '$stringToUTF8', '$locateLibraryFromFS', '$getDefaultLibDirs'],

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1236,6 +1236,7 @@ var LibraryDylink = {
   },
 
   _dylink_resolve_path_js__deps: ['$UTF8ToString', '$stringToUTF8', '$locateLibraryFromFS', '$getDefaultLibDirs'],
+  _dylink_resolve_path_js__proxy: 'sync',
   _dylink_resolve_path_js: (cbuf, cfile, buflen) => {
     var file = UTF8ToString(cfile);
     if (file.startsWith("/")) {

--- a/src/lib/libsigs.js
+++ b/src/lib/libsigs.js
@@ -282,7 +282,7 @@ sigs = {
   _dlopen_js__sig: 'pp',
   _dlsym_catchup_js__sig: 'ppi',
   _dlsym_js__sig: 'pppp',
-  _dylink_resolve_path_js: 'pppp',
+  _dylink_resolve_path_js__sig: 'pppp',
   _embind_create_inheriting_constructor__sig: 'pppp',
   _embind_finalize_value_array__sig: 'vp',
   _embind_finalize_value_object__sig: 'vp',

--- a/src/lib/libsigs.js
+++ b/src/lib/libsigs.js
@@ -282,6 +282,7 @@ sigs = {
   _dlopen_js__sig: 'pp',
   _dlsym_catchup_js__sig: 'ppi',
   _dlsym_js__sig: 'pppp',
+  _dylink_resolve_path_js: 'pppp',
   _embind_create_inheriting_constructor__sig: 'pppp',
   _embind_finalize_value_array__sig: 'vp',
   _embind_finalize_value_object__sig: 'vp',

--- a/system/lib/libc/dynlink.c
+++ b/system/lib/libc/dynlink.c
@@ -494,49 +494,6 @@ static struct dso* find_existing(const char* file) {
   return NULL;
 }
 
-// Modified version of path_open from musl/ldso/dynlink.c
-static int path_find(const char *name, const char *s, char *buf, size_t buf_size) {
-  size_t l;
-  int fd;
-  for (;;) {
-    s += strspn(s, ":\n");
-    l = strcspn(s, ":\n");
-    if (l-1 >= INT_MAX) return -1;
-    if (snprintf(buf, buf_size, "%.*s/%s", (int)l, s, name) < buf_size) {
-      dbg("dlopen: path_find: %s", buf);
-      struct stat statbuf;
-      if (stat(buf, &statbuf) == 0 && S_ISREG(statbuf.st_mode)) {
-        return 0;
-      }
-      switch (errno) {
-      case ENOENT:
-      case ENOTDIR:
-      case EACCES:
-      case ENAMETOOLONG:
-        break;
-      default:
-        dbg("dlopen: path_find failed: %s", strerror(errno));
-        /* Any negative value but -1 will inhibit
-         * futher path search. */
-        return -2;
-      }
-    }
-    s += l;
-  }
-}
-
-// Resolve filename using LD_LIBRARY_PATH
-static const char* resolve_path(char* buf, const char* file, size_t buflen) {
-  if (!strchr(file, '/')) {
-    const char* env_path = getenv("LD_LIBRARY_PATH");
-    if (env_path && path_find(file, env_path, buf, buflen) == 0) {
-      dbg("dlopen: found in LD_LIBRARY_PATH: %s", buf);
-      return buf;
-    }
-  }
-  return file;
-}
-
 // Internal version of dlopen with typed return value.
 // Without this, the compiler won't tell us if we have the wrong return type.
 static struct dso* _dlopen(const char* file, int flags) {

--- a/system/lib/libc/emscripten_internal.h
+++ b/system/lib/libc/emscripten_internal.h
@@ -90,6 +90,7 @@ void _emscripten_dlopen_js(struct dso* handle,
                            dlopen_callback_func onsuccess,
                            dlopen_callback_func onerror,
                            void* user_data);
+const char* _dylink_resolve_path_js(char* buf, const char* file, size_t buflen);
 void* _dlsym_catchup_js(struct dso* handle, int sym_index);
 
 int _setitimer_js(int which, double timeout);

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7555,19 +7555,12 @@ int main(int argc, char** argv) {
     self.assertBinaryEqual('main.wasm', 'main2.wasm')
 
   @parameterized({
-    '': (False, False),
-    'pthread': (True, False),
-    'wasm64': (False, True),
-    'pthread-wasm64': (True, True),
+    '': ([],),
+    'pthread': (['-g', '-pthread', '-Wno-experimental', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'],),
   })
-  def test_ld_library_path(self, pthread, wasm64):
-    args = []
-    if pthread:
-      args += ['-g', '-pthread', '-Wno-experimental', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME']
+  def test_ld_library_path(self, args):
+    if args:
       self.setup_node_pthreads()
-    if wasm64:
-      self.require_wasm64()
-      args += ['-sMEMORY64']
     create_file('hello1.c', r'''
 #include <stdio.h>
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7567,7 +7567,7 @@ int main(int argc, char** argv) {
       self.setup_node_pthreads()
     if wasm64:
       self.require_wasm64()
-      args += ['-sMEMORY64']
+      args += ['-sMEMORY64', '-sENVIRONMENT=node,shell']
     create_file('hello1.c', r'''
 #include <stdio.h>
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7555,8 +7555,8 @@ int main(int argc, char** argv) {
     self.assertBinaryEqual('main.wasm', 'main2.wasm')
 
   @parameterized({
-    '': ([],),
-    'pthread': (['-g', '-pthread', '-Wno-experimental', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'],),
+    '': (['-sDYLINK_DEBUG'],),
+    'pthread': (['-g', '-pthread', '-Wno-experimental', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME', '-sDYLINK_DEBUG'],),
   })
   def test_ld_library_path(self, args):
     if args:

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7555,12 +7555,19 @@ int main(int argc, char** argv) {
     self.assertBinaryEqual('main.wasm', 'main2.wasm')
 
   @parameterized({
-    '': ([],),
-    'pthread': (['-g', '-pthread', '-Wno-experimental', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'],),
+    '': (False, False),
+    'pthread': (True, False),
+    'wasm64': (False, True),
+    'pthread-wasm64': (True, True),
   })
-  def test_ld_library_path(self, args):
-    if args:
+  def test_ld_library_path(self, pthread, wasm64):
+    args = []
+    if pthread:
+      args += ['-g', '-pthread', '-Wno-experimental', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME']
       self.setup_node_pthreads()
+    if wasm64:
+      self.require_wasm64()
+      args += ['-sMEMORY64']
     create_file('hello1.c', r'''
 #include <stdio.h>
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7567,7 +7567,7 @@ int main(int argc, char** argv) {
       self.setup_node_pthreads()
     if wasm64:
       self.require_wasm64()
-      args += ['-sMEMORY64', '-sENVIRONMENT=node,shell']
+      args += ['-sMEMORY64']
     create_file('hello1.c', r'''
 #include <stdio.h>
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7555,8 +7555,8 @@ int main(int argc, char** argv) {
     self.assertBinaryEqual('main.wasm', 'main2.wasm')
 
   @parameterized({
-    '': (['-sDYLINK_DEBUG'],),
-    'pthread': (['-g', '-pthread', '-Wno-experimental', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME', '-sDYLINK_DEBUG'],),
+    '': ([],),
+    'pthread': (['-g', '-pthread', '-Wno-experimental', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'],),
   })
   def test_ld_library_path(self, args):
     if args:


### PR DESCRIPTION
Reopening #23935 

---

As discussed in https://github.com/emscripten-core/emscripten/pull/23872, this PR reimplements resolve_path function, which is used to locate the library using LD_LIBRARY_PATH in JavaScript, so that it can be reused inside libdylink.js.

Currently, this code doesn't work in thread.