### PR TITLE
Remove use of `new.target`

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7040,7 +7040,7 @@ int main(void) {
     self.run_process([EMCC, test_file('hello_world.c'), '-sMODULARIZE', '-sEXPORT_NAME=Foo'])
     create_file('run.js', 'var m = require("./a.out.js"); new m();')
     err = self.run_js('run.js', assert_returncode=NON_ZERO)
-    self.assertContained('Error: Foo() should not be called with `new Foo()`', err)
+    self.assertContained('TypeError: m is not a constructor', err)
 
   @parameterized({
     '': ([],),

--- a/tools/link.py
+++ b/tools/link.py
@@ -2469,19 +2469,6 @@ var %(EXPORT_NAME)s = (() => {
         'wrapper_function': wrapper_function,
       }
 
-  if settings.ASSERTIONS and settings.MODULARIZE != 'instance':
-    src += '''\
-(() => {
-  // Create a small, never-async wrapper around %(EXPORT_NAME)s which
-  // checks for callers incorrectly using it with `new`.
-  var real_%(EXPORT_NAME)s = %(EXPORT_NAME)s;
-  %(EXPORT_NAME)s = function(arg) {
-    if (new.target) throw new Error("%(EXPORT_NAME)s() should not be called with `new %(EXPORT_NAME)s()`");
-    return real_%(EXPORT_NAME)s(arg);
-  }
-})();
-''' % {'EXPORT_NAME': settings.EXPORT_NAME}
-
   if settings.SOURCE_PHASE_IMPORTS:
     src = f"import source wasmModule from './{settings.WASM_BINARY_FILE}';\n\n" + src
 


### PR DESCRIPTION
This syntax is not transpile-able to ES5, so its better to avoid it for now.

The error produced without this extra check seems reasonable enough.

Fixes: #23959