### PR TITLE
Deprecate -sMAYBE_WASM2JS settings

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8388,7 +8388,7 @@ Module.onRuntimeInitialized = () => {
       self.skipTest('redundant to test wasm2js in wasm2js* mode')
     self.set_setting('MAYBE_WASM2JS')
     # see that running as wasm works
-    self.do_core_test('test_hello_world.c')
+    self.do_core_test('test_hello_world.c', emcc_args=['-Wno-deprecated'])
     # run wasm2js, bundle the code, and use the wasm2js path
     cmd = [PYTHON, path_from_root('tools/maybe_wasm2js.py'), 'test_hello_world.js', 'test_hello_world.wasm']
     if self.is_optimizing():

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -126,6 +126,7 @@ DEPRECATED_SETTINGS = {
     'LEGALIZE_JS_FFI': 'to disable JS type legalization use `-sWASM_BIGINT` or `-sSTANDALONE_WASM`',
     'ASYNCIFY_EXPORTS': 'please use JSPI_EXPORTS instead',
     'EMULATE_FUNCTION_POINTER_CASTS': 'lack of usage',
+    'MAYBE_WASM2JS': 'lack of usage',
 }
 
 # Settings that don't need to be externalized when serializing to json because they


### PR DESCRIPTION
Users of this settings will now see:

```
emcc: warning: MAYBE_WASM2JS is deprecated (no known users). Please open a bug if you have a continuing need for this setting [-Wdeprecated]
```

See #23969