### PR TITLE
Initial experimental support for ESM integration

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 4.0.7 (in development)
 ----------------------
+- Added experimental support for Wasm ESM integration with
+  `-sWASM_ESM_INTEGRATION`. This is currently only supported in node behind a
+  flag and not in any browsers. (#23985)
 
 4.0.6 - 03/26/25
 ----------------

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -3345,3 +3345,13 @@ and not yet supported by browsers.
 Requires EXPORT_ES6
 
 Default value: false
+
+.. _wasm_esm_integration:
+
+WASM_ESM_INTEGRATION
+====================
+
+Experimental support for wasm ESM integration.
+Requires EXPORT_ES6 and MODULARIZE=instance
+
+Default value: false

--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -857,7 +857,7 @@ var proxiedFunctionTable = [
       includeFile(fileName);
     }
 
-    if (MODULARIZE) {
+    if (MODULARIZE && !WASM_ESM_INTEGRATION) {
       includeSystemFile('postamble_modularize.js');
     }
 

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -305,7 +305,16 @@ consumedModuleProp('preInit');
 #endif
 #endif
 
+
+#if WASM_ESM_INTEGRATION
+export default function init(moduleArg = {}) {
+  // TODO(sbc): moduleArg processing
+  updateMemoryViews();
+  run();
+}
+#else
 run();
+#endif
 
 #if BUILD_AS_WORKER
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -46,7 +46,9 @@ if (typeof WebAssembly != 'object') {
 
 // Wasm globals
 
+#if !WASM_ESM_INTEGRATION
 var wasmMemory;
+#endif
 
 #if SHARED_MEMORY
 // For sending to workers.
@@ -220,7 +222,11 @@ function initRuntime() {
   <<< ATINITS >>>
 
 #if hasExportedSymbol('__wasm_call_ctors')
+#if WASM_ESM_INTEGRATION
+  ___wasm_call_ctors();
+#else
   wasmExports['__wasm_call_ctors']();
+#endif
 #endif
 
   <<< ATPOSTCTORS >>>
@@ -577,7 +583,7 @@ function resetPrototype(constructor, attrs) {
 }
 #endif
 
-#if !SOURCE_PHASE_IMPORTS
+#if !SOURCE_PHASE_IMPORTS && !WASM_ESM_INTEGRATION
 var wasmBinaryFile;
 
 function findWasmBinary() {
@@ -819,6 +825,7 @@ async function instantiateAsync(binary, binaryFile, imports) {
 #endif // WASM_ASYNC_COMPILATION
 #endif // SOURCE_PHASE_IMPORTS
 
+#if !WASM_ESM_INTEGRATION
 function getWasmImports() {
 #if PTHREADS
   assignWasmImports();
@@ -1058,6 +1065,7 @@ function getWasmImports() {
 #endif // WASM_ASYNC_COMPILATION
 #endif // SOURCE_PHASE_IMPORTS
 }
+#endif
 
 #if !WASM_BIGINT
 // Globals used by JS i64 conversions (see makeSetValue)

--- a/src/runtime_shared.js
+++ b/src/runtime_shared.js
@@ -54,7 +54,7 @@ var wasmOffsetConverter;
       }
     }
     if (shouldExport) {
-      if (MODULARIZE === 'instance') {
+      if (MODULARIZE === 'instance' && !WASM_ESM_INTEGRATION) {
         return `__exp_${x} = `
       }
       return `Module['${x}'] = `;

--- a/src/settings.js
+++ b/src/settings.js
@@ -2188,6 +2188,11 @@ var SIGNATURE_CONVERSIONS = [];
 // [link]
 var SOURCE_PHASE_IMPORTS = false;
 
+// Experimental support for wasm ESM integration.
+// Requires EXPORT_ES6 and MODULARIZE=instance
+// [link]
+var WASM_ESM_INTEGRATION = false;
+
 // For renamed settings the format is:
 // [OLD_NAME, NEW_NAME]
 // For removed settings (which now effectively have a fixed value and can no

--- a/src/shell.js
+++ b/src/shell.js
@@ -20,7 +20,9 @@
 // after the generated code, you will need to define   var Module = {};
 // before the code. Then that object will be used in the code, and you
 // can continue to use Module afterwards as well.
-#if MODULARIZE
+#if WASM_ESM_INTEGRATION
+var Module = {};
+#elif MODULARIZE
 var Module = moduleArg;
 #elif USE_CLOSURE_COMPILER
 /** @type{Object} */

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -360,12 +360,22 @@ class other(RunnerCore):
 
   @requires_node_canary
   def test_esm_source_phase_imports(self):
-    self.node_args += ['--experimental-wasm-modules']
+    self.node_args += ['--experimental-wasm-modules', '--no-warnings']
     self.run_process([EMCC, '-o', 'hello_world.mjs', '-sSOURCE_PHASE_IMPORTS',
                       '--extern-post-js', test_file('modularize_post_js.js'),
                       test_file('hello_world.c')])
     self.assertContained('import source wasmModule from', read_file('hello_world.mjs'))
     self.assertContained('hello, world!', self.run_js('hello_world.mjs'))
+
+  @requires_node_canary
+  def test_esm_integration(self):
+    self.node_args += ['--experimental-wasm-modules', '--no-warnings']
+    self.run_process([EMCC, '-o', 'hello_world.mjs', '-sWASM_ESM_INTEGRATION', '-Wno-experimental', test_file('hello_world.c')])
+    create_file('runner.mjs', '''
+      import init from "./hello_world.mjs";
+      await init();
+    ''')
+    self.assertContained('hello, world!', self.run_js('runner.mjs'))
 
   @parameterized({
     '': ([],),


### PR DESCRIPTION
This change add a new experimental settings call `WASM_ESM_INTEGRATION`.

In this mode we can elide all of the wasm module loading and instantiation code, and instead rely on the module loader to both load and instantiate the wasm file.

Current limitations:

- No support for INCOMING_JS_MODULE_API / moduleArg.
- No support for closure
- Many features such as threads and dynamic linking do not work