### PR TITLE
[EH] Fix __get_exception_message for multiple inheritance

### DIFF
--- a/system/lib/libcxxabi/src/cxa_exception_js_utils.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception_js_utils.cpp
@@ -4,6 +4,7 @@
 
 #include "cxa_exception.h"
 #include "private_typeinfo.h"
+#include <assert.h>
 #include <stdio.h>
 // #include <stdint.h>
 // #include <stdlib.h>
@@ -87,10 +88,14 @@ void __get_exception_message(void* thrown_object, char** type, char** message) {
   int can_catch = catch_type->can_catch(thrown_type, thrown_object);
   if (can_catch) {
 #if __WASM_EXCEPTIONS__
-    if (isDependentException(&exception_header->unwindHeader))
+    if (isDependentException(&exception_header->unwindHeader)) {
       thrown_object =
         reinterpret_cast<__cxa_dependent_exception*>(exception_header)
           ->primaryException;
+      // can_catch can adjust thrown_object ptr, so rerun it
+      bool ret = catch_type->can_catch(thrown_type, thrown_object);
+      assert(ret);
+    }
 #endif
 
     const char* what =

--- a/system/lib/libcxxabi/src/cxa_exception_js_utils.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception_js_utils.cpp
@@ -93,7 +93,8 @@ void __get_exception_message(void* thrown_object, char** type, char** message) {
         reinterpret_cast<__cxa_dependent_exception*>(exception_header)
           ->primaryException;
       // can_catch can adjust thrown_object ptr, so rerun it
-      bool ret = catch_type->can_catch(thrown_type, thrown_object);
+      [[maybe_unused]] bool ret =
+        catch_type->can_catch(thrown_type, thrown_object);
       assert(ret);
     }
 #endif

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9732,7 +9732,8 @@ int main() {
         }
       }
     ''')
-    self.do_runf('src.cpp', 'ERROR\n', emcc_args=['-DNDEBUG'])
+    self.set_setting('ASSERTIONS')
+    self.do_runf('src.cpp', 'ERROR\n')
 
 
   @requires_node

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9704,6 +9704,37 @@ int main() {
     self.set_setting('EXIT_RUNTIME')
     self.do_other_test('test_exceptions_exit_runtime.cpp')
 
+  @with_all_eh_sjlj
+  def test_multi_inheritance_exception_message(self):
+    # Regression test for a bug that getting exception message in the DEBUG mode
+    # did not retrieve the correct thrown object pointer in case of multiple
+    # inheritance
+    create_file('src.cpp', r'''
+      #include <iostream>
+
+      struct Virt {
+        virtual void virt1() {}
+      };
+
+      struct MyEx : Virt, public std::runtime_error {
+        explicit MyEx(std::string msg) : std::runtime_error(std::move(msg)) {}
+      };
+
+      int main() {
+        try {
+          throw MyEx("ERROR");
+        } catch (...) {
+          try {
+            std::rethrow_exception(std::current_exception());
+          } catch (const std::exception &ex) {
+            std::cout << ex.what() << '\n';
+          }
+        }
+      }
+    ''')
+    self.do_runf('src.cpp', 'ERROR\n', emcc_args=['-DNDEBUG'])
+
+
   @requires_node
   def test_jsrun(self):
     print(config.NODE_JS)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9735,7 +9735,6 @@ int main() {
     self.set_setting('ASSERTIONS')
     self.do_runf('src.cpp', 'ERROR\n')
 
-
   @requires_node
   def test_jsrun(self):
     print(config.NODE_JS)


### PR DESCRIPTION
 #23552 added a routine to `__get_exception_message` so that in case of a dependent exception (i.e., a rethrown exception using `std::rethrow_exception`), it retrieves the correct primary exception's pointer to call `what()` on. But this turns out not to be correct in all cases, because `can_catch` can adjust the `thrown_object` pointer here: https://github.com/emscripten-core/emscripten/blob/ea8eda50e93d28876907bd6576c705478f1c35da/system/lib/libcxxabi/src/cxa_exception_js_utils.cpp#L87-L94 Note that `adjustedPtr` parameter is a reference:
https://github.com/emscripten-core/emscripten/blob/ea8eda50e93d28876907bd6576c705478f1c35da/system/lib/libcxxabi/src/private_typeinfo.h#L25-L26

It appears one of the cases that `thrown_object` pointer can be adjusted is when the caught exception is of a class that inherits from multiple classes.

So in case of a dependent exception, if we just retrieve `reinterpret_cast<__cxa_dependent_exception*>(exception_header)->primaryException`, we lose the adjustment applied by `can_catch`.

This calls `can_catch` again to make the necessary adjustment again in case of a dependent exception.

Fixes #23733.