### PR TITLE
Allow undefined to be returned from {{{ }}} blocks

### DIFF
--- a/src/lib/libegl.js
+++ b/src/lib/libegl.js
@@ -22,7 +22,6 @@ const eglDefaultDisplay = 62000;
 const eglDefaultConfig = 62002;
 // Magic ID for Emscripten EGLContext
 const eglDefaultContext = 62004;
-null;
 }}}
 
 var LibraryEGL = {

--- a/src/lib/libemval.js
+++ b/src/lib/libemval.js
@@ -19,7 +19,6 @@
 {{{
   const EMVAL_RESERVED_HANDLES = 5;
   const EMVAL_LAST_RESERVED_HANDLE = EMVAL_RESERVED_HANDLES * 2 - 1;
-  null;
 }}}
 var LibraryEmVal = {
   // Stack of handles available for reuse.

--- a/src/lib/libglemu.js
+++ b/src/lib/libglemu.js
@@ -21,7 +21,6 @@ assert(!FULL_ES3, 'cannot emulate both ES3 and legacy GL');
     }
     return '';
   };
-  null;
 }}}
 
 var LibraryGLEmulation = {

--- a/src/lib/libhtml5_webgpu.js
+++ b/src/lib/libhtml5_webgpu.js
@@ -1,8 +1,8 @@
 {{{
   // Helper functions for code generation
-  globalThis.html5_gpu = {
-    makeImportExport: (snake_case, CamelCase) => {
-      return `
+const html5_gpu = {
+  makeImportExport: (snake_case, CamelCase) => {
+    return `
 LibraryHTML5WebGPU.emscripten_webgpu_import_${snake_case}__deps = ['$WebGPU', '$JsValStore'];
 LibraryHTML5WebGPU.emscripten_webgpu_import_${snake_case} = (handle) =>
   WebGPU.mgr${CamelCase}.create(JsValStore.get(handle));
@@ -10,9 +10,8 @@ LibraryHTML5WebGPU.emscripten_webgpu_import_${snake_case} = (handle) =>
 LibraryHTML5WebGPU.emscripten_webgpu_export_${snake_case}__deps = ['$WebGPU', '$JsValStore'];
 LibraryHTML5WebGPU.emscripten_webgpu_export_${snake_case} = (handle) =>
   JsValStore.add(WebGPU.mgr${CamelCase}.get(handle));`
-    },
-  };
-  null;
+  },
+};
 }}}
 
 

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -52,7 +52,6 @@ const pthreadWorkerOptions = `{
 #endif
 #endif
 }`;
-null
 }}}
 
 var LibraryPThread = {

--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -10,7 +10,6 @@
   const captureModuleArg = () => MODULARIZE ? '' : 'self.Module=d;';
   const instantiateModule = () => MODULARIZE ? `${EXPORT_NAME}(d);` : '';
   const instantiateWasm = () => MINIMAL_RUNTIME ? '' : 'd[`instantiateWasm`]=(i,r)=>{var n=new WebAssembly.Instance(d[`wasm`],i);return r(n,d[`wasm`]);};';
-  null;
 }}}
 #endif
 
@@ -43,7 +42,6 @@
     locateFile('${WASM_WORKER_FILE}')
 #endif
 `;
-  null;
 }}}
 
 #endif // ~WASM_WORKERS

--- a/src/lib/libwebgl.js
+++ b/src/lib/libwebgl.js
@@ -15,7 +15,6 @@
     if (MIN_WEBGL_VERSION >= 2) return 'true';
     return 'GL.currentContext.version >= 2';
   }
-  null;
 }}}
 
 var LibraryGL = {

--- a/src/lib/libwebgpu.js
+++ b/src/lib/libwebgpu.js
@@ -185,7 +185,6 @@ wgpu${type}Release: (id) => WebGPU.mgr${type}.release(id),`;
       Instance: 3,
     },
   };
-  null;
 }}}
 
 var LibraryWebGPU = {

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -40,7 +40,7 @@ export function processMacros(text, filename) {
   try {
     return text.replace(/{{{([\s\S]+?)}}}/g, (_, str) => {
       const ret = runInMacroContext(str, {filename: filename});
-      return ret !== null ? ret.toString() : '';
+      return ret?.toString() ?? '';
     });
   } finally {
     popCurrentFile();

--- a/src/runtime_shared.js
+++ b/src/runtime_shared.js
@@ -38,7 +38,7 @@ var wasmOffsetConverter;
 {{{
   // Helper function to export a heap symbol on the module object,
   // if requested.
-  globalThis.maybeExportHeap = (x) => {
+  const maybeExportHeap = (x) => {
     // For now, we export all heap object when not building with MINIMAL_RUNTIME
     let shouldExport = !MINIMAL_RUNTIME && !STRICT;
     if (!shouldExport) {
@@ -61,7 +61,6 @@ var wasmOffsetConverter;
     }
     return '';
   };
-  null;
 }}}
 
 function updateMemoryViews() {


### PR DESCRIPTION
This means we don't need to inject artificial `null` statements.