### PR TITLE
When using AudioWorklets, print the error messages also in ASSERTIONS build mode

### DIFF
--- a/src/lib/libwebaudio.js
+++ b/src/lib/libwebaudio.js
@@ -163,7 +163,7 @@ let LibraryWebAudio = {
 #endif
 
     let audioWorkletCreationFailed = () => {
-#if WEBAUDIO_DEBUG
+#if ASSERTIONS || WEBAUDIO_DEBUG
       console.error(`emscripten_start_wasm_audio_worklet_thread_async() addModule() failed!`);
 #endif
       {{{ makeDynCall('viip', 'callback') }}}(contextHandle, 0/*EM_FALSE*/, userData);
@@ -171,7 +171,7 @@ let LibraryWebAudio = {
 
     // Does browser not support AudioWorklets?
     if (!audioWorklet) {
-#if WEBAUDIO_DEBUG
+#if ASSERTIONS || WEBAUDIO_DEBUG
       if (location.protocol == 'http:') {
         console.error(`AudioWorklets are not supported. This is possibly due to running the page over unsecure http:// protocol. Try running over https://, or debug via a localhost-based server, which should also allow AudioWorklets to function.`);
       } else {


### PR DESCRIPTION
When using AudioWorklets, print the error messages also in ASSERTIONS build mode, since people might not find WEBAUDIO_DEBUG, and WEBAUDIO_DEBUG also prints all sorts of positive confirmation/trace messages. ASSERTIONS is enabled by default in -O0 builds, so does not need to be explicitly enabled for debugging errors. Helps #21178.