### PR TITLE
Fix regression with instantiateWasm + MODULARIZE + Asyncify

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -996,8 +996,7 @@ function getWasmImports() {
       try {
 #endif
         Module['instantiateWasm'](info, (mod, inst) => {
-          receiveInstance(mod, inst);
-          resolve(mod.exports);
+          resolve(receiveInstance(mod, inst));
         });
 #if ASSERTIONS
       } catch(e) {


### PR DESCRIPTION
While updating to the latest emcc, I found a regression that affects MODULARIZE + Asyncify, but not only. I bisected and identified the problematic set of commits:

https://chromium.googlesource.com/external/github.com/emscripten-core/emscripten.git/+log/7924a238f187..ec40bc528ea6

As you can see, in these changes, instantiateWasm resolves with mod.exports, which is incorrect because receiveInstance modifies the exports and returns the modified version. For example, in the case of Asyncify, using the original exports leads to exceptions inside the Asyncify code because the exports are not instrumented. 

The fix is trivial—if you agree with my assessment, I can also add a test case.