### PR TITLE
Run 'npm audit fix' to fix security CVE reports for @babel/runtime and vite.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1433,10 +1433,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
-      "license": "MIT",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -5873,11 +5872,10 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "postcss": "^8.5.3",


### PR DESCRIPTION
Run 'npm audit fix' to fix the following security CVE reports:
```
# npm audit report

@babel/runtime  <7.26.10
Severity: moderate
Babel has inefficient RexExp complexity in generated code with .replace when transpiling named capturing groups - https://github.com/advisories/GHSA-968p-4wvh-cqc8 fix available via `npm audit fix`
node_modules/@babel/runtime

vite  6.2.0 - 6.2.3
Severity: moderate
Vite has a `server.fs.deny` bypassed for `inline` and `raw` with `?import` query - https://github.com/advisories/GHSA-4r4m-qw57-chr8 fix available via `npm audit fix`
node_modules/vite

2 moderate severity vulnerabilities
```

These are highly unlikely to be real security issues for Emscripten, but this is to appease the CVE report scanner tool utilizing security experts.