### PR TITLE
Fix `__pycache__` in `.gitignore`. NFC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 *.swp
 
 # Compiled python files
-*.pyc
+__pycache__
 
 # Default emscripten cache
 /cache


### PR DESCRIPTION
We were ignoring all `.pyc` files which is normally enough to also ignore all `__pycache__` directories but I've seen some machines where `__pycache__` also contains files ending in `.er`.