### PR TITLE
[embind] Fix misindexed template parameters which prevented policies from being applied to class functions or constructors

### DIFF
--- a/test/embind/embind.test.js
+++ b/test/embind/embind.test.js
@@ -1461,6 +1461,9 @@ module({
             assert.equal("foo", b.getValFunction());
             b.setValFunction("bar");
 
+            // get & set with templated signature
+            assert.equal("bar", b.getThisPointer().getVal());
+
             // get & set via 'callable'
             assert.equal("bar", b.getValFunctor());
             b.setValFunctor("baz");
@@ -1832,6 +1835,11 @@ module({
                 new cm.AbstractClass();
             });
             assert.equal("AbstractClass has no accessible constructor", e.message);
+        });
+
+        test("can construct class with external constructor with custom signature", function() {
+            const valHolder = new cm.ValHolder(1,2);
+            assert.equal(valHolder.getVal(), 3);
         });
 
         test("can construct class with external constructor", function() {

--- a/test/embind/embind_test.cpp
+++ b/test/embind/embind_test.cpp
@@ -327,8 +327,16 @@ ValHolder emval_test_return_ValHolder() {
   return val::object();
 }
 
+ValHolder valholder_from_sum(int x, int y) {
+  return val(x+y);
+}
+
 val valholder_get_value_mixin(const ValHolder& target) {
   return target.getVal();
+}
+
+ValHolder* valholder_get_this_ptr(ValHolder& target) {
+  return &target;
 }
 
 void valholder_set_value_mixin(ValHolder& target, const val& value) {
@@ -2005,6 +2013,7 @@ EMSCRIPTEN_BINDINGS(tests) {
   class_<ValHolder>("ValHolder")
     .smart_ptr<std::shared_ptr<ValHolder>>("std::shared_ptr<ValHolder>")
     .constructor<val>()
+    .constructor<ValHolder(int, int)>(&valholder_from_sum, allow_raw_pointers()) // custom signature with policy
     .function("getVal", &ValHolder::getVal)
     .function("getValNonConst", &ValHolder::getValNonConst)
     .function("getConstVal", &ValHolder::getConstVal)
@@ -2012,6 +2021,7 @@ EMSCRIPTEN_BINDINGS(tests) {
     .function("setVal", &ValHolder::setVal)
     .function("getValFunction", std::function<val(const ValHolder&)>(&valholder_get_value_mixin))
     .function("setValFunction", std::function<void(ValHolder&, const val&)>(&valholder_set_value_mixin))
+    .function<ValHolder*(ValHolder&)>("getThisPointer", std::function<ValHolder*(ValHolder&)>(&valholder_get_this_ptr), allow_raw_pointer<ret_val>())
     .function<val(const ValHolder&)>("getValFunctor", std::bind(&valholder_get_value_mixin, _1))
     .function<void(ValHolder&, const val&)>("setValFunctor", std::bind(&valholder_set_value_mixin, _1, _2))
     .property("val", &ValHolder::getVal, &ValHolder::setVal)


### PR DESCRIPTION
Hi, trying to `allow_raw_pointers()` in a class method bound with embind when a custom signature was given as a template argument to `.class_function` failed. It's easy to see why by comparing the definition of either `RegisterClassMethod` or `RegisterClassConstructor` with their usage:

```cpp
template<typename ReturnType, typename ThisType, typename... Args>
struct RegisterClassMethod<ReturnType (ThisType, Args...)> {

    template <typename ClassType, typename Callable, typename... Policies>
    static void invoke(const char* methodName,
...
```

and its invocation in `class_function`:

```cpp
using invoker = internal::RegisterClassConstructor<
            typename std::conditional<std::is_same<Signature, internal::DeduceArgumentsTag>::value,
                                      Callable,
                                      Signature>::type>;

invoker::template invoke<ClassType, Policies...>(callable);
```

which will skip the `Callable` template argument in some specializations (and `Callable` will become the return value policy). To fix this, I used the same approach used by the getters/setter `PropertyTag`s (c.f. diff). Please let me know if anything is off.