### PR TITLE
Fix failing tests under node-canary. NFC

### DIFF
--- a/src/lib/libwasi.js
+++ b/src/lib/libwasi.js
@@ -49,12 +49,12 @@ var WasiLibrary = {
   $getEnvStrings: () => {
     if (!getEnvStrings.strings) {
       // Default values.
-#if !DETERMINISTIC
-      // Browser language detection #8751
-      var lang = ((typeof navigator == 'object' && navigator.languages && navigator.languages[0]) || 'C').replace('-', '_') + '.UTF-8';
-#else
+#if DETERMINISTIC
       // Deterministic language detection, ignore the browser's language.
       var lang = 'C.UTF-8';
+#else
+      // Browser language detection #8751
+      var lang = ((typeof navigator == 'object' && navigator.languages && navigator.languages[0]) || 'C').replace('-', '_') + '.UTF-8';
 #endif
       var env = {
 #if !PURE_WASI

--- a/test/test_browser_language_detection.c
+++ b/test/test_browser_language_detection.c
@@ -4,10 +4,9 @@
 
 int main(int argc, char** argv) {
   if (getenv("LANG")) {
-    printf("%s\n", getenv("LANG"));
+    printf("LANG=%s\n", getenv("LANG"));
   }
 
-#ifndef __EMSCRIPTEN__
   // Emscripten has no locale support in *scanf as of 2019-06.
   // These tests for future use - or native/desktop testing:
   char* cur_locale = setlocale(LC_ALL, "");
@@ -17,11 +16,10 @@ int main(int argc, char** argv) {
   printf("%f\n", ret);
   sscanf("3.4", "%f", &ret);
   printf("%f\n", ret);
-  
+
   // Expected results:
   // LANG=C ./a.out: 1 / 3.4
   // LANG=fr_FR.UTF-8 ./a.out: 1,2 / 3
   // Note: requested locale needs to be installed locally (cf. `locale -a`)
   //       otherwise setlocale(3) is no-op
-#endif
 }


### PR DESCRIPTION
One change here is that new versions of node now support navigator.language/languages natively.