### PR TITLE
Add support for passing a response file to `file_packager`

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3739,6 +3739,22 @@ More info: https://emscripten.org
 
     self.assertTextDataIdentical(clean(proc.stdout), clean(proc2.stdout))
 
+  def test_file_packager_response_file(self):
+    filenames = [f'foo.{i:032}' for i in range(4096)]
+
+    create_file('src.c', 'int main() { return 0; }\n')
+    create_file('data.txt', '')
+
+    response_data = '\n'.join(f'--preload-file data.txt@{f}' for f in filenames)
+    self.assertGreater(len(response_data), (1 << 16))
+    create_file('data.rsp', response_data)
+
+    self.run_process([EMCC, 'src.c', '@data.rsp'])
+    data = read_file('a.out.js')
+
+    for f in filenames:
+      self.assertTrue(f'"/{f}"' in data)
+
   def test_file_packager_separate_metadata(self):
     # verify '--separate-metadata' option produces separate metadata file
     ensure_dir('subdir')

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -84,6 +84,7 @@ __rootdir__ = os.path.dirname(__scriptdir__)
 sys.path.insert(0, __rootdir__)
 
 from tools import shared, utils, js_manipulation
+from tools.response_file import substitute_response_files
 
 
 DEBUG = os.environ.get('EMCC_DEBUG')
@@ -368,12 +369,18 @@ def main():  # noqa: C901, PLR0912, PLR0915
   See the source for more details.''')
     return 1
 
-  data_target = sys.argv[1]
+  # read response files very early on
+  try:
+    args = substitute_response_files(sys.argv[1:])
+  except IOError as e:
+    shared.exit_with_error(e)
+
+  data_target = args[0]
   data_files = []
   plugins = []
   leading = ''
 
-  for arg in sys.argv[2:]:
+  for arg in args[1:]:
     if arg == '--preload':
       leading = 'preload'
     elif arg == '--embed':

--- a/tools/link.py
+++ b/tools/link.py
@@ -3070,7 +3070,8 @@ def package_files(options, target):
     file_args += ['--obj-output=' + object_file]
     rtn.append(object_file)
 
-  cmd = [shared.FILE_PACKAGER, shared.replace_suffix(target, '.data')] + file_args
+  cmd = building.get_command_with_possible_response_file(
+    [shared.FILE_PACKAGER, shared.replace_suffix(target, '.data')] + file_args)
   if options.preload_files:
     # Preloading files uses --pre-js code that runs before the module is loaded.
     file_code = shared.check_call(cmd, stdout=PIPE).stdout


### PR DESCRIPTION
Because calls to `file_packager` go through the shell wrapper, this can on Windows due to a "command line is too long" error (e.g. with a long list of `--preload-file`), even if a response file was provided to `emcc` in order avoid the issue.

Fix it by supporting response files in `file_packager`, and changing `link` so that it uses a response file where needed.

----
#### Original PR description (superseded, kept for posterity)

Going through the batch scripts on Windows can end up failing due to a "command line is too long" error, even if a response file was provided to `emcc` in order avoid the issue.

Since this code already executes in a Python interpreter, there's no reason not to use that interpreter to execute the target script directly instead of going through the batch file, thus allowing the use of longer command lines.