### PR TITLE
[wasm-esm-integration] Fix EMSCRIPETEN_KEEPALIVE

### DIFF
--- a/test/core/test_esm_integration.c
+++ b/test/core/test_esm_integration.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <emscripten.h>
+
+EMSCRIPTEN_KEEPALIVE void foo() {
+  printf("foo called\n");
+}
+
+int main(int argc, char* argv[]) {
+  printf("hello, world! (%d)\n", argc);
+  return 0;
+}

--- a/test/core/test_esm_integration.expected.mjs
+++ b/test/core/test_esm_integration.expected.mjs
@@ -1,2 +1,4 @@
-export { __main_argc_argv as main } from './hello_world.wasm';
-export { default, err, stringToNewUTF8 } from './hello_world.support.mjs';
+// The wasm module must be imported here first before the support file
+// in order to avoid issues with circular dependencies.
+import * as unused from './hello_world.wasm';
+export { default, _foo, _main, err, stringToNewUTF8 } from './hello_world.support.mjs';

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9568,9 +9568,9 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # TODO(sbc): WASM_ESM_INTEGRATION doesn't currently work with closure.
     # self.maybe_closure()
     self.node_args += ['--experimental-wasm-modules', '--no-warnings']
-    self.run_process([EMCC, '-o', 'hello_world.mjs', '-sEXPORTED_RUNTIME_METHODS=err', '-sEXPORTED_FUNCTIONS=_main,stringToNewUTF8', '-sWASM_ESM_INTEGRATION', '-Wno-experimental', test_file('hello_world_argv.c')] + self.get_emcc_args())
+    self.run_process([EMCC, '-o', 'hello_world.mjs', '-sEXPORTED_RUNTIME_METHODS=err', '-sEXPORTED_FUNCTIONS=_main,stringToNewUTF8', '-sWASM_ESM_INTEGRATION', '-Wno-experimental', test_file('core/test_esm_integration.c')] + self.get_emcc_args())
     create_file('runner.mjs', '''
-      import init, { err, stringToNewUTF8, main } from "./hello_world.mjs";
+      import init, { err, stringToNewUTF8, _main, _foo } from "./hello_world.mjs";
       await init({arguments: ['foo', 'bar']});
       err('this is a pointer:', stringToNewUTF8('hello'));
     ''')


### PR DESCRIPTION
As part of this change we re-export all wasm symbols from the support JS file.  Going forward this also means we can support things like JS wrappers.

Fixes: #24083