### PR TITLE
[test] Simplify esm integration tests

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1393,16 +1393,20 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       assert shared.suffix(filename) != '.c', 'force_c is not needed for source files ending in .c'
       compiler.append('-xc')
 
+    all_emcc_args = self.get_emcc_args(main_file=True)
+    if emcc_args:
+      all_emcc_args += emcc_args
     if not output_suffix:
-      output_suffix = '.mjs' if emcc_args and '-sEXPORT_ES6' in emcc_args else '.js'
+      if '-sEXPORT_ES6' in all_emcc_args or '-sWASM_ESM_INTEGRATION' in all_emcc_args:
+        output_suffix = '.mjs'
+      else:
+        output_suffix = '.js'
 
     if output_basename:
       output = output_basename + output_suffix
     else:
       output = shared.unsuffixed_basename(filename) + output_suffix
-    cmd = compiler + [filename, '-o', output] + self.get_emcc_args(main_file=True)
-    if emcc_args:
-      cmd += emcc_args
+    cmd = compiler + [filename, '-o', output] + all_emcc_args
     if libraries:
       cmd += libraries
     if includes:

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -47,6 +47,7 @@ def esm_integration(func):
   def decorated(self, *args, **kwargs):
     self.require_node_canary()
     self.node_args += ['--experimental-wasm-modules', '--no-warnings']
+    self.emcc_args += ['-sWASM_ESM_INTEGRATION', '-Wno-experimental']
     if self.is_wasm64():
       self.skipTest('wasm64 requires wasm export wrappers')
     func(self, *args, **kwargs)
@@ -9578,13 +9579,13 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @esm_integration
   def test_esm_integration_main(self):
-    self.do_runf('hello_world.c', 'hello, world!', emcc_args=['-sWASM_ESM_INTEGRATION', '-Wno-experimental'], output_suffix='.mjs')
+    self.do_runf('hello_world.c', 'hello, world!')
 
   @esm_integration
   def test_esm_integration(self):
     # TODO(sbc): WASM_ESM_INTEGRATION doesn't currently work with closure.
     # self.maybe_closure()
-    self.run_process([EMCC, '-o', 'hello_world.mjs', '-sEXPORTED_RUNTIME_METHODS=err', '-sEXPORTED_FUNCTIONS=_main,stringToNewUTF8', '-sWASM_ESM_INTEGRATION', '-Wno-experimental', test_file('core/test_esm_integration.c')] + self.get_emcc_args())
+    self.run_process([EMCC, '-o', 'hello_world.mjs', '-sEXPORTED_RUNTIME_METHODS=err', '-sEXPORTED_FUNCTIONS=_main,stringToNewUTF8', test_file('core/test_esm_integration.c')] + self.get_emcc_args())
     create_file('runner.mjs', '''
       import init, { err, stringToNewUTF8, _main, _foo } from "./hello_world.mjs";
       await init({arguments: ['foo', 'bar']});


### PR DESCRIPTION
Output `.mjs` files by default in `-sWASM_ESM_INTEGRATION` mode.

Add the `-sWASM_ESM_INTEGRATION` in the `@esm_integration` decorator.