### PR TITLE
Add bullet to embuilder MINIMAL set

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -88,6 +88,7 @@ MINIMAL_TASKS = [
     'libnoexit',
     'libwebgpu',
     'libwebgpu_cpp',
+    'bullet',
 ]
 
 # Additional tasks on top of MINIMAL_TASKS that are necessary for PIC testing on


### PR DESCRIPTION
This allows test_bullet_wasm64 to run in CI.

This should have been part of #24125.