### PR TITLE
Remove old invalid-input warning. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12733,7 +12733,7 @@ int main(void) {
     stderr = self.run_process(cmd + ['-w'], stderr=PIPE).stderr
     self.assertNotContained('warning', stderr)
 
-    # -Wno-invalid-input to suppress just this one warning
+    # -Wno-emcc to suppress just this one warning
     stderr = self.run_process(cmd + ['-Wno-emcc'], stderr=PIPE).stderr
     self.assertNotContained('warning', stderr)
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -72,7 +72,6 @@ diagnostics.add_warning('absolute-paths', enabled=False, part_of_all=False)
 # unused diagnostic flags.  TODO(sbc): remove at some point
 diagnostics.add_warning('almost-asm')
 diagnostics.add_warning('experimental')
-diagnostics.add_warning('invalid-input')
 # Don't show legacy settings warnings by default
 diagnostics.add_warning('legacy-settings', enabled=False, part_of_all=False)
 # Catch-all for other emcc warnings


### PR DESCRIPTION
The usage of this warning was removed in #10560.