### PR TITLE
Revert deprecation of EMULATE_FUNCTION_POINTER_CASTS

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -467,9 +467,8 @@ sent value to memory and loaded the received type from the same memory (using
 truncs/extends/ reinterprets). This means that when types do not match the
 emulated values may not match (this is true of native too, for that matter -
 this is all undefined behavior). This approaches appears good enough to
-support Python, which is the main use case motivating this feature.
-
-.. note:: This setting is deprecated
+support Python (the original motiviation for this feature) and Glib (the
+continued motivation).
 
 Default value: false
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -342,9 +342,9 @@ var SAFE_HEAP_LOG = false;
 // truncs/extends/ reinterprets). This means that when types do not match the
 // emulated values may not match (this is true of native too, for that matter -
 // this is all undefined behavior). This approaches appears good enough to
-// support Python, which is the main use case motivating this feature.
+// support Python (the original motiviation for this feature) and Glib (the
+// continued motivation).
 // [link]
-// [deprecated]
 var EMULATE_FUNCTION_POINTER_CASTS = false;
 
 // Print out exceptions in emscriptened code.

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -5733,7 +5733,7 @@ int main() {
         if safe:
           cmd += ['-sSAFE_HEAP']
         if emulate_casts:
-          cmd += ['-sEMULATE_FUNCTION_POINTER_CASTS', '-Wno-deprecated']
+          cmd += ['-sEMULATE_FUNCTION_POINTER_CASTS']
         if relocatable:
           cmd += ['-sRELOCATABLE'] # disables asm-optimized safe heap
         print(cmd)
@@ -12598,7 +12598,7 @@ int main(void) {
         }
       }
     ''')
-    self.do_runf('src.c', 'ok\ndone\n', emcc_args=['-Wno-deprecated', '-sEMULATE_FUNCTION_POINTER_CASTS'])
+    self.do_runf('src.c', 'ok\ndone\n', emcc_args=['-sEMULATE_FUNCTION_POINTER_CASTS'])
 
   def test_no_lto(self):
     # This used to fail because settings.LTO didn't reflect `-fno-lto`.

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -124,7 +124,6 @@ DEPRECATED_SETTINGS = {
     'CLOSURE_WARNINGS': 'use -Wclosure instead',
     'LEGALIZE_JS_FFI': 'to disable JS type legalization use `-sWASM_BIGINT` or `-sSTANDALONE_WASM`',
     'ASYNCIFY_EXPORTS': 'please use JSPI_EXPORTS instead',
-    'EMULATE_FUNCTION_POINTER_CASTS': 'lack of usage',
     'MAYBE_WASM2JS': 'lack of usage',
 }
 


### PR DESCRIPTION
This change effectively reverts #23953

It turns out there is an ongoing need for this in the glib project: See https://gitlab.gnome.org/GNOME/glib/-/issues/3670 and https://gitlab.gnome.org/GNOME/glib/-/blob/main/docs/toolchain-requirements.md?ref_type=heads#calling-functions-through-differently-typed-function-pointers

Fixes: #23952