### PR TITLE
Disallow -sWASM_WORKERS with sanitizers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,7 +546,6 @@ jobs:
             asan.test_dlfcn_basic
             asan.test_async_hello_jspi
             asan.test_cubescript
-            asan.test_wasm_worker_hello
             asan.test_externref_emjs_dynlink
             asan.test_asyncify_longjmp
             asan.test_pthread_run_on_main_thread

--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -204,12 +204,6 @@ if (ENVIRONMENT_IS_WASM_WORKER
 #endif
       'sb': stackLowestAddress, // sb = stack bottom (lowest stack address, SP points at this when stack is full)
       'sz': stackSize,          // sz = stack size
-#if USE_OFFSET_CONVERTER
-      'wasmOffsetData': wasmOffsetConverter,
-#endif
-#if LOAD_SOURCE_MAP
-      'wasmSourceMapData': wasmSourceMap,
-#endif
     });
     worker.onmessage = _wasmWorkerRunPostMessage;
 #if ENVIRONMENT_MAY_BE_NODE

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -886,6 +886,7 @@ base align: 0, 0, 0, 0'''])
   def test_longjmp(self):
     self.do_core_test('test_longjmp.c')
 
+  @no_asan('ASan does not support WASM_WORKERS')
   def test_longjmp_wasm_workers(self):
     self.do_core_test('test_longjmp.c', emcc_args=['-sWASM_WORKERS'])
 
@@ -9566,14 +9567,17 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_runf('test_emscripten_async_load_script.c', emcc_args=['-sFORCE_FILESYSTEM'])
 
   @node_pthreads
+  @no_asan('ASan does not support WASM_WORKERS')
   def test_wasm_worker_hello(self):
     self.do_run_in_out_file_test('wasm_worker/hello_wasm_worker.c', emcc_args=['-sWASM_WORKERS'])
 
   @node_pthreads
+  @no_asan('ASan does not support WASM_WORKERS')
   def test_wasm_worker_malloc(self):
     self.do_run_in_out_file_test('wasm_worker/malloc_wasm_worker.c', emcc_args=['-sWASM_WORKERS'])
 
   @node_pthreads
+  @no_asan('ASan does not support WASM_WORKERS')
   def test_wasm_worker_wait_async(self):
     self.do_runf('atomic/test_wait_async.c', emcc_args=['-sWASM_WORKERS'])
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -1556,6 +1556,8 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     diagnostics.warning('emcc', 'output suffix .js requested, but wasm side modules are just wasm files; emitting only a .wasm, no .js')
 
   if options.sanitize:
+    if settings.WASM_WORKERS:
+      exit_with_error('WASM_WORKERS is not currently compatible with `-fsanitize` tools')
     settings.USE_OFFSET_CONVERTER = 1
     # These symbols are needed by `withBuiltinMalloc` which used to implement
     # the `__noleakcheck` attribute.  However this dependency is not yet represented in the JS


### PR DESCRIPTION
Back in #21701 I moved the creation of wasmOffsetConvert and wasmOffset into runtime_pthread.js but I didn't update libwasm_worker.js which still uses the old name `wasmOffsetData` in its initial post message.

When trying to update this just now I noticed that the offset converter (and santiizers in general) don't seem to work on `WASM_WORKERS` so this change simply disables them.

The passing of `wasmOffsetData` and `wasmSourceMapData` was added back in #20188 but it doesn't looks like support for santizers was supposed to be part of that.