### PR TITLE
Improve assertions in `test_sdl_mouse`. NFC

### DIFF
--- a/test/browser/test_glfw_joystick.c
+++ b/test/browser/test_glfw_joystick.c
@@ -20,8 +20,7 @@ void error_callback(int error, const char* description);
 
 int joy_connected = -1;
 
-void joystick_callback(int joy, int event)
-{
+void joystick_callback(int joy, int event) {
   if (event == GLFW_CONNECTED) {
     printf("Joystick %d was connected: %s\n", joy, glfwGetJoystickName(joy));
     joy_connected = joy; // use the most recently connected joystick
@@ -104,15 +103,13 @@ void main_2(void *arg) {
 }
 
 int main() {
-  if (!glfwInit())
-  {
+  if (!glfwInit()) {
     printf("Could not create window. Test failed.\n");
     return 1;
   }
   glfwWindowHint(GLFW_RESIZABLE , 1);
   g_window = glfwCreateWindow(600, 450, "GLFW joystick test", NULL, NULL);
-  if (!g_window)
-  {
+  if (!g_window) {
     printf("Could not create window. Test failed.\n");
     glfwTerminate();
     return 1;

--- a/test/browser/test_sdl_mouse.c
+++ b/test/browser/test_sdl_mouse.c
@@ -11,24 +11,33 @@
 #include <emscripten.h>
 
 #define abs(x) ((x) < 0 ? -(x) : (x))
+
 void one() {
   SDL_Event event;
   while (SDL_PollEvent(&event)) {
-    switch(event.type) {
+    switch (event.type) {
       case SDL_MOUSEMOTION: {
         SDL_MouseMotionEvent *m = (SDL_MouseMotionEvent*)&event;
         assert(m->state == 0);
         int x, y;
         SDL_GetMouseState(&x, &y);
         assert(x == m->x && y == m->y);
-        printf("motion: %d,%d  %d,%d\n", m->x, m->y, m->xrel, m->yrel);
+        printf("motion: abs:%d,%d  rel:%d,%d\n", m->x, m->y, m->xrel, m->yrel);
+        static bool first_motion = true;
+        if (first_motion) {
+          first_motion = false;
 #ifdef TEST_SDL_MOUSE_OFFSETS
-        assert( (abs(m->x-5) <= 1 && abs(m->y-15) <= 1 && abs(m->xrel-5) <= 1 && abs(m->yrel-15) <= 1)
-            ||  (abs(m->x-25) <= 1 && abs(m->y-72) <= 1 && abs(m->xrel-20) <= 1 && abs(m->yrel-57) <= 1) );
+          assert(abs(m->x-5) <= 1 && abs(m->y-15) <= 1 && abs(m->xrel-5) <= 1 && abs(m->yrel-15) <= 1);
 #else
-        assert( (abs(m->x-10) <= 1 && abs(m->y-20) <= 1 && abs(m->xrel-10) <= 1 && abs(m->yrel-20) <= 1)
-            ||  (abs(m->x-30) <= 1 && abs(m->y-77) <= 1 && abs(m->xrel-20) <= 1 && abs(m->yrel-57) <= 1) );
+          assert(abs(m->x-10) <= 1 && abs(m->y-20) <= 1 && abs(m->xrel-10) <= 1 && abs(m->yrel-20) <= 1);
 #endif
+        } else {
+#ifdef TEST_SDL_MOUSE_OFFSETS
+          assert(abs(m->x-25) <= 1 && abs(m->y-72) <= 1 && abs(m->xrel-20) <= 1 && abs(m->yrel-57) <= 1);
+#else
+          assert(abs(m->x-30) <= 1 && abs(m->y-77) <= 1 && abs(m->xrel-20) <= 1 && abs(m->yrel-57) <= 1);
+#endif
+        }
         break;
       }
       case SDL_MOUSEBUTTONDOWN: {
@@ -37,20 +46,22 @@ void one() {
           emscripten_force_exit(0);
         }
         printf("button down: %d,%d  %d,%d\n", m->button, m->state, m->x, m->y);
+        assert(m->button == 1 && m->state == 1);
 #ifdef TEST_SDL_MOUSE_OFFSETS
-        assert(m->button == 1 && m->state == 1 && abs(m->x-5) <= 1 && abs(m->y-15) <= 1);
+        assert(abs(m->x-5) <= 1 && abs(m->y-15) <= 1);
 #else
-        assert(m->button == 1 && m->state == 1 && abs(m->x-10) <= 1 && abs(m->y-20) <= 1);
+        assert(abs(m->x-10) <= 1 && abs(m->y-20) <= 1);
 #endif
         break;
       }
       case SDL_MOUSEBUTTONUP: {
         SDL_MouseButtonEvent *m = (SDL_MouseButtonEvent*)&event;
         printf("button up: %d,%d  %d,%d\n", m->button, m->state, m->x, m->y);
+        assert(m->button == 1 && m->state == 0);
 #ifdef TEST_SDL_MOUSE_OFFSETS
-        assert(m->button == 1 && m->state == 0 && abs(m->x-5) <= 1 && abs(m->y-15) <= 1);
+        assert(abs(m->x-5) <= 1 && abs(m->y-15) <= 1);
 #else
-        assert(m->button == 1 && m->state == 0 && abs(m->x-10) <= 1 && abs(m->y-20) <= 1);
+        assert(abs(m->x-10) <= 1 && abs(m->y-20) <= 1);
 #endif
         // Remove another click we want to ignore
         assert(SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_MOUSEBUTTONDOWN, SDL_MOUSEBUTTONDOWN) == 1);
@@ -60,8 +71,6 @@ void one() {
     }
   }
 }
-
-void main_2(void* arg);
 
 int main() {
   SDL_Init(SDL_INIT_VIDEO);
@@ -84,4 +93,3 @@ int main() {
 
   emscripten_set_main_loop(one, 0, 0);
 }
-

--- a/test/browser/test_sdl_resize.c
+++ b/test/browser/test_sdl_resize.c
@@ -38,8 +38,6 @@ void loop() {
   }
 }
 
-void main_2();
-
 int main() {
   SDL_Init(SDL_INIT_VIDEO);
   SDL_Surface *screen = SDL_SetVideoMode(600, 450, 32, SDL_HWSURFACE);

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3062,7 +3062,7 @@ Module["preRun"] = () => {
       </html>
     ''')
 
-    self.compile_btest('browser/test_sdl2_mouse.c', ['-DTEST_SDL_MOUSE_OFFSETS=1', '-O2', '--minify=0', '-o', 'sdl2_mouse.js', '--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=2', '-sEXIT_RUNTIME'])
+    self.compile_btest('browser/test_sdl2_mouse.c', ['-DTEST_SDL_MOUSE_OFFSETS', '-O2', '--minify=0', '-o', 'sdl2_mouse.js', '--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=2', '-sEXIT_RUNTIME'])
     self.run_browser('page.html', '', '/report_result?exit:0')
 
   def test_sdl2_threads(self):


### PR DESCRIPTION
This should give us more clues as to why this test is being flaky.

Also, remove some unused declarations.

Also, use `-DDTEST_SDL_MOUSE_OFFSETS` over `-DDTEST_SDL_MOUSE_OFFSETS=1` for consistency with other usages.