### PR TITLE
Add some test coverage of of MODULARIZE + WASM_WORKERS + closure under node. NFC

### DIFF
--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -30,6 +30,9 @@
 #if PROXY_TO_WORKER
 #error "-sPROXY_TO_WORKER is not supported with -sWASM_WORKERS"
 #endif
+#if WASM2JS && MODULARIZE
+#error "-sWASM=0 + -sMODULARIZE + -sWASM_WORKERS is not supported"
+#endif
 
 {{{
   const workerSupportsFutexWait = () => AUDIO_WORKLET ? "typeof AudioWorkletGlobalScope === 'undefined'" : '1';

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9569,7 +9569,11 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @node_pthreads
   @no_asan('ASan does not support WASM_WORKERS')
   @also_with_minimal_runtime
+  @also_with_modularize
   def test_wasm_worker_hello(self):
+    if self.is_wasm2js() and '-sMODULARIZE' in self.emcc_args:
+      self.skipTest('WASM2JS + MODULARIZE + WASM_WORKERS is not supported')
+    self.maybe_closure()
     self.do_run_in_out_file_test('wasm_worker/hello_wasm_worker.c', emcc_args=['-sWASM_WORKERS'])
 
   @node_pthreads


### PR DESCRIPTION
These combinations were previously only covered by browser tests.

This uncovered that MODULARIZE + WASM2SJ + WASM_WORKERS is not currently
a supported configuration so this change also explictly disallows that
combination.  See #24184
