### PR TITLE
Add support for getentropy in d8

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -268,3 +268,6 @@ Navigator.prototype.webkitGetUserMedia = function(
  * @type {symbol}
  */
 Symbol.dispose;
+
+// Common between node-externs and v8-externs
+var os = {};

--- a/src/closure-externs/node-externs.js
+++ b/src/closure-externs/node-externs.js
@@ -144,15 +144,3 @@ path.isAbsolute;
 path.posix;
 
 crypto.randomFillSync;
-
-
-// d8
-
-var os;
-
-/**
- * @param {string} cmd
- * @param {Array.<string>=} args
- * @return {string}
- */
-os.system = function (cmd, args) {};

--- a/src/closure-externs/node-externs.js
+++ b/src/closure-externs/node-externs.js
@@ -144,3 +144,15 @@ path.isAbsolute;
 path.posix;
 
 crypto.randomFillSync;
+
+
+// d8
+
+var os;
+
+/**
+ * @param {string} cmd
+ * @param {Array.<string>=} args
+ * @return {string}
+ */
+os.system = function (cmd, args) {};

--- a/src/closure-externs/v8-externs.js
+++ b/src/closure-externs/v8-externs.js
@@ -32,3 +32,12 @@ var scriptArgs = [];
  * @suppress {duplicate}
  */
 var quit = function(status) {};
+
+var os;
+
+/**
+ * @param {string} cmd
+ * @param {Array.<string>=} args
+ * @return {string}
+ */
+os.system = function (cmd, args) {};

--- a/src/closure-externs/v8-externs.js
+++ b/src/closure-externs/v8-externs.js
@@ -33,8 +33,6 @@ var scriptArgs = [];
  */
 var quit = function(status) {};
 
-var os;
-
 /**
  * @param {string} cmd
  * @param {Array.<string>=} args

--- a/src/lib/libwasi.js
+++ b/src/lib/libwasi.js
@@ -567,6 +567,9 @@ var WasiLibrary = {
 
   // random.h
 
+#if ENVIRONMENT_MAY_BE_SHELL
+  $initRandomFill__deps: ['$base64Decode'],
+#endif
   $initRandomFill: () => {
 #if ENVIRONMENT_MAY_BE_NODE && MIN_NODE_VERSION < 190000
     // This block is not needed on v19+ since crypto.getRandomValues is builtin
@@ -575,6 +578,18 @@ var WasiLibrary = {
       return (view) => nodeCrypto.randomFillSync(view);
     }
 #endif // ENVIRONMENT_MAY_BE_NODE
+
+#if ENVIRONMENT_MAY_BE_SHELL
+    if (ENVIRONMENT_IS_SHELL) {
+      return (view) => {
+        if (!os.system) {
+          throw new Error('randomFill not supported on d8 unless --enable-os-system is passed');
+        }
+        const b64 = os.system('sh', ['-c', `head -c${view.byteLength} /dev/urandom | base64 --wrap=0`]);
+        view.set(base64Decode(b64));
+      };
+    }
+#endif
 
 #if SHARED_MEMORY
     // like with most Web APIs, we can't use Web Crypto API directly on shared memory,

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -77,7 +77,7 @@ function calculateLibraries() {
     libraries.push('libmemoryprofiler.js');
   }
 
-  if (SUPPORT_BASE64_EMBEDDING) {
+  if (SUPPORT_BASE64_EMBEDDING || ENVIRONMENT_MAY_BE_SHELL) {
     libraries.push('libbase64.js');
   }
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -16032,7 +16032,7 @@ addToLibrary({
   @requires_v8
   def test_getentropy_d8(self):
     create_file('main.c', '''
-      #include "assert.h"
+      #include <assert.h>
       #include <unistd.h>
 
       int main() {

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -16028,3 +16028,21 @@ addToLibrary({
     baseline_size = os.path.getsize('baseline.js')
     js_api_size = os.path.getsize('hello_world.js')
     self.assertLess(js_api_size, baseline_size)
+
+  @requires_v8
+  def test_getentropy_d8(self):
+    create_file('main.c', '''
+      #include "assert.h"
+      #include <unistd.h>
+
+      int main() {
+        char buf[100];
+        assert(getentropy(buf, sizeof(buf)) == 0);
+        return 0;
+      }
+    ''')
+
+    msg = 'randomFill not supported on d8 unless --enable-os-system is passed'
+    self.do_runf('main.c', msg, assert_returncode=1)
+    self.v8_args += ['--enable-os-system']
+    self.do_runf('main.c')

--- a/third_party/closure-compiler/node-externs/os.js
+++ b/third_party/closure-compiler/node-externs/os.js
@@ -27,7 +27,6 @@
  END_NODE_INCLUDE
  */
     
-var os = {};
 
 /**
  * @return {string}


### PR DESCRIPTION
Use `os.system` to read from `/dev/urandom` and then base 64 encode the result. Then use `base64Decode` to read the result. Only works when `--enable-os-system` is passed to d8.