### PR TITLE
[AUDIO_WORKLET] Inline `.aw.js` file into the main output `.js` file

### DIFF
--- a/src/audio_worklet.js
+++ b/src/audio_worklet.js
@@ -12,24 +12,16 @@
 // the node constructor's "processorOptions" field, we can share the necessary
 // bootstrap information from the main thread to the AudioWorkletGlobalScope.
 
+if (ENVIRONMENT_IS_AUDIO_WORKLET) {
+
 function createWasmAudioWorkletProcessor(audioParams) {
   class WasmAudioWorkletProcessor extends AudioWorkletProcessor {
     constructor(args) {
       super();
 
-      // Copy needed stack allocation functions from the Module object
-      // to global scope, these will be accessed in hot paths, so maybe
-      // they'll be a bit faster to access directly, rather than referencing
-      // them as properties of the Module object.
-      globalThis.stackAlloc = Module['stackAlloc'];
-      globalThis.stackSave = Module['stackSave'];
-      globalThis.stackRestore = Module['stackRestore'];
-      globalThis.HEAPU32 = Module['HEAPU32'];
-      globalThis.HEAPF32 = Module['HEAPF32'];
-
       // Capture the Wasm function callback to invoke.
       let opts = args.processorOptions;
-      this.callbackFunction = Module['wasmTable'].get(opts['cb']);
+      this.callbackFunction = wasmTable.get(opts['cb']);
       this.userData = opts['ud'];
       // Then the samples per channel to process, fixed for the lifetime of the
       // context that created this processor. Note for when moving to Web Audio
@@ -43,6 +35,9 @@ function createWasmAudioWorkletProcessor(audioParams) {
       return audioParams;
     }
 
+    /**
+     * @param {Object} parameters
+     */
     process(inputList, outputList, parameters) {
       // Marshal all inputs and parameters to the Wasm memory on the thread stack,
       // then perform the wasm audio worklet call,
@@ -99,6 +94,7 @@ function createWasmAudioWorkletProcessor(audioParams) {
       paramsPtr = dataPtr;
       k = paramsPtr >> 2;
       dataPtr += numParams * {{{ C_STRUCTS.AudioParamFrame.__size__ }}};
+
       for (i = 0; paramArray = parameters[i++];) {
         // Write the AudioParamFrame struct instance
         HEAPU32[k + {{{ C_STRUCTS.AudioParamFrame.length / 4 }}}] = paramArray.length;
@@ -134,28 +130,15 @@ function createWasmAudioWorkletProcessor(audioParams) {
   return WasmAudioWorkletProcessor;
 }
 
+var messagePort;
+
 // Specify a worklet processor that will be used to receive messages to this
 // AudioWorkletGlobalScope.  We never connect this initial AudioWorkletProcessor
 // to the audio graph to do any audio processing.
 class BootstrapMessages extends AudioWorkletProcessor {
   constructor(arg) {
     super();
-    // Audio worklets need to show up as wasm workers.  This is the way we signal
-    // that.
-    globalThis.name = 'em-ww';
-    // Initialize the global Emscripten Module object that contains e.g. the
-    // Wasm Module and Memory objects.  After this we are ready to load in the
-    // main application JS script, which the main thread will addModule()
-    // to this scope.
-    globalThis.Module = arg['processorOptions'];
-#if !MINIMAL_RUNTIME
-    // Default runtime relies on an injected instantiateWasm() function to
-    // initialize the Wasm Module.
-    globalThis.Module['instantiateWasm'] = (info, receiveInstance) => {
-      var instance = new WebAssembly.Instance(Module['wasm'], info);
-      return receiveInstance(instance, Module['wasm']);
-    };
-#endif
+    startWasmWorker(arg['processorOptions'])
 #if WEBAUDIO_DEBUG
     console.log('AudioWorklet global scope looks like this:');
     console.dir(globalThis);
@@ -163,24 +146,13 @@ class BootstrapMessages extends AudioWorkletProcessor {
     // Listen to messages from the main thread. These messages will ask this
     // scope to create the real AudioWorkletProcessors that call out to Wasm to
     // do audio processing.
-    let p = globalThis['messagePort'] = this.port;
-    p.onmessage = async (msg) => {
+    messagePort = this.port;
+    /** @suppress {checkTypes} */
+    messagePort.onmessage = async (msg) => {
       let d = msg.data;
       if (d['_wpn']) {
         // '_wpn' is short for 'Worklet Processor Node', using an identifier
         // that will never conflict with user messages
-#if MODULARIZE
-        // Instantiate the MODULARIZEd Module function, which is stored for us
-        // under the special global name AudioWorkletModule in
-        // MODULARIZE+AUDIO_WORKLET builds.
-        if (globalThis.AudioWorkletModule) {
-          // This populates the Module object with all the Wasm properties
-          globalThis.Module = await AudioWorkletModule(Module);
-          // We have now instantiated the Module function, can discard it from
-          // global scope
-          delete globalThis.AudioWorkletModule;
-        }
-#endif
         // Register a real AudioWorkletProcessor that will actually do audio processing.
         // 'ap' being the audio params
         registerProcessor(d['_wpn'], createWasmAudioWorkletProcessor(d['ap']));
@@ -196,14 +168,14 @@ class BootstrapMessages extends AudioWorkletProcessor {
         // 'cb' the callback function
         // 'ch' the context handle
         // 'ud' the passed user data
-        p.postMessage({'_wsc': d['cb'], 'x': [d['ch'], 1/*EM_TRUE*/, d['ud']] });
+        messagePort.postMessage({'_wsc': d['cb'], 'x': [d['ch'], 1/*EM_TRUE*/, d['ud']] });
       } else if (d['_wsc']) {
 #if MEMORY64
         var ptr = BigInt(d['_wsc']);
 #else
         var ptr = d['_wsc'];
 #endif
-        Module['wasmTable'].get(ptr)(...d['x']);
+        wasmTable.get(ptr)(...d['x']);
       };
     }
   }
@@ -220,4 +192,6 @@ class BootstrapMessages extends AudioWorkletProcessor {
 };
 
 // Register the dummy processor that will just receive messages.
-registerProcessor('message', BootstrapMessages);
+registerProcessor('em-bootstrap', BootstrapMessages);
+
+} // ENVIRONMENT_IS_AUDIO_WORKLET

--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -271,3 +271,5 @@ Symbol.dispose;
 
 // Common between node-externs and v8-externs
 var os = {};
+
+AudioWorkletProcessor.parameterDescriptors;

--- a/src/lib/libwebaudio.js
+++ b/src/lib/libwebaudio.js
@@ -181,13 +181,11 @@ let LibraryWebAudio = {
       return audioWorkletCreationFailed();
     }
 
-    // TODO: In MINIMAL_RUNTIME builds, read this file off of a preloaded Blob,
-    // and/or embed from a string like with WASM_WORKERS==2 mode.
-    audioWorklet.addModule('{{{ TARGET_BASENAME }}}.aw.js').then(() => {
+    audioWorklet.addModule({{{ wasmWorkerJs }}}).then(() => {
 #if WEBAUDIO_DEBUG
-      console.log(`emscripten_start_wasm_audio_worklet_thread_async() addModule('audioworklet.js') completed`);
+      console.log(`emscripten_start_wasm_audio_worklet_thread_async() addModule() completed`);
 #endif
-      audioWorklet.bootstrapMessage = new AudioWorkletNode(audioContext, 'message', {
+      audioWorklet.bootstrapMessage = new AudioWorkletNode(audioContext, 'em-bootstrap', {
         processorOptions: {
           // Assign the loaded AudioWorkletGlobalScope a Wasm Worker ID so that
           // it can utilized its own TLS slots, and it is recognized to not be
@@ -195,33 +193,15 @@ let LibraryWebAudio = {
           '$ww': _wasmWorkersID++,
 #if MINIMAL_RUNTIME
           'wasm': Module['wasm'],
-          'mem': wasmMemory,
 #else
           'wasm': wasmModule,
-          'wasmMemory': wasmMemory,
 #endif
+          'mem': wasmMemory,
           'sb': stackLowestAddress, // sb = stack base
           'sz': stackSize,          // sz = stack size
         }
       });
       audioWorklet.bootstrapMessage.port.onmessage = _EmAudioDispatchProcessorCallback;
-
-      // AudioWorklets do not have a importScripts() function like Web Workers
-      // do (and AudioWorkletGlobalScope does not allow dynamic import()
-      // either), but instead, the main thread must load all JS code into the
-      // worklet scope. Send the application main JS script to the audio
-      // worklet.
-      return audioWorklet.addModule(
-#if MINIMAL_RUNTIME
-        Module['js']
-#else
-        Module['mainScriptUrlOrBlob'] || _scriptName
-#endif
-      );
-    }).then(() => {
-#if WEBAUDIO_DEBUG
-      console.log(`emscripten_start_wasm_audio_worklet_thread_async() addModule() of main application JS completed`);
-#endif
       {{{ makeDynCall('viii', 'callback') }}}(contextHandle, 1/*EM_TRUE*/, userData);
     }).catch(audioWorkletCreationFailed);
   },
@@ -335,11 +315,11 @@ let LibraryWebAudio = {
   emscripten_current_thread_is_audio_worklet: () => typeof AudioWorkletGlobalScope !== 'undefined',
 
   emscripten_audio_worklet_post_function_v: (audioContext, funcPtr) => {
-    (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : globalThis['messagePort']).postMessage({'_wsc': funcPtr, 'x': [] }); // "WaSm Call"
+    (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : messagePort).postMessage({'_wsc': funcPtr, 'x': [] }); // "WaSm Call"
   },
 
   $emscripten_audio_worklet_post_function_1: (audioContext, funcPtr, arg0) => {
-    (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : globalThis['messagePort']).postMessage({'_wsc': funcPtr, 'x': [arg0] }); // "WaSm Call"
+    (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : messagePort).postMessage({'_wsc': funcPtr, 'x': [arg0] }); // "WaSm Call"
   },
 
   emscripten_audio_worklet_post_function_vi__deps: ['$emscripten_audio_worklet_post_function_1'],
@@ -353,7 +333,7 @@ let LibraryWebAudio = {
   },
 
   $emscripten_audio_worklet_post_function_2: (audioContext, funcPtr, arg0, arg1) => {
-    (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : globalThis['messagePort']).postMessage({'_wsc': funcPtr, 'x': [arg0, arg1] }); // "WaSm Call"
+    (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : messagePort).postMessage({'_wsc': funcPtr, 'x': [arg0, arg1] }); // "WaSm Call"
   },
 
   emscripten_audio_worklet_post_function_vii__deps: ['$emscripten_audio_worklet_post_function_2'],
@@ -367,7 +347,7 @@ let LibraryWebAudio = {
   },
 
   $emscripten_audio_worklet_post_function_3: (audioContext, funcPtr, arg0, arg1, arg2) => {
-    (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : globalThis['messagePort']).postMessage({'_wsc': funcPtr, 'x': [arg0, arg1, arg2] }); // "WaSm Call"
+    (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : messagePort).postMessage({'_wsc': funcPtr, 'x': [arg0, arg1, arg2] }); // "WaSm Call"
   },
   emscripten_audio_worklet_post_function_viii__deps: ['$emscripten_audio_worklet_post_function_3'],
   emscripten_audio_worklet_post_function_viii: (audioContext, funcPtr, arg0, arg1, arg2) => {
@@ -387,7 +367,7 @@ let LibraryWebAudio = {
     assert(UTF8ToString(sigPtr)[0] != 'v', 'Do NOT specify the return argument in the signature string for a call to emscripten_audio_worklet_post_function_sig(), just pass the function arguments.');
     assert(varargs);
 #endif
-    (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : globalThis['messagePort']).postMessage({'_wsc': funcPtr, 'x': readEmAsmArgs(sigPtr, varargs) });
+    (audioContext ? EmAudio[audioContext].audioWorklet.bootstrapMessage.port : messagePort).postMessage({'_wsc': funcPtr, 'x': readEmAsmArgs(sigPtr, varargs) });
   }
 };
 

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -118,7 +118,7 @@ var imports = {
 #if ASSERTIONS && !WASM2JS
 // Module['wasm'] should contain a typed array of the Wasm object data, or a
 // precompiled WebAssembly Module.
-if (!WebAssembly.instantiateStreaming && !Module['wasm']) throw 'Must load WebAssembly Module in to variable Module.wasm before adding compiled output .js script to the DOM';
+assert(WebAssembly.instantiateStreaming || Module['wasm'], 'Must load WebAssembly Module in to variable Module.wasm before adding compiled output .js script to the DOM');
 #endif
 (WebAssembly.instantiateStreaming
   ? WebAssembly.instantiateStreaming(fetch('{{{ TARGET_BASENAME }}}.wasm'), imports)
@@ -131,7 +131,7 @@ WebAssembly.instantiateStreaming(fetch('{{{ TARGET_BASENAME }}}.wasm'), imports)
 #if ASSERTIONS && !WASM2JS
 // Module['wasm'] should contain a typed array of the Wasm object data, or a
 // precompiled WebAssembly Module.
-if (!Module['wasm']) throw 'Must load WebAssembly Module in to variable Module.wasm before adding compiled output .js script to the DOM';
+assert(Module['wasm'], 'Must load WebAssembly Module in to variable Module.wasm before adding compiled output .js script to the DOM');
 #endif
 
 <<< ATMODULES >>>
@@ -259,8 +259,5 @@ WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
 }
 
 // When running in a background thread we delay module loading until we have
-#if AUDIO_WORKLET
-if (ENVIRONMENT_IS_AUDIO_WORKLET) loadModule();
-#endif
 {{{ runIfMainThread('loadModule();') }}}
 #endif

--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -12,9 +12,6 @@
 // check for full engine support (use string 'subarray' to avoid closure compiler confusion)
 
 function initMemory() {
-#if AUDIO_WORKLET
-  if (!ENVIRONMENT_IS_AUDIO_WORKLET)
-#endif
   {{{ runIfWorkerThread('return') }}}
 
 #if expectToReceiveOnModule('wasmMemory')

--- a/src/runtime_shared.js
+++ b/src/runtime_shared.js
@@ -47,6 +47,10 @@ if (ENVIRONMENT_IS_NODE && {{{ ENVIRONMENT_IS_WORKER_THREAD() }}}) {
 #include "wasm_worker.js"
 #endif
 
+#if AUDIO_WORKLET
+#include "audio_worklet.js"
+#endif
+
 #if LOAD_SOURCE_MAP
 var wasmSourceMap;
 #include "source_map_support.js"
@@ -63,11 +67,6 @@ var wasmOffsetConverter;
   const shouldExportHeap = (x) => {
     let shouldExport = false;
     if (MODULARIZE && EXPORT_ALL) {
-      shouldExport = true;
-    } else if (AUDIO_WORKLET && (x == 'HEAPU32' || x == 'HEAPF32')) {
-      // Export to the AudioWorkletGlobalScope the needed variables to access
-      // the heap. AudioWorkletGlobalScope is unable to access global JS vars
-      // in the compiled main JS file.
       shouldExport = true;
     } else if (EXPORTED_RUNTIME_METHODS.includes(x)) {
       shouldExport = true;

--- a/src/shell.js
+++ b/src/shell.js
@@ -53,12 +53,20 @@ var readyPromise = new Promise((resolve, reject) => {
 });
 #endif
 
-// Determine the runtime environment we are in. You can customize this by
-// setting the ENVIRONMENT setting at compile time (see settings.js).
+#if WASM_WORKERS
+// The way we signal to a worker that it is hosting a pthread is to construct
+// it with a specific name.
+var ENVIRONMENT_IS_WASM_WORKER = globalThis.name == 'em-ww';
+#endif
 
 #if AUDIO_WORKLET
 var ENVIRONMENT_IS_AUDIO_WORKLET = typeof AudioWorkletGlobalScope !== 'undefined';
+// Audio worklets behave as wasm workers.
+if (ENVIRONMENT_IS_AUDIO_WORKLET) ENVIRONMENT_IS_WASM_WORKER = true;
 #endif
+
+// Determine the runtime environment we are in. You can customize this by
+// setting the ENVIRONMENT setting at compile time (see settings.js).
 
 #if ENVIRONMENT && !ENVIRONMENT.includes(',')
 var ENVIRONMENT_IS_WEB = {{{ ENVIRONMENT === 'web' }}};
@@ -100,12 +108,6 @@ if (ENVIRONMENT_IS_PTHREAD) {
   globalThis.moduleLoaded = true;
 }
 #endif
-#endif
-
-#if WASM_WORKERS
-// The way we signal to a worker that it is hosting a pthread is to construct
-// it with a specific name.
-var ENVIRONMENT_IS_WASM_WORKER = globalThis.name == 'em-ww';
 #endif
 
 #if ENVIRONMENT_MAY_BE_NODE

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -51,10 +51,6 @@ var ENVIRONMENT_IS_NODE = typeof process == 'object' && process.type != 'rendere
 var ENVIRONMENT_IS_SHELL = typeof read == 'function';
 #endif
 
-#if AUDIO_WORKLET
-var ENVIRONMENT_IS_AUDIO_WORKLET = typeof AudioWorkletGlobalScope !== 'undefined';
-#endif
-
 #if ASSERTIONS || PTHREADS
 #if !ENVIRONMENT_MAY_BE_NODE && !ENVIRONMENT_MAY_BE_SHELL
 var ENVIRONMENT_IS_WEB = true
@@ -86,6 +82,11 @@ if (ENVIRONMENT_IS_NODE) {
   ENVIRONMENT_IS_WASM_WORKER = worker_threads['workerData'] == 'em-ww'
 }
 #endif
+#endif
+
+#if AUDIO_WORKLET
+var ENVIRONMENT_IS_AUDIO_WORKLET = typeof AudioWorkletGlobalScope !== 'undefined';
+if (ENVIRONMENT_IS_AUDIO_WORKLET) ENVIRONMENT_IS_WASM_WORKER = true;
 #endif
 
 #if ASSERTIONS && ENVIRONMENT_MAY_BE_NODE && ENVIRONMENT_MAY_BE_SHELL

--- a/test/code_size/audio_worklet_wasm.js
+++ b/test/code_size/audio_worklet_wasm.js
@@ -1,79 +1,147 @@
-var g = globalThis.Module || "undefined" != typeof Module ? Module : {}, k = "undefined" !== typeof AudioWorkletGlobalScope, m = "em-ww" == globalThis.name, n, p, q, r, t, x, U, V, A, Q, C, W;
+var h = globalThis.Module || "undefined" != typeof Module ? Module : {}, p = "em-ww" == globalThis.name, q = "undefined" !== typeof AudioWorkletGlobalScope, r, t, v, x, y, H, X, Y, K, J, I, Z;
 
-m && !k && (onmessage = a => {
-    onmessage = null;
-    a = a.data;
-    g ||= {};
-    Object.assign(g, a);
-    t = a.mem;
-    u();
-    v();
+q && (p = !0);
+
+function C(a) {
+    h ||= {};
+    Object.assign(h, a);
+    y = a.mem;
+    D();
+    F();
     a.wasm = a.mem = 0;
-});
-
-function u() {
-    var a = t.buffer;
-    p = new Uint8Array(a);
-    n = new Int32Array(a);
-    g.HEAPU32 = q = new Uint32Array(a);
-    g.HEAPF32 = r = new Float32Array(a);
 }
 
-if (k || !m) t = g.mem || new WebAssembly.Memory({
+p && !q && (onmessage = a => {
+    onmessage = null;
+    C(a.data);
+});
+
+if (q) {
+    function a(c) {
+        class e extends AudioWorkletProcessor {
+            constructor(d) {
+                super();
+                d = d.processorOptions;
+                this.v = H.get(d.cb);
+                this.A = d.ud;
+                this.s = d.sc;
+            }
+            static get parameterDescriptors() {
+                return c;
+            }
+            process(d, k, f) {
+                let m = d.length, w = k.length, E = 0, l, z, n, u = 4 * this.s, g = 12 * (m + w), V = I(), A, G, B;
+                for (l of d) g += l.length * u;
+                for (l of k) g += l.length * u;
+                for (l in f) g += f[l].byteLength + 8, ++E;
+                A = J(g);
+                g = A >> 2;
+                n = A + 12 * m;
+                for (l of d) {
+                    v[g] = l.length;
+                    v[g + 1] = this.s;
+                    v[g + 2] = n;
+                    g += 3;
+                    for (z of l) x.set(z, n >> 2), n += u;
+                }
+                G = n;
+                g = G >> 2;
+                d = (n += 12 * w) >> 2;
+                for (l of k) v[g] = l.length, v[g + 1] = this.s, v[g + 2] = n, g += 3, n += u * l.length;
+                u = n;
+                g = u >> 2;
+                n += 8 * E;
+                for (l = 0; B = f[l++]; ) v[g] = B.length, v[g + 1] = n, g += 2, x.set(B, n >> 2), 
+                n += 4 * B.length;
+                if (f = this.v(m, A, w, G, E, u, this.A)) for (l of k) for (z of l) for (g = 0; g < this.s; ++g) z[g] = x[d++];
+                K(V);
+                return !!f;
+            }
+        }
+        return e;
+    }
+    var L;
+    class b extends AudioWorkletProcessor {
+        constructor(c) {
+            super();
+            C(c.processorOptions);
+            L = this.port;
+            L.onmessage = async e => {
+                e = e.data;
+                e._wpn ? (registerProcessor(e._wpn, a(e.ap)), L.postMessage({
+                    _wsc: e.cb,
+                    x: [ e.ch, 1, e.ud ]
+                })) : e._wsc && H.get(e._wsc)(...e.x);
+            };
+        }
+        process() {}
+    }
+    registerProcessor("em-bootstrap", b);
+}
+
+function D() {
+    var a = y.buffer;
+    t = new Uint8Array(a);
+    r = new Int32Array(a);
+    v = new Uint32Array(a);
+    x = new Float32Array(a);
+}
+
+p || (y = h.mem || new WebAssembly.Memory({
     initial: 256,
     maximum: 256,
     shared: !0
-}), u();
+}), D());
 
-var w = [], y = a => {
+var M = [], N = a => {
     a = a.data;
     let b = a._wsc;
-    b && x.get(b)(...a.x);
-}, z = a => {
-    w.push(a);
-}, B = a => A(a), D = () => C(), G = (a, b, c, e) => {
-    b = E[b];
-    E[a].connect(b.destination || b, c, e);
-}, E = {}, H = 0, I = "undefined" != typeof TextDecoder ? new TextDecoder : void 0, J = (a = 0) => {
-    for (var b = p, c = a + NaN, e = a; b[e] && !(e >= c); ) ++e;
-    if (16 < e - a && b.buffer && I) return I.decode(b.slice(a, e));
+    b && H.get(b)(...a.x);
+}, O = a => {
+    M.push(a);
+}, P = a => K(a), Q = () => I(), S = (a, b, c, e) => {
+    b = R[b];
+    R[a].connect(b.destination || b, c, e);
+}, R = {}, T = 0, U = "undefined" != typeof TextDecoder ? new TextDecoder : void 0, W = (a = 0) => {
+    for (var b = t, c = a + NaN, e = a; b[e] && !(e >= c); ) ++e;
+    if (16 < e - a && b.buffer && U) return U.decode(b.slice(a, e));
     for (c = ""; a < e; ) {
         var d = b[a++];
         if (d & 128) {
-            var h = b[a++] & 63;
-            if (192 == (d & 224)) c += String.fromCharCode((d & 31) << 6 | h); else {
+            var k = b[a++] & 63;
+            if (192 == (d & 224)) c += String.fromCharCode((d & 31) << 6 | k); else {
                 var f = b[a++] & 63;
-                d = 224 == (d & 240) ? (d & 15) << 12 | h << 6 | f : (d & 7) << 18 | h << 12 | f << 6 | b[a++] & 63;
+                d = 224 == (d & 240) ? (d & 15) << 12 | k << 6 | f : (d & 7) << 18 | k << 12 | f << 6 | b[a++] & 63;
                 65536 > d ? c += String.fromCharCode(d) : (d -= 65536, c += String.fromCharCode(55296 | d >> 10, 56320 | d & 1023));
             }
         } else c += String.fromCharCode(d);
     }
     return c;
-}, K = a => {
+}, aa = a => {
     var b = window.AudioContext || window.webkitAudioContext;
     if (a >>= 2) {
-        var c = q[a] ? (c = q[a]) ? J(c) : "" : void 0;
+        var c = v[a] ? (c = v[a]) ? W(c) : "" : void 0;
         a = {
             latencyHint: c,
-            sampleRate: n[a + 1] || void 0
+            sampleRate: r[a + 1] || void 0
         };
     } else a = void 0;
-    if (c = b) b = new b(a), E[++H] = b, c = H;
+    if (c = b) b = new b(a), R[++T] = b, c = T;
     return c;
-}, L = (a, b, c, e, d) => {
+}, ba = (a, b, c, e, d) => {
     if (c >>= 2) {
-        var h = n[c], f = n[c + 1];
-        if (q[c + 2]) {
-            var l = q[c + 2] >> 2;
-            c = n[c + 1];
-            let F = [];
-            for (;c--; ) F.push(q[l++]);
-            l = F;
-        } else l = void 0;
+        var k = r[c], f = r[c + 1];
+        if (v[c + 2]) {
+            var m = v[c + 2] >> 2;
+            c = r[c + 1];
+            let w = [];
+            for (;c--; ) w.push(v[m++]);
+            m = w;
+        } else m = void 0;
         e = {
-            numberOfInputs: h,
+            numberOfInputs: k,
             numberOfOutputs: f,
-            outputChannelCount: l,
+            outputChannelCount: m,
             processorOptions: {
                 cb: e,
                 ud: d,
@@ -81,96 +149,92 @@ var w = [], y = a => {
             }
         };
     } else e = void 0;
-    a = new AudioWorkletNode(E[a], b ? J(b) : "", e);
-    E[++H] = a;
-    return H;
-}, M = (a, b, c, e) => {
+    a = new AudioWorkletNode(R[a], b ? W(b) : "", e);
+    R[++T] = a;
+    return T;
+}, ca = (a, b, c, e) => {
     b >>= 2;
-    let d = [], h = q[b + 1], f = q[b + 2] >> 2, l = 0;
-    for (;h--; ) d.push({
-        name: l++,
-        defaultValue: r[f++],
-        minValue: r[f++],
-        maxValue: r[f++],
-        automationRate: [ "a", "k" ][q[f++]] + "-rate"
+    let d = [], k = v[b + 1], f = v[b + 2] >> 2, m = 0;
+    for (;k--; ) d.push({
+        name: m++,
+        defaultValue: x[f++],
+        minValue: x[f++],
+        maxValue: x[f++],
+        automationRate: [ "a", "k" ][v[f++]] + "-rate"
     });
-    h = E[a].audioWorklet.s.port;
-    f = h.postMessage;
-    b = (b = q[b]) ? J(b) : "";
-    f.call(h, {
+    k = R[a].audioWorklet.u.port;
+    f = k.postMessage;
+    b = (b = v[b]) ? W(b) : "";
+    f.call(k, {
         _wpn: b,
         ap: d,
         ch: a,
         cb: c,
         ud: e
     });
-}, N = () => !1, O = 1, P = a => {
+}, da = () => !1, ea = 1, fa = a => {
     a = a.data;
     let b = a._wsc;
-    b && x.get(b)(...a.x);
-}, R = a => Q(a), S = (a, b, c, e, d) => {
-    let h = E[a], f = h.audioWorklet, l = () => {
-        x.get(e)(a, 0, d);
+    b && H.get(b)(...a.x);
+}, ha = a => J(a), ia = (a, b, c, e, d) => {
+    let k = R[a], f = k.audioWorklet, m = () => {
+        H.get(e)(a, 0, d);
     };
-    if (!f) return l();
-    f.addModule("a.aw.js").then((() => {
-        f.s = new AudioWorkletNode(h, "message", {
+    if (!f) return m();
+    f.addModule(h.js).then((() => {
+        f.u = new AudioWorkletNode(k, "em-bootstrap", {
             processorOptions: {
-                $ww: O++,
-                wasm: g.wasm,
-                mem: t,
+                $ww: ea++,
+                wasm: h.wasm,
+                mem: y,
                 sb: b,
                 sz: c
             }
         });
-        f.s.port.onmessage = P;
-        return f.addModule(g.js);
-    })).then((() => {
-        x.get(e)(a, 1, d);
-    })).catch(l);
+        f.u.port.onmessage = fa;
+        H.get(e)(a, 1, d);
+    })).catch(m);
 };
 
-function T(a) {
+function ja(a) {
     let b = document.createElement("button");
     b.innerHTML = "Toggle playback";
     document.body.appendChild(b);
-    a = E[a];
+    a = R[a];
     b.onclick = () => {
         "running" != a.state ? a.resume() : a.suspend();
     };
 }
 
-function v() {
-    U = {
-        f: T,
-        g: G,
-        d: K,
-        h: L,
-        e: M,
-        b: N,
-        c: S,
-        a: t
+function F() {
+    X = {
+        f: ja,
+        g: S,
+        d: aa,
+        h: ba,
+        e: ca,
+        b: da,
+        c: ia,
+        a: y
     };
-    WebAssembly.instantiate(g.wasm, {
-        a: U
+    WebAssembly.instantiate(h.wasm, {
+        a: X
     }).then((a => {
         a = a.instance.exports;
-        V = a.j;
-        A = a.l;
-        Q = a.m;
-        C = a.n;
-        W = a.o;
-        x = a.k;
-        g.stackSave = D;
-        g.stackAlloc = R;
-        g.stackRestore = B;
-        g.wasmTable = x;
-        m ? (a = g, W(a.sb, a.sz), "undefined" === typeof AudioWorkletGlobalScope && (removeEventListener("message", z), 
-        w = w.forEach(y), addEventListener("message", y))) : a.i();
-        m || V();
+        Y = a.j;
+        K = a.l;
+        J = a.m;
+        I = a.n;
+        Z = a.o;
+        H = a.k;
+        h.stackSave = Q;
+        h.stackAlloc = ha;
+        h.stackRestore = P;
+        h.wasmTable = H;
+        p ? (a = h, Z(a.sb, a.sz), "undefined" === typeof AudioWorkletGlobalScope && (removeEventListener("message", O), 
+        M = M.forEach(N), addEventListener("message", N))) : a.i();
+        p || Y();
     }));
 }
 
-k && v();
-
-m || v();
+p || F();

--- a/test/code_size/audio_worklet_wasm.json
+++ b/test/code_size/audio_worklet_wasm.json
@@ -1,12 +1,10 @@
 {
   "a.html": 519,
   "a.html.gz": 364,
-  "a.js": 2851,
-  "a.js.gz": 1583,
-  "a.aw.js": 2551,
-  "a.aw.js.gz": 922,
+  "a.js": 3886,
+  "a.js.gz": 2070,
   "a.wasm": 1287,
   "a.wasm.gz": 859,
-  "total": 7208,
-  "total_gz": 3728
+  "total": 5692,
+  "total_gz": 3293
 }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11802,9 +11802,6 @@ int main () {
       return ' ({:+.2f}%)'.format((actual - expected) * 100.0 / expected)
 
     outputs = ['a.html', 'a.js']
-    if '-sAUDIO_WORKLET' in sources:
-      outputs += ['a.aw.js']
-
     args = smallest_code_size_args[:]
 
     if wasm2js:

--- a/test/webaudio/audioworklet_params_mixing.c
+++ b/test/webaudio/audioworklet_params_mixing.c
@@ -22,7 +22,8 @@ bool process(int numInputs, const AudioSampleFrame* inputs, int numOutputs, Audi
 #endif
 
   // Single stereo output
-  assert(numOutputs == 1 && outputs[0].numberOfChannels == 2);
+  assert(numOutputs == 1);
+  assert(outputs[0].numberOfChannels == 2);
   int outSamplesPerChannel = outputs[0].samplesPerChannel;
   for (int n = 0; n < numInputs; n++) {
     // And all inputs are also stereo (or disabled)

--- a/tools/building.py
+++ b/tools/building.py
@@ -605,6 +605,7 @@ def closure_compiler(filename, advanced=True, extra_closure_args=None):
   args += ['--language_out', 'NO_TRANSPILE']
   # Tell closure never to inject the 'use strict' directive.
   args += ['--emit_use_strict=false']
+  args += ['--assume_static_inheritance_is_not_used=false']
 
   if settings.IGNORE_CLOSURE_COMPILER_ERRORS:
     args.append('--jscomp_off=*')

--- a/tools/js_manipulation.py
+++ b/tools/js_manipulation.py
@@ -44,7 +44,7 @@ def add_files_pre_js(pre_js_list, files_pre_js):
   utils.write_file(pre, '''
     // All the pre-js content up to here must remain later on, we need to run
     // it.
-    if (Module['$ww'] || (typeof ENVIRONMENT_IS_PTHREAD != 'undefined' && ENVIRONMENT_IS_PTHREAD)) Module['preRun'] = [];
+    if (Module['$ww'] || (typeof ENVIRONMENT_IS_PTHREAD != 'undefined' && ENVIRONMENT_IS_PTHREAD) || (typeof ENVIRONMENT_IS_AUDIO_WORKLET != 'undefined' && ENVIRONMENT_IS_AUDIO_WORKLET)) Module['preRun'] = [];
     var necessaryPreJSTasks = Module['preRun'].slice();
   ''')
   utils.write_file(post, '''

--- a/tools/maint/gen_sig_info.py
+++ b/tools/maint/gen_sig_info.py
@@ -6,7 +6,7 @@
 
 """This tool extracts native/C signature information for JS library functions
 
-It generates a file called `src/libsigs.js` which contains `__sig` declarations
+It generates a file called `src/lib/libsigs.js` which contains `__sig` declarations
 for the majority of JS library functions.
 """
 
@@ -304,8 +304,6 @@ def extract_sig_info(sig_info, extra_settings=None, extra_cflags=None, cxx=False
     'FETCH': 1,
     'PTHREADS': 1,
     'SHARED_MEMORY': 1,
-    'AUDIO_WORKLET': 1,
-    'WASM_WORKERS': 1,
     'JS_LIBRARIES': [
       'libwebsocket.js',
       'libexports.js',
@@ -377,7 +375,7 @@ def extract_sig_info(sig_info, extra_settings=None, extra_cflags=None, cxx=False
 
 def main(args):
   parser = argparse.ArgumentParser()
-  parser.add_argument('-o', '--output', default='src/libsigs.js')
+  parser.add_argument('-o', '--output', default='src/lib/libsigs.js')
   parser.add_argument('-r', '--remove', action='store_true', help='remove from JS library files any `__sig` entries that are part of the auto-generated file')
   parser.add_argument('-u', '--update', action='store_true', help='update with JS library files any `__sig` entries that are part of the auto-generated file')
   args = parser.parse_args()
@@ -391,7 +389,7 @@ def main(args):
                               'BUILD_AS_WORKER': 1,
                               'LINK_AS_CXX': 1,
                               'AUTO_JS_LIBRARIES': 0}, cxx=True)
-  extract_sig_info(sig_info, {'WASM_WORKERS': 1, 'JS_LIBRARIES': ['libwasm_worker.js']})
+  extract_sig_info(sig_info, {'AUDIO_WORKLET': 1, 'WASM_WORKERS': 1, 'JS_LIBRARIES': ['libwasm_worker.js', 'libwebaudio.js']})
   extract_sig_info(sig_info, {'USE_GLFW': 3}, ['-DGLFW3'])
   extract_sig_info(sig_info, {'JS_LIBRARIES': ['libembind.js', 'libemval.js'],
                               'USE_SDL': 0,


### PR DESCRIPTION
This is similar to what we already did for pthreads (#24163) and normal wasm workers (#24163).  By integrating this file we can actually share more startup code with normal wasm workers.