### PR TITLE
Allow setting of CLOSURE_ARGS in ports

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@ See docs/process.md for more on how version tagging works.
 - Programs built with `-sWASM_WORKERS` no longer generate a separate `.ww.js`
   file.  This is similar to the change that was already made for pthreads in
   #21701.  This saves on complexity, code size and network requests (#24163)
+- Closure arguments can now be used from ports using `settings.CLOSURE_ARGS`
+  (#24192)
 
 4.0.7 - 04/15/25
 ----------------

--- a/emcc.py
+++ b/emcc.py
@@ -142,7 +142,6 @@ class EmccOptions:
     self.requested_debug = None
     self.emit_symbol_map = False
     self.use_closure_compiler = None
-    self.closure_args = []
     self.js_transform = None
     self.pre_js = [] # before all js
     self.post_js = [] # after all js
@@ -1125,7 +1124,7 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
       consume_arg()
     elif check_arg('--closure-args'):
       args = consume_arg()
-      options.closure_args += shlex.split(args)
+      settings.CLOSURE_ARGS += shlex.split(args)
     elif check_arg('--closure'):
       options.use_closure_compiler = int(consume_arg())
     elif check_arg('--js-transform'):

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -227,6 +227,11 @@ var LINK_AS_CXX = false;
 // emitted in that case for closure compiler.
 var MAYBE_CLOSURE_COMPILER = false;
 
+// List of closure args for the closure compiler.
+// This list is populated from the --closure-args argument and can be extended
+// in ports using settings.CLOSURE_ARGS
+var CLOSURE_ARGS = [];
+
 // Set when some minimum browser version triggers doesn't support the minimum
 // set of JavaScript features.  This triggers transpilation using babel.
 var TRANSPILE = false;

--- a/test/test_closure_args_port.py
+++ b/test/test_closure_args_port.py
@@ -1,0 +1,14 @@
+import os
+
+def get(ports, settings, shared):
+  return []
+
+
+def clear(ports, settings, shared):
+  pass
+
+
+def linker_setup(ports, settings):
+  externs_file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                             'test_closure_externs.js')
+  settings.CLOSURE_ARGS += [ f'--externs={externs_file}']

--- a/test/test_closure_args_port.py
+++ b/test/test_closure_args_port.py
@@ -1,5 +1,6 @@
 import os
 
+
 def get(ports, settings, shared): # noqa: ARG001
   return []
 
@@ -11,4 +12,4 @@ def clear(ports, settings, shared): # noqa: ARG001
 def linker_setup(ports, settings): # noqa: ARG001
   externs_file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                              'test_closure_externs.js')
-  settings.CLOSURE_ARGS += [ f'--externs={externs_file}']
+  settings.CLOSURE_ARGS += [f'--externs={externs_file}']

--- a/test/test_closure_args_port.py
+++ b/test/test_closure_args_port.py
@@ -1,14 +1,14 @@
 import os
 
-def get(unused_ports, unused_settings, unused_shared):
+def get(ports, settings, shared): # noqa: ARG001
   return []
 
 
-def clear(unused_ports, unused_settings, unused_shared):
+def clear(ports, settings, shared): # noqa: ARG001
   pass
 
 
-def linker_setup(unused_ports, settings):
+def linker_setup(ports, settings): # noqa: ARG001
   externs_file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                              'test_closure_externs.js')
   settings.CLOSURE_ARGS += [ f'--externs={externs_file}']

--- a/test/test_closure_args_port.py
+++ b/test/test_closure_args_port.py
@@ -1,14 +1,14 @@
 import os
 
-def get(ports, settings, shared):
+def get(unused_ports, unused_settings, unused_shared):
   return []
 
 
-def clear(ports, settings, shared):
+def clear(unused_ports, unused_settings, unused_shared):
   pass
 
 
-def linker_setup(ports, settings):
+def linker_setup(unused_ports, settings):
   externs_file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                              'test_closure_externs.js')
   settings.CLOSURE_ARGS += [ f'--externs={externs_file}']

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10269,6 +10269,15 @@ end
                         '--pre-js', test_file('test_closure_externs_pre_js.js')] +
                        args)
 
+  # Tests that ports can add closure args by using settings.CLOSURE_ARGS
+  @crossplatform
+  def test_closure_args_from_port(self):
+    port = test_file('test_closure_args_port.py')
+    self.run_process([EMCC, test_file('hello_world.c'),
+                      f'--use-port={port}',
+                      '--closure=1',
+                      '--pre-js', test_file('test_closure_externs_pre_js.js')])
+
   # Tests that it is possible to enable the Closure compiler via --closure=1 even if any of the input files reside in a path with unicode characters.
   def test_closure_cmdline_utf8_chars(self):
     test = "☃ äö Ć € ' 🦠.c"

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10272,9 +10272,8 @@ end
   # Tests that ports can add closure args by using settings.CLOSURE_ARGS
   @crossplatform
   def test_closure_args_from_port(self):
-    port = test_file('test_closure_args_port.py')
     self.run_process([EMCC, test_file('hello_world.c'),
-                      f'--use-port={port}',
+                      '--use-port', test_file('test_closure_args_port.py'),
                       '--closure=1',
                       '--pre-js', test_file('test_closure_externs_pre_js.js')])
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -2335,7 +2335,7 @@ def phase_binaryen(target, options, wasm_target):
 
     if options.use_closure_compiler:
       with ToolchainProfiler.profile_block('closure_compile'):
-        final_js = building.closure_compiler(final_js, extra_closure_args=options.closure_args)
+        final_js = building.closure_compiler(final_js, extra_closure_args=settings.CLOSURE_ARGS)
       save_intermediate('closure')
 
     if settings.TRANSPILE:

--- a/tools/link.py
+++ b/tools/link.py
@@ -2195,7 +2195,7 @@ def phase_final_emitting(options, target, js_target, wasm_target):
     # Finally, rerun Closure compile with simple optimizations. It will be able
     # to further minify the code. (n.b. it would not be safe to run in advanced
     # mode)
-    final_js = building.closure_compiler(final_js, advanced=False, extra_closure_args=options.closure_args)
+    final_js = building.closure_compiler(final_js, advanced=False, extra_closure_args=settings.CLOSURE_ARGS)
     # Run unsafe_optimizations.js once more.  This allows the cleanup of newly
     # unused things that closure compiler leaves behind (e.g `new Float64Array(x)`).
     shared.run_js_tool(utils.path_from_root('tools/unsafe_optimizations.mjs'), [final_js, '-o', final_js], cwd=utils.path_from_root('.'))


### PR DESCRIPTION
This is the implementation that was discussed in #24109 

I can update the Changelog in a later commit if the tests pass in CI and this PR is approved.

* I manually/locally ran `other.test_closure_externs` to make sure that the changes were not affecting existing code
* I added a test `other.test_closure_args_from_port` that piggy back on `test_closure_externs` to pass the same parameter in the port instead and make sure that these changes actually do what they are supposed to do in the first place.

Hopefully I didn't forget anything. The changes are pretty straightforward in the grand scheme of things.