### PR TITLE
Fix manual triggering in test_audioworklet_emscripten_locks

### DIFF
--- a/test/webaudio/audioworklet_emscripten_locks.c
+++ b/test/webaudio/audioworklet_emscripten_locks.c
@@ -46,6 +46,18 @@ double startTime = 0;
 
 bool ProcessAudio(int numInputs, const AudioSampleFrame *inputs, int numOutputs, AudioSampleFrame *outputs, int numParams, const AudioParamFrame *params, void *userData) {
   assert(emscripten_current_thread_is_audio_worklet());
+
+  // Produce at few empty frames of audio before we start trying to interact
+  // with the with main thread.
+  // On chrome at least it appears the main thread completely blocks until
+  // a few frames have been produced.  This means it may not be safe to interact
+  // with the main thread during initial frames?
+  // In my experiments it seems like 5 was the magic number that I needed to
+  // produce before the main thread could continue to run.
+  // See https://github.com/emscripten-core/emscripten/issues/24213
+  static int count = 0;
+  if (count++ < 5) return true;
+
   int result = 0;
   switch (whichTest) {
   case TEST_HAS_WAIT:


### PR DESCRIPTION
At least under chrome it seems that the main thread doesn't run at all until the first few frames have been produced.

This fixes the test failures I've been seeing while working on #24190