### PR TITLE
Reduce `hello_wasm_worker.c` testing in `test_other.py`

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14591,12 +14591,8 @@ int main() {
     else:
       self.run_process([EMCC, test_file('hello_world.c'), '-Werror'] + args)
 
-  @parameterized({
-    '': [[]],
-    'trusted': [['-sTRUSTED_TYPES']],
-  })
-  def test_wasm_worker_hello(self, args):
-    self.do_runf('wasm_worker/hello_wasm_worker.c', emcc_args=['-sWASM_WORKERS'] + args)
+  def test_wasm_worker_trusted_types(self):
+    self.do_run_in_out_file_test('wasm_worker/hello_wasm_worker.c', emcc_args=['-sWASM_WORKERS', '-sTRUSTED_TYPES'])
 
   def test_wasm_worker_terminate(self):
     self.do_runf('wasm_worker/terminate_wasm_worker.c', emcc_args=['-sWASM_WORKERS'])


### PR DESCRIPTION
`hello_wasm_worker.c` is extensively tested in `test_core.py`. The only part that wasn't was the `-sTRUSTED_TYPES` part, so leave that here in `test_other.py`