### PR TITLE
Skip wasm worker tests in sanitizer configurations. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -886,7 +886,7 @@ base align: 0, 0, 0, 0'''])
   def test_longjmp(self):
     self.do_core_test('test_longjmp.c')
 
-  @no_asan('ASan does not support WASM_WORKERS')
+  @no_sanitize('sanitizers do not support WASM_WORKERS')
   def test_longjmp_wasm_workers(self):
     self.do_core_test('test_longjmp.c', emcc_args=['-sWASM_WORKERS'])
 
@@ -7588,7 +7588,7 @@ void* operator new(size_t size) {
     self.emcc_args += ['-lembind', '-fno-rtti', '-frtti']
     self.do_run(src, '418\ndotest returned: 42\n')
 
-  @no_asan('ASan does not support WASM_WORKERS')
+  @no_sanitize('sanitizers do not support WASM_WORKERS')
   def test_embind_wasm_workers(self):
     self.do_run_in_out_file_test('embind/test_embind_wasm_workers.cpp', emcc_args=['-lembind', '-sWASM_WORKERS'])
 
@@ -9571,7 +9571,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_runf('test_emscripten_async_load_script.c', emcc_args=['-sFORCE_FILESYSTEM'])
 
   @node_pthreads
-  @no_asan('ASan does not support WASM_WORKERS')
+  @no_sanitize('sanitizers do not support WASM_WORKERS')
   @also_with_minimal_runtime
   @also_with_modularize
   def test_wasm_worker_hello(self):
@@ -9581,12 +9581,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_run_in_out_file_test('wasm_worker/hello_wasm_worker.c', emcc_args=['-sWASM_WORKERS'])
 
   @node_pthreads
-  @no_asan('ASan does not support WASM_WORKERS')
+  @no_sanitize('sanitizers do not support WASM_WORKERS')
   def test_wasm_worker_malloc(self):
     self.do_run_in_out_file_test('wasm_worker/malloc_wasm_worker.c', emcc_args=['-sWASM_WORKERS'])
 
   @node_pthreads
-  @no_asan('ASan does not support WASM_WORKERS')
+  @no_sanitize('sanitizers do not support WASM_WORKERS')
   def test_wasm_worker_wait_async(self):
     self.do_runf('atomic/test_wait_async.c', emcc_args=['-sWASM_WORKERS'])
 


### PR DESCRIPTION
This configuration was recently marked as unsupported (#24171)