### PR TITLE
[cmake] Re-enable EMSCRIPTEN_FORCE_COMPILERS by default

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,8 @@ See docs/process.md for more on how version tagging works.
   network requests. (#24163, #24190)
 - Closure arguments can now be used from ports using `settings.CLOSURE_ARGS`
   (#24192)
+- When using cmake the EMSCRIPTEN_FORCE_COMPILERS setting was reverted to
+  being on by default due to issues that were found with disabling it. (#24223)
 
 4.0.7 - 04/15/25
 ----------------

--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -121,9 +121,11 @@ endif()
 file(TO_CMAKE_PATH "${_emcache_output}" _emcache_output)
 set(EMSCRIPTEN_SYSROOT "${_emcache_output}/sysroot")
 
-# Allow skipping of CMake compiler autodetection, since this is quite slow with
-# Emscripten. Pass -DEMSCRIPTEN_FORCE_COMPILERS=ON to enable
-option(EMSCRIPTEN_FORCE_COMPILERS "Force C/C++ compiler" OFF)
+# Allow skipping of CMake compiler autodetection.  On by default since this is
+# quite slow with Emscripten and also leads to issues with
+# CMAKE_C_IMPLICIT_LINK_LIBRARIES.
+# See https://github.com/emscripten-core/emscripten/issues/23944
+option(EMSCRIPTEN_FORCE_COMPILERS "Force C/C++ compiler" ON)
 if (EMSCRIPTEN_FORCE_COMPILERS)
 
   # Detect version of the 'emcc' executable. Note that for CMake, we tell it the

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -920,7 +920,7 @@ f.close()
   @no_windows('Skipped on Windows because CMake does not configure native Clang builds well on Windows.')
   @parameterized({
     '': ([],),
-    'force': (['-DEMSCRIPTEN_FORCE_COMPILERS=ON'],),
+    'noforce': (['-DEMSCRIPTEN_FORCE_COMPILERS=OFF'],),
   })
   def test_cmake_compile_features(self, args):
     os.mkdir('build_native')
@@ -979,7 +979,7 @@ f.close()
   @crossplatform
   @parameterized({
     '': ([],),
-    'force': (['-DEMSCRIPTEN_FORCE_COMPILERS=ON'],),
+    'noforce': (['-DEMSCRIPTEN_FORCE_COMPILERS=OFF'],),
   })
   def test_cmake_compile_commands(self, args):
     self.run_process([EMCMAKE, 'cmake', test_file('cmake/static_lib'), '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON'] + args)


### PR DESCRIPTION
This effectively reverts #23537

Fixes: #23944