### PR TITLE
Fix rpath calculation in nested dependencies

### DIFF
--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -904,7 +904,8 @@ var LibraryDylink = {
     // We need to set rpath in flags based on the current library's rpath.
     // We can't mutate flags or else if a depends on b and c and b depends on d,
     // then c will be loaded with b's rpath instead of a's.
-    flags = {...flags, rpath: { parentLibPath: libName, paths: metadata.runtimePaths }}
+    var dso = LDSO.loadedLibsByName[libName];
+    flags = {...flags, rpath: { parentLibPath: dso.path, paths: metadata.runtimePaths }}
     // now load needed libraries and the module itself.
     if (flags.loadAsync) {
       return metadata.neededDynlibs
@@ -937,6 +938,7 @@ var LibraryDylink = {
     var dso = {
       refcount: Infinity,
       name,
+      path: name, // full path to the library, updated when the library is resolved in the filesystem.
       exports: syms,
       global: true,
     };
@@ -1105,6 +1107,7 @@ var LibraryDylink = {
 #endif
       if (f) {
         var libData = FS.readFile(f, {encoding: 'binary'});
+        dso.path = f;
         return flags.loadAsync ? Promise.resolve(libData) : libData;
       }
 #endif


### PR DESCRIPTION
This fixes a bug in rpath calculation in nested dependencies.

Basically, it fixes a case when a relative path is passed to the `loadDynamicLibrary`.

Think of the following scenario:

0. libhello.wasm depends on libhello_dep.so depends on libhello_nested_dep.so
1. [main.c] calls dlopen('/usr/lib/libhello.wasm')
2. [dynlink.c] loads '/usr/lib/libhello.wasm' and locates the absolute path of `libhello_dep.so` (`/usr/lib/libhello_dep.so`), and calls `loadDynamicLibrary('/usr/lib/libhello_dep.so')` (_dlopen_js ==> dlopenInternal ==> loadDynamicLibrary)
3. [libdylink.js] While loading `/usr/lib/libhello_dep.so`, it loads its dependency 'libhello_nested_dep.so' first. So it calls `loadDynamicLibrary('libhello_nested_dep.so')`.

In step 3, the relative path to the library is passed to the `loadDynamicLibrary`, and it wasn't correctly handled during RPATH calculation.
