### PR TITLE
Docs: Fix typo in flag `wasm-exceptions`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -878,7 +878,7 @@ See docs/process.md for more on how version tagging works.
   `ASSERTIONS` is enabled. This option is mainly for the users who want only
   exceptions' stack traces without turning `ASSERTIONS` on. (#18642 and #18535)
 - `SUPPORT_LONGJMP`'s default value now depends on the exception mode. If Wasm
-  EH (`-fwasm-exception`) is used, it defaults to `wasm`, and if Emscripten EH
+  EH (`-fwasm-exceptions`) is used, it defaults to `wasm`, and if Emscripten EH
   (`-sDISABLE_EXCEPTION_CATCHING=0`) is used or no exception support is used, it
   defaults to `emscripten`. Previously it always defaulted to `emscripten`, so
   when a user specified `-fwasm-exceptions`, it resulted in Wasm EH + Emscripten

--- a/site/source/docs/porting/setjmp-longjmp.rst
+++ b/site/source/docs/porting/setjmp-longjmp.rst
@@ -10,7 +10,7 @@ by the ``SUPPORT_LONGJMP`` setting, which can take these values:
 * ``emscripten``: JavaScript-based support
 * ``wasm``: WebAssembly exception handling-based support
 * 0: No support
-* 1: Default support, depending on the exception mode. ``wasm`` if ``-fwasm-exception`` is used, ``emscripten`` otherwise.
+* 1: Default support, depending on the exception mode. ``wasm`` if ``-fwasm-exceptions`` is used, ``emscripten`` otherwise.
 
 If :ref:`native Wasm exceptions <webassembly-exception-handling-based-support>`
 are used, ``SUPPORT_LONGJMP`` defaults to ``wasm``, and if :ref:`JavaScript-based

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -2998,7 +2998,7 @@ little bit of code size and performance when catching exceptions.
 
 - 0: No setjmp/longjmp handling
 - 1: Default setjmp/longjmp/handling, depending on the mode of exceptions.
-  'wasm' if '-fwasm-exception' is used, 'emscripten' otherwise.
+  'wasm' if '-fwasm-exceptions' is used, 'emscripten' otherwise.
 
 [compile+link] - at compile time this enables the transformations needed for
 longjmp support at codegen time, while at link it allows linking in the

--- a/src/settings.js
+++ b/src/settings.js
@@ -1969,7 +1969,7 @@ var MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION = false;
 //
 // - 0: No setjmp/longjmp handling
 // - 1: Default setjmp/longjmp/handling, depending on the mode of exceptions.
-//   'wasm' if '-fwasm-exception' is used, 'emscripten' otherwise.
+//   'wasm' if '-fwasm-exceptions' is used, 'emscripten' otherwise.
 //
 // [compile+link] - at compile time this enables the transformations needed for
 // longjmp support at codegen time, while at link it allows linking in the


### PR DESCRIPTION
This pull request fixes a typo in the flag `wasm-exceptions`.

In the docs page for [C setjmp-longjmp Support](https://emscripten.org/docs/porting/setjmp-longjmp.html), it mentions a command-line option `-fwasm-exception`.

> 1: Default support, depending on the exception mode. `wasm` if `-fwasm-exception` is used, `emscripten` otherwise.

I got an error when I tried to use it.

```
clang: error: unknown argument '-fwasm-exception'; did you mean '-fwasm-exceptions'?
```

Searching the `emscripten` codebase, I found several places where the flag was misspelled with a missing `s`.

```
$ grep -RHIn wasm-exception | grep -v wasm-exceptions

ChangeLog.md:881:  EH (`-fwasm-exception`) is used, it defaults to `wasm`, and if Emscripten EH
site/source/docs/tools_reference/settings_reference.rst:3001:  'wasm' if '-fwasm-exception' is used, 'emscripten' otherwise.
site/source/docs/porting/setjmp-longjmp.rst:13:* 1: Default support, depending on the exception mode. ``wasm`` if ``-fwasm-exception`` is used, ``emscripten`` otherwise.
src/settings.js:1972://   'wasm' if '-fwasm-exception' is used, 'emscripten' otherwise.
```

The wording is the same in some places so maybe they were copy & pasted, or generated from a comment block. I fixed all occurrences just in case.