### PR TITLE
Implement `open`/`stat`/`mkdir`/`symlink` for standalone WASI mode

### DIFF
--- a/system/lib/standalone/paths.c
+++ b/system/lib/standalone/paths.c
@@ -1,0 +1,228 @@
+#define _GNU_SOURCE
+#include "paths.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sysexits.h>
+
+/// A name and file descriptor pair.
+typedef struct preopen {
+  /// The path prefix associated with the file descriptor.
+  const char* prefix;
+
+  /// The file descriptor.
+  __wasi_fd_t fd;
+} preopen;
+
+/// A simple growable array of `preopen`.
+static preopen* preopens;
+static size_t num_preopens;
+static size_t preopen_capacity;
+
+#ifdef NDEBUG
+#define assert_invariants() // assertions disabled
+#else
+static void assert_invariants(void) {
+  assert(num_preopens <= preopen_capacity);
+  assert(preopen_capacity == 0 || preopens != NULL);
+  assert(preopen_capacity == 0 ||
+         preopen_capacity * sizeof(preopen) > preopen_capacity);
+
+  for (size_t i = 0; i < num_preopens; ++i) {
+    const preopen* pre = &preopens[i];
+    assert(pre->prefix != NULL);
+    assert(pre->fd != (__wasi_fd_t)-1);
+#ifdef __wasm__
+    assert((uintptr_t)pre->prefix <
+           (__uint128_t)__builtin_wasm_memory_size(0) * PAGESIZE);
+#endif
+  }
+}
+#endif
+
+/// Allocate space for more preopens. Returns 0 on success and -1 on failure.
+static bool resize_preopens(void) {
+  size_t start_capacity = 4;
+  size_t old_capacity = preopen_capacity;
+  size_t new_capacity = old_capacity == 0 ? start_capacity : old_capacity * 2;
+
+  preopen* old_preopens = preopens;
+  preopen* new_preopens = calloc(sizeof(preopen), new_capacity);
+  if (new_preopens == NULL) {
+    return false;
+  }
+
+  memcpy(new_preopens, old_preopens, num_preopens * sizeof(preopen));
+  preopens = new_preopens;
+  preopen_capacity = new_capacity;
+  free(old_preopens);
+
+  assert_invariants();
+  return true;
+}
+
+// Normalize an absolute path. Removes leading `/` and leading `./`, so the
+// first character is the start of a directory name. This works because our
+// process always starts with a working directory of `/`. Additionally translate
+// `.` to the empty string.
+static const char* strip_prefixes(const char* path) {
+  while (1) {
+    if (path[0] == '/') {
+      path++;
+    } else if (path[0] == '.' && path[1] == '/') {
+      path += 2;
+    } else if (path[0] == '.' && path[1] == 0) {
+      path++;
+    } else {
+      break;
+    }
+  }
+
+  return path;
+}
+
+/// Register the given preopened file descriptor under the given path.
+///
+/// This function takes ownership of `prefix`.
+static bool register_preopened_fd(__wasi_fd_t fd, const char* relprefix) {
+  // Check preconditions.
+  assert_invariants();
+  assert(fd != AT_FDCWD);
+  assert(fd != -1);
+  assert(relprefix != NULL);
+
+  if (num_preopens == preopen_capacity && !resize_preopens()) {
+    return false;
+  }
+
+  char* prefix = strdup(strip_prefixes(relprefix));
+  if (prefix == NULL) {
+    return false;
+  }
+  preopens[num_preopens++] = (preopen){
+    prefix,
+    fd,
+  };
+
+  assert_invariants();
+  return true;
+}
+
+/// Are the `prefix_len` bytes pointed to by `prefix` a prefix of `path`?
+static bool
+prefix_matches(const char* prefix, size_t prefix_len, const char* path) {
+  // Allow an empty string as a prefix of any relative path.
+  if (path[0] != '/' && prefix_len == 0)
+    return true;
+
+  // Check whether any bytes of the prefix differ.
+  if (memcmp(path, prefix, prefix_len) != 0)
+    return false;
+
+  // Ignore trailing slashes in directory names.
+  size_t i = prefix_len;
+  while (i > 0 && prefix[i - 1] == '/') {
+    --i;
+  }
+
+  // Match only complete path components.
+  char last = path[i];
+  return last == '/' || last == '\0';
+}
+
+bool __paths_resolve_path(int* resolved_dirfd, const char** path_ptr) {
+  const char* path = *path_ptr;
+
+  if (*resolved_dirfd != AT_FDCWD && path[0] != '/') {
+    return true;
+  }
+
+  // Strip leading `/` characters, the prefixes we're mataching won't have
+  // them.
+  while (*path == '/')
+    path++;
+  // Search through the preopens table. Iterate in reverse so that more
+  // recently added preopens take precedence over less recently addded ones.
+  size_t match_len = 0;
+  int fd = -1;
+  for (size_t i = num_preopens; i > 0; --i) {
+    const preopen* pre = &preopens[i - 1];
+    const char* prefix = pre->prefix;
+    size_t len = strlen(prefix);
+
+    // If we haven't had a match yet, or the candidate path is longer than
+    // our current best match's path, and the candidate path is a prefix of
+    // the requested path, take that as the new best path.
+    if ((fd == -1 || len > match_len) && prefix_matches(prefix, len, path)) {
+      fd = pre->fd;
+      match_len = len;
+    }
+  }
+
+  if (fd == -1) {
+    return false;
+  }
+
+  // The relative path is the substring after the portion that was matched.
+  const char* computed = path + match_len;
+
+  // Omit leading slashes in the relative path.
+  while (*computed == '/')
+    ++computed;
+
+  // *at syscalls don't accept empty relative paths, so use "." instead.
+  if (*computed == '\0')
+    computed = ".";
+
+  *resolved_dirfd = fd;
+  *path_ptr = computed;
+  return true;
+}
+
+// Populate WASI preopens.
+__attribute__((constructor(100))) // construct this before user code
+static void _standalone_populate_preopens(void) {
+  // Skip stdin, stdout, and stderr, and count up until we reach an invalid
+  // file descriptor.
+  for (__wasi_fd_t fd = 3; fd != 0; ++fd) {
+    __wasi_prestat_t prestat;
+    __wasi_errno_t ret = __wasi_fd_prestat_get(fd, &prestat);
+    if (ret == __WASI_ERRNO_BADF)
+      break;
+    if (ret != __WASI_ERRNO_SUCCESS)
+      goto oserr;
+    switch (prestat.pr_type) {
+      case __WASI_PREOPENTYPE_DIR: {
+        char* prefix = malloc(prestat.u.dir.pr_name_len + 1);
+        if (prefix == NULL)
+          goto software;
+
+        // TODO: Remove the cast on `path` once the witx is updated with
+        // char8 support.
+        ret = __wasi_fd_prestat_dir_name(
+          fd, (uint8_t*)prefix, prestat.u.dir.pr_name_len);
+        if (ret != __WASI_ERRNO_SUCCESS)
+          goto oserr;
+        prefix[prestat.u.dir.pr_name_len] = '\0';
+
+        if (!register_preopened_fd(fd, prefix))
+          goto software;
+        free(prefix);
+
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return;
+oserr:
+  _Exit(EX_OSERR);
+software:
+  _Exit(EX_SOFTWARE);
+}

--- a/system/lib/standalone/paths.h
+++ b/system/lib/standalone/paths.h
@@ -1,0 +1,21 @@
+#ifndef STANDALONE_PATHS_H
+#define STANDALONE_PATHS_H
+
+#include <stdbool.h>
+
+//
+// Resolve a (dirfd, relative/absolute path) pair.
+//
+// Arguments:
+// - `resolved_dirfd`:
+//   - as input: input dirfd, may be `AT_FDCWD`
+//   - as output: resolved dirfd (which always is a preopened fd)
+// - `path_ptr`:
+//   - as input: pointer to a relative or absolute path
+//   - as output: a path relative to `resolved_dirfd`
+//
+// Returns: `true` if resolution was successful, `false` otherwise.
+//
+bool __paths_resolve_path(int* resolved_dirfd, const char** path_ptr);
+
+#endif

--- a/test/common.py
+++ b/test/common.py
@@ -614,7 +614,7 @@ def can_do_standalone(self, impure=False):
 
 # Impure means a test that cannot run in a wasm VM yet, as it is not 100%
 # standalone. We can still run them with the JS code though.
-def also_with_standalone_wasm(impure=False):
+def also_with_standalone_wasm(impure=False, exclude_engines=None):
   def decorated(func):
     @wraps(func)
     def metafunc(self, standalone):
@@ -623,11 +623,19 @@ def also_with_standalone_wasm(impure=False):
       if not standalone:
         func(self)
       else:
+        nonlocal exclude_engines
+        if exclude_engines is None:
+          exclude_engines = []
         if not can_do_standalone(self, impure):
           self.skipTest('Test configuration is not compatible with STANDALONE_WASM')
         self.set_setting('STANDALONE_WASM')
         if not impure:
           self.set_setting('PURE_WASI')
+        if 'node' in exclude_engines:
+          # When not running under node we don't care for any undefined symbols
+          # in the .js as we are only interested in the .wasm file.
+          self.set_setting('ERROR_ON_UNDEFINED_SYMBOLS=0')
+          self.emcc_args.append('-Wno-js-compiler')
         # we will not legalize the JS ffi interface, so we must use BigInt
         # support in order for JS to have a chance to run this without trapping
         # when it sees an i64 on the ffi.
@@ -636,8 +644,14 @@ def also_with_standalone_wasm(impure=False):
         # if we are impure, disallow all wasm engines
         if impure:
           self.wasm_engines = []
-        nodejs = self.require_node()
-        self.node_args += shared.node_bigint_flags(nodejs)
+        else:
+          self.wasm_engines = [engine for engine in self.wasm_engines
+            if all([not excluded in os.path.basename(engine[0]) for excluded in exclude_engines])]
+        if 'node' in exclude_engines:
+          self.js_engines = []
+        else:
+          nodejs = self.require_node(allow_wasm_engines=True)
+          self.node_args += shared.node_bigint_flags(nodejs)
         func(self)
 
     parameterize(metafunc, {'': (False,),
@@ -981,14 +995,14 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       return None
     return config.NODE_JS_TEST
 
-  def require_node(self):
+  def require_node(self, allow_wasm_engines=False):
     nodejs = self.get_nodejs()
     if not nodejs:
       if 'EMTEST_SKIP_NODE' in os.environ:
         self.skipTest('test requires node and EMTEST_SKIP_NODE is set')
       else:
         self.fail('node required to run this test.  Use EMTEST_SKIP_NODE to skip')
-    self.require_engine(nodejs)
+    self.require_engine(nodejs, allow_wasm_engines)
     return nodejs
 
   def node_is_canary(self, nodejs):
@@ -1005,13 +1019,14 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     else:
       self.fail('node canary required to run this test.  Use EMTEST_SKIP_NODE_CANARY to skip')
 
-  def require_engine(self, engine):
+  def require_engine(self, engine, allow_wasm_engines=False):
     logger.debug(f'require_engine: {engine}')
     if self.required_engine and self.required_engine != engine:
       self.skipTest(f'Skipping test that requires `{engine}` when `{self.required_engine}` was previously required')
     self.required_engine = engine
     self.js_engines = [engine]
-    self.wasm_engines = []
+    if not allow_wasm_engines:
+      self.wasm_engines = []
 
   def require_wasm64(self):
     if self.is_browser_test():
@@ -1505,7 +1520,11 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def run_js(self, filename, engine=None, args=None,
              assert_returncode=0,
              interleaved_output=True,
-             input=None):
+             input=None,
+             run_in_tmpdir=False):
+    if run_in_tmpdir:
+      ensure_dir(self.in_dir('fs'))
+
     # use files, as PIPE can get too full and hang us
     stdout_file = self.in_dir('stdout')
     stderr_file = None
@@ -1527,6 +1546,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       engine = engine + self.spidermonkey_args
     try:
       jsrun.run_js(filename, engine, args,
+                   cwd=self.in_dir('fs') if run_in_tmpdir else None,
                    stdout=stdout,
                    stderr=stderr,
                    assert_returncode=assert_returncode,
@@ -1561,6 +1581,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         self.fail('JS subprocess unexpectedly succeeded (%s):  Output:\n%s' % (error.cmd, ret))
       else:
         self.fail('JS subprocess failed (%s): %s (expected=%s).  Output:\n%s' % (error.cmd, error.returncode, assert_returncode, ret))
+
+    if run_in_tmpdir:
+      force_delete_contents(self.in_dir('fs'))
 
     return ret
 
@@ -1957,7 +1980,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       js_file = self.build(filename, **kwargs)
     self.assertExists(js_file)
 
-    engines = self.js_engines.copy()
+    engines = [(el, False) for el in self.js_engines.copy()]
     if len(engines) > 1 and not self.use_all_engines:
       engines = engines[:1]
     # In standalone mode, also add wasm vms as we should be able to run there too.
@@ -1966,13 +1989,14 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       # like with js engines, but for now as we bring it up, test in all of them
       if not self.wasm_engines:
         logger.warning('no wasm engine was found to run the standalone part of this test')
-      engines += self.wasm_engines
+      engines += [(el, True) for el in self.wasm_engines]
     if len(engines) == 0:
       self.fail('No JS engine present to run this test with. Check %s and the paths therein.' % config.EM_CONFIG)
-    for engine in engines:
+    for engine, run_in_tmpdir in engines:
       js_output = self.run_js(js_file, engine, args,
                               assert_returncode=assert_returncode,
-                              interleaved_output=interleaved_output)
+                              interleaved_output=interleaved_output,
+                              run_in_tmpdir=run_in_tmpdir)
       js_output = js_output.replace('\r\n', '\n')
       if expected_output:
         if type(expected_output) not in [list, tuple]:

--- a/test/jsrun.py
+++ b/test/jsrun.py
@@ -40,10 +40,15 @@ def make_command(filename, engine, args=None):
   is_jsc = 'jsc' in jsengine or 'javascriptcore' in jsengine
   is_wasmer = 'wasmer' in jsengine
   is_wasmtime = 'wasmtime' in jsengine
+  is_toywasm = 'toywasm' in jsengine
   command_flags = []
   if is_wasmer:
     command_flags += ['run']
-  if is_wasmer or is_wasmtime:
+  elif is_wasmtime:
+    command_flags += ['--dir', '.', '--']
+  elif is_toywasm:
+    command_flags += ['--wasi', '--wasi-dir', '.', '--']
+  if is_wasmer or is_wasmtime or is_toywasm:
     # in a wasm runtime, run the wasm, not the js
     filename = shared.replace_suffix(filename, '.wasm')
   # Separates engine flags from script flags

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5582,6 +5582,7 @@ got: 10
 
   @crossplatform
   @also_with_nodefs_both
+  @also_with_standalone_wasm(exclude_engines=['node', 'wasmer'])
   def test_fcntl_open(self):
     nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
     if nodefs and WINDOWS:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2217,6 +2217,7 @@ class libstandalonewasm(MuslInternalLibrary):
         path='system/lib/standalone',
         filenames=['standalone.c',
                    'standalone_wasm_stdio.c',
+                   'paths.c',
                    '__main_void.c'])
     # It is more efficient to use JS methods for time, normally.
     files += files_in_path(


### PR DESCRIPTION
Based on <https://github.com/emscripten-core/emscripten/pull/18285>, implement just enough syscalls to make the `test_fcntl_open` test from `test_core` work in standalone WASI mode.

Compared to #18285 I moved the preopen handling into their own `paths.{h,c}` component. The idea is that this component will also be responsible for cwd handling in a follow up PR.

Some Notes:

- The preopen handling is done before `main` runs. Therefore, I removed the locking functions.
- To enable the `test_fcntl_open` test I had to extend the `@also_with_standalone_wasm` decorator a bit. The test doesn't run on node and wasmer. Wasmer crashes when resolving symlinks. However, both wasmtime and toywasm successfully run the test.
- Standalone WASM engines now get a temporary `fs` folder inside the `out/test` folder to put temporary files in. This folder is cleaned after each WASM engine is done. I couldn't make this work for wasmer, but for wasmtime and toywasm it works very nicely.