### PR TITLE
Add CWD handling to standalone WASI mode, and some related syscalls

### DIFF
--- a/system/lib/libc/musl/src/dirent/rewinddir.c
+++ b/system/lib/libc/musl/src/dirent/rewinddir.c
@@ -6,7 +6,9 @@
 void rewinddir(DIR *dir)
 {
 	LOCK(dir->lock);
+#if !defined(__EMSCRIPTEN__)
 	lseek(dir->fd, 0, SEEK_SET);
+#endif
 	dir->buf_pos = dir->buf_end = 0;
 	dir->tell = 0;
 	UNLOCK(dir->lock);

--- a/system/lib/libc/musl/src/dirent/seekdir.c
+++ b/system/lib/libc/musl/src/dirent/seekdir.c
@@ -6,7 +6,11 @@
 void seekdir(DIR *dir, long off)
 {
 	LOCK(dir->lock);
+#if defined(__EMSCRIPTEN__)
+	dir->tell = off;
+#else
 	dir->tell = lseek(dir->fd, off, SEEK_SET);
+#endif
 	dir->buf_pos = dir->buf_end = 0;
 	UNLOCK(dir->lock);
 }

--- a/system/lib/standalone/paths.c
+++ b/system/lib/standalone/paths.c
@@ -1,0 +1,228 @@
+#define _GNU_SOURCE
+#include "paths.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sysexits.h>
+
+/// A name and file descriptor pair.
+typedef struct preopen {
+  /// The path prefix associated with the file descriptor.
+  const char* prefix;
+
+  /// The file descriptor.
+  __wasi_fd_t fd;
+} preopen;
+
+/// A simple growable array of `preopen`.
+static preopen* preopens;
+static size_t num_preopens;
+static size_t preopen_capacity;
+
+#ifdef NDEBUG
+#define assert_invariants() // assertions disabled
+#else
+static void assert_invariants(void) {
+  assert(num_preopens <= preopen_capacity);
+  assert(preopen_capacity == 0 || preopens != NULL);
+  assert(preopen_capacity == 0 ||
+         preopen_capacity * sizeof(preopen) > preopen_capacity);
+
+  for (size_t i = 0; i < num_preopens; ++i) {
+    const preopen* pre = &preopens[i];
+    assert(pre->prefix != NULL);
+    assert(pre->fd != (__wasi_fd_t)-1);
+#ifdef __wasm__
+    assert((uintptr_t)pre->prefix <
+           (__uint128_t)__builtin_wasm_memory_size(0) * PAGESIZE);
+#endif
+  }
+}
+#endif
+
+/// Allocate space for more preopens. Returns 0 on success and -1 on failure.
+static bool resize_preopens(void) {
+  size_t start_capacity = 4;
+  size_t old_capacity = preopen_capacity;
+  size_t new_capacity = old_capacity == 0 ? start_capacity : old_capacity * 2;
+
+  preopen* old_preopens = preopens;
+  preopen* new_preopens = calloc(sizeof(preopen), new_capacity);
+  if (new_preopens == NULL) {
+    return false;
+  }
+
+  memcpy(new_preopens, old_preopens, num_preopens * sizeof(preopen));
+  preopens = new_preopens;
+  preopen_capacity = new_capacity;
+  free(old_preopens);
+
+  assert_invariants();
+  return true;
+}
+
+// Normalize an absolute path. Removes leading `/` and leading `./`, so the
+// first character is the start of a directory name. This works because our
+// process always starts with a working directory of `/`. Additionally translate
+// `.` to the empty string.
+static const char* strip_prefixes(const char* path) {
+  while (1) {
+    if (path[0] == '/') {
+      path++;
+    } else if (path[0] == '.' && path[1] == '/') {
+      path += 2;
+    } else if (path[0] == '.' && path[1] == 0) {
+      path++;
+    } else {
+      break;
+    }
+  }
+
+  return path;
+}
+
+/// Register the given preopened file descriptor under the given path.
+///
+/// This function takes ownership of `prefix`.
+static bool register_preopened_fd(__wasi_fd_t fd, const char* relprefix) {
+  // Check preconditions.
+  assert_invariants();
+  assert(fd != AT_FDCWD);
+  assert(fd != -1);
+  assert(relprefix != NULL);
+
+  if (num_preopens == preopen_capacity && !resize_preopens()) {
+    return false;
+  }
+
+  char* prefix = strdup(strip_prefixes(relprefix));
+  if (prefix == NULL) {
+    return false;
+  }
+  preopens[num_preopens++] = (preopen){
+    prefix,
+    fd,
+  };
+
+  assert_invariants();
+  return true;
+}
+
+/// Are the `prefix_len` bytes pointed to by `prefix` a prefix of `path`?
+static bool
+prefix_matches(const char* prefix, size_t prefix_len, const char* path) {
+  // Allow an empty string as a prefix of any relative path.
+  if (path[0] != '/' && prefix_len == 0)
+    return true;
+
+  // Check whether any bytes of the prefix differ.
+  if (memcmp(path, prefix, prefix_len) != 0)
+    return false;
+
+  // Ignore trailing slashes in directory names.
+  size_t i = prefix_len;
+  while (i > 0 && prefix[i - 1] == '/') {
+    --i;
+  }
+
+  // Match only complete path components.
+  char last = path[i];
+  return last == '/' || last == '\0';
+}
+
+bool __paths_resolve_path(int* resolved_dirfd, const char** path_ptr) {
+  const char* path = *path_ptr;
+
+  if (*resolved_dirfd != AT_FDCWD && path[0] != '/') {
+    return true;
+  }
+
+  // Strip leading `/` characters, the prefixes we're mataching won't have
+  // them.
+  while (*path == '/')
+    path++;
+  // Search through the preopens table. Iterate in reverse so that more
+  // recently added preopens take precedence over less recently addded ones.
+  size_t match_len = 0;
+  int fd = -1;
+  for (size_t i = num_preopens; i > 0; --i) {
+    const preopen* pre = &preopens[i - 1];
+    const char* prefix = pre->prefix;
+    size_t len = strlen(prefix);
+
+    // If we haven't had a match yet, or the candidate path is longer than
+    // our current best match's path, and the candidate path is a prefix of
+    // the requested path, take that as the new best path.
+    if ((fd == -1 || len > match_len) && prefix_matches(prefix, len, path)) {
+      fd = pre->fd;
+      match_len = len;
+    }
+  }
+
+  if (fd == -1) {
+    return false;
+  }
+
+  // The relative path is the substring after the portion that was matched.
+  const char* computed = path + match_len;
+
+  // Omit leading slashes in the relative path.
+  while (*computed == '/')
+    ++computed;
+
+  // *at syscalls don't accept empty relative paths, so use "." instead.
+  if (*computed == '\0')
+    computed = ".";
+
+  *resolved_dirfd = fd;
+  *path_ptr = computed;
+  return true;
+}
+
+// Populate WASI preopens.
+__attribute__((constructor(100))) // construct this before user code
+static void _standalone_populate_preopens(void) {
+  // Skip stdin, stdout, and stderr, and count up until we reach an invalid
+  // file descriptor.
+  for (__wasi_fd_t fd = 3; fd != 0; ++fd) {
+    __wasi_prestat_t prestat;
+    __wasi_errno_t ret = __wasi_fd_prestat_get(fd, &prestat);
+    if (ret == __WASI_ERRNO_BADF)
+      break;
+    if (ret != __WASI_ERRNO_SUCCESS)
+      goto oserr;
+    switch (prestat.pr_type) {
+      case __WASI_PREOPENTYPE_DIR: {
+        char* prefix = malloc(prestat.u.dir.pr_name_len + 1);
+        if (prefix == NULL)
+          goto software;
+
+        // TODO: Remove the cast on `path` once the witx is updated with
+        // char8 support.
+        ret = __wasi_fd_prestat_dir_name(
+          fd, (uint8_t*)prefix, prestat.u.dir.pr_name_len);
+        if (ret != __WASI_ERRNO_SUCCESS)
+          goto oserr;
+        prefix[prestat.u.dir.pr_name_len] = '\0';
+
+        if (!register_preopened_fd(fd, prefix))
+          goto software;
+        free(prefix);
+
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return;
+oserr:
+  _Exit(EX_OSERR);
+software:
+  _Exit(EX_SOFTWARE);
+}

--- a/system/lib/standalone/paths.h
+++ b/system/lib/standalone/paths.h
@@ -1,0 +1,21 @@
+#ifndef STANDALONE_PATHS_H
+#define STANDALONE_PATHS_H
+
+#include <stdbool.h>
+
+//
+// Resolve a (dirfd, relative/absolute path) pair.
+//
+// Arguments:
+// - `resolved_dirfd`:
+//   - as input: input dirfd, may be `AT_FDCWD`
+//   - as output: resolved dirfd (which always is a preopened fd)
+// - `path_ptr`:
+//   - as input: pointer to a relative or absolute path
+//   - as output: a path relative to `resolved_dirfd`
+//
+// Returns: `true` if resolution was successful, `false` otherwise.
+//
+bool __paths_resolve_path(int* resolved_dirfd, const char** path_ptr);
+
+#endif

--- a/system/lib/standalone/paths.h
+++ b/system/lib/standalone/paths.h
@@ -2,20 +2,45 @@
 #define STANDALONE_PATHS_H
 
 #include <stdbool.h>
+#include <stddef.h>
+
+#include <wasi/api.h>
 
 //
 // Resolve a (dirfd, relative/absolute path) pair.
 //
 // Arguments:
+// - `need_unlock`: Is set by the function. If `true`, must make sure to call
+//   `__paths_unlock()` when done with the `resolved_dirfd`.
 // - `resolved_dirfd`:
 //   - as input: input dirfd, may be `AT_FDCWD`
-//   - as output: resolved dirfd (which always is a preopened fd)
+//   - as output: resolved dirfd, may be either a preopened fd or a fd
+//     representing the cwd.
 // - `path_ptr`:
 //   - as input: pointer to a relative or absolute path
 //   - as output: a path relative to `resolved_dirfd`
 //
 // Returns: `true` if resolution was successful, `false` otherwise.
 //
-bool __paths_resolve_path(int* resolved_dirfd, const char** path_ptr);
+bool __paths_resolve_path(bool* need_unlock,
+                          int* resolved_dirfd,
+                          const char** path_ptr);
+
+// Must be called by the user when `need_unlock` of `__paths_resolve_path()`
+// was true, and `resolved_dirfd` is no longer needed.
+void __paths_unlock();
+
+// Changes the current working directory to `path`, which may be either an
+// absolute path or a path relative to the current working directory.
+__wasi_errno_t __paths_chdir(const char* path);
+
+// Changes the current working directory to the directory represented by `fd`.
+__wasi_errno_t __paths_fchdir(int fd);
+
+// Puts a string representing the current working directory into the buffer
+// `buf`. `size` is an in/out parameter: input is the size of the buffer `buf`,
+// output is the number of characters written into `buf`, including a
+// terminating zero.
+__wasi_errno_t __paths_getcwd(char* buf, size_t* size);
 
 #endif

--- a/test/common.py
+++ b/test/common.py
@@ -614,7 +614,7 @@ def can_do_standalone(self, impure=False):
 
 # Impure means a test that cannot run in a wasm VM yet, as it is not 100%
 # standalone. We can still run them with the JS code though.
-def also_with_standalone_wasm(impure=False):
+def also_with_standalone_wasm(impure=False, exclude_engines=None):
   def decorated(func):
     @wraps(func)
     def metafunc(self, standalone):
@@ -623,11 +623,19 @@ def also_with_standalone_wasm(impure=False):
       if not standalone:
         func(self)
       else:
+        nonlocal exclude_engines
+        if exclude_engines is None:
+          exclude_engines = []
         if not can_do_standalone(self, impure):
           self.skipTest('Test configuration is not compatible with STANDALONE_WASM')
         self.set_setting('STANDALONE_WASM')
         if not impure:
           self.set_setting('PURE_WASI')
+        if 'node' in exclude_engines:
+          # When not running under node we don't care for any undefined symbols
+          # in the .js as we are only interested in the .wasm file.
+          self.set_setting('ERROR_ON_UNDEFINED_SYMBOLS=0')
+          self.emcc_args.append('-Wno-js-compiler')
         # we will not legalize the JS ffi interface, so we must use BigInt
         # support in order for JS to have a chance to run this without trapping
         # when it sees an i64 on the ffi.
@@ -636,8 +644,14 @@ def also_with_standalone_wasm(impure=False):
         # if we are impure, disallow all wasm engines
         if impure:
           self.wasm_engines = []
-        nodejs = self.require_node()
-        self.node_args += shared.node_bigint_flags(nodejs)
+        else:
+          self.wasm_engines = [engine for engine in self.wasm_engines
+            if all([not excluded in os.path.basename(engine[0]) for excluded in exclude_engines])]
+        if 'node' in exclude_engines:
+          self.js_engines = []
+        else:
+          nodejs = self.require_node(allow_wasm_engines=True)
+          self.node_args += shared.node_bigint_flags(nodejs)
         func(self)
 
     parameterize(metafunc, {'': (False,),
@@ -981,14 +995,14 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       return None
     return config.NODE_JS_TEST
 
-  def require_node(self):
+  def require_node(self, allow_wasm_engines=False):
     nodejs = self.get_nodejs()
     if not nodejs:
       if 'EMTEST_SKIP_NODE' in os.environ:
         self.skipTest('test requires node and EMTEST_SKIP_NODE is set')
       else:
         self.fail('node required to run this test.  Use EMTEST_SKIP_NODE to skip')
-    self.require_engine(nodejs)
+    self.require_engine(nodejs, allow_wasm_engines)
     return nodejs
 
   def node_is_canary(self, nodejs):
@@ -1005,13 +1019,14 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     else:
       self.fail('node canary required to run this test.  Use EMTEST_SKIP_NODE_CANARY to skip')
 
-  def require_engine(self, engine):
+  def require_engine(self, engine, allow_wasm_engines=False):
     logger.debug(f'require_engine: {engine}')
     if self.required_engine and self.required_engine != engine:
       self.skipTest(f'Skipping test that requires `{engine}` when `{self.required_engine}` was previously required')
     self.required_engine = engine
     self.js_engines = [engine]
-    self.wasm_engines = []
+    if not allow_wasm_engines:
+      self.wasm_engines = []
 
   def require_wasm64(self):
     if self.is_browser_test():
@@ -1505,7 +1520,11 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def run_js(self, filename, engine=None, args=None,
              assert_returncode=0,
              interleaved_output=True,
-             input=None):
+             input=None,
+             run_in_tmpdir=False):
+    if run_in_tmpdir:
+      ensure_dir(self.in_dir('fs'))
+
     # use files, as PIPE can get too full and hang us
     stdout_file = self.in_dir('stdout')
     stderr_file = None
@@ -1527,6 +1546,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       engine = engine + self.spidermonkey_args
     try:
       jsrun.run_js(filename, engine, args,
+                   cwd=self.in_dir('fs') if run_in_tmpdir else None,
                    stdout=stdout,
                    stderr=stderr,
                    assert_returncode=assert_returncode,
@@ -1561,6 +1581,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         self.fail('JS subprocess unexpectedly succeeded (%s):  Output:\n%s' % (error.cmd, ret))
       else:
         self.fail('JS subprocess failed (%s): %s (expected=%s).  Output:\n%s' % (error.cmd, error.returncode, assert_returncode, ret))
+
+    if run_in_tmpdir:
+      force_delete_contents(self.in_dir('fs'))
 
     return ret
 
@@ -1957,7 +1980,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       js_file = self.build(filename, **kwargs)
     self.assertExists(js_file)
 
-    engines = self.js_engines.copy()
+    engines = [(el, False) for el in self.js_engines.copy()]
     if len(engines) > 1 and not self.use_all_engines:
       engines = engines[:1]
     # In standalone mode, also add wasm vms as we should be able to run there too.
@@ -1966,13 +1989,14 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       # like with js engines, but for now as we bring it up, test in all of them
       if not self.wasm_engines:
         logger.warning('no wasm engine was found to run the standalone part of this test')
-      engines += self.wasm_engines
+      engines += [(el, True) for el in self.wasm_engines]
     if len(engines) == 0:
       self.fail('No JS engine present to run this test with. Check %s and the paths therein.' % config.EM_CONFIG)
-    for engine in engines:
+    for engine, run_in_tmpdir in engines:
       js_output = self.run_js(js_file, engine, args,
                               assert_returncode=assert_returncode,
-                              interleaved_output=interleaved_output)
+                              interleaved_output=interleaved_output,
+                              run_in_tmpdir=run_in_tmpdir)
       js_output = js_output.replace('\r\n', '\n')
       if expected_output:
         if type(expected_output) not in [list, tuple]:

--- a/test/dirent/test_readdir.c
+++ b/test/dirent/test_readdir.c
@@ -53,8 +53,9 @@ void test() {
   dir = opendir("noexist");
   assert(!dir);
   assert(errno == ENOENT);
-// NODERAWFS tests run as root, and the root user can opendir any directory
-#ifndef NODERAWFS
+  // NODERAWFS/STANDALONE_WASM tests run as root, and the root user can opendir
+  // any directory
+#if !defined(NODERAWFS) && !defined(STANDALONE_WASM)
   dir = opendir("nocanread");
   assert(!dir);
   assert(errno == EACCES);

--- a/test/jsrun.py
+++ b/test/jsrun.py
@@ -40,10 +40,15 @@ def make_command(filename, engine, args=None):
   is_jsc = 'jsc' in jsengine or 'javascriptcore' in jsengine
   is_wasmer = 'wasmer' in jsengine
   is_wasmtime = 'wasmtime' in jsengine
+  is_toywasm = 'toywasm' in jsengine
   command_flags = []
   if is_wasmer:
     command_flags += ['run']
-  if is_wasmer or is_wasmtime:
+  elif is_wasmtime:
+    command_flags += ['--dir', '.', '--']
+  elif is_toywasm:
+    command_flags += ['--wasi', '--wasi-dir', '.', '--']
+  if is_wasmer or is_wasmtime or is_toywasm:
     # in a wasm runtime, run the wasm, not the js
     filename = shared.replace_suffix(filename, '.wasm')
   # Separates engine flags from script flags

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5532,12 +5532,15 @@ got: 10
     self.do_run(src, '3\n')
 
   @also_with_noderawfs
+  @also_with_standalone_wasm(exclude_engines=['node', 'wasmer'])
   def test_readdir(self):
     if self.get_setting('WASMFS') and self.get_setting('NODERAWFS'):
       # WasmFS + NODERAWFS lacks ino numbers in directory listings, see
       # https://github.com/emscripten-core/emscripten/issues/19418
       # We need to tell the test we are in this mode so it can ignore them.
       self.emcc_args += ['-DWASMFS_NODERAWFS']
+    if self.get_setting('STANDALONE_WASM'):
+      self.emcc_args += ['-DSTANDALONE_WASM']
     self.do_run_in_out_file_test('dirent/test_readdir.c')
 
   @also_with_wasm_bigint
@@ -5952,9 +5955,12 @@ Module.onRuntimeInitialized = () => {
       out_suffix = ''
     self.do_run_in_out_file_test('unistd/access.c', out_suffix=out_suffix)
 
+  @also_with_standalone_wasm(exclude_engines=['node', 'wasmtime', 'wasmer'])
   def test_unistd_curdir(self):
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
+    if self.get_setting('STANDALONE_WASM'):
+      self.emcc_args += ['-DSTANDALONE_WASM']
     self.do_run_in_out_file_test('unistd/curdir.c')
 
   @also_with_noderawfs

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5582,6 +5582,7 @@ got: 10
 
   @crossplatform
   @also_with_nodefs_both
+  @also_with_standalone_wasm(exclude_engines=['node', 'wasmer'])
   def test_fcntl_open(self):
     nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
     if nodefs and WINDOWS:

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14286,7 +14286,10 @@ Module.postRun = () => {{
     self.do_run_in_out_file_test('wasmfs/wasmfs_mkdir.c')
 
   @also_with_wasmfs
+  @also_with_standalone_wasm(exclude_engines=['node'])
   def test_unistd_cwd(self):
+    if self.get_setting('STANDALONE_WASM'):
+      self.emcc_args += ['-DSTANDALONE_WASM']
     self.do_run_in_out_file_test('wasmfs/wasmfs_chdir.c')
 
   def test_unistd_chown(self):

--- a/test/unistd/curdir.c
+++ b/test/unistd/curdir.c
@@ -5,6 +5,8 @@
  * found in the LICENSE file.
  */
 
+#include <sys/stat.h>
+
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -14,6 +16,7 @@
 #include <emscripten.h>
 
 int main() {
+#if !defined(STANDALONE_WASM)
   EM_ASM(
     var dummy_device = FS.makedev(64, 0);
     FS.registerDevice(dummy_device, {});
@@ -23,6 +26,26 @@ int main() {
     FS.symlink('/folder', '/link');
     FS.writeFile('/file', "", { mode: 0o777 });
   );
+#else
+  {
+    int fd = open("device", O_CREAT, 0777);
+    assert(fd >= 0);
+    close(fd);
+  }
+  {
+    int rv = mkdir("folder", 0777);
+    assert(rv == 0);
+  }
+  {
+    int rv = symlink("folder", "link");
+    assert(rv == 0);
+  }
+  {
+    int fd = open("file", O_CREAT, 0777);
+    assert(fd >= 0);
+    close(fd);
+  }
+#endif
 
   char buffer[256];
 

--- a/test/wasmfs/wasmfs_chdir.c
+++ b/test/wasmfs/wasmfs_chdir.c
@@ -22,6 +22,15 @@ int main() {
   assert(mkdir("working", 0777) != -1);
   assert(mkdir("/working/test", 0777) != -1);
 
+#ifdef STANDALONE_WASM
+  assert(mkdir("/dev", 0777) != -1);
+  {
+    int fd = open("/dev/file", O_CREAT, 0777);
+    assert(fd >= 0);
+    close(fd);
+  }
+#endif
+
   // Try to pass a size of 0.
   errno = 0;
   getcwd(cwd, 0);
@@ -92,7 +101,11 @@ int main() {
   printf("Current working dir: %s\n", cwd);
 
   // Try to change cwd to a file.
+#ifdef STANDALONE_WASM
+  chdir("/dev/file");
+#else
   chdir("/dev/stdout");
+#endif
   printf("Errno: %s\n", strerror(errno));
   assert(errno == ENOTDIR);
   ret = getcwd(cwd, sizeof(cwd));

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2217,6 +2217,7 @@ class libstandalonewasm(MuslInternalLibrary):
         path='system/lib/standalone',
         filenames=['standalone.c',
                    'standalone_wasm_stdio.c',
+                   'paths.c',
                    '__main_void.c'])
     # It is more efficient to use JS methods for time, normally.
     files += files_in_path(

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -105,7 +105,9 @@ def delete_contents(dirname, exclude=None):
     if exclude and entry in exclude:
       continue
     entry = os.path.join(dirname, entry)
-    if os.path.isdir(entry):
+    if os.path.islink(entry):
+      os.unlink(entry)
+    elif os.path.isdir(entry):
       delete_dir(entry)
     else:
       delete_file(entry)


### PR DESCRIPTION
This PR builds on top of <https://github.com/emscripten-core/emscripten/pull/24246> and adds "proper" CWD handling in standalone WASI mode. It takes more code from PR <https://github.com/emscripten-core/emscripten/pull/18285> (modified were needed).

Unlike wasi-libc, all of `chdir`, `fchdir` and `getcwd` are properly supported. This is done by maintaining a global directory fd in `O_SEARCH` mode and modifying the path resolution function `__paths_resolve_path()` from `paths.{h,c}` accordingly.

`getcwd` is implemented by walking from the current CWD fd "up" until a root, i.e. a preopened fd is reached, and comparing dirent names along the way.

To support this, the following syscalls are implemented:

- `F_GETFD`, `F_SETFD`, `F_GETFL` of `fcntl`
- `fstat`
- `chdir`
- `fchdir`
- `getcwd`
- `getdents64` (note that this now accesses the `tell` member of the `DIR*` with some `offsetof` hackery in order to find out the current offset inside the directory)

The following tests work now in standalone WASM mode:

- `test_readdir`: wastime and toywasm work
- `test_unistd_curdir`: just toywasm works -- on wasmtime, `openat(AT_FDCWD, "..")` always seems to fail with a permission error, so the implementation strategy of `getcwd` does not work right now. Wasmer can do this, but fails because of a symlink issue.
- `test_unistd_cwd`

I had do to some minor adjustments to the tests.