### PR TITLE
Remove no-op branch from acorn-optimizer. NFC

### DIFF
--- a/tools/acorn-optimizer.mjs
+++ b/tools/acorn-optimizer.mjs
@@ -1731,6 +1731,9 @@ function minifyLocals(ast) {
   assert(extraInfo && extraInfo.globals);
 
   for (const fun of ast.body) {
+    if (fun.type !== 'FunctionDeclaration') {
+      continue;
+    }
     // Find the list of local names, including params.
     const localNames = new Set();
     for (const param of fun.params) {

--- a/tools/acorn-optimizer.mjs
+++ b/tools/acorn-optimizer.mjs
@@ -1731,9 +1731,6 @@ function minifyLocals(ast) {
   assert(extraInfo && extraInfo.globals);
 
   for (const fun of ast.body) {
-    if (!fun.type === 'FunctionDeclaration') {
-      continue;
-    }
     // Find the list of local names, including params.
     const localNames = new Set();
     for (const param of fun.params) {


### PR DESCRIPTION
This line is equivalent to `(!fun.type) === 'FunctionDeclaration'` which is equivalent to `false === 'FunctionDeclaration'` which is equivalent to just `if (false)`.

The intent was obviously `!==` so fixing to reflect that.