### PR TITLE
[embind] Do not export InternalError and BindingError by default.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,9 @@ See docs/process.md for more on how version tagging works.
 ----------------------
 - When using cmake the EMSCRIPTEN_FORCE_COMPILERS setting was reverted to
   being on by default due to issues that were found with disabling it. (#24223)
+- Embind symbols `InternalError`, `BindingError`, and `count_emval_handles` are
+  no longer exported by default. They can be exported using
+  `-sEXPORTED_RUNTIME_METHODS=InternalError,BindingError,count_emval_handles`
 
 4.0.8 - 04/30/25
 ----------------

--- a/src/lib/libembind_shared.js
+++ b/src/lib/libembind_shared.js
@@ -3,8 +3,8 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 var LibraryEmbindShared = {
-  $InternalError: "=Module['InternalError'] = class InternalError extends Error { constructor(message) { super(message); this.name = 'InternalError'; }}",
-  $BindingError: "=Module['BindingError'] = class BindingError extends Error { constructor(message) { super(message); this.name = 'BindingError'; }}",
+  $InternalError: "= class InternalError extends Error { constructor(message) { super(message); this.name = 'InternalError'; }}",
+  $BindingError: "= class BindingError extends Error { constructor(message) { super(message); this.name = 'BindingError'; }}",
 
   $throwInternalError__deps: ['$InternalError'],
   $throwInternalError: (message) => { throw new InternalError(message); },

--- a/src/lib/libemval.js
+++ b/src/lib/libemval.js
@@ -41,7 +41,6 @@ var LibraryEmVal = {
   #if ASSERTIONS
     assert(emval_handles.length === {{{ EMVAL_RESERVED_HANDLES }}} * 2);
   #endif
-    Module['count_emval_handles'] = count_emval_handles;
   },
 
   $count_emval_handles__deps: ['$emval_freelist', '$emval_handles'],

--- a/test/code_size/embind_hello_wasm.json
+++ b/test/code_size/embind_hello_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 380,
-  "a.js": 9094,
-  "a.js.gz": 3993,
+  "a.js": 9015,
+  "a.js.gz": 3957,
   "a.wasm": 7332,
   "a.wasm.gz": 3369,
-  "total": 16978,
-  "total_gz": 7742
+  "total": 16899,
+  "total_gz": 7706
 }

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 380,
-  "a.js": 6940,
-  "a.js.gz": 2999,
+  "a.js": 6877,
+  "a.js.gz": 2968,
   "a.wasm": 9133,
   "a.wasm.gz": 4710,
-  "total": 16625,
-  "total_gz": 8089
+  "total": 16562,
+  "total_gz": 8058
 }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3347,7 +3347,7 @@ More info: https://emscripten.org
       '-Wno-deprecated-declarations',
       '-lembind',
       '-sRETAIN_COMPILER_SETTINGS',
-      '-sEXPORTED_RUNTIME_METHODS=getCompilerSetting,setDelayFunction,flushPendingDeletes,PureVirtualError,HEAP8',
+      '-sEXPORTED_RUNTIME_METHODS=getCompilerSetting,setDelayFunction,flushPendingDeletes,PureVirtualError,HEAP8,InternalError,BindingError,count_emval_handles',
       '-sWASM_ASYNC_COMPILATION=0',
       # This test uses a `CustomSmartPtr` class which has 1MB of data embedded in
       # it which means we need more stack space than normal.


### PR DESCRIPTION
These exports are likely not needed by default. They also use a non standard way of exporting on the Module object by manually assigning, which causes issues in the future with MODULARIZE=instance.