### PR TITLE
Remove `emval_init`. NFC

### DIFF
--- a/src/lib/libemval.js
+++ b/src/lib/libemval.js
@@ -24,24 +24,18 @@ var LibraryEmVal = {
   // Stack of handles available for reuse.
   $emval_freelist: [],
   // Array of alternating pairs (value, refcount).
-  $emval_handles: [],
+  // reserve 0 and some special values. These never get de-allocated.
+  $emval_handles: [
+    0, 1,
+    undefined, 1,
+    null, 1,
+    true, 1,
+    false, 1,
+  ],
+#if ASSERTIONS
+  $emval_handles__postset: 'assert(emval_handles.length === {{{ EMVAL_RESERVED_HANDLES }}} * 2)',
+#endif
   $emval_symbols: {}, // address -> string
-
-  $init_emval__deps: ['$count_emval_handles', '$emval_handles'],
-  $init_emval__postset: 'init_emval();',
-  $init_emval: () => {
-    // reserve 0 and some special values. These never get de-allocated.
-    emval_handles.push(
-      0, 1,
-      undefined, 1,
-      null, 1,
-      true, 1,
-      false, 1,
-    );
-  #if ASSERTIONS
-    assert(emval_handles.length === {{{ EMVAL_RESERVED_HANDLES }}} * 2);
-  #endif
-  },
 
   $count_emval_handles__deps: ['$emval_freelist', '$emval_handles'],
   $count_emval_handles: () => {
@@ -62,7 +56,7 @@ var LibraryEmVal = {
     return symbol;
   },
 
-  $Emval__deps: ['$emval_freelist', '$emval_handles', '$throwBindingError', '$init_emval'],
+  $Emval__deps: ['$emval_freelist', '$emval_handles', '$throwBindingError'],
   $Emval: {
     toValue: (handle) => {
       if (!handle) {

--- a/test/code_size/embind_hello_wasm.json
+++ b/test/code_size/embind_hello_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 380,
-  "a.js": 9015,
+  "a.js": 9000,
   "a.js.gz": 3957,
   "a.wasm": 7332,
   "a.wasm.gz": 3369,
-  "total": 16899,
+  "total": 16884,
   "total_gz": 7706
 }

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 380,
-  "a.js": 6877,
-  "a.js.gz": 2968,
+  "a.js": 6862,
+  "a.js.gz": 2965,
   "a.wasm": 9133,
   "a.wasm.gz": 4710,
-  "total": 16562,
-  "total_gz": 8058
+  "total": 16547,
+  "total_gz": 8055
 }


### PR DESCRIPTION
I noticed this should no longer be needed while reviewing #24259.