### PR TITLE
Use Asyncify shorthands. NFC

### DIFF
--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1247,11 +1247,10 @@ var LibraryDylink = {
 #endif
   _dlopen_js: {{{ asyncIf(ASYNCIFY == 2) }}} (handle) => {
 #if ASYNCIFY
-    return Asyncify.handleSleep((wakeUp) => {
+    return Asyncify.handleAsync(() =>
       dlopenInternal(handle, { loadAsync: true })
-        .then(wakeUp)
-        .catch(() => wakeUp(0));
-    });
+      .catch(() => 0)
+    );
 #else
     return dlopenInternal(handle, { loadAsync: false });
 #endif

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1245,16 +1245,19 @@ var LibraryDylink = {
 #if ASYNCIFY
   _dlopen_js__async: true,
 #endif
-  _dlopen_js: {{{ asyncIf(ASYNCIFY == 2) }}} (handle) => {
+  _dlopen_js: {{{ asyncIf(ASYNCIFY == 2) }}} (handle) =>
 #if ASYNCIFY
-    return Asyncify.handleAsync(() =>
+    Asyncify.handleSleep((wakeUp) =>
       dlopenInternal(handle, { loadAsync: true })
-      .catch(() => 0)
-    );
+      .then(wakeUp)
+      // Note: this currently relies on being able to catch errors even from `wakeUp` callback itself.
+      // That's why we can't refactor it to `handleAsync` at the moment.
+      .catch(() => wakeUp(0))
+    )
 #else
-    return dlopenInternal(handle, { loadAsync: false });
+    dlopenInternal(handle, { loadAsync: false })
 #endif
-  },
+    ,
 
   // Async version of dlopen.
   _emscripten_dlopen_js__deps: ['$dlopenInternal', '$callUserCallback', '$dlSetError'],

--- a/src/lib/libpromise.js
+++ b/src/lib/libpromise.js
@@ -266,15 +266,10 @@ addToLibrary({
 #if RUNTIME_DEBUG
     dbg(`emscripten_promise_await: ${id}`);
 #endif
-    return Asyncify.handleSleep((wakeUp) => {
-      getPromise(id).then((value) => {
-        setPromiseResult(returnValuePtr, true, value);
-        wakeUp();
-      }, (value) => {
-        setPromiseResult(returnValuePtr, false, value);
-        wakeUp();
-      });
-    });
+    return Asyncify.handleAsync(() => getPromise(id).then(
+      value => setPromiseResult(returnValuePtr, true, value),
+      error => setPromiseResult(returnValuePtr, false, error)
+    ));
 #else
     abort('emscripten_promise_await is only available with ASYNCIFY');
 #endif

--- a/src/lib/libwasi.js
+++ b/src/lib/libwasi.js
@@ -544,11 +544,7 @@ var WasiLibrary = {
         return;
       }
       mount.type.syncfs(mount, false, (err) => {
-        if (err) {
-          wakeUp({{{ cDefs.EIO }}});
-          return;
-        }
-        wakeUp(0);
+        wakeUp(err ? {{{ cDefs.EIO }}} : 0);
       });
     });
 #else


### PR DESCRIPTION
Noticed a few places where Asyncify.handleSleep was used with promises, for which handleAsync is a more natural fit; also switched a few places to arrow functions.

It makes code slightly cleaner, and, if used with JSPI where Promises are first-class, avoids jumping through handleSleep wrapping as well.