### PR TITLE
Fix test_utf under minimal runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -646,7 +646,9 @@ jobs:
             wasmfs.test_fcntl_open
             wasmfs.test_fs_llseek
             wasmfs.test_fs_llseek_rawfs
-            wasmfs.test_freetype"
+            wasmfs.test_freetype
+            minimal0.test_utf
+            "
   test-wasm2js1:
     environment:
       EMTEST_SKIP_NODE_CANARY: "1"

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -117,8 +117,8 @@ if (ENVIRONMENT_IS_NODE) {
 var out = defaultPrint;
 var err = defaultPrintErr;
 #else
-var out = (text) => console.log(text);
-var err = (text) => console.error(text);
+var out = (...args) => console.log(...args);
+var err = (...args) => console.error(...args);
 #endif
 
 // Override this function in a --pre-js file to get a signal for when

--- a/test/code_size/embind_hello_wasm.json
+++ b/test/code_size/embind_hello_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 380,
-  "a.js": 9000,
-  "a.js.gz": 3957,
+  "a.js": 9005,
+  "a.js.gz": 3961,
   "a.wasm": 7332,
   "a.wasm.gz": 3369,
-  "total": 16884,
-  "total_gz": 7706
+  "total": 16889,
+  "total_gz": 7710
 }

--- a/test/code_size/random_printf_wasm.json
+++ b/test/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 12490,
-  "a.html.gz": 6832,
-  "total": 12490,
-  "total_gz": 6832
+  "a.html": 12506,
+  "a.html.gz": 6840,
+  "total": 12506,
+  "total_gz": 6840
 }

--- a/test/code_size/random_printf_wasm2js.json
+++ b/test/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17170,
-  "a.html.gz": 7510,
-  "total": 17170,
-  "total_gz": 7510
+  "a.html": 17186,
+  "a.html.gz": 7515,
+  "total": 17186,
+  "total_gz": 7515
 }

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5615,8 +5615,6 @@ got: 10
   def test_futimens(self):
     self.do_runf('utime/test_futimens.c', 'success')
 
-  @no_minimal_runtime('MINIMAL_RUNTIME does not have getValue() and setValue() (TODO add it to a JS library function to get it in)')
-  @requires_node  # only node handles utf well
   def test_utf(self):
     self.set_setting('EXPORTED_RUNTIME_METHODS', ['getValue', 'setValue', 'UTF8ToString', 'stringToUTF8OnStack'])
     self.do_core_test('test_utf.c')


### PR DESCRIPTION
As part of this I extended the out/err handlers for MINIMAL_RUNTIME to support multiple arguments. Previously they would just drop extras args.