### PR TITLE
[esm-integration] Fix syntax error in output at -O2 and above

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -794,8 +794,8 @@ jobs:
             other.test_native_call_before_init
             other.test_node_unhandled_rejection
             core2.test_hello_world
-            core2.test_esm_integration
-            core0.test_esm_integration
+            core2.test_esm_integration*
+            core0.test_esm_integration*
             core0.test_pthread_join_and_asyncify
             core0.test_async_ccall_promise_jspi*
             core0.test_cubescript_jspi"

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -523,6 +523,7 @@ function exportRuntimeSymbols() {
   const results = exports.filter((name) => name);
 
   if (MODULARIZE == 'instance') {
+    if (results.length == 0) return '';
     return '// Runtime exports\nexport { ' + results.join(', ') + ' };\n';
   }
 


### PR DESCRIPTION
When no exported runtime methods we were generating:

export { };

Which acorn (I think) was then just converting to `export`.