### PR TITLE
Don't treat internal globals as expected user exports. NFC

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -750,15 +750,6 @@ def minify_wasm_js(js_file, wasm_file, expensive_optimizations, debug_info):
   return js_file
 
 
-def is_internal_global(name):
-  internal_start_stop_symbols = {'__start_em_asm', '__stop_em_asm',
-                                 '__start_em_js', '__stop_em_js',
-                                 '__start_em_lib_deps', '__stop_em_lib_deps',
-                                 '__em_lib_deps'}
-  internal_prefixes = ('__em_js__', '__em_lib_deps')
-  return not shared.treat_as_user_export(name) or name in internal_start_stop_symbols or any(name.startswith(p) for p in internal_prefixes)
-
-
 # get the flags to pass into the very last binaryen tool invocation, that runs
 # the final set of optimizations
 def get_last_binaryen_opts():
@@ -864,7 +855,7 @@ def metadce(js_file, wasm_file, debug_info, last):
         unused_imports.append(native_name)
       elif name.startswith('emcc$export$') and settings.DECLARE_ASM_MODULE_EXPORTS:
         native_name = export_name_map[name]
-        if not is_internal_global(native_name):
+        if shared.is_user_export(native_name):
           unused_exports.append(native_name)
   if not unused_exports and not unused_imports:
     # nothing found to be unused, so we have nothing to remove

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -30,7 +30,6 @@ from tools import webassembly
 from tools import extract_metadata
 from tools.utils import exit_with_error, path_from_root, removeprefix
 from tools.shared import DEBUG, asmjs_mangle, in_temp
-from tools.shared import treat_as_user_export
 from tools.settings import settings, user_settings
 
 sys.path.append(path_from_root('third_party'))
@@ -282,7 +281,7 @@ def trim_asm_const_body(body):
 def create_global_exports(global_exports):
   lines = []
   for k, v in global_exports.items():
-    if building.is_internal_global(k):
+    if shared.is_internal_global(k):
       continue
 
     v = int(v)
@@ -571,7 +570,7 @@ def finalize_wasm(infile, outfile, js_syms):
   # EMSCRIPTEN_KEEPALIVE (llvm.used).
   # These are any exports that were not requested on the command line and are
   # not known auto-generated system functions.
-  unexpected_exports = [e for e in metadata.all_exports if treat_as_user_export(e)]
+  unexpected_exports = [e for e in metadata.all_exports if shared.is_user_export(e)]
   for n in unexpected_exports:
     if not n.isidentifier():
       exit_with_error(f'invalid export name: {n}')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -636,7 +636,18 @@ def is_c_symbol(name):
   return name.startswith('_')
 
 
-def treat_as_user_export(name):
+def is_internal_global(name):
+  internal_start_stop_symbols = {'__start_em_asm', '__stop_em_asm',
+                                 '__start_em_js', '__stop_em_js',
+                                 '__start_em_lib_deps', '__stop_em_lib_deps',
+                                 '__em_lib_deps'}
+  internal_prefixes = ('__em_js__', '__em_lib_deps')
+  return name in internal_start_stop_symbols or any(name.startswith(p) for p in internal_prefixes)
+
+
+def is_user_export(name):
+  if is_internal_global(name):
+    return False
   return name not in ['__indirect_function_table', 'memory'] and not name.startswith(('dynCall_', 'orig$'))
 
 
@@ -650,7 +661,7 @@ def asmjs_mangle(name):
   # to simply `main` which is expected by the emscripten JS glue code.
   if name == '__main_argc_argv':
     name = 'main'
-  if treat_as_user_export(name):
+  if is_user_export(name):
     return '_' + name
   return name
 


### PR DESCRIPTION
This change renames `treat_as_user_export` to `is_user_export` and inverts the relationship between this function and `is_internal_global`.

Internal globals is a subset of all non-user symbols, not the other way around.

This change is split of from a larger ESM integration change I'm working on.