### PR TITLE
Make exported __cpp_exception into a global. NFC

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -2202,7 +2202,7 @@ addToLibrary({
   __asyncify_state: "new WebAssembly.Global({'value': 'i32', 'mutable': true}, 0)",
   __asyncify_data: "new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': true}, {{{ to64(0) }}})",
 #endif
-#endif
+#endif // RELOCATABLE
 
   _emscripten_fs_load_embedded_files__deps: ['$FS', '$PATH'],
   _emscripten_fs_load_embedded_files: (ptr) => {

--- a/src/lib/libexceptions.js
+++ b/src/lib/libexceptions.js
@@ -283,16 +283,11 @@ var LibraryExceptions = {
   },
 #endif
 #if WASM_EXCEPTIONS
-  $getCppExceptionTag: () =>
-    // In static linking, tags are defined within the wasm module and are
-    // exported, whereas in dynamic linking, tags are defined in library.js in
-    // JS code and wasm modules import them.
-#if RELOCATABLE
-    ___cpp_exception // defined in library.js
-#else
-    wasmExports['__cpp_exception']
-#endif
-  ,
+  $getCppExceptionTag__deps: ['__cpp_exception'],
+  // In static linking, tags are defined within the wasm module and are
+  // exported, whereas in dynamic linking, tags are defined in libcore.js in
+  // JS code and wasm modules import them.
+  $getCppExceptionTag: () => ___cpp_exception,
 
 #if EXCEPTION_STACK_TRACES
   // Throw a WebAssembly.Exception object with the C++ tag with a stack trace

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -924,6 +924,11 @@ function getWasmImports() {
 #endif
 #endif
 
+#if hasExportedSymbol('__cpp_exception') && !RELOCATABLE
+    ___cpp_exception = wasmExports['__cpp_exception'];
+    {{{ receivedSymbol('___cpp_exception') }}};
+#endif
+
 #if hasExportedSymbol('__wasm_apply_data_relocs')
     __RELOC_FUNCS__.push(wasmExports['__wasm_apply_data_relocs']);
 #endif

--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -256,6 +256,14 @@ def get_function_exports(module):
   return rtn
 
 
+def get_tag_exports(module):
+  rtn = []
+  for e in module.get_exports():
+    if e.kind == webassembly.ExternType.TAG:
+      rtn.append(e.name)
+  return rtn
+
+
 def update_metadata(filename, metadata):
   imports = []
   invoke_funcs = []
@@ -270,6 +278,7 @@ def update_metadata(filename, metadata):
         imports.append(i.field)
 
     metadata.function_exports = get_function_exports(module)
+    metadata.tag_exports = get_tag_exports(module)
     metadata.all_exports = [utils.removeprefix(e.name, '__em_js__') for e in module.get_exports()]
 
   metadata.imports = imports
@@ -340,6 +349,7 @@ def extract_metadata(filename):
     metadata = Metadata()
     metadata.imports = import_names
     metadata.function_exports = get_function_exports(module)
+    metadata.tag_exports = get_tag_exports(module)
     metadata.all_exports = [utils.removeprefix(e.name, '__em_js__') for e in exports]
     metadata.em_asm_consts = get_section_strings(module, export_map, 'em_asm')
     metadata.js_deps = [d for d in get_section_strings(module, export_map, 'em_lib_deps').values() if d]


### PR DESCRIPTION
This still is not quite a generic as I would like so as a followup we can probably make this work for all tags, and perhaps unify the updating of the globals when the exports are available.