### PR TITLE
Avoid exporting __emscripten_embedded_file_data data symbol

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -318,8 +318,6 @@ def generate_object_file(data_files):
       # A list of triples of:
       # (file_name_ptr, file_data_size, file_data_ptr)
       # The list in null terminate with a single 0
-      .globl __emscripten_embedded_file_data
-      .export_name __emscripten_embedded_file_data, __emscripten_embedded_file_data
       .section .rodata.__emscripten_embedded_file_data,"",@
       __emscripten_embedded_file_data:
       .p2align {align}


### PR DESCRIPTION
I'm not sure why this symbol was ever made global or exported.