### PR TITLE
[esm-integration] Fix handling of EM_JS exports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -800,7 +800,9 @@ jobs:
             core0.test_esm_integration*
             core0.test_pthread_join_and_asyncify
             core0.test_async_ccall_promise_jspi*
-            core0.test_cubescript_jspi"
+            core0.test_cubescript_jspi
+            esm_integration.test_fs_js_api*
+            "
       # Run some basic tests with the minimum version of node that we currently
       # support in the generated code.
       # Keep this in sync with `OLDEST_SUPPORTED_NODE` in `feature_matrix.py`

--- a/src/shell.js
+++ b/src/shell.js
@@ -22,7 +22,7 @@
 // can continue to use Module afterwards as well.
 #if MODULARIZE
 #if MODULARIZE == 'instance'
-var Module;
+var Module = {};
 #else
 var Module = moduleArg;
 #endif

--- a/test/fs/test_fs_js_api.c
+++ b/test/fs/test_fs_js_api.c
@@ -240,19 +240,19 @@ EM_JS(void, test_fs_close, (), {
 
 void test_fs_mknod() {
   EM_ASM(
-    FS.mknod("mknodtest", 0100000 | 0777 /* S_IFREG | S_RWXU | S_RWXG | S_RWXO */);
+    FS.mknod("mknodtest", 0o100000 | 0o777 /* S_IFREG | S_RWXU | S_RWXG | S_RWXO */);
 
-    FS.create("createtest", 0400 /* S_IRUSR */);
+    FS.create("createtest", 0o400 /* S_IRUSR */);
   );
   struct stat s;
   stat("mknodtest", &s);
 
   assert(S_ISREG(s.st_mode));
-  assert(s.st_mode & 0777);
+  assert(s.st_mode & 0o777);
 
   stat("createtest", &s);
   assert(S_ISREG(s.st_mode));
-  assert(s.st_mode & 0400);
+  assert(s.st_mode & 0o400);
 
   remove("mknodtest");
   remove("createtest");
@@ -382,7 +382,7 @@ void test_fs_mmap() {
 void test_fs_mkdirTree() {
   EM_ASM(
     FS.mkdirTree("/test1/test2/test3"); // Abs path
-    FS.mkdirTree("/readable", 0400 /* S_IRUSR */);
+    FS.mkdirTree("/readable", 0o400 /* S_IRUSR */);
   );
 
   struct stat s;
@@ -394,7 +394,7 @@ void test_fs_mkdirTree() {
   assert(S_ISDIR(s.st_mode));
 
   assert(stat("/readable", &s) == 0);
-  assert(s.st_mode & 0400 /* S_IRUSR */);
+  assert(s.st_mode & 0o400 /* S_IRUSR */);
 
   EM_ASM(
     var ex;

--- a/test/runner.py
+++ b/test/runner.py
@@ -71,6 +71,7 @@ passing_core_test_modes = [
   'wasm64',
   'wasm64_v8',
   'wasm64_4gb',
+  'esm_integration',
 ]
 
 # The default core test mode, used when none is specified

--- a/test/unistd/access.c
+++ b/test/unistd/access.c
@@ -42,17 +42,17 @@ void test_fchmod() {
   chmod("fchmodtest", S_IRUGO | S_IWUGO);
   struct stat fileStats;
   stat("fchmodtest", &fileStats);
-  int mode = fileStats.st_mode & 0777;
+  int mode = fileStats.st_mode & 0o777;
   // Allow S_IXUGO in addtion to S_IWUGO because on windows
   // we always report the execute bit.
   assert(mode == (S_IRUGO | S_IWUGO) || mode == (S_IRUGO | S_IWUGO | S_IXUGO));
 
   EM_ASM(
     var fchmodstream = FS.open("fchmodtest", "r");
-    FS.fchmod(fchmodstream.fd, 0777);
+    FS.fchmod(fchmodstream.fd, 0o777);
   );
   stat("fchmodtest", &fileStats);
-  assert((fileStats.st_mode & 0777) == 0777);
+  assert((fileStats.st_mode & 0o777) == 0o777);
 }
 
 void test_lchmod() {
@@ -61,7 +61,7 @@ void test_lchmod() {
   // so skip this part of the test.
   EM_ASM(
     FS.symlink('writeable', 'symlinkfile');
-    FS.lchmod('symlinkfile', 0777);
+    FS.lchmod('symlinkfile', 0o777);
   );
 
   struct stat symlinkStats;
@@ -80,21 +80,21 @@ void test_chmod_errors() {
   EM_ASM(
     var ex;
     try {
-      FS.chmod("nonexistent", 0777);
+      FS.chmod("nonexistent", 0o777);
     } catch (err) {
       ex = err;
     }
     assert(ex.name === "ErrnoError" && ex.errno === 44 /* ENOENT */);
 
     try {
-      FS.fchmod(99, 0777);
+      FS.fchmod(99, 0o777);
     } catch (err) {
       ex = err;
     }
     assert(ex.name === "ErrnoError" && ex.errno === 8 /* EBADF */);
 
     try {
-      FS.lchmod("nonexistent", 0777);
+      FS.lchmod("nonexistent", 0o777);
     } catch (err) {
       ex = err;
     }


### PR DESCRIPTION
This change also adds a new core test mode for ESM integration and uses this to run all the variants of test_fs_js_api.

As part of this I also updated the octal constants in test_fs_js_api.c which are required to be of the new form in strict JS.  All code in ES modules is implicitly in strict mode.

Split out from #24288

See #24060