### PR TITLE
[esm-integration] Fix some tests that did't run in strict JS mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -803,6 +803,8 @@ jobs:
             core0.test_cubescript_jspi
             esm_integration.test_fs_js_api*
             instance.test_hello_world
+            esm_integration.test_inlinejs3
+            esm_integration.test_embind_val_basics
             "
       # Run some basic tests with the minimum version of node that we currently
       # support in the generated code.

--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -721,10 +721,21 @@ function(${args}) {
         //  emits
         //   'var foo;[code here verbatim];'
         contentText = 'var ' + mangled + snippet;
-        if (snippet[snippet.length - 1] != ';' && snippet[snippet.length - 1] != '}')
+        if (snippet[snippet.length - 1] != ';' && snippet[snippet.length - 1] != '}') {
           contentText += ';';
+        }
       } else if (typeof snippet == 'undefined') {
-        contentText = `var ${mangled};`;
+        // wasmTable is kind of special.  In the normal configuration we export
+        // it from the wasm module under the name `__indirect_function_table`
+        // but we declare it as an 'undefined'.  It then gets assigned manually
+        // once the wasm module is available.
+        // TODO(sbc): This is kind of hacky, we should come up with a better solution.
+        var isDirectWasmExport = WASM_ESM_INTEGRATION && mangled == 'wasmTable';
+        if (isDirectWasmExport) {
+          contentText = '';
+        } else {
+          contentText = `var ${mangled};`;
+        }
       } else {
         // In JS libraries
         //   foo: '=[value]'

--- a/test/core/test_inlinejs3.c
+++ b/test/core/test_inlinejs3.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
                       },
                       i, (double)i / 12);
   }
-  EM_ASM_INT({ globalVar = $0 }, sum); // no outputs, just input
+  EM_ASM_INT({ globalThis.globalVar = $0 }, sum); // no outputs, just input
   sum = 0;
   sum = EM_ASM_INT(return globalVar); // no inputs, just output
   printf("sum: %d\n", sum);

--- a/test/embind/test_val.cpp
+++ b/test/embind/test_val.cpp
@@ -164,8 +164,15 @@ int main() {
 
   test("bool isNull()");
   EM_ASM(
-    a = null;
-    b = false;
+    globalThis.a = null;
+    globalThis.b = false;
+    globalThis.c = null;
+    globalThis.d = null;
+    globalThis.e = null;
+    globalThis.f = null;
+    globalThis.g = null;
+    globalThis.h = null;
+    globalThis.i = null;
   );
   ensure(val::global("a").isNull());
   ensure_not(val::global("b").isNull());
@@ -384,7 +391,7 @@ int main() {
 
   test("template<typename... Args> val new_(Args&&... args)");
   EM_ASM(
-    A = function() {
+    globalThis.A = function() {
       this.value = 2;
     }
   );
@@ -392,7 +399,7 @@ int main() {
   ensure_js("a instanceof A");
   ensure_js("a.value == 2");
   EM_ASM(
-    A = function(arg1, arg2) {
+    globalThis.A = function(arg1, arg2) {
       this.arg1 = arg1;
       this.arg2 = arg2;
     }
@@ -441,10 +448,10 @@ int main() {
   ensure(val::global("f")().as<int>() == 2);
   ensure_not(val::global("f")().as<int>() == 3);
   EM_ASM(
-    f1 = function(arg1, arg2) {
+    globalThis.f1 = function(arg1, arg2) {
       return arg1;
     };
-    f2 = function(arg1, arg2) {
+    globalThis.f2 = function(arg1, arg2) {
       return arg2;
     };
   );
@@ -453,14 +460,14 @@ int main() {
 
   test("template<typename ReturnValue, typename... Args> ReturnValue call(const char* name, Args&&... args)");
   EM_ASM(
-    C = function() {
+    globalThis.C = function() {
       this.method = function() { return this; };
     };
     c = new C;
   );
   ensure(val::global("c").call<val>("method") == val::global("c"));
   EM_ASM(
-    C = function() {
+    globalThis.C = function() {
       this.method = function(arg) { return arg; };
     };
     c = new C;
@@ -536,8 +543,8 @@ int main() {
 
   test("bool instanceof(const val& v)");
   EM_ASM(
-    A = function() {};
-    B = function() {};
+    globalThis.A = function() {};
+    globalThis.B = function() {};
     a = new A;
   );
   ensure(val::global("a").instanceof(val::global("A")));
@@ -583,15 +590,11 @@ int main() {
 
   test("void throw_() const");
   EM_ASM(
-    test_val_throw_ = function(error)
-    {
-      try
-      {
+    globalThis.test_val_throw_ = function(error) {
+      try {
         Module.throw_js_error(error);
         return false;
-      }
-      catch(error_thrown)
-      {
+      } catch(error_thrown) {
         if (error_thrown != error)
           throw error_thrown;
       }


### PR DESCRIPTION
In strict JS mode all variables need to be declared.

In addition this change fixes an error where `wasmTable` was being both delared and imported via an ES6 import.