### PR TITLE
Implement SDL_DisplayFormat

### DIFF
--- a/src/lib/libsdl.js
+++ b/src/lib/libsdl.js
@@ -1897,6 +1897,9 @@ var LibrarySDL = {
     return ret;
   },
 
+  SDL_DisplayFormat__deps: ['SDL_ConvertSurface'],
+  SDL_DisplayFormat: (surf) => _SDL_ConvertSurface(surf, 0, 0),
+
   SDL_DisplayFormatAlpha__deps: ['SDL_ConvertSurface'],
   SDL_DisplayFormatAlpha: (surf) => _SDL_ConvertSurface(surf, 0, 0),
 

--- a/src/lib/libsigs.js
+++ b/src/lib/libsigs.js
@@ -66,6 +66,7 @@ sigs = {
   SDL_DestroyMutex__sig: 'vp',
   SDL_DestroyRenderer__sig: 'vp',
   SDL_DestroyWindow__sig: 'vp',
+  SDL_DisplayFormat__sig: 'pp',
   SDL_DisplayFormatAlpha__sig: 'pp',
   SDL_EnableKeyRepeat__sig: 'iii',
   SDL_EnableUNICODE__sig: 'ii',


### PR DESCRIPTION
This converts surfaces to the format used by the screen. Since the screen in Emscripten has an alpha component, this behaves the same as `SDL_DisplayFormatAlpha`.