### PR TITLE
[jspi] Fix returning pointers from async dyncalls.

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1818,14 +1818,23 @@ addToLibrary({
     }
 #endif
     var rtn = func(...args);
-#endif
+    function convert(rtn) {
 #if MEMORY64
-    return sig[0] == 'p' ? Number(rtn) : rtn;
+      return sig[0] == 'p' ? Number(rtn) : rtn;
 #elif CAN_ADDRESS_2GB
-    return sig[0] == 'p' ? rtn >>> 0 : rtn;
+      return sig[0] == 'p' ? rtn >>> 0 : rtn;
 #else
-    return rtn;
+      return rtn;
 #endif
+    }
+#endif
+
+#if JSPI
+    if (promising) {
+      return rtn.then(convert);
+    }
+#endif
+    return convert(rtn);
   },
 
   $callRuntimeCallbacks__internal: true,

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1818,6 +1818,8 @@ addToLibrary({
     }
 #endif
     var rtn = func(...args);
+#endif // DYNCALLS
+
     function convert(rtn) {
 #if MEMORY64
       return sig[0] == 'p' ? Number(rtn) : rtn;
@@ -1827,7 +1829,6 @@ addToLibrary({
       return rtn;
 #endif
     }
-#endif
 
 #if JSPI
     if (promising) {


### PR DESCRIPTION
When dyncall calls an async function it should wait for the result of the promise to then convert the pointer.

Fixes #24307