### PR TITLE
Initialize the stack bounds prior to checking the cookie

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -539,6 +539,7 @@ jobs:
           title: "asan+lsan"
           test_targets: "
             asan.test_stat
+            asan.test_stack
             asan.test_float_builtins
             asan.test_embind*
             asan.test_abort_on_exceptions

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -60,10 +60,10 @@ function initRuntime(wasmExports) {
 
 #if STACK_OVERFLOW_CHECK
   _emscripten_stack_init();
-  writeStackCookie();
 #if STACK_OVERFLOW_CHECK >= 2
   setStackLimits();
 #endif
+  writeStackCookie();
 #endif
 
 #if PTHREADS

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -199,12 +199,12 @@ function initRuntime() {
   if (ENVIRONMENT_IS_PTHREAD) return startWorker(Module);
 #endif
 
-#if STACK_OVERFLOW_CHECK
-  checkStackCookie();
-#endif
-
 #if STACK_OVERFLOW_CHECK >= 2
   setStackLimits();
+#endif
+
+#if STACK_OVERFLOW_CHECK
+  checkStackCookie();
 #endif
 
 #if RELOCATABLE

--- a/test/core/test_stack.c
+++ b/test/core/test_stack.c
@@ -5,7 +5,9 @@
  * found in the LICENSE file.
  */
 
+#include <assert.h>
 #include <stdio.h>
+
 int test(int i) {
   int x = 10;
   int ret = (long)&x;  // both for the number, and forces x to not be nativized
@@ -17,11 +19,15 @@ int test(int i) {
   }
   return ret;
 }
+
 int main(int argc, char **argv) {
   // We should get the same value for the first and last - stack has unwound
+  printf("in main\n");
   int x1 = test(argc - 2);
   int x2 = test(100);
   int x3 = test((argc - 2) / 4);
+  assert(x2 != x1);
+  assert(x3 == x1);
   printf("*%d,%d*\n", x3 - x1, x2 != x1);
   return 0;
 }


### PR DESCRIPTION
Without this change reading of the cookie value calls into __asan_loadN which then tries to use SP, but SP is not yet initialzed, so the asan code itself trigger a STACK_OVERFLOW_CHECK error.

This fixes the asan.test_stack test which was broken by #24314 but went unnoticed because we don't run all the asan tests in emscripten CI.