### PR TITLE
[esm-integration] Allow modules to be runnable even without `main`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -802,7 +802,6 @@ jobs:
             core0.test_pthread_join_and_asyncify
             core0.test_async_ccall_promise_jspi*
             core0.test_cubescript_jspi
-            esm_integration.test_fs_js_api*
             instance.test_hello_world
             instance.test_dylink_basics
             instance.test_cube2hash*
@@ -812,8 +811,10 @@ jobs:
             instance.test_iostream_and_determinism
             instance.test_fannkuch
             instance.test_fasta
+            esm_integration.test_fs_js_api*
             esm_integration.test_inlinejs3
             esm_integration.test_embind_val_basics
+            esm_integration.test_undefined_main
             "
       # Run some basic tests with the minimum version of node that we currently
       # support in the generated code.

--- a/test/core/test_esm_integration.expected.mjs
+++ b/test/core/test_esm_integration.expected.mjs
@@ -3,7 +3,8 @@
 import * as unused from './hello_world.wasm';
 export { default, _foo, _main, err, stringToNewUTF8 } from './hello_world.support.mjs';
 
-// When run as the main module under node, execute main directly here
+// When run as the main module under node, create the module directly.  This will
+// execute any startup code along with main (if it exists).
 import init from './hello_world.support.mjs';
 const isNode = typeof process == 'object' && typeof process.versions == 'object' && typeof process.versions.node == 'string' && process.type != 'renderer';
 if (isNode) {


### PR DESCRIPTION
Also, ensure the output format defaults to `MJS` in esm integration and modularize=instance modes.