### PR TITLE
[embind] Initialize embind on workers after main thread ctors.

### DIFF
--- a/src/lib/libembind.js
+++ b/src/lib/libembind.js
@@ -31,6 +31,10 @@ var LibraryEmbind = {
   $UnboundTypeError: class extends Error {},
   $PureVirtualError: class extends Error {},
   $GenericWireTypeSize: {{{ 2 * POINTER_SIZE }}},
+#if PTHREADS || WASM_WORKERS
+  $postCtors: null, // Unused symbol stub for injecting post ctors call.
+  $postCtors__postset: () => { addAtPostCtor('__embind_post_ctors()'); },
+#endif
 #if EMBIND_AOT
   $InvokerFunctions: '<<< EMBIND_AOT_INVOKERS >>>',
 #endif
@@ -2319,5 +2323,9 @@ var LibraryEmbind = {
     });
   },
 };
+
+#if PTHREADS || WASM_WORKERS
+extraLibraryFuncs.push('$postCtors');
+#endif
 
 addToLibrary(LibraryEmbind);

--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -138,7 +138,7 @@ addToLibrary({
 
 #if EMBIND
     // Embind must initialize itself on all threads, as it generates support JS.
-    __embind_initialize_bindings();
+    __embind_initialize_worker_bindings();
 #endif
 
 #if AUDIO_WORKLET

--- a/src/runtime_pthread.js
+++ b/src/runtime_pthread.js
@@ -147,7 +147,7 @@ if (ENVIRONMENT_IS_PTHREAD) {
 #endif
           // Embind must initialize itself on all threads, as it generates support JS.
           // We only do this once per worker since they get reused
-          __embind_initialize_bindings();
+          __embind_initialize_worker_bindings();
 #endif // EMBIND
           initializedJS = true;
         }

--- a/test/embind/test_embind_val_in_static_pthread.cpp
+++ b/test/embind/test_embind_val_in_static_pthread.cpp
@@ -1,0 +1,14 @@
+#include <emscripten/val.h>
+#include <emscripten/emscripten.h>
+#include <thread>
+
+auto BGThread = std::thread([]() {
+  auto globalThis = emscripten::val::global("globalThis");
+  assert(globalThis.typeOf().as<std::string>() == "object");
+  printf("worker\n");
+});
+
+int main() {
+  BGThread.join();
+  printf("done\n");
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3429,6 +3429,12 @@ More info: https://emscripten.org
     ''')
     self.do_runf('main.cpp', emcc_args=['-lembind'])
 
+  @node_pthreads
+  def test_embind_val_in_static_pthread(self):
+    # Test that threads wait for embind to initialize before running.
+    self.emcc_args += ['-lembind', '-sPTHREAD_POOL_SIZE=2']
+    self.do_runf('embind/test_embind_val_in_static_pthread.cpp', 'worker\ndone\n')
+
   @requires_jspi
   @parameterized({
     '': [['-sJSPI_EXPORTS=async*']],

--- a/tools/link.py
+++ b/tools/link.py
@@ -1376,7 +1376,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     # https://github.com/emscripten-core/emscripten/issues/21653
     settings.REQUIRED_EXPORTS.append('__getTypeName')
     if settings.PTHREADS or settings.WASM_WORKERS:
-      settings.REQUIRED_EXPORTS.append('_embind_initialize_bindings')
+      settings.REQUIRED_EXPORTS += ['_embind_initialize_worker_bindings', '_embind_post_ctors']
     # Needed to assign the embind exports to the ES exports.
     if settings.MODULARIZE == 'instance':
       settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$addOnPostCtor']

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1927,7 +1927,7 @@ class libwebgpu_cpp(MTLibrary):
   src_files = ['webgpu_cpp.cpp']
 
 
-class libembind(Library):
+class libembind(MTLibrary):
   name = 'libembind'
   never_force = True
 


### PR DESCRIPTION
Previously, when a statically constructed thread was created it could potentially run before all of the embind static constructors on the main thread had run. This caused the workers to miss the embind bindings.

To fix this, I've added a `std::atomic` so that each worker waits for embind to be ready before running the binding code.

Fixes #19849