### PR TITLE
[dylink] Use multiple argument in calls to dbg(). NFC

### DIFF
--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -29,7 +29,7 @@ var LibraryDylink = {
           () => loadWebAssemblyModule(byteArray, {loadAsync: true, nodelete: true}, name, {})).then(
             (exports) => {
 #if DYLINK_DEBUG
-              dbg(`registering preloadedWasm: ${name}`);
+              dbg('registering preloadedWasm:', name);
 #endif
               preloadedWasm[name] = exports;
               onload(byteArray);
@@ -217,7 +217,7 @@ var LibraryDylink = {
   $updateGOT__deps: ['$GOT', '$isInternalSym', '$addFunction'],
   $updateGOT: (exports, replace) => {
 #if DYLINK_DEBUG
-    dbg("updateGOT: adding " + Object.keys(exports).length + " symbols");
+    dbg(`updateGOT: adding ${Object.keys(exports).length} symbols`);
 #endif
     for (var symName in exports) {
       if (isInternalSym(symName)) {
@@ -304,7 +304,7 @@ var LibraryDylink = {
         if (!value && !entry.required) {
           // Ignore undefined symbols that are imported as weak.
 #if DYLINK_DEBUG
-          dbg(`ignoring undefined weak symbol: ${symName}`);
+          dbg('ignoring undefined weak symbol:', symName);
 #endif
           continue;
         }
@@ -357,7 +357,7 @@ var LibraryDylink = {
   $dlSetError__deps: ['__dl_seterr', '$stringToUTF8OnStack', '$stackSave', '$stackRestore'],
   $dlSetError: (msg) => {
 #if DYLINK_DEBUG
-    dbg(`dlSetError: ${msg}`);
+    dbg('dlSetError:', msg);
 #endif
     var sp = stackSave();
     var cmsg = stringToUTF8OnStack(msg);
@@ -503,7 +503,7 @@ var LibraryDylink = {
         customSection.runtimePaths = getStringList();
       } else {
 #if ASSERTIONS
-        err(`unknown dylink.0 subsection: ${subsectionType}`)
+        err('unknown dylink.0 subsection:', subsectionType)
 #endif
         // unknown subsection
         offset += subsectionSize;
@@ -517,7 +517,7 @@ var LibraryDylink = {
 #endif
 
 #if DYLINK_DEBUG
-    dbg(`dylink needed:${customSection.neededDynlibs}`);
+    dbg('dylink needed:', customSection.neededDynlibs);
 #endif
 
     return customSection;
@@ -613,7 +613,7 @@ var LibraryDylink = {
   ],
   $loadWebAssemblyModule: (binary, flags, libName, localScope, handle) => {
 #if DYLINK_DEBUG
-    dbg(`loadWebAssemblyModule: ${libName}`);
+    dbg('loadWebAssemblyModule:', libName);
 #endif
     var metadata = getDylinkMetadata(binary);
     currentModuleWeakSymbols = metadata.weakImports;
@@ -758,7 +758,7 @@ var LibraryDylink = {
 #if PTHREADS
         if (!ENVIRONMENT_IS_PTHREAD && libName) {
 #if DYLINK_DEBUG
-          dbg(`registering sharedModules: ${libName}`)
+          dbg('registering sharedModules:', libName)
 #endif
           // cache all loaded modules in `sharedModules`, which gets passed
           // to new workers when they are created.
@@ -797,7 +797,7 @@ var LibraryDylink = {
           args = args.join(',');
           var func = `(${args}) => { ${body} };`;
 #if DYLINK_DEBUG
-          dbg(`adding new EM_ASM constant at: ${ptrToString(start)}`);
+          dbg('adding new EM_ASM constant at:', ptrToString(start));
 #endif
           {{{ makeEval('ASM_CONSTS[start] = eval(func)') }}};
         }
@@ -1036,7 +1036,7 @@ var LibraryDylink = {
   $loadDynamicLibrary: function(libName, flags = {global: true, nodelete: true}, localScope, handle) {
 #if DYLINK_DEBUG
     dbg(`loadDynamicLibrary: ${libName} handle: ${handle}`);
-    dbg(`existing: ${Object.keys(LDSO.loadedLibsByName)}`);
+    dbg('existing:', Object.keys(LDSO.loadedLibsByName));
 #endif
     // when loadDynamicLibrary did not have flags, libraries were loaded
     // globally & permanently
@@ -1184,7 +1184,7 @@ var LibraryDylink = {
     }
 
 #if DYLINK_DEBUG
-    dbg(`loadDylibs: ${dynamicLibraries}`);
+    dbg('loadDylibs:', dynamicLibraries);
 #endif
 
     // Load binaries asynchronously
@@ -1211,7 +1211,7 @@ var LibraryDylink = {
     var filename = UTF8ToString(handle + {{{ C_STRUCTS.dso.name }}});
     var flags = {{{ makeGetValue('handle', C_STRUCTS.dso.flags, 'i32') }}};
 #if DYLINK_DEBUG
-    dbg(`dlopenInternal: ${filename}`);
+    dbg('dlopenInternal:', filename);
 #endif
     filename = PATH.normalize(filename);
     var searchpaths = [];
@@ -1305,7 +1305,7 @@ var LibraryDylink = {
     // http://pubs.opengroup.org/onlinepubs/009695399/functions/dlsym.html
     symbol = UTF8ToString(symbol);
 #if DYLINK_DEBUG
-    dbg(`dlsym_js: ${symbol}`);
+    dbg('dlsym_js:', symbol);
 #endif
     var result;
     var newSymIndex;
@@ -1343,7 +1343,7 @@ var LibraryDylink = {
       var addr = getFunctionAddress(result);
       if (addr) {
 #if DYLINK_DEBUG
-        dbg(`symbol already exists in table: ${symbol}`);
+        dbg('symbol already exists in table:', symbol);
 #endif
         result = addr;
       } else {
@@ -1353,7 +1353,7 @@ var LibraryDylink = {
         // `<func>__sig` specified in library JS file.
         result = addFunction(result, result.sig);
 #if DYLINK_DEBUG
-        dbg(`adding symbol to table: ${symbol}`);
+        dbg('adding symbol to table:',  symbol);
 #endif
         {{{ makeSetValue('symbolIndex', 0, 'newSymIndex', '*') }}};
       }


### PR DESCRIPTION
This generates slightly nicer formatting in some cases I noticed.  Its also a little less syntax when string templating is overkill.