### PR TITLE
[MODULARIZE=instance] Allow Module argument in `--pre-js` code.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -813,6 +813,8 @@ jobs:
             instance.test_fasta
             instance.test_EXPORTED_RUNTIME_METHODS
             instance.test_ccall
+            instance.test_dylink_basics*
+            instance.test_Module_dynamicLibraries
             esm_integration.test_fs_js_api*
             esm_integration.test_inlinejs3
             esm_integration.test_embind_val_basics

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -303,7 +303,7 @@ function preInit() {
 // In MODULARIZE=instance mode we delay most of the initialization work until
 // the `init` function is called.
 export default async function init(moduleArg = {}) {
-  Module = moduleArg;
+  Object.assign(Module, moduleArg);
   processModuleArgs();
 #if WASM_ESM_INTEGRATION
   updateMemoryViews();

--- a/tools/link.py
+++ b/tools/link.py
@@ -813,10 +813,10 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     diagnostics.warning('experimental', '-sMODULARIZE=instance is still experimental. Many features may not work or will change.')
     if options.oformat != OFormat.MJS:
       exit_with_error('MODULARIZE instance is only compatible with ES module output format')
-    limit_incoming_module_api()
-    for s in ['wasmMemory', 'INITIAL_MEMORY']:
-      if s in settings.INCOMING_MODULE_JS_API:
-        exit_with_error(f'{s} cannot be in INCOMING_MODULE_JS_API in MODULARIZE=instance mode')
+    if 'INCOMING_MODULE_JS_API' in user_settings:
+      for s in ['wasmMemory', 'INITIAL_MEMORY']:
+        if s in settings.INCOMING_MODULE_JS_API:
+          exit_with_error(f'{s} cannot be in INCOMING_MODULE_JS_API in MODULARIZE=instance mode')
 
   if options.oformat in (OFormat.WASM, OFormat.BARE):
     if options.emit_tsd:


### PR DESCRIPTION
Previously we were clobbering any existing Module arguments with the arguments passed to the `init()` function.

Also, don't limit INCOMING_MODULE_JS_API in MODULARIZE=instance mode. At least for now I think we should go for compatibility by default.

The test I've enabled here sets the `dynamicLibraries` Module property during in a pre-js script.