### PR TITLE
[CI] Limit number of core uses in test-node-compat runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ executors:
   linux-python:
     docker:
       - image: cimg/python:3.10.7
+    environment:
+      EMCC_CORES: "4"
   focal:
     docker:
       - image: emscripten/emscripten-ci:focal


### PR DESCRIPTION
Recently we have been added more tests here and seeing SIGKILL from the OS.