### PR TITLE
[MODULARIZE=instance] Mark MINIMAL_RUNTIME as not supported

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,9 +651,14 @@ jobs:
             wasmfs.test_fs_llseek_rawfs
             wasmfs.test_freetype
             minimal0.test_utf
-            instance.test_async_hello_v8
-            instance.test_environment
             "
+  test-modularize-instance:
+    executor: focal
+    environment:
+      EMTEST_SKIP_NODE_CANARY: "1"
+    steps:
+      - run-tests-linux:
+          test_targets: "instance"
   test-wasm2js1:
     environment:
       EMTEST_SKIP_NODE_CANARY: "1"
@@ -806,26 +811,6 @@ jobs:
             core0.test_pthread_join_and_asyncify
             core0.test_async_ccall_promise_jspi*
             core0.test_cubescript_jspi
-            instance.test_hello_world
-            instance.test_dylink_basics
-            instance.test_cube2hash*
-            instance.test_exceptions_3*
-            instance.test_memorygrowth
-            instance.test_stat
-            instance.test_iostream_and_determinism
-            instance.test_fannkuch
-            instance.test_fasta
-            instance.test_EXPORTED_RUNTIME_METHODS
-            instance.test_abort_on_exceptions*
-            instance.test_ccall
-            instance.test_dylink_basics*
-            instance.test_Module_dynamicLibraries*
-            instance.test_dylink_argv_argc
-            instance.test_dlmalloc*
-            instance.test_dyncall*
-            instance.test_em_asm*
-            instance.test_embind*
-            instance.test_module_wasm_memory
             esm_integration.test_fs_js_api*
             esm_integration.test_inlinejs3
             esm_integration.test_embind_val_basics
@@ -1152,6 +1137,9 @@ workflows:
           requires:
             - build-linux
       - test-other:
+          requires:
+            - build-linux
+      - test-modularize-instance:
           requires:
             - build-linux
       - test-browser-chrome

--- a/site/source/docs/compiling/Modularized-Output.rst
+++ b/site/source/docs/compiling/Modularized-Output.rst
@@ -133,6 +133,8 @@ fix in future releses.  Current limitations include:
 * :ref:`asyncify_lazy_load_code` is not supported (depends on ``wasmExports``
   global)
 
+* :ref:`minimal_runtime` is not supported.
+
 * The output of file_packager is not compatible so :ref:`emcc-preload-file` and
   :ref:`emcc-embed-file` do not work.
 

--- a/src/lib/libccall.js
+++ b/src/lib/libccall.js
@@ -6,7 +6,7 @@
 
 addToLibrary({
   // Returns the C function with a specified identifier (for C++, you need to do manual name mangling)
-#if MODULARIZE == 'instance'
+#if MODULARIZE == 'instance' && !INCLUDE_FULL_LIBRARY
   $getCFunc__deps: [() => error('ccall is not yet compatible with MODULARIZE=instance')],
 #endif
   $getCFunc__internal: true,

--- a/test/common.py
+++ b/test/common.py
@@ -522,6 +522,8 @@ def also_with_minimal_runtime(f):
       print('parameterize:minimal_runtime=%s' % with_minimal_runtime)
     assert self.get_setting('MINIMAL_RUNTIME') is None
     if with_minimal_runtime:
+      if self.get_setting('MODULARIZE') == 'instance':
+        self.skipTest('MODULARIZE=instance is not compatible with MINIMAL_RUNTIME')
       self.set_setting('MINIMAL_RUNTIME', 1)
       # This extra helper code is needed to cleanly handle calls to exit() which throw
       # an ExitCode exception.

--- a/test/core/pthread/test_pthread_exit_runtime.pre.js
+++ b/test/core/pthread/test_pthread_exit_runtime.pre.js
@@ -1,7 +1,7 @@
 var address = 0;
 
 Module.onRuntimeInitialized = function() {
-  address = Module['_join_returned_address']();
+  address = _join_returned_address();
   assert(address);
   assert(HEAP8[address] == 0);
 }

--- a/test/core/test_env.out
+++ b/test/core/test_env.out
@@ -5,7 +5,7 @@ PATH=/
 PWD=/
 HOME=/home/web_user
 LANG=(C|en_US).UTF-8
-_=.*(/test_env.js|./this.program)
+_=.*(/test_env.m?js|./this.program)
 
 getenv\(PATH\): /
 getenv\(NONEXISTENT\): \(null\)

--- a/test/core/test_environ.out
+++ b/test/core/test_environ.out
@@ -4,4 +4,4 @@ PATH=/
 PWD=/
 HOME=/home/web_user
 LANG=(C|en_US).UTF-8
-_=.*(/test_environ.js|/this.program)
+_=.*(/test_environ.m?js|/this.program)

--- a/test/core/test_main_reads_args.out
+++ b/test/core/test_main_reads_args.out
@@ -1,2 +1,2 @@
 argc: 1
-argv\[0\]: (test_main_reads_args\.js|this\.program)
+argv\[0\]: (test_main_reads_args\.m?js|this\.program)

--- a/test/core/test_utf.c
+++ b/test/core/test_utf.c
@@ -6,16 +6,21 @@
  */
 
 #include <stdio.h>
-#include <emscripten.h>
 #include <stdlib.h>
+
+#include <emscripten/emscripten.h>
+#include <emscripten/em_js.h>
+
+EM_JS_DEPS(deps, "$stringToUTF8OnStack,$getValue");
 
 int main() {
   char *c = "μ†ℱ ╋ℯ╳╋ 😇";
   printf("%hhu %hhu %hhu %hhu %s\n", c[0], c[1], c[2], c[3], c);
-  emscripten_run_script(
-    "var cheez = Module.stringToUTF8OnStack(\"μ†ℱ ╋ℯ╳╋ 😇\");"
-    "out(UTF8ToString(cheez), Module.getValue(cheez+0, 'i8')&0xff, "
-    "                         Module.getValue(cheez+1, 'i8')&0xff, "
-    "                         Module.getValue(cheez+2, 'i8')&0xff, "
-    "                         Module.getValue(cheez+3, 'i8')&0xff);");
+  EM_ASM({
+    var cheez = stringToUTF8OnStack("μ†ℱ ╋ℯ╳╋ 😇");
+    out(UTF8ToString(cheez), getValue(cheez+0, 'i8')&0xff,
+                             getValue(cheez+1, 'i8')&0xff,
+                             getValue(cheez+2, 'i8')&0xff,
+                             getValue(cheez+3, 'i8')&0xff);
+  });
 }

--- a/test/test_force_exit.c
+++ b/test/test_force_exit.c
@@ -32,7 +32,7 @@ int main() {
 
   EM_ASM({
     // Use callUserCallback here so that ExitStatus is handled correctly
-    setTimeout(() => callUserCallback(Module._later), 1);
+    setTimeout(() => callUserCallback(_later), 1);
   });
 
   printf("exit, but still alive\n");

--- a/tools/link.py
+++ b/tools/link.py
@@ -828,6 +828,8 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       exit_with_error('MODULARIZE=instance is not compatible with -sDYNCALLS')
     if settings.ASYNCIFY_LAZY_LOAD_CODE:
       exit_with_error('MODULARIZE=instance is not compatible with -sASYNCIFY_LAZY_LOAD_CODE')
+    if settings.MINIMAL_RUNTIME:
+      exit_with_error('MODULARIZE=instance is not compatible with MINIMAL_RUNTIME')
     if options.use_preload_plugins or len(options.preload_files):
       exit_with_error('MODULARIZE=instance is not compatible with --embed-file/--preload-file')
 


### PR DESCRIPTION
Also disable a bunch of unsupported tests.

Now we can run the entire core test in MODULARIZE=instance mode!  I'm adding a new test running here, which we might not want to keep around forever, but its very useful while working on ESM integration.