### PR TITLE
acorn-optimizer: improve for-var elimination

### DIFF
--- a/test/js_optimizer/JSDCE-fors-output.js
+++ b/test/js_optimizer/JSDCE-fors-output.js
@@ -2,4 +2,4 @@ for (var i in x) {}
 
 for (var i of [ 1, 2, 3 ]) {}
 
-for (var j = 0; ;) {}
+for (;;) {}


### PR DESCRIPTION
- Simplify `var` handling in `for` loops by handling them directly during traversal instead of store-restore.
- Allow to remove unused `var` in a plain C-style `for` loop.

Split out from #24348.