### PR TITLE
Use AsciiToString in Embind. NFC

### DIFF
--- a/src/lib/libembind.js
+++ b/src/lib/libembind.js
@@ -8,7 +8,7 @@
 /*global Module, asm*/
 /*global _malloc, _free, _memcpy*/
 /*global FUNCTION_TABLE, HEAP8, HEAPU8, HEAP16, HEAPU16, HEAP32, HEAPU32, HEAPF32, HEAPF64*/
-/*global readLatin1String*/
+/*global AsciiToString*/
 /*global Emval, emval_handle_array, __emval_decref*/
 /*jslint sub:true*/ /* The symbols 'fromWireType' and 'toWireType' must be accessed via array notation to be closure-safe since craftInvokerFunction crafts functions as strings that can't be closured. */
 
@@ -229,9 +229,9 @@ var LibraryEmbind = {
     return sharedRegisterType(rawType, registeredInstance, options);
   },
 
-  _embind_register_void__deps: ['$readLatin1String', '$registerType'],
+  _embind_register_void__deps: ['$AsciiToString', '$registerType'],
   _embind_register_void: (rawType, name) => {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     registerType(rawType, {
       isVoid: true, // void return values can be optimized out sometimes
       name,
@@ -243,9 +243,9 @@ var LibraryEmbind = {
   },
 
   _embind_register_bool__docs: '/** @suppress {globalThis} */',
-  _embind_register_bool__deps: ['$readLatin1String', '$registerType', '$GenericWireTypeSize'],
+  _embind_register_bool__deps: ['$AsciiToString', '$registerType', '$GenericWireTypeSize'],
   _embind_register_bool: (rawType, name, trueValue, falseValue) => {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     registerType(rawType, {
         name,
         'fromWireType': function(wt) {
@@ -331,14 +331,14 @@ var LibraryEmbind = {
   // When converting a number from JS to C++ side, the valid range of the number is
   // [minRange, maxRange], inclusive.
   _embind_register_integer__deps: [
-    '$integerReadValueFromPointer', '$readLatin1String', '$registerType',
+    '$integerReadValueFromPointer', '$AsciiToString', '$registerType',
 #if ASSERTIONS
     '$embindRepr',
     '$assertIntegerRange',
 #endif
   ],
   _embind_register_integer: (primitiveType, name, size, minRange, maxRange) => {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
 
     const isUnsignedType = minRange === 0;
 
@@ -372,14 +372,14 @@ var LibraryEmbind = {
 #if WASM_BIGINT
   _embind_register_bigint__docs: '/** @suppress {globalThis} */',
   _embind_register_bigint__deps: [
-    '$readLatin1String', '$registerType', '$integerReadValueFromPointer',
+    '$AsciiToString', '$registerType', '$integerReadValueFromPointer',
 #if ASSERTIONS
     '$embindRepr',
     '$assertIntegerRange',
 #endif
   ],
   _embind_register_bigint: (primitiveType, name, size, minRange, maxRange) => {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
 
     const isUnsignedType = minRange === 0n;
 
@@ -426,13 +426,13 @@ var LibraryEmbind = {
 #endif
 
   _embind_register_float__deps: [
-    '$floatReadValueFromPointer', '$readLatin1String', '$registerType',
+    '$floatReadValueFromPointer', '$AsciiToString', '$registerType',
 #if ASSERTIONS
     '$embindRepr',
 #endif
   ],
   _embind_register_float: (rawType, name, size) => {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     registerType(rawType, {
       name,
       'fromWireType': (value) => value,
@@ -458,11 +458,11 @@ var LibraryEmbind = {
   },
 
   _embind_register_std_string__deps: [
-    '$readLatin1String', '$registerType',
+    '$AsciiToString', '$registerType',
     '$readPointer', '$throwBindingError',
     '$stringToUTF8', '$lengthBytesUTF8', 'malloc', 'free'],
   _embind_register_std_string: (rawType, name) => {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     var stdStringIsUTF8
 #if EMBIND_STD_STRING_IS_UTF8
     = true;
@@ -561,12 +561,12 @@ var LibraryEmbind = {
   },
 
   _embind_register_std_wstring__deps: [
-    '$readLatin1String', '$registerType', '$readPointer',
+    '$AsciiToString', '$registerType', '$readPointer',
     '$UTF16ToString', '$stringToUTF16', '$lengthBytesUTF16',
     '$UTF32ToString', '$stringToUTF32', '$lengthBytesUTF32',
     ],
   _embind_register_std_wstring: (rawType, charSize, name) => {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     var decodeString, encodeString, readCharAt, lengthBytesUTF;
     if (charSize === 2) {
       decodeString = UTF16ToString;
@@ -646,7 +646,7 @@ var LibraryEmbind = {
     registerType(rawOptionalType, EmValOptionalType);
   },
 
-  _embind_register_memory_view__deps: ['$readLatin1String', '$registerType'],
+  _embind_register_memory_view__deps: ['$AsciiToString', '$registerType'],
   _embind_register_memory_view: (rawType, dataTypeIndex, name) => {
     var typeMapping = [
       Int8Array,
@@ -671,7 +671,7 @@ var LibraryEmbind = {
       return new TA(HEAP8.buffer, data, size);
     }
 
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     registerType(rawType, {
       name,
       'fromWireType': decodeMemoryView,
@@ -844,7 +844,7 @@ var LibraryEmbind = {
     return createNamedFunction(humanName, invokerFn);
   },
 
-  $embind__requireFunction__deps: ['$readLatin1String', '$throwBindingError'
+  $embind__requireFunction__deps: ['$AsciiToString', '$throwBindingError'
 #if DYNCALLS || !WASM_BIGINT || MEMORY64 || CAN_ADDRESS_2GB
     , '$getDynCaller'
 #endif
@@ -854,7 +854,7 @@ var LibraryEmbind = {
     assert(!isAsync, 'Async bindings are only supported with JSPI.');
 #endif
 
-    signature = readLatin1String(signature);
+    signature = AsciiToString(signature);
 
     function makeDynCaller() {
 #if DYNCALLS
@@ -889,11 +889,11 @@ var LibraryEmbind = {
 
   _embind_register_function__deps: [
     '$craftInvokerFunction', '$exposePublicSymbol', '$heap32VectorToArray',
-    '$readLatin1String', '$replacePublicSymbol', '$embind__requireFunction',
+    '$AsciiToString', '$replacePublicSymbol', '$embind__requireFunction',
     '$throwUnboundTypeError', '$whenDependentTypesAreResolved', '$getFunctionName'],
   _embind_register_function: (name, argCount, rawArgTypesAddr, signature, rawInvoker, fn, isAsync, isNonnullReturn) => {
     var argTypes = heap32VectorToArray(argCount, rawArgTypesAddr);
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     name = getFunctionName(name);
 
     rawInvoker = embind__requireFunction(signature, rawInvoker, isAsync);
@@ -910,7 +910,7 @@ var LibraryEmbind = {
   },
 
   _embind_register_value_array__deps: [
-    '$tupleRegistrations', '$readLatin1String', '$embind__requireFunction'],
+    '$tupleRegistrations', '$AsciiToString', '$embind__requireFunction'],
   _embind_register_value_array: (
     rawType,
     name,
@@ -920,7 +920,7 @@ var LibraryEmbind = {
     rawDestructor
   ) => {
     tupleRegistrations[rawType] = {
-      name: readLatin1String(name),
+      name: AsciiToString(name),
       rawConstructor: embind__requireFunction(constructorSignature, rawConstructor),
       rawDestructor: embind__requireFunction(destructorSignature, rawDestructor),
       elements: [],
@@ -1011,7 +1011,7 @@ var LibraryEmbind = {
   },
 
   _embind_register_value_object__deps: [
-    '$structRegistrations', '$readLatin1String', '$embind__requireFunction'],
+    '$structRegistrations', '$AsciiToString', '$embind__requireFunction'],
   _embind_register_value_object: (
     rawType,
     name,
@@ -1021,7 +1021,7 @@ var LibraryEmbind = {
     rawDestructor
   ) => {
     structRegistrations[rawType] = {
-      name: readLatin1String(name),
+      name: AsciiToString(name),
       rawConstructor: embind__requireFunction(constructorSignature, rawConstructor),
       rawDestructor: embind__requireFunction(destructorSignature, rawDestructor),
       fields: [],
@@ -1029,7 +1029,7 @@ var LibraryEmbind = {
   },
 
   _embind_register_value_object_field__deps: [
-    '$structRegistrations', '$readLatin1String', '$embind__requireFunction'],
+    '$structRegistrations', '$AsciiToString', '$embind__requireFunction'],
   _embind_register_value_object_field: (
     structType,
     fieldName,
@@ -1043,7 +1043,7 @@ var LibraryEmbind = {
     setterContext
   ) => {
     structRegistrations[structType].fields.push({
-      fieldName: readLatin1String(fieldName),
+      fieldName: AsciiToString(fieldName),
       getterReturnType,
       getter: embind__requireFunction(getterSignature, getter),
       getterContext,
@@ -1687,7 +1687,7 @@ var LibraryEmbind = {
   _embind_register_class__deps: [
     '$BindingError', '$ClassHandle', '$createNamedFunction',
     '$registeredPointers', '$exposePublicSymbol',
-    '$makeLegalFunctionName', '$readLatin1String',
+    '$makeLegalFunctionName', '$AsciiToString',
     '$RegisteredClass', '$RegisteredPointer', '$replacePublicSymbol',
     '$embind__requireFunction', '$throwUnboundTypeError',
     '$whenDependentTypesAreResolved'],
@@ -1704,7 +1704,7 @@ var LibraryEmbind = {
                            name,
                            destructorSignature,
                            rawDestructor) => {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     getActualType = embind__requireFunction(getActualTypeSignature, getActualType);
     upcast &&= embind__requireFunction(upcastSignature, upcast);
     downcast &&= embind__requireFunction(downcastSignature, downcast);
@@ -1887,7 +1887,7 @@ var LibraryEmbind = {
   },
 
   _embind_register_class_function__deps: [
-    '$craftInvokerFunction', '$heap32VectorToArray', '$readLatin1String',
+    '$craftInvokerFunction', '$heap32VectorToArray', '$AsciiToString',
     '$embind__requireFunction', '$throwUnboundTypeError',
     '$whenDependentTypesAreResolved', '$getFunctionName'],
   _embind_register_class_function: (rawClassType,
@@ -1901,7 +1901,7 @@ var LibraryEmbind = {
                                     isAsync,
                                     isNonnullReturn) => {
     var rawArgTypes = heap32VectorToArray(argCount, rawArgTypesAddr);
-    methodName = readLatin1String(methodName);
+    methodName = AsciiToString(methodName);
     methodName = getFunctionName(methodName);
     rawInvoker = embind__requireFunction(invokerSignature, rawInvoker, isAsync);
 
@@ -1958,7 +1958,7 @@ var LibraryEmbind = {
   },
 
   _embind_register_class_property__deps: [
-    '$readLatin1String', '$embind__requireFunction', '$runDestructors',
+    '$AsciiToString', '$embind__requireFunction', '$runDestructors',
     '$throwBindingError', '$throwUnboundTypeError',
     '$whenDependentTypesAreResolved', '$validateThis'],
   _embind_register_class_property: (classType,
@@ -1971,7 +1971,7 @@ var LibraryEmbind = {
                                     setterSignature,
                                     setter,
                                     setterContext) => {
-    fieldName = readLatin1String(fieldName);
+    fieldName = AsciiToString(fieldName);
     getter = embind__requireFunction(getterSignature, getter);
 
     whenDependentTypesAreResolved([], [classType], (classType) => {
@@ -2026,7 +2026,7 @@ var LibraryEmbind = {
 
   _embind_register_class_class_function__deps: [
     '$craftInvokerFunction', '$ensureOverloadTable', '$heap32VectorToArray',
-    '$readLatin1String', '$embind__requireFunction', '$throwUnboundTypeError',
+    '$AsciiToString', '$embind__requireFunction', '$throwUnboundTypeError',
     '$whenDependentTypesAreResolved', '$getFunctionName'],
   _embind_register_class_class_function: (rawClassType,
                                           methodName,
@@ -2038,7 +2038,7 @@ var LibraryEmbind = {
                                           isAsync,
                                           isNonnullReturn) => {
     var rawArgTypes = heap32VectorToArray(argCount, rawArgTypesAddr);
-    methodName = readLatin1String(methodName);
+    methodName = AsciiToString(methodName);
     methodName = getFunctionName(methodName);
     rawInvoker = embind__requireFunction(invokerSignature, rawInvoker, isAsync);
     whenDependentTypesAreResolved([], [rawClassType], (classType) => {
@@ -2094,7 +2094,7 @@ var LibraryEmbind = {
   },
 
   _embind_register_class_class_property__deps: [
-    '$readLatin1String', '$embind__requireFunction', '$runDestructors',
+    '$AsciiToString', '$embind__requireFunction', '$runDestructors',
     '$throwBindingError', '$throwUnboundTypeError',
     '$whenDependentTypesAreResolved'],
   _embind_register_class_class_property: (rawClassType,
@@ -2105,7 +2105,7 @@ var LibraryEmbind = {
                                           getter,
                                           setterSignature,
                                           setter) => {
-    fieldName = readLatin1String(fieldName);
+    fieldName = AsciiToString(fieldName);
     getter = embind__requireFunction(getterSignature, getter);
 
     whenDependentTypesAreResolved([], [rawClassType], (classType) => {
@@ -2158,12 +2158,12 @@ var LibraryEmbind = {
 
   _embind_create_inheriting_constructor__deps: [
     '$createNamedFunction', '$Emval',
-    '$PureVirtualError', '$readLatin1String',
+    '$PureVirtualError', '$AsciiToString',
     '$registerInheritedInstance',
     '$requireRegisteredType', '$throwBindingError',
     '$unregisterInheritedInstance', '$detachFinalizer', '$attachFinalizer'],
   _embind_create_inheriting_constructor: (constructorName, wrapperType, properties) => {
-    constructorName = readLatin1String(constructorName);
+    constructorName = AsciiToString(constructorName);
     wrapperType = requireRegisteredType(wrapperType, 'wrapper');
     properties = Emval.toValue(properties);
 
@@ -2246,7 +2246,7 @@ var LibraryEmbind = {
                                rawShare,
                                destructorSignature,
                                rawDestructor) => {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     rawGetPointee = embind__requireFunction(getPointeeSignature, rawGetPointee);
     rawConstructor = embind__requireFunction(constructorSignature, rawConstructor);
     rawShare = embind__requireFunction(shareSignature, rawShare);
@@ -2273,9 +2273,9 @@ var LibraryEmbind = {
 
   _embind_register_enum__docs: '/** @suppress {globalThis} */',
   _embind_register_enum__deps: ['$exposePublicSymbol', '$enumReadValueFromPointer',
-    '$readLatin1String', '$registerType'],
+    '$AsciiToString', '$registerType'],
   _embind_register_enum: (rawType, name, size, isSigned) => {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
 
     function ctor() {}
     ctor.values = {};
@@ -2294,10 +2294,10 @@ var LibraryEmbind = {
     exposePublicSymbol(name, ctor);
   },
 
-  _embind_register_enum_value__deps: ['$createNamedFunction', '$readLatin1String', '$requireRegisteredType'],
+  _embind_register_enum_value__deps: ['$createNamedFunction', '$AsciiToString', '$requireRegisteredType'],
   _embind_register_enum_value: (rawEnumType, name, enumValue) => {
     var enumType = requireRegisteredType(rawEnumType, 'enum');
-    name = readLatin1String(name);
+    name = AsciiToString(name);
 
     var Enum = enumType.constructor;
 
@@ -2309,9 +2309,9 @@ var LibraryEmbind = {
     Enum[name] = Value;
   },
 
-  _embind_register_constant__deps: ['$readLatin1String', '$whenDependentTypesAreResolved'],
+  _embind_register_constant__deps: ['$AsciiToString', '$whenDependentTypesAreResolved'],
   _embind_register_constant: (name, type, value) => {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     whenDependentTypesAreResolved([], [type], (type) => {
       type = type[0];
       Module[name] = type['fromWireType'](value);

--- a/src/lib/libembind_gen.js
+++ b/src/lib/libembind_gen.js
@@ -481,17 +481,17 @@ var LibraryEmbind = {
   },
   $registerPrimitiveType__deps: ['$registerType', '$PrimitiveType'],
   $registerPrimitiveType: (id, name, destructorType) => {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     registerType(id, new PrimitiveType(id, name, destructorType));
   },
   $registerIntegerType__deps: ['$registerType', '$IntegerType'],
   $registerIntegerType: (id) => {
     registerType(id, new IntegerType(id));
   },
-  $createFunctionDefinition__deps: ['$FunctionDefinition', '$heap32VectorToArray', '$readLatin1String', '$Argument', '$whenDependentTypesAreResolved', '$getFunctionName', '$getFunctionArgsName', '$PointerDefinition', '$ClassDefinition'],
+  $createFunctionDefinition__deps: ['$FunctionDefinition', '$heap32VectorToArray', '$AsciiToString', '$Argument', '$whenDependentTypesAreResolved', '$getFunctionName', '$getFunctionArgsName', '$PointerDefinition', '$ClassDefinition'],
   $createFunctionDefinition: (name, argCount, rawArgTypesAddr, functionIndex, hasThis, isNonnullReturn, isAsync, cb) => {
     const argTypes = heap32VectorToArray(argCount, rawArgTypesAddr);
-    name = typeof name === 'string' ? name : readLatin1String(name);
+    name = typeof name === 'string' ? name : AsciiToString(name);
 
     whenDependentTypesAreResolved([], argTypes, function (argTypes) {
       const argsName = getFunctionArgsName(name);
@@ -556,9 +556,9 @@ var LibraryEmbind = {
   _embind_register_emval: (rawType) => {
     registerType(rawType, new PrimitiveType(rawType, 'emscripten::val', 'none'));
   },
-  _embind_register_user_type__deps: ['$registerType', '$readLatin1String', '$UserType'],
+  _embind_register_user_type__deps: ['$registerType', '$AsciiToString', '$UserType'],
   _embind_register_user_type: (rawType, name) => {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     registerType(rawType, new UserType(rawType, name));
   },
   _embind_register_optional__deps: ['$OptionalType'],
@@ -577,7 +577,7 @@ var LibraryEmbind = {
       moduleDefinitions.push(funcDef);
     });
   },
-  _embind_register_class__deps: ['$readLatin1String', '$ClassDefinition', '$whenDependentTypesAreResolved', '$moduleDefinitions', '$PointerDefinition'],
+  _embind_register_class__deps: ['$AsciiToString', '$ClassDefinition', '$whenDependentTypesAreResolved', '$moduleDefinitions', '$PointerDefinition'],
   _embind_register_class: function(rawType,
                                   rawPointerType,
                                   rawConstPointerType,
@@ -591,7 +591,7 @@ var LibraryEmbind = {
                                   name,
                                   destructorSignature,
                                   rawDestructor) {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     whenDependentTypesAreResolved(
       [rawType, rawPointerType, rawConstPointerType],
       baseClassRawType ? [baseClassRawType] : [],
@@ -641,7 +641,7 @@ var LibraryEmbind = {
     });
   },
   _embind_register_class_property__deps: [
-    '$readLatin1String', '$whenDependentTypesAreResolved', '$ClassProperty'],
+    '$AsciiToString', '$whenDependentTypesAreResolved', '$ClassProperty'],
   _embind_register_class_property: function(classType,
                                             fieldName,
                                             getterReturnType,
@@ -652,7 +652,7 @@ var LibraryEmbind = {
                                             setterSignature,
                                             setter,
                                             setterContext) {
-    fieldName = readLatin1String(fieldName);
+    fieldName = AsciiToString(fieldName);
     const readonly = setter === 0;
     if (!(readonly || getterReturnType === setterArgumentType)) {
       throw new error('Mismatched getter and setter types are not supported.');
@@ -687,7 +687,7 @@ var LibraryEmbind = {
     });
   },
   _embind_register_class_class_property__deps: [
-    '$readLatin1String', '$whenDependentTypesAreResolved', '$ClassProperty'],
+    '$AsciiToString', '$whenDependentTypesAreResolved', '$ClassProperty'],
   _embind_register_class_class_property: (rawClassType,
                                           fieldName,
                                           rawFieldType,
@@ -696,7 +696,7 @@ var LibraryEmbind = {
                                           getter,
                                           setterSignature,
                                           setter) => {
-    fieldName = readLatin1String(fieldName);
+    fieldName = AsciiToString(fieldName);
     whenDependentTypesAreResolved([], [rawClassType], function(classType) {
       classType = classType[0];
       whenDependentTypesAreResolved([], [rawFieldType], function(types) {
@@ -709,22 +709,22 @@ var LibraryEmbind = {
   },
   // Stub function. This is called a when extending an object and not needed for TS generation.
   _embind_create_inheriting_constructor: (constructorName, wrapperType, properties) => {},
-  _embind_register_enum__deps: ['$readLatin1String', '$EnumDefinition', '$moduleDefinitions'],
+  _embind_register_enum__deps: ['$AsciiToString', '$EnumDefinition', '$moduleDefinitions'],
   _embind_register_enum: function(rawType, name, size, isSigned) {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     const enumDef = new EnumDefinition(rawType, name);
     registerType(rawType, enumDef);
     moduleDefinitions.push(enumDef);
   },
-  _embind_register_enum_value__deps: ['$readLatin1String', '$requireRegisteredType'],
+  _embind_register_enum_value__deps: ['$AsciiToString', '$requireRegisteredType'],
   _embind_register_enum_value: function(rawEnumType, name, enumValue) {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     const enumDef = requireRegisteredType(rawEnumType, name);
     enumDef.items.push([name, enumValue]);
   },
-  _embind_register_constant__deps: ['$readLatin1String', '$ConstantDefinition', '$whenDependentTypesAreResolved', '$moduleDefinitions'],
+  _embind_register_constant__deps: ['$AsciiToString', '$ConstantDefinition', '$whenDependentTypesAreResolved', '$moduleDefinitions'],
   _embind_register_constant: function(name, typeId, value) {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     whenDependentTypesAreResolved([], [typeId], function(types) {
       const def = new ConstantDefinition(types[0], name);
       moduleDefinitions.push(def);
@@ -732,7 +732,7 @@ var LibraryEmbind = {
     });
   },
   _embind_register_value_array__deps: [
-    '$readLatin1String', '$ValueArrayDefinition', '$tupleRegistrations'],
+    '$AsciiToString', '$ValueArrayDefinition', '$tupleRegistrations'],
   _embind_register_value_array: function(
     rawType,
     name,
@@ -741,7 +741,7 @@ var LibraryEmbind = {
     destructorSignature,
     rawDestructor
   ) {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     const valueArray = new ValueArrayDefinition(rawType, name);
     tupleRegistrations[rawType] = valueArray;
   },
@@ -774,7 +774,7 @@ var LibraryEmbind = {
       return [valueArray];
     });
   },
-  _embind_register_value_object__deps: ['$readLatin1String', '$ValueObjectDefinition', '$structRegistrations'],
+  _embind_register_value_object__deps: ['$AsciiToString', '$ValueObjectDefinition', '$structRegistrations'],
   _embind_register_value_object: function(
     rawType,
     name,
@@ -783,12 +783,12 @@ var LibraryEmbind = {
     destructorSignature,
     rawDestructor
   ) {
-    name = readLatin1String(name);
+    name = AsciiToString(name);
     const valueObject = new ValueObjectDefinition(rawType, name);
     structRegistrations[rawType] = valueObject;
   },
   _embind_register_value_object_field__deps: [
-    '$readLatin1String', '$structRegistrations'],
+    '$AsciiToString', '$structRegistrations'],
   _embind_register_value_object_field: function(
     structType,
     fieldName,
@@ -807,7 +807,7 @@ var LibraryEmbind = {
     }
 
     valueObject.fieldTypeIds.push(getterReturnType);
-    valueObject.fieldNames.push(readLatin1String(fieldName));
+    valueObject.fieldNames.push(AsciiToString(fieldName));
   },
   _embind_finalize_value_object__deps: ['$moduleDefinitions', '$whenDependentTypesAreResolved', '$structRegistrations'],
   _embind_finalize_value_object: function(structType) {

--- a/src/lib/libembind_shared.js
+++ b/src/lib/libembind_shared.js
@@ -93,29 +93,10 @@ var LibraryEmbindShared = {
     }
   },
 
-  $embind_charCodes__deps: ['$embind_init_charCodes'],
-  $embind_charCodes__postset: "embind_init_charCodes()",
-  $embind_charCodes: undefined,
-  $embind_init_charCodes: () => {
-    var codes = new Array(256);
-    for (var i = 0; i < 256; ++i) {
-        codes[i] = String.fromCharCode(i);
-    }
-    embind_charCodes = codes;
-  },
-  $readLatin1String__deps: ['$embind_charCodes'],
-  $readLatin1String: (ptr) => {
-    var ret = "";
-    var c = ptr;
-    while (HEAPU8[c]) {
-        ret += embind_charCodes[HEAPU8[c++]];
-    }
-    return ret;
-  },
-  $getTypeName__deps: ['$readLatin1String', '__getTypeName', 'free'],
+  $getTypeName__deps: ['$AsciiToString', '__getTypeName', 'free'],
   $getTypeName: (type) => {
     var ptr = ___getTypeName(type);
-    var rv = readLatin1String(ptr);
+    var rv = AsciiToString(ptr);
     _free(ptr);
     return rv;
   },

--- a/src/lib/libemval.js
+++ b/src/lib/libemval.js
@@ -6,7 +6,7 @@
 /*global Module:true, Runtime*/
 /*global HEAP32*/
 /*global createNamedFunction*/
-/*global readLatin1String, stringToUTF8*/
+/*global AsciiToString, stringToUTF8*/
 /*global requireRegisteredType, throwBindingError, runDestructors*/
 /*jslint sub:true*/ /* The symbols 'fromWireType' and 'toWireType' must be accessed via array notation to be closure-safe since craftInvokerFunction crafts functions as strings that can't be closured. */
 
@@ -42,16 +42,16 @@ var LibraryEmVal = {
     return emval_handles.length / 2 - {{{ EMVAL_RESERVED_HANDLES }}} - emval_freelist.length;
   },
 
-  _emval_register_symbol__deps: ['$emval_symbols', '$readLatin1String'],
+  _emval_register_symbol__deps: ['$emval_symbols', '$AsciiToString'],
   _emval_register_symbol: (address) => {
-    emval_symbols[address] = readLatin1String(address);
+    emval_symbols[address] = AsciiToString(address);
   },
 
-  $getStringOrSymbol__deps: ['$emval_symbols', '$readLatin1String'],
+  $getStringOrSymbol__deps: ['$emval_symbols', '$AsciiToString'],
   $getStringOrSymbol: (address) => {
     var symbol = emval_symbols[address];
     if (symbol === undefined) {
-      return readLatin1String(address);
+      return AsciiToString(address);
     }
     return symbol;
   },

--- a/test/code_size/embind_hello_wasm.json
+++ b/test/code_size/embind_hello_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 380,
-  "a.js": 8657,
-  "a.js.gz": 3835,
+  "a.js": 8609,
+  "a.js.gz": 3806,
   "a.wasm": 7344,
   "a.wasm.gz": 3368,
-  "total": 16553,
-  "total_gz": 7583
+  "total": 16505,
+  "total_gz": 7554
 }

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 380,
-  "a.js": 6514,
-  "a.js.gz": 2827,
+  "a.js": 6469,
+  "a.js.gz": 2800,
   "a.wasm": 9137,
   "a.wasm.gz": 4700,
-  "total": 16203,
-  "total_gz": 7907
+  "total": 16158,
+  "total_gz": 7880
 }


### PR DESCRIPTION
Embind had its own read readLatin1String, which is functionally identical to the AsciiToString helper we have in the shared libstrings library.

The only difference is that It had extra logic for caching characters by code, which are likely not even an optimisation in modern JIT engines, and if we do want to do that in the future for some reason, it's best to do so in centralised helpers.

For now, a simple search-replace gives an easy win in terms of code size.