### PR TITLE
Fix crash in getifaddrs

### DIFF
--- a/src/lib/libsockfs.js
+++ b/src/lib/libsockfs.js
@@ -44,7 +44,15 @@ addToLibrary({
       return FS.createNode(null, '/', {{{ cDefs.S_IFDIR | 0o777 }}}, 0);
     },
     createSocket(family, type, protocol) {
+      // Emscripten only supports AF_INET
+      if (family != {{{ cDefs.AF_INET }}}) {
+        throw new FS.ErrnoError({{{ cDefs.EAFNOSUPPORT }}});
+      }
       type &= ~{{{ cDefs.SOCK_CLOEXEC | cDefs.SOCK_NONBLOCK }}}; // Some applications may pass it; it makes no sense for a single process.
+      // Emscripten only supports SOCK_STREAM and SOCK_DGRAM
+      if (type != {{{ cDefs.SOCK_STREAM }}} && type != {{{ cDefs.SOCK_DGRAM }}}) {
+        throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
+      }
       var streaming = type == {{{ cDefs.SOCK_STREAM }}};
       if (streaming && protocol && protocol != {{{ cDefs.IPPROTO_TCP }}}) {
         throw new FS.ErrnoError({{{ cDefs.EPROTONOSUPPORT }}}); // if SOCK_STREAM, must be tcp or 0.

--- a/test/other/test_getifaddrs.c
+++ b/test/other/test_getifaddrs.c
@@ -1,0 +1,12 @@
+#include <sys/types.h>
+#include <ifaddrs.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+
+int main() {
+   struct ifaddrs* ifaddrs = NULL;
+   int rtn = getifaddrs(&ifaddrs);
+   printf("getifaddrs => %d (%s)\n", rtn, strerror(errno));
+   return 0;
+}

--- a/test/other/test_getifaddrs.out
+++ b/test/other/test_getifaddrs.out
@@ -1,0 +1,1 @@
+getifaddrs => -1 (Address family not supported by protocol)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -16092,3 +16092,6 @@ addToLibrary({
       }
     ''')
     self.do_runf('main.c')
+
+  def test_getifaddrs(self):
+    self.do_other_test('test_getifaddrs.c')


### PR DESCRIPTION
We don't support `AF_NETLINK` sockets so just fail early here.

Replaces #24187