### PR TITLE
Unify legacy dyncall mechanisms

### DIFF
--- a/site/source/docs/compiling/Modularized-Output.rst
+++ b/site/source/docs/compiling/Modularized-Output.rst
@@ -126,10 +126,6 @@ fix in future releses.  Current limitations include:
 * :ref:`abort_on_wasm_exceptions` is not supported (requires wrapping wasm
   exports).
 
-* :ref:`dyncalls` is not supported (depends on the ``Module`` global)
-
-* :ref:`asyncify` is not supported (depends on :ref:`dyncalls`)
-
 * :ref:`asyncify_lazy_load_code` is not supported (depends on ``wasmExports``
   global)
 
@@ -171,6 +167,10 @@ This setting implicitly enables :ref:`export_es6` and sets :ref:`MODULARIZE` to
 Some additional limitations are:
 
 - ``-pthread`` / :ref:`wasm_workers` are not yet supported.
+
+* :ref:`dyncalls` is not supported (depends on the ``Module`` global)
+
+* :ref:`asyncify` is not supported (depends on :ref:`dyncalls`)
 
 - Setting :ref:`wasm` to ``0`` is not supported.
 

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1729,25 +1729,13 @@ addToLibrary({
   },
 
 #if DYNCALLS || !WASM_BIGINT
-#if MINIMAL_RUNTIME
-  $dynCalls: '{}',
-#endif
-  $dynCallLegacy__deps: [
-#if MINIMAL_RUNTIME
-    '$dynCalls',
-#endif
-#if MODULARIZE == 'instance'
-    () => error('dynCallLegacy is not yet compatible with MODULARIZE=instance'),
-#endif
-  ],
+  $dynCalls__internal: true,
+  $dynCalls: {},
+  $dynCallLegacy__deps: ['$dynCalls'],
   $dynCallLegacy: (sig, ptr, args) => {
     sig = sig.replace(/p/g, {{{ MEMORY64 ? "'j'" : "'i'" }}})
 #if ASSERTIONS
-#if MINIMAL_RUNTIME
     assert(sig in dynCalls, `bad function pointer type - sig is not in dynCalls: '${sig}'`);
-#else
-    assert(('dynCall_' + sig) in Module, `bad function pointer type - dynCall function not found for sig '${sig}'`);
-#endif
     if (args?.length) {
 #if WASM_BIGINT
       // j (64-bit integer) is fine, and is implemented as a BigInt. Without
@@ -1762,11 +1750,7 @@ addToLibrary({
       assert(sig.length == 1);
     }
 #endif
-#if MINIMAL_RUNTIME
     var f = dynCalls[sig];
-#else
-    var f = Module['dynCall_' + sig];
-#endif
     return f(ptr, ...args);
   },
 #if DYNCALLS

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -212,8 +212,6 @@ def with_asyncify_and_jspi(f):
       self.require_jspi()
     else:
       self.set_setting('ASYNCIFY')
-      if self.get_setting('MODULARIZE') == 'instance':
-        self.skipTest('MODULARIZE=instance is not compatible with ASYNCIFY=1')
     f(self, *args, **kwargs)
 
   parameterize(metafunc, {'': (False,),
@@ -233,8 +231,6 @@ def also_with_asyncify_and_jspi(f):
       self.require_jspi()
     elif asyncify == 1:
       self.set_setting('ASYNCIFY')
-      if self.get_setting('MODULARIZE') == 'instance':
-        self.skipTest('MODULARIZE=instance is not compatible with ASYNCIFY=1')
     else:
       assert asyncify == 0
     f(self, *args, **kwargs)
@@ -1885,7 +1881,7 @@ int main() {
     self.set_setting('RETAIN_COMPILER_SETTINGS')
     self.do_runf(src, read_file(output).replace('waka', utils.EMSCRIPTEN_VERSION))
 
-  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
+  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
   def test_emscripten_has_asyncify(self):
     src = r'''
       #include <stdio.h>
@@ -7024,7 +7020,7 @@ void* operator new(size_t size) {
     self.do_core_test('EXPORTED_RUNTIME_METHODS.c')
 
   @also_with_minimal_runtime
-  @no_modularize_instance('uses dynCallLegacy')
+  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with DYNCALLS')
   def test_dyncall_specific(self):
     if self.get_setting('WASM_BIGINT') != 0 and not self.is_wasm2js():
       # define DYNCALLS because this test does test calling them directly, and
@@ -7051,8 +7047,8 @@ void* operator new(size_t size) {
     'legacy': (['-sDYNCALLS'],),
   })
   def test_dyncall_pointers(self, args):
-    if args:
-      self.skipTest('dynCallLegacy is not yet compatible with WASM_ESM_INTEGRATION')
+    if args and self.get_setting('WASM_ESM_INTEGRATION'):
+      self.skipTest('WASM_ESM_INTEGRATION is not compatible with DYNCALLS')
     self.do_core_test('test_dyncall_pointers.c', emcc_args=args)
 
   @also_with_wasm_bigint
@@ -8068,7 +8064,7 @@ void* operator new(size_t size) {
 
   # Test async sleeps in the presence of invoke_* calls, which can happen with
   # longjmp or exceptions.
-  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
+  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
   def test_asyncify_longjmp(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('STRICT')
@@ -8128,7 +8124,7 @@ int main() {
     self.do_runf('main.c', 'hello 0\nhello 1\nhello 2\nhello 3\nhello 4\n')
 
   @requires_v8
-  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
+  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
   def test_async_hello_v8(self):
     self.test_async_hello()
 
@@ -8233,7 +8229,7 @@ Module.onRuntimeInitialized = () => {
     self.emcc_args += ['--pre-js', 'pre.js']
     self.do_runf('main.c', 'stringf: first\nsecond\n6.4')
 
-  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
+  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
   def test_fibers_asyncify(self):
     self.set_setting('ASYNCIFY')
     self.maybe_closure()
@@ -8244,7 +8240,7 @@ Module.onRuntimeInitialized = () => {
     # test a program not using asyncify, but the pref is set
     self.do_core_test('test_hello_world.c')
 
-  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
+  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
   @parameterized({
     'normal': ([], True),
     'removelist_a': (['-sASYNCIFY_REMOVE=["foo(int, double)"]'], False),
@@ -8292,7 +8288,7 @@ Module.onRuntimeInitialized = () => {
     # virt() manually, rather than have them inferred automatically.
     'add_no_prop': (['-sASYNCIFY_IGNORE_INDIRECT', '-sASYNCIFY_ADD=["__original_main","main","virt()"]', '-sASYNCIFY_PROPAGATE_ADD=0'], True),
   })
-  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
+  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
   def test_asyncify_indirect_lists(self, args, should_pass):
     self.set_setting('ASYNCIFY')
     self.emcc_args += args
@@ -8310,7 +8306,7 @@ Module.onRuntimeInitialized = () => {
         raise
 
   @with_dylink_reversed
-  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
+  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
   def test_asyncify_side_module(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('ASYNCIFY_IMPORTS', ['my_sleep'])
@@ -8340,12 +8336,12 @@ Module.onRuntimeInitialized = () => {
     ''', 'before sleep\n42\n42\nafter sleep\n', header='void my_sleep(int);', force_c=True)
 
   @no_asan('asyncify stack operations confuse asan')
-  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
+  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
   def test_emscripten_scan_registers(self):
     self.set_setting('ASYNCIFY')
     self.do_core_test('test_emscripten_scan_registers.cpp')
 
-  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
+  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
   def test_asyncify_assertions(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('ASYNCIFY_IMPORTS', ['suspend'])
@@ -8354,7 +8350,7 @@ Module.onRuntimeInitialized = () => {
 
   @no_lsan('leaks asyncify stack during exit')
   @no_asan('leaks asyncify stack during exit')
-  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
+  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
   def test_asyncify_during_exit(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('ASSERTIONS')

--- a/tools/link.py
+++ b/tools/link.py
@@ -800,6 +800,10 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       exit_with_error('WASM_ESM_INTEGRATION requires MODULARIZE=instance')
     if settings.RELOCATABLE:
       exit_with_error('WASM_ESM_INTEGRATION is not compatible with dynamic linking')
+    if settings.ASYNCIFY == 1:
+      exit_with_error('WASM_ESM_INTEGRATION is not compatible with -sASYNCIFY=1')
+    if settings.DYNCALLS:
+      exit_with_error('WASM_ESM_INTEGRATION is not compatible with DYNCALLS')
     if settings.WASM_WORKERS or settings.PTHREADS:
       exit_with_error('WASM_ESM_INTEGRATION is not compatible with multi-threading')
     if settings.USE_OFFSET_CONVERTER:
@@ -832,10 +836,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       exit_with_error('MODULARIZE=instance requires EXPORT_ES6')
     if settings.ABORT_ON_WASM_EXCEPTIONS:
       exit_with_error('MODULARIZE=instance is not compatible with ABORT_ON_WASM_EXCEPTIONS')
-    if settings.ASYNCIFY == 1:
-      exit_with_error('MODULARIZE=instance is not compatible with -sASYNCIFY=1')
-    if settings.DYNCALLS:
-      exit_with_error('MODULARIZE=instance is not compatible with -sDYNCALLS')
     if settings.ASYNCIFY_LAZY_LOAD_CODE:
       exit_with_error('MODULARIZE=instance is not compatible with -sASYNCIFY_LAZY_LOAD_CODE')
     if settings.MINIMAL_RUNTIME:


### PR DESCRIPTION
With this change we use the MINIMAL_RUNTIME technique in all cases.

That is, dyncall functions are stored in a global `dynCalls` object that maps signatures to functions.  Previously we were relying on the `dynCall_xx` helpers existing on the `Module` object.

This allows `-sMODULARIZE=instance` to work with `-sDYNCALL` and by extension with `-sASYNCIFY=1`.