### PR TITLE
[MODULARIZE=instance] Enable ABORT_ON_WASM_EXCEPTIONS. NFC

### DIFF
--- a/site/source/docs/compiling/Modularized-Output.rst
+++ b/site/source/docs/compiling/Modularized-Output.rst
@@ -123,9 +123,6 @@ fix in future releses.  Current limitations include:
 
 * `ccall`/`cwrap` are not supported (depends on the ``Module`` global).
 
-* :ref:`abort_on_wasm_exceptions` is not supported (requires wrapping wasm
-  exports).
-
 * :ref:`dyncalls` is not supported (depends on the ``Module`` global)
 
 * :ref:`asyncify` is not supported (depends on :ref:`dyncalls`)
@@ -170,11 +167,14 @@ This setting implicitly enables :ref:`export_es6` and sets :ref:`MODULARIZE` to
 
 Some additional limitations are:
 
-- ``-pthread`` / :ref:`wasm_workers` are not yet supported.
+* ``-pthread`` / :ref:`wasm_workers` are not yet supported.
 
-- Setting :ref:`wasm` to ``0`` is not supported.
+* :ref:`abort_on_wasm_exceptions` is not supported (requires wrapping wasm
+  exports).
 
-- Setting :ref:`wasm_async_compilation` to ``0`` is not supported.
+* Setting :ref:`wasm` to ``0`` is not supported.
+
+* Setting :ref:`wasm_async_compilation` to ``0`` is not supported.
 
 
 .. _Source phase imports: https://github.com/tc39/proposal-source-phase-imports

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6954,7 +6954,7 @@ void* operator new(size_t size) {
   ### Integration tests
 
   @crossplatform
-  @no_modularize_instance('ccall is not compatible with WASM_ESM_INTEGRATION')
+  @no_modularize_instance('ccall is not compatible with MODULARIZE=instance')
   def test_ccall(self):
     self.emcc_args.append('-Wno-return-stack-address')
     self.set_setting('EXPORTED_RUNTIME_METHODS', ['ccall', 'cwrap', 'STACK_SIZE'])
@@ -6999,7 +6999,7 @@ void* operator new(size_t size) {
     if self.maybe_closure():
       self.do_core_test('test_ccall.cpp')
 
-  @no_modularize_instance('ccall is not compatible with WASM_ESM_INTEGRATION')
+  @no_modularize_instance('ccall is not compatible with MODULARIZE=instance')
   def test_ccall_cwrap_fast_path(self):
     self.emcc_args.append('-Wno-return-stack-address')
     self.set_setting('EXPORTED_RUNTIME_METHODS', ['ccall', 'cwrap'])
@@ -8132,7 +8132,7 @@ int main() {
   def test_async_hello_v8(self):
     self.test_async_hello()
 
-  @no_modularize_instance('ccall is not compatible with WASM_ESM_INTEGRATION')
+  @no_modularize_instance('ccall is not compatible with MODULARIZE=instance')
   def test_async_ccall_bad(self):
     # check bad ccall use
     # needs to flush stdio streams
@@ -8164,7 +8164,7 @@ Module.onRuntimeInitialized = () => {
     self.do_runf('main.c', 'The call to main is running asynchronously.')
 
   @with_asyncify_and_jspi
-  @no_modularize_instance('ccall is not compatible with WASM_ESM_INTEGRATION')
+  @no_modularize_instance('ccall is not compatible with MODULARIZE=instance')
   def test_async_ccall_good(self):
     # check reasonable ccall use
     self.set_setting('ASYNCIFY')
@@ -8193,7 +8193,7 @@ Module.onRuntimeInitialized = () => {
     'exit_runtime': (True,),
   })
   @with_asyncify_and_jspi
-  @no_modularize_instance('ccall is not compatible with WASM_ESM_INTEGRATION')
+  @no_modularize_instance('ccall is not compatible with MODULARIZE=instance')
   def test_async_ccall_promise(self, exit_runtime):
     if self.get_setting('ASYNCIFY') == 2:
       self.set_setting('JSPI_EXPORTS', ['stringf', 'floatf'])
@@ -9544,7 +9544,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_core_test('test_stack_get_free.c')
 
   # Tests settings.ABORT_ON_WASM_EXCEPTIONS
-  @no_modularize_instance('ABORT_ON_WASM_EXCEPTIONS')
+  @no_modularize_instance('ccall is not compatible with MODULARIZE=instance')
   def test_abort_on_exceptions(self):
     self.set_setting('ABORT_ON_WASM_EXCEPTIONS')
     self.set_setting('ALLOW_TABLE_GROWTH')
@@ -9553,7 +9553,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args += ['-lembind', '--post-js', test_file('core/test_abort_on_exceptions_post.js')]
     self.do_core_test('test_abort_on_exceptions.cpp', interleaved_output=False)
 
-  @no_modularize_instance('ABORT_ON_WASM_EXCEPTIONS')
+  @no_esm_integration('ABORT_ON_WASM_EXCEPTIONS is not compatible with WASM_ESM_INTEGRATION')
   def test_abort_on_exceptions_main(self):
     # The unhandled exception wrappers should not kick in for exceptions thrown during main
     self.set_setting('ABORT_ON_WASM_EXCEPTIONS')
@@ -9567,7 +9567,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @node_pthreads
   @flaky('https://github.com/emscripten-core/emscripten/issues/20067')
-  @no_modularize_instance('ABORT_ON_WASM_EXCEPTIONS')
+  @no_esm_integration('ABORT_ON_WASM_EXCEPTIONS is not compatible with WASM_ESM_INTEGRATION')
   def test_abort_on_exceptions_pthreads(self):
     self.set_setting('ABORT_ON_WASM_EXCEPTIONS')
     self.set_setting('PROXY_TO_PTHREAD')

--- a/tools/link.py
+++ b/tools/link.py
@@ -810,6 +810,8 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       exit_with_error('WASM_ESM_INTEGRATION is not compatible with WASM2JS')
     if settings.MAYBE_WASM2JS:
       exit_with_error('WASM_ESM_INTEGRATION is not compatible with MAYBE_WASM2JS')
+    if settings.ABORT_ON_WASM_EXCEPTIONS:
+      exit_with_error('WASM_ESM_INTEGRATION is not compatible with ABORT_ON_WASM_EXCEPTIONS')
 
   if settings.MODULARIZE and settings.MODULARIZE not in [1, 'instance']:
     exit_with_error(f'Invalid setting "{settings.MODULARIZE}" for MODULARIZE.')
@@ -830,8 +832,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     diagnostics.warning('experimental', 'MODULARIZE=instance is still experimental. Many features may not work or will change.')
     if not settings.EXPORT_ES6:
       exit_with_error('MODULARIZE=instance requires EXPORT_ES6')
-    if settings.ABORT_ON_WASM_EXCEPTIONS:
-      exit_with_error('MODULARIZE=instance is not compatible with ABORT_ON_WASM_EXCEPTIONS')
     if settings.ASYNCIFY == 1:
       exit_with_error('MODULARIZE=instance is not compatible with -sASYNCIFY=1')
     if settings.DYNCALLS:


### PR DESCRIPTION
Turns out this works already in `MODULARIZE=instance` mode but not in `WASM_ESM_INTEGRATION` mode.