### PR TITLE
Set MIN_x_VERSION as unsupported when not targeting ENVIRONMENT

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -171,6 +171,18 @@ def setup_environment_settings():
   settings.ENVIRONMENT_MAY_BE_NODE = not settings.ENVIRONMENT or 'node' in environments
   settings.ENVIRONMENT_MAY_BE_SHELL = not settings.ENVIRONMENT or 'shell' in environments
 
+  if not settings.ENVIRONMENT_MAY_BE_NODE:
+    if 'MIN_NODE_VERSION' in user_settings:
+      diagnostics.warning('unused-command-line-argument', 'ignoring MIN_NODE_VERSION because `node` environment is not enabled')
+    settings.MIN_NODE_VERSION = feature_matrix.UNSUPPORTED
+
+  if not (settings.ENVIRONMENT_MAY_BE_WEB or settings.ENVIRONMENT_MAY_BE_WEBVIEW):
+    for browser in ('FIREFOX', 'SAFARI', 'CHROME'):
+      key = f'MIN_{browser}_VERSION'
+      if key in user_settings:
+        diagnostics.warning('unused-command-line-argument', 'ignoring %s because `web` and `webview` environments are not enabled', key)
+      settings[key] = feature_matrix.UNSUPPORTED
+
   # The worker case also includes Node.js workers when pthreads are
   # enabled and Node.js is one of the supported environments for the build to
   # run on. Node.js workers are detected as a combination of

--- a/tools/link.py
+++ b/tools/link.py
@@ -2053,8 +2053,7 @@ def run_embind_gen(options, wasm_target, js_syms, extra_settings):
     dirname, basename = os.path.split(lib)
     if basename == 'libembind.js':
       settings.JS_LIBRARIES[i] = os.path.join(dirname, 'libembind_gen.js')
-  if settings.MEMORY64:
-    settings.MIN_NODE_VERSION = 160000
+  settings.MIN_NODE_VERSION = 160000 if settings.MEMORY64 else 150000
   # Source maps haven't been generated yet and aren't needed to run embind_gen.
   settings.LOAD_SOURCE_MAP = 0
   outfile_js = in_temp('tsgen.js')


### PR DESCRIPTION
If `ENVIRONMENT` doesn't contain `node`, treat `MIN_NODE_VERSION` as unsupported, and vice versa - if `ENVIRONMENT` only contains `node`, treat all browser `MIN_*_VERSION` as unsupported.

Will show a warning if user specified their own `MIN_*_VERSION` despite corresponding environment not being targeted.

Fixes #20561.