### PR TITLE
Fix core3.test_dyncall_pointers_legacy after #24371

### DIFF
--- a/test/js_optimizer/applyDCEGraphRemovals-output.js
+++ b/test/js_optimizer/applyDCEGraphRemovals-output.js
@@ -13,11 +13,11 @@ var _expD3 = Module["_expD3"] = wasmExports["expD3"];
 
 var _expD5 = wasmExports["expD5"];
 
-var _expI1 = Module["_expI1"] = () => (expI1 = Module["_expI1"] = wasmExports["expI1"])();
+var _expI1 = Module["_expI1"] = () => (_expI1 = Module["_expI1"] = wasmExports["expI1"])();
 
-var _expI2 = Module["_expI2"] = () => (expI2 = Module["_expI2"] = wasmExports["expI2"])();
+var _expI2 = Module["_expI2"] = () => (_expI2 = Module["_expI2"] = wasmExports["expI2"])();
 
-var _expI3 = Module["_expI3"] = () => (expI3 = Module["_expI3"] = wasmExports["expI3"])();
+var _expI3 = Module["_expI3"] = () => (_expI3 = Module["_expI3"] = wasmExports["expI3"])();
 
 var _expI5 = () => (_expI5 = wasmExports["expI5"])();
 

--- a/test/js_optimizer/applyDCEGraphRemovals.js
+++ b/test/js_optimizer/applyDCEGraphRemovals.js
@@ -15,16 +15,21 @@ var _expD4 = Module['_expD4'] = wasmExports['expD4'];
 // Like above, but not exported on the Module
 var _expD5 = wasmExports['expD5'];
 var _expD6 = wasmExports['expD6'];
+// Exported on Module and dynCalls
+var _expD7 = Module['_expD7'] = dynCalls['iii'] = wasmExports['expD7'];
 
 // exports gotten indirectly (async compilation
-var _expI1 = Module['_expI1'] = () => (expI1 = Module['_expI1'] = wasmExports['expI1'])();
-var _expI2 = Module['_expI2'] = () => (expI2 = Module['_expI2'] = wasmExports['expI2'])();
-var _expI3 = Module['_expI3'] = () => (expI3 = Module['_expI3'] = wasmExports['expI3'])();
-var _expI4 = Module['_expI4'] = () => (expI4 = Module['_expI4'] = wasmExports['expI4'])();
+var _expI1 = Module['_expI1'] = () => (_expI1 = Module['_expI1'] = wasmExports['expI1'])();
+var _expI2 = Module['_expI2'] = () => (_expI2 = Module['_expI2'] = wasmExports['expI2'])();
+var _expI3 = Module['_expI3'] = () => (_expI3 = Module['_expI3'] = wasmExports['expI3'])();
+var _expI4 = Module['_expI4'] = () => (_expI4 = Module['_expI4'] = wasmExports['expI4'])();
 
 // Like above, but not exported on the Module
 var _expI5 = () => (_expI5 = wasmExports['expI5'])();
 var _expI6 = () => (_expI6 = wasmExports['expI6'])();
+
+// Exported on Module and dynCalls
+var _expI7 = Module['_expI7'] = dynCalls['iii'] = () => (_expI7 = Module['_expI7'] = dynCalls['iii'] = wasmExports['expI7'])();
 
 // add uses for some of them, leave *4 as non-roots
 _expD1;
@@ -35,4 +40,4 @@ _expI1;
 Module['_expI2'];
 wasmExports['_expI3'];
 
-// EXTRA_INFO: { "unusedImports": ["number", "name", "func"], "unusedExports": ["expD4", "expD6", "expI4", "expI6"] }
+// EXTRA_INFO: { "unusedImports": ["number", "name", "func"], "unusedExports": ["expD4", "expD6", "expD7", "expI4", "expI6", "expI7"] }


### PR DESCRIPTION
I mistakenly landed #24371 without waiting for all tests to pass. It turns out that adding the extra `dynCalls` assignment interfered with the assumption in `applyDCEGraphRemovals`.