### PR TITLE
Revert "Unify legacy dyncall mechanisms"

### DIFF
--- a/site/source/docs/compiling/Modularized-Output.rst
+++ b/site/source/docs/compiling/Modularized-Output.rst
@@ -126,6 +126,10 @@ fix in future releses.  Current limitations include:
 * :ref:`abort_on_wasm_exceptions` is not supported (requires wrapping wasm
   exports).
 
+* :ref:`dyncalls` is not supported (depends on the ``Module`` global)
+
+* :ref:`asyncify` is not supported (depends on :ref:`dyncalls`)
+
 * :ref:`asyncify_lazy_load_code` is not supported (depends on ``wasmExports``
   global)
 
@@ -167,10 +171,6 @@ This setting implicitly enables :ref:`export_es6` and sets :ref:`MODULARIZE` to
 Some additional limitations are:
 
 - ``-pthread`` / :ref:`wasm_workers` are not yet supported.
-
-* :ref:`dyncalls` is not supported (depends on the ``Module`` global)
-
-* :ref:`asyncify` is not supported (depends on :ref:`dyncalls`)
 
 - Setting :ref:`wasm` to ``0`` is not supported.
 

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1729,13 +1729,25 @@ addToLibrary({
   },
 
 #if DYNCALLS || !WASM_BIGINT
-  $dynCalls__internal: true,
-  $dynCalls: {},
-  $dynCallLegacy__deps: ['$dynCalls'],
+#if MINIMAL_RUNTIME
+  $dynCalls: '{}',
+#endif
+  $dynCallLegacy__deps: [
+#if MINIMAL_RUNTIME
+    '$dynCalls',
+#endif
+#if MODULARIZE == 'instance'
+    () => error('dynCallLegacy is not yet compatible with MODULARIZE=instance'),
+#endif
+  ],
   $dynCallLegacy: (sig, ptr, args) => {
     sig = sig.replace(/p/g, {{{ MEMORY64 ? "'j'" : "'i'" }}})
 #if ASSERTIONS
+#if MINIMAL_RUNTIME
     assert(sig in dynCalls, `bad function pointer type - sig is not in dynCalls: '${sig}'`);
+#else
+    assert(('dynCall_' + sig) in Module, `bad function pointer type - dynCall function not found for sig '${sig}'`);
+#endif
     if (args?.length) {
 #if WASM_BIGINT
       // j (64-bit integer) is fine, and is implemented as a BigInt. Without
@@ -1750,7 +1762,11 @@ addToLibrary({
       assert(sig.length == 1);
     }
 #endif
+#if MINIMAL_RUNTIME
     var f = dynCalls[sig];
+#else
+    var f = Module['dynCall_' + sig];
+#endif
     return f(ptr, ...args);
   },
 #if DYNCALLS

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -212,6 +212,8 @@ def with_asyncify_and_jspi(f):
       self.require_jspi()
     else:
       self.set_setting('ASYNCIFY')
+      if self.get_setting('MODULARIZE') == 'instance':
+        self.skipTest('MODULARIZE=instance is not compatible with ASYNCIFY=1')
     f(self, *args, **kwargs)
 
   parameterize(metafunc, {'': (False,),
@@ -231,6 +233,8 @@ def also_with_asyncify_and_jspi(f):
       self.require_jspi()
     elif asyncify == 1:
       self.set_setting('ASYNCIFY')
+      if self.get_setting('MODULARIZE') == 'instance':
+        self.skipTest('MODULARIZE=instance is not compatible with ASYNCIFY=1')
     else:
       assert asyncify == 0
     f(self, *args, **kwargs)
@@ -1881,7 +1885,7 @@ int main() {
     self.set_setting('RETAIN_COMPILER_SETTINGS')
     self.do_runf(src, read_file(output).replace('waka', utils.EMSCRIPTEN_VERSION))
 
-  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
+  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
   def test_emscripten_has_asyncify(self):
     src = r'''
       #include <stdio.h>
@@ -7020,7 +7024,7 @@ void* operator new(size_t size) {
     self.do_core_test('EXPORTED_RUNTIME_METHODS.c')
 
   @also_with_minimal_runtime
-  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with DYNCALLS')
+  @no_modularize_instance('uses dynCallLegacy')
   def test_dyncall_specific(self):
     if self.get_setting('WASM_BIGINT') != 0 and not self.is_wasm2js():
       # define DYNCALLS because this test does test calling them directly, and
@@ -7047,8 +7051,8 @@ void* operator new(size_t size) {
     'legacy': (['-sDYNCALLS'],),
   })
   def test_dyncall_pointers(self, args):
-    if args and self.get_setting('WASM_ESM_INTEGRATION'):
-      self.skipTest('WASM_ESM_INTEGRATION is not compatible with DYNCALLS')
+    if args:
+      self.skipTest('dynCallLegacy is not yet compatible with WASM_ESM_INTEGRATION')
     self.do_core_test('test_dyncall_pointers.c', emcc_args=args)
 
   @also_with_wasm_bigint
@@ -8064,7 +8068,7 @@ void* operator new(size_t size) {
 
   # Test async sleeps in the presence of invoke_* calls, which can happen with
   # longjmp or exceptions.
-  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
+  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
   def test_asyncify_longjmp(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('STRICT')
@@ -8124,7 +8128,7 @@ int main() {
     self.do_runf('main.c', 'hello 0\nhello 1\nhello 2\nhello 3\nhello 4\n')
 
   @requires_v8
-  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
+  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
   def test_async_hello_v8(self):
     self.test_async_hello()
 
@@ -8229,7 +8233,7 @@ Module.onRuntimeInitialized = () => {
     self.emcc_args += ['--pre-js', 'pre.js']
     self.do_runf('main.c', 'stringf: first\nsecond\n6.4')
 
-  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
+  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
   def test_fibers_asyncify(self):
     self.set_setting('ASYNCIFY')
     self.maybe_closure()
@@ -8240,7 +8244,7 @@ Module.onRuntimeInitialized = () => {
     # test a program not using asyncify, but the pref is set
     self.do_core_test('test_hello_world.c')
 
-  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
+  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
   @parameterized({
     'normal': ([], True),
     'removelist_a': (['-sASYNCIFY_REMOVE=["foo(int, double)"]'], False),
@@ -8288,7 +8292,7 @@ Module.onRuntimeInitialized = () => {
     # virt() manually, rather than have them inferred automatically.
     'add_no_prop': (['-sASYNCIFY_IGNORE_INDIRECT', '-sASYNCIFY_ADD=["__original_main","main","virt()"]', '-sASYNCIFY_PROPAGATE_ADD=0'], True),
   })
-  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
+  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
   def test_asyncify_indirect_lists(self, args, should_pass):
     self.set_setting('ASYNCIFY')
     self.emcc_args += args
@@ -8306,7 +8310,7 @@ Module.onRuntimeInitialized = () => {
         raise
 
   @with_dylink_reversed
-  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
+  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
   def test_asyncify_side_module(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('ASYNCIFY_IMPORTS', ['my_sleep'])
@@ -8336,12 +8340,12 @@ Module.onRuntimeInitialized = () => {
     ''', 'before sleep\n42\n42\nafter sleep\n', header='void my_sleep(int);', force_c=True)
 
   @no_asan('asyncify stack operations confuse asan')
-  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
+  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
   def test_emscripten_scan_registers(self):
     self.set_setting('ASYNCIFY')
     self.do_core_test('test_emscripten_scan_registers.cpp')
 
-  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
+  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
   def test_asyncify_assertions(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('ASYNCIFY_IMPORTS', ['suspend'])
@@ -8350,7 +8354,7 @@ Module.onRuntimeInitialized = () => {
 
   @no_lsan('leaks asyncify stack during exit')
   @no_asan('leaks asyncify stack during exit')
-  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
+  @no_modularize_instance('MODULARIZE=instance is not compatible with ASYNCIFY=1')
   def test_asyncify_during_exit(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('ASSERTIONS')

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -907,15 +907,6 @@ def can_use_await():
   return settings.MODULARIZE
 
 
-def make_dyncall_assignment(sym):
-  if not sym.startswith('dynCall_'):
-    return ''
-  if not settings.DYNCALLS or '$dynCall' not in settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE:
-    return ''
-  sig = sym.replace('dynCall_', '')
-  return f"dynCalls['{sig}'] = "
-
-
 def make_export_wrappers(function_exports):
   assert not settings.MINIMAL_RUNTIME
 
@@ -954,8 +945,6 @@ def make_export_wrappers(function_exports):
     elif should_export:
       exported = "Module['%s'] = " % mangled
       wrapper += exported
-
-    wrapper += make_dyncall_assignment(name)
 
     if settings.ASSERTIONS and install_wrapper(name):
       # With assertions enabled we create a wrapper that are calls get routed through, for
@@ -1006,16 +995,17 @@ def create_receiving(function_exports, tag_exports):
     # var _main;
     # function assignWasmExports(wasmExport) {
     #   _main = wasmExports["_main"];
+    generate_dyncall_assignment = settings.DYNCALLS and '$dynCall' in settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE
     exports = [x for x in function_exports if x != building.WASM_CALL_CTORS]
     receiving.append('function assignWasmExports(wasmExports) {')
     for s in exports:
       mangled = asmjs_mangle(s)
-      dyncall_assignment = make_dyncall_assignment(s)
+      dynCallAssignment = ('dynCalls["' + s.replace('dynCall_', '') + '"] = ') if generate_dyncall_assignment and mangled.startswith('dynCall_') else ''
       should_export = settings.EXPORT_ALL or (settings.EXPORT_KEEPALIVE and mangled in settings.EXPORTED_FUNCTIONS)
       export_assignment = ''
       if settings.MODULARIZE and should_export:
         export_assignment = f"Module['{mangled}'] = "
-      receiving.append(f"  {export_assignment}{dyncall_assignment}{mangled} = wasmExports['{s}'];")
+      receiving.append(f"  {export_assignment}{dynCallAssignment}{mangled} = wasmExports['{s}'];")
     receiving.append('}')
     sep = ',\n  '
     mangled = [asmjs_mangle(s) for s in exports]

--- a/tools/link.py
+++ b/tools/link.py
@@ -800,10 +800,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       exit_with_error('WASM_ESM_INTEGRATION requires MODULARIZE=instance')
     if settings.RELOCATABLE:
       exit_with_error('WASM_ESM_INTEGRATION is not compatible with dynamic linking')
-    if settings.ASYNCIFY == 1:
-      exit_with_error('WASM_ESM_INTEGRATION is not compatible with -sASYNCIFY=1')
-    if settings.DYNCALLS:
-      exit_with_error('WASM_ESM_INTEGRATION is not compatible with DYNCALLS')
     if settings.WASM_WORKERS or settings.PTHREADS:
       exit_with_error('WASM_ESM_INTEGRATION is not compatible with multi-threading')
     if settings.USE_OFFSET_CONVERTER:
@@ -836,6 +832,10 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       exit_with_error('MODULARIZE=instance requires EXPORT_ES6')
     if settings.ABORT_ON_WASM_EXCEPTIONS:
       exit_with_error('MODULARIZE=instance is not compatible with ABORT_ON_WASM_EXCEPTIONS')
+    if settings.ASYNCIFY == 1:
+      exit_with_error('MODULARIZE=instance is not compatible with -sASYNCIFY=1')
+    if settings.DYNCALLS:
+      exit_with_error('MODULARIZE=instance is not compatible with -sDYNCALLS')
     if settings.ASYNCIFY_LAZY_LOAD_CODE:
       exit_with_error('MODULARIZE=instance is not compatible with -sASYNCIFY_LAZY_LOAD_CODE')
     if settings.MINIMAL_RUNTIME:


### PR DESCRIPTION
Reverts emscripten-core/emscripten#24371

Turns out this was failing the core3.test_dyncall_pointers_legacy test.  Will need to revist.