### PR TITLE
Restore test_dyncall_pointers_legacy test. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7051,8 +7051,8 @@ void* operator new(size_t size) {
     'legacy': (['-sDYNCALLS'],),
   })
   def test_dyncall_pointers(self, args):
-    if args:
-      self.skipTest('dynCallLegacy is not yet compatible with WASM_ESM_INTEGRATION')
+    if args and self.get_setting('MODULARIZE') == 'instance' or self.get_setting('WASM_ESM_INTEGRATION'):
+      self.skipTest('dynCallLegacy is not yet compatible with MODULARIZE=instance')
     self.do_core_test('test_dyncall_pointers.c', emcc_args=args)
 
   @also_with_wasm_bigint


### PR DESCRIPTION
I accidentally disabled this unconditionally in #24326