### PR TITLE
[ASYNCIFY] Avoid dependency on the names of exports

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9863,7 +9863,7 @@ core_2gb = make_run('core_2gb', emcc_args=['--profiling-funcs'],
                     settings={'INITIAL_MEMORY': '2200mb', 'GLOBAL_BASE': '2gb'})
 
 # MEMORY64=1
-wasm64 = make_run('wasm64', emcc_args=['-O1', '-Wno-experimental', '--profiling-funcs'],
+wasm64 = make_run('wasm64', emcc_args=['-Wno-experimental', '--profiling-funcs'],
                   settings={'MEMORY64': 1}, require_wasm64=True, require_node=True)
 wasm64_v8 = make_run('wasm64_v8', emcc_args=['-Wno-experimental', '--profiling-funcs'],
                      settings={'MEMORY64': 1}, require_wasm64=True, require_v8=True)

--- a/tools/maint/gen_sig_info.py
+++ b/tools/maint/gen_sig_info.py
@@ -395,6 +395,7 @@ def main(args):
                               'USE_SDL': 0,
                               'MAX_WEBGL_VERSION': 0,
                               'AUTO_JS_LIBRARIES': 0,
+                              'ASYNCIFY_LAZY_LOAD_CODE': 1,
                               'ASYNCIFY': 1}, cxx=True, extra_cflags=['-std=c++20'])
   extract_sig_info(sig_info, {'LEGACY_GL_EMULATION': 1}, ['-DGLES'])
   extract_sig_info(sig_info, {'USE_GLFW': 2, 'FULL_ES3': 1, 'MAX_WEBGL_VERSION': 2})


### PR DESCRIPTION
This change moves from using export names to function identity to track the functions in the resumption stack.

The upside of this is that we can wrap non-exports, such as table entire, which we currently avoid by enabling `-sDYNCALLS` whenever `ASYNCIFY=1` is used.

It also means we can potentially make `ASYNCIFY=1` work with the `wasmExports` global existing (i.e. in `WASM_ESM_INTEGRATION` mode.