### PR TITLE
Mark ASYNCIFY_LAZY_LOAD_CODE as deprecated

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 4.0.10 (in development)
 ----------------------
+- The `-sASYNCIFY_LAZY_LOAD_CODE` setting was deprecated.  This setting was
+  added as an experiment a long time ago and as far we know has no active users.
+  In addition, it cannot work with JSPI (the future of ASYNCIFY). (#24383)
 
 4.0.9 - 05/19/25
 ----------------

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1349,6 +1349,8 @@ ASYNCIFY_LAZY_LOAD_CODE
 Allows lazy code loading: where emscripten_lazy_load_code() is written, we
 will pause execution, load the rest of the code, and then resume.
 
+.. note:: This setting is deprecated
+
 Default value: false
 
 .. _asyncify_debug:

--- a/src/settings.js
+++ b/src/settings.js
@@ -913,6 +913,7 @@ var ASYNCIFY_ADVISE = false;
 // Allows lazy code loading: where emscripten_lazy_load_code() is written, we
 // will pause execution, load the rest of the code, and then resume.
 // [link]
+// [deprecated]
 var ASYNCIFY_LAZY_LOAD_CODE = false;
 
 // Runtime debug logging from asyncify internals.

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8396,7 +8396,7 @@ Module.onRuntimeInitialized = () => {
     self.set_setting('ASYNCIFY_LAZY_LOAD_CODE')
     self.set_setting('ASYNCIFY_IGNORE_INDIRECT')
     self.set_setting('MALLOC', 'emmalloc')
-    self.emcc_args += ['--profiling-funcs'] # so that we can find the functions for the changes below
+    self.emcc_args += ['-Wno-deprecated', '--profiling-funcs'] # so that we can find the functions for the changes below
     if conditional:
       self.emcc_args += ['-DCONDITIONAL']
     self.do_core_test('emscripten_lazy_load_code.c', args=['0'])

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -125,6 +125,7 @@ DEPRECATED_SETTINGS = {
     'LEGALIZE_JS_FFI': 'to disable JS type legalization use `-sWASM_BIGINT` or `-sSTANDALONE_WASM`',
     'ASYNCIFY_EXPORTS': 'please use JSPI_EXPORTS instead',
     'MAYBE_WASM2JS': 'lack of usage',
+    'ASYNCIFY_LAZY_LOAD_CODE': 'lack of usage',
 }
 
 # Settings that don't need to be externalized when serializing to json because they


### PR DESCRIPTION
This setting was added as an experiment a long time ago and as far we know has no active users.