### PR TITLE
[esm-integration] Export embind bindings.

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
   raise Exception('do not run this file directly; do something like: test/runner')
 
 from tools.shared import PIPE
-from tools.shared import EMCC, EMAR, FILE_PACKAGER
+from tools.shared import EMCC, EMAR, EMXX, FILE_PACKAGER
 from tools.utils import WINDOWS, MACOS, LINUX, write_file, delete_file
 from tools import shared, building, config, utils, webassembly
 import common
@@ -9636,11 +9636,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.assertContained('main1\nmain2\nfoo\nbar\nbaz\n', self.run_js('runner.mjs'))
 
   def test_modularize_instance_embind(self):
-    self.run_process([EMCC, test_file('modularize_instance_embind.cpp'),
+    self.run_process([EMXX, test_file('modularize_instance_embind.cpp'),
                       '-sMODULARIZE=instance',
+                      '-Wno-experimental',
                       '-lembind',
                       '-sEMBIND_AOT',
-                      '-o', 'modularize_instance_embind.mjs'])
+                      '-o', 'modularize_instance_embind.mjs'] + self.get_emcc_args())
 
     create_file('runner.mjs', '''
       import init, { foo, Bar } from "./modularize_instance_embind.mjs";

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9635,6 +9635,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
     self.assertContained('main1\nmain2\nfoo\nbar\nbaz\n', self.run_js('runner.mjs'))
 
+  @no_4gb('EMBIND_AOT can\'t lower 4gb')
   def test_modularize_instance_embind(self):
     self.run_process([EMXX, test_file('modularize_instance_embind.cpp'),
                       '-sMODULARIZE=instance',

--- a/tools/link.py
+++ b/tools/link.py
@@ -1996,6 +1996,8 @@ def run_embind_gen(options, wasm_target, js_syms, extra_settings):
   # Ignore -sMODULARIZE which could otherwise effect how we run the module
   # to generate the bindings.
   settings.MODULARIZE = False
+  # Disable ESM integration to avoid enabling the experimental feature in node.
+  settings.WASM_ESM_INTEGRATION = False
   # Don't include any custom user JS or files.
   settings.PRE_JS_FILES = []
   settings.POST_JS_FILES = []
@@ -2078,6 +2080,9 @@ addOnPostCtor(assignEmbindExports);
 // end embind exports'''
     src += exports
   write_file(final_js, src)
+  if settings.WASM_ESM_INTEGRATION:
+    # With ESM integration the embind exports also need to be exported by the main file.
+    settings.EXPORTED_RUNTIME_METHODS.extend(out['publicSymbols'])
 
 
 # for Popen, we cannot have doublequotes, so provide functionality to


### PR DESCRIPTION
Adds the embind bindings to re-export the functions in the support file. As with modularize instance, this requires EMBIND_AOT to work.