### PR TITLE
Fix test runner warning caused by previous commit, and rename calculateDuration() to calculateElapsed() to avoid confusing/overloading similar terms.

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -109,9 +109,11 @@ class BufferedParallelTestResult:
   def test(self):
     return self.buffered_result.test
 
-  def calculateDuration(self):
-    self.test_duration = time.perf_counter() - self.start_time
-    return self.test_duration
+  def addDuration(self, test, elapsed):
+    self.test_duration = elapsed
+
+  def calculateElapsed(self):
+    return time.perf_counter() - self.start_time
 
   def updateResult(self, result):
     result.startTest(self.test)
@@ -130,17 +132,17 @@ class BufferedParallelTestResult:
 
   def addSuccess(self, test):
     if hasattr(time, 'perf_counter'):
-      print(test, '... ok (%.2fs)' % (self.calculateDuration()), file=sys.stderr)
+      print(test, '... ok (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
     self.buffered_result = BufferedTestSuccess(test)
 
   def addExpectedFailure(self, test, err):
     if hasattr(time, 'perf_counter'):
-      print(test, '... expected failure (%.2fs)' % (self.calculateDuration()), file=sys.stderr)
+      print(test, '... expected failure (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
     self.buffered_result = BufferedTestExpectedFailure(test, err)
 
   def addUnexpectedSuccess(self, test):
     if hasattr(time, 'perf_counter'):
-      print(test, '... unexpected success (%.2fs)' % (self.calculateDuration()), file=sys.stderr)
+      print(test, '... unexpected success (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
     self.buffered_result = BufferedTestUnexpectedSuccess(test)
 
   def addSkip(self, test, reason):


### PR DESCRIPTION
I removed the odd stub `addDuration()` function in the previous PR: https://github.com/emscripten-core/emscripten/pull/24396/files#diff-fd5a5983b044aa841287bf197f2b5e46781162bf0e6a0ca8d1ccaddf1cc1c969L110-L111

turns out that Python unit test runner starts to warn if this function is not present.

```
test_sse4 (test_core.strict_js.test_sse4) ... ok (1.14s)
C:\python\Lib\unittest\case.py:580: RuntimeWarning: TestResult has no addDuration method
  warnings.warn("TestResult has no addDuration method",
test_sse4 (test_core.bigint.test_sse4) ... ok (1.10s)
C:\python\Lib\unittest\case.py:580: RuntimeWarning: TestResult has no addDuration method
  warnings.warn("TestResult has no addDuration method",
test_sse4 (test_core.instance.test_sse4) ... ok (1.13s)
C:\python\Lib\unittest\case.py:580: RuntimeWarning: TestResult has no addDuration method
  warnings.warn("TestResult has no addDuration method",
test_sse4 (test_core.core_2gb.test_sse4) ... ok (1.25s)
```

Add it back in, and use it to register the elapsed time in the test (looks like Python internally tracks it).

Rename the `calculateDuration()` function to a `calculateElapsed()` method so it doesn't look too similar to the `addDuration()` one.