### PR TITLE
Fix sysroot installation when emscripten itself is read-only

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -694,7 +694,7 @@ def get_file_suffix(filename):
 
 
 def make_writable(filename):
-  assert os.path.isfile(filename)
+  assert os.path.exists(filename)
   old_mode = stat.S_IMODE(os.stat(filename).st_mode)
   os.chmod(filename, old_mode | stat.S_IWUSR)
 


### PR DESCRIPTION
The resulting header tree need to be at least user-writable so that we can incrementally copy files into it, adding new files and also updating previously copied ones.

Sadly, python's shutil doesn't seem to have any options for disabling the copying of mode bits.

This was originally fixed in #15386 but then regressed in #23417.

Fixes: #24404