### PR TITLE
[embind] Write generated output to a temp file.

### DIFF
--- a/src/lib/libembind_gen.js
+++ b/src/lib/libembind_gen.js
@@ -446,7 +446,7 @@ var LibraryEmbind = {
       if (this.usedEmbindString) {
         out.unshift('type EmbindString = ArrayBuffer|Uint8Array|Uint8ClampedArray|Int8Array|string;\n');
       }
-      console.log(out.join(''));
+      return out.join('');
     }
   },
 
@@ -468,10 +468,10 @@ var LibraryEmbind = {
         def.printJs(out);
       }
       out.push('}\n');
-      console.log(JSON.stringify({
+      return JSON.stringify({
         'invokers': out.join(''),
         publicSymbols,
-      }));
+      });
     }
   },
 
@@ -843,27 +843,27 @@ var LibraryEmbind = {
     });
   },
 
+  $emitOutput__deps: ['$awaitingDependencies', '$throwBindingError', '$getTypeName', '$moduleDefinitions',
 #if EMBIND_AOT
-  $embindEmitAotJs__deps: ['$awaitingDependencies', '$throwBindingError', '$getTypeName', '$moduleDefinitions', '$JsPrinter'],
-  $embindEmitAotJs__postset: () => { addAtPostCtor('embindEmitAotJs()'); },
-  $embindEmitAotJs: () => {
-    for (const typeId in awaitingDependencies) {
-      throwBindingError(`Missing binding for type: '${getTypeName(typeId)}' typeId: ${typeId}`);
-    }
-    const printer = new JsPrinter(moduleDefinitions);
-    printer.print();
-  },
-#else // EMBIND_AOT
-  $embindEmitTypes__deps: ['$awaitingDependencies', '$throwBindingError', '$getTypeName', '$moduleDefinitions', '$TsPrinter'],
-  $embindEmitTypes__postset: () => { addAtPostCtor('embindEmitTypes()'); },
-  $embindEmitTypes: () => {
-    for (const typeId in awaitingDependencies) {
-      throwBindingError(`Missing binding for type: '${getTypeName(typeId)}' typeId: ${typeId}`);
-    }
-    const printer = new TsPrinter(moduleDefinitions);
-    printer.print();
-  },
+    '$JsPrinter',
+#else
+    '$TsPrinter',
 #endif
+  ],
+  $emitOutput__postset: () => { addAtPostCtor('emitOutput()'); },
+  $emitOutput: () => {
+    for (const typeId in awaitingDependencies) {
+      throwBindingError(`Missing binding for type: '${getTypeName(typeId)}' typeId: ${typeId}`);
+    }
+#if EMBIND_AOT
+    const printer = new JsPrinter(moduleDefinitions);
+    #else
+    const printer = new TsPrinter(moduleDefinitions);
+#endif
+    const output = printer.print();
+    var fs = require('fs');
+    fs.writeFileSync(process.argv[2], output + '\n');
+  },
 
   // Stub functions used by eval, but not needed for TS generation:
   $makeLegalFunctionName: () => { throw new Error('stub function should not be called'); },
@@ -874,10 +874,6 @@ var LibraryEmbind = {
   $PureVirtualError: () => { throw new Error('stub function should not be called'); },
 };
 
-#if EMBIND_AOT
-extraLibraryFuncs.push('$embindEmitAotJs');
-#else
-extraLibraryFuncs.push('$embindEmitTypes');
-#endif
+extraLibraryFuncs.push('$emitOutput');
 
 addToLibrary(LibraryEmbind);

--- a/tools/link.py
+++ b/tools/link.py
@@ -2071,9 +2071,10 @@ def run_embind_gen(options, wasm_target, js_syms, extra_settings):
   if settings.WASM_EXCEPTIONS:
     node_args += shared.node_exception_flags(config.NODE_JS)
   # Run the generated JS file with the proper flags to generate the TypeScript bindings.
-  out = shared.run_js_tool(outfile_js, [], node_args, stdout=PIPE)
+  output_file = in_temp('embind_generated_output.js')
+  shared.run_js_tool(outfile_js, [output_file], node_args)
   settings.restore(original_settings)
-  return out
+  return read_file(output_file)
 
 
 @ToolchainProfiler.profile_block('emit tsd')


### PR DESCRIPTION
Instead of writing to stdout, write to a file to avoid any logging output entering the TS definitions or AOT code.