### PR TITLE
Fix: Include <features.h> in wasi/api.h to define _Noreturn in C++ mode

### DIFF
--- a/system/include/wasi/api.h
+++ b/system/include/wasi/api.h
@@ -47,6 +47,8 @@ _Static_assert(_Alignof(void*) == 4, "non-wasi data layout");
 extern "C" {
 #endif
 
+#include <features.h>
+
 // TODO: Encoding this in witx.
 #define __WASI_DIRCOOKIE_START (UINT64_C(0))
 typedef __SIZE_TYPE__ __wasi_size_t;


### PR DESCRIPTION
Hi, 

I maintain xeus-cpp-lite, a Jupyter Kernel that allows users to run C++ directly in the browser through Jupyterlite
Feel free to try it out here https://compiler-research.org/xeus-cpp/lab/index.html (check demo notebook for what all can be achieved)

1) We use emsdk 3.1.73
2) We obviously preload the sysroot for standard headers and other 3rd party lib headers (SDL etc)
3) This is what I observe 

![image](https://github.com/user-attachments/assets/99a6e507-fcd8-4821-a683-bb3c1e70d005)

i) trying to include wasi/api.h fails with 
```
Aborted(Assertion failed: D->getLexicalDeclContext() == this && "Decl inserted into wrong lexical context", at: /home/runner/work/recipes/recipes/output/bld/rattler-build_llvm_1748329150/work/clang/lib/AST/DeclBase.cpp,1758,addHiddenDecl)
```
ii) Looking into api.h and pasting the code from there into the cell and running it, I observe this is the minimal block replicating the error 
```
#ifndef __wasi_api_h
#define __wasi_api_h

#include <stddef.h>
#include <stdint.h>

#pragma push_macro("_Static_assert")
#undef _Static_assert
#define _Static_assert(X, Y)

_Static_assert(_Alignof(int8_t) == 1, "non-wasi data layout");
_Static_assert(_Alignof(uint8_t) == 1, "non-wasi data layout");
_Static_assert(_Alignof(int16_t) == 2, "non-wasi data layout");
_Static_assert(_Alignof(uint16_t) == 2, "non-wasi data layout");
_Static_assert(_Alignof(int32_t) == 4, "non-wasi data layout");
_Static_assert(_Alignof(uint32_t) == 4, "non-wasi data layout");
_Static_assert(_Alignof(int64_t) == 8, "non-wasi data layout");
_Static_assert(_Alignof(uint64_t) == 8, "non-wasi data layout");
_Static_assert(_Alignof(void*) == 4, "non-wasi data layout");

#ifdef __cplusplus
extern "C" {
#endif

/**
 * Exit code generated by a process when exiting.
 */
typedef uint32_t __wasi_exitcode_t;

_Static_assert(sizeof(__wasi_exitcode_t) == 4, "witx calculated size");
_Static_assert(_Alignof(__wasi_exitcode_t) == 4, "witx calculated align");

_Noreturn void __wasi_proc_exit(
    /**
     * The exit code returned by the process.
     */
    __wasi_exitcode_t rval
) __attribute__((
    __import_module__("wasi_snapshot_preview1"),
    __import_name__("proc_exit")));


/** @} */

#ifdef __cplusplus
}
#endif

#pragma pop_macro("_Static_assert")

#endif
```
Gives the same error 

![image](https://github.com/user-attachments/assets/85a25c00-7932-47c4-a5e3-b2e876a62bb0)
