### PR TITLE
Remove/fix usage of MIN_SAFARI_VERSION

### DIFF
--- a/src/lib/libemval.js
+++ b/src/lib/libemval.js
@@ -303,7 +303,7 @@ var LibraryEmVal = {
     return id;
   },
 
-#if MIN_CHROME_VERSION < 49 || MIN_FIREFOX_VERSION < 42 || MIN_SAFARI_VERSION < 100101
+#if MIN_CHROME_VERSION < 49 || MIN_FIREFOX_VERSION < 42
   $reflectConstruct: null,
   $reflectConstruct__postset: `
     if (typeof Reflect != 'undefined') {

--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -901,7 +901,7 @@ var LibraryHTML5 = {
       }
       orientationAngle = screenOrientObj.angle;
     }
-#if MIN_SAFARI_VERSION < 0x100400
+#if MIN_SAFARI_VERSION < 160400
     else {
       // fallback for Safari earlier than 16.4 (March 2023)
       orientationAngle = window.orientation;

--- a/tools/link.py
+++ b/tools/link.py
@@ -1264,10 +1264,9 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
                           settings.MIN_SAFARI_VERSION < 140000 or
                           settings.MIN_NODE_VERSION < 160000)
 
-  # https://caniuse.com/class: FF:45 CHROME:49 SAFARI:9
+  # https://caniuse.com/class: FF:45 CHROME:49
   supports_es6_classes = (settings.MIN_FIREFOX_VERSION >= 45 and
-                          settings.MIN_CHROME_VERSION >= 49 and
-                          settings.MIN_SAFARI_VERSION >= 90000)
+                          settings.MIN_CHROME_VERSION >= 49)
 
   if not settings.DISABLE_EXCEPTION_CATCHING and settings.EXCEPTION_STACK_TRACES and not supports_es6_classes:
     diagnostics.warning('transpile', '-sEXCEPTION_STACK_TRACES requires an engine that support ES6 classes.')


### PR DESCRIPTION
We don't support targeting safari version older than 10.10.00 so two of these conditions were always true.

The third check was added in #21428 and looks to me like it was always wrong.  The window.orientation API was added in safari 16.4 as the comment says so I updated the check to match.  I'm not sure where the old value of 0x100400 came from or what it means.