### PR TITLE
Fix bootstrap.py script to not depend on tools/shared.py

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -10,6 +10,7 @@ of a Makefile).
 import argparse
 import os
 import shutil
+import subprocess
 import sys
 
 __rootdir__ = os.path.dirname(os.path.abspath(__file__))
@@ -17,7 +18,10 @@ sys.path.insert(0, __rootdir__)
 
 STAMP_DIR = os.path.join(__rootdir__, 'out')
 
-from tools import shared, utils
+# N.b. This script bootstrap.py cannot use 'from tools import shared',
+# because shared.py requires that a valid .emscripten config is already
+# created. Bootstrap.py needs to be run before an .emscripten config exists.
+from tools import utils
 
 actions = [
   ('npm packages', [
@@ -93,7 +97,7 @@ def main(args):
       if not cmd[0]:
         utils.exit_with_error(f'command not found: {orig_exe}')
     print(' -> %s' % ' '.join(cmd))
-    shared.run_process(cmd, cwd=utils.path_from_root())
+    subprocess.run(cmd, check=True, text=True, encoding='utf-8', cwd=utils.path_from_root())
     utils.safe_ensure_dirs(STAMP_DIR)
     utils.write_file(stamp_file, 'Timestamp file created by bootstrap.py')
   return 0

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -822,13 +822,9 @@ fi
   # cause an exception. (A first time run scenario is before .emscripten, env.
   # vars nor PATH has been configured)
   def test_bootstrap_without_em_config(self):
-    # Make sure we don't have an EM_CONFIG file.
-    if os.path.isfile(EM_CONFIG):
-      os.remove(EM_CONFIG)
-
     # Remove all environment variables that might help config.py to locate Emscripten tools.
     env = os.environ.copy()
-    for e in ['LLVM_ROOT', 'EMSDK_NODE', 'EMSDK_PYTHON', 'EMSDK', 'EMSCRIPTEN', 'BINARYEN_ROOT', 'EMCC_SKIP_SANITY_CHECK']:
+    for e in ['LLVM_ROOT', 'EMSDK_NODE', 'EMSDK_PYTHON', 'EMSDK', 'EMSCRIPTEN', 'BINARYEN_ROOT', 'EMCC_SKIP_SANITY_CHECK', 'EM_CONFIG']:
       env.pop(e, None)
 
     # Remove from PATH every directory that contains clang.exe so that bootstrap.py cannot
@@ -837,8 +833,4 @@ fi
     env['PATH'] = os.pathsep.join(new_path)
 
     # Running bootstrap.py should not fail
-    try:
-      self.run_process([shared.bat_suffix(shared.path_from_root('bootstrap'))], env=env)
-    finally:
-      # Restore the deleted config file to not disturb other tests
-      restore()
+    self.run_process([shared.bat_suffix(shared.path_from_root('bootstrap'))], env=env)

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -817,3 +817,28 @@ fi
 
     # Now the compiler should work again
     self.run_process([EMCC, test_file('hello_world.c')])
+
+  # Verify that running bootstrap.py in a first-time run scenario should not
+  # cause an exception. (A first time run scenario is before .emscripten, env.
+  # vars nor PATH has been configured)
+  def test_bootstrap_without_em_config(self):
+    # Make sure we don't have an EM_CONFIG file.
+    if os.path.isfile(EM_CONFIG):
+      os.remove(EM_CONFIG)
+
+    # Remove all environment variables that might help config.py to locate Emscripten tools.
+    env = os.environ.copy()
+    for e in ['LLVM_ROOT', 'EMSDK_NODE', 'EMSDK_PYTHON', 'EMSDK', 'EMSCRIPTEN', 'BINARYEN_ROOT', 'EMCC_SKIP_SANITY_CHECK']:
+      env.pop(e, None)
+
+    # Remove from PATH every directory that contains clang.exe so that bootstrap.py cannot
+    # accidentally succeed by virtue of locating tools in PATH.
+    new_path = [d for d in env['PATH'].split(os.pathsep) if not os.path.isfile(os.path.join(d, shared.exe_suffix('clang')))]
+    env['PATH'] = os.pathsep.join(new_path)
+
+    # Running bootstrap.py should not fail
+    try:
+      self.run_process([shared.bat_suffix(shared.path_from_root('bootstrap'))], env=env)
+    finally:
+      # Restore the deleted config file to not disturb other tests
+      restore()


### PR DESCRIPTION
Fix bootstrap.py script to not depend on tools/shared.py so that it can be run during emsdk installation phase when no .emscripten config yet exists. Fixes https://github.com/emscripten-core/emsdk/issues/1545