### PR TITLE
[MODULARIZE=instance] Fix growableHeap pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,6 +557,7 @@ jobs:
             asan.test_pthread_run_on_main_thread
             asan.test_minimal_runtime_global_initializer
             asan.test_fs_js_api_wasmfs
+            asan.test_modularize_instance_pthreads
             lsan.test_dylink_dso_needed
             lsan.test_stdio_locking
             lsan.test_dlfcn_basic

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9700,8 +9700,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
     'pthreads': (['-pthread'],),
   })
   def test_modularize_instance(self, args):
-    if self.get_setting('WASM_ESM_INTEGRATION') and '-pthread' in args:
-      self.skipTest('pthread is not compatible with WASM_ESM_INTEGRATION')
+    if args:
+      self.setup_node_pthreads()
     create_file('library.js', '''\
     addToLibrary({
       $baz: () => console.log('baz'),

--- a/tools/acorn-optimizer.mjs
+++ b/tools/acorn-optimizer.mjs
@@ -1174,6 +1174,9 @@ function littleEndianHeap(ast) {
 // in each access), see #8365.
 function growableHeap(ast) {
   recursiveWalk(ast, {
+    ExportNamedDeclaration() {
+      // Do not recurse export statements since we don't want to rewrite, for example, `export { HEAP32 }`
+    },
     FunctionDeclaration(node, c) {
       // Do not recurse into the helper function itself.
       if (


### PR DESCRIPTION
This was causing `asan.test_modularize_instance_pthreads` to fail.