### PR TITLE
Skip Intel x86 SSE tests on ARM64 platforms that cannot natively compile SSE code.

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -140,13 +140,13 @@ def needs_dylink(func):
   return decorated
 
 
-def requires_x86_cpu(func):
+def requires_x64_cpu(func):
   assert callable(func)
 
   @wraps(func)
   def decorated(self, *args, **kwargs):
-    if platform.machine().lower() not in ['i686', 'x86_64', 'amd64']:
-      return self.skipTest(f'This test requires a native x86 CPU. Current CPU is {platform.machine()}.')
+    if platform.machine().lower() not in ['x86_64', 'amd64']:
+      return self.skipTest(f'This test requires a native x64 CPU. Current CPU is {platform.machine()}.')
     return func(self, *args, **kwargs)
 
   return decorated
@@ -6550,7 +6550,7 @@ void* operator new(size_t size) {
   @wasm_simd
   @crossplatform
   @requires_native_clang
-  @requires_x86_cpu
+  @requires_x64_cpu
   @no_safe_heap('has unaligned 64-bit operations in wasm')
   @no_ubsan('test contains UB')
   @parameterized({
@@ -6570,7 +6570,7 @@ void* operator new(size_t size) {
   # Tests invoking the SIMD API via x86 SSE2 emmintrin.h header (_mm_x() functions)
   @wasm_simd
   @requires_native_clang
-  @requires_x86_cpu
+  @requires_x64_cpu
   @no_safe_heap('has unaligned 64-bit operations in wasm')
   @is_slow_test
   @no_ubsan('https://github.com/emscripten-core/emscripten/issues/19688')
@@ -6593,7 +6593,7 @@ void* operator new(size_t size) {
   # Tests invoking the SIMD API via x86 SSE3 pmmintrin.h header (_mm_x() functions)
   @wasm_simd
   @requires_native_clang
-  @requires_x86_cpu
+  @requires_x64_cpu
   def test_sse3(self):
     src = test_file('sse/test_sse3.cpp')
     self.run_process([shared.CLANG_CXX, src, '-msse3', '-Wno-argument-outside-range', '-o', 'test_sse3', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
@@ -6606,7 +6606,7 @@ void* operator new(size_t size) {
   # Tests invoking the SIMD API via x86 SSSE3 tmmintrin.h header (_mm_x() functions)
   @wasm_simd
   @requires_native_clang
-  @requires_x86_cpu
+  @requires_x64_cpu
   def test_ssse3(self):
     src = test_file('sse/test_ssse3.cpp')
     self.run_process([shared.CLANG_CXX, src, '-mssse3', '-Wno-argument-outside-range', '-o', 'test_ssse3', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
@@ -6620,7 +6620,7 @@ void* operator new(size_t size) {
   @no_ubsan('https://github.com/emscripten-core/emscripten/issues/19749')
   @wasm_simd
   @requires_native_clang
-  @requires_x86_cpu
+  @requires_x64_cpu
   @is_slow_test
   def test_sse4_1(self):
     if self.is_wasm64():
@@ -6640,7 +6640,7 @@ void* operator new(size_t size) {
   # Tests invoking the SIMD API via x86 SSE4.2 nmmintrin.h header (_mm_x() functions)
   @wasm_simd
   @requires_native_clang
-  @requires_x86_cpu
+  @requires_x64_cpu
   @parameterized({
     '': (False,),
     '2': (True,),
@@ -6658,7 +6658,7 @@ void* operator new(size_t size) {
   # Tests invoking the SIMD API via x86 AVX avxintrin.h header (_mm_x() functions)
   @wasm_simd
   @requires_native_clang
-  @requires_x86_cpu
+  @requires_x64_cpu
   @is_slow_test
   @no_asan('local count too large')
   @no_ubsan('local count too large')
@@ -6678,7 +6678,7 @@ void* operator new(size_t size) {
   # Tests invoking the SIMD API via x86 AVX2 avx2intrin.h header (_mm_x()/_mm256_x() functions)
   @wasm_simd
   @requires_native_clang
-  @requires_x86_cpu
+  @requires_x64_cpu
   @is_slow_test
   @no_asan('local count too large')
   @no_ubsan('local count too large')


### PR DESCRIPTION
Also remove one case of @requires_native_clang that wasn't needed.