### PR TITLE
[wasmfs] FetchFS: fix getFileRange out-of-bounds issues

### DIFF
--- a/src/lib/libwasmfs_fetch.js
+++ b/src/lib/libwasmfs_fetch.js
@@ -90,6 +90,12 @@ addToLibrary({
       // one request for all the chunks we need, rather than one
       // request per chunk.
       var start = firstChunk * chunkSize;
+
+      // Out of bounds. No request necessary.
+      if (start >= wasmFS$JSMemoryRanges[file].size) {
+        return Promise.resolve();
+      }
+
       // We must fetch *up to* the last byte of the last chunk.
       var end = (lastChunk+1) * chunkSize;
       var response = await fetch(url, {headers:{'Range': `bytes=${start}-${end-1}`}});


### PR DESCRIPTION
This change is authored by @foxtacles (See #24438)

Fixes: #24438