### PR TITLE
Fix other.test_output_name_collision after recent node upgrade

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13806,7 +13806,11 @@ exec "$@"
     self.run_process([EMCC, '-o', 'hello.wasm', '--oformat=js', test_file('hello_world.c')])
     self.assertExists('hello.wasm')
     self.assertExists('hello_.wasm')
-    self.assertContained('hello, world!', self.run_js('hello.wasm'))
+    self.assertFalse(building.is_wasm('hello.wasm'))
+    self.assertTrue(building.is_wasm('hello_.wasm'))
+    # Node cannot actually run the generated JS if it's in a file with the .wasm extension
+    os.rename('hello.wasm', 'hello.js')
+    self.assertContained('hello, world!', self.run_js('hello.js'))
 
   def test_main_module_no_undefined(self):
     # Test that ERROR_ON_UNDEFINED_SYMBOLS works with MAIN_MODULE.


### PR DESCRIPTION
New versions of node cannot run `hello.wasm` even if the file contains JS:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".wasm" for /usr/local/google/home/sbc/dev/wasm/emscripten/out/test/hello.wasm
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:183:9)
    at defaultGetFormat (node:internal/modules/esm/get_format:209:36)
    at defaultLoad (node:internal/modules/esm/load:119:22)
    at async ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:590:32)
    at async #link (node:internal/modules/esm/module_job:141:19) {
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
}
```

I'm not sure if this should be considered a bug or not.