### PR TITLE
Fix running babel and terser when there is no node in PATH.

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -818,6 +818,7 @@ f.close()
     create_file('myconfig.py', f'''
       LLVM_ROOT = r'{config.LLVM_ROOT}'
       BINARYEN_ROOT = r'{config.BINARYEN_ROOT}'
+      NODE_JS = r'{config.NODE_JS[0]}'
       CACHE = r'{os.path.abspath("cache")}'
       print("filename", __file__)
     ''')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11883,7 +11883,11 @@ int main () {
       # N.b. this requires node in PATH, it does not run against NODE from
       # Emscripten config file. If you have this line fail, make sure 'node' is
       # visible in PATH.
-      self.run_process(terser + ['-b', 'beautify=true', 'a.js', '-o', 'pretty.js'])
+      # terser expects to see 'node' executable in PATH, but it might not exist there
+      # if we are running Emscripten from Emsdk (which does not add Node/Python to PATH)
+      env = os.environ.copy()
+      env['PATH'] = f'{shared.get_node_directory()}{os.pathsep}{env['PATH']}'
+      self.run_process(terser + ['-b', 'beautify=true', 'a.js', '-o', 'pretty.js'], env=env)
       self.assertFileContents(js_out, read_file('pretty.js'))
 
     obtained_results = {}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11883,11 +11883,7 @@ int main () {
       # N.b. this requires node in PATH, it does not run against NODE from
       # Emscripten config file. If you have this line fail, make sure 'node' is
       # visible in PATH.
-      # terser expects to see 'node' executable in PATH, but it might not exist there
-      # if we are running Emscripten from Emsdk (which does not add Node/Python to PATH)
-      env = os.environ.copy()
-      env['PATH'] = f'{shared.get_node_directory()}{os.pathsep}{env["PATH"]}'
-      self.run_process(terser + ['-b', 'beautify=true', 'a.js', '-o', 'pretty.js'], env=env)
+      self.run_process(terser + ['-b', 'beautify=true', 'a.js', '-o', 'pretty.js'], env=shared.env_with_node_in_path())
       self.assertFileContents(js_out, read_file('pretty.js'))
 
     obtained_results = {}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11886,7 +11886,7 @@ int main () {
       # terser expects to see 'node' executable in PATH, but it might not exist there
       # if we are running Emscripten from Emsdk (which does not add Node/Python to PATH)
       env = os.environ.copy()
-      env['PATH'] = f'{shared.get_node_directory()}{os.pathsep}{env['PATH']}'
+      env['PATH'] = f'{shared.get_node_directory()}{os.pathsep}{env["PATH"]}'
       self.run_process(terser + ['-b', 'beautify=true', 'a.js', '-o', 'pretty.js'], env=env)
       self.assertFileContents(js_out, read_file('pretty.js'))
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -537,6 +537,9 @@ def transpile(filename):
   # in the emscripten tree, so we explicitly set NODE_PATH here.
   env = os.environ.copy()
   env['NODE_PATH'] = path_from_root('node_modules')
+  # Babel expects to see 'node' executable in PATH, but it might not exist there
+  # if we are running Emscripten from Emsdk (which does not add Node/Python to PATH)
+  env['PATH'] = f'{shared.get_node_directory()}{os.pathsep}{env['PATH']}'
   check_call(cmd, env=env)
   return outfile
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -539,7 +539,7 @@ def transpile(filename):
   env['NODE_PATH'] = path_from_root('node_modules')
   # Babel expects to see 'node' executable in PATH, but it might not exist there
   # if we are running Emscripten from Emsdk (which does not add Node/Python to PATH)
-  env['PATH'] = f'{shared.get_node_directory()}{os.pathsep}{env['PATH']}'
+  env['PATH'] = f'{shared.get_node_directory()}{os.pathsep}{env["PATH"]}'
   check_call(cmd, env=env)
   return outfile
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -535,11 +535,8 @@ def transpile(filename):
   # Babel needs access to `node_modules` for things like `preset-env`, but the
   # location of the config file (and the current working directory) might not be
   # in the emscripten tree, so we explicitly set NODE_PATH here.
-  env = os.environ.copy()
+  env = shared.env_with_node_in_path()
   env['NODE_PATH'] = path_from_root('node_modules')
-  # Babel expects to see 'node' executable in PATH, but it might not exist there
-  # if we are running Emscripten from Emsdk (which does not add Node/Python to PATH)
-  env['PATH'] = f'{shared.get_node_directory()}{os.pathsep}{env["PATH"]}'
   check_call(cmd, env=env)
   return outfile
 


### PR DESCRIPTION
Fix running babel as part of the build when there is no node in PATH. Fixes test other.test_wasm_features.