### PR TITLE
Fix test other.test_abspaths

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1295,6 +1295,8 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
       exit_with_error('cannot --separate-asm with the wasm backend, since not emitting asm.js')
     elif arg.startswith(('-I', '-L')):
       path_name = arg[2:]
+      # Look for '/' explicitly so that we can also diagnose identically if -I/foo/bar is passed on Windows.
+      # Python since 3.13 does not treat '/foo/bar' as an absolute path on Windows.
       if (path_name.startswith('/') or os.path.isabs(path_name)) and not is_valid_abspath(options, path_name):
         # Of course an absolute path to a non-system-specific library or header
         # is fine, and you can ignore this warning. The danger are system headers

--- a/emcc.py
+++ b/emcc.py
@@ -1295,7 +1295,7 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
       exit_with_error('cannot --separate-asm with the wasm backend, since not emitting asm.js')
     elif arg.startswith(('-I', '-L')):
       path_name = arg[2:]
-      if os.path.isabs(path_name) and not is_valid_abspath(options, path_name):
+      if (path_name.startswith('/') or os.path.isabs(path_name)) and not is_valid_abspath(options, path_name):
         # Of course an absolute path to a non-system-specific library or header
         # is fine, and you can ignore this warning. The danger are system headers
         # that are e.g. x86 specific and non-portable. The emscripten bundled

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1759,7 +1759,6 @@ Module['postRun'] = () => {
     self.emcc('main.c', ['--embed-file', 'my_test.input'], output_filename='a.out.js')
     self.assertContained('zyx', self.run_process(config.JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).stdout)
 
-  @no_windows('This test is written to work on Linux and macOS only')
   def test_abspaths(self):
     # Includes with absolute paths are generally dangerous, things like -I/usr/.. will get to system
     # local headers, not our portable ones.


### PR DESCRIPTION
Python 3.13 changed behavior so that `os.path.isabs('/foo/bar')` now returns `False` when run on Windows.