### PR TITLE
[dylink] Fix execution order in emscripten_dlopen_promise

### DIFF
--- a/system/lib/libc/dynlink.c
+++ b/system/lib/libc/dynlink.c
@@ -656,12 +656,14 @@ em_promise_t emscripten_dlopen_promise(const char* filename, int flags) {
   // Create a promise that is resolved (and destroyed) once the operation
   // succeeds.
   em_promise_t p = emscripten_promise_create();
-  emscripten_dlopen(filename, flags, p, promise_onsuccess, promise_onerror);
-
   // Create a second promise bound the first one to return the caller.  It's
   // then up to the caller to destroy this promise.
   em_promise_t ret = emscripten_promise_create();
+  
+  // The order matters here. Calling emscripten_dlopen before resolving the second promise
+  // may destroy the first promise before resolving the value.
   emscripten_promise_resolve(ret, EM_PROMISE_MATCH, p);
+  emscripten_dlopen(filename, flags, p, promise_onsuccess, promise_onerror);
   return ret;
 }
 


### PR DESCRIPTION
This PR changes the order of promise execution in `emscripten_dlopen_promise` to prevent the promise from being destroyed when resolving happens.

Current behavior of `emscripten_dlopen_promise` is:

1. Call `emscripten_dlopen` with callbacks (with promise `p`)
1.a. These callbacks destroy the promise `p` when the dlopen is finished.
2. Call `emscripten_promise_resolve` with another promise `ret`, which resolves to `p`.

The problem happens when 1.a. is called before 2. The success (or error) callback will destroy `p`, and the `emscripten_promise_resolve` failes to resolve the promise for `p` because it is already destroyed.

This PR fixes it by calling `emscripten_promise_resolve` then `emscripten_dlopen` to ensure the promise for `p` always exists when calling `emscripten_promise_resolve`

I am not sure how to test this behavior, as this it related to how JS schedules the promise, but in Pyodide, we experienced this issue (https://github.com/pyodide/pyodide/pull/5610#issuecomment-2926336938), and this patch fixes it.
