### PR TITLE
Update rebaseline_tests to handle non-json changes

### DIFF
--- a/test/other/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/other/codesize/test_codesize_minimal_O0.expected.js
@@ -253,7 +253,7 @@ function _free() {
  */
 var isFileURI = (filename) => filename.startsWith('file://');
 
-// include: runtime_shared.js
+// include: runtime_common.js
 // include: runtime_stack_check.js
 // Initializes the stack cookie. Called at the startup of main and at the startup of each thread in pthreads mode.
 function writeStackCookie() {
@@ -465,7 +465,7 @@ function updateMemoryViews() {
 
 // include: memoryprofiler.js
 // end include: memoryprofiler.js
-// end include: runtime_shared.js
+// end include: runtime_common.js
 assert(typeof Int32Array != 'undefined' && typeof Float64Array !== 'undefined' && Int32Array.prototype.subarray != undefined && Int32Array.prototype.set != undefined,
        'JS engine does not provide full typed array support');
 

--- a/tools/maint/rebaseline_tests.py
+++ b/tools/maint/rebaseline_tests.py
@@ -39,6 +39,8 @@ all_deltas = []
 
 
 def process_changed_file(filename):
+  if os.path.splitext(filename)[1] != '.json':
+    return f'{filename} updated\n'
   content = open(filename).read()
   old_content = run(['git', 'show', f'HEAD:{filename}'])
   print(f'processing {filename}')
@@ -50,7 +52,7 @@ def process_changed_file(filename):
       current_json = json.loads(content)
       old_json = json.loads(old_content)
     except Exception:
-      print(f'{filename}: Unable to parse json content. Unsupported file format?')
+      print(f'{filename}: Unable to parse json content')
       sys.exit(1)
     size = current_json['total']
     old_size = old_json['total']
@@ -114,7 +116,8 @@ running the tests with `--rebaseline`:
   for file in filenames:
     message += process_changed_file(file)
 
-  message += f'\nAverage change: {statistics.mean(all_deltas):+.2f}% ({min(all_deltas):+.2f}% - {max(all_deltas):+.2f}%)\n'
+  if all_deltas:
+    message += f'\nAverage change: {statistics.mean(all_deltas):+.2f}% ({min(all_deltas):+.2f}% - {max(all_deltas):+.2f}%)\n'
 
   message += '```\n'
 


### PR DESCRIPTION
After this update I ran the script and it generated:

This is an automatic change generated by tools/maint/rebaseline_tests.py.

The following (1) test expectation files were updated by running the tests with `--rebaseline`:

```
test/other/codesize/test_codesize_minimal_O0.expected.js updated
```