### PR TITLE
Update Emdawnwebgpu port to v20250531.224602

### DIFF
--- a/tools/ports/emdawnwebgpu.py
+++ b/tools/ports/emdawnwebgpu.py
@@ -3,14 +3,77 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
+r"""
+# Emdawnwebgpu
 
-TAG = 'v20250516.124039'
+Emdawnwebgpu is Dawn's implementation of webgpu.h for Emscripten (on top of the
+WebGPU JS API). It is a fork of Emscripten's original `USE_WEBGPU` bindings,
+and while it is maintained in Dawn, it works in any browser supporting WebGPU
+(modulo individual feature support).
+
+The package includes all of the necessary files to use
+`<webgpu/webgpu.h>` and the Dawn-style `<webgpu/webgpu_cpp.h>` with Emscripten.
+
+Find new versions of this package at <https://github.com/google/dawn/releases>.
+
+If you find any issue with this release, please verify it in the latest release,
+and then report it at <https://crbug.com/new?component=1570785&noWizard=True>.
+
+## How to use this package
+
+First, start with either:
+
+- A "remote" port file `emdawnwebgpu-v*.remoteport.py` (requires Emscripten 4.0.10+).
+- An `emdawnwebgpu_pkg` containing a local port file `emdawnwebgpu.port.py`.
+  (Either from a pre-built zip release, or from a Dawn build output directory.)
+
+## How to use this package (local or remote)
+
+Pass the following flag to `emcc`, during both compile and link, to set the
+include paths and link the implementation:
+
+    --use-port=path/to/emdawnwebgpu_port_or_remoteport_file.py
+
+If (and only if) using Emscripten before 4.0.7, also pass this flag during link:
+
+    --closure-args=--externs=path/to/emdawnwebgpu_pkg/webgpu/src/webgpu-externs.js
+
+## Port options
+
+Options can be set by appending `:key1=value:key2=value` to `--use-port`.
+For information about port options, run:
+
+    emcc --use-port=emdawnwebgpu:help
+    emcc --use-port=path/to/emdawnwebgpu.port.py:help
+    emcc --use-port=path/to/emdawnwebgpu-*.remoteport.py:help
+
+### C++ bindings
+
+By default, C++ bindings are provided in the include path. Note that unlike
+`webgpu.h`, these are not intended to be fully stable. If you don't want these
+for any reason (you have custom bindings, you're using a pinned snapshot of
+`webgpu_cpp.h`, etc.), you can set the option `cpp_bindings=false`:
+
+    --use-port=emdawnwebgpu:cpp_bindings=false
+    --use-port=path/to/emdawnwebgpu.port.py:cpp_bindings=false
+    --use-port=path/to/emdawnwebgpu-*.remoteport.py:cpp_bindings=false
+
+## Embuilder
+
+If your build process needs a separate step to build the port before linking,
+use Emscripten's `embuilder`.
+
+Under `embuilder`, some options cannot be set automatically, so they must be
+set manually. See `OPTIONS` in `emdawnwebgpu.port.py` for details.
+"""
+
+TAG = 'v20250531.224602'
 
 EXTERNAL_PORT = f'https://github.com/google/dawn/releases/download/{TAG}/emdawnwebgpu_pkg-{TAG}.zip'
-SHA512 = '994eac4be5f69d8ec83838af9c7b4cc87f15fa22bede589517c169320dd69ab5cf164528f7bd6ec6503b1ef178da3d87df0565d16445dac2a69f98450083dd8f'
+SHA512 = 'e3db5b2a4cc97cbb9b8a0c1f6fe7a740bf644322dfa4641a7b0902c192c58205d76acb9b359a0d6da1fdc9795e85eb1cf1927aa47f2a82814ee29868fef6670e'
 PORT_FILE = 'emdawnwebgpu_pkg/emdawnwebgpu.port.py'
 
 # Port information (required)
 URL = 'https://dawn.googlesource.com/dawn/+/refs/heads/main/src/emdawnwebgpu/'
-DESCRIPTION = "Emdawnwebgpu is a fork of Emscripten's original USE_WEBGPU, implementing a newer, more stable version of the standardized webgpu.h interface. If you find issues, verify in the latest nightly release (https://github.com/google/dawn/releases) and file feedback with Dawn. (Emdawnwebgpu is maintained as part of Dawn, the open-source WebGPU implementation used by Chromium, but it is still cross-browser.)"
+DESCRIPTION = "Emdawnwebgpu is a fork of Emscripten's original USE_WEBGPU, implementing a newer, more stable version of the standardized webgpu.h interface."
 LICENSE = "Some files: BSD 3-Clause License. Other files: Emscripten's license (available under both MIT License and University of Illinois/NCSA Open Source License)"


### PR DESCRIPTION
Release page: <https://github.com/google/dawn/releases/tag/v20250531.224602>

Emdawnwebgpu releases now generate these "remoteport" files, which can be copied directly into Emscripten. The README is just included in the file for people who download it from Dawn's releases page because it's a single file download - I don't expect `--use-port=emdawnwebgpu` users to read it.

I thought about including a link to the README (<https://dawn.googlesource.com/dawn/+/ea66c0fa309f01f2ba1ec2fd2c680cc992eaf72a/src/emdawnwebgpu/pkg/README.md>) in the `DESCRIPTION` but I don't think the description is user-visible? (It doesn't show up in `--show-ports`.) It _would_ be nice to make sure the readme is findable by users.

This is tested by `test_remote_ports` and `test_emdawnwebgpu_link_test`.