### PR TITLE
Update autodebug to handle new memory growth instrumentation in Binaryen

### DIFF
--- a/src/lib/libautodebug.js
+++ b/src/lib/libautodebug.js
@@ -123,6 +123,14 @@ addToLibrary({
     dbg('store_val_f64 ' + [loc, value]);
     return value;
   },
+  $memory_grow_pre: (loc, delta) => {
+    dbg('memory_grow_pre ' + [loc, delta]);
+    return delta;
+  },
+  $memory_grow_post: (loc, result) => {
+    dbg('memory_grow_post ' + [loc, result]);
+    return result;
+  },
 });
 
 extraLibraryFuncs.push(
@@ -153,4 +161,6 @@ extraLibraryFuncs.push(
   '$store_val_i64',
   '$store_val_f32',
   '$store_val_f64',
+  '$memory_grow_pre',
+  '$memory_grow_post',
 );

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -811,6 +811,8 @@ def add_standard_wasm_imports(send_items_map):
       'store_val_i64',
       'store_val_f32',
       'store_val_f64',
+      'memory_grow_pre',
+      'memory_grow_post',
     ]
 
   if settings.SPLIT_MODULE and settings.ASYNCIFY == 2:


### PR DESCRIPTION
This was added in https://github.com/WebAssembly/binaryen/pull/7388
