### PR TITLE
Remove node canary test decorators. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,7 +524,7 @@ jobs:
   test-core0:
     executor: focal
     environment:
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE24: "1"
     steps:
       - run-tests-linux:
           test_targets: "core0"
@@ -532,7 +532,7 @@ jobs:
     executor: focal
     environment:
       EMTEST_BROWSER: "node"
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE24: "1"
     steps:
       - run-tests-linux:
           # also run a few asan tests.  Run these with frozen_cache disabled
@@ -577,7 +577,7 @@ jobs:
   test-core3:
     executor: focal
     environment:
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE24: "1"
     steps:
       - run-tests-linux:
           frozen_cache: false
@@ -656,7 +656,7 @@ jobs:
   test-modularize-instance:
     executor: focal
     environment:
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE24: "1"
     steps:
       - run-tests-linux:
           test_targets: "instance"
@@ -677,7 +677,7 @@ jobs:
       - upload-test-results
   test-wasm2js1:
     environment:
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE24: "1"
     executor: focal
     steps:
       - run-tests-linux:
@@ -920,7 +920,7 @@ jobs:
   test-other:
     executor: focal
     environment:
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE24: "1"
       EMTEST_SKIP_RUST: "1"
       EMTEST_SKIP_WASM64: "1"
       EMTEST_SKIP_NEW_CMAKE: "1"
@@ -997,7 +997,7 @@ jobs:
     executor: focal
     environment:
       EMTEST_LACKS_WEBGPU: "1"
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE24: "1"
     steps:
       - run-tests-chrome:
           title: "browser64_4gb"
@@ -1069,7 +1069,7 @@ jobs:
       EMTEST_SKIP_WASM64: "1"
       EMTEST_SKIP_SCONS: "1"
       EMTEST_SKIP_RUST: "1"
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE24: "1"
       EMTEST_BROWSER: "0"
     steps:
       - checkout

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1643,9 +1643,9 @@ simulateKeyUp(100, undefined, 'Numpad4');
     self.run_browser('main.html', '/report_result?hello from worker, and :' + ('data for w' if file_data else '') + ':')
 
     # code should run standalone too
-    # To great memories >4gb we need the canary version of node
+    # To create memories >4gb we need a recent version of node
     if self.is_4gb():
-      self.require_node_canary()
+      self.require_node_version(24)
     self.assertContained('you should not see this text when in a worker!', self.run_js('worker.js'))
 
   @no_wasmfs('https://github.com/emscripten-core/emscripten/issues/19608')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -26,7 +26,7 @@ import common
 from common import RunnerCore, path_from_root, requires_native_clang, test_file, create_file
 from common import skip_if, no_windows, no_mac, is_slow_test, parameterized, parameterize
 from common import env_modify, with_env_modify, disabled, flaky, node_pthreads, also_with_wasm_bigint
-from common import read_file, read_binary, requires_v8, requires_node, requires_dev_dependency, requires_wasm2js, requires_node_canary
+from common import read_file, read_binary, requires_v8, requires_node, requires_dev_dependency, requires_wasm2js
 from common import compiler_for, crossplatform, no_4gb, no_2gb, also_with_minimal_runtime, also_with_modularize
 from common import with_all_fs, also_with_nodefs, also_with_nodefs_both, also_with_noderawfs, also_with_wasmfs
 from common import with_all_eh_sjlj, with_all_sjlj, also_with_standalone_wasm, can_do_standalone, no_wasm64, requires_wasm_eh, requires_jspi
@@ -409,7 +409,7 @@ class TestCoreBase(RunnerCore):
     return all(f not in self.emcc_args for f in prohibited) and any(f in self.emcc_args for f in required)
 
   def setup_esm_integration(self):
-    self.require_node_canary()
+    self.require_node_version(24)
     self.node_args += ['--experimental-wasm-modules', '--no-warnings']
     self.set_setting('WASM_ESM_INTEGRATION')
     self.emcc_args += ['-Wno-experimental']
@@ -8408,11 +8408,10 @@ Module.onRuntimeInitialized = () => {
     self.do_core_test('test_hello_world.c')
 
   # Test that pthread_join works correctly with asyncify.
-  @requires_node_canary
   @node_pthreads
+  @requires_jspi
   def test_pthread_join_and_asyncify(self):
     # TODO Test with ASYNCIFY=1 https://github.com/emscripten-core/emscripten/issues/17552
-    self.require_jspi()
     self.do_runf('core/test_pthread_join_and_asyncify.c', 'joining thread!\njoined thread!',
                  emcc_args=['-sJSPI',
                             '-sEXIT_RUNTIME=1',

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -34,7 +34,7 @@ from tools.shared import CLANG_CC, CLANG_CXX, LLVM_AR, LLVM_DWARFDUMP, LLVM_DWP,
 from common import RunnerCore, path_from_root, is_slow_test, ensure_dir, disabled, make_executable
 from common import env_modify, no_mac, no_windows, only_windows, requires_native_clang, with_env_modify
 from common import create_file, parameterized, NON_ZERO, node_pthreads, TEST_ROOT, test_file
-from common import compiler_for, EMBUILDER, requires_v8, requires_node, requires_wasm64, requires_node_canary, requires_dev_dependency
+from common import compiler_for, EMBUILDER, requires_v8, requires_node, requires_wasm64, requires_node_version, requires_dev_dependency
 from common import requires_wasm_eh, crossplatform, with_all_eh_sjlj, with_all_sjlj, requires_jspi
 from common import also_with_standalone_wasm, also_with_wasm2js, also_with_noderawfs
 from common import also_with_modularize, also_with_wasmfs, with_all_fs
@@ -357,7 +357,7 @@ class other(RunnerCore):
     self.assertContained('export default Module;', read_file('hello_world.mjs'))
     self.assertContained('hello, world!', self.run_js('hello_world.mjs'))
 
-  @requires_node_canary
+  @requires_node_version(24)
   def test_esm_source_phase_imports(self):
     self.node_args += ['--experimental-wasm-modules', '--no-warnings']
     self.run_process([EMCC, '-o', 'hello_world.mjs', '-sSOURCE_PHASE_IMPORTS',
@@ -3414,7 +3414,7 @@ More info: https://emscripten.org
 
     self.do_runf('embind/test_return_value_policy.cpp')
 
-  @requires_node_canary
+  @requires_node_version(24)
   def test_embind_resource_management(self):
     self.node_args.append('--js-explicit-resource-management')
 
@@ -7471,7 +7471,6 @@ int main() {
     self.assertContained('done', self.run_js('a.out.js'))
 
   @requires_wasm64
-  @requires_node_canary
   def test_failing_growth_wasm64(self):
     self.require_wasm64()
     create_file('test.c', r'''
@@ -15501,7 +15500,6 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     self.do_other_test('test_quick_exit.c')
 
   @requires_wasm64
-  @requires_node_canary
   def test_memory64_proxies(self):
     self.run_process([EMCC, test_file('hello_world.c'),
                       '-sMEMORY64=1',
@@ -16110,7 +16108,7 @@ addToLibrary({
                  emcc_args=['--pre-js', 'pre.js',
                             '--extern-post-js', test_file('modularize_post_js.js')] + args)
 
-  @requires_node_canary
+  @requires_node_version(24)
   def test_js_base64_api(self):
     self.node_args += ['--js_base_64']
     self.do_runf('hello_world.c', 'hello, world!', emcc_args=['-sSINGLE_FILE'], output_basename='baseline')


### PR DESCRIPTION
All these features actually work on the official node 24 these days.