### PR TITLE
Remove @requires_v8 from test_dlmalloc_inline. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6402,8 +6402,6 @@ int main(void) {
   def test_whets(self):
     self.do_runf('third_party/whets.c', 'Single Precision C Whetstone Benchmark')
 
-  # node is slower, and fail on 64-bit
-  @requires_v8
   @no_asan('depends on the specifics of memory size, which for asan we are forced to increase')
   @no_lsan('depends on the specifics of memory size, which for lsan we are forced to increase')
   def test_dlmalloc_inline(self):


### PR DESCRIPTION
Node runs this test fine and in wasm64 without any issue.  The test take on average 293ms on node and 251ms on d8.