### PR TITLE
Never run callbacks synchronously in emscripten_dlopen

### DIFF
--- a/src/lib/libeventloop.js
+++ b/src/lib/libeventloop.js
@@ -85,6 +85,15 @@ LibraryJSEventLoop = {
   $emClearImmediate_deps: ['$emSetImmediate'],
   $emClearImmediate: undefined,
 
+  emscripten_queue_microtask__deps: ['$emSetImmediate', '$callUserCallback'],
+  emscripten_queue_microtask: (cb, userData) => {
+    {{{ runtimeKeepalivePush(); }}}
+    return queueMicrotask(() => {
+      {{{ runtimeKeepalivePop(); }}}
+      callUserCallback(() => {{{ makeDynCall('vp', 'cb') }}}(userData));
+    });
+  },
+
   emscripten_set_immediate__deps: ['$emSetImmediate', '$callUserCallback'],
   emscripten_set_immediate: (cb, userData) => {
     {{{ runtimeKeepalivePush(); }}}

--- a/src/lib/libpromise.js
+++ b/src/lib/libpromise.js
@@ -51,7 +51,7 @@ addToLibrary({
                                      'emscripten_promise_destroy'],
   emscripten_promise_resolve: (id, result, value) => {
 #if RUNTIME_DEBUG
-    dbg(`emscripten_promise_resolve: ${id}`);
+    dbg(`emscripten_promise_resolve: ${id} -> ${value}`);
 #endif
     var info = promiseMap.get(id);
     switch (result) {
@@ -59,9 +59,15 @@ addToLibrary({
         info.resolve(value);
         return;
       case {{{ cDefs.EM_PROMISE_MATCH }}}:
+#if ASSERTIONS
+        assert(id != value, 'cannot resolve promise to itself')
+#endif
         info.resolve(getPromise(value));
         return;
       case {{{ cDefs.EM_PROMISE_MATCH_RELEASE }}}:
+#if ASSERTIONS
+        assert(id != value, 'cannot resolve promise to itself')
+#endif
         info.resolve(getPromise(value));
         _emscripten_promise_destroy(value);
         return;

--- a/src/lib/libsigs.js
+++ b/src/lib/libsigs.js
@@ -733,6 +733,7 @@ sigs = {
   emscripten_promise_race__sig: 'ppp',
   emscripten_promise_resolve__sig: 'vpip',
   emscripten_promise_then__sig: 'ppppp',
+  emscripten_queue_microtask__sig: 'ipp',
   emscripten_random__sig: 'f',
   emscripten_request_animation_frame__sig: 'ipp',
   emscripten_request_animation_frame_loop__sig: 'vpp',

--- a/system/include/emscripten/eventloop.h
+++ b/system/include/emscripten/eventloop.h
@@ -26,6 +26,8 @@ void emscripten_set_immediate_loop(bool (*cb)(void *user_data), void *user_data)
 int emscripten_set_interval(void (*cb)(void *user_data) __attribute__((nonnull)), double interval_ms, void *user_data);
 void emscripten_clear_interval(int id);
 
+int emscripten_queue_microtask(void (*cb)(void *user_data) __attribute__((nonnull)), void *user_data);
+
 void emscripten_runtime_keepalive_push(void);
 void emscripten_runtime_keepalive_pop(void);
 bool emscripten_runtime_keepalive_check(void);

--- a/test/other/test_dlopen_promise.c
+++ b/test/other/test_dlopen_promise.c
@@ -6,12 +6,25 @@
 #include <emscripten/emscripten.h>
 #include <emscripten/promise.h>
 
+void load_side_module();
+
+int load_count = 0;
+bool in_callback = false;
+
 em_promise_result_t on_fullfilled(void **result, void* data, void *handle) {
-  printf("onsuccess\n");
+  printf("onsuccess: %d\n", load_count++);
   int* foo = (int*)dlsym(handle, "foo");
   assert(foo);
   printf("foo = %d\n", *foo);
   assert(*foo == 42);
+
+  in_callback = true;
+  if (load_count < 2) {
+    // Load the same again, and make sure we don't re-enter ourselves.
+    load_side_module();
+  }
+  in_callback = false;
+
   return EM_PROMISE_FULFILL;
 }
 
@@ -20,11 +33,15 @@ em_promise_result_t on_rejected(void **result, void* data, void *value) {
   return EM_PROMISE_FULFILL;
 }
 
-int main() {
+void load_side_module() {
   em_promise_t inner = emscripten_dlopen_promise("libside.so", RTLD_NOW);
   em_promise_t outer = emscripten_promise_then(inner, on_fullfilled, on_rejected, NULL);
   emscripten_promise_destroy(outer);
   emscripten_promise_destroy(inner);
+}
+
+int main() {
+  load_side_module();
   printf("returning from main\n");
   return 0;
 }

--- a/test/other/test_dlopen_promise.out
+++ b/test/other/test_dlopen_promise.out
@@ -1,3 +1,5 @@
 returning from main
-onsuccess
+onsuccess: 0
+foo = 42
+onsuccess: 1
 foo = 42


### PR DESCRIPTION
Having sometimes-syncrinous callbacks is a bad idea, and it was actually causing real issues with the emscripten_dlopen_promice API.

See #24461 and https://github.com/pyodide/pyodide/pull/5610#issuecomment-2926336938