### PR TITLE
Refactor gen_struct_info to emit JSON directly. NFC

### DIFF
--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -195,6 +195,8 @@ def generate_c_code(headers):
 
           defines.set(name, type_, name)
 
+  code.append('puts("");')  # Add a newline after the JSON output to flush it.
+
   code.append('return 0;')
   code.append('}')
 
@@ -217,7 +219,6 @@ def generate_cmd(js_file_path, src_file_path, cflags):
                                '-O0',
                                '-Werror',
                                '-Wno-format',
-                               '-nolibc',
                                '-sBOOTSTRAPPING_STRUCT_INFO',
                                '-sINCOMING_MODULE_JS_API=',
                                '-sSTRICT',


### PR DESCRIPTION
I wanted to add something to gen_struct_info functionality, but found it difficult to comprehend the custom intermediate format of the C program's output.

I changed it to emit the desired result directly as JSON instead, which results in the same output but makes code easier to reason about and debug, as well as possibly tiny bit faster as well.