### PR TITLE
Add experimental llvm-libc build

### DIFF
--- a/system/lib/llvm-libc/src/__support/StringUtil/platform_errors.h
+++ b/system/lib/llvm-libc/src/__support/StringUtil/platform_errors.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_STRINGUTIL_PLATFORM_ERRORS_H
 #define LLVM_LIBC_SRC___SUPPORT_STRINGUTIL_PLATFORM_ERRORS_H
 
-#if defined(__linux__) || defined(__Fuchsia__)
+#if defined(__linux__) || defined(__Fuchsia__) || defined(__EMSCRIPTEN__)
 #include "tables/linux_platform_errors.h"
 #else
 #include "tables/minimal_platform_errors.h"

--- a/system/lib/llvm-libc/src/__support/StringUtil/tables/posix_errors.h
+++ b/system/lib/llvm-libc/src/__support/StringUtil/tables/posix_errors.h
@@ -63,7 +63,12 @@ LIBC_INLINE_VAR constexpr MsgTable<76> POSIX_ERRORS = {
     MsgMapping(EPROTO, "Protocol error"),
     MsgMapping(EMULTIHOP, "Multihop attempted"),
     MsgMapping(EBADMSG, "Bad message"),
+#ifdef __EMSCRIPTEN__
+    // For now, match the musl string
+    MsgMapping(EOVERFLOW, "Value too large for data type"),
+#else
     MsgMapping(EOVERFLOW, "Value too large for defined data type"),
+#endif
     MsgMapping(ENOTSOCK, "Socket operation on non-socket"),
     MsgMapping(EDESTADDRREQ, "Destination address required"),
     MsgMapping(EMSGSIZE, "Message too long"),

--- a/system/lib/llvm-libc/src/__support/StringUtil/tables/stdc_errors.h
+++ b/system/lib/llvm-libc/src/__support/StringUtil/tables/stdc_errors.h
@@ -16,7 +16,12 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LIBC_INLINE_VAR constexpr const MsgTable<4> STDC_ERRORS = {
+#ifdef __EMSCRIPTEN__
+    // For now, match the musl name for errno 0.
+    MsgMapping(0, "No error information"),
+#else
     MsgMapping(0, "Success"),
+#endif
     MsgMapping(EDOM, "Numerical argument out of domain"),
     MsgMapping(ERANGE, "Numerical result out of range"),
     MsgMapping(EILSEQ, "Invalid or incomplete multibyte or wide character"),

--- a/system/lib/llvm-libc/src/__support/macros/properties/architectures.h
+++ b/system/lib/llvm-libc/src/__support/macros/properties/architectures.h
@@ -41,6 +41,10 @@
 #define LIBC_TARGET_ARCH_IS_ARM
 #endif
 
+#if defined(__wasm__)
+#define LIBC_TARGET_ARCH_IS_WASM
+#endif
+
 #if defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)
 #define LIBC_TARGET_ARCH_IS_AARCH64
 #endif

--- a/system/lib/llvm-libc/src/errno/libc_errno.cpp
+++ b/system/lib/llvm-libc/src/errno/libc_errno.cpp
@@ -1,0 +1,96 @@
+//===-- Implementation of libc_errno --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "libc_errno.h"
+#include "src/__support/macros/config.h"
+
+// libc uses a fallback default value, either system or thread local.
+#define LIBC_ERRNO_MODE_DEFAULT 0
+// libc never stores a value; `errno` macro uses get link-time failure.
+#define LIBC_ERRNO_MODE_UNDEFINED 1
+// libc maintains per-thread state (requires C++ `thread_local` support).
+#define LIBC_ERRNO_MODE_THREAD_LOCAL 2
+// libc maintains shared state used by all threads, contrary to standard C
+// semantics unless always single-threaded; nothing prevents data races.
+#define LIBC_ERRNO_MODE_SHARED 3
+// libc doesn't maintain any internal state, instead the embedder must define
+// `int *__llvm_libc_errno(void);` C function.
+#define LIBC_ERRNO_MODE_EXTERNAL 4
+// libc uses system `<errno.h>` `errno` macro directly in the overlay mode; in
+// fullbuild mode, effectively the same as `LIBC_ERRNO_MODE_EXTERNAL`.
+#define LIBC_ERRNO_MODE_SYSTEM 5
+
+#if !defined(LIBC_ERRNO_MODE) || LIBC_ERRNO_MODE == LIBC_ERRNO_MODE_DEFAULT
+#undef LIBC_ERRNO_MODE
+#if defined(LIBC_FULL_BUILD) || !defined(LIBC_COPT_PUBLIC_PACKAGING)
+#define LIBC_ERRNO_MODE LIBC_ERRNO_MODE_THREAD_LOCAL
+#else
+#define LIBC_ERRNO_MODE LIBC_ERRNO_MODE_SYSTEM
+#endif
+#endif // LIBC_ERRNO_MODE
+
+#if LIBC_ERRNO_MODE != LIBC_ERRNO_MODE_DEFAULT &&                              \
+    LIBC_ERRNO_MODE != LIBC_ERRNO_MODE_UNDEFINED &&                            \
+    LIBC_ERRNO_MODE != LIBC_ERRNO_MODE_THREAD_LOCAL &&                         \
+    LIBC_ERRNO_MODE != LIBC_ERRNO_MODE_SHARED &&                               \
+    LIBC_ERRNO_MODE != LIBC_ERRNO_MODE_EXTERNAL &&                             \
+    LIBC_ERRNO_MODE != LIBC_ERRNO_MODE_SYSTEM
+#error LIBC_ERRNO_MODE must be one of the following values: \
+LIBC_ERRNO_MODE_DEFAULT, \
+LIBC_ERRNO_MODE_UNDEFINED, \
+LIBC_ERRNO_MODE_THREAD_LOCAL, \
+LIBC_ERRNO_MODE_SHARED, \
+LIBC_ERRNO_MODE_EXTERNAL, \
+LIBC_ERRNO_MODE_SYSTEM
+#endif
+
+namespace LIBC_NAMESPACE_DECL {
+
+#if LIBC_ERRNO_MODE == LIBC_ERRNO_MODE_UNDEFINED
+
+void Errno::operator=(int) {}
+Errno::operator int() { return 0; }
+
+#elif LIBC_ERRNO_MODE == LIBC_ERRNO_MODE_THREAD_LOCAL
+
+namespace {
+LIBC_THREAD_LOCAL int thread_errno;
+}
+
+extern "C" int *__llvm_libc_errno() noexcept { return &thread_errno; }
+
+void Errno::operator=(int a) { thread_errno = a; }
+Errno::operator int() { return thread_errno; }
+
+#elif LIBC_ERRNO_MODE == LIBC_ERRNO_MODE_SHARED
+
+namespace {
+int shared_errno;
+}
+
+extern "C" int *__llvm_libc_errno() noexcept { return &shared_errno; }
+
+void Errno::operator=(int a) { shared_errno = a; }
+Errno::operator int() { return shared_errno; }
+
+#elif LIBC_ERRNO_MODE == LIBC_ERRNO_MODE_EXTERNAL
+
+void Errno::operator=(int a) { *__llvm_libc_errno() = a; }
+Errno::operator int() { return *__llvm_libc_errno(); }
+
+#elif LIBC_ERRNO_MODE == LIBC_ERRNO_MODE_SYSTEM
+
+void Errno::operator=(int a) { errno = a; }
+Errno::operator int() { return errno; }
+
+#endif
+
+// Define the global `libc_errno` instance.
+Errno libc_errno;
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/errno/libc_errno.h
+++ b/system/lib/llvm-libc/src/errno/libc_errno.h
@@ -1,0 +1,47 @@
+//===-- Implementation header for libc_errno --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_ERRNO_LIBC_ERRNO_H
+#define LLVM_LIBC_SRC_ERRNO_LIBC_ERRNO_H
+
+#include "src/__support/macros/attributes.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/architectures.h"
+
+#include "hdr/errno_macros.h"
+
+// This header is to be consumed by internal implementations, in which all of
+// them should refer to `libc_errno` instead of using `errno` directly from
+// <errno.h> header.
+
+// Unit and hermetic tests should:
+// - #include "src/errno/libc_errno.h"
+// - NOT #include <errno.h>
+// - Only use `libc_errno` in the code
+// - Depend on libc.src.errno.errno
+
+// Integration tests should:
+// - NOT #include "src/errno/libc_errno.h"
+// - #include <errno.h>
+// - Use regular `errno` in the code
+// - Still depend on libc.src.errno.errno
+
+namespace LIBC_NAMESPACE_DECL {
+
+extern "C" int *__llvm_libc_errno() noexcept;
+
+struct Errno {
+  void operator=(int);
+  operator int();
+};
+
+extern Errno libc_errno;
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_ERRNO_LIBC_ERRNO_H

--- a/system/lib/llvm-libc/src/string/allocating_string_utils.h
+++ b/system/lib/llvm-libc/src/string/allocating_string_utils.h
@@ -1,0 +1,38 @@
+//===-- Allocating string utils ---------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_ALLOCATING_STRING_UTILS_H
+#define LLVM_LIBC_SRC_STRING_ALLOCATING_STRING_UTILS_H
+
+#include "src/__support/CPP/new.h"
+#include "src/__support/CPP/optional.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memcpy.h"
+#include "src/string/string_utils.h"
+
+#include <stddef.h> // For size_t
+
+namespace LIBC_NAMESPACE_DECL {
+namespace internal {
+
+LIBC_INLINE cpp::optional<char *> strdup(const char *src) {
+  if (src == nullptr)
+    return cpp::nullopt;
+  size_t len = string_length(src) + 1;
+  AllocChecker ac;
+  char *newstr = new (ac) char[len];
+  if (!ac)
+    return cpp::nullopt;
+  inline_memcpy(newstr, src, len);
+  return newstr;
+}
+
+} // namespace internal
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_ALLOCATING_STRING_UTILS_H

--- a/system/lib/llvm-libc/src/string/memccpy.cpp
+++ b/system/lib/llvm-libc/src/string/memccpy.cpp
@@ -1,0 +1,36 @@
+//===-- Implementation of memccpy ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/memccpy.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include <stddef.h> // For size_t.
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void *, memccpy,
+                   (void *__restrict dest, const void *__restrict src, int c,
+                    size_t count)) {
+  unsigned char end = static_cast<unsigned char>(c);
+  const unsigned char *uc_src = static_cast<const unsigned char *>(src);
+  unsigned char *uc_dest = static_cast<unsigned char *>(dest);
+  size_t i = 0;
+  // Copy up until end is found.
+  for (; i < count && uc_src[i] != end; ++i)
+    uc_dest[i] = uc_src[i];
+  // if i < count, then end must have been found, so copy end into dest and
+  // return the byte after.
+  if (i < count) {
+    uc_dest[i] = uc_src[i];
+    return uc_dest + i + 1;
+  }
+  return nullptr;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/memccpy.h
+++ b/system/lib/llvm-libc/src/string/memccpy.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for memccpy -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMCCPY_H
+#define LLVM_LIBC_SRC_STRING_MEMCCPY_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+void *memccpy(void *__restrict dest, const void *__restrict src, int c,
+              size_t count);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMCCPY_H

--- a/system/lib/llvm-libc/src/string/memchr.cpp
+++ b/system/lib/llvm-libc/src/string/memchr.cpp
@@ -1,0 +1,25 @@
+//===-- Implementation of memchr ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/memchr.h"
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+
+#include "src/__support/common.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO: Look at performance benefits of comparing words.
+LLVM_LIBC_FUNCTION(void *, memchr, (const void *src, int c, size_t n)) {
+  return internal::find_first_character(
+      reinterpret_cast<const unsigned char *>(src),
+      static_cast<unsigned char>(c), n);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/memchr.h
+++ b/system/lib/llvm-libc/src/string/memchr.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for memchr ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMCHR_H
+#define LLVM_LIBC_SRC_STRING_MEMCHR_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+void *memchr(const void *src, int c, size_t n);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMCHR_H

--- a/system/lib/llvm-libc/src/string/memcmp.cpp
+++ b/system/lib/llvm-libc/src/string/memcmp.cpp
@@ -1,0 +1,22 @@
+//===-- Implementation of memcmp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/memcmp.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memcmp.h"
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, memcmp,
+                   (const void *lhs, const void *rhs, size_t count)) {
+  return inline_memcmp(lhs, rhs, count);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/memcmp.h
+++ b/system/lib/llvm-libc/src/string/memcmp.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for memcmp ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMCMP_H
+#define LLVM_LIBC_SRC_STRING_MEMCMP_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+int memcmp(const void *lhs, const void *rhs, size_t count);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMCMP_H

--- a/system/lib/llvm-libc/src/string/memcpy.cpp
+++ b/system/lib/llvm-libc/src/string/memcpy.cpp
@@ -1,0 +1,23 @@
+//===-- Implementation of memcpy ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/memcpy.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memcpy.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void *, memcpy,
+                   (void *__restrict dst, const void *__restrict src,
+                    size_t size)) {
+  inline_memcpy(dst, src, size);
+  return dst;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/memcpy.h
+++ b/system/lib/llvm-libc/src/string/memcpy.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for memcpy ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMCPY_H
+#define LLVM_LIBC_SRC_STRING_MEMCPY_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+void *memcpy(void *__restrict, const void *__restrict, size_t);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMCPY_H

--- a/system/lib/llvm-libc/src/string/memmem.cpp
+++ b/system/lib/llvm-libc/src/string/memmem.cpp
@@ -1,0 +1,25 @@
+//===-- Implementation of memmem ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/memmem.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memmem.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void *, memmem,
+                   (const void *haystack, size_t haystack_len,
+                    const void *needle, size_t needle_len)) {
+  constexpr auto COMP = [](unsigned char l, unsigned char r) -> int {
+    return l - r;
+  };
+  return inline_memmem(haystack, haystack_len, needle, needle_len, COMP);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/memmem.h
+++ b/system/lib/llvm-libc/src/string/memmem.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for memmem ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMMEM_H
+#define LLVM_LIBC_SRC_STRING_MEMMEM_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h> // For size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+void *memmem(const void *haystack, size_t haystack_len, const void *needle,
+             size_t needle_len);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMMEM_H

--- a/system/lib/llvm-libc/src/string/memmove.cpp
+++ b/system/lib/llvm-libc/src/string/memmove.cpp
@@ -1,0 +1,32 @@
+//===-- Implementation of memmove -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/memmove.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memcpy.h"
+#include "src/string/memory_utils/inline_memmove.h"
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void *, memmove,
+                   (void *dst, const void *src, size_t count)) {
+  // Memmove may handle some small sizes as efficiently as inline_memcpy.
+  // For these sizes we may not do is_disjoint check.
+  // This both avoids additional code for the most frequent smaller sizes
+  // and removes code bloat (we don't need the memcpy logic for small sizes).
+  if (inline_memmove_small_size(dst, src, count))
+    return dst;
+  if (is_disjoint(dst, src, count))
+    inline_memcpy(dst, src, count);
+  else
+    inline_memmove_follow_up(dst, src, count);
+  return dst;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/memmove.h
+++ b/system/lib/llvm-libc/src/string/memmove.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for memmove -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMMOVE_H
+#define LLVM_LIBC_SRC_STRING_MEMMOVE_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+void *memmove(void *dst, const void *src, size_t count);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMMOVE_H

--- a/system/lib/llvm-libc/src/string/memory_utils/README.md
+++ b/system/lib/llvm-libc/src/string/memory_utils/README.md
@@ -1,0 +1,97 @@
+# The mem* framework
+
+The framework handles the following mem* functions:
+ - `memcpy`
+ - `memmove`
+ - `memset`
+ - `bzero`
+ - `bcmp`
+ - `memcmp`
+
+## Building blocks
+
+These functions can be built out of a set of lower-level operations:
+ - **`block`** : operates on a block of `SIZE` bytes.
+ - **`tail`** : operates on the last `SIZE` bytes of the buffer (e.g., `[dst + count - SIZE, dst + count]`)
+ - **`head_tail`** : operates on the first and last `SIZE` bytes. This is the same as calling `block` and `tail`.
+ - **`loop_and_tail`** : calls `block` in a loop to consume as much as possible of the `count` bytes and handle the remaining bytes with a `tail` operation.
+
+As an illustration, let's take the example of a trivial `memset` implementation:
+
+ ```C++
+ extern "C" void memset(const char* dst, int value, size_t count) {
+    if (count == 0) return;
+    if (count == 1) return Memset<1>::block(dst, value);
+    if (count == 2) return Memset<2>::block(dst, value);
+    if (count == 3) return Memset<3>::block(dst, value);
+    if (count <= 8) return Memset<4>::head_tail(dst, value, count);  // Note that 0 to 4 bytes are written twice.
+    if (count <= 16) return Memset<8>::head_tail(dst, value, count); // Same here.
+    return Memset<16>::loop_and_tail(dst, value, count);
+}
+ ```
+
+Now let's have a look into the `Memset` structure:
+
+```C++
+template <size_t Size>
+struct Memset {
+  static constexpr size_t SIZE = Size;
+
+  LIBC_INLINE static void block(Ptr dst, uint8_t value) {
+    // Implement me
+  }
+
+  LIBC_INLINE static void tail(Ptr dst, uint8_t value, size_t count) {
+    block(dst + count - SIZE, value);
+  }
+
+  LIBC_INLINE static void head_tail(Ptr dst, uint8_t value, size_t count) {
+    block(dst, value);
+    tail(dst, value, count);
+  }
+
+  LIBC_INLINE static void loop_and_tail(Ptr dst, uint8_t value, size_t count) {
+    size_t offset = 0;
+    do {
+      block(dst + offset, value);
+      offset += SIZE;
+    } while (offset < count - SIZE);
+    tail(dst, value, count);
+  }
+};
+```
+
+As you can see, the `tail`, `head_tail` and `loop_and_tail` are higher order functions that build on each others. Only `block` really needs to be implemented.
+In earlier designs we were implementing these higher order functions with templated functions but it appears that it is more readable to have the implementation explicitly stated.
+**This design is useful because it provides customization points**. For instance, for `bcmp` on `aarch64` we can provide a better implementation of `head_tail` using vector reduction intrinsics.
+
+## Scoped specializations
+
+We can have several specializations of the `Memset` structure. Depending on the target requirements we can use one or several scopes for the same implementation.
+
+In the following example we use the `generic` implementation for the small sizes but use the `x86` implementation for the loop.
+```C++
+ extern "C" void memset(const char* dst, int value, size_t count) {
+    if (count == 0) return;
+    if (count == 1) return generic::Memset<1>::block(dst, value);
+    if (count == 2) return generic::Memset<2>::block(dst, value);
+    if (count == 3) return generic::Memset<3>::block(dst, value);
+    if (count <= 8) return generic::Memset<4>::head_tail(dst, value, count);
+    if (count <= 16) return generic::Memset<8>::head_tail(dst, value, count);
+    return x86::Memset<16>::loop_and_tail(dst, value, count);
+}
+```
+
+### The `builtin` scope
+
+Ultimately we would like the compiler to provide the code for the `block` function. For this we rely on dedicated builtins available in Clang (e.g., [`__builtin_memset_inline`](https://clang.llvm.org/docs/LanguageExtensions.html#guaranteed-inlined-memset))
+
+### The `generic` scope
+
+In this scope we define pure C++ implementations using native integral types and clang vector extensions.
+
+### The arch specific scopes
+
+Then comes implementations that are using specific architectures or microarchitectures features (e.g., `rep;movsb` for `x86` or `dc zva` for `aarch64`).
+
+The purpose here is to rely on builtins as much as possible and fallback to `asm volatile` as a last resort.

--- a/system/lib/llvm-libc/src/string/memory_utils/aarch64/inline_bcmp.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/aarch64/inline_bcmp.h
@@ -1,0 +1,71 @@
+//===-- Bcmp implementation for aarch64 -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LIBC_SRC_STRING_MEMORY_UTILS_AARCH64_INLINE_BCMP_H
+#define LIBC_SRC_STRING_MEMORY_UTILS_AARCH64_INLINE_BCMP_H
+
+#include "src/__support/macros/attributes.h"   // LIBC_INLINE
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+#include "src/string/memory_utils/op_aarch64.h"
+#include "src/string/memory_utils/op_generic.h"
+#include "src/string/memory_utils/utils.h" // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[maybe_unused]] LIBC_INLINE BcmpReturnType inline_bcmp_aarch64(CPtr p1,
+                                                                CPtr p2,
+                                                                size_t count) {
+  if (LIBC_LIKELY(count <= 32)) {
+    if (LIBC_UNLIKELY(count >= 16)) {
+      return aarch64::Bcmp<16>::head_tail(p1, p2, count);
+    }
+    switch (count) {
+    case 0:
+      return BcmpReturnType::zero();
+    case 1:
+      return generic::Bcmp<uint8_t>::block(p1, p2);
+    case 2:
+      return generic::Bcmp<uint16_t>::block(p1, p2);
+    case 3:
+      return generic::Bcmp<uint16_t>::head_tail(p1, p2, count);
+    case 4:
+      return generic::Bcmp<uint32_t>::block(p1, p2);
+    case 5:
+    case 6:
+    case 7:
+      return generic::Bcmp<uint32_t>::head_tail(p1, p2, count);
+    case 8:
+      return generic::Bcmp<uint64_t>::block(p1, p2);
+    case 9:
+    case 10:
+    case 11:
+    case 12:
+    case 13:
+    case 14:
+    case 15:
+      return generic::Bcmp<uint64_t>::head_tail(p1, p2, count);
+    }
+  }
+
+  if (count <= 64)
+    return aarch64::Bcmp<32>::head_tail(p1, p2, count);
+
+  // Aligned loop if > 256, otherwise normal loop
+  if (LIBC_UNLIKELY(count > 256)) {
+    if (auto value = aarch64::Bcmp<32>::block(p1, p2))
+      return value;
+    align_to_next_boundary<16, Arg::P1>(p1, p2, count);
+  }
+  return aarch64::Bcmp<32>::loop_and_tail(p1, p2, count);
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_SRC_STRING_MEMORY_UTILS_AARCH64_INLINE_BCMP_H

--- a/system/lib/llvm-libc/src/string/memory_utils/aarch64/inline_memcmp.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/aarch64/inline_memcmp.h
@@ -1,0 +1,71 @@
+//===-- Memcmp implementation for aarch64 -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMCMP_H
+#define LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMCMP_H
+
+#include "src/__support/macros/attributes.h"   // LIBC_INLINE
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+#include "src/string/memory_utils/op_aarch64.h"
+#include "src/string/memory_utils/op_generic.h"
+#include "src/string/memory_utils/utils.h" // MemcmpReturnType
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[maybe_unused]] LIBC_INLINE MemcmpReturnType
+inline_memcmp_generic_gt16(CPtr p1, CPtr p2, size_t count) {
+  if (LIBC_UNLIKELY(count >= 384)) {
+    if (auto value = generic::Memcmp<uint8x16_t>::block(p1, p2))
+      return value;
+    align_to_next_boundary<16, Arg::P1>(p1, p2, count);
+  }
+  return generic::Memcmp<uint8x16_t>::loop_and_tail(p1, p2, count);
+}
+
+[[maybe_unused]] LIBC_INLINE MemcmpReturnType
+inline_memcmp_aarch64_neon_gt16(CPtr p1, CPtr p2, size_t count) {
+  if (LIBC_UNLIKELY(count >= 128)) { // [128, ∞]
+    if (auto value = generic::Memcmp<uint8x16_t>::block(p1, p2))
+      return value;
+    align_to_next_boundary<16, Arg::P1>(p1, p2, count);
+    return generic::Memcmp<uint8x16x2_t>::loop_and_tail(p1, p2, count);
+  }
+  if (generic::Bcmp<uint8x16_t>::block(p1, p2)) // [16, 16]
+    return generic::Memcmp<uint8x16_t>::block(p1, p2);
+  if (count < 32) // [17, 31]
+    return generic::Memcmp<uint8x16_t>::tail(p1, p2, count);
+  if (generic::Bcmp<uint8x16_t>::block(p1 + 16, p2 + 16)) // [32, 32]
+    return generic::Memcmp<uint8x16_t>::block(p1 + 16, p2 + 16);
+  if (count < 64) // [33, 63]
+    return generic::Memcmp<uint8x16x2_t>::tail(p1, p2, count);
+  // [64, 127]
+  return generic::Memcmp<uint8x16_t>::loop_and_tail(p1 + 32, p2 + 32,
+                                                    count - 32);
+}
+
+LIBC_INLINE MemcmpReturnType inline_memcmp_aarch64(CPtr p1, CPtr p2,
+                                                   size_t count) {
+  if (count == 0)
+    return MemcmpReturnType::zero();
+  if (count == 1)
+    return generic::Memcmp<uint8_t>::block(p1, p2);
+  if (count == 2)
+    return generic::Memcmp<uint16_t>::block(p1, p2);
+  if (count == 3)
+    return generic::MemcmpSequence<uint16_t, uint8_t>::block(p1, p2);
+  if (count <= 8)
+    return generic::Memcmp<uint32_t>::head_tail(p1, p2, count);
+  if (count <= 16)
+    return generic::Memcmp<uint64_t>::head_tail(p1, p2, count);
+  if constexpr (aarch64::kNeon)
+    return inline_memcmp_aarch64_neon_gt16(p1, p2, count);
+  else
+    return inline_memcmp_generic_gt16(p1, p2, count);
+}
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMCMP_H

--- a/system/lib/llvm-libc/src/string/memory_utils/aarch64/inline_memcpy.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/aarch64/inline_memcpy.h
@@ -1,0 +1,48 @@
+//===-- Memcpy implementation for aarch64 -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_AARCH64_INLINE_MEMCPY_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_AARCH64_INLINE_MEMCPY_H
+
+#include "src/__support/macros/attributes.h" // LIBC_INLINE
+#include "src/string/memory_utils/op_builtin.h"
+#include "src/string/memory_utils/utils.h"
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memcpy_aarch64(Ptr __restrict dst, CPtr __restrict src, size_t count) {
+  if (count == 0)
+    return;
+  if (count == 1)
+    return builtin::Memcpy<1>::block(dst, src);
+  if (count == 2)
+    return builtin::Memcpy<2>::block(dst, src);
+  if (count == 3)
+    return builtin::Memcpy<3>::block(dst, src);
+  if (count == 4)
+    return builtin::Memcpy<4>::block(dst, src);
+  if (count < 8)
+    return builtin::Memcpy<4>::head_tail(dst, src, count);
+  if (count < 16)
+    return builtin::Memcpy<8>::head_tail(dst, src, count);
+  if (count < 32)
+    return builtin::Memcpy<16>::head_tail(dst, src, count);
+  if (count < 64)
+    return builtin::Memcpy<32>::head_tail(dst, src, count);
+  if (count < 128)
+    return builtin::Memcpy<64>::head_tail(dst, src, count);
+  builtin::Memcpy<16>::block(dst, src);
+  align_to_next_boundary<16, Arg::Src>(dst, src, count);
+  return builtin::Memcpy<64>::loop_and_tail(dst, src, count);
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_AARCH64_INLINE_MEMCPY_H

--- a/system/lib/llvm-libc/src/string/memory_utils/aarch64/inline_memmove.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/aarch64/inline_memmove.h
@@ -1,0 +1,53 @@
+//===-- Memmove implementation for aarch64 ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LIBC_SRC_STRING_MEMORY_UTILS_AARCH64_INLINE_MEMMOVE_H
+#define LIBC_SRC_STRING_MEMORY_UTILS_AARCH64_INLINE_MEMMOVE_H
+
+#include "src/__support/macros/attributes.h"    // LIBC_INLINE
+#include "src/string/memory_utils/op_aarch64.h" // aarch64::kNeon
+#include "src/string/memory_utils/op_builtin.h"
+#include "src/string/memory_utils/op_generic.h"
+#include "src/string/memory_utils/utils.h"
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+LIBC_INLINE void inline_memmove_aarch64(Ptr dst, CPtr src, size_t count) {
+  static_assert(aarch64::kNeon, "aarch64 supports vector types");
+  using uint128_t = generic_v128;
+  using uint256_t = generic_v256;
+  using uint512_t = generic_v512;
+  if (count == 0)
+    return;
+  if (count == 1)
+    return generic::Memmove<uint8_t>::block(dst, src);
+  if (count <= 4)
+    return generic::Memmove<uint16_t>::head_tail(dst, src, count);
+  if (count <= 8)
+    return generic::Memmove<uint32_t>::head_tail(dst, src, count);
+  if (count <= 16)
+    return generic::Memmove<uint64_t>::head_tail(dst, src, count);
+  if (count <= 32)
+    return generic::Memmove<uint128_t>::head_tail(dst, src, count);
+  if (count <= 64)
+    return generic::Memmove<uint256_t>::head_tail(dst, src, count);
+  if (count <= 128)
+    return generic::Memmove<uint512_t>::head_tail(dst, src, count);
+  if (dst < src) {
+    generic::Memmove<uint256_t>::align_forward<Arg::Src>(dst, src, count);
+    return generic::Memmove<uint512_t>::loop_and_tail_forward(dst, src, count);
+  } else {
+    generic::Memmove<uint256_t>::align_backward<Arg::Src>(dst, src, count);
+    return generic::Memmove<uint512_t>::loop_and_tail_backward(dst, src, count);
+  }
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_SRC_STRING_MEMORY_UTILS_AARCH64_INLINE_MEMMOVE_H

--- a/system/lib/llvm-libc/src/string/memory_utils/aarch64/inline_memset.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/aarch64/inline_memset.h
@@ -1,0 +1,62 @@
+//===-- Memset implementation for aarch64 -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LIBC_SRC_STRING_MEMORY_UTILS_AARCH64_INLINE_MEMSET_H
+#define LIBC_SRC_STRING_MEMORY_UTILS_AARCH64_INLINE_MEMSET_H
+
+#include "src/__support/macros/attributes.h" // LIBC_INLINE
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/op_aarch64.h"
+#include "src/string/memory_utils/op_generic.h"
+#include "src/string/memory_utils/utils.h" // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[maybe_unused]] LIBC_INLINE static void
+inline_memset_aarch64(Ptr dst, uint8_t value, size_t count) {
+  static_assert(aarch64::kNeon, "aarch64 supports vector types");
+  using uint128_t = generic_v128;
+  using uint256_t = generic_v256;
+  using uint512_t = generic_v512;
+  if (count == 0)
+    return;
+  if (count <= 3) {
+    generic::Memset<uint8_t>::block(dst, value);
+    if (count > 1)
+      generic::Memset<uint16_t>::tail(dst, value, count);
+    return;
+  }
+  if (count <= 8)
+    return generic::Memset<uint32_t>::head_tail(dst, value, count);
+  if (count <= 16)
+    return generic::Memset<uint64_t>::head_tail(dst, value, count);
+  if (count <= 32)
+    return generic::Memset<uint128_t>::head_tail(dst, value, count);
+  if (count <= (32 + 64)) {
+    generic::Memset<uint256_t>::block(dst, value);
+    if (count <= 64)
+      return generic::Memset<uint256_t>::tail(dst, value, count);
+    generic::Memset<uint256_t>::block(dst + 32, value);
+    generic::Memset<uint256_t>::tail(dst, value, count);
+    return;
+  }
+  if (count >= 448 && value == 0 && aarch64::neon::hasZva()) {
+    generic::Memset<uint512_t>::block(dst, 0);
+    align_to_next_boundary<64>(dst, count);
+    return aarch64::neon::BzeroCacheLine::loop_and_tail(dst, 0, count);
+  } else {
+    generic::Memset<uint128_t>::block(dst, value);
+    align_to_next_boundary<16>(dst, count);
+    return generic::Memset<uint512_t>::loop_and_tail(dst, value, count);
+  }
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_SRC_STRING_MEMORY_UTILS_AARCH64_INLINE_MEMSET_H

--- a/system/lib/llvm-libc/src/string/memory_utils/generic/aligned_access.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/generic/aligned_access.h
@@ -1,0 +1,207 @@
+//===-- Implementations for platform with mandatory aligned memory access -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// For some platforms, unaligned loads and stores are either illegal or very
+// slow. The implementations in this file make sure all loads and stores are
+// always aligned.
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_GENERIC_ALIGNED_ACCESS_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_GENERIC_ALIGNED_ACCESS_H
+
+#include "src/__support/macros/attributes.h" // LIBC_INLINE
+#include "src/string/memory_utils/generic/byte_per_byte.h"
+#include "src/string/memory_utils/op_generic.h" // generic::splat
+#include "src/string/memory_utils/utils.h"      // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[maybe_unused]] LIBC_INLINE uint32_t load32_aligned(CPtr ptr, size_t offset,
+                                                     size_t alignment) {
+  if (alignment == 0)
+    return load32_aligned<uint32_t>(ptr, offset);
+  else if (alignment == 2)
+    return load32_aligned<uint16_t, uint16_t>(ptr, offset);
+  else // 1, 3
+    return load32_aligned<uint8_t, uint16_t, uint8_t>(ptr, offset);
+}
+
+[[maybe_unused]] LIBC_INLINE uint64_t load64_aligned(CPtr ptr, size_t offset,
+                                                     size_t alignment) {
+  if (alignment == 0)
+    return load64_aligned<uint64_t>(ptr, offset);
+  else if (alignment == 4)
+    return load64_aligned<uint32_t, uint32_t>(ptr, offset);
+  else if (alignment == 6)
+    return load64_aligned<uint16_t, uint32_t, uint16_t>(ptr, offset);
+  else if (alignment == 2)
+    return load64_aligned<uint16_t, uint16_t, uint16_t, uint16_t>(ptr, offset);
+  else // 1, 3, 5, 7
+    return load64_aligned<uint8_t, uint16_t, uint16_t, uint16_t, uint8_t>(
+        ptr, offset);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// memcpy
+///////////////////////////////////////////////////////////////////////////////
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memcpy_aligned_access_32bit(Ptr __restrict dst, CPtr __restrict src,
+                                   size_t count) {
+  constexpr size_t kAlign = sizeof(uint32_t);
+  if (count <= 2 * kAlign)
+    return inline_memcpy_byte_per_byte(dst, src, count);
+  size_t bytes_to_dst_align = distance_to_align_up<kAlign>(dst);
+  inline_memcpy_byte_per_byte(dst, src, bytes_to_dst_align);
+  size_t offset = bytes_to_dst_align;
+  size_t src_alignment = distance_to_align_down<kAlign>(src + offset);
+  for (; offset < count - kAlign; offset += kAlign) {
+    uint32_t value = load32_aligned(src, offset, src_alignment);
+    store32_aligned<uint32_t>(value, dst, offset);
+  }
+  // remainder
+  inline_memcpy_byte_per_byte(dst, src, count, offset);
+}
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memcpy_aligned_access_64bit(Ptr __restrict dst, CPtr __restrict src,
+                                   size_t count) {
+  constexpr size_t kAlign = sizeof(uint64_t);
+  if (count <= 2 * kAlign)
+    return inline_memcpy_byte_per_byte(dst, src, count);
+  size_t bytes_to_dst_align = distance_to_align_up<kAlign>(dst);
+  inline_memcpy_byte_per_byte(dst, src, bytes_to_dst_align);
+  size_t offset = bytes_to_dst_align;
+  size_t src_alignment = distance_to_align_down<kAlign>(src + offset);
+  for (; offset < count - kAlign; offset += kAlign) {
+    uint64_t value = load64_aligned(src, offset, src_alignment);
+    store64_aligned<uint64_t>(value, dst, offset);
+  }
+  // remainder
+  inline_memcpy_byte_per_byte(dst, src, count, offset);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// memset
+///////////////////////////////////////////////////////////////////////////////
+
+[[maybe_unused]] LIBC_INLINE static void
+inline_memset_aligned_access_32bit(Ptr dst, uint8_t value, size_t count) {
+  constexpr size_t kAlign = sizeof(uint32_t);
+  if (count <= 2 * kAlign)
+    return inline_memset_byte_per_byte(dst, value, count);
+  size_t bytes_to_dst_align = distance_to_align_up<kAlign>(dst);
+  inline_memset_byte_per_byte(dst, value, bytes_to_dst_align);
+  size_t offset = bytes_to_dst_align;
+  for (; offset < count - kAlign; offset += kAlign)
+    store32_aligned<uint32_t>(generic::splat<uint32_t>(value), dst, offset);
+  inline_memset_byte_per_byte(dst, value, count, offset);
+}
+
+[[maybe_unused]] LIBC_INLINE static void
+inline_memset_aligned_access_64bit(Ptr dst, uint8_t value, size_t count) {
+  constexpr size_t kAlign = sizeof(uint64_t);
+  if (count <= 2 * kAlign)
+    return inline_memset_byte_per_byte(dst, value, count);
+  size_t bytes_to_dst_align = distance_to_align_up<kAlign>(dst);
+  inline_memset_byte_per_byte(dst, value, bytes_to_dst_align);
+  size_t offset = bytes_to_dst_align;
+  for (; offset < count - kAlign; offset += kAlign)
+    store64_aligned<uint64_t>(generic::splat<uint64_t>(value), dst, offset);
+  inline_memset_byte_per_byte(dst, value, count, offset);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// bcmp
+///////////////////////////////////////////////////////////////////////////////
+
+[[maybe_unused]] LIBC_INLINE BcmpReturnType
+inline_bcmp_aligned_access_32bit(CPtr p1, CPtr p2, size_t count) {
+  constexpr size_t kAlign = sizeof(uint32_t);
+  if (count <= 2 * kAlign)
+    return inline_bcmp_byte_per_byte(p1, p2, count);
+  size_t bytes_to_p1_align = distance_to_align_up<kAlign>(p1);
+  if (auto value = inline_bcmp_byte_per_byte(p1, p2, bytes_to_p1_align))
+    return value;
+  size_t offset = bytes_to_p1_align;
+  size_t p2_alignment = distance_to_align_down<kAlign>(p2 + offset);
+  for (; offset < count - kAlign; offset += kAlign) {
+    uint32_t a = load32_aligned<uint32_t>(p1, offset);
+    uint32_t b = load32_aligned(p2, offset, p2_alignment);
+    if (a != b)
+      return BcmpReturnType::nonzero();
+  }
+  return inline_bcmp_byte_per_byte(p1, p2, count, offset);
+}
+
+[[maybe_unused]] LIBC_INLINE BcmpReturnType
+inline_bcmp_aligned_access_64bit(CPtr p1, CPtr p2, size_t count) {
+  constexpr size_t kAlign = sizeof(uint64_t);
+  if (count <= 2 * kAlign)
+    return inline_bcmp_byte_per_byte(p1, p2, count);
+  size_t bytes_to_p1_align = distance_to_align_up<kAlign>(p1);
+  if (auto value = inline_bcmp_byte_per_byte(p1, p2, bytes_to_p1_align))
+    return value;
+  size_t offset = bytes_to_p1_align;
+  size_t p2_alignment = distance_to_align_down<kAlign>(p2 + offset);
+  for (; offset < count - kAlign; offset += kAlign) {
+    uint64_t a = load64_aligned<uint64_t>(p1, offset);
+    uint64_t b = load64_aligned(p2, offset, p2_alignment);
+    if (a != b)
+      return BcmpReturnType::nonzero();
+  }
+  return inline_bcmp_byte_per_byte(p1, p2, count, offset);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// memcmp
+///////////////////////////////////////////////////////////////////////////////
+
+[[maybe_unused]] LIBC_INLINE MemcmpReturnType
+inline_memcmp_aligned_access_32bit(CPtr p1, CPtr p2, size_t count) {
+  constexpr size_t kAlign = sizeof(uint32_t);
+  if (count <= 2 * kAlign)
+    return inline_memcmp_byte_per_byte(p1, p2, count);
+  size_t bytes_to_p1_align = distance_to_align_up<kAlign>(p1);
+  if (auto value = inline_memcmp_byte_per_byte(p1, p2, bytes_to_p1_align))
+    return value;
+  size_t offset = bytes_to_p1_align;
+  size_t p2_alignment = distance_to_align_down<kAlign>(p2 + offset);
+  for (; offset < count - kAlign; offset += kAlign) {
+    uint32_t a = load32_aligned<uint32_t>(p1, offset);
+    uint32_t b = load32_aligned(p2, offset, p2_alignment);
+    if (a != b)
+      return cmp_uint32_t(Endian::to_big_endian(a), Endian::to_big_endian(b));
+  }
+  return inline_memcmp_byte_per_byte(p1, p2, count, offset);
+}
+
+[[maybe_unused]] LIBC_INLINE MemcmpReturnType
+inline_memcmp_aligned_access_64bit(CPtr p1, CPtr p2, size_t count) {
+  constexpr size_t kAlign = sizeof(uint64_t);
+  if (count <= 2 * kAlign)
+    return inline_memcmp_byte_per_byte(p1, p2, count);
+  size_t bytes_to_p1_align = distance_to_align_up<kAlign>(p1);
+  if (auto value = inline_memcmp_byte_per_byte(p1, p2, bytes_to_p1_align))
+    return value;
+  size_t offset = bytes_to_p1_align;
+  size_t p2_alignment = distance_to_align_down<kAlign>(p2 + offset);
+  for (; offset < count - kAlign; offset += kAlign) {
+    uint64_t a = load64_aligned<uint64_t>(p1, offset);
+    uint64_t b = load64_aligned(p2, offset, p2_alignment);
+    if (a != b)
+      return cmp_neq_uint64_t(Endian::to_big_endian(a),
+                              Endian::to_big_endian(b));
+  }
+  return inline_memcmp_byte_per_byte(p1, p2, count, offset);
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_GENERIC_ALIGNED_ACCESS_H

--- a/system/lib/llvm-libc/src/string/memory_utils/generic/builtin.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/generic/builtin.h
@@ -1,0 +1,42 @@
+//===-- Trivial builtin implementations  ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_GENERIC_BUILTIN_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_GENERIC_BUILTIN_H
+
+#include "src/__support/macros/attributes.h" // LIBC_INLINE
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/utils.h" // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+#if !__has_builtin(__builtin_memcpy) || !__has_builtin(__builtin_memset) ||    \
+    !__has_builtin(__builtin_memmove)
+#error "Builtin not defined");
+#endif
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memcpy_builtin(Ptr dst, CPtr src, size_t count, size_t offset = 0) {
+  __builtin_memcpy(dst + offset, src + offset, count);
+}
+
+[[maybe_unused]] LIBC_INLINE void inline_memmove_builtin(Ptr dst, CPtr src,
+                                                         size_t count) {
+  __builtin_memmove(dst, src, count);
+}
+
+[[maybe_unused]] LIBC_INLINE static void
+inline_memset_builtin(Ptr dst, uint8_t value, size_t count, size_t offset = 0) {
+  __builtin_memset(dst + offset, value, count);
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_GENERIC_BUILTIN_H

--- a/system/lib/llvm-libc/src/string/memory_utils/generic/byte_per_byte.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/generic/byte_per_byte.h
@@ -1,0 +1,78 @@
+//===-- Trivial byte per byte implementations  ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Straightforward implementations targeting the smallest code size possible.
+// This needs to be compiled with '-Os' or '-Oz'.
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_GENERIC_BYTE_PER_BYTE_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_GENERIC_BYTE_PER_BYTE_H
+
+#include "src/__support/macros/attributes.h"   // LIBC_INLINE
+#include "src/__support/macros/optimization.h" // LIBC_LOOP_NOUNROLL
+#include "src/string/memory_utils/utils.h"     // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memcpy_byte_per_byte(Ptr dst, CPtr src, size_t count,
+                            size_t offset = 0) {
+  LIBC_LOOP_NOUNROLL
+  for (; offset < count; ++offset)
+    dst[offset] = src[offset];
+}
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memmove_byte_per_byte(Ptr dst, CPtr src, size_t count) {
+  if (count == 0 || dst == src)
+    return;
+  if (dst < src) {
+    LIBC_LOOP_NOUNROLL
+    for (size_t offset = 0; offset < count; ++offset)
+      dst[offset] = src[offset];
+  } else {
+    LIBC_LOOP_NOUNROLL
+    for (ptrdiff_t offset = count - 1; offset >= 0; --offset)
+      dst[offset] = src[offset];
+  }
+}
+
+[[maybe_unused]] LIBC_INLINE static void
+inline_memset_byte_per_byte(Ptr dst, uint8_t value, size_t count,
+                            size_t offset = 0) {
+  LIBC_LOOP_NOUNROLL
+  for (; offset < count; ++offset)
+    dst[offset] = static_cast<cpp::byte>(value);
+}
+
+[[maybe_unused]] LIBC_INLINE BcmpReturnType
+inline_bcmp_byte_per_byte(CPtr p1, CPtr p2, size_t count, size_t offset = 0) {
+  LIBC_LOOP_NOUNROLL
+  for (; offset < count; ++offset)
+    if (p1[offset] != p2[offset])
+      return BcmpReturnType::nonzero();
+  return BcmpReturnType::zero();
+}
+
+[[maybe_unused]] LIBC_INLINE MemcmpReturnType
+inline_memcmp_byte_per_byte(CPtr p1, CPtr p2, size_t count, size_t offset = 0) {
+  LIBC_LOOP_NOUNROLL
+  for (; offset < count; ++offset) {
+    const int32_t a = static_cast<int32_t>(p1[offset]);
+    const int32_t b = static_cast<int32_t>(p2[offset]);
+    const int32_t diff = a - b;
+    if (diff)
+      return diff;
+  }
+  return MemcmpReturnType::zero();
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_GENERIC_BYTE_PER_BYTE_H

--- a/system/lib/llvm-libc/src/string/memory_utils/inline_bcmp.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/inline_bcmp.h
@@ -1,0 +1,46 @@
+//===-- Dispatch logic for bcmp -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_BCMP_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_BCMP_H
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/architectures.h" // LIBC_TARGET_ARCH_IS_
+
+#include <stddef.h> // size_t
+
+#if defined(LIBC_TARGET_ARCH_IS_X86)
+#include "src/string/memory_utils/x86_64/inline_bcmp.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_BCMP inline_bcmp_x86
+#elif defined(LIBC_TARGET_ARCH_IS_AARCH64)
+#include "src/string/memory_utils/aarch64/inline_bcmp.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_BCMP inline_bcmp_aarch64
+#elif defined(LIBC_TARGET_ARCH_IS_ANY_RISCV)
+#include "src/string/memory_utils/riscv/inline_bcmp.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_BCMP inline_bcmp_riscv
+#elif defined(LIBC_TARGET_ARCH_IS_ARM) || defined(LIBC_TARGET_ARCH_IS_GPU)
+#include "src/string/memory_utils/generic/byte_per_byte.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_BCMP inline_bcmp_byte_per_byte
+#else
+#error "Unsupported architecture"
+#endif
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[gnu::flatten]] LIBC_INLINE int inline_bcmp(const void *p1, const void *p2,
+                                             size_t count) {
+  return static_cast<int>(LIBC_SRC_STRING_MEMORY_UTILS_BCMP(
+      reinterpret_cast<CPtr>(p1), reinterpret_cast<CPtr>(p2), count));
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#undef LIBC_SRC_STRING_MEMORY_UTILS_BCMP
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_BCMP_H

--- a/system/lib/llvm-libc/src/string/memory_utils/inline_bzero.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/inline_bzero.h
@@ -1,0 +1,30 @@
+//===-- Implementation of bzero -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_BZERO_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_BZERO_H
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memset.h"
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[gnu::flatten]] LIBC_INLINE static void inline_bzero(Ptr dst, size_t count) {
+  inline_memset(dst, 0, count);
+}
+
+[[gnu::flatten]] LIBC_INLINE static void inline_bzero(void *dst, size_t count) {
+  inline_bzero(reinterpret_cast<Ptr>(dst), count);
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_BZERO_H

--- a/system/lib/llvm-libc/src/string/memory_utils/inline_memcmp.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/inline_memcmp.h
@@ -1,0 +1,46 @@
+//===-- Implementation of memcmp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMCMP_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMCMP_H
+
+#include "src/__support/macros/attributes.h"               // LIBC_INLINE
+#include "src/__support/macros/properties/architectures.h" // LIBC_TARGET_ARCH_IS_
+#include "src/string/memory_utils/utils.h"                 // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+#if defined(LIBC_TARGET_ARCH_IS_X86)
+#include "src/string/memory_utils/x86_64/inline_memcmp.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMCMP inline_memcmp_x86
+#elif defined(LIBC_TARGET_ARCH_IS_AARCH64)
+#include "src/string/memory_utils/aarch64/inline_memcmp.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMCMP inline_memcmp_aarch64
+#elif defined(LIBC_TARGET_ARCH_IS_ANY_RISCV)
+#include "src/string/memory_utils/riscv/inline_memcmp.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMCMP inline_memcmp_riscv
+#elif defined(LIBC_TARGET_ARCH_IS_ARM) || defined(LIBC_TARGET_ARCH_IS_GPU) || defined(LIBC_TARGET_ARCH_IS_WASM)
+#include "src/string/memory_utils/generic/byte_per_byte.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMCMP inline_memcmp_byte_per_byte
+#else
+#error "Unsupported architecture"
+#endif
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[gnu::flatten]] LIBC_INLINE int inline_memcmp(const void *p1, const void *p2,
+                                               size_t count) {
+  return static_cast<int>(LIBC_SRC_STRING_MEMORY_UTILS_MEMCMP(
+      reinterpret_cast<CPtr>(p1), reinterpret_cast<CPtr>(p2), count));
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#undef LIBC_SRC_STRING_MEMORY_UTILS_MEMCMP
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMCMP_H

--- a/system/lib/llvm-libc/src/string/memory_utils/inline_memcpy.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/inline_memcpy.h
@@ -1,0 +1,51 @@
+//===-- Memcpy implementation -----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMCPY_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMCPY_H
+
+#include "src/__support/macros/attributes.h"               // LIBC_INLINE
+#include "src/__support/macros/properties/architectures.h" // LIBC_TARGET_ARCH_IS_
+#include "src/string/memory_utils/utils.h"                 // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+#if defined(LIBC_COPT_MEMCPY_USE_EMBEDDED_TINY)
+#include "src/string/memory_utils/generic/byte_per_byte.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMCPY inline_memcpy_byte_per_byte
+#elif defined(LIBC_TARGET_ARCH_IS_X86)
+#include "src/string/memory_utils/x86_64/inline_memcpy.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMCPY                                    \
+  inline_memcpy_x86_maybe_interpose_repmovsb
+#elif defined(LIBC_TARGET_ARCH_IS_AARCH64)
+#include "src/string/memory_utils/aarch64/inline_memcpy.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMCPY inline_memcpy_aarch64
+#elif defined(LIBC_TARGET_ARCH_IS_ANY_RISCV)
+#include "src/string/memory_utils/riscv/inline_memcpy.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMCPY inline_memcpy_riscv
+#elif defined(LIBC_TARGET_ARCH_IS_ARM)
+#include "src/string/memory_utils/generic/byte_per_byte.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMCPY inline_memcpy_byte_per_byte
+#elif defined(LIBC_TARGET_ARCH_IS_GPU) || defined(LIBC_TARGET_ARCH_IS_WASM)
+#include "src/string/memory_utils/generic/builtin.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMCPY inline_memcpy_builtin
+#else
+#error "Unsupported architecture"
+#endif
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[gnu::flatten]] LIBC_INLINE void
+inline_memcpy(void *__restrict dst, const void *__restrict src, size_t count) {
+  LIBC_SRC_STRING_MEMORY_UTILS_MEMCPY(reinterpret_cast<Ptr>(dst),
+                                      reinterpret_cast<CPtr>(src), count);
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMCPY_H

--- a/system/lib/llvm-libc/src/string/memory_utils/inline_memmem.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/inline_memmem.h
@@ -1,0 +1,45 @@
+//===-- memmem implementation -----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMMEM_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMMEM_H
+
+#include "src/__support/macros/attributes.h"
+#include "src/__support/macros/config.h"
+
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+template <typename Comp>
+LIBC_INLINE constexpr static void *
+inline_memmem(const void *haystack, size_t haystack_len, const void *needle,
+              size_t needle_len, Comp &&comp) {
+  // TODO: simple brute force implementation. This can be
+  // improved upon using well known string matching algorithms.
+  if (!needle_len)
+    return const_cast<void *>(haystack);
+
+  if (needle_len > haystack_len)
+    return nullptr;
+
+  const unsigned char *h = static_cast<const unsigned char *>(haystack);
+  const unsigned char *n = static_cast<const unsigned char *>(needle);
+  for (size_t i = 0; i <= (haystack_len - needle_len); ++i) {
+    size_t j = 0;
+    for (; j < needle_len && !comp(h[i + j], n[j]); ++j)
+      ;
+    if (j == needle_len)
+      return const_cast<unsigned char *>(h + i);
+  }
+  return nullptr;
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMMEM_H

--- a/system/lib/llvm-libc/src/string/memory_utils/inline_memmove.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/inline_memmove.h
@@ -1,0 +1,73 @@
+//===-- Memmove implementation ----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMMOVE_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMMOVE_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h> // size_t, ptrdiff_t
+
+#if defined(LIBC_TARGET_ARCH_IS_X86)
+#include "src/string/memory_utils/x86_64/inline_memmove.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_SMALL_SIZE                        \
+  inline_memmove_small_size_x86
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_FOLLOW_UP                         \
+  inline_memmove_follow_up_x86
+#elif defined(LIBC_TARGET_ARCH_IS_AARCH64)
+#include "src/string/memory_utils/aarch64/inline_memmove.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_SMALL_SIZE                        \
+  inline_memmove_no_small_size
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_FOLLOW_UP inline_memmove_aarch64
+#elif defined(LIBC_TARGET_ARCH_IS_ANY_RISCV)
+#include "src/string/memory_utils/riscv/inline_memmove.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_SMALL_SIZE                        \
+  inline_memmove_no_small_size
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_FOLLOW_UP inline_memmove_riscv
+#elif defined(LIBC_TARGET_ARCH_IS_ARM)
+#include "src/string/memory_utils/generic/byte_per_byte.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_SMALL_SIZE                        \
+  inline_memmove_no_small_size
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_FOLLOW_UP                         \
+  inline_memmove_byte_per_byte
+#elif defined(LIBC_TARGET_ARCH_IS_GPU) || defined(LIBC_TARGET_ARCH_IS_WASM)
+#include "src/string/memory_utils/generic/builtin.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_SMALL_SIZE                        \
+  inline_memmove_no_small_size
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_FOLLOW_UP inline_memmove_builtin
+#else
+#error "Unsupported architecture"
+#endif
+
+namespace LIBC_NAMESPACE_DECL {
+
+LIBC_INLINE constexpr bool inline_memmove_no_small_size(void *, const void *,
+                                                        size_t) {
+  return false;
+}
+
+[[gnu::flatten]] LIBC_INLINE bool
+inline_memmove_small_size(void *dst, const void *src, size_t count) {
+  return LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_SMALL_SIZE(
+      reinterpret_cast<Ptr>(dst), reinterpret_cast<CPtr>(src), count);
+}
+
+[[gnu::flatten]] LIBC_INLINE void
+inline_memmove_follow_up(void *dst, const void *src, size_t count) {
+  LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_FOLLOW_UP(
+      reinterpret_cast<Ptr>(dst), reinterpret_cast<CPtr>(src), count);
+}
+
+LIBC_INLINE void inline_memmove(void *dst, const void *src, size_t count) {
+  if (inline_memmove_small_size(dst, src, count))
+    return;
+  inline_memmove_follow_up(dst, src, count);
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif /* LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMMOVE_H */

--- a/system/lib/llvm-libc/src/string/memory_utils/inline_memset.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/inline_memset.h
@@ -1,0 +1,47 @@
+//===-- Implementation of memset and bzero --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMSET_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMSET_H
+
+#include "src/__support/macros/attributes.h"               // LIBC_INLINE
+#include "src/__support/macros/properties/architectures.h" // LIBC_TARGET_ARCH_IS_
+#include "src/string/memory_utils/utils.h"                 // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+#if defined(LIBC_TARGET_ARCH_IS_X86)
+#include "src/string/memory_utils/x86_64/inline_memset.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMSET inline_memset_x86
+#elif defined(LIBC_TARGET_ARCH_IS_AARCH64)
+#include "src/string/memory_utils/aarch64/inline_memset.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMSET inline_memset_aarch64
+#elif defined(LIBC_TARGET_ARCH_IS_ANY_RISCV)
+#include "src/string/memory_utils/riscv/inline_memset.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMSET inline_memset_riscv
+#elif defined(LIBC_TARGET_ARCH_IS_ARM)
+#include "src/string/memory_utils/generic/byte_per_byte.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMSET inline_memset_byte_per_byte
+#elif defined(LIBC_TARGET_ARCH_IS_GPU) || defined(LIBC_TARGET_ARCH_IS_WASM)
+#include "src/string/memory_utils/generic/builtin.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMSET inline_memset_builtin
+#else
+#error "Unsupported architecture"
+#endif
+
+namespace LIBC_NAMESPACE_DECL {
+
+LIBC_INLINE static void inline_memset(void *dst, uint8_t value, size_t count) {
+  LIBC_SRC_STRING_MEMORY_UTILS_MEMSET(reinterpret_cast<Ptr>(dst), value, count);
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#undef LIBC_SRC_STRING_MEMORY_UTILS_MEMSET
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_MEMSET_H

--- a/system/lib/llvm-libc/src/string/memory_utils/inline_strcmp.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/inline_strcmp.h
@@ -1,0 +1,45 @@
+//===-- str{,case}cmp implementation ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_STRCMP_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_STRCMP_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+template <typename Comp>
+LIBC_INLINE constexpr int inline_strcmp(const char *left, const char *right,
+                                        Comp &&comp) {
+  // TODO: Look at benefits for comparing words at a time.
+  for (; *left && !comp(*left, *right); ++left, ++right)
+    ;
+  return comp(*reinterpret_cast<const unsigned char *>(left),
+              *reinterpret_cast<const unsigned char *>(right));
+}
+
+template <typename Comp>
+LIBC_INLINE constexpr int inline_strncmp(const char *left, const char *right,
+                                         size_t n, Comp &&comp) {
+  if (n == 0)
+    return 0;
+
+  // TODO: Look at benefits for comparing words at a time.
+  for (; n > 1; --n, ++left, ++right) {
+    char lc = *left;
+    if (!comp(lc, '\0') || comp(lc, *right))
+      break;
+  }
+  return comp(*reinterpret_cast<const unsigned char *>(left),
+              *reinterpret_cast<const unsigned char *>(right));
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_STRCMP_H

--- a/system/lib/llvm-libc/src/string/memory_utils/inline_strstr.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/inline_strstr.h
@@ -1,0 +1,30 @@
+//===-- str{,case}str implementation ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_STRSTR_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_STRSTR_H
+
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memmem.h"
+#include "src/string/string_utils.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+template <typename Comp>
+LIBC_INLINE constexpr char *inline_strstr(const char *haystack,
+                                          const char *needle, Comp &&comp) {
+  void *result = inline_memmem(
+      static_cast<const void *>(haystack), internal::string_length(haystack),
+      static_cast<const void *>(needle), internal::string_length(needle), comp);
+  return static_cast<char *>(result);
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_STRSTR_H

--- a/system/lib/llvm-libc/src/string/memory_utils/op_aarch64.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/op_aarch64.h
@@ -1,0 +1,276 @@
+//===-- aarch64 implementation of memory function building blocks ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides aarch64 specific building blocks to compose memory
+// functions.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_AARCH64_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_AARCH64_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/architectures.h"
+
+#if defined(LIBC_TARGET_ARCH_IS_AARCH64)
+
+#include "src/__support/CPP/type_traits.h" // cpp::always_false
+#include "src/__support/common.h"
+#include "src/string/memory_utils/op_generic.h"
+
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif //__ARM_NEON
+
+namespace LIBC_NAMESPACE_DECL {
+namespace aarch64 {
+
+LIBC_INLINE_VAR constexpr bool kNeon = LLVM_LIBC_IS_DEFINED(__ARM_NEON);
+
+namespace neon {
+
+struct BzeroCacheLine {
+  static constexpr size_t SIZE = 64;
+
+  LIBC_INLINE static void block(Ptr dst, uint8_t) {
+#if __SIZEOF_POINTER__ == 4
+    asm("dc zva, %w[dst]" : : [dst] "r"(dst) : "memory");
+#else
+    asm("dc zva, %[dst]" : : [dst] "r"(dst) : "memory");
+#endif
+  }
+
+  LIBC_INLINE static void loop_and_tail(Ptr dst, uint8_t value, size_t count) {
+    size_t offset = 0;
+    do {
+      block(dst + offset, value);
+      offset += SIZE;
+    } while (offset < count - SIZE);
+    // Unaligned store, we can't use 'dc zva' here.
+    generic::Memset<generic_v512>::tail(dst, value, count);
+  }
+};
+
+LIBC_INLINE bool hasZva() {
+  uint64_t zva_val;
+  asm("mrs %[zva_val], dczid_el0" : [zva_val] "=r"(zva_val));
+  // DC ZVA is permitted if DZP, bit [4] is zero.
+  // BS, bits [3:0] is log2 of the block count in words.
+  // So the next line checks whether the instruction is permitted and block
+  // count is 16 words (i.e. 64 bytes).
+  return (zva_val & 0b11111) == 0b00100;
+}
+
+} // namespace neon
+
+///////////////////////////////////////////////////////////////////////////////
+// Bcmp
+template <size_t Size> struct Bcmp {
+  static constexpr size_t SIZE = Size;
+  static constexpr size_t BlockSize = 32;
+
+  LIBC_INLINE static const unsigned char *as_u8(CPtr ptr) {
+    return reinterpret_cast<const unsigned char *>(ptr);
+  }
+
+  LIBC_INLINE static BcmpReturnType block(CPtr p1, CPtr p2) {
+    if constexpr (Size == 16) {
+      auto _p1 = as_u8(p1);
+      auto _p2 = as_u8(p2);
+      uint8x16_t a = vld1q_u8(_p1);
+      uint8x16_t n = vld1q_u8(_p2);
+      uint8x16_t an = veorq_u8(a, n);
+      uint32x2_t an_reduced = vqmovn_u64(vreinterpretq_u64_u8(an));
+      return vmaxv_u32(an_reduced);
+    } else if constexpr (Size == 32) {
+      auto _p1 = as_u8(p1);
+      auto _p2 = as_u8(p2);
+      uint8x16_t a = vld1q_u8(_p1);
+      uint8x16_t b = vld1q_u8(_p1 + 16);
+      uint8x16_t n = vld1q_u8(_p2);
+      uint8x16_t o = vld1q_u8(_p2 + 16);
+      uint8x16_t an = veorq_u8(a, n);
+      uint8x16_t bo = veorq_u8(b, o);
+      // anbo = (a ^ n) | (b ^ o).  At least one byte is nonzero if there is
+      // a difference between the two buffers.  We reduce this value down to 4
+      // bytes in two steps. First, calculate the saturated move value when
+      // going from 2x64b to 2x32b. Second, compute the max of the 2x32b to get
+      // a single 32 bit nonzero value if a mismatch occurred.
+      uint8x16_t anbo = vorrq_u8(an, bo);
+      uint32x2_t anbo_reduced = vqmovn_u64(vreinterpretq_u64_u8(anbo));
+      return vmaxv_u32(anbo_reduced);
+    } else if constexpr ((Size % BlockSize) == 0) {
+      for (size_t offset = 0; offset < Size; offset += BlockSize)
+        if (auto value = Bcmp<BlockSize>::block(p1 + offset, p2 + offset))
+          return value;
+    } else {
+      static_assert(cpp::always_false<decltype(Size)>, "SIZE not implemented");
+    }
+    return BcmpReturnType::zero();
+  }
+
+  LIBC_INLINE static BcmpReturnType tail(CPtr p1, CPtr p2, size_t count) {
+    return block(p1 + count - SIZE, p2 + count - SIZE);
+  }
+
+  LIBC_INLINE static BcmpReturnType head_tail(CPtr p1, CPtr p2, size_t count) {
+    if constexpr (Size == 16) {
+      auto _p1 = as_u8(p1);
+      auto _p2 = as_u8(p2);
+      uint8x16_t a = vld1q_u8(_p1);
+      uint8x16_t b = vld1q_u8(_p1 + count - 16);
+      uint8x16_t n = vld1q_u8(_p2);
+      uint8x16_t o = vld1q_u8(_p2 + count - 16);
+      uint8x16_t an = veorq_u8(a, n);
+      uint8x16_t bo = veorq_u8(b, o);
+      // anbo = (a ^ n) | (b ^ o)
+      uint8x16_t anbo = vorrq_u8(an, bo);
+      uint32x2_t anbo_reduced = vqmovn_u64(vreinterpretq_u64_u8(anbo));
+      return vmaxv_u32(anbo_reduced);
+    } else if constexpr (Size == 32) {
+      auto _p1 = as_u8(p1);
+      auto _p2 = as_u8(p2);
+      uint8x16_t a = vld1q_u8(_p1);
+      uint8x16_t b = vld1q_u8(_p1 + 16);
+      uint8x16_t c = vld1q_u8(_p1 + count - 16);
+      uint8x16_t d = vld1q_u8(_p1 + count - 32);
+      uint8x16_t n = vld1q_u8(_p2);
+      uint8x16_t o = vld1q_u8(_p2 + 16);
+      uint8x16_t p = vld1q_u8(_p2 + count - 16);
+      uint8x16_t q = vld1q_u8(_p2 + count - 32);
+      uint8x16_t an = veorq_u8(a, n);
+      uint8x16_t bo = veorq_u8(b, o);
+      uint8x16_t cp = veorq_u8(c, p);
+      uint8x16_t dq = veorq_u8(d, q);
+      uint8x16_t anbo = vorrq_u8(an, bo);
+      uint8x16_t cpdq = vorrq_u8(cp, dq);
+      // abnocpdq = ((a ^ n) | (b ^ o)) | ((c ^ p) | (d ^ q)).  Reduce this to
+      // a nonzero 32 bit value if a mismatch occurred.
+      uint64x2_t abnocpdq = vreinterpretq_u64_u8(anbo | cpdq);
+      uint32x2_t abnocpdq_reduced = vqmovn_u64(abnocpdq);
+      return vmaxv_u32(abnocpdq_reduced);
+    } else {
+      static_assert(cpp::always_false<decltype(Size)>, "SIZE not implemented");
+    }
+    return BcmpReturnType::zero();
+  }
+
+  LIBC_INLINE static BcmpReturnType loop_and_tail(CPtr p1, CPtr p2,
+                                                  size_t count) {
+    static_assert(Size > 1, "a loop of size 1 does not need tail");
+    size_t offset = 0;
+    do {
+      if (auto value = block(p1 + offset, p2 + offset))
+        return value;
+      offset += SIZE;
+    } while (offset < count - SIZE);
+    return tail(p1, p2, count);
+  }
+};
+
+} // namespace aarch64
+} // namespace LIBC_NAMESPACE_DECL
+
+namespace LIBC_NAMESPACE_DECL {
+namespace generic {
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for uint16_t
+template <> struct cmp_is_expensive<uint16_t> : public cpp::false_type {};
+template <> LIBC_INLINE bool eq<uint16_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint16_t>(p1, offset) == load<uint16_t>(p2, offset);
+}
+template <>
+LIBC_INLINE uint32_t neq<uint16_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint16_t>(p1, offset) ^ load<uint16_t>(p2, offset);
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp<uint16_t>(CPtr p1, CPtr p2, size_t offset) {
+  return static_cast<int32_t>(load_be<uint16_t>(p1, offset)) -
+         static_cast<int32_t>(load_be<uint16_t>(p2, offset));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for uint32_t
+template <> struct cmp_is_expensive<uint32_t> : cpp::false_type {};
+template <>
+LIBC_INLINE uint32_t neq<uint32_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint32_t>(p1, offset) ^ load<uint32_t>(p2, offset);
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp<uint32_t>(CPtr p1, CPtr p2, size_t offset) {
+  const auto a = load_be<uint32_t>(p1, offset);
+  const auto b = load_be<uint32_t>(p2, offset);
+  return a > b ? 1 : a < b ? -1 : 0;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for uint64_t
+template <> struct cmp_is_expensive<uint64_t> : cpp::false_type {};
+template <>
+LIBC_INLINE uint32_t neq<uint64_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint64_t>(p1, offset) != load<uint64_t>(p2, offset);
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp<uint64_t>(CPtr p1, CPtr p2, size_t offset) {
+  const auto a = load_be<uint64_t>(p1, offset);
+  const auto b = load_be<uint64_t>(p2, offset);
+  if (a != b)
+    return a > b ? 1 : -1;
+  return MemcmpReturnType::zero();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for uint8x16_t
+template <> struct is_vector<uint8x16_t> : cpp::true_type {};
+template <> struct cmp_is_expensive<uint8x16_t> : cpp::false_type {};
+template <>
+LIBC_INLINE uint32_t neq<uint8x16_t>(CPtr p1, CPtr p2, size_t offset) {
+  for (size_t i = 0; i < 2; ++i) {
+    auto a = load<uint64_t>(p1, offset);
+    auto b = load<uint64_t>(p2, offset);
+    uint32_t cond = a != b;
+    if (cond)
+      return cond;
+    offset += sizeof(uint64_t);
+  }
+  return 0;
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp<uint8x16_t>(CPtr p1, CPtr p2, size_t offset) {
+  for (size_t i = 0; i < 2; ++i) {
+    auto a = load_be<uint64_t>(p1, offset);
+    auto b = load_be<uint64_t>(p2, offset);
+    if (a != b)
+      return cmp_neq_uint64_t(a, b);
+    offset += sizeof(uint64_t);
+  }
+  return MemcmpReturnType::zero();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for uint8x16x2_t
+template <> struct is_vector<uint8x16x2_t> : cpp::true_type {};
+template <> struct cmp_is_expensive<uint8x16x2_t> : cpp::false_type {};
+template <>
+LIBC_INLINE MemcmpReturnType cmp<uint8x16x2_t>(CPtr p1, CPtr p2,
+                                               size_t offset) {
+  for (size_t i = 0; i < 4; ++i) {
+    auto a = load_be<uint64_t>(p1, offset);
+    auto b = load_be<uint64_t>(p2, offset);
+    if (a != b)
+      return cmp_neq_uint64_t(a, b);
+    offset += sizeof(uint64_t);
+  }
+  return MemcmpReturnType::zero();
+}
+} // namespace generic
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TARGET_ARCH_IS_AARCH64
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_AARCH64_H

--- a/system/lib/llvm-libc/src/string/memory_utils/op_builtin.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/op_builtin.h
@@ -1,0 +1,159 @@
+//===-- Implementation using the __builtin_XXX_inline ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides generic C++ building blocks to compose memory functions.
+// They rely on the compiler to generate the best possible code through the use
+// of the `__builtin_XXX_inline` builtins. These builtins are currently only
+// available in Clang.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_BUILTIN_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_BUILTIN_H
+
+#include "src/__support/CPP/type_traits.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/utils.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace builtin {
+
+///////////////////////////////////////////////////////////////////////////////
+// Memcpy
+template <size_t Size> struct Memcpy {
+  static constexpr size_t SIZE = Size;
+  LIBC_INLINE static void block_offset(Ptr __restrict dst, CPtr __restrict src,
+                                       size_t offset) {
+    memcpy_inline<Size>(dst + offset, src + offset);
+  }
+
+  LIBC_INLINE static void block(Ptr __restrict dst, CPtr __restrict src) {
+    block_offset(dst, src, 0);
+  }
+
+  LIBC_INLINE static void tail(Ptr __restrict dst, CPtr __restrict src,
+                               size_t count) {
+    block_offset(dst, src, count - SIZE);
+  }
+
+  LIBC_INLINE static void head_tail(Ptr __restrict dst, CPtr __restrict src,
+                                    size_t count) {
+    block(dst, src);
+    tail(dst, src, count);
+  }
+
+  LIBC_INLINE static void loop_and_tail_offset(Ptr __restrict dst,
+                                               CPtr __restrict src,
+                                               size_t count, size_t offset) {
+    static_assert(Size > 1, "a loop of size 1 does not need tail");
+    do {
+      block_offset(dst, src, offset);
+      offset += SIZE;
+    } while (offset < count - SIZE);
+    tail(dst, src, count);
+  }
+
+  LIBC_INLINE static void loop_and_tail(Ptr __restrict dst, CPtr __restrict src,
+                                        size_t count) {
+    return loop_and_tail_offset(dst, src, count, 0);
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Memset
+template <size_t Size> struct Memset {
+  using ME = Memset;
+  static constexpr size_t SIZE = Size;
+  LIBC_INLINE static void block(Ptr dst, uint8_t value) {
+#ifdef LLVM_LIBC_HAS_BUILTIN_MEMSET_INLINE
+    __builtin_memset_inline(dst, value, Size);
+#else
+    static_assert(cpp::always_false<decltype(Size)>,
+                  "Missing __builtin_memset_inline");
+    (void)dst;
+    (void)value;
+#endif
+  }
+
+  LIBC_INLINE static void tail(Ptr dst, uint8_t value, size_t count) {
+    block(dst + count - SIZE, value);
+  }
+
+  LIBC_INLINE static void head_tail(Ptr dst, uint8_t value, size_t count) {
+    block(dst, value);
+    tail(dst, value, count);
+  }
+
+  LIBC_INLINE static void loop_and_tail(Ptr dst, uint8_t value, size_t count) {
+    static_assert(Size > 1, "a loop of size 1 does not need tail");
+    size_t offset = 0;
+    do {
+      block(dst + offset, value);
+      offset += SIZE;
+    } while (offset < count - SIZE);
+    tail(dst, value, count);
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Bcmp
+template <size_t Size> struct Bcmp {
+  using ME = Bcmp;
+  static constexpr size_t SIZE = Size;
+  LIBC_INLINE static BcmpReturnType block(CPtr, CPtr) {
+    static_assert(cpp::always_false<decltype(Size)>,
+                  "Missing __builtin_memcmp_inline");
+    return BcmpReturnType::zero();
+  }
+
+  LIBC_INLINE static BcmpReturnType tail(CPtr, CPtr, size_t) {
+    static_assert(cpp::always_false<decltype(Size)>, "Not implemented");
+    return BcmpReturnType::zero();
+  }
+
+  LIBC_INLINE static BcmpReturnType head_tail(CPtr, CPtr, size_t) {
+    static_assert(cpp::always_false<decltype(Size)>, "Not implemented");
+    return BcmpReturnType::zero();
+  }
+
+  LIBC_INLINE static BcmpReturnType loop_and_tail(CPtr, CPtr, size_t) {
+    static_assert(cpp::always_false<decltype(Size)>, "Not implemented");
+    return BcmpReturnType::zero();
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Memcmp
+template <size_t Size> struct Memcmp {
+  using ME = Memcmp;
+  static constexpr size_t SIZE = Size;
+  LIBC_INLINE static MemcmpReturnType block(CPtr, CPtr) {
+    static_assert(cpp::always_false<decltype(Size)>,
+                  "Missing __builtin_memcmp_inline");
+    return MemcmpReturnType::zero();
+  }
+
+  LIBC_INLINE static MemcmpReturnType tail(CPtr, CPtr, size_t) {
+    static_assert(cpp::always_false<decltype(Size)>, "Not implemented");
+    return MemcmpReturnType::zero();
+  }
+
+  LIBC_INLINE static MemcmpReturnType head_tail(CPtr, CPtr, size_t) {
+    static_assert(cpp::always_false<decltype(Size)>, "Not implemented");
+    return MemcmpReturnType::zero();
+  }
+
+  LIBC_INLINE static MemcmpReturnType loop_and_tail(CPtr, CPtr, size_t) {
+    static_assert(cpp::always_false<decltype(Size)>, "Not implemented");
+    return MemcmpReturnType::zero();
+  }
+};
+
+} // namespace builtin
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_BUILTIN_H

--- a/system/lib/llvm-libc/src/string/memory_utils/op_generic.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/op_generic.h
@@ -1,0 +1,586 @@
+//===-- Generic implementation of memory function building blocks ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides generic C++ building blocks.
+// Depending on the requested size, the block operation uses unsigned integral
+// types, vector types or an array of the type with the maximum size.
+//
+// The maximum size is passed as a template argument. For instance, on x86
+// platforms that only supports integral types the maximum size would be 8
+// (corresponding to uint64_t). On this platform if we request the size 32, this
+// would be treated as a cpp::array<uint64_t, 4>.
+//
+// On the other hand, if the platform is x86 with support for AVX the maximum
+// size is 32 and the operation can be handled with a single native operation.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_GENERIC_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_GENERIC_H
+
+#include "src/__support/CPP/array.h"
+#include "src/__support/CPP/type_traits.h"
+#include "src/__support/common.h"
+#include "src/__support/endian_internal.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h"
+#include "src/__support/macros/properties/types.h" // LIBC_TYPES_HAS_INT64
+#include "src/string/memory_utils/op_builtin.h"
+#include "src/string/memory_utils/utils.h"
+
+#include <stdint.h>
+
+static_assert((UINTPTR_MAX == 4294967295U) ||
+                  (UINTPTR_MAX == 18446744073709551615UL),
+              "We currently only support 32- or 64-bit platforms");
+
+namespace LIBC_NAMESPACE_DECL {
+// Compiler types using the vector attributes.
+using generic_v128 = uint8_t __attribute__((__vector_size__(16)));
+using generic_v256 = uint8_t __attribute__((__vector_size__(32)));
+using generic_v512 = uint8_t __attribute__((__vector_size__(64)));
+} // namespace LIBC_NAMESPACE_DECL
+
+namespace LIBC_NAMESPACE_DECL {
+namespace generic {
+
+// We accept three types of values as elements for generic operations:
+// - scalar : unsigned integral types,
+// - vector : compiler types using the vector attributes or platform builtins,
+// - array  : a cpp::array<T, N> where T is itself either a scalar or a vector.
+// The following traits help discriminate between these cases.
+
+template <typename T> struct is_scalar : cpp::false_type {};
+template <> struct is_scalar<uint8_t> : cpp::true_type {};
+template <> struct is_scalar<uint16_t> : cpp::true_type {};
+template <> struct is_scalar<uint32_t> : cpp::true_type {};
+#ifdef LIBC_TYPES_HAS_INT64
+template <> struct is_scalar<uint64_t> : cpp::true_type {};
+#endif // LIBC_TYPES_HAS_INT64
+// Meant to match std::numeric_limits interface.
+// NOLINTNEXTLINE(readability-identifier-naming)
+template <typename T> constexpr bool is_scalar_v = is_scalar<T>::value;
+
+template <typename T> struct is_vector : cpp::false_type {};
+template <> struct is_vector<generic_v128> : cpp::true_type {};
+template <> struct is_vector<generic_v256> : cpp::true_type {};
+template <> struct is_vector<generic_v512> : cpp::true_type {};
+// Meant to match std::numeric_limits interface.
+// NOLINTNEXTLINE(readability-identifier-naming)
+template <typename T> constexpr bool is_vector_v = is_vector<T>::value;
+
+template <class T> struct is_array : cpp::false_type {};
+template <class T, size_t N> struct is_array<cpp::array<T, N>> {
+  // Meant to match std::numeric_limits interface.
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  static constexpr bool value = is_scalar_v<T> || is_vector_v<T>;
+};
+// Meant to match std::numeric_limits interface.
+// NOLINTNEXTLINE(readability-identifier-naming)
+template <typename T> constexpr bool is_array_v = is_array<T>::value;
+
+// Meant to match std::numeric_limits interface.
+// NOLINTBEGIN(readability-identifier-naming)
+template <typename T>
+constexpr bool is_element_type_v =
+    is_scalar_v<T> || is_vector_v<T> || is_array_v<T>;
+// NOLINTEND(readability-identifier-naming)
+
+// Helper struct to retrieve the number of elements of an array.
+template <class T> struct array_size {};
+template <class T, size_t N>
+struct array_size<cpp::array<T, N>> : cpp::integral_constant<size_t, N> {};
+// Meant to match std::numeric_limits interface.
+// NOLINTNEXTLINE(readability-identifier-naming)
+template <typename T> constexpr size_t array_size_v = array_size<T>::value;
+
+// Generic operations for the above type categories.
+
+template <typename T> T load(CPtr src) {
+  static_assert(is_element_type_v<T>);
+  if constexpr (is_scalar_v<T> || is_vector_v<T>) {
+    return ::LIBC_NAMESPACE::load<T>(src);
+  } else if constexpr (is_array_v<T>) {
+    using value_type = typename T::value_type;
+    T value;
+    for (size_t i = 0; i < array_size_v<T>; ++i)
+      value[i] = load<value_type>(src + (i * sizeof(value_type)));
+    return value;
+  }
+}
+
+template <typename T> void store(Ptr dst, T value) {
+  static_assert(is_element_type_v<T>);
+  if constexpr (is_scalar_v<T> || is_vector_v<T>) {
+    ::LIBC_NAMESPACE::store<T>(dst, value);
+  } else if constexpr (is_array_v<T>) {
+    using value_type = typename T::value_type;
+    for (size_t i = 0; i < array_size_v<T>; ++i)
+      store<value_type>(dst + (i * sizeof(value_type)), value[i]);
+  }
+}
+
+template <typename T> T splat(uint8_t value) {
+  static_assert(is_scalar_v<T> || is_vector_v<T>);
+  if constexpr (is_scalar_v<T>)
+    return T(~0) / T(0xFF) * T(value);
+  else if constexpr (is_vector_v<T>) {
+    T out;
+    // This for loop is optimized out for vector types.
+    for (size_t i = 0; i < sizeof(T); ++i)
+      out[i] = value;
+    return out;
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Memset
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T> struct Memset {
+  static_assert(is_element_type_v<T>);
+  static constexpr size_t SIZE = sizeof(T);
+
+  LIBC_INLINE static void block(Ptr dst, uint8_t value) {
+    if constexpr (is_scalar_v<T> || is_vector_v<T>) {
+      store<T>(dst, splat<T>(value));
+    } else if constexpr (is_array_v<T>) {
+      using value_type = typename T::value_type;
+      const auto Splat = splat<value_type>(value);
+      for (size_t i = 0; i < array_size_v<T>; ++i)
+        store<value_type>(dst + (i * sizeof(value_type)), Splat);
+    }
+  }
+
+  LIBC_INLINE static void tail(Ptr dst, uint8_t value, size_t count) {
+    block(dst + count - SIZE, value);
+  }
+
+  LIBC_INLINE static void head_tail(Ptr dst, uint8_t value, size_t count) {
+    block(dst, value);
+    tail(dst, value, count);
+  }
+
+  LIBC_INLINE static void loop_and_tail_offset(Ptr dst, uint8_t value,
+                                               size_t count, size_t offset) {
+    static_assert(SIZE > 1, "a loop of size 1 does not need tail");
+    do {
+      block(dst + offset, value);
+      offset += SIZE;
+    } while (offset < count - SIZE);
+    tail(dst, value, count);
+  }
+
+  LIBC_INLINE static void loop_and_tail(Ptr dst, uint8_t value, size_t count) {
+    return loop_and_tail_offset(dst, value, count, 0);
+  }
+};
+
+template <typename T, typename... TS> struct MemsetSequence {
+  static constexpr size_t SIZE = (sizeof(T) + ... + sizeof(TS));
+  LIBC_INLINE static void block(Ptr dst, uint8_t value) {
+    Memset<T>::block(dst, value);
+    if constexpr (sizeof...(TS) > 0)
+      return MemsetSequence<TS...>::block(dst + sizeof(T), value);
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Memmove
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T> struct Memmove {
+  static_assert(is_element_type_v<T>);
+  static constexpr size_t SIZE = sizeof(T);
+
+  LIBC_INLINE static void block(Ptr dst, CPtr src) {
+    store<T>(dst, load<T>(src));
+  }
+
+  LIBC_INLINE static void head_tail(Ptr dst, CPtr src, size_t count) {
+    const size_t offset = count - SIZE;
+    // The load and store operations can be performed in any order as long as
+    // they are not interleaved. More investigations are needed to determine
+    // the best order.
+    const auto head = load<T>(src);
+    const auto tail = load<T>(src + offset);
+    store<T>(dst, head);
+    store<T>(dst + offset, tail);
+  }
+
+  // Align forward suitable when dst < src. The alignment is performed with
+  // an HeadTail operation of count ∈ [Alignment, 2 x Alignment].
+  //
+  // e.g. Moving two bytes forward, we make sure src is aligned.
+  // [  |       |       |       |      ]
+  // [____XXXXXXXXXXXXXXXXXXXXXXXXXXXX_]
+  // [____LLLLLLLL_____________________]
+  // [___________LLLLLLLA______________]
+  // [_SSSSSSSS________________________]
+  // [________SSSSSSSS_________________]
+  //
+  // e.g. Moving two bytes forward, we make sure dst is aligned.
+  // [  |       |       |       |      ]
+  // [____XXXXXXXXXXXXXXXXXXXXXXXXXXXX_]
+  // [____LLLLLLLL_____________________]
+  // [______LLLLLLLL___________________]
+  // [_SSSSSSSS________________________]
+  // [___SSSSSSSA______________________]
+  template <Arg AlignOn>
+  LIBC_INLINE static void align_forward(Ptr &dst, CPtr &src, size_t &count) {
+    Ptr prev_dst = dst;
+    CPtr prev_src = src;
+    size_t prev_count = count;
+    align_to_next_boundary<SIZE, AlignOn>(dst, src, count);
+    adjust(SIZE, dst, src, count);
+    head_tail(prev_dst, prev_src, prev_count - count);
+  }
+
+  // Align backward suitable when dst > src. The alignment is performed with
+  // an HeadTail operation of count ∈ [Alignment, 2 x Alignment].
+  //
+  // e.g. Moving two bytes backward, we make sure src is aligned.
+  // [  |       |       |       |      ]
+  // [____XXXXXXXXXXXXXXXXXXXXXXXX_____]
+  // [ _________________ALLLLLLL_______]
+  // [ ___________________LLLLLLLL_____]
+  // [____________________SSSSSSSS_____]
+  // [______________________SSSSSSSS___]
+  //
+  // e.g. Moving two bytes backward, we make sure dst is aligned.
+  // [  |       |       |       |      ]
+  // [____XXXXXXXXXXXXXXXXXXXXXXXX_____]
+  // [ _______________LLLLLLLL_________]
+  // [ ___________________LLLLLLLL_____]
+  // [__________________ASSSSSSS_______]
+  // [______________________SSSSSSSS___]
+  template <Arg AlignOn>
+  LIBC_INLINE static void align_backward(Ptr &dst, CPtr &src, size_t &count) {
+    Ptr headtail_dst = dst + count;
+    CPtr headtail_src = src + count;
+    size_t headtail_size = 0;
+    align_to_next_boundary<SIZE, AlignOn>(headtail_dst, headtail_src,
+                                          headtail_size);
+    adjust(-2 * SIZE, headtail_dst, headtail_src, headtail_size);
+    head_tail(headtail_dst, headtail_src, headtail_size);
+    count -= headtail_size;
+  }
+
+  // Move forward suitable when dst < src. We load the tail bytes before
+  // handling the loop.
+  //
+  // e.g. Moving two bytes
+  // [   |       |       |       |       |]
+  // [___XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX___]
+  // [_________________________LLLLLLLL___]
+  // [___LLLLLLLL_________________________]
+  // [_SSSSSSSS___________________________]
+  // [___________LLLLLLLL_________________]
+  // [_________SSSSSSSS___________________]
+  // [___________________LLLLLLLL_________]
+  // [_________________SSSSSSSS___________]
+  // [_______________________SSSSSSSS_____]
+  LIBC_INLINE static void loop_and_tail_forward(Ptr dst, CPtr src,
+                                                size_t count) {
+    static_assert(SIZE > 1, "a loop of size 1 does not need tail");
+    const size_t tail_offset = count - SIZE;
+    const auto tail_value = load<T>(src + tail_offset);
+    size_t offset = 0;
+    LIBC_LOOP_NOUNROLL
+    do {
+      block(dst + offset, src + offset);
+      offset += SIZE;
+    } while (offset < count - SIZE);
+    store<T>(dst + tail_offset, tail_value);
+  }
+
+  // Move backward suitable when dst > src. We load the head bytes before
+  // handling the loop.
+  //
+  // e.g. Moving two bytes
+  // [   |       |       |       |       |]
+  // [___XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX___]
+  // [___LLLLLLLL_________________________]
+  // [_________________________LLLLLLLL___]
+  // [___________________________SSSSSSSS_]
+  // [_________________LLLLLLLL___________]
+  // [___________________SSSSSSSS_________]
+  // [_________LLLLLLLL___________________]
+  // [___________SSSSSSSS_________________]
+  // [_____SSSSSSSS_______________________]
+  LIBC_INLINE static void loop_and_tail_backward(Ptr dst, CPtr src,
+                                                 size_t count) {
+    static_assert(SIZE > 1, "a loop of size 1 does not need tail");
+    const auto head_value = load<T>(src);
+    ptrdiff_t offset = count - SIZE;
+    LIBC_LOOP_NOUNROLL
+    do {
+      block(dst + offset, src + offset);
+      offset -= SIZE;
+    } while (offset >= 0);
+    store<T>(dst, head_value);
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Low level operations for Bcmp and Memcmp that operate on memory locations.
+///////////////////////////////////////////////////////////////////////////////
+
+// Same as load above but with an offset to the pointer.
+// Making the offset explicit hints the compiler to use relevant addressing mode
+// consistently.
+template <typename T> LIBC_INLINE T load(CPtr ptr, size_t offset) {
+  return ::LIBC_NAMESPACE::load<T>(ptr + offset);
+}
+
+// Same as above but also makes sure the loaded value is in big endian format.
+// This is useful when implementing lexicograhic comparisons as big endian
+// scalar comparison directly maps to lexicographic byte comparisons.
+template <typename T> LIBC_INLINE T load_be(CPtr ptr, size_t offset) {
+  return Endian::to_big_endian(load<T>(ptr, offset));
+}
+
+// Equality: returns true iff values at locations (p1 + offset) and (p2 +
+// offset) compare equal.
+template <typename T> LIBC_INLINE bool eq(CPtr p1, CPtr p2, size_t offset);
+
+// Not equals: returns non-zero iff values at locations (p1 + offset) and (p2 +
+// offset) differ.
+template <typename T> LIBC_INLINE uint32_t neq(CPtr p1, CPtr p2, size_t offset);
+
+// Lexicographic comparison:
+// - returns 0 iff values at locations (p1 + offset) and (p2 + offset) compare
+//   equal.
+// - returns a negative value if value at location (p1 + offset) is
+//   lexicographically less than value at (p2 + offset).
+// - returns a positive value if value at location (p1 + offset) is
+//   lexicographically greater than value at (p2 + offset).
+template <typename T>
+LIBC_INLINE MemcmpReturnType cmp(CPtr p1, CPtr p2, size_t offset);
+
+// Lexicographic comparison of non-equal values:
+// - returns a negative value if value at location (p1 + offset) is
+//   lexicographically less than value at (p2 + offset).
+// - returns a positive value if value at location (p1 + offset) is
+//   lexicographically greater than value at (p2 + offset).
+template <typename T>
+LIBC_INLINE MemcmpReturnType cmp_neq(CPtr p1, CPtr p2, size_t offset);
+
+///////////////////////////////////////////////////////////////////////////////
+// Memcmp implementation
+//
+// When building memcmp, not all types are considered equals.
+//
+// For instance, the lexicographic comparison of two uint8_t can be implemented
+// as a simple subtraction, but for wider operations the logic can be much more
+// involving, especially on little endian platforms.
+//
+// For such wider types it is a good strategy to test for equality first and
+// only do the expensive lexicographic comparison if necessary.
+//
+// Decomposing the algorithm like this for wider types allows us to have
+// efficient implementation of higher order functions like 'head_tail' or
+// 'loop_and_tail'.
+///////////////////////////////////////////////////////////////////////////////
+
+// Type traits to decide whether we can use 'cmp' directly or if we need to
+// split the computation.
+template <typename T> struct cmp_is_expensive;
+
+template <typename T> struct Memcmp {
+  static_assert(is_element_type_v<T>);
+  static constexpr size_t SIZE = sizeof(T);
+
+private:
+  LIBC_INLINE static MemcmpReturnType block_offset(CPtr p1, CPtr p2,
+                                                   size_t offset) {
+    if constexpr (cmp_is_expensive<T>::value) {
+      if (!eq<T>(p1, p2, offset))
+        return cmp_neq<T>(p1, p2, offset);
+      return MemcmpReturnType::zero();
+    } else {
+      return cmp<T>(p1, p2, offset);
+    }
+  }
+
+public:
+  LIBC_INLINE static MemcmpReturnType block(CPtr p1, CPtr p2) {
+    return block_offset(p1, p2, 0);
+  }
+
+  LIBC_INLINE static MemcmpReturnType tail(CPtr p1, CPtr p2, size_t count) {
+    return block_offset(p1, p2, count - SIZE);
+  }
+
+  LIBC_INLINE static MemcmpReturnType head_tail(CPtr p1, CPtr p2,
+                                                size_t count) {
+    if constexpr (cmp_is_expensive<T>::value) {
+      if (!eq<T>(p1, p2, 0))
+        return cmp_neq<T>(p1, p2, 0);
+    } else {
+      if (const auto value = cmp<T>(p1, p2, 0))
+        return value;
+    }
+    return tail(p1, p2, count);
+  }
+
+  LIBC_INLINE static MemcmpReturnType loop_and_tail(CPtr p1, CPtr p2,
+                                                    size_t count) {
+    return loop_and_tail_offset(p1, p2, count, 0);
+  }
+
+  LIBC_INLINE static MemcmpReturnType
+  loop_and_tail_offset(CPtr p1, CPtr p2, size_t count, size_t offset) {
+    if constexpr (SIZE > 1) {
+      const size_t limit = count - SIZE;
+      LIBC_LOOP_NOUNROLL
+      for (; offset < limit; offset += SIZE) {
+        if constexpr (cmp_is_expensive<T>::value) {
+          if (!eq<T>(p1, p2, offset))
+            return cmp_neq<T>(p1, p2, offset);
+        } else {
+          if (const auto value = cmp<T>(p1, p2, offset))
+            return value;
+        }
+      }
+      return block_offset(p1, p2, limit); // tail
+    } else {
+      // No need for a tail operation when SIZE == 1.
+      LIBC_LOOP_NOUNROLL
+      for (; offset < count; offset += SIZE)
+        if (auto value = cmp<T>(p1, p2, offset))
+          return value;
+      return MemcmpReturnType::zero();
+    }
+  }
+
+  LIBC_INLINE static MemcmpReturnType
+  loop_and_tail_align_above(size_t threshold, CPtr p1, CPtr p2, size_t count) {
+    const AlignHelper<sizeof(T)> helper(p1);
+    if (LIBC_UNLIKELY(count >= threshold) && helper.not_aligned()) {
+      if (auto value = block(p1, p2))
+        return value;
+      adjust(helper.offset, p1, p2, count);
+    }
+    return loop_and_tail(p1, p2, count);
+  }
+};
+
+template <typename T, typename... TS> struct MemcmpSequence {
+  static constexpr size_t SIZE = (sizeof(T) + ... + sizeof(TS));
+  LIBC_INLINE static MemcmpReturnType block(CPtr p1, CPtr p2) {
+    // TODO: test suggestion in
+    // https://reviews.llvm.org/D148717?id=515724#inline-1446890
+    // once we have a proper way to check memory operation latency.
+    if constexpr (cmp_is_expensive<T>::value) {
+      if (!eq<T>(p1, p2, 0))
+        return cmp_neq<T>(p1, p2, 0);
+    } else {
+      if (auto value = cmp<T>(p1, p2, 0))
+        return value;
+    }
+    if constexpr (sizeof...(TS) > 0)
+      return MemcmpSequence<TS...>::block(p1 + sizeof(T), p2 + sizeof(T));
+    else
+      return MemcmpReturnType::zero();
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Bcmp
+///////////////////////////////////////////////////////////////////////////////
+template <typename T> struct Bcmp {
+  static_assert(is_element_type_v<T>);
+  static constexpr size_t SIZE = sizeof(T);
+
+  LIBC_INLINE static BcmpReturnType block(CPtr p1, CPtr p2) {
+    return neq<T>(p1, p2, 0);
+  }
+
+  LIBC_INLINE static BcmpReturnType tail(CPtr p1, CPtr p2, size_t count) {
+    const size_t tail_offset = count - SIZE;
+    return neq<T>(p1, p2, tail_offset);
+  }
+
+  LIBC_INLINE static BcmpReturnType head_tail(CPtr p1, CPtr p2, size_t count) {
+    if (const auto value = neq<T>(p1, p2, 0))
+      return value;
+    return tail(p1, p2, count);
+  }
+
+  LIBC_INLINE static BcmpReturnType loop_and_tail(CPtr p1, CPtr p2,
+                                                  size_t count) {
+    return loop_and_tail_offset(p1, p2, count, 0);
+  }
+
+  LIBC_INLINE static BcmpReturnType
+  loop_and_tail_offset(CPtr p1, CPtr p2, size_t count, size_t offset) {
+    if constexpr (SIZE > 1) {
+      const size_t limit = count - SIZE;
+      LIBC_LOOP_NOUNROLL
+      for (; offset < limit; offset += SIZE)
+        if (const auto value = neq<T>(p1, p2, offset))
+          return value;
+      return tail(p1, p2, count);
+    } else {
+      // No need for a tail operation when SIZE == 1.
+      LIBC_LOOP_NOUNROLL
+      for (; offset < count; offset += SIZE)
+        if (const auto value = neq<T>(p1, p2, offset))
+          return value;
+      return BcmpReturnType::zero();
+    }
+  }
+
+  LIBC_INLINE static BcmpReturnType
+  loop_and_tail_align_above(size_t threshold, CPtr p1, CPtr p2, size_t count) {
+    static_assert(SIZE > 1,
+                  "No need to align when processing one byte at a time");
+    const AlignHelper<sizeof(T)> helper(p1);
+    if (LIBC_UNLIKELY(count >= threshold) && helper.not_aligned()) {
+      if (auto value = block(p1, p2))
+        return value;
+      adjust(helper.offset, p1, p2, count);
+    }
+    return loop_and_tail(p1, p2, count);
+  }
+};
+
+template <typename T, typename... TS> struct BcmpSequence {
+  static constexpr size_t SIZE = (sizeof(T) + ... + sizeof(TS));
+  LIBC_INLINE static BcmpReturnType block(CPtr p1, CPtr p2) {
+    if (auto value = neq<T>(p1, p2, 0))
+      return value;
+    if constexpr (sizeof...(TS) > 0)
+      return BcmpSequence<TS...>::block(p1 + sizeof(T), p2 + sizeof(T));
+    else
+      return BcmpReturnType::zero();
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for uint8_t
+template <> struct cmp_is_expensive<uint8_t> : public cpp::false_type {};
+template <> LIBC_INLINE bool eq<uint8_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint8_t>(p1, offset) == load<uint8_t>(p2, offset);
+}
+template <> LIBC_INLINE uint32_t neq<uint8_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint8_t>(p1, offset) ^ load<uint8_t>(p2, offset);
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp<uint8_t>(CPtr p1, CPtr p2, size_t offset) {
+  return static_cast<int32_t>(load<uint8_t>(p1, offset)) -
+         static_cast<int32_t>(load<uint8_t>(p2, offset));
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp_neq<uint8_t>(CPtr p1, CPtr p2, size_t offset);
+
+} // namespace generic
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_GENERIC_H

--- a/system/lib/llvm-libc/src/string/memory_utils/op_riscv.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/op_riscv.h
@@ -1,0 +1,87 @@
+//===-- RISC-V implementation of memory function building blocks ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides x86 specific building blocks to compose memory functions.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_RISCV_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_RISCV_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/architectures.h"
+
+#if defined(LIBC_TARGET_ARCH_IS_ANY_RISCV)
+
+#include "src/__support/common.h"
+#include "src/string/memory_utils/op_generic.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace generic {
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for uint16_t
+template <> struct cmp_is_expensive<uint16_t> : public cpp::false_type {};
+template <> LIBC_INLINE bool eq<uint16_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint16_t>(p1, offset) == load<uint16_t>(p2, offset);
+}
+template <>
+LIBC_INLINE uint32_t neq<uint16_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint16_t>(p1, offset) ^ load<uint16_t>(p2, offset);
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp<uint16_t>(CPtr p1, CPtr p2, size_t offset) {
+  return static_cast<int32_t>(load_be<uint16_t>(p1, offset)) -
+         static_cast<int32_t>(load_be<uint16_t>(p2, offset));
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp_neq<uint16_t>(CPtr p1, CPtr p2, size_t offset);
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for uint32_t
+template <> struct cmp_is_expensive<uint32_t> : public cpp::false_type {};
+template <> LIBC_INLINE bool eq<uint32_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint32_t>(p1, offset) == load<uint32_t>(p2, offset);
+}
+template <>
+LIBC_INLINE uint32_t neq<uint32_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint32_t>(p1, offset) ^ load<uint32_t>(p2, offset);
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp<uint32_t>(CPtr p1, CPtr p2, size_t offset) {
+  const auto a = load_be<uint32_t>(p1, offset);
+  const auto b = load_be<uint32_t>(p2, offset);
+  return cmp_uint32_t(a, b);
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp_neq<uint32_t>(CPtr p1, CPtr p2, size_t offset);
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for uint64_t
+template <> struct cmp_is_expensive<uint64_t> : public cpp::true_type {};
+template <> LIBC_INLINE bool eq<uint64_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint64_t>(p1, offset) == load<uint64_t>(p2, offset);
+}
+template <>
+LIBC_INLINE uint32_t neq<uint64_t>(CPtr p1, CPtr p2, size_t offset) {
+  return !eq<uint64_t>(p1, p2, offset);
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp<uint64_t>(CPtr p1, CPtr p2, size_t offset);
+template <>
+LIBC_INLINE MemcmpReturnType cmp_neq<uint64_t>(CPtr p1, CPtr p2,
+                                               size_t offset) {
+  const auto a = load_be<uint64_t>(p1, offset);
+  const auto b = load_be<uint64_t>(p2, offset);
+  return cmp_neq_uint64_t(a, b);
+}
+
+} // namespace generic
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TARGET_ARCH_IS_ANY_RISCV
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_RISCV_H

--- a/system/lib/llvm-libc/src/string/memory_utils/op_x86.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/op_x86.h
@@ -1,0 +1,375 @@
+//===-- x86 implementation of memory function building blocks -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides x86 specific building blocks to compose memory functions.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_X86_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_X86_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/architectures.h"
+
+#if defined(LIBC_TARGET_ARCH_IS_X86)
+
+#include "src/__support/common.h"
+#include "src/string/memory_utils/op_builtin.h"
+#include "src/string/memory_utils/op_generic.h"
+
+#if defined(__AVX512BW__) || defined(__AVX512F__) || defined(__AVX2__) ||      \
+    defined(__SSE2__)
+#include <immintrin.h>
+#endif
+
+// Define fake functions to prevent the compiler from failing on undefined
+// functions in case the CPU extension is not present.
+#if !defined(__AVX512BW__) && (defined(_MSC_VER) || defined(__SCE__))
+#undef _mm512_cmpneq_epi8_mask
+#define _mm512_cmpneq_epi8_mask(A, B) 0
+#endif
+#if !defined(__AVX2__) && (defined(_MSC_VER) || defined(__SCE__))
+#undef _mm256_movemask_epi8
+#define _mm256_movemask_epi8(A) 0
+#endif
+#if !defined(__SSE2__) && (defined(_MSC_VER) || defined(__SCE__))
+#undef _mm_movemask_epi8
+#define _mm_movemask_epi8(A) 0
+#endif
+
+namespace LIBC_NAMESPACE_DECL {
+namespace x86 {
+
+// A set of constants to check compile time features.
+LIBC_INLINE_VAR constexpr bool K_SSE2 = LLVM_LIBC_IS_DEFINED(__SSE2__);
+LIBC_INLINE_VAR constexpr bool K_SSE41 = LLVM_LIBC_IS_DEFINED(__SSE4_1__);
+LIBC_INLINE_VAR constexpr bool K_AVX = LLVM_LIBC_IS_DEFINED(__AVX__);
+LIBC_INLINE_VAR constexpr bool K_AVX2 = LLVM_LIBC_IS_DEFINED(__AVX2__);
+LIBC_INLINE_VAR constexpr bool K_AVX512_F = LLVM_LIBC_IS_DEFINED(__AVX512F__);
+LIBC_INLINE_VAR constexpr bool K_AVX512_BW = LLVM_LIBC_IS_DEFINED(__AVX512BW__);
+
+///////////////////////////////////////////////////////////////////////////////
+// Memcpy repmovsb implementation
+struct Memcpy {
+  LIBC_INLINE static void repmovsb(void *dst, const void *src, size_t count) {
+    asm volatile("rep movsb" : "+D"(dst), "+S"(src), "+c"(count) : : "memory");
+  }
+};
+
+} // namespace x86
+} // namespace LIBC_NAMESPACE_DECL
+
+namespace LIBC_NAMESPACE_DECL {
+namespace generic {
+
+// Not equals: returns non-zero iff values at head or tail differ.
+// This function typically loads more data than necessary when the two buffer
+// differs.
+template <typename T>
+LIBC_INLINE uint32_t branchless_head_tail_neq(CPtr p1, CPtr p2, size_t count) {
+  static_assert(cpp::is_integral_v<T>);
+  return neq<T>(p1, p2, 0) | neq<T>(p1, p2, count - sizeof(T));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for uint16_t
+template <> struct cmp_is_expensive<uint16_t> : public cpp::false_type {};
+template <> LIBC_INLINE bool eq<uint16_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint16_t>(p1, offset) == load<uint16_t>(p2, offset);
+}
+template <>
+LIBC_INLINE uint32_t neq<uint16_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint16_t>(p1, offset) ^ load<uint16_t>(p2, offset);
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp<uint16_t>(CPtr p1, CPtr p2, size_t offset) {
+  return static_cast<int32_t>(load_be<uint16_t>(p1, offset)) -
+         static_cast<int32_t>(load_be<uint16_t>(p2, offset));
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp_neq<uint16_t>(CPtr p1, CPtr p2, size_t offset);
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for uint32_t
+template <> struct cmp_is_expensive<uint32_t> : public cpp::false_type {};
+template <> LIBC_INLINE bool eq<uint32_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint32_t>(p1, offset) == load<uint32_t>(p2, offset);
+}
+template <>
+LIBC_INLINE uint32_t neq<uint32_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint32_t>(p1, offset) ^ load<uint32_t>(p2, offset);
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp<uint32_t>(CPtr p1, CPtr p2, size_t offset) {
+  const auto a = load_be<uint32_t>(p1, offset);
+  const auto b = load_be<uint32_t>(p2, offset);
+  return cmp_uint32_t(a, b);
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp_neq<uint32_t>(CPtr p1, CPtr p2, size_t offset);
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for uint64_t
+template <> struct cmp_is_expensive<uint64_t> : public cpp::true_type {};
+template <> LIBC_INLINE bool eq<uint64_t>(CPtr p1, CPtr p2, size_t offset) {
+  return load<uint64_t>(p1, offset) == load<uint64_t>(p2, offset);
+}
+template <>
+LIBC_INLINE uint32_t neq<uint64_t>(CPtr p1, CPtr p2, size_t offset) {
+  return !eq<uint64_t>(p1, p2, offset);
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp<uint64_t>(CPtr p1, CPtr p2, size_t offset);
+template <>
+LIBC_INLINE MemcmpReturnType cmp_neq<uint64_t>(CPtr p1, CPtr p2,
+                                               size_t offset) {
+  const auto a = load_be<uint64_t>(p1, offset);
+  const auto b = load_be<uint64_t>(p2, offset);
+  return cmp_neq_uint64_t(a, b);
+}
+
+// SIMD types are defined with attributes. e.g., '__m128i' is defined as
+// long long  __attribute__((__vector_size__(16), __aligned__(16)))
+// When we use these SIMD types in template specialization GCC complains:
+// "ignoring attributes on template argument ‘__m128i’ [-Wignored-attributes]"
+// Therefore, we disable this warning in this file.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for __m128i
+#if defined(__SSE4_1__)
+template <> struct is_vector<__m128i> : cpp::true_type {};
+template <> struct cmp_is_expensive<__m128i> : cpp::true_type {};
+LIBC_INLINE __m128i load_and_xor_m128i(CPtr p1, CPtr p2, size_t offset) {
+  const auto a = load<__m128i>(p1, offset);
+  const auto b = load<__m128i>(p2, offset);
+  return _mm_xor_si128(a, b);
+}
+LIBC_INLINE __m128i bytewise_max(__m128i a, __m128i b) {
+  return _mm_max_epu8(a, b);
+}
+LIBC_INLINE __m128i bytewise_reverse(__m128i value) {
+  return _mm_shuffle_epi8(value, _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, //
+                                              8, 9, 10, 11, 12, 13, 14, 15));
+}
+LIBC_INLINE uint16_t big_endian_cmp_mask(__m128i max, __m128i value) {
+  return static_cast<uint16_t>(
+      _mm_movemask_epi8(bytewise_reverse(_mm_cmpeq_epi8(max, value))));
+}
+LIBC_INLINE bool is_zero(__m128i value) {
+  return _mm_testz_si128(value, value) == 1;
+}
+template <> LIBC_INLINE bool eq<__m128i>(CPtr p1, CPtr p2, size_t offset) {
+  return is_zero(load_and_xor_m128i(p1, p2, offset));
+}
+template <> LIBC_INLINE uint32_t neq<__m128i>(CPtr p1, CPtr p2, size_t offset) {
+  return !is_zero(load_and_xor_m128i(p1, p2, offset));
+}
+template <>
+LIBC_INLINE uint32_t branchless_head_tail_neq<__m128i>(CPtr p1, CPtr p2,
+                                                       size_t count) {
+  const __m128i head = load_and_xor_m128i(p1, p2, 0);
+  const __m128i tail = load_and_xor_m128i(p1, p2, count - sizeof(__m128i));
+  return !is_zero(_mm_or_si128(head, tail));
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp_neq<__m128i>(CPtr p1, CPtr p2, size_t offset) {
+  const auto a = load<__m128i>(p1, offset);
+  const auto b = load<__m128i>(p2, offset);
+  const auto vmax = bytewise_max(a, b);
+  const auto le = big_endian_cmp_mask(vmax, b);
+  const auto ge = big_endian_cmp_mask(vmax, a);
+  static_assert(cpp::is_same_v<cpp::remove_cv_t<decltype(le)>, uint16_t>);
+  return static_cast<int32_t>(ge) - static_cast<int32_t>(le);
+}
+#endif // __SSE4_1__
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for __m256i
+#if defined(__AVX__)
+template <> struct is_vector<__m256i> : cpp::true_type {};
+template <> struct cmp_is_expensive<__m256i> : cpp::true_type {};
+LIBC_INLINE __m256i xor_m256i(__m256i a, __m256i b) {
+  return _mm256_castps_si256(
+      _mm256_xor_ps(_mm256_castsi256_ps(a), _mm256_castsi256_ps(b)));
+}
+LIBC_INLINE __m256i or_m256i(__m256i a, __m256i b) {
+  return _mm256_castps_si256(
+      _mm256_or_ps(_mm256_castsi256_ps(a), _mm256_castsi256_ps(b)));
+}
+LIBC_INLINE __m256i load_and_xor_m256i(CPtr p1, CPtr p2, size_t offset) {
+  const auto a = load<__m256i>(p1, offset);
+  const auto b = load<__m256i>(p2, offset);
+  return xor_m256i(a, b);
+}
+LIBC_INLINE bool is_zero(__m256i value) {
+  return _mm256_testz_si256(value, value) == 1;
+}
+template <> LIBC_INLINE bool eq<__m256i>(CPtr p1, CPtr p2, size_t offset) {
+  return is_zero(load_and_xor_m256i(p1, p2, offset));
+}
+template <> LIBC_INLINE uint32_t neq<__m256i>(CPtr p1, CPtr p2, size_t offset) {
+  return !is_zero(load_and_xor_m256i(p1, p2, offset));
+}
+template <>
+LIBC_INLINE uint32_t branchless_head_tail_neq<__m256i>(CPtr p1, CPtr p2,
+                                                       size_t count) {
+  const __m256i head = load_and_xor_m256i(p1, p2, 0);
+  const __m256i tail = load_and_xor_m256i(p1, p2, count - sizeof(__m256i));
+  return !is_zero(or_m256i(head, tail));
+}
+#endif // __AVX__
+
+#if defined(__AVX2__)
+LIBC_INLINE __m256i bytewise_max(__m256i a, __m256i b) {
+  return _mm256_max_epu8(a, b);
+}
+LIBC_INLINE uint32_t big_endian_cmp_mask(__m256i max, __m256i value) {
+  // Bytewise comparison of 'max' and 'value'.
+  const __m256i little_endian_byte_mask = _mm256_cmpeq_epi8(max, value);
+  // Because x86 is little endian, bytes in the vector must be reversed before
+  // using movemask.
+#if defined(__AVX512VBMI__) && defined(__AVX512VL__)
+  // When AVX512BMI is available we can completely reverse the vector through
+  // VPERMB __m256i _mm256_permutexvar_epi8( __m256i idx, __m256i a);
+  const __m256i big_endian_byte_mask =
+      _mm256_permutexvar_epi8(_mm256_set_epi8(0, 1, 2, 3, 4, 5, 6, 7,         //
+                                              8, 9, 10, 11, 12, 13, 14, 15,   //
+                                              16, 17, 18, 19, 20, 21, 22, 23, //
+                                              24, 25, 26, 27, 28, 29, 30, 31),
+                              little_endian_byte_mask);
+  // And turn the byte vector mask into an 'uint32_t' for direct scalar
+  // comparison.
+  return _mm256_movemask_epi8(big_endian_byte_mask);
+#else
+  // We can't byte-reverse '__m256i' in a single instruction with AVX2.
+  // '_mm256_shuffle_epi8' can only shuffle within each 16-byte lane
+  // leading to:
+  // ymm = ymm[15,14,13,12,11,10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+  //           31,30,29,28,27,26,25,24,23,22,21,20,19,18,17,16]
+  // So we first shuffle each 16-byte lane leading to half-reversed vector mask.
+  const __m256i half_reversed = _mm256_shuffle_epi8(
+      little_endian_byte_mask, _mm256_set_epi8(0, 1, 2, 3, 4, 5, 6, 7,       //
+                                               8, 9, 10, 11, 12, 13, 14, 15, //
+                                               0, 1, 2, 3, 4, 5, 6, 7,       //
+                                               8, 9, 10, 11, 12, 13, 14, 15));
+  // Then we turn the vector into an uint32_t.
+  const uint32_t half_reversed_scalar = _mm256_movemask_epi8(half_reversed);
+  // And swap the lower and upper parts. This is optimized into a single `rorx`
+  // instruction.
+  return (half_reversed_scalar << 16) | (half_reversed_scalar >> 16);
+#endif
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp_neq<__m256i>(CPtr p1, CPtr p2, size_t offset) {
+  const auto a = load<__m256i>(p1, offset);
+  const auto b = load<__m256i>(p2, offset);
+  const auto vmax = bytewise_max(a, b);
+  const auto le = big_endian_cmp_mask(vmax, b);
+  const auto ge = big_endian_cmp_mask(vmax, a);
+  static_assert(cpp::is_same_v<cpp::remove_cv_t<decltype(le)>, uint32_t>);
+  return cmp_neq_uint64_t(ge, le);
+}
+#endif // __AVX2__
+
+///////////////////////////////////////////////////////////////////////////////
+// Specializations for __m512i
+#if defined(__AVX512BW__)
+template <> struct is_vector<__m512i> : cpp::true_type {};
+template <> struct cmp_is_expensive<__m512i> : cpp::true_type {};
+LIBC_INLINE __m512i bytewise_max(__m512i a, __m512i b) {
+  return _mm512_max_epu8(a, b);
+}
+LIBC_INLINE uint64_t big_endian_cmp_mask(__m512i max, __m512i value) {
+  // The AVX512BMI version is disabled due to bad codegen.
+  // https://github.com/llvm/llvm-project/issues/77459
+  // https://github.com/llvm/llvm-project/pull/77081
+  // TODO: Re-enable when clang version meets the fixed version.
+#if false && defined(__AVX512VBMI__)
+  // When AVX512BMI is available we can completely reverse the vector through
+  // VPERMB __m512i _mm512_permutexvar_epi8( __m512i idx, __m512i a);
+  const auto indices = _mm512_set_epi8(0, 1, 2, 3, 4, 5, 6, 7,         //
+                                       8, 9, 10, 11, 12, 13, 14, 15,   //
+                                       16, 17, 18, 19, 20, 21, 22, 23, //
+                                       24, 25, 26, 27, 28, 29, 30, 31, //
+                                       32, 33, 34, 35, 36, 37, 38, 39, //
+                                       40, 41, 42, 43, 44, 45, 46, 47, //
+                                       48, 49, 50, 51, 52, 53, 54, 55, //
+                                       56, 57, 58, 59, 60, 61, 62, 63);
+  // Then we compute the mask for equal bytes.
+  return _mm512_cmpeq_epi8_mask(_mm512_permutexvar_epi8(indices, max), //
+                                _mm512_permutexvar_epi8(indices, value));
+#else
+  // We can't byte-reverse '__m512i' in a single instruction with __AVX512BW__.
+  // '_mm512_shuffle_epi8' can only shuffle within each 16-byte lane.
+  // So we only reverse groups of 8 bytes, these groups are necessarily within a
+  // 16-byte lane.
+  // zmm = | 16 bytes  | 16 bytes  | 16 bytes  | 16 bytes  |
+  // zmm = | <8> | <8> | <8> | <8> | <8> | <8> | <8> | <8> |
+  const __m512i indices = _mm512_set_epi8(8, 9, 10, 11, 12, 13, 14, 15, //
+                                          0, 1, 2, 3, 4, 5, 6, 7,       //
+                                          8, 9, 10, 11, 12, 13, 14, 15, //
+                                          0, 1, 2, 3, 4, 5, 6, 7,       //
+                                          8, 9, 10, 11, 12, 13, 14, 15, //
+                                          0, 1, 2, 3, 4, 5, 6, 7,       //
+                                          8, 9, 10, 11, 12, 13, 14, 15, //
+                                          0, 1, 2, 3, 4, 5, 6, 7);
+  // Then we compute the mask for equal bytes. In this mask the bits of each
+  // byte are already reversed but the byte themselves should be reversed, this
+  // is done by using a bswap instruction.
+  return __builtin_bswap64(
+      _mm512_cmpeq_epi8_mask(_mm512_shuffle_epi8(max, indices), //
+                             _mm512_shuffle_epi8(value, indices)));
+
+#endif
+}
+template <> LIBC_INLINE bool eq<__m512i>(CPtr p1, CPtr p2, size_t offset) {
+  const auto a = load<__m512i>(p1, offset);
+  const auto b = load<__m512i>(p2, offset);
+  return _mm512_cmpneq_epi8_mask(a, b) == 0;
+}
+template <> LIBC_INLINE uint32_t neq<__m512i>(CPtr p1, CPtr p2, size_t offset) {
+  const auto a = load<__m512i>(p1, offset);
+  const auto b = load<__m512i>(p2, offset);
+  return _mm512_cmpneq_epi8_mask(a, b) != 0;
+}
+LIBC_INLINE __m512i load_and_xor_m512i(CPtr p1, CPtr p2, size_t offset) {
+  const auto a = load<__m512i>(p1, offset);
+  const auto b = load<__m512i>(p2, offset);
+  return _mm512_xor_epi64(a, b);
+}
+LIBC_INLINE bool is_zero(__m512i value) {
+  return _mm512_test_epi32_mask(value, value) == 0;
+}
+template <>
+LIBC_INLINE uint32_t branchless_head_tail_neq<__m512i>(CPtr p1, CPtr p2,
+                                                       size_t count) {
+  const __m512i head = load_and_xor_m512i(p1, p2, 0);
+  const __m512i tail = load_and_xor_m512i(p1, p2, count - sizeof(__m512i));
+  return !is_zero(_mm512_or_epi64(head, tail));
+}
+template <>
+LIBC_INLINE MemcmpReturnType cmp_neq<__m512i>(CPtr p1, CPtr p2, size_t offset) {
+  const auto a = load<__m512i>(p1, offset);
+  const auto b = load<__m512i>(p2, offset);
+  const auto vmax = bytewise_max(a, b);
+  const auto le = big_endian_cmp_mask(vmax, b);
+  const auto ge = big_endian_cmp_mask(vmax, a);
+  static_assert(cpp::is_same_v<cpp::remove_cv_t<decltype(le)>, uint64_t>);
+  return cmp_neq_uint64_t(ge, le);
+}
+#endif // __AVX512BW__
+
+#pragma GCC diagnostic pop
+
+} // namespace generic
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TARGET_ARCH_IS_X86
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_OP_X86_H

--- a/system/lib/llvm-libc/src/string/memory_utils/riscv/inline_bcmp.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/riscv/inline_bcmp.h
@@ -1,0 +1,34 @@
+//===-- Bcmp implementation for riscv ---------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_BCMP_H
+#define LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_BCMP_H
+
+#include "src/__support/macros/attributes.h"               // LIBC_INLINE
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/architectures.h" // LIBC_TARGET_ARCH_IS_RISCV64
+#include "src/string/memory_utils/generic/aligned_access.h"
+#include "src/string/memory_utils/utils.h" // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[maybe_unused]] LIBC_INLINE BcmpReturnType inline_bcmp_riscv(CPtr p1, CPtr p2,
+                                                              size_t count) {
+#if defined(LIBC_TARGET_ARCH_IS_RISCV64)
+  return inline_bcmp_aligned_access_64bit(p1, p2, count);
+#elif defined(LIBC_TARGET_ARCH_IS_RISCV32)
+  return inline_bcmp_aligned_access_32bit(p1, p2, count);
+#else
+#error "Unimplemented"
+#endif
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_BCMP_H

--- a/system/lib/llvm-libc/src/string/memory_utils/riscv/inline_memcmp.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/riscv/inline_memcmp.h
@@ -1,0 +1,34 @@
+//===-- Memcmp implementation for riscv -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_MEMCMP_H
+#define LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_MEMCMP_H
+
+#include "src/__support/macros/attributes.h"               // LIBC_INLINE
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/architectures.h" // LIBC_TARGET_ARCH_IS_RISCV64
+#include "src/string/memory_utils/generic/aligned_access.h"
+#include "src/string/memory_utils/utils.h" // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[maybe_unused]] LIBC_INLINE MemcmpReturnType
+inline_memcmp_riscv(CPtr p1, CPtr p2, size_t count) {
+#if defined(LIBC_TARGET_ARCH_IS_RISCV64)
+  return inline_memcmp_aligned_access_64bit(p1, p2, count);
+#elif defined(LIBC_TARGET_ARCH_IS_RISCV32)
+  return inline_memcmp_aligned_access_32bit(p1, p2, count);
+#else
+#error "Unimplemented"
+#endif
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_MEMCMP_H

--- a/system/lib/llvm-libc/src/string/memory_utils/riscv/inline_memcpy.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/riscv/inline_memcpy.h
@@ -1,0 +1,34 @@
+//===-- Memcpy implementation for riscv -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_MEMCPY_H
+#define LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_MEMCPY_H
+
+#include "src/__support/macros/attributes.h"               // LIBC_INLINE
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/architectures.h" // LIBC_TARGET_ARCH_IS_RISCV64
+#include "src/string/memory_utils/generic/aligned_access.h"
+#include "src/string/memory_utils/utils.h" // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memcpy_riscv(Ptr __restrict dst, CPtr __restrict src, size_t count) {
+#if defined(LIBC_TARGET_ARCH_IS_RISCV64)
+  return inline_memcpy_aligned_access_64bit(dst, src, count);
+#elif defined(LIBC_TARGET_ARCH_IS_RISCV32)
+  return inline_memcpy_aligned_access_32bit(dst, src, count);
+#else
+#error "Unimplemented"
+#endif
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_MEMCPY_H

--- a/system/lib/llvm-libc/src/string/memory_utils/riscv/inline_memmove.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/riscv/inline_memmove.h
@@ -1,0 +1,28 @@
+//===-- Memmove implementation for riscv ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_MEMMOVE_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_MEMMOVE_H
+
+#include "src/__support/macros/attributes.h"               // LIBC_INLINE
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/architectures.h" // LIBC_TARGET_ARCH_IS_RISCV64
+#include "src/string/memory_utils/generic/byte_per_byte.h"
+#include "src/string/memory_utils/utils.h" // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memmove_riscv(Ptr __restrict dst, CPtr __restrict src, size_t count) {
+  return inline_memmove_byte_per_byte(dst, src, count);
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_MEMMOVE_H

--- a/system/lib/llvm-libc/src/string/memory_utils/riscv/inline_memset.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/riscv/inline_memset.h
@@ -1,0 +1,34 @@
+//===-- Memset implementation for riscv -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_MEMSET_H
+#define LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_MEMSET_H
+
+#include "src/__support/macros/attributes.h"               // LIBC_INLINE
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/architectures.h" // LIBC_TARGET_ARCH_IS_RISCV64
+#include "src/string/memory_utils/generic/aligned_access.h"
+#include "src/string/memory_utils/utils.h" // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+LIBC_INLINE static void inline_memset_riscv(Ptr dst, uint8_t value,
+                                            size_t count) {
+#if defined(LIBC_TARGET_ARCH_IS_RISCV64)
+  return inline_memset_aligned_access_64bit(dst, value, count);
+#elif defined(LIBC_TARGET_ARCH_IS_RISCV32)
+  return inline_memset_aligned_access_32bit(dst, value, count);
+#else
+#error "Unimplemented"
+#endif
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_SRC_STRING_MEMORY_UTILS_RISCV_INLINE_MEMSET_H

--- a/system/lib/llvm-libc/src/string/memory_utils/utils.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/utils.h
@@ -1,0 +1,355 @@
+//===-- Memory utils --------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_UTILS_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_UTILS_H
+
+#include "src/__support/CPP/bit.h"
+#include "src/__support/CPP/cstddef.h"
+#include "src/__support/CPP/type_traits.h"
+#include "src/__support/endian_internal.h"
+#include "src/__support/macros/attributes.h" // LIBC_INLINE
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/architectures.h"
+
+#include <stddef.h> // size_t
+#include <stdint.h> // intptr_t / uintptr_t / INT32_MAX / INT32_MIN
+
+namespace LIBC_NAMESPACE_DECL {
+
+// Returns the number of bytes to substract from ptr to get to the previous
+// multiple of alignment. If ptr is already aligned returns 0.
+template <size_t alignment>
+LIBC_INLINE uintptr_t distance_to_align_down(const void *ptr) {
+  static_assert(cpp::has_single_bit(alignment),
+                "alignment must be a power of 2");
+  return reinterpret_cast<uintptr_t>(ptr) & (alignment - 1U);
+}
+
+// Returns the number of bytes to add to ptr to get to the next multiple of
+// alignment. If ptr is already aligned returns 0.
+template <size_t alignment>
+LIBC_INLINE uintptr_t distance_to_align_up(const void *ptr) {
+  static_assert(cpp::has_single_bit(alignment),
+                "alignment must be a power of 2");
+  // The logic is not straightforward and involves unsigned modulo arithmetic
+  // but the generated code is as fast as it can be.
+  return -reinterpret_cast<uintptr_t>(ptr) & (alignment - 1U);
+}
+
+// Returns the number of bytes to add to ptr to get to the next multiple of
+// alignment. If ptr is already aligned returns alignment.
+template <size_t alignment>
+LIBC_INLINE uintptr_t distance_to_next_aligned(const void *ptr) {
+  return alignment - distance_to_align_down<alignment>(ptr);
+}
+
+// Returns the same pointer but notifies the compiler that it is aligned.
+template <size_t alignment, typename T> LIBC_INLINE T *assume_aligned(T *ptr) {
+  return reinterpret_cast<T *>(__builtin_assume_aligned(ptr, alignment));
+}
+
+// Returns true iff memory regions [p1, p1 + size] and [p2, p2 + size] are
+// disjoint.
+LIBC_INLINE bool is_disjoint(const void *p1, const void *p2, size_t size) {
+  const ptrdiff_t sdiff =
+      static_cast<const char *>(p1) - static_cast<const char *>(p2);
+  // We use bit_cast to make sure that we don't run into accidental integer
+  // promotion. Notably the unary minus operator goes through integer promotion
+  // at the expression level. We assume arithmetic to be two's complement (i.e.,
+  // bit_cast has the same behavior as a regular signed to unsigned cast).
+  static_assert(-1 == ~0, "not 2's complement");
+  const size_t udiff = cpp::bit_cast<size_t>(sdiff);
+  // Integer promition would be caught here.
+  const size_t neg_udiff = cpp::bit_cast<size_t>(-sdiff);
+  // This is expected to compile a conditional move.
+  return sdiff >= 0 ? size <= udiff : size <= neg_udiff;
+}
+
+#if __has_builtin(__builtin_memcpy_inline)
+#define LLVM_LIBC_HAS_BUILTIN_MEMCPY_INLINE
+#endif
+
+#if __has_builtin(__builtin_memset_inline)
+#define LLVM_LIBC_HAS_BUILTIN_MEMSET_INLINE
+#endif
+
+// Performs a constant count copy.
+template <size_t Size>
+LIBC_INLINE void memcpy_inline(void *__restrict dst,
+                               const void *__restrict src) {
+#ifdef LLVM_LIBC_HAS_BUILTIN_MEMCPY_INLINE
+  __builtin_memcpy_inline(dst, src, Size);
+#else
+  // In memory functions `memcpy_inline` is instantiated several times with
+  // different value of the Size parameter. This doesn't play well with GCC's
+  // Value Range Analysis that wrongly detects out of bounds accesses. We
+  // disable these warnings for the purpose of this function.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+  for (size_t i = 0; i < Size; ++i)
+    static_cast<char *>(dst)[i] = static_cast<const char *>(src)[i];
+#pragma GCC diagnostic pop
+#endif
+}
+
+using Ptr = cpp::byte *;        // Pointer to raw data.
+using CPtr = const cpp::byte *; // Const pointer to raw data.
+
+// This type makes sure that we don't accidentally promote an integral type to
+// another one. It is only constructible from the exact T type.
+template <typename T> struct StrictIntegralType {
+  static_assert(cpp::is_integral_v<T>);
+
+  // Can only be constructed from a T.
+  template <typename U, cpp::enable_if_t<cpp::is_same_v<U, T>, bool> = 0>
+  LIBC_INLINE StrictIntegralType(U value) : value(value) {}
+
+  // Allows using the type in an if statement.
+  LIBC_INLINE explicit operator bool() const { return value; }
+
+  // If type is unsigned (bcmp) we allow bitwise OR operations.
+  LIBC_INLINE StrictIntegralType
+  operator|(const StrictIntegralType &Rhs) const {
+    static_assert(!cpp::is_signed_v<T>);
+    return value | Rhs.value;
+  }
+
+  // For interation with the C API we allow explicit conversion back to the
+  // `int` type.
+  LIBC_INLINE explicit operator int() const {
+    // bit_cast makes sure that T and int have the same size.
+    return cpp::bit_cast<int>(value);
+  }
+
+  // Helper to get the zero value.
+  LIBC_INLINE static constexpr StrictIntegralType zero() { return {T(0)}; }
+  LIBC_INLINE static constexpr StrictIntegralType nonzero() { return {T(1)}; }
+
+private:
+  T value;
+};
+
+using MemcmpReturnType = StrictIntegralType<int32_t>;
+using BcmpReturnType = StrictIntegralType<uint32_t>;
+
+// This implements the semantic of 'memcmp' returning a negative value when 'a'
+// is less than 'b', '0' when 'a' equals 'b' and a positive number otherwise.
+LIBC_INLINE MemcmpReturnType cmp_uint32_t(uint32_t a, uint32_t b) {
+  // We perform the difference as an int64_t.
+  const int64_t diff = static_cast<int64_t>(a) - static_cast<int64_t>(b);
+  // For the int64_t to int32_t conversion we want the following properties:
+  // - int32_t[31:31] == 1 iff diff < 0
+  // - int32_t[31:0] == 0 iff diff == 0
+
+  // We also observe that:
+  // - When diff < 0: diff[63:32] == 0xffffffff and diff[31:0] != 0
+  // - When diff > 0: diff[63:32] == 0 and diff[31:0] != 0
+  // - When diff == 0: diff[63:32] == 0 and diff[31:0] == 0
+  // - https://godbolt.org/z/8W7qWP6e5
+  // - This implies that we can only look at diff[32:32] for determining the
+  // sign bit for the returned int32_t.
+
+  // So, we do the following:
+  // - int32_t[31:31] = diff[32:32]
+  // - int32_t[30:0] = diff[31:0] == 0 ? 0 : non-0.
+
+  // And, we can achieve the above by the expression below. We could have also
+  // used (diff64 >> 1) | (diff64 & 0x1) but (diff64 & 0xFFFF) is faster than
+  // (diff64 & 0x1). https://godbolt.org/z/j3b569rW1
+  return static_cast<int32_t>((diff >> 1) | (diff & 0xFFFF));
+}
+
+// Returns a negative value if 'a' is less than 'b' and a positive value
+// otherwise. This implements the semantic of 'memcmp' when we know that 'a' and
+// 'b' differ.
+LIBC_INLINE MemcmpReturnType cmp_neq_uint64_t(uint64_t a, uint64_t b) {
+#if defined(LIBC_TARGET_ARCH_IS_X86)
+  // On x86, the best strategy would be to use 'INT32_MAX' and 'INT32_MIN' for
+  // positive and negative value respectively as they are one value apart:
+  //   xor     eax, eax         <- free
+  //   cmp     rdi, rsi         <- serializing
+  //   adc     eax, 2147483647  <- serializing
+
+  // Unfortunately we found instances of client code that negate the result of
+  // 'memcmp' to reverse ordering. Because signed integers are not symmetric
+  // (e.g., int8_t ∈ [-128, 127]) returning 'INT_MIN' would break such code as
+  // `-INT_MIN` is not representable as an int32_t.
+
+  // As a consequence, we use 5 and -5 which is still OK nice in terms of
+  // latency.
+  //   cmp     rdi, rsi         <- serializing
+  //   mov     ecx, -5          <- can be done in parallel
+  //   mov     eax, 5           <- can be done in parallel
+  //   cmovb   eax, ecx         <- serializing
+  static constexpr int32_t POSITIVE = 5;
+  static constexpr int32_t NEGATIVE = -5;
+#else
+  // On RISC-V we simply use '1' and '-1' as it leads to branchless code.
+  // On ARMv8, both strategies lead to the same performance.
+  static constexpr int32_t POSITIVE = 1;
+  static constexpr int32_t NEGATIVE = -1;
+#endif
+  static_assert(POSITIVE > 0);
+  static_assert(NEGATIVE < 0);
+  return a < b ? NEGATIVE : POSITIVE;
+}
+
+// Loads bytes from memory (possibly unaligned) and materializes them as
+// type.
+template <typename T> LIBC_INLINE T load(CPtr ptr) {
+  T out;
+  memcpy_inline<sizeof(T)>(&out, ptr);
+  return out;
+}
+
+// Stores a value of type T in memory (possibly unaligned).
+template <typename T> LIBC_INLINE void store(Ptr ptr, T value) {
+  memcpy_inline<sizeof(T)>(ptr, &value);
+}
+
+// On architectures that do not allow for unaligned access we perform several
+// aligned accesses and recombine them through shifts and logicals operations.
+// For instance, if we know that the pointer is 2-byte aligned we can decompose
+// a 64-bit operation into four 16-bit operations.
+
+// Loads a 'ValueType' by decomposing it into several loads that are assumed to
+// be aligned.
+// e.g. load_aligned<uint32_t, uint16_t, uint16_t>(ptr);
+template <typename ValueType, typename T, typename... TS>
+LIBC_INLINE ValueType load_aligned(CPtr src) {
+  static_assert(sizeof(ValueType) >= (sizeof(T) + ... + sizeof(TS)));
+  const ValueType value = load<T>(assume_aligned<sizeof(T)>(src));
+  if constexpr (sizeof...(TS) > 0) {
+    constexpr size_t SHIFT = sizeof(T) * 8;
+    const ValueType next = load_aligned<ValueType, TS...>(src + sizeof(T));
+    if constexpr (Endian::IS_LITTLE)
+      return value | (next << SHIFT);
+    else if constexpr (Endian::IS_BIG)
+      return (value << SHIFT) | next;
+    else
+      static_assert(cpp::always_false<T>, "Invalid endianness");
+  } else {
+    return value;
+  }
+}
+
+// Alias for loading a 'uint32_t'.
+template <typename T, typename... TS>
+LIBC_INLINE auto load32_aligned(CPtr src, size_t offset) {
+  static_assert((sizeof(T) + ... + sizeof(TS)) == sizeof(uint32_t));
+  return load_aligned<uint32_t, T, TS...>(src + offset);
+}
+
+// Alias for loading a 'uint64_t'.
+template <typename T, typename... TS>
+LIBC_INLINE auto load64_aligned(CPtr src, size_t offset) {
+  static_assert((sizeof(T) + ... + sizeof(TS)) == sizeof(uint64_t));
+  return load_aligned<uint64_t, T, TS...>(src + offset);
+}
+
+// Stores a 'ValueType' by decomposing it into several stores that are assumed
+// to be aligned.
+// e.g. store_aligned<uint32_t, uint16_t, uint16_t>(value, ptr);
+template <typename ValueType, typename T, typename... TS>
+LIBC_INLINE void store_aligned(ValueType value, Ptr dst) {
+  static_assert(sizeof(ValueType) >= (sizeof(T) + ... + sizeof(TS)));
+  constexpr size_t SHIFT = sizeof(T) * 8;
+  if constexpr (Endian::IS_LITTLE) {
+    store<T>(assume_aligned<sizeof(T)>(dst), value & ~T(0));
+    if constexpr (sizeof...(TS) > 0)
+      store_aligned<ValueType, TS...>(value >> SHIFT, dst + sizeof(T));
+  } else if constexpr (Endian::IS_BIG) {
+    constexpr size_t OFFSET = (0 + ... + sizeof(TS));
+    store<T>(assume_aligned<sizeof(T)>(dst + OFFSET), value & ~T(0));
+    if constexpr (sizeof...(TS) > 0)
+      store_aligned<ValueType, TS...>(value >> SHIFT, dst);
+  } else {
+    static_assert(cpp::always_false<T>, "Invalid endianness");
+  }
+}
+
+// Alias for storing a 'uint32_t'.
+template <typename T, typename... TS>
+LIBC_INLINE void store32_aligned(uint32_t value, Ptr dst, size_t offset) {
+  static_assert((sizeof(T) + ... + sizeof(TS)) == sizeof(uint32_t));
+  store_aligned<uint32_t, T, TS...>(value, dst + offset);
+}
+
+// Alias for storing a 'uint64_t'.
+template <typename T, typename... TS>
+LIBC_INLINE void store64_aligned(uint64_t value, Ptr dst, size_t offset) {
+  static_assert((sizeof(T) + ... + sizeof(TS)) == sizeof(uint64_t));
+  store_aligned<uint64_t, T, TS...>(value, dst + offset);
+}
+
+// Advances the pointers p1 and p2 by offset bytes and decrease count by the
+// same amount.
+template <typename T1, typename T2>
+LIBC_INLINE void adjust(ptrdiff_t offset, T1 *__restrict &p1,
+                        T2 *__restrict &p2, size_t &count) {
+  p1 += offset;
+  p2 += offset;
+  count -= offset;
+}
+
+// Advances p1 and p2 so p1 gets aligned to the next SIZE bytes boundary
+// and decrease count by the same amount.
+// We make sure the compiler knows about the adjusted pointer alignment.
+template <size_t SIZE, typename T1, typename T2>
+void align_p1_to_next_boundary(T1 *__restrict &p1, T2 *__restrict &p2,
+                               size_t &count) {
+  adjust(distance_to_next_aligned<SIZE>(p1), p1, p2, count);
+  p1 = assume_aligned<SIZE>(p1);
+}
+
+// Same as align_p1_to_next_boundary above but with a single pointer instead.
+template <size_t SIZE, typename T>
+LIBC_INLINE void align_to_next_boundary(T *&p1, size_t &count) {
+  const T *dummy = p1;
+  align_p1_to_next_boundary<SIZE>(p1, dummy, count);
+}
+
+// An enum class that discriminates between the first and second pointer.
+enum class Arg { P1, P2, Dst = P1, Src = P2 };
+
+// Same as align_p1_to_next_boundary but allows for aligning p2 instead of p1.
+// Precondition: &p1 != &p2
+template <size_t SIZE, Arg AlignOn, typename T1, typename T2>
+LIBC_INLINE void align_to_next_boundary(T1 *__restrict &p1, T2 *__restrict &p2,
+                                        size_t &count) {
+  if constexpr (AlignOn == Arg::P1)
+    align_p1_to_next_boundary<SIZE>(p1, p2, count);
+  else if constexpr (AlignOn == Arg::P2)
+    align_p1_to_next_boundary<SIZE>(p2, p1, count); // swapping p1 and p2.
+  else
+    static_assert(cpp::always_false<T1>,
+                  "AlignOn must be either Arg::P1 or Arg::P2");
+}
+
+template <size_t SIZE> struct AlignHelper {
+  LIBC_INLINE AlignHelper(CPtr ptr)
+      : offset(distance_to_next_aligned<SIZE>(ptr)) {}
+
+  LIBC_INLINE bool not_aligned() const { return offset != SIZE; }
+  uintptr_t offset;
+};
+
+LIBC_INLINE void prefetch_for_write(CPtr dst) {
+  __builtin_prefetch(dst, /*write*/ 1, /*max locality*/ 3);
+}
+
+LIBC_INLINE void prefetch_to_local_cache(CPtr dst) {
+  __builtin_prefetch(dst, /*read*/ 0, /*max locality*/ 3);
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_UTILS_H

--- a/system/lib/llvm-libc/src/string/memory_utils/x86_64/inline_bcmp.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/x86_64/inline_bcmp.h
@@ -1,0 +1,84 @@
+//===-- Bcmp implementation for x86_64 --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_BCMP_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_BCMP_H
+
+#include "src/__support/macros/attributes.h" // LIBC_INLINE
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/op_generic.h"
+#include "src/string/memory_utils/op_x86.h"
+#include "src/string/memory_utils/utils.h" // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[maybe_unused]] LIBC_INLINE BcmpReturnType
+inline_bcmp_generic_gt16(CPtr p1, CPtr p2, size_t count) {
+  return generic::Bcmp<uint64_t>::loop_and_tail_align_above(256, p1, p2, count);
+}
+
+#if defined(__SSE4_1__)
+[[maybe_unused]] LIBC_INLINE BcmpReturnType
+inline_bcmp_x86_sse41_gt16(CPtr p1, CPtr p2, size_t count) {
+  if (count <= 32)
+    return generic::branchless_head_tail_neq<__m128i>(p1, p2, count);
+  return generic::Bcmp<__m128i>::loop_and_tail_align_above(256, p1, p2, count);
+}
+#endif // __SSE4_1__
+
+#if defined(__AVX__)
+[[maybe_unused]] LIBC_INLINE BcmpReturnType
+inline_bcmp_x86_avx_gt16(CPtr p1, CPtr p2, size_t count) {
+  if (count <= 32)
+    return generic::branchless_head_tail_neq<__m128i>(p1, p2, count);
+  if (count <= 64)
+    return generic::branchless_head_tail_neq<__m256i>(p1, p2, count);
+  return generic::Bcmp<__m256i>::loop_and_tail_align_above(256, p1, p2, count);
+}
+#endif // __AVX__
+
+#if defined(__AVX512BW__)
+[[maybe_unused]] LIBC_INLINE BcmpReturnType
+inline_bcmp_x86_avx512bw_gt16(CPtr p1, CPtr p2, size_t count) {
+  if (count <= 32)
+    return generic::branchless_head_tail_neq<__m128i>(p1, p2, count);
+  if (count <= 64)
+    return generic::branchless_head_tail_neq<__m256i>(p1, p2, count);
+  if (count <= 128)
+    return generic::branchless_head_tail_neq<__m512i>(p1, p2, count);
+  return generic::Bcmp<__m512i>::loop_and_tail_align_above(256, p1, p2, count);
+}
+#endif // __AVX512BW__
+
+[[maybe_unused]] LIBC_INLINE BcmpReturnType inline_bcmp_x86(CPtr p1, CPtr p2,
+                                                            size_t count) {
+  if (count == 0)
+    return BcmpReturnType::zero();
+  if (count == 1)
+    return generic::Bcmp<uint8_t>::block(p1, p2);
+  if (count <= 4)
+    return generic::branchless_head_tail_neq<uint16_t>(p1, p2, count);
+  if (count <= 8)
+    return generic::branchless_head_tail_neq<uint32_t>(p1, p2, count);
+  if (count <= 16)
+    return generic::branchless_head_tail_neq<uint64_t>(p1, p2, count);
+#if defined(__AVX512BW__)
+  return inline_bcmp_x86_avx512bw_gt16(p1, p2, count);
+#elif defined(__AVX__)
+  return inline_bcmp_x86_avx_gt16(p1, p2, count);
+#elif defined(__SSE4_1__)
+  return inline_bcmp_x86_sse41_gt16(p1, p2, count);
+#else
+  return inline_bcmp_generic_gt16(p1, p2, count);
+#endif
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_BCMP_H

--- a/system/lib/llvm-libc/src/string/memory_utils/x86_64/inline_memcmp.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/x86_64/inline_memcmp.h
@@ -1,0 +1,94 @@
+//===-- Memcmp implementation for x86_64 ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMCMP_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMCMP_H
+
+#include "src/__support/macros/attributes.h"   // LIBC_INLINE
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+#include "src/string/memory_utils/op_generic.h"
+#include "src/string/memory_utils/op_x86.h"
+#include "src/string/memory_utils/utils.h" // MemcmpReturnType
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[maybe_unused]] LIBC_INLINE MemcmpReturnType
+inline_memcmp_generic_gt16(CPtr p1, CPtr p2, size_t count) {
+  return generic::Memcmp<uint64_t>::loop_and_tail_align_above(384, p1, p2,
+                                                              count);
+}
+
+#if defined(__SSE4_1__)
+[[maybe_unused]] LIBC_INLINE MemcmpReturnType
+inline_memcmp_x86_sse41_gt16(CPtr p1, CPtr p2, size_t count) {
+  return generic::Memcmp<__m128i>::loop_and_tail_align_above(384, p1, p2,
+                                                             count);
+}
+#endif // __SSE4_1__
+
+#if defined(__AVX2__)
+[[maybe_unused]] LIBC_INLINE MemcmpReturnType
+inline_memcmp_x86_avx2_gt16(CPtr p1, CPtr p2, size_t count) {
+  if (count <= 32)
+    return generic::Memcmp<__m128i>::head_tail(p1, p2, count);
+  if (count <= 64)
+    return generic::Memcmp<__m256i>::head_tail(p1, p2, count);
+  return generic::Memcmp<__m256i>::loop_and_tail_align_above(384, p1, p2,
+                                                             count);
+}
+#endif // __AVX2__
+
+#if defined(__AVX512BW__)
+[[maybe_unused]] LIBC_INLINE MemcmpReturnType
+inline_memcmp_x86_avx512bw_gt16(CPtr p1, CPtr p2, size_t count) {
+  if (count <= 32)
+    return generic::Memcmp<__m128i>::head_tail(p1, p2, count);
+  if (count <= 64)
+    return generic::Memcmp<__m256i>::head_tail(p1, p2, count);
+  if (count <= 128)
+    return generic::Memcmp<__m512i>::head_tail(p1, p2, count);
+  return generic::Memcmp<__m512i>::loop_and_tail_align_above(384, p1, p2,
+                                                             count);
+}
+#endif // __AVX512BW__
+
+LIBC_INLINE MemcmpReturnType inline_memcmp_x86(CPtr p1, CPtr p2, size_t count) {
+  if (count == 0)
+    return MemcmpReturnType::zero();
+  if (count == 1)
+    return generic::Memcmp<uint8_t>::block(p1, p2);
+  if (count == 2)
+    return generic::Memcmp<uint16_t>::block(p1, p2);
+  if (count == 3)
+    return generic::MemcmpSequence<uint16_t, uint8_t>::block(p1, p2);
+  if (count == 4)
+    return generic::Memcmp<uint32_t>::block(p1, p2);
+  if (count == 5)
+    return generic::MemcmpSequence<uint32_t, uint8_t>::block(p1, p2);
+  if (count == 6)
+    return generic::MemcmpSequence<uint32_t, uint16_t>::block(p1, p2);
+  if (count == 7)
+    return generic::Memcmp<uint32_t>::head_tail(p1, p2, 7);
+  if (count == 8)
+    return generic::Memcmp<uint64_t>::block(p1, p2);
+  if (count <= 16)
+    return generic::Memcmp<uint64_t>::head_tail(p1, p2, count);
+#if defined(__AVX512BW__)
+  return inline_memcmp_x86_avx512bw_gt16(p1, p2, count);
+#elif defined(__AVX2__)
+  return inline_memcmp_x86_avx2_gt16(p1, p2, count);
+#elif defined(__SSE4_1__)
+  return inline_memcmp_x86_sse41_gt16(p1, p2, count);
+#else
+  return inline_memcmp_generic_gt16(p1, p2, count);
+#endif
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMCMP_H

--- a/system/lib/llvm-libc/src/string/memory_utils/x86_64/inline_memcpy.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/x86_64/inline_memcpy.h
@@ -1,0 +1,234 @@
+//===-- Memcpy implementation for x86_64 ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMCPY_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMCPY_H
+
+#include "src/__support/macros/attributes.h"   // LIBC_INLINE_VAR
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+#include "src/string/memory_utils/op_builtin.h"
+#include "src/string/memory_utils/op_x86.h"
+#include "src/string/memory_utils/utils.h"
+
+#include <stddef.h> // size_t
+#include <stdint.h> // SIZE_MAX
+
+#ifdef LLVM_LIBC_MEMCPY_X86_USE_ONLY_REPMOVSB
+#error LLVM_LIBC_MEMCPY_X86_USE_ONLY_REPMOVSB is deprecated use LIBC_COPT_MEMCPY_X86_USE_REPMOVSB_FROM_SIZE=0 instead.
+#endif // LLVM_LIBC_MEMCPY_X86_USE_ONLY_REPMOVSB
+
+#ifdef LLVM_LIBC_MEMCPY_X86_USE_REPMOVSB_FROM_SIZE
+#error LLVM_LIBC_MEMCPY_X86_USE_REPMOVSB_FROM_SIZE is deprecated use LIBC_COPT_MEMCPY_X86_USE_REPMOVSB_FROM_SIZE=0 instead.
+#endif // LLVM_LIBC_MEMCPY_X86_USE_REPMOVSB_FROM_SIZE
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace x86 {
+
+LIBC_INLINE_VAR constexpr size_t K_ONE_CACHELINE = 64;
+LIBC_INLINE_VAR constexpr size_t K_TWO_CACHELINES = 2 * K_ONE_CACHELINE;
+LIBC_INLINE_VAR constexpr size_t K_THREE_CACHELINES = 3 * K_ONE_CACHELINE;
+
+LIBC_INLINE_VAR constexpr bool K_USE_SOFTWARE_PREFETCHING =
+    LLVM_LIBC_IS_DEFINED(LIBC_COPT_MEMCPY_X86_USE_SOFTWARE_PREFETCHING);
+
+// Whether to use rep;movsb exclusively (0), not at all (SIZE_MAX), or only
+// above a certain threshold. Defaults to "do not use rep;movsb".
+#ifndef LIBC_COPT_MEMCPY_X86_USE_REPMOVSB_FROM_SIZE
+#define LIBC_COPT_MEMCPY_X86_USE_REPMOVSB_FROM_SIZE SIZE_MAX
+#endif
+LIBC_INLINE_VAR constexpr size_t K_REP_MOVSB_THRESHOLD =
+    LIBC_COPT_MEMCPY_X86_USE_REPMOVSB_FROM_SIZE;
+
+} // namespace x86
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memcpy_x86_sse2_ge64(Ptr __restrict dst, CPtr __restrict src,
+                            size_t count) {
+  if (count <= 128)
+    return builtin::Memcpy<64>::head_tail(dst, src, count);
+  builtin::Memcpy<32>::block(dst, src);
+  align_to_next_boundary<32, Arg::Dst>(dst, src, count);
+  return builtin::Memcpy<32>::loop_and_tail(dst, src, count);
+}
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memcpy_x86_avx_ge64(Ptr __restrict dst, CPtr __restrict src,
+                           size_t count) {
+  if (count <= 128)
+    return builtin::Memcpy<64>::head_tail(dst, src, count);
+  if (count < 256)
+    return builtin::Memcpy<128>::head_tail(dst, src, count);
+  builtin::Memcpy<32>::block(dst, src);
+  align_to_next_boundary<32, Arg::Dst>(dst, src, count);
+  return builtin::Memcpy<64>::loop_and_tail(dst, src, count);
+}
+
+[[maybe_unused]] LIBC_INLINE void inline_memcpy_prefetch(Ptr __restrict dst,
+                                                         CPtr __restrict src,
+                                                         size_t distance) {
+  prefetch_to_local_cache(src + distance);
+  prefetch_for_write(dst + distance);
+}
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memcpy_x86_sse2_ge64_sw_prefetching(Ptr __restrict dst,
+                                           CPtr __restrict src, size_t count) {
+  using namespace LIBC_NAMESPACE::x86;
+  inline_memcpy_prefetch(dst, src, K_ONE_CACHELINE);
+  if (count <= 128)
+    return builtin::Memcpy<64>::head_tail(dst, src, count);
+  inline_memcpy_prefetch(dst, src, K_TWO_CACHELINES);
+  // Aligning 'dst' on a 32B boundary.
+  builtin::Memcpy<32>::block(dst, src);
+  align_to_next_boundary<32, Arg::Dst>(dst, src, count);
+  builtin::Memcpy<96>::block(dst, src);
+  size_t offset = 96;
+  // At this point:
+  // - we copied between 96B and 128B,
+  // - we prefetched cachelines at 'src + 64' and 'src + 128',
+  // - 'dst' is 32B aligned,
+  // - count >= 128.
+  if (count < 352) {
+    // Two cache lines at a time.
+    while (offset + K_TWO_CACHELINES + 32 <= count) {
+      inline_memcpy_prefetch(dst, src, offset + K_ONE_CACHELINE);
+      inline_memcpy_prefetch(dst, src, offset + K_TWO_CACHELINES);
+      // Copy one cache line at a time to prevent the use of `rep;movsb`.
+      for (size_t i = 0; i < 2; ++i, offset += K_ONE_CACHELINE)
+        builtin::Memcpy<K_ONE_CACHELINE>::block_offset(dst, src, offset);
+    }
+  } else {
+    // Three cache lines at a time.
+    while (offset + K_THREE_CACHELINES + 32 <= count) {
+      inline_memcpy_prefetch(dst, src, offset + K_ONE_CACHELINE);
+      inline_memcpy_prefetch(dst, src, offset + K_TWO_CACHELINES);
+      inline_memcpy_prefetch(dst, src, offset + K_THREE_CACHELINES);
+      // Copy one cache line at a time to prevent the use of `rep;movsb`.
+      for (size_t i = 0; i < 3; ++i, offset += K_ONE_CACHELINE)
+        builtin::Memcpy<K_ONE_CACHELINE>::block_offset(dst, src, offset);
+    }
+  }
+  // We don't use 'loop_and_tail_offset' because it assumes at least one
+  // iteration of the loop.
+  while (offset + 32 <= count) {
+    builtin::Memcpy<32>::block_offset(dst, src, offset);
+    offset += 32;
+  }
+  return builtin::Memcpy<32>::tail(dst, src, count);
+}
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memcpy_x86_avx_ge64_sw_prefetching(Ptr __restrict dst,
+                                          CPtr __restrict src, size_t count) {
+  using namespace LIBC_NAMESPACE::x86;
+  inline_memcpy_prefetch(dst, src, K_ONE_CACHELINE);
+  if (count <= 128)
+    return builtin::Memcpy<64>::head_tail(dst, src, count);
+  inline_memcpy_prefetch(dst, src, K_TWO_CACHELINES);
+  inline_memcpy_prefetch(dst, src, K_THREE_CACHELINES);
+  if (count < 256)
+    return builtin::Memcpy<128>::head_tail(dst, src, count);
+  // Aligning 'dst' on a 32B boundary.
+  builtin::Memcpy<32>::block(dst, src);
+  align_to_next_boundary<32, Arg::Dst>(dst, src, count);
+  builtin::Memcpy<224>::block(dst, src);
+  size_t offset = 224;
+  // At this point:
+  // - we copied between 224B and 256B,
+  // - we prefetched cachelines at 'src + 64', 'src + 128', and 'src + 196'
+  // - 'dst' is 32B aligned,
+  // - count >= 128.
+  while (offset + K_THREE_CACHELINES + 64 <= count) {
+    // Three cache lines at a time.
+    inline_memcpy_prefetch(dst, src, offset + K_ONE_CACHELINE);
+    inline_memcpy_prefetch(dst, src, offset + K_TWO_CACHELINES);
+    inline_memcpy_prefetch(dst, src, offset + K_THREE_CACHELINES);
+    // Copy one cache line at a time to prevent the use of `rep;movsb`.
+    for (size_t i = 0; i < 3; ++i, offset += K_ONE_CACHELINE)
+      builtin::Memcpy<K_ONE_CACHELINE>::block_offset(dst, src, offset);
+  }
+  // We don't use 'loop_and_tail_offset' because it assumes at least one
+  // iteration of the loop.
+  while (offset + 64 <= count) {
+    builtin::Memcpy<64>::block_offset(dst, src, offset);
+    offset += 64;
+  }
+  return builtin::Memcpy<64>::tail(dst, src, count);
+}
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memcpy_x86(Ptr __restrict dst, CPtr __restrict src, size_t count) {
+#if defined(__AVX512F__)
+  constexpr size_t VECTOR_SIZE = 64;
+#elif defined(__AVX__)
+  constexpr size_t VECTOR_SIZE = 32;
+#elif defined(__SSE2__)
+  constexpr size_t VECTOR_SIZE = 16;
+#else
+  constexpr size_t VECTOR_SIZE = 8;
+#endif
+  if (count == 0)
+    return;
+  if (count == 1)
+    return builtin::Memcpy<1>::block(dst, src);
+  if (count == 2)
+    return builtin::Memcpy<2>::block(dst, src);
+  if (count == 3)
+    return builtin::Memcpy<3>::block(dst, src);
+  if (count == 4)
+    return builtin::Memcpy<4>::block(dst, src);
+  if (count < 8)
+    return builtin::Memcpy<4>::head_tail(dst, src, count);
+  // If count is equal to a power of 2, we can handle it as head-tail
+  // of both smaller size and larger size (head-tail are either
+  // non-overlapping for smaller size, or completely collapsed
+  // for larger size). It seems to be more profitable to do the copy
+  // with the larger size, if it's natively supported (e.g. doing
+  // 2 collapsed 32-byte moves for count=64 if AVX2 is supported).
+  // But it's not profitable to use larger size if it's not natively
+  // supported: we will both use more instructions and handle fewer
+  // sizes in earlier branches.
+  if (VECTOR_SIZE >= 16 ? count < 16 : count <= 16)
+    return builtin::Memcpy<8>::head_tail(dst, src, count);
+  if (VECTOR_SIZE >= 32 ? count < 32 : count <= 32)
+    return builtin::Memcpy<16>::head_tail(dst, src, count);
+  if (VECTOR_SIZE >= 64 ? count < 64 : count <= 64)
+    return builtin::Memcpy<32>::head_tail(dst, src, count);
+  if constexpr (x86::K_AVX) {
+    if constexpr (x86::K_USE_SOFTWARE_PREFETCHING) {
+      return inline_memcpy_x86_avx_ge64_sw_prefetching(dst, src, count);
+    } else {
+      return inline_memcpy_x86_avx_ge64(dst, src, count);
+    }
+  } else {
+    if constexpr (x86::K_USE_SOFTWARE_PREFETCHING) {
+      return inline_memcpy_x86_sse2_ge64_sw_prefetching(dst, src, count);
+    } else {
+      return inline_memcpy_x86_sse2_ge64(dst, src, count);
+    }
+  }
+}
+
+[[maybe_unused]] LIBC_INLINE void
+inline_memcpy_x86_maybe_interpose_repmovsb(Ptr __restrict dst,
+                                           CPtr __restrict src, size_t count) {
+  if constexpr (x86::K_REP_MOVSB_THRESHOLD == 0) {
+    return x86::Memcpy::repmovsb(dst, src, count);
+  } else if constexpr (x86::K_REP_MOVSB_THRESHOLD == SIZE_MAX) {
+    return inline_memcpy_x86(dst, src, count);
+  } else {
+    if (LIBC_UNLIKELY(count >= x86::K_REP_MOVSB_THRESHOLD))
+      return x86::Memcpy::repmovsb(dst, src, count);
+    else
+      return inline_memcpy_x86(dst, src, count);
+  }
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMCPY_H

--- a/system/lib/llvm-libc/src/string/memory_utils/x86_64/inline_memmove.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/x86_64/inline_memmove.h
@@ -1,0 +1,120 @@
+//===-- Memmove implementation for x86_64 -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMMOVE_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMMOVE_H
+
+#include "src/__support/macros/attributes.h" // LIBC_INLINE
+#include "src/string/memory_utils/op_builtin.h"
+#include "src/string/memory_utils/op_generic.h"
+#include "src/string/memory_utils/op_x86.h"
+#include "src/string/memory_utils/utils.h"
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+LIBC_INLINE bool inline_memmove_small_size_x86(Ptr dst, CPtr src,
+                                               size_t count) {
+#if defined(__AVX512F__)
+  constexpr size_t vector_size = 64;
+  using uint128_t = generic_v128;
+  using uint256_t = generic_v256;
+  using uint512_t = generic_v512;
+#elif defined(__AVX__)
+  constexpr size_t vector_size = 32;
+  using uint128_t = generic_v128;
+  using uint256_t = generic_v256;
+  using uint512_t = cpp::array<generic_v256, 2>;
+#elif defined(__SSE2__)
+  constexpr size_t vector_size = 16;
+  using uint128_t = generic_v128;
+  using uint256_t = cpp::array<generic_v128, 2>;
+  using uint512_t = cpp::array<generic_v128, 4>;
+#else
+  constexpr size_t vector_size = 8;
+  using uint128_t = cpp::array<uint64_t, 2>;
+  using uint256_t = cpp::array<uint64_t, 4>;
+  using uint512_t = cpp::array<uint64_t, 8>;
+#endif
+  (void)vector_size;
+  if (count == 0)
+    return true;
+  if (count == 1) {
+    generic::Memmove<uint8_t>::block(dst, src);
+    return true;
+  }
+  if (count == 2) {
+    generic::Memmove<uint16_t>::block(dst, src);
+    return true;
+  }
+  if (count == 3) {
+    generic::Memmove<cpp::array<uint8_t, 3>>::block(dst, src);
+    return true;
+  }
+  if (count == 4) {
+    generic::Memmove<uint32_t>::block(dst, src);
+    return true;
+  }
+  if (count < 8) {
+    generic::Memmove<uint32_t>::head_tail(dst, src, count);
+    return true;
+  }
+  // If count is equal to a power of 2, we can handle it as head-tail
+  // of both smaller size and larger size (head-tail are either
+  // non-overlapping for smaller size, or completely collapsed
+  // for larger size). It seems to be more profitable to do the copy
+  // with the larger size, if it's natively supported (e.g. doing
+  // 2 collapsed 32-byte moves for count=64 if AVX2 is supported).
+  // But it's not profitable to use larger size if it's not natively
+  // supported: we will both use more instructions and handle fewer
+  // sizes in earlier branches.
+  if (vector_size >= 16 ? count < 16 : count <= 16) {
+    generic::Memmove<uint64_t>::head_tail(dst, src, count);
+    return true;
+  }
+  if (vector_size >= 32 ? count < 32 : count <= 32) {
+    generic::Memmove<uint128_t>::head_tail(dst, src, count);
+    return true;
+  }
+  if (vector_size >= 64 ? count < 64 : count <= 64) {
+    generic::Memmove<uint256_t>::head_tail(dst, src, count);
+    return true;
+  }
+  if (count <= 128) {
+    generic::Memmove<uint512_t>::head_tail(dst, src, count);
+    return true;
+  }
+  return false;
+}
+
+LIBC_INLINE void inline_memmove_follow_up_x86(Ptr dst, CPtr src, size_t count) {
+#if defined(__AVX512F__)
+  using uint256_t = generic_v256;
+  using uint512_t = generic_v512;
+#elif defined(__AVX__)
+  using uint256_t = generic_v256;
+  using uint512_t = cpp::array<generic_v256, 2>;
+#elif defined(__SSE2__)
+  using uint256_t = cpp::array<generic_v128, 2>;
+  using uint512_t = cpp::array<generic_v128, 4>;
+#else
+  using uint256_t = cpp::array<uint64_t, 4>;
+  using uint512_t = cpp::array<uint64_t, 8>;
+#endif
+  if (dst < src) {
+    generic::Memmove<uint256_t>::align_forward<Arg::Src>(dst, src, count);
+    return generic::Memmove<uint512_t>::loop_and_tail_forward(dst, src, count);
+  } else {
+    generic::Memmove<uint256_t>::align_backward<Arg::Src>(dst, src, count);
+    return generic::Memmove<uint512_t>::loop_and_tail_backward(dst, src, count);
+  }
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMMOVE_H

--- a/system/lib/llvm-libc/src/string/memory_utils/x86_64/inline_memset.h
+++ b/system/lib/llvm-libc/src/string/memory_utils/x86_64/inline_memset.h
@@ -1,0 +1,110 @@
+//===-- Memset implementation for x86_64 ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMSET_H
+#define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMSET_H
+
+#include "src/__support/macros/attributes.h" // LIBC_INLINE
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/op_generic.h"
+#include "src/string/memory_utils/op_x86.h"
+#include "src/string/memory_utils/utils.h" // Ptr, CPtr
+
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+namespace x86 {
+// Size of one cache line for software prefetching
+LIBC_INLINE_VAR constexpr size_t K_ONE_CACHELINE_SIZE = 64;
+LIBC_INLINE_VAR constexpr size_t K_TWO_CACHELINES_SIZE =
+    K_ONE_CACHELINE_SIZE * 2;
+LIBC_INLINE_VAR constexpr size_t K_FIVE_CACHELINES_SIZE =
+    K_ONE_CACHELINE_SIZE * 5;
+
+LIBC_INLINE_VAR constexpr bool K_USE_SOFTWARE_PREFETCHING_MEMSET =
+    LLVM_LIBC_IS_DEFINED(LIBC_COPT_MEMSET_X86_USE_SOFTWARE_PREFETCHING);
+
+} // namespace x86
+
+#if defined(__AVX512F__)
+using uint128_t = generic_v128;
+using uint256_t = generic_v256;
+using uint512_t = generic_v512;
+#elif defined(__AVX__)
+using uint128_t = generic_v128;
+using uint256_t = generic_v256;
+using uint512_t = cpp::array<generic_v256, 2>;
+#elif defined(__SSE2__)
+using uint128_t = generic_v128;
+using uint256_t = cpp::array<generic_v128, 2>;
+using uint512_t = cpp::array<generic_v128, 4>;
+#else
+using uint128_t = cpp::array<uint64_t, 2>;
+using uint256_t = cpp::array<uint64_t, 4>;
+using uint512_t = cpp::array<uint64_t, 8>;
+#endif
+
+[[maybe_unused]] LIBC_INLINE static void
+inline_memset_x86_gt64_sw_prefetching(Ptr dst, uint8_t value, size_t count) {
+  constexpr size_t PREFETCH_DISTANCE = x86::K_FIVE_CACHELINES_SIZE;
+  constexpr size_t PREFETCH_DEGREE = x86::K_TWO_CACHELINES_SIZE;
+  constexpr size_t SIZE = sizeof(uint256_t);
+  // Prefetch one cache line
+  prefetch_for_write(dst + x86::K_ONE_CACHELINE_SIZE);
+  if (count <= 128)
+    return generic::Memset<uint512_t>::head_tail(dst, value, count);
+  // Prefetch the second cache line
+  prefetch_for_write(dst + x86::K_TWO_CACHELINES_SIZE);
+  // Aligned loop
+  generic::Memset<uint256_t>::block(dst, value);
+  align_to_next_boundary<32>(dst, count);
+  if (count <= 192) {
+    return generic::Memset<uint256_t>::loop_and_tail(dst, value, count);
+  } else {
+    generic::MemsetSequence<uint512_t, uint256_t>::block(dst, value);
+    size_t offset = 96;
+    while (offset + PREFETCH_DEGREE + SIZE <= count) {
+      prefetch_for_write(dst + offset + PREFETCH_DISTANCE);
+      prefetch_for_write(dst + offset + PREFETCH_DISTANCE +
+                         x86::K_ONE_CACHELINE_SIZE);
+      for (size_t i = 0; i < PREFETCH_DEGREE; i += SIZE, offset += SIZE)
+        generic::Memset<uint256_t>::block(dst + offset, value);
+    }
+    generic::Memset<uint256_t>::loop_and_tail_offset(dst, value, count, offset);
+  }
+}
+
+[[maybe_unused]] LIBC_INLINE static void
+inline_memset_x86(Ptr dst, uint8_t value, size_t count) {
+  if (count == 0)
+    return;
+  if (count == 1)
+    return generic::Memset<uint8_t>::block(dst, value);
+  if (count == 2)
+    return generic::Memset<uint16_t>::block(dst, value);
+  if (count == 3)
+    return generic::MemsetSequence<uint16_t, uint8_t>::block(dst, value);
+  if (count <= 8)
+    return generic::Memset<uint32_t>::head_tail(dst, value, count);
+  if (count <= 16)
+    return generic::Memset<uint64_t>::head_tail(dst, value, count);
+  if (count <= 32)
+    return generic::Memset<uint128_t>::head_tail(dst, value, count);
+  if (count <= 64)
+    return generic::Memset<uint256_t>::head_tail(dst, value, count);
+  if constexpr (x86::K_USE_SOFTWARE_PREFETCHING_MEMSET)
+    return inline_memset_x86_gt64_sw_prefetching(dst, value, count);
+  if (count <= 128)
+    return generic::Memset<uint512_t>::head_tail(dst, value, count);
+  // Aligned loop
+  generic::Memset<uint256_t>::block(dst, value);
+  align_to_next_boundary<32>(dst, count);
+  return generic::Memset<uint256_t>::loop_and_tail(dst, value, count);
+}
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_X86_64_INLINE_MEMSET_H

--- a/system/lib/llvm-libc/src/string/mempcpy.cpp
+++ b/system/lib/llvm-libc/src/string/mempcpy.cpp
@@ -1,0 +1,25 @@
+//===-- Implementation of mempcpy ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/mempcpy.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memcpy.h"
+
+#include "src/__support/common.h"
+#include <stddef.h> // For size_t.
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void *, mempcpy,
+                   (void *__restrict dst, const void *__restrict src,
+                    size_t count)) {
+  inline_memcpy(dst, src, count);
+  return reinterpret_cast<char *>(dst) + count;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/mempcpy.h
+++ b/system/lib/llvm-libc/src/string/mempcpy.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for mempcpy -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMPCPY_H
+#define LLVM_LIBC_SRC_STRING_MEMPCPY_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+void *mempcpy(void *__restrict dest, const void *__restrict src, size_t count);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMPCPY_H

--- a/system/lib/llvm-libc/src/string/memrchr.cpp
+++ b/system/lib/llvm-libc/src/string/memrchr.cpp
@@ -1,0 +1,27 @@
+//===-- Implementation of memrchr -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/memrchr.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void *, memrchr, (const void *src, int c, size_t n)) {
+  const unsigned char *str = reinterpret_cast<const unsigned char *>(src);
+  const unsigned char ch = static_cast<unsigned char>(c);
+  for (; n != 0; --n) {
+    const unsigned char *s = str + n - 1;
+    if (*s == ch)
+      return const_cast<unsigned char *>(s);
+  }
+  return nullptr;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/memrchr.h
+++ b/system/lib/llvm-libc/src/string/memrchr.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for memrchr -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMRCHR_H
+#define LLVM_LIBC_SRC_STRING_MEMRCHR_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+void *memrchr(const void *src, int c, size_t n);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMRCHR_H

--- a/system/lib/llvm-libc/src/string/memset.cpp
+++ b/system/lib/llvm-libc/src/string/memset.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of memset ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/memset.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memset.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void *, memset, (void *dst, int value, size_t count)) {
+  inline_memset(dst, static_cast<uint8_t>(value), count);
+  return dst;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/memset.h
+++ b/system/lib/llvm-libc/src/string/memset.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for memset ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMSET_H
+#define LLVM_LIBC_SRC_STRING_MEMSET_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+void *memset(void *ptr, int value, size_t count);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMSET_H

--- a/system/lib/llvm-libc/src/string/memset_explicit.cpp
+++ b/system/lib/llvm-libc/src/string/memset_explicit.cpp
@@ -1,0 +1,26 @@
+//===-- Implementation of memset_explicit ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/memset_explicit.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memset.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[gnu::noinline]] LLVM_LIBC_FUNCTION(void *, memset_explicit,
+                                     (void *dst, int value, size_t count)) {
+  // Use the inline memset function to set the memory.
+  inline_memset(dst, static_cast<uint8_t>(value), count);
+  // avoid dead store elimination
+  // The asm itself should also be sufficient to behave as a compiler barrier.
+  asm("" : : "r"(dst) : "memory");
+  return dst;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/memset_explicit.h
+++ b/system/lib/llvm-libc/src/string/memset_explicit.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for memset_explicit ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_MEMSET_EXPLICIT_H
+#define LLVM_LIBC_SRC_STRING_MEMSET_EXPLICIT_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[gnu::noinline]] void *memset_explicit(void *ptr, int value, size_t count);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_MEMSET_EXPLICIT_H

--- a/system/lib/llvm-libc/src/string/stpcpy.cpp
+++ b/system/lib/llvm-libc/src/string/stpcpy.cpp
@@ -1,0 +1,29 @@
+//===-- Implementation of stpcpy ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/stpcpy.h"
+#include "src/__support/macros/config.h"
+#include "src/string/mempcpy.h"
+#include "src/string/string_utils.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, stpcpy,
+                   (char *__restrict dest, const char *__restrict src)) {
+  size_t size = internal::string_length(src) + 1;
+  char *result =
+      reinterpret_cast<char *>(LIBC_NAMESPACE::mempcpy(dest, src, size));
+
+  if (result != nullptr)
+    return result - 1;
+  return nullptr;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/stpcpy.h
+++ b/system/lib/llvm-libc/src/string/stpcpy.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for stpcpy ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STPCPY_H
+#define LLVM_LIBC_SRC_STRING_STPCPY_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *stpcpy(char *__restrict dest, const char *__restrict src);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STPCPY_H

--- a/system/lib/llvm-libc/src/string/stpncpy.cpp
+++ b/system/lib/llvm-libc/src/string/stpncpy.cpp
@@ -1,0 +1,30 @@
+//===-- Implementation of stpncpy -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/stpncpy.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_bzero.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, stpncpy,
+                   (char *__restrict dest, const char *__restrict src,
+                    size_t n)) {
+  size_t i;
+  // Copy up until \0 is found.
+  for (i = 0; i < n && src[i] != '\0'; ++i)
+    dest[i] = src[i];
+  // When n>strlen(src), n-strlen(src) \0 are appended.
+  if (n > i)
+    inline_bzero(dest + i, n - i);
+  return dest + i;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/stpncpy.h
+++ b/system/lib/llvm-libc/src/string/stpncpy.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for stpncpy -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STPNCPY_H
+#define LLVM_LIBC_SRC_STRING_STPNCPY_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *stpncpy(char *__restrict dest, const char *__restrict src, size_t n);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STPNCPY_H

--- a/system/lib/llvm-libc/src/string/strcasestr.cpp
+++ b/system/lib/llvm-libc/src/string/strcasestr.cpp
@@ -1,0 +1,29 @@
+//===-- Implementation of strcasestr --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strcasestr.h"
+
+#include "src/__support/common.h"
+#include "src/__support/ctype_utils.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_strstr.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO: This is a simple brute force implementation. This can be
+// improved upon using well known string matching algorithms.
+LLVM_LIBC_FUNCTION(char *, strcasestr,
+                   (const char *haystack, const char *needle)) {
+  auto case_cmp = [](char a, char b) {
+    return LIBC_NAMESPACE::internal::tolower(a) -
+           LIBC_NAMESPACE::internal::tolower(b);
+  };
+  return inline_strstr(haystack, needle, case_cmp);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strcasestr.h
+++ b/system/lib/llvm-libc/src/string/strcasestr.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for strcasestr --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRCASESTR_H
+#define LLVM_LIBC_SRC_STRING_STRCASESTR_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strcasestr(const char *needle, const char *haystack);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRCASESTR_H

--- a/system/lib/llvm-libc/src/string/strcat.cpp
+++ b/system/lib/llvm-libc/src/string/strcat.cpp
@@ -1,0 +1,27 @@
+//===-- Implementation of strcat ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strcat.h"
+#include "src/__support/macros/config.h"
+#include "src/string/strcpy.h"
+#include "src/string/string_utils.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strcat,
+                   (char *__restrict dest, const char *__restrict src)) {
+  size_t dest_length = internal::string_length(dest);
+  size_t src_length = internal::string_length(src);
+  LIBC_NAMESPACE::strcpy(dest + dest_length, src);
+  dest[dest_length + src_length] = '\0';
+  return dest;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strcat.h
+++ b/system/lib/llvm-libc/src/string/strcat.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strcat ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRCAT_H
+#define LLVM_LIBC_SRC_STRING_STRCAT_H
+
+#include "include/llvm-libc-types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strcat(char *__restrict dest, const char *__restrict src);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRCAT_H

--- a/system/lib/llvm-libc/src/string/strchr.cpp
+++ b/system/lib/llvm-libc/src/string/strchr.cpp
@@ -1,0 +1,22 @@
+//===-- Implementation of strchr ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strchr.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO: Look at performance benefits of comparing words.
+LLVM_LIBC_FUNCTION(char *, strchr, (const char *src, int c)) {
+  return internal::strchr_implementation(src, c);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strchr.h
+++ b/system/lib/llvm-libc/src/string/strchr.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for strchr ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRCHR_H
+#define LLVM_LIBC_SRC_STRING_STRCHR_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strchr(const char *src, int c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRCHR_H

--- a/system/lib/llvm-libc/src/string/strchrnul.cpp
+++ b/system/lib/llvm-libc/src/string/strchrnul.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of strchrnul --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strchrnul.h"
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strchrnul, (const char *src, int c)) {
+  return internal::strchr_implementation<false>(src, c);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strchrnul.h
+++ b/system/lib/llvm-libc/src/string/strchrnul.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for strchrnul --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRCHRNUL_H
+#define LLVM_LIBC_SRC_STRING_STRCHRNUL_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strchrnul(const char *src, int c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRCHRNUL_H

--- a/system/lib/llvm-libc/src/string/strcmp.cpp
+++ b/system/lib/llvm-libc/src/string/strcmp.cpp
@@ -1,0 +1,22 @@
+//===-- Implementation of strcmp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strcmp.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_strcmp.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, strcmp, (const char *left, const char *right)) {
+  auto comp = [](char l, char r) -> int { return l - r; };
+  return inline_strcmp(left, right, comp);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strcmp.h
+++ b/system/lib/llvm-libc/src/string/strcmp.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for strcmp ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRCMP_H
+#define LLVM_LIBC_SRC_STRING_STRCMP_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int strcmp(const char *left, const char *right);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRCMP_H

--- a/system/lib/llvm-libc/src/string/strcoll.cpp
+++ b/system/lib/llvm-libc/src/string/strcoll.cpp
@@ -1,0 +1,23 @@
+//===-- Implementation of strcoll -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strcoll.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO: Add support for locales.
+LLVM_LIBC_FUNCTION(int, strcoll, (const char *left, const char *right)) {
+  for (; *left && *left == *right; ++left, ++right)
+    ;
+  return static_cast<int>(*left) - static_cast<int>(*right);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strcoll.h
+++ b/system/lib/llvm-libc/src/string/strcoll.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for strcoll -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRCOLL_H
+#define LLVM_LIBC_SRC_STRING_STRCOLL_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int strcoll(const char *left, const char *right);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRCOLL_H

--- a/system/lib/llvm-libc/src/string/strcoll_l.cpp
+++ b/system/lib/llvm-libc/src/string/strcoll_l.cpp
@@ -1,0 +1,24 @@
+//===-- Implementation of strcoll_l ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strcoll_l.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO: Add support for locales.
+LLVM_LIBC_FUNCTION(int, strcoll_l,
+                   (const char *left, const char *right, locale_t)) {
+  for (; *left && *left == *right; ++left, ++right)
+    ;
+  return static_cast<int>(*left) - static_cast<int>(*right);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strcoll_l.h
+++ b/system/lib/llvm-libc/src/string/strcoll_l.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strcoll_l ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRCOLL_L_H
+#define LLVM_LIBC_SRC_STRING_STRCOLL_L_H
+
+#include "include/llvm-libc-types/locale_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int strcoll_l(const char *left, const char *right, locale_t locale);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRCOLL_L_H

--- a/system/lib/llvm-libc/src/string/strcpy.cpp
+++ b/system/lib/llvm-libc/src/string/strcpy.cpp
@@ -1,0 +1,25 @@
+//===-- Implementation of strcpy ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strcpy.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memcpy.h"
+#include "src/string/string_utils.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strcpy,
+                   (char *__restrict dest, const char *__restrict src)) {
+  size_t size = internal::string_length(src) + 1;
+  inline_memcpy(dest, src, size);
+  return dest;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strcpy.h
+++ b/system/lib/llvm-libc/src/string/strcpy.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strcpy ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRCPY_H
+#define LLVM_LIBC_SRC_STRING_STRCPY_H
+
+#include "include/llvm-libc-types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strcpy(char *__restrict dest, const char *__restrict src);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRCPY_H

--- a/system/lib/llvm-libc/src/string/strcspn.cpp
+++ b/system/lib/llvm-libc/src/string/strcspn.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of strcspn -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strcspn.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(size_t, strcspn, (const char *src, const char *segment)) {
+  return internal::complementary_span(src, segment);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strcspn.h
+++ b/system/lib/llvm-libc/src/string/strcspn.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strcspn -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRCSPN_H
+#define LLVM_LIBC_SRC_STRING_STRCSPN_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t strcspn(const char *src, const char *segment);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRCSPN_H

--- a/system/lib/llvm-libc/src/string/strdup.cpp
+++ b/system/lib/llvm-libc/src/string/strdup.cpp
@@ -1,0 +1,29 @@
+//===-- Implementation of strdup ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strdup.h"
+#include "hdr/stdlib_macros.h"
+#include "src/__support/macros/config.h"
+#include "src/errno/libc_errno.h"
+#include "src/string/allocating_string_utils.h"
+#include "src/string/memory_utils/inline_memcpy.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strdup, (const char *src)) {
+  auto dup = internal::strdup(src);
+  if (dup)
+    return *dup;
+  if (src != nullptr)
+    libc_errno = ENOMEM;
+  return nullptr;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strdup.h
+++ b/system/lib/llvm-libc/src/string/strdup.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strdup ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRDUP_H
+#define LLVM_LIBC_SRC_STRING_STRDUP_H
+
+#include "include/llvm-libc-types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strdup(const char *src);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRDUP_H

--- a/system/lib/llvm-libc/src/string/strerror.cpp
+++ b/system/lib/llvm-libc/src/string/strerror.cpp
@@ -1,0 +1,20 @@
+//===-- Implementation of strerror ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strerror.h"
+#include "src/__support/StringUtil/error_to_string.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strerror, (int err_num)) {
+  return const_cast<char *>(get_error_string(err_num).data());
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strerror.h
+++ b/system/lib/llvm-libc/src/string/strerror.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for strerror ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRERROR_H
+#define LLVM_LIBC_SRC_STRING_STRERROR_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strerror(int err_num);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRERROR_H

--- a/system/lib/llvm-libc/src/string/strerror_r.cpp
+++ b/system/lib/llvm-libc/src/string/strerror_r.cpp
@@ -1,0 +1,24 @@
+//===-- Implementation of strerror_r --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strerror_r.h"
+#include "src/__support/StringUtil/error_to_string.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+// This is the gnu version of strerror_r. The XSI version may be added later.
+LLVM_LIBC_FUNCTION(char *, strerror_r,
+                   (int err_num, char *buf, size_t buflen)) {
+  return const_cast<char *>(get_error_string(err_num, {buf, buflen}).data());
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strerror_r.h
+++ b/system/lib/llvm-libc/src/string/strerror_r.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strerror_r --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRERROR_R_H
+#define LLVM_LIBC_SRC_STRING_STRERROR_R_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strerror_r(int err_num, char *buf, size_t buflen);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRERROR_R_H

--- a/system/lib/llvm-libc/src/string/string_utils.h
+++ b/system/lib/llvm-libc/src/string/string_utils.h
@@ -1,0 +1,252 @@
+//===-- String utils --------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Standalone string utility functions. Utilities requiring memory allocations
+// should be placed in allocating_string_utils.h instead.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRING_UTILS_H
+#define LLVM_LIBC_SRC_STRING_STRING_UTILS_H
+
+#include "hdr/types/size_t.h"
+#include "src/__support/CPP/bitset.h"
+#include "src/__support/CPP/type_traits.h" // cpp::is_same_v
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+#include "src/string/memory_utils/inline_bzero.h"
+#include "src/string/memory_utils/inline_memcpy.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace internal {
+
+template <typename Word> LIBC_INLINE constexpr Word repeat_byte(Word byte) {
+  constexpr size_t BITS_IN_BYTE = 8;
+  constexpr size_t BYTE_MASK = 0xff;
+  Word result = 0;
+  byte = byte & BYTE_MASK;
+  for (size_t i = 0; i < sizeof(Word); ++i)
+    result = (result << BITS_IN_BYTE) | byte;
+  return result;
+}
+
+// The goal of this function is to take in a block of arbitrary size and return
+// if it has any bytes equal to zero without branching. This is done by
+// transforming the block such that zero bytes become non-zero and non-zero
+// bytes become zero.
+// The first transformation relies on the properties of carrying in arithmetic
+// subtraction. Specifically, if 0x01 is subtracted from a byte that is 0x00,
+// then the result for that byte must be equal to 0xff (or 0xfe if the next byte
+// needs a carry as well).
+// The next transformation is a simple mask. All zero bytes will have the high
+// bit set after the subtraction, so each byte is masked with 0x80. This narrows
+// the set of bytes that result in a non-zero value to only zero bytes and bytes
+// with the high bit and any other bit set.
+// The final transformation masks the result of the previous transformations
+// with the inverse of the original byte. This means that any byte that had the
+// high bit set will no longer have it set, narrowing the list of bytes which
+// result in non-zero values to just the zero byte.
+template <typename Word> LIBC_INLINE constexpr bool has_zeroes(Word block) {
+  constexpr Word LOW_BITS = repeat_byte<Word>(0x01);
+  constexpr Word HIGH_BITS = repeat_byte<Word>(0x80);
+  Word subtracted = block - LOW_BITS;
+  Word inverted = ~block;
+  return (subtracted & inverted & HIGH_BITS) != 0;
+}
+
+template <typename Word>
+LIBC_INLINE size_t string_length_wide_read(const char *src) {
+  const char *char_ptr = src;
+  // Step 1: read 1 byte at a time to align to block size
+  for (; reinterpret_cast<uintptr_t>(char_ptr) % sizeof(Word) != 0;
+       ++char_ptr) {
+    if (*char_ptr == '\0')
+      return char_ptr - src;
+  }
+  // Step 2: read blocks
+  for (const Word *block_ptr = reinterpret_cast<const Word *>(char_ptr);
+       !has_zeroes<Word>(*block_ptr); ++block_ptr) {
+    char_ptr = reinterpret_cast<const char *>(block_ptr);
+  }
+  // Step 3: find the zero in the block
+  for (; *char_ptr != '\0'; ++char_ptr) {
+    ;
+  }
+  return char_ptr - src;
+}
+
+// Returns the length of a string, denoted by the first occurrence
+// of a null terminator.
+template <typename T> LIBC_INLINE size_t string_length(const T *src) {
+#ifdef LIBC_COPT_STRING_UNSAFE_WIDE_READ
+  // Unsigned int is the default size for most processors, and on x86-64 it
+  // performs better than larger sizes when the src pointer can't be assumed to
+  // be aligned to a word boundary, so it's the size we use for reading the
+  // string a block at a time.
+  if constexpr (cpp::is_same_v<T, char>)
+    return string_length_wide_read<unsigned int>(src);
+#else
+  size_t length;
+  for (length = 0; *src; ++src, ++length)
+    ;
+  return length;
+#endif
+}
+
+template <typename Word>
+LIBC_INLINE void *find_first_character_wide_read(const unsigned char *src,
+                                                 unsigned char ch, size_t n) {
+  const unsigned char *char_ptr = src;
+  size_t cur = 0;
+
+  // Step 1: read 1 byte at a time to align to block size
+  for (; reinterpret_cast<uintptr_t>(char_ptr) % sizeof(Word) != 0 && cur < n;
+       ++char_ptr, ++cur) {
+    if (*char_ptr == ch)
+      return const_cast<unsigned char *>(char_ptr);
+  }
+
+  const Word ch_mask = repeat_byte<Word>(ch);
+
+  // Step 2: read blocks
+  for (const Word *block_ptr = reinterpret_cast<const Word *>(char_ptr);
+       !has_zeroes<Word>((*block_ptr) ^ ch_mask) && cur < n;
+       ++block_ptr, cur += sizeof(Word)) {
+    char_ptr = reinterpret_cast<const unsigned char *>(block_ptr);
+  }
+
+  // Step 3: find the match in the block
+  for (; *char_ptr != ch && cur < n; ++char_ptr, ++cur) {
+    ;
+  }
+
+  if (*char_ptr != ch || cur >= n)
+    return static_cast<void *>(nullptr);
+
+  return const_cast<unsigned char *>(char_ptr);
+}
+
+LIBC_INLINE void *find_first_character_byte_read(const unsigned char *src,
+                                                 unsigned char ch, size_t n) {
+  for (; n && *src != ch; --n, ++src)
+    ;
+  return n ? const_cast<unsigned char *>(src) : nullptr;
+}
+
+// Returns the first occurrence of 'ch' within the first 'n' characters of
+// 'src'. If 'ch' is not found, returns nullptr.
+LIBC_INLINE void *find_first_character(const unsigned char *src,
+                                       unsigned char ch, size_t max_strlen) {
+#ifdef LIBC_COPT_STRING_UNSAFE_WIDE_READ
+  // If the maximum size of the string is small, the overhead of aligning to a
+  // word boundary and generating a bitmask of the appropriate size may be
+  // greater than the gains from reading larger chunks. Based on some testing,
+  // the crossover point between when it's faster to just read bytewise and read
+  // blocks is somewhere between 16 and 32, so 4 times the size of the block
+  // should be in that range.
+  // Unsigned int is used for the same reason as in strlen.
+  using BlockType = unsigned int;
+  if (max_strlen > (sizeof(BlockType) * 4)) {
+    return find_first_character_wide_read<BlockType>(src, ch, max_strlen);
+  }
+#endif
+  return find_first_character_byte_read(src, ch, max_strlen);
+}
+
+// Returns the maximum length span that contains only characters not found in
+// 'segment'. If no characters are found, returns the length of 'src'.
+LIBC_INLINE size_t complementary_span(const char *src, const char *segment) {
+  const char *initial = src;
+  cpp::bitset<256> bitset;
+
+  for (; *segment; ++segment)
+    bitset.set(*reinterpret_cast<const unsigned char *>(segment));
+  for (; *src && !bitset.test(*reinterpret_cast<const unsigned char *>(src));
+       ++src)
+    ;
+  return src - initial;
+}
+
+// Given the similarities between strtok and strtok_r, we can implement both
+// using a utility function. On the first call, 'src' is scanned for the
+// first character not found in 'delimiter_string'. Once found, it scans until
+// the first character in the 'delimiter_string' or the null terminator is
+// found. We define this span as a token. The end of the token is appended with
+// a null terminator, and the token is returned. The point where the last token
+// is found is then stored within 'context' for subsequent calls. Subsequent
+// calls will use 'context' when a nullptr is passed in for 'src'. Once the null
+// terminating character is reached, returns a nullptr.
+template <bool SkipDelim = true>
+LIBC_INLINE char *string_token(char *__restrict src,
+                               const char *__restrict delimiter_string,
+                               char **__restrict saveptr) {
+  // Return nullptr immediately if both src AND saveptr are nullptr
+  if (LIBC_UNLIKELY(src == nullptr && ((src = *saveptr) == nullptr)))
+    return nullptr;
+
+  cpp::bitset<256> delimiter_set;
+  for (; *delimiter_string != '\0'; ++delimiter_string)
+    delimiter_set.set(*delimiter_string);
+
+  if constexpr (SkipDelim)
+    for (; *src != '\0' && delimiter_set.test(*src); ++src)
+      ;
+  if (*src == '\0') {
+    *saveptr = src;
+    return nullptr;
+  }
+  char *token = src;
+  for (; *src != '\0'; ++src) {
+    if (delimiter_set.test(*src)) {
+      *src = '\0';
+      ++src;
+      break;
+    }
+  }
+  *saveptr = src;
+  return token;
+}
+
+LIBC_INLINE size_t strlcpy(char *__restrict dst, const char *__restrict src,
+                           size_t size) {
+  size_t len = internal::string_length(src);
+  if (!size)
+    return len;
+  size_t n = len < size - 1 ? len : size - 1;
+  inline_memcpy(dst, src, n);
+  dst[n] = '\0';
+  return len;
+}
+
+template <bool ReturnNull = true>
+LIBC_INLINE constexpr static char *strchr_implementation(const char *src,
+                                                         int c) {
+  char ch = static_cast<char>(c);
+  for (; *src && *src != ch; ++src)
+    ;
+  char *ret = ReturnNull ? nullptr : const_cast<char *>(src);
+  return *src == ch ? const_cast<char *>(src) : ret;
+}
+
+LIBC_INLINE constexpr static char *strrchr_implementation(const char *src,
+                                                          int c) {
+  char ch = static_cast<char>(c);
+  char *last_occurrence = nullptr;
+  while (true) {
+    if (*src == ch)
+      last_occurrence = const_cast<char *>(src);
+    if (!*src)
+      return last_occurrence;
+    ++src;
+  }
+}
+
+} // namespace internal
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif //  LLVM_LIBC_SRC_STRING_STRING_UTILS_H

--- a/system/lib/llvm-libc/src/string/strlcat.cpp
+++ b/system/lib/llvm-libc/src/string/strlcat.cpp
@@ -1,0 +1,28 @@
+//===-- Implementation of strlcat -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strlcat.h"
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(size_t, strlcat,
+                   (char *__restrict dst, const char *__restrict src,
+                    size_t size)) {
+  char *new_dst = reinterpret_cast<char *>(internal::find_first_character(
+      reinterpret_cast<unsigned char *>(dst), 0, size));
+  if (!new_dst)
+    return size + internal::string_length(src);
+  size_t first_len = new_dst - dst;
+  return first_len + internal::strlcpy(new_dst, src, size - first_len);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strlcat.h
+++ b/system/lib/llvm-libc/src/string/strlcat.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strlcat -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRLCAT_H
+#define LLVM_LIBC_SRC_STRING_STRLCAT_H
+
+#include "include/llvm-libc-types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t strlcat(char *__restrict dst, const char *__restrict src, size_t size);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRLCAT_H

--- a/system/lib/llvm-libc/src/string/strlcpy.cpp
+++ b/system/lib/llvm-libc/src/string/strlcpy.cpp
@@ -1,0 +1,23 @@
+//===-- Implementation of strlcpy -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strlcpy.h"
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(size_t, strlcpy,
+                   (char *__restrict dst, const char *__restrict src,
+                    size_t size)) {
+  return internal::strlcpy(dst, src, size);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strlcpy.h
+++ b/system/lib/llvm-libc/src/string/strlcpy.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strlcpy -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRLCPY_H
+#define LLVM_LIBC_SRC_STRING_STRLCPY_H
+
+#include "include/llvm-libc-types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t strlcpy(char *__restrict dst, const char *__restrict src, size_t size);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRLCPY_H

--- a/system/lib/llvm-libc/src/string/strlen.cpp
+++ b/system/lib/llvm-libc/src/string/strlen.cpp
@@ -1,0 +1,23 @@
+//===-- Implementation of strlen ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strlen.h"
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO: investigate the performance of this function.
+// There might be potential for compiler optimization.
+LLVM_LIBC_FUNCTION(size_t, strlen, (const char *src)) {
+  return internal::string_length(src);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strlen.h
+++ b/system/lib/llvm-libc/src/string/strlen.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strlen ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRLEN_H
+#define LLVM_LIBC_SRC_STRING_STRLEN_H
+
+#include "include/llvm-libc-types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t strlen(const char *src);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRLEN_H

--- a/system/lib/llvm-libc/src/string/strncat.cpp
+++ b/system/lib/llvm-libc/src/string/strncat.cpp
@@ -1,0 +1,29 @@
+//===-- Implementation of strncat -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strncat.h"
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+#include "src/string/strncpy.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strncat,
+                   (char *__restrict dest, const char *__restrict src,
+                    size_t count)) {
+  size_t src_length = internal::string_length(src);
+  size_t copy_amount = src_length > count ? count : src_length;
+  size_t dest_length = internal::string_length(dest);
+  LIBC_NAMESPACE::strncpy(dest + dest_length, src, copy_amount);
+  dest[dest_length + copy_amount] = '\0';
+  return dest;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strncat.h
+++ b/system/lib/llvm-libc/src/string/strncat.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strncat -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRNCAT_H
+#define LLVM_LIBC_SRC_STRING_STRNCAT_H
+
+#include "include/llvm-libc-types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strncat(char *__restrict dest, const char *__restrict src, size_t count);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRNCAT_H

--- a/system/lib/llvm-libc/src/string/strncmp.cpp
+++ b/system/lib/llvm-libc/src/string/strncmp.cpp
@@ -1,0 +1,25 @@
+//===-- Implementation of strncmp -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strncmp.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_strcmp.h"
+
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, strncmp,
+                   (const char *left, const char *right, size_t n)) {
+  auto comp = [](char l, char r) -> int { return l - r; };
+  return inline_strncmp(left, right, n, comp);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strncmp.h
+++ b/system/lib/llvm-libc/src/string/strncmp.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strncmp -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRNCMP_H
+#define LLVM_LIBC_SRC_STRING_STRNCMP_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+int strncmp(const char *left, const char *right, size_t n);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRNCMP_H

--- a/system/lib/llvm-libc/src/string/strncpy.cpp
+++ b/system/lib/llvm-libc/src/string/strncpy.cpp
@@ -1,0 +1,30 @@
+//===-- Implementation of strncpy -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strncpy.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include <stddef.h> // For size_t.
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strncpy,
+                   (char *__restrict dest, const char *__restrict src,
+                    size_t n)) {
+  size_t i = 0;
+  // Copy up until \0 is found.
+  for (; i < n && src[i] != '\0'; ++i)
+    dest[i] = src[i];
+  // When n>strlen(src), n-strlen(src) \0 are appended.
+  for (; i < n; ++i)
+    dest[i] = '\0';
+  return dest;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strncpy.h
+++ b/system/lib/llvm-libc/src/string/strncpy.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strncpy -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRNCPY_H
+#define LLVM_LIBC_SRC_STRING_STRNCPY_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strncpy(char *__restrict dest, const char *__restrict src, size_t n);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRNCPY_H

--- a/system/lib/llvm-libc/src/string/strndup.cpp
+++ b/system/lib/llvm-libc/src/string/strndup.cpp
@@ -1,0 +1,36 @@
+//===-- Implementation of strndup -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strndup.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memcpy.h"
+#include "src/string/string_utils.h"
+
+#include "src/__support/CPP/new.h"
+#include "src/__support/common.h"
+
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strndup, (const char *src, size_t size)) {
+  if (src == nullptr)
+    return nullptr;
+  size_t len = internal::string_length(src);
+  if (len > size)
+    len = size;
+  AllocChecker ac;
+  char *dest = new (ac) char[len + 1];
+  if (!ac)
+    return nullptr;
+  inline_memcpy(dest, src, len + 1);
+  dest[len] = '\0';
+  return dest;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strndup.h
+++ b/system/lib/llvm-libc/src/string/strndup.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strndup -----------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRNDUP_H
+#define LLVM_LIBC_SRC_STRING_STRNDUP_H
+
+#include "include/llvm-libc-types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strndup(const char *src, size_t size);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRNDUP_H

--- a/system/lib/llvm-libc/src/string/strnlen.cpp
+++ b/system/lib/llvm-libc/src/string/strnlen.cpp
@@ -1,0 +1,24 @@
+//===-- Implementation of strnlen------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strnlen.h"
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+
+#include "src/__support/common.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(size_t, strnlen, (const char *src, size_t n)) {
+  const void *temp = internal::find_first_character(
+      reinterpret_cast<const unsigned char *>(src), '\0', n);
+  return temp ? reinterpret_cast<const char *>(temp) - src : n;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strnlen.h
+++ b/system/lib/llvm-libc/src/string/strnlen.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strnlen ------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRNLEN_H
+#define LLVM_LIBC_SRC_STRING_STRNLEN_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t strnlen(const char *src, size_t n);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRNLEN_H

--- a/system/lib/llvm-libc/src/string/strpbrk.cpp
+++ b/system/lib/llvm-libc/src/string/strpbrk.cpp
@@ -1,0 +1,22 @@
+//===-- Implementation of strpbrk -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strpbrk.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strpbrk, (const char *src, const char *breakset)) {
+  src += internal::complementary_span(src, breakset);
+  return *src ? const_cast<char *>(src) : nullptr;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strpbrk.h
+++ b/system/lib/llvm-libc/src/string/strpbrk.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for strpbrk -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRPBRK_H
+#define LLVM_LIBC_SRC_STRING_STRPBRK_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strpbrk(const char *src, const char *breakset);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRPBRK_H

--- a/system/lib/llvm-libc/src/string/strrchr.cpp
+++ b/system/lib/llvm-libc/src/string/strrchr.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of strrchr------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strrchr.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strrchr, (const char *src, int c)) {
+  return internal::strrchr_implementation(src, c);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strrchr.h
+++ b/system/lib/llvm-libc/src/string/strrchr.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for strrchr -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRRCHR_H
+#define LLVM_LIBC_SRC_STRING_STRRCHR_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strrchr(const char *src, int c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRRCHR_H

--- a/system/lib/llvm-libc/src/string/strsep.cpp
+++ b/system/lib/llvm-libc/src/string/strsep.cpp
@@ -1,0 +1,23 @@
+//===-- Implementation of strsep ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strsep.h"
+
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strsep,
+                   (char **__restrict stringp, const char *__restrict delim)) {
+  if (!*stringp)
+    return nullptr;
+  return internal::string_token<false>(*stringp, delim, stringp);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strsep.h
+++ b/system/lib/llvm-libc/src/string/strsep.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for strsep ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRSEP_H
+#define LLVM_LIBC_SRC_STRING_STRSEP_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strsep(char **__restrict stringp, const char *__restrict delim);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRSEP_H

--- a/system/lib/llvm-libc/src/string/strsignal.cpp
+++ b/system/lib/llvm-libc/src/string/strsignal.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of strsignal
+//----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strsignal.h"
+#include "src/__support/StringUtil/signal_to_string.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strsignal, (int sig_num)) {
+  return const_cast<char *>(get_signal_string(sig_num).data());
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strsignal.h
+++ b/system/lib/llvm-libc/src/string/strsignal.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strsignal ----------------------*- C++
+//-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRSIGNAL_H
+#define LLVM_LIBC_SRC_STRING_STRSIGNAL_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strsignal(int sig_num);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRSIGNAL_H

--- a/system/lib/llvm-libc/src/string/strspn.cpp
+++ b/system/lib/llvm-libc/src/string/strspn.cpp
@@ -1,0 +1,30 @@
+//===-- Implementation of strspn ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strspn.h"
+
+#include "src/__support/CPP/bitset.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(size_t, strspn, (const char *src, const char *segment)) {
+  const char *initial = src;
+  cpp::bitset<256> bitset;
+
+  for (; *segment; ++segment)
+    bitset.set(*reinterpret_cast<const unsigned char *>(segment));
+  for (; *src && bitset.test(*reinterpret_cast<const unsigned char *>(src));
+       ++src)
+    ;
+  return src - initial;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strspn.h
+++ b/system/lib/llvm-libc/src/string/strspn.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strspn ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRSPN_H
+#define LLVM_LIBC_SRC_STRING_STRSPN_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t strspn(const char *src, const char *segment);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRSPN_H

--- a/system/lib/llvm-libc/src/string/strstr.cpp
+++ b/system/lib/llvm-libc/src/string/strstr.cpp
@@ -1,0 +1,24 @@
+//===-- Implementation of strstr ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strstr.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_strstr.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO: This is a simple brute force implementation. This can be
+// improved upon using well known string matching algorithms.
+LLVM_LIBC_FUNCTION(char *, strstr, (const char *haystack, const char *needle)) {
+  auto comp = [](char l, char r) -> int { return l - r; };
+  return inline_strstr(haystack, needle, comp);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strstr.h
+++ b/system/lib/llvm-libc/src/string/strstr.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for strstr ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRSTR_H
+#define LLVM_LIBC_SRC_STRING_STRSTR_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strstr(const char *haystack, const char *needle);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRSTR_H

--- a/system/lib/llvm-libc/src/string/strtok.cpp
+++ b/system/lib/llvm-libc/src/string/strtok.cpp
@@ -1,0 +1,25 @@
+//===-- Implementation of strtok ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strtok.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+static char *strtok_str = nullptr;
+
+LLVM_LIBC_FUNCTION(char *, strtok,
+                   (char *__restrict src,
+                    const char *__restrict delimiter_string)) {
+  return internal::string_token(src, delimiter_string, &strtok_str);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strtok.h
+++ b/system/lib/llvm-libc/src/string/strtok.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for strtok ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRTOK_H
+#define LLVM_LIBC_SRC_STRING_STRTOK_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strtok(char *__restrict src, const char *__restrict delimiter_string);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRTOK_H

--- a/system/lib/llvm-libc/src/string/strtok_r.cpp
+++ b/system/lib/llvm-libc/src/string/strtok_r.cpp
@@ -1,0 +1,24 @@
+//===-- Implementation of strtok_r ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strtok_r.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/string/string_utils.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(char *, strtok_r,
+                   (char *__restrict src,
+                    const char *__restrict delimiter_string,
+                    char **__restrict saveptr)) {
+  return internal::string_token(src, delimiter_string, saveptr);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strtok_r.h
+++ b/system/lib/llvm-libc/src/string/strtok_r.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for strtok_r ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRTOK_R_H
+#define LLVM_LIBC_SRC_STRING_STRTOK_R_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+char *strtok_r(char *__restrict src, const char *__restrict delimiter_string,
+               char **__restrict saveptr);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRTOK_R_H

--- a/system/lib/llvm-libc/src/string/strxfrm.cpp
+++ b/system/lib/llvm-libc/src/string/strxfrm.cpp
@@ -1,0 +1,28 @@
+//===-- Implementation of strxfrm -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strxfrm.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memcpy.h"
+#include "src/string/string_utils.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO: Add support for locales.
+LLVM_LIBC_FUNCTION(size_t, strxfrm,
+                   (char *__restrict dest, const char *__restrict src,
+                    size_t n)) {
+  size_t len = internal::string_length(src);
+  if (n > len)
+    inline_memcpy(dest, src, len + 1);
+  return len;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strxfrm.h
+++ b/system/lib/llvm-libc/src/string/strxfrm.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for strxfrm -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRXFRM_H
+#define LLVM_LIBC_SRC_STRING_STRXFRM_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h> // For size_t
+namespace LIBC_NAMESPACE_DECL {
+
+size_t strxfrm(char *__restrict dest, const char *__restrict src, size_t n);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRXFRM_H

--- a/system/lib/llvm-libc/src/string/strxfrm_l.cpp
+++ b/system/lib/llvm-libc/src/string/strxfrm_l.cpp
@@ -1,0 +1,28 @@
+//===-- Implementation of strxfrm_l ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/string/strxfrm_l.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memcpy.h"
+#include "src/string/string_utils.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO: Add support for locales.
+LLVM_LIBC_FUNCTION(size_t, strxfrm_l,
+                   (char *__restrict dest, const char *__restrict src, size_t n,
+                    locale_t)) {
+  size_t len = internal::string_length(src);
+  if (n > len)
+    inline_memcpy(dest, src, len + 1);
+  return len;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/string/strxfrm_l.h
+++ b/system/lib/llvm-libc/src/string/strxfrm_l.h
@@ -1,0 +1,23 @@
+//===-- Implementation header for strxfrm_l ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRXFRM_L_H
+#define LLVM_LIBC_SRC_STRING_STRXFRM_L_H
+
+#include "include/llvm-libc-types/locale_t.h"
+#include "src/__support/macros/config.h"
+#include <stddef.h> // For size_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t strxfrm_l(char *__restrict dest, const char *__restrict src, size_t n,
+                 locale_t locale);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRXFRM_L_H

--- a/system/lib/update_libcxx.py
+++ b/system/lib/update_libcxx.py
@@ -25,6 +25,8 @@ libc_copy_dirs = [
     ('include', 'llvm-libc-types'),
     ('shared',),
     ('src', '__support'),
+    ('src', 'string'),
+    ('src', 'errno'),
 ]
 
 def clean_dir(dirname):

--- a/test/common.py
+++ b/test/common.py
@@ -978,6 +978,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def check_dylink(self):
     if self.get_setting('WASM_ESM_INTEGRATION'):
       self.skipTest('dynamic linking not supported with WASM_ESM_INTEGRATION')
+    if '-lllvmlibc' in self.emcc_args:
+      self.skipTest('dynamic linking not supported with llvm-libc')
     if self.is_wasm2js():
       self.skipTest('dynamic linking not supported with wasm2js')
     if '-fsanitize=undefined' in self.emcc_args:
@@ -1364,7 +1366,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   #                  libraries, for example
   def get_emcc_args(self, main_file=False, compile_only=False, asm_only=False):
     def is_ldflag(f):
-      return any(f.startswith(s) for s in ['-sEXPORT_ES6', '--proxy-to-worker', '-sGL_TESTING', '-sPROXY_TO_WORKER', '-sPROXY_TO_PTHREAD', '-sENVIRONMENT=', '--pre-js=', '--post-js=', '-sPTHREAD_POOL_SIZE='])
+      return f.startswith('-l') or any(f.startswith(s) for s in ['-sEXPORT_ES6', '--proxy-to-worker', '-sGL_TESTING', '-sPROXY_TO_WORKER', '-sPROXY_TO_PTHREAD', '-sENVIRONMENT=', '--pre-js=', '--post-js=', '-sPTHREAD_POOL_SIZE='])
 
     args = self.serialize_settings(compile_only or asm_only) + self.emcc_args
     if asm_only:

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1832,7 +1832,7 @@ int main() {
     self.set_setting('EXPORTED_FUNCTIONS', ['_main', '_save_me_aimee'])
     self.do_core_test('test_emscripten_api.c')
 
-    # Sanitizers are not compatible with LINKABLE (dynamic linking.
+    # Sanitizers are not compatible with LINKABLE (dynamic linking).
     if not is_sanitizing(self.emcc_args) and not self.is_wasm64():
       # test EXPORT_ALL
       self.clear_setting('EXPORTED_FUNCTIONS')
@@ -9956,6 +9956,7 @@ asani = make_run('asani', emcc_args=['-fsanitize=address', '--profiling', '--pre
 
 # Experimental modes (not tested by CI)
 minimal0 = make_run('minimal0', emcc_args=['-g'], settings={'MINIMAL_RUNTIME': 1})
+llvmlibc = make_run('llvmlibc', emcc_args=['-lllvmlibc'])
 
 # TestCoreBase is just a shape for the specific subclasses, we don't test it itself
 del TestCoreBase # noqa

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -104,6 +104,22 @@ def uses_canonical_tmp(func):
   return decorated
 
 
+def also_with_llvm_libc(f):
+  assert callable(f)
+
+  @wraps(f)
+  def metafunc(self, llvm_libc, *args, **kwargs):
+    if shared.DEBUG:
+      print('parameterize:llvm_libc=%d' % llvm_libc)
+    if llvm_libc:
+      self.emcc_args += ['-lllvmlibc']
+    f(self, *args, **kwargs)
+
+  parameterize(metafunc, {'': (False,),
+                          'llvm_libc': (True,)})
+  return metafunc
+
+
 def with_both_compilers(f):
   assert callable(f)
 
@@ -15674,6 +15690,7 @@ addToLibrary({
   def test_llrint(self):
     self.do_other_test('test_llrint.c')
 
+  @also_with_llvm_libc
   def test_strings(self):
     self.do_other_test('test_strings.c', args=['wowie', 'too', '74'])
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -991,6 +991,19 @@ class libnoexit(Library):
   src_files = ['atexit_dummy.c']
 
 
+class llvmlibc(DebugLibrary, AsanInstrumentedLibrary, MTLibrary):
+  name = 'libllvmlibc'
+  never_force = True
+  includes = ['system/lib/llvm-libc']
+  cflags = ['-DLIBC_NAMESPACE=__llvm_libc', '-DLIBC_COPT_PUBLIC_PACKAGING']
+
+  def get_files(self):
+    files = glob_in_path('system/lib/llvm-libc/src/string', '*.cpp')
+    files += glob_in_path('system/lib/llvm-libc/src/errno', '*.cpp')
+    files += glob_in_path('system/lib/llvm-libc/src/__support/StringUtil', '*.cpp')
+    return files
+
+
 class libc(MuslInternalLibrary,
            DebugLibrary,
            AsanInstrumentedLibrary,
@@ -2426,7 +2439,6 @@ def get_libs_to_link(options):
 
 
 def calculate(options):
-
   libs_to_link = get_libs_to_link(options)
 
   # When LINKABLE is set the entire link command line is wrapped in --whole-archive by


### PR DESCRIPTION
This uses llvm-libc in overlay mode.  See https://libc.llvm.org/overlay_mode.html.

This just builds string.h function to a library called libllvmlibc.a that must be linked in manually for now.

The results of running our codesize tests with this initial version of llvm-libc are as follows:

```
code_size/embind_hello_wasm.json: 15801 => 15742 [-59 bytes / -0.37%]
code_size/embind_val_wasm.json: 15606 => 15422 [-184 bytes / -1.18%]
code_size/random_printf_wasm.json: 12498 => 12322 [-176 bytes / -1.41%]
code_size/random_printf_wasm2js.json: 17215 => 16949 [-266 bytes / -1.55%]
other/codesize/test_codesize_cxx_ctors1.size: 129749 => 128613 [-1136 bytes / -0.88%]
other/codesize/test_codesize_cxx_ctors2.size: 129134 => 127995 [-1139 bytes / -0.88%]
other/codesize/test_codesize_cxx_except.size: 171419 => 172333 [+914 bytes / +0.53%]
other/codesize/test_codesize_cxx_except_wasm.size: 144865 => 145763 [+898 bytes / +0.62%]
other/codesize/test_codesize_cxx_except_wasm_legacy.size: 142455 => 143358 [+903 bytes / +0.63%]
other/codesize/test_codesize_cxx_lto.size: 121979 => 126348 [+4369 bytes / +3.58%]
other/codesize/test_codesize_cxx_mangle.size: 235483 => 236396 [+913 bytes / +0.39%]
other/codesize/test_codesize_cxx_noexcept.size: 132122 => 130986 [-1136 bytes / -0.86%]
other/codesize/test_codesize_cxx_wasmfs.size: 169992 => 168858 [-1134 bytes / -0.67%]
other/codesize/test_codesize_files_wasmfs.size: 50330 => 50012 [-318 bytes / -0.63%]
test/other/codesize/test_codesize_hello_O0.funcs updated
other/codesize/test_codesize_hello_O0.size: 15163 => 16188 [+1025 bytes / +6.76%]
test/other/codesize/test_codesize_hello_O1.funcs updated
other/codesize/test_codesize_hello_O1.size: 2673 => 2051 [-622 bytes / -23.27%]
other/codesize/test_codesize_hello_O2.size: 1977 => 1379 [-598 bytes / -30.25%]
other/codesize/test_codesize_hello_O3.size: 1733 => 1177 [-556 bytes / -32.08%]
other/codesize/test_codesize_hello_Os.size: 1724 => 1169 [-555 bytes / -32.19%]
other/codesize/test_codesize_hello_Oz.size: 1259 => 1169 [-90 bytes / -7.15%]
test/other/codesize/test_codesize_hello_dylink.funcs updated
other/codesize/test_codesize_hello_dylink.size: 18543 => 17520 [-1023 bytes / -5.52%]
test/other/codesize/test_codesize_hello_single_file.gzsize updated
test/other/codesize/test_codesize_hello_single_file.jssize updated
other/codesize/test_codesize_hello_wasmfs.size: 1733 => 1177 [-556 bytes / -32.08%]
test/other/codesize/test_codesize_minimal_pthreads.funcs updated
test/other/codesize/test_codesize_minimal_pthreads_memgrowth.funcs updated
other/test_unoptimized_code_size.wasm.size: 15163 => 16188 [+1025 bytes / +6.76%]
other/test_unoptimized_code_size_no_asserts.wasm.size: 12244 => 11172 [-1072 bytes / -8.76%]
other/test_unoptimized_code_size_strict.wasm.size: 15163 => 16188 [+1025 bytes / +6.76%]

Average change: -6.15% (-32.19% - +6.76%)
```

See #24493