### PR TITLE
Allow using Closure Compiler with debug flags

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -49,6 +49,8 @@ See docs/process.md for more on how version tagging works.
 - `emscripten_fetch_get_response_headers_length` now excludes the trailing
   null character from the length calculation to match the documented behaviour.
   (#24486)
+- `--closure=1` can now be used while preserving readable function names with
+  `-g2` or `-g`.
 
 4.0.9 - 05/19/25
 ----------------

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12805,27 +12805,27 @@ int main(void) {
 
   def test_warning_flags(self):
     self.run_process([EMCC, '-c', '-o', 'hello.o', test_file('hello_world.c')])
-    cmd = [EMCC, 'hello.o', '-o', 'a.js', '-g', '--closure=1']
+    cmd = [EMCC, 'hello.o', '-o', 'a.js', '-g', '--llvm-opts=""']
 
     # warning that is enabled by default
     stderr = self.run_process(cmd, stderr=PIPE).stderr
-    self.assertContained('emcc: warning: disabling closure because debug info was requested [-Wemcc]', stderr)
+    self.assertContained('emcc: warning: --llvm-opts is deprecated.  All non-emcc args are passed through to clang. [-Wdeprecated]', stderr)
 
     # -w to suppress warnings
     stderr = self.run_process(cmd + ['-w'], stderr=PIPE).stderr
     self.assertNotContained('warning', stderr)
 
     # -Wno-emcc to suppress just this one warning
-    stderr = self.run_process(cmd + ['-Wno-emcc'], stderr=PIPE).stderr
+    stderr = self.run_process(cmd + ['-Wno-deprecated'], stderr=PIPE).stderr
     self.assertNotContained('warning', stderr)
 
     # with -Werror should fail
     stderr = self.expect_fail(cmd + ['-Werror'])
-    self.assertContained('error: disabling closure because debug info was requested [-Wemcc] [-Werror]', stderr)
+    self.assertContained('error: --llvm-opts is deprecated.  All non-emcc args are passed through to clang. [-Wdeprecated] [-Werror]', stderr)
 
     # with -Werror + -Wno-error=<type> should only warn
-    stderr = self.run_process(cmd + ['-Werror', '-Wno-error=emcc'], stderr=PIPE).stderr
-    self.assertContained('emcc: warning: disabling closure because debug info was requested [-Wemcc]', stderr)
+    stderr = self.run_process(cmd + ['-Werror', '-Wno-error=deprecated'], stderr=PIPE).stderr
+    self.assertContained('emcc: warning: --llvm-opts is deprecated.  All non-emcc args are passed through to clang. [-Wdeprecated]', stderr)
 
     # check that `-Werror=foo` also enales foo
     stderr = self.expect_fail(cmd + ['-Werror=legacy-settings', '-sTOTAL_MEMORY'])
@@ -15595,6 +15595,11 @@ addToLibrary({
 
   def test_strict_closure(self):
     self.emcc(test_file('hello_world.c'), ['-sSTRICT', '--closure=1'])
+
+  def test_closure_debug(self):
+    self.emcc(test_file('hello_world.c'), ['-sSTRICT', '--closure=1', '-g'])
+    src = read_file('a.out.js')
+    self.assertContained('$Module$$', src)
 
   def test_arguments_global(self):
     self.emcc(test_file('hello_world_argv.c'), ['-sENVIRONMENT=web', '-sSTRICT', '--closure=1', '-O2'])

--- a/tools/building.py
+++ b/tools/building.py
@@ -615,6 +615,9 @@ def closure_compiler(filename, advanced=True, extra_closure_args=None):
     args += ['--externs', e]
   args += user_args
 
+  if settings.DEBUG_LEVEL > 1:
+    args += ['--debug']
+
   cmd = closure_cmd + args
   return run_closure_cmd(cmd, filename, env)
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -1046,10 +1046,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
 
   # Use settings
 
-  if settings.DEBUG_LEVEL > 1 and options.use_closure_compiler:
-    diagnostics.warning('emcc', 'disabling closure because debug info was requested')
-    options.use_closure_compiler = False
-
   if settings.WASM == 2 and settings.SINGLE_FILE:
     exit_with_error('cannot have both WASM=2 and SINGLE_FILE enabled at the same time')
 


### PR DESCRIPTION
Closure Compiler has a `--debug` mode that generates debug names that can be easily matched to original ones, while still performing all the usual advanced optimisations - constant folding, DCE, and so on.

Even though it's not strictly preserving original function names 1:1, such debug output is much more useful for debugging Closure-optimised code than disabling Closure altogether when `-g` is requested.