### PR TITLE
fix compilation of `test/gl_in_mainthread_after_pthread.c`

### DIFF
--- a/test/gl_in_mainthread_after_pthread.c
+++ b/test/gl_in_mainthread_after_pthread.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <emscripten/emscripten.h>
 #include <emscripten/html5.h>
+#include <emscripten/threading.h>
 #include <bits/errno.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
The test was missing an Emscripten header so wasn't compiling. Should be working now!

Compiled with:
```
emcc gl_in_mainthread_after_pthread.c -o hello.html -pthread -sOFFSCREEN_FRAMEBUFFER 
```