### PR TITLE
ChangeLog: Fix formatting of latest entry

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,11 +19,12 @@ to browse the changes between the tags.
 See docs/process.md for more on how version tagging works.
 
 4.0.11 (in development)
-----------------------
+-----------------------
 
 
 4.0.10 - 06/07/25
------------------- Emscripten ports now install pkg-config `.pc` files so they will show up, for
+-----------------
+- Emscripten ports now install pkg-config `.pc` files so they will show up, for
   example, when you run `pkg-config --list-all` or `pkg-config --cflags
   <portname>`. Bare in mind that the correct PKG_CONFIG_PATH needs to be set for
   this to work.  One way to do this is to run `emmake pkg-config`. (#24426)


### PR DESCRIPTION
You might want to double check the logic of the release bot which introduced the issue in #24515.