### PR TITLE
[embind] Remove argPackAdvance. NFC

### DIFF
--- a/src/lib/libemval.js
+++ b/src/lib/libemval.js
@@ -310,6 +310,8 @@ var LibraryEmVal = {
     '$createNamedFunction', '$emval_returnValue',
   ],
   _emval_get_method_caller: (argCount, argTypes, kind) => {
+    var GenericWireTypeSize = {{{ 2 * POINTER_SIZE }}};
+
     var types = emval_lookupTypes(argCount, argTypes);
     var retType = types.shift();
     argCount--; // remove the shifted off return type
@@ -320,7 +322,7 @@ var LibraryEmVal = {
       var offset = 0;
       for (var i = 0; i < argCount; ++i) {
         argN[i] = types[i]['readValueFromPointer'](args + offset);
-        offset += types[i].argPackAdvance;
+        offset += GenericWireTypeSize;
       }
       var rv = kind === /* CONSTRUCTOR */ 1 ? Reflect.construct(func, argN) : func.apply(obj, argN);
       return emval_returnValue(retType, destructorsRef, rv);
@@ -342,7 +344,7 @@ var LibraryEmVal = {
       args.push(types[i]);
       functionBody +=
         `  var arg${i} = argType${i}.readValueFromPointer(args${offset ? '+' + offset : ''});\n`;
-      offset += types[i].argPackAdvance;
+      offset += GenericWireTypeSize;
     }
     var invoker = kind === /* CONSTRUCTOR */ 1 ? 'new func' : 'func.call';
     functionBody +=

--- a/test/code_size/embind_hello_wasm.json
+++ b/test/code_size/embind_hello_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 380,
-  "a.js": 7716,
-  "a.js.gz": 3372,
+  "a.js": 7680,
+  "a.js.gz": 3363,
   "a.wasm": 7290,
   "a.wasm.gz": 3343,
-  "total": 15558,
-  "total_gz": 7095
+  "total": 15522,
+  "total_gz": 7086
 }

--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 380,
-  "a.js": 5726,
-  "a.js.gz": 2548,
+  "a.js": 5685,
+  "a.js.gz": 2538,
   "a.wasm": 9083,
   "a.wasm.gz": 4682,
-  "total": 15361,
-  "total_gz": 7610
+  "total": 15320,
+  "total_gz": 7600
 }


### PR DESCRIPTION
Some time in long past, we unified all types to use a single GenericWireType when packed in a vararg buffer, but never removed argPackAdvance so it remained always set to GenericWireType (except for `void`, which we don't care about as you can't pass it in params anyway).