### PR TITLE
Support llvm-libc directory in push_llvm_changes.py

### DIFF
--- a/system/lib/push_llvm_changes.py
+++ b/system/lib/push_llvm_changes.py
@@ -18,10 +18,11 @@ script_dir = os.path.abspath(os.path.dirname(__file__))
 emscripten_root = os.path.dirname(os.path.dirname(script_dir))
 default_llvm_dir = os.path.join(os.path.dirname(emscripten_root), 'llvm-project')
 copy_dirs = [
-  'compiler-rt',
-  'libcxx',
-  'libcxxabi',
-  'libunwind',
+  ('compiler-rt', 'compiler-rt'),
+  ('libcxx', 'libcxx'),
+  ('libcxxabi', 'libcxxabi'),
+  ('libunwind', 'libunwind'),
+  ('llvm-libc', 'libc'),
 ]
 
 
@@ -34,12 +35,12 @@ def main():
     print(f'llvm tree not found: {upstream_root}')
     return 1
 
-  for dir in copy_dirs:
-    assert os.path.exists(os.path.join(upstream_root, dir))
+  for _, upstream_name in copy_dirs:
+    assert os.path.exists(os.path.join(upstream_root, upstream_name))
 
-  for dir in copy_dirs:
-    local_dir = os.path.join(script_dir, dir)
-    upstream_dir = os.path.join(upstream_root, dir)
+  for local_name, upstream_name in copy_dirs:
+    local_dir = os.path.join(script_dir, local_name)
+    upstream_dir = os.path.join(upstream_root, upstream_name)
     print(f'copying {local_dir} -> {upstream_dir}')
     shutil.copytree(local_dir, upstream_dir, dirs_exist_ok=True)
 


### PR DESCRIPTION
Given that we use different names for the `libc` in our copy (`llvm-libc`), `copy_dirs` is now a list of tuples.