### PR TITLE
Fix create_release.py script to handle bad underlines

### DIFF
--- a/tools/maint/create_release.py
+++ b/tools/maint/create_release.py
@@ -28,7 +28,11 @@ def update_changelog(release_version, new_version):
   marker = f'{release_version} (in development)'
   pos = changelog.find(marker)
   assert pos != -1
-  pos += 2 * len(marker) + 1
+  pos += len(marker) + 1
+  # Skip the next line which should just be hyphens
+  assert changelog[pos] == '-'
+  pos = changelog.find('\n', pos)
+  assert pos != -1
 
   # Add new entry
   today = datetime.now().strftime('%m/%d/%y')


### PR DESCRIPTION
The script was assuming the underline was the same length as the title itself.

e.g. it did not handle.

```
1.3.4 (in development)
-------------------
```

See #24516