### PR TITLE
Allow to set custom websocket factory

### DIFF
--- a/site/source/docs/porting/networking.rst
+++ b/site/source/docs/porting/networking.rst
@@ -51,6 +51,9 @@ This is the default build mode for Emscripten. Use the linker flag
 to connect to, and the linker flag ``-sWEBSOCKET_SUBPROTOCOL`` or
 ``Module['websocket']['subprotocol']`` to control the connection type
 (``'binary'`` or ``'text'``).
+Or define custom WebSocket factory using ``Module['websocket']['factory']``. Factory
+is called with options param ``{addr, port, type, family, protocol}`` and
+must return WebSocket instance.
 
 Full POSIX Sockets over WebSocket Proxy Server
 ==============================================

--- a/src/lib/libsockfs.js
+++ b/src/lib/libsockfs.js
@@ -172,6 +172,19 @@ addToLibrary({
             addr = result[1];
             port = parseInt(result[2], 10);
           }
+        } else if (typeof SOCKFS.websocketArgs["factory"] === "function") {
+          try {
+            ws = SOCKFS.websocketArgs["factory"]({
+              addr,
+              port,
+              type: sock.type,
+              family: sock.family,
+              protocol: sock.protocol
+            });
+            ws.binaryType = 'arraybuffer';
+          } catch (e) {
+            throw new FS.ErrnoError({{{ cDefs.EHOSTUNREACH }}});
+          }
         } else {
           // create the actual websocket object and connect
           try {


### PR DESCRIPTION
In some cases, especially when application uses more then one connection, it will be handy to define custom websocket factory.
