### PR TITLE
Fix test failures on Windows when path contains spaces or current codepage is Unicode

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6314,9 +6314,12 @@ PORT: 3979
     # are having the desired effect.
     # This means that files open()'d by emscripten without an explicit encoding will
     # cause this test to file, hopefully catching any places where we forget to do this.
-    create_file('expect_fail.py', 'print(len(open(r"%s").read()))' % test_file('unicode_library.js'))
-    err = self.expect_fail([PYTHON, 'expect_fail.py'], expect_traceback=True)
-    self.assertContained('UnicodeDecodeError', err)
+
+    # On Windows when Unicode support is enabled, this test code does not fail.
+    if not (WINDOWS and self.run_process(['chcp'], stdout=PIPE, shell=True).stdout.strip() == 'Active code page: 65001'):
+      create_file('expect_fail.py', 'print(len(open(r"%s").read()))' % test_file('unicode_library.js'))
+      err = self.expect_fail([PYTHON, 'expect_fail.py'], expect_traceback=True)
+      self.assertContained('UnicodeDecodeError', err)
 
     self.emcc_args += ['-sMODULARIZE', '--js-library', test_file('unicode_library.js'), '--extern-post-js', test_file('modularize_post_js.js'), '--post-js', test_file('unicode_postjs.js')]
     self.do_run_in_out_file_test('test_unicode_js_library.c')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15312,7 +15312,7 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
   @only_windows('This test verifies Windows batch script behavior against bug https://github.com/microsoft/terminal/issues/15212')
   @with_env_modify({'PATH': path_from_root() + os.pathsep + os.getenv('PATH')})
   def test_windows_batch_file_dp0_expansion_bug(self):
-    create_file('build_with_quotes.bat',  f'@"emcc" {test_file("hello_world.c")}')
+    create_file('build_with_quotes.bat',  f'@"emcc" "{test_file("hello_world.c")}"')
     self.run_process(['build_with_quotes.bat'])
 
   @only_windows('Check that directory permissions are properly retrieved on Windows')


### PR DESCRIPTION
Fix two tests to pass on Windows when the Emscripten SDK directory contains spaces, or current codepage is Unicode.