### PR TITLE
Fix -gsource-map with UTF-8 chars in directory and file names in the path.

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10757,7 +10757,7 @@ int main() {
     ensure_dir('build')
 
     def test(infile, source_map_added_dir=''):
-      expected_source_map_path = 'a.cpp'
+      expected_source_map_path = 'A ä☃ö Z.cpp'
       if source_map_added_dir:
         expected_source_map_path = source_map_added_dir + '/' + expected_source_map_path
       print(infile, expected_source_map_path)
@@ -10778,10 +10778,10 @@ int main() {
         self.run_process([EMCC, 'a.o', '-gsource-map'], cwd='build')
         self.assertIn('"../%s"' % expected_source_map_path, read_file('build/a.out.wasm.map'))
 
-    test('a.cpp')
+    test('A ä☃ö Z.cpp')
 
-    ensure_dir('inner')
-    test('inner/a.cpp', 'inner')
+    ensure_dir('inner Z ö☃ä A')
+    test('inner Z ö☃ä A/A ä☃ö Z.cpp', 'inner Z ö☃ä A')
 
   def test_wasm_sourcemap_extract_comp_dir_map(self):
     wasm_sourcemap = importlib.import_module('tools.wasm-sourcemap')

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -205,8 +205,8 @@ def decode_octal_encoded_utf8(str):
   o = 0
   final_length = len(str)
   while i < len(str):
-    if str[i] == '\\' and (str[i+1] == '2' or str[i+1] == '3'):
-      out[o] = int(str[i+1:i+4], 8)
+    if str[i] == '\\' and (str[i + 1] == '2' or str[i + 1] == '3'):
+      out[o] = int(str[i + 1:i + 4], 8)
       i += 4
       final_length -= 3
     else:


### PR DESCRIPTION
Fix -gsource-map with UTF-8 chars in directory and file names in the path. Fixes #24557.