### PR TITLE
Fix running Closure when input file is located in a path with a UTF-8 character. 

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -637,7 +637,7 @@ def run_closure_cmd(cmd, filename, env):
   tempfiles = shared.get_temp_files()
 
   def move_to_safe_7bit_ascii_filename(filename):
-    if filename.isascii():
+    if os.path.abspath(filename).isascii():
       return os.path.abspath(filename)
     safe_filename = tempfiles.get('.js').name  # Safe 7-bit filename
     shutil.copyfile(filename, safe_filename)


### PR DESCRIPTION
Fix running Closure when input file is located in a path with a UTF-8 character. Fixes `other.test_no_minify_and_later_closure` when emsdk installed under a UTF-8 subdir.