### PR TITLE
Fix decode_octal_encoded_utf8()

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10780,8 +10780,8 @@ int main() {
 
     test('A ä☃ö Z.cpp')
 
-    ensure_dir('inner Z ö☃ä A')
-    test('inner Z ö☃ä A/A ä☃ö Z.cpp', 'inner Z ö☃ä A')
+    ensure_dir('inner Z ö☃ä A/21')
+    test('inner Z ö☃ä A/21/A ä☃ö Z.cpp', 'inner Z ö☃ä A/21')
 
   def test_wasm_sourcemap_extract_comp_dir_map(self):
     wasm_sourcemap = importlib.import_module('tools.wasm-sourcemap')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10780,6 +10780,8 @@ int main() {
 
     test('A ä☃ö Z.cpp')
 
+    # Explicitly test the case of spaces, UTF-8 chars, and a tricky case of a path consisting
+    # of only two digits (that could be confused for an octal escape sequence)
     ensure_dir('inner Z ö☃ä A/21')
     test('inner Z ö☃ä A/21/A ä☃ö Z.cpp', 'inner Z ö☃ä A/21')
 

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -204,13 +204,16 @@ def decode_octal_encoded_utf8(str):
   i = 0
   o = 0
   final_length = len(str)
+  in_escape = False
   while i < len(str):
-    if str[i] == '\\' and (str[i + 1] == '2' or str[i + 1] == '3'):
+    if not in_escape and str[i] == '\\' and (str[i + 1] == '2' or str[i + 1] == '3'):
       out[o] = int(str[i + 1:i + 4], 8)
       i += 4
       final_length -= 3
+      in_escape = False
     else:
       out[o] = ord(str[i])
+      in_escape = False if in_escape else (str[i] == '\\')
       i += 1
     o += 1
   return out[:final_length].decode('utf-8')


### PR DESCRIPTION
Fix decode_octal_encoded_utf8() to work in scenario where a directory name consists of exactly two digits, i.e. '\\foo\\21\\bar'