### PR TITLE
Fix `makeRemovedFSAssert()` resolved path

### DIFF
--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -19,6 +19,7 @@ import {
   runInMacroContext,
   pushCurrentFile,
   popCurrentFile,
+  localFile,
   warn,
   srcDir,
 } from './utility.mjs';
@@ -921,7 +922,7 @@ function makeModuleReceiveWithVar(localName, moduleName, defaultValue) {
 function makeRemovedFSAssert(fsName) {
   assert(ASSERTIONS);
   const lower = fsName.toLowerCase();
-  if (JS_LIBRARIES.includes(path.resolve(path.join('lib', `lib${lower}.js`)))) return '';
+  if (JS_LIBRARIES.includes(localFile(path.join('lib', `lib${lower}.js`)))) return '';
   return `var ${fsName} = '${fsName} is no longer included by default; build with -l${lower}.js';`;
 }
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -16234,3 +16234,18 @@ addToLibrary({
     # and in debug mode at least we expect to see the error message from libc++
     expected = 'system_error was thrown in -fno-exceptions mode with error 6 and message "thread constructor failed"'
     self.do_runf('main.cpp', expected, assert_returncode=NON_ZERO)
+
+  def test_parsetools_make_removed_fs_assert(self):
+    """
+    This tests that parseTools.mjs `makeRemovedFSAssert()` works as intended,
+    if it creates a stub when a builtin library isn't included, but not when
+    it is.
+    """
+
+    removed_fs_assert_content = "IDBFS is no longer included by default"
+
+    self.emcc(test_file('hello_world.c'), output_filename='hello_world.js')
+    self.assertContained(removed_fs_assert_content, read_file('hello_world.js'))
+
+    self.emcc(test_file('hello_world.c'), ['-lidbfs.js'], output_filename='hello_world.js')
+    self.assertNotContained(removed_fs_assert_content, read_file('hello_world.js'))


### PR DESCRIPTION
This fixes an issue where `path.resolve()` resolves using the CWD (which is usually the target project path) instead of the directory of the script itself.

The current behavior [causes issues with the Closure compiler](https://github.com/godotengine/godot/pull/107460#issuecomment-2970895256), as stubs are erroneously created instead of being skipped in `src/shell.js`. Closure then complains that variables are declared twice.

The issue was caused by #23348 which changed the logic of the search.