### PR TITLE
Fix race condition in browser.test_clientside_vertex_arrays_es3

### DIFF
--- a/test/clientside_vertex_arrays_es3.c
+++ b/test/clientside_vertex_arrays_es3.c
@@ -19,7 +19,7 @@ void onDraw(void* arg) {
   glfwSwapBuffers(window);
   glfwPollEvents();
 #ifdef __EMSCRIPTEN__
-  EM_ASM(doReftest()); // All done, perform the JS side image comparison reftest.
+  EM_ASM({reftestUnblock()}); // All done, perform the JS side image comparison reftest.
 #endif
 }
 
@@ -117,7 +117,7 @@ int main() {
 #ifdef __EMSCRIPTEN__
   // This test kicks off an asynchronous main loop, so do not perform a synchronous
   // reftest immediately after falling out from main.
-  EM_ASM({ delete Module['postRun']; });
+  EM_ASM({reftestBlock()});
 
   emscripten_set_main_loop_arg(onDraw, &window, 0, 1);
 #else


### PR DESCRIPTION
Without this, browser would run the reftest as a Module['postRun'] trigger immediately after finishing main().

But because reftest is asynchronous, as it has to load an image asynchronously, the requestAnimationFrame() timers might race to squeeze in the needed test tick function call to render the expected image, or they might not, if the XHR of the reftest image is fast.
