### PR TITLE
[test] Use `cflags` rather than `emcc_args`. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -417,7 +417,7 @@ def also_with_wasmfs(f):
     if wasmfs:
       self.setup_wasmfs_test()
     else:
-      self.emcc_args += ['-DMEMFS']
+      self.cflags += ['-DMEMFS']
     f(self, *args, **kwargs)
 
   parameterize(metafunc, {'': (False,),
@@ -433,7 +433,7 @@ def also_with_nodefs(func):
     if fs == 'nodefs':
       self.setup_nodefs_test()
     else:
-      self.emcc_args += ['-DMEMFS']
+      self.cflags += ['-DMEMFS']
       assert fs is None
     func(self, *args, **kwargs)
 
@@ -452,7 +452,7 @@ def also_with_nodefs_both(func):
     elif fs == 'rawfs':
       self.setup_noderawfs_test()
     else:
-      self.emcc_args += ['-DMEMFS']
+      self.cflags += ['-DMEMFS']
       assert fs is None
     func(self, *args, **kwargs)
 
@@ -474,7 +474,7 @@ def with_all_fs(func):
     elif fs == 'rawfs':
       self.setup_noderawfs_test()
     else:
-      self.emcc_args += ['-DMEMFS']
+      self.cflags += ['-DMEMFS']
       assert fs is None
     func(self, *args, **kwargs)
 
@@ -497,7 +497,7 @@ def also_with_noderawfs(func):
     if rawfs:
       self.setup_noderawfs_test()
     else:
-      self.emcc_args += ['-DMEMFS']
+      self.cflags += ['-DMEMFS']
     func(self, *args, **kwargs)
 
   parameterize(metafunc, {'': (False,),
@@ -544,7 +544,7 @@ def also_with_minimal_runtime(f):
       self.set_setting('MINIMAL_RUNTIME', 1)
       # This extra helper code is needed to cleanly handle calls to exit() which throw
       # an ExitCode exception.
-      self.emcc_args += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]
+      self.cflags += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]
     f(self, *args, **kwargs)
 
   parameterize(metafunc, {'': (False,),
@@ -623,7 +623,7 @@ def can_do_standalone(self, impure=False):
       not self.get_setting('MINIMAL_RUNTIME') and \
       not self.get_setting('WASM_ESM_INTEGRATION') and \
       not self.get_setting('SAFE_HEAP') and \
-      not any(a.startswith('-fsanitize=') for a in self.emcc_args)
+      not any(a.startswith('-fsanitize=') for a in self.cflags)
 
 
 # Impure means a test that cannot run in a wasm VM yet, as it is not 100%
@@ -644,7 +644,7 @@ def also_with_standalone_wasm(impure=False):
         # support in order for JS to have a chance to run this without trapping
         # when it sees an i64 on the ffi.
         self.set_setting('WASM_BIGINT')
-        self.emcc_args.append('-Wno-unused-command-line-argument')
+        self.cflags.append('-Wno-unused-command-line-argument')
         # if we are impure, disallow all wasm engines
         if impure:
           self.wasm_engines = []
@@ -669,7 +669,7 @@ def also_with_asan(f):
         self.skipTest('TODO: ASAN in memory64')
       if self.is_2gb() or self.is_4gb():
         self.skipTest('asan doesnt support GLOBAL_BASE')
-      self.emcc_args.append('-fsanitize=address')
+      self.cflags.append('-fsanitize=address')
     f(self, *args, **kwargs)
 
   parameterize(metafunc, {'': (False,),
@@ -685,7 +685,7 @@ def also_with_modularize(f):
     if modularize:
       if '-sWASM_ESM_INTEGRATION':
         self.skipTest('also_with_modularize is not compatible with WASM_ESM_INTEGRATION')
-      self.emcc_args += ['--extern-post-js', test_file('modularize_post_js.js'), '-sMODULARIZE']
+      self.cflags += ['--extern-post-js', test_file('modularize_post_js.js'), '-sMODULARIZE']
     f(self, *args, **kwargs)
 
   parameterize(metafunc, {'': (False,),
@@ -709,7 +709,7 @@ def with_all_eh_sjlj(f):
       # Wasm EH is currently supported only in wasm backend and V8
       if self.is_wasm2js():
         self.skipTest('wasm2js does not support wasm EH/SjLj')
-      self.emcc_args.append('-fwasm-exceptions')
+      self.cflags.append('-fwasm-exceptions')
       self.set_setting('SUPPORT_LONGJMP', 'wasm')
       if mode == 'wasm':
         self.require_wasm_eh()
@@ -980,11 +980,11 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def check_dylink(self):
     if self.get_setting('WASM_ESM_INTEGRATION'):
       self.skipTest('dynamic linking not supported with WASM_ESM_INTEGRATION')
-    if '-lllvmlibc' in self.emcc_args:
+    if '-lllvmlibc' in self.cflags:
       self.skipTest('dynamic linking not supported with llvm-libc')
     if self.is_wasm2js():
       self.skipTest('dynamic linking not supported with wasm2js')
-    if '-fsanitize=undefined' in self.emcc_args:
+    if '-fsanitize=undefined' in self.cflags:
       self.skipTest('dynamic linking not supported with UBSan')
     # MEMORY64=2 mode doesn't currently support dynamic linking because
     # The side modules are lowered to wasm32 when they are built, making
@@ -999,7 +999,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       else:
         self.fail('d8 required to run this test.  Use EMTEST_SKIP_V8 to skip')
     self.require_engine(config.V8_ENGINE)
-    self.emcc_args.append('-sENVIRONMENT=shell')
+    self.cflags.append('-sENVIRONMENT=shell')
 
   def get_nodejs(self):
     if config.NODE_JS_TEST not in self.js_engines:
@@ -1046,7 +1046,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       return
 
     if config.V8_ENGINE and config.V8_ENGINE in self.js_engines:
-      self.emcc_args.append('-sENVIRONMENT=shell')
+      self.cflags.append('-sENVIRONMENT=shell')
       self.js_engines = [config.V8_ENGINE]
       return
 
@@ -1074,7 +1074,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       return
 
     if config.V8_ENGINE and config.V8_ENGINE in self.js_engines:
-      self.emcc_args.append('-sENVIRONMENT=shell')
+      self.cflags.append('-sENVIRONMENT=shell')
       self.js_engines = [config.V8_ENGINE]
       return
 
@@ -1089,7 +1089,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       return
 
     if config.V8_ENGINE and config.V8_ENGINE in self.js_engines:
-      self.emcc_args.append('-sENVIRONMENT=shell')
+      self.cflags.append('-sENVIRONMENT=shell')
       self.js_engines = [config.V8_ENGINE]
       return
 
@@ -1108,7 +1108,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       return
 
     if config.V8_ENGINE and config.V8_ENGINE in self.js_engines:
-      self.emcc_args.append('-sENVIRONMENT=shell')
+      self.cflags.append('-sENVIRONMENT=shell')
       self.js_engines = [config.V8_ENGINE]
       self.v8_args.append('--experimental-wasm-exnref')
       return
@@ -1121,7 +1121,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def require_jspi(self):
     # emcc warns about stack switching being experimental, and we build with
     # warnings-as-errors, so disable that warning
-    self.emcc_args += ['-Wno-experimental']
+    self.cflags += ['-Wno-experimental']
     self.set_setting('JSPI')
     if self.is_wasm2js():
       self.skipTest('JSPI is not currently supported for WASM2JS')
@@ -1140,7 +1140,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       return
 
     if config.V8_ENGINE and config.V8_ENGINE in self.js_engines:
-      self.emcc_args.append('-sENVIRONMENT=shell')
+      self.cflags.append('-sENVIRONMENT=shell')
       self.js_engines = [config.V8_ENGINE]
       self.v8_args += exp_args
       return
@@ -1163,20 +1163,20 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     if self.get_setting('WASMFS'):
       # without this the JS setup code in setup_nodefs.js doesn't work
       self.set_setting('FORCE_FILESYSTEM')
-    self.emcc_args += ['-DNODEFS', '-lnodefs.js', '--pre-js', test_file('setup_nodefs.js'), '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized]']
+    self.cflags += ['-DNODEFS', '-lnodefs.js', '--pre-js', test_file('setup_nodefs.js'), '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized]']
 
   def setup_noderawfs_test(self):
     self.require_node()
-    self.emcc_args += ['-DNODERAWFS']
+    self.cflags += ['-DNODERAWFS']
     self.set_setting('NODERAWFS')
 
   def setup_wasmfs_test(self):
     self.set_setting('WASMFS')
-    self.emcc_args += ['-DWASMFS']
+    self.cflags += ['-DWASMFS']
 
   def setup_node_pthreads(self):
     self.require_node()
-    self.emcc_args += ['-Wno-pthreads-mem-growth', '-pthread']
+    self.cflags += ['-Wno-pthreads-mem-growth', '-pthread']
     if self.get_setting('MINIMAL_RUNTIME'):
       self.skipTest('node pthreads not yet supported with MINIMAL_RUNTIME')
     nodejs = self.get_nodejs()
@@ -1199,7 +1199,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     self.js_engines = config.JS_ENGINES.copy()
     self.settings_mods = {}
     self.skip_exec = None
-    self.emcc_args = ['-Wclosure', '-Werror', '-Wno-limited-postlink-optimizations']
+    self.cflags = ['-Wclosure', '-Werror', '-Wno-limited-postlink-optimizations']
     # TODO(https://github.com/emscripten-core/emscripten/issues/11121)
     # For historical reasons emcc compiles and links as C++ by default.
     # However we want to run our tests in a more strict manner.  We can
@@ -1233,10 +1233,10 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         int(emcc_min_node_version_str[4:6]),
       )
       if node_version < emcc_min_node_version:
-        self.emcc_args += building.get_emcc_node_flags(node_version)
-        self.emcc_args.append('-Wno-transpile')
+        self.cflags += building.get_emcc_node_flags(node_version)
+        self.cflags.append('-Wno-transpile')
       if node_version[0] < feature_matrix.min_browser_versions[feature_matrix.Feature.JS_BIGINT_INTEGRATION]['node'] / 10000:
-        self.emcc_args.append('-sWASM_BIGINT=0')
+        self.cflags.append('-sWASM_BIGINT=0')
 
     self.v8_args = ['--wasm-staging']
     self.env = {}
@@ -1350,27 +1350,27 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def add_pre_run(self, code):
     assert not self.get_setting('MINIMAL_RUNTIME')
     create_file('prerun.js', 'Module.preRun = function() { %s }\n' % code)
-    self.emcc_args += ['--pre-js', 'prerun.js', '-sINCOMING_MODULE_JS_API=[preRun]']
+    self.cflags += ['--pre-js', 'prerun.js', '-sINCOMING_MODULE_JS_API=[preRun]']
 
   def add_post_run(self, code):
     assert not self.get_setting('MINIMAL_RUNTIME')
     create_file('postrun.js', 'Module.postRun = function() { %s }\n' % code)
-    self.emcc_args += ['--pre-js', 'postrun.js', '-sINCOMING_MODULE_JS_API=[postRun]']
+    self.cflags += ['--pre-js', 'postrun.js', '-sINCOMING_MODULE_JS_API=[postRun]']
 
   def add_on_exit(self, code):
     assert not self.get_setting('MINIMAL_RUNTIME')
     create_file('onexit.js', 'Module.onExit = function() { %s }\n' % code)
-    self.emcc_args += ['--pre-js', 'onexit.js', '-sINCOMING_MODULE_JS_API=[onExit]']
+    self.cflags += ['--pre-js', 'onexit.js', '-sINCOMING_MODULE_JS_API=[onExit]']
 
   # returns the full list of arguments to pass to emcc
   # param @main_file whether this is the main file of the test. some arguments
   #                  (like --pre-js) do not need to be passed when building
   #                  libraries, for example
-  def get_emcc_args(self, main_file=False, compile_only=False, asm_only=False):
+  def get_cflags(self, main_file=False, compile_only=False, asm_only=False):
     def is_ldflag(f):
       return f.startswith('-l') or any(f.startswith(s) for s in ['-sEXPORT_ES6', '--proxy-to-worker', '-sGL_TESTING', '-sPROXY_TO_WORKER', '-sPROXY_TO_PTHREAD', '-sENVIRONMENT=', '--pre-js=', '--post-js=', '-sPTHREAD_POOL_SIZE='])
 
-    args = self.serialize_settings(compile_only or asm_only) + self.emcc_args
+    args = self.serialize_settings(compile_only or asm_only) + self.cflags
     if asm_only:
       args = [a for a in args if not a.startswith('-O')]
     if compile_only or asm_only:
@@ -1407,7 +1407,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       self.fail('es-check failed to verify ES5 output compliance')
 
   # Build JavaScript code from source code
-  def build(self, filename, libraries=None, includes=None, force_c=False, emcc_args=None, output_basename=None, output_suffix=None):
+  def build(self, filename, libraries=None, includes=None, force_c=False, cflags=None, output_basename=None, output_suffix=None):
     if not os.path.exists(filename):
       filename = test_file(filename)
     compiler = [compiler_for(filename, force_c)]
@@ -1416,17 +1416,17 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       assert shared.suffix(filename) != '.c', 'force_c is not needed for source files ending in .c'
       compiler.append('-xc')
 
-    all_emcc_args = self.get_emcc_args(main_file=True)
-    if emcc_args:
-      all_emcc_args += emcc_args
+    all_cflags = self.get_cflags(main_file=True)
+    if cflags:
+      all_cflags += cflags
     if not output_suffix:
-      output_suffix = get_output_suffix(all_emcc_args)
+      output_suffix = get_output_suffix(all_cflags)
 
     if output_basename:
       output = output_basename + output_suffix
     else:
       output = shared.unsuffixed_basename(filename) + output_suffix
-    cmd = compiler + [str(filename), '-o', output] + all_emcc_args
+    cmd = compiler + [str(filename), '-o', output] + all_cflags
     if libraries:
       cmd += libraries
     if includes:
@@ -1723,15 +1723,15 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
     build_dir = self.get_build_dir()
 
-    emcc_args = []
+    cflags = []
     if not native:
       # get_library() is used to compile libraries, and not link executables,
       # so we don't want to pass linker flags here (emscripten warns if you
       # try to pass linker settings when compiling).
-      emcc_args = self.get_emcc_args(compile_only=True)
+      cflags = self.get_cflags(compile_only=True)
 
-    hash_input = (str(emcc_args) + ' $ ' + str(env_init)).encode('utf-8')
-    cache_name = name + ','.join([opt for opt in emcc_args if len(opt) < 7]) + '_' + hashlib.md5(hash_input).hexdigest() + cache_name_extra
+    hash_input = (str(cflags) + ' $ ' + str(env_init)).encode('utf-8')
+    cache_name = name + ','.join([opt for opt in cflags if len(opt) < 7]) + '_' + hashlib.md5(hash_input).hexdigest() + cache_name_extra
 
     valid_chars = "_%s%s" % (string.ascii_letters, string.digits)
     cache_name = ''.join([(c if c in valid_chars else '_') for c in cache_name])
@@ -1751,7 +1751,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       configure = list(configure)
       configure += configure_args
 
-    cflags = ' '.join(emcc_args)
+    cflags = ' '.join(cflags)
     env_init.setdefault('CFLAGS', cflags)
     env_init.setdefault('CXXFLAGS', cflags)
     return build_library(name, build_dir, generated_libs, configure,
@@ -1778,7 +1778,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
   def emcc(self, filename, args=[], output_filename=None, **kwargs):  # noqa
     compile_only = '-c' in args or '-sSIDE_MODULE' in args
-    cmd = [compiler_for(filename), filename] + self.get_emcc_args(compile_only=compile_only) + args
+    cmd = [compiler_for(filename), filename] + self.get_cflags(compile_only=compile_only) + args
     if output_filename:
       cmd += ['-o', output_filename]
     self.run_process(cmd, **kwargs)
@@ -1872,7 +1872,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     so = '.wasm' if self.is_wasm() else '.js'
 
     def ccshared(src, linkto=None):
-      cmdv = [EMCC, src, '-o', shared.unsuffixed(src) + so, '-sSIDE_MODULE'] + self.get_emcc_args()
+      cmdv = [EMCC, src, '-o', shared.unsuffixed(src) + so, '-sSIDE_MODULE'] + self.get_cflags()
       if linkto:
         cmdv += linkto
       self.run_process(cmdv)
@@ -1899,7 +1899,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         return 0;
       }
       ''',
-           'a: loaded\na: b (prev: (null))\na: c (prev: b)\n', emcc_args=extra_args)
+           'a: loaded\na: b (prev: (null))\na: c (prev: b)\n', cflags=extra_args)
 
     extra_args = []
     for libname in ('liba', 'libb', 'libc'):
@@ -1929,7 +1929,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         return 0;
       }
     ''' % locals(),
-           'a: loaded\na: b (prev: (null))\na: c (prev: b)\n', emcc_args=extra_args)
+           'a: loaded\na: b (prev: (null))\na: c (prev: b)\n', cflags=extra_args)
 
   def do_run(self, src, expected_output=None, force_c=False, **kwargs):
     if 'no_build' in kwargs:
@@ -2011,7 +2011,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     return js_output
 
   def get_freetype_library(self):
-    self.emcc_args += [
+    self.cflags += [
       '-Wno-misleading-indentation',
       '-Wno-unused-but-set-variable',
       '-Wno-pointer-bool-conversion',
@@ -2027,14 +2027,14 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def get_poppler_library(self, env_init=None):
     freetype = self.get_freetype_library()
 
-    self.emcc_args += [
+    self.cflags += [
       '-I' + test_file('third_party/freetype/include'),
       '-I' + test_file('third_party/poppler/include'),
     ]
 
     # Poppler has some pretty glaring warning.  Suppress them to keep the
     # test output readable.
-    self.emcc_args += [
+    self.cflags += [
       '-Wno-sentinel',
       '-Wno-logical-not-parentheses',
       '-Wno-unused-private-field',
@@ -2065,14 +2065,14 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def get_zlib_library(self, cmake):
     assert cmake or not WINDOWS, 'on windows, get_zlib_library only supports cmake'
 
-    old_args = self.emcc_args.copy()
+    old_args = self.cflags.copy()
     # inflate.c does -1L << 16
-    self.emcc_args.append('-Wno-shift-negative-value')
+    self.cflags.append('-Wno-shift-negative-value')
     # adler32.c uses K&R sytyle function declarations
-    self.emcc_args.append('-Wno-deprecated-non-prototype')
+    self.cflags.append('-Wno-deprecated-non-prototype')
     # Work around configure-script error. TODO: remove when
     # https://github.com/emscripten-core/emscripten/issues/16908 is fixed
-    self.emcc_args.append('-Wno-pointer-sign')
+    self.cflags.append('-Wno-pointer-sign')
     if cmake:
       rtn = self.get_library(os.path.join('third_party', 'zlib'), os.path.join('libz.a'),
                              configure=['cmake', '.'],
@@ -2080,7 +2080,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
                              make_args=[])
     else:
       rtn = self.get_library(os.path.join('third_party', 'zlib'), os.path.join('libz.a'), make_args=['libz.a'])
-    self.emcc_args = old_args
+    self.cflags = old_args
     return rtn
 
 
@@ -2400,25 +2400,25 @@ class BrowserCore(RunnerCore):
       time.sleep(5)
       print('(moving on..)')
 
-  def compile_btest(self, filename, emcc_args, reporting=Reporting.FULL):
+  def compile_btest(self, filename, cflags, reporting=Reporting.FULL):
     # Inject support code for reporting results. This adds an include a header so testcases can
     # use REPORT_RESULT, and also adds a cpp file to be compiled alongside the testcase, which
     # contains the implementation of REPORT_RESULT (we can't just include that implementation in
     # the header as there may be multiple files being compiled here).
     if reporting != Reporting.NONE:
       # For basic reporting we inject JS helper funtions to report result back to server.
-      emcc_args += ['--pre-js', test_file('browser_reporting.js')]
+      cflags += ['--pre-js', test_file('browser_reporting.js')]
       if reporting == Reporting.FULL:
         # If C reporting (i.e. the REPORT_RESULT macro) is required we
         # also include report_result.c and force-include report_result.h
         self.run_process([EMCC, '-c', '-I' + TEST_ROOT,
-                          test_file('report_result.c')] + self.get_emcc_args(compile_only=True) + (['-fPIC'] if '-fPIC' in emcc_args else []))
-        emcc_args += ['report_result.o', '-include', test_file('report_result.h')]
+                          test_file('report_result.c')] + self.get_cflags(compile_only=True) + (['-fPIC'] if '-fPIC' in cflags else []))
+        cflags += ['report_result.o', '-include', test_file('report_result.h')]
     if EMTEST_BROWSER == 'node':
-      emcc_args.append('-DEMTEST_NODE')
+      cflags.append('-DEMTEST_NODE')
     if not os.path.exists(filename):
       filename = test_file(filename)
-    self.run_process([compiler_for(filename), filename] + self.get_emcc_args() + emcc_args)
+    self.run_process([compiler_for(filename), filename] + self.get_cflags() + cflags)
 
   def btest_exit(self, filename, assert_returncode=0, *args, **kwargs):
     """Special case of `btest` that reports its result solely via exiting
@@ -2436,21 +2436,21 @@ class BrowserCore(RunnerCore):
 
   def btest(self, filename, expected=None,
             post_build=None,
-            emcc_args=None,
+            cflags=None,
             timeout=None,
             extra_tries=1,
             reporting=Reporting.FULL,
             output_basename='test'):
     assert expected, 'a btest must have an expected output'
-    if emcc_args is None:
-      emcc_args = []
-    emcc_args = emcc_args.copy()
+    if cflags is None:
+      cflags = []
+    cflags = cflags.copy()
     filename = find_browser_test_file(filename)
     outfile = output_basename + '.html'
-    emcc_args += ['-o', outfile]
-    # print('all args:', emcc_args)
+    cflags += ['-o', outfile]
+    # print('cflags:', cflags)
     utils.delete_file(outfile)
-    self.compile_btest(filename, emcc_args, reporting=reporting)
+    self.compile_btest(filename, cflags, reporting=reporting)
     self.assertExists(outfile)
     if post_build:
       post_build()

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -977,7 +977,7 @@ class benchmark(common.RunnerCore):
     self.do_benchmark('matrix_multiply', read_file(test_file('matrix_multiply.cpp')), 'Total elapsed:', output_parser=output_parser, shared_args=['-I' + test_file('benchmark')])
 
   def lua(self, benchmark, expected, output_parser=None, args_processor=None):
-    self.emcc_args.remove('-Werror')
+    self.cflags.remove('-Werror')
     shutil.copyfile(test_file(f'third_party/lua/{benchmark}.lua'), benchmark + '.lua')
 
     def lib_builder(name, native, env_init):
@@ -1002,7 +1002,7 @@ class benchmark(common.RunnerCore):
     self.lua('binarytrees', 'long lived tree of depth')
 
   def test_zzz_zlib(self):
-    self.emcc_args.remove('-Werror')
+    self.cflags.remove('-Werror')
     src = read_file(test_file('benchmark/test_zlib_benchmark.c'))
 
     def lib_builder(name, native, env_init):
@@ -1032,8 +1032,8 @@ class benchmark(common.RunnerCore):
     self.do_benchmark('box2d', src, 'frame averages', shared_args=['-I' + test_file('third_party/box2d')], lib_builder=lib_builder)
 
   def test_zzz_bullet(self):
-    self.emcc_args.remove('-Werror')
-    self.emcc_args += ['-Wno-c++11-narrowing', '-Wno-deprecated-register', '-Wno-writable-strings']
+    self.cflags.remove('-Werror')
+    self.cflags += ['-Wno-c++11-narrowing', '-Wno-deprecated-register', '-Wno-writable-strings']
     src = read_file(test_file('third_party/bullet/Demos/Benchmarks/BenchmarkDemo.cpp'))
     src += read_file(test_file('third_party/bullet/Demos/Benchmarks/main.cpp'))
 

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -86,7 +86,7 @@ def also_with_wasmfs(f):
       print('parameterize:wasmfs=%d' % wasmfs)
     if wasmfs:
       self.set_setting('WASMFS')
-      self.emcc_args = self.emcc_args.copy() + ['-DWASMFS']
+      self.cflags = self.cflags.copy() + ['-DWASMFS']
       f(self, *args, **kwargs)
     else:
       f(self, *args, **kwargs)
@@ -195,7 +195,7 @@ def also_with_threads(f):
   @wraps(f)
   def decorated(self, threads, *args, **kwargs):
     if threads:
-      self.emcc_args += ['-pthread']
+      self.cflags += ['-pthread']
     f(self, *args, **kwargs)
 
   parameterize(decorated, {'': (False,),
@@ -236,7 +236,7 @@ class browser(BrowserCore):
       print()
 
   def proxy_to_worker(self):
-    self.emcc_args += ['--proxy-to-worker', '-sGL_TESTING']
+    self.cflags += ['--proxy-to-worker', '-sGL_TESTING']
 
   def require_jspi(self):
     if not is_chrome():
@@ -278,14 +278,14 @@ window.close = () => {
     assert 'expected' not in kwargs
     expected = [str(i) for i in range(reference_slack + 1)]
     self.make_reftest(reference)
-    if '--proxy-to-worker' in self.emcc_args:
+    if '--proxy-to-worker' in self.cflags:
       assert 'post_build' not in kwargs
       kwargs['post_build'] = self.post_manual_reftest
       create_file('fakereftest.js', 'var reftestUnblock = () => {}; var reftestBlock = () => {};')
-      kwargs['emcc_args'] += ['--pre-js', 'fakereftest.js']
+      kwargs['cflags'] += ['--pre-js', 'fakereftest.js']
     else:
-      kwargs.setdefault('emcc_args', [])
-      kwargs['emcc_args'] += ['--pre-js', 'reftest.js', '-sGL_TESTING']
+      kwargs.setdefault('cflags', [])
+      kwargs['cflags'] += ['--pre-js', 'reftest.js', '-sGL_TESTING']
 
     try:
       return self.btest(filename, expected=expected, *args, **kwargs)
@@ -302,11 +302,11 @@ window.close = () => {
     self.reftest('hello_world_sdl.c', 'htmltest.png')
 
   def test_sdl1(self):
-    self.reftest('hello_world_sdl.c', 'htmltest.png', emcc_args=['-lSDL', '-lGL'])
-    self.reftest('hello_world_sdl.c', 'htmltest.png', emcc_args=['-sUSE_SDL', '-lGL']) # is the default anyhow
+    self.reftest('hello_world_sdl.c', 'htmltest.png', cflags=['-lSDL', '-lGL'])
+    self.reftest('hello_world_sdl.c', 'htmltest.png', cflags=['-sUSE_SDL', '-lGL']) # is the default anyhow
 
   def test_sdl1_es6(self):
-    self.reftest('hello_world_sdl.c', 'htmltest.png', emcc_args=['-sUSE_SDL', '-lGL', '-sEXPORT_ES6'])
+    self.reftest('hello_world_sdl.c', 'htmltest.png', cflags=['-sUSE_SDL', '-lGL', '-sEXPORT_ES6'])
 
   # Deliberately named as test_zzz_* to make this test the last one
   # as this test may take the focus away from the main test window
@@ -347,7 +347,7 @@ If manually bisecting:
 ''')
 
   def test_emscripten_log(self):
-    self.btest_exit('test_emscripten_log.cpp', emcc_args=['-Wno-deprecated-pragma', '-gsource-map'])
+    self.btest_exit('test_emscripten_log.cpp', cflags=['-Wno-deprecated-pragma', '-gsource-map'])
 
   @also_with_wasmfs
   def test_preload_file(self):
@@ -403,7 +403,7 @@ If manually bisecting:
     for srcpath, dstpath in test_cases:
       print('Testing', srcpath, dstpath)
       make_main(dstpath)
-      self.btest_exit('main.c', emcc_args=['--preload-file', srcpath])
+      self.btest_exit('main.c', cflags=['--preload-file', srcpath])
     if WINDOWS:
       # On Windows, the following non-alphanumeric non-control code ASCII characters are supported.
       # The characters <, >, ", |, ?, * are not allowed, because the Windows filesystem doesn't support those.
@@ -414,7 +414,7 @@ If manually bisecting:
     create_file(tricky_filename, 'load me right before running the code please')
     make_main(tricky_filename)
     # As an Emscripten-specific feature, the character '@' must be escaped in the form '@@' to not confuse with the 'src@dst' notation.
-    self.btest_exit('main.c', emcc_args=['--preload-file', tricky_filename.replace('@', '@@')])
+    self.btest_exit('main.c', cflags=['--preload-file', tricky_filename.replace('@', '@@')])
 
     # TODO: WASMFS doesn't support the rest of this test yet. Exit early.
     if self.get_setting('WASMFS'):
@@ -423,7 +423,7 @@ If manually bisecting:
     # By absolute path
 
     make_main('somefile.txt') # absolute becomes relative
-    self.btest_exit('main.c', emcc_args=['--preload-file', absolute_src_path])
+    self.btest_exit('main.c', cflags=['--preload-file', absolute_src_path])
 
     # Test subdirectory handling with asset packaging.
     delete_dir('assets')
@@ -476,7 +476,7 @@ If manually bisecting:
       (srcpath, dstpath1, dstpath2, nonexistingpath) = test
       make_main_two_files(dstpath1, dstpath2, nonexistingpath)
       print(srcpath)
-      self.btest_exit('main.c', emcc_args=['--preload-file', srcpath, '--exclude-file', '*/.*'])
+      self.btest_exit('main.c', cflags=['--preload-file', srcpath, '--exclude-file', '*/.*'])
 
     # Should still work with -o subdir/..
 
@@ -492,7 +492,7 @@ If manually bisecting:
       Module.preRun = () => FS.createPreloadedFile('/', 'someotherfile.txt', 'somefile.txt', true, false);
     ''')
     make_main('someotherfile.txt')
-    self.btest_exit('main.c', emcc_args=['--pre-js', 'pre.js', '--use-preload-plugins'])
+    self.btest_exit('main.c', cflags=['--pre-js', 'pre.js', '--use-preload-plugins'])
 
   # Tests that user .html shell files can manually download .data files created with --preload-file cmdline.
   @parameterized({
@@ -717,7 +717,7 @@ If manually bisecting:
     ''')
 
     # by individual files
-    self.btest_exit('main.c', emcc_args=['--preload-file', 'subdirr/data1.txt', '--preload-file', 'subdirr/moar/data2.txt'])
+    self.btest_exit('main.c', cflags=['--preload-file', 'subdirr/data1.txt', '--preload-file', 'subdirr/moar/data2.txt'])
 
     # by directory, and remove files to make sure
     self.set_setting('EXIT_RUNTIME')
@@ -838,11 +838,11 @@ If manually bisecting:
     self.btest_exit('fs/test_fs_dev_random.c')
 
   def test_sdl_swsurface(self):
-    self.btest_exit('test_sdl_swsurface.c', emcc_args=['-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_swsurface.c', cflags=['-lSDL', '-lGL'])
 
   def test_sdl_surface_lock_opts(self):
     # Test Emscripten-specific extensions to optimize SDL_LockSurface and SDL_UnlockSurface.
-    self.reftest('hello_world_sdl.c', 'htmltest.png', emcc_args=['-DTEST_SDL_LOCK_OPTS', '-lSDL', '-lGL'])
+    self.reftest('hello_world_sdl.c', 'htmltest.png', cflags=['-DTEST_SDL_LOCK_OPTS', '-lSDL', '-lGL'])
 
   @also_with_wasmfs
   def test_sdl_image(self):
@@ -851,7 +851,7 @@ If manually bisecting:
     src = test_file('browser/test_sdl_image.c')
     for dest, dirname, basename in [('screenshot.jpg', '/', 'screenshot.jpg'),
                                     ('screenshot.jpg@/assets/screenshot.jpg', '/assets', 'screenshot.jpg')]:
-      self.btest_exit(src, emcc_args=[
+      self.btest_exit(src, cflags=[
         '-O2', '-lSDL', '-lGL',
         '--preload-file', dest, '-DSCREENSHOT_DIRNAME="' + dirname + '"', '-DSCREENSHOT_BASENAME="' + basename + '"', '--use-preload-plugins',
       ])
@@ -859,7 +859,7 @@ If manually bisecting:
   @also_with_wasmfs
   def test_sdl_image_jpeg(self):
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.jpeg')
-    self.btest_exit('test_sdl_image.c', emcc_args=[
+    self.btest_exit('test_sdl_image.c', cflags=[
       '--preload-file', 'screenshot.jpeg',
       '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.jpeg"', '--use-preload-plugins',
       '-lSDL', '-lGL',
@@ -867,7 +867,7 @@ If manually bisecting:
 
   def test_sdl_image_webp(self):
     shutil.copy(test_file('screenshot.webp'), '.')
-    self.btest_exit('test_sdl_image.c', emcc_args=[
+    self.btest_exit('test_sdl_image.c', cflags=[
       '--preload-file', 'screenshot.webp',
       '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.webp"', '--use-preload-plugins',
       '-lSDL', '-lGL',
@@ -878,7 +878,7 @@ If manually bisecting:
   def test_sdl_image_prepare(self):
     # load an image file, get pixel data.
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.not')
-    self.reftest('test_sdl_image_prepare.c', 'screenshot.jpg', emcc_args=['--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
+    self.reftest('test_sdl_image_prepare.c', 'screenshot.jpg', cflags=['--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
   @parameterized({
     '': ([],),
@@ -890,46 +890,46 @@ If manually bisecting:
   def test_sdl_image_prepare_data(self, args):
     # load an image file, get pixel data.
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.not')
-    self.reftest('test_sdl_image_prepare_data.c', 'screenshot.jpg', emcc_args=['--preload-file', 'screenshot.not', '-lSDL', '-lGL'] + args)
+    self.reftest('test_sdl_image_prepare_data.c', 'screenshot.jpg', cflags=['--preload-file', 'screenshot.not', '-lSDL', '-lGL'] + args)
 
   def test_sdl_image_must_prepare(self):
     # load an image file, get pixel data.
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.jpg')
-    self.reftest('test_sdl_image_must_prepare.c', 'screenshot.jpg', emcc_args=['--preload-file', 'screenshot.jpg', '-lSDL', '-lGL'])
+    self.reftest('test_sdl_image_must_prepare.c', 'screenshot.jpg', cflags=['--preload-file', 'screenshot.jpg', '-lSDL', '-lGL'])
 
   def test_sdl_stb_image(self):
     # load an image file, get pixel data.
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.not')
-    self.reftest('test_sdl_stb_image.c', 'screenshot.jpg', emcc_args=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
+    self.reftest('test_sdl_stb_image.c', 'screenshot.jpg', cflags=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
   def test_sdl_stb_image_bpp(self):
     # load grayscale image without alpha
     shutil.copy(test_file('browser/test_sdl-stb-bpp1.png'), 'screenshot.not')
-    self.reftest('test_sdl_stb_image.c', 'test_sdl-stb-bpp1.png', emcc_args=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
+    self.reftest('test_sdl_stb_image.c', 'test_sdl-stb-bpp1.png', cflags=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
     # load grayscale image with alpha
     self.clear()
     shutil.copy(test_file('browser/test_sdl-stb-bpp2.png'), 'screenshot.not')
-    self.reftest('test_sdl_stb_image.c', 'test_sdl-stb-bpp2.png', emcc_args=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
+    self.reftest('test_sdl_stb_image.c', 'test_sdl-stb-bpp2.png', cflags=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
     # load RGB image
     self.clear()
     shutil.copy(test_file('browser/test_sdl-stb-bpp3.png'), 'screenshot.not')
-    self.reftest('test_sdl_stb_image.c', 'test_sdl-stb-bpp3.png', emcc_args=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
+    self.reftest('test_sdl_stb_image.c', 'test_sdl-stb-bpp3.png', cflags=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
     # load RGBA image
     self.clear()
     shutil.copy(test_file('browser/test_sdl-stb-bpp4.png'), 'screenshot.not')
-    self.reftest('test_sdl_stb_image.c', 'test_sdl-stb-bpp4.png', emcc_args=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
+    self.reftest('test_sdl_stb_image.c', 'test_sdl-stb-bpp4.png', cflags=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
   def test_sdl_stb_image_data(self):
     # load an image file, get pixel data.
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.not')
-    self.reftest('test_sdl_stb_image_data.c', 'screenshot.jpg', emcc_args=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
+    self.reftest('test_sdl_stb_image_data.c', 'screenshot.jpg', cflags=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
   def test_sdl_stb_image_cleanup(self):
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.not')
-    self.btest_exit('test_sdl_stb_image_cleanup.c', emcc_args=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL', '--memoryprofiler'])
+    self.btest_exit('test_sdl_stb_image_cleanup.c', cflags=['-sSTB_IMAGE', '--preload-file', 'screenshot.not', '-lSDL', '-lGL', '--memoryprofiler'])
 
   @parameterized({
     '': ([],),
@@ -937,12 +937,12 @@ If manually bisecting:
     'safe_heap_O2': (['-sSAFE_HEAP', '-O2'],),
   })
   def test_sdl_canvas(self, args):
-    self.btest_exit('test_sdl_canvas.c', emcc_args=['-sLEGACY_GL_EMULATION', '-lSDL', '-lGL'] + args)
+    self.btest_exit('test_sdl_canvas.c', cflags=['-sLEGACY_GL_EMULATION', '-lSDL', '-lGL'] + args)
 
   @proxied
   def test_sdl_canvas_proxy(self):
     create_file('data.txt', 'datum')
-    self.reftest('test_sdl_canvas_proxy.c', 'test_sdl_canvas_proxy.png', emcc_args=['--proxy-to-worker', '--preload-file', 'data.txt', '-lSDL', '-lGL'])
+    self.reftest('test_sdl_canvas_proxy.c', 'test_sdl_canvas_proxy.png', cflags=['--proxy-to-worker', '--preload-file', 'data.txt', '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_glgears_proxy_jstarget(self):
@@ -958,8 +958,8 @@ If manually bisecting:
     # See https://github.com/emscripten-core/emscripten/issues/4069.
     create_file('flag_0.js', "Module['arguments'] = ['-0'];")
 
-    self.reftest('test_sdl_canvas_alpha.c', 'test_sdl_canvas_alpha.png', emcc_args=['-lSDL', '-lGL'], reference_slack=12)
-    self.reftest('test_sdl_canvas_alpha.c', 'test_sdl_canvas_alpha_flag_0.png', emcc_args=['--pre-js', 'flag_0.js', '-lSDL', '-lGL'], reference_slack=12)
+    self.reftest('test_sdl_canvas_alpha.c', 'test_sdl_canvas_alpha.png', cflags=['-lSDL', '-lGL'], reference_slack=12)
+    self.reftest('test_sdl_canvas_alpha.c', 'test_sdl_canvas_alpha_flag_0.png', cflags=['--pre-js', 'flag_0.js', '-lSDL', '-lGL'], reference_slack=12)
 
   @parameterized({
     '': ([],),
@@ -993,7 +993,7 @@ If manually bisecting:
        %s
       }
     ''' % (settimeout_start, settimeout_end, settimeout_start, settimeout_end))
-    self.btest_exit('test_sdl_key.c', 223092870, emcc_args=defines + async_ + ['--pre-js', test_file('browser/fake_events.js'), '--pre-js=pre.js', '-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_key.c', 223092870, cflags=defines + async_ + ['--pre-js', test_file('browser/fake_events.js'), '--pre-js=pre.js', '-lSDL', '-lGL'])
 
   def test_sdl_key_proxy(self):
     shutil.copy(test_file('browser/fake_events.js'), '.')
@@ -1023,10 +1023,10 @@ simulateKeyDown(100);simulateKeyUp(100); // trigger the end
 </body>''')
       create_file('test.html', html)
 
-    self.btest_exit('test_sdl_key_proxy.c', 223092870, emcc_args=['--proxy-to-worker', '--pre-js', 'pre.js', '-lSDL', '-lGL', '-sRUNTIME_DEBUG'], post_build=post)
+    self.btest_exit('test_sdl_key_proxy.c', 223092870, cflags=['--proxy-to-worker', '--pre-js', 'pre.js', '-lSDL', '-lGL', '-sRUNTIME_DEBUG'], post_build=post)
 
   def test_canvas_focus(self):
-    self.btest_exit('test_canvas_focus.c', emcc_args=['--pre-js', test_file('browser/fake_events.js')])
+    self.btest_exit('test_canvas_focus.c', cflags=['--pre-js', test_file('browser/fake_events.js')])
 
   def test_keydown_preventdefault_proxy(self):
     def post():
@@ -1050,7 +1050,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
       create_file('test.html', html)
 
     shutil.copy(test_file('browser/fake_events.js'), '.')
-    self.btest_exit('browser/test_keydown_preventdefault_proxy.c', 300, emcc_args=['--proxy-to-worker'], post_build=post)
+    self.btest_exit('browser/test_keydown_preventdefault_proxy.c', 300, cflags=['--proxy-to-worker'], post_build=post)
 
   def test_sdl_text(self):
     create_file('pre.js', '''
@@ -1063,10 +1063,10 @@ simulateKeyUp(100, undefined, 'Numpad4');
       }
     ''')
 
-    self.btest_exit('test_sdl_text.c', emcc_args=['--pre-js', 'pre.js', '--pre-js', test_file('browser/fake_events.js'), '-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_text.c', cflags=['--pre-js', 'pre.js', '--pre-js', test_file('browser/fake_events.js'), '-lSDL', '-lGL'])
 
   def test_sdl_mouse(self):
-    self.btest_exit('test_sdl_mouse.c', emcc_args=['-O2', '--minify=0', '--pre-js', test_file('browser/fake_events.js'), '-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_mouse.c', cflags=['-O2', '--minify=0', '--pre-js', test_file('browser/fake_events.js'), '-lSDL', '-lGL'])
 
   def test_sdl_mouse_offsets(self):
     create_file('page.html', '''
@@ -1119,21 +1119,21 @@ simulateKeyUp(100, undefined, 'Numpad4');
     self.run_browser('page.html', '', '/report_result?exit:0')
 
   def test_glut_touchevents(self):
-    self.btest_exit('glut_touchevents.c', emcc_args=['-lglut'])
+    self.btest_exit('glut_touchevents.c', cflags=['-lglut'])
 
   def test_glut_wheelevents(self):
-    self.btest_exit('glut_wheelevents.c', emcc_args=['-lglut'])
+    self.btest_exit('glut_wheelevents.c', cflags=['-lglut'])
 
   @requires_graphics_hardware
   def test_glut_glutget_no_antialias(self):
-    self.btest_exit('glut_glutget.c', emcc_args=['-lglut', '-lGL'])
-    self.btest_exit('glut_glutget.c', emcc_args=['-lglut', '-lGL', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED'])
+    self.btest_exit('glut_glutget.c', cflags=['-lglut', '-lGL'])
+    self.btest_exit('glut_glutget.c', cflags=['-lglut', '-lGL', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED'])
 
   # This test supersedes the one above, but it's skipped in the CI because anti-aliasing is not well supported by the Mesa software renderer.
   @requires_graphics_hardware
   def test_glut_glutget(self):
-    self.btest_exit('glut_glutget.c', emcc_args=['-lglut', '-lGL'])
-    self.btest_exit('glut_glutget.c', emcc_args=['-lglut', '-lGL', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED'])
+    self.btest_exit('glut_glutget.c', cflags=['-lglut', '-lGL'])
+    self.btest_exit('glut_glutget.c', cflags=['-lglut', '-lGL', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED'])
 
   def test_sdl_joystick_1(self):
     # Generates events corresponding to the Working Draft of the HTML5 Gamepad API.
@@ -1165,7 +1165,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
       };
     ''')
 
-    self.btest_exit('test_sdl_joystick.c', emcc_args=['-O2', '--minify=0', '-o', 'page.html', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_joystick.c', cflags=['-O2', '--minify=0', '-o', 'page.html', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
 
   def test_sdl_joystick_2(self):
     # Generates events corresponding to the Editor's Draft of the HTML5 Gamepad API.
@@ -1201,7 +1201,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
       };
     ''')
 
-    self.btest_exit('test_sdl_joystick.c', emcc_args=['-O2', '--minify=0', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_joystick.c', cflags=['-O2', '--minify=0', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_glfw_joystick(self):
@@ -1244,7 +1244,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
       };
     ''')
 
-    self.btest_exit('test_glfw_joystick.c', emcc_args=['-O2', '--minify=0', '-o', 'page.html', '--pre-js', 'pre.js', '-lGL', '-lglfw3', '-sUSE_GLFW=3'])
+    self.btest_exit('test_glfw_joystick.c', cflags=['-O2', '--minify=0', '-o', 'page.html', '--pre-js', 'pre.js', '-lGL', '-lglfw3', '-sUSE_GLFW=3'])
 
   @requires_graphics_hardware
   def test_webgl_context_attributes(self):
@@ -1289,16 +1289,16 @@ simulateKeyUp(100, undefined, 'Numpad4');
     self.set_setting('STACK_SIZE', '1MB')
 
     # perform tests with attributes activated
-    self.btest_exit('test_webgl_context_attributes_glut.c', emcc_args=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED', '-lGL', '-lglut', '-lGLEW'])
-    self.btest_exit('test_webgl_context_attributes_sdl.c', emcc_args=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED', '-lGL', '-lSDL', '-lGLEW'])
+    self.btest_exit('test_webgl_context_attributes_glut.c', cflags=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED', '-lGL', '-lglut', '-lGLEW'])
+    self.btest_exit('test_webgl_context_attributes_sdl.c', cflags=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED', '-lGL', '-lSDL', '-lGLEW'])
     if not self.is_wasm64():
-      self.btest_exit('test_webgl_context_attributes_sdl2.c', emcc_args=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED', '-lGL', '-sUSE_SDL=2', '-lGLEW', '-sGL_ENABLE_GET_PROC_ADDRESS=1'])
-    self.btest_exit('test_webgl_context_attributes_glfw.c', emcc_args=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED', '-lGL', '-lglfw', '-lGLEW'])
+      self.btest_exit('test_webgl_context_attributes_sdl2.c', cflags=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED', '-lGL', '-sUSE_SDL=2', '-lGLEW', '-sGL_ENABLE_GET_PROC_ADDRESS=1'])
+    self.btest_exit('test_webgl_context_attributes_glfw.c', cflags=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED', '-lGL', '-lglfw', '-lGLEW'])
 
     # perform tests with attributes desactivated
-    self.btest_exit('test_webgl_context_attributes_glut.c', emcc_args=['--js-library', 'check_webgl_attributes_support.js', '-lGL', '-lglut', '-lGLEW'])
-    self.btest_exit('test_webgl_context_attributes_sdl.c', emcc_args=['--js-library', 'check_webgl_attributes_support.js', '-lGL', '-lSDL', '-lGLEW'])
-    self.btest_exit('test_webgl_context_attributes_glfw.c', emcc_args=['--js-library', 'check_webgl_attributes_support.js', '-lGL', '-lglfw', '-lGLEW'])
+    self.btest_exit('test_webgl_context_attributes_glut.c', cflags=['--js-library', 'check_webgl_attributes_support.js', '-lGL', '-lglut', '-lGLEW'])
+    self.btest_exit('test_webgl_context_attributes_sdl.c', cflags=['--js-library', 'check_webgl_attributes_support.js', '-lGL', '-lSDL', '-lGLEW'])
+    self.btest_exit('test_webgl_context_attributes_glfw.c', cflags=['--js-library', 'check_webgl_attributes_support.js', '-lGL', '-lglfw', '-lGLEW'])
 
   @requires_graphics_hardware
   def test_webgl_no_double_error(self):
@@ -1310,20 +1310,20 @@ simulateKeyUp(100, undefined, 'Numpad4');
 
   @requires_graphics_hardware
   def test_webgl_explicit_uniform_location(self):
-    self.btest_exit('webgl_explicit_uniform_location.c', emcc_args=['-sGL_EXPLICIT_UNIFORM_LOCATION', '-sMIN_WEBGL_VERSION=2'])
+    self.btest_exit('webgl_explicit_uniform_location.c', cflags=['-sGL_EXPLICIT_UNIFORM_LOCATION', '-sMIN_WEBGL_VERSION=2'])
 
   @requires_graphics_hardware
   def test_webgl_sampler_layout_binding(self):
-    self.btest_exit('webgl_sampler_layout_binding.c', emcc_args=['-sGL_EXPLICIT_UNIFORM_BINDING'])
+    self.btest_exit('webgl_sampler_layout_binding.c', cflags=['-sGL_EXPLICIT_UNIFORM_BINDING'])
 
   @requires_graphics_hardware
   def test_webgl2_ubo_layout_binding(self):
-    self.btest_exit('webgl2_ubo_layout_binding.c', emcc_args=['-sGL_EXPLICIT_UNIFORM_BINDING', '-sMIN_WEBGL_VERSION=2'])
+    self.btest_exit('webgl2_ubo_layout_binding.c', cflags=['-sGL_EXPLICIT_UNIFORM_BINDING', '-sMIN_WEBGL_VERSION=2'])
 
   # Test that -sGL_PREINITIALIZED_CONTEXT works and allows user to set Module['preinitializedWebGLContext'] to a preinitialized WebGL context.
   @requires_graphics_hardware
   def test_preinitialized_webgl_context(self):
-    self.btest_exit('test_preinitialized_webgl_context.c', emcc_args=['-sGL_PREINITIALIZED_CONTEXT', '--shell-file', test_file('test_preinitialized_webgl_context.html')])
+    self.btest_exit('test_preinitialized_webgl_context.c', cflags=['-sGL_PREINITIALIZED_CONTEXT', '--shell-file', test_file('test_preinitialized_webgl_context.html')])
 
   @parameterized({
     '': ([],),
@@ -1331,13 +1331,13 @@ simulateKeyUp(100, undefined, 'Numpad4');
     'closure': (['-sENVIRONMENT=web', '-O2', '--closure=1'],),
   })
   def test_emscripten_get_now(self, args):
-    self.btest_exit('test_emscripten_get_now.c', emcc_args=args)
+    self.btest_exit('test_emscripten_get_now.c', cflags=args)
 
   def test_write_file_in_environment_web(self):
-    self.btest_exit('write_file.c', emcc_args=['-sENVIRONMENT=web', '-Os', '--closure=1'])
+    self.btest_exit('write_file.c', cflags=['-sENVIRONMENT=web', '-Os', '--closure=1'])
 
   def test_fflush(self):
-    self.btest('test_fflush.cpp', '0', emcc_args=['-sEXIT_RUNTIME', '--shell-file', test_file('test_fflush.html')], reporting=Reporting.NONE)
+    self.btest('test_fflush.cpp', '0', cflags=['-sEXIT_RUNTIME', '--shell-file', test_file('test_fflush.html')], reporting=Reporting.NONE)
 
   @parameterized({
     '': ([],),
@@ -1348,8 +1348,8 @@ simulateKeyUp(100, undefined, 'Numpad4');
   def test_fs_idbfs_sync(self, args):
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$ccall')
     secret = str(time.time())
-    self.btest('fs/test_idbfs_sync.c', '1', emcc_args=['-lidbfs.js', f'-DSECRET="{secret}"', '-sEXPORTED_FUNCTIONS=_main,_test,_report_result', '-lidbfs.js'] + args + ['-DFIRST'])
-    self.btest('fs/test_idbfs_sync.c', '1', emcc_args=['-lidbfs.js', f'-DSECRET="{secret}"', '-sEXPORTED_FUNCTIONS=_main,_test,_report_result', '-lidbfs.js'] + args)
+    self.btest('fs/test_idbfs_sync.c', '1', cflags=['-lidbfs.js', f'-DSECRET="{secret}"', '-sEXPORTED_FUNCTIONS=_main,_test,_report_result', '-lidbfs.js'] + args + ['-DFIRST'])
+    self.btest('fs/test_idbfs_sync.c', '1', cflags=['-lidbfs.js', f'-DSECRET="{secret}"', '-sEXPORTED_FUNCTIONS=_main,_test,_report_result', '-lidbfs.js'] + args)
 
   def test_fs_idbfs_fsync(self):
     # sync from persisted state into memory before main()
@@ -1369,13 +1369,13 @@ simulateKeyUp(100, undefined, 'Numpad4');
 
     args = ['--pre-js', 'pre.js', '-lidbfs.js', '-sEXIT_RUNTIME', '-sASYNCIFY']
     secret = str(time.time())
-    self.btest('fs/test_idbfs_fsync.c', '1', emcc_args=args + ['-DFIRST', f'-DSECRET="{secret}"', '-lidbfs.js'])
-    self.btest('fs/test_idbfs_fsync.c', '1', emcc_args=args + [f'-DSECRET="{secret}"', '-lidbfs.js'])
+    self.btest('fs/test_idbfs_fsync.c', '1', cflags=args + ['-DFIRST', f'-DSECRET="{secret}"', '-lidbfs.js'])
+    self.btest('fs/test_idbfs_fsync.c', '1', cflags=args + [f'-DSECRET="{secret}"', '-lidbfs.js'])
 
   def test_fs_memfs_fsync(self):
     args = ['-sASYNCIFY', '-sEXIT_RUNTIME']
     secret = str(time.time())
-    self.btest_exit('fs/test_memfs_fsync.c', emcc_args=args + [f'-DSECRET="{secret}"'])
+    self.btest_exit('fs/test_memfs_fsync.c', cflags=args + [f'-DSECRET="{secret}"'])
 
   def test_fs_workerfs_read(self):
     secret = 'a' * 10
@@ -1391,7 +1391,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
         }, '/work');
       };
     ''' % (secret, secret2))
-    self.btest_exit('fs/test_workerfs_read.c', emcc_args=['-lworkerfs.js', '--pre-js', 'pre.js', f'-DSECRET="{secret}"', f'-DSECRET2="{secret2}"', '--proxy-to-worker', '-lworkerfs.js'])
+    self.btest_exit('fs/test_workerfs_read.c', cflags=['-lworkerfs.js', '--pre-js', 'pre.js', f'-DSECRET="{secret}"', f'-DSECRET2="{secret2}"', '--proxy-to-worker', '-lworkerfs.js'])
 
   def test_fs_workerfs_package(self):
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$ccall')
@@ -1399,7 +1399,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
     ensure_dir('sub')
     create_file('sub/file2.txt', 'second')
     self.run_process([FILE_PACKAGER, 'files.data', '--preload', 'file1.txt', 'sub/file2.txt', '--separate-metadata', '--js-output=files.js'])
-    self.btest(Path('fs/test_workerfs_package.cpp'), '1', emcc_args=['-lworkerfs.js', '--proxy-to-worker', '-lworkerfs.js'])
+    self.btest(Path('fs/test_workerfs_package.cpp'), '1', cflags=['-lworkerfs.js', '--proxy-to-worker', '-lworkerfs.js'])
 
   def test_fs_lz4fs_package(self):
     # generate data
@@ -1413,19 +1413,19 @@ simulateKeyUp(100, undefined, 'Numpad4');
     # compress in emcc, -sLZ4 tells it to tell the file packager
     print('emcc-normal')
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$ccall')
-    self.btest_exit(Path('fs/test_lz4fs.cpp'), 2, emcc_args=['-sLZ4', '--preload-file', 'file1.txt', '--preload-file', 'subdir/file2.txt', '--preload-file', 'file3.txt'])
+    self.btest_exit(Path('fs/test_lz4fs.cpp'), 2, cflags=['-sLZ4', '--preload-file', 'file1.txt', '--preload-file', 'subdir/file2.txt', '--preload-file', 'file3.txt'])
     assert os.path.getsize('file1.txt') + os.path.getsize('subdir/file2.txt') + os.path.getsize('file3.txt') == 3 * 1024 * 128 * 10 + 1
     assert os.path.getsize('test.data') < (3 * 1024 * 128 * 10) / 2  # over half is gone
     print('    emcc-opts')
-    self.btest_exit(Path('fs/test_lz4fs.cpp'), 2, emcc_args=['-sLZ4', '--preload-file', 'file1.txt', '--preload-file', 'subdir/file2.txt', '--preload-file', 'file3.txt', '-O2'])
+    self.btest_exit(Path('fs/test_lz4fs.cpp'), 2, cflags=['-sLZ4', '--preload-file', 'file1.txt', '--preload-file', 'subdir/file2.txt', '--preload-file', 'file3.txt', '-O2'])
 
     # compress in the file packager, on the server. the client receives compressed data and can just use it. this is typical usage
     print('normal')
     out = subprocess.check_output([FILE_PACKAGER, 'files.data', '--preload', 'file1.txt', 'subdir/file2.txt', 'file3.txt', '--lz4'])
     create_file('files.js', out, binary=True)
-    self.btest_exit('fs/test_lz4fs.cpp', 2, emcc_args=['--pre-js', 'files.js', '-sLZ4', '-sFORCE_FILESYSTEM'])
+    self.btest_exit('fs/test_lz4fs.cpp', 2, cflags=['--pre-js', 'files.js', '-sLZ4', '-sFORCE_FILESYSTEM'])
     print('    opts')
-    self.btest_exit('fs/test_lz4fs.cpp', 2, emcc_args=['--pre-js', 'files.js', '-sLZ4', '-sFORCE_FILESYSTEM', '-O2'])
+    self.btest_exit('fs/test_lz4fs.cpp', 2, cflags=['--pre-js', 'files.js', '-sLZ4', '-sFORCE_FILESYSTEM', '-O2'])
     print('    modularize')
     self.compile_btest('fs/test_lz4fs.cpp', ['--pre-js', 'files.js', '-sLZ4', '-sFORCE_FILESYSTEM', '-sMODULARIZE', '-sEXIT_RUNTIME'])
     create_file('a.html', '''
@@ -1439,11 +1439,11 @@ simulateKeyUp(100, undefined, 'Numpad4');
     # load the data into LZ4FS manually at runtime. This means we compress on the client. This is generally not recommended
     print('manual')
     subprocess.check_output([FILE_PACKAGER, 'files.data', '--preload', 'file1.txt', 'subdir/file2.txt', 'file3.txt', '--separate-metadata', '--js-output=files.js'])
-    self.btest_exit('fs/test_lz4fs.cpp', 1, emcc_args=['-DLOAD_MANUALLY', '-sLZ4', '-sFORCE_FILESYSTEM'])
+    self.btest_exit('fs/test_lz4fs.cpp', 1, cflags=['-DLOAD_MANUALLY', '-sLZ4', '-sFORCE_FILESYSTEM'])
     print('    opts')
-    self.btest_exit('fs/test_lz4fs.cpp', 1, emcc_args=['-DLOAD_MANUALLY', '-sLZ4', '-sFORCE_FILESYSTEM', '-O2'])
+    self.btest_exit('fs/test_lz4fs.cpp', 1, cflags=['-DLOAD_MANUALLY', '-sLZ4', '-sFORCE_FILESYSTEM', '-O2'])
     print('    opts+closure')
-    self.btest_exit('fs/test_lz4fs.cpp', 1, emcc_args=['-DLOAD_MANUALLY', '-sLZ4',
+    self.btest_exit('fs/test_lz4fs.cpp', 1, cflags=['-DLOAD_MANUALLY', '-sLZ4',
                                                        '-sFORCE_FILESYSTEM', '-O2',
                                                        '--closure=1', '-g1', '-Wno-closure'])
 
@@ -1457,7 +1457,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
     shutil.copy('file3.txt', 'files/'))
     out = subprocess.check_output([FILE_PACKAGER, 'files.data', '--preload', 'files/file1.txt', 'files/file2.txt', 'files/file3.txt'])
     create_file('files.js', out, binary=True)
-    self.btest_exit('fs/test_lz4fs.cpp', 2, emcc_args=['--pre-js', 'files.js'])'''
+    self.btest_exit('fs/test_lz4fs.cpp', 2, cflags=['--pre-js', 'files.js'])'''
 
   def test_separate_metadata_later(self):
     # see issue #6654 - we need to handle separate-metadata both when we run before
@@ -1465,14 +1465,14 @@ simulateKeyUp(100, undefined, 'Numpad4');
 
     create_file('data.dat', ' ')
     self.run_process([FILE_PACKAGER, 'more.data', '--preload', 'data.dat', '--separate-metadata', '--js-output=more.js'])
-    self.btest(Path('browser/separate_metadata_later.cpp'), '1', emcc_args=['-sFORCE_FILESYSTEM'])
+    self.btest(Path('browser/separate_metadata_later.cpp'), '1', cflags=['-sFORCE_FILESYSTEM'])
 
   def test_idbstore(self):
     secret = str(time.time())
     for stage in (0, 1, 2, 3, 0, 1, 2, 0, 0, 1, 4, 2, 5, 0, 4, 6, 5):
       print(stage)
       self.btest_exit('test_idbstore.c',
-                      emcc_args=['-lidbstore.js', f'-DSTAGE={stage}', f'-DSECRET="{secret}"'],
+                      cflags=['-lidbstore.js', f'-DSTAGE={stage}', f'-DSECRET="{secret}"'],
                       output_basename=f'idbstore_{stage}')
 
   @parameterized({
@@ -1483,97 +1483,97 @@ simulateKeyUp(100, undefined, 'Numpad4');
     if asyncify == 2:
       self.require_jspi()
     secret = str(time.time())
-    self.btest('test_idbstore_sync.c', '8', emcc_args=['-sSTRICT', '-lidbstore.js', f'-DSECRET="{secret}"', '-O3', '--closure=1', f'-sASYNCIFY={asyncify}'])
+    self.btest('test_idbstore_sync.c', '8', cflags=['-sSTRICT', '-lidbstore.js', f'-DSECRET="{secret}"', '-O3', '--closure=1', f'-sASYNCIFY={asyncify}'])
 
   def test_idbstore_sync_worker(self):
     secret = str(time.time())
-    self.btest('test_idbstore_sync_worker.c', expected='0', emcc_args=['-lidbstore.js', f'-DSECRET="{secret}"', '-O3', '-g2', '--proxy-to-worker', '-sASYNCIFY'])
+    self.btest('test_idbstore_sync_worker.c', expected='0', cflags=['-lidbstore.js', f'-DSECRET="{secret}"', '-O3', '-g2', '--proxy-to-worker', '-sASYNCIFY'])
 
   def test_force_exit(self):
     self.btest_exit('test_force_exit.c')
 
   def test_sdl_pumpevents(self):
     # key events should be detected using SDL_PumpEvents
-    self.btest_exit('test_sdl_pumpevents.c', emcc_args=['--pre-js', test_file('browser/fake_events.js'), '-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_pumpevents.c', cflags=['--pre-js', test_file('browser/fake_events.js'), '-lSDL', '-lGL'])
 
   def test_sdl_canvas_size(self):
     self.btest_exit('test_sdl_canvas_size.c',
-                    emcc_args=['-O2', '--minify=0', '--shell-file',
+                    cflags=['-O2', '--minify=0', '--shell-file',
                                test_file('browser/test_sdl_canvas_size.html'), '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_gl_extensions(self):
-    self.btest_exit('test_sdl_gl_extensions.c', emcc_args=['-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_gl_extensions.c', cflags=['-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_gl_read(self):
     # SDL, OpenGL, readPixels
-    self.btest_exit('test_sdl_gl_read.c', emcc_args=['-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_gl_read.c', cflags=['-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_gl_mapbuffers(self):
-    self.btest_exit('test_sdl_gl_mapbuffers.c', emcc_args=['-sFULL_ES3', '-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_gl_mapbuffers.c', cflags=['-sFULL_ES3', '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_ogl(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl_ogl.c', 'screenshot-gray-purple.png', reference_slack=1,
-                 emcc_args=['-O2', '--minify=0', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
+                 cflags=['-O2', '--minify=0', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_ogl_regal(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl_ogl.c', 'screenshot-gray-purple.png', reference_slack=1,
-                 emcc_args=['-O2', '--minify=0', '--preload-file', 'screenshot.png', '-sUSE_REGAL', '-DUSE_REGAL', '--use-preload-plugins', '-lSDL', '-lGL', '-lc++', '-lc++abi'])
+                 cflags=['-O2', '--minify=0', '--preload-file', 'screenshot.png', '-sUSE_REGAL', '-DUSE_REGAL', '--use-preload-plugins', '-lSDL', '-lGL', '-lc++', '-lc++abi'])
 
   @requires_graphics_hardware
   def test_sdl_ogl_defaultmatrixmode(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl_ogl_defaultMatrixMode.c', 'screenshot-gray-purple.png', reference_slack=1,
-                 emcc_args=['--minify=0', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
+                 cflags=['--minify=0', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_ogl_p(self):
     # Immediate mode with pointers
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl_ogl_p.c', 'screenshot-gray.png', reference_slack=1,
-                 emcc_args=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
+                 cflags=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_ogl_proc_alias(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl_ogl_proc_alias.c', 'screenshot-gray-purple.png', reference_slack=1,
-                 emcc_args=['-O2', '-g2', '-sINLINING_LIMIT', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '-sGL_ENABLE_GET_PROC_ADDRESS', '--use-preload-plugins', '-lSDL', '-lGL'])
+                 cflags=['-O2', '-g2', '-sINLINING_LIMIT', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '-sGL_ENABLE_GET_PROC_ADDRESS', '--use-preload-plugins', '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_fog_simple(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl_fog_simple.c', 'screenshot-fog-simple.png',
-                 emcc_args=['-O2', '--minify=0', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
+                 cflags=['-O2', '--minify=0', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_fog_negative(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl_fog_negative.c', 'screenshot-fog-negative.png',
-                 emcc_args=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
+                 cflags=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_fog_density(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl_fog_density.c', 'screenshot-fog-density.png',
-                 emcc_args=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
+                 cflags=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_fog_exp2(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl_fog_exp2.c', 'screenshot-fog-exp2.png',
-                 emcc_args=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
+                 cflags=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_fog_linear(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl_fog_linear.c', 'screenshot-fog-linear.png', reference_slack=1,
-                 emcc_args=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
+                 cflags=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins', '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   @parameterized({
@@ -1582,17 +1582,17 @@ simulateKeyUp(100, undefined, 'Numpad4');
     'both_flags': (['-sUSE_GLFW=2', '-lglfw'],),
   })
   def test_glfw(self, args):
-    self.btest_exit('test_glfw.c', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-sGL_ENABLE_GET_PROC_ADDRESS'] + args)
+    self.btest_exit('test_glfw.c', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-sGL_ENABLE_GET_PROC_ADDRESS'] + args)
 
   @parameterized({
     '': ([],),
     's_flag': (['-sUSE_GLFW=2'],),
   })
   def test_glfw_minimal(self, args):
-    self.btest_exit('test_glfw_minimal.c', emcc_args=['-lglfw', '-lGL'] + args)
+    self.btest_exit('test_glfw_minimal.c', cflags=['-lglfw', '-lGL'] + args)
 
   def test_glfw_time(self):
-    self.btest_exit('test_glfw_time.c', emcc_args=['-sUSE_GLFW=3', '-lglfw', '-lGL'])
+    self.btest_exit('test_glfw_time.c', cflags=['-sUSE_GLFW=3', '-lglfw', '-lGL'])
 
   @parameterized({
     '': ([],),
@@ -1600,18 +1600,18 @@ simulateKeyUp(100, undefined, 'Numpad4');
   })
   @requires_graphics_hardware
   def test_egl(self, args):
-    self.btest_exit('test_egl.c', emcc_args=['-O2', '-lEGL', '-lGL', '-sGL_ENABLE_GET_PROC_ADDRESS'] + args)
+    self.btest_exit('test_egl.c', cflags=['-O2', '-lEGL', '-lGL', '-sGL_ENABLE_GET_PROC_ADDRESS'] + args)
 
   @parameterized({
     '': ([],),
     'proxy_to_pthread': (['-pthread', '-sPROXY_TO_PTHREAD'],),
   })
   def test_egl_width_height(self, args):
-    self.btest_exit('test_egl_width_height.c', emcc_args=['-O2', '-lEGL', '-lGL'] + args)
+    self.btest_exit('test_egl_width_height.c', cflags=['-O2', '-lEGL', '-lGL'] + args)
 
   @requires_graphics_hardware
   def test_egl_createcontext_error(self):
-    self.btest_exit('test_egl_createcontext_error.c', emcc_args=['-lEGL', '-lGL'])
+    self.btest_exit('test_egl_createcontext_error.c', cflags=['-lEGL', '-lGL'])
 
   @parameterized({
     '': ([False],),
@@ -1635,7 +1635,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
       </html>
     ''' % self.PORT)
 
-    cmd = [EMCC, test_file('hello_world_worker.c'), '-o', 'worker.js'] + self.get_emcc_args()
+    cmd = [EMCC, test_file('hello_world_worker.c'), '-o', 'worker.js'] + self.get_cflags()
     if file_data:
       cmd += ['--preload-file', 'file.dat']
     self.run_process(cmd)
@@ -1656,7 +1656,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
         FS.createLazyFile('/', "lazy.txt", "lazydata.dat", true, false);
       }
     ''')
-    self.emcc_args += ['--pre-js=pre.js', '--proxy-to-worker']
+    self.cflags += ['--pre-js=pre.js', '--proxy-to-worker']
     self.btest_exit('test_mmap_lazyfile.c')
 
   @no_wasmfs('https://github.com/emscripten-core/emscripten/issues/19608')
@@ -1739,7 +1739,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
   @requires_graphics_hardware
   def test_glgears(self, extra_args=[]):  # noqa
     self.reftest('hello_world_gles.c', 'gears.png', reference_slack=3,
-                 emcc_args=['-DHAVE_BUILTIN_SINCOS', '-lGL', '-lglut'] + extra_args)
+                 cflags=['-DHAVE_BUILTIN_SINCOS', '-lGL', '-lglut'] + extra_args)
 
   @requires_graphics_hardware
   def test_glgears_pthreads(self, extra_args=[]):  # noqa
@@ -1755,7 +1755,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
   })
   def test_glgears_long(self, args):
     args += ['-DHAVE_BUILTIN_SINCOS', '-DLONGTEST', '-lGL', '-lglut', '-DANIMATE']
-    self.btest('hello_world_gles.c', expected='0', emcc_args=args)
+    self.btest('hello_world_gles.c', expected='0', cflags=args)
 
   @requires_graphics_hardware
   @parameterized({
@@ -1775,18 +1775,18 @@ simulateKeyUp(100, undefined, 'Numpad4');
 
   @requires_graphics_hardware
   def test_fulles2_sdlproc(self):
-    self.btest_exit('full_es2_sdlproc.c', emcc_args=['-sGL_TESTING', '-DHAVE_BUILTIN_SINCOS', '-sFULL_ES2', '-lGL', '-lSDL', '-lglut', '-sGL_ENABLE_GET_PROC_ADDRESS', '-Wno-int-conversion'])
+    self.btest_exit('full_es2_sdlproc.c', cflags=['-sGL_TESTING', '-DHAVE_BUILTIN_SINCOS', '-sFULL_ES2', '-lGL', '-lSDL', '-lglut', '-sGL_ENABLE_GET_PROC_ADDRESS', '-Wno-int-conversion'])
 
   @requires_graphics_hardware
   def test_glgears_deriv(self):
     self.reftest('hello_world_gles_deriv.c', 'gears.png', reference_slack=2,
-                 emcc_args=['-DHAVE_BUILTIN_SINCOS', '-lGL', '-lglut'])
+                 cflags=['-DHAVE_BUILTIN_SINCOS', '-lGL', '-lglut'])
     assert 'gl-matrix' not in read_file('test.html'), 'Should not include glMatrix when not needed'
 
   @requires_graphics_hardware
   def test_glbook(self):
-    self.emcc_args.append('-Wno-int-conversion')
-    self.emcc_args.append('-Wno-pointer-sign')
+    self.cflags.append('-Wno-int-conversion')
+    self.cflags.append('-Wno-pointer-sign')
     programs = self.get_library('third_party/glbook', [
       'Chapter_2/Hello_Triangle/CH02_HelloTriangle.o',
       'Chapter_8/Simple_VertexShader/CH08_SimpleVertexShader.o',
@@ -1812,7 +1812,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
         shutil.copy(book_path('Chapter_13/ParticleSystem/smoke.tga'), '.')
         args += ['--preload-file', 'smoke.tga', '-O2'] # test optimizations and closure here as well for more coverage
 
-      self.reftest(program, book_path(basename.replace('.o', '.png')), emcc_args=args)
+      self.reftest(program, book_path(basename.replace('.o', '.png')), cflags=args)
 
   @requires_graphics_hardware
   @parameterized({
@@ -1836,7 +1836,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
     ]:
       print(source)
       self.reftest(source, reference,
-                   emcc_args=['-I' + test_file('third_party/glbook/Common'),
+                   cflags=['-I' + test_file('third_party/glbook/Common'),
                               test_file('third_party/glbook/Common/esUtil.c'),
                               test_file('third_party/glbook/Common/esShader.c'),
                               test_file('third_party/glbook/Common/esShapes.c'),
@@ -1846,10 +1846,10 @@ simulateKeyUp(100, undefined, 'Numpad4');
 
   @requires_graphics_hardware
   def test_clientside_vertex_arrays_es3(self):
-    self.reftest('clientside_vertex_arrays_es3.c', 'gl_triangle.png', emcc_args=['-sFULL_ES3', '-sUSE_GLFW=3', '-lglfw', '-lGLESv2'])
+    self.reftest('clientside_vertex_arrays_es3.c', 'gl_triangle.png', cflags=['-sFULL_ES3', '-sUSE_GLFW=3', '-lglfw', '-lGLESv2'])
 
   def test_emscripten_api(self):
-    self.btest_exit('emscripten_api_browser.c', emcc_args=['-lSDL'])
+    self.btest_exit('emscripten_api_browser.c', cflags=['-lSDL'])
 
   @also_with_wasmfs
   def test_emscripten_async_load_script(self):
@@ -1862,7 +1862,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
 
     setup()
     self.run_process([FILE_PACKAGER, 'test.data', '--preload', 'file1.txt', 'file2.txt'], stdout=open('script2.js', 'w'))
-    self.btest_exit('test_emscripten_async_load_script.c', emcc_args=['-sFORCE_FILESYSTEM'])
+    self.btest_exit('test_emscripten_async_load_script.c', cflags=['-sFORCE_FILESYSTEM'])
 
     # check using file packager to another dir
     self.clear()
@@ -1870,7 +1870,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
     ensure_dir('sub')
     self.run_process([FILE_PACKAGER, 'sub/test.data', '--preload', 'file1.txt', 'file2.txt'], stdout=open('script2.js', 'w'))
     shutil.copy(Path('sub/test.data'), '.')
-    self.btest_exit('test_emscripten_async_load_script.c', emcc_args=['-sFORCE_FILESYSTEM'])
+    self.btest_exit('test_emscripten_async_load_script.c', cflags=['-sFORCE_FILESYSTEM'])
 
   @also_with_wasmfs
   def test_emscripten_overlapped_package(self):
@@ -1885,7 +1885,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
     setup()
     self.run_process([FILE_PACKAGER, 'test.data', '--preload', 'sub/file1.txt@/target/file1.txt'], stdout=open('script1.js', 'w'))
     self.run_process([FILE_PACKAGER, 'test2.data', '--preload', 'sub/file2.txt@/target/file2.txt'], stdout=open('script2.js', 'w'))
-    self.btest_exit('test_emscripten_overlapped_package.c', emcc_args=['-sFORCE_FILESYSTEM'])
+    self.btest_exit('test_emscripten_overlapped_package.c', cflags=['-sFORCE_FILESYSTEM'])
     self.clear()
 
   def test_emscripten_api_infloop(self):
@@ -1896,7 +1896,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
     'pthreads': (['-pthread', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'],),
   })
   def test_emscripten_main_loop(self, args):
-    self.btest_exit('test_emscripten_main_loop.c', emcc_args=args)
+    self.btest_exit('test_emscripten_main_loop.c', cflags=args)
 
   @parameterized({
     '': ([],),
@@ -1904,14 +1904,14 @@ simulateKeyUp(100, undefined, 'Numpad4');
     'pthreads': (['-pthread', '-sPROXY_TO_PTHREAD', '-sAUTO_JS_LIBRARIES=0'],),
   })
   def test_emscripten_main_loop_settimeout(self, args):
-    self.btest_exit('test_emscripten_main_loop_settimeout.c', emcc_args=args)
+    self.btest_exit('test_emscripten_main_loop_settimeout.c', cflags=args)
 
   @parameterized({
     '': ([],),
     'pthreads': (['-pthread', '-sPROXY_TO_PTHREAD'],),
   })
   def test_emscripten_main_loop_and_blocker(self, args):
-    self.btest_exit('test_emscripten_main_loop_and_blocker.c', emcc_args=args)
+    self.btest_exit('test_emscripten_main_loop_and_blocker.c', cflags=args)
 
   def test_emscripten_main_loop_and_blocker_exit(self):
     # Same as above but tests that EXIT_RUNTIME works with emscripten_main_loop.  The
@@ -1925,47 +1925,47 @@ simulateKeyUp(100, undefined, 'Numpad4');
     'strict': (['-sSTRICT'],),
   })
   def test_emscripten_main_loop_setimmediate(self, args):
-    self.btest_exit('test_emscripten_main_loop_setimmediate.c', emcc_args=args)
+    self.btest_exit('test_emscripten_main_loop_setimmediate.c', cflags=args)
 
   @parameterized({
     '': ([],),
     'O1': (['-O1'],),
   })
   def test_fs_after_main(self, args):
-    self.btest_exit('test_fs_after_main.c', emcc_args=args)
+    self.btest_exit('test_fs_after_main.c', cflags=args)
 
   def test_sdl_quit(self):
-    self.btest_exit('test_sdl_quit.c', emcc_args=['-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_quit.c', cflags=['-lSDL', '-lGL'])
 
   def test_sdl_resize(self):
     # FIXME(https://github.com/emscripten-core/emscripten/issues/12978)
-    self.emcc_args.append('-Wno-deprecated-declarations')
-    self.btest_exit('test_sdl_resize.c', emcc_args=['-lSDL', '-lGL'])
+    self.cflags.append('-Wno-deprecated-declarations')
+    self.btest_exit('test_sdl_resize.c', cflags=['-lSDL', '-lGL'])
 
   def test_glshaderinfo(self):
-    self.btest_exit('test_glshaderinfo.c', emcc_args=['-lGL', '-lglut'])
+    self.btest_exit('test_glshaderinfo.c', cflags=['-lGL', '-lglut'])
 
   @requires_graphics_hardware
   def test_glgetattachedshaders(self):
-    self.btest('glgetattachedshaders.c', '1', emcc_args=['-lGL', '-lEGL'])
+    self.btest('glgetattachedshaders.c', '1', cflags=['-lGL', '-lEGL'])
 
   # Covered by dEQP text suite (we can remove it later if we add coverage for that).
   @requires_graphics_hardware
   def test_glframebufferattachmentinfo(self):
-    self.btest('glframebufferattachmentinfo.c', '1', emcc_args=['-lGLESv2', '-lEGL'])
+    self.btest('glframebufferattachmentinfo.c', '1', cflags=['-lGLESv2', '-lEGL'])
 
   @requires_graphics_hardware
   def test_sdl_glshader(self):
-    self.reftest('test_sdl_glshader.c', 'test_sdl_glshader.png', emcc_args=['-O2', '--closure=1', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-sGL_ENABLE_GET_PROC_ADDRESS'])
+    self.reftest('test_sdl_glshader.c', 'test_sdl_glshader.png', cflags=['-O2', '--closure=1', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-sGL_ENABLE_GET_PROC_ADDRESS'])
 
   @requires_graphics_hardware
   @also_with_proxying
   def test_sdl_glshader2(self):
-    self.btest_exit('test_sdl_glshader2.c', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-sGL_ENABLE_GET_PROC_ADDRESS'])
+    self.btest_exit('test_sdl_glshader2.c', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-sGL_ENABLE_GET_PROC_ADDRESS'])
 
   @requires_graphics_hardware
   def test_gl_glteximage(self):
-    self.btest('gl_teximage.c', '1', emcc_args=['-lGL', '-lSDL'])
+    self.btest('gl_teximage.c', '1', cflags=['-lGL', '-lSDL'])
 
   @parameterized({
     '': ([],),
@@ -1973,71 +1973,71 @@ simulateKeyUp(100, undefined, 'Numpad4');
   })
   @requires_graphics_hardware
   def test_gl_textures(self, args):
-    self.btest_exit('gl_textures.c', emcc_args=['-lGL', '-g', '-sSTACK_SIZE=1MB'] + args)
+    self.btest_exit('gl_textures.c', cflags=['-lGL', '-g', '-sSTACK_SIZE=1MB'] + args)
 
   @requires_graphics_hardware
   def test_gl_ps(self):
     # pointers and a shader
     shutil.copy(test_file('screenshot.png'), '.')
-    self.reftest('gl_ps.c', 'gl_ps.png', emcc_args=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '--use-preload-plugins'], reference_slack=1)
+    self.reftest('gl_ps.c', 'gl_ps.png', cflags=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '--use-preload-plugins'], reference_slack=1)
 
   @requires_graphics_hardware
   def test_gl_ps_packed(self):
     # packed data that needs to be strided
     shutil.copy(test_file('screenshot.png'), '.')
-    self.reftest('gl_ps_packed.c', 'gl_ps.png', emcc_args=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '--use-preload-plugins'], reference_slack=1)
+    self.reftest('gl_ps_packed.c', 'gl_ps.png', cflags=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '--use-preload-plugins'], reference_slack=1)
 
   @requires_graphics_hardware
   def test_gl_ps_strides(self):
     shutil.copy(test_file('screenshot.png'), '.')
-    self.reftest('gl_ps_strides.c', 'gl_ps_strides.png', emcc_args=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '--use-preload-plugins'])
+    self.reftest('gl_ps_strides.c', 'gl_ps_strides.png', cflags=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '--use-preload-plugins'])
 
   @requires_graphics_hardware
   @also_with_proxying
   def test_gl_ps_worker(self):
     shutil.copy(test_file('screenshot.png'), '.')
-    self.reftest('gl_ps_worker.c', 'gl_ps.png', emcc_args=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '--use-preload-plugins'], reference_slack=1)
+    self.reftest('gl_ps_worker.c', 'gl_ps.png', cflags=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '--use-preload-plugins'], reference_slack=1)
 
   @requires_graphics_hardware
   def test_gl_renderers(self):
-    self.reftest('gl_renderers.c', 'gl_renderers.png', emcc_args=['-sGL_UNSAFE_OPTS=0', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('gl_renderers.c', 'gl_renderers.png', cflags=['-sGL_UNSAFE_OPTS=0', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   @no_2gb('render fails')
   @no_4gb('render fails')
   def test_gl_stride(self):
-    self.reftest('gl_stride.c', 'gl_stride.png', emcc_args=['-sGL_UNSAFE_OPTS=0', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('gl_stride.c', 'gl_stride.png', cflags=['-sGL_UNSAFE_OPTS=0', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_gl_vertex_buffer_pre(self):
-    self.reftest('gl_vertex_buffer_pre.c', 'gl_vertex_buffer_pre.png', emcc_args=['-sGL_UNSAFE_OPTS=0', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('gl_vertex_buffer_pre.c', 'gl_vertex_buffer_pre.png', cflags=['-sGL_UNSAFE_OPTS=0', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_gl_vertex_buffer(self):
-    self.reftest('gl_vertex_buffer.c', 'gl_vertex_buffer.png', emcc_args=['-sGL_UNSAFE_OPTS=0', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'], reference_slack=1)
+    self.reftest('gl_vertex_buffer.c', 'gl_vertex_buffer.png', cflags=['-sGL_UNSAFE_OPTS=0', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'], reference_slack=1)
 
   @requires_graphics_hardware
   @also_with_proxying
   def test_gles2_uniform_arrays(self):
-    self.btest_exit('test_gles2_uniform_arrays.c', emcc_args=['-sGL_ASSERTIONS', '-lGL', '-lSDL'])
+    self.btest_exit('test_gles2_uniform_arrays.c', cflags=['-sGL_ASSERTIONS', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_gles2_conformance(self):
-    self.btest_exit('test_gles2_conformance.c', emcc_args=['-sGL_ASSERTIONS', '-lGL', '-lSDL'])
+    self.btest_exit('test_gles2_conformance.c', cflags=['-sGL_ASSERTIONS', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_matrix_identity(self):
-    self.btest('gl_matrix_identity.c', expected=['-1882984448', '460451840', '1588195328', '2411982848'], emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.btest('gl_matrix_identity.c', expected=['-1882984448', '460451840', '1588195328', '2411982848'], cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   @no_swiftshader
   def test_cubegeom_pre(self):
-    self.reftest('third_party/cubegeom/cubegeom_pre.c', 'third_party/cubegeom/cubegeom_pre.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_pre.c', 'third_party/cubegeom/cubegeom_pre.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   @no_swiftshader
   def test_cubegeom_pre_regal(self):
-    self.reftest('third_party/cubegeom/cubegeom_pre.c', 'third_party/cubegeom/cubegeom_pre.png', emcc_args=['-sUSE_REGAL', '-DUSE_REGAL', '-lGL', '-lSDL', '-lc++', '-lc++abi'])
+    self.reftest('third_party/cubegeom/cubegeom_pre.c', 'third_party/cubegeom/cubegeom_pre.png', cflags=['-sUSE_REGAL', '-DUSE_REGAL', '-lGL', '-lSDL', '-lc++', '-lc++abi'])
 
   @requires_graphics_hardware
   @no_swiftshader
@@ -2045,17 +2045,17 @@ simulateKeyUp(100, undefined, 'Numpad4');
     # RELOCATABLE needs to be set via `set_setting` so that it will also apply when
     # building `browser_reporting.c`
     self.set_setting('RELOCATABLE')
-    self.reftest('third_party/cubegeom/cubegeom_pre.c', 'third_party/cubegeom/cubegeom_pre.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_pre.c', 'third_party/cubegeom/cubegeom_pre.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   @no_swiftshader
   def test_cubegeom_pre2(self):
-    self.reftest('third_party/cubegeom/cubegeom_pre2.c', 'third_party/cubegeom/cubegeom_pre2.png', emcc_args=['-sGL_DEBUG', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL']) # some coverage for GL_DEBUG not breaking the build
+    self.reftest('third_party/cubegeom/cubegeom_pre2.c', 'third_party/cubegeom/cubegeom_pre2.png', cflags=['-sGL_DEBUG', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL']) # some coverage for GL_DEBUG not breaking the build
 
   @requires_graphics_hardware
   @no_swiftshader
   def test_cubegeom_pre3(self):
-    self.reftest('third_party/cubegeom/cubegeom_pre3.c', 'third_party/cubegeom/cubegeom_pre2.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_pre3.c', 'third_party/cubegeom/cubegeom_pre2.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @also_with_proxying
   @parameterized({
@@ -2064,20 +2064,20 @@ simulateKeyUp(100, undefined, 'Numpad4');
   })
   @requires_graphics_hardware
   def test_cubegeom(self, args):
-    if '--proxy-to-worker' in self.emcc_args and args:
+    if '--proxy-to-worker' in self.cflags and args:
       # proxy only in the simple, normal case (we can't trace GL calls when proxied)
       self.skipTest('tracing + proxying not supported')
-    self.reftest('third_party/cubegeom/cubegeom.c', 'third_party/cubegeom/cubegeom.png', emcc_args=['-O2', '-g', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'] + args)
+    self.reftest('third_party/cubegeom/cubegeom.c', 'third_party/cubegeom/cubegeom.png', cflags=['-O2', '-g', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'] + args)
 
   @requires_graphics_hardware
   @also_with_proxying
   def test_cubegeom_regal(self):
-    self.reftest('third_party/cubegeom/cubegeom.c', 'third_party/cubegeom/cubegeom.png', emcc_args=['-O2', '-g', '-DUSE_REGAL', '-sUSE_REGAL', '-lGL', '-lSDL', '-lc++', '-lc++abi'])
+    self.reftest('third_party/cubegeom/cubegeom.c', 'third_party/cubegeom/cubegeom.png', cflags=['-O2', '-g', '-DUSE_REGAL', '-sUSE_REGAL', '-lGL', '-lSDL', '-lc++', '-lc++abi'])
 
   @requires_graphics_hardware
   @also_with_proxying
   def test_cubegeom_regal_mt(self):
-    self.reftest('third_party/cubegeom/cubegeom.c', 'third_party/cubegeom/cubegeom.png', emcc_args=['-O2', '-g', '-pthread', '-DUSE_REGAL', '-pthread', '-sUSE_REGAL', '-lGL', '-lSDL', '-lc++', '-lc++abi'])
+    self.reftest('third_party/cubegeom/cubegeom.c', 'third_party/cubegeom/cubegeom.png', cflags=['-O2', '-g', '-pthread', '-DUSE_REGAL', '-pthread', '-sUSE_REGAL', '-lGL', '-lSDL', '-lc++', '-lc++abi'])
 
   @requires_graphics_hardware
   @parameterized({
@@ -2099,127 +2099,127 @@ void *getBindBuffer() {
   return glBindBuffer;
 }
 ''')
-    self.reftest('third_party/cubegeom/cubegeom_proc.c', 'third_party/cubegeom/cubegeom.png', emcc_args=opts + ['side.c', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-sGL_ENABLE_GET_PROC_ADDRESS'])
+    self.reftest('third_party/cubegeom/cubegeom_proc.c', 'third_party/cubegeom/cubegeom.png', cflags=opts + ['side.c', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-sGL_ENABLE_GET_PROC_ADDRESS'])
 
   @also_with_wasmfs
   @requires_graphics_hardware
   def test_cubegeom_glew(self):
-    self.reftest('third_party/cubegeom/cubegeom_glew.c', 'third_party/cubegeom/cubegeom.png', emcc_args=['-O2', '--closure=1', '-sLEGACY_GL_EMULATION', '-lGL', '-lGLEW', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_glew.c', 'third_party/cubegeom/cubegeom.png', cflags=['-O2', '--closure=1', '-sLEGACY_GL_EMULATION', '-lGL', '-lGLEW', '-lSDL'])
 
   @requires_graphics_hardware
   def test_cubegeom_color(self):
-    self.reftest('third_party/cubegeom/cubegeom_color.c', 'third_party/cubegeom/cubegeom_color.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_color.c', 'third_party/cubegeom/cubegeom_color.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   @also_with_proxying
   def test_cubegeom_normal(self):
-    self.reftest('third_party/cubegeom/cubegeom_normal.c', 'third_party/cubegeom/cubegeom_normal.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_normal.c', 'third_party/cubegeom/cubegeom_normal.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   @also_with_proxying
   def test_cubegeom_normal_dap(self): # draw is given a direct pointer to clientside memory, no element array buffer
-    self.reftest('third_party/cubegeom/cubegeom_normal_dap.c', 'third_party/cubegeom/cubegeom_normal.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_normal_dap.c', 'third_party/cubegeom/cubegeom_normal.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_cubegeom_normal_dap_far(self): # indices do nto start from 0
-    self.reftest('third_party/cubegeom/cubegeom_normal_dap_far.c', 'third_party/cubegeom/cubegeom_normal.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_normal_dap_far.c', 'third_party/cubegeom/cubegeom_normal.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_cubegeom_normal_dap_far_range(self): # glDrawRangeElements
-    self.reftest('third_party/cubegeom/cubegeom_normal_dap_far_range.c', 'third_party/cubegeom/cubegeom_normal.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_normal_dap_far_range.c', 'third_party/cubegeom/cubegeom_normal.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_cubegeom_normal_dap_far_glda(self): # use glDrawArrays
-    self.reftest('third_party/cubegeom/cubegeom_normal_dap_far_glda.c', 'third_party/cubegeom/cubegeom_normal_dap_far_glda.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_normal_dap_far_glda.c', 'third_party/cubegeom/cubegeom_normal_dap_far_glda.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   @no_firefox('fails on CI but works locally')
   def test_cubegeom_normal_dap_far_glda_quad(self): # with quad
-    self.reftest('third_party/cubegeom/cubegeom_normal_dap_far_glda_quad.c', 'third_party/cubegeom/cubegeom_normal_dap_far_glda_quad.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_normal_dap_far_glda_quad.c', 'third_party/cubegeom/cubegeom_normal_dap_far_glda_quad.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_cubegeom_mt(self):
-    self.reftest('third_party/cubegeom/cubegeom_mt.c', 'third_party/cubegeom/cubegeom_mt.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL']) # multitexture
+    self.reftest('third_party/cubegeom/cubegeom_mt.c', 'third_party/cubegeom/cubegeom_mt.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL']) # multitexture
 
   @requires_graphics_hardware
   @also_with_proxying
   def test_cubegeom_color2(self):
-    self.reftest('third_party/cubegeom/cubegeom_color2.c', 'third_party/cubegeom/cubegeom_color2.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_color2.c', 'third_party/cubegeom/cubegeom_color2.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_cubegeom_texturematrix(self):
-    self.reftest('third_party/cubegeom/cubegeom_texturematrix.c', 'third_party/cubegeom/cubegeom_texturematrix.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_texturematrix.c', 'third_party/cubegeom/cubegeom_texturematrix.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_cubegeom_fog(self):
-    self.reftest('third_party/cubegeom/cubegeom_fog.c', 'third_party/cubegeom/cubegeom_fog.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_fog.c', 'third_party/cubegeom/cubegeom_fog.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   @no_swiftshader
   def test_cubegeom_pre_vao(self):
-    self.reftest('third_party/cubegeom/cubegeom_pre_vao.c', 'third_party/cubegeom/cubegeom_pre_vao.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_pre_vao.c', 'third_party/cubegeom/cubegeom_pre_vao.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   @no_swiftshader
   def test_cubegeom_pre_vao_regal(self):
-    self.reftest('third_party/cubegeom/cubegeom_pre_vao.c', 'third_party/cubegeom/cubegeom_pre_vao.png', emcc_args=['-sUSE_REGAL', '-DUSE_REGAL', '-lGL', '-lSDL', '-lc++', '-lc++abi'])
+    self.reftest('third_party/cubegeom/cubegeom_pre_vao.c', 'third_party/cubegeom/cubegeom_pre_vao.png', cflags=['-sUSE_REGAL', '-DUSE_REGAL', '-lGL', '-lSDL', '-lc++', '-lc++abi'])
 
   @requires_graphics_hardware
   @no_swiftshader
   def test_cubegeom_pre2_vao(self):
-    self.reftest('third_party/cubegeom/cubegeom_pre2_vao.c', 'third_party/cubegeom/cubegeom_pre_vao.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-sGL_ENABLE_GET_PROC_ADDRESS'])
+    self.reftest('third_party/cubegeom/cubegeom_pre2_vao.c', 'third_party/cubegeom/cubegeom_pre_vao.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-sGL_ENABLE_GET_PROC_ADDRESS'])
 
   @requires_graphics_hardware
   def test_cubegeom_pre2_vao2(self):
-    self.reftest('third_party/cubegeom/cubegeom_pre2_vao2.c', 'third_party/cubegeom/cubegeom_pre2_vao2.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-sGL_ENABLE_GET_PROC_ADDRESS'])
+    self.reftest('third_party/cubegeom/cubegeom_pre2_vao2.c', 'third_party/cubegeom/cubegeom_pre2_vao2.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-sGL_ENABLE_GET_PROC_ADDRESS'])
 
   @requires_graphics_hardware
   @no_swiftshader
   def test_cubegeom_pre_vao_es(self):
-    self.reftest('third_party/cubegeom/cubegeom_pre_vao_es.c', 'third_party/cubegeom/cubegeom_pre_vao.png', emcc_args=['-sFULL_ES2', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_pre_vao_es.c', 'third_party/cubegeom/cubegeom_pre_vao.png', cflags=['-sFULL_ES2', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   @no_swiftshader
   def test_cubegeom_row_length(self):
-    self.reftest('third_party/cubegeom/cubegeom_pre_vao_es.c', 'third_party/cubegeom/cubegeom_pre_vao.png', emcc_args=['-sFULL_ES2', '-lGL', '-lSDL', '-DUSE_UNPACK_ROW_LENGTH', '-sMIN_WEBGL_VERSION=2'])
+    self.reftest('third_party/cubegeom/cubegeom_pre_vao_es.c', 'third_party/cubegeom/cubegeom_pre_vao.png', cflags=['-sFULL_ES2', '-lGL', '-lSDL', '-DUSE_UNPACK_ROW_LENGTH', '-sMIN_WEBGL_VERSION=2'])
 
   @requires_graphics_hardware
   def test_cubegeom_u4fv_2(self):
-    self.reftest('third_party/cubegeom/cubegeom_u4fv_2.c', 'third_party/cubegeom/cubegeom_u4fv_2.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('third_party/cubegeom/cubegeom_u4fv_2.c', 'third_party/cubegeom/cubegeom_u4fv_2.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   @also_with_proxying
   def test_cube_explosion(self):
-    self.reftest('cube_explosion.c', 'cube_explosion.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('cube_explosion.c', 'cube_explosion.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_glgettexenv(self):
-    self.btest('glgettexenv.c', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'], expected='1')
+    self.btest('glgettexenv.c', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'], expected='1')
 
   def test_sdl_canvas_blank(self):
-    self.reftest('test_sdl_canvas_blank.c', 'test_sdl_canvas_blank.png', emcc_args=['-lSDL', '-lGL'])
+    self.reftest('test_sdl_canvas_blank.c', 'test_sdl_canvas_blank.png', cflags=['-lSDL', '-lGL'])
 
   def test_sdl_canvas_palette(self):
-    self.reftest('test_sdl_canvas_palette.c', 'test_sdl_canvas_palette.png', emcc_args=['-lSDL', '-lGL'])
+    self.reftest('test_sdl_canvas_palette.c', 'test_sdl_canvas_palette.png', cflags=['-lSDL', '-lGL'])
 
   def test_sdl_canvas_twice(self):
-    self.reftest('test_sdl_canvas_twice.c', 'test_sdl_canvas_twice.png', emcc_args=['-lSDL', '-lGL'])
+    self.reftest('test_sdl_canvas_twice.c', 'test_sdl_canvas_twice.png', cflags=['-lSDL', '-lGL'])
 
   def test_sdl_set_clip_rect(self):
-    self.reftest('test_sdl_set_clip_rect.c', 'test_sdl_set_clip_rect.png', emcc_args=['-lSDL', '-lGL'])
+    self.reftest('test_sdl_set_clip_rect.c', 'test_sdl_set_clip_rect.png', cflags=['-lSDL', '-lGL'])
 
   def test_sdl_maprgba(self):
-    self.reftest('test_sdl_maprgba.c', 'test_sdl_maprgba.png', emcc_args=['-lSDL', '-lGL'], reference_slack=3)
+    self.reftest('test_sdl_maprgba.c', 'test_sdl_maprgba.png', cflags=['-lSDL', '-lGL'], reference_slack=3)
 
   def test_sdl_create_rgb_surface_from(self):
-    self.reftest('test_sdl_create_rgb_surface_from.c', 'test_sdl_create_rgb_surface_from.png', emcc_args=['-lSDL', '-lGL'])
+    self.reftest('test_sdl_create_rgb_surface_from.c', 'test_sdl_create_rgb_surface_from.png', cflags=['-lSDL', '-lGL'])
 
   def test_sdl_rotozoom(self):
     shutil.copy(test_file('screenshot.png'), '.')
-    self.reftest('test_sdl_rotozoom.c', 'test_sdl_rotozoom.png', emcc_args=['--preload-file', 'screenshot.png', '--use-preload-plugins', '-lSDL', '-lGL'], reference_slack=3)
+    self.reftest('test_sdl_rotozoom.c', 'test_sdl_rotozoom.png', cflags=['--preload-file', 'screenshot.png', '--use-preload-plugins', '-lSDL', '-lGL'], reference_slack=3)
 
   def test_sdl_gfx_primitives(self):
-    self.reftest('test_sdl_gfx_primitives.c', 'test_sdl_gfx_primitives.png', emcc_args=['-lSDL', '-lGL'], reference_slack=1)
+    self.reftest('test_sdl_gfx_primitives.c', 'test_sdl_gfx_primitives.png', cflags=['-lSDL', '-lGL'], reference_slack=1)
 
   def test_sdl_canvas_palette_2(self):
     create_file('pre.js', '''
@@ -2240,36 +2240,36 @@ void *getBindBuffer() {
       Module['arguments'] = ['-b'];
     ''')
 
-    self.reftest('test_sdl_canvas_palette_2.c', 'test_sdl_canvas_palette_r.png', emcc_args=['--pre-js', 'pre.js', '--pre-js', 'args-r.js', '-lSDL', '-lGL'])
-    self.reftest('test_sdl_canvas_palette_2.c', 'test_sdl_canvas_palette_g.png', emcc_args=['--pre-js', 'pre.js', '--pre-js', 'args-g.js', '-lSDL', '-lGL'])
-    self.reftest('test_sdl_canvas_palette_2.c', 'test_sdl_canvas_palette_b.png', emcc_args=['--pre-js', 'pre.js', '--pre-js', 'args-b.js', '-lSDL', '-lGL'])
+    self.reftest('test_sdl_canvas_palette_2.c', 'test_sdl_canvas_palette_r.png', cflags=['--pre-js', 'pre.js', '--pre-js', 'args-r.js', '-lSDL', '-lGL'])
+    self.reftest('test_sdl_canvas_palette_2.c', 'test_sdl_canvas_palette_g.png', cflags=['--pre-js', 'pre.js', '--pre-js', 'args-g.js', '-lSDL', '-lGL'])
+    self.reftest('test_sdl_canvas_palette_2.c', 'test_sdl_canvas_palette_b.png', cflags=['--pre-js', 'pre.js', '--pre-js', 'args-b.js', '-lSDL', '-lGL'])
 
   def test_sdl_ttf_render_text_solid(self):
-    self.reftest('test_sdl_ttf_render_text_solid.c', 'test_sdl_ttf_render_text_solid.png', emcc_args=['-O2', '-lSDL', '-lGL'])
+    self.reftest('test_sdl_ttf_render_text_solid.c', 'test_sdl_ttf_render_text_solid.png', cflags=['-O2', '-lSDL', '-lGL'])
 
   def test_sdl_alloctext(self):
-    self.btest_exit('test_sdl_alloctext.c', emcc_args=['-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_alloctext.c', cflags=['-lSDL', '-lGL'])
 
   def test_sdl_surface_refcount(self):
-    self.btest_exit('test_sdl_surface_refcount.c', emcc_args=['-lSDL'])
+    self.btest_exit('test_sdl_surface_refcount.c', cflags=['-lSDL'])
 
   def test_sdl_free_screen(self):
-    self.reftest('test_sdl_free_screen.c', 'htmltest.png', emcc_args=['-lSDL', '-lGL'])
+    self.reftest('test_sdl_free_screen.c', 'htmltest.png', cflags=['-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_glbegin_points(self):
     shutil.copy(test_file('screenshot.png'), '.')
-    self.reftest('glbegin_points.c', 'glbegin_points.png', emcc_args=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '--use-preload-plugins'])
+    self.reftest('glbegin_points.c', 'glbegin_points.png', cflags=['--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '--use-preload-plugins'])
 
   @requires_graphics_hardware
   def test_s3tc(self):
     shutil.copy(test_file('screenshot.dds'), '.')
-    self.reftest('s3tc.c', 's3tc.png', emcc_args=['--preload-file', 'screenshot.dds', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('s3tc.c', 's3tc.png', cflags=['--preload-file', 'screenshot.dds', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_s3tc_ffp_only(self):
     shutil.copy(test_file('screenshot.dds'), '.')
-    self.reftest('s3tc.c', 's3tc.png', emcc_args=['--preload-file', 'screenshot.dds', '-sLEGACY_GL_EMULATION', '-sGL_FFP_ONLY', '-lGL', '-lSDL'])
+    self.reftest('s3tc.c', 's3tc.png', cflags=['--preload-file', 'screenshot.dds', '-sLEGACY_GL_EMULATION', '-sGL_FFP_ONLY', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   @parameterized({
@@ -2278,15 +2278,15 @@ void *getBindBuffer() {
   })
   def test_anisotropic(self, args):
     shutil.copy(test_file('browser/water.dds'), '.')
-    self.reftest('test_anisotropic.c', 'test_anisotropic.png', reference_slack=2, emcc_args=['--preload-file', 'water.dds', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-Wno-incompatible-pointer-types'] + args)
+    self.reftest('test_anisotropic.c', 'test_anisotropic.png', reference_slack=2, cflags=['--preload-file', 'water.dds', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL', '-Wno-incompatible-pointer-types'] + args)
 
   @requires_graphics_hardware
   def test_tex_nonbyte(self):
-    self.reftest('tex_nonbyte.c', 'tex_nonbyte.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('tex_nonbyte.c', 'tex_nonbyte.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_float_tex(self):
-    self.reftest('float_tex.c', 'float_tex.png', emcc_args=['-lGL', '-lglut'])
+    self.reftest('float_tex.c', 'float_tex.png', cflags=['-lGL', '-lglut'])
 
   @requires_graphics_hardware
   @parameterized({
@@ -2298,15 +2298,15 @@ void *getBindBuffer() {
   def test_subdata(self, args):
     if self.is_4gb() and '-sMIN_WEBGL_VERSION=2' in args:
       self.skipTest('texSubImage2D fails: https://crbug.com/325090165')
-    self.reftest('gl_subdata.c', 'float_tex.png', emcc_args=['-lGL', '-lglut'] + args)
+    self.reftest('gl_subdata.c', 'float_tex.png', cflags=['-lGL', '-lglut'] + args)
 
   @requires_graphics_hardware
   def test_perspective(self):
-    self.reftest('perspective.c', 'perspective.png', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
+    self.reftest('perspective.c', 'perspective.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_glerror(self):
-    self.btest('gl_error.c', expected='1', emcc_args=['-sLEGACY_GL_EMULATION', '-lGL'])
+    self.btest('gl_error.c', expected='1', cflags=['-sLEGACY_GL_EMULATION', '-lGL'])
 
   @parameterized({
     '': ([],),
@@ -2314,7 +2314,7 @@ void *getBindBuffer() {
     'closure': (['--closure=1'],),
   })
   def test_openal_error(self, args):
-    self.btest_exit('openal/test_openal_error.c', emcc_args=args)
+    self.btest_exit('openal/test_openal_error.c', cflags=args)
 
   def test_openal_capture_sanity(self):
     self.btest_exit('openal/test_openal_capture_sanity.c')
@@ -2324,10 +2324,10 @@ void *getBindBuffer() {
 
   def test_openal_playback(self):
     shutil.copy(test_file('sounds/audio.wav'), '.')
-    self.btest_exit('openal/test_openal_playback.c', emcc_args=['-O2', '--preload-file', 'audio.wav'])
+    self.btest_exit('openal/test_openal_playback.c', cflags=['-O2', '--preload-file', 'audio.wav'])
 
   def test_openal_buffers(self):
-    self.btest_exit('openal/test_openal_buffers.c', emcc_args=['--preload-file', test_file('sounds/the_entertainer.wav') + '@/'])
+    self.btest_exit('openal/test_openal_buffers.c', cflags=['--preload-file', test_file('sounds/the_entertainer.wav') + '@/'])
 
   def test_runtimelink(self):
     create_file('header.h', r'''
@@ -2375,8 +2375,8 @@ void *getBindBuffer() {
         return 0;
       }
     ''')
-    self.run_process([EMCC, 'supp.c', '-o', 'supp.wasm', '-sSIDE_MODULE', '-O2'] + self.get_emcc_args())
-    self.btest_exit('main.c', emcc_args=['-sMAIN_MODULE=2', '-O2', 'supp.wasm'])
+    self.run_process([EMCC, 'supp.c', '-o', 'supp.wasm', '-sSIDE_MODULE', '-O2'] + self.get_cflags())
+    self.btest_exit('main.c', cflags=['-sMAIN_MODULE=2', '-O2', 'supp.wasm'])
 
   @also_with_wasm2js
   def test_pre_run_deps(self):
@@ -2392,7 +2392,7 @@ void *getBindBuffer() {
       };
     ''')
 
-    self.btest('test_pre_run_deps.c', expected='10', emcc_args=['--pre-js', 'pre.js'])
+    self.btest('test_pre_run_deps.c', expected='10', cflags=['--pre-js', 'pre.js'])
 
   @also_with_wasm2js
   @parameterized({
@@ -2473,18 +2473,18 @@ void *getBindBuffer() {
 
     print('mem init, so async, call too early')
     create_file('post.js', post_prep + post_test + post_hook)
-    self.btest('test_runtime_misuse.c', expected='600', emcc_args=['--post-js', 'post.js', '-sEXIT_RUNTIME'] + extra_args, reporting=Reporting.NONE)
+    self.btest('test_runtime_misuse.c', expected='600', cflags=['--post-js', 'post.js', '-sEXIT_RUNTIME'] + extra_args, reporting=Reporting.NONE)
 
     print('sync startup, call too late')
     create_file('post.js', post_prep + 'Module.postRun = () => { ' + post_test + ' };' + post_hook)
-    self.btest('test_runtime_misuse.c', expected=second_code, emcc_args=['--post-js', 'post.js', '-sEXIT_RUNTIME'] + extra_args, reporting=Reporting.NONE)
+    self.btest('test_runtime_misuse.c', expected=second_code, cflags=['--post-js', 'post.js', '-sEXIT_RUNTIME'] + extra_args, reporting=Reporting.NONE)
 
     print('sync, runtime still alive, so all good')
     create_file('post.js', post_prep + 'expected_ok = true; Module.postRun = () => { ' + post_test + ' };' + post_hook)
-    self.btest('test_runtime_misuse.c', expected='606', emcc_args=['--post-js', 'post.js'] + extra_args, reporting=Reporting.NONE)
+    self.btest('test_runtime_misuse.c', expected='606', cflags=['--post-js', 'post.js'] + extra_args, reporting=Reporting.NONE)
 
   def test_cwrap_early(self):
-    self.btest('browser/test_cwrap_early.c', emcc_args=['-O2', '-sASSERTIONS', '--pre-js', test_file('browser/test_cwrap_early.js'), '-sEXPORTED_RUNTIME_METHODS=cwrap'], expected='0')
+    self.btest('browser/test_cwrap_early.c', cflags=['-O2', '-sASSERTIONS', '--pre-js', test_file('browser/test_cwrap_early.js'), '-sEXPORTED_RUNTIME_METHODS=cwrap'], expected='0')
 
   @no_wasm64('TODO: wasm64 + BUILD_AS_WORKER')
   def test_worker_api(self):
@@ -2494,7 +2494,7 @@ void *getBindBuffer() {
   @no_wasm64('TODO: wasm64 + BUILD_AS_WORKER')
   def test_worker_api_2(self):
     self.compile_btest('worker_api_2_worker.cpp', ['-o', 'worker.js', '-sBUILD_AS_WORKER', '-O2', '--minify=0', '-sEXPORTED_FUNCTIONS=_one,_two,_three,_four', '--closure=1'])
-    self.btest('worker_api_2_main.cpp', emcc_args=['-O2', '--minify=0'], expected='11')
+    self.btest('worker_api_2_main.cpp', cflags=['-O2', '--minify=0'], expected='11')
 
   @no_wasm64('TODO: wasm64 + BUILD_AS_WORKER')
   def test_worker_api_3(self):
@@ -2515,11 +2515,11 @@ void *getBindBuffer() {
   @also_with_wasmfs
   def test_wget(self):
     create_file('test.txt', 'emscripten')
-    self.btest_exit('test_wget.c', emcc_args=['-sASYNCIFY'])
+    self.btest_exit('test_wget.c', cflags=['-sASYNCIFY'])
 
   def test_wget_data(self):
     create_file('test.txt', 'emscripten')
-    self.btest_exit('test_wget_data.c', emcc_args=['-O2', '-g2', '-sASYNCIFY'])
+    self.btest_exit('test_wget_data.c', cflags=['-O2', '-g2', '-sASYNCIFY'])
 
   @also_with_wasmfs
   @parameterized({
@@ -2528,7 +2528,7 @@ void *getBindBuffer() {
   })
   def test_emscripten_async_wget(self, args):
     shutil.copy(test_file('screenshot.png'), '.') # preloaded *after* run
-    self.btest_exit('test_emscripten_async_wget.c', emcc_args=['-lSDL'] + args)
+    self.btest_exit('test_emscripten_async_wget.c', cflags=['-lSDL'] + args)
 
   @also_with_wasmfs
   def test_emscripten_async_wget2(self):
@@ -2541,7 +2541,7 @@ void *getBindBuffer() {
 
   def test_emscripten_async_wget_side_module(self):
     self.emcc(test_file('test_emscripten_async_wget_side_module.c'), ['-o', 'lib.wasm', '-O2', '-sSIDE_MODULE'])
-    self.btest_exit('test_emscripten_async_wget_main_module.c', emcc_args=['-O2', '-sMAIN_MODULE=2'])
+    self.btest_exit('test_emscripten_async_wget_main_module.c', cflags=['-O2', '-sMAIN_MODULE=2'])
 
   @parameterized({
     '': ([],),
@@ -2576,7 +2576,7 @@ void *getBindBuffer() {
     ''')
     self.btest_exit(
       'main.c',
-      emcc_args=['-sMAIN_MODULE=2', '--preload-file', '.@/', '--use-preload-plugins'] + args)
+      cflags=['-sMAIN_MODULE=2', '--preload-file', '.@/', '--use-preload-plugins'] + args)
 
   # This does not actually verify anything except that --cpuprofiler and --memoryprofiler compiles.
   # Run interactive.test_cpuprofiler_memoryprofiler for interactive testing.
@@ -2586,17 +2586,17 @@ void *getBindBuffer() {
     'modularized': (['-sMODULARIZE=1', '-sEXPORT_NAME=MyModule', '--shell-file', test_file('shell_that_launches_modularize.html')],),
   })
   def test_cpuprofiler_memoryprofiler(self, opts):
-    self.btest_exit('hello_world_gles.c', emcc_args=['-DLONGTEST=1', '-DTEST_MEMORYPROFILER_ALLOCATIONS_MAP=1', '--cpuprofiler', '--memoryprofiler', '-lGL', '-lglut', '-DANIMATE'] + opts)
+    self.btest_exit('hello_world_gles.c', cflags=['-DLONGTEST=1', '-DTEST_MEMORYPROFILER_ALLOCATIONS_MAP=1', '--cpuprofiler', '--memoryprofiler', '-lGL', '-lglut', '-DANIMATE'] + opts)
 
   def test_uuid(self):
-    self.btest_exit('test_uuid.c', emcc_args=['-luuid'])
+    self.btest_exit('test_uuid.c', cflags=['-luuid'])
 
   @requires_graphics_hardware
   def test_glew(self):
-    self.btest('glew.c', emcc_args=['-lGL', '-lSDL', '-lGLEW'], expected='1')
-    self.btest('glew.c', emcc_args=['-lGL', '-lSDL', '-lGLEW', '-sLEGACY_GL_EMULATION'], expected='1')
-    self.btest('glew.c', emcc_args=['-lGL', '-lSDL', '-lGLEW', '-DGLEW_MX'], expected='1')
-    self.btest('glew.c', emcc_args=['-lGL', '-lSDL', '-lGLEW', '-sLEGACY_GL_EMULATION', '-DGLEW_MX'], expected='1')
+    self.btest('glew.c', cflags=['-lGL', '-lSDL', '-lGLEW'], expected='1')
+    self.btest('glew.c', cflags=['-lGL', '-lSDL', '-lGLEW', '-sLEGACY_GL_EMULATION'], expected='1')
+    self.btest('glew.c', cflags=['-lGL', '-lSDL', '-lGLEW', '-DGLEW_MX'], expected='1')
+    self.btest('glew.c', cflags=['-lGL', '-lSDL', '-lGLEW', '-sLEGACY_GL_EMULATION', '-DGLEW_MX'], expected='1')
 
   def test_doublestart_bug(self):
     create_file('pre.js', r'''
@@ -2606,7 +2606,7 @@ Module["preRun"] = () => {
 };
 ''')
 
-    self.btest('doublestart.c', emcc_args=['--pre-js', 'pre.js'], expected='1')
+    self.btest('doublestart.c', cflags=['--pre-js', 'pre.js'], expected='1')
 
   @parameterized({
     '': ([],),
@@ -2629,8 +2629,8 @@ Module["preRun"] = () => {
         }
       });
       ''')
-      self.emcc_args.append('--pre-js=pre.js')
-    self.btest_exit('test_html5_core.c', emcc_args=opts)
+      self.cflags.append('--pre-js=pre.js')
+    self.btest_exit('test_html5_core.c', cflags=opts)
 
   @parameterized({
     '': ([],),
@@ -2638,7 +2638,7 @@ Module["preRun"] = () => {
     'pthread': (['-pthread', '-sPROXY_TO_PTHREAD'],),
   })
   def test_html5_gamepad(self, args):
-    self.btest_exit('test_gamepad.c', emcc_args=args)
+    self.btest_exit('test_gamepad.c', cflags=args)
 
   def test_html5_unknown_event_target(self):
     self.btest_exit('test_html5_unknown_event_target.c')
@@ -2650,7 +2650,7 @@ Module["preRun"] = () => {
     'full_es2': (['-sFULL_ES2'],),
   })
   def test_html5_webgl_create_context_no_antialias(self, args):
-    self.btest_exit('webgl_create_context.cpp', emcc_args=args + ['-DNO_ANTIALIAS', '-lGL'])
+    self.btest_exit('webgl_create_context.cpp', cflags=args + ['-DNO_ANTIALIAS', '-lGL'])
 
   # This test supersedes the one above, but it's skipped in the CI because anti-aliasing is not well supported by the Mesa software renderer.
   @requires_graphics_hardware
@@ -2661,7 +2661,7 @@ Module["preRun"] = () => {
     'pthread': (['-pthread'],),
   })
   def test_html5_webgl_create_context(self, args):
-    self.btest_exit('webgl_create_context.cpp', emcc_args=args + ['-lGL'])
+    self.btest_exit('webgl_create_context.cpp', cflags=args + ['-lGL'])
 
   @requires_graphics_hardware
   # Verify bug https://github.com/emscripten-core/emscripten/issues/4556: creating a WebGL context to Module.canvas without an ID explicitly assigned to it.
@@ -2675,13 +2675,13 @@ Module["preRun"] = () => {
     'offscreenframebuffer': (['-sOFFSCREEN_FRAMEBUFFER', '-DUSE_OFFSCREEN_FRAMEBUFFER'],),
   })
   def test_html5_webgl_create_context_swapcontrol(self, args):
-    self.btest_exit('browser/webgl_create_context_swapcontrol.c', emcc_args=args)
+    self.btest_exit('browser/webgl_create_context_swapcontrol.c', cflags=args)
 
   @requires_graphics_hardware
   # Verify bug https://github.com/emscripten-core/emscripten/issues/4556: creating a WebGL context to Module.canvas without an ID explicitly assigned to it.
   # (this only makes sense in the old deprecated -sDISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=0 mode)
   def test_html5_special_event_targets(self):
-    self.btest_exit('html5_special_event_targets.cpp', emcc_args=['-lGL'])
+    self.btest_exit('html5_special_event_targets.cpp', cflags=['-lGL'])
 
   @requires_graphics_hardware
   @parameterized({
@@ -2690,11 +2690,11 @@ Module["preRun"] = () => {
     'full_es2': (['-sFULL_ES2'],),
   })
   def test_html5_webgl_destroy_context(self, args):
-    self.btest_exit('webgl_destroy_context.c', emcc_args=args + ['--shell-file', test_file('browser/webgl_destroy_context_shell.html'), '-lGL'])
+    self.btest_exit('webgl_destroy_context.c', cflags=args + ['--shell-file', test_file('browser/webgl_destroy_context_shell.html'), '-lGL'])
 
   @requires_graphics_hardware
   def test_webgl_context_params(self):
-    self.btest_exit('webgl_color_buffer_readpixels.c', emcc_args=['-lGL'])
+    self.btest_exit('webgl_color_buffer_readpixels.c', cflags=['-lGL'])
 
   # Test for PR#5373 (https://github.com/emscripten-core/emscripten/pull/5373)
   @requires_graphics_hardware
@@ -2703,12 +2703,12 @@ Module["preRun"] = () => {
     'full_es2': (['-sFULL_ES2'],),
   })
   def test_webgl_shader_source_length(self, args):
-    self.btest_exit('webgl_shader_source_length.c', emcc_args=args + ['-lGL'])
+    self.btest_exit('webgl_shader_source_length.c', cflags=args + ['-lGL'])
 
   # Tests calling glGetString(GL_UNMASKED_VENDOR_WEBGL).
   @requires_graphics_hardware
   def test_webgl_unmasked_vendor_webgl(self):
-    self.btest_exit('webgl_unmasked_vendor_webgl.c', emcc_args=['-lGL'])
+    self.btest_exit('webgl_unmasked_vendor_webgl.c', cflags=['-lGL'])
 
   @requires_graphics_hardware
   @parameterized({
@@ -2719,23 +2719,23 @@ Module["preRun"] = () => {
   def test_webgl2(self, args):
     if '-sMIN_CHROME_VERSION=0' in args and self.is_wasm64():
       self.skipTest('wasm64 not supported by legacy browsers')
-    self.btest_exit('webgl2.c', emcc_args=['-sMAX_WEBGL_VERSION=2', '-lGL'] + args)
+    self.btest_exit('webgl2.c', cflags=['-sMAX_WEBGL_VERSION=2', '-lGL'] + args)
 
   # Tests the WebGL 2 glGetBufferSubData() functionality.
   @requires_graphics_hardware
   @no_4gb('getBufferSubData fails: https://crbug.com/325090165')
   def test_webgl2_get_buffer_sub_data(self):
-    self.btest_exit('webgl2_get_buffer_sub_data.c', emcc_args=['-sMAX_WEBGL_VERSION=2', '-lGL'])
+    self.btest_exit('webgl2_get_buffer_sub_data.c', cflags=['-sMAX_WEBGL_VERSION=2', '-lGL'])
 
   @requires_graphics_hardware
   def test_webgl2_pthreads(self):
     # test that a program can be compiled with pthreads and render WebGL2 properly on the main thread
     # (the testcase doesn't even use threads, but is compiled with thread support).
-    self.btest_exit('webgl2.c', emcc_args=['-sMAX_WEBGL_VERSION=2', '-lGL', '-pthread'])
+    self.btest_exit('webgl2.c', cflags=['-sMAX_WEBGL_VERSION=2', '-lGL', '-pthread'])
 
   @requires_graphics_hardware
   def test_webgl2_objects(self):
-    self.btest_exit('webgl2_objects.c', emcc_args=['-sMAX_WEBGL_VERSION=2', '-lGL'])
+    self.btest_exit('webgl2_objects.c', cflags=['-sMAX_WEBGL_VERSION=2', '-lGL'])
 
   @requires_graphics_hardware
   @parameterized({
@@ -2746,7 +2746,7 @@ Module["preRun"] = () => {
   def test_html5_webgl_api(self, args):
     if '-sOFFSCREENCANVAS_SUPPORT' in args and os.getenv('EMTEST_LACKS_OFFSCREEN_CANVAS'):
       return
-    self.btest_exit('html5_webgl.c', emcc_args=['-sMAX_WEBGL_VERSION=2', '-lGL'] + args)
+    self.btest_exit('html5_webgl.c', cflags=['-sMAX_WEBGL_VERSION=2', '-lGL'] + args)
 
   @parameterized({
     'webgl1': (['-DWEBGL_VERSION=1'],),
@@ -2756,11 +2756,11 @@ Module["preRun"] = () => {
   })
   @requires_graphics_hardware
   def test_webgl_preprocessor_variables(self, opts):
-    self.btest_exit('webgl_preprocessor_variables.c', emcc_args=['-lGL'] + opts)
+    self.btest_exit('webgl_preprocessor_variables.c', cflags=['-lGL'] + opts)
 
   @requires_graphics_hardware
   def test_webgl2_ubos(self):
-    self.btest_exit('webgl2_ubos.c', emcc_args=['-sMAX_WEBGL_VERSION=2', '-lGL'])
+    self.btest_exit('webgl2_ubos.c', cflags=['-sMAX_WEBGL_VERSION=2', '-lGL'])
 
   @requires_graphics_hardware
   @parameterized({
@@ -2770,94 +2770,94 @@ Module["preRun"] = () => {
   def test_webgl2_garbage_free_entrypoints(self, args):
     if args and self.is_4gb():
       self.skipTest('readPixels fails: https://crbug.com/324992397')
-    self.btest_exit('webgl2_garbage_free_entrypoints.c', emcc_args=args)
+    self.btest_exit('webgl2_garbage_free_entrypoints.c', cflags=args)
 
   @requires_graphics_hardware
   def test_webgl2_backwards_compatibility_emulation(self):
-    self.btest_exit('webgl2_backwards_compatibility_emulation.c', emcc_args=['-sMAX_WEBGL_VERSION=2', '-sWEBGL2_BACKWARDS_COMPATIBILITY_EMULATION'])
+    self.btest_exit('webgl2_backwards_compatibility_emulation.c', cflags=['-sMAX_WEBGL_VERSION=2', '-sWEBGL2_BACKWARDS_COMPATIBILITY_EMULATION'])
 
   @requires_graphics_hardware
   def test_webgl2_runtime_no_context(self):
     # tests that if we support WebGL1 and 2, and WebGL2RenderingContext exists,
     # but context creation fails, that we can then manually try to create a
     # WebGL1 context and succeed.
-    self.btest_exit('test_webgl2_runtime_no_context.cpp', emcc_args=['-sMAX_WEBGL_VERSION=2'])
+    self.btest_exit('test_webgl2_runtime_no_context.cpp', cflags=['-sMAX_WEBGL_VERSION=2'])
 
   @requires_graphics_hardware
   def test_webgl_context_major_version(self):
     # testing that majorVersion accepts only valid values
-    self.btest('test_webgl_context_major_version.c', expected='abort:Expected Error: Invalid WebGL version requested: 0', emcc_args=['-lGL', '-DWEBGL_CONTEXT_MAJOR_VERSION=0'])
-    self.btest('test_webgl_context_major_version.c', expected='abort:Expected Error: Invalid WebGL version requested: 3', emcc_args=['-lGL', '-DWEBGL_CONTEXT_MAJOR_VERSION=3'])
+    self.btest('test_webgl_context_major_version.c', expected='abort:Expected Error: Invalid WebGL version requested: 0', cflags=['-lGL', '-DWEBGL_CONTEXT_MAJOR_VERSION=0'])
+    self.btest('test_webgl_context_major_version.c', expected='abort:Expected Error: Invalid WebGL version requested: 3', cflags=['-lGL', '-DWEBGL_CONTEXT_MAJOR_VERSION=3'])
 
     # no linker flag (equivalent to -sMIN_WEBGL_VERSION=1 -sMAX_WEBGL_VERSION=1) => only 1 allowed
-    self.btest_exit('test_webgl_context_major_version.c', emcc_args=['-lGL', '-DWEBGL_CONTEXT_MAJOR_VERSION=1'])
-    self.btest('test_webgl_context_major_version.c', expected='abort:Expected Error: WebGL 2 requested but only WebGL 1 is supported (set -sMAX_WEBGL_VERSION=2 to fix the problem)', emcc_args=['-lGL', '-DWEBGL_CONTEXT_MAJOR_VERSION=2'])
+    self.btest_exit('test_webgl_context_major_version.c', cflags=['-lGL', '-DWEBGL_CONTEXT_MAJOR_VERSION=1'])
+    self.btest('test_webgl_context_major_version.c', expected='abort:Expected Error: WebGL 2 requested but only WebGL 1 is supported (set -sMAX_WEBGL_VERSION=2 to fix the problem)', cflags=['-lGL', '-DWEBGL_CONTEXT_MAJOR_VERSION=2'])
 
     # -sMIN_WEBGL_VERSION=2 => only 2 allowed
-    self.btest('test_webgl_context_major_version.c', expected='abort:Expected Error: WebGL 1 requested but only WebGL 2 is supported (MIN_WEBGL_VERSION is 2)', emcc_args=['-lGL', '-sMIN_WEBGL_VERSION=2', '-DWEBGL_CONTEXT_MAJOR_VERSION=1'])
-    self.btest_exit('test_webgl_context_major_version.c', emcc_args=['-lGL', '-sMIN_WEBGL_VERSION=2', '-DWEBGL_CONTEXT_MAJOR_VERSION=2'])
+    self.btest('test_webgl_context_major_version.c', expected='abort:Expected Error: WebGL 1 requested but only WebGL 2 is supported (MIN_WEBGL_VERSION is 2)', cflags=['-lGL', '-sMIN_WEBGL_VERSION=2', '-DWEBGL_CONTEXT_MAJOR_VERSION=1'])
+    self.btest_exit('test_webgl_context_major_version.c', cflags=['-lGL', '-sMIN_WEBGL_VERSION=2', '-DWEBGL_CONTEXT_MAJOR_VERSION=2'])
 
     # -sMAX_WEBGL_VERSION=2 => 1 and 2 are ok
-    self.btest_exit('test_webgl_context_major_version.c', emcc_args=['-lGL', '-sMAX_WEBGL_VERSION=2', '-DWEBGL_CONTEXT_MAJOR_VERSION=1'])
-    self.btest_exit('test_webgl_context_major_version.c', emcc_args=['-lGL', '-sMAX_WEBGL_VERSION=2', '-DWEBGL_CONTEXT_MAJOR_VERSION=2'])
+    self.btest_exit('test_webgl_context_major_version.c', cflags=['-lGL', '-sMAX_WEBGL_VERSION=2', '-DWEBGL_CONTEXT_MAJOR_VERSION=1'])
+    self.btest_exit('test_webgl_context_major_version.c', cflags=['-lGL', '-sMAX_WEBGL_VERSION=2', '-DWEBGL_CONTEXT_MAJOR_VERSION=2'])
 
   @requires_graphics_hardware
   def test_webgl2_invalid_teximage2d_type(self):
-    self.btest_exit('webgl2_invalid_teximage2d_type.c', emcc_args=['-sMAX_WEBGL_VERSION=2'])
+    self.btest_exit('webgl2_invalid_teximage2d_type.c', cflags=['-sMAX_WEBGL_VERSION=2'])
 
   @requires_graphics_hardware
   def test_webgl_with_closure(self):
-    self.btest_exit('webgl_with_closure.c', emcc_args=['-O2', '-sMAX_WEBGL_VERSION=2', '--closure=1', '-lGL'])
+    self.btest_exit('webgl_with_closure.c', cflags=['-O2', '-sMAX_WEBGL_VERSION=2', '--closure=1', '-lGL'])
 
   # Tests that -sGL_ASSERTIONS and glVertexAttribPointer with packed types works
   @requires_graphics_hardware
   def test_webgl2_packed_types(self):
-    self.btest_exit('webgl2_draw_packed_triangle.c', emcc_args=['-lGL', '-sMAX_WEBGL_VERSION=2', '-sGL_ASSERTIONS'])
+    self.btest_exit('webgl2_draw_packed_triangle.c', cflags=['-lGL', '-sMAX_WEBGL_VERSION=2', '-sGL_ASSERTIONS'])
 
   @requires_graphics_hardware
   @no_4gb('compressedTexSubImage2D fails: https://crbug.com/324562920')
   def test_webgl2_pbo(self):
-    self.btest_exit('webgl2_pbo.c', emcc_args=['-sMAX_WEBGL_VERSION=2', '-lGL'])
+    self.btest_exit('webgl2_pbo.c', cflags=['-sMAX_WEBGL_VERSION=2', '-lGL'])
 
   @no_firefox('fails on CI likely due to GPU drivers there')
   @requires_graphics_hardware
   def test_webgl2_sokol_mipmap(self):
     self.reftest('third_party/sokol/mipmap-emsc.c', 'third_party/sokol/mipmap-emsc.png',
-                 emcc_args=['-sMAX_WEBGL_VERSION=2', '-lGL', '-O1'], reference_slack=2)
+                 cflags=['-sMAX_WEBGL_VERSION=2', '-lGL', '-O1'], reference_slack=2)
 
   @no_firefox('fails on CI likely due to GPU drivers there')
   @no_4gb('fails to render')
   @requires_graphics_hardware
   def test_webgl2_sokol_mrt(self):
     self.reftest('third_party/sokol/mrt-emcc.c', 'third_party/sokol/mrt-emcc.png',
-                 emcc_args=['-sMAX_WEBGL_VERSION=2', '-lGL'])
+                 cflags=['-sMAX_WEBGL_VERSION=2', '-lGL'])
 
   @requires_graphics_hardware
   @no_4gb('fails to render')
   def test_webgl2_sokol_arraytex(self):
     self.reftest('third_party/sokol/arraytex-emsc.c', 'third_party/sokol/arraytex-emsc.png',
-                 emcc_args=['-sMAX_WEBGL_VERSION=2', '-lGL'])
+                 cflags=['-sMAX_WEBGL_VERSION=2', '-lGL'])
 
   @parameterized({
     '': ([],),
     'closure': (['-O2', '-g1', '--closure=1'],),
   })
   def test_sdl_touch(self, opts):
-    self.btest_exit('test_sdl_touch.c', emcc_args=opts + ['-DAUTOMATE_SUCCESS=1', '-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_touch.c', cflags=opts + ['-DAUTOMATE_SUCCESS=1', '-lSDL', '-lGL'])
 
   @parameterized({
     '': ([],),
     'closure': (['-O2', '-g1', '--closure=1'],),
   })
   def test_html5_mouse(self, opts):
-    self.btest('test_html5_mouse.c', emcc_args=opts + ['-DAUTOMATE_SUCCESS=1'], expected='0')
+    self.btest('test_html5_mouse.c', cflags=opts + ['-DAUTOMATE_SUCCESS=1'], expected='0')
 
   @parameterized({
     '': ([],),
     'closure': (['-O2', '-g1', '--closure=1'],),
   })
   def test_sdl_mousewheel(self, opts):
-    self.btest_exit('test_sdl_mousewheel.c', emcc_args=opts + ['-DAUTOMATE_SUCCESS=1', '-lSDL', '-lGL'])
+    self.btest_exit('test_sdl_mousewheel.c', cflags=opts + ['-DAUTOMATE_SUCCESS=1', '-lSDL', '-lGL'])
 
   @also_with_wasm2js
   @parameterized({
@@ -2919,7 +2919,7 @@ Module["preRun"] = () => {
 
   @requires_graphics_hardware
   def test_glfw3_default_hints(self):
-    self.btest_exit('test_glfw3_default_hints.c', emcc_args=['-sUSE_GLFW=3', '-lglfw', '-lGL'])
+    self.btest_exit('test_glfw3_default_hints.c', cflags=['-sUSE_GLFW=3', '-lglfw', '-lGL'])
 
   @requires_graphics_hardware
   @parameterized({
@@ -2932,7 +2932,7 @@ Module["preRun"] = () => {
     'closure': (['-Os', '--closure=1'],),
   })
   def test_glfw3(self, args, opts):
-    self.btest_exit('test_glfw3.c', emcc_args=['-sUSE_GLFW=3', '-lglfw', '-lGL'] + args + opts)
+    self.btest_exit('test_glfw3.c', cflags=['-sUSE_GLFW=3', '-lglfw', '-lGL'] + args + opts)
 
   @parameterized({
     '': (['-sUSE_GLFW=2', '-DUSE_GLFW=2'],),
@@ -2940,15 +2940,15 @@ Module["preRun"] = () => {
   })
   @requires_graphics_hardware
   def test_glfw_events(self, args):
-    self.btest_exit('test_glfw_events.c', emcc_args=args + ['-lglfw', '-lGL', '--pre-js', test_file('browser/fake_events.js')])
+    self.btest_exit('test_glfw_events.c', cflags=args + ['-lglfw', '-lGL', '--pre-js', test_file('browser/fake_events.js')])
 
   @requires_graphics_hardware
   def test_glfw3_hi_dpi_aware(self):
-    self.btest_exit('test_glfw3_hi_dpi_aware.c', emcc_args=['-sUSE_GLFW=3', '-lGL'])
+    self.btest_exit('test_glfw3_hi_dpi_aware.c', cflags=['-sUSE_GLFW=3', '-lGL'])
 
   @requires_graphics_hardware
   def test_glfw3_css_scaling(self):
-    self.btest_exit('test_glfw3_css_scaling.c', emcc_args=['-sUSE_GLFW=3'])
+    self.btest_exit('test_glfw3_css_scaling.c', cflags=['-sUSE_GLFW=3'])
 
   @requires_graphics_hardware
   @also_with_wasm2js
@@ -2958,7 +2958,7 @@ Module["preRun"] = () => {
 
     for dest, dirname, basename in [('screenshot.jpg', '/', 'screenshot.jpg'),
                                     ('screenshot.jpg@/assets/screenshot.jpg', '/assets', 'screenshot.jpg')]:
-      self.btest_exit('test_sdl2_image.c', 600, emcc_args=[
+      self.btest_exit('test_sdl2_image.c', 600, cflags=[
         '-O2',
         '--preload-file', dest,
         '-DSCREENSHOT_DIRNAME="' + dirname + '"',
@@ -2969,7 +2969,7 @@ Module["preRun"] = () => {
   @requires_graphics_hardware
   def test_sdl2_image_jpeg(self):
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.jpeg')
-    self.btest_exit('test_sdl2_image.c', 600, emcc_args=[
+    self.btest_exit('test_sdl2_image.c', 600, cflags=[
       '--preload-file', 'screenshot.jpeg',
       '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.jpeg"',
       '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--use-preload-plugins',
@@ -2981,19 +2981,19 @@ Module["preRun"] = () => {
   def test_sdl2_image_formats(self):
     shutil.copy(test_file('screenshot.png'), '.')
     shutil.copy(test_file('screenshot.jpg'), '.')
-    self.btest_exit('test_sdl2_image.c', 512, emcc_args=[
+    self.btest_exit('test_sdl2_image.c', 512, cflags=[
       '--preload-file', 'screenshot.png',
       '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.png"', '-DNO_PRELOADED',
       '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '-sSDL2_IMAGE_FORMATS=png',
     ])
-    self.btest_exit('test_sdl2_image.c', 600, emcc_args=[
+    self.btest_exit('test_sdl2_image.c', 600, cflags=[
       '--preload-file', 'screenshot.jpg',
       '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.jpg"', '-DBITSPERPIXEL=24', '-DNO_PRELOADED',
       '--use-port=sdl2', '--use-port=sdl2_image:formats=jpg',
     ])
 
   def test_sdl2_key(self):
-    self.btest_exit('test_sdl2_key.c', 37182145, emcc_args=['-sUSE_SDL=2', '--pre-js', test_file('browser/fake_events.js')])
+    self.btest_exit('test_sdl2_key.c', 37182145, cflags=['-sUSE_SDL=2', '--pre-js', test_file('browser/fake_events.js')])
 
   def test_sdl2_text(self):
     create_file('pre.js', '''
@@ -3006,11 +3006,11 @@ Module["preRun"] = () => {
       }
     ''')
 
-    self.btest_exit('test_sdl2_text.c', emcc_args=['--pre-js', 'pre.js', '--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=2'])
+    self.btest_exit('test_sdl2_text.c', cflags=['--pre-js', 'pre.js', '--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_mouse(self):
-    self.btest_exit('test_sdl2_mouse.c', emcc_args=['-O2', '--minify=0', '--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=2'])
+    self.btest_exit('test_sdl2_mouse.c', cflags=['-O2', '--minify=0', '--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_mouse_offsets(self):
@@ -3064,31 +3064,31 @@ Module["preRun"] = () => {
     self.run_browser('page.html', '', '/report_result?exit:0')
 
   def test_sdl2_threads(self):
-    self.btest_exit('test_sdl2_threads.c', emcc_args=['-pthread', '-sUSE_SDL=2', '-sPROXY_TO_PTHREAD'])
+    self.btest_exit('test_sdl2_threads.c', cflags=['-pthread', '-sUSE_SDL=2', '-sPROXY_TO_PTHREAD'])
 
   @requires_graphics_hardware
   @also_with_proxying
   def test_sdl2_glshader(self):
-    if '--proxy-to-worker' not in self.emcc_args:
+    if '--proxy-to-worker' not in self.cflags:
       # closure build current fails on proxying
-      self.emcc_args += ['--closure=1', '-g1']
-    self.reftest('test_sdl2_glshader.c', 'test_sdl_glshader.png', emcc_args=['-sUSE_SDL=2', '-sLEGACY_GL_EMULATION'])
+      self.cflags += ['--closure=1', '-g1']
+    self.reftest('test_sdl2_glshader.c', 'test_sdl_glshader.png', cflags=['-sUSE_SDL=2', '-sLEGACY_GL_EMULATION'])
 
   @requires_graphics_hardware
   def test_sdl2_canvas_blank(self):
-    self.reftest('test_sdl2_canvas_blank.c', 'test_sdl_canvas_blank.png', emcc_args=['-sUSE_SDL=2'])
+    self.reftest('test_sdl2_canvas_blank.c', 'test_sdl_canvas_blank.png', cflags=['-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_canvas_palette(self):
-    self.reftest('test_sdl2_canvas_palette.c', 'test_sdl_canvas_palette.png', emcc_args=['-sUSE_SDL=2'])
+    self.reftest('test_sdl2_canvas_palette.c', 'test_sdl_canvas_palette.png', cflags=['-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_canvas_twice(self):
-    self.reftest('test_sdl2_canvas_twice.c', 'test_sdl_canvas_twice.png', emcc_args=['-sUSE_SDL=2'])
+    self.reftest('test_sdl2_canvas_twice.c', 'test_sdl_canvas_twice.png', cflags=['-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_gfx(self):
-    self.reftest('test_sdl2_gfx.c', 'test_sdl2_gfx.png', emcc_args=['-sUSE_SDL=2', '-sUSE_SDL_GFX=2'], reference_slack=2)
+    self.reftest('test_sdl2_gfx.c', 'test_sdl2_gfx.png', cflags=['-sUSE_SDL=2', '-sUSE_SDL_GFX=2'], reference_slack=2)
 
   @requires_graphics_hardware
   def test_sdl2_canvas_palette_2(self):
@@ -3104,128 +3104,128 @@ Module["preRun"] = () => {
       Module['arguments'] = ['-b'];
     ''')
 
-    self.reftest('test_sdl2_canvas_palette_2.c', 'test_sdl_canvas_palette_r.png', emcc_args=['-sUSE_SDL=2', '--pre-js', 'args-r.js'])
-    self.reftest('test_sdl2_canvas_palette_2.c', 'test_sdl_canvas_palette_g.png', emcc_args=['-sUSE_SDL=2', '--pre-js', 'args-g.js'])
-    self.reftest('test_sdl2_canvas_palette_2.c', 'test_sdl_canvas_palette_b.png', emcc_args=['-sUSE_SDL=2', '--pre-js', 'args-b.js'])
+    self.reftest('test_sdl2_canvas_palette_2.c', 'test_sdl_canvas_palette_r.png', cflags=['-sUSE_SDL=2', '--pre-js', 'args-r.js'])
+    self.reftest('test_sdl2_canvas_palette_2.c', 'test_sdl_canvas_palette_g.png', cflags=['-sUSE_SDL=2', '--pre-js', 'args-g.js'])
+    self.reftest('test_sdl2_canvas_palette_2.c', 'test_sdl_canvas_palette_b.png', cflags=['-sUSE_SDL=2', '--pre-js', 'args-b.js'])
 
   def test_sdl2_swsurface(self):
-    self.btest_exit('test_sdl2_swsurface.c', emcc_args=['-sUSE_SDL=2'])
+    self.btest_exit('test_sdl2_swsurface.c', cflags=['-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_image_prepare(self):
     # load an image file, get pixel data.
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.not')
-    self.reftest('test_sdl2_image_prepare.c', 'screenshot.jpg', emcc_args=['--preload-file', 'screenshot.not', '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2'])
+    self.reftest('test_sdl2_image_prepare.c', 'screenshot.jpg', cflags=['--preload-file', 'screenshot.not', '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2'])
 
   @requires_graphics_hardware
   def test_sdl2_image_prepare_data(self):
     # load an image file, get pixel data.
     shutil.copy(test_file('screenshot.jpg'), 'screenshot.not')
-    self.reftest('test_sdl2_image_prepare_data.c', 'screenshot.jpg', emcc_args=['--preload-file', 'screenshot.not', '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2'])
+    self.reftest('test_sdl2_image_prepare_data.c', 'screenshot.jpg', cflags=['--preload-file', 'screenshot.not', '-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2'])
 
   @requires_graphics_hardware
   @proxied
   def test_sdl2_canvas_proxy(self):
     create_file('data.txt', 'datum')
-    self.reftest('test_sdl2_canvas_proxy.c', 'test_sdl2_canvas.png', emcc_args=['-sUSE_SDL=2', '--proxy-to-worker', '--preload-file', 'data.txt'])
+    self.reftest('test_sdl2_canvas_proxy.c', 'test_sdl2_canvas.png', cflags=['-sUSE_SDL=2', '--proxy-to-worker', '--preload-file', 'data.txt'])
 
   def test_sdl2_pumpevents(self):
     # key events should be detected using SDL_PumpEvents
-    self.btest_exit('test_sdl2_pumpevents.c', emcc_args=['--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=2'])
+    self.btest_exit('test_sdl2_pumpevents.c', cflags=['--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=2'])
 
   def test_sdl2_timer(self):
-    self.btest_exit('test_sdl2_timer.c', emcc_args=['-sUSE_SDL=2'])
+    self.btest_exit('test_sdl2_timer.c', cflags=['-sUSE_SDL=2'])
 
   def test_sdl2_canvas_size(self):
-    self.btest_exit('test_sdl2_canvas_size.c', emcc_args=['-sUSE_SDL=2'])
+    self.btest_exit('test_sdl2_canvas_size.c', cflags=['-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_gl_read(self):
     # SDL, OpenGL, readPixels
-    self.btest_exit('test_sdl2_gl_read.c', emcc_args=['-sUSE_SDL=2'])
+    self.btest_exit('test_sdl2_gl_read.c', cflags=['-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_glmatrixmode_texture(self):
     self.reftest('test_sdl2_glmatrixmode_texture.c', 'test_sdl2_glmatrixmode_texture.png',
-                 emcc_args=['-sLEGACY_GL_EMULATION', '-sUSE_SDL=2'])
+                 cflags=['-sLEGACY_GL_EMULATION', '-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_gldrawelements(self):
     self.reftest('test_sdl2_gldrawelements.c', 'test_sdl2_gldrawelements.png',
-                 emcc_args=['-sLEGACY_GL_EMULATION', '-sUSE_SDL=2'])
+                 cflags=['-sLEGACY_GL_EMULATION', '-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_glclipplane_gllighting(self):
     self.reftest('test_sdl2_glclipplane_gllighting.c', 'test_sdl2_glclipplane_gllighting.png',
-                 emcc_args=['-sLEGACY_GL_EMULATION', '-sUSE_SDL=2'])
+                 cflags=['-sLEGACY_GL_EMULATION', '-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_glalphatest(self):
     self.reftest('test_sdl2_glalphatest.c', 'test_sdl2_glalphatest.png',
-                 emcc_args=['-sLEGACY_GL_EMULATION', '-sUSE_SDL=2'])
+                 cflags=['-sLEGACY_GL_EMULATION', '-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_fog_simple(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl2_fog_simple.c', 'screenshot-fog-simple.png',
-                 emcc_args=['-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '-O2', '--minify=0', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins'])
+                 cflags=['-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '-O2', '--minify=0', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins'])
 
   @requires_graphics_hardware
   def test_sdl2_fog_negative(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl2_fog_negative.c', 'screenshot-fog-negative.png',
-                 emcc_args=['-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins'])
+                 cflags=['-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins'])
 
   @requires_graphics_hardware
   def test_sdl2_fog_density(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl2_fog_density.c', 'screenshot-fog-density.png',
-                 emcc_args=['-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins'])
+                 cflags=['-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins'])
 
   @requires_graphics_hardware
   def test_sdl2_fog_exp2(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl2_fog_exp2.c', 'screenshot-fog-exp2.png',
-                 emcc_args=['-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins'])
+                 cflags=['-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins'])
 
   @requires_graphics_hardware
   def test_sdl2_fog_linear(self):
     shutil.copy(test_file('screenshot.png'), '.')
     self.reftest('test_sdl2_fog_linear.c', 'screenshot-fog-linear.png', reference_slack=1,
-                 emcc_args=['-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins'])
+                 cflags=['-sUSE_SDL=2', '-sUSE_SDL_IMAGE=2', '--preload-file', 'screenshot.png', '-sLEGACY_GL_EMULATION', '--use-preload-plugins'])
 
   def test_sdl2_unwasteful(self):
-    self.btest_exit('test_sdl2_unwasteful.c', emcc_args=['-sUSE_SDL=2', '-O1'])
+    self.btest_exit('test_sdl2_unwasteful.c', cflags=['-sUSE_SDL=2', '-O1'])
 
   def test_sdl2_canvas_write(self):
-    self.btest_exit('test_sdl2_canvas_write.c', emcc_args=['-sUSE_SDL=2'])
+    self.btest_exit('test_sdl2_canvas_write.c', cflags=['-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   @proxied
   def test_sdl2_gl_frames_swap(self):
-    self.reftest('test_sdl2_gl_frames_swap.c', 'test_sdl2_gl_frames_swap.png', emcc_args=['--proxy-to-worker', '-sUSE_SDL=2'])
+    self.reftest('test_sdl2_gl_frames_swap.c', 'test_sdl2_gl_frames_swap.png', cflags=['--proxy-to-worker', '-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_ttf(self):
     shutil.copy2(test_file('freetype/LiberationSansBold.ttf'), self.get_dir())
     self.reftest('test_sdl2_ttf.c', 'test_sdl2_ttf.png',
-                 emcc_args=['-O2', '-sUSE_SDL=2', '-sUSE_SDL_TTF=2', '--embed-file', 'LiberationSansBold.ttf'])
+                 cflags=['-O2', '-sUSE_SDL=2', '-sUSE_SDL_TTF=2', '--embed-file', 'LiberationSansBold.ttf'])
 
   @requires_graphics_hardware
   def test_sdl2_ttf_rtl(self):
     shutil.copy2(test_file('third_party/notofont/NotoNaskhArabic-Regular.ttf'), self.get_dir())
     self.reftest('test_sdl2_ttf_rtl.c', 'test_sdl2_ttf_rtl.png',
-                 emcc_args=['-O2', '-sUSE_SDL=2', '-sUSE_SDL_TTF=2', '--embed-file', 'NotoNaskhArabic-Regular.ttf'])
+                 cflags=['-O2', '-sUSE_SDL=2', '-sUSE_SDL_TTF=2', '--embed-file', 'NotoNaskhArabic-Regular.ttf'])
 
   def test_sdl2_custom_cursor(self):
     shutil.copy(test_file('cursor.bmp'), '.')
-    self.btest_exit('test_sdl2_custom_cursor.c', emcc_args=['--preload-file', 'cursor.bmp', '-sUSE_SDL=2'])
+    self.btest_exit('test_sdl2_custom_cursor.c', cflags=['--preload-file', 'cursor.bmp', '-sUSE_SDL=2'])
 
   def test_sdl2_misc(self):
-    self.btest_exit('test_sdl2_misc.c', emcc_args=['-sUSE_SDL=2'])
+    self.btest_exit('test_sdl2_misc.c', cflags=['-sUSE_SDL=2'])
 
   def test_sdl2_misc_main_module(self):
-    self.btest_exit('test_sdl2_misc.c', emcc_args=['-sUSE_SDL=2', '-sMAIN_MODULE'])
+    self.btest_exit('test_sdl2_misc.c', cflags=['-sUSE_SDL=2', '-sMAIN_MODULE'])
 
   def test_sdl2_misc_via_object(self):
     self.emcc(test_file('browser/test_sdl2_misc.c'), ['-c', '-sUSE_SDL=2', '-o', 'test.o'])
@@ -3240,7 +3240,7 @@ Module["preRun"] = () => {
   @requires_sound_hardware
   def test_sdl2_mixer_wav(self, flags):
     shutil.copy(test_file('sounds/the_entertainer.wav'), 'sound.wav')
-    self.btest_exit('test_sdl2_mixer_wav.c', emcc_args=['--preload-file', 'sound.wav'] + flags)
+    self.btest_exit('test_sdl2_mixer_wav.c', cflags=['--preload-file', 'sound.wav'] + flags)
 
   @parameterized({
     'wav': ([],         '0',            'the_entertainer.wav'),
@@ -3266,15 +3266,15 @@ Module["preRun"] = () => {
     # libraries when using it.
     if 'mod' in formats:
       args += ['-lc++', '-lc++abi']
-    self.btest_exit('test_sdl2_mixer_music.c', emcc_args=args)
+    self.btest_exit('test_sdl2_mixer_music.c', cflags=args)
 
   def test_sdl3_misc(self):
-    self.emcc_args.append('-Wno-experimental')
-    self.btest_exit('test_sdl3_misc.c', emcc_args=['-sUSE_SDL=3'])
+    self.cflags.append('-Wno-experimental')
+    self.btest_exit('test_sdl3_misc.c', cflags=['-sUSE_SDL=3'])
 
   def test_sdl3_canvas_write(self):
-    self.emcc_args.append('-Wno-experimental')
-    self.btest_exit('test_sdl3_canvas_write.c', emcc_args=['-sUSE_SDL=3'])
+    self.cflags.append('-Wno-experimental')
+    self.btest_exit('test_sdl3_canvas_write.c', cflags=['-sUSE_SDL=3'])
 
   @requires_graphics_hardware
   @no_wasm64('cocos2d ports does not compile with wasm64')
@@ -3284,7 +3284,7 @@ Module["preRun"] = () => {
     cocos2d_root = os.path.join(ports.Ports.get_dir(), 'cocos2d', 'Cocos2d-version_3_3')
     preload_file = os.path.join(cocos2d_root, 'samples', 'Cpp', 'HelloCpp', 'Resources') + '@'
     self.reftest('cocos2d_hello.cpp', 'cocos2d_hello.png', reference_slack=1,
-                 emcc_args=['-sUSE_COCOS2D=3', '-sERROR_ON_UNDEFINED_SYMBOLS=0',
+                 cflags=['-sUSE_COCOS2D=3', '-sERROR_ON_UNDEFINED_SYMBOLS=0',
                             # This line should really just be `-std=c++14` like we use to compile
                             # the cocos library itself, but that doesn't work in this case because
                             # btest adds browser_reporting.c to the command.
@@ -3306,40 +3306,40 @@ Module["preRun"] = () => {
 
     for opts in (0, 1, 2, 3):
       print(opts)
-      self.btest_exit('async.cpp', emcc_args=['-O' + str(opts), '-g2'] + args)
+      self.btest_exit('async.cpp', cflags=['-O' + str(opts), '-g2'] + args)
 
   def test_asyncify_tricky_function_sig(self):
-    self.btest('test_asyncify_tricky_function_sig.cpp', '85', emcc_args=['-sASYNCIFY_ONLY=[foo(char.const*?.int#),foo2(),main,__original_main]', '-sASYNCIFY'])
+    self.btest('test_asyncify_tricky_function_sig.cpp', '85', cflags=['-sASYNCIFY_ONLY=[foo(char.const*?.int#),foo2(),main,__original_main]', '-sASYNCIFY'])
 
   def test_async_in_pthread(self):
-    self.btest_exit('async.cpp', emcc_args=['-sASYNCIFY', '-pthread', '-sPROXY_TO_PTHREAD', '-g'])
+    self.btest_exit('async.cpp', cflags=['-sASYNCIFY', '-pthread', '-sPROXY_TO_PTHREAD', '-g'])
 
   def test_async_2(self):
     # Error.stackTraceLimit default to 10 in chrome but this test relies on more
     # than 40 stack frames being reported.
     create_file('pre.js', 'Error.stackTraceLimit = 80;\n')
-    self.btest_exit('async_2.cpp', emcc_args=['-O3', '--pre-js', 'pre.js', '-sASYNCIFY', '-sSTACK_SIZE=1MB'])
+    self.btest_exit('async_2.cpp', cflags=['-O3', '--pre-js', 'pre.js', '-sASYNCIFY', '-sSTACK_SIZE=1MB'])
 
   @parameterized({
     '': ([],),
     'O3': (['-O3'],),
   })
   def test_async_virtual(self, args):
-    self.btest_exit('async_virtual.cpp', emcc_args=args + ['-profiling', '-sASYNCIFY'])
+    self.btest_exit('async_virtual.cpp', cflags=args + ['-profiling', '-sASYNCIFY'])
 
   @parameterized({
     '': ([],),
     'O3': (['-O3'],),
   })
   def test_async_virtual_2(self, args):
-    self.btest_exit('async_virtual_2.cpp', emcc_args=args + ['-sASSERTIONS', '-sSAFE_HEAP', '-profiling', '-sASYNCIFY'])
+    self.btest_exit('async_virtual_2.cpp', cflags=args + ['-sASSERTIONS', '-sSAFE_HEAP', '-profiling', '-sASYNCIFY'])
 
   @parameterized({
     '': ([],),
     'O3': (['-O3'],),
   })
   def test_async_mainloop(self, args):
-    self.btest_exit('test_async_mainloop.c', emcc_args=args + ['-sASYNCIFY'])
+    self.btest_exit('test_async_mainloop.c', cflags=args + ['-sASYNCIFY'])
 
   @requires_sound_hardware
   @parameterized({
@@ -3347,16 +3347,16 @@ Module["preRun"] = () => {
     'safeheap': (['-sSAFE_HEAP'],),
   })
   def test_sdl_audio_beep_sleep(self, args):
-    self.btest_exit('test_sdl_audio_beep_sleep.cpp', emcc_args=['-Os', '-sASSERTIONS', '-sDISABLE_EXCEPTION_CATCHING=0', '-profiling', '-lSDL', '-sASYNCIFY'] + args, timeout=90)
+    self.btest_exit('test_sdl_audio_beep_sleep.cpp', cflags=['-Os', '-sASSERTIONS', '-sDISABLE_EXCEPTION_CATCHING=0', '-profiling', '-lSDL', '-sASYNCIFY'] + args, timeout=90)
 
   def test_mainloop_reschedule(self):
-    self.btest('test_mainloop_reschedule.c', '1', emcc_args=['-Os', '-sASYNCIFY'])
+    self.btest('test_mainloop_reschedule.c', '1', cflags=['-Os', '-sASYNCIFY'])
 
   def test_mainloop_infloop(self):
-    self.btest('test_mainloop_infloop.c', '1', emcc_args=['-sASYNCIFY'])
+    self.btest('test_mainloop_infloop.c', '1', cflags=['-sASYNCIFY'])
 
   def test_async_iostream(self):
-    self.btest('async_iostream.cpp', '1', emcc_args=['-sASYNCIFY'])
+    self.btest('async_iostream.cpp', '1', cflags=['-sASYNCIFY'])
 
   # Test an async return value. The value goes through a custom JS library
   # method that uses asyncify, and therefore it needs to be declared in
@@ -3373,18 +3373,18 @@ Module["preRun"] = () => {
   def test_async_returnvalue(self, args):
     if '@' in str(args):
       create_file('filey.txt', 'sync_tunnel\nsync_tunnel_bool\n')
-    self.btest('async_returnvalue.cpp', '0', emcc_args=['-sASYNCIFY', '-sASYNCIFY_IGNORE_INDIRECT', '--js-library', test_file('browser/async_returnvalue.js')] + args + ['-sASSERTIONS'])
+    self.btest('async_returnvalue.cpp', '0', cflags=['-sASYNCIFY', '-sASYNCIFY_IGNORE_INDIRECT', '--js-library', test_file('browser/async_returnvalue.js')] + args + ['-sASSERTIONS'])
 
   def test_async_bad_list(self):
-    self.btest('async_bad_list.cpp', '0', emcc_args=['-sASYNCIFY', '-sASYNCIFY_ONLY=waka', '--profiling'])
+    self.btest('async_bad_list.cpp', '0', cflags=['-sASYNCIFY', '-sASYNCIFY_ONLY=waka', '--profiling'])
 
   # Tests that when building with -sMINIMAL_RUNTIME, the build can use -sMODULARIZE as well.
   def test_minimal_runtime_modularize(self):
-    self.btest_exit('browser_test_hello_world.c', emcc_args=['-sMODULARIZE', '-sMINIMAL_RUNTIME'])
+    self.btest_exit('browser_test_hello_world.c', cflags=['-sMODULARIZE', '-sMINIMAL_RUNTIME'])
 
   # Tests that when building with -sMINIMAL_RUNTIME, the build can use -sEXPORT_NAME=Foo as well.
   def test_minimal_runtime_export_name(self):
-    self.btest_exit('browser_test_hello_world.c', emcc_args=['-sEXPORT_NAME=Foo', '-sMINIMAL_RUNTIME'])
+    self.btest_exit('browser_test_hello_world.c', cflags=['-sEXPORT_NAME=Foo', '-sMINIMAL_RUNTIME'])
 
   @parameterized({
     # defaults
@@ -3516,7 +3516,7 @@ Module["preRun"] = () => {
     self.run_process([WEBIDL_BINDER, test_file('webidl/test.idl'), 'glue'])
     self.assertExists('glue.cpp')
     self.assertExists('glue.js')
-    self.btest('webidl/test.cpp', '1', emcc_args=['--post-js', 'glue.js', '-I.', '-DBROWSER'] + args)
+    self.btest('webidl/test.cpp', '1', cflags=['--post-js', 'glue.js', '-I.', '-DBROWSER'] + args)
 
   @no_wasm64('https://github.com/llvm/llvm-project/issues/98778')
   @also_with_proxying
@@ -3541,20 +3541,20 @@ Module["preRun"] = () => {
       }
     ''')
     self.emcc('side.c', ['-sSIDE_MODULE', '-O2', '-o', 'side.wasm'])
-    self.btest_exit('main.c', emcc_args=['-sMAIN_MODULE=2', '-O2', 'side.wasm'])
+    self.btest_exit('main.c', cflags=['-sMAIN_MODULE=2', '-O2', 'side.wasm'])
 
   def test_dlopen_async(self):
     create_file('side.c', 'int foo = 42;\n')
     self.emcc('side.c', ['-o', 'libside.so', '-sSIDE_MODULE'])
-    self.btest_exit('other/test_dlopen_async.c', emcc_args=['-sMAIN_MODULE=2'])
+    self.btest_exit('other/test_dlopen_async.c', cflags=['-sMAIN_MODULE=2'])
 
   def test_dlopen_blocking(self):
     self.emcc(test_file('other/test_dlopen_blocking_side.c'), ['-o', 'libside.so', '-sSIDE_MODULE', '-pthread', '-Wno-experimental'])
     # Attempt to use dlopen the side module (without preloading) should fail on the main thread
     # since the syncronous `readBinary` function does not exist.
-    self.btest_exit('other/test_dlopen_blocking.c', assert_returncode=1, emcc_args=['-sMAIN_MODULE=2', '-sAUTOLOAD_DYLIBS=0', 'libside.so'])
+    self.btest_exit('other/test_dlopen_blocking.c', assert_returncode=1, cflags=['-sMAIN_MODULE=2', '-sAUTOLOAD_DYLIBS=0', 'libside.so'])
     # But with PROXY_TO_PTHEAD it does work, since we can do blocking and sync XHR in a worker.
-    self.btest_exit('other/test_dlopen_blocking.c', emcc_args=['-sMAIN_MODULE=2', '-sPROXY_TO_PTHREAD', '-pthread', '-Wno-experimental', '-sAUTOLOAD_DYLIBS=0', 'libside.so'])
+    self.btest_exit('other/test_dlopen_blocking.c', cflags=['-sMAIN_MODULE=2', '-sPROXY_TO_PTHREAD', '-pthread', '-Wno-experimental', '-sAUTOLOAD_DYLIBS=0', 'libside.so'])
 
   # verify that dynamic linking works in all kinds of in-browser environments.
   # don't mix different kinds in a single test.
@@ -3563,9 +3563,9 @@ Module["preRun"] = () => {
     'inworker': ([1],),
   })
   def test_dylink_dso_needed(self, inworker):
-    self.emcc_args += ['-O2']
+    self.cflags += ['-O2']
 
-    def do_run(src, expected_output, emcc_args):
+    def do_run(src, expected_output, cflags):
       # XXX there is no infrastructure (yet ?) to retrieve stdout from browser in tests.
       # -> do the assert about expected output inside browser.
       #
@@ -3595,8 +3595,8 @@ Module["preRun"] = () => {
       ''' % expected_output)
       # --proxy-to-worker only on main
       if inworker:
-        emcc_args += ['--proxy-to-worker']
-      self.btest_exit('test_dylink_dso_needed.c', emcc_args=['--post-js', 'post.js'] + emcc_args)
+        cflags += ['--proxy-to-worker']
+      self.btest_exit('test_dylink_dso_needed.c', cflags=['--post-js', 'post.js'] + cflags)
 
     self._test_dylink_dso_needed(do_run)
 
@@ -3626,7 +3626,7 @@ Module["preRun"] = () => {
     ''')
     self.emcc('side.c', ['-sSIDE_MODULE', '-O2', '-o', 'side.wasm', '-lSDL'])
 
-    self.btest_exit('main.c', emcc_args=['-sMAIN_MODULE=2', '-O2', '-sLEGACY_GL_EMULATION', '-lSDL', '-lGL', 'side.wasm'])
+    self.btest_exit('main.c', cflags=['-sMAIN_MODULE=2', '-O2', '-sLEGACY_GL_EMULATION', '-lSDL', '-lGL', 'side.wasm'])
 
   def test_dylink_many(self):
     # test asynchronously loading two side modules during startup
@@ -3648,7 +3648,7 @@ Module["preRun"] = () => {
     ''')
     self.emcc('side1.c', ['-sSIDE_MODULE', '-o', 'side1.wasm'])
     self.emcc('side2.c', ['-sSIDE_MODULE', '-o', 'side2.wasm'])
-    self.btest_exit('main.c', emcc_args=['-sMAIN_MODULE=2', 'side1.wasm', 'side2.wasm'])
+    self.btest_exit('main.c', cflags=['-sMAIN_MODULE=2', 'side1.wasm', 'side2.wasm'])
 
   def test_dylink_pthread_many(self):
     # Test asynchronously loading two side modules during startup
@@ -3693,13 +3693,13 @@ Module["preRun"] = () => {
     self.emcc('side1.cpp', ['-Wno-experimental', '-pthread', '-sSIDE_MODULE', '-o', 'side1.wasm'])
     self.emcc('side2.cpp', ['-Wno-experimental', '-pthread', '-sSIDE_MODULE', '-o', 'side2.wasm'])
     self.btest_exit('main.cpp',
-                    emcc_args=['-Wno-experimental', '-pthread', '-sMAIN_MODULE=2', 'side1.wasm', 'side2.wasm'])
+                    cflags=['-Wno-experimental', '-pthread', '-sMAIN_MODULE=2', 'side1.wasm', 'side2.wasm'])
 
   @no_2gb('uses INITIAL_MEMORY')
   @no_4gb('uses INITIAL_MEMORY')
   def test_memory_growth_during_startup(self):
     create_file('data.dat', 'X' * (30 * 1024 * 1024))
-    self.btest('browser_test_hello_world.c', '0', emcc_args=['-sASSERTIONS', '-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=16MB', '-sSTACK_SIZE=16384', '--preload-file', 'data.dat'])
+    self.btest('browser_test_hello_world.c', '0', cflags=['-sASSERTIONS', '-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=16MB', '-sSTACK_SIZE=16384', '--preload-file', 'data.dat'])
 
   # pthreads tests
 
@@ -3713,22 +3713,22 @@ Module["preRun"] = () => {
 
   def test_pthread_c11_threads(self):
     self.btest_exit('pthread/test_pthread_c11_threads.c',
-                    emcc_args=['-gsource-map', '-std=gnu11', '-pthread', '-sPROXY_TO_PTHREAD'])
+                    cflags=['-gsource-map', '-std=gnu11', '-pthread', '-sPROXY_TO_PTHREAD'])
 
   def test_pthread_pool_size_strict(self):
     # Check that it doesn't fail with sufficient number of threads in the pool.
     self.btest_exit('pthread/test_pthread_c11_threads.c',
-                    emcc_args=['-g2', '-std=gnu11', '-pthread', '-sPTHREAD_POOL_SIZE=4', '-sPTHREAD_POOL_SIZE_STRICT=2'])
+                    cflags=['-g2', '-std=gnu11', '-pthread', '-sPTHREAD_POOL_SIZE=4', '-sPTHREAD_POOL_SIZE_STRICT=2'])
     # Check that it fails instead of deadlocking on insufficient number of threads in the pool.
     self.btest('pthread/test_pthread_c11_threads.c',
                expected='abort:Assertion failed: thrd_create(&t4, thread_main, NULL) == thrd_success',
-               emcc_args=['-g2', '-std=gnu11', '-pthread', '-sPTHREAD_POOL_SIZE=3', '-sPTHREAD_POOL_SIZE_STRICT=2'])
+               cflags=['-g2', '-std=gnu11', '-pthread', '-sPTHREAD_POOL_SIZE=3', '-sPTHREAD_POOL_SIZE_STRICT=2'])
 
   def test_pthread_in_pthread_pool_size_strict(self):
     # Check that it fails when there's a pthread creating another pthread.
-    self.btest_exit('pthread/test_pthread_create_pthread.c', emcc_args=['-g2', '-pthread', '-sPTHREAD_POOL_SIZE=2', '-sPTHREAD_POOL_SIZE_STRICT=2'])
+    self.btest_exit('pthread/test_pthread_create_pthread.c', cflags=['-g2', '-pthread', '-sPTHREAD_POOL_SIZE=2', '-sPTHREAD_POOL_SIZE_STRICT=2'])
     # Check that it fails when there's a pthread creating another pthread.
-    self.btest_exit('pthread/test_pthread_create_pthread.c', emcc_args=['-g2', '-pthread', '-sPTHREAD_POOL_SIZE=1', '-sPTHREAD_POOL_SIZE_STRICT=2', '-DSMALL_POOL'])
+    self.btest_exit('pthread/test_pthread_create_pthread.c', cflags=['-g2', '-pthread', '-sPTHREAD_POOL_SIZE=1', '-sPTHREAD_POOL_SIZE_STRICT=2', '-DSMALL_POOL'])
 
   # Test that the emscripten_ atomics api functions work.
   @parameterized({
@@ -3736,11 +3736,11 @@ Module["preRun"] = () => {
     'closure': (['--closure=1'],),
   })
   def test_pthread_atomics(self, args):
-    self.btest_exit('pthread/test_pthread_atomics.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8', '-g1'] + args)
+    self.btest_exit('pthread/test_pthread_atomics.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8', '-g1'] + args)
 
   # Test 64-bit atomics.
   def test_pthread_64bit_atomics(self):
-    self.btest_exit('pthread/test_pthread_64bit_atomics.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.btest_exit('pthread/test_pthread_64bit_atomics.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # Test 64-bit C++11 atomics.
   @also_with_threads
@@ -3749,15 +3749,15 @@ Module["preRun"] = () => {
     'O3': (['-O3'],),
   })
   def test_pthread_64bit_cxx11_atomics(self, opt):
-    self.btest_exit('pthread/test_pthread_64bit_cxx11_atomics.cpp', emcc_args=opt)
+    self.btest_exit('pthread/test_pthread_64bit_cxx11_atomics.cpp', cflags=opt)
 
   # Test c++ std::thread::hardware_concurrency()
   def test_pthread_hardware_concurrency(self):
-    self.btest_exit('pthread/test_pthread_hardware_concurrency.cpp', emcc_args=['-O2', '-pthread', '-sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency'])
+    self.btest_exit('pthread/test_pthread_hardware_concurrency.cpp', cflags=['-O2', '-pthread', '-sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency'])
 
   # Test that we error if not ALLOW_BLOCKING_ON_MAIN_THREAD
   def test_pthread_main_thread_blocking_wait(self):
-    self.btest('pthread/main_thread_wait.c', expected='abort:Blocking on the main thread is not allowed by default.', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE', '-sALLOW_BLOCKING_ON_MAIN_THREAD=0'])
+    self.btest('pthread/main_thread_wait.c', expected='abort:Blocking on the main thread is not allowed by default.', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE', '-sALLOW_BLOCKING_ON_MAIN_THREAD=0'])
 
   # Test that we error or warn depending on ALLOW_BLOCKING_ON_MAIN_THREAD or ASSERTIONS
   def test_pthread_main_thread_blocking_join(self):
@@ -3769,15 +3769,15 @@ Module["preRun"] = () => {
       };
     ''')
     # Test that we warn about blocking on the main thread in debug builds
-    self.btest('pthread/main_thread_join.cpp', expected='got_warn', emcc_args=['-sEXIT_RUNTIME', '-sASSERTIONS', '--pre-js', 'pre.js', '-pthread', '-sPTHREAD_POOL_SIZE'])
+    self.btest('pthread/main_thread_join.cpp', expected='got_warn', cflags=['-sEXIT_RUNTIME', '-sASSERTIONS', '--pre-js', 'pre.js', '-pthread', '-sPTHREAD_POOL_SIZE'])
     # Test that we do not warn about blocking on the main thread in release builds
-    self.btest_exit('pthread/main_thread_join.cpp', emcc_args=['-O3', '--pre-js', 'pre.js', '-pthread', '-sPTHREAD_POOL_SIZE'])
+    self.btest_exit('pthread/main_thread_join.cpp', cflags=['-O3', '--pre-js', 'pre.js', '-pthread', '-sPTHREAD_POOL_SIZE'])
     # Test that tryjoin is fine, even if not ALLOW_BLOCKING_ON_MAIN_THREAD
-    self.btest_exit('pthread/main_thread_join.cpp', assert_returncode=2, emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE', '-g', '-DTRY_JOIN', '-sALLOW_BLOCKING_ON_MAIN_THREAD=0'])
+    self.btest_exit('pthread/main_thread_join.cpp', assert_returncode=2, cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE', '-g', '-DTRY_JOIN', '-sALLOW_BLOCKING_ON_MAIN_THREAD=0'])
     # Test that tryjoin is fine, even if not ALLOW_BLOCKING_ON_MAIN_THREAD, and even without a pool
-    self.btest_exit('pthread/main_thread_join.cpp', assert_returncode=2, emcc_args=['-O3', '-pthread', '-g', '-DTRY_JOIN', '-sALLOW_BLOCKING_ON_MAIN_THREAD=0'])
+    self.btest_exit('pthread/main_thread_join.cpp', assert_returncode=2, cflags=['-O3', '-pthread', '-g', '-DTRY_JOIN', '-sALLOW_BLOCKING_ON_MAIN_THREAD=0'])
     # Test that everything works ok when we are on a pthread
-    self.btest_exit('pthread/main_thread_join.cpp', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE', '-sPROXY_TO_PTHREAD', '-sALLOW_BLOCKING_ON_MAIN_THREAD=0'])
+    self.btest_exit('pthread/main_thread_join.cpp', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE', '-sPROXY_TO_PTHREAD', '-sALLOW_BLOCKING_ON_MAIN_THREAD=0'])
 
   # Test the old GCC atomic __sync_fetch_and_op builtin operations.
   @parameterized({
@@ -3788,35 +3788,35 @@ Module["preRun"] = () => {
     'Os': (['-Os'],),
   })
   def test_pthread_gcc_atomic_fetch_and_op(self, args):
-    self.emcc_args += ['-Wno-sync-fetch-and-nand-semantics-changed']
-    self.btest_exit('pthread/test_pthread_gcc_atomic_fetch_and_op.c', emcc_args=args + ['-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.cflags += ['-Wno-sync-fetch-and-nand-semantics-changed']
+    self.btest_exit('pthread/test_pthread_gcc_atomic_fetch_and_op.c', cflags=args + ['-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # 64 bit version of the above test.
   @also_with_wasm2js
   def test_pthread_gcc_64bit_atomic_fetch_and_op(self):
     if self.is_wasm2js():
       self.skipTest('https://github.com/WebAssembly/binaryen/issues/4358')
-    self.emcc_args += ['-Wno-sync-fetch-and-nand-semantics-changed']
-    self.btest_exit('pthread/test_pthread_gcc_64bit_atomic_fetch_and_op.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.cflags += ['-Wno-sync-fetch-and-nand-semantics-changed']
+    self.btest_exit('pthread/test_pthread_gcc_64bit_atomic_fetch_and_op.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # Test the old GCC atomic __sync_op_and_fetch builtin operations.
   @also_with_wasm2js
   def test_pthread_gcc_atomic_op_and_fetch(self):
-    self.emcc_args += ['-Wno-sync-fetch-and-nand-semantics-changed']
-    self.btest_exit('pthread/test_pthread_gcc_atomic_op_and_fetch.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.cflags += ['-Wno-sync-fetch-and-nand-semantics-changed']
+    self.btest_exit('pthread/test_pthread_gcc_atomic_op_and_fetch.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # 64 bit version of the above test.
   @also_with_wasm2js
   def test_pthread_gcc_64bit_atomic_op_and_fetch(self):
     if self.is_wasm2js():
       self.skipTest('https://github.com/WebAssembly/binaryen/issues/4358')
-    self.emcc_args += ['-Wno-sync-fetch-and-nand-semantics-changed', '--profiling-funcs']
-    self.btest_exit('pthread/test_pthread_gcc_64bit_atomic_op_and_fetch.c', emcc_args=['-pthread', '-O2', '-sPTHREAD_POOL_SIZE=8'])
+    self.cflags += ['-Wno-sync-fetch-and-nand-semantics-changed', '--profiling-funcs']
+    self.btest_exit('pthread/test_pthread_gcc_64bit_atomic_op_and_fetch.c', cflags=['-pthread', '-O2', '-sPTHREAD_POOL_SIZE=8'])
 
   # Tests the rest of the remaining GCC atomics after the two above tests.
   @also_with_wasm2js
   def test_pthread_gcc_atomics(self):
-    self.btest_exit('pthread/test_pthread_gcc_atomics.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.btest_exit('pthread/test_pthread_gcc_atomics.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # Test the __sync_lock_test_and_set and __sync_lock_release primitives.
   @also_with_wasm2js
@@ -3825,7 +3825,7 @@ Module["preRun"] = () => {
     'em_instrinsics': (['-DUSE_EMSCRIPTEN_INTRINSICS'],),
   })
   def test_pthread_gcc_spinlock(self, args):
-    self.btest_exit('pthread/test_pthread_gcc_spinlock.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'] + args)
+    self.btest_exit('pthread/test_pthread_gcc_spinlock.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'] + args)
 
   @parameterized({
     '': ([],),
@@ -3835,7 +3835,7 @@ Module["preRun"] = () => {
   })
   def test_pthread_create(self, args):
     self.btest_exit('pthread/test_pthread_create.c',
-                    emcc_args=['-pthread', '-sPTHREAD_POOL_SIZE=8'] + args,
+                    cflags=['-pthread', '-sPTHREAD_POOL_SIZE=8'] + args,
                     extra_tries=0) # this should be 100% deterministic
     files = os.listdir('.')
     if '-sSINGLE_FILE' in args:
@@ -3845,17 +3845,17 @@ Module["preRun"] = () => {
 
   # Test that preallocating worker threads work.
   def test_pthread_preallocates_workers(self):
-    self.btest_exit('pthread/test_pthread_preallocates_workers.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=4', '-sPTHREAD_POOL_DELAY_LOAD'])
+    self.btest_exit('pthread/test_pthread_preallocates_workers.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=4', '-sPTHREAD_POOL_DELAY_LOAD'])
 
   # Test that allocating a lot of threads doesn't regress. This needs to be checked manually!
   @no_2gb('uses INITIAL_MEMORY')
   @no_4gb('uses INITIAL_MEMORY')
   def test_pthread_large_pthread_allocation(self):
-    self.btest_exit('pthread/test_large_pthread_allocation.c', emcc_args=['-sINITIAL_MEMORY=128MB', '-O3', '-pthread', '-sPTHREAD_POOL_SIZE=50'])
+    self.btest_exit('pthread/test_large_pthread_allocation.c', cflags=['-sINITIAL_MEMORY=128MB', '-O3', '-pthread', '-sPTHREAD_POOL_SIZE=50'])
 
   # Tests the -sPROXY_TO_PTHREAD option.
   def test_pthread_proxy_to_pthread(self):
-    self.btest_exit('pthread/test_pthread_proxy_to_pthread.c', emcc_args=['-O3', '-pthread', '-sPROXY_TO_PTHREAD'])
+    self.btest_exit('pthread/test_pthread_proxy_to_pthread.c', cflags=['-O3', '-pthread', '-sPROXY_TO_PTHREAD'])
 
   # Test that a pthread can spawn another pthread of its own.
   @parameterized({
@@ -3863,36 +3863,36 @@ Module["preRun"] = () => {
     'modularize': (['-sMODULARIZE', '-sEXPORT_NAME=MyModule', '--shell-file', test_file('shell_that_launches_modularize.html')],),
   })
   def test_pthread_create_pthread(self, args):
-    self.btest_exit('pthread/test_pthread_create_pthread.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=2'] + args)
+    self.btest_exit('pthread/test_pthread_create_pthread.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=2'] + args)
 
   # Test another case of pthreads spawning pthreads, but this time the callers immediately join on the threads they created.
   def test_pthread_nested_spawns(self):
-    self.btest_exit('pthread/test_pthread_nested_spawns.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=2'])
+    self.btest_exit('pthread/test_pthread_nested_spawns.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=2'])
 
   # Test that main thread can wait for a pthread to finish via pthread_join().
   def test_pthread_join(self):
-    self.btest_exit('pthread/test_pthread_join.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.btest_exit('pthread/test_pthread_join.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # Test that threads can rejoin the pool once detached and finished
   def test_std_thread_detach(self):
-    self.btest_exit('pthread/test_std_thread_detach.cpp', emcc_args=['-pthread'])
+    self.btest_exit('pthread/test_std_thread_detach.cpp', cflags=['-pthread'])
 
   # Test pthread_cancel() operation
   def test_pthread_cancel(self):
-    self.btest_exit('pthread/test_pthread_cancel.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.btest_exit('pthread/test_pthread_cancel.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # Test that pthread_cancel() cancels pthread_cond_wait() operation
   def test_pthread_cancel_cond_wait(self):
-    self.btest_exit('pthread/test_pthread_cancel_cond_wait.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.btest_exit('pthread/test_pthread_cancel_cond_wait.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # Test pthread_kill() operation
   @no_chrome('pthread_kill hangs chrome renderer, and keep subsequent tests from passing')
   def test_pthread_kill(self):
-    self.btest_exit('pthread/test_pthread_kill.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.btest_exit('pthread/test_pthread_kill.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # Test that pthread cleanup stack (pthread_cleanup_push/_pop) works.
   def test_pthread_cleanup(self):
-    self.btest_exit('pthread/test_pthread_cleanup.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.btest_exit('pthread/test_pthread_cleanup.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # Tests the pthread mutex api.
   @parameterized({
@@ -3900,30 +3900,30 @@ Module["preRun"] = () => {
     'spinlock': (['-DSPINLOCK_TEST'],),
   })
   def test_pthread_mutex(self, args):
-    self.btest_exit('pthread/test_pthread_mutex.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'] + args)
+    self.btest_exit('pthread/test_pthread_mutex.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'] + args)
 
   def test_pthread_attr_getstack(self):
-    self.btest_exit('pthread/test_pthread_attr_getstack.c', emcc_args=['-pthread', '-sPTHREAD_POOL_SIZE=2'])
+    self.btest_exit('pthread/test_pthread_attr_getstack.c', cflags=['-pthread', '-sPTHREAD_POOL_SIZE=2'])
 
   # Test that memory allocation is thread-safe.
   def test_pthread_malloc(self):
-    self.btest_exit('pthread/test_pthread_malloc.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.btest_exit('pthread/test_pthread_malloc.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # Stress test pthreads allocating memory that will call to sbrk(), and main thread has to free up the data.
   def test_pthread_malloc_free(self):
-    self.btest_exit('pthread/test_pthread_malloc_free.cpp', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.btest_exit('pthread/test_pthread_malloc_free.cpp', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # Test that the pthread_barrier API works ok.
   def test_pthread_barrier(self):
-    self.btest_exit('pthread/test_pthread_barrier.cpp', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.btest_exit('pthread/test_pthread_barrier.cpp', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # Test the pthread_once() function.
   def test_pthread_once(self):
-    self.btest_exit('pthread/test_pthread_once.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.btest_exit('pthread/test_pthread_once.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # Test against a certain thread exit time handling bug by spawning tons of threads.
   def test_pthread_spawns(self):
-    self.btest_exit('pthread/test_pthread_spawns.cpp', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8', '--closure=1', '-sENVIRONMENT=web'])
+    self.btest_exit('pthread/test_pthread_spawns.cpp', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8', '--closure=1', '-sENVIRONMENT=web'])
 
   # It is common for code to flip volatile global vars for thread control. This is a bit lax, but nevertheless, test whether that
   # kind of scheme will work with Emscripten as well.
@@ -3932,15 +3932,15 @@ Module["preRun"] = () => {
     'atomic': ([],),
   })
   def test_pthread_volatile(self, args):
-    self.btest_exit('pthread/test_pthread_volatile.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'] + args)
+    self.btest_exit('pthread/test_pthread_volatile.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'] + args)
 
   # Test thread-specific data (TLS).
   def test_pthread_thread_local_storage(self):
-    self.btest_exit('pthread/test_pthread_thread_local_storage.cpp', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8', '-sASSERTIONS'])
+    self.btest_exit('pthread/test_pthread_thread_local_storage.cpp', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8', '-sASSERTIONS'])
 
   # Test the pthread condition variable creation and waiting.
   def test_pthread_condition_variable(self):
-    self.btest_exit('pthread/test_pthread_condition_variable.cpp', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
+    self.btest_exit('pthread/test_pthread_condition_variable.cpp', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8'])
 
   # Test that pthreads are able to do printf.
   @parameterized({
@@ -3949,23 +3949,23 @@ Module["preRun"] = () => {
     'debug': (['-sLIBRARY_DEBUG'],),
   })
   def test_pthread_printf(self, args):
-     self.btest_exit('pthread/test_pthread_printf.c', emcc_args=['-pthread', '-sPTHREAD_POOL_SIZE'] + args)
+     self.btest_exit('pthread/test_pthread_printf.c', cflags=['-pthread', '-sPTHREAD_POOL_SIZE'] + args)
 
   # Test that pthreads are able to do cout. Failed due to https://bugzilla.mozilla.org/show_bug.cgi?id=1154858.
   def test_pthread_iostream(self):
-    self.btest_exit('pthread/test_pthread_iostream.cpp', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE'])
+    self.btest_exit('pthread/test_pthread_iostream.cpp', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE'])
 
   def test_pthread_unistd_io_bigint(self):
-    self.btest_exit('unistd/io.c', emcc_args=['-pthread', '-sPROXY_TO_PTHREAD', '-sWASM_BIGINT'])
+    self.btest_exit('unistd/io.c', cflags=['-pthread', '-sPROXY_TO_PTHREAD', '-sWASM_BIGINT'])
 
   # Test that the main thread is able to use pthread_set/getspecific.
   @also_with_wasm2js
   def test_pthread_setspecific_mainthread(self):
-    self.btest_exit('pthread/test_pthread_setspecific_mainthread.c', emcc_args=['-O3', '-pthread'])
+    self.btest_exit('pthread/test_pthread_setspecific_mainthread.c', cflags=['-O3', '-pthread'])
 
   # Test that pthreads have access to filesystem.
   def test_pthread_file_io(self):
-    self.btest_exit('pthread/test_pthread_file_io.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE'])
+    self.btest_exit('pthread/test_pthread_file_io.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE'])
 
   # Test that the pthread_create() function operates benignly in the case that threading is not supported.
   @parameterized({
@@ -3973,16 +3973,16 @@ Module["preRun"] = () => {
    'mt': (['-pthread', '-sPTHREAD_POOL_SIZE=8'],),
   })
   def test_pthread_supported(self, args):
-    self.btest_exit('pthread/test_pthread_supported.cpp', emcc_args=['-O3'] + args)
+    self.btest_exit('pthread/test_pthread_supported.cpp', cflags=['-O3'] + args)
 
   def test_pthread_dispatch_after_exit(self):
-    self.btest_exit('pthread/test_pthread_dispatch_after_exit.c', emcc_args=['-pthread'])
+    self.btest_exit('pthread/test_pthread_dispatch_after_exit.c', cflags=['-pthread'])
 
   # Test that if the main thread is performing a futex wait while a pthread
   # needs it to do a proxied operation (before that pthread would wake up the
   # main thread), that it's not a deadlock.
   def test_pthread_proxying_in_futex_wait(self):
-    self.btest_exit('pthread/test_pthread_proxying_in_futex_wait.cpp', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE'])
+    self.btest_exit('pthread/test_pthread_proxying_in_futex_wait.cpp', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE'])
 
   # Test that sbrk() operates properly in multithreaded conditions
   @no_2gb('uses INITIAL_MEMORY')
@@ -3994,7 +3994,7 @@ Module["preRun"] = () => {
   def test_pthread_sbrk(self, args):
     # With aborting malloc = 1, test allocating memory in threads
     # With aborting malloc = 0, allocate so much memory in threads that some of the allocations fail.
-    self.btest_exit('pthread/test_pthread_sbrk.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8', '-sINITIAL_MEMORY=128MB'] + args)
+    self.btest_exit('pthread/test_pthread_sbrk.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE=8', '-sINITIAL_MEMORY=128MB'] + args)
 
   # Test that -sABORTING_MALLOC=0 works in both pthreads and non-pthreads
   # builds. (sbrk fails gracefully)
@@ -4004,35 +4004,35 @@ Module["preRun"] = () => {
     'O2': (['-O2'],),
   })
   def test_gauge_available_memory(self, args):
-    self.btest_exit('test_gauge_available_memory.c', emcc_args=['-sABORTING_MALLOC=0'] + args)
+    self.btest_exit('test_gauge_available_memory.c', cflags=['-sABORTING_MALLOC=0'] + args)
 
   # Test that the proxying operations of user code from pthreads to main thread
   # work
   def test_pthread_run_on_main_thread(self):
-    self.btest_exit('pthread/test_pthread_run_on_main_thread.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE'])
+    self.btest_exit('pthread/test_pthread_run_on_main_thread.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE'])
 
   # Test how a lot of back-to-back called proxying operations behave.
   def test_pthread_run_on_main_thread_flood(self):
-    self.btest_exit('pthread/test_pthread_run_on_main_thread_flood.c', emcc_args=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE'])
+    self.btest_exit('pthread/test_pthread_run_on_main_thread_flood.c', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE'])
 
   # Test that it is possible to asynchronously call a JavaScript function on the
   # main thread.
   def test_pthread_call_async(self):
-    self.btest_exit('pthread/call_async.c', emcc_args=['-pthread'])
+    self.btest_exit('pthread/call_async.c', cflags=['-pthread'])
 
   # Test that it is possible to synchronously call a JavaScript function on the
   # main thread and get a return value back.
   def test_pthread_call_sync_on_main_thread(self):
-    self.btest_exit('pthread/call_sync_on_main_thread.c', emcc_args=['-O3', '-pthread', '-sPROXY_TO_PTHREAD', '-DPROXY_TO_PTHREAD=1', '--js-library', test_file('pthread/call_sync_on_main_thread.js')])
-    self.btest_exit('pthread/call_sync_on_main_thread.c', emcc_args=['-O3', '-pthread', '-DPROXY_TO_PTHREAD=0', '--js-library', test_file('pthread/call_sync_on_main_thread.js')])
-    self.btest_exit('pthread/call_sync_on_main_thread.c', emcc_args=['-Oz', '-DPROXY_TO_PTHREAD=0', '--js-library', test_file('pthread/call_sync_on_main_thread.js')])
+    self.btest_exit('pthread/call_sync_on_main_thread.c', cflags=['-O3', '-pthread', '-sPROXY_TO_PTHREAD', '-DPROXY_TO_PTHREAD=1', '--js-library', test_file('pthread/call_sync_on_main_thread.js')])
+    self.btest_exit('pthread/call_sync_on_main_thread.c', cflags=['-O3', '-pthread', '-DPROXY_TO_PTHREAD=0', '--js-library', test_file('pthread/call_sync_on_main_thread.js')])
+    self.btest_exit('pthread/call_sync_on_main_thread.c', cflags=['-Oz', '-DPROXY_TO_PTHREAD=0', '--js-library', test_file('pthread/call_sync_on_main_thread.js')])
 
   # Test that it is possible to asynchronously call a JavaScript function on the
   # main thread.
   def test_pthread_call_async_on_main_thread(self):
-    self.btest('pthread/call_async_on_main_thread.c', expected='7', emcc_args=['-O3', '-pthread', '-sPROXY_TO_PTHREAD', '-DPROXY_TO_PTHREAD=1', '--js-library', test_file('pthread/call_async_on_main_thread.js')])
-    self.btest('pthread/call_async_on_main_thread.c', expected='7', emcc_args=['-O3', '-pthread', '-DPROXY_TO_PTHREAD=0', '--js-library', test_file('pthread/call_async_on_main_thread.js')])
-    self.btest('pthread/call_async_on_main_thread.c', expected='7', emcc_args=['-Oz', '-DPROXY_TO_PTHREAD=0', '--js-library', test_file('pthread/call_async_on_main_thread.js')])
+    self.btest('pthread/call_async_on_main_thread.c', expected='7', cflags=['-O3', '-pthread', '-sPROXY_TO_PTHREAD', '-DPROXY_TO_PTHREAD=1', '--js-library', test_file('pthread/call_async_on_main_thread.js')])
+    self.btest('pthread/call_async_on_main_thread.c', expected='7', cflags=['-O3', '-pthread', '-DPROXY_TO_PTHREAD=0', '--js-library', test_file('pthread/call_async_on_main_thread.js')])
+    self.btest('pthread/call_async_on_main_thread.c', expected='7', cflags=['-Oz', '-DPROXY_TO_PTHREAD=0', '--js-library', test_file('pthread/call_async_on_main_thread.js')])
 
   # Tests that spawning a new thread does not cause a reinitialization of the
   # global data section of the application memory area.
@@ -4041,44 +4041,44 @@ Module["preRun"] = () => {
     'modularize': (['-sMODULARIZE', '-sEXPORT_NAME=MyModule', '--shell-file', test_file('shell_that_launches_modularize.html')],),
   })
   def test_pthread_global_data_initialization(self, args):
-    self.btest_exit('pthread/test_pthread_global_data_initialization.c', emcc_args=args + ['-pthread', '-sPROXY_TO_PTHREAD', '-sPTHREAD_POOL_SIZE'])
+    self.btest_exit('pthread/test_pthread_global_data_initialization.c', cflags=args + ['-pthread', '-sPROXY_TO_PTHREAD', '-sPTHREAD_POOL_SIZE'])
 
   @requires_wasm2js
   def test_pthread_global_data_initialization_in_sync_compilation_mode(self):
-    self.btest_exit('pthread/test_pthread_global_data_initialization.c', emcc_args=['-sWASM_ASYNC_COMPILATION=0', '-pthread', '-sPROXY_TO_PTHREAD', '-sPTHREAD_POOL_SIZE'])
+    self.btest_exit('pthread/test_pthread_global_data_initialization.c', cflags=['-sWASM_ASYNC_COMPILATION=0', '-pthread', '-sPROXY_TO_PTHREAD', '-sPTHREAD_POOL_SIZE'])
 
   # Test that emscripten_get_now() reports coherent wallclock times across all
   # pthreads, instead of each pthread independently reporting wallclock times
   # since the launch of that pthread.
   def test_pthread_clock_drift(self):
-    self.btest_exit('pthread/test_pthread_clock_drift.c', emcc_args=['-O3', '-pthread', '-sPROXY_TO_PTHREAD'])
+    self.btest_exit('pthread/test_pthread_clock_drift.c', cflags=['-O3', '-pthread', '-sPROXY_TO_PTHREAD'])
 
   def test_pthread_utf8_funcs(self):
-    self.btest_exit('pthread/test_pthread_utf8_funcs.c', emcc_args=['-pthread', '-sPTHREAD_POOL_SIZE'])
+    self.btest_exit('pthread/test_pthread_utf8_funcs.c', cflags=['-pthread', '-sPTHREAD_POOL_SIZE'])
 
   # Test the emscripten_futex_wake(addr, INT_MAX); functionality to wake all
   # waiters
   @also_with_wasm2js
   def test_pthread_wake_all(self):
-    self.btest_exit('pthread/test_futex_wake_all.c', emcc_args=['-O3', '-pthread'])
+    self.btest_exit('pthread/test_futex_wake_all.c', cflags=['-O3', '-pthread'])
 
   # Test that stack base and max correctly bound the stack on pthreads.
   def test_pthread_stack_bounds(self):
-    self.btest_exit('pthread/test_pthread_stack_bounds.cpp', emcc_args=['-pthread'])
+    self.btest_exit('pthread/test_pthread_stack_bounds.cpp', cflags=['-pthread'])
 
   # Test that real `thread_local` works.
   def test_pthread_tls(self):
-    self.btest_exit('pthread/test_pthread_tls.cpp', emcc_args=['-sPROXY_TO_PTHREAD', '-pthread'])
+    self.btest_exit('pthread/test_pthread_tls.cpp', cflags=['-sPROXY_TO_PTHREAD', '-pthread'])
 
   # Test that real `thread_local` works in main thread without PROXY_TO_PTHREAD.
   def test_pthread_tls_main(self):
-    self.btest_exit('pthread/test_pthread_tls_main.cpp', emcc_args=['-pthread'])
+    self.btest_exit('pthread/test_pthread_tls_main.cpp', cflags=['-pthread'])
 
   def test_pthread_safe_stack(self):
     # Note that as the test runs with PROXY_TO_PTHREAD, we set STACK_SIZE,
     # and not DEFAULT_PTHREAD_STACK_SIZE, as the pthread for main() gets the
     # same stack size as the main thread normally would.
-    self.btest('core/test_safe_stack.c', expected='abort:stack overflow', emcc_args=['-pthread', '-sPROXY_TO_PTHREAD', '-sSTACK_OVERFLOW_CHECK=2', '-sSTACK_SIZE=64KB'])
+    self.btest('core/test_safe_stack.c', expected='abort:stack overflow', cflags=['-pthread', '-sPROXY_TO_PTHREAD', '-sSTACK_OVERFLOW_CHECK=2', '-sSTACK_SIZE=64KB'])
 
   @no_wasm64('TODO: ASAN in memory64')
   @parameterized({
@@ -4087,7 +4087,7 @@ Module["preRun"] = () => {
   })
   @no_firefox('https://github.com/emscripten-core/emscripten/issues/15978')
   def test_pthread_lsan(self, name, args):
-    self.btest(Path('pthread', name + '.cpp'), expected='1', emcc_args=['-fsanitize=leak', '-pthread', '-sPROXY_TO_PTHREAD', '--pre-js', test_file('pthread', name + '.js')] + args)
+    self.btest(Path('pthread', name + '.cpp'), expected='1', cflags=['-fsanitize=leak', '-pthread', '-sPROXY_TO_PTHREAD', '--pre-js', test_file('pthread', name + '.js')] + args)
 
   @no_wasm64('TODO: ASAN in memory64')
   @no_2gb('ASAN + GLOBAL_BASE')
@@ -4098,13 +4098,13 @@ Module["preRun"] = () => {
     'no_leak': ['test_pthread_lsan_no_leak', []],
   })
   def test_pthread_asan(self, name, args):
-    self.btest(Path('pthread', name + '.cpp'), expected='1', emcc_args=['-fsanitize=address', '-pthread', '-sPROXY_TO_PTHREAD', '--pre-js', test_file('pthread', name + '.js')] + args)
+    self.btest(Path('pthread', name + '.cpp'), expected='1', cflags=['-fsanitize=address', '-pthread', '-sPROXY_TO_PTHREAD', '--pre-js', test_file('pthread', name + '.js')] + args)
 
   @no_wasm64('TODO: ASAN in memory64')
   @no_2gb('ASAN + GLOBAL_BASE')
   @no_4gb('ASAN + GLOBAL_BASE')
   def test_pthread_asan_use_after_free(self):
-    self.btest('pthread/test_pthread_asan_use_after_free.cpp', expected='1', emcc_args=['-fsanitize=address', '-pthread', '-sPROXY_TO_PTHREAD', '--pre-js', test_file('pthread/test_pthread_asan_use_after_free.js')])
+    self.btest('pthread/test_pthread_asan_use_after_free.cpp', expected='1', cflags=['-fsanitize=address', '-pthread', '-sPROXY_TO_PTHREAD', '--pre-js', test_file('pthread/test_pthread_asan_use_after_free.js')])
 
   @no_wasm64('TODO: ASAN in memory64')
   @no_2gb('ASAN + GLOBAL_BASE')
@@ -4116,7 +4116,7 @@ Module["preRun"] = () => {
     # of proxy-to-pthread, and also the allocation happens on the pthread
     # (which tests that it can use the offset converter to get the stack
     # trace there)
-    self.btest('pthread/test_pthread_asan_use_after_free_2.cpp', expected='1', emcc_args=['-fsanitize=address', '-pthread', '-sPTHREAD_POOL_SIZE=1', '--pre-js', test_file('pthread/test_pthread_asan_use_after_free_2.js')])
+    self.btest('pthread/test_pthread_asan_use_after_free_2.cpp', expected='1', cflags=['-fsanitize=address', '-pthread', '-sPTHREAD_POOL_SIZE=1', '--pre-js', test_file('pthread/test_pthread_asan_use_after_free_2.js')])
 
   def test_pthread_exit_process(self):
     args = ['-pthread',
@@ -4126,7 +4126,7 @@ Module["preRun"] = () => {
             '-DEXIT_RUNTIME',
             '-O0']
     args += ['--pre-js', test_file('core/pthread/test_pthread_exit_runtime.pre.js')]
-    self.btest('core/pthread/test_pthread_exit_runtime.c', expected='onExit status: 42', emcc_args=args)
+    self.btest('core/pthread/test_pthread_exit_runtime.c', expected='onExit status: 42', cflags=args)
 
   def test_pthread_trap(self):
     create_file('pre.js', '''
@@ -4143,17 +4143,17 @@ Module["preRun"] = () => {
             '-sEXIT_RUNTIME',
             '--profiling-funcs',
             '--pre-js=pre.js']
-    self.btest('pthread/test_pthread_trap.c', expected='expected exception caught', emcc_args=args)
+    self.btest('pthread/test_pthread_trap.c', expected='expected exception caught', cflags=args)
 
   # Tests MAIN_THREAD_EM_ASM_INT() function call signatures.
   def test_main_thread_em_asm_signatures(self):
     self.btest_exit('core/test_em_asm_signatures.cpp')
 
   def test_main_thread_em_asm_signatures_pthreads(self):
-    self.btest_exit('core/test_em_asm_signatures.cpp', emcc_args=['-O3', '-pthread', '-sPROXY_TO_PTHREAD', '-sASSERTIONS'])
+    self.btest_exit('core/test_em_asm_signatures.cpp', cflags=['-O3', '-pthread', '-sPROXY_TO_PTHREAD', '-sASSERTIONS'])
 
   def test_main_thread_async_em_asm(self):
-    self.btest_exit('core/test_main_thread_async_em_asm.cpp', emcc_args=['-O3', '-pthread', '-sPROXY_TO_PTHREAD', '-sASSERTIONS'])
+    self.btest_exit('core/test_main_thread_async_em_asm.cpp', cflags=['-O3', '-pthread', '-sPROXY_TO_PTHREAD', '-sASSERTIONS'])
 
   def test_main_thread_em_asm_blocking(self):
     shutil.copy(test_file('browser/test_em_asm_blocking.html'), 'page.html')
@@ -4163,16 +4163,16 @@ Module["preRun"] = () => {
 
   # Test that it is possible to send a signal via calling alarm(timeout), which in turn calls to the signal handler set by signal(SIGALRM, func);
   def test_sigalrm(self):
-    self.btest_exit('test_sigalrm.c', emcc_args=['-O3'])
+    self.btest_exit('test_sigalrm.c', cflags=['-O3'])
 
   def test_canvas_style_proxy(self):
-    self.btest('canvas_style_proxy.c', expected='1', emcc_args=['--proxy-to-worker', '--shell-file', test_file('canvas_style_proxy_shell.html'), '--pre-js', test_file('canvas_style_proxy_pre.js')])
+    self.btest('canvas_style_proxy.c', expected='1', cflags=['--proxy-to-worker', '--shell-file', test_file('canvas_style_proxy_shell.html'), '--pre-js', test_file('canvas_style_proxy_pre.js')])
 
   def test_canvas_size_proxy(self):
-    self.btest('canvas_size_proxy.c', expected='0', emcc_args=['--proxy-to-worker'])
+    self.btest('canvas_size_proxy.c', expected='0', cflags=['--proxy-to-worker'])
 
   def test_custom_messages_proxy(self):
-    self.btest('custom_messages_proxy.c', expected='1', emcc_args=['--proxy-to-worker', '--shell-file', test_file('custom_messages_proxy_shell.html'), '--post-js', test_file('custom_messages_proxy_postjs.js')])
+    self.btest('custom_messages_proxy.c', expected='1', cflags=['--proxy-to-worker', '--shell-file', test_file('custom_messages_proxy_shell.html'), '--post-js', test_file('custom_messages_proxy_postjs.js')])
 
   @parameterized({
     '': ([],),
@@ -4214,11 +4214,11 @@ Module["preRun"] = () => {
         };
       }
     ''')
-    self.emcc_args.append('--pre-js=pre.js')
-    self.btest_exit('test_async_compile.c', assert_returncode=returncode, emcc_args=opts)
+    self.cflags.append('--pre-js=pre.js')
+    self.btest_exit('test_async_compile.c', assert_returncode=returncode, cflags=opts)
     # Ensure that compilation still works and is async without instantiateStreaming available
     create_file('pre0.js', 'WebAssembly.instantiateStreaming = undefined;')
-    self.emcc_args.insert(0, '--pre-js=pre0.js')
+    self.cflags.insert(0, '--pre-js=pre0.js')
     self.btest_exit('test_async_compile.c', assert_returncode=1)
 
   # Test that implementing Module.instantiateWasm() callback works.
@@ -4240,11 +4240,11 @@ Module["preRun"] = () => {
 
   @also_with_threads
   def test_utf8_textdecoder(self):
-    self.btest_exit('benchmark/benchmark_utf8.c', 0, emcc_args=['--embed-file', test_file('utf8_corpus.txt') + '@/utf8_corpus.txt'])
+    self.btest_exit('benchmark/benchmark_utf8.c', 0, cflags=['--embed-file', test_file('utf8_corpus.txt') + '@/utf8_corpus.txt'])
 
   @also_with_threads
   def test_utf16_textdecoder(self):
-    self.btest_exit('benchmark/benchmark_utf16.cpp', 0, emcc_args=['--embed-file', test_file('utf16_corpus.txt') + '@/utf16_corpus.txt', '-sEXPORTED_RUNTIME_METHODS=UTF16ToString,stringToUTF16,lengthBytesUTF16'])
+    self.btest_exit('benchmark/benchmark_utf16.cpp', 0, cflags=['--embed-file', test_file('utf16_corpus.txt') + '@/utf16_corpus.txt', '-sEXPORTED_RUNTIME_METHODS=UTF16ToString,stringToUTF16,lengthBytesUTF16'])
 
   @also_with_threads
   @parameterized({
@@ -4252,9 +4252,9 @@ Module["preRun"] = () => {
     'closure': (['--closure=1'],),
   })
   def test_TextDecoder(self, args):
-    self.emcc_args += args
+    self.cflags += args
 
-    self.btest('browser_test_hello_world.c', '0', emcc_args=['-sTEXTDECODER=0'])
+    self.btest('browser_test_hello_world.c', '0', cflags=['-sTEXTDECODER=0'])
     just_fallback = os.path.getsize('test.js')
     print('just_fallback:\t%s' % just_fallback)
 
@@ -4262,7 +4262,7 @@ Module["preRun"] = () => {
     td_with_fallback = os.path.getsize('test.js')
     print('td_with_fallback:\t%s' % td_with_fallback)
 
-    self.btest('browser_test_hello_world.c', '0', emcc_args=['-sTEXTDECODER=2'])
+    self.btest('browser_test_hello_world.c', '0', cflags=['-sTEXTDECODER=2'])
     td_without_fallback = os.path.getsize('test.js')
     print('td_without_fallback:\t%s' % td_without_fallback)
 
@@ -4274,7 +4274,7 @@ Module["preRun"] = () => {
     self.assertGreater(just_fallback, td_without_fallback)
 
   def test_small_js_flags(self):
-    self.btest('browser_test_hello_world.c', '0', emcc_args=['-O3', '--closure=1', '-sINCOMING_MODULE_JS_API=[]', '-sENVIRONMENT=web', '--output-eol=linux'])
+    self.btest('browser_test_hello_world.c', '0', cflags=['-O3', '--closure=1', '-sINCOMING_MODULE_JS_API=[]', '-sENVIRONMENT=web', '--output-eol=linux'])
     # Check an absolute js code size, with some slack.
     size = os.path.getsize('test.js')
     print('size:', size)
@@ -4297,7 +4297,7 @@ Module["preRun"] = () => {
   @requires_offscreen_canvas
   @requires_graphics_hardware
   def test_webgl_offscreen_canvas_in_pthread(self, args):
-    self.btest('gl_in_pthread.c', expected='1', emcc_args=args + ['-pthread', '-sPTHREAD_POOL_SIZE=2', '-sOFFSCREENCANVAS_SUPPORT', '-lGL'])
+    self.btest('gl_in_pthread.c', expected='1', cflags=args + ['-pthread', '-sPTHREAD_POOL_SIZE=2', '-sOFFSCREENCANVAS_SUPPORT', '-lGL'])
 
   # Tests that it is possible to render WebGL content on a <canvas> on the main
   # thread, after it has once been used to render WebGL content in a pthread
@@ -4312,17 +4312,17 @@ Module["preRun"] = () => {
   @requires_graphics_hardware
   @disabled('This test is disabled because current OffscreenCanvas does not allow transfering it after a rendering context has been created for it.')
   def test_webgl_offscreen_canvas_in_mainthread_after_pthread(self, args):
-    self.btest('gl_in_mainthread_after_pthread.c', expected='0', emcc_args=args + ['-pthread', '-sPTHREAD_POOL_SIZE=2', '-sOFFSCREENCANVAS_SUPPORT', '-lGL'])
+    self.btest('gl_in_mainthread_after_pthread.c', expected='0', cflags=args + ['-pthread', '-sPTHREAD_POOL_SIZE=2', '-sOFFSCREENCANVAS_SUPPORT', '-lGL'])
 
   @requires_offscreen_canvas
   @requires_graphics_hardware
   def test_webgl_offscreen_canvas_only_in_pthread(self):
-    self.btest_exit('gl_only_in_pthread.c', emcc_args=['-pthread', '-sPTHREAD_POOL_SIZE', '-sOFFSCREENCANVAS_SUPPORT', '-lGL', '-sOFFSCREEN_FRAMEBUFFER'])
+    self.btest_exit('gl_only_in_pthread.c', cflags=['-pthread', '-sPTHREAD_POOL_SIZE', '-sOFFSCREENCANVAS_SUPPORT', '-lGL', '-sOFFSCREEN_FRAMEBUFFER'])
 
   # Tests that rendering from client side memory without default-enabling extensions works.
   @requires_graphics_hardware
   def test_webgl_from_client_side_memory_without_default_enabled_extensions(self):
-    self.btest_exit('webgl_draw_triangle.c', emcc_args=['-lGL', '-sOFFSCREEN_FRAMEBUFFER', '-DEXPLICIT_SWAP=1', '-DDRAW_FROM_CLIENT_MEMORY=1', '-sFULL_ES2'])
+    self.btest_exit('webgl_draw_triangle.c', cflags=['-lGL', '-sOFFSCREEN_FRAMEBUFFER', '-DEXPLICIT_SWAP=1', '-DDRAW_FROM_CLIENT_MEMORY=1', '-sFULL_ES2'])
 
   # Tests for WEBGL_multi_draw extension
   # For testing WebGL draft extensions like this, if using chrome as the browser,
@@ -4338,7 +4338,7 @@ Module["preRun"] = () => {
   })
   def test_webgl_multi_draw(self, args):
     self.reftest('webgl_multi_draw_test.c', 'webgl_multi_draw.png',
-                 emcc_args=['-lGL', '-sOFFSCREEN_FRAMEBUFFER', '-DEXPLICIT_SWAP'] + args)
+                 cflags=['-lGL', '-sOFFSCREEN_FRAMEBUFFER', '-DEXPLICIT_SWAP'] + args)
 
   # Tests for base_vertex/base_instance extension
   # For testing WebGL draft extensions like this, if using chrome as the browser,
@@ -4356,7 +4356,7 @@ Module["preRun"] = () => {
   })
   def test_webgl_draw_base_vertex_base_instance(self, multi_draw, draw_elements):
     self.reftest('webgl_draw_base_vertex_base_instance_test.c', 'webgl_draw_instanced_base_vertex_base_instance.png',
-                 emcc_args=['-lGL',
+                 cflags=['-lGL',
                             '-sMAX_WEBGL_VERSION=2',
                             '-sOFFSCREEN_FRAMEBUFFER',
                             '-DMULTI_DRAW=' + str(multi_draw),
@@ -4366,7 +4366,7 @@ Module["preRun"] = () => {
 
   @requires_graphics_hardware
   def test_webgl_sample_query(self):
-    self.btest_exit('webgl_sample_query.c', emcc_args=['-sMAX_WEBGL_VERSION=2', '-lGL'])
+    self.btest_exit('webgl_sample_query.c', cflags=['-sMAX_WEBGL_VERSION=2', '-lGL'])
 
   @requires_graphics_hardware
   @parameterized({
@@ -4378,7 +4378,7 @@ Module["preRun"] = () => {
     'v2api': (['-sMAX_WEBGL_VERSION=2', '-DTEST_WEBGL2'],),
   })
   def test_webgl_timer_query(self, args):
-    self.btest_exit('webgl_timer_query.c', emcc_args=args + ['-lGL'])
+    self.btest_exit('webgl_timer_query.c', cflags=args + ['-lGL'])
 
   # Tests that -sOFFSCREEN_FRAMEBUFFER rendering works.
   @requires_graphics_hardware
@@ -4394,12 +4394,12 @@ Module["preRun"] = () => {
   def test_webgl_offscreen_framebuffer(self, version, threads):
     # Tests all the different possible versions of libgl
     args = ['-lGL', '-sOFFSCREEN_FRAMEBUFFER', '-DEXPLICIT_SWAP=1'] + threads + version
-    self.btest_exit('webgl_draw_triangle.c', emcc_args=args)
+    self.btest_exit('webgl_draw_triangle.c', cflags=args)
 
   # Tests that VAOs can be used even if WebGL enableExtensionsByDefault is set to 0.
   @requires_graphics_hardware
   def test_webgl_vao_without_automatic_extensions(self):
-    self.btest_exit('test_webgl_no_auto_init_extensions.c', emcc_args=['-lGL', '-sGL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS=0'])
+    self.btest_exit('test_webgl_no_auto_init_extensions.c', cflags=['-lGL', '-sGL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS=0'])
 
   # Tests that offscreen framebuffer state restoration works
   @requires_graphics_hardware
@@ -4418,7 +4418,7 @@ Module["preRun"] = () => {
   })
   def test_webgl_offscreen_framebuffer_state_restoration(self, args):
     base_args = ['-lGL', '-sOFFSCREEN_FRAMEBUFFER', '-DEXPLICIT_SWAP=1']
-    self.btest_exit('webgl_offscreen_framebuffer_swap_with_bad_state.c', emcc_args=base_args + args)
+    self.btest_exit('webgl_offscreen_framebuffer_swap_with_bad_state.c', cflags=base_args + args)
 
   @parameterized({
     '': ([],),
@@ -4427,12 +4427,12 @@ Module["preRun"] = () => {
   })
   @requires_graphics_hardware
   def test_webgl_draw_triangle_with_uniform_color(self, args):
-    self.btest_exit('webgl_draw_triangle_with_uniform_color.c', emcc_args=args)
+    self.btest_exit('webgl_draw_triangle_with_uniform_color.c', cflags=args)
 
   # Tests that using an array of structs in GL uniforms works.
   @requires_graphics_hardware
   def test_webgl_array_of_structs_uniform(self):
-    self.reftest('webgl_array_of_structs_uniform.c', 'webgl_array_of_structs_uniform.png', emcc_args=['-lGL', '-sMAX_WEBGL_VERSION=2'])
+    self.reftest('webgl_array_of_structs_uniform.c', 'webgl_array_of_structs_uniform.png', cflags=['-lGL', '-sMAX_WEBGL_VERSION=2'])
 
   # Tests that if a WebGL context is created in a pthread on a canvas that has
   # not been transferred to that pthread, WebGL calls are then proxied to the
@@ -4456,7 +4456,7 @@ Module["preRun"] = () => {
       # given the synchronous render loop here, asyncify is needed to see intermediate frames and
       # the gradual color change
       args += ['-sASYNCIFY', '-DASYNCIFY']
-    self.btest_exit('gl_in_proxy_pthread.c', emcc_args=args)
+    self.btest_exit('gl_in_proxy_pthread.c', cflags=args)
 
   @parameterized({
     '': ([],),
@@ -4475,7 +4475,7 @@ Module["preRun"] = () => {
   def test_webgl_resize_offscreencanvas_from_main_thread(self, args1, args2, args3):
     cmd = args1 + args2 + args3 + ['-pthread', '-lGL', '-sGL_DEBUG']
     print(str(cmd))
-    self.btest_exit('test_webgl_resize_offscreencanvas_from_main_thread.c', emcc_args=cmd)
+    self.btest_exit('test_webgl_resize_offscreencanvas_from_main_thread.c', cflags=cmd)
 
   @requires_graphics_hardware
   @parameterized({
@@ -4492,7 +4492,7 @@ Module["preRun"] = () => {
            '-sMAX_WEBGL_VERSION=2',
            '-sGL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS=' + str(simple_enable_extensions),
            '-sGL_SUPPORT_SIMPLE_ENABLE_EXTENSIONS=' + str(simple_enable_extensions)]
-    self.btest_exit('webgl2_simple_enable_extensions.c', emcc_args=cmd)
+    self.btest_exit('webgl2_simple_enable_extensions.c', cflags=cmd)
 
   @parameterized({
     '': ([],),
@@ -4502,21 +4502,21 @@ Module["preRun"] = () => {
   })
   @requires_webgpu
   def test_webgpu_basic_rendering(self, args):
-    self.btest_exit('webgpu_basic_rendering.cpp', emcc_args=['-Wno-error=deprecated', '-sUSE_WEBGPU'] + args)
+    self.btest_exit('webgpu_basic_rendering.cpp', cflags=['-Wno-error=deprecated', '-sUSE_WEBGPU'] + args)
 
   @requires_webgpu
   def test_webgpu_required_limits(self):
-    self.btest_exit('webgpu_required_limits.c', emcc_args=['-Wno-error=deprecated', '-sUSE_WEBGPU', '-sASYNCIFY'])
+    self.btest_exit('webgpu_required_limits.c', cflags=['-Wno-error=deprecated', '-sUSE_WEBGPU', '-sASYNCIFY'])
 
   @requires_webgpu
   def test_webgpu_basic_rendering_pthreads(self):
-    self.btest_exit('webgpu_basic_rendering.cpp', emcc_args=['-Wno-error=deprecated', '-sUSE_WEBGPU', '-pthread', '-sOFFSCREENCANVAS_SUPPORT'])
+    self.btest_exit('webgpu_basic_rendering.cpp', cflags=['-Wno-error=deprecated', '-sUSE_WEBGPU', '-pthread', '-sOFFSCREENCANVAS_SUPPORT'])
 
   def test_webgpu_get_device(self):
-    self.btest_exit('webgpu_get_device.cpp', emcc_args=['-Wno-error=deprecated', '-sUSE_WEBGPU', '-sASSERTIONS', '--closure=1'])
+    self.btest_exit('webgpu_get_device.cpp', cflags=['-Wno-error=deprecated', '-sUSE_WEBGPU', '-sASSERTIONS', '--closure=1'])
 
   def test_webgpu_get_device_pthreads(self):
-    self.btest_exit('webgpu_get_device.cpp', emcc_args=['-Wno-error=deprecated', '-sUSE_WEBGPU', '-pthread'])
+    self.btest_exit('webgpu_get_device.cpp', cflags=['-Wno-error=deprecated', '-sUSE_WEBGPU', '-pthread'])
 
   # Tests the feature that shell html page can preallocate the typed array and place it
   # to Module.buffer before loading the script page.
@@ -4524,20 +4524,20 @@ Module["preRun"] = () => {
   # Preallocating the buffer in this was is asm.js only (wasm needs a Memory).
   @requires_wasm2js
   def test_preallocated_heap(self):
-    self.btest_exit('test_preallocated_heap.cpp', emcc_args=['-sWASM=0', '-sIMPORTED_MEMORY', '-sINITIAL_MEMORY=16MB', '-sABORTING_MALLOC=0', '--shell-file', test_file('test_preallocated_heap_shell.html')])
+    self.btest_exit('test_preallocated_heap.cpp', cflags=['-sWASM=0', '-sIMPORTED_MEMORY', '-sINITIAL_MEMORY=16MB', '-sABORTING_MALLOC=0', '--shell-file', test_file('test_preallocated_heap_shell.html')])
 
   # Tests emscripten_fetch() usage to XHR data directly to memory without persisting results to IndexedDB.
   @also_with_wasm2js
   def test_fetch_to_memory(self):
     # Test error reporting in the negative case when the file URL doesn't exist. (http 404)
     self.btest_exit('fetch/test_fetch_to_memory.cpp',
-                    emcc_args=['-sFETCH_DEBUG', '-sFETCH', '-DFILE_DOES_NOT_EXIST'])
+                    cflags=['-sFETCH_DEBUG', '-sFETCH', '-DFILE_DOES_NOT_EXIST'])
 
     # Test the positive case when the file URL exists. (http 200)
     shutil.copy(test_file('gears.png'), '.')
     for arg in ([], ['-sFETCH_SUPPORT_INDEXEDDB=0']):
       self.btest_exit('fetch/test_fetch_to_memory.cpp',
-                      emcc_args=['-sFETCH_DEBUG', '-sFETCH'] + arg)
+                      cflags=['-sFETCH_DEBUG', '-sFETCH'] + arg)
 
   @also_with_wasm2js
   @parameterized({
@@ -4548,25 +4548,25 @@ Module["preRun"] = () => {
   def test_fetch_from_thread(self, args):
     shutil.copy(test_file('gears.png'), '.')
     self.btest_exit('fetch/test_fetch_from_thread.cpp',
-                    emcc_args=args + ['-pthread', '-sPROXY_TO_PTHREAD', '-sFETCH_DEBUG', '-sFETCH', '-DFILE_DOES_NOT_EXIST'])
+                    cflags=args + ['-pthread', '-sPROXY_TO_PTHREAD', '-sFETCH_DEBUG', '-sFETCH', '-DFILE_DOES_NOT_EXIST'])
 
   @also_with_wasm2js
   def test_fetch_to_indexdb(self):
     shutil.copy(test_file('gears.png'), '.')
-    self.btest_exit('fetch/test_fetch_to_indexeddb.cpp', emcc_args=['-sFETCH_DEBUG', '-sFETCH'])
+    self.btest_exit('fetch/test_fetch_to_indexeddb.cpp', cflags=['-sFETCH_DEBUG', '-sFETCH'])
 
   # Tests emscripten_fetch() usage to persist an XHR into IndexedDB and subsequently load up from there.
   @also_with_wasm2js
   def test_fetch_cached_xhr(self):
     shutil.copy(test_file('gears.png'), '.')
-    self.btest_exit('fetch/test_fetch_cached_xhr.cpp', emcc_args=['-sFETCH_DEBUG', '-sFETCH'])
+    self.btest_exit('fetch/test_fetch_cached_xhr.cpp', cflags=['-sFETCH_DEBUG', '-sFETCH'])
 
   # Tests that response headers get set on emscripten_fetch_t values.
   @no_firefox('https://github.com/emscripten-core/emscripten/issues/16868')
   @also_with_wasm2js
   def test_fetch_response_headers(self):
     shutil.copy(test_file('gears.png'), '.')
-    self.btest_exit('fetch/test_fetch_response_headers.cpp', emcc_args=['-sFETCH_DEBUG', '-sFETCH', '-pthread', '-sPROXY_TO_PTHREAD'])
+    self.btest_exit('fetch/test_fetch_response_headers.cpp', cflags=['-sFETCH_DEBUG', '-sFETCH', '-pthread', '-sPROXY_TO_PTHREAD'])
 
   # Test emscripten_fetch() usage to stream a XHR in to memory without storing the full file in memory
   @also_with_wasm2js
@@ -4580,15 +4580,15 @@ Module["preRun"] = () => {
     with open('largefile.txt', 'w') as f:
       for _ in range(1024):
         f.write(s)
-    self.btest_exit('fetch/test_fetch_stream_file.cpp', emcc_args=['-sFETCH_DEBUG', '-sFETCH'])
+    self.btest_exit('fetch/test_fetch_stream_file.cpp', cflags=['-sFETCH_DEBUG', '-sFETCH'])
 
   def test_fetch_headers_received(self):
     create_file('myfile.dat', 'hello world\n')
-    self.btest_exit('fetch/test_fetch_headers_received.c', emcc_args=['-sFETCH_DEBUG', '-sFETCH'])
+    self.btest_exit('fetch/test_fetch_headers_received.c', cflags=['-sFETCH_DEBUG', '-sFETCH'])
 
   def test_fetch_xhr_abort(self):
     shutil.copy(test_file('gears.png'), '.')
-    self.btest_exit('fetch/test_fetch_xhr_abort.cpp', emcc_args=['-sFETCH_DEBUG', '-sFETCH'])
+    self.btest_exit('fetch/test_fetch_xhr_abort.cpp', cflags=['-sFETCH_DEBUG', '-sFETCH'])
 
   # Tests emscripten_fetch() usage in synchronous mode when used from the main
   # thread proxied to a Worker with -sPROXY_TO_PTHREAD option.
@@ -4596,13 +4596,13 @@ Module["preRun"] = () => {
   @also_with_wasm2js
   def test_fetch_sync_xhr(self):
     shutil.copy(test_file('gears.png'), '.')
-    self.btest_exit('fetch/test_fetch_sync_xhr.cpp', emcc_args=['-sFETCH_DEBUG', '-sFETCH', '-pthread', '-sPROXY_TO_PTHREAD'])
+    self.btest_exit('fetch/test_fetch_sync_xhr.cpp', cflags=['-sFETCH_DEBUG', '-sFETCH', '-pthread', '-sPROXY_TO_PTHREAD'])
 
   # Tests synchronous emscripten_fetch() usage from pthread
   @no_firefox('https://github.com/emscripten-core/emscripten/issues/16868')
   def test_fetch_sync(self):
     shutil.copy(test_file('gears.png'), '.')
-    self.btest_exit('fetch/test_fetch_sync.c', emcc_args=['-sFETCH', '-pthread', '-sPROXY_TO_PTHREAD'])
+    self.btest_exit('fetch/test_fetch_sync.c', cflags=['-sFETCH', '-pthread', '-sPROXY_TO_PTHREAD'])
 
   # Tests that the Fetch API works for synchronous XHRs when used with --proxy-to-worker.
   @no_firefox('https://github.com/emscripten-core/emscripten/issues/16868')
@@ -4610,53 +4610,53 @@ Module["preRun"] = () => {
   def test_fetch_sync_xhr_in_proxy_to_worker(self):
     shutil.copy(test_file('gears.png'), '.')
     self.btest_exit('fetch/test_fetch_sync_xhr.cpp',
-                    emcc_args=['-sFETCH_DEBUG', '-sFETCH', '--proxy-to-worker'])
+                    cflags=['-sFETCH_DEBUG', '-sFETCH', '--proxy-to-worker'])
 
   @disabled('https://github.com/emscripten-core/emscripten/issues/16746')
   def test_fetch_idb_store(self):
-    self.btest_exit('fetch/test_fetch_idb_store.cpp', emcc_args=['-pthread', '-sFETCH', '-sPROXY_TO_PTHREAD'])
+    self.btest_exit('fetch/test_fetch_idb_store.cpp', cflags=['-pthread', '-sFETCH', '-sPROXY_TO_PTHREAD'])
 
   @disabled('https://github.com/emscripten-core/emscripten/issues/16746')
   def test_fetch_idb_delete(self):
     shutil.copy(test_file('gears.png'), '.')
-    self.btest_exit('fetch/test_fetch_idb_delete.cpp', emcc_args=['-pthread', '-sFETCH_DEBUG', '-sFETCH', '-sWASM=0', '-sPROXY_TO_PTHREAD'])
+    self.btest_exit('fetch/test_fetch_idb_delete.cpp', cflags=['-pthread', '-sFETCH_DEBUG', '-sFETCH', '-sWASM=0', '-sPROXY_TO_PTHREAD'])
 
   def test_fetch_post(self):
-    self.btest_exit('fetch/test_fetch_post.c', emcc_args=['-sFETCH'])
+    self.btest_exit('fetch/test_fetch_post.c', cflags=['-sFETCH'])
 
   def test_fetch_progress(self):
     create_file('myfile.dat', 'hello world\n' * 1000)
-    self.btest_exit('fetch/test_fetch_progress.c', emcc_args=['-sFETCH'])
+    self.btest_exit('fetch/test_fetch_progress.c', cflags=['-sFETCH'])
 
   def test_fetch_to_memory_async(self):
     create_file('myfile.dat', 'hello world\n' * 1000)
-    self.btest_exit('fetch/test_fetch_to_memory_async.c', emcc_args=['-sFETCH'])
+    self.btest_exit('fetch/test_fetch_to_memory_async.c', cflags=['-sFETCH'])
 
   def test_fetch_to_memory_sync(self):
     create_file('myfile.dat', 'hello world\n' * 1000)
-    self.btest_exit('fetch/test_fetch_to_memory_sync.c', emcc_args=['-sFETCH', '-pthread', '-sPROXY_TO_PTHREAD'])
+    self.btest_exit('fetch/test_fetch_to_memory_sync.c', cflags=['-sFETCH', '-pthread', '-sPROXY_TO_PTHREAD'])
 
   @disabled('moz-chunked-arraybuffer was firefox-only and has been removed')
   def test_fetch_stream_async(self):
     create_file('myfile.dat', 'hello world\n' * 1000)
-    self.btest_exit('fetch/test_fetch_stream_async.c', emcc_args=['-sFETCH'])
+    self.btest_exit('fetch/test_fetch_stream_async.c', cflags=['-sFETCH'])
 
   def test_fetch_persist(self):
     create_file('myfile.dat', 'hello world\n')
-    self.btest_exit('fetch/test_fetch_persist.c', emcc_args=['-sFETCH'])
+    self.btest_exit('fetch/test_fetch_persist.c', cflags=['-sFETCH'])
 
   @no_firefox('https://github.com/emscripten-core/emscripten/issues/16868')
   def test_fetch_redirect(self):
-    self.btest_exit('fetch/test_fetch_redirect.c', emcc_args=['-sFETCH', '-pthread', '-sPROXY_TO_PTHREAD'])
+    self.btest_exit('fetch/test_fetch_redirect.c', cflags=['-sFETCH', '-pthread', '-sPROXY_TO_PTHREAD'])
 
   @parameterized({
     '': ([],),
     'mt': (['-pthread', '-sPTHREAD_POOL_SIZE=2'],),
   })
   def test_pthread_locale(self, args):
-    self.emcc_args.append('-I' + path_from_root('system/lib/libc/musl/src/internal'))
-    self.emcc_args.append('-I' + path_from_root('system/lib/pthread'))
-    self.btest_exit('pthread/test_pthread_locale.c', emcc_args=args)
+    self.cflags.append('-I' + path_from_root('system/lib/libc/musl/src/internal'))
+    self.cflags.append('-I' + path_from_root('system/lib/pthread'))
+    self.btest_exit('pthread/test_pthread_locale.c', cflags=args)
 
   # Tests the Emscripten HTML5 API emscripten_set_canvas_element_size() and
   # emscripten_get_canvas_element_size() functionality in singlethreaded programs.
@@ -4670,7 +4670,7 @@ Module["preRun"] = () => {
     'mt': (['-pthread', '-sPROXY_TO_PTHREAD'],),
   })
   def test_emscripten_get_device_pixel_ratio(self, args):
-    self.btest_exit('emscripten_get_device_pixel_ratio.c', emcc_args=args)
+    self.btest_exit('emscripten_get_device_pixel_ratio.c', cflags=args)
 
   # Tests that emscripten_run_script() variants of functions work in pthreads.
   @parameterized({
@@ -4679,7 +4679,7 @@ Module["preRun"] = () => {
   })
   def test_pthread_run_script(self, args):
     shutil.copy(test_file('pthread/foo.js'), '.')
-    self.btest_exit('pthread/test_pthread_run_script.c', emcc_args=['-O3'] + args)
+    self.btest_exit('pthread/test_pthread_run_script.c', cflags=['-O3'] + args)
 
   # Tests emscripten_set_canvas_element_size() and OffscreenCanvas functionality in different build configurations.
   @requires_graphics_hardware
@@ -4699,7 +4699,7 @@ Module["preRun"] = () => {
       cmd.append('--threadprofiler')
     if main_loop:
       cmd.append('-DTEST_EMSCRIPTEN_SET_MAIN_LOOP=1')
-    self.btest_exit('canvas_animate_resize.c', emcc_args=cmd)
+    self.btest_exit('canvas_animate_resize.c', cflags=cmd)
 
   # Tests the absolute minimum pthread-enabled application.
   @parameterized({
@@ -4712,7 +4712,7 @@ Module["preRun"] = () => {
     'O3': (['-O3'],),
   })
   def test_pthread_hello_thread(self, opts, modularize):
-    self.btest_exit('pthread/hello_thread.c', emcc_args=['-pthread'] + modularize + opts)
+    self.btest_exit('pthread/hello_thread.c', cflags=['-pthread'] + modularize + opts)
 
   # Tests that a pthreads build of -sMINIMAL_RUNTIME works well in different build modes
   @parameterized({
@@ -4723,7 +4723,7 @@ Module["preRun"] = () => {
     'O3_modularize_MINIMAL_RUNTIME_2': (['-O3', '-sMODULARIZE', '-sEXPORT_NAME=MyModule', '-sMINIMAL_RUNTIME=2'],),
   })
   def test_minimal_runtime_hello_thread(self, opts):
-    self.btest_exit('pthread/hello_thread.c', emcc_args=['--closure=1', '-sMINIMAL_RUNTIME', '-pthread'] + opts)
+    self.btest_exit('pthread/hello_thread.c', cflags=['--closure=1', '-sMINIMAL_RUNTIME', '-pthread'] + opts)
 
   # Tests memory growth in pthreads mode, but still on the main thread.
   @parameterized({
@@ -4732,9 +4732,9 @@ Module["preRun"] = () => {
   })
   @no_2gb('uses INITIAL_MEMORY')
   @no_4gb('uses INITIAL_MEMORY')
-  def test_pthread_growth_mainthread(self, emcc_args, pthread_pool_size):
+  def test_pthread_growth_mainthread(self, cflags, pthread_pool_size):
     self.set_setting('PTHREAD_POOL_SIZE', pthread_pool_size)
-    self.btest_exit('pthread/test_pthread_memory_growth_mainthread.c', emcc_args=['-Wno-pthreads-mem-growth', '-pthread', '-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=32MB', '-sMAXIMUM_MEMORY=256MB'] + emcc_args)
+    self.btest_exit('pthread/test_pthread_memory_growth_mainthread.c', cflags=['-Wno-pthreads-mem-growth', '-pthread', '-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=32MB', '-sMAXIMUM_MEMORY=256MB'] + cflags)
 
   # Tests memory growth in a pthread.
   @parameterized({
@@ -4745,15 +4745,15 @@ Module["preRun"] = () => {
   })
   @no_2gb('uses INITIAL_MEMORY')
   @no_4gb('uses INITIAL_MEMORY')
-  def test_pthread_growth(self, emcc_args, pthread_pool_size = 1):
+  def test_pthread_growth(self, cflags, pthread_pool_size = 1):
     self.set_setting('PTHREAD_POOL_SIZE', pthread_pool_size)
-    self.btest_exit('pthread/test_pthread_memory_growth.c', emcc_args=['-Wno-pthreads-mem-growth', '-pthread', '-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=32MB', '-sMAXIMUM_MEMORY=256MB'] + emcc_args)
+    self.btest_exit('pthread/test_pthread_memory_growth.c', cflags=['-Wno-pthreads-mem-growth', '-pthread', '-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=32MB', '-sMAXIMUM_MEMORY=256MB'] + cflags)
 
   # Tests that time in a pthread is relative to the main thread, so measurements
   # on different threads are still monotonic, as if checking a single central
   # clock.
   def test_pthread_reltime(self):
-    self.btest_exit('pthread/test_pthread_reltime.cpp', emcc_args=['-pthread', '-sPTHREAD_POOL_SIZE'])
+    self.btest_exit('pthread/test_pthread_reltime.cpp', cflags=['-pthread', '-sPTHREAD_POOL_SIZE'])
 
   # Tests that it is possible to load the main .js file of the application manually via mainScriptUrlOrBlob,
   # and still use pthreads.
@@ -4768,7 +4768,7 @@ Module["preRun"] = () => {
     self.set_setting('EXIT_RUNTIME')
     js_name = 'hello_thread_with_loader.%s' % ('mjs' if es6 else 'js')
     if es6:
-      self.emcc_args += ['-sEXPORT_ES6']
+      self.cflags += ['-sEXPORT_ES6']
     if es6 and use_blob:
       create_file('loader.mjs', '''
         Module['locateFile'] = (path,_prefix) => path;
@@ -4808,7 +4808,7 @@ Module["preRun"] = () => {
   # Tests that SINGLE_FILE works as intended in generated HTML (with and without Worker)
   @also_with_proxying
   def test_single_file_html(self):
-    self.btest('single_file_static_initializer.cpp', '19', emcc_args=['-sSINGLE_FILE'])
+    self.btest('single_file_static_initializer.cpp', '19', cflags=['-sSINGLE_FILE'])
     self.assertExists('test.html')
     self.assertNotExists('test.js')
     self.assertNotExists('test.worker.js')
@@ -4821,7 +4821,7 @@ Module["preRun"] = () => {
     'O3': (['-O3'],),
   })
   def test_minimal_runtime_single_file_html(self, opts):
-    self.btest('single_file_static_initializer.cpp', '19', emcc_args=opts + ['-sMINIMAL_RUNTIME', '-sSINGLE_FILE'])
+    self.btest('single_file_static_initializer.cpp', '19', cflags=opts + ['-sMINIMAL_RUNTIME', '-sSINGLE_FILE'])
     self.assertExists('test.html')
     self.assertNotExists('test.js')
     self.assertNotExists('test.wasm')
@@ -4831,7 +4831,7 @@ Module["preRun"] = () => {
 
   # Tests that SINGLE_FILE works when built with ENVIRONMENT=web and Closure enabled (#7933)
   def test_single_file_in_web_environment_with_closure(self):
-    self.btest_exit('minimal_hello.c', emcc_args=['-sSINGLE_FILE', '-sENVIRONMENT=web', '-O2', '--closure=1'])
+    self.btest_exit('minimal_hello.c', cflags=['-sSINGLE_FILE', '-sENVIRONMENT=web', '-O2', '--closure=1'])
 
   # Tests that SINGLE_FILE works as intended with locateFile
   @also_with_wasm2js
@@ -4883,11 +4883,11 @@ Module["preRun"] = () => {
 
   def test_access_file_after_heap_resize(self):
     create_file('test.txt', 'hello from file')
-    self.btest_exit('access_file_after_heap_resize.c', emcc_args=['-sALLOW_MEMORY_GROWTH', '--preload-file', 'test.txt'])
+    self.btest_exit('access_file_after_heap_resize.c', cflags=['-sALLOW_MEMORY_GROWTH', '--preload-file', 'test.txt'])
 
     # with separate file packager invocation
     self.run_process([FILE_PACKAGER, 'data.data', '--preload', 'test.txt', '--js-output=' + 'data.js'])
-    self.btest_exit('access_file_after_heap_resize.c', emcc_args=['-sALLOW_MEMORY_GROWTH', '--pre-js', 'data.js', '-sFORCE_FILESYSTEM'])
+    self.btest_exit('access_file_after_heap_resize.c', cflags=['-sALLOW_MEMORY_GROWTH', '--pre-js', 'data.js', '-sFORCE_FILESYSTEM'])
 
   def test_unicode_html_shell(self):
     create_file('main.c', r'''
@@ -4896,11 +4896,11 @@ Module["preRun"] = () => {
       }
     ''')
     create_file('shell.html', read_file(path_from_root('src/shell.html')).replace('Emscripten-Generated Code', 'Emscripten-Generated Emoji 😅'))
-    self.btest_exit('main.c', emcc_args=['--shell-file', 'shell.html'])
+    self.btest_exit('main.c', cflags=['--shell-file', 'shell.html'])
 
   # Tests the functionality of the emscripten_thread_sleep() function.
   def test_emscripten_thread_sleep(self):
-    self.btest_exit('pthread/emscripten_thread_sleep.c', emcc_args=['-pthread'])
+    self.btest_exit('pthread/emscripten_thread_sleep.c', cflags=['-pthread'])
 
   # Tests that Emscripten-compiled applications can be run from a relative path in browser that is different than the address of the current page
   def test_browser_run_from_different_directory(self):
@@ -4970,10 +4970,10 @@ Module["preRun"] = () => {
     self.btest_exit('test_request_animation_frame.c')
 
   def test_emscripten_set_timeout(self):
-    self.btest_exit('emscripten_set_timeout.c', emcc_args=['-pthread', '-sPROXY_TO_PTHREAD'])
+    self.btest_exit('emscripten_set_timeout.c', cflags=['-pthread', '-sPROXY_TO_PTHREAD'])
 
   def test_emscripten_set_timeout_loop(self):
-    self.btest_exit('emscripten_set_timeout_loop.c', emcc_args=['-pthread', '-sPROXY_TO_PTHREAD'])
+    self.btest_exit('emscripten_set_timeout_loop.c', cflags=['-pthread', '-sPROXY_TO_PTHREAD'])
 
   def test_emscripten_set_immediate(self):
     self.btest_exit('emscripten_set_immediate.c')
@@ -4982,14 +4982,14 @@ Module["preRun"] = () => {
     self.btest_exit('emscripten_set_immediate_loop.c')
 
   def test_emscripten_set_interval(self):
-    self.btest_exit('emscripten_set_interval.c', emcc_args=['-pthread', '-sPROXY_TO_PTHREAD'])
+    self.btest_exit('emscripten_set_interval.c', cflags=['-pthread', '-sPROXY_TO_PTHREAD'])
 
   # Test emscripten_performance_now() and emscripten_date_now()
   def test_emscripten_performance_now(self):
-    self.btest('emscripten_performance_now.c', '0', emcc_args=['-pthread', '-sPROXY_TO_PTHREAD'])
+    self.btest('emscripten_performance_now.c', '0', cflags=['-pthread', '-sPROXY_TO_PTHREAD'])
 
   def test_embind_with_pthreads(self):
-    self.btest_exit('embind/test_pthreads.cpp', emcc_args=['-lembind', '-pthread', '-sPTHREAD_POOL_SIZE=2'])
+    self.btest_exit('embind/test_pthreads.cpp', cflags=['-lembind', '-pthread', '-sPTHREAD_POOL_SIZE=2'])
 
   @parameterized({
     'asyncify': (['-sASYNCIFY=1'],),
@@ -5001,26 +5001,26 @@ Module["preRun"] = () => {
     if is_jspi(args) and self.is_wasm64():
       self.skipTest('_emval_await fails')
 
-    self.btest('embind_with_asyncify.cpp', '1', emcc_args=['-lembind'] + args)
+    self.btest('embind_with_asyncify.cpp', '1', cflags=['-lembind'] + args)
 
   # Test emscripten_console_log(), emscripten_console_warn() and emscripten_console_error()
   def test_emscripten_console_log(self):
-    self.btest_exit('emscripten_console_log.c', emcc_args=['--pre-js', test_file('emscripten_console_log_pre.js')])
+    self.btest_exit('emscripten_console_log.c', cflags=['--pre-js', test_file('emscripten_console_log_pre.js')])
 
   def test_emscripten_throw_number(self):
-    self.btest('emscripten_throw_number.c', '0', emcc_args=['--pre-js', test_file('emscripten_throw_number_pre.js')])
+    self.btest('emscripten_throw_number.c', '0', cflags=['--pre-js', test_file('emscripten_throw_number_pre.js')])
 
   def test_emscripten_throw_string(self):
-    self.btest('emscripten_throw_string.c', '0', emcc_args=['--pre-js', test_file('emscripten_throw_string_pre.js')])
+    self.btest('emscripten_throw_string.c', '0', cflags=['--pre-js', test_file('emscripten_throw_string_pre.js')])
 
   # Tests that Closure run in combination with -sENVIRONMENT=web mode works with a minimal console.log() application
   def test_closure_in_web_only_target_environment_console_log(self):
-    self.btest_exit('minimal_hello.c', emcc_args=['-sENVIRONMENT=web', '-O3', '--closure=1'])
+    self.btest_exit('minimal_hello.c', cflags=['-sENVIRONMENT=web', '-O3', '--closure=1'])
 
   # Tests that Closure run in combination with -sENVIRONMENT=web mode works with a small WebGL application
   @requires_graphics_hardware
   def test_closure_in_web_only_target_environment_webgl(self):
-    self.btest_exit('webgl_draw_triangle.c', emcc_args=['-lGL', '-sENVIRONMENT=web', '-O3', '--closure=1'])
+    self.btest_exit('webgl_draw_triangle.c', cflags=['-lGL', '-sENVIRONMENT=web', '-O3', '--closure=1'])
 
   @requires_wasm2js
   @parameterized({
@@ -5030,14 +5030,14 @@ Module["preRun"] = () => {
   def test_no_declare_asm_module_exports_wasm2js(self, args):
     # TODO(sbc): Fix closure warnings with MODULARIZE + WASM=0
     self.ldflags.append('-Wno-error=closure')
-    self.btest_exit('declare_asm_module_exports.c', emcc_args=['-sDECLARE_ASM_MODULE_EXPORTS=0', '-sENVIRONMENT=web', '-O3', '--closure=1', '-sWASM=0'] + args)
+    self.btest_exit('declare_asm_module_exports.c', cflags=['-sDECLARE_ASM_MODULE_EXPORTS=0', '-sENVIRONMENT=web', '-O3', '--closure=1', '-sWASM=0'] + args)
 
   @parameterized({
     '': (1,),
     '2': (2,),
   })
   def test_no_declare_asm_module_exports_wasm_minimal_runtime(self, mode):
-    self.btest_exit('declare_asm_module_exports.c', emcc_args=['-sDECLARE_ASM_MODULE_EXPORTS=0', '-sENVIRONMENT=web', '-O3', '--closure=1', f'-sMINIMAL_RUNTIME={mode}'])
+    self.btest_exit('declare_asm_module_exports.c', cflags=['-sDECLARE_ASM_MODULE_EXPORTS=0', '-sENVIRONMENT=web', '-O3', '--closure=1', f'-sMINIMAL_RUNTIME={mode}'])
 
   # Tests that the different code paths in src/shell_minimal_runtime.html all work ok.
   @parameterized({
@@ -5047,7 +5047,7 @@ Module["preRun"] = () => {
   @also_with_wasm2js
   def test_minimal_runtime_loader_shell(self, args):
     args = ['-sMINIMAL_RUNTIME=2']
-    self.btest_exit('minimal_hello.c', emcc_args=args)
+    self.btest_exit('minimal_hello.c', cflags=args)
 
   # Tests that -sMINIMAL_RUNTIME works well in different build modes
   @parameterized({
@@ -5056,14 +5056,14 @@ Module["preRun"] = () => {
     'streaming_inst': (['-sMINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION', '--closure=1'],),
   })
   def test_minimal_runtime_hello_world(self, args):
-    self.btest_exit('small_hello_world.c', emcc_args=args + ['-sMINIMAL_RUNTIME'])
+    self.btest_exit('small_hello_world.c', cflags=args + ['-sMINIMAL_RUNTIME'])
 
   @parameterized({
     '': ([],),
     'pthread': (['-sPROXY_TO_PTHREAD', '-pthread'],),
   })
   def test_offset_converter(self, args):
-    self.btest_exit('test_offset_converter.c', emcc_args=['-sUSE_OFFSET_CONVERTER', '-gsource-map'] + args)
+    self.btest_exit('test_offset_converter.c', cflags=['-sUSE_OFFSET_CONVERTER', '-gsource-map'] + args)
 
   # Tests emscripten_unwind_to_js_event_loop() behavior
   def test_emscripten_unwind_to_js_event_loop(self):
@@ -5115,21 +5115,21 @@ Module["preRun"] = () => {
   # Tests the hello_wasm_worker.c documentation example code.
   @also_with_minimal_runtime
   def test_wasm_worker_hello(self):
-    self.btest_exit('wasm_worker/hello_wasm_worker.c', emcc_args=['-sWASM_WORKERS', '-sENVIRONMENT=web'])
+    self.btest_exit('wasm_worker/hello_wasm_worker.c', cflags=['-sWASM_WORKERS', '-sENVIRONMENT=web'])
 
   def test_wasm_worker_hello_minimal_runtime_2(self):
-    self.btest_exit('wasm_worker/hello_wasm_worker.c', emcc_args=['-sWASM_WORKERS', '-sMINIMAL_RUNTIME=2'])
+    self.btest_exit('wasm_worker/hello_wasm_worker.c', cflags=['-sWASM_WORKERS', '-sMINIMAL_RUNTIME=2'])
 
   # Tests Wasm Workers build in Wasm2JS mode.
   @requires_wasm2js
   @also_with_minimal_runtime
   def test_wasm_worker_hello_wasm2js(self):
-    self.btest_exit('wasm_worker/hello_wasm_worker.c', emcc_args=['-sWASM_WORKERS', '-sWASM=0'])
+    self.btest_exit('wasm_worker/hello_wasm_worker.c', cflags=['-sWASM_WORKERS', '-sWASM=0'])
 
   # Tests the WASM_WORKERS=2 build mode, which embeds the Wasm Worker bootstrap JS script file to the main JS file.
   @also_with_minimal_runtime
   def test_wasm_worker_hello_embedded(self):
-    self.btest_exit('wasm_worker/hello_wasm_worker.c', emcc_args=['-sWASM_WORKERS=2'])
+    self.btest_exit('wasm_worker/hello_wasm_worker.c', cflags=['-sWASM_WORKERS=2'])
 
   # Tests that it is possible to call emscripten_futex_wait() in Wasm Workers.
   @parameterized({
@@ -5137,7 +5137,7 @@ Module["preRun"] = () => {
     'pthread': (['-pthread'],),
   })
   def test_wasm_worker_futex_wait(self, args):
-    self.btest('wasm_worker/wasm_worker_futex_wait.c', expected='0', emcc_args=['-sWASM_WORKERS=1', '-sASSERTIONS'] + args)
+    self.btest('wasm_worker/wasm_worker_futex_wait.c', expected='0', cflags=['-sWASM_WORKERS=1', '-sASSERTIONS'] + args)
 
   # Tests Wasm Worker thread stack setup
   @also_with_minimal_runtime
@@ -5147,53 +5147,53 @@ Module["preRun"] = () => {
     '2': (2,),
   })
   def test_wasm_worker_thread_stack(self, mode):
-    self.btest('wasm_worker/thread_stack.c', expected='0', emcc_args=['-sWASM_WORKERS', f'-sSTACK_OVERFLOW_CHECK={mode}'])
+    self.btest('wasm_worker/thread_stack.c', expected='0', cflags=['-sWASM_WORKERS', f'-sSTACK_OVERFLOW_CHECK={mode}'])
 
   # Tests emscripten_malloc_wasm_worker() and emscripten_current_thread_is_wasm_worker() functions
   @also_with_minimal_runtime
   def test_wasm_worker_malloc(self):
-    self.btest_exit('wasm_worker/malloc_wasm_worker.c', emcc_args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/malloc_wasm_worker.c', cflags=['-sWASM_WORKERS'])
 
   # Tests Wasm Worker+pthreads simultaneously
   @also_with_minimal_runtime
   def test_wasm_worker_and_pthreads(self):
-    self.btest('wasm_worker/wasm_worker_and_pthread.c', expected='0', emcc_args=['-sWASM_WORKERS', '-pthread'])
+    self.btest('wasm_worker/wasm_worker_and_pthread.c', expected='0', cflags=['-sWASM_WORKERS', '-pthread'])
 
   # Tests emscripten_wasm_worker_self_id() function
   @also_with_minimal_runtime
   def test_wasm_worker_self_id(self):
-    self.btest('wasm_worker/wasm_worker_self_id.c', expected='0', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/wasm_worker_self_id.c', expected='0', cflags=['-sWASM_WORKERS'])
 
   # Tests direct Wasm Assembly .S file based TLS variables in Wasm Workers
   @also_with_minimal_runtime
   def test_wasm_worker_tls_wasm_assembly(self):
     self.btest('wasm_worker/wasm_worker_tls_wasm_assembly.c',
-               expected='42', emcc_args=['-sWASM_WORKERS', test_file('wasm_worker/wasm_worker_tls_wasm_assembly.S')])
+               expected='42', cflags=['-sWASM_WORKERS', test_file('wasm_worker/wasm_worker_tls_wasm_assembly.S')])
 
   # Tests C++11 keyword thread_local for TLS in Wasm Workers
   @also_with_minimal_runtime
   def test_wasm_worker_cpp11_thread_local(self):
-    self.btest('wasm_worker/cpp11_thread_local.cpp', expected='42', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/cpp11_thread_local.cpp', expected='42', cflags=['-sWASM_WORKERS'])
 
   # Tests C11 keyword _Thread_local for TLS in Wasm Workers
   @also_with_minimal_runtime
   def test_wasm_worker_c11__Thread_local(self):
-    self.btest('wasm_worker/c11__Thread_local.c', expected='42', emcc_args=['-sWASM_WORKERS', '-std=gnu11']) # Cannot test C11 - because of EM_ASM must test Gnu11.
+    self.btest('wasm_worker/c11__Thread_local.c', expected='42', cflags=['-sWASM_WORKERS', '-std=gnu11']) # Cannot test C11 - because of EM_ASM must test Gnu11.
 
   # Tests GCC specific extension keyword __thread for TLS in Wasm Workers
   @also_with_minimal_runtime
   def test_wasm_worker_gcc___thread(self):
-    self.btest('wasm_worker/gcc___Thread.c', expected='42', emcc_args=['-sWASM_WORKERS', '-std=gnu11'])
+    self.btest('wasm_worker/gcc___Thread.c', expected='42', cflags=['-sWASM_WORKERS', '-std=gnu11'])
 
   # Tests emscripten_wasm_worker_sleep()
   @also_with_minimal_runtime
   def test_wasm_worker_sleep(self):
-    self.btest('wasm_worker/wasm_worker_sleep.c', expected='1', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/wasm_worker_sleep.c', expected='1', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_terminate_wasm_worker()
   @also_with_minimal_runtime
   def test_wasm_worker_terminate(self):
-    self.btest_exit('wasm_worker/terminate_wasm_worker.c', emcc_args=['-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/terminate_wasm_worker.c', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_terminate_all_wasm_workers()
   @also_with_minimal_runtime
@@ -5206,78 +5206,78 @@ Module["preRun"] = () => {
   # Tests emscripten_wasm_worker_post_function_*() API
   @also_with_minimal_runtime
   def test_wasm_worker_post_function(self):
-    self.btest('wasm_worker/post_function.c', expected='8', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/post_function.c', expected='8', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_wasm_worker_post_function_*() API and EMSCRIPTEN_WASM_WORKER_ID_PARENT
   # to send a message back from Worker to its parent thread.
   @also_with_minimal_runtime
   def test_wasm_worker_post_function_to_main_thread(self):
-    self.btest('wasm_worker/post_function_to_main_thread.c', expected='10', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/post_function_to_main_thread.c', expected='10', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_navigator_hardware_concurrency() and emscripten_atomics_is_lock_free()
   @also_with_minimal_runtime
   def test_wasm_worker_hardware_concurrency_is_lock_free(self):
-    self.btest('wasm_worker/hardware_concurrency_is_lock_free.c', expected='0', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/hardware_concurrency_is_lock_free.c', expected='0', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_wait_u32() and emscripten_atomic_notify() functions.
   @also_with_minimal_runtime
   def test_wasm_worker_wait32_notify(self):
-    self.btest('atomic/test_wait32_notify.c', expected='3', emcc_args=['-sWASM_WORKERS'])
+    self.btest('atomic/test_wait32_notify.c', expected='3', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_wait_u64() and emscripten_atomic_notify() functions.
   @also_with_minimal_runtime
   def test_wasm_worker_wait64_notify(self):
-    self.btest('atomic/test_wait64_notify.c', expected='3', emcc_args=['-sWASM_WORKERS'])
+    self.btest('atomic/test_wait64_notify.c', expected='3', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_wait_async() function.
   @also_with_minimal_runtime
   def test_wasm_worker_wait_async(self):
-    self.btest_exit('atomic/test_wait_async.c', emcc_args=['-sWASM_WORKERS'])
+    self.btest_exit('atomic/test_wait_async.c', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_cancel_wait_async() function.
   @also_with_minimal_runtime
   def test_wasm_worker_cancel_wait_async(self):
-    self.btest('wasm_worker/cancel_wait_async.c', expected='1', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/cancel_wait_async.c', expected='1', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_cancel_all_wait_asyncs() function.
   @also_with_minimal_runtime
   def test_wasm_worker_cancel_all_wait_asyncs(self):
-    self.btest('wasm_worker/cancel_all_wait_asyncs.c', expected='1', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/cancel_all_wait_asyncs.c', expected='1', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_atomic_cancel_all_wait_asyncs_at_address() function.
   @also_with_minimal_runtime
   def test_wasm_worker_cancel_all_wait_asyncs_at_address(self):
-    self.btest('wasm_worker/cancel_all_wait_asyncs_at_address.c', expected='1', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/cancel_all_wait_asyncs_at_address.c', expected='1', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_lock_init(), emscripten_lock_waitinf_acquire() and emscripten_lock_release()
   @also_with_minimal_runtime
   def test_wasm_worker_lock_waitinf(self):
-    self.btest('wasm_worker/lock_waitinf_acquire.c', expected='4000', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/lock_waitinf_acquire.c', expected='4000', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_lock_wait_acquire() and emscripten_lock_try_acquire() in Worker.
   @also_with_minimal_runtime
   def test_wasm_worker_lock_wait(self):
-    self.btest('wasm_worker/lock_wait_acquire.c', expected='0', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/lock_wait_acquire.c', expected='0', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_lock_wait_acquire() between two Wasm Workers.
   @also_with_minimal_runtime
   def test_wasm_worker_lock_wait2(self):
-    self.btest('wasm_worker/lock_wait_acquire2.c', expected='0', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/lock_wait_acquire2.c', expected='0', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_lock_async_acquire() function.
   @also_with_minimal_runtime
   def test_wasm_worker_lock_async_acquire(self):
-    self.btest_exit('wasm_worker/lock_async_acquire.c', emcc_args=['--closure=1', '-sWASM_WORKERS'])
+    self.btest_exit('wasm_worker/lock_async_acquire.c', cflags=['--closure=1', '-sWASM_WORKERS'])
 
   # Tests emscripten_lock_busyspin_wait_acquire() in Worker and main thread.
   @also_with_minimal_runtime
   def test_wasm_worker_lock_busyspin_wait(self):
-    self.btest('wasm_worker/lock_busyspin_wait_acquire.c', expected='0', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/lock_busyspin_wait_acquire.c', expected='0', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_lock_busyspin_waitinf_acquire() in Worker and main thread.
   @also_with_minimal_runtime
   def test_wasm_worker_lock_busyspin_waitinf(self):
-    self.btest('wasm_worker/lock_busyspin_waitinf_acquire.c', expected='1', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/lock_busyspin_waitinf_acquire.c', expected='1', cflags=['-sWASM_WORKERS'])
 
   # Tests that proxied JS functions cannot be called from Wasm Workers
   @also_with_minimal_runtime
@@ -5287,25 +5287,25 @@ Module["preRun"] = () => {
     # Test uses the dynCall library function in its EM_ASM code
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$dynCall'])
     self.btest('wasm_worker/no_proxied_js_functions.c', expected='0',
-               emcc_args=['--js-library', test_file('wasm_worker/no_proxied_js_functions.js')])
+               cflags=['--js-library', test_file('wasm_worker/no_proxied_js_functions.js')])
 
   # Tests emscripten_semaphore_init(), emscripten_semaphore_waitinf_acquire() and emscripten_semaphore_release()
   @also_with_minimal_runtime
   def test_wasm_worker_semaphore_waitinf_acquire(self):
-    self.btest('wasm_worker/semaphore_waitinf_acquire.c', expected='0', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/semaphore_waitinf_acquire.c', expected='0', cflags=['-sWASM_WORKERS'])
 
   # Tests emscripten_semaphore_try_acquire() on the main thread
   @also_with_minimal_runtime
   def test_wasm_worker_semaphore_try_acquire(self):
-    self.btest('wasm_worker/semaphore_try_acquire.c', expected='0', emcc_args=['-sWASM_WORKERS'])
+    self.btest('wasm_worker/semaphore_try_acquire.c', expected='0', cflags=['-sWASM_WORKERS'])
 
   # Tests that calling any proxied function in a Wasm Worker will abort at runtime when ASSERTIONS are enabled.
   def test_wasm_worker_proxied_function(self):
     error_msg = "abort:Assertion failed: Attempted to call proxied function '_proxied_js_function' in a Wasm Worker, but in Wasm Worker enabled builds, proxied function architecture is not available!"
     # Test that program aborts in ASSERTIONS-enabled builds
-    self.btest('wasm_worker/proxied_function.c', expected=error_msg, emcc_args=['--js-library', test_file('wasm_worker/proxied_function.js'), '-sWASM_WORKERS', '-sASSERTIONS'])
+    self.btest('wasm_worker/proxied_function.c', expected=error_msg, cflags=['--js-library', test_file('wasm_worker/proxied_function.js'), '-sWASM_WORKERS', '-sASSERTIONS'])
     # Test that code does not crash in ASSERTIONS-disabled builds
-    self.btest('wasm_worker/proxied_function.c', expected='0', emcc_args=['--js-library', test_file('wasm_worker/proxied_function.js'), '-sWASM_WORKERS', '-sASSERTIONS=0'])
+    self.btest('wasm_worker/proxied_function.c', expected='0', cflags=['--js-library', test_file('wasm_worker/proxied_function.js'), '-sWASM_WORKERS', '-sASSERTIONS=0'])
 
   @no_firefox('no 4GB support yet')
   @no_2gb('uses MAXIMUM_MEMORY')
@@ -5319,7 +5319,7 @@ Module["preRun"] = () => {
 
     # test that we can allocate in the 2-4GB range, if we enable growth and
     # set the max appropriately
-    self.emcc_args += ['-O2', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=4GB']
+    self.cflags += ['-O2', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=4GB']
     self.do_run_in_out_file_test('browser/test_4GB.cpp')
 
   # Tests that emmalloc supports up to 4GB Wasm heaps.
@@ -5330,7 +5330,7 @@ Module["preRun"] = () => {
     # means we don't compete for memory with anything else (and run it
     # at the very very end, to reduce the risk of it OOM-killing the
     # browser).
-    self.btest_exit('test_mem_growth.c', emcc_args=['-sMALLOC=emmalloc', '-sABORTING_MALLOC=0', '-sALLOW_MEMORY_GROWTH=1', '-sMAXIMUM_MEMORY=4GB'])
+    self.btest_exit('test_mem_growth.c', cflags=['-sMALLOC=emmalloc', '-sABORTING_MALLOC=0', '-sALLOW_MEMORY_GROWTH=1', '-sMAXIMUM_MEMORY=4GB'])
 
   # Test that it is possible to malloc() a huge 3GB memory block in 4GB mode using emmalloc.
   # Also test emmalloc-memvalidate and emmalloc-memvalidate-verbose build configurations.
@@ -5347,7 +5347,7 @@ Module["preRun"] = () => {
       self.set_setting('MAXIMUM_MEMORY', '8GB')
     else:
       self.set_setting('MAXIMUM_MEMORY', '4GB')
-    self.btest_exit('alloc_3gb.c', emcc_args=['-sALLOW_MEMORY_GROWTH=1'] + args)
+    self.btest_exit('alloc_3gb.c', cflags=['-sALLOW_MEMORY_GROWTH=1'] + args)
 
   # Test that it is possible to malloc() a huge 3GB memory block in 4GB mode using dlmalloc.
   @no_firefox('no 4GB support yet')
@@ -5357,7 +5357,7 @@ Module["preRun"] = () => {
       self.set_setting('MAXIMUM_MEMORY', '8GB')
     else:
       self.set_setting('MAXIMUM_MEMORY', '4GB')
-    self.btest_exit('alloc_3gb.c', emcc_args=['-sMALLOC=dlmalloc', '-sALLOW_MEMORY_GROWTH=1'])
+    self.btest_exit('alloc_3gb.c', cflags=['-sMALLOC=dlmalloc', '-sALLOW_MEMORY_GROWTH=1'])
 
   @no_wasm64()
   @parameterized({
@@ -5381,7 +5381,7 @@ Module["preRun"] = () => {
     create_file('subdir/backendfile', 'file 1')
     create_file('subdir/backendfile2', 'file 2')
     self.btest_exit('wasmfs/wasmfs_fetch.c',
-                    emcc_args=['-sWASMFS', '-pthread', '-sPROXY_TO_PTHREAD',
+                    cflags=['-sWASMFS', '-pthread', '-sPROXY_TO_PTHREAD',
                                '-sFORCE_FILESYSTEM', '-lfetchfs.js',
                                '--js-library', test_file('wasmfs/wasmfs_fetch.js')] + args)
 
@@ -5397,21 +5397,21 @@ Module["preRun"] = () => {
       self.require_jspi()
     test = test_file('wasmfs/wasmfs_opfs.c')
     args = ['-sWASMFS', '-O3'] + args
-    self.btest_exit(test, emcc_args=args + ['-DWASMFS_SETUP'])
-    self.btest_exit(test, emcc_args=args + ['-DWASMFS_RESUME'])
+    self.btest_exit(test, cflags=args + ['-DWASMFS_SETUP'])
+    self.btest_exit(test, cflags=args + ['-DWASMFS_RESUME'])
 
   @no_firefox('no OPFS support yet')
   def test_wasmfs_opfs_errors(self):
     test = test_file('wasmfs/wasmfs_opfs_errors.c')
     postjs = test_file('wasmfs/wasmfs_opfs_errors_post.js')
     args = ['-sWASMFS', '-pthread', '-sPROXY_TO_PTHREAD', '--post-js', postjs]
-    self.btest(test, emcc_args=args, expected='0')
+    self.btest(test, cflags=args, expected='0')
 
   @no_firefox('no 4GB support yet')
   def test_emmalloc_memgrowth(self):
     if not self.is_4gb():
       self.set_setting('MAXIMUM_MEMORY', '4GB')
-    self.btest_exit('emmalloc_memgrowth.cpp', emcc_args=['-sMALLOC=emmalloc', '-sALLOW_MEMORY_GROWTH=1', '-sABORTING_MALLOC=0', '-sASSERTIONS=2', '-sMINIMAL_RUNTIME=1'])
+    self.btest_exit('emmalloc_memgrowth.cpp', cflags=['-sMALLOC=emmalloc', '-sALLOW_MEMORY_GROWTH=1', '-sABORTING_MALLOC=0', '-sASSERTIONS=2', '-sMINIMAL_RUNTIME=1'])
 
   @no_firefox('no 4GB support yet')
   @no_2gb('uses MAXIMUM_MEMORY')
@@ -5425,7 +5425,7 @@ Module["preRun"] = () => {
 
     # test that growth doesn't go beyond 2GB without the max being set for that,
     # and that we can catch an allocation failure exception for that
-    self.emcc_args += ['-O2', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=2GB']
+    self.cflags += ['-O2', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=2GB']
     self.do_run_in_out_file_test('browser/test_2GB_fail.cpp')
 
   @no_firefox('no 4GB support yet')
@@ -5441,7 +5441,7 @@ Module["preRun"] = () => {
     # test that we properly report an allocation error that would overflow over
     # 4GB.
     self.set_setting('MAXIMUM_MEMORY', '4GB')
-    self.emcc_args += ['-O2', '-sALLOW_MEMORY_GROWTH', '-sABORTING_MALLOC=0', '-sASSERTIONS']
+    self.cflags += ['-O2', '-sALLOW_MEMORY_GROWTH', '-sABORTING_MALLOC=0', '-sASSERTIONS']
     self.do_run_in_out_file_test('browser/test_4GB_fail.cpp')
 
   # Tests that Emscripten-compiled applications can be run when a slash in the URL query or fragment of the js file
@@ -5468,7 +5468,7 @@ Module["preRun"] = () => {
     # at some point, using 0% CPU. often that occured in 0-200 iterations, but
     # you may want to adjust "ITERATIONS".
     self.btest_exit('pthread/test_pthread_proxy_hammer.cpp',
-                    emcc_args=['-pthread', '-O2', '-sPROXY_TO_PTHREAD',
+                    cflags=['-pthread', '-O2', '-sPROXY_TO_PTHREAD',
                                '-DITERATIONS=1024', '-g1'] + args,
                     timeout=10000,
                     # don't run this with the default extra_tries value, as this is
@@ -5482,16 +5482,16 @@ Module["preRun"] = () => {
     # Check that an unhandled promise rejection is propagated to the main thread
     # as an error. This test is failing if it hangs!
     self.btest('pthread/test_pthread_unhandledrejection.c',
-               emcc_args=['-pthread', '-sPROXY_TO_PTHREAD', '--post-js',
+               cflags=['-pthread', '-sPROXY_TO_PTHREAD', '--post-js',
                           test_file('pthread/test_pthread_unhandledrejection.post.js')],
                # Firefox and Chrome report this slightly differently
                expected=['exception:Uncaught rejected!', 'exception:uncaught exception: rejected!'])
 
   def test_pthread_key_recreation(self):
-    self.btest_exit('pthread/test_pthread_key_recreation.c', emcc_args=['-pthread', '-sPTHREAD_POOL_SIZE=1'])
+    self.btest_exit('pthread/test_pthread_key_recreation.c', cflags=['-pthread', '-sPTHREAD_POOL_SIZE=1'])
 
   def test_full_js_library_strict(self):
-    self.btest_exit('hello_world.c', emcc_args=['-sINCLUDE_FULL_LIBRARY', '-sSTRICT_JS'])
+    self.btest_exit('hello_world.c', cflags=['-sINCLUDE_FULL_LIBRARY', '-sSTRICT_JS'])
 
   # Tests the AudioWorklet demo
   @parameterized({
@@ -5511,12 +5511,12 @@ Module["preRun"] = () => {
   @no_2gb('https://github.com/emscripten-core/emscripten/pull/23508')
   @requires_sound_hardware
   def test_audio_worklet(self, args):
-    self.btest_exit('webaudio/audioworklet.c', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-DTEST_AND_EXIT'] + args)
+    self.btest_exit('webaudio/audioworklet.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-DTEST_AND_EXIT'] + args)
 
   # Tests that audioworklets and workers can be used at the same time
   # Note: doesn't need audio hardware (and has no AW code that tests 2GB or wasm64)
   def test_audio_worklet_worker(self):
-    self.btest_exit('webaudio/audioworklet_worker.c', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
+    self.btest_exit('webaudio/audioworklet_worker.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
 
   # Tests that posting functions between the main thread and the audioworklet thread works
   @parameterized({
@@ -5525,7 +5525,7 @@ Module["preRun"] = () => {
   })
   # Note: doesn't need audio hardware (and has no AW code that tests 2GB or wasm64)
   def test_audio_worklet_post_function(self, args):
-    self.btest_exit('webaudio/audioworklet_post_function.c', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'] + args)
+    self.btest_exit('webaudio/audioworklet_post_function.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS'] + args)
 
   @parameterized({
     '': ([],),
@@ -5535,7 +5535,7 @@ Module["preRun"] = () => {
   @no_2gb('https://github.com/emscripten-core/emscripten/pull/23508')
   @requires_sound_hardware
   def test_audio_worklet_modularize(self, args):
-    self.btest_exit('webaudio/audioworklet.c', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sMODULARIZE=1', '-sEXPORT_NAME=MyModule', '--shell-file', test_file('shell_that_launches_modularize.html'), '-DTEST_AND_EXIT'] + args)
+    self.btest_exit('webaudio/audioworklet.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sMODULARIZE=1', '-sEXPORT_NAME=MyModule', '--shell-file', test_file('shell_that_launches_modularize.html'), '-DTEST_AND_EXIT'] + args)
 
   # Tests an AudioWorklet with multiple stereo inputs mixing in the processor
   # via a varying parameter to a single stereo output (touching all of the API
@@ -5551,7 +5551,7 @@ Module["preRun"] = () => {
     os.mkdir('audio_files')
     shutil.copy(test_file('webaudio/audio_files/emscripten-beat.mp3'), 'audio_files/')
     shutil.copy(test_file('webaudio/audio_files/emscripten-bass.mp3'), 'audio_files/')
-    self.btest_exit('webaudio/audioworklet_params_mixing.c', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-DTEST_AND_EXIT'] + args)
+    self.btest_exit('webaudio/audioworklet_params_mixing.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-DTEST_AND_EXIT'] + args)
 
   # Tests AudioWorklet with emscripten_lock_busyspin_wait_acquire() and friends
   @no_wasm64('https://github.com/emscripten-core/emscripten/pull/23508')
@@ -5559,16 +5559,16 @@ Module["preRun"] = () => {
   @requires_sound_hardware
   @also_with_minimal_runtime
   def test_audio_worklet_emscripten_locks(self):
-    self.btest_exit('webaudio/audioworklet_emscripten_locks.c', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-pthread'])
+    self.btest_exit('webaudio/audioworklet_emscripten_locks.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-pthread'])
 
   def test_error_reporting(self):
     # Test catching/reporting Error objects
     create_file('post.js', 'throw new Error("oops");')
-    self.btest('hello_world.c', emcc_args=['--post-js=post.js'], expected='exception:oops')
+    self.btest('hello_world.c', cflags=['--post-js=post.js'], expected='exception:oops')
 
     # Test catching/reporting non-Error objects
     create_file('post.js', 'throw "foo";')
-    self.btest('hello_world.c', emcc_args=['--post-js=post.js'], expected='exception:foo')
+    self.btest('hello_world.c', cflags=['--post-js=post.js'], expected='exception:foo')
 
   @also_with_threads
   @parameterized({
@@ -5578,7 +5578,7 @@ Module["preRun"] = () => {
   def test_webpack(self, es6):
     if es6:
       copytree(test_file('webpack_es6'), '.')
-      self.emcc_args += ['-sEXPORT_ES6', '-pthread', '-sPTHREAD_POOL_SIZE=1']
+      self.cflags += ['-sEXPORT_ES6', '-pthread', '-sPTHREAD_POOL_SIZE=1']
       outfile = 'src/hello.mjs'
     else:
       copytree(test_file('webpack'), '.')
@@ -5733,7 +5733,7 @@ class browser64_4gb(browser):
     self.set_setting('INITIAL_MEMORY', '4200mb')
     self.set_setting('GLOBAL_BASE', '4gb')
     # Without this we get a warning about GLOBAL_BASE being ignored when used with SIDE_MODULE
-    self.emcc_args.append('-Wno-unused-command-line-argument')
+    self.cflags.append('-Wno-unused-command-line-argument')
     self.require_wasm64()
 
 
@@ -5752,4 +5752,4 @@ class browser_2gb(browser):
     self.set_setting('INITIAL_MEMORY', '2200mb')
     self.set_setting('GLOBAL_BASE', '2gb')
     # Without this we get a warning about GLOBAL_BASE being ignored when used with SIDE_MODULE
-    self.emcc_args.append('-Wno-unused-command-line-argument')
+    self.cflags.append('-Wno-unused-command-line-argument')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -94,10 +94,10 @@ def wasm_simd(f):
       self.skipTest('https://github.com/WebAssembly/binaryen/issues/4638')
     if self.is_wasm2js():
       self.skipTest('wasm2js only supports MVP for now')
-    if '-O3' in self.emcc_args:
+    if '-O3' in self.cflags:
       self.skipTest('SIMD tests are too slow with -O3 in the new LLVM pass manager, https://github.com/emscripten-core/emscripten/issues/13427')
-    self.emcc_args.append('-msimd128')
-    self.emcc_args.append('-fno-lax-vector-conversions')
+    self.cflags.append('-msimd128')
+    self.cflags.append('-fno-lax-vector-conversions')
     self.v8_args.append('--experimental-wasm-simd')
     f(self, *args, **kwargs)
   return decorated
@@ -128,7 +128,7 @@ def wasm_relaxed_simd(f):
     # We don't actually run any tests yet, so don't require any engines.
     if self.is_wasm2js():
       self.skipTest('wasm2js only supports MVP for now')
-    self.emcc_args.append('-mrelaxed-simd')
+    self.cflags.append('-mrelaxed-simd')
     f(self)
   return decorated
 
@@ -299,7 +299,7 @@ def no_asan(note):
 
     @wraps(f)
     def decorated(self, *args, **kwargs):
-      if '-fsanitize=address' in self.emcc_args:
+      if '-fsanitize=address' in self.cflags:
         self.skipTest(note)
       f(self, *args, **kwargs)
     return decorated
@@ -314,7 +314,7 @@ def no_lsan(note):
 
     @wraps(f)
     def decorated(self, *args, **kwargs):
-      if '-fsanitize=leak' in self.emcc_args:
+      if '-fsanitize=leak' in self.cflags:
         self.skipTest(note)
       f(self, *args, **kwargs)
     return decorated
@@ -329,7 +329,7 @@ def no_ubsan(note):
 
     @wraps(f)
     def decorated(self, *args, **kwargs):
-      if '-fsanitize=undefined' in self.emcc_args:
+      if '-fsanitize=undefined' in self.cflags:
         self.skipTest(note)
       f(self, *args, **kwargs)
     return decorated
@@ -344,7 +344,7 @@ def no_sanitize(note):
 
     @wraps(f)
     def decorated(self, *args, **kwargs):
-      if any(a.startswith('-fsanitize=') for a in self.emcc_args):
+      if any(a.startswith('-fsanitize=') for a in self.cflags):
         self.skipTest(note)
       f(self, *args, **kwargs)
     return decorated
@@ -375,7 +375,7 @@ def make_no_decorator_for_setting(name):
 
       @wraps(f)
       def decorated(self, *args, **kwargs):
-        if (name + '=1') in self.emcc_args or self.get_setting(name):
+        if (name + '=1') in self.cflags or self.get_setting(name):
           self.skipTest(note)
         f(self, *args, **kwargs)
       return decorated
@@ -414,20 +414,20 @@ class TestCoreBase(RunnerCore):
 
   # A simple check whether the compiler arguments cause optimization.
   def is_optimizing(self):
-    return '-O' in str(self.emcc_args) and '-O0' not in self.emcc_args
+    return '-O' in str(self.cflags) and '-O0' not in self.cflags
 
   def should_use_closure(self):
     # Don't run closure in all test modes, just a couple, since it slows
     # the tests down quite a bit.
     required = ('-O2', '-Os')
     prohibited = ('-g', '--profiling')
-    return all(f not in self.emcc_args for f in prohibited) and any(f in self.emcc_args for f in required)
+    return all(f not in self.cflags for f in prohibited) and any(f in self.cflags for f in required)
 
   def setup_esm_integration(self):
     self.require_node_canary()
     self.node_args += ['--experimental-wasm-modules', '--no-warnings']
     self.set_setting('WASM_ESM_INTEGRATION')
-    self.emcc_args += ['-Wno-experimental']
+    self.cflags += ['-Wno-experimental']
     if self.is_wasm64():
       self.skipTest('wasm64 requires wasm export wrappers')
     if self.is_wasm2js():
@@ -435,8 +435,8 @@ class TestCoreBase(RunnerCore):
 
   # Use closure in some tests for some additional coverage
   def maybe_closure(self):
-    if '--closure=1' not in self.emcc_args and self.should_use_closure():
-      self.emcc_args += ['--closure=1']
+    if '--closure=1' not in self.cflags and self.should_use_closure():
+      self.cflags += ['--closure=1']
       logger.debug('using closure compiler..')
       return True
     return False
@@ -507,7 +507,7 @@ class TestCoreBase(RunnerCore):
 
   def test_int53(self):
     if common.EMTEST_REBASELINE:
-      self.run_process([EMCC, test_file('core/test_int53.c'), '-o', 'a.js', '-DGENERATE_ANSWERS'] + self.emcc_args)
+      self.run_process([EMCC, test_file('core/test_int53.c'), '-o', 'a.js', '-DGENERATE_ANSWERS'] + self.cflags)
       ret = self.run_process(config.NODE_JS + ['a.js'], stdout=PIPE).stdout
       write_file(test_file('core/test_int53.out'), ret)
     else:
@@ -515,7 +515,7 @@ class TestCoreBase(RunnerCore):
 
   def test_int53_convertI32PairToI53Checked(self):
     if common.EMTEST_REBASELINE:
-      self.run_process([EMCC, test_file('core/test_convertI32PairToI53Checked.cpp'), '-o', 'a.js', '-DGENERATE_ANSWERS'] + self.emcc_args)
+      self.run_process([EMCC, test_file('core/test_convertI32PairToI53Checked.cpp'), '-o', 'a.js', '-DGENERATE_ANSWERS'] + self.cflags)
       ret = self.run_process(config.NODE_JS + ['a.js'], stdout=PIPE).stdout
       write_file(test_file('core/test_convertI32PairToI53Checked.out'), ret)
     else:
@@ -600,7 +600,7 @@ class TestCoreBase(RunnerCore):
   @requires_node
   def test_i64_invoke_bigint(self):
     self.set_setting('WASM_BIGINT')
-    self.emcc_args += ['-fexceptions']
+    self.cflags += ['-fexceptions']
     self.node_args += shared.node_bigint_flags(self.get_nodejs())
     self.do_core_test('test_i64_invoke_bigint.cpp')
 
@@ -663,12 +663,12 @@ class TestCoreBase(RunnerCore):
 
   def test_core_types(self):
     if self.get_setting('STRICT'):
-      self.emcc_args += ['-DIN_STRICT_MODE=1']
+      self.cflags += ['-DIN_STRICT_MODE=1']
     self.do_runf('core/test_core_types.c')
 
   def test_cube2md5(self):
     shutil.copy(test_file('core/test_cube2md5.txt'), '.')
-    self.do_core_test('test_cube2md5.c', emcc_args=['--embed-file', 'test_cube2md5.txt'])
+    self.do_core_test('test_cube2md5.c', cflags=['--embed-file', 'test_cube2md5.txt'])
 
   @also_with_standalone_wasm()
   @needs_make('make')
@@ -773,7 +773,7 @@ class TestCoreBase(RunnerCore):
     '''
     self.do_run(src, '*4294967295,0,4294967219*\n*-1,1,-1,1*\n*-2,1,-2,1*\n*246,296*\n*1,0*')
 
-    self.emcc_args.append('-Wno-constant-conversion')
+    self.cflags.append('-Wno-constant-conversion')
     src = '''
       #include <stdio.h>
       int main()
@@ -831,7 +831,7 @@ class TestCoreBase(RunnerCore):
     self.do_core_test('closebitcasts.c')
 
   def test_fast_math(self):
-    self.emcc_args += ['-ffast-math']
+    self.cflags += ['-ffast-math']
     self.do_core_test('test_fast_math.c', args=['5', '6', '8'])
 
   @only_wasm2js('tests division by zero')
@@ -915,12 +915,12 @@ base align: 0, 0, 0, 0'''])
     # the assumption that they are external, so like in system_libs.py where we build
     # malloc, we need to disable builtin here too
     self.set_setting('MALLOC', 'none')
-    self.emcc_args += [
+    self.cflags += [
       '-fno-builtin',
       path_from_root('system/lib/libc/sbrk.c'),
       path_from_root('system/lib/emmalloc.c'),
     ]
-    self.emcc_args += args
+    self.cflags += args
     self.do_run_in_out_file_test('core/test_emmalloc.c')
 
   @no_asan('ASan does not support custom memory allocators')
@@ -943,7 +943,7 @@ base align: 0, 0, 0, 0'''])
 
     self.set_setting('INITIAL_MEMORY', '128mb')
     self.set_setting('MALLOC', 'emmalloc')
-    self.emcc_args += ['-g']
+    self.cflags += ['-g']
     self.do_core_test('test_emmalloc_memory_statistics.c', out_suffix=out_suffix)
 
   @no_optimize('output is sensitive to optimization flags, so only test unoptimized builds')
@@ -954,7 +954,7 @@ base align: 0, 0, 0, 0'''])
   @disabled('https://github.com/emscripten-core/emscripten/issues/23343')
   def test_emmalloc_trim(self):
     self.set_setting('MALLOC', 'emmalloc')
-    self.emcc_args += ['-sINITIAL_MEMORY=128MB', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=2147418112']
+    self.cflags += ['-sINITIAL_MEMORY=128MB', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=2147418112']
 
     self.do_core_test('test_emmalloc_trim.c')
 
@@ -979,11 +979,11 @@ base align: 0, 0, 0, 0'''])
   @no_sanitize('sanitizers do not support WASM_WORKERS')
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
   def test_longjmp_wasm_workers(self):
-    self.do_core_test('test_longjmp.c', emcc_args=['-sWASM_WORKERS'])
+    self.do_core_test('test_longjmp.c', cflags=['-sWASM_WORKERS'])
 
   @with_all_sjlj
   def test_longjmp_zero(self):
-    if '-fsanitize=undefined' in self.emcc_args and self.get_setting('SUPPORT_LONGJMP') == 'emscripten':
+    if '-fsanitize=undefined' in self.cflags and self.get_setting('SUPPORT_LONGJMP') == 'emscripten':
       # For some reason this tests fails under ubsan, but only with emscripten EH.
       self.skipTest('https://github.com/emscripten-core/emscripten/issues/21533')
     self.do_core_test('test_longjmp_zero.c')
@@ -1002,12 +1002,12 @@ base align: 0, 0, 0, 0'''])
     if self.is_wasm2js():
       self.skipTest('wasm2js does not support wasm EH/SjLj')
     # FIXME Temporarily disabled. Enable this later when the bug is fixed.
-    if '-fsanitize=address' in self.emcc_args:
+    if '-fsanitize=address' in self.cflags:
       self.skipTest('Wasm EH does not work with asan yet')
     for legacy in [0, 1]:
       self.set_setting('WASM_LEGACY_EXCEPTIONS', legacy)
       for arg in ('-fwasm-exceptions', '-fno-exceptions'):
-        self.do_core_test('test_longjmp.c', emcc_args=[arg])
+        self.do_core_test('test_longjmp.c', cflags=[arg])
 
   @with_all_sjlj
   def test_longjmp2(self):
@@ -1057,7 +1057,7 @@ base align: 0, 0, 0, 0'''])
 
   @with_all_sjlj
   def test_longjmp_i64(self):
-    self.emcc_args += ['-g']
+    self.cflags += ['-g']
     self.do_core_test('test_longjmp_i64.c', assert_returncode=NON_ZERO)
 
   @with_all_sjlj
@@ -1138,9 +1138,9 @@ int main()
     if self.is_wasm2js():
       self.skipTest('wasm2js does not support wasm EH/SjLj')
     # FIXME Temporarily disabled. Enable this later when the bug is fixed.
-    if '-fsanitize=address' in self.emcc_args:
+    if '-fsanitize=address' in self.cflags:
       self.skipTest('Wasm EH does not work with asan yet')
-    self.emcc_args.append('-fwasm-exceptions')
+    self.cflags.append('-fwasm-exceptions')
     for legacy in [0, 1]:
       self.set_setting('WASM_LEGACY_EXCEPTIONS', legacy)
       for support_longjmp in (0, 'wasm'):
@@ -1158,7 +1158,7 @@ int main()
   def test_exceptions_minimal_runtime(self):
     self.maybe_closure()
     self.set_setting('MINIMAL_RUNTIME')
-    self.emcc_args += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]
+    self.cflags += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]
     for support_longjmp in (0, 1):
       self.set_setting('SUPPORT_LONGJMP', support_longjmp)
 
@@ -1216,7 +1216,7 @@ int main()
   def test_exceptions_2(self):
     for safe in (0, 1):
       print(safe)
-      if safe and '-fsanitize=address' in self.emcc_args:
+      if safe and '-fsanitize=address' in self.cflags:
         # Can't use safe heap with ASan
         continue
       self.set_setting('SAFE_HEAP', safe)
@@ -1301,12 +1301,12 @@ int main(int argc, char **argv) {
     # empty list acts the same as fully disabled
     self.assertEqual(empty_size, disabled_size)
     # big change when we disable exception catching of the function
-    if '-fsanitize=leak' not in self.emcc_args:
+    if '-fsanitize=leak' not in self.cflags:
       self.assertGreater(size - empty_size, 0.01 * size)
     # full disable can remove a little bit more
     # For some reason this no longer holds true at high optimizations
     # levels: https://github.com/emscripten-core/emscripten/issues/18312
-    if not any(o in self.emcc_args for o in ('-O3', '-Oz', '-Os')):
+    if not any(o in self.cflags for o in ('-O3', '-Oz', '-Os')):
       self.assertLess(disabled_size, fake_size)
 
   def test_exceptions_allowed_2(self):
@@ -1317,11 +1317,11 @@ int main(int argc, char **argv) {
 
     # When 'main' function does not have a signature, its contents will be
     # outlined to '__original_main'. Check if we can handle that case.
-    self.emcc_args += ['-DMAIN_NO_SIGNATURE']
+    self.cflags += ['-DMAIN_NO_SIGNATURE']
     self.do_core_test('test_exceptions_allowed_2.cpp')
 
   def test_exceptions_allowed_uncaught(self):
-    self.emcc_args += ['-std=c++11']
+    self.cflags += ['-std=c++11']
     self.set_setting('EXCEPTION_CATCHING_ALLOWED', ["_Z4testv"])
     # otherwise it is inlined and not identified
     self.set_setting('INLINING_LIMIT')
@@ -1333,22 +1333,22 @@ int main(int argc, char **argv) {
 
     # Test old =2 setting for DISABLE_EXCEPTION_CATCHING
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 2)
-    err = self.expect_fail([EMCC, test_file('hello_world.c')] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.c')] + self.get_cflags())
     self.assertContained('error: DISABLE_EXCEPTION_CATCHING=X is no longer needed when specifying EXCEPTION_CATCHING_ALLOWED [-Wdeprecated] [-Werror]', err)
 
     # =0 should also be a warning
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
-    err = self.expect_fail([EMCC, test_file('hello_world.c')] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.c')] + self.get_cflags())
     self.assertContained('error: DISABLE_EXCEPTION_CATCHING=X is no longer needed when specifying EXCEPTION_CATCHING_ALLOWED [-Wdeprecated] [-Werror]', err)
 
     # =1 should be a hard error
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
-    err = self.expect_fail([EMCC, test_file('hello_world.c')] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.c')] + self.get_cflags())
     self.assertContained('error: DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_ALLOWED are mutually exclusive', err)
 
     # even setting an empty list should trigger the error;
     self.set_setting('EXCEPTION_CATCHING_ALLOWED', [])
-    err = self.expect_fail([EMCC, test_file('hello_world.c')] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.c')] + self.get_cflags())
     self.assertContained('error: DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_ALLOWED are mutually exclusive', err)
 
   @with_all_eh_sjlj
@@ -1492,7 +1492,7 @@ int main(int argc, char **argv) {
     # FIXME Temporary workaround. See 'FIXME' in the test source code below for
     # details.
     if self.get_setting('DISABLE_EXCEPTION_CATCHING') == 0:
-      self.emcc_args.append('-D__USING_EMSCRIPTEN_EXCEPTION__')
+      self.cflags.append('-D__USING_EMSCRIPTEN_EXCEPTION__')
 
     self.maybe_closure()
     create_file('main.cpp', '''
@@ -1646,19 +1646,19 @@ int main() {
 
     # Emscripten EH and Wasm EH cannot be enabled at the same time
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags())
     self.assertContained('error: DISABLE_EXCEPTION_CATCHING=0 is not compatible with -fwasm-exceptions', err)
     clear_all_relevant_settings(self)
 
     self.set_setting('DISABLE_EXCEPTION_THROWING', 0)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags())
     self.assertContained('error: DISABLE_EXCEPTION_THROWING=0 is not compatible with -fwasm-exceptions', err)
     clear_all_relevant_settings(self)
 
     # Emscripten EH: You can't enable catching and disable throwing
     self.set_setting('DISABLE_EXCEPTION_THROWING', 1)
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags())
     self.assertContained("error: DISABLE_EXCEPTION_THROWING was set (probably from -fno-exceptions) but is not compatible with enabling exception catching (DISABLE_EXCEPTION_CATCHING=0). If you don't want exceptions, set DISABLE_EXCEPTION_CATCHING to 1; if you do want exceptions, don't link with -fno-exceptions", err)
     clear_all_relevant_settings(self)
 
@@ -1668,49 +1668,49 @@ int main() {
     # We only warn on these cases, but the tests here error out because the
     # test setting includes -Werror.
     self.set_setting('DISABLE_EXCEPTION_THROWING', 1)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags())
     self.assertContained('error: you no longer need to pass DISABLE_EXCEPTION_CATCHING or DISABLE_EXCEPTION_THROWING when using Wasm exceptions', err)
     clear_all_relevant_settings(self)
 
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags())
     self.assertContained('error: you no longer need to pass DISABLE_EXCEPTION_CATCHING or DISABLE_EXCEPTION_THROWING when using Wasm exceptions', err)
     clear_all_relevant_settings(self)
 
     # Emscripten SjLj and Wasm EH cannot mix
     self.set_setting('SUPPORT_LONGJMP', 'emscripten')
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags())
     self.assertContained('error: SUPPORT_LONGJMP=emscripten is not compatible with -fwasm-exceptions', err)
     clear_all_relevant_settings(self)
 
     # Wasm SjLj and Emscripten EH cannot mix
     self.set_setting('SUPPORT_LONGJMP', 'wasm')
     self.set_setting('DISABLE_EXCEPTION_THROWING', 0)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags())
     self.assertContained('error: SUPPORT_LONGJMP=wasm cannot be used with DISABLE_EXCEPTION_THROWING=0', err)
     clear_all_relevant_settings(self)
 
     self.set_setting('SUPPORT_LONGJMP', 'wasm')
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags())
     self.assertContained('error: SUPPORT_LONGJMP=wasm cannot be used with DISABLE_EXCEPTION_CATCHING=0', err)
     clear_all_relevant_settings(self)
 
     # Wasm EH does not support ASYNCIFY=1
     self.set_setting('ASYNCIFY', 1)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags())
     self.assertContained('error: ASYNCIFY=1 is not compatible with -fwasm-exceptions. Parts of the program that mix ASYNCIFY and exceptions will not compile.', err)
     clear_all_relevant_settings(self)
 
     # EXPORT_EXCEPTION_HANDLING_HELPERS and EXCEPTION_STACK_TRACES requires
     # either Emscripten EH or Wasm EH
     self.set_setting('EXPORT_EXCEPTION_HANDLING_HELPERS')
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags())
     self.assertContained('error: EXPORT_EXCEPTION_HANDLING_HELPERS requires either of -fexceptions or -fwasm-exceptions', err)
     clear_all_relevant_settings(self)
 
     self.set_setting('EXCEPTION_STACK_TRACES')
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags())
     self.assertContained('error: EXCEPTION_STACK_TRACES requires either of -fexceptions or -fwasm-exceptions', err)
     clear_all_relevant_settings(self)
 
@@ -1719,7 +1719,7 @@ int main() {
   @also_with_standalone_wasm(impure=True)
   @no_2gb('https://github.com/WebAssembly/binaryen/issues/5893')
   def test_ctors_no_main(self):
-    self.emcc_args.append('--no-entry')
+    self.cflags.append('--no-entry')
     self.do_core_test('test_ctors_no_main.cpp')
 
   @no_wasm2js('eval_ctors not supported yet')
@@ -1729,7 +1729,7 @@ int main() {
     if self.get_setting('MEMORY64') == 1:
       self.skipTest('https://github.com/WebAssembly/binaryen/issues/5017')
     self.set_setting('EVAL_CTORS')
-    self.emcc_args.append('--no-entry')
+    self.cflags.append('--no-entry')
     self.do_core_test('test_ctors_no_main.cpp')
 
   def test_float_builtins(self):
@@ -1798,7 +1798,7 @@ int main() {
 
   @also_with_wasmfs
   def test_rename(self):
-    if is_sanitizing(self.emcc_args) and self.get_setting('WASMFS'):
+    if is_sanitizing(self.cflags) and self.get_setting('WASMFS'):
       self.skipTest('https://github.com/emscripten-core/emscripten/issues/15820')
     self.do_run_in_out_file_test('stdio/test_rename.c')
 
@@ -1848,7 +1848,7 @@ int main() {
     self.do_core_test('test_emscripten_api.c')
 
     # Sanitizers are not compatible with LINKABLE (dynamic linking).
-    if not is_sanitizing(self.emcc_args) and not self.is_wasm64():
+    if not is_sanitizing(self.cflags) and not self.is_wasm64():
       # test EXPORT_ALL
       self.clear_setting('EXPORTED_FUNCTIONS')
       self.set_setting('EXPORT_ALL')
@@ -1964,14 +1964,14 @@ int main(int argc, char **argv) {
     self.do_core_test('test_em_asm.cpp')
 
   def test_em_asm_c(self):
-    self.emcc_args.append('-std=gnu89')
+    self.cflags.append('-std=gnu89')
     self.do_core_test('test_em_asm.cpp', force_c=True)
 
   # Tests various different ways to invoke the EM_ASM(), EM_ASM_INT()
   # and EM_ASM_DOUBLE() macros.
   def test_em_asm_2(self):
     self.do_core_test('test_em_asm_2.cpp')
-    self.emcc_args.append('-std=gnu89')
+    self.cflags.append('-std=gnu89')
     self.do_core_test('test_em_asm_2.cpp', force_c=True)
 
   # Tests various different ways to invoke the MAIN_THREAD_EM_ASM(),
@@ -1993,8 +1993,8 @@ int main(int argc, char **argv) {
     expected_result = read_file(test_file('core/test_em_asm_2.out'))
     create_file('test.out', expected_result.replace('EM_ASM', 'MAIN_THREAD_EM_ASM'))
 
-    self.do_run_in_out_file_test('test.cpp', emcc_args=args)
-    self.do_run_in_out_file_test('test.cpp', emcc_args=args, force_c=True)
+    self.do_run_in_out_file_test('test.cpp', cflags=args)
+    self.do_run_in_out_file_test('test.cpp', cflags=args, force_c=True)
 
   @needs_dylink
   @parameterized({
@@ -2003,7 +2003,7 @@ int main(int argc, char **argv) {
     'force_c': ([], True),
   })
   def test_main_thread_async_em_asm(self, args, force_c=False):
-    self.do_core_test('test_main_thread_async_em_asm.cpp', emcc_args=args, force_c=force_c)
+    self.do_core_test('test_main_thread_async_em_asm.cpp', cflags=args, force_c=force_c)
 
   # Tests MAIN_THREAD_EM_ASM_INT() function call with different signatures.
   def test_main_thread_em_asm_signatures(self):
@@ -2039,8 +2039,8 @@ int main(int argc, char **argv) {
 
   @needs_dylink
   def test_em_asm_side_module(self):
-    self.build('core/test_em_asm_side.c', output_suffix='.wasm', emcc_args=['-sSIDE_MODULE'], output_basename='side')
-    self.do_core_test('test_em_asm_main.c', emcc_args=['-sMAIN_MODULE=2', 'side.wasm'])
+    self.build('core/test_em_asm_side.c', output_suffix='.wasm', cflags=['-sSIDE_MODULE'], output_basename='side')
+    self.do_core_test('test_em_asm_main.c', cflags=['-sMAIN_MODULE=2', 'side.wasm'])
 
   @parameterized({
     '': ([], False),
@@ -2054,7 +2054,7 @@ int main(int argc, char **argv) {
   def test_em_js(self, args, force_c):
     if '-sMAIN_MODULE=2' in args:
       self.check_dylink()
-    self.emcc_args += ['-sEXPORTED_FUNCTIONS=_main,_malloc'] + args
+    self.cflags += ['-sEXPORTED_FUNCTIONS=_main,_malloc'] + args
     if '-pthread' in args:
       self.setup_node_pthreads()
 
@@ -2104,7 +2104,7 @@ int main(int argc, char **argv) {
     if self.maybe_closure():
       # verify NO_DYNAMIC_EXECUTION is compatible with closure
       self.set_setting('DYNAMIC_EXECUTION', 0)
-      self.emcc_args.append('-Wno-closure')
+      self.cflags.append('-Wno-closure')
     # With typed arrays in particular, it is dangerous to use more memory than INITIAL_MEMORY,
     # since we then need to enlarge the heap(s).
     src = test_file('core/test_memorygrowth.c')
@@ -2118,7 +2118,7 @@ int main(int argc, char **argv) {
     self.do_runf(src, '*pre: hello,4.955*\n*hello,4.955*\n*hello,4.955*')
     win = read_file(self.output_name('test_memorygrowth'))
 
-    if '-O2' in self.emcc_args and self.is_wasm2js():
+    if '-O2' in self.cflags and self.is_wasm2js():
       # Make sure ALLOW_MEMORY_GROWTH generates different code (should be less optimized)
       code_start = '// EMSCRIPTEN_START_FUNCS'
       self.assertContained(code_start, fail)
@@ -2129,7 +2129,7 @@ int main(int argc, char **argv) {
     # Tracing of memory growths should work
     # (SAFE_HEAP would instrument the tracing code itself, leading to recursion)
     if not self.get_setting('SAFE_HEAP'):
-      self.emcc_args += ['--tracing']
+      self.cflags += ['--tracing']
       self.do_runf(src, '*pre: hello,4.955*\n*hello,4.955*\n*hello,4.955*')
 
   @no_4gb('memory growth issues')
@@ -2151,7 +2151,7 @@ int main(int argc, char **argv) {
     self.do_runf(src, '*pre: hello,4.955*\n*hello,4.955*\n*hello,4.955*')
     win = read_file(self.output_name('test_memorygrowth_2'))
 
-    if '-O2' in self.emcc_args and self.is_wasm2js():
+    if '-O2' in self.cflags and self.is_wasm2js():
       # Make sure ALLOW_MEMORY_GROWTH generates different code (should be less optimized)
       assert len(fail) < len(win), 'failing code - without memory growth on - is more optimized, and smaller' + str([len(fail), len(win)])
 
@@ -2174,7 +2174,7 @@ int main(int argc, char **argv) {
       self.skipTest('wasm memory specific test')
 
     # check that memory growth does not exceed the wasm mem max limit
-    self.emcc_args += ['-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=64Mb', '-sMAXIMUM_MEMORY=100Mb']
+    self.cflags += ['-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=64Mb', '-sMAXIMUM_MEMORY=100Mb']
     self.do_core_test('test_memorygrowth_wasm_mem_max.c')
 
   @no_4gb('depends on INITIAL_MEMORY')
@@ -2186,7 +2186,7 @@ int main(int argc, char **argv) {
       self.skipTest('wasm memory specific test')
 
     # check that memory growth does not exceed the wasm mem max limit and is exactly or one step below the wasm mem max
-    self.emcc_args += ['-sALLOW_MEMORY_GROWTH', '-sSTACK_SIZE=1Mb', '-sINITIAL_MEMORY=32Mb', '-sMAXIMUM_MEMORY=64Mb', '-sMEMORY_GROWTH_LINEAR_STEP=1Mb']
+    self.cflags += ['-sALLOW_MEMORY_GROWTH', '-sSTACK_SIZE=1Mb', '-sINITIAL_MEMORY=32Mb', '-sMAXIMUM_MEMORY=64Mb', '-sMEMORY_GROWTH_LINEAR_STEP=1Mb']
     self.do_core_test('test_memorygrowth_linear_step.c')
 
   @no_ubsan('UBSan seems to effect the precise memory usage')
@@ -2198,7 +2198,7 @@ int main(int argc, char **argv) {
     if self.is_wasm2js():
       self.skipTest('wasm memory specific test')
 
-    self.emcc_args += ['-sINITIAL_MEMORY=16MB', '-sALLOW_MEMORY_GROWTH', '-sMEMORY_GROWTH_GEOMETRIC_STEP=8.5', '-sMEMORY_GROWTH_GEOMETRIC_CAP=32MB']
+    self.cflags += ['-sINITIAL_MEMORY=16MB', '-sALLOW_MEMORY_GROWTH', '-sMEMORY_GROWTH_GEOMETRIC_STEP=8.5', '-sMEMORY_GROWTH_GEOMETRIC_CAP=32MB']
     self.do_core_test('test_memorygrowth_geometric_step.c')
 
   def test_memorygrowth_3_force_fail_reallocBuffer(self):
@@ -2221,7 +2221,7 @@ int main(int argc, char **argv) {
   def test_aborting_new(self, args):
     # test that C++ new properly errors if we fail to malloc when growth is
     # enabled, with or without growth
-    self.emcc_args += args
+    self.cflags += args
     self.do_core_test('test_aborting_new.cpp')
 
   @parameterized({
@@ -2233,7 +2233,7 @@ int main(int argc, char **argv) {
   @no_4gb('depends on MAXIMUM_MEMORY')
   @no_2gb('depends on MAXIMUM_MEMORY')
   def test_nothrow_new(self, args):
-    self.emcc_args += args
+    self.cflags += args
     self.do_core_test('test_nothrow_new.cpp')
 
   @no_wasm2js('no WebAssembly.Memory()')
@@ -2243,7 +2243,7 @@ int main(int argc, char **argv) {
   @no_2gb('depends on memory size')
   @no_esm_integration('external wasmMemory')
   def test_module_wasm_memory(self):
-    self.emcc_args += ['--pre-js', test_file('core/test_module_wasm_memory.js')]
+    self.cflags += ['--pre-js', test_file('core/test_module_wasm_memory.js')]
     self.set_setting('IMPORTED_MEMORY')
     self.set_setting('STRICT')
     self.set_setting('INCOMING_MODULE_JS_API', ['wasmMemory'])
@@ -2314,7 +2314,7 @@ Success!''')
 
   @no_ubsan('local count too large for VMs')
   def test_indirectbr(self):
-    self.emcc_args = [x for x in self.emcc_args if x != '-g']
+    self.cflags = [x for x in self.cflags if x != '-g']
 
     self.do_core_test('test_indirectbr.c')
 
@@ -2574,7 +2574,7 @@ The current type of b is: 9
   @node_pthreads
   @also_with_modularize
   def test_pthread_proxying(self):
-    if '-sMODULARIZE' in self.emcc_args:
+    if '-sMODULARIZE' in self.cflags:
       if self.get_setting('WASM') == 0:
         self.skipTest('MODULARIZE + WASM=0 + pthreads does not work (#16794)')
       self.set_setting('EXPORT_NAME=ModuleFactory')
@@ -2644,16 +2644,16 @@ The current type of b is: 9
   @node_pthreads
   def test_pthread_setspecific_mainthread(self):
     print('.. return')
-    self.do_runf('pthread/test_pthread_setspecific_mainthread.c', 'done!', emcc_args=['-DRETURN'])
+    self.do_runf('pthread/test_pthread_setspecific_mainthread.c', 'done!', cflags=['-DRETURN'])
     print('.. exit')
-    self.do_runf('pthread/test_pthread_setspecific_mainthread.c', 'done!', emcc_args=['-DEXIT'])
+    self.do_runf('pthread/test_pthread_setspecific_mainthread.c', 'done!', cflags=['-DEXIT'])
     print('.. pthread_exit')
     self.do_run_in_out_file_test('pthread/test_pthread_setspecific_mainthread.c')
 
   @node_pthreads
   @also_with_minimal_runtime
   def test_pthread_attr_getstack(self):
-    if self.get_setting('MINIMAL_RUNTIME') and is_sanitizing(self.emcc_args):
+    if self.get_setting('MINIMAL_RUNTIME') and is_sanitizing(self.cflags):
       self.skipTest('MINIMAL_RUNTIME + threads + asan does not work')
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     self.do_run_in_out_file_test('pthread/test_pthread_attr_getstack.c')
@@ -2667,7 +2667,7 @@ The current type of b is: 9
     # handler will only be present in the main thread (much like it would if it
     # was passed in by pre-populating the module object on prior to loading).
     self.add_pre_run("Module.onAbort = () => console.log('onAbort called');")
-    self.emcc_args += ['-sINCOMING_MODULE_JS_API=[preRun,onAbort]']
+    self.cflags += ['-sINCOMING_MODULE_JS_API=[preRun,onAbort]']
     self.do_run_in_out_file_test('pthread/test_pthread_abort.c', assert_returncode=NON_ZERO)
 
   @node_pthreads
@@ -2680,7 +2680,7 @@ The current type of b is: 9
   @no_lsan('LSan does not support custom memory allocators')
   @node_pthreads
   def test_pthread_emmalloc(self):
-    self.emcc_args += ['-fno-builtin']
+    self.cflags += ['-fno-builtin']
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('ASSERTIONS', 2)
@@ -2704,7 +2704,7 @@ The current type of b is: 9
   @needs_dylink
   def test_pthread_tls_dylink(self):
     self.set_setting('MAIN_MODULE', 2)
-    self.emcc_args.append('-Wno-experimental')
+    self.cflags.append('-Wno-experimental')
     self.do_run_in_out_file_test('pthread/test_pthread_tls_dylink.c')
 
   @no_modularize_instance('uses global Module objecgt')
@@ -2735,7 +2735,7 @@ The current type of b is: 9
   @node_pthreads
   @also_with_minimal_runtime
   def test_pthread_run_on_main_thread(self):
-    if self.get_setting('MINIMAL_RUNTIME') and is_sanitizing(self.emcc_args):
+    if self.get_setting('MINIMAL_RUNTIME') and is_sanitizing(self.cflags):
       self.skipTest('MINIMAL_RUNTIME + threads + asan does not work')
     self.do_run_in_out_file_test('pthread/test_pthread_run_on_main_thread.c')
 
@@ -2759,7 +2759,7 @@ The current type of b is: 9
     'bulkmem': (['-mbulk-memory'],),
   })
   def test_memcpy_zero_bytes(self, args):
-    self.do_core_test('test_memcpy_zero_bytes.c', emcc_args=['-fno-builtin'] + args)
+    self.do_core_test('test_memcpy_zero_bytes.c', cflags=['-fno-builtin'] + args)
 
   def test_memcpy2(self):
     self.do_core_test('test_memcpy2.c')
@@ -2825,7 +2825,7 @@ The current type of b is: 9
     int main() {
       return foo();
     }''')
-    self.do_runf('main.c', emcc_args=['--js-library=lib.js'])
+    self.do_runf('main.c', cflags=['--js-library=lib.js'])
 
   def test_nestedstructs(self):
     src = r'''
@@ -2933,17 +2933,17 @@ The current type of b is: 9
     self.clear_setting('SIDE_MODULE')
     # Link against the side modules but don't load them on startup.
     self.set_setting('NO_AUTOLOAD_DYLIBS')
-    self.emcc_args += libs
+    self.cflags += libs
     # This means we can use MAIN_MODULE=2 without needing to explicitly
     # specify EXPORTED_FUNCTIONS.
     self.set_setting('MAIN_MODULE', 2)
 
-  def build_dlfcn_lib(self, filename, outfile='liblib.so', emcc_args=None):
+  def build_dlfcn_lib(self, filename, outfile='liblib.so', cflags=None):
     self.clear_setting('MAIN_MODULE')
     self.set_setting('SIDE_MODULE')
-    cmd = [compiler_for(filename), filename, '-o', outfile] + self.get_emcc_args()
-    if emcc_args:
-      cmd += emcc_args
+    cmd = [compiler_for(filename), filename, '-o', outfile] + self.get_cflags()
+    if cflags:
+      cmd += cflags
     self.run_process(cmd)
 
   @needs_dylink
@@ -2977,7 +2977,7 @@ The current type of b is: 9
   def test_dlfcn_basic(self, args):
     if args:
       self.setup_node_pthreads()
-    self.emcc_args += args
+    self.cflags += args
     create_file('liblib.cpp', '''
       #include <cstdio>
 
@@ -3385,7 +3385,7 @@ Var: 42
       return
 
     # sanitizers add a lot of extra symbols
-    if is_sanitizing(self.emcc_args):
+    if is_sanitizing(self.cflags):
       return
 
     def get_data_exports(wasm):
@@ -3823,7 +3823,7 @@ ok
   @needs_dylink
   @needs_non_trapping_float_to_int
   def test_dlfcn_feature_in_lib(self):
-    self.emcc_args.append('-mnontrapping-fptoint')
+    self.cflags.append('-mnontrapping-fptoint')
 
     create_file('liblib.c', r'''
         int magic(float x) {
@@ -3899,9 +3899,9 @@ ok
         "side.so",
         test_file("core/test_dlfcn_jspi_side.c"),
         "-sSIDE_MODULE",
-      ] + self.get_emcc_args(),
+      ] + self.get_cflags(),
     )
-    self.do_run_in_out_file_test("core/test_dlfcn_jspi.c", emcc_args=["side.so", "-sMAIN_MODULE=2"])
+    self.do_run_in_out_file_test("core/test_dlfcn_jspi.c", cflags=["side.so", "-sMAIN_MODULE=2"])
 
   @needs_dylink
   def test_dlfcn_rtld_local(self):
@@ -3943,8 +3943,8 @@ ok
     ''')
 
     self.build_dlfcn_lib('libsub.c', outfile='libsub.so')
-    self.build_dlfcn_lib('libb.c', outfile='libb.so', emcc_args=['libsub.so'])
-    self.build_dlfcn_lib('liba.c', outfile='liba.so', emcc_args=['libsub.so'])
+    self.build_dlfcn_lib('libb.c', outfile='libb.so', cflags=['libsub.so'])
+    self.build_dlfcn_lib('liba.c', outfile='liba.so', cflags=['libsub.so'])
 
     self.prep_dlfcn_main(['liba.so', 'libb.so', '-L.'])
     create_file('main.c', r'''
@@ -4010,7 +4010,7 @@ ok
         return liba_fun()*2;
       }
     ''')
-    self.build_dlfcn_lib('libb.c', outfile='libb.so', emcc_args=['liba.so'])
+    self.build_dlfcn_lib('libb.c', outfile='libb.so', cflags=['liba.so'])
 
     self.prep_dlfcn_main(['--preload-file', 'libb.so', '--use-preload-plugins', '-L.', '-sAUTOLOAD_DYLIBS=0', 'libb.so'])
     create_file('main.c', r'''
@@ -4052,22 +4052,22 @@ ok
 
     return self.dylink_testf(main, side, expected, main_module=main_module, **kwargs)
 
-  def dylink_testf(self, main, side=None, expected=None, force_c=False, main_emcc_args=None,
+  def dylink_testf(self, main, side=None, expected=None, force_c=False, main_cflags=None,
                    main_module=2,
                    so_dir='',
                    so_name='liblib.so',
                    **kwargs):
-    main_emcc_args = main_emcc_args or []
+    main_cflags = main_cflags or []
     if getattr(self, 'dylink_reversed', False):
       # Test the reverse case.  There we flip the role of the side module and main module.
       # - We add --no-entry since the side module doesn't have a `main`
       side_ = side
       side = main
       main = side_
-      main_emcc_args += ['--no-entry']
+      main_cflags += ['--no-entry']
     self.maybe_closure()
     # Same as dylink_test but takes source code as filenames on disc.
-    old_args = self.emcc_args.copy()
+    old_args = self.cflags.copy()
     if not expected:
       outfile = shared.replace_suffix(main, '.out')
       expected = read_file(outfile)
@@ -4083,7 +4083,7 @@ ok
     so_file = os.path.join(so_dir, so_name)
     if isinstance(side, list):
       # side is just a library
-      self.run_process([EMCC] + side + self.get_emcc_args() + ['-o', so_file])
+      self.run_process([EMCC] + side + self.get_cflags() + ['-o', so_file])
     else:
       out_file = self.build(side, output_suffix='.so')
       shutil.move(out_file, so_file)
@@ -4092,22 +4092,22 @@ ok
     self.settings_mods = old_settings
     self.set_setting('MAIN_MODULE', main_module)
     self.clear_setting('SIDE_MODULE')
-    self.emcc_args += main_emcc_args
-    self.emcc_args.append(so_file)
+    self.cflags += main_cflags
+    self.cflags.append(so_file)
 
     if force_c:
-      self.emcc_args.append('-nostdlib++')
+      self.cflags.append('-nostdlib++')
 
     if isinstance(main, list):
       # main is just a library
       outfile = self.output_name('main')
       delete_file(outfile)
-      self.run_process([EMCC] + main + self.get_emcc_args() + ['-o', outfile])
+      self.run_process([EMCC] + main + self.get_cflags() + ['-o', outfile])
       self.do_run(outfile, expected, no_build=True, **kwargs)
     else:
       self.do_runf(main, expected, force_c=force_c, **kwargs)
 
-    self.emcc_args = old_args
+    self.cflags = old_args
 
   def do_basic_dylink_test(self, **kwargs):
     self.dylink_test(r'''
@@ -4127,7 +4127,7 @@ ok
     ''', 'other says 11.', 'int sidey();', force_c=True, **kwargs)
 
   def output_name(self, basename):
-    suffix = common.get_output_suffix(self.get_emcc_args())
+    suffix = common.get_output_suffix(self.get_cflags())
     return basename + suffix
 
   @needs_dylink
@@ -4177,7 +4177,7 @@ ok
       }
     };
     ''' % (so_name, so_dir))
-    self.do_basic_dylink_test(so_dir=so_dir, so_name=so_name, main_emcc_args=['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[locateFile]'])
+    self.do_basic_dylink_test(so_dir=so_dir, so_name=so_name, main_cflags=['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[locateFile]'])
 
   @with_dylink_reversed
   def test_dylink_function_pointer_equality(self):
@@ -4489,7 +4489,7 @@ res64 - external 64\n''', header='''\
   def test_dylink_i64_invoke(self, rtld_local):
     if rtld_local:
       self.set_setting('NO_AUTOLOAD_DYLIBS')
-      self.emcc_args.append('-DUSE_DLOPEN')
+      self.cflags.append('-DUSE_DLOPEN')
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
     self.dylink_test(r'''\
     #include <assert.h>
@@ -4587,7 +4587,7 @@ res64 - external 64\n''', header='''\
         assert(js_address == &my_number);
         return 0;
       }
-    ''', emcc_args=['-sMAIN_MODULE'], force_c=True)
+    ''', cflags=['-sMAIN_MODULE'], force_c=True)
 
   @with_dylink_reversed
   def test_dylink_global_var_modded(self):
@@ -4671,7 +4671,7 @@ res64 - external 64\n''', header='''\
         printf("main2 sed: %u, %c\n", temp, temp/2);
         return test_lib_func(temp);
       }
-    ''', expected='other says 45.2', main_emcc_args=['--js-library', 'lib.js'], force_c=True)
+    ''', expected='other says 45.2', main_cflags=['--js-library', 'lib.js'], force_c=True)
 
   @with_dylink_reversed
   def test_dylink_many_postsets(self):
@@ -4749,7 +4749,7 @@ res64 - external 64\n''', header='''\
     # one module uses libcxx, need to force its inclusion when it isn't the main
     if not with_reversed and self.dylink_reversed:
       self.skipTest('with_reversed is false')
-    self.emcc_args.append('-Wno-deprecated')
+    self.cflags.append('-Wno-deprecated')
     self.set_setting('WARN_ON_UNDEFINED_SYMBOLS', 0)
 
     if assertions is not None:
@@ -5004,7 +5004,7 @@ res64 - external 64\n''', header='''\
         printf("only_in_third_1: %d, %d, %d, %d\n", sidef(), sideg, second_to_third, x);
       }
     ''')
-    self.run_process([EMCC, 'third.cpp', '-o', 'third.wasm', '-sSIDE_MODULE'] + self.get_emcc_args())
+    self.run_process([EMCC, 'third.cpp', '-o', 'third.wasm', '-sSIDE_MODULE'] + self.get_cflags())
     self.dylink_test(main=r'''
       #include <stdio.h>
       #include <emscripten.h>
@@ -5083,9 +5083,9 @@ res64 - external 64\n''', header='''\
 
   @needs_dylink
   def test_dylink_dso_needed(self):
-    def do_run(src, expected_output, emcc_args=None):
+    def do_run(src, expected_output, cflags=None):
       create_file('main.c', src + 'int main() { return test_main(); }')
-      self.do_runf('main.c', expected_output, emcc_args=emcc_args)
+      self.do_runf('main.c', expected_output, cflags=cflags)
     self._test_dylink_dso_needed(do_run)
 
   @with_dylink_reversed
@@ -5094,8 +5094,8 @@ res64 - external 64\n''', header='''\
     create_file('third.c', 'int sidef() { return 36; }')
     create_file('fourth.c', 'int sideg() { return 17; }')
 
-    self.run_process([EMCC, '-fPIC', '-c', 'third.c', '-o', 'third.o'] + self.get_emcc_args(compile_only=True))
-    self.run_process([EMCC, '-fPIC', '-c', 'fourth.c', '-o', 'fourth.o'] + self.get_emcc_args(compile_only=True))
+    self.run_process([EMCC, '-fPIC', '-c', 'third.c', '-o', 'third.o'] + self.get_cflags(compile_only=True))
+    self.run_process([EMCC, '-fPIC', '-c', 'fourth.c', '-o', 'fourth.o'] + self.get_cflags(compile_only=True))
     self.run_process([EMAR, 'rc', 'libfourth.a', 'fourth.o'])
 
     self.dylink_test(main=r'''
@@ -5157,8 +5157,8 @@ main main sees -524, -534, 72.
     self.set_setting('RELOCATABLE')
     zlib_archive = self.get_zlib_library(cmake=WINDOWS)
     # example.c uses K&R style function declarations
-    self.emcc_args.append('-Wno-deprecated-non-prototype')
-    self.emcc_args.append('-I' + test_file('third_party/zlib'))
+    self.cflags.append('-Wno-deprecated-non-prototype')
+    self.cflags.append('-I' + test_file('third_party/zlib'))
     self.dylink_test(main=read_file(test_file('third_party/zlib/example.c')),
                      side=zlib_archive,
                      expected=read_file(test_file('core/test_zlib.out')),
@@ -5166,7 +5166,7 @@ main main sees -524, -534, 72.
 
   # @with_dylink_reversed
   # def test_dylink_bullet(self):
-  #   self.emcc_args += ['-I' + test_file('bullet/src')]
+  #   self.cflags += ['-I' + test_file('bullet/src')]
   #   side = self.get_bullet_library(self, True)
   #   self.dylink_test(main=read_file(test_file('bullet/Demos/HelloWorld/HelloWorld.cpp')),
   #                    side=side,
@@ -5227,7 +5227,7 @@ main main sees -524, -534, 72.
   @needs_dylink
   def test_dylink_argv_argc(self):
     # Verify that argc and argv can be sent to main when main is in a side module
-    self.emcc_args += ['--pre-js', 'pre.js', '--no-entry', '-sINCOMING_MODULE_JS_API=[arguments]']
+    self.cflags += ['--pre-js', 'pre.js', '--no-entry', '-sINCOMING_MODULE_JS_API=[arguments]']
     create_file('pre.js', "Module['arguments'] = ['hello', 'world!']")
     self.dylink_test(
       '', # main module is empty.
@@ -5255,13 +5255,13 @@ main main sees -524, -534, 72.
   @node_pthreads
   @needs_dylink
   def test_dylink_tls(self):
-    self.emcc_args.append('-Wno-experimental')
+    self.cflags.append('-Wno-experimental')
     self.dylink_testf(test_file('core/test_dylink_tls.c'))
 
   @node_pthreads
   @needs_dylink
   def test_dylink_tls_export(self):
-    self.emcc_args.append('-Wno-experimental')
+    self.cflags.append('-Wno-experimental')
     self.dylink_testf(test_file('core/test_dylink_tls_export.c'))
 
   def test_random(self):
@@ -5302,7 +5302,7 @@ int main()
   @no_wasm2js('very slow to compile: https://github.com/emscripten-core/emscripten/issues/21048')
   @is_slow_test
   def test_printf(self):
-    self.emcc_args.append('-Wno-format')
+    self.cflags.append('-Wno-format')
     # needs to flush stdio streams
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('STACK_SIZE', '1MB')
@@ -5445,16 +5445,16 @@ Pass: 0.000012 0.000012''')
   @no_strict('TODO: Fails in -sSTRICT mode due to an unknown reason.')
   def test_files(self):
     # Use closure here, to test we don't break FS stuff
-    if '-O3' in self.emcc_args and self.is_wasm2js():
+    if '-O3' in self.cflags and self.is_wasm2js():
       print('closure 2')
-      self.emcc_args += ['--closure', '2'] # Use closure 2 here for some additional coverage
+      self.cflags += ['--closure', '2'] # Use closure 2 here for some additional coverage
       # Sadly --closure=2 is not yet free of closure warnings
       # FIXME(https://github.com/emscripten-core/emscripten/issues/17080)
       self.ldflags.append('-Wno-error=closure')
     else:
       self.maybe_closure()
 
-    self.emcc_args += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[preRun]']
+    self.cflags += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[preRun]']
     self.set_setting('FORCE_FILESYSTEM')
 
     create_file('pre.js', '''
@@ -5486,7 +5486,7 @@ Module = {
       stdout: (x) => out('got: ' + x)
     };
     ''')
-    self.emcc_args += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[stdin,stdout]']
+    self.cflags += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[stdin,stdout]']
 
     src = r'''
       #include <stdio.h>
@@ -5514,8 +5514,8 @@ got: 10
   def test_mount(self):
     self.set_setting('FORCE_FILESYSTEM')
     if self.get_setting('WASMFS'):
-      self.emcc_args += ['-licasefs.js']
-      self.emcc_args += ['-ljsfilefs.js']
+      self.cflags += ['-licasefs.js']
+      self.cflags += ['-ljsfilefs.js']
     self.do_runf('fs/test_mount.c', 'success')
 
   def test_getdents64(self):
@@ -5549,7 +5549,7 @@ got: 10
       }
     '''
     create_file('file_with_byte_234.txt', b'\xea', binary=True)
-    self.emcc_args += ['--embed-file', 'file_with_byte_234.txt']
+    self.cflags += ['--embed-file', 'file_with_byte_234.txt']
     self.do_run(src, '*234\n')
 
   def test_fgets_eol(self):
@@ -5571,7 +5571,7 @@ got: 10
       }
     '''
     create_file('eol.txt', b'\n', binary=True)
-    self.emcc_args += ['--embed-file', 'eol.txt']
+    self.cflags += ['--embed-file', 'eol.txt']
     self.do_run(src, 'SUCCESS\n')
 
   def test_fscanf(self):
@@ -5594,12 +5594,12 @@ got: 10
         return 0;
       }
     '''
-    self.emcc_args += ['--embed-file', 'three_numbers.txt']
+    self.cflags += ['--embed-file', 'three_numbers.txt']
     self.do_run(src, 'match = 3\nx = -1.0, y = 0.1, z = -0.1\n')
 
   def test_fscanf_2(self):
     create_file('a.txt', '1/2/3 4/5/6 7/8/9\n')
-    self.emcc_args += ['--embed-file', 'a.txt']
+    self.cflags += ['--embed-file', 'a.txt']
     self.do_run(r'''\
       #include <stdio.h>
 
@@ -5638,7 +5638,7 @@ got: 10
         return 0;
       }
     '''
-    self.emcc_args += ['--embed-file', 'empty.txt']
+    self.cflags += ['--embed-file', 'empty.txt']
     self.do_run(src, '3\n')
 
   @also_with_noderawfs
@@ -5647,7 +5647,7 @@ got: 10
       # WasmFS + NODERAWFS lacks ino numbers in directory listings, see
       # https://github.com/emscripten-core/emscripten/issues/19418
       # We need to tell the test we are in this mode so it can ignore them.
-      self.emcc_args += ['-DWASMFS_NODERAWFS']
+      self.cflags += ['-DWASMFS_NODERAWFS']
     self.do_run_in_out_file_test('dirent/test_readdir.c')
 
   @also_with_wasm_bigint
@@ -5672,7 +5672,7 @@ got: 10
   @crossplatform
   @with_all_fs
   def test_stat_chmod(self):
-    nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
+    nodefs = '-DNODEFS' in self.cflags or '-DNODERAWFS' in self.cflags
     if nodefs and WINDOWS:
       self.skipTest('mode bits work differently on windows')
     if nodefs and self.get_setting('WASMFS'):
@@ -5686,24 +5686,24 @@ got: 10
   @also_with_wasmfs
   def test_fcntl(self):
     if self.get_setting('WASMFS'):
-      self.emcc_args += ['-sFORCE_FILESYSTEM']
+      self.cflags += ['-sFORCE_FILESYSTEM']
     self.add_pre_run("FS.createDataFile('/', 'test', 'abcdef', true, true, false);")
     self.do_run_in_out_file_test('fcntl/test_fcntl.c')
 
   @crossplatform
   @also_with_nodefs_both
   def test_fcntl_open(self):
-    nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
+    nodefs = '-DNODEFS' in self.cflags or '-DNODERAWFS' in self.cflags
     if nodefs and WINDOWS:
       self.skipTest('Stat mode behavior does not match on Windows')
-    if '-DNODERAWFS' in self.emcc_args and not LINUX:
+    if '-DNODERAWFS' in self.cflags and not LINUX:
       self.skipTest('noderawfs fails here under non-linux')
     self.do_run_in_out_file_test('fcntl/test_fcntl_open.c')
 
   @also_with_wasm_bigint
   def test_fcntl_misc(self):
     if self.get_setting('WASMFS'):
-      self.emcc_args += ['-sFORCE_FILESYSTEM']
+      self.cflags += ['-sFORCE_FILESYSTEM']
     self.add_pre_run("FS.createDataFile('/', 'test', 'abcdef', true, true, false);")
     self.do_run_in_out_file_test('fcntl/test_fcntl_misc.c')
 
@@ -5736,9 +5736,9 @@ got: 10
   @with_both_text_decoder
   @no_sanitize('requires libc to be built with -fshort-char')
   def test_utf32_short_wchar(self):
-    if '-flto' in self.emcc_args or '-flto=thin' in self.emcc_args:
+    if '-flto' in self.cflags or '-flto=thin' in self.cflags:
       self.skipTest('-fshort-wchar is not compatible with LTO (libraries would need rebuilting)')
-    self.do_runf('utf32.cpp', 'OK (short).\n', emcc_args=['-fshort-wchar'])
+    self.do_runf('utf32.cpp', 'OK (short).\n', cflags=['-fshort-wchar'])
 
   @with_both_text_decoder
   @crossplatform
@@ -5752,7 +5752,7 @@ got: 10
   @with_both_text_decoder
   @also_with_wasm_bigint
   def test_utf8_bench(self):
-    self.emcc_args += ['--embed-file', test_file('utf8_corpus.txt') + '@/utf8_corpus.txt']
+    self.cflags += ['--embed-file', test_file('utf8_corpus.txt') + '@/utf8_corpus.txt']
     self.do_runf('benchmark/benchmark_utf8.c', 'OK.')
 
   # Test that invalid character in UTF8 does not cause decoding to crash.
@@ -5762,7 +5762,7 @@ got: 10
     self.do_runf('test_utf8_invalid.c', 'OK.')
 
   def test_utf16_bench(self):
-    self.emcc_args += ['--embed-file', test_file('utf16_corpus.txt') + '@/utf16_corpus.txt']
+    self.cflags += ['--embed-file', test_file('utf16_corpus.txt') + '@/utf16_corpus.txt']
     self.do_runf('benchmark/benchmark_utf16.cpp', 'OK.')
 
   def test_wprintf(self):
@@ -5822,14 +5822,14 @@ got: 10
   @requires_node
   def test_fs_nodefs_home(self):
     self.set_setting('FORCE_FILESYSTEM')
-    self.emcc_args += ['-lnodefs.js']
+    self.cflags += ['-lnodefs.js']
     self.do_runf('fs/test_nodefs_home.c', 'success')
 
   @requires_node
   def test_fs_nodefs_nofollow(self):
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
-    self.emcc_args += ['-lnodefs.js']
+    self.cflags += ['-lnodefs.js']
     self.do_runf('fs/test_nodefs_nofollow.c', 'success')
 
   @crossplatform
@@ -5844,7 +5844,7 @@ got: 10
       # it correctly.
       os.mkfifo('named_pipe')
     os.makedirs('existing/a')
-    self.emcc_args += ['-lnodefs.js']
+    self.cflags += ['-lnodefs.js']
     suffix = ''
     if self.get_setting('WASMFS'):
       suffix = '.wasmfs'
@@ -5859,7 +5859,7 @@ got: 10
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
     os.makedirs('existing/a')
-    self.emcc_args += ['-lnodefs.js']
+    self.cflags += ['-lnodefs.js']
     self.do_runf('fs/test_nodefs_statvfs.c', 'success')
 
   @no_windows('no symlink support on windows')
@@ -5868,7 +5868,7 @@ got: 10
     self.set_setting('NODERAWFS')
     create_file('filename', 'foo')
     os.symlink('filename', 'linkname')
-    self.emcc_args += ['-lnodefs.js']
+    self.cflags += ['-lnodefs.js']
     self.do_runf('fs/test_noderawfs_nofollow.c', 'success')
 
   def test_fs_trackingdelegate(self):
@@ -5884,7 +5884,7 @@ got: 10
   @with_all_fs
   @crossplatform
   def test_fs_js_api(self):
-    nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
+    nodefs = '-DNODEFS' in self.cflags or '-DNODERAWFS' in self.cflags
     if nodefs and WINDOWS:
       self.skipTest('specific errno values differ')
     if self.get_setting('WASMFS'):
@@ -5905,7 +5905,7 @@ got: 10
   @crossplatform
   @also_with_nodefs_both
   def test_fs_enotdir(self):
-    if MACOS and '-DNODERAWFS' in self.emcc_args:
+    if MACOS and '-DNODERAWFS' in self.cflags:
       self.skipTest('BSD libc sets a different errno')
     self.do_runf('fs/test_fs_enotdir.c', 'success')
 
@@ -5935,7 +5935,7 @@ Module.onRuntimeInitialized = () => {
 ''')
     self.set_setting('EXPORTED_FUNCTIONS', '_foo')
     self.set_setting('FORCE_FILESYSTEM')
-    self.emcc_args += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[preRun, onRuntimeInitialized]']
+    self.cflags += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[preRun, onRuntimeInitialized]']
     self.do_run('int foo() { return 42; }', '', force_c=True)
 
   @also_with_noderawfs
@@ -5943,7 +5943,7 @@ Module.onRuntimeInitialized = () => {
     # Enables strict mode, which may catch some strict-mode-only errors
     # so that users can safely work with strict JavaScript if enabled.
     create_file('pre.js', '"use strict";')
-    self.emcc_args += ['--pre-js', 'pre.js']
+    self.cflags += ['--pre-js', 'pre.js']
 
     self.set_setting('FORCE_FILESYSTEM')
     self.set_setting('ASSERTIONS')
@@ -5995,7 +5995,7 @@ Module.onRuntimeInitialized = () => {
   def test_fs_symlink_resolution(self):
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
-    nodefs = '-DNODEFS' in self.emcc_args or '-DNODERAWFS' in self.emcc_args
+    nodefs = '-DNODEFS' in self.cflags or '-DNODERAWFS' in self.cflags
     if nodefs and WINDOWS:
       self.skipTest('No symlinks on Windows')
     self.do_runf('fs/test_fs_symlink_resolution.c', 'success')
@@ -6020,7 +6020,7 @@ Module.onRuntimeInitialized = () => {
 
   def test_sigalrm(self):
     self.do_runf('test_sigalrm.c', 'Received alarm!')
-    self.do_runf('test_sigalrm.c', 'Received alarm!', emcc_args=['-sEXIT_RUNTIME'])
+    self.do_runf('test_sigalrm.c', 'Received alarm!', cflags=['-sEXIT_RUNTIME'])
 
   def test_signals(self):
     self.do_core_test('test_signals.c')
@@ -6052,7 +6052,7 @@ Module.onRuntimeInitialized = () => {
     # We also report all files as executable since there is no x bit
     # recorded there.
     # See https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/chmod-wchmod?view=msvc-170#remarks
-    if WINDOWS and '-DNODERAWFS' in self.emcc_args and not self.get_setting('WASMFS'):
+    if WINDOWS and '-DNODERAWFS' in self.cflags and not self.get_setting('WASMFS'):
       out_suffix = '.win'
     else:
       out_suffix = ''
@@ -6116,25 +6116,25 @@ Module.onRuntimeInitialized = () => {
   def test_unistd_unlink(self):
     # symlinks on node.js on non-linux behave differently (e.g. on Windows they require administrative privileges)
     # so skip testing those bits on that combination.
-    if MACOS and any(arg in self.emcc_args for arg in ('-DNODEFS', '-DNODERAWFS')):
+    if MACOS and any(arg in self.cflags for arg in ('-DNODEFS', '-DNODERAWFS')):
       self.skipTest('only tested on linux')
-    if '-DNODEFS' in self.emcc_args:
+    if '-DNODEFS' in self.cflags:
       if WINDOWS:
-        self.emcc_args += ['-DNO_SYMLINK=1']
+        self.cflags += ['-DNO_SYMLINK=1']
       if self.get_setting('WASMFS'):
         self.skipTest('https://github.com/emscripten-core/emscripten/issues/18112')
 
     # Several differences/bugs on non-linux including https://github.com/nodejs/node/issues/18014
     # TODO: NODERAWFS in WasmFS
-    if '-DNODERAWFS' in self.emcc_args and os.geteuid() == 0:
+    if '-DNODERAWFS' in self.cflags and os.geteuid() == 0:
       # 0 if root user
-      self.emcc_args += ['-DSKIP_ACCESS_TESTS']
+      self.cflags += ['-DSKIP_ACCESS_TESTS']
 
     self.do_runf('unistd/unlink.c', 'success')
 
   @also_with_nodefs
   def test_unistd_links(self):
-    nodefs = '-DNODEFS' in self.emcc_args
+    nodefs = '-DNODEFS' in self.cflags
     if nodefs and WINDOWS:
       self.skipTest('Skipping NODEFS part of this test for test_unistd_links on Windows, since it would require administrative privileges.')
       # Also, other detected discrepancies if you do end up running this test on NODEFS:
@@ -6144,7 +6144,7 @@ Module.onRuntimeInitialized = () => {
     if self.get_setting('WASMFS'):
       if nodefs:
         self.skipTest('TODO: wasmfs+node')
-      self.emcc_args += ['-sFORCE_FILESYSTEM']
+      self.cflags += ['-sFORCE_FILESYSTEM']
 
     self.do_run_in_out_file_test('unistd/links.c')
 
@@ -6159,7 +6159,7 @@ Module.onRuntimeInitialized = () => {
     # Also, other detected discrepancies if you do end up running this test on NODEFS:
     # test expects /, but Windows gives \ as path slashes.
     # Calling readlink() on a non-link gives error 22 EINVAL on Unix, but simply error 0 OK on Windows.
-    self.emcc_args += ['-lnodefs.js']
+    self.cflags += ['-lnodefs.js']
     self.do_run_in_out_file_test('unistd/symlink_on_nodefs.c')
 
   @also_with_wasm_bigint
@@ -6180,7 +6180,7 @@ Module.onRuntimeInitialized = () => {
 
   def test_uname(self):
     if self.get_setting('STRICT'):
-      self.emcc_args += ['-lstubs']
+      self.cflags += ['-lstubs']
     self.do_core_test('test_uname.c', regex=True)
 
   def test_unary_literal(self):
@@ -6211,7 +6211,7 @@ Module.onRuntimeInitialized = () => {
 
   def test_getloadavg(self):
     if self.get_setting('STRICT'):
-      self.emcc_args += ['-lstubs']
+      self.cflags += ['-lstubs']
     self.do_core_test('test_getloadavg.c')
 
   def test_nl_types(self):
@@ -6234,7 +6234,7 @@ PORT: 3979
 
   def test_atomic_cxx(self):
     # the wasm backend has lock-free atomics, but not asm.js or asm2wasm
-    self.emcc_args += ['-DIS_64BIT_LOCK_FREE=1']
+    self.cflags += ['-DIS_64BIT_LOCK_FREE=1']
     self.do_core_test('test_atomic_cxx.cpp')
 
   def test_phiundef(self):
@@ -6316,7 +6316,7 @@ PORT: 3979
       });
     ''')
 
-    self.emcc_args += ['--js-library', 'mylib1.js', '--js-library', 'mylib2.js']
+    self.cflags += ['--js-library', 'mylib1.js', '--js-library', 'mylib2.js']
     self.do_runf('main.c', 'hello from lib!\n*32*\n')
 
   @with_env_modify({'LC_ALL': 'latin-1', 'PYTHONUTF8': '0', 'PYTHONCOERCECLOCALE': '0'})
@@ -6335,11 +6335,11 @@ PORT: 3979
       err = self.expect_fail([PYTHON, 'expect_fail.py'], expect_traceback=True)
       self.assertContained('UnicodeDecodeError', err)
 
-    self.emcc_args += ['-sMODULARIZE', '--js-library', test_file('unicode_library.js'), '--extern-post-js', test_file('modularize_post_js.js'), '--post-js', test_file('unicode_postjs.js')]
+    self.cflags += ['-sMODULARIZE', '--js-library', test_file('unicode_library.js'), '--extern-post-js', test_file('modularize_post_js.js'), '--post-js', test_file('unicode_postjs.js')]
     self.do_run_in_out_file_test('test_unicode_js_library.c')
 
   def test_funcptr_import_type(self):
-    self.emcc_args += ['--js-library', test_file('core/test_funcptr_import_type.js')]
+    self.cflags += ['--js-library', test_file('core/test_funcptr_import_type.js')]
     self.do_core_test('test_funcptr_import_type.cpp')
 
   @no_asan('ASan does not work with EXPORT_ALL')
@@ -6413,7 +6413,7 @@ int main(void) {
 
   @needs_non_trapping_float_to_int
   def test_fasta_nontrapping(self):
-    self.emcc_args += ['-mnontrapping-fptoint']
+    self.cflags += ['-mnontrapping-fptoint']
     self.test_fasta()
 
   def test_whets(self):
@@ -6442,7 +6442,7 @@ int main(void) {
     self.do_run(self.output_name('dlmalloc_test'), '*400,0*', args=['400', '400'], no_build=True)
 
     out_js = self.output_name('dlmalloc_test')
-    self.run_process([EMCC, test_file('dlmalloc_test.c'), '-sINITIAL_MEMORY=128MB', '-o', out_js] + self.get_emcc_args())
+    self.run_process([EMCC, test_file('dlmalloc_test.c'), '-sINITIAL_MEMORY=128MB', '-o', out_js] + self.get_cflags())
 
     self.do_run(out_js, '*1,0*', args=['200', '1'], no_build=True)
     self.do_run(out_js, '*400,0*', args=['400', '400'], no_build=True)
@@ -6464,7 +6464,7 @@ int main(void) {
   @no_4gb('output is sensitive to absolute data layout')
   @no_2gb('output is sensitive to absolute data layout')
   def test_dlmalloc_large(self):
-    self.emcc_args += ['-sABORTING_MALLOC=0', '-sALLOW_MEMORY_GROWTH=1', '-sMAXIMUM_MEMORY=128MB']
+    self.cflags += ['-sABORTING_MALLOC=0', '-sALLOW_MEMORY_GROWTH=1', '-sMAXIMUM_MEMORY=128MB']
     self.do_runf('dlmalloc_test_large.c', '0 0 0 1')
 
   @no_asan('asan also changes malloc, and that ends up linking in new twice')
@@ -6485,7 +6485,7 @@ void* operator new(size_t size) {
   @no_asan('asan also changes malloc, and that ends up linking in new twice')
   @no_lsan('lsan also changes malloc, and that ends up linking in new twice')
   def test_dlmalloc_partial_2(self):
-    if 'SAFE_HEAP' in str(self.emcc_args):
+    if 'SAFE_HEAP' in str(self.cflags):
       self.skipTest('we do unsafe stuff here')
     # present part of the symbols of dlmalloc, not all. malloc is harder to link than new which is weak.
     self.do_core_test('test_dlmalloc_partial_2.c', assert_returncode=NON_ZERO)
@@ -6519,7 +6519,7 @@ void* operator new(size_t size) {
   @also_with_standalone_wasm()
   def test_mmap_anon(self):
     # ASan needs more memory, but that is set up separately
-    if '-fsanitize=address' not in self.emcc_args and not self.has_changed_setting('INITIAL_MEMORY'):
+    if '-fsanitize=address' not in self.cflags and not self.has_changed_setting('INITIAL_MEMORY'):
       self.set_setting('INITIAL_MEMORY', '128mb')
 
     self.do_core_test('test_mmap_anon.c')
@@ -6538,12 +6538,12 @@ void* operator new(size_t size) {
   @also_with_asyncify_and_jspi
   def test_cubescript(self):
     # uses register keyword
-    self.emcc_args += ['-std=c++03', '-Wno-dynamic-class-memaccess']
+    self.cflags += ['-std=c++03', '-Wno-dynamic-class-memaccess']
     self.maybe_closure()
-    self.emcc_args += ['-I', test_file('third_party/cubescript')]
+    self.cflags += ['-I', test_file('third_party/cubescript')]
     # Test code contains memory leaks
-    if '-fsanitize=address' in self.emcc_args:
-      self.emcc_args += ['--pre-js', test_file('asan-no-leak.js')]
+    if '-fsanitize=address' in self.cflags:
+      self.cflags += ['--pre-js', test_file('asan-no-leak.js')]
 
     self.do_runf('third_party/cubescript/command.cpp', '*\nTemp is 33\n9\n5\nhello, everyone\n*')
 
@@ -6557,18 +6557,18 @@ void* operator new(size_t size) {
     def run():
       self.do_runf('test_wasm_intrinsics_simd.c', 'Success!')
     # Improves test readability
-    self.emcc_args.append('-Wno-c++11-narrowing')
-    self.emcc_args = ['-Wpedantic', '-Werror', '-Wall', '-xc++'] + self.emcc_args
+    self.cflags.append('-Wno-c++11-narrowing')
+    self.cflags = ['-Wpedantic', '-Werror', '-Wall', '-xc++'] + self.cflags
     run()
-    self.emcc_args.append('-funsigned-char')
+    self.cflags.append('-funsigned-char')
     run()
 
   # Tests invoking the NEON SIMD API via arm_neon.h header
   @wasm_simd
   def test_neon_wasm_simd(self):
-    self.emcc_args.append('-Wno-c++11-narrowing')
-    self.emcc_args.append('-mfpu=neon')
-    self.emcc_args.append('-msimd128')
+    self.cflags.append('-Wno-c++11-narrowing')
+    self.cflags.append('-mfpu=neon')
+    self.cflags.append('-msimd128')
     self.do_runf('neon/test_neon_wasm_simd.cpp', 'Success!')
 
   # Tests invoking the SIMD API via x86 SSE1 xmmintrin.h header (_mm_x() functions)
@@ -6587,7 +6587,7 @@ void* operator new(size_t size) {
     self.run_process([shared.CLANG_CXX, src, '-msse', '-o', 'test_sse1', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_sse1', stdout=PIPE).stdout
 
-    self.emcc_args += ['-I' + test_file('sse'), '-msse'] + args
+    self.cflags += ['-I' + test_file('sse'), '-msse'] + args
     self.maybe_closure()
 
     self.do_runf(src, native_result)
@@ -6609,7 +6609,7 @@ void* operator new(size_t size) {
     self.run_process([shared.CLANG_CXX, src, '-msse2', '-Wno-argument-outside-range', '-o', 'test_sse2', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_sse2', stdout=PIPE).stdout
 
-    self.emcc_args += ['-I' + test_file('sse'), '-msse2', '-fno-inline-functions', '-Wno-argument-outside-range', '-sSTACK_SIZE=1MB'] + args
+    self.cflags += ['-I' + test_file('sse'), '-msse2', '-fno-inline-functions', '-Wno-argument-outside-range', '-sSTACK_SIZE=1MB'] + args
     self.maybe_closure()
     self.do_runf(src, native_result)
 
@@ -6622,7 +6622,7 @@ void* operator new(size_t size) {
     self.run_process([shared.CLANG_CXX, src, '-msse3', '-Wno-argument-outside-range', '-o', 'test_sse3', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_sse3', stdout=PIPE).stdout
 
-    self.emcc_args += ['-I' + test_file('sse'), '-msse3', '-Wno-argument-outside-range']
+    self.cflags += ['-I' + test_file('sse'), '-msse3', '-Wno-argument-outside-range']
     self.maybe_closure()
     self.do_runf(src, native_result)
 
@@ -6635,7 +6635,7 @@ void* operator new(size_t size) {
     self.run_process([shared.CLANG_CXX, src, '-mssse3', '-Wno-argument-outside-range', '-o', 'test_ssse3', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_ssse3', stdout=PIPE).stdout
 
-    self.emcc_args += ['-I' + test_file('sse'), '-mssse3', '-Wno-argument-outside-range']
+    self.cflags += ['-I' + test_file('sse'), '-mssse3', '-Wno-argument-outside-range']
     self.maybe_closure()
     self.do_runf(src, native_result)
 
@@ -6651,7 +6651,7 @@ void* operator new(size_t size) {
     self.run_process([shared.CLANG_CXX, src, '-msse4.1', '-fno-inline-functions', '-Wno-argument-outside-range', '-o', 'test_sse4_1', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_sse4_1', stdout=PIPE).stdout
 
-    self.emcc_args += ['-I' + test_file('sse'), '-msse4.1', '-fno-inline-functions', '-Wno-argument-outside-range', '-sSTACK_SIZE=1MB']
+    self.cflags += ['-I' + test_file('sse'), '-msse4.1', '-fno-inline-functions', '-Wno-argument-outside-range', '-sSTACK_SIZE=1MB']
     self.maybe_closure()
     self.do_runf(src, native_result)
 
@@ -6669,7 +6669,7 @@ void* operator new(size_t size) {
     self.run_process([shared.CLANG_CXX, src, msse4, '-Wno-argument-outside-range', '-o', 'test_sse4_2', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_sse4_2', stdout=PIPE).stdout
 
-    self.emcc_args += ['-I' + test_file('sse'), msse4, '-Wno-argument-outside-range']
+    self.cflags += ['-I' + test_file('sse'), msse4, '-Wno-argument-outside-range']
     self.maybe_closure()
     self.do_runf(src, native_result)
 
@@ -6689,7 +6689,7 @@ void* operator new(size_t size) {
     self.run_process([shared.CLANG_CXX, src, '-mavx', '-Wno-argument-outside-range', '-Wpedantic', '-o', 'test_avx', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_avx', stdout=PIPE).stdout
 
-    self.emcc_args += ['-I' + test_file('sse'), '-mavx', '-fno-inline-functions', '-Wno-argument-outside-range', '-sSTACK_SIZE=1MB'] + args
+    self.cflags += ['-I' + test_file('sse'), '-mavx', '-fno-inline-functions', '-Wno-argument-outside-range', '-sSTACK_SIZE=1MB'] + args
     self.maybe_closure()
     self.do_runf(src, native_result)
 
@@ -6709,28 +6709,28 @@ void* operator new(size_t size) {
     self.run_process([shared.CLANG_CXX, src, '-mavx2', '-Wno-argument-outside-range', '-Wpedantic', '-o', 'test_avx2', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_avx2', stdout=PIPE).stdout
 
-    self.emcc_args += ['-I' + test_file('sse'), '-mavx2', '-Wno-argument-outside-range', '-sSTACK_SIZE=1MB'] + args
+    self.cflags += ['-I' + test_file('sse'), '-mavx2', '-Wno-argument-outside-range', '-sSTACK_SIZE=1MB'] + args
     self.maybe_closure()
     self.do_runf(src, native_result)
 
   @wasm_simd
   def test_sse_diagnostics(self):
-    self.emcc_args.remove('-Werror')
+    self.cflags.remove('-Werror')
     src = test_file('sse/test_sse_diagnostic.cpp')
 
     p = self.run_process(
-      [shared.EMXX, src, '-msse', '-DWASM_SIMD_COMPAT_SLOW'] + self.get_emcc_args(),
+      [shared.EMXX, src, '-msse', '-DWASM_SIMD_COMPAT_SLOW'] + self.get_cflags(),
       stderr=PIPE)
     self.assertContained('Instruction emulated via slow path.', p.stderr)
 
   @wasm_relaxed_simd
   def test_relaxed_simd_implies_simd128(self):
     src = test_file('sse/test_sse1.cpp')
-    self.build(src, emcc_args=['-msse'])
+    self.build(src, cflags=['-msse'])
 
   @no_asan('call stack exceeded on some versions of node')
   def test_gcc_unmangler(self):
-    self.emcc_args += ['-I' + test_file('third_party/libiberty')]
+    self.cflags += ['-I' + test_file('third_party/libiberty')]
 
     self.do_runf('third_party/libiberty/cp-demangle.c', '*d_demangle(char const*, int, unsigned int*)*', args=['_ZL10d_demanglePKciPj'])
 
@@ -6743,7 +6743,7 @@ void* operator new(size_t size) {
     ftlib = self.get_freetype_library()
 
     if self.get_setting('WASMFS'):
-      self.emcc_args += ['-sFORCE_FILESYSTEM']
+      self.cflags += ['-sFORCE_FILESYSTEM']
 
     self.add_pre_run("FS.createDataFile('/', 'font.ttf', %s, true, false, false);" % str(
       list(bytearray(read_binary(test_file('freetype/LiberationSansBold.ttf')))),
@@ -6785,11 +6785,11 @@ void* operator new(size_t size) {
   })
   def test_sqlite(self, use_pthreads):
     if self.get_setting('STRICT'):
-      self.emcc_args += ['-lstubs']
+      self.cflags += ['-lstubs']
     if use_pthreads:
-      self.emcc_args.append('-pthread')
+      self.cflags.append('-pthread')
       self.setup_node_pthreads()
-    self.emcc_args += ['-sUSE_SQLITE3']
+    self.cflags += ['-sUSE_SQLITE3']
     self.do_run_in_out_file_test('sqlite/test.c')
 
   @needs_make('mingw32-make')
@@ -6803,13 +6803,13 @@ void* operator new(size_t size) {
       self.skipTest("Windows cannot run configure sh scripts")
 
     self.maybe_closure()
-    if '-g' in self.emcc_args:
-      self.emcc_args.append('-gsource-map') # more source maps coverage
+    if '-g' in self.cflags:
+      self.cflags.append('-gsource-map') # more source maps coverage
 
     zlib = self.get_zlib_library(use_cmake)
 
     # example.c uses K&R style function declarations
-    self.emcc_args += ['-Wno-deprecated-non-prototype']
+    self.cflags += ['-Wno-deprecated-non-prototype']
     self.do_core_test('test_zlib.c', libraries=zlib, includes=[test_file('third_party/zlib')])
 
   @needs_make('make')
@@ -6824,7 +6824,7 @@ void* operator new(size_t size) {
     if WINDOWS and not use_cmake:
       self.skipTest("Windows cannot run configure sh scripts")
 
-    self.emcc_args += [
+    self.cflags += [
       '-Wno-c++11-narrowing',
       '-Wno-deprecated-register',
       '-Wno-writable-strings',
@@ -6838,7 +6838,7 @@ void* operator new(size_t size) {
     # extra testing for ASSERTIONS == 2
     if use_cmake:
       self.set_setting('ASSERTIONS', 2)
-      self.emcc_args.append('-Wno-unused-command-line-argument')
+      self.cflags.append('-Wno-unused-command-line-argument')
 
     self.do_runf('third_party/bullet/Demos/HelloWorld/HelloWorld.cpp',
                  [read_file(test_file('bullet/output.txt')), # different roundings
@@ -6857,7 +6857,7 @@ void* operator new(size_t size) {
   @crossplatform
   def test_poppler(self):
     # See https://github.com/emscripten-core/emscripten/issues/20757
-    self.emcc_args.extend(['-Wno-deprecated-declarations', '-Wno-nontrivial-memaccess'])
+    self.cflags.extend(['-Wno-deprecated-declarations', '-Wno-nontrivial-memaccess'])
     poppler = self.get_poppler_library()
     shutil.copy(test_file('poppler/paper.pdf'), '.')
 
@@ -6870,7 +6870,7 @@ void* operator new(size_t size) {
       out("Data: " + JSON.stringify(FileData));
     };
     ''')
-    self.emcc_args += ['--pre-js', 'pre.js', '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$unSign', '-sINCOMING_MODULE_JS_API=[preRun, postRun]']
+    self.cflags += ['--pre-js', 'pre.js', '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$unSign', '-sINCOMING_MODULE_JS_API=[preRun, postRun]']
 
     ppm_data = str(list(read_binary(test_file('poppler/ref.ppm'))))
     self.do_run('', 'Data: ' + ppm_data.replace(' ', ''),
@@ -6895,7 +6895,7 @@ void* operator new(size_t size) {
       return out
 
     # remove -g, so we have one test without it by default
-    self.emcc_args = [x for x in self.emcc_args if x != '-g']
+    self.cflags = [x for x in self.cflags if x != '-g']
 
     original_j2k = test_file('openjpeg/syntensity_lobby_s.j2k')
     image_bytes = list(bytearray(read_binary(original_j2k)))
@@ -6913,7 +6913,7 @@ void* operator new(size_t size) {
     builder_cmd = [EMBUILDER, 'build', 'libpng']
     if self.get_setting('MEMORY64'):
       builder_cmd.append('--wasm64')
-      self.emcc_args.append('-Wno-pointer-to-int-cast')
+      self.cflags.append('-Wno-pointer-to-int-cast')
     self.run_process(builder_cmd)
     lib = self.get_library('third_party/openjpeg',
                            ['codec/CMakeFiles/j2k_to_image.dir/index.c.o',
@@ -6957,13 +6957,13 @@ void* operator new(size_t size) {
       assert abs(true_mean - image_mean) < 0.01, [true_mean, image_mean]
       assert diff_mean < 0.01, diff_mean
 
-    self.emcc_args += ['--minify=0'] # to compare the versions
-    self.emcc_args += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[preRun,postRun]']
+    self.cflags += ['--minify=0'] # to compare the versions
+    self.cflags += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[preRun,postRun]']
 
     output = self.do_runf('third_party/openjpeg/codec/j2k_to_image.c',
                           'Successfully generated', # The real test for valid output is in image_compare
                           args='-i image.j2k -o image.raw'.split(),
-                          emcc_args=['-sUSE_LIBPNG'],
+                          cflags=['-sUSE_LIBPNG'],
                           libraries=lib,
                           includes=[test_file('third_party/openjpeg/libopenjpeg'),
                                     test_file('third_party/openjpeg/codec'),
@@ -6979,7 +6979,7 @@ void* operator new(size_t size) {
     # Binaryen's '--instrument-locals' will add their logging functions if
     # reference-types is enabled. So make sure this test passes when
     # reference-types feature is enabled as well.
-    self.emcc_args += ['-mreference-types']
+    self.cflags += ['-mreference-types']
     self.node_args += shared.node_reference_types_flags(self.get_nodejs())
     output = self.do_runf('core/test_autodebug.c', 'success')
     # test that the program both works and also emits some of the logging
@@ -6994,7 +6994,7 @@ void* operator new(size_t size) {
   @crossplatform
   @no_modularize_instance('ccall is not compatible with MODULARIZE=instance')
   def test_ccall(self):
-    self.emcc_args.append('-Wno-return-stack-address')
+    self.cflags.append('-Wno-return-stack-address')
     self.set_setting('EXPORTED_RUNTIME_METHODS', ['ccall', 'cwrap', 'STACK_SIZE'])
     self.set_setting('WASM_ASYNC_COMPILATION', 0)
     create_file('post.js', '''
@@ -7029,7 +7029,7 @@ void* operator new(size_t size) {
       out('stack is ok.');
       ccall('call_ccall_again', null);
       ''')
-    self.emcc_args += ['--post-js', 'post.js']
+    self.cflags += ['--post-js', 'post.js']
 
     self.set_setting('EXPORTED_FUNCTIONS', ['_get_int', '_get_float', '_get_bool', '_get_string', '_print_int', '_print_float', '_print_bool', '_print_string', '_multi', '_pointer', '_call_ccall_again', '_malloc'])
     self.do_core_test('test_ccall.cpp')
@@ -7039,7 +7039,7 @@ void* operator new(size_t size) {
 
   @no_modularize_instance('ccall is not compatible with MODULARIZE=instance')
   def test_ccall_cwrap_fast_path(self):
-    self.emcc_args.append('-Wno-return-stack-address')
+    self.cflags.append('-Wno-return-stack-address')
     self.set_setting('EXPORTED_RUNTIME_METHODS', ['ccall', 'cwrap'])
     self.set_setting('WASM_ASYNC_COMPILATION', 0)
     self.set_setting('ASSERTIONS', 0)
@@ -7047,7 +7047,7 @@ void* operator new(size_t size) {
       var printBool = Module['cwrap']('print_bool', null, ['boolean']);
       out(Module['_print_bool'] === printBool); // the function should be the exact raw function in the module rather than a wrapped one
       ''')
-    self.emcc_args += ['--post-js', 'post.js']
+    self.cflags += ['--post-js', 'post.js']
 
     self.set_setting('EXPORTED_FUNCTIONS', ['_print_bool'])
     self.do_runf('core/test_ccall.cpp', 'true')
@@ -7057,7 +7057,7 @@ void* operator new(size_t size) {
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$dynCall', '$ASSERTIONS'])
     self.do_core_test('EXPORTED_RUNTIME_METHODS.c')
     # test dyncall (and other runtime methods) can be exported
-    self.emcc_args += ['-DEXPORTED']
+    self.cflags += ['-DEXPORTED']
     self.set_setting('EXPORTED_RUNTIME_METHODS', ['dynCall', 'addFunction', 'lengthBytesUTF8', 'getTempRet0', 'setTempRet0'])
     self.do_core_test('EXPORTED_RUNTIME_METHODS.c')
 
@@ -7067,7 +7067,7 @@ void* operator new(size_t size) {
       # define DYNCALLS because this test does test calling them directly, and
       # in WASM_BIGINT mode we do not enable them by default (since we can do
       # more without them - we don't need to legalize)
-      self.emcc_args += ['-sDYNCALLS', '-DWASM_BIGINT']
+      self.cflags += ['-sDYNCALLS', '-DWASM_BIGINT']
     cases = [
         ('DIRECT', []),
         ('DYNAMIC_SIG', ['-sDYNCALLS']),
@@ -7081,14 +7081,14 @@ void* operator new(size_t size) {
 
     for which, extra_args in cases:
       print(str(extra_args) + ' ' + which)
-      self.do_core_test('test_dyncall_specific.c', emcc_args=['-D' + which] + extra_args)
+      self.do_core_test('test_dyncall_specific.c', cflags=['-D' + which] + extra_args)
 
   @parameterized({
     '': ([],),
     'legacy': (['-sDYNCALLS'],),
   })
   def test_dyncall_pointers(self, args):
-    self.do_core_test('test_dyncall_pointers.c', emcc_args=args)
+    self.do_core_test('test_dyncall_pointers.c', cflags=args)
 
   @also_with_wasm_bigint
   @no_modularize_instance('uses Module object directly')
@@ -7107,10 +7107,10 @@ void* operator new(size_t size) {
       self.do_run_in_out_file_test('core/test_getValue_setValue.cpp',
                                    out_suffix=out_suffix,
                                    assert_returncode=assert_returncode,
-                                   emcc_args=args)
+                                   cflags=args)
 
     if self.get_setting('WASM_BIGINT'):
-      self.emcc_args += ['-DWASM_BIGINT']
+      self.cflags += ['-DWASM_BIGINT']
 
     # see that direct usage (not on module) works. we don't export, but the use
     # keeps it alive through JSDCE
@@ -7143,7 +7143,7 @@ void* operator new(size_t size) {
       self.do_runf('core/FS_exports.cpp',
                    (read_file(test_file('core/FS_exports' + output_prefix + '.out')),
                     read_file(test_file('core/FS_exports' + output_prefix + '_2.out'))),
-                   assert_returncode=assert_returncode, emcc_args=args)
+                   assert_returncode=assert_returncode, cflags=args)
 
     # see that direct usage (not on module) works. we don't export, but the use
     # keeps it alive through JSDCE
@@ -7163,7 +7163,7 @@ void* operator new(size_t size) {
     # these used to be exported, but no longer are by default
     def test(expected, args=None, assert_returncode=0):
       self.do_runf('core/legacy_exported_runtime_numbers.cpp', expected,
-                   assert_returncode=assert_returncode, emcc_args=args)
+                   assert_returncode=assert_returncode, cflags=args)
 
     # Without assertion indirect usages (via Module) result in `undefined` and direct usage
     # generates a builtin (not very helpful) JS error.
@@ -7181,7 +7181,7 @@ void* operator new(size_t size) {
 
     # Adding the symbol to DEFAULT_LIBRARY_FUNCS_TO_INCLUDE should allow direct usage, but
     # Module usage should continue to fail.
-    self.emcc_args += ['-Wno-deprecated']
+    self.cflags += ['-Wno-deprecated']
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$ALLOC_STACK'])
     test(not_exported, assert_returncode=NON_ZERO)
     test('1', args=['-DDIRECT'])
@@ -7195,7 +7195,7 @@ void* operator new(size_t size) {
     out_js = self.output_name('response_file')
     response_data = '-o "%s" "%s"' % (out_js, test_file('hello_world.cpp'))
     create_file('rsp_file', response_data.replace('\\', '\\\\'))
-    self.run_process([EMCC, "@rsp_file"] + self.get_emcc_args())
+    self.run_process([EMCC, "@rsp_file"] + self.get_cflags())
     self.do_run(out_js, 'hello, world', no_build=True)
 
     self.assertContained('response file not found: foo.txt', self.expect_fail([EMCC, '@foo.txt']))
@@ -7203,11 +7203,11 @@ void* operator new(size_t size) {
   def test_linker_response_file(self):
     objfile = 'response_file.o'
     out_js = self.output_name('response_file')
-    self.run_process([EMCC, '-c', test_file('hello_world.cpp'), '-o', objfile] + self.get_emcc_args(compile_only=True))
+    self.run_process([EMCC, '-c', test_file('hello_world.cpp'), '-o', objfile] + self.get_cflags(compile_only=True))
     # This should expand into -Wl,--start-group <objfile> -Wl,--end-group
     response_data = '--start-group ' + objfile + ' --end-group'
     create_file('rsp_file', response_data.replace('\\', '\\\\'))
-    self.run_process([EMCC, "-Wl,@rsp_file", '-o', out_js] + self.get_emcc_args())
+    self.run_process([EMCC, "-Wl,@rsp_file", '-o', out_js] + self.get_cflags())
     self.do_run(out_js, 'hello, world', no_build=True)
 
   @no_modularize_instance('uses Module object directly')
@@ -7277,7 +7277,7 @@ void* operator new(size_t size) {
     # https://github.com/emscripten-core/emscripten/issues/15081
     self.set_setting('EXIT_RUNTIME', 0)
     self.set_setting('EMULATE_FUNCTION_POINTER_CASTS')
-    self.do_core_test('test_emulate_function_pointer_casts.cpp', emcc_args=['-Wno-deprecated'])
+    self.do_core_test('test_emulate_function_pointer_casts.cpp', cflags=['-Wno-deprecated'])
 
   @no_wasm2js('TODO: nicely printed names in wasm2js')
   @parameterized({
@@ -7285,12 +7285,12 @@ void* operator new(size_t size) {
     'noexcept': (['-fno-exceptions'],),
   })
   def test_demangle_stacks(self, extra_args):
-    self.emcc_args += extra_args
+    self.cflags += extra_args
     self.set_setting('ASSERTIONS')
     # disable aggressive inlining in binaryen
     self.set_setting('BINARYEN_EXTRA_PASSES', '--one-caller-inline-max-function-size=1')
     # ensure function names are preserved
-    self.emcc_args += ['--profiling-funcs']
+    self.cflags += ['--profiling-funcs']
     self.do_core_test('test_demangle_stacks.cpp', assert_returncode=NON_ZERO)
 
     # there should be a name section in the file
@@ -7307,9 +7307,9 @@ void* operator new(size_t size) {
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$jsStackTrace')
 
     self.set_setting('ENVIRONMENT', 'node,shell')
-    if '-O' not in str(self.emcc_args) or '-O0' in self.emcc_args or '-O1' in self.emcc_args or '-g' in self.emcc_args:
+    if '-O' not in str(self.cflags) or '-O0' in self.cflags or '-O1' in self.cflags or '-g' in self.cflags:
       self.skipTest("without opts, we don't emit a symbol map")
-    self.emcc_args += ['--emit-symbol-map']
+    self.cflags += ['--emit-symbol-map']
     self.do_runf('core/test_demangle_stacks.cpp', 'Aborted', assert_returncode=NON_ZERO)
     # make sure the shortened name is the right one
     full_aborter = None
@@ -7336,13 +7336,13 @@ void* operator new(size_t size) {
 
   @no_safe_heap('tracing from sbrk into JS leads to an infinite loop')
   def test_tracing(self):
-    self.emcc_args += ['--tracing']
+    self.cflags += ['--tracing']
     self.do_core_test('test_tracing.c')
 
   @no_wasm2js('eval_ctors not supported yet')
   @also_with_standalone_wasm()
   def test_eval_ctors(self):
-    if '-O2' not in str(self.emcc_args) or '-O1' in str(self.emcc_args):
+    if '-O2' not in str(self.cflags) or '-O1' in str(self.cflags):
       self.skipTest('need opts')
 
     print('leave printf in ctor')
@@ -7415,12 +7415,12 @@ void* operator new(size_t size) {
   })
   def test_embind_val_basics(self, args):
     self.maybe_closure()
-    self.do_run_in_out_file_test('embind/test_embind_val_basics.cpp', emcc_args=args)
+    self.do_run_in_out_file_test('embind/test_embind_val_basics.cpp', cflags=args)
 
   @node_pthreads
   def test_embind_basics(self):
     self.maybe_closure()
-    self.emcc_args += [
+    self.cflags += [
       '-lembind', '--post-js', 'post.js',
       # for extra coverage, test using pthreads
       '-pthread', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME',
@@ -7451,7 +7451,7 @@ void* operator new(size_t size) {
     self.do_runf('test.cpp', 'lerp 166')
 
   def test_embind_unbound_types(self):
-    self.emcc_args += ['-lembind', '--post-js', 'post.js']
+    self.cflags += ['-lembind', '--post-js', 'post.js']
     create_file('post.js', '''
       function ready() {
         try {
@@ -7479,7 +7479,7 @@ void* operator new(size_t size) {
     self.do_runf('test.cpp', 'UnboundTypeError: Cannot call compute due to unbound types: Pi')
 
   def test_embind_memory_view(self):
-    self.emcc_args += ['-lembind', '--post-js', 'post.js']
+    self.cflags += ['-lembind', '--post-js', 'post.js']
     create_file('post.js', '''
       function printFirstElement() {
         out(Module['getBufferView']()[0]);
@@ -7511,28 +7511,28 @@ void* operator new(size_t size) {
     self.do_runf('test.cpp', '107')
 
   def test_embind_inheritance(self):
-    self.do_core_test('test_embind_inheritance.cpp', emcc_args=['-lembind'])
+    self.do_core_test('test_embind_inheritance.cpp', cflags=['-lembind'])
 
   def test_embind_custom_marshal(self):
-    self.emcc_args += ['-lembind', '--pre-js', test_file('embind/test_custom_marshal.js')]
+    self.cflags += ['-lembind', '--pre-js', test_file('embind/test_custom_marshal.js')]
     self.do_run_in_out_file_test('embind/test_custom_marshal.cpp', assert_identical=True)
 
   def test_embind_float_constants(self):
-    self.do_run_in_out_file_test('embind/test_float_constants.cpp', emcc_args=['-lembind'])
+    self.do_run_in_out_file_test('embind/test_float_constants.cpp', cflags=['-lembind'])
 
   def test_embind_negative_constants(self):
-    self.do_run_in_out_file_test('embind/test_negative_constants.cpp', emcc_args=['-lembind'])
+    self.do_run_in_out_file_test('embind/test_negative_constants.cpp', cflags=['-lembind'])
 
   @also_with_wasm_bigint
   @no_esm_integration('embind is not compatible with WASM_ESM_INTEGRATION')
   def test_embind_unsigned(self):
-    self.do_run_in_out_file_test('embind/test_unsigned.cpp', emcc_args=['-lembind'])
+    self.do_run_in_out_file_test('embind/test_unsigned.cpp', cflags=['-lembind'])
 
   def test_embind_val(self):
-    self.do_run_in_out_file_test('embind/test_val.cpp', emcc_args=['-lembind'])
+    self.do_run_in_out_file_test('embind/test_val.cpp', cflags=['-lembind'])
 
   def test_embind_val_read_pointer(self):
-    self.do_runf('embind/test_val_read_pointer.cpp', emcc_args=['-lembind'])
+    self.do_runf('embind/test_val_read_pointer.cpp', cflags=['-lembind'])
 
   def test_embind_val_assignment(self):
     err = self.expect_fail([EMCC, test_file('embind/test_val_assignment.cpp'), '-lembind', '-c'])
@@ -7540,7 +7540,7 @@ void* operator new(size_t size) {
 
   @node_pthreads
   def test_embind_val_cross_thread(self):
-    self.emcc_args += ['--bind']
+    self.cflags += ['--bind']
     create_file('test_embind_val_cross_thread.cpp', r'''
       #include <emscripten.h>
       #include <emscripten/val.h>
@@ -7567,7 +7567,7 @@ void* operator new(size_t size) {
 
   @node_pthreads
   def test_embind_val_cross_thread_deleted(self):
-    self.emcc_args += ['--bind']
+    self.cflags += ['--bind']
     create_file('test_embind_val_cross_thread.cpp', r'''
       #include <emscripten.h>
       #include <emscripten/val.h>
@@ -7597,7 +7597,7 @@ void* operator new(size_t size) {
     create_file('pre.js', r'''Module.onRuntimeInitialized = () => {
       Module.asyncCoro().then(console.log);
     }''')
-    self.emcc_args += ['-std=c++20', '--bind', '--pre-js=pre.js', '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized]', '--no-entry']
+    self.cflags += ['-std=c++20', '--bind', '--pre-js=pre.js', '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized]', '--no-entry']
     self.do_runf('embind/test_val_coro.cpp', '34\n')
 
   def test_embind_val_coro_propogate_cpp_exception(self):
@@ -7608,7 +7608,7 @@ void* operator new(size_t size) {
         err => console.error(`rejected with: ${err.stack}`)
       );
     }''')
-    self.emcc_args += ['-std=c++20', '--bind', '--pre-js=pre.js', '-fexceptions', '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized]', '--no-entry']
+    self.cflags += ['-std=c++20', '--bind', '--pre-js=pre.js', '-fexceptions', '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized]', '--no-entry']
     self.do_runf('embind/test_val_coro.cpp', 'rejected with: std::runtime_error: bang from throwingCoro!\n')
 
   def test_embind_val_coro_propogate_js_error(self):
@@ -7619,11 +7619,11 @@ void* operator new(size_t size) {
         err => console.error(`rejected with: ${err.message}`)
       );
     }''')
-    self.emcc_args += ['-std=c++20', '--bind', '--pre-js=pre.js', '-fexceptions']
+    self.cflags += ['-std=c++20', '--bind', '--pre-js=pre.js', '-fexceptions']
     self.do_runf('embind/test_val_coro.cpp', 'rejected with: bang from JS promise!\n')
 
   def test_embind_dynamic_initialization(self):
-    self.emcc_args += ['-lembind']
+    self.cflags += ['-lembind']
     self.do_run_in_out_file_test('embind/test_dynamic_initialization.cpp')
 
   @no_wasm2js('wasm_bigint')
@@ -7633,17 +7633,17 @@ void* operator new(size_t size) {
   })
   def test_embind_i64_val(self, safe_heap):
     self.set_setting('WASM_BIGINT')
-    if safe_heap and '-fsanitize=address' in self.emcc_args:
+    if safe_heap and '-fsanitize=address' in self.cflags:
       self.skipTest('asan does not work with SAFE_HEAP')
     self.set_setting('SAFE_HEAP', safe_heap)
-    self.emcc_args += ['-lembind']
+    self.cflags += ['-lembind']
     self.node_args += shared.node_bigint_flags(self.get_nodejs())
     self.do_run_in_out_file_test('embind/test_i64_val.cpp', assert_identical=True)
 
   @no_wasm2js('wasm_bigint')
   def test_embind_i64_binding(self):
     self.set_setting('WASM_BIGINT')
-    self.emcc_args += ['-lembind', '--js-library', test_file('embind/test_i64_binding.js')]
+    self.cflags += ['-lembind', '--js-library', test_file('embind/test_i64_binding.js')]
     self.node_args += shared.node_bigint_flags(self.get_nodejs())
     self.do_run_in_out_file_test('embind/test_i64_binding.cpp', assert_identical=True)
 
@@ -7672,7 +7672,7 @@ void* operator new(size_t size) {
         emscripten::function("dotest", &test);
       }
     ''')
-    self.emcc_args += ['-lembind', '-fno-rtti', '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0']
+    self.cflags += ['-lembind', '-fno-rtti', '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0']
     self.do_runf('main.cpp', '418\ndotest returned: 42\n')
 
   @parameterized({
@@ -7680,7 +7680,7 @@ void* operator new(size_t size) {
     'no_rtti': (['-fno-rtti', '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0'],),
   })
   def test_embind_polymorphic_class(self, args):
-    self.do_core_test('test_embind_polymorphic_class_no_rtti.cpp', emcc_args=args + ['-lembind'])
+    self.do_core_test('test_embind_polymorphic_class_no_rtti.cpp', cflags=args + ['-lembind'])
 
   def test_embind_no_rtti_followed_by_rtti(self):
     src = r'''
@@ -7707,13 +7707,13 @@ void* operator new(size_t size) {
         emscripten::function("dotest", &test);
       }
     '''
-    self.emcc_args += ['-lembind', '-fno-rtti', '-frtti']
+    self.cflags += ['-lembind', '-fno-rtti', '-frtti']
     self.do_run(src, '418\ndotest returned: 42\n')
 
   @no_sanitize('sanitizers do not support WASM_WORKERS')
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
   def test_embind_wasm_workers(self):
-    self.do_run_in_out_file_test('embind/test_embind_wasm_workers.cpp', emcc_args=['-lembind', '-sWASM_WORKERS'])
+    self.do_run_in_out_file_test('embind/test_embind_wasm_workers.cpp', cflags=['-lembind', '-sWASM_WORKERS'])
 
   @parameterized({
     '': ('DEFAULT', False),
@@ -7760,9 +7760,9 @@ void* operator new(size_t size) {
     # Export things on "TheModule". This matches the typical use pattern of
     # the bound library being used as Box2D.* or Ammo.*, and we cannot rely
     # on "Module" being always present (closure may remove it).
-    self.emcc_args += ['-sEXPORTED_FUNCTIONS=_malloc,_free', '-sEXPORTED_RUNTIME_METHODS=HEAP8,stringToUTF8', '--post-js=glue.js', '--extern-post-js=extern-post.js']
+    self.cflags += ['-sEXPORTED_FUNCTIONS=_malloc,_free', '-sEXPORTED_RUNTIME_METHODS=HEAP8,stringToUTF8', '--post-js=glue.js', '--extern-post-js=extern-post.js']
     if mode == 'ALL':
-      self.emcc_args += ['-sASSERTIONS']
+      self.cflags += ['-sASSERTIONS']
     if allow_memory_growth:
       self.set_setting('ALLOW_MEMORY_GROWTH')
       if self.get_setting('INITIAL_MEMORY') == '4200mb':
@@ -7780,7 +7780,7 @@ void* operator new(size_t size) {
     self.set_setting('WASM_ASYNC_COMPILATION', 0)
     self.set_setting('PTHREAD_POOL_DELAY_LOAD', 1)
     self.set_setting('PTHREAD_POOL_SIZE', 1)
-    self.emcc_args += ['-lembind', '--post-js=' + test_file('core/pthread/test_embind_sync_if_pthread_delayed.post.js')]
+    self.cflags += ['-lembind', '--post-js=' + test_file('core/pthread/test_embind_sync_if_pthread_delayed.post.js')]
     self.do_run_in_out_file_test('core/pthread/test_embind_sync_if_pthread_delayed.cpp')
 
   ### Tests for tools
@@ -7790,8 +7790,8 @@ void* operator new(size_t size) {
   @requires_node
   @requires_dev_dependency('source-map')
   def test_source_map(self):
-    if '-g' not in self.emcc_args:
-      self.emcc_args.append('-g')
+    if '-g' not in self.cflags:
+      self.cflags.append('-g')
 
     src = '''
       #include <stdio.h>
@@ -7813,17 +7813,17 @@ void* operator new(size_t size) {
     wasm_filename = 'a.out.wasm'
     no_maps_filename = 'no-maps.out.js'
 
-    assert '-gsource-map' not in self.emcc_args
+    assert '-gsource-map' not in self.cflags
     self.emcc('src.cpp', output_filename=out_filename)
     # the file name may find its way into the generated code, so make sure we
     # can do an apples-to-apples comparison by compiling with the same file name
     shutil.move(out_filename, no_maps_filename)
     no_maps_file = read_file(no_maps_filename)
     no_maps_file = re.sub(' *//[@#].*$', '', no_maps_file, flags=re.MULTILINE)
-    self.emcc_args.append('-gsource-map')
+    self.cflags.append('-gsource-map')
 
     self.emcc(os.path.abspath('src.cpp'),
-              self.get_emcc_args(),
+              self.get_cflags(),
               out_filename)
     map_referent = out_filename if self.is_wasm2js() else wasm_filename
     # after removing the @line and @sourceMappingURL comments, the build
@@ -7872,7 +7872,7 @@ void* operator new(size_t size) {
         val view(typed_memory_view(1, buffer));
       }
     ''')
-    self.build_dlfcn_lib('liblib.cpp', emcc_args=['-fvisibility=hidden'])
+    self.build_dlfcn_lib('liblib.cpp', cflags=['-fvisibility=hidden'])
 
     self.prep_dlfcn_main()
     self.clear_setting('NO_AUTOLOAD_DYLIBS')
@@ -7887,12 +7887,12 @@ void* operator new(size_t size) {
         return 0;
       }
     ''')
-    self.do_runf('main.cpp', 'done\n', emcc_args=['--bind'])
+    self.do_runf('main.cpp', 'done\n', cflags=['--bind'])
 
   @no_wasm2js('TODO: source maps in wasm2js')
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with dwarf output')
   def test_dwarf(self):
-    self.emcc_args.append('-g')
+    self.cflags.append('-g')
 
     shutil.copy(test_file('core/test_dwarf.c'), '.')
 
@@ -8036,7 +8036,7 @@ void* operator new(size_t size) {
       # TODO(sbc): Fix closure warnings with MODULARIZE + WASM=0
       self.ldflags.append('-Wno-error=closure')
 
-    self.emcc_args += [
+    self.cflags += [
       '--pre-js', test_file('core/modularize_closure_pre.js'),
       '--extern-post-js', test_file('modularize_post_js.js'),
       '--closure=1',
@@ -8049,9 +8049,9 @@ void* operator new(size_t size) {
   @no_modularize_instance('assumes .js output filename')
   @also_with_wasm_bigint
   def test_emscripten_log(self):
-    self.emcc_args += ['-g', '-DRUN_FROM_JS_SHELL', '-Wno-deprecated-pragma']
+    self.cflags += ['-g', '-DRUN_FROM_JS_SHELL', '-Wno-deprecated-pragma']
     if self.maybe_closure():
-      self.emcc_args += ['-g1'] # extra testing
+      self.cflags += ['-g1'] # extra testing
     self.do_run_in_out_file_test('test_emscripten_log.cpp', interleaved_output=False)
 
   def test_float_literals(self):
@@ -8093,13 +8093,13 @@ void* operator new(size_t size) {
         assert(status == EXITSTATUS);
       };
     ''')
-    self.emcc_args += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[onExit]']
+    self.cflags += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[onExit]']
     print('.. exit')
-    self.do_runf('exit.c', 'hello, world!\ncleanup\nI see exit status: 117', assert_returncode=117, emcc_args=['-DNORMAL_EXIT'])
+    self.do_runf('exit.c', 'hello, world!\ncleanup\nI see exit status: 117', assert_returncode=117, cflags=['-DNORMAL_EXIT'])
     print('.. _exit')
-    self.do_runf('exit.c', 'hello, world!\nI see exit status: 118', assert_returncode=118, emcc_args=['-DUNDER_EXIT'])
+    self.do_runf('exit.c', 'hello, world!\nI see exit status: 118', assert_returncode=118, cflags=['-DUNDER_EXIT'])
     print('.. _Exit')
-    self.do_runf('exit.c', 'hello, world!\nI see exit status: 119', assert_returncode=119, emcc_args=['-DCAPITAL_EXIT'])
+    self.do_runf('exit.c', 'hello, world!\nI see exit status: 119', assert_returncode=119, cflags=['-DCAPITAL_EXIT'])
 
   def test_minmax(self):
     self.do_runf('test_minmax.c', 'NAN != NAN\nSuccess!')
@@ -8210,7 +8210,7 @@ Module.onRuntimeInitialized = () => {
   }
 };
 ''')
-    self.emcc_args += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized]']
+    self.cflags += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized]']
     self.do_runf('main.c', 'The call to main is running asynchronously.')
 
   @with_asyncify_and_jspi
@@ -8235,7 +8235,7 @@ Module.onRuntimeInitialized = () => {
   ccall('main', null, ['number', 'string'], [2, 'waka'], { async: true });
 };
 ''')
-    self.emcc_args += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized]']
+    self.cflags += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized]']
     self.do_runf('main.c', 'HelloWorld')
 
   @parameterized({
@@ -8280,7 +8280,7 @@ Module.onRuntimeInitialized = () => {
     });
 };
 ''')
-    self.emcc_args += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized]']
+    self.cflags += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized]']
     self.do_runf('main.c', 'stringf: first\nsecond\n6.4')
 
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
@@ -8313,7 +8313,7 @@ Module.onRuntimeInitialized = () => {
       create_file('response.file', response)
       self.set_setting('ASYNCIFY_ONLY', '@response.file')
     self.set_setting('ASYNCIFY')
-    self.emcc_args += args
+    self.cflags += args
 
     if should_pass:
       self.do_core_test('test_asyncify_lists.cpp', assert_identical=True)
@@ -8325,12 +8325,12 @@ Module.onRuntimeInitialized = () => {
     if self.is_wasm():
       filename = 'test_asyncify_lists.wasm'
       # there should be no name section. sanitizers, however, always enable that
-      if not is_sanitizing(self.emcc_args) and '--profiling-funcs' not in self.emcc_args:
+      if not is_sanitizing(self.cflags) and '--profiling-funcs' not in self.cflags:
         with webassembly.Module(filename) as m:
           self.assertFalse(m.has_name_section())
       # in a fully-optimized build, imports and exports are minified too and we
       # can verify that our function names appear nowhere
-      if '-O3' in self.emcc_args:
+      if '-O3' in self.cflags:
         binary = read_binary(filename)
         self.assertFalse(b'main' in binary)
 
@@ -8346,8 +8346,8 @@ Module.onRuntimeInitialized = () => {
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
   def test_asyncify_indirect_lists(self, args, should_pass):
     self.set_setting('ASYNCIFY')
-    self.emcc_args += args
-    if '-flto' in str(self.emcc_args):
+    self.cflags += args
+    if '-flto' in str(self.cflags):
       # LTO ends up inlining virt(), so ASYNCIFY_ADD does not work as expected.
       # If wasm-opt were aware of LLVM's no-inline mark this would not happen.
       self.skipTest('https://github.com/emscripten-core/emscripten/issues/21757')
@@ -8412,7 +8412,7 @@ Module.onRuntimeInitialized = () => {
     self.set_setting('EXIT_RUNTIME', 1)
     self.do_core_test('test_asyncify_during_exit.cpp', assert_returncode=NON_ZERO)
     print('NO_ASYNC')
-    self.do_core_test('test_asyncify_during_exit.cpp', emcc_args=['-DNO_ASYNC'], out_suffix='_no_async')
+    self.do_core_test('test_asyncify_during_exit.cpp', cflags=['-DNO_ASYNC'], out_suffix='_no_async')
 
   @no_asan('asyncify stack operations confuse asan')
   @no_lsan('undefined symbol __global_base')
@@ -8430,7 +8430,7 @@ Module.onRuntimeInitialized = () => {
     # TODO Test with ASYNCIFY=1 https://github.com/emscripten-core/emscripten/issues/17552
     self.require_jspi()
     self.do_runf('core/test_pthread_join_and_asyncify.c', 'joining thread!\njoined thread!',
-                 emcc_args=['-sJSPI',
+                 cflags=['-sJSPI',
                             '-sEXIT_RUNTIME=1',
                             '-pthread', '-sPROXY_TO_PTHREAD'])
 
@@ -8447,9 +8447,9 @@ Module.onRuntimeInitialized = () => {
     self.set_setting('ASYNCIFY_LAZY_LOAD_CODE')
     self.set_setting('ASYNCIFY_IGNORE_INDIRECT')
     self.set_setting('MALLOC', 'emmalloc')
-    self.emcc_args += ['-Wno-deprecated', '--profiling-funcs'] # so that we can find the functions for the changes below
+    self.cflags += ['-Wno-deprecated', '--profiling-funcs'] # so that we can find the functions for the changes below
     if conditional:
-      self.emcc_args += ['-DCONDITIONAL']
+      self.cflags += ['-DCONDITIONAL']
     self.do_core_test('emscripten_lazy_load_code.c', args=['0'])
 
     first_size = os.path.getsize('emscripten_lazy_load_code.wasm')
@@ -8458,11 +8458,11 @@ Module.onRuntimeInitialized = () => {
     print('second wasm size', second_size)
 
     # For the purposes of this test we don't consider O1 to be optimizing
-    is_optimizing = self.is_optimizing() and '-O1' not in self.emcc_args
+    is_optimizing = self.is_optimizing() and '-O1' not in self.cflags
 
     if not conditional and is_optimizing and \
-       '-g' not in self.emcc_args and \
-       '-fsanitize=leak' not in self.emcc_args and \
+       '-g' not in self.cflags and \
+       '-fsanitize=leak' not in self.cflags and \
        not self.get_setting('WASMFS'):
       # TODO: WasmFS has not yet been optimized for code size, and the general
       #       increase it causes mixes up code size measurements like this.
@@ -8603,13 +8603,13 @@ Module.onRuntimeInitialized = () => {
         }
       });
     ''')
-    self.emcc_args += ['--memoryprofiler', '--js-library', 'lib.js']
+    self.cflags += ['--memoryprofiler', '--js-library', 'lib.js']
     self.do_runf('main.c', 'able to run memprof')
 
   def test_fs_dict(self):
     self.set_setting('FORCE_FILESYSTEM')
-    self.emcc_args += ['-lidbfs.js']
-    self.emcc_args += ['-lnodefs.js']
+    self.cflags += ['-lidbfs.js']
+    self.cflags += ['-lnodefs.js']
     create_file('pre.js', '''
       Module.preRun = () => {
         out(typeof FS.filesystems['MEMFS']);
@@ -8621,7 +8621,7 @@ Module.onRuntimeInitialized = () => {
         out(typeof NODEFS);
       };
     ''')
-    self.emcc_args += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[preRun]']
+    self.cflags += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[preRun]']
     self.do_run('int main() { return 0; }', 'object\nobject\nobject\nobject\nobject\nobject')
 
   def test_fs_dict_none(self):
@@ -8645,7 +8645,7 @@ Module.onRuntimeInitialized = () => {
         }
       };
     ''')
-    self.emcc_args += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[preRun]']
+    self.cflags += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[preRun]']
     expected = '''\
 object
 undefined
@@ -8661,7 +8661,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
     self.do_runf('stack_overflow.cpp', 'Aborted(stack overflow', assert_returncode=NON_ZERO)
 
-    self.emcc_args += ['-DONE_BIG_STRING']
+    self.cflags += ['-DONE_BIG_STRING']
     self.do_runf('stack_overflow.cpp', 'Aborted(stack overflow', assert_returncode=NON_ZERO)
 
     # ASSERTIONS=2 implies STACK_OVERFLOW_CHECK=2
@@ -8671,7 +8671,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @node_pthreads
   def test_binaryen_2170_emscripten_atomic_cas_u8(self):
-    self.emcc_args.append('-pthread')
+    self.cflags.append('-pthread')
     self.do_run_in_out_file_test('binaryen_2170_emscripten_atomic_cas_u8.cpp')
 
   @also_with_standalone_wasm()
@@ -8681,7 +8681,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_runf('test_sbrk_brk.c', 'OK.')
 
   def test_brk(self):
-    self.emcc_args += ['-DTEST_BRK=1']
+    self.cflags += ['-DTEST_BRK=1']
     self.do_runf('test_sbrk_brk.c', 'OK.')
 
   # Tests that we can use the dlmalloc mallinfo() function to obtain information
@@ -8700,7 +8700,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # 'mimalloc': (['-sMALLOC=mimalloc'],),
   })
   def test_wrap_malloc(self, args):
-    self.do_runf('core/test_wrap_malloc.c', 'OK.', emcc_args=args)
+    self.do_runf('core/test_wrap_malloc.c', 'OK.', cflags=args)
 
   def test_environment(self):
     self.set_setting('ASSERTIONS')
@@ -8754,7 +8754,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_postrun_exit_runtime(self):
     create_file('pre.js', "Module['postRun'] = () => err('post run\\n');")
     self.set_setting('EXIT_RUNTIME')
-    self.emcc_args += ['--pre-js=pre.js', '-sINCOMING_MODULE_JS_API=[postRun]']
+    self.cflags += ['--pre-js=pre.js', '-sINCOMING_MODULE_JS_API=[postRun]']
     self.do_runf('hello_world.c', 'post run')
 
   # Tests that building with -sDECLARE_ASM_MODULE_EXPORTS=0 works
@@ -8767,7 +8767,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_runf('declare_asm_module_exports.c', 'jsFunction: 1')
     js = read_file('declare_asm_module_exports.js')
     occurances = js.count('cFunction')
-    if self.is_optimizing() and '-g' not in self.emcc_args:
+    if self.is_optimizing() and '-g' not in self.cflags:
       # In optimized builds only the single reference cFunction that exists in the EM_ASM should exist
       if self.is_wasm():
         self.assertEqual(occurances, 1)
@@ -8788,7 +8788,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   })
   @requires_node  # TODO: Support for non-Node.js shells under MINIMAL_RUNTIME
   def test_minimal_runtime_hello_world(self, args):
-    self.emcc_args = args
+    self.cflags = args
     self.set_setting('MINIMAL_RUNTIME')
     self.maybe_closure()
     self.do_runf('small_hello_world.c', 'hello')
@@ -8802,11 +8802,11 @@ NODEFS is no longer included by default; build with -lnodefs.js
   })
   def test_minimal_runtime_hello_printf(self, extra_setting):
     self.set_setting('MINIMAL_RUNTIME')
-    self.emcc_args += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]
+    self.cflags += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]
     self.set_setting(extra_setting)
     # $FS is not fully compatible with MINIMAL_RUNTIME so fails with closure
     # compiler.  lsan also pulls in $FS
-    if '-fsanitize=leak' not in self.emcc_args and extra_setting != 'FORCE_FILESYSTEM':
+    if '-fsanitize=leak' not in self.cflags and extra_setting != 'FORCE_FILESYSTEM':
       self.maybe_closure()
     self.do_run_in_out_file_test('hello_world.c')
 
@@ -8816,12 +8816,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_asan('SAFE_HEAP cannot be used with ASan')
   def test_minimal_runtime_safe_heap(self):
     self.set_setting('MINIMAL_RUNTIME')
-    self.emcc_args += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]
+    self.cflags += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]
     self.set_setting('SAFE_HEAP')
     # $FS is not fully compatible with MINIMAL_RUNTIME so fails with closure
     # compiler.
     # lsan pulls in $FS
-    if '-fsanitize=leak' not in self.emcc_args:
+    if '-fsanitize=leak' not in self.cflags:
       self.maybe_closure()
     self.do_runf('small_hello_world.c', 'hello')
 
@@ -8830,7 +8830,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_modularize_instance('MODULARIZE=instance is not compatible with MINIMAL_RUNTIME')
   def test_minimal_runtime_global_initializer(self):
     self.set_setting('MINIMAL_RUNTIME')
-    self.emcc_args += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]
+    self.cflags += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]
     self.maybe_closure()
     self.do_runf('test_global_initializer.cpp', 't1 > t0: 1')
 
@@ -8845,7 +8845,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_asan('-fsanitize-minimal-runtime cannot be used with ASan')
   @no_lsan('-fsanitize-minimal-runtime cannot be used with LSan')
   def test_ubsan_minimal_too_many_errors(self):
-    self.emcc_args += ['-fsanitize=undefined', '-fsanitize-minimal-runtime']
+    self.cflags += ['-fsanitize=undefined', '-fsanitize-minimal-runtime']
     self.do_runf('core/test_ubsan_minimal_too_many_errors.c',
                  expected_output='ubsan: add-overflow by 0x[0-9a-f]*\n' * 20 + 'ubsan: too many errors\n',
                  regex=True)
@@ -8855,7 +8855,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_asan('-fsanitize-minimal-runtime cannot be used with ASan')
   @no_lsan('-fsanitize-minimal-runtime cannot be used with LSan')
   def test_ubsan_minimal_errors_same_place(self):
-    self.emcc_args += ['-fsanitize=undefined', '-fsanitize-minimal-runtime']
+    self.cflags += ['-fsanitize=undefined', '-fsanitize-minimal-runtime']
     self.do_runf('core/test_ubsan_minimal_errors_same_place.c',
                  expected_output='ubsan: add-overflow by 0x[0-9a-z]*\n' * 5,
                  regex=True)
@@ -8868,7 +8868,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_wasm2js('TODO: sanitizers in wasm2js')
   @no_esm_integration('sanitizers do not support WASM_ESM_INTEGRATION')
   def test_ubsan_full_overflow(self, args):
-    self.emcc_args += args
+    self.cflags += args
     self.do_runf(
       'core/test_ubsan_full_overflow.c',
       assert_all=True,
@@ -8884,7 +8884,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_wasm2js('TODO: sanitizers in wasm2js')
   @no_esm_integration('sanitizers do not support WASM_ESM_INTEGRATION')
   def test_ubsan_full_no_return(self, args):
-    self.emcc_args += ['-Wno-return-type'] + args
+    self.cflags += ['-Wno-return-type'] + args
     self.do_runf('core/test_ubsan_full_no_return.cpp',
                  expected_output='.cpp:1:5: runtime error: execution reached the end of a value-returning function without returning a value', assert_returncode=NON_ZERO)
 
@@ -8896,7 +8896,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_wasm2js('TODO: sanitizers in wasm2js')
   @no_esm_integration('sanitizers do not support WASM_ESM_INTEGRATION')
   def test_ubsan_full_left_shift(self, args):
-    self.emcc_args += args
+    self.cflags += args
     self.do_runf(
       'core/test_ubsan_full_left_shift.c',
       assert_all=True,
@@ -8915,9 +8915,9 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_ubsan_full_null_ref(self, args):
     if '-sMAIN_MODULE=2' in args:
       self.check_dylink()
-    if is_sanitizing(self.emcc_args):
+    if is_sanitizing(self.cflags):
       self.skipTest('test is specific to null sanitizer')
-    self.emcc_args += args
+    self.cflags += args
     self.do_runf(
       'core/test_ubsan_full_null_ref.cpp',
       assert_all=True,
@@ -8932,7 +8932,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_sanitize_vptr(self):
     self.do_runf(
       'core/test_sanitize_vptr.cpp',
-      emcc_args=['-fsanitize=vptr'],
+      cflags=['-fsanitize=vptr'],
       assert_all=True,
       expected_output=[
         ".cpp:18:10: runtime error: downcast of address",
@@ -8960,7 +8960,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
         self.skipTest('EVAL_CTORS does not support source maps')
 
     create_file('pre.js', 'Module.UBSAN_OPTIONS = "print_stacktrace=1";')
-    self.emcc_args += ['-fsanitize=null', g_flag, '--pre-js=pre.js']
+    self.cflags += ['-fsanitize=null', g_flag, '--pre-js=pre.js']
     self.set_setting('ALLOW_MEMORY_GROWTH')
     self.do_runf('core/test_ubsan_full_null_ref.cpp',
                  assert_all=True, expected_output=expected_output)
@@ -8978,11 +8978,11 @@ NODEFS is no longer included by default; build with -lnodefs.js
         return mismatch;
       }
       '''
-    self.emcc_args.append('-fsanitize=undefined')
+    self.cflags.append('-fsanitize=undefined')
     self.do_run(src, 'ok\n')
 
   def test_template_class_deduction(self):
-    self.emcc_args += ['-std=c++17']
+    self.cflags += ['-std=c++17']
     self.do_core_test('test_template_class_deduction.cpp')
 
   @asan
@@ -8991,7 +8991,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     'cpp': ['test_asan_no_error.cpp'],
   })
   def test_asan_no_error(self, name):
-    self.emcc_args.append('-fsanitize=address')
+    self.cflags.append('-fsanitize=address')
     self.set_setting('ALLOW_MEMORY_GROWTH')
     self.set_setting('INITIAL_MEMORY', '300mb')
     self.do_runf('core/' + name, '', assert_returncode=NON_ZERO)
@@ -9055,28 +9055,28 @@ NODEFS is no longer included by default; build with -lnodefs.js
     ]),
   })
   def test_asan(self, name, expected_output, cflags=None):
-    if '-Oz' in self.emcc_args:
+    if '-Oz' in self.cflags:
       self.skipTest('-Oz breaks source maps')
 
-    self.emcc_args.append('-fsanitize=address')
+    self.cflags.append('-fsanitize=address')
     self.set_setting('ALLOW_MEMORY_GROWTH')
     self.set_setting('INITIAL_MEMORY', '300mb')
     if cflags:
-      self.emcc_args += cflags
+      self.cflags += cflags
     self.do_runf('core/' + name,
                  expected_output=expected_output, assert_all=True,
                  check_for_error=False, assert_returncode=NON_ZERO)
 
   @asan
   def test_asan_js_stack_op(self):
-    self.emcc_args.append('-fsanitize=address')
+    self.cflags.append('-fsanitize=address')
     self.set_setting('ALLOW_MEMORY_GROWTH')
     self.set_setting('INITIAL_MEMORY', '300mb')
     self.do_runf('core/test_asan_js_stack_op.c', 'Hello, World!')
 
   @asan
   def test_asan_api(self):
-    self.emcc_args.append('-fsanitize=address')
+    self.cflags.append('-fsanitize=address')
     self.set_setting('INITIAL_MEMORY', '300mb')
     self.do_core_test('test_asan_api.c')
 
@@ -9085,7 +9085,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # the bug is that createModule() returns undefined, instead of the
     # proper Promise object.
     create_file('post.js', 'if (!(createModule() instanceof Promise)) throw `Promise was not returned (${typeof createModule()})`;\n')
-    self.emcc_args += ['-fsanitize=address', '--extern-post-js=post.js']
+    self.cflags += ['-fsanitize=address', '--extern-post-js=post.js']
     self.set_setting('MODULARIZE')
     self.set_setting('EXPORT_NAME', 'createModule')
     self.set_setting('USE_CLOSURE_COMPILER')
@@ -9112,7 +9112,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
     self.set_setting('STACK_SIZE', 65536)
     self.set_setting('PROXY_TO_PTHREAD')
-    self.emcc_args.append('-pthread')
+    self.cflags.append('-pthread')
     if self.is_optimizing():
       expected = ['Aborted(stack overflow']
     else:
@@ -9161,7 +9161,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     ''', ['Aborted(stack overflow', '__handle_stack_overflow'], assert_returncode=NON_ZERO, force_c=True)
 
   def test_fpic_static(self):
-    self.emcc_args.append('-fPIC')
+    self.cflags.append('-fPIC')
     self.do_core_test('test_hello_world.c')
 
   # Marked as impure since we don't have a wasi-threads is still
@@ -9183,7 +9183,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     'proxied': (['-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'],),
   })
   def test_pthread_c11_threads(self, args):
-    self.emcc_args += args
+    self.cflags += args
     self.set_setting('PTHREADS_DEBUG')
     if not self.has_changed_setting('INITIAL_MEMORY'):
       self.set_setting('INITIAL_MEMORY', '64mb')
@@ -9218,7 +9218,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_pthread_create_pool(self):
     # with a pool, we can synchronously depend on workers being available
     self.set_setting('PTHREAD_POOL_SIZE', 2)
-    self.emcc_args += ['-DALLOW_SYNC']
+    self.cflags += ['-DALLOW_SYNC']
     self.do_run_in_out_file_test('core/pthread/create.c')
 
   @node_pthreads
@@ -9226,27 +9226,27 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # with PROXY_TO_PTHREAD, we can synchronously depend on workers being available
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
-    self.emcc_args += ['-DALLOW_SYNC']
+    self.cflags += ['-DALLOW_SYNC']
     self.do_run_in_out_file_test('core/pthread/create.c')
 
   @node_pthreads
   def test_pthread_create_embind_stack_check(self):
     # embind should work with stack overflow checks (see #12356)
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
-    self.emcc_args += ['-lembind']
-    self.do_run_in_out_file_test('core/pthread/create.c', emcc_args=['-sDEFAULT_TO_CXX'])
+    self.cflags += ['-lembind']
+    self.do_run_in_out_file_test('core/pthread/create.c', cflags=['-sDEFAULT_TO_CXX'])
 
   @node_pthreads
   def test_pthread_exceptions(self):
     self.set_setting('PTHREAD_POOL_SIZE', 2)
-    self.emcc_args += ['-fexceptions']
+    self.cflags += ['-fexceptions']
     self.do_run_in_out_file_test('core/pthread/exceptions.cpp')
 
   @node_pthreads
   def test_pthread_exit_process(self):
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
-    self.emcc_args += ['-DEXIT_RUNTIME', '--pre-js', test_file('core/pthread/test_pthread_exit_runtime.pre.js'), '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized, onExit]']
+    self.cflags += ['-DEXIT_RUNTIME', '--pre-js', test_file('core/pthread/test_pthread_exit_runtime.pre.js'), '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized, onExit]']
     self.do_run_in_out_file_test('core/pthread/test_pthread_exit_runtime.c', assert_returncode=42)
 
   @node_pthreads
@@ -9269,7 +9269,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # Check that an unhandled promise rejection is propagated to the main thread
     # as an error.
     self.set_setting('PROXY_TO_PTHREAD')
-    self.emcc_args += ['--post-js', test_file('pthread/test_pthread_unhandledrejection.post.js')]
+    self.cflags += ['--post-js', test_file('pthread/test_pthread_unhandledrejection.post.js')]
     self.do_runf('pthread/test_pthread_unhandledrejection.c', 'passed')
 
   @node_pthreads
@@ -9280,10 +9280,10 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('USE_OFFSET_CONVERTER')
-    if '-sMODULARIZE' in self.emcc_args:
+    if '-sMODULARIZE' in self.cflags:
       self.set_setting('EXPORT_NAME', 'foo')
-    if '-g' in self.emcc_args:
-      self.emcc_args += ['-DDEBUG']
+    if '-g' in self.cflags:
+      self.cflags += ['-DDEBUG']
     self.do_runf('core/test_return_address.c', 'passed')
 
   def test_emscripten_atomics_stub(self):
@@ -9291,13 +9291,13 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @node_pthreads
   def test_emscripten_atomics(self):
-    self.emcc_args.append('-pthread')
+    self.cflags.append('-pthread')
     self.do_run_in_out_file_test('core/pthread/emscripten_atomics.c')
 
   @node_pthreads
   def test_emscripten_futexes(self):
-    self.emcc_args.append('-pthread')
-    self.emcc_args += ['-Wno-nonnull'] # This test explicitly checks behavior of passing NULL to emscripten_futex_wake().
+    self.cflags.append('-pthread')
+    self.cflags += ['-Wno-nonnull'] # This test explicitly checks behavior of passing NULL to emscripten_futex_wake().
     self.do_run_in_out_file_test('core/pthread/emscripten_futexes.c')
 
   @node_pthreads
@@ -9308,7 +9308,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @with_dylink_reversed
   @node_pthreads
   def test_pthread_dylink_basics(self):
-    self.emcc_args.append('-Wno-experimental')
+    self.cflags.append('-Wno-experimental')
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
     self.do_basic_dylink_test()
@@ -9316,7 +9316,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @needs_dylink
   @node_pthreads
   def test_pthread_dylink(self):
-    self.emcc_args += ['-Wno-experimental', '-pthread']
+    self.cflags += ['-Wno-experimental', '-pthread']
     main = test_file('core/pthread/test_pthread_dylink.c')
 
     # test with a long .so name, as a regression test for
@@ -9325,7 +9325,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     very_long_name = 'very_very_very_very_very_very_very_very_very_long.so'
 
     self.dylink_testf(main, so_name=very_long_name,
-                      main_emcc_args=['-sPTHREAD_POOL_SIZE=2'])
+                      main_cflags=['-sPTHREAD_POOL_SIZE=2'])
 
   @parameterized({
     '': (['-sNO_AUTOLOAD_DYLIBS'],),
@@ -9334,24 +9334,24 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @needs_dylink
   @node_pthreads
   def test_pthread_dylink_entry_point(self, args):
-    self.emcc_args += ['-Wno-experimental', '-pthread']
+    self.cflags += ['-Wno-experimental', '-pthread']
     main = test_file('core/pthread/test_pthread_dylink_entry_point.c')
-    self.dylink_testf(main, emcc_args=args, main_emcc_args=['-sPTHREAD_POOL_SIZE=1'])
+    self.dylink_testf(main, cflags=args, main_cflags=['-sPTHREAD_POOL_SIZE=1'])
 
   @needs_dylink
   @node_pthreads
   def test_pthread_dylink_exceptions(self):
-    self.emcc_args += ['-Wno-experimental', '-pthread']
-    self.emcc_args.append('-fexceptions')
+    self.cflags += ['-Wno-experimental', '-pthread']
+    self.cflags.append('-fexceptions')
     self.dylink_testf(test_file('core/pthread/test_pthread_dylink_exceptions.cpp'))
 
   @needs_dylink
   @node_pthreads
   def test_pthread_dlopen(self):
-    self.emcc_args += ['-Wno-experimental', '-pthread']
+    self.cflags += ['-Wno-experimental', '-pthread']
     self.build_dlfcn_lib(test_file('core/pthread/test_pthread_dlopen_side.c'))
 
-    self.emcc_args += ['--embed-file', 'liblib.so@libside.so']
+    self.cflags += ['--embed-file', 'liblib.so@libside.so']
     self.prep_dlfcn_main()
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('PROXY_TO_PTHREAD')
@@ -9366,7 +9366,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
      self.skipTest('https://github.com/emscripten-core/emscripten/issues/18887')
 
     nthreads = 10
-    self.emcc_args += ['-Wno-experimental', '-pthread']
+    self.cflags += ['-Wno-experimental', '-pthread']
     self.build_dlfcn_lib(test_file('core/pthread/test_pthread_dlopen_side.c'))
     for i in range(nthreads):
       shutil.copy('liblib.so', f'liblib{i}.so')
@@ -9381,16 +9381,16 @@ NODEFS is no longer included by default; build with -lnodefs.js
         jslib_func: () => err('hello from js')
       });
     ''')
-    self.emcc_args.append('--js-library=lib.js')
+    self.cflags.append('--js-library=lib.js')
     self.do_runf('core/pthread/test_pthread_dlopen_many.c',
                  ['side module ctor', 'main done', 'side module atexit'],
-                 emcc_args=[f'-DNUM_THREADS={nthreads}'],
+                 cflags=[f'-DNUM_THREADS={nthreads}'],
                  assert_all=True)
 
   @needs_dylink
   @node_pthreads
   def test_pthread_dlsym(self):
-    self.emcc_args += ['-Wno-experimental', '-pthread']
+    self.cflags += ['-Wno-experimental', '-pthread']
     self.build_dlfcn_lib(test_file('core/pthread/test_pthread_dlsym_side.c'))
 
     self.prep_dlfcn_main()
@@ -9401,16 +9401,16 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @needs_dylink
   @node_pthreads
   def test_pthread_dylink_tls(self):
-    self.emcc_args += ['-Wno-experimental', '-pthread']
+    self.cflags += ['-Wno-experimental', '-pthread']
     main = test_file('core/pthread/test_pthread_dylink_tls.c')
-    self.dylink_testf(main, main_emcc_args=['-sPTHREAD_POOL_SIZE=1'])
+    self.dylink_testf(main, main_cflags=['-sPTHREAD_POOL_SIZE=1'])
 
   @needs_dylink
   @node_pthreads
   def test_pthread_dylink_longjmp(self):
-    self.emcc_args += ['-Wno-experimental', '-pthread']
+    self.cflags += ['-Wno-experimental', '-pthread']
     main = test_file('core/pthread/test_pthread_dylink_longjmp.c')
-    self.dylink_testf(main, main_emcc_args=['-sPTHREAD_POOL_SIZE=1'])
+    self.dylink_testf(main, main_cflags=['-sPTHREAD_POOL_SIZE=1'])
 
   @needs_dylink
   @node_pthreads
@@ -9418,8 +9418,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # TODO: For some reason, -lhtml5 must be passed in -sSTRICT mode, but can NOT
     # be passed when not compiling in -sSTRICT mode. That does not seem intentional?
     if self.get_setting('STRICT'):
-      self.emcc_args += ['-lhtml5']
-    self.emcc_args += ['-Wno-experimental', '-pthread']
+      self.cflags += ['-lhtml5']
+    self.cflags += ['-Wno-experimental', '-pthread']
     self.set_setting('MAIN_MODULE')
     self.do_runf('hello_world.c')
 
@@ -9430,9 +9430,9 @@ NODEFS is no longer included by default; build with -lnodefs.js
   })
   def test_Module_dynamicLibraries(self, args):
     # test that Module.dynamicLibraries works with pthreads
-    self.emcc_args += args
-    self.emcc_args += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[dynamicLibraries]']
-    self.emcc_args += ['--js-library', 'lib.js']
+    self.cflags += args
+    self.cflags += ['--pre-js', 'pre.js', '-sINCOMING_MODULE_JS_API=[dynamicLibraries]']
+    self.cflags += ['--js-library', 'lib.js']
     # This test is for setting dynamicLibraries at runtime, so we don't
     # want emscripten loading `liblib.so` automatically (which it would
     # do without this setting)
@@ -9484,7 +9484,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_esm_integration('depends on wasmExports')
   def test_get_exported_function(self):
     self.set_setting('ALLOW_TABLE_GROWTH')
-    self.emcc_args += ['-lexports.js']
+    self.cflags += ['-lexports.js']
     self.do_core_test('test_get_exported_function.cpp')
 
   # Marked as impure since the WASI reactor modules (modules without main)
@@ -9494,7 +9494,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     if self.get_setting('STANDALONE_WASM'):
       # In standalone we don't support implicitly building without main.  The user has to explicitly
       # opt out (see below).
-      err = self.expect_fail([EMCC, test_file('core/test_ctors_no_main.cpp')] + self.get_emcc_args())
+      err = self.expect_fail([EMCC, test_file('core/test_ctors_no_main.cpp')] + self.get_cflags())
       self.assertContained('undefined symbol: main', err)
     elif not self.get_setting('STRICT'):
       # Traditionally in emscripten we allow main to be implicitly undefined.  This allows programs
@@ -9505,7 +9505,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
       # Disabling IGNORE_MISSING_MAIN should cause link to fail due to missing main
       self.set_setting('IGNORE_MISSING_MAIN', 0)
-      err = self.expect_fail([EMCC, test_file('core/test_ctors_no_main.cpp')] + self.get_emcc_args())
+      err = self.expect_fail([EMCC, test_file('core/test_ctors_no_main.cpp')] + self.get_cflags())
       self.assertContained('error: entry symbol not defined (pass --no-entry to suppress): main', err)
 
       # In non-standalone mode exporting an empty list of functions signal that we don't
@@ -9519,13 +9519,13 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @also_with_standalone_wasm(impure=True)
   def test_undefined_main_explicit(self):
     # If we pass --no-entry this test should compile without issue
-    self.emcc_args.append('--no-entry')
+    self.cflags.append('--no-entry')
     self.do_core_test('test_ctors_no_main.cpp')
 
   def test_undefined_main_wasm_output(self):
     if not can_do_standalone(self):
       self.skipTest('standalone mode only')
-    err = self.expect_fail([EMCC, '-o', 'out.wasm', test_file('core/test_ctors_no_main.cpp')] + self.get_emcc_args())
+    err = self.expect_fail([EMCC, '-o', 'out.wasm', test_file('core/test_ctors_no_main.cpp')] + self.get_cflags())
     self.assertContained('undefined symbol: main', err)
 
   @no_2gb('crashed wasmtime')
@@ -9553,14 +9553,14 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('ALLOW_TABLE_GROWTH')
     self.set_setting('EXPORTED_RUNTIME_METHODS', ['ccall', 'cwrap'])
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$addFunction', '$addOnPostRun'])
-    self.emcc_args += ['-lembind', '--post-js', test_file('core/test_abort_on_exceptions_post.js')]
+    self.cflags += ['-lembind', '--post-js', test_file('core/test_abort_on_exceptions_post.js')]
     self.do_core_test('test_abort_on_exceptions.cpp', interleaved_output=False)
 
   @no_esm_integration('ABORT_ON_WASM_EXCEPTIONS is not compatible with WASM_ESM_INTEGRATION')
   def test_abort_on_exceptions_main(self):
     # The unhandled exception wrappers should not kick in for exceptions thrown during main
     self.set_setting('ABORT_ON_WASM_EXCEPTIONS')
-    self.emcc_args.append('--minify=0')
+    self.cflags.append('--minify=0')
     output = self.do_runf('core/test_abort_on_exceptions_main.c', assert_returncode=NON_ZERO)
     # The exception should make it all the way out
     self.assertContained('Error: crash', output)
@@ -9582,15 +9582,15 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # TODO: For some reason, -lGL must be passed in -sSTRICT mode, but can NOT
     # be passed when not compiling in -sSTRICT mode. That does not seem intentional?
     if self.get_setting('STRICT'):
-      self.emcc_args += ['-lGL']
+      self.cflags += ['-lGL']
     self.set_setting('MAIN_MODULE')
-    self.emcc_args += ['-sGL_ENABLE_GET_PROC_ADDRESS']
+    self.cflags += ['-sGL_ENABLE_GET_PROC_ADDRESS']
     self.do_runf('core/test_gl_get_proc_address.c')
 
   @needs_dylink
   def test_main_module_js_symbol(self):
     self.set_setting('MAIN_MODULE', 2)
-    self.emcc_args += ['--js-library', test_file('core/test_main_module_js_symbol.js')]
+    self.cflags += ['--js-library', test_file('core/test_main_module_js_symbol.js')]
     self.do_runf('core/test_main_module_js_symbol.c')
 
   def test_emscripten_async_call(self):
@@ -9605,7 +9605,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     'no_dynamic_execution': (['-sDYNAMIC_EXECUTION=0'],),
   })
   def test_embind_lib_with_asyncify(self, args):
-    self.emcc_args += [
+    self.cflags += [
       '-lembind',
       '-sASYNCIFY',
       '-sASYNCIFY_IMPORTS=sleep_and_return',
@@ -9614,7 +9614,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
       '--no-entry',
       '-sINCOMING_MODULE_JS_API=[onRuntimeInitialized]',
     ]
-    self.emcc_args += args
+    self.cflags += args
     self.do_core_test('embind_lib_with_asyncify.cpp')
 
   @no_asan('asyncify stack operations confuse asan')
@@ -9631,9 +9631,9 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_wasm2js('wasm2js does not support reference types')
   @no_sanitize('.s files cannot be sanitized')
   def test_externref(self):
-    self.run_process([EMCC, '-c', test_file('core/test_externref.s'), '-o', 'asm.o'] + self.get_emcc_args(asm_only=True))
-    self.emcc_args += ['--js-library', test_file('core/test_externref.js')]
-    self.emcc_args += ['-mreference-types']
+    self.run_process([EMCC, '-c', test_file('core/test_externref.s'), '-o', 'asm.o'] + self.get_cflags(asm_only=True))
+    self.cflags += ['--js-library', test_file('core/test_externref.js')]
+    self.cflags += ['-mreference-types']
     self.do_core_test('test_externref.c', libraries=['asm.o'])
 
   @parameterized({
@@ -9644,7 +9644,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_wasm2js('wasm2js does not support reference types')
   @no_asan('https://github.com/llvm/llvm-project/pull/83196')
   def test_externref_emjs(self, dynlink):
-    self.emcc_args += ['-mreference-types']
+    self.cflags += ['-mreference-types']
     self.node_args += shared.node_reference_types_flags(self.get_nodejs())
     if dynlink:
       self.check_dylink()
@@ -9658,12 +9658,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_jslib_i64_params(self):
     # Tests the defineI64Param and receiveI64ParamAsI53 helpers that are
     # used to recieve i64 argument in syscalls.
-    self.emcc_args += ['--js-library=' + test_file('core/test_jslib_i64_params.js')]
+    self.cflags += ['--js-library=' + test_file('core/test_jslib_i64_params.js')]
     self.do_core_test('test_jslib_i64_params.c')
 
   def test_main_reads_args(self):
-    self.run_process([EMCC, '-c', test_file('core/test_main_reads_args_real.c'), '-o', 'real.o'] + self.get_emcc_args(compile_only=True))
-    self.do_core_test('test_main_reads_args.c', emcc_args=['real.o'], regex=True)
+    self.run_process([EMCC, '-c', test_file('core/test_main_reads_args_real.c'), '-o', 'real.o'] + self.get_cflags(compile_only=True))
+    self.do_core_test('test_main_reads_args.c', cflags=['real.o'], regex=True)
 
   @requires_node
   def test_promise(self):
@@ -9690,7 +9690,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # `--from-emcc` needed here otherwise the output defines `var Module =` which will shadow the
     # global `Module`.
     self.run_process([FILE_PACKAGER, 'test.data', '--preload', 'file1.txt', 'file2.txt', '--from-emcc', '--js-output=script2.js'])
-    self.do_runf('test_emscripten_async_load_script.c', emcc_args=['-sFORCE_FILESYSTEM'])
+    self.do_runf('test_emscripten_async_load_script.c', cflags=['-sFORCE_FILESYSTEM'])
 
   @node_pthreads
   @no_sanitize('sanitizers do not support WASM_WORKERS')
@@ -9698,22 +9698,22 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @also_with_modularize
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
   def test_wasm_worker_hello(self):
-    if self.is_wasm2js() and '-sMODULARIZE' in self.emcc_args:
+    if self.is_wasm2js() and '-sMODULARIZE' in self.cflags:
       self.skipTest('WASM2JS + MODULARIZE + WASM_WORKERS is not supported')
     self.maybe_closure()
-    self.do_run_in_out_file_test('wasm_worker/hello_wasm_worker.c', emcc_args=['-sWASM_WORKERS'])
+    self.do_run_in_out_file_test('wasm_worker/hello_wasm_worker.c', cflags=['-sWASM_WORKERS'])
 
   @node_pthreads
   @no_sanitize('sanitizers do not support WASM_WORKERS')
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
   def test_wasm_worker_malloc(self):
-    self.do_run_in_out_file_test('wasm_worker/malloc_wasm_worker.c', emcc_args=['-sWASM_WORKERS'])
+    self.do_run_in_out_file_test('wasm_worker/malloc_wasm_worker.c', cflags=['-sWASM_WORKERS'])
 
   @node_pthreads
   @no_sanitize('sanitizers do not support WASM_WORKERS')
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
   def test_wasm_worker_wait_async(self):
-    self.do_runf('atomic/test_wait_async.c', emcc_args=['-sWASM_WORKERS'])
+    self.do_runf('atomic/test_wait_async.c', cflags=['-sWASM_WORKERS'])
 
   @parameterized({
     '': ([],),
@@ -9721,13 +9721,13 @@ NODEFS is no longer included by default; build with -lnodefs.js
   })
   @esm_integration
   def test_esm_integration_main(self, args):
-    self.do_runf('hello_world.c', 'hello, world!', emcc_args=args)
+    self.do_runf('hello_world.c', 'hello, world!', cflags=args)
 
   @esm_integration
   def test_esm_integration(self):
     # TODO(sbc): WASM_ESM_INTEGRATION doesn't currently work with closure.
     # self.maybe_closure()
-    self.run_process([EMCC, '-o', 'hello_world.mjs', '-sINCOMING_MODULE_JS_API=arguments', '-sEXPORTED_RUNTIME_METHODS=err', '-sEXPORTED_FUNCTIONS=_main,stringToNewUTF8', test_file('core/test_esm_integration.c')] + self.get_emcc_args())
+    self.run_process([EMCC, '-o', 'hello_world.mjs', '-sINCOMING_MODULE_JS_API=arguments', '-sEXPORTED_RUNTIME_METHODS=err', '-sEXPORTED_FUNCTIONS=_main,stringToNewUTF8', test_file('core/test_esm_integration.c')] + self.get_cflags())
     create_file('runner.mjs', '''
       import init, { err, stringToNewUTF8, _main, _foo } from "./hello_world.mjs";
       await init({arguments: ['foo', 'bar']});
@@ -9737,7 +9737,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.assertFileContents(test_file('core/test_esm_integration.expected.mjs'), read_file('hello_world.mjs'))
 
   def test_modularize_instance_hello(self):
-    self.do_core_test('test_hello_world.c', emcc_args=['-sMODULARIZE=instance', '-Wno-experimental'])
+    self.do_core_test('test_hello_world.c', cflags=['-sMODULARIZE=instance', '-Wno-experimental'])
 
   @parameterized({
     '': ([],),
@@ -9757,7 +9757,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
                       '-sEXPORTED_RUNTIME_METHODS=baz,addOnExit,HEAP32,runtimeKeepalivePush,runtimeKeepalivePop',
                       '-sEXPORTED_FUNCTIONS=_bar,_main,qux',
                       '--js-library', 'library.js',
-                      '-o', 'modularize_instance.mjs'] + args + self.get_emcc_args())
+                      '-o', 'modularize_instance.mjs'] + args + self.get_cflags())
 
     create_file('runner.mjs', '''
       import { strict as assert } from 'assert';
@@ -9784,7 +9784,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
                       '-lembind',
                       '-sEXPORTED_RUNTIME_METHODS=runtimeKeepalivePush,runtimeKeepalivePop',
                       '-sEMBIND_AOT',
-                      '-o', 'modularize_instance_embind.mjs'] + self.get_emcc_args())
+                      '-o', 'modularize_instance_embind.mjs'] + self.get_cflags())
 
     create_file('runner.mjs', '''
       import init, { foo, Bar, runtimeKeepalivePush, runtimeKeepalivePop } from "./modularize_instance_embind.mjs";
@@ -9821,20 +9821,20 @@ NODEFS is no longer included by default; build with -lnodefs.js
 '''
     self.set_setting('NODERAWFS')
     self.set_setting('EXIT_RUNTIME')
-    self.do_core_test('test_hello_world.c', emcc_args=['-fprofile-instr-generate', '-fcoverage-mapping', '-g'])
+    self.do_core_test('test_hello_world.c', cflags=['-fprofile-instr-generate', '-fcoverage-mapping', '-g'])
     self.assertExists('default.profraw')
     self.run_process([LLVM_PROFDATA, 'merge', '-sparse', 'default.profraw', '-o', 'out.profdata'])
     self.assertExists('out.profdata')
     self.assertEqual(expected, self.run_process([LLVM_COV, 'show', 'test_hello_world.wasm', '-instr-profile=out.profdata'], stdout=PIPE).stdout)
 
 # Generate tests for everything
-def make_run(name, emcc_args=None, settings=None, env=None, # noqa
+def make_run(name, cflags=None, settings=None, env=None, # noqa
              require_v8=False, v8_args=None,
              require_node=False, node_args=None,
              require_wasm64=False,
              init=None):
-  if emcc_args is None:
-    emcc_args = {}
+  if cflags is None:
+    cflags = {}
   if env is None:
     env = {}
   if settings is None:
@@ -9842,7 +9842,7 @@ def make_run(name, emcc_args=None, settings=None, env=None, # noqa
   if settings:
     # Until we create a way to specify link-time settings separately from compile-time settings
     # we need to pass this flag here to avoid warnings from compile-only commands.
-    emcc_args.append('-Wno-unused-command-line-argument')
+    cflags.append('-Wno-unused-command-line-argument')
 
   TT = type(name, (TestCoreBase,), dict(run_name=name, env=env, __module__=__name__))  # noqa
 
@@ -9867,7 +9867,7 @@ def make_run(name, emcc_args=None, settings=None, env=None, # noqa
     for k, v in settings.items():
       self.set_setting(k, v)
 
-    self.emcc_args += emcc_args
+    self.cflags += cflags
 
     if node_args:
       self.node_args += node_args
@@ -9898,87 +9898,87 @@ def make_run(name, emcc_args=None, settings=None, env=None, # noqa
 # https://github.com/emscripten-core/emscripten/pull/15480
 
 # Main wasm test modes
-core0 = make_run('core0', emcc_args=['-O0'])
-core0g = make_run('core0g', emcc_args=['-O0', '-g'])
-core1 = make_run('core1', emcc_args=['-O1'])
-core2 = make_run('core2', emcc_args=['-O2'])
-core2g = make_run('core2g', emcc_args=['-O2', '-g'])
-core3 = make_run('core3', emcc_args=['-O3'])
-cores = make_run('cores', emcc_args=['-Os'])
-corez = make_run('corez', emcc_args=['-Oz'])
+core0 = make_run('core0', cflags=['-O0'])
+core0g = make_run('core0g', cflags=['-O0', '-g'])
+core1 = make_run('core1', cflags=['-O1'])
+core2 = make_run('core2', cflags=['-O2'])
+core2g = make_run('core2g', cflags=['-O2', '-g'])
+core3 = make_run('core3', cflags=['-O3'])
+cores = make_run('cores', cflags=['-Os'])
+corez = make_run('corez', cflags=['-Oz'])
 
 # Test >2gb memory addresses
-core_2gb = make_run('core_2gb', emcc_args=['--profiling-funcs'],
+core_2gb = make_run('core_2gb', cflags=['--profiling-funcs'],
                     settings={'INITIAL_MEMORY': '2200mb', 'GLOBAL_BASE': '2gb'})
 
 # MEMORY64=1
-wasm64 = make_run('wasm64', emcc_args=['-Wno-experimental', '--profiling-funcs'],
+wasm64 = make_run('wasm64', cflags=['-Wno-experimental', '--profiling-funcs'],
                   settings={'MEMORY64': 1}, require_wasm64=True, require_node=True)
-wasm64_v8 = make_run('wasm64_v8', emcc_args=['-Wno-experimental', '--profiling-funcs'],
+wasm64_v8 = make_run('wasm64_v8', cflags=['-Wno-experimental', '--profiling-funcs'],
                      settings={'MEMORY64': 1}, require_wasm64=True, require_v8=True)
 # Run the wasm64 tests with all memory offsets > 4gb.  Be careful running this test
 # suite with any kind of parallelism.
-wasm64_4gb = make_run('wasm64_4gb', emcc_args=['-Wno-experimental', '--profiling-funcs'],
+wasm64_4gb = make_run('wasm64_4gb', cflags=['-Wno-experimental', '--profiling-funcs'],
                       settings={'MEMORY64': 1, 'INITIAL_MEMORY': '4200mb', 'GLOBAL_BASE': '4gb'},
                       require_wasm64=True)
 # MEMORY64=2, or "lowered"
-wasm64l = make_run('wasm64l', emcc_args=['-O1', '-Wno-experimental', '--profiling-funcs'],
+wasm64l = make_run('wasm64l', cflags=['-O1', '-Wno-experimental', '--profiling-funcs'],
                    settings={'MEMORY64': 2},
                    init=lambda self: shared.node_bigint_flags(self.get_nodejs()))
 
-lto0 = make_run('lto0', emcc_args=['-flto', '-O0'])
-lto1 = make_run('lto1', emcc_args=['-flto', '-O1'])
-lto2 = make_run('lto2', emcc_args=['-flto', '-O2'])
-lto3 = make_run('lto3', emcc_args=['-flto', '-O3'])
-ltos = make_run('ltos', emcc_args=['-flto', '-Os'])
-ltoz = make_run('ltoz', emcc_args=['-flto', '-Oz'])
+lto0 = make_run('lto0', cflags=['-flto', '-O0'])
+lto1 = make_run('lto1', cflags=['-flto', '-O1'])
+lto2 = make_run('lto2', cflags=['-flto', '-O2'])
+lto3 = make_run('lto3', cflags=['-flto', '-O3'])
+ltos = make_run('ltos', cflags=['-flto', '-Os'])
+ltoz = make_run('ltoz', cflags=['-flto', '-Oz'])
 
-thinlto0 = make_run('thinlto0', emcc_args=['-flto=thin', '-O0'])
-thinlto1 = make_run('thinlto1', emcc_args=['-flto=thin', '-O1'])
-thinlto2 = make_run('thinlto2', emcc_args=['-flto=thin', '-O2'])
-thinlto3 = make_run('thinlto3', emcc_args=['-flto=thin', '-O3'])
-thinltos = make_run('thinltos', emcc_args=['-flto=thin', '-Os'])
-thinltoz = make_run('thinltoz', emcc_args=['-flto=thin', '-Oz'])
+thinlto0 = make_run('thinlto0', cflags=['-flto=thin', '-O0'])
+thinlto1 = make_run('thinlto1', cflags=['-flto=thin', '-O1'])
+thinlto2 = make_run('thinlto2', cflags=['-flto=thin', '-O2'])
+thinlto3 = make_run('thinlto3', cflags=['-flto=thin', '-O3'])
+thinltos = make_run('thinltos', cflags=['-flto=thin', '-Os'])
+thinltoz = make_run('thinltoz', cflags=['-flto=thin', '-Oz'])
 
-wasm2js0 = make_run('wasm2js0', emcc_args=['-O0'], settings={'WASM': 0})
-wasm2js1 = make_run('wasm2js1', emcc_args=['-O1'], settings={'WASM': 0})
-wasm2js2 = make_run('wasm2js2', emcc_args=['-O2'], settings={'WASM': 0})
-wasm2js3 = make_run('wasm2js3', emcc_args=['-O3'], settings={'WASM': 0})
-wasm2jss = make_run('wasm2jss', emcc_args=['-Os'], settings={'WASM': 0})
-wasm2jsz = make_run('wasm2jsz', emcc_args=['-Oz'], settings={'WASM': 0})
+wasm2js0 = make_run('wasm2js0', cflags=['-O0'], settings={'WASM': 0})
+wasm2js1 = make_run('wasm2js1', cflags=['-O1'], settings={'WASM': 0})
+wasm2js2 = make_run('wasm2js2', cflags=['-O2'], settings={'WASM': 0})
+wasm2js3 = make_run('wasm2js3', cflags=['-O3'], settings={'WASM': 0})
+wasm2jss = make_run('wasm2jss', cflags=['-Os'], settings={'WASM': 0})
+wasm2jsz = make_run('wasm2jsz', cflags=['-Oz'], settings={'WASM': 0})
 
 # Secondary test modes - run directly when there is a specific need
 
 # features
 
-simd2 = make_run('simd2', emcc_args=['-O2', '-msimd128'])
-bulkmem2 = make_run('bulkmem2', emcc_args=['-O2', '-mbulk-memory'])
-wasmfs = make_run('wasmfs', emcc_args=['-O2', '-DWASMFS'], settings={'WASMFS': 1})
+simd2 = make_run('simd2', cflags=['-O2', '-msimd128'])
+bulkmem2 = make_run('bulkmem2', cflags=['-O2', '-mbulk-memory'])
+wasmfs = make_run('wasmfs', cflags=['-O2', '-DWASMFS'], settings={'WASMFS': 1})
 
 # SAFE_HEAP/STACK_OVERFLOW_CHECK
-core0s = make_run('core2s', emcc_args=['-g'], settings={'SAFE_HEAP': 1})
-core2s = make_run('core2s', emcc_args=['-O2'], settings={'SAFE_HEAP': 1})
-core2ss = make_run('core2ss', emcc_args=['-O2'], settings={'STACK_OVERFLOW_CHECK': 2})
+core0s = make_run('core2s', cflags=['-g'], settings={'SAFE_HEAP': 1})
+core2s = make_run('core2s', cflags=['-O2'], settings={'SAFE_HEAP': 1})
+core2ss = make_run('core2ss', cflags=['-O2'], settings={'STACK_OVERFLOW_CHECK': 2})
 
-bigint = make_run('bigint', emcc_args=['--profiling-funcs'], settings={'WASM_BIGINT': 1},
+bigint = make_run('bigint', cflags=['--profiling-funcs'], settings={'WASM_BIGINT': 1},
                   init=lambda self: shared.node_bigint_flags(self.get_nodejs()))
 
 esm_integration = make_run('esm_integration', init=lambda self: self.setup_esm_integration())
-instance = make_run('instance', emcc_args=['-Wno-experimental'], settings={'MODULARIZE': 'instance'})
+instance = make_run('instance', cflags=['-Wno-experimental'], settings={'MODULARIZE': 'instance'})
 
 # Add DEFAULT_TO_CXX=0
-strict = make_run('strict', emcc_args=[], settings={'STRICT': 1})
-strict_js = make_run('strict_js', emcc_args=[], settings={'STRICT_JS': 1})
+strict = make_run('strict', cflags=[], settings={'STRICT': 1})
+strict_js = make_run('strict_js', cflags=[], settings={'STRICT_JS': 1})
 
-ubsan = make_run('ubsan', emcc_args=['-fsanitize=undefined', '--profiling'])
-lsan = make_run('lsan', emcc_args=['-fsanitize=leak', '--profiling'], settings={'ALLOW_MEMORY_GROWTH': 1})
-asan = make_run('asan', emcc_args=['-fsanitize=address', '--profiling'], settings={'ALLOW_MEMORY_GROWTH': 1})
-asani = make_run('asani', emcc_args=['-fsanitize=address', '--profiling', '--pre-js', os.path.join(os.path.dirname(__file__), 'asan-no-leak.js')],
+ubsan = make_run('ubsan', cflags=['-fsanitize=undefined', '--profiling'])
+lsan = make_run('lsan', cflags=['-fsanitize=leak', '--profiling'], settings={'ALLOW_MEMORY_GROWTH': 1})
+asan = make_run('asan', cflags=['-fsanitize=address', '--profiling'], settings={'ALLOW_MEMORY_GROWTH': 1})
+asani = make_run('asani', cflags=['-fsanitize=address', '--profiling', '--pre-js', os.path.join(os.path.dirname(__file__), 'asan-no-leak.js')],
                  settings={'ALLOW_MEMORY_GROWTH': 1})
 
 # Experimental modes (not tested by CI)
-minimal0 = make_run('minimal0', emcc_args=['-g'], settings={'MINIMAL_RUNTIME': 1})
-llvmlibc = make_run('llvmlibc', emcc_args=['-lllvmlibc'])
+minimal0 = make_run('minimal0', cflags=['-g'], settings={'MINIMAL_RUNTIME': 1})
+llvmlibc = make_run('llvmlibc', cflags=['-lllvmlibc'])
 
 # TestCoreBase is just a shape for the specific subclasses, we don't test it itself
 del TestCoreBase # noqa

--- a/test/test_interactive.py
+++ b/test/test_interactive.py
@@ -25,37 +25,37 @@ class interactive(BrowserCore):
     print()
 
   def test_html5_fullscreen(self):
-    self.btest('test_html5_fullscreen.c', expected='0', emcc_args=['-sDISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR', '-sEXPORTED_FUNCTIONS=_requestFullscreen,_enterSoftFullscreen,_main', '--shell-file', test_file('test_html5_fullscreen.html')])
+    self.btest('test_html5_fullscreen.c', expected='0', cflags=['-sDISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR', '-sEXPORTED_FUNCTIONS=_requestFullscreen,_enterSoftFullscreen,_main', '--shell-file', test_file('test_html5_fullscreen.html')])
 
   def test_html5_emscripten_exit_with_escape(self):
-    self.btest('test_html5_emscripten_exit_fullscreen.c', expected='1', emcc_args=['-DEXIT_WITH_F'])
+    self.btest('test_html5_emscripten_exit_fullscreen.c', expected='1', cflags=['-DEXIT_WITH_F'])
 
   def test_html5_emscripten_exit_fullscreen(self):
     self.btest('test_html5_emscripten_exit_fullscreen.c', expected='1')
 
   def test_html5_mouse(self):
-    self.btest('test_html5_mouse.c', expected='0', emcc_args=['-sDISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR'])
+    self.btest('test_html5_mouse.c', expected='0', cflags=['-sDISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR'])
 
   def test_html5_pointerlockerror(self):
-    self.btest('test_html5_pointerlockerror.c', expected='0', emcc_args=['-sDISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR'])
+    self.btest('test_html5_pointerlockerror.c', expected='0', cflags=['-sDISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR'])
 
   def test_sdl_mousewheel(self):
     self.btest_exit('test_sdl_mousewheel.c')
 
   def test_sdl_touch(self):
-    self.btest('test_sdl_touch.c', emcc_args=['-O2', '-g1', '--closure=1'], expected='0')
+    self.btest('test_sdl_touch.c', cflags=['-O2', '-g1', '--closure=1'], expected='0')
 
   def test_sdl_wm_togglefullscreen(self):
     self.btest_exit('test_sdl_wm_togglefullscreen.c')
 
   def test_sdl_key_test(self):
-    self.btest_exit('test_sdl_key_test.c', emcc_args=['-sRUNTIME_DEBUG'])
+    self.btest_exit('test_sdl_key_test.c', cflags=['-sRUNTIME_DEBUG'])
 
   def test_sdl_fullscreen_samecanvassize(self):
     self.btest_exit('test_sdl_fullscreen_samecanvassize.c')
 
   def test_sdl2_togglefullscreen(self):
-    self.btest_exit('browser/test_sdl_togglefullscreen.c', emcc_args=['-sUSE_SDL=2'])
+    self.btest_exit('browser/test_sdl_togglefullscreen.c', cflags=['-sUSE_SDL=2'])
 
   def test_sdl_audio(self):
     shutil.copy(test_file('sounds/alarmvictory_1.ogg'), 'sound.ogg')
@@ -65,7 +65,7 @@ class interactive(BrowserCore):
     create_file('bad.ogg', 'I claim to be audio, but am lying')
 
     # use closure to check for a possible bug with closure minifying away newer Audio() attributes
-    self.btest_exit('test_sdl_audio.c', emcc_args=['--preload-file', 'sound.ogg', '--preload-file', 'sound2.wav', '--embed-file', 'the_entertainer.ogg', '--preload-file', 'noise.ogg', '--preload-file', 'bad.ogg'])
+    self.btest_exit('test_sdl_audio.c', cflags=['--preload-file', 'sound.ogg', '--preload-file', 'sound2.wav', '--embed-file', 'the_entertainer.ogg', '--preload-file', 'noise.ogg', '--preload-file', 'bad.ogg'])
 
     # print('SDL2')
     # check sdl2 as well
@@ -83,17 +83,17 @@ class interactive(BrowserCore):
   def test_sdl_audio_mix_channels(self, args):
     shutil.copy(test_file('sounds/noise.ogg'), 'sound.ogg')
 
-    self.btest_exit('test_sdl_audio_mix_channels.c', emcc_args=['-O2', '--minify=0', '--preload-file', 'sound.ogg'] + args)
+    self.btest_exit('test_sdl_audio_mix_channels.c', cflags=['-O2', '--minify=0', '--preload-file', 'sound.ogg'] + args)
 
   def test_sdl_audio_mix_channels_halt(self):
     shutil.copy(test_file('sounds/the_entertainer.ogg'), '.')
 
-    self.btest_exit('test_sdl_audio_mix_channels_halt.c', emcc_args=['-O2', '--minify=0', '--preload-file', 'the_entertainer.ogg'])
+    self.btest_exit('test_sdl_audio_mix_channels_halt.c', cflags=['-O2', '--minify=0', '--preload-file', 'the_entertainer.ogg'])
 
   def test_sdl_audio_mix_playing(self):
     shutil.copy(test_file('sounds/noise.ogg'), '.')
 
-    self.btest_exit('test_sdl_audio_mix_playing.c', emcc_args=['-O2', '--minify=0', '--preload-file', 'noise.ogg'])
+    self.btest_exit('test_sdl_audio_mix_playing.c', cflags=['-O2', '--minify=0', '--preload-file', 'noise.ogg'])
 
   @parameterized({
     '': ([],),
@@ -104,21 +104,21 @@ class interactive(BrowserCore):
     shutil.copy(test_file('sounds/the_entertainer.ogg'), 'music.ogg')
     shutil.copy(test_file('sounds/noise.ogg'), 'noise.ogg')
 
-    self.btest_exit('test_sdl_audio_mix.c', emcc_args=['-O2', '--minify=0', '--preload-file', 'sound.ogg', '--preload-file', 'music.ogg', '--preload-file', 'noise.ogg'] + args)
+    self.btest_exit('test_sdl_audio_mix.c', cflags=['-O2', '--minify=0', '--preload-file', 'sound.ogg', '--preload-file', 'music.ogg', '--preload-file', 'noise.ogg'] + args)
 
   def test_sdl_audio_panning(self):
     shutil.copy(test_file('sounds/the_entertainer.wav'), '.')
 
     # use closure to check for a possible bug with closure minifying away newer Audio() attributes
-    self.btest_exit('test_sdl_audio_panning.c', emcc_args=['-O2', '--closure=1', '--minify=0', '--preload-file', 'the_entertainer.wav', '-sEXPORTED_FUNCTIONS=_main,_play'])
+    self.btest_exit('test_sdl_audio_panning.c', cflags=['-O2', '--closure=1', '--minify=0', '--preload-file', 'the_entertainer.wav', '-sEXPORTED_FUNCTIONS=_main,_play'])
 
   def test_sdl_audio_beeps(self):
     # use closure to check for a possible bug with closure minifying away newer Audio() attributes
-    self.btest_exit('test_sdl_audio_beep.cpp', emcc_args=['-O2', '--closure=1', '--minify=0', '-sDISABLE_EXCEPTION_CATCHING=0', '-o', 'page.html'])
+    self.btest_exit('test_sdl_audio_beep.cpp', cflags=['-O2', '--closure=1', '--minify=0', '-sDISABLE_EXCEPTION_CATCHING=0', '-o', 'page.html'])
 
   def test_sdl2_mixer_wav(self):
     shutil.copy(test_file('sounds/the_entertainer.wav'), 'sound.wav')
-    self.btest_exit('browser/test_sdl2_mixer_wav.c', emcc_args=[
+    self.btest_exit('browser/test_sdl2_mixer_wav.c', cflags=[
       '-O2',
       '-sUSE_SDL=2',
       '-sUSE_SDL_MIXER=2',
@@ -133,7 +133,7 @@ class interactive(BrowserCore):
   })
   def test_sdl2_mixer_music(self, formats, flags, music_name):
     shutil.copy(test_file('sounds', music_name), '.')
-    self.btest('browser/test_sdl2_mixer_music.c', expected='exit:0', emcc_args=[
+    self.btest('browser/test_sdl2_mixer_music.c', expected='exit:0', cflags=[
       '-O2',
       '--minify=0',
       '--preload-file', music_name,
@@ -148,7 +148,7 @@ class interactive(BrowserCore):
   def test_sdl2_audio_beeps(self):
     # use closure to check for a possible bug with closure minifying away newer Audio() attributes
     # TODO: investigate why this does not pass
-    self.btest_exit('browser/test_sdl2_audio_beep.cpp', emcc_args=['-O2', '--closure=1', '--minify=0', '-sDISABLE_EXCEPTION_CATCHING=0', '-sUSE_SDL=2'])
+    self.btest_exit('browser/test_sdl2_audio_beep.cpp', cflags=['-O2', '--closure=1', '--minify=0', '-sDISABLE_EXCEPTION_CATCHING=0', '-sUSE_SDL=2'])
 
   @parameterized({
     '': ([],),
@@ -156,49 +156,49 @@ class interactive(BrowserCore):
   })
   def test_openal_playback(self, args):
     shutil.copy(test_file('sounds/audio.wav'), '.')
-    self.btest('openal/test_openal_playback.c', '1', emcc_args=['-O2', '--preload-file', 'audio.wav'] + args)
+    self.btest('openal/test_openal_playback.c', '1', cflags=['-O2', '--preload-file', 'audio.wav'] + args)
 
   def test_openal_buffers(self):
-    self.btest_exit('openal/test_openal_buffers.c', emcc_args=['-DTEST_INTERACTIVE=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/'])
+    self.btest_exit('openal/test_openal_buffers.c', cflags=['-DTEST_INTERACTIVE=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/'])
 
   def test_openal_buffers_animated_pitch(self):
-    self.btest_exit('openal/test_openal_buffers.c', emcc_args=['-DTEST_INTERACTIVE=1', '-DTEST_ANIMATED_PITCH=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/'])
+    self.btest_exit('openal/test_openal_buffers.c', cflags=['-DTEST_INTERACTIVE=1', '-DTEST_ANIMATED_PITCH=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/'])
 
   def test_openal_looped_pitched_playback(self):
-    self.btest('openal/test_openal_playback.c', '1', emcc_args=['-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
+    self.btest('openal/test_openal_playback.c', '1', cflags=['-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
 
   def test_openal_looped_seek_playback(self):
-    self.btest('openal/test_openal_playback.c', '1', emcc_args=['-DTEST_LOOPED_SEEK_PLAYBACK=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
+    self.btest('openal/test_openal_playback.c', '1', cflags=['-DTEST_LOOPED_SEEK_PLAYBACK=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
 
   def test_openal_animated_looped_pitched_playback(self):
-    self.btest('openal/test_openal_playback.c', '1', emcc_args=['-DTEST_ANIMATED_LOOPED_PITCHED_PLAYBACK=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
+    self.btest('openal/test_openal_playback.c', '1', cflags=['-DTEST_ANIMATED_LOOPED_PITCHED_PLAYBACK=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
 
   def test_openal_animated_looped_distance_playback(self):
-    self.btest('openal/test_openal_playback.c', '1', emcc_args=['-DTEST_ANIMATED_LOOPED_DISTANCE_PLAYBACK=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
+    self.btest('openal/test_openal_playback.c', '1', cflags=['-DTEST_ANIMATED_LOOPED_DISTANCE_PLAYBACK=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
 
   def test_openal_animated_looped_doppler_playback(self):
-    self.btest('openal/test_openal_playback.c', '1', emcc_args=['-DTEST_ANIMATED_LOOPED_DOPPLER_PLAYBACK=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
+    self.btest('openal/test_openal_playback.c', '1', cflags=['-DTEST_ANIMATED_LOOPED_DOPPLER_PLAYBACK=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
 
   def test_openal_animated_looped_panned_playback(self):
-    self.btest('openal/test_openal_playback.c', '1', emcc_args=['-DTEST_ANIMATED_LOOPED_PANNED_PLAYBACK=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
+    self.btest('openal/test_openal_playback.c', '1', cflags=['-DTEST_ANIMATED_LOOPED_PANNED_PLAYBACK=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
 
   def test_openal_animated_looped_relative_playback(self):
-    self.btest('openal/test_openal_playback.c', '1', emcc_args=['-DTEST_ANIMATED_LOOPED_RELATIVE_PLAYBACK=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
+    self.btest('openal/test_openal_playback.c', '1', cflags=['-DTEST_ANIMATED_LOOPED_RELATIVE_PLAYBACK=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
 
   def test_openal_al_soft_loop_points(self):
-    self.btest('openal/test_openal_playback.c', '1', emcc_args=['-DTEST_AL_SOFT_LOOP_POINTS=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
+    self.btest('openal/test_openal_playback.c', '1', cflags=['-DTEST_AL_SOFT_LOOP_POINTS=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
 
   def test_openal_alc_soft_pause_device(self):
-    self.btest('openal/test_openal_playback.c', '1', emcc_args=['-DTEST_ALC_SOFT_PAUSE_DEVICE=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
+    self.btest('openal/test_openal_playback.c', '1', cflags=['-DTEST_ALC_SOFT_PAUSE_DEVICE=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
 
   def test_openal_al_soft_source_spatialize(self):
-    self.btest('openal/test_openal_playback.c', '1', emcc_args=['-DTEST_AL_SOFT_SOURCE_SPATIALIZE=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
+    self.btest('openal/test_openal_playback.c', '1', cflags=['-DTEST_AL_SOFT_SOURCE_SPATIALIZE=1', '-DTEST_LOOPED_PLAYBACK=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/audio.wav'])
 
   def test_openal_capture(self):
     self.btest_exit('openal/test_openal_capture.c')
 
   def get_freealut_library(self):
-    self.emcc_args += ['-Wno-pointer-sign']
+    self.cflags += ['-Wno-pointer-sign']
     if WINDOWS and shutil.which('cmake'):
       return self.get_library(os.path.join('third_party', 'freealut'), 'libalut.a', configure=['cmake', '.'], configure_args=['-DBUILD_TESTS=ON'])
     else:
@@ -207,32 +207,32 @@ class interactive(BrowserCore):
   def test_freealut(self):
     src = test_file('third_party/freealut/examples/hello_world.c')
     inc = test_file('third_party/freealut/include')
-    self.btest_exit(src, emcc_args=['-O2', '-I' + inc] + self.get_freealut_library())
+    self.btest_exit(src, cflags=['-O2', '-I' + inc] + self.get_freealut_library())
 
   def test_glfw_cursor_disabled(self):
-    self.btest_exit('interactive/test_glfw_cursor_disabled.c', emcc_args=['-sUSE_GLFW=3', '-lglfw', '-lGL'])
+    self.btest_exit('interactive/test_glfw_cursor_disabled.c', cflags=['-sUSE_GLFW=3', '-lglfw', '-lGL'])
 
   def test_glfw_dropfile(self):
-    self.btest_exit('interactive/test_glfw_dropfile.c', emcc_args=['-sUSE_GLFW=3', '-lglfw', '-lGL'])
+    self.btest_exit('interactive/test_glfw_dropfile.c', cflags=['-sUSE_GLFW=3', '-lglfw', '-lGL'])
 
   def test_glfw_fullscreen(self):
-    self.btest_exit('interactive/test_glfw_fullscreen.c', emcc_args=['-sUSE_GLFW=3'])
+    self.btest_exit('interactive/test_glfw_fullscreen.c', cflags=['-sUSE_GLFW=3'])
 
   def test_glfw_get_key_stuck(self):
-    self.btest_exit('interactive/test_glfw_get_key_stuck.c', emcc_args=['-sUSE_GLFW=3'])
+    self.btest_exit('interactive/test_glfw_get_key_stuck.c', cflags=['-sUSE_GLFW=3'])
 
   def test_glfw_joystick(self):
-    self.btest_exit('interactive/test_glfw_joystick.c', emcc_args=['-sUSE_GLFW=3'])
+    self.btest_exit('interactive/test_glfw_joystick.c', cflags=['-sUSE_GLFW=3'])
 
   def test_glfw_pointerlock(self):
-    self.btest_exit('interactive/test_glfw_pointerlock.c', emcc_args=['-sUSE_GLFW=3'])
+    self.btest_exit('interactive/test_glfw_pointerlock.c', cflags=['-sUSE_GLFW=3'])
 
   def test_glut_fullscreen(self):
     self.skipTest('looks broken')
-    self.btest_exit('glut_fullscreen.c', emcc_args=['-lglut', '-lGL'])
+    self.btest_exit('glut_fullscreen.c', cflags=['-lglut', '-lGL'])
 
   def test_cpuprofiler_memoryprofiler(self):
-    self.btest('hello_world_gles.c', expected='0', emcc_args=['-DLONGTEST=1', '-DTEST_MEMORYPROFILER_ALLOCATIONS_MAP=1', '-O2', '--cpuprofiler', '--memoryprofiler'])
+    self.btest('hello_world_gles.c', expected='0', cflags=['-DLONGTEST=1', '-DTEST_MEMORYPROFILER_ALLOCATIONS_MAP=1', '-O2', '--cpuprofiler', '--memoryprofiler'])
 
   def test_threadprofiler(self):
     args = ['-O2', '--threadprofiler',
@@ -242,13 +242,13 @@ class interactive(BrowserCore):
             '-sPTHREAD_POOL_SIZE=16',
             '-sINITIAL_MEMORY=64mb',
             '--shell-file', test_file('pthread/test_pthread_mandelbrot_shell.html')]
-    self.btest_exit('pthread/test_pthread_mandelbrot.cpp', emcc_args=args)
+    self.btest_exit('pthread/test_pthread_mandelbrot.cpp', cflags=args)
 
   # Test that event backproxying works.
   def test_html5_callbacks_on_calling_thread(self):
     # TODO: Make this automatic by injecting mouse event in e.g. shell html file.
     for args in ([], ['-DTEST_SYNC_BLOCKING_LOOP=1']):
-      self.btest('html5_callbacks_on_calling_thread.c', expected='1', emcc_args=args + ['-sDISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR', '-pthread', '-sPROXY_TO_PTHREAD'])
+      self.btest('html5_callbacks_on_calling_thread.c', expected='1', cflags=args + ['-sDISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR', '-pthread', '-sPROXY_TO_PTHREAD'])
 
   # Test that it is possible to register HTML5 event callbacks on either main browser thread, or
   # application main thread, and that the application can manually proxy the event from main browser
@@ -260,7 +260,7 @@ class interactive(BrowserCore):
   })
   def test_html5_event_callback_in_two_threads(self, args):
     # TODO: Make this automatic by injecting enter key press in e.g. shell html file.
-    self.btest_exit('html5_event_callback_in_two_threads.c', emcc_args=args)
+    self.btest_exit('html5_event_callback_in_two_threads.c', cflags=args)
 
   # Test that emscripten_hide_mouse() is callable from pthreads (and proxies to main
   # thread to obtain the proper window.devicePixelRatio value).
@@ -269,7 +269,7 @@ class interactive(BrowserCore):
     'threads': (['-pthread'],),
   })
   def test_emscripten_hide_mouse(self, args):
-    self.btest('emscripten_hide_mouse.c', expected='0', emcc_args=args)
+    self.btest('emscripten_hide_mouse.c', expected='0', cflags=args)
 
   # Tests that WebGL can be run on another thread after first having run it on one thread (and that
   # thread has exited). The intent of this is to stress graceful deinit semantics, so that it is not
@@ -280,61 +280,61 @@ class interactive(BrowserCore):
     'ofb': (['-sOFFSCREEN_FRAMEBUFFER'],),
   })
   def test_webgl_offscreen_canvas_in_two_pthreads(self, args):
-    self.btest('gl_in_two_pthreads.c', expected='1', emcc_args=args + ['-pthread', '-lGL', '-sGL_DEBUG', '-sPROXY_TO_PTHREAD'])
+    self.btest('gl_in_two_pthreads.c', expected='1', cflags=args + ['-pthread', '-lGL', '-sGL_DEBUG', '-sPROXY_TO_PTHREAD'])
 
   # Tests creating a Web Audio context using Emscripten library_webaudio.js feature.
   @also_with_minimal_runtime
   def test_web_audio(self):
-    self.btest('webaudio/create_webaudio.c', expected='0', emcc_args=['-lwebaudio.js'])
+    self.btest('webaudio/create_webaudio.c', expected='0', cflags=['-lwebaudio.js'])
 
   # Tests simple AudioWorklet noise generation
   @also_with_minimal_runtime
   def test_audio_worklet(self):
-    self.btest('webaudio/audioworklet.c', expected='0', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '--preload-file', test_file('hello_world.c') + '@/'])
-    self.btest('webaudio/audioworklet.c', expected='0', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-pthread'])
+    self.btest('webaudio/audioworklet.c', expected='0', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '--preload-file', test_file('hello_world.c') + '@/'])
+    self.btest('webaudio/audioworklet.c', expected='0', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-pthread'])
 
   # Tests a second AudioWorklet example: sine wave tone generator.
   def test_audio_worklet_tone_generator(self):
-    self.btest('webaudio/audio_worklet_tone_generator.c', expected='0', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
+    self.btest('webaudio/audio_worklet_tone_generator.c', expected='0', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
 
   # Tests that AUDIO_WORKLET+MINIMAL_RUNTIME+MODULARIZE combination works together.
   def test_audio_worklet_modularize(self):
-    self.btest('webaudio/audioworklet.c', expected='0', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sMINIMAL_RUNTIME', '-sMODULARIZE'])
+    self.btest('webaudio/audioworklet.c', expected='0', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sMINIMAL_RUNTIME', '-sMODULARIZE'])
 
   # Tests an AudioWorklet with multiple stereo inputs mixing in the processor to a single stereo output (4kB stack)
   def test_audio_worklet_stereo_io(self):
     os.mkdir('audio_files')
     shutil.copy(test_file('webaudio/audio_files/emscripten-beat.mp3'), 'audio_files/')
     shutil.copy(test_file('webaudio/audio_files/emscripten-bass.mp3'), 'audio_files/')
-    self.btest_exit('webaudio/audioworklet_in_out_stereo.c', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
+    self.btest_exit('webaudio/audioworklet_in_out_stereo.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
 
   # Tests an AudioWorklet with multiple stereo inputs copying in the processor to multiple stereo outputs (6kB stack)
   def test_audio_worklet_2x_stereo_io(self):
     os.mkdir('audio_files')
     shutil.copy(test_file('webaudio/audio_files/emscripten-beat.mp3'), 'audio_files/')
     shutil.copy(test_file('webaudio/audio_files/emscripten-bass.mp3'), 'audio_files/')
-    self.btest_exit('webaudio/audioworklet_2x_in_out_stereo.c', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
+    self.btest_exit('webaudio/audioworklet_2x_in_out_stereo.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
 
   # Tests an AudioWorklet with multiple mono inputs mixing in the processor to a single mono output (2kB stack)
   def test_audio_worklet_mono_io(self):
     os.mkdir('audio_files')
     shutil.copy(test_file('webaudio/audio_files/emscripten-beat-mono.mp3'), 'audio_files/')
     shutil.copy(test_file('webaudio/audio_files/emscripten-bass-mono.mp3'), 'audio_files/')
-    self.btest_exit('webaudio/audioworklet_in_out_mono.c', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
+    self.btest_exit('webaudio/audioworklet_in_out_mono.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
 
   # Tests an AudioWorklet with multiple mono inputs copying in the processor to L+R stereo outputs (3kB stack)
   def test_audio_worklet_2x_hard_pan_io(self):
     os.mkdir('audio_files')
     shutil.copy(test_file('webaudio/audio_files/emscripten-beat-mono.mp3'), 'audio_files/')
     shutil.copy(test_file('webaudio/audio_files/emscripten-bass-mono.mp3'), 'audio_files/')
-    self.btest_exit('webaudio/audioworklet_2x_in_hard_pan.c', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
+    self.btest_exit('webaudio/audioworklet_2x_in_hard_pan.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
 
   # Tests an AudioWorklet with multiple stereo inputs mixing in the processor via a parameter to a single stereo output (6kB stack)
   def test_audio_worklet_params_mixing(self):
     os.mkdir('audio_files')
     shutil.copy(test_file('webaudio/audio_files/emscripten-beat.mp3'), 'audio_files/')
     shutil.copy(test_file('webaudio/audio_files/emscripten-bass.mp3'), 'audio_files/')
-    self.btest_exit('webaudio/audioworklet_params_mixing.c', emcc_args=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
+    self.btest_exit('webaudio/audioworklet_params_mixing.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
 
 
 class interactive64(interactive):

--- a/test/test_posixtest.py
+++ b/test/test_posixtest.py
@@ -172,7 +172,7 @@ def make_test(name, testfile, browser):
     if browser:
       self.btest_exit(testfile, args=args)
     else:
-      self.do_runf(testfile, emcc_args=args, output_basename=name)
+      self.do_runf(testfile, cflags=args, output_basename=name)
 
   if name in expect_fail:
     f = unittest.expectedFailure(f)

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -158,7 +158,7 @@ def PythonTcpEchoServerProcess(port):
 
 
 class sockets(BrowserCore):
-  emcc_args: List[str] = []
+  cflags: List[str] = []
 
   @classmethod
   def setUpClass(cls):
@@ -185,15 +185,15 @@ class sockets(BrowserCore):
       self.skipTest('requires native clang')
 
     with harness_class(test_file('sockets/test_sockets_echo_server.c'), args, port) as harness:
-      self.btest_exit('sockets/test_sockets_echo_client.c', emcc_args=['-DSOCKK=%d' % harness.listen_port] + args)
+      self.btest_exit('sockets/test_sockets_echo_client.c', cflags=['-DSOCKK=%d' % harness.listen_port] + args)
 
   def test_sockets_echo_pthreads(self):
     with CompiledServerHarness(test_file('sockets/test_sockets_echo_server.c'), [], 49161) as harness:
-      self.btest_exit('sockets/test_sockets_echo_client.c', emcc_args=['-pthread', '-sPROXY_TO_PTHREAD', '-DSOCKK=%d' % harness.listen_port])
+      self.btest_exit('sockets/test_sockets_echo_client.c', cflags=['-pthread', '-sPROXY_TO_PTHREAD', '-DSOCKK=%d' % harness.listen_port])
 
   def test_sdl2_sockets_echo(self):
     with CompiledServerHarness('sockets/sdl2_net_server.c', ['-sUSE_SDL=2', '-sUSE_SDL_NET=2'], 49164) as harness:
-      self.btest_exit('sockets/sdl2_net_client.c', emcc_args=['-sUSE_SDL=2', '-sUSE_SDL_NET=2', '-DSOCKK=%d' % harness.listen_port])
+      self.btest_exit('sockets/sdl2_net_client.c', cflags=['-sUSE_SDL=2', '-sUSE_SDL_NET=2', '-DSOCKK=%d' % harness.listen_port])
 
   @parameterized({
     'websockify': [WebsockifyServerHarness, 49166, ['-DTEST_DGRAM=0']],
@@ -208,12 +208,12 @@ class sockets(BrowserCore):
 
     args.append('-DTEST_ASYNC=1')
     with harness_class(test_file('sockets/test_sockets_echo_server.c'), args, port) as harness:
-      self.btest_exit('sockets/test_sockets_echo_client.c', emcc_args=['-DSOCKK=%d' % harness.listen_port] + args)
+      self.btest_exit('sockets/test_sockets_echo_client.c', cflags=['-DSOCKK=%d' % harness.listen_port] + args)
 
   def test_sockets_async_bad_port(self):
     # Deliberately attempt a connection on a port that will fail to test the error callback and
     # getsockopt
-    self.btest_exit('sockets/test_sockets_echo_client.c', emcc_args=['-DSOCKK=49169', '-DTEST_ASYNC=1'])
+    self.btest_exit('sockets/test_sockets_echo_client.c', cflags=['-DSOCKK=49169', '-DTEST_ASYNC=1'])
 
   @parameterized({
     'websockify': [WebsockifyServerHarness, 49171, ['-DTEST_DGRAM=0']],
@@ -235,7 +235,7 @@ class sockets(BrowserCore):
     create_file('test_sockets_echo_bigdata.c', src.replace('#define MESSAGE "pingtothepong"', '#define MESSAGE "%s"' % message))
 
     with harness_class(test_file('sockets/test_sockets_echo_server.c'), args, port) as harness:
-      self.btest_exit('test_sockets_echo_bigdata.c', emcc_args=[sockets_include, '-DSOCKK=%d' % harness.listen_port] + args)
+      self.btest_exit('test_sockets_echo_bigdata.c', cflags=[sockets_include, '-DSOCKK=%d' % harness.listen_port] + args)
 
   @no_windows('This test is Unix-specific.')
   def test_sockets_partial(self):
@@ -244,7 +244,7 @@ class sockets(BrowserCore):
       CompiledServerHarness(test_file('sockets/test_sockets_partial_server.c'), [], 49181),
     ]:
       with harness:
-        self.btest_exit('sockets/test_sockets_partial_client.c', assert_returncode=165, emcc_args=['-DSOCKK=%d' % harness.listen_port])
+        self.btest_exit('sockets/test_sockets_partial_client.c', assert_returncode=165, cflags=['-DSOCKK=%d' % harness.listen_port])
 
   @no_windows('This test is Unix-specific.')
   def test_sockets_select_server_down(self):
@@ -253,7 +253,7 @@ class sockets(BrowserCore):
       CompiledServerHarness(test_file('sockets/test_sockets_select_server_down_server.c'), [], 49191),
     ]:
       with harness:
-        self.btest_exit('sockets/test_sockets_select_server_down_client.c', emcc_args=['-DSOCKK=%d' % harness.listen_port])
+        self.btest_exit('sockets/test_sockets_select_server_down_client.c', cflags=['-DSOCKK=%d' % harness.listen_port])
 
   @no_windows('This test is Unix-specific.')
   def test_sockets_select_server_closes_connection_rw(self):
@@ -262,7 +262,7 @@ class sockets(BrowserCore):
       CompiledServerHarness(test_file('sockets/test_sockets_echo_server.c'), ['-DCLOSE_CLIENT_AFTER_ECHO'], 49201),
     ]:
       with harness:
-        self.btest_exit('sockets/test_sockets_select_server_closes_connection_client_rw.c', emcc_args=['-DSOCKK=%d' % harness.listen_port])
+        self.btest_exit('sockets/test_sockets_select_server_closes_connection_client_rw.c', cflags=['-DSOCKK=%d' % harness.listen_port])
 
   @no_windows('This test uses Unix-specific build architecture.')
   def test_enet(self):
@@ -274,7 +274,7 @@ class sockets(BrowserCore):
       enet = [self.in_dir('enet', '.libs', 'libenet.a'), '-I' + self.in_dir('enet', 'include')]
 
     with CompiledServerHarness(test_file('sockets/test_enet_server.c'), enet, 49210) as harness:
-      self.btest_exit('sockets/test_enet_client.c', emcc_args=enet + ['-DSOCKK=%d' % harness.listen_port])
+      self.btest_exit('sockets/test_enet_client.c', cflags=enet + ['-DSOCKK=%d' % harness.listen_port])
 
   @crossplatform
   @parameterized({
@@ -290,10 +290,10 @@ class sockets(BrowserCore):
     # Basic test of node client against both a Websockified and compiled echo server.
     with harness_class(test_file('sockets/test_sockets_echo_server.c'), args, port) as harness:
       expected = 'do_msg_read: read 14 bytes'
-      self.do_runf('sockets/test_sockets_echo_client.c', expected, emcc_args=['-DSOCKK=%d' % harness.listen_port] + args)
+      self.do_runf('sockets/test_sockets_echo_client.c', expected, cflags=['-DSOCKK=%d' % harness.listen_port] + args)
 
   def test_nodejs_sockets_connect_failure(self):
-    self.do_runf('sockets/test_sockets_echo_client.c', 'connect failed: Connection refused', emcc_args=['-DSOCKK=666'], assert_returncode=NON_ZERO)
+    self.do_runf('sockets/test_sockets_echo_client.c', 'connect failed: Connection refused', cflags=['-DSOCKK=666'], assert_returncode=NON_ZERO)
 
   @requires_native_clang
   def test_nodejs_sockets_echo_subprotocol(self):
@@ -336,7 +336,7 @@ class sockets(BrowserCore):
   })
   def test_websocket_send(self, args):
     with NodeJsWebSocketEchoServerProcess():
-      self.btest_exit('websocket/test_websocket_send.c', emcc_args=['-lwebsocket', '-sNO_EXIT_RUNTIME', '-sWEBSOCKET_DEBUG'] + args)
+      self.btest_exit('websocket/test_websocket_send.c', cflags=['-lwebsocket', '-sNO_EXIT_RUNTIME', '-sWEBSOCKET_DEBUG'] + args)
 
   # Test that native POSIX sockets API can be used by proxying calls to an intermediate WebSockets
   # -> POSIX sockets bridge server
@@ -352,17 +352,17 @@ class sockets(BrowserCore):
     with BackgroundServerProcess([proxy_server, '8080']):
       with PythonTcpEchoServerProcess('7777'):
         # Build and run the TCP echo client program with Emscripten
-        self.btest_exit('websocket/tcp_echo_client.c', emcc_args=['-lwebsocket', '-sPROXY_POSIX_SOCKETS', '-pthread', '-sPROXY_TO_PTHREAD'])
+        self.btest_exit('websocket/tcp_echo_client.c', cflags=['-lwebsocket', '-sPROXY_POSIX_SOCKETS', '-pthread', '-sPROXY_TO_PTHREAD'])
 
   # Test that calling send() right after a socket connect() works.
   def test_sockets_send_while_connecting(self):
     with NodeJsWebSocketEchoServerProcess():
-      self.btest('sockets/test_sockets_send_while_connecting.c', emcc_args=['-DSOCKET_DEBUG'], expected='0')
+      self.btest('sockets/test_sockets_send_while_connecting.c', cflags=['-DSOCKET_DEBUG'], expected='0')
 
 
 class sockets64(sockets):
   def setUp(self):
     super().setUp()
     self.set_setting('MEMORY64')
-    self.emcc_args.append('-Wno-experimental')
+    self.cflags.append('-Wno-experimental')
     self.require_wasm64()


### PR DESCRIPTION
This has a few advantages:

1. It paves the way for separating out `ldflags`.
2. It the commonly used name for compiler flags.
3. Its slightly short and easier to type (important only because its repeated in many places)