### PR TITLE
[compiler-rt] Build with -DCOMPILER_RT_HAS_ATOMICS

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -939,7 +939,7 @@ class libcompiler_rt(MTLibrary, SjLjLibrary):
   # restriction soon: https://reviews.llvm.org/D71738
   force_object_files = True
 
-  cflags = ['-fno-builtin', '-DNDEBUG', '-DCOMPILER_RT_HAS_UNAME=1']
+  cflags = ['-fno-builtin', '-DNDEBUG', '-DCOMPILER_RT_HAS_UNAME=1', '-DCOMPILER_RT_HAS_ATOMICS=1']
   src_dir = 'system/lib/compiler-rt/lib/builtins'
   profile_src_dir = 'system/lib/compiler-rt/lib/profile'
   includes = ['system/lib/libc', 'system/lib/compiler-rt/include']


### PR DESCRIPTION
It looks like without this the fallback functions are not actually thread safe:

https://github.com/llvm/llvm-project/blob/63b80dd01dafc92104ee43e4f0f5296d644c25ec/compiler-rt/lib/profile/InstrProfilingUtil.c#L102-L119

Followup to #24160