### PR TITLE
Remove `Arguments` from jsdoc

### DIFF
--- a/src/lib/libccall.js
+++ b/src/lib/libccall.js
@@ -24,7 +24,7 @@ addToLibrary({
   /**
    * @param {string|null=} returnType
    * @param {Array=} argTypes
-   * @param {Arguments|Array=} args
+   * @param {Array=} args
    * @param {Object=} opts
    */`,
   $ccall: (ident, returnType, argTypes, args, opts) => {


### PR DESCRIPTION
Looks like this was originally added in #10525.

Perhaps closure compiler used to have a distinct type for `arguments` builtin in JS?  I can't see any mention of it in closure compiler documentation today though.

Fixes: #24579