### PR TITLE
Reduce usage of POINTER_TYPE in JS library code

### DIFF
--- a/src/lib/libembind.js
+++ b/src/lib/libembind.js
@@ -474,7 +474,7 @@ var LibraryEmbind = {
         // assumes POINTER_SIZE alignment
         var base = _malloc({{{ POINTER_SIZE }}} + length + 1);
         var ptr = base + {{{ POINTER_SIZE }}};
-        {{{ makeSetValue('base', '0', 'length', SIZE_TYPE) }}};
+        {{{ makeSetValue('base', '0', 'length', '*') }}};
         if (valueIsOfTypeString) {
           if (stdStringIsUTF8) {
             stringToUTF8(value, ptr, length + 1);
@@ -543,7 +543,7 @@ var LibraryEmbind = {
         // assumes POINTER_SIZE alignment
         var length = lengthBytesUTF(value);
         var ptr = _malloc({{{ POINTER_SIZE }}} + length + charSize);
-        {{{ makeSetValue('ptr', '0', 'length / charSize', SIZE_TYPE) }}};
+        {{{ makeSetValue('ptr', '0', 'length / charSize', '*') }}};
 
         encodeString(value, ptr + {{{ POINTER_SIZE }}}, length + charSize);
 

--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -44,7 +44,7 @@ var SyscallsLibrary = {
     writeStat(buf, stat) {
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_dev, 'stat.dev', 'i32') }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_mode, 'stat.mode', 'i32') }}};
-      {{{ makeSetValue('buf', C_STRUCTS.stat.st_nlink, 'stat.nlink', SIZE_TYPE) }}};
+      {{{ makeSetValue('buf', C_STRUCTS.stat.st_nlink, 'stat.nlink', '*') }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_uid, 'stat.uid', 'i32') }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_gid, 'stat.gid', 'i32') }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_rdev, 'stat.rdev', 'i32') }}};
@@ -55,11 +55,11 @@ var SyscallsLibrary = {
       var mtime = stat.mtime.getTime();
       var ctime = stat.ctime.getTime();
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_atim.tv_sec, 'Math.floor(atime / 1000)', 'i64') }}};
-      {{{ makeSetValue('buf', C_STRUCTS.stat.st_atim.tv_nsec, '(atime % 1000) * 1000 * 1000', SIZE_TYPE) }}};
+      {{{ makeSetValue('buf', C_STRUCTS.stat.st_atim.tv_nsec, '(atime % 1000) * 1000 * 1000', '*') }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_mtim.tv_sec, 'Math.floor(mtime / 1000)', 'i64') }}};
-      {{{ makeSetValue('buf', C_STRUCTS.stat.st_mtim.tv_nsec, '(mtime % 1000) * 1000 * 1000', SIZE_TYPE) }}};
+      {{{ makeSetValue('buf', C_STRUCTS.stat.st_mtim.tv_nsec, '(mtime % 1000) * 1000 * 1000', '*') }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_ctim.tv_sec, 'Math.floor(ctime / 1000)', 'i64') }}};
-      {{{ makeSetValue('buf', C_STRUCTS.stat.st_ctim.tv_nsec, '(ctime % 1000) * 1000 * 1000', SIZE_TYPE) }}};
+      {{{ makeSetValue('buf', C_STRUCTS.stat.st_ctim.tv_nsec, '(ctime % 1000) * 1000 * 1000', '*') }}};
       {{{ makeSetValue('buf', C_STRUCTS.stat.st_ino, 'stat.ino', 'i64') }}};
       return 0;
     },

--- a/src/lib/libwasi.js
+++ b/src/lib/libwasi.js
@@ -88,12 +88,12 @@ var WasiLibrary = {
   environ_sizes_get__nothrow: true,
   environ_sizes_get: (penviron_count, penviron_buf_size) => {
     var strings = getEnvStrings();
-    {{{ makeSetValue('penviron_count', 0, 'strings.length', SIZE_TYPE) }}};
+    {{{ makeSetValue('penviron_count', 0, 'strings.length', '*') }}};
     var bufSize = 0;
     for (var string of strings) {
       bufSize += lengthBytesUTF8(string) + 1;
     }
-    {{{ makeSetValue('penviron_buf_size', 0, 'bufSize', SIZE_TYPE) }}};
+    {{{ makeSetValue('penviron_buf_size', 0, 'bufSize', '*') }}};
     return 0;
   },
 
@@ -117,12 +117,12 @@ var WasiLibrary = {
   args_sizes_get__nothrow: true,
   args_sizes_get: (pargc, pargv_buf_size) => {
 #if MAIN_READS_PARAMS
-    {{{ makeSetValue('pargc', 0, 'mainArgs.length', SIZE_TYPE) }}};
+    {{{ makeSetValue('pargc', 0, 'mainArgs.length', '*') }}};
     var bufSize = 0;
     mainArgs.forEach((arg) => bufSize += arg.length + 1);
-    {{{ makeSetValue('pargv_buf_size', 0, 'bufSize', SIZE_TYPE) }}};
+    {{{ makeSetValue('pargv_buf_size', 0, 'bufSize', '*') }}};
 #else
-    {{{ makeSetValue('pargc', 0, '0', SIZE_TYPE) }}};
+    {{{ makeSetValue('pargc', 0, '0', '*') }}};
 #endif
     return 0;
   },
@@ -284,7 +284,7 @@ var WasiLibrary = {
       num += len;
     }
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
-    {{{ makeSetValue('pnum', 0, 'num', SIZE_TYPE) }}};
+    {{{ makeSetValue('pnum', 0, 'num', '*') }}};
     return 0;
   },
 
@@ -297,7 +297,7 @@ var WasiLibrary = {
     if (isNaN(offset)) return {{{ cDefs.EOVERFLOW }}};
     var stream = SYSCALLS.getStreamFromFD(fd)
     var num = doWritev(stream, iov, iovcnt, offset);
-    {{{ makeSetValue('pnum', 0, 'num', SIZE_TYPE) }}};
+    {{{ makeSetValue('pnum', 0, 'num', '*') }}};
     return 0;
 #elif ASSERTIONS
     abort('fd_pwrite called without SYSCALLS_REQUIRE_FILESYSTEM');
@@ -332,7 +332,7 @@ var WasiLibrary = {
 #if SYSCALLS_REQUIRE_FILESYSTEM
     var stream = SYSCALLS.getStreamFromFD(fd);
     var num = doReadv(stream, iov, iovcnt);
-    {{{ makeSetValue('pnum', 0, 'num', SIZE_TYPE) }}};
+    {{{ makeSetValue('pnum', 0, 'num', '*') }}};
     return 0;
 #elif ASSERTIONS
     abort('fd_read called without SYSCALLS_REQUIRE_FILESYSTEM');
@@ -350,7 +350,7 @@ var WasiLibrary = {
     if (isNaN(offset)) return {{{ cDefs.EOVERFLOW }}};
     var stream = SYSCALLS.getStreamFromFD(fd)
     var num = doReadv(stream, iov, iovcnt, offset);
-    {{{ makeSetValue('pnum', 0, 'num', SIZE_TYPE) }}};
+    {{{ makeSetValue('pnum', 0, 'num', '*') }}};
     return 0;
 #elif ASSERTIONS
     abort('fd_pread called without SYSCALLS_REQUIRE_FILESYSTEM');

--- a/src/lib/libwasmfs_jsimpl.js
+++ b/src/lib/libwasmfs_jsimpl.js
@@ -91,7 +91,7 @@ addToLibrary({
     assert(wasmFS$backends[backend]);
 #endif
     var result = await wasmFS$backends[backend].write(file, buffer, length, offset);
-    {{{ makeSetValue('result_p', 0, 'result', SIZE_TYPE) }}};
+    {{{ makeSetValue('result_p', 0, 'result', '*') }}};
     _emscripten_proxy_finish(ctx);
   },
 
@@ -102,7 +102,7 @@ addToLibrary({
     assert(wasmFS$backends[backend]);
 #endif
     var result = await wasmFS$backends[backend].read(file, buffer, length, offset);
-    {{{ makeSetValue('result_p', 0, 'result', SIZE_TYPE) }}};
+    {{{ makeSetValue('result_p', 0, 'result', '*') }}};
     _emscripten_proxy_finish(ctx);
   },
 


### PR DESCRIPTION
Same as https://github.com/emscripten-core/emscripten/pull/24490 but for the 17 usages of SIZE_TYPE which should always be the same as `*`.