### PR TITLE
Remove references to `mozRequestPointerLock` and friends. NFC

### DIFF
--- a/src/lib/libbrowser.js
+++ b/src/lib/libbrowser.js
@@ -146,32 +146,14 @@ var LibraryBrowser = {
 
       function pointerLockChange() {
         var canvas = Browser.getCanvas();
-        Browser.pointerLock = document['pointerLockElement'] === canvas ||
-                              document['mozPointerLockElement'] === canvas ||
-                              document['webkitPointerLockElement'] === canvas ||
-                              document['msPointerLockElement'] === canvas;
+        Browser.pointerLock = document.pointerLockElement === canvas;
       }
       var canvas = Browser.getCanvas();
       if (canvas) {
         // forced aspect ratio can be enabled by defining 'forcedAspectRatio' on Module
         // Module['forcedAspectRatio'] = 4 / 3;
 
-        canvas.requestPointerLock = canvas['requestPointerLock'] ||
-                                    canvas['mozRequestPointerLock'] ||
-                                    canvas['webkitRequestPointerLock'] ||
-                                    canvas['msRequestPointerLock'] ||
-                                    (() => {});
-        canvas.exitPointerLock = document['exitPointerLock'] ||
-                                 document['mozExitPointerLock'] ||
-                                 document['webkitExitPointerLock'] ||
-                                 document['msExitPointerLock'] ||
-                                 (() => {}); // no-op if function does not exist
-        canvas.exitPointerLock = canvas.exitPointerLock.bind(document);
-
         document.addEventListener('pointerlockchange', pointerLockChange, false);
-        document.addEventListener('mozpointerlockchange', pointerLockChange, false);
-        document.addEventListener('webkitpointerlockchange', pointerLockChange, false);
-        document.addEventListener('mspointerlockchange', pointerLockChange, false);
 
         if (Module['elementPointerLock']) {
           canvas.addEventListener("click", (ev) => {

--- a/src/lib/libglfw.js
+++ b/src/lib/libglfw.js
@@ -942,7 +942,7 @@ var LibraryGLFW = {
             case 0x00034001: { // GLFW_CURSOR_NORMAL
               win.inputModes[mode] = value;
               canvas.removeEventListener('click', GLFW.onClickRequestPointerLock, true);
-              canvas.exitPointerLock();
+              document.exitPointerLock();
               break;
             }
             case 0x00034002: { // GLFW_CURSOR_HIDDEN

--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -1543,7 +1543,7 @@ var LibraryHTML5 = {
 
   $fillPointerlockChangeEventData__deps: ['$JSEvents', '$stringToUTF8'],
   $fillPointerlockChangeEventData: (eventStruct) => {
-    var pointerLockElement = document.pointerLockElement || document.mozPointerLockElement || document.webkitPointerLockElement || document.msPointerLockElement;
+    var pointerLockElement = document.pointerLockElement;
     var isPointerlocked = !!pointerLockElement;
 #if !SAFE_HEAP
     // Assigning a boolean to HEAP32 with expected type coercion.
@@ -1595,10 +1595,8 @@ var LibraryHTML5 = {
     '$specialHTMLTargets'
 #endif
   ],
-  emscripten_set_pointerlockchange_callback_on_thread__docs: '/** @suppress {missingProperties} */', // Closure does not see document.body.mozRequestPointerLock etc.
   emscripten_set_pointerlockchange_callback_on_thread: (target, userData, useCapture, callbackfunc, targetThread) => {
-    // TODO: Currently not supported in pthreads or in --proxy-to-worker mode. (In pthreads mode, document object is not defined)
-    if (!document || !document.body || (!document.body.requestPointerLock && !document.body.mozRequestPointerLock && !document.body.webkitRequestPointerLock && !document.body.msRequestPointerLock)) {
+    if (!document.body?.requestPointerLock) {
       return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
 
@@ -1608,9 +1606,6 @@ var LibraryHTML5 = {
     target = target ? findEventTarget(target) : specialHTMLTargets[{{{ cDefs.EMSCRIPTEN_EVENT_TARGET_DOCUMENT }}}]; // Pointer lock change events need to be captured from 'document' by default instead of 'window'
 #endif
     if (!target) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
-    registerPointerlockChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKCHANGE }}}, "mozpointerlockchange", targetThread);
-    registerPointerlockChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKCHANGE }}}, "webkitpointerlockchange", targetThread);
-    registerPointerlockChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKCHANGE }}}, "mspointerlockchange", targetThread);
     return registerPointerlockChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKCHANGE }}}, "pointerlockchange", targetThread);
   },
 
@@ -1644,10 +1639,8 @@ var LibraryHTML5 = {
     '$specialHTMLTargets'
 #endif
   ],
-  emscripten_set_pointerlockerror_callback_on_thread__docs: '/** @suppress {missingProperties} */', // Closure does not see document.body.mozRequestPointerLock etc.
   emscripten_set_pointerlockerror_callback_on_thread: (target, userData, useCapture, callbackfunc, targetThread) => {
-    // TODO: Currently not supported in pthreads or in --proxy-to-worker mode. (In pthreads mode, document object is not defined)
-    if (!document || !document.body.requestPointerLock && !document.body.mozRequestPointerLock && !document.body.webkitRequestPointerLock && !document.body.msRequestPointerLock) {
+    if (!document.body?.requestPointerLock) {
       return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
 
@@ -1658,18 +1651,14 @@ var LibraryHTML5 = {
 #endif
 
     if (!target) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
-    registerPointerlockErrorEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKERROR }}}, "mozpointerlockerror", targetThread);
-    registerPointerlockErrorEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKERROR }}}, "webkitpointerlockerror", targetThread);
-    registerPointerlockErrorEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKERROR }}}, "mspointerlockerror", targetThread);
     return registerPointerlockErrorEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_POINTERLOCKERROR }}}, "pointerlockerror", targetThread);
   },
 
   emscripten_get_pointerlock_status__proxy: 'sync',
   emscripten_get_pointerlock_status__deps: ['$fillPointerlockChangeEventData'],
-  emscripten_get_pointerlock_status__docs: '/** @suppress {missingProperties} */', // Closure does not see document.body.mozRequestPointerLock etc.
   emscripten_get_pointerlock_status: (pointerlockStatus) => {
     if (pointerlockStatus) fillPointerlockChangeEventData(pointerlockStatus);
-    if (!document.body || (!document.body.requestPointerLock && !document.body.mozRequestPointerLock && !document.body.webkitRequestPointerLock && !document.body.msRequestPointerLock)) {
+    if (!document.body?.requestPointerLock) {
       return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
     }
     return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};

--- a/src/lib/libsdl.js
+++ b/src/lib/libsdl.js
@@ -1826,7 +1826,7 @@ var LibrarySDL = {
         // else return SDL_ENABLE to indicate the failure
         return 1;
       case 1: // SDL_ENABLE
-        Browser.getCanvas().exitPointerLock();
+        document.exitPointerLock();
         return 1;
       case -1: // SDL_QUERY
         return !Browser.pointerLock;

--- a/src/proxyWorker.js
+++ b/src/proxyWorker.js
@@ -209,7 +209,6 @@ document.createElement = (what) => {
         right: canvas.boundingClientRect.right
       });
       canvas.style = new PropertyBag();
-      canvas.exitPointerLock = () => {};
 
       canvas.width_ ||= 0;
       canvas.height_ ||= 0;
@@ -283,6 +282,8 @@ document.styleSheets = [{
 }];
 
 document.URL = 'http://worker.not.yet.ready.wait.for.window.onload?fake';
+
+document.exitPointerLock = () => {};
 
 function Audio() {
   warnOnce('faking Audio elements, no actual sound will play');


### PR DESCRIPTION
The official `requestPointerLock` API is supported in all the browsers that we support.

See https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock