### PR TITLE
Use optimal flags for the embind_val codesize test

### DIFF
--- a/test/code_size/embind_val_wasm.json
+++ b/test/code_size/embind_val_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 380,
   "a.js": 5367,
   "a.js.gz": 2540,
-  "a.wasm": 9092,
-  "a.wasm.gz": 4699,
-  "total": 15011,
-  "total_gz": 7619
+  "a.wasm": 7468,
+  "a.wasm.gz": 3468,
+  "total": 13387,
+  "total_gz": 6388
 }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11890,11 +11890,7 @@ int main () {
     hello_wasm_worker_sources = [test_file('wasm_worker/wasm_worker_code_size.c'), '-sWASM_WORKERS', '-sENVIRONMENT=web']
     audio_worklet_sources = [test_file('webaudio/audioworklet.c'), '-sWASM_WORKERS', '-sAUDIO_WORKLET', '-sENVIRONMENT=web', '-sTEXTDECODER=1']
     embind_hello_sources = [test_file('code_size/embind_hello_world.cpp'), '-lembind']
-    embind_val_sources = [test_file('code_size/embind_val_hello_world.cpp'),
-                          '-lembind',
-                          '-fno-rtti',
-                          '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0',
-                          '-sDYNAMIC_EXECUTION=0']
+    embind_val_sources = [test_file('code_size/embind_val_hello_world.cpp'), '-lembind']
 
     sources = {
       'hello_world': hello_world_sources,


### PR DESCRIPTION
- `-sDYNAMIC_EXECUTION=0` was no-op since we added it to common flags.
- `-fno-rtti` fallback is actually more expensive than the default RTTI-based mode (using actual `typeid(T)`).