### PR TITLE
[NFC][Testing] Test Poppler with optimizations

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -2030,6 +2030,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     self.cflags += [
       '-I' + test_file('third_party/freetype/include'),
       '-I' + test_file('third_party/poppler/include'),
+      # Poppler's configure script emits -O2 for gcc, and nothing for other
+      # compilers, including emcc, so set opts manually.
+      "-O2",
     ]
 
     # Poppler has some pretty glaring warning.  Suppress them to keep the

--- a/test/third_party/poppler/goo/GooLikely.h
+++ b/test/third_party/poppler/goo/GooLikely.h
@@ -11,7 +11,9 @@
 #ifndef GOOLIKELY_H
 #define GOOLIKELY_H
 
-#if defined(__GNUC__) && (__GNUC__ > 2) && defined(__OPTIMIZE__)
+// XXX EMSCRIPTEN: Remove gcc-specific detection of __builtin_expect.
+// #if defined(__GNUC__) && (__GNUC__ > 2) && defined(__OPTIMIZE__)
+#ifdef __EMSCRIPTEN__
 # define likely(x)      __builtin_expect((x), 1)
 # define unlikely(x)    __builtin_expect((x), 0)
 #else


### PR DESCRIPTION
Poppler's configure script chooses `-O2` for gcc, and nothing for all other
compilers, so we were never optimizing source files. Fix that by adding
optimizations in cflags.

This is important for test coverage, but also for branch hints, as LLVM
does not emit hints when not optimizing. Another fix for branch hints
is applied here: the likely macro was tailored (once again) to gcc. (This
is NFC for now, but if/when LLVM gets branch hint support, this will
become a useful real-world test of compiling and linking real-world code
with such hints.)

This also makes the Poppler benchmark 33% faster.