### PR TITLE
Fix benchmark.test_base64

### DIFF
--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -858,7 +858,7 @@ class benchmark(common.RunnerCore):
                       emcc_args=['-sSTACK_SIZE=1MB'])
 
   def test_base64(self):
-    src = read_file(test_file('base64.c'))
+    src = read_file(test_file('benchmark/base64.c'))
     self.do_benchmark('base64', src, 'decode')
 
   @non_core


### PR DESCRIPTION
Had been moved to another path at some point:

```
C:\emsdk\emscripten\main>test\runner benchmark.test_base64
Running test_benchmark: (1 tests)
Running Emscripten benchmarks... [ including compilation | Sat Jun 28 00:35:48 2025 | em: commit e65efb113cc27f5247b890998043f270a5314a79 | llvm: C:/emsdk/llvm/git/build_main_vs2022_64/Release/bin ]
test_base64 (test_benchmark.benchmark.test_base64) ... ERROR

======================================================================
ERROR: test_base64 (test_benchmark.benchmark.test_base64)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\emsdk\emscripten\main\test\test_benchmark.py", line 861, in test_base64
    src = read_file(test_file('base64.c'))
  File "C:\emsdk\emscripten\main\tools\utils.py", line 61, in read_file
    with open(file_path, encoding='utf-8') as fh:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\emsdk\\emscripten\\main\\test\\base64.c'

----------------------------------------------------------------------
Ran 1 test in 0.173s

FAILED (errors=1)
```
