### PR TITLE
Change standalone wasm vm tests to emit a test skip when wasm engine is not present

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1998,7 +1998,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         if 'EMTEST_SKIP_WASM_ENGINE' in os.environ:
           self.skipTest('no wasm engine was found to run the standalone part of this test')
         else:
-          self.fail('no wasm engine was found to run the standalone part of this test (Use EMTEST_SKIP_WASM_ENGINE to skip)')
+          logger.warning('no wasm engine was found to run the standalone part of this test (Use EMTEST_SKIP_WASM_ENGINE to skip)')
       engines += self.wasm_engines
     if len(engines) == 0:
       self.fail('No JS engine present to run this test with. Check %s and the paths therein.' % config.EM_CONFIG)

--- a/test/common.py
+++ b/test/common.py
@@ -1995,7 +1995,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       # TODO once standalone wasm support is more stable, apply use_all_engines
       # like with js engines, but for now as we bring it up, test in all of them
       if not self.wasm_engines:
-        logger.warning('no wasm engine was found to run the standalone part of this test')
+        self.skipTest('no wasm engine was found to run the standalone part of this test')
       engines += self.wasm_engines
     if len(engines) == 0:
       self.fail('No JS engine present to run this test with. Check %s and the paths therein.' % config.EM_CONFIG)

--- a/test/common.py
+++ b/test/common.py
@@ -1998,7 +1998,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         if 'EMTEST_SKIP_WASM_ENGINE' in os.environ:
           self.skipTest('no wasm engine was found to run the standalone part of this test')
         else:
-          logger.warning('no wasm engine was found to run the standalone part of this test (Use EMTEST_SKIP_WASM_ENGINE to mute this warning')
+          self.fail('no wasm engine was found to run the standalone part of this test (Use EMTEST_SKIP_WASM_ENGINE to skip)')
       engines += self.wasm_engines
     if len(engines) == 0:
       self.fail('No JS engine present to run this test with. Check %s and the paths therein.' % config.EM_CONFIG)

--- a/test/common.py
+++ b/test/common.py
@@ -1995,7 +1995,10 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       # TODO once standalone wasm support is more stable, apply use_all_engines
       # like with js engines, but for now as we bring it up, test in all of them
       if not self.wasm_engines:
-        self.skipTest('no wasm engine was found to run the standalone part of this test')
+        if 'EMTEST_SKIP_WASM_ENGINE' in os.environ:
+          self.skipTest('no wasm engine was found to run the standalone part of this test')
+        else:
+          logger.warning('no wasm engine was found to run the standalone part of this test (Use EMTEST_SKIP_WASM_ENGINE to mute this warning')
       engines += self.wasm_engines
     if len(engines) == 0:
       self.fail('No JS engine present to run this test with. Check %s and the paths therein.' % config.EM_CONFIG)


### PR DESCRIPTION
Change standalone wasm vm tests to emit a test skip when wasm engine is not present, rather than print a warning and then possibly fail. Fixes `test/runner core2g.test_eval_ctors_standalone` without a Wasm engine present.