### PR TITLE
Add support for setting socket's blocking mode through ioctl with FIO…

### DIFF
--- a/src/lib/libsockfs.js
+++ b/src/lib/libsockfs.js
@@ -421,6 +421,14 @@ addToLibrary({
             }
             {{{ makeSetValue('arg', '0', 'bytes', 'i32') }}};
             return 0;
+          case {{{ cDefs.FIONBIO }}}:
+            var on = {{{ makeGetValue('arg', '0', 'i32') }}};
+            if (on) {
+              sock.stream.flags |= {{{ cDefs.O_NONBLOCK }}};
+            } else {
+              sock.stream.flags &= ~{{{ cDefs.O_NONBLOCK }}};
+            }
+            return 0;
           default:
             return {{{ cDefs.EINVAL }}};
         }

--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -284,6 +284,7 @@ var SyscallsLibrary = {
         if (!stream.tty) return -{{{ cDefs.ENOTTY }}};
         return -{{{ cDefs.EINVAL }}}; // not supported
       }
+      case {{{ cDefs.FIONBIO }}}:
       case {{{ cDefs.FIONREAD }}}: {
         var argp = syscallGetVarargP();
         return FS.ioctl(stream, op, argp);

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -312,6 +312,7 @@
     {
         "file": "bits/ioctl.h",
         "defines": [
+            "FIONBIO",
             "FIONREAD",
             "TCGETA",
             "TCGETS",

--- a/src/struct_info_generated.json
+++ b/src/struct_info_generated.json
@@ -292,6 +292,7 @@
         "EWOULDBLOCK": 6,
         "EXDEV": 75,
         "EXFULL": 115,
+        "FIONBIO": 21537,
         "FIONREAD": 21531,
         "F_DUPFD": 0,
         "F_GETFD": 1,

--- a/src/struct_info_generated_wasm64.json
+++ b/src/struct_info_generated_wasm64.json
@@ -292,6 +292,7 @@
         "EWOULDBLOCK": 6,
         "EXDEV": 75,
         "EXFULL": 115,
+        "FIONBIO": 21537,
         "FIONREAD": 21531,
         "F_DUPFD": 0,
         "F_GETFD": 1,


### PR DESCRIPTION
…NBIO

Today I was recompiling quakejs (12 years later, better late than never :)) against the latest emscripten. Everything was smooth sailing, but I hit one issue because ioctl() used to be under-implemented, and now it's more fleshed out but missing support for FIONBIO (https://github.com/torvalds/linux/blob/66701750d5565c574af42bef0b789ce0203e3071/fs/ioctl.c#L341).

I don't have the tests working locally right now, so I'm crossing my fingers that some CI job kicks in here to help verify. I modified `test_sockets_echo_server` which had support for both Winsock / POSIX sockets, and shimmed it to use ioctl() on POSIX to help test this.

Edit: Of course, this doesn't actually change or implement any support for O_NONBLOCK inside of libsockfs, it's just enabling the flag to be set just as it would be through fcntl.