### PR TITLE
Modularized-Output.rst: Fix typo in example parameters

### DIFF
--- a/site/source/docs/compiling/Modularized-Output.rst
+++ b/site/source/docs/compiling/Modularized-Output.rst
@@ -35,7 +35,7 @@ separate and isolated instances of the same program.
 By default, the factory function is called ``Module``, but it can be given a
 unique name via the ``-sEXPORT_NAME`` setting.
 
-For example, a program is built using ``-sMODUARLIZE -sEXPORT_NAME=Foo`` can
+For example, a program is built using ``-sMODULARIZE -sEXPORT_NAME=Foo`` can
 be instantiated using:
 
 ::


### PR DESCRIPTION
The flag `-sMODULARIZE` was written `-sMODUARLIZE`. This is a bug that can propagate by users who copy and paste this example.