### PR TITLE
[pthreads] Initialize TLS on workers in MINIMAL_RUNTIME mode.

### DIFF
--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -51,7 +51,10 @@ function initRuntime(wasmExports) {
 #endif
 
 #if PTHREADS
-  if (ENVIRONMENT_IS_PTHREAD) return
+  if (ENVIRONMENT_IS_PTHREAD) {
+    PThread.tlsInitFunctions.push(wasmExports['_emscripten_tls_init']);
+    return;
+  }
 #endif
 
 #if WASM_WORKERS
@@ -64,10 +67,6 @@ function initRuntime(wasmExports) {
   setStackLimits();
 #endif
   writeStackCookie();
-#endif
-
-#if PTHREADS
-  PThread.tlsInitFunctions.push(wasmExports['_emscripten_tls_init']);
 #endif
 
   <<< ATINITS >>>

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -51,10 +51,8 @@ function initRuntime(wasmExports) {
 #endif
 
 #if PTHREADS
-  if (ENVIRONMENT_IS_PTHREAD) {
-    PThread.tlsInitFunctions.push(wasmExports['_emscripten_tls_init']);
-    return;
-  }
+  PThread.tlsInitFunctions.push(wasmExports['_emscripten_tls_init']);
+  if (ENVIRONMENT_IS_PTHREAD) return;
 #endif
 
 #if WASM_WORKERS

--- a/test/pthread/test_pthread_c_thread_local.c
+++ b/test/pthread/test_pthread_c_thread_local.c
@@ -1,0 +1,35 @@
+// Copyright 2025 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <stdio.h>
+
+static _Thread_local int thread_local = 0;
+
+void *thread_start(void *arg) {
+  thread_local = 1;
+  assert(thread_local == 1);
+  printf("thread_local=%d\n", thread_local);
+  return NULL;
+}
+
+int main() {
+  thread_local = 2;
+  pthread_t thread;
+  int rc;
+
+  rc = pthread_create(&thread, NULL, thread_start, NULL);
+  assert(rc == 0);
+
+  rc = pthread_join(thread, NULL);
+  assert(rc == 0);
+
+  printf("thread_local=%d\n", thread_local);
+  assert(thread_local == 2);
+  printf("done\n");
+  return 0;
+}

--- a/test/pthread/test_pthread_c_thread_local.out
+++ b/test/pthread/test_pthread_c_thread_local.out
@@ -1,0 +1,3 @@
+thread_local=1
+thread_local=2
+done

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2637,6 +2637,13 @@ The current type of b is: 9
     self.do_run_in_out_file_test('pthread/test_pthread_thread_local_storage.cpp')
 
   @node_pthreads
+  @also_with_minimal_runtime
+  def test_pthread_c_thread_local(self):
+    if self.get_setting('MINIMAL_RUNTIME') and is_sanitizing(self.cflags):
+      self.skipTest('MINIMAL_RUNTIME + threads + asan does not work')
+    self.do_run_in_out_file_test('pthread/test_pthread_c_thread_local.c')
+
+  @node_pthreads
   def test_pthread_cleanup(self):
     self.set_setting('PTHREAD_POOL_SIZE', 4)
     self.do_run_in_out_file_test('pthread/test_pthread_cleanup.c')


### PR DESCRIPTION
TLS was not initialized on workers causing the tls_base address to be 0 and write to the wrong memory location.

Fixes #21528 and is also needed for PR #24565