### PR TITLE
Remove support for old `mozIndexedDB`/`webkitIndexDB`/etc.

### DIFF
--- a/src/IDBStore.js
+++ b/src/IDBStore.js
@@ -6,13 +6,10 @@
 
 var IDBStore = {
   indexedDB() {
-    if (typeof indexedDB != 'undefined') return indexedDB;
-    var ret = null;
-    if (typeof window == 'object') ret = window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB || window.msIndexedDB;
 #if ASSERTIONS
-    assert(ret, 'IDBStore used, but indexedDB not supported');
+    assert(typeof indexedDB != 'undefined', 'IDBStore used, but indexedDB not supported');
 #endif
-    return ret;
+    return indexedDB;
   },
   DB_VERSION: 22,
   DB_STORE_NAME: 'FILE_DATA',

--- a/src/lib/libidbfs.js
+++ b/src/lib/libidbfs.js
@@ -13,13 +13,10 @@ addToLibrary({
   $IDBFS: {
     dbs: {},
     indexedDB: () => {
-      if (typeof indexedDB != 'undefined') return indexedDB;
-      var ret = null;
-      if (typeof window == 'object') ret = window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB || window.msIndexedDB;
 #if ASSERTIONS
-      assert(ret, 'IDBFS used, but indexedDB not supported');
+      assert(typeof indexedDB != 'undefined', 'IDBFS used, but indexedDB not supported');
 #endif
-      return ret;
+      return indexedDB;
     },
     DB_VERSION: 21,
     DB_STORE_NAME: 'FILE_DATA',

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -807,13 +807,7 @@ def generate_js(data_target, data_files, metadata):
               return errback();
             }'''
       code += '''
-          var indexedDB;
-          if (typeof window === 'object') {
-            indexedDB = window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB || window.msIndexedDB;
-          } else if (typeof location !== 'undefined') {
-            // worker
-            indexedDB = self.indexedDB;
-          } else {
+          if (typeof indexedDB == 'undefined') {
             throw 'using IndexedDB to cache data can only be done on a web page or in a web worker';
           }
           try {


### PR DESCRIPTION
The `indexedDB` global has been available for a long time now.  See https://caniuse.com/indexeddb.