### PR TITLE
[embind] Don't truncate `unsigned long` under wasm64

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -38,8 +38,10 @@ See docs/process.md for more on how version tagging works.
   wrapped with `WebAssembly.Suspending` functions. To automatically wrap library
   functions for use with JSPI they must now explicitly set
   `myLibraryFunction__async: true`.
-- On wasm64 Embind will now pass `size_t` as a `bigint` instead of `number` to
-  match behaviour of other bindings like `EM_ASM`.
+- Removed special casing for `size_t` in Embind, since it was also inadvertently
+  affecting `unsigned long` on wasm64. Both will now match the behaviour of
+  other 64-bit integers on wasm64 and will be passed as `bigint` instead of
+  `number` to the JavaScript code. (#24678)
 
 4.0.10 - 06/07/25
 -----------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -38,6 +38,8 @@ See docs/process.md for more on how version tagging works.
   wrapped with `WebAssembly.Suspending` functions. To automatically wrap library
   functions for use with JSPI they must now explicitly set
   `myLibraryFunction__async: true`.
+- On wasm64 Embind will now pass `size_t` as a `bigint` instead of `number` to
+  match behaviour of other bindings like `EM_ASM`.
 
 4.0.10 - 06/07/25
 -----------------

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -2040,11 +2040,11 @@ class_<std::vector<T, Allocator>> register_vector(const char* name) {
 
     return class_<VecType>(name)
         .template constructor<>()
-        .function("push_back", internal::VectorAccess<VecType>::push_back)
-        .function("resize", internal::VectorAccess<VecType>::resize)
-        .function("size", internal::VectorAccess<VecType>::size)
-        .function("get", internal::VectorAccess<VecType>::get)
-        .function("set", internal::VectorAccess<VecType>::set)
+        .function("push_back", internal::VectorAccess<VecType>::push_back, allow_raw_pointers())
+        .function("resize", internal::VectorAccess<VecType>::resize, allow_raw_pointers())
+        .function("size", internal::VectorAccess<VecType>::size, allow_raw_pointers())
+        .function("get", internal::VectorAccess<VecType>::get, allow_raw_pointers())
+        .function("set", internal::VectorAccess<VecType>::set, allow_raw_pointers())
         ;
 }
 

--- a/test/embind/embind.test.js
+++ b/test/embind/embind.test.js
@@ -857,7 +857,7 @@ module({
             assert.equal(2147483648, cm.load_unsigned_int());
 
             cm.store_unsigned_long(2147483648);
-            assert.equal(2147483648, cm.load_unsigned_long());
+            assert.equal(cm.getCompilerSetting('MEMORY64') ? 2147483648n : 2147483648, cm.load_unsigned_long());
         });
 
         if (cm.getCompilerSetting('ASSERTIONS')) {


### PR DESCRIPTION
This makes it consistent with other bindings like EM_ASM.

As part of this, I had to change vector and map sizes and indices to explicitly take `unsigned int` instead, so that users don't have to upgrade all their code to deal with unexpected bigints in e.g. `vec.size()`.

Technically this means you can't pass around a C++ vector >4GB to JS and back, but I'm sure we can live with it.