### PR TITLE
Fix unresolved symbol in standalone debug build.

### DIFF
--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -25,6 +25,7 @@
 
 #include "lock.h"
 #include "emscripten_internal.h"
+#include "unwind.h"
 
 /*
  * WASI support code. These are compiled with the program, and call out
@@ -308,3 +309,7 @@ weak void _emscripten_get_progname(char* buf, int length) {
 }
 
 weak void _emscripten_runtime_keepalive_clear() {}
+
+void __throw_exception_with_stack_trace(_Unwind_Exception* exception_object) {
+  _Unwind_RaiseException(exception_object);
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15182,6 +15182,15 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     err = self.expect_fail(base_cmd + ['-sMEMORY_GROWTH_LINEAR_STEP=1mb'])
     self.assertContained('error: MEMORY_GROWTH_LINEAR_STEP is not compatible with STANDALONE_WASM', err)
 
+  def test_standalone_imports(self):
+    # Ensure standalone binary will not have __throw_exception_with_stack_trace
+    # debug helper dependency, caused by exception-related code.
+    src_path = test_file('core/test_exceptions.cpp')
+    self.run_process([EMXX, '-O0', '-fwasm-exceptions', '-sSTANDALONE_WASM', src_path])
+    imports = self.parse_wasm('a.out.wasm')[0]
+    for name in imports:
+      self.assertTrue(name.startswith('wasi_'), 'Unexpected import %s' % name)
+
   @is_slow_test
   def test_googletest(self):
     # TODO(sbc): Should we package gtest as an emscripten "port"?  I guess we should if


### PR DESCRIPTION
Ensure WASM binaries, produced in standalone debug mode, does not require `__throw_exception_with_stack_trace` function. In non-standalone mode it implemented in JS.