### PR TITLE
Remove support for old `mozGetGamepads`/`webkitGetGamepads`/etc.

### DIFF
--- a/src/lib/libsdl.js
+++ b/src/lib/libsdl.js
@@ -1352,7 +1352,7 @@ var LibrarySDL = {
       if (!navigator.getGamepads) {
         return [];
       }
-      return navigator.getGamepads()
+      return navigator.getGamepads();
     },
 
     // Helper function: Returns the gamepad if available, or null if not.

--- a/src/lib/libsdl.js
+++ b/src/lib/libsdl.js
@@ -1349,12 +1349,10 @@ var LibrarySDL = {
     },
 
     getGamepads() {
-      var fcn = navigator.getGamepads || navigator.webkitGamepads || navigator.mozGamepads || navigator.gamepads || navigator.webkitGetGamepads;
-      if (fcn !== undefined) {
-        // The function must be applied on the navigator object.
-        return fcn.apply(navigator);
+      if (!navigator.getGamepads) {
+        return [];
       }
-      return [];
+      return navigator.getGamepads()
     },
 
     // Helper function: Returns the gamepad if available, or null if not.


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getGamepads