### PR TITLE
Remove support for older browser without requestAnimationFrame

### DIFF
--- a/src/lib/libeventloop.js
+++ b/src/lib/libeventloop.js
@@ -300,20 +300,9 @@ LibraryJSEventLoop = {
     requestAnimationFrame(func) {
       if (typeof requestAnimationFrame == 'function') {
         requestAnimationFrame(func);
-        return;
+      } else {
+        MainLoop.fakeRequestAnimationFrame(func);
       }
-      var RAF = MainLoop.fakeRequestAnimationFrame;
-#if LEGACY_VM_SUPPORT
-      if (typeof window != 'undefined') {
-        RAF = window['requestAnimationFrame'] ||
-              window['mozRequestAnimationFrame'] ||
-              window['webkitRequestAnimationFrame'] ||
-              window['msRequestAnimationFrame'] ||
-              window['oRequestAnimationFrame'] ||
-              RAF;
-      }
-#endif
-      RAF(func);
     },
   },
 

--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -107,12 +107,6 @@ function renderFrame() {
   renderFrameData = null;
 }
 
-if (typeof window != 'undefined') {
-  window.requestAnimationFrame = window.requestAnimationFrame || window.mozRequestAnimationFrame ||
-                                 window.webkitRequestAnimationFrame || window.msRequestAnimationFrame ||
-                                 renderFrame;
-}
-
 /*
 (() => {
   var trueRAF = window.requestAnimationFrame;


### PR DESCRIPTION
All the browsers we support have had requestAnimationFrame for a long time now.