### PR TITLE
Use the more optimal overload for copying `val`

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -368,6 +368,8 @@ public:
     }
   }
 
+  val(val& v) : val(static_cast<const val&>(v)) {}
+
   ~val() {
     if (uses_ref_count()) {
       internal::_emval_decref(as_handle());

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -368,6 +368,9 @@ public:
     }
   }
 
+  // Add an explicit overload for `val&` as well.
+  // Without it, C++ will try to use the `T&&` constructor instead of the more
+  // efficient `val(const val&)` when trying to copy a `val` instance.
   val(val& v) : val(static_cast<const val&>(v)) {}
 
   ~val() {


### PR DESCRIPTION
I found by accident (while stepping via the debugger) that for `val(v)` where `v` is `val&` C++ chooses the `T&&` overload as more precise one instead of `const val&`.

The runtime behaviour of the two is equivalent, so I'm not sure it can be easily tested, but forwarding to the const overload would certainly be a bit more optimal.