### PR TITLE
Add Closure extern for `toResizableBuffer()`

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -104,6 +104,10 @@ WebAssembly.Instance.prototype.exports;
  */
 WebAssembly.Memory.prototype.buffer;
 /**
+ * @returns {ArrayBuffer}
+ */
+WebAssembly.Memory.prototype.toResizableBuffer = function() {};
+/**
  * @type {number}
  */
 WebAssembly.Table.prototype.length;


### PR DESCRIPTION
Prevents Closure compiler from mangling `wasmMemory.toResizableBuffer()`.