### PR TITLE
Fix memory corruption in getrusage

### DIFF
--- a/system/lib/libc/emscripten_syscall_stubs.c
+++ b/system/lib/libc/emscripten_syscall_stubs.c
@@ -35,7 +35,7 @@ static mode_t g_umask = S_IWGRP | S_IWOTH;
 #define REPORT(name)
 #else
 #define REPORT(name) \
-  emscripten_err("warning: unsupported syscall: __syscall_" #name "\n");
+  emscripten_err("warning: unsupported syscall: __syscall_" #name);
 #endif
 
 #define UNIMPLEMENTED(name, args) \
@@ -127,14 +127,20 @@ weak int __syscall_umask(int mask) {
   return old;
 }
 
+struct kusage {
+  long utime_tv_sec;
+  long utime_tv_usec;
+  long stime_tv_sec;
+  long stime_tv_usec;
+};
+
 weak int __syscall_getrusage(int who, intptr_t usage) {
   REPORT(getrusage);
-  struct rusage *u = (struct rusage *)usage;
-  memset(u, 0, sizeof(*u));
-  u->ru_utime.tv_sec = 1;
-  u->ru_utime.tv_usec = 2;
-  u->ru_stime.tv_sec = 3;
-  u->ru_stime.tv_usec = 4;
+  struct kusage *u = (struct kusage*)usage;
+  u->utime_tv_sec = 1;
+  u->utime_tv_usec = 2;
+  u->stime_tv_sec = 3;
+  u->stime_tv_usec = 4;
   return 0;
 }
 

--- a/test/other/test_getrusage.c
+++ b/test/other/test_getrusage.c
@@ -1,8 +1,13 @@
+#include <stdio.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 
 int main() {
   struct rusage u;
-  getrusage(0, &u);
+  getrusage(RUSAGE_SELF, &u);
+  printf("ru_utime.tv_sec: %lld\n", u.ru_utime.tv_sec);
+  printf("ru_utime.tv_usec: %d\n", u.ru_utime.tv_usec);
+  printf("ru_stime.tv_sec: %lld\n", u.ru_stime.tv_sec);
+  printf("ru_stime.tv_usec: %d\n", u.ru_stime.tv_usec);
   return 0;
 }

--- a/test/other/test_getrusage.out
+++ b/test/other/test_getrusage.out
@@ -1,0 +1,5 @@
+warning: unsupported syscall: __syscall_getrusage
+ru_utime.tv_sec: 1
+ru_utime.tv_usec: 2
+ru_stime.tv_sec: 3
+ru_stime.tv_usec: 4

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13381,8 +13381,9 @@ int main () {
       'malloc() called but not included in the build - add `_malloc` to EXPORTED_FUNCTIONS',
       'free() called but not included in the build - add `_free` to EXPORTED_FUNCTIONS'), assert_all=True)
 
+  @also_with_asan
   def test_getrusage(self):
-    self.do_runf('other/test_getrusage.c')
+    self.do_other_test('test_getrusage.c')
 
   @with_env_modify({'EMMAKEN_COMPILER': shared.CLANG_CC})
   def test_emmaken_compiler(self):


### PR DESCRIPTION
The existing code we have was broken by an upstream musl change: https://git.musl-libc.org/cgit/musl/commit/?id=5850546e9669f793aab61dfc7c4f2c1ff35c4b29

Fixes: #18083