### PR TITLE
[WasmFS] Use `const char*` in JS API impl. NFC

### DIFF
--- a/system/lib/wasmfs/js_api.cpp
+++ b/system/lib/wasmfs/js_api.cpp
@@ -64,7 +64,7 @@ int _wasmfs_read_file(const char* path, uint8_t** out_buf, off_t* out_size) {
 
 // Writes to a file, possibly creating it, and returns the number of bytes
 // written successfully. If the file already exists, appends to it.
-int _wasmfs_write_file(const char* pathname, char* data, size_t data_size) {
+int _wasmfs_write_file(const char* pathname, const char* data, size_t data_size) {
   auto parsedParent = path::parseParent(pathname);
   if (parsedParent.getError()) {
     return 0;
@@ -100,7 +100,7 @@ int _wasmfs_write_file(const char* pathname, char* data, size_t data_size) {
   }
 
   auto offset = lockedFile.getSize();
-  auto result = lockedFile.write((uint8_t*)data, data_size, offset);
+  auto result = lockedFile.write((const uint8_t*)data, data_size, offset);
   if (result != __WASI_ERRNO_SUCCESS) {
     return 0;
   }


### PR DESCRIPTION
In line with #23825.