### PR TITLE
Bump expected LLVM version to 22. NFC

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -59,7 +59,7 @@ SKIP_SUBPROCS = False
 # in debian/stable (bookworm).  We need at least v18.3.0 because we make
 # use of util.parseArg which was added in v18.3.0.
 MINIMUM_NODE_VERSION = (18, 3, 0)
-EXPECTED_LLVM_VERSION = 21
+EXPECTED_LLVM_VERSION = 22
 
 # These get set by setup_temp_dirs
 TEMP_DIR = None


### PR DESCRIPTION
Upstream main branch is now on version 22.