### PR TITLE
Use getFullscreenElement over legacy fullscreen attribute. NFC

### DIFF
--- a/src/lib/libglfw.js
+++ b/src/lib/libglfw.js
@@ -632,7 +632,7 @@ var LibraryGLFW = {
       var resizeNeeded = false;
 
       // If the client is requesting fullscreen mode
-      if (document["fullscreen"] || document["fullScreen"] || document["mozFullScreen"] || document["webkitIsFullScreen"]) {
+      if (getFullscreenElement()) {
         if (!GLFW.active.fullscreen) {
           resizeNeeded = width != screen.width || height != screen.height;
           GLFW.active.storedX = GLFW.active.x;

--- a/src/lib/libglut.js
+++ b/src/lib/libglut.js
@@ -5,7 +5,7 @@
  */
 
 var LibraryGLUT = {
-  $GLUT__deps: ['$Browser', 'glutPostRedisplay'],
+  $GLUT__deps: ['$Browser', '$getFullscreenElement', 'glutPostRedisplay'],
   $GLUT: {
     initTime: null,
     idleFunc: null,
@@ -279,7 +279,7 @@ var LibraryGLUT = {
     onFullscreenEventChange: (event) => {
       var width;
       var height;
-      if (document["fullscreen"] || document["fullScreen"] || document["mozFullScreen"] || document["webkitIsFullScreen"]) {
+      if (getFullscreenElement()) {
         width = screen["width"];
         height = screen["height"];
       } else {


### PR DESCRIPTION
The getFullscreenElement utility has fallbacks for old browsers going back as far as we support.

See https://caniuse.com/mdn-api_document_fullscreenelement