### PR TITLE
Run wasm2js2.test_pthread_proxying as part of CI. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -600,6 +600,7 @@ jobs:
             core2s.test_module_wasm_memory
             cores.test_minimal_runtime_safe_heap
             wasm2js3.test_memorygrowth_2
+            wasm2js2.test_pthread_proxying
             wasmfs.test_hello_world
             wasmfs.test_unistd_links*
             wasmfs.test_atexit_standalone

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -437,6 +437,9 @@ class TestCoreBase(RunnerCore):
   def maybe_closure(self):
     if '--closure=1' not in self.cflags and self.should_use_closure():
       self.cflags += ['--closure=1']
+      if self.is_wasm2js():
+        # wasm2js output currently contains closure warnings
+        self.cflags += ['-Wno-closure']
       logger.debug('using closure compiler..')
       return True
     return False


### PR DESCRIPTION
This confirms that wasm2js + pthreads + closure compiler are compatible.

See #16706.  I believe this issues was likely fixed when we removed the separate worker.js file.

Replaces: #24719
Fixes: #16706