### PR TITLE
Exclude symbols starting with '_Z' from user exports

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -647,7 +647,7 @@ def is_internal_global(name):
 def is_user_export(name):
   if is_internal_global(name):
     return False
-  return name not in ['__indirect_function_table', 'memory'] and not name.startswith(('dynCall_', 'orig$'))
+  return name not in ['__indirect_function_table', 'memory'] and not name.startswith(('dynCall_', 'orig$', '_Z'))
 
 
 def asmjs_mangle(name):


### PR DESCRIPTION
**Regression introduced in:** Emscripten 4.0.3
**Affects:** SIDE_MODULE builds which contain mangled Rust standard library symbols.

SIDE_MODULE builds fail with "invalid export name" errors:

**Reproduction**: [nickpdemarco/emsdk-export-bug](https://github.com/nickpdemarco/emsdk-export-bug)

```
emcc: error: invalid export name: _ZN4core3fmt3num3imp52_$LT$impl$u20$core..fmt..Display$u20$for$u20$u32$GT$3fmt17h745ee1c5d9dcaa78E
```

Emscripten's post-processing incorrectly classifies mangled symbols (internal implementation details) as user exports, triggering validation that fails on invalid WebAssembly identifier characters.

Note: this issue existed prior to 4.0.3, but [this change](https://github.com/emscripten-core/emscripten/commit/08d2cc3c559c64f377bc932bcc418fd661998232) exposed it.

## Analysis

**Expected behavior**: Only explicitly requested functions should be exported from SIDE_MODULE builds
**Actual behavior**: Internal mangled symbols are misclassified as user exports

**Pipeline breakdown** (from debug analysis):
1. ✅ **Rust/cargo**: Correctly specifies `EXPORTED_FUNCTIONS=["_add_numbers","_multiply"]`
2. ✅ **Emscripten linker**: Correctly calls `wasm-ld --export=add_numbers --export=multiply`
3. ✅ **wasm-ld**: Successfully links WASM with only requested exports
4. ❌ **Emscripten post-processing**: Reads WASM file, incorrectly classifies internal `_Z*` symbols as user exports, validation fails

The problematic symbol exists in the WASM as an internal implementation detail but was **never requested for export** by the user or passed to the linker.