### PR TITLE
Revert "Ensure bootstrap has been run before install.py"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-    - run: ./bootstrap
     - name: make dist
       run: |
         make dist

--- a/tools/install.py
+++ b/tools/install.py
@@ -17,15 +17,6 @@ import shutil
 import subprocess
 import sys
 
-__scriptdir__ = os.path.dirname(os.path.abspath(__file__))
-__rootdir__ = os.path.dirname(__scriptdir__)
-sys.path.insert(0, __rootdir__)
-
-# Before we can install emscripten we need to at least have bootstrapped
-# this checkout
-import bootstrap
-bootstrap.check()
-
 EXCLUDES = [os.path.normpath(x) for x in '''
 test/third_party
 tools/maint


### PR DESCRIPTION
This reverts commit da5100759ba9245b8ea32576b82a3a2225d1903f.
(#24723)

The test_install test is failing on Chromium CI on all platforms,
failing to import the bootstrap module (but only when run from
the test runner, not when running standalone).
https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket/8709018559637274817/+/u/Emscripten_testsuite__other_/stdout
I'm not sure why, but given that we do actually run bootstrap in the right
places, it should be safe to revert this to unblock the autoroller
until we figure it out.
