### PR TITLE
Use threaded HTTP server for test harness.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from subprocess import PIPE, STDOUT
 from typing import Dict, Tuple
 from urllib.parse import unquote, unquote_plus, urlparse, parse_qs
-from http.server import HTTPServer, SimpleHTTPRequestHandler
+from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
 import contextlib
 import difflib
 import hashlib
@@ -2272,7 +2272,7 @@ def harness_server_func(in_queue, out_queue, port):
   # do not have the correct MIME type
   SimpleHTTPRequestHandler.extensions_map['.mjs'] = 'text/javascript'
 
-  httpd = HTTPServer(('localhost', port), TestServerHandler)
+  httpd = ThreadingHTTPServer(('localhost', port), TestServerHandler)
   httpd.serve_forever() # test runner will kill us
 
 


### PR DESCRIPTION
The test `test_offset_converter_pthread` hangs during the `fetch` call to report results to the server. This seems to be caused by Chrome opening an earlier connection to the server and leaving it open which in turn causes pythons`SimpleHTTPRequestHandler` to stop responding to new requests. Using the `ThreadingHTTPServer` allows python to keep processing requests and fixes the hang.

More info on this issue can be found in:  https://bugs.python.org/issue31639 and the chrome issue https://issues.chromium.org/issues/40978518.

Fixes #10232