### PR TITLE
Add git pre-push hook. NFC

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -67,19 +67,21 @@ def main(args):
   parser = argparse.ArgumentParser(description=__doc__)
   parser.add_argument('-v', '--verbose', action='store_true', help='verbose', default=False)
   parser.add_argument('-n', '--dry-run', action='store_true', help='dry run', default=False)
-  parser.add_argument('-i', '--install-post-checkout', action='store_true', help='install post checkout script', default=False)
+  parser.add_argument('-i', '--install-git-hooks', action='store_true', help='install emscripten git hooks', default=False)
   args = parser.parse_args()
 
-  if args.install_post_checkout:
+  if args.install_git_hooks:
     if not os.path.exists(utils.path_from_root('.git')):
-      print('--install-post-checkout requires git checkout')
+      print('--install-git-hooks requires git checkout')
       return 1
 
-    src = utils.path_from_root('tools/maint/post-checkout')
     dst = utils.path_from_root('.git/hooks')
     if not os.path.exists(dst):
       os.mkdir(dst)
-    shutil.copy(src, dst)
+
+    src = utils.path_from_root('tools/maint/post-checkout')
+    for src in ('tools/maint/post-checkout', 'tools/maint/pre-push'):
+      shutil.copy(utils.path_from_root(src), dst)
     return 0
 
   for name, deps, cmd in actions:

--- a/tools/maint/post-checkout
+++ b/tools/maint/post-checkout
@@ -5,6 +5,8 @@
 #
 # The bootstrap script itself is smart enough to basically do nothing unless
 # one of the relevant files was updated (e.g. package.json).
+#
+# This script can be installed using `./boostrap -i`.
 
 # Test for the existence of the bootstrap script itself to handle branches
 # that predate its existence.

--- a/tools/maint/pre-push
+++ b/tools/maint/pre-push
@@ -1,0 +1,7 @@
+#!/bin/sh
+#
+# Git pre-push script that runs some quick/simple tests.
+#
+# This script can be installed using `./boostrap -i`.
+
+exec ruff check -q


### PR DESCRIPTION
Currently this script just runs `ruff check` to avoid pushing anything with python lint errors (since ruff is super fast this seems like a reasonable thing to do).