### PR TITLE
[llvm-libc] Import setjmp from llvm-libc

### DIFF
--- a/system/lib/libc/musl/include/setjmp.h
+++ b/system/lib/libc/musl/include/setjmp.h
@@ -26,7 +26,7 @@ typedef struct __jmp_buf_tag {
  || defined(_BSD_SOURCE)
 typedef jmp_buf sigjmp_buf;
 /* XXX EMSCRIPTEN: No signals support, alias sigsetjmp and siglongjmp to their non-signals counterparts. */
-#if __EMSCRIPTEN__
+#if __EMSCRIPTEN__ && !defined(LLVM_LIBC)
 #define sigsetjmp(buf, x) setjmp((buf))
 #define siglongjmp(buf, val) longjmp(buf, val)
 #else

--- a/system/lib/llvm-libc/src/setjmp/longjmp.h
+++ b/system/lib/llvm-libc/src/setjmp/longjmp.h
@@ -1,0 +1,34 @@
+//===-- Implementation header for longjmp -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SETJMP_LONGJMP_H
+#define LLVM_LIBC_SRC_SETJMP_LONGJMP_H
+
+#include "hdr/types/jmp_buf.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/compiler.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO(https://github.com/llvm/llvm-project/issues/112427)
+// Some of the architecture-specific definitions are marked `naked`, which in
+// GCC implies `nothrow`.
+//
+// Right now, our aliases aren't marked `nothrow`, so we wind up in a situation
+// where clang will emit -Wmissing-exception-spec if we add `nothrow` here, but
+// GCC will emit -Wmissing-attributes here without `nothrow`. We need to update
+// LLVM_LIBC_FUNCTION to denote when a function throws or not.
+
+#ifdef LIBC_COMPILER_IS_GCC
+[[gnu::nothrow]]
+#endif
+void longjmp(jmp_buf buf, int val);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SETJMP_LONGJMP_H

--- a/system/lib/llvm-libc/src/setjmp/setjmp_impl.h
+++ b/system/lib/llvm-libc/src/setjmp/setjmp_impl.h
@@ -1,0 +1,37 @@
+//===-- Implementation header for setjmp ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SETJMP_SETJMP_IMPL_H
+#define LLVM_LIBC_SRC_SETJMP_SETJMP_IMPL_H
+
+// This header has the _impl prefix in its name to avoid conflict with the
+// public header setjmp.h which is also included. here.
+#include "hdr/types/jmp_buf.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/compiler.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO(https://github.com/llvm/llvm-project/issues/112427)
+// Some of the architecture-specific definitions are marked `naked`, which in
+// GCC implies `nothrow`.
+//
+// Right now, our aliases aren't marked `nothrow`, so we wind up in a situation
+// where clang will emit -Wmissing-exception-spec if we add `nothrow` here, but
+// GCC will emit -Wmissing-attributes here without `nothrow`. We need to update
+// LLVM_LIBC_FUNCTION to denote when a function throws or not.
+
+#ifdef LIBC_COMPILER_IS_GCC
+[[gnu::nothrow]]
+#endif
+[[gnu::returns_twice]] int
+setjmp(jmp_buf buf);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SETJMP_SETJMP_IMPL_H

--- a/system/lib/llvm-libc/src/setjmp/siglongjmp.cpp
+++ b/system/lib/llvm-libc/src/setjmp/siglongjmp.cpp
@@ -1,0 +1,23 @@
+//===-- Implementation of siglongjmp --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/setjmp/siglongjmp.h"
+#include "src/__support/common.h"
+#include "src/setjmp/longjmp.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// siglongjmp is the same as longjmp. The additional recovery work is done in
+// the epilogue of the sigsetjmp function.
+// TODO: move this inside the TU of longjmp and making it an alias after
+//       sigsetjmp is implemented for all architectures.
+LLVM_LIBC_FUNCTION(void, siglongjmp, (jmp_buf buf, int val)) {
+  return LIBC_NAMESPACE::longjmp(buf, val);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/setjmp/siglongjmp.h
+++ b/system/lib/llvm-libc/src/setjmp/siglongjmp.h
@@ -1,0 +1,25 @@
+//===-- Implementation header for siglongjmp --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SETJMP_SIGLONGJMP_H
+#define LLVM_LIBC_SRC_SETJMP_SIGLONGJMP_H
+
+#include "hdr/types/jmp_buf.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/compiler.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+#ifdef LIBC_COMPILER_IS_GCC
+[[gnu::nothrow]]
+#endif
+void siglongjmp(jmp_buf buf, int val);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SETJMP_SIGLONGJMP_H

--- a/system/lib/llvm-libc/src/setjmp/sigsetjmp.h
+++ b/system/lib/llvm-libc/src/setjmp/sigsetjmp.h
@@ -1,0 +1,26 @@
+//===-- Implementation header for sigsetjmp ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SETJMP_SIGSETJMP_H
+#define LLVM_LIBC_SRC_SETJMP_SIGSETJMP_H
+
+#include "hdr/types/jmp_buf.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/compiler.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+#ifdef LIBC_COMPILER_IS_GCC
+[[gnu::nothrow]]
+#endif
+[[gnu::returns_twice]] int
+sigsetjmp(sigjmp_buf buf, int savesigs);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SETJMP_SIGSETJMP_H

--- a/system/lib/llvm-libc/src/setjmp/sigsetjmp_epilogue.h
+++ b/system/lib/llvm-libc/src/setjmp/sigsetjmp_epilogue.h
@@ -1,0 +1,19 @@
+//===-- Implementation header for sigsetjmp epilogue ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SETJMP_SIGSETJMP_EPILOGUE_H
+#define LLVM_LIBC_SRC_SETJMP_SIGSETJMP_EPILOGUE_H
+
+#include "hdr/types/jmp_buf.h"
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+[[gnu::returns_twice]] int sigsetjmp_epilogue(jmp_buf buffer, int retval);
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SETJMP_SIGSETJMP_EPILOGUE_H

--- a/system/lib/llvm-libc/src/setjmp/wasm/sigsetjmp.cpp
+++ b/system/lib/llvm-libc/src/setjmp/wasm/sigsetjmp.cpp
@@ -1,0 +1,14 @@
+#include "src/setjmp/sigsetjmp.h"
+#include "hdr/offsetof_macros.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+#if !defined(LIBC_TARGET_ARCH_IS_WASM)
+#error "Invalid file include"
+#endif
+
+namespace LIBC_NAMESPACE_DECL {
+[[gnu::returns_twice]] int sigsetjmp(jmp_buf sigjmp_buf, int savesigs) {
+    return setjmp(sigjmp_buf);
+}
+}

--- a/system/lib/update_llvm_libc.py
+++ b/system/lib/update_llvm_libc.py
@@ -32,11 +32,13 @@ libc_copy_dirs = [
     'src/inttypes',
     'src/stdio/printf_core',
     'src/wchar',
+    'src/setjmp'
 ]
 
 libc_exclusion_patterns = [
     'src/math/generic/*f16*', # float16 is unsupported in Emscripten.
     'src/strings/str*casecmp_l*', # locale_t is unsupported in Overlay Mode.
+    'src/setjmp/**/*', # setjmp in Emscripten is implemented by the clang backend.
 ]
 
 def clean_dir(dirname):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1001,7 +1001,7 @@ class llvmlibc(DebugLibrary, AsanInstrumentedLibrary, MTLibrary):
   name = 'libllvmlibc'
   never_force = True
   includes = ['system/lib/llvm-libc']
-  cflags = ['-Os', '-DLIBC_NAMESPACE=__llvm_libc', '-DLIBC_COPT_PUBLIC_PACKAGING']
+  cflags = ['-Os', '-DLIBC_NAMESPACE=__llvm_libc', '-DLLVM_LIBC', '-DLIBC_COPT_PUBLIC_PACKAGING']
 
   def get_files(self):
     files = glob_in_path('system/lib/llvm-libc/src/string', '**/*.cpp')
@@ -1010,6 +1010,8 @@ class llvmlibc(DebugLibrary, AsanInstrumentedLibrary, MTLibrary):
     files += glob_in_path('system/lib/llvm-libc/src/errno', '**/*.cpp')
     files += glob_in_path('system/lib/llvm-libc/src/math', '*.cpp')
     files += glob_in_path('system/lib/llvm-libc/src/wchar', '*.cpp')
+    files += glob_in_path('system/lib/llvm-libc/src/setjmp', '*.cpp')
+    files += glob_in_path('system/lib/llvm-libc/src/setjmp', '**/*.cpp')
     files += glob_in_path('system/lib/llvm-libc/src/stdlib', '*.cpp', excludes=['at_quick_exit.cpp',
                                                                                 'quick_exit.cpp',
                                                                                 'atexit.cpp',


### PR DESCRIPTION
Defined a wasm-specific wasm/sigsetjmp.cpp that just fowards the call to setjmp.

Defines in the musl header don't quite work with llvm-libc's setjmp.