### PR TITLE
[test] Handling buffering of subprocess output. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -13,6 +13,7 @@ from http.server import HTTPServer, SimpleHTTPRequestHandler
 import contextlib
 import difflib
 import hashlib
+import io
 import itertools
 import logging
 import multiprocessing
@@ -1763,18 +1764,35 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     if shared.EMSCRIPTEN_TEMP_DIR:
       utils.delete_contents(shared.EMSCRIPTEN_TEMP_DIR)
 
-  def run_process(self, cmd, check=True, **args):
+  def run_process(self, cmd, check=True, **kwargs):
     # Wrapper around shared.run_process.  This is desirable so that the tests
     # can fail (in the unittest sense) rather than error'ing.
     # In the long run it would nice to completely remove the dependency on
     # core emscripten code (shared.py) here.
+
+    # Handle buffering for subprocesses.  The python unittest buffering mechanism
+    # will only buffer output from the current process (by overwriding sys.stdout
+    # and sys.stderr), not from sub-processes.
+    stdout_buffering = 'stdout' not in kwargs and isinstance(sys.stdout, io.StringIO)
+    stderr_buffering = 'stderr' not in kwargs and isinstance(sys.stderr, io.StringIO)
+    if stdout_buffering:
+      kwargs['stdout'] = PIPE
+    if stderr_buffering:
+      kwargs['stderr'] = PIPE
+
     try:
-      return shared.run_process(cmd, check=check, **args)
+      rtn = shared.run_process(cmd, check=check, **kwargs)
     except subprocess.CalledProcessError as e:
       if check and e.returncode != 0:
         print(e.stdout)
         print(e.stderr)
         self.fail(f'subprocess exited with non-zero return code({e.returncode}): `{shlex.join(cmd)}`')
+
+    if stdout_buffering:
+      sys.stdout.write(rtn.stdout)
+    if stderr_buffering:
+      sys.stderr.write(rtn.stderr)
+    return rtn
 
   def emcc(self, filename, args=[], output_filename=None, **kwargs):  # noqa
     compile_only = '-c' in args or '-sSIDE_MODULE' in args


### PR DESCRIPTION
The python unittest framework has a stdout/stderr buffering mechanism that we don't take advantage of but that I would like to move towards using more.

This change allows our tests to run in buffered mode without generating output on the underlying stdout and stderr file descriptors.