### PR TITLE
[test] Remove check for time.perf_counter. NFC

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -127,22 +127,18 @@ class BufferedParallelTestResult:
   def stopTest(self, test):
     # TODO(sbc): figure out a way to display this duration information again when
     # these results get passed back to the TextTestRunner/TextTestResult.
-    if hasattr(time, 'perf_counter'):
-      self.buffered_result.duration = self.test_duration
+    self.buffered_result.duration = self.test_duration
 
   def addSuccess(self, test):
-    if hasattr(time, 'perf_counter'):
-      print(test, '... ok (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
+    print(test, '... ok (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
     self.buffered_result = BufferedTestSuccess(test)
 
   def addExpectedFailure(self, test, err):
-    if hasattr(time, 'perf_counter'):
-      print(test, '... expected failure (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
+    print(test, '... expected failure (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
     self.buffered_result = BufferedTestExpectedFailure(test, err)
 
   def addUnexpectedSuccess(self, test):
-    if hasattr(time, 'perf_counter'):
-      print(test, '... unexpected success (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
+    print(test, '... unexpected success (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
     self.buffered_result = BufferedTestUnexpectedSuccess(test)
 
   def addSkip(self, test, reason):


### PR DESCRIPTION
This attribute was added in python 3.3. No need to dynamically check for it anymore.