### PR TITLE
Ensure run dependencies are fulfilled before module promise resolves

### DIFF
--- a/src/postamble_modularize.js
+++ b/src/postamble_modularize.js
@@ -4,8 +4,6 @@
 // We assign to the `moduleRtn` global here and configure closure to see
 // this as and extern so it won't get minified.
 
-#if WASM_ASYNC_COMPILATION
-
 #if USE_READY_PROMISE
 if (runtimeInitialized)  {
   moduleRtn = Module;
@@ -19,12 +17,6 @@ if (runtimeInitialized)  {
 #else
 moduleRtn = {};
 #endif
-
-#else  // WASM_ASYNC_COMPILATION
-
-moduleRtn = Module;
-
-#endif // WASM_ASYNC_COMPILATION
 
 #if ASSERTIONS
 // Assertion for attempting to access module properties on the incoming

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7147,6 +7147,22 @@ int main(void) {
     output = self.run_js('run.mjs')
     self.assertContained('done init\nhello, world!\ngot module\n', output)
 
+  def test_modularize_run_dependency(self):
+    # Ensure that dependencies are fulfilled before the module promise is resolved.
+    create_file('pre.js', '''
+    Module.preRun = () => { dbg("add-dep"); addRunDependency("my dep"); }
+    // Remove the run dependency in 100 milliseconds
+    setTimeout(() => { dbg("remove-dep"); removeRunDependency("my dep") }, 100);
+    ''')
+    create_file('run.mjs', '''
+    import Module from './hello_world.mjs';
+    await Module();
+    console.log('got module');
+    ''')
+    self.cflags += ['-sEXPORT_ES6', '-sMODULARIZE', '-sWASM_ASYNC_COMPILATION=0', '--pre-js=pre.js']
+    self.emcc(test_file('hello_world.c'), output_filename='hello_world.mjs')
+    self.assertContained('add-dep\nremove-dep\nhello, world!\ngot module\n', self.run_js('run.mjs'))
+
   def test_modularize_instantiation_error(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-o', 'out.mjs'] + self.get_cflags())
     create_file('run.mjs', '''


### PR DESCRIPTION
The existing code didn't take into account that async compilation is not the only source of async run dependencies.

Without this change the test fails because the module promise is not used and the module is returned before its run dependencies have been fulfilled.