### PR TITLE
Use 64-bit fields for fsblkcnt_t and fsfilcnt_t

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 4.0.12 (in development)
 -----------------------
+- The `fsblkcnt_t` and `fsfilcnt_t` types used by `statfs`/`statvfs` were
+  changed from 32-bit to 64-bit. (#24769)
 - Support for `-sTEXT_DECODER=0` was removed, due to widespread support for
   `TextDecoder`.  The remaining valid values for this setting are `=1`
   (conditional use of `TextDecoder` with fallback) and `=2` (unconditional use

--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -66,11 +66,11 @@ var SyscallsLibrary = {
     writeStatFs(buf, stats) {
       {{{ makeSetValue('buf', C_STRUCTS.statfs.f_bsize, 'stats.bsize', 'i32') }}};
       {{{ makeSetValue('buf', C_STRUCTS.statfs.f_frsize, 'stats.bsize', 'i32') }}};
-      {{{ makeSetValue('buf', C_STRUCTS.statfs.f_blocks, 'stats.blocks', 'i32') }}};
-      {{{ makeSetValue('buf', C_STRUCTS.statfs.f_bfree, 'stats.bfree', 'i32') }}};
-      {{{ makeSetValue('buf', C_STRUCTS.statfs.f_bavail, 'stats.bavail', 'i32') }}};
-      {{{ makeSetValue('buf', C_STRUCTS.statfs.f_files, 'stats.files', 'i32') }}};
-      {{{ makeSetValue('buf', C_STRUCTS.statfs.f_ffree, 'stats.ffree', 'i32') }}};
+      {{{ makeSetValue('buf', C_STRUCTS.statfs.f_blocks, 'stats.blocks', 'i64') }}};
+      {{{ makeSetValue('buf', C_STRUCTS.statfs.f_bfree, 'stats.bfree', 'i64') }}};
+      {{{ makeSetValue('buf', C_STRUCTS.statfs.f_bavail, 'stats.bavail', 'i64') }}};
+      {{{ makeSetValue('buf', C_STRUCTS.statfs.f_files, 'stats.files', 'i64') }}};
+      {{{ makeSetValue('buf', C_STRUCTS.statfs.f_ffree, 'stats.ffree', 'i64') }}};
       {{{ makeSetValue('buf', C_STRUCTS.statfs.f_fsid, 'stats.fsid', 'i32') }}};
       {{{ makeSetValue('buf', C_STRUCTS.statfs.f_flags, 'stats.flags', 'i32') }}};  // ST_NOSUID
       {{{ makeSetValue('buf', C_STRUCTS.statfs.f_namelen, 'stats.namelen', 'i32') }}};

--- a/src/struct_info_generated.json
+++ b/src/struct_info_generated.json
@@ -1699,17 +1699,17 @@
             "st_uid": 12
         },
         "statfs": {
-            "__size__": 64,
-            "f_bavail": 16,
-            "f_bfree": 12,
+            "__size__": 88,
+            "f_bavail": 24,
+            "f_bfree": 16,
             "f_blocks": 8,
             "f_bsize": 4,
-            "f_ffree": 24,
-            "f_files": 20,
-            "f_flags": 44,
-            "f_frsize": 40,
-            "f_fsid": 28,
-            "f_namelen": 36
+            "f_ffree": 40,
+            "f_files": 32,
+            "f_flags": 64,
+            "f_frsize": 60,
+            "f_fsid": 48,
+            "f_namelen": 56
         },
         "termios": {
             "__c_ispeed": 52,

--- a/src/struct_info_generated_wasm64.json
+++ b/src/struct_info_generated_wasm64.json
@@ -1699,17 +1699,17 @@
             "st_uid": 16
         },
         "statfs": {
-            "__size__": 104,
-            "f_bavail": 24,
-            "f_bfree": 20,
+            "__size__": 120,
+            "f_bavail": 32,
+            "f_bfree": 24,
             "f_blocks": 16,
             "f_bsize": 8,
-            "f_ffree": 32,
-            "f_files": 28,
-            "f_flags": 64,
-            "f_frsize": 56,
-            "f_fsid": 36,
-            "f_namelen": 48
+            "f_ffree": 48,
+            "f_files": 40,
+            "f_flags": 80,
+            "f_frsize": 72,
+            "f_fsid": 56,
+            "f_namelen": 64
         },
         "termios": {
             "__c_ispeed": 52,

--- a/system/lib/libc/musl/arch/emscripten/bits/alltypes.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/alltypes.h
@@ -265,12 +265,12 @@ typedef int blkcnt_t;
 #endif
 
 #if defined(__NEED_fsblkcnt_t) && !defined(__DEFINED_fsblkcnt_t)
-typedef unsigned int fsblkcnt_t;
+typedef unsigned _Int64 fsblkcnt_t;
 #define __DEFINED_fsblkcnt_t
 #endif
 
 #if defined(__NEED_fsfilcnt_t) && !defined(__DEFINED_fsfilcnt_t)
-typedef unsigned int fsfilcnt_t;
+typedef unsigned _Int64 fsfilcnt_t;
 #define __DEFINED_fsfilcnt_t
 #endif
 

--- a/test/code_size/test_codesize_hello_dylink_all.json
+++ b/test/code_size/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 246743,
-  "a.out.nodebug.wasm": 597771,
-  "total": 844514,
+  "a.out.js": 246788,
+  "a.out.nodebug.wasm": 597789,
+  "total": 844577,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/core/test_statvfs.c
+++ b/test/core/test_statvfs.c
@@ -20,9 +20,9 @@ int main() {
 
   printf("f_bsize: %lu\n", s.f_bsize);
   printf("f_frsize: %lu\n", s.f_frsize);
-  printf("f_blocks: %u\n", s.f_blocks);
-  printf("f_bfree: %u\n", s.f_bfree);
-  printf("f_bavail: %u\n", s.f_bavail);
+  printf("f_blocks: %llu\n", s.f_blocks);
+  printf("f_bfree: %llu\n", s.f_bfree);
+  printf("f_bavail: %llu\n", s.f_bavail);
   printf("f_files: %d\n", s.f_files > 5);
   printf("f_ffree: %u\n", s.f_ffree <= s.f_files && s.f_ffree > 0);
   printf("f_favail: %u\n", s.f_favail <= s.f_files && s.f_favail > 0);


### PR DESCRIPTION
We were running into issues where some of our bots were reporting numbers larger than 2^32 when calling statfs on the underlying filesystem.