### PR TITLE
Fix MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION under node. NFC

### DIFF
--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -108,13 +108,17 @@ var imports = {
 
 #if MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION
 // https://caniuse.com/#feat=wasm and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
-#if MIN_FIREFOX_VERSION < 58 || MIN_CHROME_VERSION < 61 || MIN_NODE_VERSION < 180100 || MIN_SAFARI_VERSION < 150000
+#if MIN_FIREFOX_VERSION < 58 || MIN_CHROME_VERSION < 61 || MIN_SAFARI_VERSION < 150000 || ENVIRONMENT_MAY_BE_NODE
 #if ASSERTIONS && !WASM2JS
 // Module['wasm'] should contain a typed array of the Wasm object data, or a
 // precompiled WebAssembly Module.
 assert(WebAssembly.instantiateStreaming || Module['wasm'], 'Must load WebAssembly Module in to variable Module.wasm before adding compiled output .js script to the DOM');
 #endif
 (WebAssembly.instantiateStreaming
+#if ENVIRONMENT_MAY_BE_NODE
+  // Node's fetch API cannot by used for local files, so we cannot use instantiateStreaming
+  && !ENVIRONMENT_IS_NODE
+#endif
   ? WebAssembly.instantiateStreaming(fetch('{{{ TARGET_BASENAME }}}.wasm'), imports)
   : WebAssembly.instantiate(Module['wasm'], imports)).then((output) => {
 #else
@@ -221,13 +225,12 @@ WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
 #endif
 }
 
-#if ASSERTIONS || WASM == 2
+#if WASM == 2
 , (error) => {
 #if ASSERTIONS
   console.error(error);
 #endif
 
-#if WASM == 2
 #if ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL
   if (typeof location != 'undefined') {
 #endif
@@ -239,9 +242,8 @@ WebAssembly.instantiate(Module['wasm'], imports).then((output) => {
 #if ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL
   }
 #endif
-#endif // WASM == 2
 }
-#endif // ASSERTIONS || WASM == 2
+#endif // WASM == 2
 );
 
 #if PTHREADS || WASM_WORKERS

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -116,7 +116,7 @@ assert(WebAssembly.instantiateStreaming || Module['wasm'], 'Must load WebAssembl
 #endif
 (WebAssembly.instantiateStreaming
 #if ENVIRONMENT_MAY_BE_NODE
-  // Node's fetch API cannot by used for local files, so we cannot use instantiateStreaming
+  // Node's fetch API cannot be used for local files, so we cannot use instantiateStreaming
   && !ENVIRONMENT_IS_NODE
 #endif
   ? WebAssembly.instantiateStreaming(fetch('{{{ TARGET_BASENAME }}}.wasm'), imports)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8805,7 +8805,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.cflags = args
     self.set_setting('MINIMAL_RUNTIME')
     self.maybe_closure()
-    self.do_runf('small_hello_world.c', 'hello')
+    self.do_runf('small_hello_world.c', 'hello!')
 
   # Test that printf() works in MINIMAL_RUNTIME=1
   @no_wasmfs('https://github.com/emscripten-core/emscripten/issues/16816')


### PR DESCRIPTION
We cannot actually use this API under node since the fetch API doesn't support local files.

However, this failure was going undetected for two reason:

1. The test was only looking for the string 'hello' in the output which also appears in backtraces.
2. The instantiation error was being swallowed by a catch block that simply printed the error the console, so the node process was exiting with success.