### PR TITLE
Update docs for min version of node and python. NFC

### DIFF
--- a/site/source/docs/building_from_source/toolchain_what_is_needed.rst
+++ b/site/source/docs/building_from_source/toolchain_what_is_needed.rst
@@ -22,8 +22,8 @@ Emscripten tools and dependencies
 
 In general a complete Emscripten environment requires the following tools. First test to see if they are already installed using the :ref:`instructions below <toolchain-test-which-dependencies-are-installed>`.
 
-  - :term:`Node.js` (0.8 or above; 0.10.17 or above to run websocket-using servers in node)
-  - :term:`Python` (3.6 or above)
+  - :term:`Node.js` (18.3.0 or above)
+  - :term:`Python` (3.8 or above)
   - :term:`Java` (1.6.0_31 or later). Java is optional. It can be used to run the java version of term:`Closure Compiler`.
   - :term:`Git` client. Git is required if building tools from source.
   - :term:`LLVM` (LLVM, including clang and wasm-ld)


### PR DESCRIPTION
The python version was bumped to 3.8 in #23417 (and #24422).

The node version was last updated in #23520.