### PR TITLE
[embind] Handle -fno-exceptions and try/catch redefinition macros.

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -728,6 +728,9 @@ public:
   auto initial_suspend() noexcept { return std::suspend_never{}; }
   auto final_suspend() noexcept { return std::suspend_never{}; }
 
+// When exceptions are disabled we don't define unhandled_exception and rely
+// on the default terminate behavior.
+#ifdef __cpp_exceptions
   // On an unhandled exception, reject the stored promise instead of throwing
   // it asynchronously where it can't be handled.
   void unhandled_exception() {
@@ -740,6 +743,7 @@ public:
       reject(error);
     }
   }
+#endif
 
   // Reject the stored promise due to rejection deeper in the call chain
   void reject_with(val&& error) {

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15779,6 +15779,12 @@ addToLibrary({
     create_file('b.cpp', '#include <emscripten/bind.h>')
     self.run_process([EMXX, '-std=c++23', '-lembind', 'a.cpp', 'b.cpp'])
 
+  def test_embind_no_exceptions(self):
+    # Test disabling exceptions and redefining try/catch with preprocessor
+    # macros.
+    create_file('a.cpp', '#define try\n#define catch if (0)\n#include <emscripten/bind.h>')
+    self.run_process([EMXX, '-fno-exceptions', '-std=c++23', '-lembind', 'a.cpp'])
+
   def test_no_pthread(self):
     self.do_runf('hello_world.c', cflags=['-pthread', '-no-pthread'])
     self.assertExists('hello_world.js')


### PR DESCRIPTION
When some code bases disable exceptions they also redefine try/catch with preprocessor macros. This causes the val coroutine function `unhandled_exception` to fail to compile with
`error: use of undeclared identifier 'error'`.