### PR TITLE
Simplify `new Function` call. NFC

### DIFF
--- a/src/lib/libhtml5_webgl.js
+++ b/src/lib/libhtml5_webgl.js
@@ -603,8 +603,7 @@ function handleWebGLProxying(funcs) {
         funcs[i + '__deps'].push('$' + i + '_before_on_calling_thread');
         funcBody = `${i}_before_on_calling_thread(${funcArgsString}); ` + funcBody;
       }
-      funcArgs.push(funcBody);
-      funcs[i] = new (Function.prototype.bind.call(Function, Function, ...funcArgs));
+      funcs[i] = new Function(...funcArgs, funcBody);
     } else if (targetingOffscreenFramebuffer) {
       // When targeting only OFFSCREEN_FRAMEBUFFER, unconditionally proxy all GL calls to
       // main thread.

--- a/src/lib/libhtml5_webgl.js
+++ b/src/lib/libhtml5_webgl.js
@@ -603,7 +603,7 @@ function handleWebGLProxying(funcs) {
         funcs[i + '__deps'].push('$' + i + '_before_on_calling_thread');
         funcBody = `${i}_before_on_calling_thread(${funcArgsString}); ` + funcBody;
       }
-      funcs[i] = new Function(...funcArgs, funcBody);
+      funcs[i] = new Function(funcArgs, funcBody);
     } else if (targetingOffscreenFramebuffer) {
       // When targeting only OFFSCREEN_FRAMEBUFFER, unconditionally proxy all GL calls to
       // main thread.


### PR DESCRIPTION
This code was originally added I suppose before rest/spread operators were allowed.

IIUC this code is equivalent.