### PR TITLE
Fix bug in dynCalls generation

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1735,11 +1735,14 @@ addToLibrary({
     var f = dynCalls[sig];
     return f(ptr, ...args);
   },
-#if DYNCALLS
-  $dynCall__deps: ['$dynCallLegacy'],
-#else
-  $dynCall__deps: ['$getWasmTableEntry'],
+  $dynCall__deps: [
+#if DYNCALLS || !WASM_BIGINT
+    '$dynCallLegacy',
 #endif
+#if !DYNCALLS
+    '$getWasmTableEntry',
+#endif
+  ],
 #endif
 
   // Used in library code to get JS function from wasm function pointer.

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -526,8 +526,11 @@ var LibraryDylink = {
 #if DYNCALLS || !WASM_BIGINT
   $registerDynCallSymbols: (exports) => {
     for (var [sym, exp] of Object.entries(exports)) {
-      if (sym.startsWith('dynCall_') && !Module.hasOwnProperty(sym)) {
-        Module[sym] = exp;
+      if (sym.startsWith('dynCall_')) {
+        var sig = sym.substring(8);
+        if (!dynCalls.hasOwnProperty(sig)) {
+          dynCalls[sig] = exp;
+        }
       }
     }
   },

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -4495,12 +4495,16 @@ res64 - external 64\n''', header='''\
     ''', force_c=True)
 
   @parameterized({
-    '': (False,),
-    'rtld_local': (True,),
+    '': [False],
+    'rtld_local': [True],
+  })
+  @parameterized({
+    '': [[]],
+    'nobigint': [['-sWASM_BIGINT=0']],
   })
   @needs_dylink
-  @also_with_wasm_bigint
-  def test_dylink_i64_invoke(self, rtld_local):
+  def test_dylink_i64_invoke(self, rtld_local, args):
+    self.cflags += args
     if rtld_local:
       self.set_setting('NO_AUTOLOAD_DYLIBS')
       self.cflags.append('-DUSE_DLOPEN')

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -918,8 +918,8 @@ def should_export(sym):
   return settings.EXPORT_ALL or (settings.EXPORT_KEEPALIVE and sym in settings.EXPORTED_FUNCTIONS)
 
 
-def create_receiving(function_exports, tag_exports):
-  generate_dyncall_assignment = settings.DYNCALLS and '$dynCall' in settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE
+def create_receiving(function_exports, tag_exports, library_symbols):
+  generate_dyncall_assignment = 'dynCalls' in library_symbols
   receiving = ['\n// Imports from the Wasm binary.']
 
   if settings.WASM_ESM_INTEGRATION:
@@ -1006,10 +1006,10 @@ def create_receiving(function_exports, tag_exports):
   return '\n'.join(receiving) + '\n'
 
 
-def create_module(metadata, function_exports, global_exports, tag_exports,library_symbols):
+def create_module(metadata, function_exports, global_exports, tag_exports, library_symbols):
   module = []
 
-  receiving = create_receiving(function_exports, tag_exports)
+  receiving = create_receiving(function_exports, tag_exports, library_symbols)
   receiving += create_global_exports(global_exports)
   sending = create_sending(metadata, library_symbols)
 


### PR DESCRIPTION
There are actually two different bug fixes here:

1. The deps for `dynCall` was not setup correctly in all cases
2. Addition to `dynCall` array from shared libraries were not being added.  The code was incorrectly adding these to the `Module` object, which we stopped used for this purpose in #24399

These bugs went unnoticed because the test_dylink_i64_invoke test was not correctly being run without `WASM_BIGINT`.

I have a followup to correctly / invert the `@also_with_wasm_bigint` decorator.