### PR TITLE
Fix skipping reftests and add helper to skip ref tests.

### DIFF
--- a/test/browser/webgl_draw_base_vertex_base_instance_test.c
+++ b/test/browser/webgl_draw_base_vertex_base_instance_test.c
@@ -70,7 +70,7 @@ int main() {
 
   if (!extAvailable) {
     EM_ASM({
-      fetch('http://localhost:8888/report_result?skipped:%20WEBGL_draw_instanced_base_vertex_base_instance%20is%20not%20supported!').then(() => window.close());
+      skipTest('WEBGL_draw_instanced_base_vertex_base_instance is not supported');
     });
     return 0;
   }

--- a/test/browser/webgl_multi_draw_test.c
+++ b/test/browser/webgl_multi_draw_test.c
@@ -60,7 +60,7 @@ int main()
 
   if (!extAvailable) {
     EM_ASM({
-      fetch("http://localhost:8888/report_result?skipped:%20WEBGL_multi_draw%20is%20not%20supported!").then(() => window.close());
+      skipTest('WEBGL_multi_draw is not supported');
     });
     return 0;
   }

--- a/test/browser_reporting.js
+++ b/test/browser_reporting.js
@@ -5,7 +5,7 @@ var hasModule = typeof Module === 'object' && Module;
 
 var reportingURL = 'http://localhost:8888';
 
-async function reportResultToServer(result) {
+async function reportResultToServer(result, extra = '') {
   if (reportResultToServer.reported) {
     // Only report one result per test, even if the test misbehaves and tries to report more.
     reportStderrToServer(`excessive reported results, sending ${result}, test will fail`);
@@ -14,7 +14,7 @@ async function reportResultToServer(result) {
   if ((typeof ENVIRONMENT_IS_NODE !== 'undefined' && ENVIRONMENT_IS_NODE) || (typeof ENVIRONMENT_IS_AUDIO_WORKLET !== 'undefined' && ENVIRONMENT_IS_AUDIO_WORKLET)) {
     out(`RESULT: ${result}`);
   } else {
-    await fetch(`${reportingURL}/report_result?${encodeURIComponent(result)}`);
+    await fetch(`${reportingURL}/report_result?${extra}${encodeURIComponent(result)}`);
     if (typeof window === 'object' && window && hasModule && !Module['pageThrewException']) {
       /* for easy debugging, don't close window on failure */
       window.close();
@@ -50,6 +50,11 @@ function reportStdoutToServer(message) {
   } else {
     logMessageToServer('stdout', message);
   }
+}
+
+async function skipTest(message) {
+  skipTest.skipped = true;
+  await reportResultToServer(message, 'skipped:');
 }
 
 function reportTopLevelError(e) {

--- a/test/canvas_animate_resize.c
+++ b/test/canvas_animate_resize.c
@@ -126,8 +126,7 @@ int main()
   if (!ctx) {
     if (!emscripten_supports_offscreencanvas()) {
       EM_ASM({
-        fetch("http://localhost:8888/report_result?skipped:%20OffscreenCanvas%20is%20not%20supported!")
-        .then(() => window.close());
+        skipTest('OffscreenCanvas is not supported!');
       });
     }
     return 0;

--- a/test/reftest.js
+++ b/test/reftest.js
@@ -23,6 +23,7 @@ function reftestUnblock() {
 function doReftest() {
   if (reftestBlocked) return;
   if (doReftest.done) return;
+  if (skipTest.skipped) return;
   doReftest.done = true;
   var img = new Image();
   img.onload = () => {


### PR DESCRIPTION
Reftests that were being skipped were still trying to run the reftest snapshot code and report a result. Since this was async, the result would sometimes come in while the next test was started and cause "excessive responses from previous test".

This should fix flakes with several test_webgl tests.