### PR TITLE
Avoid injecting `--experimental-wasm-bigint` into `#!` line when creating node-runnable output

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,8 +22,8 @@ See docs/process.md for more on how version tagging works.
 -----------------------
 - The `#!` line that emscripten, under some circumstances, will add to the
   generated JS code no longer injects the `--experimental-wasm-bigint` node
-  flag.  This flag is not needed on recent versions of node, so its not possible
-  to know if its safe to include. (#24808)
+  flag.  This flag is not needed on recent versions of node, and in fact
+  errors there, so it's not possible to know if it's safe to include. (#24808)
 - In `-sMODULARIZE` mode the factory function will now always return a promise,
   even when `WASM_ASYNC_COMPILATION` is disabled.  This is because emscripten
   has other features that might also return async module creation (e.g. loading

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 4.0.12 (in development)
 -----------------------
+- The `#!` line that emscripten, under some circumstances, will add to the
+  generated JS code no longer injects the `--experimental-wasm-bigint` node
+  flag.  This flag is not needed on recent versions of node, so its not possible
+  to know if its safe to include. (#24808)
 - In `-sMODULARIZE` mode the factory function will now always return a promise,
   even when `WASM_ASYNC_COMPILATION` is disabled.  This is because emscripten
   has other features that might also return async module creation (e.g. loading

--- a/test/common.py
+++ b/test/common.py
@@ -275,6 +275,15 @@ def requires_node_canary(func):
   return decorated
 
 
+def node_bigint_flags(node_version):
+  # The --experimental-wasm-bigint flag was added in v12, and then removed (enabled by default)
+  # in v16.
+  if node_version and node_version < (16, 0, 0) and node_version >= (12, 0, 0):
+    return ['--experimental-wasm-bigint']
+  else:
+    return []
+
+
 # Used to mark dependencies in various tests to npm developer dependency
 # packages, which might not be installed on Emscripten end users' systems.
 def requires_dev_dependency(package):
@@ -1214,7 +1223,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
           # Opt in to node v15 default behaviour:
           # https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
           self.node_args.append('--unhandled-rejections=throw')
-      self.node_args += shared.node_bigint_flags(nodejs)
+      self.node_args += node_bigint_flags(node_version)
 
       # If the version we are running tests in is lower than the version that
       # emcc targets then we need to tell emcc to target that older version.

--- a/tools/link.py
+++ b/tools/link.py
@@ -467,8 +467,6 @@ def get_binaryen_passes():
 def make_js_executable(script):
   src = read_file(script)
   cmd = config.NODE_JS
-  if settings.WASM_BIGINT:
-    cmd += shared.node_bigint_flags(config.NODE_JS)
   if len(cmd) > 1 or not os.path.isabs(cmd[0]):
     # Using -S (--split-string) here means that arguments to the executable are
     # correctly parsed.  We don't do this by default because old versions of env

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -344,16 +344,6 @@ def check_node_version():
   return version
 
 
-def node_bigint_flags(nodejs):
-  node_version = get_node_version(nodejs)
-  # The --experimental-wasm-bigint flag was added in v12, and then removed (enabled by default)
-  # in v16.
-  if node_version and node_version < (16, 0, 0) and node_version >= (12, 0, 0):
-    return ['--experimental-wasm-bigint']
-  else:
-    return []
-
-
 def node_reference_types_flags(nodejs):
   node_version = get_node_version(nodejs)
   # reference types were enabled by default in node v18.


### PR DESCRIPTION
This was the last remaining usage of `node_bigint_flags` in the compiler so this function
was moved into test code where it is still used.

IIUC its better not to do this at all for a few reasons:

1. The version of node used in the emscripten compiler is not the same as the version that will be used the run the output program, so basing these flags on `settings.NODE_JS` is just wrong.
2. If folks want to target older versions of node we already have ways to do that `-sMIN_NODE_VERSION`.  They can also add this flag themselves when running the output program.  I don't think is out business to inject node flags here.