### PR TITLE
Use `var` and `undefined` in libwebaudio.js. NFC

### DIFF
--- a/src/lib/libwebaudio.js
+++ b/src/lib/libwebaudio.js
@@ -8,7 +8,7 @@
 #error "-sAUDIO_WORKLET does not support -sSINGLE_FILE"
 #endif
 
-let LibraryWebAudio = {
+var LibraryWebAudio = {
   $EmAudio: {},
   $EmAudioCounter: 0,
 
@@ -54,16 +54,16 @@ let LibraryWebAudio = {
   // this avoids the user needing to manually add the dependency on the command line.
   emscripten_create_audio_context__deps: ['$emscriptenRegisterAudioObject', '$emscriptenGetAudioObject'],
   emscripten_create_audio_context: (options) => {
-    let ctx = window.AudioContext || window.webkitAudioContext;
+    var ctx = window.AudioContext || window.webkitAudioContext;
 #if ASSERTIONS
     if (!ctx) console.error('emscripten_create_audio_context failed! Web Audio is not supported.');
 #endif
     options >>= 2;
 
-    let opts = options ? {
-      latencyHint: HEAPU32[options] ? UTF8ToString(HEAPU32[options]) : void 0,
-      sampleRate: HEAP32[options+1] || void 0
-    } : void 0;
+    var opts = options ? {
+      latencyHint: HEAPU32[options] ? UTF8ToString(HEAPU32[options]) : undefined,
+      sampleRate: HEAP32[options+1] || undefined
+    } : undefined;
 
 #if WEBAUDIO_DEBUG
     console.log(`Creating new WebAudio context with parameters:`);
@@ -146,8 +146,8 @@ let LibraryWebAudio = {
     assert(EmAudio[contextHandle] instanceof (window.AudioContext || window.webkitAudioContext), `Called emscripten_start_wasm_audio_worklet_thread_async() on a context handle ${contextHandle} that is not an AudioContext, but of type ${typeof EmAudio[contextHandle]}`);
 #endif
 
-    let audioContext = EmAudio[contextHandle],
-      audioWorklet = audioContext.audioWorklet;
+    var audioContext = EmAudio[contextHandle];
+    var audioWorklet = audioContext.audioWorklet;
 
 #if ASSERTIONS
     assert(stackLowestAddress != 0, 'AudioWorklets require a dedicated stack space for audio data marshalling between Wasm and JS!');
@@ -162,7 +162,7 @@ let LibraryWebAudio = {
     console.log(`emscripten_start_wasm_audio_worklet_thread_async() adding audioworklet.js...`);
 #endif
 
-    let audioWorkletCreationFailed = () => {
+    var audioWorkletCreationFailed = () => {
 #if ASSERTIONS || WEBAUDIO_DEBUG
       console.error(`emscripten_start_wasm_audio_worklet_thread_async() addModule() failed!`);
 #endif
@@ -208,10 +208,10 @@ let LibraryWebAudio = {
 
   $_EmAudioDispatchProcessorCallback__deps: ['$getWasmTableEntry'],
   $_EmAudioDispatchProcessorCallback: (e) => {
-    let data = e.data;
+    var data = e.data;
     // '_wsc' is short for 'wasm call', trying to use an identifier name that
     // will never conflict with user code
-    let wasmCall = data['_wsc'];
+    var wasmCall = data['_wsc'];
     wasmCall && getWasmTableEntry(wasmCall)(...data.args);
   },
 
@@ -223,7 +223,7 @@ let LibraryWebAudio = {
 #endif
 
     options >>= 2;
-    let audioParams = [],
+    var audioParams = [],
       numAudioParams = HEAPU32[options+1],
       audioParamDescriptors = HEAPU32[options+2] >> 2,
       i = 0;
@@ -265,21 +265,21 @@ let LibraryWebAudio = {
     options >>= 2;
 
     function readChannelCountArray(heapIndex, numOutputs) {
-      let channelCounts = [];
+      var channelCounts = [];
       while (numOutputs--) channelCounts.push(HEAPU32[heapIndex++]);
       return channelCounts;
     }
 
-    let opts = options ? {
+    var opts = options ? {
       numberOfInputs: HEAP32[options],
       numberOfOutputs: HEAP32[options+1],
-      outputChannelCount: HEAPU32[options+2] ? readChannelCountArray(HEAPU32[options+2]>>2, HEAP32[options+1]) : void 0,
+      outputChannelCount: HEAPU32[options+2] ? readChannelCountArray(HEAPU32[options+2]>>2, HEAP32[options+1]) : undefined,
       processorOptions: {
         callback,
         userData,
         samplesPerChannel: emscriptenGetContextQuantumSize(contextHandle),
       }
-    } : void 0;
+    } : undefined;
 
 #if WEBAUDIO_DEBUG
     console.log(`Creating AudioWorkletNode "${UTF8ToString(name)}" on context=${contextHandle} with options:`);

--- a/test/code_size/audio_worklet_wasm.js
+++ b/test/code_size/audio_worklet_wasm.js
@@ -135,8 +135,7 @@ var N = [], O = a => {
         if (G[c + 2]) {
             var m = G[c + 2] >> 2;
             c = M[c + 1];
-            let w = [];
-            for (;c--; ) w.push(G[m++]);
+            for (var w = []; c--; ) w.push(G[m++]);
             m = w;
         } else m = void 0;
         d = {
@@ -155,8 +154,7 @@ var N = [], O = a => {
     return T;
 }, da = (a, b, c, d) => {
     b >>= 2;
-    let e = [], h = G[b + 1], f = G[b + 2] >> 2, m = 0;
-    for (;h--; ) e.push({
+    for (var e = [], h = G[b + 1], f = G[b + 2] >> 2, m = 0; h--; ) e.push({
         name: m++,
         defaultValue: I[f++],
         minValue: I[f++],
@@ -175,10 +173,10 @@ var N = [], O = a => {
     });
 }, ea = () => !1, fa = 1, ha = a => {
     a = a.data;
-    let b = a._wsc;
+    var b = a._wsc;
     b && C.get(b)(...a.A);
 }, ia = a => E(a), ja = (a, b, c, d, e) => {
-    let h = S[a], f = h.audioWorklet, m = () => {
+    var h = S[a], f = h.audioWorklet, m = () => {
         C.get(d)(a, 0, e);
     };
     if (!f) return m();

--- a/test/code_size/test_minimal_runtime_code_size_audio_worklet.json
+++ b/test/code_size/test_minimal_runtime_code_size_audio_worklet.json
@@ -1,10 +1,10 @@
 {
   "a.html": 519,
   "a.html.gz": 357,
-  "a.js": 3853,
-  "a.js.gz": 2045,
+  "a.js": 3851,
+  "a.js.gz": 2048,
   "a.wasm": 1288,
   "a.wasm.gz": 860,
-  "total": 5660,
-  "total_gz": 3262
+  "total": 5658,
+  "total_gz": 3265
 }


### PR DESCRIPTION
The convention for JS library code is to use var for better minification.

The use of `void 0` instead of `undefined` I believe is a minor code size optimization, but its somewhat obscure and (as you can see from the fact that the code expectations didn't change) it an optimization that is already performed on the generated code anyway.

Split out from #24732