### PR TITLE
[llvm-libc] Import assert and complex into Emscripten

### DIFF
--- a/system/lib/libc/musl/src/setjmp/longjmp.c
+++ b/system/lib/libc/musl/src/setjmp/longjmp.c
@@ -1,3 +1,0 @@
-#ifdef __EMSCRIPTEN__
-#define sigsetjmp(buf, x) setjmp((buf))
-#endif

--- a/system/lib/libc/musl/src/setjmp/setjmp.c
+++ b/system/lib/libc/musl/src/setjmp/setjmp.c
@@ -1,3 +1,0 @@
-#ifdef __EMSCRIPTEN__
-#define siglongjmp(buf, val) longjmp(buf, val)
-#endif

--- a/system/lib/llvm-libc/src/assert/__assert_fail.h
+++ b/system/lib/llvm-libc/src/assert/__assert_fail.h
@@ -1,0 +1,22 @@
+//===-- Internal header for __assert_fail -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_ASSERT___ASSERT_FAIL_H
+#define LLVM_LIBC_SRC_ASSERT___ASSERT_FAIL_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+[[noreturn]] void __assert_fail(const char *assertion, const char *file,
+                                unsigned line, const char *function);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_ASSERT___ASSERT_FAIL_H

--- a/system/lib/llvm-libc/src/assert/assert.h
+++ b/system/lib/llvm-libc/src/assert/assert.h
@@ -1,0 +1,35 @@
+// NOLINT(llvm-header-guard) https://github.com/llvm/llvm-project/issues/83339
+//===-- Internal header for assert ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/assert/__assert_fail.h"
+
+// There is no header guard here since assert is intended to be capable of being
+// included multiple times with NDEBUG defined differently, causing different
+// behavior.
+
+#undef assert
+
+#ifdef NDEBUG
+#define assert(e) (void)0
+#else
+
+#ifdef __has_builtin
+#if __has_builtin(__builtin_expect)
+#define __LIBC_ASSERT_LIKELY(e) __builtin_expect(e, 1)
+#endif
+#endif
+#ifndef __LIBC_ASSERT_LIKELY
+#define __LIBC_ASSERT_LIKELY(e) e
+#endif
+
+#define assert(e)                                                              \
+  (__LIBC_ASSERT_LIKELY(e) ? (void)0                                           \
+                           : LIBC_NAMESPACE::__assert_fail(                    \
+                                 #e, __FILE__, __LINE__, __PRETTY_FUNCTION__))
+#endif // NDEBUG

--- a/system/lib/llvm-libc/src/assert/generic/__assert_fail.cpp
+++ b/system/lib/llvm-libc/src/assert/generic/__assert_fail.cpp
@@ -1,0 +1,24 @@
+//===-- Implementation of __assert_fail -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/assert/__assert_fail.h"
+#include "src/__support/OSUtil/io.h"
+#include "src/__support/libc_assert.h"
+#include "src/__support/macros/config.h"
+#include "src/stdlib/abort.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void, __assert_fail,
+                   (const char *assertion, const char *file, unsigned line,
+                    const char *function)) {
+  LIBC_NAMESPACE::report_assertion_failure(assertion, file, line, function);
+  LIBC_NAMESPACE::abort();
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/assert/gpu/__assert_fail.cpp
+++ b/system/lib/llvm-libc/src/assert/gpu/__assert_fail.cpp
@@ -1,0 +1,41 @@
+//===-- GPU definition of a libc internal assert macro ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/assert/__assert_fail.h"
+
+#include "src/__support/CPP/atomic.h"
+#include "src/__support/GPU/utils.h"
+#include "src/__support/libc_assert.h"
+#include "src/__support/macros/config.h"
+#include "src/stdlib/abort.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// A single-use lock to allow only a single thread to print the assertion.
+static cpp::Atomic<uint32_t> lock = 0;
+
+LLVM_LIBC_FUNCTION(void, __assert_fail,
+                   (const char *assertion, const char *file, unsigned line,
+                    const char *function)) {
+  uint64_t mask = gpu::get_lane_mask();
+  // We only want a single work group or warp to handle the assertion. Each
+  // group attempts to claim the lock, if it is already claimed we simply exit.
+  uint32_t claimed = gpu::is_first_lane(mask)
+                         ? !lock.fetch_or(1, cpp::MemoryOrder::ACQUIRE)
+                         : 0;
+  if (!gpu::broadcast_value(mask, claimed))
+    gpu::end_program();
+
+  // Only a single line should be printed if an assertion is hit.
+  if (gpu::is_first_lane(mask))
+    LIBC_NAMESPACE::report_assertion_failure(assertion, file, line, function);
+  gpu::sync_lane(mask);
+  LIBC_NAMESPACE::abort();
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/cimag.h
+++ b/system/lib/llvm-libc/src/complex/cimag.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for cimag -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CIMAG_H
+#define LLVM_LIBC_SRC_COMPLEX_CIMAG_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+double cimag(_Complex double x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CIMAG_H

--- a/system/lib/llvm-libc/src/complex/cimagf.h
+++ b/system/lib/llvm-libc/src/complex/cimagf.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for cimagf ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CIMAGF_H
+#define LLVM_LIBC_SRC_COMPLEX_CIMAGF_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+float cimagf(_Complex float x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CIMAGF_H

--- a/system/lib/llvm-libc/src/complex/cimagf128.h
+++ b/system/lib/llvm-libc/src/complex/cimagf128.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for cimagf128 ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CIMAGF128_H
+#define LLVM_LIBC_SRC_COMPLEX_CIMAGF128_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/complex_types.h"
+#include "src/__support/macros/properties/types.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+float128 cimagf128(cfloat128 x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CIMAGF128_H

--- a/system/lib/llvm-libc/src/complex/cimagf16.h
+++ b/system/lib/llvm-libc/src/complex/cimagf16.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for cimagf16 ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CIMAGF16_H
+#define LLVM_LIBC_SRC_COMPLEX_CIMAGF16_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/complex_types.h"
+#include "src/__support/macros/properties/types.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+float16 cimagf16(cfloat16 x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CIMAGF16_H

--- a/system/lib/llvm-libc/src/complex/cimagl.h
+++ b/system/lib/llvm-libc/src/complex/cimagl.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for cimagl ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CIMAGL_H
+#define LLVM_LIBC_SRC_COMPLEX_CIMAGL_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+long double cimagl(_Complex long double x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CIMAGL_H

--- a/system/lib/llvm-libc/src/complex/conj.h
+++ b/system/lib/llvm-libc/src/complex/conj.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for conj --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CONJ_H
+#define LLVM_LIBC_SRC_COMPLEX_CONJ_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+_Complex double conj(_Complex double x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CONJ_H

--- a/system/lib/llvm-libc/src/complex/conjf.h
+++ b/system/lib/llvm-libc/src/complex/conjf.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for conjf -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CONJF_H
+#define LLVM_LIBC_SRC_COMPLEX_CONJF_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+_Complex float conjf(_Complex float x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CONJF_H

--- a/system/lib/llvm-libc/src/complex/conjf128.h
+++ b/system/lib/llvm-libc/src/complex/conjf128.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for conjf128 ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CONJF128_H
+#define LLVM_LIBC_SRC_COMPLEX_CONJF128_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/complex_types.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+cfloat128 conjf128(cfloat128 x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CONJF128_H

--- a/system/lib/llvm-libc/src/complex/conjf16.h
+++ b/system/lib/llvm-libc/src/complex/conjf16.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for conjf16 -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CONJF16_H
+#define LLVM_LIBC_SRC_COMPLEX_CONJF16_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/complex_types.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+cfloat16 conjf16(cfloat16 x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CONJF16_H

--- a/system/lib/llvm-libc/src/complex/conjl.h
+++ b/system/lib/llvm-libc/src/complex/conjl.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for conjl -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CONJL_H
+#define LLVM_LIBC_SRC_COMPLEX_CONJL_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+_Complex long double conjl(_Complex long double x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CONJL_H

--- a/system/lib/llvm-libc/src/complex/cproj.h
+++ b/system/lib/llvm-libc/src/complex/cproj.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for cproj -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CPROJ_H
+#define LLVM_LIBC_SRC_COMPLEX_CPROJ_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+_Complex double cproj(_Complex double x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CPROJ_H

--- a/system/lib/llvm-libc/src/complex/cprojf.h
+++ b/system/lib/llvm-libc/src/complex/cprojf.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for cprojf ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CPROJF_H
+#define LLVM_LIBC_SRC_COMPLEX_CPROJF_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+_Complex float cprojf(_Complex float x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CPROJF_H

--- a/system/lib/llvm-libc/src/complex/cprojf128.h
+++ b/system/lib/llvm-libc/src/complex/cprojf128.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for cprojf128 ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CPROJF128_H
+#define LLVM_LIBC_SRC_COMPLEX_CPROJF128_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/complex_types.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+cfloat128 cprojf128(cfloat128 x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CPROJF128_H

--- a/system/lib/llvm-libc/src/complex/cprojf16.h
+++ b/system/lib/llvm-libc/src/complex/cprojf16.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for cprojf16 ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CPROJF16_H
+#define LLVM_LIBC_SRC_COMPLEX_CPROJF16_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/complex_types.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+cfloat16 cprojf16(cfloat16 x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CPROJF16_H

--- a/system/lib/llvm-libc/src/complex/cprojl.h
+++ b/system/lib/llvm-libc/src/complex/cprojl.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for cprojl ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CPROJL_H
+#define LLVM_LIBC_SRC_COMPLEX_CPROJL_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+_Complex long double cprojl(_Complex long double x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CPROJL_H

--- a/system/lib/llvm-libc/src/complex/creal.h
+++ b/system/lib/llvm-libc/src/complex/creal.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for creal -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CREAL_H
+#define LLVM_LIBC_SRC_COMPLEX_CREAL_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+double creal(_Complex double x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CREAL_H

--- a/system/lib/llvm-libc/src/complex/crealf.h
+++ b/system/lib/llvm-libc/src/complex/crealf.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for crealf ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CREALF_H
+#define LLVM_LIBC_SRC_COMPLEX_CREALF_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+float crealf(_Complex float x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CREALF_H

--- a/system/lib/llvm-libc/src/complex/crealf128.h
+++ b/system/lib/llvm-libc/src/complex/crealf128.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for crealf128 ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CREALF128_H
+#define LLVM_LIBC_SRC_COMPLEX_CREALF128_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/complex_types.h"
+#include "src/__support/macros/properties/types.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+float128 crealf128(cfloat128 x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CREALF128_H

--- a/system/lib/llvm-libc/src/complex/crealf16.h
+++ b/system/lib/llvm-libc/src/complex/crealf16.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for crealf16 ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CREALF16_H
+#define LLVM_LIBC_SRC_COMPLEX_CREALF16_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/complex_types.h"
+#include "src/__support/macros/properties/types.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+float16 crealf16(cfloat16 x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CREALF16_H

--- a/system/lib/llvm-libc/src/complex/creall.h
+++ b/system/lib/llvm-libc/src/complex/creall.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for creall ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_COMPLEX_CREALL_H
+#define LLVM_LIBC_SRC_COMPLEX_CREALL_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+long double creall(_Complex long double x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_COMPLEX_CREALL_H

--- a/system/lib/llvm-libc/src/complex/generic/cimag.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/cimag.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of cimag function ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/cimag.h"
+#include "src/__support/CPP/bit.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_type.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, cimag, (_Complex double x)) {
+  Complex<double> x_c = cpp::bit_cast<Complex<double>>(x);
+  return x_c.imag;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/cimagf.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/cimagf.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of cimagf function ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/cimagf.h"
+#include "src/__support/CPP/bit.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_type.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(float, cimagf, (_Complex float x)) {
+  Complex<float> x_c = cpp::bit_cast<Complex<float>>(x);
+  return x_c.imag;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/cimagf128.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/cimagf128.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of cimagf128 function ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/cimagf128.h"
+#include "src/__support/CPP/bit.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_type.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(float128, cimagf128, (cfloat128 x)) {
+  Complex<float128> x_c = cpp::bit_cast<Complex<float128>>(x);
+  return x_c.imag;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/cimagl.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/cimagl.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of cimagl function ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/cimagl.h"
+#include "src/__support/CPP/bit.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_type.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(long double, cimagl, (_Complex long double x)) {
+  Complex<long double> x_c = cpp::bit_cast<Complex<long double>>(x);
+  return x_c.imag;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/conj.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/conj.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of conj function -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/conj.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_basic_ops.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(_Complex double, conj, (_Complex double x)) {
+  return conjugate<_Complex double>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/conjf.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/conjf.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of conjf function ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/conjf.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_basic_ops.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(_Complex float, conjf, (_Complex float x)) {
+  return conjugate<_Complex float>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/conjf128.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/conjf128.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of conjf128 function -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/conjf128.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_basic_ops.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(cfloat128, conjf128, (cfloat128 x)) {
+  return conjugate<cfloat128>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/conjl.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/conjl.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of conjl function ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/conjl.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_basic_ops.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(_Complex long double, conjl, (_Complex long double x)) {
+  return conjugate<_Complex long double>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/cproj.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/cproj.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of cproj function ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/cproj.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_basic_ops.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(_Complex double, cproj, (_Complex double x)) {
+  return project<_Complex double>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/cprojf.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/cprojf.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of cprojf function ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/cprojf.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_basic_ops.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(_Complex float, cprojf, (_Complex float x)) {
+  return project<_Complex float>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/cprojf128.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/cprojf128.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of cprojf128 function ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/cprojf128.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_basic_ops.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(cfloat128, cprojf128, (cfloat128 x)) {
+  return project<cfloat128>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/cprojl.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/cprojl.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of cprojl function ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/cprojl.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_basic_ops.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(_Complex long double, cprojl, (_Complex long double x)) {
+  return project<_Complex long double>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/creal.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/creal.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of creal function ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/creal.h"
+#include "src/__support/CPP/bit.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_type.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, creal, (_Complex double x)) {
+  Complex<double> x_c = cpp::bit_cast<Complex<double>>(x);
+  return x_c.real;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/crealf.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/crealf.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of crealf function ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/crealf.h"
+#include "src/__support/CPP/bit.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_type.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(float, crealf, (_Complex float x)) {
+  Complex<float> x_c = cpp::bit_cast<Complex<float>>(x);
+  return x_c.real;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/crealf128.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/crealf128.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of crealf128 function ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/crealf128.h"
+#include "src/__support/CPP/bit.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_type.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(float128, crealf128, (cfloat128 x)) {
+  Complex<float128> x_c = cpp::bit_cast<Complex<float128>>(x);
+  return x_c.real;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/llvm-libc/src/complex/generic/creall.cpp
+++ b/system/lib/llvm-libc/src/complex/generic/creall.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of creall function ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/complex/creall.h"
+#include "src/__support/CPP/bit.h"
+#include "src/__support/common.h"
+#include "src/__support/complex_type.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(long double, creall, (_Complex long double x)) {
+  Complex<long double> x_c = cpp::bit_cast<Complex<long double>>(x);
+  return x_c.real;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/system/lib/update_llvm_libc.py
+++ b/system/lib/update_llvm_libc.py
@@ -24,21 +24,26 @@ libc_copy_dirs = [
     'shared',
     'config',
     'src/__support',
+    'src/assert',
+    'src/complex',
+    'src/errno',
+    'src/inttypes',
+    'src/math',
+    'src/setjmp',
+    'src/stdio/printf_core',
+    'src/stdlib',
     'src/string',
     'src/strings',
-    'src/errno',
-    'src/math',
-    'src/stdlib',
-    'src/inttypes',
-    'src/stdio/printf_core',
     'src/wchar',
-    'src/setjmp'
 ]
 
 libc_exclusion_patterns = [
-    'src/math/generic/*f16*', # float16 is unsupported in Emscripten.
-    'src/strings/str*casecmp_l*', # locale_t is unsupported in Overlay Mode.
-    'src/setjmp/**/*', # setjmp in Emscripten is implemented by the clang backend.
+     # float16 is unsupported in Emscripten.
+    'src/complex/**/*f16*',
+    'src/math/generic/*f16*',
+
+    'src/setjmp/**/*',  # setjmp in Emscripten is implemented by the clang backend.
+    'src/strings/str*casecmp_l*',  # locale_t is unsupported in Overlay Mode.
 ]
 
 def clean_dir(dirname):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1004,7 +1004,9 @@ class llvmlibc(DebugLibrary, AsanInstrumentedLibrary, MTLibrary):
   cflags = ['-Os', '-DLIBC_NAMESPACE=__llvm_libc', '-DLLVM_LIBC', '-DLIBC_COPT_PUBLIC_PACKAGING']
 
   def get_files(self):
-    files = glob_in_path('system/lib/llvm-libc/src/string', '**/*.cpp')
+    files = glob_in_path('system/lib/llvm-libc/src/assert', '*.cpp')
+    files += glob_in_path('system/lib/llvm-libc/src/complex', '**/*.cpp')
+    files += glob_in_path('system/lib/llvm-libc/src/string', '**/*.cpp')
     files += glob_in_path('system/lib/llvm-libc/src/intypes', '*.cpp')
     files += glob_in_path('system/lib/llvm-libc/src/strings', '**/*.cpp')
     files += glob_in_path('system/lib/llvm-libc/src/errno', '**/*.cpp')


### PR DESCRIPTION
This checks assert and complex submodules into Emscripten. f16 related sources in complex are dropped. 