### PR TITLE
Fix windows color terminal output

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12407,7 +12407,15 @@ int main(void) {
     output = self.expect_fail([EMCC, '-fansi-escape-codes', flag, 'src.c'])
     self.assertIn("\x1b[1msrc.c:1:13: \x1b[0m\x1b[0;1;31merror: \x1b[0m\x1b[1mexpected '}'\x1b[0m", output)
     # Verify that emcc errors show up as red and bold
-    self.assertIn("emcc: \x1b[31m\x1b[1m", output)
+    self.assertIn('emcc: \x1b[31m\x1b[1m', output)
+
+    if WINDOWS:
+      # Also test without -fansi-escape-codes on windows.
+      # In those mode the code will use kernel calls such as SetConsoleTextAttribute to
+      # change the output color.  We cannot detect this in the output, but we can at least
+      # get coverage of the code path in the diagnositics.py.
+      output = self.expect_fail([EMCC, flag, 'src.c'])
+      self.assertNotIn('\x1b', output)
 
   def test_sanitizer_color(self):
     create_file('src.c', '''

--- a/tools/diagnostics.py
+++ b/tools/diagnostics.py
@@ -116,7 +116,8 @@ def reset_color_windows():
 
 def output_color(color):
   if WINDOWS and not force_ansi:
-    return output_color_windows(color)
+    output_color_windows(color)
+    return ''
   return '\033[3%sm' % color
 
 
@@ -129,7 +130,8 @@ def bold():
 
 def reset_color():
   if WINDOWS and not force_ansi:
-    return reset_color_windows()
+    reset_color_windows()
+    return ''
   return '\033[0m'
 
 


### PR DESCRIPTION
We cannot actually test this is working, but we can at least test
that it doesn't crash.

Fixes: #24824