### PR TITLE
[WasmFS] Fix linkage of `wasmfs_create_root_dir`. NFC

### DIFF
--- a/system/lib/wasmfs/backends/noderawfs_root.cpp
+++ b/system/lib/wasmfs/backends/noderawfs_root.cpp
@@ -5,10 +5,6 @@
 
 #include "emscripten/wasmfs.h"
 
-namespace wasmfs {
-
 backend_t wasmfs_create_root_dir(void) {
   return wasmfs_create_node_backend(".");
 }
-
-} // namespace wasmfs

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -89,7 +89,7 @@ WasmFS::~WasmFS() {
 
 // Special backends that want to install themselves as the root use this hook.
 // Otherwise, we use the default backends.
-__attribute__((weak)) extern backend_t wasmfs_create_root_dir(void) {
+__attribute__((weak)) extern "C" backend_t wasmfs_create_root_dir(void) {
 #ifdef WASMFS_CASE_INSENSITIVE
   return createIgnoreCaseBackend([]() { return createMemoryBackend(); });
 #else


### PR DESCRIPTION
This function should be `extern "C"` and not part the wasmfs namespace.