### PR TITLE
Remove skipTest from canvas_animate_resize. NFC

### DIFF
--- a/test/canvas_animate_resize.c
+++ b/test/canvas_animate_resize.c
@@ -114,8 +114,7 @@ void init() {
   glLinkProgram(program);
 }
 
-int main()
-{
+int main() {
   EmscriptenWebGLContextAttributes attr;
   emscripten_webgl_init_context_attributes(&attr);
 #if TEST_EXPLICIT_CONTEXT_SWAP
@@ -123,14 +122,7 @@ int main()
 #endif
   ctx = emscripten_webgl_create_context("#canvas", &attr);
   printf("Created context with handle %#lx\n", ctx);
-  if (!ctx) {
-    if (!emscripten_supports_offscreencanvas()) {
-      EM_ASM({
-        skipTest('OffscreenCanvas is not supported!');
-      });
-    }
-    return 0;
-  }
+  assert(ctx);
   emscripten_webgl_make_context_current(ctx);
 
   init();


### PR DESCRIPTION
Rather than magically skipping the test when OffscreenCanvas is not supported we should just fail.

If folks want to run the whole test suite on a browser without such support we can add an `EMTEST_SKIP_OFFSCREEN_CANVAS` environment variable to control if/when these tests are run.

I don't think this should be needed though since modern browsers all support `OffscreenCanvas`.

See #24854