### PR TITLE
Fix sanitizer builds of test_minimal_runtime_hello_world. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,6 +557,7 @@ jobs:
             asan.test_minimal_runtime_global_initializer
             asan.test_fs_js_api_wasmfs
             asan.test_modularize_instance_pthreads
+            asan.test_minimal_runtime_hello_world
             lsan.test_dylink_dso_needed
             lsan.test_stdio_locking
             lsan.test_dlfcn_basic

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8788,13 +8788,14 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_wasmfs('https://github.com/emscripten-core/emscripten/issues/16816')
   @no_modularize_instance('MODULARIZE=instance is not compatible with MINIMAL_RUNTIME')
   @parameterized({
-    'default': ([],),
+    '': ([],),
     'streaming_inst': (['-sMINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION'],),
     'no_export': (['-sDECLARE_ASM_MODULE_EXPORTS=0'],),
   })
   @requires_node  # TODO: Support for non-Node.js shells under MINIMAL_RUNTIME
   def test_minimal_runtime_hello_world(self, args):
     self.maybe_closure()
+    self.cflags += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]
     self.do_runf('small_hello_world.c', 'hello!', cflags=['-sMINIMAL_RUNTIME'] + args)
 
   # Test that printf() works in MINIMAL_RUNTIME=1


### PR DESCRIPTION
This test updated in #24849 which caused the asan and lsan versions of the test to start failing.  The reason is that prior to #24849 there was a bug that caused the test not actually to be run via the santizers since self.cflags was being assigned using `=` rather then `+=`.  This was clobbering all the builtin cflags such as `-fsanitizer=address`.

Once #24849 this bug was fixed but that exposed another bug in the test which is that it was not including the
`minimal_runtime_exit_handling.js` file.  Without this file included tests that use MINIMAL_RUNTIME and EXIT_RUNTIME would see an unhandled excpetion then the program exits (due to the `throw` of `exit(0)`).