### PR TITLE
[AUDIO_WORKLET] fix emscripten_create_audio_context for wasm64

### DIFF
--- a/src/lib/libwebaudio.js
+++ b/src/lib/libwebaudio.js
@@ -58,11 +58,10 @@ var LibraryWebAudio = {
 #if ASSERTIONS
     if (!ctx) console.error('emscripten_create_audio_context failed! Web Audio is not supported.');
 #endif
-    options >>= 2;
 
     var opts = options ? {
-      latencyHint: HEAPU32[options] ? UTF8ToString(HEAPU32[options]) : undefined,
-      sampleRate: HEAP32[options+1] || undefined
+      latencyHint: UTF8ToString({{{ makeGetValue('options', C_STRUCTS.EmscriptenWebAudioCreateAttributes.latencyHint, '*') }}}) || undefined,
+      sampleRate: {{{ makeGetValue('options', C_STRUCTS.EmscriptenWebAudioCreateAttributes.sampleRate, 'u32') }}} || undefined
     } : undefined;
 
 #if WEBAUDIO_DEBUG

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1266,7 +1266,11 @@
     {
         "file": "emscripten/webaudio.h",
         "structs": {
-           "WebAudioParamDescriptor": [
+            "EmscriptenWebAudioCreateAttributes": [
+              "latencyHint",
+              "sampleRate"
+            ],
+            "WebAudioParamDescriptor": [
               "defaultValue",
               "minValue",
               "maxValue",

--- a/src/struct_info_generated.json
+++ b/src/struct_info_generated.json
@@ -695,6 +695,11 @@
             "hidden": 0,
             "visibilityState": 4
         },
+        "EmscriptenWebAudioCreateAttributes": {
+            "__size__": 8,
+            "latencyHint": 0,
+            "sampleRate": 4
+        },
         "EmscriptenWebGLContextAttributes": {
             "__size__": 36,
             "alpha": 0,

--- a/src/struct_info_generated_wasm64.json
+++ b/src/struct_info_generated_wasm64.json
@@ -695,6 +695,11 @@
             "hidden": 0,
             "visibilityState": 4
         },
+        "EmscriptenWebAudioCreateAttributes": {
+            "__size__": 16,
+            "latencyHint": 0,
+            "sampleRate": 8
+        },
         "EmscriptenWebGLContextAttributes": {
             "__size__": 36,
             "alpha": 0,

--- a/test/code_size/audio_worklet_wasm.js
+++ b/test/code_size/audio_worklet_wasm.js
@@ -121,11 +121,11 @@ var M = [], N = a => {
     return e;
 }, ba = a => {
     var b = window.AudioContext || window.webkitAudioContext;
-    if (a >>= 2) {
-        var c = F[a] ? (c = F[a]) ? V(c) : "" : void 0;
+    if (a) {
+        var c = F[a >> 2];
         a = {
-            latencyHint: c,
-            sampleRate: L[a + 1] || void 0
+            latencyHint: (c ? V(c) : "") || void 0,
+            sampleRate: F[a + 4 >> 2] || void 0
         };
     } else a = void 0;
     if (c = b) b = new b(a), S[++T] = b, c = T;

--- a/test/code_size/test_minimal_runtime_code_size_audio_worklet.json
+++ b/test/code_size/test_minimal_runtime_code_size_audio_worklet.json
@@ -1,10 +1,10 @@
 {
   "a.html": 519,
   "a.html.gz": 357,
-  "a.js": 3875,
-  "a.js.gz": 2040,
+  "a.js": 3871,
+  "a.js.gz": 2036,
   "a.wasm": 1288,
   "a.wasm.gz": 860,
-  "total": 5682,
-  "total_gz": 3257
+  "total": 5678,
+  "total_gz": 3253
 }

--- a/test/webaudio/audioworklet_test_shared.inc
+++ b/test/webaudio/audioworklet_test_shared.inc
@@ -94,7 +94,11 @@ int main(void) {
   emscripten_outf("Audio worklet stack at 0x%p", workletStack);
   assert(workletStack);
 
-  EMSCRIPTEN_WEBAUDIO_T context = emscripten_create_audio_context(NULL);
+  // Set at least the latency hint to test the attribute setting
+  EmscriptenWebAudioCreateAttributes attrs = {
+    .latencyHint = "balanced"
+  };
+  EMSCRIPTEN_WEBAUDIO_T context = emscripten_create_audio_context(&attrs);
   emscripten_start_wasm_audio_worklet_thread_async(context, workletStack, AUDIO_STACK_SIZE, getStartCallback(), NULL);
 
 #ifdef TEST_AND_EXIT


### PR DESCRIPTION
I spotted there was no coverage for `emscripten_create_audio_context()` and then that it fails with wasm64 (it accesses the heap directly). This is a minor fix with an addition to the test.

Note: the code is slightly smaller than the original but still performs the same (omitting `latencyHint` or `sampleRate` results in `undefined`).