### PR TITLE
Remove internal USE_READY_PROMISE

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,14 @@ See docs/process.md for more on how version tagging works.
 
 4.0.13 (in development)
 -----------------------
+- The `-sMODULARIZE` setting generates a factory function that must be called
+  before the program is instantiated that run.  However, emscripten previously
+  had very special case where this instantiation would happen automatically
+  (with no parameterization) under certain specific circumstances: When
+  `-sMINIMAL_RUNTIME`, `-sSINGLE_FILE` and `-sMODULARIZE` were used in
+  combination with default html output.  This special case was removed.  If you
+  want to instantiate the module on startup you can still do so by adding a call
+  the factory function in `--extern-post-js`. (#24874)
 - emcc will now error if `MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION` is used
   when not generating html output.  This was always incompatible but previously
   ignored. (#24849)

--- a/src/postamble_modularize.js
+++ b/src/postamble_modularize.js
@@ -4,7 +4,6 @@
 // We assign to the `moduleRtn` global here and configure closure to see
 // this as and extern so it won't get minified.
 
-#if USE_READY_PROMISE
 if (runtimeInitialized)  {
   moduleRtn = Module;
 } else {
@@ -14,9 +13,6 @@ if (runtimeInitialized)  {
     readyPromiseReject = reject;
   });
 }
-#else
-moduleRtn = {};
-#endif
 
 #if ASSERTIONS
 // Assertion for attempting to access module properties on the incoming

--- a/src/runtime_common.js
+++ b/src/runtime_common.js
@@ -20,7 +20,7 @@
 #include "runtime_asan.js"
 #endif
 
-#if MODULARIZE && USE_READY_PROMISE
+#if MODULARIZE
 var readyPromiseResolve, readyPromiseReject;
 #endif
 

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -191,10 +191,6 @@ var WASM_EXCEPTIONS = false;
 // EXPORTED_FUNCTIONS then this gets set to 0.
 var EXPECT_MAIN = true;
 
-// Return a "ready" Promise from the MODULARIZE factory function.
-// We disable this under some circumstance if we know its not needed.
-var USE_READY_PROMISE = true;
-
 // If true, building against Emscripten's wasm heap memory profiler.
 var MEMORYPROFILER = false;
 

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -116,7 +116,7 @@ var err = (...args) => console.error(...args);
 // compilation is ready. In that callback, call the function run() to start
 // the program.
 function ready() {
-#if MODULARIZE && USE_READY_PROMISE
+#if MODULARIZE
   readyPromiseResolve?.(Module);
 #endif // MODULARIZE
 #if INVOKE_RUN && HAS_MAIN

--- a/src/shell_minimal_runtime.html
+++ b/src/shell_minimal_runtime.html
@@ -19,12 +19,6 @@ var {{{ EXPORT_NAME }}} = {}
 #if SINGLE_FILE
 // If we are doing a SINGLE_FILE=1 build, inlined JS runtime code follows here:
 {{{ JS_CONTENTS_IN_SINGLE_FILE_BUILD }}}
-
-#if MODULARIZE
-// Launch the MODULARIZEd build.
-{{{ EXPORT_NAME }}}({});
-#endif
-
 #endif
 
 </script>

--- a/test/code_size/test_minimal_runtime_code_size_hello_webgl2_wasm.json
+++ b/test/code_size/test_minimal_runtime_code_size_hello_webgl2_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 454,
   "a.html.gz": 321,
-  "a.js": 4386,
-  "a.js.gz": 2247,
+  "a.js": 4437,
+  "a.js.gz": 2281,
   "a.wasm": 8290,
   "a.wasm.gz": 5639,
-  "total": 13130,
-  "total_gz": 8207
+  "total": 13181,
+  "total_gz": 8241
 }

--- a/test/code_size/test_minimal_runtime_code_size_hello_webgl2_wasm2js.json
+++ b/test/code_size/test_minimal_runtime_code_size_hello_webgl2_wasm2js.json
@@ -1,8 +1,8 @@
 {
   "a.html": 346,
   "a.html.gz": 255,
-  "a.js": 18135,
-  "a.js.gz": 9784,
-  "total": 18481,
-  "total_gz": 10039
+  "a.js": 18198,
+  "a.js.gz": 9822,
+  "total": 18544,
+  "total_gz": 10077
 }

--- a/test/code_size/test_minimal_runtime_code_size_hello_webgl_wasm.json
+++ b/test/code_size/test_minimal_runtime_code_size_hello_webgl_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 454,
   "a.html.gz": 321,
-  "a.js": 3924,
-  "a.js.gz": 2087,
+  "a.js": 3975,
+  "a.js.gz": 2123,
   "a.wasm": 8290,
   "a.wasm.gz": 5639,
-  "total": 12668,
-  "total_gz": 8047
+  "total": 12719,
+  "total_gz": 8083
 }

--- a/test/code_size/test_minimal_runtime_code_size_hello_webgl_wasm2js.json
+++ b/test/code_size/test_minimal_runtime_code_size_hello_webgl_wasm2js.json
@@ -1,8 +1,8 @@
 {
   "a.html": 346,
   "a.html.gz": 255,
-  "a.js": 17662,
-  "a.js.gz": 9616,
-  "total": 18008,
-  "total_gz": 9871
+  "a.js": 17725,
+  "a.js.gz": 9659,
+  "total": 18071,
+  "total_gz": 9914
 }

--- a/tools/link.py
+++ b/tools/link.py
@@ -1257,14 +1257,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
   if settings.STACK_OVERFLOW_CHECK >= 2:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$setStackLimits']
 
-  if settings.MODULARIZE:
-    # in MINIMAL_RUNTIME we may not need to emit the Promise code, as the
-    # HTML output creates a singleton instance, and it does so without the
-    # Promise. However, in Pthreads mode the Promise is used for worker
-    # creation.
-    if settings.MINIMAL_RUNTIME and options.oformat == OFormat.HTML and not settings.PTHREADS:
-      settings.USE_READY_PROMISE = 0
-
   check_browser_versions()
 
   if settings.MIN_NODE_VERSION >= 150000:


### PR DESCRIPTION
This was only used in one very specific case which required all the following to be enabled:

- MINIMAL_RUNTIME
- MODULARIZE
- SINGLE_FILE
- !PTHREADS
- html output

This combination rare because most folks don't have use the emscripten generated html output.  So that rules out most of our users, then they would also have to choose `MODULARIZE` but not actually want to create multiple instances or pass in any arguments.  This is because in order to support this very special use case the generated HTML was setup to stamp out a singleton instance of the module with no arguments passed in.

While it *is* sometimes useful to stamp out a single instance of the module we don't do this in any other circumstances.  If a user wants to do this its easy enough to do with a `--post-js` file.  In fact we do this in out test code when we want to test the `-sMODULARIZE` settings.  See `test/modularize_post_js.js`.

So think this change is really an improvment and I think its very unlikely that many folks will be using this specific combination of settings.