### PR TITLE
Fix function assert in test_legalize_js_ffi.

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9475,11 +9475,11 @@ int main() {
     text = re.sub(r'\$var\$*.', '', text)
     text = re.sub(r'param \$\d+', 'param ', text)
     text = re.sub(r' +', ' ', text)
-    e_add_f32 = re.search(r'func \$add_f \(param f32\) \(param f32\) \(result f32\)', text)
+    e_add_f32 = re.search(r'func \$add_f \(type \$[0-9]+\) \(param f32\) \(param f32\) \(result f32\)', text)
     assert e_add_f32, 'add_f export missing'
     i_i64_i32 = re.search(r'import "env" "import_ll" .*\(param i32 i32\) \(result i32\)', text)
     i_i64_i64 = re.search(r'import "env" "import_ll" .*\(param i64\) \(result i64\)', text)
-    e_i64_i32 = re.search(r'func \$legalstub\$add_ll \(param i32\) \(param i32\) \(param i32\) \(param i32\) \(result i32\)', text)
+    e_i64_i32 = re.search(r'func \$legalstub\$add_ll \(type \$[0-9]+\) \(param i32\) \(param i32\) \(param i32\) \(param i32\) \(result i32\)', text)
     if js_ffi:
       assert i_i64_i32,     'i64 not converted to i32 in imports'
       assert not i_i64_i64, 'i64 not converted to i32 in imports'


### PR DESCRIPTION
After https://github.com/WebAssembly/binaryen/pull/7802 the output of the test changed from

`(func $add_f (param $0 f32) (param $1 f32) (result f32)` to
`(func $add_f (type $5) (param $0 f32) (param $1 f32) (result f32)`