### PR TITLE
Move clang flags handling to new `compile.py` file. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -33,18 +33,18 @@ from enum import Enum, auto, unique
 from subprocess import PIPE
 
 
-from tools import shared, system_libs, utils, ports, cmdline
-from tools import diagnostics, building
+from tools import shared, system_libs, utils, cmdline
+from tools import diagnostics, building, compile
 from tools.shared import unsuffixed, unsuffixed_basename, get_file_suffix
 from tools.shared import run_process, exit_with_error, DEBUG
 from tools.shared import in_temp
 from tools.shared import DYLIB_EXTENSIONS
-from tools.cmdline import SIMD_INTEL_FEATURE_TOWER, SIMD_NEON_FLAGS, CLANG_FLAGS_WITH_ARGS
+from tools.cmdline import CLANG_FLAGS_WITH_ARGS
 from tools.response_file import substitute_response_files
 from tools import config
 from tools import cache
 from tools.settings import default_setting, user_settings, settings, COMPILE_TIME_SETTINGS
-from tools.utils import read_file, memoize
+from tools.utils import read_file
 
 logger = logging.getLogger('emcc')
 
@@ -171,126 +171,6 @@ def cxx_to_c_compiler(cxx):
   return os.path.join(dirname, basename)
 
 
-def get_target_flags():
-  return ['-target', shared.get_llvm_target()]
-
-
-def get_clang_flags(user_args):
-  flags = get_target_flags()
-
-  # if exception catching is disabled, we can prevent that code from being
-  # generated in the frontend
-  if settings.DISABLE_EXCEPTION_CATCHING and not settings.WASM_EXCEPTIONS:
-    flags.append('-fignore-exceptions')
-
-  if settings.INLINING_LIMIT:
-    flags.append('-fno-inline-functions')
-
-  if settings.PTHREADS:
-    if '-pthread' not in user_args:
-      flags.append('-pthread')
-  elif settings.SHARED_MEMORY:
-    if '-matomics' not in user_args:
-      flags.append('-matomics')
-    if '-mbulk-memory' not in user_args:
-      flags.append('-mbulk-memory')
-
-  if settings.RELOCATABLE and '-fPIC' not in user_args:
-    flags.append('-fPIC')
-
-  if settings.RELOCATABLE or settings.LINKABLE or '-fPIC' in user_args:
-    if not any(a.startswith('-fvisibility') for a in user_args):
-      # For relocatable code we default to visibility=default in emscripten even
-      # though the upstream backend defaults visibility=hidden.  This matches the
-      # expectations of C/C++ code in the wild which expects undecorated symbols
-      # to be exported to other DSO's by default.
-      flags.append('-fvisibility=default')
-
-  if settings.LTO:
-    if not any(a.startswith('-flto') for a in user_args):
-      flags.append('-flto=' + settings.LTO)
-    # setjmp/longjmp handling using Wasm EH
-    # For non-LTO, '-mllvm -wasm-enable-eh' added in
-    # building.llvm_backend_args() sets this feature in clang. But in LTO, the
-    # argument is added to wasm-ld instead, so clang needs to know that EH is
-    # enabled so that it can be added to the attributes in LLVM IR.
-    if settings.SUPPORT_LONGJMP == 'wasm':
-      flags.append('-mexception-handling')
-
-  else:
-    # In LTO mode these args get passed instead at link time when the backend runs.
-    for a in building.llvm_backend_args():
-      flags += ['-mllvm', a]
-
-  return flags
-
-
-@memoize
-def get_cflags(user_args):
-  # Flags we pass to the compiler when building C/C++ code
-  # We add these to the user's flags (newargs), but not when building .s or .S assembly files
-  cflags = get_clang_flags(user_args)
-  cflags.append('--sysroot=' + cache.get_sysroot(absolute=True))
-
-  if settings.EMSCRIPTEN_TRACING:
-    cflags.append('-D__EMSCRIPTEN_TRACING__=1')
-
-  if settings.SHARED_MEMORY:
-    cflags.append('-D__EMSCRIPTEN_SHARED_MEMORY__=1')
-
-  if settings.WASM_WORKERS:
-    cflags.append('-D__EMSCRIPTEN_WASM_WORKERS__=1')
-
-  if not settings.STRICT:
-    # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code
-    # in strict mode. Code should use the define __EMSCRIPTEN__ instead.
-    cflags.append('-DEMSCRIPTEN')
-
-  ports.add_cflags(cflags, settings)
-
-  def array_contains_any_of(hay, needles):
-    for n in needles:
-      if n in hay:
-        return True
-
-  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER) or array_contains_any_of(user_args, SIMD_NEON_FLAGS):
-    if '-msimd128' not in user_args and '-mrelaxed-simd' not in user_args:
-      exit_with_error('passing any of ' + ', '.join(SIMD_INTEL_FEATURE_TOWER + SIMD_NEON_FLAGS) + ' flags also requires passing -msimd128 (or -mrelaxed-simd)!')
-    cflags += ['-D__SSE__=1']
-
-  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[1:]):
-    cflags += ['-D__SSE2__=1']
-
-  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[2:]):
-    cflags += ['-D__SSE3__=1']
-
-  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[3:]):
-    cflags += ['-D__SSSE3__=1']
-
-  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[4:]):
-    cflags += ['-D__SSE4_1__=1']
-
-  # Handle both -msse4.2 and its alias -msse4.
-  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[5:]):
-    cflags += ['-D__SSE4_2__=1']
-
-  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[7:]):
-    cflags += ['-D__AVX__=1']
-
-  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[8:]):
-    cflags += ['-D__AVX2__=1']
-
-  if array_contains_any_of(user_args, SIMD_NEON_FLAGS):
-    cflags += ['-D__ARM_NEON__=1']
-
-  if '-nostdinc' not in user_args:
-    if not settings.USE_SDL:
-      cflags += ['-Xclang', '-iwithsysroot' + os.path.join('/include', 'fakesdl')]
-    cflags += ['-Xclang', '-iwithsysroot' + os.path.join('/include', 'compat')]
-
-  return cflags
-
-
 def get_library_basename(filename):
   """Similar to get_file_suffix this strips off all numeric suffixes and then
   then final non-numeric one.  For example for 'libz.so.1.2.8' returns 'libz'"""
@@ -319,7 +199,7 @@ def run(args):
   if len(args) == 2 and args[1] == '-v':
     # autoconf likes to see 'GNU' in the output to enable shared object support
     print(cmdline.version_string(), file=sys.stderr)
-    return shared.check_call([clang, '-v'] + get_target_flags(), check=False).returncode
+    return shared.check_call([clang, '-v'] + compile.get_target_flags(), check=False).returncode
 
   # Additional compiler flags that we treat as if they were passed to us on the
   # commandline
@@ -652,13 +532,13 @@ def phase_compile_inputs(options, state, newargs):
   system_libs.ensure_sysroot()
 
   def get_clang_command():
-    return compiler + get_cflags(state.orig_args)
+    return compiler + compile.get_cflags(state.orig_args)
 
   def get_clang_command_preprocessed():
-    return compiler + get_clang_flags(state.orig_args)
+    return compiler + compile.get_clang_flags(state.orig_args)
 
   def get_clang_command_asm():
-    return compiler + get_target_flags()
+    return compiler + compile.get_target_flags()
 
   if state.mode == Mode.COMPILE_ONLY:
     if options.output_file and get_file_suffix(options.output_file) == '.bc' and not settings.LTO and '-emit-llvm' not in state.orig_args:

--- a/emscan-deps.py
+++ b/emscan-deps.py
@@ -10,8 +10,8 @@ This script acts as a frontend replacement for clang-scan-deps.
 """
 
 import sys
-import emcc
-from tools import shared, cmdline
+
+from tools import shared, cmdline, compile
 
 argv = sys.argv[1:]
 
@@ -19,6 +19,6 @@ argv = sys.argv[1:]
 newargs = cmdline.parse_arguments(argv)[1]
 
 # Add any clang flags that emcc would add.
-newargs += emcc.get_cflags(tuple(argv))
+newargs += compile.get_cflags(tuple(argv))
 
 shared.exec_process([shared.CLANG_SCAN_DEPS] + newargs)

--- a/tools/compile.py
+++ b/tools/compile.py
@@ -8,7 +8,7 @@
 
 There are three different levels of flags, each one a superset of the next:
 
-get_target_flags(): Defines just `-target` flags and should always be used be
+get_target_flags(): Defines just `-target` flags and should always be
 used when calling clang, or any other llvm tool.
 
 get_clang_flags(): In addution to the target flags this function return all the

--- a/tools/compile.py
+++ b/tools/compile.py
@@ -11,7 +11,7 @@ There are three different levels of flags, each one a superset of the next:
 get_target_flags(): Defines just `-target` flags and should always be
 used when calling clang, or any other llvm tool.
 
-get_clang_flags(): In addution to the target flags this function return all the
+get_clang_flags(): In addition to the target flags this function returns all the
 required compiler flags.
 
 get_cflags(): In addtion to clang flags this function also return pre-processor

--- a/tools/compile.py
+++ b/tools/compile.py
@@ -12,7 +12,7 @@ get_target_flags(): Defines just `-target` flags and should always be
 used when calling clang, or any other llvm tool.
 
 get_clang_flags(): In addution to the target flags this function return all the
-required clang clang.
+required compiler flags.
 
 get_cflags(): In addtion to clang flags this function also return pre-processor
 flags. For example, include paths and macro defintions.

--- a/tools/compile.py
+++ b/tools/compile.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2011 The Emscripten Authors.  All rights reserved.
+# Copyright 2025 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.

--- a/tools/compile.py
+++ b/tools/compile.py
@@ -14,7 +14,7 @@ used when calling clang, or any other llvm tool.
 get_clang_flags(): In addition to the target flags this function returns all the
 required compiler flags.
 
-get_cflags(): In addtion to clang flags this function also return pre-processor
+get_cflags(): In addition to compiler flags this function also returns pre-processor
 flags. For example, include paths and macro defintions.
 """
 

--- a/tools/compile.py
+++ b/tools/compile.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# Copyright 2011 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+"""The function in this file define the compiler flags that emcc passed to clang.
+
+There are three different levels of flags, each one a superset of the next:
+
+get_target_flags(): Defines just `-target` flags and should always be used be
+used when calling clang, or any other llvm tool.
+
+get_clang_flags(): In addution to the target flags this function return all the
+required clang clang.
+
+get_cflags(): In addtion to clang flags this function also return pre-processor
+flags. For example, include paths and macro defintions.
+"""
+
+import os
+
+from . cmdline import SIMD_INTEL_FEATURE_TOWER, SIMD_NEON_FLAGS
+from . import shared, building, cache, ports
+from . settings import settings
+from . utils import memoize
+
+
+def get_target_flags():
+  return ['-target', shared.get_llvm_target()]
+
+
+def get_clang_flags(user_args):
+  flags = get_target_flags()
+
+  # if exception catching is disabled, we can prevent that code from being
+  # generated in the frontend
+  if settings.DISABLE_EXCEPTION_CATCHING and not settings.WASM_EXCEPTIONS:
+    flags.append('-fignore-exceptions')
+
+  if settings.INLINING_LIMIT:
+    flags.append('-fno-inline-functions')
+
+  if settings.PTHREADS:
+    if '-pthread' not in user_args:
+      flags.append('-pthread')
+  elif settings.SHARED_MEMORY:
+    if '-matomics' not in user_args:
+      flags.append('-matomics')
+    if '-mbulk-memory' not in user_args:
+      flags.append('-mbulk-memory')
+
+  if settings.RELOCATABLE and '-fPIC' not in user_args:
+    flags.append('-fPIC')
+
+  if settings.RELOCATABLE or settings.LINKABLE or '-fPIC' in user_args:
+    if not any(a.startswith('-fvisibility') for a in user_args):
+      # For relocatable code we default to visibility=default in emscripten even
+      # though the upstream backend defaults visibility=hidden.  This matches the
+      # expectations of C/C++ code in the wild which expects undecorated symbols
+      # to be exported to other DSO's by default.
+      flags.append('-fvisibility=default')
+
+  if settings.LTO:
+    if not any(a.startswith('-flto') for a in user_args):
+      flags.append('-flto=' + settings.LTO)
+    # setjmp/longjmp handling using Wasm EH
+    # For non-LTO, '-mllvm -wasm-enable-eh' added in
+    # building.llvm_backend_args() sets this feature in clang. But in LTO, the
+    # argument is added to wasm-ld instead, so clang needs to know that EH is
+    # enabled so that it can be added to the attributes in LLVM IR.
+    if settings.SUPPORT_LONGJMP == 'wasm':
+      flags.append('-mexception-handling')
+
+  else:
+    # In LTO mode these args get passed instead at link time when the backend runs.
+    for a in building.llvm_backend_args():
+      flags += ['-mllvm', a]
+
+  return flags
+
+
+@memoize
+def get_cflags(user_args):
+  # Flags we pass to the compiler when building C/C++ code
+  # We add these to the user's flags (newargs), but not when building .s or .S assembly files
+  cflags = get_clang_flags(user_args)
+  cflags.append('--sysroot=' + cache.get_sysroot(absolute=True))
+
+  if settings.EMSCRIPTEN_TRACING:
+    cflags.append('-D__EMSCRIPTEN_TRACING__=1')
+
+  if settings.SHARED_MEMORY:
+    cflags.append('-D__EMSCRIPTEN_SHARED_MEMORY__=1')
+
+  if settings.WASM_WORKERS:
+    cflags.append('-D__EMSCRIPTEN_WASM_WORKERS__=1')
+
+  if not settings.STRICT:
+    # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code
+    # in strict mode. Code should use the define __EMSCRIPTEN__ instead.
+    cflags.append('-DEMSCRIPTEN')
+
+  ports.add_cflags(cflags, settings)
+
+  def array_contains_any_of(hay, needles):
+    for n in needles:
+      if n in hay:
+        return True
+
+  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER) or array_contains_any_of(user_args, SIMD_NEON_FLAGS):
+    if '-msimd128' not in user_args and '-mrelaxed-simd' not in user_args:
+      shared.exit_with_error('passing any of ' + ', '.join(SIMD_INTEL_FEATURE_TOWER + SIMD_NEON_FLAGS) + ' flags also requires passing -msimd128 (or -mrelaxed-simd)!')
+    cflags += ['-D__SSE__=1']
+
+  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[1:]):
+    cflags += ['-D__SSE2__=1']
+
+  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[2:]):
+    cflags += ['-D__SSE3__=1']
+
+  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[3:]):
+    cflags += ['-D__SSSE3__=1']
+
+  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[4:]):
+    cflags += ['-D__SSE4_1__=1']
+
+  # Handle both -msse4.2 and its alias -msse4.
+  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[5:]):
+    cflags += ['-D__SSE4_2__=1']
+
+  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[7:]):
+    cflags += ['-D__AVX__=1']
+
+  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[8:]):
+    cflags += ['-D__AVX2__=1']
+
+  if array_contains_any_of(user_args, SIMD_NEON_FLAGS):
+    cflags += ['-D__ARM_NEON__=1']
+
+  if '-nostdinc' not in user_args:
+    if not settings.USE_SDL:
+      cflags += ['-Xclang', '-iwithsysroot' + os.path.join('/include', 'fakesdl')]
+    cflags += ['-Xclang', '-iwithsysroot' + os.path.join('/include', 'compat')]
+
+  return cflags

--- a/tools/compile.py
+++ b/tools/compile.py
@@ -4,7 +4,7 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-"""The function in this file define the compiler flags that emcc passed to clang.
+"""The functions in this file define the compiler flags that emcc passes to clang.
 
 There are three different levels of flags, each one a superset of the next:
 


### PR DESCRIPTION
This mirrors the existing `link.py` file.

My plan is to make use of these functions to call clang directly when building the system libs.