### PR TITLE
Fix reference for undefined `errback`. NFC

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -807,7 +807,7 @@ def generate_js(data_target, data_files, metadata):
         var PACKAGE_STORE_NAME = 'PACKAGES';
         async function openDatabase() {
           if (typeof indexedDB == 'undefined') {
-            return errback('using IndexedDB to cache data can only be done on a web page or in a web worker');
+            throw 'using IndexedDB to cache data can only be done on a web page or in a web worker';
           }
           return new Promise((resolve, reject) => {
             var openRequest = indexedDB.open(DB_NAME, DB_VERSION);


### PR DESCRIPTION
This went unnoticed by the tests because the calling code has a `.catch` handler that calls the fallback function.  So the test still passed but with a bunch of extra output:

```
ReferenceError: errback is not defined
    at openDatabase (/usr/local/google/home/sbc/dev/wasm/emscripten/out/test/src.js:173:13)
    at runWithFS (/usr/local/google/home/sbc/dev/wasm/emscripten/out/test/src.js:333:9)
    at callRuntimeCallbacks (/usr/local/google/home/sbc/dev/wasm/emscripten/out/test/src.js:1164:26)
    at preRun (/usr/local/google/home/sbc/dev/wasm/emscripten/out/test/src.js:841:3)
    at run (/usr/local/google/home/sbc/dev/wasm/emscripten/out/test/src.js:4658:3)
    at Object.removeRunDependency (/usr/local/google/home/sbc/dev/wasm/emscripten/out/test/src.js:950:7)
    at loadPackage (/usr/local/google/home/sbc/dev/wasm/emscripten/out/test/src.js:362:34)
    at runMetaWithFS (/usr/local/google/home/sbc/dev/wasm/emscripten/out/test/src.js:371:18)
falling back to default preload behavior
done
```

Followup to #24883