### PR TITLE
Roll emdawnwebgpu port to v20250807

### DIFF
--- a/test/test_emdawnwebgpu_link_test.cpp
+++ b/test/test_emdawnwebgpu_link_test.cpp
@@ -16,8 +16,10 @@
 int main() {
   printf("%p\n", wgpuAdapterInfoFreeMembers);
   printf("%p\n", wgpuCreateInstance);
-  printf("%p\n", wgpuGetInstanceCapabilities);
+  printf("%p\n", wgpuGetInstanceFeatures);
+  printf("%p\n", wgpuGetInstanceLimits);
   printf("%p\n", wgpuGetProcAddress);
+  printf("%p\n", wgpuHasInstanceFeature);
   printf("%p\n", wgpuSupportedWGSLLanguageFeaturesFreeMembers);
   printf("%p\n", wgpuSupportedFeaturesFreeMembers);
   printf("%p\n", wgpuSurfaceCapabilitiesFreeMembers);

--- a/tools/ports/emdawnwebgpu.py
+++ b/tools/ports/emdawnwebgpu.py
@@ -3,7 +3,10 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
+# https://dawn.googlesource.com/dawn/+/80062b708e44aa4d8c48e555ed0cc801396069f6/src/emdawnwebgpu/pkg/README.md
 r"""
+The full README of Emdawnwebgpu follows.
+
 # Emdawnwebgpu
 
 Emdawnwebgpu is Dawn's implementation of webgpu.h for Emscripten (on top of the
@@ -11,32 +14,93 @@ WebGPU JS API). It is a fork of Emscripten's original `USE_WEBGPU` bindings,
 and while it is maintained in Dawn, it works in any browser supporting WebGPU
 (modulo individual feature support).
 
-The package includes all of the necessary files to use
-`<webgpu/webgpu.h>` and the Dawn-style `<webgpu/webgpu_cpp.h>` with Emscripten.
+Emdawnwebgpu provides everything necessary to use `<webgpu/webgpu.h>` and the
+Dawn-style `<webgpu/webgpu_cpp.h>` with Emscripten.
 
-Find new versions of this package at <https://github.com/google/dawn/releases>.
+<!-- TODO(crbug.com/430616385): Link to a sample project. -->
 
-If you find any issue with this release, please verify it in the latest release,
-and then report it at <https://crbug.com/new?component=1570785&noWizard=True>.
+If you find an issue in this release, please download the latest Emdawnwebgpu
+release (see below) and latest Emscripten and verify the bug, then report it at
+<https://crbug.com/new?component=1570785&noWizard=True>.
 
-## How to use this package
+## API Stability
 
-First, start with either:
+Core parts of `webgpu.h` (defined in
+<https://github.com/webgpu-native/webgpu-headers>) are considered stable APIs
+and should not change, except for bugfixes (though guarantees are not made).
+Dawn/Emscripten-specific parts, and all of `webgpu_cpp.h`, are **NOT**
+considered stable, and may change.
 
-- A "remote" port file `emdawnwebgpu-v*.remoteport.py` (requires Emscripten 4.0.10+).
-- An `emdawnwebgpu_pkg` containing a local port file `emdawnwebgpu.port.py`.
-  (Either from a pre-built zip release, or from a Dawn build output directory.)
+## How to use Emdawnwebgpu
 
-## How to use this package (local or remote)
+Emdawnwebgpu is distributed in several ways. Choose the one that works for you.
 
-Pass the following flag to `emcc`, during both compile and link, to set the
-include paths and link the implementation:
+In all cases, it is important to enable Closure to reduce code size in release
+builds. Pass the following flag to `emcc` during linking:
 
-    --use-port=path/to/emdawnwebgpu_port_or_remoteport_file.py
+    --closure=1
 
-If (and only if) using Emscripten before 4.0.7, also pass this flag during link:
+### Targeting Web only
+
+#### Easiest: "Remote" port built into Emscripten
+
+Recent releases of Emscripten vendor a copy of a "remote" port which
+automatically downloads a pinned version of Emdawnwebgpu and configures it.
+
+Pass the following flag to `emcc` during both compilation and linking:
+
+    --use-port=emdawnwebgpu
+
+#### Latest: "Remote" port from Dawn release
+
+This is the same as the built-in port, but you can download a newer version if
+you need recent bugfixes or features in Emdawnwebgpu that haven't been rolled
+into Emscripten yet. **Requires Emscripten 4.0.10+.**
+
+Download and extract the `emdawnwebgpu-*.remoteport.py` file from
+<https://github.com/google/dawn/releases>.
+
+Pass the following flag to `emcc` during both compilation and linking:
+
+    --use-port=path/to/emdawnwebgpu_remoteport_file.py
+
+#### Latest, without automatic downloading: "Local" port from Dawn release
+
+Use this method if your build system requires sources to be local (e.g. checked
+into your repository) instead of automatically downloaded, or if you use
+Emscripten before 4.0.10.
+**Note that Emdawnwebgpu may not work with older Emscripten releases.**
+
+Download and extract the `emdawnwebgpu_pkg-*.zip` package from
+<https://github.com/google/dawn/releases>.
+(Note the package is text-only and does not contain any binaries, but see below
+if you need to build the package from the original source.)
+
+Pass the following flag to `emcc` during both compilation and linking:
+
+    --use-port=path/to/emdawnwebgpu_pkg/emdawnwebgpu.port.py
+
+If (and only if) using Emscripten before 4.0.7, pass this flag during linking:
 
     --closure-args=--externs=path/to/emdawnwebgpu_pkg/webgpu/src/webgpu-externs.js
+
+### Cross-targeting Web/Native
+
+#### Using CMake
+
+Use this method if your project uses CMake and targets both Emscripten and
+native platforms.
+
+<https://developer.chrome.com/docs/web-platform/webgpu/build-app>
+
+#### Building the package locally to use with a non-CMake project
+
+If your project already has Dawn source, or you otherwise want to cross-target
+Web and native with your non-CMake project, you can use CMake to build
+`emdawnwebgpu_pkg` locally (similar to how you would build binary libraries
+to link with in native), then use the "Local" port instructions above.
+
+<https://dawn.googlesource.com/dawn/+/refs/heads/main/src/emdawnwebgpu/README.md>
 
 ## Port options
 
@@ -44,8 +108,8 @@ Options can be set by appending `:key1=value:key2=value` to `--use-port`.
 For information about port options, run:
 
     emcc --use-port=emdawnwebgpu:help
-    emcc --use-port=path/to/emdawnwebgpu.port.py:help
-    emcc --use-port=path/to/emdawnwebgpu-*.remoteport.py:help
+    emcc --use-port=path/to/emdawnwebgpu_remoteport_file.py:help
+    emcc --use-port=path/to/emdawnwebgpu_pkg/emdawnwebgpu.port.py:help
 
 ### C++ bindings
 
@@ -55,8 +119,8 @@ for any reason (you have custom bindings, you're using a pinned snapshot of
 `webgpu_cpp.h`, etc.), you can set the option `cpp_bindings=false`:
 
     --use-port=emdawnwebgpu:cpp_bindings=false
-    --use-port=path/to/emdawnwebgpu.port.py:cpp_bindings=false
-    --use-port=path/to/emdawnwebgpu-*.remoteport.py:cpp_bindings=false
+    --use-port=path/to/emdawnwebgpu_remoteport_file.py:cpp_bindings=false
+    --use-port=path/to/emdawnwebgpu_pkg/emdawnwebgpu.port.py:cpp_bindings=false
 
 ## Embuilder
 
@@ -64,16 +128,21 @@ If your build process needs a separate step to build the port before linking,
 use Emscripten's `embuilder`.
 
 Under `embuilder`, some options cannot be set automatically, so they must be
-set manually. See `OPTIONS` in `emdawnwebgpu.port.py` for details.
+set manually. For details, see `OPTIONS` in `emdawnwebgpu.port.py` (in the
+package zip).
 """
 
-TAG = 'v20250531.224602'
+TAG = 'v20250807.221415'
 
 EXTERNAL_PORT = f'https://github.com/google/dawn/releases/download/{TAG}/emdawnwebgpu_pkg-{TAG}.zip'
-SHA512 = 'e3db5b2a4cc97cbb9b8a0c1f6fe7a740bf644322dfa4641a7b0902c192c58205d76acb9b359a0d6da1fdc9795e85eb1cf1927aa47f2a82814ee29868fef6670e'
+SHA512 = 'ab9f3af2536ef3a29c20bb9c69f45b5ee512b8e33fb559f8d0bf4529cd2c11e2fbfb919c3d936e3b32af0e92bd710af71a1700776b5e56c99297cfbc3b73ceec'
 PORT_FILE = 'emdawnwebgpu_pkg/emdawnwebgpu.port.py'
 
 # Port information (required)
-URL = 'https://dawn.googlesource.com/dawn/+/refs/heads/main/src/emdawnwebgpu/'
-DESCRIPTION = "Emdawnwebgpu is a fork of Emscripten's original USE_WEBGPU, implementing a newer, more stable version of the standardized webgpu.h interface."
+
+# - Visible in emcc --show-ports and emcc --use-port=emdawnwebgpu:help
 LICENSE = "Some files: BSD 3-Clause License. Other files: Emscripten's license (available under both MIT License and University of Illinois/NCSA Open Source License)"
+
+# - Visible in emcc --use-port=emdawnwebgpu:help
+DESCRIPTION = "Emdawnwebgpu implements webgpu.h on WebGPU, replacing -sUSE_WEBGPU. **For info on usage and filing feedback, see link below.**"
+URL = 'https://dawn.googlesource.com/dawn/+/80062b708e44aa4d8c48e555ed0cc801396069f6/src/emdawnwebgpu/pkg/README.md'


### PR DESCRIPTION
From https://github.com/google/dawn/releases/tag/v20250807.221415

This version includes the last breaking change to the core API and fixes the known showstopping bugs. It also improves the documentation included in the port file so it's easier to understand what to do with it.

After this has landed for a little while it will be a good time to finally remove -sUSE_WEBGPU from Emscripten. (#24265)