### PR TITLE
Fix test_prepost_run_dep after #24890

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -251,6 +251,9 @@ function addRunDependency(id) {
 #endif
 
 #if ASSERTIONS
+#if RUNTIME_DEBUG
+  dbg('addRunDependency', id);
+#endif
   assert(id, 'addRunDependency requires an ID')
   assert(!runDependencyTracking[id]);
   runDependencyTracking[id] = 1;
@@ -274,6 +277,11 @@ function addRunDependency(id) {
         err('(end of list)');
       }
     }, 10000);
+#if ENVIRONMENT_MAY_BE_NODE
+    // Prevent this timer from keeping the runtime alive if nothing
+    // else is.
+    runDependencyWatcher.unref?.()
+#endif
   }
 #endif
 }
@@ -286,6 +294,9 @@ function removeRunDependency(id) {
 #endif
 
 #if ASSERTIONS
+#if RUNTIME_DEBUG
+  dbg('removeRunDependency', id);
+#endif
   assert(id, 'removeRunDependency requires an ID');
   assert(runDependencyTracking[id]);
   delete runDependencyTracking[id];

--- a/test/code_size/test_codesize_hello_O0.json
+++ b/test/code_size/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22449,
-  "a.out.js.gz": 8326,
+  "a.out.js": 22462,
+  "a.out.js.gz": 8336,
   "a.out.nodebug.wasm": 15143,
   "a.out.nodebug.wasm.gz": 7452,
-  "total": 37592,
-  "total_gz": 15778,
+  "total": 37605,
+  "total_gz": 15788,
   "sent": [
     "fd_write"
   ],

--- a/test/code_size/test_codesize_minimal_O0.json
+++ b/test/code_size/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 17710,
-  "a.out.js.gz": 6612,
+  "a.out.js": 17723,
+  "a.out.js.gz": 6621,
   "a.out.nodebug.wasm": 1136,
   "a.out.nodebug.wasm.gz": 659,
-  "total": 18846,
-  "total_gz": 7271,
+  "total": 18859,
+  "total_gz": 7280,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_unoptimized_code_size.json
+++ b/test/code_size/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 53804,
-  "hello_world.js.gz": 17065,
+  "hello_world.js": 53923,
+  "hello_world.js.gz": 17123,
   "hello_world.wasm": 15143,
   "hello_world.wasm.gz": 7452,
   "no_asserts.js": 26714,
   "no_asserts.js.gz": 8952,
   "no_asserts.wasm": 12227,
   "no_asserts.wasm.gz": 6008,
-  "strict.js": 51854,
-  "strict.js.gz": 16403,
+  "strict.js": 51973,
+  "strict.js.gz": 16455,
   "strict.wasm": 15143,
   "strict.wasm.gz": 7438,
-  "total": 174885,
-  "total_gz": 63318
+  "total": 175123,
+  "total_gz": 63428
 }

--- a/test/other/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/other/codesize/test_codesize_minimal_O0.expected.js
@@ -531,6 +531,9 @@ function addRunDependency(id) {
         err('(end of list)');
       }
     }, 10000);
+    // Prevent this timer from keeping the runtime alive if nothing
+    // else is.
+    runDependencyWatcher.unref?.()
   }
 }
 


### PR DESCRIPTION
- Cleanup the test
- Add and `id` to the `addRunDependency` call.
- Add `.unref` to prevent the dependency watcher from keeping the node process alive.  Prior to #24890 the lack of `id` in used in the test caused it to skip the dependency watcher.
- Add `--closure=1` to make sure closure doesn't minify the `.unref` call.
- Add some RUNTIME_DEBUG logging to add/removeRunDependency.