### PR TITLE
Remove support for windows 7 from .bat file launchers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 4.0.13 (in development)
 -----------------------
+- Support for Windows 7 and the `EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG`
+  environment variable was removed.
 - `sdl-config` and `sdl2-config` scripts were simplified to avoid using python
   and the `.bat` file versions were removed, matching upstream SDL. (#24907)
 - The `addRunDependency`/`removeRunDependency` now assert in debug builds if

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -45,42 +45,18 @@
 :: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
 :: sharing the parent's stdin handle to it, avoiding the hang.
 
-:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
-:: even when the python executable above did succeed and quit with errorlevel 0 above.
-:: On Windows 8 and newer, this issue has not been observed. It is possible that this
-:: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
-:: workaround this issue, which is to explicitly quit the calling process with the previous
-:: errorlevel from the above command.
-
 :: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
 :: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
 :: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    goto NORMAL
-  ) else (
-    goto NORMAL_EXIT
-  )
+  goto NORMAL
 ) else (
-  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    goto MUTE_STDIN
-  ) else (
-    goto MUTE_STDIN_EXIT
-  )
+  goto MUTE_STDIN
 )
-
-:NORMAL_EXIT
-@"%EM_PY%" -E "%MYDIR%%~n0.py" %*
-@exit %ERRORLEVEL%
 
 :MUTE_STDIN
 @"%EM_PY%" -E "%MYDIR%%~n0.py" %* < NUL
 @exit /b %ERRORLEVEL%
-
-:MUTE_STDIN_EXIT
-@"%EM_PY%" -E "%MYDIR%%~n0.py" %* < NUL
-@exit %ERRORLEVEL%
 
 :NORMAL
 @"%EM_PY%" -E "%MYDIR%%~n0.py" %*

--- a/em++.bat
+++ b/em++.bat
@@ -54,42 +54,18 @@
 :: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
 :: sharing the parent's stdin handle to it, avoiding the hang.
 
-:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
-:: even when the python executable above did succeed and quit with errorlevel 0 above.
-:: On Windows 8 and newer, this issue has not been observed. It is possible that this
-:: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
-:: workaround this issue, which is to explicitly quit the calling process with the previous
-:: errorlevel from the above command.
-
 :: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
 :: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
 :: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    goto NORMAL
-  ) else (
-    goto NORMAL_EXIT
-  )
+  goto NORMAL
 ) else (
-  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    goto MUTE_STDIN
-  ) else (
-    goto MUTE_STDIN_EXIT
-  )
+  goto MUTE_STDIN
 )
-
-:NORMAL_EXIT
-@%CMD% %*
-@exit %ERRORLEVEL%
 
 :MUTE_STDIN
 @%CMD% %* < NUL
 @exit /b %ERRORLEVEL%
-
-:MUTE_STDIN_EXIT
-@%CMD% %* < NUL
-@exit %ERRORLEVEL%
 
 :NORMAL
 @%CMD% %*

--- a/emcc.bat
+++ b/emcc.bat
@@ -54,42 +54,18 @@
 :: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
 :: sharing the parent's stdin handle to it, avoiding the hang.
 
-:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
-:: even when the python executable above did succeed and quit with errorlevel 0 above.
-:: On Windows 8 and newer, this issue has not been observed. It is possible that this
-:: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
-:: workaround this issue, which is to explicitly quit the calling process with the previous
-:: errorlevel from the above command.
-
 :: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
 :: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
 :: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    goto NORMAL
-  ) else (
-    goto NORMAL_EXIT
-  )
+  goto NORMAL
 ) else (
-  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    goto MUTE_STDIN
-  ) else (
-    goto MUTE_STDIN_EXIT
-  )
+  goto MUTE_STDIN
 )
-
-:NORMAL_EXIT
-@%CMD% %*
-@exit %ERRORLEVEL%
 
 :MUTE_STDIN
 @%CMD% %* < NUL
 @exit /b %ERRORLEVEL%
-
-:MUTE_STDIN_EXIT
-@%CMD% %* < NUL
-@exit %ERRORLEVEL%
 
 :NORMAL
 @%CMD% %*

--- a/test/runner.bat
+++ b/test/runner.bat
@@ -45,42 +45,18 @@
 :: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
 :: sharing the parent's stdin handle to it, avoiding the hang.
 
-:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
-:: even when the python executable above did succeed and quit with errorlevel 0 above.
-:: On Windows 8 and newer, this issue has not been observed. It is possible that this
-:: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
-:: workaround this issue, which is to explicitly quit the calling process with the previous
-:: errorlevel from the above command.
-
 :: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
 :: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
 :: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    goto NORMAL
-  ) else (
-    goto NORMAL_EXIT
-  )
+  goto NORMAL
 ) else (
-  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    goto MUTE_STDIN
-  ) else (
-    goto MUTE_STDIN_EXIT
-  )
+  goto MUTE_STDIN
 )
-
-:NORMAL_EXIT
-@"%EM_PY%" -E "%MYDIR%%~n0.py" %*
-@exit %ERRORLEVEL%
 
 :MUTE_STDIN
 @"%EM_PY%" -E "%MYDIR%%~n0.py" %* < NUL
 @exit /b %ERRORLEVEL%
-
-:MUTE_STDIN_EXIT
-@"%EM_PY%" -E "%MYDIR%%~n0.py" %* < NUL
-@exit %ERRORLEVEL%
 
 :NORMAL
 @"%EM_PY%" -E "%MYDIR%%~n0.py" %*

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14411,11 +14411,8 @@ void foo() {}
   def test_emscripten_set_timeout_loop(self):
     self.do_runf('emscripten_set_timeout_loop.c', args=['-pthread', '-sPROXY_TO_PTHREAD'])
 
-  # Verify that we are able to successfully compile a script when the Windows 7
-  # and Python workaround env. vars are enabled.
-  # See https://bugs.python.org/issue34780
-  @with_env_modify({'EM_WORKAROUND_PYTHON_BUG_34780': '1',
-                    'EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG': '1'})
+  # Verify that we are able to successfully compile a script when Python workaround env. var is set
+  @with_env_modify({'EM_WORKAROUND_PYTHON_BUG_34780': '1'})
   def test_windows_batch_script_workaround(self):
     self.run_process([EMCC, test_file('hello_world.c')])
     self.assertExists('a.out.js')

--- a/tools/maint/run_python.bat
+++ b/tools/maint/run_python.bat
@@ -45,42 +45,18 @@
 :: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
 :: sharing the parent's stdin handle to it, avoiding the hang.
 
-:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
-:: even when the python executable above did succeed and quit with errorlevel 0 above.
-:: On Windows 8 and newer, this issue has not been observed. It is possible that this
-:: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
-:: workaround this issue, which is to explicitly quit the calling process with the previous
-:: errorlevel from the above command.
-
 :: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
 :: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
 :: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    goto NORMAL
-  ) else (
-    goto NORMAL_EXIT
-  )
+  goto NORMAL
 ) else (
-  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    goto MUTE_STDIN
-  ) else (
-    goto MUTE_STDIN_EXIT
-  )
+  goto MUTE_STDIN
 )
-
-:NORMAL_EXIT
-@"%EM_PY%" -E "%MYDIR%%~n0.py" %*
-@exit %ERRORLEVEL%
 
 :MUTE_STDIN
 @"%EM_PY%" -E "%MYDIR%%~n0.py" %* < NUL
 @exit /b %ERRORLEVEL%
-
-:MUTE_STDIN_EXIT
-@"%EM_PY%" -E "%MYDIR%%~n0.py" %* < NUL
-@exit %ERRORLEVEL%
 
 :NORMAL
 @"%EM_PY%" -E "%MYDIR%%~n0.py" %*

--- a/tools/maint/run_python_compiler.bat
+++ b/tools/maint/run_python_compiler.bat
@@ -54,42 +54,18 @@
 :: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
 :: sharing the parent's stdin handle to it, avoiding the hang.
 
-:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
-:: even when the python executable above did succeed and quit with errorlevel 0 above.
-:: On Windows 8 and newer, this issue has not been observed. It is possible that this
-:: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
-:: workaround this issue, which is to explicitly quit the calling process with the previous
-:: errorlevel from the above command.
-
 :: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
 :: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
 :: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    goto NORMAL
-  ) else (
-    goto NORMAL_EXIT
-  )
+  goto NORMAL
 ) else (
-  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    goto MUTE_STDIN
-  ) else (
-    goto MUTE_STDIN_EXIT
-  )
+  goto MUTE_STDIN
 )
-
-:NORMAL_EXIT
-@%CMD% %*
-@exit %ERRORLEVEL%
 
 :MUTE_STDIN
 @%CMD% %* < NUL
 @exit /b %ERRORLEVEL%
-
-:MUTE_STDIN_EXIT
-@%CMD% %* < NUL
-@exit %ERRORLEVEL%
 
 :NORMAL
 @%CMD% %*


### PR DESCRIPTION
This removed that handling of `EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG` which is workaround for a windows 7 issue.