### PR TITLE
Convert `FS_handledByPreloadPlugin` and plugin `handle` callback to async.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 4.0.13 (in development)
 -----------------------
+- The `handle` callback on the `preloadPlugins` used by `--use-preload-plugins`
+  (and `FS_createPreloadedFile` API`) was converted from callbacks to async.
+  Any externally managed plugins would need to be updated accordingly.  An
+  assertion will detect any such non-async plugins in the wild. (#24914)
 - SDL2 updated from 2.32.0 to 2.32.8. (#24912/)
 - `sdl-config` and `sdl2-config` scripts were simplified to avoid using python
   and the `.bat` file versions were removed, matching upstream SDL. (#24907)

--- a/src/lib/libbrowser.js
+++ b/src/lib/libbrowser.js
@@ -47,32 +47,34 @@ var LibraryBrowser = {
       imagePlugin['canHandle'] = function imagePlugin_canHandle(name) {
         return !Module['noImageDecoding'] && /\.(jpg|jpeg|png|bmp|webp)$/i.test(name);
       };
-      imagePlugin['handle'] = function imagePlugin_handle(byteArray, name, onload, onerror) {
+      imagePlugin['handle'] = async function imagePlugin_handle(byteArray, name) {
         var b = new Blob([byteArray], { type: Browser.getMimetype(name) });
         if (b.size !== byteArray.length) { // Safari bug #118630
           // Safari's Blob can only take an ArrayBuffer
           b = new Blob([(new Uint8Array(byteArray)).buffer], { type: Browser.getMimetype(name) });
         }
         var url = URL.createObjectURL(b);
-        var img = new Image();
-        img.onload = () => {
+        return new Promise((resolve, reject) => {
+          var img = new Image();
+          img.onload = () => {
 #if ASSERTIONS
-          assert(img.complete, `Image ${name} could not be decoded`);
+            assert(img.complete, `Image ${name} could not be decoded`);
 #endif
-          var canvas = /** @type {!HTMLCanvasElement} */ (document.createElement('canvas'));
-          canvas.width = img.width;
-          canvas.height = img.height;
-          var ctx = canvas.getContext('2d');
-          ctx.drawImage(img, 0, 0);
-          Browser.preloadedImages[name] = canvas;
-          URL.revokeObjectURL(url);
-          onload?.(byteArray);
-        };
-        img.onerror = (event) => {
-          err(`Image ${url} could not be decoded`);
-          onerror?.();
-        };
-        img.src = url;
+            var canvas = /** @type {!HTMLCanvasElement} */ (document.createElement('canvas'));
+            canvas.width = img.width;
+            canvas.height = img.height;
+            var ctx = canvas.getContext('2d');
+            ctx.drawImage(img, 0, 0);
+            Browser.preloadedImages[name] = canvas;
+            URL.revokeObjectURL(url);
+            resolve(byteArray);
+          };
+          img.onerror = (event) => {
+            err(`Image ${url} could not be decoded`);
+            reject();
+          };
+          img.src = url;
+        });
       };
       preloadPlugins.push(imagePlugin);
 
@@ -80,53 +82,55 @@ var LibraryBrowser = {
       audioPlugin['canHandle'] = function audioPlugin_canHandle(name) {
         return !Module['noAudioDecoding'] && name.slice(-4) in { '.ogg': 1, '.wav': 1, '.mp3': 1 };
       };
-      audioPlugin['handle'] = function audioPlugin_handle(byteArray, name, onload, onerror) {
-        var done = false;
-        function finish(audio) {
-          if (done) return;
-          done = true;
-          Browser.preloadedAudios[name] = audio;
-          onload?.(byteArray);
-        }
-        var b = new Blob([byteArray], { type: Browser.getMimetype(name) });
-        var url = URL.createObjectURL(b); // XXX we never revoke this!
-        var audio = new Audio();
-        audio.addEventListener('canplaythrough', () => finish(audio), false); // use addEventListener due to chromium bug 124926
-        audio.onerror = function audio_onerror(event) {
-          if (done) return;
-          err(`warning: browser could not fully decode audio ${name}, trying slower base64 approach`);
-          function encode64(data) {
-            var BASE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-            var PAD = '=';
-            var ret = '';
-            var leftchar = 0;
-            var leftbits = 0;
-            for (var i = 0; i < data.length; i++) {
-              leftchar = (leftchar << 8) | data[i];
-              leftbits += 8;
-              while (leftbits >= 6) {
-                var curr = (leftchar >> (leftbits-6)) & 0x3f;
-                leftbits -= 6;
-                ret += BASE[curr];
-              }
-            }
-            if (leftbits == 2) {
-              ret += BASE[(leftchar&3) << 4];
-              ret += PAD + PAD;
-            } else if (leftbits == 4) {
-              ret += BASE[(leftchar&0xf) << 2];
-              ret += PAD;
-            }
-            return ret;
+      audioPlugin['handle'] = async function audioPlugin_handle(byteArray, name) {
+        return new Promise((resolve, reject) => {
+          var done = false;
+          function finish(audio) {
+            if (done) return;
+            done = true;
+            Browser.preloadedAudios[name] = audio;
+            resolve(byteArray);
           }
-          audio.src = 'data:audio/x-' + name.slice(-3) + ';base64,' + encode64(byteArray);
-          finish(audio); // we don't wait for confirmation this worked - but it's worth trying
-        };
-        audio.src = url;
-        // workaround for chrome bug 124926 - we do not always get oncanplaythrough or onerror
-        safeSetTimeout(() => {
-          finish(audio); // try to use it even though it is not necessarily ready to play
-        }, 10000);
+          var b = new Blob([byteArray], { type: Browser.getMimetype(name) });
+          var url = URL.createObjectURL(b); // XXX we never revoke this!
+          var audio = new Audio();
+          audio.addEventListener('canplaythrough', () => finish(audio), false); // use addEventListener due to chromium bug 124926
+          audio.onerror = function audio_onerror(event) {
+            if (done) return;
+            err(`warning: browser could not fully decode audio ${name}, trying slower base64 approach`);
+            function encode64(data) {
+              var BASE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+              var PAD = '=';
+              var ret = '';
+              var leftchar = 0;
+              var leftbits = 0;
+              for (var i = 0; i < data.length; i++) {
+                leftchar = (leftchar << 8) | data[i];
+                leftbits += 8;
+                while (leftbits >= 6) {
+                  var curr = (leftchar >> (leftbits-6)) & 0x3f;
+                  leftbits -= 6;
+                  ret += BASE[curr];
+                }
+              }
+              if (leftbits == 2) {
+                ret += BASE[(leftchar&3) << 4];
+                ret += PAD + PAD;
+              } else if (leftbits == 4) {
+                ret += BASE[(leftchar&0xf) << 2];
+                ret += PAD;
+              }
+              return ret;
+            }
+            audio.src = 'data:audio/x-' + name.slice(-3) + ';base64,' + encode64(byteArray);
+            finish(audio); // we don't wait for confirmation this worked - but it's worth trying
+          };
+          audio.src = url;
+          // workaround for chrome bug 124926 - we do not always get oncanplaythrough or onerror
+          safeSetTimeout(() => {
+            finish(audio); // try to use it even though it is not necessarily ready to play
+          }, 10000);
+        });
       };
       preloadPlugins.push(audioPlugin);
 #endif

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -21,24 +21,22 @@ var LibraryDylink = {
       'canHandle': (name) => {
         return !Module['noWasmDecoding'] && name.endsWith('.so')
       },
-      'handle': (byteArray, name, onload, onerror) => {
+      'handle': async (byteArray, name) =>
         // loadWebAssemblyModule can not load modules out-of-order, so rather
         // than just running the promises in parallel, this makes a chain of
         // promises to run in series.
-        wasmPlugin.promiseChainEnd = wasmPlugin.promiseChainEnd.then(
-          () => loadWebAssemblyModule(byteArray, {loadAsync: true, nodelete: true}, name, {})).then(
-            (exports) => {
+        wasmPlugin.promiseChainEnd = wasmPlugin.promiseChainEnd.then(async () => {
+          try {
+            var exports = await loadWebAssemblyModule(byteArray, {loadAsync: true, nodelete: true}, name, {});
+          } catch (error) {
+            throw new Error(`failed to instantiate wasm: ${name}: ${error}`);
+          }
 #if DYLINK_DEBUG
-              dbg('registering preloadedWasm:', name);
+          dbg('registering preloadedWasm:', name);
 #endif
-              preloadedWasm[name] = exports;
-              onload(byteArray);
-            },
-            (error) => {
-              err(`failed to instantiate wasm: ${name}: ${error}`);
-              onerror();
-            });
-      }
+          preloadedWasm[name] = exports;
+          return byteArray;
+        })
     };
     preloadPlugins.push(wasmPlugin);
   },

--- a/src/lib/liblz4.js
+++ b/src/lib/liblz4.js
@@ -56,7 +56,10 @@ addToLibrary({
               addRunDependency(dep);
               var finish = () => removeRunDependency(dep);
               var byteArray = FS.readFile(fullname);
-              plugin['handle'](byteArray, fullname, finish, finish);
+#if ASSERTIONS
+              assert(plugin['handle'].constructor.name === 'AsyncFunction', 'Filesystem plugin handlers must be async functions (See #24914)')
+#endif
+              plugin['handle'](byteArray, fullname).then(finish).catch(finish);
               break;
             }
           }

--- a/test/code_size/test_codesize_hello_dylink.json
+++ b/test/code_size/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26982,
-  "a.out.js.gz": 11461,
+  "a.out.js": 27008,
+  "a.out.js.gz": 11463,
   "a.out.nodebug.wasm": 18561,
   "a.out.nodebug.wasm.gz": 9167,
-  "total": 45543,
-  "total_gz": 20628,
+  "total": 45569,
+  "total_gz": 20630,
   "sent": [
     "__heap_base",
     "__indirect_function_table",

--- a/test/code_size/test_codesize_hello_dylink_all.json
+++ b/test/code_size/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 246799,
+  "a.out.js": 246873,
   "a.out.nodebug.wasm": 597826,
-  "total": 844625,
+  "total": 844699,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
The `FS_handledByPreloadPlugin` is completely internal so changing this
should be completely non-functional.

If external projects are implementing custom preload plugins they would
need to update their `handle` methods.  I've added an assertion in debug
builds to detect plugins that are not async.

This change will allow a followup which is to convert that whole file preloading
mechanism to async.