### PR TITLE
Avoid use of `dependenciesFulfilled` in `emscripten_lazy_load_code`. NFC

### DIFF
--- a/src/lib/libasync.js
+++ b/src/lib/libasync.js
@@ -551,10 +551,8 @@ addToLibrary({
   emscripten_lazy_load_code: () => Asyncify.handleSleep((wakeUp) => {
     // Update the expected wasm binary file to be the lazy one.
     wasmBinaryFile += '.lazy.wasm';
-    // Add a callback for when all run dependencies are fulfilled, which happens when async wasm loading is done.
-    dependenciesFulfilled = wakeUp;
-    // Load the new wasm.
-    createWasm();
+    // Load the new wasm. The resulting Promise will resolve once the async loading is done.
+    createWasm().then(() => wakeUp());
   }),
 #endif
 


### PR DESCRIPTION
Even though the lazy loading code is due to be removed I'm trying to cleanup usages of the `dependenciesFulfilled` system.