### PR TITLE
Move `createWasm` call from python to JS template. NFC

### DIFF
--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -80,6 +80,11 @@ export function preprocess(filename) {
       .replace(/\bimport\.meta\b/g, 'EMSCRIPTEN$IMPORT$META')
       .replace(/\bawait import\b/g, 'EMSCRIPTEN$AWAIT$IMPORT');
   }
+  if (MODULARIZE) {
+    // Same for out use of "top-level-await" which is not actually top level
+    // in the case of MODULARIZE.
+    text = text.replace(/\bawait createWasm\(\)/g, 'EMSCRIPTEN$AWAIT(createWasm())');
+  }
   // Remove windows line endings, if any
   text = text.replace(/\r\n/g, '\n');
 

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -6,6 +6,26 @@
 
 // === Auto-generated postamble setup entry stuff ===
 
+#if MODULARIZE == 'instance'
+var wasmExports;
+#elif WASM_ASYNC_COMPILATION
+
+#if MODULARIZE
+// In modularize mode the generated code is within a factory function so we
+// can use await here (since it's not top-level-await).
+var wasmExports = await createWasm();
+#else
+// With async instantation wasmExports is assigned asyncronously when the
+// the instance is received.
+var wasmExports;
+createWasm();
+#endif
+
+#else
+// With sync compilation wasmExports is directly returned from createWasm()
+var wasmExports = createWasm();
+#endif
+
 #if PROXY_TO_WORKER
 if (ENVIRONMENT_IS_WORKER) {
 #include "webGLWorker.js'

--- a/test/code_size/test_codesize_cxx_except.json
+++ b/test/code_size/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23410,
-  "a.out.js.gz": 9146,
+  "a.out.js": 23414,
+  "a.out.js.gz": 9142,
   "a.out.nodebug.wasm": 171285,
   "a.out.nodebug.wasm.gz": 57342,
-  "total": 194695,
-  "total_gz": 66488,
+  "total": 194699,
+  "total_gz": 66484,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/code_size/test_codesize_cxx_mangle.json
+++ b/test/code_size/test_codesize_cxx_mangle.json
@@ -1,9 +1,9 @@
 {
-  "a.out.js": 23460,
+  "a.out.js": 23464,
   "a.out.js.gz": 9162,
   "a.out.nodebug.wasm": 235325,
   "a.out.nodebug.wasm.gz": 78943,
-  "total": 258785,
+  "total": 258789,
   "total_gz": 88105,
   "sent": [
     "__cxa_begin_catch",

--- a/test/code_size/test_codesize_minimal_64.json
+++ b/test/code_size/test_codesize_minimal_64.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2622,
-  "a.out.js.gz": 1248,
+  "a.out.js": 2626,
+  "a.out.js.gz": 1250,
   "a.out.nodebug.wasm": 62,
   "a.out.nodebug.wasm.gz": 76,
-  "total": 2684,
-  "total_gz": 1324,
+  "total": 2688,
+  "total_gz": 1326,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_unoptimized_code_size.json
+++ b/test/code_size/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 53981,
-  "hello_world.js.gz": 17132,
+  "hello_world.js": 54085,
+  "hello_world.js.gz": 17171,
   "hello_world.wasm": 15143,
   "hello_world.wasm.gz": 7452,
-  "no_asserts.js": 26714,
-  "no_asserts.js.gz": 8952,
+  "no_asserts.js": 26818,
+  "no_asserts.js.gz": 8989,
   "no_asserts.wasm": 12227,
   "no_asserts.wasm.gz": 6008,
-  "strict.js": 52031,
-  "strict.js.gz": 16465,
+  "strict.js": 52135,
+  "strict.js.gz": 16503,
   "strict.wasm": 15143,
   "strict.wasm.gz": 7438,
-  "total": 175239,
-  "total_gz": 63447
+  "total": 175551,
+  "total_gz": 63561
 }

--- a/test/other/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/other/codesize/test_codesize_minimal_O0.expected.js
@@ -1304,12 +1304,15 @@ function assignWasmExports(wasmExports) {
 var _global_val = Module['_global_val'] = 65536;var wasmImports = {
   
 };
-var wasmExports;
-createWasm();
 
 
 // include: postamble.js
 // === Auto-generated postamble setup entry stuff ===
+
+// With async instantation wasmExports is assigned asyncronously when the
+// the instance is received.
+var wasmExports;
+createWasm();
 
 var calledRun;
 

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -1020,21 +1020,6 @@ def create_module(metadata, function_exports, global_exports, tag_exports, libra
     else:
       module.append('var wasmImports = %s;\n' % sending)
 
-    if not settings.MINIMAL_RUNTIME:
-      if settings.MODULARIZE == 'instance':
-        module.append("var wasmExports;\n")
-      elif settings.WASM_ASYNC_COMPILATION:
-        if settings.MODULARIZE:
-          # In modularize mode the generated code is within a factory function.
-          # This magic string gets replaced by `await createWasm`.  It needed to allow
-          # closure and acorn to process the module without seeing this as a top-level
-          # await.
-          module.append("var wasmExports = EMSCRIPTEN$AWAIT(createWasm());\n")
-        else:
-          module.append("var wasmExports;\ncreateWasm();\n")
-      else:
-        module.append("var wasmExports = createWasm();\n")
-
   if settings.SUPPORT_LONGJMP == 'emscripten' or not settings.DISABLE_EXCEPTION_CATCHING:
     module.append(create_invoke_wrappers(metadata))
   else:

--- a/tools/link.py
+++ b/tools/link.py
@@ -2125,7 +2125,8 @@ def phase_source_transforms(options):
 # Unmangle previously mangled `import.meta` and `await import` references in
 # both main code and libraries.
 # See also: `preprocess` in parseTools.js.
-def fix_es6_import_statements(js_file):
+def fix_js_mangling(js_file):
+  # We don't apply these mangliings except in MODULARIZE/EXPORT_ES6 modes.
   if not settings.MODULARIZE:
     return
 
@@ -2133,9 +2134,8 @@ def fix_es6_import_statements(js_file):
   write_file(js_file, src
              .replace('EMSCRIPTEN$IMPORT$META', 'import.meta')
              .replace('EMSCRIPTEN$AWAIT$IMPORT', 'await import')
-             .replace('EMSCRIPTEN$AWAIT(createWasm())', 'await createWasm()')
              .replace('EMSCRIPTEN$AWAIT(', 'await ('))
-  save_intermediate('es6-module')
+  save_intermediate('js-mangling')
 
 
 def node_detection_code():
@@ -2214,7 +2214,7 @@ def phase_final_emitting(options, target, js_target, wasm_target):
     shared.run_js_tool(utils.path_from_root('tools/unsafe_optimizations.mjs'), [final_js, '-o', final_js], cwd=utils.path_from_root('.'))
     save_intermediate('unsafe-optimizations2')
 
-  fix_es6_import_statements(final_js)
+  fix_js_mangling(final_js)
 
   # Apply pre and postjs files
   if options.extern_pre_js or options.extern_post_js:
@@ -2240,7 +2240,7 @@ def phase_final_emitting(options, target, js_target, wasm_target):
       support_target = unsuffixed(js_target) + '.pthread.mjs'
       pthread_code = building.read_and_preprocess(utils.path_from_root('src/pthread_esm_startup.mjs'), expand_macros=True)
       write_file(support_target, pthread_code)
-      fix_es6_import_statements(support_target)
+      fix_js_mangling(support_target)
   else:
     move_file(final_js, js_target)
 


### PR DESCRIPTION
We should always prefer JS template code to python-generated JS (IMHO).