### PR TITLE
Fix emrun with EXIT_RUNTIME=0

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -734,9 +734,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     options.post_js.append(utils.path_from_root('src/emrun_postjs.js'))
     if settings.MINIMAL_RUNTIME:
       exit_with_error('--emrun is not compatible with MINIMAL_RUNTIME')
-    # emrun mode waits on program exit
-    if user_settings.get('EXIT_RUNTIME') == '0':
-      exit_with_error('--emrun is not compatible with EXIT_RUNTIME=0')
     settings.EXIT_RUNTIME = 1
     # emrun_postjs.js needs this library function.
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$addOnExit']


### PR DESCRIPTION
I run emrun-based test harness on https://github.com/juj/wasm_webgpu and it uses `EXIT_RUNTIME=0` in the harness without problems. Not sure why this was deemed to be not working, but all the tests there are based on this mode.

After I updated Emscripten, the wasm_webgpu tests stopped working when this check had been added.