### PR TITLE
Refactor pthread and wasm worker init sequence

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -959,14 +959,13 @@ function getWasmImports() {
 
 #if PTHREADS || WASM_WORKERS
   if ({{{ ENVIRONMENT_IS_WORKER_THREAD() }}}) {
-    return new Promise((resolve) => {
-      wasmModuleReceived = (module) => {
-        // Instantiate from the module posted from the main thread.
-        // We can just use sync instantiation in the worker.
-        var instance = new WebAssembly.Instance(module, getWasmImports());
-        resolve(receiveInstance(instance, module));
-      };
-    });
+    // Instantiate from the module that was recieved via postMessage from
+    // the main thread. We can just use sync instantiation in the worker.
+#if ASSERTIONS
+    assert(wasmModule, "wasmModule should have been received via postMessage");
+#endif
+    var instance = new WebAssembly.Instance(wasmModule, getWasmImports());
+    return receiveInstance(instance, wasmModule);
   }
 #endif
 

--- a/src/runtime_common.js
+++ b/src/runtime_common.js
@@ -31,12 +31,7 @@ function growMemViews() {
 var readyPromiseResolve, readyPromiseReject;
 #endif
 
-#if PTHREADS || WASM_WORKERS
-#if !MINIMAL_RUNTIME
-var wasmModuleReceived;
-#endif
-
-#if ENVIRONMENT_MAY_BE_NODE && !WASM_ESM_INTEGRATION
+#if (PTHREADS || WASM_WORKERS) && (ENVIRONMENT_MAY_BE_NODE && !WASM_ESM_INTEGRATION)
 if (ENVIRONMENT_IS_NODE && {{{ ENVIRONMENT_IS_WORKER_THREAD() }}}) {
   // Create as web-worker-like an environment as we can.
   var parentPort = worker_threads['parentPort'];
@@ -46,8 +41,7 @@ if (ENVIRONMENT_IS_NODE && {{{ ENVIRONMENT_IS_WORKER_THREAD() }}}) {
     postMessage: (msg) => parentPort['postMessage'](msg),
   });
 }
-#endif // ENVIRONMENT_MAY_BE_NODE && !WASM_ESM_INTEGRATION
-#endif
+#endif // (PTHREADS || WASM_WORKERS) && (ENVIRONMENT_MAY_BE_NODE && !WASM_ESM_INTEGRATION)
 
 #if PTHREADS
 #include "runtime_pthread.js"

--- a/src/runtime_pthread.js
+++ b/src/runtime_pthread.js
@@ -122,7 +122,13 @@ if (ENVIRONMENT_IS_PTHREAD) {
         Module['wasm'] = msgData.wasmModule;
         loadModule();
 #else
-        wasmModuleReceived(msgData.wasmModule);
+        wasmModule = msgData.wasmModule;
+#if MODULARIZE == 'instance'
+        init();
+#else
+        createWasm();
+        run();
+#endif
 #endif // MINIMAL_RUNTIME
 #endif
       } else if (cmd === 'run') {

--- a/src/wasm_worker.js
+++ b/src/wasm_worker.js
@@ -18,7 +18,13 @@ function startWasmWorker(props) {
   Module['wasm'] = props.wasm;
   loadModule()
 #else
-  wasmModuleReceived(props.wasm);
+  wasmModule = props.wasm;
+#if MODULARIZE == 'instance'
+  init();
+#else
+  createWasm();
+  run();
+#endif
 #endif
   // Drop now unneeded references to from the Module object in this Worker,
   // these are not needed anymore.

--- a/test/code_size/test_codesize_minimal_esm.json
+++ b/test/code_size/test_codesize_minimal_esm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2513,
-  "a.out.js.gz": 1229,
+  "a.out.js": 2515,
+  "a.out.js.gz": 1230,
   "a.out.nodebug.wasm": 62,
   "a.out.nodebug.wasm.gz": 76,
-  "total": 2575,
-  "total_gz": 1305,
+  "total": 2577,
+  "total_gz": 1306,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_minimal_pthreads.json
+++ b/test/code_size/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7529,
-  "a.out.js.gz": 3720,
+  "a.out.js": 7499,
+  "a.out.js.gz": 3719,
   "a.out.nodebug.wasm": 19588,
   "a.out.nodebug.wasm.gz": 9025,
-  "total": 27117,
-  "total_gz": 12745,
+  "total": 27087,
+  "total_gz": 12744,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/code_size/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/code_size/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,9 +1,9 @@
 {
-  "a.out.js": 7956,
+  "a.out.js": 7922,
   "a.out.js.gz": 3920,
   "a.out.nodebug.wasm": 19589,
   "a.out.nodebug.wasm.gz": 9025,
-  "total": 27545,
+  "total": 27511,
   "total_gz": 12945,
   "sent": [
     "a (memory)",

--- a/test/code_size/test_unoptimized_code_size.json
+++ b/test/code_size/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 54085,
-  "hello_world.js.gz": 17171,
+  "hello_world.js": 54086,
+  "hello_world.js.gz": 17172,
   "hello_world.wasm": 15143,
   "hello_world.wasm.gz": 7452,
-  "no_asserts.js": 26818,
-  "no_asserts.js.gz": 8989,
+  "no_asserts.js": 26819,
+  "no_asserts.js.gz": 8991,
   "no_asserts.wasm": 12227,
   "no_asserts.wasm.gz": 6008,
-  "strict.js": 52135,
-  "strict.js.gz": 16503,
+  "strict.js": 52136,
+  "strict.js.gz": 16504,
   "strict.wasm": 15143,
   "strict.wasm.gz": 7438,
-  "total": 175551,
-  "total_gz": 63561
+  "total": 175554,
+  "total_gz": 63565
 }

--- a/test/other/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/other/codesize/test_codesize_minimal_O0.expected.js
@@ -1309,9 +1309,10 @@ var _global_val = Module['_global_val'] = 65536;var wasmImports = {
 // include: postamble.js
 // === Auto-generated postamble setup entry stuff ===
 
+var wasmExports;
+
 // With async instantation wasmExports is assigned asyncronously when the
 // the instance is received.
-var wasmExports;
 createWasm();
 
 var calledRun;


### PR DESCRIPTION
Rather than running `createWasm` and then returning a promise based on the `wasmModuleReceived` we now do something closer to the way it works under `MINIMUL_RUNTIME`: We delay both `createWasm` and `run` calls until the module is received via postMessage.