### PR TITLE
Fix test other.test_browser_language_detection

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6912,7 +6912,7 @@ int main(int argc, char **argv) {
 
     # We support both "C" and system LANG here since older versions of node do
     # not expose navigator.languages.
-    self.assertContained(f'LANG=({expected_lang}|C.UTF-8)', self.run_js('a.out.js'), regex=True)
+    self.assertContained(f'LANG=({expected_lang}|en_US.UTF-8|C.UTF-8)', self.run_js('a.out.js'), regex=True)
 
     # Accept-Language: fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3
     create_file('pre.js', 'var navigator = { language: "fr" };')


### PR DESCRIPTION
Fix test other.test_browser_language_detection to allow any language (e.g. en_US, en_FI, fi_FI, and so on). This allows developers who are not en_US to also run the test.