### PR TITLE
Fix sockets.test_sockets_echo_websockify on Windows.

### DIFF
--- a/test/sockets/test_sockets_echo_server.c
+++ b/test/sockets/test_sockets_echo_server.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #ifdef _WIN32
 #include <winsock2.h>
+#include <ws2tcpip.h>
 typedef int socklen_t;
 #define close closesocket
 #pragma comment(lib, "Ws2_32.lib")


### PR DESCRIPTION
Fix sockets.test_sockets_echo_websockify on Windows. The code has snuck in use of inet_pton() which only exists in ws2tcpip.h on Windows. https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-inet_pton