### PR TITLE
Fix regression to enable specifying EMTEST_BROWSER env. var in native path format on Windows.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -2343,8 +2343,10 @@ class BrowserCore(RunnerCore):
     if WINDOWS:
       # On Windows env. vars canonically use backslashes as directory delimiters, e.g.
       # set EMTEST_BROWSER=C:\Program Files\Mozilla Firefox\firefox.exe
-      # and spaces are not escaped, so convert backslashes to forward slashes to feed to shlex split.
-      EMTEST_BROWSER = EMTEST_BROWSER.replace('\\', '/')
+      # and spaces are not escaped. But make sure to also support args, e.g.
+      # set EMTEST_BROWSER="C:\Users\clb\AppData\Local\Google\Chrome SxS\Application\chrome.exe" --enable-unsafe-webgpu
+      if '"' not in EMTEST_BROWSER and "'" not in EMTEST_BROWSER:
+        EMTEST_BROWSER = f'"{EMTEST_BROWSER.replace("\\", "/")}"'
     browser_args = shlex.split(EMTEST_BROWSER)
     logger.info('Launching browser: %s', str(browser_args))
     cls.browser_proc = subprocess.Popen(browser_args + [url])

--- a/test/common.py
+++ b/test/common.py
@@ -2340,6 +2340,11 @@ class BrowserCore(RunnerCore):
     if not EMTEST_BROWSER:
       logger.info('No EMTEST_BROWSER set. Defaulting to `google-chrome`')
       EMTEST_BROWSER = 'google-chrome'
+    if WINDOWS:
+      # On Windows env. vars canonically use backslashes as directory delimiters, e.g.
+      # set EMTEST_BROWSER=C:\Program Files\Mozilla Firefox\firefox.exe
+      # and spaces are not escaped, so convert backslashes to forward slashes to feed to shlex split.
+      EMTEST_BROWSER = EMTEST_BROWSER.replace('\\', '/')
     browser_args = shlex.split(EMTEST_BROWSER)
     logger.info('Launching browser: %s', str(browser_args))
     cls.browser_proc = subprocess.Popen(browser_args + [url])

--- a/test/common.py
+++ b/test/common.py
@@ -2346,7 +2346,7 @@ class BrowserCore(RunnerCore):
       # and spaces are not escaped. But make sure to also support args, e.g.
       # set EMTEST_BROWSER="C:\Users\clb\AppData\Local\Google\Chrome SxS\Application\chrome.exe" --enable-unsafe-webgpu
       if '"' not in EMTEST_BROWSER and "'" not in EMTEST_BROWSER:
-        EMTEST_BROWSER = f'"{EMTEST_BROWSER.replace("\\", "/")}"'
+        EMTEST_BROWSER = '"' + EMTEST_BROWSER.replace("\\", "/") + '"'
     browser_args = shlex.split(EMTEST_BROWSER)
     logger.info('Launching browser: %s', str(browser_args))
     cls.browser_proc = subprocess.Popen(browser_args + [url])


### PR DESCRIPTION
Fix regression to enable specifying EMTEST_BROWSER env. var in native path format on Windows.

This is something that used to work a long time ago, and at some refactor got lost. On Windows environment variables that point to directories or files canonically use native path slashes `\` to do so.