### PR TITLE
Skip core2ss.test_pthread_dylink_tls.

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9400,6 +9400,9 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @needs_dylink
   @node_pthreads
   def test_pthread_dylink_tls(self):
+    if '-O2' in self.cflags and self.get_setting('STACK_OVERFLOW_CHECK') == 2:
+      self.skipTest('https://github.com/emscripten-core/emscripten/issues/24964: fails with Aborted(stack overflow (Attempt to set SP to 0x000114d0, with stack limits [0x00000000 - 0x00000000])')
+
     self.cflags += ['-Wno-experimental', '-pthread']
     main = test_file('core/pthread/test_pthread_dylink_tls.c')
     self.dylink_testf(main, main_cflags=['-sPTHREAD_POOL_SIZE=1'])


### PR DESCRIPTION
 https://github.com/emscripten-core/emscripten/issues/24964