### PR TITLE
Make addRunDependency/removeRunDependency optional

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 4.0.14 (in development)
 -----------------------
+- The `addRunDependency` and `removeRunDependency` API are now optional and need
+  to be included and/or exported using, for example,
+  `DEFAULT_LIBRARY_FUNCS_TO_INCLUDE` or `EXPORTED_RUNTIME_METHODS`. (#24974)
 - The `LOAD_SOURCE_MAP` setting was made an internal setting.  This was always
   an internal detail of the sanitizers, which is enabled automatically when
   needed, so setting it explicitly should never be needed. (#24967)

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -2274,6 +2274,7 @@ addToLibrary({
   $noExitRuntime__postset: () => addAtModule(makeModuleReceive('noExitRuntime')),
   $noExitRuntime: {{{ !EXIT_RUNTIME }}},
 
+#if !MINIMAL_RUNTIME
   // A counter of dependencies for calling run(). If we need to
   // do asynchronous work before running, increment this and
   // decrement it. Incrementing must happen in a place like
@@ -2293,7 +2294,7 @@ addToLibrary({
   $runDependencyWatcher: null,
 #endif
 
-  $addRunDependency__deps: ['$runDependencies',
+  $addRunDependency__deps: ['$runDependencies', '$removeRunDependency',
 #if ASSERTIONS
     '$runDependencyTracking',
     '$runDependencyWatcher',
@@ -2377,6 +2378,7 @@ addToLibrary({
       }
     }
   },
+#endif
 
   // The following addOn<X> functions are for adding runtime callbacks at
   // various executions points. Each addOn<X> function has a corresponding

--- a/src/lib/libfs_shared.js
+++ b/src/lib/libfs_shared.js
@@ -55,6 +55,8 @@ addToLibrary({
     '$PATH_FS',
     '$FS_createDataFile',
     '$getUniqueRunDependency',
+    '$addRunDependency',
+    '$removeRunDependency',
     '$FS_handledByPreloadPlugin',
   ],
   $FS_preloadFile: async (parent, name, url, canRead, canWrite, dontCreateFile, canOwn, preFinish) => {

--- a/src/lib/liblz4.js
+++ b/src/lib/liblz4.js
@@ -6,7 +6,7 @@
 
 #if LZ4
 addToLibrary({
-  $LZ4__deps: ['$FS', '$preloadPlugins', '$getUniqueRunDependency'],
+  $LZ4__deps: ['$FS', '$preloadPlugins', '$getUniqueRunDependency', '$addRunDependency', '$removeRunDependency'],
   $LZ4: {
     DIR_MODE: {{{ cDefs.S_IFDIR | 0o777 }}},
     FILE_MODE: {{{ cDefs.S_IFREG | 0o777 }}},

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -70,6 +70,10 @@ var LibraryPThread = {
 #if MAIN_MODULE
                    '$markAsFinished',
 #endif
+#if !MINIMAL_RUNTIME && PTHREAD_POOL_SIZE && !PTHREAD_POOL_DELAY_LOAD
+                   '$addRunDependency',
+                   '$removeRunDependency',
+#endif
                    '$spawnThread',
                    '_emscripten_thread_free_data',
                    'exit',

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -36,7 +36,9 @@ var mainArgs = undefined;
 {{{ asyncIf(ASYNCIFY == 2) }}}function callMain() {
 #endif
 #if ASSERTIONS
+#if '$runDependencies' in addedLibraryItems
   assert(runDependencies == 0, 'cannot call main when async dependencies remain! (listen on Module["onRuntimeInitialized"])');
+#endif
   assert(typeof onPreRuns === 'undefined' || onPreRuns.length == 0, 'cannot call main when preRun functions remain to be called');
 #endif
 
@@ -133,7 +135,7 @@ function run(args = arguments_) {
 function run() {
 #endif
 
-#if !BOOTSTRAPPING_STRUCT_INFO
+#if '$runDependencies' in addedLibraryItems
   if (runDependencies > 0) {
 #if RUNTIME_DEBUG
     dbg('run() called, but dependencies remain, so not running');
@@ -159,7 +161,7 @@ function run() {
 
   preRun();
 
-#if !BOOTSTRAPPING_STRUCT_INFO
+#if '$runDependencies' in addedLibraryItems
   // a preRun added a dependency, run will be called later
   if (runDependencies > 0) {
 #if RUNTIME_DEBUG

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -754,12 +754,12 @@ function getWasmImports() {
 #if DECLARE_ASM_MODULE_EXPORTS
     assignWasmExports(wasmExports);
 #endif
-#if WASM_ASYNC_COMPILATION
+#if WASM_ASYNC_COMPILATION && !MODULARIZE
     removeRunDependency('wasm-instantiate');
 #endif
     return wasmExports;
   }
-#if WASM_ASYNC_COMPILATION
+#if WASM_ASYNC_COMPILATION && !MODULARIZE
   addRunDependency('wasm-instantiate');
 #endif
 

--- a/test/code_size/test_codesize_cxx_ctors2.json
+++ b/test/code_size/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19731,
-  "a.out.js.gz": 8149,
+  "a.out.js.gz": 8148,
   "a.out.nodebug.wasm": 128935,
   "a.out.nodebug.wasm.gz": 48881,
   "total": 148666,
-  "total_gz": 57030,
+  "total_gz": 57029,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/code_size/test_codesize_cxx_wasmfs.json
+++ b/test/code_size/test_codesize_cxx_wasmfs.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7143,
-  "a.out.js.gz": 3340,
+  "a.out.js.gz": 3337,
   "a.out.nodebug.wasm": 169796,
   "a.out.nodebug.wasm.gz": 63083,
   "total": 176939,
-  "total_gz": 66423,
+  "total_gz": 66420,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/code_size/test_codesize_hello_O0.json
+++ b/test/code_size/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 22497,
-  "a.out.js.gz": 8330,
+  "a.out.js.gz": 8329,
   "a.out.nodebug.wasm": 15143,
   "a.out.nodebug.wasm.gz": 7452,
   "total": 37640,
-  "total_gz": 15782,
+  "total_gz": 15781,
   "sent": [
     "fd_write"
   ],

--- a/test/code_size/test_codesize_hello_O1.json
+++ b/test/code_size/test_codesize_hello_O1.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 6411,
-  "a.out.js.gz": 2477,
+  "a.out.js.gz": 2478,
   "a.out.nodebug.wasm": 2675,
   "a.out.nodebug.wasm.gz": 1491,
   "total": 9086,
-  "total_gz": 3968,
+  "total_gz": 3969,
   "sent": [
     "fd_write"
   ],

--- a/test/code_size/test_codesize_hello_O2.json
+++ b/test/code_size/test_codesize_hello_O2.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4369,
-  "a.out.js.gz": 2145,
+  "a.out.js.gz": 2146,
   "a.out.nodebug.wasm": 1979,
   "a.out.nodebug.wasm.gz": 1157,
   "total": 6348,
-  "total_gz": 3302,
+  "total_gz": 3303,
   "sent": [
     "fd_write"
   ],

--- a/test/code_size/test_codesize_hello_O3.json
+++ b/test/code_size/test_codesize_hello_O3.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4311,
-  "a.out.js.gz": 2102,
+  "a.out.js.gz": 2104,
   "a.out.nodebug.wasm": 1733,
   "a.out.nodebug.wasm.gz": 980,
   "total": 6044,
-  "total_gz": 3082,
+  "total_gz": 3084,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/code_size/test_codesize_hello_Os.json
+++ b/test/code_size/test_codesize_hello_Os.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4311,
-  "a.out.js.gz": 2102,
+  "a.out.js.gz": 2104,
   "a.out.nodebug.wasm": 1723,
   "a.out.nodebug.wasm.gz": 985,
   "total": 6034,
-  "total_gz": 3087,
+  "total_gz": 3089,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/code_size/test_codesize_hello_dylink.json
+++ b/test/code_size/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26976,
-  "a.out.js.gz": 11462,
+  "a.out.js": 26975,
+  "a.out.js.gz": 11461,
   "a.out.nodebug.wasm": 18561,
   "a.out.nodebug.wasm.gz": 9167,
-  "total": 45537,
-  "total_gz": 20629,
+  "total": 45536,
+  "total_gz": 20628,
   "sent": [
     "__heap_base",
     "__indirect_function_table",

--- a/test/code_size/test_codesize_hello_dylink_all.json
+++ b/test/code_size/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 246639,
+  "a.out.js": 246640,
   "a.out.nodebug.wasm": 597720,
-  "total": 844359,
+  "total": 844360,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/code_size/test_codesize_hello_single_file.json
+++ b/test/code_size/test_codesize_hello_single_file.json
@@ -1,6 +1,6 @@
 {
   "a.out.js": 6615,
-  "a.out.js.gz": 3612,
+  "a.out.js.gz": 3613,
   "sent": [
     "a (fd_write)"
   ]

--- a/test/code_size/test_codesize_hello_wasmfs.json
+++ b/test/code_size/test_codesize_hello_wasmfs.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4311,
-  "a.out.js.gz": 2102,
+  "a.out.js.gz": 2104,
   "a.out.nodebug.wasm": 1733,
   "a.out.nodebug.wasm.gz": 980,
   "total": 6044,
-  "total_gz": 3082,
+  "total_gz": 3084,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/code_size/test_codesize_libcxxabi_message_O3_standalone.json
+++ b/test/code_size/test_codesize_libcxxabi_message_O3_standalone.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 3605,
-  "a.out.js.gz": 1714,
+  "a.out.js.gz": 1713,
   "a.out.nodebug.wasm": 132,
   "a.out.nodebug.wasm.gz": 140,
   "total": 3737,
-  "total_gz": 1854,
+  "total_gz": 1853,
   "sent": [
     "proc_exit"
   ],

--- a/test/code_size/test_codesize_mem_O3_standalone_narg.json
+++ b/test/code_size/test_codesize_mem_O3_standalone_narg.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 3605,
-  "a.out.js.gz": 1714,
+  "a.out.js.gz": 1713,
   "a.out.nodebug.wasm": 5267,
   "a.out.nodebug.wasm.gz": 2364,
   "total": 8872,
-  "total_gz": 4078,
+  "total_gz": 4077,
   "sent": [
     "proc_exit"
   ],

--- a/test/code_size/test_codesize_mem_O3_standalone_narg_flto.json
+++ b/test/code_size/test_codesize_mem_O3_standalone_narg_flto.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 3605,
-  "a.out.js.gz": 1714,
+  "a.out.js.gz": 1713,
   "a.out.nodebug.wasm": 4080,
   "a.out.nodebug.wasm.gz": 2001,
   "total": 7685,
-  "total_gz": 3715,
+  "total_gz": 3714,
   "sent": [
     "proc_exit"
   ],

--- a/test/code_size/test_codesize_minimal_esm.json
+++ b/test/code_size/test_codesize_minimal_esm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2522,
-  "a.out.js.gz": 1231,
+  "a.out.js": 2434,
+  "a.out.js.gz": 1181,
   "a.out.nodebug.wasm": 62,
   "a.out.nodebug.wasm.gz": 76,
-  "total": 2584,
-  "total_gz": 1307,
+  "total": 2496,
+  "total_gz": 1257,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_unoptimized_code_size.json
+++ b/test/code_size/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 53807,
-  "hello_world.js.gz": 17007,
+  "hello_world.js": 53809,
+  "hello_world.js.gz": 17016,
   "hello_world.wasm": 15143,
   "hello_world.wasm.gz": 7452,
-  "no_asserts.js": 26385,
+  "no_asserts.js": 26387,
   "no_asserts.js.gz": 8797,
   "no_asserts.wasm": 12227,
   "no_asserts.wasm.gz": 6008,
-  "strict.js": 51845,
-  "strict.js.gz": 16336,
+  "strict.js": 51847,
+  "strict.js.gz": 16341,
   "strict.wasm": 15143,
   "strict.wasm.gz": 7438,
-  "total": 174550,
-  "total_gz": 63038
+  "total": 174556,
+  "total_gz": 63052
 }

--- a/test/other/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/other/codesize/test_codesize_minimal_O0.expected.js
@@ -696,10 +696,33 @@ async function createWasm() {
 
   var runDependencies = 0;
   
+  
+  var dependenciesFulfilled = null;
+  
   var runDependencyTracking = {
   };
   
   var runDependencyWatcher = null;
+  var removeRunDependency = (id) => {
+      runDependencies--;
+  
+      assert(id, 'removeRunDependency requires an ID');
+      assert(runDependencyTracking[id]);
+      delete runDependencyTracking[id];
+      if (runDependencies == 0) {
+        if (runDependencyWatcher !== null) {
+          clearInterval(runDependencyWatcher);
+          runDependencyWatcher = null;
+        }
+        if (dependenciesFulfilled) {
+          var callback = dependenciesFulfilled;
+          dependenciesFulfilled = null;
+          callback(); // can add another dependenciesFulfilled
+        }
+      }
+    };
+  
+  
   var addRunDependency = (id) => {
       runDependencies++;
   
@@ -764,29 +787,6 @@ async function createWasm() {
       // With CAN_ADDRESS_2GB or MEMORY64, pointers are already unsigned.
       ptr >>>= 0;
       return '0x' + ptr.toString(16).padStart(8, '0');
-    };
-
-  
-  var dependenciesFulfilled = null;
-  
-  
-  var removeRunDependency = (id) => {
-      runDependencies--;
-  
-      assert(id, 'removeRunDependency requires an ID');
-      assert(runDependencyTracking[id]);
-      delete runDependencyTracking[id];
-      if (runDependencies == 0) {
-        if (runDependencyWatcher !== null) {
-          clearInterval(runDependencyWatcher);
-          runDependencyWatcher = null;
-        }
-        if (dependenciesFulfilled) {
-          var callback = dependenciesFulfilled;
-          dependenciesFulfilled = null;
-          callback(); // can add another dependenciesFulfilled
-        }
-      }
     };
 
 

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1355,7 +1355,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
 
   def test_fs_idbfs_fsync(self):
     # sync from persisted state into memory before main()
-    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$ccall')
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$ccall,$addRunDependency')
     create_file('pre.js', '''
       Module.preRun = () => {
         addRunDependency('syncfs');
@@ -2382,6 +2382,7 @@ void *getBindBuffer() {
   @also_with_wasm2js
   def test_pre_run_deps(self):
     # Adding a dependency in preRun will delay run
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency')
     create_file('pre.js', '''
       Module.preRun = () => {
         addRunDependency('foo');
@@ -2600,6 +2601,7 @@ void *getBindBuffer() {
     self.btest('glew.c', cflags=['-lGL', '-lSDL', '-lGLEW', '-sLEGACY_GL_EMULATION', '-DGLEW_MX'], expected='1')
 
   def test_doublestart_bug(self):
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency,$removeRunDependency')
     create_file('pre.js', r'''
 Module["preRun"] = () => {
   addRunDependency('test_run_dependency');

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2865,6 +2865,7 @@ More info: https://emscripten.org
     # running.
     with open('pre.js', 'a') as f:
       f.write('Module["preRun"] = () => { out("add-dep"); addRunDependency("dep"); }\n')
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency')
     output = self.do_runf('hello_world.c', cflags=['--pre-js', 'pre.js', '-sRUNTIME_DEBUG', '-sWASM_ASYNC_COMPILATION=0', '-O2', '--closure=1'])
     self.assertContained('add-dep\n', output)
     self.assertNotContained('hello, world!\n', output)
@@ -5249,9 +5250,8 @@ Module["preRun"] = () => {
 };
 ''')
 
-    self.run_process([EMCC, 'code.c', '--pre-js', 'pre.js'])
-    output = self.run_js('a.out.js')
-
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency,$removeRunDependency')
+    output = self.do_runf('code.c', cflags=['--pre-js=pre.js'])
     self.assertEqual(output.count('This should only appear once.'), 1)
 
   def test_module_print(self):
@@ -7214,6 +7214,7 @@ int main(void) {
     await Module();
     console.log('got module');
     ''')
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency,$removeRunDependency')
     self.cflags += ['-sEXPORT_ES6', '-sMODULARIZE', '-sWASM_ASYNC_COMPILATION=0', '--pre-js=pre.js']
     self.emcc(test_file('hello_world.c'), output_filename='hello_world.mjs')
     self.assertContained('add-dep\nremove-dep\nhello, world!\ngot module\n', self.run_js('run.mjs'))

--- a/tools/link.py
+++ b/tools/link.py
@@ -1127,10 +1127,12 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
         settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$warnOnce']
 
       settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$getValue', '$setValue']
-      # TODO(sbc): Remove these forced dependencies.
-      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$runDependencies', '$addRunDependency', '$removeRunDependency']
 
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$ExitStatus']
+
+    # Certain configurations require the removeRunDependency/addRunDependency system.
+    if settings.LOAD_SOURCE_MAP or settings.PROXY_TO_WORKER or (settings.WASM_ASYNC_COMPILATION and not settings.MODULARIZE):
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$addRunDependency', '$removeRunDependency']
 
   if settings.ABORT_ON_WASM_EXCEPTIONS or settings.SPLIT_MODULE:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$wasmTable']


### PR DESCRIPTION
This saves on code size is configurations where its not needed. i.e. in `MODULARIZE` mode where we use `await` to wait for instantiation, or if sync instantiation is used.