### PR TITLE
Entry point scripts with all executable bits set

### DIFF
--- a/tools/maint/create_entry_points.py
+++ b/tools/maint/create_entry_points.py
@@ -58,6 +58,11 @@ entry_remap = {
 }
 
 
+def make_executable(filename):
+  old_mode = stat.S_IMODE(os.stat(filename).st_mode)
+  os.chmod(filename, old_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
 def main(all_platforms):
   is_windows = sys.platform.startswith('win')
   do_unix = all_platforms or not is_windows
@@ -87,7 +92,7 @@ def main(all_platforms):
         out_sh_file = os.path.join(__rootdir__, entry_point)
         with open(out_sh_file, 'w') as f:
           f.write(sh_data)
-        os.chmod(out_sh_file, stat.S_IMODE(os.stat(out_sh_file).st_mode) | stat.S_IXUSR)
+        make_executable(out_sh_file)
 
       if do_windows:
         with open(os.path.join(__rootdir__, entry_point + '.bat'), 'w') as f:


### PR DESCRIPTION
Prior to #23761, when all the launcher script lived in git, our emscripten-release builder was checking out the launchers scripts and bundling them will `-rwxr-xr-x` permissions.

Once #23761, and `create_entry_points.py` was used to create them on demand the `x` bit was lost except for the user.

Fixes: https://github.com/emscripten-core/emsdk/issues/1583