### PR TITLE
Fix flaky test *.test_pthread_wait_async.

### DIFF
--- a/test/atomic/test_wait_async.c
+++ b/test/atomic/test_wait_async.c
@@ -8,7 +8,6 @@
 volatile int32_t addr = 0;
 
 void run_test() {
-  emscripten_out("worker_main");
 #if __EMSCRIPTEN_WASM_WORKERS__
   emscripten_wasm_worker_sleep(1000 * 1000000ull); // Sleep one second.
 #else

--- a/test/atomic/test_wait_async.out
+++ b/test/atomic/test_wait_async.out
@@ -5,7 +5,6 @@ Waiting for 0 milliseconds should return 'timed-out'
 Waiting for >0 milliseconds should return 'ok' (but successfully time out in first call to asyncWaitFinished)
 Waiting for infinitely long should return 'ok' (and return 'ok' in second call to asyncWaitFinished)
 main: asyncWaitShouldTimeout
-worker_main
 worker: addr = 1234
 worker: notify async waiting main thread
 main: asyncWaitFinished


### PR DESCRIPTION
Fix flaky test *.test_pthread_wait_async. The test does not synchronize worker_main printing, so it could occur in different order on different runs.