### PR TITLE
Possibly fix flaky test seen to error in wasm2js3.test_stat_chmod_wasmfs.

### DIFF
--- a/test/stat/test_chmod.c
+++ b/test/stat/test_chmod.c
@@ -22,7 +22,7 @@ void create_file(const char *path, const char *buffer, int mode) {
   int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, mode);
   assert(fd >= 0);
 
-  int err = write(fd, buffer, sizeof(char) * strlen(buffer));
+  int err = (int)write(fd, buffer, sizeof(char) * strlen(buffer));
   assert(err ==  (sizeof(char) * strlen(buffer)));
 
   close(fd);

--- a/test/stat/test_chmod.c
+++ b/test/stat/test_chmod.c
@@ -44,8 +44,8 @@ void cleanup() {
 
 void test() {
   int err;
-  int lastctime;
-  int lastmtime;
+  time_t lastctime;
+  time_t lastmtime;
   struct stat s;
 
   //

--- a/test/stat/test_chmod.c
+++ b/test/stat/test_chmod.c
@@ -129,7 +129,7 @@ void test() {
 
 #ifndef WASMFS // TODO https://github.com/emscripten-core/emscripten/issues/15948
   lstat("file-link", &s);
-  int link_mode = s.st_mode;
+  mode_t link_mode = s.st_mode;
   assert((link_mode & 0777) != S_IRUSR);
 
   //

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5686,7 +5686,7 @@ got: 10
       self.skipTest('mode bits work differently on windows')
     if nodefs and self.get_setting('WASMFS'):
       self.skipTest('test requires symlink creation which currently missing from wasmfs+noderawfs')
-    self.do_runf('stat/test_chmod.c', 'success')
+    self.do_runf('stat/test_chmod.c', 'success', cflags=['-Werror=conversion'])
 
   @also_with_wasmfs
   def test_stat_mknod(self):


### PR DESCRIPTION
`time_t` is `long long`, test has a narrowing conversion to `int`.

Fails nondeterministically in http://clbri.com:8010/api/v2/logs/20165/raw_inline