### PR TITLE
Fix #24982: emsymbolizer failed to parse symbol map from C++ project

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11022,7 +11022,7 @@ int main() {
     check_symbolmap_info(unreachable_addr, '__original_main')
 
   def test_emsymbolizer_symbol_map_names(self):
-    "Test emsymbolizer with symbol map which contains demangled C++ names"
+    """Test emsymbolizer with symbol map which contains demangled C++ names"""
     create_file('test_symbol_map.cpp', r'''
       #include <emscripten.h>
       EM_JS(int, out_to_js, (), { return 0; });

--- a/tools/emsymbolizer.py
+++ b/tools/emsymbolizer.py
@@ -230,10 +230,14 @@ def symbolize_address_symbolmap(module, address, symbol_map_file):
   """Symbolize using a symbol map file."""
   func_names = {}
 
+  def split_symbolmap_line(line):
+    assert ':' in line, f'invalid symbolmap line: {line}'
+    return line.split(':', 1)
+
   with open(symbol_map_file) as f:
     lines = f.read().splitlines()
     for line in lines:
-      index, name = line.split(':')
+      index, name = split_symbolmap_line(line)
       func_names[int(index)] = name
 
   func_index = -1


### PR DESCRIPTION
1. fix symbol map line parse
2. unescape ascii code
3. update tests: test/runner "other.test_emsymbolizer*"

This PR fixes #24982