### PR TITLE
Fix test_bullet_autoconf on ARM64 macOS.

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -474,8 +474,9 @@ class TestCoreBase(RunnerCore):
       # that we are doing cross-compilation
       # and skip attempting to run the generated executable with './a.out',
       # which would fail since we are building a .js file.
-      configure_args = ['--disable-shared', '--host=i686-pc-linux-gnu',
-                        '--disable-demos', '--disable-dependency-tracking']
+      configure_args = ['--disable-shared', '--build=i686-pc-linux-gnu',
+                        '--host=i686-pc-linux-gnu', '--disable-demos',
+                        '--disable-dependency-tracking']
       generated_libs = ['src/.libs/libBulletDynamics.a',
                         'src/.libs/libBulletCollision.a',
                         'src/.libs/libLinearMath.a']


### PR DESCRIPTION
Failed with http://clbri.com:8010/api/v2/logs/20943/raw_inline

```
Invalid configuration `aarch64-apple-darwin24.5.0': machine `aarch64-apple' not recognized
configure: error: /bin/sh ./config.sub aarch64-apple-darwin24.5.0 failed
emconfigure: error: 'sh ./configure --disable-shared --host=i686-pc-linux-gnu --disable-demos --disable-dependency-tracking' failed (returned 1)
```