### PR TITLE
Fix core3.test_asyncify_lists* when Emscripten SDK was built from source.

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8305,7 +8305,6 @@ Module.onRuntimeInitialized = () => {
     'onlylist_b_response': ([], True,  'main\n__original_main\nfoo(int, double)\nbaz()\nc_baz\nStructy::funcy()\n'),
     'onlylist_c_response': ([], False, 'main\n__original_main\nfoo(int, double)\nbaz()\nc_baz\n'),
   })
-  @no_windows("TODO: Fails on Windows due to an unknown reason.")
   def test_asyncify_lists(self, args, should_pass, response=None):
     if response is not None:
       create_file('response.file', response)
@@ -8329,8 +8328,10 @@ Module.onRuntimeInitialized = () => {
       # in a fully-optimized build, imports and exports are minified too and we
       # can verify that our function names appear nowhere
       if '-O3' in self.cflags:
-        binary = read_binary(filename)
-        self.assertFalse(b'main' in binary)
+        self.assertFalse(b'__wasm_call_ctors' in read_binary(filename))
+      elif '-O0' in self.cflags:
+        # However, sanity check that in core0 test, we do see this symbol.
+        self.assertTrue(b'__wasm_call_ctors' in read_binary(filename))
 
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY')
   @parameterized({


### PR DESCRIPTION
The `self.assertFalse(b'main' in binary)` check would fail because the binary does, and should, contain the name `main`, in an assert() check. In disassembly:

```
 (data $0 (i32.const 1024) "c_baz\00-+   0X0x\00c:\\emsdk\\emscripten\\main\\test\\core\\test_asyncify_lists.cpp\00foo\00a == b\00(null)\00bar: %d\n\00foo: %d\n\00c++: %d\n")
```

i.e. the occurrence of `main` is in a path name.

Change the code to check another symbol, and verify that the symbol name is caught in some other mode so it won't become tautologically true in a future refactor.