### PR TITLE
Fix lto0 and thinlto0 tests, e.g. lto0.test_emscripten_get_compiler_setting

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2410,9 +2410,10 @@ def get_libs_to_link(options):
   if settings.ALLOW_UNIMPLEMENTED_SYSCALLS:
     add_library('libstubs')
   if not options.nolibc:
+    add_library('libc')
+    # N.b. libnoexit must be added after libc, or lto0.test_emscripten_get_compiler_setting fails.
     if not settings.EXIT_RUNTIME:
       add_library('libnoexit')
-    add_library('libc')
     if settings.MALLOC == 'mimalloc':
       add_library('libmimalloc')
       if settings.USE_ASAN:


### PR DESCRIPTION
The following tests are failing for me:

```
lto0.test_emscripten_get_compiler_setting
lto0.test_pthread_run_script
lto0.test_return_address

thinlto0.test_emscripten_get_compiler_setting
thinlto0.test_pthread_run_script
thinlto0.test_return_address
```

with errors

```
cache:INFO: generating system library: libdlmalloc-mt-debug.a... (this will be cached in "libdlmalloc-mt-debug.a" for subsequent builds)
wasm-ld: error: libc-debug.a(stderr.o): attempt to add bitcode file after LTO (stderr)
wasm-ld: error: libc-debug.a(fprintf.o): attempt to add bitcode file after LTO (fprintf)
emcc: error: 'wasm-ld -o test_pthread_run_script.wasm /tmp/emtest_rvts3x5e/emscripten_temp_5ol043gv/test_pthread_run_script_0.o -L/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/cache/sysroot/lib/wasm32-emscripten/lto -L/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/src/lib -lGL-getprocaddr -lal -lhtml5 -lstubs-debug -lnoexit -lc-debug -ldlmalloc-debug -lcompiler_rt -lsockets -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr /tmp/emtest_rvts3x5e/tmpd9n9q0wdlibemscripten_js_symbols.so --strip-debug -u__cxa_atexit --export=emscripten_stack_get_end --export=emscripten_stack_get_free --export=emscripten_stack_get_base --export=emscripten_stack_get_current --export=emscripten_stack_init --export=_emscripten_stack_alloc --export=__wasm_call_ctors --export=_emscripten_stack_restore --export-if-defined=__start_em_asm --export-if-defined=__stop_em_asm --export-if-defined=__start_em_lib_deps --export-if-defined=__stop_em_lib_deps --export-if-defined=__start_em_js --export-if-defined=__stop_em_js --export-if-defined=main --export-if-defined=__main_argc_argv --export-if-defined=fflush --export-table -z stack-size=65536 --no-growable-memory --initial-heap=16777216 --no-entry --stack-first --table-base=1' failed (returned 1)
test_pthread_run_script (test_core.lto0.test_pthread_run_script) ... FAIL
```

at e.g. http://clbri.com:8010/api/v2/logs/21019/raw_inline

I find that `libnoexit.a` is correctly built with `-flto=full`, but still, the linker command

```
wasm-ld -o test_pthread_run_script.wasm /tmp/emtest_rvts3x5e/emscripten_temp_5ol043gv/test_pthread_run_script_0.o -L/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/cache/sysroot/lib/wasm32-emscripten/lto -L/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/src/lib -lGL-getprocaddr -lal -lhtml5 -lstubs-debug -lnoexit -lc-debug -ldlmalloc-debug -lcompiler_rt -lsockets -mllvm ...
```
croaks, whereas flipping the order of `-lnoexit` and `-lc-debug` fixes the issue.

I don't understand what that is about, everything looks like is getting `-flto=full` accordingly as far as I can see.