### PR TITLE
Skip simd2.test_autodebug_wasm

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6976,6 +6976,10 @@ void* operator new(size_t size) {
   @no_asan('autodebug logging interferes with asan')
   @with_env_modify({'EMCC_AUTODEBUG': '1'})
   def test_autodebug_wasm(self):
+    # failed to asynchronously prepare wasm: LinkError: WebAssembly.instantiate(): Import #13 module="env" function="get_v128": function import requires a callable
+    if '-msimd128' in self.cflags:
+      self.skipTest('Does not work with SIMD. https://github.com/emscripten-core/emscripten/issues/25001')
+
     # Even though the test itself doesn't directly use reference types,
     # Binaryen's '--instrument-locals' will add their logging functions if
     # reference-types is enabled. So make sure this test passes when


### PR DESCRIPTION
CC @kripken is SIMD+EMCC_AUTODEBUG combination expected/intended to work? Or is this skip good?