### PR TITLE
[testing] Improve running browser tests locally.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,7 +325,7 @@ commands:
             # bypass the user gesture so audio tests work without interaction)
             CHROME_FLAGS_AUDIO: " --use-fake-device-for-media-stream --autoplay-policy=no-user-gesture-required"
           command: |
-            export EMTEST_BROWSER="/usr/bin/google-chrome $CHROME_FLAGS_BASE $CHROME_FLAGS_HEADLESS $CHROME_FLAGS_WASM $CHROME_FLAGS_NOCACHE $CHROME_FLAGS_AUDIO"
+            export EMTEST_BROWSER="/usr/bin/google-chrome"
             # There are tests in the browser test suite that using libraries
             # that are not included by "./embuilder build ALL".  For example the
             # PIC version of libSDL which is used by test_sdl2_misc_main_module
@@ -400,7 +400,7 @@ commands:
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
             DISPLAY: ":0"
           command: |
-            export EMTEST_BROWSER="$HOME/firefox/firefox -headless -profile $HOME/tmp-firefox-profile/"
+            export EMTEST_BROWSER="$HOME/firefox/firefox"
             # There are tests in the browser test suite that using libraries
             # that are not included by "./embuilder build ALL".  For example the
             # PIC version of libSDL which is used by test_sdl2_misc_main_module
@@ -423,14 +423,8 @@ commands:
           environment:
             EMTEST_LACKS_SOUND_HARDWARE: "1"
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
-            # --no-sandbox becasue we are running as root and chrome requires
-            # this flag for now: https://crbug.com/638180
-            CHROME_FLAGS_BASE: "--no-first-run -start-maximized --no-sandbox --use-gl=swiftshader --user-data-dir=/tmp/chrome-emscripten-profile"
-            CHROME_FLAGS_HEADLESS: "--headless=new --remote-debugging-port=1234"
-            CHROME_FLAGS_WASM: "--enable-experimental-webassembly-features"
-            CHROME_FLAGS_NOCACHE: "--disk-cache-dir=/dev/null --disk-cache-size=1 --media-cache-size=1 --disable-application-cache --incognito"
           command: |
-            export EMTEST_BROWSER="/usr/bin/google-chrome $CHROME_FLAGS_BASE $CHROME_FLAGS_HEADLESS $CHROME_FLAGS_WASM $CHROME_FLAGS_NOCACHE"
+            export EMTEST_BROWSER="/usr/bin/google-chrome"
             test/runner sockets
       - upload-test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,9 +378,9 @@ commands:
             EMTEST_LACKS_OFFSCREEN_CANVAS: "1"
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
             EMTEST_HEADLESS: "1"
-            EMTEST_BROWSER: "$HOME/firefox/firefox"
             DISPLAY: ":0"
           command: |
+            export EMTEST_BROWSER="$HOME/firefox/firefox"
             # There are tests in the browser test suite that using libraries
             # that are not included by "./embuilder build ALL".  For example the
             # PIC version of libSDL which is used by test_sdl2_misc_main_module

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,8 +315,8 @@ commands:
           environment:
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
             EMTEST_HEADLESS: "1"
+            EMTEST_BROWSER: "/usr/bin/google-chrome"
           command: |
-            export EMTEST_BROWSER="/usr/bin/google-chrome"
             # There are tests in the browser test suite that using libraries
             # that are not included by "./embuilder build ALL".  For example the
             # PIC version of libSDL which is used by test_sdl2_misc_main_module
@@ -378,9 +378,9 @@ commands:
             EMTEST_LACKS_OFFSCREEN_CANVAS: "1"
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
             EMTEST_HEADLESS: "1"
+            EMTEST_BROWSER: "$HOME/firefox/firefox"
             DISPLAY: ":0"
           command: |
-            export EMTEST_BROWSER="$HOME/firefox/firefox"
             # There are tests in the browser test suite that using libraries
             # that are not included by "./embuilder build ALL".  For example the
             # PIC version of libSDL which is used by test_sdl2_misc_main_module
@@ -404,8 +404,8 @@ commands:
             EMTEST_LACKS_SOUND_HARDWARE: "1"
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
             EMTEST_HEADLESS: "1"
+            EMTEST_BROWSER: "/usr/bin/google-chrome"
           command: |
-            export EMTEST_BROWSER="/usr/bin/google-chrome"
             test/runner sockets
       - upload-test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,16 +314,7 @@ commands:
           name: run tests (<< parameters.title >>)
           environment:
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
-            # --no-sandbox because we are running as root and chrome requires
-            # this flag for now: https://crbug.com/638180
-            CHROME_FLAGS_BASE: "--no-first-run -start-maximized --no-sandbox --enable-unsafe-swiftshader --use-gl=swiftshader  --user-data-dir=/tmp/chrome-emscripten-profile --enable-experimental-web-platform-features --enable-features=JavaScriptSourcePhaseImports"
-            # Increase the window size to avoid flaky sdl tests see #24236.
-            CHROME_FLAGS_HEADLESS: "--headless=new --window-size=1024,768 --remote-debugging-port=1234"
-            CHROME_FLAGS_WASM: "--enable-experimental-webassembly-features --js-flags=\"--experimental-wasm-stack-switching --experimental-wasm-type-reflection --experimental-wasm-rab-integration\""
-            CHROME_FLAGS_NOCACHE: "--disk-cache-dir=/dev/null --disk-cache-size=1 --media-cache-size=1 --disable-application-cache --incognito"
-            # The runners lack sound hardware so fallback to a dummy device (and
-            # bypass the user gesture so audio tests work without interaction)
-            CHROME_FLAGS_AUDIO: " --use-fake-device-for-media-stream --autoplay-policy=no-user-gesture-required"
+            EMTEST_HEADLESS: "1"
           command: |
             export EMTEST_BROWSER="/usr/bin/google-chrome"
             # There are tests in the browser test suite that using libraries
@@ -374,18 +365,6 @@ commands:
             apt-get install -q -y pulseaudio
             pulseaudio --start
       - run:
-          name: configure firefox
-          command: |
-            # Note: the autoplay pref allows playback without user interaction
-            mkdir ~/tmp-firefox-profile/
-            cat > ~/tmp-firefox-profile/user.js \<<EOF
-            user_pref("gfx.offscreencanvas.enabled", true);
-            user_pref("javascript.options.shared_memory", true);
-            user_pref("javascript.options.wasm_memory64", true);
-            user_pref("dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled", true);
-            user_pref("media.autoplay.default", 0);
-            EOF
-      - run:
           name: run tests (<< parameters.title >>)
           environment:
             GALLIUM_DRIVER: softpipe # TODO: use the default llvmpipe when it supports more extensions
@@ -398,6 +377,7 @@ commands:
             # OffscreenCanvas support is not yet done in Firefox.
             EMTEST_LACKS_OFFSCREEN_CANVAS: "1"
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
+            EMTEST_HEADLESS: "1"
             DISPLAY: ":0"
           command: |
             export EMTEST_BROWSER="$HOME/firefox/firefox"
@@ -423,6 +403,7 @@ commands:
           environment:
             EMTEST_LACKS_SOUND_HARDWARE: "1"
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
+            EMTEST_HEADLESS: "1"
           command: |
             export EMTEST_BROWSER="/usr/bin/google-chrome"
             test/runner sockets

--- a/test/common.py
+++ b/test/common.py
@@ -114,14 +114,14 @@ class FirefoxConfig:
     shutil.copy(test_file('firefox_user.js'), os.path.join(data_dir, 'user.js'))
 
 
-DEFAULT_BROWSER_DATA_DIR = path_from_root('out/browser-profile')
-
 # Special value for passing to assert_returncode which means we expect that program
 # to fail with non-zero return code, but we don't care about specifically which one.
 NON_ZERO = -1
 
 TEST_ROOT = path_from_root('test')
 LAST_TEST = path_from_root('out/last_test.txt')
+
+DEFAULT_BROWSER_DATA_DIR = path_from_root('out/browser-profile')
 
 WEBIDL_BINDER = shared.bat_suffix(path_from_root('tools/webidl_binder'))
 
@@ -2402,7 +2402,7 @@ class BrowserCore(RunnerCore):
       logger.info('No EMTEST_BROWSER set. Defaulting to `google-chrome`')
       EMTEST_BROWSER = 'google-chrome'
 
-    if EMTEST_BROWSER_AUTO_CONFIG and (is_chrome() or is_firefox()):
+    if EMTEST_BROWSER_AUTO_CONFIG:
       logger.info('Using default CI configuration.')
       cls.browser_data_dir = DEFAULT_BROWSER_DATA_DIR
       if os.path.exists(cls.browser_data_dir):
@@ -2412,6 +2412,8 @@ class BrowserCore(RunnerCore):
         config = ChromeConfig()
       elif is_firefox():
         config = FirefoxConfig()
+      else:
+        exit_with_error("EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome.")
       EMTEST_BROWSER += f" {config.data_dir_flag}{cls.browser_data_dir} {' '.join(config.default_flags)}"
       if EMTEST_HEADLESS == 1:
         EMTEST_BROWSER += f" {config.headless_flags}"

--- a/test/common.py
+++ b/test/common.py
@@ -47,8 +47,8 @@ logger = logging.getLogger('common')
 # test suite to run using another browser command line than the default system
 # browser. If only the path to the browser executable is given, the tests
 # will run in headless mode with a temporary profile with the same options
-# used in CircleCI. To use a custom start command specify the executable and
-# command line flags.
+# used in CI. To use a custom start command specify the executable and command
+# line flags.
 #
 # There are two special values that can be used here if running in an actual
 # browser is not desired:
@@ -84,7 +84,7 @@ if 'EM_BUILD_VERBOSE' in os.environ:
 # Default flags used to run browsers in CI testing:
 BROWSER_CONFIG = {
   'chrome': {
-    'data_dir_flag': '--user-data-dir',
+    'data_dir_flag': '--user-data-dir=',
     'default': (
       # --no-sandbox because we are running as root and chrome requires
       # this flag for now: https://crbug.com/638180
@@ -101,7 +101,7 @@ BROWSER_CONFIG = {
       '--headless=new --window-size=1024,768 --remote-debugging-port=1234',
   },
   'firefox': {
-    'data_dir_flag': '-profile',
+    'data_dir_flag': '-profile ',
     'default': {},
     'headless': '-headless',
   },
@@ -2403,7 +2403,7 @@ class BrowserCore(RunnerCore):
       else:
         logger.warning("Unknown browser type, not using default flags.")
         config = BROWSER_CONFIG['other']
-      EMTEST_BROWSER += f" {config['data_dir_flag']}={cls.browser_data_dir} {' '.join(config['default'])}"
+      EMTEST_BROWSER += f" {config['data_dir_flag']}{cls.browser_data_dir} {' '.join(config['default'])}"
       if EMTEST_HEADLESS == '1':
         EMTEST_BROWSER += f" {config['headless']}"
 

--- a/test/common.py
+++ b/test/common.py
@@ -2416,7 +2416,7 @@ class BrowserCore(RunnerCore):
       EMTEST_BROWSER = 'google-chrome'
 
     if EMTEST_BROWSER_AUTO_CONFIG:
-      logger.info('Using default to CI configuration.')
+      logger.info('Using default CI configuration.')
       cls.browser_data_dir = DEFAULT_BROWSER_DATA_DIR
       if os.path.exists(cls.browser_data_dir):
         utils.delete_dir(cls.browser_data_dir)

--- a/test/common.py
+++ b/test/common.py
@@ -2384,8 +2384,6 @@ class BrowserCore(RunnerCore):
       logger.info('Browser did not respond to `terminate`.  Using `kill`')
       cls.browser_proc.kill()
       cls.browser_proc.wait()
-    if cls.browser_data_dir:
-      utils.delete_dir(cls.browser_data_dir)
       cls.browser_data_dir = None
 
   @classmethod

--- a/test/common.py
+++ b/test/common.py
@@ -2429,7 +2429,7 @@ class BrowserCore(RunnerCore):
         logger.warning("Unknown browser type, not using default flags.")
         config = BrowserConfig()
       EMTEST_BROWSER += f" {config.data_dir_flag}{cls.browser_data_dir} {' '.join(config.default_flags)}"
-      if EMTEST_HEADLESS == '1':
+      if EMTEST_HEADLESS == 1:
         EMTEST_BROWSER += f" {config.headless_flags}"
       config.configure(cls.browser_data_dir)
 

--- a/test/common.py
+++ b/test/common.py
@@ -96,22 +96,19 @@ BROWSER_CONFIG = {
       # Cache options.
       '--disk-cache-size=1 --media-cache-size=1 --disable-application-cache',
     ),
-    'headless': (
+    'headless':
       # Increase the window size to avoid flaky sdl tests see #24236.
       '--headless=new --window-size=1024,768 --remote-debugging-port=1234',
-    ),
   },
   'firefox': {
     'data_dir_flag': '-profile',
     'default': {},
-    'headless': (
-      '-headless'
-    ),
+    'headless': '-headless',
   },
   'other': {
     'data_dir_flag': '',
     'default': {},
-    'headless': {},
+    'headless': '',
   },
 }
 DEFAULT_BROWSER_DATA_DIR = '/tmp/emscripten-profile'
@@ -2408,7 +2405,7 @@ class BrowserCore(RunnerCore):
         config = BROWSER_CONFIG['other']
       EMTEST_BROWSER += f" {config['data_dir_flag']}={cls.browser_data_dir} {' '.join(config['default'])}"
       if EMTEST_HEADLESS == '1':
-        EMTEST_BROWSER += f" {' '.join(config['headless'])}"
+        EMTEST_BROWSER += f" {config['headless']}"
 
     if WINDOWS:
       # On Windows env. vars canonically use backslashes as directory delimiters, e.g.

--- a/test/firefox_user.js
+++ b/test/firefox_user.js
@@ -1,0 +1,5 @@
+user_pref("gfx.offscreencanvas.enabled", true);
+user_pref("javascript.options.shared_memory", true);
+user_pref("javascript.options.wasm_memory64", true);
+user_pref("dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled", true);
+user_pref("media.autoplay.default", 0);

--- a/test/runner.py
+++ b/test/runner.py
@@ -392,8 +392,8 @@ def parse_args():
                       help='Automatically update test expectations for tests that support it.')
   parser.add_argument('--browser',
                       help='Command to launch web browser in which to run browser tests.')
-  parser.add_argument('--headless', default='1',
-                      help='Run browser in headless (default) or non-headless (--headless=0) mode.')
+  parser.add_argument('--headless', action='store_true',
+                      help='Run browser tests in headless mode.')
   parser.add_argument('--browser-auto-config', type=bool, default=True,
                       help='Use the default CI browser configuration.')
   parser.add_argument('tests', nargs='*')

--- a/test/runner.py
+++ b/test/runner.py
@@ -392,8 +392,10 @@ def parse_args():
                       help='Automatically update test expectations for tests that support it.')
   parser.add_argument('--browser',
                       help='Command to launch web browser in which to run browser tests.')
-  parser.add_argument('--headed', action='store_true',
-                      help='Run browser tests in regular (non-headless) mode.')
+  parser.add_argument('--headless', default='1',
+                      help='Run browser in headless (default) or non-headless (--headless=0) mode.')
+  parser.add_argument('--browser-auto-config', type=bool, default=True,
+                      help='Use the default CI browser configuration.')
   parser.add_argument('tests', nargs='*')
   parser.add_argument('--failfast', action='store_true')
   parser.add_argument('--start-at', metavar='NAME', help='Skip all tests up until <NAME>')
@@ -409,6 +411,7 @@ def parse_args():
 
 def configure():
   common.EMTEST_BROWSER = os.getenv('EMTEST_BROWSER')
+  common.EMTEST_BROWSER_AUTO_CONFIG = os.getenv('EMTEST_BROWSER_AUTO_CONFIG')
   common.EMTEST_HEADLESS = os.getenv('EMTEST_HEADLESS')
   common.EMTEST_DETECT_TEMPFILE_LEAKS = int(os.getenv('EMTEST_DETECT_TEMPFILE_LEAKS', '0'))
   common.EMTEST_ALL_ENGINES = int(os.getenv('EMTEST_ALL_ENGINES', '0'))
@@ -454,7 +457,8 @@ def main():
     os.environ[name] = value
 
   set_env('EMTEST_BROWSER', options.browser)
-  set_env('EMTEST_HEADLESS', not options.headed)
+  set_env('EMTEST_BROWSER_AUTO_CONFIG', options.browser_auto_config)
+  set_env('EMTEST_HEADLESS', options.headless)
   set_env('EMTEST_DETECT_TEMPFILE_LEAKS', options.detect_leaks)
   if options.save_dir:
     common.EMTEST_SAVE_DIR = 1

--- a/test/runner.py
+++ b/test/runner.py
@@ -392,6 +392,8 @@ def parse_args():
                       help='Automatically update test expectations for tests that support it.')
   parser.add_argument('--browser',
                       help='Command to launch web browser in which to run browser tests.')
+  parser.add_argument('--headed', action='store_true',
+                      help='Run browser tests in regular (non-headless) mode.')
   parser.add_argument('tests', nargs='*')
   parser.add_argument('--failfast', action='store_true')
   parser.add_argument('--start-at', metavar='NAME', help='Skip all tests up until <NAME>')
@@ -407,6 +409,7 @@ def parse_args():
 
 def configure():
   common.EMTEST_BROWSER = os.getenv('EMTEST_BROWSER')
+  common.EMTEST_HEADLESS = os.getenv('EMTEST_HEADLESS')
   common.EMTEST_DETECT_TEMPFILE_LEAKS = int(os.getenv('EMTEST_DETECT_TEMPFILE_LEAKS', '0'))
   common.EMTEST_ALL_ENGINES = int(os.getenv('EMTEST_ALL_ENGINES', '0'))
   common.EMTEST_SKIP_SLOW = int(os.getenv('EMTEST_SKIP_SLOW', '0'))
@@ -451,6 +454,7 @@ def main():
     os.environ[name] = value
 
   set_env('EMTEST_BROWSER', options.browser)
+  set_env('EMTEST_HEADLESS', not options.headed)
   set_env('EMTEST_DETECT_TEMPFILE_LEAKS', options.detect_leaks)
   if options.save_dir:
     common.EMTEST_SAVE_DIR = 1

--- a/test/runner.py
+++ b/test/runner.py
@@ -393,7 +393,7 @@ def parse_args():
   parser.add_argument('--browser',
                       help='Command to launch web browser in which to run browser tests.')
   parser.add_argument('--headless', action='store_true',
-                      help='Run browser tests in headless mode.')
+                      help='Run browser tests in headless mode.', default=None)
   parser.add_argument('--browser-auto-config', type=bool, default=True,
                       help='Use the default CI browser configuration.')
   parser.add_argument('tests', nargs='*')
@@ -412,7 +412,7 @@ def parse_args():
 def configure():
   common.EMTEST_BROWSER = os.getenv('EMTEST_BROWSER')
   common.EMTEST_BROWSER_AUTO_CONFIG = os.getenv('EMTEST_BROWSER_AUTO_CONFIG')
-  common.EMTEST_HEADLESS = os.getenv('EMTEST_HEADLESS')
+  common.EMTEST_HEADLESS = int(os.getenv('EMTEST_HEADLESS', '0'))
   common.EMTEST_DETECT_TEMPFILE_LEAKS = int(os.getenv('EMTEST_DETECT_TEMPFILE_LEAKS', '0'))
   common.EMTEST_ALL_ENGINES = int(os.getenv('EMTEST_ALL_ENGINES', '0'))
   common.EMTEST_SKIP_SLOW = int(os.getenv('EMTEST_SKIP_SLOW', '0'))


### PR DESCRIPTION
This changes how the browser test runner works by default. It will now automatically detect the browser type and:
 - Use the same options used in CircleCI (for chrome and firefox)
 - Create and delete a temporary profile directory
 - Terminate the browser
 
Adds two new options:
 -  `EMTEST_BROWSER_AUTO_CONFIG` or `--browser-auto-config`: disables the automatic configuration,
 - `EMTEST_HEADLESS` or `--headless`: run the test in headless mode

Last, two flags were removed from chrome:
- `--disk-cache-dir` this was causing errors (on CI and locally)
- `--incognito` not allowed in corporate environments and not needed since the profile directory is automatically deleted.

These changes make it much easier to reproduce the circle ci environment locally and make running a test multiple times more reliable.