### PR TITLE
Add debugging prints to test_stat_chmod

### DIFF
--- a/test/stat/test_chmod.c
+++ b/test/stat/test_chmod.c
@@ -66,6 +66,7 @@ void test() {
   stat("file", &s);
   assert(s.st_mode == (S_IWUSR | S_IFREG));
   assert(s.st_ctime != lastctime);
+  printf("(1) s.st_mtime=%lld, lastmtime=%lld\n", (long long)s.st_mtime, (long long)lastmtime);
   assert(s.st_mtime == lastmtime);
 
   //
@@ -82,6 +83,7 @@ void test() {
   stat("file", &s);
   assert(s.st_mode == (S_IXUSR | S_IFREG));
   assert(s.st_ctime != lastctime);
+  printf("(2) s.st_mtime=%lld, lastmtime=%lld\n", (long long)s.st_mtime, (long long)lastmtime);
   assert(s.st_mtime == lastmtime);
 
   //
@@ -106,6 +108,7 @@ void test() {
   stat("otherfile", &s);
   assert(s.st_mode == (S_IXUSR | S_IFREG));
   assert(s.st_ctime != lastctime);
+  printf("(3) s.st_mtime=%lld, lastmtime=%lld\n", (long long)s.st_mtime, (long long)lastmtime);
   assert(s.st_mtime == lastmtime);
 
   //
@@ -125,6 +128,7 @@ void test() {
   stat("folder", &s);
   assert(s.st_mode == (S_IWUSR | S_IXUSR | S_IFDIR));
   assert(s.st_ctime != lastctime);
+  printf("(4) s.st_mtime=%lld, lastmtime=%lld\n", (long long)s.st_mtime, (long long)lastmtime);
   assert(s.st_mtime == lastmtime);
 
 #ifndef WASMFS // TODO https://github.com/emscripten-core/emscripten/issues/15948

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5694,7 +5694,8 @@ got: 10
       self.skipTest('mode bits work differently on windows')
     if nodefs and self.get_setting('WASMFS'):
       self.skipTest('test requires symlink creation which currently missing from wasmfs+noderawfs')
-    self.do_runf('stat/test_chmod.c', 'success', cflags=['-Werror=conversion'])
+    output = self.do_runf('stat/test_chmod.c', 'success', cflags=['-Werror=conversion'])
+    print(str(output))
 
   @also_with_wasmfs
   def test_stat_mknod(self):


### PR DESCRIPTION
I locally ran `test/runner --repeat 100 --failfast *.test_stat_chmod*` on my Linux workstation, and could not coax out a single failure.

Nevertheless, on that very same workstation, the test maybe about 10%-20% of the time when run as part of the CI.

So add debug prints to help suggest if the issue is about close-but-not-quite timestamps, or something else.

Related to #24905.
