### PR TITLE
Fix specifying the dependency from SYSCALL_DEBUG to $strError() function.

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -2559,6 +2559,8 @@ function wrapSyscallFunction(x, library, isWasi) {
   post += "}\n";
   post += "dbg(`syscall return: ${ret}`);\n";
   post += "return ret;\n";
+  // Emit dependency to strError() since we added use of it above.
+  library[x + '__deps'].push('$strError');
 #endif
   delete library[x + '__nothrow'];
   var handler = '';

--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -10,9 +10,6 @@ var SyscallsLibrary = {
                    '$PATH',
                    '$FS',
 #endif
-#if SYSCALL_DEBUG
-                   '$strError',
-#endif
   ],
   $SYSCALLS: {
 #if SYSCALLS_REQUIRE_FILESYSTEM


### PR DESCRIPTION
Fix specifying the dependency from SYSCALL_DEBUG to $strError() function to take place directly where the use of strError() is emitted, and not indirectly via the JS SYSCALLS object. Fixes WASMFS + SYSCALLS_DEBUG build mode, e.g. in test wasmfs.test_fs_nodefs_rw.