### PR TITLE
Fix wasmfs.test_fs_nodefs_readdir on Windows.

### DIFF
--- a/test/fs/test_nodefs_readdir.wasmfs_win.out
+++ b/test/fs/test_nodefs_readdir.wasmfs_win.out
@@ -1,0 +1,13 @@
+listing contents of dir=/
+.
+..
+dev
+tmp
+listing contents of dir=/working
+.
+..
+existing
+stdout
+test_nodefs_readdir.js
+test_nodefs_readdir.wasm
+success

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5868,7 +5868,7 @@ got: 10
     self.cflags += ['-lnodefs.js']
     suffix = ''
     if self.get_setting('WASMFS'):
-      suffix = '.wasmfs'
+      suffix = '.wasmfs_win' if WINDOWS else '.wasmfs'
     elif self.is_wasm2js():
       suffix = ".wasm2js"
     self.do_run_in_out_file_test('fs/test_nodefs_readdir.c', out_suffix=suffix)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5867,6 +5867,7 @@ got: 10
     os.makedirs('existing/a')
     self.cflags += ['-lnodefs.js']
     suffix = ''
+    # Windows does not add a name_pipe to test expectations.
     if self.get_setting('WASMFS'):
       suffix = '.wasmfs_win' if WINDOWS else '.wasmfs'
     elif self.is_wasm2js():


### PR DESCRIPTION
Windows does not support fifos, so the test expectation needs to look different.