### PR TITLE
Weak link confstr

### DIFF
--- a/system/lib/libc/musl/src/conf/confstr.c
+++ b/system/lib/libc/musl/src/conf/confstr.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <errno.h>
 
+__attribute__((weak))
 size_t confstr(int name, char *buf, size_t len)
 {
 	const char *s = "";


### PR DESCRIPTION
I think it would be useful if this did not say that it Emscripten is "glibc 2.14". If it's weak linked, I can easily replace the function and make it say something else.