### PR TITLE
[contrib.glfw3] New version (flickering bug fix)

### DIFF
--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -3,10 +3,10 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-TAG = '3.4.0.20250607'
+TAG = '3.4.0.20250824'
 
 EXTERNAL_PORT = f'https://github.com/pongasoft/emscripten-glfw/releases/download/v{TAG}/emscripten-glfw3-{TAG}.zip'
-SHA512 = '1b264ac8891ffff51b899ca5853d4f945294dde9a9191eb5df9dd4cb26a4b27c5e7dac99cad42466833e9aae76d450de8a4b84381a63214321dc0427fd054f1b'
+SHA512 = 'b5b3670b80c87571ea56a54e701874d6b2323f74e359782a15c9ae0a931341fb05e4c778945950f8846aef66c7cc48556d30c8cc5939c87e3091c8be63856a1a'
 PORT_FILE = 'port/glfw3.py'
 
 # contrib port information (required)


### PR DESCRIPTION
Release notes:

- The code has been optimized for size
- Fixed [#21](https://github.com/pongasoft/emscripten-glfw/issues/21): Flicker when resizing
  - to fix this issue, resizing (when the handle is moved or the window resized) is now delayed until `glfwPollEvents()`
    is called. Make sure to call `glfwPollEvents()` at the beginning of the loop to ensure a flicker-free experience.
    See [Events & Main loop](https://github.com/pongasoft/emscripten-glfw/blob/master/docs/Usage.md#events--main-loop) for more details.

Fix has been deployed to the [demo](https://pongasoft.github.io/emscripten-glfw/test/demo/main.html) and [WebGPU Shader Toy](https://pongasoft.github.io/webgpu-shader-toy) to see it in action/test.