### PR TITLE
Support names field in source maps

### DIFF
--- a/emsymbolizer.py
+++ b/emsymbolizer.py
@@ -110,6 +110,7 @@ class WasmSourceMap:
   def __init__(self):
     self.version = None
     self.sources = []
+    self.funcs = []
     self.mappings = {}
     self.offsets = []
 
@@ -121,6 +122,7 @@ class WasmSourceMap:
 
     self.version = source_map_json['version']
     self.sources = source_map_json['sources']
+    self.funcs = source_map_json['names']
 
     chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/='
     vlq_map = {c: i for i, c in enumerate(chars)}
@@ -148,6 +150,7 @@ class WasmSourceMap:
     src = 0
     line = 1
     col = 1
+    func = 0
     for segment in source_map_json['mappings'].split(','):
       data = decodeVLQ(segment)
       info = []
@@ -162,7 +165,9 @@ class WasmSourceMap:
       if len(data) >= 4:
         col += data[3]
         info.append(col)
-      # TODO: see if we need the name, which is the next field (data[4])
+      if len(data) == 5:
+        func += data[4]
+        info.append(func)
 
       self.mappings[offset] = WasmSourceMap.Location(*info)
       self.offsets.append(offset)
@@ -189,6 +194,7 @@ class WasmSourceMap:
         self.sources[info.source] if info.source is not None else None,
         info.line,
         info.column,
+        self.funcs[info.func] if info.func is not None else None,
       )
 
 

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -194,10 +194,15 @@ var EXPECT_MAIN = true;
 // If true, building against Emscripten's wasm heap memory profiler.
 var MEMORYPROFILER = false;
 
-// Set automatically to :
-// - 1 when using `-gsource-map`
-// - 2 when using `gsource-map=inline` (embed sources content in souce map)
+// Source map related options. You can specify both like
+// -gsource-map=inline,names
+//
+// -gsource-map
 var GENERATE_SOURCE_MAP = 0;
+// -gsource-map=inline
+var EMBED_SOURCE_MAP_SOURCE = 0;
+// -gsource-map=names
+var GENERATE_SOURCE_MAP_NAMES = 0;
 
 var GENERATE_DWARF = false;
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -1145,9 +1145,10 @@ def emit_wasm_source_map(wasm_file, map_file, final_wasm):
 
   if settings.SOURCE_MAP_PREFIXES:
     sourcemap_cmd += ['--prefix', *settings.SOURCE_MAP_PREFIXES]
-
-  if settings.GENERATE_SOURCE_MAP == 2:
+  if settings.EMBED_SOURCE_MAP_SOURCE:
     sourcemap_cmd += ['--sources']
+  if settings.GENERATE_SOURCE_MAP_NAMES:
+    sourcemap_cmd += ['--names']
 
   check_call(sourcemap_cmd)
 

--- a/tools/cmdline.py
+++ b/tools/cmdline.py
@@ -394,10 +394,16 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
           else:
             settings.SEPARATE_DWARF = True
           settings.GENERATE_DWARF = 1
-        elif requested_level in ['source-map', 'source-map=inline']:
-          settings.GENERATE_SOURCE_MAP = 1 if requested_level == 'source-map' else 2
+        elif requested_level.startswith('source-map'):
+          settings.GENERATE_SOURCE_MAP = 1
           settings.EMIT_NAME_SECTION = 1
           newargs[i] = '-g'
+          if '=' in requested_level:
+            source_map_options = requested_level.split('=')[1].split(',')
+            if 'inline' in source_map_options:
+              settings.EMBED_SOURCE_MAP_SOURCE = 1
+            if 'names' in source_map_options:
+              settings.GENERATE_SOURCE_MAP_NAMES = 1
         elif requested_level == 'z':
           # Ignore `-gz`.  We don't support debug info compression.
           continue


### PR DESCRIPTION
This adds support for `names` field in source maps, which contains function names. Source map mappings are correspondingly updated and emsymbolizer now can provide function name information only with source maps.

To do this, you can use `emcc -gsource-map=names`. This also adds separate internal settings for this namd generation and the existing source embedding, making them more readable. Also because they are internal settings, they don't add the number of external options. When you run `wasm-sourcemap.py` standalone you can use `--names`.

While we have the name sections and DWARF, I think it is generally good to support, given that the field exists for that purpose and JS source maps support it. It looks Dart toolchain also supports it: https://github.com/dart-lang/sdk/blob/187c3cb004b5f6a0a1f1b242b7d1b8a6b33b9a7a/pkg/wasm_builder/lib/source_map.dart#L105-L118

To measure source map size increase, I ran this on `wasm-opt.wasm` built by the `if (EMSCRIPTEN)` setup here
(https://github.com/WebAssembly/binaryen/blob/969bf763a495b475e2a28163e7d70a5dd01f9dda/CMakeLists.txt#L299-L365) with `-gsource-map` vs. `-gsource-map=names`. The source map file size increased from 352743 to 443373, about 25%.

While I think 25% increase of the source map file size is tolerable, this option is off by default, because with this we can't use #9580. So far we only needed `DW_TAG_compile_unit`s in `llvm-dwarfdump` results, and for that we could get away with printing only the top level tags using `--recurse-depth=0`. But to gather function information, we need to parse all `DW_TAG_subprogram`s, which can be at any depth (because functions can be within nested namespaces or classes). So the trick in #9580 does not work and dumping all `.debug_info` section will be slow. To avoid this problem, we can consider using DWARF-parsing Python libraries like https://github.com/eliben/pyelftools, but this will make another third party dependency, so I'm not sure if it's worth it at this point.

Fixes #20715.