### PR TITLE
Automatic rebaseline of codesize expectations. NFC

### DIFF
--- a/test/code_size/test_codesize_cxx_lto.json
+++ b/test/code_size/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19081,
   "a.out.js.gz": 7838,
-  "a.out.nodebug.wasm": 106464,
-  "a.out.nodebug.wasm.gz": 42600,
-  "total": 125545,
-  "total_gz": 50438,
+  "a.out.nodebug.wasm": 106468,
+  "a.out.nodebug.wasm.gz": 42616,
+  "total": 125549,
+  "total_gz": 50454,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/code_size/test_codesize_cxx_wasmfs.json
+++ b/test/code_size/test_codesize_cxx_wasmfs.json
@@ -2,9 +2,9 @@
   "a.out.js": 7143,
   "a.out.js.gz": 3337,
   "a.out.nodebug.wasm": 169796,
-  "a.out.nodebug.wasm.gz": 63083,
+  "a.out.nodebug.wasm.gz": 63081,
   "total": 176939,
-  "total_gz": 66420,
+  "total_gz": 66418,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/code_size/test_codesize_files_wasmfs.json
+++ b/test/code_size/test_codesize_files_wasmfs.json
@@ -2,9 +2,9 @@
   "a.out.js": 5549,
   "a.out.js.gz": 2591,
   "a.out.nodebug.wasm": 50232,
-  "a.out.nodebug.wasm.gz": 18078,
+  "a.out.nodebug.wasm.gz": 18077,
   "total": 55781,
-  "total_gz": 20669,
+  "total_gz": 20668,
   "sent": [
     "a (emscripten_date_now)",
     "b (emscripten_err)",

--- a/test/code_size/test_codesize_hello_dylink_all.json
+++ b/test/code_size/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
   "a.out.js": 246640,
-  "a.out.nodebug.wasm": 597735,
-  "total": 844375,
+  "a.out.nodebug.wasm": 597741,
+  "total": 844381,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/code_size/test_minimal_runtime_code_size_hello_embind.json
+++ b/test/code_size/test_minimal_runtime_code_size_hello_embind.json
@@ -3,8 +3,8 @@
   "a.html.gz": 373,
   "a.js": 7255,
   "a.js.gz": 3313,
-  "a.wasm": 7305,
-  "a.wasm.gz": 3352,
-  "total": 15112,
-  "total_gz": 7038
+  "a.wasm": 7294,
+  "a.wasm.gz": 3339,
+  "total": 15101,
+  "total_gz": 7025
 }

--- a/test/code_size/test_minimal_runtime_code_size_hello_embind_val.json
+++ b/test/code_size/test_minimal_runtime_code_size_hello_embind_val.json
@@ -3,8 +3,8 @@
   "a.html.gz": 373,
   "a.js": 5356,
   "a.js.gz": 2526,
-  "a.wasm": 5842,
-  "a.wasm.gz": 2726,
-  "total": 11750,
-  "total_gz": 5625
+  "a.wasm": 5831,
+  "a.wasm.gz": 2713,
+  "total": 11739,
+  "total_gz": 5612
 }

--- a/test/code_size/test_minimal_runtime_code_size_hello_wasm_worker.json
+++ b/test/code_size/test_minimal_runtime_code_size_hello_wasm_worker.json
@@ -3,8 +3,8 @@
   "a.html.gz": 357,
   "a.js": 855,
   "a.js.gz": 543,
-  "a.wasm": 1829,
-  "a.wasm.gz": 1051,
-  "total": 3203,
-  "total_gz": 1951
+  "a.wasm": 1885,
+  "a.wasm.gz": 1072,
+  "total": 3259,
+  "total_gz": 1972
 }


### PR DESCRIPTION
This is an automatic change generated by tools/maint/rebaseline_tests.py.

The following (7) test expectation files were updated by running the tests with `--rebaseline`:

```
code_size/test_codesize_cxx_lto.json: 125545 => 125549 [+4 bytes / +0.00%]
code_size/test_codesize_cxx_wasmfs.json: 176939 => 176939 [+0 bytes / +0.00%]
code_size/test_codesize_files_wasmfs.json: 55781 => 55781 [+0 bytes / +0.00%]
code_size/test_codesize_hello_dylink_all.json: 844375 => 844381 [+6 bytes / +0.00%]
code_size/test_minimal_runtime_code_size_hello_embind.json: 15112 => 15101 [-11 bytes / -0.07%]
code_size/test_minimal_runtime_code_size_hello_embind_val.json: 11750 => 11739 [-11 bytes / -0.09%]
code_size/test_minimal_runtime_code_size_hello_wasm_worker.json: 3203 => 3259 [+56 bytes / +1.75%]

Average change: +0.23% (-0.09% - +1.75%)
```