### PR TITLE
Proxy process exit from pthread to main thread using a postMessage()

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -75,6 +75,9 @@ var LibraryPThread = {
                    '$removeRunDependency',
 #endif
                    '$spawnThread',
+#if EXIT_RUNTIME
+                   '$exitOnMainThread',
+#endif
                    '_emscripten_thread_free_data',
                    'exit',
 #if PTHREADS_DEBUG || ASSERTIONS
@@ -295,10 +298,12 @@ var LibraryPThread = {
 #endif
         } else if (cmd === 'callHandler') {
           Module[d.handler](...d.args);
+#if EXIT_RUNTIME
         } else if (cmd === 'processExit') {
           try {
             exitOnMainThread(d.code);
           } catch(e) {} // Swallow the ExitStatus exception, since we need to unwind here.
+#endif
         } else if (cmd) {
           // The received message looks like something that should be handled by this message
           // handler, (since there is a e.data.cmd field present), but is not one of the

--- a/test/code_size/test_codesize_minimal_pthreads.json
+++ b/test/code_size/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7649,
-  "a.out.js.gz": 3768,
+  "a.out.js": 7638,
+  "a.out.js.gz": 3753,
   "a.out.nodebug.wasm": 19588,
   "a.out.nodebug.wasm.gz": 9025,
-  "total": 27237,
-  "total_gz": 12793,
+  "total": 27226,
+  "total_gz": 12778,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/code_size/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/code_size/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 8076,
-  "a.out.js.gz": 3974,
+  "a.out.js": 8065,
+  "a.out.js.gz": 3960,
   "a.out.nodebug.wasm": 19589,
   "a.out.nodebug.wasm.gz": 9025,
-  "total": 27665,
-  "total_gz": 12999,
+  "total": 27654,
+  "total_gz": 12985,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -7245,10 +7245,6 @@ int main(void) {
 
   @crossplatform
   @node_pthreads
-  @flaky('https://github.com/emscripten-core/emscripten/issues/19683')
-  # The flakiness of this test is very high on macOS so just disable it
-  # completely.
-  @no_mac('https://github.com/emscripten-core/emscripten/issues/19683')
   def test_pthread_print_override_modularize(self):
     self.set_setting('EXPORT_NAME', 'Test')
     self.set_setting('PROXY_TO_PTHREAD')


### PR DESCRIPTION
Proxy process exit from pthread to main thread using a postMessage() and not the WebAssembly heap-based proxying queue, so that all postMessage()s will flush in-order before the process exit command does.

Fixes `other.test_pthread_print_override_modularize` flakiness.

There the problem was that a pthread performs a print, which is proxied over to the main thread using a `print` callHandler.

Then pthread quits, which would result in `exitOnMainThread` being called, but that would utilize the WebAssembly heap based proxying queue.

On the main thread then depending on the phase of the moon, the main thread will either flush the Wasm heap queue or the postMessage() queue first.

By `postMessage()`ing also the process exit call, then we can ensure that all previous postMessage()s, such as the print() call, will be flushed sequentially before the process exit call is processed.