### PR TITLE
Implement --emit-symbol-map locally without calling out wasm-opt

### DIFF
--- a/test/other/test_symbol_map.O2.symbols
+++ b/test/other/test_symbol_map.O2.symbols
@@ -1,7 +1,7 @@
 0:run_js
 1:emscripten_asm_const_int
 2:__wasm_call_ctors
-3:foo::cpp_func\28int\29
+3:foo::cpp_func(int)
 4:middle
 5:main
 6:_emscripten_stack_restore

--- a/test/other/test_symbol_map.O3.symbols
+++ b/test/other/test_symbol_map.O3.symbols
@@ -2,5 +2,5 @@
 1:emscripten_asm_const_int
 2:middle
 3:main
-4:foo::cpp_func\28int\29
+4:foo::cpp_func(int)
 5:__wasm_call_ctors

--- a/tools/link.py
+++ b/tools/link.py
@@ -2413,8 +2413,9 @@ def phase_binaryen(target, options, wasm_target):
   if options.emit_symbol_map:
     intermediate_debug_info -= 1
     if generating_wasm:
-      building.handle_final_wasm_symbols(wasm_file=wasm_target, symbols_file=symbols_file, debug_info=intermediate_debug_info)
-      save_intermediate_with_wasm('symbolmap', wasm_target)
+      building.write_symbol_map(wasm_target, symbols_file)
+      if not intermediate_debug_info:
+        building.strip(wasm_target, wasm_target, sections=['name'])
 
   if settings.GENERATE_DWARF and settings.SEPARATE_DWARF and generating_wasm:
     # if the dwarf filename wasn't provided, use the default target + a suffix

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -157,6 +157,21 @@ class TargetFeaturePrefix(IntEnum):
   DISALLOWED = 0x2d
 
 
+class NameType(IntEnum):
+  MODULE = 0
+  FUNCTION = 1
+  LOCAL = 2
+  LABEL = 3
+  TYPE = 4
+  TABLE = 5
+  MEMORY = 6
+  GLOBAL = 7
+  ELEMSEGMENT = 8
+  DATASEGMENT = 9
+  FIELD = 10
+  TAG = 11
+
+
 class InvalidWasmError(BaseException):
   pass
 


### PR DESCRIPTION
The binaryen version was outputting strange mangled C++ names.

Doing this in python should be faster since we don't need to parse the whole binary.