### PR TITLE
Merge two similar features-section-parsing functions (NFC)

### DIFF
--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -332,8 +332,8 @@ def extract_metadata(filename):
         string_address = to_unsigned(get_global_value(globl))
         em_js_funcs[name] = get_string_at(module, string_address)
 
-    features = module.parse_features_section()
-    features = ['--enable-' + f[1] for f in features if f[0] == '+']
+    features = module.get_target_features()
+    features = [f'--enable-{feature}' for feature, used in features.items() if used == webassembly.TargetFeaturePrefix.USED]
     features = [f.replace('--enable-atomics', '--enable-threads') for f in features]
     features = [f.replace('--enable-simd128', '--enable-simd') for f in features]
     features = [f.replace('--enable-nontrapping-fptoint', '--enable-nontrapping-float-to-int') for f in features]

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -292,19 +292,6 @@ class Module:
 
     return types
 
-  def parse_features_section(self):
-    features = []
-    sec = self.get_custom_section('target_features')
-    if sec:
-      self.seek(sec.offset)
-      self.read_string()  # name
-      feature_count = self.read_uleb()
-      while feature_count:
-        prefix = self.read_byte()
-        features.append((chr(prefix), self.read_string()))
-        feature_count -= 1
-    return features
-
   @memoize
   def parse_dylink_section(self):
     dylink_section = next(self.sections())
@@ -562,6 +549,7 @@ class Module:
       func_type = self.get_function_types()[idx - self.num_imported_funcs()]
     return self.get_types()[func_type]
 
+  @memoize
   def get_target_features(self):
     section = self.get_custom_section('target_features')
     self.seek(section.offset)

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -552,6 +552,8 @@ class Module:
   @memoize
   def get_target_features(self):
     section = self.get_custom_section('target_features')
+    if not section:
+      return {}
     self.seek(section.offset)
     assert self.read_string() == 'target_features'
     features = {}


### PR DESCRIPTION
`webassembly.Module` has two similar functions. This makes code use `get_target_features`, which returns a map so it can be queried by features.

This also adds `@memoize` decorator to `get_target_features` so its result will be cached.