### PR TITLE
Optimize quadratic test_dwarf down to linear.

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7952,24 +7952,19 @@ void* operator new(size_t size) {
 
     # parse the sections
     sections = {}
-    curr_section_name = ''
-    curr_section_body = ''
 
-    def add_section():
-      if curr_section_name:
-        sections[curr_section_name] = curr_section_body
+    lines = out.splitlines()
+    # Add a sentinel to ensure the last section gets flushed properly
+    lines += [' dummy contents:']
 
-    for line in out.splitlines():
-      if ' contents:' in line:
-        # a new section, a line like ".debug_str contents:"
-        add_section()
-        curr_section_name = line.split(' ')[0]
-        curr_section_body = ''
-      else:
-        # possibly a line in a section
-        if curr_section_name:
-          curr_section_body += line + '\n'
-    add_section()
+    curr_section_start = -1
+    for i in range(len(lines)):
+      if ' contents:' in lines[i]:
+        if curr_section_start >= 0:
+          # a new section, a line like ".debug_str contents:"
+          sections[curr_section_name] = '\n'.join(lines[curr_section_start:i])
+        curr_section_name = lines[i].split(' ')[0]
+        curr_section_start = i+1
 
     # make sure the right sections exist
     self.assertIn('.debug_abbrev', sections)


### PR DESCRIPTION
Optimize quadratic test_dwarf down to linear. Speeds up lsan.test_dwarf down from 476 seconds to 1.7 seconds.