### PR TITLE
Create a stress test that more deterministically reproduces #20067

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9632,6 +9632,17 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('EXIT_RUNTIME')
     self.do_core_test('test_hello_world.c')
 
+  # This is a stress test version that focuses on https://github.com/emscripten-core/emscripten/issues/20067
+  @node_pthreads
+  @no_esm_integration('ABORT_ON_WASM_EXCEPTIONS is not compatible with WASM_ESM_INTEGRATION')
+  @is_slow_test
+  def test_stress_proxy_to_pthread_hello_world(self):
+    self.set_setting('ABORT_ON_WASM_EXCEPTIONS')
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('EXIT_RUNTIME')
+    js_file = self.build('core/test_hello_world.c')
+    self.parallel_stress_test_js_file(js_file, expected_returncode=0, expected='hello, world!', not_expected='error')
+
   @needs_dylink
   def test_gl_main_module(self):
     # TODO: For some reason, -lGL must be passed in -sSTRICT mode, but can NOT


### PR DESCRIPTION
Create a stress test that more deterministically reproduces the flaky test error in https://github.com/emscripten-core/emscripten/issues/20067.

Ran the test 20 times, with the following results:
```
Failed in 5.167s
Failed in 2.002s
Failed in 2.324s
Failed in 2.564s
Passed (no repro), took 12.276s
Failed in 3.277s
Passed (no repro), took 12.955s
Failed in 5.717s
Failed in 2.092s
Failed in 3.836s
Failed in 2.001s
Failed in 3.475s
Failed in 1.601s
Failed in 5.307s
Failed in 1.757s
Failed in 4.716s
Failed in 2.036s
Failed in 3.001s
Failed in 3.600s
Failed in 7.481s
```

giving a repro rate of ~90%.
