### PR TITLE
[testing] Use parallel test runner for browser tests.

### DIFF
--- a/test/runner.py
+++ b/test/runner.py
@@ -319,7 +319,7 @@ def flattened_tests(loaded_tests):
 
 
 def suite_for_module(module, tests):
-  suite_supported = module.__name__ in ('test_core', 'test_other', 'test_posixtest')
+  suite_supported = module.__name__ in ('test_core', 'test_other', 'test_posixtest', 'test_browser')
   if not common.EMTEST_SAVE_DIR and not shared.DEBUG:
     has_multiple_tests = len(tests) > 1
     has_multiple_cores = parallel_testsuite.num_cores() > 1


### PR DESCRIPTION
When using the parallel test runner each worker in the pool will get its own browser and server to run independently. Workers in the pool do not allow daemon processes so the HTTP servers have been converted to use threads.