### PR TITLE
Add @requires_native_clang to test_cmake_compile_features. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -925,6 +925,7 @@ f.close()
     '': ([],),
     'noforce': (['-DEMSCRIPTEN_FORCE_COMPILERS=OFF'],),
   })
+  @requires_native_clang
   def test_cmake_compile_features(self, args):
     os.mkdir('build_native')
     cmd = ['cmake',


### PR DESCRIPTION
Because it does.

See #25062