### PR TITLE
Fix JS engines to use NODE_JS_TEST

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -64,7 +64,7 @@ def normalize_config_settings():
 
   # EM_CONFIG stuff
   if not JS_ENGINES:
-    JS_ENGINES = [NODE_JS]
+    JS_ENGINES = [NODE_JS_TEST if NODE_JS_TEST else NODE_JS]
 
   SPIDERMONKEY_ENGINE = fix_js_engine(SPIDERMONKEY_ENGINE, listify(SPIDERMONKEY_ENGINE))
   NODE_JS = fix_js_engine(NODE_JS, listify(NODE_JS))


### PR DESCRIPTION
Emsdk generates

```
import os
emsdk_path = os.path.dirname(os.getenv('EM_CONFIG')).replace('\\', '/')
LLVM_ROOT = emsdk_path + '/llvm/git/build_main_64/bin'
NODE_JS = emsdk_path + '/node/22.16.0_64bit/bin/node'
EMSCRIPTEN_ROOT = emsdk_path + '/emscripten/main'
BINARYEN_ROOT = emsdk_path + '/binaryen/main_64bit_binaryen'
NODE_JS_TEST = ['qemu-s390x', '-L', '/usr/s390x-linux-gnu/', emsdk_path + '/node-big-endian-crosscompile/22.16.0_64bit/bin/node']
```
when activating regular and big endian node. This results in a non-working Emscripten installation that complains about NODE_JS not found.

Comment at https://github.com/emscripten-core/emscripten/pull/25063#issuecomment-3229281102 suggests that the intent is that if NODE_JS_TEST is populated, it should go to JS_ENGINES, so make that happen.