### PR TITLE
Fix wasm64.test_stack_safe. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -659,27 +659,6 @@ jobs:
     steps:
       - run-tests-linux:
           test_targets: "wasm2js1"
-  test-wasm64:
-    # We don't use `bionic` here since its too old to run recent node versions:
-    # `/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found`
-    executor: linux-python
-    steps:
-      - prepare-for-tests
-      # The linux-python image uses /home/circleci rather than /root and jsvu
-      # hardcodes /root into its launcher scripts so we need to reinstall v8.
-      - run: rm -rf $HOME/.jsvu
-      - install-v8
-      - install-node-canary
-      # When running wasm64 tests we need to make sure we use the testing
-      # version of node (node canary) when running the compiler output (e.g.
-      # in configure tests.
-      - run:
-          name: configure compiler to use node-canary
-          command: echo "NODE_JS = NODE_JS_TEST" >> ~/emsdk/.emscripten
-      - run-tests:
-          title: "wasm64"
-          test_targets: "wasm64"
-      - upload-test-results
   test-wasm64-4gb:
     environment:
       LANG: "C.UTF-8"
@@ -707,6 +686,7 @@ jobs:
             core_2gb.test_*em_asm*
             core_2gb.test_*embind*
             core_2gb.test_fs_js_api_wasmfs
+            wasm64.test_safe_stack
             wasm64l.test_hello_world
             wasm64l.test_bigswitch
             wasm64l.test_module_wasm_memory

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -45,11 +45,15 @@ addToLibrary({
 #if ASSERTIONS
     assert(typeof ptr === 'number');
 #endif
-#if !CAN_ADDRESS_2GB && !MEMORY64
-    // With CAN_ADDRESS_2GB or MEMORY64, pointers are already unsigned.
+#if MEMORY64
+    // Convert to 64-bit unsigned value.  We need to use BigInt here since
+    // Number cannot represent the full 64-bit range.
+    if (ptr < 0) ptr = 2n**64n + BigInt(ptr);
+#else
+    // Convert to 32-bit unsigned value
     ptr >>>= 0;
 #endif
-    return '0x' + ptr.toString(16).padStart(8, '0');
+    return '0x' + ptr.toString(16).padStart({{{ POINTER_SIZE * 2 }}}, '0');
   },
 
   $zeroMemory: (ptr, size) => HEAPU8.fill(0, ptr, ptr + size),

--- a/test/code_size/test_unoptimized_code_size.json
+++ b/test/code_size/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 53809,
-  "hello_world.js.gz": 17016,
+  "hello_world.js": 53777,
+  "hello_world.js.gz": 16996,
   "hello_world.wasm": 15127,
   "hello_world.wasm.gz": 7448,
   "no_asserts.js": 26387,
   "no_asserts.js.gz": 8797,
   "no_asserts.wasm": 12227,
   "no_asserts.wasm.gz": 6008,
-  "strict.js": 51847,
-  "strict.js.gz": 16341,
+  "strict.js": 51815,
+  "strict.js.gz": 16321,
   "strict.wasm": 15127,
   "strict.wasm.gz": 7445,
-  "total": 174524,
-  "total_gz": 63055
+  "total": 174460,
+  "total_gz": 63015
 }

--- a/test/other/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/other/codesize/test_codesize_minimal_O0.expected.js
@@ -784,7 +784,7 @@ async function createWasm() {
 
   var ptrToString = (ptr) => {
       assert(typeof ptr === 'number');
-      // With CAN_ADDRESS_2GB or MEMORY64, pointers are already unsigned.
+      // Convert to 32-bit unsigned value
       ptr >>>= 0;
       return '0x' + ptr.toString(16).padStart(8, '0');
     };


### PR DESCRIPTION
This change fixes ptrToString to handle 64-bit pointers, as well as negative pointers.

For wasm64 have to deal with potentially negative pointer values flowing out of WebAssembly.  The `>>> 0` trick doesn't work since it would truncate the value to 32-bits.

Fixes: #25075