### PR TITLE
When printing test harness stuff, print to stderr to be more consistent.

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -81,7 +81,7 @@ class ParallelTestSuite(unittest.BaseTestSuite):
     # reverse alphabetical order.
     tests = list(self if self.failing_and_slow_first else self.reversed_tests())
     use_cores = cap_max_workers_in_pool(min(self.max_cores, len(tests), num_cores()))
-    print('Using %s parallel test processes' % use_cores)
+    print('Using %s parallel test processes' % use_cores, file=sys.stderr)
     with multiprocessing.Manager() as manager:
       pool = multiprocessing.Pool(use_cores)
       failfast_event = manager.Event() if self.failfast else None
@@ -128,9 +128,9 @@ class ParallelTestSuite(unittest.BaseTestSuite):
     return sorted(self, key=str, reverse=True)
 
   def combine_results(self, result, buffered_results):
-    print()
-    print('DONE: combining results on main thread')
-    print()
+    print('', file=sys.stderr)
+    print('DONE: combining results on main thread', file=sys.stderr)
+    print('', file=sys.stderr)
     # Sort the results back into alphabetical order. Running the tests in
     # parallel causes mis-orderings, this makes the results more readable.
     results = sorted(buffered_results, key=lambda res: str(res.test))

--- a/test/runner.py
+++ b/test/runner.py
@@ -431,7 +431,7 @@ def run_tests(options, suites):
   total_core_time = 0
   run_start_time = time.perf_counter()
   for mod_name, suite in suites:
-    print('Running %s: (%s tests)' % (mod_name, suite.countTestCases()))
+    print('Running %s: (%s tests)' % (mod_name, suite.countTestCases()), file=sys.stderr)
     res = testRunner.run(suite)
     msg = ('%s: %s run, %s errors, %s failures, %s skipped' %
            (mod_name, res.testsRun, len(res.errors), len(res.failures), len(res.skipped)))
@@ -441,7 +441,7 @@ def run_tests(options, suites):
       total_core_time += res.core_time
   total_run_time = time.perf_counter() - run_start_time
   if total_core_time > 0:
-    print('Total core time: %.3fs. Wallclock time: %.3fs. Parallelization: %.2fx.' % (total_core_time, total_run_time, total_core_time / total_run_time))
+    print('Total core time: %.3fs. Wallclock time: %.3fs. Parallelization: %.2fx.' % (total_core_time, total_run_time, total_core_time / total_run_time), file=sys.stderr)
 
   if len(resultMessages) > 1:
     print('====================')


### PR DESCRIPTION
Iirc the original rationale for the test harness was that test harness infra related prints would go to stderr, and tests itself would print to stdout? (at least that is how I gathered it to be from the start of time..)

Most of the harness stuff goes to stderr, though a few stray lines do not. So move those to print to stderr also to be more consistent.

When observing the prints on Buildbot, this distinction helps a bit visually, since stderr is printed red, and individual test output then in gray.