### PR TITLE
Add `-Wno-experimental` to bigendian test suite. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -10053,7 +10053,7 @@ llvmlibc = make_run('llvmlibc', cflags=['-lllvmlibc'])
 
 # This setup will still use the native x64 Node.js in Emscripten internal use to compile code, but
 # runs all unit tests via qemu on the s390x big endian version of Node.js.
-bigendian0 = make_run('bigendian0', cflags=['-O0'], settings={'SUPPORT_BIG_ENDIAN': 1})
+bigendian0 = make_run('bigendian0', cflags=['-O0', '-Wno-experimental'], settings={'SUPPORT_BIG_ENDIAN': 1})
 
 # TestCoreBase is just a shape for the specific subclasses, we don't test it itself
 del TestCoreBase # noqa


### PR DESCRIPTION
The change to make this config as experimental (#25058) raced with that adding of the test suite (#25068).

Adding `-Wno-experimental` here like we do for other such configurations (e.g. wasm64).