### PR TITLE
Move preInit handling to processModuleArgs. NFC

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -288,20 +288,6 @@ function checkUnflushedContent() {
 #endif // EXIT_RUNTIME
 #endif // ASSERTIONS
 
-function preInit() {
-#if expectToReceiveOnModule('preInit')
-  if (Module['preInit']) {
-    if (typeof Module['preInit'] == 'function') Module['preInit'] = [Module['preInit']];
-    while (Module['preInit'].length > 0) {
-      Module['preInit'].shift()();
-    }
-  }
-#if ASSERTIONS
-  consumedModuleProp('preInit');
-#endif
-#endif
-}
-
 var wasmExports;
 
 #if MODULARIZE == 'instance'
@@ -329,7 +315,6 @@ export default async function init(moduleArg = {}) {
 #else
   wasmExports = await createWasm();
 #endif
-  preInit();
   run();
 }
 
@@ -378,12 +363,11 @@ createWasm();
 wasmExports = createWasm();
 #endif
 
+run();
+
 #if WASM_WORKERS || PTHREADS
 }
 #endif
-
-preInit();
-{{{ runIfMainThread('run();') }}}
 
 #endif // MODULARIZE != instance
 

--- a/src/postlibrary.js
+++ b/src/postlibrary.js
@@ -40,6 +40,17 @@ function processModuleArgs()
 #endif
 #endif // ASSERTIONS
 
+#if expectToReceiveOnModule('preInit')
+  if (Module['preInit']) {
+    if (typeof Module['preInit'] == 'function') Module['preInit'] = [Module['preInit']];
+    while (Module['preInit'].length > 0) {
+      Module['preInit'].shift()();
+    }
+  }
+#if ASSERTIONS
+  consumedModuleProp('preInit');
+#endif
+#endif
 }
 
 {{{ exportJSSymbols() }}}

--- a/test/code_size/test_codesize_cxx_ctors1.json
+++ b/test/code_size/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19753,
-  "a.out.js.gz": 8160,
+  "a.out.js": 19754,
+  "a.out.js.gz": 8162,
   "a.out.nodebug.wasm": 129508,
   "a.out.nodebug.wasm.gz": 49240,
-  "total": 149261,
-  "total_gz": 57400,
+  "total": 149262,
+  "total_gz": 57402,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/code_size/test_codesize_cxx_ctors2.json
+++ b/test/code_size/test_codesize_cxx_ctors2.json
@@ -1,9 +1,9 @@
 {
-  "a.out.js": 19731,
+  "a.out.js": 19732,
   "a.out.js.gz": 8148,
   "a.out.nodebug.wasm": 128935,
   "a.out.nodebug.wasm.gz": 48881,
-  "total": 148666,
+  "total": 148667,
   "total_gz": 57029,
   "sent": [
     "__cxa_throw",

--- a/test/code_size/test_codesize_cxx_except.json
+++ b/test/code_size/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23414,
-  "a.out.js.gz": 9144,
+  "a.out.js": 23415,
+  "a.out.js.gz": 9145,
   "a.out.nodebug.wasm": 171270,
   "a.out.nodebug.wasm.gz": 57331,
-  "total": 194684,
-  "total_gz": 66475,
+  "total": 194685,
+  "total_gz": 66476,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/code_size/test_codesize_cxx_except_wasm.json
+++ b/test/code_size/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19642,
-  "a.out.js.gz": 8109,
+  "a.out.js": 19643,
+  "a.out.js.gz": 8112,
   "a.out.nodebug.wasm": 144629,
   "a.out.nodebug.wasm.gz": 54892,
-  "total": 164271,
-  "total_gz": 63001,
+  "total": 164272,
+  "total_gz": 63004,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/code_size/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/code_size/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19642,
-  "a.out.js.gz": 8109,
+  "a.out.js": 19643,
+  "a.out.js.gz": 8112,
   "a.out.nodebug.wasm": 142218,
   "a.out.nodebug.wasm.gz": 54353,
-  "total": 161860,
-  "total_gz": 62462,
+  "total": 161861,
+  "total_gz": 62465,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/code_size/test_codesize_cxx_lto.json
+++ b/test/code_size/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19081,
-  "a.out.js.gz": 7838,
+  "a.out.js": 19082,
+  "a.out.js.gz": 7841,
   "a.out.nodebug.wasm": 106464,
   "a.out.nodebug.wasm.gz": 42600,
-  "total": 125545,
-  "total_gz": 50438,
+  "total": 125546,
+  "total_gz": 50441,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/code_size/test_codesize_cxx_noexcept.json
+++ b/test/code_size/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19753,
-  "a.out.js.gz": 8160,
+  "a.out.js": 19754,
+  "a.out.js.gz": 8162,
   "a.out.nodebug.wasm": 131925,
   "a.out.nodebug.wasm.gz": 50235,
-  "total": 151678,
-  "total_gz": 58395,
+  "total": 151679,
+  "total_gz": 58397,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/code_size/test_codesize_cxx_wasmfs.json
+++ b/test/code_size/test_codesize_cxx_wasmfs.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7143,
-  "a.out.js.gz": 3337,
+  "a.out.js.gz": 3338,
   "a.out.nodebug.wasm": 169796,
   "a.out.nodebug.wasm.gz": 63083,
   "total": 176939,
-  "total_gz": 66420,
+  "total_gz": 66421,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/code_size/test_codesize_files_js_fs.json
+++ b/test/code_size/test_codesize_files_js_fs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18356,
-  "a.out.js.gz": 7467,
+  "a.out.js": 18357,
+  "a.out.js.gz": 7470,
   "a.out.nodebug.wasm": 381,
   "a.out.nodebug.wasm.gz": 260,
-  "total": 18737,
-  "total_gz": 7727,
+  "total": 18738,
+  "total_gz": 7730,
   "sent": [
     "a (fd_write)",
     "b (fd_read)",

--- a/test/code_size/test_codesize_hello_O0.json
+++ b/test/code_size/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 22496,
-  "a.out.js.gz": 8329,
+  "a.out.js.gz": 8322,
   "a.out.nodebug.wasm": 15127,
   "a.out.nodebug.wasm.gz": 7448,
   "total": 37623,
-  "total_gz": 15777,
+  "total_gz": 15770,
   "sent": [
     "fd_write"
   ],

--- a/test/code_size/test_codesize_hello_O1.json
+++ b/test/code_size/test_codesize_hello_O1.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 6411,
-  "a.out.js.gz": 2478,
+  "a.out.js.gz": 2472,
   "a.out.nodebug.wasm": 2675,
   "a.out.nodebug.wasm.gz": 1491,
   "total": 9086,
-  "total_gz": 3969,
+  "total_gz": 3963,
   "sent": [
     "fd_write"
   ],

--- a/test/code_size/test_codesize_hello_O2.json
+++ b/test/code_size/test_codesize_hello_O2.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4369,
-  "a.out.js.gz": 2146,
+  "a.out.js.gz": 2140,
   "a.out.nodebug.wasm": 1927,
   "a.out.nodebug.wasm.gz": 1138,
   "total": 6296,
-  "total_gz": 3284,
+  "total_gz": 3278,
   "sent": [
     "fd_write"
   ],

--- a/test/code_size/test_codesize_hello_O3.json
+++ b/test/code_size/test_codesize_hello_O3.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4311,
-  "a.out.js.gz": 2104,
+  "a.out.js.gz": 2097,
   "a.out.nodebug.wasm": 1681,
   "a.out.nodebug.wasm.gz": 960,
   "total": 5992,
-  "total_gz": 3064,
+  "total_gz": 3057,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/code_size/test_codesize_hello_Os.json
+++ b/test/code_size/test_codesize_hello_Os.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4311,
-  "a.out.js.gz": 2104,
+  "a.out.js.gz": 2097,
   "a.out.nodebug.wasm": 1671,
   "a.out.nodebug.wasm.gz": 964,
   "total": 5982,
-  "total_gz": 3068,
+  "total_gz": 3061,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/code_size/test_codesize_hello_Oz.json
+++ b/test/code_size/test_codesize_hello_Oz.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3930,
-  "a.out.js.gz": 1905,
+  "a.out.js": 3931,
+  "a.out.js.gz": 1902,
   "a.out.nodebug.wasm": 1205,
   "a.out.nodebug.wasm.gz": 740,
-  "total": 5135,
-  "total_gz": 2645,
+  "total": 5136,
+  "total_gz": 2642,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/code_size/test_codesize_hello_dylink.json
+++ b/test/code_size/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26975,
-  "a.out.js.gz": 11461,
+  "a.out.js": 26976,
+  "a.out.js.gz": 11458,
   "a.out.nodebug.wasm": 18561,
   "a.out.nodebug.wasm.gz": 9167,
-  "total": 45536,
-  "total_gz": 20628,
+  "total": 45537,
+  "total_gz": 20625,
   "sent": [
     "__heap_base",
     "__indirect_function_table",

--- a/test/code_size/test_codesize_hello_export_nothing.json
+++ b/test/code_size/test_codesize_hello_export_nothing.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 3209,
-  "a.out.js.gz": 1489,
+  "a.out.js.gz": 1486,
   "a.out.nodebug.wasm": 43,
   "a.out.nodebug.wasm.gz": 59,
   "total": 3252,
-  "total_gz": 1548,
+  "total_gz": 1545,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_hello_single_file.json
+++ b/test/code_size/test_codesize_hello_single_file.json
@@ -1,6 +1,6 @@
 {
   "a.out.js": 6547,
-  "a.out.js.gz": 3593,
+  "a.out.js.gz": 3586,
   "sent": [
     "a (fd_write)"
   ]

--- a/test/code_size/test_codesize_hello_wasmfs.json
+++ b/test/code_size/test_codesize_hello_wasmfs.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4311,
-  "a.out.js.gz": 2104,
+  "a.out.js.gz": 2097,
   "a.out.nodebug.wasm": 1681,
   "a.out.nodebug.wasm.gz": 960,
   "total": 5992,
-  "total_gz": 3064,
+  "total_gz": 3057,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/code_size/test_codesize_libcxxabi_message_O3.json
+++ b/test/code_size/test_codesize_libcxxabi_message_O3.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 3558,
-  "a.out.js.gz": 1678,
+  "a.out.js.gz": 1673,
   "a.out.nodebug.wasm": 89,
   "a.out.nodebug.wasm.gz": 98,
   "total": 3647,
-  "total_gz": 1776,
+  "total_gz": 1771,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_libcxxabi_message_O3_standalone.json
+++ b/test/code_size/test_codesize_libcxxabi_message_O3_standalone.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 3605,
-  "a.out.js.gz": 1713,
+  "a.out.js.gz": 1708,
   "a.out.nodebug.wasm": 132,
   "a.out.nodebug.wasm.gz": 140,
   "total": 3737,
-  "total_gz": 1853,
+  "total_gz": 1848,
   "sent": [
     "proc_exit"
   ],

--- a/test/code_size/test_codesize_mem_O3.json
+++ b/test/code_size/test_codesize_mem_O3.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4399,
-  "a.out.js.gz": 2118,
+  "a.out.js.gz": 2112,
   "a.out.nodebug.wasm": 5262,
   "a.out.nodebug.wasm.gz": 2402,
   "total": 9661,
-  "total_gz": 4520,
+  "total_gz": 4514,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/code_size/test_codesize_mem_O3_grow.json
+++ b/test/code_size/test_codesize_mem_O3_grow.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4684,
-  "a.out.js.gz": 2267,
+  "a.out.js.gz": 2264,
   "a.out.nodebug.wasm": 5263,
   "a.out.nodebug.wasm.gz": 2402,
   "total": 9947,
-  "total_gz": 4669,
+  "total_gz": 4666,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/code_size/test_codesize_mem_O3_grow_standalone.json
+++ b/test/code_size/test_codesize_mem_O3_grow_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4126,
-  "a.out.js.gz": 1978,
+  "a.out.js": 4125,
+  "a.out.js.gz": 1977,
   "a.out.nodebug.wasm": 5549,
   "a.out.nodebug.wasm.gz": 2583,
-  "total": 9675,
-  "total_gz": 4561,
+  "total": 9674,
+  "total_gz": 4560,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/code_size/test_codesize_mem_O3_standalone.json
+++ b/test/code_size/test_codesize_mem_O3_standalone.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4058,
-  "a.out.js.gz": 1945,
+  "a.out.js.gz": 1941,
   "a.out.nodebug.wasm": 5474,
   "a.out.nodebug.wasm.gz": 2524,
   "total": 9532,
-  "total_gz": 4469,
+  "total_gz": 4465,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/code_size/test_codesize_mem_O3_standalone_lib.json
+++ b/test/code_size/test_codesize_mem_O3_standalone_lib.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 3602,
-  "a.out.js.gz": 1703,
+  "a.out.js.gz": 1699,
   "a.out.nodebug.wasm": 5241,
   "a.out.nodebug.wasm.gz": 2332,
   "total": 8843,
-  "total_gz": 4035,
+  "total_gz": 4031,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_mem_O3_standalone_narg.json
+++ b/test/code_size/test_codesize_mem_O3_standalone_narg.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 3605,
-  "a.out.js.gz": 1713,
+  "a.out.js.gz": 1708,
   "a.out.nodebug.wasm": 5267,
   "a.out.nodebug.wasm.gz": 2364,
   "total": 8872,
-  "total_gz": 4077,
+  "total_gz": 4072,
   "sent": [
     "proc_exit"
   ],

--- a/test/code_size/test_codesize_mem_O3_standalone_narg_flto.json
+++ b/test/code_size/test_codesize_mem_O3_standalone_narg_flto.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 3605,
-  "a.out.js.gz": 1713,
+  "a.out.js.gz": 1708,
   "a.out.nodebug.wasm": 4080,
   "a.out.nodebug.wasm.gz": 2001,
   "total": 7685,
-  "total_gz": 3714,
+  "total_gz": 3709,
   "sent": [
     "proc_exit"
   ],

--- a/test/code_size/test_codesize_minimal_pthreads.json
+++ b/test/code_size/test_codesize_minimal_pthreads.json
@@ -1,9 +1,9 @@
 {
-  "a.out.js": 7660,
+  "a.out.js": 7659,
   "a.out.js.gz": 3776,
   "a.out.nodebug.wasm": 19588,
   "a.out.nodebug.wasm.gz": 9025,
-  "total": 27248,
+  "total": 27247,
   "total_gz": 12801,
   "sent": [
     "a (memory)",

--- a/test/code_size/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/code_size/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 8087,
-  "a.out.js.gz": 3978,
+  "a.out.js": 8086,
+  "a.out.js.gz": 3977,
   "a.out.nodebug.wasm": 19589,
   "a.out.nodebug.wasm.gz": 9025,
-  "total": 27676,
-  "total_gz": 13003,
+  "total": 27675,
+  "total_gz": 13002,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/code_size/test_unoptimized_code_size.json
+++ b/test/code_size/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 53916,
-  "hello_world.js.gz": 17035,
+  "hello_world.js": 53881,
+  "hello_world.js.gz": 17016,
   "hello_world.wasm": 15127,
   "hello_world.wasm.gz": 7448,
-  "no_asserts.js": 26387,
-  "no_asserts.js.gz": 8797,
+  "no_asserts.js": 26352,
+  "no_asserts.js.gz": 8789,
   "no_asserts.wasm": 12227,
   "no_asserts.wasm.gz": 6008,
-  "strict.js": 51954,
-  "strict.js.gz": 16362,
+  "strict.js": 51919,
+  "strict.js.gz": 16352,
   "strict.wasm": 15127,
   "strict.wasm.gz": 7445,
-  "total": 174738,
-  "total_gz": 63095
+  "total": 174633,
+  "total_gz": 63058
 }

--- a/test/other/codesize/test_codesize_file_preload.expected.js
+++ b/test/other/codesize/test_codesize_file_preload.expected.js
@@ -3206,14 +3206,10 @@ function run() {
   }
 }
 
-function preInit() {}
-
 var wasmExports;
 
 // With async instantation wasmExports is assigned asynchronously when the
 // instance is received.
 createWasm();
-
-preInit();
 
 run();

--- a/test/other/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/other/codesize/test_codesize_minimal_O0.expected.js
@@ -1389,16 +1389,12 @@ function checkUnflushedContent() {
   }
 }
 
-function preInit() {
-}
-
 var wasmExports;
 
 // With async instantation wasmExports is assigned asynchronously when the
 // instance is received.
 createWasm();
 
-preInit();
 run();
 
 // end include: postamble.js


### PR DESCRIPTION
This simplifies the startup code and paves the way for the removal of the use of `addRunDependency`/`removeRunDependency` for `wasm-instantiation`.