### PR TITLE
Disable strict.test_poppler

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6912,7 +6912,7 @@ void* operator new(size_t size) {
   @no_wasmfs('depends on MEMFS which WASMFS does not have')
   def test_poppler(self):
     # See https://github.com/emscripten-core/emscripten/issues/20757
-    self.cflags.extend(['-Wno-deprecated-declarations', '-Wno-nontrivial-memaccess', '-Wno-error=cpp'])
+    self.cflags.extend(['-Wno-deprecated-declarations', '-Wno-nontrivial-memaccess'])
     poppler = self.get_poppler_library()
     shutil.copy(test_file('poppler/paper.pdf'), '.')
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6912,7 +6912,7 @@ void* operator new(size_t size) {
   @no_wasmfs('depends on MEMFS which WASMFS does not have')
   def test_poppler(self):
     # See https://github.com/emscripten-core/emscripten/issues/20757
-    self.cflags.extend(['-Wno-deprecated-declarations', '-Wno-nontrivial-memaccess'])
+    self.cflags.extend(['-Wno-deprecated-declarations', '-Wno-nontrivial-memaccess', '-Wno-error=cpp'])
     poppler = self.get_poppler_library()
     shutil.copy(test_file('poppler/paper.pdf'), '.')
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6910,6 +6910,7 @@ void* operator new(size_t size) {
   @is_slow_test
   @crossplatform
   @no_wasmfs('depends on MEMFS which WASMFS does not have')
+  @no_strict('autoconfiguring is not compatible with STRICT')
   def test_poppler(self):
     # See https://github.com/emscripten-core/emscripten/issues/20757
     self.cflags.extend(['-Wno-deprecated-declarations', '-Wno-nontrivial-memaccess'])

--- a/tools/link.py
+++ b/tools/link.py
@@ -724,6 +724,9 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     settings.NODERAWFS = 1
     # Add `#!` line to output JS and make it executable.
     options.executable = True
+    # autoconf declares functions without their proper signatures, and STRICT causes that to trip up by passing --fatal-warnings to the linker.
+    if settings.STRICT:
+      exit_with_error('autoconfiguring is not compatible with STRICT')
 
   if settings.OPT_LEVEL >= 1:
     default_setting('ASSERTIONS', 0)


### PR DESCRIPTION
The GooTimer.cc file had a `#warning`, and `STRICT` test mode sets `-Werror`.

```
GooTimer.cc:91:2: error: "no support for GooTimer" [-Werror,-W#warnings]
   91 | #warning "no support for GooTimer"
      |  ^
1 error generated.
```
