### PR TITLE
Fix emmalloc's name for EM_JS_DEPS to be unique to emmalloc

### DIFF
--- a/system/lib/emmalloc.c
+++ b/system/lib/emmalloc.c
@@ -651,7 +651,7 @@ static size_t validate_alloc_size(size_t size) {
   return validatedSize;
 }
 
-EM_JS_DEPS(deps, "$ptrToString");
+EM_JS_DEPS(_em_malloc_deps, "$ptrToString");
 
 static void *allocate_memory(size_t alignment, size_t size) {
   ASSERT_MALLOC_IS_ACQUIRED();


### PR DESCRIPTION
Fix emmalloc's name for EM_JS_DEPS to be unique to emmalloc, so it won't conflict with user code EM_JS_DEPS.