### PR TITLE
Remove the `wasm-instantate` run dependency. NFC

### DIFF
--- a/src/lib/libbrowser.js
+++ b/src/lib/libbrowser.js
@@ -622,7 +622,7 @@ var LibraryBrowser = {
   },
 
   // TODO: currently not callable from a pthread, but immediately calls onerror() if not on main thread.
-  emscripten_async_load_script__deps: ['$UTF8ToString'],
+  emscripten_async_load_script__deps: ['$UTF8ToString', '$runDependencies'],
   emscripten_async_load_script: async (url, onload, onerror) => {
     url = UTF8ToString(url);
 #if PTHREADS

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -353,17 +353,18 @@ if ({{{ ENVIRONMENT_IS_MAIN_THREAD() }}}) {
 // In modularize mode the generated code is within a factory function so we
 // can use await here (since it's not top-level-await).
 wasmExports = await createWasm();
+run();
 #else
 // With async instantation wasmExports is assigned asynchronously when the
 // instance is received.
-createWasm();
+createWasm().then(() => run());
 #endif
 
 #else
 wasmExports = createWasm();
+run();
 #endif
 
-run();
 
 #if WASM_WORKERS || PTHREADS
 }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -754,14 +754,8 @@ function getWasmImports() {
 #if DECLARE_ASM_MODULE_EXPORTS
     assignWasmExports(wasmExports);
 #endif
-#if WASM_ASYNC_COMPILATION && !MODULARIZE
-    removeRunDependency('wasm-instantiate');
-#endif
     return wasmExports;
   }
-#if WASM_ASYNC_COMPILATION && !MODULARIZE
-  addRunDependency('wasm-instantiate');
-#endif
 
   // Prefer streaming instantiation if available.
 #if WASM_ASYNC_COMPILATION

--- a/test/code_size/test_codesize_cxx_ctors1.json
+++ b/test/code_size/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19754,
-  "a.out.js.gz": 8162,
+  "a.out.js": 19624,
+  "a.out.js.gz": 8094,
   "a.out.nodebug.wasm": 129508,
   "a.out.nodebug.wasm.gz": 49240,
-  "total": 149262,
-  "total_gz": 57402,
+  "total": 149132,
+  "total_gz": 57334,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/code_size/test_codesize_cxx_ctors2.json
+++ b/test/code_size/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19732,
-  "a.out.js.gz": 8148,
+  "a.out.js": 19602,
+  "a.out.js.gz": 8081,
   "a.out.nodebug.wasm": 128935,
   "a.out.nodebug.wasm.gz": 48881,
-  "total": 148667,
-  "total_gz": 57029,
+  "total": 148537,
+  "total_gz": 56962,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/code_size/test_codesize_cxx_except.json
+++ b/test/code_size/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23415,
-  "a.out.js.gz": 9145,
+  "a.out.js": 23283,
+  "a.out.js.gz": 9075,
   "a.out.nodebug.wasm": 171270,
   "a.out.nodebug.wasm.gz": 57331,
-  "total": 194685,
-  "total_gz": 66476,
+  "total": 194553,
+  "total_gz": 66406,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/code_size/test_codesize_cxx_except_wasm.json
+++ b/test/code_size/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19643,
-  "a.out.js.gz": 8112,
+  "a.out.js": 19513,
+  "a.out.js.gz": 8046,
   "a.out.nodebug.wasm": 144629,
   "a.out.nodebug.wasm.gz": 54892,
-  "total": 164272,
-  "total_gz": 63004,
+  "total": 164142,
+  "total_gz": 62938,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/code_size/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/code_size/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19643,
-  "a.out.js.gz": 8112,
+  "a.out.js": 19513,
+  "a.out.js.gz": 8046,
   "a.out.nodebug.wasm": 142218,
   "a.out.nodebug.wasm.gz": 54353,
-  "total": 161861,
-  "total_gz": 62465,
+  "total": 161731,
+  "total_gz": 62399,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/code_size/test_codesize_cxx_lto.json
+++ b/test/code_size/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19082,
-  "a.out.js.gz": 7841,
+  "a.out.js": 18952,
+  "a.out.js.gz": 7772,
   "a.out.nodebug.wasm": 106464,
   "a.out.nodebug.wasm.gz": 42600,
-  "total": 125546,
-  "total_gz": 50441,
+  "total": 125416,
+  "total_gz": 50372,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/code_size/test_codesize_cxx_mangle.json
+++ b/test/code_size/test_codesize_cxx_mangle.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23465,
-  "a.out.js.gz": 9164,
+  "a.out.js": 23333,
+  "a.out.js.gz": 9095,
   "a.out.nodebug.wasm": 235311,
   "a.out.nodebug.wasm.gz": 78929,
-  "total": 258776,
-  "total_gz": 88093,
+  "total": 258644,
+  "total_gz": 88024,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/code_size/test_codesize_cxx_noexcept.json
+++ b/test/code_size/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19754,
-  "a.out.js.gz": 8162,
+  "a.out.js": 19624,
+  "a.out.js.gz": 8094,
   "a.out.nodebug.wasm": 131925,
   "a.out.nodebug.wasm.gz": 50235,
-  "total": 151679,
-  "total_gz": 58397,
+  "total": 151549,
+  "total_gz": 58329,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/code_size/test_codesize_cxx_wasmfs.json
+++ b/test/code_size/test_codesize_cxx_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7143,
-  "a.out.js.gz": 3338,
+  "a.out.js": 7015,
+  "a.out.js.gz": 3268,
   "a.out.nodebug.wasm": 169796,
   "a.out.nodebug.wasm.gz": 63083,
-  "total": 176939,
-  "total_gz": 66421,
+  "total": 176811,
+  "total_gz": 66351,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/code_size/test_codesize_file_preload.json
+++ b/test/code_size/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22684,
-  "a.out.js.gz": 9375,
+  "a.out.js": 22667,
+  "a.out.js.gz": 9362,
   "a.out.nodebug.wasm": 1681,
   "a.out.nodebug.wasm.gz": 960,
-  "total": 24365,
-  "total_gz": 10335,
+  "total": 24348,
+  "total_gz": 10322,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/code_size/test_codesize_files_js_fs.json
+++ b/test/code_size/test_codesize_files_js_fs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18357,
-  "a.out.js.gz": 7470,
+  "a.out.js": 18226,
+  "a.out.js.gz": 7406,
   "a.out.nodebug.wasm": 381,
   "a.out.nodebug.wasm.gz": 260,
-  "total": 18738,
-  "total_gz": 7730,
+  "total": 18607,
+  "total_gz": 7666,
   "sent": [
     "a (fd_write)",
     "b (fd_read)",

--- a/test/code_size/test_codesize_files_wasmfs.json
+++ b/test/code_size/test_codesize_files_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 5549,
-  "a.out.js.gz": 2591,
+  "a.out.js": 5426,
+  "a.out.js.gz": 2527,
   "a.out.nodebug.wasm": 50232,
   "a.out.nodebug.wasm.gz": 18078,
-  "total": 55781,
-  "total_gz": 20669,
+  "total": 55658,
+  "total_gz": 20605,
   "sent": [
     "a (emscripten_date_now)",
     "b (emscripten_err)",

--- a/test/code_size/test_codesize_hello_O0.json
+++ b/test/code_size/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22496,
-  "a.out.js.gz": 8322,
+  "a.out.js": 21479,
+  "a.out.js.gz": 7989,
   "a.out.nodebug.wasm": 15127,
   "a.out.nodebug.wasm.gz": 7448,
-  "total": 37623,
-  "total_gz": 15770,
+  "total": 36606,
+  "total_gz": 15437,
   "sent": [
     "fd_write"
   ],

--- a/test/code_size/test_codesize_hello_O1.json
+++ b/test/code_size/test_codesize_hello_O1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 6411,
-  "a.out.js.gz": 2472,
+  "a.out.js": 6197,
+  "a.out.js.gz": 2392,
   "a.out.nodebug.wasm": 2675,
   "a.out.nodebug.wasm.gz": 1491,
-  "total": 9086,
-  "total_gz": 3963,
+  "total": 8872,
+  "total_gz": 3883,
   "sent": [
     "fd_write"
   ],

--- a/test/code_size/test_codesize_hello_O2.json
+++ b/test/code_size/test_codesize_hello_O2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4369,
-  "a.out.js.gz": 2140,
+  "a.out.js": 4245,
+  "a.out.js.gz": 2071,
   "a.out.nodebug.wasm": 1927,
   "a.out.nodebug.wasm.gz": 1138,
-  "total": 6296,
-  "total_gz": 3278,
+  "total": 6172,
+  "total_gz": 3209,
   "sent": [
     "fd_write"
   ],

--- a/test/code_size/test_codesize_hello_O3.json
+++ b/test/code_size/test_codesize_hello_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4311,
-  "a.out.js.gz": 2097,
+  "a.out.js": 4186,
+  "a.out.js.gz": 2029,
   "a.out.nodebug.wasm": 1681,
   "a.out.nodebug.wasm.gz": 960,
-  "total": 5992,
-  "total_gz": 3057,
+  "total": 5867,
+  "total_gz": 2989,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/code_size/test_codesize_hello_Os.json
+++ b/test/code_size/test_codesize_hello_Os.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4311,
-  "a.out.js.gz": 2097,
+  "a.out.js": 4186,
+  "a.out.js.gz": 2029,
   "a.out.nodebug.wasm": 1671,
   "a.out.nodebug.wasm.gz": 964,
-  "total": 5982,
-  "total_gz": 3061,
+  "total": 5857,
+  "total_gz": 2993,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/code_size/test_codesize_hello_Oz.json
+++ b/test/code_size/test_codesize_hello_Oz.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3931,
-  "a.out.js.gz": 1902,
+  "a.out.js": 3810,
+  "a.out.js.gz": 1835,
   "a.out.nodebug.wasm": 1205,
   "a.out.nodebug.wasm.gz": 740,
-  "total": 5136,
-  "total_gz": 2642,
+  "total": 5015,
+  "total_gz": 2575,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/code_size/test_codesize_hello_dylink.json
+++ b/test/code_size/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26976,
-  "a.out.js.gz": 11458,
+  "a.out.js": 26943,
+  "a.out.js.gz": 11435,
   "a.out.nodebug.wasm": 18561,
   "a.out.nodebug.wasm.gz": 9167,
-  "total": 45537,
-  "total_gz": 20625,
+  "total": 45504,
+  "total_gz": 20602,
   "sent": [
     "__heap_base",
     "__indirect_function_table",

--- a/test/code_size/test_codesize_hello_export_nothing.json
+++ b/test/code_size/test_codesize_hello_export_nothing.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3209,
-  "a.out.js.gz": 1486,
+  "a.out.js": 3088,
+  "a.out.js.gz": 1419,
   "a.out.nodebug.wasm": 43,
   "a.out.nodebug.wasm.gz": 59,
-  "total": 3252,
-  "total_gz": 1545,
+  "total": 3131,
+  "total_gz": 1478,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_hello_single_file.json
+++ b/test/code_size/test_codesize_hello_single_file.json
@@ -1,6 +1,6 @@
 {
-  "a.out.js": 6547,
-  "a.out.js.gz": 3586,
+  "a.out.js": 6421,
+  "a.out.js.gz": 3518,
   "sent": [
     "a (fd_write)"
   ]

--- a/test/code_size/test_codesize_hello_wasmfs.json
+++ b/test/code_size/test_codesize_hello_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4311,
-  "a.out.js.gz": 2097,
+  "a.out.js": 4186,
+  "a.out.js.gz": 2029,
   "a.out.nodebug.wasm": 1681,
   "a.out.nodebug.wasm.gz": 960,
-  "total": 5992,
-  "total_gz": 3057,
+  "total": 5867,
+  "total_gz": 2989,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/code_size/test_codesize_libcxxabi_message_O3.json
+++ b/test/code_size/test_codesize_libcxxabi_message_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3558,
-  "a.out.js.gz": 1673,
+  "a.out.js": 3437,
+  "a.out.js.gz": 1604,
   "a.out.nodebug.wasm": 89,
   "a.out.nodebug.wasm.gz": 98,
-  "total": 3647,
-  "total_gz": 1771,
+  "total": 3526,
+  "total_gz": 1702,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_libcxxabi_message_O3_standalone.json
+++ b/test/code_size/test_codesize_libcxxabi_message_O3_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3605,
-  "a.out.js.gz": 1708,
+  "a.out.js": 3484,
+  "a.out.js.gz": 1638,
   "a.out.nodebug.wasm": 132,
   "a.out.nodebug.wasm.gz": 140,
-  "total": 3737,
-  "total_gz": 1848,
+  "total": 3616,
+  "total_gz": 1778,
   "sent": [
     "proc_exit"
   ],

--- a/test/code_size/test_codesize_mem_O3.json
+++ b/test/code_size/test_codesize_mem_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4399,
-  "a.out.js.gz": 2112,
+  "a.out.js": 4279,
+  "a.out.js.gz": 2052,
   "a.out.nodebug.wasm": 5262,
   "a.out.nodebug.wasm.gz": 2402,
-  "total": 9661,
-  "total_gz": 4514,
+  "total": 9541,
+  "total_gz": 4454,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/code_size/test_codesize_mem_O3_grow.json
+++ b/test/code_size/test_codesize_mem_O3_grow.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4684,
-  "a.out.js.gz": 2264,
+  "a.out.js": 4565,
+  "a.out.js.gz": 2203,
   "a.out.nodebug.wasm": 5263,
   "a.out.nodebug.wasm.gz": 2402,
-  "total": 9947,
-  "total_gz": 4666,
+  "total": 9828,
+  "total_gz": 4605,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/code_size/test_codesize_mem_O3_grow_standalone.json
+++ b/test/code_size/test_codesize_mem_O3_grow_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4125,
-  "a.out.js.gz": 1977,
+  "a.out.js": 4010,
+  "a.out.js.gz": 1910,
   "a.out.nodebug.wasm": 5549,
   "a.out.nodebug.wasm.gz": 2583,
-  "total": 9674,
-  "total_gz": 4560,
+  "total": 9559,
+  "total_gz": 4493,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/code_size/test_codesize_mem_O3_standalone.json
+++ b/test/code_size/test_codesize_mem_O3_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4058,
-  "a.out.js.gz": 1941,
+  "a.out.js": 3943,
+  "a.out.js.gz": 1878,
   "a.out.nodebug.wasm": 5474,
   "a.out.nodebug.wasm.gz": 2524,
-  "total": 9532,
-  "total_gz": 4465,
+  "total": 9417,
+  "total_gz": 4402,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/code_size/test_codesize_mem_O3_standalone_lib.json
+++ b/test/code_size/test_codesize_mem_O3_standalone_lib.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3602,
-  "a.out.js.gz": 1699,
+  "a.out.js": 3482,
+  "a.out.js.gz": 1630,
   "a.out.nodebug.wasm": 5241,
   "a.out.nodebug.wasm.gz": 2332,
-  "total": 8843,
-  "total_gz": 4031,
+  "total": 8723,
+  "total_gz": 3962,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_mem_O3_standalone_narg.json
+++ b/test/code_size/test_codesize_mem_O3_standalone_narg.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3605,
-  "a.out.js.gz": 1708,
+  "a.out.js": 3484,
+  "a.out.js.gz": 1638,
   "a.out.nodebug.wasm": 5267,
   "a.out.nodebug.wasm.gz": 2364,
-  "total": 8872,
-  "total_gz": 4072,
+  "total": 8751,
+  "total_gz": 4002,
   "sent": [
     "proc_exit"
   ],

--- a/test/code_size/test_codesize_mem_O3_standalone_narg_flto.json
+++ b/test/code_size/test_codesize_mem_O3_standalone_narg_flto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3605,
-  "a.out.js.gz": 1708,
+  "a.out.js": 3484,
+  "a.out.js.gz": 1638,
   "a.out.nodebug.wasm": 4080,
   "a.out.nodebug.wasm.gz": 2001,
-  "total": 7685,
-  "total_gz": 3709,
+  "total": 7564,
+  "total_gz": 3639,
   "sent": [
     "proc_exit"
   ],

--- a/test/code_size/test_codesize_minimal_64.json
+++ b/test/code_size/test_codesize_minimal_64.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2630,
-  "a.out.js.gz": 1253,
+  "a.out.js": 2558,
+  "a.out.js.gz": 1207,
   "a.out.nodebug.wasm": 62,
   "a.out.nodebug.wasm.gz": 76,
-  "total": 2692,
-  "total_gz": 1329,
+  "total": 2620,
+  "total_gz": 1283,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_minimal_O0.json
+++ b/test/code_size/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 17757,
-  "a.out.js.gz": 6623,
+  "a.out.js": 16934,
+  "a.out.js.gz": 6341,
   "a.out.nodebug.wasm": 1136,
   "a.out.nodebug.wasm.gz": 659,
-  "total": 18893,
-  "total_gz": 7282,
+  "total": 18070,
+  "total_gz": 7000,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_minimal_O1.json
+++ b/test/code_size/test_codesize_minimal_O1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3096,
-  "a.out.js.gz": 1312,
+  "a.out.js": 2978,
+  "a.out.js.gz": 1255,
   "a.out.nodebug.wasm": 449,
   "a.out.nodebug.wasm.gz": 337,
-  "total": 3545,
-  "total_gz": 1649,
+  "total": 3427,
+  "total_gz": 1592,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_minimal_O2.json
+++ b/test/code_size/test_codesize_minimal_O2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2377,
-  "a.out.js.gz": 1183,
+  "a.out.js": 2301,
+  "a.out.js.gz": 1134,
   "a.out.nodebug.wasm": 280,
   "a.out.nodebug.wasm.gz": 226,
-  "total": 2657,
-  "total_gz": 1409,
+  "total": 2581,
+  "total_gz": 1360,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_minimal_O3.json
+++ b/test/code_size/test_codesize_minimal_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2327,
-  "a.out.js.gz": 1149,
+  "a.out.js": 2251,
+  "a.out.js.gz": 1100,
   "a.out.nodebug.wasm": 62,
   "a.out.nodebug.wasm.gz": 76,
-  "total": 2389,
-  "total_gz": 1225,
+  "total": 2313,
+  "total_gz": 1176,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_minimal_Os.json
+++ b/test/code_size/test_codesize_minimal_Os.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2327,
-  "a.out.js.gz": 1149,
+  "a.out.js": 2251,
+  "a.out.js.gz": 1100,
   "a.out.nodebug.wasm": 62,
   "a.out.nodebug.wasm.gz": 76,
-  "total": 2389,
-  "total_gz": 1225,
+  "total": 2313,
+  "total_gz": 1176,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_minimal_Oz-ctors.json
+++ b/test/code_size/test_codesize_minimal_Oz-ctors.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2306,
-  "a.out.js.gz": 1133,
+  "a.out.js": 2232,
+  "a.out.js.gz": 1086,
   "a.out.nodebug.wasm": 51,
   "a.out.nodebug.wasm.gz": 68,
-  "total": 2357,
-  "total_gz": 1201,
+  "total": 2283,
+  "total_gz": 1154,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_minimal_Oz.json
+++ b/test/code_size/test_codesize_minimal_Oz.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2327,
-  "a.out.js.gz": 1149,
+  "a.out.js": 2251,
+  "a.out.js.gz": 1100,
   "a.out.nodebug.wasm": 62,
   "a.out.nodebug.wasm.gz": 76,
-  "total": 2389,
-  "total_gz": 1225,
+  "total": 2313,
+  "total_gz": 1176,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_codesize_minimal_pthreads.json
+++ b/test/code_size/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7659,
-  "a.out.js.gz": 3776,
+  "a.out.js": 7594,
+  "a.out.js.gz": 3728,
   "a.out.nodebug.wasm": 19588,
   "a.out.nodebug.wasm.gz": 9025,
-  "total": 27247,
-  "total_gz": 12801,
+  "total": 27182,
+  "total_gz": 12753,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/code_size/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/code_size/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 8086,
-  "a.out.js.gz": 3977,
+  "a.out.js": 8021,
+  "a.out.js.gz": 3929,
   "a.out.nodebug.wasm": 19589,
   "a.out.nodebug.wasm.gz": 9025,
-  "total": 27675,
-  "total_gz": 13002,
+  "total": 27610,
+  "total_gz": 12954,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/code_size/test_codesize_minimal_wasmfs.json
+++ b/test/code_size/test_codesize_minimal_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2327,
-  "a.out.js.gz": 1149,
+  "a.out.js": 2251,
+  "a.out.js.gz": 1100,
   "a.out.nodebug.wasm": 62,
   "a.out.nodebug.wasm.gz": 76,
-  "total": 2389,
-  "total_gz": 1225,
+  "total": 2313,
+  "total_gz": 1176,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_small_js_flags.json
+++ b/test/code_size/test_small_js_flags.json
@@ -1,4 +1,4 @@
 {
-  "a.out.js": 2763,
-  "a.out.js.gz": 1494
+  "a.out.js": 2677,
+  "a.out.js.gz": 1456
 }

--- a/test/code_size/test_unoptimized_code_size.json
+++ b/test/code_size/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 53881,
-  "hello_world.js.gz": 17016,
+  "hello_world.js": 51572,
+  "hello_world.js.gz": 16461,
   "hello_world.wasm": 15127,
   "hello_world.wasm.gz": 7448,
-  "no_asserts.js": 26352,
-  "no_asserts.js.gz": 8789,
+  "no_asserts.js": 25482,
+  "no_asserts.js.gz": 8606,
   "no_asserts.wasm": 12227,
   "no_asserts.wasm.gz": 6008,
-  "strict.js": 51919,
-  "strict.js.gz": 16352,
+  "strict.js": 49734,
+  "strict.js.gz": 15824,
   "strict.wasm": 15127,
   "strict.wasm.gz": 7445,
-  "total": 174633,
-  "total_gz": 63058
+  "total": 169269,
+  "total_gz": 61792
 }

--- a/test/other/codesize/test_codesize_file_preload.expected.js
+++ b/test/other/codesize/test_codesize_file_preload.expected.js
@@ -461,10 +461,8 @@ async function createWasm() {
     wasmMemory = wasmExports["b"];
     updateMemoryViews();
     assignWasmExports(wasmExports);
-    removeRunDependency("wasm-instantiate");
     return wasmExports;
   }
-  addRunDependency("wasm-instantiate");
   // Prefer streaming instantiation if available.
   function receiveInstantiationResult(result) {
     // 'result' is a ResultObject object which has both the module and instance.
@@ -500,25 +498,6 @@ var callRuntimeCallbacks = callbacks => {
 var onPreRuns = [];
 
 var addOnPreRun = cb => onPreRuns.push(cb);
-
-var runDependencies = 0;
-
-var dependenciesFulfilled = null;
-
-var removeRunDependency = id => {
-  runDependencies--;
-  if (runDependencies == 0) {
-    if (dependenciesFulfilled) {
-      var callback = dependenciesFulfilled;
-      dependenciesFulfilled = null;
-      callback();
-    }
-  }
-};
-
-var addRunDependency = id => {
-  runDependencies++;
-};
 
 /** @param {number=} offset */ var doWritev = (stream, iov, iovcnt, offset) => {
   var ret = 0;
@@ -1324,6 +1303,25 @@ var asyncLoad = async url => {
 var FS_createDataFile = (...args) => FS.createDataFile(...args);
 
 var getUniqueRunDependency = id => id;
+
+var runDependencies = 0;
+
+var dependenciesFulfilled = null;
+
+var removeRunDependency = id => {
+  runDependencies--;
+  if (runDependencies == 0) {
+    if (dependenciesFulfilled) {
+      var callback = dependenciesFulfilled;
+      dependenciesFulfilled = null;
+      callback();
+    }
+  }
+};
+
+var addRunDependency = id => {
+  runDependencies++;
+};
 
 var preloadPlugins = [];
 
@@ -3210,6 +3208,4 @@ var wasmExports;
 
 // With async instantation wasmExports is assigned asynchronously when the
 // instance is received.
-createWasm();
-
-run();
+createWasm().then(() => run());

--- a/tools/link.py
+++ b/tools/link.py
@@ -1134,7 +1134,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$ExitStatus']
 
     # Certain configurations require the removeRunDependency/addRunDependency system.
-    if settings.LOAD_SOURCE_MAP or settings.PROXY_TO_WORKER or (settings.WASM_ASYNC_COMPILATION and not settings.MODULARIZE):
+    if settings.LOAD_SOURCE_MAP or settings.PROXY_TO_WORKER:
       settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$addRunDependency', '$removeRunDependency']
 
   if settings.ABORT_ON_WASM_EXCEPTIONS or settings.SPLIT_MODULE:


### PR DESCRIPTION
Instead we can just delay the `run` call until after the async createWasm function returns/resolves.

This results in a nice code size saving.