### PR TITLE
Bump the Emscripten cache access timeout warning print from one minute to 10 minutes.

### DIFF
--- a/tools/cache.py
+++ b/tools/cache.py
@@ -41,7 +41,7 @@ def acquire_cache_lock(reason):
     logger.debug(f'PID {os.getpid()} acquiring multiprocess file lock to Emscripten cache at {cachedir}')
     assert 'EM_CACHE_IS_LOCKED' not in os.environ, f'attempt to lock the cache while a parent process is holding the lock ({reason})'
     try:
-      cachelock.acquire(10*60)
+      cachelock.acquire(10 * 60)
     except filelock.Timeout:
       logger.warning(f'Accessing the Emscripten cache at "{cachedir}" (for "{reason}") is taking a long time, another process should be writing to it. If there are none and you suspect this process has deadlocked, try deleting the lock file "{cachelock_name}" and try again. If this occurs deterministically, consider filing a bug.')
       cachelock.acquire()


### PR DESCRIPTION
Originally when I wrote this warning, I added this because we were struggling with the notoriously buggy Python 2.x multiprocessing Pool issues on Windows.

Since then, the size of Emscripten compiled system libraries has grown, and it is common in regular operation, e.g. running `test/runner other` to get a wall of warnings

<img width="1851" height="1560" alt="image" src="https://github.com/user-attachments/assets/26086619-4a63-4b33-89fd-5e81d4c60838" />

even on a very beefy 32-thread CPU.

I don't think we have any known deadlocks here, so bump up the warning period from 1 minute to a higher 10 minutes.