### PR TITLE
Revert "Implement a progress counter to the parallel test suite runne…r. (#25099)"

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -20,14 +20,14 @@ NUM_CORES = None
 seen_class = set()
 
 
-def run_test(test, failfast_event, lock, progress_counter, num_tests):
+def run_test(test, failfast_event):
   # If failfast mode is in effect and any of the tests have failed,
   # and then we should abort executing further tests immediately.
   if failfast_event and failfast_event.is_set():
     return None
 
   olddir = os.getcwd()
-  result = BufferedParallelTestResult(lock, progress_counter, num_tests)
+  result = BufferedParallelTestResult()
   temp_dir = tempfile.mkdtemp(prefix='emtest_')
   test.set_temp_dir(temp_dir)
   try:
@@ -85,9 +85,7 @@ class ParallelTestSuite(unittest.BaseTestSuite):
     with multiprocessing.Manager() as manager:
       pool = multiprocessing.Pool(use_cores)
       failfast_event = manager.Event() if self.failfast else None
-      progress_counter = manager.Value('i', 0)
-      lock = manager.Lock()
-      results = [pool.apply_async(run_test, (t, failfast_event, lock, progress_counter, len(tests))) for t in tests]
+      results = [pool.apply_async(run_test, (t, failfast_event)) for t in tests]
       results = [r.get() for r in results]
       results = [r for r in results if r is not None]
 
@@ -147,14 +145,11 @@ class BufferedParallelTestResult:
 
   Fulfills the interface for unittest.TestResult
   """
-  def __init__(self, lock, progress_counter, num_tests):
+  def __init__(self):
     self.buffered_result = None
     self.test_duration = 0
     self.test_result = 'errored'
     self.test_name = ''
-    self.lock = lock
-    self.progress_counter = progress_counter
-    self.num_tests = num_tests
 
   @property
   def test(self):
@@ -181,39 +176,33 @@ class BufferedParallelTestResult:
     # these results get passed back to the TextTestRunner/TextTestResult.
     self.buffered_result.duration = self.test_duration
 
-  def compute_progress(self):
-    with self.lock:
-      val = f'[{int(self.progress_counter.value * 100 / self.num_tests)}%]'
-      self.progress_counter.value += 1
-    return val
-
   def addSuccess(self, test):
-    print(self.compute_progress(), test, '... ok (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
+    print(test, '... ok (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
     self.buffered_result = BufferedTestSuccess(test)
     self.test_result = 'success'
 
   def addExpectedFailure(self, test, err):
-    print(self.compute_progress(), test, '... expected failure (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
+    print(test, '... expected failure (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
     self.buffered_result = BufferedTestExpectedFailure(test, err)
     self.test_result = 'expected failure'
 
   def addUnexpectedSuccess(self, test):
-    print(self.compute_progress(), test, '... unexpected success (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
+    print(test, '... unexpected success (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
     self.buffered_result = BufferedTestUnexpectedSuccess(test)
     self.test_result = 'unexpected success'
 
   def addSkip(self, test, reason):
-    print(self.compute_progress(), test, "... skipped '%s'" % reason, file=sys.stderr)
+    print(test, "... skipped '%s'" % reason, file=sys.stderr)
     self.buffered_result = BufferedTestSkip(test, reason)
     self.test_result = 'skipped'
 
   def addFailure(self, test, err):
-    print(self.compute_progress(), test, '... FAIL', file=sys.stderr)
+    print(test, '... FAIL', file=sys.stderr)
     self.buffered_result = BufferedTestFailure(test, err)
     self.test_result = 'failed'
 
   def addError(self, test, err):
-    print(self.compute_progress(), test, '... ERROR', file=sys.stderr)
+    print(test, '... ERROR', file=sys.stderr)
     self.buffered_result = BufferedTestError(test, err)
     self.test_result = 'errored'
 


### PR DESCRIPTION
This reverts commit e1283677a2465fdd8215d7a086d9404c83103f3c.

See https://github.com/emscripten-core/emscripten/issues/25103

This is not ready for prime time.

On several runs, Python loses multiprocessing lock.
On one run, Python crashes in a mystery last print `object address  : 0x7bd9d7d28cc0` and then non-zero exit code: http://clbri.com:8010/api/v2/logs/36405/raw_inline