### PR TITLE
Optimize test_relaxed_simd_implies_simd128

### DIFF
--- a/test/sse/hello_sse.cpp
+++ b/test/sse/hello_sse.cpp
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <xmmintrin.h>
+
+// Calculate length of a 4D float vector using SSE1
+float vec4_length_sse(const float v[4]) {
+  __m128 x = _mm_loadu_ps(v);          // load vector
+  __m128 sq = _mm_mul_ps(x, x);        // square each element
+  __m128 shuf = _mm_shuffle_ps(sq, sq, _MM_SHUFFLE(2, 3, 0, 1)); // swap pairs
+  __m128 sums = _mm_add_ps(sq, shuf);  // add pairwise
+  shuf = _mm_movehl_ps(shuf, sums);    // high half -> low
+  sums = _mm_add_ss(sums, shuf);       // add final two
+  return _mm_cvtss_f32(_mm_sqrt_ss(sums)); // sqrt of sum of squares
+}
+
+int main() {
+  float v[4] = { 3, 4, 0, 0 };
+  printf("Length of a triangle with sides 3 and 4 is %f.\n", vec4_length_sse(v));
+}

--- a/test/sse/hello_sse.out
+++ b/test/sse/hello_sse.out
@@ -1,0 +1,1 @@
+Length of a triangle with sides 3 and 4 is 5.000000.

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6779,8 +6779,9 @@ void* operator new(size_t size) {
 
   @wasm_relaxed_simd
   def test_relaxed_simd_implies_simd128(self):
-    src = test_file('sse/test_sse1.cpp')
-    self.build(src, cflags=['-msse'])
+    # When using -msse, one has to also add -msimd128.
+    # This test verifies passing -mrelaxed-simd also implies -msimd128.
+    self.do_run_in_out_file_test('sse/hello_sse.cpp', cflags=['-msse'])
 
   @no_asan('call stack exceeded on some versions of node')
   def test_gcc_unmangler(self):


### PR DESCRIPTION
The test `test_relaxed_simd_implies_simd128` was set to compile test_sse.cpp. But that file is really heavy to compile, making the `test_relaxed_simd_implies_simd128` suite runtime very long:

```
[42%] test_relaxed_simd_implies_simd128 (test_core.strict.test_relaxed_simd_implies_simd128) ... ok (0.64s)
[46%] test_relaxed_simd_implies_simd128 (test_core.minimal0.test_relaxed_simd_implies_simd128) ... ok (0.66s)
[50%] test_relaxed_simd_implies_simd128 (test_core.strict_js.test_relaxed_simd_implies_simd128) ... ok (0.68s)
[53%] test_relaxed_simd_implies_simd128 (test_core.instance.test_relaxed_simd_implies_simd128) ... ok (0.69s)
[57%] test_relaxed_simd_implies_simd128 (test_core.core0.test_relaxed_simd_implies_simd128) ... ok (0.69s)
[61%] test_relaxed_simd_implies_simd128 (test_core.lsan.test_relaxed_simd_implies_simd128) ... ok (0.73s)
[65%] test_relaxed_simd_implies_simd128 (test_core.ubsan.test_relaxed_simd_implies_simd128) ... ok (0.83s)
[69%] test_relaxed_simd_implies_simd128 (test_core.core_2gb.test_relaxed_simd_implies_simd128) ... ok (0.89s)
[73%] test_relaxed_simd_implies_simd128 (test_core.core1.test_relaxed_simd_implies_simd128) ... ok (1.18s)
[76%] test_relaxed_simd_implies_simd128 (test_core.asan.test_relaxed_simd_implies_simd128) ... ok (1.23s)
[80%] test_relaxed_simd_implies_simd128 (test_core.core2.test_relaxed_simd_implies_simd128) ... ok (2.51s)
[84%] test_relaxed_simd_implies_simd128 (test_core.wasmfs.test_relaxed_simd_implies_simd128) ... ok (2.53s)
[88%] test_relaxed_simd_implies_simd128 (test_core.corez.test_relaxed_simd_implies_simd128) ... ok (2.65s)
[92%] test_relaxed_simd_implies_simd128 (test_core.cores.test_relaxed_simd_implies_simd128) ... ok (3.00s)
[96%] test_relaxed_simd_implies_simd128 (test_core.core3.test_relaxed_simd_implies_simd128) ... ok (15.52s)
Total core time: 34.546s. Wallclock time: 15.684s. Parallelization: 2.20x.
```

The test intent is to only verify that passing `-msimd128` implies passing `-msse`, so adjust the test to compile a simple hello world program, resulting in:

```
[42%] test_relaxed_simd_implies_simd128 (test_core.minimal0.test_relaxed_simd_implies_simd128) ... ok (0.57s)
[46%] test_relaxed_simd_implies_simd128 (test_core.strict.test_relaxed_simd_implies_simd128) ... ok (0.57s)
[50%] test_relaxed_simd_implies_simd128 (test_core.core1.test_relaxed_simd_implies_simd128) ... ok (0.61s)
[53%] test_relaxed_simd_implies_simd128 (test_core.strict_js.test_relaxed_simd_implies_simd128) ... ok (0.62s)
[57%] test_relaxed_simd_implies_simd128 (test_core.core0.test_relaxed_simd_implies_simd128) ... ok (0.62s)
[61%] test_relaxed_simd_implies_simd128 (test_core.instance.test_relaxed_simd_implies_simd128) ... ok (0.63s)
[65%] test_relaxed_simd_implies_simd128 (test_core.lsan.test_relaxed_simd_implies_simd128) ... ok (0.64s)
[69%] test_relaxed_simd_implies_simd128 (test_core.ubsan.test_relaxed_simd_implies_simd128) ... ok (0.66s)
[73%] test_relaxed_simd_implies_simd128 (test_core.core_2gb.test_relaxed_simd_implies_simd128) ... ok (0.85s)
[76%] test_relaxed_simd_implies_simd128 (test_core.wasmfs.test_relaxed_simd_implies_simd128) ... ok (1.00s)
[80%] test_relaxed_simd_implies_simd128 (test_core.core2.test_relaxed_simd_implies_simd128) ... ok (0.99s)
[84%] test_relaxed_simd_implies_simd128 (test_core.asan.test_relaxed_simd_implies_simd128) ... ok (1.15s)
[88%] test_relaxed_simd_implies_simd128 (test_core.corez.test_relaxed_simd_implies_simd128) ... ok (1.70s)
[92%] test_relaxed_simd_implies_simd128 (test_core.cores.test_relaxed_simd_implies_simd128) ... ok (1.70s)
[96%] test_relaxed_simd_implies_simd128 (test_core.core3.test_relaxed_simd_implies_simd128) ... ok (1.71s)
Total core time: 14.118s. Wallclock time: 1.874s. Parallelization: 7.53x.
```

