### PR TITLE
Workaround old Python broken multiprocessing shared data structures

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -22,6 +22,7 @@ seen_class = set()
 
 # Older Python versions have a bug with multiprocessing shared data
 # structures. https://github.com/emscripten-core/emscripten/issues/25103
+# and https://github.com/python/cpython/issues/71936
 def python_multiprocessing_structures_are_buggy():
   v = sys.version_info
   return (v.major, v.minor, v.micro) <= (3, 12, 7) or (v.major, v.minor, v.micro) == (3, 13, 0)

--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -201,32 +201,32 @@ class BufferedParallelTestResult:
     return val
 
   def addSuccess(self, test):
-    print(f'{self.compute_progress()}{test}', '... ok (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
+    print(f'{self.compute_progress()}{test} ... ok ({self.calculateElapsed():.2f}s)', file=sys.stderr)
     self.buffered_result = BufferedTestSuccess(test)
     self.test_result = 'success'
 
   def addExpectedFailure(self, test, err):
-    print(f'{self.compute_progress()}{test}', '... expected failure (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
+    print(f'{self.compute_progress()}{test} ... expected failure ({self.calculateElapsed():.2f}s)', file=sys.stderr)
     self.buffered_result = BufferedTestExpectedFailure(test, err)
     self.test_result = 'expected failure'
 
   def addUnexpectedSuccess(self, test):
-    print(f'{self.compute_progress()}{test}', '... unexpected success (%.2fs)' % (self.calculateElapsed()), file=sys.stderr)
+    print(f'{self.compute_progress()}{test} ... unexpected success ({self.calculateElapsed():.2f}s)', file=sys.stderr)
     self.buffered_result = BufferedTestUnexpectedSuccess(test)
     self.test_result = 'unexpected success'
 
   def addSkip(self, test, reason):
-    print(f'{self.compute_progress()}{test}', "... skipped '%s'" % reason, file=sys.stderr)
+    print(f"{self.compute_progress()}{test} ... skipped '{reason}'", file=sys.stderr)
     self.buffered_result = BufferedTestSkip(test, reason)
     self.test_result = 'skipped'
 
   def addFailure(self, test, err):
-    print(f'{self.compute_progress()}{test}', '... FAIL', file=sys.stderr)
+    print(f'{self.compute_progress()}{test} ... FAIL', file=sys.stderr)
     self.buffered_result = BufferedTestFailure(test, err)
     self.test_result = 'failed'
 
   def addError(self, test, err):
-    print(f'{self.compute_progress()}{test}', '... ERROR', file=sys.stderr)
+    print(f'{self.compute_progress()}{test} ... ERROR', file=sys.stderr)
     self.buffered_result = BufferedTestError(test, err)
     self.test_result = 'errored'
 


### PR DESCRIPTION
If running on an old python version that has broken multiprocessing shared data structures, avoid using such data structures. Fixes https://github.com/emscripten-core/emscripten/issues/25103