### PR TITLE
[wasmfs] Fix data race in thread initialization.

### DIFF
--- a/system/lib/wasmfs/thread_utils.h
+++ b/system/lib/wasmfs/thread_utils.h
@@ -24,17 +24,19 @@ namespace emscripten {
 class ProxyWorker {
   // The queue we use to proxy work and the dedicated worker.
   ProxyingQueue queue;
-  std::thread thread;
 
   // Used to notify the calling thread once the worker has been started.
   bool started = false;
   std::mutex mutex;
   std::condition_variable cond;
+  // Declare the thread last since it's dependent on the above member variables.
+  // Declaring it last isn't strictly needed since the thread is initialized in
+  // the body of the constructor, but is done out of caution.
+  std::thread thread;
 
 public:
   // Spawn the worker thread.
-  ProxyWorker()
-    : queue() {
+  ProxyWorker() : queue() {
     // Initialize the thread in the constructor to ensure the object has been
     // fully constructed before thread starts using the object to avoid a data
     // race. See #24370.


### PR DESCRIPTION
The `ProxyWorker` was creating a thread in the constructor initializer list and using a captured reference to the `started` member variable. This is problematic because it is not guaranteed that the class has been fully constructed during the initializer list.

What happens:
1) `ProxyWorker` initializers run
2) Thread starts and sets `started = true`
3) `ProxyWorker` finishes construction and sets `started = false`
4) `ProxyWorker` waits for `started` to be `true`

Step 4 will never finish in this case since the thread already ran.

To fix this we simply need to move the thread creation into the constructor body where the class is guaranteed to be fully constructed.

Fixes #24370, #24676, #20650