### PR TITLE
[test] Re-implement the @all_engines decorator based on parameteraization. NFC

### DIFF
--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -1108,10 +1108,12 @@ function ENVIRONMENT_IS_WORKER_THREAD() {
 }
 
 function nodeDetectionCode() {
-  if (ENVIRONMENT == 'node') {
+  if (ENVIRONMENT == 'node' && ASSERTIONS == 0) {
     // The only environment where this code is intended to run is Node.js.
     // Return unconditional true so that later Closure optimizer will be able to
     // optimize code size.
+    // Note that when ASSERTIONS are enabled we still want to runtime detect
+    // node so that errors can be reported when run elsewhere.
     return 'true';
   }
   return "typeof process == 'object' && process.versions?.node && process.type != 'renderer'";

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8783,6 +8783,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_wrap_malloc(self, args):
     self.do_runf('core/test_wrap_malloc.c', 'OK.', cflags=args)
 
+  @all_engines
   def test_environment(self):
     self.set_setting('ASSERTIONS')
 
@@ -8794,33 +8795,31 @@ NODEFS is no longer included by default; build with -lnodefs.js
         js = read_file(self.output_name('test_hello_world'))
       assert ('require(' in js) == ('node' in self.get_setting('ENVIRONMENT')), 'we should have require() calls only if node js specified'
 
-    for engine in config.JS_ENGINES:
-      print(f'engine: {engine}')
-      # set us to test in just this engine
-      self.require_engine(engine)
-      # tell the compiler to build with just that engine
-      if engine == config.NODE_JS_TEST:
-        right = 'node'
-        wrong = 'shell'
-      else:
-        right = 'shell'
-        wrong = 'node'
-      # test with the right env
-      self.set_setting('ENVIRONMENT', right)
-      print('ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
-      test()
-      # test with the wrong env
-      self.set_setting('ENVIRONMENT', wrong)
-      print('ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
-      try:
-        test(assert_returncode=NON_ZERO)
-        raise Exception('unexpected success')
-      except Exception as e:
-        self.assertContained('not compiled for this environment', str(e))
-      # test with a combined env
-      self.set_setting('ENVIRONMENT', right + ',' + wrong)
-      print('ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
-      test()
+    engine = self.get_current_js_engine()
+    print(f'engine: {engine}')
+    # tell the compiler to build with just that engine
+    if engine == config.NODE_JS_TEST:
+      right = 'node'
+      wrong = 'shell'
+    else:
+      right = 'shell'
+      wrong = 'node'
+    # test with the right env
+    self.set_setting('ENVIRONMENT', right)
+    print('ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
+    test()
+    # test with the wrong env
+    self.set_setting('ENVIRONMENT', wrong)
+    print('ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
+    try:
+      test(assert_returncode=NON_ZERO)
+      raise Exception('unexpected success')
+    except Exception as e:
+      self.assertContained('not compiled for this environment', str(e))
+    # test with a combined env
+    self.set_setting('ENVIRONMENT', right + ',' + wrong)
+    print('ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
+    test()
 
   @requires_node
   def test_postrun_exception(self):


### PR DESCRIPTION
This means that we can remove the loop over JS_ENGINES from few more
tests.
    
It also splits up these tests in to smaller units which is always good
and means that it much more obvious what is going on when one of them
fails.
