### PR TITLE
Switch stderr stream to blocking mode before printing the final log results of the test run.

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -148,6 +148,14 @@ class ParallelTestSuite(unittest.BaseTestSuite):
     # parallel causes mis-orderings, this makes the results more readable.
     results = sorted(buffered_results, key=lambda res: str(res.test))
     result.core_time = 0
+
+    # The next updateResult loop will print a *lot* of lines really fast. This
+    # will cause a Python exception being thrown when attempting to print to
+    # stderr, if stderr is in nonblocking mode, like it is on Buildbot CI:
+    # See https://github.com/buildbot/buildbot/issues/8659
+    # To work around that problem, set stderr to blocking mode before printing.
+    os.set_blocking(sys.stderr.fileno(), True)
+
     for r in results:
       r.updateResult(result)
     return result


### PR DESCRIPTION
Work around https://github.com/buildbot/buildbot/issues/8659 by switching stderr to blocking mode before printing the final log results of the test run.