### PR TITLE
Skip tests that are tested explicitly under minimal runtime

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -615,7 +615,7 @@ def also_with_minimal_runtime(f):
     if DEBUG:
       print('parameterize:minimal_runtime=%s' % with_minimal_runtime)
     if self.get_setting('MINIMAL_RUNTIME'):
-      self.skipTest('This test is verified for minimal runtime in the regular build modes, so running it in minimal0 suite does not apply.')
+      self.skipTest('MINIMAL_RUNTIME already enabled in test config')
     if with_minimal_runtime:
       if self.get_setting('MODULARIZE') == 'instance' or self.get_setting('WASM_ESM_INTEGRATION'):
         self.skipTest('MODULARIZE=instance is not compatible with MINIMAL_RUNTIME')

--- a/test/common.py
+++ b/test/common.py
@@ -614,7 +614,8 @@ def also_with_minimal_runtime(f):
   def metafunc(self, with_minimal_runtime, *args, **kwargs):
     if DEBUG:
       print('parameterize:minimal_runtime=%s' % with_minimal_runtime)
-    assert self.get_setting('MINIMAL_RUNTIME') is None
+    if self.get_setting('MINIMAL_RUNTIME'):
+      self.skipTest('This test is verified for minimal runtime in the regular build modes, so running it in minimal0 suite does not apply.')
     if with_minimal_runtime:
       if self.get_setting('MODULARIZE') == 'instance' or self.get_setting('WASM_ESM_INTEGRATION'):
         self.skipTest('MODULARIZE=instance is not compatible with MINIMAL_RUNTIME')


### PR DESCRIPTION
Skip tests that are tested explicitly under minimal runtime, from being run in minimal0 test mode.

This way tests that verify minimal runtime behavior as part of e.g. `core0`, `core1` and so on, won't croak when attempted to be run under `minimal0.test_foo` - they are already covered so that mode doesn't apply.