### PR TITLE
fix a bug in FS.getattr

### DIFF
--- a/src/lib/libfs.js
+++ b/src/lib/libfs.js
@@ -983,7 +983,7 @@ FS.staticInit();`;
       var node = stream.node;
       var getattr = stream.stream_ops.getattr;
       var arg = getattr ? stream : node;
-      getattr ??= node.node_ops.getattr;
+      getattr ??= node.node_ops.getattr.bind(node.node_ops);
       FS.checkOpExists(getattr, {{{ cDefs.EPERM }}})
       return getattr(arg);
     },


### PR DESCRIPTION
The implementation of BFS's getattr requires a 'this' and calling it without this always fails.

<img width="837" height="220" alt="image" src="https://github.com/user-attachments/assets/61a568a3-5cd2-4632-8254-b2882d771499" />
