### PR TITLE
Add `FS.mkdirTree` function to File System API documentation

### DIFF
--- a/site/source/docs/api_reference/Filesystem-API.rst
+++ b/site/source/docs/api_reference/Filesystem-API.rst
@@ -297,6 +297,20 @@ File system API
   :param int mode: :ref:`File permissions <fs-read-and-write-flags>` for the new node. The default setting (`in octal numeric notation <http://en.wikipedia.org/wiki/File_system_permissions#Numeric_notation>`_) is 0777.
 
 
+.. js:function:: FS.mkdirTree(path, mode)
+
+  Creates a new directory node and all parent directories in the file system. For example:
+
+  .. code-block:: javascript
+
+    FS.mkdirTree('/data/subdir1/subdir2');
+
+  .. note:: The underlying implementation does not support user or group permissions. The caller is always treated as the owner of the folder, and only permissions relevant to the owner apply.
+
+  :param string path: The path name for the new directory node.  
+  :param int mode: :ref:`File permissions <fs-read-and-write-flags>` for the new node. The default setting (`in octal numeric notation <http://en.wikipedia.org/wiki/File_system_permissions#Numeric_notation>`_) is 0777.
+
+
 .. js:function:: FS.mkdev(path, mode, dev)
 
   Creates a new device node in the file system referencing the registered device driver (:js:func:`FS.registerDevice`) for ``dev``. For example:


### PR DESCRIPTION
resolve : #25031

Introduced a new function `FS.mkdirTree` for creating directories and parent directories in the file system.
