### PR TITLE
Fix parallel test runner on Windows

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -14,6 +14,7 @@ import unittest
 import common
 
 from tools.shared import cap_max_workers_in_pool
+from tools.utils import WINDOWS
 
 
 NUM_CORES = None
@@ -154,7 +155,8 @@ class ParallelTestSuite(unittest.BaseTestSuite):
     # stderr, if stderr is in nonblocking mode, like it is on Buildbot CI:
     # See https://github.com/buildbot/buildbot/issues/8659
     # To work around that problem, set stderr to blocking mode before printing.
-    os.set_blocking(sys.stderr.fileno(), True)
+    if not WINDOWS:
+      os.set_blocking(sys.stderr.fileno(), True)
 
     for r in results:
       r.updateResult(result)


### PR DESCRIPTION
After https://github.com/emscripten-core/emscripten/pull/25118 , I start getting on Windows:

```
Traceback (most recent call last):
  File "C:\emsdk\emscripten\main\test\runner.py", line 599, in <module>
    sys.exit(main())
             ~~~~^^
  File "C:\emsdk\emscripten\main\test\runner.py", line 588, in main
    num_failures = run_tests(options, suites)
  File "C:\emsdk\emscripten\main\test\runner.py", line 434, in run_tests
    res = testRunner.run(suite)
  File "C:\Python313\Lib\unittest\runner.py", line 240, in run
    test(result)
    ~~~~^^^^^^^^
  File "C:\Python313\Lib\unittest\suite.py", line 84, in __call__
    return self.run(*args, **kwds)
           ~~~~~~~~^^^^^^^^^^^^^^^
  File "C:\emsdk\emscripten\main\test\parallel_testsuite.py", line 130, in run
    return self.combine_results(result, results)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "C:\emsdk\emscripten\main\test\parallel_testsuite.py", line 159, in combine_results
    os.set_blocking(sys.stderr.fileno(), True)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: [WinError 1] Incorrect function
```

but only if running locally on Windows. If I run the Windows runners on CI, the above error does not occur (which is why I didn't observe it in the first place).

The issue https://github.com/emscripten-core/emscripten/pull/25118 never reproduced on Windows in the first place, so this looks ok from that perspective.