### PR TITLE
Fix export of unsigned WebAssembly globals when they grow > 2GB in size.

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1629,17 +1629,23 @@ addToLibrary({
     var global_object = this;
 #endif
 
-    for (var __exportedFunc in wasmExports) {
-      var jsname = asmjsMangle(__exportedFunc);
+    for (var [name, exportedSymbol] of Object.entries(wasmExports)) {
+      name = asmjsMangle(name);
 #if DYNCALLS || !WASM_BIGINT
-      if (jsname.startsWith('dynCall_')) {
-        dynCalls[jsname.substr(8)] = wasmExports[__exportedFunc];
+      if (name.startsWith('dynCall_')) {
+        dynCalls[name.substr(8)] = exportedSymbol;
       }
 #endif
+      if (exportedSymbol instanceof WebAssembly.Global) {
+        // Globals are currently statically enumerated into the output JS.
+        // TODO: If the number of Globals grows large, consider giving them a
+        // similar DECLARE_ASM_MODULE_EXPORTS = 0 treatment.
+        continue;
+      }
 #if MINIMAL_RUNTIME
-      global_object[jsname] = wasmExports[__exportedFunc];
+      global_object[name] = exportedSymbol;
 #else
-      global_object[jsname] = Module[jsname] = wasmExports[__exportedFunc];
+      global_object[name] = Module[name] = exportedSymbol;
 #endif
     }
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8640,6 +8640,7 @@ Module.onRuntimeInitialized = () => {
           if (typeof _emscripten_stack_get_base === 'function' &&
               typeof _emscripten_stack_get_end === 'function' &&
               typeof _emscripten_stack_get_current === 'function' &&
+              typeof Module['___heap_base'] === 'number' &&
               Module['___heap_base'] > 0) {
              out('able to run memprof');
              return 0;

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -280,6 +280,13 @@ def create_global_exports(global_exports):
       continue
 
     v = int(v)
+
+    # Cast the global to an unsigned value from the signed Wasm int32, if it is one of the fields
+    # that have a semantic unsigned meaning.
+    unsigned_globals = ['__stack_base', '__memory_base', '__table_base', '__global_base', '__heap_base']
+    if k in unsigned_globals:
+      v = v & 0xFFFFFFFF
+
     if settings.RELOCATABLE:
       v += settings.GLOBAL_BASE
     mangled = asmjs_mangle(k)


### PR DESCRIPTION
Fix export of unsigned WebAssembly globals when they grow > 2GB in size. Fix DECLARE_ASM_MODULE_EXPORTS=0 mode globals export.

Fixes test `core_2gb.test_memprof_requirements`.