### PR TITLE
Remove `shell=True` from `rebaseline_tests.py`. NFC

### DIFF
--- a/test/runner.py
+++ b/test/runner.py
@@ -576,6 +576,10 @@ def main():
     tests = skip_requested_tests(tests, modules)
     tests = args_for_random_tests(tests, modules)
 
+  if not tests:
+    print('ERROR: no tests to run')
+    return 1
+
   if not options.start_at and options._continue:
     if os.path.exists(common.LAST_TEST):
       options.start_at = utils.read_file(common.LAST_TEST).strip()

--- a/tools/maint/rebaseline_tests.py
+++ b/tools/maint/rebaseline_tests.py
@@ -20,7 +20,7 @@ script_dir = os.path.dirname(os.path.abspath(__file__))
 root_dir = os.path.dirname(os.path.dirname(script_dir))
 
 sys.path.insert(0, root_dir)
-from tools import utils
+from tools import utils, shared
 
 TESTS = [
   'other.test_small_js_flags',
@@ -86,7 +86,7 @@ def main():
       print('tree is not clean')
       return 1
 
-    subprocess.check_call([os.path.join('test', 'runner'), '--rebaseline', '--browser=0'] + TESTS, cwd=root_dir, shell=True)
+    subprocess.check_call([shared.bat_suffix(os.path.join('test', 'runner')), '--rebaseline', '--browser=0'] + TESTS, cwd=root_dir)
 
   output = run(['git', 'status', '-uno', '--porcelain'])
   filenames = []


### PR DESCRIPTION
This was added in #25142 to fix windows but inadvertently broke linux.

Turns out the `shell=True` means that first argument should be a single string, and not and array of arguments.  For some reason using an array along with `shell=True` was causing `subprocess.check_call` to run `test/runner` only without any aguments.