### PR TITLE
Replace emval_get_global. NFC

### DIFF
--- a/test/code_size/test_minimal_runtime_code_size_hello_embind_val.json
+++ b/test/code_size/test_minimal_runtime_code_size_hello_embind_val.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 373,
-  "a.js": 5356,
-  "a.js.gz": 2526,
+  "a.js": 5350,
+  "a.js.gz": 2527,
   "a.wasm": 5852,
   "a.wasm.gz": 2743,
-  "total": 11760,
-  "total_gz": 5642
+  "total": 11754,
+  "total_gz": 5643
 }

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7504,10 +7504,14 @@ void* operator new(size_t size) {
     do_test(test2, level=2, prefix='hello_libcxx')
 
   @parameterized({
-    '': (['-lembind', '-sDYNAMIC_EXECUTION=0'],),
+    '': (['-lembind'],),
     'flag': (['--bind'],),
+    'legacy': (['--bind', '-sLEGACY_VM_SUPPORT'],),
+    'no_dynamic': (['--bind', '-sDYNAMIC_EXECUTION=0', '-sLEGACY_VM_SUPPORT'],),
   })
   def test_embind_val_basics(self, args):
+    if '-sLEGACY_VM_SUPPORT' in args and (self.get_setting('MODULARIZE') == 'instance' or self.get_setting('WASM_ESM_INTEGRATION')):
+      self.skipTest('LEGACY_VM_SUPPORT is not compatible with EXPORT_ES6')
     self.maybe_closure()
     self.do_run_in_out_file_test('embind/test_embind_val_basics.cpp', cflags=args)
 


### PR DESCRIPTION
- Use a constant `emGlobalThis` instead of a function call
- Calculate the constant once at startup time if its needed.

The plan is to then use this library symbol whenever we need access to globalThis.