### PR TITLE
Replace globalThis polyfill in exportWasmSymbols. NFC 

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1650,20 +1650,12 @@ addToLibrary({
 #if !DECLARE_ASM_MODULE_EXPORTS
   // When DECLARE_ASM_MODULE_EXPORTS is not set we export native symbols
   // at runtime rather than statically in JS code.
-  $exportWasmSymbols__deps: ['$asmjsMangle'
+  $exportWasmSymbols__deps: ['$asmjsMangle', '$emGlobalThis',
 #if DYNCALLS || !WASM_BIGINT
     , '$dynCalls'
 #endif
   ],
   $exportWasmSymbols: (wasmExports) => {
-#if ENVIRONMENT_MAY_BE_NODE && ENVIRONMENT_MAY_BE_WEB
-    var global_object = (typeof process != "undefined" ? global : this);
-#elif ENVIRONMENT_MAY_BE_NODE
-    var global_object = global;
-#else
-    var global_object = this;
-#endif
-
     for (var [name, exportedSymbol] of Object.entries(wasmExports)) {
       name = asmjsMangle(name);
 #if DYNCALLS || !WASM_BIGINT
@@ -1676,9 +1668,9 @@ addToLibrary({
       // similar DECLARE_ASM_MODULE_EXPORTS = 0 treatment.
       if (typeof exportedSymbol.value === 'undefined') {
 #if MINIMAL_RUNTIME
-        global_object[name] = exportedSymbol;
+        emGlobalThis[name] = exportedSymbol;
 #else
-        global_object[name] = Module[name] = exportedSymbol;
+        emGlobalThis[name] = Module[name] = exportedSymbol;
 #endif
       }
     }

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5008,11 +5008,13 @@ Module["preRun"] = () => {
     self.btest_exit('declare_asm_module_exports.c', cflags=['-sDECLARE_ASM_MODULE_EXPORTS=0', '-sENVIRONMENT=web', '-O3', '--closure=1', '-sWASM=0'] + args)
 
   @parameterized({
-    '': (1,),
-    '2': (2,),
+    '': ([],),
+    'strict_js': (['-sSTRICT_JS'],),
+    'minimal_runtime': (['-sMINIMAL_RUNTIME=1'],),
+    'minimal_runtime_2': (['-sMINIMAL_RUNTIME=2'],),
   })
-  def test_no_declare_asm_module_exports_wasm_minimal_runtime(self, mode):
-    self.btest_exit('declare_asm_module_exports.c', cflags=['-sDECLARE_ASM_MODULE_EXPORTS=0', '-sENVIRONMENT=web', '-O3', '--closure=1', f'-sMINIMAL_RUNTIME={mode}'])
+  def test_no_declare_asm_module_exports(self, args):
+    self.btest_exit('declare_asm_module_exports.c', cflags=['-sDECLARE_ASM_MODULE_EXPORTS=0', '-sENVIRONMENT=web', '-O3', '--closure=1'] + args)
 
   # Tests that the different code paths in src/shell_minimal_runtime.html all work ok.
   @parameterized({


### PR DESCRIPTION
This polyfill is code a duplicate of the `emGlobalThis` polyfill.