### PR TITLE
Fix strict.test_embind_val_basics_legacy and strict.test_embind_val_basics_no_dynamic.

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -522,8 +522,6 @@ def transpile(filename):
     config['targets']['chrome'] = str(settings.MIN_CHROME_VERSION)
   if settings.MIN_FIREFOX_VERSION != UNSUPPORTED:
     config['targets']['firefox'] = str(settings.MIN_FIREFOX_VERSION)
-  if settings.MIN_IE_VERSION != UNSUPPORTED:
-    config['targets']['ie'] = str(settings.MIN_IE_VERSION)
   if settings.MIN_SAFARI_VERSION != UNSUPPORTED:
     config['targets']['safari'] = version_split(settings.MIN_SAFARI_VERSION)
   if settings.MIN_NODE_VERSION != UNSUPPORTED:


### PR DESCRIPTION
They were failing with

```
======================================================================
FAIL: test_embind_val_basics_legacy (test_core.strict.test_embind_val_basics_legacy)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/clb/.pyenv/versions/3.13.3/lib/python3.13/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/home/clb/.pyenv/versions/3.13.3/lib/python3.13/unittest/case.py", line 651, in run
    self._callTestMethod(testMethod)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/clb/.pyenv/versions/3.13.3/lib/python3.13/unittest/case.py", line 606, in _callTestMethod
    if method() is not None:
       ~~~~~~^^
  File "/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/common.py", line 1021, in resulting_test
    return func(self, *args)
  File "/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/test_core.py", line 7520, in test_embind_val_basics
    self.do_run_in_out_file_test('embind/test_embind_val_basics.cpp', cflags=args)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/common.py", line 2099, in do_run_in_out_file_test
    output = self._build_and_run(srcfile, expected, **kwargs)
  File "/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/common.py", line 2118, in _build_and_run
    js_file = self.build(filename, **kwargs)
  File "/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/common.py", line 1559, in build
    self.run_process(cmd, stderr=self.stderr_redirect if not DEBUG else None)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/common.py", line 1913, in run_process
    self.fail(f'subprocess exited with non-zero return code({e.returncode}): `{shlex.join(cmd)}`')
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/clb/.pyenv/versions/3.13.3/lib/python3.13/unittest/case.py", line 732, in fail
    raise self.failureException(msg)
AssertionError: subprocess exited with non-zero return code(1): `/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/em++ /home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/embind/test_embind_val_basics.cpp -o test_embind_val_basics.js -sNO_DEFAULT_TO_CXX -sSTRICT -Wclosure -Werror -Wno-limited-postlink-optimizations -Wno-unused-command-line-argument --bind -sLEGACY_VM_SUPPORT`

======================================================================
FAIL: test_embind_val_basics_no_dynamic (test_core.strict.test_embind_val_basics_no_dynamic)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/clb/.pyenv/versions/3.13.3/lib/python3.13/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/home/clb/.pyenv/versions/3.13.3/lib/python3.13/unittest/case.py", line 651, in run
    self._callTestMethod(testMethod)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/clb/.pyenv/versions/3.13.3/lib/python3.13/unittest/case.py", line 606, in _callTestMethod
    if method() is not None:
       ~~~~~~^^
  File "/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/common.py", line 1021, in resulting_test
    return func(self, *args)
  File "/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/test_core.py", line 7520, in test_embind_val_basics
    self.do_run_in_out_file_test('embind/test_embind_val_basics.cpp', cflags=args)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/common.py", line 2099, in do_run_in_out_file_test
    output = self._build_and_run(srcfile, expected, **kwargs)
  File "/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/common.py", line 2118, in _build_and_run
    js_file = self.build(filename, **kwargs)
  File "/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/common.py", line 1559, in build
    self.run_process(cmd, stderr=self.stderr_redirect if not DEBUG else None)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/common.py", line 1913, in run_process
    self.fail(f'subprocess exited with non-zero return code({e.returncode}): `{shlex.join(cmd)}`')
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/clb/.pyenv/versions/3.13.3/lib/python3.13/unittest/case.py", line 732, in fail
    raise self.failureException(msg)
AssertionError: subprocess exited with non-zero return code(1): `/home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/em++ /home/clb/buildbot/h12dsi-linux-mint22/emscripten_linux_x64/build/emscripten/main/test/embind/test_embind_val_basics.cpp -o test_embind_val_basics.js -sNO_DEFAULT_TO_CXX -sSTRICT -Wclosure -Werror -Wno-limited-postlink-optimizations -Wno-unused-command-line-argument --bind -sDYNAMIC_EXECUTION=0 -sLEGACY_VM_SUPPORT`

----------------------------------------------------------------------
```
MIN_IE_VERSION is no longer a setting.