### PR TITLE
[ci] Increase EMCC_CORES for test-wasm64-4gb test suite. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -662,8 +662,6 @@ jobs:
   test-wasm64-4gb:
     environment:
       LANG: "C.UTF-8"
-      # Only run 2 tests at a time to avoid OOM (since each test used >4gb)
-      EMCC_CORES: "2"
     # We don't use `bionic` here since its too old to run recent node versions:
     # `/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found`
     executor: linux-python


### PR DESCRIPTION
Since the CI didn't report any OOMs for this suite I assume this should be safe to land.

Test time goes from ~35 or ~21 minutes.