### PR TITLE
Fix for webpack + SINGLE_FILE + WASM=0

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -413,8 +413,17 @@ function instrumentWasmTableWithAbort() {
 #if !SOURCE_PHASE_IMPORTS && !WASM_ESM_INTEGRATION
 var wasmBinaryFile;
 
+#if WASM2JS && WASM != 2
+
+// When building with wasm2js these 3 functions all no-ops.
+function findWasmBinary(file) {}
+function getBinarySync(file) {}
+function getWasmBinary(file) {}
+
+#else
+
 function findWasmBinary() {
-#if SINGLE_FILE && WASM == 1 && !WASM2JS
+#if SINGLE_FILE
   return base64Decode('<<< WASM_BINARY_DATA >>>');
 #else
 #if EXPORT_ES6 && !AUDIO_WORKLET
@@ -435,7 +444,7 @@ function findWasmBinary() {
 }
 
 function getBinarySync(file) {
-#if SINGLE_FILE && WASM == 1 && !WASM2JS
+#if SINGLE_FILE
   if (ArrayBuffer.isView(file)) {
     return file;
   }
@@ -474,6 +483,7 @@ async function getWasmBinary(binaryFile) {
   // Otherwise, getBinarySync should be able to get it synchronously
   return getBinarySync(binaryFile);
 }
+#endif
 
 #if SPLIT_MODULE
 {{{ makeModuleReceiveWithVar('loadSplitModule', undefined, 'instantiateSync') }}}
@@ -572,8 +582,8 @@ async function instantiateArrayBuffer(binaryFile, imports) {
 
 #if ASSERTIONS
     // Warn on some common problems.
-    if (isFileURI(wasmBinaryFile)) {
-      err(`warning: Loading from a file URI (${wasmBinaryFile}) is not supported in most browsers. See https://emscripten.org/docs/getting_started/FAQ.html#how-do-i-run-a-local-webserver-for-testing-why-does-my-program-stall-in-downloading-or-preparing`);
+    if (isFileURI(binaryFile)) {
+      err(`warning: Loading from a file URI (${binaryFile}) is not supported in most browsers. See https://emscripten.org/docs/getting_started/FAQ.html#how-do-i-run-a-local-webserver-for-testing-why-does-my-program-stall-in-downloading-or-preparing`);
     }
 #endif
     abort(reason);

--- a/test/code_size/test_codesize_hello_O0.json
+++ b/test/code_size/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 22485,
-  "a.out.js.gz": 8317,
+  "a.out.js.gz": 8312,
   "a.out.nodebug.wasm": 15127,
   "a.out.nodebug.wasm.gz": 7450,
   "total": 37612,
-  "total_gz": 15767,
+  "total_gz": 15762,
   "sent": [
     "fd_write"
   ],

--- a/test/code_size/test_codesize_minimal_O0.json
+++ b/test/code_size/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 17746,
-  "a.out.js.gz": 6620,
+  "a.out.js.gz": 6616,
   "a.out.nodebug.wasm": 1136,
   "a.out.nodebug.wasm.gz": 659,
   "total": 18882,
-  "total_gz": 7279,
+  "total_gz": 7275,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/code_size/test_unoptimized_code_size.json
+++ b/test/code_size/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 54027,
-  "hello_world.js.gz": 17075,
+  "hello_world.js": 54019,
+  "hello_world.js.gz": 17072,
   "hello_world.wasm": 15127,
   "hello_world.wasm.gz": 7450,
   "no_asserts.js": 26497,
   "no_asserts.js.gz": 8849,
   "no_asserts.wasm": 12227,
   "no_asserts.wasm.gz": 6010,
-  "strict.js": 52065,
-  "strict.js.gz": 16409,
+  "strict.js": 52057,
+  "strict.js.gz": 16407,
   "strict.wasm": 15127,
   "strict.wasm.gz": 7447,
-  "total": 175070,
-  "total_gz": 63240
+  "total": 175054,
+  "total_gz": 63235
 }

--- a/test/other/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/other/codesize/test_codesize_minimal_O0.expected.js
@@ -598,8 +598,8 @@ async function instantiateArrayBuffer(binaryFile, imports) {
     err(`failed to asynchronously prepare wasm: ${reason}`);
 
     // Warn on some common problems.
-    if (isFileURI(wasmBinaryFile)) {
-      err(`warning: Loading from a file URI (${wasmBinaryFile}) is not supported in most browsers. See https://emscripten.org/docs/getting_started/FAQ.html#how-do-i-run-a-local-webserver-for-testing-why-does-my-program-stall-in-downloading-or-preparing`);
+    if (isFileURI(binaryFile)) {
+      err(`warning: Loading from a file URI (${binaryFile}) is not supported in most browsers. See https://emscripten.org/docs/getting_started/FAQ.html#how-do-i-run-a-local-webserver-for-testing-why-does-my-program-stall-in-downloading-or-preparing`);
     }
     abort(reason);
   }


### PR DESCRIPTION
Without this fix the output code contains a references to the non-existent wasm file URL.

Fixes: #25012