### PR TITLE
Do not halve the number of used cores in testing

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -33,7 +33,7 @@ def python_multiprocessing_structures_are_buggy():
 
 
 def cap_max_workers_in_pool(max_workers, is_browser):
-  if is_browser and os.getenv('EMTEST_CORES') is None:
+  if is_browser and 'EMTEST_CORES' not in os.environ and 'EMCC_CORES' not in os.environ:
     # TODO experiment with this number. In browser tests we'll be creating
     # a chrome instance per worker which is expensive.
     max_workers = max_workers // 2

--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -33,10 +33,10 @@ def python_multiprocessing_structures_are_buggy():
 
 
 def cap_max_workers_in_pool(max_workers, is_browser):
-  if is_browser:
+  if is_browser and os.getenv('EMTEST_CORES') is None:
     # TODO experiment with this number. In browser tests we'll be creating
     # a chrome instance per worker which is expensive.
-    max_workers = int(max_workers / 2)
+    max_workers = max_workers // 2
   # Python has an issue that it can only use max 61 cores on Windows: https://github.com/python/cpython/issues/89240
   if WINDOWS:
     return min(max_workers, 61)


### PR DESCRIPTION
Do not halve the number of used cores if the user has explicitly specified the number of cores to use in testing.

It is a bit silly to have to say `export EMTEST_CORES=128` to get 64 cores in actuality.