### PR TITLE
Fix @flaky handler to catch subprocess.TimeoutExpired exception.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -246,7 +246,7 @@ def flaky(note=''):
       for i in range(EMTEST_RETRY_FLAKY):
         try:
           return f(*args, **kwargs)
-        except AssertionError as exc:
+        except (AssertionError, subprocess.TimeoutExpired) as exc:
           preserved_exc = exc
           logging.info(f'Retrying flaky test "{f.__name__}" (attempt {i}/{EMTEST_RETRY_FLAKY} failed): {exc}')
           # Mark down that this was a flaky test.


### PR DESCRIPTION
Fix flaky handler to catch subprocess.TimeoutExpired exception. This way test_main_thread_em_asm_pthread will actually be attempted to be repeated as flaky. https://github.com/emscripten-core/emscripten/issues/25175

E.g. flaky failure at http://clbri.com:8010/api/v2/logs/49999/raw_inline was not caught and treated as flaky.

Also fixes flaky handling of test_pthread_dlopen_many: http://clbri.com:8010/api/v2/logs/50283/raw_inline , https://github.com/emscripten-core/emscripten/issues/18887

