### PR TITLE
Mark other.test_gen_struct_info as flaky.

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13781,6 +13781,7 @@ exec "$@"
     self.assertIn('Hello from lib!', result)
 
   @crossplatform
+  @flaky('https://github.com/emscripten-core/emscripten/issues/25206')
   def test_gen_struct_info(self):
     # This test will start failing whenever the struct info changes (e.g. offset or defines
     # change).  However it's easy to rebaseline with --rebaseline.


### PR DESCRIPTION
Mark other.test_gen_struct_info as flaky. https://github.com/emscripten-core/emscripten/issues/25206