### PR TITLE
Fix race condition in assigning the pthread_t object in main thread

### DIFF
--- a/test/code_size/test_codesize_minimal_pthreads.json
+++ b/test/code_size/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7659,
   "a.out.js.gz": 3776,
-  "a.out.nodebug.wasm": 19592,
-  "a.out.nodebug.wasm.gz": 9060,
-  "total": 27251,
-  "total_gz": 12836,
+  "a.out.nodebug.wasm": 19599,
+  "a.out.nodebug.wasm.gz": 9063,
+  "total": 27258,
+  "total_gz": 12839,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/code_size/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/code_size/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 8086,
   "a.out.js.gz": 3977,
-  "a.out.nodebug.wasm": 19593,
-  "a.out.nodebug.wasm.gz": 9061,
-  "total": 27679,
-  "total_gz": 13038,
+  "a.out.nodebug.wasm": 19600,
+  "a.out.nodebug.wasm.gz": 9064,
+  "total": 27686,
+  "total_gz": 13041,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/pthread/test_pthread_proxying_reduced_stress_test_case.c
+++ b/test/pthread/test_pthread_proxying_reduced_stress_test_case.c
@@ -1,0 +1,28 @@
+#include <emscripten/proxying.h>
+#include <emscripten.h>
+#include <stdio.h>
+
+pthread_t main_thread, looper, returner, worker, worker2;
+em_proxying_queue* proxy_queue = NULL;
+
+void* dummy(void* arg) { return NULL; }
+void dummy2(void* arg) {}
+
+void* worker2_main(void* arg) {
+  pthread_t self = pthread_self();
+  const char* name = pthread_equal(self, worker2) ? "worker2" : "unknown";
+  printf("pthread_self() == %s (%p)\n", name, (void*)self);
+  return NULL;
+}
+
+int main(int argc, char* argv[]) {
+  main_thread = pthread_self();
+  proxy_queue = em_proxying_queue_create();
+  pthread_create(&looper, NULL, dummy, NULL);
+  pthread_create(&returner, NULL, dummy, NULL);
+  emscripten_proxy_callback(proxy_queue, pthread_self(), dummy2, dummy2, NULL, NULL);
+  pthread_create(&worker, NULL, dummy, 0);
+  pthread_join(worker, NULL);
+  pthread_create(&worker2, NULL, worker2_main, 0);
+  pthread_join(worker2, NULL);
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2581,7 +2581,6 @@ The current type of b is: 9
 
   @node_pthreads
   @also_with_modularize
-  @flaky('https://github.com/emscripten-core/emscripten/issues/25026')
   def test_pthread_proxying(self):
     if '-sMODULARIZE' in self.cflags:
       if self.get_setting('WASM') == 0:

--- a/test/test_stress.py
+++ b/test/test_stress.py
@@ -102,15 +102,13 @@ class stress(RunnerCore):
   @also_with_modularize
   @is_slow_test
   def test_stress_pthread_proxying(self):
-    self.skipTest('https://github.com/emscripten-core/emscripten/issues/25026')
     if '-sMODULARIZE' in self.cflags:
       if self.get_setting('WASM') == 0:
         self.skipTest('MODULARIZE + WASM=0 + pthreads does not work (#16794)')
       self.set_setting('EXPORT_NAME=ModuleFactory')
-    self.maybe_closure()
     self.set_setting('PROXY_TO_PTHREAD')
     if not self.has_changed_setting('INITIAL_MEMORY'):
       self.set_setting('INITIAL_MEMORY=32mb')
 
-    js_file = self.build('pthread/test_pthread_proxying.c')
-    self.parallel_stress_test_js_file(js_file, not_expected='running widget 17 on unknown', expected='running widget 17 on worker', assert_returncode=0)
+    js_file = self.build('pthread/test_pthread_proxying_reduced_stress_test_case.c')
+    self.parallel_stress_test_js_file(js_file, not_expected='pthread_self() == unknown', expected='pthread_self() == worker2', assert_returncode=0)


### PR DESCRIPTION
Fix race condition in assigning the pthread_t object in main thread, when creating a pthread. Fixes #25026.

Also reduce the stress test case for `test_stress_pthread_proxying` so that it runs faster and reproduces more often.