### PR TITLE
Fix typo in install_debug_wrapper()

### DIFF
--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -900,7 +900,7 @@ def install_debug_wrapper(sym):
   # The emscripten stack functions are called very early (by writeStackCookie) before
   # the runtime is initialized so we can't create these wrappers that check for
   # runtimeInitialized.
-  if sym.startswith(('_asan_', 'emscripten_stack_', '_emscripten_stack_')):
+  if sym.startswith(('__asan_', 'emscripten_stack_', '_emscripten_stack_')):
     return False
   # Likewise `__trap` can occur before the runtime is initialized since it is used in
   # abort.


### PR DESCRIPTION
Fix typo in install_debug_wrapper() that accidentally caused export wrappers to be created for all asan funtions, like __asan_loadN() and __asan_storeN(). These functions are 'low-level assembly functions' that operate outside the Emscripten C runtime being alive or not, similar to e.g. the stack init functions.