### PR TITLE
Update documentation on -sEXIT_RUNTIME.

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -95,12 +95,15 @@ exception, but will not shut down the runtime.
 Set this to 1 if you do want to retain the ability to shut down the program.
 If 1, then completing main() will by default call exit(), unless a refcount
 keeps the runtime alive. Call emscripten_exit_with_live_runtime() to finish
-main() while keeping the runtime alive. Calling exit() will shut down the
-runtime, invoking atexit()s, and flushing stdio streams.
+main() while keeping the runtime alive. Calling emscripten_force_exit() will
+shut down the runtime, invoking atexit()s, and flushing stdio streams.
 This setting is controlled automatically in STANDALONE_WASM mode:
 
 - For a command (has a main function) this is always 1
 - For a reactor (no main function) this is always 0
+
+For more details, see documentation for emscripten_force_exit() and
+emscripten_exit_with_live_runtime().
 
 Default value: false
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -93,13 +93,15 @@ var INVOKE_RUN = true;
 // Set this to 1 if you do want to retain the ability to shut down the program.
 // If 1, then completing main() will by default call exit(), unless a refcount
 // keeps the runtime alive. Call emscripten_exit_with_live_runtime() to finish
-// main() while keeping the runtime alive. Calling exit() will shut down the
-// runtime, invoking atexit()s, and flushing stdio streams.
+// main() while keeping the runtime alive. Calling emscripten_force_exit() will
+// shut down the runtime, invoking atexit()s, and flushing stdio streams.
 // This setting is controlled automatically in STANDALONE_WASM mode:
 //
 // - For a command (has a main function) this is always 1
 // - For a reactor (no main function) this is always 0
 //
+// For more details, see documentation for emscripten_force_exit() and
+// emscripten_exit_with_live_runtime().
 // [link]
 var EXIT_RUNTIME = false;
 


### PR DESCRIPTION
Closes https://github.com/emscripten-core/emscripten/issues/25217

Update documentation to reflect the current state of affairs for the meaning of `-sEXIT_RUNTIME`.