### PR TITLE
Fix shlex splitting when launching parallel browser test runner on Windows.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -2517,29 +2517,25 @@ class BrowserCore(RunnerCore):
         EMTEST_BROWSER = '"' + EMTEST_BROWSER.replace("\\", "/") + '"'
     browser_args = shlex.split(EMTEST_BROWSER)
 
-    try:
-      if EMTEST_BROWSER_AUTO_CONFIG:
-        logger.info('Using default CI configuration.')
-        cls.browser_data_dir = DEFAULT_BROWSER_DATA_DIR
-        if worker_id is not None:
-          # Running in parallel mode, give each browser its own profile dir.
-          cls.browser_data_dir += '-' + str(worker_id)
-        if os.path.exists(cls.browser_data_dir):
-          utils.delete_dir(cls.browser_data_dir)
-        os.mkdir(cls.browser_data_dir)
-        if is_chrome():
-          config = ChromeConfig()
-        elif is_firefox():
-          config = FirefoxConfig()
-        else:
-          exit_with_error("EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome.")
-        browser_args += config.data_dir_cmdline(cls.browser_data_dir) + list(config.default_flags)
-        if EMTEST_HEADLESS == 1:
-          browser_args += config.headless_flags
-        config.configure(cls.browser_data_dir)
-    except Exception as e:
-      print(str(e))
-      sys.exit(1)
+    if EMTEST_BROWSER_AUTO_CONFIG:
+      logger.info('Using default CI configuration.')
+      cls.browser_data_dir = DEFAULT_BROWSER_DATA_DIR
+      if worker_id is not None:
+        # Running in parallel mode, give each browser its own profile dir.
+        cls.browser_data_dir += '-' + str(worker_id)
+      if os.path.exists(cls.browser_data_dir):
+        utils.delete_dir(cls.browser_data_dir)
+      os.mkdir(cls.browser_data_dir)
+      if is_chrome():
+        config = ChromeConfig()
+      elif is_firefox():
+        config = FirefoxConfig()
+      else:
+        exit_with_error("EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome.")
+      browser_args += config.data_dir_cmdline(cls.browser_data_dir) + list(config.default_flags)
+      if EMTEST_HEADLESS == 1:
+        browser_args += config.headless_flags
+      config.configure(cls.browser_data_dir)
 
     logger.info('Launching browser: %s', str(browser_args))
     cls.browser_proc = subprocess.Popen(browser_args + [url])

--- a/test/common.py
+++ b/test/common.py
@@ -91,7 +91,7 @@ flaky_tests_log_filename = os.path.join(path_from_root('out/flaky_tests.txt'))
 
 # Default flags used to run browsers in CI testing:
 class ChromeConfig:
-  default_flags = [
+  default_flags = (
     # --no-sandbox because we are running as root and chrome requires
     # this flag for now: https://crbug.com/638180
     '--no-first-run -start-maximized --no-sandbox --enable-unsafe-swiftshader --use-gl=swiftshader --enable-experimental-web-platform-features --enable-features=JavaScriptSourcePhaseImports',
@@ -103,7 +103,7 @@ class ChromeConfig:
     '--disk-cache-size=1 --media-cache-size=1 --disable-application-cache',
     # Disable various background tasks downloads (e.g. updates).
     '--disable-background-networking',
-  ]
+  )
   headless_flags = ['--headless=new', '--window-size=1024,768']
 
   @staticmethod
@@ -116,7 +116,7 @@ class ChromeConfig:
 
 
 class FirefoxConfig:
-  default_flags = []
+  default_flags = ()
   headless_flags = ['-headless']
 
   @staticmethod
@@ -2533,7 +2533,7 @@ class BrowserCore(RunnerCore):
           config = FirefoxConfig()
         else:
           exit_with_error("EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome.")
-        browser_args += config.data_dir_cmdline(cls.browser_data_dir) + config.default_flags
+        browser_args += config.data_dir_cmdline(cls.browser_data_dir) + list(config.default_flags)
         if EMTEST_HEADLESS == 1:
           browser_args += [config.headless_flags]
         config.configure(cls.browser_data_dir)

--- a/test/common.py
+++ b/test/common.py
@@ -108,7 +108,7 @@ class ChromeConfig:
 
   @staticmethod
   def data_dir_cmdline(data_dir):
-    return f'--user-data-dir={data_dir}'
+    return [f'--user-data-dir={data_dir}']
 
   @staticmethod
   def configure(data_dir):

--- a/test/common.py
+++ b/test/common.py
@@ -97,7 +97,8 @@ class ChromeConfig:
     '--no-first-run', '-start-maximized', '--no-sandbox', '--enable-unsafe-swiftshader', '--use-gl=swiftshader',
     '--enable-experimental-web-platform-features', '--enable-features=JavaScriptSourcePhaseImports',
     '--enable-experimental-webassembly-features',
-    '--js-flags="--experimental-wasm-stack-switching --experimental-wasm-type-reflection --experimental-wasm-rab-integration"',
+    # N.b. the following JS engine flags are passed to --js-flags=, and must appear as one element in this list.
+    '--js-flags=--experimental-wasm-stack-switching --experimental-wasm-type-reflection --experimental-wasm-rab-integration',
     # The runners lack sound hardware so fallback to a dummy device (and
     # bypass the user gesture so audio tests work without interaction)
     '--use-fake-device-for-media-stream', '--autoplay-policy=no-user-gesture-required',

--- a/test/common.py
+++ b/test/common.py
@@ -2535,7 +2535,7 @@ class BrowserCore(RunnerCore):
           exit_with_error("EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome.")
         browser_args += config.data_dir_cmdline(cls.browser_data_dir) + list(config.default_flags)
         if EMTEST_HEADLESS == 1:
-          browser_args += [config.headless_flags]
+          browser_args += config.headless_flags
         config.configure(cls.browser_data_dir)
     except Exception as e:
       print(str(e))

--- a/test/common.py
+++ b/test/common.py
@@ -94,13 +94,15 @@ class ChromeConfig:
   default_flags = (
     # --no-sandbox because we are running as root and chrome requires
     # this flag for now: https://crbug.com/638180
-    '--no-first-run -start-maximized --no-sandbox --enable-unsafe-swiftshader --use-gl=swiftshader --enable-experimental-web-platform-features --enable-features=JavaScriptSourcePhaseImports',
-    '--enable-experimental-webassembly-features --js-flags="--experimental-wasm-stack-switching --experimental-wasm-type-reflection --experimental-wasm-rab-integration"',
+    '--no-first-run', '-start-maximized', '--no-sandbox', '--enable-unsafe-swiftshader', '--use-gl=swiftshader',
+    '--enable-experimental-web-platform-features', '--enable-features=JavaScriptSourcePhaseImports',
+    '--enable-experimental-webassembly-features',
+    '--js-flags="--experimental-wasm-stack-switching --experimental-wasm-type-reflection --experimental-wasm-rab-integration"',
     # The runners lack sound hardware so fallback to a dummy device (and
     # bypass the user gesture so audio tests work without interaction)
-    '--use-fake-device-for-media-stream --autoplay-policy=no-user-gesture-required',
+    '--use-fake-device-for-media-stream', '--autoplay-policy=no-user-gesture-required',
     # Cache options.
-    '--disk-cache-size=1 --media-cache-size=1 --disable-application-cache',
+    '--disk-cache-size=1', '--media-cache-size=1', '--disable-application-cache',
     # Disable various background tasks downloads (e.g. updates).
     '--disable-background-networking',
   )


### PR DESCRIPTION
Fix shlex splitting when launching parallel browser test runner on Windows.

Before this PR, running

```
set EMTEST_BROWSER=C:\Program Files\Mozilla Firefox\firefox.exe
test\runner browser
```
would fail with the parallel test harness attempting to launch browser command line

`["C:\Program Files\Mozilla Firefox\firefox.exe -profile C:\emsdk\emscripten\main\out\profile-1"]`

when it should instead have attempted to launch command line

`["C:\Program Files\Mozilla Firefox\firefox.exe", "-profile", "C:\emsdk\emscripten\main\out\profile-1"]`

Fix by having the browser config first do the shlex stuff to interpret `EMTEST_BROWSER`, and only then append the list of strings of command line args, rather than first append the command line args as a string spaghetti, and using shlex split to parse the resulting command line string.