### PR TITLE
Export `requestFullscreen` by default when targeting default shell html

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -1049,6 +1049,9 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     else:
       options.shell_path = DEFAULT_SHELL_HTML
 
+  if options.oformat == OFormat.HTML and options.shell_path == DEFAULT_SHELL_HTML:
+    settings.EXPORTED_RUNTIME_METHODS.append('requestFullscreen')
+
   if settings.STRICT:
     if not settings.MODULARIZE:
       default_setting('STRICT_JS', 1)


### PR DESCRIPTION
This was broken by #24269 but it seems we don't have automated tests for it.

Fixes: #25203