### PR TITLE
TYPO: Fix typo in pkg config option for zlib

### DIFF
--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -23,7 +23,7 @@ def get(ports, settings, shared):
     zconf_h = os.path.join(os.path.dirname(__file__), 'zlib/zconf.h')
     shutil.copyfile(zconf_h, os.path.join(source_path, 'zconf.h'))
     ports.install_headers(source_path)
-    ports.make_pkg_config('zlib', VERSION, '-sUSE_ZIB')
+    ports.make_pkg_config('zlib', VERSION, '-sUSE_ZLIB')
 
     # build
     srcs = 'adler32.c compress.c crc32.c deflate.c gzclose.c gzlib.c gzread.c gzwrite.c infback.c inffast.c inflate.c inftrees.c trees.c uncompr.c zutil.c'.split()


### PR DESCRIPTION
Addresses #25227 

I'm not sure the best way to add testing for this, the best I can think of is duplicating the [existing tests for `bullet`](https://github.com/sbc100/emscripten/blob/ede0b27e12db07978f5cd3e028874030a9e5847c/test/test_other.py#L1094-L1101). I'm happy to add these in if they are useful.