### PR TITLE
[test] Remove unnecessary `@requires_v8`. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -787,6 +787,7 @@ jobs:
             other.test_native_call_before_init
             other.test_node_unhandled_rejection
             other.test_*growable_arraybuffers
+            other.test_add_js_function_bigint_memory64
             core2.test_hello_world
             core2.test_esm_integration*
             core0.test_esm_integration*

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15600,7 +15600,6 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     'memory64': (True, False),
     '': (False, False),
   })
-  @requires_v8
   def test_add_js_function_bigint(self, memory64, wasm_function):
     if memory64:
       self.require_wasm64()


### PR DESCRIPTION
This was interfering with the `requires_wasm64` in the test body making the test fail on node v24 and above.

This decorator was added back in #19306 I suppose because `WebAssembly.Function` was available in v8 back then?