### PR TITLE
Fix parallel test suite handling of EMTEST_BROWSER, attempt 2

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -2525,7 +2525,7 @@ class BrowserCore(RunnerCore):
         exit_with_error("EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome.")
       if WINDOWS:
         # Remove directory delimiter backslashes to avoid shlex.split getting confused.
-        cls.browser_data_dir = cls.browser_data_dir.replace('\\', '/')
+        browser_data_dir = browser_data_dir.replace('\\', '/')
       EMTEST_BROWSER += f" {config.data_dir_flag}\"{browser_data_dir}\" {' '.join(config.default_flags)}"
       if EMTEST_HEADLESS == 1:
         EMTEST_BROWSER += f" {config.headless_flags}"


### PR DESCRIPTION
Fix parallel test suite handling of EMTEST_BROWSER, attempt 2. Keep the browser cmdline as a string salad, and don't convert to a list.