### PR TITLE
Fix browser profile directory deletion to repeat deleting if it doesn't succeed.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -2508,8 +2508,7 @@ class BrowserCore(RunnerCore):
       if worker_id is not None:
         # Running in parallel mode, give each browser its own profile dir.
         cls.browser_data_dir += '-' + str(worker_id)
-      if os.path.exists(cls.browser_data_dir):
-        utils.delete_dir(cls.browser_data_dir)
+      utils.persistent_delete_dir(cls.browser_data_dir)
       os.mkdir(cls.browser_data_dir)
       if is_chrome():
         config = ChromeConfig()

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -97,6 +97,26 @@ def delete_dir(dirname):
   shutil.rmtree(dirname)
 
 
+def persistent_delete_dir(dirname):
+  """Delete a directory that has just been released from use.
+  This variant keeps re-attempting the delete until access
+  to the directory is released. E.g. on Windows when attempting
+  to delete a Firefox profile directory right after Firefox
+  has shut down can result in an error.
+  "PermissionError: [Errno 13] The process cannot access the file
+  because it is being used by another process: 'xxx.sqlite'"
+  """
+  tries = 10
+  while os.path.isdir(dirname):
+    try:
+      shutil.rmtree(dirname)
+    except PermissionError as e:
+      if tries == 0:
+        raise e
+      time.sleep(1)
+      tries -= 1
+
+
 def delete_contents(dirname, exclude=None):
   """Delete the contents of a directory without removing
   the directory itself."""


### PR DESCRIPTION
Fix browser profile directory deletion to repeat deleting if it doesn't succeed.

Fixes a large spam of

```
======================================================================
ERROR: test_sdl_touch (test_browser.browser.test_sdl_touch)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Python313\Lib\unittest\case.py", line 58, in testPartExecutor
    yield
  File "C:\Python313\Lib\unittest\case.py", line 651, in run
    self._callTestMethod(testMethod)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "C:\Python313\Lib\unittest\case.py", line 606, in _callTestMethod
    if method() is not None:
       ~~~~~~^^
  File "C:\buildbot\win11-x64-64gb-9800x3d\emscripten_win11_x64\build\emscripten\main\test\common.py", line 1029, in resulting_test
    return func(self, *args)
  File "C:\buildbot\win11-x64-64gb-9800x3d\emscripten_win11_x64\build\emscripten\main\test\test_browser.py", line 2803, in test_sdl_touch
    self.btest_exit('test_sdl_touch.c', cflags=opts + ['-DAUTOMATE_SUCCESS=1', '-lSDL', '-lGL'])
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\buildbot\win11-x64-64gb-9800x3d\emscripten_win11_x64\build\emscripten\main\test\common.py", line 2699, in btest_exit
    return self.btest(filename, *args, **kwargs)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\buildbot\win11-x64-64gb-9800x3d\emscripten_win11_x64\build\emscripten\main\test\common.py", line 2729, in btest
    self.run_browser(outfile, expected=['/report_result?' + e for e in expected], timeout=timeout, extra_tries=extra_tries)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\buildbot\win11-x64-64gb-9800x3d\emscripten_win11_x64\build\emscripten\main\test\common.py", line 2627, in run_browser
    self.browser_restart()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "C:\buildbot\win11-x64-64gb-9800x3d\emscripten_win11_x64\build\emscripten\main\test\common.py", line 2505, in browser_restart
    cls.browser_open(cls.HARNESS_URL)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "C:\buildbot\win11-x64-64gb-9800x3d\emscripten_win11_x64\build\emscripten\main\test\common.py", line 2530, in browser_open
    utils.delete_dir(cls.browser_data_dir)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "C:\buildbot\win11-x64-64gb-9800x3d\emscripten_win11_x64\build\emscripten\main\tools\utils.py", line 97, in delete_dir
    shutil.rmtree(dirname)
    ~~~~~~~~~~~~~^^^^^^^^^
  File "C:\Python313\Lib\shutil.py", line 790, in rmtree
    return _rmtree_unsafe(path, onexc)
  File "C:\Python313\Lib\shutil.py", line 629, in _rmtree_unsafe
    onexc(os.unlink, fullname, err)
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python313\Lib\shutil.py", line 625, in _rmtree_unsafe
    os.unlink(fullname)
    ~~~~~~~~~^^^^^^^^^^
PermissionError: [Errno 13] The process cannot access the file because it is being used by another process: 'C:\\buildbot\\win11-x64-64gb-9800x3d\\emscripten_win11_x64\\build\\emscripten\\main\\out\\browser-profile-0\\7f47740d.sqlite'
```

errors when browser test suite is attempting a to restart the browser.