### PR TITLE
[testing] Do not automatically retry browser tests on failure.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -2694,7 +2694,7 @@ class BrowserCore(RunnerCore):
             post_build=None,
             cflags=None,
             timeout=None,
-            extra_tries=1,
+            extra_tries=0,
             reporting=Reporting.FULL,
             output_basename='test'):
     assert expected, 'a btest must have an expected output'

--- a/test/common.py
+++ b/test/common.py
@@ -2588,7 +2588,7 @@ class BrowserCore(RunnerCore):
   #                     synchronously, so we have a timeout, which can be hit if the VM
   #                     we run on stalls temporarily), so we let each test try more than
   #                     once by default
-  def run_browser(self, html_file, expected=None, message=None, timeout=None, extra_tries=1):
+  def run_browser(self, html_file, expected=None, message=None, timeout=None, extra_tries=0):
     if not has_browser():
       return
     assert '?' not in html_file, 'URL params not supported'

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3803,8 +3803,7 @@ Module["preRun"] = () => {
   })
   def test_pthread_create(self, args):
     self.btest_exit('pthread/test_pthread_create.c',
-                    cflags=['-pthread', '-sPTHREAD_POOL_SIZE=8'] + args,
-                    extra_tries=0) # this should be 100% deterministic
+                    cflags=['-pthread', '-sPTHREAD_POOL_SIZE=8'] + args)
     files = os.listdir('.')
     if '-sSINGLE_FILE' in args:
       self.assertEqual(len(files), 1, files)
@@ -5404,10 +5403,7 @@ Module["preRun"] = () => {
     self.btest_exit('pthread/test_pthread_proxy_hammer.cpp',
                     cflags=['-pthread', '-O2', '-sPROXY_TO_PTHREAD',
                                '-DITERATIONS=1024', '-g1'] + args,
-                    timeout=10000,
-                    # don't run this with the default extra_tries value, as this is
-                    # *meant* to notice something random, a race condition.
-                    extra_tries=0)
+                    timeout=10000)
 
   def test_assert_failure(self):
     self.btest('test_assert_failure.c', 'abort:Assertion failed: false && "this is a test"')


### PR DESCRIPTION
Running the tests more than once by default is hiding flaky tests. Instead, we should run the tests once and if they become flaky either fix them or explicitly add `extra_tries` to the individual test.