### PR TITLE
Fix parallel test runner harness to run on Firefox on Windows.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,7 @@ module = [
   "ply.*",
 ]
 ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = ["psutil", "win32gui", "win32process"]
+ignore_missing_imports = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@
 
 coverage[toml]==6.5
 mypy==1.14
+psutil==7.0.0
 ruff==0.11.7
 types-requests==2.32.0.20241016
 unittest-xml-reporting==3.2.0

--- a/test/common.py
+++ b/test/common.py
@@ -2537,6 +2537,7 @@ class BrowserCore(RunnerCore):
   # single test (hundreds of minutes)
   MAX_UNRESPONSIVE_TESTS = 10
   BROWSER_TIMEOUT = 60
+  original_EMTEST_BROWSER = None
 
   unresponsive_tests = 0
 
@@ -2572,6 +2573,13 @@ class BrowserCore(RunnerCore):
   @classmethod
   def browser_open(cls, url):
     global EMTEST_BROWSER, worker_id
+
+    # Capture the original value of EMTEST_BROWSER, so that we can modify it
+    # safely.
+    if not BrowserCore.original_EMTEST_BROWSER:
+      BrowserCore.original_EMTEST_BROWSER = EMTEST_BROWSER
+    EMTEST_BROWSER = BrowserCore.original_EMTEST_BROWSER
+
     if WINDOWS and '"' not in EMTEST_BROWSER and "'" not in EMTEST_BROWSER:
       # On Windows env. vars canonically use backslashes as directory delimiters, e.g.
       # set EMTEST_BROWSER=C:\Program Files\Mozilla Firefox\firefox.exe

--- a/test/common.py
+++ b/test/common.py
@@ -2514,20 +2514,17 @@ class FileLock:
 
 
 def move_browser_window(pid, x, y):
-  try:
-    import win32gui
-    import win32process
+  import win32gui
+  import win32process
 
-    def enum_windows_callback(hwnd, _unused):
-      _, win_pid = win32process.GetWindowThreadProcessId(hwnd)
-      if win_pid == pid and win32gui.IsWindowVisible(hwnd):
-        rect = win32gui.GetWindowRect(hwnd)
-        win32gui.MoveWindow(hwnd, x, y, rect[2] - rect[0], rect[3] - rect[1], True)
-      return True
+  def enum_windows_callback(hwnd, _unused):
+    _, win_pid = win32process.GetWindowThreadProcessId(hwnd)
+    if win_pid == pid and win32gui.IsWindowVisible(hwnd):
+      rect = win32gui.GetWindowRect(hwnd)
+      win32gui.MoveWindow(hwnd, x, y, rect[2] - rect[0], rect[3] - rect[1], True)
+    return True
 
-    win32gui.EnumWindows(enum_windows_callback, None)
-  except Exception:
-    pass
+  win32gui.EnumWindows(enum_windows_callback, None)
 
 
 class BrowserCore(RunnerCore):

--- a/test/common.py
+++ b/test/common.py
@@ -2551,7 +2551,7 @@ class BrowserCore(RunnerCore):
           logger.info('Browser did not respond to `terminate`.  Using `kill`')
           proc.kill()
           proc.wait()
-      except psutil.NoSuchProcess:
+      except (psutil.NoSuchProcess, ProcessLookupError):
         pass
 
     cls.browser_data_dir = None

--- a/test/common.py
+++ b/test/common.py
@@ -2585,7 +2585,7 @@ class BrowserCore(RunnerCore):
       # set EMTEST_BROWSER=C:\Program Files\Mozilla Firefox\firefox.exe
       # and spaces are not escaped. But make sure to also support args, e.g.
       # set EMTEST_BROWSER="C:\Users\clb\AppData\Local\Google\Chrome SxS\Application\chrome.exe" --enable-unsafe-webgpu
-      EMTEST_BROWSER = '"' + EMTEST_BROWSER.replace("\\", "/") + '"'
+      EMTEST_BROWSER = '"' + EMTEST_BROWSER.replace("\\", "\\\\") + '"'
 
     if not EMTEST_BROWSER:
       logger.info('No EMTEST_BROWSER set. Defaulting to `google-chrome`')
@@ -2608,7 +2608,7 @@ class BrowserCore(RunnerCore):
         exit_with_error("EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome.")
       if WINDOWS:
         # Remove directory delimiter backslashes to avoid shlex.split getting confused.
-        browser_data_dir = browser_data_dir.replace('\\', '/')
+        browser_data_dir = browser_data_dir.replace('\\', '\\\\')
       EMTEST_BROWSER += f" {config.data_dir_flag}\"{browser_data_dir}\" {' '.join(config.default_flags)}"
       if EMTEST_HEADLESS == 1:
         EMTEST_BROWSER += f" {config.headless_flags}"

--- a/test/common.py
+++ b/test/common.py
@@ -2626,9 +2626,10 @@ class BrowserCore(RunnerCore):
       # the browser to find which subprocesses we launched.
       procs_before = list_processes_by_name(config.executable_name)
       browser_proc = subprocess.Popen(browser_args + [url])
-      # Give Firefox time to spawn it subprocesses.
+      # Give Firefox time to spawn its subprocesses. Use an increasing timeout as
+      # a crude way to account for system load.
       if WINDOWS and is_firefox():
-        time.sleep(2)
+        time.sleep(2 + count * 0.3)
       procs_after = list_processes_by_name(config.executable_name) + [browser_proc]
       cls.browser_procs = list(set(procs_after).difference(set(procs_before)))
       # Make sure that each browser window is visible on the desktop. Otherwise browser might

--- a/test/common.py
+++ b/test/common.py
@@ -116,7 +116,7 @@ class ChromeConfig:
 
 class FirefoxConfig:
   data_dir_flag = '-profile '
-  default_flags = ()
+  default_flags = ('-new-instance',)
   headless_flags = '-headless'
   executable_name = exe_suffix('firefox')
 

--- a/test/common.py
+++ b/test/common.py
@@ -2518,7 +2518,7 @@ def move_browser_window(pid, x, y):
     import win32gui
     import win32process
 
-    def enum_windows_callback(hwnd, data):
+    def enum_windows_callback(hwnd, _unused):
       _, win_pid = win32process.GetWindowThreadProcessId(hwnd)
       if win_pid == pid and win32gui.IsWindowVisible(hwnd):
         rect = win32gui.GetWindowRect(hwnd)

--- a/test/common.py
+++ b/test/common.py
@@ -18,6 +18,7 @@ import itertools
 import json
 import logging
 import os
+import psutil
 import re
 import shlex
 import shutil
@@ -2468,14 +2469,6 @@ def init_worker(counter, lock):
 
 
 def list_processes_by_name(exe_name):
-  try:
-    import psutil
-  except Exception:
-    # If user does not have pip psutil module installed (e.g. PyWin32 on Windows),
-    # then skip this process detection mechanism.
-    logger.debug('Python psutil module is not available. Please install it with "python -m pip install psutil" if you have issues with parallel browser suite, or set EMTEST_CORES=1.')
-    return []
-
   pids = []
   if exe_name:
     for proc in psutil.process_iter():
@@ -2558,7 +2551,7 @@ class BrowserCore(RunnerCore):
           logger.info('Browser did not respond to `terminate`.  Using `kill`')
           proc.kill()
           proc.wait()
-      except Exception:  # Move on if any exception, e.g. psutil.NoSuchProcess
+      except psutil.NoSuchProcess:
         pass
 
     cls.browser_data_dir = None

--- a/test/common.py
+++ b/test/common.py
@@ -2465,13 +2465,14 @@ def init_worker(counter, lock):
 
 
 def list_processes_by_name(exe_name):
-  try:
-    import psutil
-  except Exception:
-    # If user does not have pip psutil module installed (e.g. PyWin32 on Windows),
-    # then skip this process detection mechanism.
-    logger.debug('Python psutil module is not available. Please install it with "python -m pip install psutil" if you have issues with parallel browser suite, or set EMTEST_CORES=1.')
-    return []
+  # XX require for testing
+  import psutil
+#  try:
+#  except Exception:
+#    # If user does not have pip psutil module installed (e.g. PyWin32 on Windows),
+#    # then skip this process detection mechanism.
+#    logger.debug('Python psutil module is not available. Please install it with "python -m pip install psutil" if you have issues with parallel browser suite, or set EMTEST_CORES=1.')
+#    return []
 
   pids = []
   if exe_name:

--- a/test/common.py
+++ b/test/common.py
@@ -2465,14 +2465,13 @@ def init_worker(counter, lock):
 
 
 def list_processes_by_name(exe_name):
-  # XX require for testing
-  import psutil
-#  try:
-#  except Exception:
-#    # If user does not have pip psutil module installed (e.g. PyWin32 on Windows),
-#    # then skip this process detection mechanism.
-#    logger.debug('Python psutil module is not available. Please install it with "python -m pip install psutil" if you have issues with parallel browser suite, or set EMTEST_CORES=1.')
-#    return []
+  try:
+    import psutil
+  except Exception:
+    # If user does not have pip psutil module installed (e.g. PyWin32 on Windows),
+    # then skip this process detection mechanism.
+    logger.debug('Python psutil module is not available. Please install it with "python -m pip install psutil" if you have issues with parallel browser suite, or set EMTEST_CORES=1.')
+    return []
 
   pids = []
   if exe_name:

--- a/test/common.py
+++ b/test/common.py
@@ -2505,7 +2505,7 @@ class FileLock:
 
   def __exit__(self, *a):
     with open(f'{self.path}_counter', 'w') as f:
-      f.write(str(self.counter+1))
+      f.write(str(self.counter + 1))
     os.close(self.fd)
     try:
       os.remove(self.path)

--- a/test/common.py
+++ b/test/common.py
@@ -1407,7 +1407,10 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     if self.runningInParallel() and not EMTEST_SAVE_DIR:
       # rmtree() fails on Windows if the current working directory is inside the tree.
       os.chdir(os.path.dirname(self.get_dir()))
-      force_delete_dir(self.get_dir())
+      try:
+        force_delete_dir(self.get_dir())
+      except PermissionError as e:
+        print(f'WARNING: Failed to delete directory {self.get_dir()}:\n{e}')
 
       if EMTEST_DETECT_TEMPFILE_LEAKS and not DEBUG:
         temp_files_after_run = []

--- a/test/common.py
+++ b/test/common.py
@@ -2547,7 +2547,7 @@ class BrowserCore(RunnerCore):
         # after 2 seconds kill it with force (SIGKILL).
         try:
           proc.wait(2)
-        except subprocess.TimeoutExpired:
+        except (subprocess.TimeoutExpired, psutil.TimeoutExpired):
           logger.info('Browser did not respond to `terminate`.  Using `kill`')
           proc.kill()
           proc.wait()
@@ -2624,14 +2624,16 @@ class BrowserCore(RunnerCore):
       if WINDOWS and is_firefox():
         time.sleep(2 + count * 0.3)
       procs_after = list_processes_by_name(config.executable_name) + [browser_proc]
-      cls.browser_procs = list(set(procs_after).difference(set(procs_before)))
       # Make sure that each browser window is visible on the desktop. Otherwise browser might
       # decide that the tab is backgrounded, and not load a test, or it might not tick rAF()s
       # forward, causing tests to hang.
       if WINDOWS and is_firefox():
+        cls.browser_procs = list(set(procs_after).difference(set(procs_before)))
         for proc in cls.browser_procs:
           # Wrap window positions on a Full HD desktop area modulo primes.
           move_browser_window(proc.pid, (300 + count * 47) % 1901, (10 + count * 37) % 997)
+      else:
+        cls.browser_procs = [browser_proc]
 
   @classmethod
   def setUpClass(cls):

--- a/test/common.py
+++ b/test/common.py
@@ -2597,8 +2597,12 @@ class BrowserCore(RunnerCore):
       if worker_id is not None:
         # Running in parallel mode, give each browser its own profile dir.
         browser_data_dir += '-' + str(worker_id)
-      if os.path.exists(browser_data_dir):
-        utils.delete_dir(browser_data_dir)
+      while os.path.exists(browser_data_dir):
+        try:
+          utils.delete_dir(browser_data_dir)
+        except PermissionError:
+          browser_data_dir += '-another'
+
       os.mkdir(browser_data_dir)
       if is_chrome():
         config = ChromeConfig()

--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -113,6 +113,8 @@ class ParallelTestSuite(unittest.BaseTestSuite):
 
     # Remove any old stale list of flaky tests before starting the run
     utils.delete_file(common.flaky_tests_log_filename)
+    utils.delete_file(utils.path_from_root('out/browser_spawn_lock'))
+    utils.delete_file(utils.path_from_root('out/browser_spawn_lock_counter'))
 
     # If we are running with --failing-and-slow-first, then the test list has been
     # pre-sorted based on previous test run results. Otherwise run the tests in

--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -71,7 +71,10 @@ def run_test(test, failfast_event, lock, progress_counter, num_tests):
   # Before attempting to delete the tmp dir make sure the current
   # working directory is not within it.
   os.chdir(olddir)
-  common.force_delete_dir(temp_dir)
+  try:
+    common.force_delete_dir(temp_dir)
+  except PermissionError as e:
+    print(f'WARNING: Failed to delete directory {temp_dir}:\n{e}')
   return result
 
 


### PR DESCRIPTION
Two problems that I run into with the parallel browser harness on Windows with Firefox:

1. On Windows, all the browser windows open up in the exact same X,Y coordinate. Firefox has "is browser in the background" detection, which causes all but one test foreground harness to hang when running any `requestAnimationFrame()` based test.

2. Killing a Firefox browser process with

```py
proc = subprocess.Popen(['firefox'])
proc.kill()
```

does not work. This is because Firefox is a multiprocess browser, and does not have a process hierarchy where the first launched process would be some kind of a master process. (this is an old known issue, that can be seen also in existing emrun.py code) There seems to be about 12 processes that come alive when running `subprocess.Popen(['firefox'])`.

--------------

To fix these issues:

1. ask the Windows Win32 API to move each spawned process to its own X,Y location. Use a file-based multiprocessing lock + counter file to get unique counter to each process.

2. Snapshot alive processes before spawning Firefox, and after. Then acquire the delta of these two to find which process IDs correspond to the launched Firefox. (I am not 100% sure how watertight this scheme is, but I'm at least getting successful runs with retries now)
