### PR TITLE
Fix weak symbol handling when loading multiple dynamic libraries.

### DIFF
--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -617,14 +617,13 @@ var LibraryDylink = {
     dbg('loadWebAssemblyModule:', libName);
 #endif
     var metadata = getDylinkMetadata(binary);
-    currentModuleWeakSymbols = metadata.weakImports;
-#if ASSERTIONS
-    var originalTable = wasmTable;
-#endif
 
     // loadModule loads the wasm module after all its dependencies have been loaded.
     // can be called both sync/async.
     function loadModule() {
+#if ASSERTIONS
+      var originalTable = wasmTable;
+#endif
 #if PTHREADS
       // The first thread to load a given module needs to allocate the static
       // table and memory regions.  Later threads re-use the same table region
@@ -744,6 +743,7 @@ var LibraryDylink = {
         }
       };
       var proxy = new Proxy({}, proxyHandler);
+      currentModuleWeakSymbols = metadata.weakImports;
       var info = {
         'GOT.mem': new Proxy({}, GOTHandler),
         'GOT.func': new Proxy({}, GOTHandler),

--- a/test/code_size/test_codesize_hello_dylink.json
+++ b/test/code_size/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 26969,
-  "a.out.js.gz": 11478,
+  "a.out.js.gz": 11479,
   "a.out.nodebug.wasm": 18567,
   "a.out.nodebug.wasm.gz": 9199,
   "total": 45536,
-  "total_gz": 20677,
+  "total_gz": 20678,
   "sent": [
     "__heap_base",
     "__indirect_function_table",


### PR DESCRIPTION
The `currentModuleWeakSymbols` global was being set the wrong time which would lead to the wrong set of symbols being used for a given dylib.

Also have another version of this change that removes the global completely but this one is simpler.

Fixes: #25214