### PR TITLE
Fix passing native backslashes to Windows Firefox launch.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -2502,7 +2502,7 @@ class BrowserCore(RunnerCore):
       # set EMTEST_BROWSER=C:\Program Files\Mozilla Firefox\firefox.exe
       # and spaces are not escaped. But make sure to also support args, e.g.
       # set EMTEST_BROWSER="C:\Users\clb\AppData\Local\Google\Chrome SxS\Application\chrome.exe" --enable-unsafe-webgpu
-      EMTEST_BROWSER = '"' + EMTEST_BROWSER.replace("\\", "/") + '"'
+      EMTEST_BROWSER = '"' + EMTEST_BROWSER.replace("\\", "\\\\") + '"'
 
     if not EMTEST_BROWSER:
       logger.info('No EMTEST_BROWSER set. Defaulting to `google-chrome`')
@@ -2525,7 +2525,7 @@ class BrowserCore(RunnerCore):
         exit_with_error("EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome.")
       if WINDOWS:
         # Remove directory delimiter backslashes to avoid shlex.split getting confused.
-        browser_data_dir = browser_data_dir.replace('\\', '/')
+        browser_data_dir = browser_data_dir.replace('\\', '\\\\')
       EMTEST_BROWSER += f" {config.data_dir_flag}\"{browser_data_dir}\" {' '.join(config.default_flags)}"
       if EMTEST_HEADLESS == 1:
         EMTEST_BROWSER += f" {config.headless_flags}"


### PR DESCRIPTION
Fix passing native backslashes to Windows Firefox launch. Otherwise Firefox would treat -profile C:/foo/ to be a URL http:///foo/ to visit.