### PR TITLE
Fix EMTEST_BROWSER command line to not accumulate parameters every time a browser is opened.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -2491,7 +2491,7 @@ def configure_test_browser():
     elif is_firefox():
       config = FirefoxConfig()
     else:
-      exit_with_error(f"EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome. Browser was \"{EMTEST_BROWSER}\"")
+      exit_with_error(f'EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome. Browser was "{EMTEST_BROWSER}"')
     EMTEST_BROWSER += ' ' + ' '.join(config.default_flags)
     if EMTEST_HEADLESS == 1:
       EMTEST_BROWSER += f" {config.headless_flags}"

--- a/test/common.py
+++ b/test/common.py
@@ -2491,7 +2491,7 @@ def configure_test_browser():
     elif is_firefox():
       config = FirefoxConfig()
     else:
-      exit_with_error("EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome.")
+      exit_with_error(f"EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome. Browser was \"{EMTEST_BROWSER}\"")
     EMTEST_BROWSER += ' ' + ' '.join(config.default_flags)
     if EMTEST_HEADLESS == 1:
       EMTEST_BROWSER += f" {config.headless_flags}"

--- a/test/common.py
+++ b/test/common.py
@@ -2526,7 +2526,6 @@ class BrowserCore(RunnerCore):
 
   @classmethod
   def browser_open(cls, url):
-    global worker_id
     browser_args = EMTEST_BROWSER
 
     if EMTEST_BROWSER_AUTO_CONFIG:
@@ -2556,7 +2555,6 @@ class BrowserCore(RunnerCore):
   @classmethod
   def setUpClass(cls):
     super().setUpClass()
-    global worker_id
     cls.PORT = 8888 + (0 if worker_id is None else worker_id)
     cls.SERVER_URL = f'http://localhost:{cls.PORT}'
     cls.HARNESS_URL = f'{cls.SERVER_URL}/run_harness'

--- a/test/common.py
+++ b/test/common.py
@@ -2502,7 +2502,7 @@ class BrowserCore(RunnerCore):
       # set EMTEST_BROWSER=C:\Program Files\Mozilla Firefox\firefox.exe
       # and spaces are not escaped. But make sure to also support args, e.g.
       # set EMTEST_BROWSER="C:\Users\clb\AppData\Local\Google\Chrome SxS\Application\chrome.exe" --enable-unsafe-webgpu
-      EMTEST_BROWSER = '"' + EMTEST_BROWSER.replace("\\", "/") + '"'
+      EMTEST_BROWSER = '"' + EMTEST_BROWSER.replace("\\", "\\\\") + '"'
 
     if not EMTEST_BROWSER:
       logger.info('No EMTEST_BROWSER set. Defaulting to `google-chrome`')
@@ -2525,7 +2525,7 @@ class BrowserCore(RunnerCore):
         exit_with_error("EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome.")
       if WINDOWS:
         # Remove directory delimiter backslashes to avoid shlex.split getting confused.
-        browser_data_dir = browser_data_dir.replace('\\', '/')
+        browser_data_dir = browser_data_dir.replace('\\', '\\\\')
       EMTEST_BROWSER += f" {config.data_dir_flag}\"{browser_data_dir}\" {' '.join(config.default_flags)}"
       if EMTEST_HEADLESS == 1:
         EMTEST_BROWSER += f" {config.headless_flags}"

--- a/test/common.py
+++ b/test/common.py
@@ -2464,6 +2464,9 @@ def init_worker(counter, lock):
 def configure_test_browser():
   global EMTEST_BROWSER
 
+  if not has_browser():
+    return
+
   if WINDOWS and '"' not in EMTEST_BROWSER and "'" not in EMTEST_BROWSER:
     # On Windows env. vars canonically use backslashes as directory delimiters, e.g.
     # set EMTEST_BROWSER=C:\Program Files\Mozilla Firefox\firefox.exe

--- a/test/common.py
+++ b/test/common.py
@@ -2524,7 +2524,7 @@ class BrowserCore(RunnerCore):
       else:
         exit_with_error("EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome.")
       if WINDOWS:
-        # Remove directory delimiter backslashes to avoid shlex.split getting confused.
+        # Escape directory delimiter backslashes for shlex.split.
         browser_data_dir = browser_data_dir.replace('\\', '\\\\')
       EMTEST_BROWSER += f" {config.data_dir_flag}\"{browser_data_dir}\" {' '.join(config.default_flags)}"
       if EMTEST_HEADLESS == 1:

--- a/test/common.py
+++ b/test/common.py
@@ -2485,7 +2485,6 @@ def configure_test_browser():
     EMTEST_BROWSER = 'google-chrome'
 
   if EMTEST_BROWSER_AUTO_CONFIG:
-    logger.info('Using default CI configuration.')
     config = None
     if is_chrome():
       config = ChromeConfig()
@@ -2535,6 +2534,7 @@ class BrowserCore(RunnerCore):
     browser_args = EMTEST_BROWSER
 
     if EMTEST_BROWSER_AUTO_CONFIG:
+      logger.info('Using default CI configuration.')
       browser_data_dir = DEFAULT_BROWSER_DATA_DIR
       if worker_id is not None:
         # Running in parallel mode, give each browser its own profile dir.

--- a/test/common.py
+++ b/test/common.py
@@ -2486,15 +2486,15 @@ def configure_test_browser():
 
   if EMTEST_BROWSER_AUTO_CONFIG:
     logger.info('Using default CI configuration.')
+    config = None
     if is_chrome():
       config = ChromeConfig()
     elif is_firefox():
       config = FirefoxConfig()
-    else:
-      exit_with_error(f'EMTEST_BROWSER_AUTO_CONFIG only currently works with firefox or chrome. Browser was "{EMTEST_BROWSER}"')
-    EMTEST_BROWSER += ' ' + ' '.join(config.default_flags)
-    if EMTEST_HEADLESS == 1:
-      EMTEST_BROWSER += f" {config.headless_flags}"
+    if config:
+      EMTEST_BROWSER += ' ' + ' '.join(config.default_flags)
+      if EMTEST_HEADLESS == 1:
+        EMTEST_BROWSER += f" {config.headless_flags}"
 
 
 class BrowserCore(RunnerCore):

--- a/test/runner.py
+++ b/test/runner.py
@@ -512,6 +512,8 @@ def configure():
   assert 'PARALLEL_SUITE_EMCC_CORES' not in os.environ, 'use EMTEST_CORES rather than PARALLEL_SUITE_EMCC_CORES'
   parallel_testsuite.NUM_CORES = os.environ.get('EMTEST_CORES') or os.environ.get('EMCC_CORES')
 
+  common.configure_test_browser()
+
 
 def main():
   options = parse_args()


### PR DESCRIPTION
Fix EMTEST_BROWSER command line to not accumulate parameters every time a browser is opened.

This prevents the `-profile ...` directive and other command line args from stacking up on every browser terminate + restart.