### PR TITLE
Remove unnecessary hasOwnProperty call. NFC

### DIFF
--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1313,11 +1313,11 @@ var LibraryDylink = {
 #if ASSERTIONS
     assert(lib, `Tried to dlsym() from an unopened handle: ${handle}`);
 #endif
-    if (!lib.exports.hasOwnProperty(symbol) || lib.exports[symbol].stub) {
+    newSymIndex = Object.keys(lib.exports).indexOf(symbol);
+    if (newSymIndex == -1 || lib.exports[symbol]?.stub) {
       dlSetError(`Tried to lookup unknown symbol "${symbol}" in dynamic lib: ${lib.name}`)
       return 0;
     }
-    newSymIndex = Object.keys(lib.exports).indexOf(symbol);
 #if !WASM_BIGINT
     var origSym = 'orig$' + symbol;
     result = lib.exports[origSym];

--- a/test/code_size/test_codesize_hello_dylink_all.json
+++ b/test/code_size/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 246044,
+  "a.out.js": 246022,
   "a.out.nodebug.wasm": 597767,
-  "total": 843811,
+  "total": 843789,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
This was causing issues with another patch I'm working on and I realized we can simply remove it for code size win.