### PR TITLE
Add reporting of flaky tests in browser suite

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -203,6 +203,8 @@ class ParallelTestSuite(unittest.BaseTestSuite):
     # shared data structures are hard in the python multi-processing world, so
     # use a file to share the flaky test information across test processes.
     flaky_tests = open(common.flaky_tests_log_filename).read().split() if os.path.isfile(common.flaky_tests_log_filename) else []
+    # Extract only the test short names
+    flaky_tests = [x.split('.')[-1] for x in flaky_tests]
 
     # The next updateResult loop will print a *lot* of lines really fast. This
     # will cause a Python exception being thrown when attempting to print to


### PR DESCRIPTION
Add reporting of flaky tests in browser suite to get orange colored swimlane visualizations of flake, and unify reporting of flaky tests in browser and core suites.

EMTEST_VISUALIZE=1 then shows

<img width="1540" height="874" alt="image" src="https://github.com/user-attachments/assets/232dc021-6e84-46a0-9763-3f9e3294d28b" />

(in above, `flakyX` tests had 50% chance of flaking, or succeeding)

and I pattern match the "Retrying flaky test" reports in stdout log to visualize flaked runs as orange:

<img width="1244" height="541" alt="image" src="https://github.com/user-attachments/assets/53fe18b1-b6af-44c8-b094-8014897c030b" />
