### PR TITLE
Always pass -new-instance when launching Firefox browser

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -114,7 +114,7 @@ class ChromeConfig:
 
 class FirefoxConfig:
   data_dir_flag = '-profile '
-  default_flags = ()
+  default_flags = ('-new-instance',)
   headless_flags = '-headless'
 
   @staticmethod


### PR DESCRIPTION
@brendandahl suggested it would have a positive impact on launching Firefox. Not sure that I saw any behavioral difference, though maybe this is one of those "can't hurt" things. Wdyt?