### PR TITLE
[testing] Speed up test_sdl_audio_beep_sleep.

### DIFF
--- a/test/browser/test_sdl_audio_beep_sleep.cpp
+++ b/test/browser/test_sdl_audio_beep_sleep.cpp
@@ -22,7 +22,15 @@
 #undef main
 #endif
 
-const int tone_duration = 1000;
+// Set this to true to if manually testing in browser to give longer delays
+// and beeps.
+// #define INTERACTIVE true
+
+#ifdef INTERACTIVE
+const int tone_duration = 10000;
+#else
+const int tone_duration = 10;
+#endif
 
 struct BeepObject {
   double toneFrequency;
@@ -196,7 +204,11 @@ void nextTest(void *unused = 0) {
     return;
   }
 
+#ifdef INTERACTIVE
   emscripten_sleep(100);
+#else
+  emscripten_sleep(1);
+#endif
 
   printf("Playing back a beep for %d msecs at %d Hz tone with audio format %s, %d channels, and %d samples/sec.\n",
       tone_duration, (int)Hz, SdlAudioFormatToString(sdlAudioFormats[s]), channels[c], freqs[f]);
@@ -211,7 +223,11 @@ void update() {
     delete beep;
     beep = 0;
 #ifdef __EMSCRIPTEN__
+#ifdef INTERACTIVE
     emscripten_async_call(nextTest, 0, 1500);
+#else
+    emscripten_async_call(nextTest, 0, 1);
+#endif
 #else
     SDL_Delay(1500);
     nextTest();

--- a/test/browser/test_sdl_audio_beep_sleep.cpp
+++ b/test/browser/test_sdl_audio_beep_sleep.cpp
@@ -27,8 +27,10 @@
 // #define INTERACTIVE true
 
 #ifdef INTERACTIVE
-const int tone_duration = 10000;
+const int tone_duration = 1000;
+#define DELAY 1500
 #else
+#define DELAY 1
 const int tone_duration = 10;
 #endif
 
@@ -223,13 +225,9 @@ void update() {
     delete beep;
     beep = 0;
 #ifdef __EMSCRIPTEN__
-#ifdef INTERACTIVE
-    emscripten_async_call(nextTest, 0, 1500);
+    emscripten_async_call(nextTest, 0, DELAY);
 #else
-    emscripten_async_call(nextTest, 0, 1);
-#endif
-#else
-    SDL_Delay(1500);
+    SDL_Delay(DELAY);
     nextTest();
 #endif
   }


### PR DESCRIPTION
This test takes over 60 seconds to run. There's really no point for it using such long beeps and delays when running in an automated test. After the changes it finishes in ~4 seconds.