### PR TITLE
Fix test browser configuring.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -2476,16 +2476,15 @@ def configure_test_browser():
   if not has_browser():
     return
 
+  if not EMTEST_BROWSER:
+    EMTEST_BROWSER = 'google-chrome'
+
   if WINDOWS and '"' not in EMTEST_BROWSER and "'" not in EMTEST_BROWSER:
     # On Windows env. vars canonically use backslashes as directory delimiters, e.g.
     # set EMTEST_BROWSER=C:\Program Files\Mozilla Firefox\firefox.exe
     # and spaces are not escaped. But make sure to also support args, e.g.
     # set EMTEST_BROWSER="C:\Users\clb\AppData\Local\Google\Chrome SxS\Application\chrome.exe" --enable-unsafe-webgpu
     EMTEST_BROWSER = '"' + EMTEST_BROWSER.replace("\\", "\\\\") + '"'
-
-  if not EMTEST_BROWSER:
-    logger.info('No EMTEST_BROWSER set. Defaulting to `google-chrome`')
-    EMTEST_BROWSER = 'google-chrome'
 
   if EMTEST_BROWSER_AUTO_CONFIG:
     config = None


### PR DESCRIPTION
Fix two problems with test browser configuring refactor:

1. Each run of non-browser suites would print `"No EMTEST_BROWSER set. Defaulting to google-chrome"`. Simplest way is to remove this print. There is already a print `logger.info('Launching browser: %s', str(browser_args))` later down the line, so it should be fairly explicit what browser cmdline is being run.
2. if user has no EMTEST_BROWSER set, then on Windows line 2479 would throw on the `'"' not in EMTEST_BROWSER` check, when `EMTEST_BROWSER` was still `None`.