### PR TITLE
Add a check in cache.erase() to never attempt it in FROZEN_CACHE mode.

### DIFF
--- a/tools/cache.py
+++ b/tools/cache.py
@@ -83,8 +83,7 @@ def ensure():
 
 def erase():
   ensure_setup()
-  if config.FROZEN_CACHE:
-    raise Exception('Cache cannot be erased when FROZEN_CACHE is set')
+  assert not config.FROZEN_CACHE, 'Cache cannot be erased when FROZEN_CACHE is set'
 
   with lock('erase'):
     # Delete everything except the lockfile itself


### PR DESCRIPTION
If external logic is correct, then this exception should never be thrown.

(I considered no-opping this call in FROZEN_CACHE mode, but I think that is not a good idea. Better to fix any callers to cache.erase() in FROZEN_CACHE mode directly)