### PR TITLE
Fix for errors when using `OFFSCREENCANVAS_SUPPORT`

### DIFF
--- a/src/lib/libbrowser.js
+++ b/src/lib/libbrowser.js
@@ -712,9 +712,7 @@ var LibraryBrowser = {
     styleSheet.insertRule('canvas.emscripten { border: 1px solid black; cursor: none; }', 0);
   },
 
-#if !OFFSCREENCANVAS_SUPPORT
   emscripten_set_canvas_size__proxy: 'sync',
-#endif
   emscripten_set_canvas_size: (width, height) => Browser.setCanvasSize(width, height),
 
   emscripten_get_canvas_size__proxy: 'sync',

--- a/src/lib/libbrowser.js
+++ b/src/lib/libbrowser.js
@@ -712,7 +712,9 @@ var LibraryBrowser = {
     styleSheet.insertRule('canvas.emscripten { border: 1px solid black; cursor: none; }', 0);
   },
 
+#if !OFFSCREENCANVAS_SUPPORT
   emscripten_set_canvas_size__proxy: 'sync',
+#endif
   emscripten_set_canvas_size: (width, height) => Browser.setCanvasSize(width, height),
 
   emscripten_get_canvas_size__proxy: 'sync',

--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -360,8 +360,9 @@ var LibraryHTML5 = {
     // it will move in the GL.offscreenCanvases array between threads. Hence GL.offscreenCanvases
     // represents the set of OffscreenCanvases owned by the current calling thread.
 
+    return specialHTMLTargets[target]
     // First check out the list of OffscreenCanvases by CSS selector ID ('#myCanvasID')
-    return GL.offscreenCanvases[target.slice(1)] // Remove '#' prefix
+     || GL.offscreenCanvases[target.slice(1)] // Remove '#' prefix
     // If not found, if one is querying by using DOM tag name selector 'canvas', grab the first
     // OffscreenCanvas that we can find.
      || (target == 'canvas' && Object.keys(GL.offscreenCanvases)[0])

--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -360,12 +360,13 @@ var LibraryHTML5 = {
     // it will move in the GL.offscreenCanvases array between threads. Hence GL.offscreenCanvases
     // represents the set of OffscreenCanvases owned by the current calling thread.
 
-    return specialHTMLTargets[target]
     // First check out the list of OffscreenCanvases by CSS selector ID ('#myCanvasID')
-     || GL.offscreenCanvases[target.slice(1)] // Remove '#' prefix
+    return GL.offscreenCanvases[target.slice(1)] // Remove '#' prefix
     // If not found, if one is querying by using DOM tag name selector 'canvas', grab the first
     // OffscreenCanvas that we can find.
      || (target == 'canvas' && Object.keys(GL.offscreenCanvases)[0])
+    // If not found, check specialHTMLTargets
+     || specialHTMLTargets[target]
     // If that is not found either, query via the regular DOM selector.
 #if PTHREADS
      || (typeof document != 'undefined' && document.querySelector(target));

--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -346,7 +346,7 @@ var LibraryHTML5 = {
   },
 
 #if OFFSCREENCANVAS_SUPPORT
-  $findCanvasEventTarget__deps: ['$GL', '$maybeCStringToJsString'],
+  $findCanvasEventTarget__deps: ['$GL', '$maybeCStringToJsString', '$specialHTMLTargets'],
   $findCanvasEventTarget: (target) => {
     target = maybeCStringToJsString(target);
 


### PR DESCRIPTION
This PR addresses an error encountered while using `OFFSCREENCANVAS_SUPPORT` for pthreads.
Unable to find canvas in `findCanvasEventTarget` when canvas is `specialHTMLTargets`.
```
Uncaught TypeError: document.querySelector is not a function
    at findCanvasEventTarget
    at _wgpuInstanceCreateSurface
```