### PR TITLE
Run `@is_slow_test` test first in `parallel_testsuite.py`

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -228,6 +228,7 @@ def is_slow_test(func):
       return self.skipTest('skipping slow tests')
     return func(self, *args, **kwargs)
 
+  decorated.is_slow = True
   return decorated
 
 


### PR DESCRIPTION
Previously we were relying special naming of tests (e.g. `test_xxx_foo`) and using reverse alphabetic sort to run them first, but we dropped the `test_xxx` convention in favor of the `@is_slow_test` decorator.

Ultimately it would be nice to merge this default sort with the `--failing-fast-and-slow` flag but for now they are still separate.