### PR TITLE
Deprecate RELOCATABLE and LINKABLE settings.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 4.0.15 (in development)
 -----------------------
+- The `RELOCATABLE` and `LINKABLE` settings were deprecated in favor the higher
+  level and better supported `MAIN_MODULE` / `SIDE_MODULE` settings. (#25265)
 - The `-gsource-map` flag has been updated to be independent of other types of
   debugging effects (in particular it no longer causes the wasm binary to have
   a name section, and it no longer suppresses minification of the JS output).

--- a/test/common.py
+++ b/test/common.py
@@ -2221,10 +2221,12 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
     return poppler + freetype
 
-  def get_zlib_library(self, cmake):
+  def get_zlib_library(self, cmake, cflags=None):
     assert cmake or not WINDOWS, 'on windows, get_zlib_library only supports cmake'
 
     old_args = self.cflags.copy()
+    if cflags:
+      self.cflags += cflags
     # inflate.c does -1L << 16
     self.cflags.append('-Wno-shift-negative-value')
     # adler32.c uses K&R sytyle function declarations

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2005,14 +2005,6 @@ simulateKeyUp(100, undefined, 'Numpad4');
 
   @requires_graphics_hardware
   @no_swiftshader
-  def test_cubegeom_pre_relocatable(self):
-    # RELOCATABLE needs to be set via `set_setting` so that it will also apply when
-    # building `browser_reporting.c`
-    self.set_setting('RELOCATABLE')
-    self.reftest('third_party/cubegeom/cubegeom_pre.c', 'third_party/cubegeom/cubegeom_pre.png', cflags=['-sLEGACY_GL_EMULATION', '-lGL', '-lSDL'])
-
-  @requires_graphics_hardware
-  @no_swiftshader
   def test_cubegeom_pre2(self):
     self.reftest('third_party/cubegeom/cubegeom_pre2.c', 'third_party/cubegeom/cubegeom_pre2.png', cflags=['-sGL_DEBUG', '-sLEGACY_GL_EMULATION', '-lGL', '-lSDL']) # some coverage for GL_DEBUG not breaking the build
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1844,7 +1844,7 @@ int main() {
       self.clear_setting('EXPORTED_FUNCTIONS')
       self.set_setting('EXPORT_ALL')
       self.set_setting('LINKABLE')
-      self.do_core_test('test_emscripten_api.c')
+      self.do_core_test('test_emscripten_api.c', cflags=['-Wno-deprecated'])
 
   def test_emscripten_run_script_string_int(self):
     src = r'''
@@ -5180,8 +5180,7 @@ main main sees -524, -534, 72.
   @needs_make('mingw32-make')
   @with_dylink_reversed
   def test_dylink_zlib(self):
-    self.set_setting('RELOCATABLE')
-    zlib_archive = self.get_zlib_library(cmake=WINDOWS)
+    zlib_archive = self.get_zlib_library(cmake=WINDOWS, cflags=['-fPIC'])
     # example.c uses K&R style function declarations
     self.cflags.append('-Wno-deprecated-non-prototype')
     self.cflags.append('-I' + test_file('third_party/zlib'))
@@ -5844,11 +5843,7 @@ got: 10
     self.do_core_test('test_std_function_incomplete_return.cpp')
 
   def test_istream(self):
-    for linkable in [0]: # , 1]:
-      print(linkable)
-      # regression check for issue #273
-      self.set_setting('LINKABLE', linkable)
-      self.do_core_test('test_istream.cpp')
+    self.do_core_test('test_istream.cpp')
 
   @no_wasmfs('depends on FS.makedev which WASMFS does not have')
   def test_fs_base(self):
@@ -6631,7 +6626,7 @@ void* operator new(size_t size) {
   @needs_dylink
   def test_relocatable_void_function(self):
     self.set_setting('RELOCATABLE')
-    self.do_core_test('test_relocatable_void_function.c')
+    self.do_core_test('test_relocatable_void_function.c', cflags=['-Wno-deprecated'])
 
   @wasm_simd
   @parameterized({

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1569,7 +1569,7 @@ int f() {
 
     # Explicitly test with -Oz to ensure libc_optz is included alongside
     # libc when `--whole-archive` is used.
-    self.emcc('lib.c', ['-Oz', '-sEXPORT_ALL', '-sLINKABLE', '--pre-js', 'pre.js'], output_filename='a.out.js')
+    self.emcc('lib.c', ['-Oz', '-sEXPORT_ALL', '-sLINKABLE', '-Wno-deprecated', '--pre-js', 'pre.js'], output_filename='a.out.js')
     self.assertContained('libf1\nlibf2\n', self.run_js('a.out.js'))
 
   def test_export_keepalive(self):
@@ -2504,21 +2504,21 @@ F1 -> ''
   def test_sdl2_linkable(self):
     # Ensure that SDL2 can be built with LINKABLE.  This implies there are no undefined
     # symbols in the library (because LINKABLE includes the entire library).
-    self.emcc(test_file('browser/test_sdl2_misc.c'), ['-sLINKABLE', '-sUSE_SDL=2'], output_filename='a.out.js')
-    self.emcc(test_file('browser/test_sdl2_misc.c'), ['-sLINKABLE', '--use-port=sdl2'], output_filename='a.out.js')
+    self.emcc(test_file('browser/test_sdl2_misc.c'), ['-sLINKABLE', '-Wno-deprecated', '-sUSE_SDL=2'], output_filename='a.out.js')
+    self.emcc(test_file('browser/test_sdl2_misc.c'), ['-sLINKABLE', '-Wno-deprecated', '--use-port=sdl2'], output_filename='a.out.js')
 
   def test_sdl3_linkable(self):
     # Ensure that SDL3 can be built with LINKABLE.  This implies there are no undefined
     # symbols in the library (because LINKABLE includes the entire library).
     self.cflags.append('-Wno-experimental')
-    self.emcc(test_file('browser/test_sdl3_misc.c'), ['-sLINKABLE', '-sUSE_SDL=3'], output_filename='a.out.js')
-    self.emcc(test_file('browser/test_sdl3_misc.c'), ['-sLINKABLE', '--use-port=sdl3'], output_filename='a.out.js')
+    self.emcc(test_file('browser/test_sdl3_misc.c'), ['-sLINKABLE', '-Wno-deprecated', '-sUSE_SDL=3'], output_filename='a.out.js')
+    self.emcc(test_file('browser/test_sdl3_misc.c'), ['-sLINKABLE', '-Wno-deprecated', '--use-port=sdl3'], output_filename='a.out.js')
 
   @requires_network
   def test_sdl2_gfx_linkable(self):
     # Same as above but for sdl2_gfx library
-    self.emcc(test_file('browser/test_sdl2_misc.c'), ['-Wl,-fatal-warnings', '-sLINKABLE', '-sUSE_SDL_GFX=2'], output_filename='a.out.js')
-    self.emcc(test_file('browser/test_sdl2_misc.c'), ['-Wl,-fatal-warnings', '-sLINKABLE', '--use-port=sdl2_gfx'], output_filename='a.out.js')
+    self.emcc(test_file('browser/test_sdl2_misc.c'), ['-Wl,-fatal-warnings', '-sLINKABLE', '-Wno-deprecated', '-sUSE_SDL_GFX=2'], output_filename='a.out.js')
+    self.emcc(test_file('browser/test_sdl2_misc.c'), ['-Wl,-fatal-warnings', '-sLINKABLE', '-Wno-deprecated', '--use-port=sdl2_gfx'], output_filename='a.out.js')
 
   @requires_network
   def test_libpng(self):
@@ -5894,8 +5894,8 @@ int main() {
     self.assertNotContained('new Function', src)
     delete_file('a.out.js')
 
-    # Test that -sDYNAMIC_EXECUTION=0 and -sRELOCATABLE are allowed together.
-    self.do_runf('hello_world.c', cflags=['-O1', '-sDYNAMIC_EXECUTION=0', '-sRELOCATABLE'])
+    # Test that -sDYNAMIC_EXECUTION=0 and -sMAIN_MODULE are allowed together.
+    self.do_runf('hello_world.c', cflags=['-O1', '-sDYNAMIC_EXECUTION=0', '-sMAIN_MODULE'])
 
     create_file('test.c', r'''
       #include <emscripten/emscripten.h>
@@ -9228,7 +9228,7 @@ int main() {
 
   @parameterized({
     '': ([],),
-    'relocatable': (['-sRELOCATABLE'],),
+    'main_module': (['-sMAIN_MODULE'],),
   })
   def test_ctor_ordering(self, args):
     # ctor order must be identical to js builds, deterministically
@@ -13094,10 +13094,6 @@ int main(void) {
   def test_pthread_mutex_deadlock(self):
     self.do_runf('other/test_pthread_mutex_deadlock.c', 'pthread mutex deadlock detected',
                  cflags=['-g'], assert_returncode=NON_ZERO)
-
-  @node_pthreads
-  def test_pthread_relocatable(self):
-    self.do_run_in_out_file_test('hello_world.c', cflags=['-sRELOCATABLE'])
 
   @node_pthreads
   def test_pthread_unavailable(self):

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -124,6 +124,8 @@ DEPRECATED_SETTINGS = {
     'LEGALIZE_JS_FFI': 'to disable JS type legalization use `-sWASM_BIGINT` or `-sSTANDALONE_WASM`',
     'ASYNCIFY_EXPORTS': 'please use JSPI_EXPORTS instead',
     'USE_WEBGPU': 'please try migrating to --use-port=emdawnwebgpu, which implements a newer, incompatible version of webgpu.h (see tools/ports/emdawnwebgpu.py for more info)',
+    'LINKABLE': 'scheduled for removal in favor of SIDE_MODULE/MAIN_MODULE (https://github.com/emscripten-core/emscripten/issues/25262)',
+    'RELOCATABLE': 'scheduled for removal in favor of SIDE_MODULE/MAIN_MODULE (https://github.com/emscripten-core/emscripten/issues/25262)',
 }
 
 # Settings that don't need to be externalized when serializing to json because they


### PR DESCRIPTION
For some tests that use this flag I simply replaced or removed that flag, for others I added `-Wno-deprecated` for now.

See: #25262