### PR TITLE
Update SDL3 port to version 3.2.22

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,7 @@ See docs/process.md for more on how version tagging works.
   covers debugging flags and use cases (#25238).
 - Ogg port updated to 1.3.5. (#25274)
 - Vorbis port updated to 1.3.7. (#25274)
+- SDL3 port updated to 3.2.22. (#25273)
 
 4.0.14 - 09/02/25
 -----------------

--- a/tools/ports/sdl3.py
+++ b/tools/ports/sdl3.py
@@ -9,9 +9,9 @@ import shutil
 
 from tools import diagnostics
 
-VERSION = '3.2.4'
+VERSION = '3.2.22'
 TAG = f'release-{VERSION}'
-HASH = 'c26a8afeec481e3ae3b435eec405d9f99d78752ebf5118963cd56728ceff23772769f5291df581329488da7489034e835301b08d61a42c811764e24b3542a4c2'
+HASH = '2d49f43f37b681b3b12918518fc2bb89fd79f64b6f9592cceb504402a9cfb3d5c0ae6f437cdbcd8fdef11065dfb15a86fcb61a58cf1fa41af71a61f767ab7260'
 SUBDIR = f'SDL-{TAG}'
 
 variants = {'sdl3-mt': {'PTHREADS': 1}}


### PR DESCRIPTION
This fixed some issues with polling SDL_EVENT_KEY_DOWN events (I got multiple events for a single JS event), but generally probably a good idea to keep this up to date.