### PR TITLE
Update Vorbis and Ogg ports

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,8 @@ See docs/process.md for more on how version tagging works.
   See also the newly updated
   [documentation](https://emscripten.org/docs/porting/Debugging.html) which
   covers debugging flags and use cases (#25238).
+- Ogg port updated to 1.3.5. (#25274)
+- Vorbis port updated to 1.3.7. (#25274)
 
 4.0.14 - 09/02/25
 -----------------

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -6,8 +6,8 @@
 import os
 import shutil
 
-TAG = 'version_1'
-HASH = '929e8d6003c06ae09593021b83323c8f1f54532b67b8ba189f4aedce52c25dc182bac474de5392c46ad5b0dea5a24928e4ede1492d52f4dd5cd58eea9be4dba7'
+VERSION = '1.3.5'
+HASH = 'e7b5f5d469090b66dbb33634591ae6de41af3a5644c10488e59ba7428ed78912e208a2c0fbb5003ec5b7eb2a0102a2f85cecb21fa9512d790139ecc45b6d03f4'
 
 
 def needed(settings):
@@ -15,14 +15,14 @@ def needed(settings):
 
 
 def get(ports, settings, shared):
-  ports.fetch_project('ogg', f'https://github.com/emscripten-ports/ogg/archive/{TAG}.zip', sha512hash=HASH)
+  ports.fetch_project('ogg', f'https://github.com/xiph/ogg/releases/download/v{VERSION}/libogg-{VERSION}.zip', sha512hash=HASH)
 
   def create(final):
-    source_path = ports.get_dir('ogg', 'Ogg-' + TAG)
+    source_path = ports.get_dir('ogg', 'libogg-' + VERSION)
     config_types_h = os.path.join(os.path.dirname(__file__), 'ogg/config_types.h')
     shutil.copyfile(config_types_h, os.path.join(source_path, 'include/ogg/config_types.h'))
     ports.install_headers(os.path.join(source_path, 'include', 'ogg'), target='ogg')
-    ports.make_pkg_config('ogg', TAG, '-sUSE_OGG')
+    ports.make_pkg_config('ogg', VERSION, '-sUSE_OGG')
     ports.build_port(os.path.join(source_path, 'src'), final, 'ogg')
 
   return [shared.cache.get_lib('libogg.a', create)]

--- a/tools/ports/ogg/config_types.h
+++ b/tools/ports/ogg/config_types.h
@@ -21,5 +21,6 @@ typedef uint16_t ogg_uint16_t;
 typedef int32_t ogg_int32_t;
 typedef uint32_t ogg_uint32_t;
 typedef int64_t ogg_int64_t;
+typedef uint64_t ogg_uint64_t;
 
 #endif

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -5,8 +5,8 @@
 
 import os
 
-TAG = 'version_1'
-HASH = '99bee75beb662f8520bbb18ad6dbf8590d30eb3a7360899f0ac4764ca72fe8013da37c9df21e525f9d2dc5632827d4b4cea558cbc938e7fbed0c41a29a7a2dc5'
+VERSION = '1.3.7'
+HASH = '10edd193f44f2b2d6085672e257b5be11066f5db27348d4cab53789bf9e8739c2df2cd7f42b83e4edbab53e10b5dc84320d6aab1deac0d8e18196a8a88b19b77'
 
 deps = ['ogg']
 
@@ -16,12 +16,12 @@ def needed(settings):
 
 
 def get(ports, settings, shared):
-  ports.fetch_project('vorbis', f'https://github.com/emscripten-ports/vorbis/archive/{TAG}.zip', sha512hash=HASH)
+  ports.fetch_project('vorbis', f'https://github.com/xiph/vorbis/releases/download/v{VERSION}/libvorbis-{VERSION}.zip', sha512hash=HASH)
 
   def create(final):
-    source_path = ports.get_dir('vorbis', 'Vorbis-' + TAG)
+    source_path = ports.get_dir('vorbis', 'libvorbis-' + VERSION)
     ports.install_headers(os.path.join(source_path, 'include', 'vorbis'), target='vorbis')
-    ports.make_pkg_config('vorbis', TAG, '-sUSE_VORBIS')
+    ports.make_pkg_config('vorbis', VERSION, '-sUSE_VORBIS')
     ports.build_port(os.path.join(source_path, 'lib'), final, 'vorbis',
                      flags=['-sUSE_OGG'],
                      exclude_files=['psytune', 'barkmel', 'tone', 'misc'])


### PR DESCRIPTION
The current ogg and vorbis ports are ancient (2015) and pull in repos from the old _emscripten-ports_ github org. From what I can tell, they do not have any patches and both pre-date Xiph.org's migration to Github, so presumably are just old mirrors:
- https://github.com/emscripten-ports/Vorbis/releases/tag/version_1 is the same as https://github.com/xiph/vorbis/commit/7187e7a48f0c3ba32cc080f6bc3d921fe4ec6cc2
- https://github.com/emscripten-ports/Ogg/releases/tag/version_1 is the same as xiph/ogg/commit@9b2ba419aecb4a1c97114545d57174593dc13111 

This updates both to the most recent update.(ogg one before the most recent as I haven't yet tested the most recent update)