### PR TITLE
Fix get_native_triple() on Windows-on-ARM devices.

### DIFF
--- a/test/clang_native.py
+++ b/test/clang_native.py
@@ -25,7 +25,8 @@ def get_native_triple():
 
   arch = {
       'aarch64': 'arm64',
-      'arm64': 'arm64',
+      'arm64': 'arm64', # Python on Apple Silicon ARM64 reports lowercase arm64
+      'ARM64': 'arm64', # Python on Windows-on-ARM reports uppercase ARM64
       'x86_64': 'x86_64',
       'AMD64': 'x86_64',
   }[platform.machine()]


### PR DESCRIPTION
Fixes

```
other.test_bad_triple
other.test_dot_a_all_contents_invalid
other.test_native_link_error_message
```
on Windows-on-ARM.