### PR TITLE
Cleanup python-generated JS code. NFC

### DIFF
--- a/test/code_size/test_unoptimized_code_size.json
+++ b/test/code_size/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 54019,
-  "hello_world.js.gz": 17072,
+  "hello_world.js": 54020,
+  "hello_world.js.gz": 17068,
   "hello_world.wasm": 15127,
   "hello_world.wasm.gz": 7450,
-  "no_asserts.js": 26497,
-  "no_asserts.js.gz": 8849,
+  "no_asserts.js": 26498,
+  "no_asserts.js.gz": 8848,
   "no_asserts.wasm": 12227,
   "no_asserts.wasm.gz": 6010,
-  "strict.js": 52057,
-  "strict.js.gz": 16407,
+  "strict.js": 52058,
+  "strict.js.gz": 16403,
   "strict.wasm": 15127,
   "strict.wasm.gz": 7447,
-  "total": 175054,
-  "total_gz": 63235
+  "total": 175057,
+  "total_gz": 63226
 }

--- a/test/other/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/other/codesize/test_codesize_minimal_O0.expected.js
@@ -1304,7 +1304,10 @@ function assignWasmExports(wasmExports) {
   __emscripten_stack_alloc = wasmExports['_emscripten_stack_alloc'];
   _emscripten_stack_get_current = wasmExports['emscripten_stack_get_current'];
 }
-var _global_val = Module['_global_val'] = 65536;var wasmImports = {
+
+var _global_val = Module['_global_val'] = 65536;
+
+var wasmImports = {
   
 };
 


### PR DESCRIPTION
We were not being consistent about newlines here.  This change makes the output more readable.