### PR TITLE
Remove definition of __WASM_EXCEPTIONS__. NFC

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1640,8 +1640,6 @@ class libcxxabi(ExceptionLibrary, MTLibrary, DebugLibrary):
       # The code used to interpret exceptions during terminate
       # is not compatible with emscripten exceptions.
       cflags.append('-DLIBCXXABI_SILENT_TERMINATE')
-    elif self.eh_mode == Exceptions.WASM_LEGACY:
-      cflags.append('-D__WASM_EXCEPTIONS__')
     return cflags
 
   def get_files(self):
@@ -1719,12 +1717,6 @@ class libcxx(ExceptionLibrary, MTLibrary, DebugLibrary):
     'tzdb_list.cpp',
   ]
 
-  def get_cflags(self):
-    cflags = super().get_cflags()
-    if self.eh_mode in (Exceptions.WASM_LEGACY, Exceptions.WASM):
-      cflags.append('-D__WASM_EXCEPTIONS__')
-    return cflags
-
 
 class libunwind(ExceptionLibrary, MTLibrary):
   name = 'libunwind'
@@ -1755,8 +1747,6 @@ class libunwind(ExceptionLibrary, MTLibrary):
       cflags.append('-D_LIBUNWIND_HAS_NO_EXCEPTIONS')
     elif self.eh_mode == Exceptions.EMSCRIPTEN:
       cflags.append('-D__EMSCRIPTEN_EXCEPTIONS__')
-    elif self.eh_mode in (Exceptions.WASM_LEGACY, Exceptions.WASM):
-      cflags.append('-D__WASM_EXCEPTIONS__')
     return cflags
 
 


### PR DESCRIPTION
This macros is automatically defined clang in the pre-processor when wasm exceptions are enabled.

See https://github.com/llvm/llvm-project/blob/82acc31fd4b26723b61dae76da120c0c649d0b97/clang/lib/Frontend/InitPreprocessor.cpp#L1034-L1035