### PR TITLE
Fix `findCanvasEventTarget` finding default canvas with OFFSCREENCANVAS_SUPPORT to return the canvas object instead of the canvas target name

### DIFF
--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -364,7 +364,7 @@ var LibraryHTML5 = {
     return GL.offscreenCanvases[target.slice(1)] // Remove '#' prefix
     // If not found, if one is querying by using DOM tag name selector 'canvas', grab the first
     // OffscreenCanvas that we can find.
-     || (target == 'canvas' && Object.keys(GL.offscreenCanvases)[0])
+     || (target == 'canvas' && Object.values(GL.offscreenCanvases)[0])
     // If not found, check specialHTMLTargets
      || specialHTMLTargets[target]
     // If that is not found either, query via the regular DOM selector.


### PR DESCRIPTION
When calling `findCanvasEventTarget`, with target name `canvas`, the function returns the string key `canvas` instead of the actual canvas object. From looking at the usages, it seems like it is expected for this function to return the canvas object, not the target name string.

I found this issue when trying to call [`wgpuInstanceCreateSurface`](https://github.com/google/dawn/blob/fe41c8b6d79ba421cb53430930cd037b40f8c185/third_party/emdawnwebgpu/pkg/webgpu/src/library_webgpu.js#L1979), which is expecting the canvas object, but fails to find function `getContext` on the returned string. 

The function is returning the name because its returning the element of the key array returned from `Object.keys(GL.offscreenCanvases)`, but should be using `Object.values(GL.offscreenCanvases)` instead to return the actual canvas object.
