### PR TITLE
Fix "EMTEST_BENCHMARKERS=node-64 test/runner benchmark" run.

### DIFF
--- a/emmake.py
+++ b/emmake.py
@@ -21,6 +21,7 @@ that configure tests pass. emmake uses Emscripten to
 generate JavaScript.
 """
 
+import os
 import shutil
 import sys
 from tools import building
@@ -56,7 +57,7 @@ variables so that emcc etc. are used. Typical usage:
   # On Windows, run the execution through shell to get PATH expansion and
   # executable extension lookup, e.g. 'sdl2-config' will match with
   # 'sdl2-config.bat' in PATH.
-  print('make: ' + ' '.join(args), file=sys.stderr)
+  print('make: "' + ' '.join(args) + '" in "' + os.getcwd() + '"', file=sys.stderr)
   try:
     shared.check_call(args, shell=utils.WINDOWS, env=env)
     return 0

--- a/test/third_party/lzma/Makefile
+++ b/test/third_party/lzma/Makefile
@@ -10,7 +10,7 @@ OBJECTS = \
 all: lzma.a
 
 %.o: %.c
-	$(CC) -I. $< -o $@ -O2 -c
+	$(CC) $(CFLAGS) -I. $< -o $@ -O2 -c
 
 lzma.a: $(OBJECTS)
 	$(AR) rv $@ $(OBJECTS)


### PR DESCRIPTION
Fix `EMTEST_BENCHMARKERS=node-64 test/runner benchmark` run. Improve debug printing in emmake.py.

Fixes

```
benchmark.test_zzz_bullet
benchmark.test_zzz_lua_binarytrees
benchmark.test_zzz_lua_scimark
benchmark.test_zzz_lzma
````

for the suite to pass in node-64 benchmarker mode.