### PR TITLE
Fix f-string usage in emmake.py

### DIFF
--- a/emcmake.py
+++ b/emcmake.py
@@ -62,7 +62,7 @@ variables so that emcc etc. are used. Typical usage:
       print('emcmake: no compatible cmake generator found; Please install ninja or mingw32-make, or specify a generator explicitly using -G', file=sys.stderr)
       return 1
 
-  print(f'configure: {shlex.join(args)} in directory {os.getcwd()}', file=sys.stderr)
+  print(f'emcmake: {shlex.join(args)} in directory {os.getcwd()}', file=sys.stderr)
   try:
     shared.check_call(args)
     return 0

--- a/emconfigure.py
+++ b/emconfigure.py
@@ -49,7 +49,7 @@ variables so that emcc etc. are used. Typical usage:
   # compilation with emcc, but instead do builds natively with Clang. This
   # is a heuristic emulation that may or may not work.
   env['EMMAKEN_JUST_CONFIGURE'] = '1'
-  print(f'configure: {shlex.join(args)} in directory {os.getcwd()}', file=sys.stderr)
+  print(f'emconfigure: {shlex.join(args)} in directory {os.getcwd()}', file=sys.stderr)
   try:
     shared.check_call(args, env=env)
     return 0

--- a/emmake.py
+++ b/emmake.py
@@ -22,6 +22,7 @@ generate JavaScript.
 """
 
 import os
+import shlex
 import shutil
 import sys
 from tools import building
@@ -57,7 +58,7 @@ variables so that emcc etc. are used. Typical usage:
   # On Windows, run the execution through shell to get PATH expansion and
   # executable extension lookup, e.g. 'sdl2-config' will match with
   # 'sdl2-config.bat' in PATH.
-  print(f'make: "{' '.join(args)}" in "{os.getcwd()}"', file=sys.stderr)
+  print(f'emmake: "{shlex.join(args)}" in "{os.getcwd()}"', file=sys.stderr)
   try:
     shared.check_call(args, shell=utils.WINDOWS, env=env)
     return 0


### PR DESCRIPTION
Ruff was reporting:

```
emmake.py:60:19: SyntaxError: Cannot reuse outer quote character in f-strings on Python 3.8 (syntax was added in Python 3.12)
```

Instead use shlex.join like the other scripts do.