### PR TITLE
Fix --post-js scripts to execute after main() in MODULARIZE mode in MINIMAL_RUNTIME

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,6 +694,7 @@ jobs:
             wasmfs.test_fs_llseek_rawfs
             wasmfs.test_freetype
             minimal0.test_utf
+            minimal0.test_unicode_js_library
             omitexports0.test_asyncify_longjmp
             strict.test_no_declare_asm_module_exports
             "

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -312,14 +312,17 @@ WebAssembly.instantiate(Module['wasm'], imports).then(/** @suppress {missingProp
 #if PTHREADS || WASM_WORKERS
 }
 
-// When running in a background thread we delay module loading until we have
-{{{ runIfMainThread('loadModule();') }}}
-#endif
-
-#if MODULARIZE
 // The semantics of MODULARIZE and --post-js foo.js scripts require that main()
 // should run before any of the --post-js scripts. Therefore await instantiation
 // here before reaching execution to the --post-js scripts to produce the
 // expected order.
+#if MODULARIZE
+{{{ runIfMainThread('loadModule(); await instantiatePromise;') }}}
+#else
+{{{ runIfMainThread('loadModule();') }}}
+#endif
+
+#elif MODULARIZE
 await instantiatePromise;
+
 #endif

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -164,7 +164,7 @@ var imports = {
 // precompiled WebAssembly Module.
 assert(WebAssembly.instantiateStreaming || Module['wasm'], 'Must load WebAssembly Module in to variable Module.wasm before adding compiled output .js script to the DOM');
 #endif
-#if AUDIO_WORKLET
+#if AUDIO_WORKLET || MODULARIZE
 instantiatePromise =
 #endif
 (WebAssembly.instantiateStreaming
@@ -175,7 +175,7 @@ instantiatePromise =
   ? WebAssembly.instantiateStreaming(fetch('{{{ TARGET_BASENAME }}}.wasm'), imports)
   : WebAssembly.instantiate(Module['wasm'], imports)).then((output) => {
 #else
-#if AUDIO_WORKLET
+#if AUDIO_WORKLET || MODULARIZE
 instantiatePromise =
 #endif
 WebAssembly.instantiateStreaming(fetch('{{{ TARGET_BASENAME }}}.wasm'), imports).then((output) => {
@@ -194,7 +194,7 @@ assert(Module['wasm'], 'Must load WebAssembly Module in to variable Module.wasm 
 
 // Add missingProperties supression here because closure compiler doesn't know that
 // WebAssembly.instantiate is polymorphic in its return value.
-#if AUDIO_WORKLET
+#if AUDIO_WORKLET || MODULARIZE
 instantiatePromise =
 #endif
 WebAssembly.instantiate(Module['wasm'], imports).then(/** @suppress {missingProperties} */ (output) => {
@@ -314,4 +314,11 @@ WebAssembly.instantiate(Module['wasm'], imports).then(/** @suppress {missingProp
 
 // When running in a background thread we delay module loading until we have
 {{{ runIfMainThread('loadModule();') }}}
+#endif
+
+#if MODULARIZE
+// The semantics of MODULARIZE and --post-js foo.js scripts require that main()
+// should run before any of the --post-js scripts. Therefore await instantiation
+// here before reaching execution to the --post-js scripts.
+await instantiatePromise;
 #endif

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -319,6 +319,7 @@ WebAssembly.instantiate(Module['wasm'], imports).then(/** @suppress {missingProp
 #if MODULARIZE
 // The semantics of MODULARIZE and --post-js foo.js scripts require that main()
 // should run before any of the --post-js scripts. Therefore await instantiation
-// here before reaching execution to the --post-js scripts.
+// here before reaching execution to the --post-js scripts to produce the
+// expected order.
 await instantiatePromise;
 #endif

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6409,6 +6409,9 @@ PORT: 3979
       self.assertContained('UnicodeDecodeError', err)
 
     self.cflags += ['-sMODULARIZE', '--js-library', test_file('unicode_library.js'), '--extern-post-js', test_file('modularize_post_js.js'), '--post-js', test_file('unicode_postjs.js')]
+    # In addition to verifying that --post-js files can contain UTF8 characters,
+    # this test verifies a specific semantic that in -sMODULARIZE mode, the
+    # content in --post-js files should be executed only after main() runs.
     self.do_run_in_out_file_test('test_unicode_js_library.c')
 
   def test_funcptr_import_type(self):


### PR DESCRIPTION
Fix --post-js scripts to execute after main() in MODULARIZE mode. Fixes test `minimal0.test_unicode_js_library` after this change: https://github.com/emscripten-core/emscripten/pull/23157/files#r1889243405