### PR TITLE
Update posixtestsuite to deal with OOM issue on fast computers

### DIFF
--- a/test/test_posixtest.py
+++ b/test/test_posixtest.py
@@ -166,6 +166,7 @@ def make_test(name, testfile, browser):
             '-Wno-int-conversion',
             '-Wno-format',
             '-pthread',
+            '--profiling-funcs',
             '-sEXIT_RUNTIME',
             '-sTOTAL_MEMORY=512mb',
             '-sPTHREAD_POOL_SIZE=40']

--- a/test/test_posixtest.py
+++ b/test/test_posixtest.py
@@ -168,7 +168,7 @@ def make_test(name, testfile, browser):
             '-pthread',
             '--profiling-funcs',
             '-sEXIT_RUNTIME',
-            '-sTOTAL_MEMORY=512mb',
+            '-sTOTAL_MEMORY=256mb',
             '-sPTHREAD_POOL_SIZE=40']
     if browser:
       self.btest_exit(testfile, cflags=args)

--- a/test/test_posixtest.py
+++ b/test/test_posixtest.py
@@ -167,7 +167,7 @@ def make_test(name, testfile, browser):
             '-Wno-format',
             '-pthread',
             '-sEXIT_RUNTIME',
-            '-sTOTAL_MEMORY=256mb',
+            '-sTOTAL_MEMORY=512mb',
             '-sPTHREAD_POOL_SIZE=40']
     if browser:
       self.btest_exit(testfile, cflags=args)

--- a/test/test_posixtest.py
+++ b/test/test_posixtest.py
@@ -166,6 +166,8 @@ def make_test(name, testfile, browser):
             '-Wno-int-conversion',
             '-Wno-format',
             '-pthread',
+            # Make sure all tests have callstacks to improve debuggability
+            # of log messages on CI runs.
             '--profiling-funcs',
             '-sEXIT_RUNTIME',
             '-sTOTAL_MEMORY=256mb',


### PR DESCRIPTION
A couple of tests in the posixtest suite hammer `pthread_kill()` and `pthread_cancel()` in an uncontrollably fast loop.

Since the event queue mailbox refactor, proxying `pthread_kill()` and `pthread_cancel()` allocate memory.

This causes fast CPUs like Ryzen 9800X3D 8c/16t and Apple M1 ARM to run out of memory while running the test:

http://clbri.com:8010/api/v2/logs/64925/raw_inline
http://clbri.com:8010/api/v2/logs/66008/raw_inline

Update the posixtest submodule to latest, which throttles these loops to sleep 1ms between signals.