### PR TITLE
Fix !DECLARE_ASM_MODULE_EXPORTS tests after #25298

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,6 +694,8 @@ jobs:
             wasmfs.test_fs_llseek_rawfs
             wasmfs.test_freetype
             minimal0.test_utf
+            omitexports0.test_asyncify_longjmp
+            strict.test_no_declare_asm_module_exports
             "
   test-modularize-instance:
     executor: focal

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -154,7 +154,13 @@ function unexportedRuntimeSymbol(sym) {
           msg += '. Alternatively, forcing filesystem support (-sFORCE_FILESYSTEM) can export this for you';
         }
         abort(msg);
-      }
+      },
+#if !DECLARE_ASM_MODULE_EXPORTS
+      // !DECLARE_ASM_MODULE_EXPORTS programmatically exports all wasm symbols
+      // on the Module object.  Ignore these attempts to set the properties
+      // here.
+      set(value) {}
+#endif
     });
   }
 }

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -413,7 +413,7 @@ function unexportedRuntimeSymbol(sym) {
           msg += '. Alternatively, forcing filesystem support (-sFORCE_FILESYSTEM) can export this for you';
         }
         abort(msg);
-      }
+      },
     });
   }
 }

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 54151,
-  "hello_world.js.gz": 17086,
+  "hello_world.js": 54152,
+  "hello_world.js.gz": 17088,
   "hello_world.wasm": 15127,
   "hello_world.wasm.gz": 7450,
   "no_asserts.js": 26557,
   "no_asserts.js.gz": 8869,
   "no_asserts.wasm": 12227,
   "no_asserts.wasm.gz": 6010,
-  "strict.js": 52189,
-  "strict.js.gz": 16421,
+  "strict.js": 52190,
+  "strict.js.gz": 16422,
   "strict.wasm": 15127,
   "strict.wasm.gz": 7447,
-  "total": 175378,
-  "total_gz": 63283
+  "total": 175380,
+  "total_gz": 63286
 }


### PR DESCRIPTION
In `!DECLARE_ASM_MODULE_EXPORTS` mode, all wasm symbols are programmatically exported onto the `Module` object.   After #25298, that includes the `wasmMemory` symbol.

This happens even for symbols that were not included in `EXPORTED_FUNCTIONS` or `EXPORTED_RUNTIME_SYMBOLS`.  In many of these tests `wasmMemory` was not being exported and so that `unexportedRuntimeSymbol` helper was installing a property accessor on the `Module` object, which did not allow for the assignment within `exportWasmSymbols`.

An alternative here would be to limit the list of symbols that `exportWasmSymbols` assigns to the `Module` object but that would only increase code size for very little benefit.