### PR TITLE
Fix test sockets.test_posix_proxy_sockets to work on systems with latest CMake

### DIFF
--- a/tools/websocket_to_posix_proxy/CMakeLists.txt
+++ b/tools/websocket_to_posix_proxy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 project(websocket_to_posix_proxy)
 


### PR DESCRIPTION
[CMake v3.5.0](https://github.com/Kitware/CMake/releases/tag/v3.5.0) was released on Dec 3, 2018. (7 years ago), latest CMake refuses to configure any CMakeLists.txt files with minimum CMake version older than 3.5.