### PR TITLE
Fix emscripten_set_socket_*_callback() functions to work in Wasm64 mode.

### DIFF
--- a/src/lib/libsockfs.js
+++ b/src/lib/libsockfs.js
@@ -748,10 +748,10 @@ addToLibrary({
         if (event === 'error') {
           withStackSave(() => {
             var msg = stringToUTF8OnStack(data[2]);
-            {{{ makeDynCall('viiii', 'callback') }}}(data[0], data[1], msg, userData);
+            {{{ makeDynCall('viipp', 'callback') }}}(data[0], data[1], msg, userData);
           });
         } else {
-          {{{ makeDynCall('vii', 'callback') }}}(data, userData);
+          {{{ makeDynCall('vip', 'callback') }}}(data, userData);
         }
       });
     };


### PR DESCRIPTION
Fix emscripten_set_socket_*_callback() functions to work in Wasm64 mode. Fixes test sockets64.test_sockets_async_bad_port.