### PR TITLE
Building with -sTEXTDECODER=2 when targeting -sAUDIO_WORKLET is not catastrophic

### DIFF
--- a/src/lib/libstrings.js
+++ b/src/lib/libstrings.js
@@ -9,9 +9,13 @@
 #endif
 
 addToLibrary({
+  // In -sAUDIO_WORKLET builds, TextDecoder will not exist in AudioWorkletGlobalScope,
+  // so we cannot try to unconditionally initialize it in that build mode.
+#if TEXTDECODER == 2 && !AUDIO_WORKLET
   // TextDecoder constructor defaults to UTF-8
-#if TEXTDECODER == 2
   $UTF8Decoder: "new TextDecoder()",
+#elif SUPPORTS_GLOBALTHIS
+  $UTF8Decoder: "globalThis.TextDecoder && new TextDecoder()",
 #else
   $UTF8Decoder: "typeof TextDecoder != 'undefined' ? new TextDecoder() : undefined",
 #endif

--- a/src/lib/libwebaudio.js
+++ b/src/lib/libwebaudio.js
@@ -1,8 +1,8 @@
 #if AUDIO_WORKLET && !WASM_WORKERS
-#error "Building with -sAUDIO_WORKLET also requires enabling -sWASM_WORKERS!"
+#error "Building with -sAUDIO_WORKLET also requires enabling -sWASM_WORKERS"
 #endif
 #if AUDIO_WORKLET && TEXTDECODER == 2
-#error "-sAUDIO_WORKLET does not support -sTEXTDECODER=2 since TextDecoder is not available in AudioWorkletGlobalScope! Use e.g. -sTEXTDECODER=1 when building with -sAUDIO_WORKLET"
+#warning "-sAUDIO_WORKLET does not support -sTEXTDECODER=2 since TextDecoder is not available in AudioWorkletGlobalScope. Text decoding will be unavailable in Audio Worklets. If you need string marshalling in Audio Worklets, build with -sTEXTDECODER=1."
 #endif
 #if AUDIO_WORKLET && SINGLE_FILE
 #error "-sAUDIO_WORKLET does not support -sSINGLE_FILE"


### PR DESCRIPTION
Building with -sTEXTDECODER=2 when targeting -sAUDIO_WORKLET is not catastrophic since the user might very likely never attempt to interop any strings between JS and Wasm from the Audio Worklet thread. So leaving UTF8Decoder to be null there will be fine.