### PR TITLE
Use public `wasm-sourcemap` entry point. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9961,7 +9961,7 @@ int main() {
     # on --sources and --load-prefix options).
     shutil.copy(test_file('other/wasm_sourcemap/no_main.c'), '.')
     DW_AT_decl_file = '/emscripten/test/other/wasm_sourcemap/no_main.c'
-    wasm_map_cmd = [PYTHON, path_from_root('tools/wasm-sourcemap.py'),
+    wasm_map_cmd = [shared.WASM_SOURCEMAP,
                     *sources, *prefix, *load_prefix,
                     '--dwarfdump-output',
                     test_file('other/wasm_sourcemap/foo.wasm.dump'),
@@ -10027,7 +10027,7 @@ int main() {
     self.assertRegex(output, r'"mappings":\s*"(?:[A-Za-z0-9+\/]+[,;]?)+"')
 
   def test_wasm_sourcemap_dead(self):
-    wasm_map_cmd = [PYTHON, path_from_root('tools/wasm-sourcemap.py'),
+    wasm_map_cmd = [shared.WASM_SOURCEMAP,
                     '--dwarfdump-output',
                     test_file('other/wasm_sourcemap_dead/t.wasm.dump'),
                     '-o', 'a.out.wasm.map',

--- a/tools/building.py
+++ b/tools/building.py
@@ -1145,7 +1145,7 @@ def emit_wasm_source_map(wasm_file, map_file, final_wasm):
   # source file paths must be relative to the location of the map (which is
   # emitted alongside the wasm)
   base_path = os.path.dirname(os.path.abspath(final_wasm))
-  sourcemap_cmd = [sys.executable, '-E', path_from_root('tools/wasm-sourcemap.py'),
+  sourcemap_cmd = [shared.WASM_SOURCEMAP,
                    wasm_file,
                    '--dwarfdump=' + LLVM_DWARFDUMP,
                    '-o',  map_file,


### PR DESCRIPTION
As opposed to running the `.py` file via python manually.

This may or may not help with #25323, but is strictly more correct.