### PR TITLE
Another round of `deadcode` feedback and error suppression. NFC

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -577,7 +577,7 @@ class HTTPWebServer(socketserver.ThreadingMixIn, HTTPServer):
 
 # Processes HTTP request back to the browser.
 class HTTPHandler(SimpleHTTPRequestHandler):
-  protocol_version = 'HTTP/1.1'
+  protocol_version = 'HTTP/1.1'  # noqa: DC01
 
   def send_head(self):
     global page_last_served_time
@@ -663,13 +663,13 @@ class HTTPHandler(SimpleHTTPRequestHandler):
     if code != 200:
       SimpleHTTPRequestHandler.log_request(self, code)
 
-  def log_message(self, format, *args):
+  def log_message(self, format, *args):  # noqa: DC04
     msg = '%s - - [%s] %s\n' % (self.address_string(), self.log_date_time_string(), format % args)
     # Filter out 404 messages on favicon.ico not being found to remove noise.
     if 'favicon.ico' not in msg:
       sys.stderr.write(msg)
 
-  def do_POST(self):
+  def do_POST(self):  # # noqa: DC04
     global page_exit_code, have_received_messages
 
     (_, _, path, query, _) = urlsplit(self.path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ lint.select = [
   "W",
   "YTT",
 ]
-
+lint.external = [ "D" ]
 lint.ignore = [
   "B011", # See https://github.com/PyCQA/flake8-bugbear/issues/66
   "B023",
@@ -110,4 +110,4 @@ module = ["psutil", "win32con", "win32gui", "win32process"]
 ignore_missing_imports = true
 
 [tool.deadcode]
-exclude = ["out", "third_party", "test/third_party", "node_modules", "site/source/_themes", "site/source/conf.py"]
+exclude = ["out", "cache", "third_party", "test/third_party", "node_modules", "site/source/_themes", "site/source/conf.py"]

--- a/test/common.py
+++ b/test/common.py
@@ -2274,7 +2274,7 @@ def make_test_server(in_queue, out_queue, port):
       self.send_header('Cache-Control', 'no-cache, no-store, must-revalidate')
       return SimpleHTTPRequestHandler.end_headers(self)
 
-    def do_POST(self):
+    def do_POST(self):  # noqa: DC04
       urlinfo = urlparse(self.path)
       query = parse_qs(urlinfo.query)
       content_length = int(self.headers['Content-Length'])

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -640,7 +640,7 @@ def get_libs(settings):
   return ret
 
 
-def add_cflags(args, settings): # noqa: U100
+def add_cflags(args, settings):
   """Called during compile phase add any compiler flags (e.g -Ifoo) needed
   by the selected ports.  Can also add/change settings.
 

--- a/tools/tempfiles.py
+++ b/tools/tempfiles.py
@@ -34,12 +34,12 @@ class TempFiles:
     The file will be deleted immediately once the 'with' block is exited.
     """
     class TempFileObject:
-      def __enter__(self_):
+      def __enter__(self_):  # noqa: DC02
         self_.file = tempfile.NamedTemporaryFile(dir=self.tmpdir, suffix=suffix, delete=False)
         self_.file.close() # NamedTemporaryFile passes out open file handles, but callers prefer filenames (and open their own handles manually if needed)
         return self_.file.name
 
-      def __exit__(self_, _type, _value, _traceback):
+      def __exit__(self_, _type, _value, _traceback):  # noqa: DC02
         if not self.save_debug_files:
           utils.delete_file(self_.file.name)
     return TempFileObject()


### PR DESCRIPTION
There are still quite a few false positives after this but they are fall into basically 2 classes:

- Subclasses of TestCase, which are explicitly used
- Subclasses of Library, which are no explicitly user
- Settings, which are only ever read in the JS compiler.

I think we should probably wait until the `deadcode` tool at least supports returning error codes before we try to integrate into CI.  See https://github.com/albertas/deadcode/pull/36