### PR TITLE
Bump min node/firefox/chrome version to ensure globalThis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -876,10 +876,10 @@ jobs:
       # support in the generated code.
       # Keep this in sync with `OLDEST_SUPPORTED_NODE` in `feature_matrix.py`
       - install-node-version:
-          node_version: "10.19.0"
+          node_version: "12.22.9"
       - run-tests:
-          title: "node (oldest / 10.19.0)"
-          extra-cflags: "-sMIN_NODE_VERSION=101900"
+          title: "node (oldest / 12.22.9)"
+          extra-cflags: "-sMIN_NODE_VERSION=122209"
           # We include most but not all of the nodefs and node rawfs tests here.
           # test_fs_nodefs_rw, test_fs_nodefs_statvfs, and test_unistd_io_nodefs_bigint fail.
           test_targets: "

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,11 @@ See docs/process.md for more on how version tagging works.
 
 4.0.16 (in development)
 -----------------------
+- The minimum supported versions of node, chrome and firefox were bumped in
+  order remove the globalThis polyfill: (#25375)
+  - node: v10.19.0 -> v12.22.9
+  - chrome: v70 -> v71
+  - firefox: v55 -> v65
 
 4.0.15 - 09/17/25
 -----------------

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -2859,7 +2859,7 @@ are desired to work. Pass -sMIN_FIREFOX_VERSION=majorVersion to drop support
 for Firefox versions older than < majorVersion.
 Firefox 79 was released on 2020-07-28.
 MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-Minimum supported value is 55 which was released on 2017-08-08 (see
+Minimum supported value is 65 which was released on 2019-01-29 (see
 feature_matrix.py)
 
 Default value: 79
@@ -2891,13 +2891,13 @@ Default value: 150000
 MIN_CHROME_VERSION
 ==================
 
-Specifies the oldest version of Chrome. E.g. pass -sMIN_CHROME_VERSION=58 to
-drop support for Chrome 57 and older.
+Specifies the oldest version of Chrome. E.g. pass -sMIN_CHROME_VERSION=78 to
+drop support for Chrome 77 and older.
 This setting also applies to modern Chromium-based Edge, which shares version
 numbers with Chrome.
 Chrome 85 was released on 2020-08-25.
 MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-Minimum supported value is 70, which was released on 2018-10-16 (see
+Minimum supported value is 71, which was released on 2018-12-04 (see
 feature_matrix.py).
 
 Default value: 85
@@ -2909,10 +2909,9 @@ MIN_NODE_VERSION
 
 Specifies minimum node version to target for the generated code.  This is
 distinct from the minimum version required run the emscripten compiler.
-This version aligns with the current Ubuuntu TLS 20.04 (Focal).
 Version is encoded in MMmmVV, e.g. 181401 denotes Node 18.14.01.
-Minimum supported value is 101900, which was released 2020-02-05 (see
-feature_matrix.py).
+Minimum supported value is 122209, which was released 2022-01-11 (see
+feature_matrix.py). This version aligns with the Ubuntu TLS 22.04 (Jammy).
 
 Default value: 160000
 

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1610,45 +1610,10 @@ addToLibrary({
   emscripten_asm_const_async_on_main_thread: (emAsmAddr, sigPtr, argbuf) => runMainThreadEmAsm(emAsmAddr, sigPtr, argbuf, 0),
 #endif
 
-  $emGlobalThis__internal: true,
-#if SUPPORTS_GLOBALTHIS
-  $emGlobalThis: 'globalThis',
-#else
-  $getGlobalThis__internal: true,
-  $getGlobalThis: () => {
-    if (typeof globalThis != 'undefined') {
-      return globalThis;
-    }
-#if DYNAMIC_EXECUTION
-    return new Function('return this')();
-#else
-    function testGlobal(obj) {
-      // Use __emGlobalThis as a test symbol to see if `obj` is indeed the
-      // global object.
-      obj['__emGlobalThis'] = obj;
-      var success = typeof __emGlobalThis == 'object' && obj['__emGlobalThis'] === obj;
-      delete obj['__emGlobalThis'];
-      return success;
-    }
-    if (typeof self != 'undefined' && testGlobal(self)) {
-      return self; // This works for both "window" and "self" (Web Workers) global objects
-    }
-#if ENVIRONMENT_MAY_BE_NODE
-    if (typeof global != 'undefined' && testGlobal(global)) {
-      return global;
-    }
-#endif
-    abort('unable to get global object.');
-#endif // DYNAMIC_EXECUTION
-  },
-  $emGlobalThis__deps: ['$getGlobalThis'],
-  $emGlobalThis: 'getGlobalThis()',
-#endif // SUPPORTS_GLOBALTHIS
-
 #if !DECLARE_ASM_MODULE_EXPORTS
   // When DECLARE_ASM_MODULE_EXPORTS is not set we export native symbols
   // at runtime rather than statically in JS code.
-  $exportWasmSymbols__deps: ['$asmjsMangle', '$emGlobalThis',
+  $exportWasmSymbols__deps: ['$asmjsMangle',
 #if DYNCALLS || !WASM_BIGINT
     , '$dynCalls'
 #endif
@@ -1666,9 +1631,9 @@ addToLibrary({
       // similar DECLARE_ASM_MODULE_EXPORTS = 0 treatment.
       if (typeof exportedSymbol.value === 'undefined') {
 #if MINIMAL_RUNTIME
-        emGlobalThis[name] = exportedSymbol;
+        globalThis[name] = exportedSymbol;
 #else
-        emGlobalThis[name] = Module[name] = exportedSymbol;
+        globalThis[name] = Module[name] = exportedSymbol;
 #endif
       }
     }

--- a/src/lib/libemval.js
+++ b/src/lib/libemval.js
@@ -170,13 +170,13 @@ var LibraryEmVal = {
   _emval_new_u16string__deps: ['$Emval'],
   _emval_new_u16string: (v) => Emval.toHandle(UTF16ToString(v)),
 
-  _emval_get_global__deps: ['$Emval', '$getStringOrSymbol', '$emGlobalThis'],
+  _emval_get_global__deps: ['$Emval', '$getStringOrSymbol'],
   _emval_get_global: (name) => {
     if (!name) {
-      return Emval.toHandle(emGlobalThis);
+      return Emval.toHandle(globalThis);
     }
     name = getStringOrSymbol(name);
-    return Emval.toHandle(emGlobalThis[name]);
+    return Emval.toHandle(globalThis[name]);
   },
 
   _emval_get_module_property__deps: ['$getStringOrSymbol', '$Emval'],

--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -236,10 +236,6 @@ var LibraryHTML5 = {
 
     fullscreenEnabled() {
       return document.fullscreenEnabled
-#if MIN_FIREFOX_VERSION <= 63
-      // Firefox 64 shipped unprefixed form of fullscreenEnabled (https://caniuse.com/#feat=mdn-api_document_fullscreenenabled)
-      || document.mozFullScreenEnabled
-#endif
 #if MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
       // Safari 13.0.3 on macOS Catalina 10.15.1 still ships with prefixed webkitFullscreenEnabled.
       // TODO: If Safari at some point ships with unprefixed version, update the version check above.
@@ -1072,12 +1068,7 @@ var LibraryHTML5 = {
 #endif
     if (!target) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
 
-#if MIN_FIREFOX_VERSION <= 63 // https://caniuse.com/#feat=mdn-api_element_fullscreenchange_event
-    registerFullscreenChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_FULLSCREENCHANGE }}}, "mozfullscreenchange", targetThread);
-#endif
-
-#if MIN_CHROME_VERSION < 71 || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
-    // Unprefixed Fullscreen API shipped in Chromium 71 (https://bugs.chromium.org/p/chromium/issues/detail?id=383813)
+#if MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
     // As of Safari 13.0.3 on macOS Catalina 10.15.1 still ships with prefixed webkitfullscreenchange. TODO: revisit this check once Safari ships unprefixed version.
     registerFullscreenChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_FULLSCREENCHANGE }}}, "webkitfullscreenchange", targetThread);
 #endif
@@ -1102,13 +1093,7 @@ var LibraryHTML5 = {
 
     if (target.requestFullscreen) {
       target.requestFullscreen();
-#if MIN_FIREFOX_VERSION <= 63 // https://caniuse.com/#feat=fullscreen
-    } else if (target.mozRequestFullScreen) {
-      target.mozRequestFullScreen();
-    } else if (target.mozRequestFullscreen) {
-      target.mozRequestFullscreen();
-#endif
-#if MIN_CHROME_VERSION <= 70 || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
+#if MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
     } else if (target.webkitRequestFullscreen) {
       target.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
 #endif
@@ -1214,12 +1199,7 @@ var LibraryHTML5 = {
       if (!getFullscreenElement()) {
         document.removeEventListener('fullscreenchange', restoreOldStyle);
 
-#if MIN_FIREFOX_VERSION <= 63 // https://caniuse.com/#feat=mdn-api_element_fullscreenchange_event
-        document.removeEventListener('mozfullscreenchange', restoreOldStyle);
-#endif
-
-#if MIN_CHROME_VERSION < 71 || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
-        // Unprefixed Fullscreen API shipped in Chromium 71 (https://bugs.chromium.org/p/chromium/issues/detail?id=383813)
+#if MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
         // As of Safari 13.0.3 on macOS Catalina 10.15.1 still ships with prefixed webkitfullscreenchange. TODO: revisit this check once Safari ships unprefixed version.
         document.removeEventListener('webkitfullscreenchange', restoreOldStyle);
 #endif
@@ -1258,11 +1238,7 @@ var LibraryHTML5 = {
       }
     }
     document.addEventListener('fullscreenchange', restoreOldStyle);
-#if MIN_FIREFOX_VERSION <= 63 // https://caniuse.com/#feat=mdn-api_element_fullscreenchange_event
-    document.addEventListener('mozfullscreenchange', restoreOldStyle);
-#endif
-#if MIN_CHROME_VERSION < 71 || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
-    // Unprefixed Fullscreen API shipped in Chromium 71 (https://bugs.chromium.org/p/chromium/issues/detail?id=383813)
+#if MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
     // As of Safari 13.0.3 on macOS Catalina 10.15.1 still ships with prefixed webkitfullscreenchange. TODO: revisit this check once Safari ships unprefixed version.
     document.addEventListener('webkitfullscreenchange', restoreOldStyle);
 #endif
@@ -1377,11 +1353,7 @@ var LibraryHTML5 = {
     if (!target) return {{{ cDefs.EMSCRIPTEN_RESULT_UNKNOWN_TARGET }}};
 
     if (!target.requestFullscreen
-#if MIN_FIREFOX_VERSION <= 63 // https://caniuse.com/#feat=fullscreen
-      && !target.mozRequestFullScreen
-      && !target.mozRequestFullscreen
-#endif
-#if MIN_CHROME_VERSION <= 70 || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
+#if MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
       && !target.webkitRequestFullscreen
 #endif
       ) {
@@ -1525,10 +1497,6 @@ var LibraryHTML5 = {
     var d = specialHTMLTargets[{{{ cDefs.EMSCRIPTEN_EVENT_TARGET_DOCUMENT }}}];
     if (d.exitFullscreen) {
       d.fullscreenElement && d.exitFullscreen();
-#if MIN_FIREFOX_VERSION < 64 // https://caniuse.com/#feat=mdn-api_document_exitfullscreen
-    } else if (d.mozCancelFullScreen) {
-      d.mozFullScreenElement && d.mozCancelFullScreen();
-#endif
 #if MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED // https://caniuse.com/#feat=mdn-api_document_exitfullscreen
     } else if (d.webkitExitFullscreen) {
       d.webkitFullscreenElement && d.webkitExitFullscreen();

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -158,7 +158,7 @@ var imports = {
 
 #if MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION
 // https://caniuse.com/#feat=wasm and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
-#if MIN_FIREFOX_VERSION < 58 || MIN_SAFARI_VERSION < 150000 || ENVIRONMENT_MAY_BE_NODE
+#if MIN_SAFARI_VERSION < 150000 || ENVIRONMENT_MAY_BE_NODE
 #if ASSERTIONS && !WASM2JS
 // Module['wasm'] should contain a typed array of the Wasm object data, or a
 // precompiled WebAssembly Module.

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -593,7 +593,7 @@ async function instantiateArrayBuffer(binaryFile, imports) {
 async function instantiateAsync(binary, binaryFile, imports) {
 #if !SINGLE_FILE
   if (!binary
-#if MIN_FIREFOX_VERSION < 58 || MIN_SAFARI_VERSION < 150000
+#if MIN_SAFARI_VERSION < 150000
       // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
       && WebAssembly.instantiateStreaming
 #endif

--- a/src/settings.js
+++ b/src/settings.js
@@ -1873,7 +1873,7 @@ var AUTO_NATIVE_LIBRARIES = true;
 // for Firefox versions older than < majorVersion.
 // Firefox 79 was released on 2020-07-28.
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-// Minimum supported value is 55 which was released on 2017-08-08 (see
+// Minimum supported value is 65 which was released on 2019-01-29 (see
 // feature_matrix.py)
 // [link]
 var MIN_FIREFOX_VERSION = 79;
@@ -1895,23 +1895,22 @@ var MIN_FIREFOX_VERSION = 79;
 // [link]
 var MIN_SAFARI_VERSION = 150000;
 
-// Specifies the oldest version of Chrome. E.g. pass -sMIN_CHROME_VERSION=58 to
-// drop support for Chrome 57 and older.
+// Specifies the oldest version of Chrome. E.g. pass -sMIN_CHROME_VERSION=78 to
+// drop support for Chrome 77 and older.
 // This setting also applies to modern Chromium-based Edge, which shares version
 // numbers with Chrome.
 // Chrome 85 was released on 2020-08-25.
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-// Minimum supported value is 70, which was released on 2018-10-16 (see
+// Minimum supported value is 71, which was released on 2018-12-04 (see
 // feature_matrix.py).
 // [link]
 var MIN_CHROME_VERSION = 85;
 
 // Specifies minimum node version to target for the generated code.  This is
 // distinct from the minimum version required run the emscripten compiler.
-// This version aligns with the current Ubuuntu TLS 20.04 (Focal).
 // Version is encoded in MMmmVV, e.g. 181401 denotes Node 18.14.01.
-// Minimum supported value is 101900, which was released 2020-02-05 (see
-// feature_matrix.py).
+// Minimum supported value is 122209, which was released 2022-01-11 (see
+// feature_matrix.py). This version aligns with the Ubuntu TLS 22.04 (Jammy).
 var MIN_NODE_VERSION = 160000;
 
 // If true, uses minimal sized runtime without POSIX features, Module,

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -158,9 +158,6 @@ var MINIFY_WASM_IMPORTED_MODULES = false;
 // Whether to minify exports from the Wasm module.
 var MINIFY_WASM_EXPORT_NAMES = true;
 
-// Used to track whether target environment supports the 'globalThis' attribute.
-var SUPPORTS_GLOBALTHIS = false;
-
 // Used to track whether target environment supports the 'Promise.any'.
 var SUPPORTS_PROMISE_ANY = false;
 

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -21,14 +21,9 @@ if (!Module) /** @suppress{checkTypes}*/Module =
 
 // When running on the web we expect Module to be defined externally, in the
 // HTML.  Otherwise we must define it here before its first use
-var Module =
-#if SUPPORTS_GLOBALTHIS
-  // As a small code size optimization, we can use 'globalThis' to refer to the global scope Module variable.
-  globalThis.{{{ EXPORT_NAME }}} || {};
-#else
-  // Otherwise do a good old typeof check.
-  typeof {{{ EXPORT_NAME }}} != 'undefined' ? {{{ EXPORT_NAME }}} : {};
-#endif
+// As a small code size optimization, we can use 'globalThis' to refer to the
+// global scope Module variable.
+var Module = globalThis.{{{ EXPORT_NAME }}} || {};
 
 #else
 var Module = {{{ EXPORT_NAME }}};

--- a/test/codesize/test_minimal_runtime_code_size_hello_embind_val.json
+++ b/test/codesize/test_minimal_runtime_code_size_hello_embind_val.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 373,
-  "a.js": 5350,
-  "a.js.gz": 2524,
+  "a.js": 5353,
+  "a.js.gz": 2522,
   "a.wasm": 5852,
   "a.wasm.gz": 2743,
-  "total": 11754,
-  "total_gz": 5640
+  "total": 11757,
+  "total_gz": 5638
 }

--- a/test/common.py
+++ b/test/common.py
@@ -380,7 +380,7 @@ def requires_node_canary(func):
 def node_bigint_flags(node_version):
   # The --experimental-wasm-bigint flag was added in v12, and then removed (enabled by default)
   # in v16.
-  if node_version and node_version < (16, 0, 0) and node_version >= (12, 0, 0):
+  if node_version and node_version < (16, 0, 0):
     return ['--experimental-wasm-bigint']
   else:
     return []
@@ -1346,23 +1346,20 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     # remove this if the issue above is ever fixed.
     self.set_setting('NO_DEFAULT_TO_CXX')
     self.ldflags = []
-    # Increate stack trace limit to maximise usefulness of test failure reports
-    self.node_args = ['--stack-trace-limit=50']
+    # Increase the stack trace limit to maximise usefulness of test failure reports.
+    # Also, include backtrace for all uncuaght exceptions (not just Error).
+    self.node_args = ['--stack-trace-limit=50', '--trace-uncaught']
     self.spidermonkey_args = ['-w']
 
     nodejs = self.get_nodejs()
     if nodejs:
       node_version = shared.get_node_version(nodejs)
-      if node_version < (11, 0, 0):
+      if node_version < (13, 0, 0):
         self.node_args.append('--unhandled-rejections=strict')
-        self.node_args.append('--experimental-wasm-se')
-      else:
-        # Include backtrace for all uncuaght exceptions (not just Error).
-        self.node_args.append('--trace-uncaught')
-        if node_version < (15, 0, 0):
-          # Opt in to node v15 default behaviour:
-          # https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
-          self.node_args.append('--unhandled-rejections=throw')
+      elif node_version < (15, 0, 0):
+        # Opt in to node v15 default behaviour:
+        # https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
+        self.node_args.append('--unhandled-rejections=throw')
       self.node_args += node_bigint_flags(node_version)
 
       # If the version we are running tests in is lower than the version that

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10448,8 +10448,9 @@ int main() {
     # Disable a feature
     compile(['-mno-sign-ext', '-c'])
     verify_features_sec('sign-ext', False)
+
     # Disable via browser selection
-    compile(['-sMIN_FIREFOX_VERSION=61'])
+    compile(['-sMIN_SAFARI_VERSION=120200'])
     verify_features_sec_linked('sign-ext', False)
     compile(['-sMIN_SAFARI_VERSION=140100'])
     verify_features_sec_linked('bulk-memory-opt', False)
@@ -10461,7 +10462,7 @@ int main() {
     compile(['-sMIN_SAFARI_VERSION=160000', '-mno-sign-ext'])
     verify_features_sec_linked('sign-ext', False)
     # Flag enabling overrides explicit browser version
-    compile(['-sMIN_FIREFOX_VERSION=61', '-msign-ext'])
+    compile(['-sMIN_FIREFOX_VERSION=65', '-msign-ext'])
     verify_features_sec_linked('sign-ext', True)
     # Flag disabling overrides explicit version for bulk memory
     compile(['-sMIN_SAFARI_VERSION=150000', '-mno-bulk-memory'])
@@ -14311,8 +14312,6 @@ out.js
     # Specifying an older browser version should trigger the lowering pass
     err = self.run_process(cmd + ['-sMIN_SAFARI_VERSION=120200'], stderr=subprocess.PIPE).stderr
     self.assertContained('--signext-lowering', err)
-    err = self.run_process(cmd + ['-sMIN_FIREFOX_VERSION=61'], stderr=subprocess.PIPE).stderr
-    self.assertContained('--signext-lowering', err)
     err = self.run_process(cmd + ['-sMIN_CHROME_VERSION=73'], stderr=subprocess.PIPE).stderr
     self.assertContained('--signext-lowering', err)
 
@@ -15056,7 +15055,7 @@ addToLibrary({
 
   def test_browser_too_old(self):
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sMIN_CHROME_VERSION=10'])
-    self.assertContained('emcc: error: MIN_CHROME_VERSION older than 70 is not supported', err)
+    self.assertContained('emcc: error: MIN_CHROME_VERSION older than 71 is not supported', err)
 
   def test_js_only_settings(self):
     err = self.run_process([EMCC, test_file('hello_world.c'), '-o', 'foo.wasm', '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=emscripten_get_heap_max'], stderr=PIPE).stderr

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -22,12 +22,12 @@ UNSUPPORTED = 0x7FFFFFFF
 
 # N.b. when modifying these values, update comments in src/settings.js on
 # MIN_x_VERSION fields to match accordingly.
-OLDEST_SUPPORTED_CHROME = 70  # Released on 2018-10-16
-OLDEST_SUPPORTED_FIREFOX = 55  # Released on 2017-08-08
+OLDEST_SUPPORTED_CHROME = 71  # Released on 2018-12-04
+OLDEST_SUPPORTED_FIREFOX = 65  # Released on 2019-01-29
 OLDEST_SUPPORTED_SAFARI = 120200  # Released on 2019-03-25
-# 10.19.0 is the oldest version of node that we do any testing with.
+# 12.22.09 is the oldest version of node that we do any testing with.
 # Keep this in sync with the test-node-compat in .circleci/config.yml.
-OLDEST_SUPPORTED_NODE = 101900
+OLDEST_SUPPORTED_NODE = 122209
 
 
 class Feature(IntEnum):
@@ -37,7 +37,6 @@ class Feature(IntEnum):
   MUTABLE_GLOBALS = auto()
   JS_BIGINT_INTEGRATION = auto()
   THREADS = auto()
-  GLOBALTHIS = auto()
   PROMISE_ANY = auto()
   MEMORY64 = auto()
 
@@ -81,12 +80,6 @@ min_browser_versions = {
     'firefox': 79,
     'safari': 140100,
     'node': 160400,
-  },
-  Feature.GLOBALTHIS: {
-    'chrome': 71,
-    'firefox': 65,
-    'safari': 120100,
-    'node': 120000,
   },
   Feature.PROMISE_ANY: {
     'chrome': 85,
@@ -185,7 +178,5 @@ def apply_min_browser_versions():
     enable_feature(Feature.BULK_MEMORY, 'pthreads')
   elif settings.WASM_WORKERS or settings.SHARED_MEMORY:
     enable_feature(Feature.BULK_MEMORY, 'shared-mem')
-  if settings.AUDIO_WORKLET:
-    enable_feature(Feature.GLOBALTHIS, 'AUDIO_WORKLET')
   if settings.MEMORY64 == 1:
     enable_feature(Feature.MEMORY64, 'MEMORY64')

--- a/tools/link.py
+++ b/tools/link.py
@@ -1472,7 +1472,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
 
   # TODO(sbc): Find make a generic way to expose the feature matrix to JS
   # compiler rather then adding them all ad-hoc as internal settings
-  settings.SUPPORTS_GLOBALTHIS = feature_matrix.caniuse(feature_matrix.Feature.GLOBALTHIS)
   settings.SUPPORTS_PROMISE_ANY = feature_matrix.caniuse(feature_matrix.Feature.PROMISE_ANY)
   if not settings.BULK_MEMORY:
     settings.BULK_MEMORY = feature_matrix.caniuse(feature_matrix.Feature.BULK_MEMORY)


### PR DESCRIPTION
This change bumps the minimum versions of these engines so that we no longer need to support engines without `globalThis`.