### PR TITLE
Support JS symbols that are aliases of native ones

### DIFF
--- a/src/lib/libbootstrap.js
+++ b/src/lib/libbootstrap.js
@@ -15,6 +15,8 @@ assert(Object.keys(LibraryManager.library).length === 0);
 addToLibrary({
   $callRuntimeCallbacks: () => {},
 
+  $wasmMemory: 'memory',
+
   $ExitStatus: class {
     name = 'ExitStatus';
     constructor(status) {

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1641,7 +1641,7 @@ addToLibrary({
 #endif
       }
     }
-
+    exportAliases(wasmExports);
   },
 #endif
 
@@ -2150,8 +2150,6 @@ addToLibrary({
 #endif // MINIMAL_RUNTIME
 
   $asmjsMangle: (x) => {
-    if (x == 'memory') return 'wasmMemory';
-    if (x == '__indirect_function_table') return 'wasmTable';
     if (x == '__main_argc_argv') {
       x = 'main';
     }
@@ -2287,7 +2285,14 @@ addToLibrary({
 });
 `,
 #else
-  $wasmTable: undefined,
+  $wasmTable: '__indirect_function_table',
+#endif
+
+#if IMPORTED_MEMORY
+  // This gets defined in src/runtime_init_memory.js
+  $wasmMemory: undefined,
+#else
+  $wasmMemory: 'memory',
 #endif
 
   $getUniqueRunDependency: (id) => {

--- a/src/lib/liblegacy.js
+++ b/src/lib/liblegacy.js
@@ -114,8 +114,8 @@ legacyFuncs = {
   },
 
   // Legacy names for runtime `out`/`err` symbols.
-  $print: 'out',
-  $printErr: 'err',
+  $print: '=out',
+  $printErr: '=err',
 
   // Converts a JS string to an integer base-10. Despite _s, which
   // suggests signaling error handling, this returns NaN on error.

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -24,6 +24,8 @@ import {
   srcDir,
 } from './utility.mjs';
 
+import { nativeAliases } from './modules.mjs';
+
 const FOUR_GB = 4 * 1024 * 1024 * 1024;
 const WASM_PAGE_SIZE = 64 * 1024;
 const FLOAT_TYPES = new Set(['float', 'double']);
@@ -1155,6 +1157,17 @@ function nodeWWDetection() {
   }
 }
 
+function makeExportAliases() {
+  var res = ''
+  for (var [alias, ex] of Object.entries(nativeAliases)) {
+    if (ASSERTIONS) {
+      res += `  assert(wasmExports['${ex}'], 'alias target "${ex}" not found in wasmExports');\n`;
+    }
+    res += `  globalThis['${alias}'] = wasmExports['${ex}'];\n`;
+  }
+  return res;
+}
+
 addToCompileTimeContext({
   ATEXITS,
   ATPRERUNS,
@@ -1204,6 +1217,7 @@ addToCompileTimeContext({
   isSymbolNeeded,
   makeDynCall,
   makeEval,
+  makeExportAliases,
   makeGetValue,
   makeHEAPView,
   makeModuleReceive,

--- a/src/runtime_common.js
+++ b/src/runtime_common.js
@@ -174,3 +174,9 @@ if (ENVIRONMENT_IS_NODE) {
 #endif // !IMPORTED_MEMORY && ASSERTIONS
 
 #include "memoryprofiler.js"
+
+#if !DECLARE_ASM_MODULE_EXPORTS
+function exportAliases(wasmExports) {
+{{{ makeExportAliases() }}}
+}
+#endif

--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -9,8 +9,6 @@
 #error "this file should not be be included when IMPORTED_MEMORY is set"
 #endif
 
-var wasmMemory;
-
 // check for full engine support (use string 'subarray' to avoid closure compiler confusion)
 
 function initMemory() {

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -275,3 +275,5 @@ var OUTPUT_FORMAT = '';
 // Whether we should load the WASM source map at runtime.
 // This is enabled automatically when using -gsource-map with sanitizers.
 var LOAD_SOURCE_MAP = false;
+
+var ALIASES = [];

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -3154,12 +3154,12 @@ Module["FS_createLazyFile"] = FS_createLazyFile;
 // End JS library exports
 // end include: postlibrary.js
 // Imports from the Wasm binary.
-var _main, wasmMemory, wasmTable;
+var _main, memory, __indirect_function_table, wasmMemory;
 
 function assignWasmExports(wasmExports) {
   _main = Module["_main"] = wasmExports["d"];
-  wasmMemory = wasmExports["b"];
-  wasmTable = wasmExports["__indirect_function_table"];
+  memory = wasmMemory = wasmExports["b"];
+  __indirect_function_table = wasmExports["__indirect_function_table"];
 }
 
 var wasmImports = {

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 26931,
-  "a.out.js.gz": 11473,
+  "a.out.js.gz": 11472,
   "a.out.nodebug.wasm": 18567,
   "a.out.nodebug.wasm.gz": 9199,
   "total": 45498,
-  "total_gz": 20672,
+  "total_gz": 20671,
   "sent": [
     "__heap_base",
     "__indirect_function_table",

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -850,6 +850,8 @@ async function createWasm() {
         err(text);
       }
     };
+
+  
 // End JS library code
 
 // include: postlibrary.js
@@ -1056,7 +1058,6 @@ missingLibrarySymbols.forEach(missingLibrarySymbol)
   'err',
   'callMain',
   'abort',
-  'wasmMemory',
   'wasmExports',
   'HEAPF32',
   'HEAPF64',
@@ -1084,6 +1085,7 @@ missingLibrarySymbols.forEach(missingLibrarySymbol)
   'warnOnce',
   'readEmAsmArgsArray',
   'wasmTable',
+  'wasmMemory',
   'noExitRuntime',
   'addRunDependency',
   'removeRunDependency',
@@ -1315,8 +1317,9 @@ var _emscripten_stack_get_end = makeInvalidEarlyAccess('_emscripten_stack_get_en
 var __emscripten_stack_restore = makeInvalidEarlyAccess('__emscripten_stack_restore');
 var __emscripten_stack_alloc = makeInvalidEarlyAccess('__emscripten_stack_alloc');
 var _emscripten_stack_get_current = makeInvalidEarlyAccess('_emscripten_stack_get_current');
+var memory = makeInvalidEarlyAccess('memory');
+var __indirect_function_table = makeInvalidEarlyAccess('__indirect_function_table');
 var wasmMemory = makeInvalidEarlyAccess('wasmMemory');
-var wasmTable = makeInvalidEarlyAccess('wasmTable');
 
 function assignWasmExports(wasmExports) {
   _add = Module['_add'] = createExportWrapper('add', 2);
@@ -1328,8 +1331,8 @@ function assignWasmExports(wasmExports) {
   __emscripten_stack_restore = wasmExports['_emscripten_stack_restore'];
   __emscripten_stack_alloc = wasmExports['_emscripten_stack_alloc'];
   _emscripten_stack_get_current = wasmExports['emscripten_stack_get_current'];
-  wasmMemory = wasmExports['memory'];
-  wasmTable = wasmExports['__indirect_function_table'];
+  memory = wasmMemory = wasmExports['memory'];
+  __indirect_function_table = wasmExports['__indirect_function_table'];
 }
 
 var _global_val = Module['_global_val'] = 65536;

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7613,
-  "a.out.js.gz": 3764,
+  "a.out.js": 7609,
+  "a.out.js.gz": 3762,
   "a.out.nodebug.wasm": 19599,
   "a.out.nodebug.wasm.gz": 9063,
-  "total": 27212,
-  "total_gz": 12827,
+  "total": 27208,
+  "total_gz": 12825,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,9 +1,9 @@
 {
-  "a.out.js": 8040,
+  "a.out.js": 8036,
   "a.out.js.gz": 3962,
   "a.out.nodebug.wasm": 19600,
   "a.out.nodebug.wasm.gz": 9064,
-  "total": 27640,
+  "total": 27636,
   "total_gz": 13026,
   "sent": [
     "a (memory)",

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 55400,
-  "hello_world.js.gz": 17483,
+  "hello_world.js": 55508,
+  "hello_world.js.gz": 17498,
   "hello_world.wasm": 15127,
   "hello_world.wasm.gz": 7450,
-  "no_asserts.js": 26559,
-  "no_asserts.js.gz": 8867,
+  "no_asserts.js": 26614,
+  "no_asserts.js.gz": 8877,
   "no_asserts.wasm": 12227,
   "no_asserts.wasm.gz": 6010,
-  "strict.js": 53438,
-  "strict.js.gz": 16822,
+  "strict.js": 53546,
+  "strict.js.gz": 16835,
   "strict.wasm": 15127,
   "strict.wasm.gz": 7447,
-  "total": 177878,
-  "total_gz": 64079
+  "total": 178149,
+  "total_gz": 64117
 }

--- a/test/other/test_symbol_map.O3.symbols
+++ b/test/other/test_symbol_map.O3.symbols
@@ -3,4 +3,6 @@
 2:middle
 3:main
 4:foo::cpp_func(int)
-5:__wasm_call_ctors
+5:emscripten_stack_get_current
+6:_emscripten_stack_restore
+7:__wasm_call_ctors

--- a/tools/building.py
+++ b/tools/building.py
@@ -571,7 +571,8 @@ def closure_compiler(filename, advanced=True, extra_closure_args=None):
   # externs file for the exports, Closure is able to reason about the exports.
   if settings.WASM_EXPORTS and not settings.DECLARE_ASM_MODULE_EXPORTS:
     # Generate an exports file that records all the exported symbols from the wasm module.
-    module_exports_suppressions = '\n'.join(['/**\n * @suppress {duplicate, undefinedVars}\n */\nvar %s;\n' % asmjs_mangle(i) for i in settings.WASM_EXPORTS])
+    exports = [asmjs_mangle(i) for i in settings.WASM_EXPORTS] + settings.ALIASES
+    module_exports_suppressions = '\n'.join(['/**\n * @suppress {duplicate, undefinedVars}\n */\nvar %s;\n' % e for e in exports])
     exports_file = shared.get_temp_files().get('.js', prefix='emcc_module_exports_')
     exports_file.write(module_exports_suppressions.encode())
     exports_file.close()

--- a/tools/link.py
+++ b/tools/link.py
@@ -1069,6 +1069,8 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     if prop not in settings.ALL_INCOMING_MODULE_JS_API:
       diagnostics.warning('unused-command-line-argument', f'invalid entry in INCOMING_MODULE_JS_API: {prop}')
 
+  settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.append('$wasmMemory')
+
   if 'noExitRuntime' in settings.INCOMING_MODULE_JS_API:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.append('$noExitRuntime')
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -637,11 +637,6 @@ def asmjs_mangle(name):
   Prepends '_' and replaces non-alphanumerics with '_'.
   Used by wasm backend for JS library consistency with asm.js.
   """
-  # We rename certain well-known exports to match what we call them in JS
-  if name == 'memory':
-    return 'wasmMemory'
-  if name == '__indirect_function_table':
-    return 'wasmTable'
   # We also use this function to convert the clang-mangled `__main_argc_argv`
   # to simply `main` which is expected by the emscripten JS glue code.
   if name == '__main_argc_argv':


### PR DESCRIPTION
We can then use this mechanism to replace the hacky way to we map things like `memory` -> `wasmMemory` and `__indirect_function_table` => `wasmTable`.