### PR TITLE
[testing] Fix disable browser auto config.

### DIFF
--- a/test/runner.py
+++ b/test/runner.py
@@ -495,7 +495,7 @@ def parse_args():
                       help='Command to launch web browser in which to run browser tests.')
   parser.add_argument('--headless', action='store_true',
                       help='Run browser tests in headless mode.', default=None)
-  parser.add_argument('--browser-auto-config', type=bool, default=True,
+  parser.add_argument('--browser-auto-config', action=argparse.BooleanOptionalAction, default=None,
                       help='Use the default CI browser configuration.')
   parser.add_argument('tests', nargs='*')
   parser.add_argument('--failfast', action='store_true', help='If true, test run will abort on first failed test.')
@@ -533,7 +533,7 @@ def parse_args():
 
 def configure():
   browser_common.EMTEST_BROWSER = os.getenv('EMTEST_BROWSER')
-  browser_common.EMTEST_BROWSER_AUTO_CONFIG = os.getenv('EMTEST_BROWSER_AUTO_CONFIG')
+  browser_common.EMTEST_BROWSER_AUTO_CONFIG = int(os.getenv('EMTEST_BROWSER_AUTO_CONFIG', '1'))
   browser_common.EMTEST_HEADLESS = int(os.getenv('EMTEST_HEADLESS', '0'))
   common.EMTEST_DETECT_TEMPFILE_LEAKS = int(os.getenv('EMTEST_DETECT_TEMPFILE_LEAKS', '0'))
   common.EMTEST_ALL_ENGINES = int(os.getenv('EMTEST_ALL_ENGINES', '0'))


### PR DESCRIPTION
Can now use `--no-browser-auto-config` or the env variable.