### PR TITLE
Bump min supported chrome version from 71 -> 73

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,11 +20,12 @@ See docs/process.md for more on how version tagging works.
 
 4.0.16 (in development)
 -----------------------
-- The minimum supported versions of node, chrome and firefox were bumped in
-  order remove the globalThis polyfill: (#25375)
-  - node: v10.19.0 -> v12.22.9
-  - chrome: v70 -> v71
-  - firefox: v55 -> v65
+- The minimum supported versions of Node, Chrome and Firefox were bumped
+  enabling the removal of the `globalThis` polyfill and universally enabling
+  mutable globals: (#25375, #25385)
+  - Node: v10.19.0 -> v12.22.9
+  - Chrome: v70 -> v74
+  - Firefox: v55 -> v65
 
 4.0.15 - 09/17/25
 -----------------

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -2897,7 +2897,7 @@ This setting also applies to modern Chromium-based Edge, which shares version
 numbers with Chrome.
 Chrome 85 was released on 2020-08-25.
 MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-Minimum supported value is 71, which was released on 2018-12-04 (see
+Minimum supported value is 74, which was released on 2019-04-23 (see
 feature_matrix.py).
 
 Default value: 85

--- a/src/settings.js
+++ b/src/settings.js
@@ -1901,7 +1901,7 @@ var MIN_SAFARI_VERSION = 150000;
 // numbers with Chrome.
 // Chrome 85 was released on 2020-08-25.
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-// Minimum supported value is 71, which was released on 2018-12-04 (see
+// Minimum supported value is 74, which was released on 2019-04-23 (see
 // feature_matrix.py).
 // [link]
 var MIN_CHROME_VERSION = 85;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14298,8 +14298,8 @@ out.js
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Wno-transpile', '-Werror', '-sWASM_BIGINT', '-sMIN_SAFARI_VERSION=130000'])
     self.assertContained('emcc: error: MIN_SAFARI_VERSION=130000 is not compatible with WASM_BIGINT (150000 or above required)', err)
 
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Wno-transpile', '-Werror', '-pthread', '-sMIN_CHROME_VERSION=73'])
-    self.assertContained('emcc: error: MIN_CHROME_VERSION=73 is not compatible with pthreads (74 or above required)', err)
+    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Wno-transpile', '-Werror', '-pthread', '-sMIN_FIREFOX_VERSION=65'])
+    self.assertContained('emcc: error: MIN_FIREFOX_VERSION=65 is not compatible with pthreads (79 or above required)', err)
 
   def test_signext_lowering(self):
     # Use `-v` to show the sub-commands being run by emcc.
@@ -14311,8 +14311,6 @@ out.js
 
     # Specifying an older browser version should trigger the lowering pass
     err = self.run_process(cmd + ['-sMIN_SAFARI_VERSION=120200'], stderr=subprocess.PIPE).stderr
-    self.assertContained('--signext-lowering', err)
-    err = self.run_process(cmd + ['-sMIN_CHROME_VERSION=73'], stderr=subprocess.PIPE).stderr
     self.assertContained('--signext-lowering', err)
 
   @flaky('https://github.com/emscripten-core/emscripten/issues/20125')
@@ -15055,7 +15053,7 @@ addToLibrary({
 
   def test_browser_too_old(self):
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sMIN_CHROME_VERSION=10'])
-    self.assertContained('emcc: error: MIN_CHROME_VERSION older than 71 is not supported', err)
+    self.assertContained('emcc: error: MIN_CHROME_VERSION older than 74 is not supported', err)
 
   def test_js_only_settings(self):
     err = self.run_process([EMCC, test_file('hello_world.c'), '-o', 'foo.wasm', '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=emscripten_get_heap_max'], stderr=PIPE).stderr

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -22,7 +22,7 @@ UNSUPPORTED = 0x7FFFFFFF
 
 # N.b. when modifying these values, update comments in src/settings.js on
 # MIN_x_VERSION fields to match accordingly.
-OLDEST_SUPPORTED_CHROME = 71  # Released on 2018-12-04
+OLDEST_SUPPORTED_CHROME = 74  # Released on 2019-04-23
 OLDEST_SUPPORTED_FIREFOX = 65  # Released on 2019-01-29
 OLDEST_SUPPORTED_SAFARI = 120200  # Released on 2019-03-25
 # 12.22.09 is the oldest version of node that we do any testing with.
@@ -34,7 +34,6 @@ class Feature(IntEnum):
   NON_TRAPPING_FPTOINT = auto()
   SIGN_EXT = auto()
   BULK_MEMORY = auto()
-  MUTABLE_GLOBALS = auto()
   JS_BIGINT_INTEGRATION = auto()
   THREADS = auto()
   PROMISE_ANY = auto()
@@ -62,12 +61,6 @@ min_browser_versions = {
     'firefox': 79,
     'safari': 150000,
     'node': 130000,
-  },
-  Feature.MUTABLE_GLOBALS: {
-    'chrome': 74,
-    'firefox': 61,
-    'safari': 120000,
-    'node': 120000,
   },
   Feature.JS_BIGINT_INTEGRATION: {
     'chrome': 67,


### PR DESCRIPTION
This means we no longer need to worry about engines without mutable global support.

Followup to #25375.