### PR TITLE
[CI] Remove `--experimental-wasm-stack-switching` from chrome flags.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,8 @@ commands:
             # If that download link breaks, temporarily use this URL instead:
             # wget -O ~/chrome.deb https://storage.googleapis.com/webassembly/chrome/google-chrome-stable_current_amd64.deb
             dpkg -i ~/chrome.deb
+            echo "Chrome version:"
+            /usr/bin/google-chrome --version
   emsdk-env:
     description: "emsdk_env.sh"
     steps:

--- a/test/common.py
+++ b/test/common.py
@@ -98,7 +98,7 @@ class ChromeConfig:
     # --no-sandbox because we are running as root and chrome requires
     # this flag for now: https://crbug.com/638180
     '--no-first-run -start-maximized --no-sandbox --enable-unsafe-swiftshader --use-gl=swiftshader --enable-experimental-web-platform-features --enable-features=JavaScriptSourcePhaseImports',
-    '--enable-experimental-webassembly-features --js-flags="--experimental-wasm-stack-switching --experimental-wasm-type-reflection --experimental-wasm-rab-integration"',
+    '--enable-experimental-webassembly-features --js-flags="--experimental-wasm-type-reflection --experimental-wasm-rab-integration"',
     # The runners lack sound hardware so fallback to a dummy device (and
     # bypass the user gesture so audio tests work without interaction)
     '--use-fake-device-for-media-stream --autoplay-policy=no-user-gesture-required',


### PR DESCRIPTION
It looks like this flag was removed, causing the flags after it to be ignored:

```
Error: unrecognized flag --experimental-wasm-stack-switching
The remaining arguments were ignored: --experimental-wasm-type-reflection --experimental-wasm-rab-integration
```