### PR TITLE
[contrib.glfw3] - New version (bug fix)

### DIFF
--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -3,10 +3,10 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-TAG = '3.4.0.20250824'
+TAG = '3.4.0.20250927'
 
 EXTERNAL_PORT = f'https://github.com/pongasoft/emscripten-glfw/releases/download/v{TAG}/emscripten-glfw3-{TAG}.zip'
-SHA512 = 'b5b3670b80c87571ea56a54e701874d6b2323f74e359782a15c9ae0a931341fb05e4c778945950f8846aef66c7cc48556d30c8cc5939c87e3091c8be63856a1a'
+SHA512 = 'c1906c3e9356bf645b9d74115efb4f2029ab3e5bf5a60f18ec6a6a88c22e6374e7e388ef454f4c3c2e4b9b17c4482c04a9401885e956e2bad360acdb5157a35d'
 PORT_FILE = 'port/glfw3.py'
 
 # contrib port information (required)


### PR DESCRIPTION
- Fixed [#23](https://github.com/pongasoft/emscripten-glfw/issues/23): Calling `glfwInit()` breaks various input elements
