### PR TITLE
Lift the previous 100 max workers to limit

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -229,8 +229,9 @@ def create_emrun_safe_firefox_profile():
   temp_firefox_profile_dir = tempfile.mkdtemp(prefix='temp_emrun_firefox_profile_')
   with open(os.path.join(temp_firefox_profile_dir, 'prefs.js'), 'w') as f:
     f.write('''
-// Lift the default max 20 workers limit to something higher to avoid hangs when page needs to spawn a lot of threads.
-user_pref("dom.workers.maxPerDomain", 100);
+// Old Firefox browsers have a maxPerDomain limit of 20. Newer Firefox browsers default to 512. Match the new
+// default here to help test spawning a lot of threads also on older Firefox versions.
+user_pref("dom.workers.maxPerDomain", 512);
 // Always allow opening popups
 user_pref("browser.popups.showPopupBlocker", false);
 user_pref("dom.disable_open_during_load", false);

--- a/test/firefox_user.js
+++ b/test/firefox_user.js
@@ -1,5 +1,6 @@
-// Lift the default max 20 workers limit to something higher to avoid hangs when page needs to spawn a lot of threads.
-user_pref("dom.workers.maxPerDomain", 100);
+// Old Firefox browsers have a maxPerDomain limit of 20. Newer Firefox browsers default to 512. Match the new
+// default here to help test spawning a lot of threads also on older Firefox versions.
+user_pref("dom.workers.maxPerDomain", 512);
 // Always allow opening popups
 user_pref("browser.popups.showPopupBlocker", false);
 user_pref("dom.disable_open_during_load", false);


### PR DESCRIPTION
A long time ago, Firefox had a default limit of `dom.workers.maxPerDomain == 20`, and a hardcoded cap of `navigator.hardwareConcurrency` reporting 16 even on systems that would have more hardware threads.

To work around those limits for Emscripten tests that hammered lots of Workers, we had bumped the default `dom.workers.maxPerDomain` limit from 20 up to 100.

In [August 2016](https://github.com/mozilla-firefox/firefox/commit/f6650e86149143e8ccebfac01fb8a68ed0365655#diff-8c2c5665d52eb6026c4017acc0c311c6d9cc6b2b8719f50c1539ee836f2ea361R97-R114), Firefox itself bumped the same default limit of  `dom.workers.maxPerDomain` from 20 up to 512.

Then in April of this year, Firefox [lifted the hardcoded cap](https://github.com/mozilla-firefox/firefox/commit/af05ed3758dcea82b568e3b2daf0c3f2171bab14) of `navigator.hardwareConcurrency` from 16 up to 128.

This means that the limit `user_pref("dom.workers.maxPerDomain", 100);` we now have is too small, and on a 256-thread workstation, caused attempting to spawn >100 Workers in the Pthread pool to hang, as 128 concurrent Workers would not be allowed.

So remove  the previous 100 max workers limit. Explicitly bump it up to the same default limit 512 that Firefox has to make the limit go away in testing older browsers as well.

Fixes e.g. `browser.test_pthread_hardware_concurrency` on >128-thread workstations.
