### PR TITLE
Use createNamedFunction in the dynamic linker

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -41,6 +41,10 @@ addToLibrary({
   setTempRet0: '$setTempRet0',
   getTempRet0: '$getTempRet0',
 
+  // Assign a name to a given function. This is mostly useful for debugging
+  // purposes in cases where new functions are created at runtime.
+  $createNamedFunction: (name, func) => Object.defineProperty(func, 'name', { value: name }),
+
   $ptrToString: (ptr) => {
 #if ASSERTIONS
     assert(typeof ptr === 'number', `ptrToString expects a number, got ${typeof ptr}`);

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -116,7 +116,7 @@ var LibraryDylink = {
   // the canonical name of the symbol (in some cases is modify the symbol as
   // part of the loop process, so that actual symbol looked up has a different
   // name).
-  $resolveGlobalSymbol__deps: ['$isSymbolDefined',
+  $resolveGlobalSymbol__deps: ['$isSymbolDefined', '$createNamedFunction',
 #if !DISABLE_EXCEPTION_CATCHING || SUPPORT_LONGJMP == 'emscripten'
     '$createInvokeFunction',
 #endif
@@ -138,7 +138,7 @@ var LibraryDylink = {
     // Asm.js-style exception handling: invoke wrapper generation
     else if (symName.startsWith('invoke_')) {
       // Create (and cache) new invoke_ functions on demand.
-      sym = wasmImports[symName] = createInvokeFunction(symName.split('_')[1]);
+      sym = wasmImports[symName] = createNamedFunction(symName, createInvokeFunction(symName.split('_')[1]));
     }
 #endif
 #if !DISABLE_EXCEPTION_CATCHING
@@ -147,13 +147,13 @@ var LibraryDylink = {
       // `__cxa_find_matching_catch_` (see jsifier.js) that we know are needed,
       // but a side module loaded at runtime might need different/additional
       // variants so we create those dynamically.
-      sym = wasmImports[symName] = (...args) => {
+      sym = wasmImports[symName] = createNamedFunction(symName, (...args) => {
 #if MEMORY64
         args = args.map(Number);
 #endif
         var rtn = findMatchingCatch(args);
         return {{{ to64('rtn') }}};
-      }
+      });
     }
 #endif
     return {sym, name: symName};

--- a/src/lib/libembind.js
+++ b/src/lib/libembind.js
@@ -122,8 +122,6 @@ var LibraryEmbind = {
     }
   },
 
-  $createNamedFunction: (name, func) => Object.defineProperty(func, 'name', { value: name }),
-
   $embindRepr: (v) => {
     if (v === null) {
         return 'null';

--- a/src/lib/libembind_gen.js
+++ b/src/lib/libembind_gen.js
@@ -870,7 +870,6 @@ var LibraryEmbind = {
   // Stub functions used by eval, but not needed for TS generation:
   $makeLegalFunctionName: () => { throw new Error('stub function should not be called'); },
   $runDestructors: () => { throw new Error('stub function should not be called'); },
-  $createNamedFunction: () => { throw new Error('stub function should not be called'); },
   $flushPendingDeletes: () => { throw new Error('stub function should not be called'); },
   $setDelayFunction: () => { throw new Error('stub function should not be called'); },
   $PureVirtualError: () => { throw new Error('stub function should not be called'); },

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22458,
-  "a.out.js.gz": 8308,
+  "a.out.js": 22478,
+  "a.out.js.gz": 8314,
   "a.out.nodebug.wasm": 15127,
   "a.out.nodebug.wasm.gz": 7450,
-  "total": 37585,
-  "total_gz": 15758,
+  "total": 37605,
+  "total_gz": 15764,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26946,
-  "a.out.js.gz": 11478,
+  "a.out.js": 26985,
+  "a.out.js.gz": 11495,
   "a.out.nodebug.wasm": 18567,
   "a.out.nodebug.wasm.gz": 9199,
-  "total": 45513,
-  "total_gz": 20677,
+  "total": 45552,
+  "total_gz": 20694,
   "sent": [
     "__heap_base",
     "__indirect_function_table",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 245989,
+  "a.out.js": 246028,
   "a.out.nodebug.wasm": 597755,
-  "total": 843744,
+  "total": 843783,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -877,6 +877,7 @@ Module['FS_createPreloadedFile'] = FS.createPreloadedFile;
   'stackAlloc',
   'getTempRet0',
   'setTempRet0',
+  'createNamedFunction',
   'zeroMemory',
   'exitJS',
   'getHeapMax',

--- a/test/codesize/test_codesize_minimal_O0.json
+++ b/test/codesize/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 17734,
-  "a.out.js.gz": 6610,
+  "a.out.js": 17754,
+  "a.out.js.gz": 6617,
   "a.out.nodebug.wasm": 1136,
   "a.out.nodebug.wasm.gz": 659,
-  "total": 18870,
-  "total_gz": 7269,
+  "total": 18890,
+  "total_gz": 7276,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 54108,
-  "hello_world.js.gz": 17086,
+  "hello_world.js": 54133,
+  "hello_world.js.gz": 17091,
   "hello_world.wasm": 15127,
   "hello_world.wasm.gz": 7450,
   "no_asserts.js": 26513,
   "no_asserts.js.gz": 8864,
   "no_asserts.wasm": 12227,
   "no_asserts.wasm.gz": 6010,
-  "strict.js": 52146,
-  "strict.js.gz": 16420,
+  "strict.js": 52171,
+  "strict.js.gz": 16426,
   "strict.wasm": 15127,
   "strict.wasm.gz": 7447,
-  "total": 175248,
-  "total_gz": 63277
+  "total": 175298,
+  "total_gz": 63288
 }


### PR DESCRIPTION
This helps with debugging since the runtime-generated functions show up in backtraces with meaningful names.