### PR TITLE
[WasmFS] Suppress Node.js warnings for unmanaged FDs

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -48,6 +48,12 @@ const pthreadWorkerOptions = `{
         // This is the way that we signal to the node worker that it is hosting
         // a pthread.
         'workerData': 'em-pthread',
+#if WASMFS
+        // In WasmFS, close() is not proxied to the main thread. Suppress
+        // warnings when a thread closes a file descriptor it didn't open.
+        // See: https://github.com/emscripten-core/emscripten/issues/24731
+        'trackUnmanagedFds': false,
+#endif
 #endif
 #if ENVIRONMENT_MAY_BE_WEB || ENVIRONMENT_MAY_BE_WORKER
         // This is the way that we signal to the Web Worker that it is hosting

--- a/test/other/test_pthread_fd_close.c
+++ b/test/other/test_pthread_fd_close.c
@@ -1,0 +1,29 @@
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <unistd.h>
+
+void* thread_func(void* arg) {
+    int* fd = (int*)arg;
+
+    printf("thread main\n");
+    int rc = close(*fd);
+    printf("close: %d\n", rc);
+
+    return NULL;
+}
+
+int main() {
+    printf("main\n");
+    int fd = open("example.txt", O_RDWR | O_CREAT, 0644);
+
+    pthread_t t;
+    int rc = pthread_create(&t, NULL, thread_func, &fd);
+    printf("pthread_create: %d\n", rc);
+    rc = pthread_join(t, NULL);
+    printf("pthread_join: %d\n", rc);
+
+    printf("done\n");
+
+    return 0;
+}

--- a/test/other/test_pthread_fd_close.c
+++ b/test/other/test_pthread_fd_close.c
@@ -4,26 +4,26 @@
 #include <unistd.h>
 
 void* thread_func(void* arg) {
-    int* fd = (int*)arg;
+  int* fd = (int*)arg;
 
-    printf("thread main\n");
-    int rc = close(*fd);
-    printf("close: %d\n", rc);
+  printf("thread main\n");
+  int rc = close(*fd);
+  printf("close: %d\n", rc);
 
-    return NULL;
+  return NULL;
 }
 
 int main() {
-    printf("main\n");
-    int fd = open("example.txt", O_RDWR | O_CREAT, 0644);
+  printf("main\n");
+  int fd = open("example.txt", O_RDWR | O_CREAT, 0644);
 
-    pthread_t t;
-    int rc = pthread_create(&t, NULL, thread_func, &fd);
-    printf("pthread_create: %d\n", rc);
-    rc = pthread_join(t, NULL);
-    printf("pthread_join: %d\n", rc);
+  pthread_t t;
+  int rc = pthread_create(&t, NULL, thread_func, &fd);
+  printf("pthread_create: %d\n", rc);
+  rc = pthread_join(t, NULL);
+  printf("pthread_join: %d\n", rc);
 
-    printf("done\n");
+  printf("done\n");
 
-    return 0;
+  return 0;
 }

--- a/test/other/test_pthread_fd_close.out
+++ b/test/other/test_pthread_fd_close.out
@@ -1,0 +1,6 @@
+main
+pthread_create: 0
+thread main
+close: 0
+pthread_join: 0
+done

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13556,6 +13556,13 @@ void foo() {}
   def test_pthread_set_main_loop(self, args):
     self.do_other_test('test_pthread_set_main_loop.c', cflags=args)
 
+  @node_pthreads
+  def test_pthread_fd_close_wasmfs(self):
+    create_file('node_warnings', '')
+    self.node_args += ['--trace-warnings', '--redirect-warnings=node_warnings']
+    self.do_other_test('test_pthread_fd_close.c', cflags=['-sWASMFS', '-sNODERAWFS'])
+    self.assertNotContained('closed but not opened in unmanaged mode', read_file('node_warnings'))
+
   # unistd tests
 
   def test_unistd_confstr(self):


### PR DESCRIPTION
In WasmFS, calling `close()` on a file descriptor from a thread that did not open it can trigger harmless Node.js warnings.

To prevent this, set `trackUnmanagedFds` to `false` for pthread workers when WasmFS is enabled.

Resolves: #24731.