### PR TITLE
Add env. var. EMTEST_S_SETTINGS to allow overriding -s variables for a test run.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -167,7 +167,7 @@ def errlog(*args):
 
 def parse_emtest_s_settings():
   s_settings = {}
-  for setting in shlex.split(os.getenv('EMTEST_S_SETTINGS')):
+  for setting in shlex.split(os.getenv('EMTEST_S_SETTINGS', '')):
     if '=' in setting:
       key, value = setting.split('=')
     else:

--- a/test/common.py
+++ b/test/common.py
@@ -165,6 +165,20 @@ def errlog(*args):
   print(*args, file=sys.stderr)
 
 
+def parse_emtest_s_settings():
+  s_settings = {}
+  for setting in shlex.split(os.getenv('EMTEST_S_SETTINGS')):
+    if '=' in setting:
+      key, value = setting.split('=')
+    else:
+      key = setting
+      value = '1'
+
+    logger.debug(f'Applying testing override -s{key}={value}')
+    s_settings[key] = value
+  return s_settings
+
+
 def load_previous_test_run_results():
   try:
     return json.load(open(PREVIOUS_TEST_RUN_RESULTS_FILE))
@@ -1421,6 +1435,10 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         ensure_dir(self.working_dir)
       utils.write_file(LAST_TEST, self.id() + '\n')
     os.chdir(self.working_dir)
+
+    # Apply overrides to -s settings from EMTEST_S_SETTINGS env. variable:
+    for k, v in parse_emtest_s_settings().items():
+      self.set_setting(k, v)
 
   def runningInParallel(self):
     return getattr(self, 'is_parallel', False)


### PR DESCRIPTION
Adjust the testing base class to read extra -s settings from environment variable EMTEST_S_SETTINGS.

This way I can have my CI perform custom test runs with `EMTEST_S_SETTINGS=MIN_FIREFOX_VERSION=xyz` to verify support for a specific Firefox version.

For example, I can then run through all ESR versions, and pass `-s MIN_FIREFOX_VERSION=xyz` to match that specific ESR version:

<img width="1496" height="512" alt="image" src="https://github.com/user-attachments/assets/b0cc0fef-a7ee-4914-a534-d666eacba740" />
