### PR TITLE
OffscreenCanvas support in feature matrix

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2643,6 +2643,7 @@ Module["preRun"] = () => {
     self.btest_exit('webgl_create_context2.c')
 
   @requires_graphics_hardware
+  @requires_offscreen_canvas
   # Verify bug https://github.com/emscripten-core/emscripten/issues/22943: creating a WebGL context with explicit swap control and offscreenCanvas
   @parameterized({
     'offscreencanvas': (['-sOFFSCREENCANVAS_SUPPORT'],),

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -39,6 +39,7 @@ class Feature(IntEnum):
   PROMISE_ANY = auto()
   MEMORY64 = auto()
   WORKER_ES6_MODULES = auto()
+  OFFSCREENCANVAS_SUPPORT = auto()
 
 
 disable_override_features = set()
@@ -93,6 +94,15 @@ min_browser_versions = {
     'chrome': 80,
     'firefox': 114,
     'safari': 150000,
+    'node': 0, # This is a browser only feature, no requirements on Node.js
+  },
+  # OffscreenCanvas feature allows creating canvases that are not connected to
+  # a visible DOM element, e.g. in a Worker.
+  # https://caniuse.com/offscreencanvas
+  Feature.OFFSCREENCANVAS_SUPPORT: {
+    'chrome': 69,
+    'firefox': 105,
+    'safari': 170000,
     'node': 0, # This is a browser only feature, no requirements on Node.js
   },
 }
@@ -186,3 +196,5 @@ def apply_min_browser_versions():
     enable_feature(Feature.WORKER_ES6_MODULES, 'EXPORT_ES6 with -pthread')
   if settings.EXPORT_ES6 and settings.WASM_WORKERS:
     enable_feature(Feature.WORKER_ES6_MODULES, 'EXPORT_ES6 with -sWASM_WORKERS')
+  if settings.OFFSCREENCANVAS_SUPPORT:
+    enable_feature(Feature.OFFSCREENCANVAS_SUPPORT, 'OFFSCREENCANVAS_SUPPORT')


### PR DESCRIPTION
Add item for `OffscreenCanvas` support in feature matrix, and update missing `@requires_offscreen_canvas` in browser test.

This will automatically set min browser versions when `-sOFFSCREEN_CANVAS` is used, and error our if the users explicitly requests a too-old browser version
