### PR TITLE
Skip whole browser test, not just the execution part

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -190,21 +190,6 @@ def skipExecIf(cond, message):
   return decorator
 
 
-def skipTestIf(cond, message):
-  def decorator(f):
-    assert callable(f)
-
-    @wraps(f)
-    def decorated(self, *args, **kwargs):
-      if cond:
-        self.skipTest(message)
-      f(self, *args, **kwargs)
-
-    return decorated
-
-  return decorator
-
-
 def webgl2_disabled():
   return os.getenv('EMTEST_LACKS_WEBGL2') or os.getenv('EMTEST_LACKS_GRAPHICS_HARDWARE')
 
@@ -217,8 +202,8 @@ requires_graphics_hardware = skipExecIf(os.getenv('EMTEST_LACKS_GRAPHICS_HARDWAR
 requires_webgl2 = unittest.skipIf(webgl2_disabled(), "This test requires WebGL2 to be available")
 requires_webgpu = unittest.skipIf(webgpu_disabled(), "This test requires WebGPU to be available")
 requires_sound_hardware = skipExecIf(os.getenv('EMTEST_LACKS_SOUND_HARDWARE'), 'This test requires sound hardware')
-requires_offscreen_canvas = skipTestIf(os.getenv('EMTEST_LACKS_OFFSCREEN_CANVAS'), 'This test requires a browser with OffscreenCanvas')
-requires_es6_workers = skipTestIf(os.getenv('EMTEST_LACKS_ES6_WORKERS'), 'This test requires a browser with ES6 Module Workers support')
+requires_offscreen_canvas = unittest.skipIf(os.getenv('EMTEST_LACKS_OFFSCREEN_CANVAS'), 'This test requires a browser with OffscreenCanvas')
+requires_es6_workers = unittest.skipIf(os.getenv('EMTEST_LACKS_ES6_WORKERS'), 'This test requires a browser with ES6 Module Workers support')
 
 
 class browser(BrowserCore):


### PR DESCRIPTION
I am running browser test suites several times, with

```
set EMCC_CFLAGS=-sMIN_FIREFOX_VERSION=xyz -Wno-unused-command-line-argument
```
but even when I also set the environment variables
```
set EMTEST_LACKS_OFFSCREEN_CANVAS=1
set EMTEST_LACKS_ES6_WORKERS=1
```
to skip the relevant ES6 or OffscreenCanvas tests that the Firefox browser under test does not support, the test will actually not skip, but still produce a test failure.

This is because the `skipExecIf()` function used to build the `@requires_offscreen_canvas` and `@requires_es6_workers` decorators will still attempt to compile the test, and only skip running it in the browser.

But when I have set e.g. `EMCC_CFLAGS=-sMIN_FIREFOX_VERSION=95`, then that Firefox does not support OffscreenCanvas, and it does not help even if I also set the env. var. `EMTEST_LACKS_OFFSCREEN_CANVAS=1`. The failing compilation still happens, and the test fails.

This PR fixes that issue by making EMTEST_LACKS_OFFSCREEN_CANVAS and EMTEST_LACKS_ES6_WORKERS skip the whole test, and not just the browser execution part.

Though this does have the drawback that CircleCI coverage might be reduced, e.g. for the OffscreenCanvas tests parts, if it was seen valuable to still compile those on targets that don't support OffscreenCanvas. But is that important anymore?