### PR TITLE
Add @requires_offscreen_canvas annotation

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4647,6 +4647,7 @@ Module["preRun"] = () => {
 
   # Tests emscripten_set_canvas_element_size() and OffscreenCanvas functionality in different build configurations.
   @requires_graphics_hardware
+  @requires_offscreen_canvas
   @parameterized({
     '': ([], True),
     'offscreen': (['-sOFFSCREENCANVAS_SUPPORT'], True),


### PR DESCRIPTION
Add @requires_offscreen_canvas annotation to browser.test_emscripten_animate_canvas_element_size_offscreen. This is over-conservative, but keeping test code compact for now.