### PR TITLE
Fix browser.test_sdl2_canvas_proxy on Firefox

### DIFF
--- a/src/webGLClient.js
+++ b/src/webGLClient.js
@@ -229,7 +229,12 @@ function WebGLClient() {
     40: { name: 'texImage2D', func: func9 },
     41: { name: 'compressedTexImage2D', func: func7 },
     42: { name: 'activeTexture', func: activeTexture },
-    43: { name: 'getShaderParameter', func: () => assert(ctx.getShaderParameter(objects[buffer[i++]], buffer[i++]), 'we cannot handle errors, we are async proxied WebGL') },
+    43: { name: 'getShaderParameter', func: () => {
+      // Log shader compilation errors as warnings in the console log, since we cannot get the compilation logs back to the proxied Worker in any other way.
+      var object = objects[buffer[i++]];
+      var param = buffer[i++];
+      if (!ctx.getShaderParameter(object, param) && param == ctx.COMPILE_STATUS) console.warn(`Shader compilation failed: ${ctx.getShaderInfoLog(object)}`);
+    } },
     44: { name: 'clearDepth', func: func1 },
     45: { name: 'depthFunc', func: func1 },
     46: { name: 'frontFace', func: func1 },


### PR DESCRIPTION
SDL2 renderer init attempts to compile a shader with GLES external image content. This causes Firefox to report a shader compilation error, which would cause WebGL proxying to assert().

Demote the assert() into a warning print to let Firefox pass through.

Also because async proxied code cannot get the shader info log, print the info log to the browser console when compile status is queried. This way developers will see all shader compile errors automatically in proxied GL mode.