### PR TITLE
[js-compiler] Remove special handling for JS library aliases. NFC

### DIFF
--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -505,7 +505,7 @@ function(${args}) {
       // what we just added to the library.
     }
 
-    function addFromLibrary(symbol, dependent, force = false) {
+    function addFromLibrary(symbol, dependent) {
       // don't process any special identifiers. These are looked up when
       // processing the base name of the identifier.
       if (isDecorator(symbol)) {
@@ -514,7 +514,7 @@ function(${args}) {
 
       // if the function was implemented in compiled code, there is no need to
       // include the js version
-      if (WASM_EXPORTS.has(symbol) && !force) {
+      if (WASM_EXPORTS.has(symbol)) {
         return;
       }
 
@@ -639,7 +639,6 @@ function(${args}) {
       });
 
       let isFunction = false;
-      let aliasTarget;
 
       const postsetId = symbol + '__postset';
       const postset = LibraryManager.library[postsetId];
@@ -659,7 +658,7 @@ function(${args}) {
             // Redirection for aliases. We include the parent, and at runtime
             // make ourselves equal to it.  This avoid having duplicate
             // functions with identical content.
-            aliasTarget = snippet;
+            const aliasTarget = snippet;
             snippet = mangleCSymbolName(aliasTarget);
             deps.push(aliasTarget);
           }
@@ -690,7 +689,7 @@ function(${args}) {
             'noExitRuntime cannot be referenced via __deps mechanism.  Use DEFAULT_LIBRARY_FUNCS_TO_INCLUDE or EXPORTED_RUNTIME_METHODS',
           );
         }
-        return addFromLibrary(dep, `${symbol}, referenced by ${dependent}`, dep === aliasTarget);
+        return addFromLibrary(dep, `${symbol}, referenced by ${dependent}`);
       }
       let contentText;
       if (isFunction) {
@@ -777,10 +776,6 @@ function(${args}) {
       }
 
       let commentText = '';
-      if (force) {
-        commentText += '/** @suppress {duplicate } */\n';
-      }
-
       let docs = LibraryManager.library[symbol + '__docs'];
       // Add the docs if they exist and if we are actually emitting a declaration.
       // See the TODO about wasmTable above.

--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -157,7 +157,7 @@ export function mergeInto(obj, other, options = null) {
         const deps = other[key];
         if (!Array.isArray(deps)) {
           error(
-            `JS library directive ${key}=${deps.toString()} is of type '${type}', but it should be an array`,
+            `JS library directive ${key}=${deps} is of type '${type}', but it should be an array`,
           );
         }
         for (let dep of deps) {
@@ -199,22 +199,23 @@ export function isJsOnlySymbol(symbol) {
   return symbol[0] == '$';
 }
 
+export const decoratorSuffixes = [
+  '__sig',
+  '__proxy',
+  '__asm',
+  '__deps',
+  '__postset',
+  '__docs',
+  '__nothrow',
+  '__noleakcheck',
+  '__internal',
+  '__user',
+  '__async',
+  '__i53abi',
+];
+
 export function isDecorator(ident) {
-  const suffixes = [
-    '__sig',
-    '__proxy',
-    '__asm',
-    '__deps',
-    '__postset',
-    '__docs',
-    '__nothrow',
-    '__noleakcheck',
-    '__internal',
-    '__user',
-    '__async',
-    '__i53abi',
-  ];
-  return suffixes.some((suffix) => ident.endsWith(suffix));
+  return decoratorSuffixes.some((suffix) => ident.endsWith(suffix));
 }
 
 export function readFile(filename) {
@@ -330,6 +331,7 @@ export function runInMacroContext(code, options) {
 
 addToCompileTimeContext({
   assert,
+  decoratorSuffixes,
   error,
   isDecorator,
   isJsOnlySymbol,

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 245842,
+  "a.out.js": 245841,
   "a.out.nodebug.wasm": 597755,
-  "total": 843597,
+  "total": 843596,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/test_override_system_js_lib_symbol.js
+++ b/test/test_override_system_js_lib_symbol.js
@@ -1,7 +1,7 @@
 if (!LibraryManager.library.glTexImage3D) throw 'This file should be getting processed after library_webgl2.js!';
 
 addToLibrary({
-	orig_glTexImage3D__deps: LibraryManager.library.glTexImage3D__deps,
+	orig_glTexImage3D__deps: LibraryManager.library.glTexImage3D__deps || [],
 	orig_glTexImage3D: LibraryManager.library.glTexImage3D,
 
 	glTexImage3D__deps: ['orig_glTexImage3D'],


### PR DESCRIPTION
This change remove some special casing in `addFromLibrary` which
simplifies the code, and also lays the groundwork for #25441 which
explicitly allows JS symbol to alias native ones.

This special handling was added in #19046 in order to deal with case
where `glXXX` symbols were simultaneously aliased by `emscripten_glXX`
and exported (in the case of MAIN_MODULE=1).

However, this work is no longer needed since in #21785 we stopped
stopped included symbol exported due to `MAIN_MODULE=1` as part of
`WASM_EXPORTS` (the symbols are only exported to side modules, not to
JS).

In original problem was that `emscripten_glXX` should always points to
the original JS implementation, even if a native version is exported.
Just in case somebody is explicitly exporting these symbols this change
also flips the aliases such that the `glXX` functions are now aliases of
`emscripten_glXX` and not the other way around.  This means that
exporting `glXXX` will replace/override the alias, but will not effect
`emscripten_glXX`.
