### PR TITLE
[embind] Ensure from wire type is used for optional/pointer types when needed

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -601,3 +601,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Artur Gatin <agatin@teladochealth.com> (copyright owned by Teladoc Health, Inc.)
 * Christian Lloyd <clloyd@teladochealth.com> (copyright owned by Teladoc Health, Inc.)
 * Sean Morris <sean@seanmorr.is>
+* Mitchell Wills <mwills@google.com> (copyright owned by Google, Inc.)

--- a/src/lib/libembind_gen.js
+++ b/src/lib/libembind_gen.js
@@ -398,10 +398,10 @@ var LibraryEmbind = {
         return tsName;
       }
       if (type instanceof PointerDefinition) {
-        return `${this.typeToJsName(type.classType)} | null`;
+        return `${this.typeToJsName(type.classType, isFromWireType)} | null`;
       }
       if (type instanceof OptionalType) {
-        return `${this.typeToJsName(type.type)} | undefined`;
+        return `${this.typeToJsName(type.type, isFromWireType)} | undefined`;
       }
       return type.name;
     }

--- a/test/other/embind_tsgen.cpp
+++ b/test/other/embind_tsgen.cpp
@@ -114,6 +114,10 @@ std::wstring wstring_test(std::wstring arg) {
   return L"hi";
 }
 
+std::optional<std::string> optional_string_test(std::string arg) {
+  return "hi";
+}
+
 std::optional<int> optional_test(std::optional<Foo> arg) {
   return {};
 }
@@ -212,12 +216,14 @@ EMSCRIPTEN_BINDINGS(Test) {
   function("global_fn", &global_fn);
 
   register_optional<int>();
+  register_optional<std::string>();
   register_optional<Foo>();
   function("optional_test", &optional_test);
   function("optional_and_nonoptional_test", &optional_and_nonoptional_test);
 
   function("string_test", &string_test);
   function("wstring_test", &wstring_test);
+  function("optional_string_test", &optional_string_test);
 
   class_<ClassWithConstructor>("ClassWithConstructor")
       .constructor<int, const ValArr&>()

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -150,6 +150,7 @@ interface EmbindModule {
   getValObj(): ValObj;
   setValObj(_0: ValObj): void;
   string_test(_0: EmbindString): string;
+  optional_string_test(_0: EmbindString): string | undefined;
   wstring_test(_0: string): string;
 }
 

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -161,6 +161,7 @@ interface EmbindModule {
   getValObj(): ValObj;
   setValObj(_0: ValObj): void;
   string_test(_0: EmbindString): string;
+  optional_string_test(_0: EmbindString): string | undefined;
   wstring_test(_0: string): string;
 }
 

--- a/test/other/embind_tsgen_ignore_2.d.ts
+++ b/test/other/embind_tsgen_ignore_2.d.ts
@@ -149,6 +149,7 @@ interface EmbindModule {
   getValObj(): ValObj;
   setValObj(_0: ValObj): void;
   string_test(_0: EmbindString): string;
+  optional_string_test(_0: EmbindString): string | undefined;
   wstring_test(_0: string): string;
 }
 

--- a/test/other/embind_tsgen_ignore_3.d.ts
+++ b/test/other/embind_tsgen_ignore_3.d.ts
@@ -150,6 +150,7 @@ interface EmbindModule {
   getValObj(): ValObj;
   setValObj(_0: ValObj): void;
   string_test(_0: EmbindString): string;
+  optional_string_test(_0: EmbindString): string | undefined;
   wstring_test(_0: string): string;
 }
 

--- a/test/other/embind_tsgen_module.d.ts
+++ b/test/other/embind_tsgen_module.d.ts
@@ -150,6 +150,7 @@ interface EmbindModule {
   getValObj(): ValObj;
   setValObj(_0: ValObj): void;
   string_test(_0: EmbindString): string;
+  optional_string_test(_0: EmbindString): string | undefined;
   wstring_test(_0: string): string;
 }
 


### PR DESCRIPTION
This ensures that return values of type `std::optional<std::string>` are typed as `string|undefined` instead of `EmbindString|undefined` (and similar for pointer types).