### PR TITLE
Add --password-store=basic to chrome command line for testing. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -106,6 +106,8 @@ class ChromeConfig:
     '--disk-cache-size=1 --media-cache-size=1 --disable-application-cache',
     # Disable various background tasks downloads (e.g. updates).
     '--disable-background-networking',
+    # Disable native password pop-ups
+    '--password-store=basic',
   )
   headless_flags = '--headless=new --window-size=1024,768'
 


### PR DESCRIPTION
This helps avoid gnome / KDE popping up password dialogues during testing.