### PR TITLE
[testing] Lower FPS assertion in hello_world_gles.c

### DIFF
--- a/test/hello_world_gles.c
+++ b/test/hello_world_gles.c
@@ -648,7 +648,9 @@ gears_idle(void)
       runs++;
       if (runs == 4) {
         int result = fps;
-        assert(fps >= 15 && fps <= 500);
+        // The test may be run with many browsers in parallel so we accept a
+        // very low FPS.
+        assert(fps >= 1 && fps <= 500);
 #ifdef REPORT_RESULT
         REPORT_RESULT(0);
 #endif


### PR DESCRIPTION
This test seems to flake a lot from this assertion. The fps on my machine often is only 20 fps, so I think when there are multiple browsers running the fps will be pretty low on CI.