### PR TITLE
BigInt was introduced in Firefox 78, not Firefox 68.

### DIFF
--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -68,7 +68,7 @@ min_browser_versions = {
   },
   Feature.JS_BIGINT_INTEGRATION: {
     'chrome': 67,
-    'firefox': 68,
+    'firefox': 78,
     'safari': 150000,
     'node': 130000,
   },


### PR DESCRIPTION
Firefox 77 verified to fail e.g. `browser.test_utf8_textdecoder` with

<img width="1932" height="231" alt="image" src="https://github.com/user-attachments/assets/18b4ef26-b463-4908-9793-afabaf0656f8" />

```
======================================================================
FAIL: test_utf8_textdecoder (test_browser.browser.test_utf8_textdecoder)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\emsdk\python\3.13.3_64bit\Lib\unittest\case.py", line 58, in testPartExecutor
    yield
  File "C:\emsdk\python\3.13.3_64bit\Lib\unittest\case.py", line 651, in run
    self._callTestMethod(testMethod)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "C:\emsdk\python\3.13.3_64bit\Lib\unittest\case.py", line 606, in _callTestMethod
    if method() is not None:
       ~~~~~~^^
  File "C:\emsdk\emscripten\main\test\common.py", line 960, in resulting_test
    return func(self, *args)
  File "C:\emsdk\emscripten\main\test\test_browser.py", line 157, in decorated
    f(self, *args, **kwargs)
    ~^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\emsdk\emscripten\main\test\test_browser.py", line 4231, in test_utf8_textdecoder
    self.btest_exit('benchmark/benchmark_utf8.c', 0, cflags=['--embed-file', test_file('utf8_corpus.txt') + '@/utf8_corpus.txt'])
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\emsdk\emscripten\main\test\common.py", line 2769, in btest_exit
    return self.btest(filename, *args, **kwargs)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\emsdk\emscripten\main\test\common.py", line 2798, in btest
    self.run_browser(outfile, expected=['/report_result?' + e for e in expected], timeout=timeout)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\emsdk\emscripten\main\test\common.py", line 2721, in run_browser
    raise e
  File "C:\emsdk\emscripten\main\test\common.py", line 2712, in run_browser
    self.assertContained(expected, output)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "C:\emsdk\emscripten\main\test\common.py", line 1734, in assertContained
    self.fail("Expected to find '%s' in '%s', diff:\n\n%s\n%s" % (
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      limit_size(values[0]), limit_size(string), limit_size(diff),
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      additional_info,
      ^^^^^^^^^^^^^^^^
    ))
    ^^
  File "C:\emsdk\python\3.13.3_64bit\Lib\unittest\case.py", line 732, in fail
    raise self.failureException(msg)
AssertionError: Expected to find '/report_result?exit:0
' in '/report_result?exception:cannot pass i64 to or from JS / @http://localhost:8888/test.wasm:wasm-function[44]:0x1605
@http://localhost:8888/test.wasm:wasm-function[27]:0xc80
@http://localhost:8888/test.wasm:wasm-function[38]:0x14ab
@http://localhost:8888/test.wasm:wasm-function[39]:0x14e4
@http://localhost:8888/test.wasm:wasm-function[40]:0x1510
@http://localhost:8888/test.wasm:wasm-function[15]:0x528
@http://localhost:8888/test.wasm:wasm-function[16]:0x81c
@http://localhost:8888/test.wasm:wasm-function[17]:0x88c
createExportWrapper/<@http://localhost:8888/test.js:687:12
callMain@http://localhost:8888/test.js:4810:28
doRun@http://localhost:8888/test.js:4853:24
run/<@http://localhost:8888/test.js:4860:7
', diff:
```
