### PR TITLE
Do not pass --enable-bulk-memory in Binaryen when -mno-bulk-memory is used

### DIFF
--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -116,6 +116,12 @@ def update_settings_glue(wasm_file, metadata, base_metadata):
 
   # start with the MVP features, and add any detected features.
   settings.BINARYEN_FEATURES = ['--mvp-features'] + metadata.features
+  if not settings.BULK_MEMORY:
+    if '--enable-bulk-memory' in settings.BINARYEN_FEATURES:
+      settings.BINARYEN_FEATURES.remove('--enable-bulk-memory')
+    if '--enable-bulk-memory-opt' in settings.BINARYEN_FEATURES:
+      settings.BINARYEN_FEATURES.remove('--enable-bulk-memory-opt')
+
   if settings.ASYNCIFY == 2:
     settings.BINARYEN_FEATURES += ['--enable-reference-types']
 


### PR DESCRIPTION
Do not pass --enable-bulk-memory in Binaryen when -mno-bulk-memory is used, or -sMIN_x_VERSION is too low to enable bulk memory.

Without this, running

```
emcc test\hello_world.c -o a.js -O3 -mno-bulk-memory -mno-bulk-memory-opt
```
would still produce a final output that has bulk memory enabled.

With this I was able to complete the `browser` suite with `EMCC_CFLAGS=-mno-bulk-memory -mno-bulk-memory-opt`.