### PR TITLE
Bump the minimum Firefox version to 79.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,8 @@ See docs/process.md for more on how version tagging works.
   - Node: v10.19.0 -> v12.22.9
   - Chrome: v70 -> v74
   - Firefox: v55 -> v65
+- Minimum Firefox version was further bumped up to Firefox 79, to reflect that
+  Emscripten now requires ES6 constructs (#25467)
 - The Embind `val` functions `call`, `operator()`, and `new_` now support
   passing `pointer`s by using the `allow_raw_pointers()` argument. This feature
   is only enabled with C++17 and newer. Older versions will allow pointers by

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -2871,7 +2871,7 @@ are desired to work. Pass -sMIN_FIREFOX_VERSION=majorVersion to drop support
 for Firefox versions older than < majorVersion.
 Firefox 79 was released on 2020-07-28.
 MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-Minimum supported value is 65 which was released on 2019-01-29 (see
+Minimum supported value is 79 which was released on 2020-07-28 (see
 feature_matrix.py)
 
 Default value: 79

--- a/src/settings.js
+++ b/src/settings.js
@@ -1880,7 +1880,7 @@ var AUTO_NATIVE_LIBRARIES = true;
 // for Firefox versions older than < majorVersion.
 // Firefox 79 was released on 2020-07-28.
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-// Minimum supported value is 78 which was released on 2020-06-30 (see
+// Minimum supported value is 79 which was released on 2020-07-28 (see
 // feature_matrix.py)
 // [link]
 var MIN_FIREFOX_VERSION = 79;

--- a/src/settings.js
+++ b/src/settings.js
@@ -1880,7 +1880,7 @@ var AUTO_NATIVE_LIBRARIES = true;
 // for Firefox versions older than < majorVersion.
 // Firefox 79 was released on 2020-07-28.
 // MAX_INT (0x7FFFFFFF, or -1) specifies that target is not supported.
-// Minimum supported value is 65 which was released on 2019-01-29 (see
+// Minimum supported value is 78 which was released on 2020-06-30 (see
 // feature_matrix.py)
 // [link]
 var MIN_FIREFOX_VERSION = 79;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10473,14 +10473,11 @@ int main() {
     # Flag disabling overrides explicit browser version
     compile(['-sMIN_SAFARI_VERSION=160000', '-mno-sign-ext'])
     verify_features_sec_linked('sign-ext', False)
-    # Flag enabling overrides explicit browser version
-    compile(['-sMIN_FIREFOX_VERSION=65', '-msign-ext'])
-    verify_features_sec_linked('sign-ext', True)
     # Flag disabling overrides explicit version for bulk memory
     compile(['-sMIN_SAFARI_VERSION=150000', '-mno-bulk-memory'])
     verify_features_sec_linked('bulk-memory-opt', False)
 
-    # Bigint ovrride does not cause other features to enable
+    # Bigint override does not cause other features to enable
     compile(['-sMIN_SAFARI_VERSION=140100', '-sWASM_BIGINT=1'])
     verify_features_sec_linked('bulk-memory-opt', False)
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14336,7 +14336,7 @@ out.js
     self.assertContained('emcc: error: MIN_SAFARI_VERSION=130000 is not compatible with WASM_BIGINT (MIN_SAFARI_VERSION=150000 or above required)', err)
 
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Wno-transpile', '-Werror', '-pthread', '-sMIN_FIREFOX_VERSION=65'])
-    self.assertContained('emcc: error: MIN_FIREFOX_VERSION=65 is not compatible with pthreads (MIN_FIREFOX_VERSION=79 or above required)', err)
+    self.assertContained('emcc: error: MIN_FIREFOX_VERSION older than 79 is not supported', err)
 
   def test_signext_lowering(self):
     # Use `-v` to show the sub-commands being run by emcc.

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -23,7 +23,7 @@ UNSUPPORTED = 0x7FFFFFFF
 # N.b. when modifying these values, update comments in src/settings.js on
 # MIN_x_VERSION fields to match accordingly.
 OLDEST_SUPPORTED_CHROME = 74  # Released on 2019-04-23
-OLDEST_SUPPORTED_FIREFOX = 65  # Released on 2019-01-29
+OLDEST_SUPPORTED_FIREFOX = 78  # Released on 2020-06-30
 OLDEST_SUPPORTED_SAFARI = 120200  # Released on 2019-03-25
 # 12.22.09 is the oldest version of node that we do any testing with.
 # Keep this in sync with the test-node-compat in .circleci/config.yml.

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -23,7 +23,7 @@ UNSUPPORTED = 0x7FFFFFFF
 # N.b. when modifying these values, update comments in src/settings.js on
 # MIN_x_VERSION fields to match accordingly.
 OLDEST_SUPPORTED_CHROME = 74  # Released on 2019-04-23
-OLDEST_SUPPORTED_FIREFOX = 78  # Released on 2020-06-30
+OLDEST_SUPPORTED_FIREFOX = 79  # Released on 2020-07-28
 OLDEST_SUPPORTED_SAFARI = 120200  # Released on 2019-03-25
 # 12.22.09 is the oldest version of node that we do any testing with.
 # Keep this in sync with the test-node-compat in .circleci/config.yml.


### PR DESCRIPTION
Bump the minimum Firefox version to 79. Emscripten unconditionally now depends on some ES6 syntax availability, so Emscripten output no longer runs in older Firefoxes.

I did go through the exercise of fixing Emscripten to be able to support Firefox 68ESR, which looks like this: https://github.com/emscripten-core/emscripten/compare/main...juj:emscripten:firefox_68esr_support

I can alternatively post that as a PR, and work to fix Firefox support down to 65. But I get an impression that bumping the version might be preferred.