### PR TITLE
Fix -sMIN_NODE_VERSION=-1 -sENVIRONMENT=web to build without errors.

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -179,7 +179,7 @@ def setup_environment_settings():
   settings.ENVIRONMENT_MAY_BE_WORKER = not settings.ENVIRONMENT or 'worker' in settings.ENVIRONMENT
 
   if not settings.ENVIRONMENT_MAY_BE_NODE:
-    if 'MIN_NODE_VERSION' in user_settings:
+    if 'MIN_NODE_VERSION' in user_settings and user_settings['MIN_NODE_VERSION'] != '0x7FFFFFFF':
       diagnostics.warning('unused-command-line-argument', 'ignoring MIN_NODE_VERSION because `node` environment is not enabled')
     settings.MIN_NODE_VERSION = feature_matrix.UNSUPPORTED
 


### PR DESCRIPTION
Users might "double-disable" Node.js support by setting both `-sENVIRONMENT=web` (no Node.js), and `-sMIN_NODE_VERSION=-1` (set Node to unsupported).

But Emscripten complained about this not being allowed. Let this combination pass.