### PR TITLE
Remove Node.js self.run_js() test in browser suite.

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1605,12 +1605,6 @@ simulateKeyUp(100, undefined, 'Numpad4');
     self.assertExists('worker.js')
     self.run_browser('main.html', '/report_result?hello from worker, and :' + ('data for w' if file_data else '') + ':')
 
-    # code should run standalone too
-    # To great memories >4gb we need the canary version of node
-    if self.is_4gb():
-      self.require_node_canary()
-    self.assertContained('you should not see this text when in a worker!', self.run_js('worker.js'))
-
   @no_wasmfs('https://github.com/emscripten-core/emscripten/issues/19608')
   def test_mmap_lazyfile(self):
     create_file('lazydata.dat', 'hello world')


### PR DESCRIPTION
Remove Node.js self.run_js() test in browser suite. The browser suite should test browser behavior only.

I am running the browser suite with

```
EMCC_CFLAGS= -sMIN_CHROME_VERSION=-1 -sMIN_SAFARI_VERSION=-1 -sMIN_NODE_VERSION=-1
```

to verify that targeting Firefox only should correctly result in a build that works in Firefox.

The test `test_hello_world_worker` is the only one that failed. Which happens because that test also verifies behavior in node.js.

Reading the test logic in that test, it seems to verify the file packager and `emscripten_run_script()` logic. That logic should be well covered in the `core` test suites and the `other` test suite already, so this seems redundant.