### PR TITLE
Fix lsan.test_dylink_iostream after #25449

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -661,6 +661,7 @@ jobs:
             lsan.test_dlfcn_basic
             lsan.test_pthread_create
             lsan.test_pthread_exit_main_stub
+            lsan.test_dylink_iostream
             ubsan.test_externref_emjs_dynlink"
       - freeze-cache
       - run-tests:

--- a/tools/link.py
+++ b/tools/link.py
@@ -3096,8 +3096,9 @@ def run(options, linker_args):
   # This is not normally a problem except in the case of -sMAIN_MODULE=1 where
   # the duplicate library would result in duplicate symbols.
   for s in system_libs:
-    if s not in linker_args:
-      linker_args.append(s)
+    if s.startswith('-l') and s in linker_args:
+      continue
+    linker_args.append(s)
 
   js_syms = {}
   if (not settings.SIDE_MODULE or settings.ASYNCIFY) and not shared.SKIP_SUBPROCS:


### PR DESCRIPTION
This failure was causing the emscripten-reeleases roller to fail.

 The code didn't take into about that system_libs could also contains flags such as `--whole-archive`.

In this particular test the value of `system_libs` is:

```
['-lGL-getprocaddr', '-lal', '-lhtml5', '-lstubs-debug', '-lc-debug', '-ldlmalloc-debug', '-lcompiler_rt', '--whole-archive', '-lc++-debug-noexcept', '--no-whole-archive', '-lc++abi-debug-noexcept', '-lsockets', '--whole-archive', '-llsan_rt', '--no-whole-archive', '-llsan_common_rt', '-lsanitizer_common_rt']
```

Fixes: #25472