### PR TITLE
Remove ES6 constructs from file_packager output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -935,6 +935,7 @@ jobs:
             other.test_native_call_before_init
             other.test_js_optimizer_verbose
             other.test_node_unhandled_rejection
+            other.test_file_packager_separate_metadata
             other.test_full_js_library*
             core2.test_hello_world
             core2.test_fcntl_open_nodefs

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -32,7 +32,7 @@ var ENVIRONMENT_IS_NODE = globalThis.process?.versions?.node && globalThis.proce
 // --pre-jses are emitted after the Module integration code, so that they can
 // refer to Module (if they choose; they can also define Module)
 // include: <FILENAME REPLACED>
-Module["expectedDataFileDownloads"] ??= 0;
+if (!Module["expectedDataFileDownloads"]) Module["expectedDataFileDownloads"] = 0;
 
 Module["expectedDataFileDownloads"]++;
 
@@ -41,7 +41,7 @@ Module["expectedDataFileDownloads"]++;
   var isPthread = typeof ENVIRONMENT_IS_PTHREAD != "undefined" && ENVIRONMENT_IS_PTHREAD;
   var isWasmWorker = typeof ENVIRONMENT_IS_WASM_WORKER != "undefined" && ENVIRONMENT_IS_WASM_WORKER;
   if (isPthread || isWasmWorker) return;
-  var isNode = globalThis.process?.versions?.node && globalThis.process?.type != "renderer";
+  var isNode = globalThis.process && globalThis.process.versions && globalThis.process.versions.node && globalThis.process.type != "renderer";
   async function loadPackage(metadata) {
     var PACKAGE_PATH = "";
     if (typeof window === "object") {
@@ -52,15 +52,14 @@ Module["expectedDataFileDownloads"]++;
     }
     var PACKAGE_NAME = "a.out.data";
     var REMOTE_PACKAGE_BASE = "a.out.data";
-    var REMOTE_PACKAGE_NAME = Module["locateFile"]?.(REMOTE_PACKAGE_BASE, "") ?? REMOTE_PACKAGE_BASE;
+    var REMOTE_PACKAGE_NAME = Module["locateFile"] ? Module["locateFile"](REMOTE_PACKAGE_BASE, "") : REMOTE_PACKAGE_BASE;
     var REMOTE_PACKAGE_SIZE = metadata["remote_package_size"];
     async function fetchRemotePackage(packageName, packageSize) {
       if (isNode) {
-        var fsPromises = require("fs/promises");
-        var contents = await fsPromises.readFile(packageName);
-        return contents.buffer;
+        var contents = require("fs").readFileSync(packageName);
+        return new Uint8Array(contents).buffer;
       }
-      Module["dataFileDownloads"] ??= {};
+      if (!Module["dataFileDownloads"]) Module["dataFileDownloads"] = {};
       try {
         var response = await fetch(packageName);
       } catch (e) {
@@ -73,9 +72,9 @@ Module["expectedDataFileDownloads"]++;
       }
       const chunks = [];
       const headers = response.headers;
-      const total = Number(headers.get("Content-Length") ?? packageSize);
+      const total = Number(headers.get("Content-Length") || packageSize);
       let loaded = 0;
-      Module["setStatus"]?.("Downloading data...");
+      Module["setStatus"] && Module["setStatus"]("Downloading data...");
       const reader = response.body.getReader();
       while (1) {
         var {done, value} = await reader.read();
@@ -92,7 +91,7 @@ Module["expectedDataFileDownloads"]++;
           totalLoaded += download.loaded;
           totalSize += download.total;
         }
-        Module["setStatus"]?.(`Downloading data... (${totalLoaded}/${totalSize})`);
+        Module["setStatus"] && Module["setStatus"](`Downloading data... (${totalLoaded}/${totalSize})`);
       }
       const packageData = new Uint8Array(chunks.map(c => c.length).reduce((a, b) => a + b, 0));
       let offset = 0;
@@ -119,7 +118,7 @@ Module["expectedDataFileDownloads"]++;
       }
       async function processPackageData(arrayBuffer) {
         assert(arrayBuffer, "Loading data file failed.");
-        assert(arrayBuffer.constructor.name === ArrayBuffer.name, "bad input to processPackageData");
+        assert(arrayBuffer.constructor.name === ArrayBuffer.name, "bad input to processPackageData " + arrayBuffer.constructor.name);
         var byteArray = new Uint8Array(arrayBuffer);
         // Reuse the bytearray from the XHR as the source for file reads.
         for (var file of metadata["files"]) {
@@ -132,7 +131,7 @@ Module["expectedDataFileDownloads"]++;
         Module["removeRunDependency"]("datafile_a.out.data");
       }
       Module["addRunDependency"]("datafile_a.out.data");
-      Module["preloadResults"] ??= {};
+      if (!Module["preloadResults"]) Module["preloadResults"] = {};
       Module["preloadResults"][PACKAGE_NAME] = {
         fromCache: false
       };
@@ -144,7 +143,8 @@ Module["expectedDataFileDownloads"]++;
     if (Module["calledRun"]) {
       runWithFS(Module);
     } else {
-      (Module["preRun"] ??= []).push(runWithFS);
+      if (!Module["preRun"]) Module["preRun"] = [];
+      Module["preRun"].push(runWithFS);
     }
   }
   loadPackage({

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22473,
-  "a.out.js.gz": 9349,
+  "a.out.js": 22552,
+  "a.out.js.gz": 9344,
   "a.out.nodebug.wasm": 1681,
   "a.out.nodebug.wasm.gz": 960,
-  "total": 24154,
-  "total_gz": 10309,
+  "total": 24233,
+  "total_gz": 10304,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3849,7 +3849,7 @@ More info: https://emscripten.org
       return 0;
     }
     ''')
-    self.do_runf('src.c', cflags=['--pre-js=immutable.js', '-sFORCE_FILESYSTEM'])
+    self.do_runf('src.c', 'done\n', cflags=['--extern-pre-js=immutable.js', '-sFORCE_FILESYSTEM'])
 
   def test_file_packager_unicode(self):
     unicode_name = 'unicode…☃'

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -612,7 +612,7 @@ def generate_js(data_target, data_files, metadata):
   var Module = typeof %(EXPORT_NAME)s != 'undefined' ? %(EXPORT_NAME)s : {};\n''' % {"EXPORT_NAME": options.export_name}
 
   ret += '''
-  Module['expectedDataFileDownloads'] ??= 0;
+  if (!Module['expectedDataFileDownloads']) Module['expectedDataFileDownloads'] = 0;
   Module['expectedDataFileDownloads']++;'''
 
   if not options.export_es6:
@@ -626,7 +626,7 @@ def generate_js(data_target, data_files, metadata):
     if (isPthread || isWasmWorker) return;\n'''
 
   if options.support_node:
-    ret += "    var isNode = globalThis.process?.versions?.node && globalThis.process?.type != 'renderer';\n"
+    ret += "    var isNode = globalThis.process && globalThis.process.versions && globalThis.process.versions.node && globalThis.process.type != 'renderer';\n"
 
   if options.support_node and options.export_es6:
         ret += '''if (isNode) {
@@ -682,7 +682,7 @@ def generate_js(data_target, data_files, metadata):
             await Module['FS_preloadFile'](name, null, data, true, true, false, true);
             Module['removeRunDependency'](`fp ${name}`);
           } catch (e) {
-            err(`Preloading file ${name} failed`);
+            err(`Preloading file ${name} failed`, e);
           }\n'''
     create_data = '''// canOwn this data in the filesystem, it is a slice into the heap that will never change
           Module['FS_createDataFile'](name, null, data, true, true, true);
@@ -771,7 +771,7 @@ def generate_js(data_target, data_files, metadata):
       }
       var PACKAGE_NAME = '%s';
       var REMOTE_PACKAGE_BASE = '%s';
-      var REMOTE_PACKAGE_NAME = Module['locateFile']?.(REMOTE_PACKAGE_BASE, '') ?? REMOTE_PACKAGE_BASE;\n''' % (js_manipulation.escape_for_js_string(data_target), js_manipulation.escape_for_js_string(remote_package_name))
+      var REMOTE_PACKAGE_NAME = Module['locateFile'] ? Module['locateFile'](REMOTE_PACKAGE_BASE, '') : REMOTE_PACKAGE_BASE;\n''' % (js_manipulation.escape_for_js_string(data_target), js_manipulation.escape_for_js_string(remote_package_name))
     metadata['remote_package_size'] = remote_package_size
     ret += "      var REMOTE_PACKAGE_SIZE = metadata['remote_package_size'];\n"
 
@@ -938,15 +938,14 @@ def generate_js(data_target, data_files, metadata):
     if options.support_node:
       node_support_code = '''
         if (isNode) {
-          var fsPromises = require('fs/promises');
-          var contents = await fsPromises.readFile(packageName);
-          return contents.buffer;
+          var contents = require('fs').readFileSync(packageName);
+          return new Uint8Array(contents).buffer;
         }'''.strip()
 
     ret += '''
       async function fetchRemotePackage(packageName, packageSize) {
         %(node_support_code)s
-        Module['dataFileDownloads'] ??= {};
+        if (!Module['dataFileDownloads']) Module['dataFileDownloads'] = {};
         try {
           var response = await fetch(packageName);
         } catch (e) {
@@ -958,10 +957,10 @@ def generate_js(data_target, data_files, metadata):
 
         const chunks = [];
         const headers = response.headers;
-        const total = Number(headers.get('Content-Length') ?? packageSize);
+        const total = Number(headers.get('Content-Length') || packageSize);
         let loaded = 0;
 
-        Module['setStatus']?.('Downloading data...');
+        Module['setStatus'] && Module['setStatus']('Downloading data...');
         const reader = response.body.getReader();
 
         while (1) {
@@ -979,7 +978,7 @@ def generate_js(data_target, data_files, metadata):
             totalSize += download.total;
           }
 
-          Module['setStatus']?.(`Downloading data... (${totalLoaded}/${totalSize})`);
+          Module['setStatus'] && Module['setStatus'](`Downloading data... (${totalLoaded}/${totalSize})`);
         }
 
         const packageData = new Uint8Array(chunks.map((c) => c.length).reduce((a, b) => a + b, 0));
@@ -994,7 +993,7 @@ def generate_js(data_target, data_files, metadata):
     code += '''
       async function processPackageData(arrayBuffer) {
         assert(arrayBuffer, 'Loading data file failed.');
-        assert(arrayBuffer.constructor.name === ArrayBuffer.name, 'bad input to processPackageData');
+        assert(arrayBuffer.constructor.name === ArrayBuffer.name, 'bad input to processPackageData ' + arrayBuffer.constructor.name);
         var byteArray = new Uint8Array(arrayBuffer);
         var curr;
         %s
@@ -1004,7 +1003,7 @@ def generate_js(data_target, data_files, metadata):
     # we need to find the datafile in the same dir as the html file
 
     code += '''
-      Module['preloadResults'] ??= {};\n'''
+      if (!Module['preloadResults']) Module['preloadResults'] = {};\n'''
 
     if options.use_preload_cache:
       code += '''
@@ -1034,7 +1033,7 @@ def generate_js(data_target, data_files, metadata):
           await preloadFallback(e)%s;
         }
 
-        Module['setStatus']?.('Downloading...');\n''' % catch_handler
+        Module['setStatus'] && Module['setStatus']('Downloading...');\n''' % catch_handler
     else:
       # Not using preload cache, so we might as well start the xhr ASAP,
       # potentially before JS parsing of the main codebase if it's after us.
@@ -1065,7 +1064,8 @@ def generate_js(data_target, data_files, metadata):
     if (Module['calledRun']) {
       runWithFS(Module)%s;
     } else {
-      (Module['preRun'] ??= []).push(runWithFS); // FS is not initialized yet, wait for it
+      if (!Module['preRun']) Module['preRun'] = [];
+      Module['preRun'].push(runWithFS); // FS is not initialized yet, wait for it
     }\n''' % catch_handler
 
   if options.separate_metadata:
@@ -1073,9 +1073,12 @@ def generate_js(data_target, data_files, metadata):
     if options.support_node:
       node_support_code = '''
         if (isNode) {
-          var fsPromises = require('fs/promises');
-          var contents = await fsPromises.readFile(metadataUrl, 'utf8');
-          return loadPackage(JSON.parse(contents));
+          var contents = require('fs').readFileSync(metadataUrl, 'utf8');
+          // The await here is needed, even though JSON.parse is a sync API.  It works
+          // around a issue with `removeRunDependency` otherwise being called to early
+          // on the metadata object.
+          var json = await JSON.parse(contents);
+          return loadPackage(json);
         }'''.strip()
 
     ret += '''
@@ -1084,20 +1087,21 @@ def generate_js(data_target, data_files, metadata):
 
   async function runMetaWithFS() {
     Module['addRunDependency']('%(metadata_file)s');
-    var metadataUrl = Module['locateFile']?.('%(metadata_file)s', '') ?? '%(metadata_file)s';
+    var metadataUrl = Module['locateFile'] ? Module['locateFile']('%(metadata_file)s', '') : '%(metadata_file)s';
     %(node_support_code)s
     var response = await fetch(metadataUrl);
     if (!response.ok) {
       throw new Error(`${response.status}: ${response.url}`);
     }
     var json = await response.json();
-    return loadPackage(json);
+    await loadPackage(json);
   }
 
   if (Module['calledRun']) {
     runMetaWithFS();
   } else {
-    (Module['preRun'] ??= []).push(runMetaWithFS);
+    if (!Module['preRun']) Module['preRun'] = [];
+    Module['preRun'].push(runMetaWithFS);
   }\n''' % {'node_support_code': node_support_code, 'metadata_file': os.path.basename(options.jsoutput + '.metadata')}
   else:
     ret += '''


### PR DESCRIPTION
This allows the generated code to run on older engines.

Unlike the majority of the emscripten-generated code the file packager output does not always get run through babel when targeting older engines.

Specifically tests the standalone file packages code on the oldest
support node version.   This also required removing the use of the
`fs/Promises` packages which is not present in older versions of node.

Split out from #25459