### PR TITLE
[jspi] Require async js functions when used with __async decorator.

### DIFF
--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -9,6 +9,7 @@
 
 import assert from 'node:assert';
 import * as fs from 'node:fs/promises';
+import { isAsyncFunction } from 'node:util/types';
 import {
   ATMODULES,
   ATEXITS,
@@ -536,13 +537,13 @@ function(${args}) {
         deps.push('setTempRet0');
       }
 
-      let isAsyncFunction = false;
+      let hasAsyncDecorator = false;
       if (ASYNCIFY) {
         const original = LibraryManager.library[symbol];
         if (typeof original == 'function') {
-          isAsyncFunction = LibraryManager.library[symbol + '__async'];
+          hasAsyncDecorator = LibraryManager.library[symbol + '__async'];
         }
-        if (isAsyncFunction) {
+        if (hasAsyncDecorator) {
           asyncFuncs.push(symbol);
         }
       }
@@ -669,6 +670,10 @@ function(${args}) {
         addImplicitDeps(snippet, deps);
       } else if (typeof snippet == 'function') {
         isFunction = true;
+        if (ASYNCIFY == 2 && hasAsyncDecorator && !isAsyncFunction(snippet)) {
+          error(`'${symbol}' is marked with the __async decorator but is not an async JS function.`);
+        }
+
         snippet = processLibraryFunction(snippet, symbol, mangled, deps, isStub);
         addImplicitDeps(snippet, deps);
         if (CHECK_DEPS && !isUserSymbol) {
@@ -766,7 +771,7 @@ function(${args}) {
         }
         contentText += `\n${mangled}.sig = '${sig}';`;
       }
-      if (ASYNCIFY && isAsyncFunction) {
+      if (ASYNCIFY && hasAsyncDecorator) {
         contentText += `\n${mangled}.isAsync = true;`;
       }
       if (isStub) {

--- a/src/lib/libasync.js
+++ b/src/lib/libasync.js
@@ -476,11 +476,11 @@ addToLibrary({
 
   emscripten_sleep__deps: ['$safeSetTimeout'],
   emscripten_sleep__async: true,
-  emscripten_sleep: (ms) => Asyncify.handleSleep((wakeUp) => safeSetTimeout(wakeUp, ms)),
+  emscripten_sleep: async (ms) => Asyncify.handleSleep((wakeUp) => safeSetTimeout(wakeUp, ms)),
 
   emscripten_wget_data__deps: ['$asyncLoad', 'malloc'],
   emscripten_wget_data__async: true,
-  emscripten_wget_data: (url, pbuffer, pnum, perror) => Asyncify.handleAsync(async () => {
+  emscripten_wget_data: async (url, pbuffer, pnum, perror) => Asyncify.handleAsync(async () => {
     /* no need for run dependency, this is async but will not do any prepare etc. step */
     try {
       const byteArray = await asyncLoad(UTF8ToString(url));
@@ -497,7 +497,7 @@ addToLibrary({
 
   emscripten_scan_registers__deps: ['$safeSetTimeout'],
   emscripten_scan_registers__async: true,
-  emscripten_scan_registers: (func) => {
+  emscripten_scan_registers: async (func) => {
     return Asyncify.handleSleep((wakeUp) => {
       // We must first unwind, so things are spilled to the stack. Then while
       // we are pausing we do the actual scan. After that we can resume. Note
@@ -585,7 +585,7 @@ addToLibrary({
 
   emscripten_fiber_swap__deps: ["$Asyncify", "$Fibers", '$stackSave'],
   emscripten_fiber_swap__async: true,
-  emscripten_fiber_swap: (oldFiber, newFiber) => {
+  emscripten_fiber_swap: async (oldFiber, newFiber) => {
     if (ABORT) return;
 #if ASYNCIFY_DEBUG
     dbg('ASYNCIFY/FIBER: swap', oldFiber, '->', newFiber, 'state:', Asyncify.state);

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -2615,7 +2615,7 @@ function wrapSyscallFunction(x, library, isWasi) {
   post = handler + post;
 
   if (pre || post) {
-    t = modifyJSFunction(t, (args, body) => `function (${args}) {\n${pre}${body}${post}}\n`);
+    t = modifyJSFunction(t, (args, body, async_) => `${async_} function (${args}) {\n${pre}${body}${post}}\n`);
   }
 
   library[x] = eval('(' + t + ')');

--- a/src/lib/libemval.js
+++ b/src/lib/libemval.js
@@ -402,12 +402,20 @@ ${functionBody}
 #if ASYNCIFY
   _emval_await__deps: ['$Emval', '$Asyncify'],
   _emval_await__async: true,
+#if ASYNCIFY == 1
   _emval_await: (promise) => {
     return Asyncify.handleAsync(async () => {
       var value = await Emval.toValue(promise);
       return Emval.toHandle(value);
     });
   },
+#endif
+#if ASYNCIFY == 2
+  _emval_await: async (promise) => {
+    var value = await Emval.toValue(promise);
+    return Emval.toHandle(value);
+  },
+#endif
 #endif
 
   _emval_iter_begin__deps: ['$Emval'],

--- a/src/lib/libidbstore.js
+++ b/src/lib/libidbstore.js
@@ -94,7 +94,7 @@ var LibraryIDBStore = {
 #if ASYNCIFY
   emscripten_idb_load__async: true,
   emscripten_idb_load__deps: ['malloc'],
-  emscripten_idb_load: (db, id, pbuffer, pnum, perror) => Asyncify.handleSleep((wakeUp) => {
+  emscripten_idb_load: async (db, id, pbuffer, pnum, perror) => Asyncify.handleSleep((wakeUp) => {
     IDBStore.getFile(UTF8ToString(db), UTF8ToString(id), (error, byteArray) => {
       if (error) {
         {{{ makeSetValue('perror', 0, '1', 'i32') }}};
@@ -110,7 +110,7 @@ var LibraryIDBStore = {
     });
   }),
   emscripten_idb_store__async: true,
-  emscripten_idb_store: (db, id, ptr, num, perror) => Asyncify.handleSleep((wakeUp) => {
+  emscripten_idb_store: async (db, id, ptr, num, perror) => Asyncify.handleSleep((wakeUp) => {
     IDBStore.setFile(UTF8ToString(db), UTF8ToString(id), new Uint8Array(HEAPU8.subarray(ptr, ptr+num)), (error) => {
       // Closure warns about storing booleans in TypedArrays.
       /** @suppress{checkTypes} */
@@ -119,7 +119,7 @@ var LibraryIDBStore = {
     });
   }),
   emscripten_idb_delete__async: true,
-  emscripten_idb_delete: (db, id, perror) => Asyncify.handleSleep((wakeUp) => {
+  emscripten_idb_delete: async (db, id, perror) => Asyncify.handleSleep((wakeUp) => {
     IDBStore.deleteFile(UTF8ToString(db), UTF8ToString(id), (error) => {
       /** @suppress{checkTypes} */
       {{{ makeSetValue('perror', 0, '!!error', 'i32') }}};
@@ -127,7 +127,7 @@ var LibraryIDBStore = {
     });
   }),
   emscripten_idb_exists__async: true,
-  emscripten_idb_exists: (db, id, pexists, perror) => Asyncify.handleSleep((wakeUp) => {
+  emscripten_idb_exists: async (db, id, pexists, perror) => Asyncify.handleSleep((wakeUp) => {
     IDBStore.existsFile(UTF8ToString(db), UTF8ToString(id), (error, exists) => {
       /** @suppress{checkTypes} */
       {{{ makeSetValue('pexists', 0, '!!exists', 'i32') }}};
@@ -137,7 +137,7 @@ var LibraryIDBStore = {
     });
   }),
   emscripten_idb_clear__async: true,
-  emscripten_idb_clear: (db, perror) => Asyncify.handleSleep((wakeUp) => {
+  emscripten_idb_clear: async (db, perror) => Asyncify.handleSleep((wakeUp) => {
     IDBStore.clearStore(UTF8ToString(db), (error) => {
       /** @suppress{checkTypes} */
       {{{ makeSetValue('perror', 0, '!!error', 'i32') }}};
@@ -146,7 +146,7 @@ var LibraryIDBStore = {
   }),
   // extra worker methods - proxied
   emscripten_idb_load_blob__async: true,
-  emscripten_idb_load_blob: (db, id, pblob, perror) => Asyncify.handleSleep((wakeUp) => {
+  emscripten_idb_load_blob: async (db, id, pblob, perror) => Asyncify.handleSleep((wakeUp) => {
 #if ASSERTIONS
     assert(!IDBStore.pending);
 #endif
@@ -174,7 +174,7 @@ var LibraryIDBStore = {
     });
   }),
   emscripten_idb_store_blob__async: true,
-  emscripten_idb_store_blob: (db, id, ptr, num, perror) => Asyncify.handleSleep((wakeUp) => {
+  emscripten_idb_store_blob: async (db, id, ptr, num, perror) => Asyncify.handleSleep((wakeUp) => {
 #if ASSERTIONS
     assert(!IDBStore.pending);
 #endif

--- a/src/lib/libpromise.js
+++ b/src/lib/libpromise.js
@@ -261,7 +261,7 @@ addToLibrary({
 #if ASYNCIFY
   emscripten_promise_await__deps: ['$getPromise', '$setPromiseResult'],
 #endif
-  emscripten_promise_await: (returnValuePtr, id) => {
+  emscripten_promise_await: async (returnValuePtr, id) => {
 #if ASYNCIFY
 #if RUNTIME_DEBUG
     dbg(`emscripten_promise_await: ${id}`);

--- a/src/lib/libsdl.js
+++ b/src/lib/libsdl.js
@@ -1753,7 +1753,7 @@ var LibrarySDL = {
 #else
   SDL_Delay__deps: ['emscripten_sleep'],
   SDL_Delay__async: true,
-  SDL_Delay: (delay) => _emscripten_sleep(delay),
+  SDL_Delay: async (delay) => _emscripten_sleep(delay),
 #endif
 
   SDL_WM_SetCaption__proxy: 'sync',

--- a/src/lib/libwasi.js
+++ b/src/lib/libwasi.js
@@ -532,7 +532,7 @@ var WasiLibrary = {
     return 0;
   },
 
-  fd_sync: (fd) => {
+  fd_sync: {{{ asyncIf(ASYNCIFY) }}} (fd) => {
 #if SYSCALLS_REQUIRE_FILESYSTEM
     var stream = SYSCALLS.getStreamFromFD(fd);
 #if ASYNCIFY

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4960,8 +4960,6 @@ Module["preRun"] = () => {
   def test_embind(self, args):
     if is_jspi(args) and not is_chrome():
       self.skipTest(f'Current browser ({common.EMTEST_BROWSER}) does not support JSPI. Only chromium-based browsers ({CHROMIUM_BASED_BROWSERS}) support JSPI today.')
-    if is_jspi(args) and self.is_wasm64():
-      self.skipTest('_emval_await fails')
 
     self.btest('embind_with_asyncify.cpp', '1', cflags=['-lembind'] + args)
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3246,6 +3246,7 @@ More info: https://emscripten.org
     '': [['-sDYNAMIC_EXECUTION=1']],
     'no_dynamic': [['-sDYNAMIC_EXECUTION=0']],
     'dyncall': [['-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=4GB']],
+    'wasm64': (['-sMEMORY64'],),
   })
   @requires_jspi
   def test_embind_jspi(self, args):
@@ -3483,6 +3484,24 @@ More info: https://emscripten.org
                                            '--js-library=lib.js',
                                            '-Wno-experimental',
                                            '--post-js=post.js'])
+
+  @requires_jspi
+  def test_jspi_bad_library_function(self):
+    create_file('lib.js', r'''
+      addToLibrary({
+        foo__async: true,
+        foo: function(f) {},
+      });
+    ''')
+    create_file('main.c', r'''
+      #include <emscripten.h>
+      extern void foo();
+      EMSCRIPTEN_KEEPALIVE void test() {
+        foo();
+      }
+    ''')
+    err = self.expect_fail([EMCC, 'main.c', '-o', 'out.js', '-sJSPI', '--js-library=lib.js', '-Wno-experimental',])
+    self.assertContained('error: foo is marked with the __async decorator but is not an async JS function.', err)
 
   @requires_dev_dependency('typescript')
   @parameterized({


### PR DESCRIPTION
The `_emval_await` library function is marked `_emval_await__async: true`, but the js function is not async. With memory64 enabled we auto convert to bigint and look for the async keyword (which is missing) to apply the await before creating the BigInt. With my changes __async will require an async js function, which signals the function is used with JSPI and the appropriate awaits are then inserted.

Fixes #25468