### PR TITLE
Update cache to use absPath instead of Path.resolve

### DIFF
--- a/tools/cache.py
+++ b/tools/cache.py
@@ -194,7 +194,7 @@ def get(shortname, creator, what=None, force=False, quiet=False):
 def setup():
   global cachedir, cachelock, cachelock_name
   # figure out the root directory for all caching
-  cachedir = Path(config.CACHE).resolve()
+  cachedir = os.path.abspath(config.CACHE)
 
   # since the lock itself lives inside the cache directory we need to ensure it
   # exists.


### PR DESCRIPTION
Encounter issue compiling Emscripten in windows when EM_CACHE was provided a shortcut path (symbolic link).

The original code `Path(config.CACHE).resolve()` returns the original cache path which is in a different drive from where the emscripten source is in. 

Hence in this PR, the `cachedir` was change to use `os.path.abspath(config.CACHE)` to allow the build process to access the cache via the symbolic link 

https://github.com/emscripten-core/emscripten/issues/25463