### PR TITLE
Add comment about minimum Firefox version required to run parallel test harness.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -116,6 +116,9 @@ class ChromeConfig:
     """Chrome has no special configuration step."""
 
 
+# N.b. The earliest Firefox version that can run multithreaded browser harness
+# is Firefox 67. If you need to test earlier Firefox versions, use EMTEST_CORES=1
+# environment variable to revert to the single-threaded browser harness.
 class FirefoxConfig:
   data_dir_flag = '-profile '
   default_flags = ('-new-instance',)


### PR DESCRIPTION
The new parallel Firefox test harness requires Firefox 67 or newer to run.

Firefox 66 and earlier suffer from two bugs:

1) When launching multiple browsers with

```
[C:\\emsdk\\firefox\\65.0_64bit\\firefox.exe, '-new-instance', '-profile', 'C:\\emsdk\\emscripten\\main\\out\\browser-profile-1', 'http://localhost:5555'
```

then if a previous instance of Firefox is running, Firefox will interpret the `-profile` argument as a URL to visit. (It will take that argument as profile path as well). This results in two tabs being opened in each browser instance (beyond the first):

<img width="1692" height="1205" alt="image" src="https://github.com/user-attachments/assets/7eff70b7-4455-48fa-adc7-dcc75fc1f76a" />

but unfortunately given that the actual test URL is in the background, the test never progresses.

(This issue could be fixed by passing `-url` parameter, but given this is an ancient browser, and bug 2 also exists, not worth it to complicate code)

2) If a test fails in Firefox 66 or older, and a browser instance is being terminated, it looks like all browser instances get torn down, and not just the one that was hosting the failing test. So this would result in a lot of false positives in test failures.

Bisected that the fix to the above issues occurred somewhere between Firefox 66 and 67, in this bisection range: https://hg-edge.mozilla.org/mozilla-central/pushloghtml?fromchange=4ab143dde4dc3424cfedc74b3648fbf2e47fb7bf&tochange=af29567ecdba5441117b3f01ac2559a3473c3d6a

This PR adds a comment suggesting to set `EMTEST_CORES=1` if testing older Firefox versions.