### PR TITLE
Remove some unnecessary use of `Path.resolve()`. NFC

### DIFF
--- a/site/source/conf.py
+++ b/site/source/conf.py
@@ -97,7 +97,7 @@ copyright = u'2015, '
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-version_path = Path(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'emscripten-version.txt').resolve()
+version_path = Path(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'emscripten-version.txt')
 emscripten_version = version_path.read_text().strip().strip('"')
 
 # The short X.Y version.

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -194,7 +194,7 @@ def get(shortname, creator, what=None, force=False, quiet=False):
 def setup():
   global cachedir, cachelock, cachelock_name
   # figure out the root directory for all caching
-  cachedir = Path(config.CACHE).resolve()
+  cachedir = Path(config.CACHE)
 
   # since the lock itself lives inside the cache directory we need to ensure it
   # exists.


### PR DESCRIPTION
It looks like this was first introduced in #17102 as a replacement for `os.path.normpath`, but its not actually same thing `os.path.normpath` does not resolve symlinks.

Apparently resolving symlinks can actually cause crashes on windows in some cases.  See #25463.

Fixes: #25463