### PR TITLE
Delete the Atomics.waitAsync() polyfill

### DIFF
--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -298,7 +298,6 @@ if (ENVIRONMENT_IS_WASM_WORKER
     return Atomics.isLockFree(width);
   },
 
-  emscripten_lock_async_acquire__deps: ['$polyfillWaitAsync'],
   emscripten_lock_async_acquire: (lock, asyncWaitFinished, userData, maxWaitMilliseconds) => {
     let dispatch = (val, ret) => {
       setTimeout(() => {


### PR DESCRIPTION
Delete the Atomics.waitAsync() polyfill, which is not good enough to polyfill over the usage pattern in Emscripten mailbox implementation. See https://github.com/emscripten-core/emscripten/pull/25449#issuecomment-3358594240 . The mailbox implementation has its own postMessage() fallback, so does not need the polyfill. Fixes test browser.test_gl_textures_pthreads_main_module in Firefox."

This will be a breaking change to any users who successfully depended on the polyfill (i.e. only needed the partial support it brought), though it is uncertain if there are any.

Fixes test `browser.test_gl_textures_pthreads_main_module` on Firefox.