### PR TITLE
Add colored print to test harness output

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -16,6 +16,7 @@ from tools import utils
 import common
 from common import errlog
 
+from tools.diagnostics import with_color, CYAN, GREEN, RED
 from tools.utils import WINDOWS
 
 
@@ -304,35 +305,41 @@ class BufferedParallelTestResult:
     with self.lock:
       val = f'[{int(self.progress_counter.value * 100 / self.num_tests)}%] '
       self.progress_counter.value += 1
-    return val
+    return with_color(CYAN, val)
 
   def addSuccess(self, test):
-    errlog(f'{self.compute_progress()}{test} ... ok ({self.calculateElapsed():.2f}s)')
+    msg = f'ok ({self.calculateElapsed():.2f}s)'
+    errlog(f'{self.compute_progress()}{test} ... {with_color(GREEN, msg)}')
     self.buffered_result = BufferedTestSuccess(test)
     self.test_result = 'success'
 
   def addExpectedFailure(self, test, err):
-    errlog(f'{self.compute_progress()}{test} ... expected failure ({self.calculateElapsed():.2f}s)')
+    msg = f'expected failure ({self.calculateElapsed():.2f}s)'
+    errlog(f'{self.compute_progress()}{test} ... {with_color(RED, msg)}')
     self.buffered_result = BufferedTestExpectedFailure(test, err)
     self.test_result = 'expected failure'
 
   def addUnexpectedSuccess(self, test):
-    errlog(f'{self.compute_progress()}{test} ... unexpected success ({self.calculateElapsed():.2f}s)')
+    msg = f'unexpected success ({self.calculateElapsed():.2f}s)'
+    errlog(f'{self.compute_progress()}{test} ... {with_color(RED, msg)}')
     self.buffered_result = BufferedTestUnexpectedSuccess(test)
     self.test_result = 'unexpected success'
 
   def addSkip(self, test, reason):
-    errlog(f"{self.compute_progress()}{test} ... skipped '{reason}'")
+    msg = f"skipped '{reason}'"
+    errlog(f"{self.compute_progress()}{test} ... {with_color(CYAN, msg)}")
     self.buffered_result = BufferedTestSkip(test, reason)
     self.test_result = 'skipped'
 
   def addFailure(self, test, err):
-    errlog(f'{self.compute_progress()}{test} ... FAIL')
+    msg = f'{test} ... FAIL'
+    errlog(f'{self.compute_progress()}{with_color(RED, msg)}')
     self.buffered_result = BufferedTestFailure(test, err)
     self.test_result = 'failed'
 
   def addError(self, test, err):
-    errlog(f'{self.compute_progress()}{test} ... ERROR')
+    msg = f'{test} ... ERROR'
+    errlog(f'{self.compute_progress()}{with_color(RED, msg)}')
     self.buffered_result = BufferedTestError(test, err)
     self.test_result = 'errored'
 

--- a/tools/diagnostics.py
+++ b/tools/diagnostics.py
@@ -58,7 +58,7 @@ def reset_color():
 
 
 def with_color(color, text):
-  return f'\033[9{color}m{text}\033[0m'
+  return output_color(color) + text + reset_color()
 
 
 def diag(level, msg, *args):

--- a/tools/diagnostics.py
+++ b/tools/diagnostics.py
@@ -43,18 +43,23 @@ level_prefixes = {
 
 
 def output_color(color):
-  assert color_enabled
-  return '\033[3%sm' % color
+  if color_enabled:
+    return '\033[3%sm' % color
+  else:
+    return ''
 
 
 def bold():
-  assert color_enabled
-  return '\033[1m'
+  if color_enabled:
+    return '\033[1m'
+  else:
+    return ''
 
 
 def reset_color():
-  assert color_enabled
-  return '\033[0m'
+  if color_enabled:
+    return '\033[0m'
+  return ''
 
 
 def with_color(color, text):

--- a/tools/diagnostics.py
+++ b/tools/diagnostics.py
@@ -45,15 +45,13 @@ level_prefixes = {
 def output_color(color):
   if color_enabled:
     return '\033[3%sm' % color
-  else:
-    return ''
+  return ''
 
 
 def bold():
   if color_enabled:
     return '\033[1m'
-  else:
-    return ''
+  return ''
 
 
 def reset_color():

--- a/tools/diagnostics.py
+++ b/tools/diagnostics.py
@@ -57,6 +57,10 @@ def reset_color():
   return '\033[0m'
 
 
+def with_color(color, text):
+  return f'\033[9{color}m{text}\033[0m'
+
+
 def diag(level, msg, *args):
   # Format output message as:
   # <tool>: <level>: msg


### PR DESCRIPTION
Another take at adding colors to test harness:

<img width="2183" height="1668" alt="image" src="https://github.com/user-attachments/assets/095e3207-600c-419f-962d-b430acc05f6e" />

Tested to work on:
 - Windows 10 x64
 - Windows 11 ARM64
 - MacOS 15.5 Sequoia Apple M1
 - Linux Debian 13 Trixie ARM64

