### PR TITLE
Update test skips and comments related to OffscreenCanvas tests in Firefox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1113,16 +1113,10 @@ jobs:
           # initial position of the mouse pointer relative to the canvas.
           # browser.test_html5_webgl_create_context is skipped because
           # anti-aliasing is not well supported.
-          # browser.test_webgl_offscreen_canvas_in_pthread and
-          # browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread
-          # are crashing Firefox (bugzil.la/1281796). The former case is
-          # further blocked by issue #6897.
           test_targets: "
             browser
             skip:browser.test_sdl2_mouse
             skip:browser.test_html5_webgl_create_context
-            skip:browser.test_webgl_offscreen_canvas_in_pthread
-            skip:browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread
             skip:browser.test_glut_glutget
             "
   test-browser-firefox-wasm64:

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4241,8 +4241,9 @@ Module["preRun"] = () => {
   # Tests that it is possible to initialize and render WebGL content in a
   # pthread by using OffscreenCanvas.
   @no_chrome('https://crbug.com/961765')
-  # Suffers from browser priority inversion deadlock problem: offscreenCanvas.getContext("webgl2") does not make progress in a pthread until main thread yields to event loop.
-  @no_firefox('https://bugzilla.mozilla.org/show_bug.cgi?id=1972240')
+  # The non-chained version suffers from browser priority inversion deadlock problem: offscreenCanvas.getContext("webgl2") does not make progress in a pthread until main thread yields to event loop.
+  # The chained version of this test suffers from bug https://bugzilla.mozilla.org/show_bug.cgi?id=1992576
+  @no_firefox('https://bugzilla.mozilla.org/show_bug.cgi?id=1972240 (priority inversion deadlock) + https://bugzilla.mozilla.org/show_bug.cgi?id=1992576 (chained OffscreenCanvas transfer)')
   @parameterized({
     '': ([],),
     # -DTEST_CHAINED_WEBGL_CONTEXT_PASSING:


### PR DESCRIPTION
Update test skips and comments related to OffscreenCanvas tests in Firefox.