### PR TITLE
Implement -ffast-math flag mapping to wasm-opt --fast-math

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -66,6 +66,12 @@ var ASSERTIONS = 1;
 // [link]
 var STACK_OVERFLOW_CHECK = 0;
 
+// Enable fast math optimizations in wasm-opt when -ffast-math is passed.
+// This enables aggressive floating-point optimizations that may violate
+// IEEE 754 semantics but can improve performance.
+// [link]
+var FAST_MATH = 0;
+
 // When STACK_OVERFLOW_CHECK is enabled we also check writes to address zero.
 // This can help detect NULL pointer usage.  If you want to skip this extra
 // check (for example, if you want reads from the address zero to always return

--- a/tools/building.py
+++ b/tools/building.py
@@ -789,9 +789,12 @@ def minify_wasm_js(js_file, wasm_file, expensive_optimizations, debug_info):
 # get the flags to pass into the very last binaryen tool invocation, that runs
 # the final set of optimizations
 def get_last_binaryen_opts():
-  return [f'--optimize-level={settings.OPT_LEVEL}',
+  opts = [f'--optimize-level={settings.OPT_LEVEL}',
           f'--shrink-level={settings.SHRINK_LEVEL}',
           '--optimize-stack-ir']
+  if settings.FAST_MATH:
+    opts.append('--fast-math')
+  return opts
 
 
 # run binaryen's wasm-metadce to dce both js and wasm

--- a/tools/cmdline.py
+++ b/tools/cmdline.py
@@ -294,9 +294,8 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
         settings.SHRINK_LEVEL = 0
         settings.DEBUG_LEVEL = max(settings.DEBUG_LEVEL, 1)
       elif requested_level == 'fast':
-        # TODO(https://github.com/emscripten-core/emscripten/issues/21497):
-        # If we ever map `-ffast-math` to `wasm-opt --fast-math` then
-        # then we should enable that too here.
+        # -Ofast typically includes -ffast-math semantics, so enable fast math optimizations
+        settings.FAST_MATH = 1
         requested_level = 3
         settings.SHRINK_LEVEL = 0
       else:
@@ -547,6 +546,8 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
       settings.WASM_EXCEPTIONS = 1
     elif arg == '-fignore-exceptions':
       settings.DISABLE_EXCEPTION_CATCHING = 1
+    elif arg == '-ffast-math':
+      settings.FAST_MATH = 1
     elif check_arg('--default-obj-ext'):
       exit_with_error('--default-obj-ext is no longer supported by emcc')
     elif arg.startswith('-fsanitize=cfi'):


### PR DESCRIPTION
# Implement -ffast-math flag mapping to wasm-opt --fast-math

## Description

This PR implements the mapping from the `-ffast-math` compiler flag to the `wasm-opt --fast-math` optimization flag, as requested in issue #21497.

## Changes Made

### 1. Added FAST_MATH Setting (`src/settings.js`)
- Added `FAST_MATH` setting in the Tuning section with default value 0
- Added comprehensive documentation explaining the setting
- Marked as `[link]` flag as it affects wasm-opt during linking

### 2. Command Line Flag Handling (`tools/cmdline.py`)
- Added handling for `-ffast-math` flag to set `FAST_MATH = 1`
- Enhanced `-Ofast` optimization level to also enable fast math (since `-Ofast` typically includes `-ffast-math` semantics)
- Removed the TODO comment as the feature is now implemented

### 3. wasm-opt Integration (`tools/building.py`)
- Modified `get_last_binaryen_opts()` function to include `--fast-math` flag when `FAST_MATH` setting is enabled
- Maintains backward compatibility - no `--fast-math` flag when `FAST_MATH = 0`

## How It Works

- **Without `-ffast-math`**: Normal behavior, no `--fast-math` flag passed to wasm-opt
- **With `-ffast-math`**: Sets `FAST_MATH = 1`, causing wasm-opt to receive `--fast-math` flag
- **With `-Ofast`**: Automatically enables fast math optimizations (standard behavior)

