### PR TITLE
Use the nice browser bug URL shorteners

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -1345,10 +1345,10 @@ def browser_display_name(browser):
 
 def subprocess_env():
   e = os.environ.copy()
-  # https://bugzilla.mozilla.org/show_bug.cgi?id=745154
+  # https://bugzil.la/745154
   e['MOZ_DISABLE_AUTO_SAFE_MODE'] = '1'
-  e['MOZ_DISABLE_SAFE_MODE_KEY'] = '1' # https://bugzilla.mozilla.org/show_bug.cgi?id=653410#c9
-  e['JIT_OPTION_asmJSAtomicsEnable'] = 'true' # https://bugzilla.mozilla.org/show_bug.cgi?id=1299359#c0
+  e['MOZ_DISABLE_SAFE_MODE_KEY'] = '1' # https://bugzil.la/653410#c9
+  e['JIT_OPTION_asmJSAtomicsEnable'] = 'true' # https://bugzil.la/1299359#c0
   return e
 
 

--- a/site/source/docs/api_reference/wasm_workers.rst
+++ b/site/source/docs/api_reference/wasm_workers.rst
@@ -153,7 +153,7 @@ a Wasm Worker, consider which type of hierarchy you would like, and if necessary
 hierarchy manually by posting the Worker creation over to the main thread yourself.
 
 Note that support for nested Workers varies across browsers. As of 02/2022, nested Workers are `not
-supported in Safari <https://bugs.webkit.org/show_bug.cgi?id=22723>`_. See `here 
+supported in Safari <https://webkit.org/b/22723>`_. See `here 
 <https://github.com/johanholmerin/nested-worker>`_ for a polyfill.
 
 Pthreads can use the Wasm Worker synchronization API, but not vice versa

--- a/site/source/docs/porting/pthreads.rst
+++ b/site/source/docs/porting/pthreads.rst
@@ -136,7 +136,7 @@ The Emscripten implementation for the pthreads API should follow the POSIX stand
 
 - The Emscripten implementation does also not support multiprocessing via ``fork()`` and ``join()``.
 
-- For web security purposes, there exists a fixed limit (by default 20) of threads that can be spawned when running in Firefox Nightly. `#1052398 <https://bugzilla.mozilla.org/show_bug.cgi?id=1052398>`_. To adjust the limit, navigate to about:config and change the value of the pref "dom.workers.maxPerDomain".
+- For web security purposes, there exists a fixed limit (by default 20) of threads that can be spawned when running in Firefox Nightly. `#1052398 <https://bugzil.la/1052398>`_. To adjust the limit, navigate to about:config and change the value of the pref "dom.workers.maxPerDomain".
 
 - Some of the features in the pthreads specification are unsupported since the upstream musl library that Emscripten utilizes does not support them, or they are marked optional and a conformant implementation need not support them. Such unsupported features in Emscripten include prioritization of threads, and pthread_rwlock_unlock() is not performed in thread priority order. The functions pthread_mutexattr_set/getprotocol(), pthread_mutexattr_set/getprioceiling() and pthread_attr_set/getscope() are no-ops.
 

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -921,7 +921,7 @@ GL_DISABLE_HALF_FLOAT_EXTENSION_IF_BROKEN
 
 From Safari 8 (where WebGL was introduced to Safari) onwards, OES_texture_half_float and OES_texture_half_float_linear extensions
 are broken and do not function correctly, when used as source textures.
-See https://bugs.webkit.org/show_bug.cgi?id=183321, https://bugs.webkit.org/show_bug.cgi?id=169999,
+See https://webkit.org/b/183321, https://webkit.org/b/169999,
 https://stackoverflow.com/questions/54248633/cannot-create-half-float-oes-texture-from-uint16array-on-ipad
 
 Default value: false
@@ -933,7 +933,7 @@ GL_WORKAROUND_SAFARI_GETCONTEXT_BUG
 
 Workaround Safari WebGL issue: After successfully acquiring WebGL context on a canvas,
 calling .getContext() will always return that context independent of which 'webgl' or 'webgl2'
-context version was passed. See https://bugs.webkit.org/show_bug.cgi?id=222758 and
+context version was passed. See https://webkit.org/b/222758 and
 https://github.com/emscripten-core/emscripten/issues/13295.
 Set this to 0 to force-disable the workaround if you know the issue will not affect you.
 

--- a/src/audio_worklet.js
+++ b/src/audio_worklet.js
@@ -256,8 +256,8 @@ function createWasmAudioWorkletProcessor() {
 // that has a MessagePort over to the AudioWorklet, then polyfill that by
 // a hacky AudioWorkletProcessor that provides the MessagePort.
 // Firefox added support in https://hg-edge.mozilla.org/integration/autoland/rev/ab38a1796126f2b3fc06475ffc5a625059af59c1
-// Chrome ticket: https://issues.chromium.org/issues/446920095
-// Safari ticket: https://bugs.webkit.org/show_bug.cgi?id=299386
+// Chrome ticket: https://crbug.com/446920095
+// Safari ticket: https://webkit.org/b/299386
 /**
  * @suppress {duplicate, checkTypes}
  */

--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -120,7 +120,7 @@ var LibraryHTML5 = {
         // whether it is possible to perform a request here without needing to defer. See
         // https://developer.mozilla.org/en-US/docs/Web/Security/User_activation#transient_activation
         // and https://caniuse.com/mdn-api_useractivation
-        // At the time of writing, Firefox does not support this API: https://bugzilla.mozilla.org/show_bug.cgi?id=1791079
+        // At the time of writing, Firefox does not support this API: https://bugzil.la/1791079
         return navigator.userActivation.isActive;
       }
 

--- a/src/lib/libsdl.js
+++ b/src/lib/libsdl.js
@@ -2521,7 +2521,7 @@ var LibrarySDL = {
           source['connect'](SDL.audioContext['destination']);
 
           SDL.fillWebAudioBufferFromHeap(ptr, sizeSamplesPerChannel, soundBuffer);
-          // Workaround https://bugzilla.mozilla.org/show_bug.cgi?id=883675 by setting the buffer only after filling. The order is important here!
+          // Workaround https://bugzil.la/883675 by setting the buffer only after filling. The order is important here!
           source['buffer'] = soundBuffer;
 
           // Schedule the generated sample buffer to be played out at the correct time right after the previously scheduled
@@ -2775,7 +2775,7 @@ var LibrarySDL = {
 
     // To allow user code to work around browser bugs with audio playback on <audio> elements an Web Audio, enable
     // the user code to hook in a callback to decide on a file basis whether each file should use Web Audio or <audio> for decoding and playback.
-    // In particular, see https://bugzilla.mozilla.org/show_bug.cgi?id=654787 and ?id=1012801 for tradeoffs.
+    // In particular, see https://bugzil.la/654787 and https://bugzil.la/1012801 for tradeoffs.
     var canPlayWithWebAudio = Module['SDL_canPlayWithWebAudio'] === undefined || Module['SDL_canPlayWithWebAudio'](filename, arrayBuffer);
 
     if (bytes !== undefined && SDL.webAudioAvailable() && canPlayWithWebAudio) {
@@ -3172,7 +3172,7 @@ var LibrarySDL = {
     surfData.ctx.font = fontString;
     // use bottom alignment, because it works
     // same in all browsers, more info here:
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=737852
+    // https://bugzil.la/737852
     surfData.ctx.textBaseline = 'bottom';
     surfData.ctx.fillText(text, 0, h|0);
     surfData.ctx.restore();

--- a/src/lib/libstack_trace.js
+++ b/src/lib/libstack_trace.js
@@ -51,7 +51,7 @@ var LibraryStackTrace = {
           file = parts[2];
           lineno = parts[3];
           // Old Firefox doesn't carry column information, but in new FF30, it
-          // is present. See https://bugzilla.mozilla.org/show_bug.cgi?id=762556
+          // is present. See https://bugzil.la/762556
           column = parts[4]|0;
         } else {
           // Was not able to extract this line for demangling/sourcemapping

--- a/src/lib/libwebaudio.js
+++ b/src/lib/libwebaudio.js
@@ -133,7 +133,7 @@ var LibraryWebAudio = {
     console.log(`Destroyed Web Audio Node with ID ${objectHandle}`);
 #endif
     // Explicitly disconnect the node from Web Audio graph before letting it GC,
-    // to work around browser bugs such as https://bugs.webkit.org/show_bug.cgi?id=222098#c23
+    // to work around browser bugs such as https://webkit.org/b/222098#c23
     EmAudio[objectHandle].disconnect();
     delete EmAudio[objectHandle];
   },
@@ -198,8 +198,8 @@ var LibraryWebAudio = {
       // that has a MessagePort over to the AudioWorklet, then polyfill that by
       // instantiating a dummy AudioWorkletNode to get a MessagePort over.
       // Firefox added support in https://hg-edge.mozilla.org/integration/autoland/rev/ab38a1796126f2b3fc06475ffc5a625059af59c1
-      // Chrome ticket: https://issues.chromium.org/issues/446920095
-      // Safari ticket: https://bugs.webkit.org/show_bug.cgi?id=299386
+      // Chrome ticket: https://crbug.com/446920095
+      // Safari ticket: https://webkit.org/b/299386
       if (!audioWorklet['port']) {
         audioWorklet['port'] = {
           postMessage: (msg) => {

--- a/src/lib/libwebgl.js
+++ b/src/lib/libwebgl.js
@@ -754,7 +754,7 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
       // context on a canvas, calling .getContext() will always return that
       // context independent of which 'webgl' or 'webgl2'
       // context version was passed. See:
-      //   https://bugs.webkit.org/show_bug.cgi?id=222758
+      //   https://webkit.org/b/222758
       // and:
       //   https://github.com/emscripten-core/emscripten/issues/13295.
       // TODO: Once the bug is fixed and shipped in Safari, adjust the Safari
@@ -811,7 +811,7 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
         // Bug on Safari on iOS and macOS: texImage2D() and texSubImage2D() do
         // not allow uploading pixel data to half float textures, rendering them
         // useless.
-        // See https://bugs.webkit.org/show_bug.cgi?id=183321, https://bugs.webkit.org/show_bug.cgi?id=169999,
+        // See https://webkit.org/b/183321, https://webkit.org/b/169999,
         // https://stackoverflow.com/questions/54248633/cannot-create-half-float-oes-texture-from-uint16array-on-ipad
         ctx.texImage2D(0xDE1/*GL_TEXTURE_2D*/, 0, 0x1908/*GL_RGBA*/, 1, 1, 0, 0x1908/*GL_RGBA*/, 0x8d61/*HALF_FLOAT_OES*/, new Uint16Array(4));
         var broken = ctx.getError();
@@ -821,7 +821,7 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
           ctx.realGetSupportedExtensions = ctx.getSupportedExtensions;
           ctx.getSupportedExtensions = function() {
 #if GL_ASSERTIONS
-            warnOnce('Removed broken support for half-float textures. See e.g. https://bugs.webkit.org/show_bug.cgi?id=183321');
+            warnOnce('Removed broken support for half-float textures. See e.g. https://webkit.org/b/183321');
 #endif
             // .getSupportedExtensions() can return null if context is lost, so
             // coerce to empty array.
@@ -862,7 +862,7 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
 #if MIN_FIREFOX_VERSION < 67
       else {
         // The WebGL 2 blit path doesn't work in Firefox < 67 (except in fullscreen).
-        // https://bugzilla.mozilla.org/show_bug.cgi?id=1523030
+        // https://bugzil.la/1523030
         var firefoxMatch = navigator.userAgent.toLowerCase().match(/firefox\/(\d\d)/);
         if (firefoxMatch != null) {
           var firefoxVersion = firefoxMatch[1];
@@ -1240,7 +1240,7 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
 
       // However, Firefox exposes the WebGL 1 version on WebGL 2 as well and
       // thus we look for the WebGL 1 version again if the WebGL 2 version
-      // isn't present. https://bugzilla.mozilla.org/show_bug.cgi?id=1328882
+      // isn't present. https://bugzil.la/1328882
       if (context.version < 2 || !GLctx.disjointTimerQueryExt)
 #endif
       {

--- a/src/lib/libwebgl2.js
+++ b/src/lib/libwebgl2.js
@@ -949,7 +949,7 @@ var LibraryWebGL2 = {
   glDrawRangeElements: (mode, start, end, count, type, indices) => {
     // TODO: This should be a trivial pass-though function registered at the bottom of this page as
     // glFuncs[6][1] += ' drawRangeElements';
-    // but due to https://bugzilla.mozilla.org/show_bug.cgi?id=1202427,
+    // but due to https://bugzil.la/1202427,
     // we work around by ignoring the range.
     _glDrawElements(mode, count, type, indices);
   },

--- a/src/settings.js
+++ b/src/settings.js
@@ -600,14 +600,14 @@ var STB_IMAGE = false;
 
 // From Safari 8 (where WebGL was introduced to Safari) onwards, OES_texture_half_float and OES_texture_half_float_linear extensions
 // are broken and do not function correctly, when used as source textures.
-// See https://bugs.webkit.org/show_bug.cgi?id=183321, https://bugs.webkit.org/show_bug.cgi?id=169999,
+// See https://webkit.org/b/183321, https://webkit.org/b/169999,
 // https://stackoverflow.com/questions/54248633/cannot-create-half-float-oes-texture-from-uint16array-on-ipad
 // [link]
 var GL_DISABLE_HALF_FLOAT_EXTENSION_IF_BROKEN = false;
 
 // Workaround Safari WebGL issue: After successfully acquiring WebGL context on a canvas,
 // calling .getContext() will always return that context independent of which 'webgl' or 'webgl2'
-// context version was passed. See https://bugs.webkit.org/show_bug.cgi?id=222758 and
+// context version was passed. See https://webkit.org/b/222758 and
 // https://github.com/emscripten-core/emscripten/issues/13295.
 // Set this to 0 to force-disable the workaround if you know the issue will not affect you.
 // [link]

--- a/system/include/emscripten/wasm_worker.h
+++ b/system/include/emscripten/wasm_worker.h
@@ -113,7 +113,7 @@ int emscripten_navigator_hardware_concurrency(void);
 // the given memory access width can be accessed atomically, and false
 // otherwise. Generally will return true on 1, 2 and 4 byte accesses. On 8 byte
 // accesses, behavior differs across browsers, see
-//  - https://bugzilla.mozilla.org/show_bug.cgi?id=1246139
+//  - https://bugzil.la/1246139
 //  - https://bugs.chromium.org/p/chromium/issues/detail?id=1167449
 int emscripten_atomics_is_lock_free(int byteWidth);
 

--- a/test/browser/webgl_create_context.cpp
+++ b/test/browser/webgl_create_context.cpp
@@ -147,7 +147,7 @@ int main() {
     if (!depth && stencil && numDepthBits && numStencilBits && EM_ASM_INT(navigator.userAgent.toLowerCase().indexOf('firefox')) > -1)
     {
       numDepthBits = 0;
-      printf("Applying workaround to ignore Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=982477\n");
+      printf("Applying workaround to ignore Firefox bug https://bugzil.la/982477\n");
     }
     assert(!!numDepthBits == !!depth);
     assert(!!numStencilBits == !!stencil);

--- a/test/pthread/test_pthread_mutex.c
+++ b/test/pthread/test_pthread_mutex.c
@@ -23,7 +23,7 @@ pthread_mutex_t lock;
 
 void sleepms(int msecs) {
   // Test two different variants of sleeping to verify
-  // against bug https://bugzilla.mozilla.org/show_bug.cgi?id=1131757
+  // against bug https://bugzil.la/1131757
 #ifdef SPINLOCK_TEST
   double t0 = emscripten_get_now();
   double t1 = t0 + (double)msecs;

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3943,7 +3943,7 @@ Module["preRun"] = () => {
   def test_pthread_printf(self, args):
      self.btest_exit('pthread/test_pthread_printf.c', cflags=['-pthread', '-sPTHREAD_POOL_SIZE'] + args)
 
-  # Test that pthreads are able to do cout. Failed due to https://bugzilla.mozilla.org/show_bug.cgi?id=1154858.
+  # Test that pthreads are able to do cout. Failed due to https://bugzil.la/1154858.
   def test_pthread_iostream(self):
     self.btest_exit('pthread/test_pthread_iostream.cpp', cflags=['-O3', '-pthread', '-sPTHREAD_POOL_SIZE'])
 
@@ -4242,8 +4242,8 @@ Module["preRun"] = () => {
   # pthread by using OffscreenCanvas.
   @no_chrome('https://crbug.com/961765')
   # The non-chained version suffers from browser priority inversion deadlock problem: offscreenCanvas.getContext("webgl2") does not make progress in a pthread until main thread yields to event loop.
-  # The chained version of this test suffers from bug https://bugzilla.mozilla.org/show_bug.cgi?id=1992576
-  @no_firefox('https://bugzilla.mozilla.org/show_bug.cgi?id=1972240 (priority inversion deadlock) + https://bugzilla.mozilla.org/show_bug.cgi?id=1992576 (chained OffscreenCanvas transfer)')
+  # The chained version of this test suffers from bug https://bugzil.la/1992576
+  @no_firefox('https://bugzil.la/1972240 (priority inversion deadlock) + https://bugzil.la/1992576 (chained OffscreenCanvas transfer)')
   @parameterized({
     '': ([],),
     # -DTEST_CHAINED_WEBGL_CONTEXT_PASSING:
@@ -4437,7 +4437,7 @@ Module["preRun"] = () => {
     if is_firefox() and '-sOFFSCREENCANVAS_SUPPORT' in cmd and '-sPROXY_TO_PTHREAD' in cmd:
       # Firefox is unable to transfer the same OffscreenCanvas multiple times across Workers
       # (in a chained fashion, e.g. main thread -> proxy-to-pthread main thread -> back to main thread -> user pthread)
-      self.skipTest('https://bugzilla.mozilla.org/show_bug.cgi?id=1992576')
+      self.skipTest('https://bugzil.la/1992576')
 
     print(str(cmd))
     self.btest_exit('test_webgl_resize_offscreencanvas_from_main_thread.c', cflags=cmd)

--- a/tools/link.py
+++ b/tools/link.py
@@ -1709,7 +1709,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     settings.WEBGL_USE_GARBAGE_FREE_APIS = 1
     # Some browsers have issues using the WebGL2 garbage-free APIs when the
     # memory offsets are over 2^31 or 2^32
-    # For firefox see: https://bugzilla.mozilla.org/show_bug.cgi?id=1838218
+    # For firefox see: https://bugzil.la/1838218
     if settings.MIN_FIREFOX_VERSION != feature_matrix.UNSUPPORTED and settings.MAXIMUM_MEMORY > 2 ** 31:
       settings.WEBGL_USE_GARBAGE_FREE_APIS = 0
     # For chrome see: https://crbug.com/324992397

--- a/tools/minimal_runtime_shell.py
+++ b/tools/minimal_runtime_shell.py
@@ -77,7 +77,7 @@ def generate_minimal_runtime_load_statement(target_basename):
       then_statements += ['''\
   // Detour the JS code to a separate variable to avoid instantiating with 'r' array as "this"
   // directly to avoid strict ECMAScript/Firefox GC problems that cause a leak, see
-  // https://bugzilla.mozilla.org/show_bug.cgi?id=1540101
+  // https://bugzil.la/1540101
   var js = URL.createObjectURL(new Blob([r[0]], { type: \'application/javascript\' }));
   script(js).then((c) => c({
   %s
@@ -86,7 +86,7 @@ def generate_minimal_runtime_load_statement(target_basename):
       then_statements += ['''\
   // Detour the JS code to a separate variable to avoid instantiating with 'r' array as "this"
   // directly to avoid strict ECMAScript/Firefox GC problems that cause a leak, see
-  // https://bugzilla.mozilla.org/show_bug.cgi?id=1540101
+  // https://bugzil.la/1540101
   var js = r[0];
   js({
   %s


### PR DESCRIPTION
Use the nice browser bug URL shorteners to refer to bug reports, e.g.
 - `https://bugzil.la/<ID>`,
 - `https://crbug.com/<ID>` and
 - `https://webkit.org/b/<ID>`