### PR TITLE
Move `getNativeTypeSize` library function as legacy. NFC

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -2267,9 +2267,6 @@ addToLibrary({
     }
   },
 
-  $getNativeTypeSize__deps: ['$POINTER_SIZE'],
-  $getNativeTypeSize: {{{ getNativeTypeSize }}},
-
   $wasmTable__docs: '/** @type {WebAssembly.Table} */',
 #if RELOCATABLE
   // In RELOCATABLE mode we create the table in JS.

--- a/src/lib/liblegacy.js
+++ b/src/lib/liblegacy.js
@@ -122,6 +122,9 @@ legacyFuncs = {
   // (This was a mistake in the original implementation, and kept
   // to avoid breakage.)
   $jstoi_s: 'Number',
+
+  $getNativeTypeSize__deps: ['$POINTER_SIZE'],
+  $getNativeTypeSize: {{{ getNativeTypeSize }}},
 };
 
 if (WARN_DEPRECATED && !INCLUDE_FULL_LIBRARY) {

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -937,7 +937,6 @@ Module['FS_createPreloadedFile'] = FS.createPreloadedFile;
   'alignMemory',
   'mmapAlloc',
   'HandleAllocator',
-  'getNativeTypeSize',
   'getUniqueRunDependency',
   'addOnPreRun',
   'addOnInit',

--- a/test/codesize/test_codesize_minimal_O0.json
+++ b/test/codesize/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18484,
-  "a.out.js.gz": 6842,
+  "a.out.js": 18466,
+  "a.out.js.gz": 6834,
   "a.out.nodebug.wasm": 1136,
   "a.out.nodebug.wasm.gz": 659,
-  "total": 19620,
-  "total_gz": 7501,
+  "total": 19602,
+  "total_gz": 7493,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -7,10 +7,10 @@
   "no_asserts.js.gz": 8877,
   "no_asserts.wasm": 12227,
   "no_asserts.wasm.gz": 6010,
-  "strict.js": 53546,
-  "strict.js.gz": 16835,
+  "strict.js": 53523,
+  "strict.js.gz": 16823,
   "strict.wasm": 15127,
   "strict.wasm.gz": 7447,
-  "total": 178149,
-  "total_gz": 64117
+  "total": 178126,
+  "total_gz": 64105
 }


### PR DESCRIPTION
This function is not used anywhere in emscripten anymore.