### PR TITLE
Improve testing of liblegacy.js. NFC

### DIFF
--- a/src/lib/liblegacy.js
+++ b/src/lib/liblegacy.js
@@ -2,6 +2,16 @@
  * @license
  * Copyright 2010 The Emscripten Authors
  * SPDX-License-Identifier: MIT
+ *
+ * Legacy library symbols that are no longer used by emscripten itself but
+ * could have external users.
+ *
+ * Symbols in this file are not available in `-sSTRICT` mode.
+ *
+ * Any usage of symbols in this file will result in a `-Wdeprecated` warning.
+ *
+ * Symbol in this file should be removed after "enough time" has passed such
+ * that all external users have been able to transision away.
  */
 
 legacyFuncs = {
@@ -73,8 +83,10 @@ legacyFuncs = {
     if (!dontAddNull) {{{ makeSetValue('buffer', 0, 0, 'i8') }}};
   },
 
-  $allocateUTF8: '$stringToNewUTF8',
-  $allocateUTF8OnStack: '$stringToUTF8OnStack',
+  $allocateUTF8__deps: ['$stringToNewUTF8'],
+  $allocateUTF8: (...args) => stringToNewUTF8(...args),
+  $allocateUTF8OnStack__deps: ['$stringToUTF8OnStack'],
+  $allocateUTF8OnStack: (...args) => stringToUTF8OnStack(...args),
 
 #if LINK_AS_CXX
   $demangle__deps: ['$withStackSave', '__cxa_demangle', 'free', '$stringToUTF8OnStack'],
@@ -130,8 +142,8 @@ legacyFuncs = {
 if (WARN_DEPRECATED && !INCLUDE_FULL_LIBRARY) {
   for (const name of Object.keys(legacyFuncs)) {
     if (!isDecorator(name)) {
-      depsKey = `${name}__deps`;
-      legacyFuncs[depsKey] = legacyFuncs[depsKey] || [];
+      const depsKey = `${name}__deps`;
+      legacyFuncs[depsKey] ??= []
       legacyFuncs[depsKey].push(() => {
         warn(`JS library symbol '${name}' is deprecated. Please open a bug if you have a continuing need for this symbol [-Wdeprecated]`);
       });

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 23198,
-  "a.out.js.gz": 8524,
+  "a.out.js.gz": 8525,
   "a.out.nodebug.wasm": 15127,
   "a.out.nodebug.wasm.gz": 7450,
   "total": 38325,
-  "total_gz": 15974,
+  "total_gz": 15975,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,6 +1,6 @@
 {
   "hello_world.js": 55508,
-  "hello_world.js.gz": 17498,
+  "hello_world.js.gz": 17499,
   "hello_world.wasm": 15127,
   "hello_world.wasm.gz": 7450,
   "no_asserts.js": 26614,
@@ -12,5 +12,5 @@
   "strict.wasm": 15127,
   "strict.wasm.gz": 7447,
   "total": 178126,
-  "total_gz": 64105
+  "total_gz": 64106
 }

--- a/test/other/test_legacy_runtime.c
+++ b/test/other/test_legacy_runtime.c
@@ -3,7 +3,7 @@
 
 int main () {
   intptr_t addr = EM_ASM_INT({
-     return allocate(intArrayFromString("hello from js"), ALLOC_NORMAL);
+     return stringToNewUTF8("hello from js");
   });
   printf("%s\n", (char*)addr);
   return 0;


### PR DESCRIPTION
We had some testing for `LEGACY_RUNTIME` but not explicitly for the usage of symbols in `liblegacy.js` which are two slightly different things.