### PR TITLE
[test] Use `limit_size` in regex test failure reporting. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1720,10 +1720,10 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
     if regex:
       if type(values) is str:
-        self.assertTrue(re.search(values, string, re.DOTALL), 'Expected regex "%s" to match on:\n%s' % (values, string))
+        self.assertTrue(re.search(values, string, re.DOTALL), 'Expected regex "%s" to match on:\n%s' % (values, limit_size(string)))
       else:
         match_any = any(re.search(o, string, re.DOTALL) for o in values)
-        self.assertTrue(match_any, 'Expected at least one of "%s" to match on:\n%s' % (values, string))
+        self.assertTrue(match_any, 'Expected at least one of "%s" to match on:\n%s' % (values, limit_size(string)))
       return
 
     if type(values) not in [list, tuple]:


### PR DESCRIPTION
This avoids printing (for example) thousand line files when the matches fail.  We were already using this helper for the non-regex case.