### PR TITLE
Disable Firefox quit confirmation dialog

### DIFF
--- a/test/firefox_user.js
+++ b/test/firefox_user.js
@@ -13,6 +13,9 @@ user_pref("services.sync.prefs.sync.browser.sessionstore.restore_on_demand", fal
 user_pref("browser.sessionstore.restore_on_demand", false);
 user_pref("browser.sessionstore.max_resumed_crashes", -1);
 user_pref("toolkit.startup.max_resumed_crashes", -1);
+// Ease shutting down browser instances in the parallel browser harness
+user_pref("browser.warnOnQuit", false);
+user_pref("browser.warnOnQuitShortcut", false);
 // Don't show the slow script dialog popup
 user_pref("dom.max_script_run_time", 0);
 user_pref("dom.max_chrome_script_run_time", 0);


### PR DESCRIPTION
To ease live macOS Firefox browser debugging, disable the confirmation prompt on cmd-q to kill browser.