### PR TITLE
Fix node dbg() function to log undefined correctly

### DIFF
--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -17,7 +17,13 @@ function dbg(...args) {
     // TODO(sbc): Unify with err/out implementation in shell.sh.
     var fs = require('fs');
     var utils = require('util');
-    var stringify = (a) => typeof a == 'object' ? utils.inspect(a) : a;
+    function stringify(a) {
+      switch (typeof a) {
+        case 'object': return utils.inspect(a);
+        case 'undefined': return 'undefined';
+      }
+      return a;
+    }
     fs.writeSync(2, args.map(stringify).join(' ') + '\n');
   } else
 #endif


### PR DESCRIPTION
Previously `dbg(1, 2, undefined)` would just print `1 2 `, not it printf `1 2 undefined` which is more like what console.warn does.