### PR TITLE
Fix emcc color output regression from #25502 on Windows.

### DIFF
--- a/tools/colored_logger.py
+++ b/tools/colored_logger.py
@@ -13,6 +13,7 @@ import sys
 import logging
 from functools import wraps
 
+
 # ANSI colors
 RED = 1
 GREEN = 2


### PR DESCRIPTION
This was lost in refactor of #25502 .

The reason I did not see the regression in my comment https://github.com/emscripten-core/emscripten/pull/25502#issuecomment-3373780715 is that calling `subprocess.run(['C:/emsdk/node/22.16.0_64bit/bin/node.exe', 'C:\\emsdk\\emscripten\\main\\test\\hello_world.js'])` has a side effect of also leaking/enabling `ENABLE_VIRTUAL_TERMINAL_PROCESSING` for the current terminal, so by the time that the parallel test harness was running, `node` subprocess had been executed and vterm processing was activated.