### PR TITLE
Export mutable wasm globals as JS objects. NFC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 4.0.17 (in development)
 -----------------------
+- Mutable Wasm globals can now be exported from native code.  Currently these
+  cannot be declared in C/C++ but can be defined and exported in assembly code.
+  This currently only works for mutable globals since immutables are already
+  (and continue to be) exported as plain JS numbers. (#25530)
 - Minimum Firefox version was bumped up to Firefox 68 ESR, since older Firefox
   versions are not able to run the parallel browser harness: (#25493)
   - Firefox: v65 -> v68

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -16,8 +16,8 @@
 // underscore.
 var WASM_EXPORTS = [];
 
-// Similar to above but only includes the global/data symbols.
-var WASM_GLOBAL_EXPORTS = [];
+// Similar to above but only includes the data symbols (address exports).
+var DATA_EXPORTS = [];
 
 // An array of all symbols exported from all the side modules specified on the
 // command line.

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26912,
-  "a.out.js.gz": 11470,
+  "a.out.js": 26919,
+  "a.out.js.gz": 11469,
   "a.out.nodebug.wasm": 18567,
   "a.out.nodebug.wasm.gz": 9199,
-  "total": 45479,
-  "total_gz": 20669,
+  "total": 45486,
+  "total_gz": 20668,
   "sent": [
     "__heap_base",
     "__indirect_function_table",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 245822,
+  "a.out.js": 245829,
   "a.out.nodebug.wasm": 597746,
-  "total": 843568,
+  "total": 843575,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/core/test_wasm_global.c
+++ b/test/core/test_wasm_global.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <emscripten/em_asm.h>
+#include <emscripten.h>
+
+__asm__(
+".section .data.my_global,\"\",@\n"
+".globl my_global\n"
+".globaltype my_global, i32\n"
+"my_global:\n"
+);
+
+int get_global() {
+  int val;
+  // Without volatile here this test fails in O1 and above.
+  __asm__ volatile ("global.get my_global\n"
+                    "local.set %0\n" : "=r" (val));
+  return val;
+}
+
+void set_global(int val) {
+  __asm__("local.get %0\n"
+          "global.set my_global\n" : : "r" (val));
+}
+
+int main() {
+  printf("in main: %d\n", get_global());
+  set_global(42);
+  printf("new value: %d\n", get_global());
+  EM_ASM({
+      // With the ESM integration, the Wasm global be exported as a regular
+      // number.  Otherwise it will be a WebAssembly.Global object.
+#ifdef ESM_INTEGRATION
+      assert(typeof _my_global == 'number', typeof _my_global);
+      out('from js:', _my_global);
+      _my_global += 1
+#else
+      assert(typeof _my_global == 'object', typeof _my_global);
+      out('from js:', _my_global.value);
+      _my_global.value += 1
+#endif
+  });
+  printf("done: %d\n", get_global());
+}

--- a/test/core/test_wasm_global.out
+++ b/test/core/test_wasm_global.out
@@ -1,0 +1,4 @@
+in main: 0
+new value: 42
+from js: 42
+done: 43

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9677,6 +9677,19 @@ NODEFS is no longer included by default; build with -lnodefs.js
       self.set_setting('MAIN_MODULE', 2)
     self.do_core_test('test_externref_emjs.c')
 
+  @parameterized({
+    '': [False],
+    'dylink': [True],
+  })
+  @no_esm_integration('https://github.com/emscripten-core/emscripten/issues/25543')
+  def test_wasm_global(self, dynlink):
+    if dynlink:
+      self.check_dylink()
+      self.set_setting('MAIN_MODULE', 2)
+    if self.get_setting('WASM_ESM_INTEGRATION'):
+      self.cflags.append('-DESM_INTEGRATION')
+    self.do_core_test('test_wasm_global.c', cflags=['-sEXPORTED_FUNCTIONS=_main,_my_global'])
+
   def test_syscall_intercept(self):
     self.do_core_test('test_syscall_intercept.c')
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -810,7 +810,7 @@ def metadce(js_file, wasm_file, debug_info, last):
     exports = settings.WASM_EXPORTS
   else:
     # Ignore exported wasm globals.  Those get inlined directly into the JS code.
-    exports = sorted(set(settings.WASM_EXPORTS) - set(settings.WASM_GLOBAL_EXPORTS))
+    exports = sorted(set(settings.WASM_EXPORTS) - set(settings.DATA_EXPORTS))
 
   extra_info = '{ "exports": [' + ','.join(f'["{asmjs_mangle(x)}", "{x}"]' for x in exports) + ']}'
 

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -111,7 +111,7 @@ def update_settings_glue(wasm_file, metadata, base_metadata):
     settings.WASM_EXPORTS = base_metadata.all_exports
   else:
     settings.WASM_EXPORTS = metadata.all_exports
-  settings.WASM_GLOBAL_EXPORTS = list(metadata.global_exports.keys())
+  settings.DATA_EXPORTS = list(metadata.data_exports.keys())
   settings.HAVE_EM_ASM = bool(settings.MAIN_MODULE or len(metadata.em_asm_consts) != 0)
 
   # start with the MVP features, and add any detected features.
@@ -269,9 +269,9 @@ def trim_asm_const_body(body):
   return body
 
 
-def create_global_exports(global_exports):
+def create_data_exports(data_exports):
   lines = []
-  for k, v in global_exports.items():
+  for k, v in data_exports.items():
     if shared.is_internal_global(k):
       continue
 
@@ -408,11 +408,11 @@ def emscript(in_wasm, out_wasm, outfile_js, js_syms, finalize=True, base_metadat
     other_exports = base_metadata.other_exports
     # We want the real values from the final metadata but we only want to
     # include names from the base_metadata.  See phase_link() in link.py.
-    global_exports = {k: v for k, v in metadata.global_exports.items() if k in base_metadata.global_exports}
+    data_exports = {k: v for k, v in metadata.data_exports.items() if k in base_metadata.data_exports}
   else:
     function_exports = metadata.function_exports
     other_exports = metadata.other_exports
-    global_exports = metadata.global_exports
+    data_exports = metadata.data_exports
 
   if settings.ASYNCIFY == 1:
     function_exports['asyncify_start_unwind'] = webassembly.FuncType([webassembly.Type.I32], [])
@@ -421,7 +421,7 @@ def emscript(in_wasm, out_wasm, outfile_js, js_syms, finalize=True, base_metadat
     function_exports['asyncify_stop_rewind'] = webassembly.FuncType([], [])
 
   parts = [pre]
-  parts += create_module(metadata, function_exports, global_exports, other_exports,
+  parts += create_module(metadata, function_exports, data_exports, other_exports,
                          forwarded_json['librarySymbols'], forwarded_json['nativeAliases'])
   parts.append(post)
   settings.ALIASES = list(forwarded_json['nativeAliases'].keys())
@@ -1008,10 +1008,10 @@ def create_receiving(function_exports, other_exports, library_symbols, aliases):
   return '\n'.join(receiving)
 
 
-def create_module(metadata, function_exports, global_exports, other_exports, library_symbols, aliases):
+def create_module(metadata, function_exports, data_exports, other_exports, library_symbols, aliases):
   module = []
   module.append(create_receiving(function_exports, other_exports, library_symbols, aliases))
-  module.append(create_global_exports(global_exports))
+  module.append(create_data_exports(data_exports))
 
   sending = create_sending(metadata, library_symbols)
   if settings.WASM_ESM_INTEGRATION:


### PR DESCRIPTION
For immutable wasm globals we currently export them as simple JS numbers at build time.  This is because data symbol addresses are exported as immutable globals.

However, its also useful to export real wasm globals.  For now we treat mutable globals and immutable global differently here but we should look into perhaps changing that in the future.