### PR TITLE
Fix other.test_split_module_wasm64 test. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -830,7 +830,7 @@ jobs:
             wasm64l.test_module_wasm_memory
             wasm64l.test_longjmp2_emscripten
             wasm64l.test_embind_val_basics_legacy
-            other.test_failing_growth_wasm64"
+            other.*_wasm64"
       - upload-test-results
   test-jsc:
     executor: linux-python

--- a/test/other/test_split_module.post.js
+++ b/test/other/test_split_module.post.js
@@ -1,9 +1,11 @@
+#preprocess
+
 function saveProfileData() {
   var __write_profile = wasmExports['__write_profile'];
   if (__write_profile) {
-    var len = __write_profile(0, 0);
+    var len = __write_profile({{{ to64('0') }}}, 0);
     var offset = _malloc(len);
-    var actualLen = __write_profile(offset, len);
+    var actualLen = __write_profile({{{ to64('offset') }}}, len);
     var profile_data = HEAPU8.subarray(offset, offset + len);
     if (typeof writeFile !== 'undefined') {
       console.log('using writeFile')


### PR DESCRIPTION
This should have been part of #25432 but it seems we had a gap in our wasm64 testing because the `other` test suite is run with the standard emsdk version of node (v18) which does not support wasm64.