### PR TITLE
Add `MUTABLE_GLOBALS` to feature_matrix

### DIFF
--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -276,12 +276,10 @@ var LibraryDylink = {
         continue;
       }
 #endif
-      if (typeof value?.value != 'undefined') {
-        // a breaking change in the wasm spec, globals are now objects
-        // https://github.com/WebAssembly/mutable-global/issues/1
+      // Detect wasm global exports. These represent data addresses
+      // which are relative to `memoryBase`
+      if (value instanceof WebAssembly.Global) {
         value = value.value;
-      }
-      if (typeof value == {{{ POINTER_JS_TYPE }}}) {
         value += {{{ to64('memoryBase') }}};
       }
       relocated[e] = value;

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26931,
-  "a.out.js.gz": 11472,
+  "a.out.js": 26912,
+  "a.out.js.gz": 11470,
   "a.out.nodebug.wasm": 18567,
   "a.out.nodebug.wasm.gz": 9199,
-  "total": 45498,
-  "total_gz": 20671,
+  "total": 45479,
+  "total_gz": 20669,
   "sent": [
     "__heap_base",
     "__indirect_function_table",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 245841,
+  "a.out.js": 245822,
   "a.out.nodebug.wasm": 597746,
-  "total": 843587,
+  "total": 843568,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2015,6 +2015,9 @@ Module['postRun'] = () => {
   def test_dylink_strict(self):
     self.do_run_in_out_file_test('hello_world.c', cflags=['-sSTRICT', '-sMAIN_MODULE=1'])
 
+  def test_dylink_legacy(self):
+    self.do_run_in_out_file_test('hello_world.c', cflags=['-sLEGACY_GL_EMULATION', '-sMAIN_MODULE=2'])
+
   def test_dylink_exceptions_and_assertions(self):
     # Linking side modules using the STL and exceptions should not abort with
     # "function in Table but not functionsInTableMap" when using ASSERTIONS=2

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -31,6 +31,7 @@ OLDEST_SUPPORTED_NODE = 122209
 
 
 class Feature(IntEnum):
+  MUTABLE_GLOBALS = auto()
   NON_TRAPPING_FPTOINT = auto()
   SIGN_EXT = auto()
   BULK_MEMORY = auto()
@@ -48,6 +49,12 @@ disable_override_features = set()
 enable_override_features = set()
 
 min_browser_versions = {
+  Feature.MUTABLE_GLOBALS: {
+    'chrome': 74,
+    'firefox': 61,
+    'safari': 130100,
+    'node': 120000,
+  },
   Feature.NON_TRAPPING_FPTOINT: {
     'chrome': 75,
     'firefox': 65,
@@ -213,6 +220,8 @@ def apply_min_browser_versions():
     enable_feature(Feature.BULK_MEMORY, 'pthreads')
   elif settings.WASM_WORKERS or settings.SHARED_MEMORY:
     enable_feature(Feature.BULK_MEMORY, 'shared-mem')
+  if settings.RELOCATABLE:
+    enable_feature(Feature.MUTABLE_GLOBALS, 'dynamic linking')
   if settings.MEMORY64 == 1:
     enable_feature(Feature.MEMORY64, 'MEMORY64')
   if settings.EXPORT_ES6 and settings.PTHREADS:


### PR DESCRIPTION
This is needed by dynamic linking since GOT entries are all imported as mutable globals.

The net effect of this is that you cannot actually target the oldest version of safari that we support (12) and with dynamically linked programs.  Specifying `-sLEGACY_VM_SUPPORT` will give you safari 13.1 instead of 12 if you also using `-sMAIN_MODULE`.