### PR TITLE
[ci] Split wasm64 misc tests into their own runner. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -820,7 +820,31 @@ jobs:
           command: echo "NODE_JS = NODE_JS_TEST" >> ~/emsdk/.emscripten
       - run-tests:
           title: "wasm64_4gb"
-          test_targets: "wasm64_4gb
+          test_targets: "wasm64_4gb"
+      - upload-test-results
+  test-wasm64-misc:
+    environment:
+      LANG: "C.UTF-8"
+    # We don't use `bionic` here since its too old to run recent node versions:
+    # `/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found`
+    executor: linux-python
+    steps:
+      - prepare-for-tests
+      # The linux-python image uses /home/circleci rather than /root and jsvu
+      # hardcodes /root into its launcher scripts so we need to reinstall v8.
+      - run: rm -rf $HOME/.jsvu
+      - install-v8
+      - install-node-canary
+      # When running wasm64 tests we need to make sure we use the testing
+      # version of node (node canary) when running the compiler output (e.g.
+      # in configure tests.
+      - run:
+          name: configure node canary
+          command: echo "NODE_JS = NODE_JS_TEST" >> ~/emsdk/.emscripten
+      - run-tests:
+          title: "wasm64"
+          test_targets: "
+            other.*_wasm64
             core_2gb.test_*em_asm*
             core_2gb.test_*embind*
             core_2gb.test_fs_js_api_wasmfs
@@ -829,8 +853,7 @@ jobs:
             wasm64l.test_bigswitch
             wasm64l.test_module_wasm_memory
             wasm64l.test_longjmp2_emscripten
-            wasm64l.test_embind_val_basics_legacy
-            other.*_wasm64"
+            wasm64l.test_embind_val_basics_legacy"
       - upload-test-results
   test-jsc:
     executor: linux-python
@@ -1278,6 +1301,9 @@ workflows:
           requires:
             - build-linux
       - test-core3:
+          requires:
+            - build-linux
+      - test-wasm64-misc:
           requires:
             - build-linux
       - test-wasm64-4gb:


### PR DESCRIPTION
Prior to this we were tacking on the extra misc tests on the end of wasm64-4gb runner.