### PR TITLE
Use config file instead of environment to configure ccache

### DIFF
--- a/.circleci/ccache.conf
+++ b/.circleci/ccache.conf
@@ -1,2 +1,2 @@
-debug = 1
-debuglevel = 1
+debug = true
+debug_level = 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -615,6 +615,7 @@ jobs:
           name: Configure ccache
           command: |
             mkdir -p ~/.ccache
+            cat .circleci/ccache.conf
             cp .circleci/ccache.conf ~/.ccache
       - build-libs
       - run:


### PR DESCRIPTION
Using a file will make it easier to set configurations from an earlier step to a later one, or to use a different configuration for the main and other branches.

Also dump some additional log info after building.