### PR TITLE
Simplify emitDCEGraph code for calling acorn optmimzer. NFC

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -365,7 +365,7 @@ def acorn_optimizer(filename, passes, extra_info=None, return_output=False, work
     temp = temp_files.get('.js', prefix='emcc_acorn_info_').name
     shutil.copyfile(filename, temp)
     with open(temp, 'a') as f:
-      f.write('// EXTRA_INFO: ' + extra_info)
+      f.write('// EXTRA_INFO: ' + json.dumps(extra_info))
     filename = temp
   cmd = config.NODE_JS + [optimizer, filename] + passes
   if not worker_js:
@@ -812,7 +812,7 @@ def metadce(js_file, wasm_file, debug_info, last):
     # Ignore exported wasm globals.  Those get inlined directly into the JS code.
     exports = sorted(set(settings.WASM_EXPORTS) - set(settings.DATA_EXPORTS))
 
-  extra_info = '{ "exports": [' + ','.join(f'["{asmjs_mangle(x)}", "{x}"]' for x in exports) + ']}'
+  extra_info = {"exports": [[asmjs_mangle(x), x] for x in exports]}
 
   txt = acorn_optimizer(js_file, ['emitDCEGraph', '--no-print'], return_output=True, extra_info=extra_info)
   if shared.SKIP_SUBPROCS:
@@ -904,7 +904,7 @@ def metadce(js_file, wasm_file, debug_info, last):
     logger.debug("unused_imports: %s", str(unused_imports))
     logger.debug("unused_exports: %s", str(unused_exports))
   extra_info = {'unusedImports': unused_imports, 'unusedExports': unused_exports}
-  return acorn_optimizer(js_file, passes, extra_info=json.dumps(extra_info))
+  return acorn_optimizer(js_file, passes, extra_info=extra_info)
 
 
 def minify_wasm_imports_and_exports(js_file, wasm_file, minify_exports, debug_info):
@@ -940,7 +940,7 @@ def minify_wasm_imports_and_exports(js_file, wasm_file, minify_exports, debug_in
   if settings.MINIFICATION_MAP:
     lines = [f'{new}:{old}' for old, new in mapping.items()]
     utils.write_file(settings.MINIFICATION_MAP, '\n'.join(lines) + '\n')
-  return acorn_optimizer(js_file, passes, extra_info=json.dumps(extra_info))
+  return acorn_optimizer(js_file, passes, extra_info=extra_info)
 
 
 def wasm2js(js_file, wasm_file, opt_level, use_closure_compiler, debug_info, symbols_file=None, symbols_file_js=None):


### PR DESCRIPTION
Instead of manual formatting we can just use `json.dumps`.