### PR TITLE
[WasmFS] Add missing library headers

### DIFF
--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -12,6 +12,7 @@
 #include <emscripten.h>
 #include <emscripten/html5.h>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <sys/stat.h>


### PR DESCRIPTION
`std::enable_shared_from_this` comes from \<memory\> header

See https://en.cppreference.com/w/cpp/memory/enable_shared_from_this.html