### PR TITLE
Fix tools/install.py script to use Emsdk Node.js and NPM

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15687,7 +15687,7 @@ addToLibrary({
   @crossplatform
   @requires_git_checkout
   def test_install(self):
-    self.run_process([PYTHON, path_from_root('tools/install.py'), 'newdir'])
+    self.run_process([PYTHON, path_from_root('tools/install.py'), 'newdir'], env=shared.env_with_node_in_path())
     self.assertExists('newdir/emcc')
     # Some files, such as as maintenance tools should not be part of the
     # install.


### PR DESCRIPTION
Fix tools/install.py script to use Emsdk Node.js and NPM. Fixes other.test_install on macOS if system macOS Node.js version is out of date.