### PR TITLE
Only export selected data addresses on the Module object

### DIFF
--- a/src/memoryprofiler.js
+++ b/src/memoryprofiler.js
@@ -502,7 +502,7 @@ var emscriptenMemoryProfiler = {
     html += '. STACK_MAX: ' + toHex(stackMax, width) + '.';
     html += '<br />STACK memory area used now (should be zero): ' + self.formatBytes(stackBase - stackCurrent) + '.' + colorBar('#FFFF00') + ' STACK watermark highest seen usage (approximate lower-bound!): ' + self.formatBytes(stackBase - self.stackTopWatermark);
 
-    var heap_base = Module['___heap_base'];
+    var heap_base = ___heap_base;
     var heap_end = _sbrk({{{ to64('0') }}});
     html += "<br />DYNAMIC memory area size: " + self.formatBytes(heap_end - heap_base);
     html += ". start: " + toHex(heap_base, width);

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8593,8 +8593,8 @@ Module.onRuntimeInitialized = () => {
           assert(typeof _emscripten_stack_get_base === 'function');
           assert(typeof _emscripten_stack_get_end === 'function');
           assert(typeof _emscripten_stack_get_current === 'function');
-          assert(typeof Module['___heap_base'] === 'number');
-          assert(Module['___heap_base'] > 0);
+          assert(typeof ___heap_base === 'number');
+          assert(___heap_base > 0);
           out('able to run memprof');
         }
       };

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -285,10 +285,10 @@ def create_data_exports(data_exports):
     if settings.RELOCATABLE:
       v += settings.GLOBAL_BASE
     mangled = asmjs_mangle(k)
-    if settings.MINIMAL_RUNTIME:
-      lines.append("var %s = %s;" % (mangled, v))
-    else:
+    if should_export(mangled) and not settings.MINIMAL_RUNTIME:
       lines.append("var %s = Module['%s'] = %s;" % (mangled, mangled, v))
+    else:
+      lines.append("var %s = %s;" % (mangled, v))
 
   return '\n'.join(lines)
 


### PR DESCRIPTION
Just like for other types of symbols we don't want to export symbols on the `Module` object itself if they user requested this.

Also, fix the memory profiler to not depend the external export of `__heap_base` but instead the internal version (like it does for `_sbrk` and other dependencies.