### PR TITLE
[ci] Enable console logging in chrome testing. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -114,6 +114,8 @@ class ChromeConfig:
     '--disable-background-networking',
     # Disable native password pop-ups
     '--password-store=basic',
+    # Send console messages to browser stderr
+    '--enable-logging=stderr',
   )
   headless_flags = '--headless=new --window-size=1024,768'
 


### PR DESCRIPTION
The format looks like this:

```
[4082634:4082634:1017/153703.620972:INFO:CONSOLE:146] "another line.", source: http://localhost:8888/test.html (146)
```