### PR TITLE
Allow pthread-based programs to be loaded cross-origin

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,8 @@ See docs/process.md for more on how version tagging works.
 -----------------------
 - `-sUSE_WEBGPU` was removed in favor of the external port Emdawnwebgpu which
   are used via `--use-port=emdawnwebgpu`. See 4.0.10 release notes for details.
+- A new `CROSS_ORIGIN` setting was added in order to work around issues hosting
+  emscripten programs across different origins (#25581)
 
 4.0.17 - 10/17/25
 -----------------

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -3341,3 +3341,15 @@ It's currently only available under a flag in certain browsers,
 so we disable it by default to save on code size.
 
 Default value: false
+
+.. _cross_origin:
+
+CROSS_ORIGIN
+============
+
+If the emscripten-generated program is hosted on separate origin then
+starting new pthread worker can violate CSP rules.  Enabling
+CROSS_ORIGIN uses an inline worker to instead load the worker script
+indirectly using `importScripts`
+
+Default value: false

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -454,6 +454,16 @@ var LibraryPThread = {
       worker = new Worker(new URL('{{{ pthreadWorkerScript }}}', import.meta.url), {{{ pthreadWorkerOptions }}});
 #else // EXPORT_ES6
       var pthreadMainJs = _scriptName;
+#if CROSS_ORIGIN && ENVIRONMENT_MAY_BE_WEB
+      // In order to support cross origin loading of worker threads load the
+      // worker via a tiny inline `importScripts` call.   For some reason its
+      // fine to `importScripts` across origins, in cases where new Worker
+      // itself does not allow this.
+      // https://github.com/emscripten-core/emscripten/issues/21937
+      if (ENVIRONMENT_IS_WEB) {
+        pthreadMainJs = URL.createObjectURL(new Blob([`importScripts('${_scriptName}')`], { type: 'application/javascript' }));
+      }
+#endif
 #if expectToReceiveOnModule('mainScriptUrlOrBlob')
       // We can't use makeModuleReceiveWithVar here since we want to also
       // call URL.createObjectURL on the mainScriptUrlOrBlob.

--- a/src/settings.js
+++ b/src/settings.js
@@ -2187,6 +2187,12 @@ var GROWABLE_ARRAYBUFFERS = false;
 // so we disable it by default to save on code size.
 var WASM_JS_TYPES = false;
 
+// If the emscripten-generated program is hosted on separate origin then
+// starting new pthread worker can violate CSP rules.  Enabling
+// CROSS_ORIGIN uses an inline worker to instead load the worker script
+// indirectly using `importScripts`
+var CROSS_ORIGIN = false;
+
 // For renamed settings the format is:
 // [OLD_NAME, NEW_NAME]
 // For removed settings (which now effectively have a fixed value and can no


### PR DESCRIPTION
For some reason creating new workers across origins is not allowed,
even when `importScripts` is.

Added a test case which was confirmed to fail without this PR.

Fixes: #21937
