### PR TITLE
Mark CROSS_ORIGIN as requiring pthreads and dynamic execution

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -677,6 +677,8 @@ def report_incompatible_settings():
     ('MODULARIZE', 'NODEJS_CATCH_REJECTION', None),
     ('MODULARIZE', 'NODEJS_CATCH_EXIT', None),
     ('LEGACY_VM_SUPPORT', 'MEMORY64', None),
+    ('CROSS_ORIGIN', 'NO_DYNAMIC_EXECUTION', None),
+    ('CROSS_ORIGIN', 'NO_PTHREADS', None),
   ]
 
   for a, b, reason in incompatible_settings:


### PR DESCRIPTION
This setting was recently added in #25581 and it only currently has en effect on pthread-based programs.

It is also not compatible with `-sNO_DYNAMIC_EXECUTION` because it depends on starting worker based on JS string.

These errors look like this:

```
$ emcc -sCROSS_ORIGIN -pthread -sDYNAMIC_EXECUTION=0 hello.c
emcc: error: CROSS_ORIGIN is not compatible with DYNAMIC_EXECUTION=0
```