### PR TITLE
Merge assignWasmExports and assignWasmSymbols. NFC

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1615,14 +1615,16 @@ addToLibrary({
 #endif
 
 #if !DECLARE_ASM_MODULE_EXPORTS
-  // When DECLARE_ASM_MODULE_EXPORTS is not set we export native symbols
-  // at runtime rather than statically in JS code.
-  $exportWasmSymbols__deps: ['$asmjsMangle',
+  // When DECLARE_ASM_MODULE_EXPORTS is set, this function is programatically
+  // ceated during linking.  See `create_receiving` in `emscripten.py`.
+  // When DECLARE_ASM_MODULE_EXPORTS=0 is set, `assignWasmExports` is instead
+  // defined here as a normal JS library function.
+  $assignWasmExports__deps: ['$asmjsMangle',
 #if DYNCALLS || !WASM_BIGINT
     , '$dynCalls'
 #endif
   ],
-  $exportWasmSymbols: (wasmExports) => {
+  $assignWasmExports: (wasmExports) => {
     for (var [name, exportedSymbol] of Object.entries(wasmExports)) {
       name = asmjsMangle(name);
 #if DYNCALLS || !WASM_BIGINT

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -258,11 +258,7 @@ WebAssembly.instantiate(Module['wasm'], imports).then(/** @suppress {missingProp
   wasmExports = applySignatureConversions(wasmExports);
 #endif
 
-#if DECLARE_ASM_MODULE_EXPORTS
   assignWasmExports(wasmExports);
-#else
-  exportWasmSymbols(wasmExports);
-#endif
 
 #if !IMPORTED_MEMORY
   updateMemoryViews();

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -746,13 +746,7 @@ function getWasmImports() {
     __RELOC_FUNCS__.push(wasmExports['__wasm_apply_data_relocs']);
 #endif
 
-#if DECLARE_ASM_MODULE_EXPORTS
     assignWasmExports(wasmExports);
-#else
-    // If we didn't declare the asm exports as top level enties this function
-    // is in charge of programmatically exporting them on the global object.
-    exportWasmSymbols(wasmExports);
-#endif
 
 #if ABORT_ON_WASM_EXCEPTIONS
     instrumentWasmTableWithAbort();

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -939,8 +939,8 @@ def create_receiving(function_exports, other_exports, library_symbols, aliases):
 
     return '\n'.join(receiving)
 
-  # When not declaring asm exports this section is empty and we instead programmatically export
-  # symbols on the global object by calling exportWasmSymbols after initialization
+  # When not declaring asm exports `assignWasmExports` is instead defined as a simple
+  # library function.
   if not settings.DECLARE_ASM_MODULE_EXPORTS:
     return ''
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -1400,7 +1400,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     settings.REQUIRED_EXPORTS += ['emscripten_get_sbrk_ptr', 'emscripten_stack_get_base']
 
   if not settings.DECLARE_ASM_MODULE_EXPORTS:
-    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$exportWasmSymbols']
+    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$assignWasmExports']
 
   if settings.ALLOW_MEMORY_GROWTH:
     # Setting ALLOW_MEMORY_GROWTH turns off ABORTING_MALLOC, as in that mode we default to


### PR DESCRIPTION
These two functions serve exactly the same purpose so just make them into a single function.

There are still two different methods by which this gets defined but from the POV of the caller they are the same thing.