### PR TITLE
Invert logic for checking if test suite supports parallel runner. NFC

### DIFF
--- a/test/runner.py
+++ b/test/runner.py
@@ -398,7 +398,7 @@ def flattened_tests(loaded_tests):
 
 
 def suite_for_module(module, tests, options):
-  suite_supported = module.__name__ in ('test_core', 'test_other', 'test_posixtest', 'test_browser', 'test_codesize')
+  suite_supported = module.__name__ not in ('test_sanity', 'test_benchmark', 'test_sockets', 'test_interactive', 'test_stress')
   if not common.EMTEST_SAVE_DIR and not shared.DEBUG:
     has_multiple_tests = len(tests) > 1
     has_multiple_cores = parallel_testsuite.num_cores() > 1


### PR DESCRIPTION
These days the unsupported suites are the exceptions and this will become more true is/when we split up the other suite.