### PR TITLE
Enable dylink tests under ubsan

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1084,8 +1084,6 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
       self.skipTest('dynamic linking not supported with llvm-libc')
     if self.is_wasm2js():
       self.skipTest('dynamic linking not supported with wasm2js')
-    if '-fsanitize=undefined' in self.cflags:
-      self.skipTest('dynamic linking not supported with UBSan')
     # MEMORY64=2 mode doesn't currently support dynamic linking because
     # The side modules are lowered to wasm32 when they are built, making
     # them unlinkable with wasm64 binaries.

--- a/tools/link.py
+++ b/tools/link.py
@@ -1568,10 +1568,12 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     settings.REQUIRED_EXPORTS += [
       'malloc',
       'calloc',
+      'realloc',
       'memalign',
       'free',
       'emscripten_builtin_malloc',
       'emscripten_builtin_calloc',
+      'emscripten_builtin_realloc',
       'emscripten_builtin_memalign',
       'emscripten_builtin_free',
     ]


### PR DESCRIPTION
I don't remember why these were disabled but the whole `ubsan` suite seems to still pass with this change.

I'm not why that missing realloc exports for withBuiltinMalloc were ok in other configs but their absence from this list is clearly and oversight.