### PR TITLE
Have test harness delete all old Emscripten files in the temp directory

### DIFF
--- a/test/runner.py
+++ b/test/runner.py
@@ -530,8 +530,10 @@ def cleanup_emscripten_temp():
   that look like they might have been created by Emscripten."""
   for entry in os.listdir(shared.TEMP_DIR):
     if entry.startswith(('emtest_', 'emscripten_')):
+      entry = os.path.join(shared.TEMP_DIR, entry)
       try:
-        utils.delete_dir(os.path.join(shared.TEMP_DIR, entry))
+        if os.path.isdir(entry):
+          utils.delete_dir(entry)
       except Exception:
         pass
 


### PR DESCRIPTION
When starting a test run, delete all old Emscripten files in the temp directory to help avoid runaway temp file leaks filling up a CI system hard drive.

Do it before starting a run, so that developers can still access test files in debug logs.