### PR TITLE
Avoid using a new temp directory for each parallel test. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -569,10 +569,17 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     self.node_args += shared.node_pthread_flags(nodejs)
 
   def set_temp_dir(self, temp_dir):
-    self.temp_dir = temp_dir
-    self.canonical_temp_dir = get_canonical_temp_dir(self.temp_dir)
-    # Explicitly set dedicated temporary directory for parallel tests
-    os.environ['EMCC_TEMP_DIR'] = self.temp_dir
+    if temp_dir:
+      self.temp_dir = temp_dir
+      self.canonical_temp_dir = get_canonical_temp_dir(self.temp_dir)
+      # Explicitly set dedicated temporary directory for parallel tests
+      os.environ['EMCC_TEMP_DIR'] = self.temp_dir
+    else:
+      # Deleting these instance fields will mean that the class field is used
+      # instead.
+      del self.temp_dir
+      del self.canonical_temp_dir
+      del os.environ['EMCC_TEMP_DIR']
 
   def parse_wasm(self, filename):
     wat = self.get_wasm_text(filename)
@@ -672,7 +679,8 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
           self.temp_files_before_run.append(os.path.normpath(os.path.join(root, filename)))
 
     if self.runningInParallel():
-      self.working_dir = tempfile.mkdtemp(prefix='emscripten_test_' + self.__class__.__name__ + '_', dir=self.temp_dir)
+      # When running tests in parallel each test runs it its own new temp directory
+      self.working_dir = tempfile.mkdtemp(prefix='emtest_' + self.__class__.__name__ + '_', dir=self.temp_dir)
     else:
       self.working_dir = path_from_root('out/test')
       if os.path.exists(self.working_dir):

--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -58,12 +58,9 @@ def run_test(args):
     test.__class__.setUpClass()
 
   start_time = time.perf_counter()
-  olddir = os.getcwd()
   result = BufferedParallelTestResult()
   result.start_time = start_time
   result.buffer = buffer
-  temp_dir = tempfile.mkdtemp(prefix='emtest_')
-  test.set_temp_dir(temp_dir)
   try:
     test(result)
   except KeyboardInterrupt:
@@ -73,17 +70,11 @@ def run_test(args):
   finally:
     result.elapsed = time.perf_counter() - start_time
 
-  # Before attempting to delete the tmp dir make sure the current
-  # working directory is not within it.
-  os.chdir(olddir)
-  common.force_delete_dir(temp_dir)
-
   # Since we are returning this result to the main thread we need to make sure
   # that it is serializable/picklable. To do this, we delete any non-picklable
   # fields from the instance.
   del result._original_stdout
   del result._original_stderr
-
   return result
 
 


### PR DESCRIPTION
It should be fine for all parallel tests to using the same TEMP_DIR.

The only limitation is on tests that use the canonical temp directory (e.g. EMCC_DEBUG).

It looks like we used to use a unique temp directory per process (See #6150). However that was changed to one-directory-per-test in #18214, although I don't remember why.

With this change we don't create a new temp directory except for tests that are marked as `uses_canonical_tmp`

Note that each test already run in its own unique directory, which is a different concept the TEMP_DIR.