### PR TITLE
Use createNamedFunction for asyncify wrappers. NFC

### DIFF
--- a/src/lib/libasync.js
+++ b/src/lib/libasync.js
@@ -21,6 +21,9 @@ addToLibrary({
 
 #if ASYNCIFY
   $Asyncify__deps: ['$runAndAbortIfError', '$callUserCallback',
+#if ASSERTIONS
+    '$createNamedFunction',
+#endif
 #if !MINIMAL_RUNTIME
     '$runtimeKeepalivePush', '$runtimeKeepalivePop',
 #endif
@@ -143,6 +146,9 @@ addToLibrary({
 #endif
 #if MAIN_MODULE
       wrapper.orig = original;
+#endif
+#if ASSERTIONS
+      wrapper = createNamedFunction(`__asyncify_wrapper_${original.name}`, wrapper);
 #endif
       return wrapper;
     },

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1775,6 +1775,9 @@ addToLibrary({
   },
 
   $dynCall: (sig, ptr, args = [], promising = false) => {
+#if ASSERTIONS
+    assert(ptr, `null function pointer in dynCall`);
+#endif
 #if ASSERTIONS && (DYNCALLS || !WASM_BIGINT || !JSPI)
     assert(!promising, 'async dynCall is not supported in this mode')
 #endif


### PR DESCRIPTION
Also, add an assertion to dynCall.

Split out from #25522.