### PR TITLE
Reland "Remove tempfile usage from test_sanity.py. NFC"

### DIFF
--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -5,16 +5,13 @@
 
 import glob
 import os
-import platform
 import re
 import shutil
 import stat
-import tempfile
 import time
 from pathlib import Path
 from subprocess import PIPE, STDOUT
 
-import common
 from common import (
   EMBUILDER,
   RunnerCore,
@@ -184,28 +181,27 @@ class sanity(RunnerCore):
     output = self.do([EMCC, '-v'])
     self.assertContained('emcc: warning: config file not found: %s.  You can create one by hand or run `emcc --generate-config`' % default_config, output)
 
-    try:
-      temp_bin = tempfile.mkdtemp()
+    temp_bin = os.path.abspath('bin')
+    os.mkdir(temp_bin)
 
-      def make_new_executable(name):
-        utils.write_file(os.path.join(temp_bin, name), '')
-        make_executable(os.path.join(temp_bin, name))
+    def make_new_executable(name):
+      utils.write_file(os.path.join(temp_bin, name), '')
+      make_executable(os.path.join(temp_bin, name))
 
-      make_new_executable('wasm-ld')
-      make_new_executable('node')
+    make_new_executable('wasm-ld')
+    make_new_executable('node')
 
-      with env_modify({'PATH': temp_bin + os.pathsep + os.environ['PATH']}):
-        output = self.do([EMCC, '--generate-config'])
-    finally:
-      shutil.rmtree(temp_bin)
-      config_data = utils.read_file(default_config)
+    with env_modify({'PATH': temp_bin + os.pathsep + os.environ['PATH']}):
+      output = self.do([EMCC, '--generate-config'])
+
+    config_data = utils.read_file(default_config)
 
     self.assertContained('An Emscripten settings file has been generated at:', output)
     self.assertContained(default_config, output)
     self.assertContained('It contains our best guesses for the important paths, which are:', output)
     self.assertContained('LLVM_ROOT', output)
     self.assertContained('NODE_JS', output)
-    if platform.system() != 'Windows':
+    if not utils.WINDOWS:
       # os.chmod can't make files executable on Windows
       self.assertIdentical(temp_bin, re.search("^ *LLVM_ROOT *= (.*)$", output, re.M).group(1))
       possible_nodes = [os.path.join(temp_bin, 'node')]
@@ -524,29 +520,17 @@ fi
 
   def test_emconfig(self):
     restore_and_set_up()
-
-    fd, custom_config_filename = tempfile.mkstemp(prefix='.emscripten_config_')
-
-    orig_config = utils.read_file(EM_CONFIG)
-
-    # Move the ~/.emscripten to a custom location.
-    with os.fdopen(fd, "w") as f:
-      f.write(get_basic_config())
+    create_file('custom_config', get_basic_config())
 
     # Make a syntax error in the original config file so that attempting to access it would fail.
-    utils.write_file(EM_CONFIG, 'asdfasdfasdfasdf\n\'\'\'' + orig_config)
+    utils.write_file(EM_CONFIG, 'asdfasdfasdfasdf\n')
 
-    temp_dir = tempfile.mkdtemp(prefix='emscripten_temp_')
+    # Test both relative and absolute paths to the config
+    self.run_process([EMCC, '--em-config', os.path.abspath('custom_config')] + MINIMAL_HELLO_WORLD)
+    self.assertContained('hello, world!', self.run_js('a.out.js'))
 
-    with common.chdir(temp_dir):
-      self.run_process([EMCC, '--em-config', custom_config_filename] + MINIMAL_HELLO_WORLD + ['-O2'])
-      result = self.run_js('a.out.js')
-
-    self.assertContained('hello, world!', result)
-
-    # Clean up created temp files.
-    os.remove(custom_config_filename)
-    shutil.rmtree(temp_dir)
+    self.run_process([EMCC, '--em-config', 'custom_config'] + MINIMAL_HELLO_WORLD)
+    self.assertContained('hello, world!', self.run_js('a.out.js'))
 
   def test_emcc_ports(self):
     restore_and_set_up()


### PR DESCRIPTION
This was originally landed in #25617, but reverted because the tests were failing.

In both cases the tempfile usage was not necessary.

test_emconfig: In this case we can just create a new config file in the CWD. Because the test corrupts the main config file there is no risk that the test is accidentally finding the config file via CWD alone so there is no need to change directory into an external temp dir.

test_firstrun: We an just create the fake `bin` files in a subdirectory of the current directory where the test runs. No need for an external temp dir here.

This change also makes 3 of the imports in this file no longer needed!