### PR TITLE
Use MAIN_MODULE=2 in test_dylink_global_var_export. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -905,7 +905,7 @@ base align: 0, 0, 0, 0'''])
   @no_sanitize('sanitizers do not yet support dynamic linking')
   @no_wasm2js('MAIN_MODULE support')
   @needs_dylink
-  @no_js_math('JS_MATH is not compatible with MAIN_MODULE')
+  @no_js_math('JS_MATH is not compatible with MAIN_MODULE=1')
   def test_stack_placement_pic(self):
     self.set_setting('STACK_SIZE', 1024)
     self.set_setting('MAIN_MODULE')
@@ -1027,7 +1027,7 @@ base align: 0, 0, 0, 0'''])
 
   @needs_dylink
   @with_all_sjlj
-  @no_js_math('JS_MATH is not compatible with MAIN_MODULE')
+  @no_js_math('JS_MATH is not compatible with MAIN_MODULE=1')
   def test_longjmp2_main_module(self):
     # Test for binaryen regression:
     # https://github.com/WebAssembly/binaryen/issues/2180
@@ -2991,7 +2991,7 @@ The current type of b is: 9
     self.run_process(cmd)
 
   @needs_dylink
-  @no_js_math('JS_MATH is not compatible with MAIN_MODULE')
+  @no_js_math('JS_MATH is not compatible with MAIN_MODULE=1')
   def test_dlfcn_missing(self):
     self.set_setting('MAIN_MODULE')
     self.set_setting('ASSERTIONS')
@@ -3416,7 +3416,7 @@ Var: 42
     self.do_runf('src.c', 'success.\n')
 
   @needs_dylink
-  @no_js_math('JS_MATH is not compatible with MAIN_MODULE')
+  @no_js_math('JS_MATH is not compatible with MAIN_MODULE=1')
   def test_dlfcn_self(self):
     self.set_setting('MAIN_MODULE')
     self.set_setting('EXPORT_ALL')
@@ -3806,7 +3806,7 @@ caught outer int: 123
 ''')
 
   @needs_dylink
-  @no_js_math('JS_MATH is not compatible with MAIN_MODULE')
+  @no_js_math('JS_MATH is not compatible with MAIN_MODULE=1')
   def test_dlfcn_handle_alloc(self):
     # verify that dlopen does not allocate already used handles
     create_file('a.cpp', r'''
@@ -4605,7 +4605,6 @@ res64 - external 64\n''', header='''\
     ''', expected=['extern is 123.\n'], force_c=True)
 
   @needs_dylink
-  @no_js_math('JS_MATH is not compatible with MAIN_MODULE')
   def test_dylink_global_var_export(self):
     self.do_run(r'''
       #include <assert.h>
@@ -4624,7 +4623,7 @@ res64 - external 64\n''', header='''\
         assert(js_address == &my_number);
         return 0;
       }
-    ''', cflags=['-sMAIN_MODULE'], force_c=True)
+    ''', cflags=['-sMAIN_MODULE=2'], force_c=True)
 
   @with_dylink_reversed
   def test_dylink_global_var_modded(self):
@@ -4782,7 +4781,7 @@ res64 - external 64\n''', header='''\
     'missing': ('libc,libmalloc,libc++abi', False, False, False),
     'missing_assertions': ('libc,libmalloc,libc++abi', False, False, True),
   })
-  @no_js_math('JS_MATH is not compatible with SIDE_MODULE')
+  @no_js_math('JS_MATH is not compatible with MAIN_MODULE=1')
   def test_dylink_syslibs(self, syslibs, expect_pass=True, with_reversed=True, assertions=True):
     # When testing in WASMFS mode, we also need to force the WASMFS syslib into the test.
     if self.get_setting('WASMFS') and syslibs != '1':
@@ -4977,7 +4976,7 @@ res64 - external 64\n''', header='''\
 
   @with_all_eh_sjlj
   @needs_dylink
-  @no_js_math('JS_MATH is not compatible with MAIN_MODULE')
+  @no_js_math('JS_MATH is not compatible with MAIN_MODULE=1')
   def test_dylink_exceptions_try_catch_6(self):
     create_file('main.cpp', r'''
       #include <assert.h>
@@ -5131,7 +5130,7 @@ res64 - external 64\n''', header='''\
     ''', expected=['sidef: 10'])
 
   @needs_dylink
-  @no_js_math('JS_MATH is not compatible with SIDE_MODULE')
+  @no_js_math('JS_MATH is not compatible with MAIN_MODULE=1')
   def test_dylink_dso_needed(self):
     def do_run(src, expected_output, cflags=None):
       create_file('main.c', src + 'int main() { return test_main(); }')
@@ -6342,7 +6341,7 @@ PORT: 3979
     self.do_run_in_out_file_test('netinet/in.cpp')
 
   @needs_dylink
-  @no_js_math('JS_MATH is not compatible with MAIN_MODULE')
+  @no_js_math('JS_MATH is not compatible with MAIN_MODULE=1')
   def test_main_module_static_align(self):
     if self.get_setting('ALLOW_MEMORY_GROWTH'):
       self.skipTest('no shared modules with memory growth')
@@ -9470,7 +9469,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @needs_dylink
   @node_pthreads
-  @no_js_math('JS_MATH is not compatible with MAIN_MODULE')
+  @no_js_math('JS_MATH is not compatible with MAIN_MODULE=1')
   def test_pthread_dylink_main_module_1(self):
     # TODO: For some reason, -lhtml5 must be passed in -sSTRICT mode, but can NOT
     # be passed when not compiling in -sSTRICT mode. That does not seem intentional?
@@ -9634,7 +9633,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_core_test('test_hello_world.c')
 
   @needs_dylink
-  @no_js_math('JS_MATH is not compatible with MAIN_MODULE')
+  @no_js_math('JS_MATH is not compatible with MAIN_MODULE=1')
   def test_gl_main_module(self):
     # TODO: For some reason, -lGL must be passed in -sSTRICT mode, but can NOT
     # be passed when not compiling in -sSTRICT mode. That does not seem intentional?


### PR DESCRIPTION
Using MAIN_MODULE=1 is slower and not supported by JS_MATH.