### PR TITLE
Add assert_fail test helper. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1319,12 +1319,12 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
 
   # Shared test code between main suite and others
 
-  def expect_fail(self, cmd, expect_traceback=False, **args):
+  def expect_fail(self, cmd, expect_traceback=False, **kwargs):
     """Run a subprocess and assert that it returns non-zero.
 
     Return the stderr of the subprocess.
     """
-    proc = self.run_process(cmd, check=False, stderr=PIPE, **args)
+    proc = self.run_process(cmd, check=False, stderr=PIPE, **kwargs)
     self.assertNotEqual(proc.returncode, 0, 'subprocess unexpectedly succeeded. stderr:\n' + proc.stderr)
     # When we check for failure we expect a user-visible error, not a traceback.
     # However, on windows a python traceback can happen randomly sometimes,
@@ -1336,6 +1336,13 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     if EMTEST_VERBOSE:
       sys.stderr.write(proc.stderr)
     return proc.stderr
+
+  def assert_fail(self, cmd, expected, **kwargs):
+    """Just like expect_fail, but also check for expected message in stderr.
+    """
+    err = self.expect_fail(cmd, **kwargs)
+    self.assertContained(expected, err)
+    return err
 
   # excercise dynamic linker.
   #

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2552,8 +2552,8 @@ void *getBindBuffer() {
   @no_wasm64('TODO: wasm64 + BUILD_AS_WORKER')
   def test_worker_api_with_pthread_compilation_fails(self):
     self.run_process([EMCC, '-c', '-o', 'hello.o', test_file('hello_world.c')])
-    stderr = self.expect_fail([EMCC, 'hello.o', '-o', 'a.js', '-g', '--closure=1', '-pthread', '-sBUILD_AS_WORKER'])
-    self.assertContained("pthreads + BUILD_AS_WORKER require separate modes that don't work together, see https://github.com/emscripten-core/emscripten/issues/8854", stderr)
+    expected = "pthreads + BUILD_AS_WORKER require separate modes that don't work together, see https://github.com/emscripten-core/emscripten/issues/8854"
+    self.assert_fail([EMCC, 'hello.o', '-o', 'a.js', '-g', '--closure=1', '-pthread', '-sBUILD_AS_WORKER'], expected)
 
   @also_with_wasmfs
   def test_wget(self):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1346,23 +1346,23 @@ int main(int argc, char **argv) {
 
     # Test old =2 setting for DISABLE_EXCEPTION_CATCHING
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 2)
-    err = self.expect_fail([EMCC, test_file('hello_world.c')] + self.get_cflags())
-    self.assertContained('error: DISABLE_EXCEPTION_CATCHING=X is no longer needed when specifying EXCEPTION_CATCHING_ALLOWED [-Wdeprecated] [-Werror]', err)
+    expected = 'error: DISABLE_EXCEPTION_CATCHING=X is no longer needed when specifying EXCEPTION_CATCHING_ALLOWED [-Wdeprecated] [-Werror]'
+    self.assert_fail([EMCC, test_file('hello_world.c')] + self.get_cflags(), expected)
 
     # =0 should also be a warning
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
-    err = self.expect_fail([EMCC, test_file('hello_world.c')] + self.get_cflags())
-    self.assertContained('error: DISABLE_EXCEPTION_CATCHING=X is no longer needed when specifying EXCEPTION_CATCHING_ALLOWED [-Wdeprecated] [-Werror]', err)
+    expected = 'error: DISABLE_EXCEPTION_CATCHING=X is no longer needed when specifying EXCEPTION_CATCHING_ALLOWED [-Wdeprecated] [-Werror]'
+    self.assert_fail([EMCC, test_file('hello_world.c')] + self.get_cflags(), expected)
 
     # =1 should be a hard error
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
-    err = self.expect_fail([EMCC, test_file('hello_world.c')] + self.get_cflags())
-    self.assertContained('error: DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_ALLOWED are mutually exclusive', err)
+    expected = 'error: DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_ALLOWED are mutually exclusive'
+    self.assert_fail([EMCC, test_file('hello_world.c')] + self.get_cflags(), expected)
 
     # even setting an empty list should trigger the error;
     self.set_setting('EXCEPTION_CATCHING_ALLOWED', [])
-    err = self.expect_fail([EMCC, test_file('hello_world.c')] + self.get_cflags())
-    self.assertContained('error: DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_ALLOWED are mutually exclusive', err)
+    expected = 'error: DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_ALLOWED are mutually exclusive'
+    self.assert_fail([EMCC, test_file('hello_world.c')] + self.get_cflags(), expected)
 
   @with_all_eh_sjlj
   def test_exceptions_uncaught(self):
@@ -1659,20 +1659,20 @@ int main() {
 
     # Emscripten EH and Wasm EH cannot be enabled at the same time
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags())
-    self.assertContained('error: DISABLE_EXCEPTION_CATCHING=0 is not compatible with -fwasm-exceptions', err)
+    expected = 'error: DISABLE_EXCEPTION_CATCHING=0 is not compatible with -fwasm-exceptions'
+    self.assert_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags(), expected)
     clear_all_relevant_settings(self)
 
     self.set_setting('DISABLE_EXCEPTION_THROWING', 0)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags())
-    self.assertContained('error: DISABLE_EXCEPTION_THROWING=0 is not compatible with -fwasm-exceptions', err)
+    expected = 'error: DISABLE_EXCEPTION_THROWING=0 is not compatible with -fwasm-exceptions'
+    self.assert_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags(), expected)
     clear_all_relevant_settings(self)
 
     # Emscripten EH: You can't enable catching and disable throwing
     self.set_setting('DISABLE_EXCEPTION_THROWING', 1)
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags())
-    self.assertContained("error: DISABLE_EXCEPTION_THROWING was set (probably from -fno-exceptions) but is not compatible with enabling exception catching (DISABLE_EXCEPTION_CATCHING=0). If you don't want exceptions, set DISABLE_EXCEPTION_CATCHING to 1; if you do want exceptions, don't link with -fno-exceptions", err)
+    expected = "error: DISABLE_EXCEPTION_THROWING was set (probably from -fno-exceptions) but is not compatible with enabling exception catching (DISABLE_EXCEPTION_CATCHING=0). If you don't want exceptions, set DISABLE_EXCEPTION_CATCHING to 1; if you do want exceptions, don't link with -fno-exceptions"
+    self.assert_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags(), expected)
     clear_all_relevant_settings(self)
 
     # When using Wasm EH, users are not supposed to explicitly pass
@@ -1681,50 +1681,50 @@ int main() {
     # We only warn on these cases, but the tests here error out because the
     # test setting includes -Werror.
     self.set_setting('DISABLE_EXCEPTION_THROWING', 1)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags())
-    self.assertContained('error: you no longer need to pass DISABLE_EXCEPTION_CATCHING or DISABLE_EXCEPTION_THROWING when using Wasm exceptions', err)
+    expected = 'error: you no longer need to pass DISABLE_EXCEPTION_CATCHING or DISABLE_EXCEPTION_THROWING when using Wasm exceptions'
+    self.assert_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags(), expected)
     clear_all_relevant_settings(self)
 
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags())
-    self.assertContained('error: you no longer need to pass DISABLE_EXCEPTION_CATCHING or DISABLE_EXCEPTION_THROWING when using Wasm exceptions', err)
+    expected = 'error: you no longer need to pass DISABLE_EXCEPTION_CATCHING or DISABLE_EXCEPTION_THROWING when using Wasm exceptions'
+    self.assert_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags(), expected)
     clear_all_relevant_settings(self)
 
     # Emscripten SjLj and Wasm EH cannot mix
     self.set_setting('SUPPORT_LONGJMP', 'emscripten')
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags())
-    self.assertContained('error: SUPPORT_LONGJMP=emscripten is not compatible with -fwasm-exceptions', err)
+    expected = 'error: SUPPORT_LONGJMP=emscripten is not compatible with -fwasm-exceptions'
+    self.assert_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags(), expected)
     clear_all_relevant_settings(self)
 
     # Wasm SjLj and Emscripten EH cannot mix
     self.set_setting('SUPPORT_LONGJMP', 'wasm')
     self.set_setting('DISABLE_EXCEPTION_THROWING', 0)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags())
-    self.assertContained('error: SUPPORT_LONGJMP=wasm cannot be used with DISABLE_EXCEPTION_THROWING=0', err)
+    expected = 'error: SUPPORT_LONGJMP=wasm cannot be used with DISABLE_EXCEPTION_THROWING=0'
+    self.assert_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags(), expected)
     clear_all_relevant_settings(self)
 
     self.set_setting('SUPPORT_LONGJMP', 'wasm')
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags())
-    self.assertContained('error: SUPPORT_LONGJMP=wasm cannot be used with DISABLE_EXCEPTION_CATCHING=0', err)
+    expected = 'error: SUPPORT_LONGJMP=wasm cannot be used with DISABLE_EXCEPTION_CATCHING=0'
+    self.assert_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags(), expected)
     clear_all_relevant_settings(self)
 
     # Wasm EH does not support ASYNCIFY=1
     self.set_setting('ASYNCIFY', 1)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags())
-    self.assertContained('error: ASYNCIFY=1 is not compatible with -fwasm-exceptions. Parts of the program that mix ASYNCIFY and exceptions will not compile.', err)
+    expected = 'error: ASYNCIFY=1 is not compatible with -fwasm-exceptions. Parts of the program that mix ASYNCIFY and exceptions will not compile.'
+    self.assert_fail([EMCC, test_file('hello_world.cpp'), '-fwasm-exceptions'] + self.get_cflags(), expected)
     clear_all_relevant_settings(self)
 
     # EXPORT_EXCEPTION_HANDLING_HELPERS and EXCEPTION_STACK_TRACES requires
     # either Emscripten EH or Wasm EH
     self.set_setting('EXPORT_EXCEPTION_HANDLING_HELPERS')
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags())
-    self.assertContained('error: EXPORT_EXCEPTION_HANDLING_HELPERS requires either of -fexceptions or -fwasm-exceptions', err)
+    expected = 'error: EXPORT_EXCEPTION_HANDLING_HELPERS requires either of -fexceptions or -fwasm-exceptions'
+    self.assert_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags(), expected)
     clear_all_relevant_settings(self)
 
     self.set_setting('EXCEPTION_STACK_TRACES')
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags())
-    self.assertContained('error: EXCEPTION_STACK_TRACES requires either of -fexceptions or -fwasm-exceptions', err)
+    expected = 'error: EXCEPTION_STACK_TRACES requires either of -fexceptions or -fwasm-exceptions'
+    self.assert_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags(), expected)
     clear_all_relevant_settings(self)
 
   # Marked as impure since the WASI reactor modules (modules without main)
@@ -2082,8 +2082,8 @@ int main(int argc, char **argv) {
 
   @no_wasm2js('test depends on WASM_BIGINT which is not compatible with wasm2js')
   def test_em_js_i64(self):
-    err = self.expect_fail([EMCC, '-Werror', '-sWASM_BIGINT=0', test_file('core/test_em_js_i64.c')])
-    self.assertContained('emcc: error: using 64-bit arguments in EM_JS function without WASM_BIGINT is not yet fully supported: `foo`', err)
+    expected = 'emcc: error: using 64-bit arguments in EM_JS function without WASM_BIGINT is not yet fully supported: `foo`'
+    self.assert_fail([EMCC, '-Werror', '-sWASM_BIGINT=0', test_file('core/test_em_js_i64.c')], expected)
     self.do_core_test('test_em_js_i64.c')
 
   def test_em_js_address_taken(self):
@@ -6432,8 +6432,7 @@ PORT: 3979
     # On Windows when Unicode support is enabled, this test code does not fail.
     if not (WINDOWS and self.run_process(['chcp'], stdout=PIPE, shell=True).stdout.strip() == 'Active code page: 65001'):
       create_file('expect_fail.py', 'print(len(open(r"%s").read()))' % test_file('unicode_library.js'))
-      err = self.expect_fail([PYTHON, 'expect_fail.py'], expect_traceback=True)
-      self.assertContained('UnicodeDecodeError', err)
+      self.assert_fail([PYTHON, 'expect_fail.py'], 'UnicodeDecodeError', expect_traceback=True)
 
     self.cflags += ['-sMODULARIZE', '--js-library', test_file('unicode_library.js'), '--extern-post-js', test_file('modularize_post_js.js'), '--post-js', test_file('unicode_postjs.js')]
     self.do_run_in_out_file_test('test_unicode_js_library.c')
@@ -7679,8 +7678,7 @@ void* operator new(size_t size) {
     self.do_runf('embind/test_val_read_pointer.cpp', cflags=['-lembind'])
 
   def test_embind_val_assignment(self):
-    err = self.expect_fail([EMCC, test_file('embind/test_val_assignment.cpp'), '-lembind', '-c'])
-    self.assertContained('candidate function not viable: expects an lvalue for object argument', err)
+    self.assert_fail([EMCC, test_file('embind/test_val_assignment.cpp'), '-lembind', '-c'], 'candidate function not viable: expects an lvalue for object argument')
 
   @node_pthreads
   def test_embind_val_cross_thread(self):
@@ -9550,8 +9548,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     if self.get_setting('STANDALONE_WASM'):
       # In standalone we don't support implicitly building without main.  The user has to explicitly
       # opt out (see below).
-      err = self.expect_fail([EMCC, test_file('core/test_ctors_no_main.cpp')] + self.get_cflags())
-      self.assertContained('undefined symbol: main', err)
+      self.assert_fail([EMCC, test_file('core/test_ctors_no_main.cpp')] + self.get_cflags(), 'undefined symbol: main')
     elif not self.get_setting('STRICT'):
       # Traditionally in emscripten we allow main to be implicitly undefined.  This allows programs
       # with a main and libraries without a main to be compiled identically.
@@ -9561,8 +9558,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
       # Disabling IGNORE_MISSING_MAIN should cause link to fail due to missing main
       self.set_setting('IGNORE_MISSING_MAIN', 0)
-      err = self.expect_fail([EMCC, test_file('core/test_ctors_no_main.cpp')] + self.get_cflags())
-      self.assertContained('error: entry symbol not defined (pass --no-entry to suppress): main', err)
+      expected = 'error: entry symbol not defined (pass --no-entry to suppress): main'
+      self.assert_fail([EMCC, test_file('core/test_ctors_no_main.cpp')] + self.get_cflags(), expected)
 
       # In non-standalone mode exporting an empty list of functions signal that we don't
       # have a main and so should not generate an error.
@@ -9581,8 +9578,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_undefined_main_wasm_output(self):
     if not can_do_standalone(self):
       self.skipTest('standalone mode only')
-    err = self.expect_fail([EMCC, '-o', 'out.wasm', test_file('core/test_ctors_no_main.cpp')] + self.get_cflags())
-    self.assertContained('undefined symbol: main', err)
+    self.assert_fail([EMCC, '-o', 'out.wasm', test_file('core/test_ctors_no_main.cpp')] + self.get_cflags(), 'undefined symbol: main')
 
   @no_2gb('crashed wasmtime')
   def test_export_start(self):
@@ -9741,8 +9737,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_promise(self):
     # This test depends on Promise.any, which in turn requires a modern target.  Check that it
     # fails to even build on old targets.
-    err = self.expect_fail([EMCC, test_file('core/test_promise.c'), '-sMIN_CHROME_VERSION=75'])
-    self.assertContained('error: emscripten_promise_any used, but Promise.any is not supported by the current runtime configuration', err)
+    expected = 'error: emscripten_promise_any used, but Promise.any is not supported by the current runtime configuration'
+    self.assert_fail([EMCC, test_file('core/test_promise.c'), '-sMIN_CHROME_VERSION=75'], expected)
     self.do_core_test('test_promise.c')
 
   @with_asyncify_and_jspi

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -447,8 +447,7 @@ class other(RunnerCore):
     self.assertContained('export default Module;', src)
 
   def test_esm_requires_modularize(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sEXPORT_ES6', '-sMODULARIZE=0'])
-    self.assertContained('EXPORT_ES6 requires MODULARIZE to be set', err)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sEXPORT_ES6', '-sMODULARIZE=0'], 'EXPORT_ES6 requires MODULARIZE to be set')
 
   def test_emcc_out_file(self):
     # Verify that "-ofile" works in addition to "-o" "file"
@@ -687,8 +686,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     self.assertExists('twopart_side.o')
 
     # Linking with just one of them is expected to fail
-    err = self.expect_fail([EMCC, 'twopart_main.o'])
-    self.assertContained('undefined symbol: theFunc', err)
+    self.assert_fail([EMCC, 'twopart_main.o'], 'undefined symbol: theFunc')
 
     # Linking with both should work
     self.run_process([EMCC, 'twopart_main.o', 'twopart_side.o'])
@@ -842,8 +840,7 @@ f.close()
     self.assertContained('LLVM', proc.stdout)
 
   def test_em_config_missing_arg(self):
-    out = self.expect_fail([EMCC, '--em-config'])
-    self.assertContained('error: --em-config must be followed by a filename', out)
+    self.assert_fail([EMCC, '--em-config'], 'error: --em-config must be followed by a filename')
 
   @crossplatform
   def test_em_config_filename(self):
@@ -1007,8 +1004,8 @@ f.close()
   # Tests that the Emscripten CMake toolchain option
   def test_cmake_bitcode_static_libraries(self):
     # Test that this option produces an error
-    err = self.expect_fail([EMCMAKE, 'cmake', test_file('cmake/static_lib'), '-DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=ON'])
-    self.assertContained('EMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES is not compatible with the', err)
+    expected = 'EMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES is not compatible with the'
+    self.assert_fail([EMCMAKE, 'cmake', test_file('cmake/static_lib'), '-DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=ON'], expected)
 
   @crossplatform
   @parameterized({
@@ -1252,8 +1249,7 @@ f.close()
       self.do_runf('simple' + suffix, 'hello')
 
       create_file('with_include' + suffix, '#include <stdio.h>\nint main() { puts("hello"); }')
-      err = self.expect_fail([EMCC, 'with_include' + suffix])
-      self.assertContained('fatal error: \'stdio.h\' file not found', err)
+    self.assert_fail([EMCC, 'with_include' + suffix], 'fatal error: \'stdio.h\' file not found')
 
   def test_wl_linkflags(self):
     # Test path -L and -l via -Wl, arguments and -Wl, response files
@@ -1284,14 +1280,12 @@ f.close()
     cmd = [EMCC, test_file('hello_world.c'), '-Wl,--stack-first']
     self.run_process(cmd + ['-O0'])
     self.run_process(cmd + ['-O2'])
-    err = self.expect_fail(cmd + ['-fsanitize=address'])
-    self.assertContained('error: --stack-first is not compatible with asan', err)
-    err = self.expect_fail(cmd + ['-sGLOBAL_BASE=1024'])
-    self.assertContained('error: --stack-first is not compatible with -sGLOBAL_BASE', err)
+    self.assert_fail(cmd + ['-fsanitize=address'], 'error: --stack-first is not compatible with asan')
+    self.assert_fail(cmd + ['-sGLOBAL_BASE=1024'], 'error: --stack-first is not compatible with -sGLOBAL_BASE')
 
   def test_side_module_global_base(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Werror', '-sGLOBAL_BASE=1024', '-sSIDE_MODULE'])
-    self.assertContained('emcc: error: GLOBAL_BASE is not compatible with SIDE_MODULE', err)
+    expected = 'emcc: error: GLOBAL_BASE is not compatible with SIDE_MODULE'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-Werror', '-sGLOBAL_BASE=1024', '-sSIDE_MODULE'], expected)
 
   @parameterized({
     # In a simple -O0 build we do not set --low-memory-unused (as the stack is
@@ -1398,8 +1392,8 @@ f.close()
     """
     create_file('foobar.c', 'int main(){ return 0; }')
     os.symlink('foobar.c', 'foobar.xxx')
-    err = self.expect_fail([EMCC, 'foobar.xxx', '-o', 'foobar.js'])
-    self.assertContained(['unknown file type: foobar.xxx', "archive member 'native.o' is neither Wasm object file nor LLVM bitcode"], err)
+    expected = ['unknown file type: foobar.xxx', "archive member 'native.o' is neither Wasm object file nor LLVM bitcode"]
+    self.assert_fail([EMCC, 'foobar.xxx', '-o', 'foobar.js'], expected)
 
   def test_multiply_defined_libsymbols(self):
     create_file('libA.c', 'int mult() { return 1; }')
@@ -1579,8 +1573,8 @@ int f() {
     self.run_process([CLANG_CC, 'native.c', '-c', '-o', 'native.o'] +
                      clang_native.get_clang_native_args())
     self.run_process([EMAR, 'crs', 'libfoo.a', 'native.o'])
-    stderr = self.expect_fail([EMCC, 'main.c', 'libfoo.a'])
-    self.assertContained(['unknown file type', "libfoo.a: archive member 'native.o' is neither Wasm object file nor LLVM bitcode"], stderr)
+    expected = ['unknown file type', "libfoo.a: archive member 'native.o' is neither Wasm object file nor LLVM bitcode"]
+    self.assert_fail([EMCC, 'main.c', 'libfoo.a'], expected)
 
   def test_export_all(self):
     create_file('main.c', r'''
@@ -1683,23 +1677,23 @@ int f() {
     self.assertContained('libf1\nlibf2\n', self.run_js('main.mjs'))
 
   def test_minimal_runtime_errors(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', 'out.html', '-sMINIMAL_RUNTIME_STREAMING_WASM_COMPILATION'])
-    self.assertContained('emcc: error: MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION requires MINIMAL_RUNTIME', err)
+    expected = 'emcc: error: MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION requires MINIMAL_RUNTIME'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-o', 'out.html', '-sMINIMAL_RUNTIME_STREAMING_WASM_COMPILATION'], expected)
 
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', 'our.html', '-sMINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION'])
-    self.assertContained('emcc: error: MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION requires MINIMAL_RUNTIME', err)
+    expected = 'emcc: error: MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION requires MINIMAL_RUNTIME'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-o', 'our.html', '-sMINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION'], expected)
 
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sMINIMAL_RUNTIME', '-sMINIMAL_RUNTIME_STREAMING_WASM_COMPILATION'])
-    self.assertContained('emcc: error: MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION is only compatible with html output', err)
+    expected = 'emcc: error: MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION is only compatible with html output'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sMINIMAL_RUNTIME', '-sMINIMAL_RUNTIME_STREAMING_WASM_COMPILATION'], expected)
 
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sMINIMAL_RUNTIME', '-sMINIMAL_RUNTIME_STREAMING_WASM_COMPILATION', '-oout.html', '-sSINGLE_FILE'])
-    self.assertContained('emcc: error: MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION is not compatible with SINGLE_FILE', err)
+    expected = 'emcc: error: MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION is not compatible with SINGLE_FILE'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sMINIMAL_RUNTIME', '-sMINIMAL_RUNTIME_STREAMING_WASM_COMPILATION', '-oout.html', '-sSINGLE_FILE'], expected)
 
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sMINIMAL_RUNTIME', '-sMINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION', '-oout.html', '-sSINGLE_FILE'])
-    self.assertContained('emcc: error: MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION is not compatible with SINGLE_FILE', err)
+    expected = 'emcc: error: MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION is not compatible with SINGLE_FILE'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sMINIMAL_RUNTIME', '-sMINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION', '-oout.html', '-sSINGLE_FILE'], expected)
 
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sMINIMAL_RUNTIME', '--preload-file', 'foo'])
-    self.assertContained('emcc: error: MINIMAL_RUNTIME is not compatible with --preload-file', err)
+    expected = 'emcc: error: MINIMAL_RUNTIME is not compatible with --preload-file'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sMINIMAL_RUNTIME', '--preload-file', 'foo'], expected)
 
   def test_export_all_and_exported_functions(self):
     # EXPORT_ALL should not export library functions by default.
@@ -2242,8 +2236,7 @@ Module['postRun'] = () => {
                                           'side.wasm'])
 
   def test_dylink_pthread_warning(self):
-    err = self.expect_fail([EMCC, '-Werror', '-sMAIN_MODULE', '-pthread', test_file('hello_world.c')])
-    self.assertContained('error: dynamic linking + pthreads is experimental', err)
+    self.assert_fail([EMCC, '-Werror', '-sMAIN_MODULE', '-pthread', test_file('hello_world.c')], 'error: dynamic linking + pthreads is experimental')
 
   @node_pthreads
   def test_dylink_pthread_em_asm(self):
@@ -2390,8 +2383,7 @@ Module['postRun'] = () => {
     cmd = [EMCC, 'main.c', '-fPIC', '-sMAIN_MODULE=2', '-sDYLINK_DEBUG', 'libside1.so']
 
     # Unless `.` is added to the library path the libside2.so won't be found.
-    err = self.expect_fail(cmd)
-    self.assertContained('emcc: error: libside1.so: shared library dependency not found in library path: `libside2.so`.', err)
+    self.assert_fail(cmd, 'emcc: error: libside1.so: shared library dependency not found in library path: `libside2.so`.')
 
     # Adding -L. to the library path makes it work.
     self.run_process(cmd + ['-L.'])
@@ -2430,8 +2422,7 @@ Module['postRun'] = () => {
     cmd = [EMCC, 'main.c', '-fPIC', '-sMAIN_MODULE=2', '-sDYLINK_DEBUG', 'libside1.so']
 
     # Unless `.` is added to the library path the libside2.so won't be found.
-    err = self.expect_fail(cmd)
-    self.assertContained('emcc: error: libside1.so: shared library dependency not found in library path: `libside2.so`.', err)
+    self.assert_fail(cmd, 'emcc: error: libside1.so: shared library dependency not found in library path: `libside2.so`.')
 
     # Adding -L. to the library path makes it work.
     self.run_process(cmd + ['-L.', '-Wl,-rpath,$ORIGIN'])
@@ -2482,8 +2473,7 @@ int main() {
         return 0;
       }
     ''')
-    err = self.expect_fail([EMCC, 'main.c'])
-    self.assertContained('SDL.h:1:2: error: "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"', err)
+    self.assert_fail([EMCC, 'main.c'], 'SDL.h:1:2: error: "To use the emscripten port of SDL use -sUSE_SDL or -sUSE_SDL=2"')
     self.run_process([EMCC, 'main.c', '-sUSE_SDL'])
 
   def test_sdl_endianness(self):
@@ -2686,9 +2676,8 @@ F1 -> ''
     # testing dependency
     self.do_runf('other/test_external_ports.c', 'mpg123=45\n', cflags=[f'--use-port={external_port_path}:dependency=mpg123'])
     # testing invalid dependency
-    stderr = self.expect_fail([EMCC, test_file('other/test_external_ports.c'), f'--use-port={external_port_path}:dependency=invalid', '-o', 'a4.out.js'])
+    self.assert_fail([EMCC, test_file('other/test_external_ports.c'), f'--use-port={external_port_path}:dependency=invalid', '-o', 'a4.out.js'], 'unknown dependency `invalid` for port `external`')
     self.assertFalse(os.path.exists('a4.out.js'))
-    self.assertContained('unknown dependency `invalid` for port `external`', stderr)
     # testing help
     stdout = self.run_process([EMCC, test_file('other/test_external_ports.c'), f'--use-port={external_port_path}:help'], stdout=PIPE).stdout
     self.assertContained('''external (--use-port=external; Test License)
@@ -2757,14 +2746,12 @@ More info: https://emscripten.org
 
     # Adding a missing symbol to EXPORTED_FUNCTIONS should cause a link failure
     cmd += ['-sEXPORTED_FUNCTIONS=_foobar']
-    err = self.expect_fail(cmd)
-    self.assertContained('wasm-ld: error: symbol exported via --export not found: foobar', err)
+    self.assert_fail(cmd, 'wasm-ld: error: symbol exported via --export not found: foobar')
 
     # Adding -sERROR_ON_UNDEFINED_SYMBOLS=0 means the error gets reported later
     # by emscripten.py.
     cmd += ['-sERROR_ON_UNDEFINED_SYMBOLS=0']
-    err = self.expect_fail(cmd)
-    self.assertContained('undefined exported symbol: "_foobar"', err)
+    self.assert_fail(cmd, 'undefined exported symbol: "_foobar"')
 
     # setting `-Wno-undefined` should suppress the error
     cmd += ['-Wno-undefined']
@@ -2772,8 +2759,8 @@ More info: https://emscripten.org
 
   def test_undefined_exported_runtime_method(self):
     # Adding a missing symbol to EXPORTED_RUNTIME_METHODS should cause a failure
-    err = self.expect_fail([EMCC, '-sEXPORTED_RUNTIME_METHODS=foobar', test_file('hello_world.c')])
-    self.assertContained('undefined exported symbol: "foobar" in EXPORTED_RUNTIME_METHODS', err)
+    expected = 'undefined exported symbol: "foobar" in EXPORTED_RUNTIME_METHODS'
+    self.assert_fail([EMCC, '-sEXPORTED_RUNTIME_METHODS=foobar', test_file('hello_world.c')], expected)
 
   @parameterized({
     '': ('out.js',),
@@ -2785,8 +2772,7 @@ More info: https://emscripten.org
 
     # adding a missing symbol to EXPORTED_FUNCTIONS should cause failure
     cmd += ['-sEXPORTED_FUNCTIONS=foobar']
-    err = self.expect_fail(cmd)
-    self.assertContained('undefined exported symbol: "foobar"', err)
+    self.assert_fail(cmd, 'undefined exported symbol: "foobar"')
 
     # setting `-Wno-undefined` should suppress the error
     cmd += ['-Wno-undefined']
@@ -2858,8 +2844,7 @@ More info: https://emscripten.org
       return foo;
     }
     ''')
-    output = self.expect_fail([EMCC, 'main.c'])
-    self.assertContained('undefined symbol: foo', output)
+    self.assert_fail([EMCC, 'main.c'], 'undefined symbol: foo')
 
     # With -Wl,--unresolved-symbols=ignore-all or -Wl,--allow-undefined
     # the linker should ignore any undefined data symbols.
@@ -2876,8 +2861,8 @@ More info: https://emscripten.org
   # at link time they should get a helpful error message guiding them to enable
   # the option.
   def test_get_proc_address_error_message(self):
-    err = self.expect_fail([EMCC, '-sGL_ENABLE_GET_PROC_ADDRESS=0', test_file('other/test_GetProcAddress_LEGACY_GL_EMULATION.c')])
-    self.assertContained('error: linker: Undefined symbol: SDL_GL_GetProcAddress(). Please pass -sGL_ENABLE_GET_PROC_ADDRESS at link time to link in SDL_GL_GetProcAddress().', err)
+    expected = 'error: linker: Undefined symbol: SDL_GL_GetProcAddress(). Please pass -sGL_ENABLE_GET_PROC_ADDRESS at link time to link in SDL_GL_GetProcAddress().'
+    self.assert_fail([EMCC, '-sGL_ENABLE_GET_PROC_ADDRESS=0', test_file('other/test_GetProcAddress_LEGACY_GL_EMULATION.c')], expected)
 
   @parameterized({
     '': (False, False),
@@ -3292,8 +3277,7 @@ More info: https://emscripten.org
     self.run_process([path_from_root('emscons'), 'scons', '--expected-env', expected_to_propagate])
 
   def test_embind_fail(self):
-    out = self.expect_fail([EMXX, test_file('embind/test_unsigned.cpp')])
-    self.assertContained("undefined symbol: _embind_register_function", out)
+    self.assert_fail([EMXX, test_file('embind/test_unsigned.cpp')], 'undefined symbol: _embind_register_function')
 
   def test_embind_invalid_overload(self):
     expected = 'BindingError: Cannot register multiple overloads of a function with the same number of arguments'
@@ -3389,8 +3373,7 @@ More info: https://emscripten.org
     'val_new': ['embind/test_embind_no_raw_pointers_val_new.cpp'],
   })
   def test_embind_no_raw_pointers(self, filename):
-    stderr = self.expect_fail([EMCC, '-lembind', test_file(filename)])
-    self.assertContained('Implicitly binding raw pointers is illegal.', stderr)
+    self.assert_fail([EMCC, '-lembind', test_file(filename)], 'Implicitly binding raw pointers is illegal')
 
   @is_slow_test
   @parameterized({
@@ -3459,8 +3442,7 @@ More info: https://emscripten.org
     self.assertContained('#warning "embind is likely moving to c++17', err)
 
   def test_embind_cxx03(self):
-    err = self.expect_fail([EMXX, '-c', '-std=c++03', test_file('embind/test_unsigned.cpp')])
-    self.assertContained('#error "embind requires -std=c++11 or newer"', err)
+    self.assert_fail([EMXX, '-c', '-std=c++03', test_file('embind/test_unsigned.cpp')], '#error "embind requires -std=c++11 or newer"')
 
   @requires_node
   def test_embind_finalization(self):
@@ -3684,12 +3666,11 @@ More info: https://emscripten.org
     self.assertFileContents(test_file('other/embind_tsgen_constant_only.d.ts'), read_file('out.d.ts'))
 
   def test_embind_tsgen_bigint(self):
-    args = [EMXX, test_file('other/embind_tsgen_bigint.cpp'), '-lembind', '--emit-tsd', 'embind_tsgen_bigint.d.ts']
+    cmd = [EMXX, test_file('other/embind_tsgen_bigint.cpp'), '-lembind', '--emit-tsd', 'embind_tsgen_bigint.d.ts']
     # Check that TypeScript generation fails when code contains bigints but their support is not enabled
-    stderr = self.expect_fail(args + ['-sWASM_BIGINT=0'])
-    self.assertContained("Missing primitive type to TS type for 'long long", stderr)
+    self.assert_fail(cmd + ['-sWASM_BIGINT=0'], "Missing primitive type to TS type for 'long long")
     # Check that TypeScript generation works when bigint support is enabled
-    self.run_process(args)
+    self.run_process(cmd)
     self.assertFileContents(test_file('other/embind_tsgen_bigint.d.ts'), read_file('embind_tsgen_bigint.d.ts'))
 
   @parameterized({
@@ -3761,9 +3742,8 @@ More info: https://emscripten.org
     shared.check_call(cmd)
 
   def test_emit_tsd_wasm_only(self):
-    err = self.expect_fail([EMCC, test_file('other/test_emit_tsd.c'),
-                            '--emit-tsd', 'test_emit_tsd_wasm_only.d.ts', '-o', 'out.wasm'])
-    self.assertContained('Wasm only output is not compatible --emit-tsd', err)
+    expected = 'Wasm only output is not compatible --emit-tsd'
+    self.assert_fail([EMCC, test_file('other/test_emit_tsd.c'), '--emit-tsd', 'test_emit_tsd_wasm_only.d.ts', '-o', 'out.wasm'], expected)
 
   def test_emconfig(self):
     output = self.run_process([emconfig, 'LLVM_ROOT'], stdout=PIPE).stdout.strip()
@@ -3774,17 +3754,13 @@ More info: https://emscripten.org
     self.assertEqual(output, os.path.dirname(emconfig))
     invalid = 'Usage: em-config VAR_NAME'
     # Don't accept variables that do not exist
-    output = self.expect_fail([emconfig, 'VAR_WHICH_DOES_NOT_EXIST']).strip()
-    self.assertEqual(output, invalid)
+    self.assert_fail([emconfig, 'VAR_WHICH_DOES_NOT_EXIST'], invalid)
     # Don't accept no arguments
-    output = self.expect_fail([emconfig]).strip()
-    self.assertEqual(output, invalid)
+    self.assert_fail([emconfig], invalid)
     # Don't accept more than one variable
-    output = self.expect_fail([emconfig, 'LLVM_ROOT', 'EMCC']).strip()
-    self.assertEqual(output, invalid)
+    self.assert_fail([emconfig, 'LLVM_ROOT', 'EMCC'], invalid)
     # Don't accept arbitrary python code
-    output = self.expect_fail([emconfig, 'sys.argv[1]']).strip()
-    self.assertEqual(output, invalid)
+    self.assert_fail([emconfig, 'sys.argv[1]'], invalid)
 
   def test_link_s(self):
     # -s OPT=VALUE can conflict with -s as a linker option. We warn and ignore
@@ -3847,8 +3823,7 @@ More info: https://emscripten.org
             self.fail('output contains more then one empty line in row')
 
     # relative path must be within/below the current dir
-    stderr = self.expect_fail([FILE_PACKAGER, 'test.data', '--quiet', '--preload', '../data1.txt'])
-    self.assertContained('which is not contained within the current directory', stderr)
+    self.assert_fail([FILE_PACKAGER, 'test.data', '--quiet', '--preload', '../data1.txt'], 'which is not contained within the current directory')
 
     # relative path that ends up under us is cool
     proc = self.run_process([FILE_PACKAGER, 'test.data', '--quiet', '--preload', '../subdir/data2.txt'], stderr=PIPE, stdout=PIPE)
@@ -3962,13 +3937,11 @@ More info: https://emscripten.org
 
   def test_file_packager_returns_error_if_target_equal_to_jsoutput(self):
     MESSAGE = 'error: TARGET should not be the same value of --js-output'
-    err = self.expect_fail([FILE_PACKAGER, 'test.data', '--js-output=test.data'])
-    self.assertContained(MESSAGE, err)
+    self.assert_fail([FILE_PACKAGER, 'test.data', '--js-output=test.data'], MESSAGE)
 
   def test_file_packager_returns_error_if_emcc_and_export_es6(self):
     MESSAGE = 'error: Can\'t use --export-es6 option together with --from-emcc since the code should be embedded within emcc\'s code'
-    err = self.expect_fail([FILE_PACKAGER, 'test.data', '--export-es6', '--from-emcc'])
-    self.assertContained(MESSAGE, err)
+    self.assert_fail([FILE_PACKAGER, 'test.data', '--export-es6', '--from-emcc'], MESSAGE)
 
   def test_file_packager_embed(self):
     create_file('data.txt', 'hello data')
@@ -4106,8 +4079,7 @@ More info: https://emscripten.org
 
   def test_syntax_only_invalid(self):
     create_file('src.c', 'int main() {')
-    err = self.expect_fail([EMCC, 'src.c', '-fsyntax-only'])
-    self.assertContained("src.c:1:13: error: expected '}'", err)
+    self.assert_fail([EMCC, 'src.c', '-fsyntax-only'], "src.c:1:13: error: expected '}'")
     self.assertNotExists('a.out.js')
 
   # `demangle` is a legacy JS function on longer used by emscripten
@@ -4517,8 +4489,7 @@ printErr('CWD: ' + process.cwd());
 
   def test_output_is_dir(self):
     ensure_dir('out_dir')
-    err = self.expect_fail([EMCC, '-c', test_file('hello_world.c'), '-o', 'out_dir/'])
-    self.assertContained('error: unable to open output file', err)
+    self.assert_fail([EMCC, '-c', test_file('hello_world.c'), '-o', 'out_dir/'], 'error: unable to open output file')
 
   def test_doublestart_bug(self):
     create_file('code.c', r'''
@@ -4915,8 +4886,8 @@ Waste<3> *getMore() {
     # native building on CI may not always work well
     create_file('minimal.c', 'int main() { return 0; }')
     self.run_process([CLANG_CC, 'minimal.c', '-target', 'x86_64-linux', '-c', '-emit-llvm', '-o', 'a.bc'] + clang_native.get_clang_native_args(), env=clang_native.get_clang_native_env())
-    err = self.expect_fail([EMCC, '-Werror', 'a.bc'])
-    self.assertContained('error: overriding the module target triple with wasm32-unknown-emscripten [-Werror,-Woverride-module]', err)
+    expected = 'error: overriding the module target triple with wasm32-unknown-emscripten [-Werror,-Woverride-module]'
+    self.assert_fail([EMCC, '-Werror', 'a.bc'], expected)
 
   def test_valid_abspath(self):
     # Test whether abspath warning appears
@@ -5594,8 +5565,7 @@ __EMSCRIPTEN_major__ __EMSCRIPTEN_minor__ __EMSCRIPTEN_tiny__ EMSCRIPTEN_KEEPALI
     cmd = [EMXX, test_file('hello_libcxx.cpp')]
     with env_modify(env):
       if fail:
-        err = self.expect_fail(cmd)
-        self.assertContained('undefined symbol: emscripten_builtin_memalign', err)
+        self.assert_fail(cmd, 'undefined symbol: emscripten_builtin_memalign')
       else:
         err = self.run_process(cmd, stderr=PIPE).stderr
         if 'EMCC_ONLY_FORCED_STDLIBS' in env:
@@ -6245,8 +6215,8 @@ m();
     self.assertContained('hello, world!\n', output)
 
   def test_EXPORT_NAME_with_html(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', 'a.html', '-sEXPORT_NAME=Other'])
-    self.assertContained('error: customizing EXPORT_NAME requires that the HTML be customized to use that name', err)
+    expected = 'error: customizing EXPORT_NAME requires that the HTML be customized to use that name'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-o', 'a.html', '-sEXPORT_NAME=Other'], expected)
 
   def test_modularize_sync_compilation(self):
     # Verify that, even when WASM_ASYNC_COMPILATION is disabled, the module factory
@@ -7277,10 +7247,10 @@ int main() {
 
     # Same again but with `_alGet` wich does not exist.  This is a regression
     # test for a bug we had where any prefix of a valid function was accepted.
-    err = self.expect_fail([EMCC, test_file('hello_world.c'),
-                            '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=alGetError',
-                            '-sEXPORTED_FUNCTIONS=_main,_alGet'])
-    self.assertContained('wasm-ld: error: symbol exported via --export not found: alGet', err)
+    self.assert_fail([EMCC, test_file('hello_world.c'),
+                     '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=alGetError',
+                     '-sEXPORTED_FUNCTIONS=_main,_alGet'],
+                     'wasm-ld: error: symbol exported via --export not found: alGet')
 
   def test_musl_syscalls(self):
     self.run_process([EMCC, test_file('hello_world.c')])
@@ -7345,12 +7315,10 @@ addToLibrary({
   }()),
 });
 ''')
-    err = self.expect_fail([EMCC, 'test.c', '--js-library', 'library_foo_missing.js'])
-    self.assertContained('undefined symbol: nonexistingvariable. Required by my_js', err)
+    self.assert_fail([EMCC, 'test.c', '--js-library', 'library_foo_missing.js'], 'undefined symbol: nonexistingvariable. Required by my_js')
 
     # and also for missing C code, of course (without the --js-library, it's just a missing C method)
-    err = self.expect_fail([EMCC, 'test.c'])
-    self.assertContained('undefined symbol: my_js', err)
+    self.assert_fail([EMCC, 'test.c'], 'undefined symbol: my_js')
 
   @crossplatform
   @also_with_wasmfs
@@ -7424,8 +7392,7 @@ addToLibrary({
   def test_emmalloc_2GB(self):
     def test(args, text=None):
       if text:
-        stderr = self.expect_fail([EMCC, test_file('hello_world.c'), '-sMALLOC=emmalloc'] + args)
-        self.assertContained(text, stderr)
+        self.assert_fail([EMCC, test_file('hello_world.c'), '-sMALLOC=emmalloc'] + args, text)
       else:
         self.run_process([EMCC, test_file('hello_world.c'), '-sMALLOC=emmalloc'] + args)
 
@@ -7550,8 +7517,8 @@ high = 1234
     self.run_process([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS=@response_file.txt'])
 
   def test_dash_s_response_file_misssing(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS=@foo'])
-    self.assertContained('error: foo: file not found parsing argument: EXPORTED_FUNCTIONS=@foo', err)
+    expected = 'error: foo: file not found parsing argument: EXPORTED_FUNCTIONS=@foo'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS=@foo'], expected)
 
   def test_dash_s_unclosed_quote(self):
     # Unclosed quote
@@ -7579,10 +7546,10 @@ high = 1234
     self.assertNotContained('error parsing "-s" setting', err)
 
   def test_dash_s_wrong_type(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-sEXIT_RUNTIME=[foo,bar]'])
-    self.assertContained('error: setting `EXIT_RUNTIME` expects `bool` but got `list`', err)
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-sEXIT_RUNTIME=true'])
-    self.assertContained('error: attempt to set `EXIT_RUNTIME` to `true`; use 1/0 to set boolean setting', err)
+    expected = 'error: setting `EXIT_RUNTIME` expects `bool` but got `list`'
+    self.assert_fail([EMCC, test_file('hello_world.cpp'), '-sEXIT_RUNTIME=[foo,bar]'], expected)
+    expected = 'error: attempt to set `EXIT_RUNTIME` to `true`; use 1/0 to set boolean setting'
+    self.assert_fail([EMCC, test_file('hello_world.cpp'), '-sEXIT_RUNTIME=true'], expected)
 
   def test_dash_s_typo(self):
     # with suggestions
@@ -7600,8 +7567,7 @@ high = 1234
 
   def test_dash_s_with_space(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-s', 'EXPORT_ALL'])
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-s', 'EXPORTED_FUNCTIONS=foo'])
-    self.assertContained('error: undefined exported symbol: "foo"', err)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-s', 'EXPORTED_FUNCTIONS=foo'], 'error: undefined exported symbol: "foo"')
 
   def test_dash_s_hex(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-nostdlib', '-sERROR_ON_UNDEFINED_SYMBOLS=0'])
@@ -7610,12 +7576,12 @@ high = 1234
 
   def test_dash_s_bad_json_types(self):
     # Dict rather than string/list
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS={"a":1}'])
-    self.assertContained("settings must be strings or lists (not $<class 'dict'>", err)
+    expected = "settings must be strings or lists (not $<class 'dict'>"
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS={"a":1}'], expected)
 
     # List element is not a string
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS=[{"a":1}]'])
-    self.assertContained("list members in settings must be strings (not $<class 'dict'>)", err)
+    expected = "list members in settings must be strings (not $<class 'dict'>)"
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sEXPORTED_FUNCTIONS=[{"a":1}]'], expected)
 
   def test_zeroinit(self):
     create_file('src.c', r'''
@@ -8011,8 +7977,7 @@ int main() {
     self.run_process([EMXX, '-Wall', '-x', 'c++', 'src_tmp_fixed_lang'])
     self.assertContained('Test_source_fixed_lang_hello', self.run_js('a.out.js'))
 
-    stderr = self.expect_fail([EMXX, '-Wall', 'src_tmp_fixed_lang'])
-    self.assertContained('unknown file type: src_tmp_fixed_lang', stderr)
+    self.assert_fail([EMXX, '-Wall', 'src_tmp_fixed_lang'], 'unknown file type: src_tmp_fixed_lang')
 
   def test_disable_inlining(self):
     create_file('test.c', r'''
@@ -8089,8 +8054,7 @@ int main() {
     cmd = [EMCC, test_file('hello_world.c'), '-v'] + args
 
     if expected_initial_heap is None:
-      out = self.expect_fail(cmd)
-      self.assertContained('wasm-ld: error:', out)
+      self.assert_fail(cmd, 'wasm-ld: error:')
       return
 
     out = self.run_process(cmd, stderr=PIPE)
@@ -8128,36 +8092,34 @@ int main() {
     self.assertContained('hello, world!', self.run_js('a.out.js'))
 
     # Must be a multiple of 64KB
-    ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-sINITIAL_HEAP=32505857', '-sALLOW_MEMORY_GROWTH']) # 31MB + 1 byte
-    self.assertContained('INITIAL_HEAP must be a multiple of WebAssembly page size (64KiB)', ret)
+    expected = 'INITIAL_HEAP must be a multiple of WebAssembly page size (64KiB)'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sINITIAL_HEAP=32505857', '-sALLOW_MEMORY_GROWTH'], expected) # 31MB + 1 byte
 
-    ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-sINITIAL_MEMORY=33554433']) # 32MB + 1 byte
-    self.assertContained('INITIAL_MEMORY must be a multiple of WebAssembly page size (64KiB)', ret)
+    expected = 'INITIAL_MEMORY must be a multiple of WebAssembly page size (64KiB)'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sINITIAL_MEMORY=33554433'], expected) # 32MB + 1 byte
 
     self.run_process([EMCC, test_file('hello_world.c'), '-sMAXIMUM_MEMORY=33MB', '-sALLOW_MEMORY_GROWTH'])
 
-    ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-sMAXIMUM_MEMORY=34603009', '-sALLOW_MEMORY_GROWTH']) # 33MB + 1 byte
-    self.assertContained('MAXIMUM_MEMORY must be a multiple of WebAssembly page size (64KiB)', ret)
+    expected = 'MAXIMUM_MEMORY must be a multiple of WebAssembly page size (64KiB)'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sMAXIMUM_MEMORY=34603009', '-sALLOW_MEMORY_GROWTH'], expected) # 33MB + 1 byte
 
   def test_invalid_memory_max(self):
-    err = self.expect_fail([EMCC, '-Werror', test_file('hello_world.c'), '-sMAXIMUM_MEMORY=41943040'])
-    self.assertContained('emcc: error: MAXIMUM_MEMORY is only meaningful with ALLOW_MEMORY_GROWTH', err)
+    expected = 'emcc: error: MAXIMUM_MEMORY is only meaningful with ALLOW_MEMORY_GROWTH'
+    self.assert_fail([EMCC, '-Werror', test_file('hello_world.c'), '-sMAXIMUM_MEMORY=41943040'], expected)
 
   def test_dasho_invalid_dir(self):
-    ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', 'NONEXISTING_DIRECTORY/out.js'])
-    self.assertContained('specified output file (NONEXISTING_DIRECTORY/out.js) is in a directory that does not exist', ret)
+    expected = 'specified output file (NONEXISTING_DIRECTORY/out.js) is in a directory that does not exist'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-o', 'NONEXISTING_DIRECTORY/out.js'], expected)
 
   def test_dasho_is_dir(self):
-    ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', '.'])
-    self.assertContained('emcc: error: cannot write output file `.`: Is a directory', ret)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-o', '.'], 'emcc: error: cannot write output file `.`: Is a directory')
 
     ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', '.', '--oformat=wasm'])
     self.assertContained('wasm-ld: error: cannot open output file .:', ret)
     # Linux/Mac and Windows's error messages are slightly different
     self.assertContained(['Is a directory', 'is a directory'], ret)
 
-    ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', '.', '--oformat=html'])
-    self.assertContained('emcc: error: cannot write output file `.`: Is a directory', ret)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-o', '.', '--oformat=html'], 'emcc: error: cannot write output file `.`: Is a directory')
 
   @parameterized({
     '': ([],),
@@ -8391,8 +8353,8 @@ int main() {
     self.run_process([EMCC, test_file('hello_world.c'), '-sSIDE_MODULE', '-o', 'libside2.wasm', 'libside1.wasm'])
     # When linking against `libside2.wasm` (which depends on libside1.wasm) that library path is used
     # to locate `libside1.wasm`.  Expect the link to fail with an unmodified library path.
-    err = self.expect_fail([EMCC, '-sMAIN_MODULE=2', test_file('hello_world.c'), 'libside2.wasm'])
-    self.assertContained('libside2.wasm: shared library dependency not found in library path: `libside1.wasm`', err)
+    expected = 'libside2.wasm: shared library dependency not found in library path: `libside1.wasm`'
+    self.assert_fail([EMCC, '-sMAIN_MODULE=2', test_file('hello_world.c'), 'libside2.wasm'], expected)
 
     # But succeed if `.` is added the library path.
     self.run_process([EMCC, '-sMAIN_MODULE=2', test_file('hello_world.c'), '-L.', 'libside2.wasm'])
@@ -8407,8 +8369,7 @@ int main() {
     final_link = [EMCC, '-sMAIN_MODULE=2', test_file('hello_world.c'), '-L.', 'libside3.wasm']
     self.run_process(final_link)
     os.remove('libside1.wasm')
-    err = self.expect_fail(final_link)
-    self.assertContained('error: libside2.wasm: shared library dependency not found in library path: `libside1.wasm`', err)
+    self.assert_fail(final_link, 'error: libside2.wasm: shared library dependency not found in library path: `libside1.wasm`')
 
   def test_side_module_folder_deps(self):
     # Build side modules in a subfolder
@@ -8515,8 +8476,7 @@ int main() {
   def test_exceptions_c_linker(self):
     # Test that we don't try to create __cxa_find_matching_catch_xx function automatically
     # when not linking as C++.
-    stderr = self.expect_fail([EMCC, '-sSTRICT', test_file('other/test_exceptions_c_linker.c')])
-    self.assertContained('error: undefined symbol: __cxa_find_matching_catch_1', stderr)
+    self.assert_fail([EMCC, '-sSTRICT', test_file('other/test_exceptions_c_linker.c')], 'error: undefined symbol: __cxa_find_matching_catch_1')
 
   @with_all_eh_sjlj
   def test_exceptions_stack_trace_and_message(self):
@@ -8584,8 +8544,7 @@ int main() {
     self.set_setting('ASSERTIONS', 1)
     self.set_setting('EXCEPTION_STACK_TRACES', 0)
     create_file('src.cpp', src)
-    err = self.expect_fail([EMCC, 'src.cpp'] + self.get_cflags())
-    self.assertContained('error: EXCEPTION_STACK_TRACES cannot be disabled when ASSERTIONS are enabled', err)
+    self.assert_fail([EMCC, 'src.cpp'] + self.get_cflags(), 'error: EXCEPTION_STACK_TRACES cannot be disabled when ASSERTIONS are enabled')
 
     # Doesn't print stack traces
     self.set_setting('ASSERTIONS', 0)
@@ -8744,14 +8703,12 @@ int main() {
 
   def test_error_on_missing_libraries(self):
     # -llsomenonexistingfile is an error by default
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-lsomenonexistingfile'])
-    self.assertContained('wasm-ld: error: unable to find library -lsomenonexistingfile', err)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-lsomenonexistingfile'], 'wasm-ld: error: unable to find library -lsomenonexistingfile')
 
   # Tests that if user accidentally attempts to link native object code, we show an error
   def test_native_link_error_message(self):
     self.run_process([CLANG_CC, '--target=' + clang_native.get_native_triple(), '-c', test_file('hello_123.c'), '-o', 'hello_123.o'])
-    err = self.expect_fail([EMCC, 'hello_123.o', '-o', 'hello_123.js'])
-    self.assertContained('unknown file type: hello_123.o', err)
+    self.assert_fail([EMCC, 'hello_123.o', '-o', 'hello_123.js'], 'unknown file type: hello_123.o')
 
   # Tests that we should give a clear error on INITIAL_MEMORY not being enough for static initialization + stack
   def test_clear_error_on_massive_static_data(self):
@@ -8761,8 +8718,7 @@ int main() {
           return (int)(long)&muchData;
         }
     ''')
-    err = self.expect_fail([EMCC, 'src.c', '-sSTACK_SIZE=1KB', '-sINITIAL_MEMORY=64KB'])
-    self.assertContained('wasm-ld: error: initial memory too small', err)
+    self.assert_fail([EMCC, 'src.c', '-sSTACK_SIZE=1KB', '-sINITIAL_MEMORY=64KB'], 'wasm-ld: error: initial memory too small')
 
   def test_o_level_clamp(self):
     for level in (3, 4, 20):
@@ -8771,20 +8727,15 @@ int main() {
 
   def test_o_level_invalid(self):
     # Test that string values, and negative integers are not accepted
-    err = self.expect_fail([EMCC, '-Ofoo', test_file('hello_world.c')])
-    self.assertContained('emcc: error: invalid optimization level: -Ofoo', err)
-    err = self.expect_fail([EMCC, '-O-10', test_file('hello_world.c')])
-    self.assertContained('emcc: error: invalid optimization level: -O-10', err)
+    self.assert_fail([EMCC, '-Ofoo', test_file('hello_world.c')], 'emcc: error: invalid optimization level: -Ofoo')
+    self.assert_fail([EMCC, '-O-10', test_file('hello_world.c')], 'emcc: error: invalid optimization level: -O-10')
 
   def test_g_level_invalid(self):
     # Bad integer values are handled by emcc
-    err = self.expect_fail([EMCC, '-g5', test_file('hello_world.c')])
-    self.assertContained('emcc: error: invalid debug level: -g5', err)
-    err = self.expect_fail([EMCC, '-g-10', test_file('hello_world.c')])
-    self.assertContained('emcc: error: invalid debug level: -g-10', err)
+    self.assert_fail([EMCC, '-g5', test_file('hello_world.c')], 'emcc: error: invalid debug level: -g5')
+    self.assert_fail([EMCC, '-g-10', test_file('hello_world.c')], 'emcc: error: invalid debug level: -g-10')
     # Unknown string values are passed through to clang which will error out
-    err = self.expect_fail([EMCC, '-gfoo', test_file('hello_world.c')])
-    self.assertContained("error: unknown argument: '-gfoo'", err)
+    self.assert_fail([EMCC, '-gfoo', test_file('hello_world.c')], "error: unknown argument: '-gfoo'")
 
   # Tests that if user specifies multiple -o output directives, then the last one will take precedence
   def test_multiple_o_files(self):
@@ -9056,8 +9007,7 @@ end
 
   def test_full_js_library_undefined(self):
     create_file('main.c', 'void foo(); int main() { foo(); return 0; }')
-    err = self.expect_fail([EMCC, 'main.c', '-sSTRICT_JS', '-sINCLUDE_FULL_LIBRARY'])
-    self.assertContained('undefined symbol: foo', err)
+    self.assert_fail([EMCC, 'main.c', '-sSTRICT_JS', '-sINCLUDE_FULL_LIBRARY'], 'undefined symbol: foo')
 
   def test_full_js_library_except(self):
     self.set_setting('INCLUDE_FULL_LIBRARY', 1)
@@ -9235,8 +9185,7 @@ end
   def test_toolchain_profiler(self):
     # Verify some basic functionality of EMPROFILE
     self.run_process([emprofile, '--reset'])
-    err = self.expect_fail([emprofile, '--graph'])
-    self.assertContained('No profiler logs were found', err)
+    self.assert_fail([emprofile, '--graph'], 'No profiler logs were found')
 
     self.run_process([EMCC, test_file('hello_world.c')])
     self.assertEqual('hello, world!', self.run_js('a.out.js').strip())
@@ -9266,10 +9215,8 @@ end
     expected = '--preload-file and --embed-file cannot be used with NODERAWFS which disables virtual filesystem'
     base = [EMCC, test_file('hello_world.c'), '-sNODERAWFS']
     create_file('somefile', 'foo')
-    err = self.expect_fail(base + ['--preload-file', 'somefile'])
-    self.assertContained(expected, err)
-    err = self.expect_fail(base + ['--embed-file', 'somefile'])
-    self.assertContained(expected, err)
+    self.assert_fail(base + ['--preload-file', 'somefile'], expected)
+    self.assert_fail(base + ['--embed-file', 'somefile'], expected)
 
   def test_noderawfs_access_abspath(self):
     create_file('foo', 'bar')
@@ -9384,10 +9331,10 @@ int main() {
   js();
 }
 ''')
-    stderr = self.expect_fail([EMCC, 'src.c', '-O2'] + self.get_cflags())
-    self.assertContained(('''
+    expected = ('''
 function js() { var x = !<->5.; }
-                         ^ '''), stderr)
+                         ^ ''')
+    self.assert_fail([EMCC, 'src.c', '-O2'] + self.get_cflags(), expected)
 
   @crossplatform
   def test_js_optimizer_chunk_size_determinism(self):
@@ -9896,8 +9843,7 @@ int main() {
     self.assertExists('with_dwarf.wasm')
     # the correct notation is to have exactly one '=' and in the right place
     for invalid in ('-gseparate-dwarf=x=', '-gseparate-dwarfy=', '-gseparate-dwarf-hmm'):
-      stderr = self.expect_fail([EMCC, test_file('hello_world.c'), invalid])
-      self.assertContained('invalid -gseparate-dwarf=FILENAME notation', stderr)
+      self.assert_fail([EMCC, test_file('hello_world.c'), invalid], 'invalid -gseparate-dwarf=FILENAME notation')
 
     # building to a subdirectory, but with the debug file in another place,
     # should leave a relative path to the debug wasm
@@ -10141,8 +10087,8 @@ T6:(else) !ASSERTIONS""", output)
       #error this is an error
       {{{ SCRIPT }}}
     ''')
-    err = self.expect_fail([EMCC, '-o', 'out.html', test_file('hello_world.c'), '--shell-file=shell.html'])
-    self.assertContained('error: shell.html:2: #error this is an error', err)
+    expected = 'error: shell.html:2: #error this is an error'
+    self.assert_fail([EMCC, '-o', 'out.html', test_file('hello_world.c'), '--shell-file=shell.html'], expected)
 
   @no_windows('node system() does not seem to work, see https://github.com/emscripten-core/emscripten/pull/10547')
   @requires_node
@@ -10674,8 +10620,8 @@ int main () {
 
   # Test that legacy settings that have been fixed to a specific value and their value can no longer be changed,
   def test_legacy_settings_forbidden_to_change(self):
-    stderr = self.expect_fail([EMCC, '-sMEMFS_APPEND_TO_TYPED_ARRAYS=0', test_file('hello_world.c')])
-    self.assertContained('emcc: error: invalid command line setting `-sMEMFS_APPEND_TO_TYPED_ARRAYS=0`: Starting from Emscripten 1.38.26, MEMFS_APPEND_TO_TYPED_ARRAYS=0 is no longer supported', stderr)
+    expected = 'emcc: error: invalid command line setting `-sMEMFS_APPEND_TO_TYPED_ARRAYS=0`: Starting from Emscripten 1.38.26, MEMFS_APPEND_TO_TYPED_ARRAYS=0 is no longer supported'
+    self.assert_fail([EMCC, '-sMEMFS_APPEND_TO_TYPED_ARRAYS=0', test_file('hello_world.c')], expected)
 
     self.run_process([EMCC, '-sMEMFS_APPEND_TO_TYPED_ARRAYS', test_file('hello_world.c')])
     self.run_process([EMCC, '-sPRECISE_I64_MATH=2', test_file('hello_world.c')])
@@ -10728,12 +10674,10 @@ int main () {
     cmd = [EMCC, test_file('hello_world.c'), '-sSPLIT_MEMORY=0']
     self.run_process(cmd)
 
-    stderr = self.expect_fail(cmd + ['-sSTRICT'])
-    self.assertContained('legacy setting used in strict mode: SPLIT_MEMORY', stderr)
+    self.assert_fail(cmd + ['-sSTRICT'], 'legacy setting used in strict mode: SPLIT_MEMORY')
 
     with env_modify({'EMCC_STRICT': '1'}):
-      stderr = self.expect_fail(cmd)
-      self.assertContained('legacy setting used in strict mode: SPLIT_MEMORY', stderr)
+      self.assert_fail(cmd, 'legacy setting used in strict mode: SPLIT_MEMORY')
 
   def test_strict_mode_legacy_settings_runtime(self):
     # Verify that legacy settings are not accessible at runtime under strict
@@ -10790,15 +10734,14 @@ int main () {
 ''')
     cmd = [EMCC, test_file('hello_world.c'), '-o', 'out.js', '--js-library', 'lib.js']
     self.run_process(cmd)
-    self.assertContained('ReferenceError: SPLIT_MEMORY is not defined', self.expect_fail(cmd + ['-sSTRICT']))
+    self.assert_fail(cmd + ['-sSTRICT'], 'ReferenceError: SPLIT_MEMORY is not defined')
     with env_modify({'EMCC_STRICT': '1'}):
-      self.assertContained('ReferenceError: SPLIT_MEMORY is not defined', self.expect_fail(cmd))
+      self.assert_fail(cmd, 'ReferenceError: SPLIT_MEMORY is not defined')
 
   def test_strict_mode_link_cxx(self):
     # In strict mode C++ programs fail to link unless run with `em++`.
     self.run_process([EMXX, '-sSTRICT', test_file('hello_libcxx.cpp')])
-    err = self.expect_fail([EMCC, '-sSTRICT', test_file('hello_libcxx.cpp')])
-    self.assertContained('undefined symbol: std::__2::cout', err)
+    self.assert_fail([EMCC, '-sSTRICT', test_file('hello_libcxx.cpp')], 'undefined symbol: std::__2::cout')
 
   def test_strict_mode_override(self):
     create_file('empty.c', '')
@@ -10881,8 +10824,7 @@ int main(void) {
 
   # Tests that passing -sMALLOC=none will not include system malloc() to the build.
   def test_malloc_none(self):
-    stderr = self.expect_fail([EMCC, test_file('malloc_none.c'), '-sMALLOC=none'])
-    self.assertContained('undefined symbol: malloc', stderr)
+    self.assert_fail([EMCC, test_file('malloc_none.c'), '-sMALLOC=none'], 'undefined symbol: malloc')
 
   @parameterized({
     'c': ['c', []],
@@ -11122,8 +11064,8 @@ int main(void) {
     self.do_runf('hello_world.c', 'Aborted(`Module.onRuntimeInitialized` was supplied but `onRuntimeInitialized` not included in INCOMING_MODULE_JS_API)', assert_returncode=NON_ZERO)
 
   def test_INCOMING_MODULE_JS_API_invalid(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sINCOMING_MODULE_JS_API=foo', '-Werror'])
-    self.assertContained('emcc: error: invalid entry in INCOMING_MODULE_JS_API: foo [-Wunused-command-line-argument] [-Werror]', err)
+    expected = 'emcc: error: invalid entry in INCOMING_MODULE_JS_API: foo [-Wunused-command-line-argument] [-Werror]'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sINCOMING_MODULE_JS_API=foo', '-Werror'], expected)
 
   def test_llvm_includes(self):
     create_file('atomics.c', '#include <stdatomic.h>')
@@ -11189,9 +11131,9 @@ int main(void) {
       cmd = [EMXX, test_file('other/exceptions_modes_symbols_defined.cpp'), '-sDISABLE_EXCEPTION_THROWING=%d' % (1 - throwing), '-sDISABLE_EXCEPTION_CATCHING=%d' % (1 - catching), '-O%d' % opts]
       print(cmd)
       if not throwing and not catching:
-        self.assertContained('DISABLE_EXCEPTION_THROWING was set (likely due to -fno-exceptions), which means no C++ exception throwing support code is linked in, but such support is required', self.expect_fail(cmd))
+        self.assert_fail(cmd, 'DISABLE_EXCEPTION_THROWING was set (likely due to -fno-exceptions), which means no C++ exception throwing support code is linked in, but such support is required')
       elif not throwing and catching:
-        self.assertContained('DISABLE_EXCEPTION_THROWING was set (probably from -fno-exceptions) but is not compatible with enabling exception catching (DISABLE_EXCEPTION_CATCHING=0)', self.expect_fail(cmd))
+        self.assert_fail(cmd, 'DISABLE_EXCEPTION_THROWING was set (probably from -fno-exceptions) but is not compatible with enabling exception catching (DISABLE_EXCEPTION_CATCHING=0)')
       else:
         self.run_process(cmd)
 
@@ -11347,8 +11289,7 @@ int main(void) {
         EM_ASM({ out('Hello, world!'); });
       }
     ''')
-    err = self.expect_fail([EMCC, '-std=c11', 'src.c'])
-    self.assertIn('EM_ASM does not work in -std=c* modes, use -std=gnu* modes instead', err)
+    self.assert_fail([EMCC, '-std=c11', 'src.c'], 'EM_ASM does not work in -std=c* modes, use -std=gnu* modes instead')
 
   def test_em_asm_invalid(self):
     # Test that invalid EM_ASM in side modules since is detected at build time.
@@ -11439,19 +11380,15 @@ int main(void) {
   def test_supported_linker_flag_skip_next(self):
     # Regression test for a bug where skipping an unsupported linker flag
     # could skip the next unrelated linker flag.
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Wl,-version-script,foo', '-lbar'])
-    self.assertContained('error: unable to find library -lbar', err)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-Wl,-version-script,foo', '-lbar'], 'error: unable to find library -lbar')
 
   def test_linker_flags_pass_through(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Wl,--waka'])
-    self.assertContained('wasm-ld: error: unknown argument: --waka', err)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-Wl,--waka'], 'wasm-ld: error: unknown argument: --waka')
 
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Xlinker', '--waka'])
-    self.assertContained('wasm-ld: error: unknown argument: --waka', err)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-Xlinker', '--waka'], 'wasm-ld: error: unknown argument: --waka')
 
     # Explicitly check that emcc doesn't try to process passthrough args
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Xlinker', '--post-link'])
-    self.assertContained('wasm-ld: error: unknown argument: --post-link', err)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-Xlinker', '--post-link'], 'wasm-ld: error: unknown argument: --post-link')
 
     err = self.run_process([EMCC, test_file('hello_world.c'), '-z', 'foo'], stderr=PIPE).stderr
     self.assertContained('wasm-ld: warning: unknown -z value: foo', err)
@@ -11479,8 +11416,7 @@ int main(void) {
     self.run_process(cmd + ['-ubaz', 'libtest.a'])
 
     # But adding `-ufoo` should fail because it loads foo, which depends on bar
-    err = self.expect_fail(cmd + ['-ufoo', 'libtest.a'])
-    self.assertContained('wasm-ld: error: libtest.a(test.o): undefined symbol: bar', err)
+    self.assert_fail(cmd + ['-ufoo', 'libtest.a'], 'wasm-ld: error: libtest.a(test.o): undefined symbol: bar')
 
   def test_linker_flags_unused(self):
     err = self.run_process([EMCC, test_file('hello_world.c'), '-c', '-lbar'], stderr=PIPE).stderr
@@ -11493,8 +11429,7 @@ int main(void) {
     self.assertNotContained("input unused", err)
 
   def test_linker_flags_missing(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Xlinker'])
-    self.assertContained("emcc: error: option '-Xlinker' requires an argument", err)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-Xlinker'], "emcc: error: option '-Xlinker' requires an argument")
 
   def test_linker_input_unused(self):
     self.run_process([EMCC, '-c', test_file('hello_world.c')])
@@ -11539,16 +11474,16 @@ int main(void) {
     self.assertNotContained('warning', stderr)
 
     # with -Werror should fail
-    stderr = self.expect_fail(cmd + ['-Werror'])
-    self.assertContained('error: --llvm-opts is deprecated.  All non-emcc args are passed through to clang. [-Wdeprecated] [-Werror]', stderr)
+    expected = 'error: --llvm-opts is deprecated.  All non-emcc args are passed through to clang. [-Wdeprecated] [-Werror]'
+    self.assert_fail(cmd + ['-Werror'], expected)
 
     # with -Werror + -Wno-error=<type> should only warn
     stderr = self.run_process(cmd + ['-Werror', '-Wno-error=deprecated'], stderr=PIPE).stderr
     self.assertContained('emcc: warning: --llvm-opts is deprecated.  All non-emcc args are passed through to clang. [-Wdeprecated]', stderr)
 
     # check that `-Werror=foo` also enales foo
-    stderr = self.expect_fail(cmd + ['-Werror=legacy-settings', '-sTOTAL_MEMORY'])
-    self.assertContained('error: use of legacy setting: TOTAL_MEMORY (setting renamed to INITIAL_MEMORY) [-Wlegacy-settings] [-Werror]', stderr)
+    expected = 'error: use of legacy setting: TOTAL_MEMORY (setting renamed to INITIAL_MEMORY) [-Wlegacy-settings] [-Werror]'
+    self.assert_fail(cmd + ['-Werror=legacy-settings', '-sTOTAL_MEMORY'], expected)
 
     # check that `-Wno-pthreads-mem` disables pthread + ALLOW_GROWTH_MEMORY warning
     stderr = self.run_process(cmd + ['-Wno-pthreads-mem-growth', '-pthread', '-sALLOW_MEMORY_GROWTH'], stderr=PIPE).stderr
@@ -11648,8 +11583,8 @@ int main(void) {
   def test_stdin_compile_only(self):
     # Should fail without -x lang specifier
     src = read_file(test_file('hello_world.cpp'))
-    err = self.expect_fail([EMCC, '-c', '-'], input=src)
-    self.assertContained('error: -E or -x required when input is from standard input', err)
+    expected = 'error: -E or -x required when input is from standard input'
+    self.assert_fail([EMCC, '-c', '-'], expected, input=src)
 
     self.run_process([EMCC, '-c', '-o', 'out.o', '-x', 'c++', '-'], input=src)
     self.assertExists('out.o')
@@ -11665,12 +11600,10 @@ int main(void) {
   def test_stdout_link(self):
     # linking to stdout `-` doesn't work, we have no way to pass such an output filename
     # through post-link tools such as binaryen.
-    err = self.expect_fail([EMCC, '-o', '-', test_file('hello_world.c')])
-    self.assertContained('invalid output filename: `-`', err)
+    self.assert_fail([EMCC, '-o', '-', test_file('hello_world.c')], 'invalid output filename: `-`')
     self.assertNotExists('-')
 
-    err = self.expect_fail([EMCC, '-o', '-foo', test_file('hello_world.c')])
-    self.assertContained('invalid output filename: `-foo`', err)
+    self.assert_fail([EMCC, '-o', '-foo', test_file('hello_world.c')], 'invalid output filename: `-foo`')
     self.assertNotExists('-foo')
 
   def test_immutable_after_link(self):
@@ -11822,12 +11755,10 @@ int main(void) {
     self.assertContained("clang: error: (unsupported option|unknown argument:) '--minifyXX'", err, regex=True)
 
   def test_argument_missing(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '--minify'])
-    self.assertContained("error: option '--minify' requires an argument", err)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '--minify'], "error: option '--minify' requires an argument")
 
   def test_argument_missing_file(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '--pre-js', 'foo.js'])
-    self.assertContained("emcc: error: '--pre-js': file not found: 'foo.js'", err)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '--pre-js', 'foo.js'], "emcc: error: '--pre-js': file not found: 'foo.js'")
 
   def test_default_to_cxx(self):
     create_file('foo.h', '#include <string.h>')
@@ -11837,8 +11768,7 @@ int main(void) {
     self.run_process([EMXX, '-c', 'cxxfoo.h'])
 
     # Compiling the same header using `emcc` fails, just like `clang`
-    err = self.expect_fail([EMCC, '-c', 'cxxfoo.h', '-sSTRICT'])
-    self.assertContained("'string' file not found", err)
+    self.assert_fail([EMCC, '-c', 'cxxfoo.h', '-sSTRICT'], "'string' file not found")
 
     # But it works if we pass and explicit language mode.
     self.run_process([EMCC, '-x', 'c++-header', '-c', 'cxxfoo.h'])
@@ -11869,13 +11799,12 @@ int main(void) {
   # Tests that if a JS library function is missing, the linker will print out which function
   # depended on the missing function.
   def test_chained_js_error_diagnostics(self):
-    err = self.expect_fail([EMCC, test_file('test_chained_js_error_diagnostics.c'), '--js-library', test_file('test_chained_js_error_diagnostics.js')])
-    self.assertContained('emscripten_js_symbols.so: undefined symbol: nonexistent_function. Required by foo', err)
+    expected = 'emscripten_js_symbols.so: undefined symbol: nonexistent_function. Required by foo'
+    self.assert_fail([EMCC, test_file('test_chained_js_error_diagnostics.c'), '--js-library', test_file('test_chained_js_error_diagnostics.js')], expected)
 
     # Test without chaining.  In this case we don't include the JS library at
     # all resulting in `foo` being undefined in the native code.
-    err = self.expect_fail([EMCC, test_file('test_chained_js_error_diagnostics.c')])
-    self.assertContained('undefined symbol: foo', err)
+    err = self.assert_fail([EMCC, test_file('test_chained_js_error_diagnostics.c')], 'undefined symbol: foo')
     self.assertNotContained('referenced by top-level compiled C/C++ code', err)
 
   def test_xclang_flag(self):
@@ -11884,10 +11813,8 @@ int main(void) {
 
   def test_emcc_size_parsing(self):
     create_file('foo.h', ' ')
-    err = self.expect_fail([EMCC, '-sTOTAL_MEMORY=X', 'foo.h'])
-    self.assertContained('error: invalid byte size `X`.  Valid suffixes are: kb, mb, gb, tb', err)
-    err = self.expect_fail([EMCC, '-sTOTAL_MEMORY=11PB', 'foo.h'])
-    self.assertContained('error: invalid byte size `11PB`.  Valid suffixes are: kb, mb, gb, tb', err)
+    self.assert_fail([EMCC, '-sTOTAL_MEMORY=X', 'foo.h'], 'error: invalid byte size `X`.  Valid suffixes are: kb, mb, gb, tb')
+    self.assert_fail([EMCC, '-sTOTAL_MEMORY=11PB', 'foo.h'], 'error: invalid byte size `11PB`.  Valid suffixes are: kb, mb, gb, tb')
 
   def test_native_call_before_init(self):
     self.set_setting('ASSERTIONS')
@@ -12053,13 +11980,11 @@ int main () {
 
   @with_env_modify({'EMMAKEN_COMPILER': shared.CLANG_CC})
   def test_emmaken_compiler(self):
-    stderr = self.expect_fail([EMCC, '-c', test_file('core/test_hello_world.c')])
-    self.assertContained('emcc: error: `EMMAKEN_COMPILER` is no longer supported', stderr)
+    self.assert_fail([EMCC, '-c', test_file('core/test_hello_world.c')], 'emcc: error: `EMMAKEN_COMPILER` is no longer supported')
 
   @with_env_modify({'EMMAKEN_CFLAGS': '-O2'})
   def test_emmaken_cflags(self):
-    stderr = self.expect_fail([EMCC, '-c', test_file('core/test_hello_world.c')])
-    self.assertContained('emcc: error: `EMMAKEN_CFLAGS` is no longer supported', stderr)
+    self.assert_fail([EMCC, '-c', test_file('core/test_hello_world.c')], 'emcc: error: `EMMAKEN_CFLAGS` is no longer supported')
 
   @no_windows('relies on a shell script')
   def test_compiler_wrapper(self):
@@ -12117,14 +12042,14 @@ exec "$@"
     self.do_runf('hello_world.c', '[library call:_fd_write: 0x00000001 (1)')
 
   def test_SUPPORT_LONGJMP_executable(self):
-    err = self.expect_fail([EMCC, test_file('core/test_longjmp.c'), '-sSUPPORT_LONGJMP=0'])
-    self.assertContained('error: longjmp support was disabled (SUPPORT_LONGJMP=0), but it is required by the code (either set SUPPORT_LONGJMP=1, or remove uses of it in the project)', err)
+    expected = 'error: longjmp support was disabled (SUPPORT_LONGJMP=0), but it is required by the code (either set SUPPORT_LONGJMP=1, or remove uses of it in the project)'
+    self.assert_fail([EMCC, test_file('core/test_longjmp.c'), '-sSUPPORT_LONGJMP=0'], expected)
 
   def test_SUPPORT_LONGJMP_object(self):
     # compile the object *with* support, but link without
     self.run_process([EMCC, test_file('core/test_longjmp.c'), '-c', '-sSUPPORT_LONGJMP', '-o', 'a.o'])
-    err = self.expect_fail([EMCC, 'a.o', '-sSUPPORT_LONGJMP=0'])
-    self.assertContained('error: longjmp support was disabled (SUPPORT_LONGJMP=0), but it is required by the code (either set SUPPORT_LONGJMP=1, or remove uses of it in the project)', err)
+    expected = 'error: longjmp support was disabled (SUPPORT_LONGJMP=0), but it is required by the code (either set SUPPORT_LONGJMP=1, or remove uses of it in the project)'
+    self.assert_fail([EMCC, 'a.o', '-sSUPPORT_LONGJMP=0'], expected)
 
   def test_SUPPORT_LONGJMP_wasm(self):
     # Tests if -sSUPPORT_LONGJMP=wasm alone is enough to use Wasm SjLj, i.e., it
@@ -12169,8 +12094,8 @@ exec "$@"
     self.assertContained('new ExitStatus', read_file('out.foo'))
     self.clear()
 
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '--oformat=foo'])
-    self.assertContained("error: invalid output format: `foo` (must be one of ['object', 'wasm', 'js', 'mjs', 'html', 'bare']", err)
+    expected = "error: invalid output format: `foo` (must be one of ['object', 'wasm', 'js', 'mjs', 'html', 'bare']"
+    self.assert_fail([EMCC, test_file('hello_world.c'), '--oformat=foo'], expected)
 
   # Tests that the old format of {{{ makeDynCall('sig') }}}(func, param1) works
   def test_old_makeDynCall_syntax(self):
@@ -12587,8 +12512,7 @@ exec "$@"
     self.run_js('a.out.js')
 
     # negative case: foo is undefined in test_check_undefined.c
-    err = self.expect_fail([EMCC, '-sMAIN_MODULE', test_file('other/test_check_undefined.c')])
-    self.assertContained('undefined symbol: foo', err)
+    self.assert_fail([EMCC, '-sMAIN_MODULE', test_file('other/test_check_undefined.c')], 'undefined symbol: foo')
 
   @also_with_wasm64
   @parameterized({
@@ -12614,8 +12538,7 @@ exec "$@"
 
   @with_env_modify({'EMMAKEN_NO_SDK': '1'})
   def test_EMMAKEN_NO_SDK(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c')])
-    self.assertContained('emcc: error: EMMAKEN_NO_SDK is no longer supported', err)
+    self.assert_fail([EMCC, test_file('hello_world.c')], 'emcc: error: EMMAKEN_NO_SDK is no longer supported')
 
   @parameterized({
     'default': ('', '2147483648'),
@@ -12660,8 +12583,7 @@ kill -9 $$
     ''')
     make_executable('die.sh')
     with env_modify({'EM_COMPILER_WRAPPER': './die.sh'}):
-      err = self.expect_fail([EMCC, test_file('hello_world.c')])
-      self.assertContained('failed (received SIGKILL (-9))', err)
+      self.assert_fail([EMCC, test_file('hello_world.c')], 'failed (received SIGKILL (-9))')
 
   def test_concepts(self):
     self.do_runf('other/test_concepts.cpp', '', cflags=['-std=c++20'])
@@ -12683,13 +12605,11 @@ kill -9 $$
         __attribute__((deprecated)) int foo();
         int main() { return foo(); }
     ''')
-    err = self.expect_fail([EMCC, '-c', '-Werror', 'test.c'])
-    self.assertContained("error: 'foo' is deprecated", err)
+    self.assert_fail([EMCC, '-c', '-Werror', 'test.c'], "error: 'foo' is deprecated")
     self.run_process([EMCC, '-c', '-Werror', '-Wno-deprecated', 'test.c'])
 
   def test_bad_export_name(self):
-    err = self.expect_fail([EMCC, '-sEXPORT_NAME=foo bar', test_file('hello_world.c')])
-    self.assertContained('error: EXPORT_NAME is not a valid JS identifier: `foo bar`', err)
+    self.assert_fail([EMCC, '-sEXPORT_NAME=foo bar', test_file('hello_world.c')], 'error: EXPORT_NAME is not a valid JS identifier: `foo bar`')
 
   def test_standard_library_mapping(self):
     # Test the `-l` flags on the command line get mapped the correct libraries variant
@@ -12713,14 +12633,12 @@ kill -9 $$
 EMSCRIPTEN_KEEPALIVE
 void foo() {}
 ''')
-    err = self.expect_fail([EMCC, 'lib.c', '-pthread', '-sPROXY_TO_PTHREAD'])
-    self.assertContained('crt1_proxy_main.o: undefined symbol: main', err)
+    self.assert_fail([EMCC, 'lib.c', '-pthread', '-sPROXY_TO_PTHREAD'], 'crt1_proxy_main.o: undefined symbol: main')
 
   def test_archive_bad_extension(self):
     self.run_process([EMCC, '-c', test_file('hello_world.c')])
     self.run_process([EMAR, 'crs', 'libtest.bc', 'hello_world.o'])
-    err = self.expect_fail([EMCC, 'libtest.bc'])
-    self.assertContained('libtest.bc:1:2: error: expected integer', err)
+    self.assert_fail([EMCC, 'libtest.bc'], 'libtest.bc:1:2: error: expected integer')
 
   def test_split_dwarf_implicit_compile(self):
     # Verify that the dwo file is generated in the current working directory, even when implicitly
@@ -12747,8 +12665,7 @@ void foo() {}
     ''')
     cmd = [EMCC, 'main.c', '-sASSERTIONS'] + args
     if args:
-      err = self.expect_fail(cmd)
-      self.assertContained('libc-debug.a(mincore.o): undefined symbol: __syscall_mincore', err)
+      self.assert_fail(cmd, 'libc-debug.a(mincore.o): undefined symbol: __syscall_mincore')
     else:
       self.run_process(cmd)
       err = self.run_js('a.out.js')
@@ -12769,8 +12686,7 @@ void foo() {}
     # If we build the same thing with ALLOW_UNIMPLEMENTED_SYSCALLS=0 we
     # expect a link-time failure rather than a runtime one.
     cmd += ['-sALLOW_UNIMPLEMENTED_SYSCALLS=0']
-    err = self.expect_fail(cmd)
-    self.assertContained('undefined symbol: dlopen', err)
+    self.assert_fail(cmd, 'undefined symbol: dlopen')
 
   def test_unimplemented_syscalls_dladdr(self):
     create_file('main.c', '''
@@ -13408,8 +13324,8 @@ int main() {
     self.assertContained('emcc: warning: warnings in JS library compilation [-Wjs-compiler]', err)
 
     # In strict mode legacy library functions are not available, so we get a build time error
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sEXPORTED_RUNTIME_METHODS=allocateUTF8', '-sSTRICT'] + args)
-    self.assertContained('undefined exported symbol: "allocateUTF8" in EXPORTED_RUNTIME_METHODS', err)
+    expected = 'undefined exported symbol: "allocateUTF8" in EXPORTED_RUNTIME_METHODS'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sEXPORTED_RUNTIME_METHODS=allocateUTF8', '-sSTRICT'] + args, expected)
 
   def test_fetch_settings(self):
     create_file('pre.js', '''
@@ -13479,12 +13395,12 @@ int main() {
     self.run_process([EMCC, test_file('wasm_worker/lock_async_acquire.c'), '-O2', '-sWASM_WORKERS', '--closure=1'])
 
   def test_wasm_worker_errors(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sWASM_WORKERS', '-sSINGLE_FILE'])
-    self.assertContained('-sSINGLE_FILE is not supported with -sWASM_WORKERS', err)
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sWASM_WORKERS', '-sPROXY_TO_WORKER'])
-    self.assertContained('-sPROXY_TO_WORKER is not supported with -sWASM_WORKERS', err)
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sWASM_WORKERS', '-sMAIN_MODULE'])
-    self.assertContained('dynamic linking is not supported with -sWASM_WORKERS', err)
+    expected = '-sSINGLE_FILE is not supported with -sWASM_WORKERS'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sWASM_WORKERS', '-sSINGLE_FILE'], expected)
+    expected = '-sPROXY_TO_WORKER is not supported with -sWASM_WORKERS'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sWASM_WORKERS', '-sPROXY_TO_WORKER'], expected)
+    expected = 'dynamic linking is not supported with -sWASM_WORKERS'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sWASM_WORKERS', '-sMAIN_MODULE'], expected)
 
   def test_clock_nanosleep(self):
     self.do_runf('other/test_clock_nanosleep.c')
@@ -13528,8 +13444,8 @@ int main() {
     # Using headers directly from where they live in the source tree does not work.
     # Verify that we generate a useful warning when folks try to do this.
     create_file('test.c', '#include <emscripten.h>')
-    err = self.expect_fail([EMCC, '-I' + path_from_root('system/include'), 'test.c'])
-    self.assertContained('#error "Including files directly from the emscripten source tree is not supported', err)
+    expected = '#error "Including files directly from the emscripten source tree is not supported'
+    self.assert_fail([EMCC, '-I' + path_from_root('system/include'), 'test.c'], expected)
 
   def test_multiple_g_flags(self):
     # Verify that a second -g argument overrides the first
@@ -13578,8 +13494,7 @@ int main() {
     self.assertLess(abs(stack_switching_size - nothing_size), 0.01 * nothing_size)
 
   def test_no_cfi(self):
-    err = self.expect_fail([EMCC, '-fsanitize=cfi', '-flto', test_file('hello_world.c')])
-    self.assertContained('emcc: error: emscripten does not currently support -fsanitize=cfi', err)
+    self.assert_fail([EMCC, '-fsanitize=cfi', '-flto', test_file('hello_world.c')], 'emcc: error: emscripten does not currently support -fsanitize=cfi')
 
   @also_without_bigint
   def test_parseTools(self):
@@ -13821,11 +13736,11 @@ out.js
     self.assertTextDataIdentical(expected, response)
 
   def test_min_browser_version(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Wno-transpile', '-Werror', '-sWASM_BIGINT', '-sMIN_SAFARI_VERSION=130000'])
-    self.assertContained('emcc: error: MIN_SAFARI_VERSION=130000 is not compatible with WASM_BIGINT (MIN_SAFARI_VERSION=150000 or above required)', err)
+    expected = 'emcc: error: MIN_SAFARI_VERSION=130000 is not compatible with WASM_BIGINT (MIN_SAFARI_VERSION=150000 or above required)'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-Wno-transpile', '-Werror', '-sWASM_BIGINT', '-sMIN_SAFARI_VERSION=130000'], expected)
 
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-Wno-transpile', '-Werror', '-pthread', '-sMIN_FIREFOX_VERSION=68'])
-    self.assertContained('emcc: error: MIN_FIREFOX_VERSION=68 is not compatible with pthreads (MIN_FIREFOX_VERSION=79 or above required)', err)
+    expected = 'emcc: error: MIN_FIREFOX_VERSION=68 is not compatible with pthreads (MIN_FIREFOX_VERSION=79 or above required)'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-Wno-transpile', '-Werror', '-pthread', '-sMIN_FIREFOX_VERSION=68'], expected)
 
   # Test that using two different ways to disable a target environment at the same time will not produce a warning.
   def test_double_disable_environment(self):
@@ -13910,14 +13825,14 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
   def test_standalone_settings(self):
     base_cmd = [EMCC, test_file('hello_world.c'), '-sSTANDALONE_WASM']
 
-    err = self.expect_fail(base_cmd + ['-sMINIMAL_RUNTIME'])
-    self.assertContained('emcc: error: STANDALONE_WASM is not compatible with MINIMAL_RUNTIME', err)
+    expected = 'emcc: error: STANDALONE_WASM is not compatible with MINIMAL_RUNTIME'
+    self.assert_fail(base_cmd + ['-sMINIMAL_RUNTIME'], expected)
 
-    err = self.expect_fail(base_cmd + ['-sMEMORY_GROWTH_GEOMETRIC_CAP=1mb'])
-    self.assertContained('error: MEMORY_GROWTH_GEOMETRIC_CAP is not compatible with STANDALONE_WASM', err)
+    expected = 'error: MEMORY_GROWTH_GEOMETRIC_CAP is not compatible with STANDALONE_WASM'
+    self.assert_fail(base_cmd + ['-sMEMORY_GROWTH_GEOMETRIC_CAP=1mb'], expected)
 
-    err = self.expect_fail(base_cmd + ['-sMEMORY_GROWTH_LINEAR_STEP=1mb'])
-    self.assertContained('error: MEMORY_GROWTH_LINEAR_STEP is not compatible with STANDALONE_WASM', err)
+    expected = 'error: MEMORY_GROWTH_LINEAR_STEP is not compatible with STANDALONE_WASM'
+    self.assert_fail(base_cmd + ['-sMEMORY_GROWTH_LINEAR_STEP=1mb'], expected)
 
   def test_standalone_imports(self):
     # Ensure standalone binary will not have __throw_exception_with_stack_trace
@@ -13993,21 +13908,20 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     # We support just the singular form of `-pthread`, like gcc
     # Clang supports the plural form too but I think just due to historical accident:
     # See https://github.com/llvm/llvm-project/commit/c800391fb974cdaaa62bd74435f76408c2e5ceae
-    err = self.expect_fail([EMCC, '-pthreads', '-c', test_file('hello_world.c')])
-    self.assertContained('emcc: error: unrecognized command-line option `-pthreads`; did you mean `-pthread`?', err)
+    self.assert_fail([EMCC, '-pthreads', '-c', test_file('hello_world.c')], 'emcc: error: unrecognized command-line option `-pthreads`; did you mean `-pthread`?')
 
   def test_missing_struct_info(self):
     create_file('lib.js', '''
       {{{ C_STRUCTS.Foo }}}
     ''')
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js'])
-    self.assertContained('Error: Missing C struct Foo! If you just added it to struct_info.json, you need to run ./tools/gen_struct_info.py (then run a second time with --wasm64)', err)
+    expected = 'Error: Missing C struct Foo! If you just added it to struct_info.json, you need to run ./tools/gen_struct_info.py (then run a second time with --wasm64)'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js'], expected)
 
     create_file('lib.js', '''
       {{{ C_DEFINES.Foo }}}
     ''')
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js'])
-    self.assertContained('Error: Missing C define Foo! If you just added it to struct_info.json, you need to run ./tools/gen_struct_info.py (then run a second time with --wasm64)', err)
+    expected = 'Error: Missing C define Foo! If you just added it to struct_info.json, you need to run ./tools/gen_struct_info.py (then run a second time with --wasm64)'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js'], expected)
 
   def run_wasi_test_suite_test(self, name):
     if not os.path.exists(path_from_root('test/third_party/wasi-test-suite')):
@@ -14092,8 +14006,7 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     # SUPPORT_LONGJMP by default because it uses a JS-based simulation of
     # longjmp.
     self.set_setting('PURE_WASI')
-    err = self.expect_fail([EMCC, test_file('core/test_longjmp.c')] + self.get_cflags())
-    self.assertContained('error: longjmp support was disabled (SUPPORT_LONGJMP=0)', err)
+    self.assert_fail([EMCC, test_file('core/test_longjmp.c')] + self.get_cflags(), 'error: longjmp support was disabled (SUPPORT_LONGJMP=0)')
 
     # When using Wasm exception, SUPPORT_LONGJMP defaults to 'wasm', which does
     # not use the JS-based support. This should succeed.
@@ -14103,8 +14016,7 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     self.do_runf('core/test_longjmp.c', cflags=self.get_cflags())
 
   def test_memory_init_file_unsupported(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '--memory-init-file=1'])
-    self.assertContained('error: --memory-init-file is no longer supported', err)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '--memory-init-file=1'], 'error: --memory-init-file is no longer supported')
 
   @node_pthreads
   def test_node_pthreads_err_out(self):
@@ -14315,11 +14227,9 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     self.do_runf('hello_world.c', cflags=['--target=wasm32'])
     self.do_runf('hello_world.c', cflags=['--target=wasm64-unknown-emscripten', '-Wno-experimental'])
 
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-target', 'wasm32', '-sMEMORY64'])
-    self.assertContained('emcc: error: wasm32 target is not compatible with -sMEMORY64', err)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-target', 'wasm32', '-sMEMORY64'], 'emcc: error: wasm32 target is not compatible with -sMEMORY64')
 
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '--target=arm64'])
-    self.assertContained('emcc: error: unsupported target: arm64 (emcc only supports wasm64-unknown-emscripten and wasm32-unknown-emscripten', err)
+    self.assert_fail([EMCC, test_file('hello_world.c'), '--target=arm64'], 'emcc: error: unsupported target: arm64 (emcc only supports wasm64-unknown-emscripten and wasm32-unknown-emscripten')
 
   def test_quick_exit(self):
     self.do_other_test('test_quick_exit.c')
@@ -14400,8 +14310,8 @@ addToLibrary({
   }
 });
 ''')
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js', '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=foo'])
-    self.assertContained('error: noExitRuntime cannot be referenced via __deps mechanism', err)
+    expected = 'error: noExitRuntime cannot be referenced via __deps mechanism'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '--js-library=lib.js', '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=foo'], expected)
 
   def test_hello_world_argv(self):
     self.do_runf('hello_world_argv.c', 'hello, world! (1)')
@@ -14485,8 +14395,8 @@ addToLibrary({
     self.do_other_test('test_stdint_limits.c', cflags=['-iwithsysroot/include'])
 
   def test_force_filesystem_error(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sFILESYSTEM=0', '-sFORCE_FILESYSTEM'])
-    self.assertContained('emcc: error: `-sFORCE_FILESYSTEM` cannot be used with `-sFILESYSTEM=0`', err)
+    expected = 'emcc: error: `-sFORCE_FILESYSTEM` cannot be used with `-sFILESYSTEM=0`'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sFILESYSTEM=0', '-sFORCE_FILESYSTEM'], expected)
 
   def test_aligned_alloc(self):
     self.do_runf('test_aligned_alloc.c', '',
@@ -14545,11 +14455,9 @@ addToLibrary({
     self.do_other_test('test_dynamic_cast_2.cpp')
 
   def test_no_input_files(self):
-    err = self.expect_fail([EMCC, '-c'])
-    self.assertContained('clang: error: no input files', err)
+    self.assert_fail([EMCC, '-c'], 'clang: error: no input files')
 
-    err = self.expect_fail([EMCC])
-    self.assertContained('emcc: error: no input files', err)
+    self.assert_fail([EMCC], 'emcc: error: no input files')
 
   def test_embind_negative_enum_values(self):
     # Test if negative enum values are printed correctly and not overflown to
@@ -14616,8 +14524,8 @@ addToLibrary({
       self.assertEqual(proc.stderr, '')
 
   def test_browser_too_old(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sMIN_CHROME_VERSION=10'])
-    self.assertContained('emcc: error: MIN_CHROME_VERSION older than 74 is not supported', err)
+    expected = 'emcc: error: MIN_CHROME_VERSION older than 74 is not supported'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sMIN_CHROME_VERSION=10'], expected)
 
   def test_js_only_settings(self):
     err = self.run_process([EMCC, test_file('hello_world.c'), '-o', 'foo.wasm', '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=emscripten_get_heap_max'], stderr=PIPE).stderr
@@ -14636,13 +14544,13 @@ addToLibrary({
     self.assertContained('.getRandomValues(', js_out)
 
   def test_wasm64_no_asan(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sMEMORY64', '-fsanitize=address'])
-    self.assertContained('error: MEMORY64 does not yet work with ASAN', err)
+    expected = 'error: MEMORY64 does not yet work with ASAN'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sMEMORY64', '-fsanitize=address'], expected)
 
   def test_mimalloc_no_asan(self):
     # See https://github.com/emscripten-core/emscripten/issues/23288#issuecomment-2571648258
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sMALLOC=mimalloc', '-fsanitize=address'])
-    self.assertContained('error: mimalloc is not compatible with -fsanitize=address', err)
+    expected = 'error: mimalloc is not compatible with -fsanitize=address'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sMALLOC=mimalloc', '-fsanitize=address'], expected)
 
   @crossplatform
   def test_js_preprocess_pre_post(self):
@@ -14863,8 +14771,8 @@ addToLibrary({
 
   def test_invalid_export_name(self):
     create_file('test.c', '__attribute__((export_name("my.func"))) void myfunc() {}')
-    err = self.expect_fail([EMCC, 'test.c'])
-    self.assertContained('emcc: error: invalid export name: "_my.func"', err)
+    expected = 'emcc: error: invalid export name: "_my.func"'
+    self.assert_fail([EMCC, 'test.c'], expected)
 
     # When we are generating only wasm and not JS we don't need exports to
     # be valid JS symbols.
@@ -15127,11 +15035,11 @@ addToLibrary({
     self.assertGreater(td_with_fallback, td_without_fallback)
 
   def test_TextDecoder_invalid(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sTEXTDECODER=0'])
-    self.assertContained('#error "TEXTDECODER must be either 1 or 2"', err)
+    expected = '#error "TEXTDECODER must be either 1 or 2"'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sTEXTDECODER=0'], expected)
 
-    err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sTEXTDECODER=3'])
-    self.assertContained('#error "TEXTDECODER must be either 1 or 2"', err)
+    expected = '#error "TEXTDECODER must be either 1 or 2"'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sTEXTDECODER=3'], expected)
 
   def test_reallocarray(self):
     self.do_other_test('test_reallocarray.c')

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -373,10 +373,9 @@ fi
     ''')
 
     wipe()
+    expected = 'error: inline EM_CONFIG data no longer supported.  Please use a config file.'
     with env_modify({'EM_CONFIG': get_basic_config()}):
-      out = self.expect_fail([EMCC, 'main.cpp', '-Wno-deprecated', '-o', 'a.out.js'])
-
-    self.assertContained('error: inline EM_CONFIG data no longer supported.  Please use a config file.', out)
+      self.assert_fail([EMCC, 'main.cpp', '-Wno-deprecated', '-o', 'a.out.js'], expected)
 
   def clear_cache(self):
     self.run_process([EMCC, '--clear-cache'])
@@ -676,8 +675,7 @@ fi
       make_fake_tool(self.in_dir('fake', f'llvm-nm-{version}'), expected_llvm_version)
 
     make_fake('9.9')
-    out = self.expect_fail([EMCC, '-v'])
-    self.assertContained('No such file or directory', out)
+    self.assert_fail([EMCC, '-v'], 'No such file or directory')
     with env_modify({'EM_LLVM_ADD_VERSION': '9.9', 'EM_CLANG_ADD_VERSION': '9.9'}):
       self.check_working([EMCC])
 
@@ -799,8 +797,8 @@ fi
 
     # Touching package.json should cause compiler to fail with bootstrap message
     Path(utils.path_from_root('package.json')).touch()
-    err = self.expect_fail([EMCC, test_file('hello_world.c')])
-    self.assertContained('emcc: error: emscripten setup is not complete ("npm packages" is out-of-date). Run `bootstrap` to update', err)
+    expected = 'emcc: error: emscripten setup is not complete ("npm packages" is out-of-date). Run `bootstrap` to update'
+    self.assert_fail([EMCC, test_file('hello_world.c')], expected)
 
     # Running bootstrap.py should fix that
     bootstrap = shared.bat_suffix(shared.path_from_root('bootstrap'))


### PR DESCRIPTION
I noticed that we were almost always following `expect_fail` with `assertContains` so I created a helper that does both.

In many cases this collapses two lines of test code into a single one.

In other cases I decided to keep the expectation string on its own line to avoid over-long lines, but it still simplifies the code I believe.

I mostly used some crazy regex patterns to create this PR.