### PR TITLE
Improve Firefox browser process tracking

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -30,7 +30,6 @@ from pathlib import Path
 from subprocess import PIPE, STDOUT
 from typing import Dict, Tuple
 from urllib.parse import parse_qs, unquote, unquote_plus, urlparse
-from .utils import WINDOWS
 
 import clang_native
 import jsrun


### PR DESCRIPTION
Improve Firefox browser process tracking by using the -wait-for-browser cmdline arg, and waiting longer for process startup.

Unfortunately `-wait-for-browser` is not enough to get rid of the process delta polling, since the process handle returned by `subprocess.Popen()` cannot be used to cascade the spawned Firefox windows.

Waiting for 2 seconds for Firefox startup was not enough, so make the wait time more conservative.

Add the detected processes to the list rather than replace, so that all process handles are retained.

It may be possible to remove the use of `launch_browser_harness_with_proc_snapshot_workaround()` for headless Firefox runs, but more testing will be needed to verify that.