### PR TITLE
[libwebaudio.js] Convert to handle allocator. NFC

### DIFF
--- a/test/codesize/audio_worklet_wasm.expected.js
+++ b/test/codesize/audio_worklet_wasm.expected.js
@@ -1,4 +1,4 @@
-var m = globalThis.Module || "undefined" != typeof Module ? Module : {}, r = !!globalThis.AudioWorkletGlobalScope, t = "em-ww" == globalThis.name || r, u, z, I, J, G, E, w, X, F, D, C, Y, A, Z;
+var m = globalThis.Module || "undefined" != typeof Module ? Module : {}, r = !!globalThis.AudioWorkletGlobalScope, t = "em-ww" == globalThis.name || r, u, z, I, J, H, E, w, X, F, D, C, Y, A, Z;
 
 function v(a) {
     u = a;
@@ -21,15 +21,15 @@ if (r) {
             constructor(d) {
                 super();
                 d = d.processorOptions;
-                this.v = A.get(d.v);
-                this.A = d.A;
+                this.A = A.get(d.A);
+                this.B = d.B;
                 this.u = d.u;
                 this.s = 4 * this.u;
-                this.B = Array(Math.min((u.F - 16) / this.s | 0, 64));
+                this.v = Array(Math.min((u.F - 16) / this.s | 0, 64));
                 this.K();
             }
             K() {
-                for (var d = C(), g = D(this.B.length * this.s) >> 2, e = this.B.length - 1; 0 <= e; e--) this.B[e] = E.subarray(g, g += this.u);
+                for (var d = C(), g = D(this.v.length * this.s) >> 2, e = this.v.length - 1; 0 <= e; e--) this.v[e] = E.subarray(g, g += this.u);
                 F(d);
             }
             static get parameterDescriptors() {
@@ -39,29 +39,29 @@ if (r) {
                 var l = d.length, p = g.length, f, q, k = 12 * (l + p), n = 0;
                 for (f of d) n += f.length;
                 n *= this.s;
-                var H = 0;
-                for (f of g) H += f.length;
-                n += H * this.s;
-                var N = 0;
-                for (f in e) ++N, k += 8, n += e[f].byteLength;
+                var G = 0;
+                for (f of g) G += f.length;
+                n += G * this.s;
+                var M = 0;
+                for (f in e) ++M, k += 8, n += e[f].byteLength;
                 var U = C(), B = k + n + 15 & -16;
                 k = D(B);
                 n = k + (B - n);
                 B = k;
                 for (f of d) {
-                    G[k >> 2] = f.length;
-                    G[k + 4 >> 2] = this.u;
-                    G[k + 8 >> 2] = n;
+                    H[k >> 2] = f.length;
+                    H[k + 4 >> 2] = this.u;
+                    H[k + 8 >> 2] = n;
                     k += 12;
                     for (q of f) E.set(q, n >> 2), n += this.s;
                 }
                 d = k;
-                for (f = 0; q = e[f++]; ) G[k >> 2] = q.length, G[k + 4 >> 2] = n, k += 8, E.set(q, n >> 2), 
+                for (f = 0; q = e[f++]; ) H[k >> 2] = q.length, H[k + 4 >> 2] = n, k += 8, E.set(q, n >> 2), 
                 n += 4 * q.length;
                 e = k;
-                for (f of g) G[k >> 2] = f.length, G[k + 4 >> 2] = this.u, G[k + 8 >> 2] = n, k += 12, 
+                for (f of g) H[k >> 2] = f.length, H[k + 4 >> 2] = this.u, H[k + 8 >> 2] = n, k += 12, 
                 n += this.s * f.length;
-                if (l = this.v(l, B, p, e, N, d, this.A)) for (f of g) for (q of f) q.set(this.B[--H]);
+                if (l = this.A(l, B, p, e, M, d, this.B)) for (f of g) for (q of f) q.set(this.v[--G]);
                 F(U);
                 return !!l;
             }
@@ -82,8 +82,8 @@ if (r) {
         await z;
         b = b.data;
         b._boot ? v(b) : b._wpn ? (registerProcessor(b._wpn, a(b.H)), port.postMessage({
-            _wsc: b.v,
-            C: [ b.I, 1, b.A ]
+            _wsc: b.A,
+            C: [ b.I, 1, b.B ]
         })) : b._wsc && A.get(b._wsc)(...b.C);
     };
 }
@@ -92,7 +92,7 @@ function x() {
     var a = w.buffer;
     I = new Uint8Array(a);
     J = new Int32Array(a);
-    G = new Uint32Array(a);
+    H = new Uint32Array(a);
     E = new Float32Array(a);
 }
 
@@ -106,14 +106,34 @@ var K = [], L = a => {
     a = a.data;
     let c = a._wsc;
     c && A.get(c)(...a.x);
-}, M = a => {
+}, N = a => {
     K.push(a);
-}, P = (a, c, b, h) => {
-    c = O[c];
-    O[a].connect(c.destination || c, b, h);
-}, O = {}, Q = 0, R = globalThis.TextDecoder && new TextDecoder, S = (a = 0) => {
+};
+
+function O(a) {
+    var c = P, b = c.v.pop() || c.s.length;
+    c.s[b] = a;
+    return b;
+}
+
+class Q {
+    s=[ void 0 ];
+    v=[];
+    get(a) {
+        return this.s[a];
+    }
+    has(a) {
+        return void 0 !== this.s[a];
+    }
+}
+
+var P = new Q, R = (a, c, b, h) => {
+    a = P.get(a);
+    c = P.get(c);
+    a.connect(c.destination || c, b, h);
+}, S = globalThis.TextDecoder && new TextDecoder, T = (a = 0) => {
     for (var c = I, b = a, h = b + void 0; c[b] && !(b >= h); ) ++b;
-    if (16 < b - a && c.buffer && R) return R.decode(c.slice(a, b));
+    if (16 < b - a && c.buffer && S) return S.decode(c.slice(a, b));
     for (h = ""; a < b; ) {
         var d = c[a++];
         if (d & 128) {
@@ -126,46 +146,42 @@ var K = [], L = a => {
         } else h += String.fromCharCode(d);
     }
     return h;
-}, T = a => {
+}, V = a => {
     if (a) {
-        var c = G[a >> 2];
+        var c = H[a >> 2];
         a = {
-            latencyHint: (c ? S(c) : "") || void 0,
-            sampleRate: G[a + 4 >> 2] || void 0
+            latencyHint: (c ? T(c) : "") || void 0,
+            sampleRate: H[a + 4 >> 2] || void 0
         };
     } else a = void 0;
-    a = new AudioContext(a);
-    O[++Q] = a;
-    return Q;
-}, V = (a, c, b, h, d) => {
+    return O(new AudioContext(a));
+}, W = (a, c, b, h, d) => {
     var g = b ? J[b + 4 >> 2] : 0;
     if (b) {
-        var e = J[b >> 2], l = G[b + 8 >> 2], p = g;
+        var e = J[b >> 2], l = H[b + 8 >> 2], p = g;
         if (l) {
             l >>= 2;
-            for (var f = []; p--; ) f.push(G[l++]);
+            for (var f = []; p--; ) f.push(H[l++]);
             l = f;
         } else l = void 0;
         b = {
             numberOfInputs: e,
             numberOfOutputs: g,
             outputChannelCount: l,
-            channelCount: G[b + 12 >> 2] || void 0,
+            channelCount: H[b + 12 >> 2] || void 0,
             channelCountMode: [ , "clamped-max", "explicit" ][J[b + 16 >> 2]],
             channelInterpretation: [ , "discrete" ][J[b + 20 >> 2]],
             processorOptions: {
-                v: h,
-                A: d,
+                A: h,
+                B: d,
                 u: 128
             }
         };
     } else b = void 0;
-    a = new AudioWorkletNode(O[a], c ? S(c) : "", b);
-    O[++Q] = a;
-    return Q;
-}, W = (a, c, b, h) => {
-    var d = (d = G[c >> 2]) ? S(d) : "", g = J[c + 4 >> 2];
-    c = G[c + 8 >> 2];
+    return O(new AudioWorkletNode(P.get(a), c ? T(c) : "", b));
+}, aa = (a, c, b, h) => {
+    var d = (d = H[c >> 2]) ? T(d) : "", g = J[c + 4 >> 2];
+    c = H[c + 8 >> 2];
     for (var e = [], l = 0; g--; ) e.push({
         name: l++,
         defaultValue: E[c >> 2],
@@ -173,19 +189,19 @@ var K = [], L = a => {
         maxValue: E[c + 8 >> 2],
         automationRate: (J[c + 12 >> 2] ? "k" : "a") + "-rate"
     }), c += 16;
-    O[a].audioWorklet.port.postMessage({
+    P.get(a).audioWorklet.port.postMessage({
         _wpn: d,
         H: e,
         I: a,
-        v: b,
-        A: h
+        A: b,
+        B: h
     });
-}, aa = () => !1, ba = 1, ca = a => {
+}, ba = () => !1, ca = 1, da = a => {
     a = a.data;
     var c = a._wsc;
     c && A.get(c)(...a.C);
-}, da = (a, c, b, h, d) => {
-    var g = O[a], e = g.audioWorklet, l = () => {
+}, ea = (a, c, b, h, d) => {
+    var g = P.get(a), e = g.audioWorklet, l = () => {
         A.get(h)(a, 0, d);
     };
     if (!e) return l();
@@ -201,22 +217,22 @@ var K = [], L = a => {
         });
         e.port.postMessage({
             _boot: 1,
-            N: ba++,
+            N: ca++,
             G: m.wasm,
             L: w,
             J: c,
             F: b
         });
-        e.port.onmessage = ca;
+        e.port.onmessage = da;
         A.get(h)(a, 1, d);
     })).catch(l);
 };
 
-function ea(a) {
+function fa(a) {
     let c = document.createElement("button");
     c.innerHTML = "Toggle playback";
     document.body.appendChild(c);
-    a = O[a];
+    a = P.get(a);
     c.onclick = () => {
         "running" != a.state ? a.resume() : a.suspend();
     };
@@ -224,13 +240,13 @@ function ea(a) {
 
 function y() {
     Z = {
-        f: ea,
-        g: P,
-        d: T,
-        h: V,
-        e: W,
-        b: aa,
-        c: da,
+        f: fa,
+        g: R,
+        d: V,
+        h: W,
+        e: aa,
+        b: ba,
+        c: ea,
         a: w
     };
     z = WebAssembly.instantiate(m.wasm, {
@@ -243,7 +259,7 @@ function y() {
         C = a.n;
         Y = a.o;
         A = a.k;
-        t ? (Y(u.J, u.F), r || (removeEventListener("message", M), K = K.forEach(L), addEventListener("message", L))) : a.i();
+        t ? (Y(u.J, u.F), r || (removeEventListener("message", N), K = K.forEach(L), addEventListener("message", L))) : a.i();
         t || X();
     }));
 }

--- a/test/codesize/test_minimal_runtime_code_size_audio_worklet.json
+++ b/test/codesize/test_minimal_runtime_code_size_audio_worklet.json
@@ -1,10 +1,10 @@
 {
   "a.html": 519,
   "a.html.gz": 357,
-  "a.js": 4235,
-  "a.js.gz": 2170,
+  "a.js": 4394,
+  "a.js.gz": 2224,
   "a.wasm": 1329,
   "a.wasm.gz": 895,
-  "total": 6083,
-  "total_gz": 3422
+  "total": 6242,
+  "total_gz": 3476
 }

--- a/tools/unsafe_optimizations.mjs
+++ b/tools/unsafe_optimizations.mjs
@@ -207,7 +207,7 @@ function optPassMergeVarInitializationAssignments(ast) {
 }
 
 function runOnJsText(js, pretty = false) {
-  const ast = acorn.parse(js, {ecmaVersion: 2021});
+  const ast = acorn.parse(js, {ecmaVersion: 'latest'});
 
   optPassRemoveRedundantOperatorNews(ast);
 


### PR DESCRIPTION
Also:

- Removing duplication in precondition check.
- Use `dbg()` for debug messages

The use of the HandleAllocator does add about 70 bytes to the JS
payload, but that will be amortized over the different places where
HandleAllocator is also uses.
