### PR TITLE
Add -wait-for-browser for Linux and macOS as well.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -151,6 +151,10 @@ class FirefoxConfig:
 
   @staticmethod
   def open_url_args(url):
+    # Firefox is able to launch URLs by passing them as positional arguments,
+    # but not when the -wait-for-browser flag is in use (which we need to be
+    # able to track browser liveness). So explicitly use -url option parameter
+    # to specify the page to launch. https://bugzil.la/1996614
     return ['-url', url]
 
 


### PR DESCRIPTION
In previous PR https://github.com/emscripten-core/emscripten/pull/25644 I added `-wait-for-browser` use on Windows to help single-threaded Windows runner not leave behind stale browser windows.

For some reason, it was not passing on CircleCI on Linux. Testing this again to see what the failure is.

In local testing with a test script:

```py
import subprocess, sys, time

cmd = ['C:\\Program Files\\Mozilla Firefox\\firefox.exe', '-new-instance', '-profile', sys.argv[1], '-wait-for-browser', 'https://wiki.mozilla.org/Firefox/CommandLineOptions']
print('Launching browser: ' + ' '.join(cmd))
proc = subprocess.Popen(cmd)

for i in range(10):
  if proc.poll() is not None:
    print('Oops: process already quit, so we did not get a process handle to keep track of the browser instance.')
    sys.exit(0)
  time.sleep(1)

if proc.poll() is None:
  print('terminating browser process')
  proc.terminate()
time.sleep(2)
if proc.poll() is None:
  print('terminating did not work. killing browser process')
  proc.kill()

print('All done')
```

I am unable to find a behavioral difference between Windows and Linux.

So testing this out again on CircleCI.