### PR TITLE
Don't include internal compiler settings with RETAIN_COMPILER_SETTINGS

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,12 @@ See docs/process.md for more on how version tagging works.
 
 4.0.19 (in development)
 -----------------------
+- The `RETAIN_COMPILER_SETTINGS` setting and the corresponding
+  `emscripten_get_compiler_setting` API no longer store or report internal
+  compiler settings (those listed in `setttings_internal.js`).  We made an
+  exception here for `EMSCRIPTEN_VERSION` which is the only internal setting
+  where we could find usage of `emscripten_get_compiler_setting` (in a global
+  GitHub search). (#25667)
 
 4.0.18 - 10/24/25
 -----------------

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -806,17 +806,8 @@ function addAtPostRun(code) {
 
 function makeRetainedCompilerSettings() {
   const ret = {};
-  for (const [name, value] of Object.entries(global)) {
-    if (name[0] !== '_' && name == name.toUpperCase()) {
-      if (
-        typeof value == 'number' ||
-        typeof value == 'boolean' ||
-        typeof value == 'string' ||
-        Array.isArray(name)
-      ) {
-        ret[name] = value;
-      }
-    }
+  for (const name of PUBLIC_SETTINGS) {
+    ret[name] = globalThis[name];
   }
   return ret;
 }

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -278,3 +278,6 @@ var OUTPUT_FORMAT = '';
 var LOAD_SOURCE_MAP = false;
 
 var ALIASES = [];
+
+// List of public setting names (Used by RETAIN_COMPILER_SETTINGS)
+var PUBLIC_SETTINGS = [];

--- a/test/core/emscripten_get_compiler_setting.c
+++ b/test/core/emscripten_get_compiler_setting.c
@@ -5,14 +5,25 @@
  * found in the LICENSE file.
  */
 
-#include <stdio.h>
 #include <assert.h>
 #include <emscripten.h>
+#include <stdio.h>
+#include <string.h>
 
 int main() {
+  // Test boolean, int, and string settings
   printf("INVOKE_RUN: %ld\n", emscripten_get_compiler_setting("INVOKE_RUN"));
-  assert((unsigned)emscripten_get_compiler_setting("OPT_LEVEL") <= 3);
-  assert((unsigned)emscripten_get_compiler_setting("DEBUG_LEVEL") <= 4);
+  assert((unsigned)emscripten_get_compiler_setting("ASSERTIONS") <= 2);
   printf("CLOSURE_WARNINGS: %s\n", (char*)emscripten_get_compiler_setting("CLOSURE_WARNINGS"));
+
+  // Internal setting should not be visible.
+  const char* embind = (char*)emscripten_get_compiler_setting("EMBIND");
+  printf("EMBIND: %s\n", embind);
+  assert(strstr(embind, "invalid compiler setting") != NULL);
+
+  // EMSCRIPTEN_VERSION should be allowed though..
+  const char* version = (char*)emscripten_get_compiler_setting("EMSCRIPTEN_VERSION");
+  printf("EMSCRIPTEN_VERSION: %s\n", version);
+  assert(strstr(version, "invalid compiler setting") == NULL);
 }
 

--- a/test/core/emscripten_get_compiler_setting.out
+++ b/test/core/emscripten_get_compiler_setting.out
@@ -1,2 +1,3 @@
 INVOKE_RUN: 1
 CLOSURE_WARNINGS: quiet
+EMBIND: invalid compiler setting: EMBIND

--- a/tools/link.py
+++ b/tools/link.py
@@ -1793,6 +1793,11 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
                                     'emscripten_stack_get_end']
 
   settings.EMSCRIPTEN_VERSION = utils.EMSCRIPTEN_VERSION
+  if settings.RETAIN_COMPILER_SETTINGS:
+    settings.PUBLIC_SETTINGS = [k for k in settings.attrs.keys() if k not in settings.internal_settings]
+    # Also include EMSCRIPTEN_VERSION from the internal settings since there are
+    # known usage of this with `emscripten_get_compiler_setting`.
+    settings.PUBLIC_SETTINGS.append('EMSCRIPTEN_VERSION')
   settings.SOURCE_MAP_BASE = options.source_map_base or ''
 
   settings.LINK_AS_CXX = (shared.run_via_emxx or settings.DEFAULT_TO_CXX) and not options.nostdlibxx


### PR DESCRIPTION
This is technically a breaking change so I mentioned it in the ChangeLog.

Fixes: #25663