### PR TITLE
Don't require __wasm_apply_data_relocs. NFC

### DIFF
--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26919,
-  "a.out.js.gz": 11469,
+  "a.out.js": 26974,
+  "a.out.js.gz": 11477,
   "a.out.nodebug.wasm": 18567,
   "a.out.nodebug.wasm.gz": 9199,
-  "total": 45486,
-  "total_gz": 20668,
+  "total": 45541,
+  "total_gz": 20676,
   "sent": [
     "__heap_base",
     "__indirect_function_table",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 245868,
+  "a.out.js": 245923,
   "a.out.nodebug.wasm": 597779,
-  "total": 843647,
+  "total": 843702,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/tools/link.py
+++ b/tools/link.py
@@ -1386,9 +1386,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     # make_invoke depends on stackSave and stackRestore
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$stackSave', '$stackRestore']
 
-  if settings.RELOCATABLE:
-    settings.REQUIRED_EXPORTS += ['__wasm_apply_data_relocs']
-
   if settings.SIDE_MODULE and 'GLOBAL_BASE' in user_settings:
     diagnostics.warning('unused-command-line-argument', 'GLOBAL_BASE is not compatible with SIDE_MODULE')
 


### PR DESCRIPTION
This symbol is optionally created by the linker and optionally used in preamble.js and libdylink.js.

However this requirement here was forcing it to be exported.  The only reason I think this didn't cause any issues is that its not really possible to create a main module with zero data relocations today.