### PR TITLE
Move settings of GL_ENABLE_GET_PROC_ADDRESS to sdl2.py. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -484,11 +484,6 @@ def phase_setup(options, state):
     else:
       settings.SUPPORT_LONGJMP = 'emscripten'
 
-  # SDL2 requires eglGetProcAddress() to work.
-  # NOTE: if SDL2 is updated to not rely on eglGetProcAddress(), this can be removed
-  if settings.USE_SDL == 2 or settings.USE_SDL_MIXER == 2 or settings.USE_SDL_GFX == 2:
-    default_setting('GL_ENABLE_GET_PROC_ADDRESS', 1)
-
 
 @ToolchainProfiler.profile_block('compile inputs')
 def phase_compile_inputs(options, state, newargs):

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -934,7 +934,7 @@ If 1, link with support to glGetProcAddress() functionality.
 In WebGL, glGetProcAddress() causes a substantial code size and performance impact, since WebGL
 does not natively provide such functionality, and it must be emulated. Using glGetProcAddress()
 is not recommended. If you still need to use this, e.g. when porting an existing renderer,
-you can link with -sGL_ENABLE_GET_PROC_ADDRESS=1 to get support for this functionality.
+you can link with -sGL_ENABLE_GET_PROC_ADDRESS to get support for this functionality.
 
 Default value: true
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -609,7 +609,7 @@ var GL_WORKAROUND_SAFARI_GETCONTEXT_BUG = true;
 // In WebGL, glGetProcAddress() causes a substantial code size and performance impact, since WebGL
 // does not natively provide such functionality, and it must be emulated. Using glGetProcAddress()
 // is not recommended. If you still need to use this, e.g. when porting an existing renderer,
-// you can link with -sGL_ENABLE_GET_PROC_ADDRESS=1 to get support for this functionality.
+// you can link with -sGL_ENABLE_GET_PROC_ADDRESS to get support for this functionality.
 // [link]
 var GL_ENABLE_GET_PROC_ADDRESS = true;
 

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1324,7 +1324,7 @@ simulateKeyUp(100, undefined, 'Numpad4');
     self.btest_exit('test_webgl_context_attributes_glut.c', cflags=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED', '-lGL', '-lglut', '-lGLEW'])
     self.btest_exit('test_webgl_context_attributes_sdl.c', cflags=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED', '-lGL', '-lSDL', '-lGLEW'])
     if not self.is_wasm64():
-      self.btest_exit('test_webgl_context_attributes_sdl2.c', cflags=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED', '-lGL', '-sUSE_SDL=2', '-lGLEW', '-sGL_ENABLE_GET_PROC_ADDRESS=1'])
+      self.btest_exit('test_webgl_context_attributes_sdl2.c', cflags=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED', '-lGL', '-sUSE_SDL=2', '-lGLEW'])
     self.btest_exit('test_webgl_context_attributes_glfw.c', cflags=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED', '-lGL', '-lglfw', '-lGLEW'])
 
     # perform tests with attributes desactivated

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -26,6 +26,10 @@ def process_dependencies(settings, cflags_only):
     # SDL2 includes an internal reference to Module['createContext']
     settings.EXPORTED_RUNTIME_METHODS.append('createContext')
 
+    # SDL2 requires eglGetProcAddress() to work.
+    # NOTE: if SDL2 is updated to not rely on eglGetProcAddress(), this can be removed
+    settings.GL_ENABLE_GET_PROC_ADDRESS = 1
+
 
 def get(ports, settings, shared):
   # get the port

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -103,9 +103,6 @@ COMPILE_TIME_SETTINGS = {
     'OPT_LEVEL',
     'DEBUG_LEVEL',
 
-    # Affects ports
-    'GL_ENABLE_GET_PROC_ADDRESS', # NOTE: if SDL2 is updated to not rely on eglGetProcAddress(), this can be removed
-
     # This is legacy setting that we happen to handle very early on
     'RUNTIME_LINKED_LIBS',
 }.union(PORTS_SETTINGS)


### PR DESCRIPTION
This also allows it to be removed from COMPILE_TIME_SETTINGS.

Followup to #20802