### PR TITLE
Remove RUNTIME_LINKED_LIBS setting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,9 @@ See docs/process.md for more on how version tagging works.
   exception here for `EMSCRIPTEN_VERSION` which is the only internal setting
   where we could find usage of `emscripten_get_compiler_setting` (in a global
   GitHub search). (#25667)
+- The long-deprecated `RUNTIME_LINKED_LIBS` setting was removed. You can now
+  simply link shared libraries on the command line when linking your main module
+  (e.g. `emcc -sMAIN_MODULE main.c /path/to/libfoo.so`) (#25673)
 
 4.0.18 - 10/24/25
 -----------------

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1660,17 +1660,6 @@ Corresponds to MAIN_MODULE (also supports modes 1 and 2)
 
 Default value: 0
 
-.. _runtime_linked_libs:
-
-RUNTIME_LINKED_LIBS
-===================
-
-Deprecated, list shared libraries directly on the command line instead.
-
-.. note:: This setting is deprecated
-
-Default value: []
-
 .. _build_as_worker:
 
 BUILD_AS_WORKER
@@ -3403,7 +3392,6 @@ The following settings have been proposed for removal from emscripten.  These se
 still function but may be removed in a future version.  If your project is using of
 the these settings please open a bug (or reply to one of the existing bugs).
 
- - ``RUNTIME_LINKED_LIBS``: you can simply list the libraries directly on the commandline now
  - ``CLOSURE_WARNINGS``: use -Wclosure/-Wno-closure instead
  - ``LEGALIZE_JS_FFI``: to disable JS type legalization use `-sWASM_BIGINT` or `-sSTANDALONE_WASM`
  - ``ASYNCIFY_EXPORTS``: please use JSPI_EXPORTS instead
@@ -3496,3 +3484,4 @@ for backwards compatbility with older versions:
  - ``USE_OFFSET_COVERTER``: No longer supported, not needed with modern v8 versions (Valid values: [0])
  - ``ASYNCIFY_LAZY_LOAD_CODE``: No longer supported (Valid values: [0])
  - ``USE_WEBGPU``: No longer supported; replaced by --use-port=emdawnwebgpu, which implements a newer (but incompatible) version of webgpu.h - see tools/ports/emdawnwebgpu.py (Valid values: [0])
+ - ``RUNTIME_LINKED_LIBS``: list shared libraries directly on the command line instead (Valid values: [[]])

--- a/src/settings.js
+++ b/src/settings.js
@@ -1134,11 +1134,6 @@ var MAIN_MODULE = 0;
 // [compile+link]
 var SIDE_MODULE = 0;
 
-// Deprecated, list shared libraries directly on the command line instead.
-// [link]
-// [deprecated]
-var RUNTIME_LINKED_LIBS = [];
-
 // If set to 1, this is a worker library, a special kind of library that is run
 // in a worker. See emscripten.h
 // [link]

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6644,20 +6644,7 @@ int main(int argc, char** argv) {
     self.assertLess(side_dce_fail[1], 0.95 * side_dce_work[1]) # removing that function saves a chunk
 
   def test_RUNTIME_LINKED_LIBS(self):
-    # Verify that the legacy `-sRUNTIME_LINKED_LIBS` option acts the same as passing a
-    # library on the command line directly.
-    create_file('side.c', 'int foo() { return 42; }')
-    create_file('main.c', '#include <assert.h>\nextern int foo(); int main() { assert(foo() == 42); return 0; }')
-
-    self.run_process([EMCC, '-O2', 'side.c', '-sSIDE_MODULE', '-o', 'side.wasm'])
-    self.run_process([EMCC, '-O2', 'main.c', '-sMAIN_MODULE', '-o', 'main.js', 'side.wasm'])
-    self.run_js('main.js')
-
-    err = self.run_process([EMCC, '-O2', 'main.c', '-sMAIN_MODULE', '-o', 'main2.js', '-sRUNTIME_LINKED_LIBS=side.wasm'], stderr=PIPE).stderr
-    self.assertContained('emcc: warning: RUNTIME_LINKED_LIBS is deprecated', err)
-    self.run_js('main2.js')
-
-    self.assertBinaryEqual('main.wasm', 'main2.wasm')
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sRUNTIME_LINKED_LIBS=side.wasm'], 'list shared libraries directly on the command line instead')
 
   @parameterized({
     '': ([],),

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -112,7 +112,6 @@ COMPILE_TIME_SETTINGS = {
 #
 # All settings here should be tagged as `[deprecated]` in settings.js
 DEPRECATED_SETTINGS = {
-    'RUNTIME_LINKED_LIBS': 'you can simply list the libraries directly on the commandline now',
     'CLOSURE_WARNINGS': 'use -Wclosure/-Wno-closure instead',
     'LEGALIZE_JS_FFI': 'to disable JS type legalization use `-sWASM_BIGINT` or `-sSTANDALONE_WASM`',
     'ASYNCIFY_EXPORTS': 'please use JSPI_EXPORTS instead',
@@ -257,6 +256,7 @@ LEGACY_SETTINGS = [
     ['USE_OFFSET_COVERTER', [0], 'No longer supported, not needed with modern v8 versions'],
     ['ASYNCIFY_LAZY_LOAD_CODE', [0], 'No longer supported'],
     ['USE_WEBGPU', [0], 'No longer supported; replaced by --use-port=emdawnwebgpu, which implements a newer (but incompatible) version of webgpu.h - see tools/ports/emdawnwebgpu.py'],
+    ['RUNTIME_LINKED_LIBS', [[]], 'list shared libraries directly on the command line instead'],
 ]
 
 user_settings: Dict[str, str] = {}


### PR DESCRIPTION
We have had this marked as deprecated since #14004 (more than 4 years).