### PR TITLE
Remove unnecessary forced exports. NFC

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -1162,8 +1162,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       '$reportUndefinedSymbols',
       '$relocateExports',
       '$GOTHandler',
-      '__heap_base',
-      '__stack_pointer',
     ]
 
     if settings.ASYNCIFY == 1:


### PR DESCRIPTION
The normal dependency system can handle including these when needed.