### PR TITLE
Update tools/maint/find_unused_settings.py. NFC

### DIFF
--- a/tools/maint/find_unused_settings.py
+++ b/tools/maint/find_unused_settings.py
@@ -18,13 +18,18 @@ from tools.settings import settings
 
 
 def main():
+  print(f'Searching {len(settings.internal_settings)} internal settings')
+  for key in settings.internal_settings:
+    cmd = ['git', 'grep', '-q', f'\\<{key}\\>', '*.mjs', '*.js', ':(exclude)src/settings.js', ':(exclude)src/settings_internal.js']
+    if subprocess.run(cmd, check=False).returncode:
+      print('NOT FOUND IN JS:', key)
+
   print(f'Searching {len(settings.attrs)} settings')
   for key in settings.attrs:
     cmd = ['git', 'grep', '-q', f'\\<{key}\\>',  ':(exclude)src/settings.js', ':(exclude)src/settings_internal.js']
-    print('CHECKING:', key)
     # git grep returns 0 if there is a match and non-zero when there is not
     if subprocess.run(cmd, check=False).returncode:
-      print('NOT FOUND: ', key)
+      print('NOT FOUND ANYWHERE:', key)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Now it also find settings that are not used in JS, so we can potentially move them from `settings_internal.js` to python-only.