### PR TITLE
Don't change getUnsharedTextDecoderView behaviour based on -Oz. NFC

### DIFF
--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -1043,9 +1043,9 @@ function getUnsharedTextDecoderView(heap, start, end) {
   // No need to worry about this in non-shared memory builds
   if (!SHARED_MEMORY) return unshared;
 
-  // If asked to get an unshared view to what we know will be a shared view, or if in -Oz,
+  // If asked to get an unshared view to what we know will be a shared view
   // then unconditionally do a .slice() for smallest code size.
-  if (SHRINK_LEVEL == 2 || heap == 'HEAPU8') return shared;
+  if (heap.startsWith('HEAP')) return shared;
 
   // Otherwise, generate a runtime type check: must do a .slice() if looking at
   // a SAB, or can use .subarray() otherwise.  Note: We compare with

--- a/test/codesize/audio_worklet_wasm.expected.js
+++ b/test/codesize/audio_worklet_wasm.expected.js
@@ -113,7 +113,7 @@ var K = [], L = a => {
     O[a].connect(c.destination || c, b, h);
 }, O = {}, Q = 0, R = globalThis.TextDecoder && new TextDecoder, S = (a = 0) => {
     for (var c = I, b = a, h = b + void 0; c[b] && !(b >= h); ) ++b;
-    if (16 < b - a && c.buffer && R) return R.decode(c.slice(a, b));
+    if (16 < b - a && c.buffer && R) return R.decode(c.buffer instanceof ArrayBuffer ? c.subarray(a, b) : c.slice(a, b));
     for (h = ""; a < b; ) {
         var d = c[a++];
         if (d & 128) {

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7609,
-  "a.out.js.gz": 3762,
+  "a.out.js": 7657,
+  "a.out.js.gz": 3775,
   "a.out.nodebug.wasm": 19599,
   "a.out.nodebug.wasm.gz": 9063,
-  "total": 27208,
-  "total_gz": 12825,
+  "total": 27256,
+  "total_gz": 12838,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 8036,
-  "a.out.js.gz": 3962,
+  "a.out.js": 8084,
+  "a.out.js.gz": 3977,
   "a.out.nodebug.wasm": 19600,
   "a.out.nodebug.wasm.gz": 9064,
-  "total": 27636,
-  "total_gz": 13026,
+  "total": 27684,
+  "total_gz": 13041,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/codesize/test_minimal_runtime_code_size_audio_worklet.json
+++ b/test/codesize/test_minimal_runtime_code_size_audio_worklet.json
@@ -1,10 +1,10 @@
 {
   "a.html": 519,
   "a.html.gz": 357,
-  "a.js": 4235,
-  "a.js.gz": 2170,
+  "a.js": 4283,
+  "a.js.gz": 2184,
   "a.wasm": 1329,
   "a.wasm.gz": 895,
-  "total": 6083,
-  "total_gz": 3422
+  "total": 6131,
+  "total_gz": 3436
 }


### PR DESCRIPTION
Core semantics should not change with `-Oz`.

I also widened the heursitc so we assume shared for all `HEAPXX` object which should mitigate any size regression here.

There is only a single caller of `getUnsharedTextDecoderView` that doesn't pass a `HEAP` object: UTF8ArrayToString.  So this change should have very little code size impact.