### PR TITLE
Fix nested dynamic library loading via RPATH

### DIFF
--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1051,7 +1051,7 @@ var LibraryDylink = {
 #endif
     }
     var rpathResolved = (rpath?.paths || []).map((p) => replaceORIGIN(rpath?.parentLibPath, p));
-    return withStackSave(() => {
+    var result = withStackSave(() => {
       // In dylink.c we use: `char buf[2*NAME_MAX+2];` and NAME_MAX is 255.
       // So we use the same size here.
       var bufSize = 2*255 + 2;
@@ -1061,6 +1061,7 @@ var LibraryDylink = {
       var resLibNameC = __emscripten_find_dylib(buf, rpathC, libNameC, bufSize);
       return resLibNameC ? UTF8ToString(resLibNameC) : undefined;
     });
+    return FS.lookupPath(result).path;
   },
 #endif // FILESYSTEM
 
@@ -1168,6 +1169,7 @@ var LibraryDylink = {
       dbg(`checking filesystem: ${libName}: ${f ? 'found' : 'not found'}`);
 #endif
       if (f) {
+        libName = f;
         var libData = FS.readFile(f, {encoding: 'binary'});
         return flags.loadAsync ? Promise.resolve(libData) : libData;
       }


### PR DESCRIPTION
There is a bug with dynamic library loading. Suppose liba.so is on LD_LIBRARY_PATH and it has an RPATH of `$ORIGIN/other_dir` and loads `libb.so` from other_dir. Then suppose `libb.so` has an RPATH of `$ORIGIN` and wants to load `libc.so` also from `other_dir`.

Before this PR this doesn't work. The problem is that `flags.rpath.parentLibPath` is set to `libb.so` and we replace $ORIGIN with `PATH.dirname(parentLibName)` which is `.`. So unless `other_dir` is on the `LD_LIBRARY_PATH` or is the current working directory, loading will fail.

The fix: if `findLibraryFS()` returns a value that is not `undefined`, replace `libName` with the returned value.