### PR TITLE
Remove unused argument from autoResumeAudioContext

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1711,16 +1711,9 @@ addToLibrary({
   // input events on, and registers a context resume() for them. This lets
   // audio work properly in an automatic way, as browsers won't let audio run
   // without user interaction.
-  // If @elements is not provided, we default to the document and canvas
-  // elements, which handle common use cases.
-  // TODO(sbc): Remove seemingly unused elements argument
-  $autoResumeAudioContext__docs: '/** @param {Array<Object>=} elements */',
-  $autoResumeAudioContext: (ctx, elements) => {
-    if (!elements) {
-      elements = [document, document.getElementById('canvas')];
-    }
+  $autoResumeAudioContext: (ctx) => {
     for (var event of ['keydown', 'mousedown', 'touchstart']) {
-      for (var element of elements) {
+      for (var element of [document, document.getElementById('canvas')]) {
         element?.addEventListener(event, () => {
           if (ctx.state === 'suspended') ctx.resume();
         }, { 'once': true });

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 245496,
+  "a.out.js": 245483,
   "a.out.nodebug.wasm": 574067,
-  "total": 819563,
+  "total": 819550,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
There are 3 callers of this function internally, and non of them pass more than one arg.

This fixes a TODO from 2022.