### PR TITLE
Prefer `for..of` over `forEach` with lambdas. NFC

### DIFF
--- a/src/lib/libatomic.js
+++ b/src/lib/libatomic.js
@@ -128,9 +128,9 @@ addToLibrary({
   emscripten_atomic_cancel_all_wait_asyncs__deps: ['$liveAtomicWaitAsyncs'],
   emscripten_atomic_cancel_all_wait_asyncs: () => {
     let waitAsyncs = Object.values(liveAtomicWaitAsyncs);
-    waitAsyncs.forEach((address) => {
+    for (var address of waitAsyncs) {
       Atomics.notify(HEAP32, {{{ getHeapOffset('address', 'i32') }}});
-    });
+    }
     liveAtomicWaitAsyncs = {};
     return waitAsyncs.length;
   },
@@ -138,13 +138,13 @@ addToLibrary({
   emscripten_atomic_cancel_all_wait_asyncs_at_address__deps: ['$liveAtomicWaitAsyncs'],
   emscripten_atomic_cancel_all_wait_asyncs_at_address: (address) => {
     let numCancelled = 0;
-    Object.keys(liveAtomicWaitAsyncs).forEach((waitToken) => {
-      if (liveAtomicWaitAsyncs[waitToken] == address) {
+    for (var [waitToken, waitAddress] of Object.entries(liveAtomicWaitAsyncs)) {
+      if (waitAddress == address) {
         Atomics.notify(HEAP32, {{{ getHeapOffset('address', 'i32') }}});
         delete liveAtomicWaitAsyncs[waitToken];
         numCancelled++;
       }
-    });
+    }
     return numCancelled;
   },
 

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1714,18 +1714,18 @@ addToLibrary({
   // If @elements is not provided, we default to the document and canvas
   // elements, which handle common use cases.
   // TODO(sbc): Remove seemingly unused elements argument
-  $autoResumeAudioContext__docs: '/** @param {Object=} elements */',
+  $autoResumeAudioContext__docs: '/** @param {Array<Object>=} elements */',
   $autoResumeAudioContext: (ctx, elements) => {
     if (!elements) {
       elements = [document, document.getElementById('canvas')];
     }
-    ['keydown', 'mousedown', 'touchstart'].forEach((event) => {
-      elements.forEach((element) => {
+    for (var event of ['keydown', 'mousedown', 'touchstart']) {
+      for (var element of elements) {
         element?.addEventListener(event, () => {
           if (ctx.state === 'suspended') ctx.resume();
         }, { 'once': true });
-      });
-    });
+      }
+    }
   },
 
 #if DYNCALLS || !WASM_BIGINT

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -978,7 +978,9 @@ var LibraryDylink = {
         .then(loadModule);
     }
 
-    metadata.neededDynlibs.forEach((needed) => loadDynamicLibrary(needed, flags, localScope));
+    for (var needed of metadata.neededDynlibs) {
+      loadDynamicLibrary(needed, flags, localScope)
+    }
     return loadModule();
   },
 

--- a/src/lib/libembind.js
+++ b/src/lib/libembind.js
@@ -897,20 +897,20 @@ var LibraryEmbind = {
     var rawDestructor = reg.rawDestructor;
 
     whenDependentTypesAreResolved([rawTupleType], elementTypes, (elementTypes) => {
-      elements.forEach((elt, i) => {
-        var getterReturnType = elementTypes[i];
-        var getter = elt.getter;
-        var getterContext = elt.getterContext;
-        var setterArgumentType = elementTypes[i + elementsLength];
-        var setter = elt.setter;
-        var setterContext = elt.setterContext;
+      for (const [i, elt] of elements.entries()) {
+        const getterReturnType = elementTypes[i];
+        const getter = elt.getter;
+        const getterContext = elt.getterContext;
+        const setterArgumentType = elementTypes[i + elementsLength];
+        const setter = elt.setter;
+        const setterContext = elt.setterContext;
         elt.read = (ptr) => getterReturnType.fromWireType(getter(getterContext, ptr));
         elt.write = (ptr, o) => {
           var destructors = [];
           setter(setterContext, ptr, setterArgumentType.toWireType(destructors, o));
           runDestructors(destructors);
         };
-      });
+      }
 
       return [{
         name: reg.name,
@@ -998,25 +998,23 @@ var LibraryEmbind = {
               concat(fieldRecords.map((field) => field.setterArgumentType));
     whenDependentTypesAreResolved([structType], fieldTypes, (fieldTypes) => {
       var fields = {};
-      fieldRecords.forEach((field, i) => {
-        var fieldName = field.fieldName;
-        var getterReturnType = fieldTypes[i];
-        var optional = fieldTypes[i].optional;
-        var getter = field.getter;
-        var getterContext = field.getterContext;
-        var setterArgumentType = fieldTypes[i + fieldRecords.length];
-        var setter = field.setter;
-        var setterContext = field.setterContext;
-        fields[fieldName] = {
+      for (var [i, field] of fieldRecords.entries()) {
+        const getterReturnType = fieldTypes[i];
+        const getter = field.getter;
+        const getterContext = field.getterContext;
+        const setterArgumentType = fieldTypes[i + fieldRecords.length];
+        const setter = field.setter;
+        const setterContext = field.setterContext;
+        fields[field.fieldName] = {
           read: (ptr) => getterReturnType.fromWireType(getter(getterContext, ptr)),
           write: (ptr, o) => {
             var destructors = [];
             setter(setterContext, ptr, setterArgumentType.toWireType(destructors, o));
             runDestructors(destructors);
           },
-          optional,
+          optional: getterReturnType.optional,
         };
-      });
+      }
 
       return [{
         name: reg.name,
@@ -2101,11 +2099,11 @@ var LibraryEmbind = {
     var baseClassPrototype = baseClass.instancePrototype;
     var baseConstructor = registeredClass.baseClass.constructor;
     var ctor = createNamedFunction(constructorName, function(...args) {
-      registeredClass.baseClass.pureVirtualFunctions.forEach(function(name) {
+      for (var name of registeredClass.baseClass.pureVirtualFunctions) {
         if (this[name] === baseClassPrototype[name]) {
           throw new PureVirtualError(`Pure virtual function ${name} must be implemented in JavaScript`);
         }
-      }.bind(this));
+      }
 
       Object.defineProperty(this, '__parent', {
         value: wrapperPrototype

--- a/src/lib/libembind_shared.js
+++ b/src/lib/libembind_shared.js
@@ -71,7 +71,7 @@ var LibraryEmbindShared = {
     var typeConverters = new Array(dependentTypes.length);
     var unregisteredTypes = [];
     var registered = 0;
-    dependentTypes.forEach((dt, i) => {
+    for (let [i, dt] of dependentTypes.entries()) {
       if (registeredTypes.hasOwnProperty(dt)) {
         typeConverters[i] = registeredTypes[dt];
       } else {
@@ -87,7 +87,7 @@ var LibraryEmbindShared = {
           }
         });
       }
-    });
+    }
     if (0 === unregisteredTypes.length) {
       onComplete(typeConverters);
     }

--- a/src/lib/libfs.js
+++ b/src/lib/libfs.js
@@ -583,12 +583,13 @@ FS.staticInit();`;
       };
 
       // sync all mounts
-      mounts.forEach((mount) => {
-        if (!mount.type.syncfs) {
-          return done(null);
+      for (var mount of mounts) {
+        if (mount.type.syncfs) {
+          mount.type.syncfs(mount, populate, done);
+        } else {
+          done(null);
         }
-        mount.type.syncfs(mount, populate, done);
-      });
+      }
     },
     mount(type, opts, mountpoint) {
 #if ASSERTIONS
@@ -657,9 +658,7 @@ FS.staticInit();`;
       var mount = node.mounted;
       var mounts = FS.getMounts(mount);
 
-      Object.keys(FS.nameTable).forEach((hash) => {
-        var current = FS.nameTable[hash];
-
+      for (var [hash, current] of Object.entries(FS.nameTable)) {
         while (current) {
           var next = current.name_next;
 
@@ -669,7 +668,7 @@ FS.staticInit();`;
 
           current = next;
         }
-      });
+      }
 
       // no longer a mountpoint
       node.mounted = null;
@@ -1850,14 +1849,12 @@ FS.staticInit();`;
       });
       // override each stream op with one that tries to force load the lazy file first
       var stream_ops = {};
-      var keys = Object.keys(node.stream_ops);
-      keys.forEach((key) => {
-        var fn = node.stream_ops[key];
+      for (const [key, fn] of Object.entries(node.stream_ops)) {
         stream_ops[key] = (...args) => {
           FS.forceLoadFile(node);
           return fn(...args);
         };
-      });
+      }
       function writeChunks(stream, buffer, offset, length, position) {
         var contents = stream.node.contents;
         if (position >= contents.length)

--- a/src/lib/libglemu.js
+++ b/src/lib/libglemu.js
@@ -626,10 +626,10 @@ var LibraryGLEmulation = {
         if (GL.debug) {
           dbg('[using program with shaders]');
           if (program) {
-            GL.programShaders[program].forEach((shader) => {
+            for (var shader of GL.programShaders[program]) {
               dbg(`  shader ${shader}, original source: ${GL.shaderOriginalSources[shader]}`);
               dbg(`         Source: ${GL.shaderSources[shader]}`);
-            });
+            }
           }
         }
 #endif

--- a/src/lib/libidbfs.js
+++ b/src/lib/libidbfs.js
@@ -114,7 +114,9 @@ addToLibrary({
       });
     },
     quit: () => {
-      Object.values(IDBFS.dbs).forEach((value) => value.close());
+      for (var value of Object.values(IDBFS.dbs)) {
+        value.close()
+      }
       IDBFS.dbs = {};
     },
     getDB: (name, callback) => {
@@ -312,22 +314,21 @@ addToLibrary({
       var total = 0;
 
       var create = [];
-      Object.keys(src.entries).forEach((key) => {
-        var e = src.entries[key];
+      for (var [key, e] of Object.entries(src.entries)) {
         var e2 = dst.entries[key];
         if (!e2 || e['timestamp'].getTime() != e2['timestamp'].getTime()) {
           create.push(key);
           total++;
         }
-      });
+      }
 
       var remove = [];
-      Object.keys(dst.entries).forEach((key) => {
+      for (var key of Object.keys(dst.entries)) {
         if (!src.entries[key]) {
           remove.push(key);
           total++;
         }
-      });
+      }
 
       if (!total) {
         return callback(null);
@@ -359,7 +360,7 @@ addToLibrary({
 
       // sort paths in ascending order so directory entries are created
       // before the files inside them
-      create.sort().forEach((path) => {
+      for (const path of create.sort()) {
         if (dst.type === 'local') {
           IDBFS.loadRemoteEntry(store, path, (err, entry) => {
             if (err) return done(err);
@@ -371,17 +372,17 @@ addToLibrary({
             IDBFS.storeRemoteEntry(store, path, entry, done);
           });
         }
-      });
+      }
 
       // sort paths in descending order so files are deleted before their
       // parent directories
-      remove.sort().reverse().forEach((path) => {
+      for (var path of remove.sort().reverse()) {
         if (dst.type === 'local') {
           IDBFS.removeLocalEntry(path, done);
         } else {
           IDBFS.removeRemoteEntry(store, path, done);
         }
-      });
+      }
     }
   }
 });

--- a/src/lib/libwasi.js
+++ b/src/lib/libwasi.js
@@ -119,7 +119,9 @@ var WasiLibrary = {
 #if MAIN_READS_PARAMS
     {{{ makeSetValue('pargc', 0, 'mainArgs.length', SIZE_TYPE) }}};
     var bufSize = 0;
-    mainArgs.forEach((arg) => bufSize += arg.length + 1);
+    for (var arg of mainArgs) {
+      bufSize += arg.length + 1;
+    }
     {{{ makeSetValue('pargv_buf_size', 0, 'bufSize', SIZE_TYPE) }}};
 #else
     {{{ makeSetValue('pargc', 0, '0', SIZE_TYPE) }}};
@@ -132,12 +134,12 @@ var WasiLibrary = {
   args_get: (argv, argv_buf) => {
 #if MAIN_READS_PARAMS
     var bufSize = 0;
-    mainArgs.forEach((arg, i) => {
+    for (let [i, arg] of mainArgs.entries()) {
       var ptr = argv_buf + bufSize;
       {{{ makeSetValue('argv', `i*${POINTER_SIZE}`, 'ptr', '*') }}};
       stringToAscii(arg, ptr);
       bufSize += arg.length + 1;
-    });
+    }
 #endif
     return 0;
   },

--- a/src/lib/libwasmfs_node.js
+++ b/src/lib/libwasmfs_node.js
@@ -74,7 +74,7 @@ addToLibrary({
     let path = UTF8ToString(path_p);
     return wasmfsTry(() => {
       let entries = fs.readdirSync(path, { withFileTypes: true });
-      entries.forEach((entry) => {
+      for (var entry of entries) {
         let sp = stackSave();
         let name = stringToUTF8OnStack(entry.name);
         let type;
@@ -90,7 +90,7 @@ addToLibrary({
         __wasmfs_node_record_dirent(vec, name, type);
         stackRestore(sp);
         // implicitly return 0
-      });
+      }
     });
   },
 

--- a/src/lib/libwebgl.js
+++ b/src/lib/libwebgl.js
@@ -1236,14 +1236,14 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
         GLctx.disjointTimerQueryExt = GLctx.getExtension("EXT_disjoint_timer_query");
       }
 
-      getEmscriptenSupportedExtensions(GLctx).forEach((ext) => {
+      for (var ext of getEmscriptenSupportedExtensions(GLctx)) {
         // WEBGL_lose_context, WEBGL_debug_renderer_info and WEBGL_debug_shaders
         // are not enabled by default.
         if (!ext.includes('lose_context') && !ext.includes('debug')) {
           // Call .getExtension() to enable that extension permanently.
           GLctx.getExtension(ext);
         }
-      });
+      }
     },
 #endif
 
@@ -3504,9 +3504,8 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
 
 #if GL_EXPLICIT_UNIFORM_LOCATION
     // Collect explicit uniform locations from the vertex and fragment shaders.
-    [program['vs'], program['fs']].forEach((s) => {
-      Object.keys(s.explicitUniformLocations).forEach((shaderLocation) => {
-        var loc = s.explicitUniformLocations[shaderLocation];
+    for (var s of [program['vs'], program['fs']]) {
+      for (var [shaderLocation, loc] of Object.entries(s.explicitUniformLocations)) {
         // Record each explicit uniform location temporarily as a non-array uniform
         // with size=1. This is not true, but on the first glGetUniformLocation() call
         // the array sizes will get populated to correct sizes.
@@ -3518,21 +3517,21 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
         // Make sure we will never automatically assign locations within the range
         // used for explicit layout(location=x) variables.
         program.uniformIdCounter = Math.max(program.uniformIdCounter, loc + 1);
-      });
-    });
+      }
+    }
 #endif
 
 #if GL_EXPLICIT_UNIFORM_BINDING
     function copyKeys(dst, src) {
-      Object.keys(src).forEach((key) => { dst[key] = src[key] });
+      for (var key of Object.keys(src)) { dst[key] = src[key] };
     }
     // Collect sampler and ubo binding locations from the vertex and fragment shaders.
     program.explicitUniformBindings = {};
     program.explicitSamplerBindings = {};
-    [program['vs'], program['fs']].forEach((s) => {
+    for (var s of [program['vs'], program['fs']]) {
       copyKeys(program.explicitUniformBindings, s.explicitUniformBindings);
       copyKeys(program.explicitSamplerBindings, s.explicitSamplerBindings);
-    });
+    }
     // Record that we need to apply these explicit bindings when glUseProgram() is
     // first called on this program.
     program.explicitProgramBindingsApplied = 0;
@@ -3561,8 +3560,7 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
 #if MIN_WEBGL_VERSION < 2
       if (GL.currentContext.version >= 2) {
 #endif
-        Object.keys(p.explicitUniformBindings).forEach((ubo) => {
-          var bindings = p.explicitUniformBindings[ubo];
+        for (var [ubo, bindings] of Object.entries(p.explicitUniformBindings)) {
           for (var i = 0; i < bindings[1]; ++i) {
             var blockIndex = GLctx.getUniformBlockIndex(p, ubo + (bindings[1] > 1 ? `[${i}]` : ''));
 #if GL_DEBUG
@@ -3570,20 +3568,19 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
 #endif
             GLctx.uniformBlockBinding(p, blockIndex, bindings[0]+i);
           }
-        });
+        }
 #if MIN_WEBGL_VERSION < 2
       }
 #endif
 #endif
-      Object.keys(p.explicitSamplerBindings).forEach((sampler) => {
-        var bindings = p.explicitSamplerBindings[sampler];
+      for (var [sampler, bindings] of Object.entries(p.explicitSamplerBindings)) {
         for (var i = 0; i < bindings[1]; ++i) {
 #if GL_DEBUG
           dbg('Applying initial sampler binding point ' + (bindings[0]+i) + ' for sampler "' + sampler + (i > 0 ? '['+i+']' : '') +  '"');
 #endif
           GLctx.uniform1i(GLctx.getUniformLocation(p, sampler + (i ? `[${i}]` : '')), bindings[0]+i);
         }
-      });
+      }
       p.explicitProgramBindingsApplied = 1;
     }
   },
@@ -4310,7 +4307,7 @@ function createGLPassthroughFunctions(lib, funcs) {
     const args = range(num).map((i) => 'x' + i ).join(', ');
     const stub = `(${args}) => GLctx.NAME(${args})`;
     const sigEnd = range(num).map(() => 'i').join('');
-    names.split(' ').forEach((name) => {
+    for (var name of names.split(' ')) {
       let sig;
       if (name.endsWith('*')) {
         name = name.slice(0, -1);
@@ -4327,7 +4324,7 @@ function createGLPassthroughFunctions(lib, funcs) {
       assert(!(cName in lib), "Cannot reimplement the existing function " + cName);
       lib[cName] = eval(stub.replace('NAME', name));
       assert(lib[cName + '__sig'] || LibraryManager.library[cName + '__sig'], 'missing sig for ' + cName);
-    });
+    }
   }
 }
 

--- a/src/lib/libworkerfs.js
+++ b/src/lib/libworkerfs.js
@@ -37,19 +37,19 @@ addToLibrary({
         var parts = path.split('/');
         return parts[parts.length-1];
       }
-      // We also accept FileList here, by using Array.prototype
-      Array.prototype.forEach.call(mount.opts["files"] || [], function(file) {
+      // We also accept FileList here
+      for (var file of (mount.opts["files"] || [])) {
         WORKERFS.createNode(ensureParent(file.name), base(file.name), WORKERFS.FILE_MODE, 0, file, file.lastModifiedDate);
-      });
-      (mount.opts["blobs"] || []).forEach((obj) => {
+      }
+      for (var obj of (mount.opts["blobs"] || [])) {
         WORKERFS.createNode(ensureParent(obj["name"]), base(obj["name"]), WORKERFS.FILE_MODE, 0, obj["data"]);
-      });
-      (mount.opts["packages"] || []).forEach((pack) => {
-        pack['metadata'].files.forEach((file) => {
+      }
+      for (var pack of (mount.opts["packages"] || [])) {
+        for (var file of pack['metadata'].files) {
           var name = file.filename.slice(1); // remove initial slash
           WORKERFS.createNode(ensureParent(name), base(name), WORKERFS.FILE_MODE, 0, pack['blob'].slice(file.start, file.end));
-        });
-      });
+        }
+      }
       return root;
     },
     createNode(parent, name, mode, dev, contents, mtime) {

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -64,10 +64,10 @@ var mainArgs = undefined;
   var argc = args.length;
   var argv = stackAlloc((argc + 1) * {{{ POINTER_SIZE }}});
   var argv_ptr = argv;
-  args.forEach((arg) => {
+  for (var arg of args) {
     {{{ makeSetValue('argv_ptr', 0, 'stringToUTF8OnStack(arg)', '*') }}};
     argv_ptr += {{{ POINTER_SIZE }}};
-  });
+  }
   {{{ makeSetValue('argv_ptr', 0, 0, '*') }}};
 #else
   var argc = 0;
@@ -264,7 +264,7 @@ function checkUnflushedContent() {
 #endif
 #if '$FS' in addedLibraryItems && '$TTY' in addedLibraryItems
     // also flush in the JS FS layer
-    ['stdout', 'stderr'].forEach((name) => {
+    for (var name of ['stdout', 'stderr']) {
       var info = FS.analyzePath('/dev/' + name);
       if (!info) return;
       var stream = info.object;
@@ -273,7 +273,7 @@ function checkUnflushedContent() {
       if (tty?.output?.length) {
         has = true;
       }
-    });
+    }
 #endif
   } catch(e) {}
   out = oldOut;

--- a/src/source_map_support.js
+++ b/src/source_map_support.js
@@ -43,8 +43,8 @@ class WasmSourceMap {
     }
 
     var offset = 0, src = 0, line = 1, col = 1, name = 0;
-    sourceMap.mappings.split(',').forEach(function (segment, index) {
-      if (!segment) return;
+    for (const [index, segment] of sourceMap.mappings.split(',').entries()) {
+      if (!segment) continue;
       var data = decodeVLQ(segment);
       var info = {};
 
@@ -55,7 +55,7 @@ class WasmSourceMap {
       if (data.length >= 5) info.name = name += data[4];
       this.mapping[offset] = info;
       this.offsets.push(offset);
-    }, this);
+    }
     this.offsets.sort((a, b) => a - b);
   }
 

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22552,
-  "a.out.js.gz": 9344,
+  "a.out.js": 22540,
+  "a.out.js.gz": 9333,
   "a.out.nodebug.wasm": 1681,
   "a.out.nodebug.wasm.gz": 960,
-  "total": 24233,
-  "total_gz": 10304,
+  "total": 24221,
+  "total_gz": 10293,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26568,
-  "a.out.js.gz": 11362,
+  "a.out.js": 26552,
+  "a.out.js.gz": 11345,
   "a.out.nodebug.wasm": 17757,
   "a.out.nodebug.wasm.gz": 8972,
-  "total": 44325,
-  "total_gz": 20334,
+  "total": 44309,
+  "total_gz": 20317,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 245508,
+  "a.out.js": 245496,
   "a.out.nodebug.wasm": 574067,
-  "total": 819575,
+  "total": 819563,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_mem_O3.json
+++ b/test/codesize/test_codesize_mem_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4360,
-  "a.out.js.gz": 2097,
+  "a.out.js": 4350,
+  "a.out.js.gz": 2094,
   "a.out.nodebug.wasm": 5260,
   "a.out.nodebug.wasm.gz": 2418,
-  "total": 9620,
-  "total_gz": 4515,
+  "total": 9610,
+  "total_gz": 4512,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/codesize/test_codesize_mem_O3_grow.json
+++ b/test/codesize/test_codesize_mem_O3_grow.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4645,
-  "a.out.js.gz": 2250,
+  "a.out.js": 4635,
+  "a.out.js.gz": 2243,
   "a.out.nodebug.wasm": 5261,
   "a.out.nodebug.wasm.gz": 2418,
-  "total": 9906,
-  "total_gz": 4668,
+  "total": 9896,
+  "total_gz": 4661,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/codesize/test_codesize_mem_O3_grow_standalone.json
+++ b/test/codesize/test_codesize_mem_O3_grow_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4090,
-  "a.out.js.gz": 1967,
+  "a.out.js": 4102,
+  "a.out.js.gz": 1990,
   "a.out.nodebug.wasm": 5547,
   "a.out.nodebug.wasm.gz": 2597,
-  "total": 9637,
-  "total_gz": 4564,
+  "total": 9649,
+  "total_gz": 4587,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/codesize/test_codesize_mem_O3_standalone.json
+++ b/test/codesize/test_codesize_mem_O3_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4023,
-  "a.out.js.gz": 1930,
+  "a.out.js": 4035,
+  "a.out.js.gz": 1954,
   "a.out.nodebug.wasm": 5472,
   "a.out.nodebug.wasm.gz": 2538,
-  "total": 9495,
-  "total_gz": 4468,
+  "total": 9507,
+  "total_gz": 4492,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/codesize/test_minimal_runtime_code_size_hello_embind.json
+++ b/test/codesize/test_minimal_runtime_code_size_hello_embind.json
@@ -1,10 +1,10 @@
 {
   "a.html": 552,
   "a.html.gz": 373,
-  "a.js": 7255,
-  "a.js.gz": 3314,
+  "a.js": 7262,
+  "a.js.gz": 3324,
   "a.wasm": 7315,
   "a.wasm.gz": 3371,
-  "total": 15122,
-  "total_gz": 7058
+  "total": 15129,
+  "total_gz": 7068
 }


### PR DESCRIPTION
I imagine theses usages of `forEach` predated the use of `for..of` in our codes and the `for..in` loops were more clumsy.

Using simple `for` loops here is generally faster at runtime and simpler to reason about (since `return` is not needed in place of `continue` and the binding of `this` is not hard to reason about, its just the same as the surrounding code).

Its also a codesize win.