### PR TITLE
Fix for emrun --kill-exit

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -578,8 +578,6 @@ class HTTPWebServer(socketserver.ThreadingMixIn, HTTPServer):
 
 # Processes HTTP request back to the browser.
 class HTTPHandler(SimpleHTTPRequestHandler):
-  protocol_version = 'HTTP/1.1'  # noqa: DC01
-
   def send_head(self):
     global page_last_served_time
     path = self.translate_path(self.path)


### PR DESCRIPTION
This was broken by #25359.  I though I was just moving this assignment to the correct place, but it seems like it broken emrun because the 1.1 protocol was not actually enabled before.  Once enabled it seems like this was causing `httpd.server_close` to hang forever.

Fixes: #25654