### PR TITLE
Fix issue with transitive/recursive building of PIC libraries

### DIFF
--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -780,6 +780,12 @@ fi
     self.run_process([EMBUILDER, 'build', f'{external_port_path}:dependency=sdl2', '--force'])
     self.assertExists(os.path.join(config.CACHE, 'sysroot', 'lib', 'wasm32-emscripten', 'lib_external-sdl2.a'))
 
+  def test_embuilder_transitive_pic(self):
+    restore_and_set_up()
+    self.run_process([EMBUILDER, 'clear', 'sdl2*'])
+    self.run_process([EMBUILDER, '--pic', 'clear', 'sdl2*'])
+    self.run_process([EMCC, '-sMAIN_MODULE=2', '-sUSE_SDL=2', '-sUSE_SDL_GFX=2', test_file('hello_world.c')])
+
   def test_binaryen_version(self):
     restore_and_set_up()
     with open(EM_CONFIG, 'a') as f:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -63,7 +63,11 @@ def get_base_cflags(build_dir, force_object_files=False, preprocess=True):
   if settings.LTO and not force_object_files:
     flags += ['-flto=' + settings.LTO]
   if settings.RELOCATABLE or settings.MAIN_MODULE:
-    flags += ['-fPIC']
+    # Explictly include `-sRELOCATABLE` when building system libraries.
+    # `-fPIC` alone is not enough to configure trigger the building and
+    # caching of `pic` libraries (see `get_lib_dir` in `cache.py`)
+    # FIXME(sbc): `-fPIC` should really be enough here.
+    flags += ['-fPIC', '-sRELOCATABLE']
     if preprocess:
       flags += ['-DEMSCRIPTEN_DYNAMIC_LINKING']
   if settings.MEMORY64:


### PR DESCRIPTION
This issue was introduces in #25522 when `-sRELOCATABLE` was removed from `get_base_cflags.

This is a somewhat tricky to reproduce / understand issue with transitive library building:

1. User attempts to compile program using SDL2 + SDL2_GFX.
2. `emcc` attempts to builds all needed libraries in reverse dependency order.  And ends up with the follows sequence:
  1. libsdl2-pic
  2. libsdl2_gfx-pic
3. `emcc` builds libsdl2-pic
4. `emcc` builds libsdl2_gfx-pic. The command that it constructs when building each source file looks like `emcc -fPIC gfx.c -sUSE_SDL=2`. However because neither `-sMAIN_MODULE` nor `-sRELOCATABLE` were specified this `emcc` command will not try to build the non-PIC version of libsdl2.  At this point the compiler will crash with:

    `AssertionError: attempt to lock the cache while a parent process is holding the lock (sysroot/lib/wasm32-emscripten/libSDL2.a)`

This issue is hard to reproduce because if libsdl2 is already built it will not trigger the issue.