### PR TITLE
Make command line options global. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -40,7 +40,7 @@ from tools import (
   system_libs,
   utils,
 )
-from tools.cmdline import CLANG_FLAGS_WITH_ARGS
+from tools.cmdline import CLANG_FLAGS_WITH_ARGS, options
 from tools.response_file import substitute_response_files
 from tools.settings import (
   COMPILE_TIME_SETTINGS,
@@ -225,7 +225,7 @@ emcc: supported targets: llvm bitcode, WebAssembly, NOT elf
 
   ## Process argument and setup the compiler
   state = EmccState(args)
-  options, newargs = cmdline.parse_arguments(state.orig_args)
+  newargs = cmdline.parse_arguments(state.orig_args)
 
   if not shared.SKIP_SUBPROCS:
     shared.check_sanity()
@@ -290,7 +290,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   # settings until we reach the linking phase.
   settings.limit_settings(COMPILE_TIME_SETTINGS)
 
-  phase_setup(options, state)
+  phase_setup(state)
 
   if '-print-resource-dir' in args or any(a.startswith('--print-prog-name') for a in args):
     shared.exec_process([clang] + compile.get_cflags(tuple(args)) + args)
@@ -384,7 +384,7 @@ def separate_linker_flags(newargs):
 
 
 @ToolchainProfiler.profile_block('setup')
-def phase_setup(options, state):
+def phase_setup(state):
   """Second phase: configure and setup the compiler based on the specified settings and arguments.
   """
 

--- a/emscan-deps.py
+++ b/emscan-deps.py
@@ -16,7 +16,7 @@ from tools import cmdline, compile, shared
 argv = sys.argv[1:]
 
 # Parse and discard any emcc-specific flags (e.g. -sXXX).
-newargs = cmdline.parse_arguments(argv)[1]
+newargs = cmdline.parse_arguments(argv)
 
 # Add any clang flags that emcc would add.
 newargs += compile.get_cflags(tuple(argv))

--- a/tools/cmdline.py
+++ b/tools/cmdline.py
@@ -115,6 +115,10 @@ class EmccOptions:
   valid_abspaths: List[str] = []
 
 
+# Global/singleton EmccOptions
+options = EmccOptions()
+
+
 def is_int(s):
   try:
     int(s)
@@ -152,7 +156,7 @@ def version_string():
   return f'emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) {utils.EMSCRIPTEN_VERSION}{revision_suffix}'
 
 
-def is_valid_abspath(options, path_name):
+def is_valid_abspath(path_name):
   # Any path that is underneath the emscripten repository root must be ok.
   if utils.normalize_path(path_name).startswith(utils.normalize_path(utils.path_from_root())):
     return True
@@ -226,7 +230,6 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
 
   To revalidate these numbers, run `ruff check --select=C901,PLR091`.
   """
-  options = EmccOptions()
   should_exit = False
   skip = False
 
@@ -496,7 +499,7 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
       path_name = arg[2:]
       # Look for '/' explicitly so that we can also diagnose identically if -I/foo/bar is passed on Windows.
       # Python since 3.13 does not treat '/foo/bar' as an absolute path on Windows.
-      if (path_name.startswith('/') or os.path.isabs(path_name)) and not is_valid_abspath(options, path_name):
+      if (path_name.startswith('/') or os.path.isabs(path_name)) and not is_valid_abspath(path_name):
         # Of course an absolute path to a non-system-specific library or header
         # is fine, and you can ignore this warning. The danger are system headers
         # that are e.g. x86 specific and non-portable. The emscripten bundled
@@ -641,8 +644,7 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
   if should_exit:
     sys.exit(0)
 
-  newargs = [a for a in newargs if a]
-  return options, newargs
+  return [a for a in newargs if a]
 
 
 def expand_byte_size_suffixes(value):
@@ -854,7 +856,7 @@ def parse_arguments(args):
       newargs[i] += newargs[i + 1]
       newargs[i + 1] = ''
 
-  options, newargs = parse_args(newargs)
+  newargs = parse_args(newargs)
 
   if options.post_link or options.oformat == OFormat.BARE:
     diagnostics.warning('experimental', '--oformat=bare/--post-link are experimental and subject to change.')
@@ -874,4 +876,4 @@ def parse_arguments(args):
   # Apply -s settings in newargs here (after optimization levels, so they can override them)
   apply_user_settings()
 
-  return options, newargs
+  return newargs


### PR DESCRIPTION
Refactor only.  This should allows us to start removing some of the internal settings that are currently used to communicate command line flags from part of the python codebase to another.  We should only need to add internal settings when a setting needs to be available in the JS compiler.