### PR TITLE
Revive and improve the JS compiler brenchmarker profiler. NFC

### DIFF
--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -39,6 +39,7 @@ import {
   warnOnce,
   warningOccured,
   localFile,
+  timer,
 } from './utility.mjs';
 import {LibraryManager, librarySymbols, nativeAliases} from './modules.mjs';
 
@@ -918,7 +919,9 @@ var proxiedFunctionTable = [
       }),
     );
   } else {
+    timer.start('finalCombiner')
     finalCombiner();
+    timer.stop('finalCombiner')
   }
 
   if (errorOccured()) {

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -22,6 +22,7 @@ import {
   runInMacroContext,
   mergeInto,
   localFile,
+  timer,
 } from './utility.mjs';
 import {preprocess, processMacros} from './parseTools.mjs';
 
@@ -224,6 +225,7 @@ function getTempDir() {
 }
 
 function preprocessFiles(filenames) {
+  timer.start('preprocessFiles')
   const results = {};
   for (const filename of filenames) {
     debugLog(`pre-processing JS library: ${filename}`);
@@ -237,6 +239,7 @@ function preprocessFiles(filenames) {
       popCurrentFile();
     }
   }
+  timer.stop('preprocessFiles')
   return results;
 }
 
@@ -262,15 +265,22 @@ export const LibraryManager = {
   },
 
   load() {
+    timer.start('load')
+
     assert(!this.loaded);
     this.loaded = true;
     // Save the list for has() queries later.
     this.libraries = calculateLibraries();
 
     const preprocessed = preprocessFiles(this.libraries);
+
+    timer.start('executeJS')
     for (const [filename, contents] of Object.entries(preprocessed)) {
       this.executeJSLibraryFile(filename, contents);
     }
+    timer.stop('executeJS')
+
+    timer.stop('load')
   },
 
   executeJSLibraryFile(filename, contents) {


### PR DESCRIPTION
There is a sample output:

```
$ EMPROFILE=2 ./emcc ~/test/hello.cprofiler:INFO: start block "read_ports"
profiler:INFO: block "read_ports" took 0.004 seconds
profiler:INFO: start block "main"
profiler:INFO:   start block "parse_arguments"
profiler:INFO:   block "parse_arguments" took 0.000 seconds
profiler:INFO:   start block "check_sanity"
profiler:INFO:   block "check_sanity" took 0.000 seconds
profiler:INFO:   start block "setup"
profiler:INFO:   block "setup" took 0.000 seconds
profiler:INFO:   start block "compile inputs"
profiler:INFO:     start block "ensure_sysroot"
profiler:INFO:     block "ensure_sysroot" took 0.000 seconds
profiler:INFO:   block "compile inputs" took 0.067 seconds
profiler:INFO:   start block "linker_setup"
profiler:INFO:   block "linker_setup" took 0.048 seconds
profiler:INFO:   start block "calculate linker inputs"
profiler:INFO:   block "calculate linker inputs" took 0.000 seconds
profiler:INFO:   start block "calculate system libraries"
profiler:INFO:   block "calculate system libraries" took 0.001 seconds
profiler:INFO:   start block "JS symbol generation"
profiler:INFO:   block "JS symbol generation" took 0.013 seconds
profiler:INFO:   start block "link"
profiler:INFO:   block "link" took 0.079 seconds
profiler:INFO:   start block "post link"
profiler:INFO:     start block "emscript"
profiler:INFO:       start block "get_metadata"
profiler:INFO:       block "get_metadata" took 0.001 seconds
profiler:INFO:       start block "compile_javascript"
[prof] -> overall
[prof]  -> startup
[prof]   -> loadSettingsFile
[prof]   <- loadSettingsFile [1.8 ms]
[prof]   -> loadSettingsFile
[prof]   <- loadSettingsFile [1.6 ms]
[prof]   -> read settings
[prof]   <- read settings [0.2 ms]
[prof]   -> dynamic imports
[prof]   <- dynamic imports [8.1 ms]
[prof]  <- startup [13.2 ms]
[prof]  -> runJSify
[prof]   -> load
[prof]    -> preprocessFiles
[prof]    <- preprocessFiles [65.9 ms]
[prof]    -> executeJS
[prof]    <- executeJS [31.0 ms]
[prof]   <- load [97.9 ms]
[prof]   -> finalCombiner
[prof]   <- finalCombiner [12.4 ms]
[prof]  <- runJSify [114.0 ms]
[prof] <- overall [135.6 ms]
profiler:INFO:       block "compile_javascript" took 0.177 seconds
profiler:INFO:     block "emscript" took 0.188 seconds
profiler:INFO:     start block "binaryen"
profiler:INFO:     block "binaryen" took 0.000 seconds
profiler:INFO:     start block "final emitting"
profiler:INFO:     block "final emitting" took 0.001 seconds
profiler:INFO:   block "post link" took 0.189 seconds
profiler:INFO: block "main" took 0.403 seconds
```