### PR TITLE
Move BINARYEN_PASSES out of settings_internal.js. NFC

### DIFF
--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -57,11 +57,6 @@ var TARGET_JS_NAME = '';
 // never used, then we don't actually need to support operations on streams.
 var SYSCALLS_REQUIRE_FILESYSTEM = true;
 
-// A list of feature flags to pass to each binaryen invocation (like wasm-opt,
-// etc.). This is received from wasm-emscripten-finalize, which reads it from
-// the features section.
-var BINARYEN_FEATURES = [];
-
 // Whether EMCC_AUTODEBUG is on, which automatically instruments code for
 // runtime logging that can help in debugging.
 var AUTODEBUG = false;

--- a/tools/building.py
+++ b/tools/building.py
@@ -13,7 +13,7 @@ import shutil
 import subprocess
 import sys
 from subprocess import PIPE
-from typing import Dict, Set
+from typing import Dict, List, Set
 
 from . import (
   cache,
@@ -59,6 +59,10 @@ EXPECTED_BINARYEN_VERSION = 124
 _is_ar_cache: Dict[str, bool] = {}
 # the exports the user requested
 user_requested_exports: Set[str] = set()
+# A list of feature flags to pass to each binaryen invocation (like `wasm-opt`,
+# etc.). This is received by the first call to binaryen (e.g. `wasm-emscripten-finalize`)
+# which reads it using `--detect-features`.
+binaryen_features: List[str] = []
 
 
 def get_building_env():
@@ -1187,10 +1191,10 @@ def emit_wasm_source_map(wasm_file, map_file, final_wasm):
 
 
 def get_binaryen_feature_flags():
-  # settings.BINARYEN_FEATURES is empty unless features have been extracted by
-  # wasm-emscripten-finalize already.
-  if settings.BINARYEN_FEATURES:
-    return settings.BINARYEN_FEATURES
+  # `binaryen_features` is empty unless features have been extracted by
+  # a previous call to a binaryen tool.
+  if binaryen_features:
+    return binaryen_features
   else:
     return ['--detect-features']
 

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -116,14 +116,14 @@ def update_settings_glue(wasm_file, metadata, base_metadata):
   settings.HAVE_EM_ASM = bool(settings.MAIN_MODULE or len(metadata.em_asm_consts) != 0)
 
   # start with the MVP features, and add any detected features.
-  settings.BINARYEN_FEATURES = ['--mvp-features'] + metadata.features
+  building.binaryen_features = ['--mvp-features'] + metadata.features
   if settings.ASYNCIFY == 2:
-    settings.BINARYEN_FEATURES += ['--enable-reference-types']
+    building.binaryen_features += ['--enable-reference-types']
 
   if settings.PTHREADS:
-    assert '--enable-threads' in settings.BINARYEN_FEATURES
+    assert '--enable-threads' in building.binaryen_features
   if settings.MEMORY64:
-    assert '--enable-memory64' in settings.BINARYEN_FEATURES
+    assert '--enable-memory64' in building.binaryen_features
 
   settings.HAS_MAIN = bool(settings.MAIN_MODULE) or settings.PROXY_TO_PTHREAD or settings.STANDALONE_WASM or 'main' in settings.WASM_EXPORTS or '__main_argc_argv' in settings.WASM_EXPORTS
   if settings.HAS_MAIN and not settings.MINIMAL_RUNTIME:


### PR DESCRIPTION
I'm making an effort to remove stuff from `settings_internal.js` unless its specifically needed by the JS compiler.

We might want to invent a new place for such python global state but we I think we can add this organically, over time.

See https://github.com/emscripten-core/emscripten/issues/25721