### PR TITLE
Extend EMTEST_AUTOSKIP=0/1 to cover Wasm EH and Wasm Legacy EH tests

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -10,6 +10,7 @@ import io
 import json
 import logging
 import os
+import plistlib
 import queue
 import re
 import shlex

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5,9 +5,7 @@
 
 import argparse
 import os
-import plistlib
 import random
-import re
 import shlex
 import shutil
 import subprocess
@@ -37,7 +35,6 @@ from common import (
   create_file,
   ensure_dir,
   find_browser_test_file,
-  get_firefox_version,
   get_safari_version,
   has_browser,
   is_chrome,
@@ -67,7 +64,7 @@ from decorators import (
 )
 
 from tools import ports, shared
-from tools.feature_matrix import UNSUPPORTED, Feature
+from tools.feature_matrix import Feature
 from tools.shared import DEBUG, EMCC, FILE_PACKAGER, PIPE, WINDOWS
 from tools.utils import delete_dir
 


### PR DESCRIPTION
Extend EMTEST_AUTOSKIP=0/1 to cover Wasm EH and Wasm Legacy EH tests, e.g. in browser.test_sdl2_image_formats* tests.

This allows old Firefox and Safari test runs to skip over these tests automatically.