### PR TITLE
Delete _original_stdout and _original_stderr only if they exist. #25745

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -336,8 +336,10 @@ class BufferedParallelTestResult(unittest.TestResult):
     # Once we are done running the test and any stdout/stderr buffering has
     # being taking care or, we delete these fields which the parent class uses.
     # This is because they are not picklable (serializable).
-    del self._original_stdout
-    del self._original_stderr
+    if hasattr(self, '_original_stdout'):
+      del self._original_stdout
+    if hasattr(self, '_original_stderr'):
+      del self._original_stderr
 
   def addSuccess(self, test):
     super().addSuccess(test)


### PR DESCRIPTION
The first thing that came to mind to fix #25745. I didn't dig too much into the details here if there might be something better.