### PR TITLE
[embind] Require C++17 or newer.

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -573,7 +573,6 @@ private:
   template<internal::EM_INVOKER_KIND Kind, typename Ret, typename... Args>
   static Ret internalCall(EM_VAL handle, const char *methodName, Args&&... args) {
     using namespace internal;
-#if __cplusplus >= 201703L
     using Policy = WithPolicies<FilterTypes<isPolicy, Args...>>;
     auto filteredArgs = Filter<isNotPolicy>(args...);
     return std::apply(
@@ -582,12 +581,6 @@ private:
         },
         filteredArgs
     );
-#else
-    // When std::apply is not available allow pointers by default. std::apply
-    // could be polyfilled, but it requires a lot of code.
-    static_assert(internal::conjunction<internal::isNotPolicy<Args>...>::value, "Using pointer policies with val requires C++17 or newer.");
-    return internalCallWithPolicy<Kind, WithPolicies<allow_raw_pointers>, Ret>(handle, methodName, std::forward<decltype(args)>(args)...);
-#endif
   }
 
   template<internal::EM_INVOKER_KIND Kind, typename Policy, typename Ret, typename... Args>

--- a/system/include/emscripten/wire.h
+++ b/system/include/emscripten/wire.h
@@ -7,12 +7,8 @@
 
 #pragma once
 
-#if __cplusplus < 201103L
-#error "embind requires -std=c++11 or newer"
-#endif
-
 #if __cplusplus < 201703L
-#warning "embind is likely moving to c++17 (https://github.com/emscripten-core/emscripten/issues/24850)"
+#error "embind requires -std=c++17 or newer"
 #endif
 
 // A value moving between JavaScript and C++ has three representations:
@@ -579,27 +575,6 @@ struct reference : public allow_raw_pointers {};
 
 namespace internal {
 
-#if __cplusplus >= 201703L
-template <typename... Args> using conjunction = std::conjunction<Args...>;
-template <typename... Args> using disjunction = std::disjunction<Args...>;
-#else
-// Helper available in C++14.
-template <bool _Test, class _T1, class _T2>
-using conditional_t = typename std::conditional<_Test, _T1, _T2>::type;
-
-template<class...> struct conjunction : std::true_type {};
-template<class B1> struct conjunction<B1> : B1 {};
-template<class B1, class... Bn>
-struct conjunction<B1, Bn...>
-    : conditional_t<bool(B1::value), conjunction<Bn...>, B1> {};
-
-template<class...> struct disjunction : std::false_type {};
-template<class B1> struct disjunction<B1> : B1 {};
-template<class B1, class... Bn>
-struct disjunction<B1, Bn...>
-    : conditional_t<bool(B1::value), disjunction<Bn...>, B1> {};
-#endif
-
 template<typename... Policies>
 struct isPolicy;
 
@@ -674,10 +649,10 @@ struct GetReturnValuePolicy<ReturnType, T, Rest...> {
 };
 
 template<typename... Policies>
-using isAsync = disjunction<std::is_same<async, Policies>...>;
+using isAsync = std::disjunction<std::is_same<async, Policies>...>;
 
 template<typename... Policies>
-using isNonnullReturn = disjunction<std::is_same<nonnull<ret_val>, Policies>...>;
+using isNonnullReturn = std::disjunction<std::is_same<nonnull<ret_val>, Policies>...>;
 
 // Build a tuple type that contains all the types where the predicate is true.
 // e.g. FilterTypes<std::is_integral, int, char, float> would return std::tuple<int, char>.
@@ -692,7 +667,6 @@ using FilterTypes = decltype(std::tuple_cat(
         >()...
     ));
 
-#if __cplusplus >= 201402L
 // Build a tuple that contains all the args where the predicate is true.
 template<template <class> class Predicate, typename... Args>
 auto Filter(Args&&... args) {
@@ -705,7 +679,6 @@ auto Filter(Args&&... args) {
         )(std::forward<Args>(args))...
     );
 }
-#endif
 
 } // namespace internal
 

--- a/test/cmake/cmake_with_emval/CMakeLists.txt
+++ b/test/cmake/cmake_with_emval/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(cmake_with_emval)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (NO_GNU_EXTENSIONS)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -991,8 +991,8 @@ f.close()
     self.run_process(cmd)
     self.assertExists(self.get_dir() + '/build.ninja')
 
-  # Tests that it's possible to pass C++11 or GNU++11 build modes to CMake by building code that
-  # needs C++11 (embind)
+  # Tests that it's possible to pass C++17 or GNU++17 build modes to CMake by building code that
+  # needs C++17 (embind)
   @requires_ninja
   @parameterized({
     '': [[]],
@@ -1007,9 +1007,9 @@ f.close()
 
     out = self.run_js('cmake_with_emval.js')
     if '-DNO_GNU_EXTENSIONS=1' in args:
-      self.assertContained('Hello! __STRICT_ANSI__: 1, __cplusplus: 201103', out)
+      self.assertContained('Hello! __STRICT_ANSI__: 1, __cplusplus: 201703', out)
     else:
-      self.assertContained('Hello! __STRICT_ANSI__: 0, __cplusplus: 201103', out)
+      self.assertContained('Hello! __STRICT_ANSI__: 0, __cplusplus: 201703', out)
 
   # Tests that the Emscripten CMake toolchain option
   def test_cmake_bitcode_static_libraries(self):
@@ -3395,10 +3395,10 @@ More info: https://emscripten.org
     '2gb': ['-sINITIAL_MEMORY=2200mb', '-sGLOBAL_BASE=2gb'],
   })
   @parameterized({
-    # With no arguments we are effectively testing c++17 since it is the default.
+    # With no arguments we are testing the default C++ version provided by clang.
     '': [],
-    # Ensure embind compiles under C++11 which is the miniumum supported version.
-    'cxx11': ['-std=c++11', '-Wno-#warnings'],
+    # Ensure embind compiles under C++17 which is the miniumum supported version.
+    'cxx17': ['-std=c++17', '-Wno-#warnings'],
     'o1': ['-O1'],
     'o2': ['-O2'],
     'o2_mem_growth': ['-O2', '-sALLOW_MEMORY_GROWTH', test_file('embind/isMemoryGrowthEnabled=true.cpp')],
@@ -3447,12 +3447,8 @@ More info: https://emscripten.org
     output = self.run_js(js_file)
     self.assertNotContained('FAIL', output)
 
-  def test_embind_cxx11_warning(self):
-    err = self.run_process([EMXX, '-c', '-std=c++11', test_file('embind/test_unsigned.cpp')], stderr=PIPE).stderr
-    self.assertContained('#warning "embind is likely moving to c++17', err)
-
-  def test_embind_cxx03(self):
-    self.assert_fail([EMXX, '-c', '-std=c++03', test_file('embind/test_unsigned.cpp')], '#error "embind requires -std=c++11 or newer"')
+  def test_embind_cxx11(self):
+    self.assert_fail([EMXX, '-c', '-std=c++11', test_file('embind/test_unsigned.cpp')], '#error "embind requires -std=c++17 or newer"')
 
   @requires_node
   def test_embind_finalization(self):


### PR DESCRIPTION
As announced in #24850 and on the [mailing list](https://groups.google.com/g/emscripten-discuss/c/BSLc5y2aKDY) we are going to require C++17 or newer for embind.