### PR TITLE
Disable assertions in tsgen

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -2056,10 +2056,10 @@ def run_embind_gen(options, wasm_target, js_syms, extra_settings):
     settings.MEMORY64 = 2
   # Source maps haven't been generated yet and aren't needed to run embind_gen.
   settings.LOAD_SOURCE_MAP = 0
+  settings.ASSERTIONS = 0
   outfile_js = in_temp('tsgen.js')
   # The Wasm outfile may be modified by emscripten.emscript, so use a temporary file.
   outfile_wasm = in_temp('tsgen.wasm')
-  settings.ASSERTIONS = 0
   emscripten.emscript(wasm_target, outfile_wasm, outfile_js, js_syms, finalize=False)
   # Build the flags needed by Node.js to properly run the output file.
   node_args = []


### PR DESCRIPTION
When using `tsgen` with `-sASYNCIFY=1` and assertions enabled, an assertion failure occurs: `Assertion failed: missing Wasm export: asyncify_start_unwind`. This is due to https://github.com/emscripten-core/emscripten/pull/25541.

This PR disables assertions when running `tsgen` to resolve the issue.