### PR TITLE
Remove global `currentModuleWeakSymbols` from dynamic linking code

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -684,6 +684,9 @@ function getWasmImports() {
 #endif
 #endif
   // prepare imports
+#if MAIN_MODULE || RELOCATABLE
+  var GOTProxyHandler = new Proxy(new Set({{{ JSON.stringify(Array.from(WEAK_IMPORTS)) }}}), GOTHandler);
+#endif
   var imports = {
 #if MINIFY_WASM_IMPORTED_MODULES
     'a': wasmImports,
@@ -692,8 +695,8 @@ function getWasmImports() {
     '{{{ WASI_MODULE_NAME }}}': wasmImports,
 #endif // MINIFY_WASM_IMPORTED_MODULES
 #if MAIN_MODULE || RELOCATABLE
-    'GOT.mem': new Proxy(wasmImports, GOTHandler),
-    'GOT.func': new Proxy(wasmImports, GOTHandler),
+    'GOT.mem': GOTProxyHandler,
+    'GOT.func': GOTProxyHandler,
 #endif
   };
 #if SPLIT_MODULE

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26552,
-  "a.out.js.gz": 11345,
+  "a.out.js": 26546,
+  "a.out.js.gz": 11349,
   "a.out.nodebug.wasm": 17761,
   "a.out.nodebug.wasm.gz": 9003,
-  "total": 44313,
-  "total_gz": 20348,
+  "total": 44307,
+  "total_gz": 20352,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 245483,
+  "a.out.js": 245475,
   "a.out.nodebug.wasm": 573783,
-  "total": 819266,
+  "total": 819258,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
Using a global has led to at least one bug: #25214