### PR TITLE
[CI] Use EMSCRIPTEN_BOT_TOKEN in rebaseline-tests.yml

### DIFF
--- a/.github/workflows/rebaseline-tests.yml
+++ b/.github/workflows/rebaseline-tests.yml
@@ -15,7 +15,7 @@ jobs:
     name: Rebaseline Tests
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.EMSCRIPTEN_BOT_TOKEN }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Using this token instead of the default one should mean that all the normal workflows get triggered in the created PRs.

Github has some kind of recursion guard in place for the default token.