### PR TITLE
Move emscripten lld flags to start start of cmd line

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,8 +20,11 @@ See docs/process.md for more on how version tagging works.
 
 4.0.20 (in development)
 -----------------------
-- Added `emscripten_html5_remove_event_listener` function in `html5.h` in order to be
-  able to remove a single callback. (#25535)
+- Linker flags specified on the command line are now passed to `wasm-ld` after
+  the internal emscripten linker flags.  This means that users can now override
+  emscripten defaults with things `-Wl,--stack-first`. (#25803)
+- Added `emscripten_html5_remove_event_listener` function in `html5.h` in order
+  to be able to remove a single callback. (#25535)
 - The standalone `file_packager.py` script no longer supports `--embed` with JS
   output (use `--obj-output` is now required for embedding data).  This usage
   has been producing a warning since #16050 which is now an error.  (#25049)

--- a/tools/building.py
+++ b/tools/building.py
@@ -208,6 +208,7 @@ def lld_flags_for_executable(external_symbols):
   c_exports = [e for e in c_exports if e not in external_symbols]
   c_exports += settings.REQUIRED_EXPORTS
   if settings.MAIN_MODULE:
+    cmd.append('-Bdynamic')
     c_exports += side_module_external_deps(external_symbols)
   for export in c_exports:
     if settings.ERROR_ON_UNDEFINED_SYMBOLS:
@@ -296,9 +297,6 @@ def link_lld(args, target, external_symbols=None):
     args.insert(0, '--whole-archive')
     args.append('--no-whole-archive')
 
-  if settings.MAIN_MODULE:
-    args.insert(0, '-Bdynamic')
-
   if settings.STRICT and '--no-fatal-warnings' not in args:
     args.append('--fatal-warnings')
 
@@ -307,7 +305,7 @@ def link_lld(args, target, external_symbols=None):
     # is passed.
     args.append('--keep-section=target_features')
 
-  cmd = [WASM_LD, '-o', target] + args
+  cmd = [WASM_LD, '-o', target]
   for a in llvm_backend_args():
     cmd += ['-mllvm', a]
 
@@ -327,6 +325,8 @@ def link_lld(args, target, external_symbols=None):
   # normal linker flags that are used when building and executable
   if '--relocatable' not in args and '-r' not in args:
     cmd += lld_flags_for_executable(external_symbols)
+
+  cmd += args
 
   cmd = get_command_with_possible_response_file(cmd)
   check_call(cmd)


### PR DESCRIPTION
This allows the `-Bdynamic` flag to be moved there which is its logical place.  It also theoretically allows user flags to override any system flags.