### PR TITLE
Fix core_2gb.test_memprof_requirements

### DIFF
--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 24194,
-  "a.out.js.gz": 8694,
+  "a.out.js.gz": 8693,
   "a.out.nodebug.wasm": 15144,
   "a.out.nodebug.wasm.gz": 7460,
   "total": 39338,
-  "total_gz": 16154,
+  "total_gz": 16153,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -1329,28 +1329,28 @@ var wasmMemory = makeInvalidEarlyAccess('wasmMemory');
 
 function assignWasmExports(wasmExports) {
   assert(typeof wasmExports['add'] != 'undefined', 'missing Wasm export: add');
-  _add = Module['_add'] = createExportWrapper('add', 2);
   assert(typeof wasmExports['fflush'] != 'undefined', 'missing Wasm export: fflush');
-  _fflush = createExportWrapper('fflush', 1);
   assert(typeof wasmExports['emscripten_stack_init'] != 'undefined', 'missing Wasm export: emscripten_stack_init');
-  _emscripten_stack_init = wasmExports['emscripten_stack_init'];
   assert(typeof wasmExports['emscripten_stack_get_free'] != 'undefined', 'missing Wasm export: emscripten_stack_get_free');
-  _emscripten_stack_get_free = wasmExports['emscripten_stack_get_free'];
   assert(typeof wasmExports['emscripten_stack_get_base'] != 'undefined', 'missing Wasm export: emscripten_stack_get_base');
-  _emscripten_stack_get_base = wasmExports['emscripten_stack_get_base'];
   assert(typeof wasmExports['emscripten_stack_get_end'] != 'undefined', 'missing Wasm export: emscripten_stack_get_end');
-  _emscripten_stack_get_end = wasmExports['emscripten_stack_get_end'];
   assert(typeof wasmExports['_emscripten_stack_restore'] != 'undefined', 'missing Wasm export: _emscripten_stack_restore');
-  __emscripten_stack_restore = wasmExports['_emscripten_stack_restore'];
   assert(typeof wasmExports['_emscripten_stack_alloc'] != 'undefined', 'missing Wasm export: _emscripten_stack_alloc');
-  __emscripten_stack_alloc = wasmExports['_emscripten_stack_alloc'];
   assert(typeof wasmExports['emscripten_stack_get_current'] != 'undefined', 'missing Wasm export: emscripten_stack_get_current');
-  _emscripten_stack_get_current = wasmExports['emscripten_stack_get_current'];
   assert(typeof wasmExports['memory'] != 'undefined', 'missing Wasm export: memory');
-  memory = wasmMemory = wasmExports['memory'];
   assert(typeof wasmExports['global_val'] != 'undefined', 'missing Wasm export: global_val');
-  _global_val = Module['_global_val'] = wasmExports['global_val'].value;
   assert(typeof wasmExports['__indirect_function_table'] != 'undefined', 'missing Wasm export: __indirect_function_table');
+  _add = Module['_add'] = createExportWrapper('add', 2);
+  _fflush = createExportWrapper('fflush', 1);
+  _emscripten_stack_init = wasmExports['emscripten_stack_init'];
+  _emscripten_stack_get_free = wasmExports['emscripten_stack_get_free'];
+  _emscripten_stack_get_base = wasmExports['emscripten_stack_get_base'];
+  _emscripten_stack_get_end = wasmExports['emscripten_stack_get_end'];
+  __emscripten_stack_restore = wasmExports['_emscripten_stack_restore'];
+  __emscripten_stack_alloc = wasmExports['_emscripten_stack_alloc'];
+  _emscripten_stack_get_current = wasmExports['emscripten_stack_get_current'];
+  memory = wasmMemory = wasmExports['memory'];
+  _global_val = Module['_global_val'] = wasmExports['global_val'].value;
   __indirect_function_table = wasmExports['__indirect_function_table'];
 }
 

--- a/test/codesize/test_codesize_minimal_O0.json
+++ b/test/codesize/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19489,
-  "a.out.js.gz": 7016,
+  "a.out.js.gz": 7012,
   "a.out.nodebug.wasm": 1136,
   "a.out.nodebug.wasm.gz": 659,
   "total": 20625,
-  "total_gz": 7675,
+  "total_gz": 7671,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,6 +1,6 @@
 {
   "hello_world.js": 56928,
-  "hello_world.js.gz": 17700,
+  "hello_world.js.gz": 17707,
   "hello_world.wasm": 15144,
   "hello_world.wasm.gz": 7460,
   "no_asserts.js": 26632,
@@ -8,9 +8,9 @@
   "no_asserts.wasm": 12193,
   "no_asserts.wasm.gz": 5990,
   "strict.js": 54943,
-  "strict.js.gz": 17045,
+  "strict.js.gz": 17053,
   "strict.wasm": 15144,
   "strict.wasm.gz": 7455,
   "total": 180984,
-  "total_gz": 64534
+  "total_gz": 64549
 }

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -4626,10 +4626,12 @@ res64 - external 64\n''', header='''\
 
       int main(void) {
         void* js_address = EM_ASM_PTR({
-          console.log("JS:_my_number:", _my_number, HEAP32[_my_number/4]);
+          var value = HEAP32[_my_number/4];
+          console.log("JS:_my_number:", _my_number, value);
+          assert(value == 123456, value);
           return _my_number;
         });
-        printf("C: my_number: %ld %d\n", (long)&my_number, my_number);
+        printf("C: my_number: %lu %d\n", (uintptr_t)&my_number, my_number);
         assert(js_address == &my_number);
         return 0;
       }


### PR DESCRIPTION
This was broken by #25568. This fixes the regression and updates an existing test to catch it.