### PR TITLE
Remove `--no-entry` flag when from dylink reversed tests. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -4113,7 +4113,6 @@ caught outer int: 123
       side_ = side
       side = main
       main = side_
-      main_cflags += ['--no-entry']
     self.maybe_closure()
     # Same as dylink_test but takes source code as filenames on disc.
     old_args = self.cflags.copy()


### PR DESCRIPTION
These days this should never be necessary since we always link the main module with the side module on the command line (so all symbol should be visible, reversed or not).