### PR TITLE
[docs] Remove usage of `|today|` macro from website

### DIFF
--- a/site/source/docs/contributing/AUTHORS.rst
+++ b/site/source/docs/contributing/AUTHORS.rst
@@ -7,7 +7,7 @@ AUTHORS
 The `AUTHORS <https://github.com/emscripten-core/emscripten/blob/main/AUTHORS>`_ file lists everyone who has contributed to Emscripten.
 It is optional for a contributor to add themselves to the `AUTHORS <https://github.com/emscripten-core/emscripten/blob/main/AUTHORS>`_ file before :doc:`contributing <contributing>`.
 
-The contributors for releases up to Emscripten |release| inclusive (|today|) are listed below.
+The contributors for releases up to Emscripten |release| inclusive are listed below.
 
 .. include::   ../../../../AUTHORS
    :literal:

--- a/site/source/docs/introducing_emscripten/emscripten_license.rst
+++ b/site/source/docs/introducing_emscripten/emscripten_license.rst
@@ -11,7 +11,7 @@ There is little, if any, practical difference between the licenses. They are bot
 - *MIT license* is well known and understood.
 - *University of Illinois/NCSA Open Source License* allows Emscripten's code to be integrated upstream into LLVM, should the opportunity arise.
 
-The license for Emscripten |release| (|today|) is reproduced below. The `current full licence <https://github.com/emscripten-core/emscripten/blob/main/LICENSE>`_ can be found on GitHub (and is also present in the root of the SDK).
+The license for Emscripten |release| is reproduced below. The `current full licence <https://github.com/emscripten-core/emscripten/blob/main/LICENSE>`_ can be found on GitHub (and is also present in the root of the SDK).
 
 .. include:: ../../../../LICENSE
    :literal:

--- a/tools/maint/update_docs.py
+++ b/tools/maint/update_docs.py
@@ -56,11 +56,6 @@ def main(args):
   subprocess.check_call(['make', 'install', f'EMSCRIPTEN_SITE={site_out}'], cwd=site_dir)
 
   files_changed = get_changed_files(site_out)
-  # This AUTHORS.html file happens to always contains the current date, so we don't want
-  # to consider updates that contain only this one file
-  if 'docs/contributing/AUTHORS.html' in files_changed:
-    files_changed.remove('docs/contributing/AUTHORS.html')
-
   if not files_changed:
     print('docs are up-to-date; no changes found')
     return 0


### PR DESCRIPTION
This avoids churn on the website, since it avoids the output changing every day.