### PR TITLE
Add ALC_EXT_capture to present OpenAL extensions

### DIFF
--- a/src/lib/libopenal.js
+++ b/src/lib/libopenal.js
@@ -25,6 +25,7 @@ var LibraryOpenAL = {
 
     ALC_EXTENSIONS: {
       // TODO: 'ALC_EXT_EFX': true,
+      'ALC_EXT_capture': true,
       'ALC_SOFT_pause_device': true,
       'ALC_SOFT_HRTF': true
     },

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 245765,
+  "a.out.js": 245771,
   "a.out.nodebug.wasm": 573904,
-  "total": 819669,
+  "total": 819675,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/openal/test_openal_extensions.c
+++ b/test/openal/test_openal_extensions.c
@@ -17,8 +17,9 @@
 #include <AL/alc.h>
 #include <AL/alext.h>
 
-#define NUM_ALC_EXTENSIONS 2
+#define NUM_ALC_EXTENSIONS 3
 static const ALCchar *alc_extensions[NUM_ALC_EXTENSIONS] = {
+  "ALC_EXT_capture",
   "ALC_SOFT_pause_device",
   "ALC_SOFT_HRTF",
 };


### PR DESCRIPTION
The extension is already implemented, however, alcIsExtensionPresent wasn't reporting it as present.