### PR TITLE
Move compiler paths out of top level of shared.py. NFC

### DIFF
--- a/emar.py
+++ b/emar.py
@@ -11,4 +11,4 @@ import sys
 
 from tools import shared
 
-shared.exec_process([shared.LLVM_AR] + sys.argv[1:])
+shared.exec_process([shared.paths.LLVM_AR] + sys.argv[1:])

--- a/emcc.py
+++ b/emcc.py
@@ -43,7 +43,7 @@ from tools import (
 from tools.cmdline import CLANG_FLAGS_WITH_ARGS, options
 from tools.response_file import substitute_response_files
 from tools.settings import COMPILE_TIME_SETTINGS, default_setting, settings, user_settings
-from tools.shared import DEBUG, DYLIB_EXTENSIONS, in_temp
+from tools.shared import DEBUG, DYLIB_EXTENSIONS, in_temp, paths
 from tools.toolchain_profiler import ToolchainProfiler
 from tools.utils import exit_with_error, get_file_suffix, read_file, unsuffixed_basename
 
@@ -168,9 +168,9 @@ def create_reproduce_file(name, args):
 @ToolchainProfiler.profile()
 def main(args):
   if shared.run_via_emxx:
-    clang = shared.CLANG_CXX
+    clang = paths.CLANG_CXX
   else:
-    clang = shared.CLANG_CC
+    clang = paths.CLANG_CC
 
   # Special case the handling of `-v` because it has a special/different meaning
   # when used with no other arguments.  In particular, we must handle this early
@@ -477,9 +477,9 @@ def phase_setup(state):
 @ToolchainProfiler.profile_block('compile inputs')
 def phase_compile_inputs(options, state, newargs):
   if shared.run_via_emxx:
-    compiler = [shared.CLANG_CXX]
+    compiler = [paths.CLANG_CXX]
   else:
-    compiler = [shared.CLANG_CC]
+    compiler = [paths.CLANG_CC]
 
   if config.COMPILER_WRAPPER:
     logger.debug('using compiler wrapper: %s', config.COMPILER_WRAPPER)

--- a/emranlib.py
+++ b/emranlib.py
@@ -14,4 +14,4 @@ import sys
 
 from tools import shared
 
-shared.exec_process([shared.LLVM_RANLIB] + sys.argv[1:])
+shared.exec_process([shared.paths.LLVM_RANLIB] + sys.argv[1:])

--- a/emscan-deps.py
+++ b/emscan-deps.py
@@ -21,4 +21,4 @@ newargs = cmdline.parse_arguments(argv)
 # Add any clang flags that emcc would add.
 newargs += compile.get_cflags(tuple(argv))
 
-shared.exec_process([shared.CLANG_SCAN_DEPS] + newargs)
+shared.exec_process([shared.paths.CLANG_SCAN_DEPS] + newargs)

--- a/emstrip.py
+++ b/emstrip.py
@@ -11,4 +11,4 @@ import sys
 
 from tools import shared
 
-shared.exec_process([shared.LLVM_STRIP] + sys.argv[1:])
+shared.exec_process([shared.paths.LLVM_STRIP] + sys.argv[1:])

--- a/test/browser_common.py
+++ b/test/browser_common.py
@@ -36,7 +36,7 @@ from common import (
 
 from tools import feature_matrix, shared, utils
 from tools.feature_matrix import UNSUPPORTED
-from tools.shared import DEBUG, EMCC, exit_with_error
+from tools.shared import DEBUG, exit_with_error, paths
 from tools.utils import MACOS, WINDOWS, memoize, path_from_root, read_binary
 
 logger = logging.getLogger('common')
@@ -878,7 +878,7 @@ class BrowserCore(RunnerCore):
       if reporting == Reporting.FULL:
         # If C reporting (i.e. the REPORT_RESULT macro) is required we
         # also include report_result.c and force-include report_result.h
-        self.run_process([EMCC, '-c', '-I' + TEST_ROOT,
+        self.run_process([paths.EMCC, '-c', '-I' + TEST_ROOT,
                           test_file('report_result.c')] + self.get_cflags(compile_only=True) + (['-fPIC'] if '-fPIC' in cflags else []))
         cflags += ['report_result.o', '-include', test_file('report_result.h')]
     if EMTEST_BROWSER == 'node':

--- a/test/clang_native.py
+++ b/test/clang_native.py
@@ -8,7 +8,7 @@ import os
 import platform
 import sys
 
-from tools.shared import CLANG_CC, CLANG_CXX, PIPE
+from tools.shared import PIPE, paths
 from tools.utils import MACOS, WINDOWS, path_from_root, run_process
 
 logger = logging.getLogger('clang_native')
@@ -63,9 +63,9 @@ def get_clang_native_env():
     return CACHED_CLANG_NATIVE_ENV
   env = os.environ.copy()
 
-  env['CC'] = CLANG_CC
-  env['CXX'] = CLANG_CXX
-  env['LD'] = CLANG_CXX
+  env['CC'] = paths.CLANG_CC
+  env['CXX'] = paths.CLANG_CXX
+  env['LD'] = paths.CLANG_CXX
 
   if MACOS:
     path = run_process(['xcrun', '--show-sdk-path'], stdout=PIPE).stdout.strip()

--- a/test/common.py
+++ b/test/common.py
@@ -32,7 +32,7 @@ from retryable_unittest import RetryableTestCase
 from tools import building, config, feature_matrix, shared, utils
 from tools.feature_matrix import Feature
 from tools.settings import COMPILE_TIME_SETTINGS
-from tools.shared import DEBUG, EMCC, EMXX, get_canonical_temp_dir
+from tools.shared import DEBUG, get_canonical_temp_dir, paths
 from tools.utils import (
   WINDOWS,
   exit_with_error,
@@ -130,9 +130,9 @@ def copytree(src, dest):
 
 def compiler_for(filename, force_c=False):
   if utils.suffix(filename) in ('.cc', '.cxx', '.cpp') and not force_c:
-    return EMXX
+    return paths.EMXX
   else:
-    return EMCC
+    return paths.EMCC
 
 
 def record_flaky_test(test_name, attempt_count, max_attempts, exception_msg):
@@ -1272,7 +1272,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
       ''')
 
     def ccshared(src, linkto=None):
-      cmdv = [EMCC, src, '-o', utils.unsuffixed(src) + '.wasm', '-sSIDE_MODULE'] + self.get_cflags()
+      cmdv = [paths.EMCC, src, '-o', utils.unsuffixed(src) + '.wasm', '-sSIDE_MODULE'] + self.get_cflags()
       if linkto:
         cmdv += linkto
       self.run_process(cmdv)

--- a/test/runner.py
+++ b/test/runner.py
@@ -630,8 +630,8 @@ def log_test_environment():
     print(f'LLVM git directory: "{llvm_git_root}"')
     print_repository_info(llvm_git_root, 'LLVM')
 
-  clang_version = utils.run_process([shared.CLANG_CC, '--version'], stdout=subprocess.PIPE).stdout.strip()
-  print(f'Clang: "{shared.CLANG_CC}"\n{clang_version}\n')
+  clang_version = utils.run_process([shared.paths.CLANG_CC, '--version'], stdout=subprocess.PIPE).stdout.strip()
+  print(f'Clang: "{shared.paths.CLANG_CC}"\n{clang_version}\n')
 
   print(f'EMTEST_BROWSER: {browser_common.EMTEST_BROWSER}')
   if browser_common.is_firefox():

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -25,7 +25,7 @@ from common import read_binary, read_file, test_file
 from decorators import needs_make
 
 from tools import building, utils
-from tools.shared import CLANG_CC, CLANG_CXX, EMCC, PIPE, config
+from tools.shared import PIPE, config, paths
 from tools.utils import run_process
 
 # standard arguments for timing:
@@ -232,7 +232,7 @@ class EmscriptenBenchmarker(Benchmarker):
     final = final.replace('.cpp', '')
     utils.delete_file(final)
     cmd = [
-      EMCC, filename,
+      paths.EMCC, filename,
       OPTIMIZATIONS,
       '-sINITIAL_MEMORY=256MB',
       '-sENVIRONMENT=node,shell',
@@ -361,7 +361,7 @@ benchmarkers: List[Benchmarker] = []
 aot_v8 = (config.V8_ENGINE if config.V8_ENGINE else []) + ['--no-liftoff']
 
 named_benchmarkers = {
-  'clang': NativeBenchmarker('clang', [CLANG_CC], [CLANG_CXX]),
+  'clang': NativeBenchmarker('clang', [paths.CLANG_CC], [paths.CLANG_CXX]),
   'gcc': NativeBenchmarker('gcc',   ['gcc', '-no-pie'],  ['g++', '-no-pie']),
   'size': SizeBenchmarker('size'),
   'v8': EmscriptenBenchmarker('v8', aot_v8),

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -70,8 +70,11 @@ from decorators import (
 
 from tools import ports, shared
 from tools.feature_matrix import Feature
-from tools.shared import EMCC, FILE_PACKAGER, PIPE
+from tools.shared import PIPE, paths
 from tools.utils import WINDOWS, delete_dir
+
+EMCC = paths.EMCC
+FILE_PACKAGER = paths.FILE_PACKAGER
 
 
 def make_test_chunked_synchronous_xhr_server(support_byte_ranges, data, port):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -72,7 +72,7 @@ from decorators import (
 )
 
 from tools import building, config, shared, utils, webassembly
-from tools.shared import EMAR, EMCC, EMXX, FILE_PACKAGER, LLVM_COV, LLVM_PROFDATA, PIPE
+from tools.shared import PIPE, paths
 from tools.utils import LINUX, MACOS, WINDOWS, delete_file, write_file
 
 # decorators for limiting which modes a test can run in
@@ -81,6 +81,10 @@ logger = logging.getLogger("test_core")
 
 EM_SIGINT = 2
 EM_SIGABRT = 6
+
+EMAR = paths.EMAR
+EMCC = paths.EMCC
+EMXX = paths.EMXX
 
 
 def esm_integration(func):
@@ -6615,7 +6619,7 @@ void* operator new(size_t size) {
   @no_big_endian('SIMD support is currently not compatible with big endian')
   def test_sse1(self, args):
     src = test_file('sse/test_sse1.cpp')
-    self.run_process([shared.CLANG_CXX, src, '-msse', '-o', 'test_sse1', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
+    self.run_process([paths.CLANG_CXX, src, '-msse', '-o', 'test_sse1', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_sse1', stdout=PIPE).stdout
 
     self.maybe_closure()
@@ -6636,7 +6640,7 @@ void* operator new(size_t size) {
   @no_big_endian('SIMD support is currently not compatible with big endian')
   def test_sse2(self, args):
     src = test_file('sse/test_sse2.cpp')
-    self.run_process([shared.CLANG_CXX, src, '-msse2', '-Wno-argument-outside-range', '-o', 'test_sse2', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
+    self.run_process([paths.CLANG_CXX, src, '-msse2', '-Wno-argument-outside-range', '-o', 'test_sse2', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_sse2', stdout=PIPE).stdout
 
     self.cflags += ['-I' + test_file('sse'), '-msse2', '-fno-inline-functions', '-Wno-argument-outside-range', '-sSTACK_SIZE=1MB'] + args
@@ -6650,7 +6654,7 @@ void* operator new(size_t size) {
   @no_big_endian('SIMD support is currently not compatible with big endian')
   def test_sse3(self):
     src = test_file('sse/test_sse3.cpp')
-    self.run_process([shared.CLANG_CXX, src, '-msse3', '-Wno-argument-outside-range', '-o', 'test_sse3', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
+    self.run_process([paths.CLANG_CXX, src, '-msse3', '-Wno-argument-outside-range', '-o', 'test_sse3', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_sse3', stdout=PIPE).stdout
 
     self.cflags += ['-I' + test_file('sse'), '-msse3', '-Wno-argument-outside-range']
@@ -6664,7 +6668,7 @@ void* operator new(size_t size) {
   @no_big_endian('SIMD support is currently not compatible with big endian')
   def test_ssse3(self):
     src = test_file('sse/test_ssse3.cpp')
-    self.run_process([shared.CLANG_CXX, src, '-mssse3', '-Wno-argument-outside-range', '-o', 'test_ssse3', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
+    self.run_process([paths.CLANG_CXX, src, '-mssse3', '-Wno-argument-outside-range', '-o', 'test_ssse3', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_ssse3', stdout=PIPE).stdout
 
     self.cflags += ['-I' + test_file('sse'), '-mssse3', '-Wno-argument-outside-range']
@@ -6681,7 +6685,7 @@ void* operator new(size_t size) {
   def test_sse4_1(self):
     src = test_file('sse/test_sse4_1.cpp')
     # Run with inlining disabled to avoid slow LLVM behavior with lots of macro expanded loops inside a function body.
-    self.run_process([shared.CLANG_CXX, src, '-msse4.1', '-fno-inline-functions', '-Wno-argument-outside-range', '-o', 'test_sse4_1', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
+    self.run_process([paths.CLANG_CXX, src, '-msse4.1', '-fno-inline-functions', '-Wno-argument-outside-range', '-o', 'test_sse4_1', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_sse4_1', stdout=PIPE).stdout
 
     self.cflags += ['-I' + test_file('sse'), '-msse4.1', '-fno-inline-functions', '-Wno-argument-outside-range', '-sSTACK_SIZE=1MB']
@@ -6700,7 +6704,7 @@ void* operator new(size_t size) {
   def test_sse4(self, use_4_2):
     msse4 = '-msse4.2' if use_4_2 else '-msse4'
     src = test_file('sse/test_sse4_2.cpp')
-    self.run_process([shared.CLANG_CXX, src, msse4, '-Wno-argument-outside-range', '-o', 'test_sse4_2', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
+    self.run_process([paths.CLANG_CXX, src, msse4, '-Wno-argument-outside-range', '-o', 'test_sse4_2', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_sse4_2', stdout=PIPE).stdout
 
     self.cflags += ['-I' + test_file('sse'), msse4, '-Wno-argument-outside-range']
@@ -6721,7 +6725,7 @@ void* operator new(size_t size) {
   @no_big_endian('SIMD support is currently not compatible with big endian')
   def test_avx(self, args):
     src = test_file('sse/test_avx.cpp')
-    self.run_process([shared.CLANG_CXX, src, '-mavx', '-Wno-argument-outside-range', '-Wpedantic', '-o', 'test_avx', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
+    self.run_process([paths.CLANG_CXX, src, '-mavx', '-Wno-argument-outside-range', '-Wpedantic', '-o', 'test_avx', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_avx', stdout=PIPE).stdout
 
     self.cflags += ['-I' + test_file('sse'), '-mavx', '-fno-inline-functions', '-Wno-argument-outside-range', '-sSTACK_SIZE=1MB'] + args
@@ -6742,7 +6746,7 @@ void* operator new(size_t size) {
   @no_big_endian('SIMD support is currently not compatible with big endian')
   def test_avx2(self, args):
     src = test_file('sse/test_avx2.cpp')
-    self.run_process([shared.CLANG_CXX, src, '-mavx2', '-Wno-argument-outside-range', '-Wpedantic', '-o', 'test_avx2', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
+    self.run_process([paths.CLANG_CXX, src, '-mavx2', '-Wno-argument-outside-range', '-Wpedantic', '-o', 'test_avx2', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_avx2', stdout=PIPE).stdout
 
     self.cflags += ['-I' + test_file('sse'), '-mavx2', '-Wno-argument-outside-range', '-sSTACK_SIZE=1MB'] + args
@@ -6754,9 +6758,7 @@ void* operator new(size_t size) {
     self.cflags.remove('-Werror')
     src = test_file('sse/test_sse_diagnostic.cpp')
 
-    p = self.run_process(
-      [shared.EMXX, src, '-msse', '-DWASM_SIMD_COMPAT_SLOW'] + self.get_cflags(),
-      stderr=PIPE)
+    p = self.run_process([paths.EMXX, src, '-msse', '-DWASM_SIMD_COMPAT_SLOW'] + self.get_cflags(), stderr=PIPE)
     self.assertContained('Instruction emulated via slow path.', p.stderr)
 
   @wasm_relaxed_simd
@@ -7976,7 +7978,7 @@ void* operator new(size_t size) {
 
     self.emcc('test_dwarf.c')
 
-    out = self.run_process([shared.LLVM_DWARFDUMP, 'a.out.wasm', '-all'], stdout=PIPE).stdout
+    out = self.run_process([paths.LLVM_DWARFDUMP, 'a.out.wasm', '-all'], stdout=PIPE).stdout
 
     # parse the sections
     sections = {}
@@ -9696,7 +9698,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     create_file('file2.txt', 'second')
     # `--from-emcc` needed here otherwise the output defines `var Module =` which will shadow the
     # global `Module`.
-    self.run_process([FILE_PACKAGER, 'test.data', '--preload', 'file1.txt', 'file2.txt', '--from-emcc', '--js-output=script2.js'])
+    self.run_process([paths.FILE_PACKAGER, 'test.data', '--preload', 'file1.txt', 'file2.txt', '--from-emcc', '--js-output=script2.js'])
     self.do_runf('test_emscripten_async_load_script.c', cflags=['-sFORCE_FILESYSTEM'])
 
   @node_pthreads
@@ -9836,9 +9838,9 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('EXIT_RUNTIME')
     self.do_core_test('test_hello_world.c', cflags=['-fprofile-instr-generate', '-fcoverage-mapping', '-g'])
     self.assertExists('default.profraw')
-    self.run_process([LLVM_PROFDATA, 'merge', '-sparse', 'default.profraw', '-o', 'out.profdata'])
+    self.run_process([paths.LLVM_PROFDATA, 'merge', '-sparse', 'default.profraw', '-o', 'out.profdata'])
     self.assertExists('out.profdata')
-    self.assertEqual(expected, self.run_process([LLVM_COV, 'show', 'test_hello_world.wasm', '-instr-profile=out.profdata'], stdout=PIPE).stdout)
+    self.assertEqual(expected, self.run_process([paths.LLVM_COV, 'show', 'test_hello_world.wasm', '-instr-profile=out.profdata'], stdout=PIPE).stdout)
 
 # Generate tests for everything
 def make_run(name, cflags=None, settings=None, env=None, # noqa

--- a/test/test_jslib.py
+++ b/test/test_jslib.py
@@ -9,8 +9,10 @@ from subprocess import PIPE
 from common import RunnerCore, create_file, read_file, test_file
 from decorators import parameterized
 
-from tools.shared import EMCC
+from tools.shared import paths
 from tools.utils import delete_file
+
+EMCC = paths.EMCC
 
 
 class jslib(RunnerCore):

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -92,21 +92,7 @@ from tools import building, cache, response_file, shared, utils, webassembly
 from tools.building import get_building_env
 from tools.link import binary_encode
 from tools.settings import settings
-from tools.shared import (
-  CLANG_CC,
-  CLANG_CXX,
-  EMAR,
-  EMCC,
-  EMRANLIB,
-  EMXX,
-  FILE_PACKAGER,
-  LLVM_AR,
-  LLVM_DWARFDUMP,
-  LLVM_DWP,
-  LLVM_NM,
-  WASM_LD,
-  config,
-)
+from tools.shared import config, paths
 from tools.system_libs import DETERMINISTIC_PREFIX
 from tools.utils import (
   MACOS,
@@ -125,6 +111,19 @@ empath_split = utils.bat_suffix(path_from_root('empath-split'))
 emprofile = utils.bat_suffix(path_from_root('emprofile'))
 emstrip = utils.bat_suffix(path_from_root('emstrip'))
 emsymbolizer = utils.bat_suffix(path_from_root('emsymbolizer'))
+
+CLANG_CC = paths.CLANG_CC
+CLANG_CXX = paths.CLANG_CXX
+EMAR = paths.EMAR
+EMCC = paths.EMCC
+EMRANLIB = paths.EMRANLIB
+EMXX = paths.EMXX
+FILE_PACKAGER = paths.FILE_PACKAGER
+LLVM_AR = paths.LLVM_AR
+LLVM_DWARFDUMP = paths.LLVM_DWARFDUMP
+LLVM_DWP = paths.LLVM_DWP
+LLVM_NM = paths.LLVM_NM
+WASM_LD = paths.WASM_LD
 
 
 def is_bitcode(filename):
@@ -6291,7 +6290,7 @@ print(os.environ.get('CROSS_COMPILE'))
 import os
 print(os.environ.get('NM'))
 ''')
-    check(EMCONFIGURE, [PYTHON, 'test.py'], expect=shared.LLVM_NM, fail=False)
+    check(EMCONFIGURE, [PYTHON, 'test.py'], expect=LLVM_NM, fail=False)
 
     create_file('test.c', 'int main() { return 0; }')
     os.mkdir('test_cache')
@@ -11532,12 +11531,12 @@ int main(void) {
 
     # Create a library with no archive map
     self.run_process([EMAR, 'crS', 'liba.a', 'foo.o', 'bar.o'])
-    output = self.run_process([shared.LLVM_NM, '--print-armap', 'liba.a'], stdout=PIPE).stdout
+    output = self.run_process([LLVM_NM, '--print-armap', 'liba.a'], stdout=PIPE).stdout
     self.assertNotContained('Archive map', output)
 
     # Add an archive map
     self.run_process([EMRANLIB, 'liba.a'])
-    output = self.run_process([shared.LLVM_NM, '--print-armap', 'liba.a'], stdout=PIPE).stdout
+    output = self.run_process([LLVM_NM, '--print-armap', 'liba.a'], stdout=PIPE).stdout
     self.assertContained('Archive map', output)
 
   def test_pthread_stub(self):
@@ -12023,7 +12022,7 @@ int main () {
   def test_getrusage(self):
     self.do_other_test('test_getrusage.c')
 
-  @with_env_modify({'EMMAKEN_COMPILER': shared.CLANG_CC})
+  @with_env_modify({'EMMAKEN_COMPILER': CLANG_CC})
   def test_emmaken_compiler(self):
     self.assert_fail([EMCC, '-c', test_file('core/test_hello_world.c')], 'emcc: error: `EMMAKEN_COMPILER` is no longer supported')
 

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -27,10 +27,11 @@ from decorators import crossplatform, no_windows, parameterized, with_env_modify
 
 from tools import cache, ports, response_file, shared, utils
 from tools.config import EM_CONFIG
-from tools.shared import EMCC, config
+from tools.shared import config, paths
 from tools.utils import delete_dir, delete_file
 
 SANITY_FILE = cache.get_path('sanity.txt')
+EMCC = paths.EMCC
 expected_llvm_version = str(shared.EXPECTED_LLVM_VERSION) + '.0.0'
 
 

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -29,8 +29,8 @@ from decorators import (
 )
 
 from tools import config
-from tools.shared import CLANG_CC, EMCC
-from tools.utils import path_from_root, run_process
+from tools.shared import path_from_root, paths
+from tools.utils import run_process
 
 npm_checked = False
 
@@ -80,7 +80,7 @@ class WebsockifyServerHarness:
     # NOTE empty filename support is a hack to support
     # the current test_enet
     if self.filename:
-      cmd = [CLANG_CC, test_file(self.filename), '-o', 'server', '-DSOCKK=%d' % self.target_port] + clang_native.get_clang_native_args() + self.args
+      cmd = [paths.CLANG_CC, test_file(self.filename), '-o', 'server', '-DSOCKK=%d' % self.target_port] + clang_native.get_clang_native_args() + self.args
       print(cmd)
       run_process(cmd, env=clang_native.get_clang_native_env())
       process = Popen([os.path.abspath('server')])
@@ -146,7 +146,7 @@ class CompiledServerHarness:
 
     # compile the server
     suffix = '.mjs' if '-sEXPORT_ES6' in self.args else '.js'
-    proc = run_process([EMCC, '-Werror', test_file(self.filename), '-o', 'server' + suffix, '-DSOCKK=%d' % self.listen_port] + self.args)
+    proc = run_process([paths.EMCC, '-Werror', test_file(self.filename), '-o', 'server' + suffix, '-DSOCKK=%d' % self.listen_port] + self.args)
     print('Socket server build: out:', proc.stdout or '', '/ err:', proc.stderr or '')
 
     process = Popen(config.NODE_JS + ['server' + suffix])
@@ -355,7 +355,7 @@ class sockets(BrowserCore):
     # server because as long as the subprotocol list contains binary it will configure itself to accept binary
     # This test also checks that the connect url contains the correct subprotocols.
     with WebsockifyServerHarness(test_file('sockets/test_sockets_echo_server.c'), [], 59168):
-      self.run_process([EMCC, '-Werror', test_file('sockets/test_sockets_echo_client.c'), '-o', 'client.js', '-sSOCKET_DEBUG', '-sWEBSOCKET_SUBPROTOCOL="base64, binary"', '-DSOCKK=59168'])
+      self.run_process([paths.EMCC, '-Werror', test_file('sockets/test_sockets_echo_client.c'), '-o', 'client.js', '-sSOCKET_DEBUG', '-sWEBSOCKET_SUBPROTOCOL="base64, binary"', '-DSOCKK=59168'])
 
       out = self.run_js('client.js')
       self.assertContained('do_msg_read: read 14 bytes', out)
@@ -376,7 +376,7 @@ class sockets(BrowserCore):
       };
     ''')
     with WebsockifyServerHarness(test_file('sockets/test_sockets_echo_server.c'), [], 59168):
-      self.run_process([EMCC, '-Werror', test_file('sockets/test_sockets_echo_client.c'), '-o', 'client.js', '--pre-js=websocket_pre.js', '-sSOCKET_DEBUG', '-DSOCKK=12345'])
+      self.run_process([paths.EMCC, '-Werror', test_file('sockets/test_sockets_echo_client.c'), '-o', 'client.js', '--pre-js=websocket_pre.js', '-sSOCKET_DEBUG', '-DSOCKK=12345'])
 
       out = self.run_js('client.js')
       self.assertContained('do_msg_read: read 14 bytes', out)

--- a/tools/building.py
+++ b/tools/building.py
@@ -28,17 +28,7 @@ from . import (
 from .feature_matrix import UNSUPPORTED
 from .settings import settings
 from .shared import (
-  CLANG_CC,
-  CLANG_CXX,
   DEBUG,
-  EMAR,
-  EMCC,
-  EMRANLIB,
-  EMXX,
-  LLVM_DWARFDUMP,
-  LLVM_NM,
-  LLVM_OBJCOPY,
-  WASM_LD,
   asmjs_mangle,
   check_call,
   demangle_c_symbol_name,
@@ -46,6 +36,7 @@ from .shared import (
   get_emscripten_temp_dir,
   is_c_symbol,
   path_from_root,
+  paths,
 )
 from .toolchain_profiler import ToolchainProfiler
 from .utils import WINDOWS, run_process
@@ -69,16 +60,16 @@ def get_building_env():
   cache.ensure()
   env = os.environ.copy()
   # point CC etc. to the em* tools.
-  env['CC'] = EMCC
-  env['CXX'] = EMXX
-  env['AR'] = EMAR
-  env['LD'] = EMCC
-  env['NM'] = LLVM_NM
-  env['LDSHARED'] = EMCC
-  env['RANLIB'] = EMRANLIB
+  env['CC'] = paths.EMCC
+  env['CXX'] = paths.EMXX
+  env['AR'] = paths.EMAR
+  env['LD'] = paths.EMCC
+  env['NM'] = paths.LLVM_NM
+  env['LDSHARED'] = paths.EMCC
+  env['RANLIB'] = paths.EMRANLIB
   env['EMSCRIPTEN_TOOLS'] = path_from_root('tools')
-  env['HOST_CC'] = CLANG_CC
-  env['HOST_CXX'] = CLANG_CXX
+  env['HOST_CC'] = paths.CLANG_CC
+  env['HOST_CXX'] = paths.CLANG_CXX
   env['HOST_CFLAGS'] = '-W' # if set to nothing, CFLAGS is used, which we don't want
   env['HOST_CXXFLAGS'] = '-W' # if set to nothing, CXXFLAGS is used, which we don't want
   env['PKG_CONFIG_LIBDIR'] = cache.get_sysroot_dir('local/lib/pkgconfig') + os.path.pathsep + cache.get_sysroot_dir('lib/pkgconfig')
@@ -283,8 +274,8 @@ def lld_flags_for_executable(external_symbols):
 
 
 def link_lld(args, target, external_symbols=None):
-  if not os.path.exists(WASM_LD):
-    exit_with_error('linker binary not found in LLVM directory: %s', WASM_LD)
+  if not os.path.exists(paths.WASM_LD):
+    exit_with_error('linker binary not found in LLVM directory: %s', paths.WASM_LD)
   # runs lld to link things.
   # lld doesn't currently support --start-group/--end-group since the
   # semantics are more like the windows linker where there is no need for
@@ -305,7 +296,7 @@ def link_lld(args, target, external_symbols=None):
     # is passed.
     args.append('--keep-section=target_features')
 
-  cmd = [WASM_LD, '-o', target]
+  cmd = [paths.WASM_LD, '-o', target]
   for a in llvm_backend_args():
     cmd += ['-mllvm', a]
 
@@ -355,7 +346,7 @@ def get_command_with_possible_response_file(cmd):
 
 def emar(action, output_filename, filenames, stdout=None, stderr=None, env=None):
   utils.delete_file(output_filename)
-  cmd = [EMAR, action, output_filename] + filenames
+  cmd = [paths.EMAR, action, output_filename] + filenames
   cmd = get_command_with_possible_response_file(cmd)
   run_process(cmd, stdout=stdout, stderr=stderr, env=env)
 
@@ -1016,7 +1007,7 @@ def wasm2js(js_file, wasm_file, opt_level, use_closure_compiler, debug_info, sym
 
 def strip(infile, outfile, debug=False, sections=None):
   """Strip DWARF and/or other specified sections from a wasm file"""
-  cmd = [LLVM_OBJCOPY, infile, outfile]
+  cmd = [paths.LLVM_OBJCOPY, infile, outfile]
   if debug:
     cmd += ['--remove-section=.debug*']
   if sections:
@@ -1164,7 +1155,7 @@ def emit_wasm_source_map(wasm_file, map_file, final_wasm):
   # importlib.
   wasm_sourcemap = importlib.import_module('tools.wasm-sourcemap')
   sourcemap_cmd = [wasm_file,
-                   '--dwarfdump=' + LLVM_DWARFDUMP,
+                   '--dwarfdump=' + paths.LLVM_DWARFDUMP,
                    '-o',  map_file,
                    '--basepath=' + base_path]
 

--- a/tools/emdwp.py
+++ b/tools/emdwp.py
@@ -16,4 +16,4 @@ sys.path.insert(0, __rootdir__)
 
 from tools import shared
 
-shared.exec_process([shared.LLVM_DWP] + sys.argv[1:])
+shared.exec_process([shared.paths.LLVM_DWP] + sys.argv[1:])

--- a/tools/emnm.py
+++ b/tools/emnm.py
@@ -16,4 +16,4 @@ sys.path.insert(0, __rootdir__)
 
 from tools import shared
 
-shared.exec_process([shared.LLVM_NM] + sys.argv[1:])
+shared.exec_process([shared.paths.LLVM_NM] + sys.argv[1:])

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -29,7 +29,7 @@ from tools import (
   webassembly,
 )
 from tools.settings import settings, user_settings
-from tools.shared import DEBUG, asmjs_mangle, in_temp
+from tools.shared import DEBUG, asmjs_mangle, in_temp, paths
 from tools.toolchain_profiler import ToolchainProfiler
 from tools.utils import exit_with_error, path_from_root, removeprefix
 
@@ -497,7 +497,7 @@ def finalize_wasm(infile, outfile, js_syms):
       with shared.get_temp_files().get_file('.bin') as url_file:
         utils.write_binary(url_file,
                            leb128.u.encode(len(base_url)) + base_url.encode('utf-8'))
-        cmd = [shared.LLVM_OBJCOPY,
+        cmd = [paths.LLVM_OBJCOPY,
                '--add-section',
                'sourceMappingURL=' + url_file,
                infile]

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -328,7 +328,7 @@ def generate_object_file(data_files):
       .dc.a 0
       .size __emscripten_embedded_file_data, {total_size}
       '''))
-  cmd = [shared.EMCC, '-c', asm_file, '-o', options.obj_output]
+  cmd = [shared.paths.EMCC, '-c', asm_file, '-o', options.obj_output]
   if options.wasm64:
     target = 'wasm64-unknown-emscripten'
     cmd.append('-Wno-experimental')

--- a/tools/link.py
+++ b/tools/link.py
@@ -45,7 +45,7 @@ from .settings import (
   settings,
   user_settings,
 )
-from .shared import DEBUG, DYLIB_EXTENSIONS, do_replace, in_temp
+from .shared import DEBUG, DYLIB_EXTENSIONS, do_replace, in_temp, paths
 from .toolchain_profiler import ToolchainProfiler
 from .utils import (
   WINDOWS,
@@ -3092,7 +3092,7 @@ def package_files(options, target):
     rtn.append(object_file)
 
   cmd = building.get_command_with_possible_response_file(
-    [shared.FILE_PACKAGER, utils.replace_suffix(target, '.data')] + file_args)
+    [paths.FILE_PACKAGER, utils.replace_suffix(target, '.data')] + file_args)
   if options.preload_files:
     # Preloading files uses --pre-js code that runs before the module is loaded.
     file_code = shared.check_call(cmd, stdout=PIPE).stdout

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -18,6 +18,7 @@ from typing import List, Optional
 
 from . import building, cache, diagnostics, shared, utils
 from .settings import settings
+from .shared import paths
 from .toolchain_profiler import ToolchainProfiler
 from .utils import read_file
 
@@ -194,9 +195,9 @@ ninja_required_version = 1.5
 
 ASFLAGS = {join_cmd(asflags)}
 CFLAGS = {join_cmd(cflags)}
-EMCC = {shared.EMCC}
-EMXX = {shared.EMXX}
-EMAR = {shared.EMAR}
+EMCC = {paths.EMCC}
+EMXX = {paths.EMXX}
+EMAR = {paths.EMAR}
 
 rule cc
   depfile = $out.d
@@ -496,9 +497,9 @@ class Library:
     for src in self.get_files():
       ext = utils.suffix(src)
       if ext in {'.s', '.S', '.c'}:
-        cmd = shared.EMCC
+        cmd = paths.EMCC
       else:
-        cmd = shared.EMXX
+        cmd = paths.EMXX
       cmd = [cmd, '-c']
       if ext == '.s':
         # .s files are processed directly by the assembler.  In this case we can't pass


### PR DESCRIPTION
This is a step towards separating the import of python modules from the initialization of the compiler.  The goal here is to remove top level code (i.e. Remove side effects from importing).