### PR TITLE
When Atomics.wait() is polyfilled, do not attempt to use it in _emscripten_thread_mailbox_await()

### DIFF
--- a/src/lib/libatomic.js
+++ b/src/lib/libatomic.js
@@ -22,9 +22,9 @@ addToLibrary({
   //   https://github.com/tc39/proposal-atomics-wait-async/blob/master/PROPOSAL.md
   // This polyfill performs polling with setTimeout() to observe a change in the
   // target memory location.
-  $waitAsyncPolyfilled: `Atomics.waitAsyncPolyfilled = (!Atomics.waitAsync || (globalThis.navigator?.userAgent && Number((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91));`,
+  $waitAsyncPolyfilled: '=(!Atomics.waitAsync || (globalThis.navigator?.userAgent && Number((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91));',
   $polyfillWaitAsync__deps: ['$waitAsyncPolyfilled'],
-  $polyfillWaitAsync__postset: `if (Atomics.waitAsyncPolyfilled) {
+  $polyfillWaitAsync__postset: `if (waitAsyncPolyfilled) {
   let __Atomics_waitAsyncAddresses = [/*[i32a, index, value, maxWaitMilliseconds, promiseResolve]*/];
   function __Atomics_pollWaitAsyncAddresses() {
     let now = performance.now();

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -1263,7 +1263,7 @@ var LibraryPThread = {
 
   _emscripten_thread_mailbox_await__deps: ['$checkMailbox', '$waitAsyncPolyfilled'],
   _emscripten_thread_mailbox_await: (pthread_ptr) => {
-    if (!Atomics.waitAsyncPolyfilled) {
+    if (!waitAsyncPolyfilled) {
       // Wait on the pthread's initial self-pointer field because it is easy and
       // safe to access from sending threads that need to notify the waiting
       // thread.


### PR DESCRIPTION
When Atomics.wait() is polyfilled, do not attempt to use it in _emscripten_thread_mailbox_await(), since the polyfill will not work there. This is take two at fixing #25494.