### PR TITLE
Added test for emscripten_html5_remove_event_listener

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2545,7 +2545,7 @@ Module["preRun"] = () => {
     self.btest_exit('test_html5_core.c', cflags=opts)
 
   def test_html5_remove_event_listener(self):
-    self.btest_exit('test_html5_remove_event_listener.c', cflags=['-sMIN_SAFARI_VERSION=150000'])
+    self.btest_exit('test_html5_remove_event_listener.c', cflags=[f'-DSAFARI_SUPPORT={int(not self.is_wasm64())}'])
 
   @parameterized({
     '': ([],),

--- a/test/test_html5_remove_event_listener.c
+++ b/test/test_html5_remove_event_listener.c
@@ -135,11 +135,16 @@ int main() {
 
   checkCount(2);
 
-  // internally, emscripten_set_fullscreenchange_callback sets 2 event handlers ("webkitfullscreenchange" and "fullscreenchange")
+  // internally, emscripten_set_fullscreenchange_callback can set 2 event handlers ("webkitfullscreenchange" and "fullscreenchange")
   ret = emscripten_set_fullscreenchange_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, useCapture, screen_callback);
   ASSERT_RESULT(emscripten_set_fullscreenchange_callback);
 
+#if SAFARI_SUPPORT == 1
+  // 2 events handlers are set when there is safari support
   checkCount(4);
+#else
+  checkCount(3);
+#endif
 
   // we make sure that the 2 event handlers get removed (#25846)
   ret = emscripten_html5_remove_event_listener(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, EMSCRIPTEN_EVENT_FULLSCREENCHANGE, screen_callback);


### PR DESCRIPTION
I realized while taking another look at the code, that the 2 event handlers added in the "Safari" case do not depend on where the test is running but only on a constant (`MIN_SAFARI_VERSION`):

```js
#if MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
    // As of Safari 13.0.3 on macOS Catalina 10.15.1 still ships with prefixed webkitfullscreenchange. TODO: revisit this check once Safari ships unprefixed version.
    registerFullscreenChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_FULLSCREENCHANGE }}}, "webkitfullscreenchange", targetThread);
#endif
```

So I added the test that verifies that the fix for bug #25846 (emscripten_html5_remove_event_listener does not clean fullscreenchange entirely) is properly implemented, since the test can pass on other browsers (Chrome, Firefox, etc...).