### PR TITLE
Skip `-lfoo` expansion for real dynamic libraries. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8402,8 +8402,7 @@ int main() {
     self.run_process([EMCC, test_file('hello_world.c'), '-sSIDE_MODULE', '-o', 'libside.so'])
 
     # Attempting to link statically against a side module (libside.so) should fail.
-    err = self.expect_fail([EMCC, '-L.', '-lside'])
-    self.assertContained(r'error: attempted static link of dynamic object \.[/\\]libside.so', err, regex=True)
+    self.assert_fail([EMCC, '-L.', '-lside'], 'wasm-ld: error: unable to find library -lside')
 
     # But a static library in the same location (libside.a) should take precedence.
     self.run_process([EMCC, test_file('hello_world.c'), '-c'])

--- a/tools/link.py
+++ b/tools/link.py
@@ -2800,17 +2800,17 @@ def process_libraries(options, flags):
       continue
 
     static_lib = f'lib{lib}.a'
-    if not settings.RELOCATABLE and not find_library(static_lib, options.lib_dirs):
+    if not settings.RELOCATABLE and not settings.MAIN_MODULE and not find_library(static_lib, options.lib_dirs):
       # Normally we can rely on the native linker to expand `-l` args.
-      # However, emscripten also supports `.so` files that are actually just
-      # regular object file.  This means we need to support `.so` files even
+      # However, emscripten also supports fake `.so` files that are actually
+      # just regular object files.  This means we need to support `.so` files even
       # when statically linking.  The native linker (wasm-ld) will otherwise
       # ignore .so files in this mode.
       found_dylib = False
       for ext in DYLIB_EXTENSIONS:
         name = 'lib' + lib + ext
         path = find_library(name, options.lib_dirs)
-        if path:
+        if path and not building.is_wasm_dylib(path):
           found_dylib = True
           new_flags.append(path)
           break


### PR DESCRIPTION
The code here expands `-lfoo` to `/path/to/libfoo.so` for fake shared libraries so that the linker can find them (it won't look for .so files otherwise when static linking).