### PR TITLE
Simplify test_html5_remove_event_listener.c

### DIFF
--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -1084,6 +1084,7 @@ var LibraryHTML5 = {
 
 #if MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
     // As of Safari 13.0.3 on macOS Catalina 10.15.1 still ships with prefixed webkitfullscreenchange. TODO: revisit this check once Safari ships unprefixed version.
+    // TODO: When this block is removed, also change test/test_html5_remove_event_listener.c test expectation on emscripten_set_fullscreenchange_callback().
     registerFullscreenChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefs.EMSCRIPTEN_EVENT_FULLSCREENCHANGE }}}, "webkitfullscreenchange", targetThread);
 #endif
 

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2545,7 +2545,7 @@ Module["preRun"] = () => {
     self.btest_exit('test_html5_core.c', cflags=opts)
 
   def test_html5_remove_event_listener(self):
-    self.btest_exit('test_html5_remove_event_listener.c', cflags=[f'-DSAFARI_SUPPORT={int(not self.is_wasm64())}'])
+    self.btest_exit('test_html5_remove_event_listener.c')
 
   @parameterized({
     '': ([],),

--- a/test/test_html5_remove_event_listener.c
+++ b/test/test_html5_remove_event_listener.c
@@ -56,6 +56,12 @@ void checkCount(int count) {
   assert(count == eventHandlersCount);
 }
 
+void checkCountBetween(int minCount, int maxCount) {
+  int eventHandlersCount = EM_ASM_INT({ return JSEvents.eventHandlers.length; });
+  printf("Detected [%d] handlers\n", eventHandlersCount);
+  assert(minCount <= eventHandlersCount && eventHandlersCount <= maxCount);
+}
+
 int main() {
   bool useCapture = true;
   void *userData3 = "3";
@@ -139,12 +145,9 @@ int main() {
   ret = emscripten_set_fullscreenchange_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, useCapture, screen_callback);
   ASSERT_RESULT(emscripten_set_fullscreenchange_callback);
 
-#if SAFARI_SUPPORT == 1
   // 2 events handlers are set when there is safari support
-  checkCount(4);
-#else
-  checkCount(3);
-#endif
+  // TODO: change to checkCount(3) after prefixed Safari fallback is removed.
+  checkCountBetween(3, 4);
 
   // we make sure that the 2 event handlers get removed (#25846)
   ret = emscripten_html5_remove_event_listener(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, EMSCRIPTEN_EVENT_FULLSCREENCHANGE, screen_callback);


### PR DESCRIPTION
Simplify test_html5_remove_event_listener.c to not have separate cases for SAFARI_SUPPORT. Fixes https://github.com/emscripten-core/emscripten/pull/25535#issuecomment-3583269986