### PR TITLE
Extend posixtest_browser test suite to automatically skip

### DIFF
--- a/test/test_posixtest.py
+++ b/test/test_posixtest.py
@@ -17,6 +17,7 @@ import test_posixtest_browser
 from browser_common import browser_should_skip_feature
 from common import RunnerCore, path_from_root
 from decorators import node_pthreads
+
 from tools.feature_matrix import Feature
 
 testsuite_root = path_from_root('test/third_party/posixtestsuite')


### PR DESCRIPTION
Extend posixtest_browser test suite to automatically skip tests when EMTEST_LACKS_SHARED_ARRAY_BUFFER=1 or EMTEST_AUTOSKIP=1 env. vars are set.