### PR TITLE
Mark test_posix_proxy_sockets to depend on multithreading

### DIFF
--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -26,8 +26,8 @@ from decorators import (
   requires_native_clang,
   test_file,
 )
-
 from test_browser import requires_shared_array_buffer
+
 from tools import config
 from tools.shared import CLANG_CC, EMCC
 from tools.utils import path_from_root, run_process


### PR DESCRIPTION
Mark test_posix_proxy_sockets to depend on multithreading to skip it in old non-SAB capable browsers.