### PR TITLE
Avoid "Unreachable code" error in libpthread.js

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -417,8 +417,9 @@ var LibraryPThread = {
       // Module['pthreadPoolReady'] promise.
       Module['pthreadPoolReady'] = pthreadPoolReady;
       return;
-#endif
+#else
       return pthreadPoolReady;
+#endif
     },
 #endif // PTHREAD_POOL_SIZE
 


### PR DESCRIPTION
When PTHREAD_POOL_DELAY_LOAD, the .js file will have 2 return statements next to each other, making the second unreachable.