### PR TITLE
[tsgen] Remove asyncify function exports assertions.

### DIFF
--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -962,6 +962,10 @@ def create_receiving(function_exports, other_exports, library_symbols, aliases):
   receiving.append('\nfunction assignWasmExports(wasmExports) {')
   if settings.ASSERTIONS:
     for sym in exports:
+      if settings.EMBIND_GEN_MODE and sym.startswith('asyncify_'):
+        # EMBIND_GEN_MODE is run before binaryen so the asyncify exports that
+        # are created by binaryen will be missing.
+        continue
       receiving.append(f"  assert(typeof wasmExports['{sym}'] != 'undefined', 'missing Wasm export: {sym}');")
   for sym, info in exports.items():
     is_function = type(info) == webassembly.FuncType

--- a/tools/link.py
+++ b/tools/link.py
@@ -2093,10 +2093,6 @@ def run_embind_gen(options, wasm_target, js_syms, extra_settings):
     settings.MEMORY64 = 2
   # Source maps haven't been generated yet and aren't needed to run embind_gen.
   settings.LOAD_SOURCE_MAP = 0
-  # TS generation is run before wasm-opt so some of the assertions may be incorrect
-  # e.g. when -sASYNCIFY=1 `asyncify_start_unwind` does not yet exist (that pass
-  # creates it).
-  settings.ASSERTIONS = 0
   outfile_js = in_temp('tsgen.js')
   # The Wasm outfile may be modified by emscripten.emscript, so use a temporary file.
   outfile_wasm = in_temp('tsgen.wasm')


### PR DESCRIPTION
When using `tsgen` with `-sASYNCIFY=1` and assertions enabled, an assertion failure occurs: `Assertion failed: missing Wasm export: asyncify_start_unwind`. This is due to https://github.com/emscripten-core/emscripten/pull/25541.

This PR disables assertions for the `_asyncify_<x>` exports when running `tsgen` to resolve the issue.

Continuation of #25780