### PR TITLE
[embind] Allow raw pointers for individual arguments and return values.

### DIFF
--- a/test/embind/test_embind_allow_raw_pointer.cpp
+++ b/test/embind/test_embind_allow_raw_pointer.cpp
@@ -1,0 +1,21 @@
+#include <emscripten/bind.h>
+
+using namespace emscripten;
+
+class C {};
+
+void onePointerArg(C* ptr) {}
+void twoPointerArg(C* ptr1, C* ptr2) {}
+void sandwich(int a, C* ptr1, int b) {}
+
+C* pointerRet() { return nullptr; }
+C* pointerRetPointerArg(C* ptr) { return nullptr; }
+
+EMSCRIPTEN_BINDINGS(raw_pointers) {
+  class_<C>("C");
+  function("onePointerArg", &onePointerArg, allow_raw_pointer<arg<0>>());
+  function("twoPointerArg", &twoPointerArg, allow_raw_pointer<arg<0>>(), allow_raw_pointer<arg<1>>());
+  function("sandwich", &sandwich, allow_raw_pointer<arg<1>>());
+  function("pointerRet", &pointerRet, allow_raw_pointer<ret_val>());
+  function("pointerRetPointerArg", &pointerRetPointerArg, allow_raw_pointer<ret_val>(), allow_raw_pointer<arg<0>>());
+}

--- a/test/embind/test_embind_wrong_arg_allow.cpp
+++ b/test/embind/test_embind_wrong_arg_allow.cpp
@@ -1,0 +1,12 @@
+#include <emscripten/bind.h>
+
+using namespace emscripten;
+
+class C {};
+
+void passThrough(int arg0, C* ptr) {}
+
+EMSCRIPTEN_BINDINGS(raw_pointers) {
+  class_<C>("C");
+  function("passThrough", &passThrough, allow_raw_pointer<arg<0>>());
+}

--- a/test/embind/test_embind_wrong_ret_allow.cpp
+++ b/test/embind/test_embind_wrong_ret_allow.cpp
@@ -1,0 +1,12 @@
+#include <emscripten/bind.h>
+
+using namespace emscripten;
+
+class C {};
+
+void passThrough(C* ptr) {}
+
+EMSCRIPTEN_BINDINGS(raw_pointers) {
+  class_<C>("C");
+  function("passThrough", &passThrough, allow_raw_pointer<ret_val>());
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3362,9 +3362,14 @@ More info: https://emscripten.org
     'val_invoke': ['embind/test_embind_no_raw_pointers_val_invoke.cpp'],
     'val_call': ['embind/test_embind_no_raw_pointers_val_call.cpp'],
     'val_new': ['embind/test_embind_no_raw_pointers_val_new.cpp'],
+    'wrong_ret_allow': ['embind/test_embind_wrong_ret_allow.cpp'],
+    'wrong_arg_allow': ['embind/test_embind_wrong_arg_allow.cpp'],
   })
   def test_embind_no_raw_pointers(self, filename):
     self.assert_fail([EMCC, '-lembind', test_file(filename)], 'Implicitly binding raw pointers is illegal')
+
+  def test_embind_allow_raw_pointer(self):
+    self.emcc(test_file('embind/test_embind_allow_raw_pointer.cpp'), ['-lembind'])
 
   @is_slow_test
   @parameterized({


### PR DESCRIPTION
Previously, allow_raw_pointer<arg<x>> mapped to allow_raw_pointers, which allowed pointers for all arguments. This PR implements the checks to verify just the specified argument or return value are allowed pointers.