### PR TITLE
Add assertions to emscriptenGetAudioObject. NFC

### DIFF
--- a/src/lib/libwebaudio.js
+++ b/src/lib/libwebaudio.js
@@ -73,7 +73,12 @@ var LibraryWebAudio = {
 
   // Call this function from JavaScript to get the Web Audio object corresponding to the given
   // Wasm handle ID.
-  $emscriptenGetAudioObject: (objectHandle) => emAudio[objectHandle],
+  $emscriptenGetAudioObject: (objectHandle) => {
+#if ASSERTIONS || WEBAUDIO_DEBUG
+    emAudioExpectNodeOrContext(objectHandle, 'emscriptenGetAudioObject');
+#endif
+    return emAudio[objectHandle];
+  },
 
   // Performs the work of getting the AudioContext's render quantum size.
   $emscriptenGetContextQuantumSize: (contextHandle) => {

--- a/test/webaudio/audioworklet_params_mixing.c
+++ b/test/webaudio/audioworklet_params_mixing.c
@@ -98,13 +98,11 @@ bool process(int numInputs, const AudioSampleFrame* inputs, int numOutputs, Audi
 // it's already fading up or down, we reverse the fade direction).
 EM_JS(void, doFade, (EMSCRIPTEN_AUDIO_WORKLET_NODE_T workletID), {
   var worklet = emscriptenGetAudioObject(workletID);
-  if (worklet) {
-    // Emscripten's API creates these from a C array, indexing them instead of a
-    // name. Chrome and FF work with 0 but Safari requires the correct "0".
-    var param = worklet.parameters.get("0");
-    if (param) {
-      param.setTargetAtTime((param.value > 0.5) ? 0 : 1, 0 /* same as context.currentTime */, 0.5);
-    }
+  // Emscripten's API creates these from a C array, indexing them instead of a
+  // name. Chrome and FF work with 0 but Safari requires the correct "0".
+  var param = worklet.parameters.get("0");
+  if (param) {
+    param.setTargetAtTime((param.value > 0.5) ? 0 : 1, 0 /* same as context.currentTime */, 0.5);
   }
 })
 

--- a/test/webaudio/audioworklet_test_shared.inc
+++ b/test/webaudio/audioworklet_test_shared.inc
@@ -30,30 +30,25 @@ EMSCRIPTEN_WEBAUDIO_T bassID = 0;
 // registered as an internal audio object and the ID returned).
 EM_JS(EMSCRIPTEN_WEBAUDIO_T, createTrack, (EMSCRIPTEN_WEBAUDIO_T ctxID, const char* url, bool looping), {
   var context = emscriptenGetAudioObject(ctxID);
-  if (context) {
-    var audio = document.createElement('audio');
-    // Number() wrapper is a workaround for UTF8ToString() needing a JS number
-    // and from64() not being available in EM_JS macros. Fix in UTF8ToString?
-    audio.src = UTF8ToString(Number(url));
-    audio.loop = looping;
-    var track = context.createMediaElementSource(audio);
-    return emscriptenRegisterAudioObject(track);
-  }
-  return 0;
+  var audio = document.createElement('audio');
+  // Number() wrapper is a workaround for UTF8ToString() needing a JS number
+  // and from64() not being available in EM_JS macros. Fix in UTF8ToString?
+  audio.src = UTF8ToString(Number(url));
+  audio.loop = looping;
+  var track = context.createMediaElementSource(audio);
+  return emscriptenRegisterAudioObject(track);
 })
 
 // Toggles the play/pause of a MediaElementAudioSourceNode given its ID
 EM_JS(void, toggleTrack, (EMSCRIPTEN_WEBAUDIO_T srcID), {
   var source = emscriptenGetAudioObject(srcID);
-  if (source) {
-    var audio = source.mediaElement;
-    if (audio) {
-      if (audio.paused) {
-        audio.currentTime = 0;
-        audio.play();
-      } else {
-        audio.pause();
-      }
+  var audio = source.mediaElement;
+  if (audio) {
+    if (audio.paused) {
+      audio.currentTime = 0;
+      audio.play();
+    } else {
+      audio.pause();
     }
   }
 })


### PR DESCRIPTION
This API was added when audioworklets were first added, but it doesn't
look like it was intended to work with invalid inputs: 5402fc921374.

At least none of the original usages in 5402fc921374 checked for