### PR TITLE
Remove redundant max_core param from ParallelTestSuite. NFC

### DIFF
--- a/test/parallel_testsuite.py
+++ b/test/parallel_testsuite.py
@@ -105,9 +105,8 @@ class ParallelTestSuite(unittest.BaseTestSuite):
   Creates worker threads, manages the task queue, and combines the results.
   """
 
-  def __init__(self, max_cores, options):
+  def __init__(self, options):
     super().__init__()
-    self.max_cores = max_cores
     self.max_failures = options.max_failures
     self.failing_and_slow_first = options.failing_and_slow_first
 
@@ -132,7 +131,7 @@ class ParallelTestSuite(unittest.BaseTestSuite):
     tests = self.get_sorted_tests()
     self.num_tests = self.countTestCases()
     contains_browser_test = any(test.is_browser_test() for test in tests)
-    use_cores = cap_max_workers_in_pool(min(self.max_cores, len(tests), num_cores()), contains_browser_test)
+    use_cores = cap_max_workers_in_pool(min(self.num_tests, num_cores()), contains_browser_test)
     errlog(f'Using {use_cores} parallel test processes')
     with multiprocessing.Manager() as manager:
       # Give each worker a unique ID.

--- a/test/runner.py
+++ b/test/runner.py
@@ -412,7 +412,7 @@ def suite_for_module(module, tests, options):
     has_multiple_tests = len(tests) > 1
     has_multiple_cores = parallel_testsuite.num_cores() > 1
     if suite_supported and has_multiple_tests and has_multiple_cores:
-      return parallel_testsuite.ParallelTestSuite(len(tests), options)
+      return parallel_testsuite.ParallelTestSuite(options)
   return unittest.TestSuite()
 
 


### PR DESCRIPTION
The max number of cores to used is already limited to the number of test cases so this is simply redundant.