### PR TITLE
Improve `EMTEST_DETECT_TEMPFILE_LEAKS` handling. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -696,31 +696,31 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
       os.chdir(os.path.dirname(self.get_dir()))
       force_delete_dir(self.get_dir())
 
-      if EMTEST_DETECT_TEMPFILE_LEAKS and not DEBUG:
-        temp_files_after_run = []
-        for root, dirnames, filenames in os.walk(self.temp_dir):
-          for dirname in dirnames:
-            temp_files_after_run.append(os.path.normpath(os.path.join(root, dirname)))
-          for filename in filenames:
-            temp_files_after_run.append(os.path.normpath(os.path.join(root, filename)))
+    if EMTEST_DETECT_TEMPFILE_LEAKS:
+      temp_files_after_run = []
+      for root, dirnames, filenames in os.walk(self.temp_dir):
+        for dirname in dirnames:
+          temp_files_after_run.append(os.path.normpath(os.path.join(root, dirname)))
+        for filename in filenames:
+          temp_files_after_run.append(os.path.normpath(os.path.join(root, filename)))
 
-        # Our leak detection will pick up *any* new temp files in the temp dir.
-        # They may not be due to us, but e.g. the browser when running browser
-        # tests. Until we figure out a proper solution, ignore some temp file
-        # names that we see on our CI infrastructure.
-        ignorable_file_prefixes = [
-          '/tmp/tmpaddon',
-          '/tmp/circleci-no-output-timeout',
-          '/tmp/wasmer',
-        ]
+      # Our leak detection will pick up *any* new temp files in the temp dir.
+      # They may not be due to us, but e.g. the browser when running browser
+      # tests. Until we figure out a proper solution, ignore some temp file
+      # names that we see on our CI infrastructure.
+      ignorable_file_prefixes = [
+        '/tmp/tmpaddon',
+        '/tmp/circleci-no-output-timeout',
+        '/tmp/wasmer',
+      ]
 
-        left_over_files = set(temp_files_after_run) - set(self.temp_files_before_run)
-        left_over_files = [f for f in left_over_files if not any(f.startswith(p) for p in ignorable_file_prefixes)]
-        if left_over_files:
-          errlog(f'ERROR: After running test, there are {len(left_over_files)} new temporary files/directories left behind:')
-          for f in left_over_files:
-            errlog('leaked file: ', f)
-          self.fail(f'Test leaked {len(left_over_files)} temporary files!')
+      left_over_files = set(temp_files_after_run) - set(self.temp_files_before_run)
+      left_over_files = [f for f in left_over_files if not any(f.startswith(p) for p in ignorable_file_prefixes)]
+      if left_over_files:
+        errlog(f'ERROR: After running test, there are {len(left_over_files)} new temporary files/directories left behind:')
+        for f in left_over_files:
+          errlog('leaked file: ', f)
+        self.fail(f'Test leaked {len(left_over_files)} temporary files!')
 
   def get_setting(self, key, default=None):
     return self.settings_mods.get(key, default)

--- a/test/runner.py
+++ b/test/runner.py
@@ -393,9 +393,6 @@ def load_test_suites(args, modules, options):
       suites.append((m.__name__, suite))
   if not found_start:
     utils.exit_with_error(f'unable to find --start-at test: {options.start_at}')
-  if total_tests == 1 or parallel_testsuite.num_cores() == 1:
-    # TODO: perhaps leave it at 2 if it was 2 before?
-    common.EMTEST_SAVE_DIR = 1
   return suites, unmatched_test_names
 
 
@@ -686,6 +683,14 @@ def main():
   set_env('EMTEST_VERBOSE', options.verbose > 1)
   set_env('EMTEST_CORES', options.cores)
   set_env('EMTEST_FORCE64', options.force64)
+
+  if common.EMTEST_DETECT_TEMPFILE_LEAKS:
+    if shared.DEBUG:
+      # In EMCC_DEBUG mode emscripten explicitly leaves stuff in the tmp directory
+      utils.exit_with_error('EMTEST_DETECT_TEMPFILE_LEAKS is not compatible with EMCC_DEBUG')
+    if common.EMTEST_SAVE_DIR:
+      # In --save-dir/--no-clean mode the parallel test runner leaves files in the temp directory
+      utils.exit_with_error('EMTEST_DETECT_TEMPFILE_LEAKS is not compatible with --save-dir/--no-clean')
 
   configure()
 


### PR DESCRIPTION
1. Honor `EMTEST_DETECT_TEMPFILE_LEAKS` even when in non-parallel test suites.  I'm not sure why were only trying to enforce this for the parallel runner.
2. Make `EMTEST_DETECT_TEMPFILE_LEAKS` explicitly incompatible with `EMCC_DEBUG`