### PR TITLE
Generate wrappers for JS aliases when needed

### DIFF
--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -255,6 +255,14 @@ function addImplicitDeps(snippet, deps) {
   }
 }
 
+function sigToArgs(sig) {
+  const args = []
+  for (var i = 1; i < sig.length; i++) {
+    args.push(`a${i}`);
+  }
+  return args.join(',')
+}
+
 function handleI64Signatures(symbol, snippet, sig, i53abi) {
   // Handle i64 parameters and return values.
   //
@@ -623,7 +631,7 @@ function(${args}) {
         }
       }
 
-      const isFunction = typeof snippet == 'function';
+      let isFunction = typeof snippet == 'function';
       let isNativeAlias = false;
 
       const postsetId = symbol + '__postset';
@@ -642,20 +650,34 @@ function(${args}) {
         // Redirection for aliases. We include the parent, and at runtime
         // make ourselves equal to it.  This avoid having duplicate
         // functions with identical content.
-        if (WASM_EXPORTS.has(snippet)) {
-          //printErr(`native alias: ${mangled} -> ${snippet}`);
-          //console.error(WASM_EXPORTS);
-          nativeAliases[mangled] = snippet;
+        const aliasTarget = snippet;
+        if (WASM_EXPORTS.has(aliasTarget)) {
+          debugLog(`native alias: ${mangled} -> ${aliasTarget}`);
+          nativeAliases[mangled] = aliasTarget;
           snippet = undefined;
           isNativeAlias = true;
         } else {
-          //printErr(`js alias: ${mangled} -> ${snippet}`);
-          snippet = mangleCSymbolName(snippet);
+          debugLog(`js alias: ${mangled} -> ${aliasTarget}`);
+          snippet = mangleCSymbolName(aliasTarget);
+          // When we have an alias for another JS function we can normally
+          // point them at the same function.  However, in some cases (where
+          // signatures are relevant and they differ between and alais and
+          // it's target) we need to construct a forwarding function from
+          // one to the other.
+          const isSigRelevant = MAIN_MODULE || RELOCATABLE || MEMORY64 || CAN_ADDRESS_2GB || (sig && sig.includes('j'));
+          const targetSig = LibraryManager.library[aliasTarget + '__sig'];
+          if (isSigRelevant && sig && targetSig && sig != targetSig) {
+            debugLog(`${symbol}: Alias target (${aliasTarget}) has different signature (${sig} vs ${targetSig})`)
+            isFunction = true;
+            snippet = `(${sigToArgs(sig)}) => ${snippet}(${sigToArgs(targetSig)})`;
+          }
         }
       } else if (typeof snippet == 'object') {
         snippet = stringifyWithFunctions(snippet);
         addImplicitDeps(snippet, deps);
-      } else if (isFunction) {
+      }
+
+      if (isFunction) {
         snippet = processLibraryFunction(snippet, symbol, mangled, deps, isStub);
         addImplicitDeps(snippet, deps);
         if (CHECK_DEPS && !isUserSymbol) {

--- a/src/lib/libemval.js
+++ b/src/lib/libemval.js
@@ -351,8 +351,7 @@ ${functionBody}
 
   // Same as `_emval_invoke`, just imported into Wasm under a different return type.
   // TODO: remove this if/when https://github.com/emscripten-core/emscripten/issues/20478 is fixed.
-  _emval_invoke_i64__deps: ['_emval_invoke'],
-  _emval_invoke_i64: '=__emval_invoke',
+  _emval_invoke_i64: '_emval_invoke',
 
   _emval_typeof__deps: ['$Emval'],
   _emval_typeof: (handle) => {

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 245661,
+  "a.out.js": 245751,
   "a.out.nodebug.wasm": 573748,
-  "total": 819409,
+  "total": 819499,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/test_jslib.py
+++ b/test/test_jslib.py
@@ -495,6 +495,8 @@ extraLibraryFuncs.push('jsfunc');
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '--js-library', 'foo.js'])
     self.assertContained('foo.js:5: file not found: inc.js', err)
 
+  @also_with_wasm64
+  @also_without_bigint
   @parameterized({
     '': ([],),
     'closure': (['--closure=1'],),
@@ -503,7 +505,16 @@ extraLibraryFuncs.push('jsfunc');
     create_file('foo.js', '''
       addToLibrary({
         foo: () => 42,
+        foo__sig: 'i',
+
         foo_alias: 'foo',
+
+        foo_alias_i64: 'foo',
+        foo_alias_i64__sig: 'j',
+        foo_alias_i64__i53abi: true,
+
+        foo_alias_ptr: 'foo',
+        foo_alias_ptr__sig: 'p',
 
         // Normal JS function that calls a native function
         call_native__deps: ['native_func'],
@@ -524,6 +535,8 @@ extraLibraryFuncs.push('jsfunc');
       #include <emscripten.h>
       int foo();
       int foo_alias();
+      void* foo_alias_ptr();
+      int64_t foo_alias_i64();
       int call_native();
       int call_native_alias();
 
@@ -538,6 +551,8 @@ extraLibraryFuncs.push('jsfunc');
       int main() {
         printf("foo: %d\n", foo());
         printf("foo_alias: %d\n", foo_alias());
+        printf("foo_alias_i64: %lld\n", foo_alias_i64());
+        printf("foo_alias_ptr: %p\n", foo_alias_ptr());
         printf("call_native: %d\n", call_native());
         printf("call_native_alias: %d\n", call_native_alias());
         return 0;
@@ -546,6 +561,8 @@ extraLibraryFuncs.push('jsfunc');
     expected = '''\
 foo: 42
 foo_alias: 42
+foo_alias_i64: 42
+foo_alias_ptr: 0x2a
 call_native: 43
 call_native_alias: 44
 '''


### PR DESCRIPTION
In many cases we cannot alias the same function if we have a different signature.  The two main examples are:

1. Dynamic linking where each function needs its own `.sig` attribute.
2. wasm64 / bigint handling where each function might have different signature conversion rules applied.

Fixes #25256