### PR TITLE
Allow exporting of symbols that are not valid JS identifiers

### DIFF
--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -339,7 +339,7 @@ def emscript(in_wasm, out_wasm, outfile_js, js_syms, finalize=True, base_metadat
 
   for e in settings.EXPORTED_FUNCTIONS:
     if not js_manipulation.isidentifier(e):
-      exit_with_error(f'invalid export name: "{e}"')
+      diagnostics.warning('js-compiler', f'export name is not a valid JS symbol: "{e}".  Use `Module` or `wasmExports` to access this symbol')
 
   # memory and global initializers
 
@@ -937,10 +937,16 @@ def create_receiving(function_exports, other_exports, library_symbols, aliases):
     # folks try to call/use a reference that was taken before the
     # wasm module is available.
     for sym in mangled:
-      assignment = sym
-      if (settings.MODULARIZE or not settings.MINIMAL_RUNTIME) and should_export(sym) and settings.MODULARIZE != 'instance':
-        assignment += f" = Module['{sym}']"
-      receiving.append(f"var {assignment} = makeInvalidEarlyAccess('{sym}');")
+      module_export = (settings.MODULARIZE or not settings.MINIMAL_RUNTIME) and should_export(sym) and settings.MODULARIZE != 'instance'
+      if not js_manipulation.isidentifier(sym) and not module_export:
+        continue
+      assignment = f'var {sym}'
+      if module_export:
+        if js_manipulation.isidentifier(sym):
+          assignment += f" = Module['{sym}']"
+        else:
+          assignment = f"Module['{sym}']"
+      receiving.append(f"{assignment} = makeInvalidEarlyAccess('{sym}');")
   else:
     # Declare all exports in a single var statement
     sep = ',\n  '
@@ -975,7 +981,15 @@ def create_receiving(function_exports, other_exports, library_symbols, aliases):
       sig_str = sym.removeprefix('dynCall_')
       assignment += f" = dynCalls['{sig_str}']"
     if do_module_exports and should_export(mangled):
-      assignment += f" = Module['{mangled}']"
+      if js_manipulation.isidentifier(mangled):
+        assignment += f" = Module['{mangled}']"
+      else:
+        assignment = f"Module['{mangled}']"
+    elif not js_manipulation.isidentifier(mangled):
+      # Symbol is not a valid JS identify and also not exported. In this case we
+      # have nothing to do here.
+      continue
+
     if sym in alias_inverse_map:
       for target in alias_inverse_map[sym]:
         assignment += f" = {target}"


### PR DESCRIPTION
In this case we now generate a warning instead of an errors.

Such symbols are not directly accessible in the module scope (since we cannot declare them there).  They are only accessible via `wasmExports` or `Module` dictionary objects.

See: https://github.com/llvm/llvm-project/pull/169043
Fixes: #24825, #23560