### PR TITLE
Update minimum_runtime_check.js for Safari

### DIFF
--- a/src/minimum_runtime_check.js
+++ b/src/minimum_runtime_check.js
@@ -37,7 +37,7 @@
     return;
   }
 
-  var currentSafariVersion = userAgent.includes("Safari/") && userAgent.match(/Version\/(\d+\.?\d*\.?\d*)/) ? humanReadableVersionToPacked(userAgent.match(/Version\/(\d+\.?\d*\.?\d*)/)[1]) : TARGET_NOT_SUPPORTED;
+  var currentSafariVersion = userAgent.includes("Safari/") && !userAgent.includes("Chrome/") && userAgent.match(/Version\/(\d+\.?\d*\.?\d*)/) ? humanReadableVersionToPacked(userAgent.match(/Version\/(\d+\.?\d*\.?\d*)/)[1]) : TARGET_NOT_SUPPORTED;
 #if MIN_SAFARI_VERSION == TARGET_NOT_SUPPORTED
   if (currentSafariVersion < TARGET_NOT_SUPPORTED) {
     throw new Error(`This page was compiled without support for Safari browser. Pass -sMIN_SAFARI_VERSION=${currentSafariVersion} or lower to enable support for this browser.`);


### PR DESCRIPTION
Improve Safari version check so that it no longer triggers on Android

Previous version would trip on Android Chrome which had a UA like

Mozilla/5.0 (Linux; Android 14; Pixel 9 Pro Build/AD1A.240418.003; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.6367.54 Mobile Safari/537.36

Mac OS UAs look like

Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3.1 Safari/605.1.15

So improve things by explicitly checking for "Safari" after the version number

