### PR TITLE
Enable caching of generated JS output

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 4.0.22 (in development)
 -----------------------
+- Emscripten will now cache the JS code that it generates and re-use when
+  linking with the same settings at a later date.  This should improve link
+  times generally but should especially noticeable when linking lots of small
+  programs such as during autoconf or CMake feature detection. (#25929)
 - The minimum version of python required to run emscripten was updated from 3.8
   to 3.10. (#25891)
 


### PR DESCRIPTION
Logical extension of what we were already doing for symbol lists.  This caches the whole output of the JS compiler and re-uses it when settings and JS inputs are unchanged.

This improves link time when the cache is hot (i.e. when the same program has been linked before).

Hello world:

520ms -> 350ms

Hello world + -sINCLUDE_FULL_LIBRARY:

588ms -> 370ms