### PR TITLE
Fix browser.test_fetch_stream_abort_asan race condition

### DIFF
--- a/test/fetch/test_fetch_stream_abort.cpp
+++ b/test/fetch/test_fetch_stream_abort.cpp
@@ -11,6 +11,8 @@
 #include <emscripten/fetch.h>
 #include <emscripten/eventloop.h>
 
+bool fetch_abort_queued = false;
+
 int main() {
   emscripten_fetch_attr_t attr;
   emscripten_fetch_attr_init(&attr);
@@ -32,6 +34,8 @@ int main() {
       fetch->dataOffset,
       fetch->dataOffset + fetch->numBytes);
 
+    if (fetch_abort_queued) return;
+    fetch_abort_queued = true;
     emscripten_set_immediate([](void *arg) {
       emscripten_fetch_t *fetch = (emscripten_fetch_t *)arg;
       printf("Abort fetch when downloading\n");


### PR DESCRIPTION
Fix `browser.test_fetch_stream_abort_asan race` condition by avoiding double free of the fetch structure.

The issue in the test was that `onprogress` handler in the test would queue a setimmediate to free the fetch structure after the turn of the event loop.

But the browser might also have fed a second `onprogress` handler call before the previous setimmediate, which would also trigger a second setimmediate callback.

Then the two setimmediate callbacks would fire, resulting in a double `emscripten_fetch_close()` calls, and the asan test croaking:

<img width="1361" height="1352" alt="image" src="https://github.com/user-attachments/assets/067491b5-0093-4072-98a6-aa02911e3693" />

Fix the race condition by ensuring only a single abort is queued.