### PR TITLE
Make wasm-sourcemap.py faster

### DIFF
--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -226,8 +226,6 @@ def extract_comp_dir_map(text):
   map_stmt_list_to_comp_dir = {}
   iterator = compile_unit_pattern.finditer(text)
   current_match = next(iterator, None)
-  if not current_match:
-    return map_stmt_list_to_comp_dir
 
   while current_match:
     next_match = next(iterator, None)


### PR DESCRIPTION
1. This replaces uses of `Pattern.split` with `Pattern.finditer`.
2. In `extract_func_ranges`, instead of splitting the whole text into single tags first and searching `DW_TAG_(subprogram|inlined_subroutine)` in each of them, we search the pattern from the whole text using `finditer` and tries to parse a tag from each match.

This improves the running time on `wasm-opt.wasm` by ~18% (14.9s -> 12.2s).