### PR TITLE
Fix a couple of issues with JS output caching

### DIFF
--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -194,6 +194,8 @@ def generate_js_compiler_input_hash(symbols_only=False):
   if not symbols_only:
     files += settings.PRE_JS_FILES
     files += settings.POST_JS_FILES
+    # Also include other .js files that could be included in the output.
+    files += glob.glob(utils.path_from_root('src/*.js'))
 
   for file in sorted(files):
     file_contents.append(utils.read_file(file))
@@ -340,7 +342,9 @@ def get_cached_file(filetype, filename, generator, cache_limit):
 def compile_javascript_cached():
   # Avoiding using the cache when generating struct info since
   # this step is performed while the cache is locked.
-  if DEBUG or settings.BOOTSTRAPPING_STRUCT_INFO or config.FROZEN_CACHE:
+  # Sadly we have to skip the caching whenwhere we have user JS libraries.  This is because
+  # these libraries can import arbirary other JS files (either vis node's `import` or via #include)
+  if DEBUG or settings.BOOTSTRAPPING_STRUCT_INFO or config.FROZEN_CACHE or settings.JS_LIBRARIES:
     return compile_javascript()
 
   content_hash = generate_js_compiler_input_hash()


### PR DESCRIPTION
- Skip caching of JS output in the presence of user JS libraries.
- Include our core js files, since changing them should invalid the cache.

Followup to #25942