### PR TITLE
Add node check to pthread_esm_startup. NFC

### DIFF
--- a/src/pthread_esm_startup.mjs
+++ b/src/pthread_esm_startup.mjs
@@ -14,15 +14,17 @@ console.log("Running pthread_esm_startup");
 #endif
 
 #if ENVIRONMENT_MAY_BE_NODE
-// Create as web-worker-like an environment as we can.
-var worker_threads = await import('worker_threads');
-global.Worker = worker_threads.Worker;
-var parentPort = worker_threads['parentPort'];
-parentPort.on('message', (msg) => global.onmessage?.({ data: msg }));
-Object.assign(globalThis, {
-  self: global,
-  postMessage: (msg) => parentPort['postMessage'](msg),
-});
+if ({{{ nodeDetectionCode() }}}) {
+  // Create as web-worker-like an environment as we can.
+  var worker_threads = await import('worker_threads');
+  global.Worker = worker_threads.Worker;
+  var parentPort = worker_threads['parentPort'];
+  parentPort.on('message', (msg) => global.onmessage?.({ data: msg }));
+  Object.assign(globalThis, {
+    self: global,
+    postMessage: (msg) => parentPort['postMessage'](msg),
+  });
+}
 #endif
 
 self.onmessage = async (msg) => {


### PR DESCRIPTION
This is not strictly necessary today since node is the only place we can currently use full ESM Wasm integration, but still better to be correct here.