### PR TITLE
Mark test_wasm_global as failing under wasm2js + optimizations. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9649,9 +9649,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
     'dylink': [True],
   })
   @no_esm_integration('https://github.com/emscripten-core/emscripten/issues/25543')
+  @no_omit_asm_module_exports('https://github.com/emscripten-core/emscripten/issues/25550')
   def test_wasm_global(self, dynlink):
     if '-flto' in self.cflags or '-flto=thin' in self.cflags:
       self.skipTest('https://github.com/emscripten-core/emscripten/issues/25555')
+    if self.is_wasm2js() and self.is_optimizing():
+      self.skipTest('https://github.com/emscripten-core/emscripten/issues/25550')
     if dynlink:
       self.check_dylink()
       self.set_setting('MAIN_MODULE', 2)


### PR DESCRIPTION
See #25550