### PR TITLE
Fix ruff warning in emscripten

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -1350,12 +1350,12 @@ def subprocess_env():
 def remove_tree(d):
   os.chmod(d, stat.S_IWRITE)
   try:
-    def remove_readonly_and_try_again(func, path, _exc_info):
+    def remove_readonly_and_try_again(func, path, exc_info):
       if not (os.stat(path).st_mode & stat.S_IWRITE):
         os.chmod(path, stat.S_IWRITE)
         func(path)
       else:
-        raise
+        raise exc_info[1]
     shutil.rmtree(d, onerror=remove_readonly_and_try_again)
   except Exception:
     pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ lint.ignore = [
   "UP031", # TODO
   "UP032", # TODO
 ]
-lint.per-file-ignores."emrun.py" = [ "PLE0704" ]
 lint.per-file-ignores."tools/ports/*.py" = [ "ARG001", "ARG005" ]
 lint.per-file-ignores."test/other/ports/*.py" = [ "ARG001" ]
 lint.per-file-ignores."test/parallel_testsuite.py" = [ "ARG002" ]


### PR DESCRIPTION
Using `raise` on its own outside of a catch block does not work.