### PR TITLE
Bump min cmake version in websocket_to_posix_proxy

### DIFF
--- a/tools/websocket_to_posix_proxy/CMakeLists.txt
+++ b/tools/websocket_to_posix_proxy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 project(websocket_to_posix_proxy)
 


### PR DESCRIPTION
This should probably have been part of #23538

Fixes: #25964