### PR TITLE
Simpify passing of timeout to select() syscall. NFC

### DIFF
--- a/src/lib/libsigs.js
+++ b/src/lib/libsigs.js
@@ -229,7 +229,7 @@ sigs = {
   __handle_stack_overflow__sig: 'vp',
   __pthread_create_js__sig: 'ipppp',
   __resumeException__sig: 'vp',
-  __syscall__newselect__sig: 'iipppp',
+  __syscall__newselect__sig: 'iipppj',
   __syscall_accept4__sig: 'iippiii',
   __syscall_bind__sig: 'iippiii',
   __syscall_chdir__sig: 'ip',

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -41,7 +41,7 @@ int __syscall_uname(intptr_t buf);
 int __syscall_mprotect(size_t addr, size_t len, int prot);
 int __syscall_getpgid(int pid);
 int __syscall_fchdir(int fd);
-int __syscall__newselect(int nfds, intptr_t readfds, intptr_t writefds, intptr_t exceptfds, intptr_t timeout);
+int __syscall__newselect(int nfds, intptr_t readfds, intptr_t writefds, intptr_t exceptfds, int64_t timeout);
 int __syscall_msync(intptr_t addr, size_t len, int flags);
 int __syscall_getsid(int pid);
 int __syscall_fdatasync(int fd);

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 245673,
-  "a.out.nodebug.wasm": 573748,
-  "total": 819421,
+  "a.out.js": 245617,
+  "a.out.nodebug.wasm": 573657,
+  "total": 819274,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
Rather than using a pointer to memory, simply pass the number of milliseconds to block for, using the same convensions poll():
```
-1: Block forever
 0: No blocking
>0: Block for up to N milliseconds.
```
This is already the interface used by the inner `stream.stream_ops.poll` call so this saves on conversion as well as reading from memory.