### PR TITLE
[contrib.glfw3] New version (bug fix + emscripten_html5_remove_event_listener use)

### DIFF
--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -3,10 +3,10 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-TAG = '3.4.0.20250927'
+TAG = '3.4.0.20251217'
 
 EXTERNAL_PORT = f'https://github.com/pongasoft/emscripten-glfw/releases/download/v{TAG}/emscripten-glfw3-{TAG}.zip'
-SHA512 = 'c1906c3e9356bf645b9d74115efb4f2029ab3e5bf5a60f18ec6a6a88c22e6374e7e388ef454f4c3c2e4b9b17c4482c04a9401885e956e2bad360acdb5157a35d'
+SHA512 = '6184ef7b68e108040a8295b2fa81f8e79465fa3e6e43b403fa834e6d242557ef5711c79af1d5a8369f94be59e51492aa469193101bb9e956fb4758d83b154289'
 PORT_FILE = 'port/glfw3.py'
 
 # contrib port information (required)


### PR DESCRIPTION
I just pushed a new version with the following release notes:

- Fixed [#24](https://github.com/pongasoft/emscripten-glfw/issues/24): `glfwMakeContextCurrent` non-compliance
- Use `emscripten_html5_remove_event_listener` which makes the library safer to use (it no longer iterferes with the client code). Note that the client should also use `emscripten_html5_remove_event_listener` in order not to interfere with the library.

@sbc100 This new version in particular contains the changes to use the newly introduced `emscripten_html5_remove_event_listener`. The demo/test program has been updated to demonstrate that the library is doing the "right" thing, meaning NOT interfering with the handlers set by the client code and also removing all its handlers on exit (this is how I found out that there was an issue with one of the listeners setting 2 listeners for Safari).

This is an output that demonstrates the test:

```
Before glfwInit() | Event Handlers = 0 main.js:104:150
After glfwInit() | Event Handlers = 12 main.js:104:150
GLFW: 3.4.0 | Emscripten | pongasoft/emscripten-glfw@v3.4.0.20251217-nw | Platform: 0x60006 main.js:67:481
emscripten: v4.0.21 main.js:67:481
After glfwCreateWindow(window1) | Event Handlers = 19 main.js:104:150
After glfwCreateWindow(window2) | Event Handlers = 26 main.js:104:150
canvas1 | WebGL: OpenGL ES 3.0 (WebGL 2.0) | Apple M1, or similar main.js:67:481
canvas2 | WebGL: OpenGL ES 3.0 (WebGL 2.0) | Apple M1, or similar main.js:67:481
After adding application event listener | Event Handlers = 27 main.js:104:150
After glfwDestroyWindow(canvas2) | Event Handlers = 20 main.js:104:150
After glfwDestroyWindow(canvas1) | Event Handlers = 13 main.js:104:150
After glfwTerminate() | Event Handlers = 1 main.js:104:150
After removing application event listener | Event Handlers = 0 main.js:104:150
```