### PR TITLE
Improve SDL_Delay and add testing. NFC

### DIFF
--- a/src/lib/libsdl.js
+++ b/src/lib/libsdl.js
@@ -1744,12 +1744,15 @@ var LibrarySDL = {
   },
 
 #if ASYNCIFY
-  SDL_Delay__deps: ['emscripten_sleep'],
-  SDL_Delay__async: true,
-  SDL_Delay: (delay) => _emscripten_sleep(delay),
+  SDL_Delay: 'emscripten_sleep',
 #else
+#if ASSERTIONS
+  SDL_Delay__deps: ['$warnOnce'],
+#endif
   SDL_Delay: (delay) => {
-    if (!ENVIRONMENT_IS_WORKER) abort('SDL_Delay called on the main thread! Potential infinite loop, quitting. (consider building with async support like ASYNCIFY)');
+#if ASSERTIONS
+    if (!ENVIRONMENT_IS_WORKER) warnOnce('SDL_Delay called on the main thread! Potential infinite loop, quitting. (consider building with async support like ASYNCIFY)');
+#endif
     // horrible busy-wait, but in a worker it at least does not block rendering
     var now = Date.now();
     while (Date.now() - now < delay) {}

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 245617,
+  "a.out.js": 245482,
   "a.out.nodebug.wasm": 573657,
-  "total": 819274,
+  "total": 819139,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3055,8 +3055,13 @@ Module["preRun"] = () => {
     # key events should be detected using SDL_PumpEvents
     self.btest_exit('test_sdl2_pumpevents.c', cflags=['--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=2'])
 
+  @also_with_proxy_to_pthread
+  def test_sdl_timer(self):
+    self.btest_exit('test_sdl_timer.c', cflags=['-sUSE_SDL'])
+
+  @also_with_proxy_to_pthread
   def test_sdl2_timer(self):
-    self.btest_exit('test_sdl2_timer.c', cflags=['-sUSE_SDL=2'])
+    self.btest_exit('test_sdl_timer.c', cflags=['-sUSE_SDL=2', '-DUSE_SDL2'])
 
   def test_sdl2_canvas_size(self):
     self.btest_exit('test_sdl2_canvas_size.c', cflags=['-sUSE_SDL=2'])


### PR DESCRIPTION
- Cleanup implemenation of SDL_Delay
- Add testing of SDL_Timer/SDL_Delay under SDL1
- Add testing of SDL_Timer/SDL_Delay when running on pthread
- Rename test_sdl2_timer.c -> test_sdl_timer.c since it works with both
  SDL1 and SDL2
- Avoid taking the address of stack locals in test_sdl_timer.c.

Depends on #25971