### PR TITLE
Add support for cmake 4.0+ during testing. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1571,6 +1571,8 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
       # cross compiling.
       if configure:
         if configure[0] == 'cmake':
+          # Some tests have very old cmake_minimum_version settings which is not supported by cmake 4+.
+          # Forcing a slighly more recent cmake_minimum_version works around this issue.
           configure = [EMCMAKE] + configure + ['-DCMAKE_POLICY_VERSION_MINIMUM=3.5']
         else:
           configure = [EMCONFIGURE] + configure

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -945,6 +945,9 @@ f.close()
       os.mkdir(builddir)
       with common.chdir(builddir):
         # Run Cmake
+
+        # Some tests have very old cmake_minimum_version settings which is not supported by cmake 4+.
+        # Forcing a slighly more recent cmake_minimum_version works around this issue.
         cmd = [EMCMAKE, 'cmake'] + cmake_args + ['-G', generator, cmakelistsdir, '-DCMAKE_POLICY_VERSION_MINIMUM=3.5']
 
         env = os.environ.copy()


### PR DESCRIPTION
There were some more vendored libs that weren't supported by CMake 4.0.

Follow-up to #25966 

Fixes: #25964 


