### PR TITLE
Honor buffer.byteOffset in read/write for nodefs

### DIFF
--- a/src/lib/libnodefs.js
+++ b/src/lib/libnodefs.js
@@ -272,12 +272,12 @@ addToLibrary({
       },
       read(stream, buffer, offset, length, position) {
         return NODEFS.tryFSOperation(() =>
-          fs.readSync(stream.nfd, new Int8Array(buffer.buffer, offset, length), 0, length, position)
+          fs.readSync(stream.nfd, buffer, offset, length, position)
         );
       },
       write(stream, buffer, offset, length, position) {
         return NODEFS.tryFSOperation(() =>
-          fs.writeSync(stream.nfd, new Int8Array(buffer.buffer, offset, length), 0, length, position)
+          fs.writeSync(stream.nfd, buffer, offset, length, position)
         );
       },
       llseek(stream, offset, whence) {

--- a/src/lib/libnoderawfs.js
+++ b/src/lib/libnoderawfs.js
@@ -207,7 +207,7 @@ addToLibrary({
       }
       var seeking = typeof position != 'undefined';
       if (!seeking && stream.seekable) position = stream.position;
-      var bytesRead = fs.readSync(stream.nfd, new Int8Array(buffer.buffer, offset, length), 0, length, position);
+      var bytesRead = fs.readSync(stream.nfd, buffer, offset, length, position);
       // update position marker when non-seeking
       if (!seeking) stream.position += bytesRead;
       return bytesRead;
@@ -223,7 +223,7 @@ addToLibrary({
       }
       var seeking = typeof position != 'undefined';
       if (!seeking && stream.seekable) position = stream.position;
-      var bytesWritten = fs.writeSync(stream.nfd, new Int8Array(buffer.buffer, offset, length), 0, length, position);
+      var bytesWritten = fs.writeSync(stream.nfd, buffer, offset, length, position);
       // update position marker when non-seeking
       if (!seeking) stream.position += bytesWritten;
       return bytesWritten;

--- a/test/fs/test_writeFile.cpp
+++ b/test/fs/test_writeFile.cpp
@@ -8,8 +8,9 @@
 
 int main() {
   EM_ASM(
+    const buf = Uint8Array.from('c=3\nd=4\ne=5', x => x.charCodeAt(0));
     FS.writeFile("testfile", "a=1\nb=2\n");
-    FS.writeFile("testfile", new Uint8Array([99, 61, 51]) /* c=3 */, { flags: "a" });
+    FS.writeFile("testfile", buf.subarray(4, 7) /* d=4 */, { flags: "a" });
   );
 
   std::ifstream file("testfile");
@@ -17,7 +18,8 @@ int main() {
   while (!file.eof() && !file.fail()) {
     std::string line;
     getline(file, line);
-    std::string name;
+    std::string key;
+    std::string val;
 
     std::cout << "read " << line << std::endl;
 
@@ -35,7 +37,10 @@ int main() {
         continue;
     }
 
-    name = line.substr(0, equalsPos);
+    key = line.substr(0, equalsPos);
+    val = line.substr(equalsPos + 1);
+
+    std::cout << "parsed " << key << "=" << val << std::endl;
   }
 
   return 0;

--- a/test/fs/test_writeFile.out
+++ b/test/fs/test_writeFile.out
@@ -1,3 +1,6 @@
 read a=1
+parsed a=1
 read b=2
-read c=3
+parsed b=2
+read d=4
+parsed d=4


### PR DESCRIPTION
I ran into this when writing a bunch of files from a tar archive to the file system, where each file was a subarray of the main buffer.