### PR TITLE
[SPLIT_MODULE] Fix `wasmRawExports` to actually be the raw exports. NFC

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -724,6 +724,9 @@ function getWasmImports() {
 #endif
     var origExports = wasmExports;
 #endif
+#if SPLIT_MODULE
+    wasmRawExports = wasmExports;
+#endif
 
 #if ASYNCIFY
     wasmExports = Asyncify.instrumentWasmExports(wasmExports);
@@ -739,14 +742,10 @@ function getWasmImports() {
 #endif
 #endif
 
-
 #if ABORT_ON_WASM_EXCEPTIONS
     wasmExports = instrumentWasmExportsWithAbort(wasmExports);
 #endif
 
-#if SPLIT_MODULE
-  wasmRawExports = wasmExports;
-#endif
 #if MEMORY64 || CAN_ADDRESS_2GB
     wasmExports = applySignatureConversions(wasmExports);
 #endif


### PR DESCRIPTION
We don't want the raw exports include things like
`Asyncify.instrumentWasmExports` or `relocateExports`.  They should be the actual raw exports.

See #25621