### PR TITLE
[embind] Fix TS definition for optional value object properties.

### DIFF
--- a/src/lib/libembind_gen.js
+++ b/src/lib/libembind_gen.js
@@ -357,7 +357,7 @@ var LibraryEmbind = {
       out.push(`export type ${this.name} = {\n`);
       const outFields = [];
       for (const {name, type} of this.fields) {
-        outFields.push(`  ${name}: ${nameMap(type)}`);
+        outFields.push(`  ${name}${type instanceof OptionalType ? '?' : ''}: ${nameMap(type)}`);
       }
       out.push(outFields.join(',\n'))
       out.push('\n};\n\n');

--- a/test/other/embind_tsgen.cpp
+++ b/test/other/embind_tsgen.cpp
@@ -61,6 +61,7 @@ struct ValObj {
   Bar bar;
   std::string string;
   CallbackType callback;
+  std::optional<int> optionalInt;
   ValObj() : callback(val::undefined()) {}
 };
 
@@ -209,6 +210,7 @@ EMSCRIPTEN_BINDINGS(Test) {
   value_object<ValObj>("ValObj")
       .field("string", &ValObj::string)
       .field("bar", &ValObj::bar)
+      .field("optionalInt", &ValObj::optionalInt)
       .field("callback", &ValObj::callback);
   function("getValObj", &getValObj);
   function("setValObj", &setValObj);

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -96,6 +96,7 @@ export type ValArr = [ number, number, number ];
 export type ValObj = {
   string: EmbindString,
   bar: Bar,
+  optionalInt?: number | undefined,
   callback: (message: string) => void
 };
 

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -107,6 +107,7 @@ export type ValArr = [ number, number, number ];
 export type ValObj = {
   string: EmbindString,
   bar: Bar,
+  optionalInt?: number | undefined,
   callback: (message: string) => void
 };
 

--- a/test/other/embind_tsgen_ignore_2.d.ts
+++ b/test/other/embind_tsgen_ignore_2.d.ts
@@ -95,6 +95,7 @@ export type ValArr = [ number, number, number ];
 export type ValObj = {
   string: EmbindString,
   bar: Bar,
+  optionalInt?: number | undefined,
   callback: (message: string) => void
 };
 

--- a/test/other/embind_tsgen_ignore_3.d.ts
+++ b/test/other/embind_tsgen_ignore_3.d.ts
@@ -96,6 +96,7 @@ export type ValArr = [ number, number, number ];
 export type ValObj = {
   string: EmbindString,
   bar: Bar,
+  optionalInt?: number | undefined,
   callback: (message: string) => void
 };
 

--- a/test/other/embind_tsgen_main.ts
+++ b/test/other/embind_tsgen_main.ts
@@ -25,6 +25,13 @@ import moduleFactory from './embind_tsgen.js';
     callback: () => {}
   });
 
+  module.setValObj({
+    bar: module.Bar.valueOne,
+    string: "ABCD",
+    callback: () => {},
+    optionalInt: 99
+  });
+
   const valObj = module.getValObj();
   // TODO: remove the cast below when better definitions are generated for value
   // objects.

--- a/test/other/embind_tsgen_module.d.ts
+++ b/test/other/embind_tsgen_module.d.ts
@@ -96,6 +96,7 @@ export type ValArr = [ number, number, number ];
 export type ValObj = {
   string: EmbindString,
   bar: Bar,
+  optionalInt?: number | undefined,
   callback: (message: string) => void
 };
 


### PR DESCRIPTION
TS treats optional interface properties differently if they're defined with `someProp?: type` or `someProp: type|undefined`. When creating a object literal to match the interface, the `?` doesn't require the property name whereas `type|undefined` requires the property name (though an undefined value is allowed).

Fixes #25978