### PR TITLE
Remove unnessary to64 casts from newselect system. NFC

### DIFF
--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -644,7 +644,7 @@ var SyscallsLibrary = {
               notifyDone = true;
               cleanupFuncs.forEach(cb => cb());
               fdSet.commit();
-              __emscripten_proxy_newselect_finish({{{ to64('ctx') }}}, {{{ to64('arg') }}}, fdSet.getTotal());
+              __emscripten_proxy_newselect_finish(ctx, arg, fdSet.getTotal());
           }
           cb.registerCleanupFunc = (f) => {
               if (f != null) cleanupFuncs.push(f);


### PR DESCRIPTION
These were added unnecessarily in #25523.
`_emscripten_proxy_newselect_finish` was added to
`create_pointer_conversion_wrappers` in emscripten.py which makes these conversions automatic.