### PR TITLE
Error if __async decorator applied to JS-only symbol

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -1077,9 +1077,6 @@ var LibraryPThread = {
     '$runtimeKeepaliveCounter',
 #endif
   ],
-#if ASYNCIFY
-  $invokeEntryPoint__async: true,
-#endif
   $invokeEntryPoint: {{{ asyncIf(ASYNCIFY == 2) }}}(ptr, arg) => {
 #if PTHREADS_DEBUG
     dbg(`invokeEntryPoint: ${ptrToString(ptr)}`);

--- a/src/lib/libwasmfs_opfs.js
+++ b/src/lib/libwasmfs_opfs.js
@@ -89,7 +89,6 @@ addToLibrary({
   // corresponding to the error.
   $wasmfsOPFSGetOrCreateFile__deps: ['$wasmfsOPFSDirectoryHandles',
                                      '$wasmfsOPFSFileHandles'],
-  $wasmfsOPFSGetOrCreateFile__async: {{{ !PTHREADS }}},
   $wasmfsOPFSGetOrCreateFile: async function(parent, name, create) {
     let parentHandle = wasmfsOPFSDirectoryHandles.get(parent);
     let fileHandle;
@@ -114,7 +113,6 @@ addToLibrary({
   // it if it doesn't exist and `create` or otherwise return a negative error
   // code corresponding to the error.
   $wasmfsOPFSGetOrCreateDir__deps: ['$wasmfsOPFSDirectoryHandles'],
-  $wasmfsOPFSGetOrCreateDir__async: {{{ !PTHREADS }}},
   $wasmfsOPFSGetOrCreateDir: async function(parent, name, create) {
     let parentHandle = wasmfsOPFSDirectoryHandles.get(parent);
     let childHandle;

--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -151,6 +151,13 @@ export function mergeInto(obj, other, options = null) {
       const decoratorName = key.slice(index);
       const type = typeof other[key];
 
+      if (decoratorName == '__async') {
+        const decorated = key.slice(0, index);
+        if (isJsOnlySymbol(decorated)) {
+          error(`__async decorator applied to JS symbol: ${decorated}`);
+        }
+      }
+
       // Specific type checking for `__deps` which is expected to be an array
       // (not just any old `object`)
       if (decoratorName === '__deps') {


### PR DESCRIPTION
The `__async` decorator marks JS function as async when they are imported into Wasm.  It basically adds functions to `ASYNCIFY_IMPORTS`.

It makes not sense to apply this decorator to a JS-only symbol.