### PR TITLE
[libfetch] Add missing JS library dependencies

### DIFF
--- a/src/lib/libfetch.js
+++ b/src/lib/libfetch.js
@@ -8,7 +8,13 @@
 
 var LibraryFetch = {
   $Fetch__postset: 'Fetch.init();',
-  $Fetch__deps: ['$HandleAllocator'],
+  $Fetch__deps: [
+    '$HandleAllocator',
+#if FETCH_SUPPORT_INDEXEDDB
+    '$addRunDependency',
+    '$removeRunDependency',
+#endif
+  ],
   $Fetch: Fetch,
   _emscripten_fetch_get_response_headers_length__deps: ['$lengthBytesUTF8'],
   _emscripten_fetch_get_response_headers_length: fetchGetResponseHeadersLength,


### PR DESCRIPTION
# Fix: keep run dependency helpers when FETCH uses IndexedDB

`Fetch.init()` calls `addRunDependency`/`removeRunDependency` when `FETCH_SUPPORT_INDEXEDDB` is enabled. In `-s MODULARIZE=1` builds those helpers can be DCE'd, causing `ReferenceError: addRunDependency is not defined` at runtime.

This change declares `$addRunDependency` and `$removeRunDependency` as deps of `$Fetch` (guarded by `FETCH_SUPPORT_INDEXEDDB`), so the helpers are retained without requiring extra user flags.

Fixes https://github.com/emscripten-core/emscripten/issues/26008

Repro:
```
emcc main.c -s FETCH=1 -s MODULARIZE=1 -o out.mjs
```
Open the output in a browser:
- Before: `ReferenceError: addRunDependency is not defined`
- After: no error
