### PR TITLE
Add `__async: auto` decorator

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -243,7 +243,7 @@ See docs/process.md for more on how version tagging works.
 - When JSPI is enabled `async` library functions are no longer automatically
   wrapped with `WebAssembly.Suspending` functions. To automatically wrap library
   functions for use with JSPI they must now explicitly set
-  `myLibraryFunction__async: true`.
+  `myLibraryFunction__async: true`. (#24550)
 - Removed special casing for `size_t` in Embind, since it was also inadvertently
   affecting `unsigned long` on wasm64. Both will now match the behaviour of
   other 64-bit integers on wasm64 and will be passed as `bigint` instead of

--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -350,6 +350,19 @@ ${body};
   });
 }
 
+function handleAsyncFunction(snippet) {
+  return modifyJSFunction(snippet, (args, body, async_, oneliner) => {
+    if (!oneliner) {
+      body = `{\n${body}\n}`;
+    }
+    return `\
+function(${args}) {
+  let innerFunc = ${async_} () => ${body};
+  return Asyncify.handleAsync(innerFunc);
+}\n`;
+  });
+}
+
 export async function runJSify(outputFile, symbolsOnly) {
   const libraryItems = [];
   const symbolDeps = {};
@@ -418,6 +431,11 @@ function(${args}) {
   return ret;
 }`;
       });
+    }
+
+    const isAsyncFunction = LibraryManager.library[symbol + '__async'];
+    if (ASYNCIFY && isAsyncFunction == 'auto') {
+      snippet = handleAsyncFunction(snippet);
     }
 
     const sig = LibraryManager.library[symbol + '__sig'];

--- a/src/lib/libasync.js
+++ b/src/lib/libasync.js
@@ -485,8 +485,8 @@ addToLibrary({
   emscripten_sleep: (ms) => Asyncify.handleSleep((wakeUp) => safeSetTimeout(wakeUp, ms)),
 
   emscripten_wget_data__deps: ['$asyncLoad', 'malloc'],
-  emscripten_wget_data__async: true,
-  emscripten_wget_data: (url, pbuffer, pnum, perror) => Asyncify.handleAsync(async () => {
+  emscripten_wget_data__async: 'auto',
+  emscripten_wget_data: async (url, pbuffer, pnum, perror) => {
     /* no need for run dependency, this is async but will not do any prepare etc. step */
     try {
       const byteArray = await asyncLoad(UTF8ToString(url));
@@ -499,7 +499,7 @@ addToLibrary({
     } catch (err) {
       {{{ makeSetValue('perror', 0, '1', 'i32') }}};
     }
-  }),
+  },
 
   emscripten_scan_registers__deps: ['$safeSetTimeout'],
   emscripten_scan_registers__async: true,

--- a/src/lib/libemval.js
+++ b/src/lib/libemval.js
@@ -400,12 +400,10 @@ ${functionBody}
 
 #if ASYNCIFY
   _emval_await__deps: ['$Emval', '$Asyncify'],
-  _emval_await__async: true,
-  _emval_await: (promise) => {
-    return Asyncify.handleAsync(async () => {
-      var value = await Emval.toValue(promise);
-      return Emval.toHandle(value);
-    });
+  _emval_await__async: 'auto',
+  _emval_await: async (promise) => {
+    var value = await Emval.toValue(promise);
+    return Emval.toHandle(value);
   },
 #endif
 

--- a/src/lib/libidbstore.js
+++ b/src/lib/libidbstore.js
@@ -92,13 +92,13 @@ var LibraryIDBStore = {
   },
 
 #if ASYNCIFY
-  emscripten_idb_load__async: true,
+  emscripten_idb_load__async: 'auto',
   emscripten_idb_load__deps: ['malloc'],
-  emscripten_idb_load: (db, id, pbuffer, pnum, perror) => Asyncify.handleSleep((wakeUp) => {
+  emscripten_idb_load: (db, id, pbuffer, pnum, perror) => new Promise((resolve) => {
     IDBStore.getFile(UTF8ToString(db), UTF8ToString(id), (error, byteArray) => {
       if (error) {
         {{{ makeSetValue('perror', 0, '1', 'i32') }}};
-        wakeUp();
+        resolve();
         return;
       }
       var buffer = _malloc(byteArray.length); // must be freed by the caller!
@@ -106,42 +106,42 @@ var LibraryIDBStore = {
       {{{ makeSetValue('pbuffer', 0, 'buffer', '*') }}};
       {{{ makeSetValue('pnum',    0, 'byteArray.length', 'i32') }}};
       {{{ makeSetValue('perror',  0, '0', 'i32') }}};
-      wakeUp();
+      resolve();
     });
   }),
-  emscripten_idb_store__async: true,
-  emscripten_idb_store: (db, id, ptr, num, perror) => Asyncify.handleSleep((wakeUp) => {
+  emscripten_idb_store__async: 'auto',
+  emscripten_idb_store: (db, id, ptr, num, perror) => new Promise((resolve) => {
     IDBStore.setFile(UTF8ToString(db), UTF8ToString(id), new Uint8Array(HEAPU8.subarray(ptr, ptr+num)), (error) => {
       // Closure warns about storing booleans in TypedArrays.
       /** @suppress{checkTypes} */
       {{{ makeSetValue('perror', 0, '!!error', 'i32') }}};
-      wakeUp();
+      resolve();
     });
   }),
-  emscripten_idb_delete__async: true,
-  emscripten_idb_delete: (db, id, perror) => Asyncify.handleSleep((wakeUp) => {
+  emscripten_idb_delete__async: 'auto',
+  emscripten_idb_delete: (db, id, perror) => new Promise((resolve) => {
     IDBStore.deleteFile(UTF8ToString(db), UTF8ToString(id), (error) => {
       /** @suppress{checkTypes} */
       {{{ makeSetValue('perror', 0, '!!error', 'i32') }}};
-      wakeUp();
+      resolve();
     });
   }),
-  emscripten_idb_exists__async: true,
-  emscripten_idb_exists: (db, id, pexists, perror) => Asyncify.handleSleep((wakeUp) => {
+  emscripten_idb_exists__async: 'auto',
+  emscripten_idb_exists: (db, id, pexists, perror) => new Promise((resolve) => {
     IDBStore.existsFile(UTF8ToString(db), UTF8ToString(id), (error, exists) => {
       /** @suppress{checkTypes} */
       {{{ makeSetValue('pexists', 0, '!!exists', 'i32') }}};
       /** @suppress{checkTypes} */
       {{{ makeSetValue('perror',  0, '!!error', 'i32') }}};
-      wakeUp();
+      resolve();
     });
   }),
-  emscripten_idb_clear__async: true,
-  emscripten_idb_clear: (db, perror) => Asyncify.handleSleep((wakeUp) => {
+  emscripten_idb_clear__async: 'auto',
+  emscripten_idb_clear: (db, perror) => new Promise((resolve) => {
     IDBStore.clearStore(UTF8ToString(db), (error) => {
       /** @suppress{checkTypes} */
       {{{ makeSetValue('perror', 0, '!!error', 'i32') }}};
-      wakeUp();
+      resolve();
     });
   }),
 #else

--- a/src/lib/libpromise.js
+++ b/src/lib/libpromise.js
@@ -257,7 +257,7 @@ addToLibrary({
     return id;
   },
 
-  emscripten_promise_await__async: true,
+  emscripten_promise_await__async: 'auto',
 #if ASYNCIFY
   emscripten_promise_await__deps: ['$getPromise', '$setPromiseResult'],
 #endif
@@ -266,10 +266,10 @@ addToLibrary({
 #if RUNTIME_DEBUG
     dbg(`emscripten_promise_await: ${id}`);
 #endif
-    return Asyncify.handleAsync(() => getPromise(id).then(
+    return getPromise(id).then(
       value => setPromiseResult(returnValuePtr, true, value),
       error => setPromiseResult(returnValuePtr, false, error)
-    ));
+    );
 #else
     abort('emscripten_promise_await is only available with ASYNCIFY');
 #endif

--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -186,12 +186,12 @@ export function mergeInto(obj, other, options = null) {
           __noleakcheck: 'boolean',
           __internal: 'boolean',
           __user: 'boolean',
-          __async: 'boolean',
+          __async: ['string', 'boolean'],
           __i53abi: 'boolean',
         };
         const expected = decoratorTypes[decoratorName];
         if (type !== expected && !expected.includes(type)) {
-          error(`Decorator (${key}} has wrong type. Expected '${expected}' not '${type}'`);
+          error(`Decorator (${key}) has wrong type. Expected '${expected}' not '${type}'`);
         }
       }
     }

--- a/test/test_jslib.py
+++ b/test/test_jslib.py
@@ -277,12 +277,12 @@ addToLibrary({
   def test_jslib_invalid_decorator(self):
     create_file('lib.js', r'''
 addToLibrary({
-  jslibfunc__async: 'hello',
+  jslibfunc__internal: 'hello',
   jslibfunc: (x) => {},
 });
 ''')
     self.assert_fail([EMCC, test_file('hello_world.c'), '--js-library', 'lib.js'],
-                     "lib.js: Decorator (jslibfunc__async} has wrong type. Expected 'boolean' not 'string'")
+                     "lib.js: Decorator (jslibfunc__internal) has wrong type. Expected 'boolean' not 'string'")
 
   @also_with_wasm64
   @also_without_bigint


### PR DESCRIPTION
This decorator automatically generates the Asyncify.handleAsync wrapper code.  Hopefully we can transition all out `__async` functions soon and just make this the default.