### PR TITLE
Fix __async decorators in libwasmfs_opfs.js

### DIFF
--- a/src/lib/libwasmfs_opfs.js
+++ b/src/lib/libwasmfs_opfs.js
@@ -69,7 +69,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_init_root_directory__deps: ['$wasmfsOPFSDirectoryHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_init_root_directory__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_init_root_directory__async: true,
   _wasmfs_opfs_init_root_directory: async function(ctx) {
     // allocated.length starts off as 1 since 0 is a reserved handle
     if (wasmfsOPFSDirectoryHandles.allocated.length == 1) {
@@ -136,9 +136,8 @@ addToLibrary({
 
   _wasmfs_opfs_get_child__deps: ['$wasmfsOPFSGetOrCreateFile',
                                  '$wasmfsOPFSGetOrCreateDir', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_get_child__async: {{{ !PTHREADS }}},
-  _wasmfs_opfs_get_child:
-      async function(ctx, parent, namePtr, childTypePtr, childIDPtr) {
+  _wasmfs_opfs_get_child__async: true,
+  _wasmfs_opfs_get_child: async function(ctx, parent, namePtr, childTypePtr, childIDPtr) {
     let name = UTF8ToString(namePtr);
     let childType = 1;
     let childID = await wasmfsOPFSGetOrCreateFile(parent, name, false);
@@ -157,7 +156,7 @@ addToLibrary({
     '$stackRestore',
     '_wasmfs_opfs_record_entry',
   ],
-  _wasmfs_opfs_get_entries__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_get_entries__async: true,
   _wasmfs_opfs_get_entries: async function(ctx, dirID, entriesPtr, errPtr) {
     let dirHandle = wasmfsOPFSDirectoryHandles.get(dirID);
 
@@ -182,7 +181,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_insert_file__deps: ['$wasmfsOPFSGetOrCreateFile', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_insert_file__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_insert_file__async: true,
   _wasmfs_opfs_insert_file: async function(ctx, parent, namePtr, childIDPtr) {
     let name = UTF8ToString(namePtr);
     let childID = await wasmfsOPFSGetOrCreateFile(parent, name, true);
@@ -191,9 +190,8 @@ addToLibrary({
   },
 
   _wasmfs_opfs_insert_directory__deps: ['$wasmfsOPFSGetOrCreateDir', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_insert_directory__async: {{{ !PTHREADS }}},
-  _wasmfs_opfs_insert_directory:
-      async function(ctx, parent, namePtr, childIDPtr) {
+  _wasmfs_opfs_insert_directory__async: true,
+  _wasmfs_opfs_insert_directory: async function(ctx, parent, namePtr, childIDPtr) {
     let name = UTF8ToString(namePtr);
     let childID = await wasmfsOPFSGetOrCreateDir(parent, name, true);
     {{{ makeSetValue('childIDPtr', 0, 'childID', 'i32') }}};
@@ -203,7 +201,7 @@ addToLibrary({
   _wasmfs_opfs_move_file__deps: ['$wasmfsOPFSFileHandles',
                                  '$wasmfsOPFSDirectoryHandles',
                                  '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_move_file__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_move_file__async: true,
   _wasmfs_opfs_move_file: async function(ctx, fileID, newParentID, namePtr, errPtr) {
     let name = UTF8ToString(namePtr);
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
@@ -218,7 +216,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_remove_child__deps: ['$wasmfsOPFSDirectoryHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_remove_child__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_remove_child__async: true,
   _wasmfs_opfs_remove_child: async function(ctx, dirID, namePtr, errPtr) {
     let name = UTF8ToString(namePtr);
     let dirHandle = wasmfsOPFSDirectoryHandles.get(dirID);
@@ -247,7 +245,7 @@ addToLibrary({
                                    '$wasmfsOPFSCreateAsyncAccessHandle'
 #endif
                                   ],
-  _wasmfs_opfs_open_access__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_open_access__async: true,
   _wasmfs_opfs_open_access: async function(ctx, fileID, accessIDPtr) {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     let accessID;
@@ -287,7 +285,7 @@ addToLibrary({
 
   _wasmfs_opfs_open_blob__deps: ['$wasmfsOPFSFileHandles',
                                  '$wasmfsOPFSBlobs', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_open_blob__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_open_blob__async: true,
   _wasmfs_opfs_open_blob: async function(ctx, fileID, blobIDPtr) {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     let blobID;
@@ -309,7 +307,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_close_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_close_access__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_close_access__async: true,
   _wasmfs_opfs_close_access: async function(ctx, accessID, errPtr) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     try {
@@ -348,7 +346,7 @@ addToLibrary({
 
   _wasmfs_opfs_read_blob__i53abi: true,
   _wasmfs_opfs_read_blob__deps: ['$wasmfsOPFSBlobs', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_read_blob__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_read_blob__async: true,
   _wasmfs_opfs_read_blob: async function(ctx, blobID, bufPtr, len, pos, nreadPtr) {
     let blob = wasmfsOPFSBlobs.get(blobID);
     let slice = blob.slice(pos, pos + len);
@@ -397,7 +395,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_get_size_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_get_size_access__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_get_size_access__async: true,
   _wasmfs_opfs_get_size_access: async function(ctx, accessID, sizePtr) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     let size;
@@ -418,7 +416,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_get_size_file__deps: ['$wasmfsOPFSFileHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_get_size_file__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_get_size_file__async: true,
   _wasmfs_opfs_get_size_file: async function(ctx, fileID, sizePtr) {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     let size;
@@ -433,7 +431,7 @@ addToLibrary({
 
   _wasmfs_opfs_set_size_access__i53abi: true,
   _wasmfs_opfs_set_size_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_set_size_access__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_set_size_access__async: true,
   _wasmfs_opfs_set_size_access: async function(ctx, accessID, size, errPtr) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     try {
@@ -447,7 +445,7 @@ addToLibrary({
 
   _wasmfs_opfs_set_size_file__i53abi: true,
   _wasmfs_opfs_set_size_file__deps: ['$wasmfsOPFSFileHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_set_size_file__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_set_size_file__async: true,
   _wasmfs_opfs_set_size_file: async function(ctx, fileID, size, errPtr) {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     try {
@@ -462,7 +460,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_flush_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_flush_access__async: {{{ !PTHREADS }}},
+  _wasmfs_opfs_flush_access__async: true,
   _wasmfs_opfs_flush_access: async function(ctx, accessID, errPtr) {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     try {


### PR DESCRIPTION
For functions that are unconditionally declared as `async` we should
also unconditionally mark them as `__async`.   There are two function
that are conditionally `async` and in these two cases the `__async`
decorator should also be conditional.