### PR TITLE
[test] Don't run sanitizers on esm_integration*

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -87,6 +87,7 @@ def esm_integration(func):
   assert callable(func)
 
   @wraps(func)
+  @no_sanitize('sanitizers do not support WASM_ESM_INTEGRATION')
   def decorated(self, *args, **kwargs):
     self.setup_esm_integration()
     return func(self, *args, **kwargs)


### PR DESCRIPTION
It looks `WASM_ESM_INTEGRATION` does not support sanitizers: https://github.com/emscripten-core/emscripten/blob/57ca8ad145adb1ff2df9847789d1caff06c352cf/test/test_core.py#L147-L157

Currently, without this patch, these test fail:
```
asan.test_esm_integration
lsan.test_esm_integration
asan.test_esm_integration_main
asan.test_esm_integration_main_imported_memory
```