### PR TITLE
[tsgen] Preserve user ENVIRONMENT during TS generation.

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3590,6 +3590,7 @@ More info: https://emscripten.org
     '3': [['-sWASM=0'], 'embind_tsgen_ignore_3.d.ts'],
     '4': [['-fsanitize=undefined', '-gsource-map'], 'embind_tsgen_ignore_3.d.ts'],
     '5': [['-sASYNCIFY'], 'embind_tsgen_ignore_3.d.ts'],
+    '6': [['-sENVIRONMENT=worker', '-lworkerfs.js'], 'embind_tsgen.d.ts'],
   })
   def test_embind_tsgen_ignore(self, extra_args, expected_ts_file):
     create_file('fail.js', 'assert(false);')

--- a/tools/link.py
+++ b/tools/link.py
@@ -2011,7 +2011,8 @@ def run_embind_gen(options, wasm_target, js_syms, extra_settings):
   settings.PRE_JS_FILES = []
   settings.POST_JS_FILES = []
   # Force node since that is where the tool runs.
-  settings.ENVIRONMENT = ['node']
+  if 'node' not in settings.ENVIRONMENT:
+    settings.ENVIRONMENT.append('node')
   settings.MINIMAL_RUNTIME = 0
   # Required function to trigger TS generation.
   settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$callRuntimeCallbacks', '$addRunDependency', '$removeRunDependency']


### PR DESCRIPTION
During TS generation we forced the environment to node only which doesn't work with some preprocessor guards, such as in libworkerfs.js. Instead of forcing node only, append node so the guards still pass.

Fixes #26046