### PR TITLE
Move std::optional binding support from bind.h to val.h

### DIFF
--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -1919,34 +1919,7 @@ class_<std::map<K, V, Compare, Allocator>> register_map(const char* name) {
         ;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// std::optional
-////////////////////////////////////////////////////////////////////////////////
 
-namespace internal {
-template <typename T>
-struct BindingType<std::optional<T>> {
-    using ValBinding = BindingType<val>;
-    using WireType = ValBinding::WireType;
-
-    template<typename ReturnPolicy = void>
-    static WireType toWireType(std::optional<T> value, rvp::default_tag) {
-        if (value) {
-            return ValBinding::toWireType(val(*value, allow_raw_pointers()), rvp::default_tag{});
-        }
-        return ValBinding::toWireType(val::undefined(), rvp::default_tag{});
-    }
-
-
-    static std::optional<T> fromWireType(WireType value) {
-        val optional = val::take_ownership(value);
-        if (optional.isUndefined()) {
-            return {};
-        }
-        return optional.as<T>();
-    }
-};
-} // end namespace internal
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/embind/test_optional_val_lib.cpp
+++ b/test/embind/test_optional_val_lib.cpp
@@ -1,0 +1,14 @@
+#include <emscripten/val.h>
+#include <optional>
+#include <string>
+
+// This file deliberately does NOT include <emscripten/bind.h>
+
+class MyType {
+public:
+    void RunCallback(emscripten::val callback);
+};
+
+void MyType::RunCallback(emscripten::val cb) {
+    cb(std::make_optional(std::string{"Hey"}));
+}

--- a/test/embind/test_optional_val_main.cpp
+++ b/test/embind/test_optional_val_main.cpp
@@ -1,0 +1,30 @@
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+#include <string>
+#include <iostream>
+
+using namespace emscripten;
+
+class MyType {
+public:
+    void RunCallback(emscripten::val callback);
+};
+
+int main() {
+    EM_ASM(
+        let value = new Module.MyType();
+        value.RunCallback((e) => {
+            console.log("Received: " + e);
+            if (e !== "Hey") throw "Expected 'Hey', got " + e;
+        });
+    );
+    std::cout << "done" << std::endl;
+}
+
+EMSCRIPTEN_BINDINGS(my_module) {
+    register_optional<std::string>();
+
+    class_<MyType>("MyType")
+        .constructor<>()
+        .function("RunCallback", &MyType::RunCallback);
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14471,6 +14471,15 @@ addToLibrary({
     create_file('a.cpp', '#define try\n#define catch if (0)\n#include <emscripten/bind.h>')
     self.run_process([EMXX, '-fno-exceptions', '-std=c++23', '-lembind', 'a.cpp'])
 
+  def test_embind_optional_val_no_bind(self):
+    # Ensure passing std::optional to emscripten::val works if <emscripten/bind.h>
+    # was not included in the compilation unit using val.
+    self.run_process([EMXX,'-lembind',
+                      test_file('embind/test_optional_val_main.cpp'),
+                      test_file('embind/test_optional_val_lib.cpp')])
+    output = self.run_js('a.out.js')
+    self.assertContained('done', output)
+
   def test_no_pthread(self):
     self.do_runf('hello_world.c', cflags=['-pthread', '-no-pthread'])
     self.assertExists('hello_world.js')


### PR DESCRIPTION
This change moves the BindingType specialization for std::optional from emscripten/bind.h to emscripten/val.h. This ensures that emscripten::val can use std::optional types even when emscripten/bind.h is not included in the translation unit. A regression test is added to verify the fix.

Fixes #24747