### PR TITLE
Fix building system libraries and ports when CPATH is set

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -90,7 +90,8 @@ def clean_env():
   # At least one port also uses autoconf (harfbuzz) so we also need to clear
   # CFLAGS/LDFLAGS which we don't want to affect the inner call to configure.
   safe_env = os.environ.copy()
-  for opt in ['CFLAGS', 'CXXFLAGS', 'LDFLAGS',
+  for opt in ['CPATH', 'C_INCLUDE_PATH', 'CPLUS_INCLUDE_PATH', 'OBJC_INCLUDE_PATH',
+              'CFLAGS', 'CXXFLAGS', 'LDFLAGS',
               'EMCC_CFLAGS',
               'EMCC_AUTODEBUG',
               'EMCC_FORCE_STDLIBS',


### PR DESCRIPTION
The sysroot include directory has a low priority so use the one inside the build directory.