### PR TITLE
Initialize current_match variable in read_dwarf_info in wasm-sourcemap

### DIFF
--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -417,6 +417,7 @@ def read_dwarf_info(wasm, options):
 
   entries = []
   iterator = debug_line_pattern.finditer(output)
+  current_match = None
   try:
     current_match = next(iterator)
     debug_info_end = current_match.start() # end of .debug_info contents


### PR DESCRIPTION
If `output` contains no debug line patterns, `next(iterator)` will immediately raises `StopIteration`, and `current_match` is never assigned a value. This PR initializes `current_match` so the `while current_match:` below wont trigger any error.