### PR TITLE
[test] Remove `EMTEST_BUILD_VERBOSE`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ executors:
       EMCC_CORES: "4"
       EMSDK_NOTTY: "1"
       EMTEST_WASI_SYSROOT: "~/wasi-sdk/wasi-sysroot"
-      EMTEST_BUILD_VERBOSE: "2"
       EMTEST_DETECT_TEMPFILE_LEAKS: "1"
   mac-arm64:
     environment:

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -38,7 +38,6 @@ from common import (
   EMBUILDER,
   EMCMAKE,
   EMCONFIGURE,
-  EMTEST_BUILD_VERBOSE,
   NON_ZERO,
   PYTHON,
   TEST_ROOT,
@@ -938,13 +937,13 @@ f.close()
         if test_dir == 'target_html':
           env['EMCC_SKIP_SANITY_CHECK'] = '1'
         print(str(cmd))
-        self.run_process(cmd, env=env, stdout=None if EMTEST_BUILD_VERBOSE >= 2 else PIPE, stderr=None if EMTEST_BUILD_VERBOSE >= 1 else PIPE)
+        self.run_process(cmd, env=env)
 
         # Build
         cmd = conf['build']
-        if EMTEST_BUILD_VERBOSE >= 3 and 'Ninja' not in generator:
+        if common.EMTEST_VERBOSE and 'Ninja' not in generator:
           cmd += ['VERBOSE=1']
-        self.run_process(cmd, stdout=None if EMTEST_BUILD_VERBOSE >= 2 else PIPE)
+        self.run_process(cmd)
         self.assertExists(output_file, 'building a cmake-generated Makefile failed to produce an output file %s!' % output_file)
 
         # Run through node, if CMake produced a .js file.


### PR DESCRIPTION
This setting was designed to keep the stdout/stderr of the test runner relatively clean by default and only show the details when required.

However, since #25755 we have the single line test runner that hides all stdout and stderr by default.  This means that features like `EMTEST_BUILD_VERBOSE` are now redundant since all details are hidden by default.  Running with `--verbose` will now show all the gory details, just like it does for all the other tests.