### PR TITLE
Remove only remaining explicit use of `withBuiltinMalloc`. NFC

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1501,11 +1501,9 @@ addToLibrary({
     return ENVIRONMENT_IS_NODE && process.stderr.isTTY;
   },
 
-  _emscripten_sanitizer_get_option__deps: ['$withBuiltinMalloc', '$stringToNewUTF8', '$UTF8ToString'],
+  _emscripten_sanitizer_get_option__deps: ['$stringToNewUTF8', '$UTF8ToString'],
   _emscripten_sanitizer_get_option__sig: 'pp',
-  _emscripten_sanitizer_get_option: (name) => {
-    return withBuiltinMalloc(() => stringToNewUTF8(Module[UTF8ToString(name)] || ""));
-  },
+  _emscripten_sanitizer_get_option: (name) => stringToNewUTF8(Module[UTF8ToString(name)] || ''),
 #endif
 
   $readEmAsmArgsArray: [],

--- a/system/lib/compiler-rt/lib/asan/asan_flags.cpp
+++ b/system/lib/compiler-rt/lib/asan/asan_flags.cpp
@@ -146,7 +146,7 @@ static void InitializeDefaultFlags() {
 #define MAKE_OPTION_LOAD(parser, name) \
     options = _emscripten_sanitizer_get_option(name); \
     parser.ParseString(options); \
-    emscripten_builtin_free(options);
+    free(options);
 
   MAKE_OPTION_LOAD(asan_parser, "ASAN_OPTIONS");
 #if CAN_SANITIZE_LEAKS

--- a/system/lib/compiler-rt/lib/lsan/lsan.cpp
+++ b/system/lib/compiler-rt/lib/lsan/lsan.cpp
@@ -84,7 +84,7 @@ static void InitializeFlags() {
 #if SANITIZER_EMSCRIPTEN
   char *options = _emscripten_sanitizer_get_option("LSAN_OPTIONS");
   parser.ParseString(options);
-  emscripten_builtin_free(options);
+  free(options);
 #else
   parser.ParseString(GetEnv("LSAN_OPTIONS"));
 #endif // SANITIZER_EMSCRIPTEN

--- a/system/lib/compiler-rt/lib/ubsan/ubsan_flags.cpp
+++ b/system/lib/compiler-rt/lib/ubsan/ubsan_flags.cpp
@@ -79,7 +79,7 @@ void InitializeFlags() {
 #if SANITIZER_EMSCRIPTEN
   char* options = _emscripten_sanitizer_get_option("UBSAN_OPTIONS");
   parser.ParseString(options);
-  emscripten_builtin_free(options);
+  free(options);
 #else
   parser.ParseStringFromEnv("UBSAN_OPTIONS");
 #endif // SANITIZER_EMSCRIPTEN


### PR DESCRIPTION
Turns out that malloc and free seem to work fine, even during initial setup.