### PR TITLE
Only define noLeakCheck when lsan symbols are available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -681,6 +681,7 @@ jobs:
             lsan.test_pthread_create
             lsan.test_pthread_exit_main_stub
             lsan.test_dylink_iostream
+            ubsan.test_dlfcn_self
             ubsan.test_externref_emjs_dynlink"
       - freeze-cache
       - run-tests:

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1463,7 +1463,7 @@ addToLibrary({
     else return lengthBytesUTF8(str);
   },
 
-#if USE_ASAN || USE_LSAN || UBSAN_RUNTIME
+#if USE_ASAN || USE_LSAN
   // When lsan is enabled noLeakCheck will temporarily disable leak checking
   // for the duration of the function.
   $noLeakCheck__deps: ['__lsan_enable', '__lsan_disable'],
@@ -1476,7 +1476,9 @@ addToLibrary({
       if (runtimeInitialized) ___lsan_enable();
     }
   },
+#endif
 
+#if USE_ASAN || USE_LSAN || UBSAN_RUNTIME
   _emscripten_sanitizer_use_colors: () => {
     var setting = Module['printWithColors'];
     if (setting !== undefined) {


### PR DESCRIPTION
This fixes the ubsan failures on the emscripten-releases waterfall.