### PR TITLE
Build musl 'exit' files by default. NFC

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -492,6 +492,7 @@ class Library:
     batches = {}
     commands = []
     objects = set()
+    objects_lowercase = set()
     cflags = self.get_cflags()
     for src in self.get_files():
       ext = utils.suffix(src)
@@ -509,9 +510,9 @@ class Library:
         cmd += cflags
       cmd = self.customize_build_cmd(cmd, src)
 
-      object_basename = utils.unsuffixed_basename(src).lower()
+      object_basename = utils.unsuffixed_basename(src)
       o = os.path.join(build_dir, object_basename + '.o')
-      if o in objects:
+      if o.lower() in objects_lowercase:
         # If we have seen a file with the same name before, we need a separate
         # command to compile this file with a custom unique output object
         # filename, as batch compile doesn't allow such customization.
@@ -519,7 +520,7 @@ class Library:
         # This is needed to handle, for example, _exit.o and _Exit.o.
         object_uuid = 0
         # Find a unique basename
-        while o in objects:
+        while o.lower() in objects_lowercase:
           object_uuid += 1
           o = os.path.join(build_dir, f'{object_basename}__{object_uuid}.o')
         commands.append(cmd + [src, '-o', o])
@@ -529,11 +530,10 @@ class Library:
         src = os.path.relpath(src, build_dir)
         src = utils.normalize_path(src)
         batches.setdefault(tuple(cmd), []).append(src)
-        # No -o in command, use original file name.
-        o = os.path.join(build_dir, utils.unsuffixed_basename(src) + '.o')
       else:
         commands.append(cmd + [src, '-o', o])
       objects.add(o)
+      objects_lowercase.add(o.lower())
 
     if batch_inputs:
       # Choose a chunk size that is large enough to avoid too many subprocesses
@@ -1144,7 +1144,7 @@ class libc(MuslInternalLibrary,
     # musl modules
     ignore = [
         'ipc', 'passwd', 'signal', 'sched', 'time', 'linux',
-        'aio', 'exit', 'legacy', 'mq', 'setjmp',
+        'aio', 'legacy', 'mq', 'setjmp',
         'ldso', 'malloc',
     ]
 
@@ -1158,11 +1158,13 @@ class libc(MuslInternalLibrary,
         'getgrouplist.c', 'initgroups.c', 'wordexp.c', 'timer_create.c',
         'getauxval.c',
         'lookup_name.c',
-        # 'process' exclusion
+        # 'process' exclusions
         'fork.c', 'vfork.c', 'posix_spawn.c', 'posix_spawnp.c', 'execve.c', 'waitid.c', 'system.c',
         '_Fork.c',
-        # 'env' exclusion
+        # 'env' exclusions
         '__reset_tls.c', '__init_tls.c', '__libc_start_main.c',
+        # 'exit' exclusions
+        'assert.c', 'exit.c',
     ]
 
     ignore += LIBC_SOCKETS
@@ -1311,10 +1313,6 @@ class libc(MuslInternalLibrary,
     libc_files += files_in_path(
         path='system/lib/libc/musl/src/sched',
         filenames=['sched_yield.c'])
-
-    libc_files += files_in_path(
-        path='system/lib/libc/musl/src/exit',
-        filenames=['abort.c', '_Exit.c', 'atexit.c', 'at_quick_exit.c', 'quick_exit.c'])
 
     libc_files += files_in_path(
         path='system/lib/libc/musl/src/ldso',


### PR DESCRIPTION
Previously we were by default excluding the `exit` directory and then including and explict subset.

Now we include the whole directory and exclude the files we don't want.  The overall file list should be the same before and after.  Hence NFC.