### PR TITLE
Add `-sEXECUTABLE` to add #! line to generated JS

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,8 @@ See docs/process.md for more on how version tagging works.
 4.0.24 (in development)
 -----------------------
 - compiler-rt was updated to LLVM 21.1.8. (#26405)
+- A new `-sEXECUTABLE` setting was added which adds a #! line to the resulting
+  JavaScript and makes it executable. (#26085)
 
 4.0.23 - 01/10/26
 -----------------

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -3449,6 +3449,18 @@ library.
 
 Default value: true
 
+.. _executable:
+
+EXECUTABLE
+==========
+
+Add a #! line to generated JS file and make it executable.  This is useful
+for building command line tools that run under node.
+This setting can also be set to a string value, in which case that string
+will be used as the #! command to embed in the generated file.
+
+Default value: false
+
 .. _deprecated-settings:
 
 ===================

--- a/src/settings.js
+++ b/src/settings.js
@@ -2259,3 +2259,9 @@ var CROSS_ORIGIN = false;
 // to behave like :ref:`SIDE_MODULE` and produce a dynamically linked
 // library.
 var FAKE_DYLIBS = true;
+
+// Add a #! line to generated JS file and make it executable.  This is useful
+// for building command line tools that run under node.
+// This setting can also be set to a string value, in which case that string
+// will be used as the #! command to embed in the generated file.
+var EXECUTABLE = false;

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15282,3 +15282,15 @@ for(var i = 0; i < 65536; ++i)
 console.log('OK');'''
     write_file('test.js', read_file(path_from_root('src/binaryDecode.js')) + '\nvar src = ' + binary_encoded + ';\n' + test_js)
     self.assertContained('OK', self.run_js('test.js'))
+
+  @no_windows('depends on UNIX shbang feature')
+  def test_executable(self):
+    # First test without -sEXECUTABLE
+    self.run_process([EMCC, test_file('hello_world.c')])
+    self.assertNotContained('#!/usr/bin/env node', read_file('a.out.js'))
+
+    # Now, test with -sEXECUTABLE
+    self.run_process([EMCC, test_file('hello_world.c'), '-sEXECUTABLE'])
+    self.assertContained('#!/usr/bin/env node', read_file('a.out.js'))
+    output = self.run_process([os.path.abspath('a.out.js')], stdout=PIPE).stdout
+    self.assertContained('hello, world!', output)

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -404,7 +404,7 @@ class SettingsManager:
 
   def check_type(self, name, value):
     # These settings have a variable type so cannot be easily type checked.
-    if name in ('SUPPORT_LONGJMP', 'PTHREAD_POOL_SIZE', 'SEPARATE_DWARF', 'LTO', 'MODULARIZE'):
+    if name in ('EXECUTABLE', 'SUPPORT_LONGJMP', 'PTHREAD_POOL_SIZE', 'SEPARATE_DWARF', 'LTO', 'MODULARIZE'):
       return
     expected_type = self.types.get(name)
     if not expected_type:
@@ -414,9 +414,9 @@ class SettingsManager:
       if value in (1, 0):
         value = bool(value)
       if value in ('True', 'False', 'true', 'false'):
-        exit_with_error('attempt to set `%s` to `%s`; use 1/0 to set boolean settings' % (name, value))
+        exit_with_error(f'attempt to set `{name}` to `{value}`; use 1/0 to set boolean settings')
     if type(value) is not expected_type:
-      exit_with_error('setting `%s` expects `%s` but got `%s`' % (name, expected_type.__name__, type(value).__name__))
+      exit_with_error(f'setting `{name}` expects `{expected_type.__name__}` but got `{type(value).__name__}`')
 
   def __getitem__(self, key):
     return self.attrs[key]


### PR DESCRIPTION
This ability was previously internally used when running autoconf but not otherwise available.

As a followup I plan to make this the default when the output filename as no extension at all.

Fixes: #25490, #26061