### PR TITLE
[test] Fix inconsistency regarding subprocess stdout/stderr buffering. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1177,8 +1177,15 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
 
     if stdout_buffering:
       sys.stdout.write(rtn.stdout)
+      # When we inject stdout/stderr buffering for our own internal purposes, we do not also want to
+      # make it available on the returned object.
+      # If we don't do this then callers would have access to rtn.stdout/rtn.stderr even when they
+      # didn't request it (i.e. even when they did not pass stderr=PIPE), which can lead to tests
+      # that pass in buffering mode, but fail without it.
+      rtn.stdout = None
     if stderr_buffering:
       sys.stderr.write(rtn.stderr)
+      rtn.stderr = None
     return rtn
 
   def emcc(self, filename, args=[], **kwargs):  # noqa

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -318,8 +318,8 @@ class sockets(BrowserCore):
     # this is also a good test of raw usage of emconfigure and emmake
     shutil.copytree(test_file('third_party', 'enet'), 'enet')
     with common.chdir('enet'):
-      self.run_process([path_from_root('emconfigure'), './configure', '--disable-shared'])
-      self.run_process([path_from_root('emmake'), 'make'])
+      self.run_process([common.EMCONFIGURE, './configure', '--disable-shared'])
+      self.run_process([common.EMMAKE, 'make'])
       enet = [self.in_dir('enet', '.libs', 'libenet.a'), '-I' + self.in_dir('enet', 'include')]
 
     with CompiledServerHarness(test_file('sockets/test_enet_server.c'), enet, 49210) as harness:


### PR DESCRIPTION
This bug could lead to tests that pass locally (when buffering is the default) but not in CI (which doesn't do buffering by default).

Also, drive by fix to use existing EMCONFIGURE/EMCMAKE variables in test_sockets.py.