### PR TITLE
Default to EXECUTABLE=1 when generating a JS file with no extension

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,7 +22,8 @@ See docs/process.md for more on how version tagging works.
 -----------------------
 - compiler-rt was updated to LLVM 21.1.8. (#26405)
 - A new `-sEXECUTABLE` setting was added which adds a #! line to the resulting
-  JavaScript and makes it executable. (#26085)
+  JavaScript and makes it executable.  This setting defaults to true when the
+  output filename has no extension, or ends in `.out` (e.g. `a.out`) (#26085)
 
 4.0.23 - 01/10/26
 -----------------

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -585,6 +585,11 @@ Options that are modified or new in *emcc* are listed below:
    These rules only apply when linking.  When compiling to object code
    (See *-c* below) the name of the output file is irrelevant.
 
+   Note: Linking to a file with no extension (or a file ending in
+   ".out", like "a.out") will cause the generated JavaScript file to
+   be exectuable, and include a "#!" line to make it runnable
+   directly.
+
 "-c"
    [compile] Tells *emcc* to emit an object file which can then be
    linked with other object files to produce an executable.

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -574,6 +574,10 @@ Options that are modified or new in *emcc* are listed below:
   These rules only apply when linking.  When compiling to object code (See `-c`
   below) the name of the output file is irrelevant.
 
+  Note: Linking to a file with no extension (or a file ending in ``.out``, like
+  ``a.out``) will cause the generated JavaScript file to be exectuable, and
+  include a ``#!`` line to make it runnable directly.
+
 .. _emcc-c:
 
 ``-c``

--- a/tools/link.py
+++ b/tools/link.py
@@ -931,6 +931,14 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       if s in user_settings:
         diagnostics.warning('unused-command-line-argument', f'{s} is only valid when generating JavaScript output')
 
+  # When there is no final suffix or the suffix is `.out` (as in `a.out`) then default to
+  # making the resulting file exectuable.
+  if settings.ENVIRONMENT_MAY_BE_NODE and options.oformat == OFormat.JS and final_suffix in ('', '.out'):
+    default_setting('EXECUTABLE', 1)
+
+  if settings.EXECUTABLE and not settings.ENVIRONMENT_MAY_BE_NODE:
+    exit_with_error('EXECUTABLE requires `node` in ENVRIONMENT')
+
   if options.oformat == OFormat.MJS:
     default_setting('EXPORT_ES6', 1)
 


### PR DESCRIPTION
Followup to #26085 which added initial support for `-sEXECUTABLE`.

The assumption here is that if we are generating a file with no extension (or something called `a.out`) then we are trying to build something that is directly runnable.