### PR TITLE
Remove references to nodejs (rather than node) command. NFC

### DIFF
--- a/site/source/docs/building_from_source/toolchain_what_is_needed.rst
+++ b/site/source/docs/building_from_source/toolchain_what_is_needed.rst
@@ -83,16 +83,10 @@ You can check which tools are already present using the following commands:
   # Check for Python
   python --version
 
-  # Check for node.js on Linux
-  nodejs --version
-
-  # Check for node.js on Windows
+  # Check for Node.js
   node --version
 
-  # Check for node.js on macOS
-  node -v
-
-  # Check for git
+  # Check for Git
   git --version
 
   # Check for Java

--- a/site/source/docs/getting_started/downloads.rst
+++ b/site/source/docs/getting_started/downloads.rst
@@ -163,8 +163,6 @@ Linux
     # Install CMake (optional, only needed for tests and building Binaryen or LLVM)
     sudo apt-get install cmake
 
-.. note:: If you want to use your system's Node.js instead of the emsdk's, it may be ``node`` instead of ``nodejs``, and you can adjust the ``NODE_JS`` attribute of your ``.emscripten`` file to point to it.
-
 - *Git* is not installed automatically. Git is only needed if you want to use tools from a development branch.
 
   ::

--- a/site/source/docs/porting/asyncify.rst
+++ b/site/source/docs/porting/asyncify.rst
@@ -83,13 +83,13 @@ And you can run it with
 
 ::
 
-    nodejs a.out.js
+    node a.out.js
 
 Or with JSPI
 
 ::
 
-    nodejs --experimental-wasm-stack-switching a.out.js
+    node --experimental-wasm-stack-switching a.out.js
 
 You should then see something like this:
 

--- a/site/source/docs/tools_reference/emsdk.rst
+++ b/site/source/docs/tools_reference/emsdk.rst
@@ -106,7 +106,7 @@ the variable names used to point to the different tools::
   # .emscripten file from Linux SDK
 
   import os
-  NODE_JS = 'nodejs'
+  NODE_JS = 'node'
   LLVM_ROOT='/home/ubuntu/emsdk/upstream/bin'
 
 .. _emsdk_howto:


### PR DESCRIPTION
I believe a long while back `node` was not available on certain linux systems that insisted on the more explicit `nodejs`, but I also believe those days are long gone.