### PR TITLE
[ASYNCIFY] Run continuations under callUserCallback

### DIFF
--- a/src/lib/libasync.js
+++ b/src/lib/libasync.js
@@ -323,10 +323,9 @@ addToLibrary({
       // can just call the function with no args at all since the engine will produce zeros
       // for all arguments.  However, for i64 arguments we get `undefined cannot be converted to
       // BigInt`.
-      return func(...Asyncify.restoreRewindArguments(original));
-#else
-      return func();
+      func = func.bind(0, ...Asyncify.restoreRewindArguments(original));
 #endif
+      return callUserCallback(func);
     },
 
     // This receives a function to call to start the async operation, and
@@ -480,9 +479,8 @@ addToLibrary({
 #endif
   },
 
-  emscripten_sleep__deps: ['$safeSetTimeout'],
   emscripten_sleep__async: true,
-  emscripten_sleep: (ms) => Asyncify.handleSleep((wakeUp) => safeSetTimeout(wakeUp, ms)),
+  emscripten_sleep: (ms) => Asyncify.handleSleep((wakeUp) => setTimeout(wakeUp, ms)),
 
   emscripten_wget_data__deps: ['$asyncLoad', 'malloc'],
   emscripten_wget_data__async: 'auto',

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1997,6 +1997,9 @@ addToLibrary({
       }
     }
 #endif
+#if RUNTIME_DEBUG
+    dbg("handleException: got unexpected exception, calling quit_")
+#endif
     quit_(1, e);
   },
 
@@ -2066,10 +2069,11 @@ addToLibrary({
       return;
     }
     try {
-      func();
-      maybeExit();
+      return func();
     } catch (e) {
       handleException(e);
+    } finally {
+      maybeExit();
     }
   },
 

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18993,
-  "a.out.js.gz": 7823,
+  "a.out.js": 19001,
+  "a.out.js.gz": 7824,
   "a.out.nodebug.wasm": 106442,
   "a.out.nodebug.wasm.gz": 42653,
-  "total": 125435,
-  "total_gz": 50476,
+  "total": 125443,
+  "total_gz": 50477,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 244848,
+  "a.out.js": 244863,
   "a.out.nodebug.wasm": 577876,
-  "total": 822724,
+  "total": 822739,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7722,
-  "a.out.js.gz": 3812,
+  "a.out.js": 7737,
+  "a.out.js.gz": 3816,
   "a.out.nodebug.wasm": 19604,
   "a.out.nodebug.wasm.gz": 9079,
-  "total": 27326,
-  "total_gz": 12891,
+  "total": 27341,
+  "total_gz": 12895,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 8145,
-  "a.out.js.gz": 4011,
+  "a.out.js": 8160,
+  "a.out.js.gz": 4015,
   "a.out.nodebug.wasm": 19605,
   "a.out.nodebug.wasm.gz": 9080,
-  "total": 27750,
-  "total_gz": 13091,
+  "total": 27765,
+  "total_gz": 13095,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/embind_with_asyncify.cpp
+++ b/test/embind_with_asyncify.cpp
@@ -15,8 +15,5 @@ int main() {
   val async_text = response.call<val>("text");
   std::string text = async_text.await().as<std::string>();
   assert(text == "foo");
-  // This explicit exit() should not be necessary here.
-  // TODO(https://github.com/emscripten-core/emscripten/issues/26093)
-  exit(0);
   return 0;
 }

--- a/test/test_async_exit_after_wakeup.js
+++ b/test/test_async_exit_after_wakeup.js
@@ -2,11 +2,7 @@ addToLibrary({
   async_func__async: true,
   async_func: (value) => {
     return Asyncify.handleSleep((wakeUp) => {
-      // Currently with -sASYNCIFY the wakeUp call needs to be wrapped in
-      // callUserCallback, otherwise things like `exit()` won't work from
-      // the continuation.
-      // TODO(https://github.com/emscripten-core/emscripten/issues/26093)
-      setTimeout(() => callUserCallback(() => wakeUp(42)), 0);
+      setTimeout(() => wakeUp(42), 0);
     });
   },
 });

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9587,7 +9587,10 @@ NODEFS is no longer included by default; build with -lnodefs.js
       '-sINCOMING_MODULE_JS_API=onRuntimeInitialized',
     ]
     self.cflags += args
-    self.do_core_test('embind_lib_with_asyncify.cpp')
+    # This error here is because delayed_throw occurs during execution, and
+    # even though it is caught, its influence on the returncode persists.
+    # TODO: Should that be changed?
+    self.do_core_test('embind_lib_with_asyncify.cpp', assert_returncode=NON_ZERO)
 
   @no_asan('asyncify stack operations confuse asan')
   @with_asyncify_and_jspi


### PR DESCRIPTION
Without this, its up to each callsite to inject `callUserCallback` (e.g. via `safeSetTimeout` vs `setTimeout`).

Forgetting to do so can resulting in strange behaviour such as `exit()` not work as expected when called from the continuation.