### PR TITLE
Add test_async_exit_after_wakeup. NFC

### DIFF
--- a/test/embind_with_asyncify.cpp
+++ b/test/embind_with_asyncify.cpp
@@ -14,5 +14,9 @@ int main() {
   val response = async_response.await();
   val async_text = response.call<val>("text");
   std::string text = async_text.await().as<std::string>();
-  REPORT_RESULT(text == "foo");
+  assert(text == "foo");
+  // This explicit exit() should not be necessary here.
+  // TODO(https://github.com/emscripten-core/emscripten/issues/26093)
+  exit(0);
+  return 0;
 }

--- a/test/test_async_exit_after_wakeup.c
+++ b/test/test_async_exit_after_wakeup.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+extern int async_func();
+
+int main() {
+  int result = async_func();
+  assert(result == 42);
+  printf("done\n");
+  exit(0);
+}

--- a/test/test_async_exit_after_wakeup.js
+++ b/test/test_async_exit_after_wakeup.js
@@ -1,0 +1,12 @@
+addToLibrary({
+  async_func__async: true,
+  async_func: (value) => {
+    return Asyncify.handleSleep((wakeUp) => {
+      // Currently with -sASYNCIFY the wakeUp call needs to be wrapped in
+      // callUserCallback, otherwise things like `exit()` won't work from
+      // the continuation.
+      // TODO(https://github.com/emscripten-core/emscripten/issues/26093)
+      setTimeout(() => callUserCallback(() => wakeUp(42)), 0);
+    });
+  },
+});

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4913,7 +4913,7 @@ Module["preRun"] = () => {
     if is_jspi(args) and self.is_wasm64():
       self.skipTest('_emval_await fails')
 
-    self.btest('embind_with_asyncify.cpp', '1', cflags=['-lembind'] + args)
+    self.btest_exit('embind_with_asyncify.cpp', cflags=['-lembind'] + args)
 
   # Test emscripten_console_log(), emscripten_console_warn() and emscripten_console_error()
   def test_emscripten_console_log(self):

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10310,6 +10310,9 @@ _d
     test(['-sASSERTIONS=1'],
          'Aborted(RuntimeError: unreachable). "unreachable" may be due to ASYNCIFY_STACK_SIZE not being large enough (try increasing it)')
 
+  def test_async_exit_after_wakeup(self):
+    self.do_runf('test_async_exit_after_wakeup.c', cflags=['-sASYNCIFY', '--js-library', test_file('test_async_exit_after_wakeup.js')])
+
   # Sockets and networking
 
   def test_inet(self):


### PR DESCRIPTION
This test basically shows the current issue with asyncify where we re-enter the program without the normal `callUserCallback` context.

Also, convert test_embind_asyncify to btest_exit, which also currentlly depends on an explicit exit.

See #26093