### PR TITLE
Return ENOTSUP from pthread_create when threads are not available.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 4.0.24 (in development)
 -----------------------
+- Calling pthread_create in a single-threaded build will now return ENOTSUP
+  rather then EAGAIN.  (#26105)
 - compiler-rt and libunwind were updated to LLVM 21.1.8. (#26036 and #26045)
 - A new `-sEXECUTABLE` setting was added which adds a #! line to the resulting
   JavaScript and makes it executable.  This setting defaults to true when the

--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -92,7 +92,11 @@ int pthread_barrier_destroy(pthread_barrier_t* mutex) { return 0; }
 int pthread_barrier_wait(pthread_barrier_t* mutex) { return 0; }
 
 int __pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine) (void *), void *arg) {
-  return EAGAIN;
+  // ENOTSUP, while not mentioned in the pthread_create docs, does better
+  // describe the situation.
+  // See https://github.com/WebAssembly/wasi-libc/pull/716 for discussion
+  // on this error code vs, for example, EAGAIN.
+  return ENOTSUP;
 }
 
 weak_alias(__pthread_create, emscripten_builtin_pthread_create);

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
   "a.out.js": 244848,
-  "a.out.nodebug.wasm": 577875,
-  "total": 822723,
+  "a.out.nodebug.wasm": 577876,
+  "total": 822724,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/other/test_pthread_stub.c
+++ b/test/other/test_pthread_stub.c
@@ -22,12 +22,12 @@ void* start_pthread(void* arg) {
 }
 
 #define CHECK(X, EXPECTED) rtn = X; if (rtn != EXPECTED) printf(#X " returned %s\n", strerror(rtn)); assert(rtn == EXPECTED)
-#define CHECK_FAIL(X) CHECK(X, EAGAIN)
+#define CHECK_FAIL(X) CHECK(X, ENOTSUP)
 #define CHECK_SUCCESS(X) CHECK(X, 0)
 
 #define CHECK_C11(X, expected) rtn = X; if (rtn != expected) printf(#X " returned %d\n", rtn); assert(rtn == expected)
 #define CHECK_C11_SUCCESS(X) CHECK_C11(X, thrd_success)
-#define CHECK_C11_FAIL(X) CHECK_C11(X, thrd_nomem)
+#define CHECK_C11_FAIL(X) CHECK_C11(X, thrd_error)
 
 void test_c11_threads() {
   printf("test_c11_threads\n");

--- a/test/pthread/test_pthread_supported.c
+++ b/test/pthread/test_pthread_supported.c
@@ -11,19 +11,20 @@
 #include <assert.h>
 #include <errno.h>
 
-void *ThreadMain(void *arg)
-{
-	pthread_exit(NULL);
+void *ThreadMain(void *arg) {
+  pthread_exit(NULL);
 }
 
-int main()
-{
-	pthread_t thread;
-	int rc = pthread_create(&thread, NULL, ThreadMain, NULL);
-	pthread_join(thread, NULL);
+int main() {
+  pthread_t thread;
+  int rc = pthread_create(&thread, NULL, ThreadMain, NULL);
+  pthread_join(thread, NULL);
 
-	if (emscripten_has_threading_support()) assert(rc == 0);
-	else assert(rc == EAGAIN);
+  if (emscripten_has_threading_support()) {
+    assert(rc == 0);
+  } else {
+    assert(rc == ENOTSUP);
+  }
 
-	return 0;
+  return 0;
 }

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3911,7 +3911,7 @@ Module["preRun"] = () => {
    'mt': (['-pthread', '-sPTHREAD_POOL_SIZE=8'],),
   })
   def test_pthread_supported(self, args):
-    self.btest_exit('pthread/test_pthread_supported.cpp', cflags=['-O3'] + args)
+    self.btest_exit('pthread/test_pthread_supported.c', cflags=['-O3'] + args)
 
   def test_pthread_dispatch_after_exit(self):
     self.btest_exit('pthread/test_pthread_dispatch_after_exit.c', cflags=['-pthread'])

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15095,7 +15095,7 @@ addToLibrary({
 
     # Since we are building without -pthread the thread constructor will fail,
     # and in debug mode at least we expect to see the error message from libc++
-    expected = 'system_error was thrown in -fno-exceptions mode with error 6 and message "thread constructor failed"'
+    expected = 'system_error was thrown in -fno-exceptions mode with error 138 and message "thread constructor failed"'
     self.do_runf('main.cpp', expected, assert_returncode=NON_ZERO)
 
   def test_parsetools_make_removed_fs_assert(self):


### PR DESCRIPTION
See https://github.com/WebAssembly/wasi-libc/pull/716