### PR TITLE
Fix incorrect PR numbers in ChangeLog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -87,7 +87,7 @@ See docs/process.md for more on how version tagging works.
 - The standalone `file_packager.py` script no longer supports `--embed` with JS
   output (use `--obj-output` is now required for embedding data).  This usage
   has been producing a warning since #16050 which is now an error.  (#25049)
-- Embind now requires C++17 or newer. See #25773.
+- Embind now requires C++17 or newer. (#25773)
 
 4.0.19 - 11/04/25
 -----------------


### PR DESCRIPTION
I asked Gemini to compare `ChangeLog.md` and `git log` results and fix all incorrect PR numbers it finds. It ended up fixing several but all of them are the cases where the PR number does not actually exists (i.e., they are issues, not PRs). I think there are many more but it wasn't able to find the cases where the PR number exists but incorrect.

Anyway, these are the several cases it found.