### PR TITLE
Include <stdlib.h> in test_fetch_*.cpp files

### DIFF
--- a/test/fetch/test_fetch_cached_xhr.cpp
+++ b/test/fetch/test_fetch_cached_xhr.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
+#include <stdlib.h>
 #include <emscripten/fetch.h>
 
 int result = 0;

--- a/test/fetch/test_fetch_response_headers.cpp
+++ b/test/fetch/test_fetch_response_headers.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
+#include <stdlib.h>
 #include <emscripten/fetch.h>
 
 int result = 1;

--- a/test/fetch/test_fetch_stream_file.cpp
+++ b/test/fetch/test_fetch_stream_file.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
+#include <stdlib.h>
 #include <emscripten/fetch.h>
 
 // Compute rudimentary checksum of data

--- a/test/fetch/test_fetch_to_indexeddb.cpp
+++ b/test/fetch/test_fetch_to_indexeddb.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
+#include <stdlib.h>
 #include <emscripten/fetch.h>
 
 int main() {

--- a/test/fetch/test_fetch_to_memory.cpp
+++ b/test/fetch/test_fetch_to_memory.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
+#include <stdlib.h>
 #include <emscripten/fetch.h>
 
 int result = 1;


### PR DESCRIPTION
These files use `exit()`, which requires `#include <stdlib.h>`, but didn't have the include. These didn't error out because `libcxx/include/math.h` used to contain `#include <stdlib.h>` but not anymore. It was removed in https://github.com/llvm/llvm-project/pull/139586, which is included in LLVM 21.