### PR TITLE
Use `async: auto` for `dlopen_js`. NFC

### DIFF
--- a/src/lib/libasync.js
+++ b/src/lib/libasync.js
@@ -348,7 +348,8 @@ addToLibrary({
         var reachedAfterCallback = false;
         startAsync((handleSleepReturnValue = 0) => {
 #if ASSERTIONS
-          assert(!handleSleepReturnValue || typeof handleSleepReturnValue == 'number' || typeof handleSleepReturnValue == 'boolean'); // old emterpretify API supported other stuff
+          // old emterpretify API supported other stuff
+          assert(['undefined', 'number', 'boolean', 'bigint'].includes(typeof handleSleepReturnValue), `invalid type for handleSleepReturnValue: '${typeof handleSleepReturnValue}'`);
 #endif
           if (ABORT) return;
           Asyncify.handleSleepReturnValue = handleSleepReturnValue;

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1317,22 +1317,13 @@ var LibraryDylink = {
   },
 
   _dlopen_js__deps: ['$dlopenInternal'],
+  _dlopen_js__async: 'auto',
+  _dlopen_js: (handle) =>
 #if ASYNCIFY
-  _dlopen_js__async: true,
-#endif
-  _dlopen_js: {{{ asyncIf(ASYNCIFY == 2) }}} (handle) =>
-#if ASYNCIFY
-    Asyncify.handleSleep((wakeUp) =>
-      dlopenInternal(handle, { loadAsync: true })
-      .then(wakeUp)
-      // Note: this currently relies on being able to catch errors even from `wakeUp` callback itself.
-      // That's why we can't refactor it to `handleAsync` at the moment.
-      .catch(() => wakeUp(0))
-    )
+    dlopenInternal(handle, { loadAsync: true }),
 #else
-    dlopenInternal(handle, { loadAsync: false })
+    dlopenInternal(handle, { loadAsync: false }),
 #endif
-    ,
 
   // Async version of dlopen.
   _emscripten_dlopen_js__deps: ['$dlopenInternal', '$callUserCallback', '$dlSetError'],


### PR DESCRIPTION
Followup to #26019 and #26095.

The old comment here is, I believe, no longer valid now that #26095 has landed.
