### PR TITLE
Rename @node_pthreads decorator to @requires_pthreads. NFC

### DIFF
--- a/test/decorators.py
+++ b/test/decorators.py
@@ -203,7 +203,7 @@ def requires_jspi(func):
   return decorated
 
 
-def node_pthreads(func):
+def requires_pthreads(func):
   assert callable(func)
 
   @wraps(func)

--- a/test/test_codesize.py
+++ b/test/test_codesize.py
@@ -18,7 +18,7 @@ from common import (
   read_file,
   test_file,
 )
-from decorators import node_pthreads, parameterized
+from decorators import parameterized, requires_pthreads
 
 from tools import building, shared
 
@@ -319,7 +319,7 @@ class codesize(RunnerCore):
     self.cflags.append('--no-entry')
     self.run_codesize_test('minimal.c', args, check_full_js=check_full_js)
 
-  @node_pthreads
+  @requires_pthreads
   @parameterized({
     '': ([],),
     'memgrowth': (['-sALLOW_MEMORY_GROWTH'],),

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -53,7 +53,6 @@ from decorators import (
   no_4gb,
   no_wasm64,
   no_windows,
-  node_pthreads,
   parameterize,
   parameterized,
   requires_dev_dependency,
@@ -61,6 +60,7 @@ from decorators import (
   requires_native_clang,
   requires_node,
   requires_node_canary,
+  requires_pthreads,
   requires_v8,
   requires_wasm2js,
   requires_wasm_eh,
@@ -519,7 +519,7 @@ class TestCoreBase(RunnerCore):
   def test_hello_argc(self):
     self.do_core_test('test_hello_argc.c', args=['hello', 'world'])
 
-  @node_pthreads
+  @requires_pthreads
   def test_hello_argc_pthreads(self):
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
@@ -2564,22 +2564,22 @@ The current type of b is: 9
     self.set_setting('EXIT_RUNTIME')
     self.do_core_test('test_atexit_threads.cpp')
 
-  @node_pthreads
+  @requires_pthreads
   def test_atexit_threads(self):
     self.set_setting('EXIT_RUNTIME')
     self.do_core_test('test_atexit_threads.cpp')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_cancel(self):
     self.do_run_in_out_file_test('pthread/test_pthread_cancel.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_cancel_async(self):
     self.do_run_in_out_file_test('pthread/test_pthread_cancel_async.c')
 
   @no_asan('cannot replace malloc/free with ASan')
   @no_lsan('cannot replace malloc/free with LSan')
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_proxy_deadlock(self):
     self.do_runf('pthread/test_pthread_proxy_deadlock.c')
 
@@ -2590,7 +2590,7 @@ The current type of b is: 9
   def test_pthread_equal(self):
     self.do_run_in_out_file_test('pthread/test_pthread_equal.cpp')
 
-  @node_pthreads
+  @requires_pthreads
   @also_with_modularize
   def test_pthread_proxying(self):
     if '-sMODULARIZE' in self.cflags:
@@ -2603,7 +2603,7 @@ The current type of b is: 9
       self.set_setting('INITIAL_MEMORY=32mb')
     self.do_run_in_out_file_test('pthread/test_pthread_proxying.c', interleaved_output=False)
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_proxying_cpp(self):
     self.set_setting('PROXY_TO_PTHREAD')
     if not self.has_changed_setting('INITIAL_MEMORY'):
@@ -2611,19 +2611,19 @@ The current type of b is: 9
     self.do_run_in_out_file_test('pthread/test_pthread_proxying_cpp.cpp',
                                  interleaved_output=False)
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_proxying_dropped_work(self):
     self.set_setting('PTHREAD_POOL_SIZE=2')
     self.do_run_in_out_file_test('pthread/test_pthread_proxying_dropped_work.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_proxying_canceled_work(self):
     self.set_setting('PROXY_TO_PTHREAD')
     self.do_run_in_out_file_test(
         'pthread/test_pthread_proxying_canceled_work.c',
         interleaved_output=False)
 
-  @node_pthreads
+  @requires_pthreads
   @flaky('https://github.com/emscripten-core/emscripten/issues/19795')
   def test_pthread_proxying_refcount(self):
     self.set_setting('EXIT_RUNTIME')
@@ -2631,23 +2631,23 @@ The current type of b is: 9
     self.set_setting('ASSERTIONS=0')
     self.do_run_in_out_file_test('pthread/test_pthread_proxying_refcount.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_dispatch_after_exit(self):
     self.do_run_in_out_file_test('pthread/test_pthread_dispatch_after_exit.c', interleaved_output=False)
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_atexit(self):
     # Test to ensure threads are still running when atexit-registered functions are called
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     self.do_run_in_out_file_test('pthread/test_pthread_atexit.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_nested_work_queue(self):
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     self.do_run_in_out_file_test('pthread/test_pthread_nested_work_queue.c')
 
-  @node_pthreads
+  @requires_pthreads
   @flaky('Times out in bigendian0 suite only. https://github.com/emscripten-core/emscripten/issues/25316')
   def test_pthread_thread_local_storage(self):
     self.set_setting('PROXY_TO_PTHREAD')
@@ -2656,12 +2656,12 @@ The current type of b is: 9
       self.set_setting('INITIAL_MEMORY', '300mb')
     self.do_run_in_out_file_test('pthread/test_pthread_thread_local_storage.cpp')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_cleanup(self):
     self.set_setting('PTHREAD_POOL_SIZE', 4)
     self.do_run_in_out_file_test('pthread/test_pthread_cleanup.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_setspecific_mainthread(self):
     print('.. return')
     self.do_runf('pthread/test_pthread_setspecific_mainthread.c', 'done!', cflags=['-DRETURN'])
@@ -2670,7 +2670,7 @@ The current type of b is: 9
     print('.. pthread_exit')
     self.do_run_in_out_file_test('pthread/test_pthread_setspecific_mainthread.c')
 
-  @node_pthreads
+  @requires_pthreads
   @also_with_minimal_runtime
   def test_pthread_attr_getstack(self):
     if self.get_setting('MINIMAL_RUNTIME') and is_sanitizing(self.cflags):
@@ -2678,7 +2678,7 @@ The current type of b is: 9
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     self.do_run_in_out_file_test('pthread/test_pthread_attr_getstack.c')
 
-  @node_pthreads
+  @requires_pthreads
   @flaky('flaky specifically in esm_integration suite. https://github.com/emscripten-core/emscripten/issues/25151')
   def test_pthread_abort(self):
     self.set_setting('PROXY_TO_PTHREAD')
@@ -2689,7 +2689,7 @@ The current type of b is: 9
     self.cflags += ['-sINCOMING_MODULE_JS_API=preRun,onAbort']
     self.do_run_in_out_file_test('pthread/test_pthread_abort.c', assert_returncode=NON_ZERO)
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_abort_interrupt(self):
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     expected = ['Aborted(). Build with -sASSERTIONS for more info', 'Aborted(native code called abort())']
@@ -2697,7 +2697,7 @@ The current type of b is: 9
 
   @no_asan('ASan does not support custom memory allocators')
   @no_lsan('LSan does not support custom memory allocators')
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_emmalloc(self):
     self.cflags += ['-fno-builtin']
     self.set_setting('PROXY_TO_PTHREAD')
@@ -2706,27 +2706,27 @@ The current type of b is: 9
     self.set_setting('MALLOC', 'emmalloc')
     self.do_core_test('test_emmalloc.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_stdout_after_main(self):
     # Verify that secondary threads can continue to write to stdout even
     # after the main thread returns.  We had a regression where stdio
     # streams were locked when the main thread returned.
     self.do_runf('pthread/test_pthread_stdout_after_main.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_proxy_to_pthread(self):
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test('pthread/test_pthread_proxy_to_pthread.c')
 
-  @node_pthreads
+  @requires_pthreads
   @needs_dylink
   def test_pthread_tls_dylink(self):
     self.set_setting('MAIN_MODULE', 2)
     self.cflags.append('-Wno-experimental')
     self.do_run_in_out_file_test('pthread/test_pthread_tls_dylink.c')
 
-  @node_pthreads
+  @requires_pthreads
   @also_with_minimal_runtime
   def test_pthread_tls(self):
     if self.get_setting('MINIMAL_RUNTIME') and is_sanitizing(self.cflags):
@@ -2747,25 +2747,25 @@ The current type of b is: 9
     self.set_setting('EXIT_RUNTIME')
     self.do_runf('pthread/test_pthread_run_script.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_mutex_robust(self):
     self.do_run_in_out_file_test('pthread/test_pthread_mutex_robust.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_wait32_notify(self):
     self.do_run_in_out_file_test('atomic/test_wait32_notify.c')
 
-  @node_pthreads
+  @requires_pthreads
   @no_wasm2js('https://github.com/WebAssembly/binaryen/issues/5991')
   def test_pthread_wait64_notify(self):
     self.do_run_in_out_file_test('atomic/test_wait64_notify.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_wait_async(self):
     self.set_setting('PROXY_TO_PTHREAD')
     self.do_run_in_out_file_test('atomic/test_wait_async.c')
 
-  @node_pthreads
+  @requires_pthreads
   @also_with_minimal_runtime
   def test_pthread_run_on_main_thread(self):
     if self.get_setting('MINIMAL_RUNTIME') and is_sanitizing(self.cflags):
@@ -5252,13 +5252,13 @@ main main sees -524, -534, 72.
     self.run_process([EMCC, 'liba.c', '-o', 'liba.so', '-sSIDE_MODULE', 'libb.so'] + self.get_cflags())
     self.do_runf('main.c', 'Hello from b\n', cflags=['-sMAIN_MODULE=2', '-L.', 'liba.so'])
 
-  @node_pthreads
+  @requires_pthreads
   @needs_dylink
   def test_dylink_tls(self):
     self.cflags.append('-Wno-experimental')
     self.dylink_testf(test_file('core/test_dylink_tls.c'))
 
-  @node_pthreads
+  @requires_pthreads
   @needs_dylink
   def test_dylink_tls_export(self):
     self.cflags.append('-Wno-experimental')
@@ -6545,7 +6545,7 @@ void* operator new(size_t size) {
 
     self.do_core_test('test_mmap_anon.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_mmap_anon_pthreads(self):
     # Same test with threading enabled so give is some basic sanity
     # checks of the locking on the internal data structures.
@@ -7453,7 +7453,7 @@ void* operator new(size_t size) {
     self.maybe_closure()
     self.do_run_in_out_file_test('embind/test_embind_val_basics.cpp', cflags=args)
 
-  @node_pthreads
+  @requires_pthreads
   def test_embind_basics(self):
     self.maybe_closure()
     self.cflags += [
@@ -7608,7 +7608,7 @@ void* operator new(size_t size) {
   def test_embind_val_assignment(self):
     self.assert_fail([EMCC, test_file('embind/test_val_assignment.cpp'), '-lembind', '-c'], 'candidate function not viable: expects an lvalue for object argument')
 
-  @node_pthreads
+  @requires_pthreads
   def test_embind_val_cross_thread(self):
     self.cflags += ['--bind']
     create_file('test_embind_val_cross_thread.cpp', r'''
@@ -7635,7 +7635,7 @@ void* operator new(size_t size) {
     ''')
     self.do_runf('test_embind_val_cross_thread.cpp', 'val accessed from wrong thread', assert_returncode=NON_ZERO)
 
-  @node_pthreads
+  @requires_pthreads
   def test_embind_val_cross_thread_deleted(self):
     self.cflags += ['--bind']
     create_file('test_embind_val_cross_thread.cpp', r'''
@@ -7841,7 +7841,7 @@ void* operator new(size_t size) {
   # WASM_ASYNC_COMPILATION=0 + PTHREAD_POOL_DELAY_LOAD=1.  Also checks that
   # PTHREAD_POOL_DELAY_LOAD=1 adds a pthreadPoolReady promise that users
   # can wait on for pthread initialization.
-  @node_pthreads
+  @requires_pthreads
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_ASYNC_COMPILATION=0')
   def test_embind_sync_if_pthread_delayed(self):
     self.set_setting('WASM_ASYNC_COMPILATION', 0)
@@ -8489,7 +8489,7 @@ Module.onRuntimeInitialized = () => {
 
   # Test that pthread_join works correctly with asyncify.
   @requires_node_canary
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_join_and_asyncify(self):
     # TODO Test with ASYNCIFY=1 https://github.com/emscripten-core/emscripten/issues/17552
     self.require_jspi()
@@ -8630,7 +8630,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('ASSERTIONS', 2)
     self.do_runf('stack_overflow.cpp', 'stack overflow', assert_returncode=NON_ZERO)
 
-  @node_pthreads
+  @requires_pthreads
   def test_binaryen_2170_emscripten_atomic_cas_u8(self):
     self.cflags.append('-pthread')
     self.do_run_in_out_file_test('binaryen_2170_emscripten_atomic_cas_u8.cpp')
@@ -9072,7 +9072,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
                  assert_all=True,
                  assert_returncode=NON_ZERO)
 
-  @node_pthreads
+  @requires_pthreads
   def test_safe_stack_pthread(self):
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
     self.set_setting('STACK_SIZE', 65536)
@@ -9138,7 +9138,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     '': ([],),
     'sync_instantiation': (['-sWASM_ASYNC_COMPILATION=0'],),
   })
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_create(self, args):
     if self.get_setting('WASM_ESM_INTEGRATION') and '-sWASM_ASYNC_COMPILATION=0' in args:
       self.skipTest('WASM_ESM_INTEGRATION is not compatible with WASM_ASYNC_COMPILATION=0')
@@ -9146,7 +9146,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('STRICT')
     self.do_core_test('pthread/create.c', cflags=args)
 
-  @node_pthreads
+  @requires_pthreads
   @parameterized({
     '': ([],),
     'pooled': (['-sPTHREAD_POOL_SIZE=1'],),
@@ -9160,7 +9160,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('ENVIRONMENT', 'node')
     self.do_run_in_out_file_test('pthread/test_pthread_c11_threads.c')
 
-  @node_pthreads
+  @requires_pthreads
   @parameterized({
     '': (0,),
     'pooled': (1,),
@@ -9169,7 +9169,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('PTHREAD_POOL_SIZE', pthread_pool_size)
     self.do_run_in_out_file_test('pthread/test_pthread_cxx_threads.cpp')
 
-  @node_pthreads
+  @requires_pthreads
   @parameterized({
     '': (0,),
     'pooled': (1,),
@@ -9178,20 +9178,20 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('PTHREAD_POOL_SIZE', pthread_pool_size)
     self.do_run_in_out_file_test('pthread/test_pthread_busy_wait.cpp')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_busy_wait_atexit(self):
     self.set_setting('PTHREAD_POOL_SIZE', 1)
     self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test('pthread/test_pthread_busy_wait_atexit.cpp')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_create_pool(self):
     # with a pool, we can synchronously depend on workers being available
     self.set_setting('PTHREAD_POOL_SIZE', 2)
     self.cflags += ['-DALLOW_SYNC']
     self.do_core_test('pthread/create.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_create_proxy(self):
     # with PROXY_TO_PTHREAD, we can synchronously depend on workers being available
     self.set_setting('PROXY_TO_PTHREAD')
@@ -9199,42 +9199,42 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.cflags += ['-DALLOW_SYNC']
     self.do_core_test('pthread/create.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_create_embind_stack_check(self):
     # embind should work with stack overflow checks (see #12356)
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
     self.cflags += ['-lembind']
     self.do_core_test('pthread/create.c', cflags=['-sDEFAULT_TO_CXX'])
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_exceptions(self):
     self.set_setting('PTHREAD_POOL_SIZE', 2)
     self.cflags += ['-fexceptions']
     self.do_core_test('pthread/exceptions.cpp')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_exit_process(self):
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
     self.cflags += ['-DEXIT_RUNTIME', '--pre-js', test_file('core/pthread/test_pthread_exit_runtime.pre.js'), '-sINCOMING_MODULE_JS_API=onRuntimeInitialized,onExit']
     self.do_core_test('pthread/test_pthread_exit_runtime.c', assert_returncode=42)
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_keepalive(self):
     self.do_core_test('pthread/test_pthread_keepalive.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_weak_ref(self):
     self.do_core_test('pthread/test_pthread_weak_ref.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_exit_main(self):
     self.do_core_test('pthread/test_pthread_exit_main.c')
 
   def test_pthread_exit_main_stub(self):
     self.do_core_test('pthread/test_pthread_exit_main.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_unhandledrejection(self):
     # Check that an unhandled promise rejection is propagated to the main thread
     # as an error.
@@ -9242,7 +9242,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.cflags += ['--post-js', test_file('pthread/test_pthread_unhandledrejection.post.js')]
     self.do_runf('pthread/test_pthread_unhandledrejection.c', 'passed')
 
-  @node_pthreads
+  @requires_pthreads
   @no_wasm2js('wasm2js does not support PROXY_TO_PTHREAD (custom section support)')
   @also_with_modularize
   def test_pthread_return_address(self):
@@ -9255,24 +9255,24 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_emscripten_atomics_stub(self):
     self.do_core_test('pthread/emscripten_atomics.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_emscripten_atomics(self):
     self.cflags.append('-pthread')
     self.do_core_test('pthread/emscripten_atomics.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_emscripten_futexes(self):
     self.cflags.append('-pthread')
     self.cflags += ['-Wno-nonnull'] # This test explicitly checks behavior of passing NULL to emscripten_futex_wake().
     self.do_core_test('pthread/emscripten_futexes.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_stdio_locking(self):
     self.set_setting('PTHREAD_POOL_SIZE', '2')
     self.do_core_test('test_stdio_locking.c')
 
   @with_dylink_reversed
-  @node_pthreads
+  @requires_pthreads
   @flaky('Test asani.test_pthread_dylink_basics is flaky due to some kind of racy interaction with asan + -sPROXY_TO_PTHREAD. https://github.com/emscripten-core/emscripten/issues/25211')
   def test_pthread_dylink_basics(self):
     self.cflags.append('-Wno-experimental')
@@ -9281,7 +9281,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_basic_dylink_test()
 
   @needs_dylink
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_dylink(self):
     self.cflags += ['-Wno-experimental', '-pthread']
     main = test_file('core/pthread/test_pthread_dylink.c')
@@ -9299,21 +9299,21 @@ NODEFS is no longer included by default; build with -lnodefs.js
     '': (['-sNO_AUTOLOAD_DYLIBS'],),
     'autoload': ([],),
   })
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_dylink_entry_point(self, args):
     self.cflags += ['-Wno-experimental', '-pthread']
     main = test_file('core/pthread/test_pthread_dylink_entry_point.c')
     self.dylink_testf(main, cflags=args, main_cflags=['-sPTHREAD_POOL_SIZE=1'])
 
   @needs_dylink
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_dylink_exceptions(self):
     self.cflags += ['-Wno-experimental', '-pthread']
     self.cflags.append('-fexceptions')
     self.dylink_testf(test_file('core/pthread/test_pthread_dylink_exceptions.cpp'))
 
   @needs_dylink
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_dlopen(self):
     self.cflags += ['-Wno-experimental', '-pthread']
     self.build_dlfcn_lib(test_file('core/pthread/test_pthread_dlopen_side.c'))
@@ -9327,7 +9327,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
                  assert_all=True)
 
   @needs_dylink
-  @node_pthreads
+  @requires_pthreads
   @flaky('https://github.com/emscripten-core/emscripten/issues/18887')
   def test_pthread_dlopen_many(self):
     # In other suites, this test is flaky.. but in Wasm64 suite, it is failing
@@ -9358,7 +9358,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
                  assert_all=True)
 
   @needs_dylink
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_dlsym(self):
     self.cflags += ['-Wno-experimental', '-pthread']
     self.build_dlfcn_lib(test_file('core/pthread/test_pthread_dlsym_side.c'))
@@ -9369,7 +9369,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_runf('core/pthread/test_pthread_dlsym.c')
 
   @needs_dylink
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_dylink_tls(self):
     if '-O2' in self.cflags and self.get_setting('STACK_OVERFLOW_CHECK') == 2:
       self.skipTest('https://github.com/emscripten-core/emscripten/issues/24964: fails with stack overflow (Attempt to set SP to 0x000114d0, with stack limits [0x00000000 - 0x00000000])')
@@ -9379,14 +9379,14 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.dylink_testf(main, main_cflags=['-sPTHREAD_POOL_SIZE=1'])
 
   @needs_dylink
-  @node_pthreads
+  @requires_pthreads
   def test_pthread_dylink_longjmp(self):
     self.cflags += ['-Wno-experimental', '-pthread']
     main = test_file('core/pthread/test_pthread_dylink_longjmp.c')
     self.dylink_testf(main, main_cflags=['-sPTHREAD_POOL_SIZE=1'])
 
   @needs_dylink
-  @node_pthreads
+  @requires_pthreads
   @no_js_math('JS_MATH is not compatible with MAIN_MODULE=1')
   def test_pthread_dylink_main_module_1(self):
     # TODO: For some reason, -lhtml5 must be passed in -sSTRICT mode, but can NOT
@@ -9540,7 +9540,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.assertNotContained('unhandled exception', output)
     self.assertNotContained('Aborted', output)
 
-  @node_pthreads
+  @requires_pthreads
   @no_esm_integration('ABORT_ON_WASM_EXCEPTIONS is not compatible with WASM_ESM_INTEGRATION')
   def test_abort_on_exceptions_pthreads(self):
     self.set_setting('ABORT_ON_WASM_EXCEPTIONS')
@@ -9647,11 +9647,11 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_syscall_intercept(self):
     self.do_core_test('test_syscall_intercept.c')
 
-  @node_pthreads
+  @requires_pthreads
   def test_select_blocking(self):
     self.do_runf('core/test_select_blocking.c', cflags=['-pthread', '-sPROXY_TO_PTHREAD=1', '-sEXIT_RUNTIME=1'])
 
-  @node_pthreads
+  @requires_pthreads
   def test_poll_blocking(self):
     self.do_runf('core/test_poll_blocking.c', cflags=['-pthread', '-sPROXY_TO_PTHREAD=1', '-sEXIT_RUNTIME=1'])
 
@@ -9702,7 +9702,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.run_process([FILE_PACKAGER, 'test.data', '--preload', 'file1.txt', 'file2.txt', '--from-emcc', '--js-output=script2.js'])
     self.do_runf('test_emscripten_async_load_script.c', cflags=['-sFORCE_FILESYSTEM'])
 
-  @node_pthreads
+  @requires_pthreads
   @no_sanitize('sanitizers do not support WASM_WORKERS')
   @also_with_minimal_runtime
   @also_with_modularize
@@ -9713,13 +9713,13 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.maybe_closure()
     self.do_run_in_out_file_test('wasm_worker/hello_wasm_worker.c', cflags=['-sWASM_WORKERS'])
 
-  @node_pthreads
+  @requires_pthreads
   @no_sanitize('sanitizers do not support WASM_WORKERS')
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
   def test_wasm_worker_malloc(self):
     self.do_run_in_out_file_test('wasm_worker/malloc_wasm_worker.c', cflags=['-sWASM_WORKERS'])
 
-  @node_pthreads
+  @requires_pthreads
   @no_sanitize('sanitizers do not support WASM_WORKERS')
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
   def test_wasm_worker_wait_async(self):

--- a/test/test_posixtest.py
+++ b/test/test_posixtest.py
@@ -16,7 +16,7 @@ import unittest
 import test_posixtest_browser
 from browser_common import browser_should_skip_feature
 from common import RunnerCore, path_from_root
-from decorators import node_pthreads
+from decorators import requires_pthreads
 
 from tools.feature_matrix import Feature
 
@@ -160,7 +160,7 @@ expect_fail = {
 
 def make_test(name, testfile, browser):
 
-  @node_pthreads
+  @requires_pthreads
   def f(self):
     if name in disabled:
       self.skipTest(disabled[name])

--- a/test/test_stress.py
+++ b/test/test_stress.py
@@ -17,7 +17,7 @@ import subprocess
 import threading
 
 from common import NON_ZERO, RunnerCore
-from decorators import also_with_modularize, is_slow_test, node_pthreads
+from decorators import also_with_modularize, is_slow_test, requires_pthreads
 
 
 class stress(RunnerCore):
@@ -73,7 +73,7 @@ class stress(RunnerCore):
       raise error_exception
 
   # This is a stress test version that focuses on https://github.com/emscripten-core/emscripten/issues/20067
-  @node_pthreads
+  @requires_pthreads
   @is_slow_test
   def test_stress_proxy_to_pthread_hello_world(self):
     self.skipTest('Occasionally hangs. https://github.com/emscripten-core/emscripten/issues/20067')
@@ -85,7 +85,7 @@ class stress(RunnerCore):
 
   # This is a stress test to verify that the Node.js postMessage() vs uncaughtException
   # race does not affect Emscripten execution.
-  @node_pthreads
+  @requires_pthreads
   @is_slow_test
   def test_stress_pthread_abort(self):
     self.set_setting('PROXY_TO_PTHREAD')
@@ -99,7 +99,7 @@ class stress(RunnerCore):
     # TODO: investigate why adding assert_returncode=NON_ZERO to above doesn't work.
     # Is the test test_pthread_abort still flaky?
 
-  @node_pthreads
+  @requires_pthreads
   @also_with_modularize
   @is_slow_test
   def test_stress_pthread_proxying(self):


### PR DESCRIPTION
This matches the names of the other decorators, and paves the way to support Deno and Bun as well as node.