### PR TITLE
[ASYNCIFY] Convert remaining `async` JS function to use `auto`

### DIFF
--- a/src/lib/libasync.js
+++ b/src/lib/libasync.js
@@ -446,9 +446,9 @@ addToLibrary({
     //
     // This is particularly useful for native JS `async` functions where the
     // returned value will "just work" and be passed back to C++.
-    handleAsync: (startAsync) => Asyncify.handleSleep((wakeUp) => {
+    handleAsync: (startAsync) => Asyncify.handleSleep(async (wakeUp) => {
       // TODO: add error handling as a second param when handleSleep implements it.
-      startAsync().then(wakeUp);
+      wakeUp(await startAsync());
     }),
 
 #elif ASYNCIFY == 2
@@ -480,8 +480,8 @@ addToLibrary({
 #endif
   },
 
-  emscripten_sleep__async: true,
-  emscripten_sleep: (ms) => Asyncify.handleSleep((wakeUp) => setTimeout(wakeUp, ms)),
+  emscripten_sleep__async: 'auto',
+  emscripten_sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 
   emscripten_wget_data__deps: ['$asyncLoad', 'malloc'],
   emscripten_wget_data__async: 'auto',
@@ -518,7 +518,7 @@ addToLibrary({
   },
 
   _load_secondary_module__sig: 'v',
-  _load_secondary_module__async: true,
+  _load_secondary_module__async: 'auto',
   _load_secondary_module: async function() {
     // Mark the module as loading for the wasm module (so it doesn't try to load it again).
     wasmExports['load_secondary_module_status'].value = 1;

--- a/src/lib/libwasi.js
+++ b/src/lib/libwasi.js
@@ -540,7 +540,7 @@ var WasiLibrary = {
     return 0;
   },
 
-  fd_sync__async: true,
+  fd_sync__async: 'auto',
   fd_sync: (fd) => {
 #if SYSCALLS_REQUIRE_FILESYSTEM
     var stream = SYSCALLS.getStreamFromFD(fd);
@@ -548,8 +548,8 @@ var WasiLibrary = {
 #if ASYNCIFY
     var mount = stream.node.mount;
     if (mount.type.syncfs) {
-      return Asyncify.handleSleep((wakeUp) => {
-        mount.type.syncfs(mount, false, (err) => wakeUp(err ? {{{ cDefs.EIO }}} : 0));
+      return new Promise((resolve) => {
+        mount.type.syncfs(mount, false, (err) => resolve(err ? {{{ cDefs.EIO }}} : 0));
       });
     }
 #endif // ASYNCIFY

--- a/test/test_async_exit_after_wakeup.js
+++ b/test/test_async_exit_after_wakeup.js
@@ -1,8 +1,4 @@
 addToLibrary({
-  async_func__async: true,
-  async_func: (value) => {
-    return Asyncify.handleSleep((wakeUp) => {
-      setTimeout(() => wakeUp(42), 0);
-    });
-  },
+  async_func__async: 'auto',
+  async_func: (value) => new Promise((resolve) => setTimeout(() => resolve(42), 0)),
 });


### PR DESCRIPTION
The only function that remains that still uses `async: true` is `emscripten_fiber_swap`, and this is because it doesn't use handleSleep or handleAsync, so is not a candidate for `async: auto`.

Followup to #26019 and #26095.