### PR TITLE
Fix strip_debug_sections in wasm-sourcemap.py

### DIFF
--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -138,7 +138,7 @@ def strip_debug_sections(wasm):
     if section_id == 0:
       name_len, name_pos = read_var_uint(wasm, section_body)
       name_end = name_pos + name_len
-      name = wasm[name_pos:name_end]
+      name = str(wasm[name_pos:name_end])
       if name in {'linking', 'sourceMappingURL'} or name.startswith(('reloc..debug_', '.debug_')):
         continue  # skip debug related sections
     stripped = stripped + wasm[section_start:pos]


### PR DESCRIPTION
Because `wasm` is read as bytes, `name` is bytes too. Without `str()` this crashes in the next line.

I don't think we actually use this `--strip` anywhere now because we strip debug sections using `llvm-objdump`. I'm not sure if it's worth adding a separate test for this.