### PR TITLE
gen_struct_info.py: Remove redundant `-std=c++17`. NFC

### DIFF
--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -87,7 +87,6 @@ CXXFLAGS = [
     '-I' + utils.path_from_root('system/lib/libcxxabi/src'),
     '-D__EMSCRIPTEN_EXCEPTIONS__',
     '-I' + utils.path_from_root('system/lib/wasmfs/'),
-    '-std=c++17',
 ]
 
 DEFAULT_JSON_FILES = [


### PR DESCRIPTION
This is the default C++ version in emcc/clang these days.