### PR TITLE
Minor fixes to get more test running with bun. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -419,10 +419,16 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
         return engine
     return None
 
+  def get_bun(self):
+    for engine in config.JS_ENGINES:
+      if engine_is_bun(engine):
+        return engine
+    return None
+
   def require_node(self):
     if 'EMTEST_SKIP_NODE' in os.environ:
       self.skipTest('test requires node and EMTEST_SKIP_NODE is set')
-    nodejs = self.get_nodejs()
+    nodejs = self.get_nodejs() or self.get_bun()
     if not nodejs:
       self.fail('node required to run this test.  Use EMTEST_SKIP_NODE to skip')
     self.require_engine(nodejs)
@@ -940,9 +946,9 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
       engine = self.get_current_js_engine()
     # Make a copy of the engine command before we modify/extend it.
     engine = list(engine)
-    if engine == config.NODE_JS_TEST:
+    if engine_is_node(engine) or engine_is_bun(engine):
       engine += self.node_args
-    elif engine == config.V8_ENGINE:
+    elif engine_is_v8(engine):
       engine += self.v8_args
     elif engine == config.SPIDERMONKEY_ENGINE:
       engine += self.spidermonkey_args

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11352,7 +11352,8 @@ int main(void) {
   def test_em_asm_invalid(self):
     # Test that invalid EM_ASM in side modules since is detected at build time.
     err = self.expect_fail([EMCC, '-sSIDE_MODULE', test_file('other/test_em_asm_invalid.c')])
-    self.assertContained("SyntaxError: Unexpected token '*'", err)
+    # Check for the error message syntax produced by either Node or Bun
+    self.assertContained(["SyntaxError: Unexpected token '*'", 'error: Unexpected *'], err)
     self.assertContained('emcc: error: EM_ASM function validation failed', err)
 
   def test_boost_graph(self):
@@ -12406,7 +12407,8 @@ exec "$@"
   def test_em_js_invalid(self):
     # Test that invalid EM_JS in side modules since is detected at build time.
     err = self.expect_fail([EMCC, '-sSIDE_MODULE', test_file('other/test_em_js_invalid.c')])
-    self.assertContained("SyntaxError: Unexpected token '*'", err)
+    # Check for the error message syntax produced by either Node or Bun
+    self.assertContained(["SyntaxError: Unexpected token '*'", 'error: Unexpected *'], err)
     self.assertContained('emcc: error: EM_JS function validation failed', err)
 
   @crossplatform

--- a/test/wasmfs/wasmfs_getdents.c
+++ b/test/wasmfs/wasmfs_getdents.c
@@ -109,7 +109,7 @@ int main() {
     for (var i = 0; i < entries.length; i++) {
       console.log(entries[i]);
     }
-    console.log();
+    console.log("");
   });
 
   printf("------------- Reading one from root/working Directory -------------\n");

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -67,7 +67,7 @@ __scriptdir__ = os.path.dirname(os.path.abspath(__file__))
 __rootdir__ = os.path.dirname(__scriptdir__)
 sys.path.insert(0, __rootdir__)
 
-from tools import shared, system_libs, utils
+from tools import config, shared, system_libs, utils
 
 QUIET = (__name__ != '__main__')
 DEBUG = False
@@ -96,9 +96,9 @@ DEFAULT_JSON_FILES = [
 ]
 
 
-def show(msg):
+def show(msg, *args):
   if shared.DEBUG or not QUIET:
-    sys.stderr.write('gen_struct_info: %s\n' % msg)
+    print('gen_struct_info:', msg, *args, file=sys.stderr)
 
 
 # The Scope class generates C code which, in turn, outputs JSON.
@@ -249,7 +249,7 @@ def inspect_headers(headers, cflags):
     sys.exit(1)
 
   # Run the compiled program.
-  show('Calling generated program... ' + js_file_path)
+  show('Running generated program... ' + js_file_path, config.NODE_JS)
   info = shared.run_js_tool(js_file_path, stdout=shared.PIPE)
 
   if not DEBUG:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -297,7 +297,8 @@ def check_node_version():
     diagnostics.warning('version-check', 'cannot check node version: %s', e)
     return
 
-  if version < MINIMUM_NODE_VERSION:
+  # Skip the version check is we are running `bun` instead of node.
+  if version < MINIMUM_NODE_VERSION and 'bun' not in os.path.basename(config.NODE_JS[0]):
     expected = '.'.join(str(v) for v in MINIMUM_NODE_VERSION)
     diagnostics.warning('version-check', f'node version appears too old (seeing "{actual}", expected "v{expected}")')
 


### PR DESCRIPTION
Specifically the whole the `other` and `core` test suites now pass with `NODE_JS` set to `bun`, which means that compiler is using bun internally (Note: this is not using bun to run the generated code).