### PR TITLE
Remove support for running gen_struct_info in older node versions. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -664,7 +664,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
         int(emcc_min_node_version_str[4:6]),
       )
       if node_version < emcc_min_node_version:
-        self.cflags += building.get_emcc_node_flags(node_version)
+        self.cflags.append('-sMIN_NODE_VERSION=%02d%02d%02d' % node_version)
         self.cflags.append('-Wno-transpile')
 
       # This allows much of the test suite to be run on older versions of node that don't

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12357,10 +12357,8 @@ exec "$@"
     self.assertFileContents(path_from_root('src/struct_info_generated.json'), read_file('out.json'))
 
     # Same again for wasm64
-    node_version = shared.get_node_version(self.get_nodejs())
-    if node_version and node_version >= (14, 0, 0):
-      self.run_process([PYTHON, path_from_root('tools/gen_struct_info.py'), '--wasm64', '-o', 'out.json'])
-      self.assertFileContents(path_from_root('src/struct_info_generated_wasm64.json'), read_file('out.json'))
+    self.run_process([PYTHON, path_from_root('tools/gen_struct_info.py'), '--wasm64', '-o', 'out.json'])
+    self.assertFileContents(path_from_root('src/struct_info_generated_wasm64.json'), read_file('out.json'))
 
   @crossplatform
   def test_gen_sig_info(self):

--- a/tools/building.py
+++ b/tools/building.py
@@ -1329,14 +1329,3 @@ def js_legalization_pass_flags():
     # assumes they are imports.
     flags += ['--pass-arg=legalize-js-interface-exported-helpers']
   return flags
-
-
-# Returns a list of flags to pass to emcc that make the output run properly in
-# the given node version.
-def get_emcc_node_flags(node_version):
-  if not node_version:
-    return []
-  # Convert to the format we use in our settings, XXYYZZ, for example,
-  # 10.1.7 will turn into "100107".
-  str_node_version = "%02d%02d%02d" % node_version
-  return [f'-sMIN_NODE_VERSION={str_node_version}']

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -67,7 +67,7 @@ __scriptdir__ = os.path.dirname(os.path.abspath(__file__))
 __rootdir__ = os.path.dirname(__scriptdir__)
 sys.path.insert(0, __rootdir__)
 
-from tools import building, shared, system_libs, utils
+from tools import shared, system_libs, utils
 
 QUIET = (__name__ != '__main__')
 DEBUG = False
@@ -205,8 +205,6 @@ def generate_cmd(js_file_path, src_file_path, cflags):
   else:
     compiler = shared.EMCC
 
-  node_flags = building.get_emcc_node_flags(shared.check_node_version())
-
   # -O1+ produces calls to iprintf, which libcompiler_rt doesn't support
   cmd = [compiler] + cflags + ['-o', js_file_path, src_file_path,
                                '-O0',
@@ -217,7 +215,7 @@ def generate_cmd(js_file_path, src_file_path, cflags):
                                '-sINCOMING_MODULE_JS_API=',
                                '-sSTRICT',
                                '-sSUPPORT_LONGJMP=0',
-                               '-sASSERTIONS=0'] + node_flags
+                               '-sASSERTIONS=0']
 
   # Default behavior for emcc is to warn for binaryen version check mismatches
   # so we should try to match that behavior.


### PR DESCRIPTION
We don't support running emscripten with node older that v18 anymore and gen_struct_info always uses the version of node that is running in the compiler.