### PR TITLE
Fix lsan.test_embind_lib_with_asyncify after #26095

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -681,6 +681,7 @@ jobs:
             lsan.test_pthread_create
             lsan.test_pthread_exit_main_stub
             lsan.test_dylink_iostream
+            lsan.test_embind_lib_with_asyncify
             ubsan.test_dlfcn_self
             ubsan.test_externref_emjs_dynlink"
       - freeze-cache

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9585,6 +9585,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
       '--post-js', test_file('core/embind_lib_with_asyncify.test.js'),
       '--no-entry',
       '-sINCOMING_MODULE_JS_API=onRuntimeInitialized',
+      '-sNO_EXIT_RUNTIME',
     ]
     self.cflags += args
     # This error here is because delayed_throw occurs during execution, and


### PR DESCRIPTION
This test throws exceptions from withing native code which causes the runtime to exit as the stack is unwound.