### PR TITLE
Allow more tests to run under bun

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -684,9 +684,10 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     self.required_engine = None
     self.wasm_engines = config.WASM_ENGINES.copy()
     self.use_all_engines = EMTEST_ALL_ENGINES
-    if self.get_current_js_engine() != config.NODE_JS_TEST:
-      # If our primary JS engine is something other than node then enable
-      # shell support.
+    engine = self.get_current_js_engine()
+    if not engine_is_node(engine) and not engine_is_bun(engine):
+      # If our current JS engine a "shell" environment we need to explicitly enable support for
+      # it in ENVIRONMENT.
       default_envs = 'web,webview,worker,node'
       self.set_setting('ENVIRONMENT', default_envs + ',shell')
 
@@ -830,9 +831,9 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     # use --quiet once its available
     # See: https://github.com/dollarshaveclub/es-check/pull/126/
     es_check_env = os.environ.copy()
-    # Use NODE_JS here (the version of node that the compiler uses) rather then NODE_JS_TEST (the
-    # version of node being used to run the tests) since we only care about having something that
-    # can run the es-check tool.
+    # Use NODE_JS here (the version of node that the compiler uses) rather than the version of node
+    # from JS_ENGINES (the version of node being used to run the tests) since we only care about
+    # having something that can run the es-check tool.
     es_check_env['PATH'] = os.path.dirname(config.NODE_JS[0]) + os.pathsep + es_check_env['PATH']
     inputfile = os.path.abspath(filename)
     # For some reason es-check requires unix paths, even on windows

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -27,6 +27,7 @@ from common import (
   RunnerCore,
   compiler_for,
   create_file,
+  engine_is_node,
   env_modify,
   path_from_root,
   read_binary,
@@ -8679,7 +8680,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
       # set us to test in just this engine
       self.require_engine(engine)
       # tell the compiler to build with just that engine
-      if engine == config.NODE_JS_TEST:
+      if engine_is_node(engine):
         right = 'node'
         wrong = 'shell'
       else:

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -606,7 +606,7 @@ fi
 
   @no_windows('Test relies on Unix-specific shell script')
   def test_js_engine_path(self):
-    # Test that running JS commands works for node, d8, and jsc and is not path dependent
+    # Test that running JS commands works for all JS_ENGINES, and is not path dependent
     restore_and_set_up()
 
     sample_script = test_file('print_args.js')
@@ -616,17 +616,10 @@ fi
     test_path = self.in_dir('fake', 'abcd8765')
     ensure_dir(test_path)
 
-    jsengines = [('d8',     config.V8_ENGINE),
-                 ('d8_g',   config.V8_ENGINE),
-                 ('js',     config.SPIDERMONKEY_ENGINE),
-                 ('node',   config.NODE_JS_TEST),
-                 ('nodejs', config.NODE_JS_TEST)]
-    for filename, engine in jsengines:
+    for engine in config.JS_ENGINES:
       delete_file(SANITY_FILE)
-      if not engine:
-        print('WARNING: Not testing engine %s, not configured.' % (filename))
-        continue
       engine = engine[0]
+      filename = os.path.splitext(os.path.basename(engine))[0] + '_runner'
       print(filename, engine)
 
       test_engine_path = os.path.join(test_path, filename)


### PR DESCRIPTION
This change mostly removes the usage of `config.NODE_JS_TEST` in favor
of `engine_is_node`.

There is still one remaining usage of `config.NODE_JS_TEST` in
`test_benchmark.py` which we could consider removing as a followup.