### PR TITLE
[test] Consistently use `require_engine` test helper. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -450,7 +450,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
   def require_engine(self, engine, force=False):
     logger.debug(f'require_engine: {engine}')
     if not force and self.required_engine and self.required_engine != engine:
-      self.skipTest(f'Skipping test that requires `{engine}` when `{self.required_engine}` was previously required')
+      self.fail(f'test requires `{engine}` but `{self.required_engine}` was previously required')
     self.required_engine = engine
     self.js_engines = [engine]
     self.wasm_engines = []
@@ -467,7 +467,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     v8 = self.get_v8()
     if v8:
       self.cflags.append('-sENVIRONMENT=shell')
-      self.js_engines = [v8]
+      self.require_engine(v8)
       return
 
     self.fail('either d8 or node >= 24 required to run wasm64 tests.  Use EMTEST_SKIP_WASM64 to skip')
@@ -480,7 +480,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     if version < (major, minor, revision):
       return False
 
-    self.js_engines = [nodejs]
+    self.require_engine(nodejs)
     return True
 
   def require_simd(self):
@@ -495,7 +495,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     v8 = self.get_v8()
     if v8:
       self.cflags.append('-sENVIRONMENT=shell')
-      self.js_engines = [v8]
+      self.require_engine(v8)
       return
 
     self.fail('either d8 or node >= 16 required to run wasm64 tests.  Use EMTEST_SKIP_SIMD to skip')
@@ -515,7 +515,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     v8 = self.get_v8()
     if v8:
       self.cflags.append('-sENVIRONMENT=shell')
-      self.js_engines = [v8]
+      self.require_engine(v8)
       return
 
     self.fail('either d8 or node >= 17 required to run legacy wasm-eh tests.  Use EMTEST_SKIP_WASM_LEGACY_EH to skip')
@@ -536,7 +536,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     v8 = self.get_v8()
     if v8:
       self.cflags.append('-sENVIRONMENT=shell')
-      self.js_engines = [v8]
+      self.require_engine(v8)
       self.v8_args.append('--experimental-wasm-exnref')
       return
 
@@ -565,7 +565,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     v8 = self.get_v8()
     if v8:
       self.cflags.append('-sENVIRONMENT=shell')
-      self.js_engines = [v8]
+      self.require_engine(v8)
       return
 
     self.fail('either d8 or node v24 required to run JSPI tests.  Use EMTEST_SKIP_JSPI to skip')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -62,7 +62,6 @@ from decorators import (
   requires_node,
   requires_node_canary,
   requires_pthreads,
-  requires_v8,
   requires_wasm2js,
   requires_wasm_eh,
   skip_if,
@@ -8241,11 +8240,6 @@ int main() {
 
     self.do_runf('main.c', 'hello 0\nhello 1\nhello 2\nhello 3\nhello 4\n')
 
-  @requires_v8
-  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with ASYNCIFY=1')
-  def test_async_hello_v8(self):
-    self.test_async_hello()
-
   @no_modularize_instance('ccall is not compatible with MODULARIZE=instance')
   def test_async_ccall_bad(self):
     # check bad ccall use
@@ -9604,7 +9598,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.maybe_closure()
     self.do_core_test('test_em_async_js.c')
 
-  @requires_v8
   @no_wasm2js('wasm2js does not support reference types')
   @no_sanitize('.s files cannot be sanitized')
   def test_externref(self):


### PR DESCRIPTION
Also, when `require_engine` is called more than once with conflicting
requirements it should be really be and error and not a warning. There
were a couple of places where we did this in the test suite which I've
updated accordingly.

This change remove the `test_async_hello_v8` test, which was just
calling through to `test_async_hello_v8` but with `requires_v8` added.
This can lead to contradictory requirements if, for example,
`require_wasm64` is used as in the wasm64 test suite.  I think its
simpler to just remove this test, especially since we don't have any
other `requires_v8` usage in this file and this pattern for testing
things specially in v8 doesn't exist elsewhere.
