### PR TITLE
Update SDL3 from 3.2.22 to 3.2.30

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -34,6 +34,7 @@ See docs/process.md for more on how version tagging works.
 - ASYNCIFY/JSPI functions in JS library files can now be marked as `__async:
   'auto'`, which allows async JS function to be used unmodified with
   ASYNCIFY/JSPI. (#26130, #26019)
+- SDL3 port updated to 3.2.30. (#25273)
 
 4.0.23 - 01/10/26
 -----------------

--- a/tools/ports/sdl3.py
+++ b/tools/ports/sdl3.py
@@ -9,9 +9,9 @@ import shutil
 
 from tools import diagnostics
 
-VERSION = '3.2.22'
+VERSION = '3.2.30'
 TAG = f'release-{VERSION}'
-HASH = '2d49f43f37b681b3b12918518fc2bb89fd79f64b6f9592cceb504402a9cfb3d5c0ae6f437cdbcd8fdef11065dfb15a86fcb61a58cf1fa41af71a61f767ab7260'
+HASH = '80ef7b2f257f43fe47c7ea8aa0a64f1c6f23720d91065d5e9b42f0205c62fc98bcf8dd1f1834fe09c66bea2598a18a658b82212cb29810be2d2175dece0aadce'
 SUBDIR = f'SDL-{TAG}'
 
 variants = {'sdl3-mt': {'PTHREADS': 1}}


### PR DESCRIPTION
I tried to update to the 3.4 branch but ran into some issues with GTK symbols.

See https://github.com/libsdl-org/SDL/issues/14863