### PR TITLE
Enable test_exceptions_stack_trace under node. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1076,6 +1076,8 @@ jobs:
             other.test_js_optimizer_verbose
             other.test_min_node_version
             other.test_node_emscripten_num_logical_cores
+            other.test_exceptions_stack_trace*
+            other.test_exceptions_rethrow_stack_trace*
             core2.test_pthread_create
             core2.test_i64_invoke_bigint
             core2.test_sse2


### PR DESCRIPTION
Previously this test would just always requires v8, now it can also run on modern node versions.

Node has a different backtrace format to v8 so this requires different regexs.

Split out from #26131.