### PR TITLE
Remove `wasm64_v8` test_core configuration. NFC

### DIFF
--- a/test/runner.py
+++ b/test/runner.py
@@ -93,7 +93,6 @@ passing_core_test_modes = [
   'lsan',
   'ubsan',
   'wasm64',
-  'wasm64_v8',
   'wasm64_4gb',
   'esm_integration',
   'instance',

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9847,8 +9847,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
 # Generate tests for everything
 def make_run(name, cflags=None, settings=None, env=None, # noqa
-             require_v8=False, v8_args=None,
-             require_node=False, node_args=None,
+             v8_args=None, node_args=None,
              require_wasm64=False,
              init=None):
   if cflags is None:
@@ -9893,11 +9892,6 @@ def make_run(name, cflags=None, settings=None, env=None, # noqa
     if v8_args:
       self.v8_args += v8_args
 
-    if require_v8:
-      self.require_v8()
-    elif require_node:
-      self.require_node()
-
     if require_wasm64:
       self.require_wasm64()
 
@@ -9931,9 +9925,7 @@ core_2gb = make_run('core_2gb', cflags=['--profiling-funcs'],
 
 # MEMORY64=1
 wasm64 = make_run('wasm64', cflags=['--profiling-funcs'],
-                  settings={'MEMORY64': 1}, require_wasm64=True, require_node=True)
-wasm64_v8 = make_run('wasm64_v8', cflags=['--profiling-funcs'],
-                     settings={'MEMORY64': 1}, require_wasm64=True, require_v8=True)
+                  settings={'MEMORY64': 1}, require_wasm64=True)
 # Run the wasm64 tests with all memory offsets > 4gb.  Be careful running this test
 # suite with any kind of parallelism.
 wasm64_4gb = make_run('wasm64_4gb', cflags=['--profiling-funcs'],


### PR DESCRIPTION
This change is split out from #26131.

Requiring a specific engine for test configuration like this should not be necessary and it prevents individual tests withing the test suite from then requiring a different engine (i.e. what does mean if the test suite requires v8 but specific test if marked as `@requires_node`.)

Instead we can just have a single `wasm64` test suite (like we do for all other other tests suites, and the developer can choose which engine to use by editing their config.