### PR TITLE
Fix test_environment and the resulting uncovered bug with environment testing

### DIFF
--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -1127,10 +1127,13 @@ function ENVIRONMENT_IS_WORKER_THREAD() {
 }
 
 function nodeDetectionCode() {
-  if (ENVIRONMENT == 'node') {
+  if (ENVIRONMENT == 'node' && !ASSERTIONS) {
     // The only environment where this code is intended to run is Node.js.
     // Return unconditional true so that later Closure optimizer will be able to
     // optimize code size.
+    //
+    // Note: we don't do this in debug builds because we have have assertions
+    // that want to be able to check if we really are running on node or not.
     return 'true';
   }
   return "globalThis.process?.versions?.node && globalThis.process?.type != 'renderer'";

--- a/src/shell.js
+++ b/src/shell.js
@@ -65,7 +65,7 @@ if (ENVIRONMENT_IS_AUDIO_WORKLET) ENVIRONMENT_IS_WASM_WORKER = true;
 // Determine the runtime environment we are in. You can customize this by
 // setting the ENVIRONMENT setting at compile time (see settings.js).
 
-#if ENVIRONMENT.length == 1
+#if ENVIRONMENT.length == 1 && !ASSERTIONS
 var ENVIRONMENT_IS_WEB = {{{ ENVIRONMENT[0] === 'web' }}};
 #if PTHREADS && ENVIRONMENT_MAY_BE_NODE
 // node+pthreads always supports workers; detect which we are at runtime
@@ -75,7 +75,7 @@ var ENVIRONMENT_IS_WORKER = {{{ ENVIRONMENT[0] === 'worker' }}};
 #endif
 var ENVIRONMENT_IS_NODE = {{{ ENVIRONMENT[0] === 'node' }}};
 var ENVIRONMENT_IS_SHELL = {{{ ENVIRONMENT[0] === 'shell' }}};
-#else // ENVIRONMENT
+#else // ENVIRONMENT.length == 1
 // Attempt to auto-detect the environment
 var ENVIRONMENT_IS_WEB = !!globalThis.window;
 var ENVIRONMENT_IS_WORKER = !!globalThis.WorkerGlobalScope;

--- a/test/common.py
+++ b/test/common.py
@@ -447,9 +447,9 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
 
     self.fail('node canary required to run this test.  Use EMTEST_SKIP_NODE_CANARY to skip')
 
-  def require_engine(self, engine):
+  def require_engine(self, engine, force=False):
     logger.debug(f'require_engine: {engine}')
-    if self.required_engine and self.required_engine != engine:
+    if not force and self.required_engine and self.required_engine != engine:
       self.skipTest(f'Skipping test that requires `{engine}` when `{self.required_engine}` was previously required')
     self.required_engine = engine
     self.js_engines = [engine]

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8675,10 +8675,10 @@ NODEFS is no longer included by default; build with -lnodefs.js
         js = read_file(self.output_name('test_hello_world'))
       assert ('require(' in js) == ('node' in self.get_setting('ENVIRONMENT')), 'we should have require() calls only if node js specified'
 
-    for engine in config.JS_ENGINES:
+    for engine in self.js_engines:
       print(f'engine: {engine}')
       # set us to test in just this engine
-      self.require_engine(engine)
+      self.require_engine(engine, force=True)
       # tell the compiler to build with just that engine
       if engine_is_node(engine):
         right = 'node'
@@ -8688,19 +8688,19 @@ NODEFS is no longer included by default; build with -lnodefs.js
         wrong = 'node'
       # test with the right env
       self.set_setting('ENVIRONMENT', right)
-      print('ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
+      print('right ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
       test()
       # test with the wrong env
       self.set_setting('ENVIRONMENT', wrong)
-      print('ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
+      print('wrong ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
       try:
         test(assert_returncode=NON_ZERO)
         raise Exception('unexpected success')
       except Exception as e:
-        self.assertContained('not compiled for this environment', str(e))
+        self.assertContained(['environment detected but not enabled at build time', 'not compiled for this environment'], str(e))
       # test with a combined env
       self.set_setting('ENVIRONMENT', right + ',' + wrong)
-      print('ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
+      print('both ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
       test()
 
   @requires_node


### PR DESCRIPTION
This test was being accidentally skipped for all but the first JS engine because of the second call to `require_engine` would always fail with `skipTest`.

This was masking a bug where `-sENVIRONMENT=node` was short circuiting the `isNode` check which meant it was not correctly reporting the `not compiled for this environment` error when run under v8 or some other shell.

This change is split out from #26131.