### PR TITLE
[docs] Add `smartquotes_excludes` to sphinx config

### DIFF
--- a/site/source/conf.py
+++ b/site/source/conf.py
@@ -395,3 +395,5 @@ epub_exclude_files = ['search.html']
 #highlight_language = 'default'
 
 primary_domain = 'cpp'
+
+smartquotes_excludes = {'builders': ['text', 'man']}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8675,7 +8675,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
         js = read_file(self.output_name('test_hello_world'))
       assert ('require(' in js) == ('node' in self.get_setting('ENVIRONMENT')), 'we should have require() calls only if node js specified'
 
-    for engine in config.JS_ENGINES:
+    for engine in self.js_engines:
       print(f'engine: {engine}')
       # set us to test in just this engine
       self.require_engine(engine)


### PR DESCRIPTION
I noticed my local version of sphinx was producing different quotes when I did `make text`. This fixes that issue.