### PR TITLE
[CI] Remove testing of under node canary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,27 +106,21 @@ commands:
             cat ~/emsdk/.emscripten
             echo "export PATH=\"$HOME/node-v${version}-linux-x64/bin:\$PATH\"" >> $BASH_ENV
   install-node-oldest:
-    description: "install node (oldest)"
+    description: "install node 12.22.9 (oldest)"
     steps:
       - install-node-version:
           # Keep this in sync with `OLDEST_SUPPORTED_NODE` in `feature_matrix.py`
           node_version: "12.22.9"
   install-node-lts:
-    description: "install node (current LTS)"
+    description: "install node 22.21.0 (current LTS)"
     steps:
       - install-node-version:
          node_version: "22.21.0"
   install-node-newest:
-    description: "install node (newest)"
+    description: "install node 25.4.0 (newest)"
     steps:
       - install-node-version:
-         node_version: "24.10.0"
-  install-node-canary:
-    description: "install canary version of node"
-    steps:
-      - install-node-version:
-         node_version: "25.0.0-v8-canary2025053097d65d1dc1"
-         canary: true
+         node_version: "25.4.0"
   install-v8:
     description: "install v8 using jsvu"
     steps:
@@ -639,7 +633,7 @@ jobs:
   test-core0:
     executor: ubuntu-lts
     environment:
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE_25: "1"
     steps:
       - run-tests-linux:
           test_targets: "core0"
@@ -647,7 +641,7 @@ jobs:
     executor: ubuntu-lts
     environment:
       EMTEST_BROWSER: "node"
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE_25: "1"
     steps:
       - run-tests-linux:
           # also run a few asan tests.  Run these with frozen_cache disabled
@@ -697,7 +691,7 @@ jobs:
   test-core3:
     executor: ubuntu-lts
     environment:
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE_25: "1"
     steps:
       - run-tests-linux:
           frozen_cache: false
@@ -784,14 +778,14 @@ jobs:
   test-modularize-instance:
     executor: ubuntu-lts
     environment:
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE_25: "1"
     steps:
       - run-tests-linux:
           test_targets: "instance"
   test-stress:
     executor: ubuntu-lts
     environment:
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE_25: "1"
     steps:
       - run-tests-linux:
           test_targets: "stress"
@@ -805,14 +799,14 @@ jobs:
       # hardcodes /root into its launcher scripts so we need to reinstall v8.
       - run: rm -rf $HOME/.jsvu
       - install-v8
-      - install-node-canary
+      - install-node-newest
       - run-tests:
           title: "esm_integration"
           test_targets: "esm_integration"
       - upload-test-results
   test-wasm2js1:
     environment:
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE_25: "1"
     executor: ubuntu-lts
     steps:
       - run-tests-linux:
@@ -829,12 +823,12 @@ jobs:
       # hardcodes /root into its launcher scripts so we need to reinstall v8.
       - run: rm -rf $HOME/.jsvu
       - install-v8
-      - install-node-canary
-      # When running wasm64 tests we need to make sure we use the testing
-      # version of node (node canary) when running the compiler output (e.g.
+      - install-node-newest
+      # When running wasm64 tests we need to make sure we use the latest
+      # version of node (node 25) when running the compiler output (e.g.
       # in configure tests.
       - run:
-          name: configure node canary
+          name: configure node v25
           command: echo "NODE_JS = NODE_JS_TEST" >> ~/emsdk/.emscripten
       - run-tests:
           title: "wasm64_4gb"
@@ -852,12 +846,12 @@ jobs:
       # hardcodes /root into its launcher scripts so we need to reinstall v8.
       - run: rm -rf $HOME/.jsvu
       - install-v8
-      - install-node-canary
-      # When running wasm64 tests we need to make sure we use the testing
-      # version of node (node canary) when running the compiler output (e.g.
+      - install-node-newest
+      # When running wasm64 tests we need to make sure we use the latest
+      # version of node (node v25) when running the compiler output (e.g.
       # in configure tests.
       - run:
-          name: configure node canary
+          name: configure node v25
           command: echo "NODE_JS = NODE_JS_TEST" >> ~/emsdk/.emscripten
       - run-tests:
           title: "wasm64"
@@ -980,24 +974,6 @@ jobs:
       - run:
           name: configure compiler to use 18.3.0
           command: echo "NODE_JS = '$(which node)'" >> ~/emsdk/.emscripten
-      - install-node-canary
-      - run-tests:
-          title: "node (canary)"
-          test_targets: "
-            other.test_deterministic
-            other.test_gen_struct_info
-            other.test_native_call_before_init
-            other.test_node_unhandled_rejection
-            other.test_*growable_arraybuffers
-            other.test_add_js_function_bigint_memory64
-            core2.test_hello_world
-            core2.test_esm_integration*
-            core0.test_esm_integration*
-            core0.test_pthread_join_and_asyncify
-            core0.test_async_ccall_promise_jspi*
-            core0.test_cubescript_jspi
-            core0.test_poll_blocking_asyncify_jspi
-            "
       # Run some basic tests with the minimum version of node that we currently
       # support in the generated code.
       - install-node-oldest
@@ -1093,24 +1069,34 @@ jobs:
           # those flags should not be injected on newer versions.
           title: "node (latest)"
           test_targets: "-v
+            other.test_deterministic
             other.test_gen_struct_info
             other.test_native_call_before_init
             other.test_node_unhandled_rejection
+            other.test_*growable_arraybuffers
+            other.test_add_js_function_bigint_memory64
             other.test_js_optimizer_verbose
             other.test_min_node_version
             other.test_node_emscripten_num_logical_cores
+            core2.test_hello_world
             core2.test_pthread_create
             core2.test_i64_invoke_bigint
             core2.test_sse2
             core2.test_source_map
             core2.test_exceptions_wasm_legacy
             core2.test_pthread_unhandledrejection
+            core2.test_esm_integration*
+            core0.test_esm_integration*
+            core0.test_pthread_join_and_asyncify
+            core0.test_async_ccall_promise_jspi*
+            core0.test_cubescript_jspi
+            core0.test_poll_blocking_asyncify_jspi
             "
       - upload-test-results
   test-other:
     executor: ubuntu-lts
     environment:
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE_25: "1"
       EMTEST_SKIP_RUST: "1"
       EMTEST_SKIP_WASM64: "1"
       EMTEST_SKIP_NEW_CMAKE: "1"
@@ -1295,7 +1281,7 @@ jobs:
       EMTEST_SKIP_WASM64: "1"
       EMTEST_SKIP_SCONS: "1"
       EMTEST_SKIP_RUST: "1"
-      EMTEST_SKIP_NODE_CANARY: "1"
+      EMTEST_SKIP_NODE_25: "1"
       EMTEST_BROWSER: "0"
     steps:
       - checkout

--- a/test/common.py
+++ b/test/common.py
@@ -439,18 +439,14 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     self.require_engine(nodejs)
     return nodejs
 
-  def node_is_canary(self, nodejs):
-    return nodejs and nodejs[0] and ('canary' in nodejs[0] or 'nightly' in nodejs[0])
-
-  def require_node_canary(self):
-    if 'EMTEST_SKIP_NODE_CANARY' in os.environ:
-      self.skipTest('test requires node canary and EMTEST_SKIP_NODE_CANARY is set')
+  def require_node_25(self):
+    if 'EMTEST_SKIP_NODE_25' in os.environ:
+      self.skipTest('test requires node v25 and EMTEST_SKIP_NODE_25 is set')
     nodejs = self.get_nodejs()
-    if self.node_is_canary(nodejs):
-      self.require_engine(nodejs)
-      return
-
-    self.fail('node canary required to run this test.  Use EMTEST_SKIP_NODE_CANARY to skip')
+    if not nodejs:
+      self.skipTest('Test requires nodejs to run')
+    if not self.try_require_node_version(25, 0, 0):
+      self.fail('node v25 required to run this test.  Use EMTEST_SKIP_NODE_25 to skip')
 
   def require_engine(self, engine, force=False):
     logger.debug(f'require_engine: {engine}')

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -129,12 +129,12 @@ def requires_node(func):
   return decorated
 
 
-def requires_node_canary(func):
+def requires_node_25(func):
   assert callable(func)
 
   @wraps(func)
   def decorated(self, *args, **kwargs):
-    self.require_node_canary()
+    self.require_node_25()
     return func(self, *args, **kwargs)
 
   return decorated

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -61,7 +61,7 @@ from decorators import (
   requires_jspi,
   requires_native_clang,
   requires_node,
-  requires_node_canary,
+  requires_node_25,
   requires_pthreads,
   requires_v8,
   requires_wasm2js,
@@ -449,7 +449,7 @@ class TestCoreBase(RunnerCore):
     return all(f not in self.cflags for f in prohibited) and any(f in self.cflags for f in required)
 
   def setup_esm_integration(self):
-    self.require_node_canary()
+    self.require_node_25()
     self.node_args += ['--experimental-wasm-modules', '--no-warnings']
     self.set_setting('WASM_ESM_INTEGRATION')
     self.cflags += ['-Wno-experimental']
@@ -8490,7 +8490,7 @@ Module.onRuntimeInitialized = () => {
     self.do_core_test('test_hello_world.c')
 
   # Test that pthread_join works correctly with asyncify.
-  @requires_node_canary
+  @requires_node_25
   @requires_pthreads
   def test_pthread_join_and_asyncify(self):
     # TODO Test with ASYNCIFY=1 https://github.com/emscripten-core/emscripten/issues/17552

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -78,7 +78,7 @@ from decorators import (
   requires_native_clang,
   requires_network,
   requires_node,
-  requires_node_canary,
+  requires_node_25,
   requires_pthreads,
   requires_v8,
   requires_wasm64,
@@ -408,7 +408,7 @@ class other(RunnerCore):
     self.assertContained('export default Module;', read_file('hello_world.mjs'))
     self.assertContained('hello, world!', self.run_js('hello_world.mjs'))
 
-  @requires_node_canary
+  @requires_node_25
   def test_esm_source_phase_imports(self):
     self.node_args += ['--experimental-wasm-modules', '--no-warnings']
     self.run_process([EMCC, '-o', 'hello_world.mjs', '-sSOURCE_PHASE_IMPORTS',
@@ -3457,7 +3457,7 @@ More info: https://emscripten.org
 
     self.do_runf('embind/test_return_value_policy.cpp')
 
-  @requires_node_canary
+  @requires_node_25
   def test_embind_resource_management(self):
     self.node_args.append('--js-explicit-resource-management')
 
@@ -6483,7 +6483,7 @@ int main() {
     self.assertContained('done', self.run_js('a.out.js'))
 
   @requires_wasm64
-  @requires_node_canary
+  @requires_node_25
   def test_failing_growth_wasm64(self):
     self.require_wasm64()
     create_file('test.c', r'''
@@ -12969,13 +12969,13 @@ void foo() {}
     if '-sGROWABLE_ARRAYBUFFERS' in cflags:
       self.node_args.append('--experimental-wasm-rab-integration')
       self.v8_args.append('--experimental-wasm-rab-integration')
-      self.require_node_canary()
+      self.require_node_25()
     else:
       self.cflags.append('-Wno-pthreads-mem-growth')
     self.set_setting('PTHREAD_POOL_SIZE', pthread_pool_size)
     self.do_runf('pthread/test_pthread_memory_growth_mainthread.c', cflags=['-pthread', '-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=32MB', '-sMAXIMUM_MEMORY=256MB'] + cflags)
 
-  @requires_node_canary
+  @requires_node_25
   def test_growable_arraybuffers(self):
     self.node_args.append('--experimental-wasm-rab-integration')
     self.v8_args.append('--experimental-wasm-rab-integration')
@@ -13003,13 +13003,13 @@ void foo() {}
     if WINDOWS and platform.machine() == 'ARM64':
       # https://github.com/emscripten-core/emscripten/issues/25627
       # TODO: Switch this to a "require Node.js 24" check
-      self.require_node_canary()
+      self.require_node_25()
 
     self.set_setting('PTHREAD_POOL_SIZE', pthread_pool_size)
     if '-sGROWABLE_ARRAYBUFFERS' in cflags:
       self.node_args.append('--experimental-wasm-rab-integration')
       self.v8_args.append('--experimental-wasm-rab-integration')
-      self.require_node_canary()
+      self.require_node_25()
     else:
       self.cflags.append('-Wno-pthreads-mem-growth')
     self.do_runf('pthread/test_pthread_memory_growth.c', cflags=['-pthread', '-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=32MB', '-sMAXIMUM_MEMORY=256MB'] + cflags)
@@ -15030,7 +15030,7 @@ addToLibrary({
                  cflags=['--pre-js', 'pre.js',
                             '--extern-post-js', test_file('modularize_post_js.js')] + args)
 
-  @requires_node_canary
+  @requires_node_25
   def test_js_base64_api(self):
     self.node_args += ['--js_base_64']
     self.do_runf('hello_world.c', 'hello, world!', cflags=['-sSINGLE_FILE'], output_basename='baseline')


### PR DESCRIPTION
Instead we can just use node v25 which is configured as `node-newest` which supports all the latest features we test, including the latest ESM integration stuff.