### PR TITLE
Adjust section headers in SIMD doc

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -33,7 +33,7 @@ See `WebAssembly Roadmap <https://webassembly.org/roadmap/>`_ for details about 
 
 An upcoming `Relaxed SIMD proposal <https://github.com/WebAssembly/relaxed-simd/tree/main/proposals/relaxed-simd>`_ will add more SIMD instructions to WebAssembly.
 
-================================
+
 GCC/Clang SIMD Vector Extensions
 ================================
 
@@ -41,7 +41,7 @@ At the source level, the GCC/Clang `SIMD Vector Extensions <https://gcc.gnu.org/
 
 This enables developers to create custom wide vector types via typedefs, and use arithmetic operators (+,-,*,/) on the vectorized types, as well as allow individual lane access via the vector[i] notation. However, the `GCC vector built-in functions <https://gcc.gnu.org/onlinedocs/gcc/x86-Built-in-Functions.html>`_ are not available. Instead, use the WebAssembly SIMD Intrinsics functions below.
 
-===========================
+
 WebAssembly SIMD Intrinsics
 ===========================
 
@@ -72,7 +72,7 @@ Pass flag ``-msimd128`` at compile time to enable targeting WebAssembly SIMD Int
 
 Pass ``-mrelaxed-simd`` to target WebAssembly Relaxed SIMD Intrinsics. C/C++ code can use the built-in preprocessor define ``#ifdef __wasm_relaxed_simd__`` to detect when this target is active.
 
-======================================
+
 Limitations and behavioral differences
 ======================================
 
@@ -88,7 +88,7 @@ When porting native SIMD code, it should be noted that because of portability co
 
 SIMD-related bug reports are tracked in the `Emscripten bug tracker with the label SIMD <https://github.com/emscripten-core/emscripten/issues?q=is%3Aopen+is%3Aissue+label%3ASIMD>`_.
 
-===========================
+
 Optimization considerations
 ===========================
 
@@ -140,7 +140,7 @@ When developing SIMD code to use WebAssembly SIMD, implementors should be aware 
      - Included for orthogonality, these instructions have no equivalent x86 instruction and are `emulated with 10 x86 instructions in v8 <https://github.com/v8/v8/blob/b6520eda5eafc3b007a5641b37136dfc9d92f63d/src/compiler/backend/x64/code-generator-x64.cc#L2834-L2858>`_.
 
 
-=======================================================
+
 Compiling SIMD code targeting x86 SSE* instruction sets
 =======================================================
 
@@ -1231,7 +1231,7 @@ All the 128-bit wide instructions from AVX2 instruction set are listed.
 Only a small part of the 256-bit AVX2 instruction set are listed, most of the
 256-bit wide AVX2 instructions are emulated by two 128-bit wide instructions.
 
-====================================================== 
+
 Compiling SIMD code targeting ARM NEON instruction set
 ======================================================
 


### PR DESCRIPTION
This makes them match the other docs (e.g. pthreads) and makes the
index levels match, so that under the "Porting" section in the index
there is just one element for SIMD, which expands when you click
on it.
