### PR TITLE
Update compiler-rt/include/profile from LLVM 20.1.4 to 21.1.8

### DIFF
--- a/system/lib/compiler-rt/include/profile/InstrProfData.inc
+++ b/system/lib/compiler-rt/include/profile/InstrProfData.inc
@@ -348,9 +348,6 @@ INSTR_PROF_SECT_ENTRY(IPSK_covmap, \
 INSTR_PROF_SECT_ENTRY(IPSK_covfun, \
                       INSTR_PROF_QUOTE(INSTR_PROF_COVFUN_COMMON), \
                       INSTR_PROF_COVFUN_COFF, "__LLVM_COV,")
-INSTR_PROF_SECT_ENTRY(IPSK_orderfile, \
-                      INSTR_PROF_QUOTE(INSTR_PROF_ORDERFILE_COMMON), \
-                      INSTR_PROF_QUOTE(INSTR_PROF_ORDERFILE_COFF), "__DATA,")
 INSTR_PROF_SECT_ENTRY(IPSK_covdata, \
                       INSTR_PROF_QUOTE(INSTR_PROF_COVDATA_COMMON), \
                       INSTR_PROF_COVDATA_COFF, "__LLVM_COV,")
@@ -408,14 +405,14 @@ typedef struct ValueProfRecord {
   /*!
    * Read data from this record and save it to Record.
    */
-  void deserializeTo(InstrProfRecord &Record,
+  LLVM_ABI void deserializeTo(InstrProfRecord &Record,
                      InstrProfSymtab *SymTab);
   /*
    * In-place byte swap:
    * Do byte swap for this instance. \c Old is the original order before
    * the swap, and \c New is the New byte order.
    */
-  void swapBytes(llvm::endianness Old, llvm::endianness New);
+  LLVM_ABI void swapBytes(llvm::endianness Old, llvm::endianness New);
 #endif
 } ValueProfRecord;
 
@@ -452,48 +449,48 @@ typedef struct ValueProfData {
    * Return the total size in bytes of the on-disk value profile data
    * given the data stored in Record.
    */
-  static uint32_t getSize(const InstrProfRecord &Record);
+  LLVM_ABI static uint32_t getSize(const InstrProfRecord &Record);
   /*!
    * Return a pointer to \c ValueProfData instance ready to be streamed.
    */
-  static std::unique_ptr<ValueProfData>
+  LLVM_ABI static std::unique_ptr<ValueProfData>
   serializeFrom(const InstrProfRecord &Record);
   /*!
    * Check the integrity of the record.
    */
-  Error checkIntegrity();
+  LLVM_ABI Error checkIntegrity();
   /*!
    * Return a pointer to \c ValueProfileData instance ready to be read.
    * All data in the instance are properly byte swapped. The input
    * data is assumed to be in little endian order.
    */
-  static Expected<std::unique_ptr<ValueProfData>>
+  LLVM_ABI static Expected<std::unique_ptr<ValueProfData>>
   getValueProfData(const unsigned char *SrcBuffer,
                    const unsigned char *const SrcBufferEnd,
                    llvm::endianness SrcDataEndianness);
   /*!
    * Swap byte order from \c Endianness order to host byte order.
    */
-  void swapBytesToHost(llvm::endianness Endianness);
+  LLVM_ABI void swapBytesToHost(llvm::endianness Endianness);
   /*!
    * Swap byte order from host byte order to \c Endianness order.
    */
-  void swapBytesFromHost(llvm::endianness Endianness);
+  LLVM_ABI void swapBytesFromHost(llvm::endianness Endianness);
   /*!
    * Return the total size of \c ValueProfileData.
    */
-  uint32_t getSize() const { return TotalSize; }
+  LLVM_ABI uint32_t getSize() const { return TotalSize; }
   /*!
    * Read data from this data and save it to \c Record.
    */
-  void deserializeTo(InstrProfRecord &Record,
+  LLVM_ABI void deserializeTo(InstrProfRecord &Record,
                      InstrProfSymtab *SymTab);
   void operator delete(void *ptr) { ::operator delete(ptr); }
 #endif
 } ValueProfData;
 
 /*
- * The closure is designed to abstact away two types of value profile data:
+ * The closure is designed to abstract away two types of value profile data:
  * - InstrProfRecord which is the primary data structure used to
  *   represent profile data in host tools (reader, writer, and profile-use)
  * - value profile runtime data structure suitable to be used by C
@@ -778,7 +775,6 @@ serializeValueProfDataFrom(ValueProfRecordClosure *Closure,
 #define INSTR_PROF_COVFUN_COMMON __llvm_covfun
 #define INSTR_PROF_COVDATA_COMMON __llvm_covdata
 #define INSTR_PROF_COVNAME_COMMON __llvm_covnames
-#define INSTR_PROF_ORDERFILE_COMMON __llvm_orderfile
 #define INSTR_PROF_COVINIT_COMMON __llvm_covinit
 
 /* Windows section names. Because these section names contain dollar characters,
@@ -799,7 +795,6 @@ serializeValueProfDataFrom(ValueProfRecordClosure *Closure,
  */
 #define INSTR_PROF_COVDATA_COFF ".lcovd"
 #define INSTR_PROF_COVNAME_COFF ".lcovn"
-#define INSTR_PROF_ORDERFILE_COFF ".lorderfile$M"
 
 // FIXME: Placeholder for Windows. Windows currently does not initialize
 // the GCOV functions in the runtime.
@@ -823,7 +818,6 @@ serializeValueProfDataFrom(ValueProfRecordClosure *Closure,
 #define INSTR_PROF_COVFUN_SECT_NAME INSTR_PROF_COVFUN_COFF
 #define INSTR_PROF_COVDATA_SECT_NAME INSTR_PROF_COVDATA_COFF
 #define INSTR_PROF_COVNAME_SECT_NAME INSTR_PROF_COVNAME_COFF
-#define INSTR_PROF_ORDERFILE_SECT_NAME INSTR_PROF_ORDERFILE_COFF
 #define INSTR_PROF_COVINIT_SECT_NAME INSTR_PROF_COVINIT_COFF
 #else
 /* Runtime section names and name strings.  */
@@ -843,18 +837,8 @@ serializeValueProfDataFrom(ValueProfRecordClosure *Closure,
 #define INSTR_PROF_COVFUN_SECT_NAME INSTR_PROF_QUOTE(INSTR_PROF_COVFUN_COMMON)
 #define INSTR_PROF_COVDATA_SECT_NAME INSTR_PROF_QUOTE(INSTR_PROF_COVDATA_COMMON)
 #define INSTR_PROF_COVNAME_SECT_NAME INSTR_PROF_QUOTE(INSTR_PROF_COVNAME_COMMON)
-/* Order file instrumentation. */
-#define INSTR_PROF_ORDERFILE_SECT_NAME                                         \
-  INSTR_PROF_QUOTE(INSTR_PROF_ORDERFILE_COMMON)
 #define INSTR_PROF_COVINIT_SECT_NAME INSTR_PROF_QUOTE(INSTR_PROF_COVINIT_COMMON)
 #endif
-
-#define INSTR_PROF_ORDERFILE_BUFFER_NAME _llvm_order_file_buffer
-#define INSTR_PROF_ORDERFILE_BUFFER_NAME_STR                                   \
-  INSTR_PROF_QUOTE(INSTR_PROF_ORDERFILE_BUFFER_NAME)
-#define INSTR_PROF_ORDERFILE_BUFFER_IDX_NAME _llvm_order_file_buffer_idx
-#define INSTR_PROF_ORDERFILE_BUFFER_IDX_NAME_STR                               \
-  INSTR_PROF_QUOTE(INSTR_PROF_ORDERFILE_BUFFER_IDX_NAME)
 
 /* Macros to define start/stop section symbol for a given
  * section on Linux. For instance
@@ -889,12 +873,6 @@ typedef struct InstrProfValueData {
 
 #endif /* INSTR_PROF_DATA_INC */
 
-#ifndef INSTR_ORDER_FILE_INC
-/* The maximal # of functions: 128*1024 (the buffer size will be 128*4 KB). */
-#define INSTR_ORDER_FILE_BUFFER_SIZE 131072
-#define INSTR_ORDER_FILE_BUFFER_BITS 17
-#define INSTR_ORDER_FILE_BUFFER_MASK 0x1ffff
-#endif /* INSTR_ORDER_FILE_INC */
 #else
 #undef INSTR_PROF_DATA_DEFINED
 #endif

--- a/system/lib/compiler-rt/include/profile/instr_prof_interface.h
+++ b/system/lib/compiler-rt/include/profile/instr_prof_interface.h
@@ -73,15 +73,11 @@ void __llvm_profile_reset_counters(void);
  */
 int __llvm_profile_dump(void);
 
-// Interface to dump the current process' order file to disk.
-int __llvm_orderfile_dump(void);
-
 #else
 
 #define __llvm_profile_set_filename(Name)
 #define __llvm_profile_reset_counters()
 #define __llvm_profile_dump() (0)
-#define __llvm_orderfile_dump() (0)
 
 #endif
 

--- a/system/lib/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/system/lib/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -911,4 +911,4 @@ void InitializeAsanInterceptors() {
 
 } // namespace __asan
 
-#endif  // !SANITIZER_FUCHSIA && !SANITIZER_RTEMS && !SANITIZER_EMSCRIPTEN
+#endif  // !SANITIZER_FUCHSIA && !SANITIZER_EMSCRIPTEN

--- a/system/lib/update_compiler_rt.py
+++ b/system/lib/update_compiler_rt.py
@@ -16,6 +16,7 @@ local_src = os.path.join(script_dir, 'compiler-rt')
 
 copy_dirs = [
     ('include', 'sanitizer'),
+    ('include', 'profile'),
     ('lib', 'sanitizer_common'),
     ('lib', 'asan'),
     ('lib', 'interception'),


### PR DESCRIPTION
`include/profile` and `lib/profile` have been added to compiler-rt since #24160, but only `lib/profile` was added to `update_compiler_rt.py`, which caused this directory to be missing from the subsequent LLVM library updates.