### PR TITLE
Simplify settings type checking. NFC

### DIFF
--- a/tools/settings.py
+++ b/tools/settings.py
@@ -403,12 +403,11 @@ class SettingsManager:
     self.attrs[name] = value
 
   def check_type(self, name, value):
-    # These settings have a variable type so cannot be easily type checked.
-    if name in ('EXECUTABLE', 'SUPPORT_LONGJMP', 'PTHREAD_POOL_SIZE', 'SEPARATE_DWARF', 'LTO', 'MODULARIZE'):
+    # These settings have a variable type so cannot be easily type checked, or they
+    # are legacy settings not declared in settings.js (and therefore not having any type).
+    if name in ('USE_PTHREADS', 'EXECUTABLE', 'SUPPORT_LONGJMP', 'PTHREAD_POOL_SIZE', 'SEPARATE_DWARF', 'LTO', 'MODULARIZE'):
       return
-    expected_type = self.types.get(name)
-    if not expected_type:
-      return
+    expected_type = self.types[name]
     # Allow integers 1 and 0 for type `bool`
     if expected_type == bool:
       if value in (1, 0):


### PR DESCRIPTION
All settings should have known types.