### PR TITLE
Fix dlsym_catchup error with ASYNCIFY

### DIFF
--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -1357,6 +1357,12 @@ var LibraryDylink = {
     var symDict = lib.exports;
     var symName = Object.keys(symDict)[symbolIndex];
     var sym = symDict[symName];
+#if ASYNCIFY
+    // Asyncify wraps exports, and we need to look through those wrappers.
+    if (sym.orig) {
+      sym = sym.orig;
+    }
+#endif
     var result = addFunction(sym, sym.sig);
 #if DYLINK_DEBUG
     dbg(`_dlsym_catchup: result=${result}`);


### PR DESCRIPTION
Fixes for `dlsym_catchup_js` error with `ASYNCIFY`. `Aborted(Assertion failed: Missing signature argument to addFunction: (...args) => original(...args))`. With `ASYNCIFY`, exports are wrapped so we need to pass original to `addFunction`.