### PR TITLE
Update llvm-libc readme to LLVM 21.1.8

### DIFF
--- a/system/lib/llvm-libc/readme.txt
+++ b/system/lib/llvm-libc/readme.txt
@@ -1,7 +1,14 @@
 llvm's libc
 -----------
 
-These files are from llvm-project's HEAD.
+These files are from the llvm-project based on release 21.1.8.
+
+We maintain a local fork of llvm-project that contains any Emscripten
+specific patches:
+
+  https://github.com/emscripten-core/llvm-project
+
+The current patch is based on the emscripten-libs-21 branch.
 
 Currently in production, we do not use LLVM's libc directly yet, but libcxx uses
 a subset of headers from libc. So libcxx directly depends on the following
@@ -21,3 +28,10 @@ Update Instructions
 
 Run `system/lib/update_libcxx.py path/to/llvm-project`
 Run `system/lib/update_llvm_libc.py path/to/llvm-project`
+
+Modifications
+-------------
+
+For a list of changes from upstream see the libcxx files that are part of:
+
+https://github.com/llvm/llvm-project/compare/llvmorg-21.1.8...emscripten-core:emscripten-libs-21


### PR DESCRIPTION
Missing from #26151. The newly added parts are copied from https://github.com/emscripten-core/emscripten/blob/main/system/lib/libcxx/readme.txt, which is synced with LLVM releases.