### PR TITLE
Add warning if --shell-file is used without html output

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10109,6 +10109,11 @@ T4:ASSERTIONS > 1
 T5:ASSERTIONS
 T6:(else) !ASSERTIONS""", output)
 
+  def test_shell_file_unused(self):
+    create_file('foo.html', '')
+    expected = 'emcc: error: --shell-file ignored when not generating html output [-Wunused-command-line-argument] [-Werror]'
+    self.assert_fail([EMCC, test_file('hello_world.c'), '--shell-file=foo.html', '-Werror'], expected)
+
   # Tests that Emscripten-compiled applications can be run from a relative path with node command line that is different than the current working directory.
   @requires_node
   def test_node_js_run_from_different_directory(self):

--- a/tools/cmdline.py
+++ b/tools/cmdline.py
@@ -105,7 +105,7 @@ class EmccOptions:
   s_args: list[str] = []
   save_temps = False
   shared = False
-  shell_path = None
+  shell_html = None
   source_map_base = ''
   syntax_only = False
   target = ''
@@ -446,7 +446,7 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
     elif arg == '-###':
       shared.SKIP_SUBPROCS = True
     elif check_arg('--shell-file'):
-      options.shell_path = consume_arg_file()
+      options.shell_html = consume_arg_file()
     elif check_arg('--source-map-base'):
       options.source_map_base = consume_arg()
     elif check_arg('--emit-tsd'):

--- a/tools/minimal_runtime_shell.py
+++ b/tools/minimal_runtime_shell.py
@@ -170,7 +170,7 @@ def generate_minimal_runtime_load_statement(target_basename):
 
 def generate_minimal_runtime_html(target, options, js_target, target_basename):
   logger.debug('generating HTML for minimal runtime')
-  shell = utils.read_file(options.shell_path)
+  shell = utils.read_file(options.shell_html)
   if settings.SINGLE_FILE:
     # No extra files needed to download in a SINGLE_FILE build.
     shell = shell.replace('{{{ DOWNLOAD_JS_AND_WASM_FILES }}}', '')
@@ -183,7 +183,7 @@ def generate_minimal_runtime_html(target, options, js_target, target_basename):
     shell = building.read_and_preprocess(shell_temp)
 
   if re.search(r'{{{\s*SCRIPT\s*}}}', shell):
-    utils.exit_with_error('--shell-file "' + options.shell_path + '": MINIMAL_RUNTIME uses a different kind of HTML page shell file than the traditional runtime! Please see $EMSCRIPTEN/html/shell_minimal_runtime.html for a template to use as a basis.')
+    utils.exit_with_error(f'--shell-file "{options.shell_html}": MINIMAL_RUNTIME uses a different kind of HTML page shell file than the traditional runtime! Please see $EMSCRIPTEN/html/shell_minimal_runtime.html for a template to use as a basis.')
 
   shell = shell.replace('{{{ TARGET_BASENAME }}}', settings.TARGET_BASENAME)
   shell = shell.replace('{{{ EXPORT_NAME }}}', settings.EXPORT_NAME)


### PR DESCRIPTION
Also, rename the internal option from shell_path to shell_html for clarity.