### PR TITLE
Partial revert of #25848

### DIFF
--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -415,10 +415,10 @@ var LibraryHTML5 = {
   $findCanvasEventTarget: (target) => {
     if (typeof target == 'number') target = UTF8ToString(target);
     if (!target || target === '#canvas') {
-      if (globalThis.GL?.offscreenCanvases['canvas']) return GL.offscreenCanvases['canvas']; // TODO: Remove this line, target '#canvas' should refer only to Module['canvas'], not to GL.offscreenCanvases['canvas'] - but need stricter tests to be able to remove this line.
+      if (typeof GL != 'undefined' && GL.offscreenCanvases['canvas']) return GL.offscreenCanvases['canvas']; // TODO: Remove this line, target '#canvas' should refer only to Module['canvas'], not to GL.offscreenCanvases['canvas'] - but need stricter tests to be able to remove this line.
       return Module['canvas'];
     }
-    if (globalThis.GL?.offscreenCanvases[target]) return GL.offscreenCanvases[target];
+    if (typeof GL != 'undefined' && GL.offscreenCanvases[target]) return GL.offscreenCanvases[target];
     return findEventTarget(target);
   },
 #endif


### PR DESCRIPTION
In #25848 I replaced a bunch of `typeof X` references with `globalThis.X`, but this instance should not have been replaced because in this case GL is a local the module, not a global.