### PR TITLE
[embind] Export types created by `register_type<T>(name, definition)`

### DIFF
--- a/src/lib/libembind_gen.js
+++ b/src/lib/libembind_gen.js
@@ -45,7 +45,7 @@ var LibraryEmbind = {
     }
 
     print(nameMap, out) {
-      out.push(`type ${this.name} = ${this.definition};\n\n`);
+      out.push(`export type ${this.name} = ${this.definition};\n\n`);
     }
   },
   $OptionalType: class {

--- a/test/other/embind_tsgen.d.ts
+++ b/test/other/embind_tsgen.d.ts
@@ -82,7 +82,7 @@ export interface ClassWithSmartPtrConstructor extends ClassHandle {
   fn(_0: number): number;
 }
 
-type AliasedVal = number;
+export type AliasedVal = number;
 
 export interface BaseClass extends ClassHandle {
   fn(_0: number): number;

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -93,7 +93,7 @@ export interface ClassWithSmartPtrConstructor extends ClassHandle {
   fn(_0: number): number;
 }
 
-type AliasedVal = number;
+export type AliasedVal = number;
 
 export interface BaseClass extends ClassHandle {
   fn(_0: number): number;

--- a/test/other/embind_tsgen_ignore_2.d.ts
+++ b/test/other/embind_tsgen_ignore_2.d.ts
@@ -81,7 +81,7 @@ export interface ClassWithSmartPtrConstructor extends ClassHandle {
   fn(_0: number): number;
 }
 
-type AliasedVal = number;
+export type AliasedVal = number;
 
 export interface BaseClass extends ClassHandle {
   fn(_0: number): number;

--- a/test/other/embind_tsgen_ignore_3.d.ts
+++ b/test/other/embind_tsgen_ignore_3.d.ts
@@ -82,7 +82,7 @@ export interface ClassWithSmartPtrConstructor extends ClassHandle {
   fn(_0: number): number;
 }
 
-type AliasedVal = number;
+export type AliasedVal = number;
 
 export interface BaseClass extends ClassHandle {
   fn(_0: number): number;

--- a/test/other/embind_tsgen_module.d.ts
+++ b/test/other/embind_tsgen_module.d.ts
@@ -82,7 +82,7 @@ export interface ClassWithSmartPtrConstructor extends ClassHandle {
   fn(_0: number): number;
 }
 
-type AliasedVal = number;
+export type AliasedVal = number;
 
 export interface BaseClass extends ClassHandle {
   fn(_0: number): number;


### PR DESCRIPTION
Add `export` to types created by `register_type<T>(name, definition)`, so the type can be used by other modules.

Resolves https://github.com/emscripten-core/emscripten/pull/25272#issuecomment-3766850567