### PR TITLE
Cleanup test_fs_nodefs_rw

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5802,10 +5802,8 @@ got: 10
   def test_fs_nodefs_rw(self):
     if not self.get_setting('NODERAWFS'):
       self.setup_nodefs_test()
-    self.set_setting('SYSCALL_DEBUG')
+    self.maybe_closure()
     self.do_runf('fs/test_nodefs_rw.c', 'success')
-    if self.maybe_closure():
-      self.do_runf('fs/test_nodefs_rw.c', 'success')
 
   @also_with_noderawfs
   @requires_node


### PR DESCRIPTION
- No need to run the test twice.  Calling `maybe_closure` means it will run with close in `core3` and above.
- No need for `SYSCALL_DEBUG` here. I guess it was a leftover from some debugging.