### PR TITLE
Don't change WASM_EXCEPTIONS mode when setting -fno-exceptions

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1720,6 +1720,12 @@ int main() {
     self.assert_fail([EMCC, test_file('hello_world.cpp')] + self.get_cflags(), expected)
     clear_all_relevant_settings(self)
 
+    expected = "error: cannot use 'throw' with exceptions disabled"
+    self.assert_fail([EMCC, test_file('core/test_exceptions.cpp'), '-fwasm-exceptions', '-fno-exceptions'] + self.get_cflags(), expected)
+    clear_all_relevant_settings(self)
+    self.assert_fail([EMCC, test_file('core/test_exceptions.cpp'), '-fno-exceptions', '-fwasm-exceptions'] + self.get_cflags(), expected)
+    clear_all_relevant_settings(self)
+
   # Marked as impure since the WASI reactor modules (modules without main)
   # are not yet supported by the wasm engines we test against.
   @also_with_standalone_wasm(impure=True)

--- a/tools/cmdline.py
+++ b/tools/cmdline.py
@@ -508,7 +508,6 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
     elif arg == '-fno-exceptions':
       settings.DISABLE_EXCEPTION_CATCHING = 1
       settings.DISABLE_EXCEPTION_THROWING = 1
-      settings.WASM_EXCEPTIONS = 0
     elif arg == '-mbulk-memory':
       feature_matrix.enable_feature(feature_matrix.Feature.BULK_MEMORY,
                                     '-mbulk-memory',


### PR DESCRIPTION
We have 3 main user-facing EH flags, `-fwasm-exceptions`, `-fexceptions`,
and `-fno-exceptions`. IIRC they aren't supposed to be mutually exclusive,
-fwasm-exceptions` composes with the other 2, setting the mode of codegen,
where the other 2 set whether exceptions compile.

If you do `em++ -fno-exceptions -fwasm-exceptions` on a file that has try/catch,
you get the expected compile-time error. However if you do
`em++ -fwasm-exceptions -fno-exceptions` you should get the same error, but
instead you get
`clang++: error: invalid argument '-fwasm-exceptions' not allowed with '-enable-emscripten-sjlj'`.
This is because the underlying clang is indeed getting passed the
`-mllvm -enable-emscripten-sjlj` flag in the latter case but not the former case.
