### PR TITLE
Simplify `logReadFiles`. NFC

### DIFF
--- a/site/source/docs/porting/files/packaging_files.rst
+++ b/site/source/docs/porting/files/packaging_files.rst
@@ -113,9 +113,14 @@ Monitoring file usage
 
 .. important:: Only package the files your app actually needs, in order to reduce download size and improve startup speed.
 
-There is an option to log which files are actually used at runtime. To use it, define the :js:attr:`Module.logReadFiles` object. Each file that is read will be logged to stderr.
+There is an option to log which files are actually used at runtime. To use it,
+define the :js:attr:`Module.logReadFiles` object. Each file that is read will be
+logged to stderr.  This options requires that :ref:`FS_DEBUG` is set.
 
-An alternative approach is to look at :js:func:`FS.readFiles` in your compiled JavaScript. This is an object with keys for all the files that were read from. You may find it easier to use than logging as it records files rather than potentially multiple file accesses.
+An alternative approach is to look at :js:func:`FS.readFiles` in your compiled
+JavaScript. This is an object with keys for all the files that were read from.
+You may find it easier to use than logging as it records files rather than
+potentially multiple file accesses.
 
 .. note:: You can also modify the :js:func:`FS.readFiles` object or remove it entirely. This can be useful, say, in order to see which files are read between two points in time in your app.
 

--- a/src/lib/libfs.js
+++ b/src/lib/libfs.js
@@ -59,12 +59,10 @@ FS.staticInit();`;
     ignorePermissions: true,
 #if FS_DEBUG
     trackingDelegate: {},
+    readFiles: {},
 #endif
     filesystems: null,
     syncFSRequests: 0, // we warn if there are multiple in flight at once
-#if expectToReceiveOnModule('logReadFiles')
-    readFiles: {},
-#endif
 #if ASSERTIONS
     ErrnoError: class extends Error {
 #else
@@ -1160,17 +1158,13 @@ FS.staticInit();`;
       if (created) {
         FS.chmod(node, mode & 0o777);
       }
-#if expectToReceiveOnModule('logReadFiles')
-      if (Module['logReadFiles'] && !(flags & {{{ cDefs.O_WRONLY}}})) {
-        if (!(path in FS.readFiles)) {
-          FS.readFiles[path] = 1;
 #if FS_DEBUG
-          dbg(`FS.trackingDelegate error on read file: ${path}`);
-#endif
+      if (Module['logReadFiles'] && !(flags & {{{ cDefs.O_WRONLY}}})) {
+        if (!FS.readFiles[path]) {
+          FS.readFiles[path] = 1;
+          dbg(`FS: read file: ${path}`);
         }
       }
-#endif
-#if FS_DEBUG
       FS.trackingDelegate['onOpenFile']?.(path, origFlags);
 #endif
       return stream;

--- a/src/settings.js
+++ b/src/settings.js
@@ -996,7 +996,7 @@ var INCOMING_MODULE_JS_API = [
   'buffer', 'canvas', 'doNotCaptureKeyboard', 'dynamicLibraries',
   'elementPointerLock', 'extraStackTrace', 'forcedAspectRatio',
   'instantiateWasm', 'keyboardListeningElement', 'freePreloadedMediaOnUse',
-  'loadSplitModule', 'locateFile', 'logReadFiles', 'mainScriptUrlOrBlob', 'mem',
+  'loadSplitModule', 'locateFile', 'mainScriptUrlOrBlob', 'mem',
   'monitorRunDependencies', 'noExitRuntime', 'noInitialRun', 'onAbort',
   'onExit', 'onFree', 'onFullScreen', 'onMalloc',
   'onRealloc', 'onRuntimeInitialized', 'postMainLoop', 'postRun', 'preInit',

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19664,
-  "a.out.js.gz": 8146,
+  "a.out.js": 19618,
+  "a.out.js.gz": 8116,
   "a.out.nodebug.wasm": 132844,
   "a.out.nodebug.wasm.gz": 49884,
-  "total": 152508,
-  "total_gz": 58030,
+  "total": 152462,
+  "total_gz": 58000,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19641,
-  "a.out.js.gz": 8133,
+  "a.out.js": 19595,
+  "a.out.js.gz": 8102,
   "a.out.nodebug.wasm": 132264,
   "a.out.nodebug.wasm.gz": 49542,
-  "total": 151905,
-  "total_gz": 57675,
+  "total": 151859,
+  "total_gz": 57644,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23325,
-  "a.out.js.gz": 9127,
+  "a.out.js": 23279,
+  "a.out.js.gz": 9095,
   "a.out.nodebug.wasm": 172774,
   "a.out.nodebug.wasm.gz": 57405,
-  "total": 196099,
-  "total_gz": 66532,
+  "total": 196053,
+  "total_gz": 66500,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19475,
-  "a.out.js.gz": 8072,
+  "a.out.js": 19429,
+  "a.out.js.gz": 8043,
   "a.out.nodebug.wasm": 148169,
   "a.out.nodebug.wasm.gz": 55285,
-  "total": 167644,
-  "total_gz": 63357,
+  "total": 167598,
+  "total_gz": 63328,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19549,
-  "a.out.js.gz": 8091,
+  "a.out.js": 19503,
+  "a.out.js.gz": 8063,
   "a.out.nodebug.wasm": 145975,
   "a.out.nodebug.wasm.gz": 54915,
-  "total": 165524,
-  "total_gz": 63006,
+  "total": 165478,
+  "total_gz": 62978,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19011,
-  "a.out.js.gz": 7826,
+  "a.out.js": 18965,
+  "a.out.js.gz": 7802,
   "a.out.nodebug.wasm": 102076,
   "a.out.nodebug.wasm.gz": 39428,
-  "total": 121087,
-  "total_gz": 47254,
+  "total": 121041,
+  "total_gz": 47230,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23375,
-  "a.out.js.gz": 9147,
+  "a.out.js": 23329,
+  "a.out.js.gz": 9118,
   "a.out.nodebug.wasm": 239224,
   "a.out.nodebug.wasm.gz": 79795,
-  "total": 262599,
-  "total_gz": 88942,
+  "total": 262553,
+  "total_gz": 88913,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19664,
-  "a.out.js.gz": 8146,
+  "a.out.js": 19618,
+  "a.out.js.gz": 8116,
   "a.out.nodebug.wasm": 134851,
   "a.out.nodebug.wasm.gz": 50712,
-  "total": 154515,
-  "total_gz": 58858,
+  "total": 154469,
+  "total_gz": 58828,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_files_js_fs.json
+++ b/test/codesize/test_codesize_files_js_fs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18283,
-  "a.out.js.gz": 7464,
+  "a.out.js": 18237,
+  "a.out.js.gz": 7441,
   "a.out.nodebug.wasm": 381,
   "a.out.nodebug.wasm.gz": 260,
-  "total": 18664,
-  "total_gz": 7724,
+  "total": 18618,
+  "total_gz": 7701,
   "sent": [
     "a (fd_write)",
     "b (fd_read)",

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 24225,
-  "a.out.js.gz": 8703,
+  "a.out.js": 24212,
+  "a.out.js.gz": 8700,
   "a.out.nodebug.wasm": 15138,
   "a.out.nodebug.wasm.gz": 7455,
-  "total": 39363,
-  "total_gz": 16158,
+  "total": 39350,
+  "total_gz": 16155,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26705,
-  "a.out.js.gz": 11396,
+  "a.out.js": 26659,
+  "a.out.js.gz": 11369,
   "a.out.nodebug.wasm": 17730,
   "a.out.nodebug.wasm.gz": 8957,
-  "total": 44435,
-  "total_gz": 20353,
+  "total": 44389,
+  "total_gz": 20326,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 244882,
+  "a.out.js": 244832,
   "a.out.nodebug.wasm": 577863,
-  "total": 822745,
+  "total": 822695,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -1277,7 +1277,6 @@ function checkIncomingModuleAPI() {
   ignoredModuleProp('freePreloadedMediaOnUse');
   ignoredModuleProp('loadSplitModule');
   ignoredModuleProp('locateFile');
-  ignoredModuleProp('logReadFiles');
   ignoredModuleProp('mainScriptUrlOrBlob');
   ignoredModuleProp('mem');
   ignoredModuleProp('monitorRunDependencies');

--- a/test/codesize/test_codesize_minimal_O0.json
+++ b/test/codesize/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19498,
-  "a.out.js.gz": 7013,
+  "a.out.js": 19479,
+  "a.out.js.gz": 7006,
   "a.out.nodebug.wasm": 1136,
   "a.out.nodebug.wasm.gz": 656,
-  "total": 20634,
-  "total_gz": 7669,
+  "total": 20615,
+  "total_gz": 7662,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 56906,
-  "hello_world.js.gz": 17709,
+  "hello_world.js": 56888,
+  "hello_world.js.gz": 17706,
   "hello_world.wasm": 15138,
   "hello_world.wasm.gz": 7455,
   "no_asserts.js": 26576,
   "no_asserts.js.gz": 8881,
   "no_asserts.wasm": 12187,
   "no_asserts.wasm.gz": 5984,
-  "strict.js": 54881,
-  "strict.js.gz": 17045,
+  "strict.js": 54844,
+  "strict.js.gz": 17038,
   "strict.wasm": 15138,
   "strict.wasm.gz": 7450,
-  "total": 180826,
-  "total_gz": 64524
+  "total": 180771,
+  "total_gz": 64514
 }


### PR DESCRIPTION
- Document that `logReadFiles` requires `FS_DEBUG` to be set.
- Put both parts of this features (both the logging to stderr and the tracking in `FS.openedFiles`) behing `FS_DEBUG` instead of only the former.

The actual string that was logged was changed in #7418, but I think it was in error.
