### PR TITLE
Fix `logReadFiles` tracking message

### DIFF
--- a/src/lib/libfs.js
+++ b/src/lib/libfs.js
@@ -1167,9 +1167,7 @@ FS.staticInit();`;
       if (Module['logReadFiles'] && !(flags & {{{ cDefs.O_WRONLY}}})) {
         if (!(path in FS.readFiles)) {
           FS.readFiles[path] = 1;
-#if FS_DEBUG
-          dbg(`FS.trackingDelegate error on read file: ${path}`);
-#endif
+          err(`read file: ${path}`);
         }
       }
 #endif

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19602,
-  "a.out.js.gz": 8132,
+  "a.out.js": 19623,
+  "a.out.js.gz": 8144,
   "a.out.nodebug.wasm": 132844,
   "a.out.nodebug.wasm.gz": 49884,
-  "total": 152446,
-  "total_gz": 58016,
+  "total": 152467,
+  "total_gz": 58028,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19579,
-  "a.out.js.gz": 8118,
+  "a.out.js": 19600,
+  "a.out.js.gz": 8131,
   "a.out.nodebug.wasm": 132264,
   "a.out.nodebug.wasm.gz": 49542,
-  "total": 151843,
-  "total_gz": 57660,
+  "total": 151864,
+  "total_gz": 57673,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23263,
-  "a.out.js.gz": 9109,
+  "a.out.js": 23284,
+  "a.out.js.gz": 9122,
   "a.out.nodebug.wasm": 172774,
   "a.out.nodebug.wasm.gz": 57405,
-  "total": 196037,
-  "total_gz": 66514,
+  "total": 196058,
+  "total_gz": 66527,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19413,
-  "a.out.js.gz": 8054,
+  "a.out.js": 19434,
+  "a.out.js.gz": 8068,
   "a.out.nodebug.wasm": 148169,
   "a.out.nodebug.wasm.gz": 55285,
-  "total": 167582,
-  "total_gz": 63339,
+  "total": 167603,
+  "total_gz": 63353,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19487,
-  "a.out.js.gz": 8074,
+  "a.out.js": 19508,
+  "a.out.js.gz": 8088,
   "a.out.nodebug.wasm": 145975,
   "a.out.nodebug.wasm.gz": 54915,
-  "total": 165462,
-  "total_gz": 62989,
+  "total": 165483,
+  "total_gz": 63003,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18949,
-  "a.out.js.gz": 7812,
+  "a.out.js": 18970,
+  "a.out.js.gz": 7824,
   "a.out.nodebug.wasm": 102076,
   "a.out.nodebug.wasm.gz": 39428,
-  "total": 121025,
-  "total_gz": 47240,
+  "total": 121046,
+  "total_gz": 47252,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23313,
-  "a.out.js.gz": 9128,
+  "a.out.js": 23334,
+  "a.out.js.gz": 9141,
   "a.out.nodebug.wasm": 239224,
   "a.out.nodebug.wasm.gz": 79795,
-  "total": 262537,
-  "total_gz": 88923,
+  "total": 262558,
+  "total_gz": 88936,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19602,
-  "a.out.js.gz": 8132,
+  "a.out.js": 19623,
+  "a.out.js.gz": 8144,
   "a.out.nodebug.wasm": 134851,
   "a.out.nodebug.wasm.gz": 50712,
-  "total": 154453,
-  "total_gz": 58844,
+  "total": 154474,
+  "total_gz": 58856,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_files_js_fs.json
+++ b/test/codesize/test_codesize_files_js_fs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18220,
-  "a.out.js.gz": 7450,
+  "a.out.js": 18241,
+  "a.out.js.gz": 7465,
   "a.out.nodebug.wasm": 381,
   "a.out.nodebug.wasm.gz": 260,
-  "total": 18601,
-  "total_gz": 7710,
+  "total": 18622,
+  "total_gz": 7725,
   "sent": [
     "a (fd_write)",
     "b (fd_read)",

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26642,
-  "a.out.js.gz": 11380,
+  "a.out.js": 26663,
+  "a.out.js.gz": 11392,
   "a.out.nodebug.wasm": 17730,
   "a.out.nodebug.wasm.gz": 8957,
-  "total": 44372,
-  "total_gz": 20337,
+  "total": 44393,
+  "total_gz": 20349,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 244819,
+  "a.out.js": 244840,
   "a.out.nodebug.wasm": 577863,
-  "total": 822682,
+  "total": 822703,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15338,3 +15338,14 @@ console.log('OK');'''
 
   def test_executable_requires_node(self):
     self.assert_fail([EMCC, test_file('hello_world.c'), '-sEXECUTABLE', '-sENVIRONMENT=web'], 'emcc: error: EXECUTABLE requires `node` in ENVRIONMENT')
+
+  def test_logReadFiles(self):
+    create_file('test.txt', 'hello')
+    self.cflags += ['--preload-file=test.txt']
+
+    output = self.do_runf('checksummer.c', args=['test.txt'])
+    self.assertNotContained('read file:', output)
+
+    create_file('pre.js', 'Module.logReadFiles = 1;')
+    output = self.do_runf('checksummer.c', args=['test.txt'], cflags=['--pre-js=pre.js'])
+    self.assertContained('read file: /test.txt', output)


### PR DESCRIPTION
Back in #7418 this message was updated, I believe in error.  This logging is not related to `FS.trackingDelegate` and it not logging any kind of error.

As a followup we should look at removing `logReadFiles` completely, or at least removing from `INCOMING_MODULE_JS_API` by default.

The `FS_DEBUG` was (again incorrectly) added in #15005

Also, add a test for this feature.