### PR TITLE
Log error with SOCKET_DEBUG on websocket connect

### DIFF
--- a/src/lib/libsockfs.js
+++ b/src/lib/libsockfs.js
@@ -225,6 +225,9 @@ addToLibrary({
             ws = new WebSocketConstructor(url, opts);
             ws.binaryType = 'arraybuffer';
           } catch (e) {
+#if SOCKET_DEBUG
+            dbg(`websocket: error connecting: ${e}`);
+#endif
             throw new FS.ErrnoError({{{ cDefs.EHOSTUNREACH }}});
           }
         }


### PR DESCRIPTION
I keep forgetting that if I don't install `ws` then a web socket connection will fail with the confusing error "Host is unreachable". This PR changes it such that it will actually log "Cannot find module 'ws'" when `-sSOCKET_DEBUG` is enabled.