### PR TITLE
Remove `loadSplitModule` from default INCOMING_MODULE_JS_API. NFC

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -996,7 +996,7 @@ var INCOMING_MODULE_JS_API = [
   'buffer', 'canvas', 'doNotCaptureKeyboard', 'dynamicLibraries',
   'elementPointerLock', 'extraStackTrace', 'forcedAspectRatio',
   'instantiateWasm', 'keyboardListeningElement', 'freePreloadedMediaOnUse',
-  'loadSplitModule', 'locateFile', 'mainScriptUrlOrBlob', 'mem',
+  'locateFile', 'mainScriptUrlOrBlob', 'mem',
   'monitorRunDependencies', 'noExitRuntime', 'noInitialRun', 'onAbort',
   'onExit', 'onFree', 'onFullScreen', 'onMalloc',
   'onRealloc', 'onRuntimeInitialized', 'postMainLoop', 'postRun', 'preInit',

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 24246,
-  "a.out.js.gz": 8709,
+  "a.out.js": 24268,
+  "a.out.js.gz": 8718,
   "a.out.nodebug.wasm": 15138,
   "a.out.nodebug.wasm.gz": 7455,
-  "total": 39384,
-  "total_gz": 16164,
+  "total": 39406,
+  "total_gz": 16173,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -1275,7 +1275,6 @@ function checkIncomingModuleAPI() {
   ignoredModuleProp('instantiateWasm');
   ignoredModuleProp('keyboardListeningElement');
   ignoredModuleProp('freePreloadedMediaOnUse');
-  ignoredModuleProp('loadSplitModule');
   ignoredModuleProp('locateFile');
   ignoredModuleProp('mainScriptUrlOrBlob');
   ignoredModuleProp('mem');
@@ -1309,6 +1308,7 @@ function checkIncomingModuleAPI() {
   ignoredModuleProp('websocket');
   ignoredModuleProp('fetchSettings');
   ignoredModuleProp('logReadFiles');
+  ignoredModuleProp('loadSplitModule');
 }
 
 // Imports from the Wasm binary.

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,6 +1,6 @@
 {
-  "hello_world.js": 56925,
-  "hello_world.js.gz": 17717,
+  "hello_world.js": 56965,
+  "hello_world.js.gz": 17729,
   "hello_world.wasm": 15138,
   "hello_world.wasm.gz": 7455,
   "no_asserts.js": 26576,
@@ -8,9 +8,9 @@
   "no_asserts.wasm": 12187,
   "no_asserts.wasm.gz": 5984,
   "strict.js": 54881,
-  "strict.js.gz": 17046,
+  "strict.js.gz": 17045,
   "strict.wasm": 15138,
   "strict.wasm.gz": 7450,
-  "total": 180845,
-  "total_gz": 64533
+  "total": 180885,
+  "total_gz": 64544
 }

--- a/tools/cmdline.py
+++ b/tools/cmdline.py
@@ -42,6 +42,7 @@ CLANG_FLAGS_WITH_ARGS = {
 EXTRA_INCOMING_JS_API = [
   'fetchSettings',
   'logReadFiles',
+  'loadSplitModule',
 ]
 
 logger = logging.getLogger('args')

--- a/tools/link.py
+++ b/tools/link.py
@@ -1643,8 +1643,10 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
   if settings.LEGALIZE_JS_FFI:
     settings.REQUIRED_EXPORTS += ['__get_temp_ret', '__set_temp_ret']
 
-  if settings.SPLIT_MODULE and settings.ASYNCIFY == 2:
-    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['_load_secondary_module']
+  if settings.SPLIT_MODULE:
+    settings.INCOMING_MODULE_JS_API += ['loadSplitModule']
+    if settings.ASYNCIFY == 2:
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['_load_secondary_module']
 
   # wasm side modules have suffix .wasm
   if settings.SIDE_MODULE and utils.suffix(target) in ('.js', '.mjs'):


### PR DESCRIPTION
We can instead add it to the list precisely in cases where its needed.