### PR TITLE
poll: Add pollAsync API to the stream backend

### DIFF
--- a/src/lib/libpipefs.js
+++ b/src/lib/libpipefs.js
@@ -97,7 +97,15 @@ addToLibrary({
           blocks: 0,
         };
       },
-      poll(stream, timeout, notifyCallback) {
+      pollAsync(stream, notifyCallback) {
+        var res = this.poll(stream, 0);
+        if (res != 0) return res;
+#if PTHREADS
+        stream.node.pipe.registerReadableHandler(notifyCallback);
+#endif
+        return 0;
+      },
+      poll(stream, timeout) {
         var pipe = stream.node.pipe;
 
         if ((stream.flags & {{{ cDefs.O_ACCMODE }}}) === {{{ cDefs.O_WRONLY }}}) {
@@ -109,9 +117,6 @@ addToLibrary({
           }
         }
 
-#if PTHREADS
-        if (notifyCallback) pipe.registerReadableHandler(notifyCallback);
-#endif
         return 0;
       },
       dup(stream) {

--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -625,8 +625,8 @@ var SyscallsLibrary = {
       if (stream) {
         if (stream.stream_ops.poll) {
 #if PTHREADS || ASYNCIFY
-          if (isAsyncContext && timeout) {
-            flags = stream.stream_ops.poll(stream, timeout, makeNotifyCallback(stream, pollfd));
+          if (stream.stream_ops.pollAsync && isAsyncContext && timeout) {
+            flags = stream.stream_ops.pollAsync(stream, makeNotifyCallback(stream, pollfd));
           } else
 #endif
           flags = stream.stream_ops.poll(stream, -1);


### PR DESCRIPTION
Discussed in #26192

This PR only contains the refactoring of the APIs following the suggestion in #26192. I think we need additional patches if we want to fully restore the legacy behavior (i.e. ignoring the timeout argument) for the sockfs.

This commit refactors the stream backend's poll API and explicitly splits it into synchronous and asynchronous APIs. The poll API synchronously checks the events. The backend can also implement the pollAsync API which can wait for the event asynchronously and notify the caller using the callback when the event occurs.