### PR TITLE
Allowing file path taking up more than 255 bytes

### DIFF
--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -739,7 +739,8 @@ var SyscallsLibrary = {
       {{{ makeSetValue('dirp + pos', C_STRUCTS.dirent.d_off, '(idx + 1) * struct_size', 'i64') }}};
       {{{ makeSetValue('dirp + pos', C_STRUCTS.dirent.d_reclen, C_STRUCTS.dirent.__size__, 'i16') }}};
       {{{ makeSetValue('dirp + pos', C_STRUCTS.dirent.d_type, 'type', 'i8') }}};
-      stringToUTF8(name, dirp + pos + {{{ C_STRUCTS.dirent.d_name }}}, 256);
+      var size = lengthBytesUTF8(name) + 1;
+      stringToUTF8(name, dirp + pos + {{{ C_STRUCTS.dirent.d_name }}}, size);
       pos += struct_size;
     }
     FS.llseek(stream, idx * struct_size, {{{ cDefs.SEEK_SET }}});


### PR DESCRIPTION
Paths that contain ascii may have a short length within the characters count. However it may take up bytes exceeding 256.
It does seem like the emscripten filesystems allow file path longer than 256 (with the exception of nodefs mounted on windows).