### PR TITLE
Fix blocking select/poll on pipes with ASYNCIFY. NFC

### DIFF
--- a/src/lib/libpipefs.js
+++ b/src/lib/libpipefs.js
@@ -21,7 +21,7 @@ addToLibrary({
         // able to read from the read end after write end is closed.
         refcnt : 2,
         timestamp: new Date(),
-#if PTHREADS
+#if PTHREADS || ASYNCIFY
         readableHandlers: [],
         registerReadableHandler: (callback) => {
           callback.registerCleanupFunc(() => {
@@ -109,7 +109,7 @@ addToLibrary({
           }
         }
 
-#if PTHREADS
+#if PTHREADS || ASYNCIFY
         if (notifyCallback) pipe.registerReadableHandler(notifyCallback);
 #endif
         return 0;
@@ -224,7 +224,7 @@ addToLibrary({
         if (freeBytesInCurrBuffer >= dataLen) {
           currBucket.buffer.set(data, currBucket.offset);
           currBucket.offset += dataLen;
-#if PTHREADS
+#if PTHREADS || ASYNCIFY
           pipe.notifyReadableHandlers();
 #endif
           return dataLen;
@@ -258,7 +258,7 @@ addToLibrary({
           newBucket.buffer.set(data);
         }
 
-#if PTHREADS
+#if PTHREADS || ASYNCIFY
         pipe.notifyReadableHandlers();
 #endif
         return dataLen;

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9573,7 +9573,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_poll_blocking_asyncify(self):
     if self.get_setting('JSPI') and engine_is_v8(self.get_current_js_engine()):
       self.skipTest('test requires setTimeout which is not supported under v8')
-    self.do_runf('core/test_poll_blocking_asyncify.c')
+    self.do_runf('core/test_poll_blocking_asyncify.c', 'done\n')
 
   @parameterized({
     '': ([],),


### PR DESCRIPTION
I forgot to actually test any of the stdout of this test so what was happening here is that after the timeout and the writing to the pipe, the node process was just existing with 0 exit code.  Basically the JSPI/ASYNCIFY continuation of the program was never run and node simply exits because there was nothing left in the event loop.