### PR TITLE
Fix inode number overflow in readdir test

### DIFF
--- a/test/fs/test_fs_readdir_ino_matches_stat_ino.c
+++ b/test/fs/test_fs_readdir_ino_matches_stat_ino.c
@@ -39,8 +39,8 @@ int main() {
 #ifndef NODERAWFS
   assert(chmod(".", 0675) == 0);
 #endif
-  int a_ino = -1;
-  int b_ino = -1;
+  ino_t a_ino = 0;
+  ino_t b_ino = 0;
   struct dirent *ep;
   while ((ep = readdir(dirp))) {
     if (strcmp(ep->d_name, "a") == 0) {
@@ -51,9 +51,9 @@ int main() {
     }
   }
   assert(errno == 0);
-  assert(a_ino >= 0);
-  assert(b_ino >= 0);
-  printf("readdir a_ino: %d, b_ino: %d\n", a_ino, b_ino);
+  assert(a_ino > 0);
+  assert(b_ino > 0);
+  printf("readdir a_ino: %llu, b_ino: %llu\n", a_ino, b_ino);
   printf("stat    a_ino: %llu, b_ino: %llu\n", sta.st_ino, stb.st_ino);
   assert(a_ino == sta.st_ino);
   assert(b_ino == stb.st_ino);

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5993,7 +5993,6 @@ Module.onRuntimeInitialized = () => {
   @no_windows("stat ino values don't match on windows")
   @crossplatform
   @no_wasmfs('Assertion failed: "a_ino == sta.st" in test_fs_readdir_ino_matches_stat_ino.c, line 58. https://github.com/emscripten-core/emscripten/issues/25035')
-  @flaky('https://github.com/emscripten-core/emscripten/issues/26090')
   def test_fs_readdir_ino_matches_stat_ino(self):
     self.do_runf('fs/test_fs_readdir_ino_matches_stat_ino.c', 'success')
 


### PR DESCRIPTION
The test was failing intermittently on Linux because inode numbers were stored in signed 32-bit integers. On modern Linux filesystems, inode numbers frequently exceed the range of a signed 32-bit integer, leading to narrowing overflows and negative values which triggered assertion failures.

This change updates the test to use ino_t (which is 64-bit in Emscripten).

Fixes #26090