### PR TITLE
Add checks for PROXY_SYNC_ASYNC

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -1027,7 +1027,11 @@ var LibraryPThread = {
     var rtn = func(...proxiedJSCallArgs);
     PThread.currentProxiedOperationCallerThread = 0;
     if (ctx) {
-      rtn.then((rtn) => __emscripten_run_js_on_main_thread_done(ctx, ctxArgs, rtn));
+      if (rtn && typeof rtn.then === 'function') {
+        rtn.then((rtn) => __emscripten_run_js_on_main_thread_done(ctx, ctxArgs, rtn));
+      } else {
+        __emscripten_run_js_on_main_thread_done(ctx, ctxArgs, rtn);
+      }
       return;
     }
 


### PR DESCRIPTION
Check if the returned value is actually a Promise before attempting to use it as one.

I got en error when using `fd_sync` without ASYNCIFY: https://github.com/emscripten-core/emscripten/blob/main/src/lib/libwasi.js#L556. It is assigned `__proxy: 'sync'` (https://github.com/emscripten-core/emscripten/blob/main/src/lib/libcore.js#L2627), making it being proxied using PROXY_SYNC_ASYNC mode while not being a Promise.