### PR TITLE
Reject module promise if WebAssembly.instantiate() errors out

### DIFF
--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -307,10 +307,14 @@ null;
 
 }
 
-#if WASM == 2
+#if WASM == 2 || MODULARIZE
 , (error) => {
 #if ASSERTIONS
   console.error(error);
+#endif
+
+#if MODULARIZE
+  readyPromiseReject?.(error);
 #endif
 
 #if ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL
@@ -325,7 +329,7 @@ null;
   }
 #endif
 }
-#endif // WASM == 2
+#endif // WASM == 2 || MODULARIZE
 );
 
 #if PTHREADS || WASM_WORKERS


### PR DESCRIPTION
This allows any errors thrown by WebAssembly.instantiate() to be propagated to the caller, rather than being unhandleable.