### PR TITLE
[CI] Remove windows python2 PATH addition. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1218,9 +1218,6 @@ jobs:
           name: Install packages
           command: |
             choco install -y cmake.portable ninja pkgconfiglite
-      - run:
-          name: Add python to bash path
-          command: echo "export PATH=\"$PATH:/c/Python27amd64/\"" >> $BASH_ENV
       - install-emsdk
       - pip-install:
           python: "$EMSDK_PYTHON"
@@ -1281,9 +1278,6 @@ jobs:
           name: Install packages
           command: |
             choco install -y cmake.portable ninja pkgconfiglite
-      - run:
-          name: Add python to bash path
-          command: echo "export PATH=\"$PATH:/c/Python27amd64/\"" >> $BASH_ENV
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
       - install-emsdk


### PR DESCRIPTION
We don't support python2 anywhere anymore.  This went unnoticed here because were adding this to the end of the `PATH` which already contained `python.exe` in `/c/Python312/python`.