### PR TITLE
Remove `MainLoop.method`. NFC

### DIFF
--- a/src/lib/libeventloop.js
+++ b/src/lib/libeventloop.js
@@ -201,7 +201,6 @@ LibraryJSEventLoop = {
   $MainLoop: {
     running: false,
     scheduler: null,
-    method: '',
     // Each main loop is numbered with a ID in sequence order. Only one main
     // loop can run at a time. This variable stores the ordinal number of the
     // main loop that is currently allowed to run. All previous main loops
@@ -333,12 +332,10 @@ LibraryJSEventLoop = {
         var timeUntilNextTick = Math.max(0, MainLoop.tickStartTime + value - _emscripten_get_now())|0;
         setTimeout(MainLoop.runner, timeUntilNextTick); // doing this each time means that on exception, we stop
       };
-      MainLoop.method = 'timeout';
     } else if (mode == {{{ cDefs.EM_TIMING_RAF }}}) {
       MainLoop.scheduler = function MainLoop_scheduler_rAF() {
         MainLoop.requestAnimationFrame(MainLoop.runner);
       };
-      MainLoop.method = 'rAF';
     } else {
 #if ASSERTIONS
       assert(mode == {{{ cDefs.EM_TIMING_SETIMMEDIATE}}});
@@ -373,7 +370,6 @@ LibraryJSEventLoop = {
       MainLoop.scheduler = function MainLoop_scheduler_setImmediate() {
         MainLoop.setImmediate(MainLoop.runner);
       };
-      MainLoop.method = 'immediate';
     }
     return 0;
   },
@@ -465,14 +461,12 @@ LibraryJSEventLoop = {
         return;
       } else if (MainLoop.timingMode == {{{ cDefs.EM_TIMING_SETTIMEOUT }}}) {
         MainLoop.tickStartTime = _emscripten_get_now();
-      }
-
 #if ASSERTIONS
-      if (MainLoop.method === 'timeout' && Module['ctx']) {
-        warnOnce('Looks like you are rendering without using requestAnimationFrame for the main loop. You should use 0 for the frame rate in emscripten_set_main_loop in order to use requestAnimationFrame, as that can greatly improve your frame rates!');
-        MainLoop.method = ''; // just warn once per call to set main loop
-      }
+        if (Module['ctx']) {
+          warnOnce('Looks like you are rendering without using requestAnimationFrame for the main loop. You should use 0 for the frame rate in emscripten_set_main_loop in order to use requestAnimationFrame, as that can greatly improve your frame rates!');
+        }
 #endif
+      }
 
       MainLoop.runIter(iterFunc);
 


### PR DESCRIPTION
The `MainLoop.method` property seems to be a string version of `MainLoop.timingMode`.

It had exactly one user which was to generate a warning. The warning was firing in the case when the method was `timeout` (which is the same as `timingMode` == `EM_TIMING_SETTIMEOUT`).  The warning code would then reset `MainLoop.method` so that it would only fire "once per set main loop".  However, since this was changed to `warnOnce` in #10090, the warning actually only fires once per program run.