### PR TITLE
Speed up select/poll blocking tests

### DIFF
--- a/test/core/test_poll_blocking.c
+++ b/test/core/test_poll_blocking.c
@@ -16,9 +16,15 @@
 #include <string.h>
 #include <sys/time.h>
 
+#define TIMEOUT_MS 300
+
+void sleep_ms(int ms) {
+  usleep(ms * 1000);
+}
+
 int64_t timeval_delta_ms(struct timeval* begin, struct timeval* end) {
   int64_t delta_s = end->tv_sec - begin->tv_sec;
-  int64_t delta_us =  end->tv_usec -  begin->tv_usec;
+  int64_t delta_us = end->tv_usec - begin->tv_usec;
   assert(delta_s >= 0);
   return (delta_s * 1000) + (delta_us / 1000);
 }
@@ -29,12 +35,12 @@ void test_timeout_without_fds() {
   struct timeval begin, end;
 
   gettimeofday(&begin, NULL);
-  assert(poll(NULL, 0, 1000) == 0);
+  assert(poll(NULL, 0, TIMEOUT_MS) == 0);
   gettimeofday(&end, NULL);
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= 1000);
+  assert(duration >= TIMEOUT_MS);
 }
 
 // Check if timeout works with fds without events
@@ -47,22 +53,22 @@ void test_timeout_with_fds_without_events() {
 
   gettimeofday(&begin, NULL);
   struct pollfd fds = {pipe_a[0], 0, 0};
-  assert(poll(&fds, 1, 1000) == 0);
+  assert(poll(&fds, 1, TIMEOUT_MS) == 0);
   gettimeofday(&end, NULL);
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= 1000);
+  assert(duration >= TIMEOUT_MS);
 
   close(pipe_a[0]); close(pipe_a[1]);
 }
 
 int pipe_shared[2];
 
-void *write_after_2s(void * arg) {
+void *write_after_sleep(void * arg) {
   const char *t = "test\n";
 
-  sleep(2);
+  sleep_ms(TIMEOUT_MS);
   write(pipe_shared[1], t, strlen(t));
 
   return NULL;
@@ -82,15 +88,15 @@ void test_unblock_poll() {
     {pipe_a[0], POLLIN, 0},
     {pipe_shared[0], POLLIN, 0},
   };
-  assert(pthread_create(&tid, NULL, write_after_2s, NULL) == 0);
   gettimeofday(&begin, NULL);
+  assert(pthread_create(&tid, NULL, write_after_sleep, NULL) == 0);
   assert(poll(fds, 2, -1) == 1);
   gettimeofday(&end, NULL);
   assert(fds[1].revents & POLLIN);
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= 1000);
+  assert(duration >= TIMEOUT_MS);
 
   pthread_join(tid, NULL);
 
@@ -105,11 +111,11 @@ void *do_poll_in_thread(void * arg) {
   struct pollfd fds = {pipe_shared[0], POLLIN, 0};
   assert(poll(&fds, 1, 4000) == 1);
   gettimeofday(&end, NULL);
-  assert(fds.events & POLLIN);
+  assert(fds.revents & POLLIN);
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert((duration >= 1000) && (duration < 4000));
+  assert((duration >= TIMEOUT_MS) && (duration < 4000));
 
   return NULL;
 }
@@ -125,7 +131,7 @@ void test_poll_in_threads() {
   assert(pthread_create(&tid1, NULL, do_poll_in_thread, NULL) == 0);
   assert(pthread_create(&tid2, NULL, do_poll_in_thread, NULL) == 0);
 
-  sleep(2);
+  sleep_ms(2 * TIMEOUT_MS);
   write(pipe_shared[1], t, strlen(t));
 
   pthread_join(tid1, NULL);

--- a/test/core/test_select_blocking.c
+++ b/test/core/test_select_blocking.c
@@ -13,9 +13,15 @@
 #include <string.h>
 #include <sys/time.h>
 
+#define TIMEOUT_MS 300
+
+void sleep_ms(int ms) {
+  usleep(ms * 1000);
+}
+
 int64_t timeval_delta_ms(struct timeval* begin, struct timeval* end) {
   int64_t delta_s = end->tv_sec - begin->tv_sec;
-  int64_t delta_us =  end->tv_usec -  begin->tv_usec;
+  int64_t delta_us = end->tv_usec - begin->tv_usec;
   assert(delta_s >= 0);
   return (delta_s * 1000) + (delta_us / 1000);
 }
@@ -25,15 +31,15 @@ void test_timeout_without_fds() {
   printf("test_timeout_without_fds\n");
   struct timeval tv, begin, end;
 
-  tv.tv_sec = 1;
-  tv.tv_usec = 0;
+  tv.tv_sec = 0;
+  tv.tv_usec = TIMEOUT_MS * 1000;
   gettimeofday(&begin, NULL);
   assert(select(0, NULL, NULL, NULL, &tv) == 0);
   gettimeofday(&end, NULL);
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= 1000);
+  assert(duration >= TIMEOUT_MS);
 }
 
 // Check if timeout works with fds without events
@@ -45,8 +51,8 @@ void test_timeout_with_fds_without_events() {
 
   assert(pipe(pipe_a) == 0);
 
-  tv.tv_sec = 1;
-  tv.tv_usec = 0;
+  tv.tv_sec = 0;
+  tv.tv_usec = TIMEOUT_MS * 1000;
   FD_ZERO(&readfds);
   FD_SET(pipe_a[0], &readfds);
   gettimeofday(&begin, NULL);
@@ -55,17 +61,17 @@ void test_timeout_with_fds_without_events() {
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= 1000);
+  assert(duration >= TIMEOUT_MS);
 
   close(pipe_a[0]); close(pipe_a[1]);
 }
 
 int pipe_shared[2];
 
-void *write_after_2s(void * arg) {
+void *write_after_sleep(void * arg) {
   const char *t = "test\n";
 
-  sleep(2);
+  sleep_ms(TIMEOUT_MS);
   write(pipe_shared[1], t, strlen(t));
 
   return NULL;
@@ -86,15 +92,15 @@ void test_unblock_select() {
   FD_SET(pipe_a[0], &readfds);
   FD_SET(pipe_shared[0], &readfds);
   int maxfd = (pipe_a[0] > pipe_shared[0] ? pipe_a[0] : pipe_shared[0]);
-  assert(pthread_create(&tid, NULL, write_after_2s, NULL) == 0);
   gettimeofday(&begin, NULL);
+  assert(pthread_create(&tid, NULL, write_after_sleep, NULL) == 0);
   assert(select(maxfd + 1, &readfds, NULL, NULL, NULL) == 1);
   gettimeofday(&end, NULL);
   assert(FD_ISSET(pipe_shared[0], &readfds));
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= 1000);
+  assert(duration >= TIMEOUT_MS);
 
   pthread_join(tid, NULL);
 
@@ -120,7 +126,7 @@ void *do_select_in_thread(void * arg) {
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert((duration >= 1000) && (duration < 4000));
+  assert((duration >= TIMEOUT_MS) && (duration < 4000));
 
   return NULL;
 }
@@ -136,7 +142,7 @@ void test_select_in_threads() {
   assert(pthread_create(&tid1, NULL, do_select_in_thread, NULL) == 0);
   assert(pthread_create(&tid2, NULL, do_select_in_thread, NULL) == 0);
 
-  sleep(2);
+  sleep_ms(2 * TIMEOUT_MS);
   write(pipe_shared[1], t, strlen(t));
 
   pthread_join(tid1, NULL);


### PR DESCRIPTION
Cuts the execution time for these tests from ~8s to ~3s.