### PR TITLE
Update circleci node image used for running eslint. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   linux-node:
     docker:
-      - image: cimg/node:20.15.1
+      - image: cimg/node:24.13.1
   linux-python:
     docker:
       - image: cimg/python:3.10.7


### PR DESCRIPTION
We only use this image for lint checking.