### PR TITLE
[fetch] Fix memory leak inside saveResponseAndStatus in streaming mode

### DIFF
--- a/src/lib/libfetch.js
+++ b/src/lib/libfetch.js
@@ -33,6 +33,7 @@ var LibraryFetch = {
     '$Fetch',
     '$fetchXHR',
     '$callUserCallback',
+    '$readI53FromI64',
     '$writeI53ToI64',
     '$stringToUTF8',
     '$stringToNewUTF8',

--- a/test/fetch/test_fetch_stream_file.cpp
+++ b/test/fetch/test_fetch_stream_file.cpp
@@ -20,7 +20,6 @@ int main() {
   attr.onsuccess = [](emscripten_fetch_t *fetch) {
     printf("Finished downloading %llu bytes\n", fetch->totalBytes);
     printf("Data checksum: %08X\n", checksum);
-    assert(fetch->data == 0); // The data was streamed via onprogress, no bytes available here.
     assert(fetch->numBytes == 0);
     assert(fetch->totalBytes == 134217728);
     assert(checksum == 0xA7F8E858U);


### PR DESCRIPTION
when streaming was enabled -
* onprogress allocated emscripten_fetch_t.data
* onload called saveResponseAndStatus
* xhr.response was NULL (due to streaming) which caused ptr to remain 0
* emscripten_fetch_t.data was uncondtionally overwritten by ptr, leaking what was allocated during onprogress

This change also wraps realloc in a guard to only call it if necessary (new buffer is larger than existing).

Not sure what's the best way to unobtrusively test this - is there some setting that enables some basic leak detections we could enable for an existing test that uses streaming (e.g. test_fetch_stream_async)?