### PR TITLE
[libcxxabi] Use InitByteFutex for __cxa_guard in WASM Workers

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1648,6 +1648,8 @@ class libcxxabi(ExceptionLibrary, MTLibrary, DebugLibrary):
     cflags = super().get_cflags()
     if not self.is_mt and not self.is_ww:
       cflags.append('-D_LIBCXXABI_HAS_NO_THREADS')
+    elif self.is_ww:
+      cflags.append('-D_LIBCXXABI_USE_FUTEX')
     match self.eh_mode:
       case Exceptions.NONE:
         cflags.append('-D_LIBCXXABI_NO_EXCEPTIONS')


### PR DESCRIPTION
When using `-sWASM_WORKERS`, `__cxa_guard_acquire` uses the `GlobalMutex`
implementation (`pthread_mutex_lock` + `pthread_cond_wait`), but libc links
pthread stubs where these are all noops.  This is not just a performance
problem — `GlobalMutex` does non-atomic read-then-write on the init byte
under a noop lock, so two workers can both see `UNSET` and both become the
initializer (double initialization / undefined behavior).

Switch to the `InitByteFutex` implementation which uses atomic CAS for
correctness.  Wait/wake are no-ops so losers spin in the CAS retry loop
rather than sleeping.  Cannot use real `memory.atomic.wait32` because it
traps on the main browser thread and there is no libcxxabi-compatible way
to detect the main thread (`emscripten_is_main_browser_thread` is JS-only).
In practice, contention on a single guard is rare and the spin is bounded
by the static constructor duration (typically sub-microsecond).

We hit this in production with `thread_local std::optional<T>` (non-trivial
destructor) — first access triggers `__cxa_thread_atexit` →
`static DtorsManager` → `__cxa_guard_acquire`.  When multiple WASM Workers
start executing tasks simultaneously, some workers busy-spin on the global
mutex indefinitely, causing timeouts.

Fixes #26277