### PR TITLE
Allow 1ms slop in blocking tests to fix flakiness (#26282)

### DIFF
--- a/test/core/test_poll_blocking.c
+++ b/test/core/test_poll_blocking.c
@@ -40,7 +40,7 @@ void test_timeout_without_fds() {
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= TIMEOUT_MS);
+  assert(duration >= TIMEOUT_MS - 1);
 }
 
 // Check if timeout works with fds without events
@@ -58,7 +58,7 @@ void test_timeout_with_fds_without_events() {
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= TIMEOUT_MS);
+  assert(duration >= TIMEOUT_MS - 1);
 
   close(pipe_a[0]); close(pipe_a[1]);
 }
@@ -96,7 +96,7 @@ void test_unblock_poll() {
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= TIMEOUT_MS);
+  assert(duration >= TIMEOUT_MS - 1);
 
   pthread_join(tid, NULL);
 
@@ -115,7 +115,7 @@ void *do_poll_in_thread(void * arg) {
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert((duration >= TIMEOUT_MS) && (duration < 4000));
+  assert((duration >= TIMEOUT_MS - 1) && (duration < 4000));
 
   return NULL;
 }

--- a/test/core/test_poll_blocking_asyncify.c
+++ b/test/core/test_poll_blocking_asyncify.c
@@ -37,7 +37,7 @@ void test_timeout_without_fds() {
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= 1000);
+  assert(duration >= 1000 - 1);
 }
 
 int pipe_shared[2];
@@ -69,7 +69,7 @@ void test_unblock_poll() {
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= 1000);
+  assert(duration >= 1000 - 1);
 
   close(pipe_a[0]); close(pipe_a[1]);
   close(pipe_shared[0]); close(pipe_shared[1]);

--- a/test/core/test_select_blocking.c
+++ b/test/core/test_select_blocking.c
@@ -39,7 +39,7 @@ void test_timeout_without_fds() {
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= TIMEOUT_MS);
+  assert(duration >= TIMEOUT_MS - 1);
 }
 
 // Check if timeout works with fds without events
@@ -61,7 +61,7 @@ void test_timeout_with_fds_without_events() {
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= TIMEOUT_MS);
+  assert(duration >= TIMEOUT_MS - 1);
 
   close(pipe_a[0]); close(pipe_a[1]);
 }
@@ -100,7 +100,7 @@ void test_unblock_select() {
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert(duration >= TIMEOUT_MS);
+  assert(duration >= TIMEOUT_MS - 1);
 
   pthread_join(tid, NULL);
 
@@ -126,7 +126,7 @@ void *do_select_in_thread(void * arg) {
 
   int64_t duration = timeval_delta_ms(&begin, &end);
   printf(" -> duration: %lld ms\n", duration);
-  assert((duration >= TIMEOUT_MS) && (duration < 4000));
+  assert((duration >= TIMEOUT_MS - 1) && (duration < 4000));
 
   return NULL;
 }


### PR DESCRIPTION
On the Chromium CI's node.js, setTimeout seems to be sometimes firing 1ms early relative to Date.now(), which caused these tests to fail their strict duration assertions. Allowing 1ms of slop resolves this without compromising the intent of the test.