### PR TITLE
test_benchmark.py: Don't pass `args` to benchmark build method

### DIFF
--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -161,7 +161,7 @@ class NativeBenchmarker(Benchmarker):
     self.cxx = cxx
     self.args = args or [OPTIMIZATIONS]
 
-  def build(self, parent, filename, args, shared_args, emcc_args, native_args, native_exec, lib_builder):
+  def build(self, parent, filename, shared_args, emcc_args, native_args, native_exec, lib_builder):
     native_args = native_args or []
     shared_args = shared_args or []
     self.parent = parent
@@ -214,7 +214,7 @@ class EmscriptenBenchmarker(Benchmarker):
       self.env.update(env)
     self.binaryen_opts = binaryen_opts or []
 
-  def build(self, parent, filename, args, shared_args, emcc_args, native_args, native_exec, lib_builder):
+  def build(self, parent, filename, shared_args, emcc_args, native_args, native_exec, lib_builder):
     emcc_args = emcc_args or []
     self.filename = filename
     llvm_root = self.env.get('LLVM') or config.LLVM_ROOT
@@ -295,7 +295,7 @@ class CheerpBenchmarker(Benchmarker):
     self.args = args or [OPTIMIZATIONS]
     self.binaryen_opts = binaryen_opts or []
 
-  def build(self, parent, filename, args, shared_args, emcc_args, native_args, native_exec, lib_builder):
+  def build(self, parent, filename, shared_args, emcc_args, native_args, native_exec, lib_builder):
     cheerp_args = [
       '-fno-math-errno',
     ]
@@ -457,7 +457,7 @@ class benchmark(common.RunnerCore):
         reps = 0
       baseline = b
       print('Running benchmarker: %s: %s' % (b.__class__.__name__, b.name))
-      b.build(self, filename, args, shared_args, emcc_args, native_args, native_exec, lib_builder)
+      b.build(self, filename, shared_args, emcc_args, native_args, native_exec, lib_builder)
       b.bench(args, output_parser, reps, expected_output)
       recorded_stats = b.display(baseline)
       if recorded_stats:


### PR DESCRIPTION
The `args` here are the runtime command line args for the benchmark program, not compiler flags, so do no need to be passed to the `build` method, and indeed are not used in any of them.

The args here is normally just `[DEFAULT_ARG]` which is `['4']` which would not make any sense as a compiler arg in any case.