### PR TITLE
Include HIDAPI functions in SDL2 port

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,8 @@ See docs/process.md for more on how version tagging works.
   C `bool` type rather than `int`.  For example `emscripten_proxy_sync` and
   `emscripten_is_main_runtime_thread`. (#26316)
 - SDL2 port updated from 2.32.8 to 2.32.10. (#26298)
+- SDL2 port updated to include stub functions for `SDL_hid_init()` and related
+  functions. (#26297)
 - The remaining launcher scripts (e.g. `emcc.bat`) were removed from the git
   repository.  These scripts are created by the `./bootstrap` script which
   must be run before the toolchain is usable (for folks using a git checkout of

--- a/test/browser/test_sdl2_misc.c
+++ b/test/browser/test_sdl2_misc.c
@@ -45,6 +45,10 @@ int main(int argc, char *argv[]) {
     assert(document.title === 'a custom window title');
   });
 
+  // Check if linking works with some of the HIDAPI functions added in SDL 2.0.18.
+  SDL_hid_init();
+  SDL_hid_exit();
+
   SDL_DestroyWindow(window);
   SDL_Quit();
 

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -53,7 +53,7 @@ def get(ports, settings, shared):
     dynapi/SDL_dynapi.c events/SDL_clipboardevents.c events/SDL_displayevents.c events/SDL_dropevents.c
     events/SDL_events.c events/SDL_gesture.c events/SDL_keyboard.c events/SDL_keysym_to_scancode.c
     events/SDL_scancode_tables.c events/SDL_mouse.c events/SDL_quit.c
-    events/SDL_touch.c events/SDL_windowevents.c file/SDL_rwops.c haptic/SDL_haptic.c
+    events/SDL_touch.c events/SDL_windowevents.c file/SDL_rwops.c haptic/SDL_haptic.c hidapi/SDL_hidapi.c
     joystick/controller_type.c joystick/SDL_gamecontroller.c joystick/SDL_joystick.c
     joystick/SDL_steam_virtual_gamepad.c
     power/SDL_power.c render/SDL_d3dmath.c render/SDL_render.c


### PR DESCRIPTION
This pull request updates the SDL2 port to include the stub implementations for SDL_hid_init() and related functions in SDL_hidapi.c that were added in SDL 2.0.18.

These functions are built for Emscritpen using the official SDL2 build systems. Including them in Emscripten's SDL2 port solves linker errors for software that use them.

Fixes: #26282

----

Additional source files for SDL 2.32.8 don't export any SDL2 API functions so I didn't add them to the source list in sdl2.py.