### PR TITLE
[embind] Support policies in allow_subclass

### DIFF
--- a/test/embind/test_embind_subclass_pointer.cpp
+++ b/test/embind/test_embind_subclass_pointer.cpp
@@ -1,0 +1,29 @@
+#include <emscripten/bind.h>
+
+using namespace emscripten;
+
+struct Base {
+    virtual ~Base() {}
+};
+
+struct Sub : Base {
+    Sub(Base* b) {}
+};
+
+struct SubWrapper : wrapper<Sub> {
+    EMSCRIPTEN_WRAPPER(SubWrapper);
+};
+
+EMSCRIPTEN_BINDINGS(test) {
+    class_<Base>("Base")
+        .constructor<>()
+        ;
+
+    class_<Sub>("Sub")
+        .allow_subclass<SubWrapper>("SubWrapper", constructor<Base*>(), allow_raw_pointer<arg<0>>())
+        ;
+}
+
+int main() {
+    return 0;
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3387,6 +3387,9 @@ More info: https://emscripten.org
   def test_embind_allow_raw_pointer(self):
     self.emcc(test_file('embind/test_embind_allow_raw_pointer.cpp'), ['-lembind'])
 
+  def test_embind_subclass_pointer(self):
+    self.emcc(test_file('embind/test_embind_subclass_pointer.cpp'), ['-lembind'])
+
   @is_slow_test
   @parameterized({
     '': [],


### PR DESCRIPTION
Add support for passing policies to the allow_subclass method in embind. This allows the use of constructors that require policies, such as those taking raw pointers, when enabling C++ subclassing from JavaScript.

Previously, allow_subclass only accepted a constructor argument, making it impossible to use policies like allow_raw_pointer with the generated 'implement' method.

Fixes #26270