### PR TITLE
Bugfix: Fix emrun --browser=open option for macOS 

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -1739,7 +1739,7 @@ def run(args):  # noqa: C901, PLR0912, PLR0915
       browser_exe = browser[0]
       browser_args = shlex.split(unwrap(options.browser_args))
 
-      if MACOS and ('safari' in browser_exe.lower() or browser_exe == 'open'):
+      if MACOS and 'safari' in browser_exe.lower():
         # Safari has a bug that a command line 'Safari http://page.com' does
         # not launch that page, but instead launches 'file:///http://page.com'.
         # To remedy this, must use the open -a command to run Safari, but


### PR DESCRIPTION
In #8179 it was decided, that on macOS, the default browser for `emrun` should be the system browser. And so it was implemented in #8243.

However, when fixing a seemingly unrelated Safari bug in #12034, the system browser option "open" was effectively removed. It since has the same effect, as choosing Safari.

I don't have a preference, whether the system browser or Safari should be the default. But when I explicitly choose `--browser=open`, I want my system browser.

Side note: Using Safari over brave for example, does not seem to improve my experience in any way. Both are equally detached, as they are launched with `open` and neither terminating the browser nor the emrun process stops the other.