### PR TITLE
Use bool return type for various low-level emscripten APIs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 5.0.2 (in development)
 ----------------------
+- Several low level emscripten APIs that return success/failure now return the
+  C `bool` type rather than `int`.  For example `emscripten_proxy_sync` and
+  `emscripten_is_main_runtime_thread`. (#26316)
 - SDL2 port updated from 2.32.8 to 2.32.10. (#26298)
 - The remaining launcher scripts (e.g. `emcc.bat`) were removed from the git
   repository.  These scripts are created by the `./bootstrap` script which

--- a/site/source/docs/api_reference/proxying.h.rst
+++ b/site/source/docs/api_reference/proxying.h.rst
@@ -72,21 +72,21 @@ Functions
 
   Signal the end of a task proxied with ``emscripten_proxy_sync_with_ctx``.
 
-.. c:function:: int emscripten_proxy_async(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void* arg)
+.. c:function:: bool emscripten_proxy_async(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void* arg)
 
   Enqueue ``func`` to be called with argument ``arg`` on the given queue and
   thread then return immediately without waiting for ``func`` to be executed.
-  Returns 1 if the work was successfully enqueued or 0 otherwise.
+  Returns true if the work was successfully enqueued or false otherwise.
 
-.. c:function:: int emscripten_proxy_sync(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void* arg)
+.. c:function:: bool emscripten_proxy_sync(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void* arg)
 
   Enqueue ``func`` to be called with argument ``arg`` on the given queue and
   thread then wait for ``func`` to be executed synchronously before returning.
-  Returns 1 if the ``func`` was successfully completed and 0 otherwise,
+  Returns true if the ``func`` was successfully completed and false otherwise,
   including if the target thread is canceled or exits before the work is
   completed.
 
-.. c:function:: int emscripten_proxy_sync_with_ctx(em_proxying_queue* q, pthread_t target_thread, void (*func)(em_proxying_ctx*, void*), void* arg)
+.. c:function:: bool emscripten_proxy_sync_with_ctx(em_proxying_queue* q, pthread_t target_thread, void (*func)(em_proxying_ctx*, void*), void* arg)
 
   The same as ``emscripten_proxy_sync`` except that instead of waiting for the
   proxied function to return, it waits for the proxied task to be explicitly
@@ -94,24 +94,24 @@ Functions
   ``emscripten_proxy_finish`` itself; it could instead store the context pointer
   and call ``emscripten_proxy_finish`` at an arbitrary later time.
 
-.. c:function:: int emscripten_proxy_callback(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void (*callback)(void*), void (*cancel)(void*), void* arg)
+.. c:function:: bool emscripten_proxy_callback(em_proxying_queue* q, pthread_t target_thread, void (*func)(void*), void (*callback)(void*), void (*cancel)(void*), void* arg)
 
   Enqueue ``func`` on the given queue and thread. Once (and if) it finishes
   executing, it will asynchronously proxy ``callback`` back to the current
   thread on the same queue, or if the target thread dies before the work can be
   completed, ``cancel`` will be proxied back instead. All three function will
-  receive the same argument, ``arg``. Returns 1 if ``func`` was successfully
-  enqueued and the target thread notified or 0 otherwise.
+  receive the same argument, ``arg``. Returns true if ``func`` was successfully
+  enqueued and the target thread notified or false otherwise.
 
-.. c:function:: int emscripten_proxy_callback_with_ctx(em_proxying_queue* q, pthread_t target_thread, void (*func)(em_proxying_ctx*, void*), void (*callback)(void*), void (*cancel)(void*), void* arg)
+.. c:function:: bool emscripten_proxy_callback_with_ctx(em_proxying_queue* q, pthread_t target_thread, void (*func)(em_proxying_ctx*, void*), void (*callback)(void*), void (*cancel)(void*), void* arg)
 
   Enqueue ``func`` on the given queue and thread. Once (and if) it finishes the
   task by calling ``emscripten_proxy_finish`` on the given ``em_proxying_ctx``,
   it will asynchronously proxy ``callback`` back to the current thread on the
   same queue, or if the target thread dies before the work can be completed,
   ``cancel`` will be proxied back instead. All three function will receive the
-  same argument, ``arg``. Returns 1 if ``func`` was successfully enqueued and
-  the target thread notified or 0 otherwise.
+  same argument, ``arg``. Returns true if ``func`` was successfully enqueued and
+  the target thread notified or false otherwise.
 
 C++ API
 -------

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -133,6 +133,8 @@ int emscripten_get_worker_queue_size(worker_handle worker);
 // misc.
 
 long emscripten_get_compiler_setting(const char *name);
+
+// Returns the value of -sASYNCIFY.  Can be 0, 1, or 2 (in the case of JSPI).
 int emscripten_has_asyncify(void);
 
 void emscripten_debugger(void);

--- a/system/include/emscripten/heap.h
+++ b/system/include/emscripten/heap.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <emscripten/emscripten.h>
@@ -31,7 +32,8 @@ uintptr_t *emscripten_get_sbrk_ptr(void);
 // src/settings.js variables MEMORY_GROWTH_GEOMETRIC_STEP,
 // MEMORY_GROWTH_GEOMETRIC_CAP and MEMORY_GROWTH_LINEAR_STEP. This function
 // cannot be used to shrink the size of the memory.
-int emscripten_resize_heap(size_t requested_size) EM_IMPORT(emscripten_resize_heap);
+// Returns true on success, false otherwise.
+bool emscripten_resize_heap(size_t requested_size) EM_IMPORT(emscripten_resize_heap);
 
 // Returns the current size of the WebAssembly memory (referred to as heap for
 // legacy reason).

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -9,6 +9,7 @@
 
 #include <inttypes.h>
 #include <pthread.h>
+#include <stdbool.h>
 
 #include <emscripten/html5.h>  // for EMSCRIPTEN_RESULT
 #include <emscripten/atomic.h>
@@ -24,7 +25,7 @@ extern "C" {
 // pthread_create(), and the compiled page was built with threading support
 // enabled. If this returns 0, calls to pthread_create() will fail with return
 // code EAGAIN.
-int emscripten_has_threading_support(void);
+bool emscripten_has_threading_support(void);
 
 // Returns the number of logical cores on the system.
 int emscripten_num_logical_cores(void);
@@ -39,14 +40,14 @@ int emscripten_futex_wait(volatile void/*uint32_t*/ * _Nonnull addr, uint32_t va
 // Returns -EINVAL if addr is null.
 int emscripten_futex_wake(volatile void/*uint32_t*/ * _Nonnull addr, int count);
 
-// Returns 1 if the current thread is the thread that hosts the Emscripten
+// Returns true if the current thread is the thread that hosts the Emscripten
 // runtime.
-int emscripten_is_main_runtime_thread(void);
+bool emscripten_is_main_runtime_thread(void);
 
-// Returns 1 if the current thread is the main browser thread.  In the case that
-// the emscripten module is run in a worker there may be no pthread for which
-// this returns 1.
-int emscripten_is_main_browser_thread(void);
+// Returns true if the current thread is the main browser thread.  In the case
+// that the Emscripten module is started in a worker there will be no thread
+// for which this returns true.
+bool emscripten_is_main_browser_thread(void);
 
 // A temporary workaround to issue
 // https://github.com/emscripten-core/emscripten/issues/3495:

--- a/system/include/emscripten/wasm_worker.h
+++ b/system/include/emscripten/wasm_worker.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <emscripten/atomic.h>
@@ -115,7 +116,7 @@ int emscripten_navigator_hardware_concurrency(void);
 // accesses, behavior differs across browsers, see
 //  - https://bugzil.la/1246139
 //  - https://bugs.chromium.org/p/chromium/issues/detail?id=1167449
-int emscripten_atomics_is_lock_free(int byteWidth);
+bool emscripten_atomics_is_lock_free(int byteWidth);
 
 #define emscripten_lock_t volatile uint32_t
 

--- a/system/lib/pthread/em_task_queue.h
+++ b/system/lib/pthread/em_task_queue.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <pthread.h>
 
 #include "proxying_notification_state.h"
@@ -58,22 +59,22 @@ void em_task_queue_execute(em_task_queue* queue);
 void em_task_queue_cancel(em_task_queue* queue);
 
 // Not thread safe.
-static inline int em_task_queue_is_empty(em_task_queue* queue) {
+static inline bool em_task_queue_is_empty(em_task_queue* queue) {
   return queue->head == queue->tail;
 }
 
 // Not thread safe.
-static inline int em_task_queue_is_full(em_task_queue* queue) {
+static inline bool em_task_queue_is_full(em_task_queue* queue) {
   return queue->head == (queue->tail + 1) % queue->capacity;
 }
 
-// Not thread safe. Returns 1 on success and 0 on failure.
-int em_task_queue_enqueue(em_task_queue* queue, task t);
+// Not thread safe. Returns true on success and false on failure.
+bool em_task_queue_enqueue(em_task_queue* queue, task t);
 
 // Not thread safe. Assumes the queue is not empty.
 task em_task_queue_dequeue(em_task_queue* queue);
 
 // Atomically enqueue the task and schedule the queue to be executed next time
-// its owning thread returns to its event loop. Returns 1 on success and 0
-// otherwise. Internally locks the queue.
-int em_task_queue_send(em_task_queue* queue, task t);
+// its owning thread returns to its event loop. Returns true on success and
+// false otherwise. Internally locks the queue.
+bool em_task_queue_send(em_task_queue* queue, task t);

--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -17,7 +17,7 @@
 #include <emscripten/threading.h>
 #include <emscripten/emscripten.h>
 
-int emscripten_has_threading_support() { return 0; }
+bool emscripten_has_threading_support() { return false; }
 
 int emscripten_num_logical_cores() { return 1; }
 
@@ -32,7 +32,10 @@ int emscripten_futex_wake(volatile void /*uint32_t*/* addr, int count) {
   return 0; // success
 }
 
-int emscripten_is_main_runtime_thread() { return 1; }
+bool emscripten_is_main_runtime_thread() {
+  // TODO: We probably shouldn't be returning true here in WASM_WORKERS builds.
+  return true;
+}
 
 void emscripten_main_thread_process_queued_calls() {
   // nop

--- a/system/lib/pthread/proxying_stub.c
+++ b/system/lib/pthread/proxying_stub.c
@@ -25,23 +25,23 @@ void emscripten_proxy_execute_queue(em_proxying_queue* q) { abort(); }
 
 void emscripten_proxy_finish(em_proxying_ctx* ctx) { abort(); }
 
-int emscripten_proxy_async(em_proxying_queue* q,
+bool emscripten_proxy_async(em_proxying_queue* q,
+                            pthread_t target_thread,
+                            void (*func)(void*),
+                            void* arg) {
+  abort();
+}
+
+bool emscripten_proxy_sync(em_proxying_queue* q,
                            pthread_t target_thread,
                            void (*func)(void*),
                            void* arg) {
   abort();
 }
 
-int emscripten_proxy_sync(em_proxying_queue* q,
-                          pthread_t target_thread,
-                          void (*func)(void*),
-                          void* arg) {
-  abort();
-}
-
-int emscripten_proxy_sync_with_ctx(em_proxying_queue* q,
-                                   pthread_t target_thread,
-                                   void (*func)(em_proxying_ctx*, void*),
-                                   void* arg) {
+bool emscripten_proxy_sync_with_ctx(em_proxying_queue* q,
+                                    pthread_t target_thread,
+                                    void (*func)(em_proxying_ctx*, void*),
+                                    void* arg) {
   abort();
 }

--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -128,7 +128,7 @@ size_t emscripten_get_heap_max() {
   return emscripten_get_heap_size();
 }
 
-int emscripten_resize_heap(size_t size) {
+bool emscripten_resize_heap(size_t size) {
 #if defined(EMSCRIPTEN_MEMORY_GROWTH)
   size_t old_size = __builtin_wasm_memory_size(0) * WASM_PAGE_SIZE;
   assert(old_size < size);
@@ -139,10 +139,10 @@ int emscripten_resize_heap(size_t size) {
     // Success, update JS (see https://github.com/WebAssembly/WASI/issues/82)
     emscripten_notify_memory_growth(0);
 #endif
-    return 1;
+    return true;
   }
 #endif
-  return 0;
+  return false;
 }
 
 // Call clock_gettime with a particular clock and return the result in ms.

--- a/test/codesize/test_codesize_mem_O3_grow_standalone.json
+++ b/test/codesize/test_codesize_mem_O3_grow_standalone.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4107,
   "a.out.js.gz": 1992,
-  "a.out.nodebug.wasm": 5547,
-  "a.out.nodebug.wasm.gz": 2598,
-  "total": 9654,
-  "total_gz": 4590,
+  "a.out.nodebug.wasm": 5549,
+  "a.out.nodebug.wasm.gz": 2593,
+  "total": 9656,
+  "total_gz": 4585,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7820,
   "a.out.js.gz": 3849,
-  "a.out.nodebug.wasm": 19729,
-  "a.out.nodebug.wasm.gz": 9140,
-  "total": 27549,
-  "total_gz": 12989,
+  "a.out.nodebug.wasm": 19726,
+  "a.out.nodebug.wasm.gz": 9135,
+  "total": 27546,
+  "total_gz": 12984,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 8243,
   "a.out.js.gz": 4056,
-  "a.out.nodebug.wasm": 19730,
-  "a.out.nodebug.wasm.gz": 9140,
-  "total": 27973,
-  "total_gz": 13196,
+  "a.out.nodebug.wasm": 19727,
+  "a.out.nodebug.wasm.gz": 9137,
+  "total": 27970,
+  "total_gz": 13193,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",


### PR DESCRIPTION
We converted a `EM_BOOL` from `int` to `bool` without too much fallout so
I think should a backwards compatible change for all users.

It is of course conceivable to construct code that would notice this change (e.g. `sizeof(emscripten_is_main_runtime_thread())` but its seems extremely unlikely.

I think using the explicit bool type helps make these function more
clear, and avoids confusion with tradition "0 means success" C
functions.
