### PR TITLE
Add WS dep to emscripten_websocket_new (fixes #26310)

### DIFF
--- a/src/lib/libwebsocket.js
+++ b/src/lib/libwebsocket.js
@@ -275,6 +275,7 @@ var LibraryWebSocket = {
     return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },
 
+  emscripten_websocket_new__deps: ['$WS'],
   emscripten_websocket_new__proxy: 'sync',
   emscripten_websocket_new: (createAttributes) => {
     if (!globalThis.WebSocket) {


### PR DESCRIPTION
This is a single-line fix to add a missing `$WS` dependency to the `emscripten_websocket_new` function.

See https://github.com/emscripten-core/emscripten/issues/26310 for details.

Not really a high-priority fix, since I guess `emscripten_websocket_new` is rarely used alone, and the other `emscripten_websocket_*` functions will pull in the same dependency anyway (for the same reason I think it's not worth to add a new test for this specific problem - I did test the fix locally though with the code in the issue).