### PR TITLE
Don't use quotes for `worker_threads` properties. NFC

### DIFF
--- a/src/closure-externs/node-externs.js
+++ b/src/closure-externs/node-externs.js
@@ -144,3 +144,25 @@ path.isAbsolute;
 path.posix;
 
 crypto.randomFillSync;
+
+/**
+ * @suppress {duplicate}
+ */
+var worker_threads = {};
+
+/**
+ * @type {boolean}
+ */
+worker_threads.isMainThread;
+
+/**
+ * @type {function()}
+ */
+worker_threads.Worker;
+
+/**
+ * @type {Object}
+ */
+worker_threads.workerData;
+
+worker_threads.parentPort;

--- a/src/pthread_esm_startup.mjs
+++ b/src/pthread_esm_startup.mjs
@@ -19,13 +19,13 @@ if ({{{ nodeDetectionCode() }}}) {
   globalThis.self = globalThis;
   var worker_threads = await import('node:worker_threads');
   globalThis.Worker = worker_threads.Worker;
-  var parentPort = worker_threads['parentPort'];
+  var parentPort = worker_threads.parentPort;
   // Deno and Bun already have `postMessage` defined on the global scope and
   // deliver messages to `globalThis.onmessage`, so we must not duplicate that
   // behavior here if `postMessage` is already present.
   if (!globalThis.postMessage) {
     parentPort.on('message', (msg) => globalThis.onmessage?.({ data: msg }));
-    globalThis.postMessage = (msg) => parentPort['postMessage'](msg);
+    globalThis.postMessage = (msg) => parentPort.postMessage(msg);
   }
 }
 #endif

--- a/src/runtime_common.js
+++ b/src/runtime_common.js
@@ -39,13 +39,13 @@ var readyPromiseResolve, readyPromiseReject;
 if (ENVIRONMENT_IS_NODE && {{{ ENVIRONMENT_IS_WORKER_THREAD() }}}) {
   // Create as web-worker-like an environment as we can.
   globalThis.self = globalThis;
-  var parentPort = worker_threads['parentPort'];
+  var parentPort = worker_threads.parentPort;
   // Deno and Bun already have `postMessage` defined on the global scope and
   // deliver messages to `globalThis.onmessage`, so we must not duplicate that
   // behavior here if `postMessage` is already present.
   if (!globalThis.postMessage) {
     parentPort.on('message', (msg) => globalThis.onmessage?.({ data: msg }));
-    globalThis.postMessage = (msg) => parentPort['postMessage'](msg);
+    globalThis.postMessage = (msg) => parentPort.postMessage(msg);
   }
   // Node.js Workers do not pass postMessage()s and uncaught exception events to the parent
   // thread necessarily in the same order where they were generated in sequential program order.

--- a/src/shell.js
+++ b/src/shell.js
@@ -124,10 +124,10 @@ if (ENVIRONMENT_IS_NODE) {
 #if PTHREADS
   // Under node we set `workerData` to `em-pthread` to signal that the worker
   // is hosting a pthread.
-  ENVIRONMENT_IS_PTHREAD = ENVIRONMENT_IS_WORKER && worker_threads['workerData'] == 'em-pthread'
+  ENVIRONMENT_IS_PTHREAD = ENVIRONMENT_IS_WORKER && worker_threads.workerData == 'em-pthread'
 #endif // PTHREADS
 #if WASM_WORKERS
-  ENVIRONMENT_IS_WASM_WORKER = ENVIRONMENT_IS_WORKER && worker_threads['workerData'] == 'em-ww'
+  ENVIRONMENT_IS_WASM_WORKER = ENVIRONMENT_IS_WORKER && worker_threads.workerData == 'em-ww'
 #endif
 #endif // PTHREADS || WASM_WORKERS
 }

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -74,7 +74,7 @@ var ENVIRONMENT_IS_WASM_WORKER = {{{ wasmWorkerDetection() }}};
 if (ENVIRONMENT_IS_NODE) {
   // The way we signal to a worker that it is hosting a pthread is to construct
   // it with a specific name.
-  ENVIRONMENT_IS_WASM_WORKER = worker_threads['workerData'] == 'em-ww'
+  ENVIRONMENT_IS_WASM_WORKER = worker_threads.workerData == 'em-ww'
 }
 #endif
 
@@ -156,7 +156,7 @@ if (ENVIRONMENT_IS_NODE) {
   ENVIRONMENT_IS_WORKER = !worker_threads.isMainThread;
   // Under node we set `workerData` to `em-pthread` to signal that the worker
   // is hosting a pthread.
-  ENVIRONMENT_IS_PTHREAD = ENVIRONMENT_IS_WORKER && worker_threads['workerData'] == 'em-pthread'
+  ENVIRONMENT_IS_PTHREAD = ENVIRONMENT_IS_WORKER && worker_threads.workerData == 'em-pthread'
 #if !EXPORT_ES6
   _scriptName = __filename;
 #endif

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7820,
-  "a.out.js.gz": 3849,
+  "a.out.js": 7894,
+  "a.out.js.gz": 3862,
   "a.out.nodebug.wasm": 19726,
   "a.out.nodebug.wasm.gz": 9135,
-  "total": 27546,
-  "total_gz": 12984,
+  "total": 27620,
+  "total_gz": 12997,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 8243,
-  "a.out.js.gz": 4056,
+  "a.out.js": 8316,
+  "a.out.js.gz": 4063,
   "a.out.nodebug.wasm": 19727,
   "a.out.nodebug.wasm.gz": 9137,
-  "total": 27970,
-  "total_gz": 13193,
+  "total": 28043,
+  "total_gz": 13200,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",


### PR DESCRIPTION
Instead, make closure compiler aware of the various properties.

The reason or the codesize change is that I think the unquoted `isMainThread` was
being minified incorrectly in some cases before this change.

