### PR TITLE
Remove NODEJS_CATCH_EXIT setting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 5.0.2 (in development)
 ----------------------
+- The `NODEJS_CATCH_EXIT` setting was removed.  This setting was disabled by
+  default in #22257, and is no longer used by emscripten itself.  It is also
+  problematic as it injects a global process.on handler.  It is easy to replace
+  with a simple `--pre-js` file for those that require it. (#26326)
 - Several low level emscripten APIs that return success/failure now return the
   C `bool` type rather than `int`.  For example `emscripten_proxy_sync` and
   `emscripten_is_main_runtime_thread`. (#26316)

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1168,22 +1168,6 @@ https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-
 
 Default value: true
 
-.. _nodejs_catch_exit:
-
-NODEJS_CATCH_EXIT
-=================
-
-Emscripten throws an ExitStatus exception to unwind when exit() is called.
-Without this setting enabled this can show up as a top level unhandled
-exception.
-
-With this setting enabled a global uncaughtException handler is used to
-catch and handle ExitStatus exceptions.  However, this means all other
-uncaught exceptions are also caught and re-thrown, which is not always
-desirable.
-
-Default value: false
-
 .. _nodejs_catch_rejection:
 
 NODEJS_CATCH_REJECTION
@@ -3563,3 +3547,4 @@ for backwards compatibility with older versions:
  - ``ASYNCIFY_LAZY_LOAD_CODE``: No longer supported (Valid values: [0])
  - ``USE_WEBGPU``: No longer supported; replaced by --use-port=emdawnwebgpu, which implements a newer (but incompatible) version of webgpu.h - see tools/ports/emdawnwebgpu.py (Valid values: [0])
  - ``PROXY_TO_WORKER``: No longer supported (Valid values: [0])
+ - ``NODEJS_CATCH_EXIT``: No longer supported (Valid values: [0])

--- a/src/settings.js
+++ b/src/settings.js
@@ -789,18 +789,6 @@ var EXCEPTION_STACK_TRACES = false;
 // [compile+link]
 var WASM_LEGACY_EXCEPTIONS = true;
 
-// Emscripten throws an ExitStatus exception to unwind when exit() is called.
-// Without this setting enabled this can show up as a top level unhandled
-// exception.
-//
-// With this setting enabled a global uncaughtException handler is used to
-// catch and handle ExitStatus exceptions.  However, this means all other
-// uncaught exceptions are also caught and re-thrown, which is not always
-// desirable.
-//
-// [link]
-var NODEJS_CATCH_EXIT = false;
-
 // Catch unhandled rejections in node. This only affects versions of node older
 // than 15.  Without this, old version node will print a warning, but exit
 // with a zero return code.  With this setting enabled, we handle any unhandled

--- a/src/shell.js
+++ b/src/shell.js
@@ -225,18 +225,6 @@ if (ENVIRONMENT_IS_NODE) {
   }
 #endif
 
-#if NODEJS_CATCH_EXIT
-  process.on('uncaughtException', (ex) => {
-    // suppress ExitStatus exceptions from showing an error
-#if RUNTIME_DEBUG
-    dbg(`node: uncaughtException: ${ex}`)
-#endif
-    if (ex !== 'unwind' && !(ex instanceof ExitStatus) && !(ex.context instanceof ExitStatus)) {
-      throw ex;
-    }
-  });
-#endif
-
 #if NODEJS_CATCH_REJECTION
   // Without this older versions of node (< v15) will log unhandled rejections
   // but return 0, which is not normally the desired behaviour.  This is

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1220,12 +1220,6 @@ f.close()
     self.expect_fail([compiler, test_file('hello_world.c'), '-sMODULARIZE', '-sNODEJS_CATCH_REJECTION', '-o', 'out.js'])
     self.assertFalse(os.path.exists('out.js'))
 
-  @with_both_compilers
-  def test_failure_modularize_and_catch_exit(self, compiler):
-    # Test that if sMODULARIZE and sNODEJS_CATCH_EXIT are both enabled, then emcc shouldn't succeed, and shouldn't produce an output file.
-    self.expect_fail([compiler, test_file('hello_world.c'), '-sMODULARIZE', '-sNODEJS_CATCH_EXIT', '-o', 'out.js'])
-    self.assertFalse(os.path.exists('out.js'))
-
   def test_use_cxx(self):
     create_file('empty_file', ' ')
     dash_xc = self.run_process([EMCC, '-v', '-xc', 'empty_file'], stderr=PIPE).stderr
@@ -4205,37 +4199,6 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
     # Check that main.js (which requires test.js) completes successfully when run in node.js
     # in order to check that the exports are indeed functioning correctly.
     self.assertContained('bufferTest finished', self.run_js('main.js'))
-
-  @requires_node
-  def test_node_catch_exit(self):
-    # Test that in top level JS exceptions are caught and rethrown when NODEJS_EXIT_CATCH=1
-    # is set but not by default.
-    create_file('count.c', '''
-      #include <string.h>
-      int count(const char *str) {
-        return (int)strlen(str);
-      }
-    ''')
-
-    create_file('index.js', '''
-      const count = require('./count.js');
-
-      console.log(xxx); //< here is the ReferenceError
-    ''')
-
-    reference_error_text = 'console.log(xxx); //< here is the ReferenceError'
-
-    self.run_process([EMCC, 'count.c', '-o', 'count.js', '-sNODEJS_CATCH_EXIT=1'])
-
-    # Check that the ReferenceError is caught and rethrown and thus the original error line is masked
-    self.assertNotContained(reference_error_text,
-                            self.run_js('index.js', assert_returncode=NON_ZERO))
-
-    self.run_process([EMCC, 'count.c', '-o', 'count.js'])
-
-    # Check that the ReferenceError is not caught, so we see the error properly
-    self.assertContained(reference_error_text,
-                         self.run_js('index.js', assert_returncode=NON_ZERO))
 
   @requires_node
   def test_exported_runtime_methods(self):

--- a/tools/link.py
+++ b/tools/link.py
@@ -1859,8 +1859,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       diagnostics.warning('unused-command-line-argument', 'NODERAWFS ignored since `node` not in `ENVIRONMENT`')
     if settings.NODE_CODE_CACHING:
       diagnostics.warning('unused-command-line-argument', 'NODE_CODE_CACHING ignored since `node` not in `ENVIRONMENT`')
-    if settings.NODEJS_CATCH_EXIT:
-      diagnostics.warning('unused-command-line-argument', 'NODEJS_CATCH_EXIT ignored since `node` not in `ENVIRONMENT`')
     if settings.NODEJS_CATCH_REJECTION and 'NODEJS_CATCH_REJECTION' in user_settings:
       diagnostics.warning('unused-command-line-argument', 'NODEJS_CATCH_REJECTION ignored since `node` not in `ENVIRONMENT`')
 

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -146,7 +146,6 @@ INCOMPATIBLE_SETTINGS = [
     ('SEPARATE_DWARF', 'WASM2JS', 'as there is no wasm file'),
     ('GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS', 'NO_GL_SUPPORT_SIMPLE_ENABLE_EXTENSIONS', None),
     ('MODULARIZE', 'NODEJS_CATCH_REJECTION', None),
-    ('MODULARIZE', 'NODEJS_CATCH_EXIT', None),
     ('LEGACY_VM_SUPPORT', 'MEMORY64', None),
     ('CROSS_ORIGIN', 'NO_DYNAMIC_EXECUTION', None),
     ('CROSS_ORIGIN', 'NO_PTHREADS', None),
@@ -252,6 +251,7 @@ LEGACY_SETTINGS = [
     ['ASYNCIFY_LAZY_LOAD_CODE', [0], 'No longer supported'],
     ['USE_WEBGPU', [0], 'No longer supported; replaced by --use-port=emdawnwebgpu, which implements a newer (but incompatible) version of webgpu.h - see tools/ports/emdawnwebgpu.py'],
     ['PROXY_TO_WORKER', [0], 'No longer supported'],
+    ['NODEJS_CATCH_EXIT', [0], 'No longer supported'],
 ]
 
 user_settings: dict[str, str] = {}


### PR DESCRIPTION
This setting has not been enabled by default since #22257.  

It is not used anywhere internally in emscripten test suite anymore.

Its is problematic because it installs process-wide global exit handler (so it doesn't work well with other modules or other code).

It should not be needed in general since most code paths that enter the module are wrapped in try/catch that handled ExitStatus.

Its trivial to replace with a `--pre-js` or some other external JS snippet.