### PR TITLE
Remove NODEJS_CATCH_REJECTION

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -979,7 +979,6 @@ jobs:
             other.test_gen_struct_info
             other.test_native_call_before_init
             other.test_js_optimizer_verbose
-            other.test_node_unhandled_rejection
             other.test_file_packager_separate_metadata
             other.test_full_js_library*
             core2.test_hello_world
@@ -1042,7 +1041,6 @@ jobs:
           test_targets: "-v
             other.test_gen_struct_info
             other.test_native_call_before_init
-            other.test_node_unhandled_rejection
             other.test_js_optimizer_verbose
             other.test_min_node_version
             other.test_node_emscripten_num_logical_cores
@@ -1065,7 +1063,6 @@ jobs:
             other.test_deterministic
             other.test_gen_struct_info
             other.test_native_call_before_init
-            other.test_node_unhandled_rejection
             other.test_*growable_arraybuffers
             other.test_add_js_function_bigint_memory64
             other.test_js_optimizer_verbose

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,11 @@ See docs/process.md for more on how version tagging works.
 
 5.0.2 (in development)
 ----------------------
+- The `NODEJS_CATCH_REJECTION` setting was removed. This setting only has an
+  effect when targeting very old versions of node (< 15).  Its trivial to replace
+  with a simple `--pre-js` file or with the `--unhandled-rejections=strict`
+  command line flag which it essentially emulates. Versions of node above v15
+  have this behavior by default. (#26330)
 - The `NODEJS_CATCH_EXIT` setting was removed.  This setting was disabled by
   default in #22257, and is no longer used by emscripten itself.  It is also
   problematic as it injects a global process.on handler.  It is easy to replace

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1168,21 +1168,6 @@ https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-
 
 Default value: true
 
-.. _nodejs_catch_rejection:
-
-NODEJS_CATCH_REJECTION
-======================
-
-Catch unhandled rejections in node. This only affects versions of node older
-than 15.  Without this, old version node will print a warning, but exit
-with a zero return code.  With this setting enabled, we handle any unhandled
-rejection and throw an exception, which will cause the process to exit
-immediately with a non-0 return code.
-This is not needed in Node 15+ so this setting will default to false if
-MIN_NODE_VERSION is 150000 or above.
-
-Default value: true
-
 .. _asyncify:
 
 ASYNCIFY
@@ -3548,3 +3533,4 @@ for backwards compatibility with older versions:
  - ``USE_WEBGPU``: No longer supported; replaced by --use-port=emdawnwebgpu, which implements a newer (but incompatible) version of webgpu.h - see tools/ports/emdawnwebgpu.py (Valid values: [0])
  - ``PROXY_TO_WORKER``: No longer supported (Valid values: [0])
  - ``NODEJS_CATCH_EXIT``: No longer supported (Valid values: [0])
+ - ``NODEJS_CATCH_REJECTION``: No longer supported (Valid values: [0])

--- a/src/settings.js
+++ b/src/settings.js
@@ -789,16 +789,6 @@ var EXCEPTION_STACK_TRACES = false;
 // [compile+link]
 var WASM_LEGACY_EXCEPTIONS = true;
 
-// Catch unhandled rejections in node. This only affects versions of node older
-// than 15.  Without this, old version node will print a warning, but exit
-// with a zero return code.  With this setting enabled, we handle any unhandled
-// rejection and throw an exception, which will cause the process to exit
-// immediately with a non-0 return code.
-// This is not needed in Node 15+ so this setting will default to false if
-// MIN_NODE_VERSION is 150000 or above.
-// [link]
-var NODEJS_CATCH_REJECTION = true;
-
 // Whether to support async operations in the compiled code. This makes it
 // possible to call JS functions from synchronous-looking code in C/C++.
 //

--- a/src/shell.js
+++ b/src/shell.js
@@ -225,18 +225,6 @@ if (ENVIRONMENT_IS_NODE) {
   }
 #endif
 
-#if NODEJS_CATCH_REJECTION
-  // Without this older versions of node (< v15) will log unhandled rejections
-  // but return 0, which is not normally the desired behaviour.  This is
-  // not be needed with node v15 and about because it is now the default
-  // behaviour:
-  // See https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
-  var nodeMajor = process.versions.node.split(".")[0];
-  if (nodeMajor < 15) {
-    process.on('unhandledRejection', (reason) => { throw reason; });
-  }
-#endif
-
   quit_ = (status, toThrow) => {
     process.exitCode = status;
     throw toThrow;

--- a/tools/link.py
+++ b/tools/link.py
@@ -1368,15 +1368,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
 
   check_browser_versions()
 
-  if settings.MIN_NODE_VERSION >= 150000:
-    default_setting('NODEJS_CATCH_REJECTION', 0)
-
-  # Do not catch rejections or exits in modularize mode, as these options
-  # are for use when running emscripten modules standalone
-  # see https://github.com/emscripten-core/emscripten/issues/18723#issuecomment-1429236996
-  if settings.MODULARIZE:
-    default_setting('NODEJS_CATCH_REJECTION', 0)
-
   if settings.POLYFILL:
     # Emscripten requires certain ES6+ constructs by default in library code
     # - (various ES6 operators available in all browsers listed below)
@@ -1859,8 +1850,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       diagnostics.warning('unused-command-line-argument', 'NODERAWFS ignored since `node` not in `ENVIRONMENT`')
     if settings.NODE_CODE_CACHING:
       diagnostics.warning('unused-command-line-argument', 'NODE_CODE_CACHING ignored since `node` not in `ENVIRONMENT`')
-    if settings.NODEJS_CATCH_REJECTION and 'NODEJS_CATCH_REJECTION' in user_settings:
-      diagnostics.warning('unused-command-line-argument', 'NODEJS_CATCH_REJECTION ignored since `node` not in `ENVIRONMENT`')
 
   settings.PRE_JS_FILES = options.pre_js
   settings.POST_JS_FILES = options.post_js

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -145,7 +145,6 @@ INCOMPATIBLE_SETTINGS = [
     ('MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION', 'SINGLE_FILE', None),
     ('SEPARATE_DWARF', 'WASM2JS', 'as there is no wasm file'),
     ('GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS', 'NO_GL_SUPPORT_SIMPLE_ENABLE_EXTENSIONS', None),
-    ('MODULARIZE', 'NODEJS_CATCH_REJECTION', None),
     ('LEGACY_VM_SUPPORT', 'MEMORY64', None),
     ('CROSS_ORIGIN', 'NO_DYNAMIC_EXECUTION', None),
     ('CROSS_ORIGIN', 'NO_PTHREADS', None),
@@ -252,6 +251,7 @@ LEGACY_SETTINGS = [
     ['USE_WEBGPU', [0], 'No longer supported; replaced by --use-port=emdawnwebgpu, which implements a newer (but incompatible) version of webgpu.h - see tools/ports/emdawnwebgpu.py'],
     ['PROXY_TO_WORKER', [0], 'No longer supported'],
     ['NODEJS_CATCH_EXIT', [0], 'No longer supported'],
+    ['NODEJS_CATCH_REJECTION', [0], 'No longer supported'],
 ]
 
 user_settings: dict[str, str] = {}


### PR DESCRIPTION
This settings only has an effect when targeting very old version of node (< 15).  Its trivial to replace with a simple `--pre-js` file or with the `--unhandled-rejections=strict` command line flag which is basically emulates.

Version of node above v15 have this behavior by default.