### PR TITLE
[ESM_INTEGRATION] Remove --experimental-wasm-modules node flag. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -450,7 +450,8 @@ class TestCoreBase(RunnerCore):
 
   def setup_esm_integration(self):
     self.require_node_25()
-    self.node_args += ['--experimental-wasm-modules', '--no-warnings']
+    # Using instance phase imports current generates am ExperimentalWarning under node.
+    self.node_args += ['--no-warnings']
     self.set_setting('WASM_ESM_INTEGRATION')
     self.cflags += ['-Wno-experimental']
     if self.is_wasm64():


### PR DESCRIPTION
This flag is no longer needed with node 25.