### PR TITLE
Improve python version checking

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -29,6 +29,11 @@ import tarfile
 from dataclasses import dataclass
 from enum import Enum, auto, unique
 
+# This assert needs to happen early, before any too-recent python syntax is used.
+# In particular it needs to happen before we import any python file that uses the
+# `match` keyword.
+assert sys.version_info >= (3, 10), f'emscripten requires python 3.10 or above ({sys.executable} {sys.version})'
+
 from tools import (
   building,
   cache,

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -19,10 +19,7 @@ from subprocess import PIPE
 
 from .toolchain_profiler import ToolchainProfiler
 
-# We depend on python 3.10 features
-if sys.version_info < (3, 10): # noqa: UP036
-  print(f'error: emscripten requires python 3.10 or above ({sys.executable} {sys.version})', file=sys.stderr)
-  sys.exit(1)
+assert sys.version_info >= (3, 10), f'emscripten requires python 3.10 or above ({sys.executable} {sys.version})'
 
 from . import colored_logger
 


### PR DESCRIPTION
Having the check only in `shared.py` was not working because it was running too late.

See #26331