### PR TITLE
Remove POLYFILL_OLD_MATH_FUNCTIONS from settings.js

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -952,15 +952,6 @@ can also vary between browsers.
 
 Default value: false
 
-.. _polyfill_old_math_functions:
-
-POLYFILL_OLD_MATH_FUNCTIONS
-===========================
-
-If set, enables polyfilling for Math.clz32, Math.trunc, Math.imul, Math.fround.
-
-Default value: false
-
 .. _legacy_vm_support:
 
 LEGACY_VM_SUPPORT
@@ -970,7 +961,6 @@ Set this to enable compatibility emulations for old JavaScript engines. This giv
 the highest possible probability of the code working everywhere, even in rare old
 browsers and shell environments. Specifically:
 
-- Add polyfilling for Math.clz32, Math.trunc, Math.imul, Math.fround. (-sPOLYFILL_OLD_MATH_FUNCTIONS)
 - Disable WebAssembly. (Must be paired with -sWASM=0)
 - Adjusts MIN_X_VERSION settings to 0 to include support for all browser versions.
 - Avoid TypedArray.fill, if necessary, in zeroMemory utility function.
@@ -3534,3 +3524,4 @@ for backwards compatibility with older versions:
  - ``PROXY_TO_WORKER``: No longer supported (Valid values: [0])
  - ``NODEJS_CATCH_EXIT``: No longer supported (Valid values: [0])
  - ``NODEJS_CATCH_REJECTION``: No longer supported (Valid values: [0])
+ - ``POLYFILL_OLD_MATH_FUNCTIONS``: No longer supported (Valid values: [0])

--- a/src/settings.js
+++ b/src/settings.js
@@ -622,15 +622,10 @@ var GL_ENABLE_GET_PROC_ADDRESS = true;
 // [link]
 var JS_MATH = false;
 
-// If set, enables polyfilling for Math.clz32, Math.trunc, Math.imul, Math.fround.
-// [link]
-var POLYFILL_OLD_MATH_FUNCTIONS = false;
-
 // Set this to enable compatibility emulations for old JavaScript engines. This gives you
 // the highest possible probability of the code working everywhere, even in rare old
 // browsers and shell environments. Specifically:
 //
-// - Add polyfilling for Math.clz32, Math.trunc, Math.imul, Math.fround. (-sPOLYFILL_OLD_MATH_FUNCTIONS)
 // - Disable WebAssembly. (Must be paired with -sWASM=0)
 // - Adjusts MIN_X_VERSION settings to 0 to include support for all browser versions.
 // - Avoid TypedArray.fill, if necessary, in zeroMemory utility function.

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -252,6 +252,7 @@ LEGACY_SETTINGS = [
     ['PROXY_TO_WORKER', [0], 'No longer supported'],
     ['NODEJS_CATCH_EXIT', [0], 'No longer supported'],
     ['NODEJS_CATCH_REJECTION', [0], 'No longer supported'],
+    ['POLYFILL_OLD_MATH_FUNCTIONS', [0], 'No longer supported'],
 ]
 
 user_settings: dict[str, str] = {}


### PR DESCRIPTION
This setting was effectively removed years ago in #23262 but for some reason it was not moved to `LEGACY_SETTINGS`.