### PR TITLE
Build libc++abi with _LIBCXXABI_USE_FUTEX and emscripten futex API

### DIFF
--- a/system/lib/libcxxabi/src/cxa_guard_impl.h
+++ b/system/lib/libcxxabi/src/cxa_guard_impl.h
@@ -64,6 +64,11 @@
 #include <limits.h>
 #include <stdlib.h>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten/threading.h>
+#include <math.h>
+#endif
+
 #ifndef _LIBCXXABI_HAS_NO_THREADS
 #  if defined(__ELF__) && defined(_LIBCXXABI_LINK_PTHREAD_LIB)
 #    pragma comment(lib, "pthread")
@@ -424,6 +429,13 @@ void PlatformFutexWake(int* addr) {
   constexpr int WAKE = 1;
   __tsan_release(addr);
   futex(reinterpret_cast<volatile uint32_t*>(addr), WAKE, INT_MAX, NULL, NULL);
+}
+#elif defined(__EMSCRIPTEN__)
+void PlatformFutexWait(int* addr, int expect) {
+  emscripten_futex_wait(addr, expect, INFINITY);
+}
+void PlatformFutexWake(int* addr) {
+  emscripten_futex_wake(addr, INT_MAX);
 }
 #elif defined(SYS_futex)
 void PlatformFutexWait(int* addr, int expect) {

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13525,9 +13525,7 @@ int main() {
 
   @also_with_minimal_runtime
   def test_wasm_worker_cxx_init(self):
-    # For now, C++ init guards do not work with Wasm Workers.
-    # See https://github.com/emscripten-core/emscripten/issues/26277
-    self.assert_fail([EMCC, test_file('wasm_worker/wasm_worker_cxx_init.cpp'), '-sWASM_WORKERS'], 'undefined symbol: pthread_cond_wait')
+    self.do_run_in_out_file_test('wasm_worker/wasm_worker_cxx_init.cpp', cflags=['-sWASM_WORKERS'])
 
   @parameterized({
     # we will warn here since -O2 runs the optimizer and -g enables DWARF

--- a/test/wasm_worker/wasm_worker_cxx_init.out
+++ b/test/wasm_worker/wasm_worker_cxx_init.out
@@ -1,0 +1,4 @@
+main
+create Foo
+method called
+done

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1652,6 +1652,7 @@ class libcxxabi(ExceptionLibrary, MTLibrary, DebugLibrary):
   name = 'libc++abi'
   cflags = [
       '-Oz',
+      '-D_LIBCXXABI_USE_FUTEX',
       '-D_LIBCPP_BUILDING_LIBRARY',
       '-D_LIBCXXABI_BUILDING_LIBRARY',
       '-DLIBCXXABI_NON_DEMANGLING_TERMINATE',


### PR DESCRIPTION
This removes the dependency that libc++abi has on the pthread API functions, allowing
better support for Wasm Workers.

Replaces: #26283

Fixes: #26277