### PR TITLE
Move SDL_hid_init to correct version in ChangeLog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,8 @@ See docs/process.md for more on how version tagging works.
   API stub functions.  These stub functions where never designed to work under
   Wasm Workers, so its safer to error at link time if pthread APIs are used
   in Wasm Worker-based programs. (#26336)
+- SDL2 port updated to include stub functions for `SDL_hid_init()` and related
+  functions. (#26297)
 
 5.0.2 - 02/25/26
 ----------------
@@ -46,8 +48,6 @@ See docs/process.md for more on how version tagging works.
   C `bool` type rather than `int`.  For example `emscripten_proxy_sync` and
   `emscripten_is_main_runtime_thread`. (#26316)
 - SDL2 port updated from 2.32.8 to 2.32.10. (#26298)
-- SDL2 port updated to include stub functions for `SDL_hid_init()` and related
-  functions. (#26297)
 - The remaining launcher scripts (e.g. `emcc.bat`) were removed from the git
   repository.  These scripts are created by the `./bootstrap` script which
   must be run before the toolchain is usable (for folks using a git checkout of


### PR DESCRIPTION
#26297 didn't make it into the 5.0.2 tag. This pull request moves the ChangeLog entry to 5.0.3.