### PR TITLE
Convert emscripten_performance_now to btest_exit.

### DIFF
--- a/test/emscripten_performance_now.c
+++ b/test/emscripten_performance_now.c
@@ -1,6 +1,7 @@
 #include <emscripten/html5.h>
 #include <emscripten/threading.h>
 #include <assert.h>
+#include <stdio.h>
 
 double performanceNow;
 double dateNow;
@@ -12,9 +13,8 @@ void test(void *userData) {
   double now3 = emscripten_date_now();
   assert(now3 >= dateNow + 100);
 
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  printf("done\n");
+  exit(0);
 }
 
 int main() {
@@ -30,4 +30,6 @@ int main() {
 #else
   emscripten_set_timeout(test, 200, 0);
 #endif
+
+  return 99;
 }

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4891,10 +4891,13 @@ Module["preRun"] = () => {
   def test_emscripten_set_interval(self):
     self.btest_exit('emscripten_set_interval.c', cflags=['-pthread', '-sPROXY_TO_PTHREAD'])
 
-  # Test emscripten_performance_now() and emscripten_date_now()
-  @requires_shared_array_buffer
-  def test_emscripten_performance_now(self):
-    self.btest('emscripten_performance_now.c', '0', cflags=['-pthread', '-sPROXY_TO_PTHREAD'])
+  @parameterized({
+    '': ([],),
+    'pthread': (['-pthread', '-sPROXY_TO_PTHREAD'],),
+  })
+  def test_emscripten_performance_now(self, args):
+    # Test emscripten_performance_now() and emscripten_date_now()
+    self.btest_exit('emscripten_performance_now.c', cflags=args)
 
   def test_embind_with_pthreads(self):
     self.btest_exit('embind/test_pthreads.cpp', cflags=['-lembind', '-pthread', '-sPTHREAD_POOL_SIZE=2'])


### PR DESCRIPTION
Also, run it both with and without pthreeds, as it seems like it was originally intended.