### PR TITLE
Mention WebTransport in network porting docs

### DIFF
--- a/site/source/docs/porting/networking.rst
+++ b/site/source/docs/porting/networking.rst
@@ -96,3 +96,9 @@ Direct UDP communication is not available in browsers, but as a close
 alternative, the WebRTC specification provides a mechanism to perform UDP-like
 communication with WebRTC Data Channels. Currently Emscripten does not provide a
 C/C++ API for interacting with WebRTC.
+
+WebTransport and QUIC
+=====================
+
+WebTransport may be used to send UDP like datagrams over QUIC.
+Currently Emscripten does not provide a C/C++ API for interacting with WebTransport.


### PR DESCRIPTION
The current documentation does not mention WebTransport in regards to Networking.

However, it provides a good (and more importantly modern) alternative to WebSockets and WebRTC. Interaction through JS should be fairly easy.

What I wrote here is fairly short, suggestions are welcome.
