### PR TITLE
Don't include memory tracing callback in INCOMING_MODULE_JS_API by default. NFC

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -971,9 +971,8 @@ var INCOMING_MODULE_JS_API = [
   'instantiateWasm', 'keyboardListeningElement', 'freePreloadedMediaOnUse',
   'locateFile', 'mainScriptUrlOrBlob', 'mem',
   'monitorRunDependencies', 'noExitRuntime', 'noInitialRun', 'onAbort',
-  'onExit', 'onFree', 'onFullScreen', 'onMalloc',
-  'onRealloc', 'onRuntimeInitialized', 'onSbrkGrow', 'postMainLoop', 'postRun', 'preInit',
-  'preMainLoop', 'preRun',
+  'onExit', 'onFullScreen', 'onRuntimeInitialized', 'postMainLoop', 'postRun',
+  'preInit', 'preMainLoop', 'preRun',
   'preinitializedWebGLContext', 'preloadPlugins',
   'print', 'printErr', 'setStatus', 'statusMessage', 'stderr',
   'stdin', 'stdout', 'thisProgram', 'wasm', 'wasmBinary', 'websocket'

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 24268,
-  "a.out.js.gz": 8718,
+  "a.out.js": 24329,
+  "a.out.js.gz": 8745,
   "a.out.nodebug.wasm": 15138,
   "a.out.nodebug.wasm.gz": 7455,
-  "total": 39406,
-  "total_gz": 16173,
+  "total": 39467,
+  "total_gz": 16200,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -1283,12 +1283,8 @@ function checkIncomingModuleAPI() {
   ignoredModuleProp('noInitialRun');
   ignoredModuleProp('onAbort');
   ignoredModuleProp('onExit');
-  ignoredModuleProp('onFree');
   ignoredModuleProp('onFullScreen');
-  ignoredModuleProp('onMalloc');
-  ignoredModuleProp('onRealloc');
   ignoredModuleProp('onRuntimeInitialized');
-  ignoredModuleProp('onSbrkGrow');
   ignoredModuleProp('postMainLoop');
   ignoredModuleProp('postRun');
   ignoredModuleProp('preInit');
@@ -1310,6 +1306,10 @@ function checkIncomingModuleAPI() {
   ignoredModuleProp('fetchSettings');
   ignoredModuleProp('logReadFiles');
   ignoredModuleProp('loadSplitModule');
+  ignoredModuleProp('onMalloc');
+  ignoredModuleProp('onRealloc');
+  ignoredModuleProp('onFree');
+  ignoredModuleProp('onSbrkGrow');
 }
 
 // Imports from the Wasm binary.

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,6 +1,6 @@
 {
-  "hello_world.js": 56965,
-  "hello_world.js.gz": 17729,
+  "hello_world.js": 57098,
+  "hello_world.js.gz": 17758,
   "hello_world.wasm": 15138,
   "hello_world.wasm.gz": 7455,
   "no_asserts.js": 26576,
@@ -8,9 +8,9 @@
   "no_asserts.wasm": 12187,
   "no_asserts.wasm.gz": 5984,
   "strict.js": 54916,
-  "strict.js.gz": 17054,
+  "strict.js.gz": 17055,
   "strict.wasm": 15138,
   "strict.wasm.gz": 7450,
-  "total": 180920,
-  "total_gz": 64553
+  "total": 181053,
+  "total_gz": 64583
 }

--- a/tools/cmdline.py
+++ b/tools/cmdline.py
@@ -43,6 +43,10 @@ EXTRA_INCOMING_JS_API = [
   'fetchSettings',
   'logReadFiles',
   'loadSplitModule',
+  'onMalloc',
+  'onRealloc',
+  'onFree',
+  'onSbrkGrow',
 ]
 
 logger = logging.getLogger('args')

--- a/tools/link.py
+++ b/tools/link.py
@@ -1295,6 +1295,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
                                   'emscripten_stack_get_base',
                                   'emscripten_stack_get_end',
                                   'emscripten_stack_get_current']
+    settings.INCOMING_MODULE_JS_API += ['preRun']
 
   settings.ASYNCIFY_ADD = unmangle_symbols_from_cmdline(settings.ASYNCIFY_ADD)
   settings.ASYNCIFY_REMOVE = unmangle_symbols_from_cmdline(settings.ASYNCIFY_REMOVE)
@@ -1774,6 +1775,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
 
   if settings.EMSCRIPTEN_TRACING:
     add_system_js_lib('libtrace.js')
+    settings.INCOMING_MODULE_JS_API += ['onMalloc', 'onRealloc', 'onFree', 'onSbrkGrow']
     if settings.ALLOW_MEMORY_GROWTH:
       settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['emscripten_trace_report_memory_layout']
       settings.REQUIRED_EXPORTS += ['emscripten_stack_get_current',


### PR DESCRIPTION
These are only ever used by EMSCRIPTEN_TRACING so we know exactly when to include them.

I noticed this while reviewing #26175