### PR TITLE
Move `emscripten_memprof_sbrk_grow` into libtrace.js

### DIFF
--- a/src/lib/libmemoryprofiler.js
+++ b/src/lib/libmemoryprofiler.js
@@ -1,9 +1,0 @@
-var memoryProfiler = {
-  emscripten_memprof_sbrk_grow: (old_brk, new_brk) => {
-#if MEMORYPROFILER
-    Module['onSbrkGrow']?.(old_brk, new_brk, new Error().stack.toString());
-#endif
-  },
-};
-
-addToLibrary(memoryProfiler);

--- a/src/lib/libsigs.js
+++ b/src/lib/libsigs.js
@@ -833,6 +833,7 @@ sigs = {
   emscripten_trace_report_error__sig: 'vp',
   emscripten_trace_report_memory_layout__sig: 'v',
   emscripten_trace_report_off_heap_data__sig: 'v',
+  emscripten_trace_sbrk_grow__sig: 'vpp',
   emscripten_trace_set_enabled__sig: 'vi',
   emscripten_trace_set_session_username__sig: 'vp',
   emscripten_trace_task_associate_data__sig: 'vpp',

--- a/src/lib/libtrace.js
+++ b/src/lib/libtrace.js
@@ -41,6 +41,7 @@ var LibraryTracing = {
     EVENT_OFF_HEAP: 'off-heap',
     EVENT_REALLOCATE: 'reallocate',
     EVENT_REPORT_ERROR: 'report-error',
+    EVENT_SBRK_GROW: 'sbrk-grow',
     EVENT_SESSION_NAME: 'session-name',
     EVENT_TASK_ASSOCIATE_DATA: 'task-associate-data',
     EVENT_TASK_END: 'task-end',
@@ -208,6 +209,15 @@ var LibraryTracing = {
     var callstack = (new Error).stack;
     EmscriptenTrace.post([EmscriptenTrace.EVENT_REPORT_ERROR, now,
                           UTF8ToString(error), callstack]);
+  },
+
+  emscripten_trace_sbrk_grow: (old_brk, new_brk) => {
+    Module['onSbrkGrow']?.(old_brk, new_brk, jsStackTrace());
+    if (EmscriptenTrace.postEnabled) {
+      var now = EmscriptenTrace.now();
+      EmscriptenTrace.post([EmscriptenTrace.EVENT_SBRK_GROW,
+                            now, old_brk, new_brk]);
+    }
   },
 
   emscripten_trace_record_allocation: (address, size) => {

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -78,10 +78,6 @@ function calculateLibraries() {
     libraries.push('libtime.js');
   }
 
-  if (EMSCRIPTEN_TRACING) {
-    libraries.push('libmemoryprofiler.js');
-  }
-
   if (SUPPORT_BASE64_EMBEDDING || ENVIRONMENT_MAY_BE_SHELL) {
     libraries.push('libbase64.js');
   }

--- a/system/include/emscripten/trace.h
+++ b/system/include/emscripten/trace.h
@@ -66,6 +66,8 @@ void emscripten_trace_task_end(void);
 
 void emscripten_trace_close(void);
 
+void emscripten_trace_sbrk_grow(intptr_t old, intptr_t new);
+
 #else
 
 #define emscripten_trace_configure(collector_url, application) ((void)0)
@@ -93,6 +95,7 @@ void emscripten_trace_close(void);
 #define emscripten_trace_task_resume(task_id, explanation) ((void)0)
 #define emscripten_trace_task_end() ((void)0)
 #define emscripten_trace_close() ((void)0)
+#define emscripten_trace_sbrk_grow(old, new) ((void)0)
 
 #endif
 

--- a/system/lib/libc/sbrk.c
+++ b/system/lib/libc/sbrk.c
@@ -21,13 +21,8 @@
 #include <stdlib.h>
 #endif
 
-#ifdef __EMSCRIPTEN_TRACING__
-void emscripten_memprof_sbrk_grow(intptr_t old, intptr_t new);
-#else
-#define emscripten_memprof_sbrk_grow(...) ((void)0)
-#endif
-
 #include <emscripten/heap.h>
+#include <emscripten/trace.h>
 
 extern size_t __heap_base;
 
@@ -93,7 +88,7 @@ void *_sbrk64(int64_t increment) {
     *sbrk_ptr = new_brk;
 #endif
 
-    emscripten_memprof_sbrk_grow(old_brk, new_brk);
+    emscripten_trace_sbrk_grow(old_brk, new_brk);
     return (void*)old_brk;
   }
 }


### PR DESCRIPTION
This allows for the complete removal of `libmemoryprofiler.js` since the memory profiler can now just use the same libtrace-based hooks for all events.

I noticed this while reviewing #26175