### PR TITLE
Simplify timezone setup. NFC

### DIFF
--- a/system/lib/libc/musl/src/time/__tz.c
+++ b/system/lib/libc/musl/src/time/__tz.c
@@ -9,14 +9,9 @@
 #include "lock.h"
 #include "fork_impl.h"
 
-#ifdef __EMSCRIPTEN__
-#include <stdbool.h>
-#include <pthread.h>
-#include "emscripten_internal.h"
-#endif
-
 #if defined(__EMSCRIPTEN__) && !defined(EMSCRIPTEN_STANDALONE_WASM)
 #define USE_EXTERNAL_ZONEINFO
+#include "emscripten_internal.h"
 #endif
 
 #define malloc __libc_malloc
@@ -142,17 +137,10 @@ static size_t zi_dotprod(const unsigned char *z, const unsigned char *v, size_t 
 static void do_tzset()
 {
 #ifdef USE_EXTERNAL_ZONEINFO
-	static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
-	static _Atomic bool done_init = false;
-	if (!done_init) {
-		pthread_mutex_lock(&lock);
-		if (!done_init) {
-			_tzset_js(&timezone, &daylight, std_name, dst_name);
-			__tzname[0] = std_name;
-			__tzname[1] = dst_name;
-			done_init = true;
-		}
-		pthread_mutex_unlock(&lock);
+	if (!__tzname[0]) {
+		_tzset_js(&timezone, &daylight, std_name, dst_name);
+		__tzname[0] = std_name;
+		__tzname[1] = dst_name;
 	}
 #else
 	char buf[NAME_MAX+25], *pathname=buf+24;

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19555,
   "a.out.js.gz": 8102,
-  "a.out.nodebug.wasm": 132828,
-  "a.out.nodebug.wasm.gz": 49876,
-  "total": 152383,
-  "total_gz": 57978,
+  "a.out.nodebug.wasm": 132802,
+  "a.out.nodebug.wasm.gz": 49860,
+  "total": 152357,
+  "total_gz": 57962,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19532,
   "a.out.js.gz": 8087,
-  "a.out.nodebug.wasm": 132248,
-  "a.out.nodebug.wasm.gz": 49533,
-  "total": 151780,
-  "total_gz": 57620,
+  "a.out.nodebug.wasm": 132222,
+  "a.out.nodebug.wasm.gz": 49513,
+  "total": 151754,
+  "total_gz": 57600,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 23216,
   "a.out.js.gz": 9081,
-  "a.out.nodebug.wasm": 172758,
-  "a.out.nodebug.wasm.gz": 57391,
-  "total": 195974,
-  "total_gz": 66472,
+  "a.out.nodebug.wasm": 172732,
+  "a.out.nodebug.wasm.gz": 57374,
+  "total": 195948,
+  "total_gz": 66455,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19366,
   "a.out.js.gz": 8022,
-  "a.out.nodebug.wasm": 148153,
-  "a.out.nodebug.wasm.gz": 55273,
-  "total": 167519,
-  "total_gz": 63295,
+  "a.out.nodebug.wasm": 148127,
+  "a.out.nodebug.wasm.gz": 55257,
+  "total": 167493,
+  "total_gz": 63279,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19440,
   "a.out.js.gz": 8042,
-  "a.out.nodebug.wasm": 145959,
-  "a.out.nodebug.wasm.gz": 54905,
-  "total": 165399,
-  "total_gz": 62947,
+  "a.out.nodebug.wasm": 145933,
+  "a.out.nodebug.wasm.gz": 54885,
+  "total": 165373,
+  "total_gz": 62927,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 23266,
   "a.out.js.gz": 9101,
-  "a.out.nodebug.wasm": 239192,
-  "a.out.nodebug.wasm.gz": 79786,
-  "total": 262458,
-  "total_gz": 88887,
+  "a.out.nodebug.wasm": 239166,
+  "a.out.nodebug.wasm.gz": 79776,
+  "total": 262432,
+  "total_gz": 88877,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19555,
   "a.out.js.gz": 8102,
-  "a.out.nodebug.wasm": 134835,
-  "a.out.nodebug.wasm.gz": 50703,
-  "total": 154390,
-  "total_gz": 58805,
+  "a.out.nodebug.wasm": 134809,
+  "a.out.nodebug.wasm.gz": 50697,
+  "total": 154364,
+  "total_gz": 58799,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_wasmfs.json
+++ b/test/codesize/test_codesize_cxx_wasmfs.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7053,
   "a.out.js.gz": 3325,
-  "a.out.nodebug.wasm": 172904,
-  "a.out.nodebug.wasm.gz": 63290,
-  "total": 179957,
-  "total_gz": 66615,
+  "a.out.nodebug.wasm": 172878,
+  "a.out.nodebug.wasm.gz": 63283,
+  "total": 179931,
+  "total_gz": 66608,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
   "a.out.js": 244691,
-  "a.out.nodebug.wasm": 577708,
-  "total": 822399,
+  "a.out.nodebug.wasm": 577692,
+  "total": 822383,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
The code here previously used a pthread_lock.  However this is unnecessary since all calls to the `do_tzset` function are already wrapped in `LOCK(lock)` and `UNLOCK(lock)`.

This is nice little codesize saving too.