### PR TITLE
Remove RELOCATABLE setting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,9 @@ See docs/process.md for more on how version tagging works.
 ----------------------
 - Warn on usage of the deprecated `EMSCRIPTEN` macro (`__EMSCRIPTEN__` should
   be used instead). (#26381)
+- The `-sRELOCATABLE` setting was effectively removed (moved to legacy
+  settings).  This setting was deprecated in #25265 and has not been used
+  internally since #25522.
 - When building with `-sWASM_WORKERS` emscripten will no longer include pthread
   API stub functions.  These stub functions where never designed to work under
   Wasm Workers, so its safer to error at link time if pthread APIs are used

--- a/embuilder.py
+++ b/embuilder.py
@@ -236,7 +236,7 @@ def main():
     shared.PRINT_SUBPROCS = True
 
   if args.pic:
-    settings.RELOCATABLE = 1
+    settings.MAIN_MODULE = 1
 
   if args.wasm64:
     settings.MEMORY64 = 2

--- a/emcc.py
+++ b/emcc.py
@@ -404,9 +404,6 @@ def phase_setup(state):
             'unused-command-line-argument',
             "linker flag ignored during compilation: '%s'" % arg)
 
-  if settings.SIDE_MODULE:
-    settings.RELOCATABLE = 1
-
   if 'USE_PTHREADS' in user_settings:
     settings.PTHREADS = settings.USE_PTHREADS
 

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1597,21 +1597,6 @@ the module.
 
 Default value: false
 
-.. _relocatable:
-
-RELOCATABLE
-===========
-
-If set to 1, we emit relocatable code from the LLVM backend; both
-globals and function pointers are all offset (by gb and fp, respectively)
-Automatically set for SIDE_MODULE or MAIN_MODULE.
-
-.. note:: Applicable during both linking and compilation
-
-.. note:: This setting is deprecated
-
-Default value: false
-
 .. _main_module:
 
 MAIN_MODULE
@@ -3434,7 +3419,6 @@ these settings please open a bug (or reply to one of the existing bugs).
  - ``LEGALIZE_JS_FFI``: to disable JS type legalization use `-sWASM_BIGINT` or `-sSTANDALONE_WASM`
  - ``ASYNCIFY_EXPORTS``: please use JSPI_EXPORTS instead
  - ``LINKABLE``: under consideration for removal (https://github.com/emscripten-core/emscripten/issues/25262)
- - ``RELOCATABLE``:  under consideration for removal (https://github.com/emscripten-core/emscripten/issues/25262)
 
 .. _legacy-settings:
 
@@ -3524,3 +3508,4 @@ for backwards compatibility with older versions:
  - ``NODEJS_CATCH_EXIT``: No longer supported (Valid values: [0])
  - ``NODEJS_CATCH_REJECTION``: No longer supported (Valid values: [0])
  - ``POLYFILL_OLD_MATH_FUNCTIONS``: No longer supported (Valid values: [0])
+ - ``RELOCATABLE``: No longer supported (Valid values: [0])

--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -122,7 +122,7 @@ function isDefined(symName) {
   }
   // 'invoke_' symbols are created at runtime in library_dylink.py so can
   // always be considered as defined.
-  if ((MAIN_MODULE || RELOCATABLE) && symName.startsWith('invoke_')) {
+  if (MAIN_MODULE && symName.startsWith('invoke_')) {
     return true;
   }
   return false;
@@ -607,7 +607,7 @@ function(${args}) {
       if (!LibraryManager.library.hasOwnProperty(symbol)) {
         const isWeakImport = WEAK_IMPORTS.has(symbol);
         if (!isDefined(symbol) && !isWeakImport) {
-          if (PROXY_TO_PTHREAD && !(MAIN_MODULE || RELOCATABLE) && symbol == '__main_argc_argv') {
+          if (PROXY_TO_PTHREAD && !MAIN_MODULE && symbol == '__main_argc_argv') {
             error('PROXY_TO_PTHREAD proxies main() for you, but no main exists');
             return;
           }
@@ -638,7 +638,7 @@ function(${args}) {
 
         // emit a stub that will fail at runtime
         var stubFunctionBody = `abort('missing function: ${symbol}');`
-        if (RELOCATABLE || MAIN_MODULE) {
+        if (MAIN_MODULE) {
           // Create a stub for this symbol which can later be replaced by the
           // dynamic linker.  If this stub is called before the symbol is
           // resolved assert in debug builds or trap in release builds.
@@ -703,7 +703,7 @@ function(${args}) {
           // signatures are relevant and they differ between and alais and
           // it's target) we need to construct a forwarding function from
           // one to the other.
-          const isSigRelevant = MAIN_MODULE || RELOCATABLE || MEMORY64 || CAN_ADDRESS_2GB || (sig && sig.includes('j'));
+          const isSigRelevant = MAIN_MODULE || MEMORY64 || CAN_ADDRESS_2GB || (sig && sig.includes('j'));
           const targetSig = LibraryManager.library[aliasTarget + '__sig'];
           if (isSigRelevant && sig && targetSig && sig != targetSig) {
             debugLog(`${symbol}: Alias target (${aliasTarget}) has different signature (${sig} vs ${targetSig})`)
@@ -802,7 +802,7 @@ function(${args}) {
       }
 
       // Dynamic linking needs signatures to create proper wrappers.
-      if (sig && (MAIN_MODULE || RELOCATABLE)) {
+      if (sig && MAIN_MODULE) {
         if (!WASM_BIGINT) {
           sig = sig[0].replace('j', 'i') + sig.slice(1).replace(/j/g, 'ii');
         }
@@ -814,7 +814,7 @@ function(${args}) {
       }
       if (isStub) {
         contentText += `\n${mangled}.stub = true;`;
-        if (ASYNCIFY && (MAIN_MODULE || RELOCATABLE)) {
+        if (ASYNCIFY && MAIN_MODULE) {
           contentText += `\nasyncifyStubs['${symbol}'] = undefined;`;
         }
       }

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -2175,31 +2175,6 @@ addToLibrary({
 #endif
   },
 
-#if RELOCATABLE
-  // Globals that are normally exported from the wasm module but in relocatable
-  // mode are created here and imported by the module.
-  __stack_pointer: "new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': true}, {{{ to64(STACK_HIGH) }}})",
-  // tell the memory segments where to place themselves
-  __memory_base: "new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': false}, {{{ to64(GLOBAL_BASE) }}})",
-  // the wasm backend reserves slot 0 for the NULL function pointer
-  __table_base: "new WebAssembly.Global({'value': '{{{ POINTER_WASM_TYPE }}}', 'mutable': false}, {{{ to64(TABLE_BASE) }}})",
-#if MEMORY64 == 2
-  __memory_base32: "new WebAssembly.Global({'value': 'i32', 'mutable': false}, {{{ GLOBAL_BASE }}})",
-#endif
-#if MEMORY64
-  __table_base32: {{{ TABLE_BASE }}},
-#endif
-  // To support such allocations during startup, track them on __heap_base and
-  // then when the main module is loaded it reads that value and uses it to
-  // initialize sbrk (the main module is relocatable itself, and so it does not
-  // have __heap_base hardcoded into it - it receives it from JS as an extern
-  // global, basically).
-  __heap_base: '{{{ HEAP_BASE }}}',
-  __stack_high: '{{{ STACK_HIGH }}}',
-  __stack_low: '{{{ STACK_LOW }}}',
-  __global_base: '{{{ GLOBAL_BASE }}}',
-#endif // RELOCATABLE
-
   _emscripten_fs_load_embedded_files__deps: ['$FS', '$PATH'],
   _emscripten_fs_load_embedded_files: (ptr) => {
 #if RUNTIME_DEBUG
@@ -2253,24 +2228,9 @@ addToLibrary({
     }
   },
 
-  $wasmTable__docs: '/** @type {WebAssembly.Table} */',
-#if RELOCATABLE
-  // In RELOCATABLE mode we create the table in JS.
-  $wasmTable: `=new WebAssembly.Table({
-  'initial': {{{ toIndexType(INITIAL_TABLE) }}},
-#if !ALLOW_TABLE_GROWTH
-  'maximum': {{{ toIndexType(INITIAL_TABLE) }}},
-#endif
-#if MEMORY64 == 1
-  'address': 'i64',
-#endif
-  'element': 'anyfunc'
-});
-`,
-#else
   // `wasmTable` is a JS alias for the Wasm `__indirect_function_table` export
+  $wasmTable__docs: '/** @type {WebAssembly.Table} */',
   $wasmTable: '__indirect_function_table',
-#endif
 
 #if IMPORTED_MEMORY
   // This gets defined in src/runtime_init_memory.js

--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -6,8 +6,8 @@
  * Dynamic library loading
  */
 
-#if !MAIN_MODULE && !RELOCATABLE
-#error "library_dylink.js requires MAIN_MODULE or RELOCATABLE"
+#if !MAIN_MODULE
+#error "library_dylink.js requires MAIN_MODULE"
 #endif
 
 {{{
@@ -430,13 +430,6 @@ var LibraryDylink = {
     // that once the program starts it doesn't use this region.  In relocatable
     // mode we can just update the __heap_base symbol that we are exporting to
     // the main module.
-    // When not relocatable `__heap_base` is fixed and exported by the main
-    // module, but we can update the `sbrk_ptr` value instead.  We call
-    // `_emscripten_get_sbrk_ptr` knowing that it is safe to call prior to
-    // runtime initialization (unlike, the higher level sbrk function)
-#if RELOCATABLE
-    GOT['__heap_base'].value = {{{ to64('end') }}};
-#else
 #if PTHREADS
     if (!ENVIRONMENT_IS_PTHREAD) {
 #endif
@@ -444,7 +437,6 @@ var LibraryDylink = {
       {{{ makeSetValue('sbrk_ptr', 0, 'end', '*') }}}
 #if PTHREADS
     }
-#endif
 #endif
     return ret;
   },

--- a/src/lib/libglemu.js
+++ b/src/lib/libglemu.js
@@ -10,7 +10,7 @@ assert(!FULL_ES3, 'cannot emulate both ES3 and legacy GL');
 
 {{{
   const copySigs = (func) => {
-    if (!MAIN_MODULE && !RELOCATABLE) return '';
+    if (!MAIN_MODULE) return '';
     return ` _${func}.sig = _emscripten_${func}.sig = orig_${func}.sig;`;
   };
   const fromPtr = (arg) => {

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -1245,12 +1245,6 @@ var LibraryPThread = {
       }
     }
   },
-#elif RELOCATABLE
-  // Provide a dummy version of _emscripten_thread_exit_joinable when
-  // RELOCATABLE is used without MAIN_MODULE.  This is because the call
-  // site in pthread_create.c is not able to distinguish between these
-  // two cases.
-  _emscripten_thread_exit_joinable: (thread) => {},
 #endif // MAIN_MODULE
 
   $checkMailbox__deps: ['$callUserCallback',

--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -15,7 +15,7 @@
 #if LINKABLE
 #error "-sLINKABLE is not supported with -sWASM_WORKERS"
 #endif
-#if RELOCATABLE || MAIN_MODULE
+#if MAIN_MODULE
 #error "dynamic linking is not supported with -sWASM_WORKERS"
 #endif
 #if WASM2JS && MODULARIZE

--- a/src/modules.mjs
+++ b/src/modules.mjs
@@ -90,7 +90,7 @@ function calculateLibraries() {
     libraries.push('libsyscall.js');
   }
 
-  if (MAIN_MODULE || RELOCATABLE) {
+  if (MAIN_MODULE) {
     libraries.push('libdylink.js');
   }
 

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -112,11 +112,7 @@ function stackCheckInit() {
   // See $establishStackSpace for the equivalent code that runs on a thread
   assert(!ENVIRONMENT_IS_PTHREAD);
 #endif
-#if RELOCATABLE
-  _emscripten_stack_set_limits({{{ STACK_HIGH }}} , {{{ STACK_LOW }}});
-#else
   _emscripten_stack_init();
-#endif
   // TODO(sbc): Move writeStackCookie to native to to avoid this.
   writeStackCookie();
 }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -108,7 +108,7 @@ assert(globalThis.Int32Array && globalThis.Float64Array && Int32Array.prototype.
        'JS engine does not provide full typed array support');
 #endif
 
-#if RELOCATABLE || MAIN_MODULE
+#if MAIN_MODULE
 var __RELOC_FUNCS__ = [];
 #endif
 
@@ -155,7 +155,7 @@ function initRuntime() {
   checkStackCookie();
 #endif
 
-#if MAIN_MODULE || RELOCATABLE
+#if MAIN_MODULE
   callRuntimeCallbacks(__RELOC_FUNCS__);
 #endif
 
@@ -532,12 +532,6 @@ var splitModuleProxyHandler = {
 #if RUNTIME_DEBUG
             dbg('instantiated deferred module, continuing');
 #endif
-#if RELOCATABLE
-            // When the table is dynamically laid out, the placeholder functions names
-            // are offsets from the table base. In the main module, the table base is
-            // always 1.
-            base = 1 + parseInt(base);
-#endif
             return wasmTable.get({{{ toIndexType('base') }}})(...args);
 #endif
           }
@@ -690,7 +684,7 @@ function getWasmImports() {
 #endif
 #endif
   // prepare imports
-#if MAIN_MODULE || RELOCATABLE
+#if MAIN_MODULE
   var GOTProxyHandler = new Proxy(new Set({{{ JSON.stringify(Array.from(WEAK_IMPORTS)) }}}), GOTHandler);
 #endif
   var imports = {
@@ -700,7 +694,7 @@ function getWasmImports() {
     'env': wasmImports,
     '{{{ WASI_MODULE_NAME }}}': wasmImports,
 #endif // MINIFY_WASM_IMPORTED_MODULES
-#if MAIN_MODULE || RELOCATABLE
+#if MAIN_MODULE
     'GOT.mem': GOTProxyHandler,
     'GOT.func': GOTProxyHandler,
 #endif
@@ -725,9 +719,6 @@ function getWasmImports() {
     wasmExports = instance.exports;
 
 #if MAIN_MODULE
-#if RELOCATABLE
-    wasmExports = relocateExports(wasmExports, {{{ GLOBAL_BASE }}});
-#endif
     var origExports = wasmExports;
 #endif
 #if SPLIT_MODULE
@@ -786,8 +777,6 @@ function getWasmImports() {
     LDSO.init();
 #endif
     loadDylibs();
-#elif RELOCATABLE
-    reportUndefinedSymbols();
 #endif
 
 #if ABORT_ON_WASM_EXCEPTIONS

--- a/src/settings.js
+++ b/src/settings.js
@@ -1098,13 +1098,6 @@ var DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = [];
 // [link]
 var INCLUDE_FULL_LIBRARY = false;
 
-// If set to 1, we emit relocatable code from the LLVM backend; both
-// globals and function pointers are all offset (by gb and fp, respectively)
-// Automatically set for SIDE_MODULE or MAIN_MODULE.
-// [compile+link]
-// [deprecated]
-var RELOCATABLE = false;
-
 // A main module is a file compiled in a way that allows us to link it to
 // a side module at runtime.
 //

--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -21,36 +21,6 @@ var WebAssembly = {
 #endif
   },
 
-#if RELOCATABLE
-  // Only needed in RELOCATABLE builds since normal builds export the table
-  // from the wasm module.
-  // Table is not a normal constructor and instead returns the array object.
-  // That lets us use the length property automatically, which is simpler and
-  // smaller (but instanceof will not report that an instance of Table is an
-  // instance of this function).
-  Table: /** @constructor */ function(opts) {
-    var ret = new Array(opts['initial']);
-#if ALLOW_TABLE_GROWTH
-    ret.grow = function(by) {
-      ret.push(null);
-    };
-#else
-#if ASSERTIONS // without assertions we'll throw on calling the missing function
-    ret.grow = function(by) {
-      abort('Unable to grow wasm table. Build with ALLOW_TABLE_GROWTH.')
-    };
-#endif // ASSERTIONS
-#endif // ALLOW_TABLE_GROWTH
-    ret.set = function(i, func) {
-      ret[i] = func;
-    };
-    ret.get = function(i) {
-      return ret[i];
-    };
-    return ret;
-  },
-#endif
-
   Module: function(binary) {
     // TODO: use the binary and info somehow - right now the wasm2js output is embedded in
     // the main JS

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -191,18 +191,9 @@ def needs_dylink(func):
   assert callable(func)
 
   @wraps(func)
-  def decorated(self, relocatable, *args, **kwargs):
+  def decorated(self, *args, **kwargs):
     self.check_dylink()
-    if relocatable:
-      # Since `-sMAIN_MODULE` no longer implies `-sRELOCATABLE` but we want
-      # to keep that combination working we run all the `@needs_dylink` tests
-      # both with and without the explicit `-sRELOCATABLE`
-      self.set_setting('RELOCATABLE')
-      self.cflags.append('-Wno-deprecated')
     return func(self, *args, **kwargs)
-
-  parameterize(decorated, {'': (False,),
-                           'relocatable': (True,)})
 
   return decorated
 
@@ -3319,10 +3310,6 @@ Var: 42
 
     # sanitizers add a lot of extra symbols
     if is_sanitizing(self.cflags):
-      return
-
-    if self.get_setting('RELOCATABLE'):
-      # The relocatable version of this test produces slightly different exports.
       return
 
     def get_data_exports(wasm):

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15355,20 +15355,10 @@ addToLibrary({
     err_no_fast = self.run_process([EMCC, test_file('hello_world.c'), '-v', '-O2'], stderr=PIPE).stderr
     self.assertNotContained('--fast-math', err_no_fast)
 
-  def test_relocatable(self):
-    # This setting is due for removal:
-    # https://github.com/emscripten-core/emscripten/issues/25262
-    self.do_run_in_out_file_test('hello_world.c', cflags=['-Wno-deprecated', '-sRELOCATABLE'])
-
   def test_linkable(self):
     # This setting is due for removal:
     # https://github.com/emscripten-core/emscripten/issues/25262
     self.do_run_in_out_file_test('hello_world.c', cflags=['-Wno-deprecated', '-sLINKABLE'])
-
-  def test_linkable_relocatable(self):
-    # These setting is due for removal:
-    # https://github.com/emscripten-core/emscripten/issues/25262
-    self.do_run_in_out_file_test('hello_world.c', cflags=['-Wno-deprecated', '-sLINKABLE', '-sRELOCATABLE'])
 
   # Tests encoding of all byte pairs for binary encoding in SINGLE_FILE mode.
   @parameterized({

--- a/tools/building.py
+++ b/tools/building.py
@@ -218,7 +218,7 @@ def lld_flags_for_executable(external_symbols):
 
   cmd.extend(f'--export-if-defined={e}' for e in settings.EXPORT_IF_DEFINED)
 
-  if settings.MAIN_MODULE or settings.RELOCATABLE:
+  if settings.MAIN_MODULE or settings.SIDE_MODULE:
     cmd.append('--experimental-pic')
     cmd.append('--unresolved-symbols=import-dynamic')
     if not settings.WASM_BIGINT:
@@ -228,11 +228,8 @@ def lld_flags_for_executable(external_symbols):
       # checking of shared library functions in this case.
       cmd.append('--no-shlib-sigcheck')
 
-  if settings.RELOCATABLE:
-    if settings.SIDE_MODULE:
-      cmd.append('-shared')
-    else:
-      cmd.append('-pie')
+  if settings.SIDE_MODULE:
+    cmd.append('-shared')
     if not settings.LINKABLE:
       cmd.append('--no-export-dynamic')
   else:
@@ -274,7 +271,7 @@ def lld_flags_for_executable(external_symbols):
   else:
     cmd.append('--no-stack-first')
 
-  if not settings.RELOCATABLE:
+  if not settings.SIDE_MODULE:
     cmd.append('--table-base=%s' % settings.TABLE_BASE)
     if not settings.STACK_FIRST:
       cmd.append('--global-base=%s' % settings.GLOBAL_BASE)
@@ -1322,7 +1319,7 @@ def read_and_preprocess(filename, expand_macros=False):
 
 def js_legalization_pass_flags():
   flags = []
-  if settings.RELOCATABLE or settings.MAIN_MODULE:
+  if settings.SIDE_MODULE or settings.MAIN_MODULE:
     # When building in relocatable mode, we also want access the original
     # non-legalized wasm functions (since wasm modules can and do link to
     # the original, non-legalized, functions).

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -124,7 +124,7 @@ def get_lib_dir(absolute):
       subdir.append('thinlto')
     else:
       subdir.append('lto')
-  if settings.RELOCATABLE or settings.MAIN_MODULE:
+  if settings.MAIN_MODULE:
     subdir.append('pic')
   if subdir:
     path = Path(path, '-'.join(subdir))

--- a/tools/compile.py
+++ b/tools/compile.py
@@ -50,10 +50,10 @@ def get_clang_flags(user_args):
     if '-mbulk-memory' not in user_args:
       flags.append('-mbulk-memory')
 
-  if (settings.MAIN_MODULE or settings.RELOCATABLE) and '-fPIC' not in user_args:
+  if settings.MAIN_MODULE or settings.SIDE_MODULE and '-fPIC' not in user_args:
     flags.append('-fPIC')
 
-  if settings.MAIN_MODULE or settings.RELOCATABLE or settings.LINKABLE or '-fPIC' in user_args:
+  if settings.MAIN_MODULE or settings.SIDE_MODULE or settings.LINKABLE or '-fPIC' in user_args:
     if not any(a.startswith('-fvisibility') for a in user_args):
       # For relocatable code we default to visibility=default in emscripten even
       # though the upstream backend defaults visibility=hidden.  This matches the

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -372,9 +372,6 @@ def emscript(in_wasm, out_wasm, outfile_js, js_syms, finalize=True, base_metadat
       shutil.copy(in_wasm, out_wasm)
     metadata = get_metadata(in_wasm, out_wasm, False, [])
 
-  if settings.RELOCATABLE and settings.MEMORY64 == 2:
-    metadata.imports += ['__memory_base32']
-
   # If the binary has already been finalized the settings have already been
   # updated and we can skip updating them.
   if finalize:
@@ -422,20 +419,6 @@ def emscript(in_wasm, out_wasm, outfile_js, js_syms, finalize=True, base_metadat
   for e in settings.EXPORTED_FUNCTIONS:
     if not js_manipulation.isidentifier(e):
       diagnostics.warning('js-compiler', f'export name is not a valid JS symbol: "{e}".  Use `Module` or `wasmExports` to access this symbol')
-
-  # memory and global initializers
-
-  if settings.RELOCATABLE:
-    dylink_sec = webassembly.parse_dylink_section(in_wasm)
-    static_bump = align_memory(dylink_sec.mem_size)
-    set_memory(static_bump)
-    logger.debug('stack_low: %d, stack_high: %d, heap_base: %d', settings.STACK_LOW, settings.STACK_HIGH, settings.HEAP_BASE)
-
-    # When building relocatable output (e.g. MAIN_MODULE) the reported table
-    # size does not include the reserved slot at zero for the null pointer.
-    # So we need to offset the elements by 1.
-    if settings.INITIAL_TABLE == -1:
-      settings.INITIAL_TABLE = dylink_sec.table_size + 1
 
   if metadata.invoke_funcs:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$getWasmTableEntry']
@@ -749,8 +732,6 @@ def create_asm_consts(metadata):
       func = f'function({args}) {{ {body} }}'
     else:
       func = f'({args}) => {{ {body} }}'
-    if settings.RELOCATABLE:
-      addr += settings.GLOBAL_BASE
     asm_consts[addr] = func
   asm_consts = sorted(asm_consts.items())
   return asm_consts
@@ -827,11 +808,6 @@ def add_standard_wasm_imports(send_items_map):
   # TODO(sbc): can we make these into normal library symbols?
   if settings.IMPORTED_MEMORY:
     send_items_map['memory'] = 'wasmMemory'
-
-  if settings.RELOCATABLE:
-    send_items_map['__indirect_function_table'] = 'wasmTable'
-    if settings.MEMORY64:
-      send_items_map['__table_base32'] = '___table_base32'
 
   if settings.AUTODEBUG:
     extra_sent_items += [

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -251,7 +251,7 @@ def apply_min_browser_versions():
     enable_feature(Feature.BULK_MEMORY, 'pthreads')
   elif settings.WASM_WORKERS or settings.SHARED_MEMORY:
     enable_feature(Feature.BULK_MEMORY, 'shared-mem')
-  if settings.RELOCATABLE:
+  if settings.MAIN_MODULE or settings.SIDE_MODULE:
     enable_feature(Feature.MUTABLE_GLOBALS, 'dynamic linking')
   if settings.MEMORY64 == 1:
     enable_feature(Feature.MEMORY64, 'MEMORY64')

--- a/tools/link.py
+++ b/tools/link.py
@@ -381,7 +381,7 @@ def get_binaryen_passes(options):
     passes += ['--asyncify']
     if settings.MAIN_MODULE:
       passes += ['--pass-arg=asyncify-export-globals']
-    elif settings.RELOCATABLE:
+    elif settings.SIDE_MODULE:
       passes += ['--pass-arg=asyncify-import-globals']
     if settings.ASSERTIONS:
       passes += ['--pass-arg=asyncify-asserts']
@@ -486,7 +486,7 @@ def get_worker_js_suffix():
 
 def setup_pthreads():
   # pthreads + dynamic linking has certain limitations
-  if settings.MAIN_MODULE or settings.RELOCATABLE:
+  if settings.MAIN_MODULE:
     diagnostics.warning('experimental', 'dynamic linking + pthreads is experimental')
   if settings.ALLOW_MEMORY_GROWTH and not settings.GROWABLE_ARRAYBUFFERS:
     diagnostics.warning('pthreads-mem-growth', '-pthread + ALLOW_MEMORY_GROWTH may run non-wasm code slowly, see https://github.com/WebAssembly/design/issues/1271')
@@ -527,7 +527,7 @@ def set_initial_memory():
   if settings.IMPORTED_MEMORY:
     if user_specified_initial_heap:
       # Some of these could (and should) be implemented.
-      exit_with_error('INITIAL_HEAP is currently not compatible with IMPORTED_MEMORY (which is enabled indirectly via SHARED_MEMORY, RELOCATABLE)')
+      exit_with_error('INITIAL_HEAP is currently not compatible with IMPORTED_MEMORY')
     # The default for imported memory is to fall back to INITIAL_MEMORY.
     settings.INITIAL_HEAP = -1
 
@@ -803,7 +803,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
 
   if options.shared and not settings.FAKE_DYLIBS:
     default_setting('SIDE_MODULE', 1)
-    default_setting('RELOCATABLE', 1)
 
   if not settings.FAKE_DYLIBS:
     options.dylibs = get_dylibs(options, linker_args)
@@ -952,7 +951,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       exit_with_error('WASM_ESM_INTEGRATION requires EXPORT_ES6')
     if settings.MODULARIZE != 'instance':
       exit_with_error('WASM_ESM_INTEGRATION requires MODULARIZE=instance')
-    if settings.RELOCATABLE:
+    if settings.MAIN_MODULE:
       exit_with_error('WASM_ESM_INTEGRATION is not compatible with dynamic linking')
     if settings.ASYNCIFY:
       exit_with_error('WASM_ESM_INTEGRATION is not compatible with -sASYNCIFY')
@@ -1254,8 +1253,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       settings.INCLUDE_FULL_LIBRARY = 1
     # Called from preamble.js once the main module is instantiated.
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$loadDylibs']
-    if not settings.RELOCATABLE:
-      settings.REQUIRED_EXPORTS += ['__stack_pointer']
+    settings.REQUIRED_EXPORTS += ['__stack_pointer']
 
   if settings.MAIN_MODULE == 1 or settings.SIDE_MODULE == 1:
     settings.LINKABLE = 1
@@ -1274,7 +1272,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       '$registerTLSInit',
     ]
 
-  if settings.MAIN_MODULE or settings.RELOCATABLE:
+  if settings.MAIN_MODULE:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
       '$reportUndefinedSymbols',
       '$relocateExports',
@@ -1354,15 +1352,11 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       'emscripten_stack_get_free',
       'emscripten_stack_get_base',
       'emscripten_stack_get_current',
+      # We call this function during startup which caches the stack limits
+      # in wasm globals allowing get_base/get_free to be super fast.
+      # See compiler-rt/stack_limits.S.
+      'emscripten_stack_init',
     ]
-
-    # We call one of these two functions during startup which caches the stack limits
-    # in wasm globals allowing get_base/get_free to be super fast.
-    # See compiler-rt/stack_limits.S.
-    if settings.RELOCATABLE:
-      settings.REQUIRED_EXPORTS += ['emscripten_stack_set_limits']
-    else:
-      settings.REQUIRED_EXPORTS += ['emscripten_stack_init']
 
   if settings.STACK_OVERFLOW_CHECK >= 2:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$setStackLimits']
@@ -1538,9 +1532,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     # Any "pointers" passed to JS will now be i64's, in both modes.
     settings.WASM_BIGINT = 1
 
-  if settings.MEMORY64 and settings.RELOCATABLE:
-    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.append('__table_base32')
-
   if settings.WASM_WORKERS or (settings.SHARED_MEMORY and not settings.PTHREADS):
     add_system_js_lib('libwasm_worker.js')
 
@@ -1590,7 +1581,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       'removeRunDependency',
     ]
 
-  if settings.PTHREADS or settings.WASM_WORKERS or settings.RELOCATABLE:
+  if settings.PTHREADS or settings.WASM_WORKERS:
     settings.IMPORTED_MEMORY = 1
 
   set_initial_memory()
@@ -1615,7 +1606,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       not settings.STANDALONE_WASM and \
       not settings.AUTODEBUG and \
       not settings.ASSERTIONS and \
-      not settings.RELOCATABLE and \
       not settings.MAIN_MODULE and \
           settings.MINIFY_WASM_EXPORT_NAMES:
     settings.MINIFY_WASM_IMPORTS_AND_EXPORTS = 1
@@ -2747,7 +2737,7 @@ def process_libraries(options, flags):
       continue
 
     static_lib = f'lib{lib}.a'
-    if not settings.RELOCATABLE and not settings.MAIN_MODULE and not find_library(static_lib, options.lib_dirs):
+    if not settings.MAIN_MODULE and not find_library(static_lib, options.lib_dirs):
       # Normally we can rely on the native linker to expand `-l` args.
       # However, emscripten also supports fake `.so` files that are actually
       # just regular object files.  This means we need to support `.so` files even

--- a/tools/maint/gen_sig_info.py
+++ b/tools/maint/gen_sig_info.py
@@ -395,7 +395,7 @@ def main(args):
   extract_sig_info(sig_info, {'LEGACY_GL_EMULATION': 1}, ['-DGLES'])
   extract_sig_info(sig_info, {'USE_GLFW': 2, 'FULL_ES3': 1, 'MAX_WEBGL_VERSION': 2})
   extract_sig_info(sig_info, {'STANDALONE_WASM': 1})
-  extract_sig_info(sig_info, {'MAIN_MODULE': 2, 'RELOCATABLE': 1, 'ASYNCIFY': 1})
+  extract_sig_info(sig_info, {'MAIN_MODULE': 2, 'ASYNCIFY': 1})
 
   write_sig_library(args.output, sig_info)
   if args.update:

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -116,7 +116,7 @@ def get(ports, settings, shared):
 
     cflags += ['-I' + freetype_include, '-I' + os.path.join(freetype_include, 'config')]
 
-    if settings.RELOCATABLE:
+    if settings.MAIN_MODULE:
       cflags.append('-fPIC')
 
     if settings.PTHREADS:

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -83,7 +83,6 @@ COMPILE_TIME_SETTINGS = {
     'WASM_LEGACY_EXCEPTIONS',
     'MAIN_MODULE',
     'SIDE_MODULE',
-    'RELOCATABLE',
     'LINKABLE',
     'STRICT',
     'EMSCRIPTEN_TRACING',
@@ -115,7 +114,6 @@ DEPRECATED_SETTINGS = {
     'LEGALIZE_JS_FFI': 'to disable JS type legalization use `-sWASM_BIGINT` or `-sSTANDALONE_WASM`',
     'ASYNCIFY_EXPORTS': 'please use JSPI_EXPORTS instead',
     'LINKABLE': 'under consideration for removal (https://github.com/emscripten-core/emscripten/issues/25262)',
-    'RELOCATABLE': ' under consideration for removal (https://github.com/emscripten-core/emscripten/issues/25262)',
 }
 
 # Settings that don't need to be externalized when serializing to json because they
@@ -126,12 +124,11 @@ INTERNAL_SETTINGS = {
 
 # List of incompatible settings, of the form (SETTINGS_A, SETTING_B, OPTIONAL_REASON_FOR_INCOMPAT)
 INCOMPATIBLE_SETTINGS = [
-    ('MINIMAL_RUNTIME', 'RELOCATABLE', None),
+    ('MINIMAL_RUNTIME', 'MAIN_MODULE', None),
     ('WASM2JS', 'MAIN_MODULE', 'wasm2js does not support dynamic linking'),
     ('WASM2JS', 'SIDE_MODULE', 'wasm2js does not support dynamic linking'),
     ('MODULARIZE', 'NO_DECLARE_ASM_MODULE_EXPORTS', None),
     ('EVAL_CTORS', 'WASM2JS', None),
-    ('EVAL_CTORS', 'RELOCATABLE', 'movable segments'),
     # In Asyncify exports can be called more than once, and this seems to not
     # work properly yet (see test_emscripten_scan_registers).
     ('EVAL_CTORS', 'ASYNCIFY', None),
@@ -253,6 +250,7 @@ LEGACY_SETTINGS = [
     ['NODEJS_CATCH_EXIT', [0], 'No longer supported'],
     ['NODEJS_CATCH_REJECTION', [0], 'No longer supported'],
     ['POLYFILL_OLD_MATH_FUNCTIONS', [0], 'No longer supported'],
+    ['RELOCATABLE', [0], 'No longer supported'],
 ]
 
 user_settings: dict[str, str] = {}

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -61,12 +61,12 @@ def get_base_cflags(build_dir, force_object_files=False, preprocess=True):
   flags = ['-g', '-sSTRICT', '-Werror']
   if settings.LTO and not force_object_files:
     flags += ['-flto=' + settings.LTO]
-  if settings.RELOCATABLE or settings.MAIN_MODULE:
-    # Explicitly include `-sRELOCATABLE` when building system libraries.
+  if settings.MAIN_MODULE:
+    # Explicitly include `-sMAIN_MODULE` when building system libraries.
     # `-fPIC` alone is not enough to configure trigger the building and
     # caching of `pic` libraries (see `get_lib_dir` in `cache.py`)
     # FIXME(sbc): `-fPIC` should really be enough here.
-    flags += ['-fPIC', '-sRELOCATABLE']
+    flags += ['-fPIC', '-sMAIN_MODULE']
     if preprocess:
       flags += ['-DEMSCRIPTEN_DYNAMIC_LINKING']
   if settings.MEMORY64:
@@ -1404,7 +1404,7 @@ class libc(MuslInternalLibrary,
           'system.c',
         ])
 
-    if settings.RELOCATABLE or settings.MAIN_MODULE:
+    if settings.MAIN_MODULE:
       libc_files += files_in_path(path='system/lib/libc', filenames=['dynlink.c'])
 
     libc_files += files_in_path(
@@ -1562,7 +1562,7 @@ class libwasm_workers(DebugLibrary):
 
   def can_use(self):
     # see src/library_wasm_worker.js
-    return super().can_use() and not settings.SINGLE_FILE and not settings.RELOCATABLE
+    return super().can_use() and not settings.SINGLE_FILE and not settings.MAIN_MODULE
 
 
 class libsockets(MuslInternalLibrary, MTLibrary):
@@ -2454,7 +2454,7 @@ def get_libs_to_link(options):
   else:
     add_library('libsockets')
 
-  if settings.WASM_WORKERS and (not settings.SINGLE_FILE and not settings.RELOCATABLE):
+  if settings.WASM_WORKERS and (not settings.SINGLE_FILE and not settings.MAIN_MODULE):
     # When we include libwasm_workers we use `--whole-archive` to ensure
     # that the static constructor (`emscripten_wasm_worker_main_thread_initialize`)
     # is run.


### PR DESCRIPTION
This setting was deprecated in #25265.

We stopping using RELOCATABLE in dynamic linking (to build the main module) in #25522.