### PR TITLE
Update docs for STRICT=1. NFC

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1723,7 +1723,6 @@ Changes enabled by this:
   - AUTO_JS_LIBRARIES is disabled.
   - AUTO_NATIVE_LIBRARIES is disabled.
   - DEFAULT_TO_CXX is disabled.
-  - USE_GLFW is set to 0 rather than 2 by default.
   - ALLOW_UNIMPLEMENTED_SYSCALLS is disabled.
   - INCOMING_MODULE_JS_API is set to empty by default.
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1174,7 +1174,6 @@ var LINKABLE = false;
 //   - AUTO_JS_LIBRARIES is disabled.
 //   - AUTO_NATIVE_LIBRARIES is disabled.
 //   - DEFAULT_TO_CXX is disabled.
-//   - USE_GLFW is set to 0 rather than 2 by default.
 //   - ALLOW_UNIMPLEMENTED_SYSCALLS is disabled.
 //   - INCOMING_MODULE_JS_API is set to empty by default.
 // [compile+link]


### PR DESCRIPTION
The `USE_GLFW` setting has been zero by default since #19939