### PR TITLE
Warn about usage of deprecated EMSCRIPTEN macro. NFC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 5.0.3 (in development)
 ----------------------
+- Warn on usage of the deprecated `EMSCRIPTEN` macro (`__EMSCRIPTEN__` should
+  be used instead). (#26381)
 - When building with `-sWASM_WORKERS` emscripten will no longer include pthread
   API stub functions.  These stub functions where never designed to work under
   Wasm Workers, so its safer to error at link time if pthread APIs are used

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -28,6 +28,13 @@
 #include "wget.h"
 #include "version.h"
 
+#ifdef __EMSCRIPTEN__
+#ifndef EMSCRIPTEN
+#define EMSCRIPTEN
+#endif
+#pragma clang deprecated(EMSCRIPTEN, "use __EMSCRIPTEN__ instead")
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11292,6 +11292,17 @@ int main(void) {
     test_error('Module = { preRun: [] };')
     test_error('Module.preRun = [];')
 
+  def test_EMSCRIPTEN_macro(self):
+    create_file('src.c', '''
+      #include <emscripten.h>
+
+      #ifdef EMSCRIPTEN
+      int foo;
+      #endif
+    ''')
+    self.assert_fail([EMCC, '-Werror', 'src.c', '-c'], "'EMSCRIPTEN' has been marked as deprecated: use __EMSCRIPTEN__ instead")
+    self.assert_fail([EMCC, '-sSTRICT', '-Werror', 'src.c', '-c'], "'EMSCRIPTEN' has been marked as deprecated: use __EMSCRIPTEN__ instead")
+
   def test_EMSCRIPTEN_and_STRICT(self):
     # __EMSCRIPTEN__ is the proper define; we support EMSCRIPTEN for legacy
     # code, unless STRICT is enabled.


### PR DESCRIPTION
This change is in preparation for removing the pre-defintion of this macro from the emcc driver.