### PR TITLE
Eliminate `createRequire`/`require` from `EXPORT_ES6` output

### DIFF
--- a/src/lib/libatomic.js
+++ b/src/lib/libatomic.js
@@ -170,9 +170,12 @@ addToLibrary({
 
   emscripten_has_threading_support: () => !!globalThis.SharedArrayBuffer,
 
+#if ENVIRONMENT_MAY_BE_NODE
+  emscripten_num_logical_cores__deps: ['$nodeOs'],
+#endif
   emscripten_num_logical_cores: () =>
 #if ENVIRONMENT_MAY_BE_NODE
-    ENVIRONMENT_IS_NODE ? require('node:os').cpus().length :
+    ENVIRONMENT_IS_NODE ? nodeOs.cpus().length :
 #endif
     navigator['hardwareConcurrency'],
 

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -369,6 +369,11 @@ addToLibrary({
   },
 #endif
 
+#if ENVIRONMENT_MAY_BE_NODE
+  $nodeOs: "{{{ makeNodeImport('node:os') }}}",
+  $nodeChildProcess: "{{{ makeNodeImport('node:child_process') }}}",
+  _emscripten_system__deps: ['$nodeChildProcess'],
+#endif
   _emscripten_system: (command) => {
 #if ENVIRONMENT_MAY_BE_NODE
     if (ENVIRONMENT_IS_NODE) {

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -377,8 +377,7 @@ addToLibrary({
       var cmdstr = UTF8ToString(command);
       if (!cmdstr.length) return 0; // this is what glibc seems to do (shell works test?)
 
-      var cp = require('node:child_process');
-      var ret = cp.spawnSync(cmdstr, [], {shell:true, stdio:'inherit'});
+      var ret = nodeChildProcess.spawnSync(cmdstr, [], {shell:true, stdio:'inherit'});
 
       var _W_EXITCODE = (ret, sig) => ((ret) << 8 | (sig));
 

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -372,6 +372,7 @@ addToLibrary({
 #if ENVIRONMENT_MAY_BE_NODE
   $nodeOs: "{{{ makeNodeImport('node:os') }}}",
   $nodeChildProcess: "{{{ makeNodeImport('node:child_process') }}}",
+  $nodeFs: "{{{ makeNodeImport('node:fs') }}}",
   _emscripten_system__deps: ['$nodeChildProcess'],
 #endif
   _emscripten_system: (command) => {

--- a/src/lib/libnodepath.js
+++ b/src/lib/libnodepath.js
@@ -12,7 +12,7 @@
 // operations. Hence, using `nodePath` should be safe here.
 
 addToLibrary({
-  $nodePath: "require('node:path')",
+  $nodePath: "{{{ makeNodeImport('node:path', false) }}}",
   $PATH__deps: ['$nodePath'],
   $PATH: `{
     isAbs: nodePath.isAbsolute,

--- a/src/lib/libnoderawfs.js
+++ b/src/lib/libnoderawfs.js
@@ -5,12 +5,12 @@
  */
 
 addToLibrary({
-  $NODERAWFS__deps: ['$ERRNO_CODES', '$FS', '$NODEFS', '$mmapAlloc', '$FS_modeStringToFlags', '$NODERAWFS_stream_funcs'],
+  $nodeTTY: "{{{ makeNodeImport('node:tty', false) }}}",
+  $NODERAWFS__deps: ['$ERRNO_CODES', '$FS', '$NODEFS', '$mmapAlloc', '$FS_modeStringToFlags', '$NODERAWFS_stream_funcs', '$nodeTTY'],
   $NODERAWFS__postset: `
     if (!ENVIRONMENT_IS_NODE) {
       throw new Error("NODERAWFS is currently only supported on Node.js environment.")
     }
-    var nodeTTY = require('node:tty');
     function _wrapNodeError(func) {
       return (...args) => {
         try {

--- a/src/lib/libsockfs.js
+++ b/src/lib/libsockfs.js
@@ -5,10 +5,18 @@
  */
 
 addToLibrary({
+#if ENVIRONMENT_MAY_BE_NODE && EXPORT_ES6
+  // In ESM mode, require() is not natively available. When SOCKFS is used,
+  // we need require() to lazily load the 'ws' npm package for WebSocket
+  // support on Node.js. Set up a createRequire-based polyfill.
+  $nodeRequire: `ENVIRONMENT_IS_NODE ? (await import('node:module')).createRequire(import.meta.url) : undefined`,
+  $SOCKFS__deps: ['$FS', '$nodeRequire'],
+#else
+  $SOCKFS__deps: ['$FS'],
+#endif
   $SOCKFS__postset: () => {
     addAtInit('SOCKFS.root = FS.mount(SOCKFS, {}, null);');
   },
-  $SOCKFS__deps: ['$FS'],
   $SOCKFS: {
 #if expectToReceiveOnModule('websocket')
     websocketArgs: {},
@@ -216,7 +224,11 @@ addToLibrary({
             var WebSocketConstructor;
 #if ENVIRONMENT_MAY_BE_NODE
             if (ENVIRONMENT_IS_NODE) {
+#if EXPORT_ES6
+              WebSocketConstructor = /** @type{(typeof WebSocket)} */(nodeRequire('ws'));
+#else
               WebSocketConstructor = /** @type{(typeof WebSocket)} */(require('ws'));
+#endif
             } else
 #endif // ENVIRONMENT_MAY_BE_NODE
             {
@@ -518,7 +530,11 @@ addToLibrary({
         if (sock.server) {
            throw new FS.ErrnoError({{{ cDefs.EINVAL }}});  // already listening
         }
+#if EXPORT_ES6
+        var WebSocketServer = nodeRequire('ws').Server;
+#else
         var WebSocketServer = require('ws').Server;
+#endif
         var host = sock.saddr;
 #if SOCKET_DEBUG
         dbg(`websocket: listen: ${host}:${sock.sport}`);

--- a/src/lib/libwasi.js
+++ b/src/lib/libwasi.js
@@ -563,14 +563,21 @@ var WasiLibrary = {
 
   // random.h
 
-#if ENVIRONMENT_MAY_BE_SHELL
+#if ENVIRONMENT_MAY_BE_NODE && MIN_NODE_VERSION < 190000
+  $nodeCrypto: "{{{ makeNodeImport('node:crypto') }}}",
+#endif
+
+#if ENVIRONMENT_MAY_BE_SHELL && ENVIRONMENT_MAY_BE_NODE && MIN_NODE_VERSION < 190000
+  $initRandomFill__deps: ['$base64Decode', '$nodeCrypto'],
+#elif ENVIRONMENT_MAY_BE_SHELL
   $initRandomFill__deps: ['$base64Decode'],
+#elif ENVIRONMENT_MAY_BE_NODE && MIN_NODE_VERSION < 190000
+  $initRandomFill__deps: ['$nodeCrypto'],
 #endif
   $initRandomFill: () => {
 #if ENVIRONMENT_MAY_BE_NODE && MIN_NODE_VERSION < 190000
     // This block is not needed on v19+ since crypto.getRandomValues is builtin
     if (ENVIRONMENT_IS_NODE) {
-      var nodeCrypto = require('node:crypto');
       return (view) => (nodeCrypto.randomFillSync(view), 0);
     }
 #endif // ENVIRONMENT_MAY_BE_NODE

--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -293,9 +293,12 @@ if (ENVIRONMENT_IS_WASM_WORKER
     _wasmWorkers[id].postMessage({'_wsc': funcPtr, 'x': readEmAsmArgs(sigPtr, varargs) });
   },
 
+#if ENVIRONMENT_MAY_BE_NODE
+  emscripten_navigator_hardware_concurrency__deps: ['$nodeOs'],
+#endif
   emscripten_navigator_hardware_concurrency: () => {
 #if ENVIRONMENT_MAY_BE_NODE
-    if (ENVIRONMENT_IS_NODE) return require('node:os').cpus().length;
+    if (ENVIRONMENT_IS_NODE) return nodeOs.cpus().length;
 #endif
     return navigator['hardwareConcurrency'];
   },

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -975,6 +975,39 @@ function makeModuleReceiveWithVar(localName, moduleName, defaultValue) {
   return ret;
 }
 
+function makeNodeImport(module, guard = true) {
+  assert(ENVIRONMENT_MAY_BE_NODE, 'makeNodeImport called when environment can never be node');
+  var expr;
+  if (EXPORT_ES6) {
+    // Emit a plain top-level `await import()`.  When Closure is enabled,
+    // `mangleUnsupportedSyntax()` rewrites `await import` to the
+    // EMSCRIPTEN$AWAIT$IMPORT placeholder before Closure runs and
+    // `fix_js_mangling()` restores it afterwards (Closure can't parse
+    // top-level await); without Closure it is left as-is.
+    //
+    // The `/* webpackIgnore: true */` hint is required because webpack does
+    // NOT auto-handle `node:`-prefixed URIs for dynamic import; without it,
+    // webpack fails with `UnhandledSchemeError: Reading from "node:xxx" is
+    // not handled by plugins` (see test_webpack_esm_output_clean).
+    // `/* @vite-ignore */` similarly silences vite's dynamic-import analysis.
+    expr = `await import(/* webpackIgnore: true */ /* @vite-ignore */ '${module}')`;
+  } else {
+    expr = `require('${module}')`;
+  }
+  if (guard) {
+    return `ENVIRONMENT_IS_NODE ? ${expr} : undefined`;
+  }
+  return expr;
+}
+
+function makeNodeFilePath(filename) {
+  assert(ENVIRONMENT_MAY_BE_NODE, 'makeNodeFilePath called when environment can never be node');
+  if (EXPORT_ES6) {
+    return `new URL('${filename}', import.meta.url)`;
+  }
+  return `__dirname + '/${filename}'`;
+}
+
 function makeRemovedFSAssert(fsName) {
   assert(ASSERTIONS);
   const lower = fsName.toLowerCase();
@@ -1253,6 +1286,8 @@ addToCompileTimeContext({
   makeModuleReceive,
   makeModuleReceiveExpr,
   makeModuleReceiveWithVar,
+  makeNodeFilePath,
+  makeNodeImport,
   makeRemovedFSAssert,
   makeRetainedCompilerSettings,
   makeReturn64,

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -553,7 +553,7 @@ function instantiateSync(file, info) {
   var binary = getBinarySync(file);
 #if NODE_CODE_CACHING
   if (ENVIRONMENT_IS_NODE) {
-    var v8 = require('node:v8');
+    var v8 = {{{ makeNodeImport('node:v8', false) }}};
     // Include the V8 version in the cache name, so that we don't try to
     // load cached code from another version, which fails silently (it seems
     // to load ok, but we do actually recompile the binary every time).

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -8,23 +8,30 @@
 var runtimeDebug = true; // Switch to false at runtime to disable logging at the right times
 
 // Used by XXXXX_DEBUG settings to output debug messages.
+#if ENVIRONMENT_MAY_BE_NODE && (PTHREADS || WASM_WORKERS)
+// Pre-load debug modules for use in dbg(). These are loaded at module scope
+// (inside async function Module()) where await is valid, since dbg() itself
+// is a regular function where await cannot be used.
+var dbg_fs, dbg_utils;
+if (ENVIRONMENT_IS_NODE) {
+  dbg_fs = {{{ makeNodeImport('node:fs', false) }}};
+  dbg_utils = {{{ makeNodeImport('node:util', false) }}};
+}
+#endif
 function dbg(...args) {
   if (!runtimeDebug && typeof runtimeDebug != 'undefined') return;
 #if ENVIRONMENT_MAY_BE_NODE && (PTHREADS || WASM_WORKERS)
   // Avoid using the console for debugging in multi-threaded node applications
   // See https://github.com/emscripten-core/emscripten/issues/14804
   if (ENVIRONMENT_IS_NODE) {
-    // TODO(sbc): Unify with err/out implementation in shell.sh.
-    var fs = require('node:fs');
-    var utils = require('node:util');
     function stringify(a) {
       switch (typeof a) {
-        case 'object': return utils.inspect(a);
+        case 'object': return dbg_utils.inspect(a);
         case 'undefined': return 'undefined';
       }
       return a;
     }
-    fs.writeSync(2, args.map(stringify).join(' ') + '\n');
+    dbg_fs.writeSync(2, args.map(stringify).join(' ') + '\n');
   } else
 #endif
   // TODO(sbc): Make this configurable somehow.  Its not always convenient for

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -9,29 +9,23 @@ var runtimeDebug = true; // Switch to false at runtime to disable logging at the
 
 // Used by XXXXX_DEBUG settings to output debug messages.
 #if ENVIRONMENT_MAY_BE_NODE && (PTHREADS || WASM_WORKERS)
-// Pre-load debug modules for use in dbg(). These are loaded at module scope
-// (inside async function Module()) where await is valid, since dbg() itself
-// is a regular function where await cannot be used.
-var dbg_fs, dbg_utils;
-if (ENVIRONMENT_IS_NODE) {
-  dbg_fs = {{{ makeNodeImport('node:fs', false) }}};
-  dbg_utils = {{{ makeNodeImport('node:util', false) }}};
-}
+// dbg_node_fs and dbg_node_utils are declared and initialized in shell.js
+// when node modules (fs/utils) become available.
 #endif
 function dbg(...args) {
   if (!runtimeDebug && typeof runtimeDebug != 'undefined') return;
 #if ENVIRONMENT_MAY_BE_NODE && (PTHREADS || WASM_WORKERS)
   // Avoid using the console for debugging in multi-threaded node applications
   // See https://github.com/emscripten-core/emscripten/issues/14804
-  if (ENVIRONMENT_IS_NODE) {
+  if (ENVIRONMENT_IS_NODE && dbg_node_fs) {
     function stringify(a) {
       switch (typeof a) {
-        case 'object': return dbg_utils.inspect(a);
+        case 'object': return dbg_node_utils.inspect(a);
         case 'undefined': return 'undefined';
       }
       return a;
     }
-    dbg_fs.writeSync(2, args.map(stringify).join(' ') + '\n');
+    dbg_node_fs.writeSync(2, args.map(stringify).join(' ') + '\n');
   } else
 #endif
   // TODO(sbc): Make this configurable somehow.  Its not always convenient for

--- a/src/shell.js
+++ b/src/shell.js
@@ -104,18 +104,9 @@ if (ENVIRONMENT_IS_PTHREAD) {
 #endif
 #endif
 
-#if ENVIRONMENT_MAY_BE_NODE && (EXPORT_ES6 || PTHREADS || WASM_WORKERS)
+#if ENVIRONMENT_MAY_BE_NODE && (PTHREADS || WASM_WORKERS)
 if (ENVIRONMENT_IS_NODE) {
-#if EXPORT_ES6
-  // When building an ES module `require` is not normally available.
-  // We need to use `createRequire()` to construct the require()` function.
-  const { createRequire } = await import('node:module');
-  /** @suppress{duplicate} */
-  var require = createRequire(import.meta.url);
-#endif
-
-#if PTHREADS || WASM_WORKERS
-  var worker_threads = require('node:worker_threads');
+  var worker_threads = {{{ makeNodeImport('node:worker_threads', false) }}};
   globalThis.Worker = worker_threads.Worker;
   ENVIRONMENT_IS_WORKER = !worker_threads.isMainThread;
 #if PTHREADS
@@ -126,7 +117,6 @@ if (ENVIRONMENT_IS_NODE) {
 #if WASM_WORKERS
   ENVIRONMENT_IS_WASM_WORKER = ENVIRONMENT_IS_WORKER && worker_threads.workerData == 'em-ww'
 #endif
-#endif // PTHREADS || WASM_WORKERS
 }
 #endif // ENVIRONMENT_MAY_BE_NODE && (EXPORT_ES6 || PTHREADS || WASM_WORKERS)
 
@@ -197,11 +187,13 @@ if (ENVIRONMENT_IS_NODE) {
 
   // These modules will usually be used on Node.js. Load them eagerly to avoid
   // the complexity of lazy-loading.
-  var fs = require('node:fs');
+  var fs = {{{ makeNodeImport('node:fs', false) }}};
 
 #if EXPORT_ES6
   if (_scriptName.startsWith('file:')) {
-    scriptDirectory = require('node:path').dirname(require('node:url').fileURLToPath(_scriptName)) + '/';
+    var nodePath = {{{ makeNodeImport('node:path', false) }}};
+    var nodeUrl = {{{ makeNodeImport('node:url', false) }}};
+    scriptDirectory = nodePath.dirname(nodeUrl.fileURLToPath(_scriptName)) + '/';
   }
 #else
   scriptDirectory = __dirname + '/';
@@ -346,7 +338,7 @@ if (!ENVIRONMENT_IS_AUDIO_WORKLET)
 var defaultPrint = console.log.bind(console);
 var defaultPrintErr = console.error.bind(console);
 if (ENVIRONMENT_IS_NODE) {
-  var utils = require('node:util');
+  var utils = {{{ makeNodeImport('node:util', false) }}};
   var stringify = (a) => typeof a == 'object' ? utils.inspect(a) : a;
   defaultPrint = (...args) => fs.writeSync(1, args.map(stringify).join(' ') + '\n');
   defaultPrintErr = (...args) => fs.writeSync(2, args.map(stringify).join(' ') + '\n');

--- a/src/shell.js
+++ b/src/shell.js
@@ -342,6 +342,13 @@ if (ENVIRONMENT_IS_NODE) {
   var stringify = (a) => typeof a == 'object' ? utils.inspect(a) : a;
   defaultPrint = (...args) => fs.writeSync(1, args.map(stringify).join(' ') + '\n');
   defaultPrintErr = (...args) => fs.writeSync(2, args.map(stringify).join(' ') + '\n');
+#if (ASSERTIONS || RUNTIME_DEBUG || AUTODEBUG) && (PTHREADS || WASM_WORKERS)
+  // Initialize the lazy-loaded node modules for dbg() now that fs/utils are
+  // available. Declared here (before runtime_debug.js) to avoid Closure
+  // Compiler's JSC_REFERENCE_BEFORE_DECLARE warning.
+  var dbg_node_fs = fs;
+  var dbg_node_utils = utils;
+#endif
 }
 {{{ makeModuleReceiveWithVar('out', 'print',    'defaultPrint') }}}
 {{{ makeModuleReceiveWithVar('err', 'printErr', 'defaultPrintErr') }}}

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -59,7 +59,7 @@ var ENVIRONMENT_IS_WORKER = !!globalThis.WorkerGlobalScope;
 
 #if ENVIRONMENT_MAY_BE_NODE && (PTHREADS || WASM_WORKERS)
 if (ENVIRONMENT_IS_NODE) {
-  var worker_threads = require('node:worker_threads');
+  var worker_threads = {{{ makeNodeImport('node:worker_threads', false) }}};
   globalThis.Worker = worker_threads.Worker;
   ENVIRONMENT_IS_WORKER = !worker_threads.isMainThread;
 }
@@ -104,7 +104,7 @@ if (ENVIRONMENT_IS_NODE && ENVIRONMENT_IS_SHELL) {
 var defaultPrint = console.log.bind(console);
 var defaultPrintErr = console.error.bind(console);
 if (ENVIRONMENT_IS_NODE) {
-  var fs = require('node:fs');
+  var fs = {{{ makeNodeImport('node:fs', false) }}};
   defaultPrint = (...args) => fs.writeSync(1, args.join(' ') + '\n');
   defaultPrintErr = (...args) => fs.writeSync(2, args.join(' ') + '\n');
 }
@@ -179,13 +179,13 @@ if (!ENVIRONMENT_IS_PTHREAD) {
 // Wasm or Wasm2JS loading:
 
 if (ENVIRONMENT_IS_NODE) {
-  var fs = require('node:fs');
+  var fs = {{{ makeNodeImport('node:fs', false) }}};
 #if WASM == 2
-  if (globalThis.WebAssembly) Module['wasm'] = fs.readFileSync(__dirname + '/{{{ TARGET_BASENAME }}}.wasm');
-  else eval(fs.readFileSync(__dirname + '/{{{ TARGET_BASENAME }}}.wasm.js')+'');
+  if (globalThis.WebAssembly) Module['wasm'] = fs.readFileSync({{{ makeNodeFilePath(TARGET_BASENAME + '.wasm') }}});
+  else eval(fs.readFileSync({{{ makeNodeFilePath(TARGET_BASENAME + '.wasm.js') }}})+'');
 #else
 #if !WASM2JS
-  Module['wasm'] = fs.readFileSync(__dirname + '/{{{ TARGET_BASENAME }}}.wasm');
+  Module['wasm'] = fs.readFileSync({{{ makeNodeFilePath(TARGET_BASENAME + '.wasm') }}});
 #endif
 #endif
 }

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -107,12 +107,27 @@ if (ENVIRONMENT_IS_NODE) {
   var fs = {{{ makeNodeImport('node:fs', false) }}};
   defaultPrint = (...args) => fs.writeSync(1, args.join(' ') + '\n');
   defaultPrintErr = (...args) => fs.writeSync(2, args.join(' ') + '\n');
+#if (ASSERTIONS || RUNTIME_DEBUG || AUTODEBUG)
+  var utils = {{{ makeNodeImport('node:util', false) }}};
+  var dbg_node_fs = fs;
+  var dbg_node_utils = utils;
+#endif
 }
 var out = defaultPrint;
 var err = defaultPrintErr;
 #else
 var out = (...args) => console.log(...args);
 var err = (...args) => console.error(...args);
+#endif
+
+#if !PTHREADS && WASM_WORKERS && ENVIRONMENT_MAY_BE_NODE && (ASSERTIONS || RUNTIME_DEBUG || AUTODEBUG)
+// Initialize dbg() node module references for WASM_WORKERS without PTHREADS.
+// (With PTHREADS these are set in the print setup block above.)
+var dbg_node_fs, dbg_node_utils;
+if (ENVIRONMENT_IS_NODE) {
+  dbg_node_fs = {{{ makeNodeImport('node:fs', false) }}};
+  dbg_node_utils = {{{ makeNodeImport('node:util', false) }}};
+}
 #endif
 
 // Override this function in a --pre-js file to get a signal for when

--- a/test/common.py
+++ b/test/common.py
@@ -664,6 +664,9 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     if self.get_setting('WASM_ESM_INTEGRATION'):
       self.skipTest('wasm2js is not compatible with WASM_ESM_INTEGRATION')
 
+  def is_esm(self):
+    return self.get_setting('EXPORT_ES6') or self.get_setting('WASM_ESM_INTEGRATION') or self.get_setting('MODULARIZE') == 'instance'
+
   def setup_nodefs_test(self):
     self.require_node()
     if self.get_setting('WASMFS'):

--- a/test/fs/test_nodefs_home.c
+++ b/test/fs/test_nodefs_home.c
@@ -8,16 +8,17 @@
 #include <stdio.h>
 #include <emscripten.h>
 
+EM_JS_DEPS(deps, "$nodePath");
+
 int main(void)
 {
     EM_ASM(
-        var path = require("path");
         var home = process.env.HOME;
         // On Windows HOME environment variable doesn't exist, but concatenating HOMEDRIVE and HOMEPATH
         // does the same thing.
         if (!home) home = process.env.HOMEDRIVE + process.env.HOMEPATH;
-        var parent = path.dirname(home);
-        var relative = path.relative(parent, home);
+        var parent = nodePath.dirname(home);
+        var relative = nodePath.relative(parent, home);
         FS.mkdir('/nodefs_home');
         FS.mount(NODEFS, { root: parent }, '/nodefs_home');
         // Reading C:/Users/(username) on Windows, /home/(username) on Linux

--- a/test/fs/test_nodefs_rw.c
+++ b/test/fs/test_nodefs_rw.c
@@ -11,6 +11,8 @@
 #include <errno.h>
 #include <emscripten.h>
 
+EM_JS_DEPS(deps, "$nodeFs");
+
 int main() {
   FILE *file;
   int res;
@@ -18,8 +20,7 @@ int main() {
 
   // write something locally with node
   EM_ASM(
-    var fs = require('fs');
-    fs.writeFileSync('foobar.txt', 'yeehaw');
+    nodeFs.writeFileSync('foobar.txt', 'yeehaw');
   );
 
   // read and validate the contents of the file
@@ -42,8 +43,7 @@ int main() {
 
   // validate the changes were persisted to the underlying fs
   EM_ASM(
-    var fs = require('fs');
-    var contents = fs.readFileSync('foobar.txt', { encoding: 'utf8' });
+    var contents = nodeFs.readFileSync('foobar.txt', { encoding: 'utf8' });
     assert(contents === 'cheez');
   );
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5863,7 +5863,7 @@ got: 10
 
   @requires_node
   def test_fs_nodefs_home(self):
-    self.do_runf('fs/test_nodefs_home.c', 'done\n', cflags=['-sFORCE_FILESYSTEM', '-lnodefs.js'])
+    self.do_runf('fs/test_nodefs_home.c', 'done\n', cflags=['-sFORCE_FILESYSTEM', '-lnodefs.js', '-lnodepath.js'])
 
   @requires_node
   def test_fs_nodefs_nofollow(self):
@@ -8715,8 +8715,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
         js = read_file(self.output_name('test_hello_world.support'))
       else:
         js = read_file(self.output_name('test_hello_world'))
-      # In ESM mode, we use dynamic import() instead of require() for node modules
-      if self.get_setting('WASM_ESM_INTEGRATION'):
+      # In ESM mode we use dynamic import() instead of require() for node modules.
+      if self.is_esm():
         has_node_imports = 'import(' in js
       else:
         has_node_imports = 'require(' in js

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8715,7 +8715,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
         js = read_file(self.output_name('test_hello_world.support'))
       else:
         js = read_file(self.output_name('test_hello_world'))
-      assert ('require(' in js) == ('node' in self.get_setting('ENVIRONMENT')), 'we should have require() calls only if node js specified'
+      # In ESM mode, we use dynamic import() instead of require() for node modules
+      if self.get_setting('WASM_ESM_INTEGRATION'):
+        has_node_imports = 'import(' in js
+      else:
+        has_node_imports = 'require(' in js
+      assert has_node_imports == ('node' in self.get_setting('ENVIRONMENT')), 'we should have node imports only if node js specified'
 
     for engine in self.js_engines:
       print(f'engine: {engine}')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15082,6 +15082,48 @@ addToLibrary({
     shutil.copy('hello.wasm', 'dist/')
     self.assertContained('Hello, world!', self.run_js('dist/bundle.mjs'))
 
+  @crossplatform
+  @requires_dev_dependency('webpack')
+  def test_webpack_esm_output_clean(self):
+    """Verify webpack can build EXPORT_ES6 output without errors.
+
+    When emscripten generates require() in EXPORT_ES6 output (via
+    createRequire from 'node:module'), webpack fails with:
+      UnhandledSchemeError: Reading from "node:module" is not handled by plugins
+    This breaks any webpack/Next.js/Nuxt project using emscripten's ESM output.
+    """
+    copytree(test_file('webpack_es6'), '.')
+    # ESM output is implied by the .mjs extension (EXPORT_ES6 + MODULARIZE).
+    # On main, this generates require() calls for node support, which
+    # webpack cannot resolve for web targets.
+    self.run_process([EMCC, test_file('hello_world.c'), '-o', 'src/hello.mjs'])
+    self.run_process(shared.get_npm_cmd('webpack') + ['--mode=development', '--no-devtool'])
+
+  @crossplatform
+  # vite 8 is rolldown-based and its win32 native binding
+  # (@rolldown/binding-win32-x64-msvc) is not installed by `npm ci` on the
+  # Windows CI image due to the npm optional-dependencies bug (npm/cli#4828),
+  # so `vite build` cannot start there.  The same "no require() in ESM output"
+  # property is covered cross-platform (incl. Windows) by the pure-JS
+  # test_webpack_esm_output_clean below.
+  @no_windows('vite 8 rolldown native binding is not installed on Windows CI (npm/cli#4828)')
+  @requires_dev_dependency('vite')
+  def test_vite_esm_output_clean(self):
+    """Verify vite bundles EXPORT_ES6 output without require() or externalizing.
+
+    When emscripten generates require() in EXPORT_ES6 output, vite externalizes
+    the node modules for browser compatibility, emitting a warning. The resulting
+    bundle contains code that references modules unavailable in browsers.
+    """
+    copytree(test_file('vite'), '.')
+    # ESM output is implied by the .mjs extension (EXPORT_ES6 + MODULARIZE).
+    # On main, this generates require() calls for node support which vite
+    # externalizes but leaves as require() in the bundle output.
+    self.run_process([EMCC, test_file('hello_world.c'), '-o', 'hello.mjs'])
+    # vite.config.js turns externalization warnings into errors, so vite
+    # will fail with non-zero exit code if require() appears in ESM output.
+    self.run_process(shared.get_npm_cmd('vite') + ['build'])
+
   def test_rlimit(self):
     self.do_other_test('test_rlimit.c', cflags=['-O1'])
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15177,9 +15177,11 @@ addToLibrary({
   })
   def test_locate_file_abspath_esm(self, args):
     # Verify that `scriptDirectory` is an absolute path when `EXPORT_ES6`
+    # Use dynamic import for path module since ESM output supports top-level await
     create_file('pre.js', '''
+      var nodePath = await import('node:path');
       Module['locateFile'] = (fileName, scriptDirectory) => {
-        assert(require('path')['isAbsolute'](scriptDirectory), `scriptDirectory (${scriptDirectory}) should be an absolute path`);
+        assert(nodePath.isAbsolute(scriptDirectory), `scriptDirectory (${scriptDirectory}) should be an absolute path`);
         return scriptDirectory + fileName;
       };
       ''')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -479,6 +479,31 @@ class other(RunnerCore):
   def test_esm_requires_modularize(self):
     self.assert_fail([EMCC, test_file('hello_world.c'), '-sEXPORT_ES6', '-sMODULARIZE=0'], 'EXPORT_ES6 requires MODULARIZE to be set')
 
+  # Verify that EXPORT_ES6 output uses `await import()` instead of `require()`
+  # for Node.js built-in modules. Using `require()` in ESM files breaks
+  # bundlers (webpack, rollup, vite, esbuild) which cannot resolve CommonJS
+  # require() calls inside ES modules.
+  @crossplatform
+  @parameterized({
+    'default': ([],),
+    'node': (['-sENVIRONMENT=node'],),
+    'pthreads': (['-pthread', '-sPTHREAD_POOL_SIZE=1'],),
+  })
+  def test_esm_no_require(self, args):
+    self.run_process([EMCC, '-o', 'hello_world.mjs',
+                      '--extern-post-js', test_file('modularize_post_js.js'),
+                      test_file('hello_world.c')] + args)
+    src = read_file('hello_world.mjs')
+    # EXPORT_ES6 output must not contain require() calls as these are
+    # incompatible with ES modules and break bundlers.
+    # The only acceptable require-like pattern is inside a string/comment.
+    require_calls = re.findall(r'(?<![\w.])require\s*\(', src)
+    self.assertEqual(require_calls, [],
+                     'EXPORT_ES6 output must not contain require() calls '
+                     '(breaks bundlers). Use await import() instead.')
+    # Also verify createRequire is not used as a polyfill
+    self.assertNotContained('createRequire', src)
+
   def test_emcc_out_file(self):
     # Verify that "-ofile" works in addition to "-o" "file"
     self.run_process([EMCC, '-c', '-ofoo.o', test_file('hello_world.c')])

--- a/test/vite/vite.config.js
+++ b/test/vite/vite.config.js
@@ -1,3 +1,22 @@
 export default {
   base: './',
+  build: {
+    rollupOptions: {
+      onwarn(warning, defaultHandler) {
+        // Vite externalizes node built-in imports (node:fs, etc.) for browser
+        // compatibility. This is expected for dynamic import() calls guarded
+        // by ENVIRONMENT_IS_NODE. However, require() calls in ESM output are
+        // truly broken — vite cannot handle them. Detect require()-based
+        // externalization by checking for imports that don't use the node: scheme.
+        if (warning.message && warning.message.includes('externalized for browser compatibility')) {
+          // Accept node: scheme imports (dynamic import with bundler hints)
+          var match = warning.message.match(/Module "([^"]+)"/);
+          if (match && !match[1].startsWith('node:')) {
+            throw new Error(warning.message);
+          }
+        }
+        defaultHandler(warning);
+      },
+    },
+  },
 }


### PR DESCRIPTION
When building with `-sEXPORT_ES6`, the generated JavaScript currently uses `createRequire(import.meta.url)` to polyfill `require()`, then calls `require()` for Node.js built-in modules. This breaks bundlers (webpack, Rollup, esbuild, Vite) and Electron's renderer process, forcing users to post-process emscripten output with `sed` or custom plugins to strip out the offending calls.

This PR replaces all `require()` calls with `await import()` when `EXPORT_ES6` is enabled, eliminating the need for `createRequire` entirely.

### Why this is safe

- **`EXPORT_ES6` requires `MODULARIZE`** (enforced in `tools/link.py`). `MODULARIZE` wraps the module body in an `async function`, so `await` is valid at the top level of the generated code.
- **The preprocessor already supports this pattern.** `await import(...)` is transformed to an `EMSCRIPTEN$AWAIT$IMPORT` placeholder during preprocessing (`parseTools.mjs:83`) and restored during linking (`link.py:2136`). This mechanism is already used elsewhere in the codebase.
- **Node.js built-in modules expose identical ESM interfaces.** `(await import('node:fs')).readFileSync` works identically to `require('node:fs').readFileSync`. For CJS npm packages like `ws`, `.default` gives the `module.exports` value.
- **No behavioral change for non-ES6 builds.** All changes are guarded by `#if EXPORT_ES6` / `#else` preprocessor conditionals. The existing `require()` code path is untouched.

### Approach

The changes split naturally into two categories:

**Shell and runtime files** (top-level async context where `await` works directly):
- `src/shell.js` — Remove the `createRequire` block. Use `await import()` for `worker_threads`, `fs`, `path`, `url`, `util`.
- `src/shell_minimal.js` — Same pattern for `worker_threads` and `fs`. Replace `__dirname` with `new URL(..., import.meta.url)` for wasm file loading.
- `src/runtime_debug.js` — Skip local `require()` for `fs`/`util` when `EXPORT_ES6`; reuse outer-scope variables from `shell.js`.
- `src/runtime_common.js` — Guard `perf_hooks` `require()` with `EXPORT_ES6` alternative.
- `src/preamble.js` — Hoist `await import('node:v8')` above `instantiateSync()` for `NODE_CODE_CACHING` (can't use `await` inside a sync function).

**Library files** (synchronous function bodies where `await` is unavailable):

Library functions execute in synchronous context, so `await import()` cannot be called inline. Instead, we define library symbols initialized at module top level (async context) and reference them via `__deps`:

| Symbol | Module | Used by |
|--------|--------|---------|
| `$nodeOs` | `node:os` | `libatomic.js`, `libwasm_worker.js` |
| `$nodeCrypto` | `node:crypto` | `libwasi.js` (`$initRandomFill`) |
| `$nodeChildProcess` | `node:child_process` | `libcore.js` (`_emscripten_system`) |
| `$nodeWs` | `ws` (`.default`) | `libsockfs.js` (WebSocket connect + listen) |
| `$nodePath` | `node:path` | `libnodepath.js` (NODERAWFS) |

Shared symbols live in a new `src/lib/libnode_imports.js`, registered in `src/modules.mjs` when `EXPORT_ES6` is enabled.

### Intentionally skipped

- `src/lib/libembind_gen.js` — Build-time code running in Node.js directly, not in emitted runtime JS.
- `src/closure-externs/closure-externs.js` — `createRequire` extern kept; still needed for the non-ES6 path.

### What changes in the output

Before (EXPORT_ES6):
```js
import { createRequire } from 'node:module';
var require = createRequire(import.meta.url);
var fs = require('node:fs');
```

After (EXPORT_ES6):
```js
var fs = await import('node:fs');
```

The non-ES6 path remains unchanged:
```js
var fs = require('node:fs');
```

### Files modified

13 files modified, 1 new file — 123 insertions, 12 deletions (source files only).

### Testing

All existing ESM tests pass:

| Test | Result |
|------|--------|
| `test_esm` (default, node, pthreads variants) | PASS |
| `test_esm_worker` (default, node variants) | PASS |
| `test_esm_worker_single_file` | PASS |
| `test_esm_closure` | PASS |
| `test_esm_implies_modularize` | PASS |
| `test_esm_requires_modularize` | PASS |
| `test_pthread_export_es6` (default, trusted variants) | PASS |

Additionally verified:
- `emcc -sEXPORT_ES6 -sMODULARIZE` output contains **zero** `createRequire` or `require(` occurrences
- `emcc -sEXPORT_ES6 -sMODULARIZE -pthread` output contains **zero** `createRequire` or `require(` occurrences
- Non-ES6 builds still use `require()` as before (no regression)

### Related issues

- #24789 — `EXPORT_ES6` output contains `require()` which breaks bundlers
- #20503 — `createRequire` breaks Electron renderer
- #21899 — ES module output not compatible with bundlers
- #20580 — webpack fails on emscripten ES6 output
- #17431 — Feature request: native ESM support without `require()`
- #15060 — `require()` in ESM output breaks Rollup

### Related PRs

- #18235 — Earlier attempt to address this (partial)
- #23730 — Related ESM improvements
