### PR TITLE
Simplify MEMFS to always use TypedArray for file data. NFC

### DIFF
--- a/src/lib/libmemfs.js
+++ b/src/lib/libmemfs.js
@@ -70,11 +70,14 @@ addToLibrary({
       } else if (FS.isFile(node.mode)) {
         node.node_ops = MEMFS.ops_table.file.node;
         node.stream_ops = MEMFS.ops_table.file.stream;
-        node.usedBytes = 0; // The actual number of bytes used in the typed array, as opposed to contents.length which gives the whole capacity.
-        // When the byte data of the file is populated, this will point to either a typed array, or a normal JS array. Typed arrays are preferred
-        // for performance, and used by default. However, typed arrays are not resizable like normal JS arrays are, so there is a small disk size
-        // penalty involved for appending file writes that continuously grow a file similar to std::vector capacity vs used -scheme.
-        node.contents = null; 
+        // The actual number of bytes used in the typed array, as opposed to
+        // contents.length which gives the whole capacity.
+        node.usedBytes = 0;
+        // The byte data of the file is stored in a typed array.
+        // Note: typed arrays are not resizable like normal JS arrays are, so
+        // there is a small penalty involved for appending file writes that
+        // continuously grow a file similar to std::vector capacity vs used.
+        node.contents = MEMFS.emptyFileContents ??= new Uint8Array(0);
       } else if (FS.isLink(node.mode)) {
         node.node_ops = MEMFS.ops_table.link.node;
         node.stream_ops = MEMFS.ops_table.link.stream;
@@ -93,42 +96,41 @@ addToLibrary({
 
     // Given a file node, returns its file data converted to a typed array.
     getFileDataAsTypedArray(node) {
-      if (!node.contents) return new Uint8Array(0);
-      if (node.contents.subarray) return node.contents.subarray(0, node.usedBytes); // Make sure to not return excess unused bytes.
-      return new Uint8Array(node.contents);
+#if ASSERTIONS
+      assert(FS.isFile(node.mode), 'getFileDataAsTypedArray called on non-file');
+#endif
+      return node.contents.subarray(0, node.usedBytes); // Make sure to not return excess unused bytes.
     },
 
-    // Allocates a new backing store for the given node so that it can fit at least newSize amount of bytes.
-    // May allocate more, to provide automatic geometric increase and amortized linear performance appending writes.
+    // Allocates a new backing store for the given node so that it can fit at
+    // least newSize amount of bytes.
+    // May allocate more, to provide automatic geometric increase and amortized
+    // linear performance appending writes.
     // Never shrinks the storage.
     expandFileStorage(node, newCapacity) {
-      var prevCapacity = node.contents ? node.contents.length : 0;
+      var prevCapacity = node.contents.length;
       if (prevCapacity >= newCapacity) return; // No need to expand, the storage was already large enough.
-      // Don't expand strictly to the given requested limit if it's only a very small increase, but instead geometrically grow capacity.
-      // For small filesizes (<1MB), perform size*2 geometric increase, but for large sizes, do a much more conservative size*1.125 increase to
-      // avoid overshooting the allocation cap by a very large margin.
+      // Don't expand strictly to the given requested limit if it's only a very
+      // small increase, but instead geometrically grow capacity.
+      // For small filesizes (<1MB), perform size*2 geometric increase, but for
+      // large sizes, do a much more conservative size*1.125 increase to avoid
+      // overshooting the allocation cap by a very large margin.
       var CAPACITY_DOUBLING_MAX = 1024 * 1024;
       newCapacity = Math.max(newCapacity, (prevCapacity * (prevCapacity < CAPACITY_DOUBLING_MAX ? 2.0 : 1.125)) >>> 0);
-      if (prevCapacity != 0) newCapacity = Math.max(newCapacity, 256); // At minimum allocate 256b for each file when expanding.
-      var oldContents = node.contents;
+      if (prevCapacity) newCapacity = Math.max(newCapacity, 256); // At minimum allocate 256b for each file when expanding.
+      var oldContents = MEMFS.getFileDataAsTypedArray(node);
       node.contents = new Uint8Array(newCapacity); // Allocate new storage.
-      if (node.usedBytes > 0) node.contents.set(oldContents.subarray(0, node.usedBytes), 0); // Copy old data over to the new storage.
+      node.contents.set(oldContents);
     },
 
-    // Performs an exact resize of the backing file storage to the given size, if the size is not exactly this, the storage is fully reallocated.
+    // Performs an exact resize of the backing file storage to the given size,
+    // if the size is not exactly this, the storage is fully reallocated.
     resizeFileStorage(node, newSize) {
       if (node.usedBytes == newSize) return;
-      if (newSize == 0) {
-        node.contents = null; // Fully decommit when requesting a resize to zero.
-        node.usedBytes = 0;
-      } else {
-        var oldContents = node.contents;
-        node.contents = new Uint8Array(newSize); // Allocate new storage.
-        if (oldContents) {
-          node.contents.set(oldContents.subarray(0, Math.min(newSize, node.usedBytes))); // Copy old data over to the new storage.
-        }
-        node.usedBytes = newSize;
-      }
+      var oldContents = node.contents;
+      node.contents = new Uint8Array(newSize); // Allocate new storage.
+      node.contents.set(oldContents.subarray(0, Math.min(newSize, node.usedBytes))); // Copy old data over to the new storage.
+      node.usedBytes = newSize;
     },
 
     node_ops: {
@@ -242,11 +244,7 @@ addToLibrary({
 #if ASSERTIONS
         assert(size >= 0);
 #endif
-        if (size > 8 && contents.subarray) { // non-trivial, and typed array
-          buffer.set(contents.subarray(position, position + size), offset);
-        } else {
-          for (var i = 0; i < size; i++) buffer[offset + i] = contents[position + i];
-        }
+        buffer.set(contents.subarray(position, position + size), offset);
         return size;
       },
 
@@ -275,7 +273,7 @@ addToLibrary({
         var node = stream.node;
         node.mtime = node.ctime = Date.now();
 
-        if (buffer.subarray && (!node.contents || node.contents.subarray)) { // This write is from a typed array to a typed array?
+        if (buffer.subarray) { // This write is from a typed array to a typed array?
           if (canOwn) {
 #if ASSERTIONS
             assert(position === 0, 'canOwn must imply no weird position inside the file');
@@ -295,12 +293,12 @@ addToLibrary({
 
         // Appending to an existing file and we need to reallocate, or source data did not come as a typed array.
         MEMFS.expandFileStorage(node, position+length);
-        if (node.contents.subarray && buffer.subarray) {
+        if (buffer.subarray) {
           // Use typed array write which is available.
           node.contents.set(buffer.subarray(offset, offset + length), position);
         } else {
           for (var i = 0; i < length; i++) {
-           node.contents[position + i] = buffer[offset + i]; // Or fall back to manual write if not.
+            node.contents[position + i] = buffer[offset + i]; // Or fall back to manual write if not.
           }
         }
         node.usedBytes = Math.max(node.usedBytes, position + length);
@@ -329,7 +327,7 @@ addToLibrary({
         var allocated;
         var contents = stream.node.contents;
         // Only make a new copy when MAP_PRIVATE is specified.
-        if (!(flags & {{{ cDefs.MAP_PRIVATE }}}) && contents && contents.buffer === HEAP8.buffer) {
+        if (!(flags & {{{ cDefs.MAP_PRIVATE }}}) && contents.buffer === HEAP8.buffer) {
           // We can't emulate MAP_SHARED when the file is not backed by the
           // buffer we're mapping to (e.g. the HEAP buffer).
           allocated = false;

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19555,
-  "a.out.js.gz": 8102,
+  "a.out.js": 19344,
+  "a.out.js.gz": 8016,
   "a.out.nodebug.wasm": 132813,
   "a.out.nodebug.wasm.gz": 49862,
-  "total": 152368,
-  "total_gz": 57964,
+  "total": 152157,
+  "total_gz": 57878,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19532,
-  "a.out.js.gz": 8087,
+  "a.out.js": 19321,
+  "a.out.js.gz": 8003,
   "a.out.nodebug.wasm": 132233,
   "a.out.nodebug.wasm.gz": 49515,
-  "total": 151765,
-  "total_gz": 57602,
+  "total": 151554,
+  "total_gz": 57518,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23216,
-  "a.out.js.gz": 9081,
+  "a.out.js": 23005,
+  "a.out.js.gz": 8994,
   "a.out.nodebug.wasm": 172743,
   "a.out.nodebug.wasm.gz": 57374,
-  "total": 195959,
-  "total_gz": 66455,
+  "total": 195748,
+  "total_gz": 66368,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19366,
-  "a.out.js.gz": 8022,
+  "a.out.js": 19155,
+  "a.out.js.gz": 7938,
   "a.out.nodebug.wasm": 148138,
   "a.out.nodebug.wasm.gz": 55261,
-  "total": 167504,
-  "total_gz": 63283,
+  "total": 167293,
+  "total_gz": 63199,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19440,
-  "a.out.js.gz": 8042,
+  "a.out.js": 19229,
+  "a.out.js.gz": 7959,
   "a.out.nodebug.wasm": 145944,
   "a.out.nodebug.wasm.gz": 54887,
-  "total": 165384,
-  "total_gz": 62929,
+  "total": 165173,
+  "total_gz": 62846,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18902,
-  "a.out.js.gz": 7782,
+  "a.out.js": 18692,
+  "a.out.js.gz": 7702,
   "a.out.nodebug.wasm": 102066,
   "a.out.nodebug.wasm.gz": 39421,
-  "total": 120968,
-  "total_gz": 47203,
+  "total": 120758,
+  "total_gz": 47123,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23266,
-  "a.out.js.gz": 9101,
+  "a.out.js": 23055,
+  "a.out.js.gz": 9014,
   "a.out.nodebug.wasm": 239177,
   "a.out.nodebug.wasm.gz": 79774,
-  "total": 262443,
-  "total_gz": 88875,
+  "total": 262232,
+  "total_gz": 88788,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19555,
-  "a.out.js.gz": 8102,
+  "a.out.js": 19344,
+  "a.out.js.gz": 8016,
   "a.out.nodebug.wasm": 134820,
   "a.out.nodebug.wasm.gz": 50699,
-  "total": 154375,
-  "total_gz": 58801,
+  "total": 154164,
+  "total_gz": 58715,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -1033,12 +1033,14 @@ var MEMFS = {
     } else if (FS.isFile(node.mode)) {
       node.node_ops = MEMFS.ops_table.file.node;
       node.stream_ops = MEMFS.ops_table.file.stream;
+      // The actual number of bytes used in the typed array, as opposed to
+      // contents.length which gives the whole capacity.
       node.usedBytes = 0;
-      // The actual number of bytes used in the typed array, as opposed to contents.length which gives the whole capacity.
-      // When the byte data of the file is populated, this will point to either a typed array, or a normal JS array. Typed arrays are preferred
-      // for performance, and used by default. However, typed arrays are not resizable like normal JS arrays are, so there is a small disk size
-      // penalty involved for appending file writes that continuously grow a file similar to std::vector capacity vs used -scheme.
-      node.contents = null;
+      // The byte data of the file is stored in a typed array.
+      // Note: typed arrays are not resizable like normal JS arrays are, so
+      // there is a small penalty involved for appending file writes that
+      // continuously grow a file similar to std::vector capacity vs used.
+      node.contents = MEMFS.emptyFileContents ??= new Uint8Array(0);
     } else if (FS.isLink(node.mode)) {
       node.node_ops = MEMFS.ops_table.link.node;
       node.stream_ops = MEMFS.ops_table.link.stream;
@@ -1055,42 +1057,34 @@ var MEMFS = {
     return node;
   },
   getFileDataAsTypedArray(node) {
-    if (!node.contents) return new Uint8Array(0);
-    if (node.contents.subarray) return node.contents.subarray(0, node.usedBytes);
-    // Make sure to not return excess unused bytes.
-    return new Uint8Array(node.contents);
+    return node.contents.subarray(0, node.usedBytes);
   },
   expandFileStorage(node, newCapacity) {
-    var prevCapacity = node.contents ? node.contents.length : 0;
+    var prevCapacity = node.contents.length;
     if (prevCapacity >= newCapacity) return;
     // No need to expand, the storage was already large enough.
-    // Don't expand strictly to the given requested limit if it's only a very small increase, but instead geometrically grow capacity.
-    // For small filesizes (<1MB), perform size*2 geometric increase, but for large sizes, do a much more conservative size*1.125 increase to
-    // avoid overshooting the allocation cap by a very large margin.
+    // Don't expand strictly to the given requested limit if it's only a very
+    // small increase, but instead geometrically grow capacity.
+    // For small filesizes (<1MB), perform size*2 geometric increase, but for
+    // large sizes, do a much more conservative size*1.125 increase to avoid
+    // overshooting the allocation cap by a very large margin.
     var CAPACITY_DOUBLING_MAX = 1024 * 1024;
     newCapacity = Math.max(newCapacity, (prevCapacity * (prevCapacity < CAPACITY_DOUBLING_MAX ? 2 : 1.125)) >>> 0);
-    if (prevCapacity != 0) newCapacity = Math.max(newCapacity, 256);
+    if (prevCapacity) newCapacity = Math.max(newCapacity, 256);
     // At minimum allocate 256b for each file when expanding.
-    var oldContents = node.contents;
+    var oldContents = MEMFS.getFileDataAsTypedArray(node);
     node.contents = new Uint8Array(newCapacity);
     // Allocate new storage.
-    if (node.usedBytes > 0) node.contents.set(oldContents.subarray(0, node.usedBytes), 0);
+    node.contents.set(oldContents);
   },
   resizeFileStorage(node, newSize) {
     if (node.usedBytes == newSize) return;
-    if (newSize == 0) {
-      node.contents = null;
-      // Fully decommit when requesting a resize to zero.
-      node.usedBytes = 0;
-    } else {
-      var oldContents = node.contents;
-      node.contents = new Uint8Array(newSize);
-      // Allocate new storage.
-      if (oldContents) {
-        node.contents.set(oldContents.subarray(0, Math.min(newSize, node.usedBytes)));
-      }
-      node.usedBytes = newSize;
-    }
+    var oldContents = node.contents;
+    node.contents = new Uint8Array(newSize);
+    // Allocate new storage.
+    node.contents.set(oldContents.subarray(0, Math.min(newSize, node.usedBytes)));
+    // Copy old data over to the new storage.
+    node.usedBytes = newSize;
   },
   node_ops: {
     getattr(node) {
@@ -1195,19 +1189,14 @@ var MEMFS = {
       var contents = stream.node.contents;
       if (position >= stream.node.usedBytes) return 0;
       var size = Math.min(stream.node.usedBytes - position, length);
-      if (size > 8 && contents.subarray) {
-        // non-trivial, and typed array
-        buffer.set(contents.subarray(position, position + size), offset);
-      } else {
-        for (var i = 0; i < size; i++) buffer[offset + i] = contents[position + i];
-      }
+      buffer.set(contents.subarray(position, position + size), offset);
       return size;
     },
     write(stream, buffer, offset, length, position, canOwn) {
       if (!length) return 0;
       var node = stream.node;
       node.mtime = node.ctime = Date.now();
-      if (buffer.subarray && (!node.contents || node.contents.subarray)) {
+      if (buffer.subarray) {
         // This write is from a typed array to a typed array?
         if (canOwn) {
           node.contents = buffer.subarray(offset, offset + length);
@@ -1226,7 +1215,7 @@ var MEMFS = {
       }
       // Appending to an existing file and we need to reallocate, or source data did not come as a typed array.
       MEMFS.expandFileStorage(node, position + length);
-      if (node.contents.subarray && buffer.subarray) {
+      if (buffer.subarray) {
         // Use typed array write which is available.
         node.contents.set(buffer.subarray(offset, offset + length), position);
       } else {
@@ -1259,7 +1248,7 @@ var MEMFS = {
       var allocated;
       var contents = stream.node.contents;
       // Only make a new copy when MAP_PRIVATE is specified.
-      if (!(flags & 2) && contents && contents.buffer === HEAP8.buffer) {
+      if (!(flags & 2) && contents.buffer === HEAP8.buffer) {
         // We can't emulate MAP_SHARED when the file is not backed by the
         // buffer we're mapping to (e.g. the HEAP buffer).
         allocated = false;

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22509,
-  "a.out.js.gz": 9332,
+  "a.out.js": 22299,
+  "a.out.js.gz": 9245,
   "a.out.nodebug.wasm": 1681,
   "a.out.nodebug.wasm.gz": 960,
-  "total": 24190,
-  "total_gz": 10292,
+  "total": 23980,
+  "total_gz": 10205,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_files_js_fs.json
+++ b/test/codesize/test_codesize_files_js_fs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18174,
-  "a.out.js.gz": 7430,
+  "a.out.js": 17963,
+  "a.out.js.gz": 7345,
   "a.out.nodebug.wasm": 381,
   "a.out.nodebug.wasm.gz": 260,
-  "total": 18555,
-  "total_gz": 7690,
+  "total": 18344,
+  "total_gz": 7605,
   "sent": [
     "a (fd_write)",
     "b (fd_read)",

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26596,
-  "a.out.js.gz": 11356,
+  "a.out.js": 26386,
+  "a.out.js.gz": 11267,
   "a.out.nodebug.wasm": 17730,
   "a.out.nodebug.wasm.gz": 8957,
-  "total": 44326,
-  "total_gz": 20313,
+  "total": 44116,
+  "total_gz": 20224,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 244691,
+  "a.out.js": 244478,
   "a.out.nodebug.wasm": 577692,
-  "total": 822383,
+  "total": 822170,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
As far as I can tell we have not actually support anything else for a long time so I think comment that I'm updating here was inaccurate.

There are several places where `node.contents.subarray` (only available on TypedArrays) assumed in the code.  For example the existing `expandFileStorage` and `resizeFileStorage` both only operator on TypedArrays.