### PR TITLE
Assume node.contents is a TypedArray in emscripten_run_preload_plugins. NFC

### DIFF
--- a/src/lib/libbrowser.js
+++ b/src/lib/libbrowser.js
@@ -568,12 +568,14 @@ var LibraryBrowser = {
     var _file = UTF8ToString(file);
     var data = FS.analyzePath(_file);
     if (!data.exists) return -1;
+    // Here we assume data.object.contents is a TypedArray.
+#if ASSERTIONS
+    assert(data.object.contents.subarray, 'unexpected file content')
+#endif
     FS.createPreloadedFile(
       PATH.dirname(_file),
       PATH.basename(_file),
-      // TODO: This copy is not needed if the contents are already a Uint8Array,
-      //       which they often are (and always are in WasmFS).
-      new Uint8Array(data.object.contents), true, true,
+      data.object.contents, /*canRead=*/true, /*canWrite=*/true,
       () => {
         {{{ runtimeKeepalivePop() }}}
         if (onload) {{{ makeDynCall('vp', 'onload') }}}(file);
@@ -582,7 +584,7 @@ var LibraryBrowser = {
         {{{ runtimeKeepalivePop() }}}
         if (onerror) {{{ makeDynCall('vp', 'onerror') }}}(file);
       },
-      true // don'tCreateFile - it's already there
+      /*dontCreateFile=*/true // it's already there
     );
     return 0;
   },

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 244478,
+  "a.out.js": 244462,
   "a.out.nodebug.wasm": 577692,
-  "total": 822170,
+  "total": 822154,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
Since #26398 it should be guaranteed to be.