### PR TITLE
Remove command line definition of legacy `EMSCRIPTEN` macro

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 5.0.4 (in development)
 ----------------------
+- The deprecated `EMSCRIPTEN` macro is now defined in `emscripten.h` rather than
+  on the command line (`__EMSCRIPTEN__`, which is built into LLVM, should be
+  used instead). (#26417)
 
 5.0.3 - 03/14/26
 ----------------

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1701,8 +1701,6 @@ Set the environment variable EMCC_STRICT=1 or pass -sSTRICT to test that a
 codebase builds nicely in forward compatible manner.
 Changes enabled by this:
 
-  - The C define EMSCRIPTEN is not defined (__EMSCRIPTEN__ always is, and
-    is the correct thing to use).
   - STRICT_JS is enabled.
   - IGNORE_MISSING_MAIN is disabled.
   - AUTO_JS_LIBRARIES is disabled.

--- a/src/settings.js
+++ b/src/settings.js
@@ -1160,8 +1160,6 @@ var LINKABLE = false;
 // codebase builds nicely in forward compatible manner.
 // Changes enabled by this:
 //
-//   - The C define EMSCRIPTEN is not defined (__EMSCRIPTEN__ always is, and
-//     is the correct thing to use).
 //   - STRICT_JS is enabled.
 //   - IGNORE_MISSING_MAIN is disabled.
 //   - AUTO_JS_LIBRARIES is disabled.

--- a/test/core/test_core_types.c
+++ b/test/core/test_core_types.c
@@ -75,15 +75,6 @@
 #error __BIG_ENDIAN__ is defined
 #endif
 
-// We prefer to use __EMSCRIPTEN__, but for compatibility, we define
-// EMSCRIPTEN too.
-#if defined(IN_STRICT_MODE) && defined(EMSCRIPTEN)
-#error When compiling in -sSTRICT mode, EMSCRIPTEN should not be defined, but it was!
-#endif
-#if !defined(IN_STRICT_MODE) && !defined(EMSCRIPTEN)
-#error EMSCRIPTEN is not defined
-#endif
-
 #include <stdalign.h>
 #include <stdint.h>
 #include <stddef.h>

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -695,8 +695,6 @@ class TestCoreBase(RunnerCore):
     self.do_runf('third_party/sha1.c', 'SHA1=15dd99a1991e0b3826fede3deffc1feba42278e6')
 
   def test_core_types(self):
-    if self.get_setting('STRICT'):
-      self.cflags += ['-DIN_STRICT_MODE=1']
     self.do_runf('core/test_core_types.c')
 
   def test_cube2md5(self):

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11226,17 +11226,6 @@ int main(void) {
     self.assert_fail([EMCC, '-Werror', 'src.c', '-c'], "'EMSCRIPTEN' has been marked as deprecated: use __EMSCRIPTEN__ instead")
     self.assert_fail([EMCC, '-sSTRICT', '-Werror', 'src.c', '-c'], "'EMSCRIPTEN' has been marked as deprecated: use __EMSCRIPTEN__ instead")
 
-  def test_EMSCRIPTEN_and_STRICT(self):
-    # __EMSCRIPTEN__ is the proper define; we support EMSCRIPTEN for legacy
-    # code, unless STRICT is enabled.
-    create_file('src.c', '''
-      #ifndef EMSCRIPTEN
-      #error "not defined"
-      #endif
-    ''')
-    self.run_process([EMCC, 'src.c', '-c'])
-    self.expect_fail([EMCC, 'src.c', '-sSTRICT', '-c'])
-
   def test_exception_settings(self):
     for catching, throwing, opts in itertools.product([0, 1], repeat=3):
       cmd = [EMXX, test_file('other/exceptions_modes_symbols_defined.cpp'), '-sDISABLE_EXCEPTION_THROWING=%d' % (1 - throwing), '-sDISABLE_EXCEPTION_CATCHING=%d' % (1 - catching), '-O%d' % opts]

--- a/tools/compile.py
+++ b/tools/compile.py
@@ -96,11 +96,6 @@ def get_cflags(user_args):
   if settings.WASM_WORKERS:
     cflags.append('-D__EMSCRIPTEN_WASM_WORKERS__=1')
 
-  if not settings.STRICT:
-    # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code
-    # in strict mode. Code should use the define __EMSCRIPTEN__ instead.
-    cflags.append('-DEMSCRIPTEN')
-
   ports.add_cflags(cflags, settings)
 
   def array_contains_any_of(hay, needles):


### PR DESCRIPTION
In #26381, the definition of this macro was moved into the `emscripten.h` header file, along with a warning if its used.

This change removes this macro from the clang command line generated by emcc, reducing the differences between using `emcc` and using `clang
 -target=wasm32-emscripten` directly.