### PR TITLE
Remove MEMORY64=2 special casing from embuilder. NFC

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -239,8 +239,7 @@ def main():
     settings.MAIN_MODULE = 1
 
   if args.wasm64:
-    settings.MEMORY64 = 2
-    MINIMAL_TASKS[:] = [t for t in MINIMAL_TASKS if 'emmalloc' not in t]
+    settings.MEMORY64 = 1
 
   do_build = args.operation == 'build'
   do_clear = args.operation == 'clear'

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -70,7 +70,7 @@ def get_base_cflags(build_dir, force_object_files=False, preprocess=True):
     if preprocess:
       flags += ['-DEMSCRIPTEN_DYNAMIC_LINKING']
   if settings.MEMORY64:
-    flags += ['-sMEMORY64=' + str(settings.MEMORY64)]
+    flags += ['-sMEMORY64']
 
   source_dir = utils.path_from_root()
   relative_source_dir = os.path.relpath(source_dir, build_dir)


### PR DESCRIPTION
Also, when building system libraries we don't need to distinguish between MEMORY64=1 and MEMORY64=2.