### PR TITLE
Enable `STRICT_JS` by default

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -233,6 +233,10 @@ See docs/process.md for more on how version tagging works.
   it may be possible to enable them in future. (#26487)
 - pipe2 implementation was added (with limited flag support) (#26480)
 - ppoll and pselect implementations were added (#26482)
+- The `STRICT_JS` setting is now on by default.  Previously it was enabled by
+  default in `STRICT` mode.  If you have EM_ASM or EM_JS or `--pre-js` code
+  that does not conform to JS strict mode then you may need to disable this
+  with `-sSTRICT_JS=0`. (#26421)
 
 5.0.3 - 03/14/26
 ----------------

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1766,7 +1766,6 @@ Set the environment variable EMCC_STRICT=1 or pass -sSTRICT to test that a
 codebase builds nicely in forward compatible manner.
 Changes enabled by this:
 
-  - STRICT_JS is enabled.
   - IGNORE_MISSING_MAIN is disabled.
   - AUTO_JS_LIBRARIES is disabled.
   - AUTO_NATIVE_LIBRARIES is disabled.
@@ -1797,7 +1796,7 @@ STRICT_JS
 
 Add ``"use strict;"`` to generated JS
 
-Default value: false
+Default value: true
 
 .. _warn_on_undefined_symbols:
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1216,7 +1216,6 @@ var LINKABLE = false;
 // codebase builds nicely in forward compatible manner.
 // Changes enabled by this:
 //
-//   - STRICT_JS is enabled.
 //   - IGNORE_MISSING_MAIN is disabled.
 //   - AUTO_JS_LIBRARIES is disabled.
 //   - AUTO_NATIVE_LIBRARIES is disabled.
@@ -1235,7 +1234,7 @@ var IGNORE_MISSING_MAIN = true;
 
 // Add ``"use strict;"`` to generated JS
 // [link]
-var STRICT_JS = false;
+var STRICT_JS = true;
 
 // If set to 1, we will warn on any undefined symbols that are not resolved by
 // the ``library_*.js`` files. Note that it is common in large projects to not

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -576,13 +576,12 @@ window.close = () => {
       addToLibrary({
         checkPreloadResults: function() {
           var cached = 0;
-          var packages = Object.keys(Module['preloadResults']);
-          packages.forEach(function(package) {
-            var fromCache = Module['preloadResults'][package]['fromCache'];
+          for (var result of Object.values(Module['preloadResults'])) {
+            var fromCache = result['fromCache'];
             if (fromCache) {
               cached++;
             }
-          });
+          }
           return cached;
         }
       });
@@ -916,7 +915,7 @@ window.close = () => {
   })
   @no_safari('Fails in browser_2gb.test_sdl_canvas_safe_heap variant. https://webkit.org/b/314444') # Fails in Safari 26.0.1 (21622.1.22.11.15)
   def test_sdl_canvas(self, args):
-    self.btest_exit('test_sdl_canvas.c', cflags=['-sSTRICT_JS', '-sLEGACY_GL_EMULATION', '-lSDL', '-lGL'] + args)
+    self.btest_exit('test_sdl_canvas.c', cflags=['-sLEGACY_GL_EMULATION', '-lSDL', '-lGL'] + args)
 
   def test_sdl_canvas_alpha(self):
     # N.B. On Linux with Intel integrated graphics cards, this test needs Firefox 49 or newer.
@@ -1030,7 +1029,7 @@ window.close = () => {
     self.run_browser('page.html', '', '/report_result?exit:0')
 
   def test_glut_touchevents(self):
-    self.btest_exit('glut_touchevents.c', cflags=['-lglut', '-sSTRICT_JS'])
+    self.btest_exit('glut_touchevents.c', cflags=['-lglut'])
 
   def test_glut_wheelevents(self):
     self.btest_exit('glut_wheelevents.c', cflags=['-lglut'])
@@ -4811,8 +4810,6 @@ Module["preRun"] = () => {
   # also also we eval the initial code, so currentScript is not present. That prevents us
   # from finding the file in a subdir, but here we at least check we do not regress compared to the
   # normal case of finding in the current dir.
-  # test both modularize (and creating an instance) and modularize-instance
-  # (which creates by itself)
   @parameterized({
     '': ([], ['-sMODULARIZE'], 'Module();'),
     'subdir': (['subdir'], ['-sMODULARIZE'], 'Module();'),
@@ -4829,7 +4826,7 @@ Module["preRun"] = () => {
         setTimeout(async () => {
           let response = await fetch('test.js');
           let text = await response.text();
-          eval(text);
+          let Module = eval(text + '; Module');
           %s
         }, 1);
       </script>
@@ -4918,7 +4915,6 @@ Module["preRun"] = () => {
 
   @parameterized({
     '': ([],),
-    'strict_js': (['-sSTRICT_JS'],),
     'minimal_runtime': (['-sMINIMAL_RUNTIME=1'],),
     'minimal_runtime_2': (['-sMINIMAL_RUNTIME=2'],),
   })
@@ -5415,8 +5411,8 @@ Module["preRun"] = () => {
   def test_pthread_key_recreation(self):
     self.btest_exit('pthread/test_pthread_key_recreation.c', cflags=['-pthread', '-sPTHREAD_POOL_SIZE=1'])
 
-  def test_full_js_library_strict(self):
-    self.btest_exit('hello_world.c', cflags=['-sINCLUDE_FULL_LIBRARY', '-sSTRICT_JS'])
+  def test_full_js_library(self):
+    self.btest_exit('hello_world.c', cflags=['-sINCLUDE_FULL_LIBRARY'])
 
   # Tests the AudioWorklet demo
   @parameterized({

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -439,7 +439,6 @@ def with_both_text_decoder(func):
 
 no_safe_heap = make_no_decorator_for_setting('SAFE_HEAP')
 no_strict = make_no_decorator_for_setting('STRICT')
-no_strict_js = make_no_decorator_for_setting('STRICT_JS')
 no_big_endian = make_no_decorator_for_setting('SUPPORT_BIG_ENDIAN')
 no_omit_asm_module_exports = make_no_decorator_for_setting('DECLARE_ASM_MODULE_EXPORTS=0')
 no_js_math = make_no_decorator_for_setting('JS_MATH')
@@ -9861,7 +9860,6 @@ int main() {
     self.assertFilesMatch(test_file('core/test_esm_integration.expected.mjs'), 'hello_world.mjs')
 
   @no_omit_asm_module_exports('MODULARIZE is not compatible with DECLARE_ASM_MODULE_EXPORTS=0')
-  @no_strict_js('EXPORT_ES6 is not compatible with STRICT_JS')
   def test_modularize_instance_hello(self):
     self.do_core_test('test_hello_world.c', cflags=['-sMODULARIZE=instance', '-Wno-experimental'])
 
@@ -9901,7 +9899,6 @@ int main() {
 
   @no_omit_asm_module_exports('MODULARIZE is not compatible with DECLARE_ASM_MODULE_EXPORTS=0')
   @no_4gb('EMBIND_AOT can\'t lower 4gb')
-  @no_strict_js('EXPORT_ES6 is not compatible with STRICT_JS')
   def test_modularize_instance_embind(self):
     self.run_process([EMXX, test_file('modularize_instance_embind.cpp'),
                       '-sMODULARIZE=instance',
@@ -10082,7 +10079,6 @@ instance = make_run('instance', cflags=['-Wno-experimental'], settings={'MODULAR
 
 # Add DEFAULT_TO_CXX=0
 strict = make_run('strict', cflags=[], settings={'STRICT': 1})
-strict_js = make_run('strict_js', cflags=[], settings={'STRICT_JS': 1})
 
 ubsan = make_run('ubsan', cflags=['-fsanitize=undefined', '--profiling'])
 lsan = make_run('lsan', cflags=['-fsanitize=leak', '--profiling'], settings={'ALLOW_MEMORY_GROWTH': 1})

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3502,7 +3502,6 @@ More info: https://emscripten.org
     'o2': ['-O2'],
     'o2_mem_growth': ['-O2', '-sALLOW_MEMORY_GROWTH', test_file('embind/isMemoryGrowthEnabled=true.cpp')],
     'o2_closure': ['-O2', '--closure=1', '--closure-args', '--externs ' + shlex.quote(test_file('embind/underscore-externs.js')), '-sASSERTIONS=1'],
-    'strict_js': ['-sSTRICT_JS'],
     # DYNCALLS tests the legacy native function API (ASYNCIFY implicitly enables DYNCALLS)
     'dyncalls': ['-sDYNCALLS=1'],
   })
@@ -9355,11 +9354,11 @@ end
     'embind': (['-lembind'],),
   })
   def test_full_js_library(self, args):
-    self.run_process([EMCC, test_file('hello_world.c'), '-sSTRICT_JS', '-sINCLUDE_FULL_LIBRARY'] + args)
+    self.run_process([EMCC, test_file('hello_world.c'), '-sINCLUDE_FULL_LIBRARY'] + args)
 
   def test_full_js_library_undefined(self):
     create_file('main.c', 'void foo(); int main() { foo(); return 0; }')
-    self.assert_fail([EMCC, 'main.c', '-sSTRICT_JS', '-sINCLUDE_FULL_LIBRARY'], 'undefined symbol: foo')
+    self.assert_fail([EMCC, 'main.c', '-sINCLUDE_FULL_LIBRARY'], 'undefined symbol: foo')
 
   def test_full_js_library_except(self):
     self.set_setting('INCLUDE_FULL_LIBRARY', 1)

--- a/tools/link.py
+++ b/tools/link.py
@@ -1212,9 +1212,10 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
   elif options.shell_html:
     diagnostics.warning('unused-command-line-argument', '--shell-file ignored when not generating html output')
 
+  if settings.EXPORT_ES6:
+    default_setting('STRICT_JS', 0)
+
   if settings.STRICT:
-    if not settings.EXPORT_ES6:
-      default_setting('STRICT_JS', 1)
     default_setting('DEFAULT_TO_CXX', 0)
     default_setting('IGNORE_MISSING_MAIN', 0)
     default_setting('AUTO_NATIVE_LIBRARIES', 0)


### PR DESCRIPTION
This has been enabled under `STRICT` mode since it was first added back in 2019 (#9265).

One of the benefits of enabling this by default is that we can delete the `strict` test mode and the `no_strict_js` decorator.