### PR TITLE
Move emscripten_atomics_is_lock_free to atomic.h.

### DIFF
--- a/src/lib/libatomic.js
+++ b/src/lib/libatomic.js
@@ -164,4 +164,6 @@ addToLibrary({
     ENVIRONMENT_IS_NODE ? require('node:os').cpus().length :
 #endif
     navigator['hardwareConcurrency'],
+
+  emscripten_atomics_is_lock_free: (width) => Atomics.isLockFree(width),
 });

--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -296,10 +296,6 @@ if (ENVIRONMENT_IS_WASM_WORKER
     return navigator['hardwareConcurrency'];
   },
 
-  emscripten_atomics_is_lock_free: (width) => {
-    return Atomics.isLockFree(width);
-  },
-
   emscripten_lock_async_acquire__deps: ['$polyfillWaitAsync'],
   emscripten_lock_async_acquire: (lock, asyncWaitFinished, userData, maxWaitMilliseconds) => {
     let tryAcquireLock = () => {

--- a/system/include/emscripten/atomic.h
+++ b/system/include/emscripten/atomic.h
@@ -290,6 +290,14 @@ int emscripten_atomic_cancel_all_wait_asyncs(void);
 // address.  Returns the number of async waits canceled.
 int emscripten_atomic_cancel_all_wait_asyncs_at_address(void *addr __attribute__((nonnull)));
 
+// Returns the value of the expression "Atomics.isLockFree(byteWidth)": true if
+// the given memory access width can be accessed atomically, and false
+// otherwise. Generally will return true on 1, 2 and 4 byte accesses. On 8 byte
+// accesses, behavior differs across browsers, see
+//  - https://bugzil.la/1246139
+//  - https://bugs.chromium.org/p/chromium/issues/detail?id=1167449
+bool emscripten_atomics_is_lock_free(int byteWidth);
+
 #undef _EM_INLINE
 
 #ifdef __cplusplus

--- a/system/include/emscripten/wasm_worker.h
+++ b/system/include/emscripten/wasm_worker.h
@@ -110,14 +110,6 @@ void emscripten_wasm_worker_sleep(int64_t nanoseconds);
 // logical thread of concurrency available)
 int emscripten_navigator_hardware_concurrency(void);
 
-// Returns the value of the expression "Atomics.isLockFree(byteWidth)": true if
-// the given memory access width can be accessed atomically, and false
-// otherwise. Generally will return true on 1, 2 and 4 byte accesses. On 8 byte
-// accesses, behavior differs across browsers, see
-//  - https://bugzil.la/1246139
-//  - https://bugs.chromium.org/p/chromium/issues/detail?id=1167449
-bool emscripten_atomics_is_lock_free(int byteWidth);
-
 #define emscripten_lock_t volatile uint32_t
 
 // Use with syntax "emscripten_lock_t l = EMSCRIPTEN_LOCK_T_STATIC_INITIALIZER;"

--- a/test/pthread/is_lock_free.c
+++ b/test/pthread/is_lock_free.c
@@ -1,0 +1,30 @@
+#include <emscripten/atomic.h>
+#include <pthread.h>
+#include <assert.h>
+#include <stdio.h>
+
+// Test emscripten_atomics_is_lock_free() functions
+
+void test() {
+  assert(emscripten_atomics_is_lock_free(1));
+  assert(emscripten_atomics_is_lock_free(2));
+  assert(emscripten_atomics_is_lock_free(4));
+  // Chrome is buggy, see
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=1167449
+  //assert(emscripten_atomics_is_lock_free(8));
+  assert(!emscripten_atomics_is_lock_free(31));
+}
+
+void* thread_main(void* arg) {
+  test();
+  return NULL;
+}
+
+int main() {
+  test();
+  pthread_t t;
+  pthread_create(&t, NULL, thread_main, NULL);
+  pthread_join(t, NULL);
+  printf("done\n");
+  return 0;
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2753,6 +2753,10 @@ The current type of b is: 9
       self.skipTest('MINIMAL_RUNTIME + threads + asan does not work')
     self.do_run_in_out_file_test('pthread/test_pthread_run_on_main_thread.c')
 
+  @requires_pthreads
+  def test_pthread_is_lock_free(self):
+    self.do_runf('pthread/is_lock_free.c', 'done\n', cflags=['-pthread'])
+
   def test_tcgetattr(self):
     self.do_runf('termios/test_tcgetattr.c', 'success')
 


### PR DESCRIPTION
This function really belongs alongside the atomics operations and should be available under pthreads too.