### PR TITLE
Consistent use of `_Nonnull` for function parameters. NFC

### DIFF
--- a/system/include/emscripten/atomic.h
+++ b/system/include/emscripten/atomic.h
@@ -23,16 +23,16 @@ extern "C" {
 
 // Atomically stores the given value to the memory location, and returns the
 // value that was there prior to the store.
-_EM_INLINE uint8_t emscripten_atomic_exchange_u8(void /*uint8_t*/* addr __attribute__((nonnull)), uint8_t newVal) {
+_EM_INLINE uint8_t emscripten_atomic_exchange_u8(void /*uint8_t*/* _Nonnull addr, uint8_t newVal) {
   return __c11_atomic_exchange((_Atomic uint8_t*)addr, newVal, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint16_t emscripten_atomic_exchange_u16(void /*uint16_t*/* addr __attribute__((nonnull)), uint16_t newVal) {
+_EM_INLINE uint16_t emscripten_atomic_exchange_u16(void /*uint16_t*/* _Nonnull addr, uint16_t newVal) {
   return __c11_atomic_exchange((_Atomic uint16_t*)addr, newVal, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint32_t emscripten_atomic_exchange_u32(void /*uint32_t*/* addr __attribute__((nonnull)), uint32_t newVal) {
+_EM_INLINE uint32_t emscripten_atomic_exchange_u32(void /*uint32_t*/* _Nonnull addr, uint32_t newVal) {
   return __c11_atomic_exchange((_Atomic uint32_t*)addr, newVal, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint64_t emscripten_atomic_exchange_u64(void /*uint64_t*/* addr __attribute__((nonnull)), uint64_t newVal) {
+_EM_INLINE uint64_t emscripten_atomic_exchange_u64(void /*uint64_t*/* _Nonnull addr, uint64_t newVal) {
   return __c11_atomic_exchange((_Atomic uint64_t*)addr, newVal, __ATOMIC_SEQ_CST);
 }
 
@@ -40,138 +40,138 @@ _EM_INLINE uint64_t emscripten_atomic_exchange_u64(void /*uint64_t*/* addr __att
 // operation took place.
 // That is, if the return value when calling this function equals to 'oldVal',
 // then the operation succeeded, otherwise it was ignored.
-_EM_INLINE uint8_t emscripten_atomic_cas_u8(void /*uint8_t*/* addr __attribute__((nonnull)), uint8_t oldVal, uint8_t newVal) {
+_EM_INLINE uint8_t emscripten_atomic_cas_u8(void /*uint8_t*/* _Nonnull addr, uint8_t oldVal, uint8_t newVal) {
   uint8_t expected = oldVal;
   __c11_atomic_compare_exchange_strong((_Atomic uint8_t*)addr, &expected, newVal, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
   return expected;
 }
-_EM_INLINE uint16_t emscripten_atomic_cas_u16(void /*uint16_t*/* addr __attribute__((nonnull)), uint16_t oldVal, uint16_t newVal) {
+_EM_INLINE uint16_t emscripten_atomic_cas_u16(void /*uint16_t*/* _Nonnull addr, uint16_t oldVal, uint16_t newVal) {
   uint16_t expected = oldVal;
   __c11_atomic_compare_exchange_strong((_Atomic uint16_t*)addr, &expected, newVal, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
   return expected;
 }
-_EM_INLINE uint32_t emscripten_atomic_cas_u32(void /*uint32_t*/* addr __attribute__((nonnull)), uint32_t oldVal, uint32_t newVal) {
+_EM_INLINE uint32_t emscripten_atomic_cas_u32(void /*uint32_t*/* _Nonnull addr, uint32_t oldVal, uint32_t newVal) {
   uint32_t expected = oldVal;
   __c11_atomic_compare_exchange_strong((_Atomic uint32_t*)addr, &expected, newVal, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
   return expected;
 }
-_EM_INLINE uint64_t emscripten_atomic_cas_u64(void /*uint64_t*/* addr __attribute__((nonnull)), uint64_t oldVal, uint64_t newVal) {
+_EM_INLINE uint64_t emscripten_atomic_cas_u64(void /*uint64_t*/* _Nonnull addr, uint64_t oldVal, uint64_t newVal) {
   uint64_t expected = oldVal;
   __c11_atomic_compare_exchange_strong((_Atomic uint64_t*)addr, &expected, newVal, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
   return expected;
 }
 
-_EM_INLINE uint8_t emscripten_atomic_load_u8(const void /*uint8_t*/* addr __attribute__((nonnull))) {
+_EM_INLINE uint8_t emscripten_atomic_load_u8(const void /*uint8_t*/* _Nonnull addr) {
   return __c11_atomic_load((_Atomic(uint8_t)*)addr, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint16_t emscripten_atomic_load_u16(const void /*uint16_t*/* addr __attribute__((nonnull))) {
+_EM_INLINE uint16_t emscripten_atomic_load_u16(const void /*uint16_t*/* _Nonnull addr) {
   return __c11_atomic_load((_Atomic(uint16_t)*)addr, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint32_t emscripten_atomic_load_u32(const void /*uint32_t*/* addr __attribute__((nonnull))) {
+_EM_INLINE uint32_t emscripten_atomic_load_u32(const void /*uint32_t*/* _Nonnull addr) {
   return __c11_atomic_load((_Atomic(uint32_t)*)addr, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE float emscripten_atomic_load_f32(const void /*float*/* addr __attribute__((nonnull))) {
+_EM_INLINE float emscripten_atomic_load_f32(const void /*float*/* _Nonnull addr) {
   return __c11_atomic_load((_Atomic(float)*)addr, __ATOMIC_SEQ_CST);
 }
 _EM_INLINE
-uint64_t emscripten_atomic_load_u64(const void /*uint64_t*/* addr __attribute__((nonnull))) {
+uint64_t emscripten_atomic_load_u64(const void /*uint64_t*/* _Nonnull addr) {
   return __c11_atomic_load((_Atomic(uint64_t)*)addr, __ATOMIC_SEQ_CST);
 }
 _EM_INLINE
-double emscripten_atomic_load_f64(const void /*double*/* addr __attribute__((nonnull))) {
+double emscripten_atomic_load_f64(const void /*double*/* _Nonnull addr) {
   return __c11_atomic_load((_Atomic(double)*)addr, __ATOMIC_SEQ_CST);
 }
 
 // Returns the value that was stored (i.e. 'val')
-_EM_INLINE uint8_t emscripten_atomic_store_u8(void /*uint8_t*/* addr __attribute__((nonnull)), uint8_t val) {
+_EM_INLINE uint8_t emscripten_atomic_store_u8(void /*uint8_t*/* _Nonnull addr, uint8_t val) {
   __c11_atomic_store((_Atomic(uint8_t)*)addr, val, __ATOMIC_SEQ_CST);
   return val;
 }
-_EM_INLINE uint16_t emscripten_atomic_store_u16(void /*uint16_t*/* addr __attribute__((nonnull)), uint16_t val) {
+_EM_INLINE uint16_t emscripten_atomic_store_u16(void /*uint16_t*/* _Nonnull addr, uint16_t val) {
   __c11_atomic_store((_Atomic(uint16_t)*)addr, val, __ATOMIC_SEQ_CST);
   return val;
 }
-_EM_INLINE uint32_t emscripten_atomic_store_u32(void /*uint32_t*/* addr __attribute__((nonnull)), uint32_t val) {
+_EM_INLINE uint32_t emscripten_atomic_store_u32(void /*uint32_t*/* _Nonnull addr, uint32_t val) {
   __c11_atomic_store((_Atomic(uint32_t)*)addr, val, __ATOMIC_SEQ_CST);
   return val;
 }
-_EM_INLINE float emscripten_atomic_store_f32(void /*float*/* addr __attribute__((nonnull)), float val) {
+_EM_INLINE float emscripten_atomic_store_f32(void /*float*/* _Nonnull addr, float val) {
   __c11_atomic_store((_Atomic(float)*)addr, val, __ATOMIC_SEQ_CST);
   return val;
 }
-_EM_INLINE uint64_t emscripten_atomic_store_u64(void /*uint64_t*/* addr __attribute__((nonnull)), uint64_t val) {
+_EM_INLINE uint64_t emscripten_atomic_store_u64(void /*uint64_t*/* _Nonnull addr, uint64_t val) {
   __c11_atomic_store((_Atomic(uint64_t)*)addr, val, __ATOMIC_SEQ_CST);
   return val;
 }
-_EM_INLINE double emscripten_atomic_store_f64(void /*double*/* addr __attribute__((nonnull)), double val) {
+_EM_INLINE double emscripten_atomic_store_f64(void /*double*/* _Nonnull addr, double val) {
   __c11_atomic_store((_Atomic(double)*)addr, val, __ATOMIC_SEQ_CST);
   return val;
 }
 
 // Each of the functions below (add, sub, and, or, xor) return the value that
 // was in the memory location before the operation occurred.
-_EM_INLINE uint8_t emscripten_atomic_add_u8(void /*uint8_t*/* addr __attribute__((nonnull)), uint8_t val) {
+_EM_INLINE uint8_t emscripten_atomic_add_u8(void /*uint8_t*/* _Nonnull addr, uint8_t val) {
   return __c11_atomic_fetch_add((_Atomic uint8_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint16_t emscripten_atomic_add_u16(void /*uint16_t*/* addr __attribute__((nonnull)), uint16_t val) {
+_EM_INLINE uint16_t emscripten_atomic_add_u16(void /*uint16_t*/* _Nonnull addr, uint16_t val) {
   return __c11_atomic_fetch_add((_Atomic uint16_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint32_t emscripten_atomic_add_u32(void /*uint32_t*/* addr __attribute__((nonnull)), uint32_t val) {
+_EM_INLINE uint32_t emscripten_atomic_add_u32(void /*uint32_t*/* _Nonnull addr, uint32_t val) {
   return __c11_atomic_fetch_add((_Atomic uint32_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint64_t emscripten_atomic_add_u64(void /*uint64_t*/* addr __attribute__((nonnull)), uint64_t val) {
+_EM_INLINE uint64_t emscripten_atomic_add_u64(void /*uint64_t*/* _Nonnull addr, uint64_t val) {
   return __c11_atomic_fetch_add((_Atomic uint64_t*)addr, val, __ATOMIC_SEQ_CST);
 }
 
-_EM_INLINE uint8_t emscripten_atomic_sub_u8(void /*uint8_t*/* addr __attribute__((nonnull)), uint8_t val) {
+_EM_INLINE uint8_t emscripten_atomic_sub_u8(void /*uint8_t*/* _Nonnull addr, uint8_t val) {
   return __c11_atomic_fetch_sub((_Atomic uint8_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint16_t emscripten_atomic_sub_u16(void /*uint16_t*/* addr __attribute__((nonnull)), uint16_t val) {
+_EM_INLINE uint16_t emscripten_atomic_sub_u16(void /*uint16_t*/* _Nonnull addr, uint16_t val) {
   return __c11_atomic_fetch_sub((_Atomic uint16_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint32_t emscripten_atomic_sub_u32(void /*uint32_t*/* addr __attribute__((nonnull)), uint32_t val) {
+_EM_INLINE uint32_t emscripten_atomic_sub_u32(void /*uint32_t*/* _Nonnull addr, uint32_t val) {
   return __c11_atomic_fetch_sub((_Atomic uint32_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint64_t emscripten_atomic_sub_u64(void /*uint64_t*/* addr __attribute__((nonnull)), uint64_t val) {
+_EM_INLINE uint64_t emscripten_atomic_sub_u64(void /*uint64_t*/* _Nonnull addr, uint64_t val) {
   return __c11_atomic_fetch_sub((_Atomic uint64_t*)addr, val, __ATOMIC_SEQ_CST);
 }
 
-_EM_INLINE uint8_t emscripten_atomic_and_u8(void /*uint8_t*/* addr __attribute__((nonnull)), uint8_t val) {
+_EM_INLINE uint8_t emscripten_atomic_and_u8(void /*uint8_t*/* _Nonnull addr, uint8_t val) {
   return __c11_atomic_fetch_and((_Atomic uint8_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint16_t emscripten_atomic_and_u16(void /*uint16_t*/* addr __attribute__((nonnull)), uint16_t val) {
+_EM_INLINE uint16_t emscripten_atomic_and_u16(void /*uint16_t*/* _Nonnull addr, uint16_t val) {
   return __c11_atomic_fetch_and((_Atomic uint16_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint32_t emscripten_atomic_and_u32(void /*uint32_t*/* addr __attribute__((nonnull)), uint32_t val) {
+_EM_INLINE uint32_t emscripten_atomic_and_u32(void /*uint32_t*/* _Nonnull addr, uint32_t val) {
   return __c11_atomic_fetch_and((_Atomic uint32_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint64_t emscripten_atomic_and_u64(void /*uint64_t*/* addr __attribute__((nonnull)), uint64_t val) {
+_EM_INLINE uint64_t emscripten_atomic_and_u64(void /*uint64_t*/* _Nonnull addr, uint64_t val) {
   return __c11_atomic_fetch_and((_Atomic uint64_t*)addr, val, __ATOMIC_SEQ_CST);
 }
 
-_EM_INLINE uint8_t emscripten_atomic_or_u8(void /*uint8_t*/* addr __attribute__((nonnull)), uint8_t val) {
+_EM_INLINE uint8_t emscripten_atomic_or_u8(void /*uint8_t*/* _Nonnull addr, uint8_t val) {
   return __c11_atomic_fetch_or((_Atomic uint8_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint16_t emscripten_atomic_or_u16(void /*uint16_t*/* addr __attribute__((nonnull)), uint16_t val) {
+_EM_INLINE uint16_t emscripten_atomic_or_u16(void /*uint16_t*/* _Nonnull addr, uint16_t val) {
   return __c11_atomic_fetch_or((_Atomic uint16_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint32_t emscripten_atomic_or_u32(void /*uint32_t*/* addr __attribute__((nonnull)), uint32_t val) {
+_EM_INLINE uint32_t emscripten_atomic_or_u32(void /*uint32_t*/* _Nonnull addr, uint32_t val) {
   return __c11_atomic_fetch_or((_Atomic uint32_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint64_t emscripten_atomic_or_u64(void /*uint64_t*/* addr __attribute__((nonnull)), uint64_t val) {
+_EM_INLINE uint64_t emscripten_atomic_or_u64(void /*uint64_t*/* _Nonnull addr, uint64_t val) {
   return __c11_atomic_fetch_or((_Atomic uint64_t*)addr, val, __ATOMIC_SEQ_CST);
 }
 
-_EM_INLINE uint8_t emscripten_atomic_xor_u8(void /*uint8_t*/* addr __attribute__((nonnull)), uint8_t val) {
+_EM_INLINE uint8_t emscripten_atomic_xor_u8(void /*uint8_t*/* _Nonnull addr, uint8_t val) {
   return __c11_atomic_fetch_xor((_Atomic uint8_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint16_t emscripten_atomic_xor_u16(void /*uint16_t*/* addr __attribute__((nonnull)), uint16_t val) {
+_EM_INLINE uint16_t emscripten_atomic_xor_u16(void /*uint16_t*/* _Nonnull addr, uint16_t val) {
   return __c11_atomic_fetch_xor((_Atomic uint16_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint32_t emscripten_atomic_xor_u32(void /*uint32_t*/* addr __attribute__((nonnull)), uint32_t val) {
+_EM_INLINE uint32_t emscripten_atomic_xor_u32(void /*uint32_t*/* _Nonnull addr, uint32_t val) {
   return __c11_atomic_fetch_xor((_Atomic uint32_t*)addr, val, __ATOMIC_SEQ_CST);
 }
-_EM_INLINE uint64_t emscripten_atomic_xor_u64(void /*uint64_t*/* addr __attribute__((nonnull)), uint64_t val) {
+_EM_INLINE uint64_t emscripten_atomic_xor_u64(void /*uint64_t*/* _Nonnull addr, uint64_t val) {
   return __c11_atomic_fetch_xor((_Atomic uint64_t*)addr, val, __ATOMIC_SEQ_CST);
 }
 
@@ -197,7 +197,7 @@ _EM_INLINE void emscripten_atomic_fence(void) {
 // NOTE: This function takes in the wait value in int64_t nanosecond units. Pass
 // in maxWaitNanoseconds = -1 (or ATOMICS_WAIT_DURATION_INFINITE) to wait
 // infinitely long.
-_EM_INLINE ATOMICS_WAIT_RESULT_T emscripten_atomic_wait_u32(void /*uint32_t*/*addr __attribute__((nonnull)), uint32_t expectedValue, int64_t maxWaitNanoseconds) {
+_EM_INLINE ATOMICS_WAIT_RESULT_T emscripten_atomic_wait_u32(void /*uint32_t*/* _Nonnull addr, uint32_t expectedValue, int64_t maxWaitNanoseconds) {
   return __builtin_wasm_memory_atomic_wait32((int32_t*)addr, expectedValue, maxWaitNanoseconds);
 }
 
@@ -208,7 +208,7 @@ _EM_INLINE ATOMICS_WAIT_RESULT_T emscripten_atomic_wait_u32(void /*uint32_t*/*ad
 // NOTE: This function takes in the wait value in int64_t nanosecond units. Pass
 // in maxWaitNanoseconds = -1 (or ATOMICS_WAIT_DURATION_INFINITE) to wait
 // infinitely long.
-_EM_INLINE ATOMICS_WAIT_RESULT_T emscripten_atomic_wait_u64(void /*uint64_t*/*addr __attribute__((nonnull)), uint64_t expectedValue, int64_t maxWaitNanoseconds) {
+_EM_INLINE ATOMICS_WAIT_RESULT_T emscripten_atomic_wait_u64(void /*uint64_t*/* _Nonnull addr, uint64_t expectedValue, int64_t maxWaitNanoseconds) {
   return __builtin_wasm_memory_atomic_wait64((int64_t*)addr, expectedValue, maxWaitNanoseconds);
 }
 
@@ -221,7 +221,7 @@ _EM_INLINE ATOMICS_WAIT_RESULT_T emscripten_atomic_wait_u64(void /*uint64_t*/*ad
 // Returns the number of threads that were woken up.
 // Note: this function is used to notify both waiters waiting on an u32 and u64
 // addresses.
-_EM_INLINE int64_t emscripten_atomic_notify(void *addr __attribute__((nonnull)), int64_t count) {
+_EM_INLINE int64_t emscripten_atomic_notify(void * _Nonnull addr, int64_t count) {
   return __builtin_wasm_memory_atomic_notify((int*)addr, count);
 }
 
@@ -252,9 +252,9 @@ typedef void (*emscripten_async_wait_callback_t)(int32_t* address, uint32_t valu
 //    emscripten_atomic_cancel_wait_async() to unregister an asynchronous wait.
 //    You can use the macro EMSCRIPTEN_IS_VALID_WAIT_TOKEN(retval) to check if
 //    this function returned a valid wait token.
-ATOMICS_WAIT_TOKEN_T emscripten_atomic_wait_async(volatile void *addr __attribute__((nonnull)),
+ATOMICS_WAIT_TOKEN_T emscripten_atomic_wait_async(volatile void * _Nonnull addr,
                                                   uint32_t value,
-                                                  emscripten_async_wait_callback_t asyncWaitFinished __attribute__((nonnull)),
+                                                  emscripten_async_wait_callback_t _Nonnull asyncWaitFinished,
                                                   void *userData,
                                                   double maxWaitMilliseconds);
 
@@ -288,7 +288,7 @@ int emscripten_atomic_cancel_all_wait_asyncs(void);
 
 // Cancels all pending async waits in the calling thread to the given memory
 // address.  Returns the number of async waits canceled.
-int emscripten_atomic_cancel_all_wait_asyncs_at_address(void *addr __attribute__((nonnull)));
+int emscripten_atomic_cancel_all_wait_asyncs_at_address(void * _Nonnull addr);
 
 // Returns the value of the expression "Atomics.isLockFree(byteWidth)": true if
 // the given memory access width can be accessed atomically, and false

--- a/system/include/emscripten/console.h
+++ b/system/include/emscripten/console.h
@@ -13,10 +13,10 @@ extern "C" {
 
 // Write directly to the JavaScript console.  This can be useful for debugging since it
 // bypasses the stdio and filesystem sub-systems.
-void emscripten_console_log(const char *utf8String __attribute__((nonnull)));
-void emscripten_console_warn(const char *utf8String __attribute__((nonnull)));
-void emscripten_console_error(const char *utf8String __attribute__((nonnull)));
-void emscripten_console_trace(const char *utf8String __attribute__((nonnull)));
+void emscripten_console_log(const char * _Nonnull utf8String);
+void emscripten_console_warn(const char * _Nonnull utf8String);
+void emscripten_console_error(const char * _Nonnull utf8String);
+void emscripten_console_trace(const char * _Nonnull utf8String);
 
 // Write to the out(), err() and dbg() JS functions directly.
 // These are defined in shell.js and have different behavior compared
@@ -25,16 +25,16 @@ void emscripten_console_trace(const char *utf8String __attribute__((nonnull)));
 // behavior of these functions can be overridden by print and printErr, if
 // provided on the Module object.  These functions are mainly intended for
 // internal use.
-void emscripten_out(const char *utf8String __attribute__((nonnull)));
-void emscripten_err(const char *utf8String __attribute__((nonnull)));
-void emscripten_dbg(const char *utf8String __attribute__((nonnull)));
-void emscripten_dbg_backtrace(const char *utf8String __attribute__((nonnull)));
+void emscripten_out(const char * _Nonnull utf8String);
+void emscripten_err(const char * _Nonnull utf8String);
+void emscripten_dbg(const char * _Nonnull utf8String);
+void emscripten_dbg_backtrace(const char * _Nonnull utf8String);
 
 // Same as above but only with the length of string specified by the second
 // argument.  This allows for non-NULL-terminated strings to be passed.
-void emscripten_outn(const char *utf8String __attribute__((nonnull)), size_t len);
-void emscripten_errn(const char *utf8String __attribute__((nonnull)), size_t len);
-void emscripten_dbgn(const char *utf8String __attribute__((nonnull)), size_t len);
+void emscripten_outn(const char * _Nonnull utf8String, size_t len);
+void emscripten_errn(const char * _Nonnull utf8String, size_t len);
+void emscripten_dbgn(const char * _Nonnull utf8String, size_t len);
 
 // Legacy/internal names for the above
 #define _emscripten_out(x) emscripten_out(x)
@@ -42,14 +42,14 @@ void emscripten_dbgn(const char *utf8String __attribute__((nonnull)), size_t len
 #define _emscripten_dbg(x) emscripten_dbg(x)
 
 // Similar to the above functions but operate with printf-like semantics.
-void emscripten_console_logf(const char *format __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
-void emscripten_console_warnf(const char *format __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
-void emscripten_console_errorf(const char *format __attribute__((nonnull)), ...)__attribute__((__format__(printf, 1, 2)));
-void emscripten_console_tracef(const char *format __attribute__((nonnull)), ...)__attribute__((__format__(printf, 1, 2)));
-void emscripten_outf(const char *format __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
-void emscripten_errf(const char *format __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
-void emscripten_dbgf(const char *format __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
-void emscripten_dbg_backtracef(const char *format __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
+void emscripten_console_logf(const char * _Nonnull format, ...) __attribute__((__format__(printf, 1, 2)));
+void emscripten_console_warnf(const char * _Nonnull format, ...) __attribute__((__format__(printf, 1, 2)));
+void emscripten_console_errorf(const char * _Nonnull format, ...)__attribute__((__format__(printf, 1, 2)));
+void emscripten_console_tracef(const char * _Nonnull format, ...)__attribute__((__format__(printf, 1, 2)));
+void emscripten_outf(const char * _Nonnull format, ...) __attribute__((__format__(printf, 1, 2)));
+void emscripten_errf(const char * _Nonnull format, ...) __attribute__((__format__(printf, 1, 2)));
+void emscripten_dbgf(const char * _Nonnull format, ...) __attribute__((__format__(printf, 1, 2)));
+void emscripten_dbg_backtracef(const char * _Nonnull format, ...) __attribute__((__format__(printf, 1, 2)));
 
 // Legacy/internal names for the above
 #define _emscripten_outf(format, ...) emscripten_outf(format, ##__VA_ARGS__)

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -39,11 +39,11 @@
 extern "C" {
 #endif
 
-void emscripten_run_script(const char *script __attribute__((nonnull)));
-int emscripten_run_script_int(const char *script __attribute__((nonnull)));
-char *emscripten_run_script_string(const char *script __attribute__((nonnull)));
-void emscripten_async_run_script(const char *script __attribute__((nonnull)), int millis);
-void emscripten_async_load_script(const char *script __attribute__((nonnull)), em_callback_func onload, em_callback_func onerror);
+void emscripten_run_script(const char * _Nonnull script);
+int emscripten_run_script_int(const char * _Nonnull script);
+char *emscripten_run_script_string(const char * _Nonnull script);
+void emscripten_async_run_script(const char * _Nonnull script, int millis);
+void emscripten_async_load_script(const char * _Nonnull script, em_callback_func onload, em_callback_func onerror);
 
 void emscripten_set_main_loop(em_callback_func func, int fps, bool simulate_infinite_loop);
 
@@ -86,10 +86,10 @@ double emscripten_get_device_pixel_ratio(void);
 
 char *emscripten_get_window_title(void);
 void emscripten_set_window_title(const char *);
-void emscripten_get_screen_size(int *width __attribute__((nonnull)), int *height __attribute__((nonnull)));
+void emscripten_get_screen_size(int * _Nonnull width, int * _Nonnull height);
 void emscripten_hide_mouse(void);
 void emscripten_set_canvas_size(int width, int height) __attribute__((deprecated("This variant does not allow specifying the target canvas", "Use emscripten_set_canvas_element_size() instead")));
-void emscripten_get_canvas_size(int *width __attribute__((nonnull)), int *height __attribute__((nonnull)), int *isFullscreen __attribute__((nonnull))) __attribute__((deprecated("This variant does not allow specifying the target canvas", "Use emscripten_get_canvas_element_size() and emscripten_get_fullscreen_status() instead")));
+void emscripten_get_canvas_size(int * _Nonnull width, int * _Nonnull height, int * _Nonnull isFullscreen) __attribute__((deprecated("This variant does not allow specifying the target canvas", "Use emscripten_get_canvas_element_size() and emscripten_get_fullscreen_status() instead")));
 
 double emscripten_get_now(void);
 float emscripten_random(void);
@@ -97,12 +97,12 @@ float emscripten_random(void);
 // IDB
 
 typedef void (*em_idb_onload_func)(void*, void*, int);
-void emscripten_idb_async_load(const char *db_name __attribute__((nonnull)), const char *file_id __attribute__((nonnull)), void* arg, em_idb_onload_func onload, em_arg_callback_func onerror);
-void emscripten_idb_async_store(const char *db_name __attribute__((nonnull)), const char *file_id __attribute__((nonnull)), void* ptr, int num, void* arg, em_arg_callback_func onstore, em_arg_callback_func onerror);
-void emscripten_idb_async_delete(const char *db_name __attribute__((nonnull)), const char *file_id __attribute__((nonnull)), void* arg, em_arg_callback_func ondelete, em_arg_callback_func onerror);
+void emscripten_idb_async_load(const char * _Nonnull db_name, const char * _Nonnull file_id, void* arg, em_idb_onload_func onload, em_arg_callback_func onerror);
+void emscripten_idb_async_store(const char * _Nonnull db_name, const char * _Nonnull file_id, void* ptr, int num, void* arg, em_arg_callback_func onstore, em_arg_callback_func onerror);
+void emscripten_idb_async_delete(const char * _Nonnull db_name, const char * _Nonnull file_id, void* arg, em_arg_callback_func ondelete, em_arg_callback_func onerror);
 typedef void (*em_idb_exists_func)(void*, int);
-void emscripten_idb_async_exists(const char *db_name __attribute__((nonnull)), const char *file_id __attribute__((nonnull)), void* arg, em_idb_exists_func oncheck, em_arg_callback_func onerror);
-void emscripten_idb_async_clear(const char *db_name __attribute__((nonnull)), void* arg, em_arg_callback_func onclear, em_arg_callback_func onerror);
+void emscripten_idb_async_exists(const char * _Nonnull db_name, const char * _Nonnull file_id, void* arg, em_idb_exists_func oncheck, em_arg_callback_func onerror);
+void emscripten_idb_async_clear(const char * _Nonnull db_name, void* arg, em_arg_callback_func onclear, em_arg_callback_func onerror);
 
 // IDB "sync"
 

--- a/system/include/emscripten/eventloop.h
+++ b/system/include/emscripten/eventloop.h
@@ -15,15 +15,15 @@ extern "C" {
 
 void emscripten_unwind_to_js_event_loop(void) __attribute__((__noreturn__));
 
-int emscripten_set_timeout(void (*cb)(void *user_data) __attribute__((nonnull)), double msecs, void *user_data);
+int emscripten_set_timeout(void (* _Nonnull cb)(void *user_data), double msecs, void *user_data);
 void emscripten_clear_timeout(int id);
-void emscripten_set_timeout_loop(bool (*cb)(double time, void *user_data) __attribute__((nonnull)), double interval_ms, void *user_data);
+void emscripten_set_timeout_loop(bool (* _Nonnull cb)(double time, void *user_data), double interval_ms, void *user_data);
 
-int emscripten_set_immediate(void (*cb)(void *user_data) __attribute__((nonnull)), void *user_data);
+int emscripten_set_immediate(void (* _Nonnull cb)(void *user_data), void *user_data);
 void emscripten_clear_immediate(int id);
 void emscripten_set_immediate_loop(bool (*cb)(void *user_data), void *user_data);
 
-int emscripten_set_interval(void (*cb)(void *user_data) __attribute__((nonnull)), double interval_ms, void *user_data);
+int emscripten_set_interval(void (* _Nonnull cb)(void *user_data), double interval_ms, void *user_data);
 void emscripten_clear_interval(int id);
 
 void emscripten_runtime_keepalive_push(void);

--- a/system/include/emscripten/exports.h
+++ b/system/include/emscripten/exports.h
@@ -16,7 +16,7 @@ extern "C" {
 
 // Returns a function pointer to the given exported function by name. Cast the returned pointer
 // to its proper signature before calling the function.
-void *emscripten_get_exported_function(const char *fname __attribute__((nonnull)));
+void *emscripten_get_exported_function(const char * _Nonnull fname);
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/fiber.h
+++ b/system/include/emscripten/fiber.h
@@ -32,24 +32,24 @@ typedef struct emscripten_fiber_s {
 } emscripten_fiber_t;
 
 void emscripten_fiber_init(
-  emscripten_fiber_t *fiber __attribute__((nonnull)),
+  emscripten_fiber_t * _Nonnull fiber,
   em_arg_callback_func entry_func,
   void *entry_func_arg,
-  void *c_stack __attribute__((nonnull)),
+  void * _Nonnull c_stack,
   size_t c_stack_size,
-  void *asyncify_stack __attribute__((nonnull)),
+  void * _Nonnull asyncify_stack,
   size_t asyncify_stack_size
 );
 
 void emscripten_fiber_init_from_current_context(
-  emscripten_fiber_t *fiber __attribute__((nonnull)),
-  void *asyncify_stack __attribute__((nonnull)),
+  emscripten_fiber_t * _Nonnull fiber,
+  void * _Nonnull asyncify_stack,
   size_t asyncify_stack_size
 );
 
 void emscripten_fiber_swap(
-  emscripten_fiber_t *old_fiber __attribute__((nonnull)),
-  emscripten_fiber_t *new_fiber __attribute__((nonnull))
+  emscripten_fiber_t * _Nonnull old_fiber,
+  emscripten_fiber_t * _Nonnull new_fibe
 );
 
 #ifdef __cplusplus

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -104,10 +104,10 @@ typedef struct EmscriptenKeyboardEvent {
 } EmscriptenKeyboardEvent;
 
 
-typedef bool (*em_key_callback_func)(int eventType, const EmscriptenKeyboardEvent *keyEvent __attribute__((nonnull)), void *userData);
-EMSCRIPTEN_RESULT emscripten_set_keypress_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_key_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_keydown_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_key_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_keyup_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_key_callback_func callback, pthread_t targetThread);
+typedef bool (*em_key_callback_func)(int eventType, const EmscriptenKeyboardEvent * _Nonnull keyEvent, void *userData);
+EMSCRIPTEN_RESULT emscripten_set_keypress_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_key_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_keydown_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_key_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_keyup_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_key_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenMouseEvent {
   double timestamp;
@@ -132,18 +132,18 @@ typedef struct EmscriptenMouseEvent {
 } EmscriptenMouseEvent;
 
 
-typedef bool (*em_mouse_callback_func)(int eventType, const EmscriptenMouseEvent *mouseEvent __attribute__((nonnull)), void *userData);
-EMSCRIPTEN_RESULT emscripten_set_click_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mousedown_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mouseup_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_dblclick_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mousemove_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mouseenter_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mouseleave_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mouseover_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mouseout_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+typedef bool (*em_mouse_callback_func)(int eventType, const EmscriptenMouseEvent * _Nonnull mouseEvent, void *userData);
+EMSCRIPTEN_RESULT emscripten_set_click_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mousedown_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseup_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_dblclick_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mousemove_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseenter_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseleave_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseover_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseout_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_mouse_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_mouse_status(EmscriptenMouseEvent *mouseState __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_get_mouse_status(EmscriptenMouseEvent * _Nonnull mouseState);
 
 #define DOM_DELTA_PIXEL 0x00
 #define DOM_DELTA_LINE  0x01
@@ -158,8 +158,8 @@ typedef struct EmscriptenWheelEvent {
 } EmscriptenWheelEvent;
 
 
-typedef bool (*em_wheel_callback_func)(int eventType, const EmscriptenWheelEvent *wheelEvent __attribute__((nonnull)), void *userData);
-EMSCRIPTEN_RESULT emscripten_set_wheel_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_wheel_callback_func callback, pthread_t targetThread);
+typedef bool (*em_wheel_callback_func)(int eventType, const EmscriptenWheelEvent * _Nonnull wheelEvent, void *userData);
+EMSCRIPTEN_RESULT emscripten_set_wheel_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_wheel_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenUiEvent {
   int detail;
@@ -174,20 +174,20 @@ typedef struct EmscriptenUiEvent {
 } EmscriptenUiEvent;
 
 
-typedef bool (*em_ui_callback_func)(int eventType, const EmscriptenUiEvent *uiEvent __attribute__((nonnull)), void *userData);
-EMSCRIPTEN_RESULT emscripten_set_resize_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_ui_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_scroll_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_ui_callback_func callback, pthread_t targetThread);
+typedef bool (*em_ui_callback_func)(int eventType, const EmscriptenUiEvent * _Nonnull uiEvent, void *userData);
+EMSCRIPTEN_RESULT emscripten_set_resize_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_ui_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_scroll_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_ui_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenFocusEvent {
   EM_UTF8 nodeName[EM_HTML5_LONG_STRING_LEN_BYTES];
   EM_UTF8 id[EM_HTML5_LONG_STRING_LEN_BYTES];
 } EmscriptenFocusEvent;
 
-typedef bool (*em_focus_callback_func)(int eventType, const EmscriptenFocusEvent *focusEvent __attribute__((nonnull)), void *userData);
-EMSCRIPTEN_RESULT emscripten_set_blur_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_focus_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_focus_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_focus_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_focusin_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_focus_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_focusout_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_focus_callback_func callback, pthread_t targetThread);
+typedef bool (*em_focus_callback_func)(int eventType, const EmscriptenFocusEvent * _Nonnull focusEvent, void *userData);
+EMSCRIPTEN_RESULT emscripten_set_blur_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_focus_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_focus_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_focus_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_focusin_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_focus_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_focusout_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_focus_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenDeviceOrientationEvent {
   double alpha;
@@ -197,10 +197,10 @@ typedef struct EmscriptenDeviceOrientationEvent {
 } EmscriptenDeviceOrientationEvent;
 
 
-typedef bool (*em_deviceorientation_callback_func)(int eventType, const EmscriptenDeviceOrientationEvent *deviceOrientationEvent __attribute__((nonnull)), void *userData);
+typedef bool (*em_deviceorientation_callback_func)(int eventType, const EmscriptenDeviceOrientationEvent * _Nonnull deviceOrientationEvent, void *userData);
 EMSCRIPTEN_RESULT emscripten_set_deviceorientation_callback_on_thread(void *userData, bool useCapture, em_deviceorientation_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_deviceorientation_status(EmscriptenDeviceOrientationEvent *orientationState __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_get_deviceorientation_status(EmscriptenDeviceOrientationEvent * _Nonnull orientationState);
 
 #define EMSCRIPTEN_DEVICE_MOTION_EVENT_SUPPORTS_ACCELERATION                   0x01
 #define EMSCRIPTEN_DEVICE_MOTION_EVENT_SUPPORTS_ACCELERATION_INCLUDING_GRAVITY 0x02
@@ -220,10 +220,10 @@ typedef struct EmscriptenDeviceMotionEvent {
 } EmscriptenDeviceMotionEvent;
 
 
-typedef bool (*em_devicemotion_callback_func)(int eventType, const EmscriptenDeviceMotionEvent *deviceMotionEvent __attribute__((nonnull)), void *userData);
+typedef bool (*em_devicemotion_callback_func)(int eventType, const EmscriptenDeviceMotionEvent * _Nonnull deviceMotionEvent, void *userData);
 EMSCRIPTEN_RESULT emscripten_set_devicemotion_callback_on_thread(void *userData, bool useCapture, em_devicemotion_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_devicemotion_status(EmscriptenDeviceMotionEvent *motionState __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_get_devicemotion_status(EmscriptenDeviceMotionEvent * _Nonnull motionState);
 
 #define EMSCRIPTEN_ORIENTATION_UNSUPPORTED         0
 #define EMSCRIPTEN_ORIENTATION_PORTRAIT_PRIMARY    1
@@ -237,10 +237,10 @@ typedef struct EmscriptenOrientationChangeEvent {
 } EmscriptenOrientationChangeEvent;
 
 
-typedef bool (*em_orientationchange_callback_func)(int eventType, const EmscriptenOrientationChangeEvent *orientationChangeEvent __attribute__((nonnull)), void *userData);
+typedef bool (*em_orientationchange_callback_func)(int eventType, const EmscriptenOrientationChangeEvent * _Nonnull orientationChangeEvent, void *userData);
 EMSCRIPTEN_RESULT emscripten_set_orientationchange_callback_on_thread(void *userData, bool useCapture, em_orientationchange_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_orientation_status(EmscriptenOrientationChangeEvent *orientationStatus __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_get_orientation_status(EmscriptenOrientationChangeEvent * _Nonnull orientationStatus);
 EMSCRIPTEN_RESULT emscripten_lock_orientation(int allowedOrientations);
 EMSCRIPTEN_RESULT emscripten_unlock_orientation(void);
 
@@ -256,10 +256,10 @@ typedef struct EmscriptenFullscreenChangeEvent {
 } EmscriptenFullscreenChangeEvent;
 
 
-typedef bool (*em_fullscreenchange_callback_func)(int eventType, const EmscriptenFullscreenChangeEvent *fullscreenChangeEvent __attribute__((nonnull)), void *userData);
+typedef bool (*em_fullscreenchange_callback_func)(int eventType, const EmscriptenFullscreenChangeEvent * _Nonnull fullscreenChangeEvent, void *userData);
 EMSCRIPTEN_RESULT emscripten_set_fullscreenchange_callback_on_thread(const char *target, void *userData, bool useCapture, em_fullscreenchange_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_fullscreen_status(EmscriptenFullscreenChangeEvent *fullscreenStatus __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_get_fullscreen_status(EmscriptenFullscreenChangeEvent * _Nonnull fullscreenStatus);
 
 #define EMSCRIPTEN_FULLSCREEN_SCALE int
 #define EMSCRIPTEN_FULLSCREEN_SCALE_DEFAULT 0
@@ -288,12 +288,12 @@ typedef struct EmscriptenFullscreenStrategy {
   pthread_t canvasResizedCallbackTargetThread;
 } EmscriptenFullscreenStrategy;
 
-EMSCRIPTEN_RESULT emscripten_request_fullscreen(const char *target __attribute__((nonnull)), bool deferUntilInEventHandler);
-EMSCRIPTEN_RESULT emscripten_request_fullscreen_strategy(const char *target __attribute__((nonnull)), bool deferUntilInEventHandler, const EmscriptenFullscreenStrategy *fullscreenStrategy __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_request_fullscreen(const char * _Nonnull target, bool deferUntilInEventHandler);
+EMSCRIPTEN_RESULT emscripten_request_fullscreen_strategy(const char * _Nonnull target, bool deferUntilInEventHandler, const EmscriptenFullscreenStrategy * _Nonnull fullscreenStrategy);
 
 EMSCRIPTEN_RESULT emscripten_exit_fullscreen(void);
 
-EMSCRIPTEN_RESULT emscripten_enter_soft_fullscreen(const char *target __attribute__((nonnull)), const EmscriptenFullscreenStrategy *fullscreenStrategy __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_enter_soft_fullscreen(const char * _Nonnull target, const EmscriptenFullscreenStrategy * _Nonnull fullscreenStrategy);
 
 EMSCRIPTEN_RESULT emscripten_exit_soft_fullscreen(void);
 
@@ -304,15 +304,15 @@ typedef struct EmscriptenPointerlockChangeEvent {
 } EmscriptenPointerlockChangeEvent;
 
 
-typedef bool (*em_pointerlockchange_callback_func)(int eventType, const EmscriptenPointerlockChangeEvent *pointerlockChangeEvent __attribute__((nonnull)), void *userData);
-EMSCRIPTEN_RESULT emscripten_set_pointerlockchange_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_pointerlockchange_callback_func callback, pthread_t targetThread);
+typedef bool (*em_pointerlockchange_callback_func)(int eventType, const EmscriptenPointerlockChangeEvent * _Nonnull pointerlockChangeEvent, void *userData);
+EMSCRIPTEN_RESULT emscripten_set_pointerlockchange_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_pointerlockchange_callback_func callback, pthread_t targetThread);
 
 typedef bool (*em_pointerlockerror_callback_func)(int eventType, const void *reserved, void *userData);
-EMSCRIPTEN_RESULT emscripten_set_pointerlockerror_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_pointerlockerror_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_pointerlockerror_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_pointerlockerror_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_pointerlock_status(EmscriptenPointerlockChangeEvent *pointerlockStatus __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_get_pointerlock_status(EmscriptenPointerlockChangeEvent * _Nonnull pointerlockStatus);
 
-EMSCRIPTEN_RESULT emscripten_request_pointerlock(const char *target __attribute__((nonnull)), bool deferUntilInEventHandler);
+EMSCRIPTEN_RESULT emscripten_request_pointerlock(const char * _Nonnull target, bool deferUntilInEventHandler);
 
 EMSCRIPTEN_RESULT emscripten_exit_pointerlock(void);
 
@@ -326,10 +326,10 @@ typedef struct EmscriptenVisibilityChangeEvent {
   int visibilityState;
 } EmscriptenVisibilityChangeEvent;
 
-typedef bool (*em_visibilitychange_callback_func)(int eventType, const EmscriptenVisibilityChangeEvent *visibilityChangeEvent __attribute__((nonnull)), void *userData);
+typedef bool (*em_visibilitychange_callback_func)(int eventType, const EmscriptenVisibilityChangeEvent * _Nonnull visibilityChangeEvent, void *userData);
 EMSCRIPTEN_RESULT emscripten_set_visibilitychange_callback_on_thread(void *userData, bool useCapture, em_visibilitychange_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_visibility_status(EmscriptenVisibilityChangeEvent *visibilityStatus __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_get_visibility_status(EmscriptenVisibilityChangeEvent * _Nonnull visibilityStatus);
 
 
 typedef struct EmscriptenTouchPoint {
@@ -360,11 +360,11 @@ typedef struct EmscriptenTouchEvent {
 } EmscriptenTouchEvent;
 
 
-typedef bool (*em_touch_callback_func)(int eventType, const EmscriptenTouchEvent *touchEvent __attribute__((nonnull)), void *userData);
-EMSCRIPTEN_RESULT emscripten_set_touchstart_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_touch_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_touchend_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_touch_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_touchmove_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_touch_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_touchcancel_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_touch_callback_func callback, pthread_t targetThread);
+typedef bool (*em_touch_callback_func)(int eventType, const EmscriptenTouchEvent * _Nonnull touchEvent, void *userData);
+EMSCRIPTEN_RESULT emscripten_set_touchstart_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_touch_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_touchend_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_touch_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_touchmove_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_touch_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_touchcancel_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_touch_callback_func callback, pthread_t targetThread);
 
 
 typedef struct EmscriptenGamepadEvent {
@@ -381,13 +381,13 @@ typedef struct EmscriptenGamepadEvent {
 } EmscriptenGamepadEvent;
 
 
-typedef bool (*em_gamepad_callback_func)(int eventType, const EmscriptenGamepadEvent *gamepadEvent __attribute__((nonnull)), void *userData);
+typedef bool (*em_gamepad_callback_func)(int eventType, const EmscriptenGamepadEvent * _Nonnull gamepadEvent, void *userData);
 EMSCRIPTEN_RESULT emscripten_set_gamepadconnected_callback_on_thread(void *userData, bool useCapture, em_gamepad_callback_func callback, pthread_t targetThread);
 EMSCRIPTEN_RESULT emscripten_set_gamepaddisconnected_callback_on_thread(void *userData, bool useCapture, em_gamepad_callback_func callback, pthread_t targetThread);
 
 EMSCRIPTEN_RESULT emscripten_sample_gamepad_data(void);
 int emscripten_get_num_gamepads(void);
-EMSCRIPTEN_RESULT emscripten_get_gamepad_status(int index, EmscriptenGamepadEvent *gamepadState __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_get_gamepad_status(int index, EmscriptenGamepadEvent * _Nonnull gamepadState);
 
 typedef struct EmscriptenBatteryEvent {
   double chargingTime;
@@ -396,31 +396,31 @@ typedef struct EmscriptenBatteryEvent {
   bool charging;
 } EmscriptenBatteryEvent;
 
-typedef bool (*em_battery_callback_func)(int eventType, const EmscriptenBatteryEvent *batteryEvent __attribute__((nonnull)), void *userData);
+typedef bool (*em_battery_callback_func)(int eventType, const EmscriptenBatteryEvent * _Nonnull batteryEvent, void *userData);
 EMSCRIPTEN_RESULT emscripten_set_batterychargingchange_callback_on_thread(void *userData, em_battery_callback_func callback, pthread_t targetThread);
 EMSCRIPTEN_RESULT emscripten_set_batterylevelchange_callback_on_thread(void *userData, em_battery_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_battery_status(EmscriptenBatteryEvent *batteryState __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_get_battery_status(EmscriptenBatteryEvent * _Nonnull batteryState);
 
 
 EMSCRIPTEN_RESULT emscripten_vibrate(int msecs);
-EMSCRIPTEN_RESULT emscripten_vibrate_pattern(int *msecsArray __attribute__((nonnull)), int numEntries);
+EMSCRIPTEN_RESULT emscripten_vibrate_pattern(int * _Nonnull msecsArray, int numEntries);
 
 typedef const char *(*em_beforeunload_callback)(int eventType, const void *reserved, void *userData);
 EMSCRIPTEN_RESULT emscripten_set_beforeunload_callback_on_thread(void *userData, em_beforeunload_callback callback, pthread_t targetThread);
 
 // Sets the canvas.width & canvas.height properties.
-EMSCRIPTEN_RESULT emscripten_set_canvas_element_size(const char *target __attribute__((nonnull)), int width, int height);
+EMSCRIPTEN_RESULT emscripten_set_canvas_element_size(const char * _Nonnull target, int width, int height);
 
 // Returns the canvas.width & canvas.height properties.
-EMSCRIPTEN_RESULT emscripten_get_canvas_element_size(const char *target __attribute__((nonnull)), int *width, int *height);
+EMSCRIPTEN_RESULT emscripten_get_canvas_element_size(const char * _Nonnull target, int *width, int *height);
 
-EMSCRIPTEN_RESULT emscripten_set_element_css_size(const char *target __attribute__((nonnull)), double width, double height);
-EMSCRIPTEN_RESULT emscripten_get_element_css_size(const char *target __attribute__((nonnull)), double *width, double *height);
+EMSCRIPTEN_RESULT emscripten_set_element_css_size(const char * _Nonnull target, double width, double height);
+EMSCRIPTEN_RESULT emscripten_get_element_css_size(const char * _Nonnull target, double *width, double *height);
 
 void emscripten_html5_remove_all_event_listeners(void);
 
-EMSCRIPTEN_RESULT emscripten_html5_remove_event_listener(const char *target __attribute__((nonnull)), void *userData, int eventTypeId, void *callback __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_html5_remove_event_listener(const char * _Nonnull target, void *userData, int eventTypeId, void * _Nonnull callback);
 
 #define EM_CALLBACK_THREAD_CONTEXT_MAIN_RUNTIME_THREAD ((pthread_t)0x1)
 #define EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD ((pthread_t)0x2)

--- a/system/include/emscripten/html5_webgl.h
+++ b/system/include/emscripten/html5_webgl.h
@@ -45,21 +45,21 @@ typedef struct EmscriptenWebGLContextAttributes {
   bool renderViaOffscreenBackBuffer;
 } EmscriptenWebGLContextAttributes;
 
-void emscripten_webgl_init_context_attributes(EmscriptenWebGLContextAttributes *attributes __attribute__((nonnull)));
+void emscripten_webgl_init_context_attributes(EmscriptenWebGLContextAttributes * _Nonnull attributes);
 
-EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const char *target __attribute__((nonnull)), const EmscriptenWebGLContextAttributes * _Nonnull attributes);
+EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const char * _Nonnull target, const EmscriptenWebGLContextAttributes * _Nonnull attributes);
 
 EMSCRIPTEN_RESULT emscripten_webgl_make_context_current(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
 EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_get_current_context(void);
 
-EMSCRIPTEN_RESULT emscripten_webgl_get_drawing_buffer_size(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, int *width __attribute__((nonnull)), int *height __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_webgl_get_drawing_buffer_size(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, int * _Nonnull width, int * _Nonnull height);
 
-EMSCRIPTEN_RESULT emscripten_webgl_get_context_attributes(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, EmscriptenWebGLContextAttributes *outAttributes __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_webgl_get_context_attributes(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, EmscriptenWebGLContextAttributes * _Nonnull outAttributes);
 
 EMSCRIPTEN_RESULT emscripten_webgl_destroy_context(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
-bool emscripten_webgl_enable_extension(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, const char *extension __attribute__((nonnull)));
+bool emscripten_webgl_enable_extension(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, const char * _Nonnull extension);
 
 bool emscripten_webgl_enable_ANGLE_instanced_arrays(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
@@ -80,8 +80,8 @@ bool emscripten_webgl_enable_EXT_clip_control(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE co
 bool emscripten_webgl_enable_WEBGL_polygon_mode(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
 typedef bool (*em_webgl_context_callback)(int eventType, const void *reserved, void *userData);
-EMSCRIPTEN_RESULT emscripten_set_webglcontextlost_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_webgl_context_callback callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_webglcontextrestored_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, bool useCapture, em_webgl_context_callback callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_webglcontextlost_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_webgl_context_callback callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_webglcontextrestored_callback_on_thread(const char * _Nonnull target, void *userData, bool useCapture, em_webgl_context_callback callback, pthread_t targetThread);
 
 bool emscripten_is_webgl_context_lost(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
@@ -92,15 +92,15 @@ bool emscripten_supports_offscreencanvas(void);
 // Returns function pointers to WebGL 1 functions. Please avoid using this function ever - all WebGL1/GLES2 functions, even those for WebGL1 extensions, are available to user code via static linking. Calling GL functions
 // via function pointers obtained here is slow, and using this function can greatly increase resulting compiled program size. This functionality is available only for easier program code porting purposes, but be aware
 // that calling this is causing a noticeable performance and compiled code size hit.
-void *emscripten_webgl1_get_proc_address(const char *name __attribute__((nonnull)));
+void *emscripten_webgl1_get_proc_address(const char * _Nonnull name);
 
 // Returns function pointers to WebGL 2 functions. Please avoid using this function ever - all WebGL2/GLES3 functions, even those for WebGL2 extensions, are available to user code via static linking. Calling GL functions
 // via function pointers obtained here is slow, and using this function can greatly increase resulting compiled program size. This functionality is available only for easier program code porting purposes, but be aware
 // that calling this is causing a noticeable performance and compiled code size hit.
-void *emscripten_webgl2_get_proc_address(const char *name __attribute__((nonnull)));
+void *emscripten_webgl2_get_proc_address(const char * _Nonnull name);
 
 // Combines emscripten_webgl1_get_proc_address() and emscripten_webgl2_get_proc_address() to return function pointers to both WebGL1 and WebGL2 functions. Same drawbacks apply.
-void *emscripten_webgl_get_proc_address(const char *name __attribute__((nonnull)));
+void *emscripten_webgl_get_proc_address(const char * _Nonnull name);
 
 #define emscripten_set_webglcontextlost_callback(target, userData, useCapture, callback)      emscripten_set_webglcontextlost_callback_on_thread(     (target), (userData), (useCapture), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
 #define emscripten_set_webglcontextrestored_callback(target, userData, useCapture, callback)  emscripten_set_webglcontextrestored_callback_on_thread( (target), (userData), (useCapture), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
@@ -156,7 +156,7 @@ GLint emscripten_webgl_get_vertex_attrib_o(int index, GLenum param);
 // Use dstType to specify whether to read an array of ints or floats.
 // The function writes at most dstLength array elements to array dst.
 // The actual length of the state array is returned (not the number of elements written)
-int emscripten_webgl_get_vertex_attrib_v(int index, GLenum param, void *dst __attribute__((nonnull)), int dstLength, EMSCRIPTEN_WEBGL_PARAM_TYPE dstType);
+int emscripten_webgl_get_vertex_attrib_v(int index, GLenum param, void * _Nonnull dst, int dstLength, EMSCRIPTEN_WEBGL_PARAM_TYPE dstType);
 
 // Calls GLctx.getUniform():
 // Returns the value of a uniform set in a program in the given location.
@@ -169,7 +169,7 @@ double emscripten_webgl_get_uniform_d(GLint program, int location);
 // Use dstType to specify whether to read in ints or floats.
 // The function writes at most dstLength array elements to array dst.
 // The actual length of the state array is returned (not the number of elements written)
-int emscripten_webgl_get_uniform_v(GLint program, int location, void *dst __attribute__((nonnull)), int dstLength, EMSCRIPTEN_WEBGL_PARAM_TYPE dstType);
+int emscripten_webgl_get_uniform_v(GLint program, int location, void * _Nonnull dst, int dstLength, EMSCRIPTEN_WEBGL_PARAM_TYPE dstType);
 
 // Calls GLctx.getParameter():
 // Gets an array of state set to the active WebGL context.
@@ -177,7 +177,7 @@ int emscripten_webgl_get_uniform_v(GLint program, int location, void *dst __attr
 // Use dstType to specify whether to read in ints or floats.
 // The function writes at most dstLength array elements to array dst.
 // The actual length of the state array is returned (not the number of elements written)
-int emscripten_webgl_get_parameter_v(GLenum param, void *dst __attribute__((nonnull)), int dstLength, EMSCRIPTEN_WEBGL_PARAM_TYPE dstType);
+int emscripten_webgl_get_parameter_v(GLenum param, void * _Nonnull dst, int dstLength, EMSCRIPTEN_WEBGL_PARAM_TYPE dstType);
 
 // Calls GLctx.getParameter():
 // Returns the given WebGL context state as double.
@@ -198,7 +198,7 @@ char *emscripten_webgl_get_parameter_utf8(GLenum param);
 // Calls GLctx.getParameter():
 // Returns the given WebGL context state as GLint64, written to the given heap location.
 // Call this function only for values of 'param' that return a WebGL Number type.
-void emscripten_webgl_get_parameter_i64v(GLenum param, GLint64 *dst __attribute__((nonnull)));
+void emscripten_webgl_get_parameter_i64v(GLenum param, GLint64 * _Nonnull dst);
 
 #undef GLint
 #undef GLenum

--- a/system/include/emscripten/posix_socket.h
+++ b/system/include/emscripten/posix_socket.h
@@ -6,7 +6,7 @@
 extern "C" {
 #endif
 
-EMSCRIPTEN_RESULT emscripten_init_websocket_to_posix_socket_bridge(const char *bridgeUrl __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_init_websocket_to_posix_socket_bridge(const char * _Nonnull bridgeUrl);
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/stack.h
+++ b/system/include/emscripten/stack.h
@@ -35,7 +35,7 @@ void emscripten_stack_init(void);
 // Sets the internal values reported by emscripten_stack_get_base() and
 // emscripten_stack_get_end().  This should be only used by low level libraries
 // such as asyncify fibers.
-void emscripten_stack_set_limits(void* base __attribute__((nonnull)), void* end __attribute__((nonnull)));
+void emscripten_stack_set_limits(void* _Nonnull base, void* _Nonnull end);
 
 // Returns the current stack pointer.
 uintptr_t emscripten_stack_get_current(void);

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -85,11 +85,11 @@ void emscripten_thread_sleep(double msecs);
 // The name parameter is a UTF-8 encoded string which is truncated to 32 bytes.
 // When thread profiler is not enabled (not building with --threadprofiler),
 // this is a no-op.
-void emscripten_set_thread_name(pthread_t threadId, const char *name __attribute__((nonnull)));
+void emscripten_set_thread_name(pthread_t threadId, const char * _Nonnull name);
 
 // Gets the stored pointer to a string representing the canvases to transfer to
 // the created thread.
-int emscripten_pthread_attr_gettransferredcanvases(const pthread_attr_t *a __attribute__((nonnull)), const char **str __attribute__((nonnull)));
+int emscripten_pthread_attr_gettransferredcanvases(const pthread_attr_t * _Nonnull a, const char ** _Nonnull str);
 
 // Specifies a comma-delimited list of canvas DOM element IDs to transfer to the
 // thread to be created.
@@ -97,7 +97,7 @@ int emscripten_pthread_attr_gettransferredcanvases(const pthread_attr_t *a __att
 // so must be held alive until pthread_create() has been called. If 0 or "", no
 // canvases are transferred.
 // The special value "#canvas" denotes the element stored in Module.canvas.
-int emscripten_pthread_attr_settransferredcanvases(pthread_attr_t *a __attribute__((nonnull)), const char *str __attribute__((nonnull)));
+int emscripten_pthread_attr_settransferredcanvases(pthread_attr_t * _Nonnull a, const char * _Nonnull str);
 
 // Called when blocking on the main thread. This will error if main thread
 // blocking is not enabled, see ALLOW_BLOCKING_ON_MAIN_THREAD.

--- a/system/include/emscripten/threading_legacy.h
+++ b/system/include/emscripten/threading_legacy.h
@@ -156,7 +156,7 @@ typedef struct em_queued_call em_queued_call;
 //  - Calling emscripten_sync_* functions requires that the application was
 //    compiled with pthreads support enabled (-pthread) and that the
 //    browser supports SharedArrayBuffer specification.
-int emscripten_sync_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void *func_ptr __attribute__((nonnull)), ...);
+int emscripten_sync_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void * _Nonnull func_ptr, ...);
 
 // The 'async' variant of the run_in_main_thread functions are otherwise the
 // same as the synchronous ones, except that the operation is performed in a
@@ -166,7 +166,7 @@ int emscripten_sync_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void *fun
 //  - Note that multiple asynchronous commands from a single pthread/Worker are
 //    guaranteed to be executed on the main thread in the program order they
 //    were called in.
-void emscripten_async_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void *func_ptr __attribute__((nonnull)), ...);
+void emscripten_async_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void * _Nonnull func_ptr, ...);
 
 // The 'async_waitable' variant of the run_in_main_runtime_thread functions run
 // like the 'async' variants, except that while the operation starts off
@@ -175,7 +175,7 @@ void emscripten_async_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void *f
 //  - The object returned by this function call is dynamically allocated, and
 //    should be freed up via a call to emscripten_async_waitable_close() after
 //    the wait has been performed.
-em_queued_call *emscripten_async_waitable_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void *func_ptr __attribute__((nonnull)), ...);
+em_queued_call *emscripten_async_waitable_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void * _Nonnull func_ptr, ...);
 
 // Since we can't validate the function pointer type, allow implicit casting of
 // functions to void* without complaining.
@@ -184,7 +184,7 @@ em_queued_call *emscripten_async_waitable_run_in_main_runtime_thread_(EM_FUNC_SI
 #ifdef __wasm64__
 // For wasm64 we need to special handling of pointer (P) return types since
 // int and pointer have different widths
-void* emscripten_sync_run_in_main_runtime_thread_ptr_(EM_FUNC_SIGNATURE sig, void *func_ptr __attribute__((nonnull)), ...);
+void* emscripten_sync_run_in_main_runtime_thread_ptr_(EM_FUNC_SIGNATURE sig, void * _Nonnull func_ptr, ...);
 #define emscripten_sync_run_in_main_runtime_thread_ptr(sig, func_ptr, ...) emscripten_sync_run_in_main_runtime_thread_ptr_((sig), (void*)(func_ptr),##__VA_ARGS__)
 #else
 #define emscripten_sync_run_in_main_runtime_thread_ptr emscripten_sync_run_in_main_runtime_thread
@@ -193,10 +193,10 @@ void* emscripten_sync_run_in_main_runtime_thread_ptr_(EM_FUNC_SIGNATURE sig, voi
 #define emscripten_async_run_in_main_runtime_thread(sig, func_ptr, ...) emscripten_async_run_in_main_runtime_thread_((sig), (void*)(func_ptr),##__VA_ARGS__)
 #define emscripten_async_waitable_run_in_main_runtime_thread(sig, func_ptr, ...) emscripten_async_waitable_run_in_main_runtime_thread_((sig), (void*)(func_ptr),##__VA_ARGS__)
 
-EMSCRIPTEN_RESULT emscripten_wait_for_call_v(em_queued_call *call __attribute__((nonnull)), double timeoutMSecs);
-EMSCRIPTEN_RESULT emscripten_wait_for_call_i(em_queued_call *call __attribute__((nonnull)), double timeoutMSecs, int *outResult);
+EMSCRIPTEN_RESULT emscripten_wait_for_call_v(em_queued_call * _Nonnull call, double timeoutMSecs);
+EMSCRIPTEN_RESULT emscripten_wait_for_call_i(em_queued_call * _Nonnull call, double timeoutMSecs, int *outResult);
 
-void emscripten_async_waitable_close(em_queued_call *call __attribute__((nonnull)));
+void emscripten_async_waitable_close(em_queued_call * _Nonnull call);
 
 // Runs the given function on the specified thread. If we are currently on
 // that target thread then we just execute the call synchronously; otherwise it
@@ -205,12 +205,12 @@ void emscripten_async_waitable_close(em_queued_call *call __attribute__((nonnull
 // otherwise.
 int emscripten_dispatch_to_thread_args(pthread_t target_thread,
                                        EM_FUNC_SIGNATURE sig,
-                                       void* func_ptr __attribute__((nonnull)),
+                                       void* _Nonnull func_ptr,
                                        void* satellite,
                                        va_list args);
 int emscripten_dispatch_to_thread_(pthread_t target_thread,
                                    EM_FUNC_SIGNATURE sig,
-                                   void* func_ptr __attribute__((nonnull)),
+                                   void* _Nonnull func_ptr,
                                    void* satellite,
                                    ...);
 #define emscripten_dispatch_to_thread(                                         \
@@ -223,12 +223,12 @@ int emscripten_dispatch_to_thread_(pthread_t target_thread,
 // but may be simpler to reason about in some cases.
 int emscripten_dispatch_to_thread_async_args(pthread_t target_thread,
                                              EM_FUNC_SIGNATURE sig,
-                                             void* func_ptr __attribute__((nonnull)),
+                                             void* _Nonnull func_ptr,
                                              void* satellite,
                                              va_list args);
 int emscripten_dispatch_to_thread_async_(pthread_t target_thread,
                                          EM_FUNC_SIGNATURE sig,
-                                         void* func_ptr __attribute__((nonnull)),
+                                         void* _Nonnull func_ptr,
                                          void* satellite,
                                          ...);
 #define emscripten_dispatch_to_thread_async(                                   \

--- a/system/include/emscripten/wasm_worker.h
+++ b/system/include/emscripten/wasm_worker.h
@@ -44,7 +44,7 @@ typedef void (*emscripten_async_wait_volatile_callback_t)(volatile void* address
 // be executing any code. Use emscripten_wasm_worker_post_function_*() set of
 // functions to start executing code on the Worker.
 emscripten_wasm_worker_t emscripten_malloc_wasm_worker(size_t stackSize);
-emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackPlusTLSAddress __attribute__((nonnull)), size_t stackPlusTLSSize);
+emscripten_wasm_worker_t emscripten_create_wasm_worker(void * _Nonnull stackPlusTLSAddress, size_t stackPlusTLSSize);
 
 // Terminates the given Wasm Worker some time after it has finished executing
 // its current, or possibly some subsequent posted functions. Note that this
@@ -87,14 +87,14 @@ uint32_t emscripten_wasm_worker_self_id(void);
 // atomics and synchronization primitives like mutexes. Additionally these 
 // functions will generate garbage on the JS heap.  Therefore avoid using these 
 // functions where performance is critical.
-void emscripten_wasm_worker_post_function_v(emscripten_wasm_worker_t id, void (*funcPtr)(void) __attribute__((nonnull)));
-void emscripten_wasm_worker_post_function_vi(emscripten_wasm_worker_t id, void (*funcPtr)(int) __attribute__((nonnull)), int arg0);
-void emscripten_wasm_worker_post_function_vii(emscripten_wasm_worker_t id, void (*funcPtr)(int, int) __attribute__((nonnull)), int arg0, int arg1);
-void emscripten_wasm_worker_post_function_viii(emscripten_wasm_worker_t id, void (*funcPtr)(int, int, int) __attribute__((nonnull)), int arg0, int arg1, int arg2);
-void emscripten_wasm_worker_post_function_vd(emscripten_wasm_worker_t id, void (*funcPtr)(double) __attribute__((nonnull)), double arg0);
-void emscripten_wasm_worker_post_function_vdd(emscripten_wasm_worker_t id, void (*funcPtr)(double, double) __attribute__((nonnull)), double arg0, double arg1);
-void emscripten_wasm_worker_post_function_vddd(emscripten_wasm_worker_t id, void (*funcPtr)(double, double, double) __attribute__((nonnull)), double arg0, double arg1, double arg2);
-void emscripten_wasm_worker_post_function_sig(emscripten_wasm_worker_t id, void *funcPtr __attribute__((nonnull)), const char *sig __attribute__((nonnull)), ...);
+void emscripten_wasm_worker_post_function_v(emscripten_wasm_worker_t id, void (* _Nonnull funcPtr)(void));
+void emscripten_wasm_worker_post_function_vi(emscripten_wasm_worker_t id, void (* _Nonnull funcPtr)(int), int arg0);
+void emscripten_wasm_worker_post_function_vii(emscripten_wasm_worker_t id, void (* _Nonnull funcPtr)(int, int), int arg0, int arg1);
+void emscripten_wasm_worker_post_function_viii(emscripten_wasm_worker_t id, void (* _Nonnull funcPtr)(int, int, int), int arg0, int arg1, int arg2);
+void emscripten_wasm_worker_post_function_vd(emscripten_wasm_worker_t id, void (* _Nonnull funcPtr)(double), double arg0);
+void emscripten_wasm_worker_post_function_vdd(emscripten_wasm_worker_t id, void (* _Nonnull funcPtr)(double, double), double arg0, double arg1);
+void emscripten_wasm_worker_post_function_vddd(emscripten_wasm_worker_t id, void (* _Nonnull funcPtr)(double, double, double), double arg0, double arg1, double arg2);
+void emscripten_wasm_worker_post_function_sig(emscripten_wasm_worker_t id, void * _Nonnull funcPtr, const char * _Nonnull sig, ...);
 
 // Sleeps the calling wasm worker for the given nanoseconds. Calling this
 // function on the main thread either results in a TypeError exception
@@ -115,7 +115,7 @@ int emscripten_navigator_hardware_concurrency(void);
 // Use with syntax "emscripten_lock_t l = EMSCRIPTEN_LOCK_T_STATIC_INITIALIZER;"
 #define EMSCRIPTEN_LOCK_T_STATIC_INITIALIZER 0
 
-void emscripten_lock_init(emscripten_lock_t *lock __attribute__((nonnull)));
+void emscripten_lock_init(emscripten_lock_t * _Nonnull lock);
 
 // Attempts to acquire the specified lock. If the lock is free, then this
 // function acquires the lock and immediately returns true. If the lock is
@@ -128,7 +128,7 @@ void emscripten_lock_init(emscripten_lock_t *lock __attribute__((nonnull)));
 //       browser thread, because the main browser thread cannot synchronously
 //       sleep to wait for locks.
 
-bool emscripten_lock_wait_acquire(emscripten_lock_t *lock __attribute__((nonnull)), int64_t maxWaitNanoseconds);
+bool emscripten_lock_wait_acquire(emscripten_lock_t * _Nonnull lock, int64_t maxWaitNanoseconds);
 
 // Similar to emscripten_lock_wait_acquire(), but instead of waiting for at most
 // a specified timeout value, the thread will wait indefinitely long until the
@@ -138,7 +138,7 @@ bool emscripten_lock_wait_acquire(emscripten_lock_t *lock __attribute__((nonnull
 // NOTE: This function can be only called in a Worker, and not on the main
 //       browser thread, because the main browser thread cannot synchronously
 //       sleep to wait for locks.
-void emscripten_lock_waitinf_acquire(emscripten_lock_t *lock __attribute__((nonnull)));
+void emscripten_lock_waitinf_acquire(emscripten_lock_t * _Nonnull lock);
 
 // Similar to emscripten_lock_wait_acquire(), but instead of placing the calling
 // thread to sleep until the lock can be acquired, this function will burn CPU
@@ -151,7 +151,7 @@ void emscripten_lock_waitinf_acquire(emscripten_lock_t *lock __attribute__((nonn
 //       reasonable max wait value, or otherwise a "slow script dialog"
 //       notification can pop up, and can cause the browser to stop executing
 //       the page.
-bool emscripten_lock_busyspin_wait_acquire(emscripten_lock_t *lock __attribute__((nonnull)), double maxWaitMilliseconds);
+bool emscripten_lock_busyspin_wait_acquire(emscripten_lock_t * _Nonnull lock, double maxWaitMilliseconds);
 
 // Similar to emscripten_lock_wait_acquire(), but instead of placing the calling
 // thread to sleep until the lock can be acquired, this function will burn CPU
@@ -165,7 +165,7 @@ bool emscripten_lock_busyspin_wait_acquire(emscripten_lock_t *lock __attribute__
 //       page. If you call this function on the main browser thread, be extra
 //       careful to analyze that the given lock will be extremely fast to
 //       acquire without contention from other threads.
-void emscripten_lock_busyspin_waitinf_acquire(emscripten_lock_t *lock __attribute__((nonnull)));
+void emscripten_lock_busyspin_waitinf_acquire(emscripten_lock_t * _Nonnull lock);
 
 // Registers an *asynchronous* lock acquire operation. The calling thread will
 // asynchronously try to obtain the given lock after the calling thread yields
@@ -184,8 +184,8 @@ void emscripten_lock_busyspin_waitinf_acquire(emscripten_lock_t *lock __attribut
 //         yields back to the browser, so that the Wasm call stack is empty.
 //         This is to guarantee a uniform control flow. If you use this API in
 //         a Worker, you cannot utilise an infinite loop programming model.
-void emscripten_lock_async_acquire(emscripten_lock_t *lock __attribute__((nonnull)),
-                                   emscripten_async_wait_volatile_callback_t asyncWaitFinished __attribute__((nonnull)),
+void emscripten_lock_async_acquire(emscripten_lock_t * _Nonnull lock,
+                                   emscripten_async_wait_volatile_callback_t _Nonnull asyncWaitFinished,
                                    void *userData,
                                    double maxWaitMilliseconds);
 
@@ -193,7 +193,7 @@ void emscripten_lock_async_acquire(emscripten_lock_t *lock __attribute__((nonnul
 // already held, this function will not sleep to wait until the lock is
 // released, but immediately returns false.
 // This function can be called on both main thread and in Workers.
-bool emscripten_lock_try_acquire(emscripten_lock_t *lock __attribute__((nonnull)));
+bool emscripten_lock_try_acquire(emscripten_lock_t * _Nonnull lock);
 
 // Unlocks the specified lock for another thread to access. Note that locks are
 // extremely lightweight, there is no "lock owner" tracking: this function does
@@ -201,35 +201,35 @@ bool emscripten_lock_try_acquire(emscripten_lock_t *lock __attribute__((nonnull)
 // any thread can call this function to release a lock on behalf of whichever
 // thread owns it.  This function can be called on both main thread and in
 // Workers.
-void emscripten_lock_release(emscripten_lock_t *lock __attribute__((nonnull)));
+void emscripten_lock_release(emscripten_lock_t * _Nonnull lock);
 
 #define emscripten_semaphore_t volatile uint32_t
 
 // Use with syntax emscripten_semaphore_t s = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(num);
 #define EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(num) ((int)(num))
 
-void emscripten_semaphore_init(emscripten_semaphore_t *sem __attribute__((nonnull)), int num);
+void emscripten_semaphore_init(emscripten_semaphore_t * _Nonnull sem, int num);
 
 // main thread, try acquire num instances, but do not sleep to wait if not
 // available.
 // Returns idx that was acquired or -1 if acquire failed.
-int emscripten_semaphore_try_acquire(emscripten_semaphore_t *sem __attribute__((nonnull)), int num);
+int emscripten_semaphore_try_acquire(emscripten_semaphore_t * _Nonnull sem, int num);
 
 // main thread, poll to try acquire num instances. Returns idx that was
 // acquired. If you use this API in Worker, you cannot run an infinite loop.
-void emscripten_semaphore_async_acquire(emscripten_semaphore_t *sem __attribute__((nonnull)),
+void emscripten_semaphore_async_acquire(emscripten_semaphore_t * _Nonnull sem,
                                         int num,
-                                        emscripten_async_wait_volatile_callback_t asyncWaitFinished __attribute__((nonnull)),
+                                        emscripten_async_wait_volatile_callback_t _Nonnull asyncWaitFinished,
                                         void *userData,
                                         double maxWaitMilliseconds);
 
 // worker, sleep to acquire num instances. Returns idx that was acquired, or -1
 // if timed out unable to acquire.
-int emscripten_semaphore_wait_acquire(emscripten_semaphore_t *sem __attribute__((nonnull)), int num, int64_t maxWaitNanoseconds);
+int emscripten_semaphore_wait_acquire(emscripten_semaphore_t * _Nonnull sem, int num, int64_t maxWaitNanoseconds);
 
 // worker, sleep infinitely long to acquire num instances. Returns idx that was
 // acquired.
-int emscripten_semaphore_waitinf_acquire(emscripten_semaphore_t *sem __attribute__((nonnull)), int num);
+int emscripten_semaphore_waitinf_acquire(emscripten_semaphore_t * _Nonnull sem, int num);
 
 // Releases the given number of resources back to the semaphore. Note that the
 // ownership of resources is completely conceptual - there is no actual checking
@@ -239,7 +239,7 @@ int emscripten_semaphore_waitinf_acquire(emscripten_semaphore_t *sem __attribute
 // resources were released back to the semaphore. (i.e. the index where the
 // resource was put back to)
 // [main thread or worker]
-uint32_t emscripten_semaphore_release(emscripten_semaphore_t *sem __attribute__((nonnull)), int num);
+uint32_t emscripten_semaphore_release(emscripten_semaphore_t * _Nonnull sem, int num);
 
 // Condition variable is an object that can be waited on, and another thread can
 // signal, while coordinating an access to a related mutex.
@@ -249,7 +249,7 @@ uint32_t emscripten_semaphore_release(emscripten_semaphore_t *sem __attribute__(
 #define EMSCRIPTEN_CONDVAR_T_STATIC_INITIALIZER ((int)(0))
 
 // Creates a new condition variable to the given memory location.
-void emscripten_condvar_init(emscripten_condvar_t *condvar __attribute__((nonnull)));
+void emscripten_condvar_init(emscripten_condvar_t * _Nonnull condvar);
 
 // Atomically performs the following:
 // 1. releases the given lock. The lock should (but does not strictly need to)
@@ -259,26 +259,26 @@ void emscripten_condvar_init(emscripten_condvar_t *condvar __attribute__((nonnul
 // 3. once the sleep has finished (another thread has signaled the condition
 //    variable), the calling thread wakes up and reacquires the lock prior to
 //    returning from this function.
-void emscripten_condvar_waitinf(emscripten_condvar_t *condvar __attribute__((nonnull)), emscripten_lock_t *lock __attribute__((nonnull)));
+void emscripten_condvar_waitinf(emscripten_condvar_t * _Nonnull condvar, emscripten_lock_t * _Nonnull lock);
 
 // Same as the above, except that an attempt to wait for the condition variable
 // to become true is only performed for a maximum duration.
 // On success (no timeout), this function will return true. If the wait times
 // out, this function will return false. In this case,
 // the calling thread will not try to reacquire the lock.
-bool emscripten_condvar_wait(emscripten_condvar_t *condvar __attribute__((nonnull)), emscripten_lock_t *lock __attribute__((nonnull)), int64_t maxWaitNanoseconds);
+bool emscripten_condvar_wait(emscripten_condvar_t * _Nonnull condvar, emscripten_lock_t * _Nonnull lock, int64_t maxWaitNanoseconds);
 
 // Asynchronously wait for the given condition variable to signal.
-ATOMICS_WAIT_TOKEN_T emscripten_condvar_wait_async(emscripten_condvar_t *condvar __attribute__((nonnull)),
-                                                   emscripten_lock_t *lock __attribute__((nonnull)),
-                                                   emscripten_async_wait_callback_t asyncWaitFinished __attribute__((nonnull)),
+ATOMICS_WAIT_TOKEN_T emscripten_condvar_wait_async(emscripten_condvar_t * _Nonnull condvar,
+                                                   emscripten_lock_t * _Nonnull lock,
+                                                   emscripten_async_wait_callback_t _Nonnull asyncWaitFinished,
                                                    void *userData,
                                                    double maxWaitMilliseconds);
 
 // Signals the given number of waiters on the specified condition variable.
 // Pass numWaitersToSignal == EMSCRIPTEN_NOTIFY_ALL_WAITERS to wake all waiters
 // ("broadcast" operation).
-void emscripten_condvar_signal(emscripten_condvar_t *condvar __attribute__((nonnull)), int64_t numWaitersToSignal);
+void emscripten_condvar_signal(emscripten_condvar_t * _Nonnull condvar, int64_t numWaitersToSignal);
 
 // Legacy names for emscripten_atomic_wait/notify functions, defined in
 // emscripten/atomic.h

--- a/system/include/emscripten/wasmfs.h
+++ b/system/include/emscripten/wasmfs.h
@@ -17,7 +17,7 @@ extern "C" {
 typedef struct Backend* backend_t;
 
 // Obtains the backend_t of a specified path.
-backend_t wasmfs_get_backend_by_path(const char* path __attribute__((nonnull)));
+backend_t wasmfs_get_backend_by_path(const char* _Nonnull path);
 
 // Obtains the backend_t of a specified fd.
 backend_t wasmfs_get_backend_by_fd(int fd);
@@ -27,16 +27,16 @@ backend_t wasmfs_get_backend_by_fd(int fd);
 // value on error. TODO: It might be worth returning a more specialized type
 // like __wasi_fd_t here.
 // TODO: Remove this function so that only directories can be mounted.
-int wasmfs_create_file(const char* pathname __attribute__((nonnull)), mode_t mode, backend_t backend);
+int wasmfs_create_file(const char* _Nonnull pathname, mode_t mode, backend_t backend);
 
 // Creates a new directory using a specific backend.
 // Returns 0 on success like `mkdir`, or a negative value on error.
 // TODO: Add an alias with wasmfs_mount.
-int wasmfs_create_directory(const char* path __attribute__((nonnull)), mode_t mode, backend_t backend);
+int wasmfs_create_directory(const char* _Nonnull path, mode_t mode, backend_t backend);
 
 // Unmounts the directory (Which must be a valid mountpoint) at a specific path.
 // Returns 0 on success, or a negative value on error.
-int wasmfs_unmount(const char* path __attribute__((nonnull)));
+int wasmfs_unmount(const char* _Nonnull path);
 
 // Backend creation
 
@@ -75,10 +75,9 @@ backend_t wasmfs_create_memory_backend(void);
 // TODO: Add an async version of this function that will work on the main
 // thread.
 //
-backend_t wasmfs_create_fetch_backend(const char* base_url __attribute__((nonnull)),
-                                      uint32_t chunk_size);
+backend_t wasmfs_create_fetch_backend(const char* _Nonnull base_url, uint32_t chunk_size);
 
-backend_t wasmfs_create_node_backend(const char* root __attribute__((nonnull)));
+backend_t wasmfs_create_node_backend(const char* _Nonnull root);
 
 // Note: this cannot be called on the browser main thread because it might
 // deadlock while waiting for the OPFS dedicated worker thread to be spawned.

--- a/system/include/emscripten/websocket.h
+++ b/system/include/emscripten/websocket.h
@@ -20,32 +20,32 @@ extern "C" {
 #define EMSCRIPTEN_WEBSOCKET_T int
 
 // Returns the WebSocket.readyState field into readyState. readyState must not be a null pointer.
-EMSCRIPTEN_RESULT emscripten_websocket_get_ready_state(EMSCRIPTEN_WEBSOCKET_T socket, unsigned short *readyState __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_websocket_get_ready_state(EMSCRIPTEN_WEBSOCKET_T socket, unsigned short * _Nonnull readyState);
 
 // Returns the WebSocket.bufferedAmount field into bufferedAmount. bufferedAmount must not be a null pointer.
-EMSCRIPTEN_RESULT emscripten_websocket_get_buffered_amount(EMSCRIPTEN_WEBSOCKET_T socket, size_t *bufferedAmount __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_websocket_get_buffered_amount(EMSCRIPTEN_WEBSOCKET_T socket, size_t * _Nonnull bufferedAmount);
 
 // Writes the WebSocket.url field as a UTF-8 string to the memory area pointed by url. The memory area must contain at least urlLength bytes of free space. If this memory area cannot
 // fit the url string, it will be truncated. Call emscripten_websocket_get_url_length() to determine how large memory area will be required to store the url.
 // url must not be a null pointer.
-EMSCRIPTEN_RESULT emscripten_websocket_get_url(EMSCRIPTEN_WEBSOCKET_T socket, char *url __attribute__((nonnull)), int urlLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_url(EMSCRIPTEN_WEBSOCKET_T socket, char * _Nonnull url, int urlLength);
 // Returns the byte length needed to store WebSocket.url string in Wasm heap. This length can be passed to emscripten_websocket_get_url as it includes the null byte in the count.
 // urlLength must not be a null pointer.
-EMSCRIPTEN_RESULT emscripten_websocket_get_url_length(EMSCRIPTEN_WEBSOCKET_T socket, int *urlLength __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_websocket_get_url_length(EMSCRIPTEN_WEBSOCKET_T socket, int * _Nonnull urlLength);
 
 // Similar to emscripten_websocket_get_url(), but returns WebSocket.extensions field instead.
-EMSCRIPTEN_RESULT emscripten_websocket_get_extensions(EMSCRIPTEN_WEBSOCKET_T socket, char *extensions __attribute__((nonnull)), int extensionsLength);
-EMSCRIPTEN_RESULT emscripten_websocket_get_extensions_length(EMSCRIPTEN_WEBSOCKET_T socket, int *extensionsLength __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_websocket_get_extensions(EMSCRIPTEN_WEBSOCKET_T socket, char * _Nonnull extensions, int extensionsLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_extensions_length(EMSCRIPTEN_WEBSOCKET_T socket, int * _Nonnull extensionsLength);
 
 // Similar to emscripten_websocket_get_url(), but returns WebSocket.protocol field instead.
-EMSCRIPTEN_RESULT emscripten_websocket_get_protocol(EMSCRIPTEN_WEBSOCKET_T socket, char *protocol __attribute__((nonnull)), int protocolLength);
-EMSCRIPTEN_RESULT emscripten_websocket_get_protocol_length(EMSCRIPTEN_WEBSOCKET_T socket, int *protocolLength __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_websocket_get_protocol(EMSCRIPTEN_WEBSOCKET_T socket, char * _Nonnull protocol, int protocolLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_protocol_length(EMSCRIPTEN_WEBSOCKET_T socket, int * _Nonnull protocolLength);
 
 typedef struct EmscriptenWebSocketOpenEvent {
   EMSCRIPTEN_WEBSOCKET_T socket;
 } EmscriptenWebSocketOpenEvent;
 
-typedef bool (*em_websocket_open_callback_func)(int eventType, const EmscriptenWebSocketOpenEvent *websocketEvent __attribute__((nonnull)), void *userData);
+typedef bool (*em_websocket_open_callback_func)(int eventType, const EmscriptenWebSocketOpenEvent * _Nonnull websocketEvent, void *userData);
 EMSCRIPTEN_RESULT emscripten_websocket_set_onopen_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_open_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenWebSocketMessageEvent {
@@ -55,14 +55,14 @@ typedef struct EmscriptenWebSocketMessageEvent {
   bool isText;
 } EmscriptenWebSocketMessageEvent;
 
-typedef bool (*em_websocket_message_callback_func)(int eventType, const EmscriptenWebSocketMessageEvent *websocketEvent __attribute__((nonnull)), void *userData);
+typedef bool (*em_websocket_message_callback_func)(int eventType, const EmscriptenWebSocketMessageEvent * _Nonnull websocketEvent, void *userData);
 EMSCRIPTEN_RESULT emscripten_websocket_set_onmessage_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_message_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenWebSocketErrorEvent {
   EMSCRIPTEN_WEBSOCKET_T socket;
 } EmscriptenWebSocketErrorEvent;
 
-typedef bool (*em_websocket_error_callback_func)(int eventType, const EmscriptenWebSocketErrorEvent *websocketEvent __attribute__((nonnull)), void *userData);
+typedef bool (*em_websocket_error_callback_func)(int eventType, const EmscriptenWebSocketErrorEvent * _Nonnull websocketEvent, void *userData);
 EMSCRIPTEN_RESULT emscripten_websocket_set_onerror_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_error_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenWebSocketCloseEvent {
@@ -72,7 +72,7 @@ typedef struct EmscriptenWebSocketCloseEvent {
   char reason[512]; // WebSockets spec enforces this can be max 123 characters, so as UTF-8 at most 123*4 bytes < 512.
 } EmscriptenWebSocketCloseEvent;
 
-typedef bool (*em_websocket_close_callback_func)(int eventType, const EmscriptenWebSocketCloseEvent *websocketEvent __attribute__((nonnull)), void *userData);
+typedef bool (*em_websocket_close_callback_func)(int eventType, const EmscriptenWebSocketCloseEvent * _Nonnull websocketEvent, void *userData);
 EMSCRIPTEN_RESULT emscripten_websocket_set_onclose_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_close_callback_func callback, pthread_t targetThread);
 
 #define emscripten_websocket_set_onopen_callback(socket, userData, callback)    emscripten_websocket_set_onopen_callback_on_thread(   (socket), (userData), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
@@ -106,13 +106,13 @@ bool emscripten_websocket_is_supported(void);
 // If the return value of this function is > 0, the function has succeeded and the return value represents a handle to the WebSocket object.
 // If the return value of this function is < 0, then the function has failed, and the return value can be interpreted as a EMSCRIPTEN_RESULT code
 // representing the cause of the failure. If the function returns 0, then the call has failed with an unknown reason (build with -sWEBSOCKET_DEBUG for more information)
-EMSCRIPTEN_WEBSOCKET_T emscripten_websocket_new(EmscriptenWebSocketCreateAttributes *createAttributes __attribute__((nonnull)));
+EMSCRIPTEN_WEBSOCKET_T emscripten_websocket_new(EmscriptenWebSocketCreateAttributes * _Nonnull createAttributes);
 
 // Sends the given string of null-delimited UTF8 encoded text data to the connected server.
-EMSCRIPTEN_RESULT emscripten_websocket_send_utf8_text(EMSCRIPTEN_WEBSOCKET_T socket, const char *textData __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_websocket_send_utf8_text(EMSCRIPTEN_WEBSOCKET_T socket, const char * _Nonnull textData);
 
 // Sends the given block of raw memory data out to the connected server.
-EMSCRIPTEN_RESULT emscripten_websocket_send_binary(EMSCRIPTEN_WEBSOCKET_T socket, void *binaryData __attribute__((nonnull)), uint32_t dataLength);
+EMSCRIPTEN_RESULT emscripten_websocket_send_binary(EMSCRIPTEN_WEBSOCKET_T socket, void * _Nonnull binaryData, uint32_t dataLength);
 
 // Closes the specified WebSocket. N.B.: the meaning of "closing" a WebSocket means "eager read/lazy write"-closing the socket. That is, all still
 // pending untransferred outbound bytes will continue to transfer out, but after calling close on the socket, any pending bytes still in the process

--- a/system/include/webgl/webgl1_ext.h
+++ b/system/include/webgl/webgl1_ext.h
@@ -83,12 +83,12 @@ bool emscripten_webgl_enable_OES_vertex_array_object(EMSCRIPTEN_WEBGL_CONTEXT_HA
 // call emscripten_webgl_enable_extension(ctx, "OES_vertex_array_object");
 #define GL_VERTEX_ARRAY_BINDING_OES 0x85B5
 WEBGL_APICALL void GL_APIENTRY emscripten_glBindVertexArrayOES(GLuint array);
-WEBGL_APICALL void GL_APIENTRY emscripten_glDeleteVertexArraysOES(GLsizei n, const GLuint *arrays __attribute__((nonnull)));
-WEBGL_APICALL void GL_APIENTRY emscripten_glGenVertexArraysOES(GLsizei n, GLuint *arrays __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY emscripten_glDeleteVertexArraysOES(GLsizei n, const GLuint * _Nonnull arrays);
+WEBGL_APICALL void GL_APIENTRY emscripten_glGenVertexArraysOES(GLsizei n, GLuint * _Nonnull arrays);
 WEBGL_APICALL GLboolean GL_APIENTRY emscripten_glIsVertexArrayOES(GLuint array);
 WEBGL_APICALL void GL_APIENTRY glBindVertexArrayOES(GLuint array);
-WEBGL_APICALL void GL_APIENTRY glDeleteVertexArraysOES(GLsizei n, const GLuint *arrays __attribute__((nonnull)));
-WEBGL_APICALL void GL_APIENTRY glGenVertexArraysOES(GLsizei n, GLuint *arrays __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY glDeleteVertexArraysOES(GLsizei n, const GLuint * _Nonnull arrays);
+WEBGL_APICALL void GL_APIENTRY glGenVertexArraysOES(GLsizei n, GLuint * _Nonnull arrays);
 WEBGL_APICALL GLboolean GL_APIENTRY glIsVertexArrayOES(GLuint array);
 #endif /* EMSCRIPTEN_GL_OES_vertex_array_object */
 
@@ -106,7 +106,7 @@ WEBGL_APICALL GLboolean GL_APIENTRY glIsVertexArrayOES(GLuint array);
 #define EMSCRIPTEN_GL_WEBGL_debug_shaders 1
 // To enable: call emscripten_webgl_enable_extension(ctx, "WEBGL_debug_shaders");
 //TODO:
-//WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getTranslatedShaderSource(GLuint shader, GLsizei bufSize, GLsizei *length __attribute__((nonnull)), GLchar *source __attribute__((nonnull)));
+//WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getTranslatedShaderSource(GLuint shader, GLsizei bufSize, GLsizei * _Nonnull length, GLchar * _Nonnull source);
 #endif /* EMSCRIPTEN_GL_WEBGL_debug_shaders */
 
 // 8. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/
@@ -305,28 +305,28 @@ WEBGL_APICALL void GL_APIENTRY glVertexAttribDivisorANGLE(GLuint index, GLuint d
 #define GL_TIME_ELAPSED_EXT 0x88BF
 #define GL_TIMESTAMP_EXT 0x8E28
 #define GL_GPU_DISJOINT_EXT 0x8FBB
-WEBGL_APICALL void GL_APIENTRY emscripten_glGenQueriesEXT(GLsizei n, GLuint *ids __attribute__((nonnull)));
-WEBGL_APICALL void GL_APIENTRY emscripten_glDeleteQueriesEXT(GLsizei n, const GLuint *ids __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY emscripten_glGenQueriesEXT(GLsizei n, GLuint * _Nonnull ids);
+WEBGL_APICALL void GL_APIENTRY emscripten_glDeleteQueriesEXT(GLsizei n, const GLuint * _Nonnull ids);
 WEBGL_APICALL GLboolean GL_APIENTRY emscripten_glIsQueryEXT(GLuint id);
 WEBGL_APICALL void GL_APIENTRY emscripten_glBeginQueryEXT(GLenum target, GLuint id);
 WEBGL_APICALL void GL_APIENTRY emscripten_glEndQueryEXT(GLenum target);
 WEBGL_APICALL void GL_APIENTRY emscripten_glQueryCounterEXT(GLuint id, GLenum target);
-WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryivEXT(GLenum target, GLenum pname, GLint *params __attribute__((nonnull)));
-WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjectivEXT(GLuint id, GLenum pname, GLint *params __attribute__((nonnull)));
-WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjectuivEXT(GLuint id, GLenum pname, GLuint *params __attribute__((nonnull)));
-WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjecti64vEXT(GLuint id, GLenum pname, GLint64 *params __attribute__((nonnull)));
-WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjectui64vEXT(GLuint id, GLenum pname, GLuint64 *params __attribute__((nonnull)));
-WEBGL_APICALL void GL_APIENTRY glGenQueriesEXT(GLsizei n, GLuint *ids __attribute__((nonnull)));
-WEBGL_APICALL void GL_APIENTRY glDeleteQueriesEXT(GLsizei n, const GLuint *ids __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryivEXT(GLenum target, GLenum pname, GLint * _Nonnull params);
+WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjectivEXT(GLuint id, GLenum pname, GLint * _Nonnull params);
+WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjectuivEXT(GLuint id, GLenum pname, GLuint * _Nonnull params);
+WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjecti64vEXT(GLuint id, GLenum pname, GLint64 * _Nonnull params);
+WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjectui64vEXT(GLuint id, GLenum pname, GLuint64 * _Nonnull params);
+WEBGL_APICALL void GL_APIENTRY glGenQueriesEXT(GLsizei n, GLuint * _Nonnull ids);
+WEBGL_APICALL void GL_APIENTRY glDeleteQueriesEXT(GLsizei n, const GLuint * _Nonnull ids);
 WEBGL_APICALL GLboolean GL_APIENTRY glIsQueryEXT(GLuint id);
 WEBGL_APICALL void GL_APIENTRY glBeginQueryEXT(GLenum target, GLuint id);
 WEBGL_APICALL void GL_APIENTRY glEndQueryEXT(GLenum target);
 WEBGL_APICALL void GL_APIENTRY glQueryCounterEXT(GLuint id, GLenum target);
-WEBGL_APICALL void GL_APIENTRY glGetQueryivEXT(GLenum target, GLenum pname, GLint *params __attribute__((nonnull)));
-WEBGL_APICALL void GL_APIENTRY glGetQueryObjectivEXT(GLuint id, GLenum pname, GLint *params __attribute__((nonnull)));
-WEBGL_APICALL void GL_APIENTRY glGetQueryObjectuivEXT(GLuint id, GLenum pname, GLuint *params __attribute__((nonnull)));
-WEBGL_APICALL void GL_APIENTRY glGetQueryObjecti64vEXT(GLuint id, GLenum pname, GLint64 *params __attribute__((nonnull)));
-WEBGL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT(GLuint id, GLenum pname, GLuint64 *params __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY glGetQueryivEXT(GLenum target, GLenum pname, GLint * _Nonnull params);
+WEBGL_APICALL void GL_APIENTRY glGetQueryObjectivEXT(GLuint id, GLenum pname, GLint * _Nonnull params);
+WEBGL_APICALL void GL_APIENTRY glGetQueryObjectuivEXT(GLuint id, GLenum pname, GLuint * _Nonnull params);
+WEBGL_APICALL void GL_APIENTRY glGetQueryObjecti64vEXT(GLuint id, GLenum pname, GLint64 * _Nonnull params);
+WEBGL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT(GLuint id, GLenum pname, GLuint64 * _Nonnull params);
 #endif /* EMSCRIPTEN_GL_EXT_disjoint_timer_query */
 
 // 29. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/
@@ -379,7 +379,7 @@ WEBGL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT(GLuint id, GLenum pname,
 #define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR 0x93DC
 #define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR 0x93DD
 //TODO:
-//WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getSupportedAstcProfiles(GLsizei bufSize, GLsizei *length __attribute__((nonnull)), GLchar *buf __attribute__((nonnull)));
+//WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getSupportedAstcProfiles(GLsizei bufSize, GLsizei * _Nonnull length, GLchar * _Nonnull buf);
 #endif /* EMSCRIPTEN_GL_WEBGL_compressed_texture_astc */
 
 // 31. https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/
@@ -416,44 +416,44 @@ bool emscripten_webgl_enable_WEBGL_multi_draw(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE co
 // or link with -sGL_SUPPORT_SIMPLE_ENABLE_EXTENSIONS=1 and
 // call emscripten_webgl_enable_extension(ctx, "WEBGL_multi_draw");
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysWEBGL(GLenum mode,
-                                                                 const GLint* firsts __attribute__((nonnull)),
-                                                                 const GLsizei* counts __attribute__((nonnull)),
+                                                                 const GLint* _Nonnull firsts,
+                                                                 const GLsizei* _Nonnull counts,
                                                                  GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysInstancedWEBGL(GLenum mode,
-                                                                          const GLint* firsts __attribute__((nonnull)),
-                                                                          const GLsizei* counts __attribute__((nonnull)),
-                                                                          const GLsizei* instanceCounts __attribute__((nonnull)),
+                                                                          const GLint* _Nonnull firsts,
+                                                                          const GLsizei* _Nonnull counts,
+                                                                          const GLsizei* _Nonnull instanceCounts,
                                                                           GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsWEBGL(GLenum mode,
-                                                                   const GLsizei* counts __attribute__((nonnull)),
+                                                                   const GLsizei* _Nonnull counts,
                                                                    GLenum type,
-                                                                   const GLvoid* const* offsets __attribute__((nonnull)),
+                                                                   const GLvoid* const* _Nonnull offsets,
                                                                    GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsInstancedWEBGL(GLenum mode,
-                                                                            const GLsizei* counts __attribute__((nonnull)),
+                                                                            const GLsizei* _Nonnull counts,
                                                                             GLenum type,
-                                                                            const GLvoid* const* offsets __attribute__((nonnull)),
-                                                                            const GLsizei* instanceCounts __attribute__((nonnull)),
+                                                                            const GLvoid* const* _Nonnull offsets,
+                                                                            const GLsizei* _Nonnull instanceCounts,
                                                                             GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysWEBGL(GLenum mode,
-                                                      const GLint* firsts __attribute__((nonnull)),
-                                                      const GLsizei* counts __attribute__((nonnull)),
+                                                      const GLint* _Nonnull firsts,
+                                                      const GLsizei* _Nonnull counts,
                                                       GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysInstancedWEBGL(GLenum mode,
-                                                               const GLint* firsts __attribute__((nonnull)),
-                                                               const GLsizei* counts __attribute__((nonnull)),
-                                                               const GLsizei* instanceCounts __attribute__((nonnull)),
+                                                               const GLint* _Nonnull firsts,
+                                                               const GLsizei* _Nonnull counts,
+                                                               const GLsizei* _Nonnull instanceCounts,
                                                                GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsWEBGL(GLenum mode,
-                                                        const GLsizei* counts __attribute__((nonnull)),
+                                                        const GLsizei* _Nonnull counts,
                                                         GLenum type,
-                                                        const GLvoid* const* offsets __attribute__((nonnull)),
+                                                        const GLvoid* const* _Nonnull offsets,
                                                         GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedWEBGL(GLenum mode,
-                                                                 const GLsizei* counts __attribute__((nonnull)),
+                                                                 const GLsizei* _Nonnull counts,
                                                                  GLenum type,
-                                                                 const GLvoid* const* offsets __attribute__((nonnull)),
-                                                                 const GLsizei* instanceCounts __attribute__((nonnull)),
+                                                                 const GLvoid* const* _Nonnull offsets,
+                                                                 const GLsizei* _Nonnull instanceCounts,
                                                                  GLsizei drawcount);
 #endif /* EMSCRIPTEN_GL_WEBGL_multi_draw */
 

--- a/system/include/webgl/webgl2.h
+++ b/system/include/webgl/webgl2.h
@@ -111,7 +111,7 @@ WEBGL_APICALL void GL_APIENTRY emscripten_glGetInternalformativ (GLenum target, 
 WEBGL_APICALL void GL_APIENTRY emscripten_glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, void *data);
 
 // WebGL 2 functions that do not exist in GLES3.0:
-WEBGL_APICALL void GL_APIENTRY glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, void *data __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, void * _Nonnull data);
 
 // Extensions:
 WEBGL_APICALL void GL_APIENTRY emscripten_glVertexAttribDivisorNV(GLuint index, GLuint divisor);

--- a/system/include/webgl/webgl2_ext.h
+++ b/system/include/webgl/webgl2_ext.h
@@ -36,38 +36,38 @@ WEBGL_APICALL void GL_APIENTRY glDrawElementsInstancedBaseVertexBaseInstanceWEBG
 
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysInstancedBaseInstanceWEBGL(
   GLenum mode,
-  const GLint* firsts __attribute__((nonnull)),
-  const GLsizei* counts __attribute__((nonnull)),
-  const GLsizei* instanceCounts __attribute__((nonnull)),
-  const GLuint* baseInstances __attribute__((nonnull)),
+  const GLint* _Nonnull firsts,
+  const GLsizei* _Nonnull counts,
+  const GLsizei* _Nonnull instanceCounts,
+  const GLuint* _Nonnull baseInstances,
   GLsizei drawCount);
 
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
   GLenum mode,
-  const GLsizei* counts __attribute__((nonnull)),
+  const GLsizei* _Nonnull counts,
   GLenum type,
-  const GLvoid* const* offsets __attribute__((nonnull)),
-  const GLsizei* instanceCounts __attribute__((nonnull)),
-  const GLint* baseVertices __attribute__((nonnull)),
-  const GLuint* baseInstances __attribute__((nonnull)),
+  const GLvoid* const* _Nonnull offsets,
+  const GLsizei* _Nonnull instanceCounts,
+  const GLint* _Nonnull baseVertices,
+  const GLuint* _Nonnull baseInstances,
   GLsizei drawCount);
 
 WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysInstancedBaseInstanceWEBGL(
   GLenum mode,
- const GLint* firsts __attribute__((nonnull)),
- const GLsizei* counts __attribute__((nonnull)),
- const GLsizei* instanceCounts __attribute__((nonnull)),
- const GLuint* baseInstances __attribute__((nonnull)),
+ const GLint* _Nonnull firsts,
+ const GLsizei* _Nonnull counts,
+ const GLsizei* _Nonnull instanceCounts,
+ const GLuint* _Nonnull baseInstances,
  GLsizei drawCount);
 
 WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
   GLenum mode,
-  const GLsizei* counts __attribute__((nonnull)),
+  const GLsizei* _Nonnull counts,
   GLenum type,
-  const GLvoid* const* offsets __attribute__((nonnull)),
-  const GLsizei* instanceCounts __attribute__((nonnull)),
-  const GLint* baseVertices __attribute__((nonnull)),
-  const GLuint* baseInstances __attribute__((nonnull)),
+  const GLvoid* const* _Nonnull offsets,
+  const GLsizei* _Nonnull instanceCounts,
+  const GLint* _Nonnull baseVertices,
+  const GLuint* _Nonnull baseInstances,
   GLsizei drawCount);
 
 #endif /* EMSCRIPTEN_GL_WEBGL_multi_draw_instanced_base_vertex_base_instance */

--- a/system/lib/html5/callback.c
+++ b/system/lib/html5/callback.c
@@ -10,7 +10,7 @@
 
 #include "emscripten_internal.h"
 
-typedef bool (*event_callback)(int event_type, void *event_data __attribute__((nonnull)), void *user_data);
+typedef bool (*event_callback)(int event_type, void * _Nonnull event_data, void *user_data);
 
 typedef struct callback_args_t {
   event_callback callback;

--- a/test/browser/test_html5_unknown_event_target.c
+++ b/test/browser/test_html5_unknown_event_target.c
@@ -8,18 +8,17 @@
 #include <emscripten.h>
 #include <emscripten/html5.h>
 
-bool wheel_cb(int eventType, const EmscriptenWheelEvent *wheelEvent __attribute__((nonnull)), void *userData) { return true; }
+bool wheel_cb(int eventType, const EmscriptenWheelEvent * _Nonnull wheelEvent, void *userData) { return true; }
 bool key_cb(int eventType, const EmscriptenKeyboardEvent *e, void *userData) { return true; }
-bool mouse_cb(int eventType, const EmscriptenMouseEvent *mouseEvent __attribute__((nonnull)), void *userData) { return true; }
-bool ui_cb(int eventType, const EmscriptenUiEvent *uiEvent __attribute__((nonnull)), void *userData) { return true; }
-bool focus_cb(int eventType, const EmscriptenFocusEvent *focusEvent __attribute__((nonnull)), void *userData) { return true; }
-bool fullscreenchange_cb(int eventType, const EmscriptenFullscreenChangeEvent *fullscreenChangeEvent __attribute__((nonnull)), void *userData) { return true; }
-bool pointerlockchange_cb(int eventType, const EmscriptenPointerlockChangeEvent *pointerlockChangeEvent __attribute__((nonnull)), void *userData) { return true; }
+bool mouse_cb(int eventType, const EmscriptenMouseEvent * _Nonnull mouseEvent, void *userData) { return true; }
+bool ui_cb(int eventType, const EmscriptenUiEvent * _Nonnull uiEvent, void *userData) { return true; }
+bool focus_cb(int eventType, const EmscriptenFocusEvent * _Nonnull focusEvent, void *userData) { return true; }
+bool fullscreenchange_cb(int eventType, const EmscriptenFullscreenChangeEvent * _Nonnull fullscreenChangeEvent, void *userData) { return true; }
+bool pointerlockchange_cb(int eventType, const EmscriptenPointerlockChangeEvent * _Nonnull pointerlockChangeEvent, void *userData) { return true; }
 bool pointerlockerror_cb(int eventType, const void *reserved, void *userData) { return true; }
-bool touch_cb(int eventType, const EmscriptenTouchEvent *touchEvent __attribute__((nonnull)), void *userData) { return true; }
+bool touch_cb(int eventType, const EmscriptenTouchEvent * _Nonnull touchEvent, void *userData) { return true; }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
   assert(emscripten_set_keypress_callback("this_dom_element_does_not_exist", 0, 0, key_cb) == EMSCRIPTEN_RESULT_UNKNOWN_TARGET);
   assert(emscripten_set_keydown_callback("this_dom_element_does_not_exist", 0, 0, key_cb) == EMSCRIPTEN_RESULT_UNKNOWN_TARGET);
   assert(emscripten_set_keyup_callback("this_dom_element_does_not_exist", 0, 0, key_cb) == EMSCRIPTEN_RESULT_UNKNOWN_TARGET);


### PR DESCRIPTION
Prior to this change we had a mix of both `_Nonnull` and `__attribute__((nonnull))`.