### PR TITLE
Use consistent include order in our standard headers. NFC

### DIFF
--- a/system/include/emscripten/atomic.h
+++ b/system/include/emscripten/atomic.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include <inttypes.h>
-
 #include <emscripten/em_types.h>
+
+#include <inttypes.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -11,18 +11,18 @@
 #error "embind requires -std=c++17 or newer"
 #endif
 
+#include <emscripten/em_asm.h>
+#include <emscripten/val.h>
+#include <emscripten/wire.h>
+
 #include <cassert>
 #include <cstddef>
 #include <functional>
 #include <map>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <vector>
-#include <optional>
-
-#include <emscripten/em_asm.h>
-#include <emscripten/val.h>
-#include <emscripten/wire.h>
 
 #if __has_feature(leak_sanitizer) || __has_feature(address_sanitizer)
 #include <sanitizer/lsan_interface.h>
@@ -434,7 +434,7 @@ template<typename ReturnType, typename... Args, typename... Policies>
 void function(const char* name, ReturnType (*fn)(Args...), Policies...) {
     using namespace internal;
     typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, Args...> args;
-    using ReturnPolicy = GetReturnValuePolicy<ReturnType, Policies...>::tag;
+    using ReturnPolicy = typename GetReturnValuePolicy<ReturnType, Policies...>::tag;
     auto invoke = Invoker<ReturnPolicy, ReturnType, Args...>::invoke;
     _embind_register_function(
         name,
@@ -1295,7 +1295,7 @@ struct RegisterClassMethod<ReturnType (ClassType::*)(Args...)> {
     template <typename CT, typename... Policies>
     static void invoke(const char* methodName,
                        ReturnType (ClassType::*memberFunction)(Args...)) {
-        using ReturnPolicy = GetReturnValuePolicy<ReturnType, Policies...>::tag;
+        using ReturnPolicy = typename GetReturnValuePolicy<ReturnType, Policies...>::tag;
         auto invoke = MethodInvoker<ReturnPolicy, decltype(memberFunction), ReturnType, ClassType*, Args...>::invoke;
 
         typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, AllowedRawPointer<ClassType>, Args...> args;
@@ -1325,7 +1325,7 @@ struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) const> {
     template <typename CT, typename... Policies>
     static void invoke(const char* methodName,
                        ReturnType (ClassType::*memberFunction)(Args...) const)  {
-        using ReturnPolicy = GetReturnValuePolicy<ReturnType, Policies...>::tag;
+        using ReturnPolicy = typename GetReturnValuePolicy<ReturnType, Policies...>::tag;
         auto invoke = MethodInvoker<ReturnPolicy, decltype(memberFunction), ReturnType, const ClassType*, Args...>::invoke;
 
         typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, AllowedRawPointer<const ClassType>, Args...> args;
@@ -1356,7 +1356,7 @@ struct RegisterClassMethod<ReturnType (*)(ThisType, Args...)> {
     static void invoke(const char* methodName,
                        ReturnType (*function)(ThisType, Args...)) {
         typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, ThisType, Args...> args;
-        using ReturnPolicy = GetReturnValuePolicy<ReturnType, Policies...>::tag;
+        using ReturnPolicy = typename GetReturnValuePolicy<ReturnType, Policies...>::tag;
         auto invoke = FunctionInvoker<ReturnPolicy, decltype(function), ReturnType, ThisType, Args...>::invoke;
         _embind_register_class_function(
             TypeID<ClassType>::get(),
@@ -1385,7 +1385,7 @@ struct RegisterClassMethod<std::function<ReturnType (ThisType, Args...)>> {
     static void invoke(const char* methodName,
                        std::function<ReturnType (ThisType, Args...)> function) {
         typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, ThisType, Args...> args;
-        using ReturnPolicy = GetReturnValuePolicy<ReturnType, Policies...>::tag;
+        using ReturnPolicy = typename GetReturnValuePolicy<ReturnType, Policies...>::tag;
         auto invoke = FunctorInvoker<ReturnPolicy, decltype(function), ReturnType, ThisType, Args...>::invoke;
         _embind_register_class_function(
             TypeID<ClassType>::get(),
@@ -1408,7 +1408,7 @@ struct RegisterClassMethod<FunctionTag<Callable, ReturnType (ThisType, Args...)>
     static void invoke(const char* methodName,
                        Callable& callable) {
         typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, ThisType, Args...> args;
-        using ReturnPolicy = GetReturnValuePolicy<ReturnType, Policies...>::tag;
+        using ReturnPolicy = typename GetReturnValuePolicy<ReturnType, Policies...>::tag;
         auto invoke = FunctorInvoker<ReturnPolicy, decltype(callable), ReturnType, ThisType, Args...>::invoke;
         _embind_register_class_function(
             TypeID<ClassType>::get(),
@@ -1546,7 +1546,7 @@ public:
         smart_ptr<SmartPtr>(smartPtrName);
 
         typename WithPolicies<Policies...>::template ArgTypeList<SmartPtr, Args...> args;
-        using ReturnPolicy = GetReturnValuePolicy<SmartPtr, return_value_policy::take_ownership>::tag;
+        using ReturnPolicy = typename GetReturnValuePolicy<SmartPtr, return_value_policy::take_ownership>::tag;
         auto invoke = &Invoker<ReturnPolicy, SmartPtr, Args...>::invoke;
         _embind_register_class_constructor(
             TypeID<ClassType>::get(),
@@ -1646,7 +1646,7 @@ public:
             std::conjunction<internal::isPolicy<Policies>...>::value>::type>
     EMSCRIPTEN_ALWAYS_INLINE const class_& property(const char* fieldName, const FieldType ClassType::*field, Policies...) const {
         using namespace internal;
-        using ReturnPolicy = GetReturnValuePolicy<FieldType, Policies...>::tag;
+        using ReturnPolicy = typename GetReturnValuePolicy<FieldType, Policies...>::tag;
         typename WithPolicies<Policies...>::template ArgTypeList<FieldType> returnType;
 
         auto getter = &MemberAccess<ClassType, FieldType>::template getWire<ClassType, ReturnPolicy>;
@@ -1674,7 +1674,7 @@ public:
             std::conjunction<internal::isPolicy<Policies>...>::value>::type>
     EMSCRIPTEN_ALWAYS_INLINE const class_& property(const char* fieldName, FieldType ClassType::*field, Policies...) const {
         using namespace internal;
-        using ReturnPolicy = GetReturnValuePolicy<FieldType, Policies...>::tag;
+        using ReturnPolicy = typename GetReturnValuePolicy<FieldType, Policies...>::tag;
         typename WithPolicies<Policies...>::template ArgTypeList<FieldType> returnType;
 
         auto getter = &MemberAccess<ClassType, FieldType>::template getWire<ClassType, ReturnPolicy>;
@@ -1708,7 +1708,7 @@ public:
             typename std::conditional<std::is_same<PropertyType, internal::DeduceArgumentsTag>::value,
                                                    Getter,
                                                    FunctionTag<Getter, PropertyType>>::type> GP;
-        using ReturnPolicy = GetReturnValuePolicy<typename GP::ReturnType, Policies...>::tag;
+        using ReturnPolicy = typename GetReturnValuePolicy<typename GP::ReturnType, Policies...>::tag;
         auto gter = &GP::template get<ClassType, ReturnPolicy>;
         typename WithPolicies<Policies...>::template ArgTypeList<typename GP::ReturnType> returnType;
         _embind_register_class_property(
@@ -1747,7 +1747,7 @@ public:
                                                    FunctionTag<Setter, PropertyType>>::type> SP;
 
 
-        using ReturnPolicy = GetReturnValuePolicy<typename GP::ReturnType, Policies...>::tag;
+        using ReturnPolicy = typename GetReturnValuePolicy<typename GP::ReturnType, Policies...>::tag;
         auto gter = &GP::template get<ClassType, ReturnPolicy>;
         auto ster = &SP::template set<ClassType>;
 
@@ -1776,7 +1776,7 @@ public:
         using namespace internal;
 
         typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, Args...> args;
-        using ReturnPolicy = GetReturnValuePolicy<ReturnType, Policies...>::tag;
+        using ReturnPolicy = typename GetReturnValuePolicy<ReturnType, Policies...>::tag;
         auto invoke = internal::Invoker<ReturnPolicy, ReturnType, Args...>::invoke;
         _embind_register_class_class_function(
             TypeID<ClassType>::get(),

--- a/system/include/emscripten/em_js.h
+++ b/system/include/emscripten/em_js.h
@@ -79,6 +79,7 @@
 // additional macro later is added these will be expanded and we want
 // to make sure the resulting expansion doesn't break the expectations
 // of JS code
+#include <stdbool.h>
 #if defined(true) && defined(false)
 #undef true
 #undef false

--- a/system/include/emscripten/em_types.h
+++ b/system/include/emscripten/em_types.h
@@ -5,8 +5,6 @@
  * found in the LICENSE file.
  */
 
-#include <stdbool.h>
-
 #pragma once
 
 #include <stdbool.h>

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -21,12 +21,12 @@
  */
 
 #include "em_asm.h"
+#include "em_js.h"
 #include "em_macros.h"
 #include "em_types.h"
-#include "em_js.h"
 #include "promise.h"
-#include "wget.h"
 #include "version.h"
+#include "wget.h"
 
 #ifdef __EMSCRIPTEN__
 #ifndef EMSCRIPTEN

--- a/system/include/emscripten/fetch.h
+++ b/system/include/emscripten/fetch.h
@@ -7,11 +7,12 @@
 
 #pragma once
 
+#include <emscripten/em_types.h>
+
 #include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <emscripten/em_types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/system/include/emscripten/fiber.h
+++ b/system/include/emscripten/fiber.h
@@ -7,10 +7,10 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <stddef.h>
-
 #include <emscripten/emscripten.h>
+
+#include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/system/include/emscripten/heap.h
+++ b/system/include/emscripten/heap.h
@@ -7,12 +7,13 @@
 
 #pragma once
 
+#include <emscripten/emscripten.h>
+
 #include <stdbool.h>
 #include <stddef.h>
-#include <stdint.h>
-#include <emscripten/emscripten.h>
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
+#include <stdint.h>
 
 #define WASM_PAGE_SIZE 65536
 #define EMSCRIPTEN_PAGE_SIZE WASM_PAGE_SIZE

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -7,16 +7,16 @@
 
 #pragma once
 
-#include <pthread.h>
 #include <emscripten/em_types.h>
-
 #include <emscripten/emscripten.h>
 
 // Include eventloop.h, console.h and html5_webgl.h for compat with older
 // version of this header that used to define these functions.
-#include <emscripten/eventloop.h>
 #include <emscripten/console.h>
+#include <emscripten/eventloop.h>
 #include <emscripten/html5_webgl.h>
+
+#include <pthread.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/system/include/emscripten/html5_webgl.h
+++ b/system/include/emscripten/html5_webgl.h
@@ -7,8 +7,10 @@
 
 #pragma once
 
-#include <stdint.h>
 #include <emscripten/html5.h>
+
+#include <stdint.h>
+#include <pthread.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/system/include/emscripten/proxying.h
+++ b/system/include/emscripten/proxying.h
@@ -9,8 +9,9 @@
 
 #include <emscripten/emscripten.h>
 #include <emscripten/promise.h>
-#include <stdbool.h>
+
 #include <pthread.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -7,15 +7,14 @@
 
 #pragma once
 
+#include <emscripten/atomic.h>
+// Legacy proxying functions.  See proxying.h for the new proxying system.
+#include <emscripten/threading_legacy.h>
+#include <emscripten/threading_primitives.h>
+
 #include <inttypes.h>
 #include <pthread.h>
 #include <stdbool.h>
-
-#include <emscripten/atomic.h>
-#include <emscripten/threading_primitives.h>
-
-// Legacy proxying functions.  See proxying.h for the new proxying system.
-#include <emscripten/threading_legacy.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/system/include/emscripten/threading_legacy.h
+++ b/system/include/emscripten/threading_legacy.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include <stdarg.h>
-
 #include <emscripten/html5.h>
+
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -7,15 +7,16 @@
 
 #pragma once
 
-#include <cassert>
-#include <array>
-#include <climits>
 #include <emscripten/wire.h>
+
+#include <array>
+#include <cassert>
+#include <climits>
 #include <cstdint> // uintptr_t
-#include <vector>
-#include <type_traits>
-#include <pthread.h>
 #include <optional>
+#include <pthread.h>
+#include <type_traits>
+#include <vector>
 #if __cplusplus >= 202002L
 #include <coroutine>
 #include <exception>
@@ -595,7 +596,7 @@ private:
   static Ret internalCallWithPolicy(EM_VAL handle, const char *methodName, Args&&... args) {
     using namespace internal;
 
-    using RetWire = BindingType<Ret>::WireType;
+    using RetWire = typename BindingType<Ret>::WireType;
 
     static constexpr typename Policy::template ArgTypeList<Ret, Args...> argTypes;
     thread_local EM_INVOKER mc = _emval_create_invoker(argTypes.getCount(), argTypes.getTypes(), Kind);

--- a/system/include/emscripten/wasm_worker.h
+++ b/system/include/emscripten/wasm_worker.h
@@ -7,12 +7,13 @@
 
 #pragma once
 
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
 #include <emscripten/atomic.h>
 #include <emscripten/em_types.h>
 #include <emscripten/threading_primitives.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/system/include/emscripten/webaudio.h
+++ b/system/include/emscripten/webaudio.h
@@ -7,11 +7,11 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <memory.h>
-
 #include <emscripten/emscripten.h>
 #include <emscripten/html5.h>
+
+#include <memory.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/system/include/emscripten/websocket.h
+++ b/system/include/emscripten/websocket.h
@@ -7,11 +7,11 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <memory.h>
-
 #include <emscripten/emscripten.h>
 #include <emscripten/html5.h>
+
+#include <memory.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/system/include/emscripten/wire.h
+++ b/system/include/emscripten/wire.h
@@ -652,7 +652,7 @@ struct GetReturnValuePolicy<ReturnType, return_value_policy::reference, Rest...>
 
 template<typename ReturnType, typename T, typename... Rest>
 struct GetReturnValuePolicy<ReturnType, T, Rest...> {
-    using tag = GetReturnValuePolicy<ReturnType, Rest...>::tag;
+    using tag = typename GetReturnValuePolicy<ReturnType, Rest...>::tag;
 };
 
 template<typename... Policies>

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15128,19 +15128,23 @@ addToLibrary({
 
   def test_em_js_bool_macro_expansion(self):
     # Normally macros like `true` and `false` are not expanded inside
-    # of `EM_JS` or `EM_ASM` blocks.  However, in the case then an
-    # additional macro later is added these will be expanded and we want
+    # of `EM_JS` or `EM_ASM` blocks.  However, in the case that an
+    # additional macro layer is added these will be expanded and we want
     # to make sure the resulting expansion doesn't break the expectations
     # of JS code.
     create_file('main.c', '''
       #include <emscripten.h>
+
+      #ifndef true
+      #error "expected true to be defined"
+      #endif
 
       #define EM_JS_MACROS(ret, func_name, args, body...)    \
         EM_JS(ret, func_name, args, body)
 
       EM_JS_MACROS(void, check_bool_type, (void), {
         if (typeof true !== "boolean") {
-          throw new Error("typeof true is " + typeof true + " not boolean");
+          throw new Error(`typeof true is ${typeof true} not boolean`);
         }
       })
 


### PR DESCRIPTION
This change was generated using:

```
clang-tidy -checks='llvm-include-order' -fix-errors -fix system/include/emscripten/*.h -- -x c++-header -std=c++17 --sysroot=cache/sysroot --target=wasm32-emscripten -iwithsysroot/include/compat
```

I also manually split the headers such that the internal emscripten headers always come first a group before any system headers.

This change initially resulted in the failure of `test_em_js_bool_macro_expansion` which required that addition of `stdbool.h` to `em_js.h`.