### PR TITLE
Fix test_sdl3_ttf. NFC

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2164,7 +2164,7 @@ void *getBindBuffer() {
     shutil.copy2(test_file('freetype/LiberationSansBold.ttf'), self.get_dir())
     self.reftest('test_sdl3_ttf_render_text_solid.c', 'test_sdl3_ttf_render_text_solid.png',
                  cflags=[
-                  '-O2', '-sUSE_SDL=3', '-sUSE_SDL_TTF=3', '-lGL',
+                  '-O2', '-sUSE_SDL=3', '-sUSE_SDL_TTF=3', '-lGL', '-Wno-experimental',
                   '--embed-file', 'LiberationSansBold.ttf'])
 
   def test_sdl_alloctext(self):

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2694,8 +2694,8 @@ F1 -> ''
   @requires_network
   def test_sdl3_ttf(self):
     # A compile-only test that checks if sdl3-ttf, and dependencies freetype and harfbuzz, are buildable.
-    self.emcc(test_file('browser/test_sdl3_ttf.c'), args=['-sUSE_SDL=3', '-sUSE_SDL_TTF=3'])
-    self.emcc(test_file('browser/test_sdl3_ttf.c'), args=['--use-port=sdl3', '--use-port=sdl3_ttf'])
+    self.emcc(test_file('browser/test_sdl3_ttf.c'), args=['-Wno-experimental', '-sUSE_SDL=3', '-sUSE_SDL_TTF=3'])
+    self.emcc(test_file('browser/test_sdl3_ttf.c'), args=['-Wno-experimental', '--use-port=sdl3', '--use-port=sdl3_ttf'])
 
   @requires_network
   def test_contrib_ports(self):

--- a/tools/ports/sdl3.py
+++ b/tools/ports/sdl3.py
@@ -26,11 +26,12 @@ def get_lib_name(settings):
 
 
 def get(ports, settings, shared):
+  diagnostics.warning('experimental', 'sdl3 port is still experimental')
+
   # get the port
   ports.fetch_project('sdl3', f'https://github.com/libsdl-org/SDL/archive/{TAG}.zip', sha512hash=HASH)
 
   def create(final):
-    diagnostics.warning('experimental', 'sdl3 port is still experimental')
     root_dir = ports.get_dir('sdl3', SUBDIR)
 
     # In addition copy our pre-generated SDL_build_config.h file.


### PR DESCRIPTION
Also, make the SDL3 warning show up every time its used, not just when its built.  This is why this error didn't show up in our CI, because if another SDL3 test ran first it would suppress this warning.