### PR TITLE
Fix timeout in emscripten_semaphore_wait_acquire

### DIFF
--- a/system/lib/pthread/emscripten_thread_primitives.c
+++ b/system/lib/pthread/emscripten_thread_primitives.c
@@ -87,13 +87,18 @@ int emscripten_semaphore_try_acquire(emscripten_semaphore_t *sem, int num) {
 
 int emscripten_semaphore_wait_acquire(emscripten_semaphore_t *sem, int num, int64_t maxWaitNanoseconds) {
   int val = emscripten_atomic_load_u32((void*)sem);
+  int64_t waitEnd = 0;
   for (;;) {
-    while (val < num) {
-      // TODO: Shave off maxWaitNanoseconds
-      ATOMICS_WAIT_RESULT_T waitResult = emscripten_atomic_wait_u32((void*)sem, val, maxWaitNanoseconds);
-      if (waitResult == ATOMICS_WAIT_TIMED_OUT) return -1;
+    while (val < num && maxWaitNanoseconds > 0) {
+      // Deley initialization of waitEnd until we know we are going to need to
+      // wait (since emscripten_performance_now is not cheap).
+      if (!waitEnd) waitEnd = (int64_t)(emscripten_performance_now() * 1e6) + maxWaitNanoseconds;
+      emscripten_atomic_wait_u32((void*)sem, val, maxWaitNanoseconds);
       val = emscripten_atomic_load_u32((void*)sem);
+      maxWaitNanoseconds = waitEnd - (int64_t)(emscripten_performance_now() * 1e6);
     }
+    // If we exited the loop and still don't have enough, it means we timed out.
+    if (val < num) return -1;
     int ret = (int)emscripten_atomic_cas_u32((void*)sem, val, val - num);
     if (ret == val) return val - num;
     val = ret;

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5219,6 +5219,11 @@ Module["preRun"] = () => {
   def test_wasm_worker_semaphore_waitinf_acquire(self):
     self.btest('wasm_worker/semaphore_waitinf_acquire.c', expected='0', cflags=['-sWASM_WORKERS'])
 
+  # Tests emscripten_semaphore_wait_acquire()
+  @also_with_minimal_runtime
+  def test_wasm_worker_semaphore_wait_acquire(self):
+    self.btest('wasm_worker/semaphore_wait_acquire.c', expected='0', cflags=['-sWASM_WORKERS'])
+
   # Tests emscripten_semaphore_try_acquire() on the main thread
   @also_with_minimal_runtime
   def test_wasm_worker_semaphore_try_acquire(self):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2791,6 +2791,11 @@ The current type of b is: 9
 
   @requires_pthreads
   @also_with_wasm_workers
+  def test_emscripten_semaphore_wait_acquire(self):
+    self.do_runf('wasm_worker/semaphore_wait_acquire.c', 'done\n', cflags=['-pthread'])
+
+  @requires_pthreads
+  @also_with_wasm_workers
   def test_emscripten_semaphore_try_acquire(self):
     self.do_runf('wasm_worker/semaphore_try_acquire.c', 'done\n', cflags=['-pthread'])
 

--- a/test/wasm_worker/semaphore_wait_acquire.c
+++ b/test/wasm_worker/semaphore_wait_acquire.c
@@ -1,0 +1,73 @@
+#include <emscripten.h>
+#include <emscripten/threading.h>
+#include <emscripten/wasm_worker.h>
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef __EMSCRIPTEN_PTHREADS__
+#include <pthread.h>
+#endif
+
+// Tests emscripten_semaphore_wait_acquire() and
+// emscripten_semaphore_try_acquire() in Worker.
+
+emscripten_semaphore_t sem = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(0);
+
+void worker_main() {
+  // 1. Immediate timeout (maxWaitNanoseconds = 0) when unavailable.
+  double t0 = emscripten_performance_now();
+  int ret = emscripten_semaphore_wait_acquire(&sem, 1, 0);
+  double t1 = emscripten_performance_now();
+  assert(ret == -1);
+  assert(t1 - t0 < 50); // Should be near-instant
+  assert(sem == 0);     // Should not have been decremented
+
+  // 2. Timed wait that times out.
+  t0 = emscripten_performance_now();
+  ret = emscripten_semaphore_wait_acquire(&sem, 1, 100 * 1000000ull); // 100ms
+  t1 = emscripten_performance_now();
+  assert(ret == -1);
+  assert(t1 - t0 >= 100);
+  assert(sem == 0); // Should not have been decremented
+
+  // 3. Immediate acquisition when available.
+  emscripten_semaphore_release(&sem, 2);
+  assert(sem == 2);
+  ret = emscripten_semaphore_wait_acquire(&sem, 1, 100 * 1000000ull);
+  assert(ret == 1); // returns old value minus 1
+  // If sem was 2, and we acquire 1, it returns 2 - 1 = 1.
+  assert(sem == 1);
+
+  // 4. Try acquire
+  ret = emscripten_semaphore_try_acquire(&sem, 1);
+  assert(ret == 0);
+  assert(sem == 0);
+
+#ifdef REPORT_RESULT
+  REPORT_RESULT(0);
+#endif
+}
+
+#ifdef __EMSCRIPTEN_PTHREADS__
+void* thread_main(void* arg) {
+  worker_main();
+  return NULL;
+}
+#else
+char stack[1024];
+#endif
+
+int main() {
+#ifdef __EMSCRIPTEN_PTHREADS__
+  pthread_t t;
+  pthread_create(&t, NULL, thread_main, NULL);
+  pthread_join(t, NULL);
+  printf("done\n");
+#else
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
+  emscripten_wasm_worker_post_function_v(worker, worker_main);
+#endif
+  return 0;
+}


### PR DESCRIPTION
This fixes the TODO in this function which meant that the timeout was not correctly honored in the case of multiple wakeups.

The code here is basically the same as the existing code in `emscripten_lock_wait_acquire` just above.

I also added a new test for `emscripten_lock_wait_acquire` even though the test doesn't specifically test for the TODO issue being addresses in this change (that would require a more complex test that involves generating spurious wakeups).