### PR TITLE
Update emscripten_atomic_notify to take uint32_t for count. NFC

### DIFF
--- a/system/include/emscripten/atomic.h
+++ b/system/include/emscripten/atomic.h
@@ -220,7 +220,7 @@ _EM_INLINE ATOMICS_WAIT_RESULT_T emscripten_atomic_wait_u64(void /*uint64_t*/* _
   return __builtin_wasm_memory_atomic_wait64((int64_t*)addr, expectedValue, maxWaitNanoseconds);
 }
 
-#define EMSCRIPTEN_NOTIFY_ALL_WAITERS (-1LL)
+#define EMSCRIPTEN_NOTIFY_ALL_WAITERS UINT32_MAX
 
 // Issues the wasm 'memory.atomic.notify' instruction:
 // Notifies the given number of threads waiting on a location.
@@ -229,7 +229,7 @@ _EM_INLINE ATOMICS_WAIT_RESULT_T emscripten_atomic_wait_u64(void /*uint64_t*/* _
 // Returns the number of threads that were woken up.
 // Note: this function is used to notify both waiters waiting on an u32 and u64
 // addresses.
-_EM_INLINE int64_t emscripten_atomic_notify(void * _Nonnull addr, int64_t count) {
+_EM_INLINE int64_t emscripten_atomic_notify(void * _Nonnull addr, uint32_t count) {
   return __builtin_wasm_memory_atomic_notify((int*)addr, count);
 }
 

--- a/system/include/emscripten/threading_primitives.h
+++ b/system/include/emscripten/threading_primitives.h
@@ -184,7 +184,7 @@ ATOMICS_WAIT_TOKEN_T emscripten_condvar_wait_async(emscripten_condvar_t * _Nonnu
 // Signals the given number of waiters on the specified condition variable.
 // Pass numWaitersToSignal == EMSCRIPTEN_NOTIFY_ALL_WAITERS to wake all waiters
 // ("broadcast" operation).
-void emscripten_condvar_signal(emscripten_condvar_t * _Nonnull condvar, int64_t numWaitersToSignal);
+void emscripten_condvar_signal(emscripten_condvar_t * _Nonnull condvar, uint32_t numWaitersToSignal);
 
 // If the given memory address contains value val, puts the calling thread to
 // sleep waiting for that address to be notified.

--- a/system/lib/pthread/emscripten_thread_primitives.c
+++ b/system/lib/pthread/emscripten_thread_primitives.c
@@ -153,7 +153,7 @@ ATOMICS_WAIT_TOKEN_T emscripten_condvar_wait_async(emscripten_condvar_t *condvar
   return emscripten_atomic_wait_async((void*)condvar, val, asyncWaitFinished, userData, maxWaitMilliseconds);
 }
 
-void emscripten_condvar_signal(emscripten_condvar_t *condvar, int64_t numWaitersToSignal) {
+void emscripten_condvar_signal(emscripten_condvar_t *condvar, uint32_t numWaitersToSignal) {
   emscripten_atomic_add_u32((void*)condvar, 1);
   emscripten_atomic_notify((void*)condvar, numWaitersToSignal);
 }


### PR DESCRIPTION
This matches the specification of the underlying atomic.wait instruction.

This should be a non-breaking change in almost all cases.