### PR TITLE
Handle NODERAWFS passthrough automatically. NFC

### DIFF
--- a/src/lib/libnoderawfs.js
+++ b/src/lib/libnoderawfs.js
@@ -5,13 +5,13 @@
  */
 
 addToLibrary({
-  $NODERAWFS__deps: ['$ERRNO_CODES', '$FS', '$NODEFS', '$mmapAlloc', '$FS_modeStringToFlags'],
+  $NODERAWFS__deps: ['$ERRNO_CODES', '$FS', '$NODEFS', '$mmapAlloc', '$FS_modeStringToFlags', '$NODERAWFS_stream_funcs'],
   $NODERAWFS__postset: `
     if (!ENVIRONMENT_IS_NODE) {
       throw new Error("NODERAWFS is currently only supported on Node.js environment.")
     }
-    var _wrapNodeError = function(func) {
-      return function(...args) {
+    function _wrapNodeError(func) {
+      return (...args) => {
         try {
           return func(...args)
         } catch (e) {
@@ -26,14 +26,26 @@ addToLibrary({
           throw e;
         }
       }
-    };
+    }
+    function _wrapNodeStreamFunc(func, vfs_func) {
+      return _wrapNodeError((stream, ...args) => {
+        if (stream.stream_ops) {
+          // this stream was created by some other FS. e.g: PIPEFS.
+          return vfs_func(stream, ...args);
+        }
+        return func(stream, ...args);
+      });
+    }
     // Use this to reference our in-memory filesystem
     /** @suppress {partialAlias} */
     var VFS = {...FS};
     // Wrap the whole in-memory filesystem API with
     // our Node.js based functions
-    for (var _key in NODERAWFS) {
-      FS[_key] = _wrapNodeError(NODERAWFS[_key]);
+    for (const [key, value] of Object.entries(NODERAWFS)) {
+      FS[key] = _wrapNodeError(value);
+    }
+    for (const [key, value] of Object.entries(NODERAWFS_stream_funcs)) {
+      FS[key] = _wrapNodeStreamFunc(value, FS[key]);
     }`,
   $NODERAWFS: {
     lookup(parent, name) {
@@ -174,20 +186,24 @@ addToLibrary({
       }
       return rtn;
     },
+  },
+
+  /**
+   * These functions all take a stream as the first argument which
+   * could either be a stream created by NODERAWFS itself, or, for example
+   * one created by PIPEFS.  We wrap all these function in an extra check.
+   */
+  $NODERAWFS_stream_funcs: {
     close(stream) {
       VFS.closeStream(stream.fd);
       // Don't close stdin/stdout/stderr since they are used by node itself.
-      if (!stream.stream_ops && --stream.shared.refcnt <= 0 && stream.nfd > 2) {
+      if (--stream.shared.refcnt <= 0 && stream.nfd > 2) {
         // This stream is created by our Node.js filesystem, close the
         // native file descriptor when its reference count drops to 0.
         fs.closeSync(stream.nfd);
       }
     },
     llseek(stream, offset, whence) {
-      if (stream.stream_ops) {
-        // this stream is created by in-memory filesystem
-        return VFS.llseek(stream, offset, whence);
-      }
       var position = offset;
       if (whence === {{{ cDefs.SEEK_CUR }}}) {
         position += stream.position;
@@ -204,10 +220,6 @@ addToLibrary({
       return position;
     },
     read(stream, buffer, offset, length, position) {
-      if (stream.stream_ops) {
-        // this stream is created by in-memory filesystem
-        return VFS.read(stream, buffer, offset, length, position);
-      }
       var seeking = typeof position != 'undefined';
       if (!seeking && stream.seekable) position = stream.position;
       var bytesRead = fs.readSync(stream.nfd, buffer, offset, length, position);
@@ -216,10 +228,6 @@ addToLibrary({
       return bytesRead;
     },
     write(stream, buffer, offset, length, position) {
-      if (stream.stream_ops) {
-        // this stream is created by in-memory filesystem
-        return VFS.write(stream, buffer, offset, length, position);
-      }
       if (stream.flags & {{{ cDefs.O_APPEND }}}) {
         // seek to the end before writing in append mode
         FS.llseek(stream, 0, {{{ cDefs.SEEK_END }}});
@@ -235,27 +243,17 @@ addToLibrary({
       if (!length) {
         throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
-      if (stream.stream_ops) {
-        // this stream is created by in-memory filesystem
-        return VFS.mmap(stream, length, position, prot, flags);
-      }
-
       var ptr = mmapAlloc(length);
       FS.read(stream, HEAP8, ptr, length, position);
       return { ptr, allocated: true };
     },
     msync(stream, buffer, offset, length, mmapFlags) {
-      if (stream.stream_ops) {
-        // this stream is created by in-memory filesystem
-        return VFS.msync(stream, buffer, offset, length, mmapFlags);
-      }
-
       FS.write(stream, buffer, 0, length, offset);
       // should we check if bytesWritten and length are the same?
       return 0;
     },
-    ioctl() {
+    ioctl(stream, cmd, arg) {
       throw new FS.ErrnoError({{{ cDefs.ENOTTY }}});
-    }
-  }
+    },
+  },
 });

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6090,6 +6090,7 @@ Module.onRuntimeInitialized = () => {
 
   @also_with_noderawfs
   def test_unistd_close(self):
+    self.maybe_closure()
     self.do_run_in_out_file_test('unistd/close.c')
 
   def test_unistd_fsync_stdout(self):


### PR DESCRIPTION
Many of the overrides in `NODERAWFS` have a passthrough for handling things like PIPE fds which are not actually part of `NODERAWFS` at all.