### PR TITLE
Add explicit json support to .clang-format. NFC

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,3 +14,5 @@ Language: JavaScript
 BasedOnStyle: LLVM
 ColumnLimit: 100
 ---
+Language: Json
+BasedOnStyle: LLVM


### PR DESCRIPTION
I noticed that the version of clang-format uses in CI was reporting `Configuration file(s) do(es) not support Json`.