### PR TITLE
Use `function` for ptrToString library function

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -45,7 +45,11 @@ addToLibrary({
   // purposes in cases where new functions are created at runtime.
   $createNamedFunction: (name, func) => Object.defineProperty(func, 'name', { value: name }),
 
-  $ptrToString: (ptr) => {
+  // This function is referenced *very* early on in some configurations
+  // (e.g WASM_WORKERS + RUNTIME_DEBUG) so we explictly use a function here
+  // rather than an arrow function so that it gets hoisted to the top of the
+  // scope.
+  $ptrToString: function(ptr) {
 #if ASSERTIONS
     assert(typeof ptr === 'number', `ptrToString expects a number, got ${typeof ptr}`);
 #endif

--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -220,6 +220,9 @@ if (ENVIRONMENT_IS_WASM_WORKER
       worker.on('message', (msg) => worker.onmessage({ data: msg }));
     }
 #endif
+#if RUNTIME_DEBUG
+    dbg("done _emscripten_create_wasm_worker", _wasmWorkersID)
+#endif
     return _wasmWorkersID++;
   },
 

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 24263,
-  "a.out.js.gz": 8725,
+  "a.out.js": 24271,
+  "a.out.js.gz": 8730,
   "a.out.nodebug.wasm": 15139,
   "a.out.nodebug.wasm.gz": 7458,
-  "total": 39402,
-  "total_gz": 16183,
+  "total": 39410,
+  "total_gz": 16188,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -815,12 +815,12 @@ async function createWasm() {
     }
   }
 
-  var ptrToString = (ptr) => {
+  function ptrToString(ptr) {
       assert(typeof ptr === 'number', `ptrToString expects a number, got ${typeof ptr}`);
       // Convert to 32-bit unsigned value
       ptr >>>= 0;
       return '0x' + ptr.toString(16).padStart(8, '0');
-    };
+    }
 
 
   

--- a/test/codesize/test_codesize_minimal_O0.json
+++ b/test/codesize/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19449,
-  "a.out.js.gz": 7006,
+  "a.out.js": 19457,
+  "a.out.js.gz": 7005,
   "a.out.nodebug.wasm": 1136,
   "a.out.nodebug.wasm.gz": 656,
-  "total": 20585,
-  "total_gz": 7662,
+  "total": 20593,
+  "total_gz": 7661,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 57007,
-  "hello_world.js.gz": 17736,
+  "hello_world.js": 57005,
+  "hello_world.js.gz": 17733,
   "hello_world.wasm": 15139,
   "hello_world.wasm.gz": 7458,
   "no_asserts.js": 26576,
   "no_asserts.js.gz": 8881,
   "no_asserts.wasm": 12188,
   "no_asserts.wasm.gz": 5986,
-  "strict.js": 54825,
+  "strict.js": 54823,
   "strict.js.gz": 17039,
   "strict.wasm": 15139,
   "strict.wasm.gz": 7453,
-  "total": 180874,
-  "total_gz": 64553
+  "total": 180870,
+  "total_gz": 64550
 }

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9693,6 +9693,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @requires_pthreads
   @no_sanitize('sanitizers do not support WASM_WORKERS')
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
+  def test_wasm_worker_runtime_debug(self):
+    self.do_runf('wasm_worker/hello_wasm_worker.c', 'wasm worker starting ...', cflags=['-sWASM_WORKERS', '-sRUNTIME_DEBUG'])
+
+  @requires_pthreads
+  @no_sanitize('sanitizers do not support WASM_WORKERS')
+  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
   def test_wasm_worker_wait_async(self):
     self.do_runf('atomic/test_wait_async.c', cflags=['-sWASM_WORKERS'])
 

--- a/test/wasm_worker/hello_wasm_worker.c
+++ b/test/wasm_worker/hello_wasm_worker.c
@@ -21,9 +21,11 @@ void run_in_worker() {
 }
 
 int main() {
+  emscripten_out("in main");
   assert(emscripten_is_main_runtime_thread());
   emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */1024);
   assert(worker);
   emscripten_wasm_worker_post_function_v(worker, run_in_worker);
   emscripten_exit_with_live_runtime();
+  assert(false && "should never get here");
 }


### PR DESCRIPTION
This function is referenced *very* early on in some configurations
(e.g WASM_WORKERS + RUNTIME_DEBUG) so we explictly use a function here
rather than an arrow function in so that is gets hoisted to the top of the
scope.