### PR TITLE
[CI] Disable clang-format job until we can make it more precise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
           fi
 
   clang-format-diff:
+    # This job is disabled until we can make it more precise
+    if: false
     env:
       LLVM_VERSION: 19
     runs-on: ubuntu-latest


### PR DESCRIPTION
Specifically one big problem is that `git clang-format` does not seem to honor `.clang-format-ignore` (and we have a lot of files we do *not* want to auto-format).