### PR TITLE
Don't pass `-sWASM_WORKERS` when building libc-mt (and `-mt` variants of other MTLibrary libraries). NFC

### DIFF
--- a/system/lib/pthread/emscripten_thread_state.S
+++ b/system/lib/pthread/emscripten_thread_state.S
@@ -18,7 +18,7 @@ is_runtime_thread:
 .globaltype supports_wait, i32
 supports_wait:
 
-#if WASM_WORKERS_ONLY
+#if __EMSCRIPTEN_WASM_WORKERS__
 .globaltype done_init, i32
 done_init:
 #endif
@@ -38,7 +38,7 @@ __set_thread_state:
   global.set supports_wait
   end_function
 
-#if WASM_WORKERS_ONLY
+#if __EMSCRIPTEN_WASM_WORKERS__
 // With Wasm Workers we do lazy initializtion of the thread
 // state so that only workers that call these APIs actually
 // initializes their state.
@@ -59,7 +59,7 @@ lazy_init_thread_state:
 .globl __get_tp
 __get_tp:
   .functype __get_tp () -> (PTR)
-#if WASM_WORKERS_ONLY
+#if __EMSCRIPTEN_WASM_WORKERS__
   call lazy_init_thread_state
 #endif
   global.get thread_ptr
@@ -69,7 +69,7 @@ __get_tp:
 .globl emscripten_is_main_runtime_thread
 emscripten_is_main_runtime_thread:
   .functype emscripten_is_main_runtime_thread () -> (i32)
-#if WASM_WORKERS_ONLY
+#if __EMSCRIPTEN_WASM_WORKERS__
   call lazy_init_thread_state
 #endif
   global.get is_runtime_thread
@@ -79,7 +79,7 @@ emscripten_is_main_runtime_thread:
 .globl emscripten_is_main_browser_thread
 emscripten_is_main_browser_thread:
   .functype emscripten_is_main_browser_thread () -> (i32)
-#if WASM_WORKERS_ONLY
+#if __EMSCRIPTEN_WASM_WORKERS__
   call lazy_init_thread_state
 #endif
   global.get is_main_thread
@@ -89,7 +89,7 @@ emscripten_is_main_browser_thread:
 .globl _emscripten_thread_supports_atomics_wait
 _emscripten_thread_supports_atomics_wait:
   .functype _emscripten_thread_supports_atomics_wait () -> (i32)
-#if WASM_WORKERS_ONLY
+#if __EMSCRIPTEN_WASM_WORKERS__
   call lazy_init_thread_state
 #endif
   global.get supports_wait

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -714,9 +714,9 @@ class MTLibrary(Library):
   def get_cflags(self):
     cflags = super().get_cflags()
     if self.is_mt:
-      cflags += ['-pthread', '-sWASM_WORKERS']
+      cflags += ['-pthread']
     if self.is_ww:
-      cflags += ['-sWASM_WORKERS', '-DWASM_WORKERS_ONLY']
+      cflags += ['-sWASM_WORKERS']
     return cflags
 
   def get_base_name(self):


### PR DESCRIPTION
This library gets linking into `-pthreads` build where wasm worker APIs are not available.

If we had code in libc that looks like this it would fail to link in that case:

```
 #ifdef __EMSCRIPTEN_WASM_WORKERS__ 
 use_wasm_worker_api();
 #endif
```

The fact that this is worked thus far only because we don't use that macro anywhere in libc today.