### PR TITLE
Disable building of wasm worker + dylink libraries. NFC

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -236,6 +236,12 @@ def main():
 
   if args.pic:
     settings.MAIN_MODULE = 1
+    # Note: we have to filter out the `-ww` libraries here because wasm workers don't
+    # support dynamic linking.
+    global MINIMAL_TASKS
+    global MINIMAL_PIC_TASKS
+    MINIMAL_TASKS = [t for t in MINIMAL_TASKS if '-ww' not in t]
+    MINIMAL_PIC_TASKS = [t for t in MINIMAL_PIC_TASKS if '-ww' not in t]
 
   if args.wasm64:
     settings.MEMORY64 = 1

--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -15,9 +15,6 @@
 #if LINKABLE
 #error "-sLINKABLE is not supported with -sWASM_WORKERS"
 #endif
-#if MAIN_MODULE
-#error "dynamic linking is not supported with -sWASM_WORKERS"
-#endif
 #if WASM2JS && MODULARIZE
 #error "-sWASM=0 + -sMODULARIZE + -sWASM_WORKERS is not supported"
 #endif

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -125,6 +125,7 @@ INTERNAL_SETTINGS = {
 # List of incompatible settings, of the form (SETTINGS_A, SETTING_B, OPTIONAL_REASON_FOR_INCOMPAT)
 INCOMPATIBLE_SETTINGS = [
     ('MINIMAL_RUNTIME', 'MAIN_MODULE', None),
+    ('WASM_WORKERS', 'MAIN_MODULE', 'dynamic linking is not supported with -sWASM_WORKERS'),
     ('WASM2JS', 'MAIN_MODULE', 'wasm2js does not support dynamic linking'),
     ('WASM2JS', 'SIDE_MODULE', 'wasm2js does not support dynamic linking'),
     ('MODULARIZE', 'NO_DECLARE_ASM_MODULE_EXPORTS', None),

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -746,6 +746,10 @@ class MTLibrary(Library):
     # These are mutually exclusive, only one flag will be set at any give time.
     return [combo for combo in combos if not combo['is_mt'] or not combo['is_ww']]
 
+  def can_build(self):
+    # Wasm workers do not support dynamic linking.
+    return super().can_build() and not (settings.MAIN_MODULE and self.is_ww)
+
 
 class DebugLibrary(Library):
   def __init__(self, **kwargs):


### PR DESCRIPTION
Dynamic linking (PIC) is not yet supported for WASM_WORKERS.

Without this change `./embuilder build libc-ww-debug --pic` could work, and `./embuild build ALL --pic` would include it, even though its not a reasonable combination.