### PR TITLE
Fix emscripten checks in __errno_location.c. NFC

### DIFF
--- a/system/lib/libc/musl/src/errno/__errno_location.c
+++ b/system/lib/libc/musl/src/errno/__errno_location.c
@@ -1,15 +1,16 @@
 #include <errno.h>
 #include "pthread_impl.h"
 
-#if __EMSCRIPTEN__
+#ifdef __EMSCRIPTEN__
 // For emscripten we use TLS here instead of `__pthread_self`, so that in single
 // threaded builds this gets lowered away to normal global variable.
+// This also works for WASM_WORKERS there `__pthread_self` does not work.
 static _Thread_local int __errno_storage = 0;
 #endif
 
 int *__errno_location(void)
 {
-#if __EMSCRIPTEN__
+#ifdef __EMSCRIPTEN__
 	return &__errno_storage;
 #else
 	return &__pthread_self()->errno_val;


### PR DESCRIPTION
This doesn't actually fix anything, but its more correct / consistent / portable.

Also, update the comment.