### PR TITLE
Remove workaround for `Atomics.waitAsync` deno bug. NFC

### DIFF
--- a/src/lib/libatomic.js
+++ b/src/lib/libatomic.js
@@ -22,12 +22,7 @@ addToLibrary({
   //   https://github.com/tc39/proposal-atomics-wait-async/blob/master/PROPOSAL.md
   // This polyfill performs polling with setTimeout() to observe a change in the
   // target memory location.
-#if ENVIRONMENT_MAY_BE_NODE
-  // Under Deno Atomics.waitAsync currently broken: https://github.com/denoland/deno/issues/14786
-  $waitAsyncPolyfilled: '=(!Atomics.waitAsync || globalThis.Deno || (globalThis.navigator?.userAgent && Number((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91));',
-#else
   $waitAsyncPolyfilled: '=(!Atomics.waitAsync || (globalThis.navigator?.userAgent && Number((navigator.userAgent.match(/Chrom(e|ium)\\/([0-9]+)\\./)||[])[2]) < 91));',
-#endif
   $polyfillWaitAsync__deps: ['$waitAsyncPolyfilled'],
   $polyfillWaitAsync__postset: `if (waitAsyncPolyfilled) {
   let __Atomics_waitAsyncAddresses = [/*[i32a, index, value, maxWaitMilliseconds, promiseResolve]*/];

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7884,
-  "a.out.js.gz": 3855,
+  "a.out.js": 7866,
+  "a.out.js.gz": 3852,
   "a.out.nodebug.wasm": 19707,
   "a.out.nodebug.wasm.gz": 9122,
-  "total": 27591,
-  "total_gz": 12977,
+  "total": 27573,
+  "total_gz": 12974,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 8306,
-  "a.out.js.gz": 4060,
+  "a.out.js": 8288,
+  "a.out.js.gz": 4052,
   "a.out.nodebug.wasm": 19708,
   "a.out.nodebug.wasm.gz": 9123,
-  "total": 28014,
-  "total_gz": 13183,
+  "total": 27996,
+  "total_gz": 13175,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",


### PR DESCRIPTION
See https://github.com/denoland/deno/issues/14786.  I believe the fix for this made it into https://github.com/denoland/deno/releases/tag/v2.7.6, which was just released.