### PR TITLE
Fix test_pthread_locale after #26486

### DIFF
--- a/test/pthread/test_pthread_locale.c
+++ b/test/pthread/test_pthread_locale.c
@@ -9,24 +9,16 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <locale.h>
 #include <emscripten/threading.h>
-// This is really rather naughty, we shouldn't be including
-// musl-internal headers like this.
-#define weak __attribute__(__weak__)
-#define hidden __attribute__((__visibility__("hidden")))
-#include "pthread_impl.h"
-
-#define NUM_THREADS  1
 
 locale_t do_test() {
   pthread_t thread = pthread_self();
-  locale_t loc = thread->locale;
+  locale_t loc = uselocale((locale_t)0);
   printf("  pthread_self() = %p\n", thread);
-  printf("  pthread_self()->locale = %p\n", loc);
+  printf("  current locale: %p\n", loc);
 
-  if (!loc) {
-    puts("ERROR: loc is null");
-  }
+  assert(loc);
   return loc;
 }
 

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4576,8 +4576,6 @@ Module["preRun"] = () => {
     'mt': (['-pthread', '-sPTHREAD_POOL_SIZE=2'],),
   })
   def test_pthread_locale(self, args):
-    self.cflags.append('-I' + path_from_root('system/lib/libc/musl/src/internal'))
-    self.cflags.append('-I' + path_from_root('system/lib/pthread'))
     self.btest_exit('pthread/test_pthread_locale.c', cflags=args)
 
   # Tests the Emscripten HTML5 API emscripten_set_canvas_element_size() and


### PR DESCRIPTION
This test was being very naughty indeed.  The test was added back in 2017 in #4813, although its hard to say what exactly its purpose is.