### PR TITLE
Add workaround for recent thinlto test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -705,6 +705,7 @@ jobs:
             lto0.test_exceptions_allowed_uncaught
             lto0.test_longjmp_standalone_standalone
             lto0.test_embind_i64_val
+            thinlto0.test_pthread_dlsym
             core3
             core2g.test_externref
             corez.test_dylink_iostream

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 18562,
   "a.out.js.gz": 7668,
-  "a.out.nodebug.wasm": 101956,
-  "a.out.nodebug.wasm.gz": 39461,
-  "total": 120518,
-  "total_gz": 47129,
+  "a.out.nodebug.wasm": 101954,
+  "a.out.nodebug.wasm.gz": 39462,
+  "total": 120516,
+  "total_gz": 47130,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1080,6 +1080,8 @@ class libc(MuslInternalLibrary,
 
   def __init__(self, **kwargs):
     self.non_lto_files = self.get_libcall_files()
+    # TODO(https://github.com/emscripten-core/emscripten/issues/26506)
+    self.non_lto_files.append(utils.path_from_root('system/lib/libc/musl/src/locale/uselocale.c'))
     super().__init__(**kwargs)
 
   def get_libcall_files(self):


### PR DESCRIPTION
Many thintlo tests were broken by a recent change to how musl accesses the current local (#26486).   This change simply excludes the problematic files from LTO until we can come up with a better fix.

See #26506