### PR TITLE
[embind] Only initialize pthread member in multi-threaded builds. NFC

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -566,9 +566,11 @@ public:
 
 private:
   // takes ownership, assumes handle already incref'd and lives on the same thread
-  explicit val(EM_VAL handle)
-      : handle(handle), thread(pthread_self())
-  {}
+  explicit val(EM_VAL handle) :
+#ifdef _REENTRANT
+    thread(pthread_self()),
+#endif
+    handle(handle) {}
 
   // Whether this value is a uses incref/decref (true) or is a special reserved
   // value (false).

--- a/test/codesize/test_minimal_runtime_code_size_hello_embind_val.json
+++ b/test/codesize/test_minimal_runtime_code_size_hello_embind_val.json
@@ -3,8 +3,8 @@
   "a.html.gz": 371,
   "a.js": 5353,
   "a.js.gz": 2524,
-  "a.wasm": 5798,
-  "a.wasm.gz": 2731,
-  "total": 11699,
-  "total_gz": 5626
+  "a.wasm": 5741,
+  "a.wasm.gz": 2690,
+  "total": 11642,
+  "total_gz": 5585
 }


### PR DESCRIPTION
Specifically, this avoids referencing `pthead_self` is Wasm Workers builds.

Split out from #26487