### PR TITLE
Allow passing --support-longjmp flag to embuilder

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -246,7 +246,6 @@ def main():
 
   if args.wasm64:
     settings.MEMORY64 = 1
-  
   if args.support_longjmp:
     settings.SUPPORT_LONGJMP = args.support_longjmp
 


### PR DESCRIPTION
Some ports (freetype, libpng, ...) output different lib names based on whether the `SUPPORT_LONGJMP` flag is set. It would be useful to set this flag in `embuilder` so users can build the exact version of the library that they want to use.

```
embuilder --support-longjmp=wasm build freetype
```