### PR TITLE
Fix JSEvents deferredCalls sort comparator. NFC

### DIFF
--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -102,7 +102,7 @@ var LibraryHTML5 = {
         argsList
       });
 
-      JSEvents.deferredCalls.sort((x,y) => x.precedence < y.precedence);
+      JSEvents.deferredCalls.sort((x,y) => x.precedence - y.precedence);
     },
 
     // Erases all deferred calls to the given target function from the queue list.


### PR DESCRIPTION
Use numeric subtraction so sort orders by precedence; a boolean comparator does not satisfy Array.prototype.sort's contract.