### PR TITLE
Assert when glDrawElements cannot draw anything because of missing vertex bounds

### DIFF
--- a/src/lib/libglemu.js
+++ b/src/lib/libglemu.js
@@ -3036,7 +3036,7 @@ var LibraryGLEmulation = {
           // upload based on the indices. If they are in a buffer on the GPU, that is very
           // inconvenient! So if you do not have an array buffer, you should also not have
           // an element array buffer. But best is to use both buffers!
-          assert(!GLctx.currentElementArrayBufferBinding);
+          assert(!GLctx.currentElementArrayBufferBinding, 'must use array buffers when using element buffer');
 #endif
           for (var i = 0; i < numProvidedIndexes; i++) {
             var currIndex = {{{ makeGetValue('ptr', 'i*2', 'u16') }}};

--- a/src/lib/libwebgl.js
+++ b/src/lib/libwebgl.js
@@ -575,6 +575,10 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
         var cb = GL.currentContext.clientBuffers[i];
         if (!cb.clientside || !cb.enabled) continue;
 
+#if ASSERTIONS
+        assert(count || !GLctx.currentElementArrayBufferBinding, 'must use array buffers when using element buffer');
+#endif
+
         GL.resetBufferBinding = true;
 
         var size = GL.calcBufLength(cb.size, cb.type, cb.stride, count);


### PR DESCRIPTION
Even with FULL_ES2, glDrawElements cannot handle the case where the indices are in a buffer but the vertices are client-side. Nothing will be drawn in this case. Add an assertion to make this situation visible when debugging.

Fixes #26460 