### PR TITLE
[musl] Always cancelasync as a boolean. NFC

### DIFF
--- a/system/lib/pthread/emscripten_futex_wait.c
+++ b/system/lib/pthread/emscripten_futex_wait.c
@@ -131,7 +131,7 @@ int emscripten_futex_wait(volatile void *addr, uint32_t val, double max_wait_ms)
 
 #ifdef __EMSCRIPTEN_PTHREADS__
   pthread_t self = pthread_self();
-  bool cancelable = self->cancelasync == PTHREAD_CANCEL_ASYNCHRONOUS;
+  bool cancelable = self->cancelasync;
 #else
   bool cancelable = false;
 #endif

--- a/system/lib/pthread/pthread_create.c
+++ b/system/lib/pthread/pthread_create.c
@@ -309,7 +309,7 @@ void _emscripten_thread_exit(void* result) {
   assert(self);
 
   self->canceldisable = PTHREAD_CANCEL_DISABLE;
-  self->cancelasync = PTHREAD_CANCEL_DEFERRED;
+  self->cancelasync = 0;
   self->result = result;
 
   _emscripten_thread_mailbox_shutdown(self);

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7364,
   "a.out.js.gz": 3607,
-  "a.out.nodebug.wasm": 19263,
-  "a.out.nodebug.wasm.gz": 8934,
-  "total": 26627,
-  "total_gz": 12541,
+  "a.out.nodebug.wasm": 19259,
+  "a.out.nodebug.wasm.gz": 8931,
+  "total": 26623,
+  "total_gz": 12538,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7766,
   "a.out.js.gz": 3812,
-  "a.out.nodebug.wasm": 19264,
-  "a.out.nodebug.wasm.gz": 8935,
-  "total": 27030,
-  "total_gz": 12747,
+  "a.out.nodebug.wasm": 19260,
+  "a.out.nodebug.wasm.gz": 8933,
+  "total": 27026,
+  "total_gz": 12745,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",


### PR DESCRIPTION
This is how all the other code in musl already treats it.