### PR TITLE
Fix null deref in ppoll/pselect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -669,6 +669,7 @@ jobs:
             asan.test_modularize_instance_pthreads
             asan.test_minimal_runtime_hello_world
             asan.test_select_blocking
+            asan.test_ppoll_blocking
             lsan.test_dylink_dso_needed
             lsan.test_stdio_locking
             lsan.test_dlfcn_basic

--- a/system/lib/libc/musl/src/select/ppoll.c
+++ b/system/lib/libc/musl/src/select/ppoll.c
@@ -14,9 +14,9 @@ int ppoll(struct pollfd *fds, nfds_t n, const struct timespec *to, const sigset_
 	// in terms of poll here in userspace.
 	int timeout = (to == NULL) ? -1 : (to->tv_sec * 1000 + to->tv_nsec / 1000000);
 	sigset_t origmask;
-	pthread_sigmask(SIG_SETMASK, mask, &origmask);
+	if (mask) pthread_sigmask(SIG_SETMASK, mask, &origmask);
 	int rtn = poll(fds, n, timeout);
-	pthread_sigmask(SIG_SETMASK, &origmask, NULL);
+	if (mask) pthread_sigmask(SIG_SETMASK, &origmask, NULL);
 	return rtn;
 #else
 	time_t s = to ? to->tv_sec : 0;

--- a/system/lib/libc/musl/src/select/pselect.c
+++ b/system/lib/libc/musl/src/select/pselect.c
@@ -18,9 +18,9 @@ int pselect(int n, fd_set *restrict rfds, fd_set *restrict wfds, fd_set *restric
 		tv_timeout.tv_usec = ts->tv_nsec / 1000;
 	}
 	sigset_t origmask;
-	pthread_sigmask(SIG_SETMASK, mask, &origmask);
+	if (mask) pthread_sigmask(SIG_SETMASK, mask, &origmask);
 	int rtn = select(n, rfds, wfds, efds, ts ? &tv_timeout : NULL);
-	pthread_sigmask(SIG_SETMASK, &origmask, NULL);
+	if (mask) pthread_sigmask(SIG_SETMASK, &origmask, NULL);
 	return rtn;
 #else
 	syscall_arg_t data[2] = { (uintptr_t)mask, _NSIG/8 };

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
   "a.out.js": 244320,
-  "a.out.nodebug.wasm": 577447,
-  "total": 821767,
+  "a.out.nodebug.wasm": 577506,
+  "total": 821826,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
This fixes the current failure of asan.test_ppoll_blocking on the emsdk waterfall.