### PR TITLE
Cleanup pthread_cancel tests. NFC

### DIFF
--- a/test/pthread/test_pthread_cancel.c
+++ b/test/pthread/test_pthread_cancel.c
@@ -5,6 +5,7 @@
 
 #include <pthread.h>
 #include <sys/types.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -12,45 +13,36 @@
 #include <errno.h>
 #include <emscripten/console.h>
 
-_Atomic long res = 43;
-static void cleanup_handler(void *arg)
-{
+_Atomic bool done_cleanup = false;
+
+void cleanup_handler(void *arg) {
   long a = (long)arg;
   emscripten_outf("Called clean-up handler with arg %ld", a);
-  res -= a;
+  assert(a == 42);
+  done_cleanup = true;
 }
 
-static void *thread_start(void *arg)
-{
+void *thread_start(void *arg) {
   pthread_cleanup_push(cleanup_handler, (void*)42);
   emscripten_out("Thread started!");
-  for(;;)
-  {
+  while (1) {
     pthread_testcancel();
   }
-  res = 1000; // Shouldn't ever reach here.
+  assert(false);
   pthread_cleanup_pop(0);
 }
 
-pthread_t thr;
-
-int main()
-{
+int main() {
+  pthread_t thr;
   int s = pthread_create(&thr, NULL, thread_start, (void*)0);
   assert(s == 0);
   emscripten_out("Canceling thread..");
   s = pthread_cancel(thr);
   assert(s == 0);
 
-  for(;;)
-  {
-    int result = res;
-    if (result == 1)
-    {
-      emscripten_outf("After canceling, shared variable = %d", result);
-      return 0;
-    }
+  while (!done_cleanup) {
   }
 
-  __builtin_trap();
+  emscripten_outf("After canceling, cleanup complete");
+  return 0;
 }

--- a/test/pthread/test_pthread_cancel.out
+++ b/test/pthread/test_pthread_cancel.out
@@ -1,4 +1,4 @@
 Canceling thread..
 Thread started!
 Called clean-up handler with arg 42
-After canceling, shared variable = 1
+After canceling, cleanup complete

--- a/test/pthread/test_pthread_cancel_async.c
+++ b/test/pthread/test_pthread_cancel_async.c
@@ -11,20 +11,31 @@
 #include <assert.h>
 #include <unistd.h>
 #include <errno.h>
+
+#ifdef __EMSCRIPTEN__
 #include <emscripten/console.h>
-
-pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-_Atomic long res = 43;
-_Atomic int started = false;
-
-static void cleanup_handler(void *arg)
-{
-  long a = (long)arg;
-  emscripten_outf("Called clean-up handler with arg %ld", a);
-  res -= a;
+#else
+void emscripten_out(const char* msg) {
+  printf("%s\n", msg);
 }
 
-static void *thread_start(void *arg) {
+void emscripten_outf(const char* msg, ...) {
+  printf("%s\n", msg);
+}
+#endif
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+_Atomic bool started = false;
+_Atomic bool done_cleanup = false;
+
+void cleanup_handler(void *arg) {
+  long a = (long)arg;
+  emscripten_outf("Called clean-up handler with arg %ld", a);
+  assert(a == 42);
+  done_cleanup = true;
+}
+
+void *thread_start(void *arg) {
   // Setup thread for async cancellation only
   pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
   pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
@@ -61,7 +72,7 @@ int main() {
   s = pthread_cancel(thr);
   assert(s == 0);
   // Busy wait until thread cancel handler has been run
-  while (res != 1) {
+  while (!done_cleanup) {
     sched_yield();
   }
 


### PR DESCRIPTION
- Use boolean flags
- Avoid magic numbers
- Cleanup formatting