### PR TITLE
Exclude linux-specific code from __timedwait. NFC

### DIFF
--- a/system/lib/libc/musl/src/thread/__timedwait.c
+++ b/system/lib/libc/musl/src/thread/__timedwait.c
@@ -100,13 +100,13 @@ int __timedwait_cp(volatile int *addr, int val,
 	}
 #else
 	r = -__futex4_cp(addr, FUTEX_WAIT|priv, val, top);
-#endif
 	if (r != EINTR && r != ETIMEDOUT && r != ECANCELED) r = 0;
 	/* Mitigate bug in old kernels wrongly reporting EINTR for non-
 	 * interrupting (SA_RESTART) signal handlers. This is only practical
 	 * when NO interrupting signal handlers have been installed, and
 	 * works by sigaction tracking whether that's the case. */
 	if (r == EINTR && !__eintr_valid_flag) r = 0;
+#endif
 
 	return r;
 }

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7364,
   "a.out.js.gz": 3607,
-  "a.out.nodebug.wasm": 19259,
-  "a.out.nodebug.wasm.gz": 8931,
-  "total": 26623,
-  "total_gz": 12538,
+  "a.out.nodebug.wasm": 19206,
+  "a.out.nodebug.wasm.gz": 8899,
+  "total": 26570,
+  "total_gz": 12506,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7766,
   "a.out.js.gz": 3812,
-  "a.out.nodebug.wasm": 19260,
-  "a.out.nodebug.wasm.gz": 8933,
-  "total": 27026,
-  "total_gz": 12745,
+  "a.out.nodebug.wasm": 19207,
+  "a.out.nodebug.wasm.gz": 8900,
+  "total": 26973,
+  "total_gz": 12712,
   "sent": [
     "a (memory)",
     "b (emscripten_get_now)",


### PR DESCRIPTION
This special errno handling here is specific to the linux futex syscall which we are not using.