### PR TITLE
[test] Add overrides to SingleLineTestResult to support expected failures and unexpected successes. NFC

### DIFF
--- a/test/single_line_runner.py
+++ b/test/single_line_runner.py
@@ -4,6 +4,7 @@
 # found in the LICENSE file.
 
 import shutil
+from unittest import TextTestResult
 
 from color_runner import ColorTextResult, ColorTextRunner
 
@@ -66,6 +67,27 @@ class SingleLineTestResult(ColorTextResult):
     # to end out status line
     self.stream.write('\n')
     super().printErrors()
+
+  # Override addExpectedFailure and addUnexpectedSuccess since, for some reason
+  # these methods in TextTestResult do not use `_write_status` like the other ones.
+  # TODO(sbc): Send a patch to upstream python to sue `_write_status` in TextTestResult.
+  def addExpectedFailure(self, test, err):
+    super(TextTestResult, self).addExpectedFailure(test, err)
+    if self.showAll:
+      self._write_status(test, "expected failure")
+      self.stream.flush()
+    elif self.dots:
+      self.stream.write("x")
+      self.stream.flush()
+
+  def addUnexpectedSuccess(self, test):
+    super(TextTestResult, self).addUnexpectedSuccess(test)
+    if self.showAll:
+      self._write_status(test, "unexpected success")
+      self.stream.flush()
+    elif self.dots:
+      self.stream.write("u")
+      self.stream.flush()
 
 
 class SingleLineTestRunner(ColorTextRunner):


### PR DESCRIPTION
I suppose this went unnoticed upstream in python because expected failures and unexpected successes are relatively unusual.

We have a bunch of them in the posixtest suite here.