### PR TITLE
Update zlib to 1.3.2

### DIFF
--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -6,8 +6,8 @@
 import os
 import shutil
 
-VERSION = '1.3.1'
-HASH = '8c9642495bafd6fad4ab9fb67f09b268c69ff9af0f4f20cf15dfc18852ff1f312bd8ca41de761b3f8d8e90e77d79f2ccacd3d4c5b19e475ecf09d021fdfe9088'
+VERSION = '1.3.2'
+HASH = '16fea4df307a68cf0035858abe2fd550250618a97590e202037acd18a666f57afc10f8836cbbd472d54a0e76539d0e558cb26f059d53de52ff90634bbf4f47d4'
 
 
 def needed(settings):


### PR DESCRIPTION
This pulls in the fixes from an audit - https://7asecurity.com/blog/2026/02/zlib-7asecurity-audit/

    10 Findings with Security Impact, 100% fixed
        1 High
        2 Medium
        2 Low
        5 Hardening Recommendations