### PR TITLE
Use `setproctitle` python module, when available. NFC

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ types-requests==2.32.0.20241016
 unittest-xml-reporting==3.2.0
 deadcode==2.3.1
 vulture==2.14
+setproctitle==1.3.7
 
 # This version is mentioned in `site/source/docs/site/about.rst`.  Please keep
 # them in sync.  We cannot currently update to v8 or v9 due to our python 3.10

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -619,6 +619,7 @@ def get_llvm_target():
 
 def init():
   utils.set_version_globals()
+  utils.set_process_title()
   setup_temp_dirs()
 
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -29,6 +29,29 @@ LINUX = sys.platform.startswith('linux')
 logger = logging.getLogger('utils')
 
 
+def set_process_title():
+  """Remove the python prefix of the process title.
+
+  This makes the process listing easier to read as it just shows
+  `emcc ..` rather than e.g. `python3 -E emcc.py ...`.
+
+  This code depends the `setproctitle` PiPi module which might
+  not be installed.  If the module cannot be loaded this function
+  simply does nothing.
+  """
+  try:
+    import setproctitle
+  except ImportError:
+    return
+  t = setproctitle.getproctitle()
+  t = shlex.split(t)
+  while t and not t[0].endswith('.py'):
+    t.pop(0)
+  if t:
+    t[0] = os.path.splitext(t[0])[0]
+  setproctitle.setproctitle(shlex.join(t))
+
+
 def run_process(cmd, check=True, input=None, *args, **kw):
   """Run a subprocess returning the exit code.
 


### PR DESCRIPTION
This makes the process listing easier to read as it just shows `emcc ..` rather than `python3 -E emcc.py`.  On many/most systems this won't do anything because the module is not installed.

I'm going to pass on writing a test for this for now.