### PR TITLE
Enable ruff check E275 (missing-whitespace-after-keyword). NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -540,7 +540,7 @@ jobs:
       - pip-install
       - run: ruff check
       # TODO (cclauss): When ruff supports rules these errors without --preview, remove following line
-      - run: ruff check --preview --select=E20,E30,E221,E225,E226
+      - run: ruff check --preview --select=E20,E30,E221,E225,E226,E275
   vulture:
     executor: ubuntu-lts
     steps:

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -112,7 +112,7 @@ def make_test_chunked_synchronous_xhr_server(support_byte_ranges, data, port):
       # CORS preflight makes OPTIONS requests which we need to account for.
       expectedConns = 22
       s.num_get_connections += 1
-      assert(s.num_get_connections < expectedConns)
+      assert s.num_get_connections < expectedConns
 
       if s.path == '/':
         s.sendheaders()

--- a/tools/building.py
+++ b/tools/building.py
@@ -1120,7 +1120,7 @@ def read_name_section(wasm_file):
 def write_symbol_map(wasm_file, symbols_file):
   logger.debug('handle_final_wasm_symbols')
   names = read_name_section(wasm_file)
-  assert(names)
+  assert names
   strings = [f'{id}:{name}' for id, name in names.items()]
   contents = '\n'.join(strings) + '\n'
   utils.write_file(symbols_file, contents)

--- a/tools/empath-split.py
+++ b/tools/empath-split.py
@@ -162,7 +162,7 @@ def get_sourceMappingURL(wasm, arg_sourcemap):
 def print_sources(sourcemap):
   with open(sourcemap) as f:
     sources = json.load(f).get('sources')
-    assert(isinstance(sources, list))
+    assert isinstance(sources, list)
     for src in sources:
       print(src)
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -660,7 +660,7 @@ def check_settings():
 
 @ToolchainProfiler.profile()
 def setup_sanitizers(options):
-  assert(options.sanitize)
+  assert options.sanitize
 
   if settings.WASM_WORKERS:
     exit_with_error('WASM_WORKERS is not currently compatible with `-fsanitize` tools')


### PR DESCRIPTION
This check is still in preview mode sadly so it has to be enabled from the command line like this:

https://docs.astral.sh/ruff/rules/missing-whitespace-after-keyword/#missing-whitespace-after-keyword-e275

See https://github.com/astral-sh/ruff/releases/tag/v0.0.269