### PR TITLE
Remove node_pthread_flags used for node older that v16

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@ See docs/process.md for more on how version tagging works.
 - C++ exceptions are now always thrown as CppException objects rather than raw
   pointers/numbers.  However, the `.message` and `.stack` fields of the thrown
   object will only be populated if `-sEXCEPTION_STACK_TRACES` is set. (#26523)
+- `emcmake` no longer automatically injects `--experimental-wasm-threads` nodejs
+  flags when used with versions of node older than v16. (#26560)
 
 5.0.4 - 03/23/26
 ----------------

--- a/emcmake.py
+++ b/emcmake.py
@@ -35,11 +35,7 @@ variables so that emcc etc. are used. Typical usage:
     args.append('-DCMAKE_TOOLCHAIN_FILE=' + utils.path_from_root('cmake/Modules/Platform/Emscripten.cmake'))
 
   if not has_substr(args, '-DCMAKE_CROSSCOMPILING_EMULATOR'):
-    node_js = [config.NODE_JS[0]]
-    # In order to allow cmake to run code built with pthreads we need to pass
-    # some extra flags to node.
-    node_js += shared.node_pthread_flags(config.NODE_JS)
-    node_js = ';'.join(node_js)
+    node_js = config.NODE_JS[0]
     # See https://github.com/emscripten-core/emscripten/issues/15522
     args.append(f'-DCMAKE_CROSSCOMPILING_EMULATOR={node_js}')
 

--- a/test/browser_common.py
+++ b/test/browser_common.py
@@ -34,7 +34,7 @@ from common import (
   test_file,
 )
 
-from tools import feature_matrix, shared, utils
+from tools import feature_matrix, utils
 from tools.feature_matrix import UNSUPPORTED
 from tools.shared import DEBUG, EMCC, exit_with_error
 from tools.utils import MACOS, WINDOWS, memoize, path_from_root, read_binary
@@ -929,8 +929,6 @@ class BrowserCore(RunnerCore):
     if not isinstance(expected, list):
       expected = [expected]
     if EMTEST_BROWSER == 'node':
-      nodejs = self.require_node()
-      self.node_args += shared.node_pthread_flags(nodejs)
       output = self.run_js(f'{output_basename}.js')
       self.assertContained('RESULT: ' + expected[0], output)
     else:

--- a/test/common.py
+++ b/test/common.py
@@ -457,9 +457,8 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
       self.skipTest('non-browser pthreads not yet supported with MINIMAL_RUNTIME')
     for engine in self.js_engines:
       if engine_is_node(engine):
-        self.require_node()
-        nodejs = get_nodejs()
-        self.node_args += shared.node_pthread_flags(nodejs)
+        if not self.try_require_node_version(16, 0, 0):
+          self.fail('node v16 required to run this test')
         return
       elif engine_is_bun(engine) or engine_is_deno(engine):
         self.require_engine(engine)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13540,7 +13540,6 @@ int main() {
   @also_with_minimal_runtime
   def test_shared_memory(self):
     self.do_runf('wasm_worker/shared_memory.c', '0', cflags=[])
-    self.node_args += shared.node_pthread_flags(get_nodejs())
     self.do_runf('wasm_worker/shared_memory.c', '1', cflags=['-sSHARED_MEMORY'])
     self.do_runf('wasm_worker/shared_memory.c', '1', cflags=['-sWASM_WORKERS'])
     self.do_runf('wasm_worker/shared_memory.c', '1', cflags=['-pthread'])

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -326,15 +326,6 @@ def node_exception_flags(nodejs):
   return []
 
 
-def node_pthread_flags(nodejs):
-  node_version = get_node_version(nodejs)
-  # bulk memory and wasm threads were enabled by default in node v16.
-  if node_version and node_version < (16, 0, 0):
-    return ['--experimental-wasm-bulk-memory', '--experimental-wasm-threads']
-  else:
-    return []
-
-
 @memoize
 @ToolchainProfiler.profile()
 def check_node():


### PR DESCRIPTION
This function was used to try to allows pthread code run on version of node older than v16.   It was used almost exclusively in test code.

The only place is used in the compiler itself is `emcmake` where it we added these flags to node when used in `-DCMAKE_CROSSCOMPILING_EMULATOR`.

I don't think this is worth it anymore since v16 is so old.  The oldest support node TLS is v20 these days. 
