### PR TITLE
Remove STANDALONE_WASM+SHARED_MEMORY error. NFC

### DIFF
--- a/src/lib/libpthread_stub.js
+++ b/src/lib/libpthread_stub.js
@@ -7,9 +7,6 @@
 #if PTHREADS
 #error "Internal error! PTHREADS should not be enabled when including library_pthread_stub.js."
 #endif
-#if STANDALONE_WASM && SHARED_MEMORY
-#error "STANDALONE_WASM does not support shared memories yet"
-#endif
 
 var LibraryPThreadStub = {
   // ===================================================================================


### PR DESCRIPTION
This should have been removed back in #18355.