### PR TITLE
[MINIMAL_RUNTIME] Fix `ENVIRONMENT_IS_WORKER` under `WASM_WORKERS` + nodejs

### DIFF
--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -53,10 +53,15 @@ var ENVIRONMENT_IS_WEB = !ENVIRONMENT_IS_NODE;
 #endif
 #endif // ASSERTIONS || PTHREADS
 
+#if ENVIRONMENT_MAY_BE_WORKER || (PTHREADS || WASM_WORKERS)
+var ENVIRONMENT_IS_WORKER = !!globalThis.WorkerGlobalScope;
+#endif
+
 #if ENVIRONMENT_MAY_BE_NODE && (PTHREADS || WASM_WORKERS)
 if (ENVIRONMENT_IS_NODE) {
   var worker_threads = require('node:worker_threads');
   global.Worker = worker_threads.Worker;
+  ENVIRONMENT_IS_WORKER = !worker_threads.isMainThread;
 }
 #endif
 
@@ -134,10 +139,6 @@ function ready() {
 var isFileURI = (filename) => filename.startsWith('file://');
 var readAsync, readBinary;
 #include "node_shell_read.js"
-#endif
-
-#if ENVIRONMENT_MAY_BE_WORKER || PTHREADS
-var ENVIRONMENT_IS_WORKER = !!globalThis.WorkerGlobalScope;
 #endif
 
 #if PTHREADS

--- a/test/codesize/hello_wasm_worker_wasm.expected.js
+++ b/test/codesize/hello_wasm_worker_wasm.expected.js
@@ -1,6 +1,6 @@
-var c = Module, d = "em-ww" == globalThis.name, e = !!globalThis.WorkerGlobalScope, f, g, C, r, D, n, E, w;
+var c = Module, d = !!globalThis.WorkerGlobalScope, e = "em-ww" == globalThis.name, f, g, C, r, D, n, E, w;
 
-d && (onmessage = a => {
+e && (onmessage = a => {
     onmessage = null;
     f = a = a.data;
     g = a.o;
@@ -13,7 +13,7 @@ d && (onmessage = a => {
 
 function h() {}
 
-d || (g = c.mem || new WebAssembly.Memory({
+e || (g = c.mem || new WebAssembly.Memory({
     initial: 256,
     maximum: 256,
     shared: !0
@@ -26,7 +26,7 @@ var l = [], p = a => {
 }, q = a => {
     l.push(a);
 }, t = () => {
-    r(0, !e, !d, e && 1);
+    r(0, !d, !e, d && 1);
 }, u = {}, v = 1, x = (a, b) => {
     let m = u[v] = new Worker(c.js, {
         name: "em-ww"
@@ -47,7 +47,7 @@ var l = [], p = a => {
     });
 };
 
-d && (u[0] = globalThis, addEventListener("message", q));
+e && (u[0] = globalThis, addEventListener("message", q));
 
 function B() {
     console.log("Hello from wasm worker!");
@@ -72,9 +72,9 @@ function k() {
         r = b.k;
         D = b.l;
         n = b.j;
-        d ? (D(f.v, f.s, f.u), removeEventListener("message", q), l = l.forEach(p), addEventListener("message", p)) : b.h();
-        d || C();
+        e ? (D(f.v, f.s, f.u), removeEventListener("message", q), l = l.forEach(p), addEventListener("message", p)) : b.h();
+        e || C();
     }));
 }
 
-d || k();
+e || k();

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9696,7 +9696,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.run_process([FILE_PACKAGER, 'test.data', '--preload', 'file1.txt', 'file2.txt', '--from-emcc', '--js-output=script2.js'])
     self.do_runf('test_emscripten_async_load_script.c', cflags=['-sFORCE_FILESYSTEM'])
 
-  @requires_pthreads
   @no_sanitize('sanitizers do not support WASM_WORKERS')
   @also_with_minimal_runtime
   @also_with_modularize
@@ -9707,19 +9706,16 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.maybe_closure()
     self.do_run_in_out_file_test('wasm_worker/hello_wasm_worker.c', cflags=['-sWASM_WORKERS'])
 
-  @requires_pthreads
   @no_sanitize('sanitizers do not support WASM_WORKERS')
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
   def test_wasm_worker_malloc(self):
     self.do_run_in_out_file_test('wasm_worker/malloc_wasm_worker.c', cflags=['-sWASM_WORKERS'])
 
-  @requires_pthreads
   @no_sanitize('sanitizers do not support WASM_WORKERS')
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
   def test_wasm_worker_runtime_debug(self):
     self.do_runf('wasm_worker/hello_wasm_worker.c', 'wasm worker starting ...', cflags=['-sWASM_WORKERS', '-sRUNTIME_DEBUG'])
 
-  @requires_pthreads
   @no_sanitize('sanitizers do not support WASM_WORKERS')
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
   def test_wasm_worker_wait_async(self):


### PR DESCRIPTION
This fix came about because I was trying to remove the `@requires_pthread` decorator from the `WASM_WORKER` tests in test_core.py.   This decorator should not be needed or used for wasm worker tests because it injects the `-pthread` compile flag.

Without this fix the `ENVIRONMENT_IS_WORKER` is not set correctly under node which means that `emscripten_is_main_browser_thread` was reporting the wrong value when called from within a Wasm Worker.

This bug was being hidden when the program was compiled with both pthreads and wasm workers enabled.