### PR TITLE
Run wasm_worker_futex_wait.c test in test_core.py. NFC

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5054,7 +5054,7 @@ Module["preRun"] = () => {
     'pthread': (['-pthread'],),
   })
   def test_wasm_worker_futex_wait(self, args):
-    self.btest('wasm_worker/wasm_worker_futex_wait.c', expected='0', cflags=['-sWASM_WORKERS=1', '-sASSERTIONS'] + args)
+    self.btest_exit('wasm_worker/wasm_worker_futex_wait.c', cflags=['-sWASM_WORKERS=1', '-sASSERTIONS'] + args)
 
   # Tests Wasm Worker thread stack setup
   @also_with_minimal_runtime

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9722,6 +9722,11 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @no_sanitize('sanitizers do not support WASM_WORKERS')
   @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
+  def test_wasm_worker_futex_wait(self):
+    self.do_runf('wasm_worker/wasm_worker_futex_wait.c', cflags=['-sWASM_WORKERS'])
+
+  @no_sanitize('sanitizers do not support WASM_WORKERS')
+  @no_esm_integration('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
   def test_wasm_worker_wait_async(self):
     self.do_runf('atomic/test_wait_async.c', cflags=['-sWASM_WORKERS'])
 

--- a/test/wasm_worker/wasm_worker_futex_wait.c
+++ b/test/wasm_worker/wasm_worker_futex_wait.c
@@ -12,6 +12,12 @@
 
 _Atomic uint32_t futex_value = 0;
 
+void do_exit() {
+  emscripten_out("do_exit");
+  emscripten_terminate_all_wasm_workers();
+  emscripten_force_exit(0);
+}
+
 void wake_worker_after_delay(void *user_data) {
   futex_value = 1;
   emscripten_futex_wake(&futex_value, INT_MAX);
@@ -38,9 +44,7 @@ void worker_main() {
   assert(rc == 0);
   assert(futex_value == 1);
 
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, do_exit);
 }
 
 int main() {


### PR DESCRIPTION
This involves converting the test to btest_exit.