### PR TITLE
Revert "Simplify libprintf_long_double. NFC"

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1507,6 +1507,8 @@ class libprintf_long_double(libc):
   name = 'libprintf_long_double'
   cflags = ['-DEMSCRIPTEN_PRINTF_LONG_DOUBLE']
 
+  # Need to define get_files
+  # so libprintf_long_double.get_files() does not call libc.get_files()
   def get_files(self):
     return files_in_path(
         path='system/lib/libc/musl/src/stdio',


### PR DESCRIPTION
Reverts emscripten-core/emscripten#26428

`libprintf_long_double` inherits `libc`; not defining `libprintf_long_double.get_files()` will make calling `libprintf_long_double.get_files()` to call `libc.get_files()`.