### PR TITLE
Consistent use of `thread_local` over `_Thread_local`. NFC

### DIFF
--- a/system/lib/libc/musl/src/errno/__errno_location.c
+++ b/system/lib/libc/musl/src/errno/__errno_location.c
@@ -5,7 +5,7 @@
 // For emscripten we use TLS here instead of `__pthread_self`, so that in single
 // threaded builds this gets lowered away to normal global variable.
 // This also works for WASM_WORKERS there `__pthread_self` does not work.
-static _Thread_local int __errno_storage = 0;
+static thread_local int __errno_storage = 0;
 #endif
 
 int *__errno_location(void)

--- a/system/lib/libc/musl/src/internal/locale_impl.h
+++ b/system/lib/libc/musl/src/internal/locale_impl.h
@@ -46,7 +46,7 @@ hidden char *__gettextdomain(void);
 #define UTF8_LOCALE ((locale_t)&__c_dot_utf8_locale)
 
 #ifdef __EMSCRIPTEN__
-extern _Thread_local locale_t __tls_locale;
+extern thread_local locale_t __tls_locale;
 
 #define CURRENT_LOCALE (__tls_locale)
 

--- a/system/lib/libc/musl/src/internal/pthread_impl.h
+++ b/system/lib/libc/musl/src/internal/pthread_impl.h
@@ -40,7 +40,7 @@ struct pthread {
 	/* Part 2 -- implementation details, non-ABI. */
 	int tid;
 #ifndef __EMSCRIPTEN__
-	// Emscripten uses C11 _Thread_local instead for errno
+	// Emscripten uses C11 thread_local instead for errno
 	int errno_val;
 #endif
 	volatile int detach_state;
@@ -64,7 +64,7 @@ struct pthread {
 	int h_errno_val;
 	volatile int timer_id;
 #ifndef __EMSCRIPTEN__
-	// Emscripten uses C11 _Thread_local instead for locale
+	// Emscripten uses C11 thread_local instead for locale
 	locale_t locale;
 #endif
 	volatile int killlock[1];

--- a/system/lib/libc/musl/src/locale/uselocale.c
+++ b/system/lib/libc/musl/src/locale/uselocale.c
@@ -3,7 +3,7 @@
 #include "libc.h"
 
 #ifdef __EMSCRIPTEN__
-_Thread_local locale_t __tls_locale = &libc.global_locale;
+thread_local locale_t __tls_locale = &libc.global_locale;
 #endif
 
 locale_t __uselocale(locale_t new)

--- a/system/lib/pthread/proxying.c
+++ b/system/lib/pthread/proxying.c
@@ -35,7 +35,7 @@ static em_proxying_queue system_proxying_queue = {
   .capacity = 0,
 };
 
-static _Thread_local bool system_queue_in_use = false;
+static thread_local bool system_queue_in_use = false;
 
 em_proxying_queue* emscripten_proxy_get_system_queue(void) {
   return &system_proxying_queue;


### PR DESCRIPTION
They are both valid. I chose one of over the other since its the official C23 keyword.