### PR TITLE
Support Binaryen's new output format from MinifyImportsAndExports [NFC]

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -956,10 +956,11 @@ def minify_wasm_imports_and_exports(js_file, wasm_file, minify_exports, debug_in
   #   }
   # }
   #
-  # We differentiate them by the first character.
+  # We differentiate them by the first character (if present).
+  #
   # TODO: Remove the old format eventually after the new one rolls in.
   mapping = {}
-  if out[0] != '{':
+  if not out or out[0] != '{':
     SEP = ' => '
     for line in out.split('\n'):
       if SEP in line:


### PR DESCRIPTION
The new format uses JSON and supports overlapping module names.

Corresponding Binaryen change: https://github.com/WebAssembly/binaryen/pull/8550