### PR TITLE
Mark `abort` and `proc_exit` as `@noreturn`.

### DIFF
--- a/src/lib/libwasi.js
+++ b/src/lib/libwasi.js
@@ -17,6 +17,7 @@ var WasiLibrary = {
 #endif
 
   proc_exit__nothrow: true,
+  proc_exit__docs: '/** @noreturn */',
   proc_exit: (code) => {
 #if MINIMAL_RUNTIME
     throw `exit(${code})`;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -235,7 +235,10 @@ function postRun() {
   <<< ATPOSTRUNS >>>
 }
 
-/** @param {string|number=} what */
+/**
+ * @param {string|number=} what
+ * @noreturn
+ */
 function abort(what) {
 #if expectToReceiveOnModule('onAbort')
   Module['onAbort']?.(what);

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -361,7 +361,10 @@ function preMain() {}
 
 function postRun() {}
 
-/** @param {string|number=} what */ function abort(what) {
+/**
+ * @param {string|number=} what
+ * @noreturn
+ */ function abort(what) {
   what = `Aborted(${what})`;
   // TODO(sbc): Should we remove printing and leave it up to whoever
   // catches the exception?
@@ -3079,7 +3082,7 @@ function _fd_write(fd, iov, iovcnt, pnum) {
 
 var keepRuntimeAlive = () => true;
 
-var _proc_exit = code => {
+/** @noreturn */ var _proc_exit = code => {
   EXITSTATUS = code;
   if (!keepRuntimeAlive()) {
     ABORT = true;

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -508,7 +508,10 @@ function postRun() {
   // No ATPOSTRUNS hooks
 }
 
-/** @param {string|number=} what */
+/**
+ * @param {string|number=} what
+ * @noreturn
+ */
 function abort(what) {
 
   what = `Aborted(${what})`;

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 57042,
-  "hello_world.js.gz": 17743,
+  "hello_world.js": 57078,
+  "hello_world.js.gz": 17753,
   "hello_world.wasm": 14850,
   "hello_world.wasm.gz": 7311,
-  "no_asserts.js": 26618,
-  "no_asserts.js.gz": 8888,
+  "no_asserts.js": 26654,
+  "no_asserts.js.gz": 8901,
   "no_asserts.wasm": 12010,
   "no_asserts.wasm.gz": 5880,
-  "strict.js": 54860,
-  "strict.js.gz": 17049,
+  "strict.js": 54896,
+  "strict.js.gz": 17061,
   "strict.wasm": 14850,
   "strict.wasm.gz": 7311,
-  "total": 180230,
-  "total_gz": 64182
+  "total": 180338,
+  "total_gz": 64217
 }


### PR DESCRIPTION
I'm not sure this has any actual benefit but it might help with @stephenduong1004's recent issue with closure warnings.