### PR TITLE
Fix compiler error when exporting integers while emitting tsd

### DIFF
--- a/test/other/test_emit_tsd.d.ts
+++ b/test/other/test_emit_tsd.d.ts
@@ -1,5 +1,6 @@
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
 declare namespace RuntimeExports {
+    let POINTER_SIZE: number;
     /**
      * Given a pointer 'idx' to a null-terminated UTF8-encoded string in the given
      * array that contains uint8 values, returns a copy of that string as a

--- a/test/other/test_tsd.ts
+++ b/test/other/test_tsd.ts
@@ -5,4 +5,5 @@ async function go() {
   module._fooVoid();
   let result = module._fooInt(7, 8);
   module.UTF8ArrayToString([], 99);
+  module.POINTER_SIZE;
 }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3768,7 +3768,7 @@ More info: https://emscripten.org
       self.require_jspi()
     self.run_process([EMCC, test_file('other/test_emit_tsd.c'),
                       '--emit-tsd', f'test_emit_tsd{postfix}.d.ts', '-sEXPORT_ES6',
-                      '-sMODULARIZE', '-sEXPORTED_RUNTIME_METHODS=UTF8ArrayToString,wasmTable',
+                      '-sMODULARIZE', '-sEXPORTED_RUNTIME_METHODS=POINTER_SIZE,UTF8ArrayToString,wasmTable',
                       '-o', f'test_emit_tsd{postfix}.js'] + args +
                      self.get_cflags())
     self.assertFileContents(test_file(f'other/test_emit_tsd{postfix}.d.ts'), read_file(f'test_emit_tsd{postfix}.d.ts'))

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -648,7 +648,7 @@ def create_tsd_exported_runtime_methods(metadata):
     if name in metadata.library_definitions:
       definition = metadata.library_definitions[name]
       if definition['snippet']:
-        snippet = ' = ' + definition['snippet']
+        snippet = f' = {definition["snippet"]}'
         # Clear the doc so the type is either computed from the snippet or
         # defined by the definition below.
         docs = ''


### PR DESCRIPTION
Replaces concatenation (which can error when snippet is an int) with f-string

Fixes: #26589