### PR TITLE
[WasmFS] Ensure error codes are negative in the Node backend

### DIFF
--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -254,7 +254,7 @@ private:
     }
 
     auto childPath = getChildPath(name);
-    return _wasmfs_node_rename(fromPath.c_str(), childPath.c_str());
+    return -_wasmfs_node_rename(fromPath.c_str(), childPath.c_str());
   }
 
   ssize_t getNumEntries() override {


### PR DESCRIPTION
See commit 48459c67df1dfb8233e011530d59a932715f6f25 for details.

Split out from #24733, this fixes a test failure in `core0.test_fs_js_api_wasmfs_rawfs` from that PR.