### PR TITLE
[WasmFS] Allow reading from char devices in the Node backend

### DIFF
--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -191,7 +191,9 @@ private:
     if (_wasmfs_node_get_mode(childPath.c_str(), &mode)) {
       return nullptr;
     }
-    if (S_ISREG(mode)) {
+    // Allow reading from character device files too (e.g. `/dev/random`,
+    // `/dev/urandom`)
+    if (S_ISREG(mode) || S_ISCHR(mode)) {
       return std::make_shared<NodeFile>(mode, getBackend(), childPath);
     } else if (S_ISDIR(mode)) {
       return std::make_shared<NodeDirectory>(mode, getBackend(), childPath);

--- a/test/fs/test_fs_dev_random.c
+++ b/test/fs/test_fs_dev_random.c
@@ -13,12 +13,14 @@ int main() {
   int nread;
 
   fp = fopen("/dev/random", "r");
-  nread = fread(&data, 1, byte_count, fp);
+  assert(fp != NULL);
+  nread = fread(data, 1, byte_count, fp);
   assert(nread == byte_count);
   fclose(fp);
 
   fp = fopen("/dev/urandom", "r");
-  nread = fread(&data, 1, byte_count, fp);
+  assert(fp != NULL);
+  nread = fread(data, 1, byte_count, fp);
   assert(nread == byte_count);
   fclose(fp);
 


### PR DESCRIPTION
Split out from #24733, this fixes a test failure in `other.test_fs_dev_random_wasmfs_rawfs` from that PR.