### PR TITLE
Remove TODO from libpthread.js. NFC

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -1277,7 +1277,7 @@ var LibraryPThread = {
       // safe to access from sending threads that need to notify the waiting
       // thread.
       // Note: Under wasm64 only the low 32-bit of the pthread_ptr are
-      // read/compared here, but we don't actuallly are about the exact values
+      // read/compared here, but we don't actually care about the exact values
       // here as long as they match.
       var wait = Atomics.waitAsync(HEAP32, {{{ getHeapOffset('pthread_ptr', 'i32') }}}, pthread_ptr);
 #if ASSERTIONS


### PR DESCRIPTION
This TODO was added in #18861 when the following line read:

```
Atomics.waitAsync(HEAP32, pthread_ptr >> 2, pthread_ptr);
```

I'm not sure if the TODO here was refering to that 2nd or 3rd argument but they both work fine under wasm64 right now.

The second argument now uses `getHeapOffset('pthread_ptr', 'i32')` which works find under wasm64 even for addresses over 4gb.

The third argument here is actually not important since its value never changes, it just needs to match the contents of the memory at the specific location.  I verified that this works in wasm64_4gb mode.  The `pthread_ptr` is simply converted to a U32 and then compared to the low bits of the 64-bit pthread_ptr in memory.  The assert on the line below ensure that this does indeed work.  If it didn't then `"not-equal"` would be returned from `Atomics.waitAsync`