### PR TITLE
Remove unnecessary eval() in wrapSyscallFunction

### DIFF
--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -714,6 +714,9 @@ function(${args}) {
       } else if (typeof snippet == 'object') {
         snippet = stringifyWithFunctions(snippet);
         addImplicitDeps(snippet, deps);
+      } else if (typeof snippet == 'string' && (snippet.match(/^\s*\([^}]*\)\s*=>/) || snippet.match(/^function\b/))) {
+        // Support functions that are already "stringified"
+        isFunction = true;
       }
 
       if (isFunction) {

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -2593,7 +2593,7 @@ function wrapSyscallFunction(x, library, isWasi) {
     t = modifyJSFunction(t, (args, body, async_) => `${async_}function (${args}) {\n${pre}${body}${post}}\n`);
   }
 
-  library[x] = eval(`(${t})`);
+  library[x] = t;
   // Automatically add dependency on `$SYSCALLS`
   if (!WASMFS && t.includes('SYSCALLS')) {
     library[x + '__deps'].push('$SYSCALLS');

--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -1028,8 +1028,8 @@ var SyscallsLibrary = {
   },
 };
 
-for (var x in SyscallsLibrary) {
-  wrapSyscallFunction(x, SyscallsLibrary, false);
+for (const name of Object.keys(SyscallsLibrary)) {
+  wrapSyscallFunction(name, SyscallsLibrary, false);
 }
 
 addToLibrary(SyscallsLibrary);

--- a/src/lib/libwasi.js
+++ b/src/lib/libwasi.js
@@ -620,8 +620,8 @@ var WasiLibrary = {
   random_get: (buffer, size) => randomFill(HEAPU8.subarray(buffer, buffer + size)),
 };
 
-for (var x in WasiLibrary) {
-  wrapSyscallFunction(x, WasiLibrary, true);
+for (const name of Object.keys(WasiLibrary)) {
+  wrapSyscallFunction(name, WasiLibrary, true);
 }
 
 addToLibrary(WasiLibrary);


### PR DESCRIPTION
There is no need to turn the string back into a JS function here.