### PR TITLE
Minor JS compiler cleanups. NFC

### DIFF
--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -286,8 +286,7 @@ function handleI64Signatures(symbol, snippet, sig, i53abi, isAsyncFunction) {
       error(`handleI64Signatures: signature '${sig}' too long for ${symbol}(${argNames.join(', ')})`);
       return snippet;
     }
-    for (let i = 0; i < argNames.length; i++) {
-      const name = argNames[i];
+    for (const [i, name] of argNames.entries()) {
       // If sig is shorter than argNames list then argType will be undefined
       // here, which will result in the default case below.
       const argType = sig[i + 1];

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -113,7 +113,7 @@ export function preprocess(filename) {
 
   pushCurrentFile(filename);
   try {
-    for (let [i, line] of lines.entries()) {
+    for (const [i, line] of lines.entries()) {
       if (isHtml) {
         if (line.includes('<style') && !inStyle) {
           inStyle = true;
@@ -1176,7 +1176,7 @@ function pthreadDetection() {
 
 function makeExportAliases() {
   var res = ''
-  for (var [alias, ex] of Object.entries(nativeAliases)) {
+  for (const [alias, ex] of Object.entries(nativeAliases)) {
     if (ASSERTIONS) {
       res += `  assert(wasmExports['${ex}'], 'alias target "${ex}" not found in wasmExports');\n`;
     }

--- a/src/pthread_esm_startup.mjs
+++ b/src/pthread_esm_startup.mjs
@@ -49,7 +49,7 @@ self.onmessage = async (msg) => {
     // Now that the import is completed the main program will have installed
     // its own `onmessage` handler and replaced our handler.
     // Now we can dispatch any queued messages to this new handler.
-    for (let msg of messageQueue) {
+    for (const msg of messageQueue) {
       await self.onmessage(msg);
     }
 

--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -167,7 +167,7 @@ export function mergeInto(obj, other, options = null) {
             `JS library directive ${key}=${deps} is of type '${type}', but it should be an array`,
           );
         }
-        for (let dep of deps) {
+        for (const dep of deps) {
           if (dep && typeof dep !== 'string' && typeof dep !== 'function') {
             error(
               `__deps entries must be of type 'string' or 'function' not '${typeof dep}': ${key}`,


### PR DESCRIPTION
- Use `.entries` where possible
- Use `const` where possible.