### PR TITLE
Document performance.now hack for DETERMINISIC mode. NFC

### DIFF
--- a/src/deterministic.js
+++ b/src/deterministic.js
@@ -17,10 +17,11 @@ function deterministicNow() {
 
 Date.now = deterministicNow;
 
-// Setting performance.now to deterministicNow doesn't work so we instead
-// use a helper function in parseTools (getPerformanceNow()) to call it
-// directly.
-// if (globalThis.performance) performance.now = Date.now;
+// Note: this approach does not work on certain versions of Node.js
+// Specifically it seems like its not possible to override performance.now on
+// node v16 through v18.
+// See getPerformanceNow in parseTools.mjs for how we deal with this.
+if (globalThis.performance) performance.now = deterministicNow;
 
 Module['thisProgram'] = 'thisProgram'; // for consistency between different builds than between runs of the same build
 

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -1106,7 +1106,10 @@ function formattedMinNodeVersion() {
 }
 
 function getPerformanceNow() {
-  if (DETERMINISTIC) {
+  // This is needed to support Node.js v16 - v18 where `performance.now`
+  // cannot be overridden in the normal way.
+  // TODO(sbc): remove this once we drop support for these versions.
+  if (DETERMINISTIC && ENVIRONMENT_MAY_BE_NODE) {
     return 'deterministicNow';
   } else {
     return 'performance.now';

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12041,6 +12041,7 @@ int main(int argc, char **argv) {
 }''')
     self.do_runf('src.c', cflags=['-O3', '-sWASM=0'])
 
+  @crossplatform
   def test_deterministic(self):
     # test some things that may not be nondeterministic
     create_file('src.c', r'''


### PR DESCRIPTION
I was going to remove this hack but it seems like its going to be needed as long as we support targeting node v18 and below.