### PR TITLE
Remove dead code from src/deterministic.js. NFC

### DIFF
--- a/src/deterministic.js
+++ b/src/deterministic.js
@@ -23,22 +23,5 @@ Date.now = deterministicNow;
 // See getPerformanceNow in parseTools.mjs for how we deal with this.
 if (globalThis.performance) performance.now = deterministicNow;
 
-Module['thisProgram'] = 'thisProgram'; // for consistency between different builds than between runs of the same build
-
-function hashMemory(id) {
-  var ret = 0;
-  var len = _sbrk(0);
-  for (var i = 0; i < len; i++) {
-    ret = (ret*17 + HEAPU8[i])|0;
-  }
-  return id + ':' + ret;
-}
-
-function hashString(s) {
-  var ret = 0;
-  for (var i = 0; i < s.length; i++) {
-    ret = (ret*17 + s.charCodeAt(i))|0;
-  }
-  return ret;
-}
-
+// for consistency between different builds than between runs of the same build
+Module['thisProgram'] = 'thisProgram';

--- a/tools/link.py
+++ b/tools/link.py
@@ -1286,8 +1286,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     settings.ALLOW_TABLE_GROWTH = 1
 
   # various settings require sbrk() access
-  if settings.DETERMINISTIC or \
-     settings.EMSCRIPTEN_TRACING or \
+  if settings.EMSCRIPTEN_TRACING or \
      settings.SAFE_HEAP or \
      settings.MEMORYPROFILER:
     settings.REQUIRED_EXPORTS += ['sbrk']


### PR DESCRIPTION
The `hashMemory` function was added back 2013 (156fe33bf) but has never had any testing of documenation.

The `hashString` function was added in 2015 (e1344f0df) also without any testing of example uses.

I'm hoping to simply remove the `-sDETERMINISTIC` setting, but as part of that I'm first trying to strip it down to whats actually used/tested.