### PR TITLE
Add more testing for pthread_kill.

### DIFF
--- a/system/lib/libc/raise.c
+++ b/system/lib/libc/raise.c
@@ -71,10 +71,10 @@ int raise(int sig) {
         handler(sig);
       }
     } else if (handler != SIG_IGN) {
-        // Avoid a direct call to the handler, and instead call via JS so we can
-        // avoid strict signature checking.
-        // https://github.com/emscripten-core/posixtestsuite/issues/6
-        __call_sighandler(handler, sig);
+      // Avoid a direct call to the handler, and instead call via JS so we can
+      // avoid strict signature checking.
+      // https://github.com/emscripten-core/posixtestsuite/issues/6
+      __call_sighandler(handler, sig);
     }
   }
   return 0;

--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -260,6 +260,14 @@ int pthread_equal(pthread_t t1, pthread_t t2) {
   return t1 == t2;
 }
 
+int pthread_kill(pthread_t thread, int sig) {
+  if (thread != pthread_self()) {
+    return EINVAL;
+  }
+  raise(sig);
+  return 0;
+}
+
 int pthread_mutexattr_init(pthread_mutexattr_t *attr) {
   return 0;
 }

--- a/system/lib/pthread/pthread_kill.c
+++ b/system/lib/pthread/pthread_kill.c
@@ -11,10 +11,8 @@
 #include <emscripten_internal.h>
 
 #include "pthread_impl.h"
-#include "lock.h"
 
-void do_raise(void* arg) {
-  int sig = (intptr_t)arg;
+static void do_raise(int sig) {
   if (sig == SIGCANCEL) {
     // For `SIGCANCEL` there is no need to actually call raise to run the
     // handler function.  The calling thread (the one calling `pthread_cancel`)
@@ -31,16 +29,16 @@ void do_raise(void* arg) {
     _emscripten_runtime_keepalive_clear();
     return;
   }
-  raise((intptr_t)sig);
+  raise(sig);
+}
+
+static void proxied_do_raise(void* arg) {
+  do_raise((intptr_t)arg);
 }
 
 int pthread_kill(pthread_t t, int sig) {
   if (sig < 0 || sig >= _NSIG) {
     return EINVAL;
-  }
-  if (t == emscripten_main_runtime_thread_id()) {
-    if (sig == 0) return 0; // signal == 0 is a no-op.
-    return ESRCH;
   }
   if (!t || !_emscripten_thread_is_valid(t)) {
     return ESRCH;
@@ -49,6 +47,10 @@ int pthread_kill(pthread_t t, int sig) {
 
   // The job of pthread_kill is basically to run the (process-wide) signal
   // handler on the target thread.
-  emscripten_proxy_async(emscripten_proxy_get_system_queue(), t, do_raise, (void*)(intptr_t)sig);
+  if (pthread_equal(pthread_self(), t)) {
+    do_raise(sig);
+  } else {
+    emscripten_proxy_async(emscripten_proxy_get_system_queue(), t, proxied_do_raise, (void*)(intptr_t)sig);
+  }
   return 0;
 }

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19194,
   "a.out.js.gz": 7969,
-  "a.out.nodebug.wasm": 132638,
-  "a.out.nodebug.wasm.gz": 49927,
-  "total": 151832,
-  "total_gz": 57896,
+  "a.out.nodebug.wasm": 132635,
+  "a.out.nodebug.wasm.gz": 49922,
+  "total": 151829,
+  "total_gz": 57891,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19171,
   "a.out.js.gz": 7957,
-  "a.out.nodebug.wasm": 132064,
-  "a.out.nodebug.wasm.gz": 49586,
-  "total": 151235,
-  "total_gz": 57543,
+  "a.out.nodebug.wasm": 132061,
+  "a.out.nodebug.wasm.gz": 49579,
+  "total": 151232,
+  "total_gz": 57536,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 23174,
   "a.out.js.gz": 8960,
-  "a.out.nodebug.wasm": 172516,
-  "a.out.nodebug.wasm.gz": 57438,
-  "total": 195690,
-  "total_gz": 66398,
+  "a.out.nodebug.wasm": 172526,
+  "a.out.nodebug.wasm.gz": 57447,
+  "total": 195700,
+  "total_gz": 66407,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19026,
   "a.out.js.gz": 7904,
-  "a.out.nodebug.wasm": 147922,
-  "a.out.nodebug.wasm.gz": 55312,
-  "total": 166948,
-  "total_gz": 63216,
+  "a.out.nodebug.wasm": 147926,
+  "a.out.nodebug.wasm.gz": 55308,
+  "total": 166952,
+  "total_gz": 63212,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19100,
   "a.out.js.gz": 7929,
-  "a.out.nodebug.wasm": 145729,
-  "a.out.nodebug.wasm.gz": 54945,
-  "total": 164829,
-  "total_gz": 62874,
+  "a.out.nodebug.wasm": 145732,
+  "a.out.nodebug.wasm.gz": 54936,
+  "total": 164832,
+  "total_gz": 62865,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 18563,
   "a.out.js.gz": 7666,
-  "a.out.nodebug.wasm": 102162,
-  "a.out.nodebug.wasm.gz": 39560,
-  "total": 120725,
-  "total_gz": 47226,
+  "a.out.nodebug.wasm": 102164,
+  "a.out.nodebug.wasm.gz": 39553,
+  "total": 120727,
+  "total_gz": 47219,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -2,9 +2,9 @@
   "a.out.js": 23224,
   "a.out.js.gz": 8983,
   "a.out.nodebug.wasm": 238957,
-  "a.out.nodebug.wasm.gz": 79842,
+  "a.out.nodebug.wasm.gz": 79820,
   "total": 262181,
-  "total_gz": 88825,
+  "total_gz": 88803,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19194,
   "a.out.js.gz": 7969,
-  "a.out.nodebug.wasm": 134661,
-  "a.out.nodebug.wasm.gz": 50777,
-  "total": 153855,
-  "total_gz": 58746,
+  "a.out.nodebug.wasm": 134657,
+  "a.out.nodebug.wasm.gz": 50774,
+  "total": 153851,
+  "total_gz": 58743,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_wasmfs.json
+++ b/test/codesize/test_codesize_cxx_wasmfs.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7023,
   "a.out.js.gz": 3310,
-  "a.out.nodebug.wasm": 172714,
-  "a.out.nodebug.wasm.gz": 63316,
-  "total": 179737,
-  "total_gz": 66626,
+  "a.out.nodebug.wasm": 172710,
+  "a.out.nodebug.wasm.gz": 63317,
+  "total": 179733,
+  "total_gz": 66627,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -2,9 +2,9 @@
   "a.out.js": 22141,
   "a.out.js.gz": 9184,
   "a.out.nodebug.wasm": 1648,
-  "a.out.nodebug.wasm.gz": 939,
+  "a.out.nodebug.wasm.gz": 938,
   "total": 23789,
-  "total_gz": 10123,
+  "total_gz": 10122,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 24221,
-  "a.out.js.gz": 8713,
+  "a.out.js.gz": 8717,
   "a.out.nodebug.wasm": 14850,
-  "a.out.nodebug.wasm.gz": 7311,
+  "a.out.nodebug.wasm.gz": 7314,
   "total": 39071,
-  "total_gz": 16024,
+  "total_gz": 16031,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O1.json
+++ b/test/codesize/test_codesize_hello_O1.json
@@ -2,9 +2,9 @@
   "a.out.js": 6345,
   "a.out.js.gz": 2456,
   "a.out.nodebug.wasm": 2530,
-  "a.out.nodebug.wasm.gz": 1423,
+  "a.out.nodebug.wasm.gz": 1421,
   "total": 8875,
-  "total_gz": 3879,
+  "total_gz": 3877,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O2.json
+++ b/test/codesize/test_codesize_hello_O2.json
@@ -2,9 +2,9 @@
   "a.out.js": 4323,
   "a.out.js.gz": 2130,
   "a.out.nodebug.wasm": 1898,
-  "a.out.nodebug.wasm.gz": 1122,
+  "a.out.nodebug.wasm.gz": 1120,
   "total": 6221,
-  "total_gz": 3252,
+  "total_gz": 3250,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O3.json
+++ b/test/codesize/test_codesize_hello_O3.json
@@ -2,9 +2,9 @@
   "a.out.js": 4265,
   "a.out.js.gz": 2089,
   "a.out.nodebug.wasm": 1648,
-  "a.out.nodebug.wasm.gz": 939,
+  "a.out.nodebug.wasm.gz": 938,
   "total": 5913,
-  "total_gz": 3028,
+  "total_gz": 3027,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_Os.json
+++ b/test/codesize/test_codesize_hello_Os.json
@@ -2,9 +2,9 @@
   "a.out.js": 4265,
   "a.out.js.gz": 2089,
   "a.out.nodebug.wasm": 1638,
-  "a.out.nodebug.wasm.gz": 942,
+  "a.out.nodebug.wasm.gz": 941,
   "total": 5903,
-  "total_gz": 3031,
+  "total_gz": 3030,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_Oz.json
+++ b/test/codesize/test_codesize_hello_Oz.json
@@ -2,9 +2,9 @@
   "a.out.js": 3900,
   "a.out.js.gz": 1896,
   "a.out.nodebug.wasm": 1172,
-  "a.out.nodebug.wasm.gz": 724,
+  "a.out.nodebug.wasm.gz": 723,
   "total": 5072,
-  "total_gz": 2620,
+  "total_gz": 2619,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 26185,
   "a.out.js.gz": 11171,
-  "a.out.nodebug.wasm": 17668,
-  "a.out.nodebug.wasm.gz": 8921,
-  "total": 43853,
-  "total_gz": 20092,
+  "a.out.nodebug.wasm": 17671,
+  "a.out.nodebug.wasm.gz": 8923,
+  "total": 43856,
+  "total_gz": 20094,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
   "a.out.js": 244343,
-  "a.out.nodebug.wasm": 577432,
-  "total": 821775,
+  "a.out.nodebug.wasm": 577473,
+  "total": 821816,
   "sent": [
     "IMG_Init",
     "IMG_Load",
@@ -2879,6 +2879,7 @@
     "pthread_join",
     "pthread_key_create",
     "pthread_key_delete",
+    "pthread_kill",
     "pthread_mutex_consistent",
     "pthread_mutex_destroy",
     "pthread_mutex_init",
@@ -4621,6 +4622,7 @@
     "$pthread_getattr_np",
     "$pthread_getcpuclockid",
     "$pthread_getspecific",
+    "$pthread_kill",
     "$pthread_mutexattr_getprotocol",
     "$pthread_mutexattr_getpshared",
     "$pthread_mutexattr_getrobust",

--- a/test/codesize/test_codesize_hello_single_file.json
+++ b/test/codesize/test_codesize_hello_single_file.json
@@ -1,6 +1,6 @@
 {
   "a.out.js": 5223,
-  "a.out.js.gz": 2886,
+  "a.out.js.gz": 2887,
   "sent": [
     "a (fd_write)"
   ]

--- a/test/codesize/test_codesize_hello_wasmfs.json
+++ b/test/codesize/test_codesize_hello_wasmfs.json
@@ -2,9 +2,9 @@
   "a.out.js": 4265,
   "a.out.js.gz": 2089,
   "a.out.nodebug.wasm": 1648,
-  "a.out.nodebug.wasm.gz": 939,
+  "a.out.nodebug.wasm.gz": 938,
   "total": 5913,
-  "total_gz": 3028,
+  "total_gz": 3027,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_minimal_runtime_code_size_hello_embind.json
+++ b/test/codesize/test_minimal_runtime_code_size_hello_embind.json
@@ -4,7 +4,7 @@
   "a.js": 7262,
   "a.js.gz": 3324,
   "a.wasm": 7099,
-  "a.wasm.gz": 3257,
+  "a.wasm.gz": 3246,
   "total": 14909,
-  "total_gz": 6952
+  "total_gz": 6941
 }

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,8 +1,8 @@
 {
   "hello_world.js": 56998,
-  "hello_world.js.gz": 17743,
+  "hello_world.js.gz": 17746,
   "hello_world.wasm": 14850,
-  "hello_world.wasm.gz": 7311,
+  "hello_world.wasm.gz": 7314,
   "no_asserts.js": 26622,
   "no_asserts.js.gz": 8888,
   "no_asserts.wasm": 12010,
@@ -10,7 +10,7 @@
   "strict.js": 54816,
   "strict.js.gz": 17052,
   "strict.wasm": 14850,
-  "strict.wasm.gz": 7311,
+  "strict.wasm.gz": 7310,
   "total": 180146,
-  "total_gz": 64185
+  "total_gz": 64190
 }

--- a/test/pthread/test_pthread_kill.c
+++ b/test/pthread/test_pthread_kill.c
@@ -17,14 +17,18 @@
 
 pthread_cond_t started_cond = PTHREAD_COND_INITIALIZER;
 pthread_mutex_t started_lock = PTHREAD_MUTEX_INITIALIZER;
-_Atomic bool got_term_signal = false;
+_Atomic bool got_sigterm = false;
+_Atomic bool got_sigusr1 = false;
 
-pthread_t thr;
+pthread_t main_thread;
+pthread_t child_thread;
 
 void signal_handler(int sig, siginfo_t * info, void * arg) {
-  printf("signal: %d onthread=%d\n", sig, pthread_self() == thr);
+  printf("signal: %d onthread=%d\n", sig, pthread_self() == child_thread);
   if (sig == SIGTERM) {
-    got_term_signal = true;
+    got_sigterm = true;
+  } else if (sig == SIGUSR1) {
+    got_sigusr1 = true;
   }
 }
 
@@ -34,6 +38,7 @@ void setup_handler() {
   act.sa_flags = SA_SIGINFO;
   act.sa_sigaction = signal_handler;
   sigaction(SIGTERM, &act, NULL);
+  sigaction(SIGUSR1, &act, NULL);
 }
 
 
@@ -46,17 +51,26 @@ void *thread_start(void *arg) {
   pthread_cond_signal(&started_cond);
   pthread_mutex_unlock(&started_lock);
   // As long as this thread is running, keep the shared variable latched to nonzero value.
-  while (!got_term_signal) {
+  while (!got_sigterm) {
     sleepms(1);
   }
-  printf("got term signal, shutting down thread\n");
-  pthread_exit(0);
+  printf("got term signal, sending signal back to main thread\n");
+  pthread_kill(main_thread, SIGUSR1);
+  return NULL;
 }
 
 int main() {
+  main_thread = pthread_self();
   setup_handler();
 
-  int s = pthread_create(&thr, NULL, thread_start, 0);
+  printf("tesing pthread_kill with pthread_self\n");
+  assert(!got_sigterm);
+  int s = pthread_kill(pthread_self(), SIGTERM);
+  assert(got_sigterm);
+  got_sigterm = false;
+  assert(s == 0);
+
+  s = pthread_create(&child_thread, NULL, thread_start, 0);
   assert(s == 0);
 
   // Wait until thread kicks in and sets the shared variable.
@@ -65,11 +79,15 @@ int main() {
   pthread_mutex_unlock(&started_lock);
   printf("thread has started, sending SIGTERM\n");
 
-  s = pthread_kill(thr, SIGTERM);
+  s = pthread_kill(child_thread, SIGTERM);
   assert(s == 0);
   printf("SIGTERM sent\n");
 
-
-  pthread_join(thr, NULL);
+  pthread_join(child_thread, NULL);
+  printf("joined child_thread\n");
+  while (!got_sigusr1) {
+    sleepms(1);
+  }
+  printf("got SIGUSR1. all done.\n");
   return 0;
 }

--- a/test/pthread/test_pthread_kill.out
+++ b/test/pthread/test_pthread_kill.out
@@ -1,4 +1,9 @@
+tesing pthread_kill with pthread_self
+signal: 15 onthread=0
 thread has started, sending SIGTERM
 SIGTERM sent
 signal: 15 onthread=1
-got term signal, shutting down thread
+got term signal, sending signal back to main thread
+joined child_thread
+signal: 10 onthread=0
+got SIGUSR1. all done.

--- a/test/pthread/test_pthread_kill_self.c
+++ b/test/pthread/test_pthread_kill_self.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+int main() {
+  printf("main\n");
+  pthread_kill(pthread_self(), SIGTERM);
+  assert(false && "should not get here");
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13038,6 +13038,13 @@ void foo() {}
   def test_pthread_kill(self):
     self.do_run_in_out_file_test('pthread/test_pthread_kill.c')
 
+  @parameterized({
+    '': (['-pthread'],),
+    'stub': ([],),
+  })
+  def test_pthread_kill_self(self, args):
+    self.do_runf('pthread/test_pthread_kill_self.c', 'main\n', assert_returncode=NON_ZERO, cflags=args)
+
   # Tests memory growth in pthreads mode, but still on the main thread.
   @requires_pthreads
   @parameterized({


### PR DESCRIPTION
- Test using `pthread_kill` on yourself.
- Test using `pthread_kill` from a background thread to the main thread.  For some reason this was disallowed before.
- Add a stub version of `pthread_kill` along with a test.