### PR TITLE
Emsymbolizer: Remove VMA adjustment from llvm-symbolizer call

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9684,6 +9684,7 @@ int main() {
 
   def test_emsymbolizer_srcloc(self):
     'Test emsymbolizer use cases that provide src location granularity info'
+    self.skipTest('TODO: Re-enable when https://github.com/llvm/llvm-project/pull/191329 rolls')
     def check_dwarf_loc_info(address, funcs, locs):
       out = self.run_process(
           [emsymbolizer, '-s', 'dwarf', 'test_dwarf.wasm', address],

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9685,6 +9685,7 @@ int main() {
   def test_emsymbolizer_srcloc(self):
     'Test emsymbolizer use cases that provide src location granularity info'
     self.skipTest('TODO: Re-enable when https://github.com/llvm/llvm-project/pull/191329 rolls')
+
     def check_dwarf_loc_info(address, funcs, locs):
       out = self.run_process(
           [emsymbolizer, '-s', 'dwarf', 'test_dwarf.wasm', address],

--- a/tools/emsymbolizer.py
+++ b/tools/emsymbolizer.py
@@ -67,7 +67,7 @@ def has_linking_section(module):
   return module.get_custom_section('linking') is not None
 
 
-def symbolize_address_symbolizer(module, address, is_dwarf):
+def symbolize_address_symbolizer(module, address):
   cmd = [LLVM_SYMBOLIZER, '-e', module.filename, str(address)]
   if shared.DEBUG:
     print(f'Running {" ".join(cmd)}')
@@ -275,16 +275,16 @@ def main(args):
 
     if ((has_debug_line_section(module) and not args.source) or
        'dwarf' in args.source):
-      print_loc(symbolize_address_symbolizer(module, address, is_dwarf=True))
+      print_loc(symbolize_address_symbolizer(module, address))
     elif ((get_sourceMappingURL_section(module) and not args.source) or
           'sourcemap' in args.source):
       print_loc(symbolize_address_sourcemap(module, address, args.file))
     elif ((has_name_section(module) and not args.source) or
           'names' in args.source):
-      print_loc(symbolize_address_symbolizer(module, address, is_dwarf=False))
+      print_loc(symbolize_address_symbolizer(module, address))
     elif ((has_linking_section(module) and not args.source) or
           'symtab' in args.source):
-      print_loc(symbolize_address_symbolizer(module, address, is_dwarf=False))
+      print_loc(symbolize_address_symbolizer(module, address))
     elif (args.source == 'symbolmap'):
       print_loc(symbolize_address_symbolmap(module, address, args.file))
     else:

--- a/tools/emsymbolizer.py
+++ b/tools/emsymbolizer.py
@@ -68,12 +68,7 @@ def has_linking_section(module):
 
 
 def symbolize_address_symbolizer(module, address, is_dwarf):
-  if is_dwarf:
-    vma_adjust = get_codesec_offset(module)
-  else:
-    vma_adjust = 0
-  cmd = [LLVM_SYMBOLIZER, '-e', module.filename, f'--adjust-vma={vma_adjust}',
-         str(address)]
+  cmd = [LLVM_SYMBOLIZER, '-e', module.filename, str(address)]
   if shared.DEBUG:
     print(f'Running {" ".join(cmd)}')
   out = utils.run_process(cmd, stdout=subprocess.PIPE).stdout.strip()


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/191068 it is no longer
necessary (or correct).
