### PR TITLE
[test] Add EMTEST_TIMEOUT environment variable

### DIFF
--- a/test/jsrun.py
+++ b/test/jsrun.py
@@ -15,7 +15,7 @@ import common
 from tools import utils
 
 WORKING_ENGINES = {} # Holds all configured engines and whether they work: maps path -> True/False
-DEFAULT_TIMEOUT = 5 * 60
+DEFAULT_TIMEOUT = int(os.environ.get('EMTEST_TIMEOUT', str(5 * 60)))
 
 
 def make_command(filename, engine, args=None):


### PR DESCRIPTION
This is useful when debugging tests that are timing out without having to wait the full default of 5 minutes to get the failure.

For example I've been debugging a timeout recently using:

```
EMTEST_TIMEOUT=5 ./test/runner posixtest.test_pthread_join_4_1
```

This waits for 5 seconds rather than 5 minutes.