### PR TITLE
[WASM_WORKERS] Fix UB in pthread_mutex with debug+hybrid builds

### DIFF
--- a/system/lib/libc/musl/src/thread/pthread_mutex_consistent.c
+++ b/system/lib/libc/musl/src/thread/pthread_mutex_consistent.c
@@ -7,7 +7,7 @@ int pthread_mutex_consistent(pthread_mutex_t *m)
 	int own = old & 0x3fffffff;
 	if (!(m->_m_type & 4) || !own || !(old & 0x40000000))
 		return EINVAL;
-	if (own != __pthread_self()->tid)
+	if (own != CURRENT_THREAD_ID)
 		return EPERM;
 	a_and(&m->_m_lock, ~0x40000000);
 	return 0;

--- a/system/lib/libc/musl/src/thread/pthread_mutex_timedlock.c
+++ b/system/lib/libc/musl/src/thread/pthread_mutex_timedlock.c
@@ -87,12 +87,12 @@ int __pthread_mutex_timedlock(pthread_mutex_t *restrict m, const struct timespec
 		if (!own && (!r || (type&4)))
 			continue;
 		if ((type&3) == PTHREAD_MUTEX_ERRORCHECK
-		    && own == __pthread_self()->tid)
+		    && own == CURRENT_THREAD_ID)
 			return EDEADLK;
 #if defined(__EMSCRIPTEN__) && !defined(NDEBUG)
 		// Extra check for deadlock in debug builds, but only if we would block
 		// forever (at == NULL).
-		assert(at || own != __pthread_self()->tid && "pthread mutex deadlock detected");
+		assert(at || own != CURRENT_THREAD_ID && "pthread mutex deadlock detected");
 #endif
 
 		a_inc(&m->_m_waiters);

--- a/system/lib/libc/musl/src/thread/pthread_mutex_trylock.c
+++ b/system/lib/libc/musl/src/thread/pthread_mutex_trylock.c
@@ -5,7 +5,7 @@ int __pthread_mutex_trylock_owner(pthread_mutex_t *m)
 	int old, own;
 	int type = m->_m_type;
 	pthread_t self = __pthread_self();
-	int tid = self->tid;
+	int tid = CURRENT_THREAD_ID;
 	volatile void *next;
 
 	old = m->_m_lock;

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,9 +1,9 @@
 {
   "a.out.js": 7367,
   "a.out.js.gz": 3603,
-  "a.out.nodebug.wasm": 19003,
+  "a.out.nodebug.wasm": 19005,
   "a.out.nodebug.wasm.gz": 8786,
-  "total": 26370,
+  "total": 26372,
   "total_gz": 12389,
   "sent": [
     "a (memory)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,9 +1,9 @@
 {
   "a.out.js": 7769,
   "a.out.js.gz": 3809,
-  "a.out.nodebug.wasm": 19004,
+  "a.out.nodebug.wasm": 19006,
   "a.out.nodebug.wasm.gz": 8787,
-  "total": 26773,
+  "total": 26775,
   "total_gz": 12596,
   "sent": [
     "a (memory)",

--- a/test/test_stress.py
+++ b/test/test_stress.py
@@ -113,3 +113,6 @@ class stress(RunnerCore):
 
     js_file = self.build('pthread/test_pthread_proxying_reduced_stress_test_case.c')
     self.parallel_stress_test_js_file(js_file, not_expected='pthread_self() == unknown', expected='pthread_self() == worker2', assert_returncode=0)
+
+  def test_stress_pthread_malloc(self):
+    self.do_runf('test_stress_pthread_malloc.c', 'done\n', cflags=['-pthread', '-sWASM_WORKERS'])

--- a/test/test_stress_pthread_malloc.c
+++ b/test/test_stress_pthread_malloc.c
@@ -1,0 +1,36 @@
+#include <emscripten.h>
+#include <emscripten/wasm_worker.h>
+#include <emscripten/console.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+_Atomic int running_threads = 0;
+
+static void malloc_loop() {
+  // Busy loop here until both threads are up running
+  running_threads += 1;
+  while (running_threads != 2) {}
+
+  for (int i = 0; i < 1000000; ++i) {
+    free(malloc(1));
+  }
+}
+
+static void worker_callback(void) {
+  emscripten_outf("worker_callback");
+  malloc_loop();
+}
+
+static void main_callback(void* arg) {
+  emscripten_outf("main_callback");
+  malloc_loop();
+  emscripten_outf("done");
+  emscripten_terminate_all_wasm_workers();
+}
+
+int main() {
+  emscripten_outf("main");
+  emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(1024 * 1024), worker_callback);
+  emscripten_async_call(main_callback, NULL, 0);
+  return 0;
+}


### PR DESCRIPTION
This fix only applies to the hybrid Wasm Workers + pthread build mode.

We can't currently rely on calling `pthread_self()` from a Wasm Worker, even the hybrid mode.  We are working on fixing that in #26631.  However, we do have a `CURRENT_THREAD_ID` macro that works on both Wasm Workers and pthreads.

As it happens, pthread locks under musl do not normally depend on `pthread_self` except for "recursive" which need to access the `pthread_self()->tid` field to track the current owner.   This means that I broke the debug + hybrid mode locks in #24607 because I added the recursion check to all locks in debug builds.

While I have added a repro case for this its not directly testing the issue, it just heppens to crash due to the current undefined behavior when doing `pthread_self()->tid` from a Wasm Worker.

Fixes: #26619