### PR TITLE
Cleanup test_asan_no_error test. NFC

### DIFF
--- a/test/core/test_asan_no_error.c
+++ b/test/core/test_asan_no_error.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 int f(char *x) {
   int z = *x;
@@ -15,5 +16,8 @@ int main() {
   memchr("hello", 0, 6);
   strchr("hello", 'z');
   strlen("hello");
-  return ((f(x) + y[9]) % 16) + 1;
+
+  printf("%d %d\n", f(x), y[9]);
+  printf("done\n");
+  return 0;
 }

--- a/test/core/test_asan_no_error.cpp
+++ b/test/core/test_asan_no_error.cpp
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdio.h>
 
 int f(int *x) {
   int z = *x;
@@ -9,5 +10,8 @@ int f(int *x) {
 int main() {
   int *x = new int[10];
   static char y[10];
-  return ((f(x) + y[9]) % 16) + 1;
+
+  printf("%d %d\n", f(x), y[9]);
+  printf("done\n");
+  return 0;
 }

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8958,9 +8958,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     'cpp': ['test_asan_no_error.cpp'],
   })
   def test_asan_no_error(self, name):
-    self.set_setting('ALLOW_MEMORY_GROWTH')
-    self.set_setting('INITIAL_MEMORY', '300mb')
-    self.do_runf('core/' + name, '', assert_returncode=NON_ZERO, cflags=['-fsanitize=address'])
+    self.do_runf('core/' + name, 'done\n', cflags=['-fsanitize=address'])
 
   # note: these tests have things like -fno-builtin-memset in order to avoid
   # clang optimizing things away. for example, a memset might be optimized into


### PR DESCRIPTION
- Remove unnecessary command line flags
- Check for test output
- Return 0 from test (otherwise we don't actually detect asan failures).
- Restore final checks to before #11578