### PR TITLE
Disable word-at-a-time optimization in mbsrtowcs when using ASan

### DIFF
--- a/system/lib/libc/musl/src/multibyte/mbsrtowcs.c
+++ b/system/lib/libc/musl/src/multibyte/mbsrtowcs.c
@@ -38,7 +38,7 @@ size_t mbsrtowcs(wchar_t *restrict ws, const char **restrict src, size_t wn, mbs
 	}
 
 	if (!ws) for (;;) {
-#ifdef __GNUC__
+#if defined(__GNUC__) && !__has_feature(address_sanitizer)
 		typedef uint32_t __attribute__((__may_alias__)) w32;
 		if (*s-1u < 0x7f && (uintptr_t)s%4 == 0) {
 			while (!(( *(w32*)s | *(w32*)s-0x01010101) & 0x80808080)) {
@@ -72,7 +72,7 @@ resume0:
 			*src = (const void *)s;
 			return wn0;
 		}
-#ifdef __GNUC__
+#if defined(__GNUC__) && !__has_feature(address_sanitizer)
 		typedef uint32_t __attribute__((__may_alias__)) w32;
 		if (*s-1u < 0x7f && (uintptr_t)s%4 == 0) {
 			while (wn>=5 && !(( *(w32*)s | *(w32*)s-0x01010101) & 0x80808080)) {

--- a/system/lib/libc/musl/src/multibyte/mbsrtowcs.c
+++ b/system/lib/libc/musl/src/multibyte/mbsrtowcs.c
@@ -38,6 +38,7 @@ size_t mbsrtowcs(wchar_t *restrict ws, const char **restrict src, size_t wn, mbs
 	}
 
 	if (!ws) for (;;) {
+/* XXX EMSCRIPTEN: add __has_feature check */
 #if defined(__GNUC__) && !__has_feature(address_sanitizer)
 		typedef uint32_t __attribute__((__may_alias__)) w32;
 		if (*s-1u < 0x7f && (uintptr_t)s%4 == 0) {
@@ -72,6 +73,7 @@ resume0:
 			*src = (const void *)s;
 			return wn0;
 		}
+/* XXX EMSCRIPTEN: add __has_feature check */
 #if defined(__GNUC__) && !__has_feature(address_sanitizer)
 		typedef uint32_t __attribute__((__may_alias__)) w32;
 		if (*s-1u < 0x7f && (uintptr_t)s%4 == 0) {

--- a/test/core/test_asan_no_error.c
+++ b/test/core/test_asan_no_error.c
@@ -19,7 +19,7 @@ int main() {
   strchr("hello", 'z');
   strlen("hello");
 
-  // setlocale is needed here otherwise mbsrtowcs takes the fastcopy
+  // setlocale is needed here otherwise mbsrtowcs takes the fast path
   // via strcpy.
   setlocale(LC_ALL, "en_US.UTF-8");
   const char* s = "abcd";

--- a/test/core/test_asan_no_error.c
+++ b/test/core/test_asan_no_error.c
@@ -1,6 +1,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <wchar.h>
+#include <locale.h>
 
 int f(char *x) {
   int z = *x;
@@ -16,6 +18,12 @@ int main() {
   memchr("hello", 0, 6);
   strchr("hello", 'z');
   strlen("hello");
+
+  // setlocale is needed here otherwise mbsrtowcs takes the fastcopy
+  // via strcpy.
+  setlocale(LC_ALL, "en_US.UTF-8");
+  const char* s = "abcd";
+  mbsrtowcs(NULL, &s, 0, NULL);
 
   printf("%d %d\n", f(x), y[9]);
   printf("done\n");


### PR DESCRIPTION
This optimization can cause ASan to report global-buffer-overflow because it reads up to 3 bytes past the end of the input string when checking for null terminators or non-ASCII characters.

We already do this for several other musl functions such as strlen, stpcpy, and memchr.

Also updates test_asan_no_error.c to include a regression check.

Fixes: #26657