### PR TITLE
Allow use of builtin Node WebSocket when available

### DIFF
--- a/src/lib/libsockfs.js
+++ b/src/lib/libsockfs.js
@@ -212,17 +212,13 @@ addToLibrary({
 #if SOCKET_DEBUG
             dbg(`websocket: connect: ${url}, ${subProtocols.toString()}`);
 #endif
+#if MIN_NODE_VERSION < 220400
             // If node we use the ws library.
-            var WebSocketConstructor;
-#if ENVIRONMENT_MAY_BE_NODE
-            if (ENVIRONMENT_IS_NODE) {
-              WebSocketConstructor = /** @type{(typeof WebSocket)} */(require('ws'));
-            } else
-#endif // ENVIRONMENT_MAY_BE_NODE
-            {
-              WebSocketConstructor = WebSocket;
+            if (ENVIRONMENT_IS_NODE && !globalThis.WebSocket) {
+              globalThis.WebSocket = /** @type{(typeof WebSocket)} */(require('ws'));
             }
-            ws = new WebSocketConstructor(url, opts);
+#endif // MIN_NODE_VERSION < 220400
+            ws = new WebSocket(url, opts);
             ws.binaryType = 'arraybuffer';
           } catch (e) {
 #if SOCKET_DEBUG
@@ -338,8 +334,8 @@ addToLibrary({
           SOCKFS.emit('message', sock.stream.fd);
         }
 
-#if ENVIRONMENT_MAY_BE_NODE
-        if (ENVIRONMENT_IS_NODE) {
+#if MIN_NODE_VERSION < 220400
+        if (ENVIRONMENT_IS_NODE && peer.socket.on) {
            // EventEmitter-style events use by ws library objects in Node.js).
           peer.socket.on('open', handleOpen);
           peer.socket.on('message', (data, isBinary) => {
@@ -511,10 +507,12 @@ addToLibrary({
         sock.connecting = true;
       },
       listen(sock, backlog) {
+#if !ENVIRONMENT_MAY_BE_NODE
+        throw new FS.ErrnoError({{{ cDefs.EOPNOTSUPP }}});
+#else
         if (!ENVIRONMENT_IS_NODE) {
           throw new FS.ErrnoError({{{ cDefs.EOPNOTSUPP }}});
         }
-#if ENVIRONMENT_MAY_BE_NODE
         if (sock.server) {
            throw new FS.ErrnoError({{{ cDefs.EINVAL }}});  // already listening
         }

--- a/src/lib/libsockfs.js
+++ b/src/lib/libsockfs.js
@@ -252,17 +252,13 @@ addToLibrary({
 #if SOCKET_DEBUG
             dbg(`websocket: connect: ${url}, ${subProtocols.toString()}`);
 #endif
+#if MIN_NODE_VERSION < 220400
             // If node we use the ws library.
-            var WebSocketConstructor;
-#if ENVIRONMENT_MAY_BE_NODE
-            if (ENVIRONMENT_IS_NODE) {
-              WebSocketConstructor = /** @type{(typeof WebSocket)} */(require('ws'));
-            } else
-#endif // ENVIRONMENT_MAY_BE_NODE
-            {
-              WebSocketConstructor = WebSocket;
+            if (ENVIRONMENT_IS_NODE && !globalThis.WebSocket) {
+              globalThis.WebSocket = /** @type{(typeof WebSocket)} */(require('ws'));
             }
-            ws = new WebSocketConstructor(url, opts);
+#endif // MIN_NODE_VERSION < 220400
+            ws = new WebSocket(url, opts);
             ws.binaryType = 'arraybuffer';
           } catch (e) {
 #if SOCKET_DEBUG
@@ -378,8 +374,8 @@ addToLibrary({
           SOCKFS.emit('message', sock.stream.fd);
         }
 
-#if ENVIRONMENT_MAY_BE_NODE
-        if (ENVIRONMENT_IS_NODE) {
+#if MIN_NODE_VERSION < 220400
+        if (ENVIRONMENT_IS_NODE && peer.socket.on) {
            // EventEmitter-style events use by ws library objects in Node.js).
           peer.socket.on('open', handleOpen);
           peer.socket.on('message', (data, isBinary) => {
@@ -552,10 +548,12 @@ addToLibrary({
         sock.connecting = true;
       },
       listen(sock, backlog) {
+#if !ENVIRONMENT_MAY_BE_NODE
+        throw new FS.ErrnoError({{{ cDefs.EOPNOTSUPP }}});
+#else
         if (!ENVIRONMENT_IS_NODE) {
           throw new FS.ErrnoError({{{ cDefs.EOPNOTSUPP }}});
         }
-#if ENVIRONMENT_MAY_BE_NODE
         if (sock.server) {
            throw new FS.ErrnoError({{{ cDefs.EINVAL }}});  // already listening
         }

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 244238,
+  "a.out.js": 244296,
   "a.out.nodebug.wasm": 577664,
-  "total": 821902,
+  "total": 821960,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/sockets/test_sockets_echo_client.c
+++ b/test/sockets/test_sockets_echo_client.c
@@ -257,7 +257,7 @@ int main() {
     sprintf(buffer, "%s:%u", inet_ntoa(adr_inet.sin_addr), (unsigned)ntohs(adr_inet.sin_port));
     // TODO: This is not the correct result: We should have a auto-bound address
     char *correct = "0.0.0.0:0";
-    printf("got (expected) socket: %s (%s), size %lu (%lu)\n", buffer, correct, strlen(buffer), strlen(correct));
+    printf("getsockname: %s (%s), size %lu (%lu)\n", buffer, correct, strlen(buffer), strlen(correct));
     assert(strlen(buffer) == strlen(correct));
     assert(strcmp(buffer, correct) == 0);
   }
@@ -275,7 +275,7 @@ int main() {
     sprintf(buffer, "%s:%u", inet_ntoa(adr_inet.sin_addr), (unsigned)ntohs(adr_inet.sin_port));
     char correct[1000];
     sprintf(correct, "127.0.0.1:%u", SOCKK);
-    printf("got (expected) socket: %s (%s), size %lu (%lu)\n", buffer, correct, strlen(buffer), strlen(correct));
+    printf("getpeername: %s (%s), size %lu (%lu)\n", buffer, correct, strlen(buffer), strlen(correct));
     assert(strlen(buffer) == strlen(correct));
     assert(strcmp(buffer, correct) == 0);
   }


### PR DESCRIPTION
Node v21 and up have native WebSocket support.  This change makes the import of the external `ws` module conditional so it will only run on older versions of node.

See #26676