### PR TITLE
Use uint8_t for boolean values in `pthead_impl`. NFC

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -1284,8 +1284,7 @@ var LibraryPThread = {
       assert(wait.async);
 #endif
       wait.value.then(checkMailbox);
-      var waitingAsync = pthread_ptr + {{{ C_STRUCTS.pthread.waiting_async }}};
-      Atomics.store(HEAP32, {{{ getHeapOffset('waitingAsync', 'i32') }}}, 1);
+      Atomics.store(HEAPU8, pthread_ptr + {{{ C_STRUCTS.pthread.waiting_async }}}, 1);
     }
     // If `Atomics.waitAsync` is not implemented, then we will always fall back
     // to postMessage and there is no need to do anything here.

--- a/system/lib/libc/musl/src/internal/pthread_impl.h
+++ b/system/lib/libc/musl/src/internal/pthread_impl.h
@@ -110,7 +110,7 @@ struct pthread {
 	// to initialize itself yet, the notification has to fall back to the
 	// postMessage path. Once this becomes true, it remains true so we never
 	// fall back to postMessage unnecessarily.
-	_Atomic int waiting_async;
+	_Atomic uint8_t waiting_async;
 	// The address the thread is currently waiting on in emscripten_futex_wait.
 	//
 	// This field encodes the state using the following bitmask:
@@ -126,7 +126,7 @@ struct pthread {
 	// When dynamic linking is enabled, threads use this to facilitate the
 	// synchronization of loaded code between threads.
 	// See emscripten_futex_wait.c.
-	_Atomic char sleeping;
+	_Atomic uint8_t sleeping;
 #endif
 };
 

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7367,
-  "a.out.js.gz": 3603,
+  "a.out.js": 7371,
+  "a.out.js.gz": 3609,
   "a.out.nodebug.wasm": 19075,
-  "a.out.nodebug.wasm.gz": 8818,
-  "total": 26442,
-  "total_gz": 12421,
+  "a.out.nodebug.wasm.gz": 8822,
+  "total": 26446,
+  "total_gz": 12431,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7769,
-  "a.out.js.gz": 3809,
+  "a.out.js": 7763,
+  "a.out.js.gz": 3806,
   "a.out.nodebug.wasm": 19076,
-  "a.out.nodebug.wasm.gz": 8819,
-  "total": 26845,
-  "total_gz": 12628,
+  "a.out.nodebug.wasm.gz": 8823,
+  "total": 26839,
+  "total_gz": 12629,
   "sent": [
     "a (memory)",
     "b (exit)",


### PR DESCRIPTION
This is kind of wash for codesize but a win for readability I think.