### PR TITLE
Remove redundant `sleeping` field from pthread struct. NFC

### DIFF
--- a/system/lib/libc/dynlink.c
+++ b/system/lib/libc/dynlink.c
@@ -16,6 +16,7 @@
 #include <threads.h>
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -29,6 +30,7 @@
 
 #include "dynlink.h"
 #include "pthread_impl.h"
+#include "threading_internal.h"
 #include "emscripten_internal.h"
 
 //#define DYLINK_DEBUG
@@ -406,13 +408,9 @@ int _emscripten_proxy_dlsync_async(pthread_t target_thread, em_promise_t promise
     emscripten_promise_resolve(promise, EM_PROMISE_FULFILL, NULL);
     emscripten_promise_destroy(promise);
     free(info);
-  } else if (target_thread->sleeping) {
-    // If the target thread is in the sleeping state (and this check is
-    // performed after the enqueuing of the async work) then we know its safe to
-    // resolve the promise early, since the thread will process our event as
-    // soon as it wakes up.
-    emscripten_promise_resolve(promise, EM_PROMISE_FULFILL, NULL);
-    return 0;
+  } else {
+    // Wake up the target thread in case its blocked in futex_wait
+    _emscripten_thread_notify(target_thread);
   }
   return rtn;
 }

--- a/system/lib/libc/dynlink.c
+++ b/system/lib/libc/dynlink.c
@@ -409,7 +409,7 @@ int _emscripten_proxy_dlsync_async(pthread_t target_thread, em_promise_t promise
     emscripten_promise_destroy(promise);
     free(info);
   } else {
-    // Wake up the target thread in case its blocked in futex_wait
+    // Wake up the target thread in case it's blocked in futex_wait
     _emscripten_thread_notify(target_thread);
   }
   return rtn;

--- a/system/lib/libc/musl/src/internal/pthread_impl.h
+++ b/system/lib/libc/musl/src/internal/pthread_impl.h
@@ -122,12 +122,6 @@ struct pthread {
 	// Since futex addresses must be 4-byte aligned, the low bit is safe to use.
 	_Atomic uintptr_t wait_addr;
 #endif
-#ifdef EMSCRIPTEN_DYNAMIC_LINKING
-	// When dynamic linking is enabled, threads use this to facilitate the
-	// synchronization of loaded code between threads.
-	// See emscripten_futex_wait.c.
-	_Atomic char sleeping;
-#endif
 };
 
 #ifdef __EMSCRIPTEN__

--- a/system/lib/pthread/emscripten_futex_wait.c
+++ b/system/lib/pthread/emscripten_futex_wait.c
@@ -173,12 +173,6 @@ int emscripten_futex_wait(volatile void *addr, uint32_t val, double max_wait_ms)
     max_wait_ns = (int64_t)(max_wait_ms * 1e6);
   }
 #ifdef __EMSCRIPTEN_PTHREADS__
-#ifdef EMSCRIPTEN_DYNAMIC_LINKING
-  if (!is_runtime_thread) {
-    self->sleeping = 1;
-    _emscripten_process_dlopen_queue();
-  }
-#endif
   uintptr_t expected_null = 0;
   if (atomic_compare_exchange_strong(&self->wait_addr, &expected_null, (uintptr_t)addr)) {
     DBG("emscripten_futex_wait atomic.wait ns=%lld", max_wait_ns);
@@ -197,7 +191,6 @@ int emscripten_futex_wait(volatile void *addr, uint32_t val, double max_wait_ms)
   self->wait_addr = 0;
 #ifdef EMSCRIPTEN_DYNAMIC_LINKING
   if (!is_runtime_thread) {
-    self->sleeping = 0;
     _emscripten_process_dlopen_queue();
   }
 #endif


### PR DESCRIPTION
The `sleeping` field was used to synchronize dlopen between threads, but it is now redundant since the implementation of precise futex wakeups in #26659. The `wait_addr` field now provides the same information (whether a thread is currently blocked).

We now simply call `_emscripten_thread_notify` for every thread when proxying dlopen sync events. This ensures that threads process the dlopen catch-up queue promptly, even without the periodic 100ms wakeups that were removed in #26659.

This change:
1. Removes the `sleeping` field from struct pthread.
2. Updates `emscripten_futex_wait` to no longer set/clear the sleeping field.
3. Removes a redundant `_emscripten_process_dlopen_queue` call in `emscripten_futex_wait`. (One remains at the end of the function, and one is called via `emscripten_yield` at the start).
4. Updates `dynlink.c` to use `_emscripten_thread_notify`.
