### PR TITLE
[pthreads] Fix memory leak in mailbox await loop during shutdown

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -86,6 +86,9 @@ var LibraryPThread = {
                    '$spawnThread',
                    '_emscripten_thread_free_data',
                    'exit',
+                   'pthread_self',
+                   '__set_thread_state',
+                   '$waitAsyncPolyfilled',
 #if PTHREADS_DEBUG || ASSERTIONS
                    '$ptrToString',
 #endif
@@ -190,6 +193,22 @@ var LibraryPThread = {
       PThread.runningWorkers = [];
       PThread.pthreads = {};
     },
+
+    terminateRuntime: () => {
+#if ASSERTIONS
+      assert(!ENVIRONMENT_IS_PTHREAD, 'terminateRuntime() can only ever be called from main application thread!');
+#endif
+      PThread.terminateAllThreads();
+      var pthread_ptr = _pthread_self();
+      ___set_thread_state(0, 0, 0, 1);
+      if (!waitAsyncPolyfilled) {
+        // Break the waitAsync loop.  Note that checkMailbox will not
+        // re-register since the `___set_thread_state` above causes _pthread_self
+        // to return 0.
+        Atomics.notify(HEAP32, {{{ getHeapOffset('pthread_ptr', 'i32') }}});
+      }
+    },
+
     returnWorkerToPool: (worker) => {
       // We don't want to run main thread queued calls here, since we are doing
       // some operations that leave the worker queue in an invalid state until

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -15,7 +15,7 @@
 function exitRuntime(ret) {
   <<< ATEXITS >>>
 #if PTHREADS
-  PThread.terminateAllThreads();
+  PThread.terminateRuntime();
 #endif
 
 #if ASSERTIONS

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -208,7 +208,7 @@ function exitRuntime() {
 #endif
   <<< ATEXITS >>>
 #if PTHREADS
-  PThread.terminateAllThreads();
+  PThread.terminateRuntime();
 #endif
   runtimeExited = true;
 }

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7367,
-  "a.out.js.gz": 3603,
-  "a.out.nodebug.wasm": 19075,
-  "a.out.nodebug.wasm.gz": 8818,
-  "total": 26442,
-  "total_gz": 12421,
+  "a.out.js.gz": 3605,
+  "a.out.nodebug.wasm": 19079,
+  "a.out.nodebug.wasm.gz": 8824,
+  "total": 26446,
+  "total_gz": 12429,
   "sent": [
     "a (memory)",
     "b (exit)",
@@ -38,13 +38,14 @@
     "n (__pthread_create_js)"
   ],
   "exports": [
-    "A (_emscripten_thread_free_data)",
-    "B (_emscripten_thread_exit)",
-    "C (_emscripten_check_mailbox)",
-    "D (emscripten_stack_set_limits)",
-    "E (_emscripten_stack_restore)",
-    "F (_emscripten_stack_alloc)",
-    "G (emscripten_stack_get_current)",
+    "A (_emscripten_run_js_on_main_thread)",
+    "B (_emscripten_thread_free_data)",
+    "C (_emscripten_thread_exit)",
+    "D (_emscripten_check_mailbox)",
+    "E (emscripten_stack_set_limits)",
+    "F (_emscripten_stack_restore)",
+    "G (_emscripten_stack_alloc)",
+    "H (emscripten_stack_get_current)",
     "o (__wasm_call_ctors)",
     "p (add)",
     "q (main)",
@@ -54,9 +55,9 @@
     "u (pthread_self)",
     "v (_emscripten_proxy_main)",
     "w (_emscripten_thread_init)",
-    "x (_emscripten_thread_crashed)",
-    "y (_emscripten_run_js_on_main_thread_done)",
-    "z (_emscripten_run_js_on_main_thread)"
+    "x (__set_thread_state)",
+    "y (_emscripten_thread_crashed)",
+    "z (_emscripten_run_js_on_main_thread_done)"
   ],
   "funcs": [
     "$__errno_location",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7769,
-  "a.out.js.gz": 3809,
-  "a.out.nodebug.wasm": 19076,
-  "a.out.nodebug.wasm.gz": 8819,
-  "total": 26845,
-  "total_gz": 12628,
+  "a.out.js.gz": 3811,
+  "a.out.nodebug.wasm": 19080,
+  "a.out.nodebug.wasm.gz": 8825,
+  "total": 26849,
+  "total_gz": 12636,
   "sent": [
     "a (memory)",
     "b (exit)",
@@ -38,13 +38,14 @@
     "n (__pthread_create_js)"
   ],
   "exports": [
-    "A (_emscripten_thread_free_data)",
-    "B (_emscripten_thread_exit)",
-    "C (_emscripten_check_mailbox)",
-    "D (emscripten_stack_set_limits)",
-    "E (_emscripten_stack_restore)",
-    "F (_emscripten_stack_alloc)",
-    "G (emscripten_stack_get_current)",
+    "A (_emscripten_run_js_on_main_thread)",
+    "B (_emscripten_thread_free_data)",
+    "C (_emscripten_thread_exit)",
+    "D (_emscripten_check_mailbox)",
+    "E (emscripten_stack_set_limits)",
+    "F (_emscripten_stack_restore)",
+    "G (_emscripten_stack_alloc)",
+    "H (emscripten_stack_get_current)",
     "o (__wasm_call_ctors)",
     "p (add)",
     "q (main)",
@@ -54,9 +55,9 @@
     "u (pthread_self)",
     "v (_emscripten_proxy_main)",
     "w (_emscripten_thread_init)",
-    "x (_emscripten_thread_crashed)",
-    "y (_emscripten_run_js_on_main_thread_done)",
-    "z (_emscripten_run_js_on_main_thread)"
+    "x (__set_thread_state)",
+    "y (_emscripten_thread_crashed)",
+    "z (_emscripten_run_js_on_main_thread_done)"
   ],
   "funcs": [
     "$__errno_location",

--- a/test/pthread/test_pthread_mem_leak_post.js
+++ b/test/pthread/test_pthread_mem_leak_post.js
@@ -1,0 +1,35 @@
+async function run() {
+  console.log('START');
+  let bufferCollected = false;
+  const registry = new FinalizationRegistry(() => {
+    bufferCollected = true;
+  });
+
+  await (async () => {
+    const instance = await Module();
+    console.log('GOT INSTANCE');
+    // Once this scope exits we expect the instance and its memory to be
+    // collected.
+    registry.register(instance.wasmMemory.buffer, "wasmMemory");
+  })();
+
+  // Force GC
+  const assert = require('node:assert/strict');
+  assert(global.gc);
+  for (let i = 0; i < 20; i++) {
+    global.gc();
+    await new Promise(r => setTimeout(r, 50));
+    if (bufferCollected) break;
+  }
+
+  if (bufferCollected) {
+    console.log('SUCCESS: No leak detected');
+    process.exit(0);
+  } else {
+    console.log('FAILURE: Leak detected');
+    process.exit(1);
+  }
+}
+
+if (!isPthread)
+  run();

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11753,6 +11753,16 @@ int main(void) {
     expected = ['got: hello world string, longer than 16 chars', 'pthread_create: environment does not support SharedArrayBuffer, pthreads are not available']
     self.do_runf('hello_world.c', expected, assert_all=True, assert_returncode=NON_ZERO, cflags=['--pre-js=pre.js'])
 
+  @requires_node
+  @requires_pthreads
+  def test_pthread_mem_leak(self):
+    self.set_setting('MODULARIZE')
+    self.set_setting('EXIT_RUNTIME')
+    self.set_setting('EXPORTED_RUNTIME_METHODS', ['wasmMemory'])
+    self.node_args.append('--expose-gc')
+    self.cflags += ['--extern-post-js', test_file('pthread/test_pthread_mem_leak_post.js')]
+    self.do_runf('hello_world.c', 'SUCCESS: No leak detected', cflags=['-pthread'])
+
   def test_stdin_preprocess(self):
     create_file('temp.h', '#include <string>')
     outputStdin = self.run_process([EMCC, '-x', 'c++', '-dM', '-E', '-'], input="#include <string>", stdout=PIPE).stdout


### PR DESCRIPTION
Introduce PThread.terminateRuntime which is called during runtime exit. This function not only terminates all workers but also clears the thread state of the main thread and sends a final notification to its mailbox.

By clearing the thread state, _pthread_self() will now return 0, which causes the mailbox checking loop to terminate instead of re-registering a new Atomics.waitAsync promise. This allows the Wasm memory and module instance to be garbage collected.

Fixes: #20920