### PR TITLE
Simplify emscripten_futex_wait after recent changes. NFC

### DIFF
--- a/system/lib/pthread/emscripten_futex_wait.c
+++ b/system/lib/pthread/emscripten_futex_wait.c
@@ -155,11 +155,6 @@ int emscripten_futex_wait(volatile void *addr, uint32_t val, double max_wait_ms)
     return ret;
   }
 
-  // Pass 0 here, which means we don't have access to the current time in this
-  // function.  This tells _emscripten_yield to call emscripten_get_now if (and
-  // only if) it needs to know the time.
-  _emscripten_yield(0);
-
   DBG("emscripten_futex_wait ms=%f", max_wait_ms);
 
   bool is_runtime_thread = emscripten_is_main_runtime_thread();
@@ -189,11 +184,12 @@ int emscripten_futex_wait(volatile void *addr, uint32_t val, double max_wait_ms)
   // Clear the wait_addr
   DBG("emscripten_futex_wait done notify=%d cancelable=%d cancel=%d", !!(self->wait_addr & NOTIFY_BIT), cancelable, self->cancel);
   self->wait_addr = 0;
-#ifdef EMSCRIPTEN_DYNAMIC_LINKING
-  if (!is_runtime_thread) {
-    _emscripten_process_dlopen_queue();
-  }
-#endif
+
+  // Pass 0 here, which means we don't have access to the current time in this
+  // function.  This tells _emscripten_yield to call emscripten_get_now if (and
+  // only if) it needs to know the time.
+  _emscripten_yield(0);
+
   if (cancelable && self->cancel) {
     __pthread_testcancel();
     // If __pthread_testcancel does return here it means that canceldisable

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -2,9 +2,9 @@
   "a.out.js": 7367,
   "a.out.js.gz": 3605,
   "a.out.nodebug.wasm": 19079,
-  "a.out.nodebug.wasm.gz": 8824,
+  "a.out.nodebug.wasm.gz": 8825,
   "total": 26446,
-  "total_gz": 12429,
+  "total_gz": 12430,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -2,9 +2,9 @@
   "a.out.js": 7769,
   "a.out.js.gz": 3811,
   "a.out.nodebug.wasm": 19080,
-  "a.out.nodebug.wasm.gz": 8825,
+  "a.out.nodebug.wasm.gz": 8826,
   "total": 26849,
-  "total_gz": 12636,
+  "total_gz": 12637,
   "sent": [
     "a (memory)",
     "b (exit)",


### PR DESCRIPTION
As a followup to #26691 and #26659 we can simplify `emscripten_futex_wait` even further removing all references to `_emscripten_process_dlopen_queue`.

Instead we move the call to `emscripten_yield()` until after the `atomic.wait` operation (or the skipping of it).  `emscripten_yield()` then takes care of calling `_emscripten_process_dlopen_queue` as needed.