### PR TITLE
Remove checks for window.scrollX / window.scrollY

### DIFF
--- a/src/lib/libbrowser.js
+++ b/src/lib/libbrowser.js
@@ -397,18 +397,8 @@ var LibraryBrowser = {
       var canvas = Browser.getCanvas();
       var rect = canvas.getBoundingClientRect();
 
-      // Neither .scrollX or .pageXOffset are defined in a spec, but
-      // we prefer .scrollX because it is currently in a spec draft.
-      // (see: http://www.w3.org/TR/2013/WD-cssom-view-20131217/)
-      var scrollX = ((typeof window.scrollX != 'undefined') ? window.scrollX : window.pageXOffset);
-      var scrollY = ((typeof window.scrollY != 'undefined') ? window.scrollY : window.pageYOffset);
-#if ASSERTIONS
-      // If this assert lands, it's likely because the browser doesn't support scrollX or pageXOffset
-      // and we have no viable fallback.
-      assert((typeof scrollX != 'undefined') && (typeof scrollY != 'undefined'), 'Unable to retrieve scroll position, mouse positions likely broken.');
-#endif
-      var adjustedX = pageX - (scrollX + rect.left);
-      var adjustedY = pageY - (scrollY + rect.top);
+      var adjustedX = pageX - (window.scrollX + rect.left);
+      var adjustedY = pageY - (window.scrollY + rect.top);
 
       // the canvas might be CSS-scaled compared to its backbuffer;
       // SDL-using content will want mouse coordinates in terms

--- a/src/lib/libglfw.js
+++ b/src/lib/libglfw.js
@@ -1320,18 +1320,8 @@ var LibraryGLFW = {
       // in the coordinates.
       const rect = Browser.getCanvas().getBoundingClientRect();
 
-      // Neither .scrollX or .pageXOffset are defined in a spec, but
-      // we prefer .scrollX because it is currently in a spec draft.
-      // (see: http://www.w3.org/TR/2013/WD-cssom-view-20131217/)
-      var scrollX = ((typeof window.scrollX != 'undefined') ? window.scrollX : window.pageXOffset);
-      var scrollY = ((typeof window.scrollY != 'undefined') ? window.scrollY : window.pageYOffset);
-#if ASSERTIONS
-      // If this assert lands, it's likely because the browser doesn't support scrollX or pageXOffset
-      // and we have no viable fallback.
-      assert((typeof scrollX != 'undefined') && (typeof scrollY != 'undefined'), 'Unable to retrieve scroll position, mouse positions likely broken.');
-#endif
-      var adjustedX = pageX - (scrollX + rect.left);
-      var adjustedY = pageY - (scrollY + rect.top);
+      var adjustedX = pageX - (window.scrollX + rect.left);
+      var adjustedY = pageY - (window.scrollY + rect.top);
 
       // getBoundingClientRect() returns dimension affected by CSS, so as a result:
       // - when CSS scaling is enabled, this will fix the mouse coordinates to match the width/height of the window

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 244303,
+  "a.out.js": 244191,
   "a.out.nodebug.wasm": 577664,
-  "total": 821967,
+  "total": 821855,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
The last time these checks were needed was back in the IE 8 days AFAICT.