### PR TITLE
Enable JSPI in Firefox in emrun.

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -317,6 +317,8 @@ user_pref("gfx.offscreencanvas.enabled", true);
 user_pref("javascript.options.wasm_memory64", true);
 // Do not ask user consent to enable audio playback (0: Allow autoplay for all media)
 user_pref("media.autoplay.default", 0);
+// Enable JSPI support
+user_pref("javascript.options.wasm_js_promise_integration", true);
 ''')
     if emrun_options.private_browsing:
       f.write('''


### PR DESCRIPTION
JSPI is not yet enabled by default in Firefox, so enable it to be able to use emrun to test JSPI compiled Emscripten pages.