### PR TITLE
Fix for mktime + ASSERTIONS=2

### DIFF
--- a/src/lib/libtime.js
+++ b/src/lib/libtime.js
@@ -17,6 +17,9 @@ addToLibrary({
                         {{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_min, 'i32') }}},
                         {{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_sec, 'i32') }}},
                         0);
+    if (isNaN(date.getTime())) {
+      return -1;
+    }
 
     // There's an ambiguous hour when the time goes back; the tm_isdst field is
     // used to disambiguate it.  Date() basically guesses, so we fix it up if it
@@ -48,12 +51,8 @@ addToLibrary({
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_mon, 'date.getMonth()', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_year, 'date.getYear()', 'i32') }}};
 
-    var timeMs = date.getTime();
-    if (isNaN(timeMs)) {
-      return -1;
-    }
-    // Return time in microseconds
-    return timeMs / 1000;
+    // Return time in seconds
+    return date.getTime() / 1000;
   },
 
   _gmtime_js__i53abi: true,

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 244278,
+  "a.out.js": 244303,
   "a.out.nodebug.wasm": 577664,
-  "total": 821942,
+  "total": 821967,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/other/test_time.c
+++ b/test/other/test_time.c
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <time.h>
 #include <string.h>
 #include <assert.h>
@@ -27,7 +28,7 @@ void check_gmtime_localtime(time_t time) {
   assert(loc);
   assert(strftime(locbuf, sizeof(locbuf) - 1, fmt, loc) > 0);
 
-  printf("time: %lld, gmtime: %s\n", time, gmbuf);
+  printf("time: %jd, gmtime: %s\n", (intmax_t)time, gmbuf);
 
   // gmtime and localtime should be equal when timezone is UTC
   assert(timezone != 0 || strcmp(gmbuf, locbuf) == 0);
@@ -218,12 +219,28 @@ void test_yday() {
 }
 
 void test_year_overflow() {
-  // Verify that timestamps outside of the range supported by date.getNow()
-  // cause failure with EOVERFLOW.
+  // Verify that timestamps outside of the range supported JavaScript Date
+  // object with result in a graceful failure with EOVERFLOW.
   struct tm tm_big = {0};
-  tm_big.tm_year = 292278994;
+  // The range of is approximately 273,790 years from the epoc in either
+  // direction.
+  tm_big.tm_year = 300000;
+  struct tm tm_big_copy = tm_big;
+  errno = 0;
   time_t tbig = mktime(&tm_big);
-  assert((tbig == -1 && errno == EOVERFLOW) || tbig == 9223431975273600);
+#if defined(__EMSCRIPTEN__) && !defined(STANDALONE)
+  assert(tbig == -1);
+  assert(errno == EOVERFLOW);
+  // When mktime fails with EOVERFLOW it should not touch the bits of
+  // its argument.
+  assert(memcmp(&tm_big, &tm_big_copy, sizeof(tm_big)) == 0);
+#else
+  // Outside of emscripten, or in standalone mode mktime can support larger
+  // values like this. According to the C standard, the range of tm_year (and
+  // time_t) is implementation-defined
+  assert(errno == 0);
+  assert(tbig > 9464876000000);
+#endif
 }
 
 void test_difftime() {

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -5604,7 +5604,9 @@ int main()
 
   @also_with_standalone_wasm(impure=True)
   def test_time(self):
-    self.do_other_test('test_time.c')
+    if self.get_setting('STANDALONE_WASM'):
+      self.cflags.append('-DSTANDALONE')
+    self.do_other_test('test_time.c', cflags=['-sASSERTIONS=2'])
 
   @parameterized({
     '1': ('EST+05EDT',),


### PR DESCRIPTION
There were two issues with the existing code:

1. Values were being written even when the Data was invalid.
2. In ASSERTIONS=2 these invalid values were causing assertions.

Fixes: #26704