### PR TITLE
Remove musl patch from dup3.c. NFC

### DIFF
--- a/system/lib/libc/musl/src/unistd/dup3.c
+++ b/system/lib/libc/musl/src/unistd/dup3.c
@@ -15,10 +15,8 @@ int __dup3(int old, int new, int flags)
 		if (flags & ~O_CLOEXEC) return __syscall_ret(-EINVAL);
 	}
 	while ((r=__syscall(SYS_dup2, old, new))==-EBUSY);
-#ifndef __EMSCRIPTEN__ // CLOEXEC makes no sense for a single process
 	if (r >= 0 && (flags & O_CLOEXEC))
 		__syscall(SYS_fcntl, new, F_SETFD, FD_CLOEXEC);
-#endif
 #else
 	while ((r=__syscall(SYS_dup3, old, new, flags))==-EBUSY);
 #endif


### PR DESCRIPTION
We no longer define `SYS_dup2` in emscripten as of #15418 so this patch is no longer doing anything useful.