### PR TITLE
Avoid error message on shutdown due to `checkMailbox`

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -1270,24 +1270,26 @@ var LibraryPThread = {
                         'pthread_self',
                         '_emscripten_check_mailbox',
                         '_emscripten_thread_mailbox_await'],
-  $checkMailbox: () => callUserCallback(() => {
-    // Only check the mailbox if we have a live pthread runtime. We implement
-    // pthread_self to return 0 if there is no live runtime.
-    //
-    // TODO(https://github.com/emscripten-core/emscripten/issues/25076):
-    // Is this check still needed?  `callUserCallback` is supposed to
-    // ensure the runtime is alive, and if `_pthread_self` is NULL then the
-    // runtime certainly is *not* alive, so this should be a redundant check.
+  $checkMailbox: () => {
+    // checkMailbox can be called after the pthread has shut down. See
+    // Pthread.terminateRuntime().
+    // In this case we return silently without re-registering using waitAsync.
+    // Perhaps there is a more universal way we can detect runtime has exited.
+    // TODO(https://github.com/emscripten-core/emscripten/issues/25076)
+#if ABORT_ON_WASM_EXCEPTIONS
+    if (ABORT) return;
+#endif
     var pthread_ptr = _pthread_self();
-    if (pthread_ptr) {
+    if (!pthread_ptr) return;
+    callUserCallback(() => {
       // If we are using Atomics.waitAsync as our notification mechanism, wait
       // for a notification before processing the mailbox to avoid missing any
       // work that could otherwise arrive after we've finished processing the
       // mailbox and before we're ready for the next notification.
       __emscripten_thread_mailbox_await(pthread_ptr);
       __emscripten_check_mailbox();
-    }
-  }),
+    });
+  },
 
   _emscripten_thread_mailbox_await__deps: ['$checkMailbox', '$waitAsyncPolyfilled'],
   _emscripten_thread_mailbox_await: (pthread_ptr) => {

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7330,
-  "a.out.js.gz": 3576,
+  "a.out.js": 7323,
+  "a.out.js.gz": 3573,
   "a.out.nodebug.wasm": 19095,
   "a.out.nodebug.wasm.gz": 8830,
-  "total": 26425,
-  "total_gz": 12406,
+  "total": 26418,
+  "total_gz": 12403,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7733,
-  "a.out.js.gz": 3783,
+  "a.out.js": 7726,
+  "a.out.js.gz": 3779,
   "a.out.nodebug.wasm": 19096,
   "a.out.nodebug.wasm.gz": 8831,
-  "total": 26829,
-  "total_gz": 12614,
+  "total": 26822,
+  "total_gz": 12610,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11699,7 +11699,8 @@ int main(void) {
     # Verify that we're unable to detach or join the proxied main thread
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
-    self.do_other_test('test_pthread_self_join_detach.c')
+    output = self.do_other_test('test_pthread_self_join_detach.c')
+    self.assertNotContained('user callback triggered after runtime exited', output)
 
   @requires_pthreads
   def test_pthread_asyncify(self):

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -938,7 +938,8 @@ def install_debug_wrapper(sym):
   # `__trap` can occur before the runtime is initialized since it is used in abort.
   # `emscripten_get_sbrk_ptr` can be called prior to runtime initialization by
   # the dynamic linking code.
-  return sym not in {'__trap', 'emscripten_get_sbrk_ptr'}
+  # `pthread_self` is used in `checkMailbox` after program shutdown.
+  return sym not in {'__trap', 'emscripten_get_sbrk_ptr', 'pthread_self'}
 
 
 def should_export(sym):


### PR DESCRIPTION
After #26692 landed the `checkMailbox` function is called during runtime exit in order to avoid the infinite waitAsync.  However, this was triggering: `user callback triggered after runtime exited or application aborted. Ignoring`

I also added `pthread_self` to the list of native functions that are not wrapped in `createExportWrapper`, to avoid that additional check.