### PR TITLE
[WasmFS] Fix closure-compiler incorrectly minifying readDirSync options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -769,6 +769,7 @@ jobs:
             wasmfs.test_fs_llseek
             wasmfs.test_fs_llseek_rawfs
             wasmfs.test_freetype
+            wasmfs.test_unistd_close_rawfs
             minimal0.test_utf
             minimal0.test_ubsan_full_stack_trace_gsource_map
             minimal0.test_static_variable

--- a/src/lib/libwasmfs_node.js
+++ b/src/lib/libwasmfs_node.js
@@ -60,9 +60,6 @@ var wasmFSNodeLibrary = {
     return wasmfsNodeFixStat(stat);
   },
 
-  // Ignore closure type errors due to outdated readdirSync annotations, see
-  // https://github.com/google/closure-compiler/pull/4093
-  _wasmfs_node_readdir__docs: '/** @suppress {checkTypes} */',
   _wasmfs_node_readdir__deps: [
     '$wasmfsTry',
     '$stackSave',

--- a/third_party/closure-compiler/node-externs/fs.js
+++ b/third_party/closure-compiler/node-externs/fs.js
@@ -284,10 +284,11 @@ fs.readdir = function(path, callback) {};
 
 /**
  * @param {string} path
- * @return {Array.<string>}
+ * @param {{withFileTypes: boolean}=} options
+ * @return {!Array.<string|!Object>}
  * @nosideeffects
  */
-fs.readdirSync = function(path) {};
+fs.readdirSync = function(path, options) {};
 
 /**
  * @param {*} fd


### PR DESCRIPTION
See #26736