### PR TITLE
Remove WASM_JS_TYPES setting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,8 @@ See docs/process.md for more on how version tagging works.
   wakeups. This was part of an internal change to improve inter-thread
   communication. (#26659)
 - mimalloc was updated to 3.3.1. (#26696)
+- The `WASM_JS_TYPES` setting was removed, as the corresponsing propsal was
+  pushed back to phase 1. (#26739)
 
 5.0.6 - 04/14/26
 ----------------

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -3357,19 +3357,6 @@ node/chrome.
 
 Default value: false
 
-.. _wasm_js_types:
-
-WASM_JS_TYPES
-=============
-
-Experimental support for WebAssembly js-types proposal.
-It's currently only available under a flag in certain browsers,
-so we disable it by default to save on code size.
-
-.. note:: This is an experimental setting
-
-Default value: false
-
 .. _cross_origin:
 
 CROSS_ORIGIN
@@ -3514,3 +3501,4 @@ for backwards compatibility with older versions:
  - ``NODEJS_CATCH_REJECTION``: No longer supported (Valid values: [0])
  - ``POLYFILL_OLD_MATH_FUNCTIONS``: No longer supported (Valid values: [0])
  - ``RELOCATABLE``: No longer supported (Valid values: [0])
+ - ``WASM_JS_TYPES``: No longer supported (Valid values: [0])

--- a/src/lib/libaddfunction.js
+++ b/src/lib/libaddfunction.js
@@ -17,39 +17,6 @@ addToLibrary({
     // but we don't care as it's only used in a temporary representation.
     return [(n % 128) | 128, n >> 7, ...arr];
   },
-#if WASM_JS_TYPES
-  // Converts a signature like 'vii' into a description of the wasm types, like
-  // { parameters: ['i32', 'i32'], results: [] }.
-  $sigToWasmTypes__internal: true,
-  $sigToWasmTypes: (sig) => {
-#if ASSERTIONS && !WASM_BIGINT
-    assert(!sig.includes('j'), 'i64 not permitted in function signatures when WASM_BIGINT is disabled');
-#endif
-    var typeNames = {
-      'i': 'i32',
-      'j': 'i64',
-      'f': 'f32',
-      'd': 'f64',
-      'e': 'externref',
-#if MEMORY64
-      'p': 'i64',
-#else
-      'p': 'i32',
-#endif
-    };
-    var type = {
-      parameters: [],
-      results: sig[0] == 'v' ? [] : [typeNames[sig[0]]]
-    };
-    for (var i = 1; i < sig.length; ++i) {
-#if ASSERTIONS
-      assert(sig[i] in typeNames, 'invalid signature char: ' + sig[i]);
-#endif
-      type.parameters.push(typeNames[sig[i]]);
-    }
-    return type;
-  },
-#endif
   $wasmTypeCodes__internal: true,
   // Note: using template literal here instead of plain object
   // because jsify serializes objects w/o quotes and Closure will then
@@ -81,26 +48,14 @@ addToLibrary({
   // Wraps a JS function as a wasm function with a given signature.
   $convertJsFunctionToWasm__deps: [
     '$uleb128EncodeWithLen',
-#if WASM_JS_TYPES
-    '$sigToWasmTypes',
-#endif
     '$generateTypePack'
   ],
   $convertJsFunctionToWasm: (func, sig) => {
 #if ASSERTIONS && !WASM_BIGINT
     assert(!sig.includes('j'), 'i64 not permitted in function signatures when WASM_BIGINT is disabled');
 #endif
-#if WASM_JS_TYPES
-    // If the type reflection proposal is available, use the new
-    // "WebAssembly.Function" constructor.
-    // Otherwise, construct a minimal wasm module importing the JS function and
-    // re-exporting it.
-    if (WebAssembly.Function) {
-      return new WebAssembly.Function(sigToWasmTypes(sig), func);
-    }
-#endif
-
-    // Rest of the module is static
+    // TODO: If the type reflection proposal ever makes progress we can use
+    // it here instead of creatign a new module.
     var bytes = Uint8Array.of(
       0x00, 0x61, 0x73, 0x6d, // magic ("\0asm")
       0x01, 0x00, 0x00, 0x00, // version: 1

--- a/src/settings.js
+++ b/src/settings.js
@@ -2207,12 +2207,6 @@ var JS_BASE64_API = false;
 // [link]
 var GROWABLE_ARRAYBUFFERS = false;
 
-// Experimental support for WebAssembly js-types proposal.
-// It's currently only available under a flag in certain browsers,
-// so we disable it by default to save on code size.
-// [experimental]
-var WASM_JS_TYPES = false;
-
 // If the emscripten-generated program is hosted on separate origin then
 // starting new pthread worker can violate CSP rules.  Enabling
 // CROSS_ORIGIN uses an inline worker to instead load the worker script

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -151,7 +151,6 @@ INCOMPATIBLE_SETTINGS = [
 
 EXPERIMENTAL_SETTINGS = {
     'SPLIT_MODULE': '-sSPLIT_MODULE is experimental and subject to change',
-    'WASM_JS_TYPES': '-sWASM_JS_TYPES is only supported under a flag in certain browsers',
     'SOURCE_PHASE_IMPORTS': '-sSOURCE_PHASE_IMPORTS is experimental and not yet supported in browsers',
     'JS_BASE64_API': '-sJS_BASE64_API is experimental and not yet supported in browsers',
     'GROWABLE_ARRAYBUFFERS': '-sGROWABLE_ARRAYBUFFERS is experimental and not yet supported in browsers',
@@ -253,6 +252,7 @@ LEGACY_SETTINGS = [
     ['NODEJS_CATCH_REJECTION', [0], 'No longer supported'],
     ['POLYFILL_OLD_MATH_FUNCTIONS', [0], 'No longer supported'],
     ['RELOCATABLE', [0], 'No longer supported'],
+    ['WASM_JS_TYPES', [0], 'No longer supported'],
 ]
 
 user_settings: dict[str, str] = {}


### PR DESCRIPTION
The WebAssembly JS Types proposal was recently moved back to Phase 1 and the experimental support in v8 is being removed.

We can revisit this if/when it advances once again.