### PR TITLE
Increase stack size in test_wasm_worker_futex_wait

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -712,6 +712,7 @@ jobs:
             corez.test_dylink_iostream
             core2ss.test_pthread_dylink
             core2ss.test_pthread_thread_local_storage
+            core2ss.test_wasm_worker_futex_wait
             core2s.test_dylink_syslibs_missing_assertions
             core2s.test_module_wasm_memory
             cores.test_minimal_runtime_safe_heap

--- a/test/wasm_worker/wasm_worker_futex_wait.c
+++ b/test/wasm_worker/wasm_worker_futex_wait.c
@@ -48,5 +48,5 @@ void worker_main() {
 }
 
 int main() {
-  emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(1024), worker_main);
+  emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(2048), worker_main);
 }


### PR DESCRIPTION
I think this was always overflowing its stack (due to printf I think) but it was going unreported until #26650.

Fixes: #26738