### PR TITLE
Remove redundant error checking from libpthread/libwasm_worker. NFC

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -22,9 +22,6 @@
 #if EVAL_CTORS
 #error "EVAL_CTORS is not compatible with pthreads yet (passive segments)"
 #endif
-#if EXPORT_ES6 && (MIN_FIREFOX_VERSION < 114 || MIN_CHROME_VERSION < 80 || MIN_SAFARI_VERSION < 150000)
-#error "internal error, feature_matrix should not allow this"
-#endif
 
 {{{
 #if MEMORY64

--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -18,9 +18,6 @@
 #if WASM2JS && MODULARIZE
 #error "-sWASM=0 + -sMODULARIZE + -sWASM_WORKERS is not supported"
 #endif
-#if EXPORT_ES6 && (MIN_FIREFOX_VERSION < 114 || MIN_CHROME_VERSION < 80 || MIN_SAFARI_VERSION < 150000)
-#error "internal error, feature_matrix should not allow this"
-#endif
 
 #endif // ~WASM_WORKERS
 


### PR DESCRIPTION
As the error states, this limitation is already enforced by the feature matrix (using `Feature.WORKER_ES6_MODULES`).

Duplicating the information already present in the feature matix kind of defeats the whole purpose of the feature matrix (i.e. a centralized place to store this info) and creates scope for skew.  See #26677.