### PR TITLE
Apply a small dampening factor to image reftest

### DIFF
--- a/test/reftest.js
+++ b/test/reftest.js
@@ -55,14 +55,20 @@ function doReftest() {
       actualCtx.drawImage(actualImage, 0, 0);
       var actual = actualCtx.getImageData(0, 0, actualImage.width, actualImage.height).data;
 
+      // Allow each pixel R,G,B component to be off by a few units to account for possible shading
+      // differences between GPUs.
+      function dampenError(error) {
+        return Math.max(error-2, 0);
+      }
+
       var total = 0;
       var width = img.width;
       var height = img.height;
       for (var x = 0; x < width; x++) {
         for (var y = 0; y < height; y++) {
-          total += Math.abs(expected[y*width*4 + x*4 + 0] - actual[y*width*4 + x*4 + 0]);
-          total += Math.abs(expected[y*width*4 + x*4 + 1] - actual[y*width*4 + x*4 + 1]);
-          total += Math.abs(expected[y*width*4 + x*4 + 2] - actual[y*width*4 + x*4 + 2]);
+          total += dampenError(Math.abs(expected[y*width*4 + x*4 + 0] - actual[y*width*4 + x*4 + 0]));
+          total += dampenError(Math.abs(expected[y*width*4 + x*4 + 1] - actual[y*width*4 + x*4 + 1]));
+          total += dampenError(Math.abs(expected[y*width*4 + x*4 + 2] - actual[y*width*4 + x*4 + 2]));
         }
       }
       // floor, to allow some margin of error for antialiasing


### PR DESCRIPTION
Apply a small dampening factor to image reftest, to account for slight discrepancies in the generated image. Fixes browser.test_sdl3_ttf failure that occurred after updating a Linux CI box from old Linux Mint 22 + GTX 1080 Ti to a new Debian 13 RTX 5080.

It is not clear if this is an OS, driver, or hardware discrepancy.

When debugging the failing `browser.test_sdl3_ttf` error, I am getting this output:

<img width="1168" height="1016" alt="Screenshot From 2026-04-22 14-26-12" src="https://github.com/user-attachments/assets/6ef1bbe1-b51c-4883-9deb-863bbdc1ad6f" />

In the expected image, the cyan color is RGB=(25,255,255). In the actual image, the cyan color is RGB=(17,255,255) instead.

In the expected image, the orange color is RGB=(255,152,0). In the actual image, the cyan color is RGB=(255,153,0).

By allowing a per-color channel component discrepancy of two units, before registering it as an error, the test passes on the new RTX 5080.

The test `browser.test_sdl3_ttf` was failing in all suites: http://clbri.com:8010/#/builders/11/builds/1457

<img width="1492" height="1841" alt="image" src="https://github.com/user-attachments/assets/7a74ad9b-a240-4bc4-9e04-15870100f164" />
