### PR TITLE
Fix emscripten_yield to avoid calling timers from Wasm Workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -706,6 +706,7 @@ jobs:
             lto0.test_exceptions_allowed_uncaught
             lto0.test_longjmp_standalone_standalone
             lto0.test_embind_i64_val
+            lto0.test_wasm_worker_futex_wait
             thinlto0.test_pthread_dlsym
             core3
             core2g.test_externref

--- a/system/lib/libc/emscripten_yield_stub.c
+++ b/system/lib/libc/emscripten_yield_stub.c
@@ -6,6 +6,7 @@
  */
 
 #include <features.h>
+#include <emscripten/threading.h>
 
 #include "threading_internal.h"
 
@@ -16,5 +17,8 @@ static bool dummy(double now) {
 weak_alias(dummy, _emscripten_check_timers);
 
 bool _emscripten_yield(double now) {
-  return _emscripten_check_timers(now);
+  if (emscripten_is_main_runtime_thread()) {
+    return _emscripten_check_timers(now);
+  }
+  return false;
 }

--- a/test/codesize/test_minimal_runtime_code_size_hello_wasm_worker.json
+++ b/test/codesize/test_minimal_runtime_code_size_hello_wasm_worker.json
@@ -3,8 +3,8 @@
   "a.html.gz": 355,
   "a.js": 952,
   "a.js.gz": 601,
-  "a.wasm": 2652,
-  "a.wasm.gz": 1481,
-  "total": 4119,
-  "total_gz": 2437
+  "a.wasm": 2699,
+  "a.wasm.gz": 1510,
+  "total": 4166,
+  "total_gz": 2466
 }


### PR DESCRIPTION
Timers are only ever run on them main runtime thread.  In #26655 I added an assertion to ensure that `_emscripten_check_timers` is only called from the main runtime thread.  This broke tests such as `lto0.test_wasm_worker_futex_wait`.

The reason this test only failed in the LTO build on not under core0 is due to a bug in LTO which defeats the weak alias mechanism that is designed to only pull in the timer code when needed:

```
weak_alias(dummy, _emscripten_check_timers);
```

This changes fixes the stub version of `emscripten_yield_stub` so that it avoids calling `_emscripten_check_timers` from Wasm Workers.

Note: In a Wasm Workers build one can register and use timers from the main thread, but one cannot register a timer from a Wasm Worker (because _setitimer_js is a proxied func).

Fixes: #26749