### PR TITLE
__builtin_thread_pointers now returns non-null even in single threaded builds

### DIFF
--- a/test/other/test_pthread_stub.c
+++ b/test/other/test_pthread_stub.c
@@ -51,6 +51,8 @@ void test_pthreads() {
   int rtn;
   int res;
 
+  printf("__builtin_thread_pointer non-null: %d\n", __builtin_thread_pointer() != NULL);
+
   // pthread_atfork should silently succeed.
   CHECK_SUCCESS(pthread_atfork(NULL, NULL, NULL));
 

--- a/test/other/test_pthread_stub.out
+++ b/test/other/test_pthread_stub.out
@@ -1,5 +1,6 @@
 test_c11_threads
 test_pthreads
+__builtin_thread_pointer non-null: 1
 cleanup: 42
 test_pthread_getattr_np
 stack_addr: 0, stack_size: 65536, guard_size: 8192

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1931,6 +1931,8 @@ class libmimalloc(MTLibrary):
     '-DNDEBUG',
     # Emscripten uses musl libc internally
     '-DMI_LIBC_MUSL',
+    # enable use of `__builtin_thread_pointer()`
+    '-DMI_USE_BUILTIN_THREAD_POINTER',
   ]
 
   # malloc/free/calloc are runtime functions and can be generated during LTO
@@ -1952,13 +1954,6 @@ class libmimalloc(MTLibrary):
   src_files += [utils.path_from_root('system/lib/emmalloc.c')]
   # Include sbrk.c in libc, it uses tracing and libc itself doesn't have a tracing variant.
   src_files += [utils.path_from_root('system/lib/libc/sbrk.c')]
-
-  def get_cflags(self):
-    cflags = super().get_cflags()
-    if self.is_mt:
-      # enable use of `__builtin_thread_pointer()` in multithreaded builds
-      cflags += ['-DMI_USE_BUILTIN_THREAD_POINTER']
-    return cflags
 
   def can_use(self):
     return super().can_use() and settings.MALLOC == 'mimalloc'


### PR DESCRIPTION
This change revert #26747 now that __builtin_thread_pointer is fixed for single thread builds on the LLVM side.

See https://github.com/llvm/llvm-project/pull/193563