### PR TITLE
Fix preprocessor logic error in pthread_mutex_trylock.c. NFC

### DIFF
--- a/system/lib/libc/musl/src/thread/pthread_mutex_trylock.c
+++ b/system/lib/libc/musl/src/thread/pthread_mutex_trylock.c
@@ -53,10 +53,10 @@ success:
 	}
 #endif
 
-#if defined(__EMSCRIPTEN__) || !defined(NDEBUG)
-	// We can get here for normal mutexes too, but only in debug builds
-	// (where we track ownership purely for debug purposes).
-	if ((type & 15) == PTHREAD_MUTEX_NORMAL) return 0;
+#if defined(__EMSCRIPTEN__) && !defined(NDEBUG)
+	// Under emscripten we can get here for normal mutexes too, but only in debug
+	// Jbuilds (where we track ownership purely for debug purposes).
+	if ((type&15) == PTHREAD_MUTEX_NORMAL) return 0;
 #endif
 
 	next = self->robust_list.head;

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7323,
   "a.out.js.gz": 3573,
-  "a.out.nodebug.wasm": 19065,
-  "a.out.nodebug.wasm.gz": 8807,
-  "total": 26388,
-  "total_gz": 12380,
+  "a.out.nodebug.wasm": 19053,
+  "a.out.nodebug.wasm.gz": 8794,
+  "total": 26376,
+  "total_gz": 12367,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7726,
   "a.out.js.gz": 3779,
-  "a.out.nodebug.wasm": 19066,
-  "a.out.nodebug.wasm.gz": 8808,
-  "total": 26792,
-  "total_gz": 12587,
+  "a.out.nodebug.wasm": 19054,
+  "a.out.nodebug.wasm.gz": 8796,
+  "total": 26780,
+  "total_gz": 12575,
   "sent": [
     "a (memory)",
     "b (exit)",


### PR DESCRIPTION
This was a mistake from #24607.  The only effect was that this extra (redundant) check was mistakenly included in release builds where its technically not needed.