### PR TITLE
Fix Closure compiler annotation for Atomics.notify() count parameter for bigendian compilation

### DIFF
--- a/src/lib/liblittle_endian_heap.js
+++ b/src/lib/liblittle_endian_heap.js
@@ -94,6 +94,7 @@ function LE_HEAP_UPDATE() {
     const res = order(Atomics.load(heap, offset));
     return heap.unsigned ? heap.unsigned(res) : res;
   },
+  $LE_ATOMICS_NOTIFY__docs: '/**@param {number=} count*/',
   $LE_ATOMICS_NOTIFY: (heap, offset, count) => Atomics.notify(heap, offset, count),
   $LE_ATOMICS_OR: (heap, offset, value) => {
     const order = LE_ATOMICS_NATIVE_BYTE_ORDER[heap.BYTES_PER_ELEMENT - 1];


### PR DESCRIPTION
Fix Closure compiler annotation for Atomics.notify() count parameter for bigendian compilation. (count is optional)