### PR TITLE
Honor `-m32` / `-m64` command line flags. NFC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -43,6 +43,8 @@ See docs/process.md for more on how version tagging works.
   a Wasm Worker.  This mode increases the memory used by each Wasm Worker by
   ~500 bytes (in the same way that declaring ~500 bytes of TLS data would).
   (#26757)
+- The `-m64` compiler flag is now honored, and works are an alias for
+  `-sMEMORY64` and/or `--target=wasm64`. (#26765)
 
 5.0.6 - 04/14/26
 ----------------

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3521,8 +3521,7 @@ More info: https://emscripten.org
     self.cflags += [
       '-sJSPI',
       '-sEXPORTED_RUNTIME_METHODS=addFunction,dynCall',
-      '-sALLOW_TABLE_GROWTH=1',
-      '-Wno-experimental']
+      '-sALLOW_TABLE_GROWTH=1']
     self.do_runf('other/test_jspi_add_function.c', 'done')
 
   @requires_jspi
@@ -3546,10 +3545,7 @@ More info: https://emscripten.org
         console.log('done');
       };
     ''')
-    self.do_runf('main.c', 'done', cflags=['-sJSPI',
-                                           '--js-library=lib.js',
-                                           '-Wno-experimental',
-                                           '--post-js=post.js'])
+    self.do_runf('main.c', 'done', cflags=['-sJSPI', '--js-library=lib.js', '--post-js=post.js'])
 
   @requires_dev_dependency('typescript')
   @parameterized({
@@ -3727,7 +3723,7 @@ More info: https://emscripten.org
     self.run_process([EMCC, test_file('other/test_emit_tsd.c'),
                       '--emit-tsd', 'test_emit_tsd.d.ts', '-sEXPORT_ES6',
                       '-sMODULARIZE', '-sEXPORTED_RUNTIME_METHODS=UTF8ArrayToString,wasmTable',
-                      '-Wno-experimental', '-o', 'test_emit_tsd.js'] +
+                      '-o', 'test_emit_tsd.js'] +
                      self.get_cflags())
     self.assertFileContents(test_file('other/test_emit_tsd.d.ts'), read_file('test_emit_tsd.d.ts'))
     # Test that the output compiles with a TS file that uses the definitions.
@@ -3755,7 +3751,7 @@ More info: https://emscripten.org
     self.run_process([EMCC, test_file('other/test_emit_tsd.c'),
                       '--emit-tsd', 'test_emit_tsd.d.ts',
                       '-sEXPORTED_RUNTIME_METHODS=HEAP8,HEAPU8,HEAP16,HEAPU16,HEAP32,HEAPU32,HEAPF32,HEAPF64',
-                      '-Wno-experimental', '-o', 'test_emit_tsd.js'] +
+                      '-o', 'test_emit_tsd.js'] +
                      self.get_cflags())
     actual = read_file('test_emit_tsd.d.ts')
     self.assertContained("    let HEAP8: Int8Array;", actual)
@@ -14453,11 +14449,36 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
 
   @requires_wasm64
   def test_explicit_target(self):
-    self.do_runf('hello_world.c', cflags=['-target', 'wasm32'])
-    self.do_runf('hello_world.c', cflags=['-target', 'wasm64-unknown-emscripten', '-Wno-experimental'])
+    def is_64(path):
+      with webassembly.Module(path) as wasm:
+        m = wasm.get_memories()[0]
+        return m.limits.flags & webassembly.LIMITS_IS_64
+      assert False
 
-    self.do_runf('hello_world.c', cflags=['--target=wasm32'])
-    self.do_runf('hello_world.c', cflags=['--target=wasm64-unknown-emscripten', '-Wno-experimental'])
+    self.build('hello_world.c', cflags=['-target', 'wasm32'])
+    self.assertFalse(is_64('hello_world.wasm'))
+
+    self.build('hello_world.c', cflags=['-target', 'wasm64'])
+    self.assertTrue(is_64('hello_world.wasm'))
+
+    self.build('hello_world.c', cflags=['-target', 'wasm64-unknown-emscripten'])
+    self.assertTrue(is_64('hello_world.wasm'))
+
+    self.build('hello_world.c', cflags=['--target=wasm32'])
+    self.assertFalse(is_64('hello_world.wasm'))
+
+    self.build('hello_world.c', cflags=['--target=wasm64'])
+    self.assertTrue(is_64('hello_world.wasm'))
+
+    self.build('hello_world.c', cflags=['--target=wasm64-unknown-emscripten'])
+    self.assertTrue(is_64('hello_world.wasm'))
+
+    # Test -m32 and -m64 flags
+    self.build('hello_world.c', cflags=['-m64'])
+    self.assertTrue(is_64('hello_world.wasm'))
+
+    self.build('hello_world.c', cflags=['-m64', '-m32'])
+    self.assertFalse(is_64('hello_world.wasm'))
 
     self.assert_fail([EMCC, test_file('hello_world.c'), '-target', 'wasm32', '-sMEMORY64'], 'emcc: error: wasm32 target is not compatible with -sMEMORY64')
 

--- a/tools/cmdline.py
+++ b/tools/cmdline.py
@@ -587,6 +587,10 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
       options.relocatable = True
     elif arg.startswith('-o'):
       options.output_file = arg.removeprefix('-o')
+    elif check_flag('-m64'):
+      settings.MEMORY64 = 1
+    elif check_flag('-m32'):
+      settings.MEMORY64 = 0
     elif check_arg('-target') or check_arg('--target'):
       options.target = consume_arg()
       if options.target not in {'wasm32', 'wasm64', 'wasm64-unknown-emscripten', 'wasm32-unknown-emscripten'}:

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -31,6 +31,7 @@ VERSION = b'\x01\0\0\0'
 HEADER_SIZE = 8
 
 LIMITS_HAS_MAX = 0x1
+LIMITS_IS_64 = 0x4
 
 SEG_PASSIVE = 0x1
 
@@ -184,6 +185,7 @@ Global = namedtuple('Global', ['type', 'mutable', 'init'])
 Dylink = namedtuple('Dylink', ['mem_size', 'mem_align', 'table_size', 'table_align', 'needed', 'export_info', 'import_info', 'runtime_paths'])
 Table = namedtuple('Table', ['elem_type', 'limits'])
 FunctionBody = namedtuple('FunctionBody', ['offset', 'size'])
+Memory = namedtuple('Memory', ['limits'])
 DataSegment = namedtuple('DataSegment', ['flags', 'init', 'offset', 'size'])
 FuncType = namedtuple('FuncType', ['params', 'returns'])
 
@@ -469,6 +471,20 @@ class Module:
       functions.append(FunctionBody(start, body_size))
       self.seek(start + body_size)
     return functions
+
+  @memoize
+  def get_memories(self):
+    section = self.get_section(SecType.MEMORY)
+    if not section:
+      return []
+    memories = []
+    self.seek(section.offset)
+    num_memories = self.read_uleb()
+    for _ in range(num_memories):
+      limits = self.read_limits()
+      memories.append(Memory(limits))
+
+    return memories
 
   def get_section(self, section_code):
     return next((s for s in self.sections() if s.type == section_code), None)


### PR DESCRIPTION
Clang already accepts these was ways to select 64-bit/32-bit flavors of current triple.

As a drive-by fix I also removed some no-longer-needed `-Wno-experimental` flags from the test suite.