### PR TITLE
Fix benchmark.test_compile_hello and benchmark.test_compile_noop to work again.

### DIFF
--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -80,7 +80,7 @@ class Benchmarker(ABC):
   def get_output_files(self):
     pass
 
-  def bench(self, args, reps, output_parser=None, expected_output=None):
+  def bench(self, args, reps=EMTEST_REPS, output_parser=None, expected_output=None):
     self.times = []
     for _ in range(reps):
       start = time.time()


### PR DESCRIPTION
PR #26306 regressed `benchmark.test_compile_hello` and `benchmark.test_compile_noop` from working.

http://clbri.com:8010/api/v2/logs/397274/raw_inline

```
C:\emsdk\emscripten\main>test\runner benchmark.test_compile_hello
using verbose test runner (verbose output requested)
Running 1 tests
Running Emscripten benchmarks... [ including compilation | Fri Apr 24 00:45:10 2026 | em: commit d0cab3f5e315d1edaf0f76b99e8946fcf8252981 | llvm: C:/emsdk/llvm/git/build_main_vs2022_64/Release/bin ]
[1/1] test_compile_hello (test_benchmark.benchmark.test_compile_hello) ...
ERROR

======================================================================
ERROR: test_compile_hello (test_benchmark.benchmark.test_compile_hello)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\emsdk\emscripten\main\test\test_benchmark.py", line 579, in test_compile_hello
    self.do_toolchain_benchmark(['-c', test_file('hello_world.c')])
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\emsdk\emscripten\main\test\test_benchmark.py", line 568, in do_toolchain_benchmark
    b.bench(args)
    ~~~~~~~^^^^^^
TypeError: Benchmarker.bench() missing 1 required positional argument: 'reps'

----------------------------------------------------------------------
Ran 1 test in 0.169s

FAILED (errors=1)
```
