### PR TITLE
[OpenAL] Fix sourceSeek crash on stopped sources

### DIFF
--- a/src/lib/libopenal.js
+++ b/src/lib/libopenal.js
@@ -724,11 +724,15 @@ var LibraryOpenAL = {
         AL.setSourceState(src, {{{ cDefs.AL_INITIAL }}});
       }
 
-      if (src.bufQueue[src.bufsProcessed].audioBuf !== null) {
-        src.bufsProcessed = 0;
-        while (offset > src.bufQueue[src.bufsProcessed].audioBuf.duration) {
+      src.bufsProcessed = 0;
+      if (src.bufQueue.length > 0 && src.bufQueue[0].audioBuf !== null) {
+        while (src.bufsProcessed < src.bufQueue.length && offset > src.bufQueue[src.bufsProcessed].audioBuf.duration) {
           offset -= src.bufQueue[src.bufsProcessed].audioBuf.duration;
           src.bufsProcessed++;
+        }
+
+        if (src.bufsProcessed >= src.bufQueue.length) {
+          src.bufsProcessed = src.bufQueue.length -1;
         }
 
         src.bufOffset = offset;

--- a/src/lib/libopenal.js
+++ b/src/lib/libopenal.js
@@ -725,14 +725,10 @@ var LibraryOpenAL = {
       }
 
       src.bufsProcessed = 0;
-      if (src.bufQueue.length > 0 && src.bufQueue[0].audioBuf !== null) {
+      if (src.bufQueue.length && src.bufQueue[0].audioBuf) {
         while (src.bufsProcessed < src.bufQueue.length && offset > src.bufQueue[src.bufsProcessed].audioBuf.duration) {
           offset -= src.bufQueue[src.bufsProcessed].audioBuf.duration;
           src.bufsProcessed++;
-        }
-
-        if (src.bufsProcessed >= src.bufQueue.length) {
-          src.bufsProcessed = src.bufQueue.length -1;
         }
 
         src.bufOffset = offset;

--- a/test/openal/test_openal_playback.c
+++ b/test/openal/test_openal_playback.c
@@ -54,6 +54,9 @@ void playSource(void* arg) {
   alSourceStop(source);
   alGetSourcei(source, AL_SOURCE_STATE, &state);
   assert(state == AL_STOPPED);
+  alSourcef(source, AL_SEC_OFFSET, 0.5f);
+  alGetSourcei(source, AL_SOURCE_STATE, &state);
+  assert(state == AL_STOPPED);
 #endif
 
   alSourceRewindv(1, &source);
@@ -67,6 +70,9 @@ void playSource(void* arg) {
   assert(state == AL_PAUSED);
 #ifndef TEST_LOOPED_PLAYBACK
   alSourceStopv(1, &source);
+  alGetSourcei(source, AL_SOURCE_STATE, &state);
+  assert(state == AL_STOPPED);
+  alSourcef(source, AL_SEC_OFFSET, 0.5f);
   alGetSourcei(source, AL_SOURCE_STATE, &state);
   assert(state == AL_STOPPED);
   test_finished();

--- a/test/openal/test_openal_playback.c
+++ b/test/openal/test_openal_playback.c
@@ -54,9 +54,11 @@ void playSource(void* arg) {
   alSourceStop(source);
   alGetSourcei(source, AL_SOURCE_STATE, &state);
   assert(state == AL_STOPPED);
+#ifdef TEST_STOPPED_SEEK
   alSourcef(source, AL_SEC_OFFSET, 0.5f);
   alGetSourcei(source, AL_SOURCE_STATE, &state);
   assert(state == AL_STOPPED);
+#endif
 #endif
 
   alSourceRewindv(1, &source);
@@ -72,9 +74,11 @@ void playSource(void* arg) {
   alSourceStopv(1, &source);
   alGetSourcei(source, AL_SOURCE_STATE, &state);
   assert(state == AL_STOPPED);
+#ifdef TEST_STOPPED_SEEK
   alSourcef(source, AL_SEC_OFFSET, 0.5f);
   alGetSourcei(source, AL_SOURCE_STATE, &state);
   assert(state == AL_STOPPED);
+#endif
   test_finished();
 #endif
 }
@@ -299,7 +303,7 @@ int main() {
   printf("You should hear a short audio clip playing back.\n");
 #endif
 
-#ifdef __EMSCRIPTEN__
+#if defined(__EMSCRIPTEN__) && !defined(TEST_STOPPED_SEEK)
 
   intptr_t first_src = sources[0];
 #if defined(TEST_LOOPED_PLAYBACK)

--- a/test/test_interactive.py
+++ b/test/test_interactive.py
@@ -160,6 +160,10 @@ class interactive(BrowserCore):
     copy_asset('sounds/audio.wav')
     self.btest('openal/test_openal_playback.c', '1', cflags=['-O2', '--preload-file', 'audio.wav'] + args)
 
+  def test_openal_stopped_seek_playback(self):
+    copy_asset('sounds/audio.wav')
+    self.btest('openal/test_openal_playback.c', '1', cflags=['-DTEST_STOPPED_SEEK=1', '-O2', '--preload-file', 'audio.wav'])
+
   def test_openal_buffers(self):
     self.btest_exit('openal/test_openal_buffers.c', cflags=['-DTEST_INTERACTIVE=1', '--preload-file', test_file('sounds/the_entertainer.wav') + '@/'])
 


### PR DESCRIPTION
If you tried to use `AL_SEC_OFFSET` on a stopped audio source, sourceSeek would throw a `TypeError` because `audioBuf` would be undefined.