### PR TITLE
Remove --experimental-wasm-stack-switching from being passed when running against Node 26

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -596,7 +596,9 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
 
     # Support for JSPI came earlier than 22, but the new API changes require v24
     if self.try_require_node_version(24):
-      self.node_args += ['--experimental-wasm-stack-switching']
+      # Node v26 no longer has the experimental cmdline parameter.
+      if not self.try_require_node_version(26):
+        self.node_args += ['--experimental-wasm-stack-switching']
       return
 
     v8 = get_v8()


### PR DESCRIPTION
Remove --experimental-wasm-stack-switching from being passed when running against Node 26. Fixes running JSPI tests on Node 26 nightly.

When running JSPI tests, the suite passes the `--experimental-wasm-stack-switching` parameter to `node` during execution.

I am using Nightly Node.js to test the `wasm64` suite since that suite is on the bleeding edge:

http://clbri.com:8010/api/v2/logs/397813/raw_inline

but that gives an error

```
Traceback (most recent call last):
  File "/home/clb/buildbot/linux-h12dsi/emscripten_linux_x64/build/emscripten/main/test/common.py", line 381, in resulting_test
    return func(self, *args)
  File "/home/clb/buildbot/linux-h12dsi/emscripten_linux_x64/build/emscripten/main/test/test_core.py", line 268, in metafunc
    return func(self, *args, **kwargs)
  File "/home/clb/buildbot/linux-h12dsi/emscripten_linux_x64/build/emscripten/main/test/test_core.py", line 8210, in test_async_main
    self.do_runf('main.c', 'argc=2 argv=hello', args=['hello'])
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/clb/buildbot/linux-h12dsi/emscripten_linux_x64/build/emscripten/main/test/common.py", line 1391, in do_runf
    return self._build_and_run(filename, expected_output, **kwargs)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/clb/buildbot/linux-h12dsi/emscripten_linux_x64/build/emscripten/main/test/common.py", line 1439, in _build_and_run
    js_output = self.run_js(js_file, engine, args,
                            input=input,
                            assert_returncode=assert_returncode,
                            interleaved_output=interleaved_output)
  File "/home/clb/buildbot/linux-h12dsi/emscripten_linux_x64/build/emscripten/main/test/common.py", line 1023, in run_js
    self.fail('JS subprocess failed (%s): %s (expected=%s).  Output:\n%s' % (error.cmd, error.returncode, assert_returncode, ret))
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: JS subprocess failed (/home/clb/buildbot/linux-h12dsi/emscripten_linux_x64/build/node/nightly-v26.0.0-nightly20260423acb1bd7107/bin/node --stack-trace-limit=50 --trace-uncaught --experimental-wasm-stack-switching /tmp/emtest_uxten3bw/emscripten_test_wasm64_eg582hgf/main.js hello): 9 (expected=0).  Output:
/home/clb/buildbot/linux-h12dsi/emscripten_linux_x64/build/node/nightly-v26.0.0-nightly20260423acb1bd7107/bin/node: bad option: --experimental-wasm-stack-switching
```

Removing the `--experimental-wasm-stack-switching` flag fixes the tests to pass.

Tested manually that Node 25 still has the `--experimental-wasm-stack-switching` flag, so looks like it has been removed some point during the v26 development.