### PR TITLE
Fix browser.test_sdl_ogl_defaultmatrixmode and browser.test_sdl_ogl_proc_alias

### DIFF
--- a/test/browser/test_sdl_ogl_defaultMatrixMode.c
+++ b/test/browser/test_sdl_ogl_defaultMatrixMode.c
@@ -132,6 +132,15 @@ int main(int argc, char *argv[])
         glTexCoord2f( 0.5, 1 ); glVertex3f( 310, 250, 0 );
     glEnd();
 
+    // test calls to glVertex4f
+    // Result should be equivalent as to glVertex3f( x/w, y/w, z/w )
+    glBegin( GL_QUADS );
+        glTexCoord2i( 0, 0 ); glVertex4f( 300, 300, 0, 2 ); // Square will be at (150,150) (150,250) (250,250) (250,150)
+        glTexCoord2i( 1, 0 ); glVertex4f( 300, 500, 0, 2 );
+        glTexCoord2i( 1, 1 ); glVertex4f( 500, 500, 0, 2 );
+        glTexCoord2i( 0, 1 ); glVertex4f( 500, 300, 0, 2 );
+    glEnd();
+
     glBegin( GL_TRIANGLE_STRIP );
         glTexCoord2i( 0, 0 ); glVertex3f( 100, 300, 0 );
         glTexCoord2i( 1, 0 ); glVertex3f( 300, 300, 0 );

--- a/test/browser/test_sdl_ogl_proc_alias.c
+++ b/test/browser/test_sdl_ogl_proc_alias.c
@@ -140,6 +140,15 @@ int main(int argc, char *argv[])
         glTexCoord2f( 0.5, 1 ); glVertex3f( 310, 250, 0 );
     glEnd();
 
+    // test calls to glVertex4f
+    // Result should be equivalent as to glVertex3f( x/w, y/w, z/w )
+    glBegin( GL_QUADS );
+        glTexCoord2i( 0, 0 ); glVertex4f( 300, 300, 0, 2 ); // Square will be at (150,150) (150,250) (250,250) (250,150)
+        glTexCoord2i( 1, 0 ); glVertex4f( 300, 500, 0, 2 );
+        glTexCoord2i( 1, 1 ); glVertex4f( 500, 500, 0, 2 );
+        glTexCoord2i( 0, 1 ); glVertex4f( 500, 300, 0, 2 );
+    glEnd();
+
     glBegin( GL_TRIANGLE_STRIP );
         glTexCoord2i( 0, 0 ); glVertex3f( 100, 300, 0 );
         glTexCoord2i( 1, 0 ); glVertex3f( 300, 300, 0 );


### PR DESCRIPTION
Fix browser.test_sdl_ogl_defaultmatrixmode and browser.test_sdl_ogl_proc_alias, which regressed by PR https://github.com/emscripten-core/emscripten/pull/7591. The PR added a new rendered element to browser.test_sdl_ogl and its reftest image test/screenshot-gray-purple.png, but did not realize that two other tests, browser.test_sdl_ogl_defaultmatrixmode and browser.test_sdl_ogl_proc_alias, also use the same reftest. The failure went unnoticed since our image reftest algorithm error calculation mechanism is a little bit simplistic. (an area for future improvement)

This error was now surfaced on my Linux CI, which renders output that has an additional source of discrepancy related to some kind of gamma/brightness, which then bumped the error quantity above the threshold.

Old reference image before PR #7591: (still produced by browser.test_sdl_ogl_defaultmatrixmode and browser.test_sdl_ogl_proc_alias before this PR)

<img width="640" height="480" alt="actual" src="https://github.com/user-attachments/assets/04c01506-236b-4962-9c0b-70776c3b8f25" />

Current reference image in repo:

<img width="640" height="480" alt="expected" src="https://github.com/user-attachments/assets/20f0d859-6d1f-47cb-952d-42648d4825b5" />

This PR fixes the two tests browser.test_sdl_ogl_defaultmatrixmode and browser.test_sdl_ogl_proc_alias by updating them to render that missing quad element as well, which had been added to browser.test_sdl_ogl. (by copying the code from test_sdl_ogl.c)