### PR TITLE
When autoconfiguring, autodisable STRICT mode

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6888,7 +6888,6 @@ void* operator new(size_t size) {
   @is_slow_test
   @crossplatform
   @no_wasmfs('depends on MEMFS which WASMFS does not have')
-  @no_strict('autoconfiguring is not compatible with STRICT')
   @no_big_endian('SUPPORT_BIG_ENDIAN is not propagated')
   def test_poppler(self):
     # See https://github.com/emscripten-core/emscripten/issues/20757

--- a/tools/link.py
+++ b/tools/link.py
@@ -828,8 +828,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     # Add `#!` line to output JS and make it executable.
     settings.EXECUTABLE = config.NODE_JS[0]
     # autoconf declares functions without their proper signatures, and STRICT causes that to trip up by passing --fatal-warnings to the linker.
-    if settings.STRICT:
-      exit_with_error('autoconfiguring is not compatible with STRICT')
+    settings.STRICT = 0
 
   if settings.OPT_LEVEL >= 1:
     default_setting('ASSERTIONS', 0)

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -345,7 +345,8 @@ class SettingsManager:
       # When not running in strict mode we also externalize all legacy settings
       # (Since the external tools do process LEGACY_SETTINGS themselves)
       for key in self.legacy_settings:
-        external_settings[key] = self.attrs[key]
+        if key in self.attrs:
+          external_settings[key] = self.attrs[key]
     return external_settings
 
   def keys(self):


### PR DESCRIPTION
When autoconfiguring, autodisable STRICT mode. This enables running test strict.test_poppler, and fixes failing tests strict.test_freetype and strict.test_bullet_autoconf. This can enable verifying other parts of these tests other than autoconfig in STRICT mode.

The `if key in self.attrs` check was added, since otherwise there would be errors e.g. about `BINARYEN `key not existing in `self.attrs`.