### PR TITLE
Fix incorrect WebGL test code usage of glBindAttribLocation()

### DIFF
--- a/test/browser/test_gl_float_tex.c
+++ b/test/browser/test_gl_float_tex.c
@@ -126,6 +126,7 @@ static void gl_init(void) {
     GLuint program = glCreateProgram();
     glAttachShader(program, createShader(vertex_shader  , GL_VERTEX_SHADER));
     glAttachShader(program, createShader(fragment_shader, GL_FRAGMENT_SHADER));
+    glBindAttribLocation(program, 0, "indices");
     glLinkProgram(program);
     GLint status;
     char msg[512];
@@ -150,7 +151,6 @@ static void gl_init(void) {
     glBufferData(GL_ARRAY_BUFFER, NUM_NODES * sizeof(float), &elements[0], GL_STATIC_DRAW);
     /* Get the locations of the uniforms so we can access them */
     nodeSamplerLocation = glGetUniformLocation(program, "nodeInfo");
-    glBindAttribLocation(program, 0, "indices");
 #ifndef __EMSCRIPTEN__ // GLES2 & WebGL do not have these, only pre 3.0 desktop GL and compatibility mode GL3.0+ GL do.
     // Enable glPoint size in shader, always enable in Open Gl ES 2.
     glEnable(GL_VERTEX_PROGRAM_POINT_SIZE);

--- a/test/browser/test_gl_subdata.c
+++ b/test/browser/test_gl_subdata.c
@@ -122,6 +122,7 @@ static void gl_init(void) {
     GLuint program = glCreateProgram();
     glAttachShader(program, createShader(vertex_shader  , GL_VERTEX_SHADER));
     glAttachShader(program, createShader(fragment_shader, GL_FRAGMENT_SHADER));
+    glBindAttribLocation(program, 0, "indices");
     glLinkProgram(program);
     char msg[512];
     glGetProgramInfoLog(program, sizeof msg, NULL, msg);
@@ -146,7 +147,6 @@ static void gl_init(void) {
     }
     /* Get the locations of the uniforms so we can access them */
     nodeSamplerLocation = glGetUniformLocation(program, "nodeInfo");
-    glBindAttribLocation(program, 0, "indices");
 #ifndef __EMSCRIPTEN__ // GLES2 & WebGL do not have these, only pre 3.0 desktop GL and compatibility mode GL3.0+ GL do.
     // Enable glPoint size in shader, always enable in Open Gl ES 2.
     glEnable(GL_VERTEX_PROGRAM_POINT_SIZE);

--- a/test/third_party/cubegeom/cubegeom_pre.c
+++ b/test/third_party/cubegeom/cubegeom_pre.c
@@ -242,6 +242,8 @@ int main(int argc, char *argv[])
 
     glAttachShader(program, vs);
     glAttachShader(program, fs);
+    glBindAttribLocation(program, 0, "a_position");
+    glBindAttribLocation(program, 1, "a_texCoord0");
     glLinkProgram(program);
     glGetProgramiv(program, GL_LINK_STATUS, &ok);
     assert(ok);
@@ -273,11 +275,9 @@ int main(int argc, char *argv[])
       glUniformMatrix4fv(projectionLocation, 1, GL_FALSE, data);
     }
 
-    glBindAttribLocation(program, 0, "a_position");
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 32, (void*)0);
     glEnableVertexAttribArray(0);
 
-    glBindAttribLocation(program, 1, "a_texCoord0");
     glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 32, (void*)16);
     glEnableVertexAttribArray(1);
 

--- a/test/third_party/cubegeom/cubegeom_pre_vao.c
+++ b/test/third_party/cubegeom/cubegeom_pre_vao.c
@@ -248,6 +248,8 @@ int main(int argc, char *argv[])
 
     glAttachShader(program, vs);
     glAttachShader(program, fs);
+    glBindAttribLocation(program, 0, "a_position");
+    glBindAttribLocation(program, 1, "a_texCoord0");
     glLinkProgram(program);
     glGetProgramiv(program, GL_LINK_STATUS, &ok);
     assert(ok);
@@ -279,11 +281,9 @@ int main(int argc, char *argv[])
       glUniformMatrix4fv(projectionLocation, 1, GL_FALSE, data);
     }
 
-    glBindAttribLocation(program, 0, "a_position");
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 32, (void*)0);
     glEnableVertexAttribArray(0);
 
-    glBindAttribLocation(program, 1, "a_texCoord0");
     glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 32, (void*)16);
     glEnableVertexAttribArray(1);
 

--- a/test/third_party/cubegeom/cubegeom_pre_vao_es.c
+++ b/test/third_party/cubegeom/cubegeom_pre_vao_es.c
@@ -253,6 +253,8 @@ int main(int argc, char *argv[])
 
     glAttachShader(program, vs);
     glAttachShader(program, fs);
+    glBindAttribLocation(program, 0, "a_position");
+    glBindAttribLocation(program, 1, "a_texCoord0");
     glLinkProgram(program);
     glGetProgramiv(program, GL_LINK_STATUS, &ok);
     assert(ok);
@@ -284,11 +286,9 @@ int main(int argc, char *argv[])
       glUniformMatrix4fv(projectionLocation, 1, GL_FALSE, data);
     }
 
-    glBindAttribLocation(program, 0, "a_position");
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 32, (void*)0);
     glEnableVertexAttribArray(0);
 
-    glBindAttribLocation(program, 1, "a_texCoord0");
     glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 32, (void*)16);
     glEnableVertexAttribArray(1);
 


### PR DESCRIPTION
GL specification states that glBindAttribLocation() must be called *before* calling glLinkProgram(), or the call has no effect.

<img width="915" height="569" alt="image" src="https://github.com/user-attachments/assets/15b49278-238c-4896-8523-7b8019e6d4a9" />


A few tests did not follow this rule, but attempted to call glBindAttribLocation() after glLinkProgram(), which did nothing.. but due to getting lucky, the default bind locations were the same as the requested ones. Except now on Firefox for Apple M4, it is seen that the rendering backend generates different defaults, and the test programs break.

Fixes
 - browser.test_cubegeom_pre_regal
 - browser.test_cubegeom_pre_vao_regal
 - browser.test_cubegeom_pre_vao_es
 - browser.test_cubegeom_row_length
 - browser.test_gl_float_tex
 - browser.test_gl_subdata

test code to be proper GL.

Supercedes #26779.