### PR TITLE
Improve test_pthread_join_and_asyncify. NFC

### DIFF
--- a/test/core/test_pthread_join_and_asyncify.c
+++ b/test/core/test_pthread_join_and_asyncify.c
@@ -14,9 +14,10 @@ EM_ASYNC_JS(int, async_call, (), {
 });
 
 void *run_thread(void *args) {
-  int ret = async_call();
+  intptr_t ret = async_call();
+  printf("async_call done %ld\n", ret);
   assert(ret == 42);
-  return NULL;
+  return (void*)ret;
 }
 
 int main() {
@@ -26,8 +27,9 @@ int main() {
   // Also test that JSPI works on other threads.
   pthread_create(&id, NULL, run_thread, NULL);
   printf("joining thread!\n");
-  pthread_join(id, NULL);
-  printf("joined thread!\n");
-
+  void* rtn;
+  pthread_join(id, &rtn);
+  printf("join returned -> %ld\n", (intptr_t)rtn);
+  assert((intptr_t)rtn == 42);
   return 0;
 }

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8501,8 +8501,8 @@ Module.onRuntimeInitialized = () => {
   @requires_jspi
   def test_pthread_join_and_asyncify(self):
     # TODO Test with ASYNCIFY=1 https://github.com/emscripten-core/emscripten/issues/17552
-    self.do_runf('core/test_pthread_join_and_asyncify.c', 'joining thread!\njoined thread!',
-                 cflags=['-sJSPI', '-sEXIT_RUNTIME', '-pthread', '-sPROXY_TO_PTHREAD'])
+    self.do_runf('core/test_pthread_join_and_asyncify.c', 'join returned -> 42\n',
+                 cflags=['-sJSPI', '-sEXIT_RUNTIME=1', '-pthread', '-sPROXY_TO_PTHREAD'])
 
   # Test basic wasm2js functionality in all core compilation modes.
   @no_sanitize('no wasm2js support yet in sanitizers')


### PR DESCRIPTION
I noticed that we were not checking the final return value of the thread, which is an important part of this test.