### PR TITLE
Remove assert for __get_temp_ret() and __set_temp_ret() after Binaryen JS FFI legalizer pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -717,6 +717,7 @@ jobs:
             core2s.test_dylink_syslibs_missing_assertions
             core2s.test_module_wasm_memory
             cores.test_minimal_runtime_safe_heap
+            wasm2js0.test_autodebug_wasm
             wasm2js3.test_memorygrowth_2
             wasm2js2.test_pthread_proxying
             wasmfs.test_hello_world

--- a/tools/building.py
+++ b/tools/building.py
@@ -1355,4 +1355,7 @@ def js_legalization_pass_flags():
     # assumed to be defined and exports within the module, otherwise binaryen
     # assumes they are imports.
     flags += ['--pass-arg=legalize-js-interface-exported-helpers']
+  # Ensure that the legalizer pass does not erase debug info
+  if settings.DEBUG_LEVEL:
+    flags += ['-g']
   return flags

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -1032,6 +1032,10 @@ def create_receiving(function_exports, other_exports, library_symbols, aliases):
         # EMBIND_GEN_MODE is run before binaryen so the asyncify exports that
         # are created by binaryen will be missing.
         continue
+      if settings.LEGALIZE_JS_FFI and sym in {'__get_temp_ret', '__set_temp_ret'}:
+        # The Binaryen legalizer pass will drop exports of __get_temp_ret() and __set_temp_ret()
+        # if they are unused, so do not assert their existence.
+        continue
       receiving.append(f"  assert(typeof wasmExports['{sym}'] != 'undefined', 'missing Wasm export: {sym}');")
   for sym, info in exports.items():
     is_function = type(info) == webassembly.FuncType


### PR DESCRIPTION
Binaryen JS FFI legalizer pass seems to be dropping __get_temp_ret() and __set_temp_ret() if they are unused, so do not emit assert() for their existence. Fixes https://github.com/emscripten-core/emscripten/issues/25549.

I am not 100% sure about this, but this did fix the test `wasm2js0.test_autodebug_wasm` to pass.