### PR TITLE
Re-eanble test after binaryen update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -717,6 +717,7 @@ jobs:
             core2s.test_dylink_syslibs_missing_assertions
             core2s.test_module_wasm_memory
             cores.test_minimal_runtime_safe_heap
+            wasm2js0.test_autodebug_wasm
             wasm2js3.test_memorygrowth_2
             wasm2js2.test_pthread_proxying
             wasmfs.test_hello_world

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7017,9 +7017,6 @@ void* operator new(size_t size) {
     if '-msimd128' in self.cflags:
       self.skipTest('https://github.com/emscripten-core/emscripten/issues/25001')
 
-    if self.is_wasm2js() and '-O0' in self.cflags:
-      self.skipTest('https://github.com/emscripten-core/emscripten/issues/25549')
-
     # Even though the test itself doesn't directly use reference types,
     # Binaryen's '--instrument-locals' will add their logging functions if
     # reference-types is enabled. So make sure this test passes when


### PR DESCRIPTION
This was fixed on the binaryen side: https://github.com/WebAssembly/binaryen/pull/8649

Fixes: #25549