### PR TITLE
Remove `building.emar` helper function. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1378,7 +1378,7 @@ f.close()
     self.emcc('a.c', ['-c']) # a.o
     self.emcc('b.c', ['-c']) # b.o
     self.emcc('c.c', ['-c']) # c.o
-    building.emar('cr', 'libLIB.a', ['a.o', 'b.o']) # libLIB.a with a and b
+    self.run_process([EMAR, 'cr', 'libLIB.a', 'a.o', 'b.o']) # libLIB.a with a and b
 
     # a is in the lib AND in an .o, so should be ignored in the lib. We do still need b from the lib though
     self.do_runf('main.c', 'result: 62', cflags=['a.o', 'c.o', '-L.', '-lLIB'])
@@ -1397,7 +1397,7 @@ f.close()
 
     self.emcc('lib.c', ['-c']) # lib.o
     lib_name = 'libLIB.a'
-    building.emar('cr', lib_name, ['lib.o']) # libLIB.a with lib.o
+    self.run_process([EMAR, 'cr', lib_name, 'lib.o']) # libLIB.a with lib.o
 
     def test(compiler, main_name, lib_args, err_expected):
       print(err_expected)
@@ -8997,7 +8997,7 @@ end
     create_file("hyvää päivää", ' ')
     create_file("snowman freezes covid ☃ 🦠", ' ')
     create_file("tmp.rsp", response_file.create_response_file_contents(("file'1", "file'2", "hyvää päivää", "snowman freezes covid ☃ 🦠")))
-    building.emar('cr', 'libfoo.a', ['@tmp.rsp'])
+    self.run_process([EMAR, 'cr', 'libfoo.a', '@tmp.rsp'])
 
   def test_response_file_bom(self):
     # Modern CMake version create response files in UTF-8 but with BOM

--- a/tools/building.py
+++ b/tools/building.py
@@ -353,16 +353,6 @@ def get_command_with_possible_response_file(cmd):
   return new_cmd
 
 
-def emar(action, output_filename, filenames, stdout=None, stderr=None, env=None):
-  utils.delete_file(output_filename)
-  cmd = [EMAR, action, output_filename] + filenames
-  cmd = get_command_with_possible_response_file(cmd)
-  run_process(cmd, stdout=stdout, stderr=stderr, env=env)
-
-  if 'c' in action:
-    assert os.path.exists(output_filename), 'emar could not create output file: ' + output_filename
-
-
 def opt_level_to_str(opt_level, shrink_level=0):
   # convert opt_level/shrink_level pair to a string argument like -O1
   if opt_level == 0:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -139,6 +139,13 @@ def objectfile_sort_key(filename):
     return basename
 
 
+def create_lib_emar(output_filename, filenames):
+  utils.delete_file(output_filename)
+  cmd = [shared.EMAR, 'cr', output_filename] + filenames
+  cmd = building.get_command_with_possible_response_file(cmd)
+  utils.run_process(cmd)
+
+
 def create_lib(libname, inputs):
   """Create a library from a set of input objects."""
   suffix = utils.suffix(libname)
@@ -152,7 +159,7 @@ def create_lib(libname, inputs):
       building.link_to_object(inputs, libname)
   else:
     assert suffix == '.a'
-    building.emar('cr', libname, inputs)
+    create_lib_emar(libname, inputs)
 
 
 def get_top_level_ninja_file():


### PR DESCRIPTION
Instead move the logic into system_libs.py (the only non-testing place it is used).

In the test code itself, we just replace the usage with direct calls to `EMAR`, which is better for decoupling the tests from the compiler itself.

This is in preparation for a change to skip the wrapper scripts when the compiler calls itself to build system libs (See #26799)