### PR TITLE
Avoid changing working directory EMCC_BATCH_BUILD is unset. NFC

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -102,13 +102,13 @@ def clean_env():
   return safe_env
 
 
-def run_build_commands(commands, num_inputs, build_dir=None):
+def run_build_commands(commands, num_inputs, cwd=None):
   # Before running a set of build commands make sure the common sysroot
   # headers are installed.  This prevents each sub-process from attempting
   # to setup the sysroot itself.
   ensure_sysroot()
   start_time = time()
-  shared.run_multiple_processes(commands, env=clean_env(), cwd=build_dir)
+  shared.run_multiple_processes(commands, env=clean_env(), cwd=cwd)
   logger.info(f'compiled {num_inputs} inputs in {time() - start_time:.2f}s')
 
 
@@ -546,8 +546,11 @@ class Library:
         for i in range(0, len(srcs), chunk_size):
           chunk_srcs = srcs[i:i + chunk_size]
           commands.append(building.get_command_with_possible_response_file(cmd + chunk_srcs))
-
-    run_build_commands(commands, num_inputs=len(objects), build_dir=build_dir)
+      # We need to run all these commands with cwd=build_dir because we used relative paths above
+      run_build_commands(commands, num_inputs=len(objects), cwd=build_dir)
+    else:
+      # No need to set cwd here, since all inputs are absolute paths.
+      run_build_commands(commands, num_inputs=len(objects))
     return objects
 
   def customize_build_cmd(self, cmd, _filename):


### PR DESCRIPTION
When not using `EMCC_BATCH_BUILD` the working directory does not matter.