### PR TITLE
Fix emscripten_is_main_runtime_thread() under in audio worklet

### DIFF
--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -350,7 +350,11 @@ if (ENVIRONMENT_IS_WASM_WORKER
   __do_set_thread_state: (tb) => {
     ___set_thread_state(
       /*thread_ptr=*/0,
+#if AUDIO_WORKLET
+      /*is_main_thread=*/!ENVIRONMENT_IS_WORKER && !ENVIRONMENT_IS_AUDIO_WORKLET,
+#else
       /*is_main_thread=*/!ENVIRONMENT_IS_WORKER,
+#endif
       /*is_runtime_thread=*/!ENVIRONMENT_IS_WASM_WORKER,
       /*supports_wait=*/ENVIRONMENT_IS_WORKER && {{{ workerSupportsFutexWait() }}});
   },

--- a/system/lib/pthread/emscripten_futex_wait.c
+++ b/system/lib/pthread/emscripten_futex_wait.c
@@ -32,6 +32,7 @@ extern void* _emscripten_main_thread_futex;
 static int futex_wait_main_browser_thread(volatile void* addr,
                                           uint32_t val,
                                           double timeout, bool cancelable) {
+  DBG("futex_wait_main_browser_thread");
   // Atomics.wait is not available in the main browser thread, so simulate it
   // via busy spinning. Only the main browser thread is allowed to call into
   // this function. It is not thread-safe to be called from any other thread.
@@ -154,13 +155,13 @@ static int _do_futex_wait(volatile void *addr, uint32_t val, double max_wait_ms)
   bool cancelable = false;
 #endif
 
+  DBG("emscripten_futex_wait ms=%f", max_wait_ms);
+
   // For the main browser thread and audio worklets we can't use
   // __builtin_wasm_memory_atomic_wait32 so we have busy wait instead.
   if (!_emscripten_thread_supports_atomics_wait()) {
     return futex_wait_main_browser_thread(addr, val, max_wait_ms, cancelable);
   }
-
-  DBG("emscripten_futex_wait ms=%f", max_wait_ms);
 
   bool is_runtime_thread = emscripten_is_main_runtime_thread();
   if (is_runtime_thread) {

--- a/test/webaudio/audioworklet.c
+++ b/test/webaudio/audioworklet.c
@@ -1,4 +1,5 @@
 #include <emscripten/webaudio.h>
+#include <emscripten/threading.h>
 #include <assert.h>
 #include <unistd.h>
 
@@ -38,12 +39,13 @@ bool ProcessAudio(int numInputs,
                   int numParams,
                   const AudioParamFrame* params,
                   void* userData) {
+  assert(!emscripten_is_main_browser_thread());
+  assert(emscripten_current_thread_is_audio_worklet());
 #ifdef TEST_AND_EXIT
   // Only running in the test harness, see main_thread_tls_access()
   assert(testTlsVariable == lastTlsVariableValueInAudioThread);
   ++testTlsVariable;
   lastTlsVariableValueInAudioThread = testTlsVariable;
-  assert(emscripten_current_thread_is_audio_worklet());
 #endif
 
   // Verify that getentropy fails gracefully (i.e. returns non-zero) when called
@@ -146,6 +148,7 @@ void WebAudioWorkletThreadInitialized(EMSCRIPTEN_WEBAUDIO_T audioContext, bool s
 uint8_t wasmAudioWorkletStack[4096];
 
 int main() {
+  assert(emscripten_is_main_browser_thread());
   assert(!emscripten_current_thread_is_audio_worklet());
 
   // Create an audio context


### PR DESCRIPTION
This function was incorrectly returning `true` in audio worklets because `ENVIRONMENT_IS_WORKER` is not defined in audio worklets.