### PR TITLE
Demote the warning of Closure falling back to Java from warning to a debug line

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -507,7 +507,7 @@ def get_closure_compiler_and_env(user_args):
   if not native_closure_compiler_works and not any(a.startswith('--platform') for a in user_args):
     # Run with Java Closure compiler as a fallback if the native version does not work.
     # This can happen, for example, on arm64 macOS machines that do not have Rosetta installed.
-    logger.warning('falling back to java version of closure compiler')
+    logger.debug('falling back to java version of closure compiler')
     user_args.append('--platform=java')
     check_closure_compiler(closure_cmd, user_args, env, allowed_to_fail=False)
 


### PR DESCRIPTION
Demote the warning of Closure falling back to Java from warning to a debug line. If Java works, this is not a problem, and if Java does not work, it will make itself known. Fixes other.test_closure_warnings* on Apple Silicon Mac devices.

http://clbri.com:8010/api/v2/logs/406742/raw_inline
