### PR TITLE
Fix default setting of EXECUTABLE overriding the value set in phase_linker_setup() for autoconfiguring.

### DIFF
--- a/tools/link.py
+++ b/tools/link.py
@@ -933,7 +933,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
   # When there is no final suffix or the suffix is `.out` (as in `a.out`) then default to
   # making the resulting file exectuable.
   if settings.ENVIRONMENT_MAY_BE_NODE and options.oformat == OFormat.JS and final_suffix in {'', '.out'}:
-    # linker setup phase may have initialized the EXECUTABLE setting already, so only init default here
+    # autoconf handling above may have initialized the EXECUTABLE setting already, so only init default here
     # if not yet set.
     if not settings.EXECUTABLE:
       default_setting('EXECUTABLE', 1)

--- a/tools/link.py
+++ b/tools/link.py
@@ -933,7 +933,10 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
   # When there is no final suffix or the suffix is `.out` (as in `a.out`) then default to
   # making the resulting file exectuable.
   if settings.ENVIRONMENT_MAY_BE_NODE and options.oformat == OFormat.JS and final_suffix in {'', '.out'}:
-    default_setting('EXECUTABLE', 1)
+    # linker setup phase may have initialized the EXECUTABLE setting already, so only init default here
+    # if not yet set.
+    if not settings.EXECUTABLE:
+      default_setting('EXECUTABLE', 1)
 
   if settings.EXECUTABLE and not settings.ENVIRONMENT_MAY_BE_NODE:
     exit_with_error('EXECUTABLE requires `node` in ENVRIONMENT')


### PR DESCRIPTION
Fix default setting of EXECUTABLE overriding the value set in phase_linker_setup() for autoconfiguring.

This line has no effect:

https://github.com/emscripten-core/emscripten/blob/2a8234f6651fcc2fdfaf1a97e749720ea76d55a7/tools/link.py#L829-L830

since it was being overridden by `default_setting('EXECUTABLE', 1)`, which looks only in `user_settings`, and not if the setting has already been initialized.

The result is that all autoconfigures would get the default shebang

https://github.com/emscripten-core/emscripten/blob/2a8234f6651fcc2fdfaf1a97e749720ea76d55a7/tools/link.py#L460-L462

and attempt to run Node from PATH.

On my CI, I don't have a Node in PATH (exactly for the purposes of guarding against accidental 'wrong node' accesses like this). Fixes `test_bullet_autoconf` without Node in PATH: http://clbri.com:8010/api/v2/logs/406907/raw_inline