### PR TITLE
Add more debug info to RUNTIME_DEBUG to troubleshoot issue #26823

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -2031,7 +2031,7 @@ addToLibrary({
     }
 #endif
 #if RUNTIME_DEBUG
-    dbg("handleException: got unexpected exception, calling quit_")
+    dbg(`handleException: got unexpected exception ${e}, calling quit_`)
 #endif
     quit_(1, e);
   },

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -191,6 +191,8 @@ function preMain() {
 function exitRuntime() {
 #if RUNTIME_DEBUG
   dbg('exitRuntime');
+  if (!runtimeExited && globalThis.runtimeExiting) throw 'Re-entrant call to exitRuntime!';
+  globalThis.runtimeExiting = true;
 #endif
 #if ASSERTIONS
   assert(!runtimeExited);

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5476,7 +5476,8 @@ Module["preRun"] = () => {
   # Note: doesn't need audio hardware (and has no AW code that tests 2GB or wasm64)
   @requires_shared_array_buffer
   def test_audio_worklet_worker(self):
-    self.btest_exit('webaudio/audioworklet_worker.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
+    # Build with -sRUNTIME_DEBUG to surface https://github.com/emscripten-core/emscripten/issues/26823
+    self.btest_exit('webaudio/audioworklet_worker.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sRUNTIME_DEBUG'])
 
   # Tests that posting functions between the main thread and the audioworklet thread works
   @parameterized({


### PR DESCRIPTION
The issue https://github.com/emscripten-core/emscripten/issues/26823 is very sensitive to modifying timing, e.g. via console.log() or printf(). Add RUNTIME_DEBUG checks to troubleshoot the problem.