### PR TITLE
Extend pthread-hybrid support to audio worklets

### DIFF
--- a/src/lib/libsigs.js
+++ b/src/lib/libsigs.js
@@ -314,7 +314,8 @@ sigs = {
   _embind_register_value_object__sig: 'vpppppp',
   _embind_register_value_object_field__sig: 'vpppppppppp',
   _embind_register_void__sig: 'vpp',
-  _emscripten_create_audio_worklet__sig: 'viipipp',
+  _emscripten_create_audio_worklet__sig: 'viipipipp',
+
   _emscripten_create_wasm_worker__sig: 'iipip',
   _emscripten_dlopen_js__sig: 'vpppp',
   _emscripten_dlsync_threads__sig: 'v',

--- a/src/lib/libwebaudio.js
+++ b/src/lib/libwebaudio.js
@@ -170,7 +170,7 @@ var LibraryWebAudio = {
   _emscripten_create_audio_worklet__deps: [
     '$_emAudioDispatchProcessorCallback',
     '$stackAlloc', '$stackRestore', '$stackSave'],
-  _emscripten_create_audio_worklet: (wwID, contextHandle, stackLowestAddress, stackSize, callback, userData) => {
+  _emscripten_create_audio_worklet: (wwID, contextHandle, stackLowestAddress, stackSize, pthreadPtr, callback, userData) => {
 
 #if ASSERTIONS || WEBAUDIO_DEBUG
     emAudioExpectContext(contextHandle, '_emscripten_create_audio_worklet');
@@ -256,6 +256,9 @@ var LibraryWebAudio = {
         wasmMemory,
         stackLowestAddress, // sb = stack base
         stackSize,          // sz = stack size
+#if PTHREADS
+        pthreadPtr,
+#endif
       });
       audioWorklet.port.onmessage = _emAudioDispatchProcessorCallback;
       {{{ makeDynCall('viip', 'callback') }}}(contextHandle, 1/*EM_TRUE*/, userData);

--- a/system/lib/libc/emscripten_internal.h
+++ b/system/lib/libc/emscripten_internal.h
@@ -137,7 +137,7 @@ void emscripten_fetch_free(unsigned int);
 // to perform the wasm worker creation.
 bool _emscripten_create_wasm_worker(emscripten_wasm_worker_t wwID, void *stackLowestAddress, uint32_t stackSize, void* pthreadPtr);
 
-void _emscripten_create_audio_worklet(emscripten_wasm_worker_t wwID, EMSCRIPTEN_WEBAUDIO_T audioContext, void *stackLowestAddress, uint32_t stackSize, EmscriptenStartWebAudioWorkletCallback callback, void *userData2);
+void _emscripten_create_audio_worklet(emscripten_wasm_worker_t wwID, EMSCRIPTEN_WEBAUDIO_T audioContext, void *stackLowestAddress, uint32_t stackSize, void* pthreadPtr, EmscriptenStartWebAudioWorkletCallback callback, void *userData2);
 
 void __resumeException(void* exn);
 void __cxa_call_unexpected(void* exn);

--- a/system/lib/wasm_worker/audio_worklet.c
+++ b/system/lib/wasm_worker/audio_worklet.c
@@ -10,8 +10,19 @@
 #include "emscripten_internal.h"
 #include "threading_internal.h"
 
+#ifdef __EMSCRIPTEN_PTHREADS__
+void* init_pthread_struct(void *stackPlusTLSAddress, pid_t tid, size_t* stackPlusTLSSize);
+#endif
+
 // Simple wrapper function around the JS _emscripten_create_audio_worklet
 // function that adds the _emscripten_get_next_tid() as arg0
 void emscripten_start_wasm_audio_worklet_thread_async(EMSCRIPTEN_WEBAUDIO_T audioContext, void *stackLowestAddress, uint32_t stackSize, EmscriptenStartWebAudioWorkletCallback callback, void *userData2) {
-  _emscripten_create_audio_worklet(_emscripten_get_next_tid(), audioContext, stackLowestAddress, stackSize, callback, userData2);
+  emscripten_wasm_worker_t wwID = _emscripten_get_next_tid();
+  void* pthreadPtr = stackLowestAddress;
+#ifdef __EMSCRIPTEN_PTHREADS__
+  size_t stackSize_ = stackSize;
+  stackLowestAddress = init_pthread_struct(stackLowestAddress, wwID, &stackSize_);
+  stackSize = stackSize_;
+#endif
+  _emscripten_create_audio_worklet(wwID, audioContext, stackLowestAddress, stackSize, pthreadPtr, callback, userData2);
 }


### PR DESCRIPTION
Followup to #26777.

Without this change calling pthread functions from an audio worklet lets to undefined behaviour.