### PR TITLE
Increase Wasm Worker stack size to 4KB in all used examples except #26823.

### DIFF
--- a/site/source/docs/api_reference/wasm_workers.rst
+++ b/site/source/docs/api_reference/wasm_workers.rst
@@ -23,7 +23,7 @@ Quick Example
 
   int main()
   {
-    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stackSize: */1024);
+    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stackSize: */4096);
     emscripten_wasm_worker_post_function_v(worker, run_in_worker);
   }
 

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -2031,7 +2031,7 @@ addToLibrary({
     }
 #endif
 #if RUNTIME_DEBUG
-    dbg("handleException: got unexpected exception, calling quit_")
+    dbg(`handleException: got unexpected exception ${e}, calling quit_`)
 #endif
     quit_(1, e);
   },

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -188,12 +188,19 @@ function preMain() {
 #endif
 
 #if EXIT_RUNTIME
+
+#if ASSERTIONS
+var runtimeExiting = false;
+#endif
+
 function exitRuntime() {
 #if RUNTIME_DEBUG
   dbg('exitRuntime');
 #endif
 #if ASSERTIONS
   assert(!runtimeExited);
+  assert(!runtimeExiting, 'Re-entrant call to exitRuntime()! This can happen if an atexit() registered callback throws an exception.');
+  runtimeExiting = true;
 #endif
 #if ASYNCIFY == 1 && ASSERTIONS
   // ASYNCIFY cannot be used once the runtime starts shutting down.

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -188,19 +188,12 @@ function preMain() {
 #endif
 
 #if EXIT_RUNTIME
-
-#if ASSERTIONS
-var runtimeExiting = false;
-#endif
-
 function exitRuntime() {
 #if RUNTIME_DEBUG
   dbg('exitRuntime');
 #endif
 #if ASSERTIONS
   assert(!runtimeExited);
-  assert(!runtimeExiting, 'Re-entrant call to exitRuntime()! This can happen if an atexit() registered callback throws an exception.');
-  runtimeExiting = true;
 #endif
 #if ASYNCIFY == 1 && ASSERTIONS
   // ASYNCIFY cannot be used once the runtime starts shutting down.

--- a/test/atomic/test_wait32_notify.c
+++ b/test/atomic/test_wait32_notify.c
@@ -88,7 +88,7 @@ int main() {
   emscripten_out("main: creating worker");
 
 #ifdef __EMSCRIPTEN_WASM_WORKERS__
-  static char stack[1024];
+  static char stack[4096];
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 #else

--- a/test/atomic/test_wait64_notify.c
+++ b/test/atomic/test_wait64_notify.c
@@ -45,7 +45,7 @@ void run_test() {
 // This test run in both wasm workers and pthreads mode
 #ifdef __EMSCRIPTEN_WASM_WORKERS__
 
-char stack[1024];
+char stack[4096];
 
 void worker_main() {
   run_test();

--- a/test/atomic/test_wait_async.c
+++ b/test/atomic/test_wait_async.c
@@ -84,7 +84,7 @@ int main() {
   emscripten_out("main: creating worker");
 
 #ifdef __EMSCRIPTEN_WASM_WORKERS__
-  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
+  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(4096);
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 #else
   pthread_create(&t, NULL, thread_main, NULL);

--- a/test/core/test_stdio_locking.c
+++ b/test/core/test_stdio_locking.c
@@ -52,8 +52,8 @@ int main() {
   printf("in main\n");
 #ifdef __EMSCRIPTEN_WASM_WORKERS__
   emscripten_wasm_worker_t worker[2];
-  worker[0] = emscripten_malloc_wasm_worker(/*stack size: */ 1024);
-  worker[1] = emscripten_malloc_wasm_worker(/*stack size: */ 1024);
+  worker[0] = emscripten_malloc_wasm_worker(/*stack size: */ 4096);
+  worker[1] = emscripten_malloc_wasm_worker(/*stack size: */ 4096);
   emscripten_wasm_worker_post_function_v(worker[0], thread_func);
   emscripten_wasm_worker_post_function_v(worker[1], thread_func);
 

--- a/test/embind/test_embind_wasm_workers.cpp
+++ b/test/embind/test_embind_wasm_workers.cpp
@@ -24,7 +24,7 @@ void run_in_worker() {
 }
 
 int main() {
-  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stackSize: */1024);
+  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stackSize: */4096);
   emscripten_wasm_worker_post_function_v(worker, run_in_worker);
   emscripten_exit_with_live_runtime();
 }

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5465,7 +5465,7 @@ Module["preRun"] = () => {
   # Tests that audioworklets and workers can be used at the same time
   # Note: doesn't need audio hardware (and has no AW code that tests 2GB or wasm64)
   def test_audio_worklet_worker(self):
-    self.btest_exit('webaudio/audioworklet_worker.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sSTACK_OVERFLOW_CHECK=2'])
+    self.btest_exit('webaudio/audioworklet_worker.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
 
   # Tests that posting functions between the main thread and the audioworklet thread works
   @parameterized({

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5465,7 +5465,7 @@ Module["preRun"] = () => {
   # Tests that audioworklets and workers can be used at the same time
   # Note: doesn't need audio hardware (and has no AW code that tests 2GB or wasm64)
   def test_audio_worklet_worker(self):
-    self.btest_exit('webaudio/audioworklet_worker.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS'])
+    self.btest_exit('webaudio/audioworklet_worker.c', cflags=['-sAUDIO_WORKLET', '-sWASM_WORKERS', '-sSTACK_OVERFLOW_CHECK=2'])
 
   # Tests that posting functions between the main thread and the audioworklet thread works
   @parameterized({

--- a/test/wasm_worker/c11__Thread_local.c
+++ b/test/wasm_worker/c11__Thread_local.c
@@ -23,7 +23,7 @@ void worker_main() {
   emscripten_wasm_worker_post_function_v(0, main_thread_func);
 }
 
-char stack[1024];
+char stack[4096];
 
 int main() {
   emscripten_outf("%d", tls);

--- a/test/wasm_worker/condvar_waitinf.c
+++ b/test/wasm_worker/condvar_waitinf.c
@@ -90,10 +90,10 @@ int main() {
   pthread_join(signaler, NULL);
   emscripten_out("done");
 #else
-  emscripten_wasm_worker_t waiter = emscripten_malloc_wasm_worker(1024);
+  emscripten_wasm_worker_t waiter = emscripten_malloc_wasm_worker(4096);
   emscripten_wasm_worker_post_function_v(waiter, waiter_main);
 
-  emscripten_wasm_worker_t signaler = emscripten_malloc_wasm_worker(1024);
+  emscripten_wasm_worker_t signaler = emscripten_malloc_wasm_worker(4096);
   emscripten_wasm_worker_post_function_v(signaler, signaler_main);
 #endif
 }

--- a/test/wasm_worker/cpp11_thread_local.cpp
+++ b/test/wasm_worker/cpp11_thread_local.cpp
@@ -21,7 +21,7 @@ void worker_main() {
   emscripten_wasm_worker_post_function_v(0, main_thread_func);
 }
 
-char stack[1024];
+char stack[4096];
 
 int main() {
   emscripten_outf("%d", tls);

--- a/test/wasm_worker/gcc___Thread.c
+++ b/test/wasm_worker/gcc___Thread.c
@@ -22,7 +22,7 @@ void worker_main() {
   emscripten_wasm_worker_post_function_v(0, main_thread_func);
 }
 
-char stack[1024];
+char stack[4096];
 
 int main() {
   emscripten_outf("%d", tls);

--- a/test/wasm_worker/hardware_concurrency_is_lock_free.c
+++ b/test/wasm_worker/hardware_concurrency_is_lock_free.c
@@ -45,7 +45,7 @@ void worker_main() {
 #endif
 }
 
-char stack[1024];
+char stack[4096];
 
 int main() {
   test();

--- a/test/wasm_worker/hello_wasm_worker.c
+++ b/test/wasm_worker/hello_wasm_worker.c
@@ -23,7 +23,7 @@ void run_in_worker() {
 int main() {
   emscripten_out("in main");
   assert(emscripten_is_main_runtime_thread());
-  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */1024);
+  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */4096);
   assert(worker);
   emscripten_wasm_worker_post_function_v(worker, run_in_worker);
   emscripten_exit_with_live_runtime();

--- a/test/wasm_worker/lock_async_acquire.c
+++ b/test/wasm_worker/lock_async_acquire.c
@@ -95,7 +95,7 @@ void start_worker(int arg) {
 int main() {
 #define NUM_THREADS 10
   for (int i = 0; i < NUM_THREADS; ++i) {
-    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
+    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(4096);
     emscripten_wasm_worker_post_function_vi(worker, start_worker, 0);
   }
 

--- a/test/wasm_worker/lock_busyspin_wait_acquire.c
+++ b/test/wasm_worker/lock_busyspin_wait_acquire.c
@@ -45,7 +45,7 @@ void worker_main() {
 #endif
 }
 
-char stack[1024];
+char stack[4096];
 
 int main() {
   test();

--- a/test/wasm_worker/lock_busyspin_waitinf_acquire.c
+++ b/test/wasm_worker/lock_busyspin_waitinf_acquire.c
@@ -45,7 +45,7 @@ void nothing(void* userData) {
   }
 }
 #else
-char stack[1024];
+char stack[4096];
 #endif
 
 void releaseLock(void *userData) {

--- a/test/wasm_worker/lock_wait_acquire.c
+++ b/test/wasm_worker/lock_wait_acquire.c
@@ -56,7 +56,7 @@ void* thread_main(void* arg) {
   return NULL;
 }
 #else
-char stack[1024];
+char stack[4096];
 #endif
 
 int main() {

--- a/test/wasm_worker/lock_wait_acquire2.c
+++ b/test/wasm_worker/lock_wait_acquire2.c
@@ -39,8 +39,8 @@ void worker2_main() {
 #endif
 }
 
-char stack1[1024];
-char stack2[1024];
+char stack1[4096];
+char stack2[4096];
 
 int main() {
   emscripten_wasm_worker_t worker1 = emscripten_create_wasm_worker(stack1, sizeof(stack1));

--- a/test/wasm_worker/lock_waitinf_acquire.c
+++ b/test/wasm_worker/lock_waitinf_acquire.c
@@ -92,7 +92,7 @@ int main() {
 #ifdef __EMSCRIPTEN_PTHREADS__
     pthread_create(&threads[i], NULL, pthread_main, NULL);
 #else
-    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
+    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(4096);
     emscripten_wasm_worker_post_function_v(worker, worker_main);
 #endif
   }

--- a/test/wasm_worker/malloc_wasm_worker.c
+++ b/test/wasm_worker/malloc_wasm_worker.c
@@ -19,7 +19,7 @@ void worker_main() {
 
 int main() {
   assert(!emscripten_current_thread_is_wasm_worker());
-  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */1024);
+  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */4096);
   assert(worker);
   emscripten_wasm_worker_post_function_v(worker, worker_main);
   emscripten_exit_with_live_runtime();

--- a/test/wasm_worker/no_proxied_js_functions.c
+++ b/test/wasm_worker/no_proxied_js_functions.c
@@ -39,7 +39,7 @@ void worker_main() {
 #endif
 }
 
-char stack[1024];
+char stack[4096];
 
 int main() {
   proxied_js_function();

--- a/test/wasm_worker/post_function.c
+++ b/test/wasm_worker/post_function.c
@@ -76,7 +76,7 @@ void test_finished() {
 #endif
 }
 
-char stack[1024];
+char stack[4096];
 
 int main() {
   assert(!emscripten_current_thread_is_wasm_worker());

--- a/test/wasm_worker/post_function_to_main_thread.c
+++ b/test/wasm_worker/post_function_to_main_thread.c
@@ -21,7 +21,7 @@ void worker_main() {
   emscripten_wasm_worker_post_function_sig(EMSCRIPTEN_WASM_WORKER_ID_PARENT, test_success, "id", 10, 0.5);
 }
 
-char stack[1024];
+char stack[4096];
 
 int main() {
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));

--- a/test/wasm_worker/proxied_function.c
+++ b/test/wasm_worker/proxied_function.c
@@ -27,7 +27,7 @@ void run_in_worker() {
 }
 
 int main() {
-  emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(1024), run_in_worker);
+  emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(4096), run_in_worker);
   // Pin a dependency from C code to the JS function to avoid needing to mess
   // with cmdline export directives
   proxied_js_function();

--- a/test/wasm_worker/semaphore_wait_acquire.c
+++ b/test/wasm_worker/semaphore_wait_acquire.c
@@ -56,7 +56,7 @@ void* thread_main(void* arg) {
   return NULL;
 }
 #else
-char stack[1024];
+char stack[4096];
 #endif
 
 int main() {

--- a/test/wasm_worker/semaphore_waitinf_acquire.c
+++ b/test/wasm_worker/semaphore_waitinf_acquire.c
@@ -106,11 +106,11 @@ int main() {
   }
   emscripten_out("done");
 #else
-  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
+  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(4096);
   emscripten_wasm_worker_post_function_v(worker, control_thread);
 
   for (int i = 0; i < NUM_THREADS; ++i) {
-    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
+    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(4096);
     emscripten_wasm_worker_post_function_v(worker, worker_main);
   }
 #endif

--- a/test/wasm_worker/terminate_all_wasm_workers.c
+++ b/test/wasm_worker/terminate_all_wasm_workers.c
@@ -34,8 +34,8 @@ void worker_main() {
   emscripten_set_timeout(this_function_should_not_be_called, 2000, 0);
 }
 
-char stack1[1024];
-char stack2[1024];
+char stack1[4096];
+char stack2[4096];
 
 int should_throw(void(*func)(emscripten_wasm_worker_t worker), emscripten_wasm_worker_t worker) {
   int threw = EM_ASM_INT({

--- a/test/wasm_worker/terminate_wasm_worker.c
+++ b/test/wasm_worker/terminate_wasm_worker.c
@@ -32,7 +32,7 @@ void worker_main() {
   emscripten_set_timeout(this_function_should_not_be_called, 2000, 0);
 }
 
-char stack[1024];
+char stack[4096];
 
 EM_JS_DEPS(deps, "$dynCall");
 

--- a/test/wasm_worker/test_wasm_worker_dbg.c
+++ b/test/wasm_worker/test_wasm_worker_dbg.c
@@ -22,7 +22,7 @@ void run_in_worker() {
 int main() {
   emscripten_err("err from main thread");
   emscripten_dbg("dbg from main thread");
-  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */1024);
+  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stack size: */4096);
   assert(worker);
   emscripten_wasm_worker_post_function_v(worker, run_in_worker);
   emscripten_exit_with_live_runtime();

--- a/test/wasm_worker/test_wasm_worker_exceptions.c
+++ b/test/wasm_worker/test_wasm_worker_exceptions.c
@@ -13,7 +13,7 @@ void do_abort() {
 
 int main() {
   emscripten_out("in main");
-  emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(1024), do_abort);
+  emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(4096), do_abort);
   emscripten_exit_with_live_runtime();
   assert(false && "should never get here");
 }

--- a/test/wasm_worker/thread_stack.c
+++ b/test/wasm_worker/thread_stack.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 
 #define ALIGN(x,y) ((x)+(y)-1 & -(y))
-#define THREAD_STACK_SIZE 2048
+#define THREAD_STACK_SIZE 4096
 #define NUM_THREADS 2
 void *thread_stack[NUM_THREADS];
 

--- a/test/wasm_worker/wasm_worker_and_pthread.c
+++ b/test/wasm_worker/wasm_worker_and_pthread.c
@@ -84,7 +84,7 @@ void *thread_main(void *arg) {
   return 0;
 }
 
-#define WW_STACK_SIZE 2048
+#define WW_STACK_SIZE 4096
 
 void worker_main() {
   // Test self ID

--- a/test/wasm_worker/wasm_worker_code_size.c
+++ b/test/wasm_worker/wasm_worker_code_size.c
@@ -12,5 +12,5 @@ void run_in_worker() {
 }
 
 int main() {
-  emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(1024), run_in_worker);
+  emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(4096), run_in_worker);
 }

--- a/test/wasm_worker/wasm_worker_futex_wait.c
+++ b/test/wasm_worker/wasm_worker_futex_wait.c
@@ -48,5 +48,5 @@ void worker_main() {
 }
 
 int main() {
-  emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(2048), worker_main);
+  emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(4096), worker_main);
 }

--- a/test/wasm_worker/wasm_worker_self_id.c
+++ b/test/wasm_worker/wasm_worker_self_id.c
@@ -34,8 +34,8 @@ void worker2_main() {
   }
 }
 
-char stack1[1024];
-char stack2[1024];
+char stack1[4096];
+char stack2[4096];
 
 int main() {
   assert(!emscripten_current_thread_is_wasm_worker());

--- a/test/wasm_worker/wasm_worker_sleep.c
+++ b/test/wasm_worker/wasm_worker_sleep.c
@@ -10,7 +10,7 @@ void worker_main() {
 #endif
 }
 
-char stack[1024];
+char stack[4096];
 
 int main() {
   emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));

--- a/test/wasm_worker/wasm_worker_tls_wasm_assembly.c
+++ b/test/wasm_worker/wasm_worker_tls_wasm_assembly.c
@@ -25,7 +25,7 @@ void worker_main() {
   emscripten_wasm_worker_post_function_v(0, main_thread_func);
 }
 
-char stack[1024];
+char stack[4096];
 
 int main() {
   assert(!emscripten_current_thread_is_wasm_worker());

--- a/test/webaudio/audioworklet_worker.c
+++ b/test/webaudio/audioworklet_worker.c
@@ -46,7 +46,7 @@ uint8_t wasmAudioWorkletStack[4096];
 
 int main() {
   emscripten_outf("main");
-  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stackSize: */1024);
+  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stackSize: */4096);
   emscripten_wasm_worker_post_function_v(worker, run_in_worker);
 
   context = emscripten_create_audio_context(0);

--- a/test/webaudio/audioworklet_worker.c
+++ b/test/webaudio/audioworklet_worker.c
@@ -42,7 +42,7 @@ void WebAudioWorkletThreadInitialized(EMSCRIPTEN_WEBAUDIO_T audioContext, bool s
   emscripten_audio_worklet_post_function_v(audioContext, MessageReceivedInAudioWorkletThread);
 }
 
-uint8_t wasmAudioWorkletStack[1024];
+uint8_t wasmAudioWorkletStack[4096];
 
 int main() {
   emscripten_outf("main");

--- a/test/webaudio/audioworklet_worker.c
+++ b/test/webaudio/audioworklet_worker.c
@@ -42,11 +42,11 @@ void WebAudioWorkletThreadInitialized(EMSCRIPTEN_WEBAUDIO_T audioContext, bool s
   emscripten_audio_worklet_post_function_v(audioContext, MessageReceivedInAudioWorkletThread);
 }
 
-uint8_t wasmAudioWorkletStack[4096];
+uint8_t wasmAudioWorkletStack[1024];
 
 int main() {
   emscripten_outf("main");
-  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stackSize: */4096);
+  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stackSize: */1024);
   emscripten_wasm_worker_post_function_v(worker, run_in_worker);
 
   context = emscripten_create_audio_context(0);


### PR DESCRIPTION
Increase Wasm Worker stack size to 4KB in all used examples except `audioworklet_worker.c`. It is not feasible to run Wasm Workers with tiny 1KB stack sizes, that is not enough to call `emscripten_outf()` from a Wasm Worker. Mass-convert all examples that use tiny 1KB Wasm Worker stack sizes to have a 4KB stacks.

Improve RUNTIME_DEBUG print to actually print what exception was thrown.