### PR TITLE
Increase stack size in test browser.test_audioworklet_worker to 4KB

### DIFF
--- a/test/webaudio/audioworklet_worker.c
+++ b/test/webaudio/audioworklet_worker.c
@@ -46,7 +46,7 @@ uint8_t wasmAudioWorkletStack[4096];
 
 int main() {
   emscripten_outf("main");
-  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stackSize: */1024);
+  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(/*stackSize: */4096);
   emscripten_wasm_worker_post_function_v(worker, run_in_worker);
 
   context = emscripten_create_audio_context(0);


### PR DESCRIPTION
Increase stack size in test browser.test_audioworklet_worker to 4KB, to fit emscripten_outf() call in the Worker.