### PR TITLE
Fix race condition in browser.test_audioworklet_worker

### DIFF
--- a/system/include/emscripten/threading_primitives.h
+++ b/system/include/emscripten/threading_primitives.h
@@ -189,11 +189,15 @@ void emscripten_condvar_signal(emscripten_condvar_t * _Nonnull condvar, uint32_t
 // If the given memory address contains value val, puts the calling thread to
 // sleep waiting for that address to be notified. Like the linux futex syscall
 // this function returns negative errno values on failure.
-// Returns -EINVAL if addr is null.
-// Returns -ETIMEOUT if the maxWaitMilliseconds timeout was exceeded.
-// Returns -EINTR if the operation was interrupted (e.g. a timer fired, or an
-// async signal was received).
-// Returns 0 on success (i.e. another thread signaled this address)
+// Returns:
+// * negative value -EINVAL if addr is null.
+// * negative value -ETIMEDOUT if the maxWaitMilliseconds timeout was exceeded.
+// * negative value -EINTR if the operation was interrupted (e.g. a timer fired, or an
+//   async signal was received).
+// * negative value -EWOULDBLOCK if the value of the memory address 'addr' was
+//   not equal to 'val' to begin with.
+// * negative value -ECANCELED if the calling thread has been canceled.
+// * the value 0 on success (i.e. another thread signaled this address)
 int emscripten_futex_wait(volatile void/*uint32_t*/ * _Nonnull addr, uint32_t val, double maxWaitMilliseconds);
 
 // Wakes the given number of threads waiting on a location. Pass count ==

--- a/system/include/emscripten/threading_primitives.h
+++ b/system/include/emscripten/threading_primitives.h
@@ -189,6 +189,7 @@ void emscripten_condvar_signal(emscripten_condvar_t * _Nonnull condvar, uint32_t
 // If the given memory address contains value val, puts the calling thread to
 // sleep waiting for that address to be notified. Like the linux futex syscall
 // this function returns negative errno values on failure.
+// Pass maxWaitMilliseconds = INFINITY (or __builtin_inf()) to sleep indefinitely.
 // Returns:
 // * negative value -EINVAL if addr is null.
 // * negative value -ETIMEDOUT if the maxWaitMilliseconds timeout was exceeded.

--- a/test/webaudio/audioworklet_worker.c
+++ b/test/webaudio/audioworklet_worker.c
@@ -3,6 +3,7 @@
 #include <emscripten/threading.h>
 #include <assert.h>
 #include <stdbool.h>
+#include <errno.h>
 
 // Tests that
 // - audioworklets and workers can be used at the same time.
@@ -21,13 +22,11 @@ void do_exit() {
 void run_in_worker() {
   double start = emscripten_performance_now();
   emscripten_outf("run_in_worker");
-  while (emscripten_futex_wait(&workletToWorkerFlag, 0, 30000) == 0) {
-    if (workletToWorkerFlag == true) {
-      emscripten_outf("Test success (waited %.fms)", emscripten_performance_now() - start);
-      emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, &do_exit);
-      break;
-    }
+  while (emscripten_futex_wait(&workletToWorkerFlag, 0, 30000) == -ETIMEDOUT) {
+    emscripten_outf("worker wait timed out, repeating wait..");
   }
+  emscripten_outf("Test success (waited %.fms)", emscripten_performance_now() - start);
+  emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, &do_exit);
 }
 
 // This event will fire on the audio worklet thread.

--- a/test/webaudio/audioworklet_worker.c
+++ b/test/webaudio/audioworklet_worker.c
@@ -22,9 +22,7 @@ void do_exit() {
 void run_in_worker() {
   double start = emscripten_performance_now();
   emscripten_outf("run_in_worker");
-  while (emscripten_futex_wait(&workletToWorkerFlag, 0, 30000) == -ETIMEDOUT) {
-    emscripten_outf("worker wait timed out, repeating wait..");
-  }
+  emscripten_futex_wait(&workletToWorkerFlag, 0, __builtin_inf());
   emscripten_outf("Test success (waited %.fms)", emscripten_performance_now() - start);
   emscripten_wasm_worker_post_function_v(EMSCRIPTEN_WASM_WORKER_ID_PARENT, &do_exit);
 }

--- a/test/webaudio/audioworklet_worker.c
+++ b/test/webaudio/audioworklet_worker.c
@@ -3,7 +3,6 @@
 #include <emscripten/threading.h>
 #include <assert.h>
 #include <stdbool.h>
-#include <errno.h>
 
 // Tests that
 // - audioworklets and workers can be used at the same time.


### PR DESCRIPTION
Fix race condition in browser.test_audioworklet_worker where worker might miss the wakeup signal that audio worklet has posted.

Update documentation of `emscripten_futex_wait()` for the different return values the function can have.