### PR TITLE
Fix browser.test_audioworklet_worker instability on Chrome

### DIFF
--- a/test/browser_harness.html
+++ b/test/browser_harness.html
@@ -38,7 +38,9 @@
           // should load a new page, since the iframe doesn't currently have
           // a way to tell us it completed (even if it did, we'd need to poll
           // the server to know when the next test page is ready to load).
-          setTimeout(check, 10);
+          // (A timeout value of 100msecs has been seen to stall test
+          //  browser.test_audio_worklet_worker on Chrome)
+          setTimeout(check, 200);
         })
         .catch(() => {
           document.body.innerHTML = 'Tests complete. View log in console.';


### PR DESCRIPTION
Fix browser.test_audioworklet_worker instability on Chrome.

Chrome has some kind of network throttling mechanism, which prevents the Wasm Worker from being able to start up in the test browser.test_audioworklet_worker.

There is no reason to keep fetching /check every 10 milliseconds (except for performance). Reduce the fetch interval to a more modest rate of 5 fetches per second.

The browser test suite has ~150 tests, so this can slow down the test harness by at most 30 seconds.
