### PR TITLE
Simplify musl's `__wait`. NFC

### DIFF
--- a/system/lib/libc/musl/src/thread/__wait.c
+++ b/system/lib/libc/musl/src/thread/__wait.c
@@ -14,18 +14,13 @@ void __wait(volatile int *addr, volatile int *waiters, int val, int priv)
 		else return;
 	}
 	if (waiters) a_inc(waiters);
-#ifdef __EMSCRIPTEN__
-	// loop here to handle spurious wakeups from the underlying
-	// emscripten_futex_wait.
-	int ret = 0;
-	while (*addr==val && ret == 0) {
-		ret = emscripten_futex_wait((void*)addr, val, INFINITY);
-	}
-#else
 	while (*addr==val) {
+#ifdef __EMSCRIPTEN__
+		emscripten_futex_wait((void*)addr, val, INFINITY);
+#else
 		__syscall(SYS_futex, addr, FUTEX_WAIT|priv, val, 0) != -ENOSYS
 		|| __syscall(SYS_futex, addr, FUTEX_WAIT, val, 0);
-	}
 #endif
+	}
 	if (waiters) a_dec(waiters);
 }

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7323,
   "a.out.js.gz": 3573,
-  "a.out.nodebug.wasm": 19051,
-  "a.out.nodebug.wasm.gz": 8796,
-  "total": 26374,
-  "total_gz": 12369,
+  "a.out.nodebug.wasm": 19047,
+  "a.out.nodebug.wasm.gz": 8794,
+  "total": 26370,
+  "total_gz": 12367,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 7726,
   "a.out.js.gz": 3779,
-  "a.out.nodebug.wasm": 19052,
-  "a.out.nodebug.wasm.gz": 8797,
-  "total": 26778,
-  "total_gz": 12576,
+  "a.out.nodebug.wasm": 19048,
+  "a.out.nodebug.wasm.gz": 8796,
+  "total": 26774,
+  "total_gz": 12575,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_minimal_runtime_code_size_hello_wasm_worker.json
+++ b/test/codesize/test_minimal_runtime_code_size_hello_wasm_worker.json
@@ -3,8 +3,8 @@
   "a.html.gz": 355,
   "a.js": 952,
   "a.js.gz": 601,
-  "a.wasm": 2702,
-  "a.wasm.gz": 1511,
-  "total": 4169,
-  "total_gz": 2467
+  "a.wasm": 2661,
+  "a.wasm.gz": 1479,
+  "total": 4128,
+  "total_gz": 2435
 }


### PR DESCRIPTION
The `__wait` operation is supposed to keep blocking regardless
of the return code of the underlying futex. In particular it
should keep looping/waiting even on inturrupts (i.e. `-EINTR`).