### PR TITLE
Remove early return from `exitRuntime()`. NFC

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -209,7 +209,6 @@ function exitRuntime() {
 #if STACK_OVERFLOW_CHECK
   checkStackCookie();
 #endif
-  {{{ runIfWorkerThread('return;') }}} // PThreads reuse the runtime from the main thread.
 #if !STANDALONE_WASM
   ___funcs_on_exit(); // Native atexit() functions
 #endif

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -201,6 +201,9 @@ function exitRuntime() {
   assert(!runtimeExited);
   assert(!runtimeExiting, 'Re-entrant call to exitRuntime()! This can happen if an atexit() registered callback throws an exception.');
   runtimeExiting = true;
+#if PTHREADS || WASM_WORKERS
+  assert(!{{{ ENVIRONMENT_IS_WORKER_THREAD() }}}, 'exitRuntime() should only be called from the main thread');
+#endif
 #endif
 #if ASYNCIFY == 1 && ASSERTIONS
   // ASYNCIFY cannot be used once the runtime starts shutting down.


### PR DESCRIPTION
`exitRuntime()` is never called when `ENVIRONMENT_IS_PTHREAD` is true.

Split out from #13007.