### PR TITLE
Remove use of the nascent EMSCRIPTEN_AUDIO_WORKLET_NODE_T everywhere

### DIFF
--- a/site/source/docs/api_reference/wasm_audio_worklets.rst
+++ b/site/source/docs/api_reference/wasm_audio_worklets.rst
@@ -133,8 +133,8 @@ which resumes the audio context when the user clicks on the DOM Canvas element t
     };
 
     // Create node
-    EMSCRIPTEN_AUDIO_WORKLET_NODE_T wasmAudioWorklet = emscripten_create_wasm_audio_worklet_node(audioContext,
-                                                              "noise-generator", &options, &GenerateNoise, 0);
+    EMSCRIPTEN_WEBAUDIO_T wasmAudioWorklet = emscripten_create_wasm_audio_worklet_node(audioContext,
+                                                    "noise-generator", &options, &GenerateNoise, 0);
 
     // Connect it to audio context destination
     emscripten_audio_node_connect(wasmAudioWorklet, audioContext, 0, 0);

--- a/system/include/emscripten/webaudio.h
+++ b/system/include/emscripten/webaudio.h
@@ -19,6 +19,11 @@ extern "C" {
 
 typedef int EMSCRIPTEN_WEBAUDIO_T;
 
+// An outdated node type that represented an AudioWorklet node.
+// If you are using this type in your application, replace it with
+// EMSCRIPTEN_WEBAUDIO_T handle type instead.
+typedef int EMSCRIPTEN_AUDIO_WORKLET_NODE_T;
+
 // Default render size of 128 frames
 #define AUDIO_CONTEXT_RENDER_SIZE_DEFAULT 0
 // Let the hardware determine the best render size
@@ -108,8 +113,6 @@ int emscripten_audio_context_quantum_size(EMSCRIPTEN_WEBAUDIO_T audioContext);
 // Returns the sampling rate of the given Audio Context, e.g. 48000 or 44100 or similar.
 int emscripten_audio_context_sample_rate(EMSCRIPTEN_WEBAUDIO_T audioContext);
 
-typedef int EMSCRIPTEN_AUDIO_WORKLET_NODE_T;
-
 typedef struct AudioSampleFrame
 {
 	// Number of audio channels to process (multiplied by samplesPerChannel gives the elements in data)
@@ -162,7 +165,8 @@ typedef struct EmscriptenAudioWorkletNodeCreateOptions
 
 // Instantiates the given AudioWorkletProcessor as an AudioWorkletNode, which continuously calls the specified processCallback() function on the browser's audio thread to perform audio processing.
 // userData4: A custom userdata pointer to pass to the callback function. This value will be passed on to the call to the given EmscriptenWorkletNodeProcessCallback callback function.
-EMSCRIPTEN_AUDIO_WORKLET_NODE_T emscripten_create_wasm_audio_worklet_node(EMSCRIPTEN_WEBAUDIO_T audioContext, const char *name, const EmscriptenAudioWorkletNodeCreateOptions *options, EmscriptenWorkletNodeProcessCallback processCallback, void *userData4);
+// Returns a handle to the created audio worklet node object.
+EMSCRIPTEN_WEBAUDIO_T emscripten_create_wasm_audio_worklet_node(EMSCRIPTEN_WEBAUDIO_T audioContext, const char *name, const EmscriptenAudioWorkletNodeCreateOptions *options, EmscriptenWorkletNodeProcessCallback processCallback, void *userData4);
 
 // Connects a node's output to a target, e.g., connect the worklet node to the context.
 // For outputIndex and inputIndex, see the AudioNode.connect() documentation (setting 0 as the default values)

--- a/system/include/emscripten/webaudio.h
+++ b/system/include/emscripten/webaudio.h
@@ -17,6 +17,9 @@
 extern "C" {
 #endif
 
+// A handle type that represents a JavaScript side object related to WebAudio.
+// Used to denote the AudioContext and Audio Nodes, especially the Audio Worklet
+// Node.
 typedef int EMSCRIPTEN_WEBAUDIO_T;
 
 // An outdated node type that represented an AudioWorklet node.

--- a/system/include/emscripten/webaudio.h
+++ b/system/include/emscripten/webaudio.h
@@ -25,7 +25,7 @@ typedef int EMSCRIPTEN_WEBAUDIO_T;
 // An outdated node type that represented an AudioWorklet node.
 // If you are using this type in your application, replace it with
 // EMSCRIPTEN_WEBAUDIO_T handle type instead.
-typedef int EMSCRIPTEN_AUDIO_WORKLET_NODE_T;
+typedef int EMSCRIPTEN_AUDIO_WORKLET_NODE_T __attribute__((deprecated("use EMSCRIPTEN_WEBAUDIO_T instead")));
 
 // Default render size of 128 frames
 #define AUDIO_CONTEXT_RENDER_SIZE_DEFAULT 0

--- a/test/webaudio/audio_worklet_tone_generator.c
+++ b/test/webaudio/audio_worklet_tone_generator.c
@@ -82,7 +82,7 @@ void AudioWorkletProcessorCreated(EMSCRIPTEN_WEBAUDIO_T audioContext, bool succe
   };
 
   // Instantiate the noise-generator Audio Worklet Processor.
-  EMSCRIPTEN_AUDIO_WORKLET_NODE_T wasmAudioWorklet = emscripten_create_wasm_audio_worklet_node(audioContext, "tone-generator", &options, &ProcessAudio, 0);
+  EMSCRIPTEN_WEBAUDIO_T wasmAudioWorklet = emscripten_create_wasm_audio_worklet_node(audioContext, "tone-generator", &options, &ProcessAudio, 0);
 
   // Connect the audio worklet node to the graph.
   emscripten_audio_node_connect(wasmAudioWorklet, audioContext, 0, 0);

--- a/test/webaudio/audioworklet.c
+++ b/test/webaudio/audioworklet.c
@@ -116,7 +116,7 @@ void AudioWorkletProcessorCreated(EMSCRIPTEN_WEBAUDIO_T audioContext, bool succe
   };
 
   // Instantiate the noise-generator Audio Worklet Processor.
-  EMSCRIPTEN_AUDIO_WORKLET_NODE_T wasmAudioWorklet = emscripten_create_wasm_audio_worklet_node(audioContext, "noise-generator", &options, &ProcessAudio, 0);
+  EMSCRIPTEN_WEBAUDIO_T wasmAudioWorklet = emscripten_create_wasm_audio_worklet_node(audioContext, "noise-generator", &options, &ProcessAudio, 0);
   // Connect the audio worklet node to the graph.
   emscripten_audio_node_connect(wasmAudioWorklet, audioContext, 0, 0);
 

--- a/test/webaudio/audioworklet_2x_in_hard_pan.c
+++ b/test/webaudio/audioworklet_2x_in_hard_pan.c
@@ -58,7 +58,7 @@ void processorCreated(EMSCRIPTEN_WEBAUDIO_T context, bool success, void* data) {
     .numberOfOutputs = 1,
     .outputChannelCounts = outputChannelCounts
   };
-  EMSCRIPTEN_AUDIO_WORKLET_NODE_T worklet = emscripten_create_wasm_audio_worklet_node(context, "mixer", &opts, &process, NULL);
+  EMSCRIPTEN_WEBAUDIO_T worklet = emscripten_create_wasm_audio_worklet_node(context, "mixer", &opts, &process, NULL);
   emscripten_audio_node_connect(worklet, context, 0, 0);
 
   // Create the two mono source nodes and connect them to the two inputs

--- a/test/webaudio/audioworklet_2x_in_out_stereo.c
+++ b/test/webaudio/audioworklet_2x_in_out_stereo.c
@@ -57,7 +57,7 @@ void processorCreated(EMSCRIPTEN_WEBAUDIO_T context, bool success, void* data) {
     .numberOfOutputs = 2,
     .outputChannelCounts = outputChannelCounts
   };
-  EMSCRIPTEN_AUDIO_WORKLET_NODE_T worklet = emscripten_create_wasm_audio_worklet_node(context, "mixer", &opts, &process, NULL);
+  EMSCRIPTEN_WEBAUDIO_T worklet = emscripten_create_wasm_audio_worklet_node(context, "mixer", &opts, &process, NULL);
   // Both outputs connected to the context
   emscripten_audio_node_connect(worklet, context, 0, 0);
   emscripten_audio_node_connect(worklet, context, 1, 0);

--- a/test/webaudio/audioworklet_emscripten_locks.c
+++ b/test/webaudio/audioworklet_emscripten_locks.c
@@ -190,7 +190,7 @@ void processorCreated(EMSCRIPTEN_WEBAUDIO_T ctx, bool success, void* data) {
     .numberOfOutputs = 1,
     .outputChannelCounts = outputChannelCounts
   };
-  EMSCRIPTEN_AUDIO_WORKLET_NODE_T worklet = emscripten_create_wasm_audio_worklet_node(ctx, "locks-test", &opts, &process, data);
+  EMSCRIPTEN_WEBAUDIO_T worklet = emscripten_create_wasm_audio_worklet_node(ctx, "locks-test", &opts, &process, data);
   emscripten_audio_node_connect(worklet, ctx, 0, 0);
 }
 

--- a/test/webaudio/audioworklet_in_out_mono.c
+++ b/test/webaudio/audioworklet_in_out_mono.c
@@ -65,7 +65,7 @@ void processorCreated(EMSCRIPTEN_WEBAUDIO_T context, bool success, void* data) {
     .numberOfOutputs = 1,
     .outputChannelCounts = outputChannelCounts
   };
-  EMSCRIPTEN_AUDIO_WORKLET_NODE_T worklet = emscripten_create_wasm_audio_worklet_node(context, "mixer", &opts, &process, NULL);
+  EMSCRIPTEN_WEBAUDIO_T worklet = emscripten_create_wasm_audio_worklet_node(context, "mixer", &opts, &process, NULL);
   emscripten_audio_node_connect(worklet, context, 0, 0);
 
   // Create the two mono source nodes and connect them to the two inputs

--- a/test/webaudio/audioworklet_in_out_stereo.c
+++ b/test/webaudio/audioworklet_in_out_stereo.c
@@ -65,7 +65,7 @@ void processorCreated(EMSCRIPTEN_WEBAUDIO_T context, bool success, void* data) {
     .numberOfOutputs = 1,
     .outputChannelCounts = outputChannelCounts
   };
-  EMSCRIPTEN_AUDIO_WORKLET_NODE_T worklet = emscripten_create_wasm_audio_worklet_node(context, "mixer", &opts, &process, NULL);
+  EMSCRIPTEN_WEBAUDIO_T worklet = emscripten_create_wasm_audio_worklet_node(context, "mixer", &opts, &process, NULL);
   emscripten_audio_node_connect(worklet, context, 0, 0);
 
   // Create the two stereo source nodes and connect them to the two inputs

--- a/test/webaudio/audioworklet_memory_growth.c
+++ b/test/webaudio/audioworklet_memory_growth.c
@@ -95,7 +95,7 @@ void processorCreated(EMSCRIPTEN_WEBAUDIO_T context, bool success, void* data) {
     .numberOfOutputs = 1,
     .outputChannelCounts = outputChannelCounts
   };
-  EMSCRIPTEN_AUDIO_WORKLET_NODE_T worklet = emscripten_create_wasm_audio_worklet_node(context, "mixer", &opts, &process, NULL);
+  EMSCRIPTEN_WEBAUDIO_T worklet = emscripten_create_wasm_audio_worklet_node(context, "mixer", &opts, &process, NULL);
   emscripten_audio_node_connect(worklet, context, 0, 0);
 
   // Create the two stereo source nodes and connect them to the two inputs

--- a/test/webaudio/audioworklet_params_mixing.c
+++ b/test/webaudio/audioworklet_params_mixing.c
@@ -96,7 +96,7 @@ bool process(int numInputs, const AudioSampleFrame* inputs, int numOutputs, Audi
 
 // Grabs the known worklet parameter and fades in or out (depending on whether
 // it's already fading up or down, we reverse the fade direction).
-EM_JS(void, doFade, (EMSCRIPTEN_AUDIO_WORKLET_NODE_T workletID), {
+EM_JS(void, doFade, (EMSCRIPTEN_WEBAUDIO_T workletID), {
   var worklet = emscriptenGetAudioObject(workletID);
   if (worklet) {
     // Emscripten's API creates these from a C array, indexing them instead of a
@@ -131,7 +131,7 @@ void processorCreated(EMSCRIPTEN_WEBAUDIO_T context, bool success, void* data) {
     .numberOfOutputs = 1,
     .outputChannelCounts = outputChannelCounts
   };
-  EMSCRIPTEN_AUDIO_WORKLET_NODE_T worklet = emscripten_create_wasm_audio_worklet_node(context, "mixer", &opts, &process, NULL);
+  EMSCRIPTEN_WEBAUDIO_T worklet = emscripten_create_wasm_audio_worklet_node(context, "mixer", &opts, &process, NULL);
   emscripten_audio_node_connect(worklet, context, 0, 0);
 
   // Create the two stereo source nodes and connect them to the two inputs


### PR DESCRIPTION
Remove use of the nascent EMSCRIPTEN_AUDIO_WORKLET_NODE_T everywhere, and replace its uses with the EMSCRIPTEN_WEBAUDIO_T handle type instead.

No need to have separate typedefs for Web Audio handles, that would be overkill at this point.

Addresses #23153.