### PR TITLE
Fix strict.test_wasm_worker_futex_wait_pthreads. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -786,6 +786,7 @@ jobs:
             omitexports0.test_emscripten_api
             strict.test_no_declare_asm_module_exports
             strict.test_dylink_global_inits_reversed
+            strict.test_wasm_worker_futex_wait_pthreads
             "
   test-modularize-instance:
     executor: ubuntu-lts

--- a/src/lib/libwasi.js
+++ b/src/lib/libwasi.js
@@ -22,7 +22,7 @@ var WasiLibrary = {
     throw `exit(${code})`;
 #else
 #if RUNTIME_DEBUG
-    dbg(`proc_exit: ${code}`);
+    dbg(`proc_exit: ${code} (keepRuntimeAlive=${keepRuntimeAlive()})`);
 #endif
     EXITSTATUS = code;
     if (!keepRuntimeAlive()) {

--- a/test/wasm_worker/wasm_worker_futex_wait.c
+++ b/test/wasm_worker/wasm_worker_futex_wait.c
@@ -49,4 +49,5 @@ void worker_main() {
 
 int main() {
   emscripten_wasm_worker_post_function_v(emscripten_malloc_wasm_worker(4096), worker_main);
+  emscripten_exit_with_live_runtime();
 }


### PR DESCRIPTION
This test was exiting without explicitly keeping the runtime alive.

The reason this was working for all other test modes but not for `strict` is pretty subtle.  Basically I came down to the `noExitRuntime` symbols no been linked in the strict mode.

Fixes: #26866