### PR TITLE
Remove C++ guards from internal musl syscall.h. NFC

### DIFF
--- a/system/lib/libc/musl/src/internal/syscall.h
+++ b/system/lib/libc/musl/src/internal/syscall.h
@@ -30,15 +30,9 @@
 typedef long syscall_arg_t;
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 hidden long __syscall_ret(unsigned long),
 	__syscall_cp(syscall_arg_t, syscall_arg_t, syscall_arg_t, syscall_arg_t,
 	             syscall_arg_t, syscall_arg_t, syscall_arg_t);
-#ifdef __cplusplus
-}
-#endif
 
 #ifndef __EMSCRIPTEN__
 #define __syscall1(n,a) __syscall1(n,__scc(a))
@@ -445,11 +439,7 @@ hidden long __emulate_wait4(int, int *, int, void *, int);
 #define sys_wait4(a,b,c,d) __syscall_ret(__sys_wait4(a,b,c,d))
 #define sys_wait4_cp(a,b,c,d) __syscall_ret(__sys_wait4_cp(a,b,c,d))
 
-#ifdef __cplusplus
-hidden void __procfdname(char __buf[], unsigned);
-#else
 hidden void __procfdname(char __buf[static 15+3*sizeof(int)], unsigned);
-#endif
 
 hidden void *__vdsosym(const char *, const char *);
 


### PR DESCRIPTION
These were added back when we included this file from wasmfs (written in C++), but since I created the separate syscalls.h in #26658 this is no longer needed.