### PR TITLE
Fix infinite recursion in test browser.test_webgl_context_major_version.

### DIFF
--- a/test/browser/test_webgl_context_major_version.c
+++ b/test/browser/test_webgl_context_major_version.c
@@ -14,7 +14,13 @@ int main() {
   EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context;
   // turn the error call into abort so that it can be detected by the test
   EM_ASM({
-    err = (msg) => { abort(`Expected Error: ${msg}`); }
+    var originalErr = err;
+    err = (msg) => {
+      // Restore original err() to avoid infinite recursion, because abort() will
+      // print to err().
+      err = originalErr;
+      abort(`Expected Error: ${msg}`);
+    }
   });
   context = emscripten_webgl_create_context("#canvas", &attrs);
   assert(context);


### PR DESCRIPTION
Fix infinite recursion in test browser.test_webgl_context_major_version.

abort() calls to err(), and the test would overwrite err() to call to abort().

The test would pass, but only after throwing 

```
[890/960] test_webgl_context_major_version (test_browser.browser64_4gb.test_webgl_context_major_version) ... JavaScript error: http://localhost:8888/test.js, line 193: InternalError: too much recursion
JavaScript error: http://localhost:8888/test.js, line 193: InternalError: too much recursion
JavaScript error: http://localhost:8888/test.js, line 193: InternalError: too much recursion
JavaScript error: http://localhost:8888/test.js, line 193: InternalError: too much recursion
ok
```

http://clbri.com:8010/api/v2/logs/420471/raw_inline
