### PR TITLE
Require names when using `STACK_OVERFLOW_CHECK=2`

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3192,6 +3192,7 @@ More info: https://emscripten.org
       (['-Oz', '-gsource-map'], False, True, False),
       (['-gsource-map', '-sERROR_ON_WASM_CHANGES_AFTER_LINK'], False, True, False),
       (['-gsource-map', '-Og', '-sERROR_ON_WASM_CHANGES_AFTER_LINK'], False, True, False),
+      (['-sSTACK_OVERFLOW_CHECK=2'], False, False, False),
     ]:
       print(flags, expect_dwarf, expect_sourcemap, expect_names)
       self.emcc(test_file(source_file), flags + ['-o', js_file])

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -541,7 +541,9 @@ def finalize_wasm(infile, outfile, js_syms):
     args.append('--side-module')
   if settings.STACK_OVERFLOW_CHECK >= 2:
     args.append('--check-stack-overflow')
+    # The check-stack pass in binaryen needs to be able to locate `__stack_pointer` by name.
     modify_wasm = True
+    need_name_section = True
   if settings.STANDALONE_WASM:
     args.append('--standalone-wasm')
 


### PR DESCRIPTION
This change is needed so that https://github.com/WebAssembly/binaryen/pull/8679 can roll in.

The combination will then fix #24964