### PR TITLE
[wasm64] Add casts when `makeDynCall` returns a pointer

### DIFF
--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -682,6 +682,7 @@ function makeDynCall(sig, funcPtr, promising = false) {
   }
   args = args.join(', ');
 
+  const needRtnConversion = MEMORY64 && sig[0] == 'p';
   const needArgConversion = MEMORY64 && sig.includes('p');
   let callArgs = args;
   if (needArgConversion) {
@@ -751,7 +752,11 @@ Please update to new syntax.`);
   }
 
   if (needArgConversion) {
-    return `((${args}) => ${getWasmTableEntry}.call(null, ${callArgs}))`;
+    if (needRtnConversion) {
+      return `((${args}) => Number(${getWasmTableEntry}.call(null, ${callArgs})))`;
+    } else {
+      return `((${args}) => ${getWasmTableEntry}.call(null, ${callArgs}))`;
+    }
   }
   return getWasmTableEntry;
 }

--- a/test/core/test_dyncall_ptr_handling.c
+++ b/test/core/test_dyncall_ptr_handling.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <string.h>
+
+char* get_string(char* input) {
+  static char buffer[256];
+  strcpy(buffer, "hello ");
+  strcat(buffer, input);
+  return buffer;
+}
+
+void test_ptr_handling(char* (*fnptr)(char*), char* arg);
+
+int main() {
+  test_ptr_handling(&get_string, "world");
+  return 0;
+}

--- a/test/core/test_dyncall_ptr_handling.js
+++ b/test/core/test_dyncall_ptr_handling.js
@@ -1,0 +1,8 @@
+addToLibrary({
+  test_ptr_handling: function(fnptr, arg) {
+    // Both 'p' as return type and 'p' as argument type should be handled.
+    var ptr = {{{ makeDynCall('pp', 'fnptr') }}}(arg);
+    console.log('ptr type: ' + typeof ptr);
+    console.log('ptr value: ' + UTF8ToString(ptr));
+  }
+});

--- a/test/core/test_dyncall_ptr_handling.out
+++ b/test/core/test_dyncall_ptr_handling.out
@@ -1,0 +1,2 @@
+ptr type: number
+ptr value: hello world

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7118,6 +7118,9 @@ void* operator new(size_t size) {
       print(str(extra_args) + ' ' + which)
       self.do_core_test('test_dyncall_specific.c', cflags=['-D' + which] + extra_args)
 
+  def test_dyncall_ptr_handling(self):
+    self.do_core_test('test_dyncall_ptr_handling.c', cflags=['--js-library', test_file('core/test_dyncall_ptr_handling.js')])
+
   @parameterized({
     '': ([],),
     'legacy': (['-sDYNCALLS'],),


### PR DESCRIPTION
This fixes a `UTF8ToString expects a number (got bigint)` crash in our `beforeunload` handler that was occurring on wasm64 only.

Fixes: #26876