### PR TITLE
Cache and re-use pthread blob URL when using `mainScriptUrlOrBlob`

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -492,7 +492,7 @@ var LibraryPThread = {
         if (Module['mainScriptUrlOrBlob']) {
           var pthreadMainJs = Module['mainScriptUrlOrBlob'];
           if (typeof pthreadMainJs != 'string') {
-            pthreadMainJs = URL.createObjectURL(pthreadMainJs);
+            pthreadMainJs = PThread.blobURL ??= URL.createObjectURL(pthreadMainJs);
           }
           worker = new Worker(pthreadMainJs, {{{ pthreadWorkerOptions }}});
         } else
@@ -503,8 +503,8 @@ var LibraryPThread = {
       // due to CORS restrictions.
       // https://github.com/emscripten-core/emscripten/issues/21937
       if (ENVIRONMENT_IS_WEB) {
-        var url = URL.createObjectURL(new Blob([`import '${import.meta.url}'`], { type: 'application/javascript' }));
-        worker = new Worker(url, {{{ pthreadWorkerOptions }}});
+        PThread.blobURL ??= URL.createObjectURL(new Blob([`import '${import.meta.url}'`], { type: 'application/javascript' }));
+        worker = new Worker(PThread.blobURL, {{{ pthreadWorkerOptions }}});
       } else
 #endif
       // We need to generate the URL with import.meta.url as the base URL of the JS file
@@ -522,7 +522,7 @@ var LibraryPThread = {
       // itself does not allow this.
       // https://github.com/emscripten-core/emscripten/issues/21937
       if (ENVIRONMENT_IS_WEB) {
-        pthreadMainJs = URL.createObjectURL(new Blob([`importScripts('${_scriptName}')`], { type: 'application/javascript' }));
+        pthreadMainJs = PThread.blobURL ??= URL.createObjectURL(new Blob([`importScripts('${_scriptName}')`], { type: 'application/javascript' }));
       }
 #endif
 #if expectToReceiveOnModule('mainScriptUrlOrBlob')
@@ -531,7 +531,7 @@ var LibraryPThread = {
       if (Module['mainScriptUrlOrBlob']) {
         pthreadMainJs = Module['mainScriptUrlOrBlob'];
         if (typeof pthreadMainJs != 'string') {
-          pthreadMainJs = URL.createObjectURL(pthreadMainJs);
+          pthreadMainJs = PThread.blobURL ??= URL.createObjectURL(pthreadMainJs);
         }
       }
 #endif
@@ -739,7 +739,7 @@ var LibraryPThread = {
 #if ENVIRONMENT_MAY_BE_WEB
     // Feature detect whether the main thread can block.
     try {
-      Atomics.wait(HEAP32, 0, 0, 0)
+      Atomics.wait(HEAP32, 0, 0, 0);
       can_block = true;
     } catch (e) {}
 #endif
@@ -1294,7 +1294,7 @@ var LibraryPThread = {
                         '_emscripten_thread_mailbox_await'],
   $checkMailbox: () => {
     // checkMailbox can be called after the pthread has shut down. See
-    // Pthread.terminateRuntime().
+    // PThread.terminateRuntime().
     // In this case we return silently without re-registering using waitAsync.
     // Perhaps there is a more universal way we can detect runtime has exited.
     // TODO(https://github.com/emscripten-core/emscripten/issues/25076)

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -470,7 +470,7 @@ var LibraryPThread = {
         if (Module['mainScriptUrlOrBlob']) {
           var pthreadMainJs = Module['mainScriptUrlOrBlob'];
           if (typeof pthreadMainJs != 'string') {
-            pthreadMainJs = URL.createObjectURL(pthreadMainJs);
+            pthreadMainJs = PThread.blobURL ??= URL.createObjectURL(pthreadMainJs);
           }
           worker = new Worker(pthreadMainJs, {{{ pthreadWorkerOptions }}});
         } else
@@ -481,8 +481,8 @@ var LibraryPThread = {
       // due to CORS restrictions.
       // https://github.com/emscripten-core/emscripten/issues/21937
       if (ENVIRONMENT_IS_WEB) {
-        var url = URL.createObjectURL(new Blob([`import '${import.meta.url}'`], { type: 'application/javascript' }));
-        worker = new Worker(url, {{{ pthreadWorkerOptions }}});
+        PThread.blobURL ??= URL.createObjectURL(new Blob([`import '${import.meta.url}'`], { type: 'application/javascript' }));
+        worker = new Worker(PThread.blobURL, {{{ pthreadWorkerOptions }}});
       } else
 #endif
       // We need to generate the URL with import.meta.url as the base URL of the JS file
@@ -500,7 +500,7 @@ var LibraryPThread = {
       // itself does not allow this.
       // https://github.com/emscripten-core/emscripten/issues/21937
       if (ENVIRONMENT_IS_WEB) {
-        pthreadMainJs = URL.createObjectURL(new Blob([`importScripts('${_scriptName}')`], { type: 'application/javascript' }));
+        pthreadMainJs = PThread.blobURL ??= URL.createObjectURL(new Blob([`importScripts('${_scriptName}')`], { type: 'application/javascript' }));
       }
 #endif
 #if expectToReceiveOnModule('mainScriptUrlOrBlob')
@@ -509,7 +509,7 @@ var LibraryPThread = {
       if (Module['mainScriptUrlOrBlob']) {
         pthreadMainJs = Module['mainScriptUrlOrBlob'];
         if (typeof pthreadMainJs != 'string') {
-          pthreadMainJs = URL.createObjectURL(pthreadMainJs);
+          pthreadMainJs = PThread.blobURL ??= URL.createObjectURL(pthreadMainJs);
         }
       }
 #endif
@@ -722,7 +722,7 @@ var LibraryPThread = {
 #if ENVIRONMENT_MAY_BE_WEB
     // Feature detect whether the main thread can block.
     try {
-      Atomics.wait(HEAP32, 0, 0, 0)
+      Atomics.wait(HEAP32, 0, 0, 0);
       can_block = true;
     } catch (e) {}
 #endif
@@ -1277,7 +1277,7 @@ var LibraryPThread = {
                         '_emscripten_thread_mailbox_await'],
   $checkMailbox: () => {
     // checkMailbox can be called after the pthread has shut down. See
-    // Pthread.terminateRuntime().
+    // PThread.terminateRuntime().
     // In this case we return silently without re-registering using waitAsync.
     // Perhaps there is a more universal way we can detect runtime has exited.
     // TODO(https://github.com/emscripten-core/emscripten/issues/25076)


### PR DESCRIPTION
Without this change the blobURL is constructed for each thread that is created.

Gemini seemed to think this might help with #26882

In any case this seems like obvious improvement, even though I imagine `mainScriptUrlOrBlob` has very few users.