### PR TITLE
Use `_Thread_local` for `h_errno` to match errno. NFC

### DIFF
--- a/src/struct_info_generated.json
+++ b/src/struct_info_generated.json
@@ -1040,11 +1040,11 @@
             "p_proto": 8
         },
         "pthread": {
-            "__size__": 128,
-            "profilerBlock": 104,
+            "__size__": 124,
+            "profilerBlock": 100,
             "stack": 48,
             "stack_size": 52,
-            "waiting_async": 120
+            "waiting_async": 116
         },
         "pthread_attr_t": {
             "__size__": 44,

--- a/src/struct_info_generated_wasm64.json
+++ b/src/struct_info_generated_wasm64.json
@@ -1040,11 +1040,11 @@
             "p_proto": 16
         },
         "pthread": {
-            "__size__": 224,
-            "profilerBlock": 184,
+            "__size__": 216,
+            "profilerBlock": 176,
             "stack": 80,
             "stack_size": 88,
-            "waiting_async": 212
+            "waiting_async": 204
         },
         "pthread_attr_t": {
             "__size__": 88,

--- a/system/lib/libc/musl/src/internal/pthread_impl.h
+++ b/system/lib/libc/musl/src/internal/pthread_impl.h
@@ -61,7 +61,10 @@ struct pthread {
 		long off;
 		volatile void *volatile pending;
 	} robust_list;
+#ifndef __EMSCRIPTEN__
+	// Emscripten uses C11 _Thread_local instead for h_errno
 	int h_errno_val;
+#endif
 	volatile int timer_id;
 #ifndef __EMSCRIPTEN__
 	// Emscripten uses C11 _Thread_local instead for locale

--- a/system/lib/libc/musl/src/network/h_errno.c
+++ b/system/lib/libc/musl/src/network/h_errno.c
@@ -4,8 +4,16 @@
 #undef h_errno
 int h_errno;
 
+#ifdef __EMSCRIPTEN__
+static _Thread_local int __h_errno_storage;
+#endif
+
 int *__h_errno_location(void)
 {
+#ifdef __EMSCRIPTEN__
+	return &__h_errno_storage;
+#else
 	if (!__pthread_self()->stack) return &h_errno;
 	return &__pthread_self()->h_errno_val;
+#endif
 }

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -2,9 +2,9 @@
   "a.out.js": 19260,
   "a.out.js.gz": 7991,
   "a.out.nodebug.wasm": 132627,
-  "a.out.nodebug.wasm.gz": 49921,
+  "a.out.nodebug.wasm.gz": 49919,
   "total": 151887,
-  "total_gz": 57912,
+  "total_gz": 57910,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,9 +1,9 @@
 {
   "a.out.js": 19237,
   "a.out.js.gz": 7978,
-  "a.out.nodebug.wasm": 132055,
+  "a.out.nodebug.wasm": 132053,
   "a.out.nodebug.wasm.gz": 49575,
-  "total": 151292,
+  "total": 151290,
   "total_gz": 57553,
   "sent": [
     "__cxa_throw",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -2,9 +2,9 @@
   "a.out.js": 19092,
   "a.out.js.gz": 7925,
   "a.out.nodebug.wasm": 147926,
-  "a.out.nodebug.wasm.gz": 55309,
+  "a.out.nodebug.wasm.gz": 55308,
   "total": 167018,
-  "total_gz": 63234,
+  "total_gz": 63233,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -2,9 +2,9 @@
   "a.out.js": 18629,
   "a.out.js.gz": 7685,
   "a.out.nodebug.wasm": 102164,
-  "a.out.nodebug.wasm.gz": 39547,
+  "a.out.nodebug.wasm.gz": 39552,
   "total": 120793,
-  "total_gz": 47232,
+  "total_gz": 47237,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -2,9 +2,9 @@
   "a.out.js": 19260,
   "a.out.js.gz": 7991,
   "a.out.nodebug.wasm": 134657,
-  "a.out.nodebug.wasm.gz": 50769,
+  "a.out.nodebug.wasm.gz": 50774,
   "total": 153917,
-  "total_gz": 58760,
+  "total_gz": 58765,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_wasmfs.json
+++ b/test/codesize/test_codesize_cxx_wasmfs.json
@@ -2,9 +2,9 @@
   "a.out.js": 7023,
   "a.out.js.gz": 3310,
   "a.out.nodebug.wasm": 172750,
-  "a.out.nodebug.wasm.gz": 63325,
+  "a.out.nodebug.wasm.gz": 63333,
   "total": 179773,
-  "total_gz": 66635,
+  "total_gz": 66643,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -2,9 +2,9 @@
   "a.out.js": 26251,
   "a.out.js.gz": 11195,
   "a.out.nodebug.wasm": 17671,
-  "a.out.nodebug.wasm.gz": 8925,
+  "a.out.nodebug.wasm.gz": 8920,
   "total": 43922,
-  "total_gz": 20120,
+  "total_gz": 20115,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
   "a.out.js": 268033,
-  "a.out.nodebug.wasm": 587223,
-  "total": 855256,
+  "a.out.nodebug.wasm": 587151,
+  "total": 855184,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -2,9 +2,9 @@
   "a.out.js": 7372,
   "a.out.js.gz": 3594,
   "a.out.nodebug.wasm": 19047,
-  "a.out.nodebug.wasm.gz": 8794,
+  "a.out.nodebug.wasm.gz": 8795,
   "total": 26419,
-  "total_gz": 12388,
+  "total_gz": 12389,
   "sent": [
     "a (memory)",
     "b (exit)",


### PR DESCRIPTION
This has the nice side effect of reducing the size of the pthread struct so programs that don't use `h_errno` don't pay any codesize cost.