### PR TITLE
Enabled `test_pthread_dylink_tls` under `STACK_OVERFLOW_CHECK=2`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -710,6 +710,7 @@ jobs:
             core2g.test_externref
             corez.test_dylink_iostream
             core2ss.test_pthread_dylink
+            core2ss.test_pthread_dylink_tls
             core2ss.test_pthread_thread_local_storage
             core2ss.test_wasm_worker_futex_wait
             core2s.test_dylink_syslibs_missing_assertions

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9364,9 +9364,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @needs_dylink
   @requires_pthreads
   def test_pthread_dylink_tls(self):
-    if self.get_setting('STACK_OVERFLOW_CHECK') == 2:
-      self.skipTest('https://github.com/emscripten-core/emscripten/issues/24964: fails with stack overflow (Attempt to set SP to 0x000114d0, with stack limits [0x00000000 - 0x00000000])')
-
     self.cflags += ['-Wno-experimental', '-pthread']
     main = test_file('core/pthread/test_pthread_dylink_tls.c')
     self.dylink_testf(main, main_cflags=['-sPTHREAD_POOL_SIZE=1'])


### PR DESCRIPTION
The actual fix for this was combination of #26878 and https://github.com/WebAssembly/binaryen/pull/8679

Fixes: #24964 Please enter the commit message for your changes. Lines starting