### PR TITLE
Add IDBFS.onAutoPersistStateChanged callback. Fixes flakiness in browser.test_fs_idbfs_sync_autopersist

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -38,6 +38,9 @@ See docs/process.md for more on how version tagging works.
   binaryen for wasm). (#26677)
 - The `-m64` compiler flag is now honored, and works as an alias for
   `-sMEMORY64` and/or `--target=wasm64`. (#26765)
+- The autopersistence feature in IDBFS mount now supports registering a global
+  callback `IDBFS.onAutoPersistStateChanged = active => {}`, which will be
+  notified of all IDBFS sync start and end events. (#26895)
 
 5.0.7 - 04/30/26
 ----------------

--- a/src/lib/libidbfs.js
+++ b/src/lib/libidbfs.js
@@ -18,14 +18,31 @@ addToLibrary({
     DB_VERSION: 21,
     DB_STORE_NAME: 'FILE_DATA',
 
+    // When using the autopersistence mechanism, users can set
+    // IDBFS.onAutoPersistStateChanged callback to receive notification events
+    // for when persistence operations are in-flight. Use the following syntax:
+    /*
+    IDBFS.onAutoPersistStateChanged = autoPersistActive => {
+      if (autoPersistActive) {
+        console.log('IDBFS persistence operation has started.');
+      } else {
+        console.log('IDBFS persistence operation has finished.');
+      }
+    };
+    */
+
     // Queues a new VFS -> IDBFS synchronization operation
     queuePersist: (mount) => {
       function onPersistComplete() {
         if (mount.idbPersistState === 'again') startPersist(); // If a new sync request has appeared in between, kick off a new sync
-        else mount.idbPersistState = 0; // Otherwise reset sync state back to idle to wait for a new sync later
+        else {
+          mount.idbPersistState = 0; // Otherwise reset sync state back to idle to wait for a new sync later
+          IDBFS.onAutoPersistStateChanged?.(false);
+        }
       }
       function startPersist() {
         mount.idbPersistState = 'idb'; // Mark that we are currently running a sync operation
+        IDBFS.onAutoPersistStateChanged?.(true);
         IDBFS.syncfs(mount, /*populate:*/false, onPersistComplete);
       }
 

--- a/test/fs/test_idbfs_sync.c
+++ b/test/fs/test_idbfs_sync.c
@@ -157,7 +157,7 @@ void test() {
   // Register an IDBFS autopersist completion callback to detect when the
   // filesystem sync operation has finished.
   EM_ASM({
-    IDBFS.onAutoPersistStateChanged = autoPersistActive => {
+    IDBFS.onAutoPersistStateChanged = (autoPersistActive) => {
       if (autoPersistActive) {
         console.log('IDBFS persistence operation has started.');
       } else {

--- a/test/fs/test_idbfs_sync.c
+++ b/test/fs/test_idbfs_sync.c
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <emscripten.h>
-#include <emscripten/eventloop.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -38,10 +37,6 @@ void cleanup() {
   unlink("/working1/moar.txt");
   rmdir("/working1/dir");
   EM_ASM(FS.syncfs(function(){})); // And persist deleted changes
-}
-
-void test_finish(void *user_data) {
-  finish();
 }
 
 EMSCRIPTEN_KEEPALIVE

--- a/test/fs/test_idbfs_sync.c
+++ b/test/fs/test_idbfs_sync.c
@@ -159,12 +159,18 @@ void test() {
 #ifdef IDBFS_AUTO_PERSIST
 
 #if FIRST
-  // IDBFS autopersist sync mechanism does not have a completion callback API,
-  // so we don't know exactly when it will be done. If we force-quit the
-  // browser immediately, the IDBFS persist might not have had time to complete.
-  // So give the sync some time to complete, before quitting the first phase of
-  // this test.
-  emscripten_set_timeout(test_finish, 5000, 0);
+  // Register an IDBFS autopersist completion callback to detect when the
+  // filesystem sync operation has finished.
+  EM_ASM({
+    IDBFS.onAutoPersistStateChanged = autoPersistActive => {
+      if (autoPersistActive) {
+        console.log('IDBFS persistence operation has started.');
+      } else {
+        console.log('IDBFS persistence operation has finished.');
+        callUserCallback(_finish);
+      }
+    }
+  });
 #else
   finish();
 #endif

--- a/test/fs/test_idbfs_sync.c
+++ b/test/fs/test_idbfs_sync.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <emscripten.h>
+#include <emscripten/eventloop.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -37,6 +38,10 @@ void cleanup() {
   unlink("/working1/moar.txt");
   rmdir("/working1/dir");
   EM_ASM(FS.syncfs(function(){})); // And persist deleted changes
+}
+
+void test_finish(void *user_data) {
+  finish();
 }
 
 EMSCRIPTEN_KEEPALIVE
@@ -152,7 +157,18 @@ void test() {
 #endif
 
 #ifdef IDBFS_AUTO_PERSIST
+
+#if FIRST
+  // IDBFS autopersist sync mechanism does not have a completion callback API,
+  // so we don't know exactly when it will be done. If we force-quit the
+  // browser immediately, the IDBFS persist might not have had time to complete.
+  // So give the sync some time to complete, before quitting the first phase of
+  // this test.
+  emscripten_set_timeout(test_finish, 5000, 0);
+#else
   finish();
+#endif
+
 #else
   // sync from memory state to persisted and then
   // run 'finish'


### PR DESCRIPTION
Add IDBFS.onAutoPersistStateChanged callback that can be used to detect when IDBFS autopersistence operations start and finish.

Fixes test failures in test browser.test_test_fs_idbfs_sync_autopersist, by giving the persistence logic time to complete before quitting the first phase of test.