### PR TITLE
[tsgen] Use node16 resolution for tsgen CommonJS test

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3556,7 +3556,9 @@ More info: https://emscripten.org
 
   @requires_dev_dependency('typescript')
   @parameterized({
-    'commonjs': [['-sMODULARIZE'], ['--module', 'commonjs', '--moduleResolution', 'node']],
+    # Use `node16` to avoid the deprecated `node` moduleResolution in TS 6.0+. Since there is no
+    # `type: "module"` in package.json, this still tests CommonJS.
+    'commonjs': [['-sMODULARIZE'], ['--module', 'node16', '--moduleResolution', 'node16']],
     'esm': [['-sEXPORT_ES6'], ['--module', 'NodeNext', '--moduleResolution', 'nodenext']],
     'esm_with_jsgen': [['-sEXPORT_ES6', '-sEMBIND_AOT'], ['--module', 'NodeNext', '--moduleResolution', 'nodenext']],
   })


### PR DESCRIPTION
Update the CommonJS test case in `test_embind_tsgen_end_to_end` to use `node16` for `--module` and `--moduleResolution`.

This fixes the TS5107 compiler error caused by the deprecation of the legacy `node10` resolution strategy in modern versions of TypeScript.

Because there is no `type: "module"` specified in the package.json of the test environment, `node16` resolution continues to treat and generate files as CommonJS, preserving the intent of the test.