### PR TITLE
Disable failing test browser_2gb.test_sdl_canvas_safe_heap on Safari.

### DIFF
--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -924,6 +924,7 @@ window.close = () => {
     'safe_heap': (['-sSAFE_HEAP'],),
     'safe_heap_O2': (['-sSAFE_HEAP', '-O2'],),
   })
+  @no_safari('Fails in browser_2gb.test_sdl_canvas_safe_heap variant') # Fails in Safari 26.0.1 (21622.1.22.11.15)
   def test_sdl_canvas(self, args):
     self.btest_exit('test_sdl_canvas.c', cflags=['-sSTRICT_JS', '-sLEGACY_GL_EMULATION', '-lSDL', '-lGL'] + args)
 

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -924,7 +924,7 @@ window.close = () => {
     'safe_heap': (['-sSAFE_HEAP'],),
     'safe_heap_O2': (['-sSAFE_HEAP', '-O2'],),
   })
-  @no_safari('Fails in browser_2gb.test_sdl_canvas_safe_heap variant') # Fails in Safari 26.0.1 (21622.1.22.11.15)
+  @no_safari('Fails in browser_2gb.test_sdl_canvas_safe_heap variant. https://webkit.org/b/314444') # Fails in Safari 26.0.1 (21622.1.22.11.15)
   def test_sdl_canvas(self, args):
     self.btest_exit('test_sdl_canvas.c', cflags=['-sSTRICT_JS', '-sLEGACY_GL_EMULATION', '-lSDL', '-lGL'] + args)
 


### PR DESCRIPTION
This test fails in what looks like some kind of a WebAssembly code miscompilation(!)

<img width="2869" height="1437" alt="image" src="https://github.com/user-attachments/assets/b2f6a55b-d399-490e-a565-ae538ad19fb7" />

Compiled malloc segfaults. I've no idea why that happens, and only in this test.

Above:
 - left side=Firefox, runs ok.
 - right side=Safari 26, fails.

Reduced STR:

`test.c`

```c++
#include <assert.h>
#include <stdio.h>
#include <stdlib.h>
#include <SDL/SDL.h>
#include <SDL/SDL_ttf.h>
#include <emscripten.h>
#include <emscripten/html5.h>

int main(int argc, char **argv) {
  SDL_Init(SDL_INIT_VIDEO);
  SDL_Surface *screen = SDL_SetVideoMode(600, 450, 32, SDL_HWSURFACE);
  return 0;
}
```

```
emcc test.c -sSTRICT_JS -sLEGACY_GL_EMULATION -lSDL -lGL -sSAFE_HEAP -g -sINITIAL_MEMORY=2200mb -sGLOBAL_BASE=2GB -o test.html
```

results in Safari calling out to `segfault`.

Also happens in `-sMALLOC=emmalloc`.

Will need to investigate more. For now disable the test to try to get my macOS runner green.