### PR TITLE
Rename internal var arguments_ -> programArgs

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -115,7 +115,7 @@ function stackCheckInit() {
 #endif
 
 #if MAIN_READS_PARAMS
-function run(args = arguments_) {
+function run(args = programArgs) {
 #else
 function run() {
 #endif

--- a/src/postlibrary.js
+++ b/src/postlibrary.js
@@ -17,7 +17,7 @@ function processModuleArgs()
   checkIncomingModuleAPI();
 #endif
 
-  {{{ makeModuleReceive('arguments_', 'arguments') }}}
+  {{{ makeModuleReceive('programArgs', 'arguments') }}}
   {{{ makeModuleReceive('thisProgram') }}}
 
 #if ASSERTIONS

--- a/src/shell.js
+++ b/src/shell.js
@@ -136,7 +136,7 @@ if (ENVIRONMENT_IS_NODE) {
 // refer to Module (if they choose; they can also define Module)
 {{{ preJS() }}}
 
-var arguments_ = [];
+var programArgs = [];
 var thisProgram = './this.program';
 var quit_ = (status, toThrow) => {
   throw toThrow;
@@ -215,7 +215,7 @@ if (ENVIRONMENT_IS_NODE) {
     thisProgram = process.argv[1].replace(/\\/g, '/');
   }
 
-  arguments_ = process.argv.slice(2);
+  programArgs = process.argv.slice(2);
 
 #if !MODULARIZE
   // MODULARIZE will export the module in the proper place outside, we don't need to export here
@@ -255,8 +255,8 @@ if (ENVIRONMENT_IS_SHELL) {
 
   globalThis.clearTimeout ??= (id) => {};
 
-  // v8 uses `arguments_` whereas spidermonkey uses `scriptArgs`
-  arguments_ = globalThis.arguments || globalThis.scriptArgs;
+  // v8 and jsc both use `arguments`. spidermonkey uses `scriptArgs`
+  programArgs = globalThis.arguments ?? globalThis.scriptArgs;
 
   if (globalThis.quit) {
     quit_ = (status, toThrow) => {

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -158,7 +158,7 @@ Module["expectedDataFileDownloads"]++;
 })();
 
 // end include: <FILENAME REPLACED>
-var arguments_ = [];
+var programArgs = [];
 
 var thisProgram = "./this.program";
 
@@ -209,7 +209,7 @@ if (ENVIRONMENT_IS_NODE) {
   if (process.argv.length > 1) {
     thisProgram = process.argv[1].replace(/\\/g, "/");
   }
-  arguments_ = process.argv.slice(2);
+  programArgs = process.argv.slice(2);
   // MODULARIZE will export the module in the proper place outside, we don't need to export here
   if (typeof module != "undefined") {
     module["exports"] = Module;

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -75,7 +75,7 @@ var ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIR
 // refer to Module (if they choose; they can also define Module)
 
 
-var arguments_ = [];
+var programArgs = [];
 var thisProgram = './this.program';
 var quit_ = (status, toThrow) => {
   throw toThrow;
@@ -132,7 +132,7 @@ readAsync = async (filename, binary = true) => {
     thisProgram = process.argv[1].replace(/\\/g, '/');
   }
 
-  arguments_ = process.argv.slice(2);
+  programArgs = process.argv.slice(2);
 
   // MODULARIZE will export the module in the proper place outside, we don't need to export here
   if (typeof module != 'undefined') {

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 57033,
-  "hello_world.js.gz": 17750,
+  "hello_world.js": 57036,
+  "hello_world.js.gz": 17754,
   "hello_world.wasm": 14850,
   "hello_world.wasm.gz": 7314,
-  "no_asserts.js": 26622,
-  "no_asserts.js.gz": 8888,
+  "no_asserts.js": 26625,
+  "no_asserts.js.gz": 8892,
   "no_asserts.wasm": 12010,
   "no_asserts.wasm.gz": 5880,
-  "strict.js": 54815,
-  "strict.js.gz": 17049,
+  "strict.js": 54817,
+  "strict.js.gz": 17051,
   "strict.wasm": 14850,
   "strict.wasm.gz": 7310,
-  "total": 180180,
-  "total_gz": 64191
+  "total": 180188,
+  "total_gz": 64201
 }

--- a/test/pthread/test_pthread_mandelbrot.cpp
+++ b/test/pthread/test_pthread_mandelbrot.cpp
@@ -504,7 +504,7 @@ void main_tick()
       var updatesPerFrame = (new RegExp("[\\?&]updates=([^&#]*)")).exec(location.href);
       if (updatesPerFrame) return updatesPerFrame[1];
     }
-    if (arguments_ && arguments_.length >= 1) return parseInt(arguments_[0]);
+    if (programArgs && programArgs.length >= 1) return parseInt(programArgs[0]);
     if (globalThis.document?.getElementById('updates_per_frame')) return parseInt(document.getElementById('updates_per_frame').value);
     return 50;
   });
@@ -605,7 +605,7 @@ int main(int argc, char** argv)
   if (ENVIRONMENT_IS_WEB) {
     emscripten_set_main_loop(main_tick, 0, 0);
   } else {
-    int numTotalFrames = EM_ASM_INT(return (arguments_ && arguments_.length >= 2) ? parseInt(arguments_[1]) : 1000);
+    int numTotalFrames = EM_ASM_INT(return (programArgs && programArgs.length >= 2) ? parseInt(programArgs[1]) : 1000);
     printf("Rendering %d frames of Mandelbrot. Invoke \"node|js mandelbrot.js numItersPerFrame numFrames\" to configure.\n", numTotalFrames);
     double t0 = emscripten_get_now();
     for(int i = 0; i < numTotalFrames; ++i) {


### PR DESCRIPTION
I'm not sure where this strange name originally came from but its notable enough to rename it something more consistent/meaningful.

There was one comment saying `v8 uses arguments_` but that doesn't seem to be true:

```
$ ~/.jsvu/bin/v8 test.js xx
test.js:1: ReferenceError: arguments_ is not defined
console.log(arguments_);
            ^
ReferenceError: arguments_ is not defined
    at test.c:1:13
```