### PR TITLE
[Docs] adjust sphinx theme templates for gettext builder

### DIFF
--- a/site/source/_themes/emscripten_sphinx_rtd_theme/breadcrumbs.html
+++ b/site/source/_themes/emscripten_sphinx_rtd_theme/breadcrumbs.html
@@ -1,11 +1,9 @@
 <div role="navigation" aria-label="breadcrumbs navigation">
-
   <div class="breadcrumb-box">
-     <a class="breadcrumb-box-item" href="{{ pathto(master_doc) }}">Home</a> 
-      {% for doc in parents %}
-          <a class="breadcrumb-box-item" href="{{ doc.link|e }}">&raquo;&nbsp;{{ doc.title }}</a>
-      {% endfor %}
+    <a class="breadcrumb-box-item" href="{{ pathto(master_doc) }}">{% trans %}Home{% endtrans %}</a>
+    {% for doc in parents %}
+    <a class="breadcrumb-box-item" href="{{ doc.link|e }}">&raquo;&nbsp;{{ doc.title }}</a>
+    {% endfor %}
     <div class="breadcrumb-box-item">&raquo;&nbsp;{{ title }}</div>
   </div>
- 
 </div>

--- a/site/source/_themes/emscripten_sphinx_rtd_theme/footer.html
+++ b/site/source/_themes/emscripten_sphinx_rtd_theme/footer.html
@@ -1,106 +1,88 @@
 <footer>
   {% if next or prev %}
-    <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
-      {% if next %}
-        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}"/>Next <span class="fa fa-arrow-circle-right"></span></a>
-      {% endif %}
-      {% if prev %}
-        <a href="{{ prev.link|e }}" class="btn btn-neutral" title="{{ prev.title|striptags|e }}"><span class="fa fa-arrow-circle-left"></span> Previous</a>
-      {% endif %}
-    </div>
+  <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
+    {% if next %}
+    <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}">{% trans %}Next{% endtrans %} <span class="fa fa-arrow-circle-right"></span></a>
+    {% endif %}
+    {% if prev %}
+    <a href="{{ prev.link|e }}" class="btn btn-neutral" title="{{ prev.title|striptags|e }}"><span class="fa fa-arrow-circle-left"></span> {% trans %}Previous{% endtrans %}</a>
+    {% endif %}
+  </div>
   {% endif %}
 
-     
-  <!--begin hamishw addition -->
-  
-    
-  
-  <!--  -->
-   
-   <!--Footer important links
-    If no such page exists then nav item is not created. CSS defines which of the long or short version is 
-	displayed.   -->
+  <!-- begin hamishw addition -->
 
-	
-   {% set footer_links = [
-    ('docs/getting_started/bug_reports', 'Report Bug', 'Report Bug'),
-    ('docs/introducing_emscripten/emscripten_license', 'Licensing', 'Licensing'),
-	('docs/contributing/contributing', 'Contributing', 'Contributing'),
-	('https://groups.google.com/forum/#!forum/emscripten-discuss', 'Mailing list', 'Mailing list'),
-	('https://github.com/emscripten-core/emscripten/wiki', 'Wiki', 'Wiki'),
-	('docs/introducing_emscripten/release_notes', 'Release notes', 'Release notes'),
-	('docs/introducing_emscripten/community', 'Blogs', 'Blogs'),
-	('docs/introducing_emscripten/community', 'Help', 'Contact'),
-] -%}
+  <!-- Footer important links
+    If no such page exists then nav item is not created. CSS defines which of the long or short version is displayed. -->
 
-   <div class="footer-nav-bar" style="">
-     <div class="footer-options">
-   
-        {% for document, shorttext, longtext in footer_links %}
-            {%- if hasdoc(document) %}
-              <a class="footer-navlink-short" title="{{ shorttext }}" href="{{ pathto(document) }}">{{ shorttext }}</a><a class="footer-navlink-long" title="{{ longtext }}" href="{{ pathto(document) }}">{{ longtext }}</a>
-	        {%- elif document | truncate(4, True, end='') == 'http' %} 
-		      <a class="footer-navlink-short external" href="{{ document }}">{{ shorttext }}</a><a class="footer-navlink-long external" href="{{ document }}">{{ longtext }}</a>
-			{%- else %}  
-			  {{ shorttext }}
-            {%- endif %}
-        {% endfor %} 
-				
-     </div>
-	 
-	
- 
-   </div>
-  
-    <!-- {% include "breadcrumbs.html" %} -->
-  
-    <!-- {% trans %}<a href="https://github.com/snide/sphinx_rtd_theme">Sphinx theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>{% endtrans %} --.
-   <!--end hamishw addition -->
-  
-  
-	  
-<!-- end section moved here by hamishw -->
+  {% set footer_links = [
+    ('docs/getting_started/bug_reports', _('Report Bug'), _('Report Bug')),
+    ('docs/introducing_emscripten/emscripten_license', _('Licensing'), _('Licensing')),
+    ('docs/contributing/contributing', _('Contributing'), _('Contributing')),
+    ('https://groups.google.com/forum/#!forum/emscripten-discuss', _('Mailing list'), _('Mailing list')),
+    ('https://github.com/emscripten-core/emscripten/wiki', _('Wiki'), _('Wiki')),
+    ('docs/introducing_emscripten/release_notes', _('Release notes'), _('Release notes')),
+    ('docs/introducing_emscripten/community', _('Blogs'), _('Blogs')),
+    ('docs/introducing_emscripten/community', _('Help'), _('Contact')),
+  ] -%}
+
+  <div class="footer-nav-bar" style="">
+    <div class="footer-options">
+    {% for document, shorttext, longtext in footer_links %}
+      {%- if hasdoc(document) %}
+        <a class="footer-navlink-short" title="{{ shorttext }}" href="{{ pathto(document) }}">{{ shorttext }}</a><a class="footer-navlink-long" title="{{ longtext }}" href="{{ pathto(document) }}">{{ longtext }}</a>
+      {%- elif document | truncate(4, True, end='') == 'http' %}
+        <a class="footer-navlink-short external" href="{{ document }}">{{ shorttext }}</a><a class="footer-navlink-long external" href="{{ document }}">{{ longtext }}</a>
+      {%- else %}
+        {{ shorttext }}
+      {%- endif %}
+    {% endfor %}
+    </div>
+  </div>
+
+  <!-- {% include "breadcrumbs.html" %} -->
+
+  <!-- {% trans %}<a href="https://github.com/snide/sphinx_rtd_theme">Sphinx theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>{% endtrans %} -->
+  <!-- end hamishw addition -->
+
+  <!-- end section moved here by hamishw -->
   <div role="contentinfo" class="copyright-box">
-    <!-- section moved here by hamishw - needs tidying, which is why it is still in breadcrumbs mode --> 
-  <ul class="wy-breadcrumbs">
+    <!-- section moved here by hamishw - needs tidying, which is why it is still in breadcrumbs mode -->
+    <ul class="wy-breadcrumbs">
       <li class="wy-breadcrumbs-aside">
         {% if display_github %}
-          <a href="https://github.com/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}.rst" class="fa fa-github"> Edit on GitHub</a>
+          <a href="https://github.com/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}.rst" class="fa fa-github">{% trans %}Edit on GitHub{% endtrans %}</a>
         {% elif display_bitbucket %}
-          <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}.rst" class="fa fa-bitbucket"> Edit on Bitbucket</a>
+          <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}.rst" class="fa fa-bitbucket">{% trans %}Edit on Bitbucket{% endtrans %}</a>
         {% elif show_source and has_source and sourcename %}
-          <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> View page source</a>
+          <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow">{% trans %}View page source{% endtrans %}</a>
         {% endif %}
       </li>
-
-	  <li class="wy-breadcrumbs-aside">
-	    {%- if hasdoc('docs/site/about') %}
-         <a href="{{pathto('docs/site/about')}}">About site</a>
+	    <li class="wy-breadcrumbs-aside">
+	      {%- if hasdoc('docs/site/about') %}
+          <a href="{{ pathto('docs/site/about') }}">{% trans %}About site{% endtrans %}</a>
         {%- endif %}
       </li>
-	  
-	  <li class="wy-breadcrumbs-aside">
-        <a href="https://github.com/emscripten-core/emscripten/issues/new?title=Bug%20in%20page:{{title|urlencode()}}%20&body=REPLACE%20THIS%20TEXT%20WITH%20BUG%20DESCRIPTION%20%0A%0AURL:%20{{ url_root }}{{pagename|urlencode()}}&labels=bug">Page bug</a>
+	    <li class="wy-breadcrumbs-aside">
+        <a href="https://github.com/emscripten-core/emscripten/issues/new?title=Bug%20in%20page:{{title|urlencode()}}%20&body=REPLACE%20THIS%20TEXT%20WITH%20BUG%20DESCRIPTION%20%0A%0AURL:%20{{ url_root }}{{pagename|urlencode()}}&labels=bug">{% trans %}Page bug{% endtrans %}</a>
       </li>
-  </ul>
-  
+    </ul>
     <p>
     {%- if show_copyright %}
       {%- if hasdoc('copyright') %}
-        {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %} 
+        {% trans path=pathto('copyright'), copyright=copyright|e -%}
+          &copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.
+        {%- endtrans %}
       {%- else %}
-        <!-- {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %} -->
-		&copy; Copyright {{ copyright }} <a href="{{ pathto("docs/contributing/AUTHORS") }}">Emscripten Contributors</a>.
-		<!-- update theme to remove the translation stuff here - it was breaking due to link to AUTHORS file. This is a cludge to allow specific link to my authors file -->
+        {% trans path=pathto('docs/contributing/AUTHORS'), copyright=copyright|e -%}
+          &copy; Copyright {{ copyright }} <a href="{{ path }}">Emscripten Contributors</a>.
+        {%- endtrans %}
+		    <!-- update theme to remove the translation stuff here - it was breaking due to link to AUTHORS file. This is a cludge to allow specific link to my authors file -->
       {%- endif %}
     {%- endif %}
-
     {%- if last_updated %}
       {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
     {%- endif %}
     </p>
-	
   </div>
-  
-  
 </footer>

--- a/site/source/_themes/emscripten_sphinx_rtd_theme/layout.html
+++ b/site/source/_themes/emscripten_sphinx_rtd_theme/layout.html
@@ -104,143 +104,139 @@
 </head>
 
 <body class="wy-body-for-nav">
+  <div class="grid-to-center-rtd-theme">
+    {%- block extrabody %} {% endblock %}
+    <div class="wy-grid-for-nav">
+      {#- SIDE NAV, TOGGLES ON MOBILE #}
+      <nav data-toggle="wy-nav-shift" class="wy-nav-side">
+        <div class="wy-side-scroll">
+          <div class="wy-side-nav-search" {% if theme_style_nav_header_background %} style="background: {{theme_style_nav_header_background}}" {% endif %}>
+            {%- block sidebartitle %}
 
-<div class="grid-to-center-rtd-theme"> 
+            {# the logo helper function was removed in Sphinx 6 and deprecated since Sphinx 4 #}
+            {# the master_doc variable was renamed to root_doc in Sphinx 4 (master_doc still exists in later Sphinx versions) #}
+            {%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}
+            {%- set _root_doc = root_doc|default(master_doc) %}
+            <a href="{{ pathto(_root_doc) }}">
+              <!-- <img src="{{ url_root }}/_static/{{ logo }}" alt="Logo"> -->
+              {% if not theme_logo_only %}{{ project }}{% endif %}
+              {%- if logo or logo_url %}
+                <img src="{{ _logo_url }}" class="logo" alt="{{ _('Logo') }}"/>
+              {%- endif %}
+            </a>
 
-  {%- block extrabody %} {% endblock %}
-  <div class="wy-grid-for-nav">
-    {#- SIDE NAV, TOGGLES ON MOBILE #}
-    <nav data-toggle="wy-nav-shift" class="wy-nav-side">
-      <div class="wy-side-scroll">
-        <div class="wy-side-nav-search" {% if theme_style_nav_header_background %} style="background: {{theme_style_nav_header_background}}" {% endif %}>
-          {%- block sidebartitle %}
-
-          {# the logo helper function was removed in Sphinx 6 and deprecated since Sphinx 4 #}
-          {# the master_doc variable was renamed to root_doc in Sphinx 4 (master_doc still exists in later Sphinx versions) #}
-          {%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}
-          {%- set _root_doc = root_doc|default(master_doc) %}
-          <a href="{{ pathto(_root_doc) }}">
-            <!-- <img src="{{ url_root }}/_static/{{ logo }}" alt="Logo"> -->
-            {% if not theme_logo_only %}{{ project }}{% endif %}
-            {%- if logo or logo_url %}
-              <img src="{{ _logo_url }}" class="logo" alt="{{ _('Logo') }}"/>
+            {%- if READTHEDOCS or DEBUG %}
+              {%- if theme_version_selector or theme_language_selector %}
+                <div class="switch-menus">
+                  <div class="version-switch"></div>
+                  <div class="language-switch"></div>
+                </div>
+              {%- endif %}
             {%- endif %}
-          </a>
 
-          {%- if READTHEDOCS or DEBUG %}
-            {%- if theme_version_selector or theme_language_selector %}
-              <div class="switch-menus">
-                <div class="version-switch"></div>
-                <div class="language-switch"></div>
-              </div>
-            {%- endif %}
-          {%- endif %}
+            {%- include "searchbox.html" %}
 
-          {%- include "searchbox.html" %}
-
-          {%- endblock %}
-        </div>
-
-        {%- block navigation %}
-        {#- Translators: This is an ARIA section label for the main navigation menu -#}
-        <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="{{ _('Navigation menu') }}">
-          {%- block menu %}
-            {%- set toctree = toctree(maxdepth=theme_navigation_depth|int,
-                                      collapse=theme_collapse_navigation|tobool,
-                                      includehidden=theme_includehidden|tobool,
-                                      titles_only=theme_titles_only|tobool) %}
-            {%- if toctree %}
-              {{ toctree }}
-            {%- else %}
-              <!-- Local TOC -->
-              <div class="local-toc">{{ toc }}</div>
-            {%- endif %}
-          {%- endblock %}
-        </div>
-        {%- endblock %}
-      </div>
-    </nav>
-
-    <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
-
-      {#- MOBILE NAV, TRIGGLES SIDE NAV ON TOGGLE #}
-      {#- Translators: This is an ARIA section label for the navigation menu that is visible when viewing the page on mobile devices -#}
-      <nav class="wy-nav-top" aria-label="{{ _('Mobile navigation menu') }}" {% if theme_style_nav_header_background %} style="background: {{theme_style_nav_header_background}}" {% endif %}>
-        {%- block mobile_nav %}
-          <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-          <!-- <a href="{{ pathto(master_doc) }}">{{ project }}</a> -->
-          <a href="{{ pathto(master_doc) }}"> <img src="{{ logo_url }}" alt="Logo" /> </a>
-        {%- endblock %}
-      </nav>
-
-      <div class="wy-nav-content">
-      {%- block content %}
-        {%- if theme_style_external_links|tobool %}
-        <div class="rst-content style-external-links">
-        {%- else %}
-        <div class="rst-content">
-        {%- endif %}
-        <!--begin hamishw addition -->
-
-        <!--Nav bar defined as a document followed by short version of nav text and long version
-            If no such page exists then nav item is not created. CSS defines which of the long or short version is 
-          displayed.   -->
-        {% set navigation_bar = [
-        ('docs/index', 'Docs', 'Documentation'),
-        ('docs/getting_started/downloads', 'SDK', 'Downloads'),
-        ('docs/introducing_emscripten/community', 'Help', 'Community'),
-        ('docs/index', 'GitHub', '')
-        ] -%}
-        <a href="https://github.com/emscripten-core/emscripten"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" data-canonical-src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png"></a>
-  
-        <div class="main-nav-bar" style="">   
-
-          <!-- the layout of the menu options - centered with left and right alignment of the first and last loop items respectively.
-        This is VERY UGLY as I'm adding to the CSS in the code to force the alignment. Would be better just to have the elements here and have the CSS in the CSS file. This could be done with a CSS selector, but not worked out how yet. -->
-
-        <ul id="menu-options">
-             {% for document, shorttext, longtext in navigation_bar %}
-                 {%- if hasdoc(document) %}
-                   <li{%- if loop.first %} style="text-align:left;" {%- endif %}{%- if loop.last %} style="text-align:right;" {%- endif %}><a class="navlink-short" title="{{ shorttext }}" href="{{ pathto(document) }}">{{ shorttext }}</a><a class="navlink-long" title="{{ longtext }}" href="{{ pathto(document) }}">{{ longtext }}</a></li>
-               {%- elif document | truncate(4, True, end='') == 'http' %} 
-               <li{%- if loop.first %} style="text-align:left;" {%- endif %}{%- if loop.last %} style="text-align:right;" {%- endif %}><a class="navlink-short external" href="{{ document }}">{{ shorttext }}</a><a class="navlink-long external" href="{{ document }}">{{ longtext }}</a></li>
-                 {%- endif %}
-             {% endfor %}   	
-          </ul>
-        <!-- <div style="clear:both;"></div> -->        
-          {% include "breadcrumbs.html" %}
-   </div>
-   <!--end hamishw addition -->		
-          <!--HamishW move {% include "breadcrumbs.html" %} -->
-          <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
-          {%- block document %}
-           <div itemprop="articleBody">
-             {% block body %}{% endblock %}
-           </div>
-           {%- if self.comments()|trim %}
-             <div class="articleComments">
-               {%- block comments %}{% endblock %}
-             </div>
-           {%- endif%}
+            {%- endblock %}
+          </div>
+          {%- block navigation %}
+          {#- Translators: This is an ARIA section label for the main navigation menu -#}
+          <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="{{ _('Navigation menu') }}">
+            {%- block menu %}
+              {%- set toctree = toctree(maxdepth=theme_navigation_depth|int,
+                                        collapse=theme_collapse_navigation|tobool,
+                                        includehidden=theme_includehidden|tobool,
+                                        titles_only=theme_titles_only|tobool) %}
+              {%- if toctree %}
+                {{ toctree }}
+              {%- else %}
+                <!-- Local TOC -->
+                <div class="local-toc">{{ toc }}</div>
+              {%- endif %}
+            {%- endblock %}
           </div>
           {%- endblock %}
-          {% include "footer.html" %}
         </div>
-      {%- endblock %}
-      </div>
-    </section>
-  </div>
-  {% include "versions.html" -%}
+      </nav>
 
-  <script>
+      <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
+
+        {#- MOBILE NAV, TRIGGLES SIDE NAV ON TOGGLE #}
+        {#- Translators: This is an ARIA section label for the navigation menu that is visible when viewing the page on mobile devices -#}
+        <nav class="wy-nav-top" aria-label="{{ _('Mobile navigation menu') }}" {% if theme_style_nav_header_background %} style="background: {{theme_style_nav_header_background}}" {% endif %}>
+          {%- block mobile_nav %}
+            <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
+            <!-- <a href="{{ pathto(master_doc) }}">{{ project }}</a> -->
+            <a href="{{ pathto(master_doc) }}"> <img src="{{ logo_url }}" alt="{{ _('Logo') }}" /> </a>
+          {%- endblock %}
+        </nav>
+
+        <div class="wy-nav-content">
+        {%- block content %}
+          {%- if theme_style_external_links|tobool %}
+          <div class="rst-content style-external-links">
+          {%- else %}
+          <div class="rst-content">
+          {%- endif %}
+            <!-- begin hamishw addition -->
+
+            <!-- Nav bar defined as a document followed by short version of nav text and long version
+                If no such page exists then nav item is not created. CSS defines which of the long or short version is displayed. -->
+            {% set navigation_bar = [
+              ('docs/index', _('Docs'), _('Documentation')),
+              ('docs/getting_started/downloads', _('SDK'), _('Downloads')),
+              ('docs/introducing_emscripten/community', _('Help'), _('Community')),
+              ('docs/index', _('GitHub'), '')
+            ] -%}
+            <a href="https://github.com/emscripten-core/emscripten"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png" alt="{{ _('Fork me on GitHub') }}" data-canonical-src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png"></a>
+
+            <div class="main-nav-bar" style="">
+
+              <!-- the layout of the menu options - centered with left and right alignment of the first and last loop items respectively.
+              This is VERY UGLY as I'm adding to the CSS in the code to force the alignment. Would be better just to have the elements here and have the CSS in the CSS file. This could be done with a CSS selector, but not worked out how yet. -->
+
+              <ul id="menu-options">
+                {% for document, shorttext, longtext in navigation_bar %}
+                  {%- if hasdoc(document) %}
+                    <li{%- if loop.first %} style="text-align:left;" {%- endif %}{%- if loop.last %} style="text-align:right;" {%- endif %}><a class="navlink-short" title="{{ shorttext }}" href="{{ pathto(document) }}">{{ shorttext }}</a><a class="navlink-long" title="{{ longtext }}" href="{{ pathto(document) }}">{{ longtext }}</a></li>
+                  {%- elif document | truncate(4, True, end='') == 'http' %}
+                    <li{%- if loop.first %} style="text-align:left;" {%- endif %}{%- if loop.last %} style="text-align:right;" {%- endif %}><a class="navlink-short external" href="{{ document }}">{{ shorttext }}</a><a class="navlink-long external" href="{{ document }}">{{ longtext }}</a></li>
+                  {%- endif %}
+                {% endfor %}
+              </ul>
+              <!-- <div style="clear:both;"></div> -->
+              {% include "breadcrumbs.html" %}
+            </div>
+            <!-- end hamishw addition -->
+            <!-- HamishW move {% include "breadcrumbs.html" %} -->
+            <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+              {%- block document %}
+              <div itemprop="articleBody">
+                {% block body %}{% endblock %}
+              </div>
+              {%- if self.comments()|trim %}
+              <div class="articleComments">
+                {%- block comments %}{% endblock %}
+              </div>
+              {%- endif%}
+              {%- endblock %}
+            </div>
+            {% include "footer.html" %}
+          </div>
+        {%- endblock %}
+        </div>
+      </section>
+    </div>
+    {% include "versions.html" -%}
+
+    <script>
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable({{ 'true' if theme_sticky_navigation|tobool else 'false' }});
       });
-  </script>
+    </script>
 
-  {#- Do not conflict with RTD insertion of analytics script #}
-  {%- if not READTHEDOCS %}
-    {%- if theme_analytics_id %}
+    {#- Do not conflict with RTD insertion of analytics script #}
+    {%- if not READTHEDOCS %}
+      {%- if theme_analytics_id %}
     <!-- Theme Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ theme_analytics_id }}"></script>
     <script>
@@ -253,10 +249,10 @@
       });
     </script>
 
+      {%- endif %}
     {%- endif %}
-  {%- endif %}
 
-  {%- block footer %} {% endblock %}
-</div>
+    {%- block footer %}{% endblock %}
+  </div>
 </body>
 </html>


### PR DESCRIPTION
- Add `_()` and `{% trans %}{% endtrans %}` for gettext builder.
- Adjust the indentation of the sphinx theme templates.
- Trim trailing spaces and replace tabs with spaces.