### PR TITLE
Add support for emrun `--browser` to point to a macOS browser app root path

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -1609,6 +1609,10 @@ def run(args):  # noqa: C901, PLR0912, PLR0915
 
   options = emrun_options = parse_args(args)
 
+  if MACOS and options.browser.endswith('.app') and not options.browser.startswith('open'):
+    options.browser_args = '--new --fresh --background -a ' + options.browser + ' ' + str(options.browser_args)
+    options.browser = 'open'
+
   if options.android_tunnel:
     options.android = True
 

--- a/emrun.py
+++ b/emrun.py
@@ -1610,7 +1610,7 @@ def run(args):  # noqa: C901, PLR0912, PLR0915
   options = emrun_options = parse_args(args)
 
   if MACOS and options.browser.endswith('.app') and not options.browser.startswith('open'):
-    options.browser_args = '--new --fresh --background -a ' + options.browser + ' ' + str(options.browser_args)
+    options.browser_args = f'--new --fresh --background -a {options.browser} {options.browser_args}'
     options.browser = 'open'
 
   if options.android_tunnel:


### PR DESCRIPTION
The convention taken for `EMTEST_BROWSER` is to have it point to the macOS app, and not the path to the executable inside the app. Fix emrun to also use this same convention.

Fixes test `emrun.test_emrun` on macOS, when `EMTEST_BROWSER=/Applications/Safari.app`

http://clbri.com:8010/api/v2/logs/434413/raw_inline

