### PR TITLE
Add a ChangeLog entry about the version of Java used by current Closure

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -43,6 +43,11 @@ See docs/process.md for more on how version tagging works.
   notified of all IDBFS sync start and end events. (#26895)
 - google-closure-compiler was updated to 20260429.0.0. (#26869)
   Closure compiler now provides a native macOS arm64 binary for Apple Silicon.
+  (In addition to having native binaries for Win-x64, Linux-x64 and Linux-ARM64)
+  For other platforms for which Closure compiler does not ship a native binary,
+  e.g. Intel x64 Macs and Windows-on-ARM, downloading Java SE Development Kit
+  21.0.11 from https://www.oracle.com/europe/java/technologies/downloads/#java21
+  is required in order to use Emscripten's Closure Compiler integration.
 
 5.0.7 - 04/30/26
 ----------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,8 +42,8 @@ See docs/process.md for more on how version tagging works.
   callback `IDBFS.onAutoPersistStateChanged = active => {}`, which will be
   notified of all IDBFS sync start and end events. (#26895)
 - google-closure-compiler was updated to 20260429.0.0. (#26869)
-  Closure compiler now provides a native macOS arm64 binary for Apple Silicon.
-  (In addition to having native binaries for Win-x64, Linux-x64 and Linux-ARM64)
+  Closure compiler now provides a native macOS arm64 binary for Apple Silicon,
+  in addition to having native binaries for Win-x64, Linux-x64 and Linux-ARM64.
   For other platforms for which Closure compiler does not ship a native binary,
   e.g. Intel x64 Macs and Windows-on-ARM, downloading Java SE Development Kit
   21.0.11 from https://www.oracle.com/europe/java/technologies/downloads/#java21


### PR DESCRIPTION
Add a ChangeLog entry about the version of Java used by current Closure version, and a note of when installing Java is necessary.

Attempting to use Java 20 or older will produce an error like

```
Error: LinkageError occurred while loading main class com.google.javascript.jscomp.CommandLineRunner
	java.lang.UnsupportedClassVersionError: com/google/javascript/jscomp/CommandLineRunner has been compiled
by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only
recognizes class file versions up to 57.0
```

http://clbri.com:8010/api/v2/logs/433679/raw_inline