### PR TITLE
Remove PTHREAD_POOL_SIZE form node tests. NFC

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2610,7 +2610,6 @@ The current type of b is: 9
 
   @requires_pthreads
   def test_pthread_proxying_dropped_work(self):
-    self.set_setting('PTHREAD_POOL_SIZE=2')
     self.do_run_in_out_file_test('pthread/test_pthread_proxying_dropped_work.c')
 
   @requires_pthreads
@@ -2624,7 +2623,6 @@ The current type of b is: 9
   @flaky('https://github.com/emscripten-core/emscripten/issues/19795')
   def test_pthread_proxying_refcount(self):
     self.set_setting('EXIT_RUNTIME')
-    self.set_setting('PTHREAD_POOL_SIZE=1')
     self.set_setting('ASSERTIONS=0')
     self.do_run_in_out_file_test('pthread/test_pthread_proxying_refcount.c')
 
@@ -2636,12 +2634,10 @@ The current type of b is: 9
   def test_pthread_atexit(self):
     # Test to ensure threads are still running when atexit-registered functions are called
     self.set_setting('EXIT_RUNTIME')
-    self.set_setting('PTHREAD_POOL_SIZE', 1)
     self.do_run_in_out_file_test('pthread/test_pthread_atexit.c')
 
   @requires_pthreads
   def test_pthread_nested_work_queue(self):
-    self.set_setting('PTHREAD_POOL_SIZE', 1)
     self.do_run_in_out_file_test('pthread/test_pthread_nested_work_queue.c')
 
   @requires_pthreads
@@ -2655,7 +2651,6 @@ The current type of b is: 9
 
   @requires_pthreads
   def test_pthread_cleanup(self):
-    self.set_setting('PTHREAD_POOL_SIZE', 4)
     self.do_run_in_out_file_test('pthread/test_pthread_cleanup.c')
 
   @requires_pthreads
@@ -2672,7 +2667,6 @@ The current type of b is: 9
   def test_pthread_attr_getstack(self):
     if self.get_setting('MINIMAL_RUNTIME') and is_sanitizing(self.cflags):
       self.skipTest('MINIMAL_RUNTIME + threads + asan does not work')
-    self.set_setting('PTHREAD_POOL_SIZE', 1)
     self.do_run_in_out_file_test('pthread/test_pthread_attr_getstack.c')
 
   @requires_pthreads
@@ -2689,7 +2683,6 @@ The current type of b is: 9
 
   @requires_pthreads
   def test_pthread_abort_interrupt(self):
-    self.set_setting('PTHREAD_POOL_SIZE', 1)
     expected = ['Aborted(). Build with -sASSERTIONS for more info', 'Aborted(native code called abort())']
     self.do_runf('pthread/test_pthread_abort_interrupt.c', expected, assert_returncode=NON_ZERO)
 
@@ -2775,7 +2768,7 @@ The current type of b is: 9
   @requires_pthreads
   @also_with_wasm_workers
   def test_emscripten_lock_waitinf_acquire(self):
-    self.do_runf('wasm_worker/lock_waitinf_acquire.c', 'done\n', cflags=['-pthread', '-sPTHREAD_POOL_SIZE=4'])
+    self.do_runf('wasm_worker/lock_waitinf_acquire.c', 'done\n', cflags=['-pthread'])
 
   @requires_pthreads
   @also_with_wasm_workers
@@ -2791,7 +2784,7 @@ The current type of b is: 9
   @requires_pthreads
   @also_with_wasm_workers
   def test_emscripten_semaphore_waitinf_acquire(self):
-    self.do_runf('wasm_worker/semaphore_waitinf_acquire.c', 'done\n', cflags=['-pthread', '-sPTHREAD_POOL_SIZE=7'])
+    self.do_runf('wasm_worker/semaphore_waitinf_acquire.c', 'done\n', cflags=['-pthread'])
 
   @requires_pthreads
   @also_with_wasm_workers
@@ -9138,6 +9131,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @parameterized({
     '': ([],),
     'sync_instantiation': (['-sWASM_ASYNC_COMPILATION=0'],),
+    'proxied': (['-sPROXY_TO_PTHREAD'],),
   })
   @requires_pthreads
   @crossplatform
@@ -9146,12 +9140,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
       self.skipTest('WASM_ESM_INTEGRATION is not compatible with WASM_ASYNC_COMPILATION=0')
     self.set_setting('ENVIRONMENT', 'node')
     self.set_setting('STRICT')
-    self.do_core_test('pthread/create.c', cflags=args)
+    # Under node we can always synchronously create threads.
+    self.do_core_test('pthread/create.c', cflags=args + ['-DALLOW_SYNC'])
 
   @requires_pthreads
   @parameterized({
     '': ([],),
-    'pooled': (['-sPTHREAD_POOL_SIZE=1'],),
     'proxied': (['-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'],),
   })
   def test_pthread_c11_threads(self, args):
@@ -9162,41 +9156,17 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_run_in_out_file_test('pthread/test_pthread_c11_threads.c', cflags=args)
 
   @requires_pthreads
-  @parameterized({
-    '': (0,),
-    'pooled': (1,),
-  })
-  def test_pthread_cxx_threads(self, pthread_pool_size):
-    self.set_setting('PTHREAD_POOL_SIZE', pthread_pool_size)
+  def test_pthread_cxx_threads(self):
     self.do_run_in_out_file_test('pthread/test_pthread_cxx_threads.cpp')
 
   @requires_pthreads
-  @parameterized({
-    '': (0,),
-    'pooled': (1,),
-  })
-  def test_pthread_busy_wait(self, pthread_pool_size):
-    self.set_setting('PTHREAD_POOL_SIZE', pthread_pool_size)
+  def test_pthread_busy_wait(self):
     self.do_run_in_out_file_test('pthread/test_pthread_busy_wait.cpp')
 
   @requires_pthreads
   def test_pthread_busy_wait_atexit(self):
-    self.set_setting('PTHREAD_POOL_SIZE', 1)
     self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test('pthread/test_pthread_busy_wait_atexit.cpp')
-
-  @requires_pthreads
-  def test_pthread_create_pool(self):
-    # with a pool, we can synchronously depend on workers being available
-    self.set_setting('PTHREAD_POOL_SIZE', 2)
-    self.do_core_test('pthread/create.c', cflags=['-DALLOW_SYNC'])
-
-  @requires_pthreads
-  def test_pthread_create_proxy(self):
-    # with PROXY_TO_PTHREAD, we can synchronously depend on workers being available
-    self.set_setting('PROXY_TO_PTHREAD')
-    self.set_setting('EXIT_RUNTIME')
-    self.do_core_test('pthread/create.c', cflags=['-DALLOW_SYNC'])
 
   @requires_pthreads
   def test_pthread_create_embind_stack_check(self):
@@ -9206,7 +9176,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @requires_pthreads
   def test_pthread_exceptions(self):
-    self.set_setting('PTHREAD_POOL_SIZE', 2)
     self.do_core_test('pthread/exceptions.cpp', cflags=['-fexceptions'])
 
   @requires_pthreads
@@ -9263,7 +9232,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @requires_pthreads
   def test_stdio_locking(self):
-    self.do_core_test('test_stdio_locking.c', cflags=['-sPTHREAD_POOL_SIZE=2'])
+    self.do_core_test('test_stdio_locking.c')
 
   @requires_wasm_workers
   def test_stdio_locking_ww(self):
@@ -9291,8 +9260,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # where we had a bug with long names + TextDecoder + pthreads + dylink
     very_long_name = 'very_very_very_very_very_very_very_very_very_long.so'
 
-    self.dylink_testf(main, so_name=very_long_name,
-                      main_cflags=['-sPTHREAD_POOL_SIZE=2'])
+    self.dylink_testf(main, so_name=very_long_name)
 
   @needs_dylink
   @parameterized({
@@ -9303,7 +9271,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_pthread_dylink_entry_point(self, args):
     self.cflags += ['-Wno-experimental', '-pthread']
     main = test_file('core/pthread/test_pthread_dylink_entry_point.c')
-    self.dylink_testf(main, cflags=args, main_cflags=['-sPTHREAD_POOL_SIZE=1'])
+    self.dylink_testf(main, cflags=args)
 
   @needs_dylink
   @requires_pthreads
@@ -9370,15 +9338,13 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @requires_pthreads
   def test_pthread_dylink_tls(self):
     self.cflags += ['-Wno-experimental', '-pthread']
-    main = test_file('core/pthread/test_pthread_dylink_tls.c')
-    self.dylink_testf(main, main_cflags=['-sPTHREAD_POOL_SIZE=1'])
+    self.dylink_testf(test_file('core/pthread/test_pthread_dylink_tls.c'))
 
   @needs_dylink
   @requires_pthreads
   def test_pthread_dylink_longjmp(self):
     self.cflags += ['-Wno-experimental', '-pthread']
-    main = test_file('core/pthread/test_pthread_dylink_longjmp.c')
-    self.dylink_testf(main, main_cflags=['-sPTHREAD_POOL_SIZE=1'])
+    self.dylink_testf(test_file('core/pthread/test_pthread_dylink_longjmp.c'))
 
   @needs_dylink
   @requires_pthreads

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10243,7 +10243,7 @@ T6:(else) !ASSERTIONS""", output)
     ensure_dir('subdir')
 
     # build hello_world.c
-    self.run_process([EMCC, test_file('hello_world.c'), '-o', 'subdir/module' + ext, '-pthread', '-sPTHREAD_POOL_SIZE=2', '-sMODULARIZE', '-sEXPORT_NAME=test_module'] + self.get_cflags())
+    self.run_process([EMCC, test_file('hello_world.c'), '-o', 'subdir/module' + ext, '-pthread', '-sMODULARIZE', '-sEXPORT_NAME=test_module'] + self.get_cflags())
 
     # run the module
     ret = self.run_js('moduleLoader' + ext)
@@ -11734,13 +11734,11 @@ int main(void) {
     # This was because PTHREADS_DEBUG calls back into WebAssembly for each call to `err()`.
     self.set_setting('PTHREADS_DEBUG')
     self.set_setting('ASYNCIFY')
-    self.set_setting('PTHREAD_POOL_SIZE', 2)
     self.do_other_test('test_pthread_asyncify.c')
 
   @requires_pthreads
   def test_pthread_reuse(self):
-    self.set_setting('PTHREAD_POOL_SIZE', 1)
-    self.do_other_test('test_pthread_reuse.c')
+    self.do_other_test('test_pthread_reuse.c', cflags=['-sPTHREAD_POOL_SIZE=1'])
 
   @parameterized({
     '': ([],),
@@ -13083,7 +13081,7 @@ void foo() {}
 
   @requires_pthreads
   @parameterized({
-    '': (['-sPTHREAD_POOL_SIZE=1'],),
+    '': ([],),
     'proxied': (['-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'],),
   })
   def test_pthread_sigmask(self, args):
@@ -13092,22 +13090,21 @@ void foo() {}
   # Tests memory growth in pthreads mode, but still on the main thread.
   @requires_pthreads
   @parameterized({
-    '': ([], 1),
-    'growable_arraybuffers': (['-sGROWABLE_ARRAYBUFFERS', '-Wno-experimental'], 1),
-    'proxy': (['-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'], 2),
+    '': ([],),
+    'growable_arraybuffers': (['-sGROWABLE_ARRAYBUFFERS', '-Wno-experimental'],),
+    'proxy': (['-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'],),
   })
-  def test_pthread_growth_mainthread(self, cflags, pthread_pool_size):
+  def test_pthread_growth_mainthread(self, cflags):
     if '-sGROWABLE_ARRAYBUFFERS' in cflags:
       self.node_args.append('--experimental-wasm-rab-integration')
       self.require_node_25()
     else:
       self.cflags.append('-Wno-pthreads-mem-growth')
-    self.set_setting('PTHREAD_POOL_SIZE', pthread_pool_size)
     self.do_runf('pthread/test_pthread_memory_growth_mainthread.c', cflags=['-pthread', '-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=32MB', '-sMAXIMUM_MEMORY=256MB'] + cflags)
 
   @requires_pthreads
   def test_phtread_join_interrupted(self):
-    self.do_runf('pthread/test_pthread_join_interrupted.c', cflags=['-pthread', '-sPTHREAD_POOL_SIZE=1'])
+    self.do_runf('pthread/test_pthread_join_interrupted.c', cflags=['-pthread'])
 
   @requires_node_25
   def test_growable_arraybuffers(self):
@@ -13129,16 +13126,15 @@ void foo() {}
     '': ([],),
     'growable_arraybuffers': (['-sGROWABLE_ARRAYBUFFERS', '-Wno-experimental'],),
     'assert': (['-sASSERTIONS'],),
-    'proxy': (['-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'], 2),
+    'proxy': (['-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'],),
     'minimal': (['-sMINIMAL_RUNTIME', '-sMODULARIZE', '-sEXPORT_NAME=MyModule'],),
   })
-  def test_pthread_growth(self, cflags, pthread_pool_size=1):
+  def test_pthread_growth(self, cflags):
     if WINDOWS and platform.machine() == 'ARM64':
       # https://github.com/emscripten-core/emscripten/issues/25627
       # TODO: Switch this to a "require Node.js 24" check
       self.require_node_25()
 
-    self.set_setting('PTHREAD_POOL_SIZE', pthread_pool_size)
     if '-sGROWABLE_ARRAYBUFFERS' in cflags:
       self.node_args.append('--experimental-wasm-rab-integration')
       self.require_node_25()

--- a/test/test_posixtest.py
+++ b/test/test_posixtest.py
@@ -181,11 +181,11 @@ def make_test(name, testfile, browser):
             # of log messages on CI runs.
             '--profiling-funcs',
             '-sEXIT_RUNTIME',
-            '-sTOTAL_MEMORY=256mb',
-            '-sPTHREAD_POOL_SIZE=40']
+            '-sTOTAL_MEMORY=256mb']
     if name in no_assert_tests:
       args.append('-sASSERTIONS=0')
     if browser:
+      args.append('-sPTHREAD_POOL_SIZE=40')
       self.btest_exit(testfile, cflags=args)
     else:
       self.do_runf(testfile, cflags=args, output_basename=name)


### PR DESCRIPTION
Node workers can start synchronously so there should be no need for this setting in any node tests.  I'm not sure how we ended up with so many occurrences here.

This should also speed up the posixtestsuite since (under node) we now just create threads on demand.