### PR TITLE
Fix -Wattribute-alias warnings in dlmalloc.c

### DIFF
--- a/system/lib/dlmalloc.c
+++ b/system/lib/dlmalloc.c
@@ -884,7 +884,7 @@ extern "C" {
 #if defined(__EMSCRIPTEN__)
 void* __libc_malloc(size_t) __attribute__((weak, alias("dlmalloc")));
 void  __libc_free(void*) __attribute__((weak, alias("dlfree")));
-void* __libc_calloc(size_t) __attribute__((weak, alias("dlcalloc")));
+void* __libc_calloc(size_t, size_t) __attribute__((weak, alias("dlcalloc")));
 void* __libc_realloc(void*, size_t) __attribute__((weak, alias("dlrealloc")));
 void* malloc(size_t) __attribute__((weak, alias("dlmalloc")));
 void  free(void*) __attribute__((weak, alias("dlfree")));
@@ -903,7 +903,7 @@ int malloc_trim(size_t) __attribute__((weak, alias("dlmalloc_trim")));
 #if !NO_MALLOC_STATS
 void malloc_stats(void) __attribute__((weak, alias("dlmalloc_stats")));
 #endif
-size_t malloc_usable_size(const void*) __attribute__((weak, alias("dlmalloc_usable_size")));
+size_t malloc_usable_size(void*) __attribute__((weak, alias("dlmalloc_usable_size")));
 size_t malloc_footprint(void) __attribute__((weak, alias("dlmalloc_footprint")));
 size_t malloc_max_footprint(void) __attribute__((weak, alias("dlmalloc_max_footprint")));
 size_t malloc_footprint_limit(void) __attribute__((weak, alias("dlmalloc_footprint_limit")));

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -2,9 +2,9 @@
   "a.out.js": 19322,
   "a.out.js.gz": 8008,
   "a.out.nodebug.wasm": 132627,
-  "a.out.nodebug.wasm.gz": 49918,
+  "a.out.nodebug.wasm.gz": 49916,
   "total": 151949,
-  "total_gz": 57926,
+  "total_gz": 57924,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -2,9 +2,9 @@
   "a.out.js": 19299,
   "a.out.js.gz": 7995,
   "a.out.nodebug.wasm": 132053,
-  "a.out.nodebug.wasm.gz": 49575,
+  "a.out.nodebug.wasm.gz": 49567,
   "total": 151352,
-  "total_gz": 57570,
+  "total_gz": 57562,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -2,9 +2,9 @@
   "a.out.js": 23298,
   "a.out.js.gz": 8987,
   "a.out.nodebug.wasm": 172519,
-  "a.out.nodebug.wasm.gz": 57443,
+  "a.out.nodebug.wasm.gz": 57432,
   "total": 195817,
-  "total_gz": 66430,
+  "total_gz": 66419,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -2,9 +2,9 @@
   "a.out.js": 19125,
   "a.out.js.gz": 7925,
   "a.out.nodebug.wasm": 147919,
-  "a.out.nodebug.wasm.gz": 55314,
+  "a.out.nodebug.wasm.gz": 55312,
   "total": 167044,
-  "total_gz": 63239,
+  "total_gz": 63237,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -2,9 +2,9 @@
   "a.out.js": 19199,
   "a.out.js.gz": 7955,
   "a.out.nodebug.wasm": 145725,
-  "a.out.nodebug.wasm.gz": 54936,
+  "a.out.nodebug.wasm.gz": 54928,
   "total": 164924,
-  "total_gz": 62891,
+  "total_gz": 62883,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -2,9 +2,9 @@
   "a.out.js": 23348,
   "a.out.js.gz": 9009,
   "a.out.nodebug.wasm": 238948,
-  "a.out.nodebug.wasm.gz": 79814,
+  "a.out.nodebug.wasm.gz": 79805,
   "total": 262296,
-  "total_gz": 88823,
+  "total_gz": 88814,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -2,9 +2,9 @@
   "a.out.js": 19322,
   "a.out.js.gz": 8008,
   "a.out.nodebug.wasm": 134643,
-  "a.out.nodebug.wasm.gz": 50760,
+  "a.out.nodebug.wasm.gz": 50756,
   "total": 153965,
-  "total_gz": 58768,
+  "total_gz": 58764,
   "sent": [
     "__cxa_throw",
     "_abort_js",


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/195550 added `-Wattribute-alias`, which warns on type mismatches between an alias and its aliased function. This is currently failing on the waterfall: https://ci.chromium.org/ui/p/emscripten-releases/builders/try/linux/b8681947828444624337/overview

This fixes the warnings. I'm not sure if we treat this `dlmalloc.c` as a third party code we should not modify, in which case we can consider adding `-Wno-attribute-alias` in `system_libs.py`.

Fixes: #26936