### PR TITLE
[dylink] Fix missing unlock in `emscripten_dlopen()`

### DIFF
--- a/system/lib/libc/dynlink.c
+++ b/system/lib/libc/dynlink.c
@@ -580,6 +580,7 @@ void emscripten_dlopen(const char* filename, int flags, void* user_data,
   filename = find_dylib(buf, filename, sizeof buf);
   struct dso* p = find_existing(filename);
   if (p) {
+    do_write_unlock();
     onsuccess(user_data, p);
     return;
   }


### PR DESCRIPTION
The global write lock was acquired but never released if the
requested library was already loaded.

Noticed while investigating #26913.