### PR TITLE
Add 128-bit atomics to test_atomic/test_atomic_c11/test_atomic_cxx. NFC

### DIFF
--- a/system/lib/compiler-rt/lib/builtins/atomic.c
+++ b/system/lib/compiler-rt/lib/builtins/atomic.c
@@ -185,7 +185,7 @@ bool __atomic_is_lock_free_c(size_t size, void *ptr) {
 
 /// An atomic load operation.  This is atomic with respect to the source
 /// pointer only.
-void __atomic_load_c(int size, void *src, void *dest, int model) {
+void __atomic_load_c(size_t size, void *src, void *dest, int model) {
 #define LOCK_FREE_ACTION(type)                                                 \
   *((type *)dest) = __c11_atomic_load((_Atomic(type) *)src, model);            \
   return;
@@ -199,7 +199,7 @@ void __atomic_load_c(int size, void *src, void *dest, int model) {
 
 /// An atomic store operation.  This is atomic with respect to the destination
 /// pointer only.
-void __atomic_store_c(int size, void *dest, void *src, int model) {
+void __atomic_store_c(size_t size, void *dest, void *src, int model) {
 #define LOCK_FREE_ACTION(type)                                                 \
   __c11_atomic_store((_Atomic(type) *)dest, *(type *)src, model);              \
   return;
@@ -216,7 +216,7 @@ void __atomic_store_c(int size, void *dest, void *src, int model) {
 /// they  are not, then this stores the current value from *ptr in *expected.
 ///
 /// This function returns 1 if the exchange takes place or 0 if it fails.
-int __atomic_compare_exchange_c(int size, void *ptr, void *expected,
+int __atomic_compare_exchange_c(size_t size, void *ptr, void *expected,
                                 void *desired, int success, int failure) {
 #define LOCK_FREE_ACTION(type)                                                 \
   return __c11_atomic_compare_exchange_strong(                                 \
@@ -238,7 +238,7 @@ int __atomic_compare_exchange_c(int size, void *ptr, void *expected,
 
 /// Performs an atomic exchange operation between two pointers.  This is atomic
 /// with respect to the target address.
-void __atomic_exchange_c(int size, void *ptr, void *val, void *old, int model) {
+void __atomic_exchange_c(size_t size, void *ptr, void *val, void *old, int model) {
 #define LOCK_FREE_ACTION(type)                                                 \
   *(type *)old =                                                               \
       __c11_atomic_exchange((_Atomic(type) *)ptr, *(type *)val, model);        \

--- a/test/core/test_atomic.c
+++ b/test/core/test_atomic.c
@@ -6,6 +6,7 @@
  */
 
 #include <stdio.h>
+
 int main() {
   int x = 10;
   int y = __sync_add_and_fetch(&x, 5);
@@ -21,5 +22,13 @@ int main() {
   printf("*%d,%d*\n", x, y);
   y = __sync_bool_compare_and_swap(&x, 10, 7);
   printf("*%d,%d*\n", x, y);
+
+  // Test 128-bit CAS
+  __int128 val128 = 0;
+  __int128 expected = 0;
+  __int128 desired = 42;
+  __int128 result = __sync_val_compare_and_swap(&val128, expected, desired);
+  printf("__sync_val_compare_and_swap: %lld %lld\n", (uint64_t)result, (uint64_t)val128);
+
   return 0;
 }

--- a/test/core/test_atomic.out
+++ b/test/core/test_atomic.out
@@ -3,3 +3,4 @@
 *6,10*
 *10,0*
 *7,1*
+__sync_val_compare_and_swap: 0 42

--- a/test/core/test_atomic_c11.c
+++ b/test/core/test_atomic_c11.c
@@ -133,6 +133,11 @@
            (unsigned long long)(UNSIGNED_TYPE)(atomicDog));                    \
   }
 
+typedef struct Pair128 {
+  uint64_t m1;
+  uint64_t m2;
+} Pair128;
+
 int main() {
   // test 8, 16, 32 and 64-bit data types
   printf("\n8 bits\n\n");
@@ -144,6 +149,14 @@ int main() {
   printf("\n64 bits\n\n");
   TEST(long long, unsigned long long, 0xFFFFFFFFFFFFFFFF,
        0xF0F0F0F0F0F0F0F0, 0x0F0F0F0F0F0F0F0F);
+
+  printf("\n128 bits\n\n");
+  _Atomic Pair128 atomicPair;
+  printf("is_lock_free: %s\n", atomic_is_lock_free(&atomicPair) ? "true" : "false");
+  atomicPair = (Pair128){1, 2};
+  Pair128 newPair = (Pair128){3, 4};
+  Pair128 oldPair = atomic_exchange(&atomicPair, newPair);
+  printf("exchange: %lld:%lld -> %lld:%lld\n\n", oldPair.m1, oldPair.m2, atomic_load(&atomicPair).m1, atomic_load(&atomicPair).m2);
 
   // test atomic_flag (should also have memory_orders, but probably doesn't
   // matter to find the missing atomic functions)

--- a/test/core/test_atomic_cxx.cpp
+++ b/test/core/test_atomic_cxx.cpp
@@ -110,6 +110,11 @@ template<typename TYPE, typename UNSIGNED_TYPE> void test(TYPE mask0, TYPE mask1
 
 }
 
+struct Pair128 {
+  uint64_t m1;
+  uint64_t m2;
+};
+
 int main() {
     // test 8, 16, 32 and 64-bit data types
     printf("\n8 bits\n\n");
@@ -121,12 +126,19 @@ int main() {
     printf("\n64 bits\n\n");
     test<long long, unsigned long long>(0xFFFFFFFFFFFFFFFF, 0xF0F0F0F0F0F0F0F0, 0x0F0F0F0F0F0F0F0F);
 
+    printf("\n128 bits\n\n");
+    std::atomic<Pair128> atomicPair;
+    printf("is_lock_free: %s\n", atomicPair.is_lock_free() ? "true" : "false");
+    atomicPair = {1, 2};
+    Pair128 oldPair = atomicPair.exchange({3, 4});
+    printf("exchange: %lld:%lld -> %lld:%lld\n", oldPair.m1, oldPair.m2, atomicPair.load().m1, atomicPair.load().m2);
+
     // test atomic_flag (should also have memory_orders, but probably doesn't matter
     // to find the missing atomic functions)
     std::atomic_flag af;
     af.clear();
     bool b = af.test_and_set();
-    printf("atomic_flag: %s\n", b ? "true" : "false");
+    printf("\natomic_flag: %s\n", b ? "true" : "false");
 
     printf("done.\n");
     return 0;

--- a/test/core/test_atomic_cxx.out
+++ b/test/core/test_atomic_cxx.out
@@ -222,5 +222,11 @@ operator-=: 5
 operator|=: ffffffffffffffff
 operator&=: f0f0f0f0f0f0f0f0
 operator^=: ffffffffffffffff
+
+128 bits
+
+is_lock_free: false
+exchange: 1:2 -> 3:4
+
 atomic_flag: false
 done.

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6273,7 +6273,7 @@ PORT: 3979
       self.skipTest('atomics support missing')
     # Re-use the out file from the C++ atomic test since they should have
     # identical output.
-    self.do_runf('core/test_atomic_c11.c', read_file(test_file('core/test_atomic_cxx.out')))
+    self.do_runf('core/test_atomic_c11.c', read_file(test_file('core/test_atomic_cxx.out')), cflags=['-Wno-atomic-alignment'])
 
   @also_with_pthreads
   def test_atomic_cxx(self):


### PR DESCRIPTION
Note: These should all fall back to using a lock when accessing the 128-bit values. 

These locks are implemented in `system/lib/compiler-rt/lib/builtins/atomic.c`.

See https://github.com/llvm/llvm-project/pull/197519