### PR TITLE
Simplify pthread ref/unref handling. NFC

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -296,10 +296,8 @@ var LibraryPThread = {
           markAsFinished(d.thread);
 #endif
         } else if (cmd === 'loaded') {
-          worker.loaded = true;
-#if ENVIRONMENT_MAY_BE_NODE && PTHREAD_POOL_SIZE
-          // Check that this worker doesn't have an associated pthread.
-          if (ENVIRONMENT_IS_NODE && !worker.pthread_ptr) {
+#if ENVIRONMENT_MAY_BE_NODE
+          if (ENVIRONMENT_IS_NODE && !worker.strongref) {
             // Once worker is loaded & idle, mark it as weakly referenced,
             // so that mere existence of a Worker in the pool does not prevent
             // Node.js from exiting the app.
@@ -604,7 +602,12 @@ var LibraryPThread = {
     //   back to the main thread.
 #if ENVIRONMENT_MAY_BE_NODE
     if (ENVIRONMENT_IS_NODE) {
-      PThread.pthreads[thread].ref();
+      var worker = PThread.pthreads[thread];
+      worker.ref();
+      // Also, record that we called strongref, in case this function is called
+      // bafore the 'loaded' callback from the thread (where we would normally
+      // `unref` it.
+      worker.strongref = 1;
     }
 #endif
   },
@@ -702,15 +705,6 @@ var LibraryPThread = {
     // in this file, and not from the external worker.js.
     msg.moduleCanvasId = threadParams.moduleCanvasId;
     msg.offscreenCanvases = threadParams.offscreenCanvases;
-#endif
-#if ENVIRONMENT_MAY_BE_NODE
-    if (ENVIRONMENT_IS_NODE) {
-      // Mark worker as weakly referenced once we start executing a pthread,
-      // so that its existence does not prevent Node.js from exiting.  This
-      // has no effect if the worker is already weakly referenced (e.g. if
-      // this worker was previously idle/unused).
-      worker.unref();
-    }
 #endif
     // Ask the worker to start executing its pthread entry point function.
     worker.postMessage(msg, threadParams.transferList);

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,9 +1,9 @@
 {
-  "a.out.js": 7367,
+  "a.out.js": 7365,
   "a.out.js.gz": 3587,
   "a.out.nodebug.wasm": 19037,
   "a.out.nodebug.wasm.gz": 8787,
-  "total": 26404,
+  "total": 26402,
   "total_gz": 12374,
   "sent": [
     "a (memory)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7776,
-  "a.out.js.gz": 3791,
+  "a.out.js": 7774,
+  "a.out.js.gz": 3793,
   "a.out.nodebug.wasm": 19038,
   "a.out.nodebug.wasm.gz": 8788,
-  "total": 26814,
-  "total_gz": 12579,
+  "total": 26812,
+  "total_gz": 12581,
   "sent": [
     "a (memory)",
     "b (exit)",


### PR DESCRIPTION
We don't need/want threads to be `unref` until the worker is up and
running.   This is important for #26933 since otherwise the node runtime
can shut down while a thread is starting up.

This change also simplifies the code by limiting the number of places we called `unref` to just one, which also slightly reduces codesize.

Also, remove unused `worker.loaded` assignment.

Split out from #26933