### PR TITLE
[jspi] Fix TypeScript definitions for JSPI exports

### DIFF
--- a/test/other/test_emit_tsd_jspi.d.ts
+++ b/test/other/test_emit_tsd_jspi.d.ts
@@ -1,0 +1,23 @@
+// TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
+declare namespace RuntimeExports {
+    /**
+     * Given a pointer 'idx' to a null-terminated UTF8-encoded string in the given
+     * array that contains uint8 values, returns a copy of that string as a
+     * Javascript String object.
+     * heapOrArray is either a regular array, or a JavaScript typed array view.
+     * @param {number=} idx
+     * @param {number=} maxBytesToRead
+     * @param {boolean=} ignoreNul - If true, the function will not stop on a NUL character.
+     * @return {string}
+     */
+    function UTF8ArrayToString(heapOrArray: any, idx?: number | undefined, maxBytesToRead?: number | undefined, ignoreNul?: boolean | undefined): string;
+    let wasmTable: WebAssembly.Table;
+}
+interface WasmModule {
+  _fooVoid(): Promise<void>;
+  _fooInt(_0: number, _1: number): Promise<number>;
+  _main(_0: number, _1: number): Promise<number>;
+}
+
+export type MainModule = WasmModule & typeof RuntimeExports;
+export default function MainModuleFactory (options?: unknown): Promise<MainModule>;

--- a/test/other/test_tsd_jspi.ts
+++ b/test/other/test_tsd_jspi.ts
@@ -1,0 +1,9 @@
+import moduleFactory from './test_emit_tsd_jspi.js'
+
+async function go() {
+  const module = await moduleFactory();
+  await module._fooVoid();
+  let result = await module._fooInt(7, 8);
+  let mainResult = await module._main(0, 0);
+  module.UTF8ArrayToString([], 99);
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3725,15 +3725,22 @@ More info: https://emscripten.org
     self.do_runf('other/embind_jsgen_method_pointer_stability.cpp', 'done\n', cflags=['-lembind', '-sEMBIND_AOT'])
 
   @requires_dev_dependency('typescript')
-  def test_emit_tsd(self):
+  @parameterized({
+    '': [[], ''],
+    'jspi': [['-sJSPI', '-sJSPI_EXPORTS=fooVoid,fooInt'], '_jspi'],
+    'jspi_wildcard': [['-sJSPI', '-sJSPI_EXPORTS=foo*'], '_jspi'],
+  })
+  def test_emit_tsd(self, args, postfix):
+    if postfix == '_jspi':
+      self.require_jspi()
     self.run_process([EMCC, test_file('other/test_emit_tsd.c'),
-                      '--emit-tsd', 'test_emit_tsd.d.ts', '-sEXPORT_ES6',
+                      '--emit-tsd', f'test_emit_tsd{postfix}.d.ts', '-sEXPORT_ES6',
                       '-sMODULARIZE', '-sEXPORTED_RUNTIME_METHODS=UTF8ArrayToString,wasmTable',
-                      '-o', 'test_emit_tsd.js'] +
+                      '-o', f'test_emit_tsd{postfix}.js'] + args +
                      self.get_cflags())
-    self.assertFileContents(test_file('other/test_emit_tsd.d.ts'), read_file('test_emit_tsd.d.ts'))
+    self.assertFileContents(test_file(f'other/test_emit_tsd{postfix}.d.ts'), read_file(f'test_emit_tsd{postfix}.d.ts'))
     # Test that the output compiles with a TS file that uses the definitions.
-    self.run_tsc([test_file('other/test_tsd.ts'), '--noEmit'])
+    self.run_tsc([test_file(f'other/test_tsd{postfix}.ts'), '--noEmit'])
 
   @requires_dev_dependency('typescript')
   def test_emit_tsd_sync_compilation(self):

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -10,6 +10,7 @@ from C/C++ header files (so that the JS compiler can see the constants in those
 headers, for the libc implementation in JS).
 """
 
+import fnmatch
 import glob
 import hashlib
 import json
@@ -696,10 +697,12 @@ def create_tsd(metadata, embind_tsd):
     out += f'  {mangled}({", ".join(arguments)}): '
     assert len(functype.returns) <= 1, 'One return type only supported'
     if functype.returns:
-      out += f'{type_to_ts_type(functype.returns[0])}'
+      ret_ts_type = type_to_ts_type(functype.returns[0])
     else:
-      out += 'void'
-    out += ';\n'
+      ret_ts_type = 'void'
+    if settings.ASYNCIFY == 2 and any(fnmatch.fnmatch(name, pat) for pat in settings.ASYNCIFY_EXPORTS):
+      ret_ts_type = f'Promise<{ret_ts_type}>'
+    out += f'{ret_ts_type};\n'
   out += '}\n'
   out += f'\n{embind_tsd}'
   # Combine all the various exports.


### PR DESCRIPTION
JSPI exported functions return a Promise when invoked from JavaScript. However, the generated TypeScript definitions previously typed them as returning synchronous values.

Update the TypeScript definition generator to check whether JSPI is enabled and wrap the return types of JSPI exports in a Promise. Also add test coverage for JSPI TypeScript definitions and wildcard matching.