### PR TITLE
[EH] Fix __get_exception_message for multiple virtual inheritance

### DIFF
--- a/system/lib/libcxxabi/src/cxa_exception_js_utils.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception_js_utils.cpp
@@ -85,20 +85,17 @@ void __get_exception_message(void* thrown_object, char** type, char** message) {
   *message = NULL;
   const __shim_type_info* catch_type =
     static_cast<const __shim_type_info*>(&typeid(std::exception));
-  int can_catch = catch_type->can_catch(thrown_type, thrown_object);
-  if (can_catch) {
+
 #if __WASM_EXCEPTIONS__
-    if (isDependentException(&exception_header->unwindHeader)) {
-      thrown_object =
-        reinterpret_cast<__cxa_dependent_exception*>(exception_header)
-          ->primaryException;
-      // can_catch can adjust thrown_object ptr, so rerun it
-      [[maybe_unused]] bool ret =
-        catch_type->can_catch(thrown_type, thrown_object);
-      assert(ret);
-    }
+  if (isDependentException(&exception_header->unwindHeader)) {
+    thrown_object =
+      reinterpret_cast<__cxa_dependent_exception*>(exception_header)
+        ->primaryException;
+  }
 #endif
 
+  int can_catch = catch_type->can_catch(thrown_type, thrown_object);
+  if (can_catch) {
     const char* what =
       static_cast<const std::exception*>(thrown_object)->what();
     *message = (char*)malloc(strlen(what) + 1);

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8761,6 +8761,43 @@ int main() {
     self.do_runf('src.cpp', 'ERROR\n')
 
   @with_all_eh_sjlj
+  def test_multi_inheritance_exception_message2(self):
+    # Regression test for a bug that getting exception message in the DEBUG mode
+    # did not retrieve the correct thrown object pointer in case of multiple
+    # inheritance
+    create_file('src.cpp', r'''
+      #include <exception>
+      #include <string>
+
+      class MyException : public virtual std::exception {
+      public:
+        MyException(const char *msg) : m_message(msg) {}
+        const char *what() const noexcept override { return m_message.c_str(); }
+
+      private:
+        std::string m_message;
+      };
+
+      int main() {
+        std::exception_ptr ep;
+        try {
+          throw MyException("hello");
+        } catch (...) {
+          ep = std::current_exception();
+        }
+
+        try {
+          std::rethrow_exception(ep);
+        } catch (const std::exception &e) {
+          std::printf("caught: %s\n", e.what());
+        }
+        return 0;
+      }
+    ''')
+    self.set_setting('ASSERTIONS')
+    self.do_runf('src.cpp', 'caught: hello\n')
+
+  @with_all_eh_sjlj
   def test_unused_eh_dce(self):
     # Programs that don't use exceptions should not pull in libc++abi or
     # exception formatting helpers when compiled with -fexceptions /

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -8742,37 +8742,6 @@ int main() {
     # did not retrieve the correct thrown object pointer in case of multiple
     # inheritance
     create_file('src.cpp', r'''
-      #include <iostream>
-
-      struct Virt {
-        virtual void virt1() {}
-      };
-
-      struct MyEx : Virt, public std::runtime_error {
-        explicit MyEx(std::string msg) : std::runtime_error(std::move(msg)) {}
-      };
-
-      int main() {
-        try {
-          throw MyEx("ERROR");
-        } catch (...) {
-          try {
-            std::rethrow_exception(std::current_exception());
-          } catch (const std::exception &ex) {
-            std::cout << ex.what() << '\n';
-          }
-        }
-      }
-    ''')
-    self.set_setting('ASSERTIONS')
-    self.do_runf('src.cpp', 'ERROR\n')
-
-  @with_all_eh_sjlj
-  def test_multi_inheritance_exception_message2(self):
-    # Regression test for a bug that getting exception message in the DEBUG mode
-    # did not retrieve the correct thrown object pointer in case of multiple
-    # inheritance
-    create_file('src.cpp', r'''
       #include <exception>
       #include <string>
 


### PR DESCRIPTION
This fixes `__get_exception_message` so it works with multiple virtual inheritance. #24008 tried to fix this, but the test case there didn't `virtual` in the line where the inheritance happens.

In case of dependent exceptions (= the exceptions thrown by `std::rethrow_exception`), we should not even dereference `thrown_object`, because it doesn't contain anything. #24008 ran `can_catch` on the currect primary exception but before that it called `can_catch` on the dependent exception first, which caused the memory error. #24008's test case was fine because it didn't have `virtual`, we didn't have to dereference `thrown_object` (`adjustedPtr` in this method) directly:
https://github.com/emscripten-core/emscripten/blob/b2e19a341ac53b33de3aae7b4ea7bf7168ebace7/system/lib/libcxxabi/src/private_typeinfo.cpp#L572-L579

This computes the primary exception pointer first and then call `can_catch`.

Fixes #26771.