### PR TITLE
docs: fix duplicated words in emcc/Module-Splitting/wasm_audio_worklets RST docs

### DIFF
--- a/site/source/docs/api_reference/wasm_audio_worklets.rst
+++ b/site/source/docs/api_reference/wasm_audio_worklets.rst
@@ -53,7 +53,7 @@ processing graph as AudioWorkletNodes.
 
 Once a class type is instantiated on the Web Audio graph and the graph is
 running, a C/C++ function pointer callback will be invoked for each N samples
-of the processed audio stream that flows through the node (where N is is the
+of the processed audio stream that flows through the node (where N is the
 number of samples per channel, exposed as ``AudioSampleFrame``'s
 ``samplesPerChannel``, always 128 in the 1.0 Web Audio API, though with the 1.1
 API ``emscripten_create_audio_context()`` accepts a ``renderSizeHint`` option).

--- a/site/source/docs/optimizing/Module-Splitting.rst
+++ b/site/source/docs/optimizing/Module-Splitting.rst
@@ -282,7 +282,7 @@ Here’s code implementing the base64 solution::
   console.log(window.btoa(binary));
   console.log("===END===");
 
-Then the profile file can be created by by running::
+Then the profile file can be created by running::
 
   $ echo [pasted base64] | base64 --decode > profile.data
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -241,7 +241,7 @@ Options that are modified or new in *emcc* are listed below:
   [compile+link]
   Write tar file containing inputs and command to reproduce invocation.  When
   sharing this file be aware that it will any object files, source files and
-  libraries that that were passed to the compiler.
+  libraries that were passed to the compiler.
 
 .. _emcc-emit-symbol-map:
 


### PR DESCRIPTION
Three one-line typo fixes for duplicated words in `site/source/docs/`:
- `tools_reference/emcc.rst` — "libraries that that were passed to the compiler." → "libraries that were passed to the compiler."
- `optimizing/Module-Splitting.rst` — "Then the profile file can be created by by running::" → "Then the profile file can be created by running::"
- `api_reference/wasm_audio_worklets.rst` — "(where N is is the" → "(where N is the"

No content/structure change.