### PR TITLE
[libpromise.js] Add explicit addPromise helper function

### DIFF
--- a/src/lib/libpromise.js
+++ b/src/lib/libpromise.js
@@ -25,6 +25,9 @@ addToLibrary({
     return promiseInfo;
   },
 
+  $addPromise__deps: ['$promiseMap'],
+  $addPromise: (promise) => promiseMap.allocate({promise}),
+
   $idsToPromises__deps: ['$getPromise'],
   $idsToPromises: (idBuf, size) => {
     var promises = [];
@@ -133,7 +136,7 @@ addToLibrary({
     };
   },
 
-  emscripten_promise_then__deps: ['$promiseMap',
+  emscripten_promise_then__deps: ['$addPromise',
                                   '$getPromise',
                                   '$makePromiseCallback'],
   emscripten_promise_then: (id, onFulfilled, onRejected, userData) => {
@@ -142,33 +145,30 @@ addToLibrary({
 #endif
     {{{ runtimeKeepalivePush() }}};
     var promise = getPromise(id);
-    var newId = promiseMap.allocate({
-      promise: promise.then(makePromiseCallback(onFulfilled, userData),
-                            makePromiseCallback(onRejected, userData))
-    });
+    var chainedPromise = promise.then(makePromiseCallback(onFulfilled, userData),
+                                      makePromiseCallback(onRejected, userData));
+    var newId = addPromise(chainedPromise);
 #if RUNTIME_DEBUG
     dbg(`emscripten_promise_then: -> ${newId}`);
 #endif
     return newId;
   },
 
-  emscripten_promise_all__deps: ['$promiseMap', '$idsToPromises'],
+  emscripten_promise_all__deps: ['$addPromise', '$idsToPromises'],
   emscripten_promise_all: (idBuf, resultBuf, size) => {
     var promises = idsToPromises(idBuf, size);
 #if RUNTIME_DEBUG
     dbg(`emscripten_promise_all: ${promises}`);
 #endif
-    var id = promiseMap.allocate({
-      promise: Promise.all(promises).then((results) => {
-        if (resultBuf) {
-          for (var i = 0; i < size; i++) {
-            var result = results[i];
-            {{{ makeSetValue('resultBuf', `i*${POINTER_SIZE}`, 'result', '*') }}};
-          }
+    var id = addPromise(Promise.all(promises).then((results) => {
+      if (resultBuf) {
+        for (var i = 0; i < size; i++) {
+          var result = results[i];
+          {{{ makeSetValue('resultBuf', `i*${POINTER_SIZE}`, 'result', '*') }}};
         }
-        return resultBuf;
-      })
-    });
+      }
+      return resultBuf;
+    }));
 #if RUNTIME_DEBUG
     dbg(`create: ${id}`);
 #endif
@@ -185,34 +185,32 @@ addToLibrary({
     {{{ makeSetValue('ptr', C_STRUCTS.em_settled_result_t.value, 'value', '*') }}};
   },
 
-  emscripten_promise_all_settled__deps: ['$promiseMap', '$idsToPromises', '$setPromiseResult'],
+  emscripten_promise_all_settled__deps: ['$addPromise', '$idsToPromises', '$setPromiseResult'],
   emscripten_promise_all_settled: (idBuf, resultBuf, size) => {
     var promises = idsToPromises(idBuf, size);
 #if RUNTIME_DEBUG
     dbg(`emscripten_promise_all_settled: ${promises}`);
 #endif
-    var id = promiseMap.allocate({
-      promise: Promise.allSettled(promises).then((results) => {
-        if (resultBuf) {
-          var offset = resultBuf;
-          for (var i = 0; i < size; i++, offset += {{{ C_STRUCTS.em_settled_result_t.__size__ }}}) {
-            if (results[i].status === 'fulfilled') {
-              setPromiseResult(offset, true, results[i].value);
-            } else {
-              setPromiseResult(offset, false, results[i].reason);
-            }
+    var id = addPromise(Promise.allSettled(promises).then((results) => {
+      if (resultBuf) {
+        var offset = resultBuf;
+        for (var i = 0; i < size; i++, offset += {{{ C_STRUCTS.em_settled_result_t.__size__ }}}) {
+          if (results[i].status === 'fulfilled') {
+            setPromiseResult(offset, true, results[i].value);
+          } else {
+            setPromiseResult(offset, false, results[i].reason);
           }
         }
-        return resultBuf;
-      })
-    });
+      }
+      return resultBuf;
+    }));
 #if RUNTIME_DEBUG
     dbg(`create: ${id}`);
 #endif
     return id;
   },
 
-  emscripten_promise_any__deps: ['$promiseMap', '$idsToPromises'],
+  emscripten_promise_any__deps: ['$addPromise', '$idsToPromises'],
   emscripten_promise_any: (idBuf, errorBuf, size) => {
     var promises = idsToPromises(idBuf, size);
 #if RUNTIME_DEBUG
@@ -221,31 +219,27 @@ addToLibrary({
 #if ASSERTIONS
     assert(typeof Promise.any != 'undefined', "Promise.any does not exist");
 #endif
-    var id = promiseMap.allocate({
-      promise: Promise.any(promises).catch((err) => {
-        if (errorBuf) {
-          for (var i = 0; i < size; i++) {
-            {{{ makeSetValue('errorBuf', `i*${POINTER_SIZE}`, 'err.errors[i]', '*') }}};
-          }
+    var id = addPromise(Promise.any(promises).catch((err) => {
+      if (errorBuf) {
+        for (var i = 0; i < size; i++) {
+          {{{ makeSetValue('errorBuf', `i*${POINTER_SIZE}`, 'err.errors[i]', '*') }}};
         }
-        throw errorBuf;
-      })
-    });
+      }
+      throw errorBuf;
+    }));
 #if RUNTIME_DEBUG
     dbg(`create: ${id}`);
 #endif
     return id;
   },
 
-  emscripten_promise_race__deps: ['$promiseMap', '$idsToPromises'],
+  emscripten_promise_race__deps: ['$addPromise', '$idsToPromises'],
   emscripten_promise_race: (idBuf, size) => {
     var promises = idsToPromises(idBuf, size);
 #if RUNTIME_DEBUG
     dbg(`emscripten_promise_race: ${promises}`);
 #endif
-    var id = promiseMap.allocate({
-      promise: Promise.race(promises)
-    });
+    var id = addPromise(Promise.race(promises));
 #if RUNTIME_DEBUG
     dbg(`create: ${id}`);
 #endif

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 24243,
-  "a.out.js.gz": 8720,
+  "a.out.js": 24254,
+  "a.out.js.gz": 8724,
   "a.out.nodebug.wasm": 14850,
   "a.out.nodebug.wasm.gz": 7314,
-  "total": 39093,
-  "total_gz": 16034,
+  "total": 39104,
+  "total_gz": 16038,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268093,
+  "a.out.js": 268075,
   "a.out.nodebug.wasm": 587563,
-  "total": 855656,
+  "total": 855638,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -1049,6 +1049,7 @@ Module['FS_createPreloadedFile'] = FS.createPreloadedFile;
   'registerPreMainLoop',
   'getPromise',
   'makePromise',
+  'addPromise',
   'idsToPromises',
   'makePromiseCallback',
   'Browser_asyncPrepareDataCounter',

--- a/test/codesize/test_codesize_minimal_O0.json
+++ b/test/codesize/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19393,
-  "a.out.js.gz": 6981,
+  "a.out.js": 19404,
+  "a.out.js.gz": 6985,
   "a.out.nodebug.wasm": 1015,
   "a.out.nodebug.wasm.gz": 602,
-  "total": 20408,
-  "total_gz": 7583,
+  "total": 20419,
+  "total_gz": 7587,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 57036,
-  "hello_world.js.gz": 17754,
+  "hello_world.js": 57052,
+  "hello_world.js.gz": 17758,
   "hello_world.wasm": 14850,
   "hello_world.wasm.gz": 7314,
   "no_asserts.js": 26625,
   "no_asserts.js.gz": 8892,
   "no_asserts.wasm": 12010,
   "no_asserts.wasm.gz": 5880,
-  "strict.js": 54817,
-  "strict.js.gz": 17051,
+  "strict.js": 54833,
+  "strict.js.gz": 17054,
   "strict.wasm": 14850,
   "strict.wasm.gz": 7310,
-  "total": 180188,
-  "total_gz": 64201
+  "total": 180220,
+  "total_gz": 64208
 }


### PR DESCRIPTION
In addition to making things more explicitly, this saves on codesize when more than one promise function is included (see dylink_all codesize changes).