### PR TITLE
Fix `other.test_closure_webgpu_wasm64`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1081,6 +1081,7 @@ jobs:
             other.test_min_node_version
             other.test_node_emscripten_num_logical_cores
             other.test_js_base64_api
+            other.test_closure_webgpu_wasm64
             core2.test_hello_world
             core2.test_pthread_create
             core2.test_i64_invoke_bigint

--- a/src/lib/libpromise.js
+++ b/src/lib/libpromise.js
@@ -274,6 +274,7 @@ addToLibrary({
   },
   emscripten_promise_await_unchecked: (id) => {
     abort('emscripten_promise_await_unchecked is only available with ASYNCIFY');
+    return 0;
   },
 #endif
 });

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268222,
+  "a.out.js": 268231,
   "a.out.nodebug.wasm": 587563,
-  "total": 855785,
+  "total": 855794,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
This was broken by #26954 but not covered by CI because we run the `other` testsuite with the emsdk version of node that doesn't support wasm64.

Without this change the wasm64 variant complains because it tried to cast the return value of this function to a BigInt (pointer) before returning to Wasm.