### PR TITLE
Fix wasm64 test suite failures. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -842,7 +842,9 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
   #                  libraries, for example
   def get_cflags(self, main_file=False, compile_only=False, asm_only=False):
     def is_ldflag(f):
-      return f.startswith('-l') or any(f.startswith(s) for s in ['-sEXPORT_ES6', '-sGL_TESTING', '-sPROXY_TO_PTHREAD', '-sENVIRONMENT=', '--pre-js=', '--post-js=', '-sPTHREAD_POOL_SIZE='])
+      return f.startswith(('-l', '-sEXPORT_ES6', '-sGL_TESTING', '-sPROXY_TO_PTHREAD',
+                           '-sENVIRONMENT=', '--pre-js=', '--post-js=', '-sPTHREAD_POOL_SIZE=',
+                           '--profiling-funcs'))
 
     args = self.serialize_settings(compile_only or asm_only) + self.cflags
     if asm_only:


### PR DESCRIPTION
These failures were introduced in #26963 but not caught because we currently (temporarily) disabled this suite in #26664.

Here I'm adding `--profiling-funcs` to the list of ld-only flags.  I've also switch from using `any` to just passing multiple prefixes to the `.startswith` method.

Fixes: #26968