### PR TITLE
Simplify usage of python str.startswith. NFC

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -779,7 +779,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
       ]
 
       left_over_files = set(temp_files_after_run) - set(self.temp_files_before_run)
-      left_over_files = [f for f in left_over_files if not any(f.startswith(p) for p in ignorable_file_prefixes)]
+      left_over_files = [f for f in left_over_files if not f.startswith(ignorable_file_prefixes)]
       if left_over_files:
         errlog(f'ERROR: After running test, there are {len(left_over_files)} new temporary files/directories left behind:')
         for f in left_over_files:

--- a/test/test_posixtest.py
+++ b/test/test_posixtest.py
@@ -32,15 +32,15 @@ class posixtest(RunnerCore):
 
 
 def filter_tests(all_tests):
-  prefixes = [
+  prefixes = (
     'pthread_',
     'strftime',
     'asctime',
     'gmtime',
-  ]
+  )
 
   def enable_test(t):
-    return any(t.startswith(p) for p in prefixes)
+    return t.startswith(prefixes)
 
   return [t for t in all_tests if enable_test(t)]
 

--- a/tools/maint/add_license.py
+++ b/tools/maint/add_license.py
@@ -59,7 +59,7 @@ exclude_contents = ['Copyright', 'LICENSE.TXT', 'PUBLIC DOMAIN']
 
 
 def process_file(filename):
-  if any(filename.startswith(ex) for ex in exclude_filenames):
+  if filename.startswith(exclude_filenames):
     return
   ext = os.path.splitext(filename)[1]
   if ext not in {'.py', '.c', '.cpp', '.h', '.js'}:

--- a/tools/maint/gen_sig_info.py
+++ b/tools/maint/gen_sig_info.py
@@ -175,7 +175,7 @@ def ignore_symbol(s, cxx):
   # don't need to be auto-generated.
   if s.startswith(('emscripten_gl', 'emscripten_alc')):
     return True
-  if s.startswith('gl') and any(s.endswith(x) for x in ('NV', 'EXT', 'WEBGL', 'ARB', 'ANGLE')):
+  if s.startswith('gl') and s.endswith(('NV', 'EXT', 'WEBGL', 'ARB', 'ANGLE')):
     return True
   if s in {'__stack_base', '__memory_base', '__table_base', '__global_base', '__heap_base',
            '__stack_pointer', '__stack_high', '__stack_low',
@@ -267,7 +267,7 @@ def remove_sigs(sig_info):
 
   def strip_line(l):
     l = l.strip()
-    return any(l.startswith(r) for r in to_remove)
+    return l.startswith(to_remove)
 
   files = glob.glob('src/*.js') + glob.glob('src/**/*.js')
   for file in files:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -579,7 +579,7 @@ def is_internal_global(name):
                                  '__start_em_lib_deps', '__stop_em_lib_deps',
                                  '__em_lib_deps'}
   internal_prefixes = ('__em_js__', '__em_lib_deps')
-  return name in internal_start_stop_symbols or any(name.startswith(p) for p in internal_prefixes)
+  return name in internal_start_stop_symbols or name.startswith(internal_prefixes)
 
 
 def is_user_export(name):


### PR DESCRIPTION
This method can take a tuple of prefixes to check for.

Same for `.endswith`.

I noticed this while working on #26969