### PR TITLE
Fix test_rounding for recent LLVM change

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -901,7 +901,7 @@ class TestCoreBase(RunnerCore):
     self.do_run_in_out_file_test('math/fmodf.c')
 
   def test_rounding(self):
-    self.do_core_test('test_rounding.c')
+    self.do_core_test('test_rounding.c', cflags=['-Wno-fenv-access'])
 
   def test_stack(self):
     self.set_setting('INLINING_LIMIT')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -901,8 +901,7 @@ class TestCoreBase(RunnerCore):
     self.do_run_in_out_file_test('math/fmodf.c')
 
   def test_rounding(self):
-    self.skipTest('https://github.com/emscripten-core/emscripten/pull/26975')
-    self.do_core_test('test_rounding.c', cflags=['-Wno-fenv-access'])
+    self.do_core_test('test_rounding.c', cflags=['-Wno-fenv-access', '-Wno-unknown-warning-option'])
 
   def test_stack(self):
     self.set_setting('INLINING_LIMIT')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -901,6 +901,7 @@ class TestCoreBase(RunnerCore):
     self.do_run_in_out_file_test('math/fmodf.c')
 
   def test_rounding(self):
+    self.skipTest('https://github.com/emscripten-core/emscripten/pull/26975')
     self.do_core_test('test_rounding.c', cflags=['-Wno-fenv-access'])
 
   def test_stack(self):


### PR DESCRIPTION
As of https://github.com/llvm/llvm-project/commit/5f2bedca745d5efa1955369cfe352bcd09be4633, LLVM warns on using fe* methods without proper flags.

This does not really matter in wasm, but we still must disable the warning.