### PR TITLE
Simplify setImmediate polyfill handling in `EM_TIMING_SETIMMEDIATE`

### DIFF
--- a/src/lib/libeventloop.js
+++ b/src/lib/libeventloop.js
@@ -344,14 +344,15 @@ LibraryJSEventLoop = {
         if (globalThis.setImmediate) {
           MainLoop.setImmediate = setImmediate;
         } else {
+#if RUNTIME_DEBUG
+          dbg('using polyfill for setImmediate');
+#endif
           // Emulate setImmediate. (note: not a complete polyfill, we don't emulate clearImmediate() to keep code size to minimum, since not needed)
           var setImmediates = [];
           var emscriptenMainLoopMessageId = 'setimmediate';
           /** @param {Event} event */
           var MainLoop_setImmediate_messageHandler = (event) => {
-            // When called in current thread or Worker, the main loop ID is structured slightly different to accommodate for --proxy-to-worker runtime listening to Worker events,
-            // so check for both cases.
-            if (event.data === emscriptenMainLoopMessageId || event.data.target === emscriptenMainLoopMessageId) {
+            if (event.data === emscriptenMainLoopMessageId) {
               event.stopPropagation();
               setImmediates.shift()();
             }
@@ -360,10 +361,12 @@ LibraryJSEventLoop = {
           MainLoop.setImmediate = /** @type{function(function(): ?, ...?): number} */((func) => {
             setImmediates.push(func);
             if (ENVIRONMENT_IS_WORKER) {
-              Module['setImmediates'] ??= [];
-              Module['setImmediates'].push(func);
-              postMessage({target: emscriptenMainLoopMessageId}); // In --proxy-to-worker, route the message via proxyClient.js
-            } else postMessage(emscriptenMainLoopMessageId, "*"); // On the main thread, can just send the message to itself.
+              // The postMessge API in a Worker, sends message to the main
+              // thread and does not support the `targetOrigin` (*) argument.
+              postMessage(emscriptenMainLoopMessageId);
+            } else {
+              postMessage(emscriptenMainLoopMessageId, '*');
+            }
           });
         }
       }

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -305,7 +305,7 @@ var LibraryPThread = {
           }
 #endif
           onFinishedLoading(worker);
-        } else if (d.target === 'setimmediate') {
+        } else if (d === 'setimmediate') {
           // Worker wants to postMessage() to itself to implement setImmediate()
           // emulation.
           worker.postMessage(d);

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268231,
+  "a.out.js": 268108,
   "a.out.nodebug.wasm": 587563,
-  "total": 855794,
+  "total": 855671,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7365,
-  "a.out.js.gz": 3587,
+  "a.out.js": 7358,
+  "a.out.js.gz": 3583,
   "a.out.nodebug.wasm": 19037,
   "a.out.nodebug.wasm.gz": 8787,
-  "total": 26402,
-  "total_gz": 12374,
+  "total": 26395,
+  "total_gz": 12370,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7774,
-  "a.out.js.gz": 3793,
+  "a.out.js": 7767,
+  "a.out.js.gz": 3790,
   "a.out.nodebug.wasm": 19038,
   "a.out.nodebug.wasm.gz": 8788,
-  "total": 26812,
-  "total_gz": 12581,
+  "total": 26805,
+  "total_gz": 12578,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1864,6 +1864,10 @@ window.close = () => {
   def test_emscripten_main_loop_setimmediate(self, args):
     self.btest_exit('test_emscripten_main_loop_setimmediate.c', cflags=args)
 
+  def test_emscripten_main_loop_setimmediate_polyfill(self):
+    create_file('remove_setimmediate.js', 'globalThis.setImmediate = undefined;')
+    self.btest_exit('test_emscripten_main_loop_setimmediate.c', cflags=['-sRUNTIME_DEBUG', '--pre-js=remove_setimmediate.js'])
+
   @parameterized({
     '': ([],),
     'O1': (['-O1'],),

--- a/test/test_emscripten_main_loop_setimmediate.c
+++ b/test/test_emscripten_main_loop_setimmediate.c
@@ -27,7 +27,8 @@ void looper() {
     // Expecting to run extremely fast unthrottled, and certainly not bounded by
     // vsync, so less than common 16.667 msecs per frame (this is assuming 60hz
     // display)
-    exit((msecsPerFrame < 5) ? 0 : 1);
+    assert(msecsPerFrame < 5);
+    exit(0);
   }
 }
 


### PR DESCRIPTION
Some of this logic seems to be from the `--proxy-to-worker` days, and that settings was removed a while back.