### PR TITLE
Use `scheduler.postTask` when implementing `EM_TIMING_SETIMMEDIATE`

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -234,3 +234,5 @@ Navigator.prototype.webkitGetUserMedia = function(
 var os = {};
 
 AudioWorkletProcessor.parameterDescriptors;
+
+var scheduler = {};

--- a/src/lib/libeventloop.js
+++ b/src/lib/libeventloop.js
@@ -341,11 +341,19 @@ LibraryJSEventLoop = {
       assert(mode == {{{ cDefs.EM_TIMING_SETIMMEDIATE}}});
 #endif
       if (!MainLoop.setImmediate) {
-        if (globalThis.setImmediate) {
+        if (globalThis.scheduler) {
+          // Some modern browsers implement scheduler.postTask, but not all.
+#if RUNTIME_DEBUG
+          dbg('setImmediate: using scheduler.postTask');
+#endif
+          MainLoop.setImmediate = scheduler.postTask.bind(scheduler);
+#if ENVIRONMENT_MAY_BE_NODE
+        } else if (globalThis.setImmediate) {
           MainLoop.setImmediate = setImmediate;
+#endif
         } else {
 #if RUNTIME_DEBUG
-          dbg('using polyfill for setImmediate');
+          dbg('setImmediate: using polyfill');
 #endif
           // Emulate setImmediate. (note: not a complete polyfill, we don't emulate clearImmediate() to keep code size to minimum, since not needed)
           var setImmediates = [];

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268108,
+  "a.out.js": 268175,
   "a.out.nodebug.wasm": 587563,
-  "total": 855671,
+  "total": 855738,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
IIUC this API is better than `setTimeout(0)` or `postMessage()` in terms of being a polyfill for the old/deprecated setImmediate API.

Its not clear if/when safari will implement this API so it will likely need to be feature detected for the foreseeable.