### PR TITLE
Minor gen_sig_info fixes. NFC

### DIFF
--- a/src/lib/libsigs.js
+++ b/src/lib/libsigs.js
@@ -226,6 +226,7 @@ sigs = {
   __cxa_rethrow_primary_exception__sig: 'vp',
   __cxa_throw__sig: 'vppp',
   __cxa_uncaught_exceptions__sig: 'i',
+  __do_set_thread_state__sig: 'v',
   __handle_stack_overflow__sig: 'vp',
   __pthread_create_js__sig: 'ipppp',
   __resumeException__sig: 'vp',

--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -353,7 +353,7 @@ if (ENVIRONMENT_IS_WASM_WORKER
   // `__set_thread_state` lazily to save code size for programs that don't use
   // the threads state.
   __do_set_thread_state__deps: ['__set_thread_state'],
-  __do_set_thread_state: (tb) => {
+  __do_set_thread_state: () => {
     ___set_thread_state(
       /*thread_ptr=*/0,
 #if AUDIO_WORKLET

--- a/system/lib/pthread/threading_internal.h
+++ b/system/lib/pthread/threading_internal.h
@@ -138,3 +138,7 @@ void _emscripten_thread_notify(pthread_t thread);
 intptr_t _emscripten_atomic_wait_promise(volatile void *addr,
                                          uint32_t value,
                                          double maxWaitMilliseconds);
+
+// Internal function used in wasm worker builds (included here solely for
+// gen_sig_info.py).
+void __do_set_thread_state(void);

--- a/tools/maint/gen_sig_info.py
+++ b/tools/maint/gen_sig_info.py
@@ -386,7 +386,7 @@ def main(args):
                               'LINK_AS_CXX': 1,
                               'SHARED_MEMORY': 0,
                               'AUTO_JS_LIBRARIES': 0}, cxx=True)
-  extract_sig_info(sig_info, {'AUDIO_WORKLET': 1, 'WASM_WORKERS': 1, 'JS_LIBRARIES': ['libwasm_worker.js', 'libwebaudio.js']})
+  extract_sig_info(sig_info, {'AUDIO_WORKLET': 1, 'WASM_WORKERS': 1, 'PTHREADS': 0, 'JS_LIBRARIES': ['libwasm_worker.js', 'libwebaudio.js']})
   extract_sig_info(sig_info, {'USE_GLFW': 3}, ['-DGLFW3'])
   extract_sig_info(sig_info, {'JS_LIBRARIES': ['libembind.js', 'libemval.js'],
                               'USE_SDL': 0,


### PR DESCRIPTION
Split out from #26987.

We were running the compiler with WASM_WORKERS + PTHREADS but not actually including library_pthreads.  If we disable PTHREADS then the compiler starts seeing the WASM_WORKER specific functions.