### PR TITLE
Remove setimmediate handler from pthread onmessage. NFC

### DIFF
--- a/src/runtime_pthread.js
+++ b/src/runtime_pthread.js
@@ -174,8 +174,6 @@ if (ENVIRONMENT_IS_PTHREAD) {
           dbg(`worker: Pthread 0x${_pthread_self().toString(16)} completed its main entry point with an 'unwind', keeping the worker alive for asynchronous operation.`);
 #endif
         }
-      } else if (msgData.target === 'setimmediate') {
-        // no-op
       } else if (cmd == {{{ CMD_CHECK_MAILBOX }}}) {
         if (initializedJS) {
           checkMailbox();

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7172,
-  "a.out.js.gz": 3553,
+  "a.out.js": 7143,
+  "a.out.js.gz": 3542,
   "a.out.nodebug.wasm": 19037,
   "a.out.nodebug.wasm.gz": 8787,
-  "total": 26209,
-  "total_gz": 12340,
+  "total": 26180,
+  "total_gz": 12329,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7580,
-  "a.out.js.gz": 3756,
+  "a.out.js": 7551,
+  "a.out.js.gz": 3745,
   "a.out.nodebug.wasm": 19038,
   "a.out.nodebug.wasm.gz": 8788,
-  "total": 26618,
-  "total_gz": 12544,
+  "total": 26589,
+  "total_gz": 12533,
   "sent": [
     "a (memory)",
     "b (exit)",


### PR DESCRIPTION
In #26984, I changed the format of this message so it no longer includes the `target` key.

I should have also remove this extra handler here, which is actually doing nothing.  There is no need to explicitly do any kind `no-op` handling since all messages that don't have a `cmd` key are already completely ignored by this handler.