### PR TITLE
Remove redundant Atomics annotations

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -51,17 +51,6 @@ Math.clz32 = function() {};
 Math.trunc = function() {};
 
 /**
- * Atomics
- */
-
-var Atomics = {};
-/**
- * @param {number=} maxWaitMilliseconds
- * @suppress {duplicate, checkTypes}
- */
-Atomics.waitAsync = function(i32a, index, value, maxWaitMilliseconds) {};
-
-/**
  * @const
  * @suppress {duplicate, checkTypes}
  */

--- a/src/lib/libatomic.js
+++ b/src/lib/libatomic.js
@@ -47,10 +47,6 @@ addToLibrary({
   #if ASSERTIONS && WASM_WORKERS
     if (!ENVIRONMENT_IS_WASM_WORKER) err('Current environment does not support Atomics.waitAsync(): polyfilling it, but this is going to be suboptimal.');
   #endif
-  /**
-   * @param {number=} maxWaitMilliseconds
-   * @suppress {duplicate, checkTypes}
-   */
   Atomics.waitAsync = (i32a, index, value, maxWaitMilliseconds) => {
     let val = Atomics.load(i32a, index);
     if (val != value) return { async: false, value: 'not-equal' };
@@ -101,9 +97,6 @@ addToLibrary({
   $liveAtomicWaitAsyncCounter__internal: true,
 
   emscripten_atomic_wait_async__deps: ['$atomicWaitStates', '$liveAtomicWaitAsyncs', '$liveAtomicWaitAsyncCounter', '$polyfillWaitAsync', '$callUserCallback'],
-  // Closure's Atomics.waitAsync extern incorrectly returns Promise<string>,
-  // but the spec returns a result object with async/value fields.
-  emscripten_atomic_wait_async__docs: '/** @suppress {missingProperties} */',
   emscripten_atomic_wait_async: (addr, val, asyncWaitFinished, userData, maxWaitMilliseconds) => {
     let wait = Atomics.waitAsync(HEAP32, {{{ getHeapOffset('addr', 'i32') }}}, val, maxWaitMilliseconds);
     if (!wait.async) return atomicWaitStates.indexOf(wait.value);

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -1313,9 +1313,6 @@ var LibraryPThread = {
   },
 
   _emscripten_thread_mailbox_await__deps: ['$checkMailbox', '$waitAsyncPolyfilled'],
-  // Closure's Atomics.waitAsync extern incorrectly returns Promise<string>,
-  // but the spec returns a result object with async/value fields.
-  _emscripten_thread_mailbox_await__docs: '/** @suppress {missingProperties} */',
   _emscripten_thread_mailbox_await: (pthread_ptr) => {
     if (!waitAsyncPolyfilled) {
       // Wait on the pthread's initial self-pointer field because it is easy and

--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -301,9 +301,6 @@ if (ENVIRONMENT_IS_WASM_WORKER
   },
 
   emscripten_lock_async_acquire__deps: ['$polyfillWaitAsync'],
-  // Closure's Atomics.waitAsync extern incorrectly returns Promise<string>,
-  // but the spec returns a result object with async/value fields.
-  emscripten_lock_async_acquire__docs: '/** @suppress {missingProperties} */',
   emscripten_lock_async_acquire: (lock, asyncWaitFinished, userData, maxWaitMilliseconds) => {
     let tryAcquireLock = () => {
       do {
@@ -323,9 +320,6 @@ if (ENVIRONMENT_IS_WASM_WORKER
   },
 
   emscripten_semaphore_async_acquire__deps: ['$polyfillWaitAsync'],
-  // Closure's Atomics.waitAsync extern incorrectly returns Promise<string>,
-  // but the spec returns a result object with async/value fields.
-  emscripten_semaphore_async_acquire__docs: '/** @suppress {missingProperties} */',
   emscripten_semaphore_async_acquire: (sem, num, asyncWaitFinished, userData, maxWaitMilliseconds) => {
     let dispatch = (idx, ret) => {
       setTimeout(() => {


### PR DESCRIPTION
- Continuation of emscripten-core/emscripten#26869
- google/closure-compiler#4317 was merged into `20260519.0.0` which fixes the `Atomics.waitAsync` signature
  - The `@suppress` annotations are no longer necessary