### PR TITLE
Update feature matrix for `-sGROWABLE_ARRAYBUFFERS`

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -3332,8 +3332,8 @@ GROWABLE_ARRAYBUFFERS
 =====================
 
 Enable support for GrowableSharedArrayBuffer.
-This features is only available behind a flag in recent versions of
-node/chrome.
+This feature has only recently become available across major browser engines
+and Node.js.
 
 .. note:: This is an experimental setting
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -2189,8 +2189,8 @@ var WASM_ESM_INTEGRATION = false;
 var JS_BASE64_API = false;
 
 // Enable support for GrowableSharedArrayBuffer.
-// This features is only available behind a flag in recent versions of
-// node/chrome.
+// This feature has only recently become available across major browser engines
+// and Node.js.
 // [experimental]
 // [link]
 var GROWABLE_ARRAYBUFFERS = false;

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -132,9 +132,12 @@ min_browser_versions = {
   # This feature is not used anywhere else except the test harness to detect
   # browser version.
   Feature.GROWABLE_ARRAYBUFFERS: {
-    'chrome': 136,
+    'chrome': 144,
     'firefox': 145,
-    'safari': UNSUPPORTED,
+    'safari': 260200,
+    # Supported with flag --experimental-wasm-rab-integration (TODO: Change
+    # this to unflagged version of Node.js 260000, see also the comment in
+    # Feature.WASM_EXCEPTIONS above)
     'node': 240000,
   },
 
@@ -264,3 +267,5 @@ def apply_min_browser_versions():
       enable_feature(Feature.WASM_LEGACY_EXCEPTIONS, 'Wasm Legacy exceptions (-fwasm-exceptions with -sWASM_LEGACY_EXCEPTIONS=1)')
     else:
       enable_feature(Feature.WASM_EXCEPTIONS, 'Wasm exceptions (-fwasm-exceptions with -sWASM_LEGACY_EXCEPTIONS=0)')
+  if settings.GROWABLE_ARRAYBUFFERS:
+    enable_feature(Feature.GROWABLE_ARRAYBUFFERS, 'GrowableSharedArrayBuffer')

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -152,7 +152,7 @@ EXPERIMENTAL_SETTINGS = {
     'SPLIT_MODULE': '-sSPLIT_MODULE is experimental and subject to change',
     'SOURCE_PHASE_IMPORTS': '-sSOURCE_PHASE_IMPORTS is experimental and not yet supported in browsers',
     'JS_BASE64_API': '-sJS_BASE64_API is experimental and not yet supported in browsers',
-    'GROWABLE_ARRAYBUFFERS': '-sGROWABLE_ARRAYBUFFERS is experimental and not yet supported in browsers',
+    'GROWABLE_ARRAYBUFFERS': '-sGROWABLE_ARRAYBUFFERS is still experimental and has only recently become available in browsers',
     'SUPPORT_BIG_ENDIAN': '-sSUPPORT_BIG_ENDIAN is experimental, not all features are fully supported.',
     'WASM_ESM_INTEGRATION': '-sWASM_ESM_INTEGRATION is still experimental and not yet supported in browsers',
 }


### PR DESCRIPTION
And update setting description to note recent support across major
browser engines and Node.js.

See: https://caniuse.com/mdn-webassembly_api_memory_toresizablebuffer