### PR TITLE
Fix emscripten_set_immediate when called from a pthread

### DIFF
--- a/src/lib/libeventloop.js
+++ b/src/lib/libeventloop.js
@@ -60,24 +60,29 @@ LibraryJSEventLoop = {
     } else if (globalThis.addEventListener) {
       var __setImmediate_id_counter = 0;
       var __setImmediate_queue = [];
-      var __setImmediate_message_id = "_si";
+      var __setImmediate_message_id = '_si';
       /** @param {Event} e */
       var __setImmediate_cb = (e) => {
         if (e.data === __setImmediate_message_id) {
           e.stopPropagation();
-          __setImmediate_queue.shift()();
+          __setImmediate_queue.shift()?.();
           ++__setImmediate_id_counter;
         }
       }
       addEventListener("message", __setImmediate_cb, true);
       emSetImmediate = (func) => {
-        postMessage(__setImmediate_message_id, "*");
+#if PTHREADS
+        if (ENVIRONMENT_IS_WORKER) {
+          postMessage(__setImmediate_message_id);
+        } else
+#endif
+        postMessage(__setImmediate_message_id, '*');
         return __setImmediate_id_counter + __setImmediate_queue.push(func) - 1;
       }
       emClearImmediate = /**@type{function(number=)}*/((id) => {
         var index = id - __setImmediate_id_counter;
         // must preserve the order and count of elements in the queue, so replace the pending callback with an empty function
-        if (index >= 0 && index < __setImmediate_queue.length) __setImmediate_queue[index] = () => {};
+        if (index >= 0 && index < __setImmediate_queue.length) __setImmediate_queue[index] = null;
       })
     }`,
   $emSetImmediate: undefined,

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -293,7 +293,7 @@ var LibraryPThread = {
           return;
         }
 
-        if (d === 'setimmediate') {
+        if (d === 'setimmediate' || d === '_si') {
           // Worker wants to postMessage() to itself to implement setImmediate()
           // emulation.
           worker.postMessage(d);

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7143,
-  "a.out.js.gz": 3542,
+  "a.out.js": 7154,
+  "a.out.js.gz": 3549,
   "a.out.nodebug.wasm": 19037,
   "a.out.nodebug.wasm.gz": 8787,
-  "total": 26180,
-  "total_gz": 12329,
+  "total": 26191,
+  "total_gz": 12336,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7551,
-  "a.out.js.gz": 3745,
+  "a.out.js": 7562,
+  "a.out.js.gz": 3752,
   "a.out.nodebug.wasm": 19038,
   "a.out.nodebug.wasm.gz": 8788,
-  "total": 26589,
-  "total_gz": 12533,
+  "total": 26600,
+  "total_gz": 12540,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4875,8 +4875,12 @@ Module["preRun"] = () => {
   def test_emscripten_set_timeout_loop(self):
     self.btest_exit('emscripten_set_timeout_loop.c', cflags=['-pthread', '-sPROXY_TO_PTHREAD'])
 
-  def test_emscripten_set_immediate(self):
-    self.btest_exit('emscripten_set_immediate.c')
+  @parameterized({
+    '': ([],),
+    'pthread': (['-pthread', '-sPROXY_TO_PTHREAD'],),
+  })
+  def test_emscripten_set_immediate(self, args):
+    self.btest_exit('emscripten_set_immediate.c', cflags=args)
 
   def test_emscripten_set_immediate_loop(self):
     self.btest_exit('emscripten_set_immediate_loop.c')


### PR DESCRIPTION
We have special handling for the `setimmediate` message in the pthreads code.  Without this change, `emscripten_set_immediate` (which uses `emSetImmediate` under the hood) was using `_si` as its message ID. This meant that when called from a worker, the message sent to the main thread was not recognized and therefore not forwarded back to the worker, causing the immediate callback to never run.

By unifying both to use `setimmediate`, we can reuse the existing pthreads forwarding logic.

Also update `emSetImmediate` to check if it is running in a worker and omit the target origin argument when calling `postMessage`, as the worker version of `postMessage` does not support it. This matches the logic already present in the `EM_TIMING_SETIMMEDIATE` main loop implementation.

Add a pthread variant to `test_emscripten_set_immediate` to prevent regressions.