### PR TITLE
Allow late print calls from terminating pthreads

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -591,17 +591,6 @@ var LibraryPThread = {
     dbg(`terminateWorker: ${worker.workerID}`);
 #endif
     worker.terminate();
-    // terminate() can be asynchronous, so in theory the worker can continue
-    // to run for some amount of time after termination.  However from our POV
-    // the worker is now dead and we don't want to hear from it again, so we stub
-    // out its message handler here.  This avoids having to check in each of
-    // the onmessage handlers if the message was coming from a valid worker.
-    worker.onmessage = (e) => {
-#if ASSERTIONS
-      var cmd = e.data.cmd;
-      err(`received "${cmd}" command from terminated worker: ${worker.workerID}`);
-#endif
-    };
   },
 
   _emscripten_thread_cleanup: (thread) => {

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6166,10 +6166,6 @@ int main(void) {
 
   @crossplatform
   @requires_pthreads
-  @flaky('https://github.com/emscripten-core/emscripten/issues/19683')
-  # The flakiness of this test is very high on macOS so just disable it
-  # completely.
-  @no_mac('https://github.com/emscripten-core/emscripten/issues/19683')
   def test_pthread_print_override_modularize(self):
     self.set_setting('EXPORT_NAME', 'Test')
     self.set_setting('PROXY_TO_PTHREAD')


### PR DESCRIPTION
When a pthreaded application exits under PROXY_TO_PTHREAD and EXIT_RUNTIME, the worker thread signals the main
thread to exit using the system queue. However, there can also be messages from postMessage in-flight from the worker.

This results in a race condition where the main thread processes the exit and terminates the worker (synchronously stubbing out its onmessage handler to discard further messages) before processing print messages already posted by the worker before exiting. As a result, valid printed output is lost, and the test fails due to unexpected assertion warnings.

Resolve this by allowing late-arriving print and printErr commands through the terminated-worker message stub. Fixes flaky test test_pthread_print_override_modularize.

Fixes #19683