### PR TITLE
Use .exe launchers on windows by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,7 +503,7 @@ commands:
             echo "-----"
             echo "Running browser tests (EMTEST_BROWSER=$EMTEST_BROWSER)"
             echo "-----"
-            test/runner.bat << parameters.test_targets >>
+            test/runner << parameters.test_targets >>
       - upload-test-results
   test-sockets-chrome:
     description: "Runs emscripten sockets tests under chrome"
@@ -1339,12 +1339,12 @@ jobs:
           python: "$EMSDK_PYTHON"
       - run:
           name: "crossplatform tests"
-          command: test/runner.bat --crossplatform-only
+          command: test/runner --crossplatform-only
       - upload-test-results
       # Run a single websockify-based test to ensure it works on windows.
       - run:
           name: "sockets.test_nodejs_sockets_echo*"
-          command: "test/runner.bat sockets.test_nodejs_sockets_echo*"
+          command: "test/runner sockets.test_nodejs_sockets_echo*"
       - upload-test-results
 
   test-mac-arm64:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,11 @@ See docs/process.md for more on how version tagging works.
 
 6.0.0 (in development)
 ----------------------
+- On Windows, Emscripten now ships `.exe` tool launchers, rather
+  than `.bat` and/or `.ps1`.  This means that any scripts that explicitly
+  reference, e.g. `emcc.bat`, will need to be updated to just `emcc` (or
+  `emcc.exe`).  For the time being you can still get the old `.bat` files by
+  running `tools/maint/create_entry_points.py --bat-files`. (#24858)
 - When performing a streaming Fetch operation, the max chunk size of downloaded
   bytes that is handed over to the Wasm side from JS is now capped to maximum
   of 8 megabytes. This ensures that a streaming Fetch stays streaming, rather

--- a/tools/maint/create_entry_points.py
+++ b/tools/maint/create_entry_points.py
@@ -84,7 +84,9 @@ def write_file(filename, content):
     f.write(content)
 
 
-def main(all_platforms, use_exe_files):
+def main(all_platforms, use_bat_file):
+  if 'EM_USE_BAT_FILES' in os.environ:
+    use_bat_file = True
   is_windows = sys.platform.startswith('win')
   is_msys2 = 'MSYSTEM' in os.environ
   do_unix = all_platforms or not is_windows or is_msys2
@@ -116,15 +118,15 @@ def main(all_platforms, use_exe_files):
         maybe_remove(launcher + '.bat')
         maybe_remove(launcher + '.ps1')
         maybe_remove(launcher + '.exe')
-        if use_exe_files:
-          shutil.copyfile(windows_exe, launcher + '.exe')
-        else:
+        if use_bat_file:
           write_file(launcher + '.bat', bat_data)
           write_file(launcher + '.ps1', ps1_data)
+        else:
+          shutil.copyfile(windows_exe, launcher + '.exe')
 
   generate_entry_points(entry_points, os.path.join(__scriptdir__, 'run_python'))
   generate_entry_points(compiler_entry_points, os.path.join(__scriptdir__, 'run_python_compiler'))
 
 
 if __name__ == '__main__':
-  sys.exit(main('--all' in sys.argv, '--exe-files' in sys.argv))
+  sys.exit(main('--all' in sys.argv, '--bat-files' in sys.argv))


### PR DESCRIPTION
Now that we are building the exe launcher automatically in emscripten-releases its time to start trying it out for real.

The old behaviour can be had by setting `EM_USE_BAT_FILES` when creating the launchers (normally during `./bootstrap`).

See #24858