### PR TITLE
[pthreads] Simplify message relaying code

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -278,14 +278,18 @@ var LibraryPThread = {
 #endif
 
         // If this message is intended to a recipient that is not the main
-        // thread, forward it to the target thread.
-        if (d.targetThread && d.targetThread != _pthread_self()) {
+        // thread, forward it to the target thread. This is currently only
+        // used by `CMD_CHECK_MAILBOX`.
+        if (d.targetThread) {
+#if ASSERTIONS
+          // pthreads should not be relaying messages to themselves.
+          assert(d.targetThread != _pthread_self());
+#endif
           var targetWorker = PThread.pthreads[d.targetThread];
-          if (targetWorker) {
-            targetWorker.postMessage(d, d.transferList);
-          } else {
-            err(`worker sent message (${cmd}) to pthread (${d.targetThread}) that no longer exists`);
-          }
+#if ASSERTIONS
+          if (!targetWorker) err(`worker sent message (${cmd}) to pthread (${d.targetThread}) that no longer exists`);
+#endif
+          targetWorker?.postMessage(d);
           return;
         }
 

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7110,
-  "a.out.js.gz": 3524,
+  "a.out.js": 7012,
+  "a.out.js.gz": 3472,
   "a.out.nodebug.wasm": 19069,
   "a.out.nodebug.wasm.gz": 8800,
-  "total": 26179,
-  "total_gz": 12324,
+  "total": 26081,
+  "total_gz": 12272,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7518,
-  "a.out.js.gz": 3728,
+  "a.out.js": 7420,
+  "a.out.js.gz": 3672,
   "a.out.nodebug.wasm": 19070,
   "a.out.nodebug.wasm.gz": 8801,
-  "total": 26588,
-  "total_gz": 12529,
+  "total": 26490,
+  "total_gz": 12473,
   "sent": [
     "a (memory)",
     "b (exit)",


### PR DESCRIPTION
Historically, `targetThread` relaying was used to pass `objectTransfer` messages (containing `OffscreenCanvas` objects) back to parent threads on worker exit. This was introduced in commit 1b278917cd (2018/2019) and required supporting `transferList` in the relaying code.

However, automatic canvas return on exit was later disabled in 6dcf7298e8 (2019) and the `objectTransfer` command was fully removed in 0f536c60bb (2021).

These days, the relaying mechanism is only used by `CMD_CHECK_MAILBOX` (via `_emscripten_notify_mailbox_postmessage`) to send simple mailbox notifications, which do not require a transfer list.