### PR TITLE
Use circleci "gen2" image for linux-build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,7 +494,7 @@ jobs:
     # in about 1/2 the time, so it is not cost-effective (overall it is 2x the
     # cost for the same work), but given this blocks almost all the other jobs
     # we want it to finish asap
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     environment:
       EMCC_CORES: 16
       EMCC_USE_NINJA: 1


### PR DESCRIPTION
This is our more imporant build step because many others depend on it.

The p95 runtime for build-linux over the last 30 days is 31m 40s according to https://app.circleci.com/insights/github/emscripten-core/emscripten/workflows/build-test/jobs?branch=main&reporting-window=last-30-days.

The cost of the gen2 xlarge runner is 16% more expensive (48/min for 40/min).

We could probably justify switching even if we didn't see a corresponding 16% runtime reduction, but we would need to see something significant drop, probably at least 10%. 