### PR TITLE
Fix cwrap with returnType 'boolean' to return a JS boolean

### DIFF
--- a/src/lib/libccall.js
+++ b/src/lib/libccall.js
@@ -146,7 +146,7 @@ addToLibrary({
     // When the function takes numbers and returns a number, we can just return
     // the original function
     var numericArgs = !argTypes || argTypes.every((type) => type === 'number' || type === 'boolean');
-    var numericRet = returnType !== 'string';
+    var numericRet = returnType !== 'string' && returnType !== 'boolean';
     if (numericRet && numericArgs && !opts) {
       return getCFunc(ident);
     }

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7097,10 +7097,14 @@ void* operator new(size_t size) {
     create_file('post.js', '''
       var printBool = Module['cwrap']('print_bool', null, ['boolean']);
       out(Module['_print_bool'] === printBool); // the function should be the exact raw function in the module rather than a wrapped one
+      var getBool = Module['cwrap']('get_bool', 'boolean');
+      out(Module['_get_bool'] !== getBool); // boolean return must not use the fast path so the result is coerced to a JS boolean
+      var ret = getBool();
+      out([typeof ret, ret].join(','));
       ''')
 
-    self.set_setting('EXPORTED_FUNCTIONS', ['_print_bool'])
-    self.do_runf('core/test_ccall.cpp', 'true', cflags=['--post-js=post.js', '-Wno-return-stack-address'])
+    self.set_setting('EXPORTED_FUNCTIONS', ['_print_bool', '_get_bool'])
+    self.do_runf('core/test_ccall.cpp', 'true\ntrue\nboolean,true\n', cflags=['--post-js=post.js', '-Wno-return-stack-address'])
 
   @no_modularize_instance('ccall is not yet compatible with MODULARIZE=instance')
   def test_ccall_return_pointer(self):


### PR DESCRIPTION
The cwrap fast path returned the raw wasm export whenever the return type was not 'string', bypassing the Boolean() coercion that ccall applies. Exclude 'boolean' from the fast-path return check so boolean returns go through ccall, matching ccall's behavior.

Fixes: #27021