### PR TITLE
Modernize dependency system with Promise-based run blockers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -94,6 +94,12 @@ See docs/process.md for more on how version tagging works.
   If you have JS code that was depending on this you can transition to using the
   `PThread.pthreads` object. (#26998)
 - The POSIX `pause()` function will now return 0 rather than EINTR. (#27044)
+- Emscripten's startup dependency system was modernized to be promise-based.
+  These APIs are mostly internal.  The new API is called `addRunBlocker`. The
+  previous APIs (`addRunDependency`/`removeRunDependency`) still exist but are
+  deprecated. Internal subsystems (including Fetch, pthread pool seeding,
+  dylib preloading, LZ4 packages, and Filesystem preloading) have been
+  transitioned to use the new `addRunBlocker` API directly.
 
 5.0.7 - 04/30/26
 ----------------

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -327,7 +327,7 @@ Functions
 
   Asynchronously loads a script from a URL.
 
-  This integrates with the run dependencies system, so your script can call ``addRunDependency`` multiple times, prepare various asynchronous tasks, and call ``removeRunDependency`` on them; when all are complete (or if there were no run dependencies to begin with), ``onload`` is called. An example use for this is to load an asset module, that is, the output of the file packager.
+  This integrates with the run-blocker system, so your script can call ``addRunBlocker`` multiple times, with various asynchronous tasks (promises).  Only when all are complete will ``onload`` be called. An example use for this is to load an asset module, that is, the output of the file packager.
 
   This function is currently only available in main browser thread, and it will immediately fail by calling the supplied onerror() handler if called in a pthread.
 

--- a/site/source/docs/api_reference/preamble.js.rst
+++ b/site/source/docs/api_reference/preamble.js.rst
@@ -267,32 +267,22 @@ Conversion functions — strings, pointers and arrays
 
 
 
-Run dependencies
-================
+Run blockers (dependencies)
+===========================
 
-Note that generally run dependencies are managed by the file packager and other parts of the system. It is rare for developers to use this API directly.
+Note that generally run blockers are managed by the file packager and other internal systems. It is rare for developers to use this API directly.
 
+.. js:function:: addRunBlocker(promise)
+
+  Adds a promise that must be resolved before the program starts running.
 
 .. js:function:: addRunDependency(id)
 
-  Adds an ``id`` to the list of run dependencies.
-
-  This adds a run dependency and increments the run dependency counter.
-
-  .. COMMENT (not rendered): **HamishW** Remember to link to Execution lifecycle in Browser environment or otherwise link to information on using this. Possibly its own topic.
-
-  :param id: An arbitrary id representing the operation.
-  :type id: String
-
-
+  Deprecated: Use ``addRunBlocker`` instead
 
 .. js:function:: removeRunDependency(id)
 
-  Removes a specified ``id`` from the list of run dependencies.
-
-  :param id: The identifier for the specific dependency to be removed (added with :js:func:`addRunDependency`)
-  :type id: String
-
+  Deprecated: When using ``addRunBlocker``, there is no need to manually remove dependencies, just resolve the promise.
 
 
 Stack trace

--- a/site/source/docs/porting/emscripten-runtime-environment.rst
+++ b/site/source/docs/porting/emscripten-runtime-environment.rst
@@ -118,11 +118,11 @@ Execution lifecycle
 
 When an Emscripten-compiled application is loaded, it starts by preparing data in the ``preloading`` phase. Files you marked for :ref:`preloading <emcc-preload-file>` (using ``emcc --preload-file``, or manually from JavaScript with :js:func:`FS.createPreloadedFile`) are set up at this stage.
 
-You can add additional operations with :js:func:`addRunDependency`, which is a counter of all dependencies to be executed before compiled code can run. As these are completed you can call :js:func:`removeRunDependency` to remove the completed dependencies.
+You can add additional operations with :js:func:`addRunBlocker`, which takes a promise that will prevent your program's ``main()`` function from running until it is resolved.
 
 .. note:: Generally it is not necessary to add additional operations — preloading is suitable for almost all use cases.
 
-When all dependencies are met, Emscripten will call your programs's ``main()`` function. The ``main()`` function should be used to perform initialization tasks, and will often call :c:func:`emscripten_set_main_loop` (as :ref:`described above <emscripten-runtime-environment-howto-main-loop>`). The main loop function will be then be called at the requested frequency.
+When all the blockers are resolved, Emscripten will call your programs's ``main()`` function. The ``main()`` function should be used to perform initialization tasks, and will often call :c:func:`emscripten_set_main_loop` (as :ref:`described above <emscripten-runtime-environment-howto-main-loop>`). The main loop function will be then be called at the requested frequency.
 
 You can affect the operation of the main loop in several ways:
 

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -292,28 +292,27 @@ var Fetch = {
   },
 #endif
 
-  async init() {
+  init() {
     Fetch.xhrs = new HandleAllocator();
 #if FETCH_SUPPORT_INDEXEDDB
 #if PTHREADS
     if (ENVIRONMENT_IS_PTHREAD) return;
 #endif
 
-    addRunDependency('library_fetch_init');
-    try {
-      var db = await Fetch.openDatabase('emscripten_filesystem', 1);
+    addRunBlocker((async () => {
+      try {
+        var db = await Fetch.openDatabase('emscripten_filesystem', 1);
 #if FETCH_DEBUG
-      dbg('fetch: IndexedDB successfully opened.');
+        dbg('fetch: IndexedDB successfully opened.');
 #endif
-      Fetch.dbInstance = db;
-    } catch (e) {
+        Fetch.dbInstance = db;
+      } catch (e) {
 #if FETCH_DEBUG
-      dbg('fetch: IndexedDB open failed.');
+        dbg('fetch: IndexedDB open failed.');
 #endif
-      Fetch.dbInstance = false;
-    } finally {
-      removeRunDependency('library_fetch_init');
-    }
+        Fetch.dbInstance = false;
+      }
+    })());
 #endif // ~FETCH_SUPPORT_INDEXEDDB
   }
 }

--- a/src/lib/libbrowser.js
+++ b/src/lib/libbrowser.js
@@ -617,7 +617,7 @@ var LibraryBrowser = {
   },
 
   // TODO: currently not callable from a pthread, but immediately calls onerror() if not on main thread.
-  emscripten_async_load_script__deps: ['$UTF8ToString', '$runDependencies', '$dependenciesFulfilled'],
+  emscripten_async_load_script__deps: ['$UTF8ToString', '$resolveRunBlockers'],
   emscripten_async_load_script: async (url, onload, onerror) => {
     url = UTF8ToString(url);
 #if PTHREADS
@@ -627,20 +627,14 @@ var LibraryBrowser = {
       return;
     }
 #endif
-#if ASSERTIONS
-    assert(runDependencies === 0, 'async_load_script must be run when no other dependencies are active');
-#endif
+
     {{{ runtimeKeepalivePush() }}}
 
     var loadDone = () => {
       {{{ runtimeKeepalivePop() }}}
       if (onload) {
         var onloadCallback = () => callUserCallback({{{ makeDynCall('v', 'onload') }}});
-        if (runDependencies > 0) {
-          dependenciesFulfilled = onloadCallback;
-        } else {
-          onloadCallback();
-        }
+        resolveRunBlockers().then(onloadCallback);
       }
     }
 

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -2244,126 +2244,50 @@ addToLibrary({
   $wasmMemory: 'memory',
 #endif
 
-  $getUniqueRunDependency: (id) => {
-#if ASSERTIONS
-    var orig = id;
-    while (1) {
-      if (!runDependencyTracking[id]) return id;
-      id = orig + Math.random();
-    }
-#else
-    return id;
-#endif
-  },
-
   $noExitRuntime__postset: () => addAtModule(makeModuleReceive('noExitRuntime')),
   $noExitRuntime: {{{ !EXIT_RUNTIME }}},
 
-#if !MINIMAL_RUNTIME
-  // A counter of dependencies for calling run(). If we need to
-  // do asynchronous work before running, increment this and
-  // decrement it. Incrementing must happen in a place like
-  // Module.preRun (used by emcc to add file preloading).
-  // Note that you can add dependencies in preRun, even though
-  // it happens right before run - run will be postponed until
-  // the dependencies are met.
-  $runDependencies__internal: true,
-  $runDependencies: 0,
-  // overridden to take different actions when all run dependencies are fulfilled
-  $dependenciesFulfilled__internal: true,
-  $dependenciesFulfilled: null,
-#if ASSERTIONS
-  $runDependencyTracking__internal: true,
-  $runDependencyTracking: {},
-  $runDependencyWatcher__internal: true,
-  $runDependencyWatcher: null,
+#if expectToReceiveOnModule('monitorRunDependencies')
+  $pendingRunBlockers__internal: true,
+  $pendingRunBlockers: 0,
 #endif
 
-  $addRunDependency__deps: ['$runDependencies', '$removeRunDependency',
-#if ASSERTIONS
-    '$runDependencyTracking',
-    '$runDependencyWatcher',
+  $runBlockers__internal: true,
+  $runBlockers: [],
+  $addRunBlocker__deps: ['$runBlockers', '$resolveRunBlockers',
+#if expectToReceiveOnModule('monitorRunDependencies')
+    '$pendingRunBlockers',
 #endif
   ],
-  $addRunDependency: (id) => {
-    runDependencies++;
-
+  $addRunBlocker: (promise) => {
 #if expectToReceiveOnModule('monitorRunDependencies')
-    Module['monitorRunDependencies']?.(runDependencies);
-#endif
-
-#if ASSERTIONS
-#if RUNTIME_DEBUG
-    dbg('addRunDependency', id);
-#endif
-    assert(id, 'addRunDependency requires an ID')
-    assert(!runDependencyTracking[id]);
-    runDependencyTracking[id] = 1;
-    if (runDependencyWatcher === null && globalThis.setInterval) {
-      // Check for missing dependencies every few seconds
-      runDependencyWatcher = setInterval(() => {
-        if (ABORT) {
-          clearInterval(runDependencyWatcher);
-          runDependencyWatcher = null;
-          return;
-        }
-        var shown = false;
-        for (var dep in runDependencyTracking) {
-          if (!shown) {
-            shown = true;
-            err('still waiting on run dependencies:');
-          }
-          err(`dependency: ${dep}`);
-        }
-        if (shown) {
-          err('(end of list)');
-        }
-      }, 10000);
-#if ENVIRONMENT_MAY_BE_NODE
-      // Prevent this timer from keeping the runtime alive if nothing
-      // else is.
-      runDependencyWatcher.unref?.()
-#endif
+    if (Module['monitorRunDependencies']) {
+      pendingRunBlockers++;
+      Module['monitorRunDependencies'](pendingRunBlockers);
+      var decrement = () => {
+        pendingRunBlockers--;
+        Module['monitorRunDependencies'](pendingRunBlockers);
+      };
+      var wrapped = promise.then(
+        (val) => { decrement(); return val; },
+        (err) => { decrement(); throw err; }
+      );
+      runBlockers.push(wrapped);
+      return;
     }
 #endif
+    runBlockers.push(promise);
   },
 
-  $removeRunDependency__deps: ['$runDependencies', '$dependenciesFulfilled',
-#if ASSERTIONS
-    '$runDependencyTracking',
-    '$runDependencyWatcher',
-#endif
-  ],
-  $removeRunDependency: (id) => {
-    runDependencies--;
-
-#if expectToReceiveOnModule('monitorRunDependencies')
-    Module['monitorRunDependencies']?.(runDependencies);
-#endif
-
-#if ASSERTIONS
-#if RUNTIME_DEBUG
-    dbg('removeRunDependency', id);
-#endif
-    assert(id, 'removeRunDependency requires an ID');
-    assert(runDependencyTracking[id]);
-    delete runDependencyTracking[id];
-#endif
-    if (runDependencies == 0) {
-#if ASSERTIONS
-      if (runDependencyWatcher !== null) {
-        clearInterval(runDependencyWatcher);
-        runDependencyWatcher = null;
-      }
-#endif
-      if (dependenciesFulfilled) {
-        var callback = dependenciesFulfilled;
-        dependenciesFulfilled = null;
-        callback(); // can add another dependenciesFulfilled
-      }
+  $resolveRunBlockers__internal: true,
+  $resolveRunBlockers__deps: ['$runBlockers'],
+  $resolveRunBlockers: async () => {
+    while (runBlockers.length) {
+      var current = runBlockers;
+      runBlockers = [];
+      await Promise.all(current);
     }
   },
-#endif
 
   // The following addOn<X> functions are for adding runtime callbacks at
   // various executions points. Each addOn<X> function has a corresponding

--- a/src/lib/libfetch.js
+++ b/src/lib/libfetch.js
@@ -11,8 +11,7 @@ var LibraryFetch = {
   $Fetch__deps: [
     '$HandleAllocator',
 #if FETCH_SUPPORT_INDEXEDDB
-    '$addRunDependency',
-    '$removeRunDependency',
+    '$addRunBlocker',
 #endif
   ],
   $Fetch: Fetch,

--- a/src/lib/libfs_shared.js
+++ b/src/lib/libfs_shared.js
@@ -54,19 +54,14 @@ addToLibrary({
     '$asyncLoad',
     '$PATH_FS',
     '$FS_createDataFile',
-    '$getUniqueRunDependency',
-    '$addRunDependency',
-    '$removeRunDependency',
+    '$addRunBlocker',
     '$FS_handledByPreloadPlugin',
   ],
-  $FS_preloadFile: async (parent, name, url, canRead, canWrite, dontCreateFile, canOwn, preFinish) => {
+  $FS_preloadFile: (parent, name, url, canRead, canWrite, dontCreateFile, canOwn, preFinish) => {
     // TODO we should allow people to just pass in a complete filename instead
     // of parent and name being that we just join them anyways
     var fullname = name ? PATH_FS.resolve(PATH.join2(parent, name)) : parent;
-    var dep = getUniqueRunDependency(`cp ${fullname}`); // might have several active requests for the same fullname
-    addRunDependency(dep);
-
-    try {
+    var promise = (async () => {
       var byteArray = url;
       if (typeof url == 'string') {
         byteArray = await asyncLoad(url);
@@ -77,9 +72,9 @@ addToLibrary({
       if (!dontCreateFile) {
         FS_createDataFile(parent, name, byteArray, canRead, canWrite, canOwn);
       }
-    } finally {
-      removeRunDependency(dep);
-    }
+    })();
+    addRunBlocker(promise);
+    return promise;
   },
 #endif
 

--- a/src/lib/liblegacy.js
+++ b/src/lib/liblegacy.js
@@ -137,6 +137,130 @@ legacyFuncs = {
 
   $getNativeTypeSize__deps: ['$POINTER_SIZE'],
   $getNativeTypeSize: {{{ getNativeTypeSize }}},
+
+#if !MINIMAL_RUNTIME
+  // A counter of dependencies for calling run(). If we need to
+  // do asynchronous work before running, increment this and
+  // decrement it. Incrementing must happen in a place like
+  // Module.preRun (used by emcc to add file preloading).
+  // Note that you can add dependencies in preRun, even though
+  // it happens right before run - run will be postponed until
+  // the dependencies are met.
+  $runDependencies__internal: true,
+  $runDependencies: 0,
+  // overridden to take different actions when all run dependencies are fulfilled
+  $dependenciesFulfilled__internal: true,
+  $dependenciesFulfilled: null,
+  $runDependencyPromises__internal: true,
+  $runDependencyPromises: {},
+
+#if ASSERTIONS
+  $runDependencyTracking__internal: true,
+  $runDependencyTracking: {},
+  $runDependencyWatcher__internal: true,
+  $runDependencyWatcher: null,
+#endif
+
+  $getUniqueRunDependency: (id) => {
+#if ASSERTIONS
+    var orig = id;
+    while (1) {
+      if (!runDependencyTracking[id]) return id;
+      id = orig + Math.random();
+    }
+#else
+    return id;
+#endif
+  },
+
+  $addRunDependency__deps: ['$runDependencies', '$removeRunDependency', '$runDependencyPromises', '$addRunBlocker',
+#if ASSERTIONS
+    '$runDependencyTracking',
+    '$runDependencyWatcher',
+#endif
+  ],
+  $addRunDependency: (id) => {
+    runDependencies++;
+
+
+
+    var resolve;
+    var promise = new Promise((r) => { resolve = r; });
+    runDependencyPromises[id] = resolve;
+    addRunBlocker(promise);
+
+#if ASSERTIONS
+#if RUNTIME_DEBUG
+    dbg('addRunDependency', id);
+#endif
+    assert(id, 'addRunDependency requires an ID')
+    assert(!runDependencyTracking[id]);
+    runDependencyTracking[id] = 1;
+    if (runDependencyWatcher === null && globalThis.setInterval) {
+      // Check for missing dependencies every few seconds
+      runDependencyWatcher = setInterval(() => {
+        if (ABORT) {
+          clearInterval(runDependencyWatcher);
+          runDependencyWatcher = null;
+          return;
+        }
+        var shown = false;
+        for (var dep in runDependencyTracking) {
+          if (!shown) {
+            shown = true;
+            err('still waiting on run dependencies:');
+          }
+          err(`dependency: ${dep}`);
+        }
+        if (shown) {
+          err('(end of list)');
+        }
+      }, 10000);
+#if ENVIRONMENT_MAY_BE_NODE
+      // Prevent this timer from keeping the runtime alive if nothing
+      // else is.
+      runDependencyWatcher.unref?.()
+#endif
+    }
+#endif
+  },
+
+  $removeRunDependency__deps: ['$runDependencies', '$runDependencyPromises',
+#if ASSERTIONS
+    '$runDependencyTracking',
+    '$runDependencyWatcher',
+  #endif
+  ],
+  $removeRunDependency: (id) => {
+    runDependencies--;
+
+
+
+#if ASSERTIONS
+#if RUNTIME_DEBUG
+    dbg('removeRunDependency', id);
+#endif
+    assert(id, 'removeRunDependency requires an ID');
+    assert(runDependencyTracking[id]);
+    delete runDependencyTracking[id];
+#endif
+
+    var resolve = runDependencyPromises[id];
+    if (resolve) {
+      delete runDependencyPromises[id];
+      resolve();
+    }
+
+#if ASSERTIONS
+    if (runDependencies == 0) {
+      if (runDependencyWatcher !== null) {
+        clearInterval(runDependencyWatcher);
+        runDependencyWatcher = null;
+      }
+    }
+#endif
+  },
+#endif
 };
 
 if (WARN_DEPRECATED && !INCLUDE_FULL_LIBRARY) {

--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -88,8 +88,7 @@ var LibraryPThread = {
                    '$markAsFinished',
 #endif
 #if !MINIMAL_RUNTIME && PTHREAD_POOL_SIZE && !PTHREAD_POOL_DELAY_LOAD
-                   '$addRunDependency',
-                   '$removeRunDependency',
+                   '$addRunBlocker',
 #endif
                    '$spawnThread',
                    '_emscripten_thread_free_data',
@@ -137,12 +136,10 @@ var LibraryPThread = {
 #if !MINIMAL_RUNTIME
       // MINIMAL_RUNTIME takes care of calling loadWasmModuleToAllWorkers
       // in postamble_minimal.js
-      addOnPreRun(async () => {
+      addOnPreRun(() => {
         var pthreadPoolReady = PThread.loadWasmModuleToAllWorkers();
 #if !PTHREAD_POOL_DELAY_LOAD
-        addRunDependency('loading-workers');
-        await pthreadPoolReady;
-        removeRunDependency('loading-workers');
+        addRunBlocker(pthreadPoolReady);
 #endif // PTHREAD_POOL_DELAY_LOAD
       });
 #endif // !MINIMAL_RUNTIME

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -114,7 +114,7 @@ function stackCheckInit() {
 }
 #endif
 
-{{{ asyncIf(MODULARIZE || ASYNCIFY == 2 || expectToReceiveOnModule('setStatus') || '$runDependencies' in addedLibraryItems) }}}function run({{{ MAIN_READS_PARAMS ? 'args = programArgs' : '' }}}) {
+{{{ asyncIf(MODULARIZE || ASYNCIFY == 2 || expectToReceiveOnModule('setStatus') || '$addRunBlocker' in addedLibraryItems) }}}function run({{{ MAIN_READS_PARAMS ? 'args = programArgs' : '' }}}) {
 #if ASSERTIONS
   assert(!calledRun);
   calledRun = true;
@@ -133,12 +133,12 @@ function stackCheckInit() {
 
   preRun();
 
-#if '$runDependencies' in addedLibraryItems
-  if (runDependencies > 0) {
+#if '$addRunBlocker' in addedLibraryItems
+  if (runBlockers.length) {
 #if RUNTIME_DEBUG
     dbg('run: waiting on runDependencies');
 #endif
-    await new Promise((resolve) => dependenciesFulfilled = resolve);
+    await resolveRunBlockers();
   }
 #endif
 
@@ -273,7 +273,7 @@ export default async function init(moduleArg = {}) {
 #else
   wasmExports = await createWasm();
 #endif
-  await run();
+  return run();
 }
 
 #if ENVIRONMENT_MAY_BE_NODE

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -95,13 +95,12 @@ function isExportedByForceFilesystem(name) {
          name === 'FS_createPreloadedFile' ||
          name === 'FS_preloadFile' ||
          name === 'FS_unlink' ||
-         name === 'addRunDependency' ||
 #if !WASMFS
          // The old FS has some functionality that WasmFS lacks.
          name === 'FS_createLazyFile' ||
          name === 'FS_createDevice' ||
 #endif
-         name === 'removeRunDependency';
+         name === 'addRunBlocker';
 }
 
 #if !MODULARIZE

--- a/src/source_map_support.js
+++ b/src/source_map_support.js
@@ -130,11 +130,9 @@ if ({{{ ENVIRONMENT_IS_MAIN_THREAD() }}}) {
 
 #if !MINIMAL_RUNTIME // MINIMAL_RUNTIME integrates source map loading into postamble_minimal.js
 #if WASM_ASYNC_COMPILATION
-addRunDependency('source-map');
-getSourceMapAsync().then((json) => {
+addRunBlocker(getSourceMapAsync().then((json) => {
   receiveSourceMapJSON(json);
-  removeRunDependency('source-map');
-});
+}));
 #else
 receiveSourceMapJSON(getSourceMap());
 #endif

--- a/test/browser/separate_metadata_later.cpp
+++ b/test/browser/separate_metadata_later.cpp
@@ -12,13 +12,13 @@ EMSCRIPTEN_KEEPALIVE extern "C" void finish() {
 int main() {
   EM_ASM({
     setTimeout(function() {
-      // hijack run dep logic to see when the metadata is loaded ok.
-      var real = Module["removeRunDependency"];
-      Module["removeRunDependency"] = function(id) {
-        real(id);
-        if (id === "more.js.metadata") {
+      // hijack run blocker logic to see when the metadata is loaded ok.
+      var real = Module["addRunBlocker"];
+      Module["addRunBlocker"] = function(promise) {
+        real(promise);
+        promise.then(function() {
           Module["_finish"]();
-        }
+        });
       };
       function loadChildScript(name, then) {
         var js = document.createElement("script");

--- a/test/browser/test_manual_download_data.c
+++ b/test/browser/test_manual_download_data.c
@@ -6,9 +6,11 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <emscripten.h>
 
 int main()
 {
+	assert(MAIN_THREAD_EM_ASM_INT({ return !!window.monitorRunDependenciesCalled; }));
 	FILE *handle = fopen("file.txt", "r");
 	char str[128] = {};
 	fread(str, 1, sizeof(str), handle);

--- a/test/browser/test_manual_download_data.html
+++ b/test/browser/test_manual_download_data.html
@@ -133,6 +133,8 @@
         },
         totalDependencies: 0,
         monitorRunDependencies: (left) => {
+          console.log('monitorRunDependencies called: ' + left);
+          window.monitorRunDependenciesCalled = true;
           this.totalDependencies = Math.max(this.totalDependencies, left);
           Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
         },

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19218,
-  "a.out.js.gz": 7948,
-  "a.out.nodebug.wasm": 132649,
-  "a.out.nodebug.wasm.gz": 49955,
-  "total": 151867,
-  "total_gz": 57903,
+  "a.out.js": 19313,
+  "a.out.js.gz": 7989,
+  "a.out.nodebug.wasm": 132666,
+  "a.out.nodebug.wasm.gz": 49962,
+  "total": 151979,
+  "total_gz": 57951,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19195,
-  "a.out.js.gz": 7932,
-  "a.out.nodebug.wasm": 132075,
-  "a.out.nodebug.wasm.gz": 49617,
-  "total": 151270,
-  "total_gz": 57549,
+  "a.out.js": 19290,
+  "a.out.js.gz": 7973,
+  "a.out.nodebug.wasm": 132092,
+  "a.out.nodebug.wasm.gz": 49625,
+  "total": 151382,
+  "total_gz": 57598,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23191,
-  "a.out.js.gz": 8939,
-  "a.out.nodebug.wasm": 172569,
-  "a.out.nodebug.wasm.gz": 57493,
-  "total": 195760,
-  "total_gz": 66432,
+  "a.out.js": 23287,
+  "a.out.js.gz": 8983,
+  "a.out.nodebug.wasm": 172586,
+  "a.out.nodebug.wasm.gz": 57501,
+  "total": 195873,
+  "total_gz": 66484,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19017,
-  "a.out.js.gz": 7872,
-  "a.out.nodebug.wasm": 147974,
-  "a.out.nodebug.wasm.gz": 55362,
-  "total": 166991,
-  "total_gz": 63234,
+  "a.out.js": 19112,
+  "a.out.js.gz": 7916,
+  "a.out.nodebug.wasm": 147991,
+  "a.out.nodebug.wasm.gz": 55370,
+  "total": 167103,
+  "total_gz": 63286,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19095,
-  "a.out.js.gz": 7894,
-  "a.out.nodebug.wasm": 145780,
-  "a.out.nodebug.wasm.gz": 54985,
-  "total": 164875,
-  "total_gz": 62879,
+  "a.out.js": 19190,
+  "a.out.js.gz": 7937,
+  "a.out.nodebug.wasm": 145797,
+  "a.out.nodebug.wasm.gz": 54992,
+  "total": 164987,
+  "total_gz": 62929,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18557,
-  "a.out.js.gz": 7638,
-  "a.out.nodebug.wasm": 102151,
-  "a.out.nodebug.wasm.gz": 39561,
-  "total": 120708,
-  "total_gz": 47199,
+  "a.out.js": 18652,
+  "a.out.js.gz": 7683,
+  "a.out.nodebug.wasm": 102168,
+  "a.out.nodebug.wasm.gz": 39572,
+  "total": 120820,
+  "total_gz": 47255,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23241,
-  "a.out.js.gz": 8961,
-  "a.out.nodebug.wasm": 238998,
-  "a.out.nodebug.wasm.gz": 79846,
-  "total": 262239,
-  "total_gz": 88807,
+  "a.out.js": 23337,
+  "a.out.js.gz": 9005,
+  "a.out.nodebug.wasm": 239015,
+  "a.out.nodebug.wasm.gz": 79854,
+  "total": 262352,
+  "total_gz": 88859,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19218,
-  "a.out.js.gz": 7948,
-  "a.out.nodebug.wasm": 134649,
-  "a.out.nodebug.wasm.gz": 50797,
-  "total": 153867,
-  "total_gz": 58745,
+  "a.out.js": 19313,
+  "a.out.js.gz": 7989,
+  "a.out.nodebug.wasm": 134666,
+  "a.out.nodebug.wasm.gz": 50806,
+  "total": 153979,
+  "total_gz": 58795,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_wasmfs.json
+++ b/test/codesize/test_codesize_cxx_wasmfs.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 6938,
   "a.out.js.gz": 3259,
-  "a.out.nodebug.wasm": 172786,
-  "a.out.nodebug.wasm.gz": 63366,
-  "total": 179724,
-  "total_gz": 66625,
+  "a.out.nodebug.wasm": 172803,
+  "a.out.nodebug.wasm.gz": 63374,
+  "total": 179741,
+  "total_gz": 66633,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -123,9 +123,7 @@ Module["expectedDataFileDownloads"]++;
           // canOwn this data in the filesystem, it is a slice into the heap that will never change
           Module["FS_createDataFile"](name, null, data, true, true, true);
         }
-        Module["removeRunDependency"]("datafile_a.out.data");
       }
-      Module["addRunDependency"]("datafile_a.out.data");
       if (!Module["preloadResults"]) Module["preloadResults"] = {};
       Module["preloadResults"][PACKAGE_NAME] = {
         fromCache: false
@@ -137,10 +135,12 @@ Module["expectedDataFileDownloads"]++;
     }
     // Detect whether the module JS file has already been loaded.
     if (Module["FS_createPath"]) {
-      runWithFS(Module);
+      Module["addRunBlocker"](runWithFS(Module));
     } else {
       if (!Module["preRun"]) Module["preRun"] = [];
-      Module["preRun"].push(runWithFS);
+      Module["preRun"].push(mod => {
+        mod["addRunBlocker"](runWithFS(mod));
+      });
     }
   }
   loadPackage({
@@ -1303,25 +1303,18 @@ var asyncLoad = async url => {
 
 var FS_createDataFile = (...args) => FS.createDataFile(...args);
 
-var getUniqueRunDependency = id => id;
+var runBlockers = [];
 
-var runDependencies = 0;
-
-var dependenciesFulfilled = null;
-
-var removeRunDependency = id => {
-  runDependencies--;
-  if (runDependencies == 0) {
-    if (dependenciesFulfilled) {
-      var callback = dependenciesFulfilled;
-      dependenciesFulfilled = null;
-      callback();
-    }
+var resolveRunBlockers = async () => {
+  while (runBlockers.length) {
+    var current = runBlockers;
+    runBlockers = [];
+    await Promise.all(current);
   }
 };
 
-var addRunDependency = id => {
-  runDependencies++;
+var addRunBlocker = promise => {
+  runBlockers.push(promise);
 };
 
 var preloadPlugins = [];
@@ -1339,14 +1332,11 @@ var FS_handledByPreloadPlugin = async (byteArray, fullname) => {
   return byteArray;
 };
 
-var FS_preloadFile = async (parent, name, url, canRead, canWrite, dontCreateFile, canOwn, preFinish) => {
+var FS_preloadFile = (parent, name, url, canRead, canWrite, dontCreateFile, canOwn, preFinish) => {
   // TODO we should allow people to just pass in a complete filename instead
   // of parent and name being that we just join them anyways
   var fullname = name ? PATH_FS.resolve(PATH.join2(parent, name)) : parent;
-  var dep = getUniqueRunDependency(`cp ${fullname}`);
-  // might have several active requests for the same fullname
-  addRunDependency(dep);
-  try {
+  var promise = (async () => {
     var byteArray = url;
     if (typeof url == "string") {
       byteArray = await asyncLoad(url);
@@ -1356,9 +1346,9 @@ var FS_preloadFile = async (parent, name, url, canRead, canWrite, dontCreateFile
     if (!dontCreateFile) {
       FS_createDataFile(parent, name, byteArray, canRead, canWrite, canOwn);
     }
-  } finally {
-    removeRunDependency(dep);
-  }
+  })();
+  addRunBlocker(promise);
+  return promise;
 };
 
 var FS_createPreloadedFile = (parent, name, url, canRead, canWrite, onload, onerror, dontCreateFile, canOwn, preFinish) => {
@@ -3129,9 +3119,7 @@ FS.staticInit();
 {}
 
 // Begin runtime exports
-Module["addRunDependency"] = addRunDependency;
-
-Module["removeRunDependency"] = removeRunDependency;
+Module["addRunBlocker"] = addRunBlocker;
 
 Module["FS_preloadFile"] = FS_preloadFile;
 
@@ -3180,8 +3168,8 @@ function callMain() {
 
 async function run() {
   preRun();
-  if (runDependencies > 0) {
-    await new Promise(resolve => dependenciesFulfilled = resolve);
+  if (runBlockers.length) {
+    await resolveRunBlockers();
   }
   if (ABORT) return;
   initRuntime();

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22157,
-  "a.out.js.gz": 9192,
+  "a.out.js": 22031,
+  "a.out.js.gz": 9131,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 23823,
-  "total_gz": 10137,
+  "total": 23697,
+  "total_gz": 10076,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_files_js_fs.json
+++ b/test/codesize/test_codesize_files_js_fs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 17866,
-  "a.out.js.gz": 7289,
+  "a.out.js": 17961,
+  "a.out.js.gz": 7327,
   "a.out.nodebug.wasm": 381,
   "a.out.nodebug.wasm.gz": 260,
-  "total": 18247,
-  "total_gz": 7549,
+  "total": 18342,
+  "total_gz": 7587,
   "sent": [
     "a (fd_write)",
     "b (fd_read)",

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23483,
-  "a.out.js.gz": 8523,
+  "a.out.js": 23463,
+  "a.out.js.gz": 8522,
   "a.out.nodebug.wasm": 15115,
   "a.out.nodebug.wasm.gz": 7464,
-  "total": 38598,
-  "total_gz": 15987,
+  "total": 38578,
+  "total_gz": 15986,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26271,
-  "a.out.js.gz": 11190,
+  "a.out.js": 26367,
+  "a.out.js.gz": 11231,
   "a.out.nodebug.wasm": 17861,
   "a.out.nodebug.wasm.gz": 9019,
-  "total": 44132,
-  "total_gz": 20209,
+  "total": 44228,
+  "total_gz": 20250,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268255,
-  "a.out.nodebug.wasm": 587630,
-  "total": 855885,
+  "a.out.js": 268404,
+  "a.out.nodebug.wasm": 587563,
+  "total": 855967,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -398,11 +398,10 @@ function isExportedByForceFilesystem(name) {
          name === 'FS_createPreloadedFile' ||
          name === 'FS_preloadFile' ||
          name === 'FS_unlink' ||
-         name === 'addRunDependency' ||
          // The old FS has some functionality that WasmFS lacks.
          name === 'FS_createLazyFile' ||
          name === 'FS_createDevice' ||
-         name === 'removeRunDependency';
+         name === 'addRunBlocker';
 }
 
 /**
@@ -908,9 +907,7 @@ Module['FS_createPreloadedFile'] = FS.createPreloadedFile;
   'alignMemory',
   'mmapAlloc',
   'HandleAllocator',
-  'getUniqueRunDependency',
-  'addRunDependency',
-  'removeRunDependency',
+  'addRunBlocker',
   'addOnPreRun',
   'addOnInit',
   'addOnPostCtor',

--- a/test/codesize/test_codesize_minimal_O0.json
+++ b/test/codesize/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18723,
-  "a.out.js.gz": 6778,
+  "a.out.js": 18643,
+  "a.out.js.gz": 6760,
   "a.out.nodebug.wasm": 1015,
   "a.out.nodebug.wasm.gz": 602,
-  "total": 19738,
-  "total_gz": 7380,
+  "total": 19658,
+  "total_gz": 7362,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,5 +1,5 @@
 {
-  "hello_world.js": 55305,
+  "hello_world.js": 55278,
   "hello_world.js.gz": 17405,
   "hello_world.wasm": 15115,
   "hello_world.wasm.gz": 7464,
@@ -7,10 +7,10 @@
   "no_asserts.js.gz": 8690,
   "no_asserts.wasm": 12229,
   "no_asserts.wasm.gz": 6004,
-  "strict.js": 53033,
-  "strict.js.gz": 16620,
+  "strict.js": 52931,
+  "strict.js.gz": 16593,
   "strict.wasm": 15115,
   "strict.wasm.gz": 7461,
-  "total": 176480,
-  "total_gz": 63644
+  "total": 176351,
+  "total_gz": 63617
 }

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -6,8 +6,7 @@ declare namespace RuntimeExports {
     function FS_unlink(...args: any[]): any;
     function FS_createLazyFile(...args: any[]): any;
     function FS_createDevice(...args: any[]): any;
-    function addRunDependency(id: any): void;
-    function removeRunDependency(id: any): void;
+    function addRunBlocker(promise: any): void;
 }
 interface WasmModule {
   _main(_0: number, _1: number): number;

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1314,16 +1314,18 @@ window.close = () => {
 
   def test_fs_idbfs_fsync(self):
     # sync from persisted state into memory before main()
-    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$ccall,$addRunDependency')
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$ccall,$addRunBlocker')
     create_file('pre.js', '''
       Module.preRun = () => {
-        addRunDependency('syncfs');
+        var resolve;
+        var promise = new Promise((r) => { resolve = r; });
+        addRunBlocker(promise);
 
         FS.mkdir('/working1');
         FS.mount(IDBFS, {}, '/working1');
         FS.syncfs(true, function (err) {
           if (err) throw err;
-          removeRunDependency('syncfs');
+          resolve();
         });
       };
     ''')
@@ -2313,19 +2315,39 @@ void *getBindBuffer() {
     self.btest_exit('main.c', cflags=['-sMAIN_MODULE=2', '-O2', 'supp.wasm'])
 
   @also_with_wasm2js
-  def test_pre_run_deps(self):
-    # Adding a dependency in preRun will delay run
-    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency')
-    create_file('pre.js', '''
-      Module.preRun = () => {
-        addRunDependency('foo');
-        out('preRun called, added a dependency...');
-        setTimeout(function() {
-          Module.okk = 10;
-          removeRunDependency('foo')
-        }, 2000);
-      };
-    ''')
+  @parameterized({
+    '': (False,),
+    'run_blocker': (True,),
+  })
+  def test_pre_run_deps(self, run_blocker):
+    # Adding a dependency/blocker in preRun will delay run
+    if run_blocker:
+      self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunBlocker')
+      create_file('pre.js', '''
+        Module.preRun = () => {
+          var resolve;
+          var promise = new Promise((r) => { resolve = r; });
+          addRunBlocker(promise);
+          out('preRun called, added a blocker...');
+          setTimeout(function() {
+            Module.okk = 10;
+            resolve();
+          }, 2000);
+        };
+      ''')
+    else:
+      self.cflags += ['-Wno-deprecated']
+      self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency')
+      create_file('pre.js', '''
+        Module.preRun = () => {
+          addRunDependency('foo');
+          out('preRun called, added a dependency...');
+          setTimeout(function() {
+            Module.okk = 10;
+            removeRunDependency('foo')
+          }, 2000);
+        };
+      ''')
 
     self.btest('test_pre_run_deps.c', expected='10', cflags=['--pre-js', 'pre.js'])
 
@@ -2530,14 +2552,27 @@ void *getBindBuffer() {
   def test_glew(self, args):
     self.btest_exit('test_glew.c', cflags=['-lGL', '-lSDL', '-lGLEW'] + args)
 
-  def test_doublestart_bug(self):
-    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency,$removeRunDependency')
-    create_file('pre.js', r'''
+  @parameterized({
+    '': (False,),
+    'run_blocker': (True,),
+  })
+  def test_doublestart_bug(self, run_blocker):
+    if run_blocker:
+      create_file('pre.js', r'''
+Module["preRun"] = () => {
+  addRunBlocker(Promise.resolve());
+};
+''')
+      self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunBlocker')
+    else:
+      self.cflags += ['-Wno-deprecated']
+      create_file('pre.js', r'''
 Module["preRun"] = () => {
   addRunDependency('test_run_dependency');
   removeRunDependency('test_run_dependency');
 };
 ''')
+      self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency,$removeRunDependency')
 
     self.btest_exit('test_doublestart_bug.c', cflags=['--pre-js', 'pre.js'])
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2945,9 +2945,10 @@ More info: https://emscripten.org
   @parameterized({
     '': (False, False),
     'no_initial_run': (True, False),
-    'run_dep': (False, True),
+    'run_blocker': (False, True),
+    'run_blocker_no_initial_run': (True, True),
   })
-  def test_prepost(self, no_initial_run, run_dep):
+  def test_prepost(self, no_initial_run, run_blocker):
     create_file('pre.js', '''
       Module = {
         "preRun": () => out('pre-run'),
@@ -2957,21 +2958,42 @@ More info: https://emscripten.org
 
     self.do_runf('hello_world.c', 'pre-run\nHello, world!\npost-run\n', cflags=['--pre-js', 'pre.js', '-sWASM_ASYNC_COMPILATION=0'])
 
-    # addRunDependency during preRun should prevent main, and post-run from
-    # running.
-    with open('pre.js', 'a', encoding='utf-8') as f:
-      f.write('Module["preRun"] = () => { out("add-dep"); addRunDependency("dep"); }\n')
-    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency')
-    output = self.do_runf('hello_world.c', cflags=['--pre-js', 'pre.js', '-sRUNTIME_DEBUG', '-sWASM_ASYNC_COMPILATION=0', '-O2', '--closure=1'])
-    self.assertContained('add-dep\n', output)
-    self.assertNotContained('Hello, world!\n', output)
-    self.assertNotContained('post-run\n', output)
+    if run_blocker:
+      # addRunBlocker during preRun should also prevent main and post-run.
+      with open('pre.js', 'a', encoding='utf-8') as f:
+        f.write('Module["preRun"] = () => { out("add-blocker"); addRunBlocker(new Promise(() => {})); }\n')
+      self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunBlocker')
+      output = self.do_runf('hello_world.c', cflags=['--pre-js', 'pre.js', '-sRUNTIME_DEBUG', '-sWASM_ASYNC_COMPILATION=0', '-O2', '--closure=1'])
+      self.assertContained('add-blocker\n', output)
+      self.assertNotContained('Hello, world!\n', output)
+      self.assertNotContained('post-run\n', output)
+    else:
+      # addRunDependency during preRun should prevent main, and post-run from running.
+      with open('pre.js', 'a', encoding='utf-8') as f:
+        f.write('Module["preRun"] = () => { out("add-dep"); addRunDependency("dep"); }\n')
+      self.cflags += ['-Wno-deprecated']  # avoid warning about addRunDependency
+      self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency')
+      output = self.do_runf('hello_world.c', cflags=['--pre-js', 'pre.js', '-sRUNTIME_DEBUG', '-sWASM_ASYNC_COMPILATION=0', '-O2', '--closure=1'])
+      self.assertContained('add-dep\n', output)
+      self.assertNotContained('Hello, world!\n', output)
+      self.assertNotContained('post-run\n', output)
 
     # noInitialRun prevents run
     args = ['-sWASM_ASYNC_COMPILATION=0', '-sEXPORTED_RUNTIME_METHODS=callMain']
     if no_initial_run:
       args += ['-sINVOKE_RUN=0']
-    if run_dep:
+    if run_blocker:
+      create_file('pre.js', '''
+        Module["preRun"] = () => {
+          var resolve;
+          var promise = new Promise((r) => { resolve = r; });
+          addRunBlocker(promise);
+          Module.resolveBlocker = resolve;
+        };
+      ''')
+      create_file('post.js', 'Module.resolveBlocker();')
+      args += ['--pre-js', 'pre.js', '--post-js', 'post.js']
+    else:
       create_file('pre.js', 'Module["preRun"] = () => addRunDependency("test");')
       create_file('post.js', 'removeRunDependency("test");')
       args += ['--pre-js', 'pre.js', '--post-js', 'post.js']
@@ -2983,7 +3005,7 @@ More info: https://emscripten.org
       # Calling main later should still work, filesystem etc. must be set up.
       print('call main later')
       src = read_file('hello_world.js')
-      src += '\nout("callMain -> " + Module.callMain());\n'
+      src += '\nModule["onRuntimeInitialized"] = () => { out("callMain -> " + Module.callMain()); };\n'
       create_file('hello_world.js', src)
       self.assertContained('Hello, world!\ncallMain -> 0\n', self.run_js('hello_world.js'))
 
@@ -4547,7 +4569,11 @@ printErr('CWD: ' + process.cwd());
     ensure_dir('out_dir')
     self.assert_fail([EMCC, '-c', test_file('hello_world.c'), '-o', 'out_dir/'], 'error: unable to open output file')
 
-  def test_doublestart_bug(self):
+  @parameterized({
+    '': (False,),
+    'run_blocker': (True,),
+  })
+  def test_doublestart_bug(self, run_blocker):
     create_file('code.c', r'''
 #include <stdio.h>
 #include <emscripten.h>
@@ -4564,14 +4590,23 @@ int main(void) {
 }
 ''')
 
-    create_file('pre.js', r'''
+    if run_blocker:
+      create_file('pre.js', r'''
+Module["preRun"] = () => {
+  addRunBlocker(Promise.resolve());
+};
+''')
+      self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunBlocker')
+    else:
+      self.cflags += ['-Wno-deprecated']  # avoid warning about addRunDependency
+      create_file('pre.js', r'''
 Module["preRun"] = () => {
   addRunDependency('test_run_dependency');
   removeRunDependency('test_run_dependency');
 };
 ''')
+      self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency,$removeRunDependency')
 
-    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency,$removeRunDependency')
     output = self.do_runf('code.c', cflags=['--pre-js=pre.js'])
     self.assertEqual(output.count('This should only appear once.'), 1)
 
@@ -6177,32 +6212,71 @@ int main(void) {
     output = self.run_js('run.mjs')
     self.assertContained('done init\nHello, world!\ngot module\n', output)
 
-  def test_modularize_run_dependency(self):
+  @parameterized({
+    '': (False,),
+    'run_blocker': (True,),
+  })
+  def test_modularize_run_dep(self, run_blocker):
     # Ensure that dependencies are fulfilled before the module promise is resolved.
-    create_file('pre.js', '''
-    Module.preRun = () => { dbg("add-dep"); addRunDependency("my dep"); }
-    // Remove the run dependency in 100 milliseconds
-    setTimeout(() => { dbg("remove-dep"); removeRunDependency("my dep") }, 100);
-    ''')
+    if run_blocker:
+      create_file('pre.js', '''
+      Module.preRun = () => {
+        dbg("add-blocker");
+        var resolve;
+        var promise = new Promise((r) => { resolve = r; });
+        addRunBlocker(promise);
+        setTimeout(() => { dbg("remove-blocker"); resolve(); }, 100);
+      }
+      ''')
+      self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunBlocker')
+    else:
+      create_file('pre.js', '''
+      Module.preRun = () => { dbg("add-dep"); addRunDependency("my dep"); }
+      // Remove the run dependency in 100 milliseconds
+      setTimeout(() => { dbg("remove-dep"); removeRunDependency("my dep") }, 100);
+      ''')
+      self.cflags += ['-Wno-deprecated']  # avoid warning about addRunDependency/removeRunDependency
+      self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency,$removeRunDependency')
+
     create_file('run.mjs', '''
     import Module from './hello_world.mjs';
     await Module();
     console.log('got module');
     ''')
-    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency,$removeRunDependency')
-    self.emcc('hello_world.c', ['-o', 'hello_world.mjs', '-sEXPORT_ES6', '-sMODULARIZE', '-sWASM_ASYNC_COMPILATION=0', '--pre-js=pre.js'])
-    self.assertContained('add-dep\nremove-dep\nHello, world!\ngot module\n', self.run_js('run.mjs'))
 
-  def test_modularize_instance_run_dependency(self):
+    self.emcc('hello_world.c', ['-o', 'hello_world.mjs', '-sEXPORT_ES6', '-sMODULARIZE', '-sWASM_ASYNC_COMPILATION=0', '--pre-js=pre.js'])
+
+    expected = 'add-blocker\nremove-blocker\n' if run_blocker else 'add-dep\nremove-dep\n'
+    expected += 'Hello, world!\ngot module\n'
+    self.assertContained(expected, self.run_js('run.mjs'))
+
+  @parameterized({
+    '': (False,),
+    'run_blocker': (True,),
+  })
+  def test_modularize_instance_run_dep(self, run_blocker):
     # Ensure that dependencies are fulfilled before the MODULARIZE=instance ready promise is resolved.
-    create_file('pre.js', '''
-    Module.preRun = () => {
-      dbg("add-dep");
-      addRunDependency("my-dep");
-      setTimeout(() => { dbg("remove-dep"); removeRunDependency("my-dep"); }, 100);
-    }
-    ''')
-    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency,$removeRunDependency')
+    if run_blocker:
+      create_file('pre.js', '''
+      Module.preRun = () => {
+        dbg("add-blocker");
+        var resolve;
+        var promise = new Promise((r) => { resolve = r; });
+        addRunBlocker(promise);
+        setTimeout(() => { dbg("remove-blocker"); resolve(); }, 100);
+      }
+      ''')
+      self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunBlocker')
+    else:
+      create_file('pre.js', '''
+      Module.preRun = () => {
+        dbg("add-dep");
+        addRunDependency("my-dep");
+        setTimeout(() => { dbg("remove-dep"); removeRunDependency("my-dep"); }, 100);
+      }
+      ''')
+      self.cflags += ['-Wno-deprecated']  # avoid warning about addRunDependency/removeRunDependency
+      self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency,$removeRunDependency')
 
     create_file('run.mjs', '''
     import init from './hello_world.mjs';
@@ -6212,7 +6286,8 @@ int main(void) {
 
     self.emcc('hello_world.c', ['-o', 'hello_world.mjs', '-sMODULARIZE=instance', '-Wno-experimental', '--pre-js=pre.js'])
 
-    expected = 'add-dep\nremove-dep\nHello, world!\ngot module\n'
+    expected = 'add-blocker\nremove-blocker\n' if run_blocker else 'add-dep\nremove-dep\n'
+    expected += 'Hello, world!\ngot module\n'
     self.assertContained(expected, self.run_js('run.mjs'))
 
   def test_modularize_instantiation_error(self):

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -731,9 +731,7 @@ def generate_preload_js(data_target, data_files, metadata, js_file):
             var name = file['filename'];
             var data = byteArray.subarray(file['start'], file['end']);
             %s
-          }
-          Module['removeRunDependency']('datafile_%s');''' % (finish_handler,
-                                                              js_manipulation.escape_for_js_string(data_target))
+          }''' % (finish_handler,)
     else:
       # LZ4FS usage
       temp = data_target + '.orig'
@@ -744,8 +742,7 @@ def generate_preload_js(data_target, data_files, metadata, js_file):
       use_data = '''var compressedData = %s;
             compressedData['data'] = byteArray;
             assert(typeof Module['LZ4'] === 'object', 'LZ4 not present - was your app build with -sLZ4?');
-            await Module['LZ4'].loadPackage({ 'metadata': metadata, 'compressedData': compressedData }, %s);
-            Module['removeRunDependency']('datafile_%s');''' % (meta, "true" if options.use_preload_plugins else "false", js_manipulation.escape_for_js_string(data_target))
+            await Module['LZ4'].loadPackage({ 'metadata': metadata, 'compressedData': compressedData }, %s);''' % (meta, "true" if options.use_preload_plugins else "false")
 
     if options.export_es6:
       use_data += '\nloadDataResolve();'
@@ -989,8 +986,7 @@ def generate_preload_js(data_target, data_files, metadata, js_file):
         var byteArray = new Uint8Array(arrayBuffer);
         var curr;
         %s
-      }
-      Module['addRunDependency']('datafile_%s');\n''' % (use_data, js_manipulation.escape_for_js_string(data_target))
+      }''' % (use_data,)
     # use basename because from the browser's point of view,
     # we need to find the datafile in the same dir as the html file
 
@@ -1051,15 +1047,20 @@ def generate_preload_js(data_target, data_files, metadata, js_file):
   ret += '''
     async function runWithFS(Module) {\n'''
   ret += code
-  ret += '''
+  if options.separate_metadata:
+    ret += '''
+    }
+    return runWithFS(Module)%s;''' % catch_handler
+  else:
+    ret += '''
     }
     // Detect whether the module JS file has already been loaded.
     if (Module['FS_createPath']) {
-      runWithFS(Module)%s;
+      Module['addRunBlocker'](runWithFS(Module)%s);
     } else {
       if (!Module['preRun']) Module['preRun'] = [];
-      Module['preRun'].push(runWithFS); // FS is not initialized yet, wait for it
-    }\n''' % catch_handler
+      Module['preRun'].push((mod) => { mod['addRunBlocker'](runWithFS(mod)); });
+    }''' % catch_handler
 
   if options.separate_metadata:
     node_support_code = ''
@@ -1067,19 +1068,14 @@ def generate_preload_js(data_target, data_files, metadata, js_file):
       node_support_code = '''
         if (isNode) {
           var contents = require('fs').readFileSync(metadataUrl, 'utf8');
-          // The await here is needed, even though JSON.parse is a sync API.  It works
-          // around a issue with `removeRunDependency` otherwise being called to early
-          // on the metadata object.
-          var json = await JSON.parse(contents);
+          var json = JSON.parse(contents);
           return loadPackage(json);
         }'''.strip()
 
     ret += '''
-    Module['removeRunDependency']('%(metadata_file)s');
   }
 
-  async function runMetaWithFS() {
-    Module['addRunDependency']('%(metadata_file)s');
+  async function runMetaWithFS(Module) {
     var metadataUrl = Module['locateFile'] ? Module['locateFile']('%(metadata_file)s', '') : '%(metadata_file)s';
     %(node_support_code)s
     var response = await fetch(metadataUrl);
@@ -1092,10 +1088,10 @@ def generate_preload_js(data_target, data_files, metadata, js_file):
 
   // Detect whether the module JS file has already been loaded.
   if (Module['FS_createPath']) {
-    runMetaWithFS();
+    Module['addRunBlocker'](runMetaWithFS(Module));
   } else {
     if (!Module['preRun']) Module['preRun'] = [];
-    Module['preRun'].push(runMetaWithFS);
+    Module['preRun'].push((mod) => { mod['addRunBlocker'](runMetaWithFS(mod)); });
   }\n''' % {'node_support_code': node_support_code, 'metadata_file': os.path.basename(js_file + '.metadata')}
   else:
     ret += '''

--- a/tools/link.py
+++ b/tools/link.py
@@ -1269,8 +1269,8 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$ExitStatus']
 
     if settings.LOAD_SOURCE_MAP:
-      # Loading the source map uses the addRunDependency/removeRunDependency system.
-      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$addRunDependency', '$removeRunDependency']
+      # Loading the source map uses the addRunBlocker system.
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$addRunBlocker']
 
   if settings.ABORT_ON_WASM_EXCEPTIONS or settings.SPLIT_MODULE:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$wasmTable']
@@ -1586,10 +1586,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
         'FS_createDevice',
       ]
 
-    settings.EXPORTED_RUNTIME_METHODS += [
-      'addRunDependency',
-      'removeRunDependency',
-    ]
+    settings.EXPORTED_RUNTIME_METHODS += ['addRunBlocker']
 
   if settings.PTHREADS or settings.WASM_WORKERS:
     settings.IMPORTED_MEMORY = 1


### PR DESCRIPTION
Replace the callback-based dependenciesFulfilled/runDependencies system
with a modern async/await approach using "run blockers" (Promises).

This modernizes the startup sequence, ensuring preRun and other startup
hooks are executed exactly once by pausing and resuming execution flow
instead of re-running the entry point.

To maintain backward compatibility, a bridge is implemented for the
existing addRunDependency and removeRunDependency APIs, routing them
through the new Promise-based blocking mechanism.

- Make run() in postamble.js async to support await.
- Implement $addRunBlocker and $resolveRunBlockers in libcore.js.
- Bridge $addRunDependency and $removeRunDependency to use $addRunBlocker.
- Wrap runDependencies == 0 check in ASSERTIONS guard to avoid empty block in optimized builds (fixes Closure Compiler warnings).

The following (18) test expectation files were updated by
running the tests with `--rebaseline`:

```
codesize/test_codesize_cxx_ctors1.json: 151867 => 151979 [+112 bytes / +0.07%]
codesize/test_codesize_cxx_ctors2.json: 151270 => 151382 [+112 bytes / +0.07%]
codesize/test_codesize_cxx_except.json: 195760 => 195873 [+113 bytes / +0.06%]
codesize/test_codesize_cxx_except_wasm.json: 166991 => 167103 [+112 bytes / +0.07%]
codesize/test_codesize_cxx_except_wasm_legacy.json: 164875 => 164987 [+112 bytes / +0.07%]
codesize/test_codesize_cxx_lto.json: 120708 => 120820 [+112 bytes / +0.09%]
codesize/test_codesize_cxx_mangle.json: 262239 => 262352 [+113 bytes / +0.04%]
codesize/test_codesize_cxx_noexcept.json: 153867 => 153979 [+112 bytes / +0.07%]
codesize/test_codesize_cxx_wasmfs.json: 179724 => 179741 [+17 bytes / +0.01%]
test/codesize/test_codesize_file_preload.expected.js updated
codesize/test_codesize_file_preload.json: 23823 => 23697 [-126 bytes / -0.53%]
codesize/test_codesize_files_js_fs.json: 18247 => 18342 [+95 bytes / +0.52%]
codesize/test_codesize_hello_O0.json: 38598 => 38578 [-20 bytes / -0.05%]
codesize/test_codesize_hello_dylink.json: 44132 => 44228 [+96 bytes / +0.22%]
codesize/test_codesize_hello_dylink_all.json: 855885 => 855967 [+82 bytes / +0.01%]
test/codesize/test_codesize_minimal_O0.expected.js updated
codesize/test_codesize_minimal_O0.json: 19738 => 19658 [-80 bytes / -0.41%]
codesize/test_unoptimized_code_size.json: 176480 => 176351 [-129 bytes / -0.07%]

Average change: +0.02% (-0.53% - +0.52%)
```