### PR TITLE
Add stub for `pause()` syscall in standalone mode

### DIFF
--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -115,6 +115,10 @@ weak int __syscall_newfstatat(int dirfd, intptr_t path, intptr_t buf, int flags)
   return -ENOSYS;
 }
 
+weak int __syscall_pause() {
+  return -ENOSYS;
+}
+
 weak int __syscall_lstat64(intptr_t path, intptr_t buf) {
   return -ENOSYS;
 }

--- a/test/codesize/test_codesize_mem_O3_grow_standalone.json
+++ b/test/codesize/test_codesize_mem_O3_grow_standalone.json
@@ -2,9 +2,9 @@
   "a.out.js": 4127,
   "a.out.js.gz": 1994,
   "a.out.nodebug.wasm": 5641,
-  "a.out.nodebug.wasm.gz": 2660,
+  "a.out.nodebug.wasm.gz": 2659,
   "total": 9768,
-  "total_gz": 4654,
+  "total_gz": 4653,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/codesize/test_codesize_mem_O3_standalone.json
+++ b/test/codesize/test_codesize_mem_O3_standalone.json
@@ -2,9 +2,9 @@
   "a.out.js": 4060,
   "a.out.js.gz": 1956,
   "a.out.nodebug.wasm": 5565,
-  "a.out.nodebug.wasm.gz": 2600,
+  "a.out.nodebug.wasm.gz": 2598,
   "total": 9625,
-  "total_gz": 4556,
+  "total_gz": 4554,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/codesize/test_codesize_mem_O3_standalone_narg.json
+++ b/test/codesize/test_codesize_mem_O3_standalone_narg.json
@@ -2,9 +2,9 @@
   "a.out.js": 3595,
   "a.out.js.gz": 1706,
   "a.out.nodebug.wasm": 5354,
-  "a.out.nodebug.wasm.gz": 2443,
+  "a.out.nodebug.wasm.gz": 2442,
   "total": 8949,
-  "total_gz": 4149,
+  "total_gz": 4148,
   "sent": [
     "proc_exit"
   ],


### PR DESCRIPTION
Fixes: #27036.