### PR TITLE
Fix MODULARIZE=instance ready promise to wait for run dependencies

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -304,6 +304,13 @@ export default async function init(moduleArg = {}) {
   wasmExports = await createWasm();
 #endif
   run();
+  if (!runtimeInitialized) {
+    return new Promise((resolve, reject) => {
+      // Wrap resolve to discard the 'Module' argument and resolve to undefined
+      readyPromiseResolve = () => resolve();
+      readyPromiseReject = reject;
+    });
+  }
 }
 
 #if ENVIRONMENT_MAY_BE_NODE

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6137,6 +6137,28 @@ int main(void) {
     self.emcc('hello_world.c', ['-o', 'hello_world.mjs', '-sEXPORT_ES6', '-sMODULARIZE', '-sWASM_ASYNC_COMPILATION=0', '--pre-js=pre.js'])
     self.assertContained('add-dep\nremove-dep\nHello, world!\ngot module\n', self.run_js('run.mjs'))
 
+  def test_modularize_instance_run_dependency(self):
+    # Ensure that dependencies are fulfilled before the MODULARIZE=instance ready promise is resolved.
+    create_file('pre.js', '''
+    Module.preRun = () => {
+      dbg("add-dep");
+      addRunDependency("my-dep");
+      setTimeout(() => { dbg("remove-dep"); removeRunDependency("my-dep"); }, 100);
+    }
+    ''')
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', '$addRunDependency,$removeRunDependency')
+
+    create_file('run.mjs', '''
+    import init from './hello_world.mjs';
+    await init();
+    console.log('got module');
+    ''')
+
+    self.emcc('hello_world.c', ['-o', 'hello_world.mjs', '-sMODULARIZE=instance', '-Wno-experimental', '--pre-js=pre.js'])
+
+    expected = 'add-dep\nremove-dep\nHello, world!\ngot module\n'
+    self.assertContained(expected, self.run_js('run.mjs'))
+
   def test_modularize_instantiation_error(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-o', 'out.mjs'] + self.get_cflags())
     create_file('run.mjs', '''


### PR DESCRIPTION
Without this change the `init()` function can return/resolve before the instance is ready.