### PR TITLE
Bump EXPECTED_BINARYEN_VERSION to 129

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -52,7 +52,7 @@ logger = logging.getLogger('building')
 
 #  Building
 binaryen_checked = False
-EXPECTED_BINARYEN_VERSION = 128
+EXPECTED_BINARYEN_VERSION = 129
 
 _is_ar_cache: dict[str, bool] = {}
 # the exports the user requested


### PR DESCRIPTION
Bump EXPECTED_BINARYEN_VERSION to 129 to support Binaryen v130, which
just released.
(We can update to 130 when it rolls through emscripten-releases).
