### PR TITLE
Allow metadce to track arrow functions

### DIFF
--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,40 +1,37 @@
 {
-  "a.out.js": 18662,
-  "a.out.js.gz": 7691,
-  "a.out.nodebug.wasm": 102186,
-  "a.out.nodebug.wasm.gz": 39572,
-  "total": 120848,
-  "total_gz": 47263,
+  "a.out.js": 18357,
+  "a.out.js.gz": 7566,
+  "a.out.nodebug.wasm": 101980,
+  "a.out.nodebug.wasm.gz": 39445,
+  "total": 120337,
+  "total_gz": 47011,
   "sent": [
     "a (emscripten_resize_heap)",
-    "b (_setitimer_js)",
-    "c (_emscripten_runtime_keepalive_clear)",
-    "d (_abort_js)",
-    "e (proc_exit)",
-    "f (fd_write)",
-    "g (fd_seek)",
-    "h (fd_read)",
-    "i (fd_close)",
-    "j (environ_sizes_get)",
-    "k (environ_get)"
+    "b (_emscripten_runtime_keepalive_clear)",
+    "c (_abort_js)",
+    "d (proc_exit)",
+    "e (fd_write)",
+    "f (fd_seek)",
+    "g (fd_read)",
+    "h (fd_close)",
+    "i (environ_sizes_get)",
+    "j (environ_get)"
   ],
   "imports": [
     "a (emscripten_resize_heap)",
-    "b (_setitimer_js)",
-    "c (_emscripten_runtime_keepalive_clear)",
-    "d (_abort_js)",
-    "e (proc_exit)",
-    "f (fd_write)",
-    "g (fd_seek)",
-    "h (fd_read)",
-    "i (fd_close)",
-    "j (environ_sizes_get)",
-    "k (environ_get)"
+    "b (_emscripten_runtime_keepalive_clear)",
+    "c (_abort_js)",
+    "d (proc_exit)",
+    "e (fd_write)",
+    "f (fd_seek)",
+    "g (fd_read)",
+    "h (fd_close)",
+    "i (environ_sizes_get)",
+    "j (environ_get)"
   ],
   "exports": [
-    "l (memory)",
-    "m (__wasm_call_ctors)",
-    "n (main)",
-    "o (_emscripten_timeout)"
+    "k (memory)",
+    "l (__wasm_call_ctors)",
+    "m (main)"
   ]
 }

--- a/test/js_optimizer/emitDCEGraph-output.js
+++ b/test/js_optimizer/emitDCEGraph-output.js
@@ -1,7 +1,17 @@
 [
  {
+  "name": "emcc$defun$_bad",
+  "reaches": []
+ },
+ {
   "name": "emcc$defun$applySignatureConversions",
   "reaches": []
+ },
+ {
+  "name": "emcc$defun$func",
+  "reaches": [
+   "emcc$defun$usedFromDeep2"
+  ]
  },
  {
   "name": "emcc$defun$rootedFunc1",
@@ -48,8 +58,7 @@
  },
  {
   "name": "emcc$defun$usedFromDeep2",
-  "reaches": [],
-  "root": true
+  "reaches": []
  },
  {
   "name": "emcc$defun$user",

--- a/test/js_optimizer/emitDCEGraph-scopes-output.js
+++ b/test/js_optimizer/emitDCEGraph-scopes-output.js
@@ -1,8 +1,14 @@
 [
  {
+  "name": "emcc$defun$arrow",
+  "reaches": [
+   "emcc$defun$arrowed",
+   "emcc$defun$caller"
+  ]
+ },
+ {
   "name": "emcc$defun$arrowed",
-  "reaches": [],
-  "root": true
+  "reaches": []
  },
  {
   "name": "emcc$defun$bar",

--- a/test/js_optimizer/emitDCEGraph-vardefs-output.js
+++ b/test/js_optimizer/emitDCEGraph-vardefs-output.js
@@ -1,0 +1,75 @@
+[
+ {
+  "name": "emcc$defun$__setitimer_js",
+  "reaches": [
+   "emcc$export$__emscripten_timeout"
+  ]
+ },
+ {
+  "name": "emcc$defun$helped",
+  "reaches": []
+ },
+ {
+  "name": "emcc$defun$helper",
+  "reaches": [
+   "emcc$defun$helped"
+  ]
+ },
+ {
+  "name": "emcc$defun$namedFE",
+  "reaches": [
+   "emcc$defun$recur"
+  ]
+ },
+ {
+  "name": "emcc$defun$reassigned",
+  "reaches": [
+   "emcc$defun$usedByOriginal"
+  ],
+  "root": true
+ },
+ {
+  "name": "emcc$defun$recur",
+  "reaches": []
+ },
+ {
+  "name": "emcc$defun$rootedByShadow",
+  "reaches": [],
+  "root": true
+ },
+ {
+  "name": "emcc$defun$rootedFromMethod",
+  "reaches": [],
+  "root": true
+ },
+ {
+  "name": "emcc$defun$usedByOriginal",
+  "reaches": []
+ },
+ {
+  "name": "emcc$defun$usedByReplacement",
+  "reaches": [],
+  "root": true
+ },
+ {
+  "name": "emcc$export$__emscripten_timeout",
+  "export": "_emscripten_timeout",
+  "reaches": []
+ },
+ {
+  "name": "emcc$export$_expD1",
+  "export": "expD1",
+  "reaches": [],
+  "root": true
+ },
+ {
+  "name": "emcc$import$__setitimer_js",
+  "import": [
+   "env",
+   "setitimer_js"
+  ],
+  "reaches": [
+   "emcc$defun$__setitimer_js"
+  ]
+ }
+]

--- a/test/js_optimizer/emitDCEGraph-vardefs.js
+++ b/test/js_optimizer/emitDCEGraph-vardefs.js
@@ -1,0 +1,69 @@
+// Functions defined by assignment of an arrow function or function expression
+// to a top-level variable are tracked like function declarations. This is the
+// form in which JS library functions are emitted, so it is what allows
+// breaking JS<->wasm dependency cycles (see issue #26038).
+
+// The JS implementation of a wasm import references a wasm export, forming a
+// JS<->wasm cycle. Nothing else uses either, so none of these may be rooted:
+// metadce must be able to remove the entire cycle.
+var __setitimer_js = (which, timeout) => {
+  __emscripten_timeout(which, timeout);
+};
+
+// A function expression is tracked just like an arrow function.
+function helped() {
+}
+var helper = function() {
+  helped();
+};
+
+// A named function expression: the inner reference is to the expression
+// itself, but we conservatively attribute it to the same-named top-level
+// function, keeping it alive.
+function recur() {
+}
+var namedFE = function recur() {
+  recur();
+};
+
+// Reassigning a tracked name roots it: the assignment target is an identifier
+// use, and the replacement body is treated as top-level code.
+function usedByOriginal() {
+}
+function usedByReplacement() {
+}
+var reassigned = () => {
+  usedByOriginal();
+};
+reassigned = () => {
+  usedByReplacement();
+};
+
+// A variable whose name was already saved as a wasm export is not tracked
+// (re-mapping the name would misattribute references to the export), so its
+// contents are treated as top-level code, which roots them.
+var _expD1 = wasmExports['expD1'];
+function rootedByShadow() {
+}
+var _expD1 = () => {
+  rootedByShadow();
+};
+
+// A variable function nested inside an untracked scope (an object method) is
+// not tracked either; its contents are treated as top-level code.
+function rootedFromMethod() {
+}
+var obj = {
+  method() {
+    var innerArrow = () => {
+      rootedFromMethod();
+    };
+  },
+};
+
+// wasm exports received in the usual way.
+var __emscripten_timeout = wasmExports['_emscripten_timeout'];
+
+var wasmImports = {
+  setitimer_js: __setitimer_js,
+};

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2988,6 +2988,7 @@ More info: https://emscripten.org
     'emitDCEGraph-sig': (['emitDCEGraph', '--no-print'],),
     'emitDCEGraph-prefixing': (['emitDCEGraph', '--no-print'],),
     'emitDCEGraph-scopes': (['emitDCEGraph', '--no-print'],),
+    'emitDCEGraph-vardefs': (['emitDCEGraph', '--no-print'],),
     'minimal-runtime-applyDCEGraphRemovals': (['applyDCEGraphRemovals'],),
     'applyDCEGraphRemovals': (['applyDCEGraphRemovals'],),
     'applyImportAndExportNameChanges': (['applyImportAndExportNameChanges'],),

--- a/tools/acorn-optimizer.mjs
+++ b/tools/acorn-optimizer.mjs
@@ -621,10 +621,13 @@ function emitDCEGraph(ast) {
   }
 
   // We track defined functions very carefully, so that we can remove them and
-  // the things they call, but other function scopes (like arrow functions and
-  // object methods) are trickier to track (object methods require knowing what
-  // object a function name is called on), so we do not track those. We consider
-  // all content inside them as top-level, which means it is used.
+  // the things they call. That includes functions defined by assignment of a
+  // function expression or arrow function to a top-level variable (which is
+  // how JS library functions are emitted). Other function scopes (like object
+  // methods, or arrow functions not directly assigned to a variable) are
+  // trickier to track (object methods require knowing what object a function
+  // name is called on), so we do not track those. We consider all content
+  // inside them as top-level, which means it is used.
   var specialScopes = 0;
 
   fullWalk(
@@ -699,6 +702,31 @@ function emitDCEGraph(ast) {
                 emptyOut(node);
               }
             }
+          } else if (
+            value &&
+            (value.type === 'ArrowFunctionExpression' || value.type === 'FunctionExpression') &&
+            !specialScopes &&
+            // If the name already maps to a graph node (a saved export, or an
+            // earlier same-named function) do not track this one: re-mapping
+            // the name would misattribute references to the wrong node, which
+            // could lead to unsound removals. Left untracked, the contents
+            // are treated as top-level code, which is conservative.
+            !nameToGraphName.hasOwnProperty(name)
+          ) {
+            // this is a function defined by assignment to a variable, e.g.
+            //  var x = () => { .. };
+            //  var x = function() { .. };
+            // We track it just like a function declaration, which allows DCE
+            // of wasm exports that are only used inside such functions (e.g.
+            // JS library functions, which are emitted in this form).
+            // References through the name are attributed to this function.
+            // That is precise only if the name is never reassigned (generated
+            // code never reassigns these); if it were, the assignment would
+            // root this node (the assignment target is an identifier use), so
+            // this remains conservative.
+            defuns.push({id: {name}, body: value.body});
+            nameToGraphName[name] = getGraphName(name, 'defun');
+            emptyOut(node); // ignore this in the second pass; we scan defuns separately
           }
         }
         // A variable declaration that has no initial values can be ignored in


### PR DESCRIPTION
Resolves https://github.com/emscripten-core/emscripten/issues/26038. Probably also resolves #22534.

Some libc functions are implemented in a circular way: the C-side helper functions call JS helpers, which may call those same C helpers. As I stated in #26838:

> The `setitimer` libc function calls `_emscripten_timeout`, which calls the JS-side `_setitimer_js`. This adds a dependency on the `_setitimer_js` function from libc.
> 
> Then on the JS side, `_setitimer_js` calls *back* into the WASM-side `_emscripten_timeout`, adding a dependency on it.

Emscripten is *supposed* to have a "metadce" pass (`emitDCEGraph` in acorn-optimizer.mjs), whose purpose is to track and clean up precisely those circular dependencies.

However, metadce has been silently broken since https://github.com/emscripten-core/emscripten/pull/19539 back in 2023. While it was supposedly NFC, #19539 changes JS library functions to use arrow functions to "save code size", and the metadce pass does not track arrow functions. As a result, the pass essentially does nothing now.

This PR adds support to the metadce pass for tracking top-level arrow-function variable declarations. This allows it to properly track (and eliminate) circular JS<->wasm dependencies.

A disclaimer: the code was generated by Claude. I *did* review the code (and write this PR description) myself, and the added test case should ensure that various edge cases (e.g. reassignments) are handled properly. I checked CONTRIBUTING.md, and there was no explicit guidance on AI-generated submissions. This is a fairly localized change (~a dozen lines of actual new code), so the review burden should not be too high.

Since the metadce pass has (as far as I can tell) been a no-op since 2023, there's a risk that this *may* shake some other bugs loose (e.g. if any code has been added since then which implicitly relies on metadce not doing anything).

A couple other things I want some guidance on:
- The `defuns` array is currently expected to hold Acorn `FunctionDeclaration` nodes. The new arrow-function branch creates a plain object *shaped* like a `FunctionDeclaration`, but it may be cleaner to just change what `defuns` holds. That would be a larger change, however.
- ~~I've added an `emitDCEGraph-vardefs.js` test, but have not specifically added any integration tests / regression tests for ensuring functions like `__setitimer_js` get removed when LTO is enabled. Where would those go?~~ (EDIT: looks like `test_codesize_cxx_lto.json` tracks this already.)