### PR TITLE
create_entry_points.py: Don't remove bootstrap.bat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1346,6 +1346,11 @@ jobs:
           name: "sockets.test_nodejs_sockets_echo*"
           command: "test/runner sockets.test_nodejs_sockets_echo*"
       - upload-test-results
+      - run:
+          name: "check clean"
+          command: |
+            git checkout tools/pylauncher
+            $EMSDK_PYTHON test/check_clean.py
 
   test-mac-arm64:
     executor: mac-arm64

--- a/tools/maint/create_entry_points.py
+++ b/tools/maint/create_entry_points.py
@@ -115,7 +115,10 @@ def main(all_platforms, use_bat_file):
         make_executable(launcher)
 
       if do_windows:
-        maybe_remove(launcher + '.bat')
+        if entry_point != 'bootstrap':
+          # The bootstrap.bat file is checked into source control so we
+          # don't want to delete it.
+          maybe_remove(launcher + '.bat')
         maybe_remove(launcher + '.ps1')
         maybe_remove(launcher + '.exe')
         if use_bat_file:


### PR DESCRIPTION
Unlike the other bat files this one is still checked into source control.

Also, add the check_clean.py step to the windows tester, which would have caught this oversight.