### PR TITLE
Fix JSC_UNDEFINED_VARIABLE in libeventloop.js

### DIFF
--- a/src/lib/libeventloop.js
+++ b/src/lib/libeventloop.js
@@ -351,7 +351,7 @@ LibraryJSEventLoop = {
 #if RUNTIME_DEBUG
           dbg('setImmediate: using scheduler.postTask');
 #endif
-          MainLoop.setImmediate = scheduler.postTask.bind(scheduler);
+          MainLoop.setImmediate = globalThis.scheduler.postTask.bind(globalThis.scheduler);
 #if ENVIRONMENT_MAY_BE_NODE
         } else if (globalThis.setImmediate) {
           MainLoop.setImmediate = setImmediate;

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268126,
+  "a.out.js": 268148,
   "a.out.nodebug.wasm": 587596,
-  "total": 855722,
+  "total": 855744,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
Fix error [JSC_UNDEFINED_VARIABLE] variable scheduler is undeclared `MainLoop.setImmediate = scheduler.postTask.bind(scheduler);`