### PR TITLE
Add missing rename `bootstrap -> bootstrap.py`

### DIFF
--- a/.github/workflows/rebaseline-tests.yml
+++ b/.github/workflows/rebaseline-tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           git config user.name emscripten-bot
           git config user.email emscripten-bot@users.noreply.github.com
-          ./bootstrap
+          ./bootstrap.py
           if ./tools/maint/rebaseline_tests.py --new-branch; then
              echo "rebaseline_tests returned zero, expectations up-to-date"
              # Exit early and don't create a PR


### PR DESCRIPTION
This was missing from #27060.