### PR TITLE
Always await the `createWasm` promise under `WASM_ASYNC_COMPILATION`

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -347,14 +347,13 @@ if ({{{ ENVIRONMENT_IS_MAIN_THREAD() }}}) {
 #if !MODULARIZE && WASM_ASYNC_COMPILATION
 // With async instantation wasmExports is assigned asynchronously when the
 // instance is received.
-createWasm();
+createWasm().then(() => run());
 #else
 // In modularize mode the generated code is within a factory function so we
 // can use await here (since it's not top-level-await).
 wasmExports = {{{ awaitIf(MODULARIZE && WASM_ASYNC_COMPILATION) }}}createWasm();
-#endif
-
 {{{ awaitIf(MODULARIZE) }}}run();
+#endif
 
 #if WASM_WORKERS || PTHREADS
 }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -795,14 +795,8 @@ function getWasmImports() {
     // We now have the Wasm module loaded up, keep a reference to the compiled module so we can post it to the workers.
     wasmModule = module;
 #endif
-#if WASM_ASYNC_COMPILATION && !MODULARIZE
-    removeRunDependency('wasm-instantiate');
-#endif
     return wasmExports;
   }
-#if WASM_ASYNC_COMPILATION && !MODULARIZE
-  addRunDependency('wasm-instantiate');
-#endif
 
   // Prefer streaming instantiation if available.
 #if WASM_ASYNC_COMPILATION

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19322,
-  "a.out.js.gz": 8008,
+  "a.out.js": 19192,
+  "a.out.js.gz": 7944,
   "a.out.nodebug.wasm": 132666,
   "a.out.nodebug.wasm.gz": 49962,
-  "total": 151988,
-  "total_gz": 57970,
+  "total": 151858,
+  "total_gz": 57906,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19299,
-  "a.out.js.gz": 7995,
+  "a.out.js": 19169,
+  "a.out.js.gz": 7931,
   "a.out.nodebug.wasm": 132092,
   "a.out.nodebug.wasm.gz": 49625,
-  "total": 151391,
-  "total_gz": 57620,
+  "total": 151261,
+  "total_gz": 57556,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23298,
-  "a.out.js.gz": 8987,
+  "a.out.js": 23166,
+  "a.out.js.gz": 8928,
   "a.out.nodebug.wasm": 172586,
   "a.out.nodebug.wasm.gz": 57501,
-  "total": 195884,
-  "total_gz": 66488,
+  "total": 195752,
+  "total_gz": 66429,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19125,
-  "a.out.js.gz": 7925,
+  "a.out.js": 18995,
+  "a.out.js.gz": 7862,
   "a.out.nodebug.wasm": 147991,
   "a.out.nodebug.wasm.gz": 55370,
-  "total": 167116,
-  "total_gz": 63295,
+  "total": 166986,
+  "total_gz": 63232,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19199,
-  "a.out.js.gz": 7955,
+  "a.out.js": 19069,
+  "a.out.js.gz": 7884,
   "a.out.nodebug.wasm": 145797,
   "a.out.nodebug.wasm.gz": 54992,
-  "total": 164996,
-  "total_gz": 62947,
+  "total": 164866,
+  "total_gz": 62876,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18662,
-  "a.out.js.gz": 7691,
+  "a.out.js": 18532,
+  "a.out.js.gz": 7634,
   "a.out.nodebug.wasm": 102168,
   "a.out.nodebug.wasm.gz": 39572,
-  "total": 120830,
-  "total_gz": 47263,
+  "total": 120700,
+  "total_gz": 47206,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23348,
-  "a.out.js.gz": 9009,
+  "a.out.js": 23216,
+  "a.out.js.gz": 8947,
   "a.out.nodebug.wasm": 239015,
   "a.out.nodebug.wasm.gz": 79854,
-  "total": 262363,
-  "total_gz": 88863,
+  "total": 262231,
+  "total_gz": 88801,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19322,
-  "a.out.js.gz": 8008,
+  "a.out.js": 19192,
+  "a.out.js.gz": 7944,
   "a.out.nodebug.wasm": 134666,
   "a.out.nodebug.wasm.gz": 50806,
-  "total": 153988,
-  "total_gz": 58814,
+  "total": 153858,
+  "total_gz": 58750,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_wasmfs.json
+++ b/test/codesize/test_codesize_cxx_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7056,
-  "a.out.js.gz": 3322,
+  "a.out.js": 6930,
+  "a.out.js.gz": 3252,
   "a.out.nodebug.wasm": 172677,
   "a.out.nodebug.wasm.gz": 63357,
-  "total": 179733,
-  "total_gz": 66679,
+  "total": 179607,
+  "total_gz": 66609,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -459,10 +459,8 @@ async function createWasm() {
     wasmExports = instance.exports;
     assignWasmExports(wasmExports);
     updateMemoryViews();
-    removeRunDependency("wasm-instantiate");
     return wasmExports;
   }
-  addRunDependency("wasm-instantiate");
   // Prefer streaming instantiation if available.
   function receiveInstantiationResult(result) {
     // 'result' is a ResultObject object which has both the module and instance.
@@ -3210,6 +3208,4 @@ var wasmExports;
 
 // With async instantation wasmExports is assigned asynchronously when the
 // instance is received.
-createWasm();
-
-run();
+createWasm().then(() => run());

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22126,
-  "a.out.js.gz": 9184,
+  "a.out.js": 22109,
+  "a.out.js.gz": 9180,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 23792,
-  "total_gz": 10129,
+  "total": 23775,
+  "total_gz": 10125,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_files_js_fs.json
+++ b/test/codesize/test_codesize_files_js_fs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 17970,
-  "a.out.js.gz": 7349,
+  "a.out.js": 17840,
+  "a.out.js.gz": 7285,
   "a.out.nodebug.wasm": 381,
   "a.out.nodebug.wasm.gz": 260,
-  "total": 18351,
-  "total_gz": 7609,
+  "total": 18221,
+  "total_gz": 7545,
   "sent": [
     "a (fd_write)",
     "b (fd_read)",

--- a/test/codesize/test_codesize_files_wasmfs.json
+++ b/test/codesize/test_codesize_files_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 5487,
-  "a.out.js.gz": 2586,
+  "a.out.js": 5364,
+  "a.out.js.gz": 2525,
   "a.out.nodebug.wasm": 58324,
   "a.out.nodebug.wasm.gz": 18215,
-  "total": 63811,
-  "total_gz": 20801,
+  "total": 63688,
+  "total_gz": 20740,
   "sent": [
     "a (emscripten_date_now)",
     "b (emscripten_err)",

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 24254,
-  "a.out.js.gz": 8724,
+  "a.out.js": 23358,
+  "a.out.js.gz": 8434,
   "a.out.nodebug.wasm": 15115,
   "a.out.nodebug.wasm.gz": 7464,
-  "total": 39369,
-  "total_gz": 16188,
+  "total": 38473,
+  "total_gz": 15898,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O1.json
+++ b/test/codesize/test_codesize_hello_O1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 6378,
-  "a.out.js.gz": 2461,
+  "a.out.js": 6164,
+  "a.out.js.gz": 2386,
   "a.out.nodebug.wasm": 2544,
   "a.out.nodebug.wasm.gz": 1436,
-  "total": 8922,
-  "total_gz": 3897,
+  "total": 8708,
+  "total_gz": 3822,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O2.json
+++ b/test/codesize/test_codesize_hello_O2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4344,
-  "a.out.js.gz": 2134,
+  "a.out.js": 4220,
+  "a.out.js.gz": 2070,
   "a.out.nodebug.wasm": 1912,
   "a.out.nodebug.wasm.gz": 1129,
-  "total": 6256,
-  "total_gz": 3263,
+  "total": 6132,
+  "total_gz": 3199,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O3.json
+++ b/test/codesize/test_codesize_hello_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4286,
-  "a.out.js.gz": 2092,
+  "a.out.js": 4161,
+  "a.out.js.gz": 2030,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 5952,
-  "total_gz": 3037,
+  "total": 5827,
+  "total_gz": 2975,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_Os.json
+++ b/test/codesize/test_codesize_hello_Os.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4286,
-  "a.out.js.gz": 2092,
+  "a.out.js": 4161,
+  "a.out.js.gz": 2030,
   "a.out.nodebug.wasm": 1654,
   "a.out.nodebug.wasm.gz": 953,
-  "total": 5940,
-  "total_gz": 3045,
+  "total": 5815,
+  "total_gz": 2983,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_Oz.json
+++ b/test/codesize/test_codesize_hello_Oz.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3921,
-  "a.out.js.gz": 1901,
+  "a.out.js": 3800,
+  "a.out.js.gz": 1836,
   "a.out.nodebug.wasm": 1188,
   "a.out.nodebug.wasm.gz": 731,
-  "total": 5109,
-  "total_gz": 2632,
+  "total": 4988,
+  "total_gz": 2567,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26433,
-  "a.out.js.gz": 11266,
+  "a.out.js": 26398,
+  "a.out.js.gz": 11245,
   "a.out.nodebug.wasm": 17861,
   "a.out.nodebug.wasm.gz": 9019,
-  "total": 44294,
-  "total_gz": 20285,
+  "total": 44259,
+  "total_gz": 20264,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_export_nothing.json
+++ b/test/codesize/test_codesize_hello_export_nothing.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3198,
-  "a.out.js.gz": 1491,
+  "a.out.js": 3076,
+  "a.out.js.gz": 1423,
   "a.out.nodebug.wasm": 43,
   "a.out.nodebug.wasm.gz": 59,
-  "total": 3241,
-  "total_gz": 1550,
+  "total": 3119,
+  "total_gz": 1482,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_hello_single_file.json
+++ b/test/codesize/test_codesize_hello_single_file.json
@@ -1,6 +1,6 @@
 {
-  "a.out.js": 5262,
-  "a.out.js.gz": 2895,
+  "a.out.js": 5139,
+  "a.out.js.gz": 2826,
   "sent": [
     "a (fd_write)"
   ]

--- a/test/codesize/test_codesize_hello_wasmfs.json
+++ b/test/codesize/test_codesize_hello_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4286,
-  "a.out.js.gz": 2092,
+  "a.out.js": 4161,
+  "a.out.js.gz": 2030,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 5952,
-  "total_gz": 3037,
+  "total": 5827,
+  "total_gz": 2975,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_libcxxabi_message_O3.json
+++ b/test/codesize/test_codesize_libcxxabi_message_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3548,
-  "a.out.js.gz": 1670,
+  "a.out.js": 3427,
+  "a.out.js.gz": 1605,
   "a.out.nodebug.wasm": 89,
   "a.out.nodebug.wasm.gz": 98,
-  "total": 3637,
-  "total_gz": 1768,
+  "total": 3516,
+  "total_gz": 1703,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_libcxxabi_message_O3_standalone.json
+++ b/test/codesize/test_codesize_libcxxabi_message_O3_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3595,
-  "a.out.js.gz": 1706,
+  "a.out.js": 3474,
+  "a.out.js.gz": 1638,
   "a.out.nodebug.wasm": 222,
   "a.out.nodebug.wasm.gz": 206,
-  "total": 3817,
-  "total_gz": 1912,
+  "total": 3696,
+  "total_gz": 1844,
   "sent": [
     "proc_exit"
   ],

--- a/test/codesize/test_codesize_mem_O3.json
+++ b/test/codesize/test_codesize_mem_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4375,
-  "a.out.js.gz": 2101,
+  "a.out.js": 4256,
+  "a.out.js.gz": 2038,
   "a.out.nodebug.wasm": 5260,
   "a.out.nodebug.wasm.gz": 2419,
-  "total": 9635,
-  "total_gz": 4520,
+  "total": 9516,
+  "total_gz": 4457,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/codesize/test_codesize_mem_O3_grow.json
+++ b/test/codesize/test_codesize_mem_O3_grow.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4660,
-  "a.out.js.gz": 2253,
+  "a.out.js": 4541,
+  "a.out.js.gz": 2193,
   "a.out.nodebug.wasm": 5261,
   "a.out.nodebug.wasm.gz": 2419,
-  "total": 9921,
-  "total_gz": 4672,
+  "total": 9802,
+  "total_gz": 4612,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/codesize/test_codesize_mem_O3_grow_standalone.json
+++ b/test/codesize/test_codesize_mem_O3_grow_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4127,
-  "a.out.js.gz": 1994,
+  "a.out.js": 4012,
+  "a.out.js.gz": 1933,
   "a.out.nodebug.wasm": 5641,
   "a.out.nodebug.wasm.gz": 2659,
-  "total": 9768,
-  "total_gz": 4653,
+  "total": 9653,
+  "total_gz": 4592,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/codesize/test_codesize_mem_O3_standalone.json
+++ b/test/codesize/test_codesize_mem_O3_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4060,
-  "a.out.js.gz": 1956,
+  "a.out.js": 3945,
+  "a.out.js.gz": 1893,
   "a.out.nodebug.wasm": 5565,
   "a.out.nodebug.wasm.gz": 2598,
-  "total": 9625,
-  "total_gz": 4554,
+  "total": 9510,
+  "total_gz": 4491,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/codesize/test_codesize_mem_O3_standalone_lib.json
+++ b/test/codesize/test_codesize_mem_O3_standalone_lib.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3588,
-  "a.out.js.gz": 1699,
+  "a.out.js": 3468,
+  "a.out.js.gz": 1633,
   "a.out.nodebug.wasm": 5239,
   "a.out.nodebug.wasm.gz": 2359,
-  "total": 8827,
-  "total_gz": 4058,
+  "total": 8707,
+  "total_gz": 3992,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_mem_O3_standalone_narg.json
+++ b/test/codesize/test_codesize_mem_O3_standalone_narg.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3595,
-  "a.out.js.gz": 1706,
+  "a.out.js": 3474,
+  "a.out.js.gz": 1638,
   "a.out.nodebug.wasm": 5354,
   "a.out.nodebug.wasm.gz": 2442,
-  "total": 8949,
-  "total_gz": 4148,
+  "total": 8828,
+  "total_gz": 4080,
   "sent": [
     "proc_exit"
   ],

--- a/test/codesize/test_codesize_mem_O3_standalone_narg_flto.json
+++ b/test/codesize/test_codesize_mem_O3_standalone_narg_flto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3595,
-  "a.out.js.gz": 1706,
+  "a.out.js": 3474,
+  "a.out.js.gz": 1638,
   "a.out.nodebug.wasm": 4285,
   "a.out.nodebug.wasm.gz": 2142,
-  "total": 7880,
-  "total_gz": 3848,
+  "total": 7759,
+  "total_gz": 3780,
   "sent": [
     "proc_exit"
   ],

--- a/test/codesize/test_codesize_minimal_64.json
+++ b/test/codesize/test_codesize_minimal_64.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2608,
-  "a.out.js.gz": 1251,
+  "a.out.js": 2540,
+  "a.out.js.gz": 1210,
   "a.out.nodebug.wasm": 75,
   "a.out.nodebug.wasm.gz": 88,
-  "total": 2683,
-  "total_gz": 1339,
+  "total": 2615,
+  "total_gz": 1298,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -667,10 +667,8 @@ async function createWasm() {
 
     updateMemoryViews();
 
-    removeRunDependency('wasm-instantiate');
     return wasmExports;
   }
-  addRunDependency('wasm-instantiate');
 
   // Prefer streaming instantiation if available.
   // Async compilation can be confusing when an error on the page overwrites Module
@@ -1452,9 +1450,7 @@ var wasmExports;
 
 // With async instantation wasmExports is assigned asynchronously when the
 // instance is received.
-createWasm();
-
-run();
+createWasm().then(() => run());
 
 // end include: postamble.js
 

--- a/test/codesize/test_codesize_minimal_O0.json
+++ b/test/codesize/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19404,
-  "a.out.js.gz": 6985,
+  "a.out.js": 18596,
+  "a.out.js.gz": 6720,
   "a.out.nodebug.wasm": 1015,
   "a.out.nodebug.wasm.gz": 602,
-  "total": 20419,
-  "total_gz": 7587,
+  "total": 19611,
+  "total_gz": 7322,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_O1.json
+++ b/test/codesize/test_codesize_minimal_O1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3061,
-  "a.out.js.gz": 1296,
+  "a.out.js": 2947,
+  "a.out.js.gz": 1248,
   "a.out.nodebug.wasm": 449,
   "a.out.nodebug.wasm.gz": 337,
-  "total": 3510,
-  "total_gz": 1633,
+  "total": 3396,
+  "total_gz": 1585,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_O2.json
+++ b/test/codesize/test_codesize_minimal_O2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2356,
-  "a.out.js.gz": 1176,
+  "a.out.js": 2284,
+  "a.out.js.gz": 1133,
   "a.out.nodebug.wasm": 280,
   "a.out.nodebug.wasm.gz": 226,
-  "total": 2636,
-  "total_gz": 1402,
+  "total": 2564,
+  "total_gz": 1359,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_O3.json
+++ b/test/codesize/test_codesize_minimal_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2297,
-  "a.out.js.gz": 1141,
+  "a.out.js": 2225,
+  "a.out.js.gz": 1098,
   "a.out.nodebug.wasm": 75,
   "a.out.nodebug.wasm.gz": 87,
-  "total": 2372,
-  "total_gz": 1228,
+  "total": 2300,
+  "total_gz": 1185,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_Os.json
+++ b/test/codesize/test_codesize_minimal_Os.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2297,
-  "a.out.js.gz": 1141,
+  "a.out.js": 2225,
+  "a.out.js.gz": 1098,
   "a.out.nodebug.wasm": 75,
   "a.out.nodebug.wasm.gz": 87,
-  "total": 2372,
-  "total_gz": 1228,
+  "total": 2300,
+  "total_gz": 1185,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_Oz-ctors.json
+++ b/test/codesize/test_codesize_minimal_Oz-ctors.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2276,
-  "a.out.js.gz": 1126,
+  "a.out.js": 2206,
+  "a.out.js.gz": 1086,
   "a.out.nodebug.wasm": 64,
   "a.out.nodebug.wasm.gz": 80,
-  "total": 2340,
-  "total_gz": 1206,
+  "total": 2270,
+  "total_gz": 1166,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_Oz.json
+++ b/test/codesize/test_codesize_minimal_Oz.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2297,
-  "a.out.js.gz": 1141,
+  "a.out.js": 2225,
+  "a.out.js.gz": 1098,
   "a.out.nodebug.wasm": 75,
   "a.out.nodebug.wasm.gz": 87,
-  "total": 2372,
-  "total_gz": 1228,
+  "total": 2300,
+  "total_gz": 1185,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7012,
-  "a.out.js.gz": 3472,
+  "a.out.js": 6975,
+  "a.out.js.gz": 3442,
   "a.out.nodebug.wasm": 19063,
   "a.out.nodebug.wasm.gz": 8803,
-  "total": 26075,
-  "total_gz": 12275,
+  "total": 26038,
+  "total_gz": 12245,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7420,
-  "a.out.js.gz": 3672,
+  "a.out.js": 7383,
+  "a.out.js.gz": 3643,
   "a.out.nodebug.wasm": 19064,
   "a.out.nodebug.wasm.gz": 8804,
-  "total": 26484,
-  "total_gz": 12476,
+  "total": 26447,
+  "total_gz": 12447,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_wasmfs.json
+++ b/test/codesize/test_codesize_minimal_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2297,
-  "a.out.js.gz": 1141,
+  "a.out.js": 2225,
+  "a.out.js.gz": 1098,
   "a.out.nodebug.wasm": 75,
   "a.out.nodebug.wasm.gz": 87,
-  "total": 2372,
-  "total_gz": 1228,
+  "total": 2300,
+  "total_gz": 1185,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_small_js_flags.expected.js
+++ b/test/codesize/test_small_js_flags.expected.js
@@ -237,10 +237,8 @@ async function createWasm() {
     wasmExports = instance.exports;
     assignWasmExports(wasmExports);
     updateMemoryViews();
-    removeRunDependency("wasm-instantiate");
     return wasmExports;
   }
-  addRunDependency("wasm-instantiate");
   // Prefer streaming instantiation if available.
   function receiveInstantiationResult(result) {
     // 'result' is a ResultObject object which has both the module and instance.
@@ -289,21 +287,6 @@ class ExitStatus {
 var runDependencies = 0;
 
 var dependenciesFulfilled = null;
-
-var removeRunDependency = id => {
-  runDependencies--;
-  if (runDependencies == 0) {
-    if (dependenciesFulfilled) {
-      var callback = dependenciesFulfilled;
-      dependenciesFulfilled = null;
-      callback();
-    }
-  }
-};
-
-var addRunDependency = id => {
-  runDependencies++;
-};
 
 var printCharBuffers = [ null, [], [] ];
 
@@ -491,6 +474,4 @@ var wasmExports;
 
 // With async instantation wasmExports is assigned asynchronously when the
 // instance is received.
-createWasm();
-
-run();
+createWasm().then(() => run());

--- a/test/codesize/test_small_js_flags.json
+++ b/test/codesize/test_small_js_flags.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2326,
-  "a.out.js.gz": 1283,
+  "a.out.js": 2240,
+  "a.out.js.gz": 1244,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 3992,
-  "total_gz": 2228,
+  "total": 3906,
+  "total_gz": 2189,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 57200,
-  "hello_world.js.gz": 17815,
+  "hello_world.js": 57125,
+  "hello_world.js.gz": 17796,
   "hello_world.wasm": 15115,
   "hello_world.wasm.gz": 7464,
-  "no_asserts.js": 26773,
-  "no_asserts.js.gz": 8951,
+  "no_asserts.js": 26698,
+  "no_asserts.js.gz": 8934,
   "no_asserts.wasm": 12229,
   "no_asserts.wasm.gz": 6004,
-  "strict.js": 54833,
-  "strict.js.gz": 17054,
+  "strict.js": 54758,
+  "strict.js.gz": 17042,
   "strict.wasm": 15115,
   "strict.wasm.gz": 7457,
-  "total": 181265,
-  "total_gz": 64745
+  "total": 181040,
+  "total_gz": 64697
 }


### PR DESCRIPTION
When `WASM_ASYNC_COMPILATION` is enabled `createWasm` returns a promise.  However we were not always waiting on this and instead using the `addRunDependency` system to block the running of main.

This change simplifies things by always awaiting the promise when it exists.

This is kind of a followup to #27059 and a pre-cursor to #27028 which is a much larger change.

Comes with a nice little codesize saving too, since it avoid the whole `addRunDependency` in most simple programs.