### PR TITLE
Fix test_wasm_bindgen_integration. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,6 @@ commands:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             export PATH=${HOME}/.cargo/bin:${PATH}
             rustup target add wasm32-unknown-emscripten
-            cargo install wasm-bindgen-cli
             echo "export PATH=\"\$HOME/.cargo/bin:\$PATH\"" >> $BASH_ENV
   install-node-version:
     description: "install a specific version of node"

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14842,9 +14842,9 @@ addToLibrary({
     create_file('post.js', '''
       Module.onRuntimeInitialized = () => out(Module.rs_add(17, 25));
     ''')
-    emcc_args = [lib, '-sWASM_BINDGEN', '--post-js=post.js', '-lexports.js']
 
-    self.do_runf('empty.c', '42', cflags=emcc_args)
+    self.run_process(['cargo', 'install', 'wasm-bindgen-cli'])
+    self.do_runf('empty.c', '42', cflags=[lib, '-sWASM_BINDGEN', '--post-js=post.js', '-lexports.js'])
 
   def test_relative_em_cache(self):
     with env_modify({'EM_CACHE': 'foo'}):


### PR DESCRIPTION
Without this change the test was failing on my local machine due to
missing wasm-bindgen.   An alternative would be to have a way to opt
out, but its seems easy enough to run the `install` as part of the test.