### PR TITLE
Allow using the search path from -resource-dir with `emcc -print-file-name`

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -262,15 +262,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     print(compiler_rt.get_path(absolute=True))
     return 0
 
+  resource_dir = [a for a in args if a.startswith(('-resource-dir=', '--resource-dir='))]
+  if resource_dir:
+    resource_dir = resource_dir[-1].split('=')[1]
+
   print_file_name = [a for a in args if a.startswith(('-print-file-name=', '--print-file-name='))]
   if print_file_name:
-    arg = print_file_name[-1]
-    libname = arg.split('=')[1]
-    index = args.index(arg)
-    if index >= 1:
-      system_libpath = os.path.abspath(args[0])
-    else:
-      system_libpath = cache.get_lib_dir(absolute=True)
+    libname = print_file_name[-1].split('=')[1]
+    system_libpath = resource_dir or cache.get_lib_dir(absolute=True)
     fullpath = os.path.join(system_libpath, libname)
     if os.path.isfile(fullpath):
       print(fullpath)

--- a/emcc.py
+++ b/emcc.py
@@ -262,14 +262,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     print(compiler_rt.get_path(absolute=True))
     return 0
 
-  resource_dir = [a for a in args if a.startswith(('-resource-dir=', '--resource-dir='))]
-  if resource_dir:
-    resource_dir = resource_dir[-1].split('=')[1]
-
   print_file_name = [a for a in args if a.startswith(('-print-file-name=', '--print-file-name='))]
   if print_file_name:
     libname = print_file_name[-1].split('=')[1]
-    system_libpath = resource_dir or cache.get_lib_dir(absolute=True)
+    resource_dir = [a for a in args if a.startswith(('-resource-dir=', '--resource-dir='))]
+    if resource_dir:
+      system_libpath = resource_dir[-1].split('=')[1]
+    else:
+      system_libpath = cache.get_lib_dir(absolute=True)
     fullpath = os.path.join(system_libpath, libname)
     if os.path.isfile(fullpath):
       print(fullpath)

--- a/emcc.py
+++ b/emcc.py
@@ -264,8 +264,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   print_file_name = [a for a in args if a.startswith(('-print-file-name=', '--print-file-name='))]
   if print_file_name:
-    libname = print_file_name[-1].split('=')[1]
-    system_libpath = cache.get_lib_dir(absolute=True)
+    arg = print_file_name[-1]
+    libname = arg.split('=')[1]
+    index = args.index(arg)
+    if index >= 1:
+      system_libpath = os.path.abspath(args[0])
+    else:
+      system_libpath = cache.get_lib_dir(absolute=True)
     fullpath = os.path.join(system_libpath, libname)
     if os.path.isfile(fullpath):
       print(fullpath)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -777,9 +777,9 @@ f.close()
     self.assertContained(cache.get_lib_name('libc.a'), str(filename))
 
   @crossplatform
-  def test_print_file_name_relative(self):
+  def test_print_file_name_with_resource_dir(self):
     output = self.run_process([EMCC, '-print-file-name=emcc'], stdout=PIPE).stdout
-    output_relative = self.run_process([EMCC, shlex.quote(path_from_root()), '-print-file-name=emcc'], stdout=PIPE).stdout
+    output_relative = self.run_process([EMCC, '-resource-dir=' + path_from_root(), '-print-file-name=emcc'], stdout=PIPE).stdout
     self.assertNotExists(output.rstrip())
     self.assertExists(output_relative.rstrip())
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -778,8 +778,9 @@ f.close()
 
   @crossplatform
   def test_print_file_name_with_resource_dir(self):
-    output = self.run_process([EMCC, '-print-file-name=emcc'], stdout=PIPE).stdout
-    output_relative = self.run_process([EMCC, '-resource-dir=' + path_from_root(), '-print-file-name=emcc'], stdout=PIPE).stdout
+    file = Path(EMCC).stem
+    output = self.run_process([EMCC, f'-print-file-name={file}'], stdout=PIPE).stdout
+    output_relative = self.run_process([EMCC, '-resource-dir=' + path_from_root(), f'-print-file-name={file}'], stdout=PIPE).stdout
     self.assertNotExists(output.rstrip())
     self.assertExists(output_relative.rstrip())
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -778,7 +778,7 @@ f.close()
 
   @crossplatform
   def test_print_file_name_with_resource_dir(self):
-    file = Path(EMCC).stem
+    file = Path(EMCC).name
     output = self.run_process([EMCC, f'-print-file-name={file}'], stdout=PIPE).stdout
     output_relative = self.run_process([EMCC, '-resource-dir=' + path_from_root(), f'-print-file-name={file}'], stdout=PIPE).stdout
     self.assertNotExists(output.rstrip())

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -776,6 +776,13 @@ f.close()
     settings.MEMORY64 = int('-m64' in args)
     self.assertContained(cache.get_lib_name('libc.a'), str(filename))
 
+  @crossplatform
+  def test_print_file_name_relative(self):
+    output = self.run_process([EMCC, '-print-file-name=emcc'], stdout=PIPE).stdout
+    output_relative = self.run_process([EMCC, path_from_root(), '-print-file-name=emcc'], stdout=PIPE).stdout
+    self.assertNotExists(output.rstrip())
+    self.assertExists(output_relative.rstrip())
+
   def test_emar_em_config_flag(self):
     # Test that the --em-config flag is accepted but not passed down do llvm-ar.
     # We expand this in case the EM_CONFIG is ~/.emscripten (default)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -779,7 +779,7 @@ f.close()
   @crossplatform
   def test_print_file_name_relative(self):
     output = self.run_process([EMCC, '-print-file-name=emcc'], stdout=PIPE).stdout
-    output_relative = self.run_process([EMCC, path_from_root(), '-print-file-name=emcc'], stdout=PIPE).stdout
+    output_relative = self.run_process([EMCC, shlex.quote(path_from_root()), '-print-file-name=emcc'], stdout=PIPE).stdout
     self.assertNotExists(output.rstrip())
     self.assertExists(output_relative.rstrip())
 


### PR DESCRIPTION
This allows emcc to change the search path when running it like: `emcc -resource-dir=... -print-file-name=...` which mimics the upstream clang behavior.