### PR TITLE
Mark dynamic linking as requiring async compilation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 6.0.1 (in development)
 ----------------------
+- Dynamic linking now explicitly requires asynchronous Wasm compilation. The
+  process of loading side modules at startup currently depends on this. (#27086)
 - The `-sUSE_PTHREADS` and `-sMEMORY64` flags have been deprecated in favor of the
   more standard `-pthread` and `-m64` (or `--target=wasm64`) flags. (#27025)
 - Adds wasm-bindgen support. When `-sWASM_BINDGEN` is set, Emscripten will call

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -131,6 +131,7 @@ INCOMPATIBLE_SETTINGS = [
     ('WASM_WORKERS', 'MAIN_MODULE', 'dynamic linking is not supported with -sWASM_WORKERS'),
     ('WASM2JS', 'MAIN_MODULE', 'wasm2js does not support dynamic linking'),
     ('WASM2JS', 'SIDE_MODULE', 'wasm2js does not support dynamic linking'),
+    ('MAIN_MODULE', 'NO_WASM_ASYNC_COMPILATION', 'dynamic linking requires async wasm compilation'),
     ('MODULARIZE', 'NO_DECLARE_ASM_MODULE_EXPORTS', None),
     ('EVAL_CTORS', 'WASM2JS', None),
     # In Asyncify exports can be called more than once, and this seems to not


### PR DESCRIPTION
The loading of the dynamic libraries on startup has always been async but now we make a clear error to use `-sWASM_ASYNC_COMPILATION=0` with dynamic linking.

Split out from #27079 