### PR TITLE
Use libclang_rt naming for installed compiler-rt libraries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ commands:
             ls -l ~/cache/sysroot/include/emscripten/heap.h
             cat ~/cache/sysroot/lib/wasm32-emscripten/crtbegin-mt.o.ccache-log
             date
-            cat ~/cache/build/libcompiler_rt/absvdi2.o.ccache-log
+            cat ~/cache/build/libclang_rt.builtins/absvdi2.o.ccache-log
             ccache -s
             ccache --print-stats
             ccache -p

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 6.0.1 (in development)
 ----------------------
+- The installed versions of the compiler-rt library now follow the upstream
+  naming convetion of `libclang_rt.<something>.a`. (#27089)
 - Dynamic linking now explicitly requires asynchronous Wasm compilation. The
   process of loading side modules at startup currently depends on this. (#27086)
 - The `-sUSE_PTHREADS` and `-sMEMORY64` flags have been deprecated in favor of the

--- a/embuilder.py
+++ b/embuilder.py
@@ -26,11 +26,11 @@ from tools.system_libs import USE_NINJA
 
 # Minimal subset of targets used by CI systems to build enough to be useful
 MINIMAL_TASKS = [
-    'libcompiler_rt',
-    'libcompiler_rt-mt',
-    'libcompiler_rt-legacysjlj',
-    'libcompiler_rt-wasmsjlj',
-    'libcompiler_rt-ww',
+    'libclang_rt.builtins',
+    'libclang_rt.builtins-mt',
+    'libclang_rt.builtins-legacysjlj',
+    'libclang_rt.builtins-wasmsjlj',
+    'libclang_rt.builtins-ww',
     'libc',
     'libc-debug',
     'libc-mt-debug',
@@ -120,8 +120,8 @@ MINIMAL_PIC_TASKS = [
     'libGL-mt-emu-webgl2-ofb-getprocaddr',
     'libsockets_proxy',
     'crtbegin-mt',
-    'libsanitizer_common_rt',
-    'libubsan_rt',
+    'libclang_rt.sanitizer_common',
+    'libclang_rt.ubsan',
     'libwasm_workers-debug',
     'libfetch',
     'libfetch-mt',

--- a/emcc.py
+++ b/emcc.py
@@ -270,8 +270,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   if '-print-libgcc-file-name' in args or '--print-libgcc-file-name' in args:
     settings.limit_settings(None)
-    compiler_rt = system_libs.Library.get_usable_variations()['libcompiler_rt']
-    print(compiler_rt.get_path(absolute=True))
+    clang_rt = system_libs.Library.get_usable_variations()['libclang_rt.builtins']
+    print(clang_rt.get_path(absolute=True))
     return 0
 
   print_file_name = [a for a in args if a.startswith(('-print-file-name=', '--print-file-name='))]

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -738,7 +738,7 @@ f.close()
     settings.LTO = '-flto' in args
     settings.MEMORY64 = int('-m64' in args)
     libdir = cache.get_lib_dir(absolute=True)
-    expected = os.path.join(libdir, 'libcompiler_rt.a')
+    expected = os.path.join(libdir, 'libclang_rt.builtins.a')
     self.assertEqual(output.strip(), expected)
 
   @crossplatform
@@ -11962,7 +11962,7 @@ int main(void) {
     self.assertContained(err, self.expect_fail([EMCC, test_file('unistd/close.c'), '-nodefaultlibs']))
 
     # Build again but with explicit system libraries
-    libs = ['-lc', '-lcompiler_rt']
+    libs = ['-lc', '-lclang_rt.builtins']
     self.run_process([EMCC, test_file('unistd/close.c'), '-nostdlib'] + libs)
     self.run_process([EMCC, test_file('unistd/close.c'), '-nodefaultlibs'] + libs)
     self.run_process([EMCC, test_file('unistd/close.c'), '-nolibc', '-lc'])
@@ -12873,13 +12873,13 @@ kill -9 $$
 
   def test_standard_library_mapping(self):
     # Test the `-l` flags on the command line get mapped the correct libraries variant
-    libs = ['-lc', '-lcompiler_rt', '-lmalloc']
+    libs = ['-lc', '-lclang_rt.builtins', '-lmalloc']
     err = self.run_process([EMCC, test_file('hello_world.c'), '-pthread', '-nodefaultlibs', '-v'] + libs, stderr=PIPE).stderr
 
     # Check that the linker was run with `-mt` variants because `-pthread` was passed.
     self.assertContained(' -lc-mt-debug ', err)
     self.assertContained(' -ldlmalloc-mt-debug ', err)
-    self.assertContained(' -lcompiler_rt-mt ', err)
+    self.assertContained(' -lclang_rt.builtins-mt ', err)
 
   def test_explicit_gl_linking(self):
     # Test that libGL can be linked explicitly via `-lGL` rather than implicitly.

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -947,8 +947,8 @@ class AsanInstrumentedLibrary(Library):
 
 
 # Subclass of SjLjLibrary because emscripten_setjmp.c uses SjLj support
-class libcompiler_rt(MTLibrary, SjLjLibrary):
-  name = 'libcompiler_rt'
+class libclang_rt_builtins(MTLibrary, SjLjLibrary):
+  name = 'libclang_rt.builtins'
   # compiler_rt files can't currently be part of LTO although we are hoping to remove this
   # restriction soon: https://reviews.llvm.org/D71738
   force_object_files = True
@@ -2137,8 +2137,8 @@ class CompilerRTLibrary(Library):
   force_object_files = True
 
 
-class libubsan_minimal_rt(CompilerRTLibrary, MTLibrary):
-  name = 'libubsan_minimal_rt'
+class libclang_rt_ubsan_minimal(CompilerRTLibrary, MTLibrary):
+  name = 'libclang_rt.ubsan_minimal'
   never_force = True
 
   includes = ['system/lib/compiler-rt/lib']
@@ -2146,8 +2146,8 @@ class libubsan_minimal_rt(CompilerRTLibrary, MTLibrary):
   src_files = ['ubsan_minimal_handlers.cpp']
 
 
-class libsanitizer_common_rt(CompilerRTLibrary, MTLibrary):
-  name = 'libsanitizer_common_rt'
+class libclang_rt_sanitizer_common(CompilerRTLibrary, MTLibrary):
+  name = 'libclang_rt.sanitizer_common'
   includes = ['system/lib/compiler-rt/lib',
               'system/lib/libc']
   never_force = True
@@ -2172,8 +2172,8 @@ class SanitizerLibrary(CompilerRTLibrary, MTLibrary):
   src_glob = '*.cpp'
 
 
-class libubsan_rt(SanitizerLibrary):
-  name = 'libubsan_rt'
+class libclang_rt_ubsan(SanitizerLibrary):
+  name = 'libclang_rt.ubsan'
 
   includes = ['system/lib/libc']
   cflags = ['-DUBSAN_CAN_USE_CXXABI']
@@ -2181,15 +2181,15 @@ class libubsan_rt(SanitizerLibrary):
   src_glob_exclude = {'ubsan_diag_standalone.cpp'}
 
 
-class liblsan_common_rt(SanitizerLibrary):
-  name = 'liblsan_common_rt'
+class libclang_rt_lsan_common(SanitizerLibrary):
+  name = 'libclang_rt.lsan_common'
 
   src_dir = 'system/lib/compiler-rt/lib/lsan'
   src_glob = 'lsan_common*.cpp'
 
 
-class liblsan_rt(SanitizerLibrary):
-  name = 'liblsan_rt'
+class libclang_rt_lsan(SanitizerLibrary):
+  name = 'libclang_rt.lsan'
 
   includes = ['system/lib/libc']
   src_dir = 'system/lib/compiler-rt/lib/lsan'
@@ -2197,8 +2197,8 @@ class liblsan_rt(SanitizerLibrary):
                       'lsan_common_emscripten.cpp'}
 
 
-class libasan_rt(SanitizerLibrary):
-  name = 'libasan_rt'
+class libclang_rt_asan(SanitizerLibrary):
+  name = 'libclang_rt.asan'
 
   includes = ['system/lib/libc']
   src_dir = 'system/lib/compiler-rt/lib/asan'
@@ -2380,25 +2380,25 @@ def get_libs_to_link(options):
 
   def add_sanitizer_libs():
     if settings.USE_ASAN:
-      force_include.append('libasan_rt')
-      add_library('libasan_rt')
+      force_include.append('libclang_rt.asan')
+      add_library('libclang_rt.asan')
     elif settings.USE_LSAN:
-      force_include.append('liblsan_rt')
-      add_library('liblsan_rt')
+      force_include.append('libclang_rt.lsan')
+      add_library('libclang_rt.lsan')
 
     if settings.UBSAN_RUNTIME == 1:
-      add_library('libubsan_minimal_rt')
+      add_library('libclang_rt.ubsan_minimal')
     elif settings.UBSAN_RUNTIME == 2:
-      add_library('libubsan_rt')
+      add_library('libclang_rt.ubsan')
 
     if settings.USE_LSAN or settings.USE_ASAN:
-      add_library('liblsan_common_rt')
+      add_library('libclang_rt.lsan_common')
 
     if sanitize:
-      add_library('libsanitizer_common_rt')
+      add_library('libclang_rt.sanitizer_common')
 
   if only_forced:
-    add_library('libcompiler_rt')
+    add_library('libclang_rt.builtins')
     add_sanitizer_libs()
     add_forced_libs()
     return libs_to_link
@@ -2434,7 +2434,7 @@ def get_libs_to_link(options):
         utils.exit_with_error('mimalloc is not compatible with -fsanitize=address')
     elif settings.MALLOC != 'none':
       add_library('libmalloc')
-  add_library('libcompiler_rt')
+  add_library('libclang_rt.builtins')
   if settings.LINK_AS_CXX:
     add_library('libc++')
   if settings.LINK_AS_CXX or sanitize:


### PR DESCRIPTION
This matches the upstream project which uses this filename convention when building and installing the libraries.