### PR TITLE
Automatically enable GROWABLE_ARRAYBUFFERS when min browser versions allow

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -3346,8 +3346,6 @@ Enable support for GrowableSharedArrayBuffer.
 This feature has only recently become available across major browser engines
 and Node.js.
 
-.. note:: This is an experimental setting
-
 Default value: false
 
 .. _cross_origin:

--- a/src/settings.js
+++ b/src/settings.js
@@ -2196,7 +2196,6 @@ var JS_BASE64_API = false;
 // Enable support for GrowableSharedArrayBuffer.
 // This feature has only recently become available across major browser engines
 // and Node.js.
-// [experimental]
 // [link]
 var GROWABLE_ARRAYBUFFERS = false;
 

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -9,7 +9,7 @@ import logging
 from enum import IntEnum, auto
 
 from . import diagnostics
-from .settings import settings, user_settings
+from .settings import default_setting, settings, user_settings
 
 logger = logging.getLogger('feature_matrix')
 
@@ -196,6 +196,12 @@ def caniuse(feature):
   if feature in enable_override_features:
     return True
 
+  # Certain features are incompatible with certain settings.
+  # TODO(sbc): Make this more generate, perhaps based on INCOMPATIBLE_SETTINGS
+  if feature == Feature.GROWABLE_ARRAYBUFFERS and settings.WASM2JS:
+    logger.debug(f'cannot use {feature.name} because WASM2JS is enabled')
+    return False
+
   min_versions = min_browser_versions[feature]
 
   def report_missing(setting_name):
@@ -248,10 +254,12 @@ def disable_feature(feature):
   disable_override_features.add(feature)
 
 
-# apply minimum browser version defaults based on user settings. if
-# a user requests a feature that we know is only supported in browsers
-# from a specific version and above, we can assume that browser version.
 def apply_min_browser_versions():
+  """Update minimum browser version defaults based on user settings.
+
+  If a user requests a feature that we know is only supported in browsers
+  from a specific version and above, we can assume that browser version.
+  """
   if settings.WASM_BIGINT and 'WASM_BIGINT' in user_settings:
     # WASM_BIGINT is enabled by default, don't use it to enable other features
     # unless the user explicitly enabled it.
@@ -275,3 +283,11 @@ def apply_min_browser_versions():
       enable_feature(Feature.WASM_EXCEPTIONS, 'Wasm exceptions (-fwasm-exceptions with -sWASM_LEGACY_EXCEPTIONS=0)')
   if settings.GROWABLE_ARRAYBUFFERS:
     enable_feature(Feature.GROWABLE_ARRAYBUFFERS, 'GrowableSharedArrayBuffer')
+
+
+def auto_enable_features():
+  """Enable settings based on usable features."""
+  # TODO(sbc): Find make a generic way to expose the feature matrix to JS
+  # compiler rather then adding them all ad-hoc as internal settings
+  default_setting('WASM_BIGINT', caniuse(Feature.JS_BIGINT_INTEGRATION))
+  default_setting('GROWABLE_ARRAYBUFFERS', caniuse(Feature.GROWABLE_ARRAYBUFFERS))

--- a/tools/link.py
+++ b/tools/link.py
@@ -1539,9 +1539,8 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
   # Such setting must be set before this point
   feature_matrix.apply_min_browser_versions()
 
-  # TODO(sbc): Find make a generic way to expose the feature matrix to JS
-  # compiler rather then adding them all ad-hoc as internal settings
-  default_setting('WASM_BIGINT', feature_matrix.caniuse(Feature.JS_BIGINT_INTEGRATION))
+  feature_matrix.auto_enable_features()
+
   if settings.WASM_BIGINT:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$HEAP64', '$HEAPU64']
 
@@ -1965,6 +1964,7 @@ def run_embind_gen(options, wasm_target, js_syms, extra_settings):
   # Disable proxying and thread pooling so a worker is not automatically created.
   settings.PROXY_TO_PTHREAD = False
   settings.PTHREAD_POOL_SIZE = 0
+  settings.GROWABLE_ARRAYBUFFERS = 0
   # Assume wasm support at binding generation time
   settings.WASM2JS = 0
   # Disable minify since the binaryen pass has not been run yet to change the

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -131,6 +131,7 @@ INCOMPATIBLE_SETTINGS = [
     ('WASM_WORKERS', 'MAIN_MODULE', 'dynamic linking is not supported with -sWASM_WORKERS'),
     ('WASM2JS', 'MAIN_MODULE', 'wasm2js does not support dynamic linking'),
     ('WASM2JS', 'SIDE_MODULE', 'wasm2js does not support dynamic linking'),
+    ('WASM2JS', 'GROWABLE_ARRAYBUFFERS',  None),
     ('MAIN_MODULE', 'NO_WASM_ASYNC_COMPILATION', 'dynamic linking requires async wasm compilation'),
     ('MODULARIZE', 'NO_DECLARE_ASM_MODULE_EXPORTS', None),
     ('EVAL_CTORS', 'WASM2JS', None),
@@ -155,7 +156,6 @@ EXPERIMENTAL_SETTINGS = {
     'SPLIT_MODULE': '-sSPLIT_MODULE is experimental and subject to change',
     'SOURCE_PHASE_IMPORTS': '-sSOURCE_PHASE_IMPORTS is experimental and not yet supported in browsers',
     'JS_BASE64_API': '-sJS_BASE64_API is experimental and not yet supported in browsers',
-    'GROWABLE_ARRAYBUFFERS': '-sGROWABLE_ARRAYBUFFERS is still experimental and has only recently become available in browsers',
     'SUPPORT_BIG_ENDIAN': '-sSUPPORT_BIG_ENDIAN is experimental, not all features are fully supported.',
     'WASM_ESM_INTEGRATION': '-sWASM_ESM_INTEGRATION is still experimental and not yet supported in browsers',
 }


### PR DESCRIPTION
See https://github.com/emscripten-core/emscripten/pull/27096#issuecomment-4679245284

Also, remove the experimental status, since this feature is now available in all browser and we hope
to feature-detect it soon and start using it even without this flag.

Fixes: #26099