### PR TITLE
Require node v26 for GROWABLE_ARRAYBUFFERS feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1059,6 +1059,7 @@ jobs:
             other.test_min_node_version
             other.test_node_emscripten_num_logical_cores
             other.test_js_base64_api
+            other.test_pthread_growth*
             core2.test_hello_world
             core2.test_pthread_create
             core2.test_i64_invoke_bigint

--- a/test/common.py
+++ b/test/common.py
@@ -495,6 +495,17 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
         self.skipTest('test requires node v25 and current Node.js version is older than this, with EMTEST_AUTOSKIP being set')
       self.fail('node v25 required to run this test.  Use EMTEST_SKIP_NODE_25 to skip')
 
+  def require_node_26(self):
+    if 'EMTEST_SKIP_NODE_26' in os.environ or 'EMTEST_SKIP_NODE_25' in os.environ:
+      self.skipTest('test requires node v26 and EMTEST_SKIP_NODE_25/EMTEST_SKIP_NODE_26 is set')
+    nodejs = get_nodejs()
+    if not nodejs:
+      self.skipTest('Test requires nodejs to run')
+    if not self.try_require_node_version(26, 0, 0):
+      if utils.get_env_bool('EMTEST_AUTOSKIP'):
+        self.skipTest('test requires node v26 and current Node.js version is older than this, with EMTEST_AUTOSKIP being set')
+      self.fail('node v26 required to run this test.  Use EMTEST_SKIP_NODE_25/EMTEST_SKIP_NODE_26 to skip')
+
   def require_engine(self, engine, force=False):
     logger.debug(f'require_engine: {engine}')
     if not force and self.required_engine and self.required_engine != engine:

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -146,6 +146,17 @@ def requires_node_25(func):
   return decorated
 
 
+def requires_node_26(func):
+  assert callable(func)
+
+  @wraps(func)
+  def decorated(self, *args, **kwargs):
+    self.require_node_26()
+    return func(self, *args, **kwargs)
+
+  return decorated
+
+
 # Used to mark dependencies in various tests to npm developer dependency
 # packages, which might not be installed on Emscripten end users' systems.
 def requires_dev_dependency(package):

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -84,6 +84,7 @@ from decorators import (
   requires_network,
   requires_node,
   requires_node_25,
+  requires_node_26,
   requires_pthreads,
   requires_v8,
   requires_wasm64,
@@ -13104,8 +13105,7 @@ void foo() {}
   })
   def test_pthread_growth_mainthread(self, cflags):
     if '-sGROWABLE_ARRAYBUFFERS' in cflags:
-      self.node_args.append('--experimental-wasm-rab-integration')
-      self.require_node_25()
+      self.require_node_26()
     else:
       self.cflags.append('-Wno-pthreads-mem-growth')
     self.do_runf('pthread/test_pthread_memory_growth_mainthread.c', cflags=['-pthread', '-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=32MB', '-sMAXIMUM_MEMORY=256MB'] + cflags)
@@ -13114,9 +13114,8 @@ void foo() {}
   def test_pthread_join_interrupted(self):
     self.do_runf('pthread/test_pthread_join_interrupted.c', cflags=['-pthread'])
 
-  @requires_node_25
+  @requires_node_26
   def test_growable_arraybuffers(self):
-    self.node_args.append('--experimental-wasm-rab-integration')
     self.do_runf('hello_world.c',
                  cflags=['-O2', '-pthread', '-sALLOW_MEMORY_GROWTH', '-sGROWABLE_ARRAYBUFFERS', '-Wno-experimental'],
                  output_basename='growable')
@@ -13144,8 +13143,7 @@ void foo() {}
       self.require_node_25()
 
     if '-sGROWABLE_ARRAYBUFFERS' in cflags:
-      self.node_args.append('--experimental-wasm-rab-integration')
-      self.require_node_25()
+      self.require_node_26()
     else:
       self.cflags.append('-Wno-pthreads-mem-growth')
     self.do_runf('pthread/test_pthread_memory_growth.c', cflags=['-pthread', '-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=32MB', '-sMAXIMUM_MEMORY=256MB'] + cflags)

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -144,10 +144,7 @@ min_browser_versions = {
     'chrome': 144,
     'firefox': 145,
     'safari': 260200,
-    # Supported with flag --experimental-wasm-rab-integration (TODO: Change
-    # this to unflagged version of Node.js 260000, see also the comment in
-    # Feature.WASM_EXCEPTIONS above)
-    'node': 240000,
+    'node': 260000,
   },
 
 # The following features we now support unconditionally, but keeping them around


### PR DESCRIPTION
Now that node v26 is out we don't need bother with the `--experimental-wasm-rab-integration` anymore.

Followup to #27094.