### PR TITLE
Require node v24 for WASM_EXCEPTIONS feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1034,8 +1034,6 @@ jobs:
             other.test_js_optimizer_verbose
             other.test_min_node_version
             other.test_node_emscripten_num_logical_cores
-            other.test_exceptions_stack_trace*
-            other.test_exceptions_rethrow_stack_trace*
             core2.test_pthread_create
             core2.test_i64_invoke_bigint
             core2.test_sse2
@@ -1060,6 +1058,9 @@ jobs:
             other.test_node_emscripten_num_logical_cores
             other.test_js_base64_api
             other.test_pthread_growth*
+            other.test_exceptions_stack_trace*
+            other.test_exceptions_rethrow_stack_trace*
+            core2.test_*exception*_wasm
             core2.test_hello_world
             core2.test_pthread_create
             core2.test_i64_invoke_bigint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -966,8 +966,6 @@ jobs:
             other.test_js_optimizer_verbose
             other.test_min_node_version
             other.test_node_emscripten_num_logical_cores
-            other.test_exceptions_stack_trace*
-            other.test_exceptions_rethrow_stack_trace*
             core2.test_pthread_create
             core2.test_i64_invoke_bigint
             core2.test_sse2
@@ -993,6 +991,9 @@ jobs:
             other.test_js_base64_api
             other.test_pthread_growth*
             other.test_memory_growth
+            other.test_exceptions_stack_trace*
+            other.test_exceptions_rethrow_stack_trace*
+            core2.test_*exception*_wasm
             core2.test_hello_world
             core2.test_pthread_create
             core2.test_i64_invoke_bigint

--- a/test/common.py
+++ b/test/common.py
@@ -585,15 +585,14 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
 
   def require_wasm_eh(self):
     if 'EMTEST_SKIP_WASM_EH' in os.environ:
-      self.skipTest('test requires node v24 or d8 (and EMTEST_SKIP_WASM_EH is set)')
+      self.skipTest('test requires node v26 or d8 (and EMTEST_SKIP_WASM_EH is set)')
     self.set_setting('WASM_LEGACY_EXCEPTIONS', 0)
 
     if self.is_browser_test():
       self.check_browser_feature('EMTEST_SKIP_WASM_EH', Feature.WASM_EXCEPTIONS, 'test requires Wasm EH')
       return
 
-    if self.try_require_node_version(22):
-      self.node_args.append('--experimental-wasm-exnref')
+    if self.try_require_node_version(26):
       return
 
     deno = get_deno()
@@ -610,10 +609,9 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     if v8:
       self.cflags.append('-sENVIRONMENT=shell')
       self.require_engine(v8)
-      self.v8_args.append('--experimental-wasm-exnref')
       return
 
-    self.fail('either d8, deno, bun or node v24 required to run wasm-eh tests.  Use EMTEST_SKIP_WASM_EH to skip')
+    self.fail('either d8, deno, bun or node v26 required to run wasm-eh tests.  Use EMTEST_SKIP_WASM_EH to skip')
 
   def require_jspi(self):
     if 'EMTEST_SKIP_JSPI' in os.environ:

--- a/test/common.py
+++ b/test/common.py
@@ -604,17 +604,14 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
 
   def require_wasm_eh(self):
     if 'EMTEST_SKIP_WASM_EH' in os.environ:
-      self.skipTest('test requires node v24 or d8 (and EMTEST_SKIP_WASM_EH is set)')
+      self.skipTest('test requires node v24.15 or d8 (and EMTEST_SKIP_WASM_EH is set)')
     self.set_setting('WASM_LEGACY_EXCEPTIONS', 0)
 
     if self.is_browser_test():
       self.check_browser_feature('EMTEST_SKIP_WASM_EH', Feature.WASM_EXCEPTIONS, 'test requires Wasm EH')
       return
 
-    if self.try_require_node_version(22):
-      # v25 and up don't require a flag at all
-      if not self.try_require_node_version(25):
-        self.node_args.append('--experimental-wasm-exnref')
+    if self.try_require_node_version(24, 15):
       return
 
     deno = get_deno()
@@ -633,7 +630,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
       self.require_engine(v8)
       return
 
-    self.fail('either d8, deno, bun or node v24 required to run wasm-eh tests.  Use EMTEST_SKIP_WASM_EH to skip')
+    self.fail('either d8, deno, bun or node v24.15 required to run wasm-eh tests.  Use EMTEST_SKIP_WASM_EH to skip')
 
   def require_jspi(self):
     if 'EMTEST_SKIP_JSPI' in os.environ:

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -129,11 +129,7 @@ min_browser_versions = {
     'chrome': 137,
     'firefox': 131,
     'safari': 180400,
-    # Supported with flag --experimental-wasm-exnref (TODO: Change this to
-    # unflagged version of Node.js 260000 that ships Wasm EH enabled, after
-    # Emscripten unit testing has migrated to Node.js 26, and Emsdk ships
-    # Node.js 26)
-    'node': 220000,
+    'node': 260000,
   },
   # Growable SharedArrayBuffers improves memory growth feature in multithreaded
   # builds by avoiding need to poll resizes to ArrayBuffer views in Workers.

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -129,11 +129,7 @@ min_browser_versions = {
     'chrome': 137,
     'firefox': 131,
     'safari': 180400,
-    # Supported with flag --experimental-wasm-exnref (TODO: Change this to
-    # unflagged version of Node.js 260000 that ships Wasm EH enabled, after
-    # Emscripten unit testing has migrated to Node.js 26, and Emsdk ships
-    # Node.js 26)
-    'node': 220000,
+    'node': 241500,
   },
   # Growable SharedArrayBuffers improves memory growth feature in multithreaded
   # builds by avoiding need to poll resizes to ArrayBuffer views in Workers.

--- a/tools/link.py
+++ b/tools/link.py
@@ -2087,13 +2087,9 @@ def run_embind_gen(wasm_target, js_syms, extra_settings):
   if wasm_opt_args:
     building.run_wasm_opt(outfile_wasm, outfile_wasm, wasm_opt_args)
 
-  # Build the flags needed by Node.js to properly run the output file.
-  node_args = []
-  if settings.WASM_EXCEPTIONS:
-    node_args += shared.node_exception_flags(config.NODE_JS)
   # Run the generated JS file with the proper flags to generate the TypeScript bindings.
   output_file = in_temp('embind_generated_output.js')
-  shared.run_js_tool(outfile_js, [output_file], node_args)
+  shared.run_js_tool(outfile_js, [output_file])
   settings.restore(original_settings)
   return read_file(output_file)
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -329,17 +329,6 @@ def node_reference_types_flags(nodejs):
     return []
 
 
-def node_exception_flags(nodejs):
-  node_version = get_node_version(nodejs)
-  # Legacy exception handling was enabled by default in node v17.
-  if node_version and node_version < (17, 0, 0):
-    return ['--experimental-wasm-eh']
-  # Standard exception handling was supported behind flag in node v22.
-  if node_version and node_version >= (22, 0, 0) and not settings.WASM_LEGACY_EXCEPTIONS:
-    return ['--experimental-wasm-exnref']
-  return []
-
-
 @memoize
 @ToolchainProfiler.profile()
 def check_node():


### PR DESCRIPTION
Now that Node 24 is shipping with emsdk we can remove this hack I think: https://github.com/emscripten-core/emsdk/pull/1760.

We can also remove the `node_exception_flags` helper which was designed to let older versions of node run the program during typescript generation, but that use case doesn't seems useful/necessary anymore.

Follow up #27103