### PR TITLE
Add test for recent chrome issue with stale memory views on workers

### DIFF
--- a/test/browser/test_pthread_memgrowth_stale_views.c
+++ b/test/browser/test_pthread_memgrowth_stale_views.c
@@ -1,0 +1,36 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <emscripten.h>
+
+intptr_t test_addr = 0;
+
+void* thread_run(void* arg) {
+  // Query the JS HEAP8 view size immediately.
+  intptr_t heap_len = (intptr_t)EM_ASM_PTR({ return HEAP8.byteLength; });
+
+  printf("thread: HEAP8.len=%zu, test_addr=%zu\n", heap_len, test_addr);
+
+  // Verify that the JS view has been updated to cover the new allocation.
+  // If the view is stale, heap_len will be smaller than test_addr.
+  assert(heap_len >= test_addr && "test failed: JS views are stale.");
+
+  printf("test succeeded.\n");
+  emscripten_force_exit(0);
+  return NULL;
+}
+
+int main() {
+  printf("main start\n");
+  pthread_t thread;
+  pthread_create(&thread, NULL, thread_run, NULL);
+
+  printf("main allocating 20MB\n");
+  void* dummy_ptr = malloc(20 * 1024 * 1024);
+  test_addr = (intptr_t)dummy_ptr + 19 * 1024 * 1024;
+  printf("main allocated\n");
+
+  printf("main exiting with live runtime\n");
+  emscripten_exit_with_live_runtime();
+}

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5696,6 +5696,10 @@ fetch('report_result?0');
   def test_shell_minimal(self, args):
     self.btest_exit('browser_test_hello_world.c', cflags=['--shell-file', path_from_root('html/shell_minimal.html')] + args)
 
+  def test_pthread_memgrowth_stale_views(self):
+    self.btest_exit('test_pthread_memgrowth_stale_views.c',
+                    cflags=['-pthread', '-sALLOW_MEMORY_GROWTH', '-Wno-pthreads-mem-growth'])
+
 
 class browser64(browser):
   def setUp(self):


### PR DESCRIPTION
This issue seems to only show up when the memory growth occurs in the
same event loop tick as the `new Worker`.   If the worker is already
created (e.g. via PTHREAD_POOL_SIZE=N) then the issue does not
occur.

See #27084