### PR TITLE
[CI] Add `apt-get update` before installing chrome deps. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ commands:
       - run:
           name: download chrome
           command: |
+            apt-get update
             # TODO: Make these part of the base image
             apt-get install -q -y libu2f-udev libvulkan1 xdg-utils
             wget -O ~/chrome.deb https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb


### PR DESCRIPTION
Without this `apt-get` will try to pull a package form that archive which was deleted due to a security issue:

E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/libh/libhttp-daemon-perl/libhttp-daemon-perl_6.13-1ubuntu0.1_all.deb  404  Not Found [IP: 172.66.152.176 80]

See https://ubuntu.com/security/notices/USN-8419-1