### PR TITLE
[CI] Install browsers using puppeteer/browsers tool. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,18 +25,21 @@ executors:
     resource_class: m4pro.medium
 
 commands:
-  download-chrome:
-    description: "Download chrome"
+  install-browser:
+    description: "Install browser"
+    parameters:
+      browser_name:
+        description: "Name of the the browser to install"
+        type: string
     steps:
       - run:
-          name: download chrome
+          name: download browser (<< parameters.browser_name >>)
           command: |
-            wget -O ~/chrome.deb https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb
-            # If that download link breaks, temporarily use this URL instead:
-            # wget -O ~/chrome.deb https://storage.googleapis.com/webassembly/chrome/google-chrome-stable_current_amd64.deb
-            dpkg -i ~/chrome.deb
-            echo "Chrome version:"
-            /usr/bin/google-chrome --version
+            npx --yes @puppeteer/browsers install << parameters.browser_name >> --format={{path}} | tee browser_path.txt
+            BROWSER_PATH=`cat browser_path.txt`
+            echo "browser installed to: ${BROWSER_PATH}"
+            "${BROWSER_PATH}" --version
+            echo "export EMTEST_BROWSER=\"${BROWSER_PATH}\"" >> $BASH_ENV
   emsdk-env:
     description: "emsdk_env.sh"
     steps:
@@ -342,13 +345,13 @@ commands:
         default: ""
     steps:
       - prepare-for-tests
-      - download-chrome
+      - install-browser:
+          browser_name: chrome@canary
       - run:
           name: run tests (<< parameters.title >>)
           environment:
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
             EMTEST_HEADLESS: "1"
-            EMTEST_BROWSER: "/usr/bin/google-chrome"
             EMTEST_CORES: "2"
           command: |
             # There are tests in the browser test suite that using libraries
@@ -382,18 +385,19 @@ commands:
         type: string
         default: ""
     steps:
-      - run:
-          name: download firefox
-          command: |
-            wget -O ~/ff.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
-            tar -C ~ -xf ~/ff.tar.bz2
+      - install-browser:
+          browser_name: firefox@nightly
       - run:
           name: Add audio dependencies
           command: |
             # This should add and start PulseAudio's dummy mixer. It will warn
             # that "This program is not intended to be run as root" but it can
             # be ignored.
-            pulseaudio --start
+            # (Use the presence of apt-get here to detect linux, where we don't
+            # want to run this elsewhere).
+            if which apt-get; then
+              pulseaudio --start
+            fi
       - run:
           name: run tests (<< parameters.title >>)
           environment:
@@ -409,7 +413,6 @@ commands:
             EMTEST_CORES: "2"
             DISPLAY: ":0"
           command: |
-            export EMTEST_BROWSER="$HOME/firefox/firefox"
             # There are tests in the browser test suite that using libraries
             # that are not included by "./embuilder build ALL".  For example the
             # PIC version of libSDL which is used by test_sdl2_misc_main_module
@@ -422,92 +425,18 @@ commands:
             #  "Firefox is already running, but is not responding."
             # TODO: find out a way to shut down and restart firefox
       - upload-test-results
-  run-tests-firefox-windows:
-    description: "Runs emscripten tests under firefox on Windows"
-    parameters:
-      test_targets:
-        description: "Test suites to run"
-        type: string
-      title:
-        description: "Name of given test suite"
-        type: string
-        default: ""
-    steps:
-      - run:
-          name: download firefox
-          shell: powershell.exe -ExecutionPolicy Bypass
-          command: |
-            $ErrorActionPreference = 'Stop'
-
-            # To download Firefox, we must first figure out what the latest Firefox version name is.
-            # This is because there does not exist a stable/static URL to download latest Firefox from.
-            $html = Invoke-WebRequest "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/"
-            $zipLink = $html.Links |
-              Where-Object { $_.href -match "firefox-.*\.en-US\.win64\.zip$" } |
-              Select-Object -Last 1 -ExpandProperty href
-
-            # Download Win64 Firefox.
-            $nightlyUrl = "https://archive.mozilla.org$zipLink"
-            $outZip = "$env:TEMP\firefox_nightly.zip"
-
-            Write-Host "Downloading latest Firefox Nightly: $nightlyUrl"
-            Invoke-WebRequest -Uri $nightlyUrl -OutFile $outZip
-
-            # Extract to user home directory
-            Write-Host "Extracing $outZip"
-            $installDir = Join-Path $env:USERPROFILE "firefox"
-            if (Test-Path $installDir) { Remove-Item -Recurse -Force $installDir }
-            # All files in the archive are in the firefox/ directory so extract
-            # directly to $USERPROFILE.
-            Expand-Archive -LiteralPath $outZip -DestinationPath $env:USERPROFILE
-
-            # FIXME(sbc): This does not seem to work, and EMTEST_BROWSER is
-            # not set in the bash job below.
-            # Set environment variable that will be visibvle in future steps
-            #$ffExe = Join-Path $installDir "firefox.exe"
-            #Write-Host "Setting EMTEST_BROWSER to '$ffExe' in $env:BASH_ENV"
-            #Add-Content -Path $env:BASH_ENV -Value "export EMTEST_BROWSER='$ffExe'"
-      - run:
-          name: run tests (<< parameters.title >>)
-          environment:
-            EMTEST_LACKS_GRAPHICS_HARDWARE: "1"
-            # TODO(https://github.com/emscripten-core/emscripten/issues/24205)
-            EMTEST_LACKS_SOUND_HARDWARE: "1"
-            EMTEST_LACKS_WEBGPU: "1"
-            EMTEST_DETECT_TEMPFILE_LEAKS: "0"
-            EMTEST_HEADLESS: "1"
-            EMTEST_CORES: "2"
-            DISPLAY: ":0"
-          command: |
-            # For some reason its not possible for the powershell job above to
-            # add to BASH_ENV, so we need set this here
-            export EMTEST_BROWSER="$USERPROFILE\\firefox\\firefox.exe"
-
-            # There are tests in the browser test suite that using libraries
-            # that are not included by "./embuilder build ALL".  For example the
-            # PIC version of libSDL which is used by test_sdl2_misc_main_module
-            export EM_FROZEN_CACHE=
-
-            echo "BASH_ENV($BASH_ENV):"
-            echo "-----"
-            cat $BASH_ENV
-            echo "-----"
-            echo "Running browser tests (EMTEST_BROWSER=$EMTEST_BROWSER)"
-            echo "-----"
-            test/runner << parameters.test_targets >>
-      - upload-test-results
   test-sockets-chrome:
     description: "Runs emscripten sockets tests under chrome"
     steps:
       - prepare-for-tests
-      - download-chrome
+      - install-browser:
+          browser_name: chrome@canary
       - run:
           name: run sockets tests
           environment:
             EMTEST_LACKS_SOUND_HARDWARE: "1"
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
             EMTEST_HEADLESS: "1"
-            EMTEST_BROWSER: "/usr/bin/google-chrome"
             EMTEST_CORES: "2"
           command: |
             test/runner sockets
@@ -1218,7 +1147,7 @@ jobs:
       - install-emsdk
       - pip-install:
           python: "$EMSDK_PYTHON"
-      - run-tests-firefox-windows:
+      - run-tests-firefox:
           title: "browser on firefox on windows"
           # skip browser.test_glbook, as it requires mingw32-make, which is not
           # installed on CircleCI.


### PR DESCRIPTION
This simplifies the windows firefox installation a lot and means we can completely delete `run-tests-firefox-windows`.

This also means we are using chrome-for-testing.

See https://developer.chrome.com/blog/chrome-for-testing