### PR TITLE
[wasm64] Keep nfds_t 32-bit. NFC

### DIFF
--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
@@ -869,7 +869,7 @@ struct __sanitizer_pollfd {
   short revents;
 };
 
-#  if SANITIZER_ANDROID || SANITIZER_APPLE
+#  if SANITIZER_ANDROID || SANITIZER_APPLE || SANITIZER_EMSCRIPTEN
 typedef unsigned __sanitizer_nfds_t;
 #  else
 typedef unsigned long __sanitizer_nfds_t;

--- a/system/lib/libc/musl/include/poll.h
+++ b/system/lib/libc/musl/include/poll.h
@@ -26,7 +26,8 @@ extern "C" {
 #define POLLRDHUP  0x2000
 #endif
 
-typedef unsigned long nfds_t;
+// XXX Emscripten: nfds_t is kept 32-bit even on wasm64.
+typedef unsigned int nfds_t;
 
 struct pollfd {
 	int fd;


### PR DESCRIPTION
Use unsigned int for nfds_t instead of unsigned long.

The number of file descriptors is already limited to 4096 (see
`WASMFS_FD_MAX` or `FS.MAX_OPEN_FDS`), so a 64-bit nfds_t provides
no benefit.

Split out from #27108.