### PR TITLE
Simplify `run` function, removing reentrancy

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -35,6 +35,11 @@ See docs/process.md for more on how version tagging works.
   supported. (#23493)
 - Fixed `getentropy`/`random_get` spuriously failing under Node.js and the
   shell environment for small requests. (#27122)
+- The startup process for the generated program now makes use of `async` /
+  `await` under more circumstances (specifically when using `setStatus`, or
+  run dependencies). This means that errors during startup (or during the
+  `main()` function) will more often show up as unhandled promise rejections
+  (`onunhandledreject`) rather than synchronous errors (`onerror`). (#27121)
 
 6.0.0 - 06/04/26
 ----------------

--- a/src/cpuprofiler.js
+++ b/src/cpuprofiler.js
@@ -742,13 +742,13 @@ setInterval = (fn, delay) => {
 // Hook into setTimeout to be able to capture the time spent executing them.
 emscriptenCpuProfiler.createSection(3, 'setTimeout', emscriptenCpuProfiler.colorSetTimeoutSection, /*traceable=*/true);
 var realSetTimeout = setTimeout;
-setTimeout = (fn, delay) => {
-  function wrappedSetTimeout() {
+setTimeout = (fn, delay, ...args) => {
+  function wrappedSetTimeout(...args) {
     emscriptenCpuProfiler.enterSection(3);
-    fn();
+    fn(...args);
     emscriptenCpuProfiler.endSection(3);
   };
-  return realSetTimeout(wrappedSetTimeout, delay);
+  return realSetTimeout(wrappedSetTimeout, delay, ...args);
 }
 
 // Backwards compatibility with previously compiled code. Don't call this anymore!

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -114,7 +114,12 @@ function stackCheckInit() {
 }
 #endif
 
-{{{ asyncIf(MODULARIZE) }}}function run({{{ MAIN_READS_PARAMS ? 'args = programArgs' : '' }}}) {
+{{{ asyncIf(MODULARIZE || ASYNCIFY == 2 || expectToReceiveOnModule('setStatus') || '$runDependencies' in addedLibraryItems) }}}function run({{{ MAIN_READS_PARAMS ? 'args = programArgs' : '' }}}) {
+#if ASSERTIONS
+  assert(!calledRun);
+  calledRun = true;
+#endif
+
 #if PTHREADS || WASM_WORKERS
   if ({{{ ENVIRONMENT_IS_WORKER_THREAD() }}}) {
     initRuntime();
@@ -131,80 +136,51 @@ function stackCheckInit() {
 #if '$runDependencies' in addedLibraryItems
   if (runDependencies > 0) {
 #if RUNTIME_DEBUG
-    dbg('run() called, but dependencies remain, so not running');
+    dbg('run: waiting on runDependencies');
 #endif
-#if MODULARIZE
     await new Promise((resolve) => dependenciesFulfilled = resolve);
-#else
-    dependenciesFulfilled = run;
-    return;
-#endif
   }
 #endif
 
-  {{{ asyncIf(ASYNCIFY == 2) }}}function doRun() {
-    // run may have just been called through dependencies being fulfilled just in this very frame,
-    // or while the async setStatus time below was happening
-#if ASSERTIONS
-    assert(!calledRun);
-    calledRun = true;
+#if expectToReceiveOnModule('setStatus')
+  var setStatus = Module['setStatus'];
+  if (setStatus) {
+    setStatus('Running...');
+    // Yield to the event loop to allow the browser to paint "Running..."
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    // Then we want to clear the status text, but only after the rest of this function runs.
+    setTimeout(setStatus, 1, '');
+  }
 #endif
 
-    if (ABORT) return;
+  if (ABORT) return;
 
-    initRuntime();
+  initRuntime();
 
 #if HAS_MAIN
-    preMain();
+  preMain();
 #endif
 
 #if expectToReceiveOnModule('onRuntimeInitialized')
-    Module['onRuntimeInitialized']?.();
+  Module['onRuntimeInitialized']?.();
 #if ASSERTIONS
-    consumedModuleProp('onRuntimeInitialized');
+  consumedModuleProp('onRuntimeInitialized');
 #endif
 #endif
 
 #if HAS_MAIN
-    var noInitialRun = {{{ makeModuleReceiveExpr('noInitialRun', !INVOKE_RUN) }}};
+  var noInitialRun = {{{ makeModuleReceiveExpr('noInitialRun', !INVOKE_RUN) }}};
 #if MAIN_READS_PARAMS
-    if (!noInitialRun) {{{ awaitIf(ASYNCIFY == 2) }}}callMain(args);
+  if (!noInitialRun) {{{ awaitIf(ASYNCIFY == 2) }}}callMain(args);
 #else
-    if (!noInitialRun) {{{ awaitIf(ASYNCIFY == 2) }}}callMain();
+  if (!noInitialRun) {{{ awaitIf(ASYNCIFY == 2) }}}callMain();
 #endif
-#else
-#if ASSERTIONS
-    assert(!Module['_main'], 'compiled without a main, but one is present. if you added it from JS, use Module["onRuntimeInitialized"]');
-#endif // ASSERTIONS
+#elif ASSERTIONS
+  assert(!Module['_main'], 'compiled without a main, but one is present. if you added it from JS, use Module["onRuntimeInitialized"]');
 #endif // HAS_MAIN
 
-    postRun();
-  }
+  postRun();
 
-#if expectToReceiveOnModule('setStatus')
-  if (Module['setStatus']) {
-    Module['setStatus']('Running...');
-    // Yield the main thread to allow the browser to paint "Running...", then clear
-    // the status text after the synchronous doRun() completes.
-#if MODULARIZE
-    await new Promise((resolve) => {
-      setTimeout(() => {
-        setTimeout(() => Module['setStatus'](''), 1);
-        doRun();
-        resolve();
-      }, 1);
-    });
-#else
-    setTimeout(() => {
-      setTimeout(() => Module['setStatus'](''), 1);
-      doRun();
-    }, 1);
-#endif
-  } else
-#endif
-  {
-    doRun();
-  }
 #if STACK_OVERFLOW_CHECK
   checkStackCookie();
 #endif

--- a/test/browser/test_async_bad_list.c
+++ b/test/browser/test_async_bad_list.c
@@ -9,8 +9,9 @@
 int main() {
   int x = EM_ASM_INT({
     globalThis.disableErrorReporting = true;
-    window.onerror = async (e) => {
-      var message = e.toString();
+    var checkError = (err) => {
+      if (!err) return;
+      var message = err.toString();
       var success = message.indexOf("unreachable") >= 0 || // firefox
                     message.indexOf("Script error.") >= 0; // chrome
       if (success && !Module.reported) {
@@ -19,6 +20,12 @@ int main() {
         // manually REPORT_RESULT; we shouldn't call back into native code at this point
         reportResultToServer(0);
       }
+    };
+    window.onerror = (message, source, lineno, colno, error) => {
+      checkError(error || message);
+    };
+    window.onunhandledrejection = (e) => {
+      checkError(e.reason);
     };
     return 0;
   });

--- a/test/browser/test_async_returnvalue.c
+++ b/test/browser/test_async_returnvalue.c
@@ -30,12 +30,20 @@ int main() {
 #ifdef BAD
   EM_ASM({
     globalThis.disableErrorReporting = true;
-    window.onerror = async (e) => {
-      var success = e.toString().indexOf("import sync_tunnel was not in ASYNCIFY_IMPORTS, but changed the state") > 0;
+    var checkError = (err) => {
+      if (!err) return;
+      var str = err.toString();
+      var success = str.indexOf("import sync_tunnel was not in ASYNCIFY_IMPORTS, but changed the state") > 0;
       if (success) {
         console.log("reporting success");
         maybeReportResultToServer(0);
       }
+    };
+    window.onerror = (message, source, lineno, colno, error) => {
+      checkError(error || message);
+    };
+    window.onunhandledrejection = (e) => {
+      checkError(e.reason);
     };
   });
 #endif

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19181,
-  "a.out.js.gz": 7935,
+  "a.out.js": 19218,
+  "a.out.js.gz": 7948,
   "a.out.nodebug.wasm": 132666,
   "a.out.nodebug.wasm.gz": 49962,
-  "total": 151847,
-  "total_gz": 57897,
+  "total": 151884,
+  "total_gz": 57910,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19158,
-  "a.out.js.gz": 7919,
+  "a.out.js": 19195,
+  "a.out.js.gz": 7932,
   "a.out.nodebug.wasm": 132092,
   "a.out.nodebug.wasm.gz": 49625,
-  "total": 151250,
-  "total_gz": 57544,
+  "total": 151287,
+  "total_gz": 57557,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23155,
-  "a.out.js.gz": 8922,
+  "a.out.js": 23191,
+  "a.out.js.gz": 8939,
   "a.out.nodebug.wasm": 172586,
   "a.out.nodebug.wasm.gz": 57501,
-  "total": 195741,
-  "total_gz": 66423,
+  "total": 195777,
+  "total_gz": 66440,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18980,
-  "a.out.js.gz": 7854,
+  "a.out.js": 19017,
+  "a.out.js.gz": 7872,
   "a.out.nodebug.wasm": 147991,
   "a.out.nodebug.wasm.gz": 55370,
-  "total": 166971,
-  "total_gz": 63224,
+  "total": 167008,
+  "total_gz": 63242,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19058,
-  "a.out.js.gz": 7878,
+  "a.out.js": 19095,
+  "a.out.js.gz": 7894,
   "a.out.nodebug.wasm": 145797,
   "a.out.nodebug.wasm.gz": 54992,
-  "total": 164855,
-  "total_gz": 62870,
+  "total": 164892,
+  "total_gz": 62886,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18521,
-  "a.out.js.gz": 7624,
+  "a.out.js": 18557,
+  "a.out.js.gz": 7638,
   "a.out.nodebug.wasm": 102168,
   "a.out.nodebug.wasm.gz": 39572,
-  "total": 120689,
-  "total_gz": 47196,
+  "total": 120725,
+  "total_gz": 47210,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23205,
-  "a.out.js.gz": 8945,
+  "a.out.js": 23241,
+  "a.out.js.gz": 8961,
   "a.out.nodebug.wasm": 239015,
   "a.out.nodebug.wasm.gz": 79854,
-  "total": 262220,
-  "total_gz": 88799,
+  "total": 262256,
+  "total_gz": 88815,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19181,
-  "a.out.js.gz": 7935,
+  "a.out.js": 19218,
+  "a.out.js.gz": 7948,
   "a.out.nodebug.wasm": 134666,
   "a.out.nodebug.wasm.gz": 50806,
-  "total": 153847,
-  "total_gz": 58741,
+  "total": 153884,
+  "total_gz": 58754,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_wasmfs.json
+++ b/test/codesize/test_codesize_cxx_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 6919,
-  "a.out.js.gz": 3244,
+  "a.out.js": 6938,
+  "a.out.js.gz": 3259,
   "a.out.nodebug.wasm": 172803,
   "a.out.nodebug.wasm.gz": 63374,
-  "total": 179722,
-  "total_gz": 66618,
+  "total": 179741,
+  "total_gz": 66633,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -3178,25 +3178,17 @@ function callMain() {
   }
 }
 
-function run() {
+async function run() {
   preRun();
   if (runDependencies > 0) {
-    dependenciesFulfilled = run;
-    return;
+    await new Promise(resolve => dependenciesFulfilled = resolve);
   }
-  function doRun() {
-    // run may have just been called through dependencies being fulfilled just in this very frame,
-    // or while the async setStatus time below was happening
-    if (ABORT) return;
-    initRuntime();
-    preMain();
-    var noInitialRun = false;
-    if (!noInitialRun) callMain();
-    postRun();
-  }
-  {
-    doRun();
-  }
+  if (ABORT) return;
+  initRuntime();
+  preMain();
+  var noInitialRun = false;
+  if (!noInitialRun) callMain();
+  postRun();
 }
 
 var wasmExports;

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22083,
-  "a.out.js.gz": 9166,
+  "a.out.js": 22157,
+  "a.out.js.gz": 9192,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 23749,
-  "total_gz": 10111,
+  "total": 23823,
+  "total_gz": 10137,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_files_js_fs.json
+++ b/test/codesize/test_codesize_files_js_fs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 17829,
-  "a.out.js.gz": 7275,
+  "a.out.js": 17866,
+  "a.out.js.gz": 7289,
   "a.out.nodebug.wasm": 381,
   "a.out.nodebug.wasm.gz": 260,
-  "total": 18210,
-  "total_gz": 7535,
+  "total": 18247,
+  "total_gz": 7549,
   "sent": [
     "a (fd_write)",
     "b (fd_read)",

--- a/test/codesize/test_codesize_files_wasmfs.json
+++ b/test/codesize/test_codesize_files_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 5353,
-  "a.out.js.gz": 2515,
+  "a.out.js": 5372,
+  "a.out.js.gz": 2527,
   "a.out.nodebug.wasm": 58520,
   "a.out.nodebug.wasm.gz": 18225,
-  "total": 63873,
-  "total_gz": 20740,
+  "total": 63892,
+  "total_gz": 20752,
   "sent": [
     "a (emscripten_date_now)",
     "b (emscripten_err)",

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23514,
-  "a.out.js.gz": 8493,
+  "a.out.js": 23425,
+  "a.out.js.gz": 8505,
   "a.out.nodebug.wasm": 15115,
   "a.out.nodebug.wasm.gz": 7464,
-  "total": 38629,
-  "total_gz": 15957,
+  "total": 38540,
+  "total_gz": 15969,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O1.json
+++ b/test/codesize/test_codesize_hello_O1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 6142,
-  "a.out.js.gz": 2375,
+  "a.out.js": 6081,
+  "a.out.js.gz": 2373,
   "a.out.nodebug.wasm": 2544,
   "a.out.nodebug.wasm.gz": 1436,
-  "total": 8686,
-  "total_gz": 3811,
+  "total": 8625,
+  "total_gz": 3809,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O2.json
+++ b/test/codesize/test_codesize_hello_O2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4204,
-  "a.out.js.gz": 2061,
+  "a.out.js": 4224,
+  "a.out.js.gz": 2073,
   "a.out.nodebug.wasm": 1912,
   "a.out.nodebug.wasm.gz": 1129,
-  "total": 6116,
-  "total_gz": 3190,
+  "total": 6136,
+  "total_gz": 3202,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O3.json
+++ b/test/codesize/test_codesize_hello_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4146,
-  "a.out.js.gz": 2018,
+  "a.out.js": 4166,
+  "a.out.js.gz": 2034,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 5812,
-  "total_gz": 2963,
+  "total": 5832,
+  "total_gz": 2979,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_Os.json
+++ b/test/codesize/test_codesize_hello_Os.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4146,
-  "a.out.js.gz": 2018,
+  "a.out.js": 4166,
+  "a.out.js.gz": 2034,
   "a.out.nodebug.wasm": 1654,
   "a.out.nodebug.wasm.gz": 953,
-  "total": 5800,
-  "total_gz": 2971,
+  "total": 5820,
+  "total_gz": 2987,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_Oz.json
+++ b/test/codesize/test_codesize_hello_Oz.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3785,
-  "a.out.js.gz": 1825,
+  "a.out.js": 3801,
+  "a.out.js.gz": 1840,
   "a.out.nodebug.wasm": 1188,
   "a.out.nodebug.wasm.gz": 731,
-  "total": 4973,
-  "total_gz": 2556,
+  "total": 4989,
+  "total_gz": 2571,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26254,
-  "a.out.js.gz": 11174,
+  "a.out.js": 26271,
+  "a.out.js.gz": 11190,
   "a.out.nodebug.wasm": 17861,
   "a.out.nodebug.wasm.gz": 9019,
-  "total": 44115,
-  "total_gz": 20193,
+  "total": 44132,
+  "total_gz": 20209,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268210,
+  "a.out.js": 268255,
   "a.out.nodebug.wasm": 587588,
-  "total": 855798,
+  "total": 855843,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_hello_export_nothing.json
+++ b/test/codesize/test_codesize_hello_export_nothing.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3061,
-  "a.out.js.gz": 1413,
+  "a.out.js": 3059,
+  "a.out.js.gz": 1422,
   "a.out.nodebug.wasm": 43,
   "a.out.nodebug.wasm.gz": 59,
-  "total": 3104,
-  "total_gz": 1472,
+  "total": 3102,
+  "total_gz": 1481,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_hello_single_file.json
+++ b/test/codesize/test_codesize_hello_single_file.json
@@ -1,6 +1,6 @@
 {
-  "a.out.js": 5123,
-  "a.out.js.gz": 2813,
+  "a.out.js": 5141,
+  "a.out.js.gz": 2827,
   "sent": [
     "a (fd_write)"
   ]

--- a/test/codesize/test_codesize_hello_wasmfs.json
+++ b/test/codesize/test_codesize_hello_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4146,
-  "a.out.js.gz": 2018,
+  "a.out.js": 4166,
+  "a.out.js.gz": 2034,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 5812,
-  "total_gz": 2963,
+  "total": 5832,
+  "total_gz": 2979,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_libcxxabi_message_O3.json
+++ b/test/codesize/test_codesize_libcxxabi_message_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3412,
-  "a.out.js.gz": 1594,
+  "a.out.js": 3428,
+  "a.out.js.gz": 1608,
   "a.out.nodebug.wasm": 89,
   "a.out.nodebug.wasm.gz": 98,
-  "total": 3501,
-  "total_gz": 1692,
+  "total": 3517,
+  "total_gz": 1706,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_libcxxabi_message_O3_standalone.json
+++ b/test/codesize/test_codesize_libcxxabi_message_O3_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3459,
-  "a.out.js.gz": 1628,
+  "a.out.js": 3475,
+  "a.out.js.gz": 1644,
   "a.out.nodebug.wasm": 222,
   "a.out.nodebug.wasm.gz": 206,
-  "total": 3681,
-  "total_gz": 1834,
+  "total": 3697,
+  "total_gz": 1850,
   "sent": [
     "proc_exit"
   ],

--- a/test/codesize/test_codesize_mem_O3.json
+++ b/test/codesize/test_codesize_mem_O3.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4241,
-  "a.out.js.gz": 2026,
+  "a.out.js.gz": 2031,
   "a.out.nodebug.wasm": 5260,
   "a.out.nodebug.wasm.gz": 2419,
   "total": 9501,
-  "total_gz": 4445,
+  "total_gz": 4450,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/codesize/test_codesize_mem_O3_grow.json
+++ b/test/codesize/test_codesize_mem_O3_grow.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 4526,
-  "a.out.js.gz": 2183,
+  "a.out.js.gz": 2185,
   "a.out.nodebug.wasm": 5261,
   "a.out.nodebug.wasm.gz": 2419,
   "total": 9787,
-  "total_gz": 4602,
+  "total_gz": 4604,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/codesize/test_codesize_mem_O3_grow_standalone.json
+++ b/test/codesize/test_codesize_mem_O3_grow_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3997,
-  "a.out.js.gz": 1923,
+  "a.out.js": 3995,
+  "a.out.js.gz": 1927,
   "a.out.nodebug.wasm": 5641,
   "a.out.nodebug.wasm.gz": 2659,
-  "total": 9638,
-  "total_gz": 4582,
+  "total": 9636,
+  "total_gz": 4586,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/codesize/test_codesize_mem_O3_standalone.json
+++ b/test/codesize/test_codesize_mem_O3_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3930,
-  "a.out.js.gz": 1883,
+  "a.out.js": 3928,
+  "a.out.js.gz": 1890,
   "a.out.nodebug.wasm": 5565,
   "a.out.nodebug.wasm.gz": 2598,
-  "total": 9495,
-  "total_gz": 4481,
+  "total": 9493,
+  "total_gz": 4488,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/codesize/test_codesize_mem_O3_standalone_lib.json
+++ b/test/codesize/test_codesize_mem_O3_standalone_lib.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3452,
-  "a.out.js.gz": 1622,
+  "a.out.js": 3468,
+  "a.out.js.gz": 1635,
   "a.out.nodebug.wasm": 5239,
   "a.out.nodebug.wasm.gz": 2359,
-  "total": 8691,
-  "total_gz": 3981,
+  "total": 8707,
+  "total_gz": 3994,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_mem_O3_standalone_narg.json
+++ b/test/codesize/test_codesize_mem_O3_standalone_narg.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3459,
-  "a.out.js.gz": 1628,
+  "a.out.js": 3475,
+  "a.out.js.gz": 1644,
   "a.out.nodebug.wasm": 5354,
   "a.out.nodebug.wasm.gz": 2442,
-  "total": 8813,
-  "total_gz": 4070,
+  "total": 8829,
+  "total_gz": 4086,
   "sent": [
     "proc_exit"
   ],

--- a/test/codesize/test_codesize_mem_O3_standalone_narg_flto.json
+++ b/test/codesize/test_codesize_mem_O3_standalone_narg_flto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3459,
-  "a.out.js.gz": 1628,
+  "a.out.js": 3475,
+  "a.out.js.gz": 1644,
   "a.out.nodebug.wasm": 4285,
   "a.out.nodebug.wasm.gz": 2142,
-  "total": 7744,
-  "total_gz": 3770,
+  "total": 7760,
+  "total_gz": 3786,
   "sent": [
     "proc_exit"
   ],

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -1335,29 +1335,21 @@ function stackCheckInit() {
 }
 
 function run() {
+  assert(!calledRun);
+  calledRun = true;
 
   stackCheckInit();
 
   preRun();
 
-  function doRun() {
-    // run may have just been called through dependencies being fulfilled just in this very frame,
-    // or while the async setStatus time below was happening
-    assert(!calledRun);
-    calledRun = true;
+  if (ABORT) return;
 
-    if (ABORT) return;
+  initRuntime();
 
-    initRuntime();
+  assert(!Module['_main'], 'compiled without a main, but one is present. if you added it from JS, use Module["onRuntimeInitialized"]');
 
-    assert(!Module['_main'], 'compiled without a main, but one is present. if you added it from JS, use Module["onRuntimeInitialized"]');
+  postRun();
 
-    postRun();
-  }
-
-  {
-    doRun();
-  }
   checkStackCookie();
 }
 

--- a/test/codesize/test_codesize_minimal_O0.json
+++ b/test/codesize/test_codesize_minimal_O0.json
@@ -1,9 +1,9 @@
 {
-  "a.out.js": 18667,
+  "a.out.js": 18665,
   "a.out.js.gz": 6759,
   "a.out.nodebug.wasm": 1015,
   "a.out.nodebug.wasm.gz": 602,
-  "total": 19682,
+  "total": 19680,
   "total_gz": 7361,
   "sent": [],
   "imports": [],

--- a/test/codesize/test_small_js_flags.expected.js
+++ b/test/codesize/test_small_js_flags.expected.js
@@ -441,19 +441,12 @@ function callMain() {
 
 function run() {
   preRun();
-  function doRun() {
-    // run may have just been called through dependencies being fulfilled just in this very frame,
-    // or while the async setStatus time below was happening
-    if (ABORT) return;
-    initRuntime();
-    preMain();
-    var noInitialRun = false;
-    if (!noInitialRun) callMain();
-    postRun();
-  }
-  {
-    doRun();
-  }
+  if (ABORT) return;
+  initRuntime();
+  preMain();
+  var noInitialRun = false;
+  if (!noInitialRun) callMain();
+  postRun();
 }
 
 var wasmExports;

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 55387,
-  "hello_world.js.gz": 17453,
+  "hello_world.js": 55193,
+  "hello_world.js.gz": 17384,
   "hello_world.wasm": 15115,
   "hello_world.wasm.gz": 7464,
-  "no_asserts.js": 25871,
-  "no_asserts.js.gz": 8759,
+  "no_asserts.js": 25683,
+  "no_asserts.js.gz": 8690,
   "no_asserts.wasm": 12229,
   "no_asserts.wasm.gz": 6004,
-  "strict.js": 53144,
-  "strict.js.gz": 16681,
+  "strict.js": 52921,
+  "strict.js.gz": 16589,
   "strict.wasm": 15115,
   "strict.wasm.gz": 7461,
-  "total": 176861,
-  "total_gz": 63822
+  "total": 176256,
+  "total_gz": 63592
 }

--- a/test/emscripten_throw_number_pre.js
+++ b/test/emscripten_throw_number_pre.js
@@ -1,5 +1,13 @@
-addEventListener('error', (event) => {
+function handleThrow(value) {
   globalThis.disableErrorReporting = true;
-  var result = event.error === 42 ? 0 : 1;
+  var result = value === 42 ? 0 : 1;
   fetch('/report_result?' + result);
+}
+
+addEventListener('error', (event) => {
+  handleThrow(event.error);
+});
+
+addEventListener('unhandledrejection', (event) => {
+  handleThrow(event.reason);
 });

--- a/test/emscripten_throw_string_pre.js
+++ b/test/emscripten_throw_string_pre.js
@@ -1,5 +1,11 @@
-addEventListener('error', (event) => {
+function handle(error) {
   globalThis.disableErrorReporting = true;
-  var result = event.error === 'Hello!' ? 0 : 1;
+  var result = error === 'Hello!' ? 0 : 1;
   fetch('/report_result?' + result);
+}
+addEventListener('error', (event) => {
+  handle(event.error);
+});
+addEventListener('unhandledrejection', (event) => {
+  handle(event.reason);
 });


### PR DESCRIPTION
The `run` function was historically re-entered in certain cases. For
example, if there are run blockers, or to allow `setStatus` to render
a frame.

However, it was bimodal, using reentrancy in some cases and `await`
in otherwise cases (specifically in the `-sMODUALRIZE` case).

This change removes the reentrancy completely and uses `async` /
`await` in all the cases that previously used it.

This cleans up the code significantly, flattening in out and removing
the inner `doRun` helper function.

This does some with some minor codesize regressions, for using the
`async` / `await` / `new Promise` primitives, but these only apply
in certain cases.  For programs that don't include `setStatus` in their
`INCOMING_MODULE_JS_API` or use any run dependencies there is no
overhead.

Note that some tests that were expecting errors to show up in an `onerror`
handler were updated to also handle `unhandledrejection`.  This is a normal
consequence of making more use of async / await.

The following (37) test expectation files were updated by
running the tests with `--rebaseline`:

```
codesize/test_codesize_cxx_ctors1.json: 151801 => 151838 [+37 bytes / +0.02%]
codesize/test_codesize_cxx_ctors2.json: 151204 => 151241 [+37 bytes / +0.02%]
codesize/test_codesize_cxx_except.json: 195695 => 195731 [+36 bytes / +0.02%]
codesize/test_codesize_cxx_except_wasm.json: 166925 => 166962 [+37 bytes / +0.02%]
codesize/test_codesize_cxx_except_wasm_legacy.json: 164809 => 164846 [+37 bytes / +0.02%]
codesize/test_codesize_cxx_lto.json: 120628 => 120664 [+36 bytes / +0.03%]
codesize/test_codesize_cxx_mangle.json: 262174 => 262210 [+36 bytes / +0.01%]
codesize/test_codesize_cxx_noexcept.json: 153801 => 153838 [+37 bytes / +0.02%]
codesize/test_codesize_cxx_wasmfs.json: 179676 => 179695 [+19 bytes / +0.01%]
test/codesize/test_codesize_file_preload.expected.js updated
codesize/test_codesize_file_preload.json: 23749 => 23823 [+74 bytes / +0.31%]
codesize/test_codesize_files_js_fs.json: 18210 => 18247 [+37 bytes / +0.20%]
codesize/test_codesize_files_wasmfs.json: 63873 => 63892 [+19 bytes / +0.03%]
codesize/test_codesize_hello_O0.json: 38629 => 38540 [-89 bytes / -0.23%]
codesize/test_codesize_hello_O1.json: 8686 => 8625 [-61 bytes / -0.70%]
codesize/test_codesize_hello_O2.json: 6116 => 6136 [+20 bytes / +0.33%]
codesize/test_codesize_hello_O3.json: 5812 => 5832 [+20 bytes / +0.34%]
codesize/test_codesize_hello_Os.json: 5800 => 5820 [+20 bytes / +0.34%]
codesize/test_codesize_hello_Oz.json: 4973 => 4989 [+16 bytes / +0.32%]
codesize/test_codesize_hello_dylink.json: 44115 => 44132 [+17 bytes / +0.04%]
codesize/test_codesize_hello_dylink_all.json: 855713 => 855758 [+45 bytes / +0.01%]
codesize/test_codesize_hello_export_nothing.json: 3104 => 3102 [-2 bytes / -0.06%]
codesize/test_codesize_hello_single_file.json: 5123 => 5141 [+18 bytes / +0.35%]
codesize/test_codesize_hello_wasmfs.json: 5812 => 5832 [+20 bytes / +0.34%]
codesize/test_codesize_libcxxabi_message_O3.json: 3501 => 3517 [+16 bytes / +0.46%]
codesize/test_codesize_libcxxabi_message_O3_standalone.json: 3681 => 3697 [+16 bytes / +0.43%]
codesize/test_codesize_mem_O3.json: 9501 => 9501 [+0 bytes / +0.00%]
codesize/test_codesize_mem_O3_grow.json: 9787 => 9787 [+0 bytes / +0.00%]
codesize/test_codesize_mem_O3_grow_standalone.json: 9638 => 9636 [-2 bytes / -0.02%]
codesize/test_codesize_mem_O3_standalone.json: 9495 => 9493 [-2 bytes / -0.02%]
codesize/test_codesize_mem_O3_standalone_lib.json: 8691 => 8707 [+16 bytes / +0.18%]
codesize/test_codesize_mem_O3_standalone_narg.json: 8813 => 8829 [+16 bytes / +0.18%]
codesize/test_codesize_mem_O3_standalone_narg_flto.json: 7744 => 7760 [+16 bytes / +0.21%]
test/codesize/test_codesize_minimal_O0.expected.js updated
codesize/test_codesize_minimal_O0.json: 19682 => 19680 [-2 bytes / -0.01%]
test/codesize/test_small_js_flags.expected.js updated
codesize/test_unoptimized_code_size.json: 176861 => 176256 [-605 bytes / -0.34%]

Average change: +0.08% (-0.70% - +0.46%)
```
