### PR TITLE
Remove `calledRun` module property

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -66,7 +66,7 @@ addToLibrary({
   setTempRet0: '$setTempRet0',
   getTempRet0: '$getTempRet0',
 
-  // Used by the file_packager-generated code to detect if program has already
+  // Used by the file_packager-generated code to detect if the program has already
   // be started.
   $isInitialized: () => runtimeInitialized,
 

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -66,6 +66,10 @@ addToLibrary({
   setTempRet0: '$setTempRet0',
   getTempRet0: '$getTempRet0',
 
+  // Used by the file_packager-generated code to detect if program has already
+  // be started.
+  $isInitialized: () => runtimeInitialized,
+
   // Assign a name to a given function. This is mostly useful for debugging
   // purposes in cases where new functions are created at runtime.
   $createNamedFunction: (name, func) => Object.defineProperty(func, 'name', { value: name }),

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -165,7 +165,6 @@ function stackCheckInit() {
     assert(!calledRun);
     calledRun = true;
 #endif
-    Module['calledRun'] = true;
 
     if (ABORT) return;
 

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19196,
-  "a.out.js.gz": 7943,
+  "a.out.js": 19181,
+  "a.out.js.gz": 7935,
   "a.out.nodebug.wasm": 132666,
   "a.out.nodebug.wasm.gz": 49962,
-  "total": 151862,
-  "total_gz": 57905,
+  "total": 151847,
+  "total_gz": 57897,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19173,
-  "a.out.js.gz": 7930,
+  "a.out.js": 19158,
+  "a.out.js.gz": 7919,
   "a.out.nodebug.wasm": 132092,
   "a.out.nodebug.wasm.gz": 49625,
-  "total": 151265,
-  "total_gz": 57555,
+  "total": 151250,
+  "total_gz": 57544,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23170,
-  "a.out.js.gz": 8928,
+  "a.out.js": 23155,
+  "a.out.js.gz": 8922,
   "a.out.nodebug.wasm": 172586,
   "a.out.nodebug.wasm.gz": 57501,
-  "total": 195756,
-  "total_gz": 66429,
+  "total": 195741,
+  "total_gz": 66423,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18995,
-  "a.out.js.gz": 7862,
+  "a.out.js": 18980,
+  "a.out.js.gz": 7854,
   "a.out.nodebug.wasm": 147991,
   "a.out.nodebug.wasm.gz": 55370,
-  "total": 166986,
-  "total_gz": 63232,
+  "total": 166971,
+  "total_gz": 63224,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19073,
-  "a.out.js.gz": 7886,
+  "a.out.js": 19058,
+  "a.out.js.gz": 7878,
   "a.out.nodebug.wasm": 145797,
   "a.out.nodebug.wasm.gz": 54992,
-  "total": 164870,
-  "total_gz": 62878,
+  "total": 164855,
+  "total_gz": 62870,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18536,
-  "a.out.js.gz": 7636,
+  "a.out.js": 18521,
+  "a.out.js.gz": 7624,
   "a.out.nodebug.wasm": 102168,
   "a.out.nodebug.wasm.gz": 39572,
-  "total": 120704,
-  "total_gz": 47208,
+  "total": 120689,
+  "total_gz": 47196,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23220,
-  "a.out.js.gz": 8948,
+  "a.out.js": 23205,
+  "a.out.js.gz": 8945,
   "a.out.nodebug.wasm": 239015,
   "a.out.nodebug.wasm.gz": 79854,
-  "total": 262235,
-  "total_gz": 88802,
+  "total": 262220,
+  "total_gz": 88799,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19196,
-  "a.out.js.gz": 7943,
+  "a.out.js": 19181,
+  "a.out.js.gz": 7935,
   "a.out.nodebug.wasm": 134666,
   "a.out.nodebug.wasm.gz": 50806,
-  "total": 153862,
-  "total_gz": 58749,
+  "total": 153847,
+  "total_gz": 58741,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_wasmfs.json
+++ b/test/codesize/test_codesize_cxx_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 6934,
-  "a.out.js.gz": 3252,
+  "a.out.js": 6919,
+  "a.out.js.gz": 3244,
   "a.out.nodebug.wasm": 172677,
   "a.out.nodebug.wasm.gz": 63357,
-  "total": 179611,
-  "total_gz": 66609,
+  "total": 179596,
+  "total_gz": 66601,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -135,7 +135,7 @@ Module["expectedDataFileDownloads"]++;
       }
       await processPackageData(fetched);
     }
-    if (Module["calledRun"]) {
+    if (Module["isInitialized"]?.()) {
       runWithFS(Module);
     } else {
       if (!Module["preRun"]) Module["preRun"] = [];
@@ -3115,6 +3115,8 @@ var FS_createLazyFile = (...args) => FS.createLazyFile(...args);
 
 var FS_createDevice = (...args) => FS.createDevice(...args);
 
+var isInitialized = () => runtimeInitialized;
+
 FS.createPreloadedFile = FS_createPreloadedFile;
 
 FS.preloadFile = FS_preloadFile;
@@ -3128,6 +3130,8 @@ FS.staticInit();
 {}
 
 // Begin runtime exports
+Module["isInitialized"] = isInitialized;
+
 Module["addRunDependency"] = addRunDependency;
 
 Module["removeRunDependency"] = removeRunDependency;
@@ -3191,7 +3195,6 @@ function run() {
   function doRun() {
     // run may have just been called through dependencies being fulfilled just in this very frame,
     // or while the async setStatus time below was happening
-    Module["calledRun"] = true;
     if (ABORT) return;
     initRuntime();
     preMain();

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22112,
-  "a.out.js.gz": 9182,
+  "a.out.js": 22140,
+  "a.out.js.gz": 9196,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 23778,
-  "total_gz": 10127,
+  "total": 23806,
+  "total_gz": 10141,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_files_js_fs.json
+++ b/test/codesize/test_codesize_files_js_fs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 17844,
-  "a.out.js.gz": 7285,
+  "a.out.js": 17829,
+  "a.out.js.gz": 7275,
   "a.out.nodebug.wasm": 381,
   "a.out.nodebug.wasm.gz": 260,
-  "total": 18225,
-  "total_gz": 7545,
+  "total": 18210,
+  "total_gz": 7535,
   "sent": [
     "a (fd_write)",
     "b (fd_read)",

--- a/test/codesize/test_codesize_files_wasmfs.json
+++ b/test/codesize/test_codesize_files_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 5368,
-  "a.out.js.gz": 2526,
+  "a.out.js": 5353,
+  "a.out.js.gz": 2515,
   "a.out.nodebug.wasm": 58324,
   "a.out.nodebug.wasm.gz": 18215,
-  "total": 63692,
-  "total_gz": 20741,
+  "total": 63677,
+  "total_gz": 20730,
   "sent": [
     "a (emscripten_date_now)",
     "b (emscripten_err)",

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23344,
-  "a.out.js.gz": 8443,
+  "a.out.js": 23336,
+  "a.out.js.gz": 8439,
   "a.out.nodebug.wasm": 15115,
   "a.out.nodebug.wasm.gz": 7464,
-  "total": 38459,
-  "total_gz": 15907,
+  "total": 38451,
+  "total_gz": 15903,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O1.json
+++ b/test/codesize/test_codesize_hello_O1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 6164,
-  "a.out.js.gz": 2386,
+  "a.out.js": 6142,
+  "a.out.js.gz": 2375,
   "a.out.nodebug.wasm": 2544,
   "a.out.nodebug.wasm.gz": 1436,
-  "total": 8708,
-  "total_gz": 3822,
+  "total": 8686,
+  "total_gz": 3811,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O2.json
+++ b/test/codesize/test_codesize_hello_O2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4220,
-  "a.out.js.gz": 2070,
+  "a.out.js": 4204,
+  "a.out.js.gz": 2061,
   "a.out.nodebug.wasm": 1912,
   "a.out.nodebug.wasm.gz": 1129,
-  "total": 6132,
-  "total_gz": 3199,
+  "total": 6116,
+  "total_gz": 3190,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O3.json
+++ b/test/codesize/test_codesize_hello_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4161,
-  "a.out.js.gz": 2030,
+  "a.out.js": 4146,
+  "a.out.js.gz": 2018,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 5827,
-  "total_gz": 2975,
+  "total": 5812,
+  "total_gz": 2963,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_Os.json
+++ b/test/codesize/test_codesize_hello_Os.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4161,
-  "a.out.js.gz": 2030,
+  "a.out.js": 4146,
+  "a.out.js.gz": 2018,
   "a.out.nodebug.wasm": 1654,
   "a.out.nodebug.wasm.gz": 953,
-  "total": 5815,
-  "total_gz": 2983,
+  "total": 5800,
+  "total_gz": 2971,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_Oz.json
+++ b/test/codesize/test_codesize_hello_Oz.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3800,
-  "a.out.js.gz": 1836,
+  "a.out.js": 3785,
+  "a.out.js.gz": 1825,
   "a.out.nodebug.wasm": 1188,
   "a.out.nodebug.wasm.gz": 731,
-  "total": 4988,
-  "total_gz": 2567,
+  "total": 4973,
+  "total_gz": 2556,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26269,
-  "a.out.js.gz": 11182,
+  "a.out.js": 26254,
+  "a.out.js.gz": 11174,
   "a.out.nodebug.wasm": 17861,
   "a.out.nodebug.wasm.gz": 9019,
-  "total": 44130,
-  "total_gz": 20201,
+  "total": 44115,
+  "total_gz": 20193,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268245,
+  "a.out.js": 268230,
   "a.out.nodebug.wasm": 587640,
-  "total": 855885,
+  "total": 855870,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_hello_export_nothing.json
+++ b/test/codesize/test_codesize_hello_export_nothing.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3076,
-  "a.out.js.gz": 1423,
+  "a.out.js": 3061,
+  "a.out.js.gz": 1413,
   "a.out.nodebug.wasm": 43,
   "a.out.nodebug.wasm.gz": 59,
-  "total": 3119,
-  "total_gz": 1482,
+  "total": 3104,
+  "total_gz": 1472,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_hello_single_file.json
+++ b/test/codesize/test_codesize_hello_single_file.json
@@ -1,6 +1,6 @@
 {
-  "a.out.js": 5139,
-  "a.out.js.gz": 2826,
+  "a.out.js": 5123,
+  "a.out.js.gz": 2813,
   "sent": [
     "a (fd_write)"
   ]

--- a/test/codesize/test_codesize_hello_wasmfs.json
+++ b/test/codesize/test_codesize_hello_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4161,
-  "a.out.js.gz": 2030,
+  "a.out.js": 4146,
+  "a.out.js.gz": 2018,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 5827,
-  "total_gz": 2975,
+  "total": 5812,
+  "total_gz": 2963,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_libcxxabi_message_O3.json
+++ b/test/codesize/test_codesize_libcxxabi_message_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3427,
-  "a.out.js.gz": 1605,
+  "a.out.js": 3412,
+  "a.out.js.gz": 1594,
   "a.out.nodebug.wasm": 89,
   "a.out.nodebug.wasm.gz": 98,
-  "total": 3516,
-  "total_gz": 1703,
+  "total": 3501,
+  "total_gz": 1692,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_libcxxabi_message_O3_standalone.json
+++ b/test/codesize/test_codesize_libcxxabi_message_O3_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3474,
-  "a.out.js.gz": 1638,
+  "a.out.js": 3459,
+  "a.out.js.gz": 1628,
   "a.out.nodebug.wasm": 222,
   "a.out.nodebug.wasm.gz": 206,
-  "total": 3696,
-  "total_gz": 1844,
+  "total": 3681,
+  "total_gz": 1834,
   "sent": [
     "proc_exit"
   ],

--- a/test/codesize/test_codesize_mem_O3.json
+++ b/test/codesize/test_codesize_mem_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4256,
-  "a.out.js.gz": 2038,
+  "a.out.js": 4241,
+  "a.out.js.gz": 2026,
   "a.out.nodebug.wasm": 5260,
   "a.out.nodebug.wasm.gz": 2419,
-  "total": 9516,
-  "total_gz": 4457,
+  "total": 9501,
+  "total_gz": 4445,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/codesize/test_codesize_mem_O3_grow.json
+++ b/test/codesize/test_codesize_mem_O3_grow.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4541,
-  "a.out.js.gz": 2193,
+  "a.out.js": 4526,
+  "a.out.js.gz": 2183,
   "a.out.nodebug.wasm": 5261,
   "a.out.nodebug.wasm.gz": 2419,
-  "total": 9802,
-  "total_gz": 4612,
+  "total": 9787,
+  "total_gz": 4602,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/codesize/test_codesize_mem_O3_grow_standalone.json
+++ b/test/codesize/test_codesize_mem_O3_grow_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4012,
-  "a.out.js.gz": 1933,
+  "a.out.js": 3997,
+  "a.out.js.gz": 1923,
   "a.out.nodebug.wasm": 5641,
   "a.out.nodebug.wasm.gz": 2659,
-  "total": 9653,
-  "total_gz": 4592,
+  "total": 9638,
+  "total_gz": 4582,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/codesize/test_codesize_mem_O3_standalone.json
+++ b/test/codesize/test_codesize_mem_O3_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3945,
-  "a.out.js.gz": 1893,
+  "a.out.js": 3930,
+  "a.out.js.gz": 1883,
   "a.out.nodebug.wasm": 5565,
   "a.out.nodebug.wasm.gz": 2598,
-  "total": 9510,
-  "total_gz": 4491,
+  "total": 9495,
+  "total_gz": 4481,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/codesize/test_codesize_mem_O3_standalone_lib.json
+++ b/test/codesize/test_codesize_mem_O3_standalone_lib.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3468,
-  "a.out.js.gz": 1633,
+  "a.out.js": 3452,
+  "a.out.js.gz": 1622,
   "a.out.nodebug.wasm": 5239,
   "a.out.nodebug.wasm.gz": 2359,
-  "total": 8707,
-  "total_gz": 3992,
+  "total": 8691,
+  "total_gz": 3981,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_mem_O3_standalone_narg.json
+++ b/test/codesize/test_codesize_mem_O3_standalone_narg.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3474,
-  "a.out.js.gz": 1638,
+  "a.out.js": 3459,
+  "a.out.js.gz": 1628,
   "a.out.nodebug.wasm": 5354,
   "a.out.nodebug.wasm.gz": 2442,
-  "total": 8828,
-  "total_gz": 4080,
+  "total": 8813,
+  "total_gz": 4070,
   "sent": [
     "proc_exit"
   ],

--- a/test/codesize/test_codesize_mem_O3_standalone_narg_flto.json
+++ b/test/codesize/test_codesize_mem_O3_standalone_narg_flto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3474,
-  "a.out.js.gz": 1638,
+  "a.out.js": 3459,
+  "a.out.js.gz": 1628,
   "a.out.nodebug.wasm": 4285,
   "a.out.nodebug.wasm.gz": 2142,
-  "total": 7759,
-  "total_gz": 3780,
+  "total": 7744,
+  "total_gz": 3770,
   "sent": [
     "proc_exit"
   ],

--- a/test/codesize/test_codesize_minimal_64.json
+++ b/test/codesize/test_codesize_minimal_64.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2540,
-  "a.out.js.gz": 1210,
+  "a.out.js": 2525,
+  "a.out.js.gz": 1200,
   "a.out.nodebug.wasm": 75,
   "a.out.nodebug.wasm.gz": 88,
-  "total": 2615,
-  "total_gz": 1298,
+  "total": 2600,
+  "total_gz": 1288,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -861,6 +861,7 @@ Module['FS_createPreloadedFile'] = FS.createPreloadedFile;
   'stackAlloc',
   'getTempRet0',
   'setTempRet0',
+  'isInitialized',
   'createNamedFunction',
   'zeroMemory',
   'exitJS',
@@ -1329,7 +1330,6 @@ function run() {
     // or while the async setStatus time below was happening
     assert(!calledRun);
     calledRun = true;
-    Module['calledRun'] = true;
 
     if (ABORT) return;
 

--- a/test/codesize/test_codesize_minimal_O0.json
+++ b/test/codesize/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18687,
-  "a.out.js.gz": 6766,
+  "a.out.js": 18681,
+  "a.out.js.gz": 6763,
   "a.out.nodebug.wasm": 1015,
   "a.out.nodebug.wasm.gz": 602,
-  "total": 19702,
-  "total_gz": 7368,
+  "total": 19696,
+  "total_gz": 7365,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_O1.json
+++ b/test/codesize/test_codesize_minimal_O1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2947,
-  "a.out.js.gz": 1248,
+  "a.out.js": 2927,
+  "a.out.js.gz": 1237,
   "a.out.nodebug.wasm": 449,
   "a.out.nodebug.wasm.gz": 337,
-  "total": 3396,
-  "total_gz": 1585,
+  "total": 3376,
+  "total_gz": 1574,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_O2.json
+++ b/test/codesize/test_codesize_minimal_O2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2284,
-  "a.out.js.gz": 1133,
+  "a.out.js": 2269,
+  "a.out.js.gz": 1125,
   "a.out.nodebug.wasm": 280,
   "a.out.nodebug.wasm.gz": 226,
-  "total": 2564,
-  "total_gz": 1359,
+  "total": 2549,
+  "total_gz": 1351,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_O3.json
+++ b/test/codesize/test_codesize_minimal_O3.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2225,
-  "a.out.js.gz": 1098,
+  "a.out.js": 2210,
+  "a.out.js.gz": 1089,
   "a.out.nodebug.wasm": 75,
   "a.out.nodebug.wasm.gz": 87,
-  "total": 2300,
-  "total_gz": 1185,
+  "total": 2285,
+  "total_gz": 1176,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_Os.json
+++ b/test/codesize/test_codesize_minimal_Os.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2225,
-  "a.out.js.gz": 1098,
+  "a.out.js": 2210,
+  "a.out.js.gz": 1089,
   "a.out.nodebug.wasm": 75,
   "a.out.nodebug.wasm.gz": 87,
-  "total": 2300,
-  "total_gz": 1185,
+  "total": 2285,
+  "total_gz": 1176,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_Oz-ctors.json
+++ b/test/codesize/test_codesize_minimal_Oz-ctors.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2206,
-  "a.out.js.gz": 1086,
+  "a.out.js": 2192,
+  "a.out.js.gz": 1077,
   "a.out.nodebug.wasm": 64,
   "a.out.nodebug.wasm.gz": 80,
-  "total": 2270,
-  "total_gz": 1166,
+  "total": 2256,
+  "total_gz": 1157,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_Oz.json
+++ b/test/codesize/test_codesize_minimal_Oz.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2225,
-  "a.out.js.gz": 1098,
+  "a.out.js": 2210,
+  "a.out.js.gz": 1089,
   "a.out.nodebug.wasm": 75,
   "a.out.nodebug.wasm.gz": 87,
-  "total": 2300,
-  "total_gz": 1185,
+  "total": 2285,
+  "total_gz": 1176,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_esm.json
+++ b/test/codesize/test_codesize_minimal_esm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2368,
-  "a.out.js.gz": 1122,
+  "a.out.js": 2348,
+  "a.out.js.gz": 1111,
   "a.out.nodebug.wasm": 75,
   "a.out.nodebug.wasm.gz": 87,
-  "total": 2443,
-  "total_gz": 1209,
+  "total": 2423,
+  "total_gz": 1198,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 6969,
-  "a.out.js.gz": 3438,
+  "a.out.js": 6954,
+  "a.out.js.gz": 3428,
   "a.out.nodebug.wasm": 19063,
   "a.out.nodebug.wasm.gz": 8803,
-  "total": 26032,
-  "total_gz": 12241,
+  "total": 26017,
+  "total_gz": 12231,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7377,
-  "a.out.js.gz": 3640,
+  "a.out.js": 7362,
+  "a.out.js.gz": 3631,
   "a.out.nodebug.wasm": 19064,
   "a.out.nodebug.wasm.gz": 8804,
-  "total": 26441,
-  "total_gz": 12444,
+  "total": 26426,
+  "total_gz": 12435,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_wasmfs.json
+++ b/test/codesize/test_codesize_minimal_wasmfs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2225,
-  "a.out.js.gz": 1098,
+  "a.out.js": 2210,
+  "a.out.js.gz": 1089,
   "a.out.nodebug.wasm": 75,
   "a.out.nodebug.wasm.gz": 87,
-  "total": 2300,
-  "total_gz": 1185,
+  "total": 2285,
+  "total_gz": 1176,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_small_js_flags.expected.js
+++ b/test/codesize/test_small_js_flags.expected.js
@@ -444,7 +444,6 @@ function run() {
   function doRun() {
     // run may have just been called through dependencies being fulfilled just in this very frame,
     // or while the async setStatus time below was happening
-    Module["calledRun"] = true;
     if (ABORT) return;
     initRuntime();
     preMain();

--- a/test/codesize/test_small_js_flags.json
+++ b/test/codesize/test_small_js_flags.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 2240,
-  "a.out.js.gz": 1244,
+  "a.out.js": 2225,
+  "a.out.js.gz": 1232,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 3906,
-  "total_gz": 2189,
+  "total": 3891,
+  "total_gz": 2177,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 55076,
-  "hello_world.js.gz": 17352,
+  "hello_world.js": 55063,
+  "hello_world.js.gz": 17349,
   "hello_world.wasm": 15115,
   "hello_world.wasm.gz": 7464,
-  "no_asserts.js": 25903,
-  "no_asserts.js.gz": 8768,
+  "no_asserts.js": 25871,
+  "no_asserts.js.gz": 8759,
   "no_asserts.wasm": 12229,
   "no_asserts.wasm.gz": 6004,
-  "strict.js": 52833,
-  "strict.js.gz": 16583,
+  "strict.js": 52820,
+  "strict.js.gz": 16580,
   "strict.wasm": 15115,
   "strict.wasm.gz": 7461,
-  "total": 176271,
-  "total_gz": 63632
+  "total": 176213,
+  "total_gz": 63617
 }

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -6,6 +6,7 @@ declare namespace RuntimeExports {
     function FS_unlink(...args: any[]): any;
     function FS_createLazyFile(...args: any[]): any;
     function FS_createDevice(...args: any[]): any;
+    function isInitialized(): any;
     function addRunDependency(id: any): void;
     function removeRunDependency(id: any): void;
 }

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -1033,7 +1033,7 @@ def generate_preload_js(data_target, data_files, metadata):
   ret += code
   ret += '''
     }
-    if (Module['calledRun']) {
+    if (Module['isInitialized']?.()) {
       runWithFS(Module)%s;
     } else {
       if (!Module['preRun']) Module['preRun'] = [];
@@ -1069,7 +1069,7 @@ def generate_preload_js(data_target, data_files, metadata):
     loadPackage(json);
   }
 
-  if (Module['calledRun']) {
+  if (Module['isInitialized']?.()) {
     runMetaWithFS();
   } else {
     if (!Module['preRun']) Module['preRun'] = [];

--- a/tools/link.py
+++ b/tools/link.py
@@ -995,10 +995,10 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       exit_with_error('MODULARIZE=instance requires EXPORT_ES6')
     if settings.MINIMAL_RUNTIME:
       exit_with_error('MODULARIZE=instance is not compatible with MINIMAL_RUNTIME')
-    if options.use_preload_plugins or len(options.preload_files):
+    if options.use_preload_plugins or options.preload_files:
       exit_with_error('MODULARIZE=instance is not compatible with --embed-file/--preload-file')
 
-  if settings.MINIMAL_RUNTIME and len(options.preload_files):
+  if settings.MINIMAL_RUNTIME and options.preload_files:
     exit_with_error('MINIMAL_RUNTIME is not compatible with --preload-file')
 
   if options.oformat in {OFormat.WASM, OFormat.BARE}:
@@ -1389,7 +1389,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
   if settings.MIN_WEBGL_VERSION > settings.MAX_WEBGL_VERSION:
     exit_with_error('MIN_WEBGL_VERSION must be smaller or equal to MAX_WEBGL_VERSION!')
 
-  if options.use_preload_plugins or len(options.preload_files) or len(options.embed_files):
+  if options.use_preload_plugins or options.preload_files or options.embed_files:
     if settings.NODERAWFS:
       exit_with_error('--preload-file and --embed-file cannot be used with NODERAWFS which disables virtual filesystem')
     # if we include any files, or intend to use preload plugins, then we definitely need filesystem support
@@ -1573,6 +1573,7 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       ]
 
     settings.EXPORTED_RUNTIME_METHODS += [
+      'isInitialized',
       'addRunDependency',
       'removeRunDependency',
     ]
@@ -3098,7 +3099,7 @@ def run(options, linker_args):
   linker_args = phase_calculate_linker_inputs(options, linker_args)
 
   # Embed and preload files
-  if len(options.preload_files) or len(options.embed_files):
+  if options.preload_files or options.embed_files:
     linker_args += package_files(options, target)
 
   if options.oformat == OFormat.OBJECT:


### PR DESCRIPTION
This is an undocumented module property that the file_packager-generated code was using to detect if the runtime was initialized or not.

Replace it with a normal opt-in library symbol, so that we don't need to include it in all programs unconditionally.