### PR TITLE
Fix late preRun additions in file_packager (separate metadata)

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -66,9 +66,6 @@ addToLibrary({
   setTempRet0: '$setTempRet0',
   getTempRet0: '$getTempRet0',
 
-  // Used by the file_packager-generated code to detect if the program has already
-  // be started.
-  $isInitialized: () => runtimeInitialized,
 
   // Assign a name to a given function. This is mostly useful for debugging
   // purposes in cases where new functions are created at runtime.

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -50,15 +50,31 @@ err('warning: running JS from STANDALONE_WASM without WASM_BIGINT will fail if a
 #endif
 
 function consumedModuleProp(prop) {
-  if (!Object.getOwnPropertyDescriptor(Module, prop)) {
-    Object.defineProperty(Module, prop, {
-      configurable: true,
-      set() {
-        abort(`Attempt to set \`Module.${prop}\` after it has already been processed.  This can happen, for example, when code is injected via '--post-js' rather than '--pre-js'`);
-
+  var value = Module[prop];
+  var msg = `Attempt to modify \`Module.${prop}\` after it has already been processed.  This can happen, for example, when code is injected via '--post-js' rather than '--pre-js'`;
+  if (Array.isArray(value)) {
+    value = new Proxy(value, {
+      set(target, key, val) {
+        abort(msg);
+        return false;
+      },
+      defineProperty(target, key, descriptor) {
+        abort(msg);
+        return false;
+      },
+      deleteProperty(target, key) {
+        abort(msg);
+        return false;
       }
     });
   }
+  Object.defineProperty(Module, prop, {
+    configurable: true,
+    get() { return value; },
+    set() {
+      abort(msg);
+    }
+  });
 }
 
 function makeInvalidEarlyAccess(name) {

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -135,7 +135,8 @@ Module["expectedDataFileDownloads"]++;
       }
       await processPackageData(fetched);
     }
-    if (Module["isInitialized"]?.()) {
+    // Detect whether the module JS file has already been loaded.
+    if (Module["FS_createPath"]) {
       runWithFS(Module);
     } else {
       if (!Module["preRun"]) Module["preRun"] = [];
@@ -3115,8 +3116,6 @@ var FS_createLazyFile = (...args) => FS.createLazyFile(...args);
 
 var FS_createDevice = (...args) => FS.createDevice(...args);
 
-var isInitialized = () => runtimeInitialized;
-
 FS.createPreloadedFile = FS_createPreloadedFile;
 
 FS.preloadFile = FS_preloadFile;
@@ -3130,8 +3129,6 @@ FS.staticInit();
 {}
 
 // Begin runtime exports
-Module["isInitialized"] = isInitialized;
-
 Module["addRunDependency"] = addRunDependency;
 
 Module["removeRunDependency"] = removeRunDependency;

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22122,
-  "a.out.js.gz": 9190,
+  "a.out.js": 22083,
+  "a.out.js.gz": 9166,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 23788,
-  "total_gz": 10135,
+  "total": 23749,
+  "total_gz": 10111,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23336,
-  "a.out.js.gz": 8439,
+  "a.out.js": 23514,
+  "a.out.js.gz": 8493,
   "a.out.nodebug.wasm": 15115,
   "a.out.nodebug.wasm.gz": 7464,
-  "total": 38451,
-  "total_gz": 15903,
+  "total": 38629,
+  "total_gz": 15957,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -353,15 +353,31 @@ function dbg(...args) {
 })();
 
 function consumedModuleProp(prop) {
-  if (!Object.getOwnPropertyDescriptor(Module, prop)) {
-    Object.defineProperty(Module, prop, {
-      configurable: true,
-      set() {
-        abort(`Attempt to set \`Module.${prop}\` after it has already been processed.  This can happen, for example, when code is injected via '--post-js' rather than '--pre-js'`);
-
+  var value = Module[prop];
+  var msg = `Attempt to modify \`Module.${prop}\` after it has already been processed.  This can happen, for example, when code is injected via '--post-js' rather than '--pre-js'`;
+  if (Array.isArray(value)) {
+    value = new Proxy(value, {
+      set(target, key, val) {
+        abort(msg);
+        return false;
+      },
+      defineProperty(target, key, descriptor) {
+        abort(msg);
+        return false;
+      },
+      deleteProperty(target, key) {
+        abort(msg);
+        return false;
       }
     });
   }
+  Object.defineProperty(Module, prop, {
+    configurable: true,
+    get() { return value; },
+    set() {
+      abort(msg);
+    }
+  });
 }
 
 function makeInvalidEarlyAccess(name) {
@@ -861,7 +877,6 @@ Module['FS_createPreloadedFile'] = FS.createPreloadedFile;
   'stackAlloc',
   'getTempRet0',
   'setTempRet0',
-  'isInitialized',
   'createNamedFunction',
   'zeroMemory',
   'exitJS',

--- a/test/codesize/test_codesize_minimal_O0.json
+++ b/test/codesize/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18681,
-  "a.out.js.gz": 6763,
+  "a.out.js": 18667,
+  "a.out.js.gz": 6759,
   "a.out.nodebug.wasm": 1015,
   "a.out.nodebug.wasm.gz": 602,
-  "total": 19696,
-  "total_gz": 7365,
+  "total": 19682,
+  "total_gz": 7361,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 55063,
-  "hello_world.js.gz": 17349,
+  "hello_world.js": 55387,
+  "hello_world.js.gz": 17453,
   "hello_world.wasm": 15115,
   "hello_world.wasm.gz": 7464,
   "no_asserts.js": 25871,
   "no_asserts.js.gz": 8759,
   "no_asserts.wasm": 12229,
   "no_asserts.wasm.gz": 6004,
-  "strict.js": 52820,
-  "strict.js.gz": 16580,
+  "strict.js": 53144,
+  "strict.js.gz": 16681,
   "strict.wasm": 15115,
   "strict.wasm.gz": 7461,
-  "total": 176213,
-  "total_gz": 63617
+  "total": 176861,
+  "total_gz": 63822
 }

--- a/test/other/embind_tsgen_ignore_1.d.ts
+++ b/test/other/embind_tsgen_ignore_1.d.ts
@@ -6,7 +6,6 @@ declare namespace RuntimeExports {
     function FS_unlink(...args: any[]): any;
     function FS_createLazyFile(...args: any[]): any;
     function FS_createDevice(...args: any[]): any;
-    function isInitialized(): any;
     function addRunDependency(id: any): void;
     function removeRunDependency(id: any): void;
 }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15043,7 +15043,7 @@ addToLibrary({
     # it runs.
     for prop in ('onRuntimeInitialized', 'postRun', 'preRun', 'preInit'):
       create_file('post.js', f'Module.{prop} = () => console.log("will never fire since assigned too late")')
-      expected = f"Aborted(Attempt to set `Module.{prop}` after it has already been processed.  This can happen, for example, when code is injected via '--post-js' rather than '--pre-js')"
+      expected = f"Aborted(Attempt to modify `Module.{prop}` after it has already been processed.  This can happen, for example, when code is injected via '--post-js' rather than '--pre-js')"
       self.do_runf('hello_world.c', expected, cflags=['--post-js=post.js', '-sWASM_ASYNC_COMPILATION=0'], assert_returncode=NON_ZERO)
 
   @crossplatform

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -1033,7 +1033,8 @@ def generate_preload_js(data_target, data_files, metadata):
   ret += code
   ret += '''
     }
-    if (Module['isInitialized']?.()) {
+    // Detect whether the module JS file has already been loaded.
+    if (Module['FS_createPath']) {
       runWithFS(Module)%s;
     } else {
       if (!Module['preRun']) Module['preRun'] = [];
@@ -1069,7 +1070,8 @@ def generate_preload_js(data_target, data_files, metadata):
     loadPackage(json);
   }
 
-  if (Module['isInitialized']?.()) {
+  // Detect whether the module JS file has already been loaded.
+  if (Module['FS_createPath']) {
     runMetaWithFS();
   } else {
     if (!Module['preRun']) Module['preRun'] = [];

--- a/tools/link.py
+++ b/tools/link.py
@@ -1573,7 +1573,6 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       ]
 
     settings.EXPORTED_RUNTIME_METHODS += [
-      'isInitialized',
       'addRunDependency',
       'removeRunDependency',
     ]


### PR DESCRIPTION
In the separate-metadata case, file preloading happens asynchronously after the metadata is fetched. Previously, this would result in `runWithFS` being pushed to `Module['preRun']` after `preRun()` had already been called.

Instead of waiting for `preRun` (which has already passed), we can run `runWithFS` immediately as long as the FS library has loaded. We now check for `Module['FS_createPath']` to detect if the library is loaded and ready, rather than checking `Module['isInitialized']`.

This allows us to remove the recently added `isInitialized` helper.

Also, improve `consumedModuleProp` to detect late modifications to `Module['preRun']` (using a Proxy) to prevent similar issues in the future.
