### PR TITLE
Remove duplicate processing of runDependencies in run()

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -115,21 +115,6 @@ function stackCheckInit() {
 #endif
 
 {{{ asyncIf(MODULARIZE) }}}function run({{{ MAIN_READS_PARAMS ? 'args = programArgs' : '' }}}) {
-
-#if '$runDependencies' in addedLibraryItems
-  if (runDependencies > 0) {
-#if RUNTIME_DEBUG
-    dbg('run() called, but dependencies remain, so not running');
-#endif
-#if MODULARIZE
-    await new Promise((resolve) => dependenciesFulfilled = resolve);
-#else
-    dependenciesFulfilled = run;
-    return;
-#endif
-  }
-#endif
-
 #if PTHREADS || WASM_WORKERS
   if ({{{ ENVIRONMENT_IS_WORKER_THREAD() }}}) {
     initRuntime();
@@ -144,7 +129,6 @@ function stackCheckInit() {
   preRun();
 
 #if '$runDependencies' in addedLibraryItems
-  // a preRun added a dependency, run will be called later
   if (runDependencies > 0) {
 #if RUNTIME_DEBUG
     dbg('run() called, but dependencies remain, so not running');

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -3182,12 +3182,7 @@ function callMain() {
 }
 
 function run() {
-  if (runDependencies > 0) {
-    dependenciesFulfilled = run;
-    return;
-  }
   preRun();
-  // a preRun added a dependency, run will be called later
   if (runDependencies > 0) {
     dependenciesFulfilled = run;
     return;

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22140,
-  "a.out.js.gz": 9196,
+  "a.out.js": 22122,
+  "a.out.js.gz": 9190,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 23806,
-  "total_gz": 10141,
+  "total": 23788,
+  "total_gz": 10135,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268230,
+  "a.out.js": 268210,
   "a.out.nodebug.wasm": 587503,
-  "total": 855733,
+  "total": 855713,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
This means that preRun callbacks run before any runDependencies which doesn't seem like an issue.

Split out from my larger refactor of `run`: #27121