### PR TITLE
Export wasm-bindgen symbols under MODULARIZE=instance

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14914,6 +14914,30 @@ addToLibrary({
     self.run_process(['cargo', 'install', 'wasm-bindgen-cli'])
     self.do_runf('empty.c', '42', cflags=[lib, '-sWASM_BINDGEN', '--post-js=post.js', '-lexports.js'])
 
+  @requires_rust
+  def test_wasm_bindgen_integration_instance(self):
+    # In MODULARIZE=instance mode the wasm-bindgen exports must be emitted as
+    # named ES module exports, mirroring how they are reachable as `Module.foo`
+    # in factory mode.
+    copytree(test_file('rust/bindgen_integration'), '.')
+    self.run_process(['cargo', 'add', 'wasm-bindgen'])
+    self.run_process(['cargo', 'build'])
+    lib = 'target/wasm32-unknown-emscripten/debug/libbindgen_integration.a'
+    self.assertExists(lib)
+
+    create_file('empty.c', '')
+    self.run_process(['cargo', 'install', 'wasm-bindgen-cli'])
+    self.run_process([EMCC, 'empty.c', lib, '-sWASM_BINDGEN',
+                      '-sMODULARIZE=instance', '-Wno-experimental',
+                      '-o', 'out.mjs'])
+
+    create_file('runner.mjs', '''
+      import init, { rs_add } from './out.mjs';
+      await init();
+      console.log(rs_add(17, 25));
+    ''')
+    self.assertContained('42', self.run_js('runner.mjs'))
+
   def test_relative_em_cache(self):
     with env_modify({'EM_CACHE': 'foo'}):
       self.assert_fail([EMCC, '-c', test_file('hello_world.c')], 'emcc: error: environment variable EM_CACHE must be an absolute path: foo')

--- a/tools/building.py
+++ b/tools/building.py
@@ -1308,7 +1308,17 @@ def run_wasm_bindgen(infile):
 
   shutil.copyfile(os.path.join(bindgen_out_dir, new_wasm_file), infile)
 
-  return os.path.join(bindgen_out_dir, 'library_bindgen.js')
+  bindgen_jslib = os.path.join(bindgen_out_dir, 'library_bindgen.js')
+  return bindgen_jslib, get_wasm_bindgen_js_exports(bindgen_jslib)
+
+
+def get_wasm_bindgen_js_exports(bindgen_jslib):
+  # wasm-bindgen communicates the names of its clean, user-facing JS exports by
+  # assigning them to `Module` (e.g. `Module.fetch = fetch;`) inside the library
+  # it generates.  Collect those names so they can be re-exported as named ES
+  # module exports under MODULARIZE=instance.
+  contents = utils.read_file(bindgen_jslib)
+  return re.findall(r'(?<![\w.])Module\.(\w+)\s*=\s*\1;', contents)
 
 
 intermediate_counter = 0

--- a/tools/link.py
+++ b/tools/link.py
@@ -1510,6 +1510,10 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
     if settings.MODULARIZE == 'instance':
       settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$addOnPostCtor']
 
+  # Needed to assign the wasm-bindgen exports to the ES exports.
+  if settings.WASM_BINDGEN and settings.MODULARIZE == 'instance':
+    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$addOnPostCtor']
+
   if options.emit_tsd:
     settings.EMIT_TSD = True
 
@@ -1888,11 +1892,15 @@ def phase_post_link(options, in_wasm, wasm_target, target, js_syms, base_metadat
 
   settings.TARGET_JS_NAME = os.path.basename(js_target)
 
+  bindgen_exports = []
   if settings.WASM_BINDGEN:
-    bindgen_jslib = building.run_wasm_bindgen(in_wasm)
+    bindgen_jslib, bindgen_exports = building.run_wasm_bindgen(in_wasm)
     settings.JS_LIBRARIES.append(bindgen_jslib)
 
   metadata = phase_emscript(in_wasm, wasm_target, js_syms, base_metadata)
+
+  if settings.WASM_BINDGEN and settings.MODULARIZE == 'instance':
+    phase_wasm_bindgen_instance_exports(bindgen_exports)
 
   if settings.EMBIND_AOT:
     phase_embind_aot(options, wasm_target, js_syms)
@@ -2032,6 +2040,27 @@ def phase_emit_tsd(options, wasm_target, js_target, js_syms, metadata):
   all_tsd = emscripten.create_tsd(metadata, embind_tsd, bindgen_ts_files)
   out_file = os.path.join(os.path.dirname(js_target), filename)
   write_file(out_file, all_tsd)
+
+
+def phase_wasm_bindgen_instance_exports(bindgen_exports):
+  # In MODULARIZE=instance mode the wasm-bindgen library only assigns its clean
+  # JS exports to `Module` (a dead assignment, since consumers receive the ESM
+  # named exports rather than `Module`).  Mirror the embind approach and
+  # re-export them as named ES module exports, binding them once the runtime is
+  # initialized (the wasm-bindgen wrappers are populated via `addOnInit`, which
+  # runs before `addOnPostCtor`).
+  if not bindgen_exports:
+    return
+  src = read_file(final_js)
+  decls = '\n'.join(f'export var {name};' for name in bindgen_exports)
+  assigns = '\n'.join(f"{name} = Module['{name}'];" for name in bindgen_exports)
+  src += f'''
+// start wasm-bindgen exports
+function assignBindgenExports() {{ {assigns} }};
+addOnPostCtor(assignBindgenExports);
+{decls}
+// end wasm-bindgen exports'''
+  write_file(final_js, src)
 
 
 @ToolchainProfiler.profile_block('embind aot js')


### PR DESCRIPTION
The wasm-bindgen integration assigns its clean JS exports to `Module` (`Module.rs_add = rs_add;`), which is correct for MODULARIZE=1 (factory) but a dead assignment under MODULARIZE=instance, where consumers only receive the ESM named exports plus a default init. As a result the wasm-bindgen API was unreachable; only the mangled wasm export (_rs_add) was exported.

Mirror the embind-instance approach: collect the export names from the generated library and re-export them as named ES module exports, binding them via addOnPostCtor (which runs after the addOnInit that populates the wrappers).

_Note: AI was used in the creation of this PR_