### PR TITLE
Enable more sanitizer tests under wasm64

### DIFF
--- a/src/lib/libstack_trace.js
+++ b/src/lib/libstack_trace.js
@@ -231,7 +231,7 @@ var LibraryStackTrace = {
     }
 
     for (var i = 0; i < count && stack[i+offset]; ++i) {
-      {{{ makeSetValue('buffer', 'i*4', 'convertFrameToPC(stack[i + offset])', 'i32') }}};
+      {{{ makeSetValue('buffer', `i*${POINTER_SIZE}`, 'convertFrameToPC(stack[i + offset])', '*') }}};
     }
     return i;
   },

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4027,7 +4027,6 @@ Module["preRun"] = () => {
     # same stack size as the main thread normally would.
     self.btest('core/test_safe_stack.c', expected='abort:stack overflow', cflags=['-pthread', '-sPROXY_TO_PTHREAD', '-sSTACK_OVERFLOW_CHECK=2', '-sSTACK_SIZE=64KB'])
 
-  @no_wasm64('TODO: ASAN in memory64')
   @parameterized({
     'leak': ['test_pthread_lsan_leak', ['-gsource-map']],
     'no_leak': ['test_pthread_lsan_no_leak', []],
@@ -4037,7 +4036,6 @@ Module["preRun"] = () => {
   def test_pthread_lsan(self, name, args):
     self.btest(Path('pthread', name + '.cpp'), expected='1', cflags=['-fsanitize=leak', '-pthread', '-sPROXY_TO_PTHREAD', '--pre-js', test_file('pthread', name + '.js')] + args)
 
-  @no_wasm64('TODO: ASAN in memory64')
   @no_highmem('ASAN + GLOBAL_BASE')
   @parameterized({
     # Reusing the LSan test files for ASan.
@@ -4048,12 +4046,10 @@ Module["preRun"] = () => {
   def test_pthread_asan(self, name, args):
     self.btest(Path('pthread', name + '.cpp'), expected='1', cflags=['-fsanitize=address', '-pthread', '-sPROXY_TO_PTHREAD', '--pre-js', test_file('pthread', name + '.js')] + args)
 
-  @no_wasm64('TODO: ASAN in memory64')
   @no_highmem('ASAN + GLOBAL_BASE')
   def test_pthread_asan_use_after_free(self):
     self.btest('pthread/test_pthread_asan_use_after_free.cpp', expected='1', cflags=['-fsanitize=address', '-pthread', '-sPROXY_TO_PTHREAD', '--pre-js', test_file('pthread/test_pthread_asan_use_after_free.js')])
 
-  @no_wasm64('TODO: ASAN in memory64')
   @no_highmem('ASAN + GLOBAL_BASE')
   @no_firefox('https://github.com/emscripten-core/emscripten/issues/20006')
   @no_safari('TODO: Hangs') # Fails in Safari 17.6 (17618.3.11.11.7, 17618), Safari 26.0.1 (21622.1.22.11.15)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -11174,11 +11174,12 @@ int main(void) {
     self.assert_fail([EMCC, test_file('malloc_none.c'), '-sMALLOC=none'], 'undefined symbol: malloc')
 
   @no_bun('https://github.com/emscripten-core/emscripten/issues/26198')
+  @also_with_wasm64
   @parameterized({
-    'c': ['c', []],
-    'cpp': ['cpp', []],
-    'growth': ['cpp', ['-sALLOW_MEMORY_GROWTH']],
-    'wasmfs': ['c', ['-sWASMFS']],
+    '': ('c', []),
+    'cpp': ('cpp', []),
+    'growth': ('cpp', ['-sALLOW_MEMORY_GROWTH']),
+    'wasmfs': ('c', ['-sWASMFS']),
   })
   def test_lsan_leaks(self, ext, args):
     self.do_runf(
@@ -13139,6 +13140,7 @@ void foo() {}
 
   @no_bun('https://github.com/emscripten-core/emscripten/issues/26198')
   @requires_pthreads
+  @also_with_wasm64
   def test_pthread_lsan_leak(self):
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')


### PR DESCRIPTION
This should really have been part of #27145.

This change also includes small change to emscripten_stack_unwind_buffer which was causing invalid backtraces under wasm64.