### PR TITLE
Refactor release automation and integrate custom release notes. NFC

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -13,43 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-      # Updates changelog and writes the release version into the environment
-      - name: Update Changelog
-        run: python3 tools/maint/create_release.py --action
-      - name: Create Changelog PR
-        id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.EMSCRIPTEN_BOT_TOKEN }}
-          title: Mark ${{ env.RELEASE_VERSION }} as released
-          body: Update changelog and emscripten-version.txt [ci skip]
-          team-reviewers: release-reviewers
-          branch: release_${{ env.RELEASE_VERSION }}
-          delete-branch: true
-      - name: Enable auto-merge
-        run: gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
+          fetch-depth: 0
+      - name: Create Release
+        run: python3 tools/maint/create_release.py --release-commit ${{ inputs.release-sha }}
         env:
           GH_TOKEN: ${{ secrets.EMSCRIPTEN_BOT_TOKEN }}
-      - name: Create new tag and draft release
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.EMSCRIPTEN_BOT_TOKEN }}
-          script: |
-            const tag_sha = '${{ inputs.release-sha }}';
-            const release_version = '${{ env.RELEASE_VERSION }}';
-            console.log(`Version ${release_version} at SHA ${tag_sha}`);
-            const regex = /^[0-9]+.[0-9]+.[0-9]+$/;
-            const match = release_version.match(regex);
-            if (!match) {
-              throw new Error('Malformed release version');
-            }
-            await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: release_version,
-              target_commitish: tag_sha,
-              name: release_version,
-              draft: true,
-              generate_release_notes: true
-            });
+          GIT_AUTHOR_NAME: emscripten-bot
+          GIT_AUTHOR_EMAIL: emscripten-bot@users.noreply.github.com
+          GIT_COMMITTER_NAME: emscripten-bot
+          GIT_COMMITTER_EMAIL: emscripten-bot@users.noreply.github.com

--- a/tools/maint/create_release.py
+++ b/tools/maint/create_release.py
@@ -4,6 +4,7 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
+import argparse
 import os
 import subprocess
 import sys
@@ -14,6 +15,9 @@ root_dir = os.path.dirname(os.path.dirname(script_dir))
 
 sys.path.insert(0, root_dir)
 from tools import utils
+
+REPO = 'emscripten-core/emscripten'
+GIT_REMOTE = 'upstream'
 
 
 def update_version_txt(release_version, new_version):
@@ -46,28 +50,61 @@ def update_changelog(release_version, new_version):
   utils.write_file(changelog_file, changelog)
 
 
-def create_git_branch(release_version):
+def create_git_branch(release_version, dry_run):
   branch_name = 'version_' + release_version
 
-  # Create a new git branch
-  subprocess.check_call(['git', 'checkout', '-b', branch_name, 'upstream/main'], cwd=root_dir)
+  # Create a new git branch from upstream/main
+  print(f'Checking out new branch {branch_name} from {GIT_REMOTE}/main')
+  subprocess.check_call(['git', 'checkout', '-b', branch_name, f'{GIT_REMOTE}/main'], cwd=root_dir)
 
   # Create auto-generated changes to the new git branch
   subprocess.check_call(['git', 'add', '-u', '.'], cwd=root_dir)
   subprocess.check_call(['git', 'commit', '-m', f'Mark {release_version} as released'], cwd=root_dir)
   print('New release created in branch: `%s`' % branch_name)
 
-  if '-n' not in sys.argv:
+  if not dry_run:
     # Push new branch to upstream
-    subprocess.check_call(['git', 'push', 'upstream', branch_name], cwd=root_dir)
+    subprocess.check_call(['git', 'push', GIT_REMOTE, branch_name], cwd=root_dir)
 
 
-def main(argv):
+def create_draft_release(version, base_commit):
+  print(f'Creating draft release for {version}...', file=sys.stderr)
+
+  # Call gen_release_notes.py
+  gen_script = os.path.join(script_dir, 'gen_release_notes.py')
+  notes = subprocess.check_output([sys.executable, gen_script, version], text=True)
+
+  # Save notes to out/release-notes-{version}.md
+  out_dir = os.path.join(root_dir, 'out')
+  os.makedirs(out_dir, exist_ok=True)
+  notes_file = os.path.join(out_dir, f'release-notes-{version}.md')
+  with open(notes_file, 'w', encoding='utf-8') as f:
+    f.write(notes)
+
+  # Create the draft release
+  cmd = [
+      'gh', 'release', 'create', version,
+      '--draft',
+      '--title', version,
+      '--notes-file', notes_file,
+      '-R', REPO,
+  ]
+  if base_commit:
+    cmd.extend(['--target', base_commit])
+  subprocess.run(cmd, check=True)
+  print(f'Draft release created successfully! Notes saved to {notes_file}', file=sys.stderr)
+  return 0
+
+
+def main():
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument('-n', '--dry-run', action='store_true', help='Dry run (do not push branch/tag/release)')
+  parser.add_argument('--release-commit', help='Base commit/SHA for the release')
+  args = parser.parse_args()
+
   if subprocess.check_output(['git', 'status', '-uno', '--porcelain'], cwd=root_dir).strip():
     print('tree is not clean')
     return 1
-
-  is_github_runner = len(argv) > 1 and argv[1] == '--action'
 
   utils.set_version_globals()
 
@@ -84,15 +121,13 @@ def main(argv):
 
   print('Creating new release: %s' % release_version)
 
-  if is_github_runner: # For GitHub Actions workflows
-    with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as f:
-      f.write(f'RELEASE_VERSION={release_version}')
-  else: # Local use
-    create_git_branch(release_version)
-    # TODO(sbc): Maybe create the tag too
+  create_git_branch(release_version, args.dry_run)
+
+  if not args.dry_run:
+    create_draft_release(release_version, args.release_commit)
 
   return 0
 
 
 if __name__ == '__main__':
-  sys.exit(main(sys.argv))
+  sys.exit(main())

--- a/tools/maint/gen_release_notes.py
+++ b/tools/maint/gen_release_notes.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+"""Helper script to generate GitHub release notes using ChangeLog.md.
+
+It uses the `gh` CLI to fetch default release notes (to get the contributor list
+and changelog link), parses ChangeLog.md for the actual release description,
+and combines them into a final release notes draft.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import Counter
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+root_dir = os.path.dirname(os.path.dirname(script_dir))
+
+BOTS = {'dependabot[bot]', 'emscripten-bot', 'github-actions[bot]', 'web-flow'}
+REPO = 'emscripten-core/emscripten'
+
+
+def get_changelog_entry(changelog_path, version):
+  if not os.path.exists(changelog_path):
+    print(f'Error: Changelog not found at {changelog_path}', file=sys.stderr)
+    return None
+
+  with open(changelog_path, encoding='utf-8') as f:
+    lines = f.readlines()
+
+  start_idx = -1
+  end_idx = -1
+
+  for i, line in enumerate(lines):
+    line = line.strip()
+    # Match version followed by space, dash, or end of string
+    if re.match(rf'^{re.escape(version)}(?:\s|$|-)', line):
+      # A header is followed by a line of dashes
+      if i + 1 < len(lines) and re.match(r'^--+$', lines[i + 1].strip()):
+        start_idx = i + 2
+        break
+
+  if start_idx == -1:
+    return None
+
+  for i in range(start_idx, len(lines)):
+    line = lines[i].strip()
+    if i + 1 < len(lines) and re.match(r'^--+$', lines[i + 1].strip()):
+      end_idx = i
+      break
+  else:
+    end_idx = len(lines)
+
+  entry_lines = lines[start_idx:end_idx]
+  while entry_lines and not entry_lines[0].strip():
+    entry_lines.pop(0)
+  while entry_lines and not entry_lines[-1].strip():
+    entry_lines.pop()
+
+  return ''.join(entry_lines)
+
+
+def get_latest_version(changelog_path):
+  if not os.path.exists(changelog_path):
+    return None
+  with open(changelog_path, encoding='utf-8') as f:
+    lines = f.readlines()
+  for i, line in enumerate(lines):
+    line = line.strip()
+    # A header is followed by a line of dashes
+    if i + 1 < len(lines) and re.match(r'^--+$', lines[i + 1].strip()):
+      # Skip "in development" versions
+      if '(in development)' in line:
+        continue
+      match = re.match(r'^([0-9.]+)', line)
+      if match:
+        return match.group(1)
+  return None
+
+
+def get_previous_version(changelog_path, version):
+  if not os.path.exists(changelog_path):
+    return None
+
+  with open(changelog_path, encoding='utf-8') as f:
+    lines = f.readlines()
+
+  # Find the header for the target version
+  target_idx = -1
+  for i, line in enumerate(lines):
+    line = line.strip()
+    if re.match(rf'^{re.escape(version)}(?:\s|$|-)', line):
+      if i + 1 < len(lines) and re.match(r'^--+$', lines[i + 1].strip()):
+        target_idx = i
+        break
+
+  if target_idx == -1:
+    return None
+
+  # Find the next header after the target version
+  for i in range(target_idx + 2, len(lines)):
+    line = lines[i].strip()
+    if i + 1 < len(lines) and re.match(r'^--+$', lines[i + 1].strip()):
+      match = re.match(r'^([0-9.]+)', line)
+      if match:
+        return match.group(1)
+  return None
+
+
+def generate_default_notes(tag, previous_tag):
+  cmd = [
+      'gh', 'api',
+      f'/repos/{REPO}/releases/generate-notes',
+      '-f', f'tag_name={tag}',
+      '-f', f'previous_tag_name={previous_tag}',
+  ]
+  result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+  return json.loads(result.stdout)
+
+
+def parse_default_notes(body):
+  sections = {}
+  current_header = None
+  current_content = []
+
+  # Parse the default notes into sections based on H2 headers (##)
+  for line in body.split('\n'):
+    if line.startswith('## '):
+      if current_header:
+        sections[current_header] = '\n'.join(current_content).strip()
+      current_header = line[3:].strip()
+      current_content = []
+    elif line.startswith('**Full Changelog**'):
+      if current_header:
+        sections[current_header] = '\n'.join(current_content).strip()
+      current_header = 'Full Changelog'
+      current_content = [line]
+    else:
+      current_content.append(line)
+
+  if current_header:
+    sections[current_header] = '\n'.join(current_content).strip()
+
+  return sections
+
+
+def extract_pr_authors(whats_changed_content):
+  if not whats_changed_content:
+    return Counter()
+  # Match "by @username"
+  matches = re.findall(r'\sby\s@([a-zA-Z0-9-]+(?:\[bot\])?)', whats_changed_content)
+  return Counter(matches)
+
+
+def main():
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument('version', nargs='?', help='Version to generate notes for (e.g. 6.0.0). Defaults to the latest entry in ChangeLog.md.')
+  args = parser.parse_args()
+
+  changelog_path = os.path.join(root_dir, 'ChangeLog.md')
+
+  version = args.version
+  if not version:
+    version = get_latest_version(changelog_path)
+    if not version:
+      print(f'Error: Could not detect latest version from {changelog_path}', file=sys.stderr)
+      return 1
+
+  # 1. Get Changelog Entry
+  changelog_entry = get_changelog_entry(changelog_path, version)
+  if changelog_entry is None:
+    print(f'Error: Could not find changelog entry for version {version} in {changelog_path}', file=sys.stderr)
+    return 1
+
+  # 2. Detect Previous Tag
+  previous_tag = get_previous_version(changelog_path, version)
+  if not previous_tag:
+    print(f'Error: Could not detect previous version for {version} from ChangeLog.md.', file=sys.stderr)
+    return 1
+
+  # 3. Generate Default Notes from GitHub
+  default_notes_json = generate_default_notes(version, previous_tag)
+  default_body = default_notes_json.get('body', '')
+
+  # 4. Parse Default Notes
+  default_sections = parse_default_notes(default_body)
+
+  # 5. Extract Contributors
+  whats_changed = default_sections.get('What\'s Changed', '')
+  new_contributors_content = default_sections.get('New Contributors', '')
+
+  pr_authors_counts = extract_pr_authors(whats_changed)
+  contributors = {user: count for user, count in pr_authors_counts.items() if user not in BOTS}
+
+  # 6. Assemble Final Notes
+  notes = []
+  notes.append('## What\'s Changed')
+  notes.append(changelog_entry)
+  notes.append('')
+
+  if contributors:
+    notes.append('## Contributors')
+    sorted_contributors = sorted(
+        contributors.items(),
+        key=lambda item: (-item[1], item[0].lower()),
+    )
+    mentions = ' '.join(f'@{user} ({count})' for user, count in sorted_contributors)
+    notes.append(f'Thanks to the following contributors: {mentions}')
+    notes.append('')
+
+  if new_contributors_content:
+    notes.append('## New Contributors')
+    notes.append(new_contributors_content)
+    notes.append('')
+
+  full_changelog = default_sections.get('Full Changelog')
+  if full_changelog:
+    notes.append(full_changelog)
+
+  # 7. Output Final Notes
+  print('\n'.join(notes))
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
This change consolidates and simplifies the release automation by moving
the draft release creation directly into `create_release.py` and
introducing a pure release notes generator.

1. Add `gen_release_notes.py`: A helper script that parses
   `ChangeLog.md` for the release entry, fetches default notes from
   GitHub to extract and count contributors (sorted by count, then
   alphabetically), and prints the custom markdown notes to stdout.

2. Refactor `create_release.py`: Upgraded argument parsing to use
   `argparse` with `--release-commit` and `--dry-run` (-n) flags. The
   script now orchestrates the full release flow: branching from
   `upstream/main`, committing the version bump, pushing, calling
   `gen_release_notes.py`, and creating the draft release on GitHub
   targeted at the release commit.

3. Simplify `.github/workflows/tag-release.yml`: Reduced the workflow to
   a single job running `create_release.py` with the `--release-commit`
   flag. Used standard Git environment variables in the workflow step to
   declaratively configure the bot identity.