### PR TITLE
Disable default Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 VERSION = $(shell cat emscripten-version.txt | sed s/\"//g)
-DESTDIR ?= ../emscripten-$(VERSION)
+DESTDIR ?= out/emscripten-$(VERSION)
 DISTFILE = emscripten-$(VERSION).tar.bz2
+
+no_default:
+	@echo 'Error: You must specify an explicit make target (e.g. `dist` or `install`)'
+	@exit 1
 
 dist: $(DISTFILE)
 


### PR DESCRIPTION
It can be confusing that typing `make` on its own runs `make dist`.

Also, move the default `make dist` target directory to the `out/` directory.

See #27167