### PR TITLE
Fix template injection vulnerabilities in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,11 @@ jobs:
         # Skip this step for rebaseline PRs, since the target branch is expected
         # to be out of date in this case.
         if: "!contains(github.event.pull_request.title, 'Automatic rebaseline of codesize expectations')"
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          echo "Checking out ${{ github.base_ref }}"
-          git checkout ${{ github.base_ref }}
+          echo "Checking out $BASE_REF"
+          git checkout "$BASE_REF"
           git rev-parse HEAD
           # Uncomment this like to pull the rebaseline_tests.py from the
           # current branch:
@@ -77,11 +79,14 @@ jobs:
             exit 1
           fi
       - name: Check test expectations on PR branch
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
-          echo "Checking out ${{ github.ref }} (${{ github.sha }})"
-          # For some reason we cannot pass ${{ github.ref }} direclty to git
+          echo "Checking out $GITHUB_REF ($GITHUB_SHA)"
+          # For some reason we cannot pass $GITHUB_REF direclty to git
           # since it doesn't recognise it.
-          git checkout ${{ github.sha }}
+          git checkout "$GITHUB_SHA"
           git rev-parse HEAD
           ./bootstrap.py
           if ! ./tools/maint/rebaseline_tests.py --check-only --clear-cache; then

--- a/.github/workflows/rebaseline-tests.yml
+++ b/.github/workflows/rebaseline-tests.yml
@@ -35,6 +35,8 @@ jobs:
           python3 --version
           python3 -m pip install -r requirements-dev.txt
       - name: Rebaseline tests
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           git config user.name emscripten-bot
           git config user.email emscripten-bot@users.noreply.github.com
@@ -51,5 +53,5 @@ jobs:
             fi
           fi
           git push origin rebaseline_tests
-          gh pr create --fill --base ${{ github.ref_name }} --reviewer sbc100,kripken
+          gh pr create --fill --base "$REF_NAME" --reviewer sbc100,kripken
           gh pr merge --squash --auto

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,10 +18,11 @@ jobs:
           token: ${{ secrets.EMSCRIPTEN_BOT_TOKEN }}
           fetch-depth: 0
       - name: Create Release
-        run: python3 tools/maint/create_release.py --release-commit ${{ inputs.release-sha }}
         env:
+          RELEASE_SHA: ${{ inputs.release-sha }}
           GH_TOKEN: ${{ secrets.EMSCRIPTEN_BOT_TOKEN }}
           GIT_AUTHOR_NAME: emscripten-bot
           GIT_AUTHOR_EMAIL: emscripten-bot@users.noreply.github.com
           GIT_COMMITTER_NAME: emscripten-bot
           GIT_COMMITTER_EMAIL: emscripten-bot@users.noreply.github.com
+        run: python3 tools/maint/create_release.py --release-commit "$RELEASE_SHA"


### PR DESCRIPTION
Address security findings from zizmor by passing GitHub context
variables through the environment instead of expanding them directly
in shell scripts.
