### PR TITLE
[CI] Pin GitHub Actions to specific commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,14 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Install emsdk
-        uses: emscripten-core/setup-emsdk@v16
+        uses: emscripten-core/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
         with:
           version: tot
       - name: Set EM_CONFIG
         run:
           echo "EM_CONFIG=$EMSDK/.emscripten" >> $GITHUB_ENV
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           submodules: true
           fetch-depth: 0 # We want access to other branches, specifically `main`
@@ -101,7 +101,7 @@ jobs:
       LLVM_VERSION: 19
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       # Fetch all history for all tags and branches
       with:
         fetch-depth: 0

--- a/.github/workflows/rebaseline-tests.yml
+++ b/.github/workflows/rebaseline-tests.yml
@@ -18,14 +18,14 @@ jobs:
       GH_TOKEN: ${{ secrets.EMSCRIPTEN_BOT_TOKEN }}
     steps:
       - name: Install emsdk
-        uses: emscripten-core/setup-emsdk@v16
+        uses: emscripten-core/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
         with:
           version: tot
       - name: Set EM_CONFIG
         run:
           echo "EM_CONFIG=$EMSDK/.emscripten" >> $GITHUB_ENV
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           token: ${{ secrets.EMSCRIPTEN_BOT_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -13,12 +13,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.EMSCRIPTEN_BOT_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           fetch-depth: 0
           submodules: true
       - name: Checkout website repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           repository: kripken/emscripten-site
           ref: gh-pages


### PR DESCRIPTION
Pin actions/checkout and setup-emsdk to specific commit SHAs to
ensure build reproducibility and security against upstream changes.
