### PR TITLE
[CI] Add explicit read-only permissions to workflows

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -7,6 +7,8 @@ on:
       release-sha:
         required: true
         type: string
+permissions:
+  contents: read
 
 jobs:
   create-release:

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+
 permissions:
   contents: read
 

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+permissions:
+  contents: read
 
 jobs:
   update-website:


### PR DESCRIPTION
Define explicit 'permissions: contents: read' at the workflow level for
tag-release.yml and update-website.yml to adhere to the principle of
least privilege. The permissions block controls the ambient token
used for checkout (the separate EMSCRIPTEN_BOT_TOKEN is used
for the actual actions).
