### PR TITLE
Remove `buffer` from INCOMING_MODULE_JS_API. NFC

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -1006,7 +1006,7 @@ var EXPORTED_RUNTIME_METHODS = [];
 var INCOMING_MODULE_JS_API = [
   'ENVIRONMENT', 'GL_MAX_TEXTURE_IMAGE_UNITS', 'SDL_canPlayWithWebAudio',
   'SDL_numSimultaneouslyQueuedBuffers', 'INITIAL_MEMORY', 'wasmMemory', 'arguments',
-  'buffer', 'canvas', 'doNotCaptureKeyboard', 'dynamicLibraries',
+  'canvas', 'doNotCaptureKeyboard', 'dynamicLibraries',
   'elementPointerLock', 'extraStackTrace', 'forcedAspectRatio',
   'instantiateWasm', 'keyboardListeningElement', 'freePreloadedMediaOnUse',
   'locateFile', 'mainScriptUrlOrBlob', 'mem',

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -1226,7 +1226,6 @@ function checkIncomingModuleAPI() {
   ignoredModuleProp('INITIAL_MEMORY');
   ignoredModuleProp('wasmMemory');
   ignoredModuleProp('arguments');
-  ignoredModuleProp('buffer');
   ignoredModuleProp('canvas');
   ignoredModuleProp('doNotCaptureKeyboard');
   ignoredModuleProp('dynamicLibraries');

--- a/test/codesize/test_codesize_minimal_O0.json
+++ b/test/codesize/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18723,
-  "a.out.js.gz": 6778,
+  "a.out.js": 18710,
+  "a.out.js.gz": 6773,
   "a.out.nodebug.wasm": 1015,
   "a.out.nodebug.wasm.gz": 602,
-  "total": 19738,
-  "total_gz": 7380,
+  "total": 19725,
+  "total_gz": 7375,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -7,10 +7,10 @@
   "no_asserts.js.gz": 8690,
   "no_asserts.wasm": 12229,
   "no_asserts.wasm.gz": 6004,
-  "strict.js": 53033,
-  "strict.js.gz": 16620,
+  "strict.js": 53002,
+  "strict.js.gz": 16607,
   "strict.wasm": 15115,
   "strict.wasm.gz": 7461,
-  "total": 176480,
-  "total_gz": 63644
+  "total": 176449,
+  "total_gz": 63631
 }


### PR DESCRIPTION
Support for passing a pre-allocated ArrayBuffer via Module['buffer'] was only supported in non-WASM (asm.js) mode, which was completely removed in September 2020 (commit d5ec187f8281) when the fastcomp backend was dropped.

Internal usage for passing the `buffer` to pthread workers was also removed in January 2023 (commit a6e8d85e2a70).