### PR TITLE
Inline `preMain` and cleanup `postRun`. NFC

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -158,7 +158,7 @@ function stackCheckInit() {
   initRuntime();
 
 #if HAS_MAIN
-  preMain();
+  <<< ATMAINS >>>
 #endif
 
 #if expectToReceiveOnModule('onRuntimeInitialized')
@@ -180,10 +180,6 @@ function stackCheckInit() {
 #endif // HAS_MAIN
 
   postRun();
-
-#if STACK_OVERFLOW_CHECK
-  checkStackCookie();
-#endif
 }
 
 #if ASSERTIONS

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -175,16 +175,11 @@ function initRuntime() {
 #if RUNTIME_DEBUG
   dbg('done ATPOSTCTORS');
 #endif
-}
 
-#if HAS_MAIN
-function preMain() {
 #if STACK_OVERFLOW_CHECK
   checkStackCookie();
 #endif
-  <<< ATMAINS >>>
 }
-#endif
 
 #if EXIT_RUNTIME
 
@@ -226,7 +221,6 @@ function postRun() {
 #if STACK_OVERFLOW_CHECK
   checkStackCookie();
 #endif
-  {{{ runIfWorkerThread('return;') }}} // PThreads reuse the runtime from the main thread.
 
 #if expectToReceiveOnModule('postRun')
   var postRun = Module['postRun'];

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -352,8 +352,6 @@ function initRuntime() {
   FS.ignorePermissions = false;
 }
 
-function preMain() {}
-
 function postRun() {}
 
 /**
@@ -3185,7 +3183,7 @@ async function run() {
   }
   if (ABORT) return;
   initRuntime();
-  preMain();
+  // No ATMAINS hooks
   var noInitialRun = false;
   if (!noInitialRun) callMain();
   postRun();

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23508,
-  "a.out.js.gz": 8595,
+  "a.out.js": 23503,
+  "a.out.js.gz": 8594,
   "a.out.nodebug.wasm": 15115,
   "a.out.nodebug.wasm.gz": 7464,
-  "total": 38623,
-  "total_gz": 16059,
+  "total": 38618,
+  "total_gz": 16058,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -517,11 +517,12 @@ function initRuntime() {
   wasmExports['__wasm_call_ctors']();
 
   // No ATPOSTCTORS hooks
+
+  checkStackCookie();
 }
 
 function postRun() {
   checkStackCookie();
-   // PThreads reuse the runtime from the main thread.
 
   // No ATPOSTRUNS hooks
 }
@@ -1349,8 +1350,6 @@ function run() {
   assert(!Module['_main'], 'compiled without a main, but one is present. if you added it from JS, use Module["onRuntimeInitialized"]');
 
   postRun();
-
-  checkStackCookie();
 }
 
 function checkUnflushedContent() {

--- a/test/codesize/test_small_js_flags.expected.js
+++ b/test/codesize/test_small_js_flags.expected.js
@@ -130,8 +130,6 @@ function initRuntime() {
   wasmExports["c"]();
 }
 
-function preMain() {}
-
 function postRun() {}
 
 /**
@@ -443,7 +441,7 @@ function run() {
   preRun();
   if (ABORT) return;
   initRuntime();
-  preMain();
+  // No ATMAINS hooks
   var noInitialRun = false;
   if (!noInitialRun) callMain();
   postRun();

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 55820,
-  "hello_world.js.gz": 17610,
+  "hello_world.js": 55706,
+  "hello_world.js.gz": 17578,
   "hello_world.wasm": 15115,
   "hello_world.wasm.gz": 7464,
-  "no_asserts.js": 25465,
-  "no_asserts.js.gz": 8700,
+  "no_asserts.js": 25373,
+  "no_asserts.js.gz": 8666,
   "no_asserts.wasm": 12229,
   "no_asserts.wasm.gz": 6004,
-  "strict.js": 52922,
-  "strict.js.gz": 16583,
+  "strict.js": 52808,
+  "strict.js.gz": 16552,
   "strict.wasm": 15115,
   "strict.wasm.gz": 7461,
-  "total": 176666,
-  "total_gz": 63822
+  "total": 176346,
+  "total_gz": 63725
 }


### PR DESCRIPTION
This avoids ever generating an empty version this function, which can show up as dead code in the output.

I think the need for separate function here probably came out the complex logic we used to have to re-entering the `run` function.  These days with async this function is pretty much straight line. 

