### PR TITLE
Remove default second argument from addEventListener calls. NFC

### DIFF
--- a/src/lib/libbrowser.js
+++ b/src/lib/libbrowser.js
@@ -97,7 +97,7 @@ var LibraryBrowser = {
           var b = new Blob([byteArray], { type: Browser.getMimetype(name) });
           var url = URL.createObjectURL(b); // XXX we never revoke this!
           var audio = new Audio();
-          audio.addEventListener('canplaythrough', () => finish(audio), false); // use addEventListener due to chromium bug 124926
+          audio.addEventListener('canplaythrough', () => finish(audio)); // use addEventListener due to chromium bug 124926
           audio.onerror = (event) => {
             if (done) return;
             err(`warning: browser could not fully decode audio ${name}, trying slower base64 approach`);
@@ -149,7 +149,7 @@ var LibraryBrowser = {
         // forced aspect ratio can be enabled by defining 'forcedAspectRatio' on Module
         // Module['forcedAspectRatio'] = 4 / 3;
 
-        document.addEventListener('pointerlockchange', pointerLockChange, false);
+        document.addEventListener('pointerlockchange', pointerLockChange);
 
         if (Module['elementPointerLock']) {
           canvas.addEventListener("click", (ev) => {
@@ -157,7 +157,7 @@ var LibraryBrowser = {
               Browser.getCanvas().requestPointerLock();
               ev.preventDefault();
             }
-          }, false);
+          });
         }
       }
     },
@@ -254,10 +254,10 @@ var LibraryBrowser = {
 
       if (!Browser.fullscreenHandlersInstalled) {
         Browser.fullscreenHandlersInstalled = true;
-        document.addEventListener('fullscreenchange', fullscreenChange, false);
-        document.addEventListener('mozfullscreenchange', fullscreenChange, false);
-        document.addEventListener('webkitfullscreenchange', fullscreenChange, false);
-        document.addEventListener('MSFullscreenChange', fullscreenChange, false);
+        document.addEventListener('fullscreenchange', fullscreenChange);
+        document.addEventListener('mozfullscreenchange', fullscreenChange);
+        document.addEventListener('webkitfullscreenchange', fullscreenChange);
+        document.addEventListener('MSFullscreenChange', fullscreenChange);
       }
 
       // create a new parent to ensure the canvas has no siblings. this allows browsers to optimize full screen performance when its parent is the full screen root

--- a/src/lib/libglfw.js
+++ b/src/lib/libglfw.js
@@ -1249,10 +1249,10 @@ var LibraryGLFW = {
 
       if (!Browser.fullscreenHandlersInstalled) {
         Browser.fullscreenHandlersInstalled = true;
-        document.addEventListener('fullscreenchange', fullscreenChange, false);
-        document.addEventListener('mozfullscreenchange', fullscreenChange, false);
-        document.addEventListener('webkitfullscreenchange', fullscreenChange, false);
-        document.addEventListener('MSFullscreenChange', fullscreenChange, false);
+        document.addEventListener('fullscreenchange', fullscreenChange);
+        document.addEventListener('mozfullscreenchange', fullscreenChange);
+        document.addEventListener('webkitfullscreenchange', fullscreenChange);
+        document.addEventListener('MSFullscreenChange', fullscreenChange);
       }
 
       // create a new parent to ensure the canvas has no siblings. this allows browsers to optimize full screen performance when its parent is the full screen root

--- a/src/lib/libtrace.js
+++ b/src/lib/libtrace.js
@@ -75,7 +75,7 @@ var LibraryTracing = {
       EmscriptenTrace.worker.addEventListener('error', (e) => {
         out('TRACE WORKER ERROR:');
         out(e);
-      }, false);
+      });
       EmscriptenTrace.worker.postMessage({ 'cmd': 'configure',
                                            'data_version': EmscriptenTrace.DATA_VERSION,
                                            'session_id': session_id,

--- a/src/lib/libwebgl.js
+++ b/src/lib/libwebgl.js
@@ -736,7 +736,7 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
       function onContextCreationError(event) {
         errorInfo = event.statusMessage || errorInfo;
       }
-      canvas.addEventListener('webglcontextcreationerror', onContextCreationError, false);
+      canvas.addEventListener('webglcontextcreationerror', onContextCreationError);
 #endif
 
 #if GL_PREINITIALIZED_CONTEXT
@@ -794,7 +794,7 @@ for (/**@suppress{duplicate}*/var i = 0; i <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}};
 #endif
 
 #if GL_DEBUG
-      canvas.removeEventListener('webglcontextcreationerror', onContextCreationError, false);
+      canvas.removeEventListener('webglcontextcreationerror', onContextCreationError);
       if (!ctx) {
         dbg('Could not create canvas: ' + [errorInfo, JSON.stringify(webGLContextAttributes)]);
         return 0;

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268603,
+  "a.out.js": 268582,
   "a.out.nodebug.wasm": 587520,
-  "total": 856123,
+  "total": 856102,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
One explanation for why this argument might have been included back in the day.  In older browsers (for example, Firefox versions prior to 6.0, which was released in 2011), omitting the third argument would actually throw a signature mismatch error or cause the browser to fail to register the listener.

See https://caniuse.com/mdn-api_eventtarget_addeventlistener_usecapture_parameter_optional