### PR TITLE
Remove redundant ',' from Array.join calls. NFC

### DIFF
--- a/src/lib/libdylink.js
+++ b/src/lib/libdylink.js
@@ -834,7 +834,7 @@ var LibraryDylink = {
             if (!body.includes(argName)) break;
             args.push(argName);
           }
-          args = args.join(',');
+          args = args.join();
           var func = `(${args}) => { ${body} };`;
 #if DYLINK_DEBUG
           dbg('adding new EM_ASM constant at:', ptrToString(start));

--- a/src/lib/libembind_shared.js
+++ b/src/lib/libembind_shared.js
@@ -216,8 +216,8 @@ var LibraryEmbindShared = {
       argsList.push(`arg${i}`)
       argsListWired.push(`arg${i}Wired`)
     }
-    argsList = argsList.join(',')
-    argsListWired = argsListWired.join(',')
+    argsList = argsList.join()
+    argsListWired = argsListWired.join()
 
     var invokerFnBody = `return function (${argsList}) {\n`;
 

--- a/src/lib/libexceptions.js
+++ b/src/lib/libexceptions.js
@@ -436,7 +436,7 @@ addCxaCatch = (n) => {
     args.push(`arg${i}`);
     sig += 'p';
   }
-  const argString = args.join(',');
+  const argString = args.join();
   LibraryManager.library[`__cxa_find_matching_catch_${n}__sig`] = sig;
   LibraryManager.library[`__cxa_find_matching_catch_${n}__deps`] = ['$findMatchingCatch'];
   LibraryManager.library[`__cxa_find_matching_catch_${n}`] = eval(`(${args}) => findMatchingCatch([${argString}])`);

--- a/src/lib/libhtml5_webgl.js
+++ b/src/lib/libhtml5_webgl.js
@@ -598,7 +598,7 @@ function handleWebGLProxying(funcs) {
       funcs[i + '__deps'].push(i + '_main_thread');
       delete funcs[i + '__proxy'];
       const funcArgs = listOfNFunctionArgs(funcs[i]);
-      const funcArgsString = funcArgs.join(',');
+      const funcArgsString = funcArgs.join();
       const retStatement = sig[0] != 'v' ? 'return' : '';
       const contextCheck = proxyContextHandle ? 'GL.contexts[p0]' : 'GLctx';
       var funcBody = `${retStatement} ${contextCheck} ? _${i}_calling_thread(${funcArgsString}) : _${i}_main_thread(${funcArgsString});`;

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26269,
-  "a.out.js.gz": 11189,
+  "a.out.js": 26266,
+  "a.out.js.gz": 11188,
   "a.out.nodebug.wasm": 17861,
   "a.out.nodebug.wasm.gz": 9019,
-  "total": 44130,
-  "total_gz": 20208,
+  "total": 44127,
+  "total_gz": 20207,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268582,
+  "a.out.js": 268579,
   "a.out.nodebug.wasm": 587520,
-  "total": 856102,
+  "total": 856099,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
`,` is the default separator for `Array.prototype.join`.