### PR TITLE
Enable GROWABLE_ARRAYBUFFERS under Firefox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1101,11 +1101,6 @@ jobs:
           test_targets: "browser64_4gb skip:browser64_4gb.test_mainScriptUrlOrBlob*"
   test-browser-firefox:
     executor: ubuntu-lts
-    environment:
-      # Deserializing a growable SharedArrayBuffer is currently broken in Firefox.
-      # See: https://github.com/emscripten-core/emscripten/issues/27118
-      # See: https://bugzilla.mozilla.org/show_bug.cgi?id=2021136
-      EMTEST_LACKS_GROWABLE_ARRAYBUFFERS: "1"
     steps:
       - prepare-for-tests
       - run-tests-firefox:

--- a/src/runtime_common.js
+++ b/src/runtime_common.js
@@ -117,11 +117,11 @@ function getMemoryBuffer() {
   return wasmMemory.toResizableBuffer();
 #else
 #if GROWABLE_ARRAYBUFFERS == 1
-#if SHARED_MEMORY && (MIN_FIREFOX_VERSION != TARGET_NOT_SUPPORTED)
-  // Deserializing a growable SharedArrayBuffer is currently broken in Firefox.
-  // See: https://github.com/emscripten-core/emscripten/issues/27118
+#if SHARED_MEMORY && (MIN_FIREFOX_VERSION < 154)
+  // Deserializing a growable SharedArrayBuffer was broken until Firefox 154
   // See: https://bugzilla.mozilla.org/show_bug.cgi?id=2021136
-  if (!globalThis.navigator?.userAgent?.match(/firefox/i)) {
+  var firefoxMatch = globalThis.navigator?.userAgent?.match(/Firefox\/(\d+)/);
+  if (!firefoxMatch || Number(firefoxMatch[1]) >= 154) {
 #endif
   try {
     // This method may be missing or could fail with `Memory must have a maximum`
@@ -132,7 +132,7 @@ function getMemoryBuffer() {
     return b;
     
   } catch {}
-#if SHARED_MEMORY && (MIN_FIREFOX_VERSION != TARGET_NOT_SUPPORTED)
+#if SHARED_MEMORY && (MIN_FIREFOX_VERSION < 154)
   }
 #endif
 #endif // GROWABLE_ARRAYBUFFERS == 1

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -137,8 +137,6 @@ min_browser_versions = {
   },
   # Growable SharedArrayBuffers improves memory growth feature in multithreaded
   # builds by avoiding need to poll resizes to ArrayBuffer views in Workers.
-  # This feature is not used anywhere else except the test harness to detect
-  # browser version.
   # https://caniuse.com/mdn-webassembly_api_memory_toresizablebuffer
   Feature.GROWABLE_ARRAYBUFFERS: {
     'chrome': 144,


### PR DESCRIPTION
The upstream bug is now fixed in nightly and slated for release in 154.

Fixes: #27118