### PR TITLE
Set GROWABLE_ARRAYBUFFERS=1 by default

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 6.0.2 (in development)
 ----------------------
+- The `GROWABLE_ARRAYBUFFERS` setting now defaults to 1, which means it will be
+  used when available. Note that this only affects programs that are built with
+  `ALLOW_MEMORY_GROWTH`, which is not enabled by default. (#27212)
 - New `-sNODERAWSOCKETS` setting that backs the POSIX sockets API with real TCP
   (`node:net`) and UDP (`node:dgram`) sockets on Node.js, with no `ws`, proxy
   process, or pthreads required. Supports incoming and outgoing TCP, UDP, IPv6,

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -3404,13 +3404,13 @@ GROWABLE_ARRAYBUFFERS
 Enable support for growable views of Wasm memory. This is a recent Web
 platform feature that can make growing the Wasm memory more efficient,
 especially in multi-threaded builds.
-Setting this to 1 will auto-detect the presence of this API and use it
-when available.
+The default setting of 1 will auto-detect the presence of this API and use
+it when available.
 Setting this to 2 will unconditionally require it. This is the only way
 to completely remove the overhead of growable memory + pthreads.
 This settings does nothing unless ALLOW_MEMORY_GROWTH is set.
 
-Default value: 0
+Default value: 1
 
 .. _cross_origin:
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -2250,13 +2250,13 @@ var JS_BASE64_API = false;
 // Enable support for growable views of Wasm memory. This is a recent Web
 // platform feature that can make growing the Wasm memory more efficient,
 // especially in multi-threaded builds.
-// Setting this to 1 will auto-detect the presence of this API and use it
-// when available.
+// The default setting of 1 will auto-detect the presence of this API and use
+// it when available.
 // Setting this to 2 will unconditionally require it. This is the only way
 // to completely remove the overhead of growable memory + pthreads.
 // This settings does nothing unless ALLOW_MEMORY_GROWTH is set.
 // [link]
-var GROWABLE_ARRAYBUFFERS = 0;
+var GROWABLE_ARRAYBUFFERS = 1;
 
 // If the emscripten-generated program is hosted on separate origin then
 // starting new pthread worker can violate CSP rules.  Enabling

--- a/test/codesize/test_codesize_mem_O3_grow.json
+++ b/test/codesize/test_codesize_mem_O3_grow.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4339,
-  "a.out.js.gz": 2132,
+  "a.out.js": 4386,
+  "a.out.js.gz": 2154,
   "a.out.nodebug.wasm": 5261,
   "a.out.nodebug.wasm.gz": 2419,
-  "total": 9600,
-  "total_gz": 4551,
+  "total": 9647,
+  "total_gz": 4573,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/codesize/test_codesize_mem_O3_grow_standalone.json
+++ b/test/codesize/test_codesize_mem_O3_grow_standalone.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 3805,
-  "a.out.js.gz": 1869,
+  "a.out.js": 3852,
+  "a.out.js.gz": 1896,
   "a.out.nodebug.wasm": 5641,
   "a.out.nodebug.wasm.gz": 2659,
-  "total": 9446,
-  "total_gz": 4528,
+  "total": 9493,
+  "total_gz": 4555,
   "sent": [
     "args_get",
     "args_sizes_get",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7381,
-  "a.out.js.gz": 3643,
+  "a.out.js": 7552,
+  "a.out.js.gz": 3708,
   "a.out.nodebug.wasm": 19064,
   "a.out.nodebug.wasm.gz": 8804,
-  "total": 26445,
-  "total_gz": 12447,
+  "total": 26616,
+  "total_gz": 12512,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/tools/link.py
+++ b/tools/link.py
@@ -1752,6 +1752,8 @@ def phase_linker_setup(options, linker_args):  # noqa: C901, PLR0912, PLR0915
       exit_with_error('wasm2js does not support WASM_BIGINT')
     if settings.CAN_ADDRESS_2GB:
       exit_with_error('wasm2js does not support >2gb address space')
+    # WASM2JS does not support GROWABLE_ARRAYBUFFERS at all
+    default_setting('GROWABLE_ARRAYBUFFERS', 0)
 
   if settings.NODE_CODE_CACHING:
     if settings.WASM_ASYNC_COMPILATION:


### PR DESCRIPTION
This means we auto-detect and use the `toResizeableBuffer` method in cases
where it is useful.

By default this still has no effect because `ALLOW_MEMORY_GROWTH` is not
enabled by default.

See `TEXTDECODER` for similar ternary setting where we default to 1.