### PR TITLE
Separate test config from core compiler. NFC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,9 @@ mypy_path = "third_party/,third_party/ply,third_party/websockify"
 files = [ "." ]
 exclude = '''
 (?x)(
-cache |
-third_party |
+out/ |
+cache/ |
+third_party/ |
 conf\.py |
 emrun\.py |
 site/source/_themes/ |

--- a/test/benchmark/benchmark_sse.py
+++ b/test/benchmark/benchmark_sse.py
@@ -20,7 +20,7 @@ sys.path.insert(0, __testdir__)
 import clang_native
 from common import EMRUN, test_file
 
-from tools.config import V8_ENGINE
+from tools import config
 from tools.shared import CLANG_CXX, EMCC
 from tools.utils import WINDOWS, run_process, write_file
 
@@ -56,7 +56,7 @@ def run_benchmark(benchmark_file, results_file, build_args):
     print(' '.join(cmd))
     run_process(cmd)
 
-    cmd = V8_ENGINE + [os.path.basename(out_file)]
+    cmd = config.V8_ENGINE + [os.path.basename(out_file)]
     print(' '.join(cmd))
     wasm_results = subprocess.check_output(cmd, cwd=out_dir, text=True)
 

--- a/test/common.py
+++ b/test/common.py
@@ -79,13 +79,26 @@ WASM_DIS = os.path.join(building.get_binaryen_bin(), 'wasm-dis')
 LLVM_OBJDUMP = shared.llvm_tool_path('llvm-objdump')
 PYTHON = sys.executable
 
-assert config.NODE_JS # assert for mypy's benefit
-# By default we run the tests in the same version of node as emscripten itself used.
-if not config.NODE_JS_TEST:
-  config.NODE_JS_TEST = config.NODE_JS
-# The default set of JS_ENGINES contains just node.
-if not config.JS_ENGINES:
-  config.JS_ENGINES = [config.NODE_JS_TEST]
+
+def setup_test_config():
+  assert config.NODE_JS # assert for mypy's benefit
+  # By default we run the tests in the same version of node as emscripten itself used.
+  if not config.NODE_JS_TEST:
+    config.NODE_JS_TEST = config.NODE_JS
+  # The default set of JS_ENGINES contains just node.
+  if not config.JS_ENGINES:
+    config.JS_ENGINES = [config.NODE_JS_TEST]
+  if not config.WASM_ENGINES:
+    config.WASM_ENGINES = []
+
+  config.SPIDERMONKEY_ENGINE = config.listify(config.SPIDERMONKEY_ENGINE)
+  config.NODE_JS_TEST = config.listify(config.NODE_JS_TEST)
+  config.V8_ENGINE = config.listify(config.V8_ENGINE)
+  config.JS_ENGINES = [config.listify(e) for e in config.JS_ENGINES]
+  config.WASM_ENGINES = [config.listify(e) for e in config.WASM_ENGINES]
+
+
+setup_test_config()
 
 
 def errlog(*args):
@@ -1010,7 +1023,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
       engine += ['--unstable-detect-cjs', '--allow-all', '--v8-flags=--expose-gc']
     elif engine_is_v8(engine):
       engine += self.v8_args
-    elif engine == config.SPIDERMONKEY_ENGINE:
+    elif engine_is_spidermonkey(engine):
       engine += self.spidermonkey_args
     return engine
 

--- a/test/runner.py
+++ b/test/runner.py
@@ -40,6 +40,9 @@ from functools import cmp_to_key
 __rootpath__ = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, __rootpath__)
 
+# Let config.py know to parse test config settings
+os.environ['_EM_TEST_RUNNER'] = '1'
+
 import browser_common
 import common
 import jsrun

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -3,6 +3,8 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
+# mypy: disable-error-code="attr-defined"
+
 import json
 import math
 import os

--- a/tools/config.py
+++ b/tools/config.py
@@ -27,20 +27,10 @@ FROZEN_CACHE = None
 CACHE = None
 PORTS = None
 COMPILER_WRAPPER = None
+LLVM_ROOT = None
 
 # Set by init()
 EM_CONFIG = None
-
-# Settings that are only used for testing.  emcc itself does not use
-# any of these.
-NODE_JS_TEST = None
-SPIDERMONKEY_ENGINE = None
-V8_ENGINE: list[str] | None = None
-LLVM_ROOT = None
-JS_ENGINES: list[list[str]] = []
-WASMER = None
-WASMTIME = None
-WASM_ENGINES: list[list[str]] = []
 
 
 def listify(x):
@@ -49,24 +39,10 @@ def listify(x):
   return [x]
 
 
-def fix_js_engine(old, new):
-  if old is None:
-    return
-  global JS_ENGINES
-  JS_ENGINES = [new if x == old else x for x in JS_ENGINES]
-  return new
-
-
 def normalize_config_settings():
-  global CACHE, PORTS, LLVM_ADD_VERSION, CLANG_ADD_VERSION, CLOSURE_COMPILER
-  global NODE_JS, NODE_JS_TEST, V8_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, WASM_ENGINES
+  global CACHE, PORTS, CLOSURE_COMPILER, NODE_JS
 
-  SPIDERMONKEY_ENGINE = fix_js_engine(SPIDERMONKEY_ENGINE, listify(SPIDERMONKEY_ENGINE))
-  NODE_JS = fix_js_engine(NODE_JS, listify(NODE_JS))
-  NODE_JS_TEST = fix_js_engine(NODE_JS_TEST, listify(NODE_JS_TEST))
-  V8_ENGINE = fix_js_engine(V8_ENGINE, listify(V8_ENGINE))
-  JS_ENGINES = [listify(engine) for engine in JS_ENGINES]
-  WASM_ENGINES = [listify(engine) for engine in WASM_ENGINES]
+  NODE_JS = listify(NODE_JS)
   CLOSURE_COMPILER = listify(CLOSURE_COMPILER)
   if not CACHE:
     CACHE = path_from_root('cache')
@@ -115,23 +91,31 @@ def parse_config_file():
 
   CONFIG_KEYS = (
     'NODE_JS',
-    'NODE_JS_TEST',
     'BINARYEN_ROOT',
-    'SPIDERMONKEY_ENGINE',
-    'V8_ENGINE',
     'LLVM_ROOT',
     'LLVM_ADD_VERSION',
     'CLANG_ADD_VERSION',
     'CLOSURE_COMPILER',
-    'JS_ENGINES',
-    'WASMER',
-    'WASMTIME',
-    'WASM_ENGINES',
     'FROZEN_CACHE',
     'CACHE',
     'PORTS',
     'COMPILER_WRAPPER',
   )
+
+  if '_EM_TEST_RUNNER' in os.environ:
+    # TODO(sbc): Move this completely out of the core compiler and into the test framework.
+    TEST_KEYS = (
+      'NODE_JS_TEST',
+      'V8_ENGINE',
+      'SPIDERMONKEY_ENGINE',
+      'JS_ENGINES',
+      'WASMER',
+      'WASMTIME',
+      'WASM_ENGINES',
+    )
+    CONFIG_KEYS += TEST_KEYS
+    for key in TEST_KEYS:
+      globals()[key] = None
 
   # Only propagate certain settings from the config file.
   for key in CONFIG_KEYS:


### PR DESCRIPTION
This is the first part of my plan to separate test setup from the compiler setup.

Note that we no longer need `fix_js_engine` because we no longer do identity checks on the JS engine anywhere in the test code. i.e. we no longer depend on being able to do `if engine == V8_ENGINE`, and instead we have an `is_engine_v8` helper function.

See #27219 and #26453 for the long term reason for doing this, but its also just good hygiene to keep the test setup out of the core compiler.