### PR TITLE
run_python.sh: Add `readlink` to allow symlinks to compiler entry points to work correctly

### DIFF
--- a/tools/maint/run_python.sh
+++ b/tools/maint/run_python.sh
@@ -30,4 +30,4 @@ if [ -z "$_EM_PY" ]; then
   exit 1
 fi
 
-exec "$_EM_PY" -E "$0.py" "$@"
+exec "$_EM_PY" -E "$(readlink -f $0).py" "$@"


### PR DESCRIPTION
This allows symbol links to the the compiler to work.  Without this change, if you have for example `/usr/bin/emcc` as a symlink for `/usr/local/share/emscripten/emcc` then it would not work.

Fixes: #27211