### PR TITLE
[CI] Remove Rosetta from macOS build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,7 +363,6 @@ commands:
       - upload-test-results
   setup-macos:
     steps:
-      - macos/install-rosetta
       - run:
           name: Install brew package dependencies
           environment:


### PR DESCRIPTION
This should no longer be needed with the new closure compiler.