### PR TITLE
Refactor async poll()/select() onto a per-inode readiness wait-queue

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,11 @@ See docs/process.md for more on how version tagging works.
 - The `GROWABLE_ARRAYBUFFERS` setting now defaults to 1, which means it will be
   used when available. Note that this only affects programs that are built with
   `ALLOW_MEMORY_GROWTH`, which is not enabled by default. (#27212)
+- The async `poll()`/`select()` implementation was refactored onto a per-inode
+  readiness wait-queue. As part of this, the (undocumented) `stream_ops.poll`
+  FS-backend handler signature changed from `poll(stream, timeout)` to
+  `poll(stream)` returning the current readiness mask; out-of-tree custom FS
+  backends with a `poll` handler must update. (#27207)
 - New `-sNODERAWSOCKETS` setting that backs the POSIX sockets API with real TCP
   (`node:net`) and UDP (`node:dgram`) sockets on Node.js, with no `ws`, proxy
   process, or pthreads required. Supports incoming and outgoing TCP, UDP, IPv6,

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,7 +27,7 @@ See docs/process.md for more on how version tagging works.
   readiness wait-queue. As part of this, the (undocumented) `stream_ops.poll`
   FS-backend handler signature changed from `poll(stream, timeout)` to
   `poll(stream)` returning the current readiness mask; out-of-tree custom FS
-  backends with a `poll` handler must update. (#27207)
+  backends with a `poll` handler must update. (#27226)
 - New `-sNODERAWSOCKETS` setting that backs the POSIX sockets API with real TCP
   (`node:net`) and UDP (`node:dgram`) sockets on Node.js, with no `ws`, proxy
   process, or pthreads required. Supports incoming and outgoing TCP, UDP, IPv6,

--- a/src/lib/libfs.js
+++ b/src/lib/libfs.js
@@ -134,6 +134,15 @@ FS.staticInit();`;
       readMode = {{{ cDefs.S_IRUGO }}} | {{{ cDefs.S_IXUGO }}};
       writeMode = {{{ cDefs.S_IWUGO }}};
       mounted = null;
+#if USE_CLOSURE_COMPILER
+      // Closure (@struct) requires these declared ahead of time. The readiness
+      // wait-queue is populated lazily, and only on nodes that derive real
+      // readiness (sockets, pipes, an epoll's own node).
+      /** @type {Set<?>|null} */
+      listeners = null;
+      /** @type {number} */
+      exclTurn = 0;
+#endif
       constructor(parent, name, mode, rdev) {
         if (!parent) {
           parent = this;  // root node sets parent to itself
@@ -163,6 +172,48 @@ FS.staticInit();`;
       }
       get isDevice() {
         return FS.isChrdev(this.mode);
+      }
+      // The per-inode readiness wait-queue. The node carries a Set of listener
+      // entries {cb}; producers (SOCKFS, PIPEFS) call notifyListeners on a
+      // readiness transition, and poll()/epoll consume it. It lives on the node
+      // (not the fd) so dup'd fds share one queue. Only nodes that derive real
+      // readiness (sockets, pipes, and an epoll's own node) ever use this -
+      // always-ready types (regular files, ttys) never register or notify.
+      addListener(cb, exclusive = false) {
+        var entry = {cb, exclusive};
+        var listeners = (this.listeners ??= new Set());
+        listeners.add(entry);
+        return {listeners, entry};
+      }
+      notifyListeners(flags) {
+        // Iterates the set without copying, which is safe ONLY under a
+        // load-bearing contract that every internal listener must honour:
+        //   1. A listener must not run user code synchronously (a poll waiter only
+        //      resolves a Promise; an epoll registration only re-lists +
+        //      re-notifies; the epoll callback only schedules a tick). User code
+        //      runs on a later tick, never inside this loop.
+        //   2. A listener may delete entries only from ITS OWN waiter, never from
+        //      a sibling node's set that may be mid-iteration. (Deleting an entry
+        //      of the set being iterated here is fine - a Set tolerates removal of
+        //      a not-yet-visited entry mid-iteration; mutating a *different* node's
+        //      set is fine because that set is not being iterated.)
+        // Violating either gives silently skipped wakeups that are near-impossible
+        // to reproduce. Any new producer/listener must preserve it.
+        if (!this.listeners) return;
+        // Fire every non-exclusive listener. Among EPOLLEXCLUSIVE registrations
+        // (one fd watched by several epolls) wake only one, rotating round-robin
+        // per node, to avoid a thundering herd. (Only epoll registrations are ever
+        // exclusive; poll waiters and a node's own consumers are not.)
+        var excl;
+        for (var entry of this.listeners) {
+          if (entry.exclusive) (excl ||= []).push(entry);
+          else entry.cb(flags);
+        }
+        if (excl) {
+          var i = (this.exclTurn || 0) % excl.length;
+          this.exclTurn = i + 1;
+          excl[i].cb(flags);
+        }
       }
     },
 
@@ -1189,6 +1240,11 @@ FS.staticInit();`;
         throw new FS.ErrnoError({{{ cDefs.EBADF }}});
       }
       if (stream.getdents) stream.getdents = null; // free readdir state
+      // The fd is going away: wake anything waiting on it (poll/epoll) with
+      // POLLNVAL so a blocking wait unblocks and an epoll registration is evicted
+      // on its next derive. Only sockets/pipes/epoll ever carry a wait-queue, so
+      // for every other stream (incl. nodeless noderawfs stdio) this is a no-op.
+      stream.node?.notifyListeners({{{ cDefs.POLLNVAL }}});
       try {
         if (stream.stream_ops.close) {
           stream.stream_ops.close(stream);

--- a/src/lib/libpipefs.js
+++ b/src/lib/libpipefs.js
@@ -21,23 +21,6 @@ addToLibrary({
         // able to read from the read end after write end is closed.
         refcnt : 2,
         timestamp: new Date(),
-#if PTHREADS || ASYNCIFY
-        readableHandlers: [],
-        registerReadableHandler: (callback) => {
-          callback.registerCleanupFunc(() => {
-            const i = pipe.readableHandlers.indexOf(callback);
-            if (i !== -1) pipe.readableHandlers.splice(i, 1);
-          });
-          pipe.readableHandlers.push(callback);
-        },
-        notifyReadableHandlers: () => {
-          while (pipe.readableHandlers.length > 0) {
-            const cb = pipe.readableHandlers.shift();
-            if (cb) cb({{{ cDefs.POLLRDNORM }}} | {{{ cDefs.POLLIN }}});
-          }
-          pipe.readableHandlers = [];
-        }
-#endif
       };
 
       pipe.buckets.push({
@@ -53,6 +36,8 @@ addToLibrary({
 
       rNode.pipe = pipe;
       wNode.pipe = pipe;
+      // The read end's node carries the poll wait-queue; writes wake it.
+      pipe.readNode = rNode;
 
       var readableStream = FS.createStream({
         path: rName,
@@ -97,7 +82,7 @@ addToLibrary({
           blocks: 0,
         };
       },
-      poll(stream, timeout, notifyCallback) {
+      poll(stream) {
         var pipe = stream.node.pipe;
 
         if ((stream.flags & {{{ cDefs.O_ACCMODE }}}) === {{{ cDefs.O_WRONLY }}}) {
@@ -108,10 +93,6 @@ addToLibrary({
             return ({{{ cDefs.POLLRDNORM }}} | {{{ cDefs.POLLIN }}});
           }
         }
-
-#if PTHREADS || ASYNCIFY
-        if (notifyCallback) pipe.registerReadableHandler(notifyCallback);
-#endif
         return 0;
       },
       dup(stream) {
@@ -233,9 +214,7 @@ addToLibrary({
         if (freeBytesInCurrBuffer >= dataLen) {
           currBucket.buffer.set(data, currBucket.offset);
           currBucket.offset += dataLen;
-#if PTHREADS || ASYNCIFY
-          pipe.notifyReadableHandlers();
-#endif
+          pipe.readNode.notifyListeners({{{ cDefs.POLLRDNORM }}} | {{{ cDefs.POLLIN }}});
           return dataLen;
         } else if (freeBytesInCurrBuffer > 0) {
           currBucket.buffer.set(data.subarray(0, freeBytesInCurrBuffer), currBucket.offset);
@@ -267,9 +246,7 @@ addToLibrary({
           newBucket.buffer.set(data);
         }
 
-#if PTHREADS || ASYNCIFY
-        pipe.notifyReadableHandlers();
-#endif
+        pipe.readNode.notifyListeners({{{ cDefs.POLLRDNORM }}} | {{{ cDefs.POLLIN }}});
         return dataLen;
       },
       close(stream) {

--- a/src/lib/libsockfs.js
+++ b/src/lib/libsockfs.js
@@ -23,6 +23,18 @@ addToLibrary({
     },
     emit(event, param) {
       SOCKFS.callbacks[event]?.(param);
+      // Bridge socket readiness into the inode wait-queue (poll/epoll). The
+      // 'error' event carries [fd, ...]; the rest carry the fd directly.
+      var fd = event === 'error' ? param[0] : param;
+      var flags = {
+        'message':    {{{ cDefs.POLLRDNORM }}} | {{{ cDefs.POLLIN }}},
+        'open':       {{{ cDefs.POLLOUT }}},
+        'connection': {{{ cDefs.POLLRDNORM }}} | {{{ cDefs.POLLIN }}},
+        'close':      {{{ cDefs.POLLIN }}} | {{{ cDefs.POLLHUP }}},
+        'error':      {{{ cDefs.POLLERR }}},
+      }[event];
+      // 'listen' has no readiness mapping; skip it.
+      if (flags) FS.getStream(fd)?.node.notifyListeners(flags);
     },
     mount(mount) {
 #if expectToReceiveOnModule('websocket')
@@ -417,7 +429,8 @@ addToLibrary({
           if (sock.connecting) {
             mask |= {{{ cDefs.POLLOUT }}};
           } else  {
-            mask |= {{{ cDefs.POLLHUP }}};
+            // A closed peer is both a full hangup and a read-side hangup.
+            mask |= {{{ cDefs.POLLHUP }}} | {{{ cDefs.POLLRDHUP }}};
           }
         }
 
@@ -555,6 +568,8 @@ addToLibrary({
             // push to queue for accept to pick up
             sock.pending.push(newsock);
             SOCKFS.emit('connection', newsock.stream.fd);
+            // A queued client makes the listening socket readable (POLLIN).
+            sock.stream.node.notifyListeners({{{ cDefs.POLLRDNORM }}} | {{{ cDefs.POLLIN }}});
           } else {
             // create a peer on the listen socket so calling sendto
             // with the listen socket and an address will resolve

--- a/src/lib/libsockfs_node.js
+++ b/src/lib/libsockfs_node.js
@@ -341,7 +341,10 @@ var NodeSockFSLibrary = {
       } else if (sock.connection && sock.state === {{{ SOCK_STATE_CONNECTED }}} && !sock.writeBlocked) {
         mask |= {{{ cDefs.POLLOUT }}};
       }
-      if (sock.readClosed) mask |= {{{ cDefs.POLLHUP }}};
+      // A peer FIN / read-side hangup (recv will see EOF) is POLLRDHUP; only a
+      // fully closed connection is a POLLHUP.
+      if (sock.readClosed) mask |= {{{ cDefs.POLLRDHUP }}};
+      if (sock.state === {{{ SOCK_STATE_CLOSED }}}) mask |= {{{ cDefs.POLLHUP }}};
       return mask;
     },
     ioctl(sock, request, arg) {
@@ -507,6 +510,8 @@ var NodeSockFSLibrary = {
         try { conn.resume(); } catch (e) {} // paused by pauseOnConnect
         sock.pending.push(newsock);
         SOCKFS.emit('connection', newsock.stream.fd);
+        // A queued client makes the listening socket readable (POLLIN).
+        sock.stream.node.notifyListeners({{{ cDefs.POLLRDNORM }}} | {{{ cDefs.POLLIN }}});
       });
       server.on('error', (e) => {
         sock.error = nodeSockHelpers.nodeErrToErrno(e);

--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -583,11 +583,6 @@ var SyscallsLibrary = {
     var stream = SYSCALLS.getStreamFromFD(fd);
     return 0; // we can't do anything synchronously; the in-memory FS is already synced to
   },
-  // The inode readiness wait-queue. It lives on the FS node (so dup'd fds share
-  // one queue) as a Set of identity entries {cb}: identity lets the same `cb` be
-  // registered more than once (a dup'd fd) and removed in O(1) without copying.
-  // Producers (SOCKFS.emit, pipe writes, epoll_ctl) feed it; poll()/epoll_wait
-  // consume it.
   // Derive readiness for one fd against its requested `events`: POLLNVAL for a
   // closed/bad fd, default readable+writable for types without a poll handler.
   // POLLERR/POLLHUP/POLLNVAL are output-only conditions reported regardless of
@@ -595,22 +590,18 @@ var SyscallsLibrary = {
   $pollOne__internal: true,
   $pollOne__deps: ['$FS'],
   $pollOne: (fd, events) => {
-    var flags = {{{ cDefs.POLLNVAL }}};
     var stream = FS.getStream(fd);
-    if (stream) {
-      // Streams without a poll handler (regular files, incl. NODERAWFS/NODEFS
-      // which leave stream_ops unset) are treated as always readable+writable.
-      if (stream.stream_ops?.poll) {
-        flags = stream.stream_ops.poll(stream);
-      } else {
-        flags = {{{ cDefs.POLLIN | cDefs.POLLOUT }}};
-      }
-    }
+    if (!stream) return {{{ cDefs.POLLNVAL }}};
+    // Streams without a poll handler (regular files, incl. NODERAWFS/NODEFS
+    // which leave stream_ops unset) are treated as always readable+writable.
+    var flags = stream.stream_ops?.poll
+      ? stream.stream_ops.poll(stream)
+      : {{{ cDefs.POLLIN | cDefs.POLLOUT }}};
     return flags & (events | {{{ cDefs.POLLERR }}} | {{{ cDefs.POLLHUP }}} | {{{ cDefs.POLLNVAL }}});
   },
   __syscall_poll__proxy: 'sync',
   __syscall_poll__async: 'auto',
-  __syscall_poll__deps: ['$doPoll',
+  __syscall_poll__deps: ['$doPollSync',
 #if PTHREADS || ASYNCIFY
     '$readPollfds', '$writePollfds', '$pollWait',
 #endif
@@ -624,7 +615,9 @@ var SyscallsLibrary = {
 #endif
     // When proxied from a worker (PTHREADS) or able to suspend (ASYNCIFY/JSPI),
     // block on the wait-queue: read the interests out of memory, wait, then
-    // write revents back into the (still-live) pollfd array and resolve.
+    // write revents back into the (still-live) pollfd array and resolve. This
+    // must run for every timeout (including zero): a proxied syscall's return is
+    // awaited by the caller thread, so it has to be a Promise even for a probe.
     if (isAsyncContext) {
 #if RUNTIME_DEBUG
       dbg('async poll start');
@@ -636,7 +629,7 @@ var SyscallsLibrary = {
       }));
     }
 #endif
-    var count = doPoll(fds, nfds);
+    var count = doPollSync(fds, nfds);
 #if ASSERTIONS
     if (!count && timeout != 0) warnOnce('non-zero poll() timeout not supported: ' + timeout)
 #endif
@@ -644,9 +637,9 @@ var SyscallsLibrary = {
   },
   // Synchronous poll(): derive each fd in place, writing revents and returning
   // the ready count. Used by the non-suspending syscall paths.
-  $doPoll__internal: true,
-  $doPoll__deps: ['$pollOne'],
-  $doPoll: (fds, nfds) => {
+  $doPollSync__internal: true,
+  $doPollSync__deps: ['$pollOne'],
+  $doPollSync: (fds, nfds) => {
     var count = 0;
     for (var i = 0; i < nfds; i++) {
       var pollfd = fds + {{{ C_STRUCTS.pollfd.__size__ }}} * i;
@@ -687,7 +680,8 @@ var SyscallsLibrary = {
   // Wait for readiness across a set of interests {fd, events, revents}, calling
   // complete(count) once: now if any are ready (or timeout 0), else register one
   // waiter per fd on its node wait-queue and re-derive the whole set on any wake
-  // (the wake flags are just the trigger), completing then or after `timeout`.
+  // (the wake flags are just the trigger), completing then or, for a positive
+  // `timeout`, once it elapses. A negative `timeout` waits forever.
   $pollWait__internal: true,
   $pollWait__deps: ['$FS', '$pollOne'],
   $pollWait: (pfds, timeout, complete) => {
@@ -716,11 +710,11 @@ var SyscallsLibrary = {
     if (count || !timeout) {
       finish(count);
     } else {
-      var recheck = () => {
+      function recheck() {
         if (done) return;
         var c = derive();
         if (c) finish(c);
-      };
+      }
       for (var p of pfds) {
         var stream = FS.getStream(p.fd);
         if (stream) regs.push(stream.node.addListener(recheck));
@@ -735,9 +729,9 @@ var SyscallsLibrary = {
   // __syscall_poll is a suspending import and traps when called from a stack
   // that wasn't entered through a promising export).
   __syscall_poll_nonblocking__proxy: 'sync',
-  __syscall_poll_nonblocking__deps: ['$doPoll'],
+  __syscall_poll_nonblocking__deps: ['$doPollSync'],
   __syscall_poll_nonblocking: (fds, nfds) => {
-    return doPoll(fds, nfds);
+    return doPollSync(fds, nfds);
   },
   // epoll is not yet implemented in the legacy (non-WASMFS) JS syscall layer.
   __syscall_epoll_create1__nothrow: true,

--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -583,11 +583,36 @@ var SyscallsLibrary = {
     var stream = SYSCALLS.getStreamFromFD(fd);
     return 0; // we can't do anything synchronously; the in-memory FS is already synced to
   },
+  // The inode readiness wait-queue. It lives on the FS node (so dup'd fds share
+  // one queue) as a Set of identity entries {cb}: identity lets the same `cb` be
+  // registered more than once (a dup'd fd) and removed in O(1) without copying.
+  // Producers (SOCKFS.emit, pipe writes, epoll_ctl) feed it; poll()/epoll_wait
+  // consume it.
+  // Derive readiness for one fd against its requested `events`: POLLNVAL for a
+  // closed/bad fd, default readable+writable for types without a poll handler.
+  // POLLERR/POLLHUP/POLLNVAL are output-only conditions reported regardless of
+  // `events` (a bad fd reports POLLNVAL even if the caller didn't ask for it).
+  $pollOne__internal: true,
+  $pollOne__deps: ['$FS'],
+  $pollOne: (fd, events) => {
+    var flags = {{{ cDefs.POLLNVAL }}};
+    var stream = FS.getStream(fd);
+    if (stream) {
+      // Streams without a poll handler (regular files, incl. NODERAWFS/NODEFS
+      // which leave stream_ops unset) are treated as always readable+writable.
+      if (stream.stream_ops?.poll) {
+        flags = stream.stream_ops.poll(stream);
+      } else {
+        flags = {{{ cDefs.POLLIN | cDefs.POLLOUT }}};
+      }
+    }
+    return flags & (events | {{{ cDefs.POLLERR }}} | {{{ cDefs.POLLHUP }}} | {{{ cDefs.POLLNVAL }}});
+  },
   __syscall_poll__proxy: 'sync',
   __syscall_poll__async: 'auto',
   __syscall_poll__deps: ['$doPoll',
 #if PTHREADS || ASYNCIFY
-    '$doPollAsync',
+    '$readPollfds', '$writePollfds', '$pollWait',
 #endif
   ],
   __syscall_poll: (fds, nfds, timeout) => {
@@ -597,114 +622,113 @@ var SyscallsLibrary = {
 #else
     const isAsyncContext = true;
 #endif
+    // When proxied from a worker (PTHREADS) or able to suspend (ASYNCIFY/JSPI),
+    // block on the wait-queue: read the interests out of memory, wait, then
+    // write revents back into the (still-live) pollfd array and resolve.
     if (isAsyncContext) {
-      return doPollAsync(fds, nfds, timeout);
+#if RUNTIME_DEBUG
+      dbg('async poll start');
+#endif
+      var pfds = readPollfds(fds, nfds);
+      return new Promise((resolve) => pollWait(pfds, timeout, (count) => {
+        writePollfds(fds, pfds);
+        resolve(count);
+      }));
     }
 #endif
-
-    var count = doPoll(fds, nfds, 0, undefined);
+    var count = doPoll(fds, nfds);
 #if ASSERTIONS
     if (!count && timeout != 0) warnOnce('non-zero poll() timeout not supported: ' + timeout)
 #endif
     return count;
   },
-#if PTHREADS || ASYNCIFY
-  $doPollAsync__internal: true,
-  $doPollAsync__deps: ['$FS', '$doPoll'],
-  $doPollAsync: (fds, nfds, timeout) => {
-#if RUNTIME_DEBUG
-    dbg('async poll start');
-#endif
-
-    // Enable event handlers only when the poll call is proxied from a worker.
-    // TODO: Could use `Promise.withResolvers` here if we know its available.
-    var resolve;
-    var promise = new Promise((resolve_) => { resolve = resolve_; });
-    var cleanupFuncs = [];
-    var notifyDone = false;
-
-    function asyncPollComplete(count) {
-      if (notifyDone) {
-        return;
-      }
-      notifyDone = true;
-#if RUNTIME_DEBUG
-      dbg('asyncPollComplete', count);
-#endif
-      cleanupFuncs.forEach(cb => cb());
-      resolve(count);
-    }
-
-    function makeNotifyCallback(stream, pollfd) {
-      var cb = (flags) => {
-        if (notifyDone) {
-          return;
-        }
-#if RUNTIME_DEBUG
-        dbg(`async poll notify: stream=${stream}`);
-#endif
-        var events = {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.events, 'i16') }}};
-        flags &= events | {{{ cDefs.POLLERR }}} | {{{ cDefs.POLLHUP }}} | {{{ cDefs.POLLNVAL }}};
-#if ASSERTIONS
-        assert(flags)
-#endif
-        {{{ makeSetValue('pollfd', C_STRUCTS.pollfd.revents, 'flags', 'i16') }}};
-        asyncPollComplete(1);
-      }
-      cb.registerCleanupFunc = (f) => {
-        if (f) cleanupFuncs.push(f);
-      }
-      return cb;
-    }
-    if (timeout > 0) {
-      var t = setTimeout(() => {
-#if RUNTIME_DEBUG
-        dbg('poll: timeout', timeout);
-#endif
-        asyncPollComplete(0);
-      }, timeout);
-      cleanupFuncs.push(() => clearTimeout(t));
-    }
-    // A zero timeout never registers notifications: the derivation alone
-    // answers, matching the non-blocking probe.
-    var count = doPoll(fds, nfds, timeout, makeNotifyCallback);
-    if (count || !timeout) {
-      asyncPollComplete(count);
-    }
-    return promise;
-  },
-#endif
-  // The shared readiness derivation: one pass over the pollfds, writing
-  // revents and returning the ready count. With a nonzero `timeout`, a
-  // readiness notification is also registered on each stream by the same
-  // `stream_ops.poll` call that derives it, so there is no window between
-  // registration and derivation; a zero `timeout` means the caller will not
-  // wait, so no notification is registered (the plain probe).
+  // Synchronous poll(): derive each fd in place, writing revents and returning
+  // the ready count. Used by the non-suspending syscall paths.
   $doPoll__internal: true,
-  $doPoll__deps: ['$FS'],
-  $doPoll: (fds, nfds, timeout, makeNotifyCallback) => {
+  $doPoll__deps: ['$pollOne'],
+  $doPoll: (fds, nfds) => {
     var count = 0;
     for (var i = 0; i < nfds; i++) {
       var pollfd = fds + {{{ C_STRUCTS.pollfd.__size__ }}} * i;
-      var fd = {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.fd, 'i32') }}};
-      var events = {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.events, 'i16') }}};
-      var flags = {{{ cDefs.POLLNVAL }}};
-      var stream = FS.getStream(fd);
-      if (stream) {
-        if (stream.stream_ops.poll) {
-          flags = timeout
-            ? stream.stream_ops.poll(stream, timeout, makeNotifyCallback(stream, pollfd))
-            : stream.stream_ops.poll(stream, -1);
-        } else {
-          flags = {{{ cDefs.POLLIN | cDefs.POLLOUT }}};
-        }
-      }
-      flags &= events | {{{ cDefs.POLLERR }}} | {{{ cDefs.POLLHUP }}} | {{{ cDefs.POLLNVAL }}};
-      if (flags) count++;
-      {{{ makeSetValue('pollfd', C_STRUCTS.pollfd.revents, 'flags', 'i16') }}};
+      var revents = pollOne(
+        {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.fd, 'i32') }}},
+        {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.events, 'i16') }}});
+      if (revents) count++;
+      {{{ makeSetValue('pollfd', C_STRUCTS.pollfd.revents, 'revents', 'i16') }}};
     }
     return count;
   },
+#if PTHREADS || ASYNCIFY
+  // Read a pollfd array into JS interests (fd + events); the source buffer need
+  // not persist afterwards.
+  $readPollfds__internal: true,
+  $readPollfds: (fds, nfds) => {
+    var pfds = [];
+    for (var i = 0; i < nfds; i++) {
+      var pollfd = fds + {{{ C_STRUCTS.pollfd.__size__ }}} * i;
+      pfds.push({
+        fd: {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.fd, 'i32') }}},
+        events: {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.events, 'i16') }}},
+        revents: 0,
+      });
+    }
+    return pfds;
+  },
+  // Write JS interests (fd + events + revents) into a pollfd array.
+  $writePollfds__internal: true,
+  $writePollfds: (fds, pfds) => {
+    for (var i = 0; i < pfds.length; i++) {
+      var pollfd = fds + {{{ C_STRUCTS.pollfd.__size__ }}} * i;
+      {{{ makeSetValue('pollfd', C_STRUCTS.pollfd.fd, 'pfds[i].fd', 'i32') }}};
+      {{{ makeSetValue('pollfd', C_STRUCTS.pollfd.events, 'pfds[i].events', 'i16') }}};
+      {{{ makeSetValue('pollfd', C_STRUCTS.pollfd.revents, 'pfds[i].revents', 'i16') }}};
+    }
+  },
+  // Wait for readiness across a set of interests {fd, events, revents}, calling
+  // complete(count) once: now if any are ready (or timeout 0), else register one
+  // waiter per fd on its node wait-queue and re-derive the whole set on any wake
+  // (the wake flags are just the trigger), completing then or after `timeout`.
+  $pollWait__internal: true,
+  $pollWait__deps: ['$FS', '$pollOne'],
+  $pollWait: (pfds, timeout, complete) => {
+    var regs = [];
+    var timer;
+    var done = false;
+    function derive() {
+      var count = 0;
+      for (var p of pfds) {
+        p.revents = pollOne(p.fd, p.events);
+        if (p.revents) count++;
+      }
+      return count;
+    }
+    function teardown() {
+      done = true;
+      for (var r of regs) r.listeners.delete(r.entry);
+      if (timer) clearTimeout(timer);
+    }
+    function finish(count) {
+      if (done) return;
+      teardown();
+      complete(count);
+    }
+    var count = derive();
+    if (count || !timeout) {
+      finish(count);
+    } else {
+      var recheck = () => {
+        if (done) return;
+        var c = derive();
+        if (c) finish(c);
+      };
+      for (var p of pfds) {
+        var stream = FS.getStream(p.fd);
+        if (stream) regs.push(stream.node.addListener(recheck));
+      }
+      if (timeout > 0) timer = setTimeout(() => finish(0), timeout);
+    }
+  },
+#endif
   // libc routes zero-timeout poll() calls here: the same synchronous
   // readiness derivation as __syscall_poll, but as a plain import that never
   // suspends, so probes stay callable from any context (under JSPI,
@@ -713,7 +737,7 @@ var SyscallsLibrary = {
   __syscall_poll_nonblocking__proxy: 'sync',
   __syscall_poll_nonblocking__deps: ['$doPoll'],
   __syscall_poll_nonblocking: (fds, nfds) => {
-    return doPoll(fds, nfds, 0, undefined);
+    return doPoll(fds, nfds);
   },
   // epoll is not yet implemented in the legacy (non-WASMFS) JS syscall layer.
   __syscall_epoll_create1__nothrow: true,

--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -603,7 +603,7 @@ var SyscallsLibrary = {
   __syscall_poll__async: 'auto',
   __syscall_poll__deps: ['$doPollSync',
 #if PTHREADS || ASYNCIFY
-    '$readPollfds', '$writePollfds', '$pollWait',
+    '$doPollAsync',
 #endif
   ],
   __syscall_poll: (fds, nfds, timeout) => {
@@ -614,19 +614,14 @@ var SyscallsLibrary = {
     const isAsyncContext = true;
 #endif
     // When proxied from a worker (PTHREADS) or able to suspend (ASYNCIFY/JSPI),
-    // block on the wait-queue: read the interests out of memory, wait, then
-    // write revents back into the (still-live) pollfd array and resolve. This
-    // must run for every timeout (including zero): a proxied syscall's return is
-    // awaited by the caller thread, so it has to be a Promise even for a probe.
+    // block on the wait-queue. This must run for every timeout (including zero):
+    // a proxied syscall's return is awaited by the caller thread, so it has to
+    // be a Promise even for a probe.
     if (isAsyncContext) {
 #if RUNTIME_DEBUG
       dbg('async poll start');
 #endif
-      var pfds = readPollfds(fds, nfds);
-      return new Promise((resolve) => pollWait(pfds, timeout, (count) => {
-        writePollfds(fds, pfds);
-        resolve(count);
-      }));
+      return doPollAsync(fds, nfds, timeout);
     }
 #endif
     var count = doPollSync(fds, nfds);
@@ -641,8 +636,7 @@ var SyscallsLibrary = {
   $doPollSync__deps: ['$pollOne'],
   $doPollSync: (fds, nfds) => {
     var count = 0;
-    for (var i = 0; i < nfds; i++) {
-      var pollfd = fds + {{{ C_STRUCTS.pollfd.__size__ }}} * i;
+    for (var i = 0, pollfd = fds; i < nfds; i++, pollfd += {{{ C_STRUCTS.pollfd.__size__ }}}) {
       var revents = pollOne(
         {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.fd, 'i32') }}},
         {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.events, 'i16') }}});
@@ -652,59 +646,34 @@ var SyscallsLibrary = {
     return count;
   },
 #if PTHREADS || ASYNCIFY
-  // Read a pollfd array into JS interests (fd + events); the source buffer need
-  // not persist afterwards.
-  $readPollfds__internal: true,
-  $readPollfds: (fds, nfds) => {
-    var pfds = [];
-    for (var i = 0; i < nfds; i++) {
-      var pollfd = fds + {{{ C_STRUCTS.pollfd.__size__ }}} * i;
-      pfds.push({
-        fd: {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.fd, 'i32') }}},
-        events: {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.events, 'i16') }}},
-        revents: 0,
-      });
-    }
-    return pfds;
-  },
-  // Write JS interests (fd + events + revents) into a pollfd array.
-  $writePollfds__internal: true,
-  $writePollfds: (fds, pfds) => {
-    for (var i = 0; i < pfds.length; i++) {
-      var pollfd = fds + {{{ C_STRUCTS.pollfd.__size__ }}} * i;
-      {{{ makeSetValue('pollfd', C_STRUCTS.pollfd.fd, 'pfds[i].fd', 'i32') }}};
-      {{{ makeSetValue('pollfd', C_STRUCTS.pollfd.events, 'pfds[i].events', 'i16') }}};
-      {{{ makeSetValue('pollfd', C_STRUCTS.pollfd.revents, 'pfds[i].revents', 'i16') }}};
-    }
-  },
-  // Wait for readiness across a set of interests {fd, events, revents}, calling
-  // complete(count) once: now if any are ready (or timeout 0), else register one
-  // waiter per fd on its node wait-queue and re-derive the whole set on any wake
-  // (the wake flags are just the trigger), completing then or, for a positive
-  // `timeout`, once it elapses. A negative `timeout` waits forever.
-  $pollWait__internal: true,
-  $pollWait__deps: ['$FS', '$pollOne'],
-  $pollWait: (pfds, timeout, complete) => {
+  // Async poll(): derive each fd in place (like doPollSync), but if nothing is
+  // ready and `timeout` is non-zero, register one waiter per fd on its node
+  // wait-queue and re-derive the whole set on any wake (the wake flags are just
+  // the trigger), resolving then or, for a positive `timeout`, once it elapses.
+  // A negative `timeout` waits forever. Returns a Promise of the ready count.
+  $doPollAsync__internal: true,
+  $doPollAsync__deps: ['$FS', '$pollOne'],
+  $doPollAsync: (fds, nfds, timeout) => new Promise((resolve) => {
     var regs = [];
     var timer;
     var done = false;
     function derive() {
       var count = 0;
-      for (var p of pfds) {
-        p.revents = pollOne(p.fd, p.events);
-        if (p.revents) count++;
+      for (var i = 0, pollfd = fds; i < nfds; i++, pollfd += {{{ C_STRUCTS.pollfd.__size__ }}}) {
+        var revents = pollOne(
+          {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.fd, 'i32') }}},
+          {{{ makeGetValue('pollfd', C_STRUCTS.pollfd.events, 'i16') }}});
+        if (revents) count++;
+        {{{ makeSetValue('pollfd', C_STRUCTS.pollfd.revents, 'revents', 'i16') }}};
       }
       return count;
     }
-    function teardown() {
+    function finish(count) {
+      if (done) return;
       done = true;
       for (var r of regs) r.listeners.delete(r.entry);
       if (timer) clearTimeout(timer);
-    }
-    function finish(count) {
-      if (done) return;
-      teardown();
-      complete(count);
+      resolve(count);
     }
     var count = derive();
     if (count || !timeout) {
@@ -715,13 +684,13 @@ var SyscallsLibrary = {
         var c = derive();
         if (c) finish(c);
       }
-      for (var p of pfds) {
-        var stream = FS.getStream(p.fd);
+      for (var i = 0, pollfd = fds; i < nfds; i++, pollfd += {{{ C_STRUCTS.pollfd.__size__ }}}) {
+        var stream = FS.getStream({{{ makeGetValue('pollfd', C_STRUCTS.pollfd.fd, 'i32') }}});
         if (stream) regs.push(stream.node.addListener(recheck));
       }
       if (timeout > 0) timer = setTimeout(() => finish(0), timeout);
     }
-  },
+  }),
 #endif
   // libc routes zero-timeout poll() calls here: the same synchronous
   // readiness derivation as __syscall_poll, but as a plain import that never

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -130,7 +130,8 @@
             "POLLWRNORM",
             "POLLIN",
             "POLLOUT",
-            "POLLNVAL"
+            "POLLNVAL",
+            "POLLRDHUP"
         ],
         "structs": {
             "pollfd": [

--- a/src/struct_info_generated.json
+++ b/src/struct_info_generated.json
@@ -352,6 +352,7 @@
         "POLLIN": 1,
         "POLLNVAL": 32,
         "POLLOUT": 4,
+        "POLLRDHUP": 8192,
         "POLLRDNORM": 64,
         "POLLWRNORM": 256,
         "PROT_WRITE": 2,

--- a/src/struct_info_generated_wasm64.json
+++ b/src/struct_info_generated_wasm64.json
@@ -352,6 +352,7 @@
         "POLLIN": 1,
         "POLLNVAL": 32,
         "POLLOUT": 4,
+        "POLLRDHUP": 8192,
         "POLLRDNORM": 64,
         "POLLWRNORM": 256,
         "PROT_WRITE": 2,

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19002,
-  "a.out.js.gz": 7881,
+  "a.out.js": 19183,
+  "a.out.js.gz": 7971,
   "a.out.nodebug.wasm": 132603,
   "a.out.nodebug.wasm.gz": 49939,
-  "total": 151605,
-  "total_gz": 57820,
+  "total": 151786,
+  "total_gz": 57910,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18979,
-  "a.out.js.gz": 7866,
+  "a.out.js": 19160,
+  "a.out.js.gz": 7957,
   "a.out.nodebug.wasm": 132029,
   "a.out.nodebug.wasm.gz": 49599,
-  "total": 151008,
-  "total_gz": 57465,
+  "total": 151189,
+  "total_gz": 57556,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22977,
-  "a.out.js.gz": 8862,
+  "a.out.js": 23158,
+  "a.out.js.gz": 8955,
   "a.out.nodebug.wasm": 172523,
   "a.out.nodebug.wasm.gz": 57480,
-  "total": 195500,
-  "total_gz": 66342,
+  "total": 195681,
+  "total_gz": 66435,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18801,
-  "a.out.js.gz": 7798,
+  "a.out.js": 18982,
+  "a.out.js.gz": 7888,
   "a.out.nodebug.wasm": 147928,
   "a.out.nodebug.wasm.gz": 55349,
-  "total": 166729,
-  "total_gz": 63147,
+  "total": 166910,
+  "total_gz": 63237,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18879,
-  "a.out.js.gz": 7823,
+  "a.out.js": 19060,
+  "a.out.js.gz": 7913,
   "a.out.nodebug.wasm": 145734,
   "a.out.nodebug.wasm.gz": 54976,
-  "total": 164613,
-  "total_gz": 62799,
+  "total": 164794,
+  "total_gz": 62889,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18342,
-  "a.out.js.gz": 7573,
+  "a.out.js": 18526,
+  "a.out.js.gz": 7665,
   "a.out.nodebug.wasm": 102090,
   "a.out.nodebug.wasm.gz": 39548,
-  "total": 120432,
-  "total_gz": 47121,
+  "total": 120616,
+  "total_gz": 47213,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23027,
-  "a.out.js.gz": 8883,
+  "a.out.js": 23208,
+  "a.out.js.gz": 8976,
   "a.out.nodebug.wasm": 238952,
   "a.out.nodebug.wasm.gz": 79833,
-  "total": 261979,
-  "total_gz": 88716,
+  "total": 262160,
+  "total_gz": 88809,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19002,
-  "a.out.js.gz": 7881,
+  "a.out.js": 19183,
+  "a.out.js.gz": 7971,
   "a.out.nodebug.wasm": 134603,
   "a.out.nodebug.wasm.gz": 50779,
-  "total": 153605,
-  "total_gz": 58660,
+  "total": 153786,
+  "total_gz": 58750,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -1459,6 +1459,53 @@ var FS = {
     get isDevice() {
       return FS.isChrdev(this.mode);
     }
+    // The per-inode readiness wait-queue. The node carries a Set of listener
+    // entries {cb}; producers (SOCKFS, PIPEFS) call notifyListeners on a
+    // readiness transition, and poll()/epoll consume it. It lives on the node
+    // (not the fd) so dup'd fds share one queue. Only nodes that derive real
+    // readiness (sockets, pipes, and an epoll's own node) ever use this -
+    // always-ready types (regular files, ttys) never register or notify.
+    addListener(cb, exclusive = false) {
+      var entry = {
+        cb,
+        exclusive
+      };
+      var listeners = (this.listeners ??= new Set);
+      listeners.add(entry);
+      return {
+        listeners,
+        entry
+      };
+    }
+    notifyListeners(flags) {
+      // Iterates the set without copying, which is safe ONLY under a
+      // load-bearing contract that every internal listener must honour:
+      //   1. A listener must not run user code synchronously (a poll waiter only
+      //      resolves a Promise; an epoll registration only re-lists +
+      //      re-notifies; the epoll callback only schedules a tick). User code
+      //      runs on a later tick, never inside this loop.
+      //   2. A listener may delete entries only from ITS OWN waiter, never from
+      //      a sibling node's set that may be mid-iteration. (Deleting an entry
+      //      of the set being iterated here is fine - a Set tolerates removal of
+      //      a not-yet-visited entry mid-iteration; mutating a *different* node's
+      //      set is fine because that set is not being iterated.)
+      // Violating either gives silently skipped wakeups that are near-impossible
+      // to reproduce. Any new producer/listener must preserve it.
+      if (!this.listeners) return;
+      // Fire every non-exclusive listener. Among EPOLLEXCLUSIVE registrations
+      // (one fd watched by several epolls) wake only one, rotating round-robin
+      // per node, to avoid a thundering herd. (Only epoll registrations are ever
+      // exclusive; poll waiters and a node's own consumers are not.)
+      var excl;
+      for (var entry of this.listeners) {
+        if (entry.exclusive) (excl ||= []).push(entry); else entry.cb(flags);
+      }
+      if (excl) {
+        var i = (this.exclTurn || 0) % excl.length;
+        this.exclTurn = i + 1;
+        excl[i].cb(flags);
+      }
+    }
   },
   lookupPath(path, opts = {}) {
     if (!path) {
@@ -2371,6 +2418,11 @@ var FS = {
     }
     if (stream.getdents) stream.getdents = null;
     // free readdir state
+    // The fd is going away: wake anything waiting on it (poll/epoll) with
+    // POLLNVAL so a blocking wait unblocks and an epoll registration is evicted
+    // on its next derive. Only sockets/pipes/epoll ever carry a wait-queue, so
+    // for every other stream (incl. nodeless noderawfs stdio) this is a no-op.
+    stream.node?.notifyListeners(32);
     try {
       if (stream.stream_ops.close) {
         stream.stream_ops.close(stream);

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22080,
-  "a.out.js.gz": 9172,
+  "a.out.js": 22262,
+  "a.out.js.gz": 9262,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 23746,
-  "total_gz": 10117,
+  "total": 23928,
+  "total_gz": 10207,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_files_js_fs.json
+++ b/test/codesize/test_codesize_files_js_fs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 17650,
-  "a.out.js.gz": 7219,
+  "a.out.js": 17831,
+  "a.out.js.gz": 7311,
   "a.out.nodebug.wasm": 381,
   "a.out.nodebug.wasm.gz": 258,
-  "total": 18031,
-  "total_gz": 7477,
+  "total": 18212,
+  "total_gz": 7569,
   "sent": [
     "a (fd_write)",
     "b (fd_read)",

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26005,
-  "a.out.js.gz": 11108,
+  "a.out.js": 26190,
+  "a.out.js.gz": 11198,
   "a.out.nodebug.wasm": 17861,
   "a.out.nodebug.wasm.gz": 9019,
-  "total": 43866,
-  "total_gz": 20127,
+  "total": 44051,
+  "total_gz": 20217,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268338,
+  "a.out.js": 268331,
   "a.out.nodebug.wasm": 587978,
-  "total": 856316,
+  "total": 856309,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268347,
+  "a.out.js": 268338,
   "a.out.nodebug.wasm": 587978,
-  "total": 856325,
+  "total": 856316,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268000,
+  "a.out.js": 268347,
   "a.out.nodebug.wasm": 587978,
-  "total": 855978,
+  "total": 856325,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
This refactors out a partial base from https://github.com/emscripten-core/emscripten/pull/27207.

Move the readiness wait-queue onto FSNode (addListener/notifyListeners) so dup'd fds share one queue, and rewrite the suspending poll() path (readPollfds/writePollfds/pollWait) on top of it. Producers (SOCKFS, PIPEFS) now notify the node on readiness transitions, and close() wakes waiters with POLLNVAL.

- FSNode gains `addListener(cb, exclusive)` / `notifyListeners(flags)` — a per-inode Set of listener entries. It lives on the node (not the fd) so dup'd fds share one queue. Only nodes with real readiness (sockets, pipes) ever populate it; always-ready types (regular files, ttys) never touch it.
- The suspending `poll()` path is rewritten on top of it (`readPollfds`/`writePollfds`/`pollWait`/`pollOne`), replacing the old doPollAsync + makeNotifyCallback machinery.
- Producers now notify the node on a readiness transition: `PIPEFS` on writes, `SOCKFS` via its emit bridge, and `close()` wakes any waiter with `POLLNVAL`.
- Socket hangup semantics tightened: a peer half-close is `POLLRDHUP` (only a fully closed connection is `POLLHUP`), and a queued client makes a listening socket `POLLIN`.

The stream_ops.poll backend handler signature changes from `poll(stream, timeout)` to `poll(stream)` returning the current readiness mask.

Note: the `exclusive` parameter on `addListener` and the round-robin wakeup path in `notifyListeners` are deliberately layered in here as groundwork for the EPOLLEXCLUSIVE handling that lands in the epoll followup (#27207). No caller passes `exclusive` in this PR yet, so that branch is currently inert — it's included now to keep the wait-queue API stable across the split.
