### PR TITLE
Use dedicated variable for run dependency resolver

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -2272,6 +2272,8 @@ addToLibrary({
   $runDependencies: 0,
   $dependenciesPromise__internal: true,
   $dependenciesPromise: null,
+  $dependenciesPromiseResolve__internal: true,
+  $dependenciesPromiseResolve: null,
   $resolveRunDependencies__internal: true,
   $resolveRunDependencies__deps: ['$dependenciesPromise'],
   $resolveRunDependencies: async () => dependenciesPromise,
@@ -2282,7 +2284,7 @@ addToLibrary({
   $runDependencyWatcher: null,
 #endif
 
-  $addRunDependency__deps: ['$runDependencies', '$removeRunDependency', '$dependenciesPromise',
+  $addRunDependency__deps: ['$runDependencies', '$removeRunDependency', '$dependenciesPromise', '$dependenciesPromiseResolve',
 #if ASSERTIONS
     '$runDependencyTracking',
     '$runDependencyWatcher',
@@ -2290,9 +2292,7 @@ addToLibrary({
   ],
   $addRunDependency: (id) => {
     if (!runDependencies) {
-      var resolve;
-      dependenciesPromise = new Promise((r) => resolve = r);
-      dependenciesPromise.resolve = resolve;
+      dependenciesPromise = new Promise((resolve) => dependenciesPromiseResolve = resolve);
     }
     runDependencies++;
 
@@ -2336,7 +2336,7 @@ addToLibrary({
 #endif
   },
 
-  $removeRunDependency__deps: ['$runDependencies', '$dependenciesPromise',
+  $removeRunDependency__deps: ['$runDependencies', '$dependenciesPromiseResolve',
 #if ASSERTIONS
     '$runDependencyTracking',
     '$runDependencyWatcher',
@@ -2364,7 +2364,7 @@ addToLibrary({
         runDependencyWatcher = null;
       }
 #endif
-      dependenciesPromise.resolve();
+      dependenciesPromiseResolve();
     }
   },
 #endif

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -1312,18 +1312,18 @@ var resolveRunDependencies = async () => dependenciesPromise;
 
 var runDependencies = 0;
 
+var dependenciesPromiseResolve = null;
+
 var removeRunDependency = id => {
   runDependencies--;
   if (!runDependencies) {
-    dependenciesPromise.resolve();
+    dependenciesPromiseResolve();
   }
 };
 
 var addRunDependency = id => {
   if (!runDependencies) {
-    var resolve;
-    dependenciesPromise = new Promise(r => resolve = r);
-    dependenciesPromise.resolve = resolve;
+    dependenciesPromise = new Promise(resolve => dependenciesPromiseResolve = resolve);
   }
   runDependencies++;
 };

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22262,
-  "a.out.js.gz": 9262,
+  "a.out.js": 22239,
+  "a.out.js.gz": 9251,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 23928,
-  "total_gz": 10207,
+  "total": 23905,
+  "total_gz": 10196,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268331,
+  "a.out.js": 268311,
   "a.out.nodebug.wasm": 587978,
-  "total": 856309,
+  "total": 856289,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
Store the Promise resolve callback in a dedicated internal variable
rather than attaching it directly to the Promise instance.

Attaching custom properties to native Promise objects pollutes standard
built-in instances and makes it so closure can't minify the name. Using
an internal variable avoids native object mutation and saves code size.