### PR TITLE
Emit source phase import for MODULARIZE=instance

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -41,7 +41,12 @@ if (!globalThis.WebAssembly) {
 
 // Wasm globals
 
-#if SHARED_MEMORY
+#if SOURCE_PHASE_IMPORTS && MODULARIZE == 'instance'
+// In MODULARIZE=instance mode the output is itself an ES module (it is not
+// wrapped by modularize.js), so the source phase import is emitted here at
+// module scope, next to where wasmModule is used.
+import source wasmModule from './{{{ WASM_BINARY_FILE }}}';
+#elif SHARED_MEMORY
 // For sending to workers.
 var wasmModule;
 #endif // SHARED_MEMORY

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -440,6 +440,17 @@ class other(RunnerCore):
     self.assertContained('import source wasmModule from', read_file('hello_world.mjs'))
     self.assertContained('Hello, world!', self.run_js('hello_world.mjs'))
 
+  @requires_node_25
+  @parameterized({
+    '': ([],),
+    'O3': (['-O3'],),
+  })
+  def test_esm_source_phase_imports_instance(self, args):
+    self.set_setting('SOURCE_PHASE_IMPORTS')
+    self.set_setting('MODULARIZE', 'instance')
+    self.do_runf_out_file('hello_world.c', cflags=['-Wno-experimental'] + args)
+    self.assertContained('import source wasmModule from', read_file(self.output_name('hello_world')))
+
   @parameterized({
     '': ([],),
     'node': (['-sENVIRONMENT=node'],),


### PR DESCRIPTION
This makes `-sSOURCE_PHASE_IMPORTS` work together with `-sMODULARIZE=instance` (and `EXPORT_ES6`).

In `MODULARIZE=instance` mode the output is not wrapped by `modularize()`, so the top-level `import source wasmModule` statement that `src/modularize.js` normally emits was never produced. This left `preamble.js` referencing an undefined `wasmModule`, breaking source phase imports in instance mode.

Since instance mode output is itself a module, the source phase import is now emitted directly from `postamble.js` at module scope when both settings are enabled:

```js
#if SOURCE_PHASE_IMPORTS && MODULARIZE == 'instance'
import source wasmModule from './{{{ WASM_BINARY_FILE }}}';
#endif
```

Adds a parameterized `test_esm_source_phase_imports_instance` (default and `-O3`) that builds with `-sSOURCE_PHASE_IMPORTS -sMODULARIZE=instance` and verifies the import is emitted and the module runs.
