### PR TITLE
Add Closure externs for `growable` and `resizable` properties

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -210,3 +210,9 @@ var os = {};
 AudioWorkletProcessor.parameterDescriptors;
 
 var scheduler = {};
+
+/** @type {boolean} */
+ArrayBuffer.prototype.resizable;
+
+/** @type {boolean} */
+SharedArrayBuffer.prototype.growable;

--- a/test/codesize/test_codesize_mem_O3_grow.json
+++ b/test/codesize/test_codesize_mem_O3_grow.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 4386,
-  "a.out.js.gz": 2154,
+  "a.out.js": 4394,
+  "a.out.js.gz": 2155,
   "a.out.nodebug.wasm": 5261,
   "a.out.nodebug.wasm.gz": 2419,
-  "total": 9647,
-  "total_gz": 4573,
+  "total": 9655,
+  "total_gz": 4574,
   "sent": [
     "a (emscripten_resize_heap)"
   ],

--- a/test/codesize/test_codesize_mem_O3_grow_standalone.json
+++ b/test/codesize/test_codesize_mem_O3_grow_standalone.json
@@ -1,9 +1,9 @@
 {
-  "a.out.js": 3852,
+  "a.out.js": 3860,
   "a.out.js.gz": 1896,
   "a.out.nodebug.wasm": 5641,
   "a.out.nodebug.wasm.gz": 2659,
-  "total": 9493,
+  "total": 9501,
   "total_gz": 4555,
   "sent": [
     "args_get",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7543,
-  "a.out.js.gz": 3705,
+  "a.out.js": 7550,
+  "a.out.js.gz": 3708,
   "a.out.nodebug.wasm": 19064,
   "a.out.nodebug.wasm.gz": 8804,
-  "total": 26607,
-  "total_gz": 12509,
+  "total": 26614,
+  "total_gz": 12512,
   "sent": [
     "a (memory)",
     "b (exit)",


### PR DESCRIPTION
Prevents Closure compiler from mangling the `resizable` and
`growable` properties accessed on `HEAP8.buffer`.