### PR TITLE
Update preserve list of library update scripts

### DIFF
--- a/system/lib/update_libcxx.py
+++ b/system/lib/update_libcxx.py
@@ -34,7 +34,7 @@ def clean_dir(dirname):
   if not os.path.exists(dirname):
     return
   for f in os.listdir(dirname):
-    if f in preserve_files:
+    if f in preserve_files or 'emscripten' in f:
       continue
     full = os.path.join(dirname, f)
     if os.path.isdir(full):

--- a/system/lib/update_libcxxabi.py
+++ b/system/lib/update_libcxxabi.py
@@ -16,12 +16,12 @@ local_src = os.path.join(local_root, 'src')
 local_inc = os.path.join(local_root, 'include')
 
 excludes = ('CMakeLists.txt',)
-preserve_files = ()
+preserve_files = ('cxa_exception_js_utils.cpp', '__cpp_exception.S')
 
 
 def clean_dir(dirname):
   for f in os.listdir(dirname):
-    if f in preserve_files:
+    if f in preserve_files or 'emscripten' in f:
       continue
     full = os.path.join(dirname, f)
     if os.path.isdir(full):

--- a/system/lib/update_libunwind.py
+++ b/system/lib/update_libunwind.py
@@ -21,7 +21,7 @@ preserve_files = ()
 
 def clean_dir(dirname):
   for f in os.listdir(dirname):
-    if f in preserve_files:
+    if f in preserve_files or 'emscripten' in f:
       continue
     full = os.path.join(dirname, f)
     if os.path.isdir(full):

--- a/system/lib/update_llvm_libc.py
+++ b/system/lib/update_llvm_libc.py
@@ -50,7 +50,7 @@ def clean_dir(dirname):
   if not os.path.exists(dirname):
     return
   for f in os.listdir(dirname):
-    if f in preserve_files:
+    if f in preserve_files or 'emscripten' in f:
       continue
     full = os.path.join(dirname, f)
     if os.path.isdir(full):


### PR DESCRIPTION
Following `update_comiler_rt.py`, this updates other update scripts so that we don't remove files having `emscripten` in their names. https://github.com/emscripten-core/emscripten/blob/dd4ab289cfc2721ebaef602d400eea381161c4bb/system/lib/update_compiler_rt.py#L35

Also this adds two more missing files (that don't have `emscripten`) in libcxxabi to its `preserve_files` list so that they don't get deleted every time `update_libcxxabi.py` runs.