### PR TITLE
Use `= {0}` initialization instead of explicit `memset` for stack variables

### DIFF
--- a/system/lib/websocket/websocket_to_posix_socket.c
+++ b/system/lib/websocket/websocket_to_posix_socket.c
@@ -820,7 +820,7 @@ int getaddrinfo(const char* node,
     int ai_family;
     int ai_socktype;
     int ai_protocol;
-  } d;
+  } d = {0};
 
   typedef struct ResAddrinfo {
     int ai_flags;
@@ -838,7 +838,6 @@ int getaddrinfo(const char* node,
     uint8_t /*ResAddrinfo[]*/ addr[];
   } Result;
 
-  memset(&d, 0, sizeof(d));
   PosixSocketCallResult *b = allocate_call_result(sizeof(Result));
   d.header.callId = b->callId;
   d.header.function = POSIX_SOCKET_MSG_GETADDRINFO;

--- a/test/browser/test_gl_subdata.c
+++ b/test/browser/test_gl_subdata.c
@@ -139,8 +139,7 @@ static void gl_init(void) {
     /* Store the vertices in a vertex buffer object (VBO) */
     glGenBuffers(1, &indicesVBO);
     glBindBuffer(GL_ARRAY_BUFFER, indicesVBO);
-    float zeroes[NUM_NODES];
-    memset(zeroes, 0, sizeof(zeroes));
+    float zeroes[NUM_NODES] = {0};
     glBufferData(GL_ARRAY_BUFFER, NUM_NODES * sizeof(float), zeroes, GL_STATIC_DRAW);
     for (int x = 0; x < NUM_NODES; x++) {
       glBufferSubData(GL_ARRAY_BUFFER, x * sizeof(float), sizeof(float), &elements[x]);

--- a/test/core/test_sscanf.c
+++ b/test/core/test_sscanf.c
@@ -12,8 +12,7 @@
 int main() {
 #define CHECK(str)                     \
   {                                    \
-    char name[1000];                   \
-    memset(name, 0, 1000);             \
+    char name[1000] = {0};             \
     int prio = 99;                     \
     sscanf(str, "%s %d", name, &prio); \
     printf("%s : %d\n", name, prio);   \
@@ -70,8 +69,7 @@ int main() {
     printf("%i\n", a);
   }
 
-  char buf1[100], buf2[100], buf3[100], buf4[100];
-  memset(buf4, 0, 100);
+  char buf1[100], buf2[100], buf3[100], buf4[100] = {0};
 
 
   int numItems = sscanf("level=4:ref=3", "%99[^:=]=%99[^:]:%99[^=]=%c",

--- a/test/core/test_sscanf_6.c
+++ b/test/core/test_sscanf_6.c
@@ -9,8 +9,7 @@
 #include <string.h>
 int main() {
   const char *date = "18.07.2013w";
-  char c[10];
-  memset(c, 0, 10);
+  char c[10] = {0};
   int y, m, d, i;
   i = sscanf(date, "%d.%d.%4d%c", &d, &m, &y, c);
   printf("date: %s; day %2d, month %2d, year %4d, extra: %c, %d\n", date, d, m,

--- a/test/core/test_typeid.cpp
+++ b/test/core/test_typeid.cpp
@@ -12,10 +12,8 @@
 int main() {
   printf("*\n");
 #define MAX 100
-  long ptrs[MAX];
-  int groups[MAX];
-  memset(ptrs, 0, MAX * sizeof(long));
-  memset(groups, 0, MAX * sizeof(int));
+  long ptrs[MAX] = {0};
+  int groups[MAX] = {0};
   int next_group = 1;
 #define TEST(X)                         \
   {                                     \

--- a/test/core/test_wprintf.cpp
+++ b/test/core/test_wprintf.cpp
@@ -13,8 +13,7 @@
 
 void PrintWide ( const wchar_t * format, ... )
 {
-  wchar_t buffer[MAX_CHARS_SMALL];
-  memset(buffer, 0, MAX_CHARS_SMALL);
+  wchar_t buffer[MAX_CHARS_SMALL] = {0};
   va_list args;
   va_start ( args, format );
   wprintf(L"format    starts with 0x%x\n", *(int*)format);
@@ -77,8 +76,7 @@ int main ()
    wprintf (L"Width trick: %*d \n", 5, 10);
    wprintf (L"%ls \n", L"A wide string");
 
-   wchar_t buffer [100];
-   memset(buffer, 0, sizeof(buffer));
+   wchar_t buffer [100] = {0};
    int cx;
    cx = swprintf(buffer, 100, L"The half of %d is %d", 80, 80/2);
    wprintf(L"swprintf told us %d\n", cx);

--- a/test/fs/test_mmap.c
+++ b/test/fs/test_mmap.c
@@ -66,8 +66,7 @@ void test_mmap_write() {
   {
     FILE* fd = fopen("out.txt", "r");
     assert(fd >= 0);
-    char buffer[15];
-    memset(buffer, 0, 15);
+    char buffer[15] = {0};
     fread(buffer, 1, 14, fd);
     printf("out.txt content=%s\n", buffer);
     fclose(fd);
@@ -104,8 +103,7 @@ void test_mmap_readonly() {
   {
     FILE* fd = fopen("outreadonly.txt", "r");
     assert(fd >= 0);
-    char buffer[16];
-    memset(buffer, 0, 16);
+    char buffer[16] = {0};
     fread(buffer, 1, 15, fd);
     printf("outreadonly.txt content=%s\n", buffer);
     fclose(fd);
@@ -137,8 +135,7 @@ void test_mmap_private() {
   {
     FILE* fd = fopen("private.txt", "r");
     assert(fd >= 0);
-    char buffer[15];
-    memset(buffer, 0, 15);
+    char buffer[15] = {0};
     fread(buffer, 1, 14, fd);
     printf("private.txt content=%s\n", buffer);
     fclose(fd);
@@ -185,8 +182,7 @@ void test_mmap_shared_with_offset() {
     assert(fd >= 0);
     size_t offset = sysconf(_SC_PAGE_SIZE) * 2;
 
-    char buffer[33];
-    memset(buffer, 0, 33);
+    char buffer[33] = {0};
     fseek(fd, offset, SEEK_SET);
     fread(buffer, 1, 32, fd);
     // expect text written from mmap operation to appear at offset in the file

--- a/test/test_emscripten_async_load_script.c
+++ b/test/test_emscripten_async_load_script.c
@@ -20,8 +20,7 @@ EMSCRIPTEN_KEEPALIVE void set(int x) {
 void load2() {
   printf("load2\n");
 
-  char buffer[10];
-  memset(buffer, 0, 10);
+  char buffer[10] = {0};
   FILE *f = fopen("file1.txt", "r");
   assert(f);
   fread(buffer, 1, 5, f);

--- a/test/test_emscripten_overlapped_package.c
+++ b/test/test_emscripten_overlapped_package.c
@@ -15,8 +15,7 @@ void error2() {
 }
 
 void load2() {
-  char buffer[10];
-  memset(buffer, 0, 10);
+  char buffer[10] = {0};
   FILE *f = fopen("/target/file1.txt", "r");
   assert(f);
   fread(buffer, 1, 5, f);

--- a/test/unistd/pipe.c
+++ b/test/unistd/pipe.c
@@ -73,8 +73,7 @@ void test_select(int *fd, bool data_available) {
 }
 
 void test_poll(int *fd, int data_available) {
-  struct pollfd pfds[2];
-  memset(pfds, 0, sizeof pfds);
+  struct pollfd pfds[2] = {0};
   pfds[0].fd = fd[0];
   pfds[0].events = POLLIN | POLLOUT;
   pfds[1].fd = fd[1];
@@ -212,8 +211,7 @@ void test_redirect_stderr_to_pipe() {
   assert(dup2(original_fd, stderrfd) == stderrfd); //  restore fd (stderr) to its original state
   assert(close(original_fd) == 0);
 
-  char buffer[10];
-  memset(buffer, 0, 10);
+  char buffer[10] = {0};
   assert(read(read_end_fd, buffer, 10) == 3);
   assert(strcmp(buffer, "xyz") == 0);
   assert(close(read_end_fd) == 0); // Close the read end of the pipe

--- a/test/unistd/test_unistd_write_broken_link.c
+++ b/test/unistd/test_unistd_write_broken_link.c
@@ -16,8 +16,7 @@ int main() {
   {
     int target_fd = open("link_target", O_RDONLY);
     printf("target_fd: %d, errno: %d %s\n", target_fd, errno, strerror(errno));
-    char buf[10];
-    memset(buf, 0, 10);
+    char buf[10] = {0};
     size_t r = read(target_fd, buf, 10);
     assert(r == 3);
     printf("buf: '%s'\n", buf);
@@ -26,8 +25,7 @@ int main() {
   {
     int target_fd = open("link_source", O_RDONLY);
     printf("target_fd: %d, errno: %d %s\n", target_fd, errno, strerror(errno));
-    char buf[10];
-    memset(buf, 0, 10);
+    char buf[10] = {0};
     size_t r = read(target_fd, buf, 10);
     assert(r == 3);
     printf("buf: '%s'\n", buf);


### PR DESCRIPTION
Replace explicit `memset(..., 0, ...)` calls after local array or struct declarations on the stack with direct aggregate zero initialization `= {0}`. This simplifies the code and allows the compiler to better optimize local variable initialization.