### PR TITLE
[test] Rename `do_run_in_out_file_test` to match `do_runf` naming

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1450,7 +1450,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
   def do_runf(self, filename, expected_output=None, **kwargs):
     return self._build_and_run(filename, expected_output, **kwargs)
 
-  def do_run_in_out_file_test(self, srcfile, **kwargs):
+  def do_runf_out_file(self, srcfile, **kwargs):
     srcfile = maybe_test_file(srcfile)
     out_suffix = kwargs.pop('out_suffix', '')
     outfile = utils.unsuffixed(srcfile) + out_suffix + '.out'

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5239,7 +5239,7 @@ Module["preRun"] = () => {
     # test that we can allocate in the 2-4GB range, if we enable growth and
     # set the max appropriately
     self.cflags += ['-O2', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=4GB']
-    self.do_run_in_out_file_test('browser/test_4gb.cpp')
+    self.do_runf_out_file('browser/test_4gb.cpp')
 
   # Tests that emmalloc supports up to 4GB Wasm heaps.
   @no_firefox('no 4GB support yet')
@@ -5375,7 +5375,7 @@ Module["preRun"] = () => {
     # test that growth doesn't go beyond 2GB without the max being set for that,
     # and that we can catch an allocation failure exception for that
     self.cflags += ['-O2', '-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=2GB']
-    self.do_run_in_out_file_test('browser/test_2gb_fail.c')
+    self.do_runf_out_file('browser/test_2gb_fail.c')
 
   @no_firefox('no 4GB support yet')
   @no_highmem('uses MAXIMUM_MEMORY')
@@ -5390,7 +5390,7 @@ Module["preRun"] = () => {
     # 4GB.
     self.set_setting('MAXIMUM_MEMORY', '4GB')
     self.cflags += ['-O2', '-sALLOW_MEMORY_GROWTH', '-sABORTING_MALLOC=0', '-sASSERTIONS']
-    self.do_run_in_out_file_test('browser/test_4gb_fail.c')
+    self.do_runf_out_file('browser/test_4gb_fail.c')
 
   # Tests that Emscripten-compiled applications can be run when a slash in the URL query or fragment of the js file
   def test_browser_run_with_slash_in_query_and_hash(self):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -496,7 +496,7 @@ class TestCoreBase(RunnerCore):
     self.run_js(strict_filename)
 
   def do_core_test(self, testname, **kwargs):
-    self.do_run_in_out_file_test(Path('core', testname), **kwargs)
+    self.do_runf_out_file(Path('core', testname), **kwargs)
 
   def get_bullet_library(self, use_cmake):
     if use_cmake:
@@ -648,7 +648,7 @@ class TestCoreBase(RunnerCore):
 
   @only_wasm2js('tests va_arg()')
   def test_vararg_copy(self):
-    self.do_run_in_out_file_test('va_arg/test_va_copy.c')
+    self.do_runf_out_file('va_arg/test_va_copy.c')
 
   def test_llvm_fabs(self):
     self.do_core_test('test_llvm_fabs.c')
@@ -892,11 +892,11 @@ class TestCoreBase(RunnerCore):
 
   @only_wasm2js('tests lgamma and signbit')
   def test_math_lgamma(self):
-    self.do_run_in_out_file_test('math/lgamma.c', assert_returncode=NON_ZERO)
+    self.do_runf_out_file('math/lgamma.c', assert_returncode=NON_ZERO)
 
   @only_wasm2js('tests fmodf (which may use JS math)')
   def test_math_fmodf(self):
-    self.do_run_in_out_file_test('math/fmodf.c')
+    self.do_runf_out_file('math/fmodf.c')
 
   def test_rounding(self):
     self.do_core_test('test_rounding.c')
@@ -1802,16 +1802,16 @@ int main() {
   def test_rename(self):
     if is_sanitizing(self.cflags) and self.get_setting('WASMFS'):
       self.skipTest('https://github.com/emscripten-core/emscripten/issues/15820')
-    self.do_run_in_out_file_test('stdio/test_rename.c')
+    self.do_runf_out_file('stdio/test_rename.c')
 
   def test_remove(self):
-   self.do_run_in_out_file_test('stdio/test_remove.c')
+   self.do_runf_out_file('stdio/test_remove.c')
 
   def test_alloca_stack(self):
     self.do_core_test('test_alloca_stack.c')
 
   def test_life(self):
-    self.do_run_in_out_file_test('life.c', args=['2'])
+    self.do_runf_out_file('life.c', args=['2'])
 
   def test_array2(self):
     self.do_core_test('test_array2.c')
@@ -1993,8 +1993,8 @@ int main(int argc, char **argv) {
     expected_result = read_file(test_file('core/test_em_asm_2.out'))
     create_file('test.out', expected_result.replace('EM_ASM', 'MAIN_THREAD_EM_ASM'))
 
-    self.do_run_in_out_file_test('test.cpp', cflags=args)
-    self.do_run_in_out_file_test('test.cpp', cflags=args, force_c=True)
+    self.do_runf_out_file('test.cpp', cflags=args)
+    self.do_runf_out_file('test.cpp', cflags=args, force_c=True)
 
   @needs_dylink
   @parameterized({
@@ -2539,7 +2539,7 @@ The current type of b is: 9
 
   def test_force_exit(self):
     self.set_setting('EXIT_RUNTIME')
-    self.do_run_in_out_file_test('test_force_exit.c')
+    self.do_runf_out_file('test_force_exit.c')
 
   @no_lsan('https://github.com/emscripten-core/emscripten/issues/15988')
   def test_atexit_threads_stub(self):
@@ -2554,11 +2554,11 @@ The current type of b is: 9
 
   @requires_pthreads
   def test_pthread_cancel(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_cancel.c')
+    self.do_runf_out_file('pthread/test_pthread_cancel.c')
 
   @requires_pthreads
   def test_pthread_cancel_async(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_cancel_async.c')
+    self.do_runf_out_file('pthread/test_pthread_cancel_async.c')
 
   @no_asan('cannot replace malloc/free with ASan')
   @no_lsan('cannot replace malloc/free with LSan')
@@ -2568,10 +2568,10 @@ The current type of b is: 9
 
   @no_asan('test relies on null pointer reads')
   def test_pthread_specific(self):
-    self.do_run_in_out_file_test('pthread/specific.c')
+    self.do_runf_out_file('pthread/specific.c')
 
   def test_pthread_equal(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_equal.cpp')
+    self.do_runf_out_file('pthread/test_pthread_equal.cpp')
 
   @requires_pthreads
   @also_with_modularize
@@ -2584,24 +2584,24 @@ The current type of b is: 9
     self.set_setting('PROXY_TO_PTHREAD')
     if not self.has_changed_setting('INITIAL_MEMORY'):
       self.set_setting('INITIAL_MEMORY=32mb')
-    self.do_run_in_out_file_test('pthread/test_pthread_proxying.c', interleaved_output=False)
+    self.do_runf_out_file('pthread/test_pthread_proxying.c', interleaved_output=False)
 
   @requires_pthreads
   def test_pthread_proxying_cpp(self):
     self.set_setting('PROXY_TO_PTHREAD')
     if not self.has_changed_setting('INITIAL_MEMORY'):
       self.set_setting('INITIAL_MEMORY=32mb')
-    self.do_run_in_out_file_test('pthread/test_pthread_proxying_cpp.cpp',
+    self.do_runf_out_file('pthread/test_pthread_proxying_cpp.cpp',
                                  interleaved_output=False)
 
   @requires_pthreads
   def test_pthread_proxying_dropped_work(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_proxying_dropped_work.c')
+    self.do_runf_out_file('pthread/test_pthread_proxying_dropped_work.c')
 
   @requires_pthreads
   def test_pthread_proxying_canceled_work(self):
     self.set_setting('PROXY_TO_PTHREAD')
-    self.do_run_in_out_file_test(
+    self.do_runf_out_file(
         'pthread/test_pthread_proxying_canceled_work.c',
         interleaved_output=False)
 
@@ -2610,21 +2610,21 @@ The current type of b is: 9
   def test_pthread_proxying_refcount(self):
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('ASSERTIONS=0')
-    self.do_run_in_out_file_test('pthread/test_pthread_proxying_refcount.c')
+    self.do_runf_out_file('pthread/test_pthread_proxying_refcount.c')
 
   @requires_pthreads
   def test_pthread_dispatch_after_exit(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_dispatch_after_exit.c', interleaved_output=False)
+    self.do_runf_out_file('pthread/test_pthread_dispatch_after_exit.c', interleaved_output=False)
 
   @requires_pthreads
   def test_pthread_atexit(self):
     # Test to ensure threads are still running when atexit-registered functions are called
     self.set_setting('EXIT_RUNTIME')
-    self.do_run_in_out_file_test('pthread/test_pthread_atexit.c')
+    self.do_runf_out_file('pthread/test_pthread_atexit.c')
 
   @requires_pthreads
   def test_pthread_nested_work_queue(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_nested_work_queue.c')
+    self.do_runf_out_file('pthread/test_pthread_nested_work_queue.c')
 
   @requires_pthreads
   @flaky('Times out in bigendian0 suite only. https://github.com/emscripten-core/emscripten/issues/25316')
@@ -2633,11 +2633,11 @@ The current type of b is: 9
     self.set_setting('EXIT_RUNTIME')
     if not self.has_changed_setting('INITIAL_MEMORY'):
       self.set_setting('INITIAL_MEMORY', '300mb')
-    self.do_run_in_out_file_test('pthread/test_pthread_thread_local_storage.c')
+    self.do_runf_out_file('pthread/test_pthread_thread_local_storage.c')
 
   @requires_pthreads
   def test_pthread_cleanup(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_cleanup.c')
+    self.do_runf_out_file('pthread/test_pthread_cleanup.c')
 
   @requires_pthreads
   def test_pthread_setspecific_mainthread(self):
@@ -2646,14 +2646,14 @@ The current type of b is: 9
     print('.. exit')
     self.do_runf('pthread/test_pthread_setspecific_mainthread.c', 'done!', cflags=['-DEXIT'])
     print('.. pthread_exit')
-    self.do_run_in_out_file_test('pthread/test_pthread_setspecific_mainthread.c')
+    self.do_runf_out_file('pthread/test_pthread_setspecific_mainthread.c')
 
   @requires_pthreads
   @also_with_minimal_runtime
   def test_pthread_attr_getstack(self):
     if self.get_setting('MINIMAL_RUNTIME') and is_sanitizing(self.cflags):
       self.skipTest('MINIMAL_RUNTIME + threads + asan does not work')
-    self.do_run_in_out_file_test('pthread/test_pthread_attr_getstack.c')
+    self.do_runf_out_file('pthread/test_pthread_attr_getstack.c')
 
   @requires_pthreads
   @no_bun('https://github.com/emscripten-core/emscripten/issues/26199')
@@ -2665,7 +2665,7 @@ The current type of b is: 9
     # was passed in by pre-populating the module object on prior to loading).
     self.add_pre_run("Module.onAbort = () => console.log('My custom onAbort called');")
     self.cflags += ['-sINCOMING_MODULE_JS_API=preRun,onAbort']
-    self.do_run_in_out_file_test('pthread/test_pthread_abort.c', assert_returncode=NON_ZERO)
+    self.do_runf_out_file('pthread/test_pthread_abort.c', assert_returncode=NON_ZERO)
 
   @requires_pthreads
   def test_pthread_abort_interrupt(self):
@@ -2691,12 +2691,12 @@ The current type of b is: 9
 
   @requires_pthreads
   def test_pthread_proxy_to_pthread(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_proxy_to_pthread.c', cflags=['-sEXIT_RUNTIME', '-sPROXY_TO_PTHREAD'])
+    self.do_runf_out_file('pthread/test_pthread_proxy_to_pthread.c', cflags=['-sEXIT_RUNTIME', '-sPROXY_TO_PTHREAD'])
 
   @requires_pthreads
   @needs_dylink
   def test_pthread_tls_dylink(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_tls_dylink.c', cflags=['-sMAIN_MODULE=2', '-Wno-experimental'])
+    self.do_runf_out_file('pthread/test_pthread_tls_dylink.c', cflags=['-sMAIN_MODULE=2', '-Wno-experimental'])
 
   @requires_pthreads
   @also_with_minimal_runtime
@@ -2721,21 +2721,21 @@ The current type of b is: 9
 
   @requires_pthreads
   def test_pthread_mutex_robust(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_mutex_robust.c')
+    self.do_runf_out_file('pthread/test_pthread_mutex_robust.c')
 
   @requires_pthreads
   def test_pthread_wait32_notify(self):
-    self.do_run_in_out_file_test('atomic/test_wait32_notify.c')
+    self.do_runf_out_file('atomic/test_wait32_notify.c')
 
   @requires_pthreads
   @no_wasm2js('https://github.com/WebAssembly/binaryen/issues/5991')
   def test_pthread_wait64_notify(self):
-    self.do_run_in_out_file_test('atomic/test_wait64_notify.c')
+    self.do_runf_out_file('atomic/test_wait64_notify.c')
 
   @requires_pthreads
   def test_pthread_wait_async(self):
     self.set_setting('PROXY_TO_PTHREAD')
-    self.do_run_in_out_file_test('atomic/test_wait_async.c')
+    self.do_runf_out_file('atomic/test_wait_async.c')
 
   # Include @requires_node_25 explictly here so that this test will be disabled
   # by EMTEST_SKIP_NODE_25.  Without this, the `requires_pthreads` and `requires_jspi` can
@@ -2747,14 +2747,14 @@ The current type of b is: 9
   @with_asyncify_and_jspi
   @also_with_wasm_workers
   def test_pthread_wait_suspending(self):
-    self.do_run_in_out_file_test('atomic/test_wait_suspending.c')
+    self.do_runf_out_file('atomic/test_wait_suspending.c')
 
   @requires_pthreads
   @also_with_minimal_runtime
   def test_pthread_run_on_main_thread(self):
     if self.get_setting('MINIMAL_RUNTIME') and is_sanitizing(self.cflags):
       self.skipTest('MINIMAL_RUNTIME + threads + asan does not work')
-    self.do_run_in_out_file_test('pthread/test_pthread_run_on_main_thread.c')
+    self.do_runf_out_file('pthread/test_pthread_run_on_main_thread.c')
 
   @requires_pthreads
   def test_pthread_is_lock_free(self):
@@ -5347,16 +5347,16 @@ int main()
       out_suffix = '64'
     else:
       out_suffix = ''
-    self.do_run_in_out_file_test('printf/test_printf.c', out_suffix=out_suffix)
+    self.do_runf_out_file('printf/test_printf.c', out_suffix=out_suffix)
 
   def test_printf_2(self):
     self.do_core_test('test_printf_2.c')
 
   def test_printf_float(self):
-    self.do_run_in_out_file_test('printf/test_float.c')
+    self.do_runf_out_file('printf/test_float.c')
 
   def test_printf_octal(self):
-    self.do_run_in_out_file_test('printf/test_octal.c')
+    self.do_runf_out_file('printf/test_octal.c')
 
   def test_printf_macros(self):
     self.do_core_test('test_printf_macros.c')
@@ -5514,7 +5514,7 @@ Module = {
 
     create_file('test.file', 'some data')
 
-    self.do_run_in_out_file_test('test_files.c')
+    self.do_runf_out_file('test_files.c')
 
   @no_wasmfs('Error: EAGAIN: resource temporarily unavailable. https://github.com/emscripten-core/emscripten/issues/25035')
   def test_module_stdin(self):
@@ -5561,14 +5561,14 @@ got: 10
     self.do_runf('fs/test_getdents64.c', '..')
 
   def test_getdents64_special_cases(self):
-    self.do_run_in_out_file_test('fs/test_getdents64_special_cases.c')
+    self.do_runf_out_file('fs/test_getdents64_special_cases.c')
 
   def test_getcwd_with_non_ascii_name(self):
-    self.do_run_in_out_file_test('fs/test_getcwd_with_non_ascii_name.c')
+    self.do_runf_out_file('fs/test_getcwd_with_non_ascii_name.c')
 
   @no_wasmfs('no support for /proc/self/fd/, see https://github.com/emscripten-core/emscripten/issues/19430')
   def test_proc_self_fd(self):
-    self.do_run_in_out_file_test('fs/test_proc_self_fd.c')
+    self.do_runf_out_file('fs/test_proc_self_fd.c')
 
   def test_fwrite_0(self):
     self.do_core_test('test_fwrite_0.c')
@@ -5687,14 +5687,14 @@ got: 10
       # https://github.com/emscripten-core/emscripten/issues/19418
       # We need to tell the test we are in this mode so it can ignore them.
       self.cflags += ['-DWASMFS_NODERAWFS']
-    self.do_run_in_out_file_test('dirent/test_readdir.c')
+    self.do_runf_out_file('dirent/test_readdir.c')
 
   @also_without_bigint
   def test_readdir_empty(self):
-    self.do_run_in_out_file_test('dirent/test_readdir_empty.c')
+    self.do_runf_out_file('dirent/test_readdir_empty.c')
 
   def test_readdir_unlink(self):
-    self.do_run_in_out_file_test('dirent/test_readdir_unlink.c')
+    self.do_runf_out_file('dirent/test_readdir_unlink.c')
 
   def test_stat(self):
     self.set_setting("FORCE_FILESYSTEM")
@@ -5727,7 +5727,7 @@ got: 10
     if self.get_setting('WASMFS'):
       self.cflags += ['-sFORCE_FILESYSTEM']
     self.add_pre_run("FS.createDataFile('/', 'test', 'abcdef', true, true, false);")
-    self.do_run_in_out_file_test('fcntl/test_fcntl.c')
+    self.do_runf_out_file('fcntl/test_fcntl.c')
 
   @crossplatform
   @also_with_nodefs_both
@@ -5741,14 +5741,14 @@ got: 10
       self.skipTest('Stat mode behavior does not match on Windows')
     if '-DNODERAWFS' in self.cflags and not LINUX:
       self.skipTest('noderawfs fails here under non-linux')
-    self.do_run_in_out_file_test('fcntl/test_fcntl_open.c')
+    self.do_runf_out_file('fcntl/test_fcntl_open.c')
 
   @also_without_bigint
   def test_fcntl_misc(self):
     if self.get_setting('WASMFS'):
       self.cflags += ['-sFORCE_FILESYSTEM']
     self.add_pre_run("FS.createDataFile('/', 'test', 'abcdef', true, true, false);")
-    self.do_run_in_out_file_test('fcntl/test_fcntl_misc.c')
+    self.do_runf_out_file('fcntl/test_fcntl_misc.c')
 
   def test_poll(self):
     if self.get_setting('WASMFS'):
@@ -5830,7 +5830,7 @@ got: 10
   def test_fs_base(self):
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$FS'])
     self.add_pre_run(read_file(test_file('fs/test_fs_base.js')))
-    self.do_run_in_out_file_test('fs/test_fs_base.c')
+    self.do_runf_out_file('fs/test_fs_base.c')
 
   @also_with_noderawfs
   @is_slow_test
@@ -5887,7 +5887,7 @@ got: 10
       suffix = '.wasmfs_win' if WINDOWS else '.wasmfs'
     elif self.is_wasm2js():
       suffix = ".wasm2js"
-    self.do_run_in_out_file_test('fs/test_nodefs_readdir.c', out_suffix=suffix, cflags=['-lnodefs.js'])
+    self.do_runf_out_file('fs/test_nodefs_readdir.c', out_suffix=suffix, cflags=['-lnodefs.js'])
 
   @requires_node
   @crossplatform
@@ -5909,13 +5909,13 @@ got: 10
 
   @no_wasmfs('depends on FS.trackingDelegate which WASMFS does not have')
   def test_fs_trackingdelegate(self):
-    self.do_run_in_out_file_test('fs/test_trackingdelegate.c', cflags=['-sFS_DEBUG'])
+    self.do_runf_out_file('fs/test_trackingdelegate.c', cflags=['-sFS_DEBUG'])
 
   @with_all_fs
   def test_fs_writeFile(self):
     if self.get_setting('WASMFS'):
       self.set_setting("FORCE_FILESYSTEM")
-    self.do_run_in_out_file_test('fs/test_writeFile.cpp')
+    self.do_runf_out_file('fs/test_writeFile.cpp')
 
   @with_all_fs
   @crossplatform
@@ -5931,11 +5931,11 @@ got: 10
   def test_fs_write(self):
     if self.get_setting('WASMFS'):
       self.set_setting("FORCE_FILESYSTEM")
-    self.do_run_in_out_file_test('fs/test_fs_write.c')
+    self.do_runf_out_file('fs/test_fs_write.c')
 
   @also_with_noderawfs
   def test_fs_emptyPath(self):
-    self.do_run_in_out_file_test('fs/test_emptyPath.c')
+    self.do_runf_out_file('fs/test_emptyPath.c')
 
   @no_windows('https://github.com/emscripten-core/emscripten/issues/8882')
   @crossplatform
@@ -5954,7 +5954,7 @@ got: 10
   def test_fs_mmap(self):
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
-    self.do_run_in_out_file_test('fs/test_mmap.c')
+    self.do_runf_out_file('fs/test_mmap.c')
 
   @no_wasmfs('wasmfs will (?) need a non-JS mechanism to ignore permissions during startup')
   @also_with_minimal_runtime
@@ -6093,20 +6093,20 @@ Module.onRuntimeInitialized = () => {
       out_suffix = '.win'
     else:
       out_suffix = ''
-    self.do_run_in_out_file_test('unistd/access.c', out_suffix=out_suffix)
+    self.do_runf_out_file('unistd/access.c', out_suffix=out_suffix)
 
   def test_unistd_curdir(self):
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
-    self.do_run_in_out_file_test('unistd/curdir.c')
+    self.do_runf_out_file('unistd/curdir.c')
 
   @also_with_noderawfs
   def test_unistd_close(self):
     self.maybe_closure()
-    self.do_run_in_out_file_test('unistd/close.c')
+    self.do_runf_out_file('unistd/close.c')
 
   def test_unistd_fsync_stdout(self):
-    self.do_run_in_out_file_test('unistd/fsync_stdout.c')
+    self.do_runf_out_file('unistd/fsync_stdout.c')
 
   @also_with_noderawfs
   def test_unistd_pipe(self):
@@ -6114,7 +6114,7 @@ Module.onRuntimeInitialized = () => {
 
   @also_with_noderawfs
   def test_unistd_dup(self):
-    self.do_run_in_out_file_test('unistd/dup.c')
+    self.do_runf_out_file('unistd/dup.c')
 
   @with_all_fs
   def test_unistd_truncate(self):
@@ -6122,7 +6122,7 @@ Module.onRuntimeInitialized = () => {
       self.set_setting('FORCE_FILESYSTEM')
     if WINDOWS or os.geteuid() == 0:
       self.skipTest('Root access invalidates this test by being able to write on readonly files')
-    self.do_run_in_out_file_test('unistd/truncate.c')
+    self.do_runf_out_file('unistd/truncate.c')
 
   @also_with_standalone_wasm()
   def test_unistd_sysconf(self):
@@ -6130,7 +6130,7 @@ Module.onRuntimeInitialized = () => {
       out_suffix = '64'
     else:
       out_suffix = ''
-    self.do_run_in_out_file_test('unistd/sysconf.c', out_suffix=out_suffix)
+    self.do_runf_out_file('unistd/sysconf.c', out_suffix=out_suffix)
 
   @no_asan('ASan alters memory layout')
   def test_unistd_sysconf_phys_pages(self):
@@ -6184,13 +6184,13 @@ Module.onRuntimeInitialized = () => {
         self.skipTest('TODO: wasmfs+node')
       self.cflags += ['-sFORCE_FILESYSTEM']
 
-    self.do_run_in_out_file_test('unistd/links.c')
+    self.do_runf_out_file('unistd/links.c')
 
   @also_with_noderawfs
   @no_windows('TODO: Fails on Windows due to an unknown reason.')
   @no_wasmfs('Assertion failed: "r == 3" in test_unistd_write_broken_link.c line 22. https://github.com/emscripten-core/emscripten/issues/25035')
   def test_unistd_write_broken_link(self):
-    self.do_run_in_out_file_test('unistd/test_unistd_write_broken_link.c')
+    self.do_runf_out_file('unistd/test_unistd_write_broken_link.c')
 
   @no_windows('Skipping NODEFS test, since it would require administrative privileges.')
   @requires_node
@@ -6202,14 +6202,14 @@ Module.onRuntimeInitialized = () => {
     # Also, other detected discrepancies if you do end up running this test on NODEFS:
     # test expects /, but Windows gives \ as path slashes.
     # Calling readlink() on a non-link gives error 22 EINVAL on Unix, but simply error 0 OK on Windows.
-    self.do_run_in_out_file_test('unistd/symlink_on_nodefs.c', cflags=['-lnodefs.js'])
+    self.do_runf_out_file('unistd/symlink_on_nodefs.c', cflags=['-lnodefs.js'])
 
   @also_without_bigint
   @also_with_nodefs
   def test_unistd_io(self):
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')
-    self.do_run_in_out_file_test('unistd/io.c')
+    self.do_runf_out_file('unistd/io.c')
 
   @no_windows('https://github.com/emscripten-core/emscripten/issues/8882')
   @also_with_nodefs
@@ -6217,7 +6217,7 @@ Module.onRuntimeInitialized = () => {
   def test_unistd_misc(self):
     if self.get_setting('STRICT'):
       self.set_setting('ALLOW_UNIMPLEMENTED_SYSCALLS')
-    self.do_run_in_out_file_test('unistd/misc.c', interleaved_output=False)
+    self.do_runf_out_file('unistd/misc.c', interleaved_output=False)
 
   @also_with_standalone_wasm()
   def test_posixtime(self):
@@ -6298,7 +6298,7 @@ PORT: 3979
     self.do_core_test('test_phiundef.c')
 
   def test_netinet_in(self):
-    self.do_run_in_out_file_test('netinet/in.cpp')
+    self.do_runf_out_file('netinet/in.cpp')
 
   @needs_dylink
   @no_js_math('JS_MATH is not compatible with MAIN_MODULE=1')
@@ -6392,7 +6392,7 @@ PORT: 3979
       self.assert_fail([PYTHON, 'expect_fail.py'], 'UnicodeDecodeError', expect_traceback=True)
 
     self.cflags += ['-sMODULARIZE', '--js-library', test_file('unicode_library.js'), '--extern-post-js', test_file('modularize_post_js.js'), '--post-js', test_file('unicode_postjs.js')]
-    self.do_run_in_out_file_test('test_unicode_js_library.c')
+    self.do_runf_out_file('test_unicode_js_library.c')
 
   def test_funcptr_import_type(self):
     self.do_core_test('test_funcptr_import_type.cpp', cflags=['--js-library', test_file('core/test_funcptr_import_type.js')])
@@ -6800,7 +6800,7 @@ void* operator new(size_t size) {
   def test_relaxed_simd_implies_simd128(self):
     # When using -msse, one has to also add -msimd128.
     # This test verifies passing -mrelaxed-simd also implies -msimd128.
-    self.do_run_in_out_file_test('sse/hello_sse.cpp', cflags=['-msse'])
+    self.do_runf_out_file('sse/hello_sse.cpp', cflags=['-msse'])
 
   @no_asan('call stack exceeded on some versions of node')
   def test_gcc_unmangler(self):
@@ -6825,26 +6825,26 @@ void* operator new(size_t size) {
     ))
 
     # Main
-    self.do_run_in_out_file_test('freetype/main.c',
+    self.do_runf_out_file('freetype/main.c',
                                  args=['font.ttf', 'test!', '150', '120', '25'],
                                  libraries=ftlib,
                                  includes=[test_file('third_party/freetype/include')])
 
     # github issue 324
     print('[issue 324]')
-    self.do_run_in_out_file_test('freetype/main_2.c',
+    self.do_runf_out_file('freetype/main_2.c',
                                  args=['font.ttf', 'w', '32', '32', '25'],
                                  libraries=ftlib,
                                  includes=[test_file('third_party/freetype/include')])
 
     print('[issue 324 case 2]')
-    self.do_run_in_out_file_test('freetype/main_3.c',
+    self.do_runf_out_file('freetype/main_3.c',
                                  args=['font.ttf', 'W', '32', '32', '0'],
                                  libraries=ftlib,
                                  includes=[test_file('third_party/freetype/include')])
 
     print('[issue 324 case 3]')
-    self.do_run_in_out_file_test('freetype/main_3.c',
+    self.do_runf_out_file('freetype/main_3.c',
                                  out_suffix='_alt',
                                  args=['font.ttf', 'ea', '40', '32', '0'],
                                  libraries=ftlib,
@@ -6858,7 +6858,7 @@ void* operator new(size_t size) {
   def test_sqlite(self):
     if self.get_setting('STRICT'):
       self.cflags += ['-lstubs']
-    self.do_run_in_out_file_test('sqlite/test.c', cflags=['-sUSE_SQLITE3'])
+    self.do_runf_out_file('sqlite/test.c', cflags=['-sUSE_SQLITE3'])
 
   @needs_make('mingw32-make')
   @is_slow_test
@@ -7498,7 +7498,7 @@ void* operator new(size_t size) {
       if self.is_wasm64():
         self.skipTest('LEGACY_VM_SUPPORT is not compatible with wasm64')
     self.maybe_closure()
-    self.do_run_in_out_file_test('embind/test_embind_val_basics.cpp', cflags=args)
+    self.do_runf_out_file('embind/test_embind_val_basics.cpp', cflags=args)
 
   @requires_pthreads
   def test_embind_basics(self):
@@ -7630,21 +7630,21 @@ void* operator new(size_t size) {
 
   def test_embind_custom_marshal(self):
     self.cflags += ['-lembind', '--pre-js', test_file('embind/test_custom_marshal.js')]
-    self.do_run_in_out_file_test('embind/test_custom_marshal.cpp', assert_identical=True)
+    self.do_runf_out_file('embind/test_custom_marshal.cpp', assert_identical=True)
 
   def test_embind_float_constants(self):
-    self.do_run_in_out_file_test('embind/test_float_constants.cpp', cflags=['-lembind'])
+    self.do_runf_out_file('embind/test_float_constants.cpp', cflags=['-lembind'])
 
   def test_embind_negative_constants(self):
-    self.do_run_in_out_file_test('embind/test_negative_constants.cpp', cflags=['-lembind'])
+    self.do_runf_out_file('embind/test_negative_constants.cpp', cflags=['-lembind'])
 
   @also_without_bigint
   @no_esm_integration('embind is not compatible with WASM_ESM_INTEGRATION')
   def test_embind_unsigned(self):
-    self.do_run_in_out_file_test('embind/test_unsigned.cpp', cflags=['-lembind'])
+    self.do_runf_out_file('embind/test_unsigned.cpp', cflags=['-lembind'])
 
   def test_embind_val(self):
-    self.do_run_in_out_file_test('embind/test_val.cpp', cflags=['-lembind'])
+    self.do_runf_out_file('embind/test_val.cpp', cflags=['-lembind'])
 
   @no_big_endian("Incompatible with SUPPORT_BIG_ENDIAN")
   def test_embind_val_read_pointer(self):
@@ -7762,7 +7762,7 @@ void* operator new(size_t size) {
 
   def test_embind_dynamic_initialization(self):
     self.cflags += ['-lembind']
-    self.do_run_in_out_file_test('embind/test_dynamic_initialization.cpp')
+    self.do_runf_out_file('embind/test_dynamic_initialization.cpp')
 
   @no_wasm2js('wasm_bigint')
   @parameterized({
@@ -7775,12 +7775,12 @@ void* operator new(size_t size) {
       self.skipTest('asan does not work with SAFE_HEAP')
     self.set_setting('SAFE_HEAP', safe_heap)
     out_suffix = '64' if self.is_wasm64() else ''
-    self.do_run_in_out_file_test('embind/test_i64_val.cpp', assert_identical=True, out_suffix=out_suffix, cflags=['-lembind'])
+    self.do_runf_out_file('embind/test_i64_val.cpp', assert_identical=True, out_suffix=out_suffix, cflags=['-lembind'])
 
   @no_wasm2js('wasm_bigint')
   def test_embind_i64_binding(self):
     self.cflags += ['-lembind', '--js-library', test_file('embind/test_i64_binding.js')]
-    self.do_run_in_out_file_test('embind/test_i64_binding.cpp', assert_identical=True)
+    self.do_runf_out_file('embind/test_i64_binding.cpp', assert_identical=True)
 
   def test_embind_no_rtti(self):
     create_file('main.cpp', r'''
@@ -7846,15 +7846,15 @@ void* operator new(size_t size) {
 
   @requires_wasm_workers
   def test_embind_wasm_workers(self):
-    self.do_run_in_out_file_test('embind/test_embind_wasm_workers.cpp', cflags=['-lembind', '-sWASM_WORKERS'])
+    self.do_runf_out_file('embind/test_embind_wasm_workers.cpp', cflags=['-lembind', '-sWASM_WORKERS'])
 
   @with_all_eh_sjlj
   def test_embind_throw_cpp_exception(self):
-    self.do_run_in_out_file_test('embind/test_embind_throw_cpp_exception.cpp', cflags=['-lembind', '-std=c++20'])
+    self.do_runf_out_file('embind/test_embind_throw_cpp_exception.cpp', cflags=['-lembind', '-std=c++20'])
 
   @with_all_eh_sjlj
   def test_embind_throw_val_uncaught_and_refcount(self):
-    self.do_run_in_out_file_test('embind/test_embind_throw_val_uncaught_and_refcount.cpp', cflags=['-lembind', '-std=c++20'])
+    self.do_runf_out_file('embind/test_embind_throw_val_uncaught_and_refcount.cpp', cflags=['-lembind', '-std=c++20'])
 
   @parameterized({
     '': ('DEFAULT', False),
@@ -7908,7 +7908,7 @@ void* operator new(size_t size) {
       if self.get_setting('INITIAL_MEMORY') == '4200mb':
         self.set_setting('MAXIMUM_MEMORY', '4300mb')
 
-    self.do_run_in_out_file_test(test_file('webidl/test.cpp'), out_suffix='_' + mode, includes=['.'])
+    self.do_runf_out_file(test_file('webidl/test.cpp'), out_suffix='_' + mode, includes=['.'])
 
   # Test that we can perform fully-synchronous initialization when combining
   # WASM_ASYNC_COMPILATION=0 + PTHREAD_POOL_DELAY_LOAD=1.  Also checks that
@@ -8188,10 +8188,10 @@ void* operator new(size_t size) {
     self.cflags += ['-g', '-DRUN_FROM_JS_SHELL', '-Wno-deprecated-pragma']
     if self.maybe_closure():
       self.cflags += ['-g1'] # extra testing
-    self.do_run_in_out_file_test('test_emscripten_log.cpp', interleaved_output=False)
+    self.do_runf_out_file('test_emscripten_log.cpp', interleaved_output=False)
 
   def test_float_literals(self):
-    self.do_run_in_out_file_test('test_float_literals.cpp')
+    self.do_runf_out_file('test_float_literals.cpp')
 
   def test_exit_status(self):
     # needs to flush stdio streams
@@ -8699,7 +8699,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @requires_pthreads
   def test_binaryen_2170_emscripten_atomic_cas_u8(self):
-    self.do_run_in_out_file_test('binaryen_2170_emscripten_atomic_cas_u8.cpp', cflags=['-pthread'])
+    self.do_runf_out_file('binaryen_2170_emscripten_atomic_cas_u8.cpp', cflags=['-pthread'])
 
   @also_with_standalone_wasm()
   def test_sbrk(self):
@@ -8830,7 +8830,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # compiler.  lsan also pulls in $FS
     if '-fsanitize=leak' not in self.cflags and extra_setting != 'FORCE_FILESYSTEM':
       self.maybe_closure()
-    self.do_run_in_out_file_test('hello_world.c')
+    self.do_runf_out_file('hello_world.c')
 
   # Tests that -sMINIMAL_RUNTIME works well with SAFE_HEAP
   @no_modularize_instance('MODULARIZE=instance is not compatible with MINIMAL_RUNTIME')
@@ -9118,7 +9118,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('USE_CLOSURE_COMPILER')
     self.set_setting('ALLOW_MEMORY_GROWTH')
     self.set_setting('INITIAL_MEMORY', '300mb')
-    self.do_run_in_out_file_test('hello_world.c', cflags=['-fsanitize=address', '--extern-post-js=post.js'])
+    self.do_runf_out_file('hello_world.c', cflags=['-fsanitize=address', '--extern-post-js=post.js'])
 
   def test_safe_stack(self):
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
@@ -9221,20 +9221,20 @@ NODEFS is no longer included by default; build with -lnodefs.js
     if not self.has_changed_setting('INITIAL_MEMORY'):
       self.set_setting('INITIAL_MEMORY', '64mb')
     self.set_setting('ENVIRONMENT', 'node')
-    self.do_run_in_out_file_test('pthread/test_pthread_c11_threads.c', cflags=args)
+    self.do_runf_out_file('pthread/test_pthread_c11_threads.c', cflags=args)
 
   @requires_pthreads
   def test_pthread_cxx_threads(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_cxx_threads.cpp')
+    self.do_runf_out_file('pthread/test_pthread_cxx_threads.cpp')
 
   @requires_pthreads
   def test_pthread_busy_wait(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_busy_wait.cpp')
+    self.do_runf_out_file('pthread/test_pthread_busy_wait.cpp')
 
   @requires_pthreads
   def test_pthread_busy_wait_atexit(self):
     self.set_setting('EXIT_RUNTIME')
-    self.do_run_in_out_file_test('pthread/test_pthread_busy_wait_atexit.cpp')
+    self.do_runf_out_file('pthread/test_pthread_busy_wait_atexit.cpp')
 
   @requires_pthreads
   def test_pthread_create_embind_stack_check(self):
@@ -9771,7 +9771,7 @@ int main() {
     if self.is_wasm2js() and '-sMODULARIZE' in self.cflags:
       self.skipTest('WASM2JS + MODULARIZE + WASM_WORKERS is not supported')
     self.maybe_closure()
-    self.do_run_in_out_file_test('wasm_worker/hello_wasm_worker.c', cflags=['-sWASM_WORKERS'])
+    self.do_runf_out_file('wasm_worker/hello_wasm_worker.c', cflags=['-sWASM_WORKERS'])
 
   @requires_wasm_workers
   def test_wasm_worker_exceptions(self):
@@ -9779,7 +9779,7 @@ int main() {
 
   @requires_wasm_workers
   def test_wasm_worker_malloc(self):
-    self.do_run_in_out_file_test('wasm_worker/malloc_wasm_worker.c', cflags=['-sWASM_WORKERS'])
+    self.do_runf_out_file('wasm_worker/malloc_wasm_worker.c', cflags=['-sWASM_WORKERS'])
 
   @requires_wasm_workers
   def test_wasm_worker_runtime_debug(self):

--- a/test/test_jslib.py
+++ b/test/test_jslib.py
@@ -99,7 +99,7 @@ addToLibrary({
 });
 ''')
 
-    self.do_run_in_out_file_test('hello_world.c', cflags=['--js-library', 'lib.js'])
+    self.do_runf_out_file('hello_world.c', cflags=['--js-library', 'lib.js'])
 
   def test_jslib_proxying(self):
     # Regression test for a bug we had where jsifier would find and use
@@ -710,11 +710,11 @@ console.error('JSLIB: none of the above');
 
     # When WebGL is implicitly linked in, the implicit linking should happen before any user
     # --js-libraries, so that they can adjust the behavior afterwards.
-    self.do_run_in_out_file_test('jslib/test_jslib_override_system_symbol.c', cflags=['--js-library', test_file('jslib/test_jslib_override_system_symbol.js'), '-sMAX_WEBGL_VERSION=2'])
+    self.do_runf_out_file('jslib/test_jslib_override_system_symbol.c', cflags=['--js-library', test_file('jslib/test_jslib_override_system_symbol.js'), '-sMAX_WEBGL_VERSION=2'])
 
     # When WebGL is explicitly linked to in strict mode, the linking order on command line should enable overriding.
     self.cflags += ['-sAUTO_JS_LIBRARIES=0', '-sMAX_WEBGL_VERSION=2', '-lwebgl.js', '--js-library', test_file('jslib/test_jslib_override_system_symbol.js')]
-    self.do_run_in_out_file_test('jslib/test_jslib_override_system_symbol.c')
+    self.do_runf_out_file('jslib/test_jslib_override_system_symbol.c')
 
   def test_jslib_version_check(self):
     create_file('libfoo.js', '''
@@ -760,7 +760,7 @@ console.error('JSLIB: none of the above');
     'closure': (['--closure', '1'],),
   })
   def test_multiline_string(self, args):
-    self.do_run_in_out_file_test('jslib/test_multiline_string.c', cflags=['--js-library', test_file('jslib/test_multiline_string.js')] + args)
+    self.do_runf_out_file('jslib/test_multiline_string.c', cflags=['--js-library', test_file('jslib/test_multiline_string.js')] + args)
 
   def test_export(self):
     create_file('post.js', 'Module.myFunc();')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -329,7 +329,7 @@ class other(RunnerCore):
     self.assertTrue(building.is_wasm_dylib(filename))
 
   def do_other_test(self, testname, cflags=None, **kwargs):
-    return self.do_run_in_out_file_test(test_file('other', testname), cflags=cflags, **kwargs)
+    return self.do_runf_out_file(test_file('other', testname), cflags=cflags, **kwargs)
 
   def run_on_pty(self, cmd):
     master, slave = os.openpty()
@@ -2150,10 +2150,10 @@ Module['postRun'] = () => {
     self.do_runf('main.c', cflags=['--embed-file', 'tst', '--exclude-file', '!*hello.exe', '--exclude-file', '*.exe'])
 
   def test_dylink_strict(self):
-    self.do_run_in_out_file_test('hello_world.c', cflags=['-sSTRICT', '-sMAIN_MODULE=1'])
+    self.do_runf_out_file('hello_world.c', cflags=['-sSTRICT', '-sMAIN_MODULE=1'])
 
   def test_dylink_legacy(self):
-    self.do_run_in_out_file_test('hello_world.c', cflags=['-sLEGACY_GL_EMULATION', '-sMAIN_MODULE=2'])
+    self.do_runf_out_file('hello_world.c', cflags=['-sLEGACY_GL_EMULATION', '-sMAIN_MODULE=2'])
 
   def test_dylink_exceptions_and_assertions(self):
     # Linking side modules using the STL and exceptions should not abort with
@@ -2703,13 +2703,13 @@ F1 -> ''
     # the test program will print an ascii representation of a bitmap where the
     # 'w' character has been rendered using the Liberation Sans Bold font.
     # See test_freetype.out
-    self.do_run_in_out_file_test('test_freetype.c', cflags=['--use-port=freetype'])
+    self.do_runf_out_file('test_freetype.c', cflags=['--use-port=freetype'])
 
   @requires_network
   def test_freetype_pthreads(self):
     # This test also verifies the `-sUSE_FREETYPE` alternative to --use-port=freetype works.
     copy_asset('freetype/LiberationSansBold.ttf')
-    self.do_run_in_out_file_test('test_freetype.c', cflags=['--embed-file=LiberationSansBold.ttf', '-pthread', '-sUSE_FREETYPE'])
+    self.do_runf_out_file('test_freetype.c', cflags=['--embed-file=LiberationSansBold.ttf', '-pthread', '-sUSE_FREETYPE'])
 
   @requires_network
   def test_icu(self):
@@ -8747,9 +8747,9 @@ int main() {
     self.set_setting('EXCEPTION_DEBUG')
     self.cflags += ['-fwasm-exceptions', '-flto']
     self.set_setting('WASM_LEGACY_EXCEPTIONS', 0)
-    self.do_run_in_out_file_test('core/test_exceptions.cpp', out_suffix='_caught')
+    self.do_runf_out_file('core/test_exceptions.cpp', out_suffix='_caught')
     self.set_setting('WASM_LEGACY_EXCEPTIONS')
-    self.do_run_in_out_file_test('core/test_exceptions.cpp', out_suffix='_caught')
+    self.do_runf_out_file('core/test_exceptions.cpp', out_suffix='_caught')
 
   @parameterized({
     '': ([],),
@@ -10879,7 +10879,7 @@ ok.
     self.do_runf('sockets/test_getnameinfo.c', 'done\n')
 
   def test_gethostbyname(self):
-    self.do_run_in_out_file_test('sockets/test_gethostbyname.c')
+    self.do_runf_out_file('sockets/test_gethostbyname.c')
 
   def test_getprotobyname(self):
     self.do_runf('sockets/test_getprotobyname.c', 'done\n')
@@ -11075,7 +11075,7 @@ int main () {
     # via the environment EMCC_STRICT=1 and from the command line `-sSTRICT`
     self.do_runf('hello_world.c', cflags=['-sSTRICT'])
     with env_modify({'EMCC_STRICT': '1'}):
-      self.do_run_in_out_file_test('hello_world.c')
+      self.do_runf_out_file('hello_world.c')
 
   def test_strict_mode_full_library(self):
     self.do_runf('hello_world.c', cflags=['-sSTRICT', '-sINCLUDE_FULL_LIBRARY'])
@@ -11992,7 +11992,7 @@ int main(void) {
   def test_pthread_unavailable(self):
     # Run a simple hello world program that uses pthreads
     self.cflags += ['-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME', '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$stringToNewUTF8,$UTF8ToString']
-    self.do_run_in_out_file_test('hello_world.c')
+    self.do_runf_out_file('hello_world.c')
 
     # Now run the same program but with SharedArrayBuffer undefined, it should run
     # fine and then fail on the first call to pthread_create.
@@ -12401,9 +12401,9 @@ int main () {
     self.wasm_engines = []
     self.cflags += ['-fwasm-exceptions']
     self.set_setting('WASM_LEGACY_EXCEPTIONS', 0)
-    self.do_run_in_out_file_test('core/test_exceptions.cpp', out_suffix='_caught')
+    self.do_runf_out_file('core/test_exceptions.cpp', out_suffix='_caught')
     self.set_setting('WASM_LEGACY_EXCEPTIONS')
-    self.do_run_in_out_file_test('core/test_exceptions.cpp', out_suffix='_caught')
+    self.do_runf_out_file('core/test_exceptions.cpp', out_suffix='_caught')
 
   def test_missing_malloc_export(self):
     # we used to include malloc by default. show a clear error in builds with
@@ -12538,7 +12538,7 @@ exec "$@"
       self.assertContained(r'emcc: error: WASM2JS is not compatible with .*_MODULE \(wasm2js does not support dynamic linking\)', err, regex=True)
 
   def test_wasm2js_standalone(self):
-    self.do_run_in_out_file_test('hello_world.c', cflags=['-sSTANDALONE_WASM', '-sWASM=0'])
+    self.do_runf_out_file('hello_world.c', cflags=['-sSTANDALONE_WASM', '-sWASM=0'])
 
   def test_oformat(self):
     self.run_process([EMCC, test_file('hello_world.c'), '--oformat=wasm', '-o', 'out.foo'])
@@ -12571,7 +12571,7 @@ exec "$@"
     'dyncalls': (['-sDYNCALLS'],),
   })
   def test_this_in_dyncall(self, args):
-    self.do_run_in_out_file_test('test_this_in_dyncall.c', cflags=['--js-library', test_file('test_this_in_dyncall.js')] + args)
+    self.do_runf_out_file('test_this_in_dyncall.c', cflags=['--js-library', test_file('test_this_in_dyncall.js')] + args)
 
   # Tests that dynCalls are produced in Closure-safe way in DYNCALLS mode when no actual dynCalls are used
   @parameterized({
@@ -12820,7 +12820,7 @@ exec "$@"
   def test_shell_Oz(self):
     # regression test for -Oz working on non-web, non-node environments that
     # lack TextDecoder
-    self.do_run_in_out_file_test('hello_world.c', cflags=['-Oz'])
+    self.do_runf_out_file('hello_world.c', cflags=['-Oz'])
 
   def test_runtime_keepalive(self):
     # Depends on Module['onExit']
@@ -13215,8 +13215,8 @@ void foo() {}
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
     self.cflags += ['-gsource-map', '-pthread']
-    self.do_run_in_out_file_test('pthread/test_pthread_lsan_no_leak.cpp', cflags=['-fsanitize=leak'])
-    self.do_run_in_out_file_test('pthread/test_pthread_lsan_no_leak.cpp', cflags=['-fsanitize=address'])
+    self.do_runf_out_file('pthread/test_pthread_lsan_no_leak.cpp', cflags=['-fsanitize=leak'])
+    self.do_runf_out_file('pthread/test_pthread_lsan_no_leak.cpp', cflags=['-fsanitize=address'])
 
   @no_bun('https://github.com/emscripten-core/emscripten/issues/26198')
   @requires_pthreads
@@ -13308,7 +13308,7 @@ void foo() {}
   @requires_pthreads
   @flaky('https://github.com/emscripten-core/emscripten/issues/24725')
   def test_pthread_kill(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_kill.c')
+    self.do_runf_out_file('pthread/test_pthread_kill.c')
 
   @parameterized({
     '': (['-pthread'],),
@@ -13388,7 +13388,7 @@ void foo() {}
 
   # Test emscripten_console_log(), emscripten_console_warn() and emscripten_console_error()
   def test_emscripten_console_log(self):
-    self.do_run_in_out_file_test('emscripten_console_log.c', cflags=['--pre-js', test_file('emscripten_console_log_pre.js')])
+    self.do_runf_out_file('emscripten_console_log.c', cflags=['--pre-js', test_file('emscripten_console_log_pre.js')])
 
   # Tests emscripten_unwind_to_js_event_loop() behavior
   def test_emscripten_unwind_to_js_event_loop(self):
@@ -13457,16 +13457,16 @@ void foo() {}
   # unistd tests
 
   def test_unistd_confstr(self):
-    self.do_run_in_out_file_test('unistd/confstr.c')
+    self.do_runf_out_file('unistd/confstr.c')
 
   def test_unistd_ttyname(self):
     self.do_runf('unistd/ttyname.c', 'done\n')
 
   def test_unistd_pathconf(self):
-    self.do_run_in_out_file_test('unistd/pathconf.c')
+    self.do_runf_out_file('unistd/pathconf.c')
 
   def test_unistd_swab(self):
-    self.do_run_in_out_file_test('unistd/swab.c')
+    self.do_runf_out_file('unistd/swab.c')
 
   @also_with_noderawfs
   @crossplatform
@@ -13482,17 +13482,17 @@ void foo() {}
     self.do_runf('unistd/isatty.c', 'done\n')
 
   def test_unistd_login(self):
-    self.do_run_in_out_file_test('unistd/login.c')
+    self.do_runf_out_file('unistd/login.c')
 
   def test_unistd_sleep(self):
-    self.do_run_in_out_file_test('unistd/sleep.c')
+    self.do_runf_out_file('unistd/sleep.c')
 
   @crossplatform
   @with_all_fs
   def test_unistd_fstatfs(self):
     if '-DNODERAWFS' in self.cflags and WINDOWS:
       self.skipTest('depends on /dev filesystem')
-    self.do_run_in_out_file_test('unistd/fstatfs.c', cflags=['-sASSERTIONS=2'])
+    self.do_runf_out_file('unistd/fstatfs.c', cflags=['-sASSERTIONS=2'])
 
   @no_windows("test is Linux-specific")
   @no_mac("test is Linux-specific")
@@ -13515,19 +13515,19 @@ Module.postRun = () => {{
     'Post: \\n' + openFilesPost);
 }}
 ''')
-    self.do_run_in_out_file_test('unistd/close.c', cflags=['--pre-js', 'pre.js'])
+    self.do_runf_out_file('unistd/close.c', cflags=['--pre-js', 'pre.js'])
 
   @also_with_wasmfs
   def test_unistd_dup(self):
-    self.do_run_in_out_file_test('wasmfs/wasmfs_dup.c')
+    self.do_runf_out_file('wasmfs/wasmfs_dup.c')
 
   @also_with_wasmfs
   def test_unistd_open(self):
-    self.do_run_in_out_file_test('wasmfs/wasmfs_open.c')
+    self.do_runf_out_file('wasmfs/wasmfs_open.c')
 
   @also_with_wasmfs
   def test_unistd_open_append(self):
-    self.do_run_in_out_file_test('wasmfs/wasmfs_open_append.c')
+    self.do_runf_out_file('wasmfs/wasmfs_open_append.c')
 
   @also_with_wasmfs
   def test_unistd_stat(self):
@@ -13536,29 +13536,29 @@ Module.postRun = () => {{
   @also_with_wasmfs
   def test_unistd_create(self):
     self.set_setting('WASMFS')
-    self.do_run_in_out_file_test('wasmfs/wasmfs_create.c')
+    self.do_runf_out_file('wasmfs/wasmfs_create.c')
 
   def test_unistd_fdatasync(self):
     # TODO: Remove this test in favor of unistd/misc.c
     self.set_setting('WASMFS')
-    self.do_run_in_out_file_test('wasmfs/wasmfs_fdatasync.c')
+    self.do_runf_out_file('wasmfs/wasmfs_fdatasync.c')
 
   @also_with_wasmfs
   def test_unistd_seek(self):
-    self.do_run_in_out_file_test('wasmfs/wasmfs_seek.c')
+    self.do_runf_out_file('wasmfs/wasmfs_seek.c')
 
   @also_with_wasmfs
   def test_unistd_mkdir(self):
-    self.do_run_in_out_file_test('wasmfs/wasmfs_mkdir.c')
+    self.do_runf_out_file('wasmfs/wasmfs_mkdir.c')
 
   @also_with_wasmfs
   def test_unistd_cwd(self):
-    self.do_run_in_out_file_test('wasmfs/wasmfs_chdir.c')
+    self.do_runf_out_file('wasmfs/wasmfs_chdir.c')
 
   def test_unistd_chown(self):
     # TODO: Remove this test in favor of unistd/misc.c
     self.set_setting('WASMFS')
-    self.do_run_in_out_file_test('wasmfs/wasmfs_chown.c')
+    self.do_runf_out_file('wasmfs/wasmfs_chown.c')
 
   @wasmfs_all_backends
   def test_wasmfs_getdents(self):
@@ -13566,23 +13566,23 @@ Module.postRun = () => {{
       self.skipTest('test expectations assumes /dev is virtualized')
     # Run only in WASMFS for now.
     self.set_setting('FORCE_FILESYSTEM')
-    self.do_run_in_out_file_test('wasmfs/wasmfs_getdents.c')
+    self.do_runf_out_file('wasmfs/wasmfs_getdents.c')
 
   def test_wasmfs_jsfile(self):
     self.set_setting('WASMFS')
-    self.do_run_in_out_file_test('wasmfs/wasmfs_jsfile.c')
+    self.do_runf_out_file('wasmfs/wasmfs_jsfile.c')
 
   def test_wasmfs_before_preload(self):
     self.set_setting('WASMFS')
     os.mkdir('js_backend_files')
     create_file('js_backend_files/file.dat', 'data')
-    self.do_run_in_out_file_test('wasmfs/wasmfs_before_preload.c', cflags=['--preload-file', 'js_backend_files/file.dat'])
+    self.do_runf_out_file('wasmfs/wasmfs_before_preload.c', cflags=['--preload-file', 'js_backend_files/file.dat'])
 
   def test_hello_world_above_2gb(self):
-    self.do_run_in_out_file_test('hello_world.c', cflags=['-sGLOBAL_BASE=2GB', '-sINITIAL_MEMORY=3GB'])
+    self.do_runf_out_file('hello_world.c', cflags=['-sGLOBAL_BASE=2GB', '-sINITIAL_MEMORY=3GB'])
 
   def test_unistd_strerror(self):
-    self.do_run_in_out_file_test('unistd/strerror.c')
+    self.do_runf_out_file('unistd/strerror.c')
 
   def test_hello_function(self):
     # hello_function.cpp is referenced/used in the docs.  This test ensures that it
@@ -13703,7 +13703,7 @@ int main() {
 
     # Try again with INCOMING_MODULE_JS_API set
     self.set_setting('INCOMING_MODULE_JS_API', 'fetchSettings')
-    self.do_run_in_out_file_test('hello_world.c')
+    self.do_runf_out_file('hello_world.c')
     src = read_file('hello_world.js')
     self.assertContained("fetch(binaryFile, Module['fetchSettings'] || ", src)
 
@@ -13737,7 +13737,7 @@ int main() {
 
   @also_with_minimal_runtime
   def test_wasm_worker_cxx_init(self):
-    self.do_run_in_out_file_test('wasm_worker/wasm_worker_cxx_init.cpp', cflags=['-sWASM_WORKERS'])
+    self.do_runf_out_file('wasm_worker/wasm_worker_cxx_init.cpp', cflags=['-sWASM_WORKERS'])
 
   @parameterized({
     # we will warn here since -O2 runs the optimizer and -g enables DWARF
@@ -13757,19 +13757,19 @@ int main() {
       self.run_process([EMCC, test_file('hello_world.c'), '-Werror'] + args)
 
   def test_wasm_worker_trusted_types(self):
-    self.do_run_in_out_file_test('wasm_worker/hello_wasm_worker.c', cflags=['-sWASM_WORKERS', '-sTRUSTED_TYPES'])
+    self.do_runf_out_file('wasm_worker/hello_wasm_worker.c', cflags=['-sWASM_WORKERS', '-sTRUSTED_TYPES'])
 
   def test_wasm_worker_export_es6(self):
-    self.do_run_in_out_file_test('wasm_worker/hello_wasm_worker.c', cflags=['-sWASM_WORKERS',
-                                                                            '-sEXPORT_ES6',
-                                                                            '--extern-post-js',
-                                                                            test_file('modularize_post_js.js')])
+    self.do_runf_out_file('wasm_worker/hello_wasm_worker.c', cflags=['-sWASM_WORKERS',
+                                                                     '-sEXPORT_ES6',
+                                                                     '--extern-post-js',
+                                                                     test_file('modularize_post_js.js')])
 
   def test_wasm_worker_terminate(self):
     self.do_runf('wasm_worker/terminate_wasm_worker.c', cflags=['-sWASM_WORKERS'])
 
   def test_wasm_worker_dbg(self):
-    self.do_run_in_out_file_test('wasm_worker/test_wasm_worker_dbg.c', cflags=['-sWASM_WORKERS'])
+    self.do_runf_out_file('wasm_worker/test_wasm_worker_dbg.c', cflags=['-sWASM_WORKERS'])
 
   @also_with_minimal_runtime
   def test_wasm_worker_closure(self):
@@ -13816,7 +13816,7 @@ int main() {
   })
   @requires_wasm64
   def test_wasm64(self, args):
-    self.do_run_in_out_file_test('core/test_hello_argc.c', args=['hello', 'world'], cflags=['-m64'] + args)
+    self.do_runf_out_file('core/test_hello_argc.c', args=['hello', 'world'], cflags=['-m64'] + args)
 
   # Verfy that MAIN_MODULE=1 (which includes all symbols from all libraries)
   # works with -sPROXY_POSIX_SOCKETS and -Oz, both of which affect linking of
@@ -14463,7 +14463,7 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     self.cflags += args + ['--post-js', test_file('interop/test_add_function_post.js')]
 
     print('basics')
-    self.do_run_in_out_file_test('interop/test_add_function.cpp')
+    self.do_runf_out_file('interop/test_add_function.cpp')
 
     print('with ALLOW_TABLE_GROWTH=0')
     self.set_setting('ALLOW_TABLE_GROWTH', 0)
@@ -14481,7 +14481,7 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     self.set_setting('ALLOW_TABLE_GROWTH')
     # enable costly assertions to verify correct table behavior
     self.set_setting('ASSERTIONS', 2)
-    self.do_run_in_out_file_test('interop/test_add_function.cpp', interleaved_output=False, cflags=['-DGROWTH'])
+    self.do_runf_out_file('interop/test_add_function.cpp', interleaved_output=False, cflags=['-DGROWTH'])
 
   @parameterized({
     'memory64_wasm_function': (True, True),
@@ -14680,19 +14680,19 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     self.set_setting('EXIT_RUNTIME')
 
     # Normally, with EXIT_RUNTIME set we expect onExit to be called.
-    output = self.do_run_in_out_file_test('hello_world.c')
+    output = self.do_runf_out_file('hello_world.c')
     self.assertContained(onexit_called, output)
 
     # However, if we set `Module.noExitRuntime = true`, then it should
     # not be called.
     create_file('noexit.js', 'Module.noExitRuntime = true;\n')
-    output = self.do_run_in_out_file_test('hello_world.c', cflags=['--pre-js=noexit.js'])
+    output = self.do_runf_out_file('hello_world.c', cflags=['--pre-js=noexit.js'])
     self.assertNotContained(onexit_called, output)
 
     # Setting the internal `noExitRuntime` after startup should have the
     # same effect.
     create_file('noexit_oninit.js', 'Module.preRun = () => { noExitRuntime = true; }')
-    output = self.do_run_in_out_file_test('hello_world.c', cflags=['--pre-js=noexit_oninit.js'])
+    output = self.do_runf_out_file('hello_world.c', cflags=['--pre-js=noexit_oninit.js'])
     self.assertNotContained(onexit_called, output)
 
   def test_noExitRuntime_deps(self):
@@ -15053,7 +15053,7 @@ addToLibrary({
   @also_with_wasmfs
   def test_fs_writev_partial_write(self):
     self.set_setting('FORCE_FILESYSTEM')
-    self.do_run_in_out_file_test('fs/test_writev_partial_write.c')
+    self.do_runf_out_file('fs/test_writev_partial_write.c')
 
   def test_fs_lzfs(self):
     # generate data
@@ -15605,7 +15605,7 @@ addToLibrary({
   def test_linkable(self):
     # This setting is due for removal:
     # https://github.com/emscripten-core/emscripten/issues/25262
-    self.do_run_in_out_file_test('hello_world.c', cflags=['-Wno-deprecated', '-sLINKABLE'])
+    self.do_runf_out_file('hello_world.c', cflags=['-Wno-deprecated', '-sLINKABLE'])
 
   # Tests encoding of all byte pairs for binary encoding in SINGLE_FILE mode.
   @parameterized({


### PR DESCRIPTION
Specifically we don't use the `_test` suffix for these helpers normally and I wanted to shared the `do_runf` prefix.