### PR TITLE
Make update_*.py update readme's LLVM version

### DIFF
--- a/system/lib/update_common.py
+++ b/system/lib/update_common.py
@@ -1,22 +1,28 @@
 import os
 import sys
 import shutil
+import subprocess
+import re
+import argparse
 
 script_dir = os.path.abspath(os.path.dirname(__file__))
 emscripten_root = os.path.dirname(os.path.dirname(script_dir))
 default_llvm_dir = os.path.join(os.path.dirname(emscripten_root), 'llvm-project')
 
 
-def get_llvm_dir():
-  if len(sys.argv) > 1:
-    llvm_dir = os.path.abspath(sys.argv[1])
-  else:
-    llvm_dir = default_llvm_dir
-  if not os.path.isdir(llvm_dir):
-    print(f'LLVM directory not found: {llvm_dir}', file=sys.stderr)
-    print(f'Usage: {sys.argv[0]} [llvm_dir]', file=sys.stderr)
+def parse_args(default_dir, dir_name='llvm_dir'):
+  parser = argparse.ArgumentParser(description=f'Update library from {dir_name}')
+  parser.add_argument('-f', '--force', action='store_true', help='Force update even if the Emscripten tree is not clean')
+  parser.add_argument('src_dir', nargs='?', default=default_dir, help=f'Path to {dir_name}')
+  args = parser.parse_args()
+
+  src_dir = os.path.abspath(args.src_dir)
+  if not os.path.isdir(src_dir):
+    print(f'{dir_name} directory not found: {src_dir}', file=sys.stderr)
+    parser.print_help(sys.stderr)
     sys.exit(1)
-  return llvm_dir
+
+  return src_dir, args.force
 
 
 def clean_dir(dirname, preserve_files=()):
@@ -47,3 +53,53 @@ def copy_tree(upstream_dir, local_dir, excludes=()):
         if f in excludes:
           full = os.path.join(root, f)
           os.remove(full)
+
+
+def check_clean(force=False):
+  if force:
+    return
+  try:
+    status = subprocess.check_output(['git', 'status', '--porcelain', '--untracked-files=no'], cwd=emscripten_root, stderr=subprocess.PIPE).decode('utf-8').strip()
+    if status:
+      print('Emscripten tree is not clean (has uncommitted changes).', file=sys.stderr)
+      sys.exit(1)
+  except subprocess.CalledProcessError as e:
+    print('Emscripten tree is not a valid git repository or git failed.', file=sys.stderr)
+    if e.stderr:
+      print(e.stderr.decode('utf-8').strip(), file=sys.stderr)
+    sys.exit(1)
+
+
+def get_llvm_version(upstream_dir):
+  cmake_file = os.path.join(upstream_dir, 'cmake', 'Modules', 'LLVMVersion.cmake')
+  if not os.path.exists(cmake_file):
+    return None, None
+  with open(cmake_file, 'r') as f:
+    content = f.read()
+  major = re.search(r'set\(LLVM_VERSION_MAJOR\s+(\d+)\)', content)
+  minor = re.search(r'set\(LLVM_VERSION_MINOR\s+(\d+)\)', content)
+  patch = re.search(r'set\(LLVM_VERSION_PATCH\s+(\d+)\)', content)
+  if major and minor and patch:
+    return major.group(1), f'{major.group(1)}.{minor.group(1)}.{patch.group(1)}'
+  return None, None
+
+
+def update_readme(local_dir, llvm_dir):
+  readme_path = os.path.join(local_dir, 'readme.txt')
+  if not os.path.exists(readme_path):
+    readme_path = os.path.join(local_dir, 'README.txt')
+    if not os.path.exists(readme_path):
+      return
+
+  with open(readme_path, 'r') as f:
+    content = f.read()
+
+  major, full_version = get_llvm_version(llvm_dir)
+  if major and full_version:
+    # Find full version numbers in the form of x.y.z and update them
+    content = re.sub(r'\b\d+\.\d+\.\d+\b', full_version, content)
+    # Find 'emscripten-libs-NN' strings and update them with the major version
+    content = re.sub(r'emscripten-libs-\d+', f'emscripten-libs-{major}', content)
+
+  with open(readme_path, 'w') as f:
+    f.write(content)

--- a/system/lib/update_common.py
+++ b/system/lib/update_common.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import shutil
-import subprocess
 import re
 import argparse
 
@@ -12,7 +11,6 @@ default_llvm_dir = os.path.join(os.path.dirname(emscripten_root), 'llvm-project'
 
 def parse_args(default_dir, dir_name='llvm_dir'):
   parser = argparse.ArgumentParser(description=f'Update library from {dir_name}')
-  parser.add_argument('-f', '--force', action='store_true', help='Force update even if the Emscripten tree is not clean')
   parser.add_argument('src_dir', nargs='?', default=default_dir, help=f'Path to {dir_name}')
   args = parser.parse_args()
 
@@ -22,7 +20,7 @@ def parse_args(default_dir, dir_name='llvm_dir'):
     parser.print_help(sys.stderr)
     sys.exit(1)
 
-  return src_dir, args.force
+  return src_dir
 
 
 def clean_dir(dirname, preserve_files=()):
@@ -53,21 +51,6 @@ def copy_tree(upstream_dir, local_dir, excludes=()):
         if f in excludes:
           full = os.path.join(root, f)
           os.remove(full)
-
-
-def check_clean(force=False):
-  if force:
-    return
-  try:
-    status = subprocess.check_output(['git', 'status', '--porcelain', '--untracked-files=no'], cwd=emscripten_root, stderr=subprocess.PIPE).decode('utf-8').strip()
-    if status:
-      print('Emscripten tree is not clean (has uncommitted changes).', file=sys.stderr)
-      sys.exit(1)
-  except subprocess.CalledProcessError as e:
-    print('Emscripten tree is not a valid git repository or git failed.', file=sys.stderr)
-    if e.stderr:
-      print(e.stderr.decode('utf-8').strip(), file=sys.stderr)
-    sys.exit(1)
 
 
 def get_llvm_version(upstream_dir):

--- a/system/lib/update_compiler_rt.py
+++ b/system/lib/update_compiler_rt.py
@@ -31,7 +31,6 @@ preserve_files = ('readme.txt',)
 
 def main():
   llvm_dir = parse_args(default_llvm_dir, 'llvm_dir')
-  check_clean()
   upstream_dir = os.path.join(llvm_dir, 'compiler-rt')
   assert os.path.exists(upstream_dir)
   upstream_src = os.path.join(upstream_dir, 'lib', 'builtins')

--- a/system/lib/update_compiler_rt.py
+++ b/system/lib/update_compiler_rt.py
@@ -30,7 +30,8 @@ preserve_files = ('readme.txt',)
 
 
 def main():
-  llvm_dir = get_llvm_dir()
+  llvm_dir, force = parse_args(default_llvm_dir, 'llvm_dir')
+  check_clean(force)
   upstream_dir = os.path.join(llvm_dir, 'compiler-rt')
   assert os.path.exists(upstream_dir)
   upstream_src = os.path.join(upstream_dir, 'lib', 'builtins')
@@ -53,6 +54,7 @@ def main():
 
   shutil.copy2(os.path.join(upstream_dir, 'CREDITS.TXT'), local_src)
   shutil.copy2(os.path.join(upstream_dir, 'LICENSE.TXT'), local_src)
+  update_readme(local_src, llvm_dir)
 
 
 if __name__ == '__main__':

--- a/system/lib/update_compiler_rt.py
+++ b/system/lib/update_compiler_rt.py
@@ -30,8 +30,8 @@ preserve_files = ('readme.txt',)
 
 
 def main():
-  llvm_dir, force = parse_args(default_llvm_dir, 'llvm_dir')
-  check_clean(force)
+  llvm_dir = parse_args(default_llvm_dir, 'llvm_dir')
+  check_clean()
   upstream_dir = os.path.join(llvm_dir, 'compiler-rt')
   assert os.path.exists(upstream_dir)
   upstream_src = os.path.join(upstream_dir, 'lib', 'builtins')

--- a/system/lib/update_libcxx.py
+++ b/system/lib/update_libcxx.py
@@ -63,6 +63,8 @@ def generate_modules(cmake_version: str):
   shutil.copytree(dist, dst, dirs_exist_ok=True)
 
 def main():
+  llvm_dir, force = parse_args(default_llvm_dir, 'llvm_dir')
+  check_clean(force)
   # Exit early if cmake is not found
   try:
     output= subprocess.check_output(['cmake', '--version'], text=True)
@@ -112,6 +114,7 @@ def main():
     copy_tree(upstream_dir, local_dir, excludes)
 
   shutil.copy2(os.path.join(libc_upstream_dir, 'LICENSE.TXT'), libc_local_dir)
+  update_readme(local_root, llvm_dir)
 
 if __name__ == '__main__':
   main()

--- a/system/lib/update_libcxx.py
+++ b/system/lib/update_libcxx.py
@@ -63,8 +63,7 @@ def generate_modules(cmake_version: str):
   shutil.copytree(dist, dst, dirs_exist_ok=True)
 
 def main():
-  llvm_dir, force = parse_args(default_llvm_dir, 'llvm_dir')
-  check_clean(force)
+  llvm_dir = parse_args(default_llvm_dir, 'llvm_dir')
   # Exit early if cmake is not found
   try:
     output= subprocess.check_output(['cmake', '--version'], text=True)

--- a/system/lib/update_libcxxabi.py
+++ b/system/lib/update_libcxxabi.py
@@ -19,8 +19,7 @@ preserve_files = ('cxa_exception_js_utils.cpp', '__cpp_exception.S')
 
 
 def main():
-  llvm_dir, force = parse_args(default_llvm_dir, 'llvm_dir')
-  check_clean(force)
+  llvm_dir = parse_args(default_llvm_dir, 'llvm_dir')
   upstream_root = os.path.join(llvm_dir, 'libcxxabi')
   upstream_src = os.path.join(upstream_root, 'src')
   upstream_inc = os.path.join(upstream_root, 'include')

--- a/system/lib/update_libcxxabi.py
+++ b/system/lib/update_libcxxabi.py
@@ -19,7 +19,8 @@ preserve_files = ('cxa_exception_js_utils.cpp', '__cpp_exception.S')
 
 
 def main():
-  llvm_dir = get_llvm_dir()
+  llvm_dir, force = parse_args(default_llvm_dir, 'llvm_dir')
+  check_clean(force)
   upstream_root = os.path.join(llvm_dir, 'libcxxabi')
   upstream_src = os.path.join(upstream_root, 'src')
   upstream_inc = os.path.join(upstream_root, 'include')
@@ -34,6 +35,7 @@ def main():
   copy_tree(upstream_inc, local_inc, excludes)
   shutil.copy2(os.path.join(upstream_root, 'CREDITS.TXT'), local_root)
   shutil.copy2(os.path.join(upstream_root, 'LICENSE.TXT'), local_root)
+  update_readme(local_root, llvm_dir)
 
 
 if __name__ == '__main__':

--- a/system/lib/update_libunwind.py
+++ b/system/lib/update_libunwind.py
@@ -19,7 +19,8 @@ preserve_files = ()
 
 
 def main():
-  llvm_dir = get_llvm_dir()
+  llvm_dir, force = parse_args(default_llvm_dir, 'llvm_dir')
+  check_clean(force)
   upstream_root = os.path.join(llvm_dir, 'libunwind')
   upstream_src = os.path.join(upstream_root, 'src')
   upstream_inc = os.path.join(upstream_root, 'include')
@@ -33,6 +34,7 @@ def main():
   copy_tree(upstream_src, local_src, excludes)
   copy_tree(upstream_inc, local_inc, excludes)
   shutil.copy2(os.path.join(upstream_root, 'LICENSE.TXT'), local_root)
+  update_readme(local_root, llvm_dir)
 
 
 if __name__ == '__main__':

--- a/system/lib/update_libunwind.py
+++ b/system/lib/update_libunwind.py
@@ -19,8 +19,7 @@ preserve_files = ()
 
 
 def main():
-  llvm_dir, force = parse_args(default_llvm_dir, 'llvm_dir')
-  check_clean(force)
+  llvm_dir = parse_args(default_llvm_dir, 'llvm_dir')
   upstream_root = os.path.join(llvm_dir, 'libunwind')
   upstream_src = os.path.join(upstream_root, 'src')
   upstream_inc = os.path.join(upstream_root, 'include')

--- a/system/lib/update_llvm_libc.py
+++ b/system/lib/update_llvm_libc.py
@@ -46,8 +46,7 @@ libc_exclusion_patterns = [
 
 
 def main():
-  llvm_dir, force = parse_args(default_llvm_dir, 'llvm_dir')
-  check_clean(force)
+  llvm_dir = parse_args(default_llvm_dir, 'llvm_dir')
   libc_upstream_dir = os.path.join(llvm_dir, 'libc')
   assert os.path.exists(libc_upstream_dir)
   libc_local_dir = os.path.join(script_dir, 'llvm-libc')

--- a/system/lib/update_llvm_libc.py
+++ b/system/lib/update_llvm_libc.py
@@ -46,7 +46,8 @@ libc_exclusion_patterns = [
 
 
 def main():
-  llvm_dir = get_llvm_dir()
+  llvm_dir, force = parse_args(default_llvm_dir, 'llvm_dir')
+  check_clean(force)
   libc_upstream_dir = os.path.join(llvm_dir, 'libc')
   assert os.path.exists(libc_upstream_dir)
   libc_local_dir = os.path.join(script_dir, 'llvm-libc')
@@ -65,6 +66,8 @@ def main():
     files_to_exclude = glob.glob(os.path.join(libc_local_dir, exclusion_pattern))
     for file in files_to_exclude:
       os.remove(file)
+
+  update_readme(libc_local_dir, llvm_dir)
 
 if __name__ == '__main__':
   main()

--- a/system/lib/update_musl.py
+++ b/system/lib/update_musl.py
@@ -92,9 +92,8 @@ def make_ignore(root):
 
 
 def main():
-  musl_dir, force = parse_args(default_musl_dir, 'musl_dir')
+  musl_dir = parse_args(default_musl_dir, 'musl_dir')
   assert os.path.exists(musl_dir)
-  check_clean(force)
 
   # Remove old version
   shutil.rmtree(local_src)

--- a/system/lib/update_musl.py
+++ b/system/lib/update_musl.py
@@ -69,16 +69,6 @@ allowed_files = (
 )
 
 
-if len(sys.argv) > 1:
-  musl_dir = os.path.abspath(sys.argv[1])
-else:
-  musl_dir = default_musl_dir
-if not os.path.isdir(musl_dir):
-  print(f'musl directory not found: {musl_dir}', file=sys.stderr)
-  print(f'Usage: {sys.argv[0]} [musl_dir]', file=sys.stderr)
-  sys.exit(1)
-
-
 def make_ignore(root):
   root = Path(root).resolve()
 
@@ -102,7 +92,9 @@ def make_ignore(root):
 
 
 def main():
+  musl_dir, force = parse_args(default_musl_dir, 'musl_dir')
   assert os.path.exists(musl_dir)
+  check_clean(force)
 
   # Remove old version
   shutil.rmtree(local_src)


### PR DESCRIPTION
This makes `update_*.py` automatically update version numbers in `readme.txt`. This also makes the scripts use `argparse`.

Suggested in https://github.com/emscripten-core/emscripten/pull/27252#issuecomment-4879991836.