### PR TITLE
Temporarily skip tests to allow Binaryen roll

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10609,8 +10609,8 @@ _d
     self.assertContained('   DOS_ReadFile(unsigned short', proc.stderr)
     self.assertContained('Try using a response file', proc.stderr)
 
+  @disabled('Expected error message needs updating after the Binaryen roll')
   def test_asyncify_response_file(self):
-    self.skipTest('Expected error message needs updating after the Binaryen roll')
     create_file('a.txt', r'''[
   "DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)"
 ]
@@ -15525,8 +15525,8 @@ addToLibrary({
     self.do_runf('main.c', 'done\n', cflags=['-sFORCE_FILESYSTEM', '--post-js=post.js'])
 
   @crossplatform
+  @disabled('Needs updates after Binaryen roll changes function name escaping')
   def test_empath_split(self):
-    self.skipTest('Needs updates after Binaryen roll changes function name escaping')
     create_file('main.cpp', r'''
       #include <iostream>
       void foo();

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10610,6 +10610,7 @@ _d
     self.assertContained('Try using a response file', proc.stderr)
 
   def test_asyncify_response_file(self):
+    self.skipTest('Expected error message needs updating after the Binaryen roll')
     create_file('a.txt', r'''[
   "DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)"
 ]
@@ -15525,6 +15526,7 @@ addToLibrary({
 
   @crossplatform
   def test_empath_split(self):
+    self.skipTest('Needs updates after Binaryen roll changes function name escaping')
     create_file('main.cpp', r'''
       #include <iostream>
       void foo();


### PR DESCRIPTION
https://github.com/WebAssembly/binaryen/pull/8880 updated Binaryen to no
longer escape function names stored in the IR. This means that directly printed function names are no longer escaped. An error message was also tweaked to improve readability.

These changes break Emscripten tests, so temporarily skip those tests to allow the Binaryen roll to proceed. A follow-on change after the roll will update and re-enable the tests.
