### PR TITLE
Temporarily disable -fcoverage-mapping test

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -35,6 +35,9 @@ See docs/process.md for more on how version tagging works.
   `poll(stream)` returning the current readiness mask; out-of-tree custom FS
   backends with a `poll` handler must update. (#27226)
 - compiler-rt and libunwind were updated to LLVM 22.1.8. (#27245, #27246)
+- `-fcoverage-mapping` is currently broken due to a mismatch between the version
+  of LLVM used and the imported version of compiler-rt.  We hope to fix this
+  in the next release. (#27261)
 
 6.0.2 - 07/01/26
 ----------------

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9880,6 +9880,7 @@ int main() {
 
     self.assertContained('main\nfoo\nbar\n', self.run_js('runner.mjs'))
 
+  @disabled('https://github.com/emscripten-core/emscripten/issues/27223')
   @no_esm_integration('fcoverage is not compatible with WASM_ESM_INTEGRATION')
   @no_wasm2js('wasm binary required to produce code coverage results with llvm-cov')
   def test_fcoverage_mapping(self):


### PR DESCRIPTION
This test is currently blocking the LLVM roller because the version of the coverage data changes in upstream LLVM, but the version of compiler-rt we use is currently pinned to the stable version.

See #27223