### PR TITLE
[html5] Fix argument count for __emscripten_run_callback_on_thread

### DIFF
--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -1126,7 +1126,7 @@ var LibraryHTML5 = {
 
     if (strategy.canvasResizedCallback) {
 #if PTHREADS
-      if (strategy.canvasResizedCallbackTargetThread) __emscripten_run_callback_on_thread(strategy.canvasResizedCallbackTargetThread, strategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, strategy.canvasResizedCallbackUserData);
+      if (strategy.canvasResizedCallbackTargetThread) __emscripten_run_callback_on_thread(strategy.canvasResizedCallbackTargetThread, strategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, 0, strategy.canvasResizedCallbackUserData);
       else
 #endif
       {{{ makeDynCall('iipp', 'strategy.canvasResizedCallback') }}}({{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, strategy.canvasResizedCallbackUserData);
@@ -1251,7 +1251,7 @@ var LibraryHTML5 = {
 
         if (currentFullscreenStrategy.canvasResizedCallback) {
 #if PTHREADS
-          if (currentFullscreenStrategy.canvasResizedCallbackTargetThread) __emscripten_run_callback_on_thread(currentFullscreenStrategy.canvasResizedCallbackTargetThread, currentFullscreenStrategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
+          if (currentFullscreenStrategy.canvasResizedCallbackTargetThread) __emscripten_run_callback_on_thread(currentFullscreenStrategy.canvasResizedCallbackTargetThread, currentFullscreenStrategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
           else
 #endif
           {{{ makeDynCall('iipp', 'currentFullscreenStrategy.canvasResizedCallback') }}}({{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
@@ -1356,7 +1356,7 @@ var LibraryHTML5 = {
 
     if (!inCenteredWithoutScalingFullscreenMode && currentFullscreenStrategy.canvasResizedCallback) {
 #if PTHREADS
-      if (currentFullscreenStrategy.canvasResizedCallbackTargetThread) __emscripten_run_callback_on_thread(currentFullscreenStrategy.canvasResizedCallbackTargetThread, currentFullscreenStrategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
+      if (currentFullscreenStrategy.canvasResizedCallbackTargetThread) __emscripten_run_callback_on_thread(currentFullscreenStrategy.canvasResizedCallbackTargetThread, currentFullscreenStrategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
       else
 #endif
       {{{ makeDynCall('iipp', 'currentFullscreenStrategy.canvasResizedCallback') }}}({{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, currentFullscreenStrategy.canvasResizedCallbackUserData);
@@ -1468,7 +1468,7 @@ var LibraryHTML5 = {
       removeEventListener('resize', softFullscreenResizeWebGLRenderTarget);
       if (strategy.canvasResizedCallback) {
 #if PTHREADS
-        if (strategy.canvasResizedCallbackTargetThread) __emscripten_run_callback_on_thread(strategy.canvasResizedCallbackTargetThread, strategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, strategy.canvasResizedCallbackUserData);
+        if (strategy.canvasResizedCallbackTargetThread) __emscripten_run_callback_on_thread(strategy.canvasResizedCallbackTargetThread, strategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, 0, strategy.canvasResizedCallbackUserData);
         else
 #endif
         {{{ makeDynCall('iipp', 'strategy.canvasResizedCallback') }}}({{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, strategy.canvasResizedCallbackUserData);
@@ -1482,7 +1482,7 @@ var LibraryHTML5 = {
     // Inform the caller that the canvas size has changed.
     if (strategy.canvasResizedCallback) {
 #if PTHREADS
-      if (strategy.canvasResizedCallbackTargetThread) __emscripten_run_callback_on_thread(strategy.canvasResizedCallbackTargetThread, strategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, strategy.canvasResizedCallbackUserData);
+      if (strategy.canvasResizedCallbackTargetThread) __emscripten_run_callback_on_thread(strategy.canvasResizedCallbackTargetThread, strategy.canvasResizedCallback, {{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, 0, strategy.canvasResizedCallbackUserData);
       else
 #endif
       {{{ makeDynCall('iipp', 'strategy.canvasResizedCallback') }}}({{{ cDefs.EMSCRIPTEN_EVENT_CANVASRESIZED }}}, 0, strategy.canvasResizedCallbackUserData);
@@ -1602,7 +1602,7 @@ var LibraryHTML5 = {
 
     var pointerlockErrorEventHandlerFunc = (e) => {
 #if PTHREADS
-      if (targetThread) __emscripten_run_callback_on_thread(targetThread, callbackfunc, eventTypeId, 0, userData);
+      if (targetThread) __emscripten_run_callback_on_thread(targetThread, callbackfunc, eventTypeId, 0, 0, userData);
       else
 #endif
       if ({{{ makeDynCall('iipp', 'callbackfunc') }}}(eventTypeId, 0, userData)) e.preventDefault();

--- a/src/lib/libhtml5_webgl.js
+++ b/src/lib/libhtml5_webgl.js
@@ -433,7 +433,7 @@ var LibraryHtml5WebGL = {
 
     var webGlEventHandlerFunc = (e) => {
 #if PTHREADS
-      if (targetThread) __emscripten_run_callback_on_thread(targetThread, callbackfunc, eventTypeId, 0, userData);
+      if (targetThread) __emscripten_run_callback_on_thread(targetThread, callbackfunc, eventTypeId, 0, 0, userData);
       else
 #endif
       if ({{{ makeDynCall('iiii', 'callbackfunc') }}}(eventTypeId, 0, userData)) e.preventDefault();

--- a/test/browser/webgl_context_lost_pthread.c
+++ b/test/browser/webgl_context_lost_pthread.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <GLES2/gl2.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#include <emscripten/threading.h>
+#include <pthread.h>
+
+pthread_t worker_thread;
+
+bool context_lost(int eventType, const void *reserved, void *userData) {
+  EM_ASM({
+    console.log('DEBUG context_lost userData: ' + $0);
+  }, userData);
+  if (pthread_self() != worker_thread) {
+    emscripten_force_exit(1);
+  }
+  if (userData != (void*)0x1234) {
+    emscripten_force_exit(2);
+  }
+  printf("Test finished with result 0\n");
+  emscripten_force_exit(0);
+  return true;
+}
+
+void* thread_main(void* arg) {
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context = (EMSCRIPTEN_WEBGL_CONTEXT_HANDLE)(uintptr_t)arg;
+
+  EMSCRIPTEN_RESULT res = emscripten_set_webglcontextlost_callback("#canvas", (void*)0x1234, false, context_lost);
+  assert(res == EMSCRIPTEN_RESULT_SUCCESS);
+
+  MAIN_THREAD_EM_ASM({
+    var glExt = GL.contexts[$0].GLctx.getExtension('WEBGL_lose_context');
+    glExt.loseContext();
+  }, context);
+
+  emscripten_exit_with_live_runtime();
+}
+
+int main() {
+  EmscriptenWebGLContextAttributes attrs;
+  emscripten_webgl_init_context_attributes(&attrs);
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context = emscripten_webgl_create_context("#canvas", &attrs);
+  assert(context > 0);
+
+  int rc = pthread_create(&worker_thread, NULL, thread_main, (void*)(uintptr_t)context);
+  assert(rc == 0);
+  return 0;
+}

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2616,6 +2616,10 @@ Module["preRun"] = () => {
     self.btest_exit('webgl_destroy_context.c', cflags=args + ['--shell-file', test_file('browser/webgl_destroy_context_shell.html'), '-lGL'])
 
   @requires_graphics_hardware
+  def test_html5_webgl_context_lost_pthread(self):
+    self.btest_exit('webgl_context_lost_pthread.c', cflags=['-pthread', '-lGL', '-sASSERTIONS', '--shell-file', test_file('browser/webgl_destroy_context_shell.html')])
+
+  @requires_graphics_hardware
   def test_webgl_context_params(self):
     self.btest_exit('webgl_color_buffer_readpixels.c', cflags=['-lGL'])
 


### PR DESCRIPTION
In #25783, `_emscripten_run_callback_on_thread` was updated to take an event_data_size parameter. However, call sites passing 0 for event data in `libhtml5.js` and `libhtml5_webgl.js` were missed and left with 5 arguments instead of 6, causing `userData` to be passed as `event_data_size` and `user_data` to be omitted.