### PR TITLE
[FS] Remove obsolete socket fd assertion

### DIFF
--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -353,9 +353,6 @@ var SyscallsLibrary = {
   __syscall_socket__deps: ['$SOCKFS'],
   __syscall_socket: (domain, type, protocol, u1, u2, u3) => {
     var sock = SOCKFS.createSocket(domain, type, protocol);
-#if ASSERTIONS
-    assert(sock.stream.fd < 64); // XXX ? select() assumes socket fd values are in 0..63
-#endif
     return sock.stream.fd;
   },
   __syscall_getsockname__deps: ['$getSocketFromFD', '$writeSockaddr', '$DNS'],


### PR DESCRIPTION
This assertion dates back to commit 87b9fe11e545 (2013) when select() was implemented directly in JavaScript using a 64-bit fd bitmask.

Since select() was moved to musl C code and implemented via poll()/ __syscall_poll, select() supports up to FD_SETSIZE (1024) and fd values > 63 are handled properly by the FS and SOCKFS JS layers.