### PR TITLE
Honor MSG_PEEK in the socket recv path

### DIFF
--- a/src/lib/libsockfs.js
+++ b/src/lib/libsockfs.js
@@ -697,14 +697,17 @@ addToLibrary({
           throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
         }
       },
-      recvmsg(sock, length) {
+      recvmsg(sock, length, flags) {
         // http://pubs.opengroup.org/onlinepubs/7908799/xns/recvmsg.html
         if (sock.type === {{{ cDefs.SOCK_STREAM }}} && sock.server) {
           // tcp servers should not be recv()'ing on the listen socket
           throw new FS.ErrnoError({{{ cDefs.ENOTCONN }}});
         }
 
-        var queued = sock.recv_queue.shift();
+        // MSG_PEEK returns the head of the queue without consuming it, so a
+        // later recv sees the same bytes and poll still reports it readable.
+        var peek = flags & {{{ cDefs.MSG_PEEK }}};
+        var queued = sock.recv_queue[0];
         if (!queued) {
           if (sock.type === {{{ cDefs.SOCK_STREAM }}}) {
             var dest = SOCKFS.websocket_sock_ops.getPeer(sock, sock.daddr, sock.dport);
@@ -738,6 +741,9 @@ addToLibrary({
 #if SOCKET_DEBUG
         dbg(`websocket: read (${bytesRead} bytes): ${res.buffer}`);
 #endif
+
+        if (peek) return res;
+        sock.recv_queue.shift();
 
         // push back any unread data for TCP connections
         if (sock.type === {{{ cDefs.SOCK_STREAM }}} && bytesRead < queuedLength) {

--- a/src/lib/libsockfs_node.js
+++ b/src/lib/libsockfs_node.js
@@ -599,9 +599,13 @@ var NodeSockFSLibrary = {
       if (!ok) sock.writeBlocked = true; // cleared on 'drain', gates poll's POLLOUT
       return length;
     },
-    recvmsg(sock, length) {
+    recvmsg(sock, length, flags) {
+      // MSG_PEEK returns the data from the head of the queue without consuming
+      // it: no shift, no recv_bytes/flow-control adjustment, so a later recv
+      // sees the same bytes and poll still reports the socket readable.
+      var peek = flags & {{{ cDefs.MSG_PEEK }}};
       if (sock.type === {{{ cDefs.SOCK_DGRAM }}}) {
-        var dgram = sock.recv_queue.shift();
+        var dgram = sock.recv_queue[0];
         if (!dgram) {
           // poll reports the socket readable on a pending error, so surface
           // (and clear) it here rather than spinning on EAGAIN.
@@ -614,9 +618,11 @@ var NodeSockFSLibrary = {
         }
         // A datagram is atomic: return up to length bytes and drop the rest.
         var dd = dgram.data;
-        return { buffer: dd.subarray(0, Math.min(length, dd.length)), addr: dgram.addr, port: dgram.port };
+        var res = { buffer: dd.subarray(0, Math.min(length, dd.length)), addr: dgram.addr, port: dgram.port };
+        if (!peek) sock.recv_queue.shift();
+        return res;
       }
-      var queued = sock.recv_queue.shift();
+      var queued = sock.recv_queue[0];
       if (!queued) {
         if (sock.readClosed) return null; // EOF
         if (!sock.connection) {
@@ -627,6 +633,8 @@ var NodeSockFSLibrary = {
       var q = queued.data;
       var bytesRead = Math.min(length, q.length);
       var res = { buffer: q.subarray(0, bytesRead), addr: queued.addr, port: queued.port };
+      if (peek) return res;
+      sock.recv_queue.shift();
       if (bytesRead < q.length) {
         queued.data = q.subarray(bytesRead);
         sock.recv_queue.unshift(queued);

--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -421,7 +421,7 @@ var SyscallsLibrary = {
   __syscall_recvfrom__deps: ['$getSocketFromFD', '$writeSockaddr', '$DNS'],
   __syscall_recvfrom: (fd, buf, len, flags, addr, alen) => {
     var sock = getSocketFromFD(fd);
-    var msg = sock.sock_ops.recvmsg(sock, len);
+    var msg = sock.sock_ops.recvmsg(sock, len, flags);
     if (!msg) return 0; // socket is closed
     if (addr) {
       var errno = writeSockaddr(addr, sock.family, DNS.lookup_name(msg.addr), msg.port, alen);
@@ -517,15 +517,13 @@ var SyscallsLibrary = {
     for (var i = 0; i < num; i++) {
       total += {{{ makeGetValue('iov', `(${C_STRUCTS.iovec.__size__} * i) + ${C_STRUCTS.iovec.iov_len}`, 'i32') }}};
     }
-    // try to read total data
-    var msg = sock.sock_ops.recvmsg(sock, total);
+    // try to read total data (MSG_PEEK, when set, leaves it buffered)
+    var msg = sock.sock_ops.recvmsg(sock, total, flags);
     if (!msg) return 0; // socket is closed
 
     // TODO honor flags:
     // MSG_OOB
     // Requests out-of-band data. The significance and semantics of out-of-band data are protocol-specific.
-    // MSG_PEEK
-    // Peeks at the incoming message.
     // MSG_WAITALL
     // Requests that the function block until the full amount of data requested can be returned. The function may return a smaller amount of data if a signal is caught, if the connection is terminated, if MSG_PEEK was specified, or if an error is pending for the socket.
 

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -293,6 +293,7 @@
             "SOCK_STREAM",
             "SOCK_CLOEXEC",
             "SOCK_NONBLOCK",
+             "MSG_PEEK",
              "AF_INET",
              "AF_UNSPEC",
              "AF_INET6",

--- a/src/struct_info_generated.json
+++ b/src/struct_info_generated.json
@@ -323,6 +323,7 @@
         "KMOD_RCTRL": 128,
         "KMOD_RSHIFT": 2,
         "MAP_PRIVATE": 2,
+        "MSG_PEEK": 2,
         "NCCS": 32,
         "NI_NAMEREQD": 8,
         "NI_NUMERICHOST": 1,

--- a/src/struct_info_generated_wasm64.json
+++ b/src/struct_info_generated_wasm64.json
@@ -323,6 +323,7 @@
         "KMOD_RCTRL": 128,
         "KMOD_RSHIFT": 2,
         "MAP_PRIVATE": 2,
+        "MSG_PEEK": 2,
         "NCCS": 32,
         "NI_NAMEREQD": 8,
         "NI_NUMERICHOST": 1,

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268243,
+  "a.out.js": 268279,
   "a.out.nodebug.wasm": 587978,
-  "total": 856221,
+  "total": 856257,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/sockets/test_sockets_echo_client.c
+++ b/test/sockets/test_sockets_echo_client.c
@@ -93,6 +93,24 @@ void main_loop() {
     res = ioctl(server.fd, FIONREAD, &available);
     assert(res != -1);
     assert(available);
+
+    // Before consuming anything, MSG_PEEK must return the head of the queue
+    // without removing it: the same bytes stay available for the real recv
+    // below and the socket remains readable (FIONREAD unchanged).
+    char peeked[sizeof(int)];
+    int peeked_len = 0;
+    if (echo_read == 0 && !server.msg.length) {
+      res = recvfrom(server.fd, peeked, sizeof(peeked), MSG_PEEK, NULL, NULL);
+      if (res == -1) {
+        assert(errno == EAGAIN);
+        return;
+      }
+      assert(res > 0);
+      peeked_len = res;
+      int available2;
+      assert(ioctl(server.fd, FIONREAD, &available2) != -1);
+      assert(available2 == available);
+    }
 #endif
 
     res = do_msg_read(server.fd, &server.msg, echo_read, 0, NULL, NULL);
@@ -102,6 +120,16 @@ void main_loop() {
       perror("server closed");
       finish(EXIT_FAILURE);
     }
+
+#if !TEST_DGRAM
+    // do_msg_read consumed the length header; the bytes we peeked earlier must
+    // match the bytes actually delivered, proving the peek did not corrupt or
+    // reorder the stream.
+    if (peeked_len == sizeof(int) && server.msg.length) {
+      assert(memcmp(peeked, &server.msg.length, sizeof(int)) == 0);
+      printf("peek verified\n");
+    }
+#endif
 
     echo_read += res;
 

--- a/test/sockets/test_tcp_peek.c
+++ b/test/sockets/test_tcp_peek.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ *
+ * Self-contained TCP loopback peek test. A listener and a client live in one
+ * process. The client sends one message; the server recv()s it with MSG_PEEK
+ * (which must leave the data buffered), asserts the socket is still readable,
+ * then recv()s it again without MSG_PEEK and gets the same bytes. This is plain
+ * POSIX and also builds/runs natively against the host stack.
+ */
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
+#define MSG "peekme"
+#define MSGLEN 6
+
+int listen_fd = -1;
+int client_fd = -1;
+int peer_fd = -1; // accepted (server-side) connection
+struct sockaddr_in dest;
+bool connected = false;
+bool sent = false;
+
+void set_nonblocking(int fd) {
+  fcntl(fd, F_SETFL, O_NONBLOCK);
+}
+
+void test_success(void) {
+  printf("TCP PEEK PASS\n");
+  if (listen_fd >= 0) close(listen_fd);
+  if (client_fd >= 0) close(client_fd);
+  if (peer_fd >= 0) close(peer_fd);
+#ifdef __EMSCRIPTEN__
+  emscripten_cancel_main_loop();
+#else
+  exit(0);
+#endif
+}
+
+void start_client(void) {
+  if (client_fd >= 0) close(client_fd);
+  client_fd = socket(AF_INET, SOCK_STREAM, 0);
+  assert(client_fd >= 0);
+  set_nonblocking(client_fd);
+  connected = false;
+  sent = false;
+  int r = connect(client_fd, (struct sockaddr*)&dest, sizeof(dest));
+  assert((r == 0 || errno == EINPROGRESS) && "connect");
+}
+
+int readable(int fd) {
+  fd_set fdr;
+  struct timeval tv = {0};
+  FD_ZERO(&fdr);
+  FD_SET(fd, &fdr);
+  return select(fd + 1, &fdr, NULL, NULL, &tv) > 0 && FD_ISSET(fd, &fdr);
+}
+
+void main_loop(void) {
+  fd_set fdr, fdw;
+  struct timeval tv = {0};
+  FD_ZERO(&fdr);
+  FD_ZERO(&fdw);
+  FD_SET(listen_fd, &fdr);
+  FD_SET(client_fd, &fdw);
+  if (peer_fd >= 0) FD_SET(peer_fd, &fdr);
+  select(64, &fdr, &fdw, NULL, &tv);
+
+  // server: accept the incoming connection
+  if (peer_fd < 0 && FD_ISSET(listen_fd, &fdr)) {
+    peer_fd = accept(listen_fd, NULL, NULL);
+    if (peer_fd >= 0) set_nonblocking(peer_fd);
+  }
+
+  // client: connect completion (retry while the listener is coming up)
+  if (!connected && FD_ISSET(client_fd, &fdw)) {
+    int err = 0;
+    socklen_t l = sizeof(err);
+    getsockopt(client_fd, SOL_SOCKET, SO_ERROR, &err, &l);
+    if (err == ECONNREFUSED || err == ECONNRESET) {
+      start_client();
+      return;
+    }
+    assert(err == 0 && "connect failed");
+    connected = true;
+  }
+
+  // client: send the message once connected
+  if (connected && !sent && FD_ISSET(client_fd, &fdw)) {
+    if (send(client_fd, MSG, MSGLEN, 0) == MSGLEN) sent = true;
+  }
+
+  // server: peek, then read - both must return the same bytes
+  if (peer_fd >= 0 && FD_ISSET(peer_fd, &fdr)) {
+    char buf[MSGLEN];
+
+    memset(buf, 0, sizeof(buf));
+    ssize_t n = recv(peer_fd, buf, sizeof(buf), MSG_PEEK);
+    assert(n == MSGLEN && "peek length");
+    assert(memcmp(buf, MSG, MSGLEN) == 0 && "peek data");
+
+    // The peek must not have consumed the data: still readable.
+    assert(readable(peer_fd) && "readable after peek");
+
+    memset(buf, 0, sizeof(buf));
+    n = recv(peer_fd, buf, sizeof(buf), 0);
+    assert(n == MSGLEN && "recv length");
+    assert(memcmp(buf, MSG, MSGLEN) == 0 && "recv data");
+
+    test_success();
+  }
+}
+
+int main(void) {
+  listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+  assert(listen_fd >= 0);
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(0); // ephemeral
+  inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+  if (bind(listen_fd, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    perror("bind");
+    return 1;
+  }
+  if (listen(listen_fd, 4) != 0) {
+    perror("listen");
+    return 1;
+  }
+
+  struct sockaddr_in la;
+  socklen_t ll = sizeof(la);
+  if (getsockname(listen_fd, (struct sockaddr*)&la, &ll) != 0) {
+    perror("getsockname");
+    return 1;
+  }
+  set_nonblocking(listen_fd);
+
+  memset(&dest, 0, sizeof(dest));
+  dest.sin_family = AF_INET;
+  dest.sin_port = la.sin_port;
+  inet_pton(AF_INET, "127.0.0.1", &dest.sin_addr);
+  start_client();
+
+#ifdef __EMSCRIPTEN__
+  emscripten_set_main_loop(main_loop, 0, 0);
+#else
+  while (1) {
+    main_loop();
+    usleep(1000);
+  }
+#endif
+  return 0;
+}

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -456,6 +456,12 @@ class sockets(BrowserCore):
     # and recv over real OS sockets via the tcp_wrap server path.
     self.do_runf('sockets/test_tcp_server.c', 'TCP SERVER PASS', cflags=['-sNODERAWSOCKETS'])
 
+  @also_with_proxy_to_pthread
+  def test_noderawsockets_peek(self):
+    # recv(MSG_PEEK) must leave the data buffered: a peek returns the bytes, the
+    # socket stays readable, and the following plain recv returns them again.
+    self.do_runf('sockets/test_tcp_peek.c', 'TCP PEEK PASS', cflags=['-sNODERAWSOCKETS'])
+
   def test_noderawsockets_server_autobind(self):
     # listen() without a prior bind() must auto-bind an ephemeral port and
     # getsockname() must report it (POSIX), then accept+echo as usual.


### PR DESCRIPTION
recv/recvfrom/recvmsg ignored the MSG_PEEK flag, so a "peek" consumed the data instead of leaving it buffered. The recvmsg sock-op always shifted the head off recv_queue, and the syscall wrappers never passed the flags through. A subsequent real recv then returned EAGAIN, and epoll/poll derived the socket as not-readable (its recv_queue was now empty). This surfaced in the mio test suite (tcp_stream peek tests) on wasm32-unknown-emscripten under NODERAWSOCKETS + PROXY_TO_PTHREAD + JSPI.

* Thread the syscall `flags` through to `sock_ops.recvmsg(sock, len, flags)`.
* When `MSG_PEEK` is set, return up to `len` bytes from the head of the queue without mutating any state — no shift, no `recv_bytes` accounting, and no resuming the paused node stream — so a later recv returns the same bytes and readiness is unchanged.
* Applied to both the node:net (NODERAWSOCKETS) and websocket backends, for stream and datagram sockets.
* Adds `MSG_PEEK` to struct_info.

Before, the backend consumed unconditionally:

```js
recvmsg(sock, length) {
  var queued = sock.recv_queue.shift();
  ...
}
```

After, a peek reads the head without removing it:

```js
recvmsg(sock, length, flags) {
  var peek = flags & MSG_PEEK;
  var queued = sock.recv_queue[0];
  ...
  if (peek) return res;
  sock.recv_queue.shift();
  ...
}
```

Adds `test/sockets/test_tcp_peek.c`, a self-contained loopback peek-then-read (also builds/runs natively against the host stack) wired up as `test_noderawsockets_peek` and run under both the direct and PROXY_TO_PTHREAD configurations. It fails on the old code (the socket reads as not-readable right after the peek) and passes with the fix.

_Made with AI assistance under my review_