### PR TITLE
Report POLLHUP for a locally fully-shutdown TCP socket in NODERAWSOCKETS

### DIFF
--- a/src/lib/libsockfs_node.js
+++ b/src/lib/libsockfs_node.js
@@ -341,10 +341,14 @@ var NodeSockFSLibrary = {
       } else if (sock.connection && sock.state === {{{ SOCK_STATE_CONNECTED }}} && !sock.writeBlocked) {
         mask |= {{{ cDefs.POLLOUT }}};
       }
-      // A peer FIN / read-side hangup (recv will see EOF) is POLLRDHUP; only a
-      // fully closed connection is a POLLHUP.
+      // A peer FIN / read-side hangup (recv will see EOF) is POLLRDHUP. POLLHUP
+      // means both halves are hung up: either the connection is fully closed, or
+      // we locally shut down both directions (shutdown(SHUT_RDWR)), which Linux
+      // epoll reports as a hangup even though the node connection is still live.
       if (sock.readClosed) mask |= {{{ cDefs.POLLRDHUP }}};
-      if (sock.state === {{{ SOCK_STATE_CLOSED }}}) mask |= {{{ cDefs.POLLHUP }}};
+      if (sock.state === {{{ SOCK_STATE_CLOSED }}} || (sock.readClosed && sock.writeShutdown)) {
+        mask |= {{{ cDefs.POLLHUP }}};
+      }
       return mask;
     },
     ioctl(sock, request, arg) {

--- a/test/sockets/test_tcp_client_semantics.c
+++ b/test/sockets/test_tcp_client_semantics.c
@@ -7,7 +7,8 @@
  * Outgoing TCP client error/state semantics against a loopback echo server
  * started by the test harness (port in argv[1]). Checks connecting twice gives
  * EISCONN, that shutdown(SHUT_WR) half-closes the write side while reads still
- * work, and that writing after that gives EPIPE. Plain POSIX, also runs
+ * work, that writing after that gives EPIPE, and that a full
+ * shutdown(SHUT_RDWR) hangs up both halves (POLLHUP). Plain POSIX, also runs
  * natively.
  */
 
@@ -16,6 +17,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -84,6 +86,13 @@ void main_loop(void) {
     // Writing after a write-shutdown is a broken pipe.
     ssize_t w = send(fd, "more", 4, 0);
     assert(w == -1 && errno == EPIPE);
+
+    // A full local shutdown hangs up both halves: poll must report POLLHUP,
+    // matching Linux epoll even though the peer hasn't closed.
+    assert(shutdown(fd, SHUT_RDWR) == 0);
+    struct pollfd pfd = {.fd = fd, .events = POLLIN | POLLOUT};
+    assert(poll(&pfd, 1, 1000) > 0);
+    assert(pfd.revents & POLLHUP);
 
     test_success();
   }

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -419,8 +419,8 @@ class sockets(BrowserCore):
       thread.join()
 
   def test_noderawsockets_client_semantics(self):
-    # EISCONN on a second connect, shutdown(SHUT_WR) leaving reads working, and
-    # EPIPE on a write after that.
+    # EISCONN on a second connect, shutdown(SHUT_WR) leaving reads working,
+    # EPIPE on a write after that, and POLLHUP after a full shutdown(SHUT_RDWR).
     self._run_against_echo_server('sockets/test_tcp_client_semantics.c', 'CLIENT SEMANTICS PASS')
 
   def test_noderawsockets_refused(self):


### PR DESCRIPTION
After `shutdown(fd, SHUT_RDWR)` on a connected TCP socket, `poll`/`epoll` should report `POLLHUP` — Linux does — but the `NODERAWSOCKETS` backend did not. `poll()` only set `POLLHUP` once the underlying node connection reached `SOCK_STATE_CLOSED`, whereas after a local full shutdown the connection is still `CONNECTED` (FIN sent, socket not destroyed). So a locally fully-shut socket returned `POLLIN|POLLRDHUP|POLLOUT` with no `POLLHUP`.

`shutdown(SHUT_RDWR)` already sets both `sock.readClosed` and `sock.writeShutdown`, but `poll()` ignored `writeShutdown` entirely. This treats a socket whose read and write halves are both locally shut as hung up:

```js
if (sock.state === SOCK_STATE_CLOSED || (sock.readClosed && sock.writeShutdown)) {
  mask |= POLLHUP;
}
```

matching Linux epoll behavior even though the peer hasn't closed.

Found while running the `mio` test suite (`wasm32-unknown-emscripten`, `NODERAWSOCKETS`+`PROXY_TO_PTHREAD`+`JSPI`): `tcp_stream::tcp_shutdown_client_both_close_event` expects a `WRITE_CLOSED` event after `shutdown(Both)` that was never delivered.

Test coverage: extended `test_tcp_client_semantics.c` to assert `poll()` reports `POLLHUP` after a full `shutdown(SHUT_RDWR)`. Verified the new assertion fails without the fix and passes with it. The `SHUT_WR`-only case is left unchanged (a genuine epoll-vs-kqueue difference, already ignored on epoll platforms).

_Made with AI assistance under my review_