### PR TITLE
Enable pthreads when -fopenmp is specified

### DIFF
--- a/tools/cmdline.py
+++ b/tools/cmdline.py
@@ -542,6 +542,8 @@ def parse_args(newargs):  # noqa: C901, PLR0912, PLR0915
     # Record PTHREADS setting because it controls whether --shared-memory is passed to lld
     elif arg in {'-fopenmp', '-fopenmp=libomp'}:
       options.openmp = 1
+      settings.PTHREADS = 1
+      settings.USE_PTHREADS = 1
     elif arg == '-pthread':
       settings.PTHREADS = 1
       # Also set the legacy setting name, in case use JS code depends on it.


### PR DESCRIPTION
In Clang, specifying -fopenmp automatically enables thread support. Match this behavior in Emscripten to prevent link and runtime errors when using OpenMP libraries.