### PR TITLE
Refactor/rename `is_user_symbol`. NFC

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -883,7 +883,10 @@ def metadce(js_file, wasm_file, debug_info, last):
         unused_imports.append(native_name)
       elif name.startswith('emcc$export$') and settings.DECLARE_ASM_MODULE_EXPORTS:
         native_name = export_name_map[name]
-        if shared.is_user_export(native_name):
+        # Internal/system exports (e.g. memory, __asyncify_data, dynCall_*, etc.)
+        # do not have standard JS receiving assignments (_name = wasmExports['name']),
+        # so including them in unused_exports would fail applyDCEGraphRemovals's assertion.
+        if not shared.is_internal_symbol(native_name):
           unused_exports.append(native_name)
   if not unused_exports and not unused_imports:
     # nothing found to be unused, so we have nothing to remove

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -606,7 +606,7 @@ def finalize_wasm(infile, outfile, js_syms):
   # EMSCRIPTEN_KEEPALIVE (llvm.used).
   # These are any exports that were not requested on the command line and are
   # not known auto-generated system functions.
-  unexpected_exports = [e for e in metadata.all_exports if shared.is_user_export(e)]
+  unexpected_exports = [e for e in metadata.all_exports if not shared.is_internal_symbol(e)]
   unexpected_exports = [asmjs_mangle(e) for e in unexpected_exports]
   unexpected_exports = [e for e in unexpected_exports if e not in expected_exports]
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -582,10 +582,10 @@ def is_internal_global(name):
   return name in internal_start_stop_symbols or name.startswith(internal_prefixes)
 
 
-def is_user_export(name):
+def is_internal_symbol(name):
   if is_internal_global(name):
-    return False
-  return name not in {'__asyncify_data', '__asyncify_state', '__indirect_function_table', 'memory'} and not name.startswith(('dynCall_', 'orig$'))
+    return True
+  return name in {'__asyncify_data', '__asyncify_state', '__indirect_function_table', 'memory'} or name.startswith(('dynCall_', 'orig$'))
 
 
 def asmjs_mangle(name):
@@ -598,9 +598,10 @@ def asmjs_mangle(name):
   # to simply `main` which is expected by the emscripten JS glue code.
   if name == '__main_argc_argv':
     name = 'main'
-  if is_user_export(name):
-    return '_' + name
-  return name
+  if is_internal_symbol(name):
+    # Don't mangle "internal" symbols.
+    return name
+  return '_' + name
 
 
 def do_replace(input_, pattern, replacement):


### PR DESCRIPTION
Referring to "user" symbols was confusing because it could mean "user requested symbol" or "user exported symbol".