### PR TITLE
Gather writev iovecs into a single FS.write

### DIFF
--- a/src/lib/libwasi.js
+++ b/src/lib/libwasi.js
@@ -225,34 +225,27 @@ var WasiLibrary = {
   },
   $doWritev__docs: '/** @param {number=} offset */',
   $doWritev: (stream, iov, iovcnt, offset) => {
-    var ret = 0;
-    for (var i = 0; i < iovcnt; i++) {
-      var ptr = {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_base, '*') }}};
-      var len = {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_len, '*') }}};
-      iov += {{{ C_STRUCTS.iovec.__size__ }}};
-      try {
-        var curr = FS.write(stream, HEAP8, ptr, len, offset);
-      } catch (e) {
-        // On a non-blocking stream a subsequent write may would-block after we
-        // already sent data. POSIX writev is a single gather-write: return
-        // what we have rather than failing the whole call.
-        if (ret > 0 && e instanceof FS.ErrnoError &&
-            (e.errno == {{{ cDefs.EAGAIN }}} || e.errno == {{{ cDefs.EWOULDBLOCK }}})) {
-          break;
-        }
-        throw e;
-      }
-      if (curr < 0) return -1;
-      ret += curr;
-      if (curr < len) {
-        // No more space to write.
-        break;
-      }
-      if (typeof offset != 'undefined') {
-        offset += curr;
-      }
+    // Gather all iovecs into one contiguous buffer and issue a single
+    // FS.write, matching POSIX writev's single gather-write semantics (as
+    // __syscall_sendmsg already does). Per-iovec writes fragment a stream
+    // socket send into multiple segments, breaking stream byte semantics.
+    if (iovcnt == 1) {
+      // Single iovec: write directly from HEAP8, no gather buffer needed.
+      return FS.write(stream, HEAP8, {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_base, '*') }}}, {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_len, '*') }}}, offset);
     }
-    return ret;
+    var total = 0;
+    for (var i = 0; i < iovcnt; i++) {
+      total += {{{ makeGetValue('iov', `(${C_STRUCTS.iovec.__size__} * i) + ${C_STRUCTS.iovec.iov_len}`, '*') }}};
+    }
+    var view = new Uint8Array(total);
+    var voff = 0;
+    for (var i = 0; i < iovcnt; i++) {
+      var ptr = {{{ makeGetValue('iov', `(${C_STRUCTS.iovec.__size__} * i) + ${C_STRUCTS.iovec.iov_base}`, '*') }}};
+      var len = {{{ makeGetValue('iov', `(${C_STRUCTS.iovec.__size__} * i) + ${C_STRUCTS.iovec.iov_len}`, '*') }}};
+      view.set(HEAPU8.subarray(ptr, ptr + len), voff);
+      voff += len;
+    }
+    return FS.write(stream, view, 0, total, offset);
   },
 #else
   // MEMFS filesystem disabled lite handling of stdout and stderr:

--- a/src/lib/libwasi.js
+++ b/src/lib/libwasi.js
@@ -234,14 +234,14 @@ var WasiLibrary = {
       return FS.write(stream, HEAP8, {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_base, '*') }}}, {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_len, '*') }}}, offset);
     }
     var total = 0;
-    for (var i = 0; i < iovcnt; i++) {
-      total += {{{ makeGetValue('iov', `(${C_STRUCTS.iovec.__size__} * i) + ${C_STRUCTS.iovec.iov_len}`, '*') }}};
+    for (var i = 0, p = iov; i < iovcnt; i++, p += {{{ C_STRUCTS.iovec.__size__ }}}) {
+      total += {{{ makeGetValue('p', C_STRUCTS.iovec.iov_len, '*') }}};
     }
     var view = new Uint8Array(total);
     var voff = 0;
-    for (var i = 0; i < iovcnt; i++) {
-      var ptr = {{{ makeGetValue('iov', `(${C_STRUCTS.iovec.__size__} * i) + ${C_STRUCTS.iovec.iov_base}`, '*') }}};
-      var len = {{{ makeGetValue('iov', `(${C_STRUCTS.iovec.__size__} * i) + ${C_STRUCTS.iovec.iov_len}`, '*') }}};
+    for (var i = 0; i < iovcnt; i++, iov += {{{ C_STRUCTS.iovec.__size__ }}}) {
+      var ptr = {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_base, '*') }}};
+      var len = {{{ makeGetValue('iov', C_STRUCTS.iovec.iov_len, '*') }}};
       view.set(HEAPU8.subarray(ptr, ptr + len), voff);
       voff += len;
     }

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19321,
-  "a.out.js.gz": 8000,
+  "a.out.js": 19328,
+  "a.out.js.gz": 8143,
   "a.out.nodebug.wasm": 132556,
   "a.out.nodebug.wasm.gz": 49942,
-  "total": 151877,
-  "total_gz": 57942,
+  "total": 151884,
+  "total_gz": 58085,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19328,
-  "a.out.js.gz": 8143,
+  "a.out.js.gz": 8148,
   "a.out.nodebug.wasm": 132556,
   "a.out.nodebug.wasm.gz": 49942,
   "total": 151884,
-  "total_gz": 58085,
+  "total_gz": 58090,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19305,
-  "a.out.js.gz": 8126,
+  "a.out.js.gz": 8131,
   "a.out.nodebug.wasm": 131982,
   "a.out.nodebug.wasm.gz": 49601,
   "total": 151287,
-  "total_gz": 57727,
+  "total_gz": 57732,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19298,
-  "a.out.js.gz": 7986,
+  "a.out.js": 19305,
+  "a.out.js.gz": 8126,
   "a.out.nodebug.wasm": 131982,
   "a.out.nodebug.wasm.gz": 49601,
-  "total": 151280,
-  "total_gz": 57587,
+  "total": 151287,
+  "total_gz": 57727,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23296,
-  "a.out.js.gz": 8993,
+  "a.out.js": 23307,
+  "a.out.js.gz": 9130,
   "a.out.nodebug.wasm": 172466,
   "a.out.nodebug.wasm.gz": 57476,
-  "total": 195762,
-  "total_gz": 66469,
+  "total": 195773,
+  "total_gz": 66606,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 23307,
-  "a.out.js.gz": 9130,
+  "a.out.js.gz": 9134,
   "a.out.nodebug.wasm": 172466,
   "a.out.nodebug.wasm.gz": 57476,
   "total": 195773,
-  "total_gz": 66606,
+  "total_gz": 66610,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19127,
-  "a.out.js.gz": 8061,
+  "a.out.js.gz": 8063,
   "a.out.nodebug.wasm": 147881,
   "a.out.nodebug.wasm.gz": 55369,
   "total": 167008,
-  "total_gz": 63430,
+  "total_gz": 63432,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19120,
-  "a.out.js.gz": 7923,
+  "a.out.js": 19127,
+  "a.out.js.gz": 8061,
   "a.out.nodebug.wasm": 147881,
   "a.out.nodebug.wasm.gz": 55369,
-  "total": 167001,
-  "total_gz": 63292,
+  "total": 167008,
+  "total_gz": 63430,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19205,
-  "a.out.js.gz": 8087,
+  "a.out.js.gz": 8089,
   "a.out.nodebug.wasm": 145687,
   "a.out.nodebug.wasm.gz": 54986,
   "total": 164892,
-  "total_gz": 63073,
+  "total_gz": 63075,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19198,
-  "a.out.js.gz": 7948,
+  "a.out.js": 19205,
+  "a.out.js.gz": 8087,
   "a.out.nodebug.wasm": 145687,
   "a.out.nodebug.wasm.gz": 54986,
-  "total": 164885,
-  "total_gz": 62934,
+  "total": 164892,
+  "total_gz": 63073,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 18672,
-  "a.out.js.gz": 7839,
+  "a.out.js.gz": 7841,
   "a.out.nodebug.wasm": 102063,
   "a.out.nodebug.wasm.gz": 39527,
   "total": 120735,
-  "total_gz": 47366,
+  "total_gz": 47368,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/codesize/test_codesize_cxx_lto.json
+++ b/test/codesize/test_codesize_cxx_lto.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18665,
-  "a.out.js.gz": 7692,
+  "a.out.js": 18672,
+  "a.out.js.gz": 7839,
   "a.out.nodebug.wasm": 102063,
   "a.out.nodebug.wasm.gz": 39527,
-  "total": 120728,
-  "total_gz": 47219,
+  "total": 120735,
+  "total_gz": 47366,
   "sent": [
     "a (emscripten_resize_heap)",
     "b (_setitimer_js)",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23346,
-  "a.out.js.gz": 9013,
+  "a.out.js": 23357,
+  "a.out.js.gz": 9150,
   "a.out.nodebug.wasm": 238895,
   "a.out.nodebug.wasm.gz": 79814,
-  "total": 262241,
-  "total_gz": 88827,
+  "total": 262252,
+  "total_gz": 88964,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 23357,
-  "a.out.js.gz": 9150,
+  "a.out.js.gz": 9153,
   "a.out.nodebug.wasm": 238895,
   "a.out.nodebug.wasm.gz": 79814,
   "total": 262252,
-  "total_gz": 88964,
+  "total_gz": 88967,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 19321,
-  "a.out.js.gz": 8000,
+  "a.out.js": 19328,
+  "a.out.js.gz": 8143,
   "a.out.nodebug.wasm": 134556,
   "a.out.nodebug.wasm.gz": 50787,
-  "total": 153877,
-  "total_gz": 58787,
+  "total": 153884,
+  "total_gz": 58930,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19328,
-  "a.out.js.gz": 8143,
+  "a.out.js.gz": 8148,
   "a.out.nodebug.wasm": 134556,
   "a.out.nodebug.wasm.gz": 50787,
   "total": 153884,
-  "total_gz": 58930,
+  "total_gz": 58935,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -523,14 +523,14 @@ var onPreRuns = [];
     return FS.write(stream, HEAP8, HEAPU32[((iov) >> 2)], HEAPU32[(((iov) + (4)) >> 2)], offset);
   }
   var total = 0;
-  for (var i = 0; i < iovcnt; i++) {
-    total += HEAPU32[(((iov) + ((8 * i) + 4)) >> 2)];
+  for (var i = 0, p = iov; i < iovcnt; i++, p += 8) {
+    total += HEAPU32[(((p) + (4)) >> 2)];
   }
   var view = new Uint8Array(total);
   var voff = 0;
-  for (var i = 0; i < iovcnt; i++) {
-    var ptr = HEAPU32[(((iov) + ((8 * i) + 0)) >> 2)];
-    var len = HEAPU32[(((iov) + ((8 * i) + 4)) >> 2)];
+  for (var i = 0; i < iovcnt; i++, iov += 8) {
+    var ptr = HEAPU32[((iov) >> 2)];
+    var len = HEAPU32[(((iov) + (4)) >> 2)];
     view.set(HEAPU8.subarray(ptr, ptr + len), voff);
     voff += len;
   }

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -514,33 +514,27 @@ var callRuntimeCallbacks = callbacks => {
 var onPreRuns = [];
 
 /** @param {number=} offset */ var doWritev = (stream, iov, iovcnt, offset) => {
-  var ret = 0;
-  for (var i = 0; i < iovcnt; i++) {
-    var ptr = HEAPU32[((iov) >> 2)];
-    var len = HEAPU32[(((iov) + (4)) >> 2)];
-    iov += 8;
-    try {
-      var curr = FS.write(stream, HEAP8, ptr, len, offset);
-    } catch (e) {
-      // On a non-blocking stream a subsequent write may would-block after we
-      // already sent data. POSIX writev is a single gather-write: return
-      // what we have rather than failing the whole call.
-      if (ret > 0 && e instanceof FS.ErrnoError && (e.errno == 6 || e.errno == 6)) {
-        break;
-      }
-      throw e;
-    }
-    if (curr < 0) return -1;
-    ret += curr;
-    if (curr < len) {
-      // No more space to write.
-      break;
-    }
-    if (typeof offset != "undefined") {
-      offset += curr;
-    }
+  // Gather all iovecs into one contiguous buffer and issue a single
+  // FS.write, matching POSIX writev's single gather-write semantics (as
+  // __syscall_sendmsg already does). Per-iovec writes fragment a stream
+  // socket send into multiple segments, breaking stream byte semantics.
+  if (iovcnt == 1) {
+    // Single iovec: write directly from HEAP8, no gather buffer needed.
+    return FS.write(stream, HEAP8, HEAPU32[((iov) >> 2)], HEAPU32[(((iov) + (4)) >> 2)], offset);
   }
-  return ret;
+  var total = 0;
+  for (var i = 0; i < iovcnt; i++) {
+    total += HEAPU32[(((iov) + ((8 * i) + 4)) >> 2)];
+  }
+  var view = new Uint8Array(total);
+  var voff = 0;
+  for (var i = 0; i < iovcnt; i++) {
+    var ptr = HEAPU32[(((iov) + ((8 * i) + 0)) >> 2)];
+    var len = HEAPU32[(((iov) + ((8 * i) + 4)) >> 2)];
+    view.set(HEAPU8.subarray(ptr, ptr + len), voff);
+    voff += len;
+  }
+  return FS.write(stream, view, 0, total, offset);
 };
 
 var PATH = {

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 22308,
-  "a.out.js.gz": 9277,
+  "a.out.js": 22300,
+  "a.out.js.gz": 9279,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
-  "total": 23974,
-  "total_gz": 10222,
+  "total": 23966,
+  "total_gz": 10224,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 22300,
-  "a.out.js.gz": 9279,
+  "a.out.js.gz": 9289,
   "a.out.nodebug.wasm": 1666,
   "a.out.nodebug.wasm.gz": 945,
   "total": 23966,
-  "total_gz": 10224,
+  "total_gz": 10234,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_files_js_fs.json
+++ b/test/codesize/test_codesize_files_js_fs.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 17969,
-  "a.out.js.gz": 7342,
+  "a.out.js": 17971,
+  "a.out.js.gz": 7482,
   "a.out.nodebug.wasm": 381,
   "a.out.nodebug.wasm.gz": 258,
-  "total": 18350,
-  "total_gz": 7600,
+  "total": 18352,
+  "total_gz": 7740,
   "sent": [
     "a (fd_write)",
     "b (fd_read)",

--- a/test/codesize/test_codesize_files_js_fs.json
+++ b/test/codesize/test_codesize_files_js_fs.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 17971,
-  "a.out.js.gz": 7482,
+  "a.out.js.gz": 7480,
   "a.out.nodebug.wasm": 381,
   "a.out.nodebug.wasm.gz": 258,
   "total": 18352,
-  "total_gz": 7740,
+  "total_gz": 7738,
   "sent": [
     "a (fd_write)",
     "b (fd_read)",

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 26265,
-  "a.out.js.gz": 11201,
+  "a.out.js.gz": 11212,
   "a.out.nodebug.wasm": 17861,
   "a.out.nodebug.wasm.gz": 9019,
   "total": 44126,
-  "total_gz": 20220,
+  "total_gz": 20231,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 26260,
-  "a.out.js.gz": 11231,
+  "a.out.js": 26265,
+  "a.out.js.gz": 11201,
   "a.out.nodebug.wasm": 17861,
   "a.out.nodebug.wasm.gz": 9019,
-  "total": 44121,
-  "total_gz": 20250,
+  "total": 44126,
+  "total_gz": 20220,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268425,
+  "a.out.js": 268427,
   "a.out.nodebug.wasm": 587978,
-  "total": 856403,
+  "total": 856405,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268427,
+  "a.out.js": 268425,
   "a.out.nodebug.wasm": 587978,
-  "total": 856405,
+  "total": 856403,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/fs/test_readv_eagain.c
+++ b/test/fs/test_readv_eagain.c
@@ -66,8 +66,10 @@ int main() {
   char out1[4] = "EFGH";
   struct iovec wiov[] = {{.iov_base = out0, .iov_len = 4},
                          {.iov_base = out1, .iov_len = 4}};
+  // writev gathers both iovecs into a single write, so the whole 8 bytes go
+  // out in one call and the would-block second call never happens.
   ssize_t nwrite = writev(wfd, wiov, 2);
-  assert(nwrite == 4);
+  assert(nwrite == 8);
   close(wfd);
 
   printf("done\n");

--- a/test/fs/test_trackingdelegate.out
+++ b/test/fs/test_trackingdelegate.out
@@ -1,14 +1,12 @@
 Opened "/file.txt" with flags O_CREAT O_TRUNC O_RDWR and file size 0
 Wrote to file "/file.txt" with 12 bytes written
-Wrote to file "/file.txt" with 0 bytes written
 Seek on "/file.txt" with position 0 and whence 0
 Read 12 bytes from "/file.txt"
 Read 0 bytes from "/file.txt"
 Read 0 bytes from "/file.txt"
 Read 0 bytes from "/file.txt"
-Wrote to file "/dev/tty" with 11 bytes written
 hello world
-Wrote to file "/dev/tty" with 1 bytes written
+Wrote to file "/dev/tty" with 12 bytes written
 Closed /file.txt
 About to move "/file.txt" to "/renamed.txt"
 Moved "/file.txt" to "/renamed.txt"
@@ -17,9 +15,8 @@ Read 0 bytes from "/renamed.txt"
 Read 12 bytes from "/renamed.txt"
 Read 0 bytes from "/renamed.txt"
 Read 0 bytes from "/renamed.txt"
-Wrote to file "/dev/tty" with 31 bytes written
 File read returned 'hello world'
-Wrote to file "/dev/tty" with 2 bytes written
+Wrote to file "/dev/tty" with 33 bytes written
 Closed /renamed.txt
 Opened "/renamed.txt" with flags O_RDONLY and file size 12
 Closed /renamed.txt
@@ -29,9 +26,8 @@ Opened "/renamed.txt" with flags O_RDWR and file size 12
 Wrote to file "/renamed.txt" with 10 bytes written
 Seek on "/renamed.txt" with position 0 and whence 0
 Read 12 bytes from "/renamed.txt"
-Wrote to file "/dev/tty" with 18 bytes written
 read returned test
-Wrote to file "/dev/tty" with 1 bytes written
+Wrote to file "/dev/tty" with 19 bytes written
 Closed /renamed.txt
 Opened "/renamed.txt" with flags O_CREAT O_RDONLY and file size 12
 Closed /renamed.txt

--- a/test/fs/test_writev_gather.c
+++ b/test/fs/test_writev_gather.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+// Regression test: writev must gather all iovecs into a single FS.write so a
+// stream socket send is not fragmented into one segment per iovec.
+
+#include <assert.h>
+#include <emscripten/emscripten.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+int main() {
+  EM_ASM({
+    var dev = FS.makedev(64, 0);
+    FS.registerDevice(dev, {
+      write: (stream, buffer, offset, length, pos) => {
+        // A single gather-write for the whole payload, exactly once.
+        assert(length == 8, 'expected a single 8-byte gather write');
+        var s = String.fromCharCode.apply(null, buffer.subarray(offset, offset + length));
+        assert(s == 'a=1\nb=2\n', 'unexpected gather-write payload: ' + s);
+        return length;
+      }
+    });
+    FS.mkdev('/wdev', dev);
+  });
+
+  int fd = open("/wdev", O_WRONLY);
+  assert(fd >= 0);
+
+  char buf0[] = "a=1\n";
+  char buf1[] = "b=2\n";
+  struct iovec iov[] = {{.iov_base = buf0, .iov_len = 4},
+                        {.iov_base = buf1, .iov_len = 4}};
+  ssize_t nwritten = writev(fd, iov, 2);
+  assert(nwritten == 8);
+  close(fd);
+
+  printf("done\n");
+  return 0;
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6040,6 +6040,9 @@ Module.onRuntimeInitialized = () => {
   def test_fs_readv_eagain(self):
     self.do_runf('fs/test_readv_eagain.c', 'done\n', cflags=['-sFORCE_FILESYSTEM'])
 
+  def test_fs_writev_gather(self):
+    self.do_runf('fs/test_writev_gather.c', 'done\n', cflags=['-sFORCE_FILESYSTEM'])
+
   def test_fs_64bit(self):
     if self.get_setting('WASMFS'):
       self.set_setting('FORCE_FILESYSTEM')


### PR DESCRIPTION
`doWritev` currently issues one `FS.write` per iovec. For a stream socket that fragments a single `writev` into one segment per iovec, which breaks stream byte semantics — e.g. mio's TCP writes came through split rather than as one contiguous send.

POSIX `writev` is a single gather-write, and `__syscall_sendmsg` already gathers all iovecs into one contiguous buffer before writing. This makes `doWritev` do the same:

* sum the iovec lengths
* copy each iovec into one contiguous buffer
* issue a single `FS.write`

Adds `test/fs/test_writev_gather.c`, which registers a device whose `write` hook asserts it receives the whole payload in exactly one call.

_Made with AI assistance under my review_
