### PR TITLE
Fix compiler-rt/openpm with latest LLVM + `-Wunused-template`

### DIFF
--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_flag_parser.h
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_flag_parser.h
@@ -189,8 +189,8 @@ class FlagParser {
 };
 
 template <typename T>
-static void RegisterFlag(FlagParser *parser, const char *name, const char *desc,
-                         T *var) {
+void RegisterFlag(FlagParser *parser, const char *name, const char *desc,
+                  T *var) {
   FlagHandler<T> *fh = new (GetGlobalLowLevelAllocator()) FlagHandler<T>(var);
   parser->RegisterHandler(name, fh, desc);
 }

--- a/system/lib/llvm-openmp/src/kmp_dispatch.h
+++ b/system/lib/llvm-openmp/src/kmp_dispatch.h
@@ -291,8 +291,8 @@ template <typename T> kmp_uint32 __kmp_eq(T value, T checker) {
     TODO: make inline function (move to header file for icl)
 */
 template <typename UT>
-static UT __kmp_wait(volatile UT *spinner, UT checker,
-                     kmp_uint32 (*pred)(UT, UT) USE_ITT_BUILD_ARG(void *obj)) {
+UT __kmp_wait(volatile UT *spinner, UT checker,
+              kmp_uint32 (*pred)(UT, UT) USE_ITT_BUILD_ARG(void *obj)) {
   // note: we may not belong to a team at this point
   volatile UT *spin = spinner;
   UT check = checker;


### PR DESCRIPTION
Basically cherry-pick https://github.com/llvm/llvm-project/pull/206308:

    [compiler-rt][sanitizer_common] Remove internal linkage from RegisterFlag (NFC) (#206308)

    RegisterFlag is a static function template in a header, so every TU that
    includes it without calling it trips `-Wunused-template`. Dropping
    static gives it normal external linkage and clears the warning.

    NFC. Part of #202945.

And https://github.com/llvm/llvm-project/pull/#207983

    [OpenMP] Remove internal linkage from __kmp_wait template (NFC) (#207983)

    __kmp_wait in kmp_dispatch.h is a static function template in a header,
    so any TU that includes it without instantiating it trips
    -Wunused-template (kmp_runtime.cpp, kmp_affinity.cpp, kmp_global.cpp,
    kmp_settings.cpp). It is used by kmp_dispatch.cpp and
    kmp_dispatch_hier.h. Drop static, which the comment above it already
    suggests.

    Part of #202945