### PR TITLE
Support UDP multicast setsockopt/getsockopt in NODERAWSOCKETS

### DIFF
--- a/src/lib/libsockfs_node.js
+++ b/src/lib/libsockfs_node.js
@@ -231,16 +231,25 @@ var NodeSockFSLibrary = {
       var h = sock.udp;
       var o = sock.opts;
       if (!h || !o || !sock.udpReceiving) return;
+      // libuv's multicast TTL/loopback setters apply to whichever family the
+      // socket is, so IP_MULTICAST_TTL/IPV6_MULTICAST_HOPS and the two
+      // *_MULTICAST_LOOP options funnel through the same handle methods.
+      var mcastTtl = o.multicastTtl ?? o.multicastHops;
+      var mcastLoop = o.multicastLoop6 ?? o.multicastLoop;
       if (sock.udpPublic) {
         if (o.ttl !== undefined) { try { h.setTTL(o.ttl); } catch (e) {} }
         if (o.broadcast !== undefined) { try { h.setBroadcast(!!o.broadcast); } catch (e) {} }
         if (o.recvBuf !== undefined) { try { h.setRecvBufferSize(o.recvBuf); } catch (e) {} }
         if (o.sendBuf !== undefined) { try { h.setSendBufferSize(o.sendBuf); } catch (e) {} }
+        if (mcastTtl !== undefined) { try { h.setMulticastTTL(mcastTtl); } catch (e) {} }
+        if (mcastLoop !== undefined) { try { h.setMulticastLoopback(!!mcastLoop); } catch (e) {} }
       } else {
         if (o.ttl !== undefined) { try { h.setTTL(o.ttl); } catch (e) {} }
         if (o.broadcast !== undefined) { try { h.setBroadcast(o.broadcast ? 1 : 0); } catch (e) {} }
         if (o.recvBuf !== undefined) { try { h.bufferSize(o.recvBuf, true, {}); } catch (e) {} }
         if (o.sendBuf !== undefined) { try { h.bufferSize(o.sendBuf, false, {}); } catch (e) {} }
+        if (mcastTtl !== undefined) { try { h.setMulticastTTL(mcastTtl); } catch (e) {} }
+        if (mcastLoop !== undefined) { try { h.setMulticastLoopback(mcastLoop ? 1 : 0); } catch (e) {} }
       }
     },
     // The live OS buffer size from a bound UDP socket, or undefined.
@@ -683,19 +692,37 @@ var NodeSockFSLibrary = {
             return 0;
         }
       } else if (level === {{{ cDefs.IPPROTO_IP }}}) {
-        if (optname === 2 /* IP_TTL */) {
-          sock.opts.ttl = val;
-          nodeSockHelpers.applyUdpOptions(sock);
-          return 0;
+        switch (optname) {
+          case 2: // IP_TTL
+            sock.opts.ttl = val;
+            nodeSockHelpers.applyUdpOptions(sock);
+            return 0;
+          case 33: // IP_MULTICAST_TTL
+            sock.opts.multicastTtl = val;
+            nodeSockHelpers.applyUdpOptions(sock);
+            return 0;
+          case 34: // IP_MULTICAST_LOOP
+            sock.opts.multicastLoop = !!val;
+            nodeSockHelpers.applyUdpOptions(sock);
+            return 0;
         }
       } else if (level === {{{ cDefs.IPPROTO_IPV6 }}}) {
-        if (optname === {{{ cDefs.IPV6_V6ONLY }}}) {
-          // Bind-time only: IPV6_V6ONLY cannot change once the socket is bound,
-          // so reject a late change (POSIX returns EINVAL). Before any
-          // bind/connect/listen we cache it for the BoundSocket constructor.
-          if (sock.state) return -{{{ cDefs.EINVAL }}};
-          sock.opts.ipv6Only = !!val;
-          return 0;
+        switch (optname) {
+          case {{{ cDefs.IPV6_V6ONLY }}}:
+            // Bind-time only: IPV6_V6ONLY cannot change once the socket is bound,
+            // so reject a late change (POSIX returns EINVAL). Before any
+            // bind/connect/listen we cache it for the BoundSocket constructor.
+            if (sock.state) return -{{{ cDefs.EINVAL }}};
+            sock.opts.ipv6Only = !!val;
+            return 0;
+          case 18: // IPV6_MULTICAST_HOPS
+            sock.opts.multicastHops = val;
+            nodeSockHelpers.applyUdpOptions(sock);
+            return 0;
+          case 19: // IPV6_MULTICAST_LOOP
+            sock.opts.multicastLoop6 = !!val;
+            nodeSockHelpers.applyUdpOptions(sock);
+            return 0;
         }
       } else if (level === {{{ cDefs.IPPROTO_TCP }}}) {
         switch (optname) {
@@ -741,11 +768,19 @@ var NodeSockFSLibrary = {
           default: return -{{{ cDefs.ENOPROTOOPT }}};
         }
       } else if (level === {{{ cDefs.IPPROTO_IP }}}) {
-        if (optname !== 2 /* IP_TTL */) return -{{{ cDefs.ENOPROTOOPT }}};
-        val = sock.opts.ttl || 64;
+        switch (optname) {
+          case 2: val = sock.opts.ttl || 64; break; // IP_TTL
+          case 33: val = sock.opts.multicastTtl ?? 1; break; // IP_MULTICAST_TTL
+          case 34: val = sock.opts.multicastLoop === undefined ? 1 : (sock.opts.multicastLoop ? 1 : 0); break; // IP_MULTICAST_LOOP
+          default: return -{{{ cDefs.ENOPROTOOPT }}};
+        }
       } else if (level === {{{ cDefs.IPPROTO_IPV6 }}}) {
-        if (optname !== {{{ cDefs.IPV6_V6ONLY }}}) return -{{{ cDefs.ENOPROTOOPT }}};
-        val = sock.opts.ipv6Only ? 1 : 0;
+        switch (optname) {
+          case {{{ cDefs.IPV6_V6ONLY }}}: val = sock.opts.ipv6Only ? 1 : 0; break;
+          case 18: val = sock.opts.multicastHops ?? 1; break; // IPV6_MULTICAST_HOPS
+          case 19: val = sock.opts.multicastLoop6 === undefined ? 1 : (sock.opts.multicastLoop6 ? 1 : 0); break; // IPV6_MULTICAST_LOOP
+          default: return -{{{ cDefs.ENOPROTOOPT }}};
+        }
       } else if (level === {{{ cDefs.IPPROTO_TCP }}}) {
         switch (optname) {
           case 1: val = sock.opts.noDelay ? 1 : 0; break;    // TCP_NODELAY

--- a/test/sockets/test_udp_sockopts.c
+++ b/test/sockets/test_udp_sockopts.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ *
+ * UDP multicast socket options. Exercises IP_MULTICAST_TTL / IP_MULTICAST_LOOP
+ * on an AF_INET datagram socket and IPV6_MULTICAST_HOPS / IPV6_MULTICAST_LOOP
+ * on an AF_INET6 one: reading an option that was never set returns the POSIX
+ * default (TTL/HOPS 1, LOOP 1), and a set is observable by a subsequent get.
+ * Plain POSIX, also runs natively.
+ */
+
+#include <assert.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static int get_int(int fd, int level, int opt) {
+  int val = -1;
+  socklen_t len = sizeof(val);
+  assert(getsockopt(fd, level, opt, &val, &len) == 0);
+  return val;
+}
+
+static void set_int(int fd, int level, int opt, int val) {
+  assert(setsockopt(fd, level, opt, &val, sizeof(val)) == 0);
+}
+
+int main(void) {
+  int v4 = socket(AF_INET, SOCK_DGRAM, 0);
+  assert(v4 >= 0);
+
+  // Defaults are readable without any prior set.
+  assert(get_int(v4, IPPROTO_IP, IP_MULTICAST_TTL) == 1);
+  assert(get_int(v4, IPPROTO_IP, IP_MULTICAST_LOOP) == 1);
+
+  set_int(v4, IPPROTO_IP, IP_MULTICAST_TTL, 5);
+  assert(get_int(v4, IPPROTO_IP, IP_MULTICAST_TTL) == 5);
+
+  set_int(v4, IPPROTO_IP, IP_MULTICAST_LOOP, 0);
+  assert(get_int(v4, IPPROTO_IP, IP_MULTICAST_LOOP) == 0);
+  set_int(v4, IPPROTO_IP, IP_MULTICAST_LOOP, 1);
+  assert(get_int(v4, IPPROTO_IP, IP_MULTICAST_LOOP) == 1);
+
+  int v6 = socket(AF_INET6, SOCK_DGRAM, 0);
+  assert(v6 >= 0);
+
+  assert(get_int(v6, IPPROTO_IPV6, IPV6_MULTICAST_HOPS) == 1);
+  assert(get_int(v6, IPPROTO_IPV6, IPV6_MULTICAST_LOOP) == 1);
+
+  set_int(v6, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, 3);
+  assert(get_int(v6, IPPROTO_IPV6, IPV6_MULTICAST_HOPS) == 3);
+
+  set_int(v6, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, 0);
+  assert(get_int(v6, IPPROTO_IPV6, IPV6_MULTICAST_LOOP) == 0);
+  set_int(v6, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, 1);
+  assert(get_int(v6, IPPROTO_IPV6, IPV6_MULTICAST_LOOP) == 1);
+
+  close(v4);
+  close(v6);
+  printf("UDP SOCKOPTS PASS\n");
+  return 0;
+}

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -509,6 +509,13 @@ class sockets(BrowserCore):
     # peer, and datagrams from a non-peer socket are filtered out.
     self.do_runf('sockets/test_udp_connect.c', 'UDP CONNECT PASS', cflags=['-sNODERAWSOCKETS'])
 
+  @also_with_proxy_to_pthread
+  def test_noderawsockets_udp_sockopts(self):
+    # UDP multicast socket options: IP_MULTICAST_TTL/LOOP and their IPv6
+    # counterparts round-trip through set/getsockopt, with POSIX defaults
+    # readable before any set.
+    self.do_runf('sockets/test_udp_sockopts.c', 'UDP SOCKOPTS PASS', cflags=['-sNODERAWSOCKETS'])
+
   @requires_native_clang
   @requires_python_dev_packages
   def test_nodejs_sockets_echo_subprotocol(self):

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -513,8 +513,11 @@ class sockets(BrowserCore):
   def test_noderawsockets_udp_sockopts(self):
     # UDP multicast socket options: IP_MULTICAST_TTL/LOOP and their IPv6
     # counterparts round-trip through set/getsockopt, with POSIX defaults
-    # readable before any set.
-    self.do_runf('sockets/test_udp_sockopts.c', 'UDP SOCKOPTS PASS', cflags=['-sNODERAWSOCKETS'])
+    # readable before any set. EXIT_RUNTIME so the plain synchronous main()
+    # tears down the proxy worker on return (otherwise noExitRuntime keeps the
+    # worker, and thus node, alive under PROXY_TO_PTHREAD).
+    self.do_runf('sockets/test_udp_sockopts.c', 'UDP SOCKOPTS PASS',
+                 cflags=['-sNODERAWSOCKETS', '-sEXIT_RUNTIME'])
 
   @requires_native_clang
   @requires_python_dev_packages


### PR DESCRIPTION
With `-sNODERAWSOCKETS`, the UDP multicast socket options failed with `ENOPROTOOPT` (errno 50): `setsockopt`/`getsockopt` in `src/lib/libsockfs_node.js` only handled `IP_TTL` under `IPPROTO_IP` and `IPV6_V6ONLY` under `IPPROTO_IPV6`, so `IP_MULTICAST_TTL`, `IP_MULTICAST_LOOP`, `IPV6_MULTICAST_HOPS` and `IPV6_MULTICAST_LOOP` had no getter and were silently dropped on set. This broke UDP multicast configuration for downstream socket test suites.

This adds symmetric get/set for those options:

* `IPPROTO_IP`: `IP_MULTICAST_TTL` (default 1), `IP_MULTICAST_LOOP` (default 1)
* `IPPROTO_IPV6`: `IPV6_MULTICAST_HOPS` (default 1), `IPV6_MULTICAST_LOOP` (default 1)

Values are stored on `sock.opts` and applied to the node `dgram` handle through `applyUdpOptions`, which calls `setMulticastTTL(n)` / `setMulticastLoopback(bool)` on both the public `dgram` socket and the fallback `udp_wrap` handle (libuv applies these regardless of family, so the IPv6 hops/loop options funnel through the same methods). All handle calls are guarded in try/catch so they are safe to (re)apply before bind. `getsockopt` returns the stored value, or the POSIX default when unset, so reads without a prior set succeed.

Adds a self-contained `test/sockets/test_udp_sockopts.c` (run as `test_noderawsockets_udp_sockopts`) covering defaults-without-set and set/get round-trips on both AF_INET and AF_INET6 sockets. Verified it fails against the old code (the first `getsockopt` asserts) and passes with the fix.

_Made with AI assistance under my review_
