### PR TITLE
Add co-author of libomp support to AUTHORS. NFC

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -604,3 +604,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Mitchell Wills <mwills@google.com> (copyright owned by Google, Inc.)
 * Han Jiang <jhcarl0814@gmail.com>
 * Abdelrahman Teima <abdelrahmanteima@gmail.com>
+* Jaap Aarts <jaap.aarts1@gmail.com>


### PR DESCRIPTION
as discussed in #27073 