### PR TITLE
Fix stack cookie failure reporting under wasm64

### DIFF
--- a/src/runtime_stack_check.js
+++ b/src/runtime_stack_check.js
@@ -5,6 +5,10 @@
  */
 
 #if STACK_OVERFLOW_CHECK
+
+const stackCookie1 = 0x02135467;
+const stackCookie2 = 0x89BACDFE;
+
 // Initializes the stack cookie. Called at the startup of main and at the startup of each thread in pthreads mode.
 function writeStackCookie() {
   var max = _emscripten_stack_get_end();
@@ -23,12 +27,16 @@ function writeStackCookie() {
   // The stack grow downwards towards _emscripten_stack_get_end.
   // We write cookies to the final two words in the stack and detect if they are
   // ever overwritten.
-  {{{ makeSetValue('max', 0, '0x02135467', 'u32') }}};
-  {{{ makeSetValue('max', 4, '0x89BACDFE', 'u32') }}};
+  {{{ makeSetValue('max', 0, 'stackCookie1', 'u32') }}};
+  {{{ makeSetValue('max', 4, 'stackCookie2', 'u32') }}};
 #if CHECK_NULL_WRITES
   // Also test the global address 0 for integrity.
   {{{ makeSetValue(0, 0, 0x63736d65 /* 'emsc' */, 'u32') }}};
 #endif
+}
+
+function u32ToHexString(num) {
+  return '0x' + (num >>> 0).toString(16).padStart(8, '0');
 }
 
 function checkStackCookie() {
@@ -43,10 +51,10 @@ function checkStackCookie() {
   if (max == 0) {
     max += 4;
   }
-  var cookie1 = {{{ makeGetValue('max', 0, 'u32') }}};
-  var cookie2 = {{{ makeGetValue('max', 4, 'u32') }}};
-  if (cookie1 != 0x02135467 || cookie2 != 0x89BACDFE) {
-    abort(`Stack overflow! Stack cookie has been overwritten at ${ptrToString(max)}, expected hex dwords 0x89BACDFE and 0x2135467, but received ${ptrToString(cookie2)} ${ptrToString(cookie1)}`);
+  var val1 = {{{ makeGetValue('max', 0, 'u32') }}};
+  var val2 = {{{ makeGetValue('max', 4, 'u32') }}};
+  if (val1 != stackCookie1 || val2 != stackCookie2) {
+    abort(`Stack overflow! Stack cookie has been overwritten at ${ptrToString(max)}, expected hex dwords ${u32ToHexString(stackCookie2)} and ${u32ToHexString(stackCookie1)}, but received ${u32ToHexString(val2)} ${u32ToHexString(val1)}`);
   }
 #if CHECK_NULL_WRITES
   // Also test the global address 0 for integrity.
@@ -55,4 +63,5 @@ function checkStackCookie() {
   }
 #endif
 }
+
 #endif

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 23586,
-  "a.out.js.gz": 8615,
+  "a.out.js": 23675,
+  "a.out.js.gz": 8611,
   "a.out.nodebug.wasm": 15115,
   "a.out.nodebug.wasm.gz": 7464,
-  "total": 38701,
-  "total_gz": 16079,
+  "total": 38790,
+  "total_gz": 16075,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -294,6 +294,9 @@ var isFileURI = (filename) => filename.startsWith('file://');
 
 // include: runtime_common.js
 // include: runtime_stack_check.js
+const stackCookie1 = 0x02135467;
+const stackCookie2 = 0x89BACDFE;
+
 // Initializes the stack cookie. Called at the startup of main and at the startup of each thread in pthreads mode.
 function writeStackCookie() {
   var max = _emscripten_stack_get_end();
@@ -307,10 +310,14 @@ function writeStackCookie() {
   // The stack grow downwards towards _emscripten_stack_get_end.
   // We write cookies to the final two words in the stack and detect if they are
   // ever overwritten.
-  HEAPU32[((max)>>2)] = 0x02135467;
-  HEAPU32[(((max)+(4))>>2)] = 0x89BACDFE;
+  HEAPU32[((max)>>2)] = stackCookie1;
+  HEAPU32[(((max)+(4))>>2)] = stackCookie2;
   // Also test the global address 0 for integrity.
   HEAPU32[((0)>>2)] = 1668509029;
+}
+
+function u32ToHexString(num) {
+  return '0x' + (num >>> 0).toString(16).padStart(8, '0');
 }
 
 function checkStackCookie() {
@@ -320,16 +327,17 @@ function checkStackCookie() {
   if (max == 0) {
     max += 4;
   }
-  var cookie1 = HEAPU32[((max)>>2)];
-  var cookie2 = HEAPU32[(((max)+(4))>>2)];
-  if (cookie1 != 0x02135467 || cookie2 != 0x89BACDFE) {
-    abort(`Stack overflow! Stack cookie has been overwritten at ${ptrToString(max)}, expected hex dwords 0x89BACDFE and 0x2135467, but received ${ptrToString(cookie2)} ${ptrToString(cookie1)}`);
+  var val1 = HEAPU32[((max)>>2)];
+  var val2 = HEAPU32[(((max)+(4))>>2)];
+  if (val1 != stackCookie1 || val2 != stackCookie2) {
+    abort(`Stack overflow! Stack cookie has been overwritten at ${ptrToString(max)}, expected hex dwords ${u32ToHexString(stackCookie2)} and ${u32ToHexString(stackCookie1)}, but received ${u32ToHexString(val2)} ${u32ToHexString(val1)}`);
   }
   // Also test the global address 0 for integrity.
   if (HEAPU32[((0)>>2)] != 0x63736d65 /* 'emsc' */) {
     abort('Runtime error: The application has corrupted its heap memory area (address zero)!');
   }
 }
+
 // end include: runtime_stack_check.js
 // include: runtime_exceptions.js
 // Base Emscripten EH error class

--- a/test/codesize/test_codesize_minimal_O0.json
+++ b/test/codesize/test_codesize_minimal_O0.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 18790,
-  "a.out.js.gz": 6786,
+  "a.out.js": 18853,
+  "a.out.js.gz": 6778,
   "a.out.nodebug.wasm": 1015,
   "a.out.nodebug.wasm.gz": 602,
-  "total": 19805,
-  "total_gz": 7388,
+  "total": 19868,
+  "total_gz": 7380,
   "sent": [],
   "imports": [],
   "exports": [

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
-  "hello_world.js": 56153,
-  "hello_world.js.gz": 17678,
+  "hello_world.js": 56353,
+  "hello_world.js.gz": 17728,
   "hello_world.wasm": 15115,
   "hello_world.wasm.gz": 7464,
   "no_asserts.js": 25585,
   "no_asserts.js.gz": 8688,
   "no_asserts.wasm": 12229,
   "no_asserts.wasm.gz": 6004,
-  "strict.js": 53255,
-  "strict.js.gz": 16649,
+  "strict.js": 53455,
+  "strict.js.gz": 16702,
   "strict.wasm": 15115,
   "strict.wasm.gz": 7461,
-  "total": 177452,
-  "total_gz": 63944
+  "total": 177852,
+  "total_gz": 64047
 }

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14102,6 +14102,27 @@ int main() {
                  cflags=['-O1', '--profiling-funcs'],
                  assert_returncode=NON_ZERO)
 
+  @also_with_wasm64
+  @parameterized({
+    '': ([],),
+    'no_stack_first': (['-Wl,--no-stack-first'],),
+  })
+  def test_stack_cookie_curruption(self, args):
+    create_file('test.c', r'''
+      #include <emscripten/stack.h>
+      #include <stdint.h>
+
+      int main() {
+        uint32_t *stack_end = (uint32_t *)emscripten_stack_get_end();
+        if (stack_end == 0) stack_end++;
+        stack_end[0] = 0xfffffff0;
+        stack_end[1] = 0xaaaaaaa0;
+        return 0;
+      }
+    ''')
+    expected = 'Stack overflow! Stack cookie has been overwritten at 0x[a-f0-9]*, expected hex dwords 0x89bacdfe and 0x02135467, but received 0xaaaaaaa0 0xfffffff0'
+    self.do_runf('test.c', expected, regex=True, cflags=args + ['-sSTACK_OVERFLOW_CHECK=1'], assert_returncode=NON_ZERO)
+
   @crossplatform
   def test_reproduce(self):
     ensure_dir('tmp')


### PR DESCRIPTION
In particular on wasm64 were printing `0x00000000AAAAAAAA` instead of `0xAAAAAAAA`.

IIUC we didn't have any testing for stack cookie corruption errors until now.