### PR TITLE
Disable test_pthread_print_override_modularize under deno. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6329,9 +6329,10 @@ int main(void) {
   @crossplatform
   @requires_pthreads
   @flaky('https://github.com/emscripten-core/emscripten/issues/19683')
-  # The flakiness of this test is very high on macOS so just disable it
-  # completely.
+  # The flakiness of this test is very high on macOS, and deno so just disable it
+  # completely in these cases.
   @no_mac('https://github.com/emscripten-core/emscripten/issues/19683')
+  @no_deno('https://github.com/emscripten-core/emscripten/issues/19683')
   def test_pthread_print_override_modularize(self):
     self.set_setting('EXPORT_NAME', 'Test')
     self.set_setting('PROXY_TO_PTHREAD')


### PR DESCRIPTION
At least until we can fix the race condition.