### PR TITLE
[fetch] Fix POST request body handling in pthread builds

### DIFF
--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -568,7 +568,7 @@ function fetchXHR(fetch, onsuccess, onerror, onprogress, onreadystatechange) {
   dbg(`fetch: id=${id}`);
 #endif
   {{{ makeSetValue('fetch', C_STRUCTS.emscripten_fetch_t.id, 'id', 'u32') }}};
-  var data = (dataPtr && dataLength) ? HEAPU8.subarray(dataPtr, dataPtr + dataLength) : null;
+  var data = (dataPtr && dataLength) ? {{{ getHeapViewOrCopy('HEAPU8', 'dataPtr', 'dataPtr + dataLength') }}} : null;
   // TODO: Support specifying custom headers to the request.
 
   // Share the code to save the response, as we need to do so both on success
@@ -841,10 +841,10 @@ function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
   var fetchAttrPersistFile = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_PERSIST_FILE }}});
   var fetchAttrNoDownload = !!(fetchAttributes & {{{ cDefs.EMSCRIPTEN_FETCH_NO_DOWNLOAD }}});
   if (requestMethod === 'EM_IDB_STORE') {
-    // TODO(?): Here we perform a clone of the data, because storing shared typed arrays to IndexedDB does not seem to be allowed.
     var ptr = {{{ makeGetValue('fetch_attr', C_STRUCTS.emscripten_fetch_attr_t.requestData, '*') }}};
     var size = {{{ makeGetValue('fetch_attr', C_STRUCTS.emscripten_fetch_attr_t.requestDataSize, '*') }}};
-    fetchCacheData(Fetch.dbInstance, fetch, HEAPU8.subarray(ptr, ptr + size), reportSuccess, reportError);
+    // Storing shared or resizable typed arrays to IndexedDB is not allowed, so use getHeapViewOrCopy.
+    fetchCacheData(Fetch.dbInstance, fetch, {{{ getHeapViewOrCopy('HEAPU8', 'ptr', 'ptr + size') }}}, reportSuccess, reportError);
   } else if (requestMethod === 'EM_IDB_DELETE') {
     fetchDeleteCachedData(Fetch.dbInstance, fetch, reportSuccess, reportError);
   } else if (!fetchAttrReplace) {

--- a/src/lib/libstrings.js
+++ b/src/lib/libstrings.js
@@ -63,11 +63,11 @@ addToLibrary({
     var endPtr = findStringEnd(heapOrArray, idx, maxBytesToRead, ignoreNul);
 
 #if TEXTDECODER == 2
-    return UTF8Decoder.decode(heapOrArray.buffer ? {{{ getUnsharedTextDecoderView('heapOrArray', 'idx', 'endPtr') }}} : new Uint8Array(heapOrArray.slice(idx, endPtr)));
+    return UTF8Decoder.decode(heapOrArray.buffer ? {{{ getHeapViewOrCopy('heapOrArray', 'idx', 'endPtr') }}} : new Uint8Array(heapOrArray.slice(idx, endPtr)));
 #else // TEXTDECODER == 2
     // When using conditional TextDecoder, skip it for short strings as the overhead of the native call is not worth it.
     if (endPtr - idx > 16 && heapOrArray.buffer && UTF8Decoder) {
-      return UTF8Decoder.decode({{{ getUnsharedTextDecoderView('heapOrArray', 'idx', 'endPtr') }}});
+      return UTF8Decoder.decode({{{ getHeapViewOrCopy('heapOrArray', 'idx', 'endPtr') }}});
     }
     var str = '';
     while (idx < endPtr) {
@@ -129,7 +129,7 @@ addToLibrary({
 #if TEXTDECODER == 2
     if (!ptr) return '';
     var end = findStringEnd(HEAPU8, ptr, maxBytesToRead, ignoreNul);
-    return UTF8Decoder.decode({{{ getUnsharedTextDecoderView('HEAPU8', 'ptr', 'end') }}});
+    return UTF8Decoder.decode({{{ getHeapViewOrCopy('HEAPU8', 'ptr', 'end') }}});
 #else
     return ptr ? UTF8ArrayToString(HEAPU8, ptr, maxBytesToRead, ignoreNul) : '';
 #endif
@@ -330,7 +330,7 @@ addToLibrary({
     // When using conditional TextDecoder, skip it for short strings as the overhead of the native call is not worth it.
     if (endIdx - idx > 16 && UTF16Decoder)
 #endif // TEXTDECODER != 2
-      return UTF16Decoder.decode({{{ getUnsharedTextDecoderView('HEAPU16', 'idx', 'endIdx') }}});
+      return UTF16Decoder.decode({{{ getHeapViewOrCopy('HEAPU16', 'idx', 'endIdx') }}});
 
 #if TEXTDECODER != 2
     // Fallback: decode without UTF16Decoder

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -1081,12 +1081,13 @@ function runtimeKeepalivePop() {
   return 'runtimeKeepalivePop();';
 }
 
-// Some web functions like TextDecoder.decode() do not work with a view of a
-// SharedArrayBuffer (see https://github.com/whatwg/encoding/issues/172) or of
-// a resizable ArrayBuffer (see
-// https://github.com/emscripten-core/emscripten/issues/27241).
-// To avoid that, this function allows obtaining a copy in those cases.
-function getUnsharedTextDecoderView(heap, start, end) {
+// Some web APIs like TextDecoder.decode() and XMLHttpRequest.send() do not
+// work with a view of a SharedArrayBuffer (see
+// https://github.com/whatwg/encoding/issues/172) or of a resizable ArrayBuffer
+// (see https://github.com/emscripten-core/emscripten/issues/27241).
+// To avoid that, this function allows obtaining a copy in those cases, or a view
+// otherwise.
+function getHeapViewOrCopy(heap, start, end) {
   const copy = `${heap}.slice(${start}, ${end})`;
   const view = `${heap}.subarray(${start}, ${end})`;
 
@@ -1259,7 +1260,7 @@ addToCompileTimeContext({
   getHeapForType,
   getHeapOffset,
   getNativeTypeSize,
-  getUnsharedTextDecoderView,
+  getHeapViewOrCopy,
   hasExportedSymbol,
   isSymbolNeeded,
   makeDynCall,

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4524,8 +4524,12 @@ Module["preRun"] = () => {
     self.btest_exit('fetch/test_fetch_idb_delete.cpp', cflags=['-pthread', '-sFETCH_DEBUG', '-sFETCH', '-sWASM=0', '-sPROXY_TO_PTHREAD'])
 
   @also_with_fetch_streaming
-  def test_fetch_post(self):
-    self.btest_exit('fetch/test_fetch_post.c', cflags=['-sFETCH'])
+  @parameterized({
+    '': ([],),
+    'pthread': (['-pthread', '-sPROXY_TO_PTHREAD'],),
+  })
+  def test_fetch_post(self, args):
+    self.btest_exit('fetch/test_fetch_post.c', cflags=['-sFETCH'] + args)
 
   @also_with_fetch_streaming
   def test_fetch_progress(self):

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4524,12 +4524,9 @@ Module["preRun"] = () => {
     self.btest_exit('fetch/test_fetch_idb_delete.cpp', cflags=['-pthread', '-sFETCH_DEBUG', '-sFETCH', '-sWASM=0', '-sPROXY_TO_PTHREAD'])
 
   @also_with_fetch_streaming
-  @parameterized({
-    '': ([],),
-    'pthread': (['-pthread', '-sPROXY_TO_PTHREAD'],),
-  })
-  def test_fetch_post(self, args):
-    self.btest_exit('fetch/test_fetch_post.c', cflags=['-sFETCH'] + args)
+  @also_with_proxy_to_pthread
+  def test_fetch_post(self):
+    self.btest_exit('fetch/test_fetch_post.c', cflags=['-sFETCH'])
 
   @also_with_fetch_streaming
   def test_fetch_progress(self):


### PR DESCRIPTION
In #27129, `HEAPU8.slice` was replaced with `HEAPU8.subarray` when passing request data to `XMLHttpRequest.send()` in `Fetch.js`. However, in `-pthread` builds (`SHARED_MEMORY`), `HEAPU8.buffer` is a `SharedArrayBuffer`, and browsers reject `SharedArrayBuffer`-backed views passed to `XMLHttpRequest.send()`.

Rename `getUnsharedTextDecoderView` to `getHeapViewOrCopy` and use it in `Fetch.js` when passing `requestData` to `xhr.send(data)` and when storing to IndexedDB (`EM_IDB_STORE`).

Parameterize `test_fetch_post` in `test_browser.py` so it also run in `-sPROXY_TO_PTHREAD` mode.

Fixes: #27301