### PR TITLE
Remove "check codesize on target branch" CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: true
-          fetch-depth: 0 # We want access to other branches, specifically `main`
       - name: Read emsdk version
         id: emsdk_version
         run: echo "version=$(cat test/emsdk_version.txt)" >> $GITHUB_OUTPUT
@@ -55,47 +54,10 @@ jobs:
           which python3
           python3 --version
           python3 -m pip install -r requirements-dev.txt
-      - name: Check test expectations on target branch
-        # Skip this step for rebaseline PRs, since the target branch is expected
-        # to be out of date in this case.
-        if: "!contains(github.event.pull_request.title, 'Automatic rebaseline of codesize expectations')"
-        env:
-          BASE_REF: ${{ github.base_ref }}
+      - name: Check codesize expectations
         run: |
-          echo "Checking out $BASE_REF"
-          git checkout "$BASE_REF"
-          git rev-parse HEAD
-          # Uncomment this like to pull the rebaseline_tests.py from the
-          # current branch:
-          # git checkout - ./tools/maint/rebaseline_tests.py
           ./bootstrap.py
           if ! ./tools/maint/rebaseline_tests.py --check-only; then
-            echo ""
-            echo "Test expectations are out-of-date on the target branch."
-            echo "Please run the 'Rebaseline Tests' github action on the target"
-            echo "branch (normally 'main') before proceeding.  You can do this"
-            echo "from the web UI or from the command line:"
-            echo ""
-            echo "  gh workflow run rebaseline-tests.yml"
-            echo ""
-            echo "You can also run the following command locally and upload"
-            echo "your own PR:"
-            echo ""
-            echo "  ./tools/maint/rebaseline_tests.py --new-branch'"
-            exit 1
-          fi
-      - name: Check test expectations on PR branch
-        env:
-          GITHUB_REF: ${{ github.ref }}
-          GITHUB_SHA: ${{ github.sha }}
-        run: |
-          echo "Checking out $GITHUB_REF ($GITHUB_SHA)"
-          # For some reason we cannot pass $GITHUB_REF direclty to git
-          # since it doesn't recognise it.
-          git checkout "$GITHUB_SHA"
-          git rev-parse HEAD
-          ./bootstrap.py
-          if ! ./tools/maint/rebaseline_tests.py --check-only --clear-cache; then
             echo "Test expectations are out-of-date on the PR branch."
             echo ""
             echo "You can run './tools/maint/rebaseline_tests.py' to"


### PR DESCRIPTION
This simplifies the Codesize Checks CI job.  We used to run the checks both on main *and* on the PR branch.

Now that we have a pinned version of emsdk the risk of main not being up-to-date is very low so there is no need to check this for each PR. Furthermore its currently broken because we really need to install the correct version of emsdk *after* sync'ing main (i.e. to make this correct we would need to run the emsdk install part twice too).

I think its faster and better to just remove the ""check codesize on target branch" part.