### PR TITLE
[docs] Add onMakeDirectory and onMakeSymlink to the list of tracking delegates

### DIFF
--- a/site/source/docs/api_reference/Filesystem-API.rst
+++ b/site/source/docs/api_reference/Filesystem-API.rst
@@ -883,6 +883,8 @@ File system API
   - ``onReadFile`` — Indicates file is being read and number of bytes read.
   - ``onSeekFile`` — Indicates seeking within a file, position, and whence.
   - ``onCloseFile`` — Indicates a file being closed.
+  - ``onMakeDirectory`` — Indicates a directory being created.
+  - ``onMakeSymlink`` — Indicates a symlink (symbolic link) being created.
 
   :callback name: The name of the callback that indicates the filesystem event
 


### PR DESCRIPTION
This is to match the example code below that list, which contains onMakeDirectory and onMakeSymlink, while they are absent from the list above.

Reading only the list and not the example code below it, I was confused about how to track directory creation, and this pull request should resolve that confusion for others.