### PR TITLE
Try gen2 resource classes for Circle executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,11 @@ executors:
   linux-node:
     docker:
       - image: cimg/node:24.13.1
+    resource_class: medium.gen2
   ubuntu-lts:
     docker:
       - image: emscripten/emscripten-ci:jammy.v2
+    resource_class: medium.gen2
     environment:
       LANG: "C.UTF-8"
       EMCC_CORES: "4"
@@ -494,7 +496,7 @@ jobs:
     # in about 1/2 the time, so it is not cost-effective (overall it is 2x the
     # cost for the same work), but given this blocks almost all the other jobs
     # we want it to finish asap
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     environment:
       EMCC_CORES: 16
       EMCC_USE_NINJA: 1


### PR DESCRIPTION
These cost 20% more but are supposed to be up to 40% faster