### PR TITLE
Support multi-value returns in TS definitions

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15146,6 +15146,26 @@ addToLibrary({
     self.run_process(['cargo', 'install', 'wasm-bindgen-cli'])
     self.do_runf('empty.c', '42', cflags=[lib, '-sWASM_BINDGEN', '--post-js=post.js', '-lexports.js'])
 
+  @requires_rust
+  @requires_dev_dependency('typescript')
+  def test_wasm_bindgen_tsd_multi_return(self):
+    copytree(test_file('rust/bindgen_integration'), '.')
+    create_file('src/lib.rs', '''
+      use wasm_bindgen::prelude::*;
+      #[wasm_bindgen]
+      pub fn multi_value_return() -> Result<i32, JsValue> {
+          Ok(42)
+      }
+    ''')
+    self.run_process(['cargo', 'add', 'wasm-bindgen'])
+    self.run_process(['cargo', 'build'])
+    lib = 'target/wasm32-unknown-emscripten/debug/libbindgen_integration.a'
+    create_file('empty.c', '')
+    self.run_process(['cargo', 'install', 'wasm-bindgen-cli'])
+    self.run_process([EMCC, 'empty.c', '--emit-tsd', 'test_multi.d.ts', '-sWASM_BINDGEN', '-o', 'test_multi.js'] + [lib] + self.get_cflags())
+    actual = read_file('test_multi.d.ts')
+    self.assertContained("multi_value_return(): [number, number, number];", actual)
+
   def test_relative_em_cache(self):
     with env_modify({'EM_CACHE': 'foo'}):
       self.assert_fail([EMCC, '-c', test_file('hello_world.c')], 'emcc: error: environment variable EM_CACHE must be an absolute path: foo')

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -691,11 +691,13 @@ def create_tsd(metadata, embind_tsd, bindgen_tsd):
     for index, type in enumerate(functype.params):
       arguments.append(f"_{index}: {type_to_ts_type(type)}")
     out += f'  {mangled}({", ".join(arguments)}): '
-    assert len(functype.returns) <= 1, 'One return type only supported'
-    if functype.returns:
+    if not functype.returns:
+      ret_ts_type = 'void'
+    elif len(functype.returns) == 1:
       ret_ts_type = type_to_ts_type(functype.returns[0])
     else:
-      ret_ts_type = 'void'
+      tuple_types = [type_to_ts_type(t) for t in functype.returns]
+      ret_ts_type = f'[{", ".join(tuple_types)}]'
     if settings.ASYNCIFY == 2 and any(fnmatch.fnmatch(name, pat) for pat in settings.ASYNCIFY_EXPORTS):
       ret_ts_type = f'Promise<{ret_ts_type}>'
     out += f'{ret_ts_type};\n'


### PR DESCRIPTION
`wasm-bindgen` generates WebAssembly functions with multiple return values, so we need to remove the assertion that enforces a single return type in tools/emscripten.py. This PR removes the assertion and correctly maps multi-value returns to TypeScript tuples.