### PR TITLE
Remove support for ancient gamepad DOM API

### DIFF
--- a/src/lib/libglfw.js
+++ b/src/lib/libglfw.js
@@ -733,7 +733,7 @@ var LibraryGLFW = {
     refreshJoysticks: () => {
       // Produce a new Gamepad API sample if we are ticking a new game frame, or if not using emscripten_set_main_loop() at all to drive animation.
       if (MainLoop.currentFrameNumber !== GLFW.lastGamepadStateFrame || !MainLoop.currentFrameNumber) {
-        GLFW.lastGamepadState = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads || []);
+        GLFW.lastGamepadState = navigator.getGamepads?.() ?? [];
         GLFW.lastGamepadStateFrame = MainLoop.currentFrameNumber;
 
         for (var joy = 0; joy < GLFW.lastGamepadState.length; ++joy) {

--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -1898,20 +1898,8 @@ var LibraryHTML5 = {
       {{{ makeSetValue('eventStruct+i*8', C_STRUCTS.EmscriptenGamepadEvent.axis, 'e.axes[i]', 'double') }}};
     }
     for (var i = 0; i < e.buttons.length; ++i) {
-      if (typeof e.buttons[i] == 'object') {
-        {{{ makeSetValue('eventStruct+i*8', C_STRUCTS.EmscriptenGamepadEvent.analogButton, 'e.buttons[i].value', 'double') }}};
-      } else {
-        {{{ makeSetValue('eventStruct+i*8', C_STRUCTS.EmscriptenGamepadEvent.analogButton, 'e.buttons[i]', 'double') }}};
-      }
-    }
-    for (var i = 0; i < e.buttons.length; ++i) {
-      if (typeof e.buttons[i] == 'object') {
-        {{{ makeSetValue('eventStruct+i', C_STRUCTS.EmscriptenGamepadEvent.digitalButton, 'e.buttons[i].pressed', 'i8') }}};
-      } else {
-        // Assigning a boolean to HEAP32, that's ok, but Closure would like to warn about it:
-        /** @suppress {checkTypes} */
-        {{{ makeSetValue('eventStruct+i', C_STRUCTS.EmscriptenGamepadEvent.digitalButton, 'e.buttons[i] == 1', 'i8') }}};
-      }
+      {{{ makeSetValue('eventStruct+i', C_STRUCTS.EmscriptenGamepadEvent.digitalButton, 'e.buttons[i].pressed', 'i8') }}};
+      {{{ makeSetValue('eventStruct+i*8', C_STRUCTS.EmscriptenGamepadEvent.analogButton, 'e.buttons[i].value', 'double') }}};
     }
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenGamepadEvent.connected, 'e.connected', 'i8') }}};
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenGamepadEvent.index, 'e.index', 'i32') }}};

--- a/src/lib/libsdl.js
+++ b/src/lib/libsdl.js
@@ -1268,7 +1268,7 @@ var LibrarySDL = {
       // Standardize button state.
       var buttons = [];
       for (var button of state.buttons) {
-        buttons.push(SDL.getJoystickButtonState(button));
+        buttons.push(button.pressed);
       }
 
       SDL.lastJoystickState[joystick] = {
@@ -1278,19 +1278,6 @@ var LibrarySDL = {
         index: state.index,
         id: state.id
       };
-    },
-    // Retrieves the button state of the given gamepad button.
-    // Abstracts away implementation differences.
-    // Returns 'true' if pressed, 'false' otherwise.
-    getJoystickButtonState(button) {
-      if (typeof button == 'object') {
-        // Current gamepad API editor's draft (Firefox Nightly)
-        // https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#idl-def-GamepadButton
-        return button['pressed'];
-      }
-      // Current gamepad API working draft (Firefox / Chrome Stable)
-      // http://www.w3.org/TR/2012/WD-gamepad-20120529/#gamepad-interface
-      return button > 0;
     },
     // Queries for and inserts controller events into the SDL queue.
     queryJoysticks() {
@@ -1307,7 +1294,7 @@ var LibrarySDL = {
         if (typeof state.timestamp != 'number' || state.timestamp != prevState.timestamp || !state.timestamp) {
           var i;
           for (i = 0; i < state.buttons.length; i++) {
-            var buttonState = SDL.getJoystickButtonState(state.buttons[i]);
+            var buttonState = state.buttons[i].pressed;
             // NOTE: The previous state already has a boolean representation of
             //       its button, so no need to standardize its button state here.
             if (buttonState !== prevState.buttons[i]) {
@@ -1347,10 +1334,7 @@ var LibrarySDL = {
     },
 
     getGamepads() {
-      if (!navigator.getGamepads) {
-        return [];
-      }
-      return navigator.getGamepads();
+      return navigator.getGamepads?.() ?? [];
     },
 
     // Helper function: Returns the gamepad if available, or null if not.
@@ -3554,7 +3538,7 @@ var LibrarySDL = {
   SDL_JoystickGetButton: (joystick, button) => {
     var gamepad = SDL.getGamepad(joystick - 1);
     if (gamepad?.buttons.length > button) {
-      return SDL.getJoystickButtonState(gamepad.buttons[button]) ? 1 : 0;
+      return gamepad.buttons[button].pressed ? 1 : 0;
     }
     return 0;
   },

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 269157,
+  "a.out.js": 268975,
   "a.out.nodebug.wasm": 588047,
-  "total": 857204,
+  "total": 857022,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1049,41 +1049,9 @@ window.close = () => {
   def test_glut_resize(self):
     self.btest_exit('test_glut_resize.c')
 
-  def test_sdl_joystick_1(self):
-    # Generates events corresponding to the Working Draft of the HTML5 Gamepad API.
-    # http://www.w3.org/TR/2012/WD-gamepad-20120529/#gamepad-interface
-    create_file('pre.js', '''
-      var gamepads = [];
-      // Spoof this function.
-      navigator['getGamepads'] = () => gamepads;
-      window['addNewGamepad'] = (id, numAxes, numButtons) => {
-        var index = gamepads.length;
-        gamepads.push({
-          axes: new Array(numAxes),
-          buttons: new Array(numButtons),
-          id: id,
-          index: index
-        });
-        var i;
-        for (i = 0; i < numAxes; i++) gamepads[index].axes[i] = 0;
-        for (i = 0; i < numButtons; i++) gamepads[index].buttons[i] = 0;
-      };
-      window['simulateGamepadButtonDown'] = (index, button) => {
-        gamepads[index].buttons[button] = 1;
-      };
-      window['simulateGamepadButtonUp'] = (index, button) => {
-        gamepads[index].buttons[button] = 0;
-      };
-      window['simulateAxisMotion'] = (index, axis, value) => {
-        gamepads[index].axes[axis] = value;
-      };
-    ''')
-
-    self.btest_exit('test_sdl_joystick.c', cflags=['-O2', '--minify=0', '-o', 'page.html', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
-
-  def test_sdl_joystick_2(self):
-    # Generates events corresponding to the Editor's Draft of the HTML5 Gamepad API.
-    # https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#idl-def-Gamepad
+  def test_sdl_joystick(self):
+    # Generates events corresponding to the HTML5 Gamepad API.
+    # https://www.w3.org/TR/gamepad/#idl-def-Gamepad
     create_file('pre.js', '''
       var gamepads = [];
       // Spoof this function.
@@ -1119,8 +1087,8 @@ window.close = () => {
 
   @requires_graphics_hardware
   def test_glfw_joystick(self):
-    # Generates events corresponding to the Editor's Draft of the HTML5 Gamepad API.
-    # https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#idl-def-Gamepad
+    # Generates events corresponding to the HTML5 Gamepad API.
+    # https://www.w3.org/TR/gamepad/#idl-def-Gamepad
     create_file('pre.js', '''
       var gamepads = [];
       // Spoof this function.


### PR DESCRIPTION
We already used the new API unconditionally in libglfw.js.

See https://www.w3.org/TR/gamepad/#dom-gamepadbutton

The last browsers where you had to handle raw numbers in  Gamepad.buttons  or use  webkitGetGamepads  were Chrome 34 and  Firefox 28.    Those versions were replaced in April/May 2014 making the old API ~12 years old.  Every desktop and mobile browser released over the past decade unconditionally provides GamepadButton objects.
