### PR TITLE
Remove support for old vendor-prefixed screen orientation API

### DIFF
--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -896,10 +896,7 @@ var LibraryHTML5 = {
   _emscripten_get_last_devicemotion_event__deps: ['$JSEvents'],
   _emscripten_get_last_devicemotion_event: () => JSEvents.deviceMotionEvent,
 
-  $screenOrientation: () => {
-    if (!window.screen) return undefined;
-    return screen.orientation || screen['mozOrientation'] || screen['webkitOrientation'];
-  },
+  $screenOrientation: () => window.screen?.orientation,
 
   $fillOrientationChangeEventData__deps: ['$screenOrientation'],
   $fillOrientationChangeEventData: (eventStruct) => {
@@ -911,7 +908,7 @@ var LibraryHTML5 = {
     var orientationIndex = {{{ cDefs.EMSCRIPTEN_ORIENTATION_UNSUPPORTED }}};
     var orientationAngle = 0;
     var screenOrientObj  = screenOrientation();
-    if (typeof screenOrientObj === 'object') {
+    if (screenOrientObj) {
       orientationIndex = orientationsType1.indexOf(screenOrientObj.type);
       if (orientationIndex < 0) {
         orientationIndex = orientationsType2.indexOf(screenOrientObj.type);
@@ -974,8 +971,9 @@ var LibraryHTML5 = {
   emscripten_get_orientation_status__proxy: 'sync',
   emscripten_get_orientation_status__deps: ['$fillOrientationChangeEventData', '$screenOrientation'],
   emscripten_get_orientation_status: (orientationChangeEvent) => {
-    // screenOrientation() resolving standard, window.orientation being the deprecated mobile-only
-    if (!screenOrientation() && typeof orientation == 'undefined') return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
+    if (!screenOrientation()) {
+      return {{{ cDefs.EMSCRIPTEN_RESULT_NOT_SUPPORTED }}};
+    }
     fillOrientationChangeEventData(orientationChangeEvent);
     return {{{ cDefs.EMSCRIPTEN_RESULT_SUCCESS }}};
   },

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268945,
+  "a.out.js": 268837,
   "a.out.nodebug.wasm": 588047,
-  "total": 856992,
+  "total": 856884,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation