### PR TITLE
[sdl] Remove obsolete mozAudioChannelType workaround

### DIFF
--- a/src/lib/libsdl.js
+++ b/src/lib/libsdl.js
@@ -2802,7 +2802,6 @@ var LibrarySDL = {
       var url = URL.createObjectURL(blob);
       audio = new Audio();
       audio.src = url;
-      audio.mozAudioChannelType = 'content'; // bugzilla 910340
     }
 
     var id = SDL.audios.length;
@@ -2839,7 +2838,6 @@ var LibrarySDL = {
       webAudio = { decodedBuffer: buffer };
     } else {
       audio = new Audio();
-      audio.mozAudioChannelType = 'content'; // bugzilla 910340
       // Record the number of channels and frequency for later usage
       audio.numChannels = SDL.mixerNumChannels;
       audio.frequency = SDL.mixerFrequency;

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268975,
+  "a.out.js": 268945,
   "a.out.nodebug.wasm": 588047,
-  "total": 857022,
+  "total": 856992,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
Remove references to `mozAudioChannelType` from `Mix_LoadWAV` and `Mix_QuickLoad_RAW` in `libsdl.js`.

This workaround (`audio.mozAudioChannelType = 'content'`) was added in 2014 (commit f0d152957d) for Boot to Gecko (B2G) / Firefox OS games so that audio on the `content` channel would behave correctly when the screen turned off or the app went to the background.

This is safe to remove because:
1. Firefox OS / B2G was discontinued (~2016) and moved to the Firefox OS Graveyard.
2. The `AudioChannel` API and `mozAudioChannelType` property were removed from Gecko (`mozilla-central`). Setting `mozAudioChannelType` has no effect on Firefox desktop or any modern browser.
3. Bugzilla bug #910340 (`When screen is switched off, visibilitychange is not firing when audio is playing`) was closed in 2014 as `RESOLVED WONTFIX` since continuing audio playback when the screen turns off is expected mobile behavior.

See: https://bugzilla.mozilla.org/show_bug.cgi?id=910340