### PR TITLE
Remove workarounds for old DOM APIs prior ot event.movementX/Y

### DIFF
--- a/src/lib/libbrowser.js
+++ b/src/lib/libbrowser.js
@@ -330,21 +330,6 @@ var LibraryBrowser = {
       window.getUserMedia(func);
     },
 
-
-    getMovementX(event) {
-      return event['movementX'] ||
-             event['mozMovementX'] ||
-             event['webkitMovementX'] ||
-             0;
-    },
-
-    getMovementY(event) {
-      return event['movementY'] ||
-             event['mozMovementY'] ||
-             event['webkitMovementY'] ||
-             0;
-    },
-
     // Browsers specify wheel direction according to the page CSS pixel Y direction:
     // Scrolling mouse wheel down (==towards user/away from screen) on Windows/Linux (and macOS without 'natural scroll' enabled)
     // is the positive wheel direction. Scrolling mouse wheel up (towards the screen) is the negative wheel direction.
@@ -430,14 +415,8 @@ var LibraryBrowser = {
       if (Browser.pointerLock) {
         // When the pointer is locked, calculate the coordinates
         // based on the movement of the mouse.
-        // Workaround for Firefox bug 764498
-        if (event.type != 'mousemove' &&
-            ('mozMovementX' in event)) {
-          Browser.mouseMovementX = Browser.mouseMovementY = 0;
-        } else {
-          Browser.mouseMovementX = Browser.getMovementX(event);
-          Browser.mouseMovementY = Browser.getMovementY(event);
-        }
+        Browser.mouseMovementX = event.movementX;
+        Browser.mouseMovementY = event.movementY;
 
         // add the mouse delta to the current absolute mouse position
         Browser.mouseX += Browser.mouseMovementX;

--- a/src/lib/libhtml5.js
+++ b/src/lib/libhtml5.js
@@ -481,9 +481,9 @@ var LibraryHTML5 = {
     HEAP16[idx*2 + {{{ C_STRUCTS.EmscriptenMouseEvent.button / 2 }}}] = e.button;
     HEAP16[idx*2 + {{{ C_STRUCTS.EmscriptenMouseEvent.buttons / 2 }}}] = e.buttons;
 
-    HEAP32[idx + {{{ C_STRUCTS.EmscriptenMouseEvent.movementX / 4 }}}] = e["movementX"];
+    HEAP32[idx + {{{ C_STRUCTS.EmscriptenMouseEvent.movementX / 4 }}}] = e.movementX;
 
-    HEAP32[idx + {{{ C_STRUCTS.EmscriptenMouseEvent.movementY / 4 }}}] = e["movementY"];
+    HEAP32[idx + {{{ C_STRUCTS.EmscriptenMouseEvent.movementY / 4 }}}] = e.movementY;
 
 #if !DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
     if (Module['canvas']) {

--- a/src/lib/libsdl.js
+++ b/src/lib/libsdl.js
@@ -670,20 +670,6 @@ var LibrarySDL = {
               }
             });
           }
-          if (Browser.pointerLock) {
-            // workaround for firefox bug 750111
-            if ('mozMovementX' in event) {
-              event['movementX'] = event['mozMovementX'];
-              event['movementY'] = event['mozMovementY'];
-            }
-            // workaround for Firefox bug 782777
-            if (event['movementX'] == 0 && event['movementY'] == 0) {
-              // ignore a mousemove event if it doesn't contain any movement info
-              // (without pointer lock, we infer movement from pageX/pageY, so this check is unnecessary)
-              event.preventDefault();
-              return;
-            }
-          }
           // fall through
         case 'keydown':
         case 'keyup':

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268837,
+  "a.out.js": 268568,
   "a.out.nodebug.wasm": 588047,
-  "total": 856884,
+  "total": 856615,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
Inline `event.movementX` and `event.movementY` directly into `calculateMouseEvent` in `libbrowser.js`, removing the `getMovementX` and `getMovementY` helper methods from `LibraryBrowser`.

Remove references to `mozMovementX`, `webkitMovementX`, `mozMovementY`, and `webkitMovementY` from `libbrowser.js` and `libsdl.js`. Also update `libhtml5.js` and `libsdl.js` to use standard dot notation (`e.movementX`, `event.movementX`) instead of bracket notation across all mouse event handling.

These prefixed properties and their workarounds (`if ('mozMovementX' in event)`) were added between 2012 and 2013 for early implementations of the W3C Pointer Lock API to address Firefox bugs #750111 and #764498.

This is safe to remove because:
1. `MouseEvent.movementX` and `MouseEvent.movementY` became standard unprefixed properties in Firefox 41 (2015) and Chrome 37 (2014).
2. Emscripten's minimum supported browser versions (`MIN_FIREFOX_VERSION` and `MIN_CHROME_VERSION`) are well beyond when unprefixed `movementX` became universal across all engines.
3. The vendor-prefixed properties (`mozMovementX`, `webkitMovementX`) have been removed from modern browser engines.
4. Bugzilla bugs #750111 (`mozMovementX is transient and becomes zero later`) and #764498 (`movementX and movementY have the wrong value for mousedown and mouseup`) were both resolved in 2012 (Firefox 15).

See: https://bugzilla.mozilla.org/show_bug.cgi?id=750111
See: https://bugzilla.mozilla.org/show_bug.cgi?id=764498
See: https://bugzilla.mozilla.org/show_bug.cgi?id=782777