### PR TITLE
Remove mingw build script for pylauncher. NFC

### DIFF
--- a/tools/pylauncher/build.sh
+++ b/tools/pylauncher/build.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
-cd ${SCRIPT_DIR}
-
-x86_64-w64-mingw32-gcc -Werror -static-libgcc -static-libstdc++ -s -Os -Wl,--no-insert-timestamp pylauncher.c -o pylauncher.exe


### PR DESCRIPTION
This script was already not working since #27048.  Also, IIUC its not possible build the same tiny, dependency-free binary with mingw that we can with cl.exe.