### PR TITLE
Simplify NODERAWSOCKETS test output to 'done'

### DIFF
--- a/test/sockets/test_tcp_backpressure.c
+++ b/test/sockets/test_tcp_backpressure.c
@@ -36,7 +36,7 @@ long long sent_total = 0;
 const long long CAP = 512LL * 1024 * 1024;
 
 void test_success(void) {
-  printf("BACKPRESSURE PASS\n");
+  printf("done\n");
   if (fd >= 0) close(fd);
 #ifdef __EMSCRIPTEN__
   emscripten_cancel_main_loop();

--- a/test/sockets/test_tcp_client_bind.c
+++ b/test/sockets/test_tcp_client_bind.c
@@ -36,7 +36,7 @@ bool connected = false;
 bool ping_sent = false;
 
 void test_success(void) {
-  printf("CLIENT BIND PASS\n");
+  printf("done\n");
   if (client_fd >= 0) close(client_fd);
 #ifdef __EMSCRIPTEN__
   emscripten_cancel_main_loop();

--- a/test/sockets/test_tcp_client_semantics.c
+++ b/test/sockets/test_tcp_client_semantics.c
@@ -39,7 +39,7 @@ bool ping_sent = false;
 bool echoed = false;
 
 void test_success(void) {
-  printf("CLIENT SEMANTICS PASS\n");
+  printf("done\n");
   if (fd >= 0) close(fd);
 #ifdef __EMSCRIPTEN__
   emscripten_cancel_main_loop();

--- a/test/sockets/test_tcp_echo.c
+++ b/test/sockets/test_tcp_echo.c
@@ -36,7 +36,7 @@ bool connected = false;
 bool ping_sent = false;
 
 void test_success(void) {
-  printf("TCP ECHO PASS\n");
+  printf("done\n");
   if (client_fd >= 0) close(client_fd);
 #ifdef __EMSCRIPTEN__
   // The socket is closed and the main loop cancelled, so node's event loop

--- a/test/sockets/test_tcp_ipv6.c
+++ b/test/sockets/test_tcp_ipv6.c
@@ -39,7 +39,7 @@ bool pong_sent = false;
 void set_nonblocking(int fd) { fcntl(fd, F_SETFL, O_NONBLOCK); }
 
 void test_success(void) {
-  printf("TCP IPV6 PASS\n");
+  printf("done\n");
   if (listen_fd >= 0) close(listen_fd);
   if (client_fd >= 0) close(client_fd);
   if (peer_fd >= 0) close(peer_fd);

--- a/test/sockets/test_tcp_peek.c
+++ b/test/sockets/test_tcp_peek.c
@@ -44,7 +44,7 @@ void set_nonblocking(int fd) {
 }
 
 void test_success(void) {
-  printf("TCP PEEK PASS\n");
+  printf("done\n");
   if (listen_fd >= 0) close(listen_fd);
   if (client_fd >= 0) close(client_fd);
   if (peer_fd >= 0) close(peer_fd);

--- a/test/sockets/test_tcp_refused.c
+++ b/test/sockets/test_tcp_refused.c
@@ -29,7 +29,7 @@
 int fd = -1;
 
 void test_success(void) {
-  printf("REFUSED PASS\n");
+  printf("done\n");
   if (fd >= 0) close(fd);
 #ifdef __EMSCRIPTEN__
   emscripten_cancel_main_loop();

--- a/test/sockets/test_tcp_server.c
+++ b/test/sockets/test_tcp_server.c
@@ -42,7 +42,7 @@ void set_nonblocking(int fd) {
 }
 
 void test_success(void) {
-  printf("TCP SERVER PASS\n");
+  printf("done\n");
   if (listen_fd >= 0) close(listen_fd);
   if (client_fd >= 0) close(client_fd);
   if (peer_fd >= 0) close(peer_fd);

--- a/test/sockets/test_udp_connect.c
+++ b/test/sockets/test_udp_connect.c
@@ -40,7 +40,7 @@ void set_nonblocking(int fd) {
 }
 
 void test_success(void) {
-  printf("UDP CONNECT PASS\n");
+  printf("done\n");
   if (server_fd >= 0) close(server_fd);
   if (client_fd >= 0) close(client_fd);
   if (other_fd >= 0) close(other_fd);

--- a/test/sockets/test_udp_echo.c
+++ b/test/sockets/test_udp_echo.c
@@ -40,7 +40,7 @@ void set_nonblocking(int fd) {
 }
 
 void test_success(void) {
-  printf("UDP ECHO PASS\n");
+  printf("done\n");
   if (server_fd >= 0) close(server_fd);
   if (client_fd >= 0) close(client_fd);
 #ifdef __EMSCRIPTEN__

--- a/test/sockets/test_udp_ipv6.c
+++ b/test/sockets/test_udp_ipv6.c
@@ -37,7 +37,7 @@ bool pong_sent = false;
 void set_nonblocking(int fd) { fcntl(fd, F_SETFL, O_NONBLOCK); }
 
 void test_success(void) {
-  printf("UDP IPV6 PASS\n");
+  printf("done\n");
   if (server_fd >= 0) close(server_fd);
   if (client_fd >= 0) close(client_fd);
 #ifdef __EMSCRIPTEN__

--- a/test/sockets/test_udp_sockopts.c
+++ b/test/sockets/test_udp_sockopts.c
@@ -60,6 +60,6 @@ int main(void) {
 
   close(v4);
   close(v6);
-  printf("UDP SOCKOPTS PASS\n");
+  printf("done\n");
   return 0;
 }

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -389,7 +389,7 @@ class sockets(BrowserCore):
   def test_nodejs_sockets_connect_failure(self):
     self.do_runf('sockets/test_sockets_echo_client.c', r'connect failed: (Connection refused|Host is unreachable)', regex=True, cflags=['-DSOCKK=666'], assert_returncode=NON_ZERO)
 
-  def _run_against_echo_server(self, src, expected):
+  def _run_against_echo_server(self, src):
     # Start a loopback TCP echo server on an ephemeral port and run the test
     # against it, passing the port as argv[1].
     server = socketserver.TCPServer(('127.0.0.1', 0), EchoHandler)
@@ -397,7 +397,7 @@ class sockets(BrowserCore):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-      self.do_runf(src, expected, cflags=['-sNODERAWSOCKETS'], args=[str(port)])
+      self.do_runf(src, 'done', cflags=['-sNODERAWSOCKETS'], args=[str(port)])
     finally:
       server.shutdown()
       server.server_close()
@@ -410,7 +410,7 @@ class sockets(BrowserCore):
   def test_noderawsockets_echo(self):
     # With -sNODERAWSOCKETS the client does a non-blocking connect, send and
     # recv over a real OS socket against a loopback echo server we run here.
-    self._run_against_echo_server('sockets/test_tcp_echo.c', 'TCP ECHO PASS')
+    self._run_against_echo_server('sockets/test_tcp_echo.c')
 
   def test_noderawsockets_client_bind(self):
     # A client that bind()s an explicit source port has it honored by connect(),
@@ -427,7 +427,7 @@ class sockets(BrowserCore):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-      self.do_runf('sockets/test_tcp_client_bind.c', 'CLIENT BIND PASS',
+      self.do_runf('sockets/test_tcp_client_bind.c', 'done',
                    cflags=['-sNODERAWSOCKETS'], args=[str(port), str(src_port)])
     finally:
       server.shutdown()
@@ -437,11 +437,11 @@ class sockets(BrowserCore):
   def test_noderawsockets_client_semantics(self):
     # EISCONN on a second connect, shutdown(SHUT_WR) leaving reads working,
     # EPIPE on a write after that, and POLLHUP after a full shutdown(SHUT_RDWR).
-    self._run_against_echo_server('sockets/test_tcp_client_semantics.c', 'CLIENT SEMANTICS PASS')
+    self._run_against_echo_server('sockets/test_tcp_client_semantics.c')
 
   def test_noderawsockets_refused(self):
     # A connect to a loopback port with nothing listening reports ECONNREFUSED.
-    self.do_runf('sockets/test_tcp_refused.c', 'REFUSED PASS', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_tcp_refused.c', 'done', cflags=['-sNODERAWSOCKETS'])
 
   def test_noderawsockets_backpressure(self):
     # A sink server that accepts but never reads, so the client's writes fill
@@ -457,7 +457,7 @@ class sockets(BrowserCore):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-      self.do_runf('sockets/test_tcp_backpressure.c', 'BACKPRESSURE PASS',
+      self.do_runf('sockets/test_tcp_backpressure.c', 'done',
                    cflags=['-sNODERAWSOCKETS'], args=[str(port)])
     finally:
       done.set()
@@ -470,18 +470,18 @@ class sockets(BrowserCore):
     # Self-contained loopback accept+echo, exercising bind(:0)+getsockname
     # (synchronous ephemeral port), listen, accept, non-blocking connect, send
     # and recv over real OS sockets via the tcp_wrap server path.
-    self.do_runf('sockets/test_tcp_server.c', 'TCP SERVER PASS', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_tcp_server.c', 'done', cflags=['-sNODERAWSOCKETS'])
 
   @also_with_proxy_to_pthread
   def test_noderawsockets_peek(self):
     # recv(MSG_PEEK) must leave the data buffered: a peek returns the bytes, the
     # socket stays readable, and the following plain recv returns them again.
-    self.do_runf('sockets/test_tcp_peek.c', 'TCP PEEK PASS', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_tcp_peek.c', 'done', cflags=['-sNODERAWSOCKETS'])
 
   def test_noderawsockets_server_autobind(self):
     # listen() without a prior bind() must auto-bind an ephemeral port and
     # getsockname() must report it (POSIX), then accept+echo as usual.
-    self.do_runf('sockets/test_tcp_server.c', 'TCP SERVER PASS',
+    self.do_runf('sockets/test_tcp_server.c', 'done',
                  cflags=['-sNODERAWSOCKETS', '-DNO_EXPLICIT_BIND'])
 
   def test_noderawsockets_tcp_ipv6(self):
@@ -489,25 +489,25 @@ class sockets(BrowserCore):
     # listen, accept, non-blocking connect, send/recv on AF_INET6 sockets.
     if not HAS_IPV6_LOOPBACK:
       self.skipTest('no IPv6 loopback available')
-    self.do_runf('sockets/test_tcp_ipv6.c', 'TCP IPV6 PASS', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_tcp_ipv6.c', 'done', cflags=['-sNODERAWSOCKETS'])
 
   def test_noderawsockets_udp_ipv6(self):
     # Self-contained IPv6 UDP loopback echo over ::1 on AF_INET6 sockets.
     if not HAS_IPV6_LOOPBACK:
       self.skipTest('no IPv6 loopback available')
-    self.do_runf('sockets/test_udp_ipv6.c', 'UDP IPV6 PASS', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_udp_ipv6.c', 'done', cflags=['-sNODERAWSOCKETS'])
 
   @also_with_proxy_to_pthread
   def test_noderawsockets_udp(self):
     # Self-contained loopback UDP echo: the server binds(:0)+getsockname for its
     # ephemeral port, the client sends a datagram, the server echoes it back.
-    self.do_runf('sockets/test_udp_echo.c', 'UDP ECHO PASS', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_udp_echo.c', 'done', cflags=['-sNODERAWSOCKETS'])
 
   @also_with_proxy_to_pthread
   def test_noderawsockets_udp_connect(self):
     # Connected UDP: sendto() with an address gives EISCONN, send() reaches the
     # peer, and datagrams from a non-peer socket are filtered out.
-    self.do_runf('sockets/test_udp_connect.c', 'UDP CONNECT PASS', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_udp_connect.c', 'done', cflags=['-sNODERAWSOCKETS'])
 
   @also_with_proxy_to_pthread
   def test_noderawsockets_udp_sockopts(self):
@@ -516,7 +516,7 @@ class sockets(BrowserCore):
     # readable before any set. EXIT_RUNTIME so the plain synchronous main()
     # tears down the proxy worker on return (otherwise noExitRuntime keeps the
     # worker, and thus node, alive under PROXY_TO_PTHREAD).
-    self.do_runf('sockets/test_udp_sockopts.c', 'UDP SOCKOPTS PASS',
+    self.do_runf('sockets/test_udp_sockopts.c', 'done',
                  cflags=['-sNODERAWSOCKETS', '-sEXIT_RUNTIME'])
 
   @requires_native_clang

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -427,8 +427,7 @@ class sockets(BrowserCore):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-      self.do_runf('sockets/test_tcp_client_bind.c', 'done',
-                   cflags=['-sNODERAWSOCKETS'], args=[str(port), str(src_port)])
+      self.do_runf('sockets/test_tcp_client_bind.c', 'done', cflags=['-sNODERAWSOCKETS'], args=[str(port), str(src_port)])
     finally:
       server.shutdown()
       server.server_close()
@@ -457,8 +456,7 @@ class sockets(BrowserCore):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-      self.do_runf('sockets/test_tcp_backpressure.c', 'done',
-                   cflags=['-sNODERAWSOCKETS'], args=[str(port)])
+      self.do_runf('sockets/test_tcp_backpressure.c', 'done', cflags=['-sNODERAWSOCKETS'], args=[str(port)])
     finally:
       done.set()
       server.shutdown()
@@ -481,8 +479,7 @@ class sockets(BrowserCore):
   def test_noderawsockets_server_autobind(self):
     # listen() without a prior bind() must auto-bind an ephemeral port and
     # getsockname() must report it (POSIX), then accept+echo as usual.
-    self.do_runf('sockets/test_tcp_server.c', 'done',
-                 cflags=['-sNODERAWSOCKETS', '-DNO_EXPLICIT_BIND'])
+    self.do_runf('sockets/test_tcp_server.c', 'done', cflags=['-sNODERAWSOCKETS', '-DNO_EXPLICIT_BIND'])
 
   def test_noderawsockets_tcp_ipv6(self):
     # Self-contained IPv6 TCP loopback accept+echo over ::1: bind(:0)+getsockname,
@@ -516,8 +513,7 @@ class sockets(BrowserCore):
     # readable before any set. EXIT_RUNTIME so the plain synchronous main()
     # tears down the proxy worker on return (otherwise noExitRuntime keeps the
     # worker, and thus node, alive under PROXY_TO_PTHREAD).
-    self.do_runf('sockets/test_udp_sockopts.c', 'done',
-                 cflags=['-sNODERAWSOCKETS', '-sEXIT_RUNTIME'])
+    self.do_runf('sockets/test_udp_sockopts.c', 'done', cflags=['-sNODERAWSOCKETS', '-sEXIT_RUNTIME'])
 
   @requires_native_clang
   @requires_python_dev_packages

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -397,7 +397,7 @@ class sockets(BrowserCore):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-      self.do_runf(src, 'done', cflags=['-sNODERAWSOCKETS'], args=[str(port)])
+      self.do_runf(src, 'done\n', cflags=['-sNODERAWSOCKETS'], args=[str(port)])
     finally:
       server.shutdown()
       server.server_close()
@@ -427,7 +427,7 @@ class sockets(BrowserCore):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-      self.do_runf('sockets/test_tcp_client_bind.c', 'done', cflags=['-sNODERAWSOCKETS'], args=[str(port), str(src_port)])
+      self.do_runf('sockets/test_tcp_client_bind.c', 'done\n', cflags=['-sNODERAWSOCKETS'], args=[str(port), str(src_port)])
     finally:
       server.shutdown()
       server.server_close()
@@ -440,7 +440,7 @@ class sockets(BrowserCore):
 
   def test_noderawsockets_refused(self):
     # A connect to a loopback port with nothing listening reports ECONNREFUSED.
-    self.do_runf('sockets/test_tcp_refused.c', 'done', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_tcp_refused.c', 'done\n', cflags=['-sNODERAWSOCKETS'])
 
   def test_noderawsockets_backpressure(self):
     # A sink server that accepts but never reads, so the client's writes fill
@@ -456,7 +456,7 @@ class sockets(BrowserCore):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-      self.do_runf('sockets/test_tcp_backpressure.c', 'done', cflags=['-sNODERAWSOCKETS'], args=[str(port)])
+      self.do_runf('sockets/test_tcp_backpressure.c', 'done\n', cflags=['-sNODERAWSOCKETS'], args=[str(port)])
     finally:
       done.set()
       server.shutdown()
@@ -468,43 +468,43 @@ class sockets(BrowserCore):
     # Self-contained loopback accept+echo, exercising bind(:0)+getsockname
     # (synchronous ephemeral port), listen, accept, non-blocking connect, send
     # and recv over real OS sockets via the tcp_wrap server path.
-    self.do_runf('sockets/test_tcp_server.c', 'done', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_tcp_server.c', 'done\n', cflags=['-sNODERAWSOCKETS'])
 
   @also_with_proxy_to_pthread
   def test_noderawsockets_peek(self):
     # recv(MSG_PEEK) must leave the data buffered: a peek returns the bytes, the
     # socket stays readable, and the following plain recv returns them again.
-    self.do_runf('sockets/test_tcp_peek.c', 'done', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_tcp_peek.c', 'done\n', cflags=['-sNODERAWSOCKETS'])
 
   def test_noderawsockets_server_autobind(self):
     # listen() without a prior bind() must auto-bind an ephemeral port and
     # getsockname() must report it (POSIX), then accept+echo as usual.
-    self.do_runf('sockets/test_tcp_server.c', 'done', cflags=['-sNODERAWSOCKETS', '-DNO_EXPLICIT_BIND'])
+    self.do_runf('sockets/test_tcp_server.c', 'done\n', cflags=['-sNODERAWSOCKETS', '-DNO_EXPLICIT_BIND'])
 
   def test_noderawsockets_tcp_ipv6(self):
     # Self-contained IPv6 TCP loopback accept+echo over ::1: bind(:0)+getsockname,
     # listen, accept, non-blocking connect, send/recv on AF_INET6 sockets.
     if not HAS_IPV6_LOOPBACK:
       self.skipTest('no IPv6 loopback available')
-    self.do_runf('sockets/test_tcp_ipv6.c', 'done', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_tcp_ipv6.c', 'done\n', cflags=['-sNODERAWSOCKETS'])
 
   def test_noderawsockets_udp_ipv6(self):
     # Self-contained IPv6 UDP loopback echo over ::1 on AF_INET6 sockets.
     if not HAS_IPV6_LOOPBACK:
       self.skipTest('no IPv6 loopback available')
-    self.do_runf('sockets/test_udp_ipv6.c', 'done', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_udp_ipv6.c', 'done\n', cflags=['-sNODERAWSOCKETS'])
 
   @also_with_proxy_to_pthread
   def test_noderawsockets_udp(self):
     # Self-contained loopback UDP echo: the server binds(:0)+getsockname for its
     # ephemeral port, the client sends a datagram, the server echoes it back.
-    self.do_runf('sockets/test_udp_echo.c', 'done', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_udp_echo.c', 'done\n', cflags=['-sNODERAWSOCKETS'])
 
   @also_with_proxy_to_pthread
   def test_noderawsockets_udp_connect(self):
     # Connected UDP: sendto() with an address gives EISCONN, send() reaches the
     # peer, and datagrams from a non-peer socket are filtered out.
-    self.do_runf('sockets/test_udp_connect.c', 'done', cflags=['-sNODERAWSOCKETS'])
+    self.do_runf('sockets/test_udp_connect.c', 'done\n', cflags=['-sNODERAWSOCKETS'])
 
   @also_with_proxy_to_pthread
   def test_noderawsockets_udp_sockopts(self):
@@ -513,7 +513,7 @@ class sockets(BrowserCore):
     # readable before any set. EXIT_RUNTIME so the plain synchronous main()
     # tears down the proxy worker on return (otherwise noExitRuntime keeps the
     # worker, and thus node, alive under PROXY_TO_PTHREAD).
-    self.do_runf('sockets/test_udp_sockopts.c', 'done', cflags=['-sNODERAWSOCKETS', '-sEXIT_RUNTIME'])
+    self.do_runf('sockets/test_udp_sockopts.c', 'done\n', cflags=['-sNODERAWSOCKETS', '-sEXIT_RUNTIME'])
 
   @requires_native_clang
   @requires_python_dev_packages


### PR DESCRIPTION
The `-sNODERAWSOCKETS` tests each printed a bespoke success string (`TCP SERVER PASS`, `UDP ECHO PASS`, etc.) which the Python harness then matched against. That meant every `do_runf` call had to carry a unique expected string, pushing several onto multiple lines and giving no real benefit over a uniform marker.

This switches all of these tests to print `done\n` on completion and checks for `'done'` in the harness instead:

* the 12 `test/sockets/test_tcp_*.c` / `test_udp_*.c` files now `printf("done\n")` at the end
* `_run_against_echo_server` drops its `expected` parameter and checks for `'done'`
* the individual `do_runf` calls pass `'done'`

Correctness is still enforced by in-test `assert()`s (nonzero exit on failure) plus the `'done'` check confirming the program ran to completion.

_Made with AI assistance under my review_
