### PR TITLE
Fix synchronously proxied async JS functions under ASYNCIFY

### DIFF
--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -359,11 +359,18 @@ ${body};
   });
 }
 
-function handleAsyncFunction(snippet, sig) {
+function handleAsyncFunction(snippet, sig, proxied) {
   const return64 = sig && (MEMORY64 && sig.startsWith('p') || sig.startsWith('j'))
   let handleAsync = 'Asyncify.handleAsync(innerFunc)'
   if (return64 && ASYNCIFY == 1) {
     handleAsync = makeReturn64(handleAsync);
+  }
+  // When dispatching on behalf of a proxied caller (PROXY_SYNC_ASYNC), the
+  // caller awaits the returned promise, so return it directly rather than
+  // suspending the main thread.
+  let proxiedDispatch = '';
+  if (ASYNCIFY == 1 && PTHREADS && proxied) {
+    proxiedDispatch = 'if (PThread.currentProxiedOperationCallerThread) return innerFunc();\n  ';
   }
   return modifyJSFunction(snippet, (args, body, async_, oneliner) => {
     if (!oneliner) {
@@ -372,7 +379,7 @@ function handleAsyncFunction(snippet, sig) {
     return `\
 function(${args}) {
   let innerFunc = ${async_} () => ${body};
-  return ${handleAsync};
+  ${proxiedDispatch}return ${handleAsync};
 }\n`;
   });
 }
@@ -479,11 +486,12 @@ function(${args}) {
       compileTimeContext.i53ConversionDeps.forEach((d) => deps.push(d));
     }
 
+    const proxyingMode = LibraryManager.library[symbol + '__proxy'];
+
     if (ASYNCIFY && isAsyncFunction == 'auto') {
-      snippet = handleAsyncFunction(snippet, sig);
+      snippet = handleAsyncFunction(snippet, sig, proxyingMode == 'sync');
     }
 
-    const proxyingMode = LibraryManager.library[symbol + '__proxy'];
     if (proxyingMode) {
       if (!['sync', 'async', 'none'].includes(proxyingMode)) {
         error(`JS library error: invalid proxying mode '${symbol}__proxy: ${proxyingMode}' specified`);

--- a/src/lib/libasync.js
+++ b/src/lib/libasync.js
@@ -443,10 +443,20 @@ addToLibrary({
     //
     // This is particularly useful for native JS `async` functions where the
     // returned value will "just work" and be passed back to C++.
-    handleAsync: (startAsync) => Asyncify.handleSleep(async (wakeUp) => {
-      // TODO: add error handling as a second param when handleSleep implements it.
-      wakeUp(await startAsync());
-    }),
+    handleAsync: (startAsync) => {
+#if PTHREADS
+      // When dispatching a proxied call on behalf of another thread
+      // (PROXY_SYNC_ASYNC), the caller awaits the returned Promise; the main
+      // thread must not asyncify-unwind.
+      if (PThread.currentProxiedOperationCallerThread) {
+        return startAsync();
+      }
+#endif
+      return Asyncify.handleSleep(async (wakeUp) => {
+        // TODO: add error handling as a second param when handleSleep implements it.
+        wakeUp(await startAsync());
+      });
+    },
 
 #elif ASYNCIFY == 2
     //

--- a/src/lib/libasync.js
+++ b/src/lib/libasync.js
@@ -443,20 +443,10 @@ addToLibrary({
     //
     // This is particularly useful for native JS `async` functions where the
     // returned value will "just work" and be passed back to C++.
-    handleAsync: (startAsync) => {
-#if PTHREADS
-      // When dispatching a proxied call on behalf of another thread
-      // (PROXY_SYNC_ASYNC), the caller awaits the returned Promise; the main
-      // thread must not asyncify-unwind.
-      if (PThread.currentProxiedOperationCallerThread) {
-        return startAsync();
-      }
-#endif
-      return Asyncify.handleSleep(async (wakeUp) => {
-        // TODO: add error handling as a second param when handleSleep implements it.
-        wakeUp(await startAsync());
-      });
-    },
+    handleAsync: (startAsync) => Asyncify.handleSleep(async (wakeUp) => {
+      // TODO: add error handling as a second param when handleSleep implements it.
+      wakeUp(await startAsync());
+    }),
 
 #elif ASYNCIFY == 2
     //

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9757,6 +9757,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
       self.skipTest('test requires setTimeout which is not supported under v8')
     self.do_runf('core/test_poll_blocking_asyncify.c', 'done\n')
 
+  # Include @requires_node_25 explictly here so that this test will be disabled
+  # by EMTEST_SKIP_NODE_25.  Without this, the `requires_pthreads` and `requires_jspi` can
+  # end with conflicting requirements because we often run with both v8 (which satisfies
+  # the `requires_jspi` part have node 22 (which satisfies the `requires_pthreads` part).
+  # FIXME: This should not be needed.
+  @requires_node_25
   @with_asyncify_and_jspi
   @requires_pthreads
   @no_wasmfs('https://github.com/emscripten-core/emscripten/issues/26736')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9757,6 +9757,11 @@ NODEFS is no longer included by default; build with -lnodefs.js
       self.skipTest('test requires setTimeout which is not supported under v8')
     self.do_runf('core/test_poll_blocking_asyncify.c', 'done\n')
 
+  @requires_pthreads
+  @no_wasmfs('https://github.com/emscripten-core/emscripten/issues/26736')
+  def test_poll_blocking_asyncify_pthread(self):
+    self.do_runf('core/test_poll_blocking.c', cflags=['-pthread', '-sPROXY_TO_PTHREAD=1', '-sASYNCIFY', '-sEXIT_RUNTIME=1'])
+
   @parameterized({
     '': ([],),
     'pthread': (['-pthread'],),

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9757,10 +9757,13 @@ NODEFS is no longer included by default; build with -lnodefs.js
       self.skipTest('test requires setTimeout which is not supported under v8')
     self.do_runf('core/test_poll_blocking_asyncify.c', 'done\n')
 
+  @with_asyncify_and_jspi
   @requires_pthreads
   @no_wasmfs('https://github.com/emscripten-core/emscripten/issues/26736')
   def test_poll_blocking_asyncify_pthread(self):
-    self.do_runf('core/test_poll_blocking.c', cflags=['-pthread', '-sPROXY_TO_PTHREAD=1', '-sASYNCIFY', '-sEXIT_RUNTIME=1'])
+    if self.get_setting('JSPI') and engine_is_v8(self.get_current_js_engine()):
+      self.skipTest('test requires setTimeout which is not supported under v8')
+    self.do_runf('core/test_poll_blocking.c', cflags=['-pthread', '-sPROXY_TO_PTHREAD=1', '-sEXIT_RUNTIME=1'])
 
   @parameterized({
     '': ([],),


### PR DESCRIPTION
This fixes the crash from #27291 where calling `poll()` from a pthread under ASYNCIFY aborts with `import _emscripten_receive_on_main_thread_js was not in ASYNCIFY_IMPORTS, but changed the state`.

Functions marked both `__proxy: 'sync'` and `__async` (e.g. `__syscall_poll`) are dispatched from pthreads to the main thread using PROXY_SYNC_ASYNC (#26000): `_emscripten_receive_on_main_thread_js` expects the library function to return a Promise, and wakes the calling thread when it resolves. Under ASYNCIFY, however, the jsifier also wraps these functions in `Asyncify.handleAsync`, so the proxied dispatch on the main thread would start an asyncify unwind of the main thread's proxy-queue frame instead of returning the Promise. With assertions this hits the ASYNCIFY_IMPORTS abort; adding the import to ASYNCIFY_IMPORTS as the message suggests then fails with `TypeError: rtn.then is not a function`, since the wrapper returns the asyncify sleep sentinel (0) rather than the Promise.

The fix is for `Asyncify.handleAsync` to return the raw Promise when executing on behalf of a proxied caller (`PThread.currentProxiedOperationCallerThread` is set), satisfying the PROXY_SYNC_ASYNC contract.

Behavior for the #27291 repro (blocking `poll()` on a pthread), before/after this change:

* `-pthread -sPROXY_TO_PTHREAD -sASYNCIFY`: crashed before, works now (new test)
* `-pthread -sPROXY_TO_PTHREAD`: unaffected, worked before and after
* `-pthread -sASYNCIFY` (the issue as filed): no longer crashes, but still hangs: the PROXY_SYNC_ASYNC completion requires the main thread event loop (the limitation noted in #26000) while the main thread is blocked in `pthread_join`. Plain `-pthread` hangs the same way both before and after this change. Making that configuration either work or fail loudly seems worth a separate discussion.

Test coverage: `core.test_poll_blocking_asyncify_pthread` runs the existing test_poll_blocking.c under `-sPROXY_TO_PTHREAD -sASYNCIFY`, which aborted before this change.

_Made with AI assistance under my review_