### PR TITLE
Add emscripten_promising_count() for querying in-flight async invocations

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 6.0.4 (in development)
 ----------------------
+- New function `emscripten_promising_count()` that returns the number of async
+  (promising) wasm invocations currently in flight under ASYNCIFY or JSPI.
 - Legacy support for ancient vendor-prefixed DOM APIs was removed (#27341,
   #27339, #27338, #27340, #27347)
 

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -1365,6 +1365,20 @@ Functions
   :returns: 1 if program was compiled with -sASYNCIFY, 0 otherwise.
 
 
+.. c:function:: int emscripten_promising_count()
+
+  Returns the number of async (promising) wasm invocations currently in
+  flight, i.e. entered but with their returned promise not yet settled.
+  Under ``-sJSPI`` a promising export counts for its entire invocation and
+  multiple invocations may be in flight simultaneously. Under ``-sASYNCIFY``
+  only a single async invocation can be in flight at a time, and it is only
+  counted from the point that it first suspends.
+
+  :rtype: int
+  :returns: The number of async wasm invocations in flight, always 0 when
+    compiled without ``-sASYNCIFY`` or ``-sJSPI``.
+
+
 .. c:function:: void emscripten_debugger()
 
   Emits ``debugger``.

--- a/src/lib/libasync.js
+++ b/src/lib/libasync.js
@@ -37,6 +37,9 @@ addToLibrary({
     //
     // Asyncify code that is shared between mode 1 (original) and mode 2 (JSPI).
     //
+
+    // Number of async (promising) wasm invocations currently in flight.
+    promisingCount: 0,
 #if ASYNCIFY == 1 && MEMORY64
     rewindArguments: new Map(),
 #endif
@@ -381,6 +384,7 @@ addToLibrary({
           // Track whether the return value was handled by any promise handlers.
           var handled = false;
           if (!Asyncify.currData) {
+            Asyncify.promisingCount--;
             // All asynchronous execution has finished.
             // `asyncWasmReturnValue` now contains the final
             // return value of the exported async WASM function.
@@ -411,6 +415,9 @@ addToLibrary({
         if (!reachedCallback) {
           // A true async operation was begun; start a sleep.
           Asyncify.state = Asyncify.State.Unwinding;
+          // A nested sleep of an invocation that is already in flight (via
+          // doRewind) must not be recounted.
+          if (!Asyncify.promisingCount) Asyncify.promisingCount = 1;
           // TODO: reuse, don't alloc/free every sleep
           Asyncify.currData = Asyncify.allocateData();
 #if ASYNCIFY_DEBUG
@@ -472,13 +479,20 @@ addToLibrary({
 #if ASYNCIFY_DEBUG
       dbg('asyncify: makeAsyncFunction for', original);
 #endif
-      return WebAssembly.promising(original);
+      var promising = WebAssembly.promising(original);
+      return (...args) => {
+        Asyncify.promisingCount++;
+        return promising(...args).finally(() => Asyncify.promisingCount--);
+      };
     },
 #endif
   },
 
   emscripten_sleep__async: 'auto',
   emscripten_sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+
+  emscripten_promising_count__deps: ['$Asyncify'],
+  emscripten_promising_count: () => Asyncify.promisingCount,
 
   emscripten_wget_data__deps: ['$asyncLoad', 'malloc'],
   emscripten_wget_data__async: 'auto',
@@ -610,6 +624,7 @@ addToLibrary({
     }
   },
 #else // ASYNCIFY
+  emscripten_promising_count: () => 0,
   emscripten_sleep: () => {
     abort('Please compile your program with async support in order to use asynchronous operations like emscripten_sleep');
   },

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -1818,7 +1818,7 @@ addToLibrary({
     var func = getWasmTableEntry(ptr);
 #if JSPI
     if (promising) {
-      func = WebAssembly.promising(func);
+      func = Asyncify.makeAsyncFunction(func);
     }
 #endif
     var rtn = func(...args);

--- a/src/lib/libembind.js
+++ b/src/lib/libembind.js
@@ -843,7 +843,7 @@ var LibraryEmbind = {
       var rtn = getWasmTableEntry(rawFunction);
 #if JSPI
       if (isAsync) {
-        rtn = WebAssembly.promising(rtn);
+        rtn = Asyncify.makeAsyncFunction(rtn);
       }
 #endif
       return rtn;

--- a/src/lib/libsigs.js
+++ b/src/lib/libsigs.js
@@ -742,6 +742,7 @@ sigs = {
   emscripten_promise_race__sig: 'ppp',
   emscripten_promise_resolve__sig: 'vpip',
   emscripten_promise_then__sig: 'ppppp',
+  emscripten_promising_count__sig: 'i',
   emscripten_random__sig: 'f',
   emscripten_request_animation_frame__sig: 'ipp',
   emscripten_request_animation_frame_loop__sig: 'vpp',

--- a/src/parseTools.mjs
+++ b/src/parseTools.mjs
@@ -764,7 +764,7 @@ Please update to new syntax.`);
 
   let getWasmTableEntry = `getWasmTableEntry(${funcPtr})`;
   if (promising) {
-    getWasmTableEntry = `WebAssembly.promising(${getWasmTableEntry})`;
+    getWasmTableEntry = `Asyncify.makeAsyncFunction(${getWasmTableEntry})`;
   }
 
   if (needArgConversion) {

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -144,6 +144,10 @@ long emscripten_get_compiler_setting(const char *name);
 // Returns the value of -sASYNCIFY.  Can be 0, 1, or 2 (in the case of JSPI).
 int emscripten_has_asyncify(void);
 
+// Returns the number of async (promising) wasm invocations currently in
+// flight (via -sASYNCIFY or -sJSPI).  Always 0 without async support.
+int emscripten_promising_count(void);
+
 void emscripten_debugger(void);
 
 // Forward declare FILE from musl libc headers to avoid needing to #include <stdio.h> from emscripten.h

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8375,6 +8375,23 @@ int main() {
 
     self.do_runf('main.c', 'hello 0\nhello 1\nhello 2\nhello 3\nhello 4\n')
 
+  @with_asyncify_and_jspi
+  def test_promising_count(self):
+    create_file('main.c', r'''
+#include <stdio.h>
+#include <emscripten.h>
+int main() {
+  EM_ASM({
+    setTimeout(() => out('suspended: ' + _emscripten_promising_count()), 0);
+    setTimeout(() => out('done: ' + _emscripten_promising_count()), 20);
+  });
+  emscripten_sleep(10);
+  printf("after: %d\n", emscripten_promising_count());
+}
+''')
+
+    self.do_runf('main.c', 'suspended: 1\nafter: 1\ndone: 0\n')
+
   @no_modularize_instance('ccall is not compatible with MODULARIZE=instance')
   def test_async_ccall_bad(self):
     # check bad ccall use


### PR DESCRIPTION
This adds a new `emscripten_promising_count()` function returning the number of async (promising) wasm invocations currently in flight, entered but with their returned promise not yet settled, under both ASYNCIFY and JSPI.

This allows runtime code to detect whether any async wasm invocations are pending, for example to verify or assert reentrancy invariants.

* For JSPI (`ASYNCIFY==2`), the counter is bumped in `Asyncify.makeAsyncFunction` around each promising invocation, decrementing when the returned promise settles. All `WebAssembly.promising` usage (exports, `dynCall`, embind, `makeDynCall` codegen) is now routed through `makeAsyncFunction` as a single chokepoint, so this is a single bump per invocation rather than per import call.
* For ASYNCIFY, the single suspendable invocation is counted from its first unwind until its final rewind completes, so the value is 0 or 1 (fiber swaps are not counted).
* Without async support the function compiles to a constant 0.

One documented asymmetry: under JSPI a promising export counts for its entire invocation, while under ASYNCIFY an invocation is only counted once it first suspends.

Includes a new `test_promising_count` core test run under both ASYNCIFY and JSPI, observing the count from JS during an `emscripten_sleep` suspension, from C after resume, and confirming it returns to 0 after the invocation settles. Docs and ChangeLog updated.

_Made with AI assistance under my review_