### PR TITLE
Fix update_openmp.py, openmp README. NFC

### DIFF
--- a/system/lib/openmp/README.md
+++ b/system/lib/openmp/README.md
@@ -1,6 +1,9 @@
 llvm's OpenMP
 -------------
 
+Note: This version of openmp is actually based on 1823581ecb but
+we are in the process of updating it.
+
 These files are from the llvm-project based on release 21.1.8.
 
 We maintain a local fork of llvm-project that contains any Emscripten

--- a/system/lib/update_openmp.py
+++ b/system/lib/update_openmp.py
@@ -5,14 +5,17 @@
 # found in the LICENSE file.
 
 import os
-import sys
 import shutil
 import subprocess
 
-
-script_dir = os.path.abspath(os.path.dirname(__file__))
-emscripten_root = os.path.dirname(os.path.dirname(script_dir))
-default_llvm_dir = os.path.join(os.path.dirname(emscripten_root), 'llvm-project')
+from update_common import (
+  clean_dir,
+  copy_tree,
+  default_llvm_dir,
+  emscripten_root,
+  parse_args,
+  script_dir,
+)
 
 # system/lib/openmp (to be updated)
 local_root = os.path.join(script_dir, 'openmp')
@@ -21,51 +24,27 @@ local_include = os.path.join(local_root, 'include')
 local_prebuilt = os.path.join(local_root, 'prebuilt')
 
 # Files to ignore during copy_tree
-excludes = [
-  'doc',
-  'build',
-  'tests',
-  'CMakeFiles',
-  'libgomp.a',
-  'libiomp5.a',
-  'libomp.a',
-]
-
-
-def clean_dir(dirname):
-  for f in os.listdir(dirname):
-    full = os.path.join(dirname, f)
-    if os.path.isdir(full):
-      shutil.rmtree(full)
-    else:
-      os.remove(full)
-
-
-def copy_tree(upstream_dir, local_dir):
-  for f in os.listdir(upstream_dir):
-    full = os.path.join(upstream_dir, f)
-    if f not in excludes:
-      if os.path.isdir(full):
-        if not os.path.exists(os.path.join(local_dir, f)):
-          os.makedirs(os.path.join(local_dir, f))
-        copy_tree(full, os.path.join(local_dir, f))
-      else:
-        shutil.copy2(full, os.path.join(local_dir, f))
+excludes = (
+    'doc',
+    'build',
+    'tests',
+    'CMakeFiles',
+    'libgomp.a',
+    'libiomp5.a',
+    'libomp.a',
+)
 
 
 def main():
-  if len(sys.argv) > 1:
-    llvm_dir = os.path.join(os.path.abspath(sys.argv[1]))
-  else:
-    llvm_dir = default_llvm_dir
+  llvm_dir = parse_args(default_llvm_dir, 'llvm_dir')
 
   # Output directory for build
   output_dir = os.path.join(emscripten_root, 'out')
   build_dir = os.path.join(output_dir, 'build_openmp')
 
   # LLVM/OpenMP folder containing latest version
-  upstream_runtimes = os.path.join(llvm_dir, 'runtimes/')
-  upstream_root = os.path.join(llvm_dir, 'openmp/')
+  upstream_runtimes = os.path.join(llvm_dir, 'runtimes')
+  upstream_root = os.path.join(llvm_dir, 'openmp')
   upstream_runtime_root = os.path.join(upstream_root, 'runtime/src')
   assert os.path.exists(upstream_runtime_root)
 
@@ -73,25 +52,19 @@ def main():
   upstream_build_src = os.path.join(build_dir, 'openmp/runtime/src') # contains various *.a and generated *.h
 
   # Remove old version
-  clean_dir(local_root)
-  os.mkdir(local_src)
-  os.mkdir(local_include)
-  os.mkdir(local_prebuilt)
+  clean_dir(local_src)
+  clean_dir(local_include)
+  clean_dir(local_prebuilt)
 
   # Update source
-  copy_tree(upstream_runtime_root, local_src)
+  copy_tree(upstream_runtime_root, local_src, excludes)
 
   # Generates header files for OpenMP library build
-  subprocess.run(
-    [
-      'emcmake',
-      'cmake',
-      '-S',
-      f'{upstream_runtimes}',
-      '-B',
-      f'{build_dir}',
-      '-G',
-      'Ninja',
+  subprocess.run([
+      os.path.join(emscripten_root, 'emcmake'), 'cmake',
+      '-S', upstream_runtimes,
+      '-B', build_dir,
+      '-G', 'Ninja',
       '-DLLVM_ENABLE_RUNTIMES=openmp',
       '-DLLVM_DEFAULT_TARGET_TRIPLE=wasm32-unknown-emscripten',
       '-DOPENMP_ENABLE_LIBOMPTARGET=OFF',
@@ -103,9 +76,8 @@ def main():
       '-DLIBOMP_ENABLE_SHARED=OFF',
       '-DLIBOMP_ARCH=wasm32',
       '-DOPENMP_ENABLE_LIBOMPTARGET_PROFILING=OFF',
-    ]
-  )
-  subprocess.run(['cmake', '--build', '.'], cwd=build_dir)
+  ], check=True)
+  subprocess.run(['cmake', '--build', '.'], cwd=build_dir, check=True)
 
   # Update license file
   shutil.copy2(os.path.join(upstream_root, 'LICENSE.TXT'), local_root)
@@ -116,7 +88,7 @@ def main():
     shutil.copy2(os.path.join(upstream_build_src, file), local_include)
 
   # Update generated header files
-  built_files = ['kmp_config.h', 'kmp_i18n_id.inc',  'kmp_i18n_default.inc']
+  built_files = ['kmp_config.h', 'kmp_i18n_id.inc', 'kmp_i18n_default.inc']
   for file in built_files:
     shutil.copy2(os.path.join(upstream_build_src, file), local_prebuilt)
 


### PR DESCRIPTION
The version of openmp that we imported was based on LLVM commit 1823581ecb rather than an emscripten-libs branch.

This change updates the update_openmp.py script, and I verified that running it against 1823581ecb was a no-op aside from the one-line downstream patch I made in #27289.