### PR TITLE
Apply ruff checks to files under `system/lib`. NFC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ exclude = [
   "./node_modules/",
   "./site/source/_themes/",
   "./site/source/conf.py",
-  "./system/lib/",
   "./test/third_party/",
   "./third_party/",
   "./tools/filelock.py",

--- a/system/lib/push_llvm_changes.py
+++ b/system/lib/push_llvm_changes.py
@@ -9,10 +9,9 @@
 # and update_libcxxabi.py which copy changes from the upstream llvm
 # into emscripten.
 
-import glob
 import os
-import sys
 import shutil
+import sys
 
 script_dir = os.path.abspath(os.path.dirname(__file__))
 emscripten_root = os.path.dirname(os.path.dirname(script_dir))

--- a/system/lib/push_musl_changes.py
+++ b/system/lib/push_musl_changes.py
@@ -8,10 +8,9 @@
 # This is the logical inverse of update_musl.py which copies changes
 # from the upstream musl tree into emscripten.
 
-import glob
 import os
-import sys
 import shutil
+import sys
 
 script_dir = os.path.abspath(os.path.dirname(__file__))
 local_dir = os.path.join(script_dir, 'libc', 'musl')

--- a/system/lib/update_common.py
+++ b/system/lib/update_common.py
@@ -1,11 +1,15 @@
-import os
-import sys
-import shutil
-import re
 import argparse
+import os
+import re
+import shutil
+import sys
 
 script_dir = os.path.abspath(os.path.dirname(__file__))
 emscripten_root = os.path.dirname(os.path.dirname(script_dir))
+sys.path.append(emscripten_root)
+
+from tools.utils import read_file, write_file
+
 default_llvm_dir = os.path.join(os.path.dirname(emscripten_root), 'llvm-project')
 
 
@@ -46,7 +50,7 @@ def copy_tree(upstream_dir, local_dir, excludes=()):
     elif f not in excludes:
       shutil.copy2(full, os.path.join(local_dir, f))
   if excludes:
-    for root, dirs, files in os.walk(local_dir):
+    for root, _dirs, files in os.walk(local_dir):
       for f in files:
         if f in excludes:
           full = os.path.join(root, f)
@@ -57,8 +61,7 @@ def get_llvm_version(upstream_dir):
   cmake_file = os.path.join(upstream_dir, 'cmake', 'Modules', 'LLVMVersion.cmake')
   if not os.path.exists(cmake_file):
     return None, None
-  with open(cmake_file, 'r') as f:
-    content = f.read()
+  content = read_file(cmake_file)
   major = re.search(r'set\(LLVM_VERSION_MAJOR\s+(\d+)\)', content)
   minor = re.search(r'set\(LLVM_VERSION_MINOR\s+(\d+)\)', content)
   patch = re.search(r'set\(LLVM_VERSION_PATCH\s+(\d+)\)', content)
@@ -72,8 +75,7 @@ def update_readme(local_dir, llvm_dir):
   if not os.path.exists(readme_path):
     return
 
-  with open(readme_path, 'r') as f:
-    content = f.read()
+  content = read_file(readme_path)
 
   major, full_version = get_llvm_version(llvm_dir)
   if major and full_version:
@@ -82,5 +84,4 @@ def update_readme(local_dir, llvm_dir):
     # Find 'emscripten-libs-NN' strings and update them with the major version
     content = re.sub(r'emscripten-libs-\d+', f'emscripten-libs-{major}', content)
 
-  with open(readme_path, 'w') as f:
-    f.write(content)
+  write_file(readme_path, content)

--- a/system/lib/update_compiler_rt.py
+++ b/system/lib/update_compiler_rt.py
@@ -4,12 +4,16 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-import glob
 import os
-import sys
 import shutil
 
-from update_common import *
+from update_common import (
+  clean_dir,
+  default_llvm_dir,
+  parse_args,
+  script_dir,
+  update_readme,
+)
 
 local_src = os.path.join(script_dir, 'compiler-rt')
 
@@ -44,9 +48,9 @@ def main():
     dest = os.path.join(local_src, *dirname)
     clean_dir(dest, preserve_files)
     for name in os.listdir(srcdir):
-      if name in ('.clang-format', 'CMakeLists.txt', 'README.txt', 'weak_symbols.txt'):
+      if name in {'.clang-format', 'CMakeLists.txt', 'README.txt', 'weak_symbols.txt'}:
         continue
-      if name.endswith('.syms.extra') or name.endswith('.S'):
+      if name.endswith(('.syms.extra', '.S')):
         continue
       if os.path.isfile(os.path.join(srcdir, name)):
         shutil.copy2(os.path.join(srcdir, name), dest)

--- a/system/lib/update_libcxx.py
+++ b/system/lib/update_libcxx.py
@@ -6,11 +6,20 @@
 
 import os
 import re
-import sys
 import shutil
 import subprocess
+import sys
 
-from update_common import *
+from update_common import (
+  clean_dir,
+  copy_tree,
+  default_llvm_dir,
+  emscripten_root,
+  parse_args,
+  script_dir,
+  update_readme,
+  write_file,
+)
 
 local_root = os.path.join(script_dir, 'libcxx')
 local_src = os.path.join(local_root, 'src')
@@ -41,12 +50,11 @@ def generate_modules(cmake_version: str):
 
   clean_dir(build_dir, preserve_files)
   os.makedirs(build_dir, exist_ok=True)
-  with open(f'{build_dir}/CMakeLists.txt', 'x', encoding='utf-8') as CMakeLists:
-    CMakeLists.write(f'''\
-      cmake_minimum_required(VERSION {cmake_version})
-      project(libcxx-modules)
-      add_subdirectory("{local_modules}" libcxx)
-    ''')
+  write_file(f'{build_dir}/CMakeLists.txt', f'''\
+    cmake_minimum_required(VERSION {cmake_version})
+    project(libcxx-modules)
+    add_subdirectory("{local_modules}" libcxx)
+  ''')
 
   vars = [
     ('LIBCXX_INSTALL_LIBRARY_DIR',  lib),
@@ -62,18 +70,18 @@ def generate_modules(cmake_version: str):
   subprocess.run(['cmake', '--build', binary_dir], stdout=subprocess.DEVNULL)
   shutil.copytree(dist, dst, dirs_exist_ok=True)
 
+
 def main():
   llvm_dir = parse_args(default_llvm_dir, 'llvm_dir')
   # Exit early if cmake is not found
   try:
-    output= subprocess.check_output(['cmake', '--version'], text=True)
+    output = subprocess.check_output(['cmake', '--version'], text=True)
   except OSError:
     print('CMake not found', file=sys.stderr)
     sys.exit(1)
 
   cmake_version = re.search(r'^cmake version (\d+(?:\.\d+)*)', output).group(1)
 
-  llvm_dir = get_llvm_dir()
   libcxx_dir = os.path.join(llvm_dir, 'libcxx')
   upstream_src = os.path.join(libcxx_dir, 'src')
   upstream_inc = os.path.join(libcxx_dir, 'include')
@@ -114,6 +122,7 @@ def main():
 
   shutil.copy2(os.path.join(libc_upstream_dir, 'LICENSE.TXT'), libc_local_dir)
   update_readme(local_root, llvm_dir)
+
 
 if __name__ == '__main__':
   main()

--- a/system/lib/update_libcxxabi.py
+++ b/system/lib/update_libcxxabi.py
@@ -5,10 +5,16 @@
 # found in the LICENSE file.
 
 import os
-import sys
 import shutil
 
-from update_common import *
+from update_common import (
+  clean_dir,
+  copy_tree,
+  default_llvm_dir,
+  parse_args,
+  script_dir,
+  update_readme,
+)
 
 local_root = os.path.join(script_dir, 'libcxxabi')
 local_src = os.path.join(local_root, 'src')

--- a/system/lib/update_libunwind.py
+++ b/system/lib/update_libunwind.py
@@ -5,10 +5,16 @@
 # found in the LICENSE file.
 
 import os
-import sys
 import shutil
 
-from update_common import *
+from update_common import (
+  clean_dir,
+  copy_tree,
+  default_llvm_dir,
+  parse_args,
+  script_dir,
+  update_readme,
+)
 
 local_root = os.path.join(script_dir, 'libunwind')
 local_src = os.path.join(local_root, 'src')

--- a/system/lib/update_llvm_libc.py
+++ b/system/lib/update_llvm_libc.py
@@ -4,12 +4,17 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-import os
-import sys
-import shutil
 import glob
+import os
 
-from update_common import *
+from update_common import (
+  clean_dir,
+  copy_tree,
+  default_llvm_dir,
+  parse_args,
+  script_dir,
+  update_readme,
+)
 
 preserve_files = ('readme.txt', '__assertion_handler', '__config_site')
 # ryu_long_double_constants.h from libc is unused (and very large)
@@ -67,6 +72,7 @@ def main():
       os.remove(file)
 
   update_readme(libc_local_dir, llvm_dir)
+
 
 if __name__ == '__main__':
   main()

--- a/system/lib/update_musl.py
+++ b/system/lib/update_musl.py
@@ -18,12 +18,10 @@ changes can then be copied back into emscripten using this script.
 """
 
 import os
-import sys
 import shutil
-
 from pathlib import Path
 
-from update_common import *
+from update_common import emscripten_root, parse_args, read_file, script_dir, write_file
 
 local_src = os.path.join(script_dir, 'libc', 'musl')
 default_musl_dir = os.path.join(os.path.dirname(emscripten_root), 'musl')
@@ -36,7 +34,7 @@ exclude_dirs = (
   'aarch64', 'arm', 'i386', 'loongarch64', 'm68k',
   'microblaze', 'mips', 'mips64', 'mipsn32', 'or1k',
   'powerpc', 'powerpc64', 'riscv32', 'riscv64', 's390x',
-  'sh', 'x32', 'x86_64'
+  'sh', 'x32', 'x86_64',
 )
 exclude_files = (
   'aio.h',
@@ -102,9 +100,8 @@ def main():
   shutil.copytree(musl_dir, local_src, ignore=make_ignore(musl_dir))
 
   # Create version.h
-  version = open(os.path.join(local_src, 'VERSION')).read().strip()
-  with open(os.path.join(local_src, 'src', 'internal', 'version.h'), 'w') as f:
-    f.write('#define VERSION "%s"\n' % version)
+  version = read_file(os.path.join(local_src, 'VERSION')).strip()
+  write_file(os.path.join(local_src, 'src', 'internal', 'version.h'), f'#define VERSION "{version}"\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Remove `system/lib` exclusions from `pyproject.toml` and fix all lint warnings in `system/lib/*.py`.

Instead of adding `encoding='utf-8'` to individual `open()` calls, use `read_file()` and `write_file()` from `tools/utils.py`.