### PR TITLE
[test] Remove EMTEST_ALL_ENGINES

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -50,9 +50,6 @@ flaky_tests_log_filename = path_from_root('out/flaky_tests.txt')
 
 EMTEST_DETECT_TEMPFILE_LEAKS = None
 EMTEST_SAVE_DIR = None
-# generally js engines are equivalent, testing 1 is enough. set this
-# to force testing on all js engines, good to find js engine bugs
-EMTEST_ALL_ENGINES = None
 EMTEST_SKIP_SLOW = None
 EMTEST_SKIP_FLAKY = None
 EMTEST_RETRY_FLAKY = None
@@ -771,7 +768,6 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     self.temp_files_before_run = []
     self.required_engine = None
     self.wasm_engines = config.WASM_ENGINES.copy()
-    self.use_all_engines = EMTEST_ALL_ENGINES
     engine = self.get_current_js_engine()
     if not engine_is_node(engine) and not engine_is_bun(engine) and not engine_is_deno(engine):
       # If our current JS engine a "shell" environment we need to explicitly enable support for
@@ -1480,21 +1476,16 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
       js_file = self.build(filename, **kwargs)
     self.assertExists(js_file)
 
-    engines = self.js_engines.copy()
-    if len(engines) > 1 and not self.use_all_engines:
-      engines = engines[:1]
+    engines = [self.get_current_js_engine()]
     # In standalone mode, also add wasm vms as we should be able to run there too.
     if self.get_setting('STANDALONE_WASM'):
-      # TODO once standalone wasm support is more stable, apply use_all_engines
-      # like with js engines, but for now as we bring it up, test in all of them
       if not self.wasm_engines:
         if 'EMTEST_SKIP_WASM_ENGINE' in os.environ:
           self.skipTest('no wasm engine was found to run the standalone part of this test')
         else:
           logger.warning('no wasm engine was found to run the standalone part of this test (Use EMTEST_SKIP_WASM_ENGINE to skip)')
       engines += self.wasm_engines
-    if len(engines) == 0:
-      self.fail('No JS engine present to run this test with. Check %s and the paths therein.' % config.EM_CONFIG)
+
     for engine in engines:
       js_output = self.run_js(js_file, engine, args,
                               input=input,

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -236,21 +236,6 @@ def crossplatform(func):
   return func
 
 
-# without EMTEST_ALL_ENGINES set we only run tests in a single VM by
-# default. in some tests we know that cross-VM differences may happen and
-# so are worth testing, and they should be marked with this decorator
-def all_engines(func):
-  assert callable(func)
-
-  @wraps(func)
-  def decorated(self, *args, **kwargs):
-    self.use_all_engines = True
-    self.set_setting('ENVIRONMENT', 'web,node,shell')
-    return func(self, *args, **kwargs)
-
-  return decorated
-
-
 # Decorator version of env_modify
 def with_env_modify(updates):
   assert not callable(updates)

--- a/test/runner.py
+++ b/test/runner.py
@@ -16,8 +16,6 @@ see
 http://kripken.github.io/emscripten-site/docs/getting_started/test-suite.html
 """
 
-# Use EMTEST_ALL_ENGINES=1 in the environment or pass --all-engines to test all engines!
-
 import argparse
 import atexit
 import datetime
@@ -140,9 +138,6 @@ def check_js_engines():
   if not all(jsrun.check_engine(e) for e in config.JS_ENGINES):
     errlog('Not all the JS engines in JS_ENGINES appear to work.')
     sys.exit(1)
-
-  if common.EMTEST_ALL_ENGINES:
-    errlog('(using ALL js engines)')
 
 
 def get_and_import_modules():
@@ -507,7 +502,6 @@ def parse_args():
                       help="Show test stdout and stderr, and don't use the single-line test reporting. "
                            'Specifying `-v` twice will enable test framework logging (i.e. EMTEST_VERBOSE)')
   parser.add_argument('--ansi', action=argparse.BooleanOptionalAction, default=None)
-  parser.add_argument('--all-engines', action='store_true')
   parser.add_argument('--detect-leaks', action='store_true')
   parser.add_argument('--skip-slow', action='store_true', help='Skip tests marked as slow')
   parser.add_argument('--cores', '-j',
@@ -559,7 +553,6 @@ def configure():
   browser_common.EMTEST_BROWSER_AUTO_CONFIG = utils.get_env_bool('EMTEST_BROWSER_AUTO_CONFIG', '1')
   browser_common.EMTEST_HEADLESS = utils.get_env_bool('EMTEST_HEADLESS')
   common.EMTEST_DETECT_TEMPFILE_LEAKS = utils.get_env_bool('EMTEST_DETECT_TEMPFILE_LEAKS')
-  common.EMTEST_ALL_ENGINES = utils.get_env_bool('EMTEST_ALL_ENGINES')
   common.EMTEST_SKIP_SLOW = utils.get_env_bool('EMTEST_SKIP_SLOW')
   common.EMTEST_SKIP_FLAKY = utils.get_env_bool('EMTEST_SKIP_FLAKY')
   common.EMTEST_RETRY_FLAKY = utils.get_env_int('EMTEST_RETRY_FLAKY')
@@ -703,7 +696,6 @@ def main():
   if options.no_clean:
     common.EMTEST_SAVE_DIR = 2
   set_env('EMTEST_SKIP_SLOW', options.skip_slow)
-  set_env('EMTEST_ALL_ENGINES', options.all_engines)
   set_env('EMTEST_REBASELINE', options.rebaseline)
   set_env('EMTEST_VERBOSE', options.verbose > 1)
   set_env('EMTEST_CORES', options.cores)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -39,7 +39,6 @@ from common import (
   test_file,
 )
 from decorators import (
-  all_engines,
   also_with_minimal_runtime,
   also_with_modularize,
   also_with_nodefs,
@@ -4374,7 +4373,6 @@ caught outer int: 123
     ''', 'other says 42.', force_c=True)
 
   @with_dylink_reversed
-  @all_engines
   def test_dylink_i64_b(self):
     self.dylink_test(r'''
       #include <stdio.h>

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -59,7 +59,6 @@ from common import (
   test_file,
 )
 from decorators import (
-  all_engines,
   also_with_asan,
   also_with_minimal_runtime,
   also_with_modularize,
@@ -1752,7 +1751,6 @@ int f() {
     self.do_runf('lib.c', '_libfunc2 is not defined', cflags=['-sEXPORT_ALL', '--pre-js', 'pre.js'], assert_returncode=NON_ZERO)
     self.do_runf('lib.c', 'libfunc\n', cflags=['-sEXPORTED_FUNCTIONS=_libfunc2', '-sEXPORT_ALL', '--pre-js', 'pre.js'])
 
-  @all_engines
   @with_all_fs
   @crossplatform
   @parameterized({
@@ -4382,7 +4380,6 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
     self.assertContained("Aborted('ptrToString' was not exported. add it to EXPORTED_RUNTIME_METHODS", err)
 
   @crossplatform
-  @all_engines
   def test_fs_stream_proto(self):
     create_file('src.c', br'''
 #include <stdio.h>
@@ -5836,7 +5833,7 @@ Creating file: /tmp/file with content of size=79
 Failed to open file for writing: /tmp/file; errno=2; Permission denied
 ''')
 
-  @all_engines
+  @crossplatform
   def test_embed_file_large(self):
     # If such long files are encoded on one line,
     # they overflow the interpreter's limit
@@ -11488,7 +11485,7 @@ int main(void) {
     # otherwise in such a trivial program).
     self.assertLess(no, 0.95 * yes)
 
-  @all_engines
+  @crossplatform
   def test_INCOMING_MODULE_JS_API(self):
     def test(args):
       self.do_runf_out_file('hello_world.c', cflags=['-O3', '--closure=1', '-sENVIRONMENT=node,shell', '--output-eol=linux'] + args)
@@ -11891,7 +11888,7 @@ int main(void) {
     # In this case the compiler does not produce any output file.
     self.assertNotExists('out.o')
 
-  @all_engines
+  @crossplatform
   def test_non_wasm_without_wasm_in_vm(self):
     create_file('pre.js', 'var WebAssembly = null;\n')
     # Test that our non-wasm output does not depend on wasm support in the vm.
@@ -12413,7 +12410,6 @@ int main () {
   @requires_wasm_eh
   def test_standalone_wasm_exceptions(self):
     self.set_setting('STANDALONE_WASM')
-    self.wasm_engines = []
     self.cflags += ['-fwasm-exceptions']
     self.set_setting('WASM_LEGACY_EXCEPTIONS', 0)
     self.do_runf_out_file('core/test_exceptions.cpp', out_suffix='_caught')


### PR DESCRIPTION
This simplifies the test runner by removing the ability to run a single test under multiple engines.

The way that out testing works today is that we run all tests (or a subset of tests such as `--crossplatform-only`) with a given engine configured.  We don't have any CI jobs, for example, that use the `--all-engines` / `EMTEST_ALL_ENGINES` feature and I can't remember the last time I used it myself.

This change is part of an effort to simplify emscripten config file.