### PR TITLE
Simplify LTO flag passing in `get_clang_flags`

### DIFF
--- a/tools/compile.py
+++ b/tools/compile.py
@@ -61,21 +61,8 @@ def get_clang_flags(user_args):
       # to be exported to other DSO's by default.
       flags.append('-fvisibility=default')
 
-  if settings.LTO:
-    if not any(a.startswith('-flto') for a in user_args):
-      flags.append('-flto=' + settings.LTO)
-    # setjmp/longjmp handling using Wasm EH
-    # For non-LTO, '-mllvm -wasm-enable-eh' added in
-    # building.llvm_backend_args() sets this feature in clang. But in LTO, the
-    # argument is added to wasm-ld instead, so clang needs to know that EH is
-    # enabled so that it can be added to the attributes in LLVM IR.
-    if settings.SUPPORT_LONGJMP == 'wasm':
-      flags.append('-mexception-handling')
-
-  else:
-    # In LTO mode these args get passed instead at link time when the backend runs.
-    for a in building.llvm_backend_args():
-      flags += ['-mllvm', a]
+  for a in building.llvm_backend_args():
+    flags += ['-mllvm', a]
 
   return flags
 


### PR DESCRIPTION
Previously, `get_clang_flags` in `tools/compile.py` handled LTO and non-LTO modes separately:
- In non-LTO mode, `building.llvm_backend_args()` was passed to `clang` via `-mllvm`.
- In LTO mode (`settings.LTO`), `building.llvm_backend_args()` was not passed to `clang` (as backend flags are passed to `wasm-ld` at link time). Instead, `-mexception-handling` was explicitly appended when `settings.SUPPORT_LONGJMP == 'wasm'` so that `clang` added `target-features=+exception-handling` to LLVM IR attributes. Also, if `-flto` was not in `user_args`, `-flto=` was appended.

This change simplifies `get_clang_flags` by unconditionally passing `building.llvm_backend_args()` to `clang` via `-mllvm` in both LTO and non-LTO modes. Because `building.llvm_backend_args()` includes `-wasm-enable-sjlj` when `settings.SUPPORT_LONGJMP == 'wasm'`, the `clang` driver automatically adds `target-features=+exception-handling` to LLVM IR, removing the need for the special `-mexception-handling` case. It also removes the fallback `-flto=` injection from `get_clang_flags`.