### PR TITLE
Fix config string parsing for windows pathnames (with backslashes)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ commands:
             echo "import os" >> .emscripten
             # We use an out-of-tree cache directory so it can be part of the
             # persisted workspace (see below).
-            echo "CACHE = os.path.expanduser('~/cache')" >> .emscripten
+            echo "CACHE = '~/cache'" >> .emscripten
             # Refer to commit 0bc3640 if we need to pin V8 version.
             echo "V8_ENGINE = '~/.jsvu/bin/v8'" >> .emscripten
             echo "JS_ENGINES = [NODE_JS]" >> .emscripten

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13271,6 +13271,7 @@ void foo() {}
     self.set_setting('EXIT_RUNTIME')
     self.do_runf('other/test_pthread_js_exception.c', 'missing is not defined', assert_returncode=NON_ZERO, cflags=['-pthread'])
 
+  @crossplatform
   def test_config_closure_compiler(self):
     self.run_process([EMCC, test_file('hello_world.c'), '--closure=1'])
     with env_modify({'EM_CLOSURE_COMPILER': sys.executable}):

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -584,7 +584,7 @@ WASMER = '~/wasmer'
     cfg_file = os.path.join(config_dir, 'custom_config')
 
     extra_config = '''
-NODE_JS = '/path/to/node --with-arg --option="hello world"'
+NODE_JS = '"/path/to/node with spaces" --with-arg --option="hello world"'
 CLOSURE_COMPILER = ['/path/to/closure', '--legacy-flag']
 '''
     create_file(cfg_file, get_basic_config() + extra_config, absolute=True)
@@ -594,7 +594,7 @@ CLOSURE_COMPILER = ['/path/to/closure', '--legacy-flag']
         return self.run_process([EMCONFIG, var_name], stdout=PIPE, stderr=PIPE)
 
       proc = get_em_config('NODE_JS')
-      self.assertEqual(proc.stdout.strip(), "['/path/to/node', '--with-arg', '--option=hello world']")
+      self.assertEqual(proc.stdout.strip(), "['/path/to/node with spaces', '--with-arg', '--option=hello world']")
 
       proc = get_em_config('CLOSURE_COMPILER')
       self.assertEqual(proc.stdout.strip(), "['/path/to/closure', '--legacy-flag']")

--- a/tools/config.py
+++ b/tools/config.py
@@ -40,7 +40,13 @@ def listify(x):
   if type(x) is list:
     logger.warning(f'Found list-style config entry ({x}).  Please use a single string with spaces between args.')
     return x
-  return shlex.split(x)
+  # Use posix=True here so that quotes are handled as expected, but clear the
+  # `escape` list so that backslashes are not treated as escape chars (which
+  # would break windows pathnames that use backslashes).
+  lexer = shlex.shlex(x, posix=True)
+  lexer.escape = []
+  lexer.whitespace_split = True
+  return list(lexer)
 
 
 def normalize_config_settings():


### PR DESCRIPTION
By using `shlex.shlex(x, posix=True)` and clearing `lexer.escape`, config
strings are parsed with POSIX quote handling while allowing Windows
paths to be specified with backslashes.

See: #27219