### PR TITLE
Remove redundant llvm args from link_lld. NFC

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -327,11 +327,6 @@ def lld_flags(args, linker_inputs=None):
   if settings.WASM_EXCEPTIONS:
     args += ['-mllvm', '-wasm-enable-eh']
   if settings.WASM_EXCEPTIONS or settings.SUPPORT_LONGJMP == 'wasm':
-    if settings.WASM_LEGACY_EXCEPTIONS:
-      args += ['-mllvm', '-wasm-use-legacy-eh']
-    else:
-      args += ['-mllvm', '-wasm-use-legacy-eh=0']
-  if settings.WASM_EXCEPTIONS or settings.SUPPORT_LONGJMP == 'wasm':
     args += ['-mllvm', '-exception-model=wasm']
 
   return args


### PR DESCRIPTION
These flags are already included in `llvm_backend_args` just above.

It looks like this duplication was added by accident in #23469