### PR TITLE
Fix warning for link-only flags that contains `=` (e.g. `--closure=1`)

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -427,7 +427,7 @@ def phase_setup(state):
             'unused-command-line-argument',
             "linker setting ignored during compilation: '%s'" % key)
     for arg in state.orig_args:
-      if arg in LINK_ONLY_FLAGS:
+      if arg.split('=')[0] in LINK_ONLY_FLAGS:
         diagnostics.warning(
             'unused-command-line-argument',
             "linker flag ignored during compilation: '%s'" % arg)

--- a/test/common.py
+++ b/test/common.py
@@ -899,7 +899,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     def is_ldflag(f):
       return f.startswith(('-l', '-sEXPORT_ES6', '-sGL_TESTING', '-sPROXY_TO_PTHREAD',
                            '-sENVIRONMENT=', '--pre-js=', '--post-js=', '-sPTHREAD_POOL_SIZE=',
-                           '--profiling-funcs'))
+                           '--profiling-funcs', '--closure'))
 
     args = self.serialize_settings(compile_only or asm_only) + self.cflags
     if asm_only:

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6940,7 +6940,7 @@ void* operator new(size_t size) {
     zlib = self.get_zlib_library(use_cmake)
 
     # example.c uses K&R style function declarations
-    self.cflags += ['-Wno-deprecated-non-prototype']
+    self.cflags += ['-Wno-deprecated-non-prototype', '-Wno-unused-command-line-argument']
     self.do_core_test('test_zlib.c', libraries=zlib, includes=[test_file('third_party/zlib')])
 
   @needs_make('make')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13106,6 +13106,10 @@ kill -9 $$
     err = self.run_process([EMCC, '--embed-file', 'file', '-c', test_file('hello_world.c')], stderr=PIPE).stderr
     self.assertContained("warning: linker flag ignored during compilation: '--embed-file' [-Wunused-command-line-argument]", err)
 
+    # Also test for the format that includes an =arg suffix
+    err = self.run_process([EMCC, '--embed-file=file', '-c', test_file('hello_world.c')], stderr=PIPE).stderr
+    self.assertContained("warning: linker flag ignored during compilation: '--embed-file=file' [-Wunused-command-line-argument]", err)
+
   def test_no_deprecated(self):
     # Test that -Wno-deprecated is passed on to clang driver
     create_file('test.c', '''\


### PR DESCRIPTION
I noticed this oversight while implementing the native launcher in #27401 