### PR TITLE
Fix embind exports with MODULARIZE=instance and AUTO_INIT

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -2402,7 +2402,12 @@ addToLibrary({
     ATPOSTCTORS.unshift('callRuntimeCallbacks(onPostCtors);');
   },
   $addOnPostCtor__deps: ['$onPostCtors'],
-  $addOnPostCtor: (cb) => onPostCtors.push(cb),
+  $addOnPostCtor: (cb) => {
+#if ASSERTIONS
+    assert(!runtimeInitialized, 'addOnPostCtor called too late: ctors have already run');
+#endif
+    onPostCtors.push(cb);
+  },
   // See ATMAINS in parseTools.mjs for more information.
   $onMains: [],
   $onMains__internal: true,

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -244,6 +244,11 @@ var wasmRawExports;
 #endif
 
 #if MODULARIZE == 'instance'
+#if EMBIND_AOT
+// The embind exports are declared here so that their post-ctor registration
+// precedes any self-initialization below.  See phase_embind_aot in link.py.
+<<< EMBIND_AOT_EXPORTS >>>
+#endif
 // In MODULARIZE=instance mode we delay most of the initialization work until
 // the `init` function is called.
 #if ASSERTIONS

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6273,6 +6273,25 @@ int main(void) {
 
     self.assertContained('main1\nmain2\nfoo\nbar\nbaz\n', self.run_js('runner.mjs'))
 
+  def test_modularize_instance_auto_init_embind(self):
+    # Embind exports must be assigned when the module self-initializes on
+    # import.  See https://github.com/emscripten-core/emscripten/issues/27411
+    self.run_process([EMXX, test_file('modularize_instance_embind.cpp'),
+                      '-sMODULARIZE=instance', '-sAUTO_INIT',
+                      '-Wno-experimental',
+                      '-lembind', '-sEMBIND_AOT',
+                      '-o', 'modularize_instance_embind.mjs'] + self.get_cflags())
+
+    create_file('runner.mjs', '''
+      import { foo, Bar } from "./modularize_instance_embind.mjs";
+      foo();
+      const bar = new Bar();
+      bar.print();
+      bar.delete();
+    ''')
+
+    self.assertContained('main\nfoo\nbar\n', self.run_js('runner.mjs'))
+
   @also_with_pthreads
   @requires_node_25
   def test_esm_integration_auto_init(self):

--- a/tools/link.py
+++ b/tools/link.py
@@ -2126,7 +2126,7 @@ function assignEmbindExports() {{ {assigns} }};
 addOnPostCtor(assignEmbindExports);
 {decls}
 // end embind exports'''
-    src += exports
+    src = do_replace(src, '<<< EMBIND_AOT_EXPORTS >>>', exports)
   write_file(final_js, src)
   if settings.WASM_ESM_INTEGRATION:
     # With ESM integration the embind exports also need to be exported by the main file.


### PR DESCRIPTION
This fixes embind ES module exports being `undefined` when using `-sMODULARIZE=instance -sAUTO_INIT -sEMBIND_AOT`, resolves #27411.

With AUTO_INIT the module self-initializes via top-level `await init()` in the postamble, but the embind AOT export snippet was appended after the postamble. Its `addOnPostCtor(assignEmbindExports)` therefore registered only after `onPostCtors` had already fired during init, so the export assignments never ran.

Following review feedback, rather than supporting late registration, the snippet is now emitted via a `<<< EMBIND_AOT_EXPORTS >>>` placeholder at the start of the MODULARIZE=instance postamble (same mechanism as `EMBIND_AOT_INVOKERS`), so registration always precedes initialization. `addOnPostCtor` additionally asserts under ASSERTIONS that it is not called after ctors have run, rather than silently never firing.

Adds `other.test_modularize_instance_auto_init_embind` reusing `modularize_instance_embind.cpp`, verified to fail before the fix and pass after; existing modularize=instance, ESM integration, dylink and codesize tests still pass (also manually verified WASM_ESM_INTEGRATION + AUTO_INIT + EMBIND_AOT under node 26).

_Made with AI assistance under my review_