### PR TITLE
Fix missing $_emscriptenWasmWorkerPolicy dependency in wasm workers

### DIFF
--- a/src/lib/libwasm_worker.js
+++ b/src/lib/libwasm_worker.js
@@ -173,6 +173,9 @@ addToLibrary({
   _emscripten_create_wasm_worker__deps: [
     '$_wasmWorkers',
     '$_wasmWorkerAppendToQueue', '$_wasmWorkerRunPostMessage',
+#if TRUSTED_TYPES
+    '$_emscriptenWasmWorkerPolicy',
+#endif
 #if ASSERTIONS
     'emscripten_has_threading_support',
 #endif


### PR DESCRIPTION
Add `$_emscriptenWasmWorkerPolicy` to the `_emscripten_create_wasm_worker__deps` array to prevent it from being stripped during compilation. This fixes a runtime ReferenceError when creating Wasm workers with Trusted Types enabled.