### PR TITLE
Revert #27397: Use shlex.split for executables in config file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 6.0.5 (in development)
 ----------------------
+- Revert #27397, which changed the way config keys such as NODE_JS were parsed
+  when reading the config file.  This change broke emsdk installations that
+  contained spaces. (#27421)
 
 6.0.4 - 07/24/26
 ----------------

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -584,7 +584,7 @@ WASMER = '~/wasmer'
     cfg_file = os.path.join(config_dir, 'custom_config')
 
     extra_config = '''
-NODE_JS = '"/path/to/node with spaces" --with-arg --option="hello world"'
+NODE_JS = '/path/to/node with spaces'
 CLOSURE_COMPILER = ['/path/to/closure', '--legacy-flag']
 '''
     create_file(cfg_file, get_basic_config() + extra_config, absolute=True)
@@ -594,11 +594,10 @@ CLOSURE_COMPILER = ['/path/to/closure', '--legacy-flag']
         return self.run_process([EMCONFIG, var_name], stdout=PIPE, stderr=PIPE)
 
       proc = get_em_config('NODE_JS')
-      self.assertEqual(proc.stdout.strip(), "['/path/to/node with spaces', '--with-arg', '--option=hello world']")
+      self.assertEqual(proc.stdout.strip(), "['/path/to/node with spaces']")
 
       proc = get_em_config('CLOSURE_COMPILER')
       self.assertEqual(proc.stdout.strip(), "['/path/to/closure', '--legacy-flag']")
-      self.assertContained('Found list-style config entry', proc.stderr)
 
   def test_emcc_ports(self):
     restore_and_set_up()

--- a/tools/config.py
+++ b/tools/config.py
@@ -5,7 +5,6 @@
 
 import logging
 import os
-import shlex
 import shutil
 import sys
 
@@ -35,18 +34,9 @@ EM_CONFIG = None
 
 
 def listify(x):
-  if x is None:
+  if x is None or type(x) is list:
     return x
-  if type(x) is list:
-    logger.warning(f'Found list-style config entry ({x}).  Please use a single string with spaces between args.')
-    return x
-  # Use posix=True here so that quotes are handled as expected, but clear the
-  # `escape` list so that backslashes are not treated as escape chars (which
-  # would break windows pathnames that use backslashes).
-  lexer = shlex.shlex(x, posix=True)
-  lexer.escape = []
-  lexer.whitespace_split = True
-  return list(lexer)
+  return [x]
 
 
 def normalize_config_settings():


### PR DESCRIPTION
This ended up breaking emsdk in ways that would require more complexity to fix.  See https://github.com/emscripten-core/emsdk/issues/1752.

This issue is that if emsdk is installed in the path contains spaces the NODE_JS path, for example, then needs to be quoted correctly in the config file.  e.g. `NODE_JS = '"path with spaces/bin/node"'.

Instead I think we should just revert this change.  It turns out not to be needed for #27401 anyway since the LLVM_ROOT is never a list anyway.