### PR TITLE
Add AF_UNIX named (pathname) stream socket support under NODERAWSOCKETS

### DIFF
--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -822,7 +822,11 @@ addToLibrary({
     return str;
   },
 
-  $readSockaddr__deps: ['$inetNtop4', '$inetNtop6', 'ntohs'],
+  $readSockaddr__deps: ['$inetNtop4', '$inetNtop6', 'ntohs'
+#if NODERAWSOCKETS
+    , '$UTF8ArrayToString'
+#endif
+  ],
   $readSockaddr: (sa, salen) => {
     // family / port offsets are common to both sockaddr_in and sockaddr_in6
     var family = {{{ makeGetValue('sa', C_STRUCTS.sockaddr_in.sin_family, 'i16') }}};
@@ -830,6 +834,26 @@ addToLibrary({
     var addr;
 
     switch (family) {
+#if NODERAWSOCKETS
+      case {{{ cDefs.AF_UNIX }}}: {
+        // sun_path runs from offsetof(sun_path) to salen. An address of only the
+        // family (salen <= offset) is the unnamed/autobind case -> empty path. A
+        // leading NUL marks the Linux abstract namespace; keep the NUL so the
+        // path round-trips and never collides with a filesystem path.
+        var pathStart = sa + {{{ C_STRUCTS.sockaddr_un.sun_path }}};
+        var pathLen = salen - {{{ C_STRUCTS.sockaddr_un.sun_path }}};
+        var path = '';
+        if (pathLen > 0) {
+          if (HEAPU8[pathStart] === 0) {
+            path = '\0' + UTF8ArrayToString(HEAPU8, pathStart + 1, pathLen - 1, /*ignoreNul=*/true);
+          } else {
+            // A pathname address is NUL-terminated; stop at the first NUL.
+            path = UTF8ArrayToString(HEAPU8, pathStart, pathLen);
+          }
+        }
+        return { family, addr: path, port: 0 };
+      }
+#endif
       case {{{ cDefs.AF_INET }}}:
         if (salen !== {{{ C_STRUCTS.sockaddr_in.__size__ }}}) {
           return { errno: {{{ cDefs.EINVAL }}} };
@@ -856,9 +880,39 @@ addToLibrary({
     return { family: family, addr: addr, port: port };
   },
   $writeSockaddr__docs: '/** @param {number=} addrlen */',
-  $writeSockaddr__deps: ['$inetPton4', '$inetPton6', '$zeroMemory', 'htons'],
+  $writeSockaddr__deps: ['$inetPton4', '$inetPton6', '$zeroMemory', 'htons'
+#if NODERAWSOCKETS
+    , '$lengthBytesUTF8', '$stringToUTF8Array'
+#endif
+  ],
   $writeSockaddr: (sa, family, addr, port, addrlen) => {
     switch (family) {
+#if NODERAWSOCKETS
+      case {{{ cDefs.AF_UNIX }}}: {
+        // addr is the JS path string produced by readSockaddr: a leading '\0'
+        // marks the abstract namespace (its bytes are written verbatim, no NUL
+        // terminator), any other path is written NUL-terminated. An empty path
+        // is the unnamed address (family only).
+        addr ||= '';
+        var abstract = addr.charCodeAt(0) === 0;
+        // Pathname addresses include the trailing NUL in the reported length;
+        // abstract addresses do not; an empty address is family-only (unnamed).
+        var bytes = addr ? lengthBytesUTF8(addr) + (abstract ? 0 : 1) : 0;
+        var total = {{{ C_STRUCTS.sockaddr_un.sun_path }}} + bytes;
+        zeroMemory(sa, total);
+        {{{ makeSetValue('sa', C_STRUCTS.sockaddr_un.sun_family, 'family', 'i16') }}};
+        if (addr) {
+          // stringToUTF8Array NUL-terminates and needs room for it, so hand it a
+          // budget one past the path bytes; the terminating NUL lands on the
+          // zeroed byte just past the reported length and is harmless.
+          stringToUTF8Array(addr, HEAPU8, sa + {{{ C_STRUCTS.sockaddr_un.sun_path }}}, bytes + 1);
+        }
+        if (addrlen) {
+          {{{ makeSetValue('addrlen', 0, 'total', 'i32') }}};
+        }
+        break;
+      }
+#endif
       case {{{ cDefs.AF_INET }}}:
         addr = inetPton4(addr);
         zeroMemory(sa, {{{ C_STRUCTS.sockaddr_in.__size__ }}});

--- a/src/lib/libcore.js
+++ b/src/lib/libcore.js
@@ -824,7 +824,7 @@ addToLibrary({
 
   $readSockaddr__deps: ['$inetNtop4', '$inetNtop6', 'ntohs'
 #if NODERAWSOCKETS
-    , '$UTF8ArrayToString'
+    , '$UTF8ToString'
 #endif
   ],
   $readSockaddr: (sa, salen) => {
@@ -845,10 +845,10 @@ addToLibrary({
         var path = '';
         if (pathLen > 0) {
           if (HEAPU8[pathStart] === 0) {
-            path = '\0' + UTF8ArrayToString(HEAPU8, pathStart + 1, pathLen - 1, /*ignoreNul=*/true);
+            path = '\0' + UTF8ToString(pathStart + 1, pathLen - 1, /*ignoreNul=*/true);
           } else {
             // A pathname address is NUL-terminated; stop at the first NUL.
-            path = UTF8ArrayToString(HEAPU8, pathStart, pathLen);
+            path = UTF8ToString(pathStart, pathLen);
           }
         }
         return { family, addr: path, port: 0 };
@@ -880,9 +880,9 @@ addToLibrary({
     return { family: family, addr: addr, port: port };
   },
   $writeSockaddr__docs: '/** @param {number=} addrlen */',
-  $writeSockaddr__deps: ['$inetPton4', '$inetPton6', '$zeroMemory', 'htons'
+  $writeSockaddr__deps: ['$inetPton4', '$inetPton6', '$zeroMemory', '$DNS', 'htons'
 #if NODERAWSOCKETS
-    , '$lengthBytesUTF8', '$stringToUTF8Array'
+    , '$lengthBytesUTF8', '$stringToUTF8'
 #endif
   ],
   $writeSockaddr: (sa, family, addr, port, addrlen) => {
@@ -902,10 +902,10 @@ addToLibrary({
         zeroMemory(sa, total);
         {{{ makeSetValue('sa', C_STRUCTS.sockaddr_un.sun_family, 'family', 'i16') }}};
         if (addr) {
-          // stringToUTF8Array NUL-terminates and needs room for it, so hand it a
+          // stringToUTF8 NUL-terminates and needs room for it, so hand it a
           // budget one past the path bytes; the terminating NUL lands on the
           // zeroed byte just past the reported length and is harmless.
-          stringToUTF8Array(addr, HEAPU8, sa + {{{ C_STRUCTS.sockaddr_un.sun_path }}}, bytes + 1);
+          stringToUTF8(addr, sa + {{{ C_STRUCTS.sockaddr_un.sun_path }}}, bytes + 1);
         }
         if (addrlen) {
           {{{ makeSetValue('addrlen', 0, 'total', 'i32') }}};
@@ -914,7 +914,10 @@ addToLibrary({
       }
 #endif
       case {{{ cDefs.AF_INET }}}:
-        addr = inetPton4(addr);
+        // The address may still be an unresolved hostname (e.g. a peer name
+        // recorded at connect time); map it to its (possibly fake) IP here so
+        // callers can pass names and IPs alike.
+        addr = inetPton4(DNS.lookup_name(addr));
         zeroMemory(sa, {{{ C_STRUCTS.sockaddr_in.__size__ }}});
         if (addrlen) {
           {{{ makeSetValue('addrlen', 0, C_STRUCTS.sockaddr_in.__size__, 'i32') }}};
@@ -924,7 +927,7 @@ addToLibrary({
         {{{ makeSetValue('sa', C_STRUCTS.sockaddr_in.sin_port, '_htons(port)', 'i16') }}};
         break;
       case {{{ cDefs.AF_INET6 }}}:
-        addr = inetPton6(addr);
+        addr = inetPton6(DNS.lookup_name(addr));
         zeroMemory(sa, {{{ C_STRUCTS.sockaddr_in6.__size__ }}});
         if (addrlen) {
           {{{ makeSetValue('addrlen', 0, C_STRUCTS.sockaddr_in6.__size__, 'i32') }}};

--- a/src/lib/libsockfs.js
+++ b/src/lib/libsockfs.js
@@ -64,6 +64,14 @@ addToLibrary({
 #if NODERAWSOCKETS
           // The node:net backend supports IPv6; other backends are IPv4 only.
           && family != {{{ cDefs.AF_INET6 }}}
+#if NODERAWFS
+          // AF_UNIX stream sockets are backed by node's named pipes, and their
+          // paths live in the host filesystem. That only stays coherent with the
+          // program's own file syscalls (bind's parent dir, getsockname, unlink)
+          // under NODERAWFS, so the family is gated behind it - MEMFS paths are a
+          // disjoint namespace and would fail confusingly.
+          && family != {{{ cDefs.AF_UNIX }}}
+#endif
 #endif
          ) {
         throw new FS.ErrnoError({{{ cDefs.EAFNOSUPPORT }}});
@@ -73,8 +81,20 @@ addToLibrary({
       if (type != {{{ cDefs.SOCK_STREAM }}} && type != {{{ cDefs.SOCK_DGRAM }}}) {
         throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
       }
+#if NODERAWSOCKETS && NODERAWFS
+      // node has no AF_UNIX datagram primitive; only stream unix sockets exist.
+      if (family == {{{ cDefs.AF_UNIX }}} && type != {{{ cDefs.SOCK_STREAM }}}) {
+        throw new FS.ErrnoError({{{ cDefs.EPROTONOSUPPORT }}});
+      }
+#endif
       var streaming = type == {{{ cDefs.SOCK_STREAM }}};
-      if (streaming && protocol && protocol != {{{ cDefs.IPPROTO_TCP }}}) {
+      // The IPPROTO_TCP protocol guard only applies to INET stream sockets; unix
+      // stream sockets use protocol 0.
+      if (streaming && protocol && protocol != {{{ cDefs.IPPROTO_TCP }}}
+#if NODERAWSOCKETS && NODERAWFS
+          && family != {{{ cDefs.AF_UNIX }}}
+#endif
+         ) {
         throw new FS.ErrnoError({{{ cDefs.EPROTONOSUPPORT }}}); // if SOCK_STREAM, must be tcp or 0.
       }
 

--- a/src/lib/libsockfs_node.js
+++ b/src/lib/libsockfs_node.js
@@ -156,6 +156,52 @@ var NodeSockFSLibrary = {
       try { handle.close(); } catch (e) {}
       throw new FS.ErrnoError(nodeSockHelpers.codeToErrno(code));
     },
+    // AF_UNIX stream sockets bind through net.BoundSocket when node offers a
+    // path-capable one, else the private pipe_wrap binding - the same
+    // public-then-private choice bindHandle() makes for TCP (BoundSocket else
+    // tcp_wrap). The capability signal is the presence of the `isPipe` accessor
+    // on the prototype (a { path } bind reports isPipe true). Chosen once, like
+    // useBoundSocket().
+    useBoundPipe() {
+      var BoundSocket = nodeSockHelpers.getNet().BoundSocket;
+      return nodeSockHelpers.boundPipeOk ??= !!(BoundSocket && 'isPipe' in BoundSocket.prototype);
+    },
+    getPipe() {
+      if (nodeSockHelpers.pipeModule) return nodeSockHelpers.pipeModule;
+      try {
+        return nodeSockHelpers.pipeModule = process.binding('pipe_wrap');
+      } catch (e) {
+        throw new FS.ErrnoError({{{ cDefs.EOPNOTSUPP }}});
+      }
+    },
+    // Synchronously bind an AF_UNIX stream socket to a filesystem path,
+    // reserving the entry (EADDRINUSE if already in use) exactly when POSIX
+    // bind() would, and record the path. sock.bound is the resulting bound
+    // handle - a net.BoundSocket or a raw pipe_wrap Pipe - adopted as-is by
+    // listen() (server.listen). node reports no name back for a pipe, so the
+    // path we store here is authoritative for getsockname().
+    bindPipe(sock, path) {
+      if (nodeSockHelpers.useBoundPipe()) {
+        // The constructor binds synchronously and throws a conflict
+        // (EADDRINUSE etc.) right here, matching POSIX bind().
+        try {
+          var bh = new (nodeSockHelpers.getNet().BoundSocket)({ path });
+        }
+        catch (e) { throw new FS.ErrnoError(nodeSockHelpers.nodeErrToErrno(e)); }
+        sock.bound = bh;
+        sock.saddr = path;
+        return;
+      }
+      var pipe = nodeSockHelpers.getPipe();
+      var handle = new pipe.Pipe(pipe.constants.SERVER);
+      var code = handle.bind(path);
+      if (code) {
+        try { handle.close(); } catch (e) {}
+        throw new FS.ErrnoError(nodeSockHelpers.codeToErrno(code));
+      }
+      sock.bound = handle;
+      sock.saddr = path;
+    },
     // The peer address is already a numeric IP (emscripten resolves names in
     // its own DNS layer), so skip node's async DNS lookup. The family follows
     // the literal: a colon means IPv6.
@@ -432,6 +478,13 @@ var NodeSockFSLibrary = {
       if (sock.saddr !== undefined || sock.sport !== undefined) {
         throw new FS.ErrnoError({{{ cDefs.EINVAL }}}); // already bound
       }
+      if (sock.family === {{{ cDefs.AF_UNIX }}}) {
+        // addr is a filesystem path (or an abstract '\0...' name). Bind
+        // synchronously so EADDRINUSE surfaces here and getsockname() works.
+        nodeSockHelpers.bindPipe(sock, addr);
+        sock.state = {{{ SOCK_STATE_BOUND }}};
+        return;
+      }
       if (sock.type === {{{ cDefs.SOCK_DGRAM }}}) {
         var udp = nodeSockHelpers.ensureUdpHandle(sock);
         if (sock.udpPublic) {
@@ -462,6 +515,29 @@ var NodeSockFSLibrary = {
       sock.state = {{{ SOCK_STATE_BOUND }}};
     },
     connect(sock, addr, port) {
+      if (sock.family === {{{ cDefs.AF_UNIX }}}) {
+        if (sock.server) throw new FS.ErrnoError({{{ cDefs.EOPNOTSUPP }}});
+        if (sock.connection) {
+          throw new FS.ErrnoError(sock.state === {{{ SOCK_STATE_CONNECTING }}} ? {{{ cDefs.EALREADY }}} : {{{ cDefs.EISCONN }}});
+        }
+        // addr is the peer path. node reports no name back, so record it as the
+        // peer name ourselves; the local end is unnamed unless bind() named it.
+        sock.daddr = addr;
+        sock.state = {{{ SOCK_STATE_CONNECTING }}};
+        var uconn = new (nodeSockHelpers.getNet().Socket)({ allowHalfOpen: true });
+        uconn.once('connect', () => {
+          sock.state = {{{ SOCK_STATE_CONNECTED }}};
+          sock.saddr ??= '';
+          try { uconn.resume(); } catch (e) {}
+          SOCKFS.emit('open', sock.stream.fd);
+        });
+        // A missing path surfaces as ENOENT and a non-socket path as
+        // ECONNREFUSED, both through wireConnection's 'error' handler and the
+        // same SO_ERROR/poll seam as TCP.
+        nodeSockHelpers.wireConnection(sock, uconn);
+        uconn.connect({ path: addr });
+        return;
+      }
       if (sock.type === {{{ cDefs.SOCK_DGRAM }}}) {
         sock.daddr = addr;
         sock.dport = port;
@@ -521,10 +597,15 @@ var NodeSockFSLibrary = {
       if (sock.type !== {{{ cDefs.SOCK_STREAM }}}) throw new FS.ErrnoError({{{ cDefs.EOPNOTSUPP }}}); // not a stream socket
       if (sock.server) throw new FS.ErrnoError({{{ cDefs.EINVAL }}}); // already listening
       if (sock.connection) throw new FS.ErrnoError({{{ cDefs.EINVAL }}}); // a connected socket cannot listen
-      // POSIX listen without a prior bind auto-binds an ephemeral port. The bind
-      // is eager and synchronous (bindHandle), so the assigned port is known and
-      // any conflict surfaces before we listen.
-      if (!sock.bound) {
+      // AF_UNIX has no autobind for listen(): the socket must have been named by
+      // a prior bind() (which produced the bound Pipe handle we listen on).
+      var isUnix = sock.family === {{{ cDefs.AF_UNIX }}};
+      if (isUnix) {
+        if (!sock.bound) throw new FS.ErrnoError({{{ cDefs.EINVAL }}});
+      } else if (!sock.bound) {
+        // POSIX listen without a prior bind auto-binds an ephemeral port. The
+        // bind is eager and synchronous (bindHandle), so the assigned port is
+        // known and any conflict surfaces before we listen.
         nodeSockHelpers.bindHandle(sock, '0.0.0.0', 0);
         sock.state = {{{ SOCK_STATE_BOUND }}};
       }
@@ -534,10 +615,17 @@ var NodeSockFSLibrary = {
       server.on('connection', (conn) => {
         var newsock = SOCKFS.createSocket(sock.family, sock.type, sock.protocol);
         newsock.state = {{{ SOCK_STATE_CONNECTED }}};
-        newsock.saddr = conn.localAddress;
-        newsock.sport = conn.localPort;
-        newsock.daddr = conn.remoteAddress;
-        newsock.dport = conn.remotePort;
+        if (isUnix) {
+          // node reports no name for a pipe: the accepted socket's local name is
+          // the listener's path, the peer is unnamed (the client rarely binds).
+          newsock.saddr = sock.saddr;
+          newsock.daddr = '';
+        } else {
+          newsock.saddr = conn.localAddress;
+          newsock.sport = conn.localPort;
+          newsock.daddr = conn.remoteAddress;
+          newsock.dport = conn.remotePort;
+        }
         nodeSockHelpers.wireConnection(newsock, conn);
         try { conn.resume(); } catch (e) {} // paused by pauseOnConnect
         sock.pending.push(newsock);

--- a/src/lib/libsockfs_node.js
+++ b/src/lib/libsockfs_node.js
@@ -167,12 +167,14 @@ var NodeSockFSLibrary = {
       return nodeSockHelpers.boundPipeOk ??= !!(BoundSocket && 'isPipe' in BoundSocket.prototype);
     },
     getPipe() {
-      if (nodeSockHelpers.pipeModule) return nodeSockHelpers.pipeModule;
-      try {
-        return nodeSockHelpers.pipeModule = process.binding('pipe_wrap');
-      } catch (e) {
-        throw new FS.ErrnoError({{{ cDefs.EOPNOTSUPP }}});
+      if (!nodeSockHelpers.pipeModule) {
+        try {
+          nodeSockHelpers.pipeModule = process.binding('pipe_wrap');
+        } catch (e) {
+          throw new FS.ErrnoError({{{ cDefs.EOPNOTSUPP }}});
+        }
       }
+      return nodeSockHelpers.pipeModule;
     },
     // Synchronously bind an AF_UNIX stream socket to a filesystem path,
     // reserving the entry (EADDRINUSE if already in use) exactly when POSIX

--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -344,6 +344,10 @@ var SyscallsLibrary = {
   $getSocketAddress: (addrp, addrlen) => {
     var info = readSockaddr(addrp, addrlen);
     if (info.errno) throw new FS.ErrnoError(info.errno);
+#if NODERAWSOCKETS
+    // AF_UNIX addresses are filesystem paths, not IP names; pass them verbatim.
+    if (info.family != {{{ cDefs.AF_UNIX }}})
+#endif
     info.addr = DNS.lookup_addr(info.addr) || info.addr;
 #if SYSCALL_DEBUG
     dbg(`    (socketaddress: "${[info.addr, info.port]}")`);
@@ -358,6 +362,14 @@ var SyscallsLibrary = {
   __syscall_getsockname__deps: ['$getSocketFromFD', '$writeSockaddr', '$DNS'],
   __syscall_getsockname: (fd, addr, len, u1, u2, u3) => {
     var sock = getSocketFromFD(fd);
+#if NODERAWSOCKETS
+    if (sock.family == {{{ cDefs.AF_UNIX }}}) {
+      // AF_UNIX names are filesystem paths; report the bound path verbatim (an
+      // unbound socket is unnamed -> family-only address).
+      writeSockaddr(addr, sock.family, sock.saddr || '', 0, len);
+      return 0;
+    }
+#endif
     // TODO: sock.saddr should never be undefined, see TODO in websocket_sock_ops.getname
     var errno = writeSockaddr(addr, sock.family, DNS.lookup_name(sock.saddr || '0.0.0.0'), sock.sport, len);
 #if ASSERTIONS
@@ -368,6 +380,17 @@ var SyscallsLibrary = {
   __syscall_getpeername__deps: ['$getSocketFromFD', '$writeSockaddr', '$DNS'],
   __syscall_getpeername: (fd, addr, len, u1, u2, u3) => {
     var sock = getSocketFromFD(fd);
+#if NODERAWSOCKETS
+    if (sock.family == {{{ cDefs.AF_UNIX }}}) {
+      // A connected AF_UNIX socket has daddr set (possibly '' for an unnamed
+      // peer, e.g. a socketpair end); an unconnected one has it undefined.
+      if (sock.daddr === undefined) {
+        return -{{{ cDefs.ENOTCONN }}};
+      }
+      writeSockaddr(addr, sock.family, sock.daddr, 0, len);
+      return 0;
+    }
+#endif
     if (!sock.daddr) {
       return -{{{ cDefs.ENOTCONN }}}; // The socket is not connected.
     }
@@ -398,10 +421,17 @@ var SyscallsLibrary = {
     var sock = getSocketFromFD(fd);
     var newsock = sock.sock_ops.accept(sock);
     if (addr) {
-      var errno = writeSockaddr(addr, newsock.family, DNS.lookup_name(newsock.daddr), newsock.dport, len);
-#if ASSERTIONS
-      assert(!errno);
+#if NODERAWSOCKETS
+      if (newsock.family == {{{ cDefs.AF_UNIX }}}) {
+        writeSockaddr(addr, newsock.family, newsock.daddr || '', 0, len);
+      } else
 #endif
+      {
+        var errno = writeSockaddr(addr, newsock.family, DNS.lookup_name(newsock.daddr), newsock.dport, len);
+#if ASSERTIONS
+        assert(!errno);
+#endif
+      }
     }
     return newsock.stream.fd;
   },
@@ -424,10 +454,17 @@ var SyscallsLibrary = {
     var msg = sock.sock_ops.recvmsg(sock, len, flags);
     if (!msg) return 0; // socket is closed
     if (addr) {
-      var errno = writeSockaddr(addr, sock.family, DNS.lookup_name(msg.addr), msg.port, alen);
-#if ASSERTIONS
-      assert(!errno);
+#if NODERAWSOCKETS
+      if (sock.family == {{{ cDefs.AF_UNIX }}}) {
+        writeSockaddr(addr, sock.family, msg.addr || '', 0, alen);
+      } else
 #endif
+      {
+        var errno = writeSockaddr(addr, sock.family, DNS.lookup_name(msg.addr), msg.port, alen);
+#if ASSERTIONS
+        assert(!errno);
+#endif
+      }
     }
     HEAPU8.set(msg.buffer, buf);
     return msg.buffer.byteLength;
@@ -531,10 +568,17 @@ var SyscallsLibrary = {
     var name = {{{ makeGetValue('message', C_STRUCTS.msghdr.msg_name, '*') }}};
     if (name) {
       var namelen = message + {{{ C_STRUCTS.msghdr.msg_namelen }}};
-      var errno = writeSockaddr(name, sock.family, DNS.lookup_name(msg.addr), msg.port, namelen);
-#if ASSERTIONS
-      assert(!errno);
+#if NODERAWSOCKETS
+      if (sock.family == {{{ cDefs.AF_UNIX }}}) {
+        writeSockaddr(name, sock.family, msg.addr || '', 0, namelen);
+      } else
 #endif
+      {
+        var errno = writeSockaddr(name, sock.family, DNS.lookup_name(msg.addr), msg.port, namelen);
+#if ASSERTIONS
+        assert(!errno);
+#endif
+      }
     }
     // write the buffer out to the scatter-gather arrays
     var bytesRead = 0;

--- a/src/lib/libsyscall.js
+++ b/src/lib/libsyscall.js
@@ -359,42 +359,36 @@ var SyscallsLibrary = {
     var sock = SOCKFS.createSocket(domain, type, protocol);
     return sock.stream.fd;
   },
-  __syscall_getsockname__deps: ['$getSocketFromFD', '$writeSockaddr', '$DNS'],
+  __syscall_getsockname__deps: ['$getSocketFromFD', '$writeSockaddr'],
   __syscall_getsockname: (fd, addr, len, u1, u2, u3) => {
     var sock = getSocketFromFD(fd);
 #if NODERAWSOCKETS
-    if (sock.family == {{{ cDefs.AF_UNIX }}}) {
-      // AF_UNIX names are filesystem paths; report the bound path verbatim (an
-      // unbound socket is unnamed -> family-only address).
-      writeSockaddr(addr, sock.family, sock.saddr || '', 0, len);
-      return 0;
-    }
+    // An unbound AF_UNIX socket is unnamed (family-only address), not a
+    // wildcard IP.
+    var defaultAddr = sock.family == {{{ cDefs.AF_UNIX }}} ? '' : '0.0.0.0';
+#else
+    var defaultAddr = '0.0.0.0';
 #endif
     // TODO: sock.saddr should never be undefined, see TODO in websocket_sock_ops.getname
-    var errno = writeSockaddr(addr, sock.family, DNS.lookup_name(sock.saddr || '0.0.0.0'), sock.sport, len);
+    var errno = writeSockaddr(addr, sock.family, sock.saddr || defaultAddr, sock.sport, len);
 #if ASSERTIONS
     assert(!errno);
 #endif
     return 0;
   },
-  __syscall_getpeername__deps: ['$getSocketFromFD', '$writeSockaddr', '$DNS'],
+  __syscall_getpeername__deps: ['$getSocketFromFD', '$writeSockaddr'],
   __syscall_getpeername: (fd, addr, len, u1, u2, u3) => {
     var sock = getSocketFromFD(fd);
 #if NODERAWSOCKETS
-    if (sock.family == {{{ cDefs.AF_UNIX }}}) {
-      // A connected AF_UNIX socket has daddr set (possibly '' for an unnamed
-      // peer, e.g. a socketpair end); an unconnected one has it undefined.
-      if (sock.daddr === undefined) {
-        return -{{{ cDefs.ENOTCONN }}};
-      }
-      writeSockaddr(addr, sock.family, sock.daddr, 0, len);
-      return 0;
-    }
-#endif
+    // '' is a valid connected-but-unnamed AF_UNIX peer (e.g. an accepted
+    // connection's client), so only undefined means not connected there.
+    if (sock.family == {{{ cDefs.AF_UNIX }}} ? sock.daddr === undefined : !sock.daddr) {
+#else
     if (!sock.daddr) {
+#endif
       return -{{{ cDefs.ENOTCONN }}}; // The socket is not connected.
     }
-    var errno = writeSockaddr(addr, sock.family, DNS.lookup_name(sock.daddr), sock.dport, len);
+    var errno = writeSockaddr(addr, sock.family, sock.daddr, sock.dport, len);
 #if ASSERTIONS
     assert(!errno);
 #endif
@@ -416,22 +410,15 @@ var SyscallsLibrary = {
     return -{{{ cDefs.ENOSYS }}}; // unsupported feature
 #endif
   },
-  __syscall_accept4__deps: ['$getSocketFromFD', '$writeSockaddr', '$DNS'],
+  __syscall_accept4__deps: ['$getSocketFromFD', '$writeSockaddr'],
   __syscall_accept4: (fd, addr, len, flags, u1, u2) => {
     var sock = getSocketFromFD(fd);
     var newsock = sock.sock_ops.accept(sock);
     if (addr) {
-#if NODERAWSOCKETS
-      if (newsock.family == {{{ cDefs.AF_UNIX }}}) {
-        writeSockaddr(addr, newsock.family, newsock.daddr || '', 0, len);
-      } else
-#endif
-      {
-        var errno = writeSockaddr(addr, newsock.family, DNS.lookup_name(newsock.daddr), newsock.dport, len);
+      var errno = writeSockaddr(addr, newsock.family, newsock.daddr, newsock.dport, len);
 #if ASSERTIONS
-        assert(!errno);
+      assert(!errno);
 #endif
-      }
     }
     return newsock.stream.fd;
   },
@@ -448,23 +435,16 @@ var SyscallsLibrary = {
     sock.sock_ops.listen(sock, backlog);
     return 0;
   },
-  __syscall_recvfrom__deps: ['$getSocketFromFD', '$writeSockaddr', '$DNS'],
+  __syscall_recvfrom__deps: ['$getSocketFromFD', '$writeSockaddr'],
   __syscall_recvfrom: (fd, buf, len, flags, addr, alen) => {
     var sock = getSocketFromFD(fd);
     var msg = sock.sock_ops.recvmsg(sock, len, flags);
     if (!msg) return 0; // socket is closed
     if (addr) {
-#if NODERAWSOCKETS
-      if (sock.family == {{{ cDefs.AF_UNIX }}}) {
-        writeSockaddr(addr, sock.family, msg.addr || '', 0, alen);
-      } else
-#endif
-      {
-        var errno = writeSockaddr(addr, sock.family, DNS.lookup_name(msg.addr), msg.port, alen);
+      var errno = writeSockaddr(addr, sock.family, msg.addr, msg.port, alen);
 #if ASSERTIONS
-        assert(!errno);
+      assert(!errno);
 #endif
-      }
     }
     HEAPU8.set(msg.buffer, buf);
     return msg.buffer.byteLength;
@@ -544,7 +524,7 @@ var SyscallsLibrary = {
     // write the buffer
     return sock.sock_ops.sendmsg(sock, view, 0, total, addr, port);
   },
-  __syscall_recvmsg__deps: ['$getSocketFromFD', '$writeSockaddr', '$DNS'],
+  __syscall_recvmsg__deps: ['$getSocketFromFD', '$writeSockaddr'],
   __syscall_recvmsg: (fd, message, flags, u1, u2, u3) => {
     var sock = getSocketFromFD(fd);
     var iov = {{{ makeGetValue('message', C_STRUCTS.msghdr.msg_iov, '*') }}};
@@ -568,17 +548,10 @@ var SyscallsLibrary = {
     var name = {{{ makeGetValue('message', C_STRUCTS.msghdr.msg_name, '*') }}};
     if (name) {
       var namelen = message + {{{ C_STRUCTS.msghdr.msg_namelen }}};
-#if NODERAWSOCKETS
-      if (sock.family == {{{ cDefs.AF_UNIX }}}) {
-        writeSockaddr(name, sock.family, msg.addr || '', 0, namelen);
-      } else
-#endif
-      {
-        var errno = writeSockaddr(name, sock.family, DNS.lookup_name(msg.addr), msg.port, namelen);
+      var errno = writeSockaddr(name, sock.family, msg.addr, msg.port, namelen);
 #if ASSERTIONS
-        assert(!errno);
+      assert(!errno);
 #endif
-      }
     }
     // write the buffer out to the scatter-gather arrays
     var bytesRead = 0;

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -300,10 +300,20 @@
              "AF_INET",
              "AF_UNSPEC",
              "AF_INET6",
+             "AF_UNIX",
              "SOL_SOCKET",
              "SO_ERROR",
              "SO_REUSEPORT"
         ]
+    },
+    {
+        "file": "sys/un.h",
+        "structs": {
+            "sockaddr_un": [
+                "sun_family",
+                "sun_path"
+            ]
+        }
     },
     {
         "file": "bits/ioctl.h",

--- a/src/struct_info_generated.json
+++ b/src/struct_info_generated.json
@@ -2,6 +2,7 @@
     "defines": {
         "AF_INET": 2,
         "AF_INET6": 10,
+        "AF_UNIX": 1,
         "AF_UNSPEC": 0,
         "AI_ADDRCONFIG": 32,
         "AI_ALL": 16,
@@ -1083,6 +1084,11 @@
             },
             "sin6_family": 0,
             "sin6_port": 2
+        },
+        "sockaddr_un": {
+            "__size__": 110,
+            "sun_family": 0,
+            "sun_path": 2
         },
         "stat": {
             "__size__": 96,

--- a/src/struct_info_generated_wasm64.json
+++ b/src/struct_info_generated_wasm64.json
@@ -2,6 +2,7 @@
     "defines": {
         "AF_INET": 2,
         "AF_INET6": 10,
+        "AF_UNIX": 1,
         "AF_UNSPEC": 0,
         "AI_ADDRCONFIG": 32,
         "AI_ALL": 16,
@@ -1083,6 +1084,11 @@
             },
             "sin6_family": 0,
             "sin6_port": 2
+        },
+        "sockaddr_un": {
+            "__size__": 110,
+            "sun_family": 0,
+            "sun_path": 2
         },
         "stat": {
             "__size__": 104,

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 268229,
+  "a.out.js": 268215,
   "a.out.nodebug.wasm": 588309,
-  "total": 856538,
+  "total": 856524,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/sockets/test_unix_bind_inuse.c
+++ b/test/sockets/test_unix_bind_inuse.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ *
+ * Binding an AF_UNIX socket to a path that is already bound must fail
+ * synchronously with EADDRINUSE, exactly as POSIX bind() does. Self-contained
+ * and also runs natively.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+static const char* SOCK_PATH = "/tmp/emscripten_unix_inuse.sock";
+
+int main(void) {
+  unlink(SOCK_PATH);
+
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strcpy(addr.sun_path, SOCK_PATH);
+
+  int a = socket(AF_UNIX, SOCK_STREAM, 0);
+  assert(a >= 0);
+  assert(bind(a, (struct sockaddr*)&addr, sizeof(addr)) == 0 && "first bind");
+
+  int b = socket(AF_UNIX, SOCK_STREAM, 0);
+  assert(b >= 0);
+  int r = bind(b, (struct sockaddr*)&addr, sizeof(addr));
+  printf("second bind returned %d, errno %d (%s)\n", r, errno, strerror(errno));
+  assert(r == -1 && errno == EADDRINUSE && "expected EADDRINUSE");
+
+  close(a);
+  close(b);
+  unlink(SOCK_PATH);
+  printf("done\n");
+  return 0;
+}

--- a/test/sockets/test_unix_refused.c
+++ b/test/sockets/test_unix_refused.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ *
+ * A non-blocking connect to an AF_UNIX path with nothing listening must surface
+ * ENOENT (no such socket file), whether reported synchronously by connect() or
+ * asynchronously via SO_ERROR. Self-contained and also runs natively.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
+int fd = -1;
+
+void test_success(void) {
+  printf("done\n");
+  if (fd >= 0) close(fd);
+#ifdef __EMSCRIPTEN__
+  emscripten_cancel_main_loop();
+#else
+  exit(0);
+#endif
+}
+
+void main_loop(void) {
+  fd_set fdw;
+  struct timeval tv = {0};
+  FD_ZERO(&fdw);
+  FD_SET(fd, &fdw);
+  select(64, NULL, &fdw, NULL, &tv);
+
+  if (FD_ISSET(fd, &fdw)) {
+    int err = 0;
+    socklen_t l = sizeof(err);
+    getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &l);
+    if (err == 0) return; // not resolved yet
+    printf("connect resolved with errno %d (%s)\n", err, strerror(err));
+    assert(err == ENOENT && "expected ENOENT");
+    test_success();
+  }
+}
+
+int main(void) {
+  fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  assert(fd >= 0);
+  fcntl(fd, F_SETFL, O_NONBLOCK);
+
+  struct sockaddr_un dest;
+  memset(&dest, 0, sizeof(dest));
+  dest.sun_family = AF_UNIX;
+  strcpy(dest.sun_path, "/tmp/emscripten_unix_nonexistent.sock");
+  unlink(dest.sun_path); // ensure it really is absent
+
+  // A non-blocking connect may return 0 (emscripten) or fail synchronously
+  // (native). The async failure is checked via SO_ERROR in the main loop.
+  int r = connect(fd, (struct sockaddr*)&dest, sizeof(dest));
+  if (r == -1 && errno == ENOENT) {
+    printf("connect resolved with errno %d (%s)\n", errno, strerror(errno));
+    test_success();
+    return 0;
+  }
+  assert((r == 0 || errno == EINPROGRESS) && "connect");
+
+#ifdef __EMSCRIPTEN__
+  emscripten_set_main_loop(main_loop, 0, 0);
+#else
+  while (1) {
+    main_loop();
+    usleep(1000);
+  }
+#endif
+  return 0;
+}

--- a/test/sockets/test_unix_server.c
+++ b/test/sockets/test_unix_server.c
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ *
+ * Self-contained AF_UNIX (named pathname) loopback accept+echo. A listener and
+ * a client live in one process, both non-blocking, driven by select. Exercises
+ * bind(path), listen, getsockname (the bound path), accept, getpeername,
+ * non-blocking connect-by-path, send and recv. Plain POSIX, so it also builds
+ * and runs natively against the host stack.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
+static const char* SOCK_PATH = "/tmp/emscripten_unix_server.sock";
+
+int listen_fd = -1;
+int client_fd = -1;
+int peer_fd = -1; // accepted (server-side) connection
+struct sockaddr_un dest;
+bool connected = false;
+bool ping_sent = false;
+bool pong_sent = false;
+
+void set_nonblocking(int fd) {
+  fcntl(fd, F_SETFL, O_NONBLOCK);
+}
+
+void test_success(void) {
+  printf("done\n");
+  if (listen_fd >= 0) close(listen_fd);
+  if (client_fd >= 0) close(client_fd);
+  if (peer_fd >= 0) close(peer_fd);
+  unlink(SOCK_PATH);
+#ifdef __EMSCRIPTEN__
+  emscripten_cancel_main_loop();
+#else
+  exit(0);
+#endif
+}
+
+void start_client(void) {
+  if (client_fd >= 0) close(client_fd);
+  client_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  assert(client_fd >= 0);
+  set_nonblocking(client_fd);
+  connected = false;
+  ping_sent = false;
+  int r = connect(client_fd, (struct sockaddr*)&dest, sizeof(dest));
+  assert((r == 0 || errno == EINPROGRESS) && "connect");
+}
+
+void main_loop(void) {
+  fd_set fdr, fdw;
+  struct timeval tv = {0};
+  FD_ZERO(&fdr);
+  FD_ZERO(&fdw);
+  FD_SET(listen_fd, &fdr);
+  FD_SET(client_fd, &fdr);
+  FD_SET(client_fd, &fdw);
+  if (peer_fd >= 0) FD_SET(peer_fd, &fdr);
+  select(64, &fdr, &fdw, NULL, &tv);
+
+  // server: accept the incoming connection
+  if (peer_fd < 0 && FD_ISSET(listen_fd, &fdr)) {
+    struct sockaddr_un ca;
+    socklen_t cl = sizeof(ca);
+    peer_fd = accept(listen_fd, (struct sockaddr*)&ca, &cl);
+    if (peer_fd >= 0) {
+      set_nonblocking(peer_fd);
+      printf("accepted\n");
+    }
+  }
+
+  // client: connect completion (retry while the listener is coming up)
+  if (!connected && FD_ISSET(client_fd, &fdw)) {
+    int err = 0;
+    socklen_t l = sizeof(err);
+    getsockopt(client_fd, SOL_SOCKET, SO_ERROR, &err, &l);
+    if (err == ECONNREFUSED || err == ECONNRESET || err == ENOENT) {
+      start_client();
+      return;
+    }
+    assert(err == 0 && "connect failed");
+    connected = true;
+    // The connected client's peer name is the listener's path.
+    struct sockaddr_un pa;
+    socklen_t pl = sizeof(pa);
+    if (getpeername(client_fd, (struct sockaddr*)&pa, &pl) == 0) {
+      assert(pa.sun_family == AF_UNIX);
+      assert(strcmp(pa.sun_path, SOCK_PATH) == 0 && "peer path");
+      printf("connected to %s\n", pa.sun_path);
+    }
+  }
+
+  // client: send ping
+  if (connected && !ping_sent && FD_ISSET(client_fd, &fdw)) {
+    if (send(client_fd, "ping", 4, 0) == 4) ping_sent = true;
+  }
+
+  // server: echo ping -> pong
+  if (peer_fd >= 0 && !pong_sent && FD_ISSET(peer_fd, &fdr)) {
+    char buf[4];
+    ssize_t n = recv(peer_fd, buf, sizeof(buf), 0);
+    if (n == 4 && memcmp(buf, "ping", 4) == 0) {
+      send(peer_fd, "pong", 4, 0);
+      pong_sent = true;
+    }
+  }
+
+  // client: receive pong
+  if (ping_sent && FD_ISSET(client_fd, &fdr)) {
+    char buf[4];
+    ssize_t n = recv(client_fd, buf, sizeof(buf), 0);
+    if (n == 4 && memcmp(buf, "pong", 4) == 0) {
+      test_success();
+    } else if (n == 0) {
+      assert(false && "peer closed unexpectedly");
+    }
+  }
+}
+
+int main(void) {
+  // Remove any stale socket file from a previous run (a lingering file makes
+  // bind() fail with EADDRINUSE).
+  unlink(SOCK_PATH);
+
+  listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  assert(listen_fd >= 0);
+
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strcpy(addr.sun_path, SOCK_PATH);
+  if (bind(listen_fd, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    perror("bind");
+    return 1;
+  }
+  if (listen(listen_fd, 4) != 0) {
+    perror("listen");
+    return 1;
+  }
+
+  // getsockname() must report the bound path synchronously.
+  struct sockaddr_un la;
+  socklen_t ll = sizeof(la);
+  if (getsockname(listen_fd, (struct sockaddr*)&la, &ll) != 0) {
+    perror("getsockname");
+    return 1;
+  }
+  assert(la.sun_family == AF_UNIX);
+  assert(strcmp(la.sun_path, SOCK_PATH) == 0 && "bound path");
+  printf("listening on %s\n", la.sun_path);
+  set_nonblocking(listen_fd);
+
+  memset(&dest, 0, sizeof(dest));
+  dest.sun_family = AF_UNIX;
+  strcpy(dest.sun_path, SOCK_PATH);
+  start_client();
+
+#ifdef __EMSCRIPTEN__
+  emscripten_set_main_loop(main_loop, 0, 0);
+#else
+  while (1) {
+    main_loop();
+    usleep(1000);
+  }
+#endif
+  return 0;
+}

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -476,6 +476,24 @@ class sockets(BrowserCore):
     # socket stays readable, and the following plain recv returns them again.
     self.do_runf('sockets/test_tcp_peek.c', 'done\n', cflags=['-sNODERAWSOCKETS'])
 
+  # AF_UNIX is gated behind NODERAWFS: the socket path lives in the host
+  # filesystem, which only stays coherent with the program's own file syscalls
+  # (bind's parent dir, getsockname, unlink) when the FS is the host FS.
+  @also_with_proxy_to_pthread
+  def test_noderawsockets_unix_server(self):
+    # Self-contained named AF_UNIX (pathname) loopback accept+echo: bind(path),
+    # listen, getsockname (the bound path), accept, getpeername, non-blocking
+    # connect-by-path, send and recv over a real node pipe.
+    self.do_runf('sockets/test_unix_server.c', 'done\n', cflags=['-sNODERAWSOCKETS', '-sNODERAWFS'])
+
+  def test_noderawsockets_unix_refused(self):
+    # A connect to an AF_UNIX path with no socket file reports ENOENT.
+    self.do_runf('sockets/test_unix_refused.c', 'done\n', cflags=['-sNODERAWSOCKETS', '-sNODERAWFS'])
+
+  def test_noderawsockets_unix_bind_inuse(self):
+    # Binding an already-bound AF_UNIX path fails synchronously with EADDRINUSE.
+    self.do_runf('sockets/test_unix_bind_inuse.c', 'done\n', cflags=['-sNODERAWSOCKETS', '-sNODERAWFS'])
+
   def test_noderawsockets_server_autobind(self):
     # listen() without a prior bind() must auto-bind an ephemeral port and
     # getsockname() must report it (POSIX), then accept+echo as usual.


### PR DESCRIPTION
Named unix-domain sockets let POSIX code compiled to wasm participate in the host's unix-socket IPC as a first-class client or server: connect() to a daemon path (docker.sock, postgres/redis) or bind()+listen()+accept() a path that native tools connect into. This is a straight remap of the existing node:net TCP flow from (host, port) to (path), reusing the same readiness/poll seam so mio/tokio IPC types work unmodified.

The socket path lives in the host filesystem (node owns it), so it only stays coherent with the program's own file syscalls - bind's parent directory, getsockname, unlink - when the program's FS is the host FS. The family is therefore gated behind NODERAWFS; requesting AF_UNIX otherwise returns EAFNOSUPPORT rather than half-working against a disjoint MEMFS namespace.

- Address plumbing: add AF_UNIX and sockaddr_un to struct info; readSockaddr/ writeSockaddr encode/decode sun_path (pathname, unnamed, and Linux abstract '\0' names), and the socket syscalls pass unix paths verbatim rather than through the IP DNS layer.
- createSocket accepts AF_UNIX only under NODERAWFS (datagram -> EPROTONOSUPPORT; the IPPROTO_TCP guard is INET-only, unix uses protocol 0).
- Backend: synchronous bind reserving the filesystem entry (bind-time EADDRINUSE), server.listen on the bound handle, onconnection accept queue, connect-by-path through the shared wireConnection, and getsockname/getpeername reporting the tracked path. Bind prefers net.BoundSocket({ path }) when the node build exposes it (detected via 'isPipe' in BoundSocket.prototype), else falls back to the private pipe_wrap binding - mirroring the existing useBoundSocket() -> tcp_wrap seam.
- Tests (NODERAWSOCKETS + NODERAWFS): self-contained named accept+echo (bind/ listen/getsockname/accept/getpeername/connect), connect-to-missing-path -> ENOENT, and rebind -> EADDRINUSE. All also build and run natively.

socketpair()/UnixStream::pair() remains unimplemented (ENOSYS) for now.