### PR TITLE
[OpenAL] Fix sourceSeek crash on stopped sources

### DIFF
--- a/src/lib/libopenal.js
+++ b/src/lib/libopenal.js
@@ -721,15 +721,17 @@ var LibraryOpenAL = {
         AL.setSourceState(src, {{{ cDefs.AL_INITIAL }}});
       }
 
-      if (src.bufQueue[src.bufsProcessed].audioBuf !== null) {
-        src.bufsProcessed = 0;
-        while (offset > src.bufQueue[src.bufsProcessed].audioBuf.duration) {
-          offset -= src.bufQueue[src.bufsProcessed].audioBuf.duration;
-          src.bufsProcessed++;
+      src.bufsProcessed = 0;
+      for (var buf of src.bufQueue) {
+        var duration = buf.audioBuf?.duration ?? 0.0;
+        if (offset < duration) {
+          break;
         }
-
-        src.bufOffset = offset;
+        offset -= duration;
+        src.bufsProcessed++;
       }
+      // 'offset' is now the intra-buffer offset within the target buffer.
+      src.bufOffset = offset;
 
       if (playing) {
         AL.setSourceState(src, {{{ cDefs.AL_PLAYING }}});

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 267949,
+  "a.out.js": 267933,
   "a.out.nodebug.wasm": 588309,
-  "total": 856258,
+  "total": 856242,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/openal/test_openal_error.c
+++ b/test/openal/test_openal_error.c
@@ -38,6 +38,39 @@ void test_offsets_with_zero_buffer(void) {
   alDeleteBuffers(1, &buf);
 }
 
+void test_stopped_seek(void) {
+  ALuint buf = 0;
+  alGenBuffers(1, &buf);
+  short dummy_data[2000] = {0};
+  alBufferData(buf, AL_FORMAT_MONO16, dummy_data, sizeof(dummy_data), 44100);
+  assert(alGetError() == AL_NO_ERROR);
+
+  ALuint src = 0;
+  alGenSources(1, &src);
+  assert(alGetError() == AL_NO_ERROR);
+
+  alSourcei(src, AL_BUFFER, buf);
+  assert(alGetError() == AL_NO_ERROR);
+
+  alSourcePlay(src);
+  assert(alGetError() == AL_NO_ERROR);
+
+  alSourceStop(src);
+  assert(alGetError() == AL_NO_ERROR);
+
+  // See of 0.01 seconds while the stream in stopped.
+  alSourcef(src, AL_SEC_OFFSET, 0.01f);
+  assert(alGetError() == AL_NO_ERROR);
+
+  // Verify the the seek was successful
+  float offset = 0.0f;
+  alGetSourcef(src, AL_SEC_OFFSET, &offset);
+  assert(offset == 0.01f);
+
+  alDeleteSources(1, &src);
+  alDeleteBuffers(1, &buf);
+}
+
 int main(int argc, char* argv[]) {
   ALCboolean ret;
 
@@ -64,6 +97,7 @@ int main(int argc, char* argv[]) {
   assert(alGetError() == AL_NO_ERROR);
 
   test_offsets_with_zero_buffer();
+  test_stopped_seek();
 
   ret = alcMakeContextCurrent(NULL);
   assert(ret == ALC_TRUE);


### PR DESCRIPTION
Fix a crash in `sourceSeek` when called on a stopped source by resetting `bufsProcessed = 0` before evaluating buffer durations.

This replaces #26770. Unlike #26770, which added a top-level check on `src.bufQueue[0]`, this change handles zero/dummy buffers and empty queues safely anywhere in `bufQueue` via `for .. of` iteration and `audioBuf?.duration ?? 0.0`. It also adds assertions to `test_openal_error.c` to verify state correctness after seeking.

See: #26770