### PR TITLE
Cleanup legacy browser support in libopenal.js. NFC

### DIFF
--- a/src/lib/libopenal.js
+++ b/src/lib/libopenal.js
@@ -20,6 +20,12 @@ var LibraryOpenAL = {
     QUEUE_INTERVAL: 25,
     QUEUE_LOOKAHEAD: 100.0 / 1000.0,
 
+#if MIN_SAFARI_VERSION < 140500
+    AudioContext: globalThis.AudioContext ?? globalThis.webkitAudioContext,
+#else
+    AudioContext: globalThis.AudioContext,
+#endif
+
     DEVICE_NAME: 'Emscripten OpenAL',
     CAPTURE_DEVICE_NAME: 'Emscripten OpenAL capture',
 
@@ -1649,7 +1655,11 @@ var LibraryOpenAL = {
       return 0;
     }
 
-    var AudioContext = window.AudioContext || window.webkitAudioContext;
+#if MIN_SAFARI_VERSION < 140500
+    // We depend on the global AudioContext for modern browsers, but
+    // old older safari versions we may still need to use webkitAudioContext.
+    var AudioContext = AL.AudioContext;
+#endif
 
     if (!AL.sharedCaptureAudioCtx) {
       try {
@@ -2047,7 +2057,7 @@ var LibraryOpenAL = {
       }
     }
 
-    if (globalThis.AudioContext || globalThis.webkitAudioContext) {
+    if (AL.AudioContext) {
       var deviceId = AL.newId();
       AL.deviceRefCounts[deviceId] = 0;
       return deviceId;
@@ -2077,7 +2087,7 @@ var LibraryOpenAL = {
       return 0;
     }
 
-    var options = null;
+    var options;
     var attrs = [];
     var hrtf = null;
     pAttrList >>= 2;
@@ -2142,15 +2152,13 @@ var LibraryOpenAL = {
       }
     }
 
-    var AudioContext = window.AudioContext || window.webkitAudioContext;
-    var ac = null;
+#if MIN_SAFARI_VERSION < 140500
+    var AudioContext = window.AudioContext ?? window.webkitAudioContext;
+#endif
+
+    var ac;
     try {
-      // Only try to pass options if there are any, for compat with browsers that don't support this
-      if (options) {
-        ac = new AudioContext(options);
-      } else {
-        ac = new AudioContext();
-      }
+      ac = new AudioContext(options);
     } catch (e) {
       if (e.name === 'NotSupportedError') {
 #if OPENAL_DEBUG
@@ -2372,14 +2380,14 @@ var LibraryOpenAL = {
       ret = 'Out of Memory';
       break;
     case 0x1004 /* ALC_DEFAULT_DEVICE_SPECIFIER */:
-      if (globalThis.AudioContext || globalThis.webkitAudioContext) {
+      if (AL.AudioContext) {
         ret = AL.DEVICE_NAME;
       } else {
         return 0;
       }
       break;
     case 0x1005 /* ALC_DEVICE_SPECIFIER */:
-      if (globalThis.AudioContext || globalThis.webkitAudioContext) {
+      if (AL.AudioContext) {
         ret = AL.DEVICE_NAME + '\0';
       } else {
         ret = '\0';

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 267933,
+  "a.out.js": 267629,
   "a.out.nodebug.wasm": 588309,
-  "total": 856242,
+  "total": 855938,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
This brings libopenal.js inline with libwebaudio.js in a couple of ways:

- Only support webkitAudioContext on older safari versions.
- Drop support for `new AudioContext` that does not accept options.

This change should make is easy for us to remove this support once we drop support for Safari < 14.5.