### PR TITLE
Remove all references to webkitAudioContext. NFC

### DIFF
--- a/site/source/docs/porting/Audio.rst
+++ b/site/source/docs/porting/Audio.rst
@@ -110,7 +110,6 @@ Right now though there's a quick and *de facto* reliable way to do this (C examp
     // Avoid calling this more than once! Caching the value is up to you.
     unsigned query_sample_rate_of_audiocontexts() {
         return EM_ASM_INT({
-            var AudioContext = window.AudioContext || window.webkitAudioContext;
             var ctx = new AudioContext();
             var sr = ctx.sampleRate;
             ctx.close();

--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -1063,9 +1063,6 @@ First consider the JavaScript below, which shows how to use the API:
 
 .. code-block:: javascript
 
-   // Get web audio api context
-   var AudioContext = window.AudioContext || window.webkitAudioContext;
-
    // Got an AudioContext: Create context and OscillatorNode
    var context = new AudioContext();
    var oscillator = context.createOscillator();
@@ -1092,10 +1089,6 @@ The code can be transliterated to C++ using ``val``, as shown below:
 
    int main() {
      val AudioContext = val::global("AudioContext");
-     if (!AudioContext.as<bool>()) {
-       printf("No global AudioContext, trying webkitAudioContext\n");
-       AudioContext = val::global("webkitAudioContext");
-     }
 
      printf("Got an AudioContext\n");
      val context = AudioContext.new_();
@@ -1113,11 +1106,10 @@ The code can be transliterated to C++ using ``val``, as shown below:
    }
 
 First we use :cpp:func:`~emscripten::val::global` to get the symbol for
-the global ``AudioContext`` object (or ``webkitAudioContext`` if that
-does not exist). We then use :cpp:func:`~emscripten::val::new_` to create
-the context, and from this context we can create an ``oscillator``,
-:cpp:func:`~emscripten::val::set` its properties (again using ``val``)
-and then play the tone.
+the global ``AudioContext`` object.  We then use
+:cpp:func:`~emscripten::val::new_` to create the context, and from this context
+we can create an ``oscillator``, :cpp:func:`~emscripten::val::set` its
+properties (again using ``val``) and then play the tone.
 
 The example can be compiled on the Linux/macOS terminal with::
 

--- a/src/lib/libopenal.js
+++ b/src/lib/libopenal.js
@@ -1649,8 +1649,6 @@ var LibraryOpenAL = {
       return 0;
     }
 
-    var AudioContext = window.AudioContext || window.webkitAudioContext;
-
     if (!AL.sharedCaptureAudioCtx) {
       try {
         AL.sharedCaptureAudioCtx = new AudioContext();
@@ -2047,12 +2045,13 @@ var LibraryOpenAL = {
       }
     }
 
-    if (globalThis.AudioContext || globalThis.webkitAudioContext) {
-      var deviceId = AL.newId();
-      AL.deviceRefCounts[deviceId] = 0;
-      return deviceId;
+    if (!globalThis.AudioContext) {
+      return 0;
     }
-    return 0;
+
+    var deviceId = AL.newId();
+    AL.deviceRefCounts[deviceId] = 0;
+    return deviceId;
   },
 
   alcCloseDevice__proxy: 'sync',
@@ -2077,7 +2076,7 @@ var LibraryOpenAL = {
       return 0;
     }
 
-    var options = null;
+    var options = {};
     var attrs = [];
     var hrtf = null;
     pAttrList >>= 2;
@@ -2095,10 +2094,6 @@ var LibraryOpenAL = {
 
         switch (attr) {
         case 0x1007 /* ALC_FREQUENCY */:
-          if (!options) {
-            options = {};
-          }
-
           options.sampleRate = val;
           break;
         case 0x1010 /* ALC_MONO_SOURCES */: // fallthrough
@@ -2142,15 +2137,9 @@ var LibraryOpenAL = {
       }
     }
 
-    var AudioContext = window.AudioContext || window.webkitAudioContext;
-    var ac = null;
+    var ac;
     try {
-      // Only try to pass options if there are any, for compat with browsers that don't support this
-      if (options) {
-        ac = new AudioContext(options);
-      } else {
-        ac = new AudioContext();
-      }
+      ac = new AudioContext(options);
     } catch (e) {
       if (e.name === 'NotSupportedError') {
 #if OPENAL_DEBUG
@@ -2372,14 +2361,14 @@ var LibraryOpenAL = {
       ret = 'Out of Memory';
       break;
     case 0x1004 /* ALC_DEFAULT_DEVICE_SPECIFIER */:
-      if (globalThis.AudioContext || globalThis.webkitAudioContext) {
+      if (globalThis.AudioContext) {
         ret = AL.DEVICE_NAME;
       } else {
         return 0;
       }
       break;
     case 0x1005 /* ALC_DEVICE_SPECIFIER */:
-      if (globalThis.AudioContext || globalThis.webkitAudioContext) {
+      if (globalThis.AudioContext) {
         ret = AL.DEVICE_NAME + '\0';
       } else {
         ret = '\0';

--- a/src/lib/libsdl.js
+++ b/src/lib/libsdl.js
@@ -1186,12 +1186,8 @@ var LibrarySDL = {
       // initialize Web Audio context ever once on the web page, since
       // initializing multiple times fails on Chrome saying 'audio resources
       // have been exhausted'.
-      if (!SDL.audioContext) {
-        if (typeof AudioContext != 'undefined') {
-          SDL.audioContext = new AudioContext();
-        } else if (typeof webkitAudioContext != 'undefined') {
-          SDL.audioContext = new webkitAudioContext();
-        }
+      if (!SDL.audioContext && globalThis.AudioContext) {
+        SDL.audioContext = new AudioContext();
       }
     },
 

--- a/src/lib/libwebaudio.js
+++ b/src/lib/libwebaudio.js
@@ -45,7 +45,7 @@ var LibraryWebAudio = {
   $emAudioExpectContext: (handle, methodName) => {
     var obj = _emAudioExpectHandle(handle, methodName);
 #if ASSERTIONS
-    assert(obj instanceof (window.AudioContext || window.webkitAudioContext), `${methodName}() called with ${handle} that is not an AudioContext, but of type ${typeof obj}`);
+    assert(obj instanceof window.AudioContext, `${methodName}() called with ${handle} that is not an AudioContext, but of type ${typeof obj}`);
 #endif
   },
 
@@ -61,7 +61,7 @@ var LibraryWebAudio = {
   $emAudioExpectNodeOrContext: (handle, methodName) => {
     var obj = _emAudioExpectHandle(handle, methodName);
 #if ASSERTIONS
-    assert(obj instanceof window.AudioNode || obj instanceof (window.AudioContext || window.webkitAudioContext), `${methodName}() called with a handle ${handle} that is not an AudioContext or AudioNode, but of type ${typeof obj}`);
+    assert(obj instanceof window.AudioNode || obj instanceof window.AudioContext, `${methodName}() called with a handle ${handle} that is not an AudioContext or AudioNode, but of type ${typeof obj}`);
 #endif
   },
 #endif
@@ -88,11 +88,8 @@ var LibraryWebAudio = {
   emscripten_create_audio_context__deps: ['$emscriptenRegisterAudioObject', '$emscriptenGetAudioObject'],
   emscripten_create_audio_context: (options) => {
     // Safari added unprefixed AudioContext support in Safari 14.5 on iOS: https://caniuse.com/audio-api
-#if MIN_SAFARI_VERSION < 140500 || ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL
-    var ctx = window.AudioContext || window.webkitAudioContext;
 #if ASSERTIONS
-    if (!ctx) console.error('emscripten_create_audio_context failed! Web Audio is not supported.');
-#endif
+    if (!globalThis.AudioContext) console.error('emscripten_create_audio_context failed! Web Audio is not supported.');
 #endif
 
     // Converts AUDIO_CONTEXT_RENDER_SIZE_* into AudioContextRenderSizeCategory
@@ -111,12 +108,7 @@ var LibraryWebAudio = {
     console.dir(opts);
 #endif
 
-#if MIN_SAFARI_VERSION < 140500 || ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL
-    return ctx && emscriptenRegisterAudioObject(new ctx(opts));
-#else
-    // We are targeting an environment where we assume that AudioContext() API unconditionally exists.
     return emscriptenRegisterAudioObject(new AudioContext(opts));
-#endif
   },
 
   emscripten_resume_audio_context_async: (contextHandle, callback, userData) => {

--- a/test/browser/test_sdl2_mixer_music.c
+++ b/test/browser/test_sdl2_mixer_music.c
@@ -27,12 +27,7 @@ int main(int argc, char* argv[])
 	}
 
 	frequency = EM_ASM_INT({
-		var context;
-		try {
-		  context = new AudioContext();
-		} catch (e) {
-		  context = new webkitAudioContext(); // safari only
-		}
+		var context = new AudioContext();
 		return context.sampleRate;
 	});
 

--- a/test/browser/test_sdl2_mixer_wav.c
+++ b/test/browser/test_sdl2_mixer_wav.c
@@ -31,12 +31,7 @@ int main(int argc, char* argv[]){
         return 100;
     }
     int const frequency = EM_ASM_INT({
-        var context;
-        try {
-            context = new AudioContext();
-        } catch (e) {
-            context = new webkitAudioContext(); // safari only
-        }
+        var context = new AudioContext();
         return context.sampleRate;
     });
     if(Mix_OpenAudio(frequency, MIX_DEFAULT_FORMAT, 2, 1024) == -1) {

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 267788,
+  "a.out.js": 267539,
   "a.out.nodebug.wasm": 588309,
-  "total": 856097,
+  "total": 855848,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
We were only keeping this code around to support older safari versions.  However the oldest safari version we currently support is 14.1, which is the first release to support the modern AudioContext object.

There is some confusion only about Safari 14.1 was release as part of iOS 14.5.  As far as I can tell Safari 14.1 is the version we should be caring about for AudioContext.

See https://webkit.org/blog/11648/new-webkit-features-in-safari-14-1/