### PR TITLE
[html5] Align event_data in callback_args_t to max_align_t

### DIFF
--- a/system/lib/html5/callback.c
+++ b/system/lib/html5/callback.c
@@ -5,6 +5,8 @@
  * found in the LICENSE file.
  */
 #include <assert.h>
+#include <stdalign.h>
+#include <stddef.h>
 #include <string.h>
 #include <emscripten/html5.h>
 
@@ -16,7 +18,10 @@ typedef struct callback_args_t {
   event_callback callback;
   int event_type;
   void *user_data;
-  uint8_t event_data[];
+  // Since we cast this to various event types it needs to be at aligned to the
+  // to the same level as any the event types.   The simplest way to acheive
+  // this is with max_align-t.
+  alignas(max_align_t) uint8_t event_data[];
 } callback_args_t;
 
 static void do_callback(void* arg) {

--- a/system/lib/html5/callback.c
+++ b/system/lib/html5/callback.c
@@ -19,7 +19,7 @@ typedef struct callback_args_t {
   int event_type;
   void *user_data;
   // Since we cast this to various event types it needs to be at aligned to the
-  // to the same level as any the event types.   The simplest way to acheive
+  // to the same level as any the event types.   The simplest way to achieve
   // this is with max_align-t.
   alignas(max_align_t) uint8_t event_data[];
 } callback_args_t;

--- a/test/pthread/test_pthread_callback_alignment.c
+++ b/test/pthread/test_pthread_callback_alignment.c
@@ -26,6 +26,8 @@ extern void _emscripten_run_callback_on_thread(pthread_t t,
 
 static bool on_wheel(int event_type, void *event_data, void *user_data) {
   const EmscriptenWheelEvent *e = (const EmscriptenWheelEvent *)event_data;
+  // Test that the event_data contents are properly aligned.  These accesses
+  // will fail under SAFE_HEAP if they are not.
   assert(e->deltaX == 1.0);
   assert(e->deltaY == 2.0);
   assert(e->deltaZ == 3.0);

--- a/test/pthread/test_pthread_callback_alignment.c
+++ b/test/pthread/test_pthread_callback_alignment.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <assert.h>
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#include <emscripten/threading.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef bool (*event_callback)(int event_type, void *event_data, void *user_data);
+extern void _emscripten_run_callback_on_thread(pthread_t t,
+                                               event_callback f,
+                                               int event_type,
+                                               void *event_data,
+                                               size_t event_data_size,
+                                               void *user_data);
+
+static bool on_wheel(int event_type, void *event_data, void *user_data) {
+  const EmscriptenWheelEvent *e = (const EmscriptenWheelEvent *)event_data;
+  assert(e->deltaX == 1.0);
+  assert(e->deltaY == 2.0);
+  assert(e->deltaZ == 3.0);
+  printf("done\n");
+  emscripten_force_exit(0);
+  return true;
+}
+
+static void *sender(void *arg) {
+  pthread_t target = (pthread_t)arg;
+  EmscriptenWheelEvent ev;
+  memset(&ev, 0, sizeof(ev));
+  ev.deltaX = 1.0;
+  ev.deltaY = 2.0;
+  ev.deltaZ = 3.0;
+  _emscripten_run_callback_on_thread(target, on_wheel, EMSCRIPTEN_EVENT_WHEEL,
+                                     &ev, sizeof(ev), NULL);
+  return NULL;
+}
+
+static void dummy(void) {}
+
+int main(void) {
+  pthread_t t;
+  pthread_create(&t, NULL, sender, (void *)pthread_self());
+  emscripten_set_main_loop(dummy, 1, 0);
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2628,6 +2628,10 @@ The current type of b is: 9
     self.do_runf_out_file('pthread/test_pthread_nested_work_queue.c')
 
   @requires_pthreads
+  def test_pthread_callback_alignment(self):
+    self.do_runf('pthread/test_pthread_callback_alignment.c', 'done\n', cflags=['-sSAFE_HEAP'])
+
+  @requires_pthreads
   @flaky('Times out in bigendian0 suite only. https://github.com/emscripten-core/emscripten/issues/25316')
   def test_pthread_thread_local_storage(self):
     self.set_setting('PROXY_TO_PTHREAD')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -2628,10 +2628,6 @@ The current type of b is: 9
     self.do_runf_out_file('pthread/test_pthread_nested_work_queue.c')
 
   @requires_pthreads
-  def test_pthread_callback_alignment(self):
-    self.do_runf('pthread/test_pthread_callback_alignment.c', 'done\n', cflags=['-sSAFE_HEAP'])
-
-  @requires_pthreads
   @flaky('Times out in bigendian0 suite only. https://github.com/emscripten-core/emscripten/issues/25316')
   def test_pthread_thread_local_storage(self):
     self.set_setting('PROXY_TO_PTHREAD')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -13449,6 +13449,11 @@ void foo() {}
     self.do_runf('pthread/test_pthread_memory_growth_mainthread.c', cflags=['-pthread', '-sALLOW_MEMORY_GROWTH', '-sINITIAL_MEMORY=32MB', '-sMAXIMUM_MEMORY=256MB'] + cflags)
 
   @requires_pthreads
+  def test_pthread_callback_alignment(self):
+    # Use `SAFE_HEAP` here so that incorrect alignment will trap.
+    self.do_runf('pthread/test_pthread_callback_alignment.c', 'done\n', cflags=['-sSAFE_HEAP'])
+
+  @requires_pthreads
   def test_pthread_join_interrupted(self):
     self.do_runf('pthread/test_pthread_join_interrupted.c', cflags=['-pthread'])
 


### PR DESCRIPTION
Align `event_data` flexible array member in `callback_args_t` to `max_align_t` so that structure members requiring 8-byte alignment (e.g., doubles in `EmscriptenWheelEvent`) do not cause misaligned reads and trigger alignment faults under `-sSAFE_HEAP=1`.

Fixes: #27447