### PR TITLE
Handle symbolic links in create_entry_points.py

### DIFF
--- a/tools/maint/create_entry_points.py
+++ b/tools/maint/create_entry_points.py
@@ -72,7 +72,7 @@ def make_executable(filename):
 
 
 def maybe_remove(filename):
-  if os.path.exists(filename):
+  if os.path.lexists(filename):
     os.remove(filename)
 
 
@@ -82,6 +82,7 @@ def read_file(filename):
 
 
 def write_file(filename, content):
+  maybe_remove(filename)
   with open(filename, 'w', encoding='utf-8') as f:
     f.write(content)
 


### PR DESCRIPTION
When creating the entry points we need to first delete them, in case they are sym links (which they may be once #27401 lands).

If we don't do this then if the file exists and is a symlink then the `open` will actually open the target of the symlink for writing, which is not what we want.