### PR TITLE
[test] Parse start hex offset when extracting WAT address in test_dwarf

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -8164,7 +8164,7 @@ void* operator new(size_t size) {
       start_addr_loc = wat.find('0x', call_loc)
       assert start_addr_loc > 0
       start_addr_loc_end = wat.find('\n', start_addr_loc)
-      start_addr = int(wat[start_addr_loc:start_addr_loc_end], 0)
+      start_addr = int(wat[start_addr_loc:start_addr_loc_end].split()[0], 0)
       # the call ends with the drop, which is the last in the stream, at the
       # highest address
       end_addr_loc = wat.rfind('drop', 0, call_loc)
@@ -8173,7 +8173,7 @@ void* operator new(size_t size) {
       assert end_addr_loc > 0
       end_addr_loc_end = wat.find('\n', end_addr_loc)
       assert end_addr_loc_end > 0
-      end_addr = int(wat[end_addr_loc:end_addr_loc_end], 0)
+      end_addr = int(wat[end_addr_loc:end_addr_loc_end].split()[0], 0)
       return (start_addr, end_addr)
 
     # match up the DWARF and the wat


### PR DESCRIPTION
https://github.com/WebAssembly/binaryen/pull/8944 changed WAT code offset annotations from single addresses `;; code offset: 0x8` to address ranges `;; code offset: 0x8 - 0xa`.

Extracting `.split()[0]` works with both single addresses and address ranges.