### PR TITLE
Add example config and testing for meson build system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -760,6 +760,7 @@ jobs:
   test-wasm64-misc:
     environment:
       LANG: "C.UTF-8"
+      EMTEST_SKIP_NINJA: "1"
     executor: ubuntu-lts
     steps:
       - prepare-for-tests
@@ -790,6 +791,7 @@ jobs:
     executor: ubuntu-lts
     environment:
       EMTEST_SKIP_NEW_CMAKE: "1"
+      EMTEST_SKIP_NINJA: "1"
       EMTEST_SKIP_WASM64: "1"
     steps:
       - checkout
@@ -807,6 +809,7 @@ jobs:
     executor: ubuntu-lts
     environment:
       EMTEST_SKIP_NEW_CMAKE: "1"
+      EMTEST_SKIP_NINJA: "1"
     steps:
       - checkout
       - pip-install
@@ -1230,6 +1233,7 @@ jobs:
       EMTEST_SKIP_RUST: "1"
       EMTEST_SKIP_NODE_25: "1"
       EMTEST_SKIP_PKG_CONFIG: "1"
+      EMTEST_SKIP_MESON: "1"
       EMTEST_BROWSER: "0"
     steps:
       - checkout
@@ -1271,6 +1275,7 @@ jobs:
       EMTEST_SKIP_WASM_EH: "1"
       EMTEST_SKIP_WASM64: "1"
       EMTEST_SKIP_SCONS: "1"
+      EMTEST_SKIP_MESON: "1"
       EMTEST_SKIP_RUST: "1"
       EMTEST_SKIP_NODE_25: "1"
       # Some native clang tests assume x86 clang (e.g. -sse2)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@ See docs/process.md for more on how version tagging works.
 - `DEFAULT_TO_CXX` is now disabled by default. This means that `em++` is now
   required when linking C++ programs, matching the behavior of clang and gcc.
   The old behavior is still available using `-sDEFAULT_TO_CXX`. (#11121)
+- Added example Meson cross compilation files (`wasm32-emscripten.ini` and
+  `wasm64-emscripten.ini`) in `tools/meson/`. (#27478)
 - libcxx and libcxxabi were updated to LLVM 22.1.8. (#27428)
 
 6.0.5 - 07/29/26

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,5 +22,8 @@ sphinx-design==0.6.1
 sphinxcontrib-jquery==4.0
 shibuya==2026.5.19
 
-# Needed by test/test_sockets.py
+# Needed by tests in test_sockets.py
 websockify==0.12.0
+
+# Needed by tests in test_other.py
+meson==1.11.2

--- a/test/meson/simple/main.c
+++ b/test/meson/simple/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+  printf("sizeof pointer: %zu\n", sizeof(void*));
+  return 0;
+}

--- a/test/meson/simple/meson.build
+++ b/test/meson/simple/meson.build
@@ -1,0 +1,3 @@
+project('simple', 'c')
+exe = executable('hello', 'main.c')
+test('simple_test', exe)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -248,7 +248,7 @@ def requires_tool(tool, env_name=None):
         env_var = f'EMTEST_SKIP_{tool.upper()}'
       if not shutil.which(tool):
         if env_var in os.environ:
-          self.skipTest(f'test requires ccache and {env_var} is set')
+          self.skipTest(f'test requires {tool} and {env_var} is set')
         else:
           self.fail(f'{tool} required to run this test.  Use {env_var} to skip')
       return func(self, *args, **kwargs)
@@ -3380,6 +3380,28 @@ More info: https://emscripten.org
     })
 
     self.run_process([path_from_root('emscons'), 'scons', '--expected-env', expected_to_propagate])
+
+  @crossplatform
+  @requires_tool('meson')
+  @requires_ninja
+  @with_env_modify({'PATH': path_from_root() + os.pathsep + os.getenv('PATH', '')})
+  def test_meson(self):
+    self.run_process(['meson', 'setup', '.', test_file('meson/simple'), '--cross-file', path_from_root('tools/meson/wasm32-emscripten.ini')])
+    self.run_process(['meson', 'compile', '-C', '.'])
+    output = self.run_js('hello.js')
+    self.assertContained('sizeof pointer: 4', output)
+    self.run_process(['meson', 'test', '-C', '.'])
+
+  @requires_tool('meson')
+  @requires_ninja
+  @requires_wasm64
+  @with_env_modify({'PATH': path_from_root() + os.pathsep + os.getenv('PATH', '')})
+  def test_meson_wasm64(self):
+    self.run_process(['meson', 'setup', '.', test_file('meson/simple'), '--cross-file', path_from_root('tools/meson/wasm64-emscripten.ini')])
+    self.run_process(['meson', 'compile', '-C', '.'])
+    output = self.run_js('hello.js')
+    self.assertContained('sizeof pointer: 8', output)
+    self.run_process(['meson', 'test', '-C', '.'])
 
   def test_embind_fail(self):
     self.assert_fail([EMXX, test_file('embind/test_unsigned.cpp')], 'undefined symbol: _embind_register_function')

--- a/tools/meson/wasm32-emscripten.ini
+++ b/tools/meson/wasm32-emscripten.ini
@@ -1,0 +1,15 @@
+# Example Meson cross file for Emscripten (wasm32)
+# Usage: meson setup builddir --cross-file tools/meson/wasm32-emscripten.ini
+
+[binaries]
+c = 'emcc'
+cpp = 'em++'
+ar = 'emar'
+ranlib = 'emranlib'
+exe_wrapper = 'node'
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm32'
+endian = 'little'

--- a/tools/meson/wasm64-emscripten.ini
+++ b/tools/meson/wasm64-emscripten.ini
@@ -1,0 +1,21 @@
+# Example Meson cross file for Emscripten (wasm64)
+# Usage: meson setup builddir --cross-file tools/meson/wasm64-emscripten.ini
+
+[binaries]
+c = 'emcc'
+cpp = 'em++'
+ar = 'emar'
+ranlib = 'emranlib'
+exe_wrapper = 'node'
+
+[built-in options]
+c_args = ['-m64']
+c_link_args = ['-m64']
+cpp_args = ['-m64']
+cpp_link_args = ['-m64']
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm64'
+cpu = 'wasm64'
+endian = 'little'


### PR DESCRIPTION
This is a meta-build-system (like cmake) that generated Ninja by
default.  It pretty popular in certain open source communities.  For
example the whole Gnome and X.Org / Wayland is based on it.

Add simple tests for the meson build system along with example cross
files for `wasm32` and `wasm64` in `test/meson/`.

* `test/meson/wasm32-emscripten.ini`: Cross file for wasm32 with `node` wrapper.
* `test/meson/wasm64-emscripten.ini`: Cross file for wasm64 with `-m64` flags.
* `test/meson/simple/`: C test project for standard Meson build.
