### PR TITLE
Allow `-pthreads` as well as `-pthread`

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -14429,12 +14429,9 @@ w:0,t:0x[0-9a-fA-F]+: formatted: 42
     self.run_process([EMXX, '-std=c++20', test_file('other/hello_world.cppm'), '--precompile', '-o', 'hello_world.pcm'])
     self.do_other_test('test_cpp_module.cpp', cflags=['-std=c++20', '-fprebuilt-module-path=.', 'hello_world.pcm'])
 
-  @crossplatform
   def test_pthreads_flag(self):
-    # We support just the singular form of `-pthread`, like gcc
-    # Clang supports the plural form too but I think just due to historical accident:
-    # See https://github.com/llvm/llvm-project/commit/c800391fb974cdaaa62bd74435f76408c2e5ceae
-    self.assert_fail([EMCC, '-pthreads', '-c', test_file('hello_world.c')], 'emcc: error: unrecognized command-line option `-pthreads`; did you mean `-pthread`?')
+    # Test support for plural `-pthreads` flag
+    self.do_runf_out_file('hello_world.c', cflags=['-pthreads'])
 
   def test_missing_struct_info(self):
     create_file('lib.js', '''

--- a/tools/cmdline.py
+++ b/tools/cmdline.py
@@ -537,7 +537,7 @@ def parse_args(newargs):  # ruff: ignore[complex-structure, too-many-branches, t
       options.openmp = 1
       settings.PTHREADS = 1
       settings.USE_PTHREADS = 1
-    elif arg == '-pthread':
+    elif arg in {'-pthread', '-pthreads'}:
       settings.PTHREADS = 1
       # Also set the legacy setting name, in case use JS code depends on it.
       settings.USE_PTHREADS = 1
@@ -545,8 +545,6 @@ def parse_args(newargs):  # ruff: ignore[complex-structure, too-many-branches, t
       settings.PTHREADS = 0
       # Also set the legacy setting name, in case use JS code depends on it.
       settings.USE_PTHREADS = 0
-    elif arg == '-pthreads':
-      exit_with_error('unrecognized command-line option `-pthreads`; did you mean `-pthread`?')
     elif arg == '-fno-rtti':
       settings.USE_RTTI = 0
     elif arg == '-frtti':


### PR DESCRIPTION
This is just to to match upstream clang behavior.