### PR TITLE
Fix warnings in box2d and bullet benchmarks. NFC

### DIFF
--- a/test/benchmark/test_box2d_benchmark.cpp
+++ b/test/benchmark/test_box2d_benchmark.cpp
@@ -26,6 +26,9 @@ typedef struct {
 #include <cstdio>
 #include <time.h>
 #include <math.h>
+#include <limits>
+
+#define MAX_CLOCK_T std::numeric_limits<clock_t>::max()
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
@@ -63,7 +66,7 @@ result_t measure(clock_t *times) {
 }
 
 b2World *world;
-clock_t *times, minn = CLOCKS_PER_SEC * 1000 * 100, maxx = -1;
+clock_t *times, minn = MAX_CLOCK_T, maxx = -1;
 b2Body* topBody;
 int32 frameCounter = 0;
 

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -1112,26 +1112,38 @@ class benchmark(common.RunnerCore):
     def lib_builder(name, native, env_init):
       return self.get_library(os.path.join('third_party', 'box2d'), ['box2d.a'], configure=None, native=native, cache_name_extra=name, env_init=env_init)
 
-    self.do_benchmarkf('box2d', 'benchmark/test_box2d_benchmark.cpp', 'frame averages', shared_args=['-I' + test_file('third_party/box2d')], lib_builder=lib_builder)
+    cflags = ['-Wno-null-conversion']
+    self.do_benchmarkf('box2d', 'benchmark/test_box2d_benchmark.cpp', 'frame averages', shared_args=['-I' + test_file('third_party/box2d')], lib_builder=lib_builder, emcc_args=cflags, native_args=cflags)
 
   def test_zzz_bullet(self):
     self.cflags.remove('-Werror')
-    self.cflags += ['-Wno-c++11-narrowing', '-Wno-deprecated-register', '-Wno-writable-strings']
+    bullet_cflags = [
+        '-Wno-int-to-void-pointer-cast',
+        '-Wno-c++11-narrowing',
+        '-Wno-deprecated-register',
+        '-Wno-writable-strings',
+        '-Wno-shift-negative-value',
+        '-Wno-format',
+        '-Wno-nontrivial-memcall',
+        '-Wno-single-bit-bitfield-constant-conversion',
+    ]
     src = read_file(test_file('third_party/bullet/Demos/Benchmarks/BenchmarkDemo.cpp'))
     src += read_file(test_file('third_party/bullet/Demos/Benchmarks/main.cpp'))
 
     def lib_builder(name, native, env_init):
-      cflags = ' '.join(self.cflags) + ' ' + env_init.get('CFLAGS', '')
+      cflags = env_init.get('CFLAGS', '') + ' ' + ' '.join(bullet_cflags)
+      if not native:
+        cflags += ' ' + ' '.join(self.cflags)
       return self.get_library(str(Path('third_party/bullet')),
                               ['src/BulletDynamics/libBulletDynamics.a',
                                'src/BulletCollision/libBulletCollision.a',
                                'src/LinearMath/libLinearMath.a'],
                               configure=['cmake', '.'], configure_args=['-DCMAKE_POLICY_VERSION_MINIMUM=3.5', '-DBUILD_DEMOS=OFF', '-DBUILD_EXTRAS=OFF', '-DUSE_GLUT=OFF', '-DCMAKE_CXX_STANDARD=14', f'-DCMAKE_CXX_FLAGS={cflags}'],
-                              make=['cmake', '--build', '.', '--'], make_args=[], native=native, cache_name_extra=name, env_init=env_init)
+                              make=['cmake', '--build', '.', '--'], native=native, cache_name_extra=name, env_init=env_init)
 
     self.do_benchmark('bullet', src, '\nok.\n',
                       shared_args=['-I' + test_file('third_party/bullet/src'), '-I' + test_file('third_party/bullet/Demos/Benchmarks')],
-                      lib_builder=lib_builder)
+                      lib_builder=lib_builder, native_args=bullet_cflags, emcc_args=bullet_cflags)
 
   def test_zzz_lzma(self):
     def lib_builder(name, native, env_init):


### PR DESCRIPTION
Also, allow bullet to build in parallel by removing `make_args=[]`.