### PR TITLE
Remove extra line breaks in JS error messages. NFC

### DIFF
--- a/src/jsifier.mjs
+++ b/src/jsifier.mjs
@@ -580,9 +580,7 @@ function(${args}) {
     // of argument.
     if (LINK_AS_CXX && !WASM_EXCEPTIONS && symbol.startsWith('__cxa_find_matching_catch_')) {
       if (DISABLE_EXCEPTION_THROWING) {
-        error(
-          'DISABLE_EXCEPTION_THROWING was set (likely due to -fno-exceptions), which means no C++ exception throwing support code is linked in, but exception catching code appears. Either do not set DISABLE_EXCEPTION_THROWING (if you do want exception throwing) or compile all source files with -fno-exceptions (so that no exceptions support code is required); also make sure DISABLE_EXCEPTION_CATCHING is set to the right value - if you want exceptions, it should be off, and vice versa.',
-        );
+        error('DISABLE_EXCEPTION_THROWING was set (likely due to -fno-exceptions), which means no C++ exception throwing support code is linked in, but exception catching code appears. Either do not set DISABLE_EXCEPTION_THROWING (if you do want exception throwing) or compile all source files with -fno-exceptions (so that no exceptions support code is required); also make sure DISABLE_EXCEPTION_CATCHING is set to the right value - if you want exceptions, it should be off, and vice versa.');
         return;
       }
       if (!(symbol in LibraryManager.library)) {
@@ -777,9 +775,7 @@ function(${args}) {
         // in libcore.js and libpthread.js.  These happen before deps are
         // processed so depending on it via `__deps` doesn't work.
         if (dep === '$noExitRuntime') {
-          error(
-            'noExitRuntime cannot be referenced via __deps mechanism.  Use DEFAULT_LIBRARY_FUNCS_TO_INCLUDE or EXPORTED_RUNTIME_METHODS',
-          );
+          error('noExitRuntime cannot be referenced via __deps mechanism.  Use DEFAULT_LIBRARY_FUNCS_TO_INCLUDE or EXPORTED_RUNTIME_METHODS');
         }
         return addFromLibrary(dep, `${symbol}, referenced by ${dependent}`);
       }

--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -102,9 +102,7 @@ export function mergeInto(obj, other, options = null) {
     if (options.noOverride) {
       for (const key of Object.keys(other)) {
         if (obj.hasOwnProperty(key)) {
-          error(
-            `Symbol re-definition in JavaScript library: ${key}. Do not use noOverride if this is intended`,
-          );
+          error(`Symbol re-definition in JavaScript library: ${key}. Do not use noOverride if this is intended`);
           return;
         }
       }
@@ -163,15 +161,11 @@ export function mergeInto(obj, other, options = null) {
       if (decoratorName === '__deps') {
         const deps = other[key];
         if (!Array.isArray(deps)) {
-          error(
-            `JS library directive ${key}=${deps} is of type '${type}', but it should be an array`,
-          );
+          error(`JS library directive ${key}=${deps} is of type '${type}', but it should be an array`);
         }
         for (const dep of deps) {
           if (dep && typeof dep !== 'string' && typeof dep !== 'function') {
-            error(
-              `__deps entries must be of type 'string' or 'function' not '${typeof dep}': ${key}`,
-            );
+            error(`__deps entries must be of type 'string' or 'function' not '${typeof dep}': ${key}`);
           }
         }
       } else {


### PR DESCRIPTION
The line breaks here don't really help because the strings themselves are already way over the max line length.

IMHO these extra line breaks only hurt readability.