### PR TITLE
[test] Assert parameterize arguments are tuples and convert test lists

### DIFF
--- a/test/decorators.py
+++ b/test/decorators.py
@@ -637,7 +637,9 @@ def parameterize(func, parameters):
   """
   prev = getattr(func, '_parameterize', None)
   assert not any(p.startswith('_') for p in parameters), 'test variant names should not start with _'
+  assert all(isinstance(v, tuple) for v in parameters.values()), f'parameter values must be tuples: {parameters}'
   if prev:
+    assert all(isinstance(v, tuple) for v in prev.values()), f'previous parameter values must be tuples: {prev}'
     # If we're parameterizing 2nd time, construct a cartesian product for various combinations.
     func._parameterize = {
       '_'.join(filter(None, [k1, k2])): v2 + v1 for (k1, v1), (k2, v2) in itertools.product(prev.items(), parameters.items())

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -4004,8 +4004,8 @@ Module["preRun"] = () => {
     self.btest('core/test_safe_stack.c', expected='abort:stack overflow', cflags=['-pthread', '-sPROXY_TO_PTHREAD', '-sSTACK_OVERFLOW_CHECK=2', '-sSTACK_SIZE=64KB'])
 
   @parameterized({
-    'leak': ['test_pthread_lsan_leak', ['-gsource-map']],
-    'no_leak': ['test_pthread_lsan_no_leak', []],
+    'leak': ('test_pthread_lsan_leak', ['-gsource-map']),
+    'no_leak': ('test_pthread_lsan_no_leak', []),
   })
   @no_firefox('https://github.com/emscripten-core/emscripten/issues/15978')
   @no_safari('TODO: browser.test_pthread_lsan_leak fails with /report_result?0') # Fails in Safari 17.6 (17618.3.11.11.7, 17618), Safari 26.0.1 (21622.1.22.11.15)
@@ -4015,8 +4015,8 @@ Module["preRun"] = () => {
   @no_highmem('ASAN + GLOBAL_BASE')
   @parameterized({
     # Reusing the LSan test files for ASan.
-    'leak': ['test_pthread_lsan_leak', ['-gsource-map']],
-    'no_leak': ['test_pthread_lsan_no_leak', []],
+    'leak': ('test_pthread_lsan_leak', ['-gsource-map']),
+    'no_leak': ('test_pthread_lsan_no_leak', []),
   })
   @no_safari('TODO: browser.test_pthread_asan_leak fails with /report_result?0') # Fails in Safari 17.6 (17618.3.11.11.7, 17618), Safari 26.0.1 (21622.1.22.11.15)
   def test_pthread_asan(self, name, args):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -936,9 +936,9 @@ class TestCoreBase(RunnerCore):
   @no_asan('ASan does not support custom memory allocators')
   @no_lsan('LSan does not support custom memory allocators')
   @parameterized({
-    'normal': [],
-    'memvalidate': ['-DEMMALLOC_MEMVALIDATE'],
-    'memvalidate_verbose': ['-DEMMALLOC_MEMVALIDATE', '-DEMMALLOC_VERBOSE', '-DRANDOM_ITERS=130'],
+    'normal': (),
+    'memvalidate': ('-DEMMALLOC_MEMVALIDATE',),
+    'memvalidate_verbose': ('-DEMMALLOC_MEMVALIDATE', '-DEMMALLOC_VERBOSE', '-DRANDOM_ITERS=130'),
   })
   def test_emmalloc(self, *args):
     self.maybe_closure()
@@ -9041,8 +9041,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @asan
   @parameterized({
-    'c': ['test_asan_no_error.c'],
-    'cpp': ['test_asan_no_error.cpp'],
+    'c': ('test_asan_no_error.c',),
+    'cpp': ('test_asan_no_error.cpp',),
   })
   def test_asan_no_error(self, name):
     self.do_runf('core/' + name, 'done\n', cflags=['-fsanitize=address'])
@@ -9657,8 +9657,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_core_test('test_externref.c', libraries=['asm.o'])
 
   @parameterized({
-    '': [False],
-    'dynlink': [True],
+    '': (False,),
+    'dynlink': (True,),
   })
   @requires_node
   @no_wasm2js('wasm2js does not support reference types')
@@ -9671,8 +9671,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_core_test('test_externref_emjs.c', cflags=['-mreference-types'])
 
   @parameterized({
-    '': [False],
-    'dylink': [True],
+    '': (False,),
+    'dylink': (True,),
   })
   @no_esm_integration('https://github.com/emscripten-core/emscripten/issues/25543')
   @no_omit_asm_module_exports('https://github.com/emscripten-core/emscripten/issues/25550')

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -514,8 +514,8 @@ class other(RunnerCore):
     self.assertExists('foo.js')
 
   @parameterized({
-    'c': [EMCC, '.c'],
-    'cxx': [EMXX, '.cpp'],
+    'c': (EMCC, '.c'),
+    'cxx': (EMXX, '.cpp'),
   })
   def test_emcc_basics(self, compiler, suffix):
     # emcc src.cpp ==> writes a.out.js and a.out.wasm
@@ -575,8 +575,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     self.assertContained('wasm64-unknown-emscripten', output)
 
   @parameterized({
-    'c': [EMCC, '.c'],
-    'cxx': [EMXX, '.cpp'],
+    'c': (EMCC, '.c'),
+    'cxx': (EMXX, '.cpp'),
   })
   def test_emcc_2(self, compiler, suffix):
     # emcc src.cpp -c    and   emcc -c src.cpp -o src.[o|foo|so] ==> should always give an object file
@@ -607,8 +607,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     self.run_process([EMCC, 'out.a'])
 
   @parameterized({
-    'c': [EMCC, '.c'],
-    'cxx': [EMXX, '.cpp'],
+    'c': (EMCC, '.c'),
+    'cxx': (EMXX, '.cpp'),
   })
   def test_emcc_3(self, compiler, suffix):
     # handle singleton archives
@@ -745,9 +745,9 @@ f.close()
 
   @crossplatform
   @parameterized({
-    '': [[]],
-    'lto': [['-flto']],
-    'wasm64': [['-m64']],
+    '': ([],),
+    'lto': (['-flto'],),
+    'wasm64': (['-m64'],),
   })
   def test_print_search_dirs(self, args):
     output = self.run_process([EMCC, '-print-search-dirs'] + args, stdout=PIPE).stdout
@@ -765,9 +765,9 @@ f.close()
 
   @crossplatform
   @parameterized({
-    '': [[]],
-    'lto': [['-flto']],
-    'wasm64': [['-m64']],
+    '': ([],),
+    'lto': (['-flto'],),
+    'wasm64': (['-m64'],),
   })
   def test_print_libgcc_file_name(self, args):
     output = self.run_process([EMCC, '-print-libgcc-file-name'] + args, stdout=PIPE).stdout
@@ -799,9 +799,9 @@ f.close()
 
   @crossplatform
   @parameterized({
-    '': [[]],
-    'lto': [['-flto']],
-    'wasm64': [['-m64']],
+    '': ([],),
+    'lto': (['-flto'],),
+    'wasm64': (['-m64'],),
   })
   def test_print_file_name(self, args):
     # make sure the corresponding version of libc exists in the cache
@@ -1021,8 +1021,8 @@ f.close()
   # needs C++17 (embind)
   @requires_ninja
   @parameterized({
-    '': [[]],
-    'no_gnu': [['-DNO_GNU_EXTENSIONS=1']],
+    '': ([],),
+    'no_gnu': (['-DNO_GNU_EXTENSIONS=1'],),
   })
   def test_cmake_with_embind_cpp11_mode(self, args):
     # Use ninja generator here since we assume its always installed on our build/test machines.
@@ -1063,8 +1063,8 @@ f.close()
     self.assertContained(include_dir_cxx, command)
 
   @parameterized({
-    '': ['0'],
-    'suffix': ['1'],
+    '': ('0',),
+    'suffix': ('1',),
   })
   def test_cmake_static_lib(self, custom):
     # Test that one is able to use custom suffixes for static libraries.
@@ -1169,9 +1169,9 @@ f.close()
     self.assertContained('-sUSE_BULLET', out)
 
   @parameterized({
-    '': [None],
-    'wasm64': ['-m64'],
-    'pthreads': ['-pthread'],
+    '': (None,),
+    'wasm64': ('-m64',),
+    'pthreads': ('-pthread',),
   })
   def test_cmake_check_type_size(self, cflag):
     if cflag == '-m64':
@@ -1404,8 +1404,8 @@ f.close()
     self.assertContained('|0|', self.run_js('a.js'))
 
   @parameterized({
-    'expand_symlinks': [[]],
-    'no_canonical_prefixes': [['-no-canonical-prefixes']],
+    'expand_symlinks': ([],),
+    'no_canonical_prefixes': (['-no-canonical-prefixes'],),
   })
   @no_windows('Windows does not support symlinks')
   def test_symlink_points_to_bad_suffix(self, flags):
@@ -2883,14 +2883,14 @@ More info: https://emscripten.org
     self.run_process(cmd)
 
   @parameterized({
-    '': [[]],
-    'O1': [['-O1']],
-    'GL2': [['-sMAX_WEBGL_VERSION=2']],
+    '': ([],),
+    'O1': (['-O1'],),
+    'GL2': (['-sMAX_WEBGL_VERSION=2'],),
   })
   @parameterized({
-    'warn': ['WARN'],
-    'error': ['ERROR'],
-    'ignore': [None],
+    'warn': ('WARN',),
+    'error': ('ERROR',),
+    'ignore': (None,),
   })
   def test_undefined_symbols(self, args, action):
     create_file('main.c', r'''
@@ -3497,14 +3497,14 @@ More info: https://emscripten.org
                  cflags=['--no-entry', '-lembind', '-O2', '--closure=1', '--minify=0', '--post-js=post.js'])
 
   @parameterized({
-    'val_1': ['embind/test_embind_no_raw_pointers_val_1.cpp'],
-    'val_2': ['embind/test_embind_no_raw_pointers_val_2.cpp'],
-    'val_3': ['embind/test_embind_no_raw_pointers_val_3.cpp'],
-    'val_invoke': ['embind/test_embind_no_raw_pointers_val_invoke.cpp'],
-    'val_call': ['embind/test_embind_no_raw_pointers_val_call.cpp'],
-    'val_new': ['embind/test_embind_no_raw_pointers_val_new.cpp'],
-    'wrong_ret_allow': ['embind/test_embind_wrong_ret_allow.cpp'],
-    'wrong_arg_allow': ['embind/test_embind_wrong_arg_allow.cpp'],
+    'val_1': ('embind/test_embind_no_raw_pointers_val_1.cpp',),
+    'val_2': ('embind/test_embind_no_raw_pointers_val_2.cpp',),
+    'val_3': ('embind/test_embind_no_raw_pointers_val_3.cpp',),
+    'val_invoke': ('embind/test_embind_no_raw_pointers_val_invoke.cpp',),
+    'val_call': ('embind/test_embind_no_raw_pointers_val_call.cpp',),
+    'val_new': ('embind/test_embind_no_raw_pointers_val_new.cpp',),
+    'wrong_ret_allow': ('embind/test_embind_wrong_ret_allow.cpp',),
+    'wrong_arg_allow': ('embind/test_embind_wrong_arg_allow.cpp',),
   })
   def test_embind_no_raw_pointers(self, filename):
     self.assert_fail([EMCC, '-lembind', test_file(filename)], 'Implicitly binding raw pointers is illegal')
@@ -3517,25 +3517,25 @@ More info: https://emscripten.org
 
   @is_slow_test
   @parameterized({
-    '': [],
-    'no_utf8': ['-sEMBIND_STD_STRING_IS_UTF8=0'],
-    'no_dynamic': ['-sDYNAMIC_EXECUTION=0'],
-    'aot_js': ['-sDYNAMIC_EXECUTION=0', '-sEMBIND_AOT', '-DSKIP_UNBOUND_TYPES'],
-    'wasm64': ['-m64'],
-    '2gb': ['-sINITIAL_MEMORY=2200mb', '-sGLOBAL_BASE=2gb'],
+    '': (),
+    'no_utf8': ('-sEMBIND_STD_STRING_IS_UTF8=0',),
+    'no_dynamic': ('-sDYNAMIC_EXECUTION=0',),
+    'aot_js': ('-sDYNAMIC_EXECUTION=0', '-sEMBIND_AOT', '-DSKIP_UNBOUND_TYPES'),
+    'wasm64': ('-m64',),
+    '2gb': ('-sINITIAL_MEMORY=2200mb', '-sGLOBAL_BASE=2gb'),
   })
   @parameterized({
     # With no arguments we are testing the default C++ version provided by clang.
-    '': [],
+    '': (),
     # Ensure embind compiles under C++17 which is the minimum supported version.
-    'cxx17': ['-std=c++17', '-Wno-#warnings'],
-    'o1': ['-O1'],
-    'o2': ['-O2'],
-    'o2_mem_growth': ['-O2', '-sALLOW_MEMORY_GROWTH', test_file('embind/isMemoryGrowthEnabled=true.cpp')],
-    'o2_closure': ['-O2', '--closure=1', '--closure-args', '--externs ' + shlex.quote(test_file('embind/underscore-externs.js')), '-sASSERTIONS=1'],
-    'strict_js': ['-sSTRICT_JS'],
+    'cxx17': ('-std=c++17', '-Wno-#warnings'),
+    'o1': ('-O1',),
+    'o2': ('-O2',),
+    'o2_mem_growth': ('-O2', '-sALLOW_MEMORY_GROWTH', test_file('embind/isMemoryGrowthEnabled=true.cpp')),
+    'o2_closure': ('-O2', '--closure=1', '--closure-args', '--externs ' + shlex.quote(test_file('embind/underscore-externs.js')), '-sASSERTIONS=1'),
+    'strict_js': ('-sSTRICT_JS',),
     # DYNCALLS tests the legacy native function API (ASYNCIFY implicitly enables DYNCALLS)
-    'dyncalls': ['-sDYNCALLS=1'],
+    'dyncalls': ('-sDYNCALLS=1',),
   })
   def test_embind(self, *extra_args):
     # This test is actually a large set of smaller JS unittest.
@@ -3636,8 +3636,8 @@ More info: https://emscripten.org
 
   @requires_jspi
   @parameterized({
-    '': [['-sJSPI_EXPORTS=async*']],
-    'deprecated': [['-Wno-deprecated', '-sASYNCIFY_EXPORTS=async*']],
+    '': (['-sJSPI_EXPORTS=async*'],),
+    'deprecated': (['-Wno-deprecated', '-sASYNCIFY_EXPORTS=async*'],),
   })
   def test_jspi_wildcard(self, args):
     self.do_runf('other/test_jspi_wildcard.c', 'done\n', cflags=args)
@@ -3678,9 +3678,9 @@ More info: https://emscripten.org
   @parameterized({
     # Use `node16` to avoid the deprecated `node` moduleResolution in TS 6.0+. Since there is no
     # `type: "module"` in package.json, this still tests CommonJS.
-    'commonjs': [['-sMODULARIZE'], ['--module', 'node16', '--moduleResolution', 'node16']],
-    'esm': [['-sEXPORT_ES6'], ['--module', 'NodeNext', '--moduleResolution', 'nodenext']],
-    'esm_with_jsgen': [['-sEXPORT_ES6', '-sEMBIND_AOT'], ['--module', 'NodeNext', '--moduleResolution', 'nodenext']],
+    'commonjs': (['-sMODULARIZE'], ['--module', 'node16', '--moduleResolution', 'node16']),
+    'esm': (['-sEXPORT_ES6'], ['--module', 'NodeNext', '--moduleResolution', 'nodenext']),
+    'esm_with_jsgen': (['-sEXPORT_ES6', '-sEMBIND_AOT'], ['--module', 'NodeNext', '--moduleResolution', 'nodenext']),
   })
   def test_embind_tsgen_end_to_end(self, opts, tsc_opts):
     # Check that TypeScript generation works and that the program is runs as
@@ -3704,7 +3704,7 @@ More info: https://emscripten.org
   # These extra arguments are not related to TS binding generation but we want to
   # verify that they do not interfere with it.
   @parameterized({
-    '1': [['-sALLOW_MEMORY_GROWTH=1',
+    '1': (['-sALLOW_MEMORY_GROWTH=1',
            '-Wno-pthreads-mem-growth',
            '-sMAXIMUM_MEMORY=4GB',
            '--pre-js', 'fail.js',
@@ -3721,18 +3721,18 @@ More info: https://emscripten.org
            '-sPTHREAD_POOL_SIZE=1',
            '-sSINGLE_FILE',
            '-lembind', # Test duplicated link option.
-          ], 'embind_tsgen_ignore_1.d.ts'],
-    '2': [['--embed-file', 'fail.js',
+          ], 'embind_tsgen_ignore_1.d.ts'),
+    '2': (['--embed-file', 'fail.js',
            '-sMINIMAL_RUNTIME=2',
            '-sEXPORT_ES6=1',
            '-sASSERTIONS=0',
            '-sSTRICT=1',
-          ], 'embind_tsgen_ignore_2.d.ts'],
-    '3': [['-sWASM=0'], 'embind_tsgen_ignore_3.d.ts'],
-    '4': [['-fsanitize=undefined', '-gsource-map'], 'embind_tsgen_ignore_3.d.ts'],
-    '5': [['-sASYNCIFY'], 'embind_tsgen_ignore_3.d.ts'],
-    '6': [['-sENVIRONMENT=worker', '-lworkerfs.js'], 'embind_tsgen.d.ts'],
-    '7': [['-m64', '-gsource-map'], 'embind_tsgen_ignore_7.d.ts'],
+          ], 'embind_tsgen_ignore_2.d.ts'),
+    '3': (['-sWASM=0'], 'embind_tsgen_ignore_3.d.ts'),
+    '4': (['-fsanitize=undefined', '-gsource-map'], 'embind_tsgen_ignore_3.d.ts'),
+    '5': (['-sASYNCIFY'], 'embind_tsgen_ignore_3.d.ts'),
+    '6': (['-sENVIRONMENT=worker', '-lworkerfs.js'], 'embind_tsgen.d.ts'),
+    '7': (['-m64', '-gsource-map'], 'embind_tsgen_ignore_7.d.ts'),
   })
   def test_embind_tsgen_ignore(self, extra_args, expected_ts_file):
     create_file('fail.js', 'assert(false);')
@@ -3804,9 +3804,9 @@ More info: https://emscripten.org
     self.assertFilesMatch(test_file('other/embind_tsgen_bigint.d.ts'), 'embind_tsgen_bigint.d.ts')
 
   @parameterized({
-    '': [[]],
-    'pthread': [['-pthread']],
-    'maximum_memory_over_4gb': [['-Wno-pthreads-mem-growth', '-pthread', '-sALLOW_MEMORY_GROWTH=1', '-sMAXIMUM_MEMORY=16GB']],
+    '': ([],),
+    'pthread': (['-pthread'],),
+    'maximum_memory_over_4gb': (['-Wno-pthreads-mem-growth', '-pthread', '-sALLOW_MEMORY_GROWTH=1', '-sMAXIMUM_MEMORY=16GB'],),
   })
   @requires_wasm64
   def test_embind_tsgen_wasm64(self, args):
@@ -3825,8 +3825,8 @@ More info: https://emscripten.org
     self.assertFilesMatch(test_file('other/embind_tsgen_jspi.d.ts'), 'embind_tsgen_jspi.d.ts')
 
   @parameterized({
-    '': [0],
-    'legacy': [1],
+    '': (0,),
+    'legacy': (1,),
   })
   def test_embind_tsgen_exceptions(self, legacy):
     if not legacy and shared.get_node_version(config.NODE_JS)[0] < 22:
@@ -3847,9 +3847,9 @@ More info: https://emscripten.org
 
   @requires_dev_dependency('typescript')
   @parameterized({
-    '': [[], ''],
-    'jspi': [['-sJSPI', '-sJSPI_EXPORTS=fooVoid,fooInt'], '_jspi'],
-    'jspi_wildcard': [['-sJSPI', '-sJSPI_EXPORTS=foo*'], '_jspi'],
+    '': ([], ''),
+    'jspi': (['-sJSPI', '-sJSPI_EXPORTS=fooVoid,fooInt'], '_jspi'),
+    'jspi_wildcard': (['-sJSPI', '-sJSPI_EXPORTS=foo*'], '_jspi'),
   })
   def test_emit_tsd(self, args, postfix):
     if postfix == '_jspi':
@@ -4654,8 +4654,8 @@ Module.print = (x) => { throw '<{(' + x + ')}>' };
     self.run_process([EMCC, '-Werror', '-xc++-header', 'header.h'])
 
   @parameterized({
-    'gch': ['gch'],
-    'pch': ['pch'],
+    'gch': ('gch',),
+    'pch': ('pch',),
   })
   @crossplatform
   def test_precompiled_headers(self, suffix):
@@ -4897,8 +4897,8 @@ int main() {
       self.assertContained('Hello, world!', self.run_js('a.out.js'))
 
   @parameterized({
-    '': [[]],
-    'O1': [['-O1']],
+    '': ([],),
+    'O1': (['-O1'],),
   })
   def test_fs_after_main(self, args):
     self.do_runf('test_fs_after_main.c', 'Test passed.', cflags=args)
@@ -5030,13 +5030,13 @@ Waste<3> *getMore() {
 
   @crossplatform
   @parameterized({
-    'O2': [['-O2']],
-    'O3': [['-O3']],
+    'O2': (['-O2'],),
+    'O3': (['-O3'],),
   })
   @parameterized({
-    '': [1],
-    'wasm2js': [0],
-    'wasm2js_2': [2],
+    '': (1,),
+    'wasm2js': (0,),
+    'wasm2js_2': (2,),
   })
   @no_bun('https://github.com/emscripten-core/emscripten/issues/26197')
   @no_deno('https://github.com/emscripten-core/emscripten/issues/26234')
@@ -5136,10 +5136,10 @@ int main() {
       self.assertContained(UNMINIFIED_MIDDLE, js)
 
   @parameterized({
-    '': [[]],
+    '': ([],),
     # bigint support is interesting to test here because it changes which
     # binaryen tools get run, which can affect how debug info is kept around
-    'nobigint': [['-sWASM_BIGINT=0']],
+    'nobigint': (['-sWASM_BIGINT=0'],),
   })
   def test_symbol_map_output_size(self, args):
     # build with and without a symbol map and verify that the sizes are the
@@ -5321,8 +5321,8 @@ int main(int argc, char **argv) {
     self.assertContained('I am ' + utils.normalize_path(os.path.realpath(self.get_dir())) + '/code.js', utils.normalize_path(output))
 
   @parameterized({
-    'no_exit_runtime': [True],
-    '': [False],
+    'no_exit_runtime': (True,),
+    '': (False,),
   })
   def test_returncode(self, no_exit):
     create_file('src.c', r'''
@@ -5670,15 +5670,15 @@ __EMSCRIPTEN_MAJOR__ __EMSCRIPTEN_MINOR__ __EMSCRIPTEN_TINY__ EMSCRIPTEN_KEEPALI
     self.do_runf('fs/test_fs_dev_random.c', 'done\n')
 
   @parameterized({
-    'none': [{'EMCC_FORCE_STDLIBS': None}, False],
+    'none': ({'EMCC_FORCE_STDLIBS': None}, False),
     # forced libs is ok, they were there anyhow
-    'normal': [{'EMCC_FORCE_STDLIBS': 'libc,libc++abi,libc++'}, False],
+    'normal': ({'EMCC_FORCE_STDLIBS': 'libc,libc++abi,libc++'}, False),
     # partial list, but ok since we grab them as needed
-    'partial': [{'EMCC_FORCE_STDLIBS': 'libc++'}, False],
+    'partial': ({'EMCC_FORCE_STDLIBS': 'libc++'}, False),
     # fail! not enough stdlibs
-    'partial_only': [{'EMCC_FORCE_STDLIBS': 'libc++,libc,libc++abi', 'EMCC_ONLY_FORCED_STDLIBS': '1'}, True],
+    'partial_only': ({'EMCC_FORCE_STDLIBS': 'libc++,libc,libc++abi', 'EMCC_ONLY_FORCED_STDLIBS': '1'}, True),
     # force all the needed stdlibs, so this works even though we ignore the input file
-    'full_only': [{'EMCC_FORCE_STDLIBS': 'libc,libc++abi,libc++,libmalloc', 'EMCC_ONLY_FORCED_STDLIBS': '1'}, False],
+    'full_only': ({'EMCC_FORCE_STDLIBS': 'libc,libc++abi,libc++,libmalloc', 'EMCC_ONLY_FORCED_STDLIBS': '1'}, False),
   })
   def test_only_force_stdlibs(self, env, fail):
     cmd = [EMXX, test_file('hello_libcxx.cpp')]
@@ -8787,10 +8787,10 @@ int main() {
     self.assertContained('Hello, world!', self.run_js('a.out.js'))
 
   @parameterized({
-    'noexcept': [],
-    'except_emscripten': ['-sDISABLE_EXCEPTION_CATCHING=0'],
-    'except_wasm': ['-fwasm-exceptions', '-sWASM_LEGACY_EXCEPTIONS=0'],
-    'except_wasm_legacy': ['-fwasm-exceptions', '-sWASM_LEGACY_EXCEPTIONS'],
+    'noexcept': (),
+    'except_emscripten': ('-sDISABLE_EXCEPTION_CATCHING=0',),
+    'except_wasm': ('-fwasm-exceptions', '-sWASM_LEGACY_EXCEPTIONS=0'),
+    'except_wasm_legacy': ('-fwasm-exceptions', '-sWASM_LEGACY_EXCEPTIONS'),
   })
   def test_lto_libcxx(self, *args):
     self.run_process([EMXX, test_file('hello_libcxx.cpp'), '-flto'] + list(args))
@@ -9418,15 +9418,15 @@ end
 
   @crossplatform
   @parameterized({
-    '': [[]],
+    '': ([],),
     # bigint support is interesting to test here because it changes which
     # binaryen tools get run, which can affect how debug info is kept around
-    'nobigint': [['-sWASM_BIGINT=0']],
-    'pthread': [['-pthread', '-Wno-experimental']],
-    'pthread_offscreen': [['-pthread', '-Wno-experimental', '-sOFFSCREEN_FRAMEBUFFER']],
-    'wasmfs': [['-sWASMFS']],
-    'min_webgl_version': [['-sMIN_WEBGL_VERSION=2', '-sLEGACY_GL_EMULATION=0']],
-    'full_es3': [['-sMIN_WEBGL_VERSION=2', '-sLEGACY_GL_EMULATION=0', '-sFULL_ES3']],
+    'nobigint': (['-sWASM_BIGINT=0'],),
+    'pthread': (['-pthread', '-Wno-experimental'],),
+    'pthread_offscreen': (['-pthread', '-Wno-experimental', '-sOFFSCREEN_FRAMEBUFFER'],),
+    'wasmfs': (['-sWASMFS'],),
+    'min_webgl_version': (['-sMIN_WEBGL_VERSION=2', '-sLEGACY_GL_EMULATION=0'],),
+    'full_es3': (['-sMIN_WEBGL_VERSION=2', '-sLEGACY_GL_EMULATION=0', '-sFULL_ES3'],),
   })
   def test_closure_full_js_library(self, args):
     # Test for closure errors and warnings in the entire JS library.
@@ -9830,8 +9830,8 @@ int main() {
     self.assertExists('a.out.wasm.map')
 
   @parameterized({
-    'normal': [],
-    'profiling': ['--profiling'], # -gsource-map --profiling should still emit a source map; see #8584
+    'normal': (),
+    'profiling': ('--profiling',), # -gsource-map --profiling should still emit a source map; see #8584
   })
   def test_check_sourcemapurl_default(self, *args):
     if self.is_wasm2js():
@@ -11335,20 +11335,20 @@ int main(void) {
 
   @no_bun('https://github.com/emscripten-core/emscripten/issues/26198')
   @parameterized({
-    'c': ['c', [
+    'c': ('c', [
       r'in malloc .*lsan_interceptors\.cpp:\d+:\d+',
       r'(?im)in f (|[/a-z\.]:).*/test_lsan_leaks\.c:6:21$',
       r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.c:10:16$',
       r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.c:12:3$',
       r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.c:13:3$',
-    ]],
-    'cpp': ['cpp', [
+    ]),
+    'cpp': ('cpp', [
       r'in operator new\[\]\(unsigned long\) .*lsan_interceptors\.cpp:\d+:\d+',
       r'(?im)in f\(\) (|[/a-z\.]:).*/test_lsan_leaks\.cpp:4:21$',
       r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.cpp:8:16$',
       r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.cpp:10:3$',
       r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.cpp:11:3$',
-    ]],
+    ]),
   })
   def test_lsan_stack_trace(self, ext, regexes):
     self.do_runf(
@@ -11365,8 +11365,8 @@ int main(void) {
 
   @no_bun('https://github.com/emscripten-core/emscripten/issues/26198')
   @parameterized({
-    'c': ['c'],
-    'cpp': ['cpp'],
+    'c': ('c',),
+    'cpp': ('cpp',),
   })
   def test_lsan_no_leak(self, ext):
     self.do_runf('other/test_lsan_no_leak.' + ext,
@@ -11442,12 +11442,12 @@ int main(void) {
     self.do_runf('other/test_asan_strncpy.c', cflags=['-fsanitize=address'])
 
   @parameterized({
-    'asan': ['AddressSanitizer: null-pointer-dereference', '-fsanitize=address'],
-    'safe_heap': ['Aborted(segmentation fault storing 1 bytes at address 0)', '-sSAFE_HEAP'],
+    'asan': ('AddressSanitizer: null-pointer-dereference', '-fsanitize=address'),
+    'safe_heap': ('Aborted(segmentation fault storing 1 bytes at address 0)', '-sSAFE_HEAP'),
   })
   @parameterized({
-    '': [],
-    'memgrowth': ['-pthread', '-sALLOW_MEMORY_GROWTH', '-Wno-pthreads-mem-growth'],
+    '': (),
+    'memgrowth': ('-pthread', '-sALLOW_MEMORY_GROWTH', '-Wno-pthreads-mem-growth'),
   })
   def test_null_deref_via_js(self, expected_output, *args):
     # Multiple JS transforms look for pattern like `HEAPxx[...]` and transform it.
@@ -11481,8 +11481,8 @@ int main(void) {
 
   @crossplatform
   @parameterized({
-    '': ['-fno-diagnostics-color'],
-    'never': ['-fdiagnostics-color=never'],
+    '': ('-fno-diagnostics-color',),
+    'never': ('-fdiagnostics-color=never',),
   })
   @no_windows('ptys and select are not available on windows')
   def test_color_diagnostics_disable(self, flag):
@@ -11495,9 +11495,9 @@ int main(void) {
   @crossplatform
   #  There are 3 different ways for force color output in clang
   @parameterized({
-    '': ['-fcolor-diagnostics'],
-    'alt': ['-fdiagnostics-color'],
-    'always': ['-fdiagnostics-color=always'],
+    '': ('-fcolor-diagnostics',),
+    'alt': ('-fdiagnostics-color',),
+    'always': ('-fdiagnostics-color=always',),
   })
   def test_color_diagnostics_force(self, flag):
     create_file('src.c', 'int main() {')
@@ -12576,8 +12576,8 @@ exec "$@"
     self.assertContained('try_table', self.get_wasm_text('b.o'))
 
   @parameterized({
-    '': [[]],
-    'trusted': [['-sTRUSTED_TYPES']],
+    '': ([],),
+    'trusted': (['-sTRUSTED_TYPES'],),
   })
   def test_pthread_export_es6(self, args):
     self.run_process([EMCC, test_file('hello_world.c'), '-o', 'out.mjs', '-pthread', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME'] + args)
@@ -12632,9 +12632,9 @@ exec "$@"
 
   # Tests that dynCalls are produced in Closure-safe way in DYNCALLS mode when no actual dynCalls are used
   @parameterized({
-    '': [[]],
-    'asyncify': [['-sASYNCIFY']],
-    'asyncify_nobigint': [['-sASYNCIFY', '-sWASM_BIGINT=0']],
+    '': ([],),
+    'asyncify': (['-sASYNCIFY'],),
+    'asyncify_nobigint': (['-sASYNCIFY', '-sWASM_BIGINT=0'],),
   })
   def test_closure_safe(self, args):
     self.run_process([EMCC, test_file('hello_world.c'), '--closure=1'] + args)
@@ -13196,9 +13196,9 @@ void foo() {}
     self.assertExists('hello_world.dwo')
 
   @parameterized({
-    '': [[]],
-    'strict': [['-sSTRICT']],
-    'no_allow': [['-sALLOW_UNIMPLEMENTED_SYSCALLS=0']],
+    '': ([],),
+    'strict': (['-sSTRICT'],),
+    'no_allow': (['-sALLOW_UNIMPLEMENTED_SYSCALLS=0'],),
   })
   def test_unimplemented_syscalls(self, args):
     create_file('main.c', '''
@@ -15203,11 +15203,11 @@ addToLibrary({
     self.run_process([EMCC, '-sSUPPORT_BIG_ENDIAN', test_file('hello_world.c')])
 
   @parameterized({
-    'noexcept': ['-fno-exceptions'],
-    'default': [],
-    'except': ['-sDISABLE_EXCEPTION_CATCHING=0'],
-    'except_wasm': ['-fwasm-exceptions', '-sWASM_LEGACY_EXCEPTIONS=0'],
-    'except_wasm_legacy': ['-fwasm-exceptions', '-sWASM_LEGACY_EXCEPTIONS'],
+    'noexcept': ('-fno-exceptions',),
+    'default': (),
+    'except': ('-sDISABLE_EXCEPTION_CATCHING=0',),
+    'except_wasm': ('-fwasm-exceptions', '-sWASM_LEGACY_EXCEPTIONS=0'),
+    'except_wasm_legacy': ('-fwasm-exceptions', '-sWASM_LEGACY_EXCEPTIONS'),
   })
   def test_std_promise_link(self, *args):
     # Regression test for a bug where std::promise's destructor caused a link
@@ -15262,8 +15262,8 @@ addToLibrary({
 
   @requires_v8
   @parameterized({
-    '': [[]],
-    'O3': [['-O3']],
+    '': ([],),
+    'O3': (['-O3'],),
   })
   def test_fp16(self, args):
     self.v8_args += ['--wasm-fp16']

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -511,9 +511,9 @@ fi
       for_all_files(path_from_root('system/include'), utils.make_writable)
 
   @parameterized({
-    '': [False, False],
-    'response_files': [True, False],
-    'relative': [False, True],
+    '': (False, False),
+    'response_files': (True, False),
+    'relative': (False, True),
   })
   def test_emcc_cache_flag(self, use_response_files, relative):
     restore_and_set_up()

--- a/test/test_sockets.py
+++ b/test/test_sockets.py
@@ -243,11 +243,11 @@ class sockets(BrowserCore):
   # CompiledServerHarness only uses one. Start with 49160 & 49159 as the first server port
   # addresses. If adding new tests, increment the used port addresses below.
   @parameterized({
-    'websockify': [WebsockifyServerHarness, 49160, ['-DTEST_DGRAM=0']],
-    'tcp': [CompiledServerHarness, 49161, ['-DTEST_DGRAM=0']],
-    'udp': [CompiledServerHarness, 49162, ['-DTEST_DGRAM=1']],
+    'websockify': (WebsockifyServerHarness, 49160, ['-DTEST_DGRAM=0']),
+    'tcp': (CompiledServerHarness, 49161, ['-DTEST_DGRAM=0']),
+    'udp': (CompiledServerHarness, 49162, ['-DTEST_DGRAM=1']),
     # The following forces non-NULL addr and addlen parameters for the accept call
-    'accept_addr': [CompiledServerHarness, 49163, ['-DTEST_DGRAM=0', '-DTEST_ACCEPT_ADDR=1']],
+    'accept_addr': (CompiledServerHarness, 49163, ['-DTEST_DGRAM=0', '-DTEST_ACCEPT_ADDR=1']),
   })
   def test_sockets_echo(self, harness_class, port, args):
     if harness_class == WebsockifyServerHarness and common.EMTEST_LACKS_NATIVE_CLANG:
@@ -271,11 +271,11 @@ class sockets(BrowserCore):
       self.btest_exit('sockets/sdl2_net_client.c', cflags=['-sUSE_SDL=2', '-sUSE_SDL_NET=2', f'-DSOCKK={harness.listen_port}'])
 
   @parameterized({
-    'websockify': [WebsockifyServerHarness, 49166, ['-DTEST_DGRAM=0']],
-    'tcp': [CompiledServerHarness, 49167, ['-DTEST_DGRAM=0']],
-    'udp': [CompiledServerHarness, 49168, ['-DTEST_DGRAM=1']],
+    'websockify': (WebsockifyServerHarness, 49166, ['-DTEST_DGRAM=0']),
+    'tcp': (CompiledServerHarness, 49167, ['-DTEST_DGRAM=0']),
+    'udp': (CompiledServerHarness, 49168, ['-DTEST_DGRAM=1']),
     # The following forces non-NULL addr and addlen parameters for the accept call
-    'accept_addr': [CompiledServerHarness, 49169, ['-DTEST_DGRAM=0', '-DTEST_ACCEPT_ADDR=1']],
+    'accept_addr': (CompiledServerHarness, 49169, ['-DTEST_DGRAM=0', '-DTEST_ACCEPT_ADDR=1']),
   })
   def test_sockets_async_echo(self, harness_class, port, args):
     if harness_class == WebsockifyServerHarness and common.EMTEST_LACKS_NATIVE_CLANG:
@@ -295,9 +295,9 @@ class sockets(BrowserCore):
     self.btest_exit('sockets/test_sockets_echo_client.c', cflags=['-DSOCKK=49169', '-DTEST_ASYNC=1'])
 
   @parameterized({
-    'websockify': [WebsockifyServerHarness, 49171, ['-DTEST_DGRAM=0']],
-    'tcp': [CompiledServerHarness, 49172, ['-DTEST_DGRAM=0']],
-    'udp': [CompiledServerHarness, 49173, ['-DTEST_DGRAM=1']],
+    'websockify': (WebsockifyServerHarness, 49171, ['-DTEST_DGRAM=0']),
+    'tcp': (CompiledServerHarness, 49172, ['-DTEST_DGRAM=0']),
+    'udp': (CompiledServerHarness, 49173, ['-DTEST_DGRAM=1']),
   })
   def test_sockets_echo_bigdata(self, harness_class, port, args):
     if harness_class == WebsockifyServerHarness and common.EMTEST_LACKS_NATIVE_CLANG:
@@ -368,10 +368,10 @@ class sockets(BrowserCore):
 
   @crossplatform
   @parameterized({
-    'native': [WebsockifyServerHarness, 59160, ['-DTEST_DGRAM=0']],
-    'tcp': [CompiledServerHarness, 59162, ['-DTEST_DGRAM=0', '-sEXPORT_ES6', '--extern-post-js', test_file('modularize_post_js.js')]],
-    'udp': [CompiledServerHarness, 59164, ['-DTEST_DGRAM=1']],
-    'pthread': [CompiledServerHarness, 59166, ['-pthread', '-sPROXY_TO_PTHREAD']],
+    'native': (WebsockifyServerHarness, 59160, ['-DTEST_DGRAM=0']),
+    'tcp': (CompiledServerHarness, 59162, ['-DTEST_DGRAM=0', '-sEXPORT_ES6', '--extern-post-js', test_file('modularize_post_js.js')]),
+    'udp': (CompiledServerHarness, 59164, ['-DTEST_DGRAM=1']),
+    'pthread': (CompiledServerHarness, 59166, ['-pthread', '-sPROXY_TO_PTHREAD']),
   })
   def test_nodejs_sockets_echo(self, harness_class, port, args):
     if harness_class == WebsockifyServerHarness and common.EMTEST_LACKS_NATIVE_CLANG:
@@ -588,9 +588,9 @@ class sockets(BrowserCore):
   # N.B. running this test requires 'npm install ws' in Emscripten root directory
   # NOTE: Shared buffer is not allowed for websocket sending.
   @parameterized({
-    '': [[]],
-    'shared': [['-sSHARED_MEMORY']],
-    'deinitialize': [['-DTEST_EMSCRIPTEN_WEBSOCKET_DEINITIALIZE']],
+    '': ([],),
+    'shared': (['-sSHARED_MEMORY'],),
+    'deinitialize': (['-DTEST_EMSCRIPTEN_WEBSOCKET_DEINITIALIZE'],),
   })
   @requires_dev_dependency('ws')
   def test_websocket_send(self, args):


### PR DESCRIPTION
Ensure all argument lists passed to `parameterize` and `@parameterized` are tuples so that composing multiple parameterizing decorators via tuple concatenation (`v2 + v1`) is always valid.

Add an assertion in `parameterize` to enforce tuple parameter values, and convert existing list parameter values in tests to tuples.

Standardizing on tuples was chosen over lists because all 17 predefined decorators in `decorators.py` and ~95% of `@parameterized` call sites in test files (1,041 tuples vs 165 lists) already used tuples. Going with lists would have resulted in a ~6x larger patch.

See https://github.com/emscripten-core/emscripten/pull/27493#discussion_r3731257269