### PR TITLE
[pthread] Clear waitAsync waiter in returnWorkerToPool to prevent deadlock

### DIFF
--- a/src/lib/libpthread.js
+++ b/src/lib/libpthread.js
@@ -205,6 +205,12 @@ var LibraryPThread = {
       PThread.pthreads = {};
     },
 
+    clearMailboxAwait: (pthread_ptr) => {
+      if (!waitAsyncPolyfilled) {
+        Atomics.notify(HEAP32, {{{ getHeapOffset('pthread_ptr', 'i32') }}});
+      }
+    },
+
     terminateRuntime: () => {
 #if ASSERTIONS
       assert(!ENVIRONMENT_IS_PTHREAD, 'terminateRuntime() should only be called from the main thread');
@@ -212,12 +218,7 @@ var LibraryPThread = {
       PThread.terminateAllThreads();
       var pthread_ptr = _pthread_self();
       ___set_thread_state(0, 0, 0, 1);
-      if (!waitAsyncPolyfilled) {
-        // Break the waitAsync loop.  Note that checkMailbox will not
-        // re-register since the `___set_thread_state` above causes _pthread_self
-        // to return 0.
-        Atomics.notify(HEAP32, {{{ getHeapOffset('pthread_ptr', 'i32') }}});
-      }
+      PThread.clearMailboxAwait(pthread_ptr);
     },
 
     returnWorkerToPool: (worker) => {
@@ -246,6 +247,11 @@ var LibraryPThread = {
         worker.unref();
       }
 #endif
+
+      // Clear any pending waitAsync waiter armed on this thread's struct
+      // BEFORE freeing the memory so that memory recycled by malloc in another
+      // thread will not have a window where a stale async waiter is still active.
+      PThread.clearMailboxAwait(pthread_ptr);
 
       // Finally, free the underlying (and now-unused) pthread structure in
       // linear memory.

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 6856,
-  "a.out.js.gz": 3406,
+  "a.out.js": 6883,
+  "a.out.js.gz": 3422,
   "a.out.nodebug.wasm": 19119,
   "a.out.nodebug.wasm.gz": 8831,
-  "total": 25975,
-  "total_gz": 12237,
+  "total": 26002,
+  "total_gz": 12253,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7307,
-  "a.out.js.gz": 3624,
+  "a.out.js": 7341,
+  "a.out.js.gz": 3639,
   "a.out.nodebug.wasm": 19120,
   "a.out.nodebug.wasm.gz": 8832,
-  "total": 26427,
-  "total_gz": 12456,
+  "total": 26461,
+  "total_gz": 12471,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/other/test_pthread_waitasync_after_exit.c
+++ b/test/other/test_pthread_waitasync_after_exit.c
@@ -1,0 +1,61 @@
+#define _GNU_SOURCE
+#include <assert.h>
+#include <emscripten.h>
+#include <emscripten/threading.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+static _Atomic int* word;
+static _Atomic bool woken = false;
+static pthread_barrier_t started;
+
+void* dummy_thread(void* arg) {
+  return NULL;
+}
+
+void* waiter_thread(void* arg) {
+  *word = 2;
+  pthread_barrier_wait(&started);
+  int res = __builtin_wasm_memory_atomic_wait32((int*)word, 2, -1);
+  assert(res == ATOMICS_WAIT_OK);
+  woken = true;
+  return NULL;
+}
+
+// See https://github.com/emscripten-core/emscripten/issues/27492
+// Test that exiting threads clear their Atomics.waitAsync waiters. Otherwise,
+// recycling the freed pthread_t struct memory via malloc can cause a stale
+// waiter to intercept Atomics.notify notifications meant for another thread.
+int main(void) {
+  pthread_barrier_init(&started, NULL, 2);
+
+  pthread_t dead;
+  pthread_create(&dead, NULL, dummy_thread, NULL);
+  pthread_join(dead, NULL);
+
+  // malloc should reuse the memory block freed when dummy_thread exited.
+  word = malloc(1024);
+
+  pthread_t w;
+  pthread_create(&w, NULL, waiter_thread, NULL);
+
+  pthread_barrier_wait(&started);
+  emscripten_thread_sleep(100);
+
+  *word = 0;
+  __builtin_wasm_memory_atomic_notify((int*)word, 1);
+
+  struct timespec ts;
+  clock_gettime(CLOCK_REALTIME, &ts);
+  ts.tv_sec += 5;
+  if (pthread_timedjoin_np(w, NULL, &ts) != 0 || !woken) {
+    printf("DEADLOCK: parked thread was not woken!\n");
+    return 1;
+  }
+
+  pthread_barrier_destroy(&started);
+  printf("done\n");
+  return 0;
+}

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12114,6 +12114,10 @@ int main(void) {
     self.cflags += ['--extern-post-js', test_file('pthread/test_pthread_mem_leak_post.js')]
     self.do_runf('hello_world.c', 'SUCCESS: No leak detected', cflags=['-pthread'])
 
+  @requires_pthreads
+  def test_pthread_waitasync_after_exit(self):
+    self.do_runf('other/test_pthread_waitasync_after_exit.c', 'done\n', cflags=['-pthread'])
+
   def test_stdin_preprocess(self):
     create_file('temp.h', '#include <string>')
     outputStdin = self.run_process([EMCC, '-x', 'c++', '-dM', '-E', '-'], input="#include <string>", stdout=PIPE).stdout


### PR DESCRIPTION
When a thread exits and its worker is returned to pool, clear any pending `Atomics.waitAsync` waiter armed on the thread's structure before freeing its memory in `_emscripten_thread_free_data`.

Fixes: #27492