### PR TITLE
[CI] Add test-linux-arm64 CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,14 @@ executors:
       EMSDK_NOTTY: "1"
       EMTEST_WASI_SYSROOT: "~/wasi-sdk/wasi-sysroot"
       EMTEST_DETECT_TEMPFILE_LEAKS: "1"
+  linux-arm64:
+    machine:
+      image: ubuntu-2204:current
+    resource_class: arm.medium
+    environment:
+      LANG: "C.UTF-8"
+      EMSDK_NOTTY: "1"
+      EMTEST_DETECT_TEMPFILE_LEAKS: "1"
   mac-arm64:
     environment:
       EMSDK_NOTTY: "1"
@@ -741,8 +749,6 @@ jobs:
       - run-tests-linux:
           test_targets: "wasm2js1"
   test-wasm64-4gb:
-    environment:
-      LANG: "C.UTF-8"
     executor: ubuntu-lts
     steps:
       - prepare-for-tests
@@ -759,7 +765,6 @@ jobs:
       - upload-test-results
   test-wasm64-misc:
     environment:
-      LANG: "C.UTF-8"
       EMTEST_SKIP_NINJA: "1"
     executor: ubuntu-lts
     steps:
@@ -871,7 +876,6 @@ jobs:
   test-node-compat:
     executor: ubuntu-lts
     environment:
-      LANG: "C.UTF-8"
       EMTEST_SKIP_V8: "1"
     steps:
       - checkout
@@ -1303,6 +1307,29 @@ jobs:
           test_targets: "--crossplatform-only"
       - upload-test-results
 
+  test-linux-arm64:
+    executor: linux-arm64
+    environment:
+      EMTEST_SKIP_V8: "1"
+      EMTEST_SKIP_WASM_LEGACY_EH: "1"
+      EMTEST_SKIP_WASM_EH: "1"
+      EMTEST_SKIP_WASM64: "1"
+      EMTEST_SKIP_RUST: "1"
+      EMTEST_SKIP_NEW_CMAKE: "1"
+      EMTEST_SKIP_NODE_25: "1"
+      # Some native clang tests assume x86 clang (e.g. -sse2)
+      EMTEST_LACKS_NATIVE_CLANG: "1"
+      EMCC_SKIP_SANITY_CHECK: "1"
+    steps:
+      - checkout
+      - install-emsdk
+      - pip-install
+      - run: sudo apt-get install -q -y ninja-build scons cmake make
+      - run-tests-linux:
+          title: "crossplatform tests"
+          frozen_cache: false
+          test_targets: "--crossplatform-only"
+
 workflows:
   build-test:
     jobs:
@@ -1377,3 +1404,4 @@ workflows:
       - test-mac-arm64:
          requires:
            - build-linux
+      - test-linux-arm64


### PR DESCRIPTION
Add test-linux-arm64 job to CircleCI configuration to run crossplatform tests on ARM64 Linux hardware.