### PR TITLE
[contrib.glfw3] Upgraded emscripten-glfw to latest 3.5.1 GLFW API

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@ See docs/process.md for more on how version tagging works.
 
 - JavaScript library symbols can now use the `__force` and `__export`
   decorators to control inclusion and export visibility. (#27436)
+- contrib.glfw3 port upgraded to use the latest version of GLFW 3.5.1
+  (#27508)
 
 6.0.6 - 08/05/26
 ----------------

--- a/tools/ports/contrib/glfw3.py
+++ b/tools/ports/contrib/glfw3.py
@@ -3,13 +3,13 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-TAG = '3.4.0.20260301'
+TAG = '3.5.1.20260809'
 
 EXTERNAL_PORT = f'https://github.com/pongasoft/emscripten-glfw/releases/download/v{TAG}/emscripten-glfw3-{TAG}.zip'
-SHA512 = '57913935492c9372199fc37fc88354ec5922ad627bdf39890fe5b7fcd3b51aaa57d65f059492563f2f2773e31181c9f3d56c05413445e85467c609206016ed6d'
+SHA512 = '9efad6b2022885a39c92195540982027a0f13cf346272913ed89c7c67139d653c5835c799fe6325e83047afbb388532226174cbde476847ac3364500218e4efc'
 PORT_FILE = 'port/glfw3.py'
 
 # contrib port information (required)
 URL = 'https://github.com/pongasoft/emscripten-glfw'
-DESCRIPTION = 'This project is an emscripten port of GLFW 3.4 written in C++ for the web/webassembly platform'
+DESCRIPTION = 'This project is an emscripten port of GLFW 3.5 written in C++ for the web/webassembly platform'
 LICENSE = 'Apache 2.0 license'


### PR DESCRIPTION
GLFW just released a new version and I ported emscripten-glfw to it. Here are the release notes:

- Upgraded to GLFW 3.5.1 (check the [Changelog](https://www.glfw.org/changelog.html) for details, although most changes
  are related to bug fixes in other platforms)
- Added support for the new input mode `GLFW_UNLIMITED_MOUSE_BUTTONS`
