### PR TITLE
Prevent HTML minification from corrupting embedded WASM data

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9308,6 +9308,26 @@ int main() {
     self.assertExists('hello_world.js')
     self.assertFileContents('hello_world.wasm', 'not wasm')
 
+  def test_single_file_html_minified(self):
+    # Test that HTML minification in SINGLE_FILE mode does not corrupt
+    # WASM binary data containing custom fragment patterns like <?foo?>.
+    create_file('src.c', '''
+#include <stdio.h>
+#include <string.h>
+volatile const char custom_fragment_test[] = "   <?foo?>   ";
+int main(int argc, char** argv) {
+  int len = 0;
+  for (int i = 0; i < 13; i++) {
+    if (custom_fragment_test[i]) len++;
+  }
+  printf("Length: %d\\n", len);
+  return 0;
+}
+''')
+    self.run_process([EMCC, 'src.c', '-O2', '-sSINGLE_FILE', '-o', 'out.html'])
+    html = read_file('out.html')
+    self.assertContained('   <?foo?>   ', html)
+
   def test_single_file_disables_source_map(self):
     cmd = [EMCC, test_file('hello_world.c'), '-sSINGLE_FILE', '-gsource-map']
     stderr = self.run_process(cmd, stderr=PIPE).stderr

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9311,6 +9311,7 @@ int main() {
   def test_single_file_html_minified(self):
     # Test that HTML minification in SINGLE_FILE mode does not corrupt
     # WASM binary data containing custom fragment patterns like <?foo?>.
+    # The whitespace around <?foo?> must not be removed here.
     create_file('src.c', '''
 #include <stdio.h>
 #include <string.h>

--- a/tools/link.py
+++ b/tools/link.py
@@ -2637,7 +2637,11 @@ def minify_html(filename):
              '--remove-style-link-type-attributes',
              '--use-short-doctype',
              '--minify-css', 'true',
-             '--minify-js', 'true']
+             '--minify-js', 'true',
+             # Disable default PHP/ASP fragment regexes (<?...?> and <%...%>)
+             # which can match raw byte sequences in embedded WASM binary
+             # data in SINGLE_FILE builds and corrupt surrounding whitespace.
+             '--ignore-custom-fragments', '[]']
 
   # html-minifier also has the following options, but they look unsafe for use:
   # '--collapse-inline-tag-whitespace': removes whitespace between inline tags in visible text,


### PR DESCRIPTION
Pass `--ignore-custom-fragments '[]'` to `html-minifier-terser`.

By default, `html-minifier-terser` includes custom fragment regexes
`/<%[\s\S]*?%>/` and `/<\?[\s\S]*?\?>/` intended for ignoring server-side
preprocessor tags (like PHP `<?php ... ?>` or ASP `<% ... %>`). When
matching these fragments, `html-minifier-terser` matches surrounding
whitespace `\s*` and collapses it.

When WASM binary data is embedded in JavaScript inside an HTML file
(such as in `-sSINGLE_FILE=1` builds), arbitrary byte sequences in the
WASM binary can happen to match `<?...?>` or `<%...%>`. In these cases,
`html-minifier-terser` mistakes the binary data for preprocessor tags
and collapses surrounding spaces (`0x20` bytes), corrupting the embedded
WASM binary payload.

Passing `--ignore-custom-fragments '[]'` disables this behavior. It is
safe for Emscripten because generated HTML files are standard
client-side documents, not server-side PHP/ASP template files containing
preprocessor tags.

Fixes: #27156