### PR TITLE
[ci] Verify cmake and ninja installation after choco install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1154,6 +1154,11 @@ jobs:
           name: Install packages
           command: |
             choco install -y cmake.portable ninja
+            # Choco can return 0 even if package installation/resolution fails (e.g. 504 Gateway Timeout).
+            # See: https://github.com/chocolatey/choco/issues/1609
+            # Explicitly check version commands to ensure executables exist in PATH.
+            cmake --version
+            ninja --version
       - install-emsdk
       - pip-install:
           python: "$EMSDK_PYTHON"
@@ -1245,6 +1250,11 @@ jobs:
           name: Install packages
           command: |
             choco install -y cmake.portable ninja
+            # Choco can return 0 even if package installation/resolution fails (e.g. 504 Gateway Timeout).
+            # See: https://github.com/chocolatey/choco/issues/1609
+            # Explicitly check version commands to ensure executables exist in PATH.
+            cmake --version
+            ninja --version
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
       - install-emsdk


### PR DESCRIPTION
Chocolatey can return exit code 0 even when package resolution fails (e.g., when a NuGet feed timeout causes a `NuGetResolverInputException` and Chocolatey drops the failed package from the install list.  See https://github.com/chocolatey/choco/issues/1609

Explicitly run `cmake --version` and `ninja --version` after `choco` in `.circleci/config.yml` to ensure the executables exist in `PATH` and fail the step immediately if either package failed to install.

Fixes: #27511