### PR TITLE
[openal] Remove code duplication in setSourceParam(AL_BUFFER). NFC

### DIFF
--- a/src/lib/libopenal.js
+++ b/src/lib/libopenal.js
@@ -1316,33 +1316,26 @@ var LibraryOpenAL = {
           return;
         }
 
-        if (value === 0) {
-          for (var b of src.bufQueue) {
-            b.refCount--;
-          }
-          src.bufQueue.length = 1;
-          src.bufQueue[0] = AL.buffers[0];
+        var buf = AL.buffers[value];
+        if (!buf) {
+#if OPENAL_DEBUG
+          dbg('alSourcei(AL_BUFFER) called with an invalid buffer');
+#endif
+          AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
+          return;
+        }
 
-          src.bufsProcessed = 0;
+        for (var oldBuf of src.bufQueue) {
+          oldBuf.refCount--;
+        }
+
+        src.bufQueue = [buf];
+        src.bufsProcessed = 0;
+
+        if (!value) {
           src.type = 0x1030 /* AL_UNDETERMINED */;
         } else {
-          var buf = AL.buffers[value];
-          if (!buf) {
-#if OPENAL_DEBUG
-            dbg('alSourcei(AL_BUFFER) called with an invalid buffer');
-#endif
-            AL.currentCtx.err = {{{ cDefs.AL_INVALID_VALUE }}};
-            return;
-          }
-
-          for (var b of src.bufQueue) {
-            b.refCount--;
-          }
-          src.bufQueue.length = 0;
-
           buf.refCount++;
-          src.bufQueue = [buf];
-          src.bufsProcessed = 0;
           src.type = {{{ cDefs.AL_STATIC }}};
         }
 

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
-  "a.out.js": 267896,
+  "a.out.js": 267819,
   "a.out.nodebug.wasm": 588314,
-  "total": 856210,
+  "total": 856133,
   "sent": [
     "IMG_Init",
     "IMG_Load",


### PR DESCRIPTION
Consolidate the zero (`AL_BUFFER` = 0) and non-zero buffer handling in `setSourceParam(AL_BUFFER)`.

Previously, setting `AL_BUFFER` to 0 handled queue clearing and refCount decrements in a separate `if (value === 0)` branch from non-zero buffer assignment.

This change is safe and NFC because:
1. `AL.buffers[0]` is pre-populated as a placeholder object in `AL.buffers`, so looking up `buf = AL.buffers[value]` works for 0 and will not trigger the `!buf` check (`AL_INVALID_VALUE`).
2. Moving the `!buf` check to the top allows invalid non-zero buffer IDs to return early before modifying `bufQueue` or `refCount`, preserving existing error handling behavior.
3. In both branches, previous buffer refCounts in `src.bufQueue` are decremented and `src.bufQueue` is replaced with `[buf]` (which is `[AL.buffers[0]]` when `value === 0`).
4. `src.bufsProcessed` is reset to 0 in both cases.
5. The remaining differences (incrementing `buf.refCount` and setting `src.type` to `AL_STATIC` vs `AL_UNDETERMINED`) are handled by checking `if (!value)`.

Split out from #27425.