### PR TITLE
Consistent closure compiler args

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -512,13 +512,7 @@ def get_closure_compiler():
     return config.CLOSURE_COMPILER
 
   # Otherwise use the one installed via npm
-  cmd = shared.get_npm_cmd('google-closure-compiler')
-  if not WINDOWS:
-    # Work around an issue that Closure compiler can take up a lot of memory and crash in an error
-    # "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap
-    # out of memory"
-    cmd.insert(-1, '--max_old_space_size=8192')
-  return cmd
+  return shared.get_npm_cmd('google-closure-compiler')
 
 
 def check_closure_compiler(cmd, args, env, allowed_to_fail):
@@ -543,6 +537,10 @@ def check_closure_compiler(cmd, args, env, allowed_to_fail):
 
 def get_closure_compiler_and_env(user_args):
   env = shared.env_with_node_in_path()
+  # Work around an issue that Closure compiler can take up a lot of memory and crash in an error
+  # "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap
+  # out of memory"
+  env['NODE_OPTIONS'] = '--max_old_space_size=8192'
   closure_cmd = get_closure_compiler()
 
   native_closure_compiler_works = check_closure_compiler(closure_cmd, user_args, env, allowed_to_fail=True)


### PR DESCRIPTION
We we only passing `--max_old_space_size` on non-Windows because get_npm_cmd has no way to add node arguments (that node command is embedded within `node_modules/.bin/closure-compiler` so cannot be modified directly.  Settings NODE_OPTIONS, works on all platforms.

This platform discrepancy dates back to #9989 when `--max_old_space_size` was first added.