### PR TITLE
Do not check `isFileURI` in `SINGLE_FILE` mode

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -610,7 +610,7 @@ async function instantiateArrayBuffer(binaryFile, imports) {
 #endif
 #endif // WASM == 2
 
-#if ASSERTIONS
+#if ASSERTIONS && !SINGLE_FILE
     // Warn on some common problems.
     if (isFileURI(binaryFile)) {
       err(`warning: Loading from a file URI (${binaryFile}) is not supported in most browsers. See https://emscripten.org/docs/getting_started/FAQ.html#how-do-i-run-a-local-webserver-for-testing-why-does-my-program-stall-in-downloading-or-preparing`);
@@ -714,7 +714,7 @@ async function instantiateAsync(binary, binaryFile, imports) {
       // fall back of instantiateArrayBuffer below
     };
   }
-#endif
+#endif // !SINGLE_FILE
   return instantiateArrayBuffer(binaryFile, imports);
 }
 #endif // WASM_ASYNC_COMPILATION

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9330,6 +9330,16 @@ int main(int argc, char** argv) {
     html = read_file('out.html')
     self.assertContained('   <?foo?>   ', html)
 
+  def test_single_file_instantiate_failure(self):
+    self.run_process([EMCC, test_file('hello_world.c'), '-sSINGLE_FILE', '-sASSERTIONS=1', '-o', 'out.js'])
+    code = read_file('out.js')
+    # Stub out binaryDecode so that it returns an invalid wasm binary.
+    code = code.replace('function binaryDecode(bin) {', 'function binaryDecode(bin) { return new Uint8Array([0]);')
+    write_file('out_bad.js', code)
+    out = self.run_js('out_bad.js', assert_returncode=1)
+    self.assertContained('Aborted(CompileError', out)
+    self.assertNotContained('startsWith is not a function', out)
+
   def test_single_file_disables_source_map(self):
     cmd = [EMCC, test_file('hello_world.c'), '-sSINGLE_FILE', '-gsource-map']
     stderr = self.run_process(cmd, stderr=PIPE).stderr


### PR DESCRIPTION
In `SINGLE_FILE` mode, `binaryFile` is passed as a `Uint8Array` in memory. Guarding the `isFileURI` assertion warning with `#if ASSERTIONS && !SINGLE_FILE` prevents `isFileURI(binaryFile)` from being called on a `Uint8Array` when instantiation fails, avoiding `TypeError: A.startsWith is not a function`.

See: #27156