### PR TITLE
[ports] Catch exceptions when downloading ports to avoid full backtrace

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -16148,3 +16148,18 @@ console.log('OK');'''
 
     self.assertTextDataIdentical(normalized_original, normalized_rolled,
                                  fromfile='hello.normalized.mjs', tofile='hello.rolled.normalized.mjs')
+
+  @crossplatform
+  def test_download_failure(self):
+    if config.FROZEN_CACHE:
+      self.skipTest("test doesn't work with frozen cache")
+    bad_port_path = self.in_dir('bad_port.py')
+    write_file(bad_port_path, '''
+URL = 'http://127.0.0.1:0/nonexistent.zip'
+DESCRIPTION = 'Bad Port'
+LICENSE = 'MIT'
+SHA512 = 'dummy'
+PORT_FILE = 'port.py'
+EXTERNAL_PORT = URL
+''')
+    self.assert_fail([EMCC, test_file('hello_world.c'), f'--use-port={bad_port_path}'], 'failed to download port "bad_port"')

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -5,6 +5,7 @@
 
 import glob
 import hashlib
+import http.client
 import importlib.util
 import logging
 import os
@@ -359,8 +360,11 @@ class Ports:
         # available on macOS.
         data = subprocess.check_output(['curl', '-sSL', url])
       else:
-        f = urlopen(url)
-        data = f.read()
+        try:
+          with urlopen(url) as f:
+            data = f.read()
+        except (OSError, http.client.HTTPException) as e:
+          utils.exit_with_error(f'failed to download port "{name}" from {url}: {e}')
 
       if sha512hash:
         actual_hash = hashlib.sha512(data).hexdigest()


### PR DESCRIPTION
Catch network and download exceptions `tools/ports/__init__.py` when retrieving port artifacts, so that user-facing errors are reported cleanly via `utils.exit_with_error` without printing an unhandled Python backtrace.