### PR TITLE
Add extended-const to feature matrix and pass to wasm-ld

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -10480,6 +10480,13 @@ int main() {
     compile(['-sMIN_SAFARI_VERSION=140100', '-mbulk-memory'])
     verify_features_sec_linked('nontrapping-fptoint', False)
 
+    compile(['-sMIN_CHROME_VERSION=100'])
+    verify_features_sec_linked('extended-const', False)
+    compile(['-mextended-const'])
+    verify_features_sec_linked('extended-const', True)
+    compile(['-sMIN_CHROME_VERSION=114', '-sMIN_FIREFOX_VERSION=112', '-sMIN_SAFARI_VERSION=170400', '-sMIN_NODE_VERSION=210000'])
+    verify_features_sec_linked('extended-const', True)
+
   def test_no_bulk_memory(self):
     # The test_wasm_features test (above) uses the feature section to confirm
     # if a feature is present, but that doesn't work in optimizing builds

--- a/tools/building.py
+++ b/tools/building.py
@@ -20,6 +20,7 @@ from . import (
   colored_logger,
   config,
   diagnostics,
+  feature_matrix,
   js_optimizer,
   response_file,
   shared,
@@ -277,6 +278,9 @@ def lld_flags_for_executable(external_symbols):
     cmd.append('--table-base=%s' % settings.TABLE_BASE)
     if not settings.STACK_FIRST:
       cmd.append('--global-base=%s' % settings.GLOBAL_BASE)
+
+  if feature_matrix.caniuse(feature_matrix.Feature.EXTENDED_CONST):
+    cmd.append('--extra-features=extended-const')
 
   return cmd
 

--- a/tools/cmdline.py
+++ b/tools/cmdline.py
@@ -510,6 +510,12 @@ def parse_args(newargs):  # ruff: ignore[complex-structure, too-many-branches, t
                                     override=True)
     elif arg == '-mno-nontrapping-fptoint':
       feature_matrix.disable_feature(feature_matrix.Feature.NON_TRAPPING_FPTOINT)
+    elif arg == '-mextended-const':
+      feature_matrix.enable_feature(feature_matrix.Feature.EXTENDED_CONST,
+                                    '-mextended-const',
+                                    override=True)
+    elif arg == '-mno-extended-const':
+      feature_matrix.disable_feature(feature_matrix.Feature.EXTENDED_CONST)
     elif arg == '-fexceptions':
       # TODO Currently -fexceptions only means Emscripten EH. Switch to wasm
       # exception handling by default when -fexceptions is given when wasm

--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -53,17 +53,19 @@ def is_orig_main_wrapper(module, function):
 
 
 def get_const_expr_value(expr):
-  assert len(expr) == 2
-  assert expr[1][0] == OpCode.END
-  opcode, immediates = expr[0]
-  match opcode:
-    case OpCode.I32_CONST | OpCode.I64_CONST:
-      assert len(immediates) == 1
-      return immediates[0]
-    case OpCode.GLOBAL_GET:
-      return 0
-    case _:
-      exit_with_error('unexpected opcode in const expr: %s', opcode)
+  assert expr[-1][0] == OpCode.END
+  for inst in expr:
+    opcode, immediates = inst
+    match opcode:
+      case OpCode.I32_CONST | OpCode.I64_CONST:
+        assert len(immediates) == 1
+        return immediates[0]
+      case OpCode.GLOBAL_GET:
+        continue
+      case OpCode.END:
+        return 0
+      case _:
+        exit_with_error('unexpected opcode in const expr: %s', opcode)
 
 
 def get_global_value(globl):

--- a/tools/feature_matrix.py
+++ b/tools/feature_matrix.py
@@ -42,6 +42,7 @@ class Feature(IntEnum):
   WEBGL2 = auto()
   WEBGPU = auto()
   GROWABLE_ARRAYBUFFERS = auto()
+  EXTENDED_CONST = auto()
 
 
 disable_override_features: set[Feature] = set()
@@ -135,10 +136,18 @@ min_browser_versions = {
   # builds by avoiding need to poll resizes to ArrayBuffer views in Workers.
   # https://caniuse.com/mdn-webassembly_api_memory_toresizablebuffer
   Feature.GROWABLE_ARRAYBUFFERS: {
+
     'chrome': 144,
     'firefox': 145,
     'safari': 260200,
     'node': 260000,
+  },
+  # https://caniuse.com/wasm-extended-const
+  Feature.EXTENDED_CONST: {
+    'chrome': 114,
+    'firefox': 112,
+    'safari': 170400,
+    'node': 210000,
   },
 
 # The following features we now support unconditionally, but keeping them around


### PR DESCRIPTION
Add `Feature.EXTENDED_CONST` to `tools/feature_matrix.py` with minimum supported engine versions (Chrome 114, Firefox 112, Safari 17.4, Node 21.0.0).

Also handle `-mextended-const` and `-mno-extended-const` flags in `tools/cmdline.py`, and pass `--extra-features=extended-const` to `wasm-ld` in `tools/building.py` when `extended-const` is available.

Even though this feature is not enabled by our default browser versions this change does enable this feature automatically when opting into other newer features such as `MEMORY64` or `WASM_EXCEPTIONS`.