### PR TITLE
Remove internal JS settings in favor of `EmccOptions` fields

### DIFF
--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -103,23 +103,11 @@ var JS_LIBRARIES = [];
 // they are being used with.
 var EMSCRIPTEN_VERSION = '';
 
-// Will be set to 0 if -fno-rtti is used on the command line.
-var USE_RTTI = true;
-
-// This will contain the optimization level (-Ox).
-var OPT_LEVEL = 0;
-
-// This will contain the debug level (-gx).
-var DEBUG_LEVEL = 0;
-
 // This will contain the shrink level (1 or 2 for -Os or -Oz, or just 0).
 var SHRINK_LEVEL = 0;
 
 // Whether or not to emit the name section in the final wasm binary.
 var EMIT_NAME_SECTION = false;
-
-// Whether we are emitting a symbol map.
-var EMIT_SYMBOL_MAP = false;
 
 // List of symbols explicitly exported by user on the command line.
 var USER_EXPORTS = [];
@@ -127,8 +115,6 @@ var USER_EXPORTS = [];
 // name of the file containing wasm binary, if relevant
 var WASM_BINARY_FILE = '';
 
-// Base URL the source mapfile, if relevant
-var SOURCE_MAP_BASE = '';
 
 // If set to 1 then base64 decoding functions will be included in the bundle.
 // This is set internally when needed (SINGLE_FILE)
@@ -282,8 +268,6 @@ var WARN_DEPRECATED = true;
 var WEBGL_USE_GARBAGE_FREE_APIS = false;
 
 var INCLUDE_WEBGL1_FALLBACK = true;
-
-var MINIFICATION_MAP = '';
 
 var OUTPUT_FORMAT = '';
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -16,7 +16,6 @@ from subprocess import PIPE
 
 from . import (
   cache,
-  cmdline,
   colored_logger,
   config,
   diagnostics,
@@ -26,6 +25,7 @@ from . import (
   utils,
   webassembly,
 )
+from .cmdline import options
 from .settings import settings
 from .shared import (
   CLANG_CC,
@@ -188,13 +188,13 @@ def lld_flags_for_executable(external_symbols):
   # section and DWARF, so we can only use it when we don't need any of
   # those things.
   if (not settings.GENERATE_DWARF and
-      not settings.EMIT_SYMBOL_MAP and
+      not options.emit_symbol_map and
       not settings.GENERATE_SOURCE_MAP and
       not settings.EMIT_NAME_SECTION and
       not settings.ASYNCIFY):
     cmd.append('--strip-debug')
 
-  if cmdline.options.lto and not settings.EXIT_RUNTIME:
+  if options.lto and not settings.EXIT_RUNTIME:
     # The WebAssembly backend can generate new references to `__cxa_atexit` at
     # LTO time.  This `-u` flag forces the `__cxa_atexit` symbol to be
     # included at LTO time.  For other such symbols we exclude them from LTO
@@ -647,7 +647,7 @@ def closure_compiler(filename, advanced=True, extra_closure_args=None):
     args += ['--externs', e]
   args += user_args
 
-  if settings.DEBUG_LEVEL > 1:
+  if options.debug_level > 1:
     args += ['--debug']
 
   # Now that we have run closure compiler once, we have stripped all the closure compiler
@@ -813,7 +813,7 @@ def minify_wasm_js(js_file, wasm_file, expensive_optimizations, debug_info):
 # get the flags to pass into the very last binaryen tool invocation, that runs
 # the final set of optimizations
 def get_last_binaryen_opts():
-  return [f'--optimize-level={settings.OPT_LEVEL}',
+  return [f'--optimize-level={options.opt_level}',
           f'--shrink-level={settings.SHRINK_LEVEL}',
           '--optimize-stack-ir']
 
@@ -985,9 +985,9 @@ def minify_wasm_imports_and_exports(js_file, wasm_file, minify_exports, debug_in
   if settings.MINIFY_WHITESPACE:
     passes.append('--minify-whitespace')
   extra_info = {'mapping': mapping}
-  if settings.MINIFICATION_MAP:
+  if options.minification_map:
     lines = [f'{new}:{old}' for old, new in mapping.items()]
-    utils.write_file(settings.MINIFICATION_MAP, '\n'.join(lines) + '\n')
+    utils.write_file(options.minification_map, '\n'.join(lines) + '\n')
   return acorn_optimizer(js_file, passes, extra_info=extra_info)
 
 
@@ -1286,7 +1286,7 @@ def run_binaryen_command(tool, infile, outfile=None, args=None, debug=False, std
       # in are not enough to see what went wrong)
       if settings.LEGALIZE_JS_FFI:
         extra += '\nnote: to disable int64 legalization (which requires changes after link) use -sWASM_BIGINT'
-      if settings.OPT_LEVEL > 1:
+      if options.opt_level > 1:
         extra += '\nnote: -O2+ optimizations always require changes, build with -O0 or -O1 instead'
       exit_with_error(f'changes to the wasm are required after link, but disallowed by ERROR_ON_WASM_CHANGES_AFTER_LINK: {cmd}{extra}')
   if debug:

--- a/tools/cmdline.py
+++ b/tools/cmdline.py
@@ -56,6 +56,7 @@ class EmccOptions:
   clear_cache = False
   clear_ports = False
   cpu_profiler = False
+  debug_level = 0
   dash_E = False
   dash_M = False
   dash_S = False
@@ -77,6 +78,7 @@ class EmccOptions:
   lib_dirs: list[str] = []
   lto: str | None = None
   memory_profiler = False
+  minification_map = ''
   no_entry = False
   no_minify = False
   nodefaultlibs = False
@@ -86,6 +88,7 @@ class EmccOptions:
   nostdlib = False
   nostdlibxx = False
   oformat = None
+  opt_level = 0
   # Specifies the line ending format to use for all generated text files.
   # Defaults to using the native EOL on each platform (\r\n on Windows, \n on
   # Linux & MacOS)
@@ -98,6 +101,7 @@ class EmccOptions:
   relocatable = False
   reproduce = os.getenv('EMCC_REPRODUCE')  # None by default.
   requested_debug = None
+  rtti = True
   sanitize: set[str] = set()
   sanitize_minimal_runtime = False
   show_ports = False
@@ -297,7 +301,7 @@ def parse_args(newargs):  # ruff: ignore[complex-structure, too-many-branches, t
       elif opt_level == 'g':
         opt_level = 1
         settings.SHRINK_LEVEL = 0
-        settings.DEBUG_LEVEL = max(settings.DEBUG_LEVEL, 1)
+        options.debug_level = max(options.debug_level, 1)
       elif opt_level == 'fast':
         # -Ofast typically includes -ffast-math semantics
         options.fast_math = True
@@ -313,7 +317,7 @@ def parse_args(newargs):  # ruff: ignore[complex-structure, too-many-branches, t
         diagnostics.warn(f"optimization level '{arg}' is not supported; using '-O3' instead")
         newargs[i] = '-O3'
         level = 3
-      settings.OPT_LEVEL = level
+      options.opt_level = level
     elif arg.startswith('-flto'):
       if '=' in arg:
         options.lto = arg.split('=')[1]
@@ -361,7 +365,7 @@ def parse_args(newargs):  # ruff: ignore[complex-structure, too-many-branches, t
       if is_unsigned_int(debug_level):
         # the -gX value is the debug level (-g1, -g2, etc.)
         debug_level = int(debug_level)
-        settings.DEBUG_LEVEL = debug_level
+        options.debug_level = debug_level
         if debug_level == 0:
           # Set these explicitly so -g0 overrides previous -g on the cmdline
           settings.GENERATE_DWARF = 0
@@ -400,7 +404,7 @@ def parse_args(newargs):  # ruff: ignore[complex-structure, too-many-branches, t
           else:
             settings.SEPARATE_DWARF = True
           settings.GENERATE_DWARF = 1
-          settings.DEBUG_LEVEL = 3
+          options.debug_level = 3
         elif debug_level in {'source-map', 'source-map=inline'}:
           settings.GENERATE_SOURCE_MAP = 1 if debug_level == 'source-map' else 2
           newargs[i] = '-g'
@@ -413,9 +417,9 @@ def parse_args(newargs):  # ruff: ignore[complex-structure, too-many-branches, t
           # clang and make the emscripten code treat it like any other DWARF.
           settings.GENERATE_DWARF = 1
           settings.EMIT_NAME_SECTION = 1
-          settings.DEBUG_LEVEL = 3
+          options.debug_level = 3
     elif check_flag('-profiling') or check_flag('--profiling'):
-      settings.DEBUG_LEVEL = max(settings.DEBUG_LEVEL, 2)
+      options.debug_level = max(options.debug_level, 2)
       settings.EMIT_NAME_SECTION = 1
     elif check_flag('-profiling-funcs') or check_flag('--profiling-funcs'):
       settings.EMIT_NAME_SECTION = 1
@@ -426,9 +430,8 @@ def parse_args(newargs):  # ruff: ignore[complex-structure, too-many-branches, t
       settings.EMSCRIPTEN_TRACING = 1
     elif check_flag('--emit-symbol-map'):
       options.emit_symbol_map = True
-      settings.EMIT_SYMBOL_MAP = 1
     elif check_arg('--emit-minification-map'):
-      settings.MINIFICATION_MAP = consume_arg()
+      options.minification_map = consume_arg()
     elif check_arg('--embed-file'):
       options.embed_files.append(consume_arg())
     elif check_arg('--preload-file'):
@@ -548,9 +551,9 @@ def parse_args(newargs):  # ruff: ignore[complex-structure, too-many-branches, t
     elif arg == '-pthreads':
       exit_with_error('unrecognized command-line option `-pthreads`; did you mean `-pthread`?')
     elif arg == '-fno-rtti':
-      settings.USE_RTTI = 0
+      options.rtti = False
     elif arg == '-frtti':
-      settings.USE_RTTI = 1
+      options.rtti = True
     elif arg.startswith('-jsD'):
       key = arg.removeprefix('-jsD')
       if '=' in key:

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -34,6 +34,7 @@ from tools import (
   utils,
   webassembly,
 )
+from tools.cmdline import options
 from tools.native_sigs import native_sigs
 from tools.settings import settings, user_settings
 from tools.shared import DEBUG, asmjs_mangle, in_temp
@@ -513,7 +514,7 @@ def finalize_wasm(infile, outfile, js_syms):
     # wasm2js requires full legalization (and will do extra wasm binary
     # later processing later anyhow)
     modify_wasm = True
-  if settings.DEBUG_LEVEL >= 2 or settings.ASYNCIFY_ADD or settings.ASYNCIFY_ADVISE or settings.ASYNCIFY_ONLY or settings.ASYNCIFY_REMOVE or settings.EMIT_SYMBOL_MAP or settings.EMIT_NAME_SECTION:
+  if options.debug_level >= 2 or settings.ASYNCIFY_ADD or settings.ASYNCIFY_ADVISE or settings.ASYNCIFY_ONLY or settings.ASYNCIFY_REMOVE or options.emit_symbol_map or settings.EMIT_NAME_SECTION:
     need_name_section = True
     args.append('-g')
   if settings.WASM_BIGINT:
@@ -551,7 +552,7 @@ def finalize_wasm(infile, outfile, js_syms):
   if settings.STANDALONE_WASM:
     args.append('--standalone-wasm')
 
-  if settings.DEBUG_LEVEL >= 3:
+  if options.debug_level >= 3:
     args.append('--dwarf')
 
   if infile != outfile:
@@ -560,7 +561,7 @@ def finalize_wasm(infile, outfile, js_syms):
   if settings.GENERATE_SOURCE_MAP:
     building.emit_wasm_source_map(infile, outfile + '.map', outfile)
     building.save_intermediate(outfile + '.map', 'base_wasm.map')
-    base_url = settings.SOURCE_MAP_BASE + os.path.basename(outfile) + '.map'
+    base_url = options.source_map_base + os.path.basename(outfile) + '.map'
     if modify_wasm:
       # If we are already modifying, just let Binaryen add the sourcemap URL
       args += ['--output-source-map-url=' + base_url]

--- a/tools/link.py
+++ b/tools/link.py
@@ -173,7 +173,7 @@ def will_metadce():
   # when assertions are enabled.
   if settings.ASSERTIONS:
     return False
-  return settings.OPT_LEVEL >= 3 or settings.SHRINK_LEVEL >= 1
+  return options.opt_level >= 3 or settings.SHRINK_LEVEL >= 1
 
 
 def setup_environment_settings():
@@ -307,7 +307,7 @@ def should_run_binaryen_optimizer():
   # great majority of the work; not running the binaryen optimizer in that case
   # keeps -O1 mostly-optimized while compiling quickly and without rewriting
   # DWARF etc.
-  return settings.OPT_LEVEL >= 2
+  return options.opt_level >= 2
 
 
 def get_binaryen_lowering_passes():
@@ -362,7 +362,7 @@ def get_binaryen_passes():
     passes += ['--post-emscripten']
     if settings.SIDE_MODULE:
       passes += ['--pass-arg=post-emscripten-side-module']
-    passes += [building.opt_level_to_str(settings.OPT_LEVEL, settings.SHRINK_LEVEL)]
+    passes += [building.opt_level_to_str(options.opt_level, settings.SHRINK_LEVEL)]
     # when optimizing, use the fact that low memory is never used (1024 is a
     # hardcoded value in the binaryen pass). we also cannot do it when the stack
     # is first, as then the stack is in the low memory that should be unused.
@@ -894,7 +894,7 @@ def phase_linker_setup(linker_args):  # ruff: ignore[complex-structure, too-many
     # See https://github.com/llvm/llvm-project/issues/214557
     linker_args.append('--no-shlib-sigcheck')
 
-  if settings.OPT_LEVEL >= 1:
+  if options.opt_level >= 1:
     default_setting('ASSERTIONS', 0)
 
   if options.emrun:
@@ -1657,8 +1657,8 @@ def phase_linker_setup(linker_args):  # ruff: ignore[complex-structure, too-many
   # JSPI does not support this optimization yet as it has a hardcoded check for 'main' as an
   # export name. TODO
   if will_metadce() and \
-      settings.OPT_LEVEL >= 2 and \
-      settings.DEBUG_LEVEL <= 2 and \
+      options.opt_level >= 2 and \
+      options.debug_level <= 2 and \
       options.oformat not in {OFormat.WASM, OFormat.BARE} and \
       settings.ASYNCIFY != 2 and \
       not settings.LINKABLE and \
@@ -1703,7 +1703,7 @@ def phase_linker_setup(linker_args):  # ruff: ignore[complex-structure, too-many
     # ASan and SAFE_HEAP check address 0 themselves
     settings.CHECK_NULL_WRITES = 0
 
-  if 'GLOBAL_BASE' not in user_settings and not settings.SHRINK_LEVEL and not settings.OPT_LEVEL and not settings.USE_ASAN:
+  if 'GLOBAL_BASE' not in user_settings and not settings.SHRINK_LEVEL and not options.opt_level and not settings.USE_ASAN:
     # When optimizing for size it helps to put static data first before
     # the stack (since this makes instructions for accessing this data
     # use a smaller LEB encoding).
@@ -1824,7 +1824,6 @@ def phase_linker_setup(linker_args):  # ruff: ignore[complex-structure, too-many
     # Also include EMSCRIPTEN_VERSION from the internal settings since there are
     # known usage of this with `emscripten_get_compiler_setting`.
     settings.PUBLIC_SETTINGS.append('EMSCRIPTEN_VERSION')
-  settings.SOURCE_MAP_BASE = options.source_map_base or ''
 
   settings.LINK_AS_CXX = (shared.run_via_emxx or settings.DEFAULT_TO_CXX) and not options.nostdlibxx
 
@@ -1880,7 +1879,7 @@ def phase_linker_setup(linker_args):  # ruff: ignore[complex-structure, too-many
   settings.PRE_JS_FILES = options.pre_js
   settings.POST_JS_FILES = options.post_js
 
-  settings.MINIFY_WHITESPACE = settings.OPT_LEVEL >= 2 and settings.DEBUG_LEVEL == 0 and not options.no_minify
+  settings.MINIFY_WHITESPACE = options.opt_level >= 2 and options.debug_level == 0 and not options.no_minify
 
   # Closure might be run if we run it ourselves, or if whitespace is not being
   # minified. In the latter case we keep both whitespace and comments, and the
@@ -2265,7 +2264,7 @@ def phase_final_emitting(target, js_target, wasm_target):
   # Run a final optimization pass to clean up items that were not possible to
   # optimize by Closure, or unoptimalities that were left behind by processing
   # steps that occurred after Closure.
-  if settings.MINIMAL_RUNTIME == 2 and settings.USE_CLOSURE_COMPILER and settings.DEBUG_LEVEL == 0:
+  if settings.MINIMAL_RUNTIME == 2 and settings.USE_CLOSURE_COMPILER and options.debug_level == 0:
     args = [final_js, '-o', final_js]
     if not settings.MINIFY_WHITESPACE:
       args.append('--pretty')
@@ -2331,7 +2330,7 @@ def phase_binaryen(target, wasm_target):
   global final_js
   logger.debug('using binaryen')
   # whether we need to emit -g (function name debug info) in the final wasm
-  debug_function_names = settings.DEBUG_LEVEL >= 2 or settings.EMIT_NAME_SECTION
+  debug_function_names = options.debug_level >= 2 or settings.EMIT_NAME_SECTION
   # whether we need to emit -g in the intermediate binaryen invocations (but not
   # necessarily at the very end). this is necessary if we depend on debug info
   # during compilation, even if we do not emit it at the end.
@@ -2403,7 +2402,7 @@ def phase_binaryen(target, wasm_target):
       with ToolchainProfiler.profile_block('little_endian_heap'):
         final_js = building.little_endian_heap(final_js)
 
-    if settings.OPT_LEVEL >= 2 and settings.DEBUG_LEVEL <= 2:
+    if options.opt_level >= 2 and options.debug_level <= 2:
       # minify the JS. Do not minify whitespace if Closure is used, so that
       # Closure can print out readable error messages (Closure will then
       # minify whitespace afterwards)
@@ -2442,7 +2441,7 @@ def phase_binaryen(target, wasm_target):
 
     wasm2js = building.wasm2js(wasm2js_template,
                                wasm_target,
-                               opt_level=settings.OPT_LEVEL,
+                               opt_level=options.opt_level,
                                use_closure_compiler=options.use_closure_compiler,
                                debug_info=debug_function_names,
                                symbols_file=symbols_file,
@@ -2609,19 +2608,19 @@ def generate_traditional_runtime_html(target, js_target, wasm_target):
 
 @ToolchainProfiler.profile()
 def minify_html(filename):
-  if settings.DEBUG_LEVEL >= 2:
+  if options.debug_level >= 2:
     return
 
   opts = []
   # -g1 and greater retain whitespace and comments in source
-  if settings.DEBUG_LEVEL == 0:
+  if options.debug_level == 0:
     opts += ['--collapse-whitespace',
              '--remove-comments',
              '--remove-tag-whitespace',
              '--sort-attributes',
              '--sort-class-name']
   # -g2 and greater do not minify HTML at all
-  if settings.DEBUG_LEVEL <= 1:
+  if options.debug_level <= 1:
     opts += ['--decode-entities',
              '--collapse-boolean-attributes',
              '--remove-attribute-quotes',
@@ -2695,7 +2694,7 @@ def generate_html(target, js_target, target_basename, wasm_target):
   else:
     generate_traditional_runtime_html(target, js_target, wasm_target)
 
-  if settings.MINIFY_HTML and (settings.OPT_LEVEL >= 1 or settings.SHRINK_LEVEL >= 1):
+  if settings.MINIFY_HTML and (options.opt_level >= 1 or settings.SHRINK_LEVEL >= 1):
     minify_html(target)
 
   convert_line_endings_in_file(target, options.output_eol)

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -95,8 +95,6 @@ COMPILE_TIME_SETTINGS = {
     # Internal settings used during compilation
     'EXCEPTION_CATCHING_ALLOWED',
     'WASM_EXCEPTIONS',
-    'OPT_LEVEL',
-    'DEBUG_LEVEL',
 }.union(PORTS_SETTINGS)
 
 # Unlike `LEGACY_SETTINGS`, deprecated settings can still be used

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2020,7 +2020,7 @@ class libembind(MTLibrary):
 
   @classmethod
   def get_default_variation(cls, **kwargs):
-    return super().get_default_variation(with_rtti=settings.USE_RTTI, **kwargs)
+    return super().get_default_variation(with_rtti=options.rtti, **kwargs)
 
 
 class libfetch(MTLibrary):


### PR DESCRIPTION
Remove internal settings `OPT_LEVEL`, `USE_RTTI`, `DEBUG_LEVEL`, `EMIT_SYMBOL_MAP`, `SOURCE_MAP_BASE`, and `MINIFICATION_MAP` from `src/settings_internal.js` and `tools/settings.py` since they are toolchain-internal settings not used in JavaScript libraries or runtime code. Store their state on `EmccOptions` fields instead.