### PR TITLE
[ports] Fix fetching binary data via curl and test binary downloads

### DIFF
--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -360,7 +360,7 @@ class Ports:
           # Unlike on Windows or Linux, curl is guaranteed to always be
           # available on macOS.
           # EMCC_USE_CURL here is purely for testing and undocumented.
-          data = utils.run_process(['curl', '-sSL', url], stdout=subprocess.PIPE).stdout
+          data = utils.run_process(['curl', '-sSL', url], stdout=subprocess.PIPE, text=False).stdout
         else:
           with urlopen(url) as f:
             data = f.read()

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -41,7 +41,8 @@ def run_process(cmd, check=True, input=None, *args, **kw):
   sys.stdout.flush()
   sys.stderr.flush()
   kw.setdefault('text', True)
-  kw.setdefault('encoding', 'utf-8')
+  if kw['text']:
+    kw.setdefault('encoding', 'utf-8')
   ret = subprocess.run(cmd, check=check, input=input, *args, **kw)
   debug_text = '%sexecuted %s' % ('successfully ' if check else '', shlex.join(cmd))
   logger.debug(debug_text)


### PR DESCRIPTION
Ensure `utils.run_process` respects `text=False` by only setting `encoding='utf-8'` when text mode is enabled. Pass `text=False` when fetching ports with `curl` in `tools/ports/__init__.py` to prevent decoding binary download data as UTF-8.

See: #27536