### PR TITLE
Fix poppler benchmark environment flags

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1200,6 +1200,8 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
       make = ['make']
     if env_init is None:
       env_init = {}
+    else:
+      env_init = env_init.copy()
     if make_args is None:
       make_args = ['-j', str(utils.get_num_cores())]
 
@@ -1234,8 +1236,9 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
       configure += configure_args
 
     cflags = ' '.join(cflags)
-    env_init.setdefault('CFLAGS', cflags)
-    env_init.setdefault('CXXFLAGS', cflags)
+    # Append library-specific cflags without overwriting caller-provided optimizations
+    env_init['CFLAGS'] = f"{env_init.get('CFLAGS', '')} {cflags}".strip()
+    env_init['CXXFLAGS'] = f"{env_init.get('CXXFLAGS', '')} {cflags}".strip()
     return self.build_library(name, build_dir, generated_libs, configure,
                               make, make_args, cache_name, env_init=env_init, native=native)
 
@@ -1512,7 +1515,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
           raise
     return js_output
 
-  def get_freetype_library(self):
+  def get_freetype_library(self, env_init=None):
     self.cflags += [
       '-Wno-misleading-indentation',
       '-Wno-unused-but-set-variable',
@@ -1524,10 +1527,11 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     ]
     return self.get_library(os.path.join('third_party', 'freetype'),
                             os.path.join('objs', '.libs', 'libfreetype.a'),
+                            env_init=env_init,
                             configure_args=['--disable-shared', '--without-zlib'])
 
   def get_poppler_library(self, env_init=None):
-    freetype = self.get_freetype_library()
+    freetype = self.get_freetype_library(env_init=env_init)
 
     self.cflags += [
       '-I' + test_file('third_party/freetype/include'),

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -255,6 +255,7 @@ class EmscriptenBenchmarker(Benchmarker):
       # systems (like zlib) if they see a CFLAGS it will override all their
       # default flags, including optimizations.
       env_init['CFLAGS'] = ' '.join(LLVM_FEATURE_FLAGS + [OPTIMIZATIONS] + self.cflags)
+      env_init['CXXFLAGS'] = env_init['CFLAGS']
       # Avoid mutating incoming emcc_args
       emcc_args = emcc_args.copy()
       emcc_args += lib_builder('js_' + llvm_root, native=False, env_init=env_init)


### PR DESCRIPTION
Preserve existing environment flags in the test library builder instead of overwriting them. This ensures caller-provided optimization settings are maintained.

Set CXXFLAGS alongside CFLAGS to ensure C++ dependencies compile with the correct settings. Pass environment overrides to the freetype dependency to fix the poppler benchmark build with LTO.