### PR TITLE
Remove support for non-standard -no-pthreads command line flag

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15079,11 +15079,6 @@ addToLibrary({
     # was not included in the compilation unit using val.
     self.do_runf('embind/test_optional_val_main.cpp', 'done\n', cflags=['-lembind', test_file('embind/test_optional_val_lib.cpp')])
 
-  def test_no_pthread(self):
-    self.do_runf_out_file('hello_world.c', cflags=['-pthread', '-no-pthread'])
-    self.assertExists('hello_world.js')
-    self.assertNotContained('new Worker(', read_file('hello_world.js'))
-
   def test_sysroot_includes_first(self):
     self.do_other_test('test_stdint_limits.c', cflags=['-iwithsysroot/include'])
 

--- a/tools/cmdline.py
+++ b/tools/cmdline.py
@@ -541,10 +541,6 @@ def parse_args(newargs):  # ruff: ignore[complex-structure, too-many-branches, t
       settings.PTHREADS = 1
       # Also set the legacy setting name, in case use JS code depends on it.
       settings.USE_PTHREADS = 1
-    elif arg == '-no-pthread':
-      settings.PTHREADS = 0
-      # Also set the legacy setting name, in case use JS code depends on it.
-      settings.USE_PTHREADS = 0
     elif arg == '-pthreads':
       exit_with_error('unrecognized command-line option `-pthreads`; did you mean `-pthread`?')
     elif arg == '-fno-rtti':


### PR DESCRIPTION
It turns out this was never really supported by LLVM in the way I thought it was when I added support here:
https://github.com/llvm/llvm-project/pull/216378
  
I'm pretty we never advertised the availability of this non-standard flag anywhere so I think removing it should be low risk.  See #20723 for where it was added.