### PR TITLE
Remove experimental warning from `-sJSPI`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 6.0.8 (in development)
 ----------------------
+- The `JSPI` setting is no longer considered experimental, and the compiler
+  diagnostic warning has been removed. (#27559)
 
 6.0.7 - 08/17/26
 ----------------

--- a/site/source/docs/porting/asyncify.rst
+++ b/site/source/docs/porting/asyncify.rst
@@ -20,9 +20,8 @@ mechanisms to work.
     you, so that it is asynchronous (hence the name "Asyncify") even though you
     wrote it in a normal synchronous way. This works in most environments, but
     can cause the Wasm output to be much larger.
-  * `JSPI` (experimental) - Uses the VM's support for JavaScript Promise
-    Integration (JSPI) for interacting with async JavaScript. The code size will
-    remain the same, but support for this feature is still experimental.
+  * `JSPI` - Uses the VM's support for JavaScript Promise Integration (JSPI)
+    for interacting with async JavaScript. The code size will remain the same.
 
 For more on Asyncify see the
 `Asyncify introduction blogpost <https://kripken.github.io/blog/wasm/2019/07/16/asyncify.html>`_

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -1374,11 +1374,10 @@ JSPI
 ====
 
 Use VM support for the JavaScript Promise Integration proposal. This allows
-async operations to happen without the overhead of modifying the wasm. This
-is experimental at the moment while spec discussion is ongoing, see
-https://github.com/WebAssembly/js-promise-integration/ TODO: document which
-of the following flags are still relevant in this mode (e.g. IGNORE_INDIRECT
-etc. are not needed)
+async operations to happen without the overhead of modifying the wasm.
+See https://github.com/WebAssembly/js-promise-integration/
+TODO: document which of the following flags are still relevant in this mode
+(e.g. IGNORE_INDIRECT etc. are not needed)
 
 Default value: 0
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -933,11 +933,10 @@ var ASYNCIFY_DEBUG = 0;
 var ASYNCIFY_EXPORTS = [];
 
 // Use VM support for the JavaScript Promise Integration proposal. This allows
-// async operations to happen without the overhead of modifying the wasm. This
-// is experimental at the moment while spec discussion is ongoing, see
-// https://github.com/WebAssembly/js-promise-integration/ TODO: document which
-// of the following flags are still relevant in this mode (e.g. IGNORE_INDIRECT
-// etc. are not needed)
+// async operations to happen without the overhead of modifying the wasm.
+// See https://github.com/WebAssembly/js-promise-integration/
+// TODO: document which of the following flags are still relevant in this mode
+// (e.g. IGNORE_INDIRECT etc. are not needed)
 //
 // [link]
 var JSPI = 0;

--- a/test/common.py
+++ b/test/common.py
@@ -635,9 +635,6 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
   def require_jspi(self):
     if 'EMTEST_SKIP_JSPI' in os.environ:
       self.skipTest('skipping JSPI (EMTEST_SKIP_JSPI is set)')
-    # emcc warns about stack switching being experimental, and we build with
-    # warnings-as-errors, so disable that warning
-    self.cflags += ['-Wno-experimental']
     self.set_setting('JSPI')
     if self.is_wasm2js():
       self.skipTest('JSPI is not currently supported for WASM2JS')

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3202,9 +3202,9 @@ Module["preRun"] = () => {
   @parameterized({
     'asyncify': (['-sASYNCIFY'],),
     'asyncify_minimal_runtime': (['-sMINIMAL_RUNTIME', '-sASYNCIFY'],),
-    'jspi': (['-sJSPI', '-Wno-experimental'],),
-    'jspi_wasm_bigint': (['-sJSPI', '-sWASM_BIGINT', '-Wno-experimental'],),
-    'jspi_wasm_bigint_minimal_runtime': (['-sMINIMAL_RUNTIME', '-sJSPI', '-sWASM_BIGINT', '-Wno-experimental'],),
+    'jspi': (['-sJSPI'],),
+    'jspi_wasm_bigint': (['-sJSPI', '-sWASM_BIGINT'],),
+    'jspi_wasm_bigint_minimal_runtime': (['-sMINIMAL_RUNTIME', '-sJSPI', '-sWASM_BIGINT'],),
   })
   def test_async(self, opt, args):
     if is_jspi(args) and not is_chrome():
@@ -4883,7 +4883,7 @@ Module["preRun"] = () => {
 
   @parameterized({
     'asyncify': (['-sASYNCIFY'],),
-    'jspi': (['-sJSPI', '-Wno-experimental'],),
+    'jspi': (['-sJSPI'],),
   })
   def test_embind(self, args):
     if is_jspi(args) and not is_chrome():
@@ -5292,8 +5292,8 @@ Module["preRun"] = () => {
   @no_firefox('no OPFS support yet')
   @parameterized({
     '': (['-pthread', '-sPROXY_TO_PTHREAD'],),
-    'jspi': (['-Wno-experimental', '-sJSPI'],),
-    'jspi_wasm_bigint': (['-Wno-experimental', '-sJSPI', '-sWASM_BIGINT'],),
+    'jspi': (['-sJSPI'],),
+    'jspi_wasm_bigint': (['-sJSPI', '-sWASM_BIGINT'],),
     'asyncify': (['-sASYNCIFY=1'],),
   })
   @no_safari('TODO: Fails with abort:Assertion failed: err == 0') # Fails in Safari 17.6 (17618.3.11.11.7, 17618), Safari 26.0.1 (21622.1.22.11.15)

--- a/tools/link.py
+++ b/tools/link.py
@@ -1752,9 +1752,6 @@ def phase_linker_setup(linker_args):  # ruff: ignore[complex-structure, too-many
 
     settings.ASYNCIFY_IMPORTS = [get_full_import_name(i) for i in settings.ASYNCIFY_IMPORTS]
 
-    if settings.ASYNCIFY == 2:
-      diagnostics.warning('experimental', '-sJSPI (ASYNCIFY=2) is still experimental')
-
   if settings.WASM2JS:
     if settings.GENERATE_SOURCE_MAP:
       exit_with_error('wasm2js does not support source maps yet (debug in wasm for now)')


### PR DESCRIPTION
Now that JSPI has reached Phase 4 and is shipping (enabled by default without a flag since Chrome 137 and Node 26), remove the diagnostic warning when linking with `-sJSPI`. Also update documentation and clean up `-Wno-experimental` suppressions in test files.