### PR TITLE
Avoid throwing on `blob:` created via `URL.createObjectURL()`

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -101,6 +101,12 @@ function _free() {
 #endif // ASSERTIONS
 
 /**
+ * Indicates whether filename is delivered via URL.createObjectURL()
+ * @noinline
+ */
+var isBlobURI = (filename) => filename.startsWith('blob:');
+
+/**
  * Indicates whether filename is delivered via file protocol (as opposed to http/https)
  * @noinline
  */
@@ -685,13 +691,18 @@ async function instantiateAsync(binary, binaryFile, imports) {
       && !isFileURI(binaryFile)
 #endif
 #if ENVIRONMENT_MAY_BE_NODE
-      // Avoid instantiateStreaming() on Node.js environment for now, as while
-      // Node.js v18.1.0 implements it, it does not have a full fetch()
-      // implementation yet.
-      //
-      // Reference:
-      //   https://github.com/emscripten-core/emscripten/pull/16917
-      && !ENVIRONMENT_IS_NODE
+      && (
+        // Avoid instantiateStreaming() on Node.js environment for now, as while
+        // Node.js v18.1.0 implements it, it does not have a full fetch()
+        // implementation yet.
+        //
+        // Reference:
+        //   https://github.com/emscripten-core/emscripten/pull/16917
+        !ENVIRONMENT_IS_NODE
+        // On browsers this check won't be reached but on Node.js it is the only way to avoid
+        // throwing when URL.createObjectURL(blob) has been passed as the binaryFile.
+        || isBlobURI(binaryFile)
+      )
 #endif
 #if ENVIRONMENT_MAY_BE_SHELL
       // Shell environments don't have fetch.

--- a/test/codesize/test_codesize_file_preload.expected.js
+++ b/test/codesize/test_codesize_file_preload.expected.js
@@ -295,6 +295,11 @@ var ABORT = false;
 var EXITSTATUS;
 
 /**
+ * Indicates whether filename is delivered via URL.createObjectURL()
+ * @noinline
+ */ var isBlobURI = (filename) => filename.startsWith('blob:');
+
+/**
  * Indicates whether filename is delivered via file protocol (as opposed to http/https)
  * @noinline
  */ var isFileURI = filename => filename.startsWith("file://");
@@ -415,7 +420,7 @@ async function instantiateArrayBuffer(binaryFile, imports) {
 }
 
 async function instantiateAsync(binary, binaryFile, imports) {
-  if (!binary && !isFileURI(binaryFile) && !ENVIRONMENT_IS_NODE) {
+  if (!binary && !isFileURI(binaryFile) && (!ENVIRONMENT_IS_NODE || isBlobURI(binaryFile))) {
     try {
       var response = fetch(binaryFile, {
         credentials: "same-origin"

--- a/test/codesize/test_codesize_minimal_O0.expected.js
+++ b/test/codesize/test_codesize_minimal_O0.expected.js
@@ -287,6 +287,12 @@ function _free() {
 }
 
 /**
+ * Indicates whether filename is delivered via URL.createObjectURL()
+ * @noinline
+ */
+var isBlobURI = (filename) => filename.startsWith('blob:');
+
+/**
  * Indicates whether filename is delivered via file protocol (as opposed to http/https)
  * @noinline
  */
@@ -651,13 +657,18 @@ async function instantiateAsync(binary, binaryFile, imports) {
   if (!binary
       // Don't use streaming for file:// delivered objects in a webview, fetch them synchronously.
       && !isFileURI(binaryFile)
-      // Avoid instantiateStreaming() on Node.js environment for now, as while
-      // Node.js v18.1.0 implements it, it does not have a full fetch()
-      // implementation yet.
-      //
-      // Reference:
-      //   https://github.com/emscripten-core/emscripten/pull/16917
-      && !ENVIRONMENT_IS_NODE
+      && (
+        // Avoid instantiateStreaming() on Node.js environment for now, as while
+        // Node.js v18.1.0 implements it, it does not have a full fetch()
+        // implementation yet.
+        //
+        // Reference:
+        //   https://github.com/emscripten-core/emscripten/pull/16917
+        !ENVIRONMENT_IS_NODE
+        // On browsers this check won't be reached but on Node.js it is the only way to avoid
+        // throwing when URL.createObjectURL(blob) has been passed as the binaryFile.
+        || isBlobURI(binaryFile)
+      )
      ) {
     try {
       var response = fetch(binaryFile, { credentials: 'same-origin' });


### PR DESCRIPTION
The current artifact fails at instantiating blobs that contain runtime WASM artifacts.

Fixes https://github.com/WebAssembly/wabt/issues/2828