### PR TITLE
Flip the default for LEGALIZE_JS_FFI. NFC

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -2188,14 +2188,14 @@ Default value: false
 LEGALIZE_JS_FFI
 ===============
 
-Whether to legalize the JS FFI interfaces (imports/exports) by wrapping them
-to automatically demote i64 to i32 and promote f32 to f64. This is necessary
-in order to interface with JavaScript.  For non-web/non-JS embeddings,
-setting this to 0 may be desirable.
+Whether to lower i64 parameters and return values for function
+imports/exports.  This is done by lowering them to pairs of i32 and should
+only be needed on JS engines that do not have Wasm/BigInt integration.
+This is automatically enabled when WASM_BIGINT is disabled.
 
 .. note:: This setting is deprecated
 
-Default value: true
+Default value: false
 
 .. _use_sdl:
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1521,13 +1521,13 @@ var EMIT_PRODUCERS_SECTION = false;
 // [link]
 var EMIT_EMSCRIPTEN_LICENSE = false;
 
-// Whether to legalize the JS FFI interfaces (imports/exports) by wrapping them
-// to automatically demote i64 to i32 and promote f32 to f64. This is necessary
-// in order to interface with JavaScript.  For non-web/non-JS embeddings,
-// setting this to 0 may be desirable.
+// Whether to lower i64 parameters and return values for function
+// imports/exports.  This is done by lowering them to pairs of i32 and should
+// only be needed on JS engines that do not have Wasm/BigInt integration.
+// This is automatically enabled when WASM_BIGINT is disabled.
 // [link]
 // [deprecated]
-var LEGALIZE_JS_FFI = true;
+var LEGALIZE_JS_FFI = false;
 
 // Ports
 

--- a/tools/link.py
+++ b/tools/link.py
@@ -1120,9 +1120,6 @@ def phase_linker_setup(linker_args):  # ruff: ignore[complex-structure, too-many
       exit_with_error('explicitly setting EXIT_RUNTIME not compatible with STANDALONE_WASM.  EXIT_RUNTIME will always be True for programs (with a main function) and False for reactors (not main function).')
     settings.EXIT_RUNTIME = settings.EXPECT_MAIN
     settings.IGNORE_MISSING_MAIN = 0
-    # the wasm must be runnable without the JS, so there cannot be anything that
-    # requires JS legalization
-    default_setting('LEGALIZE_JS_FFI', 0)
     if 'MEMORY_GROWTH_LINEAR_STEP' in user_settings:
       exit_with_error('MEMORY_GROWTH_LINEAR_STEP is not compatible with STANDALONE_WASM')
     if 'MEMORY_GROWTH_GEOMETRIC_CAP' in user_settings:
@@ -1642,8 +1639,8 @@ def phase_linker_setup(linker_args):  # ruff: ignore[complex-structure, too-many
     # module names buys nothing and would break that rewrite.
     settings.MINIFY_WASM_IMPORTED_MODULES = not settings.WASM_ESM_INTEGRATION
 
-  if settings.WASM_BIGINT:
-    settings.LEGALIZE_JS_FFI = 0
+  if not settings.WASM_BIGINT:
+    default_setting('LEGALIZE_JS_FFI', 1)
 
   if settings.SINGLE_FILE and settings.GENERATE_SOURCE_MAP:
     diagnostics.warning('emcc', 'SINGLE_FILE disables source map support (which requires a .map file)')


### PR DESCRIPTION
This setting has already been deprecated for a long time.  Flipping its default is really no-op here but it makes the followup changes to remove it simpler.

Split out from #27558.