### PR TITLE
Fix Bun 1.4 + pthreads by always bridging `parentPort` in worker threads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -805,10 +805,7 @@ jobs:
       - run:
           name: install bun
           command: |
-            # Temporally pin to 1.3.14 (the last non-rust version) until we
-            # can investigate the breakages:
-            # https://github.com/emscripten-core/emscripten/issues/27580
-            curl -fsSL https://bun.com/install | bash -s "bun-v1.3.14"
+            curl -fsSL https://bun.com/install | bash
             echo "BUN = '~/.bun/bin/bun'" >> ~/emsdk/.emscripten
             echo "JS_ENGINES = [BUN]" >> ~/emsdk/.emscripten
       - run-tests:

--- a/src/pthread_esm_startup.mjs
+++ b/src/pthread_esm_startup.mjs
@@ -20,13 +20,8 @@ if ({{{ nodeDetectionCode() }}}) {
   var worker_threads = await import('node:worker_threads');
   globalThis.Worker = worker_threads.Worker;
   var parentPort = worker_threads.parentPort;
-  // Deno and Bun already have `postMessage` defined on the global scope and
-  // deliver messages to `globalThis.onmessage`, so we must not duplicate that
-  // behavior here if `postMessage` is already present.
-  if (!globalThis.postMessage) {
-    parentPort.on('message', (msg) => globalThis.onmessage?.({ data: msg }));
-    globalThis.postMessage = (msg) => parentPort.postMessage(msg);
-  }
+  parentPort.on('message', (msg) => globalThis.onmessage?.({ data: msg }));
+  globalThis.postMessage = (msg) => parentPort.postMessage(msg);
 }
 #endif
 

--- a/src/runtime_common.js
+++ b/src/runtime_common.js
@@ -39,13 +39,8 @@ if (ENVIRONMENT_IS_NODE && {{{ ENVIRONMENT_IS_WORKER_THREAD() }}}) {
   // Create as web-worker-like an environment as we can.
   globalThis.self = globalThis;
   var parentPort = worker_threads.parentPort;
-  // Deno and Bun already have `postMessage` defined on the global scope and
-  // deliver messages to `globalThis.onmessage`, so we must not duplicate that
-  // behavior here if `postMessage` is already present.
-  if (!globalThis.postMessage) {
-    parentPort.on('message', (msg) => globalThis.onmessage?.({ data: msg }));
-    globalThis.postMessage = (msg) => parentPort.postMessage(msg);
-  }
+  parentPort.on('message', (msg) => globalThis.onmessage?.({ data: msg }));
+  globalThis.postMessage = (msg) => parentPort.postMessage(msg);
   // Node.js Workers do not pass postMessage()s and uncaught exception events to the parent
   // thread necessarily in the same order where they were generated in sequential program order.
   // See https://github.com/nodejs/node/issues/59617

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -2,9 +2,9 @@
   "a.out.js": 19224,
   "a.out.js.gz": 8124,
   "a.out.nodebug.wasm": 134722,
-  "a.out.nodebug.wasm.gz": 51543,
+  "a.out.nodebug.wasm.gz": 51542,
   "total": 153946,
-  "total_gz": 59667,
+  "total_gz": 59666,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -2,9 +2,9 @@
   "a.out.js": 22917,
   "a.out.js.gz": 9078,
   "a.out.nodebug.wasm": 177188,
-  "a.out.nodebug.wasm.gz": 59120,
+  "a.out.nodebug.wasm.gz": 59121,
   "total": 200105,
-  "total_gz": 68198,
+  "total_gz": 68199,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -2,9 +2,9 @@
   "a.out.js": 19023,
   "a.out.js.gz": 8039,
   "a.out.nodebug.wasm": 150451,
-  "a.out.nodebug.wasm.gz": 56610,
+  "a.out.nodebug.wasm.gz": 56609,
   "total": 169474,
-  "total_gz": 64649,
+  "total_gz": 64648,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -2,9 +2,9 @@
   "a.out.js": 19101,
   "a.out.js.gz": 8065,
   "a.out.nodebug.wasm": 148233,
-  "a.out.nodebug.wasm.gz": 56298,
+  "a.out.nodebug.wasm.gz": 56299,
   "total": 167334,
-  "total_gz": 64363,
+  "total_gz": 64364,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -2,9 +2,9 @@
   "a.out.js": 22967,
   "a.out.js.gz": 9098,
   "a.out.nodebug.wasm": 243468,
-  "a.out.nodebug.wasm.gz": 81314,
+  "a.out.nodebug.wasm.gz": 81315,
   "total": 266435,
-  "total_gz": 90412,
+  "total_gz": 90413,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 23471,
   "a.out.js.gz": 8555,
-  "a.out.nodebug.wasm": 15109,
-  "a.out.nodebug.wasm.gz": 7456,
-  "total": 38580,
-  "total_gz": 16011,
+  "a.out.nodebug.wasm": 15115,
+  "a.out.nodebug.wasm.gz": 7460,
+  "total": 38586,
+  "total_gz": 16015,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_minimal_pthreads.json
+++ b/test/codesize/test_codesize_minimal_pthreads.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 6883,
-  "a.out.js.gz": 3422,
+  "a.out.js": 6857,
+  "a.out.js.gz": 3416,
   "a.out.nodebug.wasm": 19118,
   "a.out.nodebug.wasm.gz": 8835,
-  "total": 26001,
-  "total_gz": 12257,
+  "total": 25975,
+  "total_gz": 12251,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
+++ b/test/codesize/test_codesize_minimal_pthreads_memgrowth.json
@@ -1,10 +1,10 @@
 {
-  "a.out.js": 7341,
-  "a.out.js.gz": 3639,
+  "a.out.js": 7315,
+  "a.out.js.gz": 3633,
   "a.out.nodebug.wasm": 19119,
   "a.out.nodebug.wasm.gz": 8836,
-  "total": 26460,
-  "total_gz": 12475,
+  "total": 26434,
+  "total_gz": 12469,
   "sent": [
     "a (memory)",
     "b (exit)",

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
   "hello_world.js": 54465,
   "hello_world.js.gz": 17297,
-  "hello_world.wasm": 15109,
-  "hello_world.wasm.gz": 7456,
+  "hello_world.wasm": 15115,
+  "hello_world.wasm.gz": 7460,
   "no_asserts.js": 23544,
   "no_asserts.js.gz": 8261,
   "no_asserts.wasm": 12223,
-  "no_asserts.wasm.gz": 5996,
+  "no_asserts.wasm.gz": 5991,
   "strict.js": 51616,
   "strict.js.gz": 16308,
-  "strict.wasm": 15109,
-  "strict.wasm.gz": 7453,
-  "total": 172066,
-  "total_gz": 62771
+  "strict.wasm": 15115,
+  "strict.wasm.gz": 7456,
+  "total": 172078,
+  "total_gz": 62773
 }


### PR DESCRIPTION
In #25947, a check for `!globalThis.postMessage` was added before wiring `parentPort.on('message') -> globalThis.onmessage` and `globalThis.postMessage = (msg) => parentPort.postMessage(msg)`.

However, in Bun 1.4+, `node:worker_threads` deliveries are isolated to `parentPort` (they are no longer automatically routed to `globalThis.onmessage`), while `globalThis.postMessage` remains defined on the global object. Because `globalThis.postMessage` was truthy, Emscripten skipped hooking `parentPort.on('message')`, leaving worker threads unresponsive to initialization messages from the main thread.

Removing the `if (!globalThis.postMessage)` guard ensures `parentPort` is always correctly wired whenever running in a Node-style worker thread.

Fixes: #27580