### PR TITLE
Fix stale requestFileHandles() call in Cross-Origin Storage docs

### DIFF
--- a/site/source/docs/compiling/CrossOriginStorage.rst
+++ b/site/source/docs/compiling/CrossOriginStorage.rst
@@ -329,7 +329,7 @@ via a reference to that config object:
        // read the hash via the outer Module reference instead.
        const cosHash = Module['wasmHash'];
        if (cosHash?.value && globalThis.navigator?.crossOriginStorage) {
-         navigator.crossOriginStorage.requestFileHandles(cosHash)
+         navigator.crossOriginStorage.requestFileHandle(cosHash)
            .then(handle => handle.getFile())
            .then(f => f.arrayBuffer())
            .then(bytes => WebAssembly.instantiate(bytes, imports))


### PR DESCRIPTION
The `instantiateWasm` example in `site/source/docs/compiling/CrossOriginStorage.rst` called `navigator.crossOriginStorage.requestFileHandles(cosHash)` with a bare hash and then treated the result as a single `FileSystemFileHandle` (`.then(handle => handle.getFile())`).

The API is `requestFileHandle()` (singular). The plural form was an early draft that took an array of hashes and returned an array of handles; it was [removed in favor of the singular form](https://github.com/WICG/cross-origin-storage/issues/61). The rest of this document — and the actual implementation in `src/preamble.js` — already use the singular form, so this example was the only stale call site.

Docs-only, one line.