### PR TITLE
Avoid recursive cache lock in SDL TTF ports

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -99,7 +99,7 @@ from decorators import (
   with_env_modify,
 )
 
-from tools import building, cache, response_file, shared, utils, webassembly
+from tools import building, cache, ports, response_file, shared, utils, webassembly
 from tools.building import get_building_env
 from tools.cmdline import options
 from tools.link import binary_encode
@@ -2752,6 +2752,17 @@ F1 -> ''
     # A compile-only test that checks if sdl3-ttf, and dependencies freetype and harfbuzz, are buildable.
     self.emcc(test_file('browser/test_sdl3_ttf.c'), args=['-Wno-experimental', '-sUSE_SDL=3', '-sUSE_SDL_TTF=3'])
     self.emcc(test_file('browser/test_sdl3_ttf.c'), args=['-Wno-experimental', '--use-port=sdl3', '--use-port=sdl3_ttf'])
+
+  @requires_network
+  def test_sdl_ttf_parent_cache_lock(self):
+    # Verify that building sdl2_ttf while holding the cache lock (as a parent process does)
+    # succeeds even if libharfbuzz.a is not yet present in the cache.
+    shared.cache.erase_lib('libharfbuzz.a')
+    shared.cache.erase_lib('libSDL2_ttf.a')
+    self.set_setting('USE_SDL', 2)
+    self.set_setting('USE_SDL_TTF', 2)
+    with shared.cache.lock('test_sdl_ttf_parent_cache_lock'):
+      ports.get_port_by_name('sdl2_ttf').get(ports.Ports, settings, shared)
 
   @requires_network
   def test_contrib_ports(self):

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -440,6 +440,7 @@ class Ports:
   def write_file(filename, contents):
     if os.path.exists(filename) and utils.read_file(filename) == contents:
       return
+    utils.safe_ensure_dirs(os.path.dirname(filename))
     utils.write_file(filename, contents)
 
   @staticmethod

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -25,10 +25,15 @@ def get(ports, settings, shared):
   def create(final):
     src_root = ports.get_dir('sdl2_ttf', 'SDL_ttf-' + TAG)
     ports.install_headers(src_root, target='SDL2')
-    flags = ['-DTTF_USE_HARFBUZZ=1', '-sUSE_SDL=2', '-sUSE_FREETYPE', '-sUSE_HARFBUZZ']
+    includes = [
+      ports.get_include_dir('SDL2'),
+      ports.get_include_dir('freetype2'),
+      ports.get_include_dir('harfbuzz'),
+    ]
+    flags = ['-DTTF_USE_HARFBUZZ=1']
     if settings.PTHREADS:
       flags += ['-pthread']
-    ports.build_port(src_root, final, 'sdl2_ttf', flags=flags, srcs=['SDL_ttf.c'])
+    ports.build_port(src_root, final, 'sdl2_ttf', includes=includes, flags=flags, srcs=['SDL_ttf.c'])
 
   return [shared.cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/sdl3_ttf.py
+++ b/tools/ports/sdl3_ttf.py
@@ -27,7 +27,13 @@ def get(ports, settings, shared):
   def create(final):
     src_root = ports.get_dir('sdl3_ttf', 'SDL_ttf-' + TAG)
     ports.install_header_dir(os.path.join(src_root, 'include'), target='.')
-    flags = ['-Wno-experimental', '-DTTF_USE_HARFBUZZ=1', '-sUSE_SDL=3', '-sUSE_FREETYPE', '-sUSE_HARFBUZZ']
+    includes = [
+      ports.get_include_dir(),
+      ports.get_include_dir('SDL3'),
+      ports.get_include_dir('freetype2'),
+      ports.get_include_dir('harfbuzz'),
+    ]
+    flags = ['-Wno-experimental', '-DTTF_USE_HARFBUZZ=1']
     if settings.PTHREADS:
       flags += ['-pthread']
 
@@ -40,7 +46,7 @@ def get(ports, settings, shared):
       'src/SDL_ttf.c',
     ]
 
-    ports.build_port(src_root, final, 'sdl3_ttf', flags=flags, srcs=srcs)
+    ports.build_port(src_root, final, 'sdl3_ttf', includes=includes, flags=flags, srcs=srcs)
 
   return [shared.cache.get_lib(get_lib_name(settings), create, what='port')]
 


### PR DESCRIPTION
When building port libraries, build_port compiles sources with emcc in a subprocess while the parent process holds EM_CACHE_IS_LOCKED. Passing -sUSE_* flags causes the child emcc to resolve ports and attempt to acquire the cache lock if dependencies like harfbuzz are not yet in the cache, causing an AssertionError.

Pass include directories directly instead of port settings flags when compiling SDL TTF port sources. Also ensure parent directories exist when writing port assets.