### PR TITLE
Remove explicit `-sUSE_SDL=0` when build sdl2/sdl3 ports.

### DIFF
--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -87,7 +87,7 @@ def get(ports, settings, shared):
 
     srcs = [os.path.join(src_dir, 'src', s) for s in srcs]
     # TODO: Remove fwrapv when we update to a version which includes https://github.com/libsdl-org/SDL/pull/12581
-    flags = ['-sUSE_SDL=0', '-fwrapv-pointer']
+    flags = ['-fwrapv-pointer']
     includes = [ports.get_include_dir('SDL2')]
     if settings.PTHREADS:
       flags += ['-pthread']

--- a/tools/ports/sdl3.py
+++ b/tools/ports/sdl3.py
@@ -106,7 +106,7 @@ def get(ports, settings, shared):
       'sensor/dummy/*.c',
     ]
 
-    flags = ['-sUSE_SDL=0']
+    flags = []
     if settings.PTHREADS:
       glob_patterns.append('thread/pthread/*.c')
       flags += ['-pthread']


### PR DESCRIPTION
This should have been remove in #18443.