### PR TITLE
Remove `-fwrapv-pointer` from SDL2 build. NFC

### DIFF
--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -86,8 +86,7 @@ def get(ports, settings, shared):
     srcs += ['thread/%s/%s' % (thread_backend, s) for s in thread_srcs]
 
     srcs = [os.path.join(src_dir, 'src', s) for s in srcs]
-    # TODO: Remove fwrapv when we update to a version which includes https://github.com/libsdl-org/SDL/pull/12581
-    flags = ['-fwrapv-pointer']
+    flags = []
     includes = [ports.get_include_dir('SDL2')]
     if settings.PTHREADS:
       flags += ['-pthread']


### PR DESCRIPTION
This should have been removed in #24912.