### PR TITLE
[noderawfs] Support TTY ioctls and add `test_ioctl_termios_noderawfs`

### DIFF
--- a/src/lib/libnoderawfs.js
+++ b/src/lib/libnoderawfs.js
@@ -5,7 +5,7 @@
  */
 
 addToLibrary({
-  $NODERAWFS__deps: ['$ERRNO_CODES', '$FS', '$NODEFS', '$mmapAlloc', '$FS_modeStringToFlags', '$NODERAWFS_stream_funcs'],
+  $NODERAWFS__deps: ['$ERRNO_CODES', '$FS', '$NODEFS', '$TTY', '$mmapAlloc', '$FS_modeStringToFlags', '$NODERAWFS_stream_funcs'],
   $NODERAWFS__postset: `
     if (!ENVIRONMENT_IS_NODE) {
       throw new Error('NODERAWFS is currently only supported on Node.js environment.')
@@ -201,7 +201,9 @@ addToLibrary({
       if (!stream.stream_ops) {
         rtn.shared.refcnt ??= 0;
         rtn.shared.refcnt++;
-        rtn.tty = nodeTTY.isatty(rtn.nfd);
+        if (nodeTTY.isatty(rtn.nfd)) {
+          rtn.tty = { ops: TTY.default_tty_ops };
+        }
       }
       return rtn;
     },

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -9744,10 +9744,16 @@ end
     # ioctl requires filesystem
     self.do_other_test('test_ioctl.c', cflags=['-sFORCE_FILESYSTEM'])
 
-  # @also_with_noderawfs # NODERAWFS needs to implement the ioctl syscalls, see issue #22264.
   def test_ioctl_termios(self):
     # ioctl requires filesystem
     self.do_other_test('test_ioctl_termios.c', cflags=['-sFORCE_FILESYSTEM'])
+
+  @no_windows('ptys and select are not available on windows')
+  def test_ioctl_termios_noderawfs(self):
+    self.run_process([EMCC, test_file('other/test_ioctl_termios.c'), '-sNODERAWFS', '-sFORCE_FILESYSTEM'])
+    returncode, output = self.run_on_pty(config.NODE_JS + ['a.out.js'])
+    self.assertEqual(returncode, 0)
+    self.assertIn(b'done\r\n', output)
 
   def test_fd_closed(self):
     self.do_other_test('test_fd_closed.cpp')


### PR DESCRIPTION
Set `stream.tty` to a TTY device object with `TTY.default_tty_ops` when `nodeTTY.isatty(nfd)` is true, allowing termios and window size ioctls (`TCGETS`, `TCSETS`, `TIOCGWINSZ`) to work under `NODERAWFS`.

Add `test_ioctl_termios_noderawfs` to `test/test_other.py`.

See: #22264