### PR TITLE
[CI] Move x86 Windows launcher build job to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1198,29 +1198,6 @@ jobs:
     steps:
       - test-sockets-chrome
 
-  build-windows-launcher:
-    executor:
-      name: win/server-2022
-      shell: bash.exe -eo pipefail
-    steps:
-      - checkout
-      - run:
-          name: "build pylauncher"
-          shell: cmd.exe
-          command: .circleci\setup_vs2022.bat && cd tools\pylauncher && call build.bat
-      - store_artifacts:
-          path: tools/pylauncher/pylauncher.exe
-          destination: pylauncher.exe
-      - install-emsdk
-      - pip-install:
-          python: "$EMSDK_PYTHON"
-      - run:
-          name: "create_entry_points"
-          command: $EMSDK_PYTHON tools/maint/create_entry_points.py --exe-files
-      - run:
-          name: "crossplatform tests"
-          command: test/runner.exe core0.test_hello_world
-
 
   # windows and mac do not have separate build and test jobs, as they only run
   # a limited set of tests; it is simpler and faster to do it all in one job.
@@ -1403,7 +1380,6 @@ workflows:
       - test-node-compat
       - test-windows
       - test-windows-browser-firefox
-      - build-windows-launcher
       - test-mac-arm64:
          requires:
            - build-linux

--- a/.circleci/setup_vs2022.bat
+++ b/.circleci/setup_vs2022.bat
@@ -1,4 +1,0 @@
-echo "setting up x64 toolchain"
-call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
-where cl.exe
-echo "done"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,25 @@ jobs:
         sudo update-alternatives --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-19 100
     - run: tools/maint/clang-format-diff.sh origin/$GITHUB_BASE_REF
 
+  build-pylauncher-x64:
+    name: Build pylauncher (x64)
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Setup MSVC
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      with:
+        arch: x64
+    - name: Build pylauncher
+      run: |
+        cd tools\pylauncher
+        call build.bat
+      shell: cmd
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: pylauncher.exe
+        path: tools/pylauncher/pylauncher.exe
+
   build-pylauncher-arm64:
     name: Build pylauncher (ARM64)
     runs-on: windows-11-arm


### PR DESCRIPTION
Move the `build-windows-launcher` job from CircleCI to GitHub Actions (`build-pylauncher-x64`), matching the existing ARM64 launcher build job. Remove `build-windows-launcher` from `.circleci/config.yml` and delete the unused `.circleci/setup_vs2022.bat`.