### PR TITLE
Use streaming compilation on both Cross-Origin Storage paths

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 6.0.9 (in development)
 ----------------------
+- The `-sCROSS_ORIGIN_STORAGE` cache-hit and cache-miss paths now use
+  `WebAssembly.instantiateStreaming()` (via `Blob.stream()` and a `tee()`'d
+  network body respectively), so enabling the flag no longer loses the
+  download/compile overlap of the standard streaming path.
 
 6.0.8 - 08/20/26
 ----------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,7 +23,7 @@ See docs/process.md for more on how version tagging works.
 - The `-sCROSS_ORIGIN_STORAGE` cache-hit and cache-miss paths now use
   `WebAssembly.instantiateStreaming()` (via `Blob.stream()` and a `tee()`'d
   network body respectively), so enabling the flag no longer loses the
-  download/compile overlap of the standard streaming path.
+  download/compile overlap of the standard streaming path. (#27609)
 
 6.0.8 - 08/20/26
 ----------------

--- a/site/source/docs/compiling/CrossOriginStorage.rst
+++ b/site/source/docs/compiling/CrossOriginStorage.rst
@@ -191,17 +191,20 @@ When the page loads, the generated JavaScript follows this logic:
 
 2. **Cache hit** — call
    ``navigator.crossOriginStorage.requestFileHandle(cosHash)``.
-   If the handle is returned (the module is already in COS), read it with
-   ``handle.getFile()`` → ``.arrayBuffer()`` and pass the bytes to
-   ``WebAssembly.instantiate()``.
-   Then invoke ``Module['onCOSCacheHit'](hash)`` if defined.
+   If the handle is returned (the module is already in COS), invoke
+   ``Module['onCOSCacheHit'](hash)`` if defined, then wrap
+   ``handle.getFile().stream()`` in a ``Response`` with an ``application/wasm``
+   content type and pass it to ``WebAssembly.instantiateStreaming()``, so
+   compilation overlaps reading the file from disk.
 
 3. **Cache miss** — if a ``NotFoundError`` is thrown, fetch the ``.wasm``
-   over the network as usual, invoke ``Module['onCOSCacheMiss'](hash, url)`` if
-   defined, call ``WebAssembly.instantiate()`` immediately so the page loads
-   without delay, and then write the bytes into COS in the background
-   (fire-and-forget) using the ``origins`` value controlled by
-   :ref:`CROSS_ORIGIN_STORAGE_ORIGINS` (``'*'`` by default).
+   over the network as usual and invoke ``Module['onCOSCacheMiss'](hash, url)``
+   if defined. The response body is split with ``tee()``: one branch is passed
+   to ``WebAssembly.instantiateStreaming()`` immediately so compilation overlaps
+   the download exactly as on the standard path, and the other branch is piped
+   into COS in the background (fire-and-forget) using the ``origins`` value
+   controlled by :ref:`CROSS_ORIGIN_STORAGE_ORIGINS` (``'*'`` by default).
+   COS verifies the hash when the writable closes.
    Once the write completes, invoke ``Module['onCOSStore'](hash)`` if defined.
 
 4. **Fallback** — any unexpected error (``NotAllowedError`` from the browser,
@@ -329,26 +332,30 @@ via a reference to that config object:
        // read the hash via the outer Module reference instead.
        const cosHash = Module['wasmHash'];
        if (cosHash?.value && globalThis.navigator?.crossOriginStorage) {
+         const wasmHeaders = { headers: { 'Content-Type': 'application/wasm' } };
          navigator.crossOriginStorage.requestFileHandle(cosHash)
            .then(handle => handle.getFile())
-           .then(f => f.arrayBuffer())
-           .then(bytes => WebAssembly.instantiate(bytes, imports))
+           // stream from the stored file so compilation overlaps reading
+           .then(f => WebAssembly.instantiateStreaming(
+             new Response(f.stream(), wasmHeaders), imports))
            .then(({instance, module}) => onSuccess(instance, module))
            .catch(err => {
              if (err.name !== 'NotFoundError') throw err;
-             // cache miss — fetch normally and store in the background
-             fetch('hello.wasm')
-               .then(r => r.arrayBuffer())
-               .then(bytes => {
-                 WebAssembly.instantiate(bytes, imports)
-                   .then(({instance, module}) => onSuccess(instance, module));
-                 // fire-and-forget store
-                 navigator.crossOriginStorage
-                   .requestFileHandle(cosHash, { create: true, origins: '*' })
-                   .then(wh => wh.createWritable())
-                   .then(w => w.write(new Blob([bytes], {type:'application/wasm'}))
-                               .then(() => w.close()));
-               });
+             // cache miss — split the body: compile one branch while
+             // streaming the other into COS in the background
+             fetch('hello.wasm').then(r => {
+               const [compileStream, storeStream] = r.body.tee();
+               WebAssembly.instantiateStreaming(
+                 new Response(compileStream, wasmHeaders), imports)
+                 .then(({instance, module}) => onSuccess(instance, module));
+               // fire-and-forget store; pipeTo() closes the writable and COS
+               // verifies the hash on close
+               navigator.crossOriginStorage
+                 .requestFileHandle(cosHash, { create: true, origins: '*' })
+                 .then(wh => wh.createWritable())
+                 .then(w => storeStream.pipeTo(w))
+                 .catch(() => storeStream.cancel());
+             });
            });
          return;  // async; onSuccess called above
        }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -620,6 +620,19 @@ async function instantiateArrayBuffer(binaryFile, imports) {
   }
 }
 
+#if CROSS_ORIGIN_STORAGE
+// Stream Wasm bytes into the compiler. A fixed `application/wasm` type is
+// used rather than any server-supplied MIME type: on a cache hit the bytes
+// were hash-verified when written into COS, and on a cache miss the store
+// branch is already consuming the body, so the standard path's re-download
+// fallback for a bad MIME type is not available. A wrong file still fails
+// compilation and falls through to the standard path.
+function cosInstantiateStream(stream, imports) {
+  var response = new Response(stream, { headers: { 'Content-Type': 'application/wasm' } });
+  return WebAssembly.instantiateStreaming(response, imports);
+}
+#endif
+
 async function instantiateAsync(binary, binaryFile, imports) {
 #if !SINGLE_FILE
 #if CROSS_ORIGIN_STORAGE
@@ -631,16 +644,13 @@ async function instantiateAsync(binary, binaryFile, imports) {
     var cosHash = Module['wasmHash'];
     try {
       var cosHandle = await navigator.crossOriginStorage.requestFileHandle(cosHash);
-      // Cache hit — stream the stored Blob into the compiler rather than
-      // materializing it as an ArrayBuffer first, so compilation overlaps
-      // reading from disk. The bytes were hash-verified when they were
-      // written into COS, so a fixed `application/wasm` type is safe here.
+      // Cache hit. getFile() resolves to a lazy File reference; no bytes are
+      // read until the stream is consumed by the compiler below.
       var cosFile = await cosHandle.getFile();
 #if expectToReceiveOnModule('onCOSCacheHit')
       Module['onCOSCacheHit']?.(cosHash.value);
 #endif
-      var cosResponse = new Response(cosFile.stream(), { headers: { 'Content-Type': 'application/wasm' } });
-      return WebAssembly.instantiateStreaming(cosResponse, imports);
+      return cosInstantiateStream(cosFile.stream(), imports);
     } catch {
       // Any error (not found, not allowed, …) — fetch from the network and
       // attempt to store in COS for future page loads.
@@ -683,12 +693,7 @@ async function instantiateAsync(binary, binaryFile, imports) {
             storeStream.cancel().catch(() => {});
           }
         })();
-        // The server's MIME type is deliberately not forwarded: the standard
-        // path would fall back to a full re-download on a bad MIME type, but
-        // here the store branch is already consuming the body. A wrong file
-        // still fails compilation and falls through to the standard path.
-        var compileResponse = new Response(compileStream, { headers: { 'Content-Type': 'application/wasm' } });
-        return WebAssembly.instantiateStreaming(compileResponse, imports);
+        return cosInstantiateStream(compileStream, imports);
       } catch (fetchErr) {
         // Network fetch failed; fall through to the standard path below.
         err(`COS fallback fetch failed: ${fetchErr}`);

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -631,23 +631,34 @@ async function instantiateAsync(binary, binaryFile, imports) {
     var cosHash = Module['wasmHash'];
     try {
       var cosHandle = await navigator.crossOriginStorage.requestFileHandle(cosHash);
-      // Cache hit — read the Blob and instantiate from its ArrayBuffer.
+      // Cache hit — stream the stored Blob into the compiler rather than
+      // materializing it as an ArrayBuffer first, so compilation overlaps
+      // reading from disk. The bytes were hash-verified when they were
+      // written into COS, so a fixed `application/wasm` type is safe here.
       var cosFile = await cosHandle.getFile();
-      var cosBytes = await cosFile.arrayBuffer();
 #if expectToReceiveOnModule('onCOSCacheHit')
       Module['onCOSCacheHit']?.(cosHash.value);
 #endif
-      return WebAssembly.instantiate(cosBytes, imports);
+      var cosResponse = new Response(cosFile.stream(), { headers: { 'Content-Type': 'application/wasm' } });
+      return WebAssembly.instantiateStreaming(cosResponse, imports);
     } catch {
       // Any error (not found, not allowed, …) — fetch from the network and
       // attempt to store in COS for future page loads.
       try {
         var networkResponse = await fetch(binaryFile, {{{ makeModuleReceiveExpr('fetchSettings', "{ credentials: 'same-origin' }") }}});
-        var wasmBytes = await networkResponse.arrayBuffer();
+        if (!networkResponse.ok) {
+          throw new Error(`HTTP ${networkResponse.status}`);
+        }
 #if expectToReceiveOnModule('onCOSCacheMiss')
         Module['onCOSCacheMiss']?.(cosHash.value, binaryFile);
 #endif
+        // Split the body so that one branch feeds streaming compilation while
+        // the other is written into COS in the background. This keeps the
+        // download/compile overlap of the standard instantiateStreaming()
+        // path instead of waiting for the whole file to arrive first.
+        var [compileStream, storeStream] = networkResponse.body.tee();
         // Fire-and-forget store; never block instantiation on the write.
+        // pipeTo() closes the writable, and COS verifies the hash on close.
         (async () => {
           try {
             var writeHandle = await navigator.crossOriginStorage.requestFileHandle(
@@ -661,16 +672,23 @@ async function instantiateAsync(binary, binaryFile, imports) {
 #endif
             );
             var writable = await writeHandle.createWritable();
-            await writable.write(new Blob([wasmBytes], { type: 'application/wasm' }));
-            await writable.close();
+            await storeStream.pipeTo(writable);
 #if expectToReceiveOnModule('onCOSStore')
             Module['onCOSStore']?.(cosHash.value);
 #endif
           } catch (storeErr) {
             err(`COS store failed: ${storeErr}`);
+            // Release the tee branch so the body is not buffered indefinitely
+            // on behalf of a writer that will never consume it.
+            storeStream.cancel().catch(() => {});
           }
         })();
-        return WebAssembly.instantiate(wasmBytes, imports);
+        // The server's MIME type is deliberately not forwarded: the standard
+        // path would fall back to a full re-download on a bad MIME type, but
+        // here the store branch is already consuming the body. A wrong file
+        // still fails compilation and falls through to the standard path.
+        var compileResponse = new Response(compileStream, { headers: { 'Content-Type': 'application/wasm' } });
+        return WebAssembly.instantiateStreaming(compileResponse, imports);
       } catch (fetchErr) {
         // Network fetch failed; fall through to the standard path below.
         err(`COS fallback fetch failed: ${fetchErr}`);


### PR DESCRIPTION
Follow-up to #27066. The Cross-Origin Storage integration read the module into an `ArrayBuffer` on both the cache-hit and cache-miss paths and called `WebAssembly.instantiate()`, so enabling `-sCROSS_ORIGIN_STORAGE` lost the download/compile overlap of the standard `instantiateStreaming()` path. Every first-visit user hit the slower miss path. (Thanks to @reillyeon for spotting this in WICG/cross-origin-storage#74.)

**Cache hit:** `handle.getFile().stream()` is wrapped in a `Response` with an `application/wasm` content type and passed to `instantiateStreaming()`. The bytes were hash-verified when written into COS, so the fixed type is safe.

**Cache miss:** the fetch body is `tee()`'d. One branch goes to `instantiateStreaming()` immediately; the other is `pipeTo()`'d into the COS writable in the background (`pipeTo()` closes the writable, and COS verifies the hash on close). If the store fails before consuming, the tee branch is cancelled so the body is not buffered indefinitely.

The server's MIME type is deliberately not forwarded on the miss path: the standard path recovers from a bad MIME type by re-downloading, but here the store branch is already consuming the body. A wrong file still fails compilation and falls through to the standard path as before. A non-OK response now throws early rather than being handed to the compiler.

Docs, the custom `Module['instantiateWasm']` example, and the ChangeLog are updated to match. No test changes: the existing `test_cross_origin_storage_*` browser tests exercise both paths and the instrumentation callbacks fire at the same points.