### PR TITLE
[CI] Remove `--enable-experimental-web-platform-features` from chrome flags

### DIFF
--- a/test/browser_common.py
+++ b/test/browser_common.py
@@ -241,7 +241,7 @@ class ChromeConfig:
   default_flags = (
     # --no-sandbox because we are running as root and chrome requires
     # this flag for now: https://crbug.com/638180
-    '--no-first-run -start-maximized --no-sandbox --enable-unsafe-swiftshader --use-gl=swiftshader --enable-experimental-web-platform-features --enable-features=JavaScriptSourcePhaseImports',
+    '--no-first-run -start-maximized --no-sandbox --enable-unsafe-swiftshader --use-gl=swiftshader --enable-features=JavaScriptSourcePhaseImports',
     '--enable-experimental-webassembly-features',
     # The runners lack sound hardware so fallback to a dummy device (and
     # bypass the user gesture so audio tests work without interaction)


### PR DESCRIPTION
This flag was originally added in #16813 to test WasmFS OPFS support, which has shipped in stable Chrome since version 102.

In Chrome 154, `--enable-experimental-web-platform-features` enables `AudioWorklet.port` (https://crbug.com/446920095). However, Chrome cannot deserialize `WebAssembly.Module` over a `MessagePort` into `AudioWorkletGlobalScope` (https://crbug.com/40210558).

This causes Emscripten's feature check in `src/lib/libwebaudio.js` to skip the `em-bootstrap` AudioWorkletProcessor and attempt to transfer the Wasm module over `audioWorklet.port`, triggering a `messageerror` and breaking all audio worklet tests in Chrome 154.