### PR TITLE
Mark WASM_BINDGEN as an experimental setting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 6.0.9 (in development)
 ----------------------
+- The `WASM_BINDGEN` setting is now marked experimental, and enabling it
+  produces a compiler diagnostic warning, since the integration is still
+  evolving and subject to change.
 - The `-sCROSS_ORIGIN_STORAGE` cache-hit and cache-miss paths now use
   `WebAssembly.instantiateStreaming()` (via `Blob.stream()` and a `tee()`'d
   network body respectively), so enabling the flag no longer loses the

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,7 +22,7 @@ See docs/process.md for more on how version tagging works.
 ----------------------
 - The `WASM_BINDGEN` setting is now marked experimental, and enabling it
   produces a compiler diagnostic warning, since the integration is still
-  evolving and subject to change.
+  evolving and subject to change. (#27616)
 - The `-sCROSS_ORIGIN_STORAGE` cache-hit and cache-miss paths now use
   `WebAssembly.instantiateStreaming()` (via `Blob.stream()` and a `tee()`'d
   network body respectively), so enabling the flag no longer loses the

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -3373,6 +3373,8 @@ WASM_BINDGEN
 
 Run wasm-bindgen and integrate the rust-exported symbols into the rest of Emscripten's JS output.
 
+.. note:: This is an experimental setting
+
 Default value: 0
 
 .. _source_phase_imports:

--- a/src/settings.js
+++ b/src/settings.js
@@ -2238,6 +2238,7 @@ var SIGNATURE_CONVERSIONS = [];
 
 // Run wasm-bindgen and integrate the rust-exported symbols into the rest of Emscripten's JS output.
 // [link]
+// [experimental]
 var WASM_BINDGEN = 0;
 
 // Experimental support for wasm source phase imports.

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15398,7 +15398,7 @@ addToLibrary({
     ''')
 
     self.run_process(['cargo', 'install', 'wasm-bindgen-cli'])
-    self.do_runf('empty.c', '42', cflags=[lib, '-sWASM_BINDGEN', '--post-js=post.js', '-lexports.js'])
+    self.do_runf('empty.c', '42', cflags=[lib, '-sWASM_BINDGEN', '-Wno-experimental', '--post-js=post.js', '-lexports.js'])
 
   @requires_rust
   @requires_dev_dependency('typescript')
@@ -15416,7 +15416,7 @@ addToLibrary({
     lib = 'target/wasm32-unknown-emscripten/debug/libbindgen_integration.a'
     create_file('empty.c', '')
     self.run_process(['cargo', 'install', 'wasm-bindgen-cli'])
-    self.run_process([EMCC, 'empty.c', '--emit-tsd', 'test_multi.d.ts', '-sWASM_BINDGEN', '-o', 'test_multi.js'] + [lib] + self.get_cflags())
+    self.run_process([EMCC, 'empty.c', '--emit-tsd', 'test_multi.d.ts', '-sWASM_BINDGEN', '-Wno-experimental', '-o', 'test_multi.js'] + [lib] + self.get_cflags())
     actual = read_file('test_multi.d.ts')
     self.assertContained("multi_value_return(): [number, number, number];", actual)
 

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -166,6 +166,7 @@ EXPERIMENTAL_SETTINGS = {
     'SUPPORT_BIG_ENDIAN': '-sSUPPORT_BIG_ENDIAN is experimental, not all features are fully supported.',
     'WASM_ESM_INTEGRATION': '-sWASM_ESM_INTEGRATION is still experimental and not yet supported in browsers',
     'SHARED_WASMGC': '-sSHARED_WASMGC is experimental and subject to change',
+    'WASM_BINDGEN': '-sWASM_BINDGEN is experimental and subject to change',
 }
 
 # For renamed settings the format is:


### PR DESCRIPTION
This marks `-sWASM_BINDGEN` as an experimental setting, since the wasm-bindgen integration is still evolving and subject to change.

* Adds the `[experimental]` tag in `settings.js` and an `EXPERIMENTAL_SETTINGS` entry, so enabling it now emits the standard `-Wexperimental` diagnostic:

```
emcc: warning: -sWASM_BINDGEN is experimental and subject to change [-Wexperimental]
```

* Regenerates the settings reference docs and adds a ChangeLog entry.
