### PR TITLE
Compare LLVM_ROOT case-insensitively in the sanity check on Windows

### DIFF
--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -25,7 +25,7 @@ from common import (
   path_from_root,
   test_file,
 )
-from decorators import no_windows, parameterized, with_env_modify
+from decorators import no_windows, only_windows, parameterized, with_env_modify
 
 from tools import building, cache, ports, response_file, shared, utils
 from tools.config import EM_CONFIG
@@ -379,6 +379,23 @@ fi
     output = self.check_working(EMCC)
     self.assertNotContained(SANITY_MESSAGE, output)
     self.assertNotContained(SANITY_FAIL_MESSAGE, output)
+
+  @only_windows('only Windows aliases path case and separator style')
+  def test_llvm_root_path_spelling(self):
+    # The same LLVM can reach us spelled differently depending on how the
+    # compiler was invoked -- an IDE that lowercases the compiler path, a build
+    # system that hands over backslashes. Windows resolves all of those to one
+    # directory, so they must not count as a config change: doing so erases the
+    # whole cache, and the reinstalled sysroot headers then force a rebuild of
+    # every object in the user's project.
+    restore_and_set_up()
+    self.check_working(EMCC)
+
+    respelled = config.LLVM_ROOT.replace('/', '\\').upper()
+    self.assertNotEqual(respelled, config.LLVM_ROOT)
+    with env_modify({'EM_LLVM_ROOT': respelled}):
+      output = self.check_working(EMCC)
+    self.assertNotContained(SANITY_MESSAGE, output)
 
   def test_em_config_env_var(self):
     # emcc should be configurable directly from EM_CONFIG without any config file

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -339,7 +339,12 @@ def check_node():
 
 
 def generate_sanity():
-  return f'{utils.EMSCRIPTEN_VERSION}|{config.LLVM_ROOT}\n'
+  # Spell LLVM_ROOT canonically. It is derived from the path the compiler was
+  # invoked through, so on Windows the same directory reaches us as either
+  # "C:/llvm/bin" or "c:\llvm\bin" depending on the caller. Comparing those
+  # verbatim reports a config change that never happened and erases the cache.
+  # normcase() is a no-op on POSIX, where the two spellings really are distinct.
+  return f'{utils.EMSCRIPTEN_VERSION}|{os.path.normcase(config.LLVM_ROOT)}\n'
 
 
 @memoize


### PR DESCRIPTION
### Problem

`generate_sanity()` embeds `config.LLVM_ROOT` verbatim, and `check_sanity()` compares that string against `cache/sanity.txt`, calling `cache.erase()` on any difference:

```python
def generate_sanity():
  return f'{utils.EMSCRIPTEN_VERSION}|{config.LLVM_ROOT}\n'
```

`LLVM_ROOT` is derived from the path the compiler was invoked through, so on Windows the very same directory can arrive as `C:/llvm/bin` from one caller and `c:\llvm\bin` from another. Windows resolves both to one directory, but they produce different sanity strings — so two callers that spell it differently erase each other's cache on every alternation.

### How it shows up in practice

This needs nothing unusual to trigger. VSCode's CMake Tools normalizes the compiler path with `util.platformNormalizePath` (`normCase: 'platform'`, i.e. lowercase on win32) before handing it to the C/C++ extension as `compilerPath`, and the extension then *executes* it to query built-in defines and includes. CMake and ninja invoke the same `em++` in its canonical case. The two alternate, so the cache is erased on each window load.

Each wipe reinstalls the sysroot headers. Every object file depends on those headers, so the build system then considers the entire project out of date. On a large codebase that is a full rebuild — minutes of work — every time the editor restarts, with nothing in the source tree, the CMake cache, or the build directory having changed.

Straight from a CMake configure log, with the two strings side by side:

```
shared:INFO: old sanity: 6.0.3|c:/users/user/.../upstream/bin
shared:INFO: new sanity: 6.0.3|C:/Users/User/.../upstream/bin
shared:INFO: (Emscripten: config changed, clearing cache)
shared:INFO: (Emscripten: Running sanity checks)
cache:INFO: generating system headers: sysroot_install.stamp...
```

Minimal reproduction on Windows — compile anything twice, varying only the case of the path you invoke the compiler through, and watch the cache get erased both times:

```
C:\path\to\emsdk\upstream\emscripten\emcc.exe -c hello.c -o hello.o
c:\path\to\emsdk\upstream\emscripten\emcc.exe -c hello.c -o hello.o
```

### Fix

Run `LLVM_ROOT` through `os.path.normcase()` when building the sanity string. On Windows that folds both case and separator style (`ntpath.normcase` lowercases and maps `/` to `\`), so every spelling of one directory yields one sanity string. On POSIX it is the identity, where the spellings genuinely are distinct paths.

### Notes

- This costs one cache clear on the release that includes it, as any change to the sanity string does.
- I considered normalizing once in `config.normalize_config_settings()` instead. I kept it at the point of comparison so that nothing else in the toolchain observes a rewritten `LLVM_ROOT` — happy to move it if you would rather have the config normalized at load.
- Related: #15053 asks for the sanity file to stop being sensitive to *where* the toolchain lives. This is the narrower case: same location, different spelling.

### Testing

Added `test_llvm_root_path_spelling` to `test/test_sanity.py`. It establishes the sanity file, then re-runs `emcc` with `EM_LLVM_ROOT` respelled (uppercased, backslash-separated) and asserts that no sanity re-check occurs. It fails before this change and passes after. Marked `@only_windows`, since path case and separator style only alias there.

One caveat in the interest of full disclosure: I was not able to run the suite locally — I do not have an LLVM 24 build to hand — so I am relying on CI for the Windows run. I verified the underlying property directly (`ntpath.normcase` maps both spellings to one string; `posixpath.normcase` is the identity).
