### PR TITLE
Normalize case for key config pathnames on Windows

### DIFF
--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -25,7 +25,7 @@ from common import (
   path_from_root,
   test_file,
 )
-from decorators import no_windows, parameterized, with_env_modify
+from decorators import no_windows, only_windows, parameterized, with_env_modify
 
 from tools import building, cache, ports, response_file, shared, utils
 from tools.config import EM_CONFIG
@@ -172,8 +172,8 @@ class sanity(RunnerCore):
   def check_working(self, command, expected=None, env=None):
     if type(command) is not list:
       command = [command]
-    if command == [EMCC]:
-      command = [EMCC, '--version']
+    if len(command) == 1 and os.path.normcase(command[0]) == os.path.normcase(EMCC):
+      command = [command[0], '--version']
     if expected is None:
       expected = 'emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld)'
 
@@ -379,6 +379,29 @@ fi
     output = self.check_working(EMCC)
     self.assertNotContained(SANITY_MESSAGE, output)
     self.assertNotContained(SANITY_FAIL_MESSAGE, output)
+
+  @only_windows('test windows-specific case insensitivity')
+  def test_windows_path_casing(self):
+    # On windows, that case uses to run the compiler can have knock-on
+    # effects.  This test verifies that C:/PATH/TO/emcc and C:/path/to/emcc
+    # at treated the same, in particular from POV of the sanity checks.
+    restore_and_set_up()
+    self.check_working(EMCC)
+
+    # Calling the compiler via differently-cased paths should not trigger
+    # a sanity check.
+    output = self.check_working(EMCC.lower())
+    self.assertNotContained(SANITY_MESSAGE, output)
+    output = self.check_working(EMCC.upper())
+    self.assertNotContained(SANITY_MESSAGE, output)
+
+    # Calling with a respelled EM_LLVM_ROOT environment override should
+    # also not trigger a sanity check.
+    new_llvm_root = config.LLVM_ROOT.upper()
+    self.assertNotEqual(new_llvm_root, config.LLVM_ROOT)
+    with env_modify({'EM_LLVM_ROOT': new_llvm_root}):
+      output = self.check_working(EMCC)
+    self.assertNotContained(SANITY_MESSAGE, output)
 
   def test_em_config_env_var(self):
     # emcc should be configurable directly from EM_CONFIG without any config file

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -382,21 +382,21 @@ fi
 
   @only_windows('test windows-specific case insensitivity')
   def test_windows_path_casing(self):
-    # On windows, that case uses to run the compiler can have knock-on
+    # On Windows, the case used to run the compiler can have knock-on
     # effects.  This test verifies that C:/PATH/TO/emcc and C:/path/to/emcc
-    # at treated the same, in particular from POV of the sanity checks.
+    # are treated the same, in particular from the POV of the sanity checks.
     restore_and_set_up()
     self.check_working(EMCC)
 
     # Calling the compiler via differently-cased paths should not trigger
     # a sanity check.
-    output = self.check_working(EMCC.lower())
-    self.assertNotContained(SANITY_MESSAGE, output)
-    output = self.check_working(EMCC.upper())
+    new_emcc = EMCC.upper()
+    self.assertNotEqual(new_emcc, EMCC)
+    output = self.check_working(new_emcc)
     self.assertNotContained(SANITY_MESSAGE, output)
 
-    # Calling with a respelled EM_LLVM_ROOT environment override should
-    # also not trigger a sanity check.
+    # Calling with a differently-cased EM_LLVM_ROOT should also not trigger a
+    # sanity check.
     new_llvm_root = config.LLVM_ROOT.upper()
     self.assertNotEqual(new_llvm_root, config.LLVM_ROOT)
     with env_modify({'EM_LLVM_ROOT': new_llvm_root}):

--- a/tools/config.py
+++ b/tools/config.py
@@ -237,7 +237,7 @@ def find_config_file():
   # We could remove this special case if emsdk were to write its embedded config
   # file into the emscripten directory itself.
   # See: https://github.com/emscripten-core/emsdk/pull/367
-  emsdk_root = os.path.dirname(os.path.dirname(path_from_root()))
+  emsdk_root = os.path.dirname(os.path.dirname(__rootpath__))
   emsdk_embedded_config = os.path.join(emsdk_root, '.emscripten')
 
   if os.path.isfile(emsdk_embedded_config):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -339,7 +339,8 @@ def check_node():
 
 
 def generate_sanity():
-  return f'{utils.EMSCRIPTEN_VERSION}|{config.LLVM_ROOT}\n'
+  llvm_root = os.path.normcase(config.LLVM_ROOT)
+  return f'{utils.EMSCRIPTEN_VERSION}|{llvm_root}\n'
 
 
 @memoize

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -21,7 +21,12 @@ from pathlib import Path
 
 from . import diagnostics
 
-__rootpath__ = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+# On Windows, the command line used (argv[0]) can affect the value of `__file__`
+# here.  e.g. `python.exe c:/path/to/emcc.py` and `python.exe C:/PATH/TO/emcc.py`
+# yield different results.  Use `normcase` so we get consistent values whatever
+# case was used to run the compiler.
+normalized_file = os.path.abspath(os.path.normcase(__file__))
+__rootpath__ = os.path.dirname(os.path.dirname(normalized_file))
 WINDOWS = sys.platform.startswith('win')
 MACOS = sys.platform == 'darwin'
 LINUX = sys.platform.startswith('linux')


### PR DESCRIPTION
On Windows, file systems are case-insensitive. When tools like VS Code
CMake Tools invoke the compiler through an all-lowercased path (e.g. via
its `platformNormalizePath` helper), the caller-specified casing affects
the value of `__file__` in Python which then propagates all the way to
`LLVM_ROOT` and the `sanity.txt` file (at least in the emsdk case):
`__file__` -> `__rootpath__` -> `EM_CONFIG` -> `CFGDIR` -> `LLVM_ROOT`
-> `sanity.txt`.

Address this in two places:
1. In `tools/utils.py`, normalize `__file__` using `normcase` when
   initializing `__rootpath__`. This prevents caller-specified casing
   from polluting paths derived from the script location (default
   `EM_CONFIG`, `$CFGDIR`, and default `CACHE`).
2. In `tools/shared.py`, normalize `config.LLVM_ROOT` using `normcase`
   in `generate_sanity()`. This ensures that even if `LLVM_ROOT` was
   configured explicitly (e.g. via `EM_LLVM_ROOT` or an absolute path
   in `.emscripten`), the string written to `sanity.txt` is always
   canonical on Windows.

The proximate cause of the issue was that the VS Code CMake Tools
extension explicitly lowercases compiler paths on Windows:
https://github.com/microsoft/vscode-cmake-tools/blob/09dd68b54de06469bd1b81d84d6b8666aa2dce1d/src/util.ts#L113-L115
By forcing the command line to all-lowercase, the above chain of events
kicked in whenever the IDE queried compiler settings.

See: #27624