### PR TITLE
[CI] Run sanity.test_windows_path_casing in Windows CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1255,6 +1255,10 @@ jobs:
           command: "test/runner sockets_node.test_nodejs_sockets_echo*"
       - upload-test-results
       - run:
+          name: "sanity tests"
+          command: test/runner sanity.test_windows_path_casing
+      - upload-test-results
+      - run:
           name: "check clean"
           command: |
             git checkout tools/pylauncher


### PR DESCRIPTION
Sanity tests previously ran on Windows via `--crossplatform-only` after #22492, but were removed in #26365 when all tests were combined into a single parallel test suite (which made mixing parallel and non-parallel modules an error).

Run `sanity.test_windows_path_casing` as a dedicated step in `test-windows` so the Windows path casing regression test from #27626 is exercised in CI.
