### PR TITLE
Fix fstat on stdio streams under NODERAWFS

### DIFF
--- a/src/lib/libnoderawfs.js
+++ b/src/lib/libnoderawfs.js
@@ -65,10 +65,15 @@ addToLibrary({
       return { path, node: { id: st.ino, mode, node_ops: NODERAWFS, path }};
     },
     createStandardStreams() {
-      FS.createStream({ nfd: 0, position: 0, path: '/dev/stdin', flags: 0 }, 0);
-      var paths = [,'/dev/stdout', '/dev/stderr'];
-      for (var i = 1; i < 3; i++) {
-        FS.createStream({ nfd: i, position: 0, path: paths[i], flags: {{{ cDefs.O_TRUNC | cDefs.O_CREAT | cDefs.O_WRONLY }}} }, i);
+      var paths = ['/dev/stdin', '/dev/stdout', '/dev/stderr'];
+      for (var i = 0; i < 3; i++) {
+        // Like open() below, give the stream a node carrying the identity of
+        // whatever the inherited descriptor refers to (tty, pipe, file, ...):
+        // every stream has a node.
+        var st = fs.fstatSync(i);
+        var node = { id: st.ino, mode: st.mode, node_ops: NODERAWFS, path: paths[i] };
+        var flags = i ? {{{ cDefs.O_TRUNC | cDefs.O_CREAT | cDefs.O_WRONLY }}} : 0;
+        FS.createStream({ nfd: i, position: 0, path: paths[i], flags, node }, i);
       }
     },
     // generic function for all node creation

--- a/test/fs/test_fstat_stdio.c
+++ b/test/fs/test_fstat_stdio.c
@@ -7,7 +7,9 @@ int main(void) {
     struct stat st;
     int ret = fstat(fd, &st);
     assert(ret == 0);
-    assert(st.st_mode & S_IFMT);
+    // A standard stream is a tty, or a pipe or regular file when redirected
+    // (as under NODERAWFS, where it reflects the real inherited descriptor).
+    assert(S_ISCHR(st.st_mode) || S_ISFIFO(st.st_mode) || S_ISREG(st.st_mode));
   }
   printf("done\n");
   return 0;

--- a/test/fs/test_fstat_stdio.c
+++ b/test/fs/test_fstat_stdio.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+int main(void) {
+  for (int fd = 0; fd < 3; fd++) {
+    struct stat st;
+    int ret = fstat(fd, &st);
+    assert(ret == 0);
+    assert(st.st_mode & S_IFMT);
+  }
+  printf("done\n");
+  return 0;
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -6119,6 +6119,11 @@ Module.onRuntimeInitialized = () => {
   def test_fs_stat_unnamed_file_descriptor(self):
     self.do_runf('fs/test_stat_unnamed_file_descriptor.c', 'done\n')
 
+  @crossplatform
+  @with_all_fs
+  def test_fs_fstat_stdio(self):
+    self.do_runf('fs/test_fstat_stdio.c', 'done\n')
+
   @requires_node
   @crossplatform
   @with_all_fs


### PR DESCRIPTION
This fixes a crash in `fstat` on the standard streams under `-sNODERAWFS`, resolving #27628.

The getattr dispatch added in #27305 for virtual streams (pipes, sockets) dereferences `stream.node`, but the standard streams created by NODERAWFS carried no node at all — unlike streams from `open()`, which since #23364 carry a synthetic node with the identity of the underlying file. Rather than special-casing the missing node, this gives the standard streams the same synthetic node, built from `fstat` of the inherited descriptor, restoring the invariant that every stream has a node:

* `createStandardStreams` now constructs each stdio stream with a node carrying the id and mode of whatever the descriptor refers to (tty, pipe, file).
* `fstat` on stdio falls through to `fs.fstatSync` on the raw descriptor as before.

Adds `test_fs_fstat_stdio` covering `fstat` on fds 0-2 across all filesystem backends.

_Made with AI assistance under my review_