### PR TITLE
[test] Mark test_cmake_install as @crossplatform. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -1125,6 +1125,7 @@ f.close()
     self.run_process([EMCC, test_file('hello_world.c'), '-sUSE_ZLIB'])
     self.run_process([EMCMAKE, 'cmake', test_file('cmake/find_stuff')])
 
+  @crossplatform
   def test_cmake_install(self):
     # Build and install a library `foo`
     os.mkdir('build1')


### PR DESCRIPTION
This test is failing on emscripten-release on windows only.