### PR TITLE
Revert normalize case of `__rootpath__` on Windows

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -21,12 +21,7 @@ from pathlib import Path
 
 from . import diagnostics
 
-# On Windows, the command line used (argv[0]) can affect the value of `__file__`
-# here.  e.g. `python.exe c:/path/to/emcc.py` and `python.exe C:/PATH/TO/emcc.py`
-# yield different results.  Use `normcase` so we get consistent values whatever
-# case was used to run the compiler.
-normalized_file = os.path.abspath(os.path.normcase(__file__))
-__rootpath__ = os.path.dirname(os.path.dirname(normalized_file))
+__rootpath__ = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 WINDOWS = sys.platform.startswith('win')
 MACOS = sys.platform == 'darwin'
 LINUX = sys.platform.startswith('linux')


### PR DESCRIPTION
In #27626, `__rootpath__` was changed to use
`os.path.normcase(__file__)` to prevent caller-specified casing from propagating to `config.LLVM_ROOT` and `sanity.txt`.

However, on Windows `normcase` unconditionally converts the entire path including the drive letter to lowercase (`c:\...`). This lowercases all paths derived from `path_from_root`, including default `config.CACHE` and `EMSCRIPTEN_SYSROOT`.

When CMake runs on Windows, imported targets and compiler autodetection preserve uppercase drive letters (`C:\...`). Because CMake's implicit include directory checks are case-sensitive string comparisons, the mismatch between `c:\...` and `C:\...` caused CMake to treat the sysroot include directory as an explicit non-system include, injecting `-isystem` and disrupting libc++ header search order in `test_cmake_install`. It also caused assertion failures in `test_cmake_compile_commands_noforce`.

The normalization of `config.LLVM_ROOT` in `generate_sanity()` in `tools/shared.py` (also added in #27626) is already sufficient to ensure that `sanity.txt` remains consistent regardless of the casing used to invoke `emcc`. Normalizing `__rootpath__` is unnecessary and harmful.

See: #27626