### PR TITLE
[test] Add test_sdl3_text.c based on test_sdl2_text.c. NFC

### DIFF
--- a/test/browser/fake_events.js
+++ b/test/browser/fake_events.js
@@ -2,7 +2,17 @@
  * Helper function used in browser tests to simulate HTML5 events
  */
 
-function simulateKeyEvent(eventType, keyCode, code, key, target) {
+function deriveKey(code, keyCode) {
+  if (code && !code.startsWith('Key') && !code.startsWith('Digit')) {
+    return code;
+  }
+  if (keyCode) {
+    return String.fromCharCode(keyCode);
+  }
+}
+
+function simulateKeyEvent(eventType, keyCode, code = undefined, key = undefined, target = undefined) {
+  if (!key) key = deriveKey(code, keyCode);
   var props = { keyCode, charCode: keyCode, view: window, bubbles: true, cancelable: true };
   if (code) props['code'] = code;
   if (key) props['key'] = key;
@@ -20,13 +30,13 @@ function simulateKeyDown(keyCode, code = undefined, key = undefined, target = un
   }
 }
 
-function simulateKeyUp(keyCode, code = undefined, target = undefined) {
-  simulateKeyEvent('keyup', keyCode, code, target);
+function simulateKeyUp(keyCode, code = undefined, key = undefined, target = undefined) {
+  simulateKeyEvent('keyup', keyCode, code, key, target);
 }
 
-function simulateKeyDownUp(keyCode, code = undefined, target = undefined) {
-  simulateKeyDown(keyCode, code, target);
-  simulateKeyUp(keyCode, code, target);
+function simulateKeyDownUp(keyCode, code = undefined, key = undefined, target = undefined) {
+  simulateKeyDown(keyCode, code, key, target);
+  simulateKeyUp(keyCode, code, key, target);
 }
 
 function simulateMouseEvent(eventType, x, y, button, absolute) {

--- a/test/browser/fake_events.js
+++ b/test/browser/fake_events.js
@@ -2,13 +2,14 @@
  * Helper function used in browser tests to simulate HTML5 events
  */
 
+// Derive `event.key` when not explicitly provided. For named keys (e.g.
+// 'ArrowUp', 'Enter'), `key` matches `code`. For letter keys ('KeyA'..'KeyZ')
+// or when `code` is omitted, derive `key` from `keyCode`.
 function deriveKey(code, keyCode) {
-  if (code && !code.startsWith('Key') && !code.startsWith('Digit')) {
+  if (code && !code.startsWith('Key')) {
     return code;
   }
-  if (keyCode) {
-    return String.fromCharCode(keyCode);
-  }
+  return String.fromCharCode(keyCode);
 }
 
 function simulateKeyEvent(eventType, keyCode, code = undefined, key = undefined, target = undefined) {

--- a/test/browser/test_sdl2_text.c
+++ b/test/browser/test_sdl2_text.c
@@ -11,9 +11,9 @@
 #include <assert.h>
 #include <emscripten.h>
 
-int result = 0;
+static int result = 0;
 
-EMSCRIPTEN_KEEPALIVE void one() {
+static void process_events() {
   SDL_Event event;
   while (SDL_PollEvent(&event)) {
     switch (event.type) {
@@ -40,7 +40,7 @@ int main() {
   emscripten_run_script("simulateKeyDown('a'.charCodeAt(0))");
   emscripten_run_script("simulateKeyDown('A'.charCodeAt(0))");
 
-  one();
+  process_events();
 
-  return 0;
+  return 99;
 }

--- a/test/browser/test_sdl3_text.c
+++ b/test/browser/test_sdl3_text.c
@@ -11,9 +11,9 @@
 #include <assert.h>
 #include <emscripten.h>
 
-int result = 0;
+static int result = 0;
 
-EMSCRIPTEN_KEEPALIVE void one() {
+static void process_events() {
   SDL_Event event;
   while (SDL_PollEvent(&event)) {
     switch (event.type) {
@@ -40,7 +40,7 @@ int main() {
   emscripten_run_script("simulateKeyDown('a'.charCodeAt(0))");
   emscripten_run_script("simulateKeyDown('A'.charCodeAt(0))");
 
-  one();
+  process_events();
 
-  return 0;
+  return 99;
 }

--- a/test/browser/test_sdl3_text.c
+++ b/test/browser/test_sdl3_text.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <SDL3/SDL.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <emscripten.h>
+
+int result = 0;
+
+EMSCRIPTEN_KEEPALIVE void one() {
+  SDL_Event event;
+  while (SDL_PollEvent(&event)) {
+    switch (event.type) {
+      case SDL_EVENT_TEXT_EDITING: assert(0); break;
+      case SDL_EVENT_TEXT_INPUT:
+        printf("Received %s\n", event.text.text);
+        if (!strcmp("a", event.text.text)) {
+          result = 1;
+        } else if (!strcmp("A", event.text.text)) {
+          assert(result);
+          emscripten_force_exit(0);
+        }
+        break;
+    }
+  }
+}
+
+int main() {
+  SDL_Init(SDL_INIT_VIDEO);
+  SDL_Window *window = SDL_CreateWindow("window", 600, 450, 0);
+  assert(window);
+  SDL_StartTextInput(window);
+
+  emscripten_run_script("simulateKeyDown('a'.charCodeAt(0))");
+  emscripten_run_script("simulateKeyDown('A'.charCodeAt(0))");
+
+  one();
+
+  return 0;
+}

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -3174,6 +3174,20 @@ Module["preRun"] = () => {
     self.cflags.append('-Wno-experimental')
     self.btest_exit('test_sdl3_canvas_write.c', cflags=['-sUSE_SDL=3'])
 
+  def test_sdl3_text(self):
+    create_file('pre.js', '''
+      Module.postRun = () => {
+        function doOne() {
+          Module._one();
+          setTimeout(doOne, 1000/60);
+        }
+        setTimeout(doOne, 1000/60);
+      }
+    ''')
+
+    self.cflags.append('-Wno-experimental')
+    self.btest_exit('test_sdl3_text.c', cflags=['--pre-js', 'pre.js', '--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=3'])
+
   @requires_graphics_hardware
   @no_wasm64('cocos2d ports does not compile with wasm64')
   def test_cocos2d_hello(self):

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2905,17 +2905,7 @@ Module["preRun"] = () => {
     self.btest_exit('test_sdl2_key.c', 37182145, cflags=['-sUSE_SDL=2', '--pre-js', test_file('browser/fake_events.js')])
 
   def test_sdl2_text(self):
-    create_file('pre.js', '''
-      Module.postRun = () => {
-        function doOne() {
-          Module._one();
-          setTimeout(doOne, 1000/60);
-        }
-        setTimeout(doOne, 1000/60);
-      }
-    ''')
-
-    self.btest_exit('test_sdl2_text.c', cflags=['--pre-js', 'pre.js', '--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=2'])
+    self.btest_exit('test_sdl2_text.c', cflags=['--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=2'])
 
   @requires_graphics_hardware
   def test_sdl2_mouse(self):
@@ -3175,18 +3165,7 @@ Module["preRun"] = () => {
     self.btest_exit('test_sdl3_canvas_write.c', cflags=['-sUSE_SDL=3'])
 
   def test_sdl3_text(self):
-    create_file('pre.js', '''
-      Module.postRun = () => {
-        function doOne() {
-          Module._one();
-          setTimeout(doOne, 1000/60);
-        }
-        setTimeout(doOne, 1000/60);
-      }
-    ''')
-
-    self.cflags.append('-Wno-experimental')
-    self.btest_exit('test_sdl3_text.c', cflags=['--pre-js', 'pre.js', '--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=3'])
+    self.btest_exit('test_sdl3_text.c', cflags=['--pre-js', test_file('browser/fake_events.js'), '-sUSE_SDL=3', '-Wno-experimental'])
 
   @requires_graphics_hardware
   @no_wasm64('cocos2d ports does not compile with wasm64')


### PR DESCRIPTION
Update `fake_events.js` to derive `event.key` when not explicitly provided.

This is needed for SDL3, where text input handling in upstream SDL (and in SDL2 with commit e64034952) has moved away from the deprecated `keyEvent->charCode` and now requires `keyEvent->key`.

Existing tests like `test_sdl3_text.c` and `test_sdl2_text.c` simulate text input using `simulateKeyDown('a'.charCodeAt(0))`, passing only the key code. Without deriving `key`, `event.key` defaults to an empty string, so `SDL_utf8strlen(keyEvent->key) == 1` fails and no `SDL_EVENT_TEXT_INPUT` (or `SDL_TEXTINPUT` in SDL2) events are emitted.