### PR TITLE
Fix WasmFS OPFS backend under JSPI and pthreads

### DIFF
--- a/src/lib/libwasmfs_opfs.js
+++ b/src/lib/libwasmfs_opfs.js
@@ -69,7 +69,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_init_root_directory__deps: ['$wasmfsOPFSDirectoryHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_init_root_directory__async: 'auto',
+  _wasmfs_opfs_init_root_directory__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_init_root_directory: async (ctx) => {
     // allocated.length starts off as 1 since 0 is a reserved handle
     if (wasmfsOPFSDirectoryHandles.allocated.length == 1) {
@@ -136,7 +136,7 @@ addToLibrary({
 
   _wasmfs_opfs_get_child__deps: ['$wasmfsOPFSGetOrCreateFile',
                                  '$wasmfsOPFSGetOrCreateDir', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_get_child__async: 'auto',
+  _wasmfs_opfs_get_child__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_get_child: async (ctx, parent, namePtr, childTypePtr, childIDPtr) => {
     let name = UTF8ToString(namePtr);
     let childType = 1;
@@ -156,7 +156,7 @@ addToLibrary({
     '$stackRestore',
     '_wasmfs_opfs_record_entry',
   ],
-  _wasmfs_opfs_get_entries__async: 'auto',
+  _wasmfs_opfs_get_entries__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_get_entries: async (ctx, dirID, entriesPtr, errPtr) => {
     let dirHandle = wasmfsOPFSDirectoryHandles.get(dirID);
 
@@ -181,7 +181,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_insert_file__deps: ['$wasmfsOPFSGetOrCreateFile', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_insert_file__async: 'auto',
+  _wasmfs_opfs_insert_file__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_insert_file: async (ctx, parent, namePtr, childIDPtr) => {
     let name = UTF8ToString(namePtr);
     let childID = await wasmfsOPFSGetOrCreateFile(parent, name, true);
@@ -190,7 +190,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_insert_directory__deps: ['$wasmfsOPFSGetOrCreateDir', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_insert_directory__async: 'auto',
+  _wasmfs_opfs_insert_directory__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_insert_directory: async (ctx, parent, namePtr, childIDPtr) => {
     let name = UTF8ToString(namePtr);
     let childID = await wasmfsOPFSGetOrCreateDir(parent, name, true);
@@ -201,7 +201,7 @@ addToLibrary({
   _wasmfs_opfs_move_file__deps: ['$wasmfsOPFSFileHandles',
                                  '$wasmfsOPFSDirectoryHandles',
                                  '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_move_file__async: 'auto',
+  _wasmfs_opfs_move_file__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_move_file: async (ctx, fileID, newParentID, namePtr, errPtr) => {
     let name = UTF8ToString(namePtr);
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
@@ -216,7 +216,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_remove_child__deps: ['$wasmfsOPFSDirectoryHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_remove_child__async: 'auto',
+  _wasmfs_opfs_remove_child__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_remove_child: async (ctx, dirID, namePtr, errPtr) => {
     let name = UTF8ToString(namePtr);
     let dirHandle = wasmfsOPFSDirectoryHandles.get(dirID);
@@ -245,7 +245,7 @@ addToLibrary({
                                    '$wasmfsOPFSCreateAsyncAccessHandle'
 #endif
                                   ],
-  _wasmfs_opfs_open_access__async: 'auto',
+  _wasmfs_opfs_open_access__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_open_access: async (ctx, fileID, accessIDPtr) => {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     let accessID;
@@ -285,7 +285,7 @@ addToLibrary({
 
   _wasmfs_opfs_open_blob__deps: ['$wasmfsOPFSFileHandles',
                                  '$wasmfsOPFSBlobs', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_open_blob__async: 'auto',
+  _wasmfs_opfs_open_blob__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_open_blob: async (ctx, fileID, blobIDPtr) => {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     let blobID;
@@ -307,7 +307,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_close_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_close_access__async: 'auto',
+  _wasmfs_opfs_close_access__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_close_access: async (ctx, accessID, errPtr) => {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     try {
@@ -327,7 +327,7 @@ addToLibrary({
 
   _wasmfs_opfs_read_access__i53abi: true,
   _wasmfs_opfs_read_access__deps: ['$wasmfsOPFSAccessHandles'],
-  _wasmfs_opfs_read_access__async: 'auto',
+  _wasmfs_opfs_read_access__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_read_access: {{{ asyncIf(!PTHREADS) }}}(accessID, bufPtr, len, pos) => {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     let data = HEAPU8.subarray(bufPtr, bufPtr + len);
@@ -346,7 +346,7 @@ addToLibrary({
 
   _wasmfs_opfs_read_blob__i53abi: true,
   _wasmfs_opfs_read_blob__deps: ['$wasmfsOPFSBlobs', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_read_blob__async: 'auto',
+  _wasmfs_opfs_read_blob__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_read_blob: async (ctx, blobID, bufPtr, len, pos, nreadPtr) => {
     let blob = wasmfsOPFSBlobs.get(blobID);
     let slice = blob.slice(pos, pos + len);
@@ -377,7 +377,7 @@ addToLibrary({
 
   _wasmfs_opfs_write_access__i53abi: true,
   _wasmfs_opfs_write_access__deps: ['$wasmfsOPFSAccessHandles'],
-  _wasmfs_opfs_write_access__async: 'auto',
+  _wasmfs_opfs_write_access__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_write_access: {{{ asyncIf(!PTHREADS) }}}(accessID, bufPtr, len, pos) => {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     let data = HEAPU8.subarray(bufPtr, bufPtr + len);
@@ -395,7 +395,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_get_size_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_get_size_access__async: 'auto',
+  _wasmfs_opfs_get_size_access__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_get_size_access: async (ctx, accessID, sizePtr) => {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     let size;
@@ -416,7 +416,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_get_size_file__deps: ['$wasmfsOPFSFileHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_get_size_file__async: 'auto',
+  _wasmfs_opfs_get_size_file__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_get_size_file: async (ctx, fileID, sizePtr) => {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     let size;
@@ -431,7 +431,7 @@ addToLibrary({
 
   _wasmfs_opfs_set_size_access__i53abi: true,
   _wasmfs_opfs_set_size_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_set_size_access__async: 'auto',
+  _wasmfs_opfs_set_size_access__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_set_size_access: async (ctx, accessID, size, errPtr) => {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     try {
@@ -445,7 +445,7 @@ addToLibrary({
 
   _wasmfs_opfs_set_size_file__i53abi: true,
   _wasmfs_opfs_set_size_file__deps: ['$wasmfsOPFSFileHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_set_size_file__async: 'auto',
+  _wasmfs_opfs_set_size_file__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_set_size_file: async (ctx, fileID, size, errPtr) => {
     let fileHandle = wasmfsOPFSFileHandles.get(fileID);
     try {
@@ -460,7 +460,7 @@ addToLibrary({
   },
 
   _wasmfs_opfs_flush_access__deps: ['$wasmfsOPFSAccessHandles', '$wasmfsOPFSProxyFinish'],
-  _wasmfs_opfs_flush_access__async: 'auto',
+  _wasmfs_opfs_flush_access__async: {{{ !PTHREADS ? "'auto'" : false }}},
   _wasmfs_opfs_flush_access: async (ctx, accessID, errPtr) => {
     let accessHandle = wasmfsOPFSAccessHandles.get(accessID);
     try {

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5291,6 +5291,7 @@ Module["preRun"] = () => {
   @parameterized({
     '': (['-pthread', '-sPROXY_TO_PTHREAD'],),
     'jspi': (['-sJSPI'],),
+    'jspi_pthread': (['-pthread', '-sPROXY_TO_PTHREAD', '-sJSPI'],),
     'asyncify': (['-sASYNCIFY=1'],),
   })
   @no_safari('TODO: Fails with abort:Assertion failed: err == 0') # Fails in Safari 17.6 (17618.3.11.11.7, 17618), Safari 26.0.1 (21622.1.22.11.15)


### PR DESCRIPTION
When pthreads are enabled, WasmFS OPFS operations run on a dedicated ProxyWorker pthread and notify callers without suspending WebAssembly. Marking OPFS functions with `__async: 'auto'` unconditionally caused them to be treated as suspending imports under JSPI, leading to a SuspendError when called on the proxy worker.

Only mark OPFS functions as async when pthreads are disabled.

Fixes #27620.