### PR TITLE
Remove experimental warning from SDL3 port

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 6.0.10 (in development)
 ----------------------
+- The SDL3 port is no longer considered experimental, and the compiler
+  diagnostic warning has been removed. (#27646)
 
 6.0.9 - 09/01/26
 ----------------

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -2175,9 +2175,10 @@ USE_SDL
 Specify the SDL version that is being linked against.
 1, the default, is 1.3, which is implemented in JS
 2 is a port of the SDL C code on emscripten-ports
+3 is a port of SDL3 on emscripten-ports
 When AUTO_JS_LIBRARIES is set to 0 this defaults to 0 and SDL
 is not linked in.
-Alternate syntax for using the port: --use-port=sdl2
+Alternate syntax for using the port: --use-port=sdl3
 
 .. note:: Applicable during both linking and compilation
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1512,9 +1512,10 @@ var EMIT_EMSCRIPTEN_LICENSE = false;
 // Specify the SDL version that is being linked against.
 // 1, the default, is 1.3, which is implemented in JS
 // 2 is a port of the SDL C code on emscripten-ports
+// 3 is a port of SDL3 on emscripten-ports
 // When AUTO_JS_LIBRARIES is set to 0 this defaults to 0 and SDL
 // is not linked in.
-// Alternate syntax for using the port: --use-port=sdl2
+// Alternate syntax for using the port: --use-port=sdl3
 // [compile+link]
 var USE_SDL = 0;
 

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -2130,14 +2130,13 @@ void *getBindBuffer() {
     self.reftest('test_sdl_canvas_palette_2.c', 'test_sdl_canvas_palette_b.png', cflags=['--pre-js', 'pre.js', '--pre-js', 'args-b.js', '-lSDL', '-lGL'])
 
   def test_sdl_ttf_render_text_solid(self):
-    self.reftest('test_sdl_ttf_render_text_solid.c', cflags=['-O2', '-lSDL', '-lGL', '-Wno-experimental'])
+    self.reftest('test_sdl_ttf_render_text_solid.c', cflags=['-O2', '-lSDL', '-lGL'])
 
   def test_sdl3_ttf_render_text_solid(self):
-    self.cflags.append('-Wno-experimental')
     copy_asset('freetype/LiberationSansBold.ttf')
     self.reftest('test_sdl3_ttf_render_text_solid.c', 'test_sdl3_ttf_render_text_solid.png',
                  cflags=[
-                  '-O2', '-sUSE_SDL=3', '-sUSE_SDL_TTF=3', '-lGL', '-Wno-experimental',
+                  '-O2', '-sUSE_SDL=3', '-sUSE_SDL_TTF=3', '-lGL',
                   '--embed-file', 'LiberationSansBold.ttf'])
 
   def test_sdl_alloctext(self):
@@ -3110,7 +3109,7 @@ Module["preRun"] = () => {
   def test_sdl3_ttf(self):
     copy_asset('freetype/LiberationSansBold.ttf')
     self.reftest('test_sdl3_ttf.c', 'test_sdl3_ttf.png',
-                 cflags=['-O2', '-sUSE_SDL=3', '-sUSE_SDL_TTF=3', '--embed-file', 'LiberationSansBold.ttf', '-Wno-experimental'])
+                 cflags=['-O2', '-sUSE_SDL=3', '-sUSE_SDL_TTF=3', '--embed-file', 'LiberationSansBold.ttf'])
 
   @requires_graphics_hardware
   def test_sdl2_ttf_rtl(self):
@@ -3167,11 +3166,9 @@ Module["preRun"] = () => {
     self.btest_exit('test_sdl2_mixer_music.c', cflags=args)
 
   def test_sdl3_misc(self):
-    self.cflags.append('-Wno-experimental')
     self.btest_exit('test_sdl3_misc.c', cflags=['-sUSE_SDL=3'])
 
   def test_sdl3_canvas_write(self):
-    self.cflags.append('-Wno-experimental')
     self.btest_exit('test_sdl3_canvas_write.c', cflags=['-sUSE_SDL=3'])
 
   @requires_graphics_hardware

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -2630,7 +2630,6 @@ F1 -> ''
   def test_sdl3_linkable(self):
     # Ensure that SDL3 can be built with MAIN_MODULE.  This implies there are no undefined
     # symbols in the library (because MAIN_MODULE=1 includes the entire library).
-    self.cflags.append('-Wno-experimental')
     self.emcc('browser/test_sdl3_misc.c', ['-sMAIN_MODULE', '-sUSE_SDL=3', '-o', 'a.out.js'])
     self.emcc('browser/test_sdl3_misc.c', ['-sMAIN_MODULE', '--use-port=sdl3', '-o', 'a.out.js'])
 
@@ -2773,8 +2772,8 @@ F1 -> ''
   @requires_network
   def test_sdl3_ttf(self):
     # A compile-only test that checks if sdl3-ttf, and dependencies freetype and harfbuzz, are buildable.
-    self.emcc(test_file('browser/test_sdl3_ttf.c'), args=['-Wno-experimental', '-sUSE_SDL=3', '-sUSE_SDL_TTF=3'])
-    self.emcc(test_file('browser/test_sdl3_ttf.c'), args=['-Wno-experimental', '--use-port=sdl3', '--use-port=sdl3_ttf'])
+    self.emcc(test_file('browser/test_sdl3_ttf.c'), args=['-sUSE_SDL=3', '-sUSE_SDL_TTF=3'])
+    self.emcc(test_file('browser/test_sdl3_ttf.c'), args=['--use-port=sdl3', '--use-port=sdl3_ttf'])
 
   @requires_network
   def test_contrib_ports(self):

--- a/tools/ports/sdl3.py
+++ b/tools/ports/sdl3.py
@@ -7,8 +7,6 @@ import glob
 import os
 import shutil
 
-from tools import diagnostics
-
 VERSION = '3.4.2'
 TAG = f'release-{VERSION}'
 HASH = 'a17fe538993a3956e0b85fda21e7b431244e803a5facb35bb7a2bfd9ee23f1aac65838ed3225f526b81410cae7c23da7c40693c2e791385281f0764239116bce'
@@ -26,8 +24,6 @@ def get_lib_name(settings):
 
 
 def get(ports, settings, shared):
-  diagnostics.warning('experimental', 'sdl3 port is still experimental')
-
   # get the port
   ports.fetch_project('sdl3', f'https://github.com/libsdl-org/SDL/archive/{TAG}.zip', sha512hash=HASH)
 

--- a/tools/ports/sdl3_ttf.py
+++ b/tools/ports/sdl3_ttf.py
@@ -27,7 +27,7 @@ def get(ports, settings, shared):
   def create(final):
     src_root = ports.get_dir('sdl3_ttf', 'SDL_ttf-' + TAG)
     ports.install_header_dir(os.path.join(src_root, 'include'), target='.')
-    flags = ['-Wno-experimental', '-DTTF_USE_HARFBUZZ=1', '-sUSE_SDL=3', '-sUSE_FREETYPE', '-sUSE_HARFBUZZ']
+    flags = ['-DTTF_USE_HARFBUZZ=1', '-sUSE_SDL=3', '-sUSE_FREETYPE', '-sUSE_HARFBUZZ']
     if settings.PTHREADS:
       flags += ['-pthread']
 


### PR DESCRIPTION
We haven't had any reports of issues with this port since it was added.