### PR TITLE
[ports] Pass integer for WASM_LEGACY_EXCEPTIONS when building ports

### DIFF
--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -11,8 +11,8 @@ PKG_VERSION = '26.2.20'
 HASH = '460ea4dc9cc879822556d801341a1cf3efcd57a13cd4da64169603ea98873337dd19e3c8c6d9054b27d10acbbaa8d5c59b7f560c697b98dc2640bcd88f57554a'
 
 variants = {
-  'freetype-wasmsjlj': {'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': 0},
-  'freetype-legacysjlj': {'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': 1},
+  'freetype-wasmsjlj': {'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': False},
+  'freetype-legacysjlj': {'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': True},
 }
 deps = ['zlib']
 
@@ -103,7 +103,7 @@ def get(ports, settings, shared):
 
     if settings.SUPPORT_LONGJMP == 'wasm':
       flags.append('-sSUPPORT_LONGJMP=wasm')
-      flags.append(f'-sWASM_LEGACY_EXCEPTIONS={settings.WASM_LEGACY_EXCEPTIONS}')
+      flags.append(f'-sWASM_LEGACY_EXCEPTIONS={int(settings.WASM_LEGACY_EXCEPTIONS)}')
 
     ports.make_pkg_config('freetype2', PKG_VERSION, '-sUSE_FREETYPE')
     ports.build_port(source_path, final, 'freetype', flags=flags, srcs=srcs)

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -13,10 +13,10 @@ HASH = '177d81fd1ba1a46ff64da7f24260814876bd0a27ee5bed6dc9dbdd1fe28f3a67cb6f11c7
 deps = ['zlib']
 variants = {
   'libpng-mt': {'PTHREADS': 1},
-  'libpng-wasmsjlj': {'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': 0},
-  'libpng-mt-wasmsjlj': {'PTHREADS': 1, 'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': 0},
-  'libpng-legacysjlj': {'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': 1},
-  'libpng-mt-legacysjlj': {'PTHREADS': 1, 'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': 1},
+  'libpng-wasmsjlj': {'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': False},
+  'libpng-mt-wasmsjlj': {'PTHREADS': 1, 'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': False},
+  'libpng-legacysjlj': {'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': True},
+  'libpng-mt-legacysjlj': {'PTHREADS': 1, 'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': True},
 }
 
 
@@ -51,7 +51,7 @@ def get(ports, settings, shared):
       flags += ['-pthread']
     if settings.SUPPORT_LONGJMP == 'wasm':
       flags.append('-sSUPPORT_LONGJMP=wasm')
-      flags.append(f'-sWASM_LEGACY_EXCEPTIONS={settings.WASM_LEGACY_EXCEPTIONS}')
+      flags.append(f'-sWASM_LEGACY_EXCEPTIONS={int(settings.WASM_LEGACY_EXCEPTIONS)}')
 
     ports.build_port(source_path, final, 'libpng', flags=flags, exclude_files=['pngtest'], exclude_dirs=['scripts', 'contrib'])
 

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -8,8 +8,8 @@ HASH = '2175d11a90211871f2289c8d57b31fe830e4b46af7361925c2c30cd521c1c677d2ee244f
 
 deps = ['sdl2']
 variants = {
-  'sdl2_image-wasmsjlj': {'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': 0},
-  'sdl2_image-legacysjlj': {'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': 1},
+  'sdl2_image-wasmsjlj': {'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': False},
+  'sdl2_image-legacysjlj': {'SUPPORT_LONGJMP': 'wasm', 'WASM_LEGACY_EXCEPTIONS': True},
   'sdl2_image-jpg':    {'SDL2_IMAGE_FORMATS': ["jpg"]},
   'sdl2_image-png':    {'SDL2_IMAGE_FORMATS': ["png"]},
   'sdl2_image-jpg-mt': {'SDL2_IMAGE_FORMATS': ["jpg"], 'PTHREADS': 1},
@@ -81,7 +81,7 @@ def get(ports, settings, shared):
 
     if settings.SUPPORT_LONGJMP == 'wasm':
       flags.append('-sSUPPORT_LONGJMP=wasm')
-      flags.append(f'-sWASM_LEGACY_EXCEPTIONS={settings.WASM_LEGACY_EXCEPTIONS}')
+      flags.append(f'-sWASM_LEGACY_EXCEPTIONS={int(settings.WASM_LEGACY_EXCEPTIONS)}')
 
     ports.build_port(src_dir, final, 'sdl2_image', flags=flags, srcs=srcs)
 


### PR DESCRIPTION
In #27579, `WASM_LEGACY_EXCEPTIONS` was forwarded to sub-compilations when building ports with wasm SjLj. However, `settings.WASM_LEGACY_EXCEPTIONS` defaults to a boolean (`True`) in Python when not explicitly set via `-s` on the command line (e.g. when using `-fwasm-exceptions`). Stringifying it into `-sWASM_LEGACY_EXCEPTIONS={settings.WASM_LEGACY_EXCEPTIONS}` resulted in `-sWASM_LEGACY_EXCEPTIONS=True`, which `emcc` rejects because boolean settings require 1 or 0.

Ensure we format it as an integer so `1` or `0` is always passed.

Also, update the variants to set `WASM_LEGACY_EXCEPTIONS` to True/False which means that the embuilder build of these libraries will fail in the same way.

Fixes: #27650