### PR TITLE
[libc] Always use __builtin_wasm_memory_copy in memcpy

### DIFF
--- a/system/lib/libc/emscripten_memcpy.c
+++ b/system/lib/libc/emscripten_memcpy.c
@@ -18,86 +18,12 @@ static void *__memcpy(void *dest, const void *src, size_t n) {
   return dest;
 }
 
-#elif defined(EMSCRIPTEN_OPTIMIZE_FOR_OZ)
+#else
 
 static void *__memcpy(void *restrict dest, const void *restrict src, size_t n) {
   // memory.copy traps on OOB zero-length copies, but memcpy must not.
   if (n) {
     __builtin_wasm_memory_copy(0, 0, dest, src, n);
-  }
-  return dest;
-}
-
-#else
-
-static void *__memcpy(void *restrict dest, const void *restrict src, size_t n) {
-  unsigned char *d = dest;
-  const unsigned char *s = src;
-
-  unsigned char *aligned_d_end;
-  unsigned char *block_aligned_d_end;
-  unsigned char *d_end;
-
-  if (n >= 512) {
-    // TODO: Re-investigate the size threshold to enable this
-    __builtin_wasm_memory_copy(0, 0, dest, src, n);
-    return dest;
-  }
-
-  d_end = d + n;
-  if ((((uintptr_t)d) & 3) == (((uintptr_t)s) & 3)) {
-    // The initial unaligned < 4-byte front.
-    while ((((uintptr_t)d) & 3) && d < d_end) {
-      *d++ = *s++;
-    }
-    aligned_d_end = (unsigned char *)(((uintptr_t)d_end) & -4);
-    if (((uintptr_t)aligned_d_end) >= 64) {
-      block_aligned_d_end = aligned_d_end - 64;
-      while (d <= block_aligned_d_end) {
-        // TODO: we could use 64-bit ops here, but we'd need to make sure the
-        //       alignment is 64-bit, which might cost us
-        *(((uint32_t*)d)) = *(((uint32_t*)s));
-        *(((uint32_t*)d) + 1) = *(((uint32_t*)s) + 1);
-        *(((uint32_t*)d) + 2) = *(((uint32_t*)s) + 2);
-        *(((uint32_t*)d) + 3) = *(((uint32_t*)s) + 3);
-        *(((uint32_t*)d) + 4) = *(((uint32_t*)s) + 4);
-        *(((uint32_t*)d) + 5) = *(((uint32_t*)s) + 5);
-        *(((uint32_t*)d) + 6) = *(((uint32_t*)s) + 6);
-        *(((uint32_t*)d) + 7) = *(((uint32_t*)s) + 7);
-        *(((uint32_t*)d) + 8) = *(((uint32_t*)s) + 8);
-        *(((uint32_t*)d) + 9) = *(((uint32_t*)s) + 9);
-        *(((uint32_t*)d) + 10) = *(((uint32_t*)s) + 10);
-        *(((uint32_t*)d) + 11) = *(((uint32_t*)s) + 11);
-        *(((uint32_t*)d) + 12) = *(((uint32_t*)s) + 12);
-        *(((uint32_t*)d) + 13) = *(((uint32_t*)s) + 13);
-        *(((uint32_t*)d) + 14) = *(((uint32_t*)s) + 14);
-        *(((uint32_t*)d) + 15) = *(((uint32_t*)s) + 15);
-        d += 64;
-        s += 64;
-      }
-    }
-    while (d < aligned_d_end) {
-      *((uint32_t *)d) = *((uint32_t *)s);
-      d += 4;
-      s += 4;
-    }
-  } else {
-    // In the unaligned copy case, unroll a bit as well.
-    if (((uintptr_t)d_end) >= 4) {
-      aligned_d_end = d_end - 4;
-      while (d <= aligned_d_end) {
-        *d = *s;
-        *(d + 1) = *(s + 1);
-        *(d + 2) = *(s + 2);
-        *(d + 3) = *(s + 3);
-        d += 4;
-        s += 4;
-      }
-    }
-  }
-  // The remaining unaligned < 4 byte tail.
-  while (d < d_end) {
-    *d++ = *s++;
   }
   return dest;
 }

--- a/test/codesize/test_codesize_cxx_ctors1.json
+++ b/test/codesize/test_codesize_cxx_ctors1.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19224,
   "a.out.js.gz": 8124,
-  "a.out.nodebug.wasm": 134748,
-  "a.out.nodebug.wasm.gz": 51563,
-  "total": 153972,
-  "total_gz": 59687,
+  "a.out.nodebug.wasm": 134250,
+  "a.out.nodebug.wasm.gz": 51364,
+  "total": 153474,
+  "total_gz": 59488,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_ctors2.json
+++ b/test/codesize/test_codesize_cxx_ctors2.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19201,
   "a.out.js.gz": 8107,
-  "a.out.nodebug.wasm": 134177,
-  "a.out.nodebug.wasm.gz": 51223,
-  "total": 153378,
-  "total_gz": 59330,
+  "a.out.nodebug.wasm": 133679,
+  "a.out.nodebug.wasm.gz": 51045,
+  "total": 152880,
+  "total_gz": 59152,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_except.json
+++ b/test/codesize/test_codesize_cxx_except.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 22917,
   "a.out.js.gz": 9078,
-  "a.out.nodebug.wasm": 177205,
-  "a.out.nodebug.wasm.gz": 59096,
-  "total": 200122,
-  "total_gz": 68174,
+  "a.out.nodebug.wasm": 176707,
+  "a.out.nodebug.wasm.gz": 58892,
+  "total": 199624,
+  "total_gz": 67970,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_except_wasm.json
+++ b/test/codesize/test_codesize_cxx_except_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19023,
   "a.out.js.gz": 8039,
-  "a.out.nodebug.wasm": 150465,
-  "a.out.nodebug.wasm.gz": 56613,
-  "total": 169488,
-  "total_gz": 64652,
+  "a.out.nodebug.wasm": 149967,
+  "a.out.nodebug.wasm.gz": 56437,
+  "total": 168990,
+  "total_gz": 64476,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_except_wasm_legacy.json
+++ b/test/codesize/test_codesize_cxx_except_wasm_legacy.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19101,
   "a.out.js.gz": 8065,
-  "a.out.nodebug.wasm": 148247,
-  "a.out.nodebug.wasm.gz": 56292,
-  "total": 167348,
-  "total_gz": 64357,
+  "a.out.nodebug.wasm": 147749,
+  "a.out.nodebug.wasm.gz": 56113,
+  "total": 166850,
+  "total_gz": 64178,
   "sent": [
     "_abort_js",
     "_tzset_js",

--- a/test/codesize/test_codesize_cxx_mangle.json
+++ b/test/codesize/test_codesize_cxx_mangle.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 22967,
   "a.out.js.gz": 9098,
-  "a.out.nodebug.wasm": 243485,
-  "a.out.nodebug.wasm.gz": 81301,
-  "total": 266452,
-  "total_gz": 90399,
+  "a.out.nodebug.wasm": 242987,
+  "a.out.nodebug.wasm.gz": 81112,
+  "total": 265954,
+  "total_gz": 90210,
   "sent": [
     "__cxa_begin_catch",
     "__cxa_end_catch",

--- a/test/codesize/test_codesize_cxx_noexcept.json
+++ b/test/codesize/test_codesize_cxx_noexcept.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 19224,
   "a.out.js.gz": 8124,
-  "a.out.nodebug.wasm": 136658,
-  "a.out.nodebug.wasm.gz": 52180,
-  "total": 155882,
-  "total_gz": 60304,
+  "a.out.nodebug.wasm": 136160,
+  "a.out.nodebug.wasm.gz": 51987,
+  "total": 155384,
+  "total_gz": 60111,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_cxx_wasmfs.json
+++ b/test/codesize/test_codesize_cxx_wasmfs.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 6604,
   "a.out.js.gz": 3154,
-  "a.out.nodebug.wasm": 174384,
-  "a.out.nodebug.wasm.gz": 64935,
-  "total": 180988,
-  "total_gz": 68089,
+  "a.out.nodebug.wasm": 173886,
+  "a.out.nodebug.wasm.gz": 64740,
+  "total": 180490,
+  "total_gz": 67894,
   "sent": [
     "__cxa_throw",
     "_abort_js",

--- a/test/codesize/test_codesize_file_preload.json
+++ b/test/codesize/test_codesize_file_preload.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 22203,
   "a.out.js.gz": 9267,
-  "a.out.nodebug.wasm": 1661,
-  "a.out.nodebug.wasm.gz": 944,
-  "total": 23864,
-  "total_gz": 10211,
+  "a.out.nodebug.wasm": 1198,
+  "a.out.nodebug.wasm.gz": 730,
+  "total": 23401,
+  "total_gz": 9997,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_O0.json
+++ b/test/codesize/test_codesize_hello_O0.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 23471,
   "a.out.js.gz": 8555,
-  "a.out.nodebug.wasm": 15088,
-  "a.out.nodebug.wasm.gz": 7441,
-  "total": 38559,
-  "total_gz": 15996,
+  "a.out.nodebug.wasm": 14578,
+  "a.out.nodebug.wasm.gz": 7228,
+  "total": 38049,
+  "total_gz": 15783,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O1.json
+++ b/test/codesize/test_codesize_hello_O1.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 5516,
   "a.out.js.gz": 2242,
-  "a.out.nodebug.wasm": 2523,
-  "a.out.nodebug.wasm.gz": 1424,
-  "total": 8039,
-  "total_gz": 3666,
+  "a.out.nodebug.wasm": 2013,
+  "a.out.nodebug.wasm.gz": 1202,
+  "total": 7529,
+  "total_gz": 3444,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O2.json
+++ b/test/codesize/test_codesize_hello_O2.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 3855,
   "a.out.js.gz": 1966,
-  "a.out.nodebug.wasm": 1907,
-  "a.out.nodebug.wasm.gz": 1125,
-  "total": 5762,
-  "total_gz": 3091,
+  "a.out.nodebug.wasm": 1398,
+  "a.out.nodebug.wasm.gz": 894,
+  "total": 5253,
+  "total_gz": 2860,
   "sent": [
     "fd_write"
   ],

--- a/test/codesize/test_codesize_hello_O3.json
+++ b/test/codesize/test_codesize_hello_O3.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 3797,
   "a.out.js.gz": 1925,
-  "a.out.nodebug.wasm": 1661,
-  "a.out.nodebug.wasm.gz": 944,
-  "total": 5458,
-  "total_gz": 2869,
+  "a.out.nodebug.wasm": 1198,
+  "a.out.nodebug.wasm.gz": 730,
+  "total": 4995,
+  "total_gz": 2655,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_Os.json
+++ b/test/codesize/test_codesize_hello_Os.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 3797,
   "a.out.js.gz": 1925,
-  "a.out.nodebug.wasm": 1649,
-  "a.out.nodebug.wasm.gz": 950,
-  "total": 5446,
-  "total_gz": 2875,
+  "a.out.nodebug.wasm": 1188,
+  "a.out.nodebug.wasm.gz": 732,
+  "total": 4985,
+  "total_gz": 2657,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_dylink.json
+++ b/test/codesize/test_codesize_hello_dylink.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 26258,
   "a.out.js.gz": 11211,
-  "a.out.nodebug.wasm": 17862,
-  "a.out.nodebug.wasm.gz": 9041,
-  "total": 44120,
-  "total_gz": 20252,
+  "a.out.nodebug.wasm": 17365,
+  "a.out.nodebug.wasm.gz": 8831,
+  "total": 43623,
+  "total_gz": 20042,
   "sent": [
     "__syscall_stat64",
     "emscripten_resize_heap",
@@ -37,7 +37,6 @@
     "$__emscripten_stdout_close",
     "$__emscripten_stdout_seek",
     "$__fwritex",
-    "$__memcpy",
     "$__memset",
     "$__stdio_write",
     "$__strchrnul",

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
   "a.out.js": 270584,
-  "a.out.nodebug.wasm": 588647,
-  "total": 859231,
+  "a.out.nodebug.wasm": 588865,
+  "total": 859449,
   "sent": [
     "IMG_Init",
     "IMG_Load",

--- a/test/codesize/test_codesize_hello_esm_integration.json
+++ b/test/codesize/test_codesize_hello_esm_integration.json
@@ -3,10 +3,10 @@
   "a.out.mjs.gz": 401,
   "a.out.support.mjs": 6089,
   "a.out.support.mjs.gz": 2388,
-  "a.out.nodebug.wasm": 1683,
-  "a.out.nodebug.wasm.gz": 971,
-  "total": 8443,
-  "total_gz": 3760,
+  "a.out.nodebug.wasm": 1220,
+  "a.out.nodebug.wasm.gz": 757,
+  "total": 7980,
+  "total_gz": 3546,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_codesize_hello_single_file.json
+++ b/test/codesize/test_codesize_hello_single_file.json
@@ -1,6 +1,6 @@
 {
-  "a.out.js": 4844,
-  "a.out.js.gz": 2746,
+  "a.out.js": 4366,
+  "a.out.js.gz": 2521,
   "sent": [
     "a (fd_write)"
   ]

--- a/test/codesize/test_codesize_hello_wasmfs.json
+++ b/test/codesize/test_codesize_hello_wasmfs.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 3797,
   "a.out.js.gz": 1925,
-  "a.out.nodebug.wasm": 1661,
-  "a.out.nodebug.wasm.gz": 944,
-  "total": 5458,
-  "total_gz": 2869,
+  "a.out.nodebug.wasm": 1198,
+  "a.out.nodebug.wasm.gz": 730,
+  "total": 4995,
+  "total_gz": 2655,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_small_js_flags.json
+++ b/test/codesize/test_small_js_flags.json
@@ -1,10 +1,10 @@
 {
   "a.out.js": 2062,
   "a.out.js.gz": 1182,
-  "a.out.nodebug.wasm": 1661,
-  "a.out.nodebug.wasm.gz": 944,
-  "total": 3723,
-  "total_gz": 2126,
+  "a.out.nodebug.wasm": 1198,
+  "a.out.nodebug.wasm.gz": 730,
+  "total": 3260,
+  "total_gz": 1912,
   "sent": [
     "a (fd_write)"
   ],

--- a/test/codesize/test_unoptimized_code_size.json
+++ b/test/codesize/test_unoptimized_code_size.json
@@ -1,16 +1,16 @@
 {
   "hello_world.js": 54465,
   "hello_world.js.gz": 17297,
-  "hello_world.wasm": 15088,
-  "hello_world.wasm.gz": 7441,
+  "hello_world.wasm": 14578,
+  "hello_world.wasm.gz": 7228,
   "no_asserts.js": 23544,
   "no_asserts.js.gz": 8261,
-  "no_asserts.wasm": 12202,
-  "no_asserts.wasm.gz": 5980,
+  "no_asserts.wasm": 11692,
+  "no_asserts.wasm.gz": 5768,
   "strict.js": 51616,
   "strict.js.gz": 16308,
-  "strict.wasm": 15088,
-  "strict.wasm.gz": 7438,
-  "total": 172003,
-  "total_gz": 62725
+  "strict.wasm": 14578,
+  "strict.wasm.gz": 7223,
+  "total": 170473,
+  "total_gz": 62085
 }

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1450,7 +1450,7 @@ class libc_optz(libc):
     # some files also appear in libc, and a #define affects them
     mem_files = files_in_path(
       path='system/lib/libc',
-      filenames=['emscripten_memcpy.c', 'emscripten_memset.c',
+      filenames=['emscripten_memset.c',
                  'emscripten_memmove.c'])
 
     # some functions have separate files


### PR DESCRIPTION
Remove the manual 32-bit copy loop for sizes < 512 bytes in `emscripten_memcpy.c` and always use `__builtin_wasm_memory_copy` instead, matching the behavior previously used only for `-Oz`.

Benchmarking across V8, SpiderMonkey, and JavaScriptCore shows that `memory.copy` is consistently faster than the manual loop for small sizes, especially for unaligned copies.

Head-to-head microbenchmark comparing the old manual loop against `__builtin_wasm_memory_copy` for sizes <= 511 bytes (500k iterations per size):

Aligned copies (sizes 1B to 511B):
- V8:             72.82ms vs 100.87ms (27.8% faster)
- SpiderMonkey:   93.09ms vs 100.27ms (7.2% faster)
- JavaScriptCore: 60.04ms vs  91.14ms (34.1% faster)

Unaligned copies (source and dest offsets 0..3):
- V8:            148.72ms vs 357.02ms (58.3% faster)
- SpiderMonkey:  186.95ms vs 440.61ms (57.6% faster)
- JavaScriptCore: 124.16ms vs 372.28ms (66.6% faster)