### PR TITLE
[libc] Always use __builtin_wasm_memory_copy in memmove

### DIFF
--- a/system/lib/libc/emscripten_memmove.c
+++ b/system/lib/libc/emscripten_memmove.c
@@ -1,27 +1,41 @@
-// XXX EMSCRIPTEN ASAN: build an uninstrumented version of memmove
-#if defined(__EMSCRIPTEN__) && defined(__has_feature)
+/*
+ * Copyright 2019 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include "libc.h"
+
+// Use the simple/naive version of memmove when building with asan
 #if __has_feature(address_sanitizer)
-#define memmove __attribute__((no_sanitize("address"))) emscripten_builtin_memmove
-#endif
-#endif
 
-#ifdef EMSCRIPTEN_OPTIMIZE_FOR_OZ
-
-#include <stddef.h>
-
-void *memcpy(void *dest, const void *src, size_t n);
-
-void *memmove(void *dest, const void *src, size_t n) {
-  if (dest < src) return memcpy(dest, src, n);
-  unsigned char *d = (unsigned char *)dest + n;
-  const unsigned char *s = (const unsigned char *)src + n;
-#pragma clang loop unroll(disable)
-  while(n--) *--d = *--s;
+static void *__memmove(void *dest, const void *src, size_t n) {
+  unsigned char *d = (unsigned char *)dest;
+  const unsigned char *s = (const unsigned char *)src;
+  if (d < s) {
+    while (n--) *d++ = *s++;
+  } else {
+    d += n;
+    s += n;
+    while (n--) *--d = *--s;
+  }
   return dest;
 }
 
 #else
 
-#include "musl/src/string/memmove.c"
+static void *__memmove(void *dest, const void *src, size_t n) {
+  // memory.copy traps on OOB zero-length copies, but memmove must not.
+  if (n) {
+    __builtin_wasm_memory_copy(0, 0, dest, src, n);
+  }
+  return dest;
+}
 
 #endif
+
+weak_alias(__memmove, emscripten_builtin_memmove);
+weak_alias(__memmove, memmove);

--- a/test/codesize/test_codesize_hello_dylink_all.json
+++ b/test/codesize/test_codesize_hello_dylink_all.json
@@ -1,7 +1,7 @@
 {
   "a.out.js": 270584,
-  "a.out.nodebug.wasm": 588865,
-  "total": 859449,
+  "a.out.nodebug.wasm": 588564,
+  "total": 859148,
   "sent": [
     "IMG_Init",
     "IMG_Load",
@@ -2549,6 +2549,7 @@
     "emscripten_builtin_malloc",
     "emscripten_builtin_memalign",
     "emscripten_builtin_memcpy",
+    "emscripten_builtin_memmove",
     "emscripten_builtin_memset",
     "emscripten_builtin_mmap",
     "emscripten_builtin_munmap",
@@ -4846,7 +4847,6 @@
     "$memchr",
     "$memcmp",
     "$memmem",
-    "$memmove",
     "$mempcpy",
     "$mincore",
     "$mkdir",

--- a/tools/native_sigs.py
+++ b/tools/native_sigs.py
@@ -785,6 +785,7 @@ native_sigs = {
   'emscripten_builtin_malloc': 'pp',
   'emscripten_builtin_memalign': 'ppp',
   'emscripten_builtin_memcpy': 'pppp',
+  'emscripten_builtin_memmove': 'pppp',
   'emscripten_builtin_memset': 'pp_p',
   'emscripten_builtin_mmap': 'ppp____',
   'emscripten_builtin_munmap': '_pp',

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1446,8 +1446,7 @@ class libc_optz(libc):
     # some files also appear in libc, and a #define affects them
     mem_files = files_in_path(
       path='system/lib/libc',
-      filenames=['emscripten_memset.c',
-                 'emscripten_memmove.c'])
+      filenames=['emscripten_memset.c'])
 
     # some functions have separate files
     math_files = files_in_path(


### PR DESCRIPTION
Followup to #27653.

Replace Musl's `memmove.c` and the `-Oz` manual loop in `emscripten_memmove.c` with `__builtin_wasm_memory_copy`.

WebAssembly's `memory.copy` instruction is specified with overlapping copy (`memmove`) semantics, and engines (V8, SpiderMonkey, JSC) implement it using native host `memmove`.

In Musl's C implementation, misaligned overlapping copies fall back to a byte-by-byte scalar loop in wasm, which is 15x to 33x slower than `memory.copy`.

Overlapping copy benchmark results (200k iterations across sizes 1B to 16KB):

Shift forward (dest > src):
- V8:             34.51ms vs  576.50ms (94.0% faster, 16.7x)
- SpiderMonkey:   33.73ms vs 1129.64ms (97.0% faster, 33.5x)
- JavaScriptCore: 33.32ms vs  715.26ms (95.3% faster, 21.5x)

Shift backward (dest < src):
- V8:             34.28ms vs  551.30ms (93.8% faster, 16.1x)
- SpiderMonkey:   33.74ms vs  546.25ms (93.8% faster, 16.2x)
- JavaScriptCore: 32.90ms vs  535.86ms (93.9% faster, 16.3x)