### PR TITLE
Mark wasm2js (WASM=0) as deprecated

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,7 @@ See docs/process.md for more on how version tagging works.
 ----------------------
 - The SDL3 port is no longer considered experimental, and the compiler
   diagnostic warning has been removed. (#27646)
+- `WASM=0` and `WASM=2` (wasm2js) were marked as deprecated. (See #27608)
 
 6.0.9 - 09/01/26
 ----------------

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -2025,12 +2025,12 @@ WASM
 ====
 
 Whether to use compile code to WebAssembly. Set this to 0 to compile to JS
-instead of wasm.
+instead of wasm (deprecated).
 
-Specify -sWASM=2 to target both WebAssembly and JavaScript at the same time.
-In that build mode, two files a.wasm and a.wasm.js are produced, and at runtime
-the WebAssembly file is loaded if browser/shell supports it. Otherwise the
-.wasm.js fallback will be used.
+Specify -sWASM=2 to target both WebAssembly and JavaScript at the same time
+(deprecated). In that build mode, two files a.wasm and a.wasm.js are produced,
+and at runtime the WebAssembly file is loaded if browser/shell supports it.
+Otherwise the .wasm.js fallback will be used.
 
 If WASM=2 is enabled and the browser fails to compile the WebAssembly module,
 the page will be reloaded in Wasm2JS mode.
@@ -3514,6 +3514,8 @@ these settings please open a bug (or reply to one of the existing bugs).
  - ``USE_PTHREADS``: prefer the standard -pthread flag
  - ``MEMORY64``: prefer the standard -m64 or --target=wasm64 flags
  - ``SOCKET_WEBRTC``: under consideration for removal (https://github.com/emscripten-core/emscripten/issues/27366)
+ - ``WASM=0``: under consideration for removal (https://github.com/emscripten-core/emscripten/issues/27608)
+ - ``WASM=2``: under consideration for removal (https://github.com/emscripten-core/emscripten/issues/27608)
 
 .. _legacy-settings:
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1406,12 +1406,12 @@ var EMSCRIPTEN_TRACING = false;
 var USE_GLFW = 0;
 
 // Whether to use compile code to WebAssembly. Set this to 0 to compile to JS
-// instead of wasm.
+// instead of wasm (deprecated).
 //
-// Specify -sWASM=2 to target both WebAssembly and JavaScript at the same time.
-// In that build mode, two files a.wasm and a.wasm.js are produced, and at runtime
-// the WebAssembly file is loaded if browser/shell supports it. Otherwise the
-// .wasm.js fallback will be used.
+// Specify -sWASM=2 to target both WebAssembly and JavaScript at the same time
+// (deprecated). In that build mode, two files a.wasm and a.wasm.js are produced,
+// and at runtime the WebAssembly file is loaded if browser/shell supports it.
+// Otherwise the .wasm.js fallback will be used.
 //
 // If WASM=2 is enabled and the browser fails to compile the WebAssembly module,
 // the page will be reloaded in Wasm2JS mode.

--- a/test/common.py
+++ b/test/common.py
@@ -672,6 +672,8 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
       self.skipTest('wasm2js does not support over 2gb of memory')
     if self.get_setting('WASM_ESM_INTEGRATION'):
       self.skipTest('wasm2js is not compatible with WASM_ESM_INTEGRATION')
+    if '-Wno-deprecated' not in self.cflags:
+      self.cflags.append('-Wno-deprecated')
 
   def setup_nodefs_test(self):
     self.require_node()

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -461,6 +461,7 @@ def also_with_wasm2js(func):
     if with_wasm2js:
       self.require_wasm2js()
       self.set_setting('WASM', 0)
+      self.cflags.append('-Wno-deprecated')
     return func(self, *args, **kwargs)
 
   parameterize(metafunc, {'': (False,),

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1357,29 +1357,6 @@ int main(int argc, char **argv) {
     self.set_setting('INLINING_LIMIT')
     self.do_core_test('test_exceptions_allowed_uncaught.cpp', cflags=['-std=c++11'])
 
-  def test_exceptions_allowed_misuse(self):
-    self.set_setting('EXCEPTION_CATCHING_ALLOWED', ['foo'])
-
-    # Test old =2 setting for DISABLE_EXCEPTION_CATCHING
-    self.set_setting('DISABLE_EXCEPTION_CATCHING', 2)
-    expected = 'error: DISABLE_EXCEPTION_CATCHING=X is no longer needed when specifying EXCEPTION_CATCHING_ALLOWED [-Wdeprecated] [-Werror]'
-    self.assert_fail([EMCC, test_file('hello_world.c')] + self.get_cflags(), expected)
-
-    # =0 should also be a warning
-    self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
-    expected = 'error: DISABLE_EXCEPTION_CATCHING=X is no longer needed when specifying EXCEPTION_CATCHING_ALLOWED [-Wdeprecated] [-Werror]'
-    self.assert_fail([EMCC, test_file('hello_world.c')] + self.get_cflags(), expected)
-
-    # =1 should be a hard error
-    self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
-    expected = 'error: DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_ALLOWED are mutually exclusive'
-    self.assert_fail([EMCC, test_file('hello_world.c')] + self.get_cflags(), expected)
-
-    # even setting an empty list should trigger the error;
-    self.set_setting('EXCEPTION_CATCHING_ALLOWED', [])
-    expected = 'error: DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_ALLOWED are mutually exclusive'
-    self.assert_fail([EMCC, test_file('hello_world.c')] + self.get_cflags(), expected)
-
   @with_all_eh_sjlj
   def test_exceptions_uncaught(self):
     src = r'''
@@ -2079,7 +2056,7 @@ int main(int argc, char **argv) {
   @no_wasm2js('test depends on WASM_BIGINT which is not compatible with wasm2js')
   def test_em_js_i64(self):
     expected = 'emcc: error: using 64-bit arguments in EM_JS function without WASM_BIGINT is not yet fully supported: `foo`'
-    self.assert_fail([EMCC, '-Werror', '-sWASM=0', test_file('core/test_em_js_i64.c')], expected)
+    self.assert_fail([EMCC, '-Werror', '-Wno-deprecated', '-sWASM=0', test_file('core/test_em_js_i64.c')], expected)
     self.do_core_test('test_em_js_i64.c')
 
   def test_em_js_address_taken(self):
@@ -10090,12 +10067,12 @@ thinlto3 = make_run('thinlto3', cflags=['-flto=thin', '-O3'])
 thinltos = make_run('thinltos', cflags=['-flto=thin', '-Os'])
 thinltoz = make_run('thinltoz', cflags=['-flto=thin', '-Oz'])
 
-wasm2js0 = make_run('wasm2js0', cflags=['-O0'], settings={'WASM': 0})
-wasm2js1 = make_run('wasm2js1', cflags=['-O1'], settings={'WASM': 0})
-wasm2js2 = make_run('wasm2js2', cflags=['-O2'], settings={'WASM': 0})
-wasm2js3 = make_run('wasm2js3', cflags=['-O3'], settings={'WASM': 0})
-wasm2jss = make_run('wasm2jss', cflags=['-Os'], settings={'WASM': 0})
-wasm2jsz = make_run('wasm2jsz', cflags=['-Oz'], settings={'WASM': 0})
+wasm2js0 = make_run('wasm2js0', cflags=['-O0', '-Wno-deprecated'], settings={'WASM': 0})
+wasm2js1 = make_run('wasm2js1', cflags=['-O1', '-Wno-deprecated'], settings={'WASM': 0})
+wasm2js2 = make_run('wasm2js2', cflags=['-O2', '-Wno-deprecated'], settings={'WASM': 0})
+wasm2js3 = make_run('wasm2js3', cflags=['-O3', '-Wno-deprecated'], settings={'WASM': 0})
+wasm2jss = make_run('wasm2jss', cflags=['-Os', '-Wno-deprecated'], settings={'WASM': 0})
+wasm2jsz = make_run('wasm2jsz', cflags=['-Oz', '-Wno-deprecated'], settings={'WASM': 0})
 
 # Secondary test modes - run directly when there is a specific need
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3760,7 +3760,7 @@ More info: https://emscripten.org
            '-sASSERTIONS=0',
            '-sSTRICT=1',
           ], 'embind_tsgen_ignore_2.d.ts'),
-    '3': (['-sWASM=0'], 'embind_tsgen_ignore_3.d.ts'),
+    '3': (['-sWASM=0', '-Wno-deprecated'], 'embind_tsgen_ignore_3.d.ts'),
     '4': (['-fsanitize=undefined', '-gsource-map'], 'embind_tsgen_ignore_3.d.ts'),
     '5': (['-sASYNCIFY'], 'embind_tsgen_ignore_3.d.ts'),
     '6': (['-sENVIRONMENT=worker', '-lworkerfs.js'], 'embind_tsgen.d.ts'),
@@ -6104,8 +6104,8 @@ This locale is not the C locale.
     'o1': (['-O1'], 91000),
     'o2': (['-O2'], 46000),
     'o3_closure': (['-O3', '--closure=1'], 17000),
-    'o3_closure_js': (['-O3', '--closure=1', '-sWASM=0'], 36000),
-    'o3_closure2_js': (['-O3', '--closure=2', '-sWASM=0'], 33000), # might change now and then
+    'o3_closure_js': (['-O3', '--closure=1', '-sWASM=0', '-Wno-deprecated'], 36000),
+    'o3_closure2_js': (['-O3', '--closure=2', '-sWASM=0', '-Wno-deprecated'], 33000), # might change now and then
   })
   def test_no_filesystem_code_size(self, opts, absolute):
     print('opts, absolute:', opts, absolute)
@@ -9378,7 +9378,7 @@ int main(int argc, char** argv) {
 
   def test_wasm2js_no_clobber_wasm(self):
     create_file('hello_world.wasm', 'not wasm')
-    self.do_runf_out_file('hello_world.c', cflags=['-sWASM=0'])
+    self.do_runf_out_file('hello_world.c', cflags=['-sWASM=0', '-Wno-deprecated'])
     self.assertExists('hello_world.js')
     self.assertFileContents('hello_world.wasm', 'not wasm')
 
@@ -9506,7 +9506,7 @@ end
     '': ([],),
     # wasm2js support is interesting to test here because it changes which
     # binaryen tools get run, which can affect how debug info is kept around
-    'wasm2js': (['-sWASM=0'],),
+    'wasm2js': (['-sWASM=0', '-Wno-deprecated'],),
     'pthread': (['-pthread', '-Wno-experimental'],),
     'pthread_offscreen': (['-pthread', '-Wno-experimental', '-sOFFSCREEN_FRAMEBUFFER'],),
     'wasmfs': (['-sWASMFS'],),
@@ -11157,7 +11157,7 @@ int main () {
   })
   @parameterized({
     'sync': (['-sWASM_ASYNC_COMPILATION=0'],),
-    'wasm2js': (['-sWASM=0'],),
+    'wasm2js': (['-sWASM=0', '-Wno-deprecated'],),
   })
   def test_function_exports_are_small(self, args, opt, closure):
     extra_args = args + opt + closure
@@ -11710,6 +11710,29 @@ int main(void) {
     self.assert_fail([EMCC, '-Werror', 'src.c', '-c'], "'EMSCRIPTEN' has been marked as deprecated: use __EMSCRIPTEN__ instead")
     self.assert_fail([EMCC, '-sSTRICT', '-Werror', 'src.c', '-c'], "'EMSCRIPTEN' has been marked as deprecated: use __EMSCRIPTEN__ instead")
 
+  def test_exceptions_allowed_misuse(self):
+    self.set_setting('EXCEPTION_CATCHING_ALLOWED', ['foo'])
+
+    # Test old =2 setting for DISABLE_EXCEPTION_CATCHING
+    self.set_setting('DISABLE_EXCEPTION_CATCHING', 2)
+    expected = 'error: DISABLE_EXCEPTION_CATCHING=X is no longer needed when specifying EXCEPTION_CATCHING_ALLOWED [-Wdeprecated] [-Werror]'
+    self.assert_fail([EMCC, test_file('hello_world.c')] + self.get_cflags(), expected)
+
+    # =0 should also be a warning
+    self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
+    expected = 'error: DISABLE_EXCEPTION_CATCHING=X is no longer needed when specifying EXCEPTION_CATCHING_ALLOWED [-Wdeprecated] [-Werror]'
+    self.assert_fail([EMCC, test_file('hello_world.c')] + self.get_cflags(), expected)
+
+    # =1 should be a hard error
+    self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
+    expected = 'error: DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_ALLOWED are mutually exclusive'
+    self.assert_fail([EMCC, test_file('hello_world.c')] + self.get_cflags(), expected)
+
+    # even setting an empty list should trigger the error;
+    self.set_setting('EXCEPTION_CATCHING_ALLOWED', [])
+    expected = 'error: DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_ALLOWED are mutually exclusive'
+    self.assert_fail([EMCC, test_file('hello_world.c')] + self.get_cflags(), expected)
+
   def test_exception_settings(self):
     for catching, throwing, opts in itertools.product([0, 1], repeat=3):
       cmd = [EMXX, test_file('other/exceptions_modes_symbols_defined.cpp'), '-sDISABLE_EXCEPTION_THROWING=%d' % (1 - throwing), '-sDISABLE_EXCEPTION_CATCHING=%d' % (1 - catching), '-O%d' % opts]
@@ -12031,7 +12054,7 @@ int main(void) {
   def test_non_wasm_without_wasm_in_vm(self):
     create_file('pre.js', 'var WebAssembly = null;\n')
     # Test that our non-wasm output does not depend on wasm support in the vm.
-    self.do_runf_out_file('hello_world.c', cflags=['-sWASM=0', '-sENVIRONMENT=node,shell', '--extern-pre-js=pre.js'])
+    self.do_runf_out_file('hello_world.c', cflags=['-sWASM=0', '-sENVIRONMENT=node,shell', '--extern-pre-js=pre.js', '-Wno-deprecated'])
 
   def test_empty_output_extension(self):
     # Default to JS output when no extension is present
@@ -12461,7 +12484,7 @@ int main(int argc, char **argv) {
   // do some i64 math, but return 0
   return (x % (x - 20)) == 42;
 }''')
-    self.do_runf('src.c', cflags=['-O3', '-sWASM=0'])
+    self.do_runf('src.c', cflags=['-O3', '-sWASM=0', '-Wno-deprecated'])
 
   @crossplatform
   def test_deterministic(self):
@@ -12708,7 +12731,7 @@ exec "$@"
       self.assertContained(r'emcc: error: WASM2JS is not compatible with .*_MODULE \(wasm2js does not support dynamic linking\)', err, regex=True)
 
   def test_wasm2js_standalone(self):
-    self.do_runf_out_file('hello_world.c', cflags=['-sSTANDALONE_WASM', '-sWASM=0'])
+    self.do_runf_out_file('hello_world.c', cflags=['-sSTANDALONE_WASM', '-sWASM=0', '-Wno-deprecated'])
 
   def test_oformat(self):
     self.run_process([EMCC, test_file('hello_world.c'), '--oformat=wasm', '-o', 'out.foo'])
@@ -14661,8 +14684,8 @@ throw_tag:
 
   @parameterized({
     '': ([],),
-    'wasm2js': (['-sWASM=0'],),
-    'wasm2js_fallback': (['-sWASM=2'],),
+    'wasm2js': (['-sWASM=0', '-Wno-deprecated'],),
+    'wasm2js_fallback': (['-sWASM=2', '-Wno-deprecated'],),
   })
   def test_add_js_function(self, args):
     self.set_setting('INVOKE_RUN', 0)

--- a/tools/link.py
+++ b/tools/link.py
@@ -610,6 +610,10 @@ def check_settings():
         # Don't warn about -sMEMORY64=2 (since its the only way to enable the lowering pass)
         continue
       diagnostics.warning('deprecated', f'{s} is deprecated ({reason}). Please open a bug if you have a continuing need for this setting')
+    elif '=' in s:
+      setting, val = s.split('=', 1)
+      if user_settings.get(setting) == val:
+        diagnostics.warning('deprecated', f'{s} is deprecated ({reason}). Please open a bug if you have a continuing need for this setting')
 
   for name, msg in EXPERIMENTAL_SETTINGS.items():
     if getattr(settings, name):

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -117,6 +117,8 @@ DEPRECATED_SETTINGS = {
     'USE_PTHREADS': 'prefer the standard -pthread flag',
     'MEMORY64': 'prefer the standard -m64 or --target=wasm64 flags',
     'SOCKET_WEBRTC': 'under consideration for removal (https://github.com/emscripten-core/emscripten/issues/27366)',
+    'WASM=0': 'under consideration for removal (https://github.com/emscripten-core/emscripten/issues/27608)',
+    'WASM=2': 'under consideration for removal (https://github.com/emscripten-core/emscripten/issues/27608)',
 }
 
 # Settings that don't need to be externalized when serializing to json because they


### PR DESCRIPTION
Add `WASM=0` to `DEPRECATED_SETTINGS` in `tools/settings.py` so that passing `-sWASM=0` emits a deprecation warning under `-Wdeprecated`.

Also update settings documentation, `src/settings.js` comments, `ChangeLog.md`, and test runner/tests to ignore the warning where wasm2js is tested.

See: #27608