### PR TITLE
Remove use of `shared.DEBUG` from test code. NFC

### DIFF
--- a/test/browser_common.py
+++ b/test/browser_common.py
@@ -37,7 +37,7 @@ from common import (
 
 from tools import feature_matrix, utils
 from tools.feature_matrix import OLDEST_SUPPORTED_FIREFOX, UNSUPPORTED
-from tools.shared import DEBUG, EMCC, exit_with_error
+from tools.shared import EMCC, exit_with_error
 from tools.utils import LINUX, MACOS, WINDOWS, memoize, path_from_root, read_binary
 
 logger = logging.getLogger('common')
@@ -465,7 +465,7 @@ def make_test_server(in_queue, out_queue, port):
     def do_GET(self):
       info = urlparse(self.path)
       if info.path == '/run_harness':
-        if DEBUG:
+        if common.EMTEST_VERBOSE:
           print('[server startup]')
         self.send_response(200)
         self.send_header('Content-type', 'text/html')
@@ -493,7 +493,7 @@ def make_test_server(in_queue, out_queue, port):
         else:
           path = self.path
           url = '?'
-        if DEBUG:
+        if common.EMTEST_VERBOSE:
           print('[server response:', path, url, ']')
         if out_queue.empty():
           out_queue.put(path)
@@ -520,7 +520,7 @@ def make_test_server(in_queue, out_queue, port):
         if not in_queue.empty():
           # there is a new test ready to be served
           url, dir = in_queue.get()
-          if DEBUG:
+          if common.EMTEST_VERBOSE:
             print('[queue command:', url, dir, ']')
           assert in_queue.empty(), 'should not be any blockage - one test runs at a time'
           assert out_queue.empty(), 'the single response from the last test was read'
@@ -531,7 +531,7 @@ def make_test_server(in_queue, out_queue, port):
           self.wfile.write(b'(wait)')
       else:
         # Use SimpleHTTPServer default file serving operation for GET.
-        if DEBUG:
+        if common.EMTEST_VERBOSE:
           print('[simple HTTP serving:', unquote_plus(self.path), ']')
         if self.headers.get('Range'):
           self.send_response(206)
@@ -869,7 +869,7 @@ class BrowserCore(RunnerCore):
     BrowserCore.num_tests_ran += 1
 
     self.assert_out_queue_empty('previous test')
-    if DEBUG:
+    if common.EMTEST_VERBOSE:
       print('[browser launch:', html_file, ']')
     assert not (message and expected), 'run_browser expects `expected` or `message`, but not both'
 

--- a/test/common.py
+++ b/test/common.py
@@ -31,7 +31,7 @@ from retryable_unittest import RetryableTestCase
 from tools import building, config, shared, utils
 from tools.feature_matrix import Feature
 from tools.settings import COMPILE_TIME_SETTINGS
-from tools.shared import DEBUG, EMCC, EMXX, get_canonical_temp_dir
+from tools.shared import EMCC, EMXX, get_canonical_temp_dir
 from tools.utils import (
   WINDOWS,
   exe_path_from_root,
@@ -439,10 +439,6 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
   # override these
   temp_dir = shared.TEMP_DIR
   canonical_temp_dir = get_canonical_temp_dir(shared.TEMP_DIR)
-
-  # This avoids cluttering the test runner output, which is stderr too, with compiler warnings etc.
-  # Change this to None to get stderr reporting, for debugging purposes
-  stderr_redirect = STDOUT
 
   library_cache: dict[str, tuple[str, object]] = {}
 
@@ -956,7 +952,7 @@ class RunnerCore(RetryableTestCase, metaclass=RunnerMeta):
     if includes:
       cmd += ['-I' + str(include) for include in includes]
 
-    self.run_process(cmd, stderr=self.stderr_redirect if not DEBUG else None)
+    self.run_process(cmd)
     self.assertExists(output)
 
     if output_suffix in {'.js', '.mjs'}:

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -18,7 +18,6 @@ from functools import wraps
 import common
 from common import test_file
 
-from tools.shared import DEBUG
 from tools.utils import MACOS, WINDOWS
 
 requires_network = unittest.skipIf(os.getenv('EMTEST_SKIP_NETWORK_TESTS'), 'This test requires network access')
@@ -302,7 +301,7 @@ def also_with_wasmfs(func):
 
   @wraps(func)
   def metafunc(self, wasmfs, *args, **kwargs):
-    if DEBUG:
+    if common.EMTEST_VERBOSE:
       print(f'parameterize:wasmfs={wasmfs}')
     if wasmfs:
       self.setup_wasmfs_test()
@@ -318,7 +317,7 @@ def also_with_wasmfs(func):
 def also_with_nodefs(func):
   @wraps(func)
   def metafunc(self, fs, *args, **kwargs):
-    if DEBUG:
+    if common.EMTEST_VERBOSE:
       print(f'parameterize:fs={fs}')
     if fs == 'nodefs':
       self.setup_nodefs_test()
@@ -335,7 +334,7 @@ def also_with_nodefs(func):
 def also_with_nodefs_both(func):
   @wraps(func)
   def metafunc(self, fs, *args, **kwargs):
-    if DEBUG:
+    if common.EMTEST_VERBOSE:
       print(f'parameterize:fs={fs}')
     if fs == 'nodefs':
       self.setup_nodefs_test()
@@ -355,7 +354,7 @@ def also_with_nodefs_both(func):
 def with_all_fs(func):
   @wraps(func)
   def metafunc(self, wasmfs, fs, *args, **kwargs):
-    if DEBUG:
+    if common.EMTEST_VERBOSE:
       print(f'parameterize:fs={fs}')
     if wasmfs:
       self.setup_wasmfs_test()
@@ -382,7 +381,7 @@ def also_with_noderawfs(func):
 
   @wraps(func)
   def metafunc(self, rawfs, *args, **kwargs):
-    if DEBUG:
+    if common.EMTEST_VERBOSE:
       print(f'parameterize:rawfs={rawfs}')
     if rawfs:
       self.setup_noderawfs_test()
@@ -400,7 +399,7 @@ def also_with_minimal_runtime(func):
 
   @wraps(func)
   def metafunc(self, with_minimal_runtime, *args, **kwargs):
-    if DEBUG:
+    if common.EMTEST_VERBOSE:
       print(f'parameterize:minimal_runtime={with_minimal_runtime}')
     if self.get_setting('MINIMAL_RUNTIME'):
       self.skipTest('MINIMAL_RUNTIME already enabled in test config')
@@ -423,7 +422,7 @@ def also_with_wasm64(func):
 
   @wraps(func)
   def metafunc(self, with_wasm64, *args, **kwargs):
-    if DEBUG:
+    if common.EMTEST_VERBOSE:
       print(f'parameterize:wasm64={with_wasm64}')
     if with_wasm64:
       self.require_wasm64()
@@ -456,7 +455,7 @@ def also_with_wasm2js(func):
   @wraps(func)
   def metafunc(self, with_wasm2js, *args, **kwargs):
     assert self.get_setting('WASM') is None
-    if DEBUG:
+    if common.EMTEST_VERBOSE:
       print(f'parameterize:wasm2js={with_wasm2js}')
     if with_wasm2js:
       self.require_wasm2js()
@@ -492,7 +491,7 @@ def also_with_standalone_wasm(impure=False):
   def decorated(func):
     @wraps(func)
     def metafunc(self, standalone, *args, **kwargs):
-      if DEBUG:
+      if common.EMTEST_VERBOSE:
         print(f'parameterize:standalone={standalone}')
       if standalone:
         if not can_do_standalone(self, impure):
@@ -561,7 +560,7 @@ def with_all_eh_sjlj(func):
 
   @wraps(func)
   def metafunc(self, mode, *args, **kwargs):
-    if DEBUG:
+    if common.EMTEST_VERBOSE:
       print(f'parameterize:eh_mode={mode}')
     if mode in {'wasm', 'wasm_legacy'}:
       if self.is_wasm2js():

--- a/test/runner.py
+++ b/test/runner.py
@@ -67,6 +67,8 @@ else:
   # For git checkouts the bootstrap.py script would take care of creating this.
   os.makedirs('out', exist_ok=True)
 
+EMCC_DEBUG = utils.get_env_bool('EMCC_DEBUG')
+
 
 # Test modes from 'core' that fully pass all tests. When running a random
 # selection of tests (e.g. "random100" runs 100 random tests) they will be
@@ -377,7 +379,7 @@ def create_test_run_sorter(sort_failing_tests_at_front):
 
 def use_parallel_suite(module):
   suite_supported = module.__name__ not in {'test_sanity', 'test_benchmark', 'test_sockets_node', 'test_sockets_browser', 'test_interactive', 'test_stress', 'test_emrun'}
-  if not common.EMTEST_SAVE_DIR and not shared.DEBUG:
+  if not common.EMTEST_SAVE_DIR and not EMCC_DEBUG:
     has_multiple_cores = parallel_testsuite.num_cores() > 1
     if suite_supported and has_multiple_cores:
       return True
@@ -564,7 +566,7 @@ def configure():
   common.EMTEST_RETRY_FLAKY = utils.get_env_int('EMTEST_RETRY_FLAKY')
   common.EMTEST_LACKS_NATIVE_CLANG = utils.get_env_bool('EMTEST_LACKS_NATIVE_CLANG')
   common.EMTEST_REBASELINE = utils.get_env_bool('EMTEST_REBASELINE')
-  common.EMTEST_VERBOSE = utils.get_env_bool('EMTEST_VERBOSE') or shared.DEBUG
+  common.EMTEST_VERBOSE = utils.get_env_bool('EMTEST_VERBOSE') or EMCC_DEBUG
   if common.EMTEST_VERBOSE:
     logging.root.setLevel(logging.DEBUG)
 
@@ -708,7 +710,7 @@ def main():
   set_env('EMTEST_CORES', options.cores)
 
   if common.EMTEST_DETECT_TEMPFILE_LEAKS:
-    if shared.DEBUG:
+    if EMCC_DEBUG:
       # In EMCC_DEBUG mode emscripten explicitly leaves stuff in the tmp directory
       utils.exit_with_error('EMTEST_DETECT_TEMPFILE_LEAKS is not compatible with EMCC_DEBUG')
     if common.EMTEST_SAVE_DIR:
@@ -724,7 +726,7 @@ def main():
   # emscripten.lock from shared.py).
   # Note: We only do this in the CI environment, since it prevents multiple
   # emscripten checkouts from running tests at the same time.
-  if os.getenv('CI') and not (shared.DEBUG or common.EMTEST_SAVE_DIR):
+  if os.getenv('CI') and not (EMCC_DEBUG or common.EMTEST_SAVE_DIR):
     cleanup_temp_directory()
   utils.delete_file(common.flaky_tests_log_filename)
 

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -195,7 +195,7 @@ def also_with_llvm_libc(func):
 
   @wraps(func)
   def metafunc(self, llvm_libc, *args, **kwargs):
-    if shared.DEBUG:
+    if common.EMTEST_VERBOSE:
       print('parameterize:llvm_libc=%d' % llvm_libc)
     if llvm_libc:
       self.cflags += ['-lllvmlibc']
@@ -9076,7 +9076,7 @@ int main() {
 
   @with_all_eh_sjlj
   def test_multi_inheritance_exception_message(self):
-    # Regression test for a bug that getting exception message in the DEBUG mode
+    # Regression test for a bug that getting exception message in the debug mode
     # did not retrieve the correct thrown object pointer in case of multiple
     # inheritance
     create_file('src.cpp', r'''


### PR DESCRIPTION
Part of my effort to decouple test code from compiler internals.

See #27666