### PR TITLE
Migrate incompatible settings checks to INCOMPATIBLE_SETTINGS. NFC

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -6388,6 +6388,23 @@ int main(void) {
 
     self.assertContained('main1\nmain2\nfoo\nbar\nbaz\n', self.run_js('runner.mjs'))
 
+  def test_esm_integration_incompatible_settings(self):
+    base_cmd = [EMCC, test_file('hello_world.c'), '-sWASM_ESM_INTEGRATION']
+    self.assert_fail(base_cmd + ['-sMAIN_MODULE'],
+                     'emcc: error: WASM_ESM_INTEGRATION is not compatible with MAIN_MODULE (dynamic linking is not supported)')
+    self.assert_fail(base_cmd + ['-sSIDE_MODULE'],
+                     'emcc: error: WASM_ESM_INTEGRATION is not compatible with SIDE_MODULE (dynamic linking is not supported)')
+    self.assert_fail(base_cmd + ['-sASYNCIFY'],
+                     'emcc: error: WASM_ESM_INTEGRATION is not compatible with ASYNCIFY')
+    self.assert_fail(base_cmd + ['-sWASM_WORKERS'],
+                     'emcc: error: WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
+    self.assert_fail(base_cmd + ['-sWASM_ASYNC_COMPILATION=0'],
+                     'emcc: error: WASM_ESM_INTEGRATION is not compatible with WASM_ASYNC_COMPILATION=0')
+    self.assert_fail(base_cmd + ['-sWASM=0'],
+                     'emcc: error: WASM_ESM_INTEGRATION is not compatible with WASM2JS')
+    self.assert_fail(base_cmd + ['-sABORT_ON_WASM_EXCEPTIONS'],
+                     'emcc: error: WASM_ESM_INTEGRATION is not compatible with ABORT_ON_WASM_EXCEPTIONS')
+
   def test_modularize_instantiation_error(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-o', 'out.mjs'] + self.get_cflags())
     create_file('run.mjs', '''
@@ -9760,6 +9777,10 @@ end
     self.assertEqual(read_binary(get_cached()).count(b'waka'), 0)
     self.assertNotContained(ERROR, self.run_js('a.out.js'))
 
+  def test_node_code_caching_incompatible_settings(self):
+    self.assert_fail([EMCC, test_file('hello_world.c'), '-sNODE_CODE_CACHING', '-sWASM_ASYNC_COMPILATION=0', '-sSINGLE_FILE'],
+                     'emcc: error: NODE_CODE_CACHING is not compatible with SINGLE_FILE (saves a file on the side)')
+
   @with_env_modify({'LC_ALL': 'C'})
   def test_autotools_shared_check(self):
     expected = ': supported targets:.* elf'
@@ -12730,6 +12751,15 @@ exec "$@"
       err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sWASM=0', arg])
       self.assertContained(r'emcc: error: WASM2JS is not compatible with .*_MODULE \(wasm2js does not support dynamic linking\)', err, regex=True)
 
+  def test_wasm2js_incompatible_settings(self):
+    base_cmd = [EMCC, test_file('hello_world.c'), '-sWASM=0']
+    self.assert_fail(base_cmd + ['-sSUPPORT_BIG_ENDIAN'],
+                     'emcc: error: WASM2JS is not compatible with SUPPORT_BIG_ENDIAN')
+    self.assert_fail(base_cmd + ['-sMEMORY64'],
+                     'emcc: error: WASM2JS is not compatible with MEMORY64')
+    self.assert_fail(base_cmd + ['-sWASM_BIGINT'],
+                     'emcc: error: WASM_BIGINT=1 is not compatible with wasm2js')
+
   def test_wasm2js_standalone(self):
     self.do_runf_out_file('hello_world.c', cflags=['-sSTANDALONE_WASM', '-sWASM=0', '-Wno-deprecated'])
 
@@ -15020,7 +15050,7 @@ addToLibrary({
     self.do_other_test('test_stdint_limits.c', cflags=['-iwithsysroot/include'])
 
   def test_force_filesystem_error(self):
-    expected = 'emcc: error: `-sFORCE_FILESYSTEM` cannot be used with `-sFILESYSTEM=0`'
+    expected = 'emcc: error: FORCE_FILESYSTEM is not compatible with FILESYSTEM=0'
     self.assert_fail([EMCC, test_file('hello_world.c'), '-sFILESYSTEM=0', '-sFORCE_FILESYSTEM'], expected)
 
   def test_aligned_alloc(self):

--- a/tools/link.py
+++ b/tools/link.py
@@ -975,27 +975,12 @@ def phase_linker_setup(linker_args):  # ruff: ignore[complex-structure, too-many
 
   settings.OUTPUT_FORMAT = options.oformat.name
 
-  if settings.SUPPORT_BIG_ENDIAN and settings.WASM2JS:
-    exit_with_error('WASM2JS is currently not compatible with SUPPORT_BIG_ENDIAN')
-
   if settings.WASM_ESM_INTEGRATION:
     default_setting('MODULARIZE', 'instance')
     if not settings.EXPORT_ES6:
       exit_with_error('WASM_ESM_INTEGRATION requires EXPORT_ES6')
     if settings.MODULARIZE != 'instance':
       exit_with_error('WASM_ESM_INTEGRATION requires MODULARIZE=instance')
-    if settings.MAIN_MODULE:
-      exit_with_error('WASM_ESM_INTEGRATION is not compatible with dynamic linking')
-    if settings.ASYNCIFY:
-      exit_with_error('WASM_ESM_INTEGRATION is not compatible with -sASYNCIFY')
-    if settings.WASM_WORKERS:
-      exit_with_error('WASM_ESM_INTEGRATION is not compatible with WASM_WORKERS')
-    if not settings.WASM_ASYNC_COMPILATION:
-      exit_with_error('WASM_ESM_INTEGRATION is not compatible with WASM_ASYNC_COMPILATION=0')
-    if not settings.WASM:
-      exit_with_error('WASM_ESM_INTEGRATION is not compatible with WASM2JS')
-    if settings.ABORT_ON_WASM_EXCEPTIONS:
-      exit_with_error('WASM_ESM_INTEGRATION is not compatible with ABORT_ON_WASM_EXCEPTIONS')
 
   if settings.MODULARIZE and settings.MODULARIZE not in {1, 'instance'}:
     exit_with_error(f'Invalid setting "{settings.MODULARIZE}" for MODULARIZE.')
@@ -1430,9 +1415,6 @@ def phase_linker_setup(linker_args):  # ruff: ignore[complex-structure, too-many
     # File preloading uses `Module['preRun']`.
     settings.INCOMING_MODULE_JS_API.append('preRun')
 
-  if settings.FORCE_FILESYSTEM and not settings.FILESYSTEM:
-    exit_with_error('`-sFORCE_FILESYSTEM` cannot be used with `-sFILESYSTEM=0`')
-
   if settings.WASMFS:
     settings.FILESYSTEM = 1
     settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
@@ -1748,10 +1730,6 @@ def phase_linker_setup(linker_args):  # ruff: ignore[complex-structure, too-many
   if settings.WASM2JS:
     if settings.GENERATE_SOURCE_MAP:
       exit_with_error('wasm2js does not support source maps yet (debug in wasm for now)')
-    if settings.MEMORY64:
-      exit_with_error('wasm2js does not support MEMORY64')
-    if settings.WASM_BIGINT:
-      exit_with_error('wasm2js does not support WASM_BIGINT')
     if settings.CAN_ADDRESS_2GB:
       exit_with_error('wasm2js does not support >2gb address space')
     # WASM2JS does not support GROWABLE_ARRAYBUFFERS at all
@@ -1762,8 +1740,6 @@ def phase_linker_setup(linker_args):  # ruff: ignore[complex-structure, too-many
       exit_with_error('NODE_CODE_CACHING requires sync compilation (WASM_ASYNC_COMPILATION=0)')
     if not settings.ENVIRONMENT_MAY_BE_NODE:
       exit_with_error('NODE_CODE_CACHING only works in node, but target environments do not include it')
-    if settings.SINGLE_FILE:
-      exit_with_error('NODE_CODE_CACHING saves a file on the side and is not compatible with SINGLE_FILE')
 
   if not js_manipulation.isidentifier(settings.EXPORT_NAME):
     exit_with_error(f'EXPORT_NAME is not a valid JS identifier: `{settings.EXPORT_NAME}`')

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -134,6 +134,8 @@ INCOMPATIBLE_SETTINGS = [
   ('WASM2JS', 'MAIN_MODULE', 'wasm2js does not support dynamic linking'),
   ('WASM2JS', 'SIDE_MODULE', 'wasm2js does not support dynamic linking'),
   ('WASM2JS', 'GROWABLE_ARRAYBUFFERS',  None),
+  ('WASM2JS', 'SUPPORT_BIG_ENDIAN', None),
+  ('WASM2JS', 'MEMORY64', None),
   ('MAIN_MODULE', 'NO_WASM_ASYNC_COMPILATION', 'dynamic linking requires async wasm compilation'),
   ('MODULARIZE', 'NO_DECLARE_ASM_MODULE_EXPORTS', None),
   ('EVAL_CTORS', 'WASM2JS', None),
@@ -157,6 +159,15 @@ INCOMPATIBLE_SETTINGS = [
   ('CROSS_ORIGIN_STORAGE', 'SIDE_MODULE', 'no JS glue is emitted to carry the hash or perform the COS lookup'),
   ('NODERAWSOCKETS', 'WASMFS', 'the node:net backend is not wired into WASMFS sockets'),
   ('NODERAWSOCKETS', 'PROXY_POSIX_SOCKETS', 'they are alternative socket backends'),
+  ('WASM_ESM_INTEGRATION', 'MAIN_MODULE', 'dynamic linking is not supported'),
+  ('WASM_ESM_INTEGRATION', 'SIDE_MODULE', 'dynamic linking is not supported'),
+  ('WASM_ESM_INTEGRATION', 'ASYNCIFY', None),
+  ('WASM_ESM_INTEGRATION', 'WASM_WORKERS', None),
+  ('WASM_ESM_INTEGRATION', 'NO_WASM_ASYNC_COMPILATION', None),
+  ('WASM_ESM_INTEGRATION', 'WASM2JS', None),
+  ('WASM_ESM_INTEGRATION', 'ABORT_ON_WASM_EXCEPTIONS', None),
+  ('FORCE_FILESYSTEM', 'NO_FILESYSTEM', None),
+  ('NODE_CODE_CACHING', 'SINGLE_FILE', 'saves a file on the side'),
 ]
 
 EXPERIMENTAL_SETTINGS = {


### PR DESCRIPTION
Move error checks from `tools/link.py` to `INCOMPATIBLE_SETTINGS` in `tools/settings.py` for:
- `WASM2JS` with `SUPPORT_BIG_ENDIAN` and `MEMORY64`
- `WASM_ESM_INTEGRATION` with `MAIN_MODULE`, `SIDE_MODULE`, `ASYNCIFY`, `WASM_WORKERS`, `WASM_ASYNC_COMPILATION=0`, `WASM2JS`, and `ABORT_ON_WASM_EXCEPTIONS`
- `FORCE_FILESYSTEM` with `FILESYSTEM=0`
- `NODE_CODE_CACHING` with `SINGLE_FILE`

Also remove redundant checks in `tools/link.py` and add test coverage in `test/test_other.py`.