### PR TITLE
Drop the WASM_BINDGEN wasmExports namespace import for ESM integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,8 @@ commands:
             export PATH=${HOME}/.cargo/bin:${PATH}
             rustup target add wasm32-unknown-emscripten
             echo "export PATH=\"\$HOME/.cargo/bin:\$PATH\"" >> $BASH_ENV
-            WB=wasm-bindgen-0.2.127-x86_64-unknown-linux-musl
-            curl -sSfL https://github.com/wasm-bindgen/wasm-bindgen/releases/download/0.2.127/$WB.tar.gz | tar xz -C /tmp
+            WB=wasm-bindgen-0.2.128-x86_64-unknown-linux-musl
+            curl -sSfL https://github.com/wasm-bindgen/wasm-bindgen/releases/download/0.2.128/$WB.tar.gz | tar xz -C /tmp
             mv /tmp/$WB/wasm-bindgen ${HOME}/.cargo/bin/
   install-node-version:
     description: "install a specific version of node"

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -238,14 +238,7 @@ function checkUnflushedContent() {
 #endif // EXIT_RUNTIME
 #endif // ASSERTIONS
 
-#if WASM_ESM_INTEGRATION && WASM_BINDGEN
-// wasm-bindgen's glue reaches the wasm exports by name on an aggregate object.
-// TODO: Remove once the minimum wasm-bindgen version uses the per-export
-// receiving bindings instead (wasm-bindgen/wasm-bindgen#5270).
-import * as wasmExports from './{{{ WASM_BINARY_FILE }}}';
-#else
 var wasmExports;
-#endif
 #if SPLIT_MODULE
 var wasmRawExports;
 #endif

--- a/test/rust/bindgen_greeter/Cargo.toml
+++ b/test/rust/bindgen_greeter/Cargo.toml
@@ -7,7 +7,7 @@ name = "bindgen_greeter"
 path = "src/main.rs"
 
 [dependencies]
-# 0.2.127 is the first release with the emscripten __export/__force attribute
-# support (wasm-bindgen/wasm-bindgen#5253); must match the wasm-bindgen-cli
+# 0.2.128 is the first release whose emscripten glue does not need an aggregate
+# `wasmExports` object (wasm-bindgen/wasm-bindgen#5270); must match the wasm-bindgen-cli
 # version exactly.
-wasm-bindgen = "0.2.127"
+wasm-bindgen = "0.2.128"

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15364,7 +15364,7 @@ addToLibrary({
     copytree(test_file('rust/bindgen_integration'), '.')
     # Pin the library to the (managed) wasm-bindgen-cli version on PATH;
     # wasm-bindgen requires the CLI and the library to match exactly.
-    self.run_process(['cargo', 'add', 'wasm-bindgen@0.2.127'])
+    self.run_process(['cargo', 'add', 'wasm-bindgen@0.2.128'])
     self.run_process(['cargo', 'build'])
     lib = 'target/wasm32-unknown-emscripten/debug/libbindgen_integration.a'
     self.assertExists(lib)
@@ -15460,13 +15460,16 @@ addToLibrary({
           Ok(42)
       }
     ''')
-    self.run_process(['cargo', 'add', 'wasm-bindgen@0.2.127'])
+    self.run_process(['cargo', 'add', 'wasm-bindgen@0.2.128'])
     self.run_process(['cargo', 'build'])
     lib = 'target/wasm32-unknown-emscripten/debug/libbindgen_integration.a'
     create_file('empty.c', '')
     self.run_process([EMCC, 'empty.c', '--emit-tsd', 'test_multi.d.ts', '-sWASM_BINDGEN', '-Wno-experimental', '-o', 'test_multi.js'] + [lib] + self.get_cflags())
     actual = read_file('test_multi.d.ts')
-    self.assertContained("multi_value_return(): [number, number, number];", actual)
+    # Only wasm-bindgen's unwrapping wrapper is surfaced; the raw multi-value
+    # `Result` ABI export stays internal.
+    self.assertContained("multi_value_return(): number;", actual)
+    self.assertNotContained("_multi_value_return(", actual)
 
   def test_relative_em_cache(self):
     with env_modify({'EM_CACHE': 'foo'}):


### PR DESCRIPTION
This removes the `WASM_ESM_INTEGRATION && WASM_BINDGEN` namespace import of the wasm module added in #27208, resolves #27658.

wasm-bindgen 0.2.128 no longer reads `wasmExports[...]` inline in its emscripten glue; it binds the asmjs-mangled identifiers that `assignWasmExports` already provides for every export (wasm-bindgen/wasm-bindgen#5270), so the aggregate object is not needed.

* Remove the conditional `import * as wasmExports` from `src/postamble.js`, leaving the plain `var wasmExports` declaration for all modes.
* Bump the pinned wasm-bindgen library and CLI from 0.2.127 to 0.2.128 (test crates, `cargo add` calls, CircleCI install).
* `test_wasm_bindgen_tsd_multi_return` now asserts the correct public surface: only wasm-bindgen's unwrapping wrapper `multi_value_return(): number` is typed, and the raw multi-value `Result` ABI export `_multi_value_return` stays internal. With 0.2.127 the raw export leaked into `WasmModule`, which is what the old `[number, number, number]` assertion was matching.

All `test_wasm_bindgen_*` tests pass against wasm-bindgen 0.2.128.

_Made with AI assistance under my review_