### PR TITLE
Pin wasm-bindgen test crate to an exact version

### DIFF
--- a/test/rust/bindgen_greeter/Cargo.toml
+++ b/test/rust/bindgen_greeter/Cargo.toml
@@ -10,4 +10,4 @@ path = "src/main.rs"
 # 0.2.128 is the first release whose emscripten glue does not need an aggregate
 # `wasmExports` object (wasm-bindgen/wasm-bindgen#5270); must match the wasm-bindgen-cli
 # version exactly.
-wasm-bindgen = "0.2.128"
+wasm-bindgen = "=0.2.128"

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -15364,7 +15364,7 @@ addToLibrary({
     copytree(test_file('rust/bindgen_integration'), '.')
     # Pin the library to the (managed) wasm-bindgen-cli version on PATH;
     # wasm-bindgen requires the CLI and the library to match exactly.
-    self.run_process(['cargo', 'add', 'wasm-bindgen@0.2.128'])
+    self.run_process(['cargo', 'add', 'wasm-bindgen@=0.2.128'])
     self.run_process(['cargo', 'build'])
     lib = 'target/wasm32-unknown-emscripten/debug/libbindgen_integration.a'
     self.assertExists(lib)
@@ -15460,7 +15460,7 @@ addToLibrary({
           Ok(42)
       }
     ''')
-    self.run_process(['cargo', 'add', 'wasm-bindgen@0.2.128'])
+    self.run_process(['cargo', 'add', 'wasm-bindgen@=0.2.128'])
     self.run_process(['cargo', 'build'])
     lib = 'target/wasm32-unknown-emscripten/debug/libbindgen_integration.a'
     create_file('empty.c', '')


### PR DESCRIPTION
The wasm-bindgen tests pin the crate to the CLI version installed in CI, but `cargo add wasm-bindgen@0.2.N` writes `wasm-bindgen = "0.2.N"`, which cargo treats as the caret range `^0.2.N`. As soon as a newer 0.2.x patch is published, cargo resolves to it while the CLI on PATH stays at the older version, and wasm-bindgen rejects the crate/CLI mismatch at link time. This broke CI when 0.2.128 was released while the CLI was still at 0.2.127.

* Use exact requirements (`=0.2.128`) in the `cargo add` calls in `test_other.py`
* Same for `test/rust/bindgen_greeter/Cargo.toml`

Verified that `cargo add wasm-bindgen@0.2.127` locks to 0.2.128 while `cargo add wasm-bindgen@=0.2.127` locks to 0.2.127, so future releases no longer affect the pinned tests. `other.test_wasm_bindgen_*` pass locally.

_Made with AI assistance under my review_