### PR TITLE
Fix missing runtime exports in --emit-tsd

### DIFF
--- a/test/test_other.py
+++ b/test/test_other.py
@@ -3932,6 +3932,17 @@ More info: https://emscripten.org
     self.assertContained("    HEAPF32: Float32Array;", actual)
     self.assertContained("    HEAPF64: Float64Array;", actual)
 
+  @requires_dev_dependency('typescript')
+  def test_emit_tsd_callmain(self):
+    self.run_process([EMCC, test_file('other/test_emit_tsd.c'),
+                      '--emit-tsd', 'test_emit_tsd.d.ts',
+                      '-sEXPORT_ES6', '-sMODULARIZE',
+                      '-sEXPORTED_RUNTIME_METHODS=callMain',
+                      '-o', 'test_emit_tsd.js'] +
+                     self.get_cflags())
+    actual = read_file('test_emit_tsd.d.ts')
+    self.assertContained("    callMain: any;", actual)
+
   def test_emconfig(self):
     output = self.run_process([EMCONFIG, 'LLVM_ROOT'], stdout=PIPE).stdout.strip()
     self.assertEqual(output, config.LLVM_ROOT)

--- a/tools/emscripten.py
+++ b/tools/emscripten.py
@@ -653,7 +653,7 @@ def create_tsd_exported_runtime_methods(metadata):
   # for generation.
   js_doc = 'var RuntimeExports = {};\n'
   for name in settings.EXPORTED_RUNTIME_METHODS:
-    docs = '/** @type {{any}} */'
+    docs = '/** @type {any} */'
     snippet = ''
     if name in metadata.library_definitions:
       definition = metadata.library_definitions[name]
@@ -664,10 +664,10 @@ def create_tsd_exported_runtime_methods(metadata):
         docs = ''
       if definition['docs']:
         docs = definition['docs']
-        # TSC does not generate the correct type if there are jsdocs and nothing
-        # is assigned to the property.
-        if not snippet:
-          snippet = ' = null'
+    # TSC does not generate the correct type if there are jsdocs and nothing
+    # is assigned to the property.
+    if not snippet:
+      snippet = ' = null'
     js_doc += f'{docs}\nRuntimeExports[\'{name}\']{snippet};\n'
 
   file = 'jsdoc'


### PR DESCRIPTION
TypeScript 7 ignores unassigned property accesses on object literals during declaration emission. As a result, runtime exports without JS library definitions (such as callMain) were omitted from RuntimeExports.

Always assign a value when emitting intermediate runtime declarations so all exported runtime methods appear in the generated types. Also fix double curly braces in JSDoc type annotations.

Fixes #27682.