### PR TITLE
Don't build libopenmp in wasm64 mode

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2328,6 +2328,9 @@ class libopenmp(Library):
     'kmp_ftn_extra.cpp', 'kmp_version.cpp', 'z_Linux_asm.S',
   ]
 
+  def can_build(self):
+    return super().can_build() and not settings.MEMORY64
+
 
 def get_libs_to_link():
   libs_to_link = []

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2329,6 +2329,8 @@ class libopenmp(Library):
   ]
 
   def can_build(self):
+    # OpenMP currently doesn't support Wasm64, see
+    # https://github.com/emscripten-core/emscripten/issues/27221
     return super().can_build() and not settings.MEMORY64
 
 


### PR DESCRIPTION
The library doesn't support wasm64 and will error out. This causes
`./embuilder --wasm64 build SYSTEM`
to fail.
See https://github.com/emscripten-core/emscripten/issues/27221