### PR TITLE
Use separate lib build paths for different configurations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ commands:
             ls -l ~/cache/sysroot/include/emscripten/heap.h
             cat ~/cache/sysroot/lib/wasm32-emscripten/crtbegin-mt.o.ccache-log
             date
-            cat ~/cache/build/libclang_rt.builtins/absvdi2.o.ccache-log
+            cat ~/cache/build/wasm32-emscripten/libclang_rt.builtins/absvdi2.o.ccache-log
             ccache -s
             ccache --print-stats
             ccache -p

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -109,15 +109,13 @@ def get_sysroot_dir(*parts):
   return str(Path(get_sysroot(absolute=True), *parts))
 
 
-def get_lib_dir(absolute):
+def get_lib_dir_relative():
   from .cmdline import options
 
-  ensure_setup()
-  path = Path(get_sysroot(absolute=absolute), 'lib')
   if settings.MEMORY64:
-    path = Path(path, 'wasm64-emscripten')
+    path = Path('wasm64-emscripten')
   else:
-    path = Path(path, 'wasm32-emscripten')
+    path = Path('wasm32-emscripten')
   # if relevant, use a subdir of the cache
   subdir = []
   if options.lto:
@@ -130,6 +128,11 @@ def get_lib_dir(absolute):
   if subdir:
     path = Path(path, '-'.join(subdir))
   return path
+
+
+def get_lib_dir(absolute):
+  ensure_setup()
+  return Path(get_sysroot(absolute=absolute), 'lib', get_lib_dir_relative())
 
 
 def get_lib_name(name, absolute=False):

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -285,7 +285,7 @@ class Ports:
 
   @staticmethod
   def get_build_dir():
-    return system_libs.get_build_dir()
+    return cache.get_path('build')
 
   name_cache: set[str] = set()
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -15,6 +15,7 @@ import subprocess
 import textwrap
 from enum import IntEnum, auto
 from glob import iglob
+from pathlib import Path
 from time import time
 
 from . import building, cache, diagnostics, shared, utils
@@ -84,7 +85,7 @@ def get_base_cflags(build_dir, force_object_files=False, preprocess=True):
 
 
 def get_build_dir():
-  return cache.get_path('build')
+  return cache.get_path(Path('build', cache.get_lib_dir_relative()))
 
 
 def clean_env():
@@ -179,6 +180,7 @@ def run_ninja(build_dir):
 def ensure_target_in_ninja_file(ninja_file, target):
   if os.path.isfile(ninja_file) and target in read_file(ninja_file):
     return
+  utils.safe_ensure_dirs(os.path.dirname(ninja_file))
   with open(ninja_file, 'a', encoding='utf-8') as f:
     f.write(target + '\n')
 


### PR DESCRIPTION
Libraries with different configurations use different directories in the sysroot (e.g. wasm64-emscripten/pic) but currently all use the same build directory across configurations. When using Ninja, these intermediate directories persist and can result in corruption if one configuration is built after another. We could solve this by just clearing them, but keeping the build directories around can be useful for local development, and will also allow building all the configurations at once (in a future PR).

This PR just makes the build directory share the path logic with the lib directory. (The ports system has its own separate logic).