### PR TITLE
Clarify GROWABLE_ARRAYBUFFERS options in warning

### DIFF
--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -3415,11 +3415,18 @@ GROWABLE_ARRAYBUFFERS
 
 Enable support for growable views of Wasm memory. This is a recent Web
 platform feature that can make growing the Wasm memory more efficient,
-especially in multi-threaded builds.
+especially in multi-threaded builds. For background, see
+https://github.com/WebAssembly/design/issues/1271
+
 Setting this to 1 will auto-detect the presence of this API and use
 it when available.
 Setting this to 2 will unconditionally require it. This is the only way
 to completely remove the overhead of growable memory + pthreads.
+  * Note that while browser support for this feature is widespread
+    (https://caniuse.com/?search=sharedarraybuffer.resize), it was
+    not usable on Firefox until Firefox 154,
+    https://bugzilla.mozilla.org/show_bug.cgi?id=2021136
+
 This settings does nothing unless ALLOW_MEMORY_GROWTH is set.
 
 Default value: 0

--- a/site/source/docs/tools_reference/settings_reference.rst
+++ b/site/source/docs/tools_reference/settings_reference.rst
@@ -3422,10 +3422,11 @@ Setting this to 1 will auto-detect the presence of this API and use
 it when available.
 Setting this to 2 will unconditionally require it. This is the only way
 to completely remove the overhead of growable memory + pthreads.
-  * Note that while browser support for this feature is widespread
-    (https://caniuse.com/?search=sharedarraybuffer.resize), it was
-    not usable on Firefox until Firefox 154,
-    https://bugzilla.mozilla.org/show_bug.cgi?id=2021136
+
+Note that while browser support for this feature is widespread
+(https://caniuse.com/?search=sharedarraybuffer.resize), it was not usable on
+Firefox until Firefox 154,
+https://bugzilla.mozilla.org/show_bug.cgi?id=2021136
 
 This settings does nothing unless ALLOW_MEMORY_GROWTH is set.
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -2262,11 +2262,18 @@ var JS_BASE64_API = false;
 
 // Enable support for growable views of Wasm memory. This is a recent Web
 // platform feature that can make growing the Wasm memory more efficient,
-// especially in multi-threaded builds.
+// especially in multi-threaded builds. For background, see
+// https://github.com/WebAssembly/design/issues/1271
+//
 // Setting this to 1 will auto-detect the presence of this API and use
 // it when available.
 // Setting this to 2 will unconditionally require it. This is the only way
 // to completely remove the overhead of growable memory + pthreads.
+//   * Note that while browser support for this feature is widespread
+//     (https://caniuse.com/?search=sharedarraybuffer.resize), it was
+//     not usable on Firefox until Firefox 154,
+//     https://bugzilla.mozilla.org/show_bug.cgi?id=2021136
+//
 // This settings does nothing unless ALLOW_MEMORY_GROWTH is set.
 // [link]
 var GROWABLE_ARRAYBUFFERS = 0;

--- a/src/settings.js
+++ b/src/settings.js
@@ -2269,10 +2269,11 @@ var JS_BASE64_API = false;
 // it when available.
 // Setting this to 2 will unconditionally require it. This is the only way
 // to completely remove the overhead of growable memory + pthreads.
-//   * Note that while browser support for this feature is widespread
-//     (https://caniuse.com/?search=sharedarraybuffer.resize), it was
-//     not usable on Firefox until Firefox 154,
-//     https://bugzilla.mozilla.org/show_bug.cgi?id=2021136
+//
+// Note that while browser support for this feature is widespread
+// (https://caniuse.com/?search=sharedarraybuffer.resize), it was not usable on
+// Firefox until Firefox 154,
+// https://bugzilla.mozilla.org/show_bug.cgi?id=2021136
 //
 // This settings does nothing unless ALLOW_MEMORY_GROWTH is set.
 // [link]

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12139,7 +12139,7 @@ int main(void) {
 
     # check that `-Wno-pthreads-mem` disables pthread + ALLOW_GROWTH_MEMORY warning
     stderr = self.run_process(cmd + ['-Wno-pthreads-mem-growth', '-pthread', '-sALLOW_MEMORY_GROWTH'], stderr=PIPE).stderr
-    self.assertNotContained('pthreads + ALLOW_MEMORY_GROWTH may run non-wasm code slowly, see https://github.com/WebAssembly/design/issues/1271', stderr)
+    self.assertNotContained('pthreads + ALLOW_MEMORY_GROWTH may run non-wasm code slowly, consider -sGROWABLE_ARRAYBUFFERS=2', stderr)
 
   def test_emranlib(self):
     create_file('foo.c', 'int foo = 1;')

--- a/tools/link.py
+++ b/tools/link.py
@@ -461,7 +461,7 @@ def setup_pthreads():
   if settings.MAIN_MODULE:
     diagnostics.warning('experimental', 'dynamic linking + pthreads is experimental')
   if settings.ALLOW_MEMORY_GROWTH and settings.GROWABLE_ARRAYBUFFERS != 2:
-    diagnostics.warning('pthreads-mem-growth', '-pthread + ALLOW_MEMORY_GROWTH may run non-wasm code slowly, see https://github.com/WebAssembly/design/issues/1271')
+    diagnostics.warning('pthreads-mem-growth', '-pthread + ALLOW_MEMORY_GROWTH may run non-wasm code slowly, consider -sGROWABLE_ARRAYBUFFERS=2')
 
   default_setting('DEFAULT_PTHREAD_STACK_SIZE', settings.STACK_SIZE)
 


### PR DESCRIPTION
We linked to the design issue, but did not explain how to work around
the issue, which we now have an option for.